### PR TITLE
Add the Accelerate framework to the CMake builds of the samples

### DIFF
--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -23,6 +23,8 @@ find_package(OpenMP REQUIRED)
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS})
 set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 """
+    elif env["OS"] == "Darwin":
+        localenv["cmake_extra"] = "find_library(ACCELERATE_FRAMEWORK Accelerate)"
     else:
         localenv['cmake_extra'] = ''
 
@@ -44,6 +46,8 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     localenv['cmake_cantera_incdirs'] = ' '.join(quoted(x) for x in incdirs if x)
     localenv['tmpl_cantera_libs'] = repr(localenv['cantera_libs'])
     localenv['cmake_cantera_libs'] = ' '.join(localenv['cantera_libs'])
+    if env['OS'] == 'Darwin':
+        localenv['cmake_cantera_libs'] += ' ${ACCELERATE_FRAMEWORK}'
     localenv['tmpl_cantera_libdirs'] = repr([x for x in libdirs if x])
     localenv['cmake_cantera_libdirs'] = ' '.join(quoted(x) for x in libdirs if x)
     localenv['tmpl_cantera_linkflags'] = repr(localenv['LINKFLAGS'])

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -48,6 +48,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     localenv['cmake_cantera_libs'] = ' '.join(localenv['cantera_libs'])
     if env['OS'] == 'Darwin':
         localenv['cmake_cantera_libs'] += ' ${ACCELERATE_FRAMEWORK}'
+        localenv['cmake_cantera_incdirs'] += ' "/usr/local/include"'
     localenv['tmpl_cantera_libdirs'] = repr([x for x in libdirs if x])
     localenv['cmake_cantera_libdirs'] = ' '.join(quoted(x) for x in libdirs if x)
     localenv['tmpl_cantera_linkflags'] = repr(localenv['LINKFLAGS'])


### PR DESCRIPTION
Adds the Accelerate framework to the CMake builds of the C++ samples on macOS.

Does the CI run the samples? If not, I can try to set that up.