### PR TITLE
Removes uneeded .close() calls

### DIFF
--- a/src/base/plots.cpp
+++ b/src/base/plots.cpp
@@ -22,10 +22,8 @@ void writePlotFile(const std::string& fname, const std::string& fmt,
     }
     if (fmt == "TEC") {
         outputTEC(f, plotTitle, names, data);
-        f.close();
     } else if (fmt == "XL" || fmt == "CSV") {
         outputExcel(f, plotTitle, names, data);
-        f.close();
     } else {
         throw CanteraError("writePlotFile",
                            "unsupported plot type:" + fmt);


### PR DESCRIPTION
These calls are not needed.  
ofstream's destructor will close the file.
This is consistent with having your constructor open the file.  
Even if the exception was thrown, your file will be closed when f falls out of scope.
