### PR TITLE
[Equil] Don't use saved element potentials as initial guess

### DIFF
--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -103,8 +103,7 @@ public:
      * ThermoPhase object. The properties must be already contained within the
      * current thermodynamic state of the system.
      */
-    int equilibrate(thermo_t& s, const char* XY,
-                    bool useThermoPhaseElementPotentials = false, int loglevel = 0);
+    int equilibrate(thermo_t& s, const char* XY, int loglevel = 0);
 
     /*!
      * Compute the equilibrium composition for two specified properties and the
@@ -117,16 +116,13 @@ public:
      * @param s phase object to be equilibrated
      * @param XY property pair to hold constant
      * @param elMoles specified vector of element abundances.
-     * @param useThermoPhaseElementPotentials get the initial estimate for the
-     *     chemical potentials from the ThermoPhase object (true) or create
-     *     our own estimate (false)
      * @param loglevel Specify amount of debug logging (0 to disable)
      * @return Successful returns are indicated by a return value of 0.
      *     Unsuccessful returns are indicated by a return value of -1 for lack
      *     of convergence or -3 for a singular Jacobian.
      */
     int equilibrate(thermo_t& s, const char* XY, vector_fp& elMoles,
-                    bool useThermoPhaseElementPotentials = false, int loglevel = 0);
+                    int loglevel = 0);
     const vector_fp& elementPotentials() const {
         return m_lambda;
     }

--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -123,6 +123,8 @@ public:
      */
     int equilibrate(thermo_t& s, const char* XY, vector_fp& elMoles,
                     int loglevel = 0);
+
+    //! @deprecated To be removed after Cantera 2.4.
     const vector_fp& elementPotentials() const {
         return m_lambda;
     }
@@ -266,6 +268,7 @@ protected:
     vector_fp m_molefractions;
 
     //! Current value of the dimensional element potentials. length = #m_mm
+    //! @deprecated To be removed after Cantera 2.4.
     vector_fp m_lambda;
 
     //! Current value of the sum of the element abundances given the current

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1618,10 +1618,12 @@ protected:
     doublereal m_phi;
 
     //! Vector of element potentials. Length equal to number of elements.
+    //! @deprecated To be removed after Cantera 2.4.
     vector_fp m_lambdaRRT;
 
     //! Boolean indicating whether there is a valid set of saved element
     //! potentials for this phase
+    //! @deprecated To be removed after Cantera 2.4.
     bool m_hasElementPotentials;
 
     //! Boolean indicating whether a charge neutrality condition is a necessity

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1196,12 +1196,12 @@ public:
      *  @param max_iter  For the 'gibbs' and 'vcs' solvers, this is the maximum
      *      number of outer temperature or pressure iterations to take when T
      *      and/or P is not held fixed.
-     *  @param estimate_equil integer indicating whether the solver should
-     *      estimate its own initial condition. If 0, the initial mole fraction
-     *      vector in the ThermoPhase object is used as the initial condition.
-     *      If 1, the initial mole fraction vector is used if the element
-     *      abundances are satisfied. If -1, the initial mole fraction vector is
-     *      thrown out, and an estimate is formulated.
+     *  @param estimate_equil For MultiPhaseEquil solver, an integer indicating
+     *      whether the solver should estimate its own initial condition. If 0,
+     *      the initial mole fraction vector in the ThermoPhase object is used
+     *      as the initial condition. If 1, the initial mole fraction vector is
+     *      used if the element abundances are satisfied. If -1, the initial
+     *      mole fraction vector is thrown out, and an estimate is formulated.
      *  @param log_level  loglevel Controls amount of diagnostic output.
      *      log_level=0 suppresses diagnostics, and increasingly-verbose
      *      messages are written as loglevel increases.

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1331,6 +1331,9 @@ cdef class ThermoPhase(_SolutionBase):
         defined for equilibrium states. This method first sets the composition
         to a state of equilibrium at constant T and P, then computes the
         element potentials for this equilibrium state.
+
+        .. deprecated:: 2.3
+            To be removed after Cantera 2.4.
         """
         self.equilibrate('TP')
         cdef np.ndarray[np.double_t, ndim=1] data = np.zeros(self.n_elements)

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -305,20 +305,16 @@ int ChemEquil::estimateElementPotentials(thermo_t& s, vector_fp& lambda_RT,
     return info;
 }
 
-int ChemEquil::equilibrate(thermo_t& s, const char* XY,
-                           bool useThermoPhaseElementPotentials, int loglevel)
+int ChemEquil::equilibrate(thermo_t& s, const char* XY, int loglevel)
 {
     initialize(s);
     update(s);
     vector_fp elMolesGoal = m_elementmolefracs;
-    return equilibrate(s, XY, elMolesGoal, useThermoPhaseElementPotentials,
-                       loglevel-1);
+    return equilibrate(s, XY, elMolesGoal, loglevel-1);
 }
 
 int ChemEquil::equilibrate(thermo_t& s, const char* XYstr,
-                           vector_fp& elMolesGoal,
-                           bool useThermoPhaseElementPotentials,
-                           int loglevel)
+                           vector_fp& elMolesGoal, int loglevel)
 {
     int fail = 0;
     bool tempFixed = true;
@@ -501,29 +497,12 @@ int ChemEquil::equilibrate(thermo_t& s, const char* XYstr,
 
     setInitialMoles(s, elMolesGoal,loglevel);
 
-    // If requested, get the initial estimate for the chemical potentials from
-    // the ThermoPhase object itself. Or else, create our own estimate.
-    if (useThermoPhaseElementPotentials) {
-        bool haveEm = s.getElementPotentials(x.data());
-        if (haveEm) {
-            if (s.temperature() < 100.) {
-                writelog("we are here {:g}\n", s.temperature());
-            }
-            for (size_t m = 0; m < m_mm; m++) {
-                x[m] *= 1.0 / s.RT();
-            }
-        } else {
-            estimateElementPotentials(s, x, elMolesGoal);
-        }
-    } else {
-        // Calculate initial estimates of the element potentials. This algorithm
-        // uses the MultiPhaseEquil object's initialization capabilities to
-        // calculate an initial estimate of the mole fractions for a set of
-        // linearly independent component species. Then, the element potentials
-        // are solved for based on the chemical potentials of the component
-        // species.
-        estimateElementPotentials(s, x, elMolesGoal);
-    }
+    // Calculate initial estimates of the element potentials. This algorithm
+    // uses the MultiPhaseEquil object's initialization capabilities to
+    // calculate an initial estimate of the mole fractions for a set of linearly
+    // independent component species. Then, the element potentials are solved
+    // for based on the chemical potentials of the component species.
+    estimateElementPotentials(s, x, elMolesGoal);
 
     // Do a better estimate of the element potentials. We have found that the
     // current estimate may not be good enough to avoid drastic numerical issues

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -585,9 +585,6 @@ int ChemEquil::equilibrate(thermo_t& s, const char* XYstr,
                 adjustEloc(s, elMolesGoal);
             }
 
-            // Save the calculated and converged element potentials to the
-            // original ThermoPhase object.
-            s.setElementPotentials(m_lambda);
             if (s.temperature() > s.maxTemp() + 1.0 ||
                     s.temperature() < s.minTemp() - 1.0) {
                 writelog("Warning: Temperature ({} K) outside valid range of "

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -697,8 +697,7 @@ void ThermoPhase::equilibrate(const std::string& XY, const std::string& solver,
             ChemEquil E;
             E.options.maxIterations = max_steps;
             E.options.relTolerance = rtol;
-            bool use_element_potentials = (estimate_equil == 0);
-            int ret = E.equilibrate(*this, XY.c_str(), use_element_potentials, log_level-1);
+            int ret = E.equilibrate(*this, XY.c_str(), log_level-1);
             if (ret < 0) {
                 throw CanteraError("ThermoPhase::equilibrate",
                     "ChemEquil solver failed. Return code: {}", ret);

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -702,7 +702,11 @@ void ThermoPhase::equilibrate(const std::string& XY, const std::string& solver,
                 throw CanteraError("ThermoPhase::equilibrate",
                     "ChemEquil solver failed. Return code: {}", ret);
             }
-            setElementPotentials(E.elementPotentials());
+            m_lambdaRRT.resize(nElements());
+            for (size_t m = 0; m < nElements(); m++) {
+                m_lambdaRRT[m] = E.elementPotentials()[m] / RT();
+            }
+            m_hasElementPotentials = true;
             debuglog("ChemEquil solver succeeded\n", log_level);
             return;
         } catch (std::exception& err) {
@@ -733,6 +737,8 @@ void ThermoPhase::equilibrate(const std::string& XY, const std::string& solver,
 
 void ThermoPhase::setElementPotentials(const vector_fp& lambda)
 {
+    warn_deprecated("ThermoPhase::setElementPotentials",
+        "To be removed after Cantera 2.4");
     size_t mm = nElements();
     if (lambda.size() < mm) {
         throw CanteraError("setElementPotentials", "lambda too small");
@@ -746,6 +752,8 @@ void ThermoPhase::setElementPotentials(const vector_fp& lambda)
 
 bool ThermoPhase::getElementPotentials(doublereal* lambda) const
 {
+    warn_deprecated("ThermoPhase::getElementPotentials",
+        "To be removed after Cantera 2.4");
     if (m_hasElementPotentials) {
         scale(m_lambdaRRT.begin(), m_lambdaRRT.end(), lambda, RT());
     }

--- a/test/thermo/ThermoPhase_Test.cpp
+++ b/test/thermo/ThermoPhase_Test.cpp
@@ -23,29 +23,6 @@ public:
     }
 };
 
-TEST_F(ThermoPhase_Fixture, SetAndGetElementPotentials)
-{
-  initializeElements();
-
-  // Check that getElementPotentials returns false if no element potentials have been set yet.
-  vector_fp getLambda(3);
-  EXPECT_FALSE(test_phase.getElementPotentials(&getLambda[0]));
-
-  vector_fp tooSmall(2);
-  EXPECT_THROW(test_phase.setElementPotentials(tooSmall), CanteraError);
-
-  vector_fp setLambda(3);
-  setLambda[0] = 1.;
-  setLambda[1] = 2.;
-  setLambda[2] = 3.;
-  test_phase.setElementPotentials(setLambda);
-
-  EXPECT_TRUE(test_phase.getElementPotentials(&getLambda[0]));
-  EXPECT_DOUBLE_EQ(setLambda[0], getLambda[0]);
-  EXPECT_DOUBLE_EQ(setLambda[1], getLambda[1]);
-  EXPECT_DOUBLE_EQ(setLambda[2], getLambda[2]);
-}
-
 class TestThermoMethods : public testing::Test
 {
 public:


### PR DESCRIPTION
Saved element potentials are only valid at equilibrium, and may not be a good
guess for calls to equilibrate() after the state has changed.

By always using the estimation method for the element potentials at the start of
the ChemEquil algorithm, the results of equilibrate() are repeatable, and do not
depend on the results of previous calls to equilibrate().

Resolves #524