### PR TITLE
[Doc] Clarify surface coverage modification equation

### DIFF
--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -94,13 +94,21 @@ protected:
 /**
  * An Arrhenius rate with coverage-dependent terms.
  *
- * The rate expression is given by:
+ * The rate expression is given by [Kee, R. J., Coltrin, M. E., & Glarborg, P.
+ * (2005). Chemically reacting flow: theory and practice. John Wiley & Sons.
+ * Eq 11.113]:
  * \f[
  *     k_f = A T^b \exp \left(
  *             \ln 10 \sum a_k \theta_k
  *             - \frac{1}{RT} \left( E_a + \sum E_k\theta_k \right)
  *             + \sum m_k \ln \theta_k
  *             \right)
+ *   \f]
+ * or, equivalently, and as implemented in Cantera,
+ * \f[
+ *     k_f = A T^b \exp \left( - \frac{E_a}{RT} \right)
+ *             \prod_k 10^{a_k \theta_k} \theta_k^{m_k}
+ *             \exp \left( \frac{- E_k \theta_k}{RT} \right)
  *   \f]
  * where the parameters \f$ (a_k, E_k, m_k) \f$ describe the dependency on the
  * surface coverage of species \f$k, \theta_k \f$.


### PR DESCRIPTION
According to docs, "an Arrhenius rate with coverage-dependent terms" is ([see docs here](http://www.cantera.org/docs/sphinx/html/cti/reactions.html#surface-reactions)):
![Image1](https://cloud.githubusercontent.com/assets/6708143/13300868/2ade2b10-db53-11e5-9179-54e9df5bf533.png)

It is the equation used by Surface CHEMKIN (kindly see print p. 36 [in the manual](http://www.cvd.louisville.edu/Course/Chemical%20Vapour%20Deposition/Manuals/chemkin/chemkin11surfacechemkin.pdf))

In the code ([link to code](https://cantera.github.io/docs/doxygen/html/classCantera_1_1SurfaceArrhenius.html#ae24cd084de63f6b9eb3b6d68e61608ba)), the real formula Cantera uses in calculations is: 
![image](https://cloud.githubusercontent.com/assets/6708143/13301956/707d6e1a-db58-11e5-82b9-cac1c9d1fc60.png)

[And this, second formula is provided in doxygen code documentation](https://cantera.github.io/docs/doxygen/html/classCantera_1_1SurfaceArrhenius.html#details)

Luckily, these are **the identical formulae**, but this could be unnoticeable from a quick view because of logarithms and powers.

That's why, I want to clarify this thing in the code documentation. The formula written in the user's docs is more nice, I believe, so I also add it to doxygen docs.
