### PR TITLE
Burner ion flame

### DIFF
--- a/include/cantera/clib/ctonedim.h
+++ b/include/cantera/clib/ctonedim.h
@@ -55,7 +55,7 @@ extern "C" {
 
     CANTERA_CAPI int inlet_setSpreadRate(int i, double v);
 
-    CANTERA_CAPI int stflow_new(int iph, int ikin, int itr, int itype);
+    CANTERA_CAPI int stflow_new(int iph, int ikin, int itr);
     CANTERA_CAPI int stflow_setTransport(int i, int itr);
     CANTERA_CAPI int stflow_enableSoret(int i, int iSoret);
     CANTERA_CAPI int stflow_setPressure(int i, double p);

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -28,10 +28,10 @@ namespace Cantera
  * Combustion and Flames 94.4(1993): 433-448.
  * @ingroup onedim
  */
-class IonFlow : public FreeFlame
+class IonFlow : public StFlow
 {
 public:
-    IonFlow(IdealGasPhase* ph = 0, size_t nsp = 1, size_t points = 1);
+    IonFlow(IdealGasPhase* ph = 0, size_t nsp = 1, size_t points = 1, std::string type = "Free Flame");
     //! set the solving stage
     virtual void setSolvingStage(const size_t phase);
     //! set electric voltage at inlet and outlet

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -45,6 +45,7 @@ public:
     //!     to evaluate all thermodynamic, kinetic, and transport properties.
     //! @param nsp Number of species.
     //! @param points Initial number of grid points
+    //! @param type flow type. It can be 'Free Flow' or 'Axisymmetric Stagnation'.
     StFlow(IdealGasPhase* ph = 0, size_t nsp = 1, size_t points = 1, std::string type = "Axisymmetric Stagnation");
 
     //! @name Problem Specification
@@ -147,7 +148,7 @@ public:
     virtual void restore(const XML_Node& dom, doublereal* soln,
                          int loglevel);
 
-    // overloaded in subclasses
+    //! Get the current flow type.
     virtual std::string flowType() {
         return m_flowType;
     }
@@ -436,12 +437,14 @@ protected:
     size_t m_kExcessLeft;
     size_t m_kExcessRight;
 
+    //! Flag for updating viscosity.
     bool m_dovisc;
 
     //! Update the transport properties at grid points in the range from `j0`
     //! to `j1`, based on solution `x`.
     virtual void updateTransport(doublereal* x, size_t j0, size_t j1);
 
+    //! Flow type of flame.
     std::string m_flowType;
 
 private:

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -672,7 +672,7 @@ cdef extern from "cantera/oneD/Inlet1D.h":
 
 cdef extern from "cantera/oneD/StFlow.h":
     cdef cppclass CxxStFlow "Cantera::StFlow":
-        CxxStFlow(CxxIdealGasPhase*, int, int)
+        CxxStFlow(CxxIdealGasPhase*, int, int, string)
         void setKinetics(CxxKinetics&) except +translate_exception
         void setTransport(CxxTransport&, cbool) except +translate_exception
         void setTransport(CxxTransport&) except +translate_exception
@@ -688,16 +688,10 @@ cdef extern from "cantera/oneD/StFlow.h":
         void enableSoret(cbool) except +translate_exception
         cbool withSoret()
 
-    cdef cppclass CxxFreeFlame "Cantera::FreeFlame":
-        CxxFreeFlame(CxxIdealGasPhase*, int, int)
-
-    cdef cppclass CxxAxiStagnFlow "Cantera::AxiStagnFlow":
-        CxxAxiStagnFlow(CxxIdealGasPhase*, int, int)
-
 
 cdef extern from "cantera/oneD/IonFlow.h":
     cdef cppclass CxxIonFlow "Cantera::IonFlow":
-        CxxIonFlow(CxxIdealGasPhase*, int, int)
+        CxxIonFlow(CxxIdealGasPhase*, int, int, string)
         void setSolvingStage(int)
         void setElectricPotential(const double, const double)
         void solvePoissonEqn()

--- a/interfaces/cython/cantera/examples/onedim/burner_ion_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/burner_ion_flame.py
@@ -1,0 +1,28 @@
+"""
+A burner-stabilized lean premixed hydrogen-oxygen flame at low pressure.
+"""
+
+import cantera as ct
+import numpy as np
+
+p = ct.one_atm
+tburner = 600.0
+reactants = 'CH4:1.0, O2:2.0, N2:7.52'  # premixed gas composition
+width = 0.5 # m
+loglevel = 1  # amount of diagnostic output (0 to 5)
+
+gas = ct.Solution('gri30_ion.cti')
+gas.TPX = tburner, p, reactants
+mdot = 0.15 * gas.density
+
+f = ct.BurnerIonFlame(gas, width=width)
+f.burner.mdot = mdot
+f.set_refine_criteria(ratio=3.0, slope=0.05, curve=0.1)
+f.show_solution()
+
+f.transport_model = 'Ion'
+f.solve(loglevel, auto=True)
+f.solve(loglevel=loglevel, stage=2, enable_energy=True)
+f.save('CH4_burner_flame.xml', 'mix', 'solution with mixture-averaged transport')
+
+f.write_csv('CH4_burner_flame.csv', quiet=False)

--- a/interfaces/cython/cantera/examples/onedim/ion_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/ion_flame.py
@@ -26,6 +26,10 @@ f.show_solution()
 f.solve(loglevel=loglevel, auto=True)
 
 # stage two
+# sometime Mix transport is easier to converge
+f.transport_model = 'Mix'
+f.solve(loglevel=loglevel, stage=2, enable_energy=True)
+f.transport_model = 'Ion'
 f.solve(loglevel=loglevel, stage=2, enable_energy=True)
 
 f.save('CH4_adiabatic.xml', 'ion', 'solution with ionized gas transport')

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -768,6 +768,7 @@ class BurnerFlame(FlameBase):
 
 
 class BurnerIonFlame(BurnerFlame, IonFlameBase):
+    """A burner-stabilized flat flame with ionized gas."""
     __slots__ = ('burner', 'flame', 'outlet')
 
     def __init__(self, gas, grid=None, width=None):

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -392,7 +392,7 @@ class FreeFlame(FlameBase):
     """A freely-propagating flat flame."""
     __slots__ = ('inlet', 'outlet', 'flame')
 
-    def __init__(self, gas, grid=None, width=None):
+    def __init__(self, gas, grid=None, width=None, type='Free Flame'):
         """
         A domain of type FreeFlow named 'flame' will be created to represent
         the flame. The three domains comprising the stack are stored as
@@ -559,23 +559,7 @@ class FreeFlame(FlameBase):
         return self.solve_adjoint(perturb, self.gas.n_reactions, dgdx) / Su0
 
 
-class IonFlame(FreeFlame):
-    __slots__ = ('inlet', 'outlet', 'flame')
-
-    def __init__(self, gas, grid=None, width=None):
-        if not hasattr(self, 'flame'):
-            # Create flame domain if not already instantiated by a child class
-            self.flame = IonFlow(gas, name='flame')
-
-        super(IonFlame, self).__init__(gas, grid, width)
-
-    def solve(self, loglevel=1, refine_grid=True, auto=False, stage=1, enable_energy=True):
-        self.flame.set_solvingStage(stage)
-        if stage == 1:
-            super(IonFlame, self).solve(loglevel, refine_grid, auto)
-        if stage == 2:
-            self.poisson_enabled = True
-            super(IonFlame, self).solve(loglevel, refine_grid, auto)
+class IonFlameBase(FlameBase):
 
     def write_csv(self, filename, species='X', quiet=True):
         """
@@ -638,6 +622,27 @@ class IonFlame(FreeFlame):
             Efield.append((phi[n-1] - phi[n+1]) / (z[n+1] - z[n-1]))
         Efield.append((phi[np-2] - phi[np-1]) / (z[np-1] - z[np-2]))
         return Efield
+
+class IonFlame(FreeFlame, IonFlameBase):
+    __slots__ = ('inlet', 'outlet', 'flame')
+
+    def __init__(self, gas, grid=None, width=None):
+        if not hasattr(self, 'flame'):
+            # Create flame domain if not already instantiated by a child class
+            self.flame = IonFreeFlow(gas, name='flame')
+
+        super(IonFlame, self).__init__(gas, grid, width)
+
+    def solve(self, loglevel=1, refine_grid=True, auto=False, stage=1, enable_energy=True):
+        self.flame.set_solvingStage(stage)
+        if stage == 1:
+            super(IonFlame, self).solve(loglevel, refine_grid, auto)
+        if stage == 2:
+            self.poisson_enabled = True
+            super(IonFlame, self).solve(loglevel, refine_grid, auto)
+
+    def write_csv(self, filename, species='X', quiet=True):
+        IonFlameBase.write_csv(filename, species, quiet)
 
 
 class BurnerFlame(FlameBase):

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -482,7 +482,7 @@ cdef class FreeFlow(_FlowBase):
 
 cdef class IonFlow(_FlowBase):
     """
-    An ion flow domain.
+    The base for an ion flow domain.
 
     In an ion flow dommain, the electric drift is added to the diffusion flux
     """
@@ -504,12 +504,18 @@ cdef class IonFlow(_FlowBase):
 
 
 cdef class IonFreeFlow(IonFlow):
+    """
+    A domain of free flow with ionized gas.
+    """
     def __cinit__(self, _SolutionBase thermo, *args, **kwargs):
         gas = getIdealGasPhase(thermo)
         self.flow = <CxxStFlow*>(new CxxIonFlow(gas, thermo.n_species, 2, "Free Flame"))
 
 
 cdef class IonAxisymmetricStagnationFlow(IonFlow):
+    """
+    A domain of axisymmetric flow with ionized gas.
+    """
     def __cinit__(self, _SolutionBase thermo, *args, **kwargs):
         gas = getIdealGasPhase(thermo)
         self.flow = <CxxStFlow*>(new CxxIonFlow(gas, thermo.n_species, 2, "Axisymmetric Stagnation"))

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -509,6 +509,12 @@ cdef class IonFreeFlow(IonFlow):
         self.flow = <CxxStFlow*>(new CxxIonFlow(gas, thermo.n_species, 2, "Free Flame"))
 
 
+cdef class IonAxisymmetricStagnationFlow(IonFlow):
+    def __cinit__(self, _SolutionBase thermo, *args, **kwargs):
+        gas = getIdealGasPhase(thermo)
+        self.flow = <CxxStFlow*>(new CxxIonFlow(gas, thermo.n_species, 2, "Axisymmetric Stagnation"))
+
+
 cdef class AxisymmetricStagnationFlow(_FlowBase):
     """
     An axisymmetric flow domain.

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -477,7 +477,7 @@ cdef CxxIdealGasPhase* getIdealGasPhase(ThermoPhase phase) except *:
 cdef class FreeFlow(_FlowBase):
     def __cinit__(self, _SolutionBase thermo, *args, **kwargs):
         gas = getIdealGasPhase(thermo)
-        self.flow = <CxxStFlow*>(new CxxFreeFlame(gas, thermo.n_species, 2))
+        self.flow = new CxxStFlow(gas, thermo.n_species, 2, "Free Flame")
 
 
 cdef class IonFlow(_FlowBase):
@@ -486,10 +486,6 @@ cdef class IonFlow(_FlowBase):
 
     In an ion flow dommain, the electric drift is added to the diffusion flux
     """
-    def __cinit__(self, _SolutionBase thermo, *args, **kwargs):
-        gas = getIdealGasPhase(thermo)
-        self.flow = <CxxStFlow*>(new CxxIonFlow(gas, thermo.n_species, 2))
-
     def set_solvingStage(self, stage):
         (<CxxIonFlow*>self.flow).setSolvingStage(stage)
 
@@ -505,6 +501,12 @@ cdef class IonFlow(_FlowBase):
                 (<CxxIonFlow*>self.flow).solvePoissonEqn()
             else:
                 (<CxxIonFlow*>self.flow).fixElectricPotential()
+
+
+cdef class IonFreeFlow(IonFlow):
+    def __cinit__(self, _SolutionBase thermo, *args, **kwargs):
+        gas = getIdealGasPhase(thermo)
+        self.flow = <CxxStFlow*>(new CxxIonFlow(gas, thermo.n_species, 2, "Free Flame"))
 
 
 cdef class AxisymmetricStagnationFlow(_FlowBase):
@@ -538,7 +540,7 @@ cdef class AxisymmetricStagnationFlow(_FlowBase):
     """
     def __cinit__(self, _SolutionBase thermo, *args, **kwargs):
         gas = getIdealGasPhase(thermo)
-        self.flow = <CxxStFlow*>(new CxxAxiStagnFlow(gas, thermo.n_species, 2))
+        self.flow = new CxxStFlow(gas, thermo.n_species, 2, "Axisymmetric Stagnation")
 
 
 cdef class Sim1D:

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -952,3 +952,28 @@ class TestIonFlame(utilities.CanteraTest):
 
         # Regression test
         self.assertNear(max(self.sim.E), 131.9956, 1e-3)
+
+
+class TestBurnerIonFlame(utilities.CanteraTest):
+    def test_ion_profile(self):
+        reactants = 'CH4:1.0, O2:2.0, N2:7.52'
+        p = ct.one_atm
+        Tburner = 400
+        width = 0.03
+
+        # IdealGasMix object used to compute mixture properties
+        self.gas = ct.Solution('ch4_ion.cti')
+        self.gas.TPX = Tburner, p, reactants
+        self.sim = ct.BurnerIonFlame(self.gas, width=width)
+        self.sim.set_refine_criteria(ratio=4, slope=0.8, curve=1.0)
+        self.sim.burner.mdot = self.gas.density * 0.15
+        self.sim.transport_model = 'Ion'
+
+        # stage one
+        self.sim.solve(loglevel=0, auto=True)
+
+        #stage two
+        self.sim.solve(loglevel=0, stage=2, enable_energy=True)
+
+        # Regression test
+        self.assertNear(max(self.sim.E), 439.2874, 1e-3)

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -365,23 +365,14 @@ extern "C" {
 
     //------------------ stagnation flow domains --------------------
 
-    int stflow_new(int iph, int ikin, int itr, int itype)
+    int stflow_new(int iph, int ikin, int itr)
     {
         try {
             IdealGasPhase& ph = ThermoCabinet::get<IdealGasPhase>(iph);
-            if (itype == 1) {
-                AxiStagnFlow* x = new AxiStagnFlow(&ph, ph.nSpecies(), 2);
-                x->setKinetics(KineticsCabinet::item(ikin));
-                x->setTransport(TransportCabinet::item(itr));
-                return DomainCabinet::add(x);
-            } else if (itype == 2) {
-                FreeFlame* x = new FreeFlame(&ph, ph.nSpecies(), 2);
-                x->setKinetics(KineticsCabinet::item(ikin));
-                x->setTransport(TransportCabinet::item(itr));
-                return DomainCabinet::add(x);
-            } else {
-                return -2;
-            }
+            StFlow* x = new StFlow(&ph, ph.nSpecies(), 2);
+            x->setKinetics(KineticsCabinet::item(ikin));
+            x->setTransport(TransportCabinet::item(itr));
+            return DomainCabinet::add(x);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -15,8 +15,8 @@ using namespace std;
 namespace Cantera
 {
 
-IonFlow::IonFlow(IdealGasPhase* ph, size_t nsp, size_t points) :
-    FreeFlame(ph, nsp, points),
+IonFlow::IonFlow(IdealGasPhase* ph, size_t nsp, size_t points, string type) :
+    StFlow(ph, nsp, points, type),
     m_import_electron_transport(false),
     m_stage(1),
     m_inletVoltage(0.0),
@@ -273,7 +273,7 @@ void IonFlow::setElectronTransport(vector_fp& tfix, vector_fp& diff_e,
 
 void IonFlow::_finalize(const double* x)
 {
-    FreeFlame::_finalize(x);
+    StFlow::_finalize(x);
 
     bool p = m_do_poisson[0];
     for (size_t j = 0; j < m_points; j++) {

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -440,7 +440,7 @@ int Sim1D::setFixedTemperature(doublereal t)
 
         // loop over points in the current grid to determine where new point is
         // needed.
-        FreeFlame* d_free = dynamic_cast<FreeFlame*>(&domain(n));
+        StFlow* d_free = dynamic_cast<StFlow*>(&domain(n));
         size_t npnow = d.nPoints();
         size_t nstart = znew.size();
         if (d_free) {

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -13,8 +13,10 @@ using namespace std;
 namespace Cantera
 {
 
-StFlow::StFlow(IdealGasPhase* ph, size_t nsp, size_t points) :
+StFlow::StFlow(IdealGasPhase* ph, size_t nsp, size_t points, string type) :
     Domain1D(nsp+c_offset_Y, points),
+    m_zfixed(Undef),
+    m_tfixed(Undef),
     m_press(-1.0),
     m_nsp(nsp),
     m_thermo(0),
@@ -26,7 +28,9 @@ StFlow::StFlow(IdealGasPhase* ph, size_t nsp, size_t points) :
     m_do_multicomponent(false),
     m_do_radiation(false),
     m_kExcessLeft(0),
-    m_kExcessRight(0)
+    m_kExcessRight(0),
+    m_dovisc(true),
+    m_flowType(type)
 {
     m_type = cFlowType;
     m_points = points;
@@ -85,7 +89,7 @@ StFlow::StFlow(IdealGasPhase* ph, size_t nsp, size_t points) :
         gr.push_back(1.0*ng/m_points);
     }
     setupGrid(m_points, gr.data());
-    setID("stagnation flow");
+    //setID("stagnation flow");
 
     // Find indices for radiating species
     m_kRadiating.resize(2, npos);
@@ -203,6 +207,29 @@ void StFlow::_finalize(const doublereal* x)
     }
     if (e) {
         solveEnergyEqn();
+    }
+
+    if (flowType() == "Free Flame") {
+        // If the domain contains the temperature fixed point, make sure that it
+        // is correctly set. This may be necessary when the grid has been modified
+        // externally.
+        if (m_tfixed != Undef) {
+            for (size_t j = 0; j < m_points; j++) {
+                if (z(j) == m_zfixed) {
+                    return; // fixed point is already set correctly
+                }
+            }
+
+            for (size_t j = 0; j < m_points - 1; j++) {
+                // Find where the temperature profile crosses the current
+                // fixed temperature.
+                if ((T(x, j) - m_tfixed) * (T(x, j+1) - m_tfixed) <= 0.0) {
+                    m_tfixed = T(x, j+1);
+                    m_zfixed = z(j+1);
+                    return;
+                }
+            }
+        }
     }
 }
 
@@ -459,6 +486,10 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
 
 void StFlow::updateTransport(doublereal* x, size_t j0, size_t j1)
 {
+     if (m_flowType == "Free Flame") {
+       // no need viscosity in the governing equations
+       m_dovisc = false;
+     }
      if (m_do_multicomponent) {
         for (size_t j = j0; j < j1; j++) {
             setGasAtMidpoint(x,j);
@@ -750,6 +781,11 @@ void StFlow::restore(const XML_Node& dom, doublereal* soln, int loglevel)
                               getFloat(ref, "curve"), getFloat(ref, "prune"));
         refiner().setGridMin(getFloat(ref, "grid_min"));
     }
+
+    if (flowType() == "Free Flame") {
+        getOptionalFloat(dom, "t_fixed", m_tfixed);
+        getOptionalFloat(dom, "z_fixed", m_zfixed);
+    }
 }
 
 XML_Node& StFlow::save(XML_Node& o, const doublereal* const sol)
@@ -807,6 +843,10 @@ XML_Node& StFlow::save(XML_Node& o, const doublereal* const sol)
     addFloat(ref, "curve", refiner().maxSlope());
     addFloat(ref, "prune", refiner().prune());
     addFloat(ref, "grid_min", refiner().gridMin());
+    if (m_zfixed != Undef) {
+        addFloat(flow, "z_fixed", m_zfixed, "m");
+        addFloat(flow, "t_fixed", m_tfixed, "K");
+    }
     return flow;
 }
 
@@ -872,62 +912,7 @@ void StFlow::fixTemperature(size_t j)
     }
 }
 
-void AxiStagnFlow::evalRightBoundary(doublereal* x, doublereal* rsd,
-                                     integer* diag, doublereal rdt)
-{
-    size_t j = m_points - 1;
-    // the boundary object connected to the right of this one may modify or
-    // replace these equations. The default boundary conditions are zero u, V,
-    // and T, and zero diffusive flux for all species.
-    rsd[index(c_offset_U,j)] = rho_u(x,j);
-    rsd[index(c_offset_V,j)] = V(x,j);
-    if (m_do_energy[j]) {
-        rsd[index(c_offset_T,j)] = T(x,j);
-    } else {
-        rsd[index(c_offset_T, j)] = T(x,j) - T_fixed(j);
-    }
-    rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
-    diag[index(c_offset_L, j)] = 0;
-    doublereal sum = 0.0;
-    for (size_t k = 0; k < m_nsp; k++) {
-        sum += Y(x,k,j);
-        rsd[index(k+c_offset_Y,j)] = m_flux(k,j-1) + rho_u(x,j)*Y(x,k,j);
-    }
-    rsd[index(c_offset_Y + rightExcessSpecies(), j)] = 1.0 - sum;
-    diag[index(c_offset_Y + rightExcessSpecies(), j)] = 0;
-}
-
-void AxiStagnFlow::evalContinuity(size_t j, doublereal* x, doublereal* rsd,
-                                  integer* diag, doublereal rdt)
-{
-    //----------------------------------------------
-    //    Continuity equation
-    //
-    //    Note that this propagates the mass flow rate information to the left
-    //    (j+1 -> j) from the value specified at the right boundary. The
-    //    lambda information propagates in the opposite direction.
-    //
-    //    d(\rho u)/dz + 2\rho V = 0
-    //------------------------------------------------
-    rsd[index(c_offset_U,j)] =
-        -(rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
-        -(density(j+1)*V(x,j+1) + density(j)*V(x,j));
-
-    //algebraic constraint
-    diag[index(c_offset_U, j)] = 0;
-}
-
-FreeFlame::FreeFlame(IdealGasPhase* ph, size_t nsp, size_t points) :
-    StFlow(ph, nsp, points),
-    m_zfixed(Undef),
-    m_tfixed(Undef)
-{
-    m_dovisc = false;
-    setID("flame");
-}
-
-void FreeFlame::evalRightBoundary(doublereal* x, doublereal* rsd,
-                                  integer* diag, doublereal rdt)
+void StFlow::evalRightBoundary(double* x, double* rsd, int* diag, double rdt)
 {
     size_t j = m_points - 1;
 
@@ -935,10 +920,7 @@ void FreeFlame::evalRightBoundary(doublereal* x, doublereal* rsd,
     // replace these equations. The default boundary conditions are zero u, V,
     // and T, and zero diffusive flux for all species.
 
-    // zero gradient
-    rsd[index(c_offset_U,j)] = rho_u(x,j) - rho_u(x,j-1);
     rsd[index(c_offset_V,j)] = V(x,j);
-    rsd[index(c_offset_T,j)] = T(x,j) - T(x,j-1);
     doublereal sum = 0.0;
     rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
     diag[index(c_offset_L, j)] = 0;
@@ -948,76 +930,53 @@ void FreeFlame::evalRightBoundary(doublereal* x, doublereal* rsd,
     }
     rsd[index(c_offset_Y + rightExcessSpecies(), j)] = 1.0 - sum;
     diag[index(c_offset_Y + rightExcessSpecies(), j)] = 0;
-}
-
-void FreeFlame::evalContinuity(size_t j, doublereal* x, doublereal* rsd,
-                               integer* diag, doublereal rdt)
-{
-    //----------------------------------------------
-    //    Continuity equation
-    //
-    //    d(\rho u)/dz + 2\rho V = 0
-    //----------------------------------------------
-    if (grid(j) > m_zfixed) {
-        rsd[index(c_offset_U,j)] =
-            - (rho_u(x,j) - rho_u(x,j-1))/m_dz[j-1]
-            - (density(j-1)*V(x,j-1) + density(j)*V(x,j));
-    } else if (grid(j) == m_zfixed) {
+    if (flowType() == "Axisymmetric Stagnation") {
+        rsd[index(c_offset_U,j)] = rho_u(x,j);
         if (m_do_energy[j]) {
-            rsd[index(c_offset_U,j)] = (T(x,j) - m_tfixed);
+            rsd[index(c_offset_T,j)] = T(x,j);
         } else {
-            rsd[index(c_offset_U,j)] = (rho_u(x,j)
-                                        - m_rho[0]*0.3);
+            rsd[index(c_offset_T, j)] = T(x,j) - T_fixed(j);
         }
-    } else if (grid(j) < m_zfixed) {
-        rsd[index(c_offset_U,j)] =
-            - (rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
-            - (density(j+1)*V(x,j+1) + density(j)*V(x,j));
+    } else if (flowType() == "Free Flame") {
+        rsd[index(c_offset_U,j)] = rho_u(x,j) - rho_u(x,j-1);
+        rsd[index(c_offset_T,j)] = T(x,j) - T(x,j-1);
     }
+}
+
+void StFlow::evalContinuity(size_t j, double* x, double* rsd, int* diag, double rdt)
+{
     //algebraic constraint
     diag[index(c_offset_U, j)] = 0;
-}
-
-void FreeFlame::_finalize(const doublereal* x)
-{
-    StFlow::_finalize(x);
-    // If the domain contains the temperature fixed point, make sure that it
-    // is correctly set. This may be necessary when the grid has been modified
-    // externally.
-    if (m_tfixed != Undef) {
-        for (size_t j = 0; j < m_points; j++) {
-            if (z(j) == m_zfixed) {
-                return; // fixed point is already set correctly
+    //----------------------------------------------
+    //    Continuity equation
+    //
+    //    d(\rho u)/dz + 2\rho V = 0
+    //----------------------------------------------
+    if (flowType() == "Axisymmetric Stagnation") {
+        // Note that this propagates the mass flow rate information to the left
+        // (j+1 -> j) from the value specified at the right boundary. The
+        // lambda information propagates in the opposite direction.
+        rsd[index(c_offset_U,j)] =
+            -(rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
+            -(density(j+1)*V(x,j+1) + density(j)*V(x,j));
+    } else if (flowType() == "Free Flame") {
+        if (grid(j) > m_zfixed) {
+            rsd[index(c_offset_U,j)] =
+                - (rho_u(x,j) - rho_u(x,j-1))/m_dz[j-1]
+                - (density(j-1)*V(x,j-1) + density(j)*V(x,j));
+        } else if (grid(j) == m_zfixed) {
+            if (m_do_energy[j]) {
+                rsd[index(c_offset_U,j)] = (T(x,j) - m_tfixed);
+            } else {
+                rsd[index(c_offset_U,j)] = (rho_u(x,j)
+                                            - m_rho[0]*0.3);
             }
-        }
-
-        for (size_t j = 0; j < m_points - 1; j++) {
-            // Find where the temperature profile crosses the current
-            // fixed temperature.
-            if ((T(x, j) - m_tfixed) * (T(x, j+1) - m_tfixed) <= 0.0) {
-                m_tfixed = T(x, j+1);
-                m_zfixed = z(j+1);
-                return;
-            }
+        } else if (grid(j) < m_zfixed) {
+            rsd[index(c_offset_U,j)] =
+                - (rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
+                - (density(j+1)*V(x,j+1) + density(j)*V(x,j));
         }
     }
-}
-
-void FreeFlame::restore(const XML_Node& dom, doublereal* soln, int loglevel)
-{
-    StFlow::restore(dom, soln, loglevel);
-    getOptionalFloat(dom, "t_fixed", m_tfixed);
-    getOptionalFloat(dom, "z_fixed", m_zfixed);
-}
-
-XML_Node& FreeFlame::save(XML_Node& o, const doublereal* const sol)
-{
-    XML_Node& flow = StFlow::save(o, sol);
-    if (m_zfixed != Undef) {
-        addFloat(flow, "z_fixed", m_zfixed, "m");
-        addFloat(flow, "t_fixed", m_tfixed, "K");
-    }
-    return flow;
 }
 
 } // namespace

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -148,7 +148,7 @@ int Refiner::analyze(size_t n, const doublereal* z,
         }
     }
 
-    FreeFlame* fflame = dynamic_cast<FreeFlame*>(m_domain);
+    StFlow* fflame = dynamic_cast<StFlow*>(m_domain);
 
     // Refine based on properties of the grid itself
     for (size_t j = 1; j < n-1; j++) {


### PR DESCRIPTION
This PR is about developing IonFlow/IonFlame class.

Changes proposed in this pull request:
- Merge class FreeFlame and AxisymmetricStagnationFlow back to StFlow. Both classes are short and can be replaced by using a flag in StFlow. This make the programming flow simpler.
- Make IonFlow inherit from StFlow, so FreeFlame or AxisymmetricStagnationFlow can be choose, and used with IonFlow.
- Add a new 1D simulation BurnerIonFlame. This python class can solved the profile of ions for a burner flame.

Note: this PR make FreeFlame and AxisymmetricStagnationFlow deprecated. I will add the description later if you think this is a good approach. 
