### PR TITLE
Correct doxygen string for SRI reactions

### DIFF
--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -181,7 +181,7 @@ protected:
  *  \f[ P_r = \frac{k_0 [M]}{k_{\infty}} \f]
  *
  *  \f[ F = {\left( a \; exp(\frac{-b}{T}) + exp(\frac{-T}{c})\right)}^n
- *              \;  d \; exp(\frac{-e}{T}) \f]
+ *              \;  d \; T^e \f]
  *      where
  *  \f[ n = \frac{1.0}{1.0 + {\log_{10} P_r}^2} \f]
  *


### PR DESCRIPTION
Should be "T^e" instead of "exp(\frac{-e}{T})" according to CHEMKIN theory guide and actual code in https://github.com/Cantera/cantera/blob/master/src/kinetics/Falloff.cpp#L101 .
