### PR TITLE
Fixes `ConstDensityThermo::standardConcentration()`

### DIFF
--- a/src/thermo/ConstDensityThermo.cpp
+++ b/src/thermo/ConstDensityThermo.cpp
@@ -59,7 +59,7 @@ void ConstDensityThermo::getActivityCoefficients(doublereal* ac) const
 
 doublereal ConstDensityThermo::standardConcentration(size_t k) const
 {
-    return molarDensity();
+    return density()/molecularWeight(k);
 }
 
 void ConstDensityThermo::getChemPotentials(doublereal* mu) const

--- a/test/data/sofc-test.xml
+++ b/test/data/sofc-test.xml
@@ -40,11 +40,11 @@
       <pressure units="Pa">101325.0</pressure>
       <moleFractions>Ox:0.95 VO**:0.05</moleFractions>
     </state>
-    <thermo model="Incompressible">
+    <thermo model="IdealSolidSolution">
       <density units="g/cm3">0.7</density>
     </thermo>
-    <transport model="None"/>
-    <kinetics model="none"/>
+    <standardConc model="unity"/>
+    <transport model="None"/>      <kinetics model="none"/>
   </phase>
 
   <!-- phase metal_surface     -->
@@ -132,6 +132,9 @@
            <cp0 units="J/mol/K">0.0</cp0>
         </const_cp>
       </thermo>
+      <standardState>
+        <molarVolume>0.0018</molarVolume>
+      </standardState>
     </species>
 
     <!-- species Ox    -->
@@ -146,6 +149,9 @@
            <cp0 units="J/mol/K">0.0</cp0>
         </const_cp>
       </thermo>
+      <standardState>
+        <molarVolume>0.0018</molarVolume>
+      </standardState>
     </species>
 
     <!-- species (m)    -->


### PR DESCRIPTION
 Fixes #458 .

Changes proposed in this pull request:
-`ConstDensityThermo::standardConcentration` for species k is calculated as
`density()/molecularWeight(k)`.  Was previously calculated (incorrectly) as
`molarDensity()`. 
- Note that any species with a molecularWeight of zero (i.e. a vacancy) will 
cause problems, and therefore should be avoided for this phase.
-For this reason, sofc-text.xml also had to be changed and models the YSZ 
electrolyte as `IdealSolidSolution`, rather than as `incompressible_solid`.
