### PR TITLE
Unity lewis number

### DIFF
--- a/include/cantera/transport/UnityLewisNumberTransport.h
+++ b/include/cantera/transport/UnityLewisNumberTransport.h
@@ -1,7 +1,9 @@
 /**
- *  @file MixTransport.h
- *    Headers for the MixTransport object, which models transport properties
- *    in ideal gas solutions using a mixture averaged approximation
+ *  @file UnityLewisTransport.h
+ *    Headers for the UnityLewisTransport object, which extends the MixTransport
+ *    object, which models transport properties in ideal gas solutions using a 
+ *    mixture averaged approximation. This object assumes Lewis numbers to be 
+ *    unity for all species.
  *    (see \ref tranprops and \link Cantera::MixTransport MixTransport \endlink) .
  */
 
@@ -12,178 +14,35 @@
 #define CT_UNITYLEWISTRAN_H
 
 #include "GasTransport.h"
+#include "MixTransport.h"
 #include "cantera/numerics/DenseMatrix.h"
 
 namespace Cantera
 {
 //! Class UnityLewisTransport implements mixture-averaged transport properties for
 //! ideal gas mixtures.
-/*!
- * The model is based on that described in: R. J. Kee, M. J. Coltrin, and P.
- * Glarborg, "Chemically Reacting Flow: Theory & Practice", John Wiley & Sons,
- * 2003.
- *
- * The viscosity is computed using the Wilke mixture rule (kg /m /s)
- *
- * \f[
- *     \mu = \sum_k \frac{\mu_k X_k}{\sum_j \Phi_{k,j} X_j}.
- * \f]
- *
- * Here \f$ \mu_k \f$ is the viscosity of pure species \e k, and
- *
- * \f[
- *     \Phi_{k,j} = \frac{\left[1
- *                  + \sqrt{\left(\frac{\mu_k}{\mu_j}\sqrt{\frac{M_j}{M_k}}\right)}\right]^2}
- *                  {\sqrt{8}\sqrt{1 + M_k/M_j}}
- * \f]
- *
- * The thermal conductivity is computed from the following mixture rule:
- * \f[
- *     \lambda = 0.5 \left( \sum_k X_k \lambda_k  + \frac{1}{\sum_k X_k/\lambda_k} \right)
- * \f]
- *
- * It's used to compute the flux of energy due to a thermal gradient
- *
- * \f[
- *     j_T =  - \lambda  \nabla T
- * \f]
- *
- * The flux of energy has units of energy (kg m2 /s2) per second per area.
- *
- * The units of lambda are W / m K which is equivalent to kg m / s^3 K.
- * @ingroup tranprops
- */
 class UnityLewisTransport : public MixTransport
 {
 public:
     //! Default constructor.
     UnityLewisTransport();
 
+    virtual void init(thermo_t* thermo, int mode=0, int log_level=0);
+
     virtual std::string transportType() const {
         return "UnityLewisNumber";
     }
 
-    //! Return the thermal diffusion coefficients
-    /*!
-     * For this approximation, these are all zero.
-     *
-     * @param dt  Vector of thermal diffusion coefficients. Units = kg/m/s
-     */
-    virtual void getThermalDiffCoeffs(double* const dt);
+    virtual void getMixDiffCoeffs(doublereal* const d);
 
-    //! Returns the mixture thermal conductivity (W/m /K)
-    /*!
-     * The thermal conductivity is computed from the following mixture rule:
-     * \f[
-     *     \lambda = 0.5 \left( \sum_k X_k \lambda_k  + \frac{1}{\sum_k X_k/\lambda_k} \right)
-     * \f]
-     *
-     * It's used to compute the flux of energy due to a thermal gradient
-     *
-     * \f[
-     *     j_T =  - \lambda  \nabla T
-     * \f]
-     *
-     * The flux of energy has units of energy (kg m2 /s2) per second per area.
-     *
-     * The units of lambda are W / m K which is equivalent to kg m / s^3 K.
-     *
-     * @returns the mixture thermal conductivity, with units of W/m/K
-     */
-    virtual double thermalConductivity();
+    virtual void getMixDiffCoeffsMole(doublereal* const d);
 
-    //! Get the Electrical mobilities (m^2/V/s).
-    /*!
-     * This function returns the mobilities. In some formulations this is equal
-     * to the normal mobility multiplied by Faraday's constant.
-     *
-     * Here, the mobility is calculated from the diffusion coefficient using the
-     * Einstein relation
-     *
-     * \f[
-     *     \mu^e_k = \frac{F D_k}{R T}
-     * \f]
-     *
-     * @param mobil  Returns the mobilities of the species in array \c mobil.
-     *               The array must be dimensioned at least as large as the
-     *               number of species.
-     */
-    virtual void getMobilities(double* const mobil);
+    virtual void getMixDiffCoeffsMass(doublereal* const d);
 
-    //! Update the internal parameters whenever the temperature has changed
-    /*!
-     * This is called whenever a transport property is requested if the
-     * temperature has changed since the last call to update_T().
-     */
-    virtual void update_T();
-
-    //! Update the internal parameters whenever the concentrations have changed
-    /*!
-     * This is called whenever a transport property is requested if the
-     * concentrations have changed since the last call to update_C().
-     */
-    virtual void update_C();
-
-    //! Get the species diffusive mass fluxes wrt to the mass averaged velocity,
-    //! given the gradients in mole fraction and temperature
-    /*!
-     * Units for the returned fluxes are kg m-2 s-1.
-     *
-     * The diffusive mass flux of species \e k is computed from
-     * \f[
-     *     \vec{j}_k = -n M_k D_k \nabla X_k.
-     * \f]
-     *
-     * @param ndim      Number of dimensions in the flux expressions
-     * @param grad_T    Gradient of the temperature (length = ndim)
-     * @param ldx       Leading dimension of the grad_X array
-     *                  (usually equal to m_nsp but not always)
-     * @param grad_X    Gradients of the mole fraction. Flat vector with the
-     *                  m_nsp in the inner loop. length = ldx * ndim
-     * @param ldf       Leading dimension of the fluxes array
-     *                  (usually equal to m_nsp but not always)
-     * @param fluxes    Output of the diffusive mass fluxes. Flat vector with
-     *                  the m_nsp in the inner loop. length = ldx * ndim
-     */
-    virtual void getSpeciesFluxes(size_t ndim, const double* const grad_T,
-                                  size_t ldx, const double* const grad_X,
-                                  size_t ldf, double* const fluxes);
-
-    virtual void init(thermo_t* thermo, int mode=0, int log_level=0);
 
 private:
-    //! Calculate the pressure from the ideal gas law
-    double pressure_ig() const {
-        return (m_thermo->molarDensity() * GasConstant *
-                m_thermo->temperature());
-    }
 
-    //! Update the temperature dependent parts of the species thermal
-    //! conductivities
-    /*!
-     * These are evaluated from the polynomial fits of the temperature and are
-     * assumed to be independent of pressure
-     */
-    void updateCond_T();
-
-    //! vector of species thermal conductivities (W/m /K)
-    /*!
-     * These are used in wilke's rule to calculate the viscosity of the
-     * solution. units = W /m /K = kg m /s^3 /K. length = m_kk.
-     */
-    vector_fp m_cond;
-
-    //! Internal storage for the calculated mixture thermal conductivity
-    /*!
-     *  Units = W /m /K
-     */
-    double m_lambda;
-
-    //! Update boolean for the species thermal conductivities
-    bool m_spcond_ok;
-
-    //! Update boolean for the mixture rule for the mixture thermal conductivity
-    bool m_condmix_ok;
 };
+
 }
 #endif

--- a/include/cantera/transport/UnityLewisNumberTransport.h
+++ b/include/cantera/transport/UnityLewisNumberTransport.h
@@ -1,0 +1,189 @@
+/**
+ *  @file MixTransport.h
+ *    Headers for the MixTransport object, which models transport properties
+ *    in ideal gas solutions using a mixture averaged approximation
+ *    (see \ref tranprops and \link Cantera::MixTransport MixTransport \endlink) .
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_UNITYLEWISTRAN_H
+#define CT_UNITYLEWISTRAN_H
+
+#include "GasTransport.h"
+#include "cantera/numerics/DenseMatrix.h"
+
+namespace Cantera
+{
+//! Class UnityLewisTransport implements mixture-averaged transport properties for
+//! ideal gas mixtures.
+/*!
+ * The model is based on that described in: R. J. Kee, M. J. Coltrin, and P.
+ * Glarborg, "Chemically Reacting Flow: Theory & Practice", John Wiley & Sons,
+ * 2003.
+ *
+ * The viscosity is computed using the Wilke mixture rule (kg /m /s)
+ *
+ * \f[
+ *     \mu = \sum_k \frac{\mu_k X_k}{\sum_j \Phi_{k,j} X_j}.
+ * \f]
+ *
+ * Here \f$ \mu_k \f$ is the viscosity of pure species \e k, and
+ *
+ * \f[
+ *     \Phi_{k,j} = \frac{\left[1
+ *                  + \sqrt{\left(\frac{\mu_k}{\mu_j}\sqrt{\frac{M_j}{M_k}}\right)}\right]^2}
+ *                  {\sqrt{8}\sqrt{1 + M_k/M_j}}
+ * \f]
+ *
+ * The thermal conductivity is computed from the following mixture rule:
+ * \f[
+ *     \lambda = 0.5 \left( \sum_k X_k \lambda_k  + \frac{1}{\sum_k X_k/\lambda_k} \right)
+ * \f]
+ *
+ * It's used to compute the flux of energy due to a thermal gradient
+ *
+ * \f[
+ *     j_T =  - \lambda  \nabla T
+ * \f]
+ *
+ * The flux of energy has units of energy (kg m2 /s2) per second per area.
+ *
+ * The units of lambda are W / m K which is equivalent to kg m / s^3 K.
+ * @ingroup tranprops
+ */
+class UnityLewisTransport : public MixTransport
+{
+public:
+    //! Default constructor.
+    UnityLewisTransport();
+
+    virtual std::string transportType() const {
+        return "UnityLewisNumber";
+    }
+
+    //! Return the thermal diffusion coefficients
+    /*!
+     * For this approximation, these are all zero.
+     *
+     * @param dt  Vector of thermal diffusion coefficients. Units = kg/m/s
+     */
+    virtual void getThermalDiffCoeffs(double* const dt);
+
+    //! Returns the mixture thermal conductivity (W/m /K)
+    /*!
+     * The thermal conductivity is computed from the following mixture rule:
+     * \f[
+     *     \lambda = 0.5 \left( \sum_k X_k \lambda_k  + \frac{1}{\sum_k X_k/\lambda_k} \right)
+     * \f]
+     *
+     * It's used to compute the flux of energy due to a thermal gradient
+     *
+     * \f[
+     *     j_T =  - \lambda  \nabla T
+     * \f]
+     *
+     * The flux of energy has units of energy (kg m2 /s2) per second per area.
+     *
+     * The units of lambda are W / m K which is equivalent to kg m / s^3 K.
+     *
+     * @returns the mixture thermal conductivity, with units of W/m/K
+     */
+    virtual double thermalConductivity();
+
+    //! Get the Electrical mobilities (m^2/V/s).
+    /*!
+     * This function returns the mobilities. In some formulations this is equal
+     * to the normal mobility multiplied by Faraday's constant.
+     *
+     * Here, the mobility is calculated from the diffusion coefficient using the
+     * Einstein relation
+     *
+     * \f[
+     *     \mu^e_k = \frac{F D_k}{R T}
+     * \f]
+     *
+     * @param mobil  Returns the mobilities of the species in array \c mobil.
+     *               The array must be dimensioned at least as large as the
+     *               number of species.
+     */
+    virtual void getMobilities(double* const mobil);
+
+    //! Update the internal parameters whenever the temperature has changed
+    /*!
+     * This is called whenever a transport property is requested if the
+     * temperature has changed since the last call to update_T().
+     */
+    virtual void update_T();
+
+    //! Update the internal parameters whenever the concentrations have changed
+    /*!
+     * This is called whenever a transport property is requested if the
+     * concentrations have changed since the last call to update_C().
+     */
+    virtual void update_C();
+
+    //! Get the species diffusive mass fluxes wrt to the mass averaged velocity,
+    //! given the gradients in mole fraction and temperature
+    /*!
+     * Units for the returned fluxes are kg m-2 s-1.
+     *
+     * The diffusive mass flux of species \e k is computed from
+     * \f[
+     *     \vec{j}_k = -n M_k D_k \nabla X_k.
+     * \f]
+     *
+     * @param ndim      Number of dimensions in the flux expressions
+     * @param grad_T    Gradient of the temperature (length = ndim)
+     * @param ldx       Leading dimension of the grad_X array
+     *                  (usually equal to m_nsp but not always)
+     * @param grad_X    Gradients of the mole fraction. Flat vector with the
+     *                  m_nsp in the inner loop. length = ldx * ndim
+     * @param ldf       Leading dimension of the fluxes array
+     *                  (usually equal to m_nsp but not always)
+     * @param fluxes    Output of the diffusive mass fluxes. Flat vector with
+     *                  the m_nsp in the inner loop. length = ldx * ndim
+     */
+    virtual void getSpeciesFluxes(size_t ndim, const double* const grad_T,
+                                  size_t ldx, const double* const grad_X,
+                                  size_t ldf, double* const fluxes);
+
+    virtual void init(thermo_t* thermo, int mode=0, int log_level=0);
+
+private:
+    //! Calculate the pressure from the ideal gas law
+    double pressure_ig() const {
+        return (m_thermo->molarDensity() * GasConstant *
+                m_thermo->temperature());
+    }
+
+    //! Update the temperature dependent parts of the species thermal
+    //! conductivities
+    /*!
+     * These are evaluated from the polynomial fits of the temperature and are
+     * assumed to be independent of pressure
+     */
+    void updateCond_T();
+
+    //! vector of species thermal conductivities (W/m /K)
+    /*!
+     * These are used in wilke's rule to calculate the viscosity of the
+     * solution. units = W /m /K = kg m /s^3 /K. length = m_kk.
+     */
+    vector_fp m_cond;
+
+    //! Internal storage for the calculated mixture thermal conductivity
+    /*!
+     *  Units = W /m /K
+     */
+    double m_lambda;
+
+    //! Update boolean for the species thermal conductivities
+    bool m_spcond_ok;
+
+    //! Update boolean for the mixture rule for the mixture thermal conductivity
+    bool m_condmix_ok;
+};
+}
+#endif

--- a/src/transport/UnityLewisNumberTransport.cpp
+++ b/src/transport/UnityLewisNumberTransport.cpp
@@ -1,0 +1,138 @@
+/**
+ *  @file UnityLewisNumberTransport.cpp
+ *  Mixture-averaged transport properties for ideal gas mixtures with
+ *  diffusion coefficients set based on the assumption that Lewis #  = 1.
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
+#include "cantera/transport/UnityLewisNumberTransport.h"
+#include "cantera/base/stringUtils.h"
+
+using namespace std;
+
+namespace Cantera
+{
+UnityLewisTransport::UnityLewisTransport() :
+    m_lambda(0.0),
+    m_spcond_ok(false),
+    m_condmix_ok(false)
+{
+}
+
+void UnityLewisTransport::init(ThermoPhase* thermo, int mode, int log_level)
+{
+    GasTransport::init(thermo, mode, log_level);
+    m_cond.resize(m_nsp);
+
+    // set flags all false
+    m_spcond_ok = false;
+    m_condmix_ok = false;
+}
+
+
+void UnityLewisTransport::getMixDiffCoeffs(doublereal* const d)
+{
+    update_T();
+    update_C();
+
+    // update the binary diffusion coefficients if necessary
+    if (!m_bindiff_ok) {
+        updateDiff_T();
+    }
+
+    doublereal mmw = m_thermo->meanMolecularWeight();
+    doublereal p = m_thermo->pressure();
+    if (m_nsp == 1) {
+        d[0] = m_bdiff(0,0) / p;
+    } else {
+        for (size_t k = 0; k < m_nsp; k++) {
+            double sum2 = 0.0;
+            for (size_t j = 0; j < m_nsp; j++) {
+                if (j != k) {
+                    sum2 += m_molefracs[j] / m_bdiff(j,k);
+                }
+            }
+            if (sum2 <= 0.0) {
+                d[k] = m_bdiff(k,k) / p;
+            } else {
+                d[k] = (mmw - m_molefracs[k] * m_mw[k])/(p * mmw * sum2);
+            }
+        }
+    }
+}
+
+
+void MixTransport::getSpeciesFluxes(size_t ndim, const doublereal* const grad_T,
+                                    size_t ldx, const doublereal* const grad_X,
+                                    size_t ldf, doublereal* const fluxes)
+{
+    update_T();
+    update_C();
+    getMixDiffCoeffs(m_spwork.data());
+    const vector_fp& mw = m_thermo->molecularWeights();
+    const doublereal* y = m_thermo->massFractions();
+    doublereal rhon = m_thermo->molarDensity();
+    vector_fp sum(ndim,0.0);
+    for (size_t n = 0; n < ndim; n++) {
+        for (size_t k = 0; k < m_nsp; k++) {
+            fluxes[n*ldf + k] = -rhon * mw[k] * m_spwork[k] * grad_X[n*ldx + k];
+            sum[n] += fluxes[n*ldf + k];
+        }
+    }
+    // add correction flux to enforce sum to zero
+    for (size_t n = 0; n < ndim; n++) {
+        for (size_t k = 0; k < m_nsp; k++) {
+            fluxes[n*ldf + k] -= y[k]*sum[n];
+        }
+    }
+}
+
+void MixTransport::update_T()
+{
+    doublereal t = m_thermo->temperature();
+    if (t == m_temp && m_nsp == m_thermo->nSpecies()) {
+        return;
+    }
+    if (t < 0.0) {
+        throw CanteraError("MixTransport::update_T",
+                           "negative temperature {}", t);
+    }
+    GasTransport::update_T();
+    // temperature has changed, so polynomial fits will need to be redone.
+    m_spcond_ok = false;
+    m_bindiff_ok = false;
+    m_condmix_ok = false;
+}
+
+void MixTransport::update_C()
+{
+    // signal that concentration-dependent quantities will need to be recomputed
+    // before use, and update the local mole fractions.
+    m_visc_ok = false;
+    m_condmix_ok = false;
+    m_thermo->getMoleFractions(m_molefracs.data());
+
+    // add an offset to avoid a pure species condition
+    for (size_t k = 0; k < m_nsp; k++) {
+        m_molefracs[k] = std::max(Tiny, m_molefracs[k]);
+    }
+}
+
+void MixTransport::updateCond_T()
+{
+    if (m_mode == CK_Mode) {
+        for (size_t k = 0; k < m_nsp; k++) {
+            m_cond[k] = exp(dot4(m_polytempvec, m_condcoeffs[k]));
+        }
+    } else {
+        for (size_t k = 0; k < m_nsp; k++) {
+            m_cond[k] = m_sqrt_t * dot5(m_polytempvec, m_condcoeffs[k]);
+        }
+    }
+    m_spcond_ok = true;
+    m_condmix_ok = false;
+}
+
+}


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #507 

Changes proposed in this pull request:
- Add derived class of MixTransport called UnityLewisTransport
- Override the getMixDiffCoeff methods to return thermal diffusivity  Le_k = alpha / Dm_k
-
