### PR TITLE
Deprecate magic numbers in zeroD CLIB

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -6,6 +6,7 @@ tracker.
 
 Emil Atz
 Philip Berndt
+Wolfgang Bessler, Offenburg University of Applied Science
 Tilman Bremer
 Victor Brunini, Sandia National Laboratory
 Bang-Shiuh Chen, Purdue University
@@ -25,16 +26,20 @@ Jon Kristofer
 Kyle Linevitch, Jr.
 Christopher Leuth
 Nicholas Malaya, University of Texas at Austin
+Thanasis Mattas, Aristotle University of Thessaloniki
 Evan McCorkle
 Ivan Mitrichev, Mendeleev University of Chemical Technology of Russia
 Harry Moffat, Sandia National Laboratory
 Christopher Neal
 Kyle Niemeyer, Oregon State University
-@pwcnorthrop
+Paul Northrop
 Andreas Rücker
 Jeff Santner
+Satyam Saxena
+Ingmar Schoegl, Louisiana State University
 Santosh Shanbhogue, Massachusetts Institute of Technology
 David Sondak
 Raymond Speth, Massachusetts Institute of Technology
+Sergey Torokhov
 Bryan Weber, University of Connecticut
 Armin Wehrfritz

--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -14,7 +14,8 @@
 extern "C" {
 #endif
 
-    CANTERA_CAPI int reactor_new(int type);
+    CANTERA_CAPI int reactor_new2(const char* type);
+    CANTERA_CAPI int reactor_new(int type); //!< @deprecated To be changed after Cantera 2.5.
     CANTERA_CAPI int reactor_del(int i);
     CANTERA_CAPI int reactor_setInitialVolume(int i, double v);
     CANTERA_CAPI int reactor_setChemistry(int i, int cflag);
@@ -47,7 +48,8 @@ extern "C" {
     CANTERA_CAPI double reactornet_atol(int i);
     CANTERA_CAPI double reactornet_sensitivity(int i, const char* v, int p, int r);
 
-    CANTERA_CAPI int flowdev_new(int type);
+    CANTERA_CAPI int flowdev_new2(const char* type);
+    CANTERA_CAPI int flowdev_new(int type); //!< @deprecated To be changed after Cantera 2.5.
     CANTERA_CAPI int flowdev_del(int i);
     CANTERA_CAPI int flowdev_install(int i, int n, int m);
     CANTERA_CAPI int flowdev_setMaster(int i, int n);
@@ -56,7 +58,8 @@ extern "C" {
     CANTERA_CAPI int flowdev_setParameters(int i, int n, const double* v);
     CANTERA_CAPI int flowdev_setFunction(int i, int n);
 
-    CANTERA_CAPI int wall_new(int type);
+    CANTERA_CAPI int wall_new2(const char* type);
+    CANTERA_CAPI int wall_new(int type); //!< @deprecated To be changed after Cantera 2.5.
     CANTERA_CAPI int wall_del(int i);
     CANTERA_CAPI int wall_install(int i, int n, int m);
     CANTERA_CAPI double wall_vdot(int i, double t);

--- a/include/cantera/zeroD/ConstPressureReactor.h
+++ b/include/cantera/zeroD/ConstPressureReactor.h
@@ -24,7 +24,18 @@ class ConstPressureReactor : public Reactor
 public:
     ConstPressureReactor() {}
 
+    virtual std::string typeStr() const {
+        return "ConstPressureReactor";
+    }
+
+    /*!
+     * @deprecated To be changed after Cantera 2.5.
+     */
     virtual int type() const {
+        warn_deprecated("ConstPressureReactor::type()",
+                        "To be changed after Cantera 2.5. "
+                        "Return string instead of magic number; use "
+                        "ConstPressureReactor::typeStr() during transition");
         return ConstPressureReactorType;
     }
 

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -15,6 +15,8 @@ namespace Cantera
 class Func1;
 class ReactorBase;
 
+//! Magic numbers
+//! @deprecated To be removed after Cantera 2.5.
 const int MFC_Type = 1;
 const int PressureController_Type = 2;
 const int Valve_Type = 3;
@@ -33,8 +35,21 @@ public:
     FlowDevice(const FlowDevice&) = delete;
     FlowDevice& operator=(const FlowDevice&) = delete;
 
+    //! String indicating the flow device implemented. Usually
+    //! corresponds to the name of the derived class.
+    virtual std::string typeStr() const {
+        return "FlowDevice";
+    }
+
     //! Return an integer indicating the type of flow device
-    int type() {
+    /*!
+     * @deprecated To be changed after Cantera 2.5.
+     */
+    virtual int type() const {
+        warn_deprecated("FlowDevice::type()",
+                        "To be changed after Cantera 2.5. "
+                        "Return string instead of magic number; use "
+                        "FlowDevice::typeStr() during transition.");
         return m_type;
     }
 
@@ -100,7 +115,7 @@ protected:
     doublereal m_mdot;
     Func1* m_func;
     vector_fp m_coeffs;
-    int m_type;
+    int m_type; //!< @deprecated To be removed after Cantera 2.5.
 
 private:
     size_t m_nspin, m_nspout;

--- a/include/cantera/zeroD/FlowDeviceFactory.h
+++ b/include/cantera/zeroD/FlowDeviceFactory.h
@@ -46,6 +46,8 @@ public:
      * @param name the name of the flow device type.
      * @param type the type identifier of the flow device.
      * Integer type identifiers are used by clib and matlab interfaces.
+     *
+     * @deprecated To be removed after Cantera 2.5.
      */
     void reg_type(const std::string& name, const int type) {
         m_types[type] = name;
@@ -53,6 +55,7 @@ public:
 
 protected:
     //! Map containing flow device type identifier / type name pairs.
+    //! @deprecated To be removed after Cantera 2.5.
     std::unordered_map<int, std::string> m_types;
 
 private:

--- a/include/cantera/zeroD/FlowReactor.h
+++ b/include/cantera/zeroD/FlowReactor.h
@@ -17,7 +17,18 @@ class FlowReactor : public Reactor
 public:
     FlowReactor();
 
+    virtual std::string typeStr() const {
+        return "FlowReactor";
+    }
+
+    /*!
+     * @deprecated To be changed after Cantera 2.5.
+     */
     virtual int type() const {
+        warn_deprecated("FlowReactor::type()",
+                        "To be changed after Cantera 2.5. "
+                        "Return string instead of magic number; use "
+                        "FlowReactor::typeStr() during transition");
         return FlowReactorType;
     }
 

--- a/include/cantera/zeroD/IdealGasConstPressureReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureReactor.h
@@ -23,7 +23,19 @@ class IdealGasConstPressureReactor : public ConstPressureReactor
 public:
     IdealGasConstPressureReactor() {}
 
+    virtual std::string typeStr() const {
+        return "IdealGasConstPressureReactor";
+    }
+
+    /*!
+     * @deprecated To be changed after Cantera 2.5.
+     */
     virtual int type() const {
+        warn_deprecated("IdealGasConstPressureReactor::type()",
+                        "To be changed after Cantera 2.5. "
+                        "Return string instead of magic number; use "
+                        "IdealGasConstPressureReactor::typeStr() during "
+                        "transition");
         return IdealGasConstPressureReactorType;
     }
 

--- a/include/cantera/zeroD/IdealGasReactor.h
+++ b/include/cantera/zeroD/IdealGasReactor.h
@@ -21,7 +21,18 @@ class IdealGasReactor : public Reactor
 public:
     IdealGasReactor() {}
 
+    virtual std::string typeStr() const {
+        return "IdealGasReactor";
+    }
+
+    /*!
+     * @deprecated To be changed after Cantera 2.5.
+     */
     virtual int type() const {
+        warn_deprecated("IdealGasReactor::type()",
+                        "To be changed after Cantera 2.5. "
+                        "Return string instead of magic number; use "
+                        "IdealGasReactor::typeStr() during transition");
         return IdealGasReactorType;
     }
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -39,7 +39,18 @@ class Reactor : public ReactorBase
 public:
     Reactor();
 
+    virtual std::string typeStr() const {
+        return "Reactor";
+    }
+
+    /*!
+     * @deprecated To be changed after Cantera 2.5.
+     */
     virtual int type() const {
+        warn_deprecated("Reactor::type()",
+                        "To be changed after Cantera 2.5. "
+                        "Return string instead of magic number; use "
+                        "Reactor::typeStr() during transition");
         return ReactorType;
     }
 
@@ -53,10 +64,9 @@ public:
         setKineticsMgr(contents);
     }
 
-    void setKineticsMgr(Kinetics& kin);
+    virtual void setKineticsMgr(Kinetics& kin);
 
-    //! Enable or disable changes in reactor composition due to chemical reactions.
-    void setChemistry(bool cflag = true) {
+    virtual void setChemistry(bool cflag = true) {
         m_chem = cflag;
     }
 
@@ -65,8 +75,7 @@ public:
         return m_chem;
     }
 
-    //! Set the energy equation on or off.
-    void setEnergy(int eflag = 1) {
+    virtual void setEnergy(int eflag = 1) {
         if (eflag > 0) {
             m_energy = true;
         } else {

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -15,7 +15,10 @@ class FlowDevice;
 class WallBase;
 class ReactorNet;
 class ReactorSurface;
+class Kinetics;
 
+//! Magic numbers
+//! @deprecated To be removed after Cantera 2.5.
 const int ReservoirType = 1;
 const int ReactorType = 2;
 const int FlowReactorType = 3;
@@ -49,8 +52,19 @@ public:
     ReactorBase(const ReactorBase&) = delete;
     ReactorBase& operator=(const ReactorBase&) = delete;
 
+    //! String indicating the reactor model implemented. Usually
+    //! corresponds to the name of the derived class.
+    virtual std::string typeStr() const {
+        return "ReactorBase";
+    }
+
     //! Return a constant indicating the type of this Reactor
+    //! @deprecated To be changed after Cantera 2.5.
     virtual int type() const {
+        warn_deprecated("ReactorBase::type()",
+                        "To be changed after Cantera 2.5. "
+                        "Return string instead of magic number; use "
+                        "ReactorBase::typeStr() during transition");
         return 0;
     }
 
@@ -76,6 +90,21 @@ public:
     //! this substance is stored, and as the integration proceeds, the state of
     //! the substance is modified.
     virtual void setThermoMgr(thermo_t& thermo);
+
+    //! Specify chemical kinetics governing the reactor.
+    virtual void setKineticsMgr(Kinetics& kin) {
+        throw NotImplementedError("ReactorBase::setKineticsMgr");
+    }
+
+    //! Enable or disable changes in reactor composition due to chemical reactions.
+    virtual void setChemistry(bool cflag = true) {
+        throw NotImplementedError("ReactorBase::setChemistry");
+    }
+
+    //! Set the energy equation on or off.
+    virtual void setEnergy(int eflag = 1) {
+        throw NotImplementedError("ReactorBase::setEnergy");
+    }
 
     //! Connect an inlet FlowDevice to this reactor
     void addInlet(FlowDevice& inlet);

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -46,6 +46,8 @@ public:
      * @param name the name of the reactor type.
      * @param type the type identifier of the reactor.
      * Integer type identifiers are used by clib and matlab interfaces.
+     *
+     * @deprecated To be removed after Cantera 2.5.
      */
     void reg_type(const std::string& name, const int type) {
         m_types[type] = name;
@@ -53,6 +55,7 @@ public:
 
 protected:
     //! Map containing reactor type identifier / reactor type name pairs.
+    //! @deprecated To be removed after Cantera 2.5.
     std::unordered_map<int, std::string> m_types;
 
 private:

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -15,7 +15,19 @@ class Reservoir : public ReactorBase
 {
 public:
     Reservoir() {}
+
+    virtual std::string typeStr() const {
+        return "Reservoir";
+    }
+
+    /*!
+     * @deprecated To be changed after Cantera 2.5.
+     */
     virtual int type() const {
+        warn_deprecated("Reservoir::type()",
+                        "To be changed after Cantera 2.5. "
+                        "Return string instead of magic number; use "
+                        "Reservoir::typeStr() during transition");
         return ReservoirType;
     }
     virtual void initialize(doublereal t0 = 0.0) {}

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -17,6 +17,8 @@ class Kinetics;
 class SurfPhase;
 class Func1;
 
+//! Magic numbers
+//! @deprecated To be removed after Cantera 2.5.
 const int WallType = 1;
 
 /**

--- a/include/cantera/zeroD/WallFactory.h
+++ b/include/cantera/zeroD/WallFactory.h
@@ -46,6 +46,8 @@ public:
      * @param name the name of the wall type.
      * @param type the type identifier of the wall.
      * Integer type identifiers are used by clib and matlab interfaces.
+     *
+     * @deprecated To be removed after Cantera 2.5.
      */
     void reg_type(const std::string& name, const int type) {
         m_types[type] = name;
@@ -53,6 +55,7 @@ public:
 
 protected:
     //! Map containing wall type identifier / wall type name pairs.
+    //! @deprecated To be removed after Cantera 2.5.
     std::unordered_map<int, std::string> m_types;
 
 private:

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -20,6 +20,10 @@ class MassFlowController : public FlowDevice
 public:
     MassFlowController();
 
+    virtual std::string typeStr() const {
+        return "MassFlowController";
+    }
+
     virtual bool ready() {
         return FlowDevice::ready() && m_mdot >= 0.0;
     }
@@ -39,6 +43,10 @@ class PressureController : public FlowDevice
 {
 public:
     PressureController();
+
+    virtual std::string typeStr() const {
+        return "PressureController";
+    }
 
     virtual bool ready() {
         return FlowDevice::ready() && m_master != 0 && m_coeffs.size() == 1;
@@ -75,6 +83,10 @@ class Valve : public FlowDevice
 {
 public:
     Valve();
+
+    virtual std::string typeStr() const {
+        return "Valve";
+    }
 
     virtual bool ready() {
         return FlowDevice::ready() && (m_coeffs.size() == 1 || m_func);

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -495,15 +495,16 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxFlowDevice "Cantera::FlowDevice"
 
     # factories
-    
+
     cdef CxxReactorBase* newReactor(string) except +translate_exception
     cdef CxxFlowDevice* newFlowDevice(string) except +translate_exception
     cdef CxxWallBase* newWall(string) except +translate_exception
-    
+
     # reactors
 
     cdef cppclass CxxReactorBase "Cantera::ReactorBase":
         CxxReactorBase()
+        string typeStr()
         void setThermoMgr(CxxThermoPhase&) except +translate_exception
         void restoreState() except +translate_exception
         void syncState() except +translate_exception
@@ -581,6 +582,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
 
     cdef cppclass CxxFlowDevice "Cantera::FlowDevice":
         CxxFlowDevice()
+        string typeStr()
         double massFlowRate(double) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&) except +translate_exception
         void setFunction(CxxFunc1*)

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -49,6 +49,11 @@ cdef class ReactorBase:
         self._thermo._references[self._weakref_proxy] = True
         self.rbase.setThermoMgr(deref(solution.thermo))
 
+    property type:
+        """The type of the reactor."""
+        def __get__(self):
+            return pystr(self.rbase.typeStr())
+
     property name:
         """The name of the reactor."""
         def __get__(self):
@@ -532,7 +537,7 @@ cdef class WallBase:
         self._right_reactor = right
 
     property type:
-        """ The left surface of this wall. """
+        """The type of the wall."""
         def __get__(self):
             return pystr(self.wall.type())
 
@@ -683,6 +688,11 @@ cdef class FlowDevice:
 
     def __dealloc__(self):
         del self.dev
+
+    property type:
+        """The type of the flow device."""
+        def __get__(self):
+            return pystr(self.dev.typeStr())
 
     def _install(self, ReactorBase upstream, ReactorBase downstream):
         """

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -77,6 +77,10 @@ class TestReactor(utilities.CanteraTest):
         self.r1.name = 'hello'
         self.assertEqual(self.r1.name, 'hello')
 
+    def test_types(self):
+        self.make_reactors()
+        self.assertEqual(self.r1.type, self.reactorClass.__name__)
+
     def test_component_index(self):
         self.make_reactors(n_reactors=1)
         self.net.step()
@@ -438,6 +442,7 @@ class TestReactor(utilities.CanteraTest):
         mfc = ct.MassFlowController(reservoir, self.r1)
         mfc.set_mass_flow_rate(lambda t: 0.1 if 0.2 <= t < 1.2 else 0.0)
 
+        self.assertEqual(mfc.type, type(mfc).__name__)
         self.assertEqual(len(reservoir.inlets), 0)
         self.assertEqual(len(reservoir.outlets), 1)
         self.assertEqual(reservoir.outlets[0], mfc)

--- a/interfaces/matlab/toolbox/@FlowDevice/FlowDevice.m
+++ b/interfaces/matlab/toolbox/@FlowDevice/FlowDevice.m
@@ -13,21 +13,29 @@ function x = FlowDevice(typ)
 % See also: :mat:func:`MassFlowController`, :mat:func:`Valve`
 %
 % :param typ:
-%     Type of :mat:func:`FlowDevice` to be created. ``typ=1`` for
-%     :mat:func:`MassFlowController` and ``typ=3`` for
+%     Type of :mat:func:`FlowDevice` to be created. ``typ='MassFlowController'``
+%     for :mat:func:`MassFlowController`,  ``typ='PressureController'`` for
+%     :mat:func:`PressureController` and ``typ='Valve'`` for
 %     :mat:func:`Valve`
 % :return:
 %     Instance of class :mat:func:`FlowDevice`
 %
 
 if nargin == 0
-    typ = 1;
+    typ = 'MassFlowController';
 end
-x.index = flowdevicemethods(0, typ);
+
+if isa(typ, 'double')
+    warning('Definition via integer type to be deprecated after Cantera 2.5')
+    device_types = {'MassFlowController', 'PressureController', 'Valve'};
+    typ = device_types(typ);
+end
+
+x.type = char(typ);
+x.index = flowdevicemethods(0, x.type);
 if x.index < 0
     error(geterr);
 end
-x.type = typ;
 x.upstream = -1;
 x.downstream = -1;
 x = class(x, 'FlowDevice');

--- a/interfaces/matlab/toolbox/@FlowDevice/setFunction.m
+++ b/interfaces/matlab/toolbox/@FlowDevice/setFunction.m
@@ -10,7 +10,7 @@ function setFunction(f, mf)
 %     Instance of class :mat:func:`Func`
 %
 
-if f.type == 1
+if strcmp(f.type, 'MassFlowController')
     k = flowdevicemethods(5, f.index, func_hndl(mf));
     if k < 0
         error(geterr);

--- a/interfaces/matlab/toolbox/@FlowDevice/setMassFlowRate.m
+++ b/interfaces/matlab/toolbox/@FlowDevice/setMassFlowRate.m
@@ -9,7 +9,7 @@ function setMassFlowRate(f, mdot)
 % :param mdot:
 %     Mass flow rate
 %
-if f.type == 1
+if strcmp(f.type, 'MassFlowController')
     k = flowdevicemethods(3, f.index, mdot);
     if k < 0
         error(geterr);

--- a/interfaces/matlab/toolbox/@FlowDevice/setValveCoeff.m
+++ b/interfaces/matlab/toolbox/@FlowDevice/setValveCoeff.m
@@ -16,7 +16,7 @@ function setValveCoeff(f, k)
 %     Value of the valve coefficient. Units: kg/Pa-s
 %
 
-if f.type ~= 3
+if ~strcmp(f.type, 'Valve')
     error('Valve coefficient can only be set for valves')
 end
 ok = flowdevicemethods(4, f.index, k);

--- a/interfaces/matlab/toolbox/@Reactor/Reactor.m
+++ b/interfaces/matlab/toolbox/@Reactor/Reactor.m
@@ -18,14 +18,14 @@ function x = Reactor(contents, typ)
 %     Instance of class :mat:func:`Solution` representing the contents of the
 %     reactor
 % :param typ:
-%     Integer, reactor type. Options are:
+%     Character array, reactor type. Options are:
 %
-%     1. Reservoir
-%     2. Reactor
-%     3. Flow Reactor
-%     4. Constant Pressure Reactor
-%     5. Ideal Gas Reactor
-%     6. Ideal Gas Constant Pressure Reactor
+%     'Reservoir'
+%     'Reactor'
+%     'FlowReactor'
+%     'ConstPressureReactor'
+%     'IdealGasReactor'
+%     'IdealGasConstPressureReactor'
 %
 % :return:
 %     Instance of class :mat:func:`Reactor`
@@ -33,14 +33,23 @@ function x = Reactor(contents, typ)
 
 if nargin == 0
     contents = 0;
-    typ = 2;
+    typ = 'Reactor';
 elseif nargin == 1
-    typ = 2;
+    typ = 'Reactor';
 elseif nargin > 2
     error('too many arguments');
 end
 
-x.index = reactormethods(0, typ);
+if isa(typ, 'double')
+    warning('Definition via integer type to be deprecated after Cantera 2.5')
+    reactor_types = {'Reservoir' 'Reactor' 'FlowReactor' ...
+                     'ConstPressureReactor' 'IdealGasReactor' ...
+                     'IdealGasConstPressureReactor'};
+    typ = reactor_types(typ);
+end
+
+x.type = char(typ);
+x.index = reactormethods(0, x.type);
 if x.index < 0
     error(geterr);
 end

--- a/interfaces/matlab/toolbox/@Reactor/insert.m
+++ b/interfaces/matlab/toolbox/@Reactor/insert.m
@@ -9,4 +9,6 @@ function insert(r, gas)
 
 r.contents = gas;
 setThermoMgr(r, gas);
-setKineticsMgr(r, gas);
+if ~strcmp(r.type, 'Reservoir')
+    setKineticsMgr(r, gas);
+end

--- a/interfaces/matlab/toolbox/@Wall/Wall.m
+++ b/interfaces/matlab/toolbox/@Wall/Wall.m
@@ -57,11 +57,11 @@ function x = Wall(left, right, area, k, u, q, v)
 % :return:
 %     Instance of class :mat:func:`Wall`
 
-% This is a dummy argument, it is not actually used by wall_new in ctreactor.cpp
-typ = 1;
+% At the moment, only one wall type is implemented
+typ = 'Wall';
 
-x.index = wallmethods(0, typ);
-
+x.type = char(typ);
+x.index = wallmethods(0, x.type);
 if x.index < 0
     error(geterr);
 end

--- a/interfaces/matlab/toolbox/ConstPressureReactor.m
+++ b/interfaces/matlab/toolbox/ConstPressureReactor.m
@@ -23,4 +23,4 @@ function r = ConstPressureReactor(contents)
 if nargin == 0
     contents = 0;
 end
-r = Reactor(contents, 4);
+r = Reactor(contents, 'ConstPressureReactor');

--- a/interfaces/matlab/toolbox/FlowReactor.m
+++ b/interfaces/matlab/toolbox/FlowReactor.m
@@ -21,4 +21,4 @@ function r = FlowReactor(contents)
 if nargin == 0
     contents = 0;
 end
-r = Reactor(contents, 3);
+r = Reactor(contents, 'FlowReactor');

--- a/interfaces/matlab/toolbox/IdealGasConstPressureReactor.m
+++ b/interfaces/matlab/toolbox/IdealGasConstPressureReactor.m
@@ -25,4 +25,4 @@ function r = IdealGasConstPressureReactor(contents)
 if nargin == 0
     contents = 0;
 end
-r = Reactor(contents, 6);
+r = Reactor(contents, 'IdealGasConstPressureReactor');

--- a/interfaces/matlab/toolbox/IdealGasReactor.m
+++ b/interfaces/matlab/toolbox/IdealGasReactor.m
@@ -22,4 +22,4 @@ function r = IdealGasReactor(contents)
 if nargin == 0
     contents = 0;
 end
-r = Reactor(contents, 5);
+r = Reactor(contents, 'IdealGasReactor');

--- a/interfaces/matlab/toolbox/MassFlowController.m
+++ b/interfaces/matlab/toolbox/MassFlowController.m
@@ -19,7 +19,7 @@ function m = MassFlowController(upstream, downstream)
 %     Instance of class :mat:func:`FlowDevice`
 %
 
-m = FlowDevice(1);
+m = FlowDevice('MassFlowController');
 if nargin == 2
     install(m, upstream, downstream)
 end

--- a/interfaces/matlab/toolbox/Reservoir.m
+++ b/interfaces/matlab/toolbox/Reservoir.m
@@ -27,4 +27,4 @@ function r = Reservoir(contents)
 if nargin == 0
     contents = 0;
 end
-r = Reactor(contents, 1);
+r = Reactor(contents, 'Reservoir');

--- a/interfaces/matlab/toolbox/Valve.m
+++ b/interfaces/matlab/toolbox/Valve.m
@@ -30,7 +30,7 @@ function v = Valve(upstream, downstream)
 %     Instance of class :mat:func:`FlowDevice`
 %
 
-v = FlowDevice(3);
+v = FlowDevice('Valve');
 if nargin == 2
     install(v, upstream, downstream)
 end

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -35,7 +35,22 @@ extern "C" {
 
     // reactor
 
+    //! @deprecated To be changed after Cantera 2.5.
     int reactor_new(int type)
+    {
+        warn_deprecated("reactor_new(int)",
+                        "To be changed after Cantera 2.5. "
+                        "Argument changed to string instead of int; use"
+                        "reactor_new2(char*) during transition.");
+        try {
+            ReactorBase* r = ReactorFactory::factory()->newReactor(type);
+            return ReactorCabinet::add(r);
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int reactor_new2(const char* type)
     {
         try {
             ReactorBase* r = ReactorFactory::factory()->newReactor(type);
@@ -78,10 +93,7 @@ extern "C" {
     int reactor_setKineticsMgr(int i, int n)
     {
         try {
-            // @todo This should not fail silently
-            if (ReactorCabinet::item(i).type() >= ReactorType) {
-                ReactorCabinet::get<Reactor>(i).setKineticsMgr(KineticsCabinet::item(n));
-            }
+            ReactorCabinet::item(i).setKineticsMgr(KineticsCabinet::item(n));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -163,10 +175,7 @@ extern "C" {
     int reactor_setChemistry(int i, int cflag)
     {
         try {
-            // @todo This should not fail silently
-            if (ReactorCabinet::item(i).type() >= ReactorType) {
-                ReactorCabinet::get<Reactor>(i).setChemistry(cflag != 0);
-            }
+            ReactorCabinet::get<Reactor>(i).setChemistry(cflag != 0);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -176,10 +185,7 @@ extern "C" {
     int reactor_setEnergy(int i, int eflag)
     {
         try {
-            // @todo This should not fail silently
-            if (ReactorCabinet::item(i).type() >= ReactorType) {
-                ReactorCabinet::get<Reactor>(i).setEnergy(eflag);
-            }
+            ReactorCabinet::get<Reactor>(i).setEnergy(eflag);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -346,6 +352,20 @@ extern "C" {
 
     int flowdev_new(int type)
     {
+        warn_deprecated("flowdev_new(int)",
+                        "To be changed after Cantera 2.5. "
+                        "Argument changed to string instead of int; use"
+                        "flowdev_new2(char*) during transition.");
+        try {
+            FlowDevice* f = FlowDeviceFactory::factory()->newFlowDevice(type);
+            return FlowDeviceCabinet::add(f);
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int flowdev_new2(const char* type)
+    {
         try {
             FlowDevice* f = FlowDeviceFactory::factory()->newFlowDevice(type);
             return FlowDeviceCabinet::add(f);
@@ -431,6 +451,20 @@ extern "C" {
     /////////////    Walls   ///////////////////////
 
     int wall_new(int type)
+    {
+        warn_deprecated("wall_new(int)",
+                        "To be changed after Cantera 2.5. "
+                        "Argument changed to string instead of int; use"
+                        "wall_new2(char*) during transition.");
+        try {
+            WallBase* w = WallFactory::factory()->newWall(type);
+            return WallCabinet::add(w);
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int wall_new2(const char* type)
     {
         try {
             WallBase* w = WallFactory::factory()->newWall(type);

--- a/src/matlab/flowdevicemethods.cpp
+++ b/src/matlab/flowdevicemethods.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "ctmatutils.h"
 #include "cantera/clib/ctreactor.h"
@@ -10,8 +10,6 @@ void flowdevicemethods(int nlhs, mxArray* plhs[],
 {
     int m, iok = 0, n;
     int job = getInt(prhs[1]);
-    int i = getInt(prhs[2]);
-
     double r = Undef;
     double v = Undef;
     if (nrhs > 3) {
@@ -20,7 +18,9 @@ void flowdevicemethods(int nlhs, mxArray* plhs[],
 
     // constructor
     if (job == 0) {
-        n = flowdev_new(i);
+        char* type = getString(prhs[2]);
+
+        n = flowdev_new2(type);
         plhs[0] = mxCreateNumericMatrix(1,1,mxDOUBLE_CLASS,mxREAL);
         double* h = mxGetPr(plhs[0]);
         *h = double(n);
@@ -32,6 +32,7 @@ void flowdevicemethods(int nlhs, mxArray* plhs[],
 
     // options that do not return a value
 
+    int i = getInt(prhs[2]);
     if (job < 20) {
         switch (job) {
         case 1:

--- a/src/matlab/reactormethods.cpp
+++ b/src/matlab/reactormethods.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/clib/ctreactor.h"
 #include "cantera/clib/ct.h"
@@ -14,7 +14,6 @@ void reactormethods(int nlhs, mxArray* plhs[],
 {
     int iok = 0, n;
     int job = getInt(prhs[1]);
-    int i = getInt(prhs[2]);
     double r = Undef;
     double v = Undef;
     if (nrhs > 3) {
@@ -23,7 +22,9 @@ void reactormethods(int nlhs, mxArray* plhs[],
 
     // constructor
     if (job == 0) {
-        n = reactor_new(i);
+        char* type = getString(prhs[2]);
+
+        n = reactor_new2(type);
         plhs[0] = mxCreateNumericMatrix(1,1,mxDOUBLE_CLASS,mxREAL);
         double* h = mxGetPr(plhs[0]);
         *h = double(n);
@@ -34,6 +35,8 @@ void reactormethods(int nlhs, mxArray* plhs[],
     }
 
     // options that do not return a value
+
+    int i = getInt(prhs[2]);
     if (job < 20) {
         switch (job) {
         case 1:

--- a/src/matlab/wallmethods.cpp
+++ b/src/matlab/wallmethods.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/clib/ctreactor.h"
 #include "cantera/clib/ct.h"
@@ -14,7 +14,6 @@ void wallmethods(int nlhs, mxArray* plhs[],
 {
     int m, iok = 0, n;
     int job = getInt(prhs[1]);
-    int i = getInt(prhs[2]);
     double r = Undef;
     double v = Undef;
     if (nrhs > 3) {
@@ -23,7 +22,8 @@ void wallmethods(int nlhs, mxArray* plhs[],
 
     // constructor
     if (job == 0) {
-        n = wall_new(i);
+        char* type = getString(prhs[2]);
+        n = wall_new2(type);
         plhs[0] = mxCreateNumericMatrix(1,1,mxDOUBLE_CLASS,mxREAL);
         double* h = mxGetPr(plhs[0]);
         *h = double(n);
@@ -34,6 +34,8 @@ void wallmethods(int nlhs, mxArray* plhs[],
     }
 
     // options that do not return a value
+
+    int i = getInt(prhs[2]);
     if (job < 20) {
         switch (job) {
         case 1:

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -91,7 +91,7 @@ void ReactorNet::initialize()
             writelog("Reactor {:d}: {:d} variables.\n", n, nv);
             writelog("              {:d} sensitivity params.\n", r.nSensParams());
         }
-        if (r.type() == FlowReactorType && m_reactors.size() > 1) {
+        if (r.typeStr() == "FlowReactor" && m_reactors.size() > 1) {
             throw CanteraError("ReactorNet::initialize",
                                "FlowReactors must be used alone.");
         }

--- a/test_problems/clib_test/clib_test.c
+++ b/test_problems/clib_test/clib_test.c
@@ -72,7 +72,7 @@ int main(int argc, char** argv)
     assert(ret == 0);
 
     printf("\ntime       Temperature\n");
-    int reactor = reactor_new(5);
+    int reactor = reactor_new2("IdealGasReactor");
     int net = reactornet_new();
     ret = reactor_setThermoMgr(reactor, thermo);
     assert(ret == 0);


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #638

Changes proposed in this pull request:
- add deprecation warning for `int ReactorBase::type()` (to be changed after Cantera 2.5)
- introduce temporary `std::string ReactorBase::typeStr()` (to be renamed after Cantera 2.5) 
- deprecate all functions using the old call and introduce associated temporary functions

Temporary functions are necessary as overloading by return argument type is not possible in C++ (same for overloading of C functions). 

~~PS: Updates are threaded through MATLAB, although I do not have a way to test at the moment (I am unsure whether unit tests are implemented)~~ Edit: MATLAB testing is included in this PR.