### PR TITLE
Fix OpenMP on macOS

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -253,7 +253,15 @@ defaults.noDebugLinkFlags = ''
 defaults.warningFlags = '-Wall'
 defaults.buildPch = False
 env['pch_flags'] = []
-env['openmp_flag'] = '-fopenmp' # used to generate sample build scripts
+env['openmp_flag'] = ['-fopenmp'] # used to generate sample build scripts
+
+env['using_apple_clang'] = False
+# Check if this is actually Apple's clang on macOS
+if env['OS'] == 'Darwin':
+    result = subprocess.check_output([env.subst('$CC'), '--version']).decode('utf-8')
+    if 'clang' in result.lower() and result.startswith('Apple LLVM'):
+        env['using_apple_clang'] = True
+        env['openmp_flag'].insert(0, '-Xpreprocessor')
 
 if 'gcc' in env.subst('$CC') or 'gnu-cc' in env.subst('$CC'):
     defaults.optimizeCcFlags += ' -Wno-inline'
@@ -276,13 +284,13 @@ elif env['CC'] == 'cl': # Visual Studio
     defaults.warningFlags = '/W3'
     defaults.buildPch = True
     env['pch_flags'] = ['/FIpch/system.h']
-    env['openmp_flag'] = '/openmp'
+    env['openmp_flag'] = ['/openmp']
 
 elif 'icc' in env.subst('$CC'):
     defaults.cxxFlags = '-std=c++0x'
     defaults.ccFlags = '-vec-report0 -diag-disable 1478'
     defaults.warningFlags = '-Wcheck'
-    env['openmp_flag'] = '-openmp'
+    env['openmp_flag'] = ['-openmp']
 
 elif 'clang' in env.subst('$CC'):
     defaults.ccFlags = '-fcolor-diagnostics'

--- a/include/cantera/zerodim.h
+++ b/include/cantera/zerodim.h
@@ -7,7 +7,7 @@
 #define CT_INCL_ZERODIM_H
 
 // reactor network
-#include "zeroD/ReactorNet.h"
+#include "cantera/zeroD/ReactorNet.h"
 
 // reactors
 #include "cantera/zeroD/Reservoir.h"
@@ -30,5 +30,8 @@
 #include "cantera/zeroD/ReactorFactory.h"
 #include "cantera/zeroD/FlowDeviceFactory.h"
 #include "cantera/zeroD/WallFactory.h"
+
+// func1
+#include "cantera/numerics/Func1.h"
 
 #endif

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -18,6 +18,9 @@ for subdir, name, extensions, openmp in samples:
     localenv = env.Clone()
     if openmp:
         localenv.Append(CXXFLAGS=env['openmp_flag'], LINKFLAGS=env['openmp_flag'])
+        if env['using_apple_clang']:
+            localenv.Append(LIBS=['omp'])
+
         localenv['cmake_extra'] = """
 find_package(OpenMP REQUIRED)
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS})
@@ -28,6 +31,8 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 
     if env["OS"] == "Darwin":
         localenv["cmake_extra"] += "find_library(ACCELERATE_FRAMEWORK Accelerate)"
+
+    localenv.Append(LIBS=env['cantera_libs'])
 
     buildSample(localenv.Program, pjoin(subdir, name),
                 mglob(localenv, subdir, *extensions),

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -23,10 +23,11 @@ find_package(OpenMP REQUIRED)
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS})
 set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 """
-    elif env["OS"] == "Darwin":
-        localenv["cmake_extra"] = "find_library(ACCELERATE_FRAMEWORK Accelerate)"
     else:
         localenv['cmake_extra'] = ''
+
+    if env["OS"] == "Darwin":
+        localenv["cmake_extra"] += "find_library(ACCELERATE_FRAMEWORK Accelerate)"
 
     buildSample(localenv.Program, pjoin(subdir, name),
                 mglob(localenv, subdir, *extensions),

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -30,8 +30,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 
     buildSample(localenv.Program, pjoin(subdir, name),
                 mglob(localenv, subdir, *extensions),
-                CPPPATH=['#include'],
-                LIBS=env['cantera_libs'])
+                CPPPATH=['#include', env['boost_inc_dir']])
 
     # Note: These Makefiles and SConstruct files are automatically installed
     # by the "RecursiveInstall" that grabs everything in the cxx directory.


### PR DESCRIPTION
Changes proposed in this pull request:
- Using the macOS clang compiler distributed by Apple requires different compiler options
- Explicitly include `Func1.h` in `zerodim.h`, it had been previously implicitly included but was inadvertently removed in #632 
- Change CMakeLists.txt to use OpenMP *and* Accelerate in the samples on macOS
