### PR TITLE
Fixed Typo: MATLAB_PATH -> MATLABPATH

### DIFF
--- a/platform/posix/setup_cantera.csh.in
+++ b/platform/posix/setup_cantera.csh.in
@@ -21,7 +21,7 @@ if ("@python_cmd@" != `which python`) then
 endif
 
 if ("@matlab_toolbox@" == "y") then
-    if (! $?MATLAB_PATH) then
+    if (! $?MATLABPATH) then
         setenv MATLABPATH @ct_matlab_dir@:@ct_matlab_dir@/1D
     else
         setenv MATLABPATH $MATLABPATH:@ct_matlab_dir@:@ct_matlab_dir@/1D

--- a/platform/posix/setup_cantera.in
+++ b/platform/posix/setup_cantera.in
@@ -25,7 +25,7 @@ if [ "@python_cmd@" != `which python` ]; then
 fi
 
 if [ "@matlab_toolbox@" = "y" ]; then
-    if [ -z $MATLAB_PATH ]; then
+    if [ -z $MATLABPATH ]; then
         MATLABPATH=@ct_matlab_dir@:@ct_matlab_dir@/1D
     else
         MATLABPATH=$MATLABPATH:@ct_matlab_dir@:@ct_matlab_dir@/1D


### PR DESCRIPTION
Fixes #500

Changes proposed in this pull request:
- Change `MATLAB_PATH` to `MATLABPATH` in `setup_cantera` and `setup_cantera.csh`
