### PR TITLE
Fix conda 3to2

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -8,6 +8,10 @@ addons:
     packages:
       - python-dev
       - python-numpy
+      - python-pip
+      - python3-dev
+      - python3-numpy
+      - python3-setuptools
       - gfortran
       - libsundials-serial-dev
       - liblapack-dev
@@ -20,9 +24,10 @@ before_script: |
       brew update
       brew install scons
       brew install boost
+      brew install python3
+      pip3 install numpy
   fi
-  export PATH=$HOME/.local/bin:$PATH
   rm -f cantera.conf
 script:
-  - scons build -j2 VERBOSE=y python_package=full python3_package=n blas_lapack_libs=lapack,blas optimize=n
+  - scons build -j2 VERBOSE=y python_package=full python3_package=y blas_lapack_libs=lapack,blas optimize=n
   - scons test

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,11 +15,13 @@ addons:
       - libboost-dev
 before_script: |
   pip install --user --install-option="--no-cython-compile" cython
+  pip install --user 3to2
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       brew update
       brew install scons
       brew install boost
   fi
+  export PATH=$HOME/.local/bin:$PATH
   rm -f cantera.conf
 script:
   - scons build -j2 VERBOSE=y python_package=full python3_package=n blas_lapack_libs=lapack,blas optimize=n

--- a/SConstruct
+++ b/SConstruct
@@ -1106,7 +1106,7 @@ if env['python_package'] in ('full','default'):
                     ret = getCommandOutput(env['python_cmd'], threetotwo_cmd, '-l')
                     env['threetotwo_cmd'] = [env['python_cmd'], threetotwo_cmd]
             else:
-                ret = getCommandOutput('3to2' '-l')
+                ret = getCommandOutput('3to2', '-l')
         except (OSError, subprocess.CalledProcessError) as err:
             if env['VERBOSE']:
                 print 'Error checking for 3to2:'

--- a/SConstruct
+++ b/SConstruct
@@ -1096,7 +1096,15 @@ if env['python_package'] in ('full','default'):
             if env['OS'] == 'Windows':
                 python_dir = os.path.dirname(which(env['python_cmd']))
                 threetotwo_cmd = pjoin(python_dir, 'Scripts', '3to2')
-                ret = getCommandOutput(env['python_cmd'], threetotwo_cmd, '-l')
+                # Conda installs 3to2 as an EXE file that can be executed directly
+                # but pip installs only a script. Try executing the EXE file first,
+                # and if it fails because the file doesn't exist, try the script
+                try:
+                    ret = getCommandOutput(threetotwo_cmd, '-l')
+                    env['threetotwo_cmd'] = [threetotwo_cmd]
+                except WindowsError:
+                    ret = getCommandOutput(env['python_cmd'], threetotwo_cmd, '-l')
+                    env['threetotwo_cmd'] = [env['python_cmd'], threetotwo_cmd]
             else:
                 ret = getCommandOutput('3to2' '-l')
         except (OSError, subprocess.CalledProcessError) as err:
@@ -1108,7 +1116,8 @@ if env['python_package'] in ('full','default'):
             env['python_convert_examples'] = True
         else:
             env['python_convert_examples'] = False
-            print """WARNING: Couldn't find '3to2'. Python examples will not work correctly."""
+            print ("WARNING: Couldn't find the 3to2 package. "
+                   "Python 2 examples will not work correctly.")
 
 else:
     env['python_module_loc'] = ''

--- a/SConstruct
+++ b/SConstruct
@@ -1099,7 +1099,7 @@ if env['python_package'] in ('full','default'):
                 ret = getCommandOutput(env['python_cmd'], threetotwo_cmd, '-l')
             else:
                 ret = getCommandOutput('3to2' '-l')
-        except OSError as err:
+        except (OSError, subprocess.CalledProcessError) as err:
             if env['VERBOSE']:
                 print 'Error checking for 3to2:'
                 print err

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -5,9 +5,10 @@ install:
     C:\Python27-x64\Scripts\pip.exe install --egg scons
     C:\Python27-x64\Scripts\pip.exe install numpy
     C:\Python27-x64\Scripts\pip.exe install cython
+    C:\Python27-x64\Scripts\pip.exe install 3to2
 
 build_script:
-- cmd: C:\Python27-x64\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n
+- cmd: C:\Python27-x64\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y
 
 test_script:
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -7,9 +7,10 @@ install:
     C:\Python27-x64\Scripts\pip.exe install cython
     C:\Python27-x64\Scripts\pip.exe install 3to2
     C:\Python27-x64\Scripts\pip.exe install pypiwin32
+    C:\Python35-x64\Scripts\pip.exe install numpy
 
 build_script:
-- cmd: C:\Python27-x64\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y
+- cmd: C:\Python27-x64\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y python3_cmd=C:\Python35-x64\python.exe
 
 test_script:
 - ps: |

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -6,6 +6,7 @@ install:
     C:\Python27-x64\Scripts\pip.exe install numpy
     C:\Python27-x64\Scripts\pip.exe install cython
     C:\Python27-x64\Scripts\pip.exe install 3to2
+    C:\Python27-x64\Scripts\pip.exe install pypiwin32
 
 build_script:
 - cmd: C:\Python27-x64\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -185,9 +185,7 @@ if localenv['python_package'] == 'full':
         def convert_example(target, source, env):
             shutil.copyfile(source[0].abspath, target[0].abspath)
             if env['OS'] == 'Windows':
-                python_dir = os.path.dirname(which(env['python_cmd']))
-                threetotwo_cmd = pjoin(python_dir, 'Scripts', '3to2')
-                subprocess.call([env['python_cmd'], threetotwo_cmd, '--no-diff', '-n', '-w','-x', 'str',
+                subprocess.call(env['threetotwo_cmd'] + ['--no-diff', '-n', '-w','-x', 'str',
                              '-f', 'all', '-f', 'printfunction', '-x', 'print',
                              '-x', 'open', target[0].abspath])
             else:

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -591,24 +591,16 @@ def getSpawn(env):
 
     return ourSpawn
 
+
 def getCommandOutput(cmd, *args):
     """
     Run a command with arguments and return its output.
-    Substitute for subprocess.check_output which is only available
-    in Python >= 2.7
     """
     environ = dict(os.environ)
     if 'PYTHONHOME' in environ:
         # Can cause problems when trying to run a different Python interpreter
         del environ['PYTHONHOME']
-    proc = subprocess.Popen([cmd] + list(args),
-                            stdout=subprocess.PIPE,
-                            stderr=subprocess.PIPE,
-                            env=environ)
-    data, err = proc.communicate()
-    if proc.returncode:
-        raise OSError(err)
-
+    data = subprocess.check_output([cmd] + list(args), stderr=subprocess.STDOUT, env=environ)
     return data.strip()
 
 # Monkey patch for SCons Cygwin bug


### PR DESCRIPTION
Fixes #408

Changes proposed in this pull request:
- Switch `getCommandOutput` to `subprocess.check_output` since we've dropped Python 2.6 support (is that correct?)
- Fix calling 3to2 for conda-package installed 3to2
