### PR TITLE
Fix some ck2cti bugs

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -4,7 +4,7 @@ install:
     C:\Python37-x64\python.exe -m pip install --no-cache-dir --upgrade pip
     C:\Python37-x64\python.exe -m pip install --upgrade setuptools
     C:\Python37-x64\python.exe -m pip install --upgrade --no-warn-script-location wheel
-    C:\Python37-x64\Scripts\pip.exe install scons
+    C:\Python37-x64\Scripts\pip.exe install scons==3.0.1
     C:\Python37-x64\Scripts\pip.exe install --no-cache-dir --no-warn-script-location numpy
     C:\Python37-x64\Scripts\pip.exe install --no-warn-script-location cython
     C:\Python37-x64\Scripts\pip.exe install pypiwin32

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -1676,7 +1676,6 @@ class Parser(object):
 
                 elif tokens[0].upper().startswith('THER') and contains(line, 'NASA9'):
                     inHeader = False
-                    entryPosition = 0
                     entryLength = None
                     entry = []
                     while line is not None and not get_index(line, 'END') == 0:
@@ -1704,20 +1703,16 @@ class Parser(object):
                             except (IndexError, ValueError):
                                 pass
 
-                        if entryPosition == 0:
-                            entry.append(line)
-                        elif entryPosition == 1:
+                        entry.append(line)
+                        if len(entry) == 2:
                             entryLength = 2 + 3 * int(line.split()[0])
-                            entry.append(line)
-                        elif entryPosition < entryLength:
-                            entry.append(line)
 
-                        if entryPosition == entryLength-1:
+                        if len(entry) == entryLength:
                             label, thermo, comp, note = self.readNasa9Entry(entry)
+                            entry = []
                             if label not in self.speciesDict:
                                 if skipUndeclaredSpecies:
                                     logging.info('Skipping unexpected species "{0}" while reading thermodynamics entry.'.format(label))
-                                    thermo = []
                                     continue
                                 else:
                                     # Add a new species entry
@@ -1735,11 +1730,6 @@ class Parser(object):
                                 species.thermo = thermo
                                 species.composition = comp
                                 species.note = note
-
-                            entryPosition = -1
-                            entry = []
-
-                        entryPosition += 1
 
                 elif tokens[0].upper().startswith('THER'):
                     # List of thermodynamics (hopefully one per species!)

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -1908,6 +1908,9 @@ class Parser(object):
                         else:
                             transportLines.append(line)
                         line, comment = readline()
+                elif line.strip():
+                    raise InputParseError('Section starts with unrecognized keyword.'
+                        '\n"""\n{0}\n"""'.format(line.rstrip()))
 
                 if advance:
                     line, comment = readline()

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -2221,7 +2221,7 @@ duplicate transport data) to be ignored.
                 parser.loadChemkinFile(surfaceFile, surface=True)
             except Exception as err:
                 logging.warning("\nERROR: Unable to parse '{0}' near line {1}:\n{2}\n".format(
-                                inputFile, parser.line_number, err))
+                                surfaceFile, parser.line_number, err))
                 raise
 
         if thermoFile:

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -195,6 +195,13 @@ class chemkinConverterTest(utilities.CanteraTest):
         self.assertEqual(gas.n_species, 3)
         self.assertEqual(gas.n_reactions, 2)
 
+    def test_unrecognized_section(self):
+        with self.assertRaisesRegex(ck2cti.InputParseError, 'SPAM'):
+            convertMech(pjoin(self.test_data_dir, 'unrecognized-section.inp'),
+                        thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                        outName=pjoin(self.test_work_dir, 'unrecognized-section.cti'),
+                        quiet=True, permissive=True)
+
     def test_nasa9(self):
         convertMech(pjoin(self.test_data_dir, 'nasa9-test.inp'),
                     thermoFile=pjoin(self.test_data_dir, 'nasa9-test-therm.dat'),

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -286,6 +286,12 @@ class chemkinConverterTest(utilities.CanteraTest):
                         thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
                         outName=pjoin(self.test_work_dir, 'bad-troe.cti'), quiet=True)
 
+    def test_invalid_reaction_equation(self):
+        with self.assertRaisesRegex(ck2cti.InputParseError, 'Unparsable'):
+            convertMech(pjoin(self.test_data_dir, 'invalid-equation.inp'),
+                        thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),
+                        outName=pjoin(self.test_work_dir, 'invalid-equation.cti'), quiet=True)
+
     def test_reaction_units(self):
         convertMech(pjoin(self.test_data_dir, 'units-default.inp'),
                     thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -204,6 +204,16 @@ class chemkinConverterTest(utilities.CanteraTest):
                                         'nasa9_test.cti')
         self.checkThermo(ref, gas, [300, 500, 1200, 5000])
 
+    def test_nasa9_subset(self):
+        convertMech(pjoin(self.test_data_dir, 'nasa9-test-subset.inp'),
+                    thermoFile=pjoin(self.test_data_dir, 'nasa9-test-therm.dat'),
+                    outName=pjoin(self.test_work_dir, 'nasa9-test-subset.cti'),
+                    quiet=True)
+
+        ref, gas = self.checkConversion(pjoin(self.test_data_dir, 'nasa9-test-subset.xml'),
+                                        'nasa9-test-subset.cti')
+        self.checkThermo(ref, gas, [300, 500, 1200, 5000])
+
     def test_sri_falloff(self):
         convertMech(pjoin(self.test_data_dir, 'sri-falloff.inp'),
                     thermoFile=pjoin(self.test_data_dir, 'dummy-thermo.dat'),

--- a/test/data/invalid-equation.inp
+++ b/test/data/invalid-equation.inp
@@ -1,0 +1,15 @@
+ELEMENTS
+H  C
+END
+
+SPECIES
+H R1A R1B P1 P2A
+END
+
+REACTIONS
+R1A+R1B(+M) <=> H+P1(+M)                     1e12  0.0  20000.0
+     LOW  /  1.040E+26   -2.760   1600.00/
+     TROE/   .5620  91.00  5836.00  1.00000e+100/
+R1A <-> R1B                     1e12  0.0  20000.0
+R1A => P2A                     1e12  0.0  20000.0
+END

--- a/test/data/nasa9-test-subset.inp
+++ b/test/data/nasa9-test-subset.inp
@@ -1,0 +1,10 @@
+!
+!
+!
+!
+ELEMENTS
+O  H  Al Cl E Ar
+END
+SPECIES
+ALCL3  AR
+END

--- a/test/data/nasa9-test-subset.xml
+++ b/test/data/nasa9-test-subset.xml
@@ -1,0 +1,56 @@
+<?xml version="1.0"?>
+<ctml>
+  <validate species="yes" reactions="yes"/>
+
+  <!-- phase gas     -->
+  <phase id="gas" dim="3">
+    <elementArray datasrc="elements.xml">O H Al Cl E Ar</elementArray>
+    <speciesArray datasrc="#species_data">ALCL3  AR</speciesArray>
+    <state>
+      <temperature units="K">300.0</temperature>
+      <pressure units="Pa">101325.0</pressure>
+    </state>
+    <thermo model="IdealGas"/>
+    <kinetics model="GasKinetics"/>
+    <transport model="None"/>
+  </phase>
+
+  <!-- species definitions     -->
+  <speciesData id="species_data">
+
+    <!-- species ALCL3    -->
+    <species name="ALCL3">
+      <atomArray>Al:1 Cl:3 </atomArray>
+      <note>Gurvich,1996a pt1 p173 pt2 p134. [tpis96]</note>
+      <thermo>
+        <NASA9 Tmin="200.0" Tmax="1000.0" P0="100000.0">
+           <floatArray size="9" name="coeffs">
+             7.750600970E+04,  -1.440779717E+03,   1.401744141E+01,  -6.381631240E-03, 
+             5.871674720E-06,  -2.908872278E-09,   5.994050890E-13,  -6.579343180E+04,
+             -4.494017799E+01</floatArray>
+        </NASA9>
+        <NASA9 Tmin="1000.0" Tmax="6000.0" P0="100000.0">
+           <floatArray size="9" name="coeffs">
+             -1.378630916E+05,  -5.579207290E+01,   1.004190387E+01,  -1.682165339E-05, 
+             3.724664660E-09,  -4.275526780E-13,   1.982341329E-17,  -7.343407470E+04,
+             -2.045130429E+01</floatArray>
+        </NASA9>
+      </thermo>
+    </species>
+
+    <!-- species AR    -->
+    <species name="AR">
+      <atomArray>Ar:1 </atomArray>
+      <note>Ref-Elm. Moore,1971. Gordon,1999.. [g 3/98]</note>
+      <thermo>
+        <NASA9 Tmin="200.0" Tmax="1000.0" P0="100000.0">
+           <floatArray size="9" name="coeffs">
+             0.000000000E+00,   0.000000000E+00,   2.500000000E+00,   0.000000000E+00, 
+             0.000000000E+00,   0.000000000E+00,   0.000000000E+00,  -7.453750000E+02,
+             4.379674910E+00</floatArray>
+        </NASA9>
+      </thermo>
+    </species>
+  </speciesData>
+  <reactionData id="reaction_data"/>
+</ctml>

--- a/test/data/unrecognized-section.inp
+++ b/test/data/unrecognized-section.inp
@@ -1,0 +1,14 @@
+Elements
+H  C
+
+SPECIES
+R1A R1B H P1
+END
+
+SPAM
+R1A + R1B = H + P1      1.2345e12  1.0  200.0
+END
+
+reactions cal/mol
+R1A + R1B = H + P1      1.2345e12  1.0  200.0
+R1A + R1A = H + P1      5.4321e10  1.0  500.0


### PR DESCRIPTION
Previously, lines which did not contain a reaction equation or a known keyword and did not contain any slashes would be silently skipped, since they were being treated as lines containing 0 third-body efficiencies. This caused reactions mistakenly written using `->` as the arrow to be ignored without warning.
Fixes #582 

The logic for continuing past the NASA9 entry for a species that was not included in the model was broken, and also unnecessarily complicated. It has been simplified and fixed.
Fixes #583