### PR TITLE
RK_MFTP test coverage 

### DIFF
--- a/test/data/co2_RK_example.cti
+++ b/test/data/co2_RK_example.cti
@@ -1,0 +1,176 @@
+#
+# Generated from file air.inp
+# by ck2cti on Fri Oct 19 10:20:22 2007
+#
+# Transport data from file ../transport/gri30_tran.dat.
+
+units(length = "cm", time = "s", quantity = "mol", act_energy = "cal/mol")
+
+
+RedlichKwongMFTP(name = "carbondioxide",
+      elements = " C O H N ",
+      species = """ CO2  H2O H2 CO CH4 O2 N2 """,
+      activity_coefficients = (pureFluidParameters(species="CO2", a_coeff = [6.45714E12, 0], b_coeff = 29.65792),
+			    pureFluidParameters(species="H2O", a_coeff = [1.42674e13, 0], b_coeff = 21.12706),
+				pureFluidParameters(species="H2", a_coeff = [1.43319e11, 0], b_coeff = 18.42803),
+				pureFluidParameters(species="CO", a_coeff = [1.6202612E12, 0], b_coeff = 25.83591), 
+				pureFluidParameters(species="CH4", a_coeff = [3.22224E12, 0], b_coeff = 29.84830), 
+				pureFluidParameters(species="O2", a_coeff = [1.73132E12, 0], b_coeff = 22.04783),
+				pureFluidParameters(species="N2", a_coeff = [1.55976E12, 0], b_coeff = 26.81725),
+					    crossFluidParameters(species="CO2 H2O", a_coeff = [7.897e12, 0])     ),
+      transport = "Multi",
+      reactions = "all",
+      initial_state = state(temperature = 300.0,
+                            pressure = OneAtm,
+                            mole_fractions = 'CO2:0.99, H2:0.01')    )
+
+
+
+#-------------------------------------------------------------------------------
+#  Species data 
+#-------------------------------------------------------------------------------
+
+species(name = "H2",
+    atoms = " H:2 ",
+    thermo = (
+       NASA( [  200.00,  1000.00], [  2.344331120E+00,   7.980520750E-03, 
+               -1.947815100E-05,   2.015720940E-08,  -7.376117610E-12,
+               -9.179351730E+02,   6.830102380E-01] ),
+       NASA( [ 1000.00,  3500.00], [  3.337279200E+00,  -4.940247310E-05, 
+                4.994567780E-07,  -1.795663940E-10,   2.002553760E-14,
+               -9.501589220E+02,  -3.205023310E+00] )
+             ),
+    transport = gas_transport(
+                     geom = "linear",
+                     diam =     2.92,
+                     well_depth =    38.00,
+                     polar =     0.79,
+                     rot_relax =   280.00),
+    note = "TPIS78"
+       )
+
+species(name = "CO",
+    atoms = " C:1  O:1 ",
+    thermo = (
+       NASA( [  200.00,  1000.00], [  3.579533470E+00,  -6.103536800E-04, 
+                1.016814330E-06,   9.070058840E-10,  -9.044244990E-13,
+               -1.434408600E+04,   3.508409280E+00] ),
+       NASA( [ 1000.00,  3500.00], [  2.715185610E+00,   2.062527430E-03, 
+               -9.988257710E-07,   2.300530080E-10,  -2.036477160E-14,
+               -1.415187240E+04,   7.818687720E+00] )
+             ),
+    transport = gas_transport(
+                     geom = "linear",
+                     diam =     3.65,
+                     well_depth =    98.10,
+                     polar =     1.95,
+                     rot_relax =     1.80),
+    note = "TPIS79"
+       )
+
+
+species(name = "N2",
+    atoms = " N:2 ",
+    thermo = (
+       NASA( [  300.00,  1000.00], [  3.298677000E+00,   1.408240400E-03, 
+               -3.963222000E-06,   5.641515000E-09,  -2.444854000E-12,
+               -1.020899900E+03,   3.950372000E+00] ),
+       NASA( [ 1000.00,  5000.00], [  2.926640000E+00,   1.487976800E-03, 
+               -5.684760000E-07,   1.009703800E-10,  -6.753351000E-15,
+               -9.227977000E+02,   5.980528000E+00] )
+             ),
+    transport = gas_transport(
+                     geom = "linear",
+                     diam =     3.62,
+                     well_depth =    97.53,
+                     polar =     1.76,
+                     rot_relax =     4.00),
+    note = "121286"
+       )
+
+species(name = "O2",
+    atoms = " O:2 ",
+    thermo = (
+       NASA( [  200.00,  1000.00], [  3.782456360E+00,  -2.996734160E-03, 
+                9.847302010E-06,  -9.681295090E-09,   3.243728370E-12,
+               -1.063943560E+03,   3.657675730E+00] ),
+       NASA( [ 1000.00,  3500.00], [  3.282537840E+00,   1.483087540E-03, 
+               -7.579666690E-07,   2.094705550E-10,  -2.167177940E-14,
+               -1.088457720E+03,   5.453231290E+00] )
+             ),
+    transport = gas_transport(
+                     geom = "linear",
+                     diam =     3.46,
+                     well_depth =   107.40,
+                     polar =     1.60,
+                     rot_relax =     3.80),
+    note = "TPIS89"
+       )
+
+
+species(name = "CO2",
+    atoms = " C:1  O:2 ",
+    thermo = (
+       NASA( [  200.00,  1000.00], [  2.356773520E+00,   8.984596770E-03, 
+               -7.123562690E-06,   2.459190220E-09,  -1.436995480E-13,
+               -4.837196970E+04,   9.901052220E+00] ),
+       NASA( [ 1000.00,  3500.00], [  3.857460290E+00,   4.414370260E-03, 
+               -2.214814040E-06,   5.234901880E-10,  -4.720841640E-14,
+               -4.875916600E+04,   2.271638060E+00] )
+             ),
+    transport = gas_transport(
+                     geom = "linear",
+                     diam =     3.76,
+                     well_depth =   244.00,
+                     polar =     2.65,
+                     rot_relax =     2.10),
+    note = "L 7/88"
+       )
+
+species(name = "CH4",
+    atoms = " C:1  H:4 ",
+    thermo = (
+       NASA( [  200.00,  1000.00], [  5.149876130E+00,  -1.367097880E-02, 
+                4.918005990E-05,  -4.847430260E-08,   1.666939560E-11,
+               -1.024664760E+04,  -4.641303760E+00] ),
+       NASA( [ 1000.00,  3500.00], [  7.485149500E-02,   1.339094670E-02, 
+               -5.732858090E-06,   1.222925350E-09,  -1.018152300E-13,
+               -9.468344590E+03,   1.843731800E+01] )
+             ),
+    transport = gas_transport(
+                     geom = "nonlinear",
+                     diam =     3.75,
+                     well_depth =   141.40,
+                     polar =     2.60,
+                     rot_relax =    13.00),
+    note = "L 8/88"
+       )
+
+
+species(name = "H2O",
+    atoms = " H:2  O:1 ",
+    thermo = (
+       NASA( [  200.00,  1000.00], [  4.198640560E+00,  -2.036434100E-03, 
+                6.520402110E-06,  -5.487970620E-09,   1.771978170E-12,
+               -3.029372670E+04,  -8.490322080E-01] ),
+       NASA( [ 1000.00,  3500.00], [  3.033992490E+00,   2.176918040E-03, 
+               -1.640725180E-07,  -9.704198700E-11,   1.682009920E-14,
+               -3.000429710E+04,   4.966770100E+00] )
+             ),
+    transport = gas_transport(
+                     geom = "nonlinear",
+                     diam =     2.60,
+                     well_depth =   572.40,
+                     dipole =     1.85,
+                     rot_relax =     4.00),
+    note = "L 8/89"
+       )
+
+#———————————————————————————————————————————
+#     Reaction data
+#———————————————————————————————————————————
+
+#   Reaction 1
+#reaction( "CO + H2O <=> CO2 + H2", [1.2E+11, 0, 0])
+reaction( "CO2 + H2 <=> CO + H2O", [1.2E+3, 0, 0])
+

--- a/test/thermo/RedlichKwongMFTP_Test.cpp
+++ b/test/thermo/RedlichKwongMFTP_Test.cpp
@@ -1,0 +1,165 @@
+#include "gtest/gtest.h"
+#include "cantera/thermo/RedlichKwongMFTP.h"
+#include "cantera/thermo/ThermoFactory.h"
+
+
+namespace Cantera
+{
+
+class RedlichKwongMFTP_Test : public testing::Test
+{
+public:
+    RedlichKwongMFTP_Test() {
+        test_phase.reset(newPhase("../data/co2_RK_example.cti"));
+    }
+
+    //vary the composition of a co2-h2 mixture:
+    void set_r(const double r) {
+        vector_fp moleFracs(7);
+        moleFracs[0] = r;
+        moleFracs[2] = 1-r;
+        test_phase->setMoleFractions(&moleFracs[0]);
+    }
+
+    std::unique_ptr<ThermoPhase> test_phase;
+};
+
+TEST_F(RedlichKwongMFTP_Test, construct_from_cti)
+{
+    RedlichKwongMFTP* redlich_kwong_phase = dynamic_cast<RedlichKwongMFTP*>(test_phase.get());
+    EXPECT_TRUE(redlich_kwong_phase != NULL);
+}
+
+TEST_F(RedlichKwongMFTP_Test, chem_potentials)
+{
+    test_phase->setState_TP(298.15, 101325.);
+
+    const double expected_result[9] = {
+        -4.573578067074649e+008,
+        -4.573471163377696e+008,
+        -4.573375748803425e+008,
+        -4.573290065058332e+008,
+        -4.573212695326964e+008,
+        -4.573142485189869e+008,
+        -4.573078484551440e+008,
+        -4.573019904340246e+008,
+        -4.572966083775078e+008
+    };
+
+    double xmin = 0.6;
+    double xmax = 0.9;
+    int numSteps = 9;
+    double dx = (xmax-xmin)/(numSteps-1);
+    vector_fp chemPotentials(7);
+    for(int i=0; i < 9; ++i)
+    {
+        set_r(xmin + i*dx);
+        test_phase->getChemPotentials(&chemPotentials[0]);
+        EXPECT_NEAR(expected_result[i], chemPotentials[0], 1.e-6);
+    }
+}
+
+TEST_F(RedlichKwongMFTP_Test, activityCoeffs)
+{
+    test_phase->setState_TP(298., 1.);
+
+    // Test that mu0 + RT log(activityCoeff * MoleFrac) == mu
+    const double RT = GasConstant * 298.;
+    vector_fp mu0(7);
+    vector_fp activityCoeffs(7);
+    vector_fp chemPotentials(7);
+    double xmin = 0.6;
+    double xmax = 0.9;
+    int numSteps = 9;
+    double dx = (xmax-xmin)/(numSteps-1);
+
+    for(int i=0; i < numSteps; ++i)
+    {
+        const double r = xmin + i*dx;
+        set_r(r);
+        test_phase->getChemPotentials(&chemPotentials[0]);
+        test_phase->getActivityCoefficients(&activityCoeffs[0]);
+        test_phase->getStandardChemPotentials(&mu0[0]);
+        EXPECT_NEAR(chemPotentials[0], mu0[0] + RT*std::log(activityCoeffs[0] * r), 1.e-6);
+        EXPECT_NEAR(chemPotentials[2], mu0[2] + RT*std::log(activityCoeffs[2] * (1-r)), 1.e-6);
+    }
+}
+
+TEST_F(RedlichKwongMFTP_Test, standardConcentrations)
+{
+    EXPECT_DOUBLE_EQ(0.040621990447223283, test_phase->standardConcentration(0));
+    EXPECT_DOUBLE_EQ(0.040621990447223283, test_phase->standardConcentration(1));
+}
+
+TEST_F(RedlichKwongMFTP_Test, activityConcentrations)
+{
+    // Check to make sure activityConcentration_i == standardConcentration_i * gamma_i * X_i
+    vector_fp standardConcs(7);
+    vector_fp activityCoeffs(7);
+    vector_fp activityConcentrations(7);
+    double xmin = 0.6;
+    double xmax = 0.9;
+    int numSteps = 9;
+    double dx = (xmax-xmin)/(numSteps-1);
+
+    for(int i=0; i < 9; ++i)
+    {
+        const double r = xmin + i*dx;
+        set_r(r);
+        test_phase->getActivityCoefficients(&activityCoeffs[0]);
+        standardConcs[0] = test_phase->standardConcentration(0);
+        standardConcs[2] = test_phase->standardConcentration(2);
+        test_phase->getActivityConcentrations(&activityConcentrations[0]);
+
+        EXPECT_NEAR(standardConcs[0] * r * activityCoeffs[0], activityConcentrations[0], 1.e-6);
+        EXPECT_NEAR(standardConcs[2] * (1-r) * activityCoeffs[2], activityConcentrations[2], 1.e-6);
+    }
+}
+
+TEST_F(RedlichKwongMFTP_Test, setTP)
+{
+    // Check to make sure that the phase diagram is accurately reproduced for a few select isobars
+
+    // All sub-cooled liquid:
+    const double p1[6] = {
+        1.587029921158317e+002,
+        1.541895558698696e+002,
+        1.501572815648243e+002,
+        1.465106359800041e+002,
+        1.431807662747959e+002,
+        1.401162435728261e+002
+    };
+    // Phase change between temperatures 4 & 5:
+    const double p2[6] = {
+        6.265136821574670e+002,
+        5.991027079853330e+002,
+        5.656903533839055e+002,
+        5.196021189855490e+002,
+        3.384435863009947e+002,
+        2.755331531855265e+002
+    };
+    // All superheated vapor:
+    const double p3[6] = {
+        6.839819449357851e+002,
+        6.667277456641792e+002,
+        6.483568057147166e+002,
+        6.286479753170340e+002,
+        6.073051275696215e+002,
+        5.839223896051005e+002
+    };
+
+    for(int i=0; i<6; ++i)
+    {
+        const double temp = 294 + i*2;
+        set_r(0.99);
+        test_phase->setState_TP(temp, 5542027.5);
+        EXPECT_NEAR(test_phase->density(),p1[i],1.e-8);
+
+        test_phase->setState_TP(temp, 7389370.);
+        EXPECT_NEAR(test_phase->density(),p2[i],1.e-8);
+
+        test_phase->setState_TP(temp, 9236712.5);
+        EXPECT_NEAR(test_phase->density(),p3[i],1.e-8);
+    }
+}
+};

--- a/test/thermo/RedlichKwongMFTP_Test.cpp
+++ b/test/thermo/RedlichKwongMFTP_Test.cpp
@@ -138,7 +138,7 @@ TEST_F(RedlichKwongMFTP_Test, setTP)
         3.384435863009947e+002,
         2.755331531855265e+002
     };
-    // All superheated vapor:
+    // Supercritical; no discontinuity in rho values:
     const double p3[6] = {
         6.839819449357851e+002,
         6.667277456641792e+002,

--- a/test/thermo/RedlichKwongMFTP_Test.cpp
+++ b/test/thermo/RedlichKwongMFTP_Test.cpp
@@ -33,7 +33,10 @@ TEST_F(RedlichKwongMFTP_Test, construct_from_cti)
 TEST_F(RedlichKwongMFTP_Test, chem_potentials)
 {
     test_phase->setState_TP(298.15, 101325.);
-
+    // Chemical potential should increase with increasing co2 mole fraction:
+    //      mu = mu_0 + RT ln(gamma_k*X_k).
+    // where gamma_k is the activity coefficient.  Run regression test against values calculated using
+    // the model.
     const double expected_result[9] = {
         -4.573578067074649e+008,
         -4.573471163377696e+008,
@@ -87,8 +90,8 @@ TEST_F(RedlichKwongMFTP_Test, activityCoeffs)
 
 TEST_F(RedlichKwongMFTP_Test, standardConcentrations)
 {
-    EXPECT_DOUBLE_EQ(0.040621990447223283, test_phase->standardConcentration(0));
-    EXPECT_DOUBLE_EQ(0.040621990447223283, test_phase->standardConcentration(1));
+    EXPECT_DOUBLE_EQ(test_phase->pressure()/(test_phase->temperature()*GasConstant), test_phase->standardConcentration(0));
+    EXPECT_DOUBLE_EQ(test_phase->pressure()/(test_phase->temperature()*GasConstant), test_phase->standardConcentration(1));
 }
 
 TEST_F(RedlichKwongMFTP_Test, activityConcentrations)


### PR DESCRIPTION
Fixes # 267.

Changes proposed in this pull request:
-Test suite coverage added for `RedlichKwongMFTP` thermoPhase class, including:

1. Construct phase from cti (uses a binary mixture of H2 and CO2, for all problems).
2. `ChemPotentials`, `activityCoefficients`, and`activityConcentrations` for a range of CO2 moleFractions.
3. `standardConcentrations`
4.  Phase diagram calculations - calculating `density()` for a range of temperature and pressure values near the phase transition (one subcooled liquid, one with phase change, one supercritical)
