### PR TITLE
Improve output handling in zeroD simulations

### DIFF
--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CVODESWRAPPER_H
 #define CT_CVODESWRAPPER_H
@@ -41,6 +41,8 @@ public:
     virtual doublereal step(double tout);
     virtual double& solution(size_t k);
     virtual double* solution();
+    virtual double* derivative(double tout, int n);
+    virtual int lastOrder() const;
     virtual int nEquations() const {
         return static_cast<int>(m_neq);
     }
@@ -89,6 +91,7 @@ private:
     double m_t0;
     double m_time; //!< The current integrator time
     N_Vector m_y, m_abstol;
+    N_Vector m_dky;
     int m_type;
     int m_itol;
     int m_method;

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_INTEGRATOR_H
 #define CT_INTEGRATOR_H
@@ -138,6 +138,18 @@ public:
     //! The current value of the solution of the system of equations.
     virtual doublereal* solution() {
         warn("solution");
+        return 0;
+    }
+
+    //! n-th derivative of the output function at time tout.
+    virtual double* derivative(double tout, int n) {
+        warn("derivative");
+        return 0;
+    }
+
+    //! Order used during the last solution step
+    virtual int lastOrder() const {
+        warn("lastOrder");
         return 0;
     }
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -132,6 +132,20 @@ public:
     //! @see componentIndex()
     virtual std::string componentName(size_t k);
 
+    //! Set absolute step size limits during advance
+    //! @param limits array of step size limits with length neq
+    virtual void setAdvanceLimits(const double* limits);
+
+    //! Retrieve absolute step size limits during advance
+    //! @param[out] limits array of step size limits with length neq
+    //! @returns           True if at least one limit is set, False otherwise
+    virtual bool getAdvanceLimits(double* limits);
+
+    //! Set individual step size limit for compoment name *nm*
+    //! @param nm component name
+    //! @param limit value for step size limit
+    virtual void setAdvanceLimit(const std::string& nm, const double limit);
+
 protected:
     //! Set reaction rate multipliers based on the sensitivity variables in
     //! *params*.
@@ -179,6 +193,8 @@ protected:
     bool m_chem;
     bool m_energy;
     size_t m_nv;
+
+    vector_fp m_advancelimits; //!< Advance step limit
 
     // Data associated each sensitivity parameter
     std::vector<SensitivityParameter> m_sensParams;

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -1,7 +1,7 @@
 //! @file ReactorNet.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REACTORNET_H
 #define CT_REACTORNET_H
@@ -80,6 +80,17 @@ public:
      * @param time Time to advance to (s).
      */
     void advance(doublereal time);
+
+    /**
+     * Advance the state of all reactors in time. Take as many internal
+     * timesteps as necessary towards *time*. If *applylimit* is true,
+     * the advance step will be automatically reduced if needed to
+     * stay within limits (set by setAdvanceLimit).
+     * Returns the time at the end of integration.
+     * @param time Time to advance to (s).
+     * @param applylimit Limit advance step (boolean).
+     */
+    double advance(double time, bool applylimit);
 
     //! Advance the state of all reactors in time.
     double step();
@@ -164,6 +175,9 @@ public:
 
     virtual void getState(doublereal* y);
 
+    //! Return k-th derivative at the current time
+    virtual void getDerivative(int k, double* dky);
+
     virtual size_t nparams() {
         return m_sens_params.size();
     }
@@ -195,6 +209,10 @@ public:
         return m_paramNames.at(p);
     }
 
+    //! Initialize the reactor network. Called automatically the first time
+    //! advance or step is called.
+    void initialize();
+
     //! Reinitialize the integrator. Used to solve a new problem (different
     //! initial conditions) but with the same configuration of the reactor
     //! network. Can be called manually, or automatically after calling
@@ -222,10 +240,25 @@ public:
         return m_integ->maxSteps();
     }
 
+    //! Set absolute step size limits during advance
+    virtual void setAdvanceLimits(const double* limits);
+
+    //! Retrieve absolute step size limits during advance
+    virtual bool getAdvanceLimits(double* limits);
+
 protected:
-    //! Initialize the reactor network. Called automatically the first time
-    //! advance or step is called.
-    void initialize();
+
+    //! Estimate a future state based on current derivatives.
+    //! The function is intended for internal use by ReactorNet::advance
+    //! and deliberately not exposed in external interfaces.
+    virtual void getEstimate(double time, int k, double* yest);
+
+    //! Returns the order used for last solution step of the ODE integrator
+    //! The function is intended for internal use by ReactorNet::advance
+    //! and deliberately not exposed in external interfaces.
+    virtual int lastOrder() {
+        return m_integ->lastOrder();
+    }
 
     std::vector<Reactor*> m_reactors;
     std::unique_ptr<Integrator> m_integ;
@@ -251,6 +284,8 @@ protected:
     std::vector<std::string> m_paramNames;
 
     vector_fp m_ydot;
+    vector_fp m_yest;
+    vector_fp m_advancelimits;
 };
 }
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -502,7 +502,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         size_t neq()
         void getState(double*)
         void addSurface(CxxReactorSurface*)
-
+        void setAdvanceLimit(string&, double) except +translate_exception
         void addSensitivityReaction(size_t) except +translate_exception
         void addSensitivitySpeciesEnthalpy(size_t) except +translate_exception
         size_t nSensParams()
@@ -580,8 +580,9 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxReactorNet "Cantera::ReactorNet":
         CxxReactorNet()
         void addReactor(CxxReactor&)
-        void advance(double) except +translate_exception
+        double advance(double, cbool) except +translate_exception
         double step() except +translate_exception
+        void initialize() except +translate_exception
         void reinitialize() except +translate_exception
         double time()
         void setInitialTime(double)
@@ -596,8 +597,11 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void setVerbose(cbool)
         size_t neq()
         void getState(double*)
+        void getDerivative(int, double *) except +translate_exception
+        void setAdvanceLimits(double*)
+        cbool getAdvanceLimits(double*)
         string componentName(size_t) except +translate_exception
-
+        size_t globalComponentIndex(string&, int) except +translate_exception
         void setSensitivityTolerances(double, double)
         double rtolSensitivity()
         double atolSensitivity()

--- a/interfaces/cython/cantera/examples/reactors/reactor1.py
+++ b/interfaces/cython/cantera/examples/reactors/reactor1.py
@@ -12,16 +12,22 @@ gas.TPX = 1001.0, ct.one_atm, 'H2:2,O2:1,N2:4'
 r = ct.IdealGasConstPressureReactor(gas)
 
 sim = ct.ReactorNet([r])
-time = 0.0
+sim.verbose = True
+
+# limit advance when temperature difference is exceeded
+delta_T_max = 20.
+r.set_advance_limit('temperature', delta_T_max)
+
+dt_max = 1.e-5
+t_end = 100 * dt_max
 states = ct.SolutionArray(gas, extra=['t'])
 
-print('%10s %10s %10s %14s' % ('t [s]','T [K]','P [Pa]','u [J/kg]'))
-for n in range(100):
-    time += 1.e-5
-    sim.advance(time)
-    states.append(r.thermo.state, t=time*1e3)
-    print('%10.3e %10.3f %10.3f %14.6e' % (sim.time, r.T,
-                                           r.thermo.P, r.thermo.u))
+print('{:10s} {:10s} {:10s} {:14s}'.format('t [s]','T [K]','P [Pa]','u [J/kg]'))
+while sim.time < t_end:
+    sim.advance(sim.time + dt_max)
+    states.append(r.thermo.state, t=sim.time*1e3)
+    print('{:10.3e} {:10.3f} {:10.3f} {:14.6f}'.format(sim.time, r.T,
+                                                       r.thermo.P, r.thermo.u))
 
 # Plot the results if matplotlib is installed.
 # See http://matplotlib.org/ to get it.

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -428,7 +428,7 @@ int Sim1D::setFixedTemperature(doublereal t)
 {
     int np = 0;
     vector_fp znew, xnew;
-    doublereal zfixed;
+    doublereal zfixed = 0.0;
     doublereal z1 = 0.0, z2 = 0.0, t1,t2;
     size_t m1 = 0;
     std::vector<size_t> dsize;


### PR DESCRIPTION
Fixes #628 

Changes proposed in this pull request:
- use `CVodesIntegrator` to calculate time derivatives via `CVodeGetDky`
- implement a Taylor series expansion to estimate future states of a `ReactorNet` object
- specify maximum difference ("atol") for states between advance states
- create new `ReactorNet::advanceTowards` function as an alternative to `ReactorNet::advance`, which automatically reduces the time advance when excessive state differences are predicted (time advances are successively reduced by `2^(-1)` until differences remain within specified limits. Internal cvode time steps remain unaffected).

All functions are implemented in C++ and are accessible from the Python interface via cython. The new example `reactor3.py` illustrates differences to the standard `ReactorNet` example `reactor1.py`.