### PR TITLE
make ck2cti more deterministic in it's output

### DIFF
--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -117,7 +117,7 @@ class Species(object):
     def to_cti(self, indent=0):
         lines = []
         atoms = ' '.join('{0}:{1}'.format(*a)
-                         for a in sorted(self.composition.items())
+                         for a in sorted(self.composition.items()))
 
         prefix = ' '*(indent+8)
 

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -117,7 +117,7 @@ class Species(object):
     def to_cti(self, indent=0):
         lines = []
         atoms = ' '.join('{0}:{1}'.format(*a)
-                         for a in self.composition.items())
+                         for a in sorted(self.composition.items())
 
         prefix = ' '*(indent+8)
 
@@ -309,7 +309,7 @@ class Reaction(object):
 
         if self.fwdOrders:
             order = ' '.join('{0}:{1}'.format(k,v)
-                             for (k,v) in self.fwdOrders.items())
+                             for (k,v) in sorted(self.fwdOrders.items()))
             kinstr = kinstr[:-1] + ",\n{0}order='{1}')".format(k_indent, order)
 
         if self.ID:
@@ -379,7 +379,7 @@ class KineticsModel(object):
 
     def efficiencyString(self):
         return ' '.join('{0}:{1}'.format(mol, eff)
-                        for mol, eff in self.efficiencies.items())
+                        for mol, eff in sorted(self.efficiencies.items()))
 
 
 class KineticsData(KineticsModel):
@@ -2079,7 +2079,7 @@ class Parser(object):
             lines.append('# Element data')
             lines.append(delimiterLine)
             lines.append('')
-            for name, weight in self.element_weights.items():
+            for name, weight in sorted(self.element_weights.items()):
                 lines.append('element(symbol={0!r}, atomic_mass={1})'.format(name, weight))
 
         # Write the individual species data


### PR DESCRIPTION
A few simple fixes (sorting of dictionary items) to ensure that ck2cti's output is more deterministic.

The context of this is I have a test mechanism I have in chemkin format, and a (hopefully) identical mechanism in cantera format.

In pyJac we have our own interpreter that can parse either format, so we have unit tests that
1.) Ensure that our own internal data representations of both the parsed chemkin and cantera mechanisms are identical.
2.) Test that converting the chemkin model to cantera format produces the same mechanism as we have stored in our repository -- this is easiest to accomplish via difflib or the like (rather than writing equality functions for Cantera reaction/species classes, although that might be a worthwhile endeavor at some point)

The current issue I'm facing is that often we see different outputs from ck2cti, for example

```
species(name=u'OH',
        atoms='H:1 O:1',
```

vs.

```
species(name=u'OH',
        atoms='O:1 H:1',
```

IMO the (minor) performance hit of sorting the dictionaries based on the items (effectively, sorting based on the key) is worth having consistent deterministic output :)