### PR TITLE
Add interfaces to setChemistry methods

### DIFF
--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -55,13 +55,29 @@ public:
     void setKineticsMgr(Kinetics& kin);
 
     //! Disable changes in reactor composition due to chemical reactions.
+    //! @deprecated Use setChemistry instead. To be removed after Cantera 2.3
     void disableChemistry() {
-        m_chem = false;
+        warn_deprecated("Reactor::disableChemistry",
+            "Use setChemistry instead. To be removed after Cantera 2.3");
+        setChemistry(false);
     }
 
     //! Enable changes in reactor composition due to chemical reactions.
+    //! @deprecated Use setChemistry instead. To be removed after Cantera 2.3
     void enableChemistry() {
-        m_chem = true;
+        warn_deprecated("Reactor::enableChemistry",
+            "Use setChemistry instead. To be removed after Cantera 2.3");
+        setChemistry(true);
+    }
+
+    //! Enable or disable changes in reactor composition due to chemical reactions.
+    void setChemistry(bool cflag = true) {
+        m_chem = cflag;
+    }
+
+    //! Returns `true` if changes in the reactor composition due to chemical reactions are enabled.
+    bool chemistryEnabled() const {
+        return m_chem;
     }
 
     //! Set the energy equation on or off.

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -474,6 +474,8 @@ cdef extern from "cantera/zeroD/Reactor.h":
     cdef cppclass CxxReactor "Cantera::Reactor" (CxxReactorBase):
         CxxReactor()
         void setKineticsMgr(CxxKinetics&)
+        void setChemistry(cbool)
+        cbool chemistryEnabled()
         void setEnergy(int)
         cbool energyEnabled()
         size_t componentIndex(string&)

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -201,6 +201,18 @@ cdef class Reactor(ReactorBase):
             self.rbase.restoreState()
             return self._kinetics
 
+    property chemistry_enabled:
+        """
+        *True* when the reactor composition is allowed to change due to
+        chemical reactions in this reactor. When this is *False*, the
+        reactor composition is held constant.
+        """
+        def __get__(self):
+            return self.reactor.chemistryEnabled()
+
+        def __set__(self, pybool value):
+            self.reactor.setChemistry(value)
+
     property energy_enabled:
         """
         *True* when the energy equation is being solved for this reactor.

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -300,6 +300,16 @@ class TestReactor(utilities.CanteraTest):
         self.assertNear(self.r1.T, 500)
         self.assertNear(self.r2.T, 500)
 
+    def test_disable_chemistry(self):
+        self.make_reactors(T1=1000, n_reactors=1, X1='H2:2.0,O2:1.0')
+        self.r1.chemistry_enabled = False
+
+        self.net.advance(11.0)
+
+        self.assertNear(self.r1.T, 1000)
+        self.assertNear(self.r1.thermo.X[self.r1.thermo.species_index('H2')], 2.0/3.0)
+        self.assertNear(self.r1.thermo.X[self.r1.thermo.species_index('O2')], 1.0/3.0)
+
     def test_heat_flux_func(self):
         self.make_reactors(T1=500, T2=300)
         self.r1.volume = 0.5

--- a/interfaces/matlab/toolbox/@Reactor/setChemistry.m
+++ b/interfaces/matlab/toolbox/@Reactor/setChemistry.m
@@ -1,0 +1,29 @@
+function setChemistry(r, flag)
+% SETCHEMISTRY  Enable or disable changing reactor composition by reactions.
+% setChemistry(r, flag)
+% If the chemistry is disabled, then the reactor composition is
+% constant. The parameter should be the string ``'on'`` to enable the
+% species equations, or ``'off'`` to disable it.
+%
+% By default, Reactor objects are created with the species equations
+% enabled if there are reactions present in the mechanism file, and
+% disabled otherwise. ::
+%
+%     >> setChemistry(r, 'on');
+%     >> setChemistry(r, 'off');
+%
+% :param r:
+%     Instance of class :mat:func:`Reactor`
+% :param flag:
+%     String, either ``'on'`` or ``'off'`` to enable and disable
+%     solving the energy equation, respectively
+%
+
+if strcmp(flag, {'on'})
+    iflag = true;
+elseif strcmp(flag, {'off'})
+    iflag = false;
+else
+    error('Input to setChemistry not understood. It must be either "on" or "off".');
+end
+reactormethods(8, r.index, iflag);

--- a/interfaces/matlab/toolbox/@Reactor/setEnergy.m
+++ b/interfaces/matlab/toolbox/@Reactor/setEnergy.m
@@ -15,7 +15,7 @@ function setEnergy(r, flag)
 % :param r:
 %     Instance of class :mat:func:`Reactor`
 % :param flag:
-%     String, either ``'on'`` or ``'off`` to enable and disable
+%     String, either ``'on'`` or ``'off'`` to enable and disable
 %     solving the energy equation, respectively
 %
 

--- a/interfaces/python_minimal/.gitignore
+++ b/interfaces/python_minimal/.gitignore
@@ -4,4 +4,4 @@ cantera/ck2cti.py
 cantera/ctml_writer.py
 build
 dist
-Cantera_minimal_.egg-info
+Cantera_minimal.egg-info

--- a/interfaces/python_minimal/setup.py.in
+++ b/interfaces/python_minimal/setup.py.in
@@ -1,6 +1,6 @@
 from setuptools import setup
 
-setup(name="Cantera (minimal)",
+setup(name="Cantera_minimal",
       version="@cantera_version@",
       description="The Minimal Cantera Python Interface",
       long_description="",

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -169,6 +169,19 @@ extern "C" {
         }
     }
 
+    int reactor_setChemistry(int i, bool cflag)
+    {
+        try {
+            // @todo This should not fail silently
+            if (ReactorCabinet::item(i).type() >= ReactorType) {
+                ReactorCabinet::get<Reactor>(i).setChemistry(cflag);
+            }
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int reactor_setEnergy(int i, int eflag)
     {
         try {

--- a/src/clib/ctreactor.h
+++ b/src/clib/ctreactor.h
@@ -11,6 +11,7 @@ extern "C" {
     CANTERA_CAPI int reactor_del(int i);
     CANTERA_CAPI int reactor_copy(int i);
     CANTERA_CAPI int reactor_setInitialVolume(int i, double v);
+    CANTERA_CAPI int reactor_setChemistry(int i, bool cflag);
     CANTERA_CAPI int reactor_setEnergy(int i, int eflag);
     CANTERA_CAPI int reactor_setThermoMgr(int i, int n);
     CANTERA_CAPI int reactor_setKineticsMgr(int i, int n);

--- a/src/matlab/reactormethods.cpp
+++ b/src/matlab/reactormethods.cpp
@@ -48,6 +48,9 @@ void reactormethods(int nlhs, mxArray* plhs[],
         case 7:
             iok = reactor_setKineticsMgr(i, int(v));
             break;
+        case 8:
+            iok = reactor_setChemistry(i, bool(v));
+            break;
         case 9:
             iok = reactor_setEnergy(i, int(v));
             break;

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -29,9 +29,9 @@ void Reactor::setKineticsMgr(Kinetics& kin)
 {
     m_kin = &kin;
     if (m_kin->nReactions() == 0) {
-        disableChemistry();
+        setChemistry(false);
     } else {
-        enableChemistry();
+        setChemistry(true);
     }
 }
 


### PR DESCRIPTION
This PR creates new methods of the `Reactor` class called `setChemistry` and `chemistryEnabled` that mirror the `setEnergy` and `energyEnabled` methods. The `enableChemistry` and `disableChemistry` methods are deprecated. It also adds a Cython interface to the new methods, and a Matlab interface to `setChemistry` (there is no Matlab interface to `energyEnabled`).

It also fixes an error when installing the minimal Python interface that the version is invalid.

I need to add a test before this gets merged.
