### PR TITLE
Ambipolar diffusion is added to Mixtransport

### DIFF
--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -273,6 +273,10 @@ protected:
     //! Local copy of the species molecular weights.
     vector_fp m_mw;
 
+	//! Local copy of the charge of each species. Contains the charge of each
+	//! species (length m_nsp)
+	vector_fp m_chargeSpecies;
+
     //! Holds square roots of molecular weight ratios
     /*!
      *  @code

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -180,6 +180,10 @@ private:
      */
     vector_fp m_cond;
 
+	//! Local copy of the charge of each species. Contains the charge of each
+	//! species (length m_nsp)
+	vector_fp m_chargeSpecies;
+
     //! Internal storage for the calculated mixture thermal conductivity
     /*!
      *  Units = W /m /K

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -53,6 +53,8 @@ GasTransport::GasTransport(const GasTransport& right) :
 
 GasTransport& GasTransport::operator=(const GasTransport& right)
 {
+	Transport::operator=(right);
+	m_chargeSpecies = right.m_chargeSpecies;
     m_molefracs = right.m_molefracs;
     m_viscmix = right.m_viscmix;
     m_visc_ok = right.m_visc_ok;
@@ -361,6 +363,12 @@ void GasTransport::init(thermo_t* thermo, int mode, int log_level)
             m_wratkj1(j,k) = sqrt(1.0 + m_mw[k]/m_mw[j]);
         }
     }
+
+	//define m_chargeSpecies
+	m_chargeSpecies.resize(m_nsp, 0.0);
+	for (size_t i = 0; i < m_nsp; i++) {
+		m_chargeSpecies[i] = m_thermo->charge(i);
+	}
 
     // set flags all false
     m_visc_ok = false;


### PR DESCRIPTION
The diffusion mechanism for charge species in a charge-neutral gas
follows the ambipolar diffusion. The model is suggested by Prager et al.
2007 -Modelling ion chemistry and charged species diffusion in lean
methane-oxygen flames.
