### PR TITLE
Add Cython language_level directive to _cantera.pyx

### DIFF
--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1,5 +1,6 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at http://www.cantera.org/license.txt for license and copyright information.
+# cython: language_level=3
 
 from libcpp.vector cimport vector
 from libcpp.string cimport string

--- a/interfaces/cython/cantera/_cantera.pyx
+++ b/interfaces/cython/cantera/_cantera.pyx
@@ -7,7 +7,7 @@ import math
 
 from cython.operator cimport dereference as deref, preincrement as inc
 
-from _cantera cimport *
+from ._cantera cimport *
 
 include "utils.pyx"
 include "constants.pyx"

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -1,7 +1,7 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at http://www.cantera.org/license.txt for license and copyright information.
 
-import interrupts
+from .interrupts import no_op
 import warnings
 
 # Need a pure-python class to store weakrefs to
@@ -589,7 +589,7 @@ cdef class Sim1D:
 
         self.sim = new CxxSim1D(D)
         self.domains = tuple(domains)
-        self.set_interrupt(interrupts.no_op)
+        self.set_interrupt(no_op)
         self._initialized = False
         self._initial_guess_args = ()
         self._initial_guess_kwargs = {}

--- a/interfaces/cython/cantera/reactionpath.pyx
+++ b/interfaces/cython/cantera/reactionpath.pyx
@@ -181,7 +181,7 @@ cdef class ReactionPathDiagram:
                            self.diagram, True)
         self.built = True
         if verbose:
-            print self.log
+            print(self.log)
 
     property log:
         """


### PR DESCRIPTION
This fixes the warnings generated by recent versions of Cython that
the language_level will be changed in the future. By setting this
directive, all the code in the .pyx files should be written in
Python 3 syntax. This required several changes to the import
syntax in the files to fix relative vs. absolute imports

See https://stackoverflow.com/questions/54900723/what-does-language-level-in-setup-py-for-cython-do for more information about this setting
