### PR TITLE
Interfacial electrochemistry

### DIFF
--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -1296,7 +1296,7 @@ class reaction(object):
         elif self._type == 'chebyshev':
             self._kf = []
 
-        if self._type == 'edge':
+        if self._type == 'edge' or self._type == 'surface':
             if self._beta > 0:
                 electro = kfnode.addChild('electrochem')
                 electro['beta'] = repr(self._beta)
@@ -1605,7 +1605,8 @@ class surface_reaction(reaction):
     A heterogeneous chemical reaction with pressure-independent rate
     coefficient and mass-action kinetics.
     """
-    def __init__(self, equation='', kf=None, id='', order='', options=[]):
+    def __init__(self, equation='', kf=None, id='', order='', beta = 0.0,
+                 options=[]):
         """
         :param equation:
             A string specifying the chemical equation.
@@ -1625,9 +1626,16 @@ class surface_reaction(reaction):
             reaction in the file.
         :param options:
             Processing options, as described in :ref:`sec-reaction-options`.
+        :param beta:
+            Charge transfer coefficient: A number between 0 and 1 which, for a
+            charge transfer reaction, determines how much of the electric
+            potential difference between two phases is applied to the
+            activiation energy of the fwd reaction.  The remainder is applied to
+            the reverse reaction.
         """
         reaction.__init__(self, equation, kf, id, order, options)
         self._type = 'surface'
+        self._beta = beta
 
 
 class edge_reaction(reaction):

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -605,9 +605,10 @@ shared_ptr<Reaction> newReaction(const XML_Node& rxn_node)
 {
     std::string type = ba::to_lower_copy(rxn_node["type"]);
 
-    // Modify the reaction type for edge reactions which contain electrochemical
-    // reaction data
-    if (rxn_node.child("rateCoeff").hasChild("electrochem") && type == "edge") {
+    // Modify the reaction type for interface reactions which contain
+    // electrochemical reaction data
+    if (rxn_node.child("rateCoeff").hasChild("electrochem")
+        && (type == "edge" || type == "surface")) {
         type = "electrochemical";
     }
 


### PR DESCRIPTION
Fixes anomalous behavior when a `surface_reaction`  involves charge transfer.
Previously, only an `edge_reaction` with a `beta` value (i.e. charge transfer coefficient) assigned could be recognized as electrochemical, which triggers an adjustment of the `k_fwd` value by an activation energy associated with the voltage difference across the phase boundary.

When this adjustment is not made (i.e. for any `surface_reaction` or an `edge_reaction` where `beta` is not assigned), then thermodynamic consistency requires that the entire voltage effect is applied to k_rev, which is equivalent to the case where `beta = 0`.  This is a rather poor default to force upon users...

Changes proposed in this pull request:
-Allows charge-transfer coefficients (i.e. `beta` values) to be provided for `surface_reaction` instances (previously only available for `edge_reaction` instances).
-Allows reaction `type = electrochem` assignment for `surface_reaction` instances (again, previously only available for `edge_reaction` instances).
-Note that this approach is still limited, in that detection of an electrochemical reaction still relies upon user input.  Ideally, it should be detected automatically.  I will assign and issue to this, and it will be the subject of an upcoming PR.
