### PR TITLE
Deprecating ConstDensityThermo class

### DIFF
--- a/data/inputs/sofc.cti
+++ b/data/inputs/sofc.cti
@@ -108,10 +108,10 @@ species( name = "electron",   atoms = "E:1",
 # consider the oxygen sublattice. The only species we define are a
 # lattice oxygen, and an oxygen vacancy. Again, the density is a
 # required input, but is not used here, so may be set arbitrarily.
-incompressible_solid(name = "oxide_bulk",
+lattice(name = "oxide_bulk",
       elements = "O E",
       species = "Ox VO**",
-      density = (0.7, 'g/cm3'),
+      site_density = (0.0176, 'g/cm3'),
       initial_state = state( temperature = tt,
                              pressure = OneAtm,
                              mole_fractions = "Ox:0.95 VO**:0.05")

--- a/include/cantera/thermo/ConstDensityThermo.h
+++ b/include/cantera/thermo/ConstDensityThermo.h
@@ -24,13 +24,19 @@ namespace Cantera
  * The density is assumed to be constant, no matter what the concentration of
  * the solution.
  *
+ * @deprecated To be removed after Cantera 2.5.0. Replaceable with LatticePhase
+ * or IdealSolidSolnPhase
+ *
  * @ingroup thermoprops
  */
 class ConstDensityThermo : public ThermoPhase
 {
 public:
     //! Constructor.
-    ConstDensityThermo() {}
+    ConstDensityThermo() {
+      warn_deprecated("class ConstDensityThermo", "To be removed after Cantera "
+        "2.5.0. Consider replacing with LatticePhase or IdealSolidSolnPhase\n");
+    }
 
     virtual std::string type() const {
         return "ConstDensity";

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -2137,7 +2137,16 @@ class semiconductor(phase):
 
 
 class incompressible_solid(phase):
-    """An incompressible solid."""
+    """An incompressible solid.
+
+    .. deprecated:: 2.5
+
+        To be deprecated with version 2.5, and removed thereafter.
+        This phase pointed to an ill-considered constant_density ThermoPhase
+        model, which assumed a constant mass density. This underlying phase is
+        simultaneously being deprecated. Please consider switching to
+        either `IdealSolidSolution` or `lattice` phase, instead.
+    """
     def __init__(self,
                  name = '',
                  elements = '',

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -2295,7 +2295,7 @@ class lattice(phase):
                         initial_state, options)
         self._tr = transport
         self._n = site_density
-        self._species = species
+
         if name == '':
             raise CTI_Error('sublattice name must be specified')
         if species == '':

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -496,7 +496,7 @@ class CtmlConverterTest(utilities.CanteraTest):
 
         self.assertNear(gas_a.P, ct.one_atm)
         self.assertNear(anode_bulk['electron'].X, 1.0)
-        self.assertNear(oxide_a.density, 700)
+        self.assertNear(oxide_a.density_mole, 17.6)
 
     def test_diamond(self):
         gas, solid = ct.import_phases('diamond.cti', ['gas','diamond'])


### PR DESCRIPTION
As previously discussed, the `incompressible_solid` cti phase actually points to the `ConstDensityThermo` class.  This is misleading to a user, and moreover, a thermo class which enforces constant mass density has both dubious physical underpinning and marginal utility for a user.  It is therefore appropriate to deprecate and remove this class, and refer interested users to either the `IdealSolidSolnPhase` or `Lattice` thermo classes, which are appropriate replacements.

Changes proposed in this pull request:
- Marks `ConstDensityThermo` thermo class for deprecation, as of release 2.5, and for removal, thereafter.
- Adds appropriate messages to `ctml_writer.py` parsing routine, `ConstDensityThermo.cpp`, and `ConstDensityThermo.h` to indicate as much, and suggest use of `Lattice` or `IdealSolidSolnPhase` classes as alternates
- Removes the `incompressible_solid` phase in `sofc.cti` (which is used for the sofc example, and which aliases to the `ConstDensityThermo` class) and replaces it with an equivalent `Lattice` phase.
- Changes the cython test in `test_convert.py` which interrogates the `incompressible_solid` phase mass density in `sofc.cti` so that it instead interrogates the `Lattice` phase molar density.
