### PR TITLE
[Matlab/Doc] Fix typos in docs for some ThermoPhase getters

### DIFF
--- a/interfaces/matlab/toolbox/@ThermoPhase/cp_mass.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/cp_mass.m
@@ -1,11 +1,11 @@
 function v = cp_mass(tp)
-% CP_MASS  Get the mass-basis specific heats at constant pressure.
+% CP_MASS  Get the mass-basis specific heat at constant pressure.
 % v = cp_mass(tp)
 % :param tp:
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of specific heats of the species at
+%     Molar basis specific heat of the mixture at
 %     constant pressure. Units: J/kg-K
 %
 

--- a/interfaces/matlab/toolbox/@ThermoPhase/cp_mole.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/cp_mole.m
@@ -1,11 +1,11 @@
 function v = cp_mole(tp)
-% CP_MOLE  Get the molar-basis specific heats at constant pressure.
+% CP_MOLE  Get the molar-basis specific heat at constant pressure.
 % v = cp_mole(tp)
 % :param tp:
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of specific heats of the species at
+%     Molar basis specific heat of the mixture at
 %     constant pressure. Units: J/kmol-K
 %
 

--- a/interfaces/matlab/toolbox/@ThermoPhase/cv_mass.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/cv_mass.m
@@ -1,11 +1,11 @@
 function v = cv_mass(tp)
-% CV_MASS  Get the mass-basis specific heats at constant volume.
+% CV_MASS  Get the mass-basis specific heat at constant volume.
 % v = cv_mass(tp)
 % :param tp:
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of specific heats of the species at
+%     Mass basis specific heat of the mixture at
 %     constant volume. Units: J/kg-K
 %
 

--- a/interfaces/matlab/toolbox/@ThermoPhase/cv_mole.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/cv_mole.m
@@ -1,11 +1,11 @@
 function v = cv_mole(tp)
-% CV_MOLE  Get the molar-basis specific heats at constant volume.
+% CV_MOLE  Get the molar-basis specific heat at constant volume.
 % v = cv_mole(tp)
 % :param tp:
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of specific heats of the species at
+%     Molar basis specific heat of the mixture at
 %     constant volume. Units: J/kmol-K
 %
 

--- a/interfaces/matlab/toolbox/@ThermoPhase/enthalpy_mass.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/enthalpy_mass.m
@@ -5,7 +5,7 @@ function v = enthalpy_mass(tp)
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of mass specific enthalpies of the species. Units: J/kg
+%     Mass specific enthalpy of the mixture. Units: J/kg
 %
 
 v = thermo_get(tp.tp_id, 9);

--- a/interfaces/matlab/toolbox/@ThermoPhase/enthalpy_mole.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/enthalpy_mole.m
@@ -5,7 +5,7 @@ function v = enthalpy_mole(tp)
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of molar specific enthalpies of the species. Units: J/kmol
+%    Molar specific enthalpy of the mixture. Units: J/kmol
 %
 
 v = thermo_get(tp.tp_id, 2);

--- a/interfaces/matlab/toolbox/@ThermoPhase/entropy_mass.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/entropy_mass.m
@@ -5,7 +5,7 @@ function v = entropy_mass(tp)
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of mass specific entropies of the species. Units: J/kg-K
+%     Mass specific entropy of the mixture. Units: J/kg-K
 %
 
 v = thermo_get(tp.tp_id, 11);

--- a/interfaces/matlab/toolbox/@ThermoPhase/entropy_mole.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/entropy_mole.m
@@ -5,7 +5,7 @@ function v = entropy_mole(tp)
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of molar specific entropies of the species. Units: J/kg
+%     Molar specific entropy of the mixture. Units: J/kg
 %
 
 v = thermo_get(tp.tp_id, 4);

--- a/interfaces/matlab/toolbox/@ThermoPhase/gibbs_mass.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/gibbs_mass.m
@@ -5,8 +5,7 @@ function v = gibbs_mass(tp)
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of mass specific Gibbs functions of the species.
-%     Units: J/kg
+%     Mass specific Gibbs function of the mixture. Units: J/kg
 %
 
 v = thermo_get(tp.tp_id, 12);

--- a/interfaces/matlab/toolbox/@ThermoPhase/gibbs_mole.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/gibbs_mole.m
@@ -5,8 +5,7 @@ function v = gibbs_mole(tp)
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of mole specific Gibbs functions of the species.
-%     Units: J/kmol
+%     Molar specific Gibbs function of the mixture. Units: J/kmol
 %
 
 v = thermo_get(tp.tp_id, 5);

--- a/interfaces/matlab/toolbox/@ThermoPhase/intEnergy_mass.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/intEnergy_mass.m
@@ -5,8 +5,7 @@ function v = intEnergy_mass(tp)
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of mass specific internal energies of the species.
-%     Units: J/kg
+%     Mass specific internal energy of the mixture. Units: J/kg
 %
 
 v = thermo_get(tp.tp_id, 10);

--- a/interfaces/matlab/toolbox/@ThermoPhase/intEnergy_mole.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/intEnergy_mole.m
@@ -5,8 +5,7 @@ function v = intEnergy_mole(tp)
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     object that derives from ThermoPhase)
 % :return:
-%     Vector of mole specific internal energies of the species.
-%     Units: J/kmol
+%     Molar specific internal energy of the mixture. Units: J/kmol
 %
 
 v = thermo_get(tp.tp_id, 3);


### PR DESCRIPTION
These actually return scalars, although the docstrings
said they returned vectors

Fixes the problem reported here: https://groups.google.com/forum/#!topic/cantera-users/0sKcnEN8TPA

I couldn't tell if `cp_mass` and `cp_mole` and similar functions for `cv` also returned a scalar, and I don't have MATLAB handy to test.