### PR TITLE
Zero explicit reverse rates are not included in CTI files

### DIFF
--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -90,7 +90,7 @@ def compatible_quantities(quantity_basis, units):
     elif quantity_basis == 'molec':
         return 'molec' in units or 'mol' not in units
     else:
-        raise Exception('Unknown quantity basis: "{0}"'.format(quantity_basis))
+        raise ValueError('Unknown quantity basis: "{0}"'.format(quantity_basis))
 
 
 class InputParseError(Exception):

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -40,7 +40,6 @@ import numpy as np
 import re
 import itertools
 import getopt
-import sys
 
 QUANTITY_UNITS = {'MOL': 'mol',
                   'MOLE': 'mol',

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -891,13 +891,6 @@ def fortFloat(s):
     s = s.replace('E ', 'E+').replace('e ', 'e+')
     return float(s)
 
-def isnumberlike(text):
-    """ Returns true if `text` can be interpreted as a floating point number. """
-    try:
-        float(text)
-        return True
-    except ValueError:
-        return False
 
 def get_index(seq, value):
     """

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -1724,10 +1724,12 @@ class Parser(object):
                                 try:
                                     label, thermo, comp, note = self.readThermoEntry(thermo, TintDefault)
                                 except Exception as e:
-                                    print('Error while reading thermo entry '
-                                        'starting on line {0}:\n"""\n{1}\n"""'.format(
-                                            self.line_number-len(current)+1,
-                                            ''.join(current).rstrip()))
+                                    error_line_number = self.line_number - len(current) + 1
+                                    error_entry = ''.join(current).rstrip()
+                                    logging.error(
+                                        'Error while reading thermo entry starting on line {0}:\n'
+                                        '"""\n{1}\n"""'.format(error_line_number, error_entry)
+                                    )
                                     raise
 
                                 if label not in self.speciesDict:

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -1347,23 +1347,26 @@ class Parser(object):
             elif 'rev' in line.lower():
                 reaction.reversible = False
 
-                # Create a reaction proceeding in the opposite direction
-                revReaction = Reaction(reactants=reaction.products,
-                                       products=reaction.reactants,
-                                       thirdBody=reaction.thirdBody,
-                                       reversible=False)
                 tokens = tokens[1].split()
-                revReaction.kinetics = Arrhenius(
-                    A=(float(tokens[0].strip()), klow_units),
-                    b=float(tokens[1].strip()),
-                    Ea=(float(tokens[2].strip()), energy_units),
-                    T0=(1,"K"),
-                    parser=self
-                )
-                if thirdBody:
-                    revReaction.kinetics = ThirdBody(
-                        arrheniusHigh=revReaction.kinetics,
-                        parser=self)
+                # If the A factor in the rev line is zero, don't create the reverse reaction
+                if float(tokens[0].strip()) != 0.0:
+                    # Create a reaction proceeding in the opposite direction
+                    revReaction = Reaction(reactants=reaction.products,
+                                           products=reaction.reactants,
+                                           thirdBody=reaction.thirdBody,
+                                           reversible=False)
+
+                    revReaction.kinetics = Arrhenius(
+                        A=(float(tokens[0].strip()), klow_units),
+                        b=float(tokens[1].strip()),
+                        Ea=(float(tokens[2].strip()), energy_units),
+                        T0=(1,"K"),
+                        parser=self
+                    )
+                    if thirdBody:
+                        revReaction.kinetics = ThirdBody(
+                            arrheniusHigh=revReaction.kinetics,
+                            parser=self)
 
             elif 'ford' in line.lower():
                 tokens = tokens[1].split()

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -269,7 +269,7 @@ class Reaction(object):
 
     def _coeff_string(self, coeffs):
         L = []
-        for stoichiometry,species in coeffs:
+        for stoichiometry, species in coeffs:
             if stoichiometry != 1:
                 L.append('{0} {1}'.format(stoichiometry, species))
             else:
@@ -369,7 +369,7 @@ class KineticsModel(object):
 
     def efficiencyString(self):
         return ' '.join('{0}:{1}'.format(mol, eff)
-                        for mol,eff in self.efficiencies.items())
+                        for mol, eff in self.efficiencies.items())
 
 
 class KineticsData(KineticsModel):
@@ -489,7 +489,6 @@ class SurfaceArrhenius(Arrhenius):
 
         return s.rstrip()[:-1] + '])'
 
-
     def to_cti(self, reactantstr, arrow, productstr, indent=0):
         rxnstring = reactantstr + arrow + productstr
         return 'surface_reaction({0!r},{1})'.format(rxnstring, self.rateStr())
@@ -533,7 +532,7 @@ class PDepArrhenius(KineticsModel):
         lines = ['pdep_arrhenius({0!r},'.format(rxnstring)]
         prefix = ' '*(indent+15)
         template = '[({0}, {1!r}), {2.A[0]:e}, {2.b}, {2.Ea[0]}],'
-        for pressure,arrhenius in zip(self.pressures[0], self.arrhenius):
+        for pressure, arrhenius in zip(self.pressures[0], self.arrhenius):
             lines.append(prefix + template.format(pressure,
                                                   self.pressures[1],
                                                   arrhenius))
@@ -901,10 +900,11 @@ def get_index(seq, value):
     if isinstance(seq, string_types):
         seq = seq.split()
     value = value.lower().strip()
-    for i,item in enumerate(seq):
+    for i, item in enumerate(seq):
         if item.lower() == value:
             return i
     return None
+
 
 def contains(seq, value):
     if isinstance(seq, string_types):
@@ -924,17 +924,17 @@ class Surface(object):
 class Parser(object):
     def __init__(self):
         self.processed_units = False
-        self.energy_units = 'cal/mol' # for the current REACTIONS section
-        self.output_energy_units = 'cal/mol' # for the output file
-        self.quantity_units = 'mol' # for the current REACTIONS section
-        self.output_quantity_units = 'mol' # for the output file
+        self.energy_units = 'cal/mol'  # for the current REACTIONS section
+        self.output_energy_units = 'cal/mol'  # for the output file
+        self.quantity_units = 'mol'  # for the current REACTIONS section
+        self.output_quantity_units = 'mol'  # for the output file
         self.motz_wise = None
         self.warning_as_error = True
 
         self.elements = []
-        self.element_weights = {} # for custom elements only
-        self.speciesList = [] # bulk species only
-        self.speciesDict = {} # bulk and surface species
+        self.element_weights = {}  # for custom elements only
+        self.speciesList = []  # bulk species only
+        self.speciesDict = {}  # bulk and surface species
         self.surfaces = []
         self.reactions = []
         self.finalReactionComment = ''
@@ -1041,7 +1041,6 @@ class Parser(object):
             raise InputParseError("Error parsing elemental composition for "
                                   "species '{0}'".format(species))
 
-
         # Extract the NASA polynomial coefficients
         # Remember that the high-T polynomial comes first!
         Tmin = fortFloat(lines[0][45:55])
@@ -1063,8 +1062,6 @@ class Parser(object):
             coeffs_low = coeffs_high
         elif all(c == 0 for c in coeffs_high) and Tmax == Tint:
             coeffs_high = coeffs_low
-
-
 
         # Construct and return the thermodynamics model
         thermo = MultiNASA(
@@ -1130,7 +1127,7 @@ class Parser(object):
         # reaction string. Checking this character is necessary to correctly
         # identify species with names ending in '+' or '='.
         self.species_tokens = set()
-        for next_char in ('<','=','(','+','\n'):
+        for next_char in ('<', '=', '(', '+', '\n'):
             self.species_tokens.update(k + next_char for k in self.speciesDict)
         self.other_tokens = {'M': 'third-body', 'm': 'third-body',
                              '(+M)': 'falloff3b', '(+m)': 'falloff3b',
@@ -1217,17 +1214,17 @@ class Parser(object):
         products = []
         stoichiometry = 1
         lhs = True
-        for token,kind in [v for k,v in sorted(locs.items())]:
+        for token, kind in [v for k,v in sorted(locs.items())]:
             if kind == 'equal':
                 reversible = token in ('<=>', '=')
                 lhs = False
             elif kind == 'coeff':
                 stoichiometry = token
             elif lhs:
-                reactants.append((stoichiometry,token,kind))
+                reactants.append((stoichiometry, token, kind))
                 stoichiometry = 1
             else:
-                products.append((stoichiometry,token,kind))
+                products.append((stoichiometry, token, kind))
                 stoichiometry = 1
 
         if lhs is True:
@@ -1240,7 +1237,7 @@ class Parser(object):
             falloff3b = None
             thirdBody = False  # simple third body reaction (non-falloff)
             photon = False
-            for stoichiometry,species,kind in expression:
+            for stoichiometry, species, kind in expression:
                 if kind == 'third-body':
                     thirdBody = True
                 elif kind == 'falloff3b':
@@ -1289,7 +1286,7 @@ class Parser(object):
         # The rest of the first line contains Arrhenius parameters
         reaction_type = SurfaceArrhenius if surface else Arrhenius
         arrhenius = reaction_type(
-            A=(A,kunits),
+            A=(A, kunits),
             b=b,
             Ea=(Ea, energy_units),
             T0=(1,"K"),
@@ -1326,9 +1323,9 @@ class Parser(object):
                 # Low-pressure-limit Arrhenius parameters for "falloff" reaction
                 tokens = tokens[1].split()
                 arrheniusLow = Arrhenius(
-                    A=(float(tokens[0].strip()),klow_units),
+                    A=(float(tokens[0].strip()), klow_units),
                     b=float(tokens[1].strip()),
-                    Ea=(float(tokens[2].strip()),energy_units),
+                    Ea=(float(tokens[2].strip()), energy_units),
                     T0=(1,"K"),
                     parser=self
                 )
@@ -1338,9 +1335,9 @@ class Parser(object):
                 # activated" reaction
                 tokens = tokens[1].split()
                 arrheniusHigh = Arrhenius(
-                    A=(float(tokens[0].strip()),kunits),
+                    A=(float(tokens[0].strip()), kunits),
                     b=float(tokens[1].strip()),
-                    Ea=(float(tokens[2].strip()),energy_units),
+                    Ea=(float(tokens[2].strip()), energy_units),
                     T0=(1,"K"),
                     parser=self
                 )
@@ -1357,9 +1354,9 @@ class Parser(object):
                                        reversible=False)
                 tokens = tokens[1].split()
                 revReaction.kinetics = Arrhenius(
-                    A=(float(tokens[0].strip()),klow_units),
+                    A=(float(tokens[0].strip()), klow_units),
                     b=float(tokens[1].strip()),
-                    Ea=(float(tokens[2].strip()),energy_units),
+                    Ea=(float(tokens[2].strip()), energy_units),
                     T0=(1,"K"),
                     parser=self
                 )
@@ -1433,7 +1430,7 @@ class Parser(object):
                     tokens2 = tokens[1].split()
                     chebyshev.degreeT = int(float(tokens2[0].strip()))
                     chebyshev.degreeP = int(float(tokens2[1].strip()))
-                    chebyshev.coeffs = np.zeros((chebyshev.degreeT,chebyshev.degreeP), np.float64)
+                    chebyshev.coeffs = np.zeros((chebyshev.degreeT, chebyshev.degreeP), np.float64)
                     chebyshevCoeffs.extend([float(t.strip()) for t in tokens2[2:]])
                 else:
                     tokens2 = tokens[1].split()
@@ -1445,9 +1442,9 @@ class Parser(object):
                     pdepArrhenius = []
                 tokens = tokens[1].split()
                 pdepArrhenius.append([float(tokens[0].strip()), Arrhenius(
-                    A=(float(tokens[1].strip()),kunits),
+                    A=(float(tokens[1].strip()), kunits),
                     b=float(tokens[2].strip()),
-                    Ea=(float(tokens[3].strip()),energy_units),
+                    Ea=(float(tokens[3].strip()), energy_units),
                     T0=(1,"K"),
                     parser=self
                 )])
@@ -1471,7 +1468,7 @@ class Parser(object):
             reaction.kinetics = chebyshev
         elif pdepArrhenius is not None:
             reaction.kinetics = PDepArrhenius(
-                pressures=([P for P, arrh in pdepArrhenius],"atm"),
+                pressures=([P for P, arrh in pdepArrhenius], "atm"),
                 arrhenius=[arrh for P, arrh in pdepArrhenius],
                 parser=self
             )
@@ -1568,7 +1565,7 @@ class Parser(object):
                             # Fix the case where there THERMO ALL or REAC UNITS
                             # ends the species section
                             if (tokens[-1].upper().startswith('THER') or
-                                tokens[-1].upper().startswith('REAC')):
+                                    tokens[-1].upper().startswith('REAC')):
                                 tokens.pop()
                             break
 
@@ -1616,7 +1613,7 @@ class Parser(object):
                             # Fix the case where there THERMO ALL or REAC UNITS
                             # ends the species section
                             if (tokens[-1].upper().startswith('THER') or
-                                tokens[-1].upper().startswith('REAC')):
+                                    tokens[-1].upper().startswith('REAC')):
                                 tokens.pop()
                             break
 
@@ -1770,7 +1767,7 @@ class Parser(object):
                     for token in tokens[1:]:
                         token = token.upper()
                         if token in ENERGY_UNITS:
-                            self.energy_units =ENERGY_UNITS[token]
+                            self.energy_units = ENERGY_UNITS[token]
                             if not self.processed_units:
                                 self.output_energy_units = ENERGY_UNITS[token]
                         elif token in QUANTITY_UNITS:
@@ -1840,7 +1837,7 @@ class Parser(object):
                     self.setupKinetics()
                     for kinetics, comment, line_number in zip(kineticsList, commentsList, startLines):
                         try:
-                            reaction,revReaction = self.readKineticsEntry(kinetics, surface)
+                            reaction, revReaction = self.readKineticsEntry(kinetics, surface)
                         except Exception as e:
                             logging.error('Error reading reaction entry starting on line {0}:'.format(line_number))
                             raise
@@ -1904,15 +1901,15 @@ class Parser(object):
         for reactions in possible_duplicates.values():
             for r1,r2 in itertools.combinations(reactions, 2):
                 if r1.duplicate and r2.duplicate:
-                    pass # marked duplicate reaction
+                    pass  # marked duplicate reaction
                 elif (r1.thirdBody and r1.thirdBody.upper() == 'M' and
                       r1.kinetics.efficiencies.get(r2.thirdBody) == 0):
-                    pass # explicit zero efficiency
+                    pass  # explicit zero efficiency
                 elif (r2.thirdBody and r2.thirdBody.upper() == 'M' and
                       r2.kinetics.efficiencies.get(r1.thirdBody) == 0):
-                    pass # explicit zero efficiency
+                    pass  # explicit zero efficiency
                 elif r1.thirdBody != r2.thirdBody:
-                    pass # distinct third bodies
+                    pass  # distinct third bodies
                 else:
                     raise InputParseError(message.format(r1, r1.line_number, r2.line_number))
 
@@ -2052,7 +2049,7 @@ class Parser(object):
             lines.append('# Element data')
             lines.append(delimiterLine)
             lines.append('')
-            for name,weight in self.element_weights.items():
+            for name, weight in self.element_weights.items():
                 lines.append('element(symbol={0!r}, atomic_mass={1})'.format(name, weight))
 
         # Write the individual species data
@@ -2211,6 +2208,7 @@ duplicate transport data) to be ignored.
             print('Mechanism contains {0} species and {1} reactions.'.format(len(self.speciesList), len(self.reactions)))
         return surface_names
 
+
 def main(argv):
 
     longOptions = ['input=', 'thermo=', 'transport=', 'surface=', 'id=',
@@ -2285,6 +2283,7 @@ def main(argv):
         print('FAILED.')
         print(e)
         sys.exit(1)
+
 
 def script_entry_point():
     main(sys.argv[1:])

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -232,14 +232,22 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6])
 
         # Reactions with explicit reverse rate constants are transformed into
-        # two irreversible reactions with reactants and products swapped.
+        # two irreversible reactions with reactants and products swapped, unless
+        # the explicit reverse rate is zero so only the forward reaction is used.
         Rr = gas.reverse_rate_constants
         self.assertEqual(Rr[0], 0.0)
         self.assertEqual(Rr[1], 0.0)
+        self.assertEqual(Rr[2], 0.0)
+        self.assertEqual(Rr[3], 0.0)
+        self.assertEqual(Rr[4], 0.0)
         Rstoich = gas.reactant_stoich_coeffs()
         Pstoich = gas.product_stoich_coeffs()
-        self.assertEqual(list(Rstoich[:,0]), list(Pstoich[:,1]))
-        self.assertEqual(list(Rstoich[:,1]), list(Pstoich[:,0]))
+        self.assertEqual(list(Rstoich[:, 0]), list(Pstoich[:, 1]))
+        self.assertEqual(list(Rstoich[:, 1]), list(Pstoich[:, 0]))
+        self.assertEqual(list(Rstoich[:, 2]), list(Pstoich[:, 3]))
+        self.assertEqual(list(Rstoich[:, 3]), list(Pstoich[:, 2]))
+
+        self.assertEqual(gas.n_reactions, 5)
 
     def test_explicit_forward_order(self):
         convertMech(pjoin(self.test_data_dir, 'explicit-forward-order.inp'),

--- a/test/data/explicit-reverse-rate.inp
+++ b/test/data/explicit-reverse-rate.inp
@@ -4,7 +4,7 @@ END
 
 SPECIES
 H
-R1A R1B P1
+R1A R1B P1 R3 P3A P3B
 END
 
 REACTIONS
@@ -14,5 +14,8 @@ R1A+R1B <=> P1+H                1.0e19    0.0     5000.0
 
 R1A+R1B+M <=> P1+H+M            1.0e-2    0.0     5000.0
   REV/3.9000e12   1.0   6500.0/
+
+R3+H <=> P3A+P3B                       1.0e19    0.0     5000.0
+  REV/0.0000e00   0.0   0.0000/
 
 END

--- a/test/data/explicit-reverse-rate.xml
+++ b/test/data/explicit-reverse-rate.xml
@@ -5,7 +5,7 @@
   <!-- phase gas     -->
   <phase dim="3" id="gas">
     <elementArray datasrc="elements.xml">H C</elementArray>
-    <speciesArray datasrc="#species_data">H    R1A  R1B  P1</speciesArray>
+    <speciesArray datasrc="#species_data">H    R1A  R1B  P1  R3  P3A  P3B</speciesArray>
     <reactionArray datasrc="#reaction_data"/>
     <state>
       <temperature units="K">300.0</temperature>
@@ -25,12 +25,12 @@
       <thermo>
         <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
            <floatArray name="coeffs" size="7">
-             2.500000000E+00,   7.053328190E-13,  -1.995919640E-15,   2.300816320E-18, 
+             2.500000000E+00,   7.053328190E-13,  -1.995919640E-15,   2.300816320E-18,
              -9.277323320E-22,   2.547365990E+04,  -4.466828530E-01</floatArray>
         </NASA>
         <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
            <floatArray name="coeffs" size="7">
-             2.500000010E+00,  -2.308429730E-11,   1.615619480E-14,  -4.735152350E-18, 
+             2.500000010E+00,  -2.308429730E-11,   1.615619480E-14,  -4.735152350E-18,
              4.981973570E-22,   2.547365990E+04,  -4.466829140E-01</floatArray>
         </NASA>
       </thermo>
@@ -42,12 +42,12 @@
       <thermo>
         <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
            <floatArray name="coeffs" size="7">
-             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08, 
+             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08,
              1.666939560E-11,  -1.024664760E+04,  -4.641303760E+00</floatArray>
         </NASA>
         <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
            <floatArray name="coeffs" size="7">
-             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09, 
+             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09,
              -1.018152300E-13,  -9.468344590E+03,   1.843731800E+01</floatArray>
         </NASA>
       </thermo>
@@ -59,12 +59,12 @@
       <thermo>
         <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
            <floatArray name="coeffs" size="7">
-             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08, 
+             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08,
              1.666939560E-11,  -1.024664760E+04,  -4.641303760E+00</floatArray>
         </NASA>
         <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
            <floatArray name="coeffs" size="7">
-             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09, 
+             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09,
              -1.018152300E-13,  -9.468344590E+03,   1.843731800E+01</floatArray>
         </NASA>
       </thermo>
@@ -76,19 +76,70 @@
       <thermo>
         <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
            <floatArray name="coeffs" size="7">
-             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08, 
+             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08,
              1.666939560E-11,  -1.024664760E+04,  -4.641303760E+00</floatArray>
         </NASA>
         <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
            <floatArray name="coeffs" size="7">
-             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09, 
+             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09,
              -1.018152300E-13,  -9.468344590E+03,   1.843731800E+01</floatArray>
         </NASA>
       </thermo>
     </species>
-  </speciesData>
-  <reactionData id="reaction_data">
 
+    <!-- species R3    -->
+    <species name="R3">
+      <atomArray>H:7 C:2 </atomArray>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08,
+             1.666939560E-11,  -1.024664760E+04,  -4.641303760E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+           <floatArray name="coeffs" size="7">
+             7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09,
+             -1.018152300E-13,  -9.468344590E+03,   1.843731800E+01</floatArray>
+        </NASA>
+      </thermo>
+    </species>
+
+    <!-- species P3A    -->
+    <species name="P3A">
+      <atomArray>H:4 C:1 </atomArray>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+          <floatArray name="coeffs" size="7">
+            5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08,
+            1.666939560E-11,  -1.024664760E+04,  -4.641303760E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+          <floatArray name="coeffs" size="7">
+            7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09,
+            -1.018152300E-13,  -9.468344590E+03,   1.843731800E+01</floatArray>
+        </NASA>
+      </thermo>
+    </species>
+
+    <!-- species P3B    -->
+    <species name="P3B">
+      <atomArray>H:4 C:1 </atomArray>
+      <thermo>
+        <NASA Tmax="1000.0" Tmin="200.0" P0="100000.0">
+          <floatArray name="coeffs" size="7">
+            5.149876130E+00,  -1.367097880E-02,   4.918005990E-05,  -4.847430260E-08,
+            1.666939560E-11,  -1.024664760E+04,  -4.641303760E+00</floatArray>
+        </NASA>
+        <NASA Tmax="3500.0" Tmin="1000.0" P0="100000.0">
+          <floatArray name="coeffs" size="7">
+            7.485149500E-02,   1.339094670E-02,  -5.732858090E-06,   1.222925350E-09,
+            -1.018152300E-13,  -9.468344590E+03,   1.843731800E+01</floatArray>
+        </NASA>
+      </thermo>
+    </species>
+  </speciesData>
+
+  <reactionData id="reaction_data">
     <!-- reaction 0001    -->
     <reaction reversible="no" id="0001">
       <equation>R1A + R1B =] P1 + H</equation>
@@ -144,6 +195,20 @@
       <reactants>H:1 P1:1.0</reactants>
       <products>R1B:1 R1A:1.0</products>
     </reaction>
-  </reactionData>
+
+  <!-- reaction 0005    -->
+  <reaction reversible="no" id="0005">
+    <equation>R3 + H =] P3A + P3B</equation>
+    <rateCoeff>
+      <Arrhenius>
+         <A>1.000000E+16</A>
+         <b>0.0</b>
+         <E units="cal/mol">5000.000000</E>
+      </Arrhenius>
+    </rateCoeff>
+    <reactants>R3:1 H:1.0</reactants>
+    <products>P3A:1 P3B:1.0</products>
+  </reaction>
+</reactionData>
 
 </ctml>


### PR DESCRIPTION
Fixes #380.

Changes proposed in this pull request:
- Reactions in the Chemkin format that have an explicit reverse rate equal to zero are not included in the output CTI file
- Minor formatting changes for readability in ck2cti (I'm willing to drop these, but some of the spacing bothered me and I couldn't help "fixing" them)
