### PR TITLE
Fix YAML/Cython tests

### DIFF
--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -14,7 +14,6 @@ specified.
 """
 
 import sys
-import os
 import re
 import pathlib
 from collections import OrderedDict
@@ -1529,6 +1528,11 @@ def convert(filename=None, output_name=None, text=None):
     _phases.clear()
     _reactions.clear()
     _reactions['reactions'] = []
+
+    if filename is None and text is None:
+        raise ValueError("One of filename or text must be specified")
+    elif (filename is not None and text is not None):
+        raise ValueError("Only one of filename or text should be specified")
 
     if filename is not None:
         filename = pathlib.Path(filename).expanduser()

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1531,17 +1531,20 @@ def convert(filename=None, output_name=None, text=None):
     _reactions['reactions'] = []
 
     if filename is not None:
-        filename = os.path.expanduser(filename)
-        base = os.path.basename(filename)
-        root, _ = os.path.splitext(base)
+        filename = pathlib.Path(filename).expanduser()
+        base = filename.name
+        root = filename.stem
         dataset(root)
+
     if output_name is None and _name != 'noname':
-        output_name = _name + '.yaml'
+        output_name = pathlib.Path(_name + '.yaml')
+    else:
+        output_name = pathlib.Path(output_name)
 
     try:
         if filename is not None:
-            with open(filename, 'r', encoding='latin-1') as f:
-                code = compile(f.read(), filename, 'exec')
+            with filename.open('r', encoding='latin-1') as f:
+                code = compile(f.read(), str(filename), 'exec')
         else:
             code = compile(text, '<string>', 'exec')
         exec(code)
@@ -1598,7 +1601,7 @@ def convert(filename=None, output_name=None, text=None):
         if hasattr(cls, 'to_yaml'):
             emitter.register_class(cls)
 
-    with open(output_name, 'w') as dest:
+    with output_name.open('w') as dest:
         # information regarding conversion
         metadata = BlockMap([
             ('generator', 'cti2yaml'),

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -1,6 +1,7 @@
 import os
 from os.path import join as pjoin
 import itertools
+from pathlib import Path
 
 from . import utilities
 import cantera as ct
@@ -565,7 +566,8 @@ class cti2yamlTest(utilities.CanteraTest):
     @classmethod
     def setUpClass(cls):
         super().setUpClass()
-        cti2yaml.convert(pjoin(cls.cantera_data, 'gri30.cti'), 'gri30.yaml')
+        cti2yaml.convert(Path(cls.cantera_data).joinpath('gri30.cti'),
+                         Path(cls.test_work_dir).joinpath('gri30.yaml'))
 
     def checkConversion(self, basename, cls=ct.Solution, ctiphases=(),
                         yamlphases=(), **kwargs):
@@ -647,15 +649,15 @@ class cti2yamlTest(utilities.CanteraTest):
         self.checkTransport(ctiPhase, yamlPhase, [298, 1001, 2400])
 
     def test_pdep(self):
-        cti2yaml.convert(pjoin(self.test_data_dir, 'pdep-test.cti'),
-                         'pdep-test.yaml')
+        cti2yaml.convert(Path(self.test_data_dir).joinpath('pdep-test.cti'),
+                         Path(self.test_work_dir).joinpath('pdep-test.yaml'))
         ctiPhase, yamlPhase = self.checkConversion('pdep-test')
         self.checkKinetics(ctiPhase, yamlPhase, [300, 1000, 2200],
                            [100, ct.one_atm, 2e5, 2e6, 9.9e6])
 
     def test_ptcombust(self):
-        cti2yaml.convert(pjoin(self.cantera_data, 'ptcombust.cti'),
-                         'ptcombust.yaml')
+        cti2yaml.convert(Path(self.cantera_data).joinpath('ptcombust.cti'),
+                         Path(self.test_work_dir).joinpath('ptcombust.yaml'))
         ctiGas, yamlGas = self.checkConversion('ptcombust')
         ctiSurf, yamlSurf = self.checkConversion('ptcombust', ct.Interface,
             phaseid='Pt_surf', ctiphases=[ctiGas], yamlphases=[yamlGas])
@@ -665,7 +667,8 @@ class cti2yamlTest(utilities.CanteraTest):
         self.checkKinetics(ctiSurf, yamlSurf, [500, 1200], [1e4, 3e5])
 
     def test_sofc(self):
-        cti2yaml.convert(pjoin(self.cantera_data, 'sofc.cti'), 'sofc.yaml')
+        cti2yaml.convert(Path(self.cantera_data).joinpath('sofc.cti'),
+                         Path(self.test_work_dir).joinpath('sofc.yaml'))
         ctiGas, yamlGas = self.checkConversion('sofc')
         ctiMetal, yamlMetal = self.checkConversion('sofc', phaseid='metal')
         ctiOxide, yamlOxide = self.checkConversion('sofc', phaseid='oxide_bulk')
@@ -687,8 +690,8 @@ class cti2yamlTest(utilities.CanteraTest):
         self.checkKinetics(cti_tpb, yaml_tpb, [900, 1000, 1100], [1e5])
 
     def test_liquidvapor(self):
-        cti2yaml.convert(pjoin(self.cantera_data, 'liquidvapor.cti'),
-                         'liquidvapor.yaml')
+        cti2yaml.convert(Path(self.cantera_data).joinpath('liquidvapor.cti'),
+                         Path(self.test_work_dir).joinpath('liquidvapor.yaml'))
         for name in ['water', 'nitrogen', 'methane', 'hydrogen', 'oxygen',
                      'hfc134a', 'carbondioxide', 'heptane']:
             ctiPhase, yamlPhase = self.checkConversion('liquidvapor', phaseid=name)
@@ -696,23 +699,24 @@ class cti2yamlTest(utilities.CanteraTest):
                              [1.3 * ctiPhase.min_temp, 0.7 * ctiPhase.max_temp])
 
     def test_Redlich_Kwong_CO2(self):
-        cti2yaml.convert(pjoin(self.test_data_dir, 'co2_RK_example.cti'),
-                         'co2_RK_example.yaml')
+        cti2yaml.convert(Path(self.test_data_dir).joinpath('co2_RK_example.cti'),
+                         Path(self.test_work_dir).joinpath('co2_RK_example.yaml'))
         ctiGas, yamlGas = self.checkConversion('co2_RK_example')
         for P in [1e5, 2e6, 1.3e7]:
             yamlGas.TP = ctiGas.TP = 300, P
             self.checkThermo(ctiGas, yamlGas, [300, 400, 500])
 
     def test_Redlich_Kwong_ndodecane(self):
-        cti2yaml.convert(pjoin(self.cantera_data, 'nDodecane_Reitz.cti'),
-                         'nDodecane_Reitz.yaml')
+        cti2yaml.convert(Path(self.cantera_data).joinpath('nDodecane_Reitz.cti'),
+                         Path(self.test_work_dir).joinpath('nDodecane_Reitz.yaml'))
         ctiGas, yamlGas = self.checkConversion('nDodecane_Reitz')
         self.checkThermo(ctiGas, yamlGas, [300, 400, 500])
         self.checkKinetics(ctiGas, yamlGas, [300, 500, 1300], [1e5, 2e6, 1.4e7],
                            1e-6)
 
     def test_diamond(self):
-        cti2yaml.convert(pjoin(self.cantera_data, 'diamond.cti'), 'diamond.yaml')
+        cti2yaml.convert(Path(self.cantera_data).joinpath('diamond.cti'),
+                         Path(self.test_work_dir).joinpath('diamond.yaml'))
         ctiGas, yamlGas = self.checkConversion('diamond', phaseid='gas')
         ctiSolid, yamlSolid = self.checkConversion('diamond', phaseid='diamond')
         ctiSurf, yamlSurf = self.checkConversion('diamond',
@@ -723,8 +727,8 @@ class cti2yamlTest(utilities.CanteraTest):
         self.checkKinetics(ctiSurf, yamlSurf, [400, 800], [2e5])
 
     def test_lithium_ion_battery(self):
-        cti2yaml.convert(pjoin(self.cantera_data, 'lithium_ion_battery.cti'),
-                         'lithium_ion_battery.yaml')
+        cti2yaml.convert(Path(self.cantera_data).joinpath('lithium_ion_battery.cti'),
+                         Path(self.test_work_dir).joinpath('lithium_ion_battery.yaml'))
         name = 'lithium_ion_battery'
         ctiAnode, yamlAnode = self.checkConversion(name, phaseid='anode')
         ctiCathode, yamlCathode = self.checkConversion(name, phaseid='cathode')

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1,5 +1,5 @@
 from os.path import join as pjoin
-import pathlib
+from pathlib import Path
 import os
 import numpy as np
 import gc
@@ -263,7 +263,7 @@ class TestThermoPhase(utilities.CanteraTest):
         gas = ct.Solution('gri30.xml')
         for phi in np.linspace(0.5, 2.0, 5):
             gas.set_equivalence_ratio(phi, 'CH4:0.8, CH3OH:0.2', 'O2:1.0, N2:3.76')
-            self.assertNear(phi, gas.get_equivalence_ratio())  
+            self.assertNear(phi, gas.get_equivalence_ratio())
         # Check sulfur species
         sulfur_species = [k for k in ct.Species.listFromFile('nasa_gas.xml') if k.name in ("SO", "SO2")]
         gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
@@ -1051,7 +1051,7 @@ class TestSpecies(utilities.CanteraTest):
 
     def test_listFromYaml_section(self):
         species = ct.Species.listFromYaml(
-            pathlib.Path('../data/ideal-gas.yaml').read_text(),
+            Path(__file__).parent.joinpath('data', 'ideal-gas.yaml').read_text(),
             'species')
 
         self.assertEqual(species[0].name, 'O2')

--- a/interfaces/cython/setup.py.in
+++ b/interfaces/cython/setup.py.in
@@ -92,7 +92,7 @@ setup(
     ],
     package_data = {
         'cantera.data': ['*.*'],
-        'cantera.test.data': ['*.*'],
+        'cantera.test.data': ['*.*', '*/*.*'],
         'cantera.examples': ['*/*.*'],
         'cantera': ["@py_extension@", '*.pxd'],
     },

--- a/test/data/ideal-gas.yaml
+++ b/test/data/ideal-gas.yaml
@@ -33,7 +33,7 @@ phases:
   thermo: ideal-gas
   species:
   - species: [O2, N2]
-  - ../../test/data/test_subdir/species-elements.yaml/species: [NO2, N2O]
+  - test_subdir/species-elements.yaml/species: [NO2, N2O]
   state: {T: 300.0, P: 1 atm, X: "N2O:0.3, O2:0.7"}
 
 - name: species-all


### PR DESCRIPTION
These changes fix a few things that broke when testing the installed Cython interface (via `python -m unittest -v cantera.test`)

Changes proposed in this pull request:
- Install the `test/data/test_subdir` in the Cython interface
- Avoid using paths in the test files that implicitly relied on being in the source tree
- Write test conversions into the `test_work_dir` instead of the cwd
