### PR TITLE
[Python] Fix full-state (e.g. TPX) properties of PureFluid

### DIFF
--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -76,6 +76,14 @@ class TestPureFluid(utilities.CanteraTest):
         self.check_fd_properties(self.water.max_temp*(1-1e-5), 101325,
                               self.water.max_temp*(1-1e-4), 101325, 1e-2)
 
+    def test_TPX(self):
+        self.water.TX = 400, 0.8
+        T,P,X = self.water.TPX
+        self.assertNear(T, 400)
+        self.assertNear(X, 0.8)
+        with self.assertRaises(AttributeError):
+            self.water.TPX = 500, 101325, 0.3
+
 
 # To minimize errors when transcribing tabulated data, the input units here are:
 # T: K, P: MPa, rho: kg/m3, v: m3/kg, (u,h): kJ/kg, s: kJ/kg-K

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1219,3 +1219,51 @@ cdef class PureFluid(ThermoPhase):
             P = values[0] if values[0] is not None else self.P
             X = values[1] if values[1] is not None else self.X
             self.thermo.setState_Psat(P, X)
+
+    property TDX:
+        """
+        Get the temperature [K], density [kg/m^3 or kmol/m^3], and vapor
+        fraction.
+        """
+        def __get__(self):
+            return self.T, self.density, self.X
+
+    property TPX:
+        """Get the temperature [K], pressure [Pa], and vapor fraction."""
+        def __get__(self):
+            return self.T, self.P, self.X
+
+    property UVX:
+        """
+        Get the internal energy [J/kg or J/kmol], specific volume
+        [m^3/kg or m^3/kmol], and vapor fraction.
+        """
+        def __get__(self):
+            return self.u, self.v, self.X
+
+    property DPX:
+        """Get the density [kg/m^3], pressure [Pa], and vapor fraction."""
+        def __get__(self):
+            return self.density, self.P, self.X
+
+    property HPX:
+        """
+        Get the enthalpy [J/kg or J/kmol], pressure [Pa] and vapor fraction.
+        """
+        def __get__(self):
+            return self.h, self.P, self.X
+
+    property SPX:
+        """
+        Get the entropy [J/kg/K or J/kmol/K], pressure [Pa], and vapor fraction.
+        """
+        def __get__(self):
+            return self.s, self.P, self.X
+
+    property SVX:
+        """
+        Get the entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
+        m^3/kmol], and vapor fraction.
+        """
+        def __get__(self):
+            return self.s, self.v, self.X


### PR DESCRIPTION
The implementations which come from ThermoPhase expect "X" to mean mole
fractions, but for PureFluid "X" means vapor fraction. No setter is provided
since all three properties cannot be specified simultaneously.

Resolves #307
