### PR TITLE
New combustor example

### DIFF
--- a/include/cantera/cython/funcWrapper.h
+++ b/include/cantera/cython/funcWrapper.h
@@ -20,13 +20,13 @@ class CallbackError : public Cantera::CanteraError
 {
 public:
     CallbackError(void* type, void* value) :
+        CanteraError("Python callback function"),
         m_type((PyObject*) type),
         m_value((PyObject*) value)
     {
     }
-    const char* what() const throw() {
-        formattedMessage_ = "\n" + std::string(71, '*') + "\n";
-        formattedMessage_ += "Exception raised in Python callback function:\n";
+    std::string getMessage() const {
+        std::string msg;
 
         PyObject* name = PyObject_GetAttrString(m_type, "__name__");
         PyObject* value_str = PyObject_Str(m_value);
@@ -40,26 +40,28 @@ public:
         #endif
 
         if (name_bytes) {
-            formattedMessage_ += PyBytes_AsString(name_bytes);
+            msg += PyBytes_AsString(name_bytes);
             Py_DECREF(name_bytes);
         } else {
-            formattedMessage_ += "<error determining exception type>";
+            msg += "<error determining exception type>";
         }
 
-        formattedMessage_ += ": ";
+        msg += ": ";
 
         if (value_bytes) {
-            formattedMessage_ += PyBytes_AsString(value_bytes);
+            msg += PyBytes_AsString(value_bytes);
             Py_DECREF(value_bytes);
         } else {
-            formattedMessage_ += "<error determining exception message>";
+            msg += "<error determining exception message>";
         }
 
         Py_XDECREF(name);
         Py_XDECREF(value_str);
+        return msg;
+    }
 
-        formattedMessage_ += "\n" + std::string(71, '*') + "\n";
-        return formattedMessage_.c_str();
+    virtual std::string getClass() const {
+        return "Exception";
     }
 
     PyObject* m_type;

--- a/interfaces/cython/cantera/examples/reactors/NonIdealShockTube.py
+++ b/interfaces/cython/cantera/examples/reactors/NonIdealShockTube.py
@@ -67,11 +67,6 @@ reactorPressure = 40.0*101325.0 # Pascals
 # "Estimation of pure- component properties from group-contributions," Chem.
 # Eng. Comm. 57 (1987) 233-243, doi: 10.1080/00986448708960487
 
-# There is a slight discontinuity in the thermo for three species at the mid-
-# point temperature. We are aware and okay, so we will suppress the warning
-# statement (note: use this feature at your own risk in other codes!)
-ct.suppress_thermo_warnings()
-
 
 # Real gas IDT calculation
 

--- a/interfaces/cython/cantera/examples/reactors/fuel_injection.py
+++ b/interfaces/cython/cantera/examples/reactors/fuel_injection.py
@@ -1,0 +1,90 @@
+"""
+Simulation of fuel injection into a vitiated air mixture to show formation of
+soot precursors.
+
+Demonstrates the use of a user-supplied function for the mass flow rate through
+a MassFlowController, and the use of the SolutionArray class to store results
+during reactor network integration and use these results to generate plots.
+"""
+
+import numpy as np
+import matplotlib.pyplot as plt
+import cantera as ct
+
+# Use a reduced n-dodecane mechanism with PAH formation pathways
+gas = ct.Solution('nDodecane_Reitz.cti', 'nDodecane_IG')
+
+# Create a Reservoir for the fuel inlet, set to pure dodecane
+gas.TPX = 300, 20*ct.one_atm, 'c12h26:1.0'
+inlet = ct.Reservoir(gas)
+
+# Create Reactor and set initial contents to be products of lean combustion
+gas.TP = 1000, 20*ct.one_atm
+gas.set_equivalence_ratio(0.30, 'c12h26', 'n2:3.76, o2:1.0')
+gas.equilibrate('TP')
+r = ct.IdealGasReactor(gas)
+r.volume = 0.001  # 1 liter
+
+# Create an inlet for the fuel, supplied as a Gaussian pulse
+def fuel_mdot(t):
+    total = 3.0e-3  # mass of fuel [kg]
+    width = 0.5  # width of the pulse [s]
+    t0 = 2.0  # time of fuel pulse peak [s]
+    amplitude = total / (width * np.sqrt(2*np.pi))
+    return amplitude * np.exp(-(t-t0)**2 / (2*width**2))
+
+mfc = ct.MassFlowController(inlet, r, mdot=fuel_mdot)
+
+# Create the reactor network
+sim = ct.ReactorNet([r])
+
+# Integrate for 10 seconds, storing the results for later plotting
+tfinal = 10.0
+tnow = 0.0
+i = 0
+tprev = tnow
+states = ct.SolutionArray(gas, extra=['t'])
+
+while tnow < tfinal:
+    tnow = sim.step()
+    i += 1
+    # Storing results after every step can be excessive. Instead, store results
+    # every 10 steps, or more frequently if large steps are being taken.
+    if tnow-tprev > 1e-2 or i == 10:
+        i = 0
+        tprev = tnow
+        states.append(r.thermo.state, t=tnow)
+
+# nice names for species
+labels = {
+    'A1c2h': 'phenylacetylene',
+    'A1c2h3': 'styrene',
+    'A1': 'benzene',
+    'A2': 'naphthalene',
+    'A2r5': 'acenaphthylene',
+    'A3': 'phenanthrene',
+    'A4': 'pyrene',
+    'o2': 'O$_2$',
+    'h2o': 'H$_2$O',
+    'co2': 'CO$_2$',
+    'h2': 'H$_2$',
+    'ch4': 'CH$_4$'
+}
+
+# Plot the concentrations of some species of interest, including PAH species
+# which can be considered as precursors to soot formation.
+f, ax = plt.subplots(1,2)
+
+for s in ['o2', 'h2o', 'co2', 'CO', 'h2', 'ch4']:
+    ax[0].plot(states.t, states(s).X, label=labels.get(s, s))
+
+for s in ['A1c2h', 'A1c2h3', 'A2r5', 'A1', 'A2', 'A3', 'A4']:
+    ax[1].plot(states.t, states(s).X, label=labels[s])
+for a in ax:
+    a.legend(loc='best')
+    a.set_xlabel('time [s]')
+    a.set_ylabel('mole fraction')
+    a.set_xlim([0, tfinal])
+
+f.tight_layout()
+plt.show()

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -364,6 +364,16 @@ class TestReactor(utilities.CanteraTest):
         self.assertNear(ma + 0.1, mb)
         self.assertArrayNear(ma * Ya + 0.1 * gas2.Y, mb * Yb)
 
+    def test_user_function_error(self):
+        # Make sure Python error message actually gets displayed
+        self.make_reactors(n_reactors=2)
+        mfc = ct.MassFlowController(self.r1, self.r2)
+        mfc.set_mass_flow_rate(lambda t: eggs)
+
+        # TODO: replace with 'assertRasesRegex' after dropping Python 2.7 support
+        with self.assertRaisesRegexp(Exception, 'eggs'):
+            self.net.step()
+
     def test_valve1(self):
         self.make_reactors(P1=10*ct.one_atm, X1='AR:1.0', X2='O2:1.0')
         self.net.rtol = 1e-12

--- a/src/numerics/FuncEval.cpp
+++ b/src/numerics/FuncEval.cpp
@@ -15,7 +15,7 @@ int FuncEval::eval_nothrow(double t, double* y, double* ydot)
         eval(t, y, ydot, m_sens_params.data());
     } catch (CanteraError& err) {
         if (suppressErrors()) {
-            m_errors.push_back(err.getMessage());
+            m_errors.push_back(err.what());
         } else {
             writelog(err.what());
         }

--- a/src/thermo/NasaPoly2.cpp
+++ b/src/thermo/NasaPoly2.cpp
@@ -19,7 +19,7 @@ void NasaPoly2::validate(const std::string& name)
     mnp_high.updatePropertiesTemp(m_midT, &cp_high, &h_high, &s_high);
 
     double delta = cp_low - cp_high;
-    if (fabs(delta/(fabs(cp_low)+1.0E-4)) > 0.001) {
+    if (fabs(delta/(fabs(cp_low)+1.0E-4)) > 0.01) {
         writelog("\n\n**** WARNING ****\nFor species {}, discontinuity"
                  " in cp/R detected at Tmid = {}\n", name, m_midT);
         writelog("\tValue computed using low-temperature polynomial:  {}\n", cp_low);


### PR DESCRIPTION
The main purpose of this is to update the `combustor.py` example so that when people copy it and use it as the basis for their WSR codes, they get a reasonable method for solving such a problem. The hydrogen radical igniter used here is inefficient and complicated, and the method for specifying the inlet mixture is also overly complicated, both for setting the equivalence ratio as well as the mass flow rate.

Adds a new example (`fuel_injection.py`) where the mass flow rate is explicitly time-dependent so that we still have an example demonstrating this capability, but hopefully this configuration will not lead users astray as often.