### PR TITLE
Add get data directories function

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@ build/
 test/work/
 interfaces/cython/cantera/_cantera.h
 include/cantera/base/config.h
+include/cantera/base/config.h.build
 include/cantera/base/system.h.gch
 include/cantera/ext/
 interfaces/matlab/ctpath.m

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -212,7 +212,7 @@ if localenv['sphinx_docs']:
         '@Data': ['Air.m', 'constants.m', 'gasconstant.m', 'GRI30.m',
              'Hydrogen.m', 'Methane.m', 'Nitrogen.m', 'oneatm.m',
              'Oxygen.m', 'Water.m'],
-        '@Utilities': ['adddir.m', 'ck2cti.m', 'cleanup.m', 'geterr.m',]
+        '@Utilities': ['adddir.m', 'ck2cti.m', 'cleanup.m', 'geterr.m', 'getDataDirectories.m']
     }
 
     # These files do not need to be documented in the MATLAB classes because they

--- a/doc/sphinx/cython/importing.rst
+++ b/doc/sphinx/cython/importing.rst
@@ -47,3 +47,4 @@ Utility Functions
 -----------------
 
 .. autofunction:: add_directory
+.. autofunction:: get_data_directories

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -114,6 +114,9 @@ std::string findInputFile(const std::string& name);
 
 //! @copydoc Application::addDataDirectory
 void addDirectory(const std::string& dir);
+
+//! @copydoc Application::getDataDirectories
+std::string getDataDirectories(const std::string& sep);
 //@}
 
 //! Delete and free all memory associated with the application

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -156,6 +156,7 @@ extern "C" {
     CANTERA_CAPI int showCanteraErrors();
     CANTERA_CAPI int setLogWriter(void* logger);
     CANTERA_CAPI int addCanteraDirectory(size_t buflen, const char* buf);
+    CANTERA_CAPI int ct_getDataDirectories(int buflen, char* buf, const char* sep);
     CANTERA_CAPI int clearStorage();
 
     CANTERA_CAPI int ck_to_cti(const char* in_file, const char* db_file,

--- a/include/cantera/numerics/ctlapack.h
+++ b/include/cantera/numerics/ctlapack.h
@@ -419,7 +419,7 @@ inline doublereal ct_dtrcon(const char* norm, ctlapack::upperlower_t uplot, cons
     integer f_n = static_cast<integer>(n);
     integer f_lda = static_cast<integer>(lda);
     integer f_info = 0;
-    doublereal rcond;
+    doublereal rcond = 0.0;
     ftnlen trsize = 1;
 #ifdef LAPACK_FTN_STRING_LEN_AT_END
     _DTRCON_(&nn, &uplo, &dd, &f_n, a, &f_lda, &rcond, work, iwork, &f_info, trsize, trsize, trsize);
@@ -475,7 +475,7 @@ inline doublereal ct_dgecon(const char norm, size_t n, doublereal* a, size_t lda
     integer f_n = static_cast<integer>(n);
     integer f_lda = static_cast<integer>(lda);
     integer f_info = 0;
-    doublereal rcond;
+    doublereal rcond = 0.0;
     ftnlen trsize = 1;
 #ifdef LAPACK_FTN_STRING_LEN_AT_END
     _DGECON_(&cnorm, &f_n, a, &f_lda, &anorm, &rcond, work, iwork, &f_info, trsize);
@@ -499,7 +499,7 @@ inline doublereal ct_dgbcon(const char norm, size_t n, size_t kl, size_t ku,
     integer f_ku = static_cast<integer>(ku);
     integer f_ldab = static_cast<integer>(ldab);
     integer f_info = 0;
-    doublereal rcond;
+    doublereal rcond = 0.0;
     ftnlen trsize = 1;
 #ifdef LAPACK_FTN_STRING_LEN_AT_END
     _DGBCON_(&cnorm, &f_n, &f_kl, &f_ku, a, &f_ldab, ipiv, &anorm, &rcond, work, iwork, &f_info, trsize);

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -47,6 +47,7 @@ cdef extern from "cantera/base/stringUtils.h" namespace "Cantera":
 
 cdef extern from "cantera/base/global.h" namespace "Cantera":
     cdef void CxxAddDirectory "Cantera::addDirectory" (string)
+    cdef string CxxGetDataDirectories "Cantera::getDataDirectories" (string)
     cdef size_t CxxNpos "Cantera::npos"
     cdef void CxxAppdelete "Cantera::appdelete" ()
     cdef XML_Node* CxxGetXmlFile "Cantera::get_XML_File" (string) except +translate_exception

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -2,6 +2,7 @@
 # at http://www.cantera.org/license.txt for license and copyright information.
 
 import sys
+import os
 from cpython.ref cimport PyObject
 
 cdef int _pythonMajorVersion = sys.version_info[0]
@@ -30,6 +31,10 @@ cdef pystr(string x):
 def add_directory(directory):
     """ Add a directory to search for Cantera data files. """
     CxxAddDirectory(stringify(directory))
+
+def get_data_directories():
+    """ Get a list of the directories Cantera searches for data files. """
+    return pystr(CxxGetDataDirectories(stringify(os.pathsep))).split(os.pathsep)
 
 __sundials_version__ = '.'.join(str(get_sundials_version()))
 

--- a/interfaces/matlab/toolbox/getDataDirectories.m
+++ b/interfaces/matlab/toolbox/getDataDirectories.m
@@ -1,0 +1,10 @@
+function d = getDataDirectories()
+% GETDATADIRECTORIES  Get a cell array of the directories searched for data files.
+% getdatadirectories()
+% Get a cell array of the directories Cantera searches for data files
+%
+% :return:
+%     Cell array with strings representing the data file search directories
+%
+
+d = strsplit(ctmethods(0, 5, ';'), ';');

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -248,7 +248,7 @@ public:
      * above.
      *
      * The default set of directories specified for the application will be
-     * searched if a '/' or an '\\' is found in the name. If either is found
+     * searched if a '/' or an '\\' is not found in the name. If either is found
      * then a relative path name is presumed, and the default directories are
      * not searched.
      *

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -190,7 +190,7 @@ protected:
 public:
     //! Return a pointer to the one and only instance of class Application
     /*!
-     * If the an Application object has not yet been created it is created
+     * If the Application object has not yet been created, it is created
      */
     static Application* Instance();
 

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -9,6 +9,8 @@
 #include "cantera/base/config.h"
 #include "cantera/base/logger.h"
 
+#include <boost/algorithm/string/join.hpp>
+
 #include <set>
 #include <thread>
 
@@ -264,6 +266,20 @@ public:
      * @ingroup inputfiles
      */
     std::string findInputFile(const std::string& name);
+
+    //! Get the Cantera data directories
+    /*!
+     * This routine returns a string including the names of all the
+     * directories searched by Cantera for data files.
+     *
+     * @param sep Separator to use between directories in the string
+     * @return A string of directories separated by the input sep
+     *
+     * @ingroup inputfiles
+     */
+    std::string getDataDirectories(const std::string& sep) {
+        return boost::algorithm::join(inputDirs, sep);
+    }
 
     //! Return a pointer to the XML tree for a Cantera input file.
     /*!

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -137,6 +137,11 @@ void addDirectory(const std::string& dir)
     app()->addDataDirectory(dir);
 }
 
+std::string getDataDirectories(const std::string& sep)
+{
+    return app()->getDataDirectories(sep);
+}
+
 std::string findInputFile(const std::string& name)
 {
     return app()->findInputFile(name);

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1420,6 +1420,15 @@ extern "C" {
         }
     }
 
+    int ct_getDataDirectories(int buflen, char* buf, const char* sep)
+    {
+        try {
+            return copyString(getDataDirectories(sep), buf, buflen);
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int setLogWriter(void* logger)
     {
         try {

--- a/src/matlab/ctfunctions.cpp
+++ b/src/matlab/ctfunctions.cpp
@@ -34,7 +34,7 @@ void ctfunctions(int nlhs, mxArray* plhs[],
 {
     int job = getInt(prhs[1]);
     int iok = 0, dbg, validate;
-    char* infile, *dbfile, *trfile, *idtag;
+    char* infile, *dbfile, *trfile, *idtag, *sep;
     int buflen = 0;
     char* output_buf = 0;
 
@@ -80,6 +80,16 @@ void ctfunctions(int nlhs, mxArray* plhs[],
         iok = clear_reactors();
         iok = clear_rxnpath();
         break;
+
+        // get string of data directories
+    case 5:
+        sep = getString(prhs[2]);
+        buflen = ct_getDataDirectories(0, 0, sep);
+        output_buf = (char*)mxCalloc(buflen, sizeof(char));
+        iok = ct_getDataDirectories(buflen, output_buf, sep);
+        plhs[0] = mxCreateString(output_buf);
+        iok = 0;
+        return;
 
     default:
         mexErrMsgTxt("ctfunctions: unknown job");


### PR DESCRIPTION
Add a function to get the data directories that Cantera searches. Since we're using Boost in another spot now as a requirement, I thought it'd be OK to use that here as well. If not, we just need to implement our own string imploder to convert from `std::vector<string>` to a `std::string`.
