### PR TITLE
Add PureFluid properties

### DIFF
--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -273,7 +273,7 @@ public:
     //! Update the standard state chemical potentials and species equilibrium
     //! constant entries
     /*!
-     *  Virtual because it is overwritten when dealing with experimental open
+     *  Virtual because it is overridden when dealing with experimental open
      *  circuit voltage overrides
      */
     virtual void updateMu0();

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -646,7 +646,7 @@ protected:
 public:
     //! Set the internally stored density (gm/m^3) of the phase.
     /*!
-     * Overwritten setDensity() function is necessary because the density is not
+     * Overridden setDensity() function is necessary because the density is not
      * an independent variable.
      *
      * This function will now throw an error condition
@@ -668,7 +668,7 @@ public:
 
     //! Set the internally stored molar density (kmol/m^3) of the phase.
     /**
-     * Overwritten setMolarDensity() function is necessary because the density
+     * Overridden setMolarDensity() function is necessary because the density
      * is not an independent variable.
      *
      * This function will now throw an error condition if the input isn't

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1332,7 +1332,7 @@ protected:
 public:
     //! Set the internally stored density (kg/m^3) of the phase.
     /*!
-     * Overwritten setDensity() function is necessary because the density is not
+     * Overridden setDensity() function is necessary because the density is not
      * an independent variable.
      *
      * This function will now throw an error condition.
@@ -1354,7 +1354,7 @@ public:
 
     //! Set the internally stored molar density (kmol/m^3) for the phase.
     /**
-     * Overwritten setMolarDensity() function is necessary because of the
+     * Overridden setMolarDensity() function is necessary because of the
      * underlying water model.
      *
      * This function will now throw an error condition if the input isn't
@@ -1790,7 +1790,7 @@ public:
     //!  pressure, and solution concentration.
     /*!
      *  See Denbigh p. 278 for a thorough discussion. This class must be
-     *  overwritten in classes which derive from MolalityVPSSTP. This function
+     *  overridden in classes which derive from MolalityVPSSTP. This function
      *  takes over from the molar-based activity coefficient calculation,
      *  getActivityCoefficients(), in derived classes.
      *

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -219,7 +219,7 @@ protected:
 
 public:
     /**
-     * Overwritten setDensity() function is necessary because the density is not
+     * Overridden setDensity() function is necessary because the density is not
      * an independent variable.
      *
      * This function will now throw an error condition
@@ -233,7 +233,7 @@ public:
     void setDensity(const doublereal rho);
 
     /**
-     * Overwritten setMolarDensity() function is necessary because the density
+     * Overridden setMolarDensity() function is necessary because the density
      * is not an independent variable.
      *
      * This function will now throw an error condition.

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -224,7 +224,7 @@ public:
     void calcDensity();
 
     /**
-     * Overwritten setDensity() function is necessary because the density is not
+     * Overridden setDensity() function is necessary because the density is not
      * an independent variable.
      *
      * This function will now throw an error condition
@@ -238,7 +238,7 @@ public:
     virtual void setDensity(const doublereal rho);
 
     /**
-     * Overwritten setMolarDensity() function is necessary because the density
+     * Overridden setMolarDensity() function is necessary because the density
      * is not an independent variable.
      *
      * This function will now throw an error condition.

--- a/include/cantera/thermo/MaskellSolidSolnPhase.h
+++ b/include/cantera/thermo/MaskellSolidSolnPhase.h
@@ -75,7 +75,7 @@ public:
     virtual void setPressure(doublereal p);
 
     /**
-     * Overwritten setDensity() function is necessary because the density is not
+     * Overridden setDensity() function is necessary because the density is not
      * an independent variable.
      *
      * This function will now throw an error condition
@@ -87,7 +87,7 @@ public:
     virtual void calcDensity();
 
     /**
-     * Overwritten setMolarDensity() function is necessary because the density
+     * Overridden setMolarDensity() function is necessary because the density
      * is not an independent variable.
      *
      * This function will now throw an error condition.

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -409,7 +409,7 @@ public:
     //! the current solution temperature, pressure, and solution concentration.
     /*!
      * See Denbigh p. 278 for a thorough discussion. This class must be
-     * overwritten in classes which derive from MolalityVPSSTP. This function
+     * overridden in classes which derive from MolalityVPSSTP. This function
      * takes over from the molar-based activity coefficient calculation,
      * getActivityCoefficients(), in derived classes.
      *
@@ -540,7 +540,7 @@ protected:
     //! concentration.
     /*!
      * See Denbigh p. 278 for a thorough discussion. This class must be
-     * overwritten in classes which derive from MolalityVPSSTP. This function
+     * overridden in classes which derive from MolalityVPSSTP. This function
      * takes over from the molar-based activity coefficient calculation,
      * getActivityCoefficients(), in derived classes.
      *

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -27,7 +27,7 @@ namespace Cantera
  *
  * @ingroup thermoprops
  */
-class PureFluidPhase  : public ThermoPhase
+class PureFluidPhase : public ThermoPhase
 {
 public:
     //! Empty Base Constructor
@@ -122,17 +122,10 @@ public:
      * @{
      */
 
-    virtual void setState_HP(doublereal h, doublereal p,
-                             doublereal tol = 1.e-8);
-
-    virtual void setState_UV(doublereal u, doublereal v,
-                             doublereal tol = 1.e-8);
-
-    virtual void setState_SV(doublereal s, doublereal v,
-                             doublereal tol = 1.e-8);
-
-    virtual void setState_SP(doublereal s, doublereal p,
-                             doublereal tol = 1.e-8);
+    virtual void setState_HP(double h, double p, double tol = 1.e-8);
+    virtual void setState_UV(double u, double v, double tol = 1.e-8);
+    virtual void setState_SV(double s, double v, double tol = 1.e-8);
+    virtual void setState_SP(double s, double p, double tol = 1.e-8);
     //@}
 
     //! @name Critical State Properties

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -126,6 +126,13 @@ public:
     virtual void setState_UV(double u, double v, double tol = 1.e-8);
     virtual void setState_SV(double s, double v, double tol = 1.e-8);
     virtual void setState_SP(double s, double p, double tol = 1.e-8);
+    virtual void setState_ST(double s, double t, double tol = 1.e-8);
+    virtual void setState_TV(double t, double v, double tol = 1.e-8);
+    virtual void setState_PV(double p, double v, double tol = 1.e-8);
+    virtual void setState_UP(double u, double p, double tol = 1.e-8);
+    virtual void setState_VH(double v, double h, double tol = 1.e-8);
+    virtual void setState_TH(double t, double h, double tol = 1.e-8);
+    virtual void setState_SH(double s, double h, double tol = 1.e-8);
     //@}
 
     //! @name Critical State Properties

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -909,7 +909,6 @@ public:
      * @param x    Vector of mole fractions.
      *             Length is equal to m_kk.
      */
-
     virtual void setState_PX(doublereal p, doublereal* x);
 
     //! Set the internally stored pressure (Pa) and mass fractions.
@@ -977,16 +976,16 @@ public:
 
     //! Set the density (kg/m**3) and pressure (Pa) at constant composition
     /*!
-     *  This method must be reimplemented in derived classes, where it may
-     *  involve the solution of a nonlinear equation. Within %Cantera, the
-     *  independent variable is the density. Therefore, this function solves for
-     *  the temperature that will yield the desired input pressure and density.
-     *  The composition is held constant during this process.
+     * This method must be reimplemented in derived classes, where it may
+     * involve the solution of a nonlinear equation. Within %Cantera, the
+     * independent variable is the density. Therefore, this function solves for
+     * the temperature that will yield the desired input pressure and density.
+     * The composition is held constant during this process.
      *
-     *  This base class function will print an error, if not overwritten.
+     * This base class function will print an error, if not overwritten.
      *
-     *  @param rho Density (kg/m^3)
-     *  @param p   Pressure (Pa)
+     * @param rho Density (kg/m^3)
+     * @param p   Pressure (Pa)
      */
     virtual void setState_RP(doublereal rho, doublereal p) {
         throw NotImplementedError("ThermoPhase::setState_RP");
@@ -1011,9 +1010,9 @@ public:
      * are set. Setting the pressure may involve the solution of a nonlinear
      * equation.
      *
-     *  @param rho  Density (kg/m^3)
-     *  @param p    Pressure (Pa)
-     *  @param x    Composition map of mole fractions. Species not in
+     * @param rho  Density (kg/m^3)
+     * @param p    Pressure (Pa)
+     * @param x    Composition map of mole fractions. Species not in
      *              the composition map are assumed to have zero mole fraction
      */
     virtual void setState_RPX(doublereal rho, doublereal p, const compositionMap& x);
@@ -1024,9 +1023,9 @@ public:
      * are set. Setting the pressure may involve the solution of a nonlinear
      * equation.
      *
-     *  @param rho  Density (kg/m^3)
-     *  @param p    Pressure (Pa)
-     *  @param x    String containing a composition map of the mole fractions.
+     * @param rho  Density (kg/m^3)
+     * @param p    Pressure (Pa)
+     * @param x    String containing a composition map of the mole fractions.
      *              Species not in the composition map are assumed to have zero
      *              mole fraction
      */
@@ -1038,9 +1037,9 @@ public:
      * are set. Setting the pressure may involve the solution of a nonlinear
      * equation.
      *
-     *  @param rho  Density (kg/m^3)
-     *  @param p    Pressure (Pa)
-     *  @param y    Vector of mole fractions.
+     * @param rho  Density (kg/m^3)
+     * @param p    Pressure (Pa)
+     * @param y    Vector of mole fractions.
      *              Length is equal to m_kk.
      */
     virtual void setState_RPY(doublereal rho, doublereal p, const doublereal* y);
@@ -1051,9 +1050,9 @@ public:
      * are set. Setting the pressure may involve the solution of a nonlinear
      * equation.
      *
-     *  @param rho Density (kg/m^3)
-     *  @param p   Pressure (Pa)
-     *  @param y   Composition map of mole fractions. Species not in
+     * @param rho Density (kg/m^3)
+     * @param p   Pressure (Pa)
+     * @param y   Composition map of mole fractions. Species not in
      *             the composition map are assumed to have zero mole fraction
      */
     virtual void setState_RPY(doublereal rho, doublereal p, const compositionMap& y);
@@ -1064,9 +1063,9 @@ public:
      * are set. Setting the pressure may involve the solution of a nonlinear
      * equation.
      *
-     *  @param rho  Density (kg/m^3)
-     *  @param p    Pressure (Pa)
-     *  @param y    String containing a composition map of the mole fractions.
+     * @param rho  Density (kg/m^3)
+     * @param p    Pressure (Pa)
+     * @param y    String containing a composition map of the mole fractions.
      *              Species not in the composition map are assumed to have zero
      *              mole fraction
      */

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1243,7 +1243,7 @@ public:
 
     //! Return the fraction of vapor at the current conditions
     virtual doublereal vaporFraction() const {
-        throw NotImplementedError("ThermoPhase::vaprFraction");
+        throw NotImplementedError("ThermoPhase::vaporFraction");
     }
 
     //! Set the state to a saturated system at a particular temperature

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -974,6 +974,118 @@ public:
      */
     virtual void setState_SV(doublereal s, doublereal v, doublereal tol = 1.e-4);
 
+    //! Set the specific entropy (J/kg/K) and temperature (K).
+    /*!
+     * This function fixes the internal state of the phase so that the specific
+     * entropy and temperature have the value of the input parameters.
+     * This base class function will print an error if not overwritten.
+     *
+     * @param s    specific entropy (J/kg/K)
+     * @param t    temperature (K)
+     * @param tol   Optional parameter setting the tolerance of the calculation.
+     *              Defaults to 1.0E-4. Important for some applications where
+     *              numerical Jacobians are being calculated.
+     */
+    virtual void setState_ST(double s, double t, double tol = 1.e-4) {
+        throw NotImplementedError("ThermoPhase::setState_ST");
+    }
+
+    //! Set the temperature (K) and specific volume (m^3/kg).
+    /*!
+     * This function fixes the internal state of the phase so that the
+     * temperature and specific volume have the value of the input parameters.
+     * This base class function will print an error if not overwritten.
+     *
+     * @param t    temperature (K)
+     * @param v    specific volume (m^3/kg)
+     * @param tol   Optional parameter setting the tolerance of the calculation.
+     *              Defaults to 1.0E-4. Important for some applications where
+     *              numerical Jacobians are being calculated.
+     */
+    virtual void setState_TV(double t, double v, double tol = 1.e-4) {
+        throw NotImplementedError("ThermoPhase::setState_TV");
+    }
+
+    //! Set the pressure (Pa) and specific volume (m^3/kg).
+    /*!
+     * This function fixes the internal state of the phase so that the
+     * pressure and specific volume have the value of the input parameters.
+     * This base class function will print an error if not overwritten.
+     *
+     * @param p    pressure (Pa)
+     * @param v    specific volume (m^3/kg)
+     * @param tol   Optional parameter setting the tolerance of the calculation.
+     *              Defaults to 1.0E-4. Important for some applications where
+     *              numerical Jacobians are being calculated.
+     */
+    virtual void setState_PV(double p, double v, double tol = 1.e-4) {
+        throw NotImplementedError("ThermoPhase::setState_PV");
+    }
+
+    //! Set the specific internal energy (J/kg) and pressure (Pa).
+    /*!
+     * This function fixes the internal state of the phase so that the specific
+     * internal energy and pressure have the value of the input parameters.
+     * This base class function will print an error if not overwritten.
+     *
+     * @param u    specific internal energy (J/kg)
+     * @param p    pressure (Pa)
+     * @param tol   Optional parameter setting the tolerance of the calculation.
+     *              Defaults to 1.0E-4. Important for some applications where
+     *              numerical Jacobians are being calculated.
+     */
+    virtual void setState_UP(double u, double p, double tol = 1.e-4) {
+        throw NotImplementedError("ThermoPhase::setState_UP");
+    }
+
+    //! Set the specific volume (m^3/kg) and the specific enthalpy (J/kg)
+    /*!
+     * This function fixes the internal state of the phase so that the specific
+     * volume and the specific enthalpy have the value of the input parameters.
+     * This base class function will print an error if not overwritten.
+     *
+     * @param v    specific volume (m^3/kg)
+     * @param h    specific enthalpy (J/kg)
+     * @param tol   Optional parameter setting the tolerance of the calculation.
+     *              Defaults to 1.0E-4. Important for some applications where
+     *              numerical Jacobians are being calculated.
+     */
+    virtual void setState_VH(double v, double h, double tol = 1.e-4) {
+        throw NotImplementedError("ThermoPhase::setState_VH");
+    }
+
+    //! Set the temperature (K) and the specific enthalpy (J/kg)
+    /*!
+     * This function fixes the internal state of the phase so that the
+     * temperature and specific enthalpy have the value of the input parameters.
+     * This base class function will print an error if not overwritten.
+     *
+     * @param t    temperature (K)
+     * @param h    specific enthalpy (J/kg)
+     * @param tol   Optional parameter setting the tolerance of the calculation.
+     *              Defaults to 1.0E-4. Important for some applications where
+     *              numerical Jacobians are being calculated.
+     */
+    virtual void setState_TH(double t, double h, double tol = 1.e-4) {
+        throw NotImplementedError("ThermoPhase::setState_TH");
+    }
+
+    //! Set the specific entropy (J/kg/K) and the specific enthalpy (J/kg)
+    /*!
+     * This function fixes the internal state of the phase so that the
+     * temperature and pressure have the value of the input parameters.
+     * This base class function will print an error if not overwritten.
+     *
+     * @param s    specific entropy (J/kg/K)
+     * @param h    specific enthalpy (J/kg)
+     * @param tol   Optional parameter setting the tolerance of the calculation.
+     *              Defaults to 1.0E-4. Important for some applications where
+     *              numerical Jacobians are being calculated.
+     */
+    virtual void setState_SH(double s, double h, double tol = 1.e-4) {
+        throw NotImplementedError("ThermoPhase::setState_SH");
+    }
+
     //! Set the density (kg/m**3) and pressure (Pa) at constant composition
     /*!
      * This method must be reimplemented in derived classes, where it may

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -978,7 +978,7 @@ public:
     /*!
      * This function fixes the internal state of the phase so that the specific
      * entropy and temperature have the value of the input parameters.
-     * This base class function will print an error if not overwritten.
+     * This base class function will throw an exception if not overridden.
      *
      * @param s    specific entropy (J/kg/K)
      * @param t    temperature (K)
@@ -994,7 +994,7 @@ public:
     /*!
      * This function fixes the internal state of the phase so that the
      * temperature and specific volume have the value of the input parameters.
-     * This base class function will print an error if not overwritten.
+     * This base class function will throw an exception if not overridden.
      *
      * @param t    temperature (K)
      * @param v    specific volume (m^3/kg)
@@ -1010,7 +1010,7 @@ public:
     /*!
      * This function fixes the internal state of the phase so that the
      * pressure and specific volume have the value of the input parameters.
-     * This base class function will print an error if not overwritten.
+     * This base class function will throw an exception if not overridden.
      *
      * @param p    pressure (Pa)
      * @param v    specific volume (m^3/kg)
@@ -1026,7 +1026,7 @@ public:
     /*!
      * This function fixes the internal state of the phase so that the specific
      * internal energy and pressure have the value of the input parameters.
-     * This base class function will print an error if not overwritten.
+     * This base class function will throw an exception if not overridden.
      *
      * @param u    specific internal energy (J/kg)
      * @param p    pressure (Pa)
@@ -1042,7 +1042,7 @@ public:
     /*!
      * This function fixes the internal state of the phase so that the specific
      * volume and the specific enthalpy have the value of the input parameters.
-     * This base class function will print an error if not overwritten.
+     * This base class function will throw an exception if not overridden.
      *
      * @param v    specific volume (m^3/kg)
      * @param h    specific enthalpy (J/kg)
@@ -1058,7 +1058,7 @@ public:
     /*!
      * This function fixes the internal state of the phase so that the
      * temperature and specific enthalpy have the value of the input parameters.
-     * This base class function will print an error if not overwritten.
+     * This base class function will throw an exception if not overridden.
      *
      * @param t    temperature (K)
      * @param h    specific enthalpy (J/kg)
@@ -1074,7 +1074,7 @@ public:
     /*!
      * This function fixes the internal state of the phase so that the
      * temperature and pressure have the value of the input parameters.
-     * This base class function will print an error if not overwritten.
+     * This base class function will throw an exception if not overridden.
      *
      * @param s    specific entropy (J/kg/K)
      * @param h    specific enthalpy (J/kg)
@@ -1094,7 +1094,7 @@ public:
      * the temperature that will yield the desired input pressure and density.
      * The composition is held constant during this process.
      *
-     * This base class function will print an error, if not overwritten.
+     * This base class function will print an error, if not overridden.
      *
      * @param rho Density (kg/m^3)
      * @param p   Pressure (Pa)

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -241,7 +241,7 @@ public:
 
 protected:
     /**
-     * @internal This internal routine must be overwritten because it is not
+     * @internal This internal routine must be overridden because it is not
      *        applicable.
      */
     void _updateThermo() const;

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -181,6 +181,13 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         void setState_SP(double, double) except +
         void setState_SV(double, double) except +
         void setState_RP(double, double) except +
+        void setState_ST(double, double) except +
+        void setState_TV(double, double) except +
+        void setState_PV(double, double) except +
+        void setState_UP(double, double) except +
+        void setState_VH(double, double) except +
+        void setState_TH(double, double) except +
+        void setState_SH(double, double) except +
 
         # molar thermodynamic properties:
         double enthalpy_mole() except +

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -70,11 +70,11 @@ class TestPureFluid(utilities.CanteraTest):
 
     def test_properties_near_min(self):
         self.check_fd_properties(self.water.min_temp*(1+1e-5), 101325,
-                              self.water.min_temp*(1+1e-4), 101325, 1e-2)
+                                 self.water.min_temp*(1+1e-4), 101325, 1e-2)
 
     def test_properties_near_max(self):
         self.check_fd_properties(self.water.max_temp*(1-1e-5), 101325,
-                              self.water.max_temp*(1-1e-4), 101325, 1e-2)
+                                 self.water.max_temp*(1-1e-4), 101325, 1e-2)
 
     def test_TPX(self):
         self.water.TX = 400, 0.8
@@ -160,7 +160,7 @@ class PureFluidTestCases(object):
             a2 = self.a(state.T, 1/(V+0.5*dV))
 
             # dP/drho is high for liquids, so relax tolerances
-            tol = 100 *self.tol.dAdV if state.phase == 'liquid' else self.tol.dAdV
+            tol = 100*self.tol.dAdV if state.phase == 'liquid' else self.tol.dAdV
 
             # At constant temperature, dA = - p dV
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
@@ -198,7 +198,7 @@ class PureFluidTestCases(object):
         for state in self.states:
             self.fluid.TD = state.T, state.rho
             # dP/drho is high for liquids, so relax tolerances
-            tol = 50 *self.tol.p if state.phase == 'liquid' else self.tol.p
+            tol = 50*self.tol.p if state.phase == 'liquid' else self.tol.p
             tol *= state.tolMod
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
             self.assertNear(self.fluid.P, state.p, tol, msg=msg)
@@ -219,10 +219,10 @@ class PureFluidTestCases(object):
                             state.s - self.refState.s,
                             self.tol.s * state.tolMod, msg=msg)
 
+
 # Reference values for HFC134a taken from NIST Chemistry WebBook, which
 # implements the same EOS from Tillner-Roth and Baehr as Cantera, so close
 # agreement is expected.
-
 class HFC134a(PureFluidTestCases, utilities.CanteraTest):
     states = [
         StateData('liquid', 175.0, 0.1, rho=1577.6239, u=77.534586, s=0.44788182),
@@ -239,6 +239,7 @@ class HFC134a(PureFluidTestCases, utilities.CanteraTest):
         PureFluidTestCases.__init__(self, 'hfc134a', refState)
         utilities.CanteraTest.__init__(self, *args, **kwargs)
 
+
 # Reference values for the following substances are taken from the tables in
 # W.C. Reynolds, "Thermodynamic Properties in SI", which is the source of
 # Cantera's equations of state for these substances. Agreement is limited by
@@ -249,12 +250,11 @@ class HFC134a(PureFluidTestCases, utilities.CanteraTest):
 # different methods for satisfying the phase equilibrium condition g_l = g_v.
 # Cantera uses the actual equation of state, while the tabulated values given
 # by Reynolds are based on the given P_sat(T_sat) relations.
-
 class CarbonDioxide(PureFluidTestCases, utilities.CanteraTest):
     states = [
         StateData('liquid', 230.0, 2.0, rho=1132.4, h=28.25, s=0.1208),
         StateData('liquid', 270.0, 10.0, rho=989.97, h=110.59, s=0.4208),
-        StateData('vapor', 250.0, 1.788, v=0.02140, h=358.59, s=1.4500, relax=True), #sat
+        StateData('vapor', 250.0, 1.788, v=0.02140, h=358.59, s=1.4500, relax=True),  # sat
         StateData('vapor', 300.0, 2.0, v=0.02535, h=409.41, s=1.6174),
         StateData('super', 500.0, 1.0, v=0.09376, h=613.22, s=2.2649),
         StateData('super', 600.0, 20.0, v=0.00554, h=681.94, s=1.8366)]
@@ -269,9 +269,9 @@ class CarbonDioxide(PureFluidTestCases, utilities.CanteraTest):
 
 class Heptane(PureFluidTestCases, utilities.CanteraTest):
     states = [
-        StateData('liquid', 300.0, 0.006637, v=0.001476, h=0.0, s=0.0, relax=True), #sat
-        StateData('liquid', 400.0, 0.2175, v=0.001712, h=248.01, s=0.709, relax=True), #sat
-        StateData('vapor', 490.0, 1.282, v=0.02222, h=715.64, s=1.7137, relax=True), #sat
+        StateData('liquid', 300.0, 0.006637, v=0.001476, h=0.0, s=0.0, relax=True),  # sat
+        StateData('liquid', 400.0, 0.2175, v=0.001712, h=248.01, s=0.709, relax=True),  # sat
+        StateData('vapor', 490.0, 1.282, v=0.02222, h=715.64, s=1.7137, relax=True),  # sat
         StateData('vapor', 480.0, 0.70, v=0.04820, h=713.04, s=1.7477),
         StateData('super', 600.0, 2.0, v=0.01992, h=1014.87, s=2.2356),
         StateData('super', 680.0, 0.2, v=0.2790, h=1289.29, s=2.8450)]
@@ -287,9 +287,9 @@ class Heptane(PureFluidTestCases, utilities.CanteraTest):
 # para-hydrogen
 class Hydrogen(PureFluidTestCases, utilities.CanteraTest):
     states = [
-        StateData('liquid', 18.0, 0.04807, v=0.013660, h=30.1, s=1.856, relax=True), #sat
-        StateData('liquid', 26.0, 0.4029, v=0.015911, h=121.2, s=5.740, relax=True), #sat
-        StateData('vapor', 30.0, 0.8214, v=0.09207, h=487.4, s=17.859, relax=True), #sat
+        StateData('liquid', 18.0, 0.04807, v=0.013660, h=30.1, s=1.856, relax=True),  # sat
+        StateData('liquid', 26.0, 0.4029, v=0.015911, h=121.2, s=5.740, relax=True),  # sat
+        StateData('vapor', 30.0, 0.8214, v=0.09207, h=487.4, s=17.859, relax=True),  # sat
         StateData('super', 100.0, 0.20, v=2.061, h=1398.3, s=39.869),
         StateData('super', 200.0, 20.0, v=0.04795, h=3015.9, s=31.274),
         StateData('super', 300.0, 0.50, v=2.482, h=4511.6, s=53.143),
@@ -309,7 +309,7 @@ class Methane(PureFluidTestCases, utilities.CanteraTest):
         StateData('liquid', 100.0, 0.50, rho=439.39, h=31.65, s=0.3206),
         StateData('liquid', 140.0, 2.0, rho=379.51, h=175.48, s=1.4963),
         StateData('vapor', 150.0, 0.20, v=0.3772, h=660.72, s=5.5435),
-        StateData('vapor', 160.0, 1.594, v=0.03932, h=627.96, s=4.3648, relax=True), #sat
+        StateData('vapor', 160.0, 1.594, v=0.03932, h=627.96, s=4.3648, relax=True),  # sat
         StateData('vapor', 175.0, 1.0, v=0.08157, h=692.55, s=4.9558),
         StateData('super', 200.0, 0.2, v=0.5117, h=767.37, s=6.1574),
         StateData('super', 300.0, 0.5, v=0.3083, h=980.87, s=6.5513)]
@@ -324,8 +324,8 @@ class Methane(PureFluidTestCases, utilities.CanteraTest):
 
 class Nitrogen(PureFluidTestCases, utilities.CanteraTest):
     states = [
-        StateData('liquid', 80.0, 0.1370, v=0.001256, h=33.50, s=0.4668, relax=True), #sat
-        StateData('vapor', 110.0, 1.467, v=0.01602, h=236.28, s=2.3896, relax=True), #sat
+        StateData('liquid', 80.0, 0.1370, v=0.001256, h=33.50, s=0.4668, relax=True),  # sat
+        StateData('vapor', 110.0, 1.467, v=0.01602, h=236.28, s=2.3896, relax=True),  # sat
         StateData('super', 200.0, 0.5, v=0.1174, h=355.05, s=3.5019),
         StateData('super', 300.0, 10.0, v=0.00895, h=441.78, s=2.9797),
         StateData('super', 500.0, 5.0, v=0.03031, h=668.48, s=3.7722),
@@ -341,9 +341,9 @@ class Nitrogen(PureFluidTestCases, utilities.CanteraTest):
 
 class Oxygen(PureFluidTestCases, utilities.CanteraTest):
     states = [
-        StateData('liquid', 80.0, 0.03009, v=0.000840, h=42.56, s=0.6405, relax=True), #sat
-        StateData('liquid', 125.0, 1.351, v=0.001064, h=123.24, s=1.4236, relax=True), #sat
-        StateData('vapor', 145.0, 3.448, v=0.006458, h=276.45, s=2.4852, relax=True), #sat
+        StateData('liquid', 80.0, 0.03009, v=0.000840, h=42.56, s=0.6405, relax=True),  # sat
+        StateData('liquid', 125.0, 1.351, v=0.001064, h=123.24, s=1.4236, relax=True),  # sat
+        StateData('vapor', 145.0, 3.448, v=0.006458, h=276.45, s=2.4852, relax=True),  # sat
         StateData('super', 200.0, 0.050, v=1.038, h=374.65, s=4.1275),
         StateData('super', 300.0, 1.0, v=0.07749, h=463.76, s=3.7135),
         StateData('super', 600.0, 0.20, v=0.7798, h=753.38, s=4.7982),
@@ -395,7 +395,7 @@ class PureFluidConvergence(utilities.CanteraTest):
 
         errors = ''
         nErrors = 0
-        for T,P in itertools.product(TT,PP):
+        for T,P in itertools.product(TT, PP):
             try:
                 self.fluid.TP = T, P
                 self.assertNear(self.fluid.T, T, 1e-6)
@@ -413,7 +413,7 @@ class PureFluidConvergence(utilities.CanteraTest):
         VV = [0.001, 0.002, 0.005, 0.010, 0.10, 0.5, 1.0, 1.5, 2.0]
         errors = ''
         nErrors = 0
-        for u,v in itertools.product(UU,VV):
+        for u,v in itertools.product(UU, VV):
             try:
                 self.fluid.UV = u, v
                 self.assertNear(self.fluid.u, u, 1e-6)
@@ -431,7 +431,7 @@ class PureFluidConvergence(utilities.CanteraTest):
         PP = [1234.0, 101325.0, 5e5, 22.0e6, 22.08e6, 22.09e6, 10001000.0]
         errors = ''
         nErrors = 0
-        for h,P in itertools.product(HH,PP):
+        for h,P in itertools.product(HH, PP):
             try:
                 self.fluid.HP = h, P
                 self.assertNear(self.fluid.h, h, 1e-6)

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -26,6 +26,35 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertNear(self.water.T, 500)
         self.assertNear(self.water.X, 0.8)
 
+    def test_substance_set(self):
+        self.water.TV = 400, 1.45
+        self.assertNear(self.water.T, 400)
+        self.assertNear(self.water.v, 1.45)
+
+        self.water.PV = 101325, 1.45
+        self.assertNear(self.water.P, 101325)
+        self.assertNear(self.water.v, 1.45)
+
+        self.water.UP = -1.45e7, 101325
+        self.assertNear(self.water.u, -1.45e7)
+        self.assertNear(self.water.P, 101325)
+
+        self.water.VH = 1.45, -1.45e7
+        self.assertNear(self.water.v, 1.45)
+        self.assertNear(self.water.h, -1.45e7)
+
+        self.water.TH = 400, -1.45e7
+        self.assertNear(self.water.T, 400)
+        self.assertNear(self.water.h, -1.45e7)
+
+        self.water.SH = 5000, -1.45e7
+        self.assertNear(self.water.s, 5000)
+        self.assertNear(self.water.h, -1.45e7)
+
+        self.water.ST = 5000, 400
+        self.assertNear(self.water.s, 5000)
+        self.assertNear(self.water.T, 400)
+
     def test_set_X(self):
         self.water.TX = 500, 0.0
         p = self.water.P

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1203,7 +1203,7 @@ cdef class PureFluid(ThermoPhase):
             self.thermo.setState_Psat(self.P, X)
 
     property TX:
-        """Get/Set the temperature and vapor fraction of a two-phase state."""
+        """Get/Set the temperature [K] and vapor fraction of a two-phase state."""
         def __get__(self):
             return self.T, self.X
         def __set__(self, values):
@@ -1212,7 +1212,7 @@ cdef class PureFluid(ThermoPhase):
             self.thermo.setState_Tsat(T, X)
 
     property PX:
-        """Get/Set the pressure and vapor fraction of a two-phase state."""
+        """Get/Set the pressure [Pa] and vapor fraction of a two-phase state."""
         def __get__(self):
             return self.P, self.X
         def __set__(self, values):

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1220,6 +1220,87 @@ cdef class PureFluid(ThermoPhase):
             X = values[1] if values[1] is not None else self.X
             self.thermo.setState_Psat(P, X)
 
+    property ST:
+        """Get/Set the entropy [J/kg/K] and temperature [K] of a PureFluid."""
+        def __get__(self):
+            return self.s, self.T
+        def __set__(self, values):
+            S = values[0] if values[0] is not None else self.s
+            T = values[1] if values[1] is not None else self.T
+            self.thermo.setState_ST(S / self._mass_factor(), T)
+
+    property TV:
+        """
+        Get/Set the temperature [K] and specific volume [m^3/kg] of
+        a PureFluid.
+        """
+        def __get__(self):
+            return self.T, self.v
+        def __set__(self, values):
+            T = values[0] if values[0] is not None else self.T
+            V = values[1] if values[1] is not None else self.v
+            self.thermo.setState_TV(T, V / self._mass_factor())
+
+    property PV:
+        """
+        Get/Set the pressure [Pa] and specific volume [m^3/kg] of
+        a PureFluid.
+        """
+        def __get__(self):
+            return self.p, self.v
+        def __set__(self, values):
+            P = values[0] if values[0] is not None else self.P
+            V = values[1] if values[1] is not None else self.v
+            self.thermo.setState_PV(P, V / self._mass_factor())
+
+    property UP:
+        """
+        Get/Set the specific internal energy [J/kg] and the
+        pressure [Pa] of a PureFluid.
+        """
+        def __get__(self):
+            return self.u, self.P
+        def __set__(self, values):
+            U = values[0] if values[0] is not None else self.u
+            P = values[1] if values[1] is not None else self.P
+            self.thermo.setState_UP(U / self._mass_factor(), P)
+
+    property VH:
+        """
+        Get/Set the specfic volume [m^3/kg] and the specific
+        enthalpy [J/kg] of a PureFluid.
+        """
+        def __get__(self):
+            return self.v, self.h
+        def __set__(self, values):
+            V = values[0] if values[0] is not None else self.v
+            H = values[1] if values[1] is not None else self.h
+            self.thermo.setState_VH(V/self._mass_factor(), H/self._mass_factor())
+
+    property TH:
+        """
+        Get/Set the temperature [K] and the specific enthalpy [J/kg]
+        of a PureFluid.
+        """
+        def __get__(self):
+            return self.T, self.h
+        def __set__(self, values):
+            T = values[0] if values[0] is not None else self.T
+            H = values[1] if values[1] is not None else self.h
+            self.thermo.setState_TH(T, H / self._mass_factor())
+
+    property SH:
+        """
+        Get/Set the specific entropy [J/kg/K] and the specific
+        enthalpy [J/kg] of a PureFluid.
+        """
+        def __get__(self):
+            return self.s, self.h
+        def __set__(self, values):
+            S = values[0] if values[0] is not None else self.s
+            H = values[1] if values[1] is not None else self.h
+            self.thermo.setState_SH(S/self._mass_factor(), H/self._mass_factor())
+
     property TDX:
         """
         Get the temperature [K], density [kg/m^3 or kmol/m^3], and vapor

--- a/interfaces/matlab/toolbox/@ThermoPhase/set.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/set.m
@@ -184,6 +184,20 @@ elseif ntot == 2
         setState_SP(tp, [sval,pval]);
     elseif ns == 1 && nv == 1
         setState_SV(tp, [sval,vval]);
+    elseif ns == 1 && nt == 1
+        setState_ST(tp, [sval,tval]);
+    elseif nt == 1 && nv == 1
+        setState_TV(tp, [tval,vval]);
+    elseif np == 1 && nv == 1
+        setState_PV(tp, [pval,vval]);
+    elseif nu == 1 && np == 1
+        setState_UP(tp, [uval,pval]);
+    elseif nv == 1 && nh == 1
+        setState_VH(tp, [vval,hval]);
+    elseif nt == 1 && nh == 1
+        setState_TH(tp, [tval,hval]);
+    elseif ns == 1 && nh == 1
+        setState_SH(tp, [sval,hval]);
     else
         error('Unimplemented property pair.');
     end

--- a/interfaces/matlab/toolbox/@ThermoPhase/setState_PV.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/setState_PV.m
@@ -1,0 +1,12 @@
+function setState_PV(tp, pv)
+% SETSTATE_PV  Set the pressure and specific volume.
+% setState_PV(tp,pv)
+% :param tp:
+%     Instance of class :mat:func:`ThermoPhase` (or another
+%     class derived from ThermoPhase)
+% :param pv:
+%     Vector of length 2 containing the desired values for the
+%     pressure (Pa) and specific volume (m^3/kg).
+%
+
+thermo_set(tp.tp_id, 29, pv);

--- a/interfaces/matlab/toolbox/@ThermoPhase/setState_SH.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/setState_SH.m
@@ -1,0 +1,12 @@
+function setState_SH(tp, sh)
+% SETSTATE_SH  Set the specific entropy and specific enthalpy.
+% setState_SH(tp,sh)
+% :param tp:
+%     Instance of class :mat:func:`ThermoPhase` (or another
+%     class derived from ThermoPhase)
+% :param sh:
+%     Vector of length 2 containing the desired values for the specific
+%     entropy (J/kg/K) and specific enthalpy (J/kg).
+%
+
+thermo_set(tp.tp_id, 33, sh);

--- a/interfaces/matlab/toolbox/@ThermoPhase/setState_ST.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/setState_ST.m
@@ -1,0 +1,12 @@
+function setState_ST(tp, st)
+% SETSTATE_ST  Set the specific entropy and temperature.
+% setState_ST(tp,st)
+% :param tp:
+%     Instance of class :mat:func:`ThermoPhase` (or another
+%     class derived from ThermoPhase)
+% :param st:
+%     Vector of length 2 containing the desired values for the specific
+%     entropy (J/kg-K) and temperature (K).
+%
+
+thermo_set(tp.tp_id, 27, st);

--- a/interfaces/matlab/toolbox/@ThermoPhase/setState_TH.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/setState_TH.m
@@ -1,0 +1,12 @@
+function setState_TH(tp, th)
+% SETSTATE_TH  Set the temperature and specific enthalpy.
+% setState_TH(tp,th)
+% :param tp:
+%     Instance of class :mat:func:`ThermoPhase` (or another
+%     class derived from ThermoPhase)
+% :param th:
+%     Vector of length 2 containing the desired values for the
+%     temperature (K) and specific enthalpy (J/kg).
+%
+
+thermo_set(tp.tp_id, 32, th);

--- a/interfaces/matlab/toolbox/@ThermoPhase/setState_TV.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/setState_TV.m
@@ -1,0 +1,12 @@
+function setState_TV(tp, tv)
+% SETSTATE_TV  Set the temperature and specific volume.
+% setState_TV(tp,tv)
+% :param tp:
+%     Instance of class :mat:func:`ThermoPhase` (or another
+%     class derived from ThermoPhase)
+% :param tv:
+%     Vector of length 2 containing the desired values for the
+%     temperature (K) and specific volume (m^3/kg).
+%
+
+thermo_set(tp.tp_id, 28, tv);

--- a/interfaces/matlab/toolbox/@ThermoPhase/setState_UP.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/setState_UP.m
@@ -1,0 +1,12 @@
+function setState_UP(tp, up)
+% SETSTATE_UP  Set the specific internal energy and pressure.
+% setState_UP(tp,up)
+% :param tp:
+%     Instance of class :mat:func:`ThermoPhase` (or another
+%     class derived from ThermoPhase)
+% :param up:
+%     Vector of length 2 containing the desired values for the specific
+%     internal energy (J/kg) and pressure (Pa).
+%
+
+thermo_set(tp.tp_id, 30, up);

--- a/interfaces/matlab/toolbox/@ThermoPhase/setState_VH.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/setState_VH.m
@@ -1,0 +1,12 @@
+function setState_VH(tp, vh)
+% SETSTATE_VH  Set the specific volume and specific enthalpy.
+% setState_VH(tp,vh)
+% :param tp:
+%     Instance of class :mat:func:`ThermoPhase` (or another
+%     class derived from ThermoPhase)
+% :param vh:
+%     Vector of length 2 containing the desired values for the specific
+%     volume (m^3/kg) and specific enthalpy (J/kg).
+%
+
+thermo_set(tp.tp_id, 31, vh);

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -601,6 +601,76 @@ extern "C" {
         }
     }
 
+    int th_set_ST(int n, double* vals)
+    {
+        try {
+            ThermoCabinet::item(n).setState_ST(vals[0],vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int th_set_TV(int n, double* vals)
+    {
+        try {
+            ThermoCabinet::item(n).setState_TV(vals[0],vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int th_set_PV(int n, double* vals)
+    {
+        try {
+            ThermoCabinet::item(n).setState_PV(vals[0],vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int th_set_UP(int n, double* vals)
+    {
+        try {
+            ThermoCabinet::item(n).setState_UP(vals[0],vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int th_set_VH(int n, double* vals)
+    {
+        try {
+            ThermoCabinet::item(n).setState_VH(vals[0],vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int th_set_TH(int n, double* vals)
+    {
+        try {
+            ThermoCabinet::item(n).setState_TH(vals[0],vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int th_set_SH(int n, double* vals)
+    {
+        try {
+            ThermoCabinet::item(n).setState_SH(vals[0],vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int th_equil(int n, char* XY, int solver,
                  double rtol, int maxsteps, int maxiter, int loglevel)
     {

--- a/src/clib/ct.h
+++ b/src/clib/ct.h
@@ -78,6 +78,13 @@ extern "C" {
     CANTERA_CAPI int th_set_UV(int n, double* vals);
     CANTERA_CAPI int th_set_SV(int n, double* vals);
     CANTERA_CAPI int th_set_SP(int n, double* vals);
+    CANTERA_CAPI int th_set_ST(int n, double* vals);
+    CANTERA_CAPI int th_set_TV(int n, double* vals);
+    CANTERA_CAPI int th_set_PV(int n, double* vals);
+    CANTERA_CAPI int th_set_UP(int n, double* vals);
+    CANTERA_CAPI int th_set_VH(int n, double* vals);
+    CANTERA_CAPI int th_set_TH(int n, double* vals);
+    CANTERA_CAPI int th_set_SH(int n, double* vals);
     CANTERA_CAPI int th_equil(int n, char* XY, int solver,
                               double rtol, int maxsteps, int maxiter, int loglevel);
 

--- a/src/matlab/thermomethods.cpp
+++ b/src/matlab/thermomethods.cpp
@@ -61,6 +61,27 @@ static void thermoset(int nlhs, mxArray* plhs[],
             case 26:
                 ierr = th_set_RP(th,ptr);
                 break;
+            case 27:
+                ierr = th_set_ST(th,ptr);
+                break;
+            case 28:
+                ierr = th_set_TV(th,ptr);
+                break;
+            case 29:
+                ierr = th_set_PV(th,ptr);
+                break;
+            case 30:
+                ierr = th_set_UP(th,ptr);
+                break;
+            case 31:
+                ierr = th_set_VH(th,ptr);
+                break;
+            case 32:
+                ierr = th_set_TH(th,ptr);
+                break;
+            case 33:
+                ierr = th_set_SH(th,ptr);
+                break;
             default:
                 mexErrMsgTxt("unknown pair attribute.");
             }

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -284,6 +284,11 @@ doublereal PureFluidPhase::satTemperature(doublereal p) const
     return m_sub->Tsat(p);
 }
 
+/* The next several functions set the state. They run the Substance::Set
+ * function, followed by setting the state of the ThermoPhase object
+ * to the newly computed temperature and density of the Substance.
+ */
+
 void PureFluidPhase::setState_HP(double h, double p, double tol)
 {
     Set(tpx::PropertyPair::HP, h, p);

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -284,29 +284,25 @@ doublereal PureFluidPhase::satTemperature(doublereal p) const
     return m_sub->Tsat(p);
 }
 
-void PureFluidPhase::setState_HP(doublereal h, doublereal p,
-                                 doublereal tol)
+void PureFluidPhase::setState_HP(double h, double p, double tol)
 {
     Set(tpx::PropertyPair::HP, h, p);
     setState_TR(m_sub->Temp(), 1.0/m_sub->v());
 }
 
-void PureFluidPhase::setState_UV(doublereal u, doublereal v,
-                                 doublereal tol)
+void PureFluidPhase::setState_UV(double u, double v, double tol)
 {
     Set(tpx::PropertyPair::UV, u, v);
     setState_TR(m_sub->Temp(), 1.0/m_sub->v());
 }
 
-void PureFluidPhase::setState_SV(doublereal s, doublereal v,
-                                 doublereal tol)
+void PureFluidPhase::setState_SV(double s, double v, double tol)
 {
     Set(tpx::PropertyPair::SV, s, v);
     setState_TR(m_sub->Temp(), 1.0/m_sub->v());
 }
 
-void PureFluidPhase::setState_SP(doublereal s, doublereal p,
-                                 doublereal tol)
+void PureFluidPhase::setState_SP(double s, double p, double tol)
 {
     Set(tpx::PropertyPair::SP, s, p);
     setState_TR(m_sub->Temp(), 1.0/m_sub->v());

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -308,6 +308,48 @@ void PureFluidPhase::setState_SP(double s, double p, double tol)
     setState_TR(m_sub->Temp(), 1.0/m_sub->v());
 }
 
+void PureFluidPhase::setState_ST(double s, double t, double tol)
+{
+    Set(tpx::PropertyPair::ST, s, t);
+    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+}
+
+void PureFluidPhase::setState_TV(double t, double v, double tol)
+{
+    Set(tpx::PropertyPair::TV, t, v);
+    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+}
+
+void PureFluidPhase::setState_PV(double p, double v, double tol)
+{
+    Set(tpx::PropertyPair::PV, p, v);
+    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+}
+
+void PureFluidPhase::setState_UP(double u, double p, double tol)
+{
+    Set(tpx::PropertyPair::UP, u, p);
+    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+}
+
+void PureFluidPhase::setState_VH(double v, double h, double tol)
+{
+    Set(tpx::PropertyPair::VH, v, h);
+    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+}
+
+void PureFluidPhase::setState_TH(double t, double h, double tol)
+{
+    Set(tpx::PropertyPair::TH, t, h);
+    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+}
+
+void PureFluidPhase::setState_SH(double s, double h, double tol)
+{
+    Set(tpx::PropertyPair::SH, s, h);
+    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+}
+
 doublereal PureFluidPhase::satPressure(doublereal t)
 {
     Set(tpx::PropertyPair::TV, t, m_sub->v());

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -115,14 +115,14 @@ double Substance::Tsat(double p)
     return tsat;
 }
 
-// absolute tolerances
-static const double TolAbsH = 0.0001; // J/kg
-static const double TolAbsU = 0.0001;
+// property tolerances
+static const double TolAbsH = 1.e-4; // J/kg
+static const double TolAbsU = 1.e-4;
 static const double TolAbsS = 1.e-7;
-static const double TolAbsP = 0.000; // Pa
+static const double TolAbsP = 0.0; // Pa, this is supposed to be zero
 static const double TolAbsV = 1.e-8;
 static const double TolAbsT = 1.e-3;
-static const double TolRel = 3.e-8;
+static const double TolRel = 1.e-8;
 
 void Substance::Set(PropertyPair::type XY, double x0, double y0)
 {


### PR DESCRIPTION
The PureFluid classes allow getting/setting a larger number of properties than were previously implemented. This PR adds those missing functions, leaving them unimplemented in the general ThermoPhase, and implementing them only in the PureFluid.

There is a small issue with the algorithm to set the properties, in that the final set value for a property depends on the order in which the properties were previously set. This results in the "expected" failure in the Python tests. I'm not really sure how to fix this; I tried tightening the tolerances in the Sub.cpp file, with no effect. Nonetheless, the error is quite small, but still exceeds the defaults set up in the tester.
