### PR TITLE
Update copyright & author information

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,15 +5,15 @@ years. If you've been left off, please report the omission on the Github issue
 tracker.
 
 Philip Berndt
-Victor Brunini
-Steven Decaluwe
-Thomas Fiala
+Victor Brunini, Sandia National Laboratory
+Steven Decaluwe, Colorado School of Mines
+Thomas Fiala, Technische Universität München
 David Fronczek
-Dave Goodwin
-John Hewson
-Nicholas Malaya
-Harry Moffat
+Dave Goodwin, California Institute of Technology
+John Hewson, Sandia National Laboratory
+Nicholas Malaya, University of Texas at Austin
+Harry Moffat, Sandia National Laboratory
 Andreas Rücker
-Santosh Shanbhogue
-Raymond Speth
-Bryan Weber
+Santosh Shanbhogue, Massachusetts Institute of Technology
+Raymond Speth, Massachusetts Institute of Technology
+Bryan Weber, University of Connecticut

--- a/AUTHORS
+++ b/AUTHORS
@@ -1,18 +1,19 @@
-Cantera developers:
-
-Dave Goodwin
-Harry Moffat
-Raymond Speth
-
-Contributors:
+Cantera was originally developed by Dave Goodwin, with its first public release
+in 2001. Since then, many people have contributed to Cantera. Below is a
+partial, alphabetical list of developers and contributors to Cantera over the
+years. If you've been left off, please report the omission on the Github issue
+tracker.
 
 Philip Berndt
 Victor Brunini
 Steven Decaluwe
 Thomas Fiala
 David Fronczek
+Dave Goodwin
 John Hewson
 Nicholas Malaya
+Harry Moffat
 Andreas Rücker
 Santosh Shanbhogue
+Raymond Speth
 Bryan Weber

--- a/License.txt
+++ b/License.txt
@@ -6,6 +6,9 @@ Copyright (c) 2009 Sandia Corporation. Under the terms of
 Contract AC04-94AL85000 with Sandia Corporation, the U.S. Government
 retains certain rights in this software.
 
+Copyright (c) 2011-2016, Cantera Developers.
+All rights reserved.
+
 Redistribution and use in source and binary forms, with or without
 modification, are permitted provided that the following conditions are
 met:
@@ -33,4 +36,3 @@ DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY
 THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT
 (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
 OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
-

--- a/include/cantera/Edge.h
+++ b/include/cantera/Edge.h
@@ -1,4 +1,8 @@
 //! @file Edge.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CXX_EDGE
 #define CXX_EDGE
 

--- a/include/cantera/IdealGasMix.h
+++ b/include/cantera/IdealGasMix.h
@@ -1,4 +1,8 @@
 //! @file IdealGasMix.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CXX_IDEALGASMIX
 #define CXX_IDEALGASMIX
 

--- a/include/cantera/IncompressibleSolid.h
+++ b/include/cantera/IncompressibleSolid.h
@@ -1,4 +1,8 @@
 //! @file IncompressibleSolid.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CXX_INCOMPRESSIBLE
 #define CXX_INCOMPRESSIBLE
 

--- a/include/cantera/Interface.h
+++ b/include/cantera/Interface.h
@@ -2,6 +2,10 @@
  * @file Interface.h
  *   Declaration and Definition for the class Interface.
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CXX_INTERFACE
 #define CXX_INTERFACE
 

--- a/include/cantera/Metal.h
+++ b/include/cantera/Metal.h
@@ -1,4 +1,8 @@
 //! @file Metal.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CXX_METAL
 #define CXX_METAL
 

--- a/include/cantera/PureFluid.h
+++ b/include/cantera/PureFluid.h
@@ -1,4 +1,8 @@
 //! @file PureFluid.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CXX_PUREFLUID
 #define CXX_PUREFLUID
 

--- a/include/cantera/base/Array.h
+++ b/include/cantera/base/Array.h
@@ -1,7 +1,9 @@
 /**
  *  @file Array.h Header file for class Cantera::Array2D
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ARRAY_H
 #define CT_ARRAY_H

--- a/include/cantera/base/FactoryBase.h
+++ b/include/cantera/base/FactoryBase.h
@@ -2,6 +2,10 @@
  *  @file FactoryBase.h
  *  File contains the FactoryBase class declarations.
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_FACTORY_BASE
 #define CT_FACTORY_BASE
 

--- a/include/cantera/base/ValueCache.h
+++ b/include/cantera/base/ValueCache.h
@@ -2,6 +2,9 @@
  *  @file ValueCache.h
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_VALUECACHE_H
 #define CT_VALUECACHE_H
 

--- a/include/cantera/base/clockWC.h
+++ b/include/cantera/base/clockWC.h
@@ -3,12 +3,9 @@
  *    Declarations for a simple class that implements an Ansi C wall clock timer
  *   (see \ref Cantera::clockWC).
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CLOCKWC_H
 #define CT_CLOCKWC_H

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -8,8 +8,9 @@
  * All physical constants are stored here.
  * The module physConstants is defined here.
  */
-// Copyright 2001  California Institute of Technology
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DEFS_H
 #define CT_DEFS_H

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -4,7 +4,9 @@
  *   thrown when %Cantera experiences an error condition
  *   (also contains errorhandling module text - see \ref errorhandling).
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CTEXCEPTIONS_H
 #define CT_CTEXCEPTIONS_H

--- a/include/cantera/base/ctml.h
+++ b/include/cantera/base/ctml.h
@@ -4,7 +4,9 @@
  * to store data. These functions read and write it.
  * (see \ref inputfiles and importCTML, ck2ctml)
  */
-// Copyright 2002  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CTML_H
 #define CT_CTML_H

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -12,7 +12,9 @@
  *     -  logs        (see \ref logs)
  *     -  textlogs    (see \ref textlogs)
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_GLOBAL_H
 #define CT_GLOBAL_H

--- a/include/cantera/base/logger.h
+++ b/include/cantera/base/logger.h
@@ -3,6 +3,10 @@
  * Header for Base class for 'loggers' that write text messages to log files
  * (see \ref textlogs and class \link Cantera::Logger Logger\endlink).
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_LOGGER_H
 #define CT_LOGGER_H
 

--- a/include/cantera/base/plots.h
+++ b/include/cantera/base/plots.h
@@ -2,7 +2,9 @@
  *  @file plots.h Contains declarations for utility functions for outputing to
  *       plotting programs.
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PLOTS_H
 #define CT_PLOTS_H

--- a/include/cantera/base/stringUtils.h
+++ b/include/cantera/base/stringUtils.h
@@ -2,7 +2,9 @@
  *  @file stringUtils.h Contains declarations for string manipulation
  *       functions within Cantera.
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_STRINGUTILS_H
 #define CT_STRINGUTILS_H

--- a/include/cantera/base/utilities.h
+++ b/include/cantera/base/utilities.h
@@ -4,7 +4,9 @@
  *  operations (see \ref utils).
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 /**
  * @defgroup utils Templated Utility Functions
  *

--- a/include/cantera/base/xml.h
+++ b/include/cantera/base/xml.h
@@ -4,7 +4,9 @@
  * implement only those aspects of XML required to read, write, and
  * manipulate CTML data files.
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_XML_H
 #define CT_XML_H

--- a/include/cantera/cython/funcWrapper.h
+++ b/include/cantera/cython/funcWrapper.h
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_CYTHON_FUNC_WRAPPER
 #define CT_CYTHON_FUNC_WRAPPER
 

--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/logger.h"
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/transport/TransportBase.h"

--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -1,9 +1,9 @@
 /**
  *  @file ChemEquil.h Chemical equilibrium.
  */
-/*
- *  Copyright 2001 California Institute of Technology
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CHEM_EQUIL_H
 #define CT_CHEM_EQUIL_H

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -3,7 +3,9 @@
  * Headers for the \link Cantera::MultiPhase MultiPhase\endlink
  * object that is used to set up multiphase equilibrium problems (see \ref equilfunctions).
  */
-//  Copyright 2004  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTIPHASE_H
 #define CT_MULTIPHASE_H

--- a/include/cantera/equil/MultiPhaseEquil.h
+++ b/include/cantera/equil/MultiPhaseEquil.h
@@ -1,4 +1,8 @@
 //! @file MultiPhaseEquil.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_MULTIPHASE_EQUIL
 #define CT_MULTIPHASE_EQUIL
 

--- a/include/cantera/equil/vcs_MultiPhaseEquil.h
+++ b/include/cantera/equil/vcs_MultiPhaseEquil.h
@@ -2,6 +2,10 @@
  *  @file  vcs_MultiPhaseEquil.h
  *  Interface class for the vcsnonlinear solver
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef VCS_MULTIPHASEEQUIL_H
 #define VCS_MULTIPHASEEQUIL_H
 

--- a/include/cantera/equil/vcs_SpeciesProperties.h
+++ b/include/cantera/equil/vcs_SpeciesProperties.h
@@ -1,4 +1,8 @@
 //! @file vcs_SpeciesProperties.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef VCS_SPECIES_PROPERTIES_H
 #define VCS_SPECIES_PROPERTIES_H
 

--- a/include/cantera/equil/vcs_VolPhase.h
+++ b/include/cantera/equil/vcs_VolPhase.h
@@ -2,11 +2,9 @@
  * @file vcs_VolPhase.h
  *   Header for the object representing each phase within vcs
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef VCS_VOLPHASE_H
 #define VCS_VOLPHASE_H

--- a/include/cantera/equil/vcs_defs.h
+++ b/include/cantera/equil/vcs_defs.h
@@ -2,11 +2,9 @@
  * @file vcs_defs.h
  *    Defines and definitions within the vcs package
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef VCS_DEFS_H
 #define VCS_DEFS_H

--- a/include/cantera/equil/vcs_internal.h
+++ b/include/cantera/equil/vcs_internal.h
@@ -2,11 +2,8 @@
  *  @file vcs_internal.h Internal declarations for the VCSnonideal package
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef _VCS_INTERNAL_H
 #define _VCS_INTERNAL_H

--- a/include/cantera/equil/vcs_prob.h
+++ b/include/cantera/equil/vcs_prob.h
@@ -2,11 +2,9 @@
  * @file vcs_prob.h
  *  Header for the Interface class for the vcs thermo equilibrium solver package,
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef _VCS_PROB_H
 #define _VCS_PROB_H

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -3,11 +3,9 @@
  *    equilibrium problem (see Class \link Cantera::VCS_SOLVE
  *    VCS_SOLVE\endlink and \ref equilfunctions ).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef _VCS_SOLVE_H
 #define _VCS_SOLVE_H

--- a/include/cantera/equil/vcs_species_thermo.h
+++ b/include/cantera/equil/vcs_species_thermo.h
@@ -1,10 +1,7 @@
 //! @file vcs_species_thermo.h
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef VCS_SPECIES_THERMO_H
 #define VCS_SPECIES_THERMO_H

--- a/include/cantera/kinetics/AqueousKinetics.h
+++ b/include/cantera/kinetics/AqueousKinetics.h
@@ -3,7 +3,8 @@
  * @ingroup chemkinetics
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_AQUEOUSKINETICS_H
 #define CT_AQUEOUSKINETICS_H

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -3,6 +3,9 @@
  * @ingroup chemkinetics
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_BULKKINETICS_H
 #define CT_BULKKINETICS_H
 

--- a/include/cantera/kinetics/EdgeKinetics.h
+++ b/include/cantera/kinetics/EdgeKinetics.h
@@ -4,7 +4,9 @@
  * @ingroup chemkinetics
  * @ingroup electrochem
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_EDGEKINETICS_H
 #define CT_EDGEKINETICS_H

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_FALLOFF_H
 #define CT_FALLOFF_H
 

--- a/include/cantera/kinetics/FalloffFactory.h
+++ b/include/cantera/kinetics/FalloffFactory.h
@@ -4,7 +4,9 @@
  *  that implement gas-phase kinetics (GasKinetics, GRI_30_Kinetics)
  *  (see \ref falloffGroup and class \link Cantera::Falloff Falloff\endlink).
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_NEWFALLOFF_H
 #define CT_NEWFALLOFF_H

--- a/include/cantera/kinetics/FalloffMgr.h
+++ b/include/cantera/kinetics/FalloffMgr.h
@@ -2,7 +2,8 @@
  *  @file FalloffMgr.h
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FALLOFFMGR_H
 #define CT_FALLOFFMGR_H

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -3,7 +3,8 @@
  * @ingroup chemkinetics
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_GASKINETICS_H
 #define CT_GASKINETICS_H

--- a/include/cantera/kinetics/Group.h
+++ b/include/cantera/kinetics/Group.h
@@ -2,7 +2,8 @@
  *  @file Group.h
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RXNPATH_GROUP
 #define CT_RXNPATH_GROUP

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -4,7 +4,9 @@
  *  (see \ref  kineticsmgr and class
  *  \link Cantera::ImplicitSurfChem ImplicitSurfChem\endlink).
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IMPSURFCHEM_H
 #define CT_IMPSURFCHEM_H

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -2,7 +2,9 @@
  * @file InterfaceKinetics.h
  * @ingroup chemkinetics
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IFACEKINETICS_H
 #define CT_IFACEKINETICS_H

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -5,7 +5,8 @@
  *  \link Cantera::Kinetics Kinetics\endlink).
  */
 
-// Copyright 2001-2004  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_KINETICS_H
 #define CT_KINETICS_H

--- a/include/cantera/kinetics/KineticsFactory.h
+++ b/include/cantera/kinetics/KineticsFactory.h
@@ -1,8 +1,9 @@
 /**
  *  @file KineticsFactory.h
  */
-// Copyright 2001  California Institute of Technology
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef KINETICS_FACTORY_H
 #define KINETICS_FACTORY_H

--- a/include/cantera/kinetics/RateCoeffMgr.h
+++ b/include/cantera/kinetics/RateCoeffMgr.h
@@ -1,8 +1,9 @@
 /**
  *  @file RateCoeffMgr.h
  */
-// Copyright 2001  California Institute of Technology
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RATECOEFF_MGR_H
 #define CT_RATECOEFF_MGR_H

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -2,6 +2,9 @@
  *  @file Reaction.h
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_REACTION_H
 #define CT_REACTION_H
 

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -3,7 +3,8 @@
  *  Classes for reaction path analysis.
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RXNPATH_H
 #define CT_RXNPATH_H

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -1,7 +1,9 @@
 /**
  *  @file RxnRates.h
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RXNRATES_H
 #define CT_RXNRATES_H

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -2,7 +2,8 @@
  *  @file StoichManager.h
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_STOICH_MGR_H
 #define CT_STOICH_MGR_H

--- a/include/cantera/kinetics/ThirdBodyCalc.h
+++ b/include/cantera/kinetics/ThirdBodyCalc.h
@@ -2,6 +2,9 @@
  *  @file ThirdBodyCalc.h
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_THIRDBODYCALC_H
 #define CT_THIRDBODYCALC_H
 

--- a/include/cantera/kinetics/importKinetics.h
+++ b/include/cantera/kinetics/importKinetics.h
@@ -9,7 +9,9 @@
  *     of these routines is to initialize the %Cantera objects with data
  *     from the ctml tree structures.
  */
-// Copyright 2002  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IMPORTKINETICS_H
 #define CT_IMPORTKINETICS_H

--- a/include/cantera/kinetics/reaction_defs.h
+++ b/include/cantera/kinetics/reaction_defs.h
@@ -3,7 +3,8 @@
  * This file defines some constants used to specify reaction types.
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RXN_DEFS_H
 #define CT_RXN_DEFS_H

--- a/include/cantera/kinetics/solveSP.h
+++ b/include/cantera/kinetics/solveSP.h
@@ -2,12 +2,9 @@
  * @file solveSP.h Header file for implicit surface problem solver (see \ref
  *       chemkinetics and class \link Cantera::solveSP solveSP\endlink).
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef SOLVESP_H
 #define SOLVESP_H

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -5,7 +5,8 @@
  *    (see class \ref numerics and \link Cantera::BandMatrix BandMatrix\endlink).
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_BANDMATRIX_H
 #define CT_BANDMATRIX_H

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -1,7 +1,9 @@
 /**
  *  @file CVodesIntegrator.h
  */
-// Copyright 2005  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CVODESWRAPPER_H
 #define CT_CVODESWRAPPER_H

--- a/include/cantera/numerics/DAE_Solver.h
+++ b/include/cantera/numerics/DAE_Solver.h
@@ -3,7 +3,8 @@
  *  Header file for class DAE_Solver
  */
 
-// Copyright 2006 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DAE_Solver_H
 #define CT_DAE_Solver_H

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -5,7 +5,8 @@
  *  (see \ref numerics and \link Cantera::DenseMatrix DenseMatrix \endlink) .
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DENSEMATRIX_H
 #define CT_DENSEMATRIX_H

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -2,7 +2,8 @@
  *  @file Func1.h
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FUNC1_H
 #define CT_FUNC1_H

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -2,7 +2,8 @@
  *  @file FuncEval.h
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FUNCEVAL_H
 #define CT_FUNCEVAL_H

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -4,12 +4,8 @@
  *    (see class \ref numerics and \link Cantera::GeneralMatrix GeneralMatrix\endlink).
  */
 
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_GENERALMATRIX_H
 #define CT_GENERALMATRIX_H

--- a/include/cantera/numerics/IDA_Solver.h
+++ b/include/cantera/numerics/IDA_Solver.h
@@ -3,7 +3,8 @@
  *  Header file for class IDA_Solver
  */
 
-// Copyright 2006 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDA_SOLVER_H
 #define CT_IDA_SOLVER_H

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -6,7 +6,8 @@
  * @defgroup odeGroup ODE Integrators
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_INTEGRATOR_H
 #define CT_INTEGRATOR_H

--- a/include/cantera/numerics/ResidEval.h
+++ b/include/cantera/numerics/ResidEval.h
@@ -1,6 +1,7 @@
 //! @file ResidEval.h
 
-// Copyright 2006  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RESIDEVAL_H
 #define CT_RESIDEVAL_H

--- a/include/cantera/numerics/ResidJacEval.h
+++ b/include/cantera/numerics/ResidJacEval.h
@@ -4,12 +4,8 @@
  * Dense, Square (not sparse) matrices.
  */
 
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RESIDJACEVAL_H
 #define CT_RESIDJACEVAL_H

--- a/include/cantera/numerics/RootFind.h
+++ b/include/cantera/numerics/RootFind.h
@@ -4,12 +4,8 @@
  *       Cantera::RootFind RootFind\endlink).
  */
 
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ROOTFIND_H
 #define CT_ROOTFIND_H

--- a/include/cantera/numerics/SquareMatrix.h
+++ b/include/cantera/numerics/SquareMatrix.h
@@ -1,11 +1,7 @@
 //! @file SquareMatrix.h Dense, Square (not sparse) matrices.
 
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SQUAREMATRIX_H
 #define CT_SQUAREMATRIX_H

--- a/include/cantera/numerics/ctlapack.h
+++ b/include/cantera/numerics/ctlapack.h
@@ -1,7 +1,9 @@
 /**
  * @file ctlapack.h
  */
-// Copyright 2001 California Institute of Technology.
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CTLAPACK_H
 #define CT_CTLAPACK_H

--- a/include/cantera/numerics/funcs.h
+++ b/include/cantera/numerics/funcs.h
@@ -2,10 +2,10 @@
  *  @file funcs.h Header for a file containing miscellaneous
  *                numerical functions.
  */
-/*
- *  Copyright 2001-2003 California Institute of Technology
- *  See file License.txt for licensing information
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_FUNCS_H
 #define CT_FUNCS_H
 

--- a/include/cantera/numerics/polyfit.h
+++ b/include/cantera/numerics/polyfit.h
@@ -1,8 +1,7 @@
 //! @file polyfit.h
-/*
- *  Copyright 2001-2003 California Institute of Technology
- *  See file License.txt for licensing information
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_POLYFIT_H
 #define CT_POLYFIT_H

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -1,8 +1,7 @@
  //! @file Domain1D.h
 
-/*
- *  Copyright 2002 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DOMAIN1D_H
 #define CT_DOMAIN1D_H

--- a/include/cantera/oneD/Inlet1D.h
+++ b/include/cantera/oneD/Inlet1D.h
@@ -4,9 +4,8 @@
  * Boundary objects for one-dimensional simulations.
  */
 
-/*
- * Copyright 2002-3  California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_BDRY1D_H
 #define CT_BDRY1D_H

--- a/include/cantera/oneD/MultiJac.h
+++ b/include/cantera/oneD/MultiJac.h
@@ -1,8 +1,7 @@
 //! @file MultiJac.h
 
-/*
- *  Copyright 2002 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTIJAC_H
 #define CT_MULTIJAC_H

--- a/include/cantera/oneD/MultiNewton.h
+++ b/include/cantera/oneD/MultiNewton.h
@@ -1,8 +1,7 @@
 //! @file MultiNewton.h
 
-/*
- *  Copyright 2002 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTINEWTON_H
 #define CT_MULTINEWTON_H

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -2,6 +2,9 @@
  * @file OneDim.h
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_ONEDIM_H
 #define CT_ONEDIM_H
 

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -2,6 +2,9 @@
  * @file Sim1D.h
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_SIM1D_H
 #define CT_SIM1D_H
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -1,6 +1,7 @@
 //! @file StFlow.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_STFLOW_H
 #define CT_STFLOW_H

--- a/include/cantera/oneD/refine.h
+++ b/include/cantera/oneD/refine.h
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_REFINE_H
 #define CT_REFINE_H
 

--- a/include/cantera/thermo/AdsorbateThermo.h
+++ b/include/cantera/thermo/AdsorbateThermo.h
@@ -6,7 +6,9 @@
  * expressions for the thermo properties of a species with several vibrational
  * models.
  */
-// Copyright 2007  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ADSORBATE_H
 #define CT_ADSORBATE_H

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -4,7 +4,9 @@
  * object that employs a constant heat capacity assumption (see \ref spthermo and
  * \link Cantera::ConstCpPoly ConstCpPoly\endlink).
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CONSTCPPOLY_H
 #define CT_CONSTCPPOLY_H

--- a/include/cantera/thermo/ConstDensityThermo.h
+++ b/include/cantera/thermo/ConstDensityThermo.h
@@ -3,9 +3,9 @@
  * Header for a Thermo manager for incompressible ThermoPhases
  * (see \ref thermoprops and \link Cantera::ConstDensityThermo ConstDensityThermo\endlink).
  */
-/*
- *  Copyright 2002 California Institute of Technology
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CONSTRHOTHERMO_H
 #define CT_CONSTRHOTHERMO_H

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -8,11 +8,9 @@
  * obeys the Debye Huckel formulation for nonideality.
  */
 
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_DEBYEHUCKEL_H
 #define CT_DEBYEHUCKEL_H
 

--- a/include/cantera/thermo/EdgePhase.h
+++ b/include/cantera/thermo/EdgePhase.h
@@ -4,7 +4,8 @@
  *       \link Cantera::EdgePhase EdgePhase\endlink).
  */
 
-//  Copyright 2002 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_EDGEPHASE_H
 #define CT_EDGEPHASE_H

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -3,7 +3,9 @@
  *  Contains the getElementWeight function and the definitions of element
  *  constraint types.
  */
-//  Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ELEMENTS_H
 #define CT_ELEMENTS_H

--- a/include/cantera/thermo/FixedChemPotSSTP.h
+++ b/include/cantera/thermo/FixedChemPotSSTP.h
@@ -5,11 +5,8 @@
  * class \link Cantera::FixedChemPotSSTP FixedChemPotSSTP\endlink)
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FIXEDCHEMPOTSSTP_H
 #define CT_FIXEDCHEMPOTSSTP_H

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -5,11 +5,10 @@
  *  (see \ref thermoprops
  * and class \link Cantera::GibbsExcessVPSSTP GibbsExcessVPSSTP\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_GIBBSEXCESSVPSSTP_H
 #define CT_GIBBSEXCESSVPSSTP_H
 

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -8,11 +8,10 @@
  * obeys the Pitzer formulation for nonideality using molality-based
  * standard states.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_HMWSOLN_H
 #define CT_HMWSOLN_H
 

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -5,7 +5,9 @@
  * and class \link Cantera::IdealGasPhase IdealGasPhase\endlink).
  */
 
-//  Copyright 2001 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_IDEALGASPHASE_H
 #define CT_IDEALGASPHASE_H
 

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -11,11 +11,10 @@
  * turns out to be highly nonlinear in the limit of the solvent mole fraction
  * going to zero.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_IDEALMOLALSOLN_H
 #define CT_IDEALMOLALSOLN_H
 

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -6,11 +6,9 @@
  * This class inherits from the Cantera class ThermoPhase and implements an
  * ideal solid solution model with incompressible thermodynamics.
  */
-/*
- * Copyright 2006 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000, with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDEALSOLIDSOLNPHASE_H
 #define CT_IDEALSOLIDSOLNPHASE_H

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -6,11 +6,10 @@
  * thermodynamic properties (see \ref thermoprops and
  * class \link Cantera::IdealSolnGasVPSS IdealSolnGasVPSS\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_IDEALSOLNGASVPSS_H
 #define CT_IDEALSOLNGASVPSS_H
 

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -4,11 +4,10 @@
  *   neutral molecule thermodynamics. (see \ref thermoprops and class \link
  *   Cantera::IonsFromNeutralVPSSTP IonsFromNeutralVPSSTP\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_IONSFROMNEUTRALVPSSTP_H
 #define CT_IONSFROMNEUTRALVPSSTP_H
 

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -5,7 +5,8 @@
  *      LatticePhase\endlink).
  */
 
-//  Copyright 2005 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_LATTICE_H
 #define CT_LATTICE_H

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -5,7 +5,8 @@
  *      Cantera::LatticeSolidPhase LatticeSolidPhase\endlink).
  */
 
-//  Copyright 2005 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_LATTICESOLID_H
 #define CT_LATTICESOLID_H

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -2,11 +2,10 @@
  *  @file  MargulesVPSSTP.h (see \ref thermoprops and class \link
  *      Cantera::MargulesVPSSTP MargulesVPSSTP\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_MARGULESVPSSTP_H
 #define CT_MARGULESVPSSTP_H
 

--- a/include/cantera/thermo/MaskellSolidSolnPhase.h
+++ b/include/cantera/thermo/MaskellSolidSolnPhase.h
@@ -5,11 +5,9 @@
  * This class inherits from the Cantera class ThermoPhase and implements a
  * non-ideal solid solution model with incompressible thermodynamics.
  */
-/*
- * Copyright 2006 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000, with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MASKELLSOLIDSOLNPHASE_H
 #define CT_MASKELLSOLIDSOLNPHASE_H

--- a/include/cantera/thermo/MetalPhase.h
+++ b/include/cantera/thermo/MetalPhase.h
@@ -2,7 +2,8 @@
  *  @file MetalPhase.h
  */
 
-//  Copyright 2003 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_METALPHASE_H
 #define CT_METALPHASE_H

--- a/include/cantera/thermo/MetalSHEelectrons.h
+++ b/include/cantera/thermo/MetalSHEelectrons.h
@@ -6,11 +6,9 @@
  * class \link Cantera::MetalSHEelectrons MetalSHEelectrons\endlink)
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_METALSHEELECTRONS_H
 #define CT_METALSHEELECTRONS_H
 

--- a/include/cantera/thermo/MineralEQ3.h
+++ b/include/cantera/thermo/MineralEQ3.h
@@ -5,13 +5,9 @@
  * class \link Cantera::MineralEQ3 MineralEQ3\endlink)
  */
 
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- *
- * Copyright 2001 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_MINERALEQ3_H
 #define CT_MINERALEQ3_H
 

--- a/include/cantera/thermo/MixedSolventElectrolyte.h
+++ b/include/cantera/thermo/MixedSolventElectrolyte.h
@@ -2,11 +2,9 @@
  *  @file  MixedSolventElectrolyte.h (see \ref thermoprops and class \link
  *      Cantera::MixedSolventElectrolyte MixedSolventElectrolyte \endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MIXEDSOLVENTELECTROLYTEVPSSTP_H
 #define CT_MIXEDSOLVENTELECTROLYTEVPSSTP_H

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -4,11 +4,9 @@
  *    non-ideal mixtures based on the fugacity models (see \ref thermoprops and
  *    class \link Cantera::MixtureFugacityTP MixtureFugacityTP\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MIXTUREFUGACITYTP_H
 #define CT_MIXTUREFUGACITYTP_H

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -11,11 +11,10 @@
  * based on the molality scale.  These include most of the methods for
  * calculating liquid electrolyte thermodynamics.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_MOLALITYVPSSTP_H
 #define CT_MOLALITYVPSSTP_H
 

--- a/include/cantera/thermo/MolarityIonicVPSSTP.h
+++ b/include/cantera/thermo/MolarityIonicVPSSTP.h
@@ -7,11 +7,9 @@
  * further based upon activities based on the molarity scale.  In this class, we
  * expect that there are ions, but they are treated on the molarity scale.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MOLARITYIONICVPSSTP_H
 #define CT_MOLARITYIONICVPSSTP_H

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -5,6 +5,10 @@
  *  on a piecewise constant mu0 interpolation
  *  (see \ref spthermo and class \link Cantera::Mu0Poly Mu0Poly\endlink).
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_MU0POLY_H
 #define CT_MU0POLY_H
 

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -3,6 +3,10 @@
  *  Header for a general species thermodynamic property manager for a phase (see
  * \link Cantera::MultiSpeciesThermo MultiSpeciesThermo\endlink).
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_MULTISPECIESTHERMO_H
 #define CT_MULTISPECIESTHERMO_H
 

--- a/include/cantera/thermo/Nasa9Poly1.h
+++ b/include/cantera/thermo/Nasa9Poly1.h
@@ -7,11 +7,9 @@
  *
  * This parameterization has one NASA temperature region.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_NASA9POLY1_H
 #define CT_NASA9POLY1_H

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -10,9 +10,11 @@
  *  This parameterization has multiple NASA temperature regions.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_NASA9POLYMULTITEMPREGION_H
 #define CT_NASA9POLYMULTITEMPREGION_H
-// Copyright 2007  Sandia National Laboratories
 
 #include "cantera/thermo/Nasa9Poly1.h"
 

--- a/include/cantera/thermo/NasaPoly1.h
+++ b/include/cantera/thermo/NasaPoly1.h
@@ -8,9 +8,11 @@
  *  This parameterization has one NASA temperature region.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_NASAPOLY1_H
 #define CT_NASAPOLY1_H
-// Copyright 2001  California Institute of Technology
 
 #include "SpeciesThermoInterpType.h"
 

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -7,7 +7,9 @@
  *
  *  Two zoned NASA polynomial parameterization
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_NASAPOLY2_H
 #define CT_NASAPOLY2_H

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -4,11 +4,10 @@
  *    which handles calculations for a single species in a phase
  *    (see \ref pdssthermo and class \link Cantera::PDSS PDSS\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_PDSS_H
 #define CT_PDSS_H
 #include "cantera/base/ct_defs.h"

--- a/include/cantera/thermo/PDSS_ConstVol.h
+++ b/include/cantera/thermo/PDSS_ConstVol.h
@@ -4,11 +4,10 @@
  *    which handles calculations for a single species with a constant molar volume in a phase
  *    (see class \ref pdssthermo and \link Cantera::PDSS_ConstVol PDSS_ConstVol\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_PDSS_CONSTVOL_H
 #define CT_PDSS_CONSTVOL_H
 

--- a/include/cantera/thermo/PDSS_HKFT.h
+++ b/include/cantera/thermo/PDSS_HKFT.h
@@ -5,11 +5,9 @@
  *    HKFT standard state
  *    (see \ref pdssthermo and class \link Cantera::PDSS_HKFT PDSS_HKFT\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PDSS_HKFT_H
 #define CT_PDSS_HKFT_H

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -4,11 +4,10 @@
  *    which handles calculations for a single ideal gas species in a phase
  *    (see \ref pdssthermo and class \link Cantera::PDSS_IdealGas PDSS_IdealGas\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_PDSS_IDEALGAS_H
 #define CT_PDSS_IDEALGAS_H
 

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -5,11 +5,10 @@
  *    are calculated from another neutral molecule.
  *    (see \ref pdssthermo and class \link Cantera::PDSS_IonsFromNeutral PDSS_IonsFromNeutral\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_PDSS_IONSFROMNEUTRAL_H
 #define CT_PDSS_IONSFROMNEUTRAL_H
 

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -5,11 +5,10 @@
  *    given by an enumerated data type
  *    (see class \ref pdssthermo and \link Cantera::PDSS_SSVol PDSS_SSVol\endlink).
  */
-/*
- * Copyright (2009) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_PDSS_SSVOL_H
 #define CT_PDSS_SSVOL_H
 

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -4,11 +4,10 @@
  * virtual function for a Pure Water Phase
  * (see \ref pdssthermo and class \link Cantera::PDSS_Water PDSS_Water\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_PDSS_WATER_H
 #define CT_PDSS_WATER_H
 

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -2,7 +2,9 @@
  * @file Phase.h
  * Header file for class Phase.
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PHASE_H
 #define CT_PHASE_H

--- a/include/cantera/thermo/PhaseCombo_Interaction.h
+++ b/include/cantera/thermo/PhaseCombo_Interaction.h
@@ -6,11 +6,8 @@
  *    and class \link Cantera::PhaseCombo_Interaction PhaseCombo_Interaction\endlink).
  */
 
-/*
- * Copyright (2011) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PHASECOMBO_INTERACTION_H
 #define CT_PHASECOMBO_INTERACTION_H

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -8,7 +8,8 @@
  * It inherits from ThermoPhase, but is built on top of the tpx package.
  */
 
-//  Copyright 2003 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_EOS_TPX_H
 #define CT_EOS_TPX_H

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -2,11 +2,9 @@
  *  @file  RedlichKisterVPSSTP.h (see \ref thermoprops and class \link
  *      Cantera::RedlichKisterVPSSTP RedlichKisterVPSSTP\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REDLICHKISTERVPSSTP_H
 #define CT_REDLICHKISTERVPSSTP_H

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -1,10 +1,7 @@
 //! @file RedlichKwongMFTP.h
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REDLICHKWONGMFTP_H
 #define CT_REDLICHKWONGMFTP_H

--- a/include/cantera/thermo/SemiconductorPhase.h
+++ b/include/cantera/thermo/SemiconductorPhase.h
@@ -2,7 +2,8 @@
  *  @file SemiconductorPhase.h
  */
 
-//  Copyright 2003 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SEMICONDPHASE_H
 #define CT_SEMICONDPHASE_H

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -7,7 +7,9 @@
  *   \link Cantera::ShomatePoly2 ShomatePoly2\endlink).
  *    Shomate polynomial expressions.
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SHOMATEPOLY1_H
 #define CT_SHOMATEPOLY1_H

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -4,11 +4,10 @@
  *  that eases the construction of single species phases
  *  ( see \ref thermoprops and class \link Cantera::SingleSpeciesTP SingleSpeciesTP\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_SINGLESPECIESTP_H
 #define CT_SINGLESPECIESTP_H
 

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -1,5 +1,8 @@
 //! @file Species.h Declaration for class Cantera::Species.
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_SPECIES_H
 #define CT_SPECIES_H
 

--- a/include/cantera/thermo/SpeciesThermoFactory.h
+++ b/include/cantera/thermo/SpeciesThermoFactory.h
@@ -4,7 +4,9 @@
  *    standard-state thermodynamic properties of a set of species
  *    (see \ref spthermo);
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef SPECIESTHERMO_FACTORY_H
 #define SPECIESTHERMO_FACTORY_H

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -6,7 +6,8 @@
  * Cantera::SpeciesThermoInterpType SpeciesThermoInterpType \endlink).
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SPECIESTHERMOINTERPTYPE_H
 #define CT_SPECIESTHERMOINTERPTYPE_H

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -5,11 +5,9 @@
  * class \link Cantera::StoichSubstance StoichSubstance\endlink)
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_STOICHSUBSTANCE_H
 #define CT_STOICHSUBSTANCE_H
 

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -6,7 +6,8 @@
  *  (see \ref thermoprops and class \link Cantera::SurfPhase SurfPhase\endlink).
  */
 
-//  Copyright 2002 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SURFPHASE_H
 #define CT_SURFPHASE_H

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -3,7 +3,9 @@
  *     Headers for the factory class that can create known ThermoPhase objects
  *     (see \ref thermoprops and class \link Cantera::ThermoFactory ThermoFactory\endlink).
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef THERMO_FACTORY_H
 #define THERMO_FACTORY_H

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -5,7 +5,8 @@
  * (see \ref thermoprops and class \link Cantera::ThermoPhase ThermoPhase\endlink).
  */
 
-//  Copyright 2002 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_THERMOPHASE_H
 #define CT_THERMOPHASE_H

--- a/include/cantera/thermo/VPSSMgr.h
+++ b/include/cantera/thermo/VPSSMgr.h
@@ -6,11 +6,9 @@
  * (see \ref mgrpdssthermocalc and
  * class \link Cantera::VPSSMgr VPSSMgr\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_VPSSMGR_H
 #define CT_VPSSMGR_H

--- a/include/cantera/thermo/VPSSMgr_ConstVol.h
+++ b/include/cantera/thermo/VPSSMgr_ConstVol.h
@@ -5,11 +5,9 @@
  *  states assuming constant volume (see class
  *  \link Cantera::VPSSMgr_ConstVol VPSSMgr_ConstVol \endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_VPSSMGR_CONSTVOL_H
 #define CT_VPSSMGR_CONSTVOL_H

--- a/include/cantera/thermo/VPSSMgr_General.h
+++ b/include/cantera/thermo/VPSSMgr_General.h
@@ -6,11 +6,9 @@
  * but slow way (see \ref mgrpdssthermocalc and
  * class \link Cantera::VPSSMgr_General VPSSMgr_General\endlink).
  */
-/*
- * Copyright (2007) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_VPSSMGR_GENERAL_H
 #define CT_VPSSMGR_GENERAL_H

--- a/include/cantera/thermo/VPSSMgr_IdealGas.h
+++ b/include/cantera/thermo/VPSSMgr_IdealGas.h
@@ -6,11 +6,9 @@
  * (see \ref mgrpdssthermocalc and
  * class \link Cantera::VPSSMgr_IdealGas VPSSMgr_IdealGas\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_VPSSMGR_IDEALGAS_H
 #define CT_VPSSMGR_IDEALGAS_H

--- a/include/cantera/thermo/VPSSMgr_Water_ConstVol.h
+++ b/include/cantera/thermo/VPSSMgr_Water_ConstVol.h
@@ -7,11 +7,9 @@
  * (see \ref mgrpdssthermocalc and
  * class \link Cantera::VPSSMgr_ConstVol VPSSMgr_ConstVol\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_VPSSMGR_WATER_CONSTVOL_H
 #define CT_VPSSMGR_WATER_CONSTVOL_H

--- a/include/cantera/thermo/VPSSMgr_Water_HKFT.h
+++ b/include/cantera/thermo/VPSSMgr_Water_HKFT.h
@@ -6,11 +6,9 @@
  * (see \ref mgrpdssthermocalc and
  * class \link Cantera::VPSSMgr_Water_HKFT VPSSMgr_Water_HKFT\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_VPSSMGR_WATER_HKFT_H
 #define CT_VPSSMGR_WATER_HKFT_H

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -5,11 +5,10 @@
  *    thermodynamic properties (see \ref thermoprops and
  *    class \link Cantera::VPStandardStateTP VPStandardStateTP\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_VPSTANDARDSTATETP_H
 #define CT_VPSTANDARDSTATETP_H
 

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -5,11 +5,10 @@
  *  (see \ref thermoprops
  *   and class \link Cantera::WaterProps WaterProps\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_WATERPROPS_H
 #define CT_WATERPROPS_H
 

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -4,11 +4,10 @@
  * from the IAPWS 1995 Formulation based on the steam tables thermodynamic
  * basis (See class \link Cantera::WaterPropsIAPWS WaterPropsIAPWS\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef WATERPROPSIAPWS_H
 #define WATERPROPSIAPWS_H
 

--- a/include/cantera/thermo/WaterPropsIAPWSphi.h
+++ b/include/cantera/thermo/WaterPropsIAPWSphi.h
@@ -6,11 +6,10 @@
  *
  * This class calculates dimensionless quantities.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef WATERPROPSIAPWSPHI_H
 #define WATERPROPSIAPWSPHI_H
 

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -3,11 +3,10 @@
  * Declares a ThermoPhase class consisting of pure water (see \ref thermoprops
  * and class \link Cantera::WaterSSTP WaterSSTP\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_WATERSSTP_H
 #define CT_WATERSSTP_H
 

--- a/include/cantera/thermo/electrolytes.h
+++ b/include/cantera/thermo/electrolytes.h
@@ -4,11 +4,10 @@
  * Header file for a common definitions used in electrolytes
  * thermodynamics.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_ELECTROLYTES_H
 #define CT_ELECTROLYTES_H
 namespace Cantera

--- a/include/cantera/thermo/speciesThermoTypes.h
+++ b/include/cantera/thermo/speciesThermoTypes.h
@@ -2,7 +2,9 @@
  *  @file speciesThermoTypes.h Contains const definitions for types of species
  *       reference-state thermodynamics managers (see \ref spthermo)
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef SPECIES_THERMO_TYPES_H
 #define SPECIES_THERMO_TYPES_H

--- a/include/cantera/tpx/Sub.h
+++ b/include/cantera/tpx/Sub.h
@@ -1,4 +1,8 @@
 //! @file Sub.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_SUB_H
 #define TPX_SUB_H
 

--- a/include/cantera/transport/DustyGasTransport.h
+++ b/include/cantera/transport/DustyGasTransport.h
@@ -5,7 +5,8 @@
  *   DustyGasTransport \endlink) .
  */
 
-// Copyright 2003  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DUSTYGASTRAN_H
 #define CT_DUSTYGASTRAN_H

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -2,6 +2,9 @@
  * @file GasTransport.h
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_GAS_TRANSPORT_H
 #define CT_GAS_TRANSPORT_H
 

--- a/include/cantera/transport/HighPressureGasTransport.h
+++ b/include/cantera/transport/HighPressureGasTransport.h
@@ -3,6 +3,9 @@
  *  Interface for class HighPressureGasTransport
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_HIGHPRESSUREGASTRAN_H
 #define CT_HIGHPRESSUREGASTRAN_H
 

--- a/include/cantera/transport/LTPspecies.h
+++ b/include/cantera/transport/LTPspecies.h
@@ -3,6 +3,9 @@
  *  Header file defining class LTPspecies and its child classes
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_LTPSPECIES_H
 #define CT_LTPSPECIES_H
 

--- a/include/cantera/transport/LiquidTranInteraction.h
+++ b/include/cantera/transport/LiquidTranInteraction.h
@@ -4,6 +4,9 @@
  *  derive from LiquidTranInteraction.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_LIQUIDTRANINTERACTION_H
 #define CT_LIQUIDTRANINTERACTION_H
 

--- a/include/cantera/transport/LiquidTransport.h
+++ b/include/cantera/transport/LiquidTransport.h
@@ -2,6 +2,10 @@
  *  @file LiquidTransport.h
  *   Header file defining class LiquidTransport
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_LIQUIDTRAN_H
 #define CT_LIQUIDTRAN_H
 

--- a/include/cantera/transport/LiquidTransportData.h
+++ b/include/cantera/transport/LiquidTransportData.h
@@ -2,6 +2,10 @@
  *  @file LiquidTransportData.h
  *  Header file defining class LiquidTransportData
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_LIQUIDTRANSPORTDATA_H
 #define CT_LIQUIDTRANSPORTDATA_H
 

--- a/include/cantera/transport/LiquidTransportParams.h
+++ b/include/cantera/transport/LiquidTransportParams.h
@@ -3,6 +3,9 @@
  *  Header file defining class LiquidTransportParams
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_LIQUIDTRANSPORTPARAMS_H
 #define CT_LIQUIDTRANSPORTPARAMS_H
 

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -5,7 +5,8 @@
  *    (see \ref tranprops and \link Cantera::MixTransport MixTransport \endlink) .
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MIXTRAN_H
 #define CT_MIXTRAN_H

--- a/include/cantera/transport/MultiTransport.h
+++ b/include/cantera/transport/MultiTransport.h
@@ -3,7 +3,8 @@
  *  Interface for class MultiTransport
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTITRAN_H
 #define CT_MULTITRAN_H

--- a/include/cantera/transport/SimpleTransport.h
+++ b/include/cantera/transport/SimpleTransport.h
@@ -4,6 +4,10 @@
  *   transport properties for liquids and solids
  *   (see \ref tranprops and \link Cantera::SimpleTransport SimpleTransport \endlink) .
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_SIMPLETRAN_H
 #define CT_SIMPLETRAN_H
 

--- a/include/cantera/transport/SolidTransport.h
+++ b/include/cantera/transport/SolidTransport.h
@@ -5,7 +5,8 @@
  *  (see \ref tranprops and \link Cantera::SolidTransport SolidTransport \endlink).
  */
 
-// Copyright 2003  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SOLIDTRAN_H
 #define CT_SOLIDTRAN_H

--- a/include/cantera/transport/SolidTransportData.h
+++ b/include/cantera/transport/SolidTransportData.h
@@ -3,6 +3,9 @@
  *  Header file defining class SolidTransportData
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_SOLIDTRANSPORTDATA_H
 #define CT_SOLIDTRANSPORTDATA_H
 

--- a/include/cantera/transport/Tortuosity.h
+++ b/include/cantera/transport/Tortuosity.h
@@ -4,11 +4,8 @@
  *  assuming the Bruggeman exponent relation
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_TORTUOSITY_H
 #define CT_TORTUOSITY_H

--- a/include/cantera/transport/TransportBase.h
+++ b/include/cantera/transport/TransportBase.h
@@ -4,7 +4,9 @@
  *     tranprops group definition (see \ref tranprops and \link
  *     Cantera::Transport Transport \endlink) .
  */
-// Copyright 2001-2003  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 /**
  * @defgroup tranprops Transport Properties for Species in Phases

--- a/include/cantera/transport/TransportData.h
+++ b/include/cantera/transport/TransportData.h
@@ -1,5 +1,8 @@
 //! @file TransportData.h
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_TRANSPORTDATA_H
 #define CT_TRANSPORTDATA_H
 

--- a/include/cantera/transport/TransportFactory.h
+++ b/include/cantera/transport/TransportFactory.h
@@ -3,7 +3,9 @@
  *  Header file defining class TransportFactory
  *     (see \link Cantera::TransportFactory TransportFactory\endlink)
  */
-//  Copyright 2001 California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_TRANSPORTFACTORY_H
 #define CT_TRANSPORTFACTORY_H

--- a/include/cantera/transport/TransportParams.h
+++ b/include/cantera/transport/TransportParams.h
@@ -4,6 +4,10 @@
  *  processing of the transport object
  *  (see \ref tranprops and \link Cantera::TransportParams TransportParams \endlink).
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_TRANSPORTPARAMS_H
 #define CT_TRANSPORTPARAMS_H
 

--- a/include/cantera/transport/WaterTransport.h
+++ b/include/cantera/transport/WaterTransport.h
@@ -1,6 +1,10 @@
 /**
  *  @file WaterTransport.h Header file defining class WaterTransport
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_WATERTRAN_H
 #define CT_WATERTRAN_H
 

--- a/include/cantera/zeroD/ConstPressureReactor.h
+++ b/include/cantera/zeroD/ConstPressureReactor.h
@@ -1,6 +1,7 @@
 //! @file ConstPressureReactor.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CONSTP_REACTOR_H
 #define CT_CONSTP_REACTOR_H

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -1,6 +1,7 @@
 //! @file FlowDevice.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FLOWDEVICE_H
 #define CT_FLOWDEVICE_H

--- a/include/cantera/zeroD/FlowReactor.h
+++ b/include/cantera/zeroD/FlowReactor.h
@@ -1,6 +1,7 @@
 //! @file FlowReactor.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FLOWREACTOR_H
 #define CT_FLOWREACTOR_H

--- a/include/cantera/zeroD/IdealGasConstPressureReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureReactor.h
@@ -1,6 +1,7 @@
 //! @file ConstPressureReactor.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDEALGASCONSTP_REACTOR_H
 #define CT_IDEALGASCONSTP_REACTOR_H

--- a/include/cantera/zeroD/IdealGasReactor.h
+++ b/include/cantera/zeroD/IdealGasReactor.h
@@ -1,6 +1,7 @@
 //! @file IdealGasReactor.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDEALGASREACTOR_H
 #define CT_IDEALGASREACTOR_H

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -1,6 +1,7 @@
 //! @file Reactor.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REACTOR_H
 #define CT_REACTOR_H

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -1,6 +1,7 @@
 //! @file ReactorBase.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REACTORBASE_H
 #define CT_REACTORBASE_H

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -1,6 +1,7 @@
 //! @file ReactorFactory.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef REACTOR_FACTORY_H
 #define REACTOR_FACTORY_H

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -1,6 +1,7 @@
 //! @file ReactorNet.h
 
-// Copyright 2004  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REACTORNET_H
 #define CT_REACTORNET_H

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -1,5 +1,8 @@
 //! @file ReactorSurface.h Header file for class ReactorSurface
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_REACTOR_SURFACE_H
 #define CT_REACTOR_SURFACE_H
 

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -1,6 +1,7 @@
 //! @file Reservoir.h
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RESERVOIR_H
 #define CT_RESERVOIR_H

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -1,6 +1,7 @@
 //! @file Wall.h Header file for class Wall.
 
-// Copyright 2001-2004  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_WALL_H
 #define CT_WALL_H

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -1,6 +1,7 @@
 //! @file flowControllers.h Some flow devices derived from class FlowDevice.
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FLOWCONTR_H
 #define CT_FLOWCONTR_H

--- a/interfaces/cython/cantera/__init__.py
+++ b/interfaces/cython/cantera/__init__.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from ._cantera import *
 from ._cantera import __version__, __sundials_version__
 from .composite import *

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from libcpp.vector cimport vector
 from libcpp.string cimport string
 from libcpp.map cimport map as stdmap

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 cdef class _SolutionBase:
     def __cinit__(self, infile='', phaseid='', phases=(), origin=None,
                   source=None, thermo=None, species=(), kinetics=None,

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from ._cantera import *
 import numpy as np
 import csv as _csv

--- a/interfaces/cython/cantera/constants.pyx
+++ b/interfaces/cython/cantera/constants.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 cdef extern from "cantera/base/ct_defs.h" namespace "Cantera":
     cdef double CxxAvogadro "Cantera::Avogadro"
     cdef double CxxGasConstant "Cantera::GasConstant"

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -16,6 +16,9 @@
 #
 # This will produce CTML file 'infile.xml'
 
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from __future__ import print_function
 
 import sys

--- a/interfaces/cython/cantera/examples/onedim/diffusion_flame_batch.py
+++ b/interfaces/cython/cantera/examples/onedim/diffusion_flame_batch.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#   Copyright (c) 2014 Thomas Fiala (fiala@td.mw.tum.de), Lehrstuhl für
-#   Thermodynamik, TU München. For conditions of distribution and use, see
-#   copyright notice in License.txt.
-#
-###############################################################################
+
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 """
 This example creates two batches of counterflow diffusion flame simulations.
 The first batch computes counterflow flames at increasing pressure, the second

--- a/interfaces/cython/cantera/examples/onedim/diffusion_flame_extinction.py
+++ b/interfaces/cython/cantera/examples/onedim/diffusion_flame_extinction.py
@@ -1,11 +1,8 @@
 # -*- coding: utf-8 -*-
-###############################################################################
-#
-#   Copyright (c) 2014 Thomas Fiala (fiala@td.mw.tum.de), Lehrstuhl für
-#   Thermodynamik, TU München. For conditions of distribution and use, see
-#   copyright notice in License.txt.
-#
-###############################################################################
+
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 """
 This example computes the extinction point of a counterflow diffusion flame.
 A hydrogen-oxygen diffusion flame at 1 bar is studied.

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 
 cdef double func_callback(double t, void* obj, void** err):

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 # NOTE: These cdef functions cannot be members of Kinetics because they would
 # cause "layout conflicts" when creating derived classes with multiple bases,
 # e.g. class Solution. [Cython 0.16]

--- a/interfaces/cython/cantera/liquidvapor.py
+++ b/interfaces/cython/cantera/liquidvapor.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from . import PureFluid
 
 def Water():

--- a/interfaces/cython/cantera/mixmaster/CompositionFrame.py
+++ b/interfaces/cython/cantera/mixmaster/CompositionFrame.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 
 if sys.version_info[0] == 3:

--- a/interfaces/cython/cantera/mixmaster/ControlPanel.py
+++ b/interfaces/cython/cantera/mixmaster/ControlPanel.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from __future__ import print_function
 
 from types import *

--- a/interfaces/cython/cantera/mixmaster/DataFrame.py
+++ b/interfaces/cython/cantera/mixmaster/DataFrame.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import os, math, string, sys
 
 if sys.version_info[0] == 3:

--- a/interfaces/cython/cantera/mixmaster/DataGraph.py
+++ b/interfaces/cython/cantera/mixmaster/DataGraph.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 
 if sys.version_info[0] == 3:

--- a/interfaces/cython/cantera/mixmaster/Edit.py
+++ b/interfaces/cython/cantera/mixmaster/Edit.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from __future__ import print_function
 import sys
 

--- a/interfaces/cython/cantera/mixmaster/ElementFrame.py
+++ b/interfaces/cython/cantera/mixmaster/ElementFrame.py
@@ -3,6 +3,9 @@
 #  the selected elements
 #
 
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 if sys.version_info[0] == 3:
     from tkinter import *

--- a/interfaces/cython/cantera/mixmaster/GraphFrame.py
+++ b/interfaces/cython/cantera/mixmaster/GraphFrame.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 if sys.version_info[0] == 3:
     from tkinter import *

--- a/interfaces/cython/cantera/mixmaster/ImportFrame.py
+++ b/interfaces/cython/cantera/mixmaster/ImportFrame.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import os, math,sys
 
 if sys.version_info[0] == 3:

--- a/interfaces/cython/cantera/mixmaster/KineticsFrame.py
+++ b/interfaces/cython/cantera/mixmaster/KineticsFrame.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from __future__ import print_function
 
 import os, math, sys

--- a/interfaces/cython/cantera/mixmaster/MechManager.py
+++ b/interfaces/cython/cantera/mixmaster/MechManager.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from cantera import *
 
 import sys

--- a/interfaces/cython/cantera/mixmaster/Mix.py
+++ b/interfaces/cython/cantera/mixmaster/Mix.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from cantera import gas_constant
 from numpy import zeros, ones
 from .utilities import handleError

--- a/interfaces/cython/cantera/mixmaster/NewFlowFrame.py
+++ b/interfaces/cython/cantera/mixmaster/NewFlowFrame.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from cantera import *
 
 import sys

--- a/interfaces/cython/cantera/mixmaster/SpeciesFrame.py
+++ b/interfaces/cython/cantera/mixmaster/SpeciesFrame.py
@@ -3,6 +3,9 @@
 #  the selected elements
 #
 
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 if sys.version_info[0] == 3:
     from tkinter import *

--- a/interfaces/cython/cantera/mixmaster/SpeciesInfo.py
+++ b/interfaces/cython/cantera/mixmaster/SpeciesInfo.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 if sys.version_info[0] == 3:
     from tkinter import *

--- a/interfaces/cython/cantera/mixmaster/ThermoFrame.py
+++ b/interfaces/cython/cantera/mixmaster/ThermoFrame.py
@@ -1,4 +1,5 @@
-
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
 
 from cantera import *
 

--- a/interfaces/cython/cantera/mixmaster/ThermoProp.py
+++ b/interfaces/cython/cantera/mixmaster/ThermoProp.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 if sys.version_info[0] == 3:
     from tkinter import *

--- a/interfaces/cython/cantera/mixmaster/TransportFrame.py
+++ b/interfaces/cython/cantera/mixmaster/TransportFrame.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 if sys.version_info[0] == 3:
     from tkinter import *

--- a/interfaces/cython/cantera/mixmaster/UnitChooser.py
+++ b/interfaces/cython/cantera/mixmaster/UnitChooser.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 if sys.version_info[0] == 3:
     from tkinter import *

--- a/interfaces/cython/cantera/mixmaster/flowpanel.py
+++ b/interfaces/cython/cantera/mixmaster/flowpanel.py
@@ -1,4 +1,5 @@
-
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
 
 # functionality imports
 import sys

--- a/interfaces/cython/cantera/mixmaster/main.py
+++ b/interfaces/cython/cantera/mixmaster/main.py
@@ -4,6 +4,9 @@
 #
 #############################################################################
 
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 # options
 _app_title = 'MixMaster'
 _app_version = '1.0'

--- a/interfaces/cython/cantera/mixmaster/menu.py
+++ b/interfaces/cython/cantera/mixmaster/menu.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 if sys.version_info[0] == 3:
     from tkinter import *

--- a/interfaces/cython/cantera/mixmaster/newflow.py
+++ b/interfaces/cython/cantera/mixmaster/newflow.py
@@ -1,3 +1,5 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
 
 import sys
 if sys.version_info[0] == 3:

--- a/interfaces/cython/cantera/mixmaster/utilities.py
+++ b/interfaces/cython/cantera/mixmaster/utilities.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import string
 import os, sys
 import types, traceback

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import warnings
 
 # Need a pure-python class to store weakrefs to

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import numpy as np
 from ._cantera import *
 from .composite import Solution

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import interrupts
 
 # Need a pure-python class to store weakrefs to

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 cdef extern from "cantera/kinetics/reaction_defs.h" namespace "Cantera":
     cdef int ELEMENTARY_RXN
     cdef int THREE_BODY_RXN

--- a/interfaces/cython/cantera/reactionpath.pyx
+++ b/interfaces/cython/cantera/reactionpath.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 cdef class ReactionPathDiagram:
     def __cinit__(self, *args, **kwargs):
         self._log = new CxxStringStream()

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 from collections import defaultdict as _defaultdict
 import numbers as _numbers
 

--- a/interfaces/cython/cantera/speciesthermo.pyx
+++ b/interfaces/cython/cantera/speciesthermo.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 cdef extern from "cantera/thermo/speciesThermoTypes.h" namespace "Cantera":
     cdef int SPECIES_THERMO_CONSTANT_CP "CONSTANT_CP"
     cdef int SPECIES_THERMO_NASA2 "NASA2"

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import warnings
 import weakref
 

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 # NOTE: These cdef functions cannot be members of Transport because they would
 # cause "layout conflicts" when creating derived classes with multiple bases,
 # e.g. class Solution. [Cython 0.16]

--- a/interfaces/cython/cantera/utils.py
+++ b/interfaces/cython/cantera/utils.py
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import os
 import inspect as _inspect
 

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -1,3 +1,6 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at http://www.cantera.org/license.txt for license and copyright information.
+
 import sys
 cdef int _pythonMajorVersion = sys.version_info[0]
 

--- a/samples/cxx/kinetics1/kinetics1.cpp
+++ b/samples/cxx/kinetics1/kinetics1.cpp
@@ -2,9 +2,10 @@
 //
 // zero-dimensional kinetics example program
 //
-// copyright California Institute of Technology 2002
-//
 /////////////////////////////////////////////////////////////
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
 #include "cantera/IdealGasMix.h"

--- a/src/base/ValueCache.cpp
+++ b/src/base/ValueCache.cpp
@@ -2,6 +2,9 @@
  *  @file ValueCache.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ValueCache.h"
 #include <mutex>
 

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -1,4 +1,8 @@
 //! @file application.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "application.h"
 
 #include "cantera/base/ctml.h"

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -1,4 +1,8 @@
 //! @file application.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_BASE_APPLICATION_H
 #define CT_BASE_APPLICATION_H
 

--- a/src/base/checkFinite.cpp
+++ b/src/base/checkFinite.cpp
@@ -2,12 +2,9 @@
  *   @file checkFinite.cpp Declarations for routines that check for the
  *       presence of NaNs in the code.
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/base/stringUtils.h"

--- a/src/base/clockWC.cpp
+++ b/src/base/clockWC.cpp
@@ -3,12 +3,9 @@
  *    Definitions for a simple class that implements an Ansi C wall clock timer
  *     (see \ref Cantera::clockWC).
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include <time.h>
 #include "cantera/base/clockWC.h"

--- a/src/base/ct2ctml.cpp
+++ b/src/base/ct2ctml.cpp
@@ -3,7 +3,9 @@
  * Driver for the system call to the python executable that converts
  * cti files to ctml files (see \ref inputfiles).
  */
-// Copyright 2001-2005  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/base/stringUtils.h"

--- a/src/base/ctexceptions.cpp
+++ b/src/base/ctexceptions.cpp
@@ -1,4 +1,8 @@
 //! @file ctexceptions.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ctexceptions.h"
 #include "application.h"
 #include "cantera/base/global.h"

--- a/src/base/ctml.cpp
+++ b/src/base/ctml.cpp
@@ -2,7 +2,9 @@
  * @file ctml.cpp
  * Definitions for functions to read and write CTML.
  */
-// Copyright 2002  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/base/stringUtils.h"

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -1,5 +1,8 @@
 //! @file global.cpp
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/FactoryBase.h"
 #include "cantera/base/xml.h"
 #include "application.h"

--- a/src/base/plots.cpp
+++ b/src/base/plots.cpp
@@ -1,7 +1,9 @@
 /**
  * @file plots.cpp
  */
-// Copyright 2002  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/plots.h"
 

--- a/src/base/stringUtils.cpp
+++ b/src/base/stringUtils.cpp
@@ -3,7 +3,9 @@
  * Contains definitions for string manipulation functions
  *       within Cantera.
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 //@{
 #include "cantera/base/ct_defs.h"

--- a/src/base/units.h
+++ b/src/base/units.h
@@ -6,7 +6,9 @@
  *
  * This header is included only by file misc.cpp.
  */
-//    Copyright 2002 California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_UNITS_H
 #define CT_UNITS_H

--- a/src/base/xml.cpp
+++ b/src/base/xml.cpp
@@ -4,7 +4,9 @@
  * implement only those aspects of XML required to read, write, and
  * manipulate CTML data files.
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/xml.h"
 #include "cantera/base/stringUtils.h"

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -1,6 +1,10 @@
 /**
  * @file Cabinet.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_CABINET_H
 #define CT_CABINET_H
 

--- a/src/clib/clib_defs.h
+++ b/src/clib/clib_defs.h
@@ -2,6 +2,9 @@
  * @file clib_defs.h
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_DEFS_H
 #define CTC_DEFS_H
 

--- a/src/clib/clib_utils.h
+++ b/src/clib/clib_utils.h
@@ -2,6 +2,9 @@
  * @file clib_utils.h
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_CLIB_UTILS_H
 #define CT_CLIB_UTILS_H
 

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -8,6 +8,9 @@
  *   pointers are passed to or from the calling application.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #define CANTERA_USE_INTERNAL
 #include "ct.h"
 

--- a/src/clib/ct.h
+++ b/src/clib/ct.h
@@ -1,6 +1,10 @@
 /**
  * @file ct.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_CT_H
 #define CTC_CT_H
 

--- a/src/clib/ctbdry.h
+++ b/src/clib/ctbdry.h
@@ -1,6 +1,10 @@
 /**
  * @file ctbdry.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_BDRY_H
 #define CTC_BDRY_H
 

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -1,6 +1,10 @@
 /**
  * @file ctfunc.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #define CANTERA_USE_INTERNAL
 #include "ctfunc.h"
 

--- a/src/clib/ctfunc.h
+++ b/src/clib/ctfunc.h
@@ -1,6 +1,10 @@
 /**
  * @file ctfunc.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_FUNC1_H
 #define CTC_FUNC1_H
 

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -1,6 +1,10 @@
 /**
  * @file ctmultiphase.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #define CANTERA_USE_INTERNAL
 #include "ctmultiphase.h"
 

--- a/src/clib/ctmultiphase.h
+++ b/src/clib/ctmultiphase.h
@@ -1,6 +1,10 @@
 /**
  * @file ctmultiphase.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_MULTIPHASE_H
 #define CTC_MULTIPHASE_H
 

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -1,6 +1,10 @@
 /**
  * @file ctonedim.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #define CANTERA_USE_INTERNAL
 
 #include "ctonedim.h"

--- a/src/clib/ctonedim.h
+++ b/src/clib/ctonedim.h
@@ -1,6 +1,10 @@
 /**
  * @file ctonedim.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_ONEDIM_H
 #define CTC_ONEDIM_H
 

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -1,6 +1,10 @@
 /**
  * @file ctreactor.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #define CANTERA_USE_INTERNAL
 #include "ctreactor.h"
 

--- a/src/clib/ctreactor.h
+++ b/src/clib/ctreactor.h
@@ -1,6 +1,10 @@
 /**
  * @file ctreactor.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_REACTOR_H
 #define CTC_REACTOR_H
 

--- a/src/clib/ctrpath.cpp
+++ b/src/clib/ctrpath.cpp
@@ -1,6 +1,10 @@
 /**
  * @file ctrpath.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #define CANTERA_USE_INTERNAL
 #include "ctrpath.h"
 

--- a/src/clib/ctrpath.h
+++ b/src/clib/ctrpath.h
@@ -1,6 +1,10 @@
 /**
  * @file ctrpath.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_RXNPATH_H
 #define CTC_RXNPATH_H
 

--- a/src/clib/ctsurf.cpp
+++ b/src/clib/ctsurf.cpp
@@ -1,6 +1,10 @@
 /**
  * @file ctsurf.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 // clib header information
 #define CANTERA_USE_INTERNAL
 #include "ctsurf.h"

--- a/src/clib/ctsurf.h
+++ b/src/clib/ctsurf.h
@@ -1,6 +1,10 @@
 /**
  * @file ctsurf.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_SURF_H
 #define CTC_SURF_H
 

--- a/src/clib/ctxml.cpp
+++ b/src/clib/ctxml.cpp
@@ -1,6 +1,10 @@
 /**
  * @file ctxml.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #define CANTERA_USE_INTERNAL
 #include "ctxml.h"
 

--- a/src/clib/ctxml.h
+++ b/src/clib/ctxml.h
@@ -1,6 +1,10 @@
 /**
  * @file ctxml.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CTC_XML_H
 #define CTC_XML_H
 

--- a/src/equil/BasisOptimize.cpp
+++ b/src/equil/BasisOptimize.cpp
@@ -2,6 +2,10 @@
  * @file BasisOptimize.cpp Functions which calculation optimized basis of the
  *     stoichiometric coefficient matrix (see /ref equil functions)
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/equil/MultiPhase.h"
 
 using namespace std;

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -4,7 +4,8 @@
  *  ChemEquil.
  */
 
-//  Copyright 2001 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/ChemEquil.h"
 #include "cantera/base/stringUtils.h"

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -4,6 +4,9 @@
  * object that is used to set up multiphase equilibrium problems (see \ref equilfunctions).
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/equil/ChemEquil.h"
 #include "cantera/equil/MultiPhase.h"
 #include "cantera/equil/MultiPhaseEquil.h"

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -1,6 +1,10 @@
 /**
  * @file MultiPhaseEquil.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/equil/MultiPhaseEquil.h"
 #include "cantera/thermo/MolalityVPSSTP.h"
 #include "cantera/base/stringUtils.h"

--- a/src/equil/vcs_Gibbs.cpp
+++ b/src/equil/vcs_Gibbs.cpp
@@ -2,11 +2,9 @@
  * @file vcs_Gibbs.cpp
  *   Functions which calculate the extrinsic Gibbs Free energies
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_MultiPhaseEquil.cpp
+++ b/src/equil/vcs_MultiPhaseEquil.cpp
@@ -2,11 +2,9 @@
  *  @file vcs_MultiPhaseEquil.cpp
  *    Driver routine for the VCSnonideal equilibrium solver package
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_MultiPhaseEquil.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_SpeciesProperties.cpp
+++ b/src/equil/vcs_SpeciesProperties.cpp
@@ -1,6 +1,10 @@
 /**
  * @file vcs_SpeciesProperties.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/equil/vcs_SpeciesProperties.h"
 
 using namespace std;

--- a/src/equil/vcs_TP.cpp
+++ b/src/equil/vcs_TP.cpp
@@ -1,4 +1,8 @@
 //! @file vcs_TP.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"
 

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -1,11 +1,10 @@
 /**
  * @file vcs_VolPhase.cpp
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/equil/vcs_VolPhase.h"
 #include "cantera/equil/vcs_species_thermo.h"
 #include "cantera/equil/vcs_solve.h"

--- a/src/equil/vcs_elem.cpp
+++ b/src/equil/vcs_elem.cpp
@@ -4,6 +4,10 @@
  *  element abundances constraints and the algorithm for fixing violations
  *  of the element abundances constraints.
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/base/ctexceptions.h"
 #include "cantera/numerics/DenseMatrix.h"

--- a/src/equil/vcs_elem_rearrange.cpp
+++ b/src/equil/vcs_elem_rearrange.cpp
@@ -3,11 +3,9 @@
  *   Contains implementations for rearranging the element columns, and
  *   it contains the algorithm for choosing the rearrangement.
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_inest.cpp
+++ b/src/equil/vcs_inest.cpp
@@ -2,11 +2,9 @@
  * @file vcs_inest.cpp
  *   Implementation methods for obtaining a good initial guess
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_nondim.cpp
+++ b/src/equil/vcs_nondim.cpp
@@ -2,11 +2,9 @@
  *  @file vcs_nondim.cpp
  *     Nondimensionalization routines within VCSnonideal
  */
-/*
- * Copyright (2007) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_phaseStability.cpp
+++ b/src/equil/vcs_phaseStability.cpp
@@ -3,6 +3,10 @@
  *  Implementation class for functions associated with determining the stability of a phase
  *   (see Class \link Cantera::VCS_SOLVE VCS_SOLVE\endlink and \ref equilfunctions ).
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"
 #include "cantera/base/stringUtils.h"

--- a/src/equil/vcs_prep.cpp
+++ b/src/equil/vcs_prep.cpp
@@ -3,11 +3,8 @@
  *    This file contains some prepatory functions.
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_prob.h"

--- a/src/equil/vcs_prob.cpp
+++ b/src/equil/vcs_prob.cpp
@@ -3,11 +3,9 @@
  *  Implementation for the Interface class for the vcs thermo
  *  equilibrium solver package,
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_prob.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_rearrange.cpp
+++ b/src/equil/vcs_rearrange.cpp
@@ -2,11 +2,9 @@
  * @file vcs_rearrange.cpp
  *    implementation file for rearranging species.
  */
-/*
- * Copyright (2007) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 

--- a/src/equil/vcs_report.cpp
+++ b/src/equil/vcs_report.cpp
@@ -1,9 +1,7 @@
 //! @file vcs_report.cpp
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_rxnadj.cpp
+++ b/src/equil/vcs_rxnadj.cpp
@@ -2,11 +2,9 @@
  * @file vcs_rxnadj.cpp
  *  Routines for carrying out various adjustments to the reaction steps
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_setMolesLinProg.cpp
+++ b/src/equil/vcs_setMolesLinProg.cpp
@@ -1,11 +1,9 @@
 /*!
  * @file vcs_setMolesLinProg.cpp
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 

--- a/src/equil/vcs_solve.cpp
+++ b/src/equil/vcs_solve.cpp
@@ -2,11 +2,9 @@
  * @file vcs_solve.cpp Implementation file for the internal class that holds
  *     the problem.
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/base/ctexceptions.h"

--- a/src/equil/vcs_solve_TP.cpp
+++ b/src/equil/vcs_solve_TP.cpp
@@ -2,11 +2,9 @@
  * @file vcs_solve_TP.cpp Implementation file that contains the
  *     main algorithm for finding an equilibrium
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_solve_phaseStability.cpp
+++ b/src/equil/vcs_solve_phaseStability.cpp
@@ -1,10 +1,7 @@
 //! @file vcs_solve_phaseStability.cpp
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_prob.h"

--- a/src/equil/vcs_species_thermo.cpp
+++ b/src/equil/vcs_species_thermo.cpp
@@ -2,11 +2,9 @@
  * @file vcs_species_thermo.cpp Implementation for the VCS_SPECIES_THERMO
  *   object.
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_species_thermo.h"
 #include "cantera/equil/vcs_defs.h"

--- a/src/equil/vcs_util.cpp
+++ b/src/equil/vcs_util.cpp
@@ -2,11 +2,9 @@
  *  @file vcs_util.cpp
  *  Internal definitions for utility functions for the VCSnonideal package
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_internal.h"
 #include "cantera/equil/vcs_defs.h"

--- a/src/fortran/cantera.f90
+++ b/src/fortran/cantera.f90
@@ -3,6 +3,9 @@
 ! procedure names that map to specific procedures depending on the
 ! argument types.
 
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 MODULE CANTERA
 
   USE cantera_thermo

--- a/src/fortran/cantera_funcs.f90
+++ b/src/fortran/cantera_funcs.f90
@@ -1,3 +1,6 @@
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 module cantera_funcs
 
   use cantera_xml

--- a/src/fortran/cantera_iface.f90
+++ b/src/fortran/cantera_iface.f90
@@ -1,3 +1,6 @@
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 module cantera_iface
 
   use fct

--- a/src/fortran/cantera_kinetics.f90
+++ b/src/fortran/cantera_kinetics.f90
@@ -1,3 +1,6 @@
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 module cantera_kinetics
 
   use cantera_thermo

--- a/src/fortran/cantera_thermo.f90
+++ b/src/fortran/cantera_thermo.f90
@@ -1,3 +1,6 @@
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 module cantera_thermo
 
   use fct

--- a/src/fortran/cantera_transport.f90
+++ b/src/fortran/cantera_transport.f90
@@ -1,3 +1,6 @@
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 module cantera_transport
 
   use cantera_thermo

--- a/src/fortran/cantera_xml.f90
+++ b/src/fortran/cantera_xml.f90
@@ -1,3 +1,6 @@
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 module cantera_xml
 
   use fctxml  ! interface for C functions

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -6,6 +6,10 @@
  *   Cantera objects are stored and referenced by integers - no
  *   pointers are passed to or from the calling application.
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 // Cantera includes
 #include "cantera/kinetics/KineticsFactory.h"
 #include "cantera/transport/TransportFactory.h"

--- a/src/fortran/fct_interface.f90
+++ b/src/fortran/fct_interface.f90
@@ -1,3 +1,6 @@
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 module fct
 interface
 

--- a/src/fortran/fctxml.cpp
+++ b/src/fortran/fctxml.cpp
@@ -2,8 +2,9 @@
  * @file fctxml.cpp
  *
  */
-// Copyright 2001  California Institute of Technology
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "clib/clib_utils.h"
 #include "cantera/base/ctml.h"

--- a/src/fortran/fctxml_interface.f90
+++ b/src/fortran/fctxml_interface.f90
@@ -1,3 +1,6 @@
+! This file is part of Cantera. See License.txt in the top-level directory or
+! at http://www.cantera.org/license.txt for license and copyright information.
+
 module fctxml
 interface
     integer function fxml_new(name)

--- a/src/kinetics/AqueousKinetics.cpp
+++ b/src/kinetics/AqueousKinetics.cpp
@@ -3,11 +3,9 @@
  *
  * Homogeneous kinetics in an aqueous phase, either condensed or dilute in salts
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/AqueousKinetics.h"
 #include "cantera/kinetics/Reaction.h"

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/kinetics/BulkKinetics.h"
 #include "cantera/kinetics/Reaction.h"
 

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -3,6 +3,9 @@
  *      Falloff
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/ctexceptions.h"
 #include "cantera/kinetics/Falloff.h"

--- a/src/kinetics/FalloffFactory.cpp
+++ b/src/kinetics/FalloffFactory.cpp
@@ -1,7 +1,9 @@
 /**
  *  @file FalloffFactory.cpp
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/FalloffFactory.h"
 #include "cantera/kinetics/reaction_defs.h"

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -2,7 +2,8 @@
  *  @file GasKinetics.cpp Homogeneous kinetics in ideal gases
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/GasKinetics.h"
 

--- a/src/kinetics/Group.cpp
+++ b/src/kinetics/Group.cpp
@@ -3,7 +3,8 @@
  *  analysis.
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/Group.h"
 #include <iostream>

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -4,7 +4,9 @@
  *  (see \ref  kineticsmgr and class
  *  \link Cantera::ImplicitSurfChem ImplicitSurfChem\endlink).
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/ImplicitSurfChem.h"
 #include "cantera/kinetics/solveSP.h"

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -2,7 +2,8 @@
  *  @file InterfaceKinetics.cpp
  */
 
-// Copyright 2002  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/InterfaceKinetics.h"
 #include "cantera/kinetics/RateCoeffMgr.h"

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -5,7 +5,9 @@
  *  Kinetics managers calculate rates of progress of species due to
  *  homogeneous or heterogeneous kinetics.
  */
-// Copyright 2001-2004  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/Kinetics.h"
 #include "cantera/kinetics/Reaction.h"

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -1,7 +1,9 @@
 /**
  *  @file KineticsFactory.cpp
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/KineticsFactory.h"
 #include "cantera/kinetics/GasKinetics.h"

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -2,6 +2,9 @@
  *  @file Reaction.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/kinetics/Reaction.h"
 #include "cantera/kinetics/FalloffFactory.h"
 #include "cantera/base/ctml.h"

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -2,7 +2,9 @@
  *  @file ReactionPath.cpp
  *  Implementation file for classes used in reaction path analysis.
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/ReactionPath.h"
 #include "cantera/kinetics/reaction_defs.h"

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -1,5 +1,8 @@
 //! @file RxnRates.cpp
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/kinetics/RxnRates.h"
 #include "cantera/base/Array.h"
 

--- a/src/kinetics/importKinetics.cpp
+++ b/src/kinetics/importKinetics.cpp
@@ -9,7 +9,9 @@
  *     of these routines is to initialize the %Cantera objects with data
  *     from the ctml tree structures.
  */
-// Copyright 2002  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/importKinetics.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/kinetics/solveSP.cpp
+++ b/src/kinetics/solveSP.cpp
@@ -1,12 +1,9 @@
 /*
  * @file: solveSP.cpp Implicit surface site concentration solver
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/solveSP.h"
 #include "cantera/thermo/SurfPhase.h"

--- a/src/matlab/ctfunctions.cpp
+++ b/src/matlab/ctfunctions.cpp
@@ -1,6 +1,10 @@
 /**
  *   @file ctfunctions.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include <string.h>
 #include <iostream>
 

--- a/src/matlab/ctmatutils.h
+++ b/src/matlab/ctmatutils.h
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef CT_MATUTILS_H
 #define CT_MATUTILS_H
 

--- a/src/matlab/ctmethods.cpp
+++ b/src/matlab/ctmethods.cpp
@@ -9,6 +9,9 @@
  * class is indicated by the first parameter in the call from MATLAB.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include <string>
 
 #include "clib/ct.h"

--- a/src/matlab/flowdevicemethods.cpp
+++ b/src/matlab/flowdevicemethods.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "ctmatutils.h"
 #include "clib/ctreactor.h"
 #include "clib/ct.h"

--- a/src/matlab/funcmethods.cpp
+++ b/src/matlab/funcmethods.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "ctmatutils.h"
 #include "clib/ctfunc.h"
 #include "clib/ct.h"

--- a/src/matlab/kineticsmethods.cpp
+++ b/src/matlab/kineticsmethods.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "ctmatutils.h"
 #include "clib/ct.h"
 

--- a/src/matlab/mixturemethods.cpp
+++ b/src/matlab/mixturemethods.cpp
@@ -1,6 +1,10 @@
 /**
  * @file mixturemethods.cpp
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include <iostream>
 #include <vector>
 

--- a/src/matlab/mllogger.h
+++ b/src/matlab/mllogger.h
@@ -1,6 +1,10 @@
 /**
  * @file mlloger.h
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef MLLOGGER_H
 #define MLLOGGER_H
 

--- a/src/matlab/onedimmethods.cpp
+++ b/src/matlab/onedimmethods.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/matlab/phasemethods.cpp
+++ b/src/matlab/phasemethods.cpp
@@ -2,6 +2,9 @@
  *  @file phasemethods.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "ctmatutils.h"
 #include "clib/ct.h"
 

--- a/src/matlab/reactormethods.cpp
+++ b/src/matlab/reactormethods.cpp
@@ -2,6 +2,9 @@
  * @file reactormethods.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "clib/ctreactor.h"
 #include "clib/ct.h"
 #include "ctmatutils.h"

--- a/src/matlab/reactornetmethods.cpp
+++ b/src/matlab/reactornetmethods.cpp
@@ -2,6 +2,9 @@
  * @file reactornetmethods.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "clib/ctreactor.h"
 #include "clib/ct.h"
 #include "ctmatutils.h"

--- a/src/matlab/reactorsurfacemethods.cpp
+++ b/src/matlab/reactorsurfacemethods.cpp
@@ -2,6 +2,9 @@
  *  @file reactorsurfacemethods.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "clib/ctreactor.h"
 #include "clib/ct.h"
 #include "ctmatutils.h"

--- a/src/matlab/surfmethods.cpp
+++ b/src/matlab/surfmethods.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include <iostream>
 #include <string>
 #include <vector>

--- a/src/matlab/thermomethods.cpp
+++ b/src/matlab/thermomethods.cpp
@@ -2,6 +2,9 @@
  *  @file thermomethods.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "clib/ct.h"
 #include "ctmatutils.h"
 #include <vector>

--- a/src/matlab/transportmethods.cpp
+++ b/src/matlab/transportmethods.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include <fstream>
 
 #include "clib/ct.h"

--- a/src/matlab/wallmethods.cpp
+++ b/src/matlab/wallmethods.cpp
@@ -2,6 +2,9 @@
  *  @file wallmethods.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "clib/ctreactor.h"
 #include "clib/ct.h"
 #include "ctmatutils.h"

--- a/src/matlab/xmlmethods.cpp
+++ b/src/matlab/xmlmethods.cpp
@@ -2,6 +2,9 @@
  *  @file xmlmethods.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "clib/ctxml.h"
 #include "clib/ct.h"
 #include "ctmatutils.h"

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -1,6 +1,7 @@
 //! @file BandMatrix.cpp Banded matrices.
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/BandMatrix.h"
 #include "cantera/base/utilities.h"

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -1,6 +1,8 @@
 //! @file CVodesIntegrator.cpp
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/numerics/CVodesIntegrator.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/numerics/DAE_solvers.cpp
+++ b/src/numerics/DAE_solvers.cpp
@@ -1,11 +1,7 @@
 //! @file DAE_solvers.cpp Factory routine for picking the DAE solver package
 
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/numerics/DAE_Solver.h"

--- a/src/numerics/DenseMatrix.cpp
+++ b/src/numerics/DenseMatrix.cpp
@@ -2,7 +2,8 @@
  *  @file DenseMatrix.cpp
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/DenseMatrix.h"
 #include "cantera/base/stringUtils.h"

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -1,4 +1,8 @@
 //! @file Func1.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/numerics/Func1.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/numerics/IDA_Solver.cpp
+++ b/src/numerics/IDA_Solver.cpp
@@ -1,6 +1,7 @@
 //! @file IDA_Solver.cpp
 
-// Copyright 2006  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/IDA_Solver.h"
 #include "cantera/base/stringUtils.h"

--- a/src/numerics/ODE_integrators.cpp
+++ b/src/numerics/ODE_integrators.cpp
@@ -1,4 +1,8 @@
 //! @file ODE_integrators.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ct_defs.h"
 #include "cantera/numerics/Integrator.h"
 #include "cantera/numerics/CVodesIntegrator.h"

--- a/src/numerics/ResidJacEval.cpp
+++ b/src/numerics/ResidJacEval.cpp
@@ -1,11 +1,7 @@
 //! @file ResidJacEval.cpp
 
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/numerics/ResidJacEval.h"

--- a/src/numerics/RootFind.cpp
+++ b/src/numerics/RootFind.cpp
@@ -1,11 +1,7 @@
 //! @file: RootFind.cpp  root finder for 1D problems
 
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/RootFind.h"
 #include "cantera/base/utilities.h"

--- a/src/numerics/SquareMatrix.cpp
+++ b/src/numerics/SquareMatrix.cpp
@@ -1,11 +1,7 @@
 //! @file SquareMatrix.cpp
 
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/stringUtils.h"
 #include "cantera/numerics/SquareMatrix.h"

--- a/src/numerics/funcs.cpp
+++ b/src/numerics/funcs.cpp
@@ -1,9 +1,7 @@
 //! @file funcs.cpp file containing miscellaneous numerical functions.
 
-/*
- *  Copyright 2001-2003 California Institute of Technology
- *  See file License.txt for licensing information
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/funcs.h"
 

--- a/src/numerics/polyfit.cpp
+++ b/src/numerics/polyfit.cpp
@@ -1,5 +1,8 @@
 //! @file polyfit.cpp
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/numerics/polyfit.h"
 #include "cantera/numerics/eigen_dense.h"
 #include "cantera/base/global.h"

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -2,6 +2,9 @@
  * @file Domain1D.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/oneD/Domain1D.h"
 #include "cantera/oneD/MultiJac.h"
 #include "cantera/base/ctml.h"

--- a/src/oneD/MultiJac.cpp
+++ b/src/oneD/MultiJac.cpp
@@ -1,8 +1,7 @@
 //! @file MultiJac.cpp Implementation file for class MultiJac
 
-/*
- *  Copyright 2002 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/MultiJac.h"
 #include <ctime>

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -1,8 +1,7 @@
 //! @file MultiNewton.cpp Damped Newton solver for 1D multi-domain problems
 
-/*
- *  Copyright 2001 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/MultiNewton.h"
 #include "cantera/base/utilities.h"

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -1,4 +1,8 @@
 //! @file OneDim.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/oneD/OneDim.h"
 #include "cantera/numerics/Func1.h"
 #include "cantera/base/ctml.h"

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -2,6 +2,9 @@
  * @file Sim1D.cpp
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/oneD/Sim1D.h"
 #include "cantera/oneD/MultiJac.h"
 #include "cantera/oneD/StFlow.h"

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -1,6 +1,7 @@
 //! @file StFlow.cpp
 
-// Copyright 2002  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/StFlow.h"
 #include "cantera/base/ctml.h"

--- a/src/oneD/boundaries1D.cpp
+++ b/src/oneD/boundaries1D.cpp
@@ -1,6 +1,7 @@
 //! @file boundaries1D.cpp
 
-// Copyright 2002-3  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/Inlet1D.h"
 #include "cantera/oneD/OneDim.h"

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -1,4 +1,8 @@
 //! @file refine.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/oneD/refine.h"
 #include "cantera/oneD/StFlow.h"
 

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -4,7 +4,9 @@
  * employs a constant heat capacity assumption (see \ref spthermo and
  * \link Cantera::ConstCpPoly ConstCpPoly \endlink).
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/ConstCpPoly.h"
 

--- a/src/thermo/ConstDensityThermo.cpp
+++ b/src/thermo/ConstDensityThermo.cpp
@@ -5,7 +5,9 @@
 \endlink).
  */
 
-//  Copyright 2002 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/mix_defs.h"
 #include "cantera/thermo/ConstDensityThermo.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -7,11 +7,9 @@
  * Class DebyeHuckel represents a dilute liquid electrolyte phase which
  * obeys the Debye Huckel formulation for nonideality.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/DebyeHuckel.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -3,7 +3,8 @@
  *  This file contains a database of atomic weights.
  */
 
-//  Copyright 2003  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/Elements.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/FixedChemPotSSTP.cpp
+++ b/src/thermo/FixedChemPotSSTP.cpp
@@ -5,11 +5,8 @@
  * class \link Cantera::FixedChemPotSSTP FixedChemPotSSTP\endlink)
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/mix_defs.h"
 #include "cantera/thermo/FixedChemPotSSTP.h"

--- a/src/thermo/GibbsExcessVPSSTP.cpp
+++ b/src/thermo/GibbsExcessVPSSTP.cpp
@@ -9,11 +9,10 @@
  * further based upon expressions for the excess Gibbs free energy expressed as
  * a function of the mole fractions.
  */
-/*
- * Copyright (2009) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/GibbsExcessVPSSTP.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -11,11 +11,9 @@
  * parameter consistent with the temperature expansions used for Beta0,
  * Beta1, and Cphi.(CFJC, SNL)
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/HMWSoln.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/HMWSoln_input.cpp
+++ b/src/thermo/HMWSoln_input.cpp
@@ -7,11 +7,10 @@
  * This file contains definitions for reading in the interaction terms
  * in the formulation.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/HMWSoln.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/PDSS_Water.h"

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -5,6 +5,9 @@
  * and class \link Cantera::IdealGasPhase IdealGasPhase\endlink).
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/IdealGasPhase.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/utilities.h"

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -11,11 +11,10 @@
  * one. This turns out, actually, to be highly nonlinear when the solvent
  * densities get low.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/IdealMolalSoln.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -4,11 +4,9 @@
  *      thermoprops and \link Cantera::IdealSolidSolnPhase
  *      IdealSolidSolnPhase\endlink).
  */
-/*
- * Copyright 2006 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000, with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/IdealSolidSolnPhase.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -6,11 +6,9 @@
  * thermodynamic properties (see \ref thermoprops and
  * class \link Cantera::IdealSolnGasVPSS IdealSolnGasVPSS\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/IdealSolnGasVPSS.h"
 #include "cantera/thermo/PDSS.h"

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -10,11 +10,10 @@
  * further based upon expressions for the excess Gibbs free energy expressed as
  * a function of the mole fractions.
  */
-/*
- * Copyright (2009) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/IonsFromNeutralVPSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/PDSS_IonsFromNeutral.h"

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -5,6 +5,10 @@
  *  assuming a lattice of solid atoms
  *  (see \ref thermoprops and class \link Cantera::LatticePhase LatticePhase\endlink).
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/LatticePhase.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -6,6 +6,9 @@
  *  (see \ref thermoprops and class \link Cantera::LatticeSolidPhase LatticeSolidPhase\endlink).
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/LatticeSolidPhase.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/SpeciesThermoFactory.h"

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -5,11 +5,10 @@
  *   expansions (see \ref thermoprops
  *    and class \link Cantera::MargulesVPSSTP MargulesVPSSTP\endlink).
  */
-/*
- * Copyright (2009) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/MargulesVPSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/MaskellSolidSolnPhase.cpp
+++ b/src/thermo/MaskellSolidSolnPhase.cpp
@@ -4,11 +4,9 @@
  *      thermoprops and \link Cantera::MaskellSolidSolnPhase
  *      MaskellSolidSolnPhase\endlink).
  */
-/*
- * Copyright 2006 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000, with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MaskellSolidSolnPhase.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/MetalSHEelectrons.cpp
+++ b/src/thermo/MetalSHEelectrons.cpp
@@ -6,12 +6,9 @@
  * class \link Cantera::MetalSHEelectrons MetalSHEelectrons\endlink)
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- *
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/mix_defs.h"
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/MetalSHEelectrons.h"

--- a/src/thermo/MineralEQ3.cpp
+++ b/src/thermo/MineralEQ3.cpp
@@ -5,13 +5,9 @@
  * class \link Cantera::MineralEQ3 MineralEQ3\endlink)
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- *
- * Copyright 2001 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/mix_defs.h"
 #include "cantera/thermo/MineralEQ3.h"

--- a/src/thermo/MixedSolventElectrolyte.cpp
+++ b/src/thermo/MixedSolventElectrolyte.cpp
@@ -2,11 +2,9 @@
  *  @file MixedSolventElectrolyte.cpp see \ref thermoprops and class \link
  *      Cantera::MixedSolventElectrolyte MixedSolventElectrolyte \endlink).
  */
-/*
- * Copyright (2009) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MixedSolventElectrolyte.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -4,11 +4,9 @@
  *    non-ideal mixtures based on the fugacity models (see \ref thermoprops and
  *    class \link Cantera::MixtureFugacityTP MixtureFugacityTP\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MixtureFugacityTP.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -5,11 +5,10 @@
  *  (see \ref thermoprops
  * and class \link Cantera::MolalityVPSSTP MolalityVPSSTP\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/MolalityVPSSTP.h"
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/MolarityIonicVPSSTP.cpp
+++ b/src/thermo/MolarityIonicVPSSTP.cpp
@@ -10,11 +10,10 @@
  * further based upon expressions for the excess Gibbs free energy expressed as
  * a function of the mole fractions.
  */
-/*
- * Copyright (2009) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/MolarityIonicVPSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -5,6 +5,10 @@
  *  on a piecewise constant mu0 interpolation
  *  (see \ref spthermo and class \link Cantera::Mu0Poly Mu0Poly\endlink).
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/Mu0Poly.h"
 #include "cantera/base/ctml.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/MultiSpeciesThermo.cpp
+++ b/src/thermo/MultiSpeciesThermo.cpp
@@ -4,7 +4,9 @@
  *  in a phase (see \ref spthermo and
  * \link Cantera::MultiSpeciesThermo MultiSpeciesThermo\endlink).
  */
-// Copyright 2001-2004  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MultiSpeciesThermo.h"
 #include "cantera/thermo/SpeciesThermoFactory.h"

--- a/src/thermo/Nasa9Poly1.cpp
+++ b/src/thermo/Nasa9Poly1.cpp
@@ -8,7 +8,9 @@
  *
  * This parameterization has one NASA temperature region.
  */
-// Copyright 2007  Sandia National Laboratories
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/Nasa9Poly1.h"
 

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -10,7 +10,9 @@
  *
  *  This parameterization has one NASA temperature region.
  */
-// Copyright 2007  Sandia National Laboratories
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctexceptions.h"
 #include "cantera/thermo/Nasa9PolyMultiTempRegion.h"

--- a/src/thermo/NasaPoly2.cpp
+++ b/src/thermo/NasaPoly2.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/NasaPoly2.h"
 #include "cantera/base/global.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/PDSS.cpp
+++ b/src/thermo/PDSS.cpp
@@ -4,11 +4,10 @@
  * virtual function
  * (see class \link Cantera::PDSS PDSS\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS.h"
 #include "cantera/thermo/VPStandardStateTP.h"

--- a/src/thermo/PDSS_ConstVol.cpp
+++ b/src/thermo/PDSS_ConstVol.cpp
@@ -3,11 +3,10 @@
  * Implementation of a pressure dependent standard state
  * virtual function.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_ConstVol.h"
 #include "cantera/thermo/VPStandardStateTP.h"

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -5,11 +5,9 @@
  *    HKFT standard state
  *    (see \ref pdssthermo and class \link Cantera::PDSS_HKFT PDSS_HKFT\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_HKFT.h"

--- a/src/thermo/PDSS_IdealGas.cpp
+++ b/src/thermo/PDSS_IdealGas.cpp
@@ -3,11 +3,10 @@
  * Implementation of a pressure dependent standard state
  * virtual function.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_IdealGas.h"
 #include "cantera/thermo/VPStandardStateTP.h"

--- a/src/thermo/PDSS_IonsFromNeutral.cpp
+++ b/src/thermo/PDSS_IonsFromNeutral.cpp
@@ -3,11 +3,9 @@
  * Implementation of a pressure dependent standard state
  * virtual function.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/PDSS_IonsFromNeutral.h"
 #include "cantera/thermo/IonsFromNeutralVPSSTP.h"

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -3,11 +3,10 @@
  * Implementation of a pressure dependent standard state
  * virtual function.
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_SSVol.h"
 #include "cantera/thermo/VPStandardStateTP.h"

--- a/src/thermo/PDSS_Water.cpp
+++ b/src/thermo/PDSS_Water.cpp
@@ -1,11 +1,10 @@
 /**
  * @file PDSS_Water.cpp
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_Water.h"
 #include "cantera/thermo/WaterPropsIAPWS.h"

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -3,7 +3,8 @@
  *   Definition file for class Phase.
  */
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/Phase.h"
 #include "cantera/base/utilities.h"

--- a/src/thermo/PhaseCombo_Interaction.cpp
+++ b/src/thermo/PhaseCombo_Interaction.cpp
@@ -1,11 +1,9 @@
 /**
  *  @file PhaseCombo_Interaction.cpp
  */
-/*
- * Copyright (2009) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/PhaseCombo_Interaction.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -4,6 +4,10 @@
  *     fluid (see \ref thermoprops and class \link Cantera::PureFluidPhase
  *     PureFluidPhase\endlink).
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/base/xml.h"
 #include "cantera/thermo/PureFluidPhase.h"
 

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -5,11 +5,9 @@
  *   expansions (see \ref thermoprops
  *    and class \link Cantera::RedlichKisterVPSSTP RedlichKisterVPSSTP\endlink).
  */
-/*
- * Copyright (2009) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/RedlichKisterVPSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -1,10 +1,7 @@
 //! @file RedlichKwongMFTP.cpp
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/RedlichKwongMFTP.h"
 #include "cantera/thermo/mix_defs.h"

--- a/src/thermo/SemiconductorPhase.cpp
+++ b/src/thermo/SemiconductorPhase.cpp
@@ -1,4 +1,8 @@
 //! @file SemiconductorPhase.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/SemiconductorPhase.h"
 
 using namespace std;

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -5,11 +5,9 @@
  *  ( see \ref thermoprops and class \link Cantera::SingleSpeciesTP SingleSpeciesTP\endlink).
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/SingleSpeciesTP.h"
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/global.h"

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -1,3 +1,6 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/Species.h"
 #include "cantera/thermo/SpeciesThermoInterpType.h"
 #include "cantera/thermo/SpeciesThermoFactory.h"

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -4,7 +4,9 @@
  *    manage the standard-state thermodynamic properties of a set of species
  *    (see \ref spthermo);
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/SpeciesThermoFactory.h"
 #include "cantera/thermo/MultiSpeciesThermo.h"

--- a/src/thermo/SpeciesThermoInterpType.cpp
+++ b/src/thermo/SpeciesThermoInterpType.cpp
@@ -1,7 +1,9 @@
 /**
  *  @file SpeciesThermoInterpType.cpp
  */
-// Copyright 2007  Sandia National Laboratories
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/SpeciesThermoInterpType.h"
 #include "cantera/thermo/VPSSMgr.h"

--- a/src/thermo/StoichSubstance.cpp
+++ b/src/thermo/StoichSubstance.cpp
@@ -5,13 +5,9 @@
  * class \link Cantera::StoichSubstance StoichSubstance\endlink)
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- *
- * Copyright 2001 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/StoichSubstance.h"
 #include "cantera/thermo/mix_defs.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -5,7 +5,9 @@
  *  (see \ref thermoprops and class
  *  \link Cantera::SurfPhase SurfPhase\endlink).
  */
-// Copyright 2002  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/thermo/EdgePhase.h"

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -3,7 +3,9 @@
  *     Definitions for the factory class that can create known ThermoPhase objects
  *     (see \ref thermoprops and class \link Cantera::ThermoFactory ThermoFactory\endlink).
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/ThermoFactory.h"
 

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -5,7 +5,8 @@
  * (see class \link Cantera::ThermoPhase ThermoPhase\endlink).
  */
 
-//  Copyright 2002 California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/VPSSMgr.cpp
+++ b/src/thermo/VPSSMgr.cpp
@@ -6,11 +6,9 @@
  * (see \ref mgrpdssthermocalc and
  * class \link Cantera::VPSSMgr VPSSMgr\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/VPSSMgr.h"
 #include "cantera/thermo/VPStandardStateTP.h"

--- a/src/thermo/VPSSMgrFactory.cpp
+++ b/src/thermo/VPSSMgrFactory.cpp
@@ -5,11 +5,9 @@
  *    (see \ref spthermo and class
  *    \link Cantera::VPSSMgrFactory VPSSMgrFactory\endlink);
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "VPSSMgrFactory.h"
 #include "cantera/thermo/VPStandardStateTP.h"

--- a/src/thermo/VPSSMgrFactory.h
+++ b/src/thermo/VPSSMgrFactory.h
@@ -4,11 +4,9 @@
  *    standard-state thermodynamic properties of a set of species
  *    (see \ref mgrpdssthermocalc and class \link Cantera::VPSSMgrFactory VPSSMgrFactory\endlink);
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef VPSSSPECIESTHERMO_FACTORY_H
 #define VPSSSPECIESTHERMO_FACTORY_H

--- a/src/thermo/VPSSMgr_ConstVol.cpp
+++ b/src/thermo/VPSSMgr_ConstVol.cpp
@@ -6,11 +6,9 @@
  *  dependence (see \ref thermoprops and
  * class \link Cantera::VPSSMgr_ConstVol VPSSMgr_ConstVol\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/VPSSMgr_ConstVol.h"
 #include "cantera/thermo/VPStandardStateTP.h"

--- a/src/thermo/VPSSMgr_General.cpp
+++ b/src/thermo/VPSSMgr_General.cpp
@@ -6,11 +6,9 @@
  *  but slow way (see \ref thermoprops and
  *  class \link Cantera::VPSSMgr_General VPSSMgr_General\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/VPSSMgr_General.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/VPSSMgr_IdealGas.cpp
+++ b/src/thermo/VPSSMgr_IdealGas.cpp
@@ -6,11 +6,9 @@
  * (see \ref thermoprops and
  * class \link Cantera::VPSSMgr_IdealGas VPSSMgr_IdealGas\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/VPSSMgr_IdealGas.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/VPSSMgr_Water_ConstVol.cpp
+++ b/src/thermo/VPSSMgr_Water_ConstVol.cpp
@@ -8,11 +8,8 @@
  * \link Cantera::VPSSMgr_Water_ConstVol VPSSMgr_Water_ConstVol\endlink).
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/VPSSMgr_Water_ConstVol.h"
 #include "cantera/thermo/PDSS_Water.h"

--- a/src/thermo/VPSSMgr_Water_HKFT.cpp
+++ b/src/thermo/VPSSMgr_Water_HKFT.cpp
@@ -8,11 +8,8 @@
  * \link Cantera::VPSSMgr_Water_HKFT VPSSMgr_Water_HKFT\endlink).
  */
 
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/VPSSMgr_Water_HKFT.h"
 #include "cantera/thermo/PDSS_Water.h"

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -5,11 +5,9 @@
  * thermodynamic properties (see \ref thermoprops and
  * class \link Cantera::VPStandardStateTP VPStandardStateTP\endlink).
  */
-/*
- * Copyright (2005) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/VPStandardStateTP.h"
 #include "cantera/thermo/PDSS.h"

--- a/src/thermo/WaterProps.cpp
+++ b/src/thermo/WaterProps.cpp
@@ -1,11 +1,9 @@
 /**
  *  @file WaterProps.cpp
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/WaterProps.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -4,11 +4,10 @@
  * from the IAPWS 1995 Formulation based on the steam tables thermodynamic
  * basis (See class \link Cantera::WaterPropsIAPWS WaterPropsIAPWS\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/WaterPropsIAPWS.h"
 #include "cantera/base/ctexceptions.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/WaterPropsIAPWSphi.cpp
+++ b/src/thermo/WaterPropsIAPWSphi.cpp
@@ -4,11 +4,10 @@
  * model (see class \link Cantera::WaterPropsIAPWS WaterPropsIAPWS\endlink and
  * class \link Cantera::WaterPropsIAPWSphi WaterPropsIAPWSphi \endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/thermo/WaterPropsIAPWSphi.h"
 #include "cantera/base/global.h"
 

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -3,11 +3,9 @@
  * Definitions for a ThermoPhase class consisting of pure water (see \ref thermoprops
  * and class \link Cantera::WaterSSTP WaterSSTP\endlink).
  */
-/*
- * Copyright (2006) Sandia Corporation. Under the terms of
- * Contract DE-AC04-94AL85000 with Sandia Corporation, the
- * U.S. Government retains certain rights in this software.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/WaterSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/tpx/CarbonDioxide.cpp
+++ b/src/tpx/CarbonDioxide.cpp
@@ -5,6 +5,9 @@
  * Reynolds AUTHOR: me@rebeccahhunt.com: GCEP, Stanford University
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "CarbonDioxide.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/tpx/CarbonDioxide.h
+++ b/src/tpx/CarbonDioxide.h
@@ -1,4 +1,8 @@
 //! @file CarbonDioxide.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_CARBONDIOXIDE_H
 #define TPX_CARBONDIOXIDE_H
 

--- a/src/tpx/HFC134a.cpp
+++ b/src/tpx/HFC134a.cpp
@@ -1,5 +1,8 @@
 //! @file HFC134a.cpp
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "HFC134a.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/tpx/HFC134a.h
+++ b/src/tpx/HFC134a.h
@@ -1,4 +1,8 @@
 //! @file HFC134a.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_HFC134_H
 #define TPX_HFC134_H
 

--- a/src/tpx/Heptane.cpp
+++ b/src/tpx/Heptane.cpp
@@ -5,6 +5,9 @@
  * Reynolds. AUTHOR: jrh@stanford.edu: GCEP, Stanford University
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "Heptane.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/tpx/Heptane.h
+++ b/src/tpx/Heptane.h
@@ -1,4 +1,8 @@
 //! @file Heptane.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_HEPTANE_H
 #define TPX_HEPTANE_H
 

--- a/src/tpx/Hydrogen.cpp
+++ b/src/tpx/Hydrogen.cpp
@@ -1,4 +1,8 @@
 //! @file Hydrogen.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "Hydrogen.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/tpx/Hydrogen.h
+++ b/src/tpx/Hydrogen.h
@@ -1,4 +1,8 @@
 //! @file Hydrogen.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_HYDROGEN_H
 #define TPX_HYDROGEN_H
 

--- a/src/tpx/Methane.cpp
+++ b/src/tpx/Methane.cpp
@@ -1,4 +1,8 @@
 //! @file Methane.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "Methane.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/tpx/Methane.h
+++ b/src/tpx/Methane.h
@@ -1,4 +1,8 @@
 //! @file Methane.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_METHANE_H
 #define TPX_METHANE_H
 

--- a/src/tpx/Nitrogen.cpp
+++ b/src/tpx/Nitrogen.cpp
@@ -1,4 +1,8 @@
 //! @file Nitrogen.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "Nitrogen.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/tpx/Nitrogen.h
+++ b/src/tpx/Nitrogen.h
@@ -1,4 +1,8 @@
 //! @file Nitrogen.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_NITROGEN_H
 #define TPX_NITROGEN_H
 

--- a/src/tpx/Oxygen.cpp
+++ b/src/tpx/Oxygen.cpp
@@ -1,4 +1,8 @@
 //! @file Oxygen.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "Oxygen.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/tpx/Oxygen.h
+++ b/src/tpx/Oxygen.h
@@ -1,4 +1,8 @@
 //! @file Oxygen.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_OXYGEN_H
 #define TPX_OXYGEN_H
 

--- a/src/tpx/RedlichKwong.cpp
+++ b/src/tpx/RedlichKwong.cpp
@@ -1,4 +1,8 @@
 //! @file RedlichKwong.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "RedlichKwong.h"
 
 namespace tpx

--- a/src/tpx/RedlichKwong.h
+++ b/src/tpx/RedlichKwong.h
@@ -1,4 +1,8 @@
 //! @file RedlichKwong.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_RK_H
 #define TPX_RK_H
 

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -3,6 +3,10 @@
  * The Substance class
  * D. Goodwin, Caltech Nov. 1996
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/tpx/Sub.h"
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/global.h"

--- a/src/tpx/Water.cpp
+++ b/src/tpx/Water.cpp
@@ -1,4 +1,8 @@
 //! @file Water.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "Water.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/tpx/Water.h
+++ b/src/tpx/Water.h
@@ -1,4 +1,8 @@
 //! @file Water.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_WATER_H
 #define TPX_WATER_H
 

--- a/src/tpx/lk.cpp
+++ b/src/tpx/lk.cpp
@@ -1,5 +1,8 @@
 //! @file lk.cpp Lee-Kesler equation of state
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "lk.h"
 #include <math.h>
 

--- a/src/tpx/lk.h
+++ b/src/tpx/lk.h
@@ -1,4 +1,8 @@
 //! @file lk.h Lee-Kesler equation of state
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #ifndef TPX_LK_H
 #define TPX_LK_H
 

--- a/src/tpx/utils.cpp
+++ b/src/tpx/utils.cpp
@@ -1,4 +1,8 @@
 //! @file utils.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/tpx/utils.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -3,10 +3,8 @@
  *  Implementation file for class DustyGasTransport
  */
 
-/*
- *  Copyright 2003 California Institute of Technology
- *  See file License.txt for licensing information
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/DustyGasTransport.h"
 #include "cantera/base/stringUtils.h"

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -1,4 +1,8 @@
 //! @file GasTransport.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/GasTransport.h"
 #include "MMCollisionInt.h"
 #include "cantera/base/stringUtils.h"

--- a/src/transport/HighPressureGasTransport.cpp
+++ b/src/transport/HighPressureGasTransport.cpp
@@ -9,6 +9,10 @@
  *      of Gases and Liquids, 4th ed., 1987 (viscosity in Ch. 9, Thermal
  *      conductivity in Ch. 10, and Diffusion coefficients in Ch. 11).
  **/
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/HighPressureGasTransport.h"
 #include "cantera/numerics/ctlapack.h"
 #include "cantera/base/utilities.h"

--- a/src/transport/LTPspecies.cpp
+++ b/src/transport/LTPspecies.cpp
@@ -5,6 +5,9 @@
  *    (see \ref tranprops and \link Cantera::LTPspecies LTPspecies \endlink) .
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/LTPspecies.h"
 #include "cantera/base/ctml.h"
 

--- a/src/transport/LiquidTranInteraction.cpp
+++ b/src/transport/LiquidTranInteraction.cpp
@@ -3,6 +3,9 @@
  *  Source code for liquid mixture transport property evaluations.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/LiquidTransportParams.h"
 #include "cantera/thermo/IonsFromNeutralVPSSTP.h"
 #include "cantera/thermo/MargulesVPSSTP.h"

--- a/src/transport/LiquidTransport.cpp
+++ b/src/transport/LiquidTransport.cpp
@@ -2,6 +2,10 @@
  *  @file LiquidTransport.cpp
  *  Mixture-averaged transport properties for ideal gas mixtures.
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/LiquidTransport.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/transport/LiquidTransportData.cpp
+++ b/src/transport/LiquidTransportData.cpp
@@ -3,6 +3,9 @@
  *  Source code for liquid transport property evaluations.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/LiquidTransportData.h"
 using namespace std;
 

--- a/src/transport/LiquidTransportParams.cpp
+++ b/src/transport/LiquidTransportParams.cpp
@@ -3,6 +3,9 @@
  *  Source code for liquid mixture transport property evaluations.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/LiquidTransportParams.h"
 using namespace std;
 

--- a/src/transport/MMCollisionInt.cpp
+++ b/src/transport/MMCollisionInt.cpp
@@ -1,7 +1,9 @@
 /**
  *  @file MMCollisionInt.cpp
  */
-// Copyright 2001  California Institute of Technology */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "MMCollisionInt.h"
 #include "cantera/base/utilities.h"

--- a/src/transport/MMCollisionInt.h
+++ b/src/transport/MMCollisionInt.h
@@ -2,7 +2,9 @@
  * @file MMCollisionInt.h
  *  Monk and Monchick collision integrals
  */
-// Copyright 2001  California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MMCOLLISIONINT_H
 #define CT_MMCOLLISIONINT_H

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -2,7 +2,9 @@
  *  @file MixTransport.cpp
  *  Mixture-averaged transport properties for ideal gas mixtures.
  */
-// copyright 2001 California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/MixTransport.h"
 #include "cantera/base/stringUtils.h"

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -2,10 +2,9 @@
  *  @file MultiTransport.cpp
  *  Implementation file for class MultiTransport
  */
-/*
- *  Copyright 2001 California Institute of Technology
- *  See file License.txt for licensing information
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/MultiTransport.h"
 #include "cantera/thermo/IdealGasPhase.h"

--- a/src/transport/SimpleTransport.cpp
+++ b/src/transport/SimpleTransport.cpp
@@ -2,6 +2,10 @@
  *  @file SimpleTransport.cpp
  *  Simple mostly constant transport properties
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/SimpleTransport.h"
 #include "cantera/base/stringUtils.h"
 

--- a/src/transport/SolidTransport.cpp
+++ b/src/transport/SolidTransport.cpp
@@ -4,7 +4,9 @@
  *   of ions within solid phases
  *  (see \ref tranprops and \link Cantera::SolidTransport SolidTransport \endlink).
  */
-// copyright 2008 California Institute of Technology
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/SolidTransport.h"
 #include "cantera/transport/SolidTransportData.h"

--- a/src/transport/SolidTransportData.cpp
+++ b/src/transport/SolidTransportData.cpp
@@ -3,6 +3,9 @@
  *  Source code for solid transport property evaluations.
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/SolidTransportData.h"
 
 using namespace std;

--- a/src/transport/TransportBase.cpp
+++ b/src/transport/TransportBase.cpp
@@ -2,6 +2,10 @@
  *  @file TransportBase.cpp
  *  Mixture-averaged transport properties for ideal gas mixtures.
  */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/TransportBase.h"
 
 using namespace std;

--- a/src/transport/TransportData.cpp
+++ b/src/transport/TransportData.cpp
@@ -1,5 +1,8 @@
 //! @file TransportData.cpp
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/TransportData.h"
 #include "cantera/thermo/Species.h"
 #include "cantera/base/ctexceptions.h"

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -1,5 +1,8 @@
 //! @file TransportFactory.cpp Implementation file for class TransportFactory.
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 // known transport models
 #include "cantera/transport/MultiTransport.h"
 #include "cantera/transport/MixTransport.h"

--- a/src/transport/TransportParams.cpp
+++ b/src/transport/TransportParams.cpp
@@ -5,6 +5,9 @@
  *  (see \ref tranprops and \link Cantera::TransportParams TransportParams \endlink).
  */
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/TransportParams.h"
 
 using namespace std;

--- a/src/transport/WaterTransport.cpp
+++ b/src/transport/WaterTransport.cpp
@@ -1,4 +1,8 @@
 //! @file WaterTransport.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/transport/WaterTransport.h"
 #include "cantera/thermo/VPStandardStateTP.h"
 #include "cantera/thermo/PDSS_Water.h"

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -1,6 +1,7 @@
 //! @file ConstPressureReactor.cpp A constant pressure zero-dimensional reactor
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/ConstPressureReactor.h"
 #include "cantera/zeroD/FlowDevice.h"

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -1,4 +1,8 @@
 //! @file FlowDevice.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/ReactorBase.h"
 #include "cantera/numerics/Func1.h"

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -1,6 +1,7 @@
 //! @file FlowReactor.cpp A steady-state plug flow reactor
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/FlowReactor.h"
 #include "cantera/base/global.h"

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -1,6 +1,7 @@
 //! @file ConstPressureReactor.cpp A constant pressure zero-dimensional reactor
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/IdealGasConstPressureReactor.h"
 #include "cantera/zeroD/FlowDevice.h"

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -1,5 +1,8 @@
 //! @file IdealGasReactor.cpp A zero-dimensional reactor
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/zeroD/IdealGasReactor.h"
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/Wall.h"

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -1,6 +1,7 @@
 //! @file Reactor.cpp A zero-dimensional reactor
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/Reactor.h"
 #include "cantera/zeroD/FlowDevice.h"

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -1,6 +1,7 @@
 //! @file ReactorBase.cpp
 
-// Copyright 2001  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/ReactorBase.h"
 #include "cantera/zeroD/FlowDevice.h"

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -1,6 +1,7 @@
 //! @file ReactorFactory.cpp
 
-// Copyright 2006  California Institute of Technology
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/ReactorFactory.h"
 #include "cantera/zeroD/Reservoir.h"

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -1,4 +1,8 @@
 //! @file ReactorNet.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/Wall.h"

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -1,5 +1,8 @@
 //! @file ReactorSurface.cpp
 
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/thermo/SurfPhase.h"

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -1,4 +1,8 @@
 //! @file Wall.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 #include "cantera/zeroD/Wall.h"
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/numerics/Func1.h"

--- a/test_problems/CpJump/CpJump.cpp
+++ b/test_problems/CpJump/CpJump.cpp
@@ -1,6 +1,5 @@
-/*
- *  Copyright 2002 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/IdealGasMix.h"
 

--- a/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
+++ b/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
@@ -1,6 +1,5 @@
-/*
- *  Copyright 2002 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_MultiPhaseEquil.h"
 

--- a/test_problems/VPsilane_test/silane_equil.cpp
+++ b/test_problems/VPsilane_test/silane_equil.cpp
@@ -1,6 +1,5 @@
-/*
- *  Copyright 2002 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/IdealGasMix.h"
 #include "cantera/thermo/IdealSolnGasVPSS.h"

--- a/test_problems/cathermo/VPissp/ISSPTester.cpp
+++ b/test_problems/cathermo/VPissp/ISSPTester.cpp
@@ -1,12 +1,9 @@
 /**
  *  @file ISSPTester.cpp
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 //  Example
 //

--- a/test_problems/cathermo/ims/IMSTester.cpp
+++ b/test_problems/cathermo/ims/IMSTester.cpp
@@ -1,12 +1,9 @@
 /**
  *  @file IMSTester.cpp
  */
-/*
- * Copyright 2005 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 //  Example
 //

--- a/test_problems/cathermo/issp/ISSPTester.cpp
+++ b/test_problems/cathermo/issp/ISSPTester.cpp
@@ -1,12 +1,9 @@
 /**
  *  @file ISSPTester.cpp
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 //  Example
 //

--- a/test_problems/cxx_ex/equil_example1.cpp
+++ b/test_problems/cxx_ex/equil_example1.cpp
@@ -1,9 +1,11 @@
 /////////////////////////////////////////////////////////////
 //
 //  chemical equilibrium
-//  copyright California Institute of Technology 2002
 //
 /////////////////////////////////////////////////////////////
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "example_utils.h"
 

--- a/test_problems/cxx_ex/kinetics_example1.cpp
+++ b/test_problems/cxx_ex/kinetics_example1.cpp
@@ -2,9 +2,10 @@
 //
 //  zero-dimensional kinetics example program
 //
-//  copyright California Institute of Technology 2002
-//
 /////////////////////////////////////////////////////////////
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
 #include "cantera/IdealGasMix.h"

--- a/test_problems/cxx_ex/kinetics_example3.cpp
+++ b/test_problems/cxx_ex/kinetics_example3.cpp
@@ -2,9 +2,10 @@
 //
 //  zero-dimensional kinetics example program
 //
-//  copyright California Institute of Technology 2006
-//
 /////////////////////////////////////////////////////////////
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
 #include "cantera/IdealGasMix.h"

--- a/test_problems/cxx_ex/rxnpath_example1.cpp
+++ b/test_problems/cxx_ex/rxnpath_example1.cpp
@@ -2,9 +2,10 @@
 //
 //  reaction path diagrams
 //
-//  copyright California Institute of Technology 2002
-//
 /////////////////////////////////////////////////////////////
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
 #include "example_utils.h"

--- a/test_problems/cxx_ex/transport_example1.cpp
+++ b/test_problems/cxx_ex/transport_example1.cpp
@@ -2,9 +2,10 @@
 //
 //  mixture-averaged transport properties
 //
-//  copyright California Institute of Technology 2002
-//
 /////////////////////////////////////////////////////////////
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport.h"
 #include "example_utils.h"

--- a/test_problems/cxx_ex/transport_example2.cpp
+++ b/test_problems/cxx_ex/transport_example2.cpp
@@ -2,9 +2,10 @@
 //
 //  mixture-averaged transport properties
 //
-//  copyright California Institute of Technology 2002
-//
 /////////////////////////////////////////////////////////////
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport.h"
 #include "example_utils.h"

--- a/test_problems/shared/TemperatureTable.h
+++ b/test_problems/shared/TemperatureTable.h
@@ -1,8 +1,5 @@
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000, there is a non-exclusive license for use of this
- * work by or on behalf of the U.S. Government.
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #ifndef TEMPERATURE_TABLE_H
 #define TEMPERATURE_TABLE_H

--- a/test_problems/silane_equil/silane_equil.cpp
+++ b/test_problems/silane_equil/silane_equil.cpp
@@ -1,6 +1,5 @@
-/*
- *  Copyright 2002 California Institute of Technology
- */
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
 
 #include "cantera/IdealGasMix.h"
 

--- a/test_problems/surfSolverTest/surfaceSolver.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver.cpp
@@ -2,12 +2,10 @@
  *  @file surfaceSolver.cpp
  *
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 //  Example
 //
 //  Read a surface growth mechanism and calculate the solution

--- a/test_problems/surfSolverTest/surfaceSolver2.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver2.cpp
@@ -2,12 +2,10 @@
  *  @file surfaceSolver2.cpp
  *
  */
-/*
- * Copyright 2004 Sandia Corporation. Under the terms of Contract
- * DE-AC04-94AL85000 with Sandia Corporation, the U.S. Government
- * retains certain rights in this software.
- * See file License.txt for licensing information.
- */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
 //  Example
 //
 //  Read a surface growth mechanism and calculate the solution


### PR DESCRIPTION
Update the LICENSE.txt file to with a blanket copyright for all developers who have contributed to Cantera, leaving acknowledgement of individual authors to the AUTHORS file. This approach is common in other projects, e.g. SciPy (https://github.com/scipy/scipy/blob/master/LICENSE.txt, https://github.com/scipy/scipy/blob/master/THANKS.txt)

Along with this, I would like to eliminate the various copyright and license related fragments found throughout the code, and replace them with a reference to the LICENSE.txt which does not need to be updated or invite the introduction of piles of copyright claims in individual files. This practice is suggested by http://softwarefreedom.org/resources/2012/ManagingCopyrightInformation.html. A couple of options are:

```
This file is part of Cantera. It is subject to the copyright and license
terms in the LICENSE.txt file found at the top-level directory of this
distribution and at http://www.cantera.org/license.txt. No part of Cantera,
including this file, may be copied, modified, or distributed except according
to the terms contained in the LICENSE file.
```

or, a briefer, but less explicit version (my preference):

```
This file is part of Cantera. See LICENSE.txt in the top-level directory or
at http://www.cantera.org/license.txt for license and copyright information.
```

Suggestions / comments / alternatives welcome.
