### PR TITLE
Remove Boost from API

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -70,7 +70,10 @@
   `std::shared_ptr` when dynamic allocation is required.
 * Portions of Boost which are "header only" may be used. If possible, include
   Boost header files only within .cpp files rather than other header files to
-  avoid unnecessary increases in compilation time.
+  avoid unnecessary increases in compilation time. Boost should not be added
+  to the public interface unless its existence and use is optional. This keeps
+  the number of dependencies low for users of Cantera. In these cases,
+  CANTERA_API_NO_BOOST should be used to conditionally remove Boost dependencies.
 * While Cantera does not specifically follow these rules, the following style
   guides are useful references for possible style choices and the rationales behind them.
   * The Google C++ Style Guide: https://google.github.io/styleguide/cppguide.html

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -188,6 +188,8 @@ private:
 
 }
 
+#ifndef CANTERA_API_NO_BOOST
 #include "cantera/base/AnyMap.inl.h"
+#endif
 
 #endif

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -38,102 +38,39 @@ public:
 
     // The value knows the name of its corresponding key in order to provide
     // comprehensible error messages.
-    void setKey(const std::string& key) { m_key = key; };
+    void setKey(const std::string& key);
 
     template<class T>
-    const T& as() const {
-        try {
-            return boost::any_cast<const T&>(m_value);
-        } catch (boost::bad_any_cast&) {
-            if (m_value.type() == typeid(void)) {
-                // Values that have not been set are of type 'void'
-                throw CanteraError("AnyValue::as", "Key '{}' not found", m_key);
-            } else {
-                throw CanteraError("AnyValue::as",
-                    "Key '{}' contains a '{}',\nnot a '{}'.",
-                    m_key, demangle(m_value.type()), demangle(typeid(T)));
-            }
-        }
-    }
+    const T& as() const;
 
     template<class T>
-    T& as() {
-        try {
-            return boost::any_cast<T&>(m_value);
-        } catch (boost::bad_any_cast&) {
-            if (m_value.type() == typeid(void)) {
-                // Values that have not been set are of type 'void'
-                throw CanteraError("AnyValue::as", "Key '{}' not found", m_key);
-            } else {
-                throw CanteraError("AnyValue::as",
-                    "Key '{}' contains a '{}',\nnot a '{}'.",
-                    m_key, demangle(m_value.type()), demangle(typeid(T)));
-            }
-        }
-    }
+    T& as();
 
-    const std::type_info& type() {
-        return m_value.type();
-    }
+    const std::type_info& type();
 
     template<class T>
-    bool is() const {
-        return m_value.type() == typeid(T);
-    }
+    bool is() const;
 
-    AnyValue& operator=(const std::string& value) {
-        m_value = value;
-        return *this;
-    }
-    AnyValue& operator=(const char* value) {
-        m_value = std::string(value);
-        return *this;
-    }
-    const std::string& asString() const {
-        return as<std::string>();
-    }
+    AnyValue& operator=(const std::string& value);
+    AnyValue& operator=(const char* value);
+    const std::string& asString() const;
 
-    AnyValue& operator=(double value) {
-        m_value = value;
-        return *this;
-    }
-    double asDouble() const {
-        return as<double>();
-    }
+    AnyValue& operator=(double value);
+    double asDouble() const;
 
-    AnyValue& operator=(bool value) {
-        m_value = value;
-        return *this;
-    }
-    bool asBool() const {
-        return as<bool>();
-    }
+    AnyValue& operator=(bool value);
+    bool asBool() const;
 
-    AnyValue& operator=(long int value) {
-        m_value = value;
-        return *this;
-    }
-    AnyValue& operator=(int value) {
-        m_value = static_cast<long int>(value);
-        return *this;
-    }
-    long int asInt() const {
-        return as<long int>();
-    }
+    AnyValue& operator=(long int value);
+    AnyValue& operator=(int value);
+    long int asInt() const;
 
     template<class T>
-    AnyValue& operator=(const std::vector<T>& value) {
-        m_value = value;
-        return *this;
-    }
+    AnyValue& operator=(const std::vector<T>& value);
     template<class T>
-    const std::vector<T>& asVector() const {
-        return as<std::vector<T>>();
-    }
+    const std::vector<T>& asVector() const;
     template<class T>
-    std::vector<T>& asVector() {
-        return as<std::vector<T>>();
-    }
+    std::vector<T>& asVector();
 
     AnyValue& operator=(const AnyMap& value);
     AnyValue& operator=(AnyMap&& value);
@@ -239,60 +176,8 @@ private:
     friend class AnyValue;
 };
 
-// Definitions for templated functions which require the full declaration of
-// class AnyMap.
-
-template<class T>
-AnyValue& AnyValue::operator=(const std::unordered_map<std::string, T> items) {
-    m_value = AnyMap();
-    AnyMap& dest = as<AnyMap>();
-    for (const auto& item : items) {
-        dest[item.first] = item.second;
-    }
-    return *this;
 }
 
-template<class T>
-AnyValue& AnyValue::operator=(const std::map<std::string, T> items) {
-    m_value = AnyMap();
-    AnyMap& dest = as<AnyMap>();
-    for (const auto& item : items) {
-        dest[item.first] = item.second;
-    }
-    return *this;
-}
+#include "cantera/base/AnyMap.inl.h"
 
-template<>
-inline AnyMap& AnyValue::as<AnyMap>() {
-    try {
-        // This is where nested AnyMaps are created when the syntax
-        // m[key1][key2] is used.
-        if (m_value.type() == typeid(void)) {
-            m_value = AnyMap();
-        }
-        return boost::any_cast<AnyMap&>(m_value);
-    } catch (boost::bad_any_cast&) {
-        throw CanteraError("AnyValue::as",
-            "value of key '{}' is a '{}',\nnot an 'AnyMap'.",
-            m_key, demangle(m_value.type()));
-    }
-}
-
-template<class T>
-std::map<std::string, T> AnyValue::asMap()
-{
-    std::map<std::string, T> dest;
-    for (const auto& item : as<AnyMap>().m_data) {
-        try {
-            dest[item.first] = boost::any_cast<T>(item.second.m_value);
-        } catch (boost::bad_any_cast&) {
-            throw CanteraError("AnyValue::asMap",
-                "Value of key '{}' is not a '{}'",
-                item.first, demangle(typeid(T)));
-        }
-    }
-    return dest;
-}
-
-}
 #endif

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -7,12 +7,15 @@
 #include "cantera/base/global.h"
 #include "cantera/base/ctexceptions.h"
 
-#include <boost/any.hpp>
-#include <boost/algorithm/string.hpp>
-
 #include <string>
 #include <vector>
+#include <memory>
 #include <unordered_map>
+
+namespace boost
+{
+class any;
+}
 
 namespace Cantera
 {
@@ -32,6 +35,13 @@ class AnyMap;
 class AnyValue
 {
 public:
+    AnyValue();
+    ~AnyValue();
+    AnyValue(AnyValue const& other);
+    AnyValue(AnyValue&& other);
+    AnyValue& operator=(AnyValue const& other);
+    AnyValue& operator=(AnyValue&& other);
+
     AnyValue& operator[](const std::string& key);
 
     bool hasKey(const std::string& key) const;
@@ -88,7 +98,7 @@ private:
     std::string demangle(const std::type_info& type) const;
 
     std::string m_key;
-    boost::any m_value;
+    std::unique_ptr<boost::any> m_value;
     static std::map<std::string, std::string> s_typenames;
 };
 

--- a/include/cantera/base/AnyMap.inl.h
+++ b/include/cantera/base/AnyMap.inl.h
@@ -1,0 +1,122 @@
+//! @file AnyMap.inl.h
+
+#ifndef CT_ANYMAP_INL_H
+#define CT_ANYMAP_INL_H
+
+#include "cantera/base/AnyMap.h"
+
+#include <boost/any.hpp>
+#include <boost/algorithm/string.hpp>
+
+namespace Cantera
+{
+
+// Definitions for AnyValue templated functions
+
+template<class T>
+const T &AnyValue::as() const {
+    try {
+        return boost::any_cast<const T&>(m_value);
+    } catch (boost::bad_any_cast&) {
+        if (m_value.type() == typeid(void)) {
+            // Values that have not been set are of type 'void'
+            throw CanteraError("AnyValue::as", "Key '{}' not found", m_key);
+        } else {
+            throw CanteraError("AnyValue::as",
+                               "Key '{}' contains a '{}',\nnot a '{}'.",
+                               m_key, demangle(m_value.type()), demangle(typeid(T)));
+        }
+    }
+}
+
+template<class T>
+T &AnyValue::as() {
+    try {
+        return boost::any_cast<T&>(m_value);
+    } catch (boost::bad_any_cast&) {
+        if (m_value.type() == typeid(void)) {
+            // Values that have not been set are of type 'void'
+            throw CanteraError("AnyValue::as", "Key '{}' not found", m_key);
+        } else {
+            throw CanteraError("AnyValue::as",
+                               "Key '{}' contains a '{}',\nnot a '{}'.",
+                               m_key, demangle(m_value.type()), demangle(typeid(T)));
+        }
+    }
+}
+
+template<class T>
+bool AnyValue::is() const {
+    return m_value.type() == typeid(T);
+}
+
+template<class T>
+AnyValue &AnyValue::operator=(const std::vector<T> &value) {
+    m_value = value;
+    return *this;
+}
+
+template<class T>
+const std::vector<T> &AnyValue::asVector() const {
+    return as<std::vector<T>>();
+}
+
+template<class T>
+std::vector<T> &AnyValue::asVector() {
+    return as<std::vector<T>>();
+}
+
+template<class T>
+AnyValue& AnyValue::operator=(const std::unordered_map<std::string, T> items) {
+    m_value = AnyMap();
+    AnyMap& dest = as<AnyMap>();
+    for (const auto& item : items) {
+        dest[item.first] = item.second;
+    }
+    return *this;
+}
+
+template<class T>
+AnyValue& AnyValue::operator=(const std::map<std::string, T> items) {
+    m_value = AnyMap();
+    AnyMap& dest = as<AnyMap>();
+    for (const auto& item : items) {
+        dest[item.first] = item.second;
+    }
+    return *this;
+}
+
+template<>
+inline AnyMap& AnyValue::as<AnyMap>() {
+    try {
+        // This is where nested AnyMaps are created when the syntax
+        // m[key1][key2] is used.
+        if (m_value.type() == typeid(void)) {
+            m_value = AnyMap();
+        }
+        return boost::any_cast<AnyMap&>(m_value);
+    } catch (boost::bad_any_cast&) {
+        throw CanteraError("AnyValue::as",
+            "value of key '{}' is a '{}',\nnot an 'AnyMap'.",
+            m_key, demangle(m_value.type()));
+    }
+}
+
+template<class T>
+std::map<std::string, T> AnyValue::asMap()
+{
+    std::map<std::string, T> dest;
+    for (const auto& item : as<AnyMap>().m_data) {
+        try {
+            dest[item.first] = boost::any_cast<T>(item.second.m_value);
+        } catch (boost::bad_any_cast&) {
+            throw CanteraError("AnyValue::asMap",
+                "Value of key '{}' is not a '{}'",
+                item.first, demangle(typeid(T)));
+        }
+    }
+    return dest;
+}
+
+}
+#endif

--- a/include/cantera/base/AnyMap.inl.h
+++ b/include/cantera/base/AnyMap.inl.h
@@ -16,15 +16,15 @@ namespace Cantera
 template<class T>
 const T &AnyValue::as() const {
     try {
-        return boost::any_cast<const T&>(m_value);
+        return boost::any_cast<const T&>(*m_value);
     } catch (boost::bad_any_cast&) {
-        if (m_value.type() == typeid(void)) {
+        if (m_value->type() == typeid(void)) {
             // Values that have not been set are of type 'void'
             throw CanteraError("AnyValue::as", "Key '{}' not found", m_key);
         } else {
             throw CanteraError("AnyValue::as",
                                "Key '{}' contains a '{}',\nnot a '{}'.",
-                               m_key, demangle(m_value.type()), demangle(typeid(T)));
+                               m_key, demangle(m_value->type()), demangle(typeid(T)));
         }
     }
 }
@@ -32,27 +32,27 @@ const T &AnyValue::as() const {
 template<class T>
 T &AnyValue::as() {
     try {
-        return boost::any_cast<T&>(m_value);
+        return boost::any_cast<T&>(*m_value);
     } catch (boost::bad_any_cast&) {
-        if (m_value.type() == typeid(void)) {
+        if (m_value->type() == typeid(void)) {
             // Values that have not been set are of type 'void'
             throw CanteraError("AnyValue::as", "Key '{}' not found", m_key);
         } else {
             throw CanteraError("AnyValue::as",
                                "Key '{}' contains a '{}',\nnot a '{}'.",
-                               m_key, demangle(m_value.type()), demangle(typeid(T)));
+                               m_key, demangle(m_value->type()), demangle(typeid(T)));
         }
     }
 }
 
 template<class T>
 bool AnyValue::is() const {
-    return m_value.type() == typeid(T);
+    return m_value->type() == typeid(T);
 }
 
 template<class T>
 AnyValue &AnyValue::operator=(const std::vector<T> &value) {
-    m_value = value;
+    *m_value = value;
     return *this;
 }
 
@@ -68,7 +68,7 @@ std::vector<T> &AnyValue::asVector() {
 
 template<class T>
 AnyValue& AnyValue::operator=(const std::unordered_map<std::string, T> items) {
-    m_value = AnyMap();
+    *m_value = AnyMap();
     AnyMap& dest = as<AnyMap>();
     for (const auto& item : items) {
         dest[item.first] = item.second;
@@ -78,7 +78,7 @@ AnyValue& AnyValue::operator=(const std::unordered_map<std::string, T> items) {
 
 template<class T>
 AnyValue& AnyValue::operator=(const std::map<std::string, T> items) {
-    m_value = AnyMap();
+    *m_value = AnyMap();
     AnyMap& dest = as<AnyMap>();
     for (const auto& item : items) {
         dest[item.first] = item.second;
@@ -91,14 +91,14 @@ inline AnyMap& AnyValue::as<AnyMap>() {
     try {
         // This is where nested AnyMaps are created when the syntax
         // m[key1][key2] is used.
-        if (m_value.type() == typeid(void)) {
-            m_value = AnyMap();
+        if (m_value->type() == typeid(void)) {
+            *m_value = AnyMap();
         }
-        return boost::any_cast<AnyMap&>(m_value);
+        return boost::any_cast<AnyMap&>(*m_value);
     } catch (boost::bad_any_cast&) {
         throw CanteraError("AnyValue::as",
             "value of key '{}' is a '{}',\nnot an 'AnyMap'.",
-            m_key, demangle(m_value.type()));
+            m_key, demangle(m_value->type()));
     }
 }
 
@@ -108,7 +108,7 @@ std::map<std::string, T> AnyValue::asMap()
     std::map<std::string, T> dest;
     for (const auto& item : as<AnyMap>().m_data) {
         try {
-            dest[item.first] = boost::any_cast<T>(item.second.m_value);
+            dest[item.first] = boost::any_cast<T>(*item.second.m_value);
         } catch (boost::bad_any_cast&) {
             throw CanteraError("AnyValue::asMap",
                 "Value of key '{}' is not a '{}'",

--- a/include/cantera/base/stringUtils.h
+++ b/include/cantera/base/stringUtils.h
@@ -11,14 +11,11 @@
 
 #include "ct_defs.h"
 #include "cantera/base/fmt.h"
-#include <boost/algorithm/string.hpp>
 
 #include <string>
 
 namespace Cantera
 {
-
-namespace ba = boost::algorithm;
 
 //! Convert a vector to a string (separated by commas)
 /*!
@@ -152,6 +149,25 @@ void tokenizeString(const std::string& oval,
  *  *source*. Otherwise, returns 0.
  */
 size_t copyString(const std::string& source, char* dest, size_t length);
+
+//! Trim.
+/*!
+ *  Remove all leading and trailing spaces (with default locale).
+ */
+std::string trimCopy(const std::string &input);
+
+//! Convert to lower case.
+/*!
+ *  Convert the given string to lower case (with default locale).
+ */
+std::string toLowerCopy(const std::string& input);
+
+//! Case insensitive equality predicate.
+/*!
+ *  Returns true if and only if all elements in both strings are the same
+ *  when compared case insensitively (with default locale).
+ */
+bool caseInsensitiveEquals(const std::string &input, const std::string &test);
 
 }
 

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -17,6 +17,37 @@ std::map<std::string, std::string> AnyValue::s_typenames = {
 
 // Methods of class AnyValue
 
+AnyValue::AnyValue()
+  : m_key()
+  , m_value(new boost::any{})
+{}
+
+AnyValue::~AnyValue() = default;
+
+AnyValue::AnyValue(AnyValue const& other): m_key(other.m_key),
+                                           m_value(new boost::any{*other.m_value}) {
+}
+
+AnyValue::AnyValue(AnyValue&& other): m_key(std::move(other.m_key)),
+                                      m_value(std::move(other.m_value)) {
+}
+
+AnyValue& AnyValue::operator=(AnyValue const& other) {
+    if (this == &other)
+        return *this;
+    m_key = other.m_key;
+    m_value.reset(new boost::any{*other.m_value});
+    return *this;
+}
+
+AnyValue& AnyValue::operator=(AnyValue&& other) {
+    if (this == &other)
+        return *this;
+    m_key = std::move(other.m_key);
+    m_value = std::move(other.m_value);
+    return *this;
+}
+
 AnyValue& AnyValue::operator[](const std::string& key)
 {
     return as<AnyMap>()[key];
@@ -29,16 +60,16 @@ bool AnyValue::hasKey(const std::string& key) const {
 void AnyValue::setKey(const std::string &key) { m_key = key; }
 
 const std::type_info &AnyValue::type() {
-    return m_value.type();
+    return m_value->type();
 }
 
 AnyValue &AnyValue::operator=(const std::string &value) {
-    m_value = value;
+    *m_value = value;
     return *this;
 }
 
 AnyValue &AnyValue::operator=(const char *value) {
-    m_value = std::string(value);
+    *m_value = std::string(value);
     return *this;
 }
 
@@ -47,7 +78,7 @@ const std::string &AnyValue::asString() const {
 }
 
 AnyValue &AnyValue::operator=(double value) {
-    m_value = value;
+    *m_value = value;
     return *this;
 }
 
@@ -56,7 +87,7 @@ double AnyValue::asDouble() const {
 }
 
 AnyValue &AnyValue::operator=(bool value) {
-    m_value = value;
+    *m_value = value;
     return *this;
 }
 
@@ -65,12 +96,12 @@ bool AnyValue::asBool() const {
 }
 
 AnyValue &AnyValue::operator=(long int value) {
-    m_value = value;
+    *m_value = value;
     return *this;
 }
 
 AnyValue &AnyValue::operator=(int value) {
-    m_value = static_cast<long int>(value);
+    *m_value = static_cast<long int>(value);
     return *this;
 }
 
@@ -78,12 +109,12 @@ long int AnyValue::asInt() const {
     return as<long int>();
 }
 AnyValue& AnyValue::operator=(const AnyMap& value) {
-    m_value = value;
+    *m_value = value;
     return *this;
 }
 
 AnyValue& AnyValue::operator=(AnyMap&& value) {
-    m_value = std::move(value);
+    *m_value = std::move(value);
     return *this;
 }
 

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -26,6 +26,57 @@ bool AnyValue::hasKey(const std::string& key) const {
     return (is<AnyMap>() && as<AnyMap>().hasKey(key));
 }
 
+void AnyValue::setKey(const std::string &key) { m_key = key; }
+
+const std::type_info &AnyValue::type() {
+    return m_value.type();
+}
+
+AnyValue &AnyValue::operator=(const std::string &value) {
+    m_value = value;
+    return *this;
+}
+
+AnyValue &AnyValue::operator=(const char *value) {
+    m_value = std::string(value);
+    return *this;
+}
+
+const std::string &AnyValue::asString() const {
+    return as<std::string>();
+}
+
+AnyValue &AnyValue::operator=(double value) {
+    m_value = value;
+    return *this;
+}
+
+double AnyValue::asDouble() const {
+    return as<double>();
+}
+
+AnyValue &AnyValue::operator=(bool value) {
+    m_value = value;
+    return *this;
+}
+
+bool AnyValue::asBool() const {
+    return as<bool>();
+}
+
+AnyValue &AnyValue::operator=(long int value) {
+    m_value = value;
+    return *this;
+}
+
+AnyValue &AnyValue::operator=(int value) {
+    m_value = static_cast<long int>(value);
+    return *this;
+}
+
+long int AnyValue::asInt() const {
+    return as<long int>();
+}
 AnyValue& AnyValue::operator=(const AnyMap& value) {
     m_value = value;
     return *this;
@@ -44,7 +95,6 @@ std::string AnyValue::demangle(const std::type_info& type) const
         return type.name();
     }
 }
-
 
 // Methods of class AnyMap
 

--- a/src/base/ct2ctml.cpp
+++ b/src/base/ct2ctml.cpp
@@ -45,7 +45,7 @@ static string pypath()
     const char* py = getenv("PYTHON_CMD");
 
     if (py) {
-        string sp = ba::trim_copy(string(py));
+        string sp = trimCopy(string(py));
         if (sp.size() > 0) {
             s = sp;
         }
@@ -138,7 +138,7 @@ static std::string call_ctml_writer(const std::string& text, bool isfile)
         }
         python.close();
         python_exit_code = python.exit_code();
-        error_output = ba::trim_copy(error_stream.str());
+        error_output = trimCopy(error_stream.str());
         python_output = output_stream.str();
     } catch (std::exception& err) {
         // Report failure to execute Python
@@ -238,7 +238,7 @@ void ck2cti(const std::string& in_file, const std::string& thermo_file,
         }
         python.close();
         python_exit_code = python.exit_code();
-        python_output = ba::trim_copy(output_stream.str());
+        python_output = trimCopy(output_stream.str());
     } catch (std::exception& err) {
         // Report failure to execute Python
         stringstream message;

--- a/src/base/stringUtils.cpp
+++ b/src/base/stringUtils.cpp
@@ -245,4 +245,16 @@ size_t copyString(const std::string& source, char* dest, size_t length)
     return ret;
 }
 
+std::string trimCopy(const std::string &input) {
+    return ba::trim_copy(input);
+}
+
+std::string toLowerCopy(const std::string &input) {
+    return ba::to_lower_copy(input);
+}
+
+bool caseInsensitiveEquals(const std::string &input, const std::string &test) {
+    return ba::iequals(input, test);
+}
+
 }

--- a/src/base/xml.cpp
+++ b/src/base/xml.cpp
@@ -192,11 +192,11 @@ int XML_Reader::findQuotedString(const std::string& s, std::string& rstring) con
 void XML_Reader::parseTag(const std::string& tag, std::string& name,
                           std::map<std::string, std::string>& attribs) const
 {
-    string s = ba::trim_copy(tag);
+    string s = trimCopy(tag);
     size_t iloc = s.find(' ');
     if (iloc != string::npos) {
         name = s.substr(0, iloc);
-        s = ba::trim_copy(s.substr(iloc+1,s.size()));
+        s = trimCopy(s.substr(iloc+1,s.size()));
         if (s[s.size()-1] == '/') {
             name += "/";
         }
@@ -207,17 +207,17 @@ void XML_Reader::parseTag(const std::string& tag, std::string& name,
             if (iloc == string::npos) {
                 break;
             }
-            string attr = ba::trim_copy(s.substr(0,iloc));
+            string attr = trimCopy(s.substr(0,iloc));
             if (attr == "") {
                 break;
             }
-            s = ba::trim_copy(s.substr(iloc+1,s.size()));
+            s = trimCopy(s.substr(iloc+1,s.size()));
             string val;
             iloc = findQuotedString(s, val);
             attribs[attr] = val;
             if (iloc != string::npos) {
                 if (iloc < s.size()) {
-                    s = ba::trim_copy(s.substr(iloc,s.size()));
+                    s = trimCopy(s.substr(iloc,s.size()));
                 } else {
                     break;
                 }
@@ -301,7 +301,7 @@ std::string XML_Reader::readValue()
             tag += ch;
         }
     }
-    return ba::trim_copy(tag);
+    return trimCopy(tag);
 }
 
 //////////////////////////  XML_Node  /////////////////////////////////
@@ -443,7 +443,7 @@ void XML_Node::addValue(const std::string& val)
 
 void XML_Node::addValue(const doublereal val, const std::string& fmt)
 {
-    m_value = ba::trim_copy(fmt::sprintf(fmt, val));
+    m_value = trimCopy(fmt::sprintf(fmt, val));
 }
 
 std::string XML_Node::value() const
@@ -865,7 +865,7 @@ std::vector<XML_Node*> XML_Node::getChildren(const std::string& nm) const
 {
     std::vector<XML_Node*> children_;
     for (size_t i = 0; i < nChildren(); i++) {
-        if (ba::iequals(child(i).name(),  nm)) {
+        if (caseInsensitiveEquals(child(i).name(),  nm)) {
             children_.push_back(&child(i));
         }
     }

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -49,7 +49,7 @@ KineticsFactory::KineticsFactory() {
 
 Kinetics* KineticsFactory::newKinetics(const string& model)
 {
-    return create(ba::to_lower_copy(model));
+    return create(toLowerCopy(model));
 }
 
 }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -295,19 +295,19 @@ void readFalloff(FalloffReaction& R, const XML_Node& rc_node)
     }
 
     int falloff_type = 0;
-    if (ba::iequals(falloff["type"], "lindemann")) {
+    if (caseInsensitiveEquals(falloff["type"], "lindemann")) {
         falloff_type = SIMPLE_FALLOFF;
         if (np != 0) {
             throw CanteraError("readFalloff", "Lindemann parameterization "
                 "takes no parameters, but {} were given", np);
         }
-    } else if (ba::iequals(falloff["type"], "troe")) {
+    } else if (caseInsensitiveEquals(falloff["type"], "troe")) {
         falloff_type = TROE_FALLOFF;
         if (np != 3 && np != 4) {
             throw CanteraError("readFalloff", "Troe parameterization takes "
                 "3 or 4 parameters, but {} were given", np);
         }
-    } else if (ba::iequals(falloff["type"], "sri")) {
+    } else if (caseInsensitiveEquals(falloff["type"], "sri")) {
         falloff_type = SRI_FALLOFF;
         if (np != 3 && np != 5) {
             throw CanteraError("readFalloff", "SRI parameterization takes "
@@ -478,23 +478,23 @@ void setupChebyshevReaction(ChebyshevReaction& R, const XML_Node& rxn_node)
 
 void setupInterfaceReaction(InterfaceReaction& R, const XML_Node& rxn_node)
 {
-    if (ba::iequals(rxn_node["type"], "global")) {
+    if (caseInsensitiveEquals(rxn_node["type"], "global")) {
         R.reaction_type = GLOBAL_RXN;
     }
     XML_Node& arr = rxn_node.child("rateCoeff").child("Arrhenius");
-    if (ba::iequals(arr["type"], "stick")) {
+    if (caseInsensitiveEquals(arr["type"], "stick")) {
         R.is_sticking_coefficient = true;
         R.sticking_species = arr["species"];
 
-        if (ba::iequals(arr["motz_wise"], "true")) {
+        if (caseInsensitiveEquals(arr["motz_wise"], "true")) {
             R.use_motz_wise_correction = true;
-        } else if (ba::iequals(arr["motz_wise"], "false")) {
+        } else if (caseInsensitiveEquals(arr["motz_wise"], "false")) {
             R.use_motz_wise_correction = false;
         } else {
             // Default value for all reactions
             XML_Node* parent = rxn_node.parent();
             if (parent && parent->name() == "reactionData"
-                && ba::iequals((*parent)["motz_wise"], "true")) {
+                && caseInsensitiveEquals((*parent)["motz_wise"], "true")) {
                 R.use_motz_wise_correction = true;
             }
         }
@@ -513,7 +513,7 @@ void setupElectrochemicalReaction(ElectrochemicalReaction& R,
                                   const XML_Node& rxn_node)
 {
     // Fix reaction_type for some specialized reaction types
-    std::string type = ba::to_lower_copy(rxn_node["type"]);
+    std::string type = toLowerCopy(rxn_node["type"]);
     if (type == "butlervolmer") {
         R.reaction_type = BUTLERVOLMER_RXN;
     } else if (type == "butlervolmer_noactivitycoeffs") {
@@ -525,7 +525,7 @@ void setupElectrochemicalReaction(ElectrochemicalReaction& R,
     }
 
     XML_Node& rc = rxn_node.child("rateCoeff");
-    std::string rc_type = ba::to_lower_copy(rc["type"]);
+    std::string rc_type = toLowerCopy(rc["type"]);
     if (rc_type == "exchangecurrentdensity") {
         R.exchange_current_density_formulation = true;
     } else if (rc_type != "" && rc_type != "arrhenius") {
@@ -568,13 +568,13 @@ void setupElectrochemicalReaction(ElectrochemicalReaction& R,
         R.orders.clear();
         R.allow_nonreactant_orders = true;
         const XML_Node& rof_node = rxn_node.child("reactionOrderFormulation");
-        if (ba::iequals(rof_node["model"], "reactantorders")) {
+        if (caseInsensitiveEquals(rof_node["model"], "reactantorders")) {
             R.orders = initial_orders;
-        } else if (ba::iequals(rof_node["model"], "zeroorders")) {
+        } else if (caseInsensitiveEquals(rof_node["model"], "zeroorders")) {
             for (const auto& sp : R.reactants) {
                 R.orders[sp.first] = 0.0;
             }
-        } else if (ba::iequals(rof_node["model"], "butlervolmerorders")) {
+        } else if (caseInsensitiveEquals(rof_node["model"], "butlervolmerorders")) {
             // Reaction orders based on provided reaction orders
             for (const auto& sp : R.reactants) {
                 double c = getValue(initial_orders, sp.first, sp.second);
@@ -602,7 +602,7 @@ void setupElectrochemicalReaction(ElectrochemicalReaction& R,
 
 shared_ptr<Reaction> newReaction(const XML_Node& rxn_node)
 {
-    std::string type = ba::to_lower_copy(rxn_node["type"]);
+    std::string type = toLowerCopy(rxn_node["type"]);
 
     // Modify the reaction type for interface reactions which contain
     // electrochemical reaction data

--- a/src/kinetics/importKinetics.cpp
+++ b/src/kinetics/importKinetics.cpp
@@ -284,7 +284,7 @@ bool checkElectrochemReaction(const XML_Node& p, Kinetics& kin, const XML_Node& 
 
     // If the reaction is electrochemical, ensure the reaction is identified as
     // electrochemical. If not already specified beta is assumed to be 0.5
-    std::string type = ba::to_lower_copy(r["type"]);
+    std::string type = toLowerCopy(r["type"]);
     if (!r.child("rateCoeff").hasChild("electrochem")) {
         if ((type != "butlervolmer_noactivitycoeffs" &&
              type != "butlervolmer" &&

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -305,17 +305,17 @@ void DebyeHuckel::getPartialMolarCp(doublereal* cpbar) const
  */
 static int interp_est(const std::string& estString)
 {
-    if (ba::iequals(estString, "solvent")) {
+    if (caseInsensitiveEquals(estString, "solvent")) {
         return cEST_solvent;
-    } else if (ba::iequals(estString, "chargedspecies")) {
+    } else if (caseInsensitiveEquals(estString, "chargedspecies")) {
         return cEST_chargedSpecies;
-    } else if (ba::iequals(estString, "weakacidassociated")) {
+    } else if (caseInsensitiveEquals(estString, "weakacidassociated")) {
         return cEST_weakAcidAssociated;
-    } else if (ba::iequals(estString, "strongacidassociated")) {
+    } else if (caseInsensitiveEquals(estString, "strongacidassociated")) {
         return cEST_strongAcidAssociated;
-    } else if (ba::iequals(estString, "polarneutral")) {
+    } else if (caseInsensitiveEquals(estString, "polarneutral")) {
         return cEST_polarNeutral;
-    } else if (ba::iequals(estString, "nonpolarneutral")) {
+    } else if (caseInsensitiveEquals(estString, "nonpolarneutral")) {
         return cEST_nonpolarNeutral;
     } else {
         throw CanteraError("interp_est (DebyeHuckel)",
@@ -324,16 +324,16 @@ static int interp_est(const std::string& estString)
 }
 
 void DebyeHuckel::setDebyeHuckelModel(const std::string& model) {
-    if (model == "" || ba::iequals(model, "Dilute_limit")) {
+    if (model == "" || caseInsensitiveEquals(model, "Dilute_limit")) {
         m_formDH = DHFORM_DILUTE_LIMIT;
-    } else if (ba::iequals(model, "Bdot_with_variable_a")) {
+    } else if (caseInsensitiveEquals(model, "Bdot_with_variable_a")) {
         m_formDH = DHFORM_BDOT_AK;
-    } else if (ba::iequals(model, "Bdot_with_common_a")) {
+    } else if (caseInsensitiveEquals(model, "Bdot_with_common_a")) {
         m_formDH = DHFORM_BDOT_ACOMMON;
-    } else if (ba::iequals(model, "Beta_ij")) {
+    } else if (caseInsensitiveEquals(model, "Beta_ij")) {
         m_formDH = DHFORM_BETAIJ;
         m_Beta_ij.resize(m_kk, m_kk, 0.0);
-    } else if (ba::iequals(model, "Pitzer_with_Beta_ij")) {
+    } else if (caseInsensitiveEquals(model, "Pitzer_with_Beta_ij")) {
         m_formDH = DHFORM_PITZER_BETAIJ;
         m_Beta_ij.resize(m_kk, m_kk, 0.0);
     } else {
@@ -432,7 +432,7 @@ void DebyeHuckel::initThermoXML(XML_Node& phaseNode, const std::string& id_)
             XML_Node* ss = acNode.findByName("A_Debye");
             string modelString = ss->attrib("model");
             if (modelString != "") {
-                if (ba::iequals(modelString, "water")) {
+                if (caseInsensitiveEquals(modelString, "water")) {
                     setA_Debye(-1);
                 } else {
                     throw CanteraError("DebyeHuckel::initThermoXML",

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -167,8 +167,8 @@ double getElementWeight(const std::string& ename)
 {
     int numElements = numElementsDefined();
     int numIsotopes = numIsotopesDefined();
-    string symbol = ba::trim_copy(ename);
-    string name = ba::to_lower_copy(symbol);
+    string symbol = trimCopy(ename);
+    string name = toLowerCopy(symbol);
     for (int i = 0; i < numElements; i++) {
         if (symbol == atomicWeightTable[i].symbol) {
             return atomicWeightTable[i].atomicWeight;
@@ -199,7 +199,7 @@ string getElementSymbol(const std::string& ename)
 {
     int numElements = numElementsDefined();
     int numIsotopes = numIsotopesDefined();
-    string name = ba::to_lower_copy(ba::trim_copy(ename));
+    string name = toLowerCopy(trimCopy(ename));
     for (int i = 0; i < numElements; i++) {
         if (name == atomicWeightTable[i].fullName) {
             return atomicWeightTable[i].symbol;
@@ -227,7 +227,7 @@ string getElementName(const std::string& ename)
 {
     int numElements = numElementsDefined();
     int numIsotopes = numIsotopesDefined();
-    string symbol = ba::trim_copy(ename);
+    string symbol = trimCopy(ename);
     for (int i = 0; i < numElements; i++) {
         if (symbol == atomicWeightTable[i].symbol) {
             return atomicWeightTable[i].fullName;
@@ -255,8 +255,8 @@ int getAtomicNumber(const std::string& ename)
 {
     int numElements = numElementsDefined();
     int numIsotopes = numIsotopesDefined();
-    string symbol = ba::trim_copy(ename);
-    string name = ba::to_lower_copy(symbol);
+    string symbol = trimCopy(ename);
+    string name = toLowerCopy(symbol);
     for (int i = 0; i < numElements; i++) {
         if (symbol == atomicWeightTable[i].symbol) {
             return i+1;

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -626,11 +626,11 @@ void HMWSoln::setZeta(const std::string& sp1, const std::string& sp2,
 
 void HMWSoln::setPitzerTempModel(const std::string& model)
 {
-    if (ba::iequals(model, "constant") || ba::iequals(model, "default")) {
+    if (caseInsensitiveEquals(model, "constant") || caseInsensitiveEquals(model, "default")) {
         m_formPitzerTemp = PITZER_TEMP_CONSTANT;
-    } else if (ba::iequals(model, "linear")) {
+    } else if (caseInsensitiveEquals(model, "linear")) {
         m_formPitzerTemp = PITZER_TEMP_LINEAR;
-    } else if (ba::iequals(model, "complex") || ba::iequals(model, "complex1")) {
+    } else if (caseInsensitiveEquals(model, "complex") || caseInsensitiveEquals(model, "complex1")) {
         m_formPitzerTemp = PITZER_TEMP_COMPLEX1;
     } else {
         throw CanteraError("HMWSoln::setPitzerTempModel",
@@ -793,7 +793,7 @@ void HMWSoln::initThermoXML(XML_Node& phaseNode, const std::string& id_)
         // Look for parameters for A_Debye
         if (acNode.hasChild("A_Debye")) {
             XML_Node& ADebye = acNode.child("A_Debye");
-            if (ba::iequals(ADebye["model"], "water")) {
+            if (caseInsensitiveEquals(ADebye["model"], "water")) {
                 setA_Debye(-1);
             } else {
                 setA_Debye(getFloat(acNode, "A_Debye"));
@@ -811,19 +811,19 @@ void HMWSoln::initThermoXML(XML_Node& phaseNode, const std::string& id_)
             // Process any of the XML fields that make up the Pitzer Database.
             // Entries will be ignored if any of the species in the entry aren't
             // in the solution.
-            if (ba::iequals(nodeName, "binarysaltparameters")) {
+            if (caseInsensitiveEquals(nodeName, "binarysaltparameters")) {
                 readXMLBinarySalt(*xmlACChild);
-            } else if (ba::iequals(nodeName, "thetaanion")) {
+            } else if (caseInsensitiveEquals(nodeName, "thetaanion")) {
                 readXMLTheta(*xmlACChild);
-            } else if (ba::iequals(nodeName, "thetacation")) {
+            } else if (caseInsensitiveEquals(nodeName, "thetacation")) {
                 readXMLTheta(*xmlACChild);
-            } else if (ba::iequals(nodeName, "psicommonanion")) {
+            } else if (caseInsensitiveEquals(nodeName, "psicommonanion")) {
                 readXMLPsi(*xmlACChild);
-            } else if (ba::iequals(nodeName, "psicommoncation")) {
+            } else if (caseInsensitiveEquals(nodeName, "psicommoncation")) {
                 readXMLPsi(*xmlACChild);
-            } else if (ba::iequals(nodeName, "lambdaneutral")) {
+            } else if (caseInsensitiveEquals(nodeName, "lambdaneutral")) {
                 readXMLLambdaNeutral(*xmlACChild);
-            } else if (ba::iequals(nodeName, "zetacation")) {
+            } else if (caseInsensitiveEquals(nodeName, "zetacation")) {
                 readXMLZetaCation(*xmlACChild);
             }
         }

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -19,6 +19,7 @@
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/ctml.h"
 #include "cantera/base/stringUtils.h"
+
 #include <iostream>
 
 namespace Cantera
@@ -416,11 +417,11 @@ void IdealMolalSoln::initThermo()
 
 void IdealMolalSoln::setStandardConcentrationModel(const std::string& model)
 {
-    if (ba::iequals(model, "unity")) {
+    if (caseInsensitiveEquals(model, "unity")) {
         m_formGC = 0;
-    } else if (ba::iequals(model, "molar_volume")) {
+    } else if (caseInsensitiveEquals(model, "molar_volume")) {
         m_formGC = 1;
-    } else if (ba::iequals(model, "solvent_volume")) {
+    } else if (caseInsensitiveEquals(model, "solvent_volume")) {
         m_formGC = 2;
     } else {
         throw CanteraError("IdealSolnGasVPSS::setStandardConcentrationModel",
@@ -430,11 +431,11 @@ void IdealMolalSoln::setStandardConcentrationModel(const std::string& model)
 
 void IdealMolalSoln::setCutoffModel(const std::string& model)
 {
-    if (ba::iequals(model, "none")) {
+    if (caseInsensitiveEquals(model, "none")) {
         IMS_typeCutoff_ = 0;
-    } else if (ba::iequals(model, "poly")) {
+    } else if (caseInsensitiveEquals(model, "poly")) {
         IMS_typeCutoff_ = 1;
-    } else if (ba::iequals(model, "polyexp")) {
+    } else if (caseInsensitiveEquals(model, "polyexp")) {
         IMS_typeCutoff_ = 2;
     } else {
         throw CanteraError("IdealMolalSoln::setCutoffModel",

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -381,7 +381,7 @@ void IdealSolidSolnPhase::initThermoXML(XML_Node& phaseNode, const std::string& 
     // <thermo model="IdealSolidSolution" />
     if (phaseNode.hasChild("thermo")) {
         XML_Node& thNode = phaseNode.child("thermo");
-        if (!ba::iequals(thNode["model"], "idealsolidsolution")) {
+        if (!caseInsensitiveEquals(thNode["model"], "idealsolidsolution")) {
             throw CanteraError("IdealSolidSolnPhase::initThermoXML",
                                "Unknown thermo model: " + thNode["model"]);
         }
@@ -425,11 +425,11 @@ void IdealSolidSolnPhase::setToEquilState(const doublereal* lambda_RT)
 
 void IdealSolidSolnPhase::setStandardConcentrationModel(const std::string& model)
 {
-    if (ba::iequals(model, "unity")) {
+    if (caseInsensitiveEquals(model, "unity")) {
         m_formGC = 0;
-    } else if (ba::iequals(model, "molar_volume")) {
+    } else if (caseInsensitiveEquals(model, "molar_volume")) {
         m_formGC = 1;
-    } else if (ba::iequals(model, "solvent_volume")) {
+    } else if (caseInsensitiveEquals(model, "solvent_volume")) {
         m_formGC = 2;
     } else {
         throw CanteraError("IdealSolidSolnPhase::setStandardConcentrationModel",

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -50,11 +50,11 @@ void IdealSolnGasVPSS::setStandardConcentrationModel(const std::string& model)
                            "Standard concentration model not applicable for ideal gas");
     }
 
-    if (ba::iequals(model, "unity")) {
+    if (caseInsensitiveEquals(model, "unity")) {
         m_formGC = 0;
-    } else if (ba::iequals(model, "molar_volume")) {
+    } else if (caseInsensitiveEquals(model, "molar_volume")) {
         m_formGC = 1;
-    } else if (ba::iequals(model, "solvent_volume")) {
+    } else if (caseInsensitiveEquals(model, "solvent_volume")) {
         m_formGC = 2;
     } else {
         throw CanteraError("IdealSolnGasVPSS::setStandardConcentrationModel",

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -225,7 +225,7 @@ void MargulesVPSSTP::initThermoXML(XML_Node& phaseNode, const std::string& id_)
     XML_Node& thermoNode = phaseNode.child("thermo");
 
     // Make sure that the thermo model is Margules
-    if (!ba::iequals(thermoNode["model"], "margules")) {
+    if (!caseInsensitiveEquals(thermoNode["model"], "margules")) {
         throw CanteraError("MargulesVPSSTP::initThermoXML",
                            "model name isn't Margules: " + thermoNode["model"]);
     }
@@ -234,7 +234,7 @@ void MargulesVPSSTP::initThermoXML(XML_Node& phaseNode, const std::string& id_)
     // XML block
     if (thermoNode.hasChild("activityCoefficients")) {
         XML_Node& acNode = thermoNode.child("activityCoefficients");
-        if (!ba::iequals(acNode["model"], "margules")) {
+        if (!caseInsensitiveEquals(acNode["model"], "margules")) {
             throw CanteraError("MargulesVPSSTP::initThermoXML",
                                "Unknown activity coefficient model: " + acNode["model"]);
         }
@@ -244,7 +244,7 @@ void MargulesVPSSTP::initThermoXML(XML_Node& phaseNode, const std::string& id_)
             // Process a binary salt field, or any of the other XML fields that
             // make up the Pitzer Database. Entries will be ignored if any of
             // the species in the entry isn't in the solution.
-            if (ba::iequals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
+            if (caseInsensitiveEquals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
                 readXMLBinarySpecies(xmlACChild);
             }
         }
@@ -522,7 +522,7 @@ void MargulesVPSSTP::readXMLBinarySpecies(XML_Node& xmLBinarySpecies)
 
     for (size_t iChild = 0; iChild < xmLBinarySpecies.nChildren(); iChild++) {
         XML_Node& xmlChild = xmLBinarySpecies.child(iChild);
-        string nodeName = ba::to_lower_copy(xmlChild.name());
+        string nodeName = toLowerCopy(xmlChild.name());
 
         // Process the binary species interaction parameters.
         // They are in subblocks labeled:

--- a/src/thermo/MaskellSolidSolnPhase.cpp
+++ b/src/thermo/MaskellSolidSolnPhase.cpp
@@ -195,7 +195,7 @@ void MaskellSolidSolnPhase::initThermoXML(XML_Node& phaseNode, const std::string
     // <thermo model="MaskellSolidSolution" />
     if (phaseNode.hasChild("thermo")) {
         XML_Node& thNode = phaseNode.child("thermo");
-        if (!ba::iequals(thNode["model"], "maskellsolidsolnphase")) {
+        if (!caseInsensitiveEquals(thNode["model"], "maskellsolidsolnphase")) {
             throw CanteraError("MaskellSolidSolnPhase::initThermoXML",
                                "Unknown thermo model: " + thNode["model"]);
         }

--- a/src/thermo/MixedSolventElectrolyte.cpp
+++ b/src/thermo/MixedSolventElectrolyte.cpp
@@ -227,7 +227,7 @@ void MixedSolventElectrolyte::initThermoXML(XML_Node& phaseNode, const std::stri
     }
     XML_Node& thermoNode = phaseNode.child("thermo");
     string mString = thermoNode["model"];
-    if (!ba::iequals(thermoNode["model"], "mixedsolventelectrolyte")) {
+    if (!caseInsensitiveEquals(thermoNode["model"], "mixedsolventelectrolyte")) {
         throw CanteraError("MixedSolventElectrolyte::initThermoXML",
             "Unknown thermo model: " + thermoNode["model"]);
     }
@@ -236,7 +236,7 @@ void MixedSolventElectrolyte::initThermoXML(XML_Node& phaseNode, const std::stri
     // XML block
     if (thermoNode.hasChild("activityCoefficients")) {
         XML_Node& acNode = thermoNode.child("activityCoefficients");
-        if (!ba::iequals(acNode["model"], "margules")) {
+        if (!caseInsensitiveEquals(acNode["model"], "margules")) {
             throw CanteraError("MixedSolventElectrolyte::initThermoXML",
                                "Unknown activity coefficient model: " + acNode["model"]);
         }
@@ -246,7 +246,7 @@ void MixedSolventElectrolyte::initThermoXML(XML_Node& phaseNode, const std::stri
             // Process a binary salt field, or any of the other XML fields that
             // make up the Pitzer Database. Entries will be ignored if any of
             // the species in the entry isn't in the solution.
-            if (ba::iequals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
+            if (caseInsensitiveEquals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
                 readXMLBinarySpecies(xmlACChild);
             }
         }
@@ -531,7 +531,7 @@ void MixedSolventElectrolyte::readXMLBinarySpecies(XML_Node& xmLBinarySpecies)
 
     for (size_t iChild = 0; iChild < xmLBinarySpecies.nChildren(); iChild++) {
         XML_Node& xmlChild = xmLBinarySpecies.child(iChild);
-        string nodeName = ba::to_lower_copy(xmlChild.name());
+        string nodeName = toLowerCopy(xmlChild.name());
 
         // Process the binary species interaction child elements
         if (nodeName == "excessenthalpy") {

--- a/src/thermo/MolarityIonicVPSSTP.cpp
+++ b/src/thermo/MolarityIonicVPSSTP.cpp
@@ -281,8 +281,8 @@ void MolarityIonicVPSSTP::initThermoXML(XML_Node& phaseNode, const std::string& 
                            "no thermo XML node");
     }
     XML_Node& thermoNode = phaseNode.child("thermo");
-    if (!ba::iequals(thermoNode["model"], "molarityionicvpss")
-        && !ba::iequals(thermoNode["model"], "molarityionicvpsstp")) {
+    if (!caseInsensitiveEquals(thermoNode["model"], "molarityionicvpss")
+        && !caseInsensitiveEquals(thermoNode["model"], "molarityionicvpsstp")) {
         throw CanteraError("MolarityIonicVPSSTP::initThermoXML",
                            "Unknown thermo model: " + thermoNode["model"]
                            + " - This object only knows \"MolarityIonicVPSSTP\" ");
@@ -295,7 +295,7 @@ void MolarityIonicVPSSTP::initThermoXML(XML_Node& phaseNode, const std::string& 
         for (size_t i = 0; i < acNode.nChildren(); i++) {
             XML_Node& xmlACChild = acNode.child(i);
             // Process a binary interaction
-            if (ba::iequals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
+            if (caseInsensitiveEquals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
                 readXMLBinarySpecies(xmlACChild);
             }
         }

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -356,7 +356,7 @@ void PDSS_HKFT::setParametersFromXML(const XML_Node& speciesNode)
         throw CanteraError("PDSS_HKFT::constructPDSSXML",
                            "no thermo Node for species " + speciesNode.name());
     }
-    if (!ba::iequals(tn->attrib("model"), "hkft")) {
+    if (!caseInsensitiveEquals(tn->attrib("model"), "hkft")) {
         throw CanteraError("PDSS_HKFT::initThermoXML",
                            "thermo model for species isn't hkft: "
                            + speciesNode.name());
@@ -404,7 +404,7 @@ void PDSS_HKFT::setParametersFromXML(const XML_Node& speciesNode)
         throw CanteraError("PDSS_HKFT::constructPDSSXML",
                            "no standardState Node for species " + speciesNode.name());
     }
-    if (!ba::iequals(ss->attrib("model"), "hkft")) {
+    if (!caseInsensitiveEquals(ss->attrib("model"), "hkft")) {
         throw CanteraError("PDSS_HKFT::initThermoXML",
                            "standardState model for species isn't hkft: "
                            + speciesNode.name());

--- a/src/thermo/PDSS_IonsFromNeutral.cpp
+++ b/src/thermo/PDSS_IonsFromNeutral.cpp
@@ -47,7 +47,7 @@ void PDSS_IonsFromNeutral::setParametersFromXML(const XML_Node& speciesNode)
         throw CanteraError("PDSS_IonsFromNeutral::constructPDSSXML",
                            "no thermo Node for species " + speciesNode.name());
     }
-    if (!ba::iequals(tn->attrib("model"), "ionfromneutral")) {
+    if (!caseInsensitiveEquals(tn->attrib("model"), "ionfromneutral")) {
         throw CanteraError("PDSS_IonsFromNeutral::constructPDSSXML",
                            "thermo model for species isn't IonsFromNeutral: "
                            + speciesNode.name());

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -174,10 +174,10 @@ void Phase::getAtoms(size_t k, double* atomArray) const
 
 size_t Phase::speciesIndex(const std::string& nameStr) const
 {
-    size_t loc = getValue(m_speciesIndices, ba::to_lower_copy(nameStr), npos);
+    size_t loc = getValue(m_speciesIndices, toLowerCopy(nameStr), npos);
     if (loc == npos && nameStr.find(':') != npos) {
         std::string pn;
-        std::string sn = ba::to_lower_copy(parseSpeciesName(nameStr, pn));
+        std::string sn = toLowerCopy(parseSpeciesName(nameStr, pn));
         if (pn == "" || pn == m_name || pn == m_id) {
             return getValue(m_speciesIndices, sn, npos);
         } else {
@@ -294,7 +294,7 @@ void Phase::setMoleFractionsByName(const compositionMap& xMap)
     vector_fp mf(m_kk, 0.0);
     for (const auto& sp : xMap) {
         try {
-            mf[m_speciesIndices.at(ba::to_lower_copy(sp.first))] = sp.second;
+            mf[m_speciesIndices.at(toLowerCopy(sp.first))] = sp.second;
         } catch (std::out_of_range&) {
             throw CanteraError("Phase::setMoleFractionsByName",
                                "Unknown species '{}'", sp.first);
@@ -338,7 +338,7 @@ void Phase::setMassFractionsByName(const compositionMap& yMap)
     vector_fp mf(m_kk, 0.0);
     for (const auto& sp : yMap) {
         try {
-            mf[m_speciesIndices.at(ba::to_lower_copy(sp.first))] = sp.second;
+            mf[m_speciesIndices.at(toLowerCopy(sp.first))] = sp.second;
         } catch (std::out_of_range&) {
             throw CanteraError("Phase::setMassFractionsByName",
                                "Unknown species '{}'", sp.first);
@@ -695,7 +695,7 @@ size_t Phase::addElement(const std::string& symbol, doublereal weight,
 }
 
 bool Phase::addSpecies(shared_ptr<Species> spec) {
-    if (m_species.find(ba::to_lower_copy(spec->name)) != m_species.end()) {
+    if (m_species.find(toLowerCopy(spec->name)) != m_species.end()) {
         throw CanteraError("Phase::addSpecies",
             "Phase '{}' already contains a species named '{}'.",
             m_name, spec->name);
@@ -725,8 +725,8 @@ bool Phase::addSpecies(shared_ptr<Species> spec) {
     }
 
     m_speciesNames.push_back(spec->name);
-    m_species[ba::to_lower_copy(spec->name)] = spec;
-    m_speciesIndices[ba::to_lower_copy(spec->name)] = m_kk;
+    m_species[toLowerCopy(spec->name)] = spec;
+    m_speciesIndices[toLowerCopy(spec->name)] = m_kk;
     m_speciesCharge.push_back(spec->charge);
     size_t ne = nElements();
 
@@ -790,19 +790,19 @@ void Phase::modifySpecies(size_t k, shared_ptr<Species> spec)
             "New species name '{}' does not match existing name '{}'",
                            spec->name, speciesName(k));
     }
-    const shared_ptr<Species>& old = m_species[ba::to_lower_copy(spec->name)];
+    const shared_ptr<Species>& old = m_species[toLowerCopy(spec->name)];
     if (spec->composition != old->composition) {
         throw CanteraError("Phase::modifySpecies",
             "New composition for '{}' does not match existing composition",
             spec->name);
     }
-    m_species[ba::to_lower_copy(spec->name)] = spec;
+    m_species[toLowerCopy(spec->name)] = spec;
     invalidateCache();
 }
 
 shared_ptr<Species> Phase::species(const std::string& name) const
 {
-    return m_species.at(ba::to_lower_copy(name));
+    return m_species.at(toLowerCopy(name));
 }
 
 shared_ptr<Species> Phase::species(size_t k) const

--- a/src/thermo/PhaseCombo_Interaction.cpp
+++ b/src/thermo/PhaseCombo_Interaction.cpp
@@ -222,7 +222,7 @@ void PhaseCombo_Interaction::initThermoXML(XML_Node& phaseNode, const std::strin
                            "no thermo XML node");
     }
     XML_Node& thermoNode = phaseNode.child("thermo");
-    if (!ba::iequals(thermoNode["model"], "phasecombo_interaction")) {
+    if (!caseInsensitiveEquals(thermoNode["model"], "phasecombo_interaction")) {
         throw CanteraError("PhaseCombo_Interaction::initThermoXML",
                            "model name isn't PhaseCombo_Interaction: " + thermoNode["model"]);
     }
@@ -231,7 +231,7 @@ void PhaseCombo_Interaction::initThermoXML(XML_Node& phaseNode, const std::strin
     // XML block
     if (thermoNode.hasChild("activityCoefficients")) {
         XML_Node& acNode = thermoNode.child("activityCoefficients");
-        if (!ba::iequals(acNode["model"], "margules")) {
+        if (!caseInsensitiveEquals(acNode["model"], "margules")) {
             throw CanteraError("PhaseCombo_Interaction::initThermoXML",
                                "Unknown activity coefficient model: " + acNode["model"]);
         }
@@ -241,7 +241,7 @@ void PhaseCombo_Interaction::initThermoXML(XML_Node& phaseNode, const std::strin
             // Process a binary salt field, or any of the other XML fields that
             // make up the Pitzer Database. Entries will be ignored if any of
             // the species in the entry isn't in the solution.
-            if (ba::iequals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
+            if (caseInsensitiveEquals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
                 readXMLBinarySpecies(xmlACChild);
             }
         }
@@ -561,7 +561,7 @@ void PhaseCombo_Interaction::readXMLBinarySpecies(XML_Node& xmLBinarySpecies)
 
     for (size_t iChild = 0; iChild < xmLBinarySpecies.nChildren(); iChild++) {
         XML_Node& xmlChild = xmLBinarySpecies.child(iChild);
-        string nodeName = ba::to_lower_copy(xmlChild.name());
+        string nodeName = toLowerCopy(xmlChild.name());
 
         // Process the binary species interaction child elements
         if (nodeName == "excessenthalpy") {

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -202,7 +202,7 @@ void RedlichKisterVPSSTP::initThermoXML(XML_Node& phaseNode, const std::string& 
                            "no thermo XML node");
     }
     XML_Node& thermoNode = phaseNode.child("thermo");
-    if (!ba::iequals(thermoNode["model"], "redlich-kister")) {
+    if (!caseInsensitiveEquals(thermoNode["model"], "redlich-kister")) {
         throw CanteraError("RedlichKisterVPSSTP::initThermoXML",
                            "Unknown thermo model: " + thermoNode["model"]
                            + " - This object only knows \"Redlich-Kister\" ");
@@ -212,7 +212,7 @@ void RedlichKisterVPSSTP::initThermoXML(XML_Node& phaseNode, const std::string& 
     // XML block
     if (thermoNode.hasChild("activityCoefficients")) {
         XML_Node& acNode = thermoNode.child("activityCoefficients");
-        if (!ba::iequals(acNode["model"], "redlich-kister")) {
+        if (!caseInsensitiveEquals(acNode["model"], "redlich-kister")) {
             throw CanteraError("RedlichKisterVPSSTP::initThermoXML",
                                "Unknown activity coefficient model: " + acNode["model"]);
         }
@@ -222,7 +222,7 @@ void RedlichKisterVPSSTP::initThermoXML(XML_Node& phaseNode, const std::string& 
             // Process a binary salt field, or any of the other XML fields that
             // make up the Pitzer Database. Entries will be ignored if any of
             // the species in the entry isn't in the solution.
-            if (ba::iequals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
+            if (caseInsensitiveEquals(xmlACChild.name(), "binaryneutralspeciesparameters")) {
                 readXMLBinarySpecies(xmlACChild);
             }
         }
@@ -525,7 +525,7 @@ void RedlichKisterVPSSTP::readXMLBinarySpecies(XML_Node& xmLBinarySpecies)
     // Ok we have found a valid interaction
     for (size_t iChild = 0; iChild < xmLBinarySpecies.nChildren(); iChild++) {
         XML_Node& xmlChild = xmLBinarySpecies.child(iChild);
-        string nodeName = ba::to_lower_copy(xmlChild.name());
+        string nodeName = toLowerCopy(xmlChild.name());
 
         // Process the binary species interaction child elements
         if (nodeName == "excessenthalpy") {

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -577,9 +577,9 @@ void RedlichKwongMFTP::initThermoXML(XML_Node& phaseNode, const std::string& id)
             // parameters
             for (size_t i = 0; i < acNode.nChildren(); i++) {
                 XML_Node& xmlACChild = acNode.child(i);
-                if (ba::iequals(xmlACChild.name(), "purefluidparameters")) {
+                if (caseInsensitiveEquals(xmlACChild.name(), "purefluidparameters")) {
                     readXMLPureFluid(xmlACChild);
-                } else if (ba::iequals(xmlACChild.name(), "crossfluidparameters")) {
+                } else if (caseInsensitiveEquals(xmlACChild.name(), "crossfluidparameters")) {
                     readXMLCrossFluid(xmlACChild);
                 }
             }
@@ -602,11 +602,11 @@ void RedlichKwongMFTP::readXMLPureFluid(XML_Node& pureFluidParam)
     double b = 0.0;
     for (size_t iChild = 0; iChild < pureFluidParam.nChildren(); iChild++) {
         XML_Node& xmlChild = pureFluidParam.child(iChild);
-        string nodeName = ba::to_lower_copy(xmlChild.name());
+        string nodeName = toLowerCopy(xmlChild.name());
 
         if (nodeName == "a_coeff") {
             vector_fp vParams;
-            string iModel = ba::to_lower_copy(xmlChild.attrib("model"));
+            string iModel = toLowerCopy(xmlChild.attrib("model"));
             getFloatArray(xmlChild, vParams, true, "Pascal-m6/kmol2", "a_coeff");
 
             if (iModel == "constant" && vParams.size() == 1) {
@@ -641,12 +641,12 @@ void RedlichKwongMFTP::readXMLCrossFluid(XML_Node& CrossFluidParam)
     size_t num = CrossFluidParam.nChildren();
     for (size_t iChild = 0; iChild < num; iChild++) {
         XML_Node& xmlChild = CrossFluidParam.child(iChild);
-        string nodeName = ba::to_lower_copy(xmlChild.name());
+        string nodeName = toLowerCopy(xmlChild.name());
 
         if (nodeName == "a_coeff") {
             vector_fp vParams;
             getFloatArray(xmlChild, vParams, true, "Pascal-m6/kmol2", "a_coeff");
-            string iModel = ba::to_lower_copy(xmlChild.attrib("model"));
+            string iModel = toLowerCopy(xmlChild.attrib("model"));
             if (iModel == "constant" && vParams.size() == 1) {
                 setBinaryCoeffs(iName, jName, vParams[0], 0.0);
             } else if (iModel == "linear_a") {

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -56,7 +56,7 @@ SpeciesThermoInterpType* newSpeciesThermoInterpType(const std::string& stype,
     double tlow, double thigh, double pref, const double* coeffs)
 {
     int itype = -1;
-    std::string type = ba::to_lower_copy(stype);
+    std::string type = toLowerCopy(stype);
     if (type == "nasa2" || type == "nasa") {
         itype = NASA2; // two-region 7-coefficient NASA polynomials
     } else if (type == "const_cp" || type == "simple") {
@@ -379,7 +379,7 @@ static SpeciesThermoInterpType* newAdsorbateThermoFromXML(const XML_Node& f)
 
 SpeciesThermoInterpType* newSpeciesThermoInterpType(const XML_Node& thermo)
 {
-    std::string model = ba::to_lower_copy(thermo["model"]);
+    std::string model = toLowerCopy(thermo["model"]);
     if (model == "hkft" || model == "ionfromneutral") {
         // Some PDSS species use the 'thermo' node, but don't specify a
         // SpeciesThermoInterpType parameterization. This function needs to
@@ -399,10 +399,10 @@ SpeciesThermoInterpType* newSpeciesThermoInterpType(const XML_Node& thermo)
         }
     }
 
-    std::string thermoType = ba::to_lower_copy(tp[0]->name());
+    std::string thermoType = toLowerCopy(tp[0]->name());
 
     for (size_t i = 1; i < tp.size(); i++) {
-        if (!ba::iequals(tp[i]->name(), thermoType)) {
+        if (!caseInsensitiveEquals(tp[i]->name(), thermoType)) {
             throw CanteraError("newSpeciesThermoInterpType",
                 "Encountered unsupported mixed species thermo "
                 "parameterizations, '{}' and '{}'", tp[i]->name(), thermoType);

--- a/src/tpx/utils.cpp
+++ b/src/tpx/utils.cpp
@@ -19,7 +19,7 @@ namespace tpx
 {
 Substance* newSubstance(const std::string& name)
 {
-    std::string lcname = boost::algorithm::to_lower_copy(name);
+    std::string lcname = Cantera::toLowerCopy(name);
     if (lcname == "water") {
         return new water;
     } else if (lcname == "nitrogen") {

--- a/src/transport/LiquidTranInteraction.cpp
+++ b/src/transport/LiquidTranInteraction.cpp
@@ -63,7 +63,7 @@ void LiquidTranInteraction::init(const XML_Node& compModelNode,
     for (size_t iChild = 0; iChild < compModelNode.nChildren(); iChild++) {
         XML_Node& xmlChild = compModelNode.child(iChild);
         std::string nodeName = xmlChild.name();
-        if (!ba::iequals(nodeName, "interaction")) {
+        if (!caseInsensitiveEquals(nodeName, "interaction")) {
             throw CanteraError("TransportFactory::getLiquidInteractionsTransportData",
                                "expected <interaction> element and got <" + nodeName + ">");
         }

--- a/src/transport/TransportData.cpp
+++ b/src/transport/TransportData.cpp
@@ -53,7 +53,7 @@ void GasTransportData::validate(const Species& sp)
 {
     double nAtoms = 0;
     for (const auto& elem : sp.composition) {
-        if (!ba::iequals(elem.first, "E")) {
+        if (!caseInsensitiveEquals(elem.first, "E")) {
             nAtoms += elem.second;
         }
     }

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -93,7 +93,7 @@ void TransportFactory::deleteFactory()
 LTPspecies* TransportFactory::newLTP(const XML_Node& trNode, const std::string& name,
                                      TransportPropertyType tp_ind, thermo_t* thermo)
 {
-    std::string model = ba::to_lower_copy(trNode["model"]);
+    std::string model = toLowerCopy(trNode["model"]);
     LTPspecies* sp;
     switch (m_LTRmodelMap[model]) {
     case LTP_TD_CONSTANT:

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -3,6 +3,27 @@
 
 using namespace Cantera;
 
+TEST(AnyValue, is_copyable) {
+    AnyMap map1, map2;
+    map1["key"] = "1";
+    map2["key"] = "2";
+    AnyValue value1 = map1["key"];
+    AnyValue value2 = map2["key"];
+    value2 = value1;
+    EXPECT_EQ(value1.asString(), "1");
+    EXPECT_EQ(value2.asString(), "1");
+}
+
+TEST(AnyValue, is_moveable) {
+    AnyMap map1, map2;
+    map1["key"] = "1";
+    map2["key"] = "2";
+    AnyValue value1 = map1["key"];
+    AnyValue value2 = map2["key"];
+    value2 = std::move(value1);
+    EXPECT_EQ(value2.asString(), "1");
+}
+
 TEST(AnyMap, paths) {
     AnyMap m;
     m["simple"] = "qux";


### PR DESCRIPTION
Removes Boost headers from the API. This removes the requirement for clients to have these headers when building against Cantera.

I tried to make this as backwards compatible as possible (minor/patch). The only real non-backwards compatible pieces are the removal of the (directly unused) boost header/namespace from stringUtils.h and possibly the change to the size/layout of AnyValue). Otherwise, it is opt-in with CANTERA_API_NO_BOOST.

It seems that the generic capability of AnyMap/AnyValue isn't really used within Cantera or on its interface so it could probably just be removed if you were interested in breaking changes to the API. It is technically used in a couple places but they are all calls like as<string> that could be replaced by asString.