### PR TITLE
[Doc] Cython minimum version is 0.19

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -941,7 +941,7 @@ if env['VERBOSE']:
 env['python_cmd_esc'] = quoted(env['python_cmd'])
 
 # Python 2 Package Settings
-cython_min_version = LooseVersion('0.17')
+cython_min_version = LooseVersion('0.19')
 env['install_python2_action'] = ''
 if env['python_package'] == 'new':
     env['python_package'] = 'full' # Allow 'new' as a synonym for 'full'

--- a/doc/sphinx/compiling.rst
+++ b/doc/sphinx/compiling.rst
@@ -37,12 +37,12 @@ Linux
 
 * Building the python module also requires::
 
-      cython python-dev python-numpy python-numpy-dev
+      cython python-dev python-numpy python-numpy-dev python-setuptools
 
 * Checking out the source code from version control requires Git (install
   ``git``).
 
-* The minimum compatible Cython version is 0.17. If your distribution does not
+* The minimum compatible Cython version is 0.19. If your distribution does not
   contain a suitable version, you may be able to install a more recent version
   using `easy_install` or `pip`.
 
@@ -438,9 +438,8 @@ Optional Programs
 
 * `Cython <http://cython.org/>`_
 
-  * Required to build the Python module
-  * Known to work with versions 0.19 and 0.20. Expected to work with
-    versions >= 0.17.
+  * Required version >=0.19 to build the Python module
+  * Known to work with versions 0.19 and 0.20.
   * Tested with Python 2.7, 3.3, and 3.4. Expected to work with versions 2.6 and
     3.1+ as well.
 


### PR DESCRIPTION
<b>Cython</b> versions 0.17 and 0.18 doesn't suite anymore.
Installation with old **Cython** (<0.19) fails with:

```
............
ranlib build/lib/libcantera.a

Error compiling Cython file:
------------------------------------------------------------
...
    for species,value in X.items():
        m[stringify(species)] = value
    return m

cdef comp_map_to_dict(Composition m):
    return {pystr(species):value for species,value in m.items()}
                                                      ^
------------------------------------------------------------

interfaces/cython/cantera/utils.pyx:51:55: Object of type 'Composition' has no attribute 'items'

Error compiling Cython file:
------------------------------------------------------------
...
    for species,value in X.items():
        m[stringify(species)] = value
    return m

cdef comp_map_to_dict(Composition m):
    return {pystr(species):value for species,value in m.items()}
                                                      ^
------------------------------------------------------------

interfaces/cython/cantera/utils.pyx:51:55: Object of type 'Composition' has no attribute 'items'
scons: *** [interfaces/cython/cantera/_cantera.cpp] CompileError : /home/workstation/cantera/interfaces/cython/cantera/_cantera.pyx
Traceback (most recent call last):
  File "/usr/lib/scons/SCons/Action.py", line 1062, in execute
    result = self.execfunction(target=target, source=rsources, env=env)
  File "/home/workstation/cantera/interfaces/cython/SConscript", line 58, in cythonize
    Cython.Build.cythonize([f.abspath for f in source])
  File "/usr/local/lib/python2.7/dist-packages/Cython/Build/Dependencies.py", line 673, in cythonize
    cythonize_one(*args[1:])
  File "/usr/local/lib/python2.7/dist-packages/Cython/Build/Dependencies.py", line 737, in cythonize_one
    raise CompileError(None, pyx_file)
CompileError: /home/workstation/cantera/interfaces/cython/cantera/_cantera.pyx
scons: building terminated because of errors.
```

Tested on Ubuntu Linux.
