### PR TITLE
Allow building with Python 3.6 and scons 3.0.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -310,7 +310,7 @@ defaults.python_prefix = '$prefix' if env['OS'] != 'Windows' else ''
 # Transform lists into strings to keep cantera.conf clean
 for key,value in defaults.__dict__.items():
     if isinstance(value, (list, tuple)):
-        defaults.__dict__[key] = ' '.join(value)
+        setattr(defaults, key, ' '.join(value))
 
 # **************************************
 # *** Read user-configurable options ***


### PR DESCRIPTION
The build was failing with:
  TypeError: 'mappingproxy' object does not support item assignment