### PR TITLE
Adding faradayconstant.m to Matlab toolbox

### DIFF
--- a/interfaces/matlab/toolbox/faradayconstant.m
+++ b/interfaces/matlab/toolbox/faradayconstant.m
@@ -1,0 +1,8 @@
+function r = faradayconstant
+% FARADAYCONSTANT  Get the Faraday constant in C/kmol of electron.
+% r = faradayconstant
+% :return:
+%     The Faraday constant in C/kmol-e.
+%
+
+r = 96485336.4595687;


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a function `faradayconstant.m` to the Matlab toolbox which, akin to `gasconstant.m`, returns the value of the Faraday constant, in Coulombs per kmol of electron.
