### PR TITLE
Fix conda compilers

### DIFF
--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -74,6 +74,13 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
         env_args.append('MSVC_VERSION={0!r}'.format(localenv['MSVC_VERSION']))
     localenv['tmpl_env_args'] = ', '.join(env_args)
 
+    # If this is a conda build on macOS, we do not want to specify the conda
+    # compilers from the build environment, because those won't be installed
+    # on the user's system.
+    if env['OS'] == 'Darwin' and os.environ.get('CONDA_BUILD', False):
+        localenv['CXX'] = 'clang++'
+        localenv['CC'] = 'clang'
+
     sconstruct = localenv.SubstFile(pjoin(subdir, 'SConstruct'), 'SConstruct.in')
     install(pjoin('$inst_sampledir', 'cxx', subdir), sconstruct)
 

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -40,7 +40,18 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
                localenv['boost_inc_dir']) + tuple(localenv['extra_inc_dirs'])
     libdirs = ((localenv['ct_libdir'], localenv['sundials_libdir'],
                localenv['blas_lapack_dir']) + tuple(localenv['extra_lib_dirs']))
-    localenv['tmpl_compiler_flags'] = repr(localenv['CCFLAGS'] + localenv['CXXFLAGS'])
+    # Remove sysroot and macOS min version flags in templated output files
+    # Users should compile against their local SDKs, which should be backwards
+    # compatible with the SDK used for building. This only applies to the
+    # conda package for now.
+    if env['OS'] == 'Darwin' and os.environ.get('CONDA_BUILD', False):
+        ccFlags = []
+        for flag in localenv['CCFLAGS'] + localenv['CXXFLAGS']:
+            if not flag.startswith(('-isysroot', '-mmacosx', '/App')):
+                ccFlags.append(flag)
+    else:
+        ccFlags = localenv['CCFLAGS'] + localenv['CXXFLAGS']
+    localenv['tmpl_compiler_flags'] = repr(ccFlags)
     localenv['tmpl_cantera_frameworks'] = repr(localenv['FRAMEWORKS'])
     localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])
     localenv['cmake_cantera_incdirs'] = ' '.join(quoted(x) for x in incdirs if x)
@@ -72,7 +83,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 
     ## Generate Makefiles to be installed
     mak_path = pjoin(localenv['ct_incroot'], 'cantera', 'Cantera.mak')
-    localenv['mak_compiler_flags'] = ' '.join(localenv['CCFLAGS'] + localenv['CXXFLAGS'])
+    localenv['mak_compiler_flags'] = ' '.join(ccFlags)
     if ' ' in mak_path:
         # There is no reasonable way to handle spaces in Makefile 'include'
         # statement, so we fall back to using the relative path instead


### PR DESCRIPTION
Changes proposed in this pull request:
- If we're building the conda package with the conda compilers, they require setting the sysroot and the minimum macOS version supported. However, we don't want those variables carried into the template files distributed to users
