### PR TITLE
[Reactor] Use correct phase state after mass flow rate evaluation

### DIFF
--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -150,6 +150,12 @@ protected:
     //! @param t     the current time
     virtual void evalWalls(double t);
 
+    //! Evaluate inlet and outlet mass flow rates. This is called in evalEqs()
+    //! before setting the state of #m_thermo, since calling the mass flow rate
+    //! functions may modify ThermoPhase objects that are shared with other
+    //! reactors.
+    virtual void evalFlowDevices(double t);
+
     //! Evaluate terms related to surface reactions. Calculates #m_sdot and rate
     //! of change in surface species coverages.
     //! @param t          the current time

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -239,6 +239,13 @@ protected:
     doublereal m_pressure;
     vector_fp m_state;
     std::vector<FlowDevice*> m_inlet, m_outlet;
+
+    //! Temporary storage for mass flow rates from each inlet FlowDevice
+    vector_fp m_mdot_in;
+
+    //! Temporary storage for mass flow rates from each outlet FlowDevice
+    vector_fp m_mdot_out;
+
     std::vector<WallBase*> m_wall;
     std::vector<ReactorSurface*> m_surfaces;
     vector_int m_lr;

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -74,9 +74,11 @@ void IdealGasConstPressureReactor::evalEqs(doublereal time, doublereal* y,
     double mcpdTdt = 0.0; // m * c_p * dT/dt
     double* dYdt = ydot + 2;
 
-    m_thermo->restoreState(m_state);
+    evalFlowDevices(time);
     applySensitivity(params);
     evalWalls(time);
+
+    m_thermo->restoreState(m_state);
     double mdot_surf = evalSurfaces(time, ydot + m_nsp + 2);
     dmdt += mdot_surf;
 
@@ -103,18 +105,17 @@ void IdealGasConstPressureReactor::evalEqs(doublereal time, doublereal* y,
 
     // add terms for outlets
     for (size_t i = 0; i < m_outlet.size(); i++) {
-        dmdt -= m_outlet[i]->massFlowRate(time); // mass flow out of system
+        dmdt -= m_mdot_out[i]; // mass flow out of system
     }
 
     // add terms for inlets
     for (size_t i = 0; i < m_inlet.size(); i++) {
-        double mdot_in = m_inlet[i]->massFlowRate(time);
-        dmdt += mdot_in; // mass flow into system
-        mcpdTdt += m_inlet[i]->enthalpy_mass() * mdot_in;
+        dmdt += m_mdot_in[i]; // mass flow into system
+        mcpdTdt += m_inlet[i]->enthalpy_mass() * m_mdot_in[i];
         for (size_t n = 0; n < m_nsp; n++) {
             double mdot_spec = m_inlet[i]->outletSpeciesMassFlowRate(n);
             // flow of species into system and dilution by other species
-            dYdt[n] += (mdot_spec - mdot_in * Y[n]) / m_mass;
+            dYdt[n] += (mdot_spec - m_mdot_in[i] * Y[n]) / m_mass;
             mcpdTdt -= m_hk[n] / mw[n] * mdot_spec;
         }
     }

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -188,9 +188,10 @@ void Reactor::evalEqs(doublereal time, doublereal* y,
     double dmdt = 0.0; // dm/dt (gas phase)
     double* dYdt = ydot + 3;
 
-    m_thermo->restoreState(m_state);
-    applySensitivity(params);
+    evalFlowDevices(time);
     evalWalls(time);
+    applySensitivity(params);
+    m_thermo->restoreState(m_state);
     double mdot_surf = evalSurfaces(time, ydot + m_nsp + 3);
     dmdt += mdot_surf; // mass added to gas phase from surface reactions
 
@@ -223,24 +224,22 @@ void Reactor::evalEqs(doublereal time, doublereal* y,
 
     // add terms for outlets
     for (size_t i = 0; i < m_outlet.size(); i++) {
-        double mdot_out = m_outlet[i]->massFlowRate(time);
-        dmdt -= mdot_out; // mass flow out of system
+        dmdt -= m_mdot_out[i]; // mass flow out of system
         if (m_energy) {
-            ydot[2] -= mdot_out * m_enthalpy;
+            ydot[2] -= m_mdot_out[i] * m_enthalpy;
         }
     }
 
     // add terms for inlets
     for (size_t i = 0; i < m_inlet.size(); i++) {
-        double mdot_in = m_inlet[i]->massFlowRate(time);
-        dmdt += mdot_in; // mass flow into system
+        dmdt += m_mdot_in[i]; // mass flow into system
         for (size_t n = 0; n < m_nsp; n++) {
             double mdot_spec = m_inlet[i]->outletSpeciesMassFlowRate(n);
             // flow of species into system and dilution by other species
-            dYdt[n] += (mdot_spec - mdot_in * Y[n]) / m_mass;
+            dYdt[n] += (mdot_spec - m_mdot_in[i] * Y[n]) / m_mass;
         }
         if (m_energy) {
-            ydot[2] += mdot_in * m_inlet[i]->enthalpy_mass();
+            ydot[2] += m_mdot_in[i] * m_inlet[i]->enthalpy_mass();
         }
     }
 
@@ -256,6 +255,16 @@ void Reactor::evalWalls(double t)
         int lr = 1 - 2*m_lr[i];
         m_vdot += lr*m_wall[i]->vdot(t);
         m_Q += lr*m_wall[i]->Q(t);
+    }
+}
+
+void Reactor::evalFlowDevices(double t)
+{
+    for (size_t i = 0; i < m_outlet.size(); i++) {
+        m_mdot_out[i] = m_outlet[i]->massFlowRate(t);
+    }
+    for (size_t i = 0; i < m_inlet.size(); i++) {
+        m_mdot_in[i] = m_inlet[i]->massFlowRate(t);
     }
 }
 

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -47,11 +47,13 @@ void ReactorBase::syncState()
 void ReactorBase::addInlet(FlowDevice& inlet)
 {
     m_inlet.push_back(&inlet);
+    m_mdot_in.push_back(0.0);
 }
 
 void ReactorBase::addOutlet(FlowDevice& outlet)
 {
     m_outlet.push_back(&outlet);
+    m_mdot_out.push_back(0.0);
 }
 
 void ReactorBase::addWall(WallBase& w, int lr)


### PR DESCRIPTION
A user-defined mass flow rate function can modify the ThermoPhase object used by a reactor, for example if it depends on calculating some property of a different reactor. To make sure that the reactor governing equations are evaluated correctly, the ThermoPhase state needs to be set after all user-defined functions have been called.

Resolves a problem reported on the [Cantera Users' Group](https://groups.google.com/forum/?fromgroups=#!topic/cantera-users/JX2jzsD-mx0).

