### PR TITLE
Chemkin files with weird names break PDep reactions.

### DIFF
--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -1179,7 +1179,7 @@ class Parser(object):
         Ea = float(tokens[-1])
         reaction = ''.join(tokens[:-3]) + '\n'
 
-        # Identify species tokens in the reaction expression in order of
+        # Identify tokens in the reaction expression in order of
         # decreasing length
         locs = {}
         for i in range(self.Slen, 0, -1):
@@ -1188,14 +1188,8 @@ class Parser(object):
                 if test in self.species_tokens:
                     reaction = reaction[:j] + ' '*(i-1) + reaction[j+i-1:]
                     locs[j] = test[:-1], 'species'
-
-        # Identify other tokens in the reaction expression in order of
-        # descending length
-        for i in range(self.Slen, 0, -1):
-            for j in range(len(reaction)-i+1):
-                test = reaction[j:j+i]
-                if test in self.other_tokens:
-                    reaction = reaction[:j] + ' '*i + reaction[j+i:]
+                elif test in self.other_tokens:
+                    reaction = reaction[:j] + '\n'*i + reaction[j+i:]
                     locs[j] = test, self.other_tokens[test]
 
         # Anything that's left should be a stoichiometric coefficient or a '+'

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -1400,7 +1400,7 @@ class pdep_reaction(reaction):
             del self._p['m)']
         else:
             for r in list(self._r.keys()):
-                if r[-1] == ')' and r.find('(') < 0:
+                if r[-1] == ')' and r in self._p:
                     species = r[:-1]
                     if self._eff:
                         raise CTI_Error("In reaction '{0}', explcit third body "

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -151,7 +151,7 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.assertEqual(gas.species_name(5), 'eq=uals')
         self.assertEqual(gas.species_name(6), 'plus')
 
-        self.assertEqual(gas.n_reactions, 7)
+        self.assertEqual(gas.n_reactions, 10)
         nu = gas.product_stoich_coeffs() - gas.reactant_stoich_coeffs()
         self.assertEqual(list(nu[:,0]), [-1, -1, 0, 2, 0, 0, 0])
         self.assertEqual(list(nu[:,1]), [-2, 3, 0, -1, 0, 0, 0])

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -160,6 +160,9 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.assertEqual(list(nu[:,4]), [2, 0, 0, 0, -1, 0, -1])
         self.assertEqual(list(nu[:,5]), [1, 0, 0, 0, 1, -1, -1])
         self.assertEqual(list(nu[:,6]), [2, 0, -1, 0, 0, -1, 0])
+        self.assertEqual(list(nu[:,7]), [0, 0, 0, 0, -1, 1, 0])
+        self.assertEqual(list(nu[:,8]), [0, 0, 0, 0, -1, 1, 0])
+        self.assertEqual(list(nu[:,9]), [0, 0, 0, 0, -1, 1, 0])
 
     def test_unterminatedSections(self):
         with self.assertRaises(ck2cti.InputParseError):

--- a/test/data/species-names.inp
+++ b/test/data/species-names.inp
@@ -45,5 +45,11 @@ plus+ + (Parens) = 2plus+          9.999e9   9.9   999.9
 plus + plus+ = 2 (Parens)          9.999e9   9.9   999.9
 plus+ eq=uals = plus++(Parens)     9.999e9   9.9   999.9
 co:lons: + eq=uals = 2 (Parens)     9.999e9   9.9   999.9
+plus+ (+plus) = eq=uals  (+plus)     9.999e9   9.9   999.9
+LOW / 8.888e8   8.8   888.8 /
+plus+ (+(Parens)) = eq=uals  (+(Parens))     9.999e9   9.9   999.9
+LOW / 8.888e8   8.8   888.8 /
+plus+ (+plus+) = eq=uals  (+plus+)     9.999e9   9.9   999.9
+LOW / 8.888e8   8.8   888.8 /
 
 end


### PR DESCRIPTION
The first commit in this PR just contains a failing unit test case.
I have not figured out the solution, but thought this would perhaps be more helpful than just opening an issue. Please feel free to add a fix rather than waiting for me to finish the PR :-)

Reactions of the type
 A (+B) <=> C (+B)
ought to work, as long as they are provided a pressure-dependent rate
expression. This commit adds three examples to the test file for
pathological species names.  The first works OK (third body is called "`plus`"), the second two cause problems (third body is "`(Parens)`" or "`plus+`")

(For what it's worth, this currently crashes the official chemkin.
 Or at least the parentheses do; I've not tested the plus.
 Ansys have created a defect record and say they will fix the issue.)