### PR TITLE
Ion gas transport

### DIFF
--- a/include/cantera/transport/IonGasTransport.h
+++ b/include/cantera/transport/IonGasTransport.h
@@ -24,7 +24,7 @@ namespace Cantera
  * 1. Selle, Stefan, and Uwe Riedel. "Transport properties of ionized species."
  *    Annals of the New York Academy of Sciences 891.1 (1999): 72-80.
  * 2. Selle, Stefan, and Uwe Riedel. "Transport coefficients of reacting air at
-*     high temperatures." 38th Aerospace Sciences Meeting and Exhibit. 1999.
+ *    high temperatures." 38th Aerospace Sciences Meeting and Exhibit. 1999.
  * 3. Han, Jie, et al. "Numerical modelling of ion transport in flames."
  *    Combustion Theory and Modelling 19.6 (2015): 744-772.
  *    DOI: 10.1080/13647830.2015.1090018
@@ -34,6 +34,16 @@ namespace Cantera
  * 5. Viehland, L. A., et al. "Tables of transport collision integrals for
  *    (n, 6, 4) ion-neutral potentials." Atomic Data and Nuclear Data Tables
  *    16.6 (1975): 495-514.
+ *
+ * Stockmayer-(n,6,4) model is not suitable for collision between O2/O2-
+ * due to resonant charge transfer. Therefore, an experimental collision
+ * data is used instead.
+ *
+ * Data taken from:
+ *
+ * Prager, Jens. Modeling and simulation of charged species in
+ * lean methane-oxygen flames. Diss. 2005. Page 104.
+ *
  * @ingroup tranprops
  */
 class IonGasTransport : public MixTransport
@@ -94,6 +104,9 @@ protected:
 
     //! parameter of omega11 of n64
     DenseMatrix m_gamma;
+
+    //! polynomial of the collision integral for O2/O2-
+    vector_fp m_om11_O2;
 };
 
 }

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -161,6 +161,12 @@ class TestIonTransport(utilities.CanteraTest):
         # Regression test
         self.assertNear(mdiff, 5.057e-4, 1e-4)
 
+    def test_O2_anion_mixture_diffusion(self):
+        j = self.gas.species_index("O2-")
+        mdiff = self.gas.mix_diff_coeffs[j]
+        # Regression test
+        self.assertNear(mdiff, 2.784e-4, 1e-3)
+
 
 class TestTransportGeometryFlags(utilities.CanteraTest):
     phase_data = """

--- a/test/data/ch4_ion.cti
+++ b/test/data/ch4_ion.cti
@@ -5,7 +5,7 @@ ideal_gas(name='gas',
           species=['''gri30: H       O       OH      HO2     H2O2    C     CH
                              CH2     CH2(S)  CH3     HCO     CH2O    CH3O''',
                     '''H2    O2      H2O     CH4     CO      CO2     N2
-                       HCO+    H3O+    E'''],
+                       HCO+    H3O+    E     O2-'''],
           reactions=['gri30: all', 'all'],
           transport='Ion',
           options=['skip_undeclared_species', 'skip_undeclared_third_bodies'],
@@ -185,6 +185,22 @@ species(name = 'H3O+',
                                 polar=0.897,
                                 rot_relax=0.0),
      note = 'TPIS89')
+
+species(name='O2-',
+        atoms='E:1 O:2',
+        thermo=(NASA([298.15, 1000.00],
+                     [ 3.66442522E+00, -9.28741138E-04,  6.45477082E-06,
+                      -7.74703380E-09,  2.93332662E-12, -6.87076983E+03,
+                       4.35140681E+00]),
+                NASA([1000.00, 6000.00],
+                     [ 3.95666294E+00,  5.98141823E-04, -2.12133905E-07,
+                       3.63267581E-11, -2.24989228E-15, -7.06287229E+03,
+                       2.27871017E+00])),
+        transport=gas_transport(geom='linear',
+                                diam=3.33,
+                                well_depth=136.5,
+                                polar=1.424),
+        note='L4/89')
 
 species(name = 'E',
     atoms = ' E:1 ',


### PR DESCRIPTION
This PR is an update to ionGasTransport. The experimental data of collision integral of O2/O2- is used instead of stockmayer-(n,6,4) model due to resonant charge transfer effect. 
