### PR TITLE
Enable additional states / equations in onedim

### DIFF
--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -70,6 +70,11 @@ public:
         m_thermo = &th;
     }
 
+    //! Return number of species
+    virtual size_t nSpecies() {
+        return m_nsp;
+    }
+  
     //! Set the kinetics manager. The kinetics manager must
     void setKinetics(Kinetics& kin) {
         m_kin = &kin;

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -70,11 +70,6 @@ public:
         m_thermo = &th;
     }
 
-    //! Return number of species
-    virtual size_t nSpecies() {
-        return m_nsp;
-    }
-  
     //! Set the kinetics manager. The kinetics manager must
     void setKinetics(Kinetics& kin) {
         m_kin = &kin;

--- a/src/oneD/boundaries1D.cpp
+++ b/src/oneD/boundaries1D.cpp
@@ -137,7 +137,7 @@ void Inlet1D::init()
     }
 
     // components = u, V, T, lambda, + mass fractions
-    m_nsp = m_flow->nSpecies();
+    m_nsp = m_flow->phase().nSpecies();
     m_yin.resize(m_nsp, 0.0);
     if (m_xstr != "") {
         setMoleFractions(m_xstr);
@@ -441,7 +441,7 @@ void OutletRes1D::init()
         throw CanteraError("OutletRes1D::init","no flow!");
     }
 
-    m_nsp = m_flow->nSpecies();
+    m_nsp = m_flow->phase().nSpecies();
     m_yres.resize(m_nsp, 0.0);
     if (m_xstr != "") {
         setMoleFractions(m_xstr);

--- a/src/oneD/boundaries1D.cpp
+++ b/src/oneD/boundaries1D.cpp
@@ -137,7 +137,7 @@ void Inlet1D::init()
     }
 
     // components = u, V, T, lambda, + mass fractions
-    m_nsp = m_flow->nComponents() - c_offset_Y;
+    m_nsp = m_flow->nSpecies();
     m_yin.resize(m_nsp, 0.0);
     if (m_xstr != "") {
         setMoleFractions(m_xstr);
@@ -441,7 +441,7 @@ void OutletRes1D::init()
         throw CanteraError("OutletRes1D::init","no flow!");
     }
 
-    m_nsp = m_flow->nComponents() - c_offset_Y;
+    m_nsp = m_flow->nSpecies();
     m_yres.resize(m_nsp, 0.0);
     if (m_xstr != "") {
         setMoleFractions(m_xstr);


### PR DESCRIPTION
Fixes # [cantera-users] Additional Equations in StFlow

Changes proposed in this pull request:
- add `nSpecies() { return m_nsp; }` to `StFlow.h`
- replace  `m_nsp = m_flow->nComponents() - c_offset_Y;` by `m_nsp = m_flow->nSpecies();` in `boundaries1D.cpp`

Proposed change enables decoupling of number of components from the number of species.