### PR TITLE
[cti] Allow non-reactant orders for reaction

### DIFF
--- a/doc/sphinx/cti/reactions.rst
+++ b/doc/sphinx/cti/reactions.rst
@@ -483,6 +483,8 @@ This reaction could be defined as::
 Special care is required in this case since the units of the pre-exponential
 factor depend on the sum of the reaction orders, which may not be an integer.
 
+Note, that you can change reaction orders only for irreversible reactions.
+
 Normally, reaction orders are required to be positive. However, in some cases
 negative reaction orders are found to be better fits for experimental data. In
 these cases, the default behavior may be overridden by adding
@@ -490,6 +492,13 @@ these cases, the default behavior may be overridden by adding
 
     reaction("C8H18 + 12.5 O2 => 8 CO2 + 9 H2O", [4.6e11, 0.0, 30.0],
              order="C8H18:-0.25 O2:1.75", options=['negative_orders'])
+
+Some global reactions could have reactions orders for non-reactant species. One
+should add ``nonreactant_orders`` to the reaction options to use this feature::
+
+    reaction("C8H18 + 12.5 O2 => 8 CO2 + 9 H2O", [4.6e11, 0.0, 30.0],
+             order="C8H18:-0.25 CO:0.15", 
+             options=['negative_orders', 'nonreactant_orders'])
 
 
 .. rubric:: References

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -1110,7 +1110,8 @@ class reaction(object):
             e.g. ``"CH4:0.25 O2:1.5"``.
         :param options: Processing options, as described in
             :ref:`sec-reaction-options`. May be one or more (as a list) of the
-            following: 'skip', 'duplicate', 'negative_A', 'negative_orders'.
+            following: 'skip', 'duplicate', 'negative_A', 'negative_orders',
+            'nonreactant_orders'.
         """
         self._id = id
         self._e = equation
@@ -1140,7 +1141,8 @@ class reaction(object):
                 if o in self._rxnorder:
                     self._rxnorder[o] = order[o]
                 else:
-                    raise CTI_Error("order specified for non-reactant: "+o)
+                    if 'nonreactant_orders' not in self._options:
+                        raise CTI_Error("order specified for non-reactant: "+o)
 
         self._kf = kf
         self._igspecies = []
@@ -1211,6 +1213,8 @@ class reaction(object):
             r['negative_A'] = 'yes'
         if 'negative_orders' in self._options:
             r['negative_orders'] = 'yes'
+        if 'nonreactant_orders' in self._options:
+            r['nonreactant_orders'] = 'yes'
 
         ee = self._e.replace('<','[').replace('>',']')
         r.addChild('equation',ee)

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -1138,11 +1138,10 @@ class reaction(object):
         if self._order:
             order = getPairs(self._order)
             for o in order.keys():
-                if o in self._rxnorder:
-                    self._rxnorder[o] = order[o]
+                if o not in self._rxnorder and 'nonreactant_orders' not in self._options:
+                    raise CTI_Error("order specified for non-reactant: "+o+" and no \'nonreactant_orders\' option given")
                 else:
-                    if 'nonreactant_orders' not in self._options:
-                        raise CTI_Error("order specified for non-reactant: "+o)
+                    self._rxnorder[o] = order[o]
 
         self._kf = kf
         self._igspecies = []

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -390,3 +390,13 @@ class CtmlConverterTest(utilities.CanteraTest):
         gas = ct.Solution('../data/noninteger-atomicity.cti')
         self.assertNear(gas.molecular_weights[gas.species_index('CnHm')],
                         10.65*gas.atomic_weight('C') + 21.8*gas.atomic_weight('H'))
+
+    def test_reaction_orders(self):
+        gas = ct.Solution('../data/reaction-orders.cti')
+        R=gas.reaction(0)
+        allow=R.allow_nonreactant_orders
+        self.assertEqual(allow, True)
+        self.assertNear(R.orders.get('OH'), 0.15)
+        allow=R.allow_negative_orders
+        self.assertEqual(allow, True)
+        self.assertNear(R.orders.get('H2'), -0.25)

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -360,6 +360,9 @@ void setupElementaryReaction(ElementaryReaction& R, const XML_Node& rxn_node)
     if (rxn_node["negative_orders"] == "yes") {
         R.allow_negative_orders = true;
     }
+    if (rxn_node["nonreactant_orders"] == "yes") {
+        R.allow_nonreactant_orders = true;
+    }
     setupReaction(R, rxn_node);
 }
 

--- a/test/data/reaction-orders.cti
+++ b/test/data/reaction-orders.cti
@@ -1,0 +1,23 @@
+# Input file to test use of non-reactant species
+
+units(length = "cm", time = "s", quantity = "mol", act_energy = "kJ/mol")
+
+ideal_gas(name = "gas",
+      elements = " O H ",
+      species = """gri30: H2  O2  H2O OH """,
+      reactions = "all",
+      initial_state = state(temperature = 300.0,
+                        pressure = OneAtm)    )
+
+#-------------------------------------------------------------------------------
+#  Reactions data
+#-------------------------------------------------------------------------------
+
+#test negative orders and non-reactant orders
+reaction("2 H2 + O2 => 2 H2O", [1e13, 0.0, 0.0],
+         order="H2:-0.25 OH:0.15", 
+         options=['negative_orders', 'nonreactant_orders'])
+
+#if uncomment, should throw an error
+#reaction("2 H2 + O2 => 2 H2O", [1e13, 0.0, 0.0],
+#         order="OH:0.15")


### PR DESCRIPTION
Resolves #317.
Adding new option `nonreactant_orders` that could be used in `cti` like this:

```
reaction("C8H18 + 12.5 O2 => 8 CO2 + 9 H2O", [4.6e11, 0.0, 30.0],
         order="C8H18:-0.25 CO:0.15", 
         options=['negative_orders', 'nonreactant_orders'])
```

In the example reaction order is specified for non-reactant `CO`.
