### PR TITLE
fixed broken link to compilation instructions page

### DIFF
--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,4 +1,6 @@
-Fixes # .
+Please fill in the issue number this pull request is fixing:
+
+Fixes #
 
 Changes proposed in this pull request:
 -

--- a/README.rst
+++ b/README.rst
@@ -49,7 +49,7 @@ available for Windows, OS X, and Linux.
 
 For other platforms, or for users wishing to install a development version of
 Cantera, `compilation instructions
-<http://cantera.github.io/docs/sphinx/html/compiling.html>`_ are also available.
+<http://cantera.github.io/docs/sphinx/html/compiling/index.html>`_ are also available.
 
 Documentation
 =============

--- a/README.rst
+++ b/README.rst
@@ -105,6 +105,24 @@ Users' Group
 The `Cantera Users' Group <http://groups.google.com/group/cantera-users>`_ is a
 message board / mailing list for discussions amongst Cantera users.
 
+Cantera Gitter Chat
+============
+
+.. image:: https://badges.gitter.im/org.png
+   :target: https://gitter.im/Cantera/Lobby
+
+
+The `Cantera Gitter Chat <https://gitter.im/Cantera/Lobby>`_ is a public chat client that is linked to users' Github account. The developers do not closely monitor the discussion, so *any* discussion at all of Cantera functionality such as how to use certain function calls, syntax problems, input files, etc. should be directed the User's Group. All conversations in the Gitter room will be covered under the Cantera Code of Conduct, so please be nice.
+
+The chat room is a place to strengthen and develop the Cantera community, discuss tangentially-related topics such as how to model the underlying physics of a problem , share cool applications you’ve developed, etc. 
+
+Summary:
+
+“How do I perform this Cantera function call?” --> User's Group
+
+"What do I do with the variables that a Cantera function call returns?” --> Chat
+
+
 Continuous Integration Status
 =============================
 


### PR DESCRIPTION
Fixes #505 
Changes proposed in this pull request:
- A link was broken in the README.rst file. Fixed it and tested the link in my forked version to verify that it works now.
