### PR TITLE
Update to gtest-1.8.0.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -499,8 +499,9 @@ config_options = [
         True),
     EnumVariable(
         'system_googletest',
-        """Select whether to use gtest from system installation ('y'), from a
-           Git submodule ('n'), or to decide automatically ('default').""",
+        """Select whether to use gtest/gmock from system
+           installation ('y'), from a Git submodule ('n'), or to decide
+           automatically ('default').""",
         'default', ('default', 'y', 'n')),
     (
         'env_vars',
@@ -844,15 +845,19 @@ if env['system_fmt'] in ('n', 'default'):
 
 # Check for googletest and checkout submodule if needed
 if env['system_googletest'] in ('y', 'default'):
-    if conf.CheckCXXHeader('gtest/gtest.h', '""'):
+    has_gtest = conf.CheckCXXHeader('gtest/gtest.h', '""')
+    has_gmock = conf.CheckCXXHeader('gmock/gmock.h', '""')
+    if has_gtest and has_gmock:
         env['system_googletest'] = True
     elif env['system_googletest'] == 'y':
-        config_error('Expected system installation of Googletest, but it '
+        config_error('Expected system installation of Googletest-1.8.0, but it '
                      'could not be found.')
 
 if env['system_googletest'] in ('n', 'default'):
     env['system_googletest'] = False
-    if not os.path.exists('ext/googletest/include/gtest/gtest.h'):
+    has_gtest = os.path.exists('ext/googletest/googletest/include/gtest/gtest.h')
+    has_gmock = os.path.exists('ext/googletest/googlemock/include/gmock/gmock.h')
+    if not (has_gtest and has_gmock):
         if not os.path.exists('.git'):
             config_error('Googletest is missing. Install source in ext/googletest.')
 

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -18,10 +18,20 @@ def prep_default(env):
 
 def prep_gtest(env):
     localenv = prep_default(env)
-    localenv.Prepend(CPPPATH=[Dir('#ext/googletest'),
-                              Dir('#ext/googletest/include')],
-                    CPPDEFINES={'GTEST_HAS_PTHREAD': 0})
+    localenv.Prepend(CPPPATH=[Dir('#ext/googletest/googletest'),
+                              Dir('#ext/googletest/googletest/include')],
+                     CPPDEFINES={'GTEST_HAS_PTHREAD': 0})
     return localenv
+
+
+def prep_gmock(env):
+    localenv = prep_default(env)
+    localenv.Prepend(CPPPATH=[Dir('#ext/googletest/googletest/include'),
+                              Dir('#ext/googletest/googlemock'),
+                              Dir('#ext/googletest/googlemock/include')],
+                     CPPDEFINES={'GTEST_HAS_PTHREAD': 0})
+    return localenv
+
 
 def prep_fmt(env):
     localenv = prep_default(env)
@@ -82,7 +92,10 @@ if not env['system_eigen']:
 if not env['system_googletest']:
     localenv = prep_gtest(env)
     gtest = build(localenv.Library('../lib/gtest',
-                                   source=['googletest/src/gtest-all.cc']))
+                                   source=['googletest/googletest/src/gtest-all.cc']))
+    localenv = prep_gmock(env)
+    gmock = build(localenv.Library('../lib/gmock',
+                                   source=['googletest/googlemock/src/gmock-all.cc']))
 
 # Create license file containing licenses for Cantera and all included packages
 def generate_license(target, source, env):

--- a/test/SConscript
+++ b/test/SConscript
@@ -16,8 +16,9 @@ else:
 localenv.Prepend(CPPPATH=['#include'],
                  LIBPATH='#build/lib')
 if not env['system_googletest']:
-    localenv.Prepend(CPPPATH=['#ext/googletest/include'])
-localenv.Append(LIBS=['gtest'] + cantera_libs,
+    localenv.Prepend(CPPPATH=['#ext/googletest/googletest/include',
+                              '#ext/googletest/googlemock/include'])
+localenv.Append(LIBS=['gtest', 'gmock'] + cantera_libs,
                 CCFLAGS=env['warning_flags'])
 
 # Turn of optimization to speed up compilation


### PR DESCRIPTION
The Google Test 1.8.0 release included the merger of gtest and gmock.
Cantera is now building gmock in addition to gtest in order to take
advantage of gmock matchers in new tests. 