### PR TITLE
Updating include/cantera/RedlichKwongMFTP.h to reflect new test suite coverage.

### DIFF
--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -14,14 +14,6 @@ namespace Cantera
 /**
  * Implementation of a multi-species Redlich-Kwong equation of state
  *
- * @attention This class currently does not have any test cases or examples. Its
- *     implementation may be incomplete, and future changes to Cantera may
- *     unexpectedly cause this class to stop working. If you use this class,
- *     please consider contributing examples or test cases. In the absence of
- *     new tests or examples, this class may be deprecated and removed in a
- *     future version of Cantera. See
- *     https://github.com/Cantera/cantera/issues/267 for additional information.
- *
  * @ingroup thermoprops
  */
 class RedlichKwongMFTP : public MixtureFugacityTP


### PR DESCRIPTION
Text in the header file previously commented that the RedlichKwongMFTP
thermo class had no test suite coverage and was at risk for deprecation.
As this is no longer the case, this PR removes that language.

Please fill in the issue number this pull request is fixing:

See #267