### PR TITLE
fixes issue #275

### DIFF
--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -76,6 +76,10 @@ cdef extern from "cantera/thermo/SpeciesThermoInterpType.h":
         CxxSpeciesThermo()
         int reportType()
         void updatePropertiesTemp(double, double*, double*, double*) except +
+        double minTemp() except +
+        double maxTemp() except +
+        double refPressure() except +
+        void reportParameters(size_t&, int&, double&, double&, double&, double* const)
 
 cdef extern from "cantera/thermo/SpeciesThermoFactory.h":
     cdef CxxSpeciesThermo* CxxNewSpeciesThermo "Cantera::newSpeciesThermoInterpType"\

--- a/interfaces/cython/cantera/speciesthermo.pyx
+++ b/interfaces/cython/cantera/speciesthermo.pyx
@@ -39,6 +39,35 @@ cdef class SpeciesThermo:
         self._spthermo = other
         self.spthermo = self._spthermo.get()
 
+    property min_temp:
+        """ Minimum temperature [K] at which the parameterization is valid."""
+        def __get__(self):
+            return self.spthermo.minTemp()
+
+    property max_temp:
+        """ Maximum temperature [K] at which the parameterization is valid."""
+        def __get__(self):
+            return self.spthermo.maxTemp()
+
+    property reference_pressure:
+        """ Reference pressure [Pa] for the parameterization."""
+        def __get__(self):
+            return self.spthermo.refPressure()
+
+    property coeffs:
+        """ Array of coefficients for the parameterization. The length of this
+        array and the meaning of each element depends on the specific
+        parameterization."""
+        def __get__(self):
+            cdef size_t index = 0
+            cdef int thermo_type = 0
+            cdef double T_low = 0, T_high = 0, P_ref = 0
+            N = self.n_coeffs
+            cdef np.ndarray[np.double_t, ndim=1] data = np.empty((N,))
+            self.spthermo.reportParameters(index, thermo_type, T_low,
+                T_high, P_ref, &data[0])
+            return data
+
     def cp(self, T):
         """
         Molar heat capacity at constant pressure [J/kmol/K] at temperature *T*.

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -887,3 +887,29 @@ class TestSpeciesThermo(utilities.CanteraTest):
             self.assertAlmostEqual(st.cp(T), self.gas.cp_mole)
             self.assertAlmostEqual(st.h(T), self.gas.enthalpy_mole)
             self.assertAlmostEqual(st.s(T), self.gas.entropy_mole)
+
+    def test_params(self):
+        st = ct.NasaPoly2(300, 3500, 101325,
+                [1000.0, 3.03399249E+00, 2.17691804E-03, -1.64072518E-07,
+                 -9.70419870E-11, 1.68200992E-14, -3.00042971E+04, 4.96677010E+00,
+                 4.19864056E+00, -2.03643410E-03, 6.52040211E-06, -5.48797062E-09,
+                 1.77197817E-12, -3.02937267E+04, -8.49032208E-01])
+        self.assertEqual(st.min_temp, 300)
+        self.assertEqual(st.max_temp, 3500)
+        self.assertEqual(st.reference_pressure, 101325)
+        array = st.coeffs
+        self.assertEqual(array[0], 1000.0)
+        self.assertEqual(array[1], 3.03399249E+00)
+        self.assertEqual(array[2], 2.17691804E-03)
+        self.assertEqual(array[3], -1.64072518E-07)
+        self.assertEqual(array[4], -9.70419870E-11)
+        self.assertEqual(array[5], 1.68200992E-14)
+        self.assertEqual(array[6], -3.00042971E+04)
+        self.assertEqual(array[7], 4.96677010E+00)
+        self.assertEqual(array[8], 4.19864056E+00)
+        self.assertEqual(array[9], -2.03643410E-03)
+        self.assertEqual(array[10], 6.52040211E-06)
+        self.assertEqual(array[11], -5.48797062E-09)
+        self.assertEqual(array[12], 1.77197817E-12)
+        self.assertEqual(array[13], -3.02937267E+04)
+        self.assertEqual(array[14], -8.49032208E-01)


### PR DESCRIPTION
Added properties to the Python interface for species thermo parameters.

Used separate properties for minimum and maximum temperature, reference pressure, and coefficients.
