### PR TITLE
Support for Langmuir-Hinshelwood kinetics

### DIFF
--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -368,6 +368,11 @@ public:
     virtual void determineFwdOrdersBV(ElectrochemicalReaction& r, vector_fp& fwdFullorders);
 
 protected:
+
+    //! Add Langmuir-Hinshelwood type of reaction
+    void addLangmuirReaction(LangmuirReaction& r);
+    void modifyLangmuirReaction(size_t i, LangmuirReaction& rNew);
+
     //! Build a SurfaceArrhenius object from a Reaction, taking into account
     //! the possible sticking coefficient form and coverage dependencies
     //! @param i  Reaction number
@@ -392,6 +397,10 @@ protected:
      *  The class SurfaceArrhenius is described in RxnRates.h
      */
     Rate1<SurfaceArrhenius> m_rates;
+    Rate1<LangmuirRate> m_LH_rates;
+
+     //! Array of partial pressures for each species
+    vector_fp m_pp;
 
     bool m_redo_rates;
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -187,6 +187,29 @@ public:
     ChebyshevRate rate;
 };
 
+//! Modifications to an Langmuir-Hinshelwood rate based on species adsorption
+struct AdsorptionDependency
+{
+    //! Constructor
+    AdsorptionDependency(double A_, double b_, double H_, double m_, bool n_) : A(A_), b(b_), H(H_), m(m_), n(n_) {}
+    AdsorptionDependency() {}
+    double A;
+    double b;
+    double H;
+    double m;
+    bool n;
+};
+ //! A Langmuir-Hinshelwood type of reaction
+class LangmuirReaction : public Reaction
+{
+public:
+    LangmuirReaction();
+    LangmuirReaction(const Composition& reactants, const Composition& products,
+                      const LangmuirRate& rate);
+     LangmuirRate rate;
+    std::map<std::string, AdsorptionDependency> adsorption_deps;
+};
+
 //! Modifications to an InterfaceReaction rate based on a surface species
 //! coverage.
 struct CoverageDependency

--- a/include/cantera/kinetics/reaction_defs.h
+++ b/include/cantera/kinetics/reaction_defs.h
@@ -57,6 +57,11 @@ const int PLOG_RXN = 5;
 const int CHEBYSHEV_RXN = 6;
 
 /**
+ * A Langmuir-Hinshelwood type of reaction.
+ */
+const int LANGMUIR_RXN = 7;
+
+/**
  * A chemical activation reaction. For these reactions, the rate falls
  * off as the pressure increases, due to collisional stabilization of
  * a reaction intermediate. Example: Si + SiH4 (+M) <-> Si2H2 + H2
@@ -126,6 +131,7 @@ const int ARRHENIUS_SUM_REACTION_RATECOEFF_TYPE = 5;
 const int EXCHANGE_CURRENT_REACTION_RATECOEFF_TYPE = 6;
 const int PLOG_REACTION_RATECOEFF_TYPE = 7;
 const int CHEBYSHEV_REACTION_RATECOEFF_TYPE = 8;
+const int LANGMUIR_REACTION_RATECOEFF_TYPE = 9;
 
 //@}
 

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -152,4 +152,42 @@ ChebyshevRate::ChebyshevRate(double Tmin, double Tmax, double Pmin, double Pmax,
     }
 }
 
+LangmuirRate::LangmuirRate()
+    : m_A(0.0)
+    , m_b(0.0)
+    , m_E(0.0)
+    , m_md(2.0)
+{
+}
+ LangmuirRate::LangmuirRate(doublereal A, doublereal b, doublereal E)
+    : m_A(A)
+    , m_b(b)
+    , m_E(E)
+    , m_md(2.0)
+{
+}
+
+void LangmuirRate::correctOrderEffect(doublereal order) {
+    m_A *= std::pow(GasConstant, order);
+    m_b += order;
+};
+
+//! Set the overal exponent of the denominator
+void LangmuirRate::setDenominatorExponent(doublereal m) {
+    m_md = m;
+};
+ void LangmuirRate::addAdsorptionDependence(size_t k, doublereal a,
+                               doublereal b, doublereal h,
+                               doublereal d, bool n)
+{
+    m_sp.push_back(k);
+    m_ac.push_back(a);
+    m_bc.push_back(b);
+    m_hc.push_back(h);
+    m_dc.push_back(d);
+    m_nc.push_back(n);
+    m_Kc.push_back(0.0);
+    m_cc.push_back(0.0);
+}
+
 }


### PR DESCRIPTION
These changes should allow to use Langmuir-Hinshelwood type of kinetics, in the way it is done in Chemkin. 
This answers my question here: https://groups.google.com/forum/#!topic/cantera-users/B-l_HFkJy0c 