### PR TITLE
[Transport] Add unity Lewis number transport model

### DIFF
--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -42,6 +42,13 @@ public:
      *     D^\prime_{km} = \frac{\lambda}{\rho c_p}
      * \f]
      *
+     * In order to obtain the expected behavior from a unity Lewis number model,
+     * this formulation requires that the correction velocity be computed as
+     *
+     * \f[
+     *     V_c = \sum \frac{W_k}{\overline{W}} D^\prime_{km} \nabla X_k
+     * \f]
+     *
      * @param[out] d  Vector of diffusion coefficients for each species (m^2/s).
      * length m_nsp.
      */

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -1,0 +1,66 @@
+/**
+ *  @file UnityLewisTransport.h
+ *    Headers for the UnityLewisTransport object, which models transport
+ *    properties in ideal gas solutions using the unity Lewis number
+ *    approximation
+ *    (see \ref tranprops and \link Cantera::UnityLewisTransport UnityLewisTransport \endlink) .
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at http://www.cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_UNITYLEWISTRAN_H
+#define CT_UNITYLEWISTRAN_H
+
+#include "MixTransport.h"
+
+namespace Cantera
+{
+//! Class UnityLewisTransport implements the unity Lewis number approximation
+//! for the mixture-averaged species diffusion coefficients. Mixture-averaged
+//! transport properties for viscosity and thermal conductivity are inherited
+//! from the MixTransport class.
+//! @ingroup tranprops
+class UnityLewisTransport : public MixTransport
+{
+public:
+//    UnityLewisTransport() {}
+
+    virtual std::string transportType() const {
+        return "UnityLewis";
+    }
+
+    //! Returns the unity Lewis number approximation based diffusion
+    //! coefficients [m^2/s].
+    /*!
+     * Returns the unity Lewis number approximation based diffusion coefficients
+     * for a gas, appropriate for calculating the mass averaged diffusive flux
+     * with respect to the mass averaged velocity using gradients of the mole
+     * fraction.
+     *
+     * \f[
+     *     D^\prime_{km} = \frac{\lambda}{\rho c_p}
+     * \f]
+     *
+     * @param[out] d  Vector of diffusion coefficients for each species (m^2/s).
+     * length m_nsp.
+     */
+    virtual void getMixDiffCoeffs(double* const d) {
+        double Dm = thermalConductivity() / (m_thermo->density() * m_thermo->cp_mass());
+        for (size_t k = 0; k < m_nsp; k++) {
+            d[k] = Dm;
+        }
+    }
+
+    //! Not implemented for unity Lewis number approximation
+    virtual void getMixDiffCoeffsMole(double* const d){
+        throw NotImplementedError("UnityLewisTransport::getMixDiffCoeffsMole");
+    }
+
+    //! Not implemented for unity Lewis number approximation
+    virtual void getMixDiffCoeffsMass(double* const d){
+        throw NotImplementedError("UnityLewisTransport::getMixDiffCoeffsMass");
+    }
+};
+}
+#endif

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -64,9 +64,24 @@ public:
         throw NotImplementedError("UnityLewisTransport::getMixDiffCoeffsMole");
     }
 
-    //! Not implemented for unity Lewis number approximation
+    //! Returns the unity Lewis number approximation based diffusion
+    //! coefficients [m^2/s].
+    /*!
+     * These are the coefficients for calculating the diffusive mass fluxes
+     * from the species mass fraction gradients, computed as
+     *
+     * \f[
+     *     D_{km} = \frac{\lambda}{\rho c_p}
+     * \f]
+     *
+     * @param[out] d  Vector of diffusion coefficients for each species (m^2/s).
+     * length m_nsp.
+     */
     virtual void getMixDiffCoeffsMass(double* const d){
-        throw NotImplementedError("UnityLewisTransport::getMixDiffCoeffsMass");
+        double Dm = thermalConductivity() / (m_thermo->density() * m_thermo->cp_mass());
+        for (size_t k = 0; k < m_nsp; k++) {
+            d[k] = Dm;
+        }
     }
 };
 }

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -292,6 +292,21 @@ class TestFreeFlame(utilities.CanteraTest):
         self.assertNear(Su_multi, Su_soret, 2e-1)
         self.assertNotEqual(Su_multi, Su_soret)
 
+    def test_unity_lewis(self):
+        self.create_sim(ct.one_atm, 300, 'H2:1.1, O2:1, AR:5.3')
+        self.sim.transport_model = 'UnityLewis'
+        self.sim.set_refine_criteria(ratio=3.0, slope=0.08, curve=0.12)
+        self.sim.solve(loglevel=0, auto=True)
+        dh_unity_lewis = self.sim.enthalpy_mass.ptp()
+
+        self.sim.transport_model = 'Mix'
+        self.sim.solve(loglevel=0)
+        dh_mix = self.sim.enthalpy_mass.ptp()
+
+        # deviation of enthalpy should be much lower for unity Le model (tends
+        # towards zero as grid is refined)
+        self.assertLess(dh_unity_lewis, 0.1 * dh_mix)
+
     def test_soret_with_mix(self):
         # Test that enabling Soret diffusion without
         # multicomponent transport results in an error

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -18,11 +18,16 @@ class TestTransport(utilities.CanteraTest):
     def test_unityLewis(self):
         self.phase.transport_model = 'UnityLewis'
         alpha = self.phase.thermal_conductivity/(self.phase.density*self.phase.cp)
-        Dkm = self.phase.mix_diff_coeffs
+        Dkm_prime = self.phase.mix_diff_coeffs
+
+        Dkm = self.phase.mix_diff_coeffs_mass
 
         eps = np.spacing(1) # Machine precision
         self.assertTrue(all(np.diff(Dkm) < 2*eps))
         self.assertNear(Dkm[0], alpha)
+        self.assertTrue(all(np.diff(Dkm_prime) < 2*eps))
+        self.assertNear(Dkm_prime[0], alpha)
+
 
     def test_mixtureAveraged(self):
         self.assertEqual(self.phase.transport_model, 'Mix')

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -15,6 +15,15 @@ class TestTransport(utilities.CanteraTest):
         self.assertTrue(self.phase.viscosity > 0.0)
         self.assertTrue(self.phase.thermal_conductivity > 0.0)
 
+    def test_unityLewis(self):
+        self.phase.transport_model = 'UnityLewis'
+        alpha = self.phase.thermal_conductivity/(self.phase.density*self.phase.cp)
+        Dkm = self.phase.mix_diff_coeffs
+
+        eps = np.spacing(1) # Machine precision
+        self.assertTrue(all(np.diff(Dkm) < 2*eps))
+        self.assertNear(Dkm[0], alpha)
+
     def test_mixtureAveraged(self):
         self.assertEqual(self.phase.transport_model, 'Mix')
         Dkm1 = self.phase.mix_diff_coeffs

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -6,6 +6,7 @@
 // known transport models
 #include "cantera/transport/MultiTransport.h"
 #include "cantera/transport/MixTransport.h"
+#include "cantera/transport/UnityLewisTransport.h"
 #include "cantera/transport/SolidTransport.h"
 #include "cantera/transport/DustyGasTransport.h"
 #include "cantera/transport/SimpleTransport.h"
@@ -46,6 +47,7 @@ TransportFactory::TransportFactory()
 {
     reg("", []() { return new Transport(); });
     m_synonyms["None"] = "";
+    reg("UnityLewis", []() { return new UnityLewisTransport(); });
     reg("Mix", []() { return new MixTransport(); });
     reg("Multi", []() { return new MultiTransport(); });
     m_synonyms["CK_Mix"] = "Mix";


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #507 

Changes proposed in this pull request:
- Add unity Lewis number transport model

Supersedes pull requests #427 and #508 . The current implementation requires only minimal code changes and has been tested. The extension of the unity Lewis number transport model to a per-species Lewis number transport model is rather straight forward, but should be done in an own class.