### PR TITLE
Preserve units in PLOG entries in ck2cti

### DIFF
--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -531,11 +531,11 @@ class PDepArrhenius(KineticsModel):
         rxnstring = reactantstr + arrow + productstr
         lines = ['pdep_arrhenius({0!r},'.format(rxnstring)]
         prefix = ' '*(indent+15)
-        template = '[({0}, {1!r}), {2.A[0]:e}, {2.b}, {2.Ea[0]}],'
+        template = '[({0}, {1!r}), {2}],'
         for pressure, arrhenius in zip(self.pressures[0], self.arrhenius):
             lines.append(prefix + template.format(pressure,
                                                   self.pressures[1],
-                                                  arrhenius))
+                                                  arrhenius.rateStr()[1:-1]))
         lines[-1] = lines[-1][:-1] + ')'
         return '\n'.join(lines)
 


### PR DESCRIPTION
This PR preserves the units when converting PLOG entries from a chemkin file.

For example of how it should work, if you read and output both in cal/mol then you get this for an Arrhenius
`reaction('ch3co3h <=> ch3co2 + oh', [5.010000e+14, 0.0, 40150.0])`
but if you read in kcal/mol and output in cal/mol then you get this
`reaction('ch3co3h <=> ch3co2 + oh', [5.010000e+14, 0.0, (40.15, 'kcal/mol')])`
which is great. It preserves the units on Ea.
Also works for high and low pressure limits of all the fall-off types, as far as I can tell.
But if you have a pdep_arrhenius (PLOG) reaction the units are ignored.
Eg. if you have a reaction that ought to look (in cal/mol) like
```
pdep_arrhenius('ch2cho + o2 <=> o2ch2cho',
               [(0.01, 'atm'), 1.580000e+77, -21.9, 19350.0],
               [(0.1, 'atm'), 3.880000e+69, -18.84, 19240.0],
               [(1.0, 'atm'), 7.800000e+59, -15.4, 17650.0],
               [(10.0, 'atm'), 3.050000e+50, -12.2, 15630.0])
```
but you read it from a file in kcal/mol then your output looks like 
```
pdep_arrhenius('ch2cho + o2 <=> o2ch2cho',
               [(0.01, 'atm'), 1.580000e+77, -21.9, 19.35],
               [(0.1, 'atm'), 3.880000e+69, -18.84, 19.24],
               [(1.0, 'atm'), 7.800000e+59, -15.4, 17.65],
               [(10.0, 'atm'), 3.050000e+50, -12.2, 15.63])
```

After this PR it becomes
```
pdep_arrhenius('ch2cho + o2 <=> o2ch2cho',
               [(0.01, 'atm'), 1.580000e+77, -21.9, (19.35, 'kcal/mol')],
               [(0.1, 'atm'), 3.880000e+69, -18.84, (19.24, 'kcal/mol')],
               [(1.0, 'atm'), 7.800000e+59, -15.4, (17.65, 'kcal/mol')],
               [(10.0, 'atm'), 3.050000e+50, -12.2, (15.63, 'kcal/mol')])
```
because we re-use the unit-preserving code in the Arrhenius class.

I haven't actually checked that the resulting .cti syntax can be parsed by Cantera....
I guess that should be done before merging the PR :)

Also, chemkin syntax is a minefield (and usually the documentation is not nearly pedantic enough), so please check this!  But I thought I'd start with a patch not just an issue.