### PR TITLE
Fix property updates in BinarySolutionTabulatedThermo

### DIFF
--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -158,6 +158,12 @@ protected:
     //! Current tabulated species mole fraction
     mutable double m_xlast;
 
+    //! Tabulated contribution to h0[m_kk_tab] at the current composition
+    mutable double m_h0_tab;
+
+    //! Tabulated contribution to s0[m_kk_tab] at the current composition
+    mutable double m_s0_tab;
+
     //! Vector for storing tabulated thermo
     vector_fp m_molefrac_tab;
     vector_fp m_enthalpy_tab;

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -156,7 +156,7 @@ protected:
     size_t m_kk_tab;
 
     //! Current tabulated species mole fraction
-    double m_xlast;
+    mutable double m_xlast;
 
     //! Vector for storing tabulated thermo
     vector_fp m_molefrac_tab;
@@ -164,7 +164,7 @@ protected:
     vector_fp m_entropy_tab;
 
 private:
-    void _updateThermo();
+    virtual void _updateThermo() const;
 };
 }
 

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -681,7 +681,7 @@ private:
      * the temperature has changed, the species thermo manager is called to
      * recalculate G, Cp, H, and S at the current temperature.
      */
-    void _updateThermo() const;
+    virtual void _updateThermo() const;
 
     //@}
 };

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -113,7 +113,6 @@ void BinarySolutionTabulatedThermo::initThermoXML(XML_Node& phaseNode, const std
                 throw CanteraError("BinarySolutionTabulatedThermo::initThermoXML",
                         "Species " + tabulated_species_name + " not found.");
             }
-            m_xlast = moleFraction(m_kk_tab);
         }
         if (thermoNode.hasChild("tabulatedThermo")) {
             XML_Node& dataNode = thermoNode.child("tabulatedThermo");

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -48,7 +48,7 @@ void BinarySolutionTabulatedThermo::compositionChanged()
     _updateThermo();
 }
 
-void BinarySolutionTabulatedThermo::_updateThermo()
+void BinarySolutionTabulatedThermo::_updateThermo() const
 {
     double tnow = temperature();
     double xnow = moleFraction(m_kk_tab);

--- a/test/thermo/BinarySolutionTabulatedThermo_Test.cpp
+++ b/test/thermo/BinarySolutionTabulatedThermo_Test.cpp
@@ -52,6 +52,10 @@ TEST_F(BinarySolutionTabulatedThermo_Test,interp_h)
     {
         set_defect_X(xmin + i*dx);
         EXPECT_NEAR(expected_result[i], test_phase->enthalpy_mole(), 1.e-6);
+        // enthalpy is temperature-independent in test data file (all species
+        // use constant cp model with cp = 0)
+        test_phase->setState_TP(310, 101325);
+        EXPECT_NEAR(expected_result[i], test_phase->enthalpy_mole(), 1.e-6);
     }
 }
 
@@ -78,7 +82,10 @@ TEST_F(BinarySolutionTabulatedThermo_Test,interp_s)
     for (int i = 0; i < 9; ++i)
     {
         set_defect_X(xmin + i*dx);
-
+        EXPECT_NEAR(expected_result[i], test_phase->entropy_mole(), 1.e-6);
+        // entropy is temperature-independent in test data file (all species use
+        // constant cp model with cp = 0)
+        test_phase->setState_TP(330.0, 101325);
         EXPECT_NEAR(expected_result[i], test_phase->entropy_mole(), 1.e-6);
     }
 }


### PR DESCRIPTION
Because `IdealSolidSolnPhase::_updateThermo` wasn't a virtual method, and the signature wasn't the same as `BinarySolutionTabulatedThermo::_updateThermo` (const vs non-const), calls to this method
from `IdealSolidSolnPhase` weren't being overridden by ` BinarySolutionTabulatedThermo::_updateThermo` as expected.

After fixing this, there was still a problem in the case the temperature changed but the mole fractions were the same, where the tabulated correction to the enthalpy / entropy was being replaced by the pure species values. Now, we store the tabulated values and apply them every time.