### PR TITLE
AmbipolarDiffusion

### DIFF
--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -82,7 +82,7 @@ public:
     //! set the transport manager
     void setTransport(Transport& trans, bool withSoret = false, bool withAmbi);
     void enableSoret(bool withSoret);
-	    bool withSoret() const {
+    bool withSoret() const {
         return m_do_soret;
     }
 	void enableAmbi(bool withAmbi);

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -80,7 +80,7 @@ public:
     }
 
     //! set the transport manager
-    void setTransport(Transport& trans, bool withSoret = false, bool withAmbi);
+    void setTransport(Transport& trans, bool withSoret = false, bool withAmbi = false);
     void enableSoret(bool withSoret);
     bool withSoret() const {
         return m_do_soret;

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -28,6 +28,7 @@ const size_t c_offset_Y = 4; // mass fractions
 const int c_Mixav_Transport = 0;
 const int c_Multi_Transport = 1;
 const int c_Soret = 2;
+const int c_Ambi = 3;
 
 class Transport;
 
@@ -79,11 +80,16 @@ public:
     }
 
     //! set the transport manager
-    void setTransport(Transport& trans, bool withSoret = false);
+    void setTransport(Transport& trans, bool withSoret = false, bool withAmbi);
     void enableSoret(bool withSoret);
-    bool withSoret() const {
+	    bool withSoret() const {
         return m_do_soret;
     }
+	void enableAmbi(bool withAmbi);
+	bool withAmbi() const {
+		return m_do_ambi;
+	}
+
 
     //! Set the pressure. Since the flow equations are for the limit of small
     //! Mach number, the pressure is very nearly constant throughout the flow.
@@ -365,6 +371,9 @@ protected:
     vector_fp m_wt;
     vector_fp m_cp;
 
+	//species electrical properties
+	vector_fp m_speciesCharge;
+
     // transport properties
     vector_fp m_visc;
     vector_fp m_tcon;
@@ -393,6 +402,7 @@ protected:
     // flags
     std::vector<bool> m_do_energy;
     bool m_do_soret;
+	bool m_do_ambi;
     std::vector<bool> m_do_species;
     int m_transport_option;
 

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -21,9 +21,9 @@ StFlow::StFlow(IdealGasPhase* ph, size_t nsp, size_t points) :
     m_trans(0),
     m_epsilon_left(0.0),
     m_epsilon_right(0.0),
-	m_do_ambi(false),
-	m_do_soret(false),
-	m_transport_option(-1),
+    m_do_ambi(false),
+    m_do_soret(false),
+    m_transport_option(-1),
     m_do_radiation(false),
     m_kExcessLeft(0),
     m_kExcessRight(0)
@@ -581,8 +581,8 @@ void StFlow::updateDiffFluxes(const doublereal* x, size_t j0, size_t j1)
 	//Simple Ambipolar Diffusion Model
 	//reference:
 	//J. Prager, U. Riedel, and J. Warnatz, 
-	//“Modeling ion chemistry and charged species diffusion in lean methane–oxygen flames,” 
-	//Proc. Combust. Inst., vol. 31, no. 1, pp. 1129–1137, Jan. 2007.
+	//Â“Modeling ion chemistry and charged species diffusion in lean methaneÂ–oxygen flames,Â” 
+	//Proc. Combust. Inst., vol. 31, no. 1, pp. 1129Â–1137, Jan. 2007.
 	if (m_do_ambi) {
 		for (size_t j = j0; m < j1; j++) {
 			vector_fp beta;


### PR DESCRIPTION
The ambi-polar diffusion appears in weakly ionized gases due to small Debye length. 

I am trying a new way to import the species charge as m_chargeSpecies. I don't think m_thermo->charge(k) will work, because m_thermo equals to the IdealGasPhase object- ph, which doesn't have the feature. However, phase.cpp has m_speciesCharge.push_back(spec->charge). I just don't know how to link to it.  
