### PR TITLE
Fix pip appveyor

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,14 +1,14 @@
 version: 1.0.{build}
 install:
 - ps: |
-    C:\Python27-x64\python.exe -m pip install --upgrade pip
     C:\Python27-x64\Scripts\pip.exe install --egg scons
-    C:\Python27-x64\Scripts\pip.exe install numpy
+    C:\Python27-x64\python.exe -m pip install --no-cache-dir --upgrade pip
+    C:\Python27-x64\Scripts\pip.exe install --no-cache-dir numpy
     C:\Python27-x64\Scripts\pip.exe install cython
     C:\Python27-x64\Scripts\pip.exe install 3to2
     C:\Python27-x64\Scripts\pip.exe install pypiwin32
-    C:\Python35-x64\python.exe -m pip install --upgrade pip
-    C:\Python35-x64\Scripts\pip.exe install numpy
+    C:\Python35-x64\python.exe -m pip install --no-cache-dir --upgrade pip
+    C:\Python35-x64\Scripts\pip.exe install --no-cache-dir numpy
 
 build_script:
 - cmd: C:\Python27-x64\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y python3_cmd=C:\Python35-x64\python.exe

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,21 +1,23 @@
 version: 1.0.{build}
 install:
 - ps: |
-    C:\Python27-x64\Scripts\pip.exe install --egg scons
     C:\Python27-x64\python.exe -m pip install --no-cache-dir --upgrade pip
+    C:\Python27-x64\python.exe -m pip install --upgrade setuptools
+    C:\Python27-x64\python.exe -m pip install --upgrade --no-warn-script-location wheel
+    C:\Python27-x64\Scripts\pip.exe install scons
     C:\Python27-x64\Scripts\pip.exe install --no-cache-dir numpy
-    C:\Python27-x64\Scripts\pip.exe install cython
+    C:\Python27-x64\Scripts\pip.exe install --no-warn-script-location cython
     C:\Python27-x64\Scripts\pip.exe install 3to2
     C:\Python27-x64\Scripts\pip.exe install pypiwin32
     C:\Python35-x64\python.exe -m pip install --no-cache-dir --upgrade pip
     C:\Python35-x64\Scripts\pip.exe install --no-cache-dir numpy
 
 build_script:
-- cmd: C:\Python27-x64\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y python3_cmd=C:\Python35-x64\python.exe
+- cmd: C:\Python27-x64\Scripts\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y python3_cmd=C:\Python35-x64\python.exe
 
 test_script:
 - ps: |
-    C:\Python27-x64\scons test
+    C:\Python27-x64\Scripts\scons test
     $sconsstatus = $lastexitcode
     $wc = New-Object 'System.Net.WebClient'
     $wc.UploadFile("https://ci.appveyor.com/api/testresults/junit/$($env:APPVEYOR_JOB_ID)", (Resolve-Path .\test\work\gtest-general.xml))


### PR DESCRIPTION
Changes proposed in this pull request:
- Fix errors on Appveyor because of outdated/removed options to pip

Should we use Python 3.6 for the builds and tests here? It's probably a good idea to keep testing with Python 3.5 as long as we support that, but I'm not sure we test with Python 3.6 anywhere else (except the conda packages, I guess)