### PR TITLE
Fix cantera.pc to pass correct compiler options

### DIFF
--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -32,7 +32,7 @@ if localenv['layout'] != 'debian' and env['OS'] != 'Windows':
 pc_libs = list(localenv['cantera_libs'])
 pc_libdirs = []
 pc_incdirs = []
-pc_cflags = []
+pc_cflags = list(localenv['CXXFLAGS'])
 
 localenv['mak_corelibs'] = '-lcantera'
 

--- a/platform/posix/setup_cantera.in
+++ b/platform/posix/setup_cantera.in
@@ -7,6 +7,13 @@ else
 fi
 export LD_LIBRARY_PATH
 
+if [ -z $PKG_CONFIG_PATH ]; then
+    PKG_CONFIG_PATH=@ct_libdir@/pkgconfig
+else
+    PKG_CONFIG_PATH=@ct_libdir@/pkgconfig:$PKG_CONFIG_PATH
+fi
+export PKG_CONFIG_PATH
+
 PYTHON_CMD=@python_cmd@
 export PYTHON_CMD
 


### PR DESCRIPTION
Fixes the pkg-config utility to pass the correct flags to g++

Changes proposed in this pull request:
-Modify the SConscript file. This fixes the fact that `-std=c++0x` will be definitely passed when pkg-config is used to determine which compiler flags are needed
-Update the setup_cantera script to setup the `PKG_CONFIG_PATH` environment variable. Prior to this, the user had to set it up in addition so executing the setup_cantera script

