### PR TITLE
Add max grid points

### DIFF
--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -133,7 +133,20 @@ public:
      */
     void setRefineCriteria(int dom = -1, doublereal ratio = 10.0,
                            doublereal slope = 0.8, doublereal curve = 0.8, doublereal prune = -0.1);
+
+    /**
+     * Set the maximum number of grid points in the domain. If dom >= 0,
+     * then the settings apply only to the specified domain. If dom < 0,
+     * the settings are applied to each domain.  @see Refiner::setMaxPoints.
+     */
     void setMaxGridPoints(int dom = -1, int npoints = 300);
+
+    /**
+     * Get the maximum number of grid points in this domain. @see Refiner::maxPoints
+     *
+     * @param dom domain number, beginning with 0 for the leftmost domain.
+     */
+    size_t maxGridPoints(size_t dom);
 
     //! Set the minimum grid spacing in the specified domain(s).
     /*!

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -139,7 +139,7 @@ public:
      * then the settings apply only to the specified domain. If dom < 0,
      * the settings are applied to each domain.  @see Refiner::setMaxPoints.
      */
-    void setMaxGridPoints(int dom = -1, int npoints = 300);
+    void setMaxGridPoints(int dom, int npoints);
 
     /**
      * Get the maximum number of grid points in this domain. @see Refiner::maxPoints

--- a/include/cantera/oneD/refine.h
+++ b/include/cantera/oneD/refine.h
@@ -45,6 +45,11 @@ public:
         m_npmax = npmax;
     }
 
+    //! Returns the maximum number of points allowed in the domain
+    size_t maxPoints() const {
+        return m_npmax;
+    }
+
     //! Set the minimum allowable spacing between adjacent grid points [m].
     void setGridMin(double gridmin) {
         m_gridmin = gridmin;

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -728,6 +728,8 @@ cdef extern from "cantera/oneD/Sim1D.h":
         void setTimeStepFactor(double)
         void setMinTimeStep(double)
         void setMaxTimeStep(double)
+        void setMaxGridPoints(int, size_t) except +translate_exception
+        size_t maxGridPoints(size_t) except +translate_exception
         void setGridMin(int, double) except +translate_exception
         void setFixedTemperature(double)
         void setInterrupt(CxxFunc1*) except +translate_exception

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -74,6 +74,18 @@ class FlameBase(Sim1D):
                                            values)
 
     @property
+    def max_grid_points(self):
+        """
+        Get/Set the maximum number of grid points used in the solution of
+        this flame.
+        """
+        return super(FlameBase, self).get_max_grid_points(self.flame)
+
+    @max_grid_points.setter
+    def max_grid_points(self, npmax):
+        super(FlameBase, self).set_max_grid_points(self.flame, npmax)
+
+    @property
     def transport_model(self):
         """
         Get/Set the transport model used by the `Solution` object used for this

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -1092,5 +1092,15 @@ cdef class Sim1D:
         def __get__(self):
             return self.sim.timeStepStats()
 
+    def set_max_grid_points(self, domain, npmax):
+        """ Set the maximum number of grid points in the specified domain. """
+        idom = self.domain_index(domain)
+        self.sim.setMaxGridPoints(idom, npmax)
+
+    def get_max_grid_points(self, domain):
+        """ Get the maximum number of grid points in the specified domain. """
+        idom = self.domain_index(domain)
+        return self.sim.maxGridPoints(idom)
+
     def __dealloc__(self):
         del self.sim

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -838,6 +838,9 @@ cdef class Sim1D:
 
         for N in nPoints:
             for i,D in enumerate(flow_domains):
+                if N > self.get_max_grid_points(D):
+                    raise CanteraError('Maximum number of grid points exceeded')
+
                 if N != len(D.grid):
                     D.grid = np.linspace(zmin[i], zmax[i], N)
 

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -442,6 +442,20 @@ class TestFreeFlame(utilities.CanteraTest):
         self.solve_fixed_T()
         self.assertNear(self.sim.u[-1], ub, 1e-2)
 
+    def test_exceed_max_grid_points(self):
+        self.create_sim(ct.one_atm, 400.0, 'H2:1.1, O2:1, AR:5')
+        # Set the maximum grid points to be a low number that should
+        # be exceeded by the refinement
+        self.sim.max_grid_points = 10
+        with self.assertRaises(ct.CanteraError):
+            self.sim.solve(loglevel=0, refine_grid=True)
+
+    def test_set_max_grid_points(self):
+        self.create_sim(ct.one_atm, 400.0, 'H2:1.1, O2:1, AR:5')
+        self.assertEqual(self.sim.max_grid_points, 1000)
+        self.sim.max_grid_points = 10
+        self.assertEqual(self.sim.max_grid_points, 10)
+
 
 class TestDiffusionFlame(utilities.CanteraTest):
     # Note: to re-create the reference file:

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -709,7 +709,9 @@ class TestThermo(utilities.CanteraTest):
         self.assertTrue(self.gas.T > self.gas.max_temp)
 
     def test_volume(self):
-        """ This phase should follow the ideal gas law """
+        """
+        This phase should follow the ideal gas law
+        """
         g = self.gas
         self.assertNear(g.P, g.density_mole * ct.gas_constant * g.T)
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -555,6 +555,12 @@ void Sim1D::setMaxGridPoints(int dom, int npoints)
     }
 }
 
+size_t Sim1D::maxGridPoints(size_t dom)
+{
+    Refiner& r = domain(dom).refiner();
+    return r.maxPoints();
+}
+
 doublereal Sim1D::jacobian(int i, int j)
 {
     return OneDim::jacobian().value(i,j);

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -331,10 +331,6 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                 saveResidual("debug_sim1d.xml", "residual",
                              "After regridding");
             }
-            if (new_points < 0) {
-                writelog("Maximum number of grid points reached.");
-                new_points = 0;
-            }
         } else {
             debuglog("grid refinement disabled.\n", loglevel);
             new_points = 0;

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -12,7 +12,7 @@ namespace Cantera
 {
 Refiner::Refiner(Domain1D& domain) :
     m_ratio(10.0), m_slope(0.8), m_curve(0.8), m_prune(-0.001),
-    m_min_range(0.01), m_domain(&domain), m_npmax(3000),
+    m_min_range(0.01), m_domain(&domain), m_npmax(1000),
     m_gridmin(1e-10)
 {
     m_nv = m_domain->nComponents();

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -47,8 +47,7 @@ int Refiner::analyze(size_t n, const doublereal* z,
                      const doublereal* x)
 {
     if (n >= m_npmax) {
-        writelog("max number of grid points reached ({}).\n", m_npmax);
-        return -2;
+        throw CanteraError("Refiner::analyze", "max number of grid points reached ({}).", m_npmax);
     }
 
     if (m_domain->nPoints() <= 1) {
@@ -66,7 +65,7 @@ int Refiner::analyze(size_t n, const doublereal* z,
 
     // check consistency
     if (n != m_domain->nPoints()) {
-        throw CanteraError("analyze","inconsistent");
+        throw CanteraError("Refiner::analyze", "inconsistent");
     }
 
     // find locations where cell size ratio is too large.


### PR DESCRIPTION
Add an interface to get/set the maximum number of grid points of a 1D simulation. I made two major changes (besides adding the interface) here:

1. Change the default maximum number of grid points from 3000 to 500. In my experience 3000 is way too high for the max grid points, and 500 should be more than enough for most reasonable cases.
2. Exceeding the maximum number of grid points now throws an error. Previously, it only printed a message to the logfile and the solver exited smoothly, which implied that the solution was correct. However, if you've exceeded your max grid points, you haven't reached your refinement criteria, so the problem isn't solved.

I also changed the auto solver a bit, so that only one solve was called per try block. This way, we can handle each failure as it occurs. There was also a missing `solved=False` that I added.