### PR TITLE
Cantera flamelet and tabulation capabilities added

### DIFF
--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -45,8 +45,6 @@ public:
     Domain1D(size_t nv=1, size_t points=1, double time=0.0);
 
     virtual ~Domain1D() {}
-    Domain1D(const Domain1D&) = delete;
-    Domain1D& operator=(const Domain1D&) = delete;
 
     //! Domain type flag.
     int domainType() {
@@ -179,6 +177,15 @@ public:
         m_name[n] = name;
     }
 
+    //! @deprecated To be removed after Cantera 2.3
+    void setComponentType(size_t n, int ctype) {
+        warn_deprecated("Domain1D::setComponentType",
+                        "To be removed after Cantera 2.3.");
+        if (ctype == 0) {
+            setAlgebraic(n);
+        }
+    }
+
     //! index of component with name \a name.
     size_t componentIndex(const std::string& name) const;
 
@@ -281,6 +288,16 @@ public:
      */
     void needJacUpdate();
 
+    /*!
+     * Evaluate the steady-state residual at all points, even if in
+     * transient mode. Used only to print diagnostic output.
+     * @deprecated To be removed after Cantera 2.3
+     */
+    void evalss(doublereal* x, doublereal* r, integer* mask) {
+        warn_deprecated("Domain1D::evalss", "To be removed after Cantera 2.3");
+        eval(npos,x,r,mask,0.0);
+    }
+
     //! Evaluate the residual function at point j. If j == npos,
     //! evaluate the residual function at all points.
     /*!
@@ -295,10 +312,45 @@ public:
      *  state.)
      */
     virtual void eval(size_t j, doublereal* x, doublereal* r,
-                      integer* mask, doublereal rdt=0.0) {
-        throw NotImplementedError("Domain1D::eval");
+                      integer* mask, doublereal rdt=0.0);
+
+    //! @deprecated To be removed after Cantera 2.3. Derived classes should
+    //!     implement eval() instead.
+    virtual doublereal residual(doublereal* x, size_t n, size_t j) {
+        warn_deprecated("Domain1D::residual", "To be removed after Cantera 2.3.");
+        throw CanteraError("Domain1D::residual","residual function must be overloaded in derived class "+id());
     }
 
+    //! @deprecated To be removed after Cantera 2.3
+    int timeDerivativeFlag(size_t n) {
+        warn_deprecated("Domain1D::timeDerivativeFlag",
+                        "To be removed after Cantera 2.3.");
+        return m_td[n];
+    }
+
+    //! @deprecated To be removed after Cantera 2.3
+    void setAlgebraic(size_t n) {
+        warn_deprecated("Domain1D::setAlgebraic",
+                        "To be removed after Cantera 2.3.");
+        m_td[n] = 0;
+    }
+
+    //! @deprecated To be removed after Cantera 2.3
+    virtual void update(doublereal* x) {
+        warn_deprecated("Domain1D::update", "To be removed after Cantera 2.3.");
+    }
+
+    //! @deprecated To be removed after Cantera 2.3
+    doublereal time() const {
+        warn_deprecated("Domain1D::time", "To be removed after Cantera 2.3.");
+        return m_time;
+    }
+    //! @deprecated To be removed after Cantera 2.3
+    void incrementTime(doublereal dt) {
+        warn_deprecated("Domain1D::incrementTime",
+                        "To be removed after Cantera 2.3.");
+        m_time += dt;
+    }
     size_t index(size_t n, size_t j) const {
         return m_nv*j + n;
     }
@@ -416,6 +468,25 @@ public:
         }
     }
 
+    //! Specify descriptive text for this domain.
+    //!     @deprecated To be removed after Cantera 2.3.
+    void setDesc(const std::string& s) {
+        warn_deprecated("Domain1D::setDesc", "To be removed after Cantera 2.3.");
+        m_desc = s;
+    }
+
+    //! @deprecated To be removed after Cantera 2.3.
+    const std::string& desc() {
+        warn_deprecated("Domain1D::desc", "To be removed after Cantera 2.3.");
+        return m_desc;
+    }
+
+    //! @deprecated To be removed after Cantera 2.3.
+    virtual void getTransientMask(integer* mask) {
+        warn_deprecated("Domain1D::getTransientMask",
+                        "To be removed after Cantera 2.3.");
+    }
+
     virtual void showSolution_s(std::ostream& s, const doublereal* x) {}
 
     //! Print the solution.
@@ -478,11 +549,26 @@ public:
         m_force_full_update = update;
     }
 
+	// added by udri to support plane equation
+
+	virtual void setFlameControl(bool strainRateEqEnabled, 
+								 bool unityLewisNumber,
+								 bool oneLewisEnabled,
+								 bool twoPointEnabled, 
+								 doublereal Tfuel, 
+								 int Tfuel_j, 
+								 doublereal Toxid, 
+								 int Toxid_j,
+								 bool reactionsEnabled){}
+								 
+	void WriteValue(double value);
+
 protected:
     doublereal m_rdt;
     size_t m_nv;
     size_t m_points;
     vector_fp m_slast;
+    doublereal m_time; //!< @deprecated To be removed after Cantera 2.3.
     vector_fp m_max;
     vector_fp m_min;
     vector_fp m_rtol_ss, m_rtol_ts;
@@ -507,6 +593,7 @@ protected:
     std::string m_id;
     std::string m_desc;
     std::unique_ptr<Refiner> m_refiner;
+    vector_int m_td; //!< @deprecated To be removed after Cantera 2.3.
     std::vector<std::string> m_name;
     int m_bw;
     bool m_force_full_update;

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -140,13 +140,6 @@ public:
                            doublereal slope = 0.8, doublereal curve = 0.8, doublereal prune = -0.1);
 
     /**
-     * Get the grid refinement criteria. dom must be greater than
-     * or equal to zero (i.e., the domain must be specified).
-     * @see Refiner::getCriteria
-     */
-    vector_fp getRefineCriteria(int dom);
-
-    /**
      * Set the maximum number of grid points in the domain. If dom >= 0,
      * then the settings apply only to the specified domain. If dom < 0,
      * the settings are applied to each domain.  @see Refiner::setMaxPoints.
@@ -195,6 +188,18 @@ public:
 
     void evalSSJacobian();
 
+	const size_t nRowsJacobian() {
+		return OneDim::jacobian().nRows();
+	}
+
+	const size_t nSubDiagonalsJacobian() {
+		return OneDim::jacobian().nSubDiagonals();
+	}
+
+	const size_t nSuperDiagonalsJacobian() {
+		return OneDim::jacobian().nSuperDiagonals();
+	}
+
     //! Solve the equation \f$ J^T \lambda = b \f$.
     /**
      * Here, \f$ J = \partial f/\partial x \f$ is the Jacobian matrix of the
@@ -218,6 +223,18 @@ public:
     void setSteadyCallback(Func1* callback) {
         m_steady_callback = callback;
     }
+
+	// added by UDRI to define a plane equation used in stflow
+	void setFlameControl(size_t dom,
+						 bool strainRateEqEnabled, 
+						 bool UnityLewisNumber,
+						 bool onePointEnabled,
+						 bool twoPointEnabled, 
+						 doublereal Tfuel, 
+						 int Tfuel_j, 
+						 doublereal Toxid, 
+						 int Toxid_j,
+						 bool reactionsEnabled);
 
 protected:
     //! the solution vector

--- a/interfaces/cython/cantera/examples/onedim/ConvoluteCpp.cpp
+++ b/interfaces/cython/cantera/examples/onedim/ConvoluteCpp.cpp
@@ -1,0 +1,920 @@
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+//
+// File: ConvoluteCpp.cpp
+//
+// Description: This file contains implementation of five classes: FpArray3D, FpArray2D, ConvoluteCpp,
+// CreateOutputFile, and CreateDiffusionFlameletsFile.  All of these classes implement capability originally
+// written in python and converted to C++ for faster execution.  These C++ classes are accessed from
+// python via Cython functions.
+//
+// Creation Date: 23-Feb-2017
+//
+// Revision History:
+// SWCR            Date       Reason
+// ------------------------------------------------------------------------------------------------------------------
+//                                                                                                                   
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+//
+// No part of this program may be photocopied, transferred, or otherwise reproduced in machine or
+// human readable form without the prior written consent of The University Of Dayton.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+// HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#include "ConvoluteCPP.h"
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// class FpArray3D
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// FpArrray3d constructor that initializes member variables that define array dimensions and array memory location.
+/// </summary>
+///
+/// <param name="zlen">length of z dimension (major)</param>
+/// <param name="ylen">length of y dimension</param>
+/// <param name="xlen">length of x dimension (minor)</param>
+/// <param name="data">pointer to contiguous python memory array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+FpArray3D::FpArray3D(int zlen, int ylen, int xlen, double *data):
+    m_Zlen(zlen), m_Ylen(ylen), m_Xlen(xlen), m_data(data) {}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Gets an array data element via 3 dimensional indices (i.e. x,y,z).
+/// </summary>
+///
+/// <param name="z">index of z dimension (major)</param>
+/// <param name="y">index of y dimension</param>
+/// <param name="x">index of x dimension (minor)</param>
+///
+/// <returns>array element</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+double FpArray3D::GetData(int z, int y, int x)
+{
+    return m_data[(z*m_Ylen*m_Xlen)+(y*m_Xlen)+x];
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Sets an array data element via 3 dimensional indices (i.e. x,y,z).
+/// </summary>
+///
+/// <param name="z">index of z dimension (major)</param>
+/// <param name="y">index of y dimension</param>
+/// <param name="x">index of x dimension (minor)</param>
+/// <param name="value">new value of data element</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void FpArray3D::SetData(int z, int y, int x, double value)
+{
+    m_data[(z*m_Ylen*m_Xlen) + (y*m_Xlen) + x] = value;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Returns length of z dimension.
+/// </summary>
+///
+/// <returns>length of z dimension</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+int FpArray3D::GetZlen()
+{
+    return m_Zlen;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Returns length of y dimension.
+/// </summary>
+///
+/// <returns>length of y dimension</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+int FpArray3D::GetYlen()
+{
+    return m_Ylen;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Returns length of x dimension.
+/// </summary>
+///
+/// <returns>length of x dimension</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+int FpArray3D::GetXlen()
+{
+    return m_Xlen;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// class FpArray2D
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// FpArrray2d constructor that initializes member variables that define array dimensions and array memory location.
+/// </summary>
+///
+/// <param name="ylen">length of y dimension</param>
+/// <param name="xlen">length of x dimension (minor)</param>
+/// <param name="data">pointer to contiguous python memory array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+FpArray2D::FpArray2D(int ylen, int xlen, double *data) :
+   m_Ylen(ylen),  m_Xlen(xlen), m_data(data) {}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Gets an array data element via 2 dimensional indices (i.e. x,y).
+/// </summary>
+///
+/// <param name="y">index of y dimension</param>
+/// <param name="x">index of x dimension (minor)</param>
+///
+/// <returns>array element</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+double FpArray2D::GetData(int y, int x)
+{
+    return m_data[(y*m_Xlen) + x];
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Sets an array data element via 2 dimensional indices (i.e. x,y).
+/// </summary>
+///
+/// <param name="y">index of y dimension</param>
+/// <param name="x">index of x dimension (minor)</param>
+/// <param name="value">new value of data element</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void FpArray2D::SetData(int y, int x, double value)
+{
+    m_data[(y*m_Xlen) + x] = value;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Returns length of y dimension.
+/// </summary>
+///
+/// <returns>length of y dimension</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+int FpArray2D::GetYlen()
+{
+    return m_Ylen; 
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Returns length of x dimension.
+/// </summary>
+///
+/// <returns>length of x dimension</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+int FpArray2D::GetXlen()
+{ 
+    return m_Xlen;
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// class ConvoluteCpp
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Default ConvoluteCpp constructor that initializes member variables that define pointers to array locations to 
+/// nullptr.
+/// </summary>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ConvoluteCpp::ConvoluteCpp():
+    m_Betas(nullptr), m_Betas2(nullptr), m_DictEntry(nullptr), m_Zz(nullptr), m_rho(false)
+{
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Alternate ConvoluteCpp constructor that initializes member variables that define pointers to array locations to 
+/// nullptr.  Sets rho flag to true if specified name matches.
+/// </summary>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+ConvoluteCpp::ConvoluteCpp(char *name):
+    m_Betas(nullptr), m_Betas2(nullptr), m_DictEntry(nullptr), m_Zz(nullptr)
+{
+    m_rho = (strcmp(name, "rho") == 0);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Creates a 3 dimensional array mapping to python Betas contiguous memory pointer.
+/// </summary>
+///
+/// <param name="z">length of z dimension (major)</param>
+/// <param name="y">length of y dimension</param>
+/// <param name="x">length of x dimension (minor)</param>
+/// <param name="data">pointer to contiguous python memory array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::SetBetas(int zlen, int ylen, int xlen, double *data)
+{
+    if (m_Betas != nullptr)
+    {
+        delete m_Betas;
+    }
+    m_Betas = new FpArray3D(zlen, ylen, xlen, data);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Creates a 3 dimensional array mapping to python Betas2 contiguous memory pointer.
+/// </summary>
+///
+/// <param name="z">length of z dimension (major)</param>
+/// <param name="y">length of y dimension</param>
+/// <param name="x">length of x dimension (minor)</param>
+/// <param name="data">pointer to contiguous python memory array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::SetBetas2(int zlen, int ylen, int xlen, double *data)
+{
+    if (m_Betas2 != nullptr)
+    {
+        delete m_Betas2;
+    }
+    m_Betas2 = new FpArray3D(zlen, ylen, xlen, data);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Creates a 2 dimensional array mapping to python dictionary entry contiguous memory pointer.
+/// </summary>
+///
+/// <param name="y">length of y dimension</param>
+/// <param name="x">length of x dimension (minor)</param>
+/// <param name="data">pointer to contiguous python memory array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::SetDictEntry(int ylen, int xlen, double *data)
+{
+    if (m_DictEntry != nullptr)
+    {
+        delete m_DictEntry;
+    }
+    m_DictEntry = new FpArray2D(ylen, xlen, data);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Creates a 2 dimensional array mapping to python Zz contiguous memory pointer.
+/// </summary>
+///
+/// <param name="y">length of y dimension</param>
+/// <param name="x">length of x dimension (minor)</param>
+/// <param name="data">pointer to contiguous python memory array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::SetZz(int ylen, int xlen, double *data)
+{
+    if (m_Zz != nullptr)
+    {
+        delete m_Zz;
+    }
+    m_Zz = new FpArray2D(ylen, xlen, data);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Saves the length and a pointer to the python Zx contiguous memory pointer.
+/// </summary>
+///
+/// <param name="x">length of x dimension (minor)</param>
+/// <param name="data">pointer to contiguous python memory array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::SetZx(int xlen, double *data)
+{
+    m_Zx = data;
+    m_Xlen = xlen;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Saves the length and a pointer to the python Zy contiguous memory pointer.
+/// </summary>
+///
+/// <param name="y">length of y dimension (minor)</param>
+/// <param name="data">pointer to contiguous python memory array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::SetZy(int ylen, double *data)
+{
+    m_Zy = data;
+    m_Ylen = ylen;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Computes Zx, Zy, and Zz for rho using Betas, Betas2, and dictEntry.
+/// </summary>
+///
+/// <param name="cvar">value of c variance</param>
+/// <param name="zvar">value of z variance</param>
+/// <param name="zmeanIndex">index into zMean</param>
+/// <param name="zvarIndex">index into zVar</param>
+/// <param name="cmeanIndex">index into cMean</param>
+/// <param name="cvarIndex">index into cVar</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::EvalRho(double cvar, double zvar, int zmeanIndex, int zvarIndex, int cmeanIndex, int cvarIndex)
+{
+    for (int i = 0; i < m_Xlen; i++)
+    {
+        double beta = m_Betas->GetData(i, zmeanIndex, zvarIndex);
+        if (cvar == 0)
+        {
+            // Model "A": treats C as a Dirac delta
+            m_Zx[i] = beta / m_DictEntry->GetData(i, cmeanIndex);
+        }
+        else
+        {
+            for (int j = 0; j < m_Ylen; j++)
+            {
+                // Attempt to construct the integrand
+                double beta2 = m_Betas2->GetData(j, cmeanIndex, cvarIndex);
+                if (zvar == 0)
+                {
+                    // Model "A": treats Z as a Dirac delta
+                    m_Zy[j] = beta2 / m_DictEntry->GetData(zmeanIndex, j);
+                }
+                else
+                {
+                    // Model "A": treats Z as a Dirac delta
+                    double temp = beta * beta2 / m_DictEntry->GetData(i, j);
+                    m_Zz->SetData(i, j, temp);
+                }
+            }
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Computes Zx, Zy, and Zz for non-rho entries using Betas, Betas2, and dictEntry.
+/// </summary>
+///
+/// <param name="cvar">value of c variance</param>
+/// <param name="zvar">value of z variance</param>
+/// <param name="zmeanIndex">index into zMean</param>
+/// <param name="zvarIndex">index into zVar</param>
+/// <param name="cmeanIndex">index into cMean</param>
+/// <param name="cvarIndex">index into cVar</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::EvalNormal(double cvar, double zvar, int zmeanIndex, int zvarIndex, int cmeanIndex, int cvarIndex)
+{
+    for (int i = 0; i < m_Xlen; i++)
+    {
+        // Attempt to construct the integrand
+        double beta = m_Betas->GetData(i, zmeanIndex, zvarIndex);
+        if (cvar == 0.0)
+        {
+            // Model "A": treats C as a Dirac delta
+            m_Zx[i] = beta * m_DictEntry->GetData(i, cmeanIndex);
+        }
+        else
+        {
+            for (int j = 0; j < m_Ylen; j++)
+            {
+                double beta2 = m_Betas2->GetData(j, cmeanIndex, cvarIndex);
+                if (zvar == 0.0)
+                {
+                    // Model "A": treats Z as a Dirac delta
+                    m_Zy[j] = beta2 * m_DictEntry->GetData(zmeanIndex, j);
+                }
+                else
+                {
+                    // Model "A": treats Z as a Dirac delta
+                    double temp = beta * beta2 * m_DictEntry->GetData(i, j);
+                    m_Zz->SetData(i, j, temp);
+                }
+            }
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Computes Zx, Zy, and Zz using Betas, Betas2, and dictEntry.
+/// </summary>
+///
+/// <param name="cvar">value of c variance</param>
+/// <param name="zvar">value of z variance</param>
+/// <param name="zmeanIndex">index into zMean</param>
+/// <param name="zvarIndex">index into zVar</param>
+/// <param name="cmeanIndex">index into cMean</param>
+/// <param name="cvarIndex">index into cVar</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void ConvoluteCpp::Eval(double cvar, double zvar, int zmeanIndex, int zvarIndex, int cmeanIndex, int cvarIndex)
+{
+    if (m_rho == true)
+    {
+        EvalRho(cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex);
+    }
+    else
+    {
+        EvalNormal(cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex);
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Test function to insure Zz array storage mapped correctly.
+/// </summary>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void  ConvoluteCpp::EvalZzArray()
+{
+    for (int i = 0; i < m_Zz->GetYlen(); i++)
+    {
+        for (int j = 0; j < m_Zz->GetXlen(); j++)
+        {
+            m_Zz->SetData(i, j, i * 1000 + j);
+        }
+    }
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Test function to insure Zx array storage mapped correctly.
+/// </summary>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void  ConvoluteCpp::EvalZxArray()
+{
+    for (int i = 0; i < m_Xlen; i++)
+    {
+        m_Zx[i] += i;
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Test function to insure Betas array storage mapped correctly.
+/// </summary>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void  ConvoluteCpp::EvalBetaArray()
+{    
+    for (int k = 0; k < m_Betas->GetZlen(); k++)
+    {
+        for (int i = 0; i < m_Betas->GetYlen(); i++)
+        {
+            for (int j = 0; j < m_Betas->GetXlen(); j++)
+            {
+                m_Betas->SetData(k, i, j, k*10000 + i * 100 + j);
+            }
+        }
+    }
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// class CreateOutputFile
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Default CreateOutputFile constructor that initializes member variables to nullptr.
+/// </summary>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+CreateOutputFile::CreateOutputFile()
+{
+    m_File = nullptr;
+    m_OutputData = nullptr;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Creates/Opens the output file.  Creates the outputData array mapping.  Initializes the Zmean array mapping.
+/// Initializes local variable indicating if the file will be using a compressed format.
+/// </summary>
+///
+/// <param name="filename">output file name</param>
+/// <param name="ylen">length of y dimension of OutputData mapping</param>
+/// <param name="xlen">length of x dimension of OutputData mapping</param>
+/// <param name="data">pointer to python OutputData contiguous array</param>
+/// <param name="zmeanlen">length of zMean array</param>
+/// <param name="ZMean">pointer to python zMean contiguous array</param>
+/// <param name="compressed">flag indicating if file should be created using a compressed format</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+CreateOutputFile::CreateOutputFile(char *filename, int ylen, int xlen, double *data, int zmeanlen, double *ZMean, int compressed)
+{
+    m_OutputData = new FpArray2D(ylen, xlen, data);
+    m_ZMean = ZMean;
+    m_Zmeanlen = zmeanlen;
+    fopen_s(&m_File, filename, "a");
+    m_Compressed = compressed;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Writes a line of formatted text to the output file.
+/// </summary>
+///
+/// <param name="cvar">value of c variance</param>
+/// <param name="zvar">value of z variance</param>
+/// <param name="cmean">value of c mean</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateOutputFile::Write(double cvar, double zvar, double cmean)
+{   
+    for (int j = 0; j < m_OutputData->GetXlen(); j++)
+    {
+        if (m_Compressed == 0)
+        {
+            fprintf(m_File, "%10.6e\t", m_ZMean[j]);
+            fprintf(m_File, "%10.6e\t", cmean);
+            fprintf(m_File, "%10.6e\t", zvar);
+            fprintf(m_File, "%10.6e\t", cvar);
+        }
+        for (int i = 0; i < m_OutputData->GetYlen(); i++)
+        {
+            fprintf(m_File, "%10.6e\t", m_OutputData->GetData(i,j));
+        }
+        fprintf(m_File, "\n");
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Closes the output file.
+/// </summary>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateOutputFile::Close()
+{
+    fclose(m_File);
+}
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// class CreateDiffusionFlameletsFile
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Default CreateDiffusionFlameletsFile constructor that initializes  member variable to nullptr.
+/// </summary>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+CreateDiffusionFlameletsFile::CreateDiffusionFlameletsFile()
+{
+    m_File = nullptr;
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Creates/Opens the output file.
+/// </summary>
+///
+/// <param name="filename">output file name</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+CreateDiffusionFlameletsFile::CreateDiffusionFlameletsFile(char *filename)
+{
+    fopen_s(&m_File, filename, "w");
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Writes the output file header.
+/// </summary>
+///
+/// <param name="maxC">max C</param>
+/// <param name="numSpecies">number of species</param>
+/// <param name="gridpoints">number of gridpoints</param>
+/// <param name="pressure">value of pressure</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateDiffusionFlameletsFile::WriteHeader(double maxC, int numSpecies, int gridpoints, double pressure)
+{
+    fprintf(m_File, "HEADER\n");
+    fprintf(m_File, "PREMIX_CHI 0.0000\n");
+    fprintf(m_File, "C  %6.6f\n", maxC);
+    fprintf(m_File, "NUMOFSPECIES %3d\n", numSpecies);
+    fprintf(m_File, "GRIDPOINTS	%3d\n", gridpoints);
+    fprintf(m_File, "PRESSURE %6.2f\n", pressure);
+    fprintf(m_File, "BODY");
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Writes a section of text for the specified species.
+/// </summary>
+///
+/// <param name="len">number of data items to write out</param>
+/// <param name="data">pointer to data item array</param>
+/// <param name="name">species name</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateDiffusionFlameletsFile::WriteData(int len, double *data, char *name)
+{
+    fprintf(m_File, "\n%s\n", name);
+    for (int j = 0; j < len; j++)
+    {
+        fprintf(m_File, "%15.9e ", data[j]);
+        if (((j + 1) % 5 == 0) && ((j + 1) != len))
+        {
+            fprintf(m_File, "\n");
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Writes a section of text for the specified species.  
+/// Makes sure data is greater then minimum value or outputs 0.0.
+/// </summary>
+///
+/// <param name="len">number of data items to write out</param>
+/// <param name="data">pointer to data item array</param>
+/// <param name="name">species name</param>
+/// <param name="minValue">minimum data value allowed</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateDiffusionFlameletsFile::WriteDataMin(int len, double *data, char *name, double minValue)
+{
+    fprintf(m_File, "\n%s\n", name);
+    for (int j = 0; j < len; j++)
+    {
+        double outdata = data[j];
+        if (outdata < minValue)
+        {
+            outdata = 0.0;
+        }
+        fprintf(m_File, "%15.9e ", outdata);
+        if (((j + 1) % 5 == 0) && ((j + 1) != len))
+        {
+            fprintf(m_File, "\n");
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Writes a PREMIX-CDOT section of text when flow is laminar.  
+/// </summary>
+///
+/// <param name="ylen">ylen for mapping into net production rate array</param>
+/// <param name="xlen">xlen for mapping into net production rate array</param>
+/// <param name="nprData">pointer to net production rate contiguous python array</param>
+/// <param name="mwlen">length of molecular weight python array</param>
+/// <param name="molecularWeight">pointer to molecular weight contiguous python array</param>
+/// <param name="ialen">length of index array</param>
+/// <param name="indexArray">pointer to index contiguous python array</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateDiffusionFlameletsFile::WriteLaminarDataReaction(int ylen, int xlen, double *nprData,
+                                                     int mwlen, double *molecularWeight, 
+                                                     int ialen, int *indexArray)
+{
+    // create 2D array object
+    FpArray2D netProductionRates(ylen, xlen, nprData);
+    fprintf(m_File, "\n%s\n", "PREMIX_CDOT");
+    fprintf(m_File, "%15.9e ", 0.0);
+
+    for (int j = 1; j < xlen-1; j++)
+    {
+        double source = 0.0;
+        for (int i = 0; i < ialen; i++)
+        {
+            source += netProductionRates.GetData(indexArray[i], j) * molecularWeight[indexArray[i]];
+        }
+        fprintf(m_File, "%15.9e ", source);
+        if (((j + 1) % 5 == 0) && ((j + 1) != xlen))
+        {
+            fprintf(m_File, "\n");
+        }
+    }
+    fprintf(m_File, "%15.9e ", 0.0);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Writes a PREMIX-CDOT section of text when flow is turbulent.  
+/// </summary>
+///
+/// <param name="ylen">ylen for mapping into net production rate array</param>
+/// <param name="xlen">xlen for mapping into net production rate array</param>
+/// <param name="nprData">pointer to net production rate contiguous python array</param>
+/// <param name="mwlen">length of temperature python array</param>
+/// <param name="molecularWeight">pointer to temperature contiguous python array</param>
+/// <param name="ialen">length of index array</param>
+/// <param name="indexArray">pointer to index contiguous python array</param>
+/// <param name="pressure">value of pressure</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateDiffusionFlameletsFile::WriteTurbulentDataReaction(int ylen, int xlen, double *nprData,
+    int tlen, double *temperature,
+    int ialen, int *indexArray, double pressure)
+{
+    // create 2D array object
+    FpArray2D netProductionRates(ylen, xlen, nprData);
+    fprintf(m_File, "\n%s\n", "PREMIX_CDOT");
+    fprintf(m_File, "%15.9e ", 0.0);
+
+    const double UniversalGasConstant = 8314.5;
+    for (int j = 1; j < xlen - 1; j++)
+    {
+        double source = 0.0;
+        for (int i = 0; i < ialen; i++)
+        {
+            source += netProductionRates.GetData(indexArray[i], j);
+        }
+        double result = source / (pressure / (temperature[j] * UniversalGasConstant));
+        fprintf(m_File, "%15.9e ", result);
+        if (((j + 1) % 5 == 0) && ((j + 1) != xlen))
+        {
+            fprintf(m_File, "\n");
+        }
+    }
+    fprintf(m_File, "%15.9e ", 0.0);
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Writes a data producation section of text using the given species name.  
+/// </summary>
+///
+/// <param name="len">len for mapping into net production rate array</param>
+/// <param name="nprData">pointer to net production rate contiguous python array</param>
+/// <param name="molecularWeight">value of molecular weight</param>
+/// <param name="name">species name</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateDiffusionFlameletsFile::WriteDataProduction(int len, double *nprData, double molecularWeight, char *name)
+{
+    // create 2D array object
+    fprintf(m_File, "\n%s\n", name);
+    for (int j = 0; j < len; j++)
+    {
+        double source = nprData[j] * molecularWeight;
+        fprintf(m_File, "%15.9e ", source);
+        if (((j + 1) % 5 == 0) && ((j + 1) != len))
+        {
+            fprintf(m_File, "\n");
+        }
+    }
+}
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///
+/// <summary>
+/// Writes  two carriage returns.  
+/// </summary>
+///
+/// <param name="len">len for mapping into net production rate array</param>
+/// <param name="nprData">pointer to net production rate contiguous python array</param>
+/// <param name="molecularWeight">value of molecular weight</param>
+/// <param name="name">species name</param>
+///
+/// <returns>none</returns>
+///
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+void CreateDiffusionFlameletsFile::WriteCR()
+{
+    fprintf(m_File, "\n\n");
+}
+
+void CreateDiffusionFlameletsFile::Close()
+{
+    fclose(m_File);
+}

--- a/interfaces/cython/cantera/examples/onedim/ConvoluteCpp.h
+++ b/interfaces/cython/cantera/examples/onedim/ConvoluteCpp.h
@@ -1,0 +1,187 @@
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+//
+// No part of this program may be photocopied, transferred, or otherwise reproduced in machine or
+// human readable form without the prior written consent of The University Of Dayton.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+// THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+// INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+// FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+// UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+// INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+// LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+// OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+// LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+// NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+// EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+// HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+///////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+#pragma once
+
+#include <vector>
+#include <stdio.h>
+
+//! Vector of doubles.
+typedef std::vector<double> vector_fp;
+//! Vector of ints
+typedef std::vector<int> vector_int;
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// 
+/// <version>1.0.0</version>
+/// <author>Robert B. Olding</author>
+///
+/// <summary>
+/// The FpArray3D class provides access to a three dimensional array mapped to a contiguous one dimensional 
+/// array of python memory.
+/// </summary>
+///
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class FpArray3D
+{
+public:
+    FpArray3D(int zlen, int ylen, int xlen, double *data);
+    inline double GetData(int z, int y, int x);
+    inline void SetData(int z, int y, int x, double value);
+    inline int GetZlen();
+    inline int GetYlen();
+    inline int GetXlen();
+
+private:
+    const int m_Xlen;
+    const int m_Ylen;
+    const int m_Zlen;
+    double *m_data;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// 
+/// <version>1.0.0</version>
+/// <author>Robert B. Olding</author>
+///
+/// <summary>
+/// The FpArray2D class provides access to a two dimensional array mapped to a contiguous one dimensional 
+/// array of python memory.
+/// </summary>
+///
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class FpArray2D
+{
+public:
+    FpArray2D(int ylen, int xlen, double *data);
+    inline double GetData(int y, int x);
+    inline void SetData(int y, int x, double value);
+    inline int GetYlen();
+    inline int GetXlen();
+
+private:
+    const int m_Xlen;
+    const int m_Ylen;
+    double *m_data;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// 
+/// <version>1.0.0</version>
+/// <author>Robert B. Olding</author>
+///
+/// <summary>
+/// The ConvoluteCpp class implements some of the slower python functions implemented in the Convolution routine.
+/// </summary>
+///
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class ConvoluteCpp
+{
+
+public:
+    ConvoluteCpp();
+    ConvoluteCpp(char *name);
+
+    void SetBetas(int zlen, int ylen, int xlen, double *data);
+    void SetBetas2(int zlen, int ylen, int xlen, double *data);
+    void SetDictEntry(int ylen, int xlen, double *data);
+    void SetZz(int ylen, int xlen, double *data);
+    void SetZx(int xlen, double *data);
+    void SetZy(int ylen, double *data);
+
+    void EvalNormal(double cvar, double zvar, int zmeanIndex, int zvarIndex, int cmeanIndex, int cvarIndex);
+    void EvalRho(double cvar, double zvar, int zmeanIndex, int zvarIndex, int cmeanIndex, int cvarIndex);
+    void Eval(double cvar, double zvar, int zmeanIndex, int zvarIndex, int cmeanIndex, int cvarIndex);
+
+    void EvalZzArray();
+    void EvalZxArray();
+    void EvalBetaArray();
+
+private:
+    FpArray3D *m_Betas;
+    FpArray3D *m_Betas2;
+    FpArray2D *m_DictEntry;
+    FpArray2D *m_Zz;
+    double *m_Zx;
+    double *m_Zy;
+    int m_Xlen;
+    int m_Ylen;
+    bool m_rho;
+};
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// 
+/// <version>1.0.0</version>
+/// <author>Robert B. Olding</author>
+///
+/// <summary>
+/// The CreateOutputFile class implements fast file output via fprintf for the PdfScript python routine.
+/// </summary>
+///
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class CreateOutputFile
+{
+public:
+    CreateOutputFile();
+    CreateOutputFile(char *filename, int ylen, int xlen, double *data, int zmeanlen, double *ZMean, int m_Compressed);
+    void Write(double cvar, double zvar, double cmean);
+    void Close();
+
+private:
+    FpArray2D *m_OutputData;
+    FILE *m_File;
+    int m_Zmeanlen;
+    double* m_ZMean;
+    int m_Compressed;
+};
+
+
+/////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+/// 
+/// <version>1.0.0</version>
+/// <author>Robert B. Olding</author>
+///
+/// <summary>
+/// The CreateDiffusionFlameletsFile class implements fast file output via fprintf for the DiffusionFlaemelts
+/// python routine.
+/// </summary>
+///
+//////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+class CreateDiffusionFlameletsFile
+{
+public:
+    CreateDiffusionFlameletsFile();
+    CreateDiffusionFlameletsFile(char *filename);
+    void WriteHeader(double maxC, int numSpecies, int gridpoints, double pressuree);
+    void WriteData(int len, double *data, char *nam);
+    void WriteDataMin(int len, double *data, char *name, double minValue);
+    void WriteLaminarDataReaction(int ylen, int xlen, double *nprData,
+        int mwlen, double *molecularWeight,
+        int ialen, int *indexArray);
+    void WriteTurbulentDataReaction(int ylen, int xlen, double *nprData,
+        int tlen, double *temperature,
+        int ialen, int *indexArray, double pressure);
+    void WriteDataProduction(int len, double *nprData, double molecularWeight, char *name);
+    void WriteCR();
+    void Close();
+
+private:
+    FILE *m_File;
+};

--- a/interfaces/cython/cantera/examples/onedim/Graphics.py
+++ b/interfaces/cython/cantera/examples/onedim/Graphics.py
@@ -1,0 +1,123 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+import tkinter
+from tkinter import ttk
+import numpy as np
+
+# plot dialog class
+class PlotDlg():
+
+    # constructor - display plot dialog box
+    def __init__(self, CVar, ZVar, cvarIndex, zvarIndex, keyList, name):
+        self._dlg = tkinter.Tk()
+        self._dlg.config(borderwidth=8)
+        self._cvarNumIndex = tkinter.IntVar(self._dlg, value=len(CVar))
+        self._zvarNumIndex = tkinter.IntVar(self._dlg, value=len(ZVar))
+        self._cvarIndex = tkinter.IntVar(self._dlg, value=cvarIndex)
+        self._zvarIndex = tkinter.IntVar(self._dlg, value=zvarIndex)
+        self._variableName = tkinter.StringVar(self._dlg, value=name)
+        self._plot = False
+        self._CVar = CVar
+        self._ZVar = ZVar
+        self._dlg.title("Plot Selection")
+        # column titles
+        tkinter.Label(self._dlg, text="Min").grid( row=1, column=2)
+        tkinter.Label(self._dlg, text="Max").grid( row=1, column=3)
+        tkinter.Label(self._dlg, text="Indices").grid( row=1, column=4)
+        tkinter.Label(self._dlg, text="Selection").grid( row=1, column=5)
+        #ZVar row
+        tkinter.Label(self._dlg, text="ZVar").grid( row=2, column=1, sticky="w")
+        tkinter.Label(self._dlg, text=str(np.min(ZVar))).grid( row=2, column=2)
+        tkinter.Label(self._dlg, text=str(np.max(ZVar))).grid( row=2, column=3)
+        tkinter.Label(self._dlg, textvariable=self._zvarNumIndex).grid( row=2, column=4)
+        tkinter.Entry(self._dlg, textvariable=self._zvarIndex, width=6).grid(row=2, column=5, pady=2, padx=4)
+        # CVar row
+        tkinter.Label(self._dlg, text="CVar").grid( row=3, column=1, sticky="w")
+        tkinter.Label(self._dlg, text=str(np.min(CVar))).grid( row=3, column=2)
+        tkinter.Label(self._dlg, text=str(np.max(CVar))).grid( row=3, column=3)
+        tkinter.Label(self._dlg, textvariable=self._cvarNumIndex).grid( row=3, column=4)
+        tkinter.Entry(self._dlg, textvariable=self._cvarIndex, width=6).grid(row=3, column=5, pady=2, padx=4)
+        #variable selection
+        tkinter.Label(self._dlg, text="Variable").grid( row=4, column=1, sticky="w")
+        self._variable_combobox = ttk.Combobox(self._dlg, textvariable=self._variableName, values = keyList, width=20).grid(row=4,column=2,columnspan=3, pady=4) 
+        # button row
+        tkinter.Button(self._dlg, text = "Plot", command = self.RetryCallBack, width = 6).grid( row=5, column=3, pady=6)
+        tkinter.Button(self._dlg, text = "Exit", command = self.ExitCallBack, width = 6).grid( row=5, column=5, pady=6)
+        
+        # center Dialog on screen
+        self._dlg.withdraw()
+        self._dlg.update_idletasks()  # Update "requested size" from geometry manager
+
+        x = (self._dlg.winfo_screenwidth() - self._dlg.winfo_reqwidth()) / 2
+        y = (self._dlg.winfo_screenheight() - self._dlg.winfo_reqheight()) / 2
+        self._dlg.geometry("+%d+%d" % (x, y))
+
+        # This seems to draw the window frame immediately, so only call deiconify()
+        # after setting correct window position
+        self._dlg.deiconify()
+
+    @property
+    def cvar_index(self):
+        '''cvar index'''
+        return self._cvarIndex.get()
+
+    @property
+    def zvar_index(self):
+        '''zvar index'''
+        return self._zvarIndex.get()
+
+    @property
+    def variable_name(self):
+        '''name of variable selected'''
+        return self._variableName.get()
+    
+    # wait for user to hit button
+    def WaitResult(self):
+        self._dlg.mainloop()
+        return self._plot
+
+    # retry button handler
+    def RetryCallBack(self):
+        self._plot = True
+        if self._cvarIndex.get() < 0:
+            self._cvarIndex.set(0)
+        if self._cvarIndex.get() >= len(self._CVar):
+            self._cvarIndex.set(len(self._CVar)-1)
+        if self._zvarIndex.get() < 0:
+            self._zvarIndex.set(0)
+        if self._zvarIndex.get() >= len(self._ZVar):
+            self._zvarIndex.set(len(self._ZVar)-1)
+        self._dlg.quit()
+        self._dlg.destroy()
+
+    # exit buttonhandler
+    def ExitCallBack(self):
+        self._plot = False
+        self._dlg.quit()
+        self._dlg.destroy()

--- a/interfaces/cython/cantera/examples/onedim/InterpolationFPV.py
+++ b/interfaces/cython/cantera/examples/onedim/InterpolationFPV.py
@@ -1,0 +1,273 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+#python imports
+import numpy as np
+import sys
+import getopt
+
+from Utils import PrintFlush
+
+def printhelp():
+    # If the user requests help, display documentation.
+    PrintFlush("""
+Script for Alex.py: Find the maximum grid size in a FLUENT flamelet table.
+
+Usage:
+    Script for Alex.py [--input=<filename>]
+                       [--output=<filename>]
+                       [--help]
+                       [--debug]
+
+Example:
+    Script for Alex.py --input=flamelet.txt --output=newflamelet.txt
+
+An input file must be specified from the program to run. It should be of the FLUENT flamelet table format.    
+    
+If the output file name is not given, one will be automatically generated.
+This automatic output file will be the same as the input file, with the name having "new" appended.
+
+""")
+    sys.exit(1)
+
+def tabletoarray(input, lastlocation):
+    
+    # Initialize the array to be constructed
+    thearray=[]
+    input.seek(lastlocation)
+
+    while(1):
+        try:
+            # Read the next line and partition it into chunks divided by spaces
+            lastposition = input.tell()
+            templine = input.readline().rstrip().split(' ')
+            for entry in templine:
+                # Read each chunk as a float and add it to the end of the array
+                temp = float(entry)
+                thearray.append(temp)
+        except Exception as e:
+            # If a character cannot be parsed as a float, end the array
+            input.seek(lastposition)
+            break
+    
+    # Return the resulting array
+    return thearray
+
+# FPV interpolation function
+def InterpolateFPV(options):
+
+    PrintFlush("Start flamelet Interpolation of FPV type")
+
+    if '--help' in options:
+        printhelp()
+
+    if '--input' in options:    
+        # If the user specifies an input file, open that file
+        inputFile = options['--input']
+        input = open(inputFile,'r')    
+    else:
+        # Without an input specified, notify the user and close the program
+        inputFile = None
+        PrintFlush("You must specify an input file.")
+        sys.exit(1)
+
+    if '--output' in options:
+        # If the user specifies an output file, open that file
+        outputFile = options['--output']
+        output = open(outputFile,'w')
+    else:
+        # Without an output file specified, create one automatically
+        output = open("New " + inputFile,'w')
+
+    maximumGridSize = 0
+    tempstring = 'something'
+
+    # Cycle through all lines of the input file to find the maximum grid size
+    while tempstring != '':
+        # Read each line of the input file
+        tempstring = input.readline()
+
+        # When reaching a "gridpoints" line, isolate the numeric value
+        if tempstring.startswith("GRID"):
+            tempstring = ''.join(c for c in tempstring if c.isdigit())
+            tempGridSize = int(tempstring)
+        
+            # Update the maximum grid size, if necessary
+            if tempGridSize > maximumGridSize:
+                maximumGridSize = tempGridSize
+                input.readline()
+                input.readline()
+                input.readline()
+                lastlocation = input.tell()
+                maximumarray = tabletoarray(input, lastlocation)
+                
+    newX = maximumarray
+    
+    # Initialize variables to be used during file writing
+    input.seek(0)
+    tempstring = 'something'
+    lastline = tempstring
+
+    premix_chi = 0.0000
+    
+    # Cycle through all of the input file
+    while tempstring != '':
+        lastline = tempstring
+        lastlocation = input.tell()
+        tempstring = input.readline()
+        try:
+            # Attempt to read the next line and partition it into chunks divided by spaces
+            templine = tempstring.rstrip().split(' ')
+            for entry in templine:
+                # Attempt to read each chunk as a float
+                temp = float(entry)
+            
+            # If the reading is successful, store this chunk of text to an array
+            oldY = tabletoarray(input, lastlocation)
+
+            if lastline.startswith("massfraction"):
+                massfraction = True
+            else:
+                massfraction = False
+            
+            # If this array is also the independent variable, store it as such
+            if lastline.startswith("MIXTURE"):
+                oldX = oldY
+                newY = newX
+                #PrintFlush(oldX)
+            else: 
+                try:    
+                    # Interpolate to get the new array    
+                    #newY = interpolate(newX,oldX,oldY)
+                    newY = np.flipud(np.interp(np.flipud(newX),np.flipud(oldX),np.flipud(oldY)))
+                except Exception as e:
+                    PrintFlush("Error in interpolation.",e)
+            
+            # Print the new array in the FLUENT format
+            for i in range(0,len(newY)):
+                if massfraction and newY[i] <= 0:
+                    newY[i] = 0
+                output.write('%15.9e '% newY[i])
+                if ((i+1)%5==0 and (i+1) != len(newY)):
+                    output.write('\n')
+            output.write('\n')
+            
+        except Exception as e:
+            # If the line cannot be parsed as a table, simply print it to the new file
+            #PrintFlush(tempstring, e)
+            if tempstring.startswith("GRID"):
+                output.write('GRIDPOINTS    %3d\n' % (len(newX)))
+            elif tempstring.startswith("PREMIX_CHI"):
+                output.write('PREMIX_CHI ' + str(round(premix_chi,4)) + '\n')
+                premix_chi += 0.0001
+            else:
+                output.write(tempstring)
+
+    # write out conversion table
+    WriteConversionTable(options['--output'])
+
+
+def WriteConversionTable(file_name):
+    file = open(file_name, "r")
+    table = open("conversion_table.txt", "w")
+    
+    lambda_array = []
+    templine = 'string'
+    while templine != '':
+        # Read each line of the output file
+        templine = file.readline()
+
+        # When reaching a "C" line, isolate the numeric value
+        if templine.startswith("C"):
+            templine = templine.rstrip().split('  ') 
+            if (len(templine)>1):
+                lambda_array.append(float(templine[1]))
+    
+    #back to the beginning of the file
+    file.seek(0)
+    
+    mixture_fraction_array = []
+    progress_variable_array = []
+    with file as input_data:
+        for line in input_data:
+            if line.strip() == "MIXTURE_FRACTION":
+                break
+        for line in input_data:
+            if line.strip() == "PROGRESS VARIABLE":
+                break
+            templine = line.rstrip().split(' ')
+            for entry in templine:
+                mixture_fraction_array.append(float(entry))
+                
+    c_size = len(mixture_fraction_array) * len(lambda_array)
+    file = open(file_name, "r")
+    with file as input_data:
+        while len(progress_variable_array) < c_size:
+            for line in input_data:
+                if line.strip() == "PROGRESS VARIABLE":
+                    break
+            for line in input_data:
+                if line.strip() == "TEMPERATURE":
+                    break
+                templine = line.rstrip().split(' ')
+                for entry in templine:
+                    progress_variable_array.append(float(entry))
+
+    nGridPoints =  len(mixture_fraction_array)
+    nFlamelets = len(lambda_array)
+    print(nGridPoints, nFlamelets, len(progress_variable_array))
+    for j in range(nFlamelets-1,-1,-1):
+        for i in range(nGridPoints-1,-1,-1):
+            table.write("%15.12f %15.12f %15.12f\n" % (abs(mixture_fraction_array[i]), \
+			                             abs(progress_variable_array[nGridPoints* j+i]), \
+			                              lambda_array[j]))
+
+    table.close()
+    
+if __name__ == "__main__":    
+
+    # Declare the list of acceptable program options.
+    longOptions = ['input=', 'output=', 'help', 'debug']
+
+    # Parse the program arguments and place them in convenient format in "options"
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'dh', longOptions)
+        options = dict()
+        for o,a in optlist:
+            options[o] = a
+        if args:
+            raise getopt.GetoptError('Unexpected command line option: ' + repr(' '.join(args)))
+    except getopt.GetoptError as e:
+        PrintFlush('Error parsing arguments:')
+        PrintFlush(e)
+        PrintFlush('Run "Script for Alex.py --help" to see options.')
+        sys.exit(1)
+
+    InterpolateFPV(options)
+    sys.exit(0)

--- a/interfaces/cython/cantera/examples/onedim/MapProgressVar.py
+++ b/interfaces/cython/cantera/examples/onedim/MapProgressVar.py
@@ -1,0 +1,658 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.? THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+import sys
+import getopt
+import numpy as np
+from scipy.interpolate import interp1d
+from matplotlib import cm
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import axes3d,Axes3D
+import tkinter
+from tkinter import ttk
+from multiprocessing import Process, Pipe
+from collections import OrderedDict
+
+# UDRI imports
+from table_def import TableDef
+from Utils import PrintFlush
+from Graphics import PlotDlg
+
+# Input FileHandler class - responsible for reading input file 
+class InputFileHandler():
+
+    def __init__(self, fileName):
+        self._fileName = fileName
+        self._numGridpoints = 0     # num fmean
+        self._numFlamelets = 0      # num cmean
+        self._numFvars = 0          # num fvar 
+        self._numVars = 0           # num variables 
+        self._numCvars = 1          # num of cvar
+        self._numSpecies = 0        # num of species
+        self._numQoi = 0            # num QOI
+        self._columnHeader = "none" # column headings
+        self._data = []             # table data
+        self._input = open(fileName,'r')
+        self._variableDict = OrderedDict()
+
+    @property
+    def numGridpoints(self):
+        '''number of fmean values'''
+        return self._numGridpoints
+
+    @property
+    def numFlamelets(self):
+        '''number of cmean values'''
+        return self._numFlamelets
+
+    @property
+    def numFvars(self):
+        '''number of fvar values'''
+        return self._numFvars
+
+    @property
+    def numVars(self):
+        '''number of variables'''
+        return self._numVars
+
+    @property
+    def numCvars(self):
+        '''number of Cvar values'''
+        return self._numCvars
+
+    @property
+    def numSpecies(self):
+        '''number of species'''
+        return self._numSpecies
+
+    @property
+    def numQoi(self):
+        '''number of Qoi values'''
+        return self._numQoi
+
+    @property
+    def columnHeader(self):
+        '''column headings'''
+        return self._columnHeader
+
+    @property
+    def data(self):
+        '''table data'''
+        return self._data
+
+
+    # reads in a data set header and keeps track of number of lines read
+    def _ReadHeader(self):
+        count = 1
+        done = False
+        temp = self._input.readline()
+        while done == False:
+            name = temp.strip()
+            if name == '[NUMBER_FMEAN]':
+                temp = self._input.readline().strip()
+                self._numGridpoints = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_CPROGRESS]':
+                temp = self._input.readline().strip()
+                self._numFlamelets = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_FVAR]':
+                temp = self._input.readline().strip()
+                self._numFvars = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_CVAR]':
+                temp = self._input.readline().strip()
+                self._numCvars = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_SPECIES]':
+                temp = self._input.readline().strip()
+                self._numSpecies = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_QOI]':
+                temp = self._input.readline().strip()
+                self._numQoi = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_VARIABLES]':
+                temp = self._input.readline().strip()
+                self._numVars = int(temp)
+                count = count + 1
+            elif name == '[DATA]':
+                temp = self._input.readline().strip()
+                self._columnHeader = temp
+                done = True
+                count = count + 1
+            if done == False:
+                temp = self._input.readline()
+                count = count + 1
+        return count
+
+    # read in the input file header
+    def Read(self):
+
+        # read in the header and the data
+        lineCount = self._ReadHeader()
+
+        arrayLen = self._numCvars * self._numFvars * self._numFlamelets * self._numGridpoints
+        arrayWidth = self._numVars
+        self._data = np.zeros((arrayLen, arrayWidth), dtype=np.double)
+
+        for i, line in enumerate(self._input):
+            for j, temp in enumerate(line.split()):
+                self._data[i,j] = float(temp)
+
+        # close the file
+        self._input.close()
+
+# OutputFileHandler class - responsible for writing output file 
+class OutputFileHandler():
+
+    def __init__(self, fileName):
+        self._fileName = fileName
+        self._pressure = 0          # pressure
+        self._numGridpoints = 0     # num fmean
+        self._numFlamelets = 0      # num cmean
+        self._numFvars = 0          # num fvar 
+        self._numVars = 0           # num variables 
+        self._numCvars = 1          # num of cvar
+        self._numSpecies = 0        # num of species
+        self._numQoi = 0            # num QOI
+        self._columnHeader = "none" # column headings
+        self._output = open(fileName,'w')
+
+    @property
+    def pressure(self):
+        '''number of fmean values'''
+        return self._pressure
+
+    @pressure.setter
+    def pressure(self, value):
+        self._pressure = value
+
+    @property
+    def numGridpoints(self):
+        '''number of fmean values'''
+        return self._numGridpoints
+
+    @numGridpoints.setter
+    def numGridpoints(self, value):
+        self._numGridpoints = value
+
+    @property
+    def numFlamelets(self):
+        '''number of cmean values'''
+        return self._numFlamelets
+
+    @numFlamelets.setter
+    def numFlamelets(self, value):
+        self._numFlamelets = value
+
+    @property
+    def numFvars(self):
+        '''number of fvar values'''
+        return self._numFvars
+
+    @numFvars.setter
+    def numFvars(self, value):
+        self._numFvars = value
+
+    @property
+    def numVars(self):
+        '''number of variables'''
+        return self._numVars
+
+    @numVars.setter
+    def numVars(self, value):
+        self._numVars = value
+
+    @property
+    def numCvars(self):
+        '''number of Cvar values'''
+        return self._numCvars
+
+    @numCvars.setter
+    def numCvars(self, value):
+        self._numCvars = value
+
+    @property
+    def numSpecies(self):
+        '''number of species'''
+        return self._numSpecies
+
+    @numSpecies.setter
+    def numSpecies(self, value):
+        self._numSpecies = value
+
+    @property
+    def numQoi(self):
+        '''number of Qoi values'''
+        return self._numQoi
+
+    @numQoi.setter
+    def numQoi(self, value):
+        self._numQoi = value
+
+    @property
+    def columnHeader(self):
+        '''column headings'''
+        return self._columnHeader
+
+    @columnHeader.setter
+    def columnHeader(self, value):
+        self._columnHeader = value
+      
+    # write the header and body of file
+    def Write(self, data):
+
+        # Creating Header information for flamelets
+        self._output.write("FLAMELET PROGRESS VARIABLE MAPPED\n\n")
+        self._output.write("%s\n%.1f\n" % ("[PRESSURE]", self._pressure))
+        self._output.write("%s\n%d\n" % ("[NUMBER_FMEAN]", self._numGridpoints))
+        self._output.write("%s\n%d\n" % ("[NUMBER_CPROGRESS]", self._numFlamelets))
+        self._output.write("%s\n%d\n" % ("[NUMBER_FVAR]", self._numFvars))
+        self._output.write("%s\n%d\n" % ("[NUMBER_CVAR]", self._numCvars))
+        self._output.write("%s\n%d\n" % ("[NUMBER_SPECIES]", self._numSpecies))
+        self._output.write("%s\n%d\n" % ("[NUMBER_QOI]", self._numQoi))
+        self._output.write("%s\n%d\n" % ("[NUMBER_VARIABLES]", self._numVars))
+        self._output.write("%s\n%s\n" % ("[DATA]", self._columnHeader))
+
+        arrayLen = self._numCvars * self._numFvars * self._numFlamelets * self._numGridpoints
+        arrayWidth = self._numVars
+        for i in range(0, arrayLen):
+            for j in range(0, arrayWidth):
+                self._output.write("%10.6e\t" % data[i, j])
+            self._output.write("\n")
+
+def ParallelTableMapping(xp_source, fp_source, x_target, f_target, interpolate, n_gridpoints,n_flamelets, outPipe):			
+	
+    for k in range(0,n_gridpoints):
+        xp = []
+        fp = []
+        for i in range(0,n_flamelets):
+            xp.append(xp_source[i*n_gridpoints+k])
+            fp.append(fp_source[i*n_gridpoints+k])
+        f =  interp1d(xp, fp, kind = interpolate, assume_sorted='False')
+        for i in range(1,n_flamelets-1):
+            x = x_target[i*n_gridpoints+k]
+            f_target[i*n_gridpoints+k]=f(x)
+    
+    outPipe.send(f_target)
+    outPipe.close()
+    
+			
+def MapTable(fileHandler, interpolate):
+
+    n_fvars = fileHandler.numFvars              # num fvars
+    n_gridpoints = fileHandler.numGridpoints    # num fmean
+    n_flamelets = fileHandler.numFlamelets      # num cmean
+    n_cvars = fileHandler.numCvars              # num cvars
+
+    # useful indexing constants
+    n_gf = n_gridpoints * n_flamelets
+    n_fgf = n_fvars * n_gridpoints * n_flamelets
+
+    A = fileHandler.data                        # array of table data
+
+    #the second column from A array is lambda
+    A_Czst = np.copy(A[:,1])
+
+    # read in conversion table
+    B = np.loadtxt('conversion_table.txt')
+			
+    #the first column from B array is fmean
+    B_fmean = np.copy(B[:,0])
+
+    #the second column from B array is cmean
+    B_cmean = np.copy(B[:,1])
+
+    #the third column from B array is Czst
+    B_Czst = np.copy(B[:,2])
+
+
+    xp_source = B_Czst[:]
+    fp_source = B_cmean[:]
+    processDict = OrderedDict()
+    for m in range(0, n_cvars):
+        for n in range(0, n_fvars):
+            x_target = A_Czst[m* n_fgf + n * n_gf:m* n_fgf +  (n+1) * n_gf]
+            f_target = np.copy(x_target)
+            inputPipe, outputPipe = Pipe(duplex=False)
+            p = Process(target= ParallelTableMapping, args=(xp_source, fp_source, x_target, f_target, interpolate, n_gridpoints,n_flamelets, outputPipe))
+            processDict[n+m*n_fvars] = [p, inputPipe]
+            p.start()
+		
+    for m in range(0, n_cvars):
+        for n in range(0, n_fvars):
+             A[m* n_fgf + n * n_gf:m* n_fgf + (n+1) * n_gf,1] = processDict[n+m*n_fvars][1].recv()
+	
+    return A
+
+def ParallelRemeshing(xp_source, fp_source, x_target, f_target, interpolate, n_cvars, n_fvars, n_flamelets, n_gridpoints, outPipe):
+    # useful indexing constants
+    n_gp2 = n_gridpoints * n_gridpoints
+    n_fgp2 = n_fvars * n_gp2
+    n_gf = n_gridpoints * n_flamelets
+    n_fgf = n_fvars * n_gridpoints * n_flamelets
+
+    for m in range(0, n_cvars):
+        for n in range(0, n_fvars):
+            for k in range(0,n_gridpoints):
+                xp = []
+                fp = []
+                for i in range(0,n_flamelets):
+                    xp.append(xp_source[m*n_fgf + n*n_gf + i*n_gridpoints+k])
+                    fp.append(fp_source[m*n_fgf + n*n_gf + i*n_gridpoints+k])
+                lower_bound = np.asscalar(fp[0])
+                upper_bound = np.asscalar(fp[-1])
+                bounds = (lower_bound, upper_bound)
+                f = interp1d(xp,fp, kind = interpolate, bounds_error = False , fill_value = bounds, assume_sorted='False')
+                for j in range(1,n_gridpoints):
+                    x = x_target[m*n_fgp2 + n*n_gp2 + j*n_gridpoints+k]
+                    f_target[m*n_fgp2 + n*n_gp2 + j*n_gridpoints+k] = f(x)
+
+    outPipe.send(f_target)
+    outPipe.close()	
+						
+def RemeshTable(fileHandler, interpolate, A):
+
+    n_vars = fileHandler.numVars                # num variables
+    n_gridpoints = fileHandler.numGridpoints    # fmean
+    n_flamelets = fileHandler.numFlamelets      # num cmean
+    n_fvars = fileHandler.numFvars              # num fvar
+    n_cvars = fileHandler.numCvars              # num cvar
+
+    # useful indexing constants
+    n_gp2 = n_gridpoints * n_gridpoints
+    n_fgp2 = n_fvars * n_gp2
+    n_gf = n_gridpoints * n_flamelets
+    n_fgf = n_fvars * n_gridpoints * n_flamelets	
+	
+    # allocate the B matrix
+    n_mapped_matrix_size = n_fgp2 * n_cvars
+    B = np.zeros((n_mapped_matrix_size , n_vars))
+
+    #okay the table has been mapped in terms of cmean again, but the table is not order properly for the interpolation methods in Table.c
+    #the mapped table needs to be re-interpolated on cmean again.
+
+    #the maximum value of A[:,1] should be the maximum value of A_cmean
+    max_A_cmean = np.max(A[:,1])
+
+    # create a new range of cmean values based on the number of fmeans
+    regular_grid_A_cmean = np.zeros((n_gridpoints,1))
+    for i in range(0, n_gridpoints, 1):
+        regular_grid_A_cmean[i] = i * max_A_cmean / (n_gridpoints - 1)
+
+    fvar_values = np.zeros((n_fvars,1))	
+
+    #the values of fvar are obtained
+    for i in range(0, n_fvars, 1):
+        fvar_values[i] = A[i * n_gf,2]
+
+    cvar_values = np.zeros((n_cvars,1))	
+
+    #the values of cvar are obtained
+    for i in range(0, n_cvars, 1):
+        cvar_values[i] = A[i * n_fgf,3]
+   
+    for i in range(0, n_gridpoints, 1):
+        #copying values of fmean from A to B for fvar = 0 and cvar = 0
+        B[i * n_gridpoints: (i + 1) * n_gridpoints, 0:1] = A[0:n_gridpoints,0:1]
+        #copying values of cmean from regular_grid_A_cmean to B for fvar = 0 and cvar = 0
+        B[i * n_gridpoints: (i + 1) * n_gridpoints, 1:2] = regular_grid_A_cmean[i:i+1,0:1]
+
+    #copying values of fvar to B for cvar = 0		
+    for i in range(0, n_fvars, 1):
+        B[i * n_gp2: (i + 1) * n_gp2, 2:3] = fvar_values[i,0:1] 
+
+    #copying values of fmean and cmean for all other fvar to B for cvar = 0
+    for i in range(1, n_fvars, 1):
+        B[i * n_gp2: (i+1) * n_gp2, 0:2] = B[0:n_gp2, 0:2]
+		
+    #copying values of cvar to B		
+    for i in range(0, n_cvars, 1):
+        B[i * n_fgp2: (i + 1) * n_fgp2, 3:4] = cvar_values[i, 0:1] 
+
+    #copying values of fmean, cmean and fvar for all other cvar within B table
+    for i in range(1, n_cvars, 1):
+        B[i * n_fgp2: (i+1) * n_fgp2, 0:3] = B[0:n_fgp2, 0:3]
+
+    # i in the old cmean index in A array
+    # j is the new cmean index in B array		
+    # k is the fmean index in either array (same dimensions)		
+    # l is the variable index 
+    # n is the fvar index
+	# m is the cvar index
+
+    # No need to interpolate the table for the lower branch at each cvar, fvar		
+    for m in range(0, n_cvars):
+        for n in range(0, n_fvars):
+            B[m*n_fgp2 + n*n_gp2 : m*n_fgp2 + n*n_gp2 + n_gridpoints, 4:n_vars] = A[m*n_fgf + n*n_gf:m*n_fgf + n*n_gf + n_gridpoints,4:n_vars]
+            B[m*n_fgp2 + (n+1)*n_gp2 - n_gridpoints: m*n_fgp2 + (n+1)*n_gp2,4:n_vars] = A[m*n_fgf + (n+1)*n_gf-n_gridpoints:m*n_fgf + (n+1)*n_gf,4:n_vars]
+
+    processDict = OrderedDict()
+    # multiple process parallel section
+    for var in range(4,n_vars):
+        xp_source = A[:,1]
+        fp_source = A[:,var]
+        x_target = B[:,1]
+        f_target = B[:,var]
+        inputPipe, outputPipe = Pipe(duplex=False)
+        p = Process(target= ParallelRemeshing, args=(xp_source, fp_source, x_target, f_target, interpolate, n_cvars, n_fvars, n_flamelets, n_gridpoints, outputPipe))
+        processDict[var] = [p, inputPipe]
+        p.start()
+		
+    for var in range(4, n_vars):
+         B[:,var] = processDict[var][1].recv()
+
+    return B
+
+# start of MapProgressVarStart function
+def MapProgressVarStart(options):        
+
+    PrintFlush("*** Map Progress Variable Start ***")
+
+    # read in table definition file
+    table = TableDef()
+    if table.Read() != True:
+        return
+    
+    # assign interpolation type
+    interpolation_type = table.interpolation_type
+    pressure = table.pressure
+
+    PrintFlush("Successfully read table definition, interpolation = " + interpolation_type)
+
+    if '--help' in options:
+        #printhelp()
+        placefiller = 1
+
+    if '--input' in options:    
+        # If the user specifies an input file, open that file
+        inputFile = options['--input']
+    else:
+        # if not specified - use default
+        inputFile = "UdriTable.fla"
+
+    if '--output' in options:
+        # If the user specifies an output file, open that file
+        outputFile = options['--output']
+    else:
+        # Without an output file specified, create default automatically
+        outputFile = "UdriTable.map"
+
+    # read in input table fmean and lambda values
+    PrintFlush("Reading input file - " + inputFile)
+    inputFile = InputFileHandler(inputFile)
+    inputFile.Read()
+
+    # map the input file
+    PrintFlush("Input file read complete - Mapping progress variable")
+    A = MapTable(inputFile, interpolation_type)
+    PrintFlush("Mapping progress variable complete - remeshing table")
+
+    # remesh the table
+    B = RemeshTable(inputFile, interpolation_type, A)
+    PrintFlush("Remeshing progress variable complete - writing output file")
+
+    # write the output file
+    outputFile = OutputFileHandler(outputFile)
+    outputFile.pressure = pressure
+    outputFile.numGridpoints = inputFile.numGridpoints
+    outputFile.numFlamelets = inputFile.numGridpoints
+    outputFile.numFvars = inputFile.numFvars
+    outputFile.numCvars = inputFile.numCvars
+    outputFile.numQoi = inputFile.numQoi
+    outputFile.numSpecies = inputFile.numSpecies
+    outputFile.numVars = inputFile.numVars
+    outputFile.columnHeader = inputFile.columnHeader
+    outputFile.Write(B)
+    PrintFlush("*** Progress Variable Recovered ***")
+	
+    # set plot mode to interactive
+    plt.ion()
+    init_plot = True
+	
+    # create lengths
+    zmeanLen = inputFile.numGridpoints
+    cmeanLen = inputFile.numGridpoints
+    zvarLen = inputFile.numFvars
+    cvarLen = inputFile.numCvars
+
+    ZMean = np.zeros((zmeanLen,1))	
+    #the values of fmean are obtained
+    for i in range(0, zmeanLen, 1):
+        ZMean[i] = B[i,0]	
+		
+    CMean = np.zeros((cmeanLen,1))	
+    #the values of cmean are obtained
+    for i in range(0, cmeanLen, 1):
+        CMean[i] = B[i * zmeanLen,1]	
+
+    ZVar = np.zeros((zvarLen,1))	
+    #the values of fvar are obtained
+    for i in range(0, zvarLen, 1):
+        ZVar[i] = B[i * zmeanLen * cmeanLen,2]
+
+    CVar = np.zeros((cvarLen,1))	
+    #the values of cvar are obtained
+    for i in range(0, cvarLen, 1):
+        CVar[i] = B[i * zmeanLen * cmeanLen * zvarLen, 3]
+	
+    #create list of keys
+    keyList = inputFile.columnHeader.split()[4:]
+		
+    # Initialize the dictionary containing variable matrix that will be used to visualize the output in 3D
+    plotDict = OrderedDict()
+    for varIndex, name in enumerate(keyList):
+        plotDict[name] = np.zeros((cvarLen, zvarLen, cmeanLen, zmeanLen))
+        for cvarIndex in range (cvarLen):           
+            for zvarIndex in range(zvarLen):
+                for cmeanIndex in range(cmeanLen):
+                    for zmeanIndex in range(zmeanLen):
+                         plotDict[name][cvarIndex, zvarIndex, cmeanIndex, zmeanIndex] = B[zmeanIndex + zmeanLen * cmeanIndex + zmeanLen * cmeanLen * zvarIndex + zmeanLen * cmeanLen * zvarLen * cvarIndex, 4+varIndex]
+					
+    # display plot dialog
+    dlg = PlotDlg(CVar, ZVar, 0, 0, keyList, keyList[0])
+    retrySolve = dlg.WaitResult()
+    cvarIndex = dlg.cvar_index
+    zvarIndex = dlg.zvar_index
+    name = dlg.variable_name
+
+    plotLabel = {}
+    plotLabel['TEMPERATURE'] = 'Temperature, T [K]'
+    plotLabel['mu'] = 'Dynamic Viscosity, $\mu$ [kg/m-s]'
+    plotLabel['TC'] = 'Thermal Conductivity, k [W/m-K]'
+    plotLabel['PREMIX_CDOT'] = 'Progress Variable Source, S$_C$ [kg/m^3-s]'
+    plotLabel['MMW'] = 'Molecular Weight, MW [kg/kmol]'
+    plotLabel['rho'] = r'$\mathrm{Density, \rho  [kg/m^3]}$'
+    plotLabel['Cp'] = 'Specific Heat Capacity, C$_p$ [J/kg-K]'
+
+    # plot variable profile
+    while retrySolve == True:
+        PrintFlush("plotting variable = ", name, " cvar = ", cvarIndex, " zvar = ", zvarIndex)
+        if name in plotLabel:
+            label = plotLabel[name]
+        elif name.find('net_rxn-') != -1:
+            label = name.replace('net_rxn-', '')
+            label = label + ' Net Reaction Rate [kg/m$^3$-s]'
+        elif name.find('massfraction-') != -1:
+            label = name.replace('massfraction-', '')
+            label = label + ' Mass Fraction'
+        else:
+            label = name
+        fig = plt.figure(0)
+        ax = Axes3D(fig)
+        ZMeanAxis,CMeanAxis = np.meshgrid(ZMean,CMean)
+        ax.plot_surface(ZMeanAxis,CMeanAxis,plotDict[name][cvarIndex, zvarIndex,:,:],rstride=1,cstride=1,cmap=cm.jet)
+        plt.ylabel(r'Progress Variable, C')
+        plt.xlabel("Mixture Fraction, Z")
+        plt.xlim(0,1)
+        plt.ylim(0,1)
+        ax.set_zlabel(label)
+        ax.view_init(15,-130)
+        plt.title(str(table.fuel)+"-"+str(table.oxidizer)+", T$_{Fuel}$="\
+        +str(round(table.Tfuel))+"K"+", T$_{Oxidizer}$="+str(round(table.Toxidizer))\
+        +"K, P$_{Op}$="+str(round(table.pressure/101325,1))+"atm")
+        txtstr = r'Scaled Z$_{var}$ = '+str(np.asscalar(ZVar[zvarIndex])) \
+               +r'  Scaled C$_{var}$ = '+str(np.asscalar(CVar[cvarIndex]))
+        ax.text2D(0.30, 0.87, txtstr, transform=ax.transAxes, fontsize=12)
+        if init_plot:
+            # only position initially, allows user to move afterwards
+            mgr = plt.get_current_fig_manager()
+            mgr.window.wm_geometry("+50+400")
+            init_plot = False
+       
+        # display plot dialog
+        dlg = PlotDlg(CVar, ZVar, cvarIndex, zvarIndex, keyList, name)
+        retrySolve = dlg.WaitResult()        
+        cvarIndex = dlg.cvar_index
+        zvarIndex = dlg.zvar_index
+        name = dlg.variable_name
+
+# start of main
+if __name__ == "__main__":    
+
+    # Declare the list of acceptable program options.
+    longOptions = ['input=', 'output=', 'help', 'debug']
+
+    # Parse the program arguments and place them in convenient format in "options"
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'dh', longOptions)
+        options = dict()
+        for o,a in optlist:
+            options[o] = a
+        if args:
+            raise getopt.GetoptError('Unexpected command line option: ' + repr(' '.join(args)))
+    except getopt.GetoptError as e:
+        PrintFlush('Error parsing arguments:')
+        PrintFlush(e)
+        PrintFlush('Run "MapProgressVar.py --help" to see options.')
+        sys.exit(1)
+
+    MapProgressVarStart(options)
+    sys.exit()

--- a/interfaces/cython/cantera/examples/onedim/PDFScriptParallelCVarCppTrapz.py
+++ b/interfaces/cython/cantera/examples/onedim/PDFScriptParallelCVarCppTrapz.py
@@ -1,0 +1,649 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+# python imports
+from scipy.stats import beta as Beta
+from scipy.interpolate import RectBivariateSpline    # Potential use in Stanford flamelet models B, C, and D
+from scipy.interpolate import UnivariateSpline
+from scipy.integrate import trapz
+import matplotlib.pyplot as plt
+from matplotlib import cm
+import numpy as np
+import sys
+import getopt
+from mpl_toolkits.mplot3d import axes3d,Axes3D
+import time
+import tkinter
+from tkinter import ttk
+from multiprocessing import Process, Pipe
+from collections import OrderedDict
+
+# UDRI imports
+from convolute import PyConvolute, PyCreateOutputFile
+from table_def import TableDef
+from Utils import PrintFlush
+from Graphics import PlotDlg
+   
+# FlameletsFileHandler class - responsible for reading input file 
+# and creating a dictionary of variable data 
+# used by all processes
+class FlameletsFileHandler():
+
+    def __init__(self, fileName):
+        self._numSpecies = 0
+        self._zMean = []
+        self._cMean = []
+        self._pressure = 0
+        self._numSpecies = 0 		
+        self._gridPoints = 0
+        self._variableDict = OrderedDict()
+        self._input = open(fileName,'r')
+
+    @property
+    def variableDictionary(self):
+        '''dictionary containing all species values'''
+        return self._variableDict
+
+    @property
+    def zMean(self):
+        '''zMean'''
+        return self._zMean
+
+    @property
+    def cMean(self):
+        '''cMean'''
+        return self._cMean
+
+    @property
+    def pressure(self):
+        '''pressure'''
+        return self._pressure
+		
+    @property
+    def numSpecies(self):
+        '''numSpecies'''
+        return self._numSpecies
+		
+    # reads in a data set header
+    def _ReadHeader(self):
+        body = False
+        temp = self._input.readline()
+        while body == False and temp != "":
+            textArray = temp.strip().split()
+            name = textArray[0]
+            if name == 'NUMOFSPECIES':
+                self._numSpecies = int(textArray[1])
+            elif name == 'PRESSURE':
+                self._pressure = float(textArray[1])
+            elif name == 'Z':
+                self._zMean.append(float(textArray[1]))
+            elif name == 'GRIDPOINTS':
+                self._gridPoints = int(textArray[1])
+            elif name == 'BODY':
+                body = True
+            if body == False:
+                temp = self._input.readline()
+        return body
+
+    # reads in all data associatted with a variable
+    def _ReadVariable(self):
+        varName = self._input.readline().strip()
+        varArray = []
+        if varName != "":
+            count = 0
+            while (count < self._gridPoints):
+                templine = self._input.readline().strip().split(' ')
+                count += len(templine)
+                for entry in templine:
+                    # convert text to float and add it to the end of the array
+                    temp = float(entry)
+                    varArray.append(temp)
+        return varName, varArray
+
+    # read in the input file and assign data to a dictionary of variables
+    def Read(self):
+        body = self._ReadHeader()
+        while body == True:    
+            varName, varArray = self._ReadVariable()
+            while varName != "":
+                if varName == 'REACTION_PROGRESS':
+                    if self._cMean == []:
+                        self._cMean = varArray
+                else:
+                    if varName in self._variableDict.keys():
+                        self._variableDict[varName].append(varArray)
+                    else:
+                        self._variableDict[varName] = [varArray]
+                varName, varArray = self._ReadVariable()
+            body = self._ReadHeader()
+        self._input.close()
+
+
+# Determine betas for Z
+def BetaPDF(realization, MEAN, GAMMA):
+    alpha = MEAN*GAMMA
+    beta = (1-MEAN)*GAMMA
+    output = Beta.pdf(realization,alpha,beta)
+    return output
+    
+def BetaCDF(realization, MEAN, GAMMA):
+    alpha = MEAN*GAMMA
+    beta = (1-MEAN)*GAMMA
+    output = Beta.cdf(realization,alpha,beta)
+    return output
+
+def GetZVar(nZVar):
+    ZVar = [0]      # Not used in laminar implementation
+    if nZVar > 1:
+        variances = np.logspace(-6.64386,0.0,nZVar-1,endpoint=True,base=2)
+        for log in variances:
+            ZVar.append(round(log,4))
+    return ZVar
+
+def GetCVar(nCVar):
+    CVar = [0]      # Not used in Stanford implementation
+    if nCVar > 1:
+        variances = np.logspace(-6.64386,0.0,nCVar-1,endpoint=True,base=2)
+        for log in variances:
+            CVar.append(round(log,4))
+    return CVar
+    
+
+# convolution - create as a process - one for each variable
+def Convolution(name, filename, nZVar, nCVar, outPipe):
+
+    PrintFlush("Convolution process active - initializing: " + name)
+
+    # read input file into a dictionary of variable data
+    inputFileHandler =  FlameletsFileHandler(filename)
+    inputFileHandler.Read()
+    variableDict = inputFileHandler.variableDictionary
+    ZMean = inputFileHandler.zMean
+    CMean = inputFileHandler.cMean
+    zmeanLen = len(ZMean)
+    cmeanLen = len(CMean)
+
+    # start initialization timer
+    betastart = time.clock()
+
+    # Prepare convenience variables for the Farve-averaged calculations
+    x = np.array(ZMean)
+    y = np.array(CMean)
+    xLen = len(x)
+    yLen = len(y)
+    max_y = max(y)
+
+    # Initialize statistical properties of interest    
+    ZVar = GetZVar(nZVar)
+    CVar = GetCVar(nCVar)
+
+    #convenient lengths of cvar and zvar
+    zvarLen = len(ZVar)
+    cvarLen = len(CVar)
+    
+    # calculate Gamma
+    Gamma = np.zeros((len(ZVar)))
+    for zvarIndex, zvar in enumerate(ZVar[1:]):
+        if zvar != 1.0:
+            Gamma[zvarIndex+1] = (1/zvar) - 1
+
+    # calculate Gamma2
+    Gamma2 = np.zeros((len(CVar)))
+    for cvarIndex, cvar in enumerate(CVar[1:]):
+        if cvar != 1.0:
+            Gamma2[cvarIndex+1] = (1/cvar) - 1
+
+    # Calculate values of the beta distribution
+    Betas = np.zeros((zmeanLen, zmeanLen, zvarLen), dtype = np.double)
+    for i in range(1,zvarLen):
+        for j in range(1, zmeanLen-1):
+            Betas[:, j, i] = BetaPDF(x,ZMean[j],Gamma[i])
+
+    # Correcting the edges of the distribution from inside outwards
+    for i in range(1,zvarLen):
+        for j in range(1, zmeanLen-1):
+            for k in range(xLen):
+                if np.isinf(Betas[k,j,i]) or Betas[k,j,i] > 20.0:
+                    Betas[k,j,i] = 20.0  
+        
+    Betas2 = np.zeros((cmeanLen, cmeanLen, cvarLen), dtype=np.double)
+    for i in range(1, cvarLen):
+        for j in range(1, cmeanLen-1):
+            Betas2[:, j, i] = BetaPDF(y/max_y,CMean[j]/max_y,Gamma2[i])            
+    
+    # Correcting the edges of the distribution from inside outwards
+    for i in range(1,cvarLen):
+        for j in range(1, cmeanLen-1):
+            for k in range(yLen):
+                if np.isinf(Betas2[k,j,i]) or Betas2[k,j,i] > 20.0:
+                    Betas2[k,j,i] = 20.0
+    """
+    if name == 'TEMPERATURE':
+        fig = plt.figure()
+        for i in range(1,zvarLen):
+             for j in range(1, zmeanLen-1):
+                plt.title("Zvar = %6.3f and Zmean = %12.8f" % (ZVar[i], ZMean[j]))
+                plt.plot(x, Betas[:,j,i], figure = fig)
+                plt.pause(1)
+                plt.clf()
+    """
+    betaend = time.clock()
+    PrintFlush('Initialization time (secs): ' + str((betaend-betastart)))
+
+    # create output arrays
+    zx = np.zeros(len(x))
+    zy = np.zeros(len(y))
+    zz = np.zeros((len(x), len(y)))
+
+    # retrieve data from dictionary for this species
+    dictEntry = np.array(variableDict[name])
+
+    # create contiguous arrays for use by C++
+    cBetas = np.ascontiguousarray(Betas, dtype=np.double)
+    cBetas2 = np.ascontiguousarray(Betas2, dtype = np.double)
+    cDictEntry = np.ascontiguousarray(dictEntry, dtype = np.double)
+    cZz = np.ascontiguousarray(zz, dtype = np.double)
+    cZx = np.ascontiguousarray(zx, dtype = np.double)
+    cZy = np.ascontiguousarray(zy, dtype = np.double)
+
+    # create C++ processing object and tell it what arrays to use
+    conv = PyConvolute(name)
+    conv.set_betas(cBetas)
+    conv.set_betas2(cBetas2)
+    conv.set_dict_entry(cDictEntry)
+    conv.set_zz(cZz)
+    conv.set_zx(cZx)
+    conv.set_zy(cZy)
+
+    # create array for zmean results to send to pipe
+    pipe_results = np.zeros((zmeanLen), dtype=np.double)
+    
+    PrintFlush("Convolution process initialization complete for: " + name)
+
+    maxValue =  np.max(dictEntry)    
+    
+    # process the input data for the given species 
+    # and send array of zmean results to the file process        
+    for cvarIndex, cvar in enumerate(CVar):
+        for zvarIndex, zvar in enumerate(ZVar):
+            for cmeanIndex, cmean in enumerate(CMean):
+                for zmeanIndex, zmean in enumerate(ZMean):
+                    if zvar == 0.0 and cvar == 0.0:
+                        result = dictEntry[zmeanIndex, cmeanIndex]
+                    elif zvar != 1.0 and cvar != 1.0:
+                        conv.eval(cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex)
+                    if zvar != 0.0 and zvar != 1.0 and cvar == 0.0:
+                        result = trapz(cZx,x)
+                    if zvar == 0.0 and cvar != 0.0 and cvar != 1.0:
+                        result = trapz(cZy,y)/max_y
+                    if zvar != 0.0 and zvar != 1.0 and cvar != 0.0 and cvar != 1.0:
+                        result = trapz(trapz(Betas[:,zmeanIndex,zvarIndex] * dictEntry[zmeanIndex,cmeanIndex],x)*Betas2[:,cmeanIndex,cvarIndex], y/max_y)
+                    if zvar == 1.0 or cvar == 1.0:
+                        result = np.average(dictEntry[0,:]) * (1.0 - zmean) + np.average(dictEntry[-1,:]) * zmean                        
+                    if np.isinf(result) or np.isnan(result):
+                        result = 1.0e-30
+                    if name == 'TEMPERATURE' or name == 'mu' or name == 'TC' or name == 'PREMIX_CDOT':
+                        if result > maxValue:
+                           result = maxValue
+
+                    # save result in output array
+                    pipe_results[zmeanIndex] = result
+                
+                
+                leftBndry = dictEntry[0,cmeanIndex]    #air side
+                rightBndry = dictEntry[-1,cmeanIndex]  #fuel side
+                if name == 'rho':
+                    leftBndry = 1 / leftBndry
+                    rightBndry = 1 / rightBndry
+
+                # Corrections to the edges of the tables are needed when convoluted
+                if (zvar != 0.0 and zvar != 1.0) or (cvar != 0.0 and cvar != 1.0):
+                    if name == 'TEMPERATURE' or name == 'mu' or name == 'TC' or name == 'Cp' or name == 'rho':
+                        for zmeanIndex in range(len(ZMean)):
+                            if pipe_results[zmeanIndex] < leftBndry:
+                                pipe_results[zmeanIndex] = leftBndry * (1.0 - ZMean[zmeanIndex]) + rightBndry * ZMean[zmeanIndex]
+                            else:
+                                break
+                        for zmeanIndex in range(len(ZMean)-1,-1,-1):
+                            if pipe_results[zmeanIndex] < rightBndry:
+                                pipe_results[zmeanIndex] = leftBndry * (1.0 - ZMean[zmeanIndex]) + rightBndry * ZMean[zmeanIndex]
+                            else:    
+                                break    
+                    if name == 'rho':
+                        for zmeanIndex in range(len(ZMean)):
+                            pipe_results[zmeanIndex] = 1 / pipe_results[zmeanIndex]
+                    
+                    elif name == 'MMW':
+                        if rightBndry > leftBndry:
+                            for zmeanIndex in range(len(ZMean)):
+                                if pipe_results[zmeanIndex] < leftBndry:
+                                    pipe_results[zmeanIndex] = leftBndry * (1.0 - ZMean[zmeanIndex]) + rightBndry * ZMean[zmeanIndex]
+                                else:
+                                    break
+                            for zmeanIndex in range(int(len(ZMean)/2)+1,len(ZMean)):                        
+                                if pipe_results[zmeanIndex] < pipe_results[zmeanIndex-1] or pipe_results[zmeanIndex] > rightBndry:
+                                    pipe_results[zmeanIndex] = leftBndry * (1.0 - ZMean[zmeanIndex]) + rightBndry * ZMean[zmeanIndex]
+                        elif rightBndry < leftBndry: 
+                            for zmeanIndex in range(int(len(ZMean)/2),-1,-1):
+                                if pipe_results[zmeanIndex] < pipe_results[zmeanIndex+1] or pipe_results[zmeanIndex] > leftBndry:
+                                    pipe_results[zmeanIndex] = leftBndry * (1.0 - ZMean[zmeanIndex]) + rightBndry * ZMean[zmeanIndex]                          
+                            for zmeanIndex in range(len(ZMean)-1,-1,-1):                        
+                                if pipe_results[zmeanIndex] < rightBndry:
+                                    pipe_results[zmeanIndex] = leftBndry * (1.0 - ZMean[zmeanIndex]) + rightBndry * ZMean[zmeanIndex]
+                                else:
+                                    break      
+                        elif rightBndry == leftBndry:
+                            for zmeanIndex in range(len(ZMean)):
+                                if pipe_results[zmeanIndex] < leftBndry:
+                                    pipe_results[zmeanIndex] = leftBndry
+
+                    pipe_results[0] = dictEntry[0, cmeanIndex]
+                    pipe_results[-1] = dictEntry[-1, cmeanIndex]
+                    if cmeanIndex == 0:
+                        for zmeanIndex in range(len(ZMean)):                        
+                            pipe_results[zmeanIndex] = dictEntry[zmeanIndex, cmeanIndex]
+
+                # send output array to main file process via pipe
+                outPipe.send(pipe_results)
+                
+        
+    PrintFlush("Convolution process exiting " + name)
+
+# output axis data (cmean, fmean, etc.) supporting a compressed file format
+def OutputAxisData(output, axisName, axisData):
+    output.write('[%s]\n' % (axisName))
+    columnCount = 0
+    for axisValue in axisData:
+        output.write('%10.6e\t'% axisValue)
+        columnCount += 1
+        if columnCount >= 20:
+            output.write('\n')
+            columnCount = 0
+    if columnCount != 0:
+        # terminate partial line
+        output.write('\n')
+
+# help
+def printhelp():
+    # If the user requests help, display documentation.
+    PrintFlush("""
+    PDFScript.py: Compute the PDF table from a Cantera flamelet table.
+
+    Usage:
+    Script for Alex.py [--input=<filename>]
+                       [--output=<filename>]
+                       [--help]
+                       [--debug]
+                       [--compress]
+
+    Example:
+    PDFScript.py --input=flamelet.txt --output=newflamelet.txt
+
+    An input file must be specified from the program to run. It should be of the FLUENT flamelet table format.
+    All tables must have the same grid size for the program to work properly.    
+    
+    If the output file name is not given, one will be automatically generated.
+    This automatic output file will be the same as the input file, with the name having "new" appended.
+
+    """)
+    sys.exit(1)
+
+# start of PdfScript function
+def PdfScriptStart(options):        
+    
+    # set plot mode to interactive
+    plt.ion()
+    init_plot = True
+
+    #start the clock
+    timestart = time.clock()
+
+    # read in table definition file
+    table = TableDef()
+    if table.Read() != True:
+        return
+    
+    """
+    Obtained from Flamelet tab: Pass in the number of variances to use for Z (mixture fraction) and C (progress variable)
+    """    
+    nZVar = table.nZVar
+    nCVar = table.nCVar
+    """
+    End variable passing; note that "0" variance number is the same as a laminar calculation
+    """
+
+    if '--help' in options:
+        #printhelp()
+        placefiller = 1
+
+    if '--input' in options:    
+        # If the user specifies an input file, open that file
+        inputFile = options['--input']
+    else:
+        # if not specified - use default
+        inputFile = "inverted_diffusion_flamelets.fla"
+
+    if '--output' in options:
+        # If the user specifies an output file, open that file
+        outputFile = options['--output']
+    else:
+        # Without an output file specified, create default automatically
+        outputFile = "CVar FPV "+str(table.fuel)+", "+str(round(table.pressure/101325,1))+"atm, "+str(round(table.Tfuel))+"K Inlet.fla"
+    output = open(outputFile,'w')
+
+    if '--compress' in options:
+        compressed = True
+        PrintFlush('Creating compressed output file')
+    else:
+        compressed = False
+        PrintFlush('Creating original format output file')
+
+    # Initialize statistical properties of interest    
+    ZVar = GetZVar(nZVar)
+    PrintFlush("SMix=",ZVar)
+    PrintFlush()
+    CVar = GetCVar(nCVar)            
+    PrintFlush("SMixC=",CVar)
+    PrintFlush()
+
+    # Read input file into a dictionary of species data
+    inputFileHandler =  FlameletsFileHandler(inputFile);
+    inputFileHandler.Read()
+    variable_dictionary = inputFileHandler.variableDictionary
+    ZMean = inputFileHandler.zMean
+    CMean = inputFileHandler.cMean
+
+    # create lengths
+    zmeanLen = len(ZMean)
+    cmeanLen = len(CMean)
+    cvarLen = len(CVar)
+    zvarLen= len(ZVar)
+
+    #create list of keys with order rearranged
+    keyList = list(variable_dictionary.keys())
+    keyList.remove('PREMIX_CDOT');
+    index = keyList.index('TC');
+    keyList.insert(index+1, 'PREMIX_CDOT');
+
+    # Initialize the dictionary containing variable matrix that will be used to visualize the output in 3D
+    plotDict = OrderedDict()
+    for name in list(variable_dictionary.keys()):
+        plotDict[name] = np.zeros((cvarLen, zvarLen, cmeanLen, zmeanLen))
+
+    # Create and start a Convolution process for each variable name and add it to dictionary.
+    # Each process is assigned a half-duplex pipe.
+    processDict = OrderedDict()
+    for name in keyList:
+        inputPipe, outputPipe = Pipe(duplex=False)
+        p = Process(target= Convolution, args=(name, inputFile, nZVar, nCVar, outputPipe))
+        processDict[name] = [p, inputPipe]
+        p.start()
+
+    # Print the output file header
+    if table.model == "FPI":
+        output.write('FLAMELET PROLONGATION OF ILDM\n\n')
+    else:
+        output.write('FLAMELET PROGRESS VARIABLE\n\n')
+    output.write('[NUMBER_FMEAN]\n')
+    output.write(str(len(ZMean)) + '\n')
+    output.write('[NUMBER_CPROGRESS]\n')
+    output.write(str(len(CMean)) + '\n')
+    output.write('[NUMBER_FVAR]\n')
+    output.write(str(len(ZVar)) + '\n')
+    output.write('[NUMBER_CVAR]\n')
+    output.write(str(len(CVar)) + '\n')
+    output.write('[NUMBER_SPECIES]\n')
+    output.write(str(len(table.YQOI)) + '\n')
+    output.write('[NUMBER_QOI]\n')
+    output.write(str(len(keyList)-len(table.YQOI)) + '\n')
+    output.write('[NUMBER_VARIABLES]\n')
+    output.write(str(len(keyList)+4) + '\n')  # 4 statistical variables
+    if (compressed == True):
+        OutputAxisData(output, 'FMEAN', ZMean)
+        OutputAxisData(output, 'CMEAN', CMean)
+        OutputAxisData(output, 'FVAR', ZVar)
+        OutputAxisData(output, 'CVAR', CVar)
+    output.write('[DATA]\n')
+    if compressed == False:
+        output.write('fmean\tcmean\tfvar\tcvar\t')    
+    for variable_name in keyList:
+        output.write(variable_name + '\t')
+    output.write('\n')
+    output.close()
+
+    # create contiguous numpy arrays needed by C++ CreateOutputFile
+    outputArray = np.zeros((len(keyList), zmeanLen), dtype=np.double)
+    cOutputArray = np.ascontiguousarray(outputArray, dtype = np.double)
+    cZMean = np.ascontiguousarray(ZMean, dtype = np.double)
+    c_output = PyCreateOutputFile(outputFile, cOutputArray, cZMean, compressed)
+
+    # Cycle through all possible statistical situations
+    for cvarIndex, cvar in enumerate(CVar):           
+        for zvarIndex, zvar in enumerate(ZVar):
+            cmeanstart = time.clock()
+            for cmeanIndex, cmean in enumerate(CMean):
+
+                # receive zmean arrays from each of the convolution processes
+                for outIndex, variable_name in enumerate(keyList):
+                    cOutputArray[outIndex] = processDict[variable_name][1].recv()
+                    plotDict[variable_name][cvarIndex, zvarIndex, cmeanIndex] = cOutputArray[outIndex]
+
+                #write array of zmean values to output file
+                c_output.write(cvar, zvar, cmean)
+            
+            cmeanend = time.clock()
+            PrintFlush("***** cvar = ", cvar, " zvar = ", zvar," time (secs): " + str((cmeanend-cmeanstart)))
+          
+    # Close the output file
+    c_output.close()
+
+    timeend = time.clock()
+    PrintFlush('Total execution time (hr): ', (timeend-timestart)/3600)
+       
+    # display plot dialog
+    dlg = PlotDlg(CVar, ZVar, 0, 0, keyList, keyList[0])
+    retrySolve = dlg.WaitResult()
+    cvarIndex = dlg.cvar_index
+    zvarIndex = dlg.zvar_index
+    name = dlg.variable_name
+
+    plotLabel = {}
+    plotLabel['TEMPERATURE'] = 'Temperature, T [K]'
+    plotLabel['mu'] = 'Dynamic Viscosity, $\mu$ [kg/m-s]'
+    plotLabel['TC'] = 'Thermal Conductivity, k [W/m-K]'
+    plotLabel['PREMIX_CDOT'] = 'Progress Variable Source, S$_C$ [kg/m^3/s]'
+    plotLabel['MMW'] = 'Molecular Weight, MW [kg/kmol]'
+    plotLabel['rho'] = r'$\mathrm{Density, \rho  [kg/m^3]}$'
+    plotLabel['Cp'] = 'Specific Heat Capacity, C$_p$ [J/kg-K]'
+
+    # plot variable profile
+    while retrySolve == True:
+        PrintFlush("plotting variable = ", name, " cvar = ", cvarIndex, " zvar = ", zvarIndex)
+        if name in plotLabel:
+            label = plotLabel[name]
+        elif name.find('net_rxn-') != -1:
+            label = name.replace('net_rxn-', '')
+            label = label + ' Net Reaction Rate [kg/m$^3$-s]'
+        elif name.find('massfraction-') != -1:
+            label = name.replace('massfraction-', '')
+            label = label + ' Mass Fraction'
+        else:
+            label = name
+        fig = plt.figure(0)
+        ax = Axes3D(fig)
+        ZMeanAxis,CMeanAxis = np.meshgrid(ZMean,CMean)
+        ax.plot_surface(ZMeanAxis,CMeanAxis,plotDict[name][cvarIndex, zvarIndex,:,:],rstride=1,cstride=1,cmap=cm.jet,antialiased=False)
+        plt.ylabel(r'Progress Parameter, $\lambda$')
+        plt.xlabel("Mixture Fraction, Z")
+        plt.xlim(0,1)
+        plt.ylim(0,1)
+        ax.set_zlabel(label)
+        ax.view_init(15,-130)
+        plt.title(str(table.fuel)+"-"+str(table.oxidizer)+", T$_{Fuel}$="\
+        +str(round(table.Tfuel))+"K"+", T$_{Oxidizer}$="+str(round(table.Toxidizer))\
+        +"K, P$_{Op}$="+str(round(table.pressure/101325,1))+"atm")
+        txtstr = r'Scaled Z$_{var}$ = '+str(ZVar[zvarIndex]) \
+               +r'  Scaled C$_{var}$ = '+str(CVar[cvarIndex])
+        ax.text2D(0.30, 0.87, txtstr, transform=ax.transAxes, fontsize=12)
+        if init_plot:
+            # only position initially, allows user to move afterwards
+            mgr = plt.get_current_fig_manager()
+            mgr.window.wm_geometry("+50+400")
+            init_plot = False
+       
+        # display plot dialog
+        dlg = PlotDlg(CVar, ZVar, cvarIndex, zvarIndex, keyList, name)
+        retrySolve = dlg.WaitResult()        
+        cvarIndex = dlg.cvar_index
+        zvarIndex = dlg.zvar_index
+        name = dlg.variable_name
+
+# start of main
+if __name__ == "__main__":    
+
+    # Declare the list of acceptable program options.
+    longOptions = ['input=', 'output=', 'help', 'debug', 'nocompress']
+
+    # Parse the program arguments and place them in convenient format in "options"
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'dh', longOptions)
+        options = dict()
+        for o,a in optlist:
+            options[o] = a
+        if args:
+            raise getopt.GetoptError('Unexpected command line option: ' + repr(' '.join(args)))
+    except getopt.GetoptError as e:
+        PrintFlush('Error parsing arguments:')
+        PrintFlush(e)
+        PrintFlush('Run "PDFScript.py --help" to see options.')
+        sys.exit(1)
+
+    PdfScriptStart(options)
+    sys.exit()
+       

--- a/interfaces/cython/cantera/examples/onedim/TableInversionFPV.py
+++ b/interfaces/cython/cantera/examples/onedim/TableInversionFPV.py
@@ -1,0 +1,296 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+import numpy as np
+import sys
+import getopt
+import time
+from collections import OrderedDict
+from table_def import TableDef
+from Utils import PrintFlush
+
+def printhelp():
+	# If the user requests help, display documentation.
+    PrintFlush("""
+    TableInversionFPV.py: Compute the inverted table from a Cantera flamelet table.
+
+    Usage:
+    TableInversionFPV.py [--input=<filename>]
+                       [--output=<filename>]
+                       [--help]
+                       [--debug]
+
+    Example:
+    TableInversionFPV.py --input=flamelet.txt --output=newflamelet.txt
+
+    An input file must be specified from the program to run. It should be of the FLUENT flamelet table format.
+    All tables must have the same grid size for the program to work properly.	
+	
+    If the output file name is not given, one will be automatically generated.
+    This automatic output file will be the same as the input file, with the name having "new" appended.
+
+    """)
+    sys.exit(1)
+
+def tabletoarray(input, lastlocation):
+    
+	# Initialize the array to be constructed
+    thearray=[]
+    input.seek(lastlocation)
+	
+    while(1):
+        try:
+            # Read the next line and partition it into chunks divided by spaces
+            lastposition = input.tell()
+            templine = input.readline().rstrip().split(' ')
+            for entry in templine:
+                # Read each chunk as a float and add it to the end of the array
+                temp = float(entry)
+                thearray.append(temp)
+        except Exception as e:
+            # If a character cannot be parsed as a float, end the array
+            input.seek(lastposition)
+            break
+    
+	# Return the resulting array
+    return thearray
+
+def TableInvertFPV(options):	
+    PrintFlush("Start flamelet Inversion of FPV type")
+
+    timestart = time.clock()
+        
+    # read in table definition file
+    table = TableDef()
+    table.Read()
+	
+    """
+    ********************* output control tab ****************************
+    """
+    YQOI = table.YQOI #user chooses species mass fraction to output
+    RRQOI = table.RRQOI  # user chooses species net reaction rates (kg/m^3-s) to output
+    """
+    ***************************end of output control tab*******************************
+    """
+
+    if '--help' in options:
+        printhelp()
+	
+    if '--input' in options:	
+	    # If the user specifies an input file, open that file
+        inputFile = options['--input']
+        input = open(inputFile,'r')	
+    else:
+	    # Without an input specified, notify the user and close the program
+        inputFile = None
+        PrintFlush("You must specify an input file.")
+        sys.exit(1)
+
+    if '--output' in options:
+	    # If the user specifies an output file, open that file
+        outputFile = options['--output']
+        file = open(outputFile,'w')
+    else:
+	    # Without an output file specified, create one automatically
+        file = open("inverted_" + inputFile,'w')
+	
+	# Initialize variables that will be used during iteration through the input file
+    tempstring = 'something'
+    ZMean = []
+    CMean = []	
+    variable_dictionary = OrderedDict()
+	
+    while tempstring != '':	
+		# Store the last read line in a convenient place	
+        lastline = tempstring
+        lastlocation = input.tell()
+        tempstring = input.readline()
+        try:
+			# Attempt to read the next line and partition it into chunks divided by spaces
+            templine = tempstring.rstrip().split(' ')
+            for entry in templine:
+                # Attempt to read each chunk as a float
+                temp = float(entry)
+            
+			# If the reading is successful, store this chunk of text to an array
+            temptable = tabletoarray(input, lastlocation)
+            
+			# If this array is also an independent variable, store it as such
+            if lastline.startswith("MIXTURE"):
+                if ZMean==[]:
+                    # Read the first table of Cmean values, then ignore the rest
+                    ZMean = temptable
+                else:
+                    ZMean = ZMean
+            # Otherwise, attempt to add the array to the relevant variable's array
+            else:
+                try:
+                    # If the variable is already in memory, append the new values
+                    variable_dictionary[lastline.rstrip()].append(temptable)
+                except Exception as e:
+                    # If the variable is not already in memory, create an entry for it and start the new array
+                    variable_dictionary[lastline.rstrip()] = [temptable]
+
+        except Exception as e:
+			# If the line cannot be parsed as a table, see if it can be parsed 
+			# as a relevant flamelet parameter
+            if templine[0].startswith("NUMOF"):
+                numberofspecies = int(templine[-1])
+            if templine[0].startswith("C") and not templine[0].startswith("Cp"):
+                CMean.append(float(templine[-1]))
+            if templine[0].startswith("PRESSURE"):
+                pressure = float(templine[-1])
+
+	# Debug line: make sure all keys are being captured from the input file
+    # PrintFlush(list(variable_dictionary.keys()))
+
+	# Reverse C and Z due to the normal operation of the diffusion domain
+    ZMean.reverse()
+    CMean.reverse()
+    premix_chi = 0
+	
+    for mixture_fraction in ZMean:
+	
+        # Storing flamelet information
+        # Header information for flamelets
+        file.write('HEADER\n')
+        file.write('PREMIX_CHI %.4f\n' % premix_chi)
+        file.write('Z  %15.9e\n' % mixture_fraction)
+        file.write('NUMOFSPECIES	%3d\n' % numberofspecies)
+        file.write('GRIDPOINTS	%3d\n' % (len(CMean)))
+        file.write('PRESSURE %6.2f\n' % pressure)
+        file.write('BODY\n')
+        file.write('REACTION_PROGRESS\n')
+
+        # Write progress variable
+        for j in range(0,len(CMean)):  
+            progress_variable = CMean[j] #/ max(CMean)     # NON-NORMALIZED TABLE
+            file.write('%15.9e '% progress_variable)
+            if ((j+1)%5==0 and (j+1) != len(CMean)):
+                file.write('\n')		
+		
+        # Write temperature
+        file.write('\nTEMPERATURE\n')
+        for j in range(0,len(CMean)):
+            file.write('%15.9e '% variable_dictionary['TEMPERATURE'][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+            if ((j+1)%5==0 and (j+1) != len(CMean)):
+                file.write('\n')			
+       
+    	# Write heat capacity (not possible in FLUENT)
+        file.write('\nCp\n')
+        for j in range(0,len(CMean)):
+            file.write('%15.9e '% variable_dictionary['Cp'][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+            if ((j+1)%5==0 and (j+1) != len(CMean)):
+                file.write('\n')	
+			
+	    # Write mean molecular weight (not possible in FLUENT)
+        file.write('\nMMW\n')
+        for j in range(0,len(CMean)):
+            file.write('%15.9e '% variable_dictionary['MMW'][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+            if ((j+1)%5==0 and (j+1) != len(CMean)):
+                file.write('\n')	
+
+        # # Write density (not possible in FLUENT)
+        file.write('\nrho\n')
+        for j in range(0,len(CMean)):
+            file.write('%15.9e '% variable_dictionary['rho'][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+            if ((j+1)%5==0 and (j+1) != len(CMean)):
+                file.write('\n')
+			
+        # Write viscosity (not possible in FLUENT)
+        file.write('\nmu\n')
+        for j in range(0,len(CMean)):
+            file.write('%15.9e '% variable_dictionary['mu'][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+            if ((j+1)%5==0 and (j+1) != len(CMean)):
+                file.write('\n')
+			
+        # Write thermal conductivity (not possible in FLUENT)
+        file.write('\nTC\n')
+        for j in range(0,len(CMean)):
+            file.write('%15.9e '% variable_dictionary['TC'][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+            if ((j+1)%5==0 and (j+1) != len(CMean)):
+                file.write('\n')
+			
+    	# Write net production rates (not possible in FLUENT)
+        for name in RRQOI:
+            file.write('\nnet_rxn-'+name+'\n')
+            for j in range(0,len(CMean)):
+                file.write('%15.9e '% variable_dictionary['net_rxn-'+name][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+                if ((j+1)%5==0 and (j+1) != len(CMean)):
+                    file.write('\n')				
+    				
+        # Write species mass fractions
+        for name in YQOI:        # Sykes changed to include only select species in output
+            species_name = 'massfraction-'+name
+            file.write('\n'+species_name+'\n')
+            for j in range(0,len(CMean)):
+                file.write('%15.9e '% variable_dictionary[species_name][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+                if ((j+1)%5==0 and (j+1) != len(CMean)):
+                    file.write('\n')
+			
+        # Writing reaction progress source (Needed for FLUENT FPI calculations)
+        file.write('\nPREMIX_CDOT\n')
+        file.write('%15.9e '% 0)
+        for j in range(1,len(CMean)-1):
+            file.write('%15.9e '% variable_dictionary['PREMIX_CDOT'][len(CMean)-j-1][len(ZMean) - ZMean.index(mixture_fraction) - 1])
+            if ((j+1)%5==0 and (j+1) != len(CMean)):
+                file.write('\n')
+        file.write('%15.9e '% 0)
+
+        # Generate a new premix_chi each time for the sake of FLUENT
+        premix_chi += 0.0001
+		
+        file.write('\n')
+        file.write('\n')    
+    
+    timeend = time.clock()
+    PrintFlush('Table inversion total execution time (sec): ', (timeend-timestart))
+
+
+if __name__ == "__main__":		
+	
+    # Declare the list of acceptable program options.
+    longOptions = ['input=', 'output=', 'help', 'debug']
+
+    # Parse the program arguments and place them in convenient format in "options"
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'dh', longOptions)
+        options = dict()
+        for o,a in optlist:
+            options[o] = a
+        if args:
+            raise getopt.GetoptError('Unexpected command line option: ' + repr(' '.join(args)))
+    except getopt.GetoptError as e:
+        PrintFlush('Error parsing arguments:')
+        PrintFlush(e)
+        PrintFlush('Run "TableInversionFPV.py --help" to see options.')
+        sys.exit(1)
+
+    TableInvertFPV(options)
+    sys.exit(0)

--- a/interfaces/cython/cantera/examples/onedim/TablePreMapFPV.py
+++ b/interfaces/cython/cantera/examples/onedim/TablePreMapFPV.py
@@ -1,0 +1,212 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+import numpy as np
+import sys
+import getopt
+import os
+#UDRI imports
+from table_def import TableDef
+from Utils import PrintFlush
+from PDFScriptParallelCVarCppTrapz import FlameletsFileHandler
+from MapProgressVar import ParallelRemeshing, RemeshTable, InputFileHandler
+# UDRI C++ imports
+from convolute import PyCreateDiffusionFlameletsFile
+
+def printhelp():
+	# If the user requests help, display documentation.
+    PrintFlush("""
+    TablePreMapFPV.py: Compute the inverted table from a Cantera flamelet table.
+
+    Usage:
+    TablePreMapFPV.py [--input=<filename>]
+                       [--output=<filename>]
+                       [--help]
+                       [--debug]
+
+    Example:
+    TablePreMapFPV.py --input=flamelet.txt --output=newflamelet.txt
+
+    An input file must be specified from the program to run. It should be of the FLUENT flamelet table format.
+    All tables must have the same grid size for the program to work properly.	
+	
+    If the output file name is not given, one will be automatically generated.
+    This automatic output file will be the same as the input file, with the name having "new" appended.
+
+    """)
+    sys.exit(1)
+def WriteFlamelets(gridpoints, data, i, fast_file, keyList, pressure, numSpecies):
+
+		# write file header
+        fast_file.write_header(np.max(data[i*gridpoints:(i+1)*gridpoints,1]), numSpecies, gridpoints, pressure)
+
+        for k, item in enumerate(keyList):
+            out_array = np.ascontiguousarray(data[i*gridpoints:(i+1)*gridpoints,k], dtype = np.double)
+            fast_file.write_data(out_array, item)
+
+        #write out a few extra cr's
+        fast_file.write_cr()
+	
+def TablePreMapFPV(options):	
+    PrintFlush("Start flamelet Premapping for FPV table")
+        
+    # read in table definition file
+    table = TableDef()
+    table.Read()
+	
+    """
+    ********************* output control tab ****************************
+    """
+    interpolation_type = table.interpolation_type
+    YQOI = table.YQOI #user chooses species mass fraction to output
+    RRQOI = table.RRQOI  # user chooses species net reaction rates (kg/m^3-s) to output
+    """
+    ***************************end of output control tab*******************************
+    """
+
+    if '--help' in options:
+        printhelp()
+	
+    if '--input' in options:	
+	    # If the user specifies an input file, open that file
+        inputFile = options['--input']
+        input = open(inputFile,'r')	
+    else:
+	    # Without an input specified, notify the user and close the program
+        inputFile = None
+        PrintFlush("You must specify an input file.")
+        sys.exit(1)
+
+    if '--output' in options:
+	    # If the user specifies an output file, open that file
+        outputFile = options['--output']
+    else:
+	    # Without an output file specified, create one automatically
+        outputFile = 'premapped_' + inputFile
+	
+    # Read input file into a dictionary of species data
+    inputFileHandler =  FlameletsFileHandler(inputFile);
+    inputFileHandler.Read()
+    variable_dictionary = inputFileHandler.variableDictionary
+    ZMean = inputFileHandler.zMean
+    CMean = inputFileHandler.cMean
+    numSpecies = inputFileHandler.numSpecies
+    pressure = inputFileHandler.pressure	
+
+    #create list of keys with order rearranged
+    keyList = list(variable_dictionary.keys())
+
+    # create lengths
+    zmeanLen = np.shape(variable_dictionary['MIXTURE_FRACTION'])[1]
+    cmeanLen = np.shape(variable_dictionary['PROGRESS VARIABLE'])[0]
+	
+    header = 'FLAMELET PROGRESS VARIABLE\n\n' \
+    +'[NUMBER_FMEAN]\n' \
+    +str(zmeanLen) + '\n' \
+    +'[NUMBER_CPROGRESS]\n' \
+    +str(cmeanLen) + '\n' \
+    +'[NUMBER_FVAR]\n' \
+    +'1\n' \
+    +'[NUMBER_CVAR]\n' \
+    +'1\n' \
+    +'[NUMBER_SPECIES]\n' \
+    +str(len(table.YQOI)) + '\n' \
+    +'[NUMBER_QOI]\n' \
+    +str(len(keyList)-len(table.YQOI)) + '\n' \
+    +'[NUMBER_VARIABLES]\n' \
+    +str(len(keyList)+2) + '\n' \
+    +'[DATA]\n' \
+    +'fmean\t'+'cmean\t'+'fvar\t'+'cvar\t'
+
+    for variable_name in keyList:
+        if variable_name != 'MIXTURE_FRACTION' and variable_name != 'PROGRESS VARIABLE':
+            header += variable_name + '\t'
+
+    data = np.zeros((zmeanLen * cmeanLen, 4), dtype=np.double)
+    for variable_name in keyList:
+        if variable_name != 'MIXTURE_FRACTION' and variable_name != 'PROGRESS VARIABLE':
+            data = np.hstack((data, np.reshape(variable_dictionary[variable_name], (zmeanLen * cmeanLen,1))))
+
+    data[:,0:1]= np.reshape(variable_dictionary['MIXTURE_FRACTION'], (zmeanLen * cmeanLen,1))
+    data[:,1:2]= np.reshape(variable_dictionary['PROGRESS VARIABLE'], (zmeanLen * cmeanLen,1))
+		
+    rdata = np.zeros(np.shape(data), dtype=np.double)
+
+    for j in range(0, cmeanLen):
+	    for i in range(0,zmeanLen):
+			     rdata[j*zmeanLen + i,:] = data[j* zmeanLen + (zmeanLen - 1 - i), :] 
+
+    for j in range(0, cmeanLen):
+	    data[j* zmeanLen: (j+1)*zmeanLen,:] = rdata[(cmeanLen -1 - j)* zmeanLen: (cmeanLen - j)*zmeanLen, :] 
+	
+    #removing negative values of progress variable	
+    for i in range(0, cmeanLen * zmeanLen):
+        if data[i,1:2] < 1e-6 or i < zmeanLen:
+            data[i,1:2] = 0.0
+
+    input.close()
+    tempfile = "temp.txt"
+    np.savetxt(tempfile, data, fmt='%10.6e', header=header, comments='')
+    inputFile = InputFileHandler(tempfile)
+    inputFile.Read()
+
+    B = RemeshTable(inputFile, interpolation_type, inputFile.data)
+    os.remove(tempfile)
+
+    #debug
+    #np.savetxt(outputFile, B, fmt='%10.6e',header=header, comments='')
+
+    B = np.delete(B, 2, axis=1) #remove fvar column
+    B = np.delete(B, 2, axis=1) #remove cvar column
+    B = np.flipud(B)	
+    fast_file = PyCreateDiffusionFlameletsFile(outputFile)
+    for i in range(zmeanLen):
+        WriteFlamelets(zmeanLen, B, i, fast_file, keyList, pressure, numSpecies)
+     
+if __name__ == "__main__":		
+	
+    # Declare the list of acceptable program options.
+    longOptions = ['input=', 'output=', 'help', 'debug']
+
+    # Parse the program arguments and place them in convenient format in "options"
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'dh', longOptions)
+        options = dict()
+        for o,a in optlist:
+            options[o] = a
+        if args:
+            raise getopt.GetoptError('Unexpected command line option: ' + repr(' '.join(args)))
+    except getopt.GetoptError as e:
+        PrintFlush('Error parsing arguments:')
+        PrintFlush(e)
+        PrintFlush('Run "TablePreMapFPV.py --help" to see options.')
+        sys.exit(1)
+
+    TablePreMapFPV(options)
+    sys.exit(0)

--- a/interfaces/cython/cantera/examples/onedim/UnscaleVariances.py
+++ b/interfaces/cython/cantera/examples/onedim/UnscaleVariances.py
@@ -1,0 +1,655 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.? THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+import sys
+import getopt
+import numpy as np
+from scipy.interpolate import interp1d
+from matplotlib import cm
+import matplotlib.pyplot as plt
+from mpl_toolkits.mplot3d import axes3d,Axes3D
+from multiprocessing import Process, Pipe
+from collections import OrderedDict
+
+# UDRI imports
+from table_def import TableDef
+from Utils import PrintFlush
+from Graphics import PlotDlg
+
+# Input FileHandler class - responsible for reading input file 
+class InputFileHandler():
+
+    def __init__(self, fileName):
+        self._fileName = fileName
+        self._numGridpoints = 0     # num fmean
+        self._numFlamelets = 0      # num cmean
+        self._numFvars = 0          # num fvar 
+        self._numVars = 0           # num variables 
+        self._numCvars = 1          # num of cvar
+        self._numSpecies = 0        # num of species
+        self._numQoi = 0            # num QOI
+        self._columnHeader = "none" # column headings
+        self._data = []             # table data
+        self._input = open(fileName,'r')
+        self._variableDict = OrderedDict()
+
+    @property
+    def numGridpoints(self):
+        '''number of fmean values'''
+        return self._numGridpoints
+
+    @property
+    def numFlamelets(self):
+        '''number of cmean values'''
+        return self._numFlamelets
+
+    @property
+    def numFvars(self):
+        '''number of fvar values'''
+        return self._numFvars
+
+    @property
+    def numVars(self):
+        '''number of variables'''
+        return self._numVars
+
+    @property
+    def numCvars(self):
+        '''number of Cvar values'''
+        return self._numCvars
+
+    @property
+    def numSpecies(self):
+        '''number of species'''
+        return self._numSpecies
+
+    @property
+    def numQoi(self):
+        '''number of Qoi values'''
+        return self._numQoi
+
+    @property
+    def columnHeader(self):
+        '''column headings'''
+        return self._columnHeader
+
+    @property
+    def data(self):
+        '''table data'''
+        return self._data
+
+
+    # reads in a data set header and keeps track of number of lines read
+    def _ReadHeader(self):
+        count = 1
+        done = False
+        temp = self._input.readline()
+        while done == False:
+            name = temp.strip()
+            if name == '[NUMBER_FMEAN]':
+                temp = self._input.readline().strip()
+                self._numGridpoints = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_CPROGRESS]':
+                temp = self._input.readline().strip()
+                self._numFlamelets = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_FVAR]':
+                temp = self._input.readline().strip()
+                self._numFvars = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_CVAR]':
+                temp = self._input.readline().strip()
+                self._numCvars = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_SPECIES]':
+                temp = self._input.readline().strip()
+                self._numSpecies = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_QOI]':
+                temp = self._input.readline().strip()
+                self._numQoi = int(temp)
+                count = count + 1
+            elif name == '[NUMBER_VARIABLES]':
+                temp = self._input.readline().strip()
+                self._numVars = int(temp)
+                count = count + 1
+            elif name == '[DATA]':
+                temp = self._input.readline().strip()
+                self._columnHeader = temp
+                done = True
+                count = count + 1
+            if done == False:
+                temp = self._input.readline()
+                count = count + 1
+        return count
+
+    # read in the input file header
+    def Read(self):
+
+        # read in the header and the data
+        lineCount = self._ReadHeader()
+
+        arrayLen = self._numCvars * self._numFvars * self._numFlamelets * self._numGridpoints
+        arrayWidth = self._numVars
+        self._data = np.zeros((arrayLen, arrayWidth), dtype=np.double)
+
+        for i, line in enumerate(self._input):
+            for j, temp in enumerate(line.split()):
+                self._data[i,j] = float(temp)
+
+        # close the file
+        self._input.close()
+
+# OutputFileHandler class - responsible for writing output file 
+class OutputFileHandler():
+
+    def __init__(self, fileName):
+        self._fileName = fileName
+        self._pressure = 0          # pressure
+        self._numGridpoints = 0     # num fmean
+        self._numFlamelets = 0      # num cmean
+        self._numFvars = 0          # num fvar 
+        self._numVars = 0           # num variables 
+        self._numCvars = 1          # num of cvar
+        self._numSpecies = 0        # num of species
+        self._numQoi = 0            # num QOI
+        self._columnHeader = "none" # column headings
+        self._output = open(fileName,'w')
+
+    @property
+    def pressure(self):
+        '''number of fmean values'''
+        return self._pressure
+
+    @pressure.setter
+    def pressure(self, value):
+        self._pressure = value
+
+    @property
+    def numGridpoints(self):
+        '''number of fmean values'''
+        return self._numGridpoints
+
+    @numGridpoints.setter
+    def numGridpoints(self, value):
+        self._numGridpoints = value
+
+    @property
+    def numFlamelets(self):
+        '''number of cmean values'''
+        return self._numFlamelets
+
+    @numFlamelets.setter
+    def numFlamelets(self, value):
+        self._numFlamelets = value
+
+    @property
+    def numFvars(self):
+        '''number of fvar values'''
+        return self._numFvars
+
+    @numFvars.setter
+    def numFvars(self, value):
+        self._numFvars = value
+
+    @property
+    def numVars(self):
+        '''number of variables'''
+        return self._numVars
+
+    @numVars.setter
+    def numVars(self, value):
+        self._numVars = value
+
+    @property
+    def numCvars(self):
+        '''number of Cvar values'''
+        return self._numCvars
+
+    @numCvars.setter
+    def numCvars(self, value):
+        self._numCvars = value
+
+    @property
+    def numSpecies(self):
+        '''number of species'''
+        return self._numSpecies
+
+    @numSpecies.setter
+    def numSpecies(self, value):
+        self._numSpecies = value
+
+    @property
+    def numQoi(self):
+        '''number of Qoi values'''
+        return self._numQoi
+
+    @numQoi.setter
+    def numQoi(self, value):
+        self._numQoi = value
+
+    @property
+    def columnHeader(self):
+        '''column headings'''
+        return self._columnHeader
+
+    @columnHeader.setter
+    def columnHeader(self, value):
+        self._columnHeader = value
+      
+    # write the header and body of file
+    def Write(self, data):
+
+        # Creating Header information for flamelets
+        self._output.write("FLAMELET PROGRESS VARIABLE MAPPED\n\n")
+        self._output.write("%s\n%.1f\n" % ("[PRESSURE]", self._pressure))
+        self._output.write("%s\n%d\n" % ("[NUMBER_FMEAN]", self._numGridpoints))
+        self._output.write("%s\n%d\n" % ("[NUMBER_CPROGRESS]", self._numFlamelets))
+        self._output.write("%s\n%d\n" % ("[NUMBER_FVAR]", self._numFvars))
+        self._output.write("%s\n%d\n" % ("[NUMBER_CVAR]", self._numCvars))
+        self._output.write("%s\n%d\n" % ("[NUMBER_SPECIES]", self._numSpecies))
+        self._output.write("%s\n%d\n" % ("[NUMBER_QOI]", self._numQoi))
+        self._output.write("%s\n%d\n" % ("[NUMBER_VARIABLES]", self._numVars))
+        self._output.write("%s\n%s\n" % ("[DATA]", self._columnHeader))
+
+        arrayLen = self._numCvars * self._numFvars * self._numFlamelets * self._numGridpoints
+        arrayWidth = self._numVars
+        for i in range(0, arrayLen):
+            for j in range(0, arrayWidth):
+                self._output.write("%10.6e\t" % data[i, j])
+            self._output.write("\n")
+			
+def UnscaleTable(fileHandler, interpolate):
+
+    n_fvars = fileHandler.numFvars              # num fvars
+    n_gridpoints = fileHandler.numGridpoints    # num fmean or cmean
+    n_cvars = fileHandler.numCvars              # num cvars
+
+    # useful indexing constants
+    n_gp2 = n_gridpoints * n_gridpoints
+    n_fgf = n_fvars * n_gp2
+
+    A = fileHandler.data                        # array of table data
+
+    max_cmean = np.max(A[:,1])
+    for i in range(0, n_cvars * n_fgf):
+        fvar = A[i, 2]
+        fmean = A[i, 0]
+        cvar = A[i, 3]
+        cmean = A[i, 1]
+        A[i, 2]= fvar * fmean * (1.0 -  fmean)
+        A[i, 3]= cvar * cmean * (max_cmean -  cmean)
+
+    return A
+
+def GetZVar(nZVar):
+    ZVar = [0]      # Not used in laminar implementation
+    if nZVar > 1:
+        variances = np.logspace(-6.64386,0.0,nZVar-1,endpoint=True,base=2)
+        for log in variances:
+            ZVar.append(round(log,4))
+    return ZVar
+
+def GetCVar(nCVar):
+    CVar = [0]      # Not used in Stanford implementation
+    if nCVar > 1:
+        variances = np.logspace(-6.64386,0.0,nCVar-1,endpoint=True,base=2)
+        for log in variances:
+            CVar.append(round(log,4))
+    return CVar
+ 
+# parallel processing remeshing of the table
+def ParallelRemeshingFvar(xp_source, fp_source, x_target, interpolate, n_fvars, n_cvars, n_gp2, n_fgp2, outPipe):
+    f_target = np.copy(fp_source)
+    for m in range(0,n_cvars):
+        for j in range(0, n_gp2):
+            xp = []
+            fp = []
+            for k in range(0, n_fvars):
+                xp.append(xp_source[m*n_fgp2+k*n_gp2+j])
+                fp.append(fp_source[m*n_fgp2+k*n_gp2+j])
+            lower_bound = np.asscalar(fp[0])
+            upper_bound = np.asscalar(fp[-1])
+            bounds = (lower_bound, upper_bound)				 
+            f = interp1d(xp,fp, kind = interpolate, bounds_error = False , fill_value = bounds, assume_sorted= True)
+            for l in range(1, n_fvars):
+                x = x_target[m*n_fgp2+l*n_gp2+j]
+                f_target[m*n_fgp2+l*n_gp2+j] = f(x)
+
+    outPipe.send(f_target)
+    outPipe.close()	
+	
+# parallel processing remeshing of the table
+def ParallelRemeshingCvar(xp_source, fp_source, x_target, interpolate, n_fvars, n_cvars, n_gp2, n_fgp2, outPipe):
+    f_target = np.copy(fp_source)
+    for m in range(0,n_fvars):
+        for j in range(0, n_gp2):
+            xp = []
+            fp = []
+            for k in range(0, n_cvars):
+                xp.append(xp_source[m*n_gp2+k*n_fgp2+j])
+                fp.append(fp_source[m*n_gp2+k*n_fgp2+j])
+            lower_bound = np.asscalar(fp[0])
+            upper_bound = np.asscalar(fp[-1])
+            bounds = (lower_bound, upper_bound)				 
+            f = interp1d(xp,fp, kind = interpolate, bounds_error = False , fill_value = bounds, assume_sorted= True)
+            for l in range(1, n_cvars):
+                x = x_target[m*n_gp2+k*n_fgp2+j]
+                f_target[m*n_gp2+k*n_fgp2+j] = f(x)
+
+    outPipe.send(f_target)
+    outPipe.close()	
+	
+def RemeshTableforVariances(fileHandler, interpolate, A):
+
+    n_vars = fileHandler.numVars                # num variables
+    n_gridpoints = fileHandler.numGridpoints    # fmean or cmean
+    n_fvars = fileHandler.numFvars              # num fvar
+    n_cvars = fileHandler.numCvars              # num cvar
+
+    # useful indexing constants
+    n_gp2 = n_gridpoints * n_gridpoints
+    n_fgp2 = n_fvars * n_gp2	
+
+    # Initialize statistical properties of interest    
+    ZVar = np.multiply(0.25, GetZVar(n_fvars))
+    PrintFlush("Zvar=",ZVar)
+    PrintFlush()
+    CVar = np.multiply(0.25, GetCVar(n_cvars))            
+    PrintFlush("Cvar=",CVar)
+    PrintFlush()
+	
+    # allocate the B matrix
+    n_mapped_matrix_size = n_fgp2 * n_cvars
+    B = np.zeros((n_mapped_matrix_size , n_vars))
+
+    fvar_values = np.zeros((n_fvars,1))		
+	
+    #the values of fvar are obtained
+    for i in range(0, n_fvars, 1):
+        fvar_values[i] = ZVar[i]
+
+    cvar_values = np.zeros((n_cvars,1))	
+
+    #the values of cvar are obtained
+    for i in range(0, n_cvars, 1):
+        cvar_values[i] = CVar[i]
+
+    #critical section of parallelization starts below
+    #copying rows A to B for fvar = 0 and cvar = 0
+    B[0:n_gp2,:] = A[0:n_gp2,:]
+    #copying rows of A to B for scaled fvar = 1 OR scaled cvar = 1
+    for i in range(0, n_cvars):
+        B[i * n_fgp2 + n_gp2 * (n_fvars -1): n_gp2 * n_fvars,:] = A[i * n_fgp2 + n_gp2 * (n_fvars -1): n_gp2 * n_fvars,:]
+        B[i * n_fgp2 + n_gp2 * (n_fvars -1): n_gp2 * n_fvars,2] = 0.25
+
+    #copying other values of fvar to B for cvar = 0	
+    for i in range(1, n_fvars-1, 1):
+        B[i * n_gp2: (i + 1) * n_gp2, 2] = fvar_values[i,0] 
+
+    #copying values of fmean and cmean for all other fvar to B for cvar = 0
+    for i in range(1, n_fvars-1, 1):
+        B[i * n_gp2: (i+1) * n_gp2, 0:2] = B[0:n_gp2, 0:2]
+
+    #copying values of cvar to B		
+    for i in range(0, n_cvars, 1):
+        B[i * n_fgp2: (i + 1) * n_fgp2, 3] = cvar_values[i,0] 
+
+    #copying values of fmean, cmean and fvar for all other cvar within B table
+    for i in range(1, n_cvars, 1):
+        B[i * n_fgp2: (i+1) * n_fgp2, 0:3] = B[0:n_fgp2, 0:3]
+ 
+    if n_fvars > 1:
+        processDict = OrderedDict()
+        # multiple process parallel section
+        for var in range(4,n_vars):
+            xp_source = A[:,2]
+            fp_source = A[:,var]
+            x_target = B[:,2]
+            inputPipe, outputPipe = Pipe(duplex=False)
+            p = Process(target= ParallelRemeshingFvar, args=(xp_source, fp_source, x_target, interpolate, n_fvars, n_cvars, n_gp2, n_fgp2, outputPipe))
+            processDict[var] = [p, inputPipe]
+            p.start()
+
+        for var in range(4, n_vars):
+            B[:,var] = processDict[var][1].recv()
+
+    if n_cvars > 1:
+        processDict = OrderedDict()
+        # multiple process parallel section
+        for var in range(4,n_vars):
+            xp_source = A[:,3]
+            fp_source = A[:,var]
+            x_target = B[:,3]
+            inputPipe, outputPipe = Pipe(duplex=False)
+            p = Process(target= ParallelRemeshingCvar, args=(xp_source, fp_source, x_target, interpolate, n_fvars, n_cvars, n_gp2, n_fgp2, outputPipe))
+            processDict[var] = [p, inputPipe]
+            p.start()
+		
+        for var in range(4, n_vars):
+            B[:,var] = processDict[var][1].recv()
+
+    return B
+
+
+# start of MapProgressVarStart function
+def MapProgressVarStart(options):        
+
+    PrintFlush("*** Unscaling Variances Start ***")
+
+    # read in table definition file
+    table = TableDef()
+    if table.Read() != True:
+        return
+    
+    # assign interpolation type
+    interpolation_type = table.interpolation_type
+    pressure = table.pressure
+
+    """
+    Obtained from Flamelet tab: Pass in the number of variances to use for Z (mixture fraction) and C (progress variable)
+    """    
+    nZVar = table.nZVar
+    nCVar = table.nCVar
+    """
+    End variable passing; note that "0" variance number is the same as a laminar calculation
+    """
+
+    PrintFlush("Successfully read table definition, interpolation = " + interpolation_type)
+
+    if '--help' in options:
+        #printhelp()
+        placefiller = 1
+
+    if '--input' in options:    
+        # If the user specifies an input file, open that file
+        inputFile = options['--input']
+    else:
+        # if not specified - use default
+        inputFile = "UdriTable.fla"
+
+    if '--output' in options:
+        # If the user specifies an output file, open that file
+        outputFile = options['--output']
+    else:
+        # Without an output file specified, create default automatically
+        outputFile = "unscaled_UdriTable.map"
+
+    # read in input table fmean and lambda values
+    PrintFlush("Reading input file - " + inputFile)
+    inputFile = InputFileHandler(inputFile)
+    inputFile.Read()
+
+    # map the input file
+    PrintFlush("Input file read complete - Unscaling variances")
+    A = UnscaleTable(inputFile, interpolation_type)
+    PrintFlush("Unscaling variable complete - remeshing table")
+
+    # remesh the table
+    B = RemeshTableforVariances(inputFile, interpolation_type, A)
+    PrintFlush("Remeshing variances complete - writing output file")
+
+    # write the output file
+    outputFile = OutputFileHandler(outputFile)
+    outputFile.pressure = pressure
+    outputFile.numGridpoints = inputFile.numGridpoints
+    outputFile.numFlamelets = inputFile.numGridpoints
+    outputFile.numFvars = inputFile.numFvars
+    outputFile.numCvars = inputFile.numCvars
+    outputFile.numQoi = inputFile.numQoi
+    outputFile.numSpecies = inputFile.numSpecies
+    outputFile.numVars = inputFile.numVars
+    outputFile.columnHeader = inputFile.columnHeader
+    outputFile.Write(B)
+    PrintFlush("*** Unscaled Variances Recovered ***")
+	
+    # set plot mode to interactive
+    plt.ion()
+    init_plot = True
+	
+    # create lengths
+    zmeanLen = inputFile.numGridpoints
+    cmeanLen = inputFile.numGridpoints
+    zvarLen = inputFile.numFvars
+    cvarLen = inputFile.numCvars
+
+    ZMean = np.zeros((zmeanLen,1))	
+    #the values of fmean are obtained
+    for i in range(0, zmeanLen, 1):
+        ZMean[i] = B[i,0]	
+		
+    CMean = np.zeros((cmeanLen,1))	
+    #the values of cmean are obtained
+    for i in range(0, cmeanLen, 1):
+        CMean[i] = B[i * zmeanLen,1]	
+
+    ZVar = np.zeros((zvarLen,1))	
+    #the values of fvar are obtained
+    for i in range(0, zvarLen, 1):
+        ZVar[i] = B[i * zmeanLen * cmeanLen,2]
+
+    CVar = np.zeros((cvarLen,1))	
+    #the values of cvar are obtained
+    for i in range(0, cvarLen, 1):
+        CVar[i] = B[i * zmeanLen * cmeanLen * zvarLen, 3]
+	
+    #create list of keys
+    keyList = inputFile.columnHeader.split()[4:]
+		
+    # Initialize the dictionary containing variable matrix that will be used to visualize the output in 3D
+    plotDict = OrderedDict()
+    for varIndex, name in enumerate(keyList):
+        plotDict[name] = np.zeros((cvarLen, zvarLen, cmeanLen, zmeanLen))
+        for cvarIndex in range (cvarLen):           
+            for zvarIndex in range(zvarLen):
+                for cmeanIndex in range(cmeanLen):
+                    for zmeanIndex in range(zmeanLen):
+                         plotDict[name][cvarIndex, zvarIndex, cmeanIndex, zmeanIndex] = B[zmeanIndex + zmeanLen * cmeanIndex + zmeanLen * cmeanLen * zvarIndex + zmeanLen * cmeanLen * zvarLen * cvarIndex, 4+varIndex]
+					
+    # display plot dialog
+    dlg = PlotDlg(CVar, ZVar, 0, 0, keyList, keyList[0])
+    retrySolve = dlg.WaitResult()
+    cvarIndex = dlg.cvar_index
+    zvarIndex = dlg.zvar_index
+    name = dlg.variable_name
+
+    plotLabel = {}
+    plotLabel['TEMPERATURE'] = 'Temperature, T [K]'
+    plotLabel['mu'] = 'Dynamic Viscosity, $\mu$ [kg/m-s]'
+    plotLabel['TC'] = 'Thermal Conductivity, k [W/m-K]'
+    plotLabel['PREMIX_CDOT'] = 'Progress Variable Source, S$_C$ [kg/m^3-s]'
+    plotLabel['MMW'] = 'Molecular Weight, MW [kg/kmol]'
+    plotLabel['rho'] = r'$\mathrm{Density, \rho  [kg/m^3]}$'
+    plotLabel['Cp'] = 'Specific Heat Capacity, C$_p$ [J/kg-K]'
+
+    # plot variable profile
+    while retrySolve == True:
+        PrintFlush("plotting variable = ", name, " cvar = ", cvarIndex, " zvar = ", zvarIndex)
+        if name in plotLabel:
+            label = plotLabel[name]
+        elif name.find('net_rxn-') != -1:
+            label = name.replace('net_rxn-', '')
+            label = label + ' Net Reaction Rate [kg/m$^3$-s]'
+        elif name.find('massfraction-') != -1:
+            label = name.replace('massfraction-', '')
+            label = label + ' Mass Fraction'
+        else:
+            label = name
+        fig = plt.figure(0)
+        ax = Axes3D(fig)
+        ZMeanAxis,CMeanAxis = np.meshgrid(ZMean,CMean)
+        ax.plot_surface(ZMeanAxis,CMeanAxis,plotDict[name][cvarIndex, zvarIndex,:,:],rstride=1,cstride=1,cmap=cm.jet)
+        plt.ylabel('Progress Variable, C')
+        plt.xlabel('Mixture Fraction, Z')
+        plt.xlim(0,1)
+        plt.ylim(0,1)
+        ax.set_zlabel(label)
+        ax.view_init(15,-130)
+        plt.title(str(table.fuel)+"-"+str(table.oxidizer)+", T$_{Fuel}$="\
+        +str(round(table.Tfuel))+"K"+", T$_{Oxidizer}$="+str(round(table.Toxidizer))\
+        +"K, P$_{Op}$="+str(round(table.pressure/101325,1))+"atm")
+        txtstr = r'Unscaled Z$_{var}$ = '+str(np.asscalar(ZVar[zvarIndex])) \
+               +r'  Unscaled C$_{var}$ = '+str(np.asscalar(CVar[cvarIndex]))
+        ax.text2D(0.30, 0.87, txtstr, transform=ax.transAxes, fontsize=12)
+        if init_plot:
+            # only position initially, allows user to move afterwards
+            mgr = plt.get_current_fig_manager()
+            mgr.window.wm_geometry("+50+400")
+            init_plot = False
+       
+        # display plot dialog
+        dlg = PlotDlg(CVar, ZVar, cvarIndex, zvarIndex, keyList, name)
+        retrySolve = dlg.WaitResult()        
+        cvarIndex = dlg.cvar_index
+        zvarIndex = dlg.zvar_index
+        name = dlg.variable_name
+
+# start of main
+if __name__ == "__main__":    
+
+    # Declare the list of acceptable program options.
+    longOptions = ['input=', 'output=', 'help', 'debug']
+
+    # Parse the program arguments and place them in convenient format in "options"
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'dh', longOptions)
+        options = dict()
+        for o,a in optlist:
+            options[o] = a
+        if args:
+            raise getopt.GetoptError('Unexpected command line option: ' + repr(' '.join(args)))
+    except getopt.GetoptError as e:
+        PrintFlush('Error parsing arguments:')
+        PrintFlush(e)
+        PrintFlush('Run "MapProgressVar.py --help" to see options.')
+        sys.exit(1)
+
+    MapProgressVarStart(options)
+    sys.exit()

--- a/interfaces/cython/cantera/examples/onedim/Utils.py
+++ b/interfaces/cython/cantera/examples/onedim/Utils.py
@@ -1,0 +1,71 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+import os
+import tkinter
+import sys
+
+###############################################################################
+#
+#  Defines class used to display the 'Hit Ok to continue' dialog
+#
+###############################################################################
+
+class MessageDlg():
+
+    # constructor - display retry dialog box
+    def __init__(self, message):
+        self._dlg = tkinter.Tk()
+        self._dlg.config(borderwidth=8)
+        self._dlg.title("Message Box")
+
+        # property definitions
+        self._message = tkinter.StringVar(self._dlg, value=message)
+
+        # message text
+        tkinter.Label(self._dlg, textvariable=self._message, padx=2).grid( row=1, column=1)
+        tkinter.Label(self._dlg, text="Please hit OK to continue").grid(row=2, column=1)
+
+        # retry and exit buttons
+        tkinter.Button(self._dlg, text = "Ok", command = self.OkCallBack, width = 6).grid( row=3, column=1, pady=8)
+    
+    # wait for user to hit button
+    def WaitResult(self):
+        self._dlg.mainloop()
+
+    # OK button handler
+    def OkCallBack(self):
+        self._dlg.quit()
+        self._dlg.destroy()
+
+
+# function that flushes stdout after each print
+def PrintFlush(*arg):
+    print(*arg)
+    sys.stdout.flush()

--- a/interfaces/cython/cantera/examples/onedim/convolute.pyx
+++ b/interfaces/cython/cantera/examples/onedim/convolute.pyx
@@ -1,0 +1,160 @@
+# distutils: language = c++
+# distutils: sources = ConvoluteCpp.cpp
+
+from scipy.interpolate import RectBivariateSpline
+from scipy.integrate import trapz
+
+cimport cython
+import numpy as np
+cimport numpy as np
+from libcpp cimport bool as cbool
+
+cdef extern from "ConvoluteCpp.h":
+    cdef cppclass FpArray3D:
+        FpArray3D(int, int, int, double*) except +
+        double GetData(int, int, int)
+ 
+    cdef cppclass FpArray2D:
+        FpArray2D(int, int, double*) except +
+        double GetData(int, int)
+        int GetXlen()
+        int GetYlen()
+       
+    cdef cppclass ConvoluteCpp:
+        ConvoluteCpp() except +
+        ConvoluteCpp(char*) except +
+        void SetBetas(int, int, int, double*)
+        void SetBetas2(int, int, int, double*)
+        void SetDictEntry(int, int, double*)
+        void SetZz(int, int, double*)
+        void SetZx(int, double*)
+        void SetZy(int, double*)
+        void EvalNormal(double, double, int, int, int, int)
+        void EvalRho(double, double, int, int, int, int)
+        void Eval(double, double, int, int, int, int)
+        void EvalZzArray()
+        void EvalZxArray()
+        void EvalBetaArray()
+
+    cdef cppclass CreateOutputFile:
+        CreateOutputFile() except +
+        CreateOutputFile(char*, int, int, double*, int, double*, int) except +
+        void Write(double, double, double)
+        void Close()   
+         
+    cdef cppclass CreateDiffusionFlameletsFile:
+        CreateDiffusionFlameletsFile() except +
+        CreateDiffusionFlameletsFile(char*) except +
+        void WriteHeader(double, int, int, double) except +
+        void WriteData(int, double*, char*) except +
+        void WriteDataMin(int, double*, char*, double) except +
+        void WriteLaminarDataReaction(int, int, double*, int, double*, int, int*) except +
+        void WriteTurbulentDataReaction(int, int, double*, int, double*, int, int*, double) except +
+        void WriteDataProduction(int, double*, double, char*) except +
+        void WriteCR() except +
+        void Close() except +
+
+cdef class PyConvolute:
+    cdef ConvoluteCpp c_conv      # hold a C++ instance which we're wrapping
+    def __cinit__(self):
+        self.c_conv = ConvoluteCpp()
+    def __cinit__(self, name):
+        cdef py_bytes = name.encode()
+        cdef char* c_name = py_bytes
+        self.c_conv = ConvoluteCpp(c_name)
+    def set_betas(self, np.ndarray[double, ndim=3, mode="c"] input not None):
+        len = input.shape
+        self.c_conv.SetBetas(len[0], len[1], len[2], &input[0,0,0])
+        return True
+    def set_betas2(self, np.ndarray[double, ndim=3, mode="c"] input not None):
+        len = input.shape
+        self.c_conv.SetBetas2(len[0], len[1], len[2],  &input[0,0,0])
+        return True
+    def set_dict_entry(self, np.ndarray[double, ndim=2, mode="c"] input not None):
+        len = input.shape
+        self.c_conv.SetDictEntry(len[0], len[1], &input[0,0])
+        return True
+    def set_zz(self, np.ndarray[double, ndim=2, mode="c"] input not None):
+        len = input.shape
+        self.c_conv.SetZz(len[0], len[1], &input[0,0])
+        return True
+    def set_zx(self, np.ndarray[double, ndim=1, mode="c"] input not None):
+        len = input.shape
+        self.c_conv.SetZx(len[0], &input[0])
+        return True
+    def set_zy(self, np.ndarray[double, ndim=1, mode="c"] input not None):
+        len = input.shape
+        self.c_conv.SetZy(len[0], &input[0])
+        return True
+    def eval_normal(self, cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex):
+        self.c_conv.EvalNormal(cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex)
+    def eval_rho(self, cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex):
+        self.c_conv.EvalRho(cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex)
+    def eval(self, cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex):
+        self.c_conv.Eval(cvar, zvar, zmeanIndex, zvarIndex, cmeanIndex, cvarIndex)
+    def eval_zz_array(self):
+        self.c_conv.EvalZzArray()
+    def eval_zx_array(self):
+        self.c_conv.EvalZxArray()
+    def eval_beta_array(self):
+        self.c_conv.EvalBetaArray()
+    
+cdef class PyCreateOutputFile:
+    cdef CreateOutputFile c_conv      # hold a C++ instance which we're wrapping
+    def __cinit__(self):
+        self.c_conv = CreateOutputFile()
+    def __cinit__(self, filename, np.ndarray[double, ndim=2, mode="c"] input not None, np.ndarray[double, ndim=1, mode="c"] ZMean not None, compressed):
+        cdef py_bytes = filename.encode()
+        cdef char* name = py_bytes
+        len = input.shape
+        zlen = ZMean.shape
+        cdef int flag = 0
+        if compressed == True:
+            flag = 1
+        self.c_conv = CreateOutputFile(name, len[0], len[1], &input[0, 0], zlen[0], &ZMean[0], flag)
+    def write(self, cvar, zvar, cmean):
+        self.c_conv.Write(cvar, zvar, cmean)
+    def close(self):
+        self.c_conv.Close()
+
+cdef class PyCreateDiffusionFlameletsFile:
+    cdef CreateDiffusionFlameletsFile c_conv      # hold a C++ instance which we're wrapping
+    def __cinit__(self):
+        self.c_conv = CreateDiffusionFlameletsFile()
+    def __cinit__(self, filename):
+        cdef py_bytes = filename.encode()
+        cdef char* name = py_bytes
+        self.c_conv = CreateDiffusionFlameletsFile(name)
+    def write_header(self, maxC, numSpecies, gridpoints, pressure):
+        self.c_conv.WriteHeader(maxC, numSpecies, gridpoints, pressure)
+    def write_data(self, np.ndarray[double, ndim=1, mode="c"] input not None, data_name):
+        cdef py_bytes = data_name.encode()
+        cdef char* name = py_bytes
+        len = input.shape
+        self.c_conv.WriteData(len[0], &input[0], name)
+    def write_data_min(self, len, np.ndarray[double, ndim=1, mode="c"] input not None, data_name, minValue):
+        cdef py_bytes = data_name.encode()
+        cdef char* name = py_bytes
+        self.c_conv.WriteDataMin(len, &input[0], name, minValue)
+    def write_laminar_data_reaction(self, np.ndarray[double, ndim=2, mode="c"] npr_input not None, 
+                                    np.ndarray[double, ndim=1, mode="c"] mw_input not None,
+                                    np.ndarray[int, ndim=1, mode="c"] ia_input not None):
+        len = npr_input.shape
+        mw_len = mw_input.shape
+        ia_len = ia_input.shape
+        self.c_conv.WriteLaminarDataReaction(len[0], len[1], &npr_input[0,0], mw_len[0], &mw_input[0], ia_len[0], &ia_input[0])
+    def write_turbulent_data_reaction(self, np.ndarray[double, ndim=2, mode="c"] npr_input not None, 
+                                      np.ndarray[double, ndim=1, mode="c"] t_input not None,
+                                      np.ndarray[int, ndim=1, mode="c"] ia_input not None, pressure):
+        len = npr_input.shape
+        t_len = t_input.shape
+        ia_len = ia_input.shape
+        self.c_conv.WriteTurbulentDataReaction(len[0], len[1], &npr_input[0,0], t_len[0], &t_input[0], ia_len[0], &ia_input[0], pressure)
+    def write_data_production(self, len, np.ndarray[double, ndim=1, mode="c"] input not None, mw, data_name):
+        cdef py_bytes = data_name.encode()
+        cdef char* name = py_bytes
+        self.c_conv.WriteDataProduction(len, &input[0], mw, name)
+    def write_cr(self):
+        self.c_conv.WriteCR()
+    def close(self):
+        self.c_conv.Close()

--- a/interfaces/cython/cantera/examples/onedim/diffusion_flame_s_curve_retry.py
+++ b/interfaces/cython/cantera/examples/onedim/diffusion_flame_s_curve_retry.py
@@ -1,0 +1,1105 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+import cantera as ct
+import numpy as np
+import os
+import sys
+import time
+import matplotlib.pyplot as plt
+import warnings
+import matplotlib.cbook
+import tkinter
+import getopt
+import tempfile
+
+from table_def import TableDef
+from Utils import MessageDlg, PrintFlush
+
+
+# Suppress matplotlib warnings
+warnings.filterwarnings("ignore",category=matplotlib.cbook.mplDeprecation)
+
+# UDRI C++ imports
+from convolute import PyCreateDiffusionFlameletsFile
+
+class RetryDlg():
+
+    # constructor - display retry dialog box
+    def __init__(self, OnePointControl, TwoPointControl, UserMaxTempPercentage, FuelSign, OxidSign, MINdT, MAXdT, dT, oxidizer_flux, cmeanSkip):
+        self._dlg = tkinter.Tk()
+        self._dlg.config(borderwidth=8)
+        self._dlg.title("Flame Control")
+
+        # local point control
+        PointControl = False
+        if OnePointControl == True:
+            PointControl = 0
+        if TwoPointControl == True:
+            PointControl = 1
+
+        # property definitions
+        self._point_control = tkinter.IntVar(self._dlg, value=PointControl)
+        self._max_temp = tkinter.DoubleVar(self._dlg, value=UserMaxTempPercentage*100.0)
+        self._fuel_sign = tkinter.IntVar(self._dlg, value=FuelSign)
+        self._oxidizer_sign = tkinter.IntVar(self._dlg, value=OxidSign)
+        self._mindt = tkinter.DoubleVar(self._dlg, value=MINdT)
+        self._maxdt = tkinter.DoubleVar(self._dlg, value=MAXdT)
+        self._dt = tkinter.DoubleVar(self._dlg, value=dT)
+        self._mdot_oxidizer = tkinter.DoubleVar(self._dlg, value=oxidizer_flux)
+        self._cmean_skip = tkinter.IntVar(self._dlg, value=cmeanSkip)
+        self._retry = False
+
+        #one/two point control
+        tkinter.Radiobutton(self._dlg, text="One-point Control", command = self.OnePointCallBack, variable = self._point_control, value=0).grid(row=2, column=1, sticky="w", pady=0, padx=2, columnspan=2)
+        tkinter.Radiobutton(self._dlg, text="Two-point Control",  command = self.TwoPointCallBack,variable = self._point_control, value=1).grid(row=3, column=1, sticky="w", pady=0, padx=2, columnspan=2)
+
+        #max temperature entry
+        tkinter.Label(self._dlg, text="Max Temp %", padx=2).grid( row=4, column=1, sticky="w")
+        tkinter.Entry(self._dlg, textvariable=self._max_temp, width=10).grid(row=4, column=2, sticky="w", pady=5, padx=2)
+
+        # fuel increase/decrease
+        tkinter.Radiobutton(self._dlg, text="Increase Fuel", variable = self._fuel_sign, value=1).grid(row=5, column=1, sticky="w", pady=0, padx=2, columnspan=2)
+        tkinter.Radiobutton(self._dlg, text="Decrease Fuel", variable = self._fuel_sign, value=-1).grid(row=6, column=1, sticky="w", pady=0, padx=2, columnspan=2)
+
+        # optional oxidizer flux
+        self._mdot_label = tkinter.Label(self._dlg, text="Oxidizer Flux")
+        self._mdot_label.grid( row=7, column=1, sticky="w")
+        self._mdot_variable = tkinter.Entry(self._dlg, textvariable=self._mdot_oxidizer, width=10)
+        self._mdot_variable.grid(row=7, column=2, sticky="w", pady=2, padx=2)
+
+        #optional oxidizer increase/decrease
+        self._increase_oxid = tkinter.Radiobutton(self._dlg, text="Increase Oxidizer", variable = self._oxidizer_sign, value=1)
+        self._increase_oxid.grid(row=8, column=1, sticky="w", pady=0, padx=2, columnspan=2)
+        self._decrease_oxid = tkinter.Radiobutton(self._dlg, text="Decrease Oxidizer", variable = self._oxidizer_sign, value=-1)
+        self._decrease_oxid.grid(row=9, column=1, sticky="w", pady=0, padx=2, columnspan=2)
+        tkinter.Label(self._dlg, text="Min dT").grid( row=10, column=1, sticky="w")
+
+        # remaining mandatory entries
+        tkinter.Entry(self._dlg, textvariable=self._mindt, width=10).grid(row=10, column=2, sticky="w", pady=2, padx=2)
+        tkinter.Label(self._dlg, text="Max dT").grid( row=11, column=1, sticky="w")
+        tkinter.Entry(self._dlg, textvariable=self._maxdt, width=10).grid(row=11, column=2, sticky="w", pady=2, padx=2)
+        tkinter.Label(self._dlg, text="dT").grid( row=12, column=1, sticky="w")
+        tkinter.Entry(self._dlg, textvariable=self._dt, width=10).grid(row=12, column=2, sticky="w", pady=2, padx=2)
+        tkinter.Label(self._dlg, text="CMean Skip").grid( row=13, column=1, sticky="w")
+        tkinter.Entry(self._dlg, textvariable=self._cmean_skip, width=10).grid(row=13, column=2, sticky="w", pady=2, padx=2)
+
+        # retry and exit buttons
+        tkinter.Button(self._dlg, text = "Retry", command = self.RetryCallBack, width = 6).grid( row=14, column=1, pady=8)
+        tkinter.Button(self._dlg, text = "Exit", command = self.ExitCallBack, width = 6).grid( row=14, column=2, pady=8)
+
+        # activate optional entries/radio buttons
+        if OnePointControl == True:
+            self.OnePointCallBack()
+        if TwoPointControl == True:
+            self.TwoPointCallBack()
+
+    @property
+    def one_point_control(self):
+        '''point control selected'''
+        return (self._point_control.get() == 0)
+
+    @property
+    def two_point_control(self):
+        '''point control selected'''
+        return (self._point_control.get() == 1)
+
+    @property
+    def max_temp(self):
+        '''UserMaxTempPercentage'''
+        return self._max_temp.get()/100.0
+
+    @property
+    def fuel_sign(self):
+        '''FuelSign'''
+        return self._fuel_sign.get()
+
+    @property
+    def oxidizer_sign(self):
+        '''OxidSign'''
+        return self._oxidizer_sign.get()
+
+    @property
+    def mindt(self):
+        '''MINdT'''
+        return self._mindt.get()
+
+    @property
+    def maxdt(self):
+        '''MAXdT'''
+        return self._maxdt.get()
+
+    @property
+    def dt(self):
+        '''dT'''
+        return self._dt.get()
+    
+    @property
+    def mdot_oxidizer(self):
+        '''mdot oxidizer'''
+        return self._mdot_oxidizer.get()
+    
+    @property
+    def cmean_skip(self):
+        '''cmean skip'''
+        return self._cmean_skip.get()
+    
+    # wait for user to hit button
+    def WaitResult(self):
+        self._dlg.mainloop()
+        return self._retry
+
+    # OnePoint radio button handler
+    def OnePointCallBack(self):
+        self._increase_oxid.grid_remove()
+        self._decrease_oxid.grid_remove()
+        self._mdot_label.grid()
+        self._mdot_variable.grid()
+
+    # TwoPoint radio button handler
+    def TwoPointCallBack(self):
+        self._increase_oxid.grid()
+        self._decrease_oxid.grid()
+        self._mdot_label.grid_remove()
+        self._mdot_variable.grid_remove()
+
+    # retry button handler
+    def RetryCallBack(self):
+        self._retry = True
+        self._dlg.quit()
+        self._dlg.destroy()
+
+    # exit buttonhandler
+    def ExitCallBack(self):
+        self._dlg.quit()
+        self._dlg.destroy()
+
+# start of DiffusionFlame, set plot mode to interactive
+def DiffusionFlame(options):
+
+    # start of main, set plot mode to interactive
+    init_plot = True
+    PrintFlush("Start flamelet generation of FPV type")
+
+    # Set up a temporary data directory for later reference
+    tempdir = tempfile.TemporaryDirectory()
+    data_directory = tempdir.name + "\\"
+#    data_directory = r"C:\temp/"
+#    if not os.path.exists(data_directory):
+#        os.makedirs(data_directory)
+
+    # read in table definition file
+    table = TableDef()
+    table.Read()
+    table.Report()    
+
+    #Create a summary file for later reference
+    summary = open("Summary.txt", 'w')
+    summary.write('     Amean       Amax       Tmax      TFfix      TOfix     FuelSign     OxSign       %loc    dT\n')
+    fast_file = PyCreateDiffusionFlameletsFile('diffusion_flamelets.fla')
+
+    """
+    ******************** beginning of inputs ************************
+    """
+
+    """
+    The following entry is obtained from the C# dialog models tab
+    """
+    transport_model = table.transport_model # this can be either mix or multi
+    PrintFlush(transport_model, table.transport_model)
+    UnityLewisNumber = False
+    if transport_model == 'Unity':
+        UnityLewisNumber = True
+    transport_model = 'Mix'
+    gas = ct.Solution(table.reaction_mechanism)
+    flow = table.flow
+    """
+    end of models tab
+    """
+
+    """
+    The values below are coming from the C# dialog boundaries tab.
+    """
+    pressure = table.pressure # pressure [Pa], information passed from C# dialog GUI
+    Tfuel =  table.Tfuel # unburned gas temperature [K], information pass from C# dialog GUI
+    Toxidizer = table.Toxidizer # unburned gas temperature [K], information pass from C# dialog GUI
+    mole_fractions = table.mole_fractions # this information is passed from C# dialog GUI
+    fuel = table.fuel  #the user chooses the fuel, this should be an array; this are the species which are greater than zero
+                       # in the GUI
+    fuel_fraction = table.fuel_fraction # this fraction is passed from the GUI
+    oxidizer = table.oxidizer #the user chooses the oxidizer, this should be array; these are species > 0
+    oxidizer_fraction = table.oxidizer_fraction #these are the mole fractions chosen by user
+    init_fuel_flux = table.init_fuel_flux #kg/m^2-s, this is only a FPV input
+    """
+    end of boundary information
+    """
+
+    """
+    The values below are coming from the C# dialog numerics tab.
+    """
+    initial_grid = np.linspace(table.start, table.end, table.num_points) # m, originally 20cm
+    tol_ss = [table.ss_rel,table.ss_abs] # [rtol atol] for steady-state problem
+    tol_ts = [table.tr_rel,table.tr_abs] # [rtol atol] for time stepping
+    ss_age = table.ss_age  #Set the maximum number of times the Jacobian will be used before it must be re-evaluated by the steady solver.
+    ts_age = table.ts_age  #Set the maximum number of times the Jacobian will be used before it must be re-evaluated by the transient solver. 
+    stepsize = table.stepsize # initial time step in seconds
+    nstep = table.nstep # sequence of integer numbers
+    loglevel = table.loglevel # amount of diagnostic output (0 to 8)
+    refine = table.refine  # 'True' to enable refinement, 'False' to disable
+    temperature_limit_extinction =  table.temperature_limit_extinction # K  #lets add this parameter to the numerics tab
+    ratio = table.ratio
+    slope = table.slope
+    curve = table.curve
+    prune = table.prune
+    """
+    end of boundary information
+    """
+
+    """
+    The values below are coming from the C# dialog flamelet tab.
+    For now only one entry is being passed because we are developing the laminar flamelet
+    """
+    z_composition = ['H']
+    composition = table.composition  # progress variable definition
+    z_points = table.z_points #number of fmean. This is the same as 21 in inital_grid variable above
+    cmean_skip = table.cmean_skip # number of cmean_skip for cmean entry in the GUI
+    """
+    end of flamelet information
+    """
+
+    """
+    FPV setups requires an additional control tab named Flame Control
+    This table does not need to be accessible for FPI
+    """
+    StrainEq = table.strain_rate
+    IncludeFlameEquilibrium = False
+    precalculations = table.precalculations
+    UserStrainFactor = table.user_strain_factor
+    UpperBranchHomotopicIter = table.zero_order_steps
+    UserMaxTempPercentage = table.user_max_temp_percentage
+    FuelSign = table.fuel_sign
+    OxidSign = table.oxidizer_sign
+    OnePointControl = table.one_point_control
+    TwoPointControl = table.two_point_control
+    dT = table.dT
+    FailedSolutionsToTerminate = table.failed_solutions_to_terminate
+    maxNumberOfFlames = table.max_num_flames
+    N_opt = table.nopt
+    MAXdT = table.max_dT
+    MINdT = table.min_dT
+    OxidizerMassFlux = table.oxidizer_mass_flux;
+
+    """
+    ending Flame Control tab
+    """
+
+    """
+    ********************* output control tab ****************************
+    """
+    YQOI = table.YQOI #user chooses species mass fraction to output
+    RRQOI = table.RRQOI  # user chooses species net reaction rates (kg/m^3-s) to output
+    """
+    ***************************end of output control tab*******************************
+    """
+
+    """
+    ***********************end of inputs ****************************************
+    """
+
+    """******************************************************************************
+    *****************The settings for the Cantera flamelet calculations are set here
+    """
+
+    def get_C():
+        #start the clock
+        timestart = time.clock()
+        index_array = np.zeros((len(composition)), dtype=np.int)
+        for i,name in enumerate(composition):
+            index_array[i] = gas.species_index(name)
+        C_array = np.zeros(len(f.grid), dtype=np.double)
+        for j in range(0,len(f.grid)-1):
+            C=0.0
+            for i in index_array:
+                C += f.Y[i,j]
+            if j != 0 and C < max(C_array) and C > 0.5: 
+                break
+            C_array[j] = C
+        timeend = time.clock()
+        #PrintFlush('get_max_C execution time: ', (timeend-timestart))
+        return C_array   
+
+    def get_mixture_fraction():
+        #start the clock
+        timestart = time.clock()
+
+        # create arrays needed
+        mixture_fraction_array =  np.zeros((len(f.grid)), dtype=np.double)
+        atom_end = np.zeros((len(z_composition), len(f.grid)), dtype=np.double)
+        denominator = np.zeros((len(z_composition)), dtype=np.double)
+
+        # convert dictionary to array for faster execution
+        denominator_Z = 0.0
+        for i, atom in enumerate(z_composition):
+            atom_end[i] = f.elemental_mass_fraction(atom) 
+            denominator_Z += f.elemental_mass_fraction(atom)[0] - f.elemental_mass_fraction(atom)[-1]   
+                 
+        # calculate mixture fraction
+        for j in range(0,len(f.grid)):              
+            numerator_Z = 0.0
+            for i in range(len(z_composition)):
+                numerator_Z += atom_end[i,j] - atom_end[i, -1]
+            mixture_fraction = numerator_Z / (denominator_Z + 10**-30)
+            mixture_fraction_array[j] = mixture_fraction
+        timeend = time.clock()
+        #PrintFlush('get_mixture_fraction execution time: ', (timeend-timestart))
+        return mixture_fraction_array
+
+    # write current solution to output file quickly using cython/c++
+    def FastLaminarFlamelets(max_C, mixture_fraction_array):
+
+        #start the clock
+        timestart = time.clock()
+
+        # write file header
+        gridpoints = len(f.grid)
+        fast_file.write_header(max_C, len(gas.Y), gridpoints, gas.P)
+
+        # write mixture fraction
+        mixture_array = np.ascontiguousarray(mixture_fraction_array, dtype = np.double)
+        for j in range(0,gridpoints):  
+            if j != 0 and mixture_array[j] == mixture_fraction_array[j-1]:
+                mixture_array[j] -= mixture_array[j] * 10**-9 
+        fast_file.write_data(mixture_array, 'MIXTURE_FRACTION')
+
+        # write progress variable
+        out_array = np.ascontiguousarray(C_array, dtype = np.double)
+        fast_file.write_data(out_array, 'PROGRESS VARIABLE')
+
+        # Write temperature
+        out_array = np.ascontiguousarray(f.T, dtype = np.double)
+        fast_file.write_data(out_array, 'TEMPERATURE')
+
+        # Write heat capacity (not possible in FLUENT)
+        out_array = np.ascontiguousarray(f.cp_mass, dtype = np.double)
+        fast_file.write_data(out_array, 'Cp')
+
+        # Write mean molecular weight (not possible in FLUENT)
+        temp = np.zeros((gridpoints), dtype = np.double)
+        out_array = np.ascontiguousarray(temp, dtype = np.double)
+        for j in range(0,gridpoints):
+            out_array[j] = np.dot(f.X[:,j],gas.molecular_weights[:])
+        fast_file.write_data(out_array, 'MMW')
+
+        # Write density (not possible in FLUENT)
+        out_array = np.ascontiguousarray(f.density_mass, dtype = np.double)
+        fast_file.write_data(out_array, 'rho')
+
+        # Write viscosity (not possible in FLUENT)
+        out_array = np.ascontiguousarray(f.viscosity, dtype = np.double)
+        fast_file.write_data(out_array, 'mu')
+
+        # Write thermal conductivity (not possible in FLUENT)
+        out_array = np.ascontiguousarray(f.thermal_conductivity, dtype = np.double)
+        fast_file.write_data(out_array, 'TC')
+               
+        # Write net production rates (if any)
+        if len(RRQOI) > 0:
+            index_array = np.zeros((len(RRQOI)), dtype=np.int)
+            for i,name in enumerate(RRQOI):
+                index_array[i] = gas.species_index(name)
+            for n,i in enumerate(index_array):
+                npr_array = np.ascontiguousarray(f.net_production_rates[i,:], dtype = np.double)
+                fast_file.write_data_production(gridpoints, npr_array, gas.molecular_weights[i], 'net_rxn-'+ RRQOI[n])
+
+        # Write species mass fractions (if any)
+        if len(YQOI) > 0:
+            index_array = np.zeros((len(YQOI)), dtype=np.int)
+            for i,name in enumerate(YQOI):
+                index_array[i] = gas.species_index(name)
+            for n,i in enumerate(index_array):
+                out_array = np.ascontiguousarray(f.Y[i,:], dtype = np.double)
+                fast_file.write_data_min(len(out_array), out_array, "massfraction-"+YQOI[n], 1e-10)
+
+        # Writing reaction progress source (PREMIX_CDOT)
+        index_array = np.zeros((len(table.composition)), dtype=np.int)
+        for i,name in enumerate(table.composition):
+            index_array[i] = gas.species_index(name)    
+        npr_array = np.ascontiguousarray(f.net_production_rates, dtype = np.double)
+        ia_array = np.ascontiguousarray(index_array, dtype = np.int32)
+#        if flow == "Laminar":
+        mw_array = np.ascontiguousarray(gas.molecular_weights, dtype = np.double)
+        fast_file.write_laminar_data_reaction(npr_array, mw_array, ia_array)
+#        else:
+#            t_array = np.ascontiguousarray(f.T, dtype = np.double)
+#            fast_file.write_turbulent_data_reaction(npr_array, t_array, ia_array, pressure)      
+
+        # write out a few extra cr's
+        fast_file.write_cr()
+
+        timeend = time.clock()
+        PrintFlush('LaminarFlamelets execution time: ', (timeend-timestart))
+    
+    def iloc(percent):
+        Ttarget = percent * np.max(f.T)
+        for i in range(0,len(f.grid),1):
+            if f.T[i] > Ttarget:
+                z0 = i
+                break
+        for i in range(len(f.grid)-1,0,-1):
+            if f.T[i] > Ttarget:
+                z1 = i
+                break
+        return z0, z1
+
+    def stepControl(ieval, N_opt, dT, MAXdT, MINdT):
+        failed = False
+        xi = float(N_opt) / (ieval + 1)
+        if xi < 0.5:
+            xi = 0.5
+        elif xi > 2.0:
+            xi = 2.0
+        dT *= xi
+        if dT > MAXdT:  
+            dT = MAXdT
+            failed = True
+        elif dT < MINdT:
+            dT = MINdT  
+            failed = True
+        return failed, dT
+    
+    def setFuelBoundary():
+        reactants = ''
+        for i, molecules in enumerate(fuel):
+            reactants += str(fuel[i]) + ':' + str(fuel_fraction[i])
+            if len(fuel) > 1 and i < len(fuel) - 1:
+                reactants += ','
+        if mole_fractions:
+            f.fuel_inlet.X = reactants
+            gas.TPX = Tfuel, target_pressure, reactants
+        else:
+            f.fuel_inlet.Y = reactants
+            gas.TPY = Tfuel, target_pressure, reactants
+    
+    def setOxidBoundary():
+        reactants = ''
+        for i, molecules in enumerate(oxidizer):
+            reactants += str(oxidizer[i]) + ':' + str(oxidizer_fraction[i])
+            if len(oxidizer) > 1 and i < len(oxidizer) - 1:
+                reactants += ','
+        if mole_fractions:
+            f.oxidizer_inlet.X = reactants
+            gas.TPX = Toxidizer, target_pressure, reactants
+        else:
+            f.oxidizer_inlet.Y = reactants
+            gas.TPY = Toxidizer, target_pressure, reactants
+
+    def molarFuelAirRatio():
+        setFuelBoundary()
+        setOxidBoundary()
+        x = 0.0
+        y = 0.0
+        for j in range(0, gas.n_elements):
+            if gas.element_names[j] == 'C':
+                for i in range(gas.n_species):
+                    x += f.fuel_inlet.X[i] * gas.n_atoms(gas.species_names[i], gas.element_names[j])
+            if gas.element_names[j] == 'H':
+                for i in range(gas.n_species):
+                    y += f.fuel_inlet.X[i] * gas.n_atoms(gas.species_names[i], gas.element_names[j])
+        stoic_num_oxid_moles = x + y / 4.0
+        
+        return stoic_num_oxid_moles
+
+    def stoicFuelAirRatio():
+        """
+        Here we are assuming that fuel is only on the left and oxidizer on the right.
+        This formulation is only for diffusion flamelets
+        """
+        setFuelBoundary()
+        setOxidBoundary()
+
+        numerator = np.dot(f.fuel_inlet.X, gas.molecular_weights)           
+        denominator = np.dot (f.oxidizer_inlet.X, gas.molecular_weights)
+        denominator *= molarFuelAirRatio() * np.sum(f.oxidizer_inlet.X) / f.oxidizer_inlet.X[f.flame.component_index('O2')-5]
+
+        return numerator /  denominator
+
+    def flameEquilbrium():
+        Z = np.zeros((len(initial_grid),1))   
+        Zstoic = stoicFuelAirRatio()
+        Zfuel = 1.0
+        Zoxid = 0.0
+        
+        modified_fuel_fraction = np.zeros(len(fuel_fraction), dtype= 'float')
+        modified_fuel_fraction[:] = fuel_fraction
+        
+        for k in range(len(initial_grid)):
+            Tinter = (Tfuel - Toxidizer) * (f.grid[k] - f.grid[-1]) / (f.grid[0] - f.grid[-1]) + Toxidizer
+            Z[k] = Zfuel + (initial_grid[k] - table.start) * (Zstoic - Zfuel) / (0.5 * (table.end - table.start) - table.start)
+
+            if Z[k] < Zstoic:
+                Z[k] = Zoxid + (initial_grid[k] - table.end) * (Zstoic - Zoxid) / (0.5 * (table.end - table.start) - table.end)
+
+            if Z[k] < 1.0:
+                phi = np.asscalar(Z[k]) / (1.0 -  np.asscalar(Z[k])) / Zstoic
+                   
+                if phi > 0.0:
+                    reactants = ''
+                    shared_species = []
+                    # if species is in both the fuel and oxidizer streams Cantera cannot take duplicates
+                    for j, fuel_species in enumerate(fuel):
+                        for i, oxidizer_species in enumerate(oxidizer):
+                            if oxidizer_species == fuel_species:
+                                shared_species.append(fuel_species)
+                                temp = molarFuelAirRatio() * oxidizer_fraction[i] / oxidizer_fraction[0] / phi                             
+                                modified_fuel_fraction[j] = fuel_fraction[j] + temp
+                    for i, molecules in enumerate(fuel):
+                        reactants += str(fuel[i]) + ':' + str(modified_fuel_fraction[i])
+                        if len(fuel) > 1 and i < len(fuel) - 1:
+                            reactants += ','                    
+                        if len(shared_species) < len(oxidizer):
+                            reactants += ','
+                    for i, molecules in enumerate(oxidizer):
+                        if molecules not in shared_species:
+                            reactants += str(oxidizer[i]) + ':' \
+                            + str( molarFuelAirRatio() * oxidizer_fraction[i] / \
+                            oxidizer_fraction[0]/ phi)
+                            if len(oxidizer) > 1 and i < len(oxidizer) - 1:
+                                reactants += ','
+
+                    if mole_fractions:
+                        gas.TPX = Tinter, pressure, reactants
+                    else:
+                        gas.TPY = Tinter, pressure, reactants
+                    gas.equilibrate('HP')
+                
+                    T = gas.T
+                    f.set_value(1, 'T', k, T)
+                    for j in range(gas.n_species):
+                        f.set_value(1, 5 + j, k, gas.Y[j])
+                else:
+                    f.set_value(1, 'T', k, Toxidizer)
+                    for j in range(gas.n_species):
+                        f.set_value(1, 5 + j, k, f.oxidizer_inlet.Y[j])
+            else:
+                f.set_value(1, 'T', k, Tfuel)
+                for j in range(gas.n_species):
+                    f.set_value(1, 5 + j, k, f.fuel_inlet.Y[j])
+                    
+    def limits():
+        file =  open("equilibrium_table.txt", "w")
+        Zstoic = stoicFuelAirRatio()
+        Zfuel = 1.0
+        Zoxid = 0.0
+        Z = np.linspace(Zoxid, Zfuel, 101)
+        
+        modified_fuel_fraction = np.zeros(len(fuel_fraction), dtype= 'float')
+        modified_fuel_fraction[:] = fuel_fraction
+        for n in range(len(Z)):
+            if Z[n] == 0.0:
+            #maximum value of progress variable (C) as function of mixture fractiton(Z)
+                file.write("%f %f\n" % (Zoxid, 0.0)) 
+
+            elif Z[n] > 0.0 and Z[n] < 1.0:
+                phi = np.asscalar(Z[n]) / (1.0 -  np.asscalar(Z[n])) / Zstoic
+                
+                reactants = ''
+                shared_species = []
+                # if species is in both the fuel and oxidizer streams Cantera cannot take duplicates
+                for j, fuel_species in enumerate(fuel):
+                    for i, oxidizer_species in enumerate(oxidizer):
+                        if oxidizer_species == fuel_species:
+                            shared_species.append(fuel_species)
+                            temp = molarFuelAirRatio() * oxidizer_fraction[i] / oxidizer_fraction[0] / phi                             
+                            modified_fuel_fraction[j] = fuel_fraction[j] + temp
+                for i, molecules in enumerate(fuel):
+                    reactants += str(fuel[i]) + ':' + str(modified_fuel_fraction[i])
+                    if len(fuel) > 1 and i < len(fuel) - 1:
+                        reactants += ','                    
+                    if len(shared_species) < len(oxidizer):
+                        reactants += ','
+                for i, molecules in enumerate(oxidizer):
+                    if molecules not in shared_species:
+                        reactants += str(oxidizer[i]) + ':' \
+                        + str( molarFuelAirRatio() * oxidizer_fraction[i] / \
+                        oxidizer_fraction[0]/ phi)
+                        if len(oxidizer) > 1 and i < len(oxidizer) - 1:
+                            reactants += ','    
+                if mole_fractions:
+                    gas.TPX = 0.5*(Tfuel+Toxidizer), pressure, reactants
+                else:
+                    gas.TPY = 0.5*(Tfuel+Toxidizer), pressure, reactants
+                gas.equilibrate('HP')
+                
+                C_limit = 0.0
+                for species in composition:
+                    C_limit += gas.Y[gas.species_index(species)]
+                file.write("%f %f\n" % (Z[n], C_limit)) 
+
+            elif Z[n] == 1.0:
+            #mixture fraction(Z) vs. maximum value of progress variable (C)
+                file.write("%f %f\n" % (Zfuel, 0.0)) 
+
+        file.close()  
+                       
+    # Exponents for the initial solution variation with changes in strain rate
+    # Taken from Fiala and Sattelmayer (2014)
+    exp_d_a = - 1. / 2.
+    exp_u_a = 1. / 2.
+    exp_V_a = 1.
+    exp_lam_a = 2.
+    exp_mdot_a = 1. / 2.
+
+    #Flame object
+    f = ct.CounterflowDiffusionFlame(gas, initial_grid)
+    f.set_max_grid_points(1, 250)
+    f.set_max_jac_age(ss_age,ts_age)  #for some reason this was commented
+    f.set_time_step(stepsize,nstep)  # this was not here 
+    f.flame.set_steady_tolerances(default=tol_ss)
+    f.flame.set_transient_tolerances(default=tol_ts)
+    f.set_refine_criteria(ratio=ratio, slope=slope, curve=curve, prune=prune)
+    f.set_grid_min(1e-5) # we can keep this input to python script only
+    f.transport_model = transport_model
+
+    f.fuel_inlet.T = Tfuel
+    f.oxidizer_inlet.T = Toxidizer
+    f.fuel_inlet.spread_rate = 0.0
+    f.oxidizer_inlet.spread_rate = 0.0
+    target_pressure = pressure
+    f.fuel_inlet.mdot = init_fuel_flux
+    refine_grid = True # There is no need to add this one again
+    if OnePointControl == True:
+        oxidizer_flux = OxidizerMassFlux
+    else:
+        oxidizer_flux = f.oxidizer_inlet.mdot # oxidizer flux initialization
+
+    #############################
+    file_name = 'restart.xml'  
+    restart = False
+    retrySolve = True
+
+    #############################################
+    middleBranch = False
+    lowerBranch = False
+    turning = False
+    flameControl = False
+    # loop trying to solve for current temperatures
+    # allows retry if a solution fails
+    limits()
+    while retrySolve == True:
+        Continuation = True
+        stepSizeControl = False # Active/Deactive step size control
+        if restart == False:
+            #first time in solve loop
+            T_max = []
+            a_max = []
+            m_dots = []
+       
+            if IncludeFlameEquilibrium == True:
+                flameEquilbrium()
+                C_array = get_C()
+                max_C = np.max(C_array)
+                mixture_fraction_array = get_mixture_fraction()
+                FastLaminarFlamelets(max_C, mixture_fraction_array)
+                PrintFlush(-1, max(f.T), 0.000, "upper branch", "False")
+                T_max.append(max(f.T))
+                a_max.append(0.01)
+                m_dots.append(0.0)
+                if len(T_max) == 1:
+                    global_max_C = max_C
+                    iFlamesInUpperBranch = 1
+                    iFlamesInMiddleBranch = 0
+                    iFlamesInLowerBranch = 0
+                    n = 1
+                fig = plt.figure(0)
+                fig.suptitle("Fuel-Oxidizer S-Curve")
+                title_text = '{}-{} T{}={:6.1f}K, T{}={:6.1f}K, P{}={:6.0f}Pa'.format(fuel, oxidizer, "$_{Fuel}$", Tfuel, "$_{Oxidizer}$", Toxidizer, "$_{Op}$",pressure)
+                plt.title(title_text, fontsize=10)
+                plt.ylabel("Maximum Temperature, T$_{max}$ [K]")
+                plt.xlabel("Strain Rate [1/s]")
+                txtstr =  "$\Lambda$ = %6.4f\nT$_{F,fix}$=%6.1f\nT$_{Ox,fix}$=%6.1f" % (max_C, 0.0, 0.0)
+                props = dict(boxstyle='round', facecolor='wheat', alpha=1.0)
+                txt = plt.text(0.15, 0.60, txtstr, fontsize = 14, transform = fig.transFigure, verticalalignment = 'top', bbox = props)
+                plt.semilogx(a_max, T_max, 'b', figure = fig)
+                txt.set_visible(True)
+                plt.pause(0.05)
+                txt.set_visible(False)
+                if init_plot:
+                # only position initially, allows user to move afterwards
+                     mgr = plt.get_current_fig_manager()
+                     mgr.window.wm_geometry("+50+400")
+                fig1 = plt.figure(1)
+                fig1.suptitle("Counterflow Flames")
+                plt.title(title_text, fontsize=10)
+                plt.ylabel("Temperature, T [K]")
+                plt.xlabel("Mixture Fraction, Z")
+                plt.plot(mixture_fraction_array, f.T, figure = fig1)
+                if init_plot:
+                # only position initially, allows user to move afterwards
+                     mgr = plt.get_current_fig_manager()
+                     mgr.window.wm_geometry("+750+400")
+                     init_plot = False
+        
+            for i in range(precalculations):
+                PrintFlush(" Precalculations")
+                target_pressure = pressure * (i + 1) / precalculations
+                f.P = target_pressure
+        
+                reactants = ''
+                for i, molecules in enumerate(fuel):
+                    reactants += str(fuel[i]) + ':' + str(fuel_fraction[i])
+                    if len(fuel) > 1 and i < len(fuel) - 1:
+                        reactants += ','
+                if mole_fractions:
+                    f.fuel_inlet.X = reactants
+                    gas.TPX = Tfuel, target_pressure, reactants
+                else:
+                    f.fuel_inlet.Y = reactants
+                    gas.TPY = Tfuel, target_pressure, reactants
+                fuel_density = gas.density_mass
+        
+                reactants = ''
+                for i, molecules in enumerate(oxidizer):
+                    reactants += str(oxidizer[i]) + ':' + str(oxidizer_fraction[i])
+                    if len(oxidizer) > 1 and i < len(oxidizer) - 1:
+                        reactants += ','
+                if mole_fractions:
+                    f.oxidizer_inlet.X = reactants
+                    gas.TPX = Toxidizer, target_pressure, reactants
+                else:
+                    f.oxidizer_inlet.Y = reactants
+                    gas.TPY = Toxidizer, target_pressure, reactants
+                oxidizer_density = gas.density_mass
+        
+                if i > 0:
+                    f.fuel_inlet.mdot *= 1.0 # pow((i + 1)/i , 1.25)
+                f.oxidizer_inlet.mdot = f.fuel_inlet.mdot * np.sqrt(oxidizer_density/fuel_density)
+       
+                ###########################################################################
+                f.set_flame_control(1, StrainEq, UnityLewisNumber, False, False, -2000, -20, -2000, -20, False)
+                if i == 0:
+                    f.solve(loglevel=loglevel, refine_grid=refine_grid, auto=True)
+                else: 
+                    f.solve(loglevel=loglevel, refine_grid=refine_grid, auto=False)
+                PrintFlush("  Pressure      Tmax Fuel_mdot")
+                PrintFlush("%10.1f %10.1f %10.2f" % (f.P, max(f.T), f.fuel_inlet.mdot))
+            
+            f.save(data_directory + file_name, name='solution',
+            description='Cantera version ' + ct.__version__ +
+            ', reaction mechanism ' + table.reaction_mechanism, loglevel=loglevel)  
+            
+            mixture_fraction_array = get_mixture_fraction()	
+            title_text = '{}-{} T{}={:6.1f}K, T{}={:6.1f}K, P{}={:6.0f}Pa'.format(fuel, oxidizer, "$_{Fuel}$", Tfuel, "$_{Oxidizer}$", Toxidizer, "$_{Op}$",pressure)
+            fig1 = plt.figure(1)
+            fig1.suptitle("Counterflow Flames")
+            plt.title(title_text, fontsize=10)
+            plt.ylabel("Temperature, T [K]")
+            plt.xlabel("Mixture Fraction, Z")
+            plt.plot(mixture_fraction_array, f.T, figure = fig1)
+    
+
+        else:
+            # restarting solve loop after a failure
+            flameControl = True
+            middleBranch = True
+            sign = -1
+            f.restore(data_directory + file_name, name='solution', loglevel=loglevel)
+
+        # Write the limits to define accessible regions in the table
+        # Lists to save data
+        T_max.append(max(f.T))
+        a_max.append(f.strain_rate('max'))
+        m_dots.append(f.fuel_inlet.mdot)
+
+        C_array = get_C()
+        max_C = np.max(C_array)
+        if len(T_max) == 1:
+            global_max_C = max_C
+            iFlamesInUpperBranch = 1
+            iFlamesInMiddleBranch = 0
+            iFlamesInLowerBranch = 0
+            n = 1
+
+        mixture_fraction_array = get_mixture_fraction()
+        FastLaminarFlamelets(max_C, mixture_fraction_array)
+
+        iFailedSolutions = 0
+
+        if iFlamesInUpperBranch == 1:
+            fig = plt.figure(0)
+            fig.suptitle("Fuel-Oxidizer S-Curve")
+            title_text = '{}-{} T{}={:6.1f}K, T{}={:6.1f}K, P{}={:6.0f}Pa'.format(fuel, oxidizer, "$_{Fuel}$", Tfuel, "$_{Oxidizer}$", Toxidizer, "$_{Op}$",pressure)
+            plt.title(title_text, fontsize=10)
+            plt.ylabel("Maximum Temperature, T$_{max}$ [K]")
+            plt.xlabel("Maximum Strain Rate, a$_{max}$ [1/s]")
+            txtstr =  "$\Lambda$ = %6.4f\nT$_{F,fix}$=%6.1f\nT$_{Ox,fix}$=%6.1f" % (max_C, 0.0, 0.0)
+            props = dict(boxstyle='round', facecolor='wheat', alpha=1.0)
+            txt = plt.text(0.15, 0.60, txtstr, fontsize = 14, transform = fig.transFigure, verticalalignment = 'top', bbox = props)
+            plt.semilogx(a_max, T_max, 'b', figure = fig)
+            txt.set_visible(True)
+            plt.pause(0.05)
+            txt.set_visible(False)
+            if init_plot:
+            # only position initially, allows user to move afterwards
+                 mgr = plt.get_current_fig_manager()
+                 mgr.window.wm_geometry("+50+400")
+            fig1 = plt.figure(1)
+            fig1.suptitle("Counterflow Flames")
+            plt.title(title_text, fontsize=10)
+            plt.ylabel("Temperature, T [K]")
+            plt.xlabel("Mixture Fraction, Z")
+            plt.plot(mixture_fraction_array, f.T, figure = fig1)
+            if init_plot:
+            # only position initially, allows user to move afterwards
+                 mgr = plt.get_current_fig_manager()
+                 mgr.window.wm_geometry("+750+400")
+                 init_plot = False
+    
+        iflag = 0
+        f.clear_stats()
+        while Continuation:
+            stepFailed = False
+            Tfuel_j, Toxid_j = iloc(UserMaxTempPercentage)
+            Tfuel_fixed = f.T[Tfuel_j] + FuelSign * dT
+            Toxid_fixed = f.T[Toxid_j] + OxidSign * dT
+        
+            if restart == False and iFlamesInUpperBranch > UpperBranchHomotopicIter:
+                flameControl = True
+        
+            if n > 50 and turning == False:
+                if np.sign((a_max[-1] - a_max[-2]) * (a_max[-2] - a_max[-3])) < 0:
+                    middleBranch = True
+   
+            if middleBranch == True and iFlamesInMiddleBranch > 2000:
+                strain_factor = a_max[-1] / a_max[-2]
+                f.flame.grid *= strain_factor ** exp_d_a   
+                                    
+            if flameControl == False and middleBranch == False:
+                strain_factor = (n + UserStrainFactor ) / n
+                # Create an initial guess based on the previous solution
+                # Update grid
+                f.flame.grid *= strain_factor ** exp_d_a
+                normalized_grid = f.grid / (f.grid[-1] - f.grid[0])
+                # Update mass fluxes
+                f.fuel_inlet.mdot *= strain_factor ** exp_mdot_a
+                f.oxidizer_inlet.mdot *= strain_factor ** exp_mdot_a
+                # Update velocities
+                f.set_profile('u', normalized_grid, f.u * strain_factor ** exp_u_a)
+                f.set_profile('V', normalized_grid, f.V * strain_factor ** exp_V_a)
+                # Update pressure curvature
+                f.set_profile('lambda', normalized_grid, f.L * strain_factor ** exp_lam_a)
+
+            if flameControl == True:
+                oxidizer_flux = f.oxidizer_inlet.mdot
+                if OnePointControl == True:
+                    f.oxidizer_inlet.mdot = oxidizer_flux
+                f.set_flame_control(1, StrainEq, UnityLewisNumber, OnePointControl, TwoPointControl, \
+                                    Tfuel_fixed, Tfuel_j, Toxid_fixed, Toxid_j, True)
+
+            try:
+                success = True
+                f.solve(loglevel=loglevel, refine_grid=refine_grid, auto=False)  
+        
+            except Exception:
+                txt.set_visible(True)
+                success = False
+
+            if success == True:
+                txt.set_visible(False)
+                if f.extinct() == False:
+                    if n % 1 == 0:
+                        T_max.append(max(f.T))
+                        a_max.append(f.strain_rate('max'))
+                        m_dots.append(f.fuel_inlet.mdot)
+                    
+                        summary.write("%10.1f %10.1f %10.1f %10.1f %10.1f %10d %10d %10.1f %10.1f\n" % (f.strain_rate('mean'), \
+                        f.strain_rate('max'), max(f.T), Tfuel_fixed, Toxid_fixed, FuelSign, OxidSign, UserMaxTempPercentage, dT))
+                
+                    if n % 1 == 0 and T_max[-1] < T_max[-2]:
+                        f.save(data_directory + file_name, name='solution',
+                        description='Cantera version ' + ct.__version__ +
+                        ', reaction mechanism ' + table.reaction_mechanism, loglevel=0)
+
+                    C_array = get_C()
+                    max_C = np.max(C_array)
+                    mixture_fraction_array = get_mixture_fraction()
+    
+                    if n % cmean_skip == 0:
+                        FastLaminarFlamelets(max_C, mixture_fraction_array)
+                    
+                    ieval = f.eval_count_stats[-1]
+                    if middleBranch == False and lowerBranch == False:
+                        branch = 'upper branch'
+                    elif middleBranch == True and lowerBranch == False:
+                        branch = 'middle branch'
+                    elif middleBranch == False and lowerBranch == True:
+                        branch = 'lower branch'
+                    if n ==1 or n % 10 == 0:
+                        PrintFlush("     #n      Tmax       Amax         dT     branch   FlameControl?   # gridpoints")
+                    PrintFlush("%6d %10.1f %10.1f %10.2f %10s %10s %12d" \
+                            % (n, max(f.T), f.strain_rate('max'), dT, branch.split(' ')[0], str(flameControl),  f.flame.n_points))
+                    if middleBranch == False:
+                        iFlamesInUpperBranch += 1
+                    if middleBranch == True:
+                        iFlamesInMiddleBranch += 1     
+                        if T_max[-1] > T_max[-2]:
+                            PrintFlush("***********Maximum temperature higher than that of previous solution******")
+                            txt.set_visible(True)
+                            T_max.pop(-1)
+                            a_max.pop(-1)
+                            m_dots.pop(-1)
+                            Continuation = False
+                        else:
+                             summary.write("%10.1f %10.1f %10.1f %10.1f %10.1f %10d %10d %10.1f %10.1f\n" % (f.strain_rate('mean'), \
+                             f.strain_rate('max'), max(f.T), Tfuel_fixed, Toxid_fixed, FuelSign, OxidSign, UserMaxTempPercentage, dT))
+                    if iFailedSolutions > FailedSolutionsToTerminate:
+                        Continuation = False
+                else:          
+                    if turning == False:
+                        iflag = 1
+                        f.restore(data_directory + file_name, name='solution', loglevel=loglevel)
+                        flameControl = True
+            else:
+                txt.set_visible(True)
+                iflag = 1
+                iFailedSolutions += 1
+                stepSizeControl = True     
+                flameControl = True
+                stepFailed, dT = stepControl(ieval, N_opt, dT, MAXdT, MINdT)
+                PrintFlush('Calculation failed; the new value of dT is %f' % dT)
+                f.restore(data_directory + file_name, name='solution', loglevel=loglevel)
+                if stepFailed == False:
+                    continue
+                else:
+                    Continuation = False
+
+            if Continuation == True:
+                # success - create or update plot, update number of flames, perform step control
+                if success == True and T_max[-1] < T_max[-2]:
+                    fig = plt.figure(0)
+                    title_text = '{}-{} T{}={:6.1f}K, T{}={:6.1f}K, P{}={:6.0f}Pa'.format(fuel, oxidizer, "$_{Fuel}$", Tfuel, "$_{Oxidizer}$", Toxidizer, "$_{Op}$",pressure)
+                    txtstr =  "$\Lambda$ = %6.4f\nT$_{F,fix}$=%6.1f\nT$_{Ox,fix}$=%6.1f" % (max_C, Tfuel_fixed, Toxid_fixed)
+                    txt = plt.text(0.15, 0.60, txtstr, fontsize = 14, transform = fig.transFigure, verticalalignment = 'top', bbox = props)
+                    plt.semilogx(a_max, T_max, 'b', figure = fig)
+                    txt.set_visible(True)
+                    plt.pause(0.05)
+                    txt.set_visible(False)
+                    fig1 = plt.figure(1)
+                    plt.title(title_text, fontsize=10)
+                    plt.plot(mixture_fraction_array, f.T, figure = fig1)
+
+                # check for maximum number of flames
+                n += 1
+                if n > maxNumberOfFlames:
+                    continuation = False
+                    retrySolve = False;
+                    break   
+            
+                # update step control 
+                if stepSizeControl == True and flameControl == True:
+                    stepFailed, dT = stepControl(ieval, N_opt, dT, MAXdT, MINdT)
+
+            else:
+                # failed to solve, prompt user for parameter modification or exit
+                dlg = RetryDlg(OnePointControl, TwoPointControl, UserMaxTempPercentage, FuelSign, OxidSign, \
+                               MINdT, MAXdT, dT, oxidizer_flux, cmean_skip)
+                retrySolve = dlg.WaitResult()
+                OnePointControl = dlg.one_point_control
+                TwoPointControl = dlg.two_point_control
+                UserMaxTempPercentage = dlg.max_temp
+                FuelSign = dlg.fuel_sign
+                OxidSign = dlg.oxidizer_sign
+                MINdT = dlg.mindt
+                MAXdT = dlg.maxdt
+                dT = dlg.dt
+                oxidizer_flux = dlg.mdot_oxidizer
+                cmean_skip = dlg.cmean_skip
+                restart = True
+
+    # Calculating C = 0.0
+    txt.set_visible(False)
+    f.fuel_inlet.mdot *= 100
+    f.oxidizer_inlet.mdot *=100
+    f.set_max_grid_points(1, 101)
+    for j in range(len(f.grid)):
+        Tinter = min(Tfuel,Toxidizer)
+        f.set_value(1, 'T', j, Tinter)	
+    f.set_flame_control(1, StrainEq, UnityLewisNumber, False, False, -2000, -20, -2000, -20, False)
+    f.solve(loglevel=loglevel, refine_grid=False, auto=False)
+    T_max.append(max(f.T))
+    a_max.append(f.strain_rate('max'))
+    m_dots.append(f.fuel_inlet.mdot)
+    C_array = get_C()
+    max_C = np.abs(np.max(C_array))
+    mixture_fraction_array = get_mixture_fraction()
+    FastLaminarFlamelets(max_C, mixture_fraction_array)
+    PrintFlush("%6d %10.1f %10.1f %10.2f %10s %10s %12d" \
+            % (n, max(f.T), f.strain_rate('max'), dT, "lower", "False", f.flame.n_points))
+    fig = plt.figure(0)
+    title_text = '{}-{} T{}={:6.1f}K, T{}={:6.1f}K, P{}={:6.0f}Pa'.format(fuel, oxidizer, "$_{Fuel}$", Tfuel, "$_{Oxidizer}$", Toxidizer, "$_{Op}$",pressure)
+    txtstr =  "$\Lambda$ = %6.4f\nT$_{F,fix}$=%6.1f\nT$_{Ox,fix}$=%6.1f" % (0.0, Tfuel, Toxidizer)
+    txt = plt.text(0.15, 0.60, txtstr, fontsize = 14, transform = fig.transFigure, verticalalignment = 'top', bbox = props)
+    plt.semilogx(a_max[:-1], T_max[:-1], 'b', figure = fig)
+    plt.semilogx([a_max[-1], max(a_max)], [T_max[-1], T_max[-1]], 'b', figure = fig)
+    txt.set_visible(True)
+#    plt.pause(1000)
+    fig1 = plt.figure(1)
+    plt.plot(mixture_fraction_array, f.T, figure = fig1)
+
+    # all done, close the file
+    fast_file.close()
+    summary.close()
+    
+    dlg = MessageDlg("1D Counterflow Flames Complete!")
+    dlg.WaitResult()
+    plt.close('all')
+
+
+# start of main
+if __name__ == "__main__":    
+
+    # Declare the list of acceptable program options.
+    longOptions = ['input=', 'output=', 'help', 'debug']
+
+    # Parse the program arguments and place them in convenient format in "options"
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'dh', longOptions)
+        options = dict()
+        for o,a in optlist:
+            options[o] = a
+        if args:
+            raise getopt.GetoptError('Unexpected command line option: ' + repr(' '.join(args)))
+    except getopt.GetoptError as e:
+        PrintFlush('Error parsing arguments:')
+        PrintFlush(e)
+        PrintFlush('Run "PDFScript.py --help" to see options.')
+        sys.exit(1)
+
+    plt.ion()
+    DiffusionFlame(options)
+    sys.exit()

--- a/interfaces/cython/cantera/examples/onedim/freely_propagating_flames.py
+++ b/interfaces/cython/cantera/examples/onedim/freely_propagating_flames.py
@@ -1,0 +1,502 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+import cantera as ct
+import numpy as np
+import warnings
+import os
+import sys
+import matplotlib
+import matplotlib.pyplot as plt
+import getopt
+
+from table_def import TableDef
+from Utils import MessageDlg, PrintFlush
+
+def FreelyPropagatingFlames(option):
+
+    # Suppress matplotlib warnings
+    warnings.filterwarnings("ignore",category=matplotlib.cbook.mplDeprecation)
+
+    PrintFlush("Start flamelet generation of FPI type")
+
+    # Set up a data directory for later reference
+    data_directory = r"C:\WinPython-64bit-3.5.3.0Qt5\notebooks/"
+    if not os.path.exists(data_directory):
+        os.makedirs(data_directory)
+
+    # Create a summary file for later reference
+    file=open('premixed_flamelets.fla','w')
+    summary=open('Summary.txt','w')
+    summary.write('phi       SL      Tmax\n')
+
+    # IdealGasMix object used to compute mixture properties, set to the state of the 
+    # upstream fuel-air mixture
+
+    # read in table definition file
+    table = TableDef()
+    if table.Read() != True:
+        return
+    table.Report()
+
+    """
+    ****************** begining of inputs ***************************************
+    """
+
+    """
+    The following entry is obtained from the C# dialog models tab
+    """
+
+    gas = ct.Solution(table.reaction_mechanism)
+
+    """
+    end of models tab
+    """
+
+    """
+    The values below are coming from the C# dialog boundaries tab.
+    """
+    pressure = table.pressure # pressure [Pa], information passed from C# dialog GUI
+    Tfuel =  table.Tfuel # unburned gas temperature [K], information pass from C# dialog GUI
+    Toxidizer = table.Toxidizer # unburned gas temperature [K], information pass from C# dialog GUI
+    mole_fractions = table.mole_fractions # this information is passed from C# dialog GUI
+    fuel = table.fuel  #the user chooses the fuel, this should be an array; this are the species which are greater than zero
+                    # in the GUI
+    fuel_fraction = table.fuel_fraction # this fraction is passed from the GUI
+    oxidizer = table.oxidizer #the user chooses the oxidizer, this should be array; these are species > 0
+    oxidizer_fraction = table.oxidizer_fraction #these are the mole fractions chosesn by user
+    """
+    end of boundary information
+    """
+
+    """
+    The values below are coming from the C# dialog numerics tab.
+    """
+    initial_grid = np.linspace(table.start, table.end, table.num_points) # m, originally 20cm
+    tol_ss = [table.ss_rel,table.ss_abs] # [rtol atol] for steady-state problem
+    tol_ts = [table.tr_rel,table.tr_abs] # [rtol atol] for time stepping
+    ss_age = table.ss_age  #Set the maximum number of times the Jacobian will be used before it must be re-evaluated by the steady solver.
+    ts_age = table.ts_age  #Set the maximum number of times the Jacobian will be used before it must be re-evaluated by the transient solver. 
+    stepsize = table.stepsize # initial time step in seconds
+    nstep = table.nstep # sequence of integer numbers
+    loglevel = table.loglevel # amount of diagnostic output (0 to 8)
+    refine_grid = table.refine  # 'True' to enable refinement, 'False' to disable
+    temperature_limit_extinction =  table.temperature_limit_extinction # K  #lets add this parameter to the numerics tab
+    ratio = table.ratio
+    slope = table.slope
+    curve = table.curve
+    prune = table.prune
+    expected_lean_extinction = table.expected_lean_extinction # fuel-lean extinction limit
+    expected_rich_extinction = table.expected_rich_extinction # fuel-rich extinction limit
+    """
+    end of boundary information
+    """
+
+    """
+    The values below are coming from the C# dialog flamelet tab.
+    For now only one entry is being passed because we are developing the laminar flamelet
+    """
+    composition = table.composition  # progress variable definition
+    z_points = table.z_points #number of fmean. This is the same as 21 in inital_grid variable above
+    transport_model = table.transport_model # this can be either mix or multi
+    """
+    end of flamelet information
+    """
+    """
+    ********************* output control tab ****************************
+    """
+    YQOI = table.YQOI #user chooses species mass fraction to output
+    RRQOI = table.RRQOI  # user chooses species net reaction rates (kg/m^3-s) to output
+    """
+    ***************************end of output control tab*******************************
+    """
+
+
+    """
+    ***********************end of inputs ****************************************
+    """
+
+
+    """******************************************************************************
+    *****************The settings for the Cantera flamelet calculations are set here
+    """
+    Tin = 0.5 * (Tfuel +Toxidizer)
+    C_atoms = 0.0
+    H_atoms = 0.0
+    # Computing the stoichiometric fuel/air ratio (molar_sfar)
+    for molecules in fuel:
+        for i, char in enumerate(molecules):
+            if char == 'C':
+                flag = True
+                C_atoms = 1
+                if i + 1  < len(molecules):
+                    for atoms in gas.element_names:
+                        if molecules[i+1] == atoms:
+                            flag = False
+                    if flag == True:
+                        C_atoms = int(molecules[i+1])
+            if char == 'H':
+                flag = True
+                H_atoms = 1
+                if i + 1 < len(molecules):
+                    for atoms in gas.element_names:
+                        if molecules[i+1] == atoms:
+                            flag = False
+                    if flag == True:
+                        H_atoms = int(molecules[i+1])
+
+    molar_sfar =  C_atoms + H_atoms / 4
+
+    # Calculate the mass-based stoichiometric fuel air ratio (sfar)
+    num = 0
+    for i, molecules in enumerate(fuel):
+        if mole_fractions:
+            num += gas.molecular_weights[gas.species_index(fuel[i])] * fuel_fraction[i]
+        else:
+            num += fuel_fraction[i] / gas.molecular_weights[gas.species_index(fuel[i])]
+    if mole_fractions == False:
+        num /= num
+    # Let's assume oxidation must have some amount of O2
+    for i, molecules in enumerate(oxidizer):
+        if molecules == 'O2':
+            O2_index = i
+                                     
+    den = 0
+    for i, molecules in enumerate(oxidizer):
+        if mole_fractions:
+            den += gas.molecular_weights[gas.species_index(oxidizer[i])] * oxidizer_fraction[i] / oxidizer_fraction[O2_index]
+        else:
+            den += oxidizer_fraction[i] / gas.molecular_weights[gas.species_index(fuel[i])]
+    if mole_fractions == False:
+        den /= den
+
+    sfar= num / (molar_sfar * den)
+    PrintFlush("Stoichiometric fuel ratio: ",sfar)
+
+    # discretization of the mixture fraction (fmean) space
+    npts = int(z_points/3)
+    np_rich = 2*npts
+    z_list = []
+    for z_marker in range(0,z_points):
+        if z_marker <= npts + 1:
+            z_list.append(z_marker*sfar/npts)
+
+        elif z_marker <= np_rich :
+            z_list.append(sfar + sfar*(z_marker-npts)/(np_rich-npts))
+
+        else:
+            z_list.append(2*sfar + (1-2*sfar)*(z_marker-np_rich)/(z_points-1-np_rich))
+    PrintFlush("Number of cases:",len(z_list))
+
+    reactants_stoic = ''
+    for i, molecules in enumerate(fuel):
+        reactants_stoic += fuel[i] + ':' + str(fuel_fraction[i]) + ','
+    for i, molecules in enumerate(oxidizer):
+        reactants_stoic += oxidizer[i]+ ':' + str(molar_sfar * oxidizer_fraction[i] / oxidizer_fraction[O2_index])
+        if len(oxidizer) > 1 and i < len(oxidizer) - 1:
+            reactants_stoic += ','
+    gas.TPX = Tin, pressure, reactants_stoic
+
+    #Flame object
+    f = ct.FreeFlame(gas, initial_grid)
+    f.set_max_jac_age(ss_age,ts_age)
+    f.set_time_step(stepsize,nstep)
+    f.flame.set_steady_tolerances(default=tol_ss)
+    f.flame.set_transient_tolerances(default=tol_ts)
+
+    if transport_model == 'Unity':
+        PrintFlush("Unity = true")
+        UnityLewisNumber = True
+    else:
+        PrintFlush("Unity = false")
+        UnityLewisNumber = False
+
+    f.set_flame_control(1, False, UnityLewisNumber, False, False, -2000, -20, -2000, -20)
+    if refine_grid == True:
+        f.set_refine_criteria(ratio=ratio, slope=slope, curve=curve, prune=prune)
+
+    """
+    ********************end of Cantera settings for flamelet calculations***************************************
+    """
+    flamespeed_matrix = []
+    T_max_matrix = []
+    adiabatic_matrix = []
+
+#    plt.ion()
+    init_plot = True
+    for index, mixture_fraction in enumerate(z_list):
+        # premixed gas composition to Cantera
+        if mixture_fraction != 1.0 and mixture_fraction != 0.0:
+            phi = mixture_fraction / (1.0-mixture_fraction) / sfar
+            reactants = ''
+            for i, molecules in enumerate(fuel):
+                reactants += fuel[i] + ':' + str(fuel_fraction[i]) + ','
+            for i, molecules in enumerate(oxidizer):
+                reactants += oxidizer[i]+ ':' + str((molar_sfar / phi )* oxidizer_fraction[i] / oxidizer_fraction[O2_index])
+                if len(oxidizer) > 1 and i < len(oxidizer) - 1:
+                    reactants += ','
+        elif mixture_fraction == 1.0:
+            phi = 100000
+            reactants = ''
+            for i, molecules in enumerate(fuel):
+                reactants += fuel[i] + ':' + str(fuel_fraction[i]) + ','
+            for i, molecules in enumerate(oxidizer):
+                reactants += oxidizer[i]+ ':0.0' 
+                if len(oxidizer) > 1 and i < len(oxidizer) - 1:
+                    reactants += ','
+        elif mixture_fraction == 0.0:
+            phi = 0.0
+            reactants = ''
+            for i, molecules in enumerate(fuel):
+                reactants += fuel[i] + ':0.0,'
+            for i, molecules in enumerate(oxidizer):
+                reactants += oxidizer[i]+ ':' + str(oxidizer_fraction[i] / oxidizer_fraction[O2_index]) 
+                if len(oxidizer) > 1 and i < len(oxidizer) - 1:
+                    reactants += ','
+        f.inlet.X = reactants
+       
+        # Initialize flame object
+        gas.TPX = Tin, pressure, reactants
+        gas.equilibrate('hp')    
+        adiabatic_matrix.append(gas.T)
+        gas.TPX = Tin, pressure, reactants
+       
+        try:
+            #if phi > expected_lean_extinction and phi < expected_rich_extinction: 
+            f.solve(loglevel=loglevel, refine_grid=refine_grid, auto=True)           
+            if transport_model == 'Multi':
+                f.transport_model = 'Multi'
+                f.solve(loglevel, refine_grid=refine_grid,auto=False)
+                gas.TPX = Tin, pressure, reactants
+                gas.equilibrate('hp')
+            if f.u[0] > 0.0 and mixture_fraction > 0.0 and mixture_fraction < 1.0:
+                PrintFlush('Flamespeed = %6.4f m/s for phi = %4.2f' % (f.u[0], phi))
+            else:
+                PrintFlush("Freely propagating premixed flame solution replaced with equilibrium calculation")
+                #spurious_solution = True
+                gas.TPX = Tin, pressure, reactants
+                f = ct.FreeFlame(gas, np.linspace(table.start, table.end, 2))
+                gas.equilibrate('hp')
+                f.set_value(1, 'T', 1, gas.T)
+                for j in range(gas.n_species):
+                    f.set_value(1, 5 + j, 1, gas.Y[j])
+
+        except Exception as e:
+                PrintFlush("Freely propagating premixed flame solution replaced with equilibrium calculation")
+                #spurious_solution = True
+                gas.TPX = Tin, pressure, reactants
+                f = ct.FreeFlame(gas, np.linspace(table.start, table.end, 2))
+                gas.equilibrate('hp')
+                f.set_value(1, 'T', 1, gas.T)
+                for j in range(gas.n_species):
+                    f.set_value(1, 5 + j, 1, gas.Y[j])
+
+        flamespeed_matrix.append(f.u[0])
+        T_max_matrix.append(f.T[-1])
+        fig = plt.figure(0)
+        fig.suptitle("Hybrid Equilibrium/Premixed Flames Manifold")
+        title_text = '{}-{} T{}={:6.1f}K, T{}={:6.1f}K, P{}={:6.0f}Pa'.format(fuel, oxidizer, "$_{Fuel}$", Tfuel, "$_{Oxidizer}$", Toxidizer, "$_{Op}$",pressure)
+        plt.title(title_text, fontsize=10)
+        plt.plot(z_list[:index+1],T_max_matrix,c='b')
+        plt.xlabel("Mixture Fraction, Z")
+        plt.ylabel("Maximum Temperature, T$_{max}$ [K]")
+        plt.pause(0.05)
+        if init_plot:
+        # only position initially, allows user to move afterwards
+            mgr = plt.get_current_fig_manager()
+            mgr.window.wm_geometry("+50+400")
+        fig1 = plt.figure(1)
+        fig1.suptitle("Equilibrium Calculation and Premixed Flames")
+        plt.title(title_text, fontsize=10)
+        plt.ylabel("Temperature, T [K]")
+        plt.xlabel("Progress Variable, C")
+        C_variable = []
+        for i in range(len(f.grid)):
+            reaction_progress=0.0
+            for name in composition:
+                reaction_progress += f.Y[gas.species_index(name),i]
+            C_variable.append(reaction_progress)
+        if init_plot:
+        # only position initially, allows user to move afterwards
+            mgr = plt.get_current_fig_manager()
+            mgr.window.wm_geometry("+750+400")
+            init_plot = False
+        plt.plot(C_variable, f.T, figure = fig1)
+
+        """
+        ***********************Writes the flamelet table *****************************
+        ********************************************************************************
+        """   
+        # Storing flamelet information
+        file.write('HEADER\n')
+        file.write('PREMIX_CHI 0.0000\n')
+        #Proceeding with the output
+        file.write('Z  %6.6f\n' % mixture_fraction)
+        file.write('NUMOFSPECIES    %3d\n' % len(gas.Y))
+        file.write('GRIDPOINTS    %3d\n' % (len(f.grid)))
+        file.write('PRESSURE %6.2f\n' % gas.P)
+        file.write('BODY\n')
+        file.write('REACTION_PROGRESS\n')    
+        # Calculate and write the progress variable
+        C_variable = []
+        for i in range(0,len(f.grid)):
+            reaction_progress=0.0
+            for name in composition:
+                reaction_progress += f.Y[gas.species_index(name),i]
+            C_variable.append(reaction_progress)
+        max_C = max(C_variable)
+    
+        Lambda_variable = np.zeros(len(f.grid))
+        for i in range(len(f.grid)):
+            if i == 0:
+                Lambda_variable[i] = 0.0
+            elif i == len(f.grid)-1:
+                Lambda_variable[i] = 1.0
+            else:
+                Lambda_variable[i] = C_variable[i]/max_C
+
+        for i in range(0,len(f.grid)):
+            file.write('%15.9e '% C_variable[i])
+            if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                file.write('\n')   
+
+        # Write temperature
+        file.write('\nTEMPERATURE\n')
+        for i in range(0,len(f.grid)):
+            file.write('%15.9e '% f.T[i])
+            if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                file.write('\n')            
+   
+        # Write heat capacity 
+        file.write('\nCp\n')
+        for i in range(0,len(f.grid)):
+            file.write('%15.9e '% f.cp_mass[i])
+            if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                file.write('\n')    
+        
+        # Write mean molecular weight 
+        file.write('\nMMW\n')
+        for i in range(0,len(f.grid)):
+            file.write('%15.9e '% np.dot(f.X[:,i],gas.molecular_weights[:]))
+            if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                file.write('\n')    
+
+        # Write density 
+        file.write('\nrho\n')
+        for i in range(0,len(f.grid)):
+            file.write('%15.9e '% f.density_mass[i])
+            if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                file.write('\n')
+        
+        # Write viscosity 
+        file.write('\nmu\n')
+        for i in range(0,len(f.grid)):
+            file.write('%15.9e '% f.viscosity[i])
+            if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                file.write('\n')
+        
+        # Write thermal conductivity
+        file.write('\nTC\n')
+        for i in range(0,len(f.grid)):
+            file.write('%15.9e '% f.thermal_conductivity[i])
+            if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                file.write('\n')
+
+        # Writing reaction progress source
+        file.write('\nPREMIX_CDOT\n')
+        for i in range(0,len(f.grid)):
+            source=0.0
+            for name in composition:
+                source += (f.net_production_rates[gas.species_index(name),i] * gas.molecular_weights[gas.species_index(name)]) 
+            file.write('%15.9e '% source)
+            if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                    file.write('\n')                     
+                
+        # Write net production rates
+        for name in RRQOI:
+            file.write('\nnet_rxn-'+name+'\n')
+            for i in range(0,len(f.grid)):
+                source = f.net_production_rates[gas.species_index(name),i] * gas.molecular_weights[gas.species_index(name)]
+                file.write('%15.9e '% source)
+                if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                    file.write('\n')                
+
+        # Write species mass fractions
+        for name in YQOI:    
+            file.write('\nmassfraction-'+name+'\n')
+            for i in range(0,len(f.grid)):
+                if f.Y[gas.species_index(name),i] < 1e-10 or ((name not in YQOI) and i == 0):  
+                    file.write('%15.9e '% 0)
+                else:
+                    file.write('%15.9e '% f.Y[gas.species_index(name),i])
+                if ((i+1)%5==0 and (i+1) != len(f.grid)):
+                    file.write('\n')
+                
+        file.write('\n')
+        file.write('\n')
+    
+        # Write a calculation summary
+        summary.write('%6.3f  %6.3f    %6.2f\n' % (phi, f.u[0], np.max(f.T)))
+
+        """
+        ***********************the flamelet table completed ******************************
+        ********************************************************************************
+        """
+    # Politely close all relevant files    
+    file.close()
+    summary.close()    
+
+    dlg = MessageDlg("Freely Propagating Premixed Flames Complete!")
+    dlg.WaitResult()
+    plt.close('all')
+
+
+# start of main
+if __name__ == "__main__":    
+
+    # Declare the list of acceptable program options.
+    longOptions = ['input=', 'output=', 'help', 'debug']
+
+    # Parse the program arguments and place them in convenient format in "options"
+    try:
+        optlist, args = getopt.getopt(sys.argv[1:], 'dh', longOptions)
+        options = dict()
+        for o,a in optlist:
+            options[o] = a
+        if args:
+            raise getopt.GetoptError('Unexpected command line option: ' + repr(' '.join(args)))
+    except getopt.GetoptError as e:
+        PrintFlush('Error parsing arguments:')
+        PrintFlush(e)
+        PrintFlush('Run "PDFScript.py --help" to see options.')
+        sys.exit(1)
+
+    plt.ion()
+    FreelyPropagatingFlames(options)
+    sys.exit()

--- a/interfaces/cython/cantera/examples/onedim/table_def.py
+++ b/interfaces/cython/cantera/examples/onedim/table_def.py
@@ -1,0 +1,763 @@
+# -*- coding: utf-8 -*-
+
+#################################################################################################
+## Copyright (C) 2017 The University Of Dayton. All Rights Reserved.
+##
+## No part of this program may be photocopied, transferred, or otherwise reproduced in machine
+## or human readable form without the prior written consent of The University Of Dayton.
+#################################################################################################
+#################################################################################################
+## THIS SOFTWARE IS PROVIDED "AS IS" AND ANY EXPRESSED OR IMPLIED WARRANTIES,
+## INCLUDING, BUT NOT LIMITED TO, THE IMPLIED WARRANTIES OF MERCHANTABILITY AND
+## FITNESS FOR A PARTICULAR PURPOSE ARE DISCLAIMED. IN NO EVENT SHALL THE
+## UNIVERSITY OF DAYTON OR CONTRIBUTORS BE LIABLE FOR ANY DIRECT, INDIRECT,
+## INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL DAMAGES (INCLUDING, BUT NOT
+## LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR SERVICES; LOSS OF USE, DATA,
+## OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER CAUSED AND ON ANY THEORY OF
+## LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY, OR TORT (INCLUDING
+## NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE OF THIS SOFTWARE,
+## EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.  THE UNIVERSITY OF DAYTON
+## HAS NO OBLIGATION TO SUPPORT THE SOFTWARE.
+#################################################################################################
+
+"""
+Please cite this work as follows:
+Briones, A.M., Olding, R., Sykes, J.P., Rankin, B.A., McDevitt, K., Heyne, J.S., 
+"Combustion Modeling Software Development, Verification and Validation," Proceedings of the 2018 ASME Power & Energy Conference,
+PowerEnergy2018-7433, Lake Buena Vista, FL. 
+"""
+
+import os
+import tkinter
+import sys
+
+from Utils import PrintFlush
+
+###############################################################################
+#
+#  Defines class used to read the table definition
+#
+###############################################################################
+
+class TableDef():
+
+    def __init__(self):
+        
+        # initialize all member variables organized by tab
+        
+        # models tab
+        self._reaction_mechanism = 'gri30.xml'
+        self._model = "FPI"
+        self._flow = "Turbulent"
+
+        # boundary tab
+        self._pressure = 101325.0 # pressure [Pa], information passed from C# dialog GUI
+        self._Tfuel =  300.0 # unburned gas temperature [K], information pass from C# dialog GUI
+        self._Toxidizer = 300.0 # unburned gas temperature [K], information pass from C# dialog GUI
+        self._mole_fractions = True # this information is passed from C# dialog GUI
+        self._fuel = ['CH4']  #the user chooses the fuel, this should be an array; this are the species which are greater than zero
+                        # in the GUI
+        self._fuel_fraction = [1.0] # this fraction is passed from the GUI
+        self._oxidizer = ['O2', 'N2'] #the user chooses the oxidizer, this should be array; these are species > 0
+        self._oxidizer_fraction = [0.21, 0.79] #these are the mole fractions chosen by user
+        self._init_fuel_flux = 0.1 #kg/m^2-s, this is only a FPV input
+
+        # numerics tab
+        self._start = 0.0 # starting point (X0)
+        self._end = 0.2 # ending point (X1)
+        self._num_points = 21 # number of points between X0 and X1
+        self._ss_rel = 1.0e-7 # steady state relative
+        self._ss_abs = 1.0e-11 # steady state absolute
+        self._tr_rel = 1.0e-7 # transient relative
+        self._tr_abs = 1.0e-11 # transient absolute
+        self._ss_age = 5  #Set the maximum number of times the Jacobian will be used before it must be re-evaluated by the steady solver.
+        self._ts_age = 5  #Set the maximum number of times the Jacobian will be used before it must be re-evaluated by the transient solver. 
+        self._stepsize = 1e-5 # initial time step in seconds
+        self._nstep = [2,5,10,20] # sequence of integer numbers
+        self._loglevel = 0 # amount of diagnostic output (0 to 8)
+        self._refine = True  # 'True' to enable refinement, 'False' to disable
+        self._temperature_limit_extinction =  2000 # K  #lets add this parameter to the numerics tab
+        self._ratio = 10.0
+        self._slope = 0.2
+        self._curve = 0.2
+        self._prune = 0.05
+        self._expected_lean_extinction = 0.6 # fuel-lean extinction limit; THIS IS NOT NEEDED FOR FPV
+        self._expected_rich_extinction = 6.0 # fuel-rich extinction limit; THIS IS NOT NEEDED FOR FPV
+
+        # Table Generator tab
+        self._composition=['CO','CO2','H2','H2O']  # progress variable definition
+        self._z_points = 21 #number of fmean. This is the same as 21 in inital_grid variable above
+        self._cmean_skip = 5 # number of cmean_skip for cmean entry in the GUI
+        self._transport_model = 'Mix' # this can be either mix or multi or unity
+        self._hmean = 0 # enthalpy levels
+        self._nZVar = 0 # mixture fraction variance (fvar)
+        self._nCVar = 0 # progress variance (cvar)
+        self._z_component = ['H', 'O'] # list of elements
+        self._pdf_type = "Beta"
+
+        # Flamelet Control
+        self._strain_rate = False
+        self._precalculations = 1
+        self._user_strain_factor = 1.0
+        self._zero_order_steps = 500
+        self._user_max_temp_percentage = 0.9
+        self._fuel_sign = -1
+        self._oxidizer_sign = -1
+        self._dT = 20.0
+        self._failed_solutions_to_terminate = 10
+        self._max_num_flames = 10000
+        self._nopt = 20
+        self._max_dT = 20.0
+        self._min_dT = 1.0
+        self._one_point_control = False
+        self._two_point_control = True
+        self._oxidizer_mass_flux = 0.0
+
+        # output tab
+        self._YQOI = ['CO','CO2','H2','H2O','CH4','O2','N2','NO'] #user chooses species mass fraction to output
+        self._RRQOI = ['CO','CO2','H2','H2O']  # user chooses species net reaction rates (kg/m^3-s) to output
+        self.interpolation_type = 'slinear'
+
+
+    @property
+    def reaction_mechanism(self):
+        '''reaction_mechanism'''
+        return self._reaction_mechanism
+
+    @property
+    def model(self):
+        '''model'''
+        return self._model
+
+    @property
+    def flow(self):
+        '''flow'''
+        return self._flow
+
+    @property
+    def pressure(self):
+        '''pressure'''
+        return self._pressure
+
+    @property
+    def Tfuel(self):
+        '''fuel temperature'''
+        return self._Tfuel
+
+    @property
+    def Toxidizer(self):
+        '''oxidizer temperature'''
+        return self._Toxidizer
+
+    @property
+    def mole_fractions(self):
+        '''mole fraction'''
+        return self._mole_fractions
+
+    @property
+    def fuel(self):
+        '''fuels array'''
+        return self._fuel
+
+    @property
+    def fuel_fraction(self):
+        '''fuel fraction array'''
+        return self._fuel_fraction
+
+    @property
+    def oxidizer(self):
+        '''oxidizers array'''
+        return self._oxidizer
+
+    @property
+    def oxidizer_fraction(self):
+        '''oxidizer fractions array'''
+        return self._oxidizer_fraction
+
+    @property
+    def init_fuel_flux(self):
+        '''initial fuel flux'''
+        return self._init_fuel_flux
+ 
+    @property
+    def start(self):
+        '''start (x0)'''
+        return self._start
+ 
+    @property
+    def end(self):
+        '''end (x1)'''
+        return self._end
+ 
+    @property
+    def num_points(self):
+        '''num_points'''
+        return self._num_points
+ 
+    @property
+    def ss_rel(self):
+        '''steady state relative (ss_rel)'''
+        return self._ss_rel
+ 
+    @property
+    def ss_abs(self):
+        '''steady state absolute (ss_abs)'''
+        return self._ss_abs
+ 
+    @property
+    def tr_rel(self):
+        '''transient relative (tr_rel)'''
+        return self._tr_rel
+ 
+    @property
+    def tr_abs(self):
+        '''transient absolute (tr_abs)'''
+        return self._tr_abs
+ 
+    @property
+    def ss_age(self):
+        '''steady state jacobian age (ss_age)'''
+        return self._ss_age
+ 
+    @property
+    def ts_age(self):
+        '''transient jacobian age (ts_age)'''
+        return self._ts_age
+ 
+    @property
+    def stepsize(self):
+        '''time step size'''
+        return self._stepsize
+
+    @property
+    def nstep(self):
+        '''time step nums (nstep)'''
+        return self._nstep
+ 
+    @property
+    def loglevel(self):
+        '''log level'''
+        return self._loglevel
+ 
+    @property
+    def refine(self):
+        '''refine grid'''
+        return self._refine
+ 
+    @property
+    def temperature_limit_extinction(self):
+        '''temperature limit extinction'''
+        return self._temperature_limit_extinction
+ 
+    @property
+    def ratio(self):
+        '''grid point spacing ratio (ratio)'''
+        return self._ratio
+ 
+    @property
+    def slope(self):
+        '''grid point spacing slope (slope)'''
+        return self._slope
+ 
+    @property
+    def curve(self):
+        '''grid point spacing curve (curve)'''
+        return self._curve
+ 
+    @property
+    def prune(self):
+        '''grid point spacing prune (prune)'''
+        return self._prune
+  
+    @property
+    def expected_lean_extinction(self):
+        '''expected lean extinction'''
+        return self._expected_lean_extinction
+  
+    @property
+    def expected_rich_extinction(self):
+        '''expected rich extinction'''
+        return self._expected_rich_extinction
+  
+    @property
+    def composition(self):
+        '''progress variable definition array (composition)'''
+        return self._composition
+  
+    @property
+    def z_points(self):
+        '''fmean (z_points)'''
+        return self._z_points
+  
+    @property
+    def cmean_skip(self):
+        '''number progress points (cmean_skip)'''
+        return self._cmean_skip
+  
+    @property
+    def transport_model(self):
+        '''transport model'''
+        return self._transport_model
+  
+    @property
+    def hmean(self):
+        '''number enthalpy levels (hmean)'''
+        return self._hmean
+  
+    @property
+    def nZVar(self):
+        '''mixture fraction variance (nZVar))'''
+        return self._nZVar
+   
+    @property
+    def nCVar(self):
+        '''progress variance (nCVar)'''
+        return self._nCVar
+   
+    @property
+    def z_component(self):
+        '''progress element list (z_component)'''
+        return self._z_component
+
+    @property
+    def pdf_type(self):
+        '''pdf distribution type'''
+        return self._pdf_type
+      
+    @property
+    def YQOI(self):
+        '''array of species mass fraction to output (YQOI)'''
+        return self._YQOI
+    
+    @property
+    def RRQOI(self):
+        '''array of species net reaction rates to output (RRQOI)'''
+        return self._RRQOI
+    
+    @property
+    def strain_rate(self):
+        '''use strain equations flag'''
+        return self._strain_rate
+    
+    @property
+    def precalculations(self):
+        '''initialization pressure'''
+        return self._precalculations
+    
+    @property
+    def user_strain_factor(self):
+        '''user strain factor'''
+        return self._user_strain_factor
+    
+    @property
+    def zero_order_steps(self):
+        '''max number of scaled zero order continuation'''
+        return self._zero_order_steps
+    
+    @property
+    def user_max_temp_percentage(self):
+        '''max temperature percentage'''
+        return self._user_max_temp_percentage
+    
+    @property
+    def fuel_sign(self):
+        '''increase or decrease fuel side'''
+        return self._fuel_sign
+    
+    @property
+    def oxidizer_sign(self):
+        '''increase or decrease oxidizer side'''
+        return self._oxidizer_sign
+    
+    @property
+    def dT(self):
+        '''temperature reduction delta'''
+        return self._dT
+    
+    @property
+    def failed_solutions_to_terminate(self):
+        '''number of solution iterations before failing'''
+        return self._failed_solutions_to_terminate
+    
+    @property
+    def max_num_flames(self):
+        '''maximum number of flames'''
+        return self._max_num_flames
+    
+    @property
+    def nopt(self):
+        '''optimum number of newton iterations'''
+        return self._nopt
+    
+    @property
+    def max_dT(self):
+        '''maximum temperature reduction'''
+        return self._max_dT
+    
+    @property
+    def min_dT(self):
+        '''minmum temperature reduction'''
+        return self._min_dT
+    
+    @property
+    def one_point_control(self):
+        '''one point control'''
+        return self._one_point_control
+    
+    @property
+    def two_point_control(self):
+        '''two point control'''
+        return self._two_point_control
+    
+    @property
+    def oxidizer_mass_flux(self):
+        '''oxidizer mass flux'''
+        return self._oxidizer_mass_flux
+
+    # method that reads in TableDefinition.txt file and updates member variables
+    def Read(self):
+        # read in fuels definition file
+        PrintFlush("*** reading input file - TableDefinition.txt ***")
+        try:
+            file3=open('TableDefinition.txt', 'r')
+
+        except Exception:
+            PrintFlush("*** Error reading input file - TableDefinition.txt")
+            PrintFlush("*** Make sure Working Directory set to path where python scripts reside")
+            return False
+
+        #read cantera file name
+        temp = file3.readline().split("=")
+        self._reaction_mechanism = temp[1].strip()
+
+        #read flow
+        temp = file3.readline().split("=")
+        self._flow = temp[1].strip()
+
+        # read mole fraction flag
+        temp = file3.readline().split("=")
+        fraction = temp[1].strip()
+        if fraction == "Mole":
+                self._mole_fractions = True
+        else:
+                self._mole_fractions = False
+
+        # read pressure
+        temp = file3.readline().split("=")
+        self._pressure = float(temp[1].strip())
+
+        # read fuel Temperature
+        temp = file3.readline().split("=")
+        self._Tfuel = float(temp[1].strip())
+
+        # read oxidizer Temperature
+        temp = file3.readline().split("=")
+        self._Toxidizer = float(temp[1].strip())
+
+        #read fuels
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        self._fuel = temp.split()
+
+        #read fuel fraction
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        fraction_array = temp.split()
+        self._fuel_fraction =  [float(i) for i in fraction_array]
+
+        #read oxidizers
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        self._oxidizer = temp.split()
+
+        #read oxidizer fraction
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        oxidizer_array = temp.split()
+        self._oxidizer_fraction =  [float(i) for i in oxidizer_array]
+
+        #read start (x0)
+        temp = file3.readline().split("=")
+        self._start = float(temp[1].strip())
+
+        #read end (x1)
+        temp = file3.readline().split("=")
+        self._end = float(temp[1].strip())
+
+        #read number of points
+        temp = file3.readline().split("=")
+        self._num_points = int(temp[1].strip())
+
+        #read steady state absolute
+        temp = file3.readline().split("=")
+        self._ss_abs = float(temp[1].strip())
+
+        #read steady state relative
+        temp = file3.readline().split("=")
+        self._ss_rel = float(temp[1].strip())
+
+        #read transient absolute
+        temp = file3.readline().split("=")
+        self._tr_abs = float(temp[1].strip())
+
+        #read transient relative
+        temp = file3.readline().split("=")
+        self._tr_rel = float(temp[1].strip())
+
+        #read log level
+        temp = file3.readline().split("=")
+        self._loglevel = int(temp[1].strip())
+
+        #read refine grid flag
+        temp = file3.readline().split("=")
+        itemp = int(temp[1].strip())
+        if itemp == 0:
+            self._refine = False
+        else:
+            self._refine = True
+            
+        #read steady state jacobian age
+        temp = file3.readline().split("=")
+        self._ss_age = int(temp[1].strip())
+            
+        #read transient jacobian age
+        temp = file3.readline().split("=")
+        self._ts_age = int(temp[1].strip())
+
+        #read time step size
+        temp = file3.readline().split("=")
+        self._stepsize = float(temp[1].strip())
+
+        #read time step nums
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        step_nums_array = temp.split()
+        self._nstep =  [int(i) for i in step_nums_array]
+
+        #read temperature limit extinction
+        temp = file3.readline().split("=")
+        self._temperature_limit_extinction = float(temp[1].strip())
+
+        #read expected lean extinction
+        temp = file3.readline().split("=")
+        self._expected_lean_extinction = float(temp[1].strip())
+
+        #read expected rich extinction
+        temp = file3.readline().split("=")
+        self._expected_rich_extinction = float(temp[1].strip())
+ 
+        #read grid point spacing ratio
+        temp = file3.readline().split("=")
+        self._ratio = float(temp[1].strip())
+
+        #read grid point slope
+        temp = file3.readline().split("=")
+        self._slope = float(temp[1].strip())
+
+        #read grid point curve
+        temp = file3.readline().split("=")
+        self._curve = float(temp[1].strip())
+
+        #read grid point prune
+        temp = file3.readline().split("=")
+        self._prune = float(temp[1].strip())
+
+        #read species mass fraction to output
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        self._YQOI = temp.split()
+
+        #read species net reaction rates (kg/m^3-s) to output
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        self._RRQOI = temp.split()
+
+        #read progress variable definition
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        self._composition = temp.split()
+
+        #read fmean
+        temp = file3.readline().split("=")
+        self._z_points = int(temp[1].strip())
+
+        #read transport model
+        temp = file3.readline().split("=")
+        self._transport_model = temp[1].strip()
+
+        #read initial fuel flux (FPV only)
+        temp = file3.readline().split("=")
+        self._init_fuel_flux = float(temp[1].strip())
+
+        #read number of progress points (cmean)
+        temp = file3.readline().split("=")
+        self._cmean_skip = int(temp[1].strip())
+
+        #read number of enthalpy levels (hmean)
+        temp = file3.readline().split("=")
+        self._hmean = int(temp[1].strip())
+
+        #read mixture fraction variance (fvar)
+        temp = file3.readline().split("=")
+        self._nZVar = int(temp[1].strip())
+
+        #read progress variance (cvar)
+        temp = file3.readline().split("=")
+        self._nCVar = int(temp[1].strip())
+        
+        #read element list
+        temp = file3.readline().split("=")
+        temp = temp[1].strip()
+        self._z_component = temp.split()
+
+        #read pdf type
+        temp = file3.readline().split("=")
+        self._pdf_type = temp[1].strip()
+
+        #read strain rate flag
+        temp = file3.readline().split("=")
+        itemp = int(temp[1].strip())
+        if itemp == 0:
+            self._strain_rate = False
+        else:
+            self._strain_rate = True
+
+        #read precalculations
+        temp = file3.readline().split("=")
+        self._precalculations = int(temp[1].strip())
+
+        #read user_strain_factor
+        temp = file3.readline().split("=")
+        self._user_strain_factor = float(temp[1].strip())
+
+        #read zero_order_steps
+        temp = file3.readline().split("=")
+        self._zero_order_steps = int(temp[1].strip())
+
+        #read user_max_temp_percentage
+        temp = file3.readline().split("=")
+        self._user_max_temp_percentage = float(temp[1].strip())/100.0
+
+        #read fuel_sign
+        temp = file3.readline().split("=")
+        self._fuel_sign = int(temp[1].strip())
+
+        #read oxidizer_sign
+        temp = file3.readline().split("=")
+        self._oxidizer_sign = int(temp[1].strip())
+
+        #read dT
+        temp = file3.readline().split("=")
+        self._dT = float(temp[1].strip())
+
+        #read failed_solutions_to_terminate
+        temp = file3.readline().split("=")
+        self._failed_solutions_to_terminate = int(temp[1].strip())
+
+        #read max_num_flames
+        temp = file3.readline().split("=")
+        self._max_num_flames = int(temp[1].strip())
+
+        #read nopt
+        temp = file3.readline().split("=")
+        self._nopt = int(temp[1].strip())
+
+        #read max_dT
+        temp = file3.readline().split("=")
+        self._max_dT = float(temp[1].strip())
+
+        #read min_dT
+        temp = file3.readline().split("=")
+        self._min_dT = float(temp[1].strip())
+
+        #read one point control flag flag
+        temp = file3.readline().split("=")
+        itemp = int(temp[1].strip())
+        if itemp == 0:
+            self._one_point_control = False
+        else:
+            self._one_point_control = True
+
+        #read two point control flag flag
+        temp = file3.readline().split("=")
+        itemp = int(temp[1].strip())
+        if itemp == 0:
+            self._two_point_control = False
+        else:
+            self._two_point_control = True
+
+        #read oxidizer_mass_flux
+        temp = file3.readline().split("=")
+        self._oxidizer_mass_flux = float(temp[1].strip())
+
+        #read model
+        temp = file3.readline().split("=")
+        self._model = temp[1].strip()
+
+        PrintFlush("*** input file read complete ***")
+        file3.close()
+        return True
+
+     # method that prints contents of member variables
+    def Report(self):
+        PrintFlush("*** Reporting contents of TableDef ***")
+        PrintFlush(TableDef.reaction_mechanism.__doc__ + " = ",self.reaction_mechanism)
+        PrintFlush(TableDef.flow.__doc__ + " = ",self.flow)
+        PrintFlush(TableDef.mole_fractions.__doc__ + " = ", self.mole_fractions)
+        PrintFlush(TableDef.pressure.__doc__ + " = ", str(self.pressure))
+        PrintFlush(TableDef.Tfuel.__doc__ + " = ", str(self.Tfuel))
+        PrintFlush(TableDef.Toxidizer.__doc__ + " = ", str(self.Toxidizer))
+        PrintFlush(TableDef.fuel.__doc__ + " = ", self.fuel)
+        PrintFlush(TableDef.fuel_fraction.__doc__ + " = ", [str(i) for i in self.fuel_fraction])
+        PrintFlush(TableDef.oxidizer.__doc__ + " = ", self.oxidizer)
+        PrintFlush(TableDef.fuel_fraction.__doc__ + " = ", [str(i) for i in self.fuel_fraction])
+        PrintFlush(TableDef.start.__doc__ + " = ", str(self.start))
+        PrintFlush(TableDef.end.__doc__ + " = ", str(self.end))
+        PrintFlush(TableDef.num_points.__doc__ + " = ", str(self.num_points))
+        PrintFlush(TableDef.ss_abs.__doc__ + " = ", str(self.ss_abs))
+        PrintFlush(TableDef.ss_rel.__doc__ + " = ", str(self.ss_rel))
+        PrintFlush(TableDef.tr_abs.__doc__ + " = ", str(self.tr_abs))
+        PrintFlush(TableDef.tr_rel.__doc__ + " = ", str(self.tr_rel))
+        PrintFlush(TableDef.loglevel.__doc__ + " = ", str(self.loglevel))
+        PrintFlush(TableDef.refine.__doc__ + " = ", self.refine)
+        PrintFlush(TableDef.ss_age.__doc__ + " = ", str(self.ss_age))
+        PrintFlush(TableDef.ts_age.__doc__ + " = ", str(self.ts_age))
+        PrintFlush(TableDef.stepsize.__doc__ + " = ", str(self.stepsize))
+        PrintFlush(TableDef.nstep.__doc__ + " = ", [str(i) for i in self.nstep])
+        PrintFlush(TableDef.temperature_limit_extinction.__doc__ + " = ", str(self.temperature_limit_extinction))
+        PrintFlush(TableDef.expected_lean_extinction.__doc__ + " = ", str(self.expected_lean_extinction))
+        PrintFlush(TableDef.expected_rich_extinction.__doc__ + " = ", str(self.expected_rich_extinction))
+        PrintFlush(TableDef.ratio.__doc__ + " = ", str(self.ratio))
+        PrintFlush(TableDef.slope.__doc__ + " = ", str(self.slope))
+        PrintFlush(TableDef.curve.__doc__ + " = ", str(self.curve))
+        PrintFlush(TableDef.prune.__doc__ + " = ", str(self.prune))
+        PrintFlush(TableDef.YQOI.__doc__ + " = ", self.YQOI)
+        PrintFlush(TableDef.RRQOI.__doc__ + " = ", self.RRQOI)
+        PrintFlush(TableDef.composition.__doc__ + " = ", self.composition)
+        PrintFlush(TableDef.z_points.__doc__ + " = ", str(self.z_points))
+        PrintFlush(TableDef.transport_model.__doc__ + " = ", self.transport_model)
+        PrintFlush(TableDef.init_fuel_flux.__doc__ + " = ", str(self.init_fuel_flux))
+        PrintFlush(TableDef.cmean_skip.__doc__ + " = ", str(self.cmean_skip))
+        PrintFlush(TableDef.hmean.__doc__ + " = ", str(self.hmean))
+        PrintFlush(TableDef.nZVar.__doc__ + " = ", str(self.nZVar))
+        PrintFlush(TableDef.nCVar.__doc__ + " = ", str(self.nCVar))
+        PrintFlush(TableDef.z_component.__doc__ + " = ", self.z_component)
+        PrintFlush(TableDef.pdf_type.__doc__ + " = ", self._pdf_type)
+        PrintFlush(TableDef.strain_rate.__doc__ + " = ", str(self.strain_rate))
+        PrintFlush(TableDef.precalculations.__doc__ + " = ", str(self.precalculations))
+        PrintFlush(TableDef.user_strain_factor.__doc__ + " = ", str(self.user_strain_factor))
+        PrintFlush(TableDef.zero_order_steps.__doc__ + " = ", str(self.zero_order_steps))
+        PrintFlush(TableDef.user_max_temp_percentage.__doc__ + " = ", str(self.user_max_temp_percentage))
+        PrintFlush(TableDef.fuel_sign.__doc__ + " = ", str(self.fuel_sign))
+        PrintFlush(TableDef.oxidizer_sign.__doc__ + " = ", str(self.oxidizer_sign))
+        PrintFlush(TableDef.dT.__doc__ + " = ", str(self.dT))
+        PrintFlush(TableDef.failed_solutions_to_terminate.__doc__ + " = ", str(self.failed_solutions_to_terminate))
+        PrintFlush(TableDef.max_num_flames.__doc__ + " = ", str(self.max_num_flames))
+        PrintFlush(TableDef.nopt.__doc__ + " = ", str(self.nopt))
+        PrintFlush(TableDef.max_dT.__doc__ + " = ", str(self.max_dT))
+        PrintFlush(TableDef.min_dT.__doc__ + " = ", str(self.min_dT))
+        PrintFlush(TableDef.one_point_control.__doc__ + " = ", str(self.one_point_control))
+        PrintFlush(TableDef.two_point_control.__doc__ + " = ", str(self.two_point_control))
+        PrintFlush(TableDef.oxidizer_mass_flux.__doc__ + " = ", str(self.oxidizer_mass_flux))
+        PrintFlush(TableDef.model.__doc__ + " = ", str(self.model))
+        PrintFlush("*** Report Complete ***")

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -525,17 +525,6 @@ void Sim1D::setRefineCriteria(int dom, doublereal ratio,
     }
 }
 
-vector_fp Sim1D::getRefineCriteria(int dom)
-{
-   if (dom >= 0) {
-       Refiner& r = domain(dom).refiner();
-       return r.getCriteria();
-   } else {
-       throw CanteraError("Sim1D::getRefineCriteria",
-           "Must specify domain to get criteria from");
-   }
-}
-
 void Sim1D::setGridMin(int dom, double gridmin)
 {
     if (dom >= 0) {
@@ -607,6 +596,22 @@ void Sim1D::resize()
     OneDim::resize();
     m_x.resize(size(), 0.0);
     m_xnew.resize(size(), 0.0);
+}
+
+// added by udri to set a plance equation used by the stflow class
+void Sim1D::setFlameControl(size_t dom, 
+							bool strainRateEqEnabled,
+							bool UnityLewisNumber,
+							bool onePointEnabled,
+							bool twoPointEnabled, 
+							doublereal Tfuel, 
+							int Tfuel_j, 
+							doublereal Toxid, 
+							int Toxid_j,
+							bool reactionsEnabled)
+{
+	
+	domain(dom).setFlameControl(strainRateEqEnabled, UnityLewisNumber, onePointEnabled, twoPointEnabled, Tfuel, Tfuel_j, Toxid, Toxid_j, reactionsEnabled);
 }
 
 }


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:
The development was performed on Cantera 2.3 but I think it can be integrated in the Master.

Fixes #

Changes proposed in this pull request:
- The Cantera code was modified to handle S-curve calculations of opposed flows.
- Unity Lewis number capability was also added.
- Energy equation source terms can be activated/deactivated from the python script.
- Many python scripts are added to perform FPI and FPV turbulence-chemistry interactions.
- This tabulations can be used to run CFD simulations of reacting flows.
