### PR TITLE
Simplify python package options

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -32,9 +32,9 @@ before_script: |
   rm -f cantera.conf
 script: |
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
-      scons build -j2 VERBOSE=y python_package=none python2_package=full python3_package=full python3_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas optimize=n coverage=y
+      scons build -j2 VERBOSE=y python2_package=full python3_package=full python3_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas optimize=n coverage=y
   else
-      scons build -j2 VERBOSE=y python_package=none python2_package=full python3_package=full blas_lapack_libs=lapack,blas optimize=n coverage=y
+      scons build -j2 VERBOSE=y python2_package=full python3_package=full blas_lapack_libs=lapack,blas optimize=n coverage=y
   fi
   scons test
 after_success: |

--- a/SConstruct
+++ b/SConstruct
@@ -1112,6 +1112,14 @@ env['python_cmd_esc'] = quoted(env['python_cmd'])
 cython_min_version = LooseVersion('0.23')
 numpy_min_test_version = LooseVersion('1.8.1')
 
+# If both python2_package and python3_package are set to something
+# other than the default ignore the python_package option
+if all([env['python{}_package'.format(p)] != 'default' for p in ['2', '3']]):
+    if env['python_package'] != 'default':
+        print("WARNING: Both version-specific pythonX_package options are set. Ignoring "
+              "non-version specific python_package options")
+    env['python_package'] = 'none'
+
 if env['python_package'] == 'new':
     print("WARNING: The 'new' option for the Python package is "
           "deprecated and will be removed in the future. Use "

--- a/SConstruct
+++ b/SConstruct
@@ -1161,13 +1161,22 @@ if env['python_package'] in ('full', 'minimal', 'default'):
     else:
         major = env['python_version'][0]
         py_pkg = 'python{}_package'.format(major)
-        if env[py_pkg] in ['full', 'minimal']:
-            print("ERROR: The version of Python found by the python_cmd option is Python {v} and "
-                  "the python{v}_package option is not 'default'. Please change python_cmd to "
-                  "point to a different version of Python, set the python_package option to 'none', "
-                  "or set the python{v}_package option to 'default'.".format(v=major))
-            sys.exit(1)
-        else:
+        if env[py_pkg] == 'none':
+            if env['python_package'] != 'default':
+                # If python_package is default, and the version specific pythonX_package
+                # is none, don't print a warning. If python_package has been set, warn
+                # the user that we're ignoring that option.
+                print("WARNING: The Python {v} package has been requested not to be built. All "
+                      "non-version specific Python options have been ignored.".format(v=major))
+        elif env[py_pkg] in ['full', 'minimal']:
+            if env['python_package'] != 'default':
+                msg = ("The version of Python found by the python_cmd option is Python {v} and "
+                      "the python{v}_package option is either 'full' or 'minimal'.\n"
+                      "       Please change python_cmd to point to a different major version of "
+                       "Python or set the python_package option to 'default' or 'none'.".format(v=major))
+                print("ERROR:", msg)
+                sys.exit(1)
+        else:  # pythonX_package is 'default'
             # This dictionary has the default values for the Python related variables
             default_py_vars = {'python{}_array_home': '', 'python{}_cmd': 'python{}'.format(major),
                        'python{}_prefix': '$prefix'}
@@ -1176,12 +1185,12 @@ if env['python_package'] in ('full', 'minimal', 'default'):
             # Check whether any Python related variables are different from the default
             for key, value in default_py_vars.items():
                 if env[key.format(major)] != value:
-                    print("WARNING: The value for {} has been set and will be used instead "
-                          "of {}".format(key.format(major), key.format('')))
+                    print("WARNING: The value for {0} has been set and will be used instead "
+                          "of {1}".format(key.format(major), key.format('')))
                 else:
                     env[key.format(major)] = env[key.format('')]
 
-    del env['python_version']
+        del env['python_version']
 
 # Make sure everything gets converted to properly versioned variables by deleting
 # these so they don't get used accidentally

--- a/SConstruct
+++ b/SConstruct
@@ -1161,21 +1161,13 @@ if env['python_package'] in ('full', 'minimal', 'default'):
     else:
         major = env['python_version'][0]
         py_pkg = 'python{}_package'.format(major)
-        if env[py_pkg] == 'none':
+        if env[py_pkg] != 'default':
             if env['python_package'] != 'default':
-                # If python_package is default, and the version specific pythonX_package
-                # is none, don't print a warning. If python_package has been set, warn
-                # the user that we're ignoring that option.
-                print("WARNING: The Python {v} package has been requested not to be built. All "
-                      "non-version specific Python options have been ignored.".format(v=major))
-        elif env[py_pkg] in ['full', 'minimal']:
-            if env['python_package'] != 'default':
-                msg = ("The version of Python found by the python_cmd option is Python {v} and "
-                      "the python{v}_package option is either 'full' or 'minimal'.\n"
-                      "       Please change python_cmd to point to a different major version of "
-                       "Python or set the python_package option to 'default' or 'none'.".format(v=major))
-                print("ERROR:", msg)
-                sys.exit(1)
+                # If python_package is default don't print a warning. If python_package has been
+                # set, warn the user that we're ignoring that option.
+                print("WARNING: The python{v}_package option has been set to {option}. All "
+                      "non-version-specific Python options (including python_cmd) have been "
+                      "ignored.".format(v=major, option=env[py_pkg]))
         else:  # pythonX_package is 'default'
             # This dictionary has the default values for the Python related variables
             default_py_vars = {'python{}_array_home': '', 'python{}_cmd': 'python{}'.format(major),

--- a/SConstruct
+++ b/SConstruct
@@ -1214,7 +1214,6 @@ del env['python_prefix']
 def configure_python(py_ver):
     # Test to see if we can import numpy
     warn_no_python = False
-    python_message = ''
     script = textwrap.dedent("""\
         from __future__ import print_function
         import sys
@@ -1245,7 +1244,7 @@ def configure_python(py_ver):
         (env['python{}_version'.format(py_ver)], numpy_version) = info.splitlines()[-2:]
         numpy_version = LooseVersion(numpy_version)
         if numpy_version == LooseVersion('0.0.0'):
-            python_message += "NumPy for Python {0} not found.\n".format(env['python{}_version'.format(py_ver)])
+            print("NumPy for Python {0} not found.".format(env['python{}_version'.format(py_ver)]))
             warn_no_python = True
         elif numpy_version < numpy_min_test_version:
             print("WARNING: The installed version of Numpy for Python {0} is not tested and "
@@ -1260,13 +1259,11 @@ def configure_python(py_ver):
             print('WARNING: Not building the full Python {py_ver} package because the Python '
                   '{py_ver} interpreter {interp!r} could not be found or a required dependency '
                   '(e.g. numpy) was not found.'.format(py_ver=py_ver, interp=env['python{}_cmd'.format(py_ver)]))
-            print(python_message)
 
-            env['python{}_package'.format(py_ver)] = 'minimal'
+            env['python{}_package'.format(py_ver)] = 'minimal-default'
         else:
             print('ERROR: Could not execute the Python {py_ver} interpreter {interp!r} or a required '
                   'dependency (e.g. numpy) could not be found.'.format(py_ver=py_ver, interp=env['python{}_cmd'.format(py_ver)]))
-            print(python_message)
 
             sys.exit(1)
     else:

--- a/SConstruct
+++ b/SConstruct
@@ -1224,11 +1224,6 @@ def configure_python(py_ver):
             print(numpy.__version__)
         except ImportError:
             print('0.0.0')
-        import site
-        try:
-            print(site.getusersitepackages())
-        except AttributeError:
-            print(site.USER_SITE)
     """)
 
     if env['python{}_array_home'.format(py_ver)]:
@@ -1247,8 +1242,7 @@ def configure_python(py_ver):
             print(err, err.output)
         warn_no_python = True
     else:
-        (env['python{}_version'.format(py_ver)], numpy_version,
-         env['python{}_usersitepackages'.format(py_ver)]) = info.splitlines()[-3:]
+        (env['python{}_version'.format(py_ver)], numpy_version) = info.splitlines()[-2:]
         numpy_version = LooseVersion(numpy_version)
         if numpy_version == LooseVersion('0.0.0'):
             python_message += "NumPy for Python {0} not found.\n".format(env['python{}_version'.format(py_ver)])


### PR DESCRIPTION
This should simplify selection of the Python options. The details are below; the TLDR is

- if `python_package` is `'default'` and the matching `pythonX_package` is specified, the `pythonX_*` options are silently used
- There is no longer an error if the `python_package` and the `pythonX_package` are specified (i.e.,
 not default), it is only a warning. Hopefully that will be less hostile :smiley:
- If both `pythonX_package` options are set, ignore the general `python_package` option entirely (well, set it to 'none' at the beginning of the configuration, so nothing is done with it and then its deleted)
- I also tried to be more sensible about choosing when to build the minimal interface. Essentially, if finding Cython or NumPy fails, we try to build the minimal interfaces. If configuring (see the next bullet) the minimal interface fails, and the `pythonX_package` was initially `'default'`, don't error out, just don't build that interface (i.e., that `pythonX_package` is set to `'none'`). Also, if one of the full interfaces is being built and the user specifically requests the other minimal interface, allow that, but if the minimal interface was going to be built automatically, don't do that.
- As a second benefit to the previous bullet, if the user specifies the `minimal` interface to be built, we now check that the Python is configured properly (which is to say, it exists and can tell us its version information).
- If the `python_package` is `default` and checking for its version (with `python_cmd`) fails for some reason, warn the user and don't change any `pythonX_*` variables, just continue with the default values already present in them (this was also the behavior before, I'm just clarifying here so I remember it in the future)

# Details
Assuming 3 options
* `python2_package`
* `python3_package`
* `python_package`

with 4 levels each
* `default` (`d`)
* `full` (`f`)
* `minimal` (`m`)
* `none` (`n`)

then the following collections are possible:

* `python2_package in ['full', 'minimal', 'none']` and `python3_package in ['full', 'minimal', 'none']`, `python_package == 'default'`
  * `python_package` is ignored and the build proceeds as normal
  * Covers 9 possible combinations: ffd, fmd, fnd, mfd, mmd, mnd, nfd, nmd, nnd
  
* `python2_package in ['full', 'minimal', 'none']` and `python3_package in ['full', 'minimal', 'none']`, `python_package in ['full', 'minimal', 'none']`
  * `python_package` is ignored and the build proceeds as normal
  * The user is warned
  * Covers 27 possible combinations: fff, ffm, ffn, fmf, fmm, fmn, fnf, fnm, fnn, mff, mfm, mfn, mmf, mmm, mmn, mnf, mnm, mnn, nff, nfm, nfn, nmf, nmm, nmn, nnf, nnm, nnn

* `python2_package == 'default'` and `python3_package == 'default'` and `python_package == 'none'`
  * All Python packages are set to `none`
  * Covers 1 possible combination: ddn

* `python2_package == 'default'` and `python3_package == 'default'` and `python_package in ['default', 'full', 'minimal']`
  * Determine which version of Python that `python_cmd` points to and set the appropriate `pythonX_package` to the value of `python_package`
  * Warn the user if any `pythonX_*` variables are set and use the `pythonX_*` variables instead of the `python_*` variables
  * Covers 3 possible combinations: ddd, ddf, ddm

* `python2_package in ['full', 'minimal', 'none']` and `python3_package == 'default'` and `python_package == 'default'`
  * If `python_cmd` is Python 2
    * Use the `python2_*` options silently
  * If `python_cmd` is Python 3
    * Warn the user if any `python3_*` variables are set and use the `python3_*` variables instead of the `python_*` variables
  * Covers 3 possible combinations: fdd, mdd, ndd

* `python2_package in ['full', 'minimal', 'none']` and `python3_package == 'default'` and `python_package in ['full', 'minimal', 'none']`
  * If `python_cmd` is Python 2
    * Use the `python2_*` options
    * Warn the user that all non-version-specific options are ignored
  * If `python_cmd` is Python 3
    * Warn the user if any `python3_*` variables are set and use the `python3_*` variables instead of the `python_*` variables
  * Covers 9 possible combinations: fdf, mdf, ndf, mdf, mdm, mdn, ndf, ndm, ndn

* `python2_package == 'default'` and `python3_package in ['full', 'minimal', 'none']` and `python_package == 'default'`
  * If `python_cmd` is Python 3
    * Use the `python3_*` options silently
  * If `python_cmd` is Python 2
    * Warn the user if any `python2_*` variables are set and use the `python2_*` variables instead of the `python_*` variables
  * Covers 3 possible combinations: dfd, dmd, dnd

* `python2_package == 'default'` and `python3_package in ['full', 'minimal', 'none']` and `python_package in ['full', 'minimal', 'none']`
  * If `python_cmd` is Python 3
    * Use the `python3_*` options
    * Warn the user that all non-version-specific options are ignored
  * If `python_cmd` is Python 2
    * Warn the user if any `python2_*` variables are set and use the `python2_*` variables instead of the `python_*` variables
  * Covers 9 possible combinations: dff, dfm, dfn, dmf, dmm, dmn, dnf, dnm, dnn

Total, that's 64 possible combinations. I think I've tested all of them, and I think they all do what I expect, as detailed above