### PR TITLE
Add link to jupyter notebooks in documentation section

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -59,6 +59,8 @@ offers a number of starting points:
 
 - `Python tutorial
   <http://cantera.github.io/docs/sphinx/html/cython/tutorial.html>`_
+- `Application Examples in Python
+  <https://github.com/Cantera/cantera-jupyter#cantera-jupyter>`_
 - `A guide to Cantera's input file format
   <http://cantera.github.io/docs/sphinx/html/cti/index.html>`_
 - `A list of frequently asked questions

--- a/doc/sphinx/cython/index.rst
+++ b/doc/sphinx/cython/index.rst
@@ -18,3 +18,5 @@ Contents:
    onedim
    constants
    examples
+
+   Application Examples as Jupyter Notebooks <https://github.com/Cantera/cantera-jupyter#cantera-jupyter>


### PR DESCRIPTION
Changes proposed in this pull request:
- Make the link to jupyter notebooks more visible by including in the Documentation section, where users typically look for these sorts of things
-
-

