### PR TITLE
Make ReactorNet.step take no arguments

### DIFF
--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -107,9 +107,10 @@ public:
      */
     void advance(doublereal time);
 
-    //! Advance the state of all reactors in time. Take a single timestep
-    //! toward *time*.
-    double step(doublereal time);
+    //! Advance the state of all reactors in time.
+    //! @deprecated The *time* argument to this function is deprecated and will
+    //!     be removed after Cantera 2.3.
+    double step(doublereal time=-999);
 
     //@}
 

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -249,7 +249,10 @@ protected:
     vector_fp m_atol;
     doublereal m_rtol, m_rtolsens;
     doublereal m_atols, m_atolsens;
+
+    //! Maximum integrator internal timestep. Default of 0.0 means infinity.
     doublereal m_maxstep;
+
     int m_maxErrTestFails;
     bool m_verbose;
     size_t m_ntotpar;

--- a/interfaces/cython/cantera/examples/kinetics/mechanism_reduction.py
+++ b/interfaces/cython/cantera/examples/kinetics/mechanism_reduction.py
@@ -31,7 +31,7 @@ t = 0.0
 # Rmax is the maximum relative reaction rate at any timestep
 Rmax = np.zeros(gas.n_reactions)
 while t < 0.02:
-    t = sim.step(1.0)
+    t = sim.step()
     tt.append(1000 * t)
     TT.append(r.T)
     rnet = abs(gas.net_rates_of_progress)
@@ -73,7 +73,7 @@ for i,N in enumerate([40,50,60,70,80]):
     tt = []
     TT = []
     while t < 0.02:
-        t = sim.step(1.0)
+        t = sim.step()
         tt.append(1000 * t)
         TT.append(r.T)
 

--- a/interfaces/cython/cantera/examples/kinetics/reaction_path.py
+++ b/interfaces/cython/cantera/examples/kinetics/reaction_path.py
@@ -20,7 +20,7 @@ r = ct.IdealGasReactor(gas)
 net = ct.ReactorNet([r])
 T = r.T
 while T < 1900:
-    net.step(1.0)
+    net.step()
     T = r.T
 
 element = 'N'

--- a/interfaces/cython/cantera/examples/reactors/combustor.py
+++ b/interfaces/cython/cantera/examples/reactors/combustor.py
@@ -81,7 +81,7 @@ outfile = open('combustor.csv','w')
 csvwriter = csv.writer(outfile)
 
 while tnow < tfinal:
-    tnow = sim.step(tfinal)
+    tnow = sim.step()
     tres = combustor.mass/v.mdot(tnow)
     Tnow = combustor.T
     if abs(Tnow - Tprev) > 1.0 or tnow-tprev > 2e-2:

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -764,10 +764,14 @@ cdef class ReactorNet:
         """
         self.net.advance(t)
 
-    def step(self, double t):
+    def step(self, double t=-999):
         """
-        Take a single internal time step toward time *t* [s]. The time after
-        taking the step is returned.
+        Take a single internal time step. The time after taking the step is
+        returned.
+
+        .. deprecated:: 2.2
+            The argument *t* is deprecated and will be removed after
+            Cantera 2.3.
         """
         return self.net.step(t)
 

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -363,7 +363,7 @@ class TestReactionPath(utilities.CanteraTest):
         net = ct.ReactorNet([r])
         T = r.T
         while T < 1900:
-            net.step(1.0)
+            net.step()
             T = r.T
 
         for element in ['N','C','H','O']:

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -77,7 +77,7 @@ class TestReactor(utilities.CanteraTest):
 
     def test_component_index(self):
         self.make_reactors(n_reactors=1)
-        self.net.step(1.0)
+        self.net.step()
 
         N0 = self.net.n_vars - self.gas1.n_species
         for i, name in enumerate(self.gas1.species_names):
@@ -122,7 +122,7 @@ class TestReactor(utilities.CanteraTest):
 
         while t < tEnd:
             tPrev = t
-            t = self.net.step(tEnd)
+            t = self.net.step()
             self.assertTrue(t - tPrev <= 1.0001 * dt_max)
             self.assertNear(t, self.net.time)
 
@@ -160,7 +160,7 @@ class TestReactor(utilities.CanteraTest):
             t = 0
 
             while t < tEnd:
-                t = self.net.step(tEnd)
+                t = self.net.step()
                 nSteps += 1
 
             return nSteps
@@ -426,7 +426,7 @@ class TestReactor(utilities.CanteraTest):
 
         t = 0
         while t < 1.0:
-            t = self.net.step(1.0)
+            t = self.net.step()
             p1 = self.r1.thermo.P
             p2 = self.r2.thermo.P
             self.assertNear(mdot(p1-p2), valve.mdot(t))
@@ -452,7 +452,7 @@ class TestReactor(utilities.CanteraTest):
 
         t = 0
         while t < 1.0:
-            t = self.net.step(1.0)
+            t = self.net.step()
             self.assertNear(mdot(t), mfc.mdot(t))
             dP = self.r1.thermo.P - outlet_reservoir.thermo.P
             self.assertNear(mdot(t) + 1e-5 * dP, pc.mdot(t))
@@ -585,7 +585,7 @@ class TestWellStirredReactorIgnition(utilities.CanteraTest):
         i = 0
         while t < tf:
             i += 1
-            t = self.net.step(tf)
+            t = self.net.step()
             times.append(t)
             T.append(self.combustor.T)
         return times, T
@@ -706,7 +706,7 @@ class TestConstPressureReactor(utilities.CanteraTest):
         self.create_reactors(add_surf=True)
         for (gas,net,iface,r) in ((self.gas1, self.net1, self.interface1, self.r1),
                                   (self.gas2, self.net2, self.interface2, self.r2)):
-            net.step(1.0)
+            net.step()
 
             N0 = net.n_vars - gas.n_species - iface.n_species
             N1 = net.n_vars - iface.n_species
@@ -765,7 +765,7 @@ class TestFlowReactor(utilities.CanteraTest):
         v0 = r.speed
         self.assertNear(v0, 10 / r.density)
         while t < 10.0:
-            t = net.step(10.0)
+            t = net.step()
 
             self.assertNear(v0, r.speed)
             self.assertNear(r.distance, v0 * t)
@@ -792,7 +792,7 @@ class TestFlowReactor(utilities.CanteraTest):
             t1 = net.time
             x1 = r.distance
 
-            t = net.step(1.0)
+            t = net.step()
 
             v = (r.distance - x1) / (net.time - t1)
             self.assertNear(r.speed, v, 1e-3)
@@ -952,7 +952,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
 
         for T in (901, 905, 910, 950, 1500):
             while r2.T < T:
-                net.step(1.0)
+                net.step()
 
             S = net.sensitivities()
 
@@ -984,7 +984,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
 
         def integrate(r, net):
             while r.T < 910:
-                net.step(1.0)
+                net.step()
             return net.sensitivities()
 
         r1,net1 = setup()
@@ -1215,7 +1215,7 @@ class CombustorTestImplementation(object):
         tfinal = 0.25
         self.data = []
         while tnow < tfinal:
-            tnow = self.sim.step(tfinal)
+            tnow = self.sim.step()
             self.data.append([tnow, self.combustor.T] +
                              list(self.combustor.thermo.X))
 
@@ -1280,7 +1280,7 @@ class WallTestImplementation(object):
         tfinal = 0.01
         self.data = []
         while tnow < tfinal:
-            tnow = self.sim.step(tfinal)
+            tnow = self.sim.step()
             self.data.append([tnow,
                               self.r1.T, self.r2.T,
                               self.r1.thermo.P, self.r2.thermo.P,

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -378,6 +378,7 @@ class TestReactor(utilities.CanteraTest):
         # (constant T) we can compare with an analytical solution for
         # the mass of each reactor as a function of time
         self.make_reactors(P1=10*ct.one_atm)
+        self.net.rtol = 1e-11
         self.r1.energy_enabled = False
         self.r2.energy_enabled = False
         valve = ct.Valve(self.r1, self.r2)

--- a/interfaces/matlab/toolbox/@ReactorNet/step.m
+++ b/interfaces/matlab/toolbox/@ReactorNet/step.m
@@ -1,6 +1,6 @@
 function t = step(r, tout)
 % STEP  Take one internal time step.
-% t = step(r, tout)
+% t = step(r)
 % The integrator used to integrate the ODEs (CVODE) takes
 % variable-size steps, chosen so that a specified error
 % tolerance is maintained. At times when the solution is rapidly
@@ -19,7 +19,7 @@ function t = step(r, tout)
 %     t = 0.0
 %     tout = 0.1
 %     while t < tout
-%        t = step(r, tout)
+%        t = step(r)
 %        ,,,
 %        <commands to save desired variables>
 %        ...
@@ -29,12 +29,11 @@ function t = step(r, tout)
 %
 % :param r:
 %     Instance of class :mat:func:`ReactorNet`
-% :param tout:
-%     End time that the integrator should take one internal time
-%     step towards. This end time may not be reached, or may be
-%     exceeded by the internal time step.
 % :return:
 %     Network time after the internal time step. Units: s
 %
+if nargin == 1
+    tout = -999;
+end
 
 t = reactornetmethods(21, reactornet_hndl(r), tout);

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -14,7 +14,7 @@ ReactorNet::ReactorNet() :
     m_integ(0), m_time(0.0), m_init(false), m_integrator_init(false),
     m_nv(0), m_rtol(1.0e-9), m_rtolsens(1.0e-4),
     m_atols(1.0e-15), m_atolsens(1.0e-4),
-    m_maxstep(-1.0), m_maxErrTestFails(0),
+    m_maxstep(0.0), m_maxErrTestFails(0),
     m_verbose(false), m_ntotpar(0)
 {
     m_integ = newIntegrator("CVODE");
@@ -113,9 +113,6 @@ void ReactorNet::reinitialize()
 void ReactorNet::advance(doublereal time)
 {
     if (!m_init) {
-        if (m_maxstep < 0.0) {
-            m_maxstep = time - m_time;
-        }
         initialize();
     } else if (!m_integrator_init) {
         reinitialize();
@@ -128,9 +125,6 @@ void ReactorNet::advance(doublereal time)
 double ReactorNet::step(doublereal time)
 {
     if (!m_init) {
-        if (m_maxstep < 0.0) {
-            m_maxstep = time - m_time;
-        }
         initialize();
     } else if (!m_integrator_init) {
         reinitialize();

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -124,12 +124,16 @@ void ReactorNet::advance(doublereal time)
 
 double ReactorNet::step(doublereal time)
 {
+    if (time != -999) {
+        warn_deprecated("ReactorNet::step(t)", "The argument to this function"
+            " is deprecated and will be removed after Cantera 2.3.");
+    }
     if (!m_init) {
         initialize();
     } else if (!m_integrator_init) {
         reinitialize();
     }
-    m_time = m_integ->step(time);
+    m_time = m_integ->step(m_time + 1.0);
     updateState(m_integ->solution());
     return m_time;
 }


### PR DESCRIPTION
The current behavior is confusing, as evidenced by the repeated questions that appear on the Users' Group. This simplification to the interface should help.
