### PR TITLE
Fixes for fmtlib 5.0.0

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -881,7 +881,7 @@ if env['system_fmt'] in ('y', 'default'):
 if env['system_fmt'] in ('n', 'default'):
     env['system_fmt'] = False
     print("""INFO: Using private installation of fmt library.""")
-    if not os.path.exists('ext/fmt/fmt/ostream.h'):
+    if not os.path.exists('ext/fmt/include/fmt/ostream.h'):
         if not os.path.exists('.git'):
             config_error('fmt is missing. Install source in ext/fmt.')
 
@@ -894,6 +894,18 @@ if env['system_fmt'] in ('n', 'default'):
             config_error('fmt submodule checkout failed.\n'
                          'Try manually checking out the submodule with:\n\n'
                          '    git submodule update --init --recursive ext/fmt\n')
+
+fmt_include = '<fmt/format.h>' if env['system_fmt'] else '"../ext/fmt/include/fmt/format.h"'
+fmt_version_source = get_expression_value([fmt_include], 'FMT_VERSION')
+retcode, fmt_lib_version = conf.TryRun(fmt_version_source, '.cpp')
+try:
+    fmt_lib_version = divmod(float(fmt_lib_version.strip()), 10000)
+    (fmt_maj, (fmt_min, fmt_pat)) = fmt_lib_version[0], divmod(fmt_lib_version[1], 100)
+    env['FMT_VERSION'] = '{major:.0f}.{minor:.0f}.{patch:.0f}'.format(major=fmt_maj, minor=fmt_min, patch=fmt_pat)
+    print('INFO: Found fmt version {}'.format(env['FMT_VERSION']))
+except ValueError:
+    env['FMT_VERSION'] = '0.0.0'
+    print('INFO: Could not find version of fmt')
 
 # Check for googletest and checkout submodule if needed
 if env['system_googletest'] in ('y', 'default'):

--- a/SConstruct
+++ b/SConstruct
@@ -1684,10 +1684,6 @@ if env['blas_lapack_libs']:
     linkLibs.extend(env['blas_lapack_libs'])
     linkSharedLibs.extend(env['blas_lapack_libs'])
 
-if env['system_fmt']:
-    linkLibs.append('fmt')
-    linkSharedLibs.append('fmt')
-
 # Store the list of needed static link libraries in the environment
 env['cantera_libs'] = linkLibs
 env['cantera_shared_libs'] = linkSharedLibs

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -36,29 +36,22 @@ def prep_gmock(env):
 
 def prep_fmt(env):
     localenv = prep_default(env)
-    if not env['system_fmt']:
-        localenv.Prepend(CPPPATH=Dir('#include/cantera/ext'))
-        license_files.append(('fmtlib', 'fmt/LICENSE.rst'))
-        for name in ('format.h', 'ostream.h', 'printf.h', 'core.h', 'format-inl.h', 'posix.h'):
-            build(copyenv.Command("#include/cantera/ext/fmt/" + name,
-                                  "#ext/fmt/include/fmt/" + name,
-                                  Copy('$TARGET', '$SOURCE')))
     return localenv
 
 # each element of libs is: (subdir, (file extensions), prepfunction)
 libs = [('libexecstream', ['cpp'], prep_default)]
 
-# fmtlib versions less than 5.0.0 had the source files for the library in a different folder.
-# Also, we expect system-installed versions of fmtlib >= 5.0.0 to have a library already compiled
-if LooseVersion(env['FMT_VERSION']) < LooseVersion('5.0.0'):
-    libs.append(('fmt/fmt', ['cc'], prep_fmt))
-elif not env['system_fmt']:
-    libs.append(('fmt/src', ['cc'], prep_fmt))
-
 for subdir, extensions, prepFunction in libs:
     localenv = prepFunction(env)
     objects = localenv.SharedObject(mglob(localenv, subdir, *extensions))
     libraryTargets.extend(objects)
+
+if not env['system_fmt']:
+    license_files.append(('fmtlib', 'fmt/LICENSE.rst'))
+    for name in ('format.h', 'ostream.h', 'printf.h', 'core.h', 'format-inl.h', 'posix.h'):
+        build(copyenv.Command("#include/cantera/ext/fmt/" + name,
+                              "#ext/fmt/include/fmt/" + name,
+                              Copy('$TARGET', '$SOURCE')))
 
 if env['system_sundials'] == 'n':
     localenv = prep_default(env)

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -34,10 +34,6 @@ def prep_gmock(env):
     return localenv
 
 
-def prep_fmt(env):
-    localenv = prep_default(env)
-    return localenv
-
 # each element of libs is: (subdir, (file extensions), prepfunction)
 libs = [('libexecstream', ['cpp'], prep_default)]
 
@@ -48,7 +44,7 @@ for subdir, extensions, prepFunction in libs:
 
 if not env['system_fmt']:
     license_files.append(('fmtlib', 'fmt/LICENSE.rst'))
-    for name in ('format.h', 'ostream.h', 'printf.h', 'core.h', 'format-inl.h', 'posix.h'):
+    for name in ('format.h', 'ostream.h', 'printf.h', 'core.h', 'format-inl.h'):
         build(copyenv.Command("#include/cantera/ext/fmt/" + name,
                               "#ext/fmt/include/fmt/" + name,
                               Copy('$TARGET', '$SOURCE')))

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -37,16 +37,23 @@ def prep_gmock(env):
 def prep_fmt(env):
     localenv = prep_default(env)
     if not env['system_fmt']:
+        localenv.Prepend(CPPPATH=Dir('#include/cantera/ext'))
         license_files.append(('fmtlib', 'fmt/LICENSE.rst'))
-        for name in ('format.h', 'ostream.h'):
+        for name in ('format.h', 'ostream.h', 'printf.h', 'core.h', 'format-inl.h', 'posix.h'):
             build(copyenv.Command("#include/cantera/ext/fmt/" + name,
-                                  "#ext/fmt/fmt/" + name,
+                                  "#ext/fmt/include/fmt/" + name,
                                   Copy('$TARGET', '$SOURCE')))
     return localenv
 
 # each element of libs is: (subdir, (file extensions), prepfunction)
-libs = [('libexecstream', ['cpp'], prep_default),
-        ('fmt/fmt', ['cc'], prep_fmt)]
+libs = [('libexecstream', ['cpp'], prep_default)]
+
+# fmtlib versions less than 5.0.0 had the source files for the library in a different folder.
+# Also, we expect system-installed versions of fmtlib >= 5.0.0 to have a library already compiled
+if LooseVersion(env['FMT_VERSION']) < LooseVersion('5.0.0'):
+    libs.append(('fmt/fmt', ['cc'], prep_fmt))
+elif not env['system_fmt']:
+    libs.append(('fmt/src', ['cc'], prep_fmt))
 
 for subdir, extensions, prepFunction in libs:
     localenv = prepFunction(env)

--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -1,4 +1,6 @@
 //! @file fmt.h Wrapper for either system-installed or local headers for fmt
+#ifndef CT_FMT_H
+#define CT_FMT_H
 #include "ct_defs.h"
 
 //! Do not use the fmt macro from fmtlib because it shadows a function of
@@ -17,4 +19,20 @@
     #include "cantera/ext/fmt/printf.h"
   #endif
   #include "cantera/ext/fmt/ostream.h"
+#endif
+
+#if !defined(FMT_VERSION) || FMT_VERSION < 50000
+namespace fmt {
+using memory_buffer = MemoryWriter;
+}
+template <typename... Args>
+void format_to(fmt::memory_buffer& b, Args... args) {
+    b.write(args...);
+}
+inline std::string to_string(fmt::memory_buffer& b) {
+    return b.str();
+}
+
+#endif
+
 #endif

--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -7,6 +7,10 @@
 //! the same name in kinetics/Group.h
 #define FMT_NO_FMT_STRING_ALIAS
 
+//! Use header-only library to avoid relocation issues with linking to the
+//! static libfmt.a
+#define FMT_HEADER_ONLY
+
 #if CT_USE_SYSTEM_FMT
   #include "fmt/format.h"
   #if defined(FMT_VERSION) && FMT_VERSION >= 40000

--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -1,6 +1,10 @@
 //! @file fmt.h Wrapper for either system-installed or local headers for fmt
 #include "ct_defs.h"
 
+//! Do not use the fmt macro from fmtlib because it shadows a function of
+//! the same name in kinetics/Group.h
+#define FMT_NO_FMT_STRING_ALIAS
+
 #if CT_USE_SYSTEM_FMT
   #include "fmt/format.h"
   #if defined(FMT_VERSION) && FMT_VERSION >= 40000

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -520,12 +520,12 @@ string CVodesIntegrator::getErrorInfo(int N)
 
     N = std::min(N, static_cast<int>(m_neq));
     sort(weightedErrors.begin(), weightedErrors.end());
-    fmt::MemoryWriter s;
+    fmt::memory_buffer s;
     for (int i=0; i<N; i++) {
-        s.write("{}: {}\n",
+        format_to(s, "{}: {}\n",
                 get<2>(weightedErrors[i]), get<1>(weightedErrors[i]));
     }
-    return s.str();
+    return to_string(s);
 }
 
 }

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -374,19 +374,19 @@ bool MolalityVPSSTP::addSpecies(shared_ptr<Species> spec)
 
 std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
 {
-    fmt::MemoryWriter b;
+    fmt::memory_buffer b;
     try {
         if (name() != "") {
-            b.write("\n  {}:\n", name());
+            format_to(b, "\n  {}:\n", name());
         }
-        b.write("\n");
-        b.write("       temperature    {:12.6g}  K\n", temperature());
-        b.write("          pressure    {:12.6g}  Pa\n", pressure());
-        b.write("           density    {:12.6g}  kg/m^3\n", density());
-        b.write("  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
+        format_to(b, "\n");
+        format_to(b, "       temperature    {:12.6g}  K\n", temperature());
+        format_to(b, "          pressure    {:12.6g}  Pa\n", pressure());
+        format_to(b, "           density    {:12.6g}  kg/m^3\n", density());
+        format_to(b, "  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
 
         doublereal phi = electricPotential();
-        b.write("         potential    {:12.6g}  V\n", phi);
+        format_to(b, "         potential    {:12.6g}  V\n", phi);
 
         vector_fp x(m_kk);
         vector_fp molal(m_kk);
@@ -404,48 +404,48 @@ std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
         size_t iHp = speciesIndex("H+");
         if (iHp != npos) {
             double pH = -log(actMolal[iHp]) / log(10.0);
-            b.write("                pH    {:12.4g}\n", pH);
+            format_to(b, "                pH    {:12.4g}\n", pH);
         }
 
         if (show_thermo) {
-            b.write("\n");
-            b.write("                          1 kg            1 kmol\n");
-            b.write("                       -----------      ------------\n");
-            b.write("          enthalpy    {:12.6g}     {:12.4g}     J\n",
+            format_to(b, "\n");
+            format_to(b, "                          1 kg            1 kmol\n");
+            format_to(b, "                       -----------      ------------\n");
+            format_to(b, "          enthalpy    {:12.6g}     {:12.4g}     J\n",
                     enthalpy_mass(), enthalpy_mole());
-            b.write("   internal energy    {:12.6g}     {:12.4g}     J\n",
+            format_to(b, "   internal energy    {:12.6g}     {:12.4g}     J\n",
                     intEnergy_mass(), intEnergy_mole());
-            b.write("           entropy    {:12.6g}     {:12.4g}     J/K\n",
+            format_to(b, "           entropy    {:12.6g}     {:12.4g}     J/K\n",
                     entropy_mass(), entropy_mole());
-            b.write("    Gibbs function    {:12.6g}     {:12.4g}     J\n",
+            format_to(b, "    Gibbs function    {:12.6g}     {:12.4g}     J\n",
                     gibbs_mass(), gibbs_mole());
-            b.write(" heat capacity c_p    {:12.6g}     {:12.4g}     J/K\n",
+            format_to(b, " heat capacity c_p    {:12.6g}     {:12.4g}     J/K\n",
                     cp_mass(), cp_mole());
             try {
-                b.write(" heat capacity c_v    {:12.6g}     {:12.4g}     J/K\n",
+                format_to(b, " heat capacity c_v    {:12.6g}     {:12.4g}     J/K\n",
                         cv_mass(), cv_mole());
             } catch (NotImplementedError&) {
-                b.write(" heat capacity c_v    <not implemented>\n");
+                format_to(b, " heat capacity c_v    <not implemented>\n");
             }
         }
 
-        b.write("\n");
+        format_to(b, "\n");
         int nMinor = 0;
         doublereal xMinor = 0.0;
         if (show_thermo) {
-            b.write("                           X        "
+            format_to(b, "                           X        "
                     "   Molalities         Chem.Pot.    ChemPotSS    ActCoeffMolal\n");
-            b.write("                                    "
+            format_to(b, "                                    "
                     "                      (J/kmol)      (J/kmol)\n");
-            b.write("                     -------------  "
+            format_to(b, "                     -------------  "
                     "  ------------     ------------  ------------    ------------\n");
             for (size_t k = 0; k < m_kk; k++) {
                 if (x[k] > threshold) {
                     if (x[k] > SmallNumber) {
-                        b.write("{:>18s}  {:12.6g}     {:12.6g}     {:12.6g}   {:12.6g}   {:12.6g}\n",
+                        format_to(b, "{:>18s}  {:12.6g}     {:12.6g}     {:12.6g}   {:12.6g}   {:12.6g}\n",
                                 speciesName(k), x[k], molal[k], mu[k], muss[k], acMolal[k]);
                     } else {
-                        b.write("{:>18s}  {:12.6g}     {:12.6g}          N/A      {:12.6g}   {:12.6g}\n",
+                        format_to(b, "{:>18s}  {:12.6g}     {:12.6g}          N/A      {:12.6g}   {:12.6g}\n",
                                 speciesName(k), x[k], molal[k], muss[k], acMolal[k]);
                     }
                 } else {
@@ -454,13 +454,13 @@ std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
                 }
             }
         } else {
-            b.write("                           X"
+            format_to(b, "                           X"
                     "Molalities\n");
-            b.write("                     -------------"
+            format_to(b, "                     -------------"
                     "     ------------\n");
             for (size_t k = 0; k < m_kk; k++) {
                 if (x[k] > threshold) {
-                    b.write("{:>18s}   {:12.6g}     {:12.6g}\n",
+                    format_to(b, "{:>18s}   {:12.6g}     {:12.6g}\n",
                             speciesName(k), x[k], molal[k]);
                 } else {
                     nMinor++;
@@ -469,12 +469,12 @@ std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
             }
         }
         if (nMinor) {
-            b.write("     [{:+5d} minor] {:12.6g}\n", nMinor, xMinor);
+            format_to(b, "     [{:+5d} minor] {:12.6g}\n", nMinor, xMinor);
         }
     } catch (CanteraError& err) {
-        return b.str() + err.what();
+        return to_string(b) + err.what();
     }
-    return b.str();
+    return to_string(b);
 }
 
 void MolalityVPSSTP::getCsvReportData(std::vector<std::string>& names,

--- a/src/thermo/MolarityIonicVPSSTP.cpp
+++ b/src/thermo/MolarityIonicVPSSTP.cpp
@@ -315,19 +315,19 @@ void MolarityIonicVPSSTP::readXMLBinarySpecies(XML_Node& xmLBinarySpecies)
 
 std::string MolarityIonicVPSSTP::report(bool show_thermo, doublereal threshold) const
 {
-    fmt::MemoryWriter b;
+    fmt::memory_buffer b;
     try {
         if (name() != "") {
-            b.write("\n  {}:\n", name());
+            format_to(b, "\n  {}:\n", name());
         }
-        b.write("\n");
-        b.write("       temperature    {:12.6g}  K\n", temperature());
-        b.write("          pressure    {:12.6g}  Pa\n", pressure());
-        b.write("           density    {:12.6g}  kg/m^3\n", density());
-        b.write("  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
+        format_to(b, "\n");
+        format_to(b, "       temperature    {:12.6g}  K\n", temperature());
+        format_to(b, "          pressure    {:12.6g}  Pa\n", pressure());
+        format_to(b, "           density    {:12.6g}  kg/m^3\n", density());
+        format_to(b, "  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
 
         doublereal phi = electricPotential();
-        b.write("         potential    {:12.6g}  V\n", phi);
+        format_to(b, "         potential    {:12.6g}  V\n", phi);
 
         vector_fp x(m_kk);
         vector_fp molal(m_kk);
@@ -342,30 +342,30 @@ std::string MolarityIonicVPSSTP::report(bool show_thermo, doublereal threshold) 
         getActivities(&actMolal[0]);
 
         if (show_thermo) {
-            b.write("\n");
-            b.write("                          1 kg            1 kmol\n");
-            b.write("                       -----------      ------------\n");
-            b.write("          enthalpy    {:12.6g}     {:12.4g}     J\n",
+            format_to(b, "\n");
+            format_to(b, "                          1 kg            1 kmol\n");
+            format_to(b, "                       -----------      ------------\n");
+            format_to(b, "          enthalpy    {:12.6g}     {:12.4g}     J\n",
                     enthalpy_mass(), enthalpy_mole());
-            b.write("   internal energy    {:12.6g}     {:12.4g}     J\n",
+            format_to(b, "   internal energy    {:12.6g}     {:12.4g}     J\n",
                     intEnergy_mass(), intEnergy_mole());
-            b.write("           entropy    {:12.6g}     {:12.4g}     J/K\n",
+            format_to(b, "           entropy    {:12.6g}     {:12.4g}     J/K\n",
                     entropy_mass(), entropy_mole());
-            b.write("    Gibbs function    {:12.6g}     {:12.4g}     J\n",
+            format_to(b, "    Gibbs function    {:12.6g}     {:12.4g}     J\n",
                     gibbs_mass(), gibbs_mole());
-            b.write(" heat capacity c_p    {:12.6g}     {:12.4g}     J/K\n",
+            format_to(b, " heat capacity c_p    {:12.6g}     {:12.4g}     J/K\n",
                     cp_mass(), cp_mole());
             try {
-                b.write(" heat capacity c_v    {:12.6g}     {:12.4g}     J/K\n",
+                format_to(b, " heat capacity c_v    {:12.6g}     {:12.4g}     J/K\n",
                         cv_mass(), cv_mole());
             } catch (NotImplementedError&) {
-                b.write(" heat capacity c_v    <not implemented>\n");
+                format_to(b, " heat capacity c_v    <not implemented>\n");
             }
         }
     } catch (CanteraError& e) {
-        return b.str() + e.what();
+        return to_string(b) + e.what();
     }
-    return b.str();
+    return to_string(b);
 }
 
 }

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -378,43 +378,43 @@ void PureFluidPhase::setState_Psat(doublereal p, doublereal x)
 
 std::string PureFluidPhase::report(bool show_thermo, doublereal threshold) const
 {
-    fmt::MemoryWriter b;
+    fmt::memory_buffer b;
     if (name() != "") {
-        b.write("\n  {}:\n", name());
+        format_to(b, "\n  {}:\n", name());
     }
-    b.write("\n");
-    b.write("       temperature    {:12.6g}  K\n", temperature());
-    b.write("          pressure    {:12.6g}  Pa\n", pressure());
-    b.write("           density    {:12.6g}  kg/m^3\n", density());
-    b.write("  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
-    b.write("    vapor fraction    {:12.6g}\n", vaporFraction());
+    format_to(b, "\n");
+    format_to(b, "       temperature    {:12.6g}  K\n", temperature());
+    format_to(b, "          pressure    {:12.6g}  Pa\n", pressure());
+    format_to(b, "           density    {:12.6g}  kg/m^3\n", density());
+    format_to(b, "  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
+    format_to(b, "    vapor fraction    {:12.6g}\n", vaporFraction());
 
     doublereal phi = electricPotential();
     if (phi != 0.0) {
-        b.write("         potential    {:12.6g}  V\n", phi);
+        format_to(b, "         potential    {:12.6g}  V\n", phi);
     }
     if (show_thermo) {
-        b.write("\n");
-        b.write("                          1 kg            1 kmol\n");
-        b.write("                       -----------      ------------\n");
-        b.write("          enthalpy    {:12.6g}     {:12.4g}     J\n",
+        format_to(b, "\n");
+        format_to(b, "                          1 kg            1 kmol\n");
+        format_to(b, "                       -----------      ------------\n");
+        format_to(b, "          enthalpy    {:12.6g}     {:12.4g}     J\n",
                 enthalpy_mass(), enthalpy_mole());
-        b.write("   internal energy    {:12.6g}     {:12.4g}     J\n",
+        format_to(b, "   internal energy    {:12.6g}     {:12.4g}     J\n",
                 intEnergy_mass(), intEnergy_mole());
-        b.write("           entropy    {:12.6g}     {:12.4g}     J/K\n",
+        format_to(b, "           entropy    {:12.6g}     {:12.4g}     J/K\n",
                 entropy_mass(), entropy_mole());
-        b.write("    Gibbs function    {:12.6g}     {:12.4g}     J\n",
+        format_to(b, "    Gibbs function    {:12.6g}     {:12.4g}     J\n",
                 gibbs_mass(), gibbs_mole());
-        b.write(" heat capacity c_p    {:12.6g}     {:12.4g}     J/K\n",
+        format_to(b, " heat capacity c_p    {:12.6g}     {:12.4g}     J/K\n",
                 cp_mass(), cp_mole());
         try {
-            b.write(" heat capacity c_v    {:12.6g}     {:12.4g}     J/K\n",
+            format_to(b, " heat capacity c_v    {:12.6g}     {:12.4g}     J/K\n",
                     cv_mass(), cv_mole());
         } catch (NotImplementedError&) {
-            b.write(" heat capacity c_v    <not implemented>\n");
+            format_to(b, " heat capacity c_v    <not implemented>\n");
         }
     }
-    return b.str();
+    return to_string(b);
 }
 
 }

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -819,40 +819,40 @@ void ThermoPhase::getdlnActCoeffdlnN_numderiv(const size_t ld, doublereal* const
 
 std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
 {
-    fmt::MemoryWriter b;
+    fmt::memory_buffer b;
     try {
         if (name() != "") {
-            b.write("\n  {}:\n", name());
+            format_to(b, "\n  {}:\n", name());
         }
-        b.write("\n");
-        b.write("       temperature    {:12.6g}  K\n", temperature());
-        b.write("          pressure    {:12.6g}  Pa\n", pressure());
-        b.write("           density    {:12.6g}  kg/m^3\n", density());
-        b.write("  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
+        format_to(b, "\n");
+        format_to(b, "       temperature    {:12.6g}  K\n", temperature());
+        format_to(b, "          pressure    {:12.6g}  Pa\n", pressure());
+        format_to(b, "           density    {:12.6g}  kg/m^3\n", density());
+        format_to(b, "  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
 
         doublereal phi = electricPotential();
         if (phi != 0.0) {
-            b.write("         potential    {:12.6g}  V\n", phi);
+            format_to(b, "         potential    {:12.6g}  V\n", phi);
         }
         if (show_thermo) {
-            b.write("\n");
-            b.write("                          1 kg            1 kmol\n");
-            b.write("                       -----------      ------------\n");
-            b.write("          enthalpy    {:12.5g}     {:12.4g}     J\n",
+            format_to(b, "\n");
+            format_to(b, "                          1 kg            1 kmol\n");
+            format_to(b, "                       -----------      ------------\n");
+            format_to(b, "          enthalpy    {:12.5g}     {:12.4g}     J\n",
                     enthalpy_mass(), enthalpy_mole());
-            b.write("   internal energy    {:12.5g}     {:12.4g}     J\n",
+            format_to(b, "   internal energy    {:12.5g}     {:12.4g}     J\n",
                     intEnergy_mass(), intEnergy_mole());
-            b.write("           entropy    {:12.5g}     {:12.4g}     J/K\n",
+            format_to(b, "           entropy    {:12.5g}     {:12.4g}     J/K\n",
                     entropy_mass(), entropy_mole());
-            b.write("    Gibbs function    {:12.5g}     {:12.4g}     J\n",
+            format_to(b, "    Gibbs function    {:12.5g}     {:12.4g}     J\n",
                     gibbs_mass(), gibbs_mole());
-            b.write(" heat capacity c_p    {:12.5g}     {:12.4g}     J/K\n",
+            format_to(b, " heat capacity c_p    {:12.5g}     {:12.4g}     J/K\n",
                     cp_mass(), cp_mole());
             try {
-                b.write(" heat capacity c_v    {:12.5g}     {:12.4g}     J/K\n",
+                format_to(b, " heat capacity c_v    {:12.5g}     {:12.4g}     J/K\n",
                         cv_mass(), cv_mole());
             } catch (NotImplementedError&) {
-                b.write(" heat capacity c_v    <not implemented>       \n");
+                format_to(b, " heat capacity c_v    <not implemented>       \n");
             }
         }
 
@@ -865,19 +865,19 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
         int nMinor = 0;
         doublereal xMinor = 0.0;
         doublereal yMinor = 0.0;
-        b.write("\n");
+        format_to(b, "\n");
         if (show_thermo) {
-            b.write("                           X     "
+            format_to(b, "                           X     "
                     "            Y          Chem. Pot. / RT\n");
-            b.write("                     -------------     "
+            format_to(b, "                     -------------     "
                     "------------     ------------\n");
             for (size_t k = 0; k < m_kk; k++) {
                 if (abs(x[k]) >= threshold) {
                     if (abs(x[k]) > SmallNumber) {
-                        b.write("{:>18s}   {:12.6g}     {:12.6g}     {:12.6g}\n",
+                        format_to(b, "{:>18s}   {:12.6g}     {:12.6g}     {:12.6g}\n",
                                 speciesName(k), x[k], y[k], mu[k]/RT());
                     } else {
-                        b.write("{:>18s}   {:12.6g}     {:12.6g}\n",
+                        format_to(b, "{:>18s}   {:12.6g}     {:12.6g}\n",
                                 speciesName(k), x[k], y[k]);
                     }
                 } else {
@@ -887,11 +887,11 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
                 }
             }
         } else {
-            b.write("                           X                 Y\n");
-            b.write("                     -------------     ------------\n");
+            format_to(b, "                           X                 Y\n");
+            format_to(b, "                     -------------     ------------\n");
             for (size_t k = 0; k < m_kk; k++) {
                 if (abs(x[k]) >= threshold) {
-                    b.write("{:>18s}   {:12.6g}     {:12.6g}\n",
+                    format_to(b, "{:>18s}   {:12.6g}     {:12.6g}\n",
                             speciesName(k), x[k], y[k]);
                 } else {
                     nMinor++;
@@ -901,13 +901,13 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
             }
         }
         if (nMinor) {
-            b.write("     [{:+5d} minor]   {:12.6g}     {:12.6g}\n",
+            format_to(b, "     [{:+5d} minor]   {:12.6g}     {:12.6g}\n",
                     nMinor, xMinor, yMinor);
         }
     } catch (CanteraError& err) {
-        return b.str() + err.what();
+        return to_string(b) + err.what();
     }
-    return b.str();
+    return to_string(b);
 }
 
 void ThermoPhase::reportCSV(std::ofstream& csvFile) const


### PR DESCRIPTION
In fmtlib 5.0.0, `MemoryWriter` was removed. The [recommendation](https://github.com/fmtlib/fmt/issues/710) is to replace it with `memory_buffer`

Please fill in the issue number this pull request is fixing:

Changes proposed in this pull request:
- Switch `MemoryWriter` uses to `memory_buffer` uses

I have no idea if this is the right fix, I'm putting it out there to get some feedback and start to learn the C++ better. I also didn't test this with fmtlib 4.x, so I'm not sure if it's backwards compatible. Once this commit is applied, there is another error I don't know how to fix:

```
g++ -o build/src/kinetics/Group.os -c -std=c++0x -O3 -Wno-inline -g -Wall -include src/pch/system.h -fPIC -DNDEBUG -Iinclude -Iinclude/cantera/ext -Ibuild/src -I/Users/bryan/miniconda3/envs/cantera-dev/include src/kinetics/Group.cpp
In file included from src/kinetics/Group.cpp:9:
include/cantera/kinetics/Group.h:128:40: error: too many arguments provided to function-like macro invocation
    std::ostream& fmt(std::ostream& s, const std::vector<std::string>& esymbols) const;
                                       ^
/usr/local/include/fmt/format.h:3655:10: note: macro 'fmt' defined here
# define fmt(s) FMT_STRING(s)
         ^
In file included from src/kinetics/Group.cpp:9:
include/cantera/kinetics/Group.h:128:22: error: expected ';' at end of declaration list
    std::ostream& fmt(std::ostream& s, const std::vector<std::string>& esymbols) const;
                     ^
                     ;
include/cantera/kinetics/Group.h:23:5: error: constructor for 'Cantera::Group' must explicitly initialize the reference member 'fmt'
    Group() : m_sign(-999) { }
    ^
include/cantera/kinetics/Group.h:128:19: note: declared here
    std::ostream& fmt(std::ostream& s, const std::vector<std::string>& esymbols) const;
                  ^
include/cantera/kinetics/Group.h:24:5: error: constructor for 'Cantera::Group' must explicitly initialize the reference member 'fmt'
    Group(size_t n) : m_sign(0) {
    ^
include/cantera/kinetics/Group.h:128:19: note: declared here
    std::ostream& fmt(std::ostream& s, const std::vector<std::string>& esymbols) const;
                  ^
include/cantera/kinetics/Group.h:27:5: error: constructor for 'Cantera::Group' must explicitly initialize the reference member 'fmt'
    Group(const vector_int& elnumbers) :
    ^
include/cantera/kinetics/Group.h:128:19: note: declared here
    std::ostream& fmt(std::ostream& s, const std::vector<std::string>& esymbols) const;
                  ^
include/cantera/kinetics/Group.h:31:5: error: constructor for 'Cantera::Group' must explicitly initialize the reference member 'fmt'
    Group(const std::vector<size_t>& elnumbers) :
    ^
include/cantera/kinetics/Group.h:128:19: note: declared here
    std::ostream& fmt(std::ostream& s, const std::vector<std::string>& esymbols) const;
                  ^
include/cantera/kinetics/Group.h:38:5: error: constructor for 'Cantera::Group' must explicitly initialize the reference member 'fmt'
    Group(const Group& g) :
    ^
include/cantera/kinetics/Group.h:128:19: note: declared here
    std::ostream& fmt(std::ostream& s, const std::vector<std::string>& esymbols) const;
                  ^
src/kinetics/Group.cpp:40:26: error: too many arguments provided to function-like macro invocation
                         const std::vector<std::string>& esymbols) const
                         ^
/usr/local/include/fmt/format.h:3655:10: note: macro 'fmt' defined here
# define fmt(s) FMT_STRING(s)
         ^
src/kinetics/Group.cpp:39:22: error: non-static data member defined out-of-line
std::ostream& Group::fmt(std::ostream& s,
              ~~~~~~~^
src/kinetics/Group.cpp:39:22: error: declaration of reference variable 'fmt' requires an initializer
std::ostream& Group::fmt(std::ostream& s,
                     ^~~
src/kinetics/Group.cpp:39:25: error: expected ';' after top level declarator
std::ostream& Group::fmt(std::ostream& s,
                        ^
                        ;
src/kinetics/Group.cpp:41:1: error: expected unqualified-id
{
^
12 errors generated.
```

It looks like the `Group::fmt` function shadows the macro of the same name defined by fmtlib, but I'm not totally sure...
