### PR TITLE
Fix automatic flame solving when Soret diffusion is enabled

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -20,23 +20,27 @@ addons:
       - libboost-dev
 before_script: |
   echo TRAVIS_OS_NAME: $TRAVIS_OS_NAME
-  pip2 install --user --install-option="--no-cython-compile" cython
-  pip2 install --user 3to2
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
-      brew update
-      brew install scons
+      brew update > /dev/null
+      brew upgrade python  # Installs Python 3
+      brew install python@2  # Installs Python 2
+      brew install scons  # Install SCons which *should* use Python 3
+      pip3 install numpy cython  # Install numpy and Cython for Python 3
+      pip2 install numpy 3to2  # Install numpy and 3to2 for Python 2
       brew install boost
-      brew install python3
-      pip3 install numpy
+  else
+      pip2 install --user --install-option="--no-cython-compile" cython
+      pip2 install --user 3to2
   fi
   rm -f cantera.conf
 script: |
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then
       scons build -j2 VERBOSE=y python2_package=full python3_package=full python3_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas optimize=n coverage=y
+      scons test
   else
-      scons build -j2 VERBOSE=y python2_package=full python3_package=full blas_lapack_libs=lapack,blas optimize=n coverage=y
+      python3 `which scons` build -j2 VERBOSE=y python2_package=full python3_package=full python2_cmd=/usr/local/opt/python@2/bin/python2 blas_lapack_libs=lapack,blas optimize=n coverage=y
+      python3 `which scons` test
   fi
-  scons test
 after_success: |
   if [[ "$TRAVIS_OS_NAME" == "osx" ]]; then
       bash <(curl -s https://codecov.io/bash)

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -78,7 +78,12 @@ public:
     //! set the transport manager
     void setTransport(Transport& trans);
 
-    void enableSoret(bool withSoret);
+    //! Enable thermal diffusion, also known as Soret diffusion.
+    //! Requires that multicomponent transport properties be
+    //! enabled to carry out calculations.
+    void enableSoret(bool withSoret) {
+        m_do_soret = withSoret;
+    }
     bool withSoret() const {
         return m_do_soret;
     }

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -748,7 +748,7 @@ cdef extern from "cantera/oneD/Sim1D.h":
         void setMaxGridPoints(int, size_t) except +translate_exception
         size_t maxGridPoints(size_t) except +translate_exception
         void setGridMin(int, double) except +translate_exception
-        void setFixedTemperature(double)
+        void setFixedTemperature(double) except +translate_exception
         void setInterrupt(CxxFunc1*) except +translate_exception
         void setTimeStepCallback(CxxFunc1*)
         void setSteadyCallback(CxxFunc1*)

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -292,13 +292,38 @@ class TestFreeFlame(utilities.CanteraTest):
         self.assertNear(Su_multi, Su_soret, 2e-1)
         self.assertNotEqual(Su_multi, Su_soret)
 
-    def test_soret_flag(self):
+    def test_soret_with_mix(self):
+        # Test that enabling Soret diffusion without
+        # multicomponent transport results in an error
+
         self.create_sim(101325, 300, 'H2:1.0, O2:1.0')
         self.assertFalse(self.sim.soret_enabled)
+        self.assertFalse(self.sim.transport_model == 'Multi')
+
         with self.assertRaises(ct.CanteraError):
             self.sim.soret_enabled = True
+            self.sim.solve(loglevel=0, auto=False)
+
+    def test_soret_with_auto(self):
+        # Test that auto solving with Soret enabled works
+        self.create_sim(101325, 300, 'H2:2.0, O2:1.0')
+        self.sim.soret_enabled = True
+        self.sim.transport_model = 'Multi'
+        self.sim.solve(loglevel=0, auto=True)
+
+    def test_set_soret_multi_mix(self):
+        # Test that the transport model and Soret diffusion
+        # can be set in any order without raising errors
+
+        self.create_sim(101325, 300, 'H2:1.0, O2:1.0')
         self.sim.transport_model = 'Multi'
         self.sim.soret_enabled = True
+
+        self.sim.transport_model = 'Mix'
+        self.sim.soret_enabled = False
+
+        self.sim.soret_enabled = True
+        self.sim.transport_model = 'Multi'
 
     def test_prune(self):
         reactants = 'H2:1.1, O2:1, AR:5'

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -132,7 +132,7 @@ void StFlow::setupGrid(size_t n, const doublereal* z)
     }
 }
 
-void StFlow::resetBadValues(double* xg) 
+void StFlow::resetBadValues(double* xg)
 {
     double* x = xg + loc();
     for (size_t j = 0; j < m_points; j++) {
@@ -151,17 +151,6 @@ void StFlow::setTransport(Transport& trans)
     if (m_do_multicomponent) {
         m_multidiff.resize(m_nsp*m_nsp*m_points);
         m_dthermal.resize(m_nsp, m_points, 0.0);
-    }
-}
-
-void StFlow::enableSoret(bool withSoret)
-{
-    if (m_do_multicomponent) {
-        m_do_soret = withSoret;
-    } else {
-        throw CanteraError("setTransport",
-                           "Thermal diffusion (the Soret effect) "
-                           "requires using a multicomponent transport model.");
     }
 }
 
@@ -195,6 +184,12 @@ void StFlow::setGasAtMidpoint(const doublereal* x, size_t j)
 
 void StFlow::_finalize(const doublereal* x)
 {
+    if (!m_do_multicomponent && m_do_soret) {
+        throw CanteraError("_finalize",
+            "Thermal diffusion (the Soret effect) is enabled, and requires "
+            "using a multicomponent transport model.");
+    }
+
     size_t nz = m_zfix.size();
     bool e = m_do_energy[0];
     for (size_t j = 0; j < m_points; j++) {


### PR DESCRIPTION
Changes proposed in this pull request:
- Throw an exception if mixture-averaged transport is specified but Soret diffusion is enabled
- Turn off Soret diffusion (if enabled) in the first solving stages of the automatic flame solver

I wasn't sure if there should be an exception thrown or if we should (silently?) force Soret to be false when mixture-averaged transport is used. Also, although the test is for a FreeFlame, this should apply to all the flames equally.
