### PR TITLE
Make ct2ctml check for string size

### DIFF
--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -459,3 +459,33 @@ class CtmlConverterTest(utilities.CanteraTest):
         self.assertNear(R.orders.get('OH'), 0.15)
         self.assertTrue(R.allow_negative_orders)
         self.assertNear(R.orders.get('H2'), -0.25)
+
+    def test_long_source_input(self):
+        """
+        Here we are testing if passing a very long string will result in a
+        Solution object. This should result in a temp file creation in most OS's
+        """
+
+        gas = ct.Solution(pjoin(self.test_data_dir, 'pdep-test.cti'))
+
+        with open(pjoin(self.test_data_dir, 'pdep-test.cti'), 'r') as f:
+            data = f.read()
+        data_size_2048kB = data + ' '*2048*1024
+        gas2 = ct.Solution(source=data_size_2048kB)
+
+        self.assertEqual(gas.n_reactions, gas2.n_reactions)
+
+    def test_short_source_input(self):
+        """
+        Here we are testing if passing a short string will result in a Solution
+        object. This should not result in a temp file creation in most OS's
+        """
+
+        gas = ct.Solution(pjoin(self.test_data_dir, 'pdep-test.cti'))
+
+        with open(pjoin(self.test_data_dir, 'pdep-test.cti'), 'r') as f:
+            data = f.read()
+        data_size_32kB = data + ' '*18000
+        gas2 = ct.Solution(source=data_size_32kB)
+
+        self.assertEqual(gas.n_reactions, gas2.n_reactions)

--- a/src/base/ct2ctml.cpp
+++ b/src/base/ct2ctml.cpp
@@ -85,6 +85,12 @@ static std::string call_ctml_writer(const std::string& text, bool isfile)
     bool temp_file_created = false;
     std::string temp_cti_file_name = std::tmpnam(nullptr);
 
+    if (temp_cti_file_name.find('\\') == 0) {
+        // Some versions of MinGW give paths in the root directory. Using the
+        // current directory is more likely to succeed.
+        temp_cti_file_name = "." + temp_cti_file_name;
+    }
+
     if (isfile) {
         file = text;
         arg = "r'" + text + "'";
@@ -127,7 +133,7 @@ static std::string call_ctml_writer(const std::string& text, bool isfile)
         } else {
             // If we are here, then a temp file could not be created
             throw CanteraError("call_ctml_writer", "Very long source argument. "
-                               "Error creating temporary file");
+                               "Error creating temporary file '{}'", temp_cti_file_name);
         }
     }
 


### PR DESCRIPTION
Fixes #416  .

Changes proposed in this pull request:
- Add a test in `ct2ctml.cpp` to check for string size when a string is passed using the `source=` argument

Caveats:
- Figured out how to test for the max argv size on *nix systems
- Not sure if this can be done on Windows (MinGW vs. VisualStudio), hence hardwired a `max_argv_size`
- Should we create a test that raises this error?

