### PR TITLE
Get effective Arrhenius parameters using SurfaceArrhenius class

### DIFF
--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -161,6 +161,41 @@ public:
     virtual void getRevRateConstants(doublereal* krev,
                                      bool doIrreversible = false);
 
+    //! Return effective preexponent for the specified reaction
+    /*! Returns effective preexponent, accounting for surface coverage
+     *  dependencies. Can be called by user.
+     *  @param irxn Reaction number in the kinetics mechanism
+     *
+     *  @return Effective preexponent
+     */
+    doublereal effectivePreExponentialFactor(int irxn) {
+        return m_rates.effectivePreExponentialFactor(irxn);
+    }
+
+    //! Return effective activation energy for the specified reaction
+    /*! Returns effective activation energy, accounting for surface coverage
+     *  dependencies. Can be called by user.
+     *  @param irxn Reaction number in the kinetics mechanism
+     *
+     *  @return Effective activation energy
+     */
+    doublereal effectiveActivationEnergy_R(int irxn) {
+       return m_rates.effectiveActivationEnergy_R(irxn);
+    }
+
+    //! Return effective temperature exponent for the specified reaction
+    /*! Returns effective temperature exponenty, accounting for surface coverage
+     *  dependencies. Can be called by user.
+     *  Current parametrization in SurfaceArrhenius does not
+     *  change this parameter with the change in surface coverages.
+     *  @param irxn Reaction number in the kinetics mechanism
+     *
+     *  @return Effective temperature exponent
+     */
+    doublereal effectiveTemperatureExponent(int irxn) {
+       return m_rates.effectiveTemperatureExponent(irxn);
+    }
+
     //! @}
     //! @name Reaction Mechanism Construction
     //! @{

--- a/include/cantera/kinetics/RateCoeffMgr.h
+++ b/include/cantera/kinetics/RateCoeffMgr.h
@@ -75,6 +75,41 @@ public:
         return m_rates.size();
     }
 
+    //! Return effective preexponent of some reaction
+    /*! Returns effective preexponent, accounting for surface coverage
+     *  dependencies. Is used in InterfaceKinetics object.
+     *  @param irxn Reaction number in the kinetics mechanism
+     *
+     *  @return Effective preexponent
+     */
+    doublereal effectivePreExponentialFactor(int irxn) {
+        return m_rates[irxn].preExponentialFactor();
+    }
+
+    //! Return effective activation energy of some reaction
+    /*! Returns effective activation energy, accounting for surface coverage
+     *  dependencies. Is used in InterfaceKinetics object.
+     *  @param irxn Reaction number in the kinetics mechanism
+     *
+     *  @return Effective activation energy
+     */
+    doublereal effectiveActivationEnergy_R(int irxn) {
+        return m_rates[irxn].activationEnergy_R();
+    }
+
+    //! Return effective temperature exponent of some reaction
+    /*! Returns effective temperature exponenty, accounting for surface coverage
+     *  dependencies. Is used in InterfaceKinetics object.
+     *  Current parametrization in SurfaceArrhenius does not
+     *  change this parameter with the change in surface coverages.
+     *  @param irxn Reaction number in the kinetics mechanism
+     *
+     *  @return Effective temperature exponent
+     */
+    doublereal effectiveTemperatureExponent(int irxn) {
+        return m_rates[irxn].temperatureExponent();
+    }
+
 protected:
     std::vector<R> m_rates;
     std::vector<size_t> m_rxn;

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -175,7 +175,7 @@ public:
     }
 
 protected:
-    doublereal m_logA, m_b, m_E, m_A;
+    doublereal m_b, m_E, m_A;
     doublereal m_acov, m_ecov, m_mcov;
     std::vector<size_t> m_sp, m_msp;
     vector_fp m_ac, m_ec, m_mc;

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -72,12 +72,12 @@ public:
 
     //! Return the pre-exponential factor *A* (in m, kmol, s to powers depending
     //! on the reaction order)
-    double preExponentialFactor() const {
+    doublereal preExponentialFactor() const {
         return m_A;
     }
 
     //! Return the temperature exponent *b*
-    double temperatureExponent() const {
+    doublereal temperatureExponent() const {
         return m_b;
     }
 
@@ -118,9 +118,9 @@ public:
     explicit SurfaceArrhenius(double A, double b, double Ta);
 
     //! Add a coverage dependency for species *k*, with pre-exponential
-    //! dependence *a*, temperature exponent dependence *m* and activation
-    //! energy dependence *e*, where *e* is in Kelvin, i.e. energy divided by
-    //! the molar gas constant.
+    //! dependence *a*, rate constant exponential dependency *m* on coverage
+    //! and activation energy dependence *e*, where *e* is in Kelvin,
+    //! i.e. energy divided by the molar gas constant.
     void addCoverageDependence(size_t k, doublereal a,
                                doublereal m, doublereal e);
 
@@ -153,6 +153,23 @@ public:
                               (m_E + m_ecov)*recipT + m_mcov);
     }
 
+    //! Return the pre-exponential factor *A* (in m, kmol, s to powers depending
+    //! on the reaction order) accounting coverage dependence
+    /*! Returns reaction prexponent accounting for both *a* and *m*,
+     * since *m* is not temperature-dependent and shouldn't be included in
+     * temperature exponent
+     */
+    doublereal preExponentialFactor() const {
+        return m_A * std::exp(std::log(10.0)*m_acov + m_mcov);
+    }
+
+    //! Return effective temperature exponent
+    doublereal temperatureExponent() const {
+        return m_b;
+    }
+
+    //! Return the activation energy divided by the gas constant (i.e. the
+    //! activation temperature) [K], accounting coverage dependence
     doublereal activationEnergy_R() const {
         return m_E + m_ecov;
     }

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -26,8 +26,7 @@ Arrhenius::Arrhenius(doublereal A, doublereal b, doublereal E)
 }
 
 SurfaceArrhenius::SurfaceArrhenius()
-    : m_logA(-1.0E300)
-    , m_b(0.0)
+    : m_b(0.0)
     , m_E(0.0)
     , m_A(0.0)
     , m_acov(0.0)
@@ -48,11 +47,6 @@ SurfaceArrhenius::SurfaceArrhenius(double A, double b, double Ta)
     , m_ncov(0)
     , m_nmcov(0)
 {
-    if (m_A  <= 0.0) {
-        m_logA = -1.0E300;
-    } else {
-        m_logA = std::log(m_A);
-    }
 }
 
 void SurfaceArrhenius::addCoverageDependence(size_t k, doublereal a,

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -21,7 +21,7 @@ Arrhenius::Arrhenius(doublereal A, doublereal b, doublereal E)
     if (m_A  <= 0.0) {
         m_logA = -1.0E300;
     } else {
-        m_logA = log(m_A);
+        m_logA = std::log(m_A);
     }
 }
 
@@ -39,8 +39,7 @@ SurfaceArrhenius::SurfaceArrhenius()
 }
 
 SurfaceArrhenius::SurfaceArrhenius(double A, double b, double Ta)
-    : m_logA(std::log(A))
-    , m_b(b)
+    : m_b(b)
     , m_E(Ta)
     , m_A(A)
     , m_acov(0.0)
@@ -49,6 +48,11 @@ SurfaceArrhenius::SurfaceArrhenius(double A, double b, double Ta)
     , m_ncov(0)
     , m_nmcov(0)
 {
+    if (m_A  <= 0.0) {
+        m_logA = -1.0E300;
+    } else {
+        m_logA = std::log(m_A);
+    }
 }
 
 void SurfaceArrhenius::addCoverageDependence(size_t k, doublereal a,


### PR DESCRIPTION
1) Lattice class is added to create ideal lattice object. The code is written in a manner of IncompressibleSolid (IncompressibleSolid.h). Usage:

``` c++
Cantera::Lattice* bulk;
std::string name="1.cti";
bulk=new Cantera::Lattice(name, "bulk");
phases.push_back(bulk); //phases is std::vector<Cantera::ThermoPhase*>
//note: add bulk phase to phases before surface (idealInterface), like in cti file.
bulk->setState_TPX(Tcurr,P,Xbulk);
double * b_aconc = new double [bulk->nSpecies()];
bulk->getActivityConcentrations(baconc);
//some more stuff
//use bulk->molarDensity() to access the molar density, the characteristic of lattice species per unit of volume
delete [] b_aconc;
delete bulk;
```

2) SurfaceArrhenius class is now a derived class, the parent being Arrhenius. Some methods of SurfaceArrhenius class became virtual.
3) Getters for A, beta, E from SurfaceArrhenius class introduced, two of them are overloaded functions accounting for surface coverage modifiers inclusion into effective reaction rate parameters.
The reason for getters is to give the user the ability of inspection of reaction rate parameters during surface chemistry calculations. This is convinient when user wants to output reaction rate parameters 

These commits are not build-breaking: (scons test)

---

**\*    Testing Summary    ***

---

Tests passed: 967
Up-to-date tests skipped: 0
Tests failed: 0
