### PR TITLE
[Python] Make Python module compatible with Cython 0.26

### DIFF
--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -180,7 +180,9 @@ public:
     //!     @param m  Element index
     doublereal atomicWeight(size_t m) const;
 
-    //! Entropy of the element in its standard state at 298 K and 1 bar
+    //! Entropy of the element in its standard state at 298 K and 1 bar.
+    //! If no entropy value was provided when the phase was constructed,
+    //! returns the value `ENTROPY298_UNKNOWN`.
     //!     @param m  Element index
     doublereal entropyElement298(size_t m) const;
 

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -58,12 +58,12 @@ cdef Composition comp_map(X) except *:
 
     # assume X is dict-like
     cdef Composition m
-    for species,value in X.items():
+    for species,value in (<object>X).items():
         m[stringify(species)] = value
     return m
 
 cdef comp_map_to_dict(Composition m):
-    return {pystr(species):value for species,value in m.items()}
+    return {pystr(species):value for species,value in (<object>m).items()}
 
 class CanteraError(RuntimeError):
     pass

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -132,10 +132,7 @@ doublereal Phase::atomicWeight(size_t m) const
 
 doublereal Phase::entropyElement298(size_t m) const
 {
-    AssertThrowMsg(m_entropy298[m] != ENTROPY298_UNKNOWN,
-                   "Elements::entropy298",
-                   "Entropy at 298 K of element is unknown");
-    AssertTrace(m < m_mm);
+    checkElementIndex(m);
     return m_entropy298[m];
 }
 


### PR DESCRIPTION
Cython 0.26 unexpectedly removed automatic conversions of C++ containers to
Python containers. Explicit casting provides the old behavior.

Fixes #465
