### PR TITLE
Fix errors in duplicate reaction checks

### DIFF
--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -728,6 +728,10 @@ class TestDuplicateReactions(utilities.CanteraTest):
     def test_unmatched_duplicate(self):
         self.check('J')
 
+    def test_nonreacting_species(self):
+        gas = ct.Solution(self.infile, 'K')
+        self.assertEqual(gas.n_reactions, 3)
+
 
 class TestReaction(utilities.CanteraTest):
     @classmethod

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -104,12 +104,12 @@ std::pair<size_t, size_t> Kinetics::checkDuplicates(bool throw_err) const
 
         // Compare this reaction to others with similar participants
         vector<size_t>& related = participants[key];
-        for (size_t m = 0; m < related.size(); m++) {
-            Reaction& other = *m_reactions[related[m]];
+        for (size_t m : related) {
+            Reaction& other = *m_reactions[m];
             if (R.duplicate && other.duplicate) {
                 // marked duplicates
                 unmatched_duplicates.erase(i);
-                unmatched_duplicates.erase(related[m]);
+                unmatched_duplicates.erase(m);
                 continue;
             } else if (R.reaction_type != other.reaction_type) {
                 continue; // different reaction types

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -180,17 +180,23 @@ std::pair<size_t, size_t> Kinetics::checkDuplicates(bool throw_err) const
 double Kinetics::checkDuplicateStoich(std::map<int, double>& r1,
                                       std::map<int, double>& r2) const
 {
-    auto b = r1.begin(), e = r1.end();
-    int k1 = b->first;
+    std::unordered_set<int> keys; // species keys (k+1 or -k-1)
+    for (auto& r : r1) {
+        keys.insert(r.first);
+    }
+    for (auto& r : r2) {
+        keys.insert(r.first);
+    }
+    int k1 = r1.begin()->first;
     // check for duplicate written in the same direction
     doublereal ratio = 0.0;
     if (r1[k1] && r2[k1]) {
         ratio = r2[k1]/r1[k1];
-        ++b;
         bool different = false;
-        for (; b != e; ++b) {
-            k1 = b->first;
-            if (!r1[k1] || !r2[k1] || fabs(r2[k1]/r1[k1] - ratio) > 1.e-8) {
+        for (int k : keys) {
+            if ((r1[k] && !r2[k]) ||
+                (!r1[k] && r2[k]) ||
+                (r1[k] && fabs(r2[k]/r1[k] - ratio) > 1.e-8)) {
                 different = true;
                 break;
             }
@@ -201,16 +207,14 @@ double Kinetics::checkDuplicateStoich(std::map<int, double>& r1,
     }
 
     // check for duplicate written in the reverse direction
-    b = r1.begin();
-    k1 = b->first;
     if (r1[k1] == 0.0 || r2[-k1] == 0.0) {
         return 0.0;
     }
     ratio = r2[-k1]/r1[k1];
-    ++b;
-    for (; b != e; ++b) {
-        k1 = b->first;
-        if (!r1[k1] || !r2[-k1] || fabs(r2[-k1]/r1[k1] - ratio) > 1.e-8) {
+    for (int k : keys) {
+        if ((r1[k] && !r2[-k]) ||
+            (!r1[k] && r2[-k]) ||
+            (r1[k] && fabs(r2[-k]/r1[k] - ratio) > 1.e-8)) {
             return 0.0;
         }
     }

--- a/test/data/duplicate-reactions.cti
+++ b/test/data/duplicate-reactions.cti
@@ -17,6 +17,7 @@ make_gas('G', 'G-*')
 make_gas('H', 'H-*')
 make_gas('I', 'I-*')
 make_gas('J', ['C-1', 'F-1', 'I-1']) # unmatched duplicate
+make_gas('K', 'K-*')
 
 kf = [1e10, 0, 100]
 
@@ -60,3 +61,8 @@ three_body_reaction('O + H2 + M <=> H + OH + M', kf, id='H-2')
 # Declared duplicate (allowed)
 reaction('O + H2 <=> H + OH', kf, options='duplicate', id='I-1')
 reaction('H + OH <=> O + H2', kf, options='duplicate', id='I-2')
+
+# Not actually duplicates
+reaction('O + 2 H <=> H2O', kf, id='K-0') # random other reaction
+reaction('2 OH + H2 <=> H2O2 + H2', kf, id='K-1')
+reaction('2 OH <=> H2O2', kf, id='K-2')

--- a/test/data/duplicate-reactions.cti
+++ b/test/data/duplicate-reactions.cti
@@ -21,6 +21,7 @@ make_gas('J', ['C-1', 'F-1', 'I-1']) # unmatched duplicate
 kf = [1e10, 0, 100]
 
 # Forward multiple (not allowed)
+reaction('O + 2 H <=> H2O', kf, id='A-0') # random other reaction
 reaction('O + H2 <=> H + OH', kf, id='A-1')
 reaction('2 O + 2 H2 <=> 2 H + 2 OH', kf, id='A-2')
 
@@ -33,6 +34,7 @@ reaction('H + O2 + AR <=> HO2 + AR', kf, id='C-1')
 reaction('HO2 + AR <=> H + O2 + AR', kf, id='C-2')
 
 # Opposite direction #3 (not allowed)
+reaction('O + 2 H <=> H2O', kf, id='D-0') # random other reaction
 reaction('H + O2 + AR <=> HO2 + AR', kf, id='D-1')
 reaction('HO2 + AR => H + O2 + AR', kf, id='D-2')
 


### PR DESCRIPTION
Fix two problems identified in the duplicate reaction checks from a mechanism provided by @rwest .

In the first, we were comparing each reaction against the wrong reaction (i.e. not ones that we had identified as having the same set of species participating) causing a lot of unmarked duplicates to slip through.

In the second, reaction pairs like
```
OH* -> OH
OH* + CO2 -> OH + CO2
```
were mistakenly being flagged as duplicates.