### PR TITLE
Allow convertMech function to be called multiple times

### DIFF
--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -10,8 +10,7 @@ from cantera import ck2cti
 def convertMech(inputFile, outName=None, **kwargs):
     if os.path.exists(outName):
         os.remove(outName)
-    parser = ck2cti.Parser()
-    parser.convertMech(inputFile, outName=outName, **kwargs)
+    ck2cti.convertMech(inputFile, outName=outName, **kwargs)
 
 
 class chemkinConverterTest(utilities.CanteraTest):

--- a/src/base/ct2ctml.cpp
+++ b/src/base/ct2ctml.cpp
@@ -200,7 +200,7 @@ void ck2cti(const std::string& in_file, const std::string& thermo_file,
                 "    except ImportError:\n" <<
                 "        print('sys.path: ' + repr(sys.path))\n" <<
                 "        raise\n"
-                "    ck2cti.Parser().convertMech(r'" << in_file << "',";
+                "    ck2cti.convertMech(r'" << in_file << "',";
         if (thermo_file != "" && thermo_file != "-") {
             pyin << " thermoFile=r'" << thermo_file << "',";
         }


### PR DESCRIPTION
Each call to convertMech now creates a new Parser object to do the conversion, rather than requiring the user to do so themselves. The implementation as a `@classmethod` should fix the current method of using a `Parser` object to work, as well as the simpler free function `ck2cti.convertMech`.

Fixes #528.
