### PR TITLE
Fix 1D solver failures

### DIFF
--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1052,9 +1052,9 @@ cdef class Sim1D:
     cdef object _initialized
     cdef object _initial_guess_args
     cdef object _initial_guess_kwargs
-    cdef Func1 interrupt
-    cdef Func1 time_step_callback
-    cdef Func1 steady_callback
+    cdef public Func1 _interrupt
+    cdef public Func1 _time_step_callback
+    cdef public Func1 _steady_callback
 
 cdef class ReactionPathDiagram:
     cdef CxxReactionPathDiagram diagram

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -585,8 +585,8 @@ cdef class Sim1D:
         """
         if not isinstance(f, Func1):
             f = Func1(f)
-        self.interrupt = f
-        self.sim.setInterrupt(self.interrupt.func)
+        self._interrupt = f
+        self.sim.setInterrupt(self._interrupt.func)
 
     def set_time_step_callback(self, f):
         """
@@ -596,8 +596,8 @@ cdef class Sim1D:
         """
         if not isinstance(f, Func1):
             f = Func1(f)
-        self.time_step_callback = f
-        self.sim.setTimeStepCallback(self.time_step_callback.func)
+        self._time_step_callback = f
+        self.sim.setTimeStepCallback(self._time_step_callback.func)
 
     def set_steady_callback(self, f):
         """
@@ -607,8 +607,8 @@ cdef class Sim1D:
         """
         if not isinstance(f, Func1):
             f = Func1(f)
-        self.steady_callback = f
-        self.sim.setSteadyCallback(self.steady_callback.func)
+        self._steady_callback = f
+        self.sim.setSteadyCallback(self._steady_callback.func)
 
     def domain_index(self, dom):
         """

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -583,6 +583,11 @@ cdef class Sim1D:
         interrupt function is used to trap KeyboardInterrupt exceptions so
         that `ctrl-c` can be used to break out of the C++ solver loop.
         """
+        if f is None:
+            self.sim.setInterrupt(NULL)
+            self._interrupt = None
+            return
+
         if not isinstance(f, Func1):
             f = Func1(f)
         self._interrupt = f
@@ -594,6 +599,11 @@ cdef class Sim1D:
         The signature of *f* is `float f(float)`. The argument passed to *f* is
         the size of the timestep. The output is ignored.
         """
+        if f is None:
+            self.sim.setTimeStepCallback(NULL)
+            self._time_step_callback = None
+            return
+
         if not isinstance(f, Func1):
             f = Func1(f)
         self._time_step_callback = f
@@ -605,6 +615,11 @@ cdef class Sim1D:
         solve, before regridding. The signature of *f* is `float f(float)`. The
         argument passed to *f* is "0" and the output is ignored.
         """
+        if f is None:
+            self.sim.setSteadyCallback(NULL)
+            self._steady_callback = None
+            return
+
         if not isinstance(f, Func1):
             f = Func1(f)
         self._steady_callback = f

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -818,6 +818,19 @@ class TestBurnerFlame(utilities.CanteraTest):
         self.assertNear(sim.T[-1], 500)
         self.assertNear(max(sim.T), 1100)
 
+    def test_blowoff(self):
+        gas = ct.Solution('h2o2.cti')
+        gas.set_equivalence_ratio(0.4, 'H2', 'O2:1.0, AR:5')
+        gas.TP = 300, ct.one_atm
+        sim = ct.BurnerFlame(gas=gas, width=0.1)
+        sim.burner.mdot = 1.2
+        sim.set_refine_criteria(ratio=3, slope=0.3, curve=0.5, prune=0)
+        sim.solve(loglevel=0, auto=True)
+        # nonreacting solution
+        self.assertNear(sim.T[-1], sim.T[0], 1e-6)
+        self.assertNear(sim.u[-1], sim.u[0], 1e-6)
+        self.assertArrayNear(sim.Y[:,0], sim.Y[:,-1], 1e-6, atol=1e-6)
+
 
 class TestImpingingJet(utilities.CanteraTest):
     def run_reacting_surface(self, xch4, tsurf, mdot, width):

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -157,6 +157,19 @@ class TestFreeFlame(utilities.CanteraTest):
 
         self.assertEqual(self.sim.transport_model, 'Multi')
 
+    def test_auto_width(self):
+        Tin = 300
+        p = ct.one_atm
+        reactants = 'H2:0.65, O2:0.5, AR:2'
+        self.create_sim(p, Tin, reactants, width=0.0001)
+        self.sim.set_refine_criteria(ratio=3, slope=0.3, curve=0.2)
+        self.sim.solve(loglevel=0, refine_grid=True, auto=True)
+
+        self.gas.TPX = Tin, p, reactants
+        self.gas.equilibrate('HP')
+        Tad = self.gas.T
+        self.assertNear(Tad, self.sim.T[-1], 2e-2)
+
     def test_converge_adiabatic(self):
         # Test that the adiabatic flame temperature and species profiles
         # converge to the correct equilibrium values as the grid is refined


### PR DESCRIPTION
Fix some 1D solver failures that require watching the solver state as it progresses to detect the problem:

* #385 (failures for freely-propagating flames when the domain is narrow compared to the flame width)
* #386 (indefinite regridding for burner-stabilized flames that are in the process of blowing off)