### PR TITLE
[SCons] implement 'googletest' option

### DIFF
--- a/ext/SConscript
+++ b/ext/SConscript
@@ -88,7 +88,7 @@ if not env['system_eigen']:
                           Copy('$TARGET', '$SOURCE')))
 
 # Google Test: Used internally for Cantera unit tests.
-if not env['system_googletest']:
+if env['googletest'] == 'submodule':
     localenv = prep_gtest(env)
     gtest = build(localenv.Library('../lib/gtest',
                                    source=['googletest/googletest/src/gtest-all.cc']))

--- a/test/SConscript
+++ b/test/SConscript
@@ -15,11 +15,15 @@ else:
 
 localenv.Prepend(CPPPATH=['#include'],
                  LIBPATH='#build/lib')
-if not env['system_googletest']:
-    localenv.Prepend(CPPPATH=['#ext/googletest/googletest/include',
+if env['googletest'] in ('system', 'submodule'):
+    if not env['system_googletest']:
+        localenv.Prepend(CPPPATH=['#ext/googletest/googletest/include',
                               '#ext/googletest/googlemock/include'])
-localenv.Append(LIBS=['gtest', 'gmock'] + cantera_libs,
-                CCFLAGS=env['warning_flags'])
+    localenv.Append(LIBS=['gtest', 'gmock'] + cantera_libs,
+                    CCFLAGS=env['warning_flags'])
+else:
+    localenv.Append(LIBS=cantera_libs,
+                    CCFLAGS=env['warning_flags'])
 
 # Turn of optimization to speed up compilation
 ccflags = localenv['CCFLAGS']
@@ -87,10 +91,11 @@ def addTestProgram(subdir, progName, env_vars={}):
     passedFile = File(pjoin(str(program[0].dir), '%s.passed' % program[0].name))
     PASSED_FILES[progName] = str(passedFile)
     testResults.tests[passedFile.name] = program
-    run_program = testenv.Command(passedFile, program, gtestRunner)
-    env.Depends(run_program, env['build_targets'])
-    env.Depends(env['test_results'], run_program)
-    Alias('test-%s' % progName, run_program)
+    if env['googletest'] != 'none':
+        run_program = testenv.Command(passedFile, program, gtestRunner)
+        env.Depends(run_program, env['build_targets'])
+        env.Depends(env['test_results'], run_program)
+        Alias('test-%s' % progName, run_program)
     env['testNames'].append(progName)
     if os.path.exists(passedFile.abspath):
         Alias('test-reset', testenv.Command('reset-%s%s' % (subdir, progName),

--- a/test/SConscript
+++ b/test/SConscript
@@ -96,7 +96,10 @@ def addTestProgram(subdir, progName, env_vars={}):
         env.Depends(run_program, env['build_targets'])
         env.Depends(env['test_results'], run_program)
         Alias('test-%s' % progName, run_program)
-    env['testNames'].append(progName)
+        env['testNames'].append(progName)
+    else:
+        testResults.failed['test-%s (googletest disabled)' % progName] = 1
+
     if os.path.exists(passedFile.abspath):
         Alias('test-reset', testenv.Command('reset-%s%s' % (subdir, progName),
                                             [], [Delete(passedFile.abspath)]))

--- a/test/SConscript
+++ b/test/SConscript
@@ -15,15 +15,14 @@ else:
 
 localenv.Prepend(CPPPATH=['#include'],
                  LIBPATH='#build/lib')
-if env['googletest'] in ('system', 'submodule'):
-    if not env['system_googletest']:
-        localenv.Prepend(CPPPATH=['#ext/googletest/googletest/include',
+localenv.Append(LIBS=cantera_libs,
+                CCFLAGS=env['warning_flags'])
+
+if env['googletest'] == 'submodule':
+    localenv.Prepend(CPPPATH=['#ext/googletest/googletest/include',
                               '#ext/googletest/googlemock/include'])
-    localenv.Append(LIBS=['gtest', 'gmock'] + cantera_libs,
-                    CCFLAGS=env['warning_flags'])
-else:
-    localenv.Append(LIBS=cantera_libs,
-                    CCFLAGS=env['warning_flags'])
+if env['googletest'] != 'none':
+    localenv.Append(LIBS=['gtest', 'gmock'])
 
 # Turn of optimization to speed up compilation
 ccflags = localenv['CCFLAGS']


### PR DESCRIPTION
Fixes #515

## Changes proposed in this pull request:

-  New scons build option introduced to replace 'system_googletest'
and allow to not use 'googletest' module while running test
(all tests that require this module could be omited)

- New option description:
```
'googletest',
"""Select whether to use gtest/gmock from system
    installation ('system'), from a Git submodule ('submodule'), to decide
    automatically ('default') or don't look for gtest/gmock ('none')
    and don't run tests that depend on gtest/gmock.
    Selection of 'none' will suppress the depricated 'system_googletest' option."""
```

- Old option is still presented and mentioned as 'depricated'.
Option 'googletest = none' supress the old 'system_googletest'.

- In other cases if they is setted explicitly and contradict to eacher other - an ERROR message appears. 

P.S.
See [attached file 'scons_test_results.txt'](https://github.com/Cantera/cantera/files/1997371/scons_test_results.txt) to compare results of running 'scons test' command before and after implimentation of new option.