### PR TITLE
Remove has no python

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ before_script: |
   rm -f cantera.conf
 script: |
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      scons build -j2 VERBOSE=y python_package=full python3_package=y python3_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas optimize=n coverage=y
+      scons build -j2 VERBOSE=y python_package=none python2_package=full python3_package=full python3_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas optimize=n coverage=y
   else
-      scons build -j2 VERBOSE=y python_package=full python3_package=y blas_lapack_libs=lapack,blas optimize=n coverage=y
+      scons build -j2 VERBOSE=y python_package=none python2_package=full python3_package=full blas_lapack_libs=lapack,blas optimize=n coverage=y
   fi
   scons test
 after_success: |

--- a/SConstruct
+++ b/SConstruct
@@ -112,6 +112,7 @@ if 'clean' in COMMAND_LINE_TARGETS:
 if 'test-clean' in COMMAND_LINE_TARGETS:
     removeDirectory('build/test')
     removeDirectory('test/work')
+    removeDirectory('build/python_minimal')
 
 # ******************************************************
 # *** Set system-dependent defaults for some options ***
@@ -1788,6 +1789,21 @@ if 'msi' in COMMAND_LINE_TARGETS:
 if any(target.startswith('test') for target in COMMAND_LINE_TARGETS):
     env['testNames'] = []
     env['test_results'] = env.Command('test_results', [], testResults.printReport)
+
+    if env['python2_package'] == 'none' and env['python3_package'] == 'none':
+        # copy scripts from the full Cython module
+        test_py_int = env.Command('#build/python_minimal/cantera/__init__.py',
+                                  '#interfaces/python_minimal/cantera/__init__.py',
+                                  Copy('$TARGET', '$SOURCE'))
+        for script in ['ctml_writer', 'ck2cti']:
+            s = env.Command('#build/python_minimal/cantera/{}.py'.format(script),
+                            '#interfaces/cython/cantera/{}.py'.format(script),
+                            Copy('$TARGET', '$SOURCE'))
+            env.Depends(test_py_int, s)
+
+        env.Depends(env['test_results'], test_py_int)
+
+        env['python_cmd'] = sys.executable
 
     # Tests written using the gtest framework, the Python unittest module,
     # or the Matlab xunit package.

--- a/SConstruct
+++ b/SConstruct
@@ -109,6 +109,10 @@ if 'clean' in COMMAND_LINE_TARGETS:
     else:
         Alias('clean', [])
 
+if 'test-clean' in COMMAND_LINE_TARGETS:
+    removeDirectory('build/test')
+    removeDirectory('test/work')
+
 # ******************************************************
 # *** Set system-dependent defaults for some options ***
 # ******************************************************

--- a/SConstruct
+++ b/SConstruct
@@ -1294,23 +1294,13 @@ for py_ver in [2, 3]:
 # Check for 3to2. See http://pypi.python.org/pypi/3to2
 # Only needed for Python 2 package
 if env['python2_package'] == 'full':
+    from textwrap import dedent
+    script = dedent("""\
+    from lib3to2.main import main
+    print(main('lib3to2.fixes', ['-l']))
+    """)
     try:
-        python_dir = os.path.dirname(which(env['python2_cmd']))
-        if env['OS'] == 'Windows':
-            threetotwo_cmd = pjoin(python_dir, 'Scripts', '3to2')
-            # Conda installs 3to2 as an EXE file that can be executed directly
-            # but pip installs only a script. Try executing the EXE file first,
-            # and if it fails because the file doesn't exist, try the script
-            try:
-                ret = getCommandOutput(threetotwo_cmd, '-l')
-                env['threetotwo_cmd'] = [threetotwo_cmd]
-            except WindowsError:
-                ret = getCommandOutput(env['python2_cmd'], threetotwo_cmd, '-l')
-                env['threetotwo_cmd'] = [env['python2_cmd'], threetotwo_cmd]
-        else:
-            threetotwo_cmd = pjoin(python_dir, '3to2')
-            ret = getCommandOutput(threetotwo_cmd, '-l')
-            env['threetotwo_cmd'] = [threetotwo_cmd]
+        ret = getCommandOutput(env['python2_cmd'], '-c', script)
     except (OSError, subprocess.CalledProcessError) as err:
         if env['VERBOSE']:
             print('Error checking for 3to2:')

--- a/SConstruct
+++ b/SConstruct
@@ -329,14 +329,16 @@ config_options = [
         defaults.prefix, PathVariable.PathAccept),
     EnumVariable(
         'python_package',
-        """If you plan to work in Python 2, then you need the 'full' Cantera Python
+        """If you plan to work in Python, then you need the ``full`` Cantera Python
            package. If, on the other hand, you will only use Cantera from some
            other language (e.g. MATLAB or Fortran 90/95) and only need Python
-           to process CTI files, then you only need a 'minimal' subset of the
-           package and Cython and NumPy are not necessary. The 'none' option
-           doesn't install any components of the Python interface. The 'default'
-           behavior is to build the full Python 2 module if the required
-           prerequisites (NumPy and Cython) are installed.""",
+           to process CTI files, then you only need a ``minimal`` subset of the
+           package and Cython and NumPy are not necessary. The ``none`` option
+           doesn't install any components of the Python interface. The default
+           behavior is to build the full Python module for whichever version of
+           Python is running SCons if the required prerequisites (NumPy and
+           Cython) are installed. Note: ``y`` is a synonym for ``full`` and ``n``
+           is a synonym for ``none``.""",
         'default', ('new', 'full', 'minimal', 'none', 'n', 'y', 'default')),
     PathVariable(
         'python_cmd',
@@ -386,7 +388,7 @@ config_options = [
            the empty string or the 'prefix' option is not set, then the package
            will be installed to the system default 'site-packages' directory.
            To install to the current user's 'site-packages' directory, use
-           'python_prefix=USER'.""",
+           'python2_prefix=USER'.""",
         defaults.python_prefix, PathVariable.PathAccept),
     EnumVariable(
         'python3_package',
@@ -415,7 +417,7 @@ config_options = [
            the empty string or the 'prefix' option is not set, then the package
            will be installed to the system default 'site-packages' directory.
            To install to the current user's 'site-packages' directory, use
-           'python_prefix=USER'.""",
+           'python3_prefix=USER'.""",
         defaults.python_prefix, PathVariable.PathAccept),
     EnumVariable(
         'matlab_toolbox',

--- a/SConstruct
+++ b/SConstruct
@@ -1436,11 +1436,6 @@ configh['SOLARIS'] = 1 if env['OS'] == 'Solaris' else None
 configh['DARWIN'] = 1 if env['OS'] == 'Darwin' else None
 cdefine('NEEDS_GENERIC_TEMPL_STATIC_DECL', 'OS', 'Solaris')
 
-if env['python_package'] == 'none' and env['python3_package'] == 'n':
-    configh['HAS_NO_PYTHON'] = 1
-else:
-    configh['HAS_NO_PYTHON'] = None
-
 configh['SUNDIALS_VERSION'] = env['sundials_version'].replace('.','')
 
 if env.get('has_sundials_lapack') and env['use_lapack']:

--- a/doc/sphinx/compiling/config-options.rst
+++ b/doc/sphinx/compiling/config-options.rst
@@ -76,15 +76,17 @@ Options List
 
 .. _python-package:
 
-* ``python_package``: [ ``new`` | ``full`` | ``minimal`` | ``none`` | ``default`` ]
-    If you plan to work in Python 2, then you need the ``full`` Cantera Python
+* ``python_package``: [ ``y`` | ``n`` | ``full`` | ``minimal`` | ``none`` | ``default`` ]
+    If you plan to work in Python, then you need the ``full`` Cantera Python
     package. If, on the other hand, you will only use Cantera from some
     other language (e.g. MATLAB or Fortran 90/95) and only need Python
     to process CTI files, then you only need a ``minimal`` subset of the
     package and Cython and NumPy are not necessary. The ``none`` option
     doesn't install any components of the Python interface. The default
-    behavior is to build the full Python 2 module if the required
-    prerequisites (NumPy and Cython) are installed.
+    behavior is to build the full Python module for whichever version of
+    Python is running SCons if the required prerequisites (NumPy and
+    Cython) are installed. Note: ``y`` is a synonym for ``full`` and ``n``
+    is a synonym for ``none``.
 
     - default: ``'default'``
 
@@ -101,14 +103,14 @@ Options List
 
 * ``python_array_home``: [ ``/path/to/python_array_home`` ]
     If NumPy was installed using the ``--home`` option, set this to the home
-    directory for NumPy for Python 2.
+    directory for NumPy for Python.
 
     - default: ``''``
 
 .. _python-prefix:
 
 * ``python_prefix``: [ ``/path/to/python_prefix`` ]
-    Use this option if you want to install the Cantera Python 2 package to
+    Use this option if you want to install the Cantera Python package to
     an alternate location. On Unix-like systems, the default is the same
     as the ``prefix`` option. If the ``python_prefix`` option is set to
     the empty string or the ``prefix`` option is not set, then the package
@@ -118,9 +120,50 @@ Options List
 
     - default: ``''``
 
+.. _python2-package:
+
+* ``python2_package``: [ ``y`` | ``n`` | ``full`` | ``minimal`` | ``none`` | ``default`` ]
+    Controls whether or not the Python 2 module will be built. By
+    default, the module will be built if the Python 2 interpreter
+    and the required dependencies (NumPy for Python 2 and Cython
+    for the version of Python for which SCons is installed) can be
+    found.
+
+    - default: ``'default'``
+
+.. _python2-cmd:
+
+* ``python2_cmd``: [ ``/path/to/python2_cmd`` ]
+    The path to the Python 2 interpreter. The default is
+    ``python2``; if this executable cannot be found, this
+    value must be specified to build the Python 2 module.
+
+    - default: ``'python2'``
+
+.. _python2-array-home:
+
+* ``python2_array_home``: [ ``/path/to/python2_array_home`` ]
+    If NumPy was installed using the ``--home`` option, set this to the home
+    directory for NumPy for Python 2.
+
+    - default: ``''``
+
+.. _python2-prefix:
+
+* ``python2_prefix``: [ ``/path/to/python2_prefix`` ]
+    Use this option if you want to install the Cantera Python 2 package to
+    an alternate location. On Unix-like systems, the default is the same
+    as the ``prefix`` option. If the ``python_prefix`` option is set to
+    the empty string or the ``prefix`` option is not set, then the package
+    will be installed to the system default ``site-packages`` directory.
+    To install to the current user's ``site-packages`` directory, use
+    ``python2_prefix=USER``.
+
+    - default: ``''``
+
 .. _python3-package:
 
-* ``python3_package``: [ ``y`` | ``n`` | ``default`` ]
+* ``python3_package``: [ ``y`` | ``n`` | ``full`` | ``minimal`` | ``none`` | ``default`` ]
     Controls whether or not the Python 3 module will be built. By
     default, the module will be built if the Python 3 interpreter
     and the required dependencies (NumPy for Python 3 and Cython
@@ -155,7 +198,7 @@ Options List
     the empty string or the ``prefix`` option is not set, then the package
     will be installed to the system default ``site-packages`` directory.
     To install to the current user's ``site-packages`` directory, use
-    ``python_prefix=USER``.
+    ``python3_prefix=USER``.
 
     - default: ``''``
 

--- a/doc/sphinx/compiling/configure-build.rst
+++ b/doc/sphinx/compiling/configure-build.rst
@@ -54,32 +54,57 @@ Common Options
 * :ref:`sundials_include <sundials-include>`
 * :ref:`sundials_libdir <sundials-libdir>`
 
-Python 2 Module Options
-^^^^^^^^^^^^^^^^^^^^^^^
+General Python Module Options
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-By default, SCons will attempt to build the Cython-based Python module for
-Python 2, if both Numpy and Cython are installed. The following options control
-how the Python 2 module is built:
+By default, SCons will try to build the full Python interface for
+whichever version of Python is running SCons. This requires that
+NumPy is installed for that version of Python, and that Cython is
+installed for whichever Python is running SCons. The following SCons
+options control how the Python module is built:
 
 * :ref:`python_cmd <python-cmd>`
 * :ref:`python_package <python-package>`
 * :ref:`python_prefix <python-prefix>`
 
+Note that these general options should not be used at the same time
+as the Python-version specific options discussed below. If SCons
+detects that it is being run with Python 2, and the
+:ref:`python2_package <python2-package` option is set, the build will
+raise an error and exit; or if SCons detects that it is being run with
+Python 3, and the :ref:`python3_package <python3-package` option is
+set, the build will raise an error and exit.
+
+If a user wishes to build multiple Python interfaces, or a Python
+interface for the version of Python that is not running SCons, they
+should use the version-specific options below, and set the
+:ref:`python_package <python-package>` option to ``none``.
+
+Python 2 Module Options
+^^^^^^^^^^^^^^^^^^^^^^^
+
+By default, if SCons detects a Python 2 interpreter installed in a
+default location (i.e., ``python2`` is on the ``PATH`` environment
+variable) or ``python2_package`` is ``full``, SCons will try to build
+the Python module for Python 2. The following SCons options control how
+the Python 2 module is built:
+
+* :ref:`python2_cmd <python2-cmd>`
+* :ref:`python2_package <python2-package>`
+* :ref:`python2_prefix <python2-prefix>`
+
 Python 3 Module Options
 ^^^^^^^^^^^^^^^^^^^^^^^
 
-If SCons detects a Python 3 interpreter installed in a default location
-(i.e., ``python3`` is on the ``PATH`` environment variable) or
-``python3_package`` is ``y``, SCons will try to build the Python module
-for Python 3. The following SCons options control how the Python 3 module is
-built:
+By default, if SCons detects a Python 3 interpreter installed in a
+default location (i.e., ``python3`` is on the ``PATH`` environment
+variable) or ``python3_package`` is ``full``, SCons will try to build
+the Python module for Python 3. The following SCons options control how
+the Python 3 module is built:
 
 * :ref:`python3_cmd <python3-cmd>`
 * :ref:`python3_package <python3-package>`
 * :ref:`python3_prefix <python3-prefix>`
-
-Note that even when building the Python 3 Cantera module, you should still use
-Python 2 with SCons, as SCons does not currently support Python 3.
 
 Windows Only Options
 ^^^^^^^^^^^^^^^^^^^^

--- a/doc/sphinx/compiling/special-cases.rst
+++ b/doc/sphinx/compiling/special-cases.rst
@@ -48,5 +48,5 @@ Intel Compilers
 
   Another option is to set the :ref:`prefix <prefix>` option to a directory
   for which you have write permissions, and specify the ``USER`` value to the
-  :ref:`python_prefix <python-prefix>` or :ref:`python3_prefix <python3-prefix>`
+  :ref:`python2_prefix <python2-prefix>` or :ref:`python3_prefix <python3-prefix>`
   option.

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -70,12 +70,6 @@ typedef int ftnlen;       // Fortran hidden string length type
 // and this leads to multiple defines at link time
 %(NEEDS_GENERIC_TEMPL_STATIC_DECL)s
 
-//--------------------- Python ------------------------------------
-
-// If this is defined, then python will not be assumed to be
-// present to support conversions
-%(HAS_NO_PYTHON)s
-
 //-------------- Optional Cantera Capabilities ----------------------
 
 //    Enable Sundials to use an external BLAS/LAPACK library if it was

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -1,4 +1,4 @@
-""" Cython-based Python Module for Python 3 """
+"""Cython-based Python Module"""
 from buildutils import *
 import Cython.Build
 
@@ -70,7 +70,6 @@ for line in open('cantera/_cantera.pxd'):
 def install_module(prefix, python_version):
     major = python_version[0]
     minor = python_version.split('.')[1]
-    ver = '3' if major == '3' else ''
     dummy = 'dummy' + major
     if prefix == 'USER':
         # Install to the OS-dependent user site-packages directory
@@ -83,21 +82,21 @@ def install_module(prefix, python_version):
             # Installation to /usr/local is the default on Debian-based distributions
             extra = ''
         elif localenv['OS'] == 'Darwin':
-            extra = localenv.subst(' --prefix=${python%s_prefix}' % ver)
+            extra = localenv.subst(' --prefix=${python%s_prefix}' % major)
         elif localenv['libdirname'] == 'lib64':
             # 64-bit RHEL / Fedora
             extra = localenv.subst(
-                ' --prefix=${python%s_prefix} --install-lib=${python%s_prefix}/lib64/python%s.%s/site-packages' % (ver, ver, major, minor))
+                ' --prefix=${python%s_prefix} --install-lib=${python%s_prefix}/lib64/python%s.%s/site-packages' % (major, major, major, minor))
         else:
             extra = '--user'
             localenv.AppendENVPath(
                 'PYTHONUSERBASE',
-                normpath(localenv.subst('$python%s_prefix' % ver)))
+                normpath(localenv.subst('$python%s_prefix' % major)))
     else:
         # Install Python module in the default location
         extra = ''
 
-    env['python%s_module_loc' % ver] = '<unspecified>'
+    env['python%s_module_loc' % major] = '<unspecified>'
     if localenv['PYTHON_INSTALLER'] == 'direct':
         mod_inst = install(localenv.Command, dummy, mod,
                            build_cmd + ' install %s' % extra +
@@ -110,14 +109,13 @@ def install_module(prefix, python_version):
                 filename = filename.strip()
                 if filename.endswith(check):
                     filename = filename.replace(check,'')
-                    global_env['python%s_module_loc' % ver] = normpath(filename)
+                    global_env['python%s_module_loc' % major] = normpath(filename)
                     break
         localenv.AlwaysBuild(localenv.AddPostAction(mod_inst, find_module_dir))
-        if not ver:
-          env['install_python2_action'] = mod_inst
+        env['install_python{}_action'.format(major)] = mod_inst
 
     elif localenv['PYTHON_INSTALLER'] == 'debian':
-        extra = localenv.subst(' --root=${python%s_prefix}' % ver)
+        extra = localenv.subst(' --root=${python%s_prefix}' % major)
         install(localenv.Command, dummy, mod,
                 build_cmd + ' install --install-layout=deb --no-compile %s' % extra)
     elif localenv['PYTHON_INSTALLER'] == 'binary':
@@ -138,7 +136,8 @@ for f in ['inputs/h2o2.inp', 'inputs/gri30.inp', 'transport/gri30_tran.dat']:
     testFiles.append(inp)
 
 # Cython module for Python 3.x
-if localenv['python3_package'] == 'y':
+if localenv['python3_package'] == 'full':
+    localenv['python3_cmd_esc'] = quoted(localenv['python3_cmd'])
     py3env = localenv.Clone()
     module_ext, py3_version = configure_python(py3env, py3env['python3_cmd'])
 
@@ -150,7 +149,7 @@ if localenv['python3_package'] == 'y':
 
     py3env.SubstFile('setup3.py', 'setup.py.in')
     build_cmd = ('cd interfaces/cython &&'
-                 ' $python3_cmd setup3.py build --build-lib=../../build/python3')
+                 ' $python3_cmd_esc setup3.py build --build-lib=../../build/python3')
     mod = build(py3env.Command('#build/python3/cantera/__init__.py', 'setup3.py',
                                build_cmd))
     env['python3_module'] = mod
@@ -159,11 +158,11 @@ if localenv['python3_package'] == 'y':
     add_dependencies(mod, ext)
     install_module(py3env['python3_prefix'], py3_version)
 
-
 # Cython module for Python 2.x
-if localenv['python_package'] == 'full':
+if localenv['python2_package'] == 'full':
+    localenv['python2_cmd_esc'] = quoted(localenv['python2_cmd'])
     py2env = localenv.Clone()
-    module_ext, py2_version = configure_python(py2env, py2env['python_cmd'])
+    module_ext, py2_version = configure_python(py2env, py2env['python2_cmd'])
 
     obj = py2env.SharedObject('#build/temp-py/_cantera2', 'cantera/_cantera.cpp')
     ext = py2env.LoadableModule('#build/python2/cantera/_cantera%s' % module_ext,
@@ -172,7 +171,7 @@ if localenv['python_package'] == 'full':
     py2env['py_extension'] = ext[0].name
     py2env.SubstFile('setup2.py', 'setup.py.in')
     build_cmd = ('cd interfaces/cython &&'
-                 ' $python_cmd_esc setup2.py build --build-lib=../../build/python2')
+                 ' $python2_cmd_esc setup2.py build --build-lib=../../build/python2')
     mod = build(py2env.Command('#build/python2/cantera/__init__.py',
                                'setup2.py',
                                build_cmd))
@@ -183,15 +182,9 @@ if localenv['python_package'] == 'full':
     if env['python_convert_examples']:
         def convert_example(target, source, env):
             shutil.copyfile(source[0].abspath, target[0].abspath)
-            if env['OS'] == 'Windows':
-                subprocess.call(env['threetotwo_cmd'] + ['--no-diff', '-n', '-w','-x', 'str',
-                             '-f', 'all', '-f', 'printfunction', '-x', 'print',
-                             '-x', 'open', target[0].abspath])
-            else:
-                subprocess.call(['3to2', '--no-diff', '-n', '-w','-x', 'str',
-                             '-f', 'all', '-f', 'printfunction', '-x', 'print',
-                             '-x', 'open', target[0].abspath])
-
+            subprocess.call(env['threetotwo_cmd'] + ['--no-diff', '-n', '-w','-x', 'str',
+                         '-f', 'all', '-f', 'printfunction', '-x', 'print',
+                         '-x', 'open', target[0].abspath])
         for subdir in subdirs('cantera/examples'):
             dirpath = pjoin('cantera', 'examples', subdir)
             for filename in os.listdir(dirpath):
@@ -204,4 +197,4 @@ if localenv['python_package'] == 'full':
                 py2env.Depends(mod, a)
 
     add_dependencies(mod, ext)
-    install_module(py2env['python_prefix'], py2_version)
+    install_module(py2env['python2_prefix'], py2_version)

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -182,15 +182,14 @@ if localenv['python2_package'] == 'full':
     if env['python_convert_examples']:
         a = build(py2env.Command('#build/python2/cantera/examples', 'cantera/examples',
                                  Copy("$TARGET", "$SOURCE")))
-        from textwrap import dedent
         # In these next few things, the double quotes are necessary
         # so the command line is processed properly
         threetotwo_options = ['--no-diff', '-n', '-w', '-x', 'str', '-x', 'print', '-x', 'open',
                               '-f', 'all', '-f', 'printfunction']
         threetotwo_options = ', '.join(["'{}'"]*len(threetotwo_options)).format(*threetotwo_options)
         ex_loc = "'build/python2/cantera/examples'"
-        convert_script = dedent("""\
-        $python2_cmd_esc -c "from lib3to2.main import main; main('lib3to2.fixes', [{opts}, {loc}])"
+        convert_script = textwrap.dedent("""\
+            $python2_cmd_esc -c "from lib3to2.main import main; main('lib3to2.fixes', [{opts}, {loc}])"
         """.format(opts=threetotwo_options, loc=ex_loc))
         b = build(py2env.AddPostAction(a, convert_script))
         py2env.Depends(mod, b)

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -180,21 +180,20 @@ if localenv['python2_package'] == 'full':
 
     # Use 3to2 to convert examples from Python 3 syntax
     if env['python_convert_examples']:
-        def convert_example(target, source, env):
-            shutil.copyfile(source[0].abspath, target[0].abspath)
-            subprocess.call(env['threetotwo_cmd'] + ['--no-diff', '-n', '-w','-x', 'str',
-                         '-f', 'all', '-f', 'printfunction', '-x', 'print',
-                         '-x', 'open', target[0].abspath])
-        for subdir in subdirs('cantera/examples'):
-            dirpath = pjoin('cantera', 'examples', subdir)
-            for filename in os.listdir(dirpath):
-                if not filename.endswith('.py'):
-                    continue
-                targetdir = '../../build/python2/cantera/examples'
-                a = build(py2env.Command(pjoin(targetdir, subdir, filename),
-                                         pjoin(dirpath, filename),
-                                         convert_example))
-                py2env.Depends(mod, a)
+        a = build(py2env.Command('#build/python2/cantera/examples', 'cantera/examples',
+                                 Copy("$TARGET", "$SOURCE")))
+        from textwrap import dedent
+        # In these next few things, the double quotes are necessary
+        # so the command line is processed properly
+        threetotwo_options = ['--no-diff', '-n', '-w', '-x', 'str', '-x', 'print', '-x', 'open',
+                              '-f', 'all', '-f', 'printfunction']
+        threetotwo_options = ', '.join(["'{}'"]*len(threetotwo_options)).format(*threetotwo_options)
+        ex_loc = "'build/python2/cantera/examples'"
+        convert_script = dedent("""\
+        $python2_cmd_esc -c "from lib3to2.main import main; main('lib3to2.fixes', [{opts}, {loc}])"
+        """.format(opts=threetotwo_options, loc=ex_loc))
+        b = build(py2env.AddPostAction(a, convert_script))
+        py2env.Depends(mod, b)
 
     add_dependencies(mod, ext)
     install_module(py2env['python2_prefix'], py2_version)

--- a/interfaces/cython/cantera/examples/reactors/NonIdealShockTube.py
+++ b/interfaces/cython/cantera/examples/reactors/NonIdealShockTube.py
@@ -1,22 +1,23 @@
 # coding: utf-8
+"""
+Non-Ideal Shock Tube Example
 
-# Non-Ideal Shock Tube Example
-#
-# Ignition delay time computations in a high-pressure reflected shock tube
-# reactor
-#
-# In this example we illustrate how to setup and use a constant volume,
-# adiabatic reactor to simulate reflected shock tube experiments. This reactor
-# will then be used to compute the ignition delay of a gas at a specified
-# initial temperature and pressure. The example is written in a general way,
-# i.e., no particular EoS is presumed and ideal and real gas EoS can be used
-# equally easily.
-#
-# The reactor (system) is simply an 'insulated box,' and can technically be used
-# for any number of equations of state and constant-volume, adiabatic reactors.
-#
-# Other than the typical Cantera dependencies, plotting functions require that
-# you have matplotlib (https://matplotlib.org/) installed.
+Ignition delay time computations in a high-pressure reflected shock tube
+reactor
+
+In this example we illustrate how to setup and use a constant volume,
+adiabatic reactor to simulate reflected shock tube experiments. This reactor
+will then be used to compute the ignition delay of a gas at a specified
+initial temperature and pressure. The example is written in a general way,
+i.e., no particular EoS is presumed and ideal and real gas EoS can be used
+equally easily.
+
+The reactor (system) is simply an 'insulated box,' and can technically be used
+for any number of equations of state and constant-volume, adiabatic reactors.
+
+Other than the typical Cantera dependencies, plotting functions require that
+you have matplotlib (https://matplotlib.org/) installed.
+"""
 
 from __future__ import division
 from __future__ import print_function
@@ -72,7 +73,7 @@ reactorPressure = 40.0*101325.0 # Pascals
 ct.suppress_thermo_warnings()
 
 
-"""Real gas IDT calculation"""
+# Real gas IDT calculation
 
 # Load the real gas mechanism:
 real_gas = ct.Solution('nDodecane_Reitz.cti','nDodecane_RK')
@@ -114,7 +115,7 @@ t1 = time.time()
 print('Computed Real Gas Ignition Delay: {:.3e} seconds. Took {:3.2f}s to compute'.format(tau_RG, t1-t0))
 
 
-"""Ideal gas IDT calculation"""
+# Ideal gas IDT calculation
 # Create the ideal gas object:
 ideal_gas = ct.Solution('nDodecane_Reitz.cti','nDodecane_IG')
 
@@ -183,7 +184,7 @@ plt.legend(['Real Gas','Ideal Gas'], frameon=False)
 #plt.savefig('IDT_nDodecane_1000K_40atm.pdf',dpi=350,format='pdf')
 
 
-"""Demonstration of NTC behavior"""
+# Demonstration of NTC behavior
 # Let us use the reactor model to demonstrate the impacts of non-ideal behavior on IDTs in the
 #   Negative Temperature Coefficient (NTC) region, where observed IDTs, counter to intuition, increase
 #   with increasing temperature.
@@ -198,7 +199,7 @@ estimatedIgnitionDelayTimes = np.ones(len(T))
 estimatedIgnitionDelayTimes[:] = 0.005
 
 # Now, we simply run the code above for each temperature.
-"""Real Gas"""
+# Real Gas
 ignitionDelays_RG = np.zeros(len(T))
 for i, temperature in enumerate(T):
     # Setup the gas and reactor
@@ -230,7 +231,7 @@ for i, temperature in enumerate(T):
     ignitionDelays_RG[i] = tau
 
 
-"""Repeat for Ideal Gas"""
+# Repeat for Ideal Gas
 ignitionDelays_IG = np.zeros(len(T))
 for i, temperature in enumerate(T):
     # Setup the gas and reactor

--- a/interfaces/python_minimal/.gitignore
+++ b/interfaces/python_minimal/.gitignore
@@ -1,4 +1,4 @@
-setup.py
+setup*.py
 scripts/*
 cantera/ck2cti.py
 cantera/ctml_writer.py

--- a/interfaces/python_minimal/SConscript
+++ b/interfaces/python_minimal/SConscript
@@ -1,59 +1,62 @@
-""" Minimal Python Module for Python 2 """
+"""Minimal Python Module"""
 from buildutils import *
 
 Import('env', 'build', 'install')
 
 localenv = env.Clone()
 
-make_setup = build(localenv.SubstFile('setup.py', 'setup.py.in'))
+for py_ver in [2, 3]:
+    if env['python{}_package'.format(py_ver)] == 'minimal':
+        make_setup = build(localenv.SubstFile('setup{}.py'.format(py_ver), 'setup.py.in'))
 
-# copy scripts from the full Cython module
-for script in ['ctml_writer', 'ck2cti']:
-    # The actual script
-    s = build(env.Command('cantera/%s.py' % script,
-                          '#interfaces/cython/cantera/%s.py' % script,
-                          Copy('$TARGET', '$SOURCE')))
-    localenv.Depends(make_setup, s)
+        # copy scripts from the full Cython module
+        for script in ['ctml_writer', 'ck2cti']:
+            # The actual script
+            s = build(env.Command('cantera/%s.py' % script,
+                                  '#interfaces/cython/cantera/%s.py' % script,
+                                  Copy('$TARGET', '$SOURCE')))
+            localenv.Depends(make_setup, s)
 
-build_cmd = ('cd interfaces/python_minimal &&'
-             ' $python_cmd_esc setup.py build --build-lib=../../build/python2')
+        localenv['python{}_cmd_esc'.format(py_ver)] = quoted(localenv['python{}_cmd'.format(py_ver)])
+        build_cmd = ('cd interfaces/python_minimal &&'
+                     ' $python{py_ver}_cmd_esc setup{py_ver}.py build --build-lib=../../build/python{py_ver}'.format(py_ver=py_ver))
 
-mod = build(localenv.Command('#build/python2/cantera/__init__.py',
-                             'setup.py',
-                             build_cmd))
-env['python2_module'] = mod
+        mod = build(localenv.Command('#build/python{}/cantera/__init__.py'.format(py_ver),
+                                     'setup{}.py'.format(py_ver),
+                                     build_cmd))
+        env['python{}_module'.format(py_ver)] = mod
 
-if localenv['PYTHON_INSTALLER'] == 'direct':
-    if localenv['python_prefix'] == 'USER':
-        # Install to the OS-dependent user site-packages directory
-        extra = '--user'
-        if localenv['OS'] == 'Darwin':
-            extra += ' --prefix=""'
-    elif localenv['python_prefix']:
-        # A specific location for the Cantera python module has been given
-        extra = '--user'
-        if localenv['OS'] == 'Darwin':
-            extra += ' --prefix=""'
-        localenv.AppendENVPath(
-            'PYTHONUSERBASE',
-            normpath(localenv.subst('$python_prefix'))
-        )
-    else:
-        # Install Python module in the default location
-        extra = ''
-    mod_inst = install(localenv.Command, 'dummy', mod,
-                       build_cmd + ' install %s' % extra +
-                       ' --record=../../build/python2-installed-files.txt' +
-                       ' --single-version-externally-managed')
-    global_env = env
-
-    def find_module_dir(target, source, env):
-        check = pjoin('cantera', '__init__.py')
-        for filename in open('build/python2-installed-files.txt').readlines():
-            filename = filename.strip()
-            if filename.endswith(check):
-                filename = filename.replace(check, '')
-                global_env['python_module_loc'] = normpath(filename)
-                break
-    localenv.AlwaysBuild(localenv.AddPostAction(mod_inst, find_module_dir))
-    env['install_python2_action'] = mod_inst
+        if localenv['PYTHON_INSTALLER'] == 'direct':
+            if localenv['python{}_prefix'.format(py_ver)] == 'USER':
+                # Install to the OS-dependent user site-packages directory
+                extra = '--user'
+                if localenv['OS'] == 'Darwin':
+                    extra += ' --prefix=""'
+            elif localenv['python{}_prefix'.format(py_ver)]:
+                # A specific location for the Cantera python module has been given
+                extra = '--user'
+                if localenv['OS'] == 'Darwin':
+                    extra += ' --prefix=""'
+                localenv.AppendENVPath(
+                    'PYTHONUSERBASE',
+                    normpath(localenv.subst('$python{}_prefix'.format(py_ver)))
+                )
+            else:
+                # Install Python module in the default location
+                extra = ''
+            mod_inst = install(localenv.Command, 'dummy{}'.format(py_ver), mod,
+                               build_cmd + ' install %s' % extra +
+                               ' --record=../../build/python{}-installed-files.txt'.format(py_ver) +
+                               ' --single-version-externally-managed')
+            global_env = env
+            def find_module_dir(target, source, env):
+                check = pjoin('cantera', '__init__.py')
+                py_ver = str(source[0]).split('/')[1][-1]
+                for filename in open('build/python{}-installed-files.txt'.format(py_ver)).readlines():
+                    filename = filename.strip()
+                    if filename.endswith(check):
+                        filename = filename.replace(check, '')
+                        global_env['python{}_module_loc'.format(py_ver)] = normpath(filename)
+                        break
+            localenv.AlwaysBuild(localenv.AddPostAction(mod_inst, find_module_dir))
+            env['install_python{}_action'.format(py_ver)] = mod_inst

--- a/interfaces/python_minimal/cantera/__init__.py
+++ b/interfaces/python_minimal/cantera/__init__.py
@@ -1,2 +1,2 @@
-import ck2cti
-import ctml_writer
+from . import ck2cti
+from . import ctml_writer

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -11,19 +11,31 @@ if env['INSTALL_MANPAGES']:
 
 ### Generate customized scripts ###
 
+# If any Python 3 package is built, prefer that one. If not,
+# and if any Python 2 package is built, prefer that one.
+# In all other cases, use the Python 3 location variables,
+# which should all be empty strings
+if env['python3_package'] in ['full', 'minimal']:
+    major = '3'
+elif env['python2_package'] in ['full', 'minimal']:
+    major = '2'
+else:
+    major = '3'
+
 # 'setup_cantera'
 if localenv['layout'] != 'debian' and env['OS'] != 'Windows':
-    v = sys.version_info
 
     def copy_var(target, source, env):
-        if env['python_prefix'] == 'USER':
+        if env['python{}_prefix'.format(major)] == 'USER':
             env['python_module_loc_sc'] = ''
         else:
-            env['python_module_loc_sc'] = env['python_module_loc']
+            env['python_module_loc_sc'] = env['python{}_module_loc'.format(major)]
+        env['python_cmd'] = env['python{}_cmd'.format(major)]
+        env['python_array_home'] = env['python{}_array_home'.format(major)]
 
     target = env.SubstFile('setup_cantera', 'setup_cantera.in')
     localenv.AddPreAction(target, copy_var)
-    localenv.Depends(target, env['install_python2_action'])
+    localenv.Depends(target, env['install_python{}_action'.format(major)])
     install('$inst_bindir', target)
 
 # Cantera.mak include file for Makefile projects

--- a/platform/posix/setup_cantera.in
+++ b/platform/posix/setup_cantera.in
@@ -35,9 +35,9 @@ fi
 
 if [ "@python_module_loc_sc@" != "" ]; then
     if [ -z $PYTHONPATH ]; then
-        PYTHONPATH=@python_module_loc@
+        PYTHONPATH=@python_module_loc_sc@
     else
-        PYTHONPATH=@python_module_loc@:$PYTHONPATH
+        PYTHONPATH=@python_module_loc_sc@:$PYTHONPATH
     fi
 fi
 

--- a/src/base/ct2ctml.cpp
+++ b/src/base/ct2ctml.cpp
@@ -89,14 +89,6 @@ static std::string call_ctml_writer(const std::string& text, bool isfile)
         arg = "text=r'''" + text + "'''";
     }
 
-#ifdef HAS_NO_PYTHON
-    //! Section to bomb out if python is not present in the computation
-    //! environment.
-    throw CanteraError("ct2ctml",
-                       "python cti to ctml conversion requested for file, " + file +
-                       ", but not available in this computational environment");
-#endif
-
     string python_output, error_output;
     int python_exit_code;
     try {
@@ -191,15 +183,6 @@ std::string ct_string2ctml_string(const std::string& cti)
 void ck2cti(const std::string& in_file, const std::string& thermo_file,
             const std::string& transport_file, const std::string& id_tag)
 {
-#ifdef HAS_NO_PYTHON
-    //! Section to bomb out if python is not present in the computation
-    //! environment.
-    string ppath = in_file;
-    throw CanteraError("ct2ctml",
-                       "python ck to cti conversion requested for file, " + ppath +
-                       ", but not available in this computational environment");
-#endif
-
     string python_output;
     int python_exit_code;
     try {

--- a/src/matlab/SConscript
+++ b/src/matlab/SConscript
@@ -68,7 +68,7 @@ ctmethods = build(localenv.SharedLibrary('#interfaces/matlab/toolbox/ctmethods',
                                          SHLIBSUFFIX=mexSuffix,
                                          LIBS=linklibs))
 
-if localenv['OS'] in ('Windows', 'Darwin'):
+if localenv['OS'] in ('Windows'):
     localenv.Depends(ctmethods, localenv['cantera_shlib'])
 else:
     localenv.Depends(ctmethods, localenv['cantera_staticlib'])

--- a/src/matlab/SConscript
+++ b/src/matlab/SConscript
@@ -79,16 +79,29 @@ env['matlab_extension'] = ctmethods
 
 # 'ctpath.m'
 globalenv = env
+
+# If any Python 3 package is built, prefer that one. If not,
+# and if any Python 2 package is built, prefer that one.
+# In all other cases, use the Python 3 location variables,
+# which should all be empty strings
+if env['python3_package'] in ['full', 'minimal']:
+    major = '3'
+elif env['python2_package'] in ['full', 'minimal']:
+    major = '2'
+else:
+    major = '3'
+
 def copy_var(target, source, env):
-    if env['python_prefix'] == 'USER':
+    if env['python{}_prefix'.format(major)] == 'USER':
         env['python_module_loc_sc'] = ''
     else:
-        env['python_module_loc_sc'] = globalenv['python_module_loc']
+        env['python_module_loc_sc'] = globalenv['python{}_module_loc'.format(major)]
+    env['python_cmd'] = env['python{}_cmd'.format(major)]
 
 target = localenv.SubstFile('#interfaces/matlab/ctpath.m',
                             '#interfaces/matlab/ctpath.m.in')
 localenv.AddPreAction(target, copy_var)
-localenv.Depends(target, env['install_python2_action'])
+localenv.Depends(target, env['install_python{}_action'.format(major)])
 install('$inst_matlab_dir', target)
 
 # 'Contents.m'

--- a/test/SConscript
+++ b/test/SConscript
@@ -241,7 +241,7 @@ def make_python_tests(version):
         pyTest = addPythonTest(
             name, 'python', 'runCythonTests.py',
             args=subset,
-            interpreter='$python_cmd' if version == 2 else '$python3_cmd',
+            interpreter='$python{}_cmd'.format(version),
             outfile=File('#test/work/python%d-results.txt' % version).abspath,
             dependencies=(localenv['python%i_module' % version] +
                           localenv['python%i_extension' % version] +
@@ -251,10 +251,10 @@ def make_python_tests(version):
         localenv.Alias('test-' + name, pyTest)
         env['testNames'].append(name)
 
-if localenv['python_package'] == 'full':
+if localenv['python2_package'] == 'full':
     make_python_tests(2)
 
-if localenv['python3_package'] == 'y':
+if localenv['python3_package'] == 'full':
     make_python_tests(3)
 
 if localenv['matlab_toolbox'] == 'y':

--- a/test/SConscript
+++ b/test/SConscript
@@ -209,14 +209,15 @@ def addMatlabTest(script, testName, dependencies=None, env_vars=()):
 
     return run_program
 
-if localenv['python_package'] in ('full', 'minimal'):
+if localenv['python2_package'] in ('full', 'minimal'):
     python_env_vars = {'PYTHONPATH': localenv['pythonpath_build2'],
-                       'PYTHON_CMD': localenv.subst('$python_cmd')}
-elif localenv['python3_package'] == 'y':
+                       'PYTHON_CMD': localenv.subst('$python2_cmd')}
+elif localenv['python3_package'] in ('full', 'minimal'):
     python_env_vars = {'PYTHONPATH': localenv['pythonpath_build3'],
                        'PYTHON_CMD': localenv.subst('$python3_cmd')}
 else:
-    python_env_vars = {} # Tests calling ck2cti or ctml_writer will fail
+    python_env_vars = {'PYTHONPATH': '../../build/python_minimal',
+                       'PYTHON_CMD': localenv.subst('$python_cmd')}
 
 
 # Instantiate tests

--- a/test/kinetics/rates.cpp
+++ b/test/kinetics/rates.cpp
@@ -8,7 +8,6 @@
 namespace Cantera
 {
 
-#ifndef HAS_NO_PYTHON
 TEST(FracCoeff, ConvertFracCoeff)
 {
     IdealGasPhase thermo1("../data/frac.cti", "gas");
@@ -33,7 +32,6 @@ TEST(FracCoeff, ConvertFracCoeff)
         }
     }
 }
-#endif
 
 class FracCoeffTest : public testing::Test
 {

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -155,7 +155,6 @@ TEST(IonsFromNeutralConstructor, fromScratch)
     EXPECT_NEAR(mu[1], -2.88157298e+06, 1e-1);
 }
 
-#ifndef HAS_NO_PYTHON // skip these tests if the Python converter is unavailable
 class CtiConversionTest : public testing::Test
 {
 public:
@@ -215,7 +214,6 @@ TEST_F(ChemkinConversionTest, FailedConversion) {
     ASSERT_THROW(ck2cti("h2o2_missingThermo.inp"),
                  CanteraError);
 }
-#endif
 
 class ConstructFromScratch : public testing::Test
 {

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -19,16 +19,18 @@ if localenv['OS'] == 'Linux':
 else:
     cantera_libs = localenv['cantera_libs']
 
-if localenv['python_package'] in ('full', 'minimal'):
+if localenv['python2_package'] in ('full', 'minimal'):
     localenv['ENV']['PYTHONPATH'] = localenv['pythonpath_build2']
-    localenv['ENV']['PYTHON_CMD'] = localenv.subst('$python_cmd')
+    localenv['ENV']['PYTHON_CMD'] = localenv.subst('$python2_cmd')
     haveConverters = True
-elif localenv['python3_package'] == 'y':
+elif localenv['python3_package'] in ('full', 'minimal'):
     localenv['ENV']['PYTHONPATH'] = localenv['pythonpath_build3']
     localenv['ENV']['PYTHON_CMD'] = localenv.subst('$python3_cmd')
     haveConverters = True
 else:
-    haveConverters = False
+    localenv['ENV']['PYTHONPATH'] = '../../build/python_minimal'
+    localenv['ENV']['PYTHON_CMD'] = localenv.subst('$python_cmd')
+    haveConverters = True
 
 localenv['ENV']['CANTERA_DATA'] = pjoin(os.getcwd(), '..', 'build', 'data')
 


### PR DESCRIPTION
Changes proposed in this pull request:
- Remove the `HAS_NO_PYTHON` configuration variable to allow building just the library, then adding the Python interfaces without rebuilding everything. See https://groups.google.com/forum/#!topic/cantera-users/a3IK3A4XEfI
- Rework SConstruct to recognize that SCons can be run by Python 3 now, and remove the assumption that Python 2 is running SCons. This still keeps the ability to build both interfaces simultaneously, but attempts to make the options more consistent
- Also make the minimal Python interface compatible with and able to be installed for Python 3

I'd appreciate some feedback on this, since the changes are pretty big to SConstruct. AFAICT, everything should keep working with old versions of SCons. This is still WIP because the tests aren't working yet, and I need to update the documentation (if this gets approved). Would still appreciate some feedback while I try to fix the tests.
