### PR TITLE
Reaction path fixes

### DIFF
--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -318,7 +318,12 @@ protected:
     std::vector<vector_int> m_groups;
     std::vector<Group> m_sgroup;
     std::vector<std::string> m_elementSymbols;
+
+    //! m_transfer[reaction][reactant number][product number] where "reactant
+    //! number" means the number of the reactant in the reaction equation, e.g.
+    //! for "A+B -> C+D", "B" is reactant number 1 and "C" is product number 0.
     std::map<size_t, std::map<size_t, std::map<size_t, Group> > > m_transfer;
+
     std::vector<bool> m_determinate;
     Array2D m_atoms;
     std::map<std::string, size_t> m_enamemap;

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -307,8 +307,12 @@ void ReactionPathDiagram::exportToDot(ostream& s)
             }
         }
     } else {
-        for (size_t i = 0; i < nPaths(); i++) {
-            flmax = std::max(path(i)->flow(), flmax);
+        if (scale < 0) {
+            for (size_t i = 0; i < nPaths(); i++) {
+                flmax = std::max(path(i)->flow(), flmax);
+            }
+        } else {
+            flmax = scale;
         }
 
         for (size_t i = 0; i < nPaths(); i++) {

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -444,17 +444,17 @@ int ReactionPathBuilder::findGroups(ostream& logfile, Kinetics& s)
                     group_a0 = &r0;
                     group_b0 = &b0;
                     group_c0 = &p1;
-                    m_transfer[i][kr0][kp0] = r0;
-                    m_transfer[i][kr1][kp0] = b0;
-                    m_transfer[i][kr1][kp1] = p1;
+                    m_transfer[i][0][0] = r0;
+                    m_transfer[i][1][0] = b0;
+                    m_transfer[i][1][1] = p1;
                 } else {
                     group_a0 = &r1;
                     group_c0 = &p0;
                     b0 *= -1;
                     group_b0 = &b0;
-                    m_transfer[i][kr1][kp1] = r1;
-                    m_transfer[i][kr0][kp1] = b0;
-                    m_transfer[i][kr0][kp0] = p0;
+                    m_transfer[i][1][1] = r1;
+                    m_transfer[i][0][1] = b0;
+                    m_transfer[i][0][0] = p0;
                 }
                 logfile << "     ";
                 group_a0->fmt(logfile, m_elementSymbols);
@@ -479,9 +479,9 @@ int ReactionPathBuilder::findGroups(ostream& logfile, Kinetics& s)
                     group_b1 = &b1;
                     group_c1 = &p0;
                     if (!b0.valid()) {
-                        m_transfer[i][kr0][kp1] = r0;
-                        m_transfer[i][kr1][kp1] = b0;
-                        m_transfer[i][kr1][kp0] = p0;
+                        m_transfer[i][0][1] = r0;
+                        m_transfer[i][1][1] = b0;
+                        m_transfer[i][1][0] = p0;
                     }
                 } else {
                     group_a1 = &r1;
@@ -489,9 +489,9 @@ int ReactionPathBuilder::findGroups(ostream& logfile, Kinetics& s)
                     b1 *= -1;
                     group_b1 = &b1;
                     if (!b0.valid()) {
-                        m_transfer[i][kr1][kp0] = r1;
-                        m_transfer[i][kr0][kp0] = b0;
-                        m_transfer[i][kr0][kp1] = p1;
+                        m_transfer[i][1][0] = r1;
+                        m_transfer[i][0][0] = b0;
+                        m_transfer[i][0][1] = p1;
                     }
                 }
                 logfile << "     ";
@@ -768,10 +768,10 @@ int ReactionPathBuilder::build(Kinetics& s, const string& element,
                                 }
                                 f = 0.0;
                             } else {
-                                if (!g[kkr][kkp]) {
+                                if (!g[kr][kp]) {
                                     f = 0.0;
                                 } else {
-                                    f = g[kkr][kkp].nAtoms(m);
+                                    f = g[kr][kp].nAtoms(m);
                                 }
                             }
                         } else {

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -566,10 +566,10 @@ int ReactionPathBuilder::init(ostream& logfile, Kinetics& kin)
     vector<vector<size_t> > allReactants(m_nr);
     for (size_t i = 0; i < m_nr; i++) {
         for (size_t k = 0; k < m_ns; k++) {
-            if (kin.reactantStoichCoeff(k, i)) {
+            for (int n = 0; n < kin.reactantStoichCoeff(k, i); n++) {
                 allReactants[i].push_back(k);
             }
-            if (kin.productStoichCoeff(k, i)) {
+            for (int n = 0; n < kin.productStoichCoeff(k, i); n++) {
                 allProducts[i].push_back(k);
             }
         }


### PR DESCRIPTION
Fixes #377: Reactions where either a reactant or product has a stoichiometric coefficient of 2 were causing problems. The fix here is to treat the each molecule separately (i.e. think of "2 OH" as "OH + OH"), and use the index within the list of reactants/products as the identifier instead of the species index when necessary.

Fixes #378: The user-specified 'scale' parameter was just not being used if the 'OneWayFlow' option was set.
