### PR TITLE
cantera: Sconstruct 'libdirname' env PathVariable

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -334,6 +334,14 @@ config_options = [
         'prefix',
         'Set this to the directory where Cantera should be installed.',
         defaults.prefix, PathVariable.PathAccept),
+    PathVariable(
+        'libdirname',
+        """Set this to the directory where Cantera libraries should be installed.
+           Some distributions (e.g. Fedora/RHEL) use 'lib64' instead of 'lib' on 64-bit systems
+           or could use some other library directory name instead of 'lib' depends
+           on architecture and profile (e.g. Gentoo 'libx32' on x32 profile).
+           If user didn't set 'libdirname' configuration variable set it to default value 'lib'""",
+        'lib', PathVariable.PathAccept),
     EnumVariable(
         'python_package',
         """If you plan to work in Python, then you need the ``full`` Cantera Python
@@ -1345,12 +1353,6 @@ if env['matlab_toolbox'] == 'y':
 # **********************************************
 # *** Set additional configuration variables ***
 # **********************************************
-
-# Some distributions (e.g. Fedora/RHEL) use 'lib64' instead of 'lib' on 64-bit systems
-if any(name.startswith('/usr/lib64/python') for name in sys.path):
-    env['libdirname'] = 'lib64'
-else:
-    env['libdirname'] = 'lib'
 
 # On Debian-based systems, need to special-case installation to
 # /usr/local because of dist-packages vs site-packages


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #318

Changes proposed in this pull request:

This pull request proposed the Sconstruct `libdirname` env PathVariable
that allows to set up directly the name of Cantera libraries installation path
for cases if system's library directory name differs from default `lib`
(e.g. in Gentoo it's `libx32` on `x32` profile).

E.g. this env PathVariable could be used on scons install phase:
```
scons install libdirname="libx32"
```
or for 64-bit distributives (64-bit Fedora/RHEL, Gentoo 64-bit profile etc.) as
```
scons install libdirname="lib64"
```