### PR TITLE
Portable python tests

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -37,6 +37,7 @@ config.log
 .settings
 *.gcda
 *.gcno
+*.gch
 coverage/
 coverage.info
 doc/sphinx/cython/examples

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -135,6 +135,9 @@ testFiles = localenv.RecursiveInstall('#interfaces/cython/cantera/test/data',
                                       '#test/data')
 build(testFiles)
 
+for f in ['inputs/h2o2.inp', 'inputs/gri30.inp', 'transport/gri30_tran.dat']:
+    build(localenv.Install('#interfaces/cython/cantera/test/data/', '#data/' + f))
+
 # Cython module for Python 3.x
 if localenv['python3_package'] == 'y':
     py3env = localenv.Clone()

--- a/interfaces/cython/cantera/test/__init__.py
+++ b/interfaces/cython/cantera/test/__init__.py
@@ -1,8 +1,6 @@
 import os
 import cantera
 
-cantera.add_directory(os.path.join(os.path.dirname(__file__), 'data'))
-
 from .test_thermo import *
 from .test_purefluid import *
 from .test_equilibrium import *
@@ -13,3 +11,6 @@ from .test_func1 import *
 from .test_reactor import *
 from .test_onedim import *
 from .test_convert import *
+
+cantera.add_directory(os.path.join(os.path.dirname(__file__), 'data'))
+cantera.add_directory(os.path.join(os.path.dirname(__file__), '..', 'examples', 'surface_chemistry'))

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -1,5 +1,5 @@
 import os
-import numpy as np
+from os.path import join as pjoin
 import itertools
 
 from . import utilities
@@ -64,33 +64,34 @@ class chemkinConverterTest(utilities.CanteraTest):
                 self.assertNear(ref_kr[i], gas_kr[i], rtol=tol, msg='kr '+message)
 
     def test_gri30(self):
-        convertMech('../../data/inputs/gri30.inp',
-                    transportFile='../../data/transport/gri30_tran.dat',
-                    outName='gri30_test.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'gri30.inp'),
+                    transportFile=pjoin(self.test_data_dir, 'gri30_tran.dat'),
+                    outName=pjoin(self.test_work_dir, 'gri30_test.cti'), quiet=True)
 
         ref, gas = self.checkConversion('gri30.xml', 'gri30_test.cti')
         self.checkKinetics(ref, gas, [300, 1500], [5e3, 1e5, 2e6])
 
     def test_soot(self):
-        convertMech('../data/soot.inp',
-                    thermoFile='../data/soot-therm.dat',
-                    outName='soot_test.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'soot.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'soot-therm.dat'),
+                    outName=pjoin(self.test_work_dir, 'soot_test.cti'), quiet=True)
 
-        ref, gas = self.checkConversion('../data/soot.xml', 'soot_test.cti')
+        ref, gas = self.checkConversion('soot.xml', 'soot_test.cti')
         self.checkThermo(ref, gas, [300, 1100])
         self.checkKinetics(ref, gas, [300, 1100], [5e3, 1e5, 2e6])
 
     def test_pdep(self):
-        convertMech('../data/pdep-test.inp',
-                    outName='pdep_test.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'pdep-test.inp'),
+                    outName=pjoin(self.test_work_dir, 'pdep_test.cti'), quiet=True)
 
-        ref, gas = self.checkConversion('../data/pdep-test.xml', 'pdep_test.cti')
+        ref, gas = self.checkConversion(pjoin(self.test_data_dir, 'pdep-test.xml'),
+                                        pjoin(self.test_work_dir, 'pdep_test.cti'))
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6])
 
     def test_species_only(self):
         convertMech(None,
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='dummy-thermo.cti', quiet=True)
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'dummy-thermo.cti'), quiet=True)
 
         cti = "ideal_gas(elements='C H', species='dummy-thermo:R1A R1B P1')"
         gas = ct.Solution(source=cti)
@@ -99,24 +100,24 @@ class chemkinConverterTest(utilities.CanteraTest):
 
     def test_missingElement(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../data/h2o2_missingElement.inp',
-                        outName='h2o2_missingElement.cti',
+            convertMech(pjoin(self.test_data_dir, 'h2o2_missingElement.inp'),
+                        outName=pjoin(self.test_work_dir, 'h2o2_missingElement.cti'),
                         quiet=True)
 
     def test_missingThermo(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../data/h2o2_missingThermo.inp',
-                        outName='h2o2_missingThermo.cti',
+            convertMech(pjoin(self.test_data_dir, 'h2o2_missingThermo.inp'),
+                        outName=pjoin(self.test_work_dir, 'h2o2_missingThermo.cti'),
                         quiet=True)
 
     def test_duplicate_thermo(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../data/duplicate-thermo.inp',
-                        outName='duplicate-thermo.cti',
+            convertMech(pjoin(self.test_data_dir, 'duplicate-thermo.inp'),
+                        outName=pjoin(self.test_work_dir, 'duplicate-thermo.cti'),
                         quiet=True)
 
-        convertMech('../data/duplicate-thermo.inp',
-                    outName='duplicate-thermo.cti',
+        convertMech(pjoin(self.test_data_dir, 'duplicate-thermo.inp'),
+                    outName=pjoin(self.test_work_dir, 'duplicate-thermo.cti'),
                     quiet=True, permissive=True)
 
         gas = ct.Solution('duplicate-thermo.cti')
@@ -125,20 +126,20 @@ class chemkinConverterTest(utilities.CanteraTest):
 
     def test_duplicate_species(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../data/duplicate-species.inp',
-                        outName='duplicate-species.cti',
+            convertMech(pjoin(self.test_data_dir, 'duplicate-species.inp'),
+                        outName=pjoin(self.test_work_dir, 'duplicate-species.cti'),
                         quiet=True)
 
-        convertMech('../data/duplicate-species.inp',
-                    outName='duplicate-species.cti',
+        convertMech(pjoin(self.test_data_dir, 'duplicate-species.inp'),
+                    outName=pjoin(self.test_work_dir, 'duplicate-species.cti'),
                     quiet=True, permissive=True)
 
         gas = ct.Solution('duplicate-species.cti')
         self.assertEqual(gas.species_names, ['foo','bar','baz'])
 
     def test_pathologicalSpeciesNames(self):
-        convertMech('../data/species-names.inp',
-                    outName='species-names.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'species-names.inp'),
+                    outName=pjoin(self.test_work_dir, 'species-names.cti'), quiet=True)
         gas = ct.Solution('species-names.cti')
 
         self.assertEqual(gas.n_species, 6)
@@ -160,12 +161,12 @@ class chemkinConverterTest(utilities.CanteraTest):
 
     def test_unterminatedSections(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../data/unterminated-sections.inp',
-                        outName='unterminated-sections.cti',
+            convertMech(pjoin(self.test_data_dir, 'unterminated-sections.inp'),
+                        outName=pjoin(self.test_work_dir, 'unterminated-sections.cti'),
                         quiet=True)
 
-        convertMech('../data/unterminated-sections.inp',
-                    outName='unterminated-sections.cti',
+        convertMech(pjoin(self.test_data_dir, 'unterminated-sections.inp'),
+                    outName=pjoin(self.test_work_dir, 'unterminated-sections.cti'),
                     quiet=True, permissive=True)
 
         gas = ct.Solution('unterminated-sections.cti')
@@ -174,12 +175,12 @@ class chemkinConverterTest(utilities.CanteraTest):
 
     def test_unterminatedSections2(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../data/unterminated-sections2.inp',
-                        outName='unterminated-sections2.cti',
+            convertMech(pjoin(self.test_data_dir, 'unterminated-sections2.inp'),
+                        outName=pjoin(self.test_work_dir, 'unterminated-sections2.cti'),
                         quiet=True)
 
-        convertMech('../data/unterminated-sections2.inp',
-                    outName='unterminated-sections2.cti',
+        convertMech(pjoin(self.test_data_dir, 'unterminated-sections2.inp'),
+                    outName=pjoin(self.test_work_dir, 'unterminated-sections2.cti'),
                     quiet=True, permissive=True)
 
         gas = ct.Solution('unterminated-sections2.cti')
@@ -187,46 +188,46 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.assertEqual(gas.n_reactions, 2)
 
     def test_nasa9(self):
-        convertMech('../data/nasa9-test.inp',
-                    thermoFile='../data/nasa9-test-therm.dat',
-                    outName='nasa9_test.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'nasa9-test.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'nasa9-test-therm.dat'),
+                    outName=pjoin(self.test_work_dir, 'nasa9_test.cti'), quiet=True)
 
-        ref, gas = self.checkConversion('../data/nasa9-test.xml',
+        ref, gas = self.checkConversion(pjoin(self.test_data_dir, 'nasa9-test.xml'),
                                         'nasa9_test.cti')
         self.checkThermo(ref, gas, [300, 500, 1200, 5000])
 
     def test_sri_falloff(self):
-        convertMech('../data/sri-falloff.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='sri-falloff.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'sri-falloff.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'sri-falloff.cti'), quiet=True)
 
-        ref, gas = self.checkConversion('../data/sri-falloff.xml',
+        ref, gas = self.checkConversion(pjoin(self.test_data_dir, 'sri-falloff.xml'),
                                         'sri-falloff.cti')
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6])
 
     def test_chemically_activated(self):
         name = 'chemically-activated-reaction'
-        convertMech('../data/{0}.inp'.format(name),
-                    outName='{0}.cti'.format(name), quiet=True)
+        convertMech(pjoin(self.test_data_dir, '{0}.inp'.format(name)),
+                    outName=pjoin(self.test_work_dir, '{0}.cti'.format(name)), quiet=True)
 
-        ref, gas = self.checkConversion('../data/{0}.xml'.format(name),
-                                        '{0}.cti'.format(name))
+        ref, gas = self.checkConversion(pjoin(self.test_data_dir, '{0}.xml'.format(name)),
+                                        pjoin(self.test_work_dir, '{0}.cti'.format(name)))
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6, 1e7])
 
     def test_explicit_third_bodies(self):
-        convertMech('../data/explicit-third-bodies.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='explicit-third-bodies.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'explicit-third-bodies.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'explicit-third-bodies.cti'), quiet=True)
 
         ref, gas = self.checkConversion('explicit-third-bodies.cti',
-                                        '../data/explicit-third-bodies.xml')
+                                        pjoin(self.test_data_dir, 'explicit-third-bodies.xml'))
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6])
 
     def test_explicit_reverse_rate(self):
-        convertMech('../data/explicit-reverse-rate.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='explicit-reverse-rate.cti', quiet=True)
-        ref, gas = self.checkConversion('../data/explicit-reverse-rate.xml',
+        convertMech(pjoin(self.test_data_dir, 'explicit-reverse-rate.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'explicit-reverse-rate.cti'), quiet=True)
+        ref, gas = self.checkConversion(pjoin(self.test_data_dir, 'explicit-reverse-rate.xml'),
                                         'explicit-reverse-rate.cti')
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6])
 
@@ -241,20 +242,20 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.assertEqual(list(Rstoich[:,1]), list(Pstoich[:,0]))
 
     def test_explicit_forward_order(self):
-        convertMech('../data/explicit-forward-order.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='explicit-forward-order.cti', quiet=True)
-        ref, gas = self.checkConversion('../data/explicit-forward-order.xml',
+        convertMech(pjoin(self.test_data_dir, 'explicit-forward-order.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'explicit-forward-order.cti'), quiet=True)
+        ref, gas = self.checkConversion(pjoin(self.test_data_dir, 'explicit-forward-order.xml'),
                                         'explicit-forward-order.cti')
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6])
 
     def test_reaction_units(self):
-        convertMech('../data/units-default.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='units-default.cti', quiet=True)
-        convertMech('../data/units-custom.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='units-custom.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'units-default.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'units-default.cti'), quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'units-custom.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'units-custom.cti'), quiet=True)
 
         default, custom = self.checkConversion('units-default.cti',
                                                'units-custom.cti')
@@ -262,9 +263,9 @@ class chemkinConverterTest(utilities.CanteraTest):
                            [300, 800, 1450, 2800], [5e3, 1e5, 2e6], 1e-7)
 
     def test_float_stoich_coeffs(self):
-        convertMech('../data/float-stoich.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='float-stoich.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'float-stoich.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'float-stoich.cti'), quiet=True)
         gas = ct.Solution('float-stoich.cti')
 
         R = gas.reactant_stoich_coeffs()
@@ -275,27 +276,27 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.assertArrayNear(P[:,1], [0, 0.33, 1.67, 0])
 
     def test_photon(self):
-        convertMech('../data/photo-reaction.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='photo-reaction.cti', quiet=True,
+        convertMech(pjoin(self.test_data_dir, 'photo-reaction.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'photo-reaction.cti'), quiet=True,
                     permissive=True)
 
-        ref, gas = self.checkConversion('../data/photo-reaction.xml',
+        ref, gas = self.checkConversion(pjoin(self.test_data_dir, 'photo-reaction.xml'),
                                         'photo-reaction.cti')
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6])
 
     def test_transport_normal(self):
-        convertMech('../../data/inputs/h2o2.inp',
-                    transportFile='../../data/transport/gri30_tran.dat',
-                    outName='h2o2_transport_normal.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'h2o2.inp'),
+                    transportFile=pjoin(self.test_data_dir, 'gri30_tran.dat'),
+                    outName=pjoin(self.test_work_dir, 'h2o2_transport_normal.cti'), quiet=True)
 
         gas = ct.Solution('h2o2_transport_normal.cti')
         gas.TPX = 300, 101325, 'H2:1.0, O2:1.0'
         self.assertAlmostEqual(gas.thermal_conductivity, 0.07663, 4)
 
     def test_transport_embedded(self):
-        convertMech('../data/with-transport.inp',
-                    outName='with-transport.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'with-transport.inp'),
+                    outName=pjoin(self.test_work_dir, 'with-transport.cti'), quiet=True)
 
         gas = ct.Solution('with-transport.cti')
         gas.X = [0.2, 0.3, 0.5]
@@ -305,34 +306,34 @@ class chemkinConverterTest(utilities.CanteraTest):
 
     def test_transport_missing_species(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../../data/inputs/h2o2.inp',
-                        transportFile='../data/h2o2-missing-species-tran.dat',
-                        outName='h2o2_transport_missing_species.cti',
+            convertMech(pjoin(self.test_data_dir, 'h2o2.inp'),
+                        transportFile=pjoin(self.test_data_dir, 'h2o2-missing-species-tran.dat'),
+                        outName=pjoin(self.test_work_dir, 'h2o2_transport_missing_species.cti'),
                         quiet=True)
 
     def test_transport_duplicate_species(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../../data/inputs/h2o2.inp',
-                        transportFile='../data/h2o2-duplicate-species-tran.dat',
-                        outName='h2o2_transport_duplicate_species.cti',
+            convertMech(pjoin(self.test_data_dir, 'h2o2.inp'),
+                        transportFile=pjoin(self.test_data_dir, 'h2o2-duplicate-species-tran.dat'),
+                        outName=pjoin(self.test_work_dir, 'h2o2_transport_duplicate_species.cti'),
                         quiet=True)
 
-        convertMech('../../data/inputs/h2o2.inp',
-                    transportFile='../data/h2o2-duplicate-species-tran.dat',
-                    outName='h2o2_transport_duplicate_species.cti',
+        convertMech(pjoin(self.test_data_dir, 'h2o2.inp'),
+                    transportFile=pjoin(self.test_data_dir, 'h2o2-duplicate-species-tran.dat'),
+                    outName=pjoin(self.test_work_dir, 'h2o2_transport_duplicate_species.cti'),
                     quiet=True,
                     permissive=True)
 
     def test_transport_bad_geometry(self):
         with self.assertRaises(ck2cti.InputParseError):
-            convertMech('../../data/inputs/h2o2.inp',
-                        transportFile='../data/h2o2-bad-geometry-tran.dat',
-                        outName='h2o2_transport_bad_geometry.cti',
+            convertMech(pjoin(self.test_data_dir, 'h2o2.inp'),
+                        transportFile=pjoin(self.test_data_dir, 'h2o2-bad-geometry-tran.dat'),
+                        outName=pjoin(self.test_work_dir, 'h2o2_transport_bad_geometry.cti'),
                         quiet=True)
 
     def test_empty_reaction_section(self):
-        convertMech('../data/h2o2_emptyReactions.inp',
-                    outName='h2o2_emptyReactions.cti',
+        convertMech(pjoin(self.test_data_dir, 'h2o2_emptyReactions.inp'),
+                    outName=pjoin(self.test_work_dir, 'h2o2_emptyReactions.cti'),
                     quiet=True)
 
         gas = ct.Solution('h2o2_emptyReactions.cti')
@@ -340,26 +341,26 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.assertEqual(gas.n_reactions, 0)
 
     def test_reaction_comments1(self):
-        convertMech('../data/pdep-test.inp',
-                    outName='pdep_test.cti', quiet=True)
-        with open('pdep_test.cti') as f:
+        convertMech(pjoin(self.test_data_dir, 'pdep-test.inp'),
+                    outName=pjoin(self.test_work_dir, 'pdep_test.cti'), quiet=True)
+        with open(pjoin(self.test_work_dir, 'pdep_test.cti')) as f:
             text = f.read()
         self.assertIn('Generic mechanism header', text)
         self.assertIn('Single PLOG reaction', text)
         self.assertIn('PLOG with duplicate rates and negative A-factors', text)
 
     def test_reaction_comments2(self):
-        convertMech('../data/explicit-third-bodies.inp',
-                    thermoFile='../data/dummy-thermo.dat',
-                    outName='explicit_third_bodies.cti', quiet=True)
-        with open('explicit_third_bodies.cti') as f:
+        convertMech(pjoin(self.test_data_dir, 'explicit-third-bodies.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                    outName=pjoin(self.test_work_dir, 'explicit_third_bodies.cti'), quiet=True)
+        with open(pjoin(self.test_work_dir, 'explicit_third_bodies.cti')) as f:
             text = f.read()
         self.assertIn('An end of line comment', text)
         self.assertIn('A comment after the last reaction', text)
 
     def test_custom_element(self):
-        convertMech('../data/custom-elements.inp',
-                    outName='custom-elements.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'custom-elements.inp'),
+                    outName=pjoin(self.test_work_dir, 'custom-elements.cti'), quiet=True)
         gas = ct.Solution('custom-elements.cti')
         self.assertEqual(gas.n_elements, 4)
         self.assertNear(gas.atomic_weight(2), 13.003)
@@ -368,9 +369,9 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.assertEqual(gas.n_atoms('CC', 'Ci'), 1)
 
     def test_surface_mech(self):
-        convertMech('../data/surface1-gas.inp',
-                    surfaceFile='../data/surface1.inp',
-                    outName='surface1.cti', quiet=True)
+        convertMech(pjoin(self.test_data_dir, 'surface1-gas.inp'),
+                    surfaceFile=pjoin(self.test_data_dir, 'surface1.inp'),
+                    outName=pjoin(self.test_work_dir, 'surface1.cti'), quiet=True)
 
         gas = ct.Solution('surface1.cti', 'gas')
         surf = ct.Interface('surface1.cti', 'PT_SURFACE', [gas])
@@ -404,7 +405,7 @@ class chemkinConverterTest(utilities.CanteraTest):
 class CtmlConverterTest(utilities.CanteraTest):
     def test_sofc(self):
         gas_a, anode_bulk, oxide_a = ct.import_phases(
-            '../../interfaces/cython/cantera/examples/surface_chemistry/sofc.cti',
+            'sofc.cti',
             ['gas', 'metal', 'oxide_bulk'])
 
         self.assertNear(gas_a.P, ct.one_atm)
@@ -418,24 +419,24 @@ class CtmlConverterTest(utilities.CanteraTest):
         self.assertNear(face.site_density, 3e-8)
 
     def test_pdep(self):
-        gas = ct.Solution('../data/pdep-test.cti')
+        gas = ct.Solution('pdep-test.cti')
         self.assertEqual(gas.n_reactions, 6)
 
     def test_invalid(self):
         try:
-            gas = ct.Solution('../data/invalid.cti')
+            gas = ct.Solution('invalid.cti')
         except ct.CanteraError as e:
             err = e
 
         self.assertIn('already contains', err.args[0])
 
     def test_noninteger_atomicity(self):
-        gas = ct.Solution('../data/noninteger-atomicity.cti')
+        gas = ct.Solution('noninteger-atomicity.cti')
         self.assertNear(gas.molecular_weights[gas.species_index('CnHm')],
                         10.65*gas.atomic_weight('C') + 21.8*gas.atomic_weight('H'))
 
     def test_reaction_orders(self):
-        gas = ct.Solution('../data/reaction-orders.cti')
+        gas = ct.Solution('reaction-orders.cti')
         R = gas.reaction(0)
         self.assertTrue(R.allow_nonreactant_orders)
         self.assertNear(R.orders.get('OH'), 0.15)

--- a/interfaces/cython/cantera/test/test_equilibrium.py
+++ b/interfaces/cython/cantera/test/test_equilibrium.py
@@ -1,13 +1,13 @@
 from __future__ import division
 
 import unittest
-import os
-import warnings
+from os.path import join as pjoin
 
 import numpy as np
 
 import cantera as ct
 from . import utilities
+
 
 class EquilTestCases(object):
     def __init__(self, solver):
@@ -15,7 +15,7 @@ class EquilTestCases(object):
 
     def check(self, gas, **moles):
         nTotal = sum(moles.values())
-        for name,X in moles.items():
+        for name, X in moles.items():
             self.assertAlmostEqual(gas[name].X[0], X/nTotal)
 
     def test_equil_complete_stoichiometric(self):
@@ -135,14 +135,11 @@ class VCS_EquilTest(EquilTestCases, utilities.CanteraTest):
 
 class TestKOH_Equil(utilities.CanteraTest):
     "Test roughly based on examples/multiphase/plasma_equilibrium.py"
-    @classmethod
-    def setUpClass(cls):
-        cls.phases = ct.import_phases('KOH.xml',
+    def setUp(self):
+        self.phases = ct.import_phases('KOH.xml',
                 ['K_solid', 'K_liquid', 'KOH_a', 'KOH_b', 'KOH_liquid',
                  'K2O2_solid', 'K2O_solid', 'KO2_solid', 'ice', 'liquid_water',
                  'KOH_plasma'])
-
-    def setUp(self):
         self.mix = ct.Mixture(self.phases)
 
     def test_equil_TP(self):
@@ -158,7 +155,7 @@ class TestKOH_Equil(utilities.CanteraTest):
 
             data[i,1:] = self.mix.species_moles
 
-        self.compare(data, '../data/koh-equil-TP.csv')
+        self.compare(data, pjoin(self.test_data_dir, 'koh-equil-TP.csv'))
 
     def test_equil_HP(self):
         temperatures = range(350, 5000, 300)
@@ -181,18 +178,17 @@ class TestKOH_Equil(utilities.CanteraTest):
             data[i,1] = self.mix.T # equilibrated temperature
             data[i,2:] = self.mix.species_moles
 
-        self.compare(data, '../data/koh-equil-HP.csv')
+        self.compare(data, pjoin(self.test_data_dir, 'koh-equil-HP.csv'))
 
 
 class TestEquil_GasCarbon(utilities.CanteraTest):
     "Test rougly based on examples/multiphase/adiabatic.py"
-    @classmethod
-    def setUpClass(cls):
-        cls.gas = ct.Solution('gri30.xml')
-        cls.carbon = ct.Solution('graphite.xml')
-        cls.fuel = 'CH4'
-        cls.mix_phases = [(cls.gas, 1.0), (cls.carbon, 0.0)]
-        cls.n_species = cls.gas.n_species + cls.carbon.n_species
+    def setUp(self):
+        self.gas = ct.Solution('gri30.xml')
+        self.carbon = ct.Solution('graphite.xml')
+        self.fuel = 'CH4'
+        self.mix_phases = [(self.gas, 1.0), (self.carbon, 0.0)]
+        self.n_species = self.gas.n_species + self.carbon.n_species
 
     def solve(self, solver, **kwargs):
         n_points = 12
@@ -212,7 +208,7 @@ class TestEquil_GasCarbon(utilities.CanteraTest):
             data[i,:2] = (phi[i], mix.T)
             data[i,2:] = mix.species_moles
 
-        self.compare(data, '../data/gas-carbon-equil.csv')
+        self.compare(data, pjoin(self.test_data_dir, 'gas-carbon-equil.csv'))
 
     def test_gibbs(self):
         self.solve('gibbs')

--- a/interfaces/cython/cantera/test/test_mixture.py
+++ b/interfaces/cython/cantera/test/test_mixture.py
@@ -1,13 +1,13 @@
-import unittest
 import cantera as ct
 from . import utilities
 
 
 class TestMixture(utilities.CanteraTest):
     @classmethod
-    def setUpClass(cls):
-        cls.phase1 = ct.Solution('h2o2.xml')
-        cls.phase2 = ct.Solution('air.xml')
+    def setUpClass(self):
+        utilities.CanteraTest.setUpClass()
+        self.phase1 = ct.Solution('h2o2.xml')
+        self.phase2 = ct.Solution('air.xml')
 
     def setUp(self):
         self.mix = ct.Mixture([(self.phase1, 1.0), (self.phase2, 2.0)])
@@ -190,5 +190,5 @@ class TestMixture(utilities.CanteraTest):
 
     def test_invalid_phase_type(self):
         water = ct.Water()
-        with self.assertRaises(Exception):
+        with self.assertRaises(ct.CanteraError):
             self.mix = ct.Mixture([(self.phase1, 1.0), (water, 2.0)])

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -2,6 +2,7 @@ import cantera as ct
 from . import utilities
 import numpy as np
 import os
+from os.path import join as pjoin
 
 
 class TestOnedim(utilities.CanteraTest):
@@ -94,7 +95,7 @@ class TestOnedim(utilities.CanteraTest):
         # Some things don't work until the domains have been added to a Sim1D
         sim = ct.Sim1D((left, flame, right))
 
-        with self.assertRaises(Exception):
+        with self.assertRaises(ct.CanteraError):
             flame.set_steady_tolerances(foobar=(3e-4, 3e-6))
 
         flame.set_steady_tolerances(default=(5e-3, 5e-5),
@@ -160,7 +161,7 @@ class TestFreeFlame(utilities.CanteraTest):
         # Test that the adiabatic flame temperature and species profiles
         # converge to the correct equilibrium values as the grid is refined
 
-        reactants= 'H2:1.1, O2:1, AR:5'
+        reactants = 'H2:1.1, O2:1, AR:5'
         p = ct.one_atm
         Tin = 300
 
@@ -192,7 +193,7 @@ class TestFreeFlame(utilities.CanteraTest):
             self.assertLess(abs(X3[k]-Xad[k]), abs(X2[k]-Xad[k]))
 
     def run_mix(self, phi, T, width, p, refine):
-        reactants = {'H2': phi, 'O2':0.5, 'AR': 2}
+        reactants = {'H2': phi, 'O2': 0.5, 'AR': 2}
         self.create_sim(p * ct.one_atm, T, reactants, width)
         self.solve_mix(refine=refine)
 
@@ -228,7 +229,7 @@ class TestFreeFlame(utilities.CanteraTest):
 
     # @utilities.unittest.skip('sometimes slow')
     def test_multicomponent(self):
-        reactants= 'H2:1.1, O2:1, AR:5.3'
+        reactants = 'H2:1.1, O2:1, AR:5.3'
         p = ct.one_atm
         Tin = 300
 
@@ -265,7 +266,7 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.soret_enabled = True
 
     def test_prune(self):
-        reactants= 'H2:1.1, O2:1, AR:5'
+        reactants = 'H2:1.1, O2:1, AR:5'
         p = ct.one_atm
         Tin = 300
 
@@ -283,13 +284,13 @@ class TestFreeFlame(utilities.CanteraTest):
         # residual satisfies the error tolerances) on the new grid.
 
     def test_save_restore(self):
-        reactants= 'H2:1.1, O2:1, AR:5'
+        reactants = 'H2:1.1, O2:1, AR:5'
         p = 2 * ct.one_atm
         Tin = 400
 
         self.create_sim(p, Tin, reactants)
         self.solve_fixed_T()
-        filename = 'onedim-fixed-T{0}.xml'.format(utilities.python_version)
+        filename = pjoin(self.test_work_dir, 'onedim-fixed-T{0}.xml'.format(utilities.python_version))
         if os.path.exists(filename):
             os.remove(filename)
 
@@ -346,11 +347,11 @@ class TestFreeFlame(utilities.CanteraTest):
                 getattr(self.sim, attr)
 
     def test_save_restore_add_species(self):
-        reactants= 'H2:1.1, O2:1, AR:5'
+        reactants = 'H2:1.1, O2:1, AR:5'
         p = 2 * ct.one_atm
         Tin = 400
 
-        filename = 'onedim-add-species{0}.xml'.format(utilities.python_version)
+        filename = pjoin(self.test_work_dir, 'onedim-add-species{0}.xml'.format(utilities.python_version))
         if os.path.exists(filename):
             os.remove(filename)
 
@@ -374,11 +375,11 @@ class TestFreeFlame(utilities.CanteraTest):
             self.assertArrayNear(Y1[k1], Y2[k2])
 
     def test_save_restore_remove_species(self):
-        reactants= 'H2:1.1, O2:1, AR:5'
+        reactants = 'H2:1.1, O2:1, AR:5'
         p = 2 * ct.one_atm
         Tin = 400
 
-        filename = 'onedim-add-species{0}.xml'.format(utilities.python_version)
+        filename = pjoin(self.test_work_dir, 'onedim-add-species{0}.xml'.format(utilities.python_version))
         if os.path.exists(filename):
             os.remove(filename)
 
@@ -402,7 +403,7 @@ class TestFreeFlame(utilities.CanteraTest):
             self.assertArrayNear(Y1[k1], Y2[k2])
 
     def test_write_csv(self):
-        filename = 'onedim-write_csv{0}.csv'.format(utilities.python_version)
+        filename = pjoin(self.test_work_dir, 'onedim-write_csv{0}.csv'.format(utilities.python_version))
         if os.path.exists(filename):
             os.remove(filename)
 
@@ -421,7 +422,7 @@ class TestFreeFlame(utilities.CanteraTest):
 
         self.sim.set_refine_criteria(*good)
         for i in range(4):
-            with self.assertRaises(Exception):
+            with self.assertRaises(ct.CanteraError):
                 vals = list(good)
                 vals[i] = bad[i]
                 self.sim.set_refine_criteria(*vals)
@@ -489,7 +490,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
         self.assertEqual(self.sim.transport_model, 'Mix')
 
     def test_mixture_averaged(self, saveReference=False):
-        referenceFile = '../data/DiffusionFlameTest-h2-mix.csv'
+        referenceFile = pjoin(self.test_data_dir, 'DiffusionFlameTest-h2-mix.csv')
         self.create_sim(p=ct.one_atm)
 
         nPoints = len(self.sim.grid)
@@ -514,11 +515,12 @@ class TestDiffusionFlame(utilities.CanteraTest):
             self.assertFalse(bad, bad)
 
     def test_auto(self, saveReference=False):
-        referenceFile = '../data/DiffusionFlameTest-h2-auto.csv'
+        referenceFile = pjoin(self.test_data_dir, 'DiffusionFlameTest-h2-auto.csv')
         self.create_sim(p=ct.one_atm, mdot_fuel=2, mdot_ox=3)
 
         nPoints = []
         timesteps = []
+
         def steady_func(x):
             nPoints.append(len(self.sim.T))
             return 0
@@ -579,7 +581,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
         self.run_extinction(mdot_fuel=0.2, mdot_ox=2.0, T_ox=600, width=0.2, P=0.05)
 
     def test_mixture_averaged_rad(self, saveReference=False):
-        referenceFile = '../data/DiffusionFlameTest-h2-mix-rad.csv'
+        referenceFile = pjoin(self.test_data_dir, 'DiffusionFlameTest-h2-mix-rad.csv')
         self.create_sim(p=ct.one_atm)
 
         nPoints = len(self.sim.grid)
@@ -644,7 +646,6 @@ class TestDiffusionFlame(utilities.CanteraTest):
 
 
 class TestCounterflowPremixedFlame(utilities.CanteraTest):
-    referenceFile = '../data/CounterflowPremixedFlame-h2-mix.csv'
     # Note: to re-create the reference file:
     # (1) set PYTHONPATH to build/python2 or build/python3.
     # (2) Start Python in the test/work directory and run:
@@ -687,10 +688,11 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
         data[:,3] = sim.T
         data[:,4:] = sim.Y.T
 
+        referenceFile = pjoin(self.test_data_dir, 'CounterflowPremixedFlame-h2-mix.csv')
         if saveReference:
-            np.savetxt(self.referenceFile, data, '%11.6e', ', ')
+            np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = utilities.compareProfiles(self.referenceFile, data,
+            bad = utilities.compareProfiles(referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
             self.assertFalse(bad, bad)
 
@@ -721,6 +723,7 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
     def test_solve_case5(self):
         self.run_case(phi=2.0, T=300, width=0.2, P=0.2)
 
+
 class TestBurnerFlame(utilities.CanteraTest):
     def solve(self, phi, T, width, P):
         gas = ct.Solution('h2o2.xml')
@@ -749,8 +752,8 @@ class TestBurnerFlame(utilities.CanteraTest):
 class TestImpingingJet(utilities.CanteraTest):
     def run_reacting_surface(self, xch4, tsurf, mdot, width):
         # Simplified version of the example 'catalytic_combustion.py'
-        gas = ct.Solution('../data/ptcombust-simple.cti', 'gas')
-        surf_phase = ct.Interface('../data/ptcombust-simple.cti',
+        gas = ct.Solution('ptcombust-simple.cti', 'gas')
+        surf_phase = ct.Interface('ptcombust-simple.cti',
                                   'Pt_surf', [gas])
 
         tinlet = 300.0  # inlet temperature

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -64,11 +64,11 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertNear(self.water.X, 0.8)
 
         self.water.TP = 650, 101325
-        with self.assertRaises(Exception):
+        with self.assertRaises(ct.CanteraError):
             self.water.X = 0.1
 
         self.water.TP = 300, 101325
-        with self.assertRaises(Exception):
+        with self.assertRaises(ValueError):
             self.water.X = 0.3
 
     def test_set_minmax(self):

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -1,5 +1,7 @@
 import math
 import re
+from os.path import join as pjoin
+import os
 
 import numpy as np
 from .utilities import unittest
@@ -44,9 +46,9 @@ class TestReactor(utilities.CanteraTest):
 
     def test_insert(self):
         R = self.reactorClass()
-        with self.assertRaises(Exception):
+        with self.assertRaises(ct.CanteraError):
             R.T
-        with self.assertRaises(Exception):
+        with self.assertRaises(ct.CanteraError):
             R.kinetics.net_production_rates
 
         g = ct.Solution('h2o2.xml')
@@ -425,7 +427,6 @@ class TestReactor(utilities.CanteraTest):
             self.assertNear(m1a+m2a, m1+m2)
             self.assertArrayNear(self.r1.Y, Y1)
 
-
     def test_valve3(self):
         # This case specifies a non-linear relationship between pressure drop
         # and flow rate.
@@ -439,6 +440,7 @@ class TestReactor(utilities.CanteraTest):
         Y1 = self.r1.Y
         kO2 = self.gas1.species_index('O2')
         kAr = self.gas1.species_index('AR')
+
         def speciesMass(k):
             return self.r1.Y[k] * self.r1.mass + self.r2.Y[k] * self.r2.mass
         mO2 = speciesMass(kO2)
@@ -917,8 +919,8 @@ class TestSurfaceKinetics(utilities.CanteraTest):
         surf1.coverages = C
         self.assertArrayNear(surf1.coverages, C)
         data = []
-        test_file = 'test_coverages_regression1.csv'
-        reference_file = '../data/WallKinetics-coverages-regression1.csv'
+        test_file = pjoin(self.test_work_dir, 'test_coverages_regression1.csv')
+        reference_file = pjoin(self.test_data_dir, 'WallKinetics-coverages-regression1.csv')
         data = []
         for t in np.linspace(1e-6, 1e-3):
             self.net.advance(t)
@@ -942,8 +944,8 @@ class TestSurfaceKinetics(utilities.CanteraTest):
         surf.coverages = C
         self.assertArrayNear(surf.coverages, C)
         data = []
-        test_file = 'test_coverages_regression2.csv'
-        reference_file = '../data/WallKinetics-coverages-regression2.csv'
+        test_file = pjoin(self.test_work_dir, 'test_coverages_regression2.csv')
+        reference_file = pjoin(self.test_data_dir, 'WallKinetics-coverages-regression2.csv')
         data = []
         for t in np.linspace(1e-6, 1e-3):
             self.net.advance(t)
@@ -1281,8 +1283,8 @@ class CombustorTestImplementation(object):
     consistent output.
     """
 
-    referenceFile = '../data/CombustorTest-integrateWithAdvance.csv'
     def setUp(self):
+        self.referenceFile = pjoin(os.path.dirname(__file__), 'data', 'CombustorTest-integrateWithAdvance.csv')
         self.gas = ct.Solution('h2o2.xml')
 
         # create a reservoir for the fuel inlet, and set to pure methane.
@@ -1369,8 +1371,8 @@ class WallTestImplementation(object):
     consistent output.
     """
 
-    referenceFile = '../data/WallTest-integrateWithAdvance.csv'
     def setUp(self):
+        self.referenceFile = pjoin(os.path.dirname(__file__), 'data', 'WallTest-integrateWithAdvance.csv')
         # reservoir to represent the environment
         self.gas0 = ct.Solution('air.xml')
         self.gas0.TP = 300, ct.one_atm

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -33,8 +33,8 @@ class TestTransport(utilities.CanteraTest):
         self.assertArrayNear(Dbin1, Dbin1.T)
 
     def test_multiComponent(self):
-        with self.assertRaises(AttributeError):
-            self.phase.Multi_diff_coeffs
+        with self.assertRaises(ct.CanteraError):
+            self.phase.multi_diff_coeffs
 
         self.assertArrayNear(self.phase.thermal_diff_coeffs,
                              np.zeros(self.phase.n_species))

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -1,8 +1,8 @@
-from .utilities import unittest
 import numpy as np
 
 import cantera as ct
 from . import utilities
+
 
 class TestTransport(utilities.CanteraTest):
     def setUp(self):
@@ -33,7 +33,7 @@ class TestTransport(utilities.CanteraTest):
         self.assertArrayNear(Dbin1, Dbin1.T)
 
     def test_multiComponent(self):
-        with self.assertRaises(Exception):
+        with self.assertRaises(AttributeError):
             self.phase.Multi_diff_coeffs
 
         self.assertArrayNear(self.phase.thermal_diff_coeffs,
@@ -181,6 +181,7 @@ class TestDustyGas(utilities.CanteraTest):
 class TestTransportData(utilities.CanteraTest):
     @classmethod
     def setUpClass(cls):
+        utilities.CanteraTest.setUpClass()
         cls.gas = ct.Solution('h2o2.xml')
         cls.gas.X = 'H2O:0.6, H2:0.4'
 

--- a/interfaces/cython/cantera/test/utilities.py
+++ b/interfaces/cython/cantera/test/utilities.py
@@ -2,11 +2,15 @@ import numpy as np
 import sys
 import os
 import warnings
+import shutil
+import tempfile
+import errno
+import cantera
 
 _ver = sys.version_info[:2]
 python_version = str(_ver[0])
 
-if  _ver < (2,7) or (3,0) <= _ver < (3,2):
+if _ver < (2,7) or (3,0) <= _ver < (3,2):
     # unittest2 is a backport of the new features added to the unittest
     # testing framework in Python 2.7 and Python 3.2. See
     # https://pypi.python.org/pypi/unittest2 (for Python 2.x)
@@ -17,6 +21,41 @@ else:
 
 
 class CanteraTest(unittest.TestCase):
+    @classmethod
+    def setUpClass(cls):
+        # Create a working directory for output files. If this is
+        # an in-source test, create the directory in the root
+        # test/work directory. Otherwise, create a system level
+        # temporary directory
+        root_dir = os.path.abspath(os.path.join(os.path.dirname(__file__),
+                                                '..', '..', '..', '..'))
+        if os.path.exists(os.path.join(root_dir, 'SConstruct')):
+            cls.test_work_dir = os.path.join(root_dir, 'test', 'work',
+                                             'python{}'.format(python_version))
+            try:
+                os.makedirs(cls.test_work_dir)
+            except OSError as e:
+                if e.errno == errno.EEXIST:
+                    pass
+                elif e.errno == errno.EACCES:
+                    cls.test_work_dir = tempfile.mkdtemp()
+                else:
+                    raise
+        else:
+            cls.test_work_dir = tempfile.mkdtemp()
+
+        cantera.add_directory(cls.test_work_dir)
+        cls.test_data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
+
+    @classmethod
+    def tearDownClass(cls):
+        # Remove the working directory after testing, but only if its a temp directory
+        if tempfile.tempdir is not None:
+            try:
+                shutil.rmtree(cls.test_work_dir)
+            except OSError:
+                pass
+
     def assertNear(self, a, b, rtol=1e-8, atol=1e-12, msg=None):
         cmp = 2 * abs(a - b)/(abs(a) + abs(b) + 2 * atol / rtol)
         if cmp > rtol:


### PR DESCRIPTION
This is a rewrite of #376. The implementation is very similar, relying on a temp directory to store working files, instead of a user directory. I thought about using in-memory only files, but ck2cti expects a string instead of a file handle, so that wouldn't work. 

I preferred to implement the working directories as attributes of the `CanteraTest` class, instead of a module-level method in `utilities`. This required using `super().setUpClass()` in a few places where `setUpClass` was used in a derived class. This requirement is somewhat unfortunate, and could be alleviated by moving the derived `setUpClass` methods' into a `setUp` method, but this would cause the `setUp` method to be run for each test, typically creating a new `Solution` for each test. This could be slow, although the mechanisms we're using tend to be small, so the time hit shouldn't matter very much. Feedback is appreciated on this point.