### PR TITLE
Disabling erroneous 'sanity check' in RedlichKwongMFTP:pressure()

### DIFF
--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -169,11 +169,7 @@ doublereal RedlichKwongMFTP::pressure() const
     doublereal T = temperature();
     double molarV = meanMolecularWeight() / density();
     double pp = GasConstant * T/(molarV - m_b_current) - m_a_current/(sqrt(T) * molarV * (molarV + m_b_current));
-    if (fabs(pp -m_Pcurrent) > 1.0E-5 * fabs(m_Pcurrent)) {
-        throw CanteraError(" RedlichKwongMFTP::pressure()", "setState broken down, maybe");
-    }
-
-    return m_Pcurrent;
+    return pp;
 }
 
 void RedlichKwongMFTP::calcDensity()


### PR DESCRIPTION
I'm not really sure what these lines of code were ever supposed
to achieve, but the effect is that you can never change the
object's thermodynamic state in a way that changes the pressure,
unless you are setting the pressure directly.  I'm leaving it
commented, in case we find at a later time that it serves some
purpose.

Fixes # .

Changes proposed in this pull request:
-
-
-
