### PR TITLE
Correcting RedlichKwongMFTP::getActivityConcentrations

### DIFF
--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -207,9 +207,9 @@ void RedlichKwongMFTP::compositionChanged()
 
 void RedlichKwongMFTP::getActivityConcentrations(doublereal* c) const
 {
-    getPartialMolarVolumes(m_partialMolarVolumes.data());
+    getActivityCoefficients(c);
     for (size_t k = 0; k < m_kk; k++) {
-        c[k] = moleFraction(k) / m_partialMolarVolumes[k];
+        c[k] *= moleFraction(k)*pressure()/RT();
     }
 }
 


### PR DESCRIPTION
Fixes # .

Changes proposed in this pull request:
-Corrects previous 'getActivityConcentrations' for the mixture fugacity model.
