### PR TITLE
add integrator parameters to the InterfaceKinetics::advanceCoverages …

### DIFF
--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -61,8 +61,16 @@ public:
      * @param k  Vector of pointers to InterfaceKinetics objects Each object
      *           consists of a surface or an edge containing internal degrees of
      *           freedom representing the concentration of surface adsorbates.
+     * @param rtol   The relative tolerance for the integrator
+     * @param atol   The absolute tolerance for the integrator
+     * @param maxStepSize   The maximum step-size the integrator is allowed to take
+     * @param maxSteps   the maximum number of time-steps the integrator can take
+     * @param maxErrTestFails   the maximum permissible number of error test failures
      */
-    ImplicitSurfChem(std::vector<InterfaceKinetics*> k);
+    ImplicitSurfChem(std::vector<InterfaceKinetics*> k,
+                     doublereal rtol=1.e-7, doublereal atol=1.e-14,
+                     doublereal maxStepSize=0, size_t maxSteps=0,
+                     size_t maxErrTestFails=0);
 
     virtual ~ImplicitSurfChem() {};
 
@@ -230,6 +238,8 @@ protected:
     std::unique_ptr<Integrator> m_integ;
     doublereal m_atol, m_rtol; // tolerances
     doublereal m_maxstep; //!< max step size
+    size_t m_nmax; //!< maximum number of steps allowed
+    size_t m_maxErrTestFails; //!< maximum number of error test failures allowed
     vector_fp m_work;
 
     /**

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -63,14 +63,17 @@ public:
      *           freedom representing the concentration of surface adsorbates.
      * @param rtol   The relative tolerance for the integrator
      * @param atol   The absolute tolerance for the integrator
-     * @param maxStepSize   The maximum step-size the integrator is allowed to take
-     * @param maxSteps   the maximum number of time-steps the integrator can take
+     * @param maxStepSize   The maximum step-size the integrator is allowed to take.
+     *                      If zero, this option is disabled.
+     * @param maxSteps   The maximum number of time-steps the integrator can take.
+     *                   If not supplied, uses the default value in the CVodesIntegrator (20000).
      * @param maxErrTestFails   the maximum permissible number of error test failures
+     *                           If not supplied, uses the default value in CVODES (7).
      */
     ImplicitSurfChem(std::vector<InterfaceKinetics*> k,
-                     doublereal rtol=1.e-7, doublereal atol=1.e-14,
-                     doublereal maxStepSize=0, size_t maxSteps=0,
-                     size_t maxErrTestFails=0);
+                     double rtol=1.e-7, double atol=1.e-14,
+                     double maxStepSize=0, size_t maxSteps=20000,
+                     size_t maxErrTestFails=7);
 
     virtual ~ImplicitSurfChem() {};
 
@@ -78,6 +81,27 @@ public:
      *  Must be called before calling method 'advance'
      */
     virtual void initialize(doublereal t0 = 0.0);
+
+    /*!
+     *  Set the maximum integration step-size.  Note, setting this value to zero
+     *  disables this option
+     */
+    virtual void setMaxStepSize(double maxstep = 0.0);
+
+    /*!
+     *  Set the relative and absolute integration tolerances.
+     */
+    virtual void setTolerances(double rtol=1.e-7, double atol=1.e-14);
+
+    /*!
+     *  Set the maximum number of CVODES integration steps.
+     */
+    virtual void setMaxSteps(size_t maxsteps = 20000);
+
+    /*!
+     *  Set the maximum number of CVODES error test failures
+     */
+    virtual void setMaxErrTestFails(size_t maxErrTestFails = 7);
 
     //! Integrate from t0 to t1. The integrator is reinitialized first.
     /*!

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -242,14 +242,16 @@ public:
      * @param tstep  Time value to advance the surface coverages
      * @param rtol   The relative tolerance for the integrator
      * @param atol   The absolute tolerance for the integrator
-     * @param maxStepSize   The maximum step-size the integrator is allowed to take
-     * @param maxSteps   the maximum number of time-steps the integrator can take
-     *                   before reaching tstep
+     * @param maxStepSize   The maximum step-size the integrator is allowed to take.
+     *                      If zero, this option is disabled.
+     * @param maxSteps   The maximum number of time-steps the integrator can take.
+     *                   If not supplied, uses the default value in CVodeIntegrator (20000).
      * @param maxErrTestFails   the maximum permissible number of error test failures
+     *                           If not supplied, uses the default value in CVODES (7).
      */
-    void advanceCoverages(doublereal tstep, doublereal rtol=1.e-7,
-                          doublereal atol=1.e-14, doublereal maxStepSize=0,
-                          size_t maxSteps=0, size_t maxErrTestFails=0);
+    void advanceCoverages(doublereal tstep, double rtol=1.e-7,
+                          double atol=1.e-14, double maxStepSize=0,
+                          size_t maxSteps=20000, size_t maxErrTestFails=7);
 
     //! Solve for the pseudo steady-state of the surface problem
     /*!

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -240,8 +240,16 @@ public:
      *  \f]
      *
      * @param tstep  Time value to advance the surface coverages
+     * @param rtol   The relative tolerance for the integrator
+     * @param atol   The absolute tolerance for the integrator
+     * @param maxStepSize   The maximum step-size the integrator is allowed to take
+     * @param maxSteps   the maximum number of time-steps the integrator can take
+     *                   before reaching tstep
+     * @param maxErrTestFails   the maximum permissible number of error test failures
      */
-    void advanceCoverages(doublereal tstep);
+    void advanceCoverages(doublereal tstep, doublereal rtol=1.e-7,
+                          doublereal atol=1.e-14, doublereal maxStepSize=0,
+                          size_t maxSteps=0, size_t maxErrTestFails=0);
 
     //! Solve for the pseudo steady-state of the surface problem
     /*!

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -379,7 +379,7 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
 
 cdef extern from "cantera/kinetics/InterfaceKinetics.h":
     cdef cppclass CxxInterfaceKinetics "Cantera::InterfaceKinetics":
-        void advanceCoverages(double) except +translate_exception
+        void advanceCoverages(double, double, double, double, size_t, size_t) except +translate_exception
         void solvePseudoSteadyStateProblem() except +translate_exception
 
 

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -376,13 +376,16 @@ cdef class InterfaceKinetics(Kinetics):
             self._phase_indices[phase.name] = i
             self._phase_indices[i] = i
 
-    def advance_coverages(self, double dt):
+    def advance_coverages(self, double dt, double rtol=1e-7, double atol=1e-14,
+                          double max_step_size=0, int max_steps=20000,
+                          int max_error_test_failures=7):
         """
         This method carries out a time-accurate advancement of the surface
         coverages for a specified amount of time.
         """
-        (<CxxInterfaceKinetics*>self.kinetics).advanceCoverages(dt)
-      
+        (<CxxInterfaceKinetics*>self.kinetics).advanceCoverages(
+            dt, rtol, atol, max_step_size, max_steps, max_error_test_failures)
+
     def advance_coverages_to_steady_state(self):
         """
         This method advances the surface coverages to steady state.

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -896,7 +896,7 @@ class TestImpingingJet(utilities.CanteraTest):
 
         # integrate the coverage equations holding the gas composition fixed
         # to generate a good starting estimate for the coverages.
-        surf_phase.advance_coverages(1.0)
+        surf_phase.advance_coverages(1.)
 
         sim = ct.ImpingingJet(gas=gas, width=width, surface=surf_phase)
         sim.set_refine_criteria(10.0, 0.3, 0.4, 0.0)

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -17,13 +17,18 @@ using namespace std;
 namespace Cantera
 {
 
-ImplicitSurfChem::ImplicitSurfChem(vector<InterfaceKinetics*> k) :
+ImplicitSurfChem::ImplicitSurfChem(
+        vector<InterfaceKinetics*> k, doublereal rtol, doublereal atol,
+        doublereal maxStepSize, size_t maxSteps,
+        size_t maxErrTestFails) :
     m_nv(0),
     m_numTotalBulkSpecies(0),
     m_numTotalSpecies(0),
-    m_atol(1.e-14),
-    m_rtol(1.e-7),
-    m_maxstep(0.0),
+    m_atol(atol),
+    m_rtol(rtol),
+    m_maxstep(maxStepSize),
+    m_nmax(maxSteps),
+    m_maxErrTestFails(maxErrTestFails),
     m_mediumSpeciesStart(-1),
     m_bulkSpeciesStart(-1),
     m_surfSpeciesStart(-1),
@@ -107,6 +112,18 @@ void ImplicitSurfChem::getState(doublereal* c)
 void ImplicitSurfChem::initialize(doublereal t0)
 {
     m_integ->setTolerances(m_rtol, m_atol);
+    if (m_maxstep > 0)
+    {
+        m_integ->setMaxStepSize(m_maxstep);
+    }
+    if (m_nmax > 0)
+    {
+        m_integ->setMaxSteps(m_nmax);
+    }
+    if (m_maxErrTestFails > 0)
+    {
+        m_integ->setMaxErrTestFails(m_maxErrTestFails);
+    }
     m_integ->initialize(t0, *this);
 }
 

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -767,11 +767,14 @@ doublereal InterfaceKinetics::electrochem_beta(size_t irxn) const
     return 0.0;
 }
 
-void InterfaceKinetics::advanceCoverages(doublereal tstep)
+void InterfaceKinetics::advanceCoverages(doublereal tstep, doublereal rtol,
+                                         doublereal atol, doublereal maxStepSize,
+                                         size_t maxSteps, size_t maxErrTestFails)
 {
     if (m_integrator == 0) {
         vector<InterfaceKinetics*> k{this};
-        m_integrator = new ImplicitSurfChem(k);
+        m_integrator = new ImplicitSurfChem(k, rtol, atol, maxStepSize, maxSteps,
+                                            maxErrTestFails);
         m_integrator->initialize();
     }
     m_integrator->integrate(0.0, tstep);

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -773,10 +773,12 @@ void InterfaceKinetics::advanceCoverages(doublereal tstep, doublereal rtol,
 {
     if (m_integrator == 0) {
         vector<InterfaceKinetics*> k{this};
-        m_integrator = new ImplicitSurfChem(k, rtol, atol, maxStepSize, maxSteps,
-                                            maxErrTestFails);
-        m_integrator->initialize();
+        m_integrator = new ImplicitSurfChem(k);
     }
+    m_integrator->setTolerances(rtol, atol);
+    m_integrator->setMaxStepSize(maxStepSize);
+    m_integrator->setMaxSteps(maxSteps);
+    m_integrator->setMaxErrTestFails(maxErrTestFails);
     m_integrator->integrate(0.0, tstep);
     delete m_integrator;
     m_integrator = 0;


### PR DESCRIPTION
…& ImplicitSurfChem constructor to allow users to modfiy

Please fill in the issue number this pull request is fixing:

Fixes #608

Changes proposed in this pull request:
- Adds user-settable integrator parameters to the InterfaceKinetics::advanceCoverages method
- Adds the same to the Cython interface

@speth -- what would be a good test here?  Something like simultaneously limiting the maximum step-size to `t_out/N` while limiting the maximum number of steps to `N-1` would be a good test from the cython interface for those values, but I'm not sure how to test that the rtol / atol or error test failures are correctly set without lowering the tests into C++?  I guess I could add some information methods (similar to those in the base Integrator class) to query these directly, but that doesn't seem to fit well with the very short lived nature of the integrator inside of InterfaceKinetics...
