### PR TITLE
Build the samples on the CI services

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -23,6 +23,7 @@ addons:
     - scons
     - boost
     - python
+    - libomp
   ssh_known_hosts:
     - cantera.org
 
@@ -50,6 +51,7 @@ script: |
       set -e
       scons build -j2 python_cmd=/usr/bin/python3 VERBOSE=y python_package=full blas_lapack_libs=lapack,blas optimize=n coverage=y
       scons test
+      scons samples
       scons build sphinx_docs=y doxygen_docs=y sphinx_cmd="/usr/bin/python3 `which sphinx-build`"
       if [[ "${TRAVIS_PULL_REQUEST}" == "false" ]] && [[ "${TRAVIS_BRANCH}" == "master" ]] && [[ "${TRAVIS_REPO_SLUG}" == "Cantera/cantera" ]]; then
         openssl aes-256-cbc -k "${ctdeploy_pass}" -in ./doc/ctdeploy_key.enc -out ./doc/ctdeploy_key -d
@@ -75,6 +77,7 @@ script: |
   else
       scons build -j2 python_cmd=python3 VERBOSE=y python_package=full blas_lapack_libs=lapack,blas optimize=n coverage=y
       scons test
+      scons samples
   fi
 after_success: |
   if [[ "$TRAVIS_OS_NAME" == "linux" ]]; then

--- a/SConstruct
+++ b/SConstruct
@@ -253,7 +253,15 @@ defaults.noDebugLinkFlags = ''
 defaults.warningFlags = '-Wall'
 defaults.buildPch = False
 env['pch_flags'] = []
-env['openmp_flag'] = '-fopenmp' # used to generate sample build scripts
+env['openmp_flag'] = ['-fopenmp'] # used to generate sample build scripts
+
+env['using_apple_clang'] = False
+# Check if this is actually Apple's clang on macOS
+if env['OS'] == 'Darwin':
+    result = subprocess.check_output([env.subst('$CC'), '--version']).decode('utf-8')
+    if 'clang' in result.lower() and result.startswith('Apple LLVM'):
+        env['using_apple_clang'] = True
+        env['openmp_flag'].insert(0, '-Xpreprocessor')
 
 if 'gcc' in env.subst('$CC') or 'gnu-cc' in env.subst('$CC'):
     defaults.optimizeCcFlags += ' -Wno-inline'
@@ -276,13 +284,13 @@ elif env['CC'] == 'cl': # Visual Studio
     defaults.warningFlags = '/W3'
     defaults.buildPch = True
     env['pch_flags'] = ['/FIpch/system.h']
-    env['openmp_flag'] = '/openmp'
+    env['openmp_flag'] = ['/openmp']
 
 elif 'icc' in env.subst('$CC'):
     defaults.cxxFlags = '-std=c++0x'
     defaults.ccFlags = '-vec-report0 -diag-disable 1478'
     defaults.warningFlags = '-Wcheck'
-    env['openmp_flag'] = '-openmp'
+    env['openmp_flag'] = ['-openmp']
 
 elif 'clang' in env.subst('$CC'):
     defaults.ccFlags = '-fcolor-diagnostics'

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -11,6 +11,7 @@ install:
 
 build_script:
 - cmd: C:\Python37-x64\Scripts\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y python_package=full
+- cmd: C:\Python37-x64\Scripts\scons samples
 
 test_script:
 - ps: |

--- a/include/cantera/zerodim.h
+++ b/include/cantera/zerodim.h
@@ -7,7 +7,7 @@
 #define CT_INCL_ZERODIM_H
 
 // reactor network
-#include "zeroD/ReactorNet.h"
+#include "cantera/zeroD/ReactorNet.h"
 
 // reactors
 #include "cantera/zeroD/Reservoir.h"
@@ -30,5 +30,8 @@
 #include "cantera/zeroD/ReactorFactory.h"
 #include "cantera/zeroD/FlowDeviceFactory.h"
 #include "cantera/zeroD/WallFactory.h"
+
+// func1
+#include "cantera/numerics/Func1.h"
 
 #endif

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -18,6 +18,9 @@ for subdir, name, extensions, openmp in samples:
     localenv = env.Clone()
     if openmp:
         localenv.Append(CXXFLAGS=env['openmp_flag'], LINKFLAGS=env['openmp_flag'])
+        if env['using_apple_clang']:
+            localenv.Append(LIBS=['omp'])
+
         localenv['cmake_extra'] = """
 find_package(OpenMP REQUIRED)
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS})
@@ -28,6 +31,8 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 
     if env["OS"] == "Darwin":
         localenv["cmake_extra"] += "find_library(ACCELERATE_FRAMEWORK Accelerate)"
+
+    localenv.Append(LIBS=env['cantera_libs'])
 
     buildSample(localenv.Program, pjoin(subdir, name),
                 mglob(localenv, subdir, *extensions),

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -23,10 +23,11 @@ find_package(OpenMP REQUIRED)
 set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS})
 set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 """
-    elif env["OS"] == "Darwin":
-        localenv["cmake_extra"] = "find_library(ACCELERATE_FRAMEWORK Accelerate)"
     else:
         localenv['cmake_extra'] = ''
+
+    if env["OS"] == "Darwin":
+        localenv["cmake_extra"] += "find_library(ACCELERATE_FRAMEWORK Accelerate)"
 
     buildSample(localenv.Program, pjoin(subdir, name),
                 mglob(localenv, subdir, *extensions),

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -30,8 +30,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 
     buildSample(localenv.Program, pjoin(subdir, name),
                 mglob(localenv, subdir, *extensions),
-                CPPPATH=['#include'],
-                LIBS=env['cantera_libs'])
+                CPPPATH=['#include', env['boost_inc_dir']])
 
     # Note: These Makefiles and SConstruct files are automatically installed
     # by the "RecursiveInstall" that grabs everything in the cxx directory.

--- a/samples/cxx/openmp_ignition/openmp_ignition.cpp
+++ b/samples/cxx/openmp_ignition/openmp_ignition.cpp
@@ -34,10 +34,10 @@ void run()
     }
 
     // Points at which to compute ignition delay time
-    size_t nPoints = 50;
+    int nPoints = 50;
     vector_fp T0(nPoints);
     vector_fp ignition_time(nPoints);
-    for (size_t i = 0; i < nPoints; i++) {
+    for (int i = 0; i < nPoints; i++) {
         T0[i] = 1000 + 500 * ((float) i) / ((float) nPoints);
     }
 
@@ -51,7 +51,7 @@ void run()
     // thread in cases where the workload is biased, e.g. calculations for low
     // T0 take longer than calculations for high T0.
     #pragma omp parallel for schedule(static, 1)
-    for (size_t i = 0; i < nPoints; i++) {
+    for (int i = 0; i < nPoints; i++) {
         // Get the Cantera objects that were initialized for this thread
         size_t j = omp_get_thread_num();
         IdealGasMix& gas = *gases[j];
@@ -76,7 +76,7 @@ void run()
     // Print the computed ignition delays
     writelog("  T (K)    t_ig (s)\n");
     writelog("--------  ----------\n");
-    for (size_t i = 0; i < nPoints; i++) {
+    for (int i = 0; i < nPoints; i++) {
         writelog("{: 8.1f}  {: 10.3e}\n", T0[i], ignition_time[i]);
     }
 }


### PR DESCRIPTION
- Using the macOS clang compiler distributed by Apple requires different compiler options
- Explicitly include `Func1.h` in `zerodim.h`, it had been previously implicitly included but was inadvertently removed in #632 
- Change CMakeLists.txt to use OpenMP *and* Accelerate in the samples on macOS
- Build the samples on the CI services using scons
