### PR TITLE
Add element weights interface

### DIFF
--- a/doc/sphinx/cython/thermo.rst
+++ b/doc/sphinx/cython/thermo.rst
@@ -62,3 +62,13 @@ ShomatePoly2
 ^^^^^^^^^^^^
 .. autoclass:: ShomatePoly2(T_low, T_high, P_ref, coeffs)
     :no-undoc-members:
+
+Element
+-------
+
+.. autoclass:: Element
+    :no-undoc-members:
+
+    .. autoattribute:: num_elements_defined
+    .. autoattribute:: element_symbols
+    .. autoattribute:: element_names

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -1,6 +1,6 @@
 /**
  *  @file Elements.h
- *  Contains the LookupWtElements function and the definitions of element
+ *  Contains the getElementWeight function and the definitions of element
  *  constraint types.
  */
 //  Copyright 2001  California Institute of Technology
@@ -85,16 +85,29 @@ namespace Cantera
 #define ENTROPY298_UNKNOWN -123456789.
 
 //! Function to look up an atomic weight
-//! This function looks up the argument string in the database above and
-//! returns the associated molecular weight.
-//! The data are from the periodic table.
-//!
-//! Note: The idea behind this function is to provide a unified source for the
-//! element atomic weights. This helps to ensure that mass is conserved.
-//!     @param ename  String, Only the first 3 characters are significant
-//!     @return The atomic weight of the element
-//!     @exception CanteraError If a match is not found, throws a CanteraError
+/*!
+ * @deprecated Replaced with getElementWeight(). To be removed after Cantera 2.3
+ */
 double LookupWtElements(const std::string& ename);
+
+//! Get the atomic weight of an element.
+/*!
+ * Get the atomic weight of an element defined in Cantera by its symbol
+ * or by its name. This includes the named isotopes defined in Cantera.
+ *
+ * @param ename String, name or symbol of the element
+ * @return The atomic weight of the element
+ * @exception CanteraError If a match is not found, throws a CanteraError
+ */
+double getElementWeight(const std::string& ename);
+
+//! Get the number of named elements defined in Cantera.
+//! This array excludes named isotopes
+int numElementsDefined();
+
+//! Get the number of named isotopes defined in Cantera.
+//! This array excludes the named elements
+int numIsotopesDefined();
 
 } // namespace
 

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -101,6 +101,78 @@ double LookupWtElements(const std::string& ename);
  */
 double getElementWeight(const std::string& ename);
 
+//! Get the atomic weight of an element.
+/*!
+ * Get the atomic weight of an element defined in Cantera by its atomic
+ * number. The named isotopes cannot be accessed from this function,
+ * since the atomic number of the isotopes is the same as the regular
+ * element from which they are derived.
+ *
+ * @param atomicNumber Integer, atomic number of the element
+ * @return The atomic weight of the element
+ * @exception CanteraError If a match is not found, throws a CanteraError
+ */
+double getElementWeight(int atomicNumber);
+
+//! Get the symbol for an element
+/*!
+ * Get the symbol for an element defined in Cantera by its name. This
+ * includes the named isotopes defined in Cantera.
+ *
+ * @param ename String, name of the element
+ * @return The symbol of the element in a string
+ * @exception CanteraError If a match is not found, throws a CanteraError
+ */
+std::string getElementSymbol(const std::string& ename);
+
+//! Get the symbol for an element
+/*!
+ * Get the symbol for an element defined in Cantera by its atomic
+ * number. The named isotopes cannot be accessed from this function,
+ * since the atomic number of the isotopes is the same as the regular
+ * element from which they are derived.
+ *
+ * @param atomicNumber Integer, atomic number of the element
+ * @return The symbol of the element in a string
+ * @exception CanteraError If a match is not found, throws a CanteraError
+ */
+std::string getElementSymbol(int atomicNumber);
+
+//! Get the name of an element
+/*!
+ * Get the name of an element defined in Cantera by its symbol. This
+ * includes the named isotopes defined in Cantera.
+ *
+ * @param ename String, symbol for the element
+ * @return The name of the element, in a string
+ * @exception CanteraError If a match is not found, throws a CanteraError
+ */
+std::string getElementName(const std::string& ename);
+
+//! Get the name of an element
+/*!
+ * Get the name of an element defined in Cantera by its atomic
+ * number. The named isotopes cannot be accessed from this function,
+ * since the atomic number of the isotopes is the same as the regular
+ * element from which they are derived.
+ *
+ * @param atomicNumber Integer, atomic number of the element
+ * @return The name of the element, in a string
+ * @exception CanteraError If a match is not found, throws a CanteraError
+ */
+std::string getElementName(int atomicNumber);
+
+//! Get the atomic number for an element
+/*!
+ * Get the atomic number of an element defined in Cantera by its symbol
+ * or name. This includes the named isotopes included in Cantera.
+ *
+ *  @param ename String, name or symbol of the element
+ *  @return The integer atomic number of the element
+ *  @exception CanteraError If a match is not found, throws a CanteraError
+ */
+int getAtomicNumber(const std::string& ename);
+
 //! Get the number of named elements defined in Cantera.
 //! This array excludes named isotopes
 int numElementsDefined();

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -995,3 +995,13 @@ cdef np.ndarray get_transport_2d(Transport tran, transportMethod2d method)
 cdef CxxIdealGasPhase* getIdealGasPhase(ThermoPhase phase) except *
 cdef wrapSpeciesThermo(shared_ptr[CxxSpeciesThermo] spthermo)
 cdef Reaction wrapReaction(shared_ptr[CxxReaction] reaction)
+
+cdef extern from "cantera/thermo/Elements.h" namespace "Cantera":
+    double getElementWeight(string ename) except +
+    double getElementWeight(int atomicNumber) except +
+    int numElementsDefined()
+    int getAtomicNumber(string ename) except +
+    string getElementSymbol(string ename) except +
+    string getElementSymbol(int atomicNumber) except +
+    string getElementName(string ename) except +
+    string getElementName(int atomicNumber) except +

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1018,6 +1018,11 @@ class TestElement(utilities.CanteraTest):
         cls.ar_name = ct.Element('argon')
         cls.ar_num = ct.Element(18)
 
+    def test_element_multiple_possibilities(self):
+        carbon = ct.Element('Carbon')
+        self.assertEqual(carbon.name, 'carbon')
+        self.assertEqual(carbon.symbol, 'C')
+
     def test_element_weight(self):
         self.assertNear(self.ar_sym.weight, 39.948)
         self.assertNear(self.ar_name.weight, 39.948)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1009,3 +1009,68 @@ class TestMisc(utilities.CanteraTest):
     def test_stringify_bad(self):
         with self.assertRaises(AttributeError):
             ct.Solution(3)
+
+
+class TestElement(utilities.CanteraTest):
+    @classmethod
+    def setUpClass(cls):
+        cls.ar_sym = ct.Element('Ar')
+        cls.ar_name = ct.Element('argon')
+        cls.ar_num = ct.Element(18)
+
+    def test_element_weight(self):
+        self.assertNear(self.ar_sym.weight, 39.948)
+        self.assertNear(self.ar_name.weight, 39.948)
+        self.assertNear(self.ar_num.weight, 39.948)
+
+    def test_element_symbol(self):
+        self.assertEqual(self.ar_sym.symbol, 'Ar')
+        self.assertEqual(self.ar_name.symbol, 'Ar')
+        self.assertEqual(self.ar_num.symbol, 'Ar')
+
+    def test_element_name(self):
+        self.assertEqual(self.ar_sym.name, 'argon')
+        self.assertEqual(self.ar_name.name, 'argon')
+        self.assertEqual(self.ar_num.name, 'argon')
+
+    def test_element_atomic_number(self):
+        self.assertEqual(self.ar_sym.atomic_number, 18)
+        self.assertEqual(self.ar_name.atomic_number, 18)
+        self.assertEqual(self.ar_num.atomic_number, 18)
+
+    def test_element_name_not_present(self):
+        with self.assertRaises(RuntimeError):
+            ct.Element('I am not an element')
+
+    def test_element_atomic_number_small(self):
+        with self.assertRaises(RuntimeError):
+            ct.Element(0)
+
+    def test_element_atomic_number_big(self):
+        num_elements = ct.Element.num_elements_defined
+        with self.assertRaises(RuntimeError):
+            ct.Element(num_elements + 1)
+
+    def test_element_bad_input(self):
+        with self.assertRaises(TypeError):
+            ct.Element(1.2345)
+
+    def test_get_isotope(self):
+        d_sym = ct.Element('D')
+        self.assertEqual(d_sym.atomic_number, 1)
+        self.assertNear(d_sym.weight, 2.0)
+        self.assertEqual(d_sym.name, 'deuterium')
+        self.assertEqual(d_sym.symbol, 'D')
+
+        d_name = ct.Element('deuterium')
+        self.assertEqual(d_name.atomic_number, 1)
+        self.assertNear(d_name.weight, 2.0)
+        self.assertEqual(d_name.name, 'deuterium')
+        self.assertEqual(d_name.symbol, 'D')
+
+    def test_elements_lists(self):
+        syms = ct.Element.element_symbols
+        names = ct.Element.element_names
+        num_elements = ct.Element.num_elements_defined
+        self.assertEqual(len(syms), num_elements)
+        self.assertEqual(len(names), num_elements)

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1267,3 +1267,99 @@ cdef class PureFluid(ThermoPhase):
         """
         def __get__(self):
             return self.s, self.v, self.X
+
+
+class Element(object):
+    """
+    An element or a named isotope defined in Cantera.
+
+    Class `Element` gets data for the elements and isotopes defined in
+    `src/thermo/Elements.cpp`. This class can be used in two ways. The
+    first way is to get information about all of the elements stored in
+    Cantera. The three attributes `num_elements_defined`,
+    `element_symbols`, and `element_names` can be accessed by::
+
+        >>> ct.Element.num_elements_defined
+        >>> ct.Element.element_symbols
+        >>> ct.Element.element_names
+
+    Otherwise, if the class `Element` is called with an argument, it
+    stores the data about that particular element. For example::
+
+        >>> ar_sym = ct.Element('Ar')
+        >>> ar_name = ct.Element('argon')
+        >>> ar_num = ct.Element(18)
+
+    would all create instances with the information for argon. The
+    available argument options to create an instance of the `Element`
+    class with the element information are the `name`, `symbol`, and
+    `atomic_number`. Once an instance of the class is made, the `name`,
+    `atomic_number`, `symbol`, and atomic `weight` can be accessed as
+    attributes of the instance of the `Element` class.
+
+        >>> ar_sym.name
+        'argon'
+        >>> ar_sym.weight
+        39.948
+        >>> ar_sym.atomic_number
+        18
+        >>> ar_sym.symbol
+        'Ar'
+
+    The elements available are listed below, in the `element_symbols`
+    and `element_names` attribute documentation.
+    """
+
+    #: The number of named elements (not isotopes) defined in Cantera
+    num_elements_defined = numElementsDefined()
+
+    #: A list of the symbols of all the elements (not isotopes) defined
+    #: in Cantera
+    element_symbols = [getElementSymbol(<int>(m+1))
+                       for m in range(num_elements_defined)]
+
+    #: A list of the names of all the elements (not isotopes) defined
+    #: in Cantera
+    element_names = [getElementName(<int>m+1)
+                     for m in range(num_elements_defined)]
+
+    def __init__(self, arg):
+        if isinstance(arg, (str, unicode, bytes)):
+            try:
+                self._name = getElementName(stringify(arg))
+            except RuntimeError:
+                self._symbol = getElementSymbol(stringify(arg))
+                self._name = arg
+            else:
+                self._symbol = arg
+
+            self._atomic_number = getAtomicNumber(stringify(arg))
+            self._weight = getElementWeight(stringify(arg))
+        elif isinstance(arg, int):
+            self._atomic_number = arg
+            self._name = getElementName(<int>arg)
+            self._symbol = getElementSymbol(<int>arg)
+            self._weight = getElementWeight(<int>arg)
+        else:
+            raise TypeError('The input argument to Element must be a string '
+                            'or an integer')
+
+    @property
+    def name(self):
+        """The name of the element or isotope."""
+        return self._name
+
+    @property
+    def atomic_number(self):
+        """The atomic number of the element or isotope."""
+        return self._atomic_number
+
+    @property
+    def symbol(self):
+        """The symbol of the element or isotope."""
+        return self._symbol
+
+    @property
+    def weight(self):
+        """The atomic weight of the element or isotope."""
+        return self._weight

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1326,10 +1326,12 @@ class Element(object):
     def __init__(self, arg):
         if isinstance(arg, (str, unicode, bytes)):
             try:
+                # Assume the argument is the element symbol and try to get the name
                 self._name = getElementName(stringify(arg))
             except RuntimeError:
+                # If getting the name failed, the argument must be the name
                 self._symbol = getElementSymbol(stringify(arg))
-                self._name = arg
+                self._name = arg.lower()
             else:
                 self._symbol = arg
 

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -14,138 +14,193 @@ using namespace std;
 namespace Cantera
 {
 
-/*! Database for atomic molecular weights
+/*! Database for atomic weights
  * Values are taken from the 1989 Standard Atomic Weights, CRC
- *
- * awTable[] is a static function with scope limited to this file.
- * It can only be referenced via the LookupWtElements() function.
  *
  * units = kg / kg-mol (or equivalently gm / gm-mol)
  *
  * This structure was picked because it's simple, compact, and extensible.
  */
-struct awData {
-    char name[4]; //!< Null Terminated name, First letter capitalized
-    double atomicWeight; //!< atomic weight in kg / kg-mol
+struct atomicWeightData {
+    string symbol; //!< Element symbol, first letter capitalized
+    string fullName; //!< Element full name, first letter lowercase
+    double atomicWeight; //!< Element atomic weight in kg / kg-mol
+};
+
+/*! Database for named isotopic weights
+ * Values are taken from the 1989 Standard Atomic Weights, CRC
+ *
+ * units = kg / kg-mol (or equivalently gm / gm-mol)
+ *
+ * This structure was picked because it's simple, compact, and extensible.
+ */
+struct isotopeWeightData {
+    string symbol; //!< Isotope symbol, first letter capitalized
+    string fullName; //!< Isotope full name, first letter lowercase
+    double atomicWeight; //!< Isotope atomic weight in kg / kg-mol
+    int atomicNumber; //!< Isotope atomic number
 };
 
 /*!
- * @var static struct awData aWTable[]
- * \brief aWTable is a vector containing the atomic weights database.
+ * @var static struct atomicWeightData atomicWeightTable[]
+ * \brief atomicWeightTable is a vector containing the atomic weights database.
+ *
+ * atomicWeightTable[] is a static function with scope limited to this file.
+ * It can only be referenced via the functions in this file.
  *
  * The size of the table is given by the initial instantiation.
  */
-static struct awData aWTable[] = {
-    {"H",    1.00794},
-    {"D",    2.0    },
-    {"Tr",   3.0    },
-    {"He",   4.002602},
-    {"Li",   6.941  },
-    {"Be",   9.012182},
-    {"B",   10.811  },
-    {"C",   12.011  },
-    {"N",   14.00674},
-    {"O",   15.9994 },
-    {"F",   18.9984032},
-    {"Ne",  20.1797 },
-    {"Na",  22.98977},
-    {"Mg",  24.3050 },
-    {"Al",  26.98154},
-    {"Si",  28.0855 },
-    {"P",   30.97376},
-    {"S",   32.066  },
-    {"Cl",  35.4527 },
-    {"Ar",  39.948  },
-    {"K",   39.0983 },
-    {"Ca",  40.078  },
-    {"Sc",  44.95591},
-    {"Ti",  47.88   },
-    {"V",   50.9415 },
-    {"Cr",  51.9961 },
-    {"Mn",  54.9381 },
-    {"Fe",  55.847  },
-    {"Co",  58.9332 },
-    {"Ni",  58.69   },
-    {"Cu",  63.546  },
-    {"Zn",  65.39   },
-    {"Ga",  69.723  },
-    {"Ge",  72.61   },
-    {"As",  74.92159},
-    {"Se",  78.96   },
-    {"Br",  79.904  },
-    {"Kr",  83.80   },
-    {"Rb",  85.4678 },
-    {"Sr",  87.62   },
-    {"Y",   88.90585},
-    {"Zr",  91.224  },
-    {"Nb",  92.90638},
-    {"Mo",  95.94   },
-    {"Tc",  97.9072 },
-    {"Ru", 101.07   },
-    {"Rh", 102.9055 },
-    {"Pd", 106.42   },
-    {"Ag", 107.8682 },
-    {"Cd", 112.411  },
-    {"In", 114.82   },
-    {"Sn", 118.710  },
-    {"Sb", 121.75   },
-    {"Te", 127.6    },
-    {"I",  126.90447},
-    {"Xe", 131.29   },
-    {"Cs", 132.90543},
-    {"Ba", 137.327  },
-    {"La", 138.9055 },
-    {"Ce", 140.115  },
-    {"Pr", 140.90765},
-    {"Nd", 144.24   },
-    {"Pm", 144.9127 },
-    {"Sm", 150.36   },
-    {"Eu", 151.965  },
-    {"Gd", 157.25   },
-    {"Tb", 158.92534},
-    {"Dy", 162.50   },
-    {"Ho", 164.93032},
-    {"Er", 167.26   },
-    {"Tm", 168.93421},
-    {"Yb", 173.04   },
-    {"Lu", 174.967  },
-    {"Hf", 178.49   },
-    {"Ta", 180.9479 },
-    {"W",  183.85   },
-    {"Re", 186.207  },
-    {"Os", 190.2    },
-    {"Ir", 192.22   },
-    {"Pt", 195.08   },
-    {"Au", 196.96654},
-    {"Hg", 200.59   },
-    {"Ti", 204.3833 },
-    {"Pb", 207.2    },
-    {"Bi", 208.98037},
-    {"Po", 208.9824 },
-    {"At", 209.9871 },
-    {"Rn", 222.0176 },
-    {"Fr", 223.0197 },
-    {"Ra", 226.0254 },
-    {"Ac", 227.0279 },
-    {"Th", 232.0381 },
-    {"Pa", 231.03588},
-    {"U",  238.0508 },
-    {"Np", 237.0482 },
-    {"Pu", 244.0482 }
+static struct atomicWeightData atomicWeightTable[] = {
+    {"H",  "hydrogen",       1.00794},
+    {"He", "helium",         4.002602},
+    {"Li", "lithium",        6.941  },
+    {"Be", "beryllium",      9.012182},
+    {"B",  "boron",         10.811  },
+    {"C",  "carbon",        12.011  },
+    {"N",  "nitrogen",      14.00674},
+    {"O",  "oxygen",        15.9994 },
+    {"F",  "fluorine",      18.9984032},
+    {"Ne", "neon",          20.1797 },
+    {"Na", "sodium",        22.98977},
+    {"Mg", "magnesium",     24.3050 },
+    {"Al", "aluminum",      26.98154},
+    {"Si", "silicon",       28.0855 },
+    {"P",  "phosphorus",    30.97376},
+    {"S",  "sulfur",        32.066  },
+    {"Cl", "chlorine",      35.4527 },
+    {"Ar", "argon",         39.948  },
+    {"K",  "potassium",     39.0983 },
+    {"Ca", "calcium",       40.078  },
+    {"Sc", "scandium",      44.95591},
+    {"Ti", "titanium",      47.88   },
+    {"V",  "vanadium",      50.9415 },
+    {"Cr", "chromium",      51.9961 },
+    {"Mn", "manganese",     54.9381 },
+    {"Fe", "iron",          55.847  },
+    {"Co", "cobalt",        58.9332 },
+    {"Ni", "nickel",        58.69   },
+    {"Cu", "copper",        63.546  },
+    {"Zn", "zinc",          65.39   },
+    {"Ga", "gallium",       69.723  },
+    {"Ge", "germanium",     72.61   },
+    {"As", "arsenic",       74.92159},
+    {"Se", "selenium",      78.96   },
+    {"Br", "bromine",       79.904  },
+    {"Kr", "krypton",       83.80   },
+    {"Rb", "rubidium",      85.4678 },
+    {"Sr", "strontium",     87.62   },
+    {"Y",  "yttrium",       88.90585},
+    {"Zr", "zirconium",     91.224  },
+    {"Nb", "nobelium",      92.90638},
+    {"Mo", "molybdenum",    95.94   },
+    {"Tc", "technetium",    97.9072 },
+    {"Ru", "ruthenium",    101.07   },
+    {"Rh", "rhodium",      102.9055 },
+    {"Pd", "palladium",    106.42   },
+    {"Ag", "silver",       107.8682 },
+    {"Cd", "cadmium",      112.411  },
+    {"In", "indium",       114.82   },
+    {"Sn", "tin",          118.710  },
+    {"Sb", "antimony",     121.75   },
+    {"Te", "tellurium",    127.6    },
+    {"I",  "iodine",       126.90447},
+    {"Xe", "xenon",        131.29   },
+    {"Cs", "cesium",       132.90543},
+    {"Ba", "barium",       137.327  },
+    {"La", "lanthanum",    138.9055 },
+    {"Ce", "cerium",       140.115  },
+    {"Pr", "praseodymium", 140.90765},
+    {"Nd", "neodymium",    144.24   },
+    {"Pm", "promethium",   144.9127 },
+    {"Sm", "samarium",     150.36   },
+    {"Eu", "europium",     151.965  },
+    {"Gd", "gadolinium",   157.25   },
+    {"Tb", "terbium",      158.92534},
+    {"Dy", "dysprosium",   162.50   },
+    {"Ho", "holmium",      164.93032},
+    {"Er", "erbium",       167.26   },
+    {"Tm", "thulium",      168.93421},
+    {"Yb", "ytterbium",    173.04   },
+    {"Lu", "lutetium",     174.967  },
+    {"Hf", "hafnium",      178.49   },
+    {"Ta", "tantalum",     180.9479 },
+    {"W",  "tungsten",     183.85   },
+    {"Re", "rhenium",      186.207  },
+    {"Os", "osmium",       190.2    },
+    {"Ir", "iridium",      192.22   },
+    {"Pt", "platinum",     195.08   },
+    {"Au", "gold",         196.96654},
+    {"Hg", "mercury",      200.59   },
+    {"Tl", "thallium",     204.3833 },
+    {"Pb", "lead",         207.2    },
+    {"Bi", "bismuth",      208.98037},
+    {"Po", "polonium",     208.9824 },
+    {"At", "astatine",     209.9871 },
+    {"Rn", "radon",        222.0176 },
+    {"Fr", "francium",     223.0197 },
+    {"Ra", "radium",       226.0254 },
+    {"Ac", "actinium",     227.0279 },
+    {"Th", "thorium",      232.0381 },
+    {"Pa", "protactinium", 231.03588},
+    {"U",  "uranium",      238.0508 },
+    {"Np", "neptunium",    237.0482 },
+    {"Pu", "plutonium",    244.0482 },
 };
 
+/*!
+ * @var static struct isotopeWeightData isotopeWeightTable[]
+ * \brief isotopeWeightTable is a vector containing the atomic weights database.
+ *
+ * isotopeWeightTable[] is a static function with scope limited to this file.
+ * It can only be referenced via the functions in this file.
+ *
+ * The size of the table is given by the initial instantiation.
+ */
+static struct isotopeWeightData isotopeWeightTable[] = {
+    {"D",  "deuterium", 2.0, 1},
+    {"Tr", "tritium",   3.0, 1},
+};
 
-doublereal LookupWtElements(const std::string& ename)
+double LookupWtElements(const std::string& ename)
 {
-    int num = sizeof(aWTable) / sizeof(struct awData);
-    string s3 = ename.substr(0,3);
-    for (int i = 0; i < num; i++) {
-        if (s3 == aWTable[i].name) {
-            return aWTable[i].atomicWeight;
+    warn_deprecated("LookupWtElements",
+    "Use getElementWeight instead. To be removed after Cantera 2.3");
+    return getElementWeight(ename);
+}
+
+double getElementWeight(const std::string& ename)
+{
+    int numElements = numElementsDefined();
+    int numIsotopes = numIsotopesDefined();
+    string sym = ename.substr(0,2);
+    for (int i = 0; i < numElements; i++) {
+        if (sym == atomicWeightTable[i].symbol) {
+            return atomicWeightTable[i].atomicWeight;
+        }
+        else if (ename == atomicWeightTable[i].fullName) {
+            return atomicWeightTable[i].atomicWeight;
         }
     }
-    throw CanteraError("LookupWtElements", "element not found");
+    for (int i = 0; i < numIsotopes; i++) {
+        if (sym == isotopeWeightTable[i].symbol) {
+            return isotopeWeightTable[i].atomicWeight;
+        }
+        else if (ename == isotopeWeightTable[i].fullName) {
+            return isotopeWeightTable[i].atomicWeight;
+        }
+    }
+    throw CanteraError("getElementWeight", "element not found: " + ename);
     return -1.0;
+}
+
+int numElementsDefined()
+{
+    return sizeof(atomicWeightTable) / sizeof(struct atomicWeightData);
+}
+
+int numIsotopesDefined()
+{
+    return sizeof(isotopeWeightTable) / sizeof(struct isotopeWeightData);
 }
 
 }

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -193,6 +193,95 @@ double getElementWeight(const std::string& ename)
     return -1.0;
 }
 
+double getElementWeight(int atomicNumber)
+{
+    int num = numElementsDefined();
+    if (atomicNumber > num || atomicNumber < 1) {
+        throw IndexError("getElementWeight", "atomicWeightTable", atomicNumber, num);
+    }
+    return atomicWeightTable[atomicNumber - 1].atomicWeight;
+}
+
+string getElementSymbol(const std::string& ename)
+{
+    int numElements = numElementsDefined();
+    int numIsotopes = numIsotopesDefined();
+    for (int i = 0; i < numElements; i++) {
+        if (ename == atomicWeightTable[i].fullName) {
+            return atomicWeightTable[i].symbol;
+        }
+    }
+    for (int i = 0; i < numIsotopes; i++) {
+        if (ename == isotopeWeightTable[i].fullName) {
+            return isotopeWeightTable[i].symbol;
+        }
+    }
+    throw CanteraError("getElementSymbol", "element not found: " + ename);
+}
+
+string getElementSymbol(int atomicNumber)
+{
+    int num = numElementsDefined();
+    if (atomicNumber > num || atomicNumber < 1) {
+        throw IndexError("getElementSymbol", "atomicWeightTable", atomicNumber,
+                         num);
+    }
+    return atomicWeightTable[atomicNumber - 1].symbol;
+}
+
+string getElementName(const std::string& ename)
+{
+    int numElements = numElementsDefined();
+    int numIsotopes = numIsotopesDefined();
+    string sym = ename.substr(0,2);
+    for (int i = 0; i < numElements; i++) {
+        if (sym == atomicWeightTable[i].symbol) {
+            return atomicWeightTable[i].fullName;
+        }
+    }
+    for (int i = 0; i < numIsotopes; i++) {
+        if (sym == isotopeWeightTable[i].symbol) {
+            return isotopeWeightTable[i].fullName;
+        }
+    }
+    throw CanteraError("getElementName", "element not found: " + ename);
+}
+
+string getElementName(int atomicNumber)
+{
+    int num = numElementsDefined();
+    if (atomicNumber > num || atomicNumber < 1) {
+        throw IndexError("getElementName", "atomicWeightTable", atomicNumber,
+        num);
+    }
+    return atomicWeightTable[atomicNumber - 1].fullName;
+}
+
+int getAtomicNumber(const std::string& ename)
+{
+    int numElements = numElementsDefined();
+    int numIsotopes = numIsotopesDefined();
+    string sym = ename.substr(0,2);
+    for (int i = 0; i < numElements; i++) {
+        if (sym == atomicWeightTable[i].symbol) {
+            return i+1;
+        }
+        else if (ename == atomicWeightTable[i].fullName) {
+            return i+1;
+        }
+    }
+    for (int i = 0; i < numIsotopes; i++) {
+        if (sym == isotopeWeightTable[i].symbol) {
+            return isotopeWeightTable[i].atomicNumber;
+        }
+        else if (ename == isotopeWeightTable[i].fullName) {
+            return isotopeWeightTable[i].atomicNumber;
+        }
+    }
+    throw CanteraError("getAtomicNumber", "element not found: " + ename);
+    return -1.0;
+}
+
 int numElementsDefined()
 {
     return sizeof(atomicWeightTable) / sizeof(struct atomicWeightData);

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -164,7 +164,7 @@ static struct isotopeWeightData isotopeWeightTable[] = {
 double LookupWtElements(const std::string& ename)
 {
     warn_deprecated("LookupWtElements",
-    "Use getElementWeight instead. To be removed after Cantera 2.3");
+        "Use getElementWeight instead. To be removed after Cantera 2.3");
     return getElementWeight(ename);
 }
 
@@ -172,25 +172,23 @@ double getElementWeight(const std::string& ename)
 {
     int numElements = numElementsDefined();
     int numIsotopes = numIsotopesDefined();
-    string sym = ename.substr(0,2);
+    string symbol = stripws(ename);
+    string name = lowercase(stripws(ename));
     for (int i = 0; i < numElements; i++) {
-        if (sym == atomicWeightTable[i].symbol) {
+        if (symbol == atomicWeightTable[i].symbol) {
             return atomicWeightTable[i].atomicWeight;
-        }
-        else if (ename == atomicWeightTable[i].fullName) {
+        } else if (name == atomicWeightTable[i].fullName) {
             return atomicWeightTable[i].atomicWeight;
         }
     }
     for (int i = 0; i < numIsotopes; i++) {
-        if (sym == isotopeWeightTable[i].symbol) {
+        if (symbol == isotopeWeightTable[i].symbol) {
             return isotopeWeightTable[i].atomicWeight;
-        }
-        else if (ename == isotopeWeightTable[i].fullName) {
+        } else if (name == isotopeWeightTable[i].fullName) {
             return isotopeWeightTable[i].atomicWeight;
         }
     }
     throw CanteraError("getElementWeight", "element not found: " + ename);
-    return -1.0;
 }
 
 double getElementWeight(int atomicNumber)
@@ -206,13 +204,14 @@ string getElementSymbol(const std::string& ename)
 {
     int numElements = numElementsDefined();
     int numIsotopes = numIsotopesDefined();
+    string name = lowercase(stripws(ename));
     for (int i = 0; i < numElements; i++) {
-        if (ename == atomicWeightTable[i].fullName) {
+        if (name == atomicWeightTable[i].fullName) {
             return atomicWeightTable[i].symbol;
         }
     }
     for (int i = 0; i < numIsotopes; i++) {
-        if (ename == isotopeWeightTable[i].fullName) {
+        if (name == isotopeWeightTable[i].fullName) {
             return isotopeWeightTable[i].symbol;
         }
     }
@@ -233,14 +232,14 @@ string getElementName(const std::string& ename)
 {
     int numElements = numElementsDefined();
     int numIsotopes = numIsotopesDefined();
-    string sym = ename.substr(0,2);
+    string symbol = stripws(ename);
     for (int i = 0; i < numElements; i++) {
-        if (sym == atomicWeightTable[i].symbol) {
+        if (symbol == atomicWeightTable[i].symbol) {
             return atomicWeightTable[i].fullName;
         }
     }
     for (int i = 0; i < numIsotopes; i++) {
-        if (sym == isotopeWeightTable[i].symbol) {
+        if (symbol == isotopeWeightTable[i].symbol) {
             return isotopeWeightTable[i].fullName;
         }
     }
@@ -252,7 +251,7 @@ string getElementName(int atomicNumber)
     int num = numElementsDefined();
     if (atomicNumber > num || atomicNumber < 1) {
         throw IndexError("getElementName", "atomicWeightTable", atomicNumber,
-        num);
+                         num);
     }
     return atomicWeightTable[atomicNumber - 1].fullName;
 }
@@ -261,25 +260,23 @@ int getAtomicNumber(const std::string& ename)
 {
     int numElements = numElementsDefined();
     int numIsotopes = numIsotopesDefined();
-    string sym = ename.substr(0,2);
+    string symbol = stripws(ename);
+    string name = lowercase(stripws(ename));
     for (int i = 0; i < numElements; i++) {
-        if (sym == atomicWeightTable[i].symbol) {
+        if (symbol == atomicWeightTable[i].symbol) {
             return i+1;
-        }
-        else if (ename == atomicWeightTable[i].fullName) {
+        } else if (name == atomicWeightTable[i].fullName) {
             return i+1;
         }
     }
     for (int i = 0; i < numIsotopes; i++) {
-        if (sym == isotopeWeightTable[i].symbol) {
+        if (symbol == isotopeWeightTable[i].symbol) {
             return isotopeWeightTable[i].atomicNumber;
-        }
-        else if (ename == isotopeWeightTable[i].fullName) {
+        } else if (name == isotopeWeightTable[i].fullName) {
             return isotopeWeightTable[i].atomicNumber;
         }
     }
     throw CanteraError("getAtomicNumber", "element not found: " + ename);
-    return -1.0;
 }
 
 int numElementsDefined()

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -688,7 +688,7 @@ size_t Phase::addElement(const std::string& symbol, doublereal weight,
 {
     // Look up the atomic weight if not given
     if (weight == -12345.0) {
-        weight = LookupWtElements(symbol);
+        weight = getElementWeight(symbol);
         if (weight < 0.0) {
             throw CanteraError("Phase::addElement",
                                "No atomic weight found for element: " + symbol);


### PR DESCRIPTION
This PR adds an interface to the `LookupWtElements` C++ function (defined in `src/thermo/Elements.cpp`) to look up element weights by name, symbol, or atomic number. This is my first work in Cython, so recommendations and improvements are definitely welcome.

There is also a commit here (labeled `BROKEN`) that contains some commented out code because it causes a compiler error related to the `compositionMap`. I'm trying to add some way to return the element's `struct` as something that can be turned into a dictionary in Python, with either the symbol or the name as the dictionary index. Unfortunately, my attempt to copy the way that `getMoleFractionsByName` works didn't work here. Any help is appreciated.

Finally, I think it would be good to add a case-normalization somewhere in here, so the user can get the element regardless of the case of the name or symbol they type. I could do that in C++ but its ugly and involves defining a bunch of temporary strings; or I could do that in Python and make it prettier but only applicable to the Python interface. Any preference?
