### PR TITLE
Additional check for Troe coefficients being zero

### DIFF
--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -30,8 +30,18 @@ void Troe::init(const vector_fp& c)
             c.size());
     }
     m_a = c[0];
-    m_rt3 = 1.0/c[1];
-    m_rt1 = 1.0/c[2];
+    if (std::abs(c[1]) < SmallNumber) {
+        m_rt3 = std::numeric_limits<double>::infinity();
+    } else {
+        m_rt3 = 1.0 / c[1];
+    }
+
+    if (std::abs(c[2]) < SmallNumber) {
+        m_rt1 = std::numeric_limits<double>::infinity();
+    } else {
+        m_rt1 = 1.0 / c[2];
+    }
+
     if (c.size() == 4) {
         m_t2 = c[3];
     }


### PR DESCRIPTION
I encountered the problem that the "init" function of Troe reactions generates a floating point exception due to division by zero. I am using the FORCE Caltech mechanism from here:
http://www.theforce.caltech.edu/CaltechMech/
In the mechanism file
http://cvs.theforce.caltech.edu/cgi-bin/viewvc.cgi/CaltechMech/CaltechMech.chmech?view=co
there is the following reaction:

 H+O2(+M) = HO2(+M)                      5.590e+13    0.200      0.00
   O2/0.89/ H2/1.50/ H2O/11.70/ CO2/2.18/ AR/0.52/ CO/1.09/ 
   LOW  /  2.650e+19   -1.300      0.00 /
   TROE/     0.7     0.00 10000000000.00 10000000000.00 /

The second Troe parameter is zero. According to the Chemkin Format
http://akrmys.com/public/chemkin/CKm_inp.html.en
this corresponds to T*** or "m_rt3" in Cantera:
https://github.com/Cantera/cantera/blob/5c783c708f0c08def6f6a3d8328b336d65842357/src/kinetics/Falloff.cpp#L33

Using the standard installation of Cantera, this does not generate any errors. But in my case, I use Cantera together with another program (OpenFOAM), which throws hardware exceptions if this occurs. Of course, I could change this by hand in the mechanism file itself, but maybe it is nicer to handle this in the code.
This was actually handled in previous versions, but was removed in this commit:
https://github.com/Cantera/cantera/commit/84e6775ee304185ec11f736358a82f6da2a2c04d#diff-4210fe882743537c1bb1cacdbe10255b
and this issue:
https://github.com/Cantera/cantera/issues/404
I would argue to include a special treatment for zero in case Cantera is used together with programs like OpenFOAM which will trigger hardware exceptions if division by zero occurs.

Because this part of the code is not relevant to performance, I introduced an additional check. This will prevent hardware exceptions in case c[1] or c[2] are zero but will exactly keep the current behaviour if c[1] and c[2] are not zero.