### PR TITLE
Add cython func defn to expose species viscosity & add test

### DIFF
--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -111,6 +111,7 @@ TRANSPORT_1D(getMixDiffCoeffs)
 TRANSPORT_1D(getMixDiffCoeffsMass)
 TRANSPORT_1D(getMixDiffCoeffsMole)
 TRANSPORT_1D(getThermalDiffCoeffs)
+TRANSPORT_1D(getSpeciesViscosities)
 
 TRANSPORT_2D(getMultiDiffCoeffs)
 TRANSPORT_2D(getBinaryDiffCoeffs)

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -388,6 +388,7 @@ cdef extern from "cantera/transport/TransportBase.h" namespace "Cantera":
         double viscosity() except +translate_exception
         double thermalConductivity() except +translate_exception
         double electricalConductivity() except +translate_exception
+        void getSpeciesViscosities(double*) except +translate_exception
 
 
 cdef extern from "cantera/transport/DustyGasTransport.h" namespace "Cantera":
@@ -856,6 +857,7 @@ cdef extern from "cantera/cython/wrappers.h":
     cdef void tran_getMixDiffCoeffsMass(CxxTransport*, double*) except +translate_exception
     cdef void tran_getMixDiffCoeffsMole(CxxTransport*, double*) except +translate_exception
     cdef void tran_getThermalDiffCoeffs(CxxTransport*, double*) except +translate_exception
+    cdef void tran_getSpeciesViscosities(CxxTransport*, double*) except +translate_exception
 
     cdef void tran_getMultiDiffCoeffs(CxxTransport*, size_t, double*) except +translate_exception
     cdef void tran_getBinaryDiffCoeffs(CxxTransport*, size_t, double*) except +translate_exception

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -88,6 +88,20 @@ class TestTransport(utilities.CanteraTest):
         self.assertNear(gas1.thermal_conductivity, gas2.thermal_conductivity)
         self.assertArrayNear(gas1.multi_diff_coeffs, gas2.multi_diff_coeffs)
 
+    def test_species_visosities(self):
+        for species_name in self.phase.species_names:
+            # check that species viscosity matches overall for single-species
+            # state
+            self.phase.X = {species_name: 1}
+            self.phase.TP = 800, 2*ct.one_atm
+            visc = self.phase.viscosity
+            self.assertNear(self.phase[species_name].species_viscosities[0],
+                            visc)
+            # and ensure it doesn't change with pressure
+            self.phase.TP = 800, 5*ct.one_atm
+            self.assertNear(self.phase[species_name].species_viscosities[0],
+                            visc)
+
 
 class TestTransportGeometryFlags(utilities.CanteraTest):
     phase_data = """

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -147,6 +147,11 @@ cdef class Transport(_SolutionBase):
         def __get__(self):
             return self.transport.viscosity()
 
+    property species_viscosities:
+        """Pure species viscosities [Pa-s]"""
+        def __get__(self):
+            return get_transport_1d(self, tran_getSpeciesViscosities)
+
     property electrical_conductivity:
         """Electrical conductivity. [S/m]."""
         def __get__(self):


### PR DESCRIPTION
Fixes (N/A)

Changes proposed in this pull request:
- Expose (read-only) species viscosity from transport to user in python interface 

The proposed use case here is that OpenFOAM currently doesn't implement a species transport model based on standard kinetic theory (i.e., involving Lennard-Jones, dipole moment, well-depth etc.).  Long term, it would be nice to build a Cantera interface for OpenFOAM (IIRC, this is one of the GSoC challenges?), but in the meantime this can be worked around as follows:

1. Use a [`sutherland` transport model](https://cfd.direct/openfoam/user-guide/thermophysical/#x35-2610007.1.2) in OpenFOAM.
2. Write a simple script using scipy `curve_fit` to determine best fit Sutherland coefficients based on Cantera 