### PR TITLE
Fixed dummy element entry in elements.xml.

### DIFF
--- a/data/inputs/elements.xml
+++ b/data/inputs/elements.xml
@@ -927,6 +927,15 @@
              </source>
            </entropy298>
         </element>
-	<element name="dummy" atomicWt = "0.0" atomicNumber = "0" />
+	<element name="dummy" atomicWt = "1.0E-16" atomicNumber = "0" >
+           <entropy298 value = "0.0">
+             <source>
+                   Generic dummy element.  Simply copy this element tag
+                   and populate the property tags with your desired values.  
+                   Note that at the moment you cannot set atomicWt = "0.0"
+                   because Cantera will throw and error.
+             </source>
+           </entropy298>
+        </element>
      </elementData>
 </ctml>

--- a/data/inputs/elements.xml
+++ b/data/inputs/elements.xml
@@ -927,15 +927,5 @@
              </source>
            </entropy298>
         </element>
-	<element name="dummy" atomicWt = "1.0E-16" atomicNumber = "0" >
-           <entropy298 value = "0.0">
-             <source>
-                   Generic dummy element.  Simply copy this element tag
-                   and populate the property tags with your desired values.  
-                   Note that at the moment you cannot set atomicWt = "0.0"
-                   because Cantera will throw and error.
-             </source>
-           </entropy298>
-        </element>
      </elementData>
 </ctml>


### PR DESCRIPTION
elements.xml allowed for the creation of a dummy element but the dummy element tag was incomplete.  Trying to use the dummy element caused cantera to throw an exception:

CanteraError thrown by LookupWtElements:
element not found

I updated the dummy element tag and the exception is no longer thrown.

Another strange behavior is that if the user sets atomicWt = "0.0" in the dummy element, then cantera throws the _same_ exception as before.  Right now, I set atomicWt = "1.0E-16" which works.  Maybe cantera is trying to require positive atomic weights in which case a different error message may be more informative.
