### PR TITLE
add std:: to "inner_product" and "accumulate"

### DIFF
--- a/include/cantera/base/utilities.h
+++ b/include/cantera/base/utilities.h
@@ -107,7 +107,7 @@ template<class InputIter, class InputIter2>
 inline doublereal dot(InputIter x_begin, InputIter x_end,
                       InputIter2 y_begin)
 {
-    return inner_product(x_begin, x_end, y_begin, 0.0);
+    return std::inner_product(x_begin, x_end, y_begin, 0.0);
 }
 
 //! Multiply elements of an array by a scale factor.
@@ -234,7 +234,7 @@ template<class InputIter, class OutputIter>
 inline void normalize(InputIter begin, InputIter end,
                       OutputIter out)
 {
-    doublereal sum = accumulate(begin, end, 0.0);
+    doublereal sum = std::accumulate(begin, end, 0.0);
     for (; begin != end; ++begin, ++out) {
         *out = *begin/sum;
     }


### PR DESCRIPTION
This only works because the "dot" function is always called with std::vector<T>::iterator as input so that "argument dependent lookup" introduces the std namespace to the function. If the dot function is called like this "dot(v.data(), v.data()+v.size(), v.data())", where "v" is a std::vector and the input are plain pointers, the compiler will not find "inner_product". The same is true for the use of "accumulate".