### PR TITLE
[Doc] Fixed conda link in README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -42,7 +42,7 @@ Ubuntu. Anaconda packages containing the Cantera Python module are also
 available for Windows, OS X, and Linux.
 
 .. image:: https://anaconda.org/cantera/cantera/badges/installer/conda.svg
-    :target: https://conda.anaconda.org/cantera
+    :target: https://anaconda.org/Cantera/cantera
 
 For other platforms, or for users wishing to install a development version of
 Cantera, `compilation instructions


### PR DESCRIPTION
Changes proposed in this pull request:
- Fixed conda link in README

Original link in README for conda (https://anaconda.org/cantera/repo?type=conda&label=main) seems to be broken, so replaced with new link (https://anaconda.org/Cantera/cantera).