### PR TITLE
Exposing getDeltaEnthalpies to Matlab interface.

### DIFF
--- a/include/cantera/thermo/MetalPhase.h
+++ b/include/cantera/thermo/MetalPhase.h
@@ -85,6 +85,11 @@ public:
             c[n] = 1.0;
         }
     }
+    virtual void getPartialMolarEnthalpies(doublereal *h) const {
+        for (size_t n = 0; n < nSpecies(); n++) {
+            h[n] = 0.0;
+        }
+    }
 
     virtual Units standardConcentrationUnits() const {
         return Units(1.0);

--- a/interfaces/matlab/toolbox/@Kinetics/getDeltaEnthalpies.m
+++ b/interfaces/matlab/toolbox/@Kinetics/getDeltaEnthalpies.m
@@ -1,0 +1,14 @@
+function dH = getDeltaEnthalpies(a)
+% GETDELTAENTHALPIES  Get the enthalpy of reaction for each reaction.
+% dH = getDeltaEnthalpies(a)
+%
+% :param a:
+%     Instance of class :mat:func:`Kinetics` (or another
+%     object deriving from Kinetics) for which the enthalpies of
+%     reaction are desired.
+% :return:
+%     Returns a vector of the enthalpy of reaction for each
+%     reaction. Units: J/kmol
+%
+
+dH = kinetics_get(a.id, 17, 0);

--- a/interfaces/matlab/toolbox/@Kinetics/getDeltaEntropies.m
+++ b/interfaces/matlab/toolbox/@Kinetics/getDeltaEntropies.m
@@ -1,0 +1,14 @@
+function dS = getDeltaEntropies(a)
+% GETDELTAENTROPIES  Get the entropy of reaction for each reaction.
+% dS = getDeltaEntropies(a)
+%
+% :param a:
+%     Instance of class :mat:func:`Kinetics` (or another
+%     object deriving from Kinetics) for which the entropies of
+%     reaction are desired.
+% :return:
+%     Returns a vector of the entropy of reaction for each
+%     reaction. Units: J/kmol-K
+%
+
+dS = kinetics_get(a.id, 17, 2);

--- a/interfaces/matlab/toolbox/@Kinetics/getDeltaGibbs.m
+++ b/interfaces/matlab/toolbox/@Kinetics/getDeltaGibbs.m
@@ -1,0 +1,14 @@
+function dG = getDeltaGibbs(a)
+% GETDELTAGIBBS  Get the Gibbs free energy of reaction for each reaction.
+% dG = getDeltaGibbs(a)
+%
+% :param a:
+%     Instance of class :mat:func:`Kinetics` (or another
+%     object deriving from Kinetics) for which the Gibbs free
+%     energies of reaction are desired.
+% :return:
+%     Returns a vector of the Gibbs free energy of reaction
+%     for each reaction. Units: J/kmol
+%
+
+dG = kinetics_get(a.id, 17, 1);

--- a/src/matlab/kineticsmethods.cpp
+++ b/src/matlab/kineticsmethods.cpp
@@ -103,6 +103,9 @@ void kineticsmethods(int nlhs, mxArray* plhs[],
             case 16:
                 ok = kin_getRevRateConstants(kin,1,nr,h);
                 break;
+            case 17:
+                ok = kin_getDelta(kin,getInt(prhs[3]),nr,h);
+                break;
             default:
                 ;
             }


### PR DESCRIPTION
The general intent here was to enable calculating reaction enthalpies in the Matlab toolbox, as part of the li-ion battery simulations in PR #563.

This required several changes:

- Create getDeltaEnthalpies.m in Matlab toolbox/@Kinetics
- Add kin_getDelta to kineticsmethods.cpp.  Note that this can be easily extended to create other functions in the matlab Kinetics toolbox (see the other fucntions listed in kin_getDelta in src/clib/ct.cpp).
- Add getPartialMolarEnthalpies to metalPhase class (it returns all zeros).