### PR TITLE
[Docs] Cython 0.19 is required to build Cantera 2.2.0

### DIFF
--- a/doc/sphinx/compiling.rst
+++ b/doc/sphinx/compiling.rst
@@ -37,12 +37,12 @@ Linux
 
 * Building the python module also requires::
 
-      cython python-dev python-numpy python-numpy-dev
+      cython python-dev python-numpy python-numpy-dev python-setuptools
 
 * Checking out the source code from version control requires Git (install
   ``git``).
 
-* The minimum compatible Cython version is 0.17. If your distribution does not
+* The minimum compatible Cython version is 0.19. If your distribution does not
   contain a suitable version, you may be able to install a more recent version
   using `easy_install` or `pip`.
 
@@ -441,9 +441,8 @@ Optional Programs
 
 * `Cython <http://cython.org/>`_
 
-  * Required to build the Python module
-  * Known to work with versions 0.19 and 0.20. Expected to work with
-    versions >= 0.17.
+  * Required version >=0.19 to build the Python module
+  * Known to work with versions 0.19 and 0.20.
   * Tested with Python 2.7, 3.3, and 3.4. Expected to work with versions 2.6 and
     3.1+ as well.
 

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -161,6 +161,18 @@ public:
     virtual void getRevRateConstants(doublereal* krev,
                                      bool doIrreversible = false);
 
+    doublereal getEffectivePreExponentialFactor(int rnum) {
+        return m_rates.getEffectivePreExponentialFactor(rnum);
+    }
+
+    doublereal getEffectiveActivationEnergy_R(int rnum) {
+       return m_rates.getEffectiveActivationEnergy_R(rnum);
+    }
+
+    doublereal getEffectiveTemperatureExponent(int rnum) {
+       return m_rates.getEffectiveTemperatureExponent(rnum);
+    }
+
     //! @}
     //! @name Reaction Mechanism Construction
     //! @{

--- a/include/cantera/kinetics/RateCoeffMgr.h
+++ b/include/cantera/kinetics/RateCoeffMgr.h
@@ -75,6 +75,18 @@ public:
         return m_rates.size();
     }
 
+    doublereal getEffectivePreExponentialFactor(int rnum) {
+        return m_rates[rnum].preExponentialFactor();
+    }
+
+    doublereal getEffectiveTemperatureExponent(int rnum) {
+        return m_rates[rnum].temperatureExponent();
+    }
+
+    doublereal getEffectiveActivationEnergy_R(int rnum) {
+        return m_rates[rnum].activationEnergy_R();
+    }
+
 protected:
     std::vector<R> m_rates;
     std::vector<size_t> m_rxn;

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -21,7 +21,7 @@ Arrhenius::Arrhenius(doublereal A, doublereal b, doublereal E)
     if (m_A  <= 0.0) {
         m_logA = -1.0E300;
     } else {
-        m_logA = log(m_A);
+        m_logA = std::log(m_A);
     }
 }
 
@@ -39,8 +39,7 @@ SurfaceArrhenius::SurfaceArrhenius()
 }
 
 SurfaceArrhenius::SurfaceArrhenius(double A, double b, double Ta)
-    : m_logA(std::log(A))
-    , m_b(b)
+    : m_b(b)
     , m_E(Ta)
     , m_A(A)
     , m_acov(0.0)
@@ -49,6 +48,11 @@ SurfaceArrhenius::SurfaceArrhenius(double A, double b, double Ta)
     , m_ncov(0)
     , m_nmcov(0)
 {
+    if (m_A  <= 0.0) {
+        m_logA = -1.0E300;
+    } else {
+        m_logA = std::log(m_A);
+    }
 }
 
 void SurfaceArrhenius::addCoverageDependence(size_t k, doublereal a,


### PR DESCRIPTION
<b>Cython</b> versions 0.17 and 0.18 doesn't suite anymore.
Installation with old **Cython** (<0.19) fails with:

``````
............
ranlib build/lib/libcantera.a

Error compiling Cython file:
------------------------------------------------------------
...
    for species,value in X.items():
        m[stringify(species)] = value
    return m

cdef comp_map_to_dict(Composition m):
    return {pystr(species):value for species,value in m.items()}
                                                      ^
------------------------------------------------------------

interfaces/cython/cantera/utils.pyx:51:55: Object of type 'Composition' has no attribute 'items'

Error compiling Cython file:
------------------------------------------------------------
...
    for species,value in X.items():
        m[stringify(species)] = value
    return m

cdef comp_map_to_dict(Composition m):
    return {pystr(species):value for species,value in m.items()}
                                                      ^
------------------------------------------------------------

interfaces/cython/cantera/utils.pyx:51:55: Object of type 'Composition' has no attribute 'items'
scons: *** [interfaces/cython/cantera/_cantera.cpp] CompileError : /home/workstation/cantera/interfaces/cython/cantera/_cantera.pyx
Traceback (most recent call last):
  File "/usr/lib/scons/SCons/Action.py", line 1062, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "/home/workstation/cantera/interfaces/cython/SConscript", line 58, in cythonize
    Cython.Build.cythonize([f.abspath for f in source])
  File "/usr/local/lib/python2.7/dist-packages/Cython/Build/Dependencies.py", line 673, in cythonize
    cythonize_one(*args[1:])
  File "/usr/local/lib/python2.7/dist-packages/Cython/Build/Dependencies.py", line 737, in cythonize_one
    raise CompileError(None, pyx_file)
CompileError: /home/workstation/cantera/interfaces/cython/cantera/_cantera.pyx
scons: building terminated because of errors. ```
``````
