### PR TITLE
Overload to Phase::speciesIndex() to take an atomic composition map of the species

### DIFF
--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -262,6 +262,14 @@ public:
     //!             the value \ref npos is returned.
     size_t speciesIndex(const std::string& name) const;
 
+    //! Returns a vector of indices of species with the given elemental
+    //! composition. The first species in the phase will have an index 0 and
+    //! the last one will have an index of nSpecies() - 1.
+    //!     @param comp Composition of the species.
+    //!     @return Vector of species indices. If the composition is not found, an
+    //!             empty array is returned.
+    std::vector<size_t> speciesIndex(const Composition& comp) const;
+
     //! Name of the species with index k
     //!     @param k index of the species
     std::string speciesName(size_t k) const;

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -191,6 +191,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         shared_ptr[CxxSpecies] species(string) except +translate_exception
         shared_ptr[CxxSpecies] species(size_t) except +translate_exception
         size_t speciesIndex(string) except +translate_exception
+        vector[size_t] speciesIndex(Composition&) except +translate_exception
         string speciesName(size_t) except +translate_exception
         double nAtoms(size_t, size_t) except +translate_exception
         void getAtoms(size_t, double*) except +translate_exception
@@ -979,7 +980,6 @@ cdef class ThermoPhase(_SolutionBase):
     cdef double _mass_factor(self)
     cdef double _mole_factor(self)
     cpdef int element_index(self, element) except *
-    cpdef int species_index(self, species) except *
     cdef np.ndarray _getArray1(self, thermoMethod1d method)
     cdef void _setArray1(self, thermoMethod1d method, values) except *
     cdef public object _references

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -530,14 +530,35 @@ cdef class ThermoPhase(_SolutionBase):
                 indices = range(self.n_species)
             return [self.species_name(k) for k in indices]
 
-    cpdef int species_index(self, species) except *:
+    def species_index(self, species):
         """
-        The index of species *species*, which may be specified as a string or
-        an integer. In the latter case, the index is checked for validity and
-        returned. If no such species is present, an exception is thrown.
+        The index of species *species*, which may be specified as a string,
+        a dictionary, or an integer. The string argument should be the name
+        of a species in the phase. If an integer is given, the index is
+        checked for validity and returned. If no such species is present, an
+        exception is thrown.
+
+        The dictionary argument can be used to find the species indices of
+        species with particular elemental composition. In this case, a list
+        of indices is returned. If no species is present with the given
+        composition, an empty list is returned.
+
+        Examples::
+
+            >>> gas = ct.Solution("gri30.yaml")
+            >>> gas.species_index("H2")
+            0
+            >>> gas.species_index(0)
+            0
+            >>> gas.species_index({"H": 2})
+            [0]
+            >>> gas.species_index({"C": 1, "H": 2})
+            [10, 11]
         """
         if isinstance(species, (str, bytes)):
             index = self.thermo.speciesIndex(stringify(species))
+        elif isinstance(species, dict):
+            return [i for i in self.thermo.speciesIndex(comp_map(species))]
         elif isinstance(species, (int, float)):
             index = <int>species
         else:

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -226,6 +226,17 @@ size_t Phase::speciesIndex(const std::string& nameStr) const
     return loc;
 }
 
+vector<size_t> Phase::speciesIndex(const Composition& comp) const
+{
+    vector<size_t> speciesIndices;
+    for (const auto& k : m_speciesNames) {
+        if (m_species.at(k)->composition == comp) {
+            speciesIndices.push_back(m_speciesIndices.at(k));
+        }
+    }
+    return speciesIndices;
+}
+
 string Phase::speciesName(size_t k) const
 {
     checkSpeciesIndex(k);

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -308,6 +308,28 @@ TEST_F(ConstructFromScratch, addUndefinedElements)
     ASSERT_DOUBLE_EQ(0.5, p.massFraction("CO2"));
 }
 
+TEST_F(ConstructFromScratch, getSpeciesIndex)
+{
+    IdealGasPhase p;
+    p.addElement("H");
+    p.addElement("O");
+    p.ignoreUndefinedElements();
+
+    p.addSpecies(sO2);
+    p.addSpecies(sOH);
+
+    ASSERT_EQ(p.speciesIndex(sCO2->composition).size(), (size_t) 0);
+    ASSERT_EQ(p.speciesIndex("OH"), p.speciesIndex(sOH->composition)[0]);
+
+    IdealGasPhase gas("gri30.yaml", "gri30");
+    Composition ch2Comp = gas.species("CH2")->composition;
+
+    std::vector<size_t> ch2Indices = gas.speciesIndex(ch2Comp);
+    ASSERT_EQ(ch2Indices.size(), (size_t) 2);
+    ASSERT_EQ(ch2Indices[0], gas.speciesIndex("CH2"));
+    ASSERT_EQ(ch2Indices[1], gas.speciesIndex("CH2(S)"));
+}
+
 TEST_F(ConstructFromScratch, RedlichKwongMFTP)
 {
     RedlichKwongMFTP p;


### PR DESCRIPTION
Fixes #603 

Changes proposed in this pull request:

As noticed at the issue #603, in some cases, querying a species by name is not a well-defined process, because there is not a requirement that species be named in this way. Thus, an overload of Phase::speciesIndex() is provided, in order to find the index of the species, by passing its atomic composition map (compositionMap Species::composiotion).