### PR TITLE
Implement function to list data files

### DIFF
--- a/interfaces/cython/cantera/data/__init__.py
+++ b/interfaces/cython/cantera/data/__init__.py
@@ -1,0 +1,15 @@
+from pathlib import Path
+
+
+def list_data_files(ext=''):
+    """
+    Lists input data files.
+
+    :param ext:
+        Extension of files to be displayed.
+    :return:
+        List of input data files.
+    """
+    here = Path(__file__).parent
+    data_files = [x.name for x in here.iterdir() if not x.name.startswith('__') and x.name.endswith(ext)]
+    return data_files


### PR DESCRIPTION
Fixes #586 

Function `cantera.data.files()` returns list of all data files. It can also be used to get files of a certain type by specifying the required extension.
