### PR TITLE
Rename ambiguous variable diag

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -25,6 +25,7 @@ Jon Kristofer
 Kyle Linevitch, Jr.
 Christopher Leuth
 Nicholas Malaya, University of Texas at Austin
+Thanasis Mattas, Aristotle University of Thessaloniki
 Evan McCorkle
 Ivan Mitrichev, Mendeleev University of Chemical Technology of Russia
 Harry Moffat, Sandia National Laboratory
@@ -33,6 +34,8 @@ Kyle Niemeyer, Oregon State University
 @pwcnorthrop
 Andreas Rücker
 Jeff Santner
+Satyam Saxena
+Ingmar Schoegl, Louisiana State University
 Santosh Shanbhogue, Massachusetts Institute of Technology
 David Sondak
 Raymond Speth, Massachusetts Institute of Technology

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -42,12 +42,12 @@ public:
     }
 
     /// Set the temperature.
-    virtual void setTemperature(doublereal t) {
+    virtual void setTemperature(double t) {
         m_temp = t;
     }
 
     /// Temperature [K].
-    virtual doublereal temperature() {
+    virtual double temperature() {
         return m_temp;
     }
 
@@ -61,26 +61,26 @@ public:
     }
 
     /// Set the mole fractions by specifying an array.
-    virtual void setMoleFractions(const doublereal* xin) {
+    virtual void setMoleFractions(const double* xin) {
         throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
     /// Mass fraction of species k.
-    virtual doublereal massFraction(size_t k) {
+    virtual double massFraction(size_t k) {
         throw NotImplementedError("Boundary1D::massFraction");
     }
 
     /// Set the total mass flow rate.
-    virtual void setMdot(doublereal mdot) {
+    virtual void setMdot(double mdot) {
         m_mdot = mdot;
     }
 
     /// The total mass flow rate [kg/m2/s].
-    virtual doublereal mdot() {
+    virtual double mdot() {
         return m_mdot;
     }
 
-    virtual void setupGrid(size_t n, const doublereal* z) {}
+    virtual void setupGrid(size_t n, const double* z) {}
 
 protected:
     void _init(size_t n);
@@ -93,7 +93,7 @@ protected:
     size_t m_sp_left, m_sp_right;
     size_t m_start_left, m_start_right;
     ThermoPhase* m_phase_left, *m_phase_right;
-    doublereal m_temp, m_mdot;
+    double m_temp, m_mdot;
 };
 
 /*!
@@ -120,7 +120,7 @@ public:
     Inlet1D();
 
     /// set spreading rate
-    virtual void setSpreadRate(doublereal V0) {
+    virtual void setSpreadRate(double V0) {
         m_V0 = V0;
         needJacUpdate();
     }
@@ -137,19 +137,19 @@ public:
     }
 
     virtual void setMoleFractions(const std::string& xin);
-    virtual void setMoleFractions(const doublereal* xin);
-    virtual doublereal massFraction(size_t k) {
+    virtual void setMoleFractions(const double* xin);
+    virtual double massFraction(size_t k) {
         return m_yin[k];
     }
     virtual void init();
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* tmaskg, doublereal rdt);
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      int* tmaskg, double rdt);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 
 protected:
     int m_ilr;
-    doublereal m_V0;
+    double m_V0;
     size_t m_nsp;
     vector_fp m_yin;
     std::string m_xstr;
@@ -167,15 +167,15 @@ public:
         m_type = cEmptyType;
     }
 
-    virtual void showSolution(const doublereal* x) {}
+    virtual void showSolution(const double* x) {}
 
     virtual void init();
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* tmaskg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      int* tmaskg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 };
 
 /**
@@ -192,11 +192,11 @@ public:
 
     virtual void init();
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* tmaskg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      int* tmaskg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 };
 
 
@@ -213,11 +213,11 @@ public:
 
     virtual void init();
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* tmaskg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      int* tmaskg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 };
 
 
@@ -230,22 +230,22 @@ class OutletRes1D : public Boundary1D
 public:
     OutletRes1D();
 
-    virtual void showSolution(const doublereal* x) {}
+    virtual void showSolution(const double* x) {}
 
     virtual size_t nSpecies() {
         return m_nsp;
     }
 
     virtual void setMoleFractions(const std::string& xin);
-    virtual void setMoleFractions(const doublereal* xin);
-    virtual doublereal massFraction(size_t k) {
+    virtual void setMoleFractions(const double* xin);
+    virtual double massFraction(size_t k) {
         return m_yres[k];
     }
     virtual void init();
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* tmaskg, doublereal rdt);
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      int* tmaskg, double rdt);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 
 protected:
     size_t m_nsp;
@@ -269,15 +269,15 @@ public:
 
     virtual void init();
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* tmaskg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      int* tmaskg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 
     virtual void showSolution_s(std::ostream& s, const double* x);
 
-    virtual void showSolution(const doublereal* x) {
+    virtual void showSolution(const double* x) {
         writelog("    Temperature: {:10.4g} K \n\n", m_temp);
     }
 };
@@ -302,21 +302,21 @@ public:
     virtual void init();
     virtual void resetBadValues(double* xg);
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* tmaskg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      int* tmaskg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 
-    virtual void _getInitialSoln(doublereal* x) {
+    virtual void _getInitialSoln(double* x) {
         m_sphase->getCoverages(x);
     }
 
-    virtual void _finalize(const doublereal* x) {
+    virtual void _finalize(const double* x) {
         std::copy(x, x+m_nsp, m_fixed_cov.begin());
     }
 
-    virtual void showSolution(const doublereal* x);
+    virtual void showSolution(const double* x);
 
 protected:
     InterfaceKinetics* m_kin;

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -1,14 +1,14 @@
 /**
- * @file Inlet1D.h
+ * @file Boundary1D.h
  *
  * Boundary objects for one-dimensional simulations.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
-#ifndef CT_BDRY1D_H
-#define CT_BDRY1D_H
+#ifndef CT_BOUNDARY1D_H
+#define CT_BOUNDARY1D_H
 
 #include "Domain1D.h"
 #include "cantera/thermo/SurfPhase.h"
@@ -32,10 +32,10 @@ const int RightInlet = -1;
  * exceptions.
  * @ingroup onedim
  */
-class Bdry1D : public Domain1D
+class Boundary1D : public Domain1D
 {
 public:
-    Bdry1D();
+    Boundary1D();
 
     virtual void init() {
         _init(1);
@@ -57,17 +57,17 @@ public:
 
     /// Set the mole fractions by specifying a std::string.
     virtual void setMoleFractions(const std::string& xin) {
-        throw NotImplementedError("Bdry1D::setMoleFractions");
+        throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
     /// Set the mole fractions by specifying an array.
     virtual void setMoleFractions(const doublereal* xin) {
-        throw NotImplementedError("Bdry1D::setMoleFractions");
+        throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
     /// Mass fraction of species k.
     virtual doublereal massFraction(size_t k) {
-        throw NotImplementedError("Bdry1D::massFraction");
+        throw NotImplementedError("Boundary1D::massFraction");
     }
 
     /// Set the total mass flow rate.
@@ -96,12 +96,25 @@ protected:
     doublereal m_temp, m_mdot;
 };
 
-
+/*!
+ * Renamed base class for boundaries between one-dimensional spatial domains.
+ * @deprecated To be removed after Cantera 2.5.
+ */
+class Bdry1D : public Boundary1D
+{
+public:
+    Bdry1D() : Boundary1D() {
+        warn_deprecated("Bdry1D::Bdry1D()", 
+                        "To be removed after Cantera 2.5. "
+                        "Class renamed to Boundary1D.");        
+    }
+};
+  
 /**
  * An inlet.
  * @ingroup onedim
  */
-class Inlet1D : public Bdry1D
+class Inlet1D : public Boundary1D
 {
 public:
     Inlet1D();
@@ -130,7 +143,7 @@ public:
     }
     virtual void init();
     virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+                      integer* tmaskg, doublereal rdt);
     virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
 
@@ -147,10 +160,10 @@ protected:
  * A terminator that does nothing.
  * @ingroup onedim
  */
-class Empty1D : public Bdry1D
+class Empty1D : public Boundary1D
 {
 public:
-    Empty1D() : Bdry1D() {
+    Empty1D() : Boundary1D() {
         m_type = cEmptyType;
     }
 
@@ -159,7 +172,7 @@ public:
     virtual void init();
 
     virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+                      integer* tmaskg, doublereal rdt);
 
     virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
@@ -170,17 +183,17 @@ public:
  * zero axial gradients.
  * @ingroup onedim
  */
-class Symm1D : public Bdry1D
+class Symm1D : public Boundary1D
 {
 public:
-    Symm1D() : Bdry1D() {
+    Symm1D() : Boundary1D() {
         m_type = cSymmType;
     }
 
     virtual void init();
 
     virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+                      integer* tmaskg, doublereal rdt);
 
     virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
@@ -191,17 +204,17 @@ public:
  * An outlet.
  * @ingroup onedim
  */
-class Outlet1D : public Bdry1D
+class Outlet1D : public Boundary1D
 {
 public:
-    Outlet1D() : Bdry1D() {
+    Outlet1D() : Boundary1D() {
         m_type = cOutletType;
     }
 
     virtual void init();
 
     virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+                      integer* tmaskg, doublereal rdt);
 
     virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
@@ -212,7 +225,7 @@ public:
  * An outlet with specified composition.
  * @ingroup onedim
  */
-class OutletRes1D : public Bdry1D
+class OutletRes1D : public Boundary1D
 {
 public:
     OutletRes1D();
@@ -230,7 +243,7 @@ public:
     }
     virtual void init();
     virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+                      integer* tmaskg, doublereal rdt);
     virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
 
@@ -247,17 +260,17 @@ protected:
  * condition is imposed for the species.
  * @ingroup onedim
  */
-class Surf1D : public Bdry1D
+class Surf1D : public Boundary1D
 {
 public:
-    Surf1D() : Bdry1D() {
+    Surf1D() : Boundary1D() {
         m_type = cSurfType;
     }
 
     virtual void init();
 
     virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+                      integer* tmaskg, doublereal rdt);
 
     virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
@@ -273,7 +286,7 @@ public:
  * A reacting surface.
  * @ingroup onedim
  */
-class ReactingSurf1D : public Bdry1D
+class ReactingSurf1D : public Boundary1D
 {
 public:
     ReactingSurf1D();
@@ -290,7 +303,7 @@ public:
     virtual void resetBadValues(double* xg);
 
     virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+                      integer* tmaskg, doublereal rdt);
 
     virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -1,7 +1,7 @@
  //! @file Domain1D.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DOMAIN1D_H
 #define CT_DOMAIN1D_H
@@ -288,16 +288,16 @@ public:
     /*!
      *  This function must be implemented in classes derived from Domain1D.
      *
-     *  @param j  Grid point at which to update the residual
-     *  @param[in] x  State vector
-     *  @param[out] r  residual vector
-     *  @param[out] mask  Boolean mask indicating whether each solution
+     *  @param jg  Grid point at which to update the residual
+     *  @param[in] xg  State vector
+     *  @param[out] rg  residual vector
+     *  @param[out] tmaskg  Boolean mask indicating whether each solution
      *      component has a time derivative (1) or not (0).
      *  @param[in] rdt Reciprocal of the timestep (`rdt=0` implies steady-
      *  state.)
      */
-    virtual void eval(size_t j, doublereal* x, doublereal* r,
-                      integer* mask, doublereal rdt=0.0) {
+    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
+                      integer* tmaskg, doublereal rdt=0.0) {
         throw NotImplementedError("Domain1D::eval");
     }
 

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -1,7 +1,7 @@
 //! @file IonFlow.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IONFLOW_H
 #define CT_IONFLOW_H
@@ -66,7 +66,7 @@ protected:
      * This function overloads the original function. The residual function
      * of electric field is added.
      */
-    virtual void evalResidual(double* x, double* rsd, int* diag,
+    virtual void evalResidual(double* x, double* rsd, int* tmask,
                               double rdt, size_t jmin, size_t jmax);
     virtual void updateTransport(double* x, size_t j0, size_t j1);
     virtual void updateDiffFluxes(const double* x, size_t j0, size_t j1);

--- a/include/cantera/oneD/MultiJac.h
+++ b/include/cantera/oneD/MultiJac.h
@@ -1,7 +1,7 @@
 //! @file MultiJac.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTIJAC_H
 #define CT_MULTIJAC_H
@@ -59,7 +59,14 @@ public:
         m_age = age;
     }
 
+    /*!
+     * Unused function.
+     * @deprecated To be removed after Cantera 2.5.
+     */
     vector_int& transientMask() {
+        warn_deprecated("MultiJac::transientMask()", 
+                        "To be removed after Cantera 2.5. "
+                        "Not used by core cantera code.");        
         return m_mask;
     }
 

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ONEDIM_H
 #define CT_ONEDIM_H
@@ -188,8 +188,13 @@ public:
     //! Call after one or more grids has changed size, e.g. after being refined.
     virtual void resize();
 
+    //! Return a vector indicating which global components are transient
+    /*!
+     * @returns Boolean mask indicating whether each solution
+     *      component has a time derivative (1) or not (0).
+     */
     vector_int& transientMask() {
-        return m_mask;
+        return m_tmask;
     }
 
     /*!
@@ -336,7 +341,7 @@ protected:
     bool m_init;
     std::vector<size_t> m_nvars;
     std::vector<size_t> m_loc;
-    vector_int m_mask;
+    vector_int m_tmask;
     size_t m_pts;
     doublereal m_solve_time;
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -1,7 +1,7 @@
 //! @file StFlow.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_STFLOW_H
 #define CT_STFLOW_H
@@ -232,22 +232,22 @@ public:
 
     /*!
      *  Evaluate the residual function for axisymmetric stagnation flow. If
-     *  j == npos, the residual function is evaluated at all grid points.
+     *  jg == npos, the residual function is evaluated at all grid points.
      *  Otherwise, the residual function is only evaluated at grid points
-     *  j-1, j, and j+1. This option is used to efficiently evaluate the
+     *  jg-1, j, and jg+1. This option is used to efficiently evaluate the
      *  Jacobian numerically.
      */
-    virtual void eval(size_t j, doublereal* x, doublereal* r,
-                      integer* mask, doublereal rdt);
+    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
+                      integer* tmaskg, doublereal rdt);
 
     //! Evaluate all residual components at the right boundary.
-    virtual void evalRightBoundary(double* x, double* res, int* diag,
+    virtual void evalRightBoundary(double* x, double* res, int* tmask,
                                    double rdt);
 
     //! Evaluate the residual corresponding to the continuity equation at all
     //! interior grid points.
     virtual void evalContinuity(size_t j, double* x, double* r,
-                                int* diag, double rdt);
+                                int* tmask, double rdt);
 
     //! Index of the species on the left boundary with the largest mass fraction
     size_t leftExcessSpecies() const {
@@ -277,7 +277,7 @@ protected:
 
     //! Evaluate the residual function. This function is called in eval
     //! after updateProperties is called.
-    virtual void evalResidual(double* x, double* rsd, int* diag,
+    virtual void evalResidual(double* x, double* rsd, int* tmask,
                               double rdt, size_t jmin, size_t jmax);
 
     /**

--- a/include/cantera/onedim.h
+++ b/include/cantera/onedim.h
@@ -13,7 +13,7 @@
 
 #include "oneD/Sim1D.h"
 #include "oneD/Domain1D.h"
-#include "oneD/Inlet1D.h"
+#include "oneD/Boundary1D.h"
 #include "oneD/StFlow.h"
 
 #endif

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -674,8 +674,8 @@ cdef extern from "cantera/oneD/Domain1D.h":
         string& id()
 
 
-cdef extern from "cantera/oneD/Inlet1D.h":
-    cdef cppclass CxxBdry1D "Cantera::Bdry1D":
+cdef extern from "cantera/oneD/Boundary1D.h":
+    cdef cppclass CxxBoundary1D "Cantera::Boundary1D":
         double temperature()
         void setTemperature(double)
         double mdot()
@@ -1054,7 +1054,7 @@ cdef class Domain1D:
     cdef public pybool have_user_tolerances
 
 cdef class Boundary1D(Domain1D):
-    cdef CxxBdry1D* boundary
+    cdef CxxBoundary1D* boundary
 
 cdef class Inlet1D(Boundary1D):
     cdef CxxInlet1D* inlet

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -310,7 +310,7 @@ cdef class Inlet1D(Boundary1D):
     """
     def __cinit__(self, *args, **kwargs):
         self.inlet = new CxxInlet1D()
-        self.boundary = <CxxBdry1D*>(self.inlet)
+        self.boundary = <CxxBoundary1D*>(self.inlet)
 
     def __dealloc__(self):
         del self.inlet
@@ -332,7 +332,7 @@ cdef class Outlet1D(Boundary1D):
     """
     def __cinit__(self, *args, **kwargs):
         self.outlet = new CxxOutlet1D()
-        self.boundary = <CxxBdry1D*>(self.outlet)
+        self.boundary = <CxxBoundary1D*>(self.outlet)
 
     def __dealloc__(self):
         del self.outlet
@@ -344,7 +344,7 @@ cdef class OutletReservoir1D(Boundary1D):
     """
     def __cinit__(self, *args, **kwargs):
         self.outlet = new CxxOutletRes1D()
-        self.boundary = <CxxBdry1D*>(self.outlet)
+        self.boundary = <CxxBoundary1D*>(self.outlet)
 
     def __dealloc__(self):
         del self.outlet
@@ -354,7 +354,7 @@ cdef class SymmetryPlane1D(Boundary1D):
     """A symmetry plane."""
     def __cinit__(self, *args, **kwargs):
         self.symm = new CxxSymm1D()
-        self.boundary = <CxxBdry1D*>(self.symm)
+        self.boundary = <CxxBoundary1D*>(self.symm)
 
     def __dealloc__(self):
         del self.symm
@@ -364,7 +364,7 @@ cdef class Surface1D(Boundary1D):
     """A solid surface."""
     def __cinit__(self, *args, **kwargs):
         self.surf = new CxxSurf1D()
-        self.boundary = <CxxBdry1D*>(self.surf)
+        self.boundary = <CxxBoundary1D*>(self.surf)
 
     def __dealloc__(self):
         del self.surf
@@ -374,7 +374,7 @@ cdef class ReactingSurface1D(Boundary1D):
     """A reacting solid surface."""
     def __cinit__(self, *args, **kwargs):
         self.surf = new CxxReactingSurf1D()
-        self.boundary = <CxxBdry1D*>(self.surf)
+        self.boundary = <CxxBoundary1D*>(self.surf)
 
     def __dealloc__(self):
         del self.surf

--- a/samples/cxx/flamespeed/flamespeed.cpp
+++ b/samples/cxx/flamespeed/flamespeed.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "cantera/oneD/Sim1D.h"
-#include "cantera/oneD/Inlet1D.h"
+#include "cantera/oneD/Boundary1D.h"
 #include "cantera/oneD/StFlow.h"
 #include "cantera/IdealGasMix.h"
 #include "cantera/transport.h"

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #define CANTERA_USE_INTERNAL
 
@@ -11,7 +11,7 @@
 
 // Cantera includes
 #include "cantera/oneD/Sim1D.h"
-#include "cantera/oneD/Inlet1D.h"
+#include "cantera/oneD/Boundary1D.h"
 #include "cantera/transport/TransportBase.h"
 #include "Cabinet.h"
 
@@ -278,7 +278,7 @@ extern "C" {
     int bdry_setMdot(int i, double mdot)
     {
         try {
-            DomainCabinet::get<Bdry1D>(i).setMdot(mdot);
+            DomainCabinet::get<Boundary1D>(i).setMdot(mdot);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -288,7 +288,7 @@ extern "C" {
     int bdry_setTemperature(int i, double t)
     {
         try {
-            DomainCabinet::get<Bdry1D>(i).setTemperature(t);
+            DomainCabinet::get<Boundary1D>(i).setTemperature(t);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -298,7 +298,7 @@ extern "C" {
     int bdry_setMoleFractions(int i, const char* x)
     {
         try {
-            DomainCabinet::get<Bdry1D>(i).setMoleFractions(x);
+            DomainCabinet::get<Boundary1D>(i).setMoleFractions(x);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -308,7 +308,7 @@ extern "C" {
     double bdry_temperature(int i)
     {
         try {
-            return DomainCabinet::get<Bdry1D>(i).temperature();
+            return DomainCabinet::get<Boundary1D>(i).temperature();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -317,7 +317,7 @@ extern "C" {
     double bdry_massFraction(int i, int k)
     {
         try {
-            return DomainCabinet::get<Bdry1D>(i).massFraction(k);
+            return DomainCabinet::get<Boundary1D>(i).massFraction(k);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -326,7 +326,7 @@ extern "C" {
     double bdry_mdot(int i)
     {
         try {
-            return DomainCabinet::get<Bdry1D>(i).mdot();
+            return DomainCabinet::get<Boundary1D>(i).mdot();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -110,7 +110,7 @@ void Inlet1D::setMoleFractions(const std::string& xin)
     }
 }
 
-void Inlet1D::setMoleFractions(const doublereal* xin)
+void Inlet1D::setMoleFractions(const double* xin)
 {
     if (m_flow) {
         m_flow->phase().setMoleFractions(xin);
@@ -146,8 +146,8 @@ void Inlet1D::init()
     }
 }
 
-void Inlet1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-                   integer* tmaskg, doublereal rdt)
+void Inlet1D::eval(size_t jg, double* xg, double* rg,
+                   int* tmaskg, double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
@@ -207,7 +207,7 @@ void Inlet1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 }
 
-XML_Node& Inlet1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Inlet1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& inlt = Domain1D::save(o, soln);
     inlt.addAttribute("type","inlet");
@@ -220,7 +220,7 @@ XML_Node& Inlet1D::save(XML_Node& o, const doublereal* const soln)
     return inlt;
 }
 
-void Inlet1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Inlet1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     m_mdot = getFloat(dom, "mdot");
@@ -247,19 +247,19 @@ void Empty1D::init()
     _init(0);
 }
 
-void Empty1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-     integer* tmaskg, doublereal rdt)
+void Empty1D::eval(size_t jg, double* xg, double* rg,
+     int* tmaskg, double rdt)
 {
 }
 
-XML_Node& Empty1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Empty1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& symm = Domain1D::save(o, soln);
     symm.addAttribute("type","empty");
     return symm;
 }
 
-void Empty1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Empty1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
@@ -272,17 +272,17 @@ void Symm1D::init()
     _init(0);
 }
 
-void Symm1D::eval(size_t jg, doublereal* xg, doublereal* rg, integer* tmaskg,
-                  doublereal rdt)
+void Symm1D::eval(size_t jg, double* xg, double* rg, int* tmaskg,
+                  double rdt)
 {
     if (jg != npos && (jg + 2< firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
-    integer* tmask = tmaskg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
+    int* tmask = tmaskg + loc();
 
     if (m_flow_right) {
         size_t nc = m_flow_right->nComponents();
@@ -311,14 +311,14 @@ void Symm1D::eval(size_t jg, doublereal* xg, doublereal* rg, integer* tmaskg,
     }
 }
 
-XML_Node& Symm1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Symm1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& symm = Domain1D::save(o, soln);
     symm.addAttribute("type","symmetry");
     return symm;
 }
 
-void Symm1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Symm1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
@@ -346,17 +346,17 @@ void Outlet1D::init()
     }
 }
 
-void Outlet1D::eval(size_t jg, doublereal* xg, doublereal* rg, integer* tmaskg,
-                    doublereal rdt)
+void Outlet1D::eval(size_t jg, double* xg, double* rg, int* tmaskg,
+                    double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
-    integer* tmask = tmaskg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
+    int* tmask = tmaskg + loc();
 
     if (m_flow_right) {
         size_t nc = m_flow_right->nComponents();
@@ -395,14 +395,14 @@ void Outlet1D::eval(size_t jg, doublereal* xg, doublereal* rg, integer* tmaskg,
     }
 }
 
-XML_Node& Outlet1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Outlet1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& outlt = Domain1D::save(o, soln);
     outlt.addAttribute("type","outlet");
     return outlt;
 }
 
-void Outlet1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Outlet1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
@@ -420,7 +420,7 @@ void OutletRes1D::setMoleFractions(const std::string& xres)
     }
 }
 
-void OutletRes1D::setMoleFractions(const doublereal* xres)
+void OutletRes1D::setMoleFractions(const double* xres)
 {
     if (m_flow) {
         m_flow->phase().setMoleFractions(xres);
@@ -450,17 +450,17 @@ void OutletRes1D::init()
     }
 }
 
-void OutletRes1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-                       integer* tmaskg, doublereal rdt)
+void OutletRes1D::eval(size_t jg, double* xg, double* rg,
+                       int* tmaskg, double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
-    integer* tmask = tmaskg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
+    int* tmask = tmaskg + loc();
 
     if (m_flow_right) {
         size_t nc = m_flow_right->nComponents();
@@ -506,7 +506,7 @@ void OutletRes1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 }
 
-XML_Node& OutletRes1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& OutletRes1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& outlt = Domain1D::save(o, soln);
     outlt.addAttribute("type","outletres");
@@ -518,7 +518,7 @@ XML_Node& OutletRes1D::save(XML_Node& o, const doublereal* const soln)
     return outlt;
 }
 
-void OutletRes1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void OutletRes1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     m_temp = getFloat(dom, "temperature");
@@ -544,16 +544,16 @@ void Surf1D::init()
     _init(0);
 }
 
-void Surf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-                  integer* tmaskg, doublereal rdt)
+void Surf1D::eval(size_t jg, double* xg, double* rg,
+                  int* tmaskg, double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
 
     if (m_flow_right) {
         double* rb = r;
@@ -569,7 +569,7 @@ void Surf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 }
 
-XML_Node& Surf1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Surf1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& inlt = Domain1D::save(o, soln);
     inlt.addAttribute("type","surface");
@@ -577,7 +577,7 @@ XML_Node& Surf1D::save(XML_Node& o, const doublereal* const soln)
     return inlt;
 }
 
-void Surf1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Surf1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     m_temp = getFloat(dom, "temperature");
@@ -637,20 +637,20 @@ void ReactingSurf1D::resetBadValues(double* xg) {
     m_sphase->getCoverages(x);
 }
 
-void ReactingSurf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-                          integer* tmaskg, doublereal rdt)
+void ReactingSurf1D::eval(size_t jg, double* xg, double* rg,
+                          int* tmaskg, double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
-    integer* tmask = tmaskg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
+    int* tmask = tmaskg + loc();
 
     // set the coverages
-    doublereal sum = 0.0;
+    double sum = 0.0;
     for (size_t k = 0; k < m_nsp; k++) {
         m_work[k] = x[k];
         sum += x[k];
@@ -675,11 +675,11 @@ void ReactingSurf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 
     m_kin->getNetProductionRates(m_work.data());
-    doublereal rs0 = 1.0/m_sphase->siteDensity();
+    double rs0 = 1.0/m_sphase->siteDensity();
     size_t ioffset = m_kin->kineticsSpeciesIndex(0, m_surfindex);
 
     if (m_enabled) {
-        doublereal maxx = -1.0;
+        double maxx = -1.0;
         for (size_t k = 0; k < m_nsp; k++) {
             r[k] = m_work[k + ioffset] * m_sphase->size(k) * rs0;
             r[k] -= rdt*(x[k] - prevSoln(k,0));
@@ -715,9 +715,9 @@ void ReactingSurf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 }
 
-XML_Node& ReactingSurf1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& ReactingSurf1D::save(XML_Node& o, const double* const soln)
 {
-    const doublereal* s = soln + loc();
+    const double* s = soln + loc();
     XML_Node& dom = Domain1D::save(o, soln);
     dom.addAttribute("type","surface");
     addFloat(dom, "temperature", m_temp, "K");
@@ -727,7 +727,7 @@ XML_Node& ReactingSurf1D::save(XML_Node& o, const doublereal* const soln)
     return dom;
 }
 
-void ReactingSurf1D::restore(const XML_Node& dom, doublereal* soln,
+void ReactingSurf1D::restore(const XML_Node& dom, double* soln,
                              int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/Domain1D.h"
 #include "cantera/oneD/MultiJac.h"

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -1,7 +1,7 @@
 //! @file IonFlow.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/IonFlow.h"
 #include "cantera/oneD/StFlow.h"
@@ -167,10 +167,10 @@ void IonFlow::setSolvingStage(const size_t stage)
     }
 }
 
-void IonFlow::evalResidual(double* x, double* rsd, int* diag,
+void IonFlow::evalResidual(double* x, double* rsd, int* tmask,
                            double rdt, size_t jmin, size_t jmax)
 {
-    StFlow::evalResidual(x, rsd, diag, rdt, jmin, jmax);
+    StFlow::evalResidual(x, rsd, tmask, rdt, jmin, jmax);
     if (m_stage != 2) {
         return;
     }
@@ -184,10 +184,10 @@ void IonFlow::evalResidual(double* x, double* rsd, int* diag,
                 rsd[index(c_offset_Y + k, 0)] = Y(x,k,0) - Y(x,k,1);
             }
             rsd[index(c_offset_E, j)] = E(x,0);
-            diag[index(c_offset_E, j)] = 0;
+            tmask[index(c_offset_E, j)] = false;
         } else if (j == m_points - 1) {
             rsd[index(c_offset_E, j)] = dEdz(x,j) - rho_e(x,j) / epsilon_0;
-            diag[index(c_offset_E, j)] = 0;
+            tmask[index(c_offset_E, j)] = false;
         } else {
             //-----------------------------------------------
             //    Electric field by Gauss's law
@@ -197,7 +197,7 @@ void IonFlow::evalResidual(double* x, double* rsd, int* diag,
             //    E = -dV/dz
             //-----------------------------------------------
             rsd[index(c_offset_E, j)] = dEdz(x,j) - rho_e(x,j) / epsilon_0;
-            diag[index(c_offset_E, j)] = 0;
+            tmask[index(c_offset_E, j)] = false;
         }
     }
 }

--- a/src/oneD/MultiJac.cpp
+++ b/src/oneD/MultiJac.cpp
@@ -1,7 +1,7 @@
 //! @file MultiJac.cpp Implementation file for class MultiJac
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at http://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/MultiJac.h"
 #include <ctime>


### PR DESCRIPTION
This PR clarifies the meaning of ambiguously named variables (`diag`/`diagg`) in the C++ core of `OneD`, which indicate whether the governing equation within the state vector is to be handled as transient or a steady state. 

While the function signature for `Domain1D::eval` documents a parameter `mask`, there is no consistency in overloaded functions (`StFlow1D::eval` uses `diag`/`diagg`, etc.). Further, function parameter names in `StFlow.cpp` do not match declarations in `StFlow.h`.

Changes proposed in this pull request:
- use consistent variable names (i.e. rename `diagg` to `tmaskg` and `diag` to `tmask`, and `OneDim::m_mask` to `OneDim::m_tmask`)
- consistently add `g` to global state/residual vectors and parameters
- assign boolean values instead of `1` and `0` for clarity, and take advantage of C++ Integral promotion
- this PR also differentiates `MultiJac::m_mask` from `OneDim::m_tmask`, which are now clearly separated 
