### PR TITLE
Add get refine criteria

### DIFF
--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -140,6 +140,13 @@ public:
                            doublereal slope = 0.8, doublereal curve = 0.8, doublereal prune = -0.1);
 
     /**
+     * Get the grid refinement criteria. dom must be greater than
+     * or equal to zero (i.e., the domain must be specified).
+     * @see Refiner::getCriteria
+     */
+    vector_fp getRefineCriteria(int dom);
+
+    /**
      * Set the maximum number of grid points in the domain. If dom >= 0,
      * then the settings apply only to the specified domain. If dom < 0,
      * the settings are applied to each domain.  @see Refiner::setMaxPoints.

--- a/include/cantera/oneD/refine.h
+++ b/include/cantera/oneD/refine.h
@@ -36,6 +36,12 @@ public:
                      doublereal curve = 0.8,
                      doublereal prune = -0.1);
 
+    //! Get the grid refinement criteria. @see Refiner::setCriteria
+    vector_fp getCriteria()
+    {
+        return {m_ratio, m_slope, m_curve, m_prune};
+    }
+
     void setActive(int comp, bool state = true) {
         m_active[comp] = state;
     }

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -721,6 +721,7 @@ cdef extern from "cantera/oneD/Sim1D.h":
         void solve(int, cbool) except +translate_exception
         void refine(int) except +translate_exception
         void setRefineCriteria(size_t, double, double, double, double) except +translate_exception
+        vector[double] getRefineCriteria(int) except +translate_exception
         void save(string, string, string, int) except +translate_exception
         void restore(string, string, int) except +translate_exception
         void writeStats(int) except +translate_exception

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -57,6 +57,18 @@ class FlameBase(Sim1D):
         super(FlameBase, self).set_refine_criteria(self.flame, ratio, slope,
                                                    curve, prune)
 
+    def get_refine_criteria(self):
+        """
+        Get a dictionary of the criteria used for grid refinement. The items in
+        the dictionary are the ``ratio``, ``slope``, ``curve``, and ``prune``,
+        as defined in `~FlameBase.set_refine_criteria`.
+
+        >>> f.set_refine_criteria(ratio=3.0, slope=0.1, curve=0.2, prune=0)
+        >>> f.get_refine_criteria()
+        {'ratio': 3.0, 'slope': 0.1, 'curve': 0.2, 'prune': 0.0}
+        """
+        return super(FlameBase, self).get_refine_criteria(self.flame)
+
     def set_profile(self, component, locations, values):
         """
         Set an initial estimate for a profile of one component.
@@ -414,10 +426,10 @@ class FreeFlame(FlameBase):
         """
         Set the initial guess for the solution. The adiabatic flame
         temperature and equilibrium composition are computed for the inlet gas
-        composition. 
-        
+        composition.
+
         :param locs:
-            A list of four locations to define the temperature and mass fraction profiles. 
+            A list of four locations to define the temperature and mass fraction profiles.
             Profiles rise linearly between the second and third location.
             Locations are given as a fraction of the entire domain
         """

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -997,6 +997,23 @@ cdef class Sim1D:
         idom = self.domain_index(domain)
         self.sim.setRefineCriteria(idom, ratio, slope, curve, prune)
 
+    def get_refine_criteria(self, domain):
+        """
+        Get a dictionary of the criteria used to refine one domain. The items in
+        the dictionary are the ``ratio``, ``slope``, ``curve``, and ``prune``,
+        as defined in `~Sim1D.set_refine_criteria`.
+
+        :param domain:
+            domain object, index, or name
+
+        >>> s.set_refine_criteria(d, ratio=5.0, slope=0.2, curve=0.3, prune=0.03)
+        >>> s.get_refine_criteria(d)
+        {'ratio': 5.0, 'slope': 0.2, 'curve': 0.3, 'prune': 0.03}
+        """
+        idom = self.domain_index(domain)
+        c = self.sim.getRefineCriteria(idom)
+        return {'ratio': c[0], 'slope': c[1], 'curve': c[2], 'prune': c[3]}
+
     def set_grid_min(self, dz, domain=None):
         """
         Set the minimum grid spacing on *domain*. If *domain* is None, then

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -449,6 +449,13 @@ class TestFreeFlame(utilities.CanteraTest):
                 vals[i] = bad[i]
                 self.sim.set_refine_criteria(*vals)
 
+    def test_refine_criteria(self):
+        self.create_sim(ct.one_atm, 300.0, 'H2:1.1, O2:1, AR:5')
+        vals = {'ratio': 3.0, 'slope': 0.1, 'curve': 0.2, 'prune': 0.05}
+        self.sim.set_refine_criteria(**vals)
+        check = self.sim.get_refine_criteria()
+        self.assertEqual(vals, check)
+
     def test_replace_grid(self):
         self.create_sim(ct.one_atm, 300.0, 'H2:1.1, O2:1, AR:5')
         self.solve_fixed_T()

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -525,6 +525,17 @@ void Sim1D::setRefineCriteria(int dom, doublereal ratio,
     }
 }
 
+vector_fp Sim1D::getRefineCriteria(int dom)
+{
+   if (dom >= 0) {
+       Refiner& r = domain(dom).refiner();
+       return r.getCriteria();
+   } else {
+       throw CanteraError("Sim1D::getRefineCriteria",
+           "Must specify domain to get criteria from");
+   }
+}
+
 void Sim1D::setGridMin(int dom, double gridmin)
 {
     if (dom >= 0) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a function to get the refine criteria of a 1-D flow. I wasn't sure if it would be best to return as a vector or a struct (and into a dict in Python). Advice appreciated.