### PR TITLE
[Reactor] clarify FlowDevice interface

### DIFF
--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_REACTOR_H
 #define CTC_REACTOR_H
@@ -55,8 +55,13 @@ extern "C" {
     CANTERA_CAPI int flowdev_setMaster(int i, int n);
     CANTERA_CAPI double flowdev_massFlowRate(int i, double time);
     CANTERA_CAPI int flowdev_setMassFlowRate(int i, double mdot);
-    CANTERA_CAPI int flowdev_setParameters(int i, int n, const double* v);
-    CANTERA_CAPI int flowdev_setFunction(int i, int n);
+    CANTERA_CAPI int flowdev_setParameters(int i, int n, const double* v);  //!< @deprecated To be removed after Cantera 2.5.
+    CANTERA_CAPI int flowdev_setMassFlowCoeff(int i, double v);
+    CANTERA_CAPI int flowdev_setValveCoeff(int i, double v);
+    CANTERA_CAPI int flowdev_setPressureCoeff(int i, double v);
+    CANTERA_CAPI int flowdev_setFunction(int i, int n); //!< @deprecated To be removed after Cantera 2.5.
+    CANTERA_CAPI int flowdev_setPressureFunction(int i, int n);
+    CANTERA_CAPI int flowdev_setTimeFunction(int i, int n);
 
     CANTERA_CAPI int wall_new2(const char* type);
     CANTERA_CAPI int wall_new(int type); //!< @deprecated To be changed after Cantera 2.5.

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -585,17 +585,22 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         string typeStr()
         double massFlowRate(double) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&) except +translate_exception
-        void setFunction(CxxFunc1*)
+        void setPressureFunction(CxxFunc1*) except +translate_exception
+        void setTimeFunction(CxxFunc1*) except +translate_exception
 
     cdef cppclass CxxMassFlowController "Cantera::MassFlowController" (CxxFlowDevice):
         CxxMassFlowController()
+        void setMassFlowCoeff(double)
+        double getMassFlowCoeff()
 
     cdef cppclass CxxValve "Cantera::Valve" (CxxFlowDevice):
-        void setPressureCoeff(double)
         CxxValve()
+        double getValveCoeff()
+        void setValveCoeff(double)
 
     cdef cppclass CxxPressureController "Cantera::PressureController" (CxxFlowDevice):
         CxxPressureController()
+        double getPressureCoeff()
         void setPressureCoeff(double)
         void setMaster(CxxFlowDevice*)
 
@@ -1032,6 +1037,7 @@ cdef class Wall(WallBase):
 cdef class FlowDevice:
     cdef CxxFlowDevice* dev
     cdef Func1 _rate_func
+    cdef Func1 _time_func
     cdef str name
     cdef ReactorBase _upstream
     cdef ReactorBase _downstream

--- a/interfaces/cython/cantera/examples/reactors/ic_engine.py
+++ b/interfaces/cython/cantera/examples/reactors/ic_engine.py
@@ -125,15 +125,15 @@ for n1, t_i in enumerate(t):
     # define opening and closing of valves and injector
     if (np.mod(crank_angle(t_i) - inlet_open, 4 * np.pi) <
             np.mod(inlet_close - inlet_open, 4 * np.pi)):
-        inlet_valve.set_valve_coeff(inlet_valve_coeff)
+        inlet_valve.valve_coeff = inlet_valve_coeff
         test[n1] = 1
     else:
-        inlet_valve.set_valve_coeff(0)
+        inlet_valve.valve_coeff = 0.
     if (np.mod(crank_angle(t_i) - outlet_open, 4 * np.pi) <
             np.mod(outlet_close - outlet_open, 4 * np.pi)):
-        outlet_valve.set_valve_coeff(outlet_valve_coeff)
+        outlet_valve.valve_coeff = outlet_valve_coeff
     else:
-        outlet_valve.set_valve_coeff(0)
+        outlet_valve.valve_coeff = 0.
     if (np.mod(crank_angle(t_i) - injector_open, 4 * np.pi) <
             np.mod(injector_close - injector_open, 4 * np.pi)):
         injector_mfc.set_mass_flow_rate(injector_mass / injector_t_open)

--- a/interfaces/matlab/toolbox/@FlowDevice/setFunction.m
+++ b/interfaces/matlab/toolbox/@FlowDevice/setFunction.m
@@ -11,7 +11,7 @@ function setFunction(f, mf)
 %
 
 if strcmp(f.type, 'MassFlowController')
-    k = flowdevicemethods(5, f.index, func_hndl(mf));
+    k = flowdevicemethods(9, f.index, func_hndl(mf));
     if k < 0
         error(geterr);
     end

--- a/interfaces/matlab/toolbox/@FlowDevice/setMassFlowRate.m
+++ b/interfaces/matlab/toolbox/@FlowDevice/setMassFlowRate.m
@@ -10,7 +10,7 @@ function setMassFlowRate(f, mdot)
 %     Mass flow rate
 %
 if strcmp(f.type, 'MassFlowController')
-    k = flowdevicemethods(3, f.index, mdot);
+    k = flowdevicemethods(10, f.index, mdot);
     if k < 0
         error(geterr);
     end

--- a/samples/cxx/combustor/combustor.cpp
+++ b/samples/cxx/combustor/combustor.cpp
@@ -86,7 +86,7 @@ void runexample()
 
     MassFlowController m3;
     m3.install(igniter, combustor);
-    m3.setFunction(&igniter_mdot);
+    m3.setTimeFunction(&igniter_mdot);
 
     // put a valve on the exhaust line to regulate the pressure
     Valve v;

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -420,6 +420,7 @@ extern "C" {
 
     int flowdev_setMassFlowRate(int i, double mdot)
     {
+        /* @deprecated To be removed after Cantera 2.5. */
         try {
             FlowDeviceCabinet::item(i).setMassFlowRate(mdot);
             return 0;
@@ -430,6 +431,7 @@ extern "C" {
 
     int flowdev_setParameters(int i, int n, const double* v)
     {
+        /* @deprecated To be removed after Cantera 2.5. */
         try {
             FlowDeviceCabinet::item(i).setParameters(n, v);
             return 0;
@@ -438,10 +440,61 @@ extern "C" {
         }
     }
 
-    int flowdev_setFunction(int i, int n)
+    int flowdev_setMassFlowCoeff(int i, double v)
     {
         try {
+            FlowDeviceCabinet::get<MassFlowController>(i).setMassFlowCoeff(v);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int flowdev_setValveCoeff(int i, double v)
+    {
+        try {
+            FlowDeviceCabinet::get<Valve>(i).setValveCoeff(v);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int flowdev_setPressureCoeff(int i, double v)
+    {
+        try {
+            FlowDeviceCabinet::get<PressureController>(i).setPressureCoeff(v);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int flowdev_setFunction(int i, int n)
+    {
+        /* @deprecated To be removed after Cantera 2.5. */
+        try {
             FlowDeviceCabinet::item(i).setFunction(&FuncCabinet::item(n));
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int flowdev_setPressureFunction(int i, int n)
+    {
+        try {
+            FlowDeviceCabinet::item(i).setPressureFunction(&FuncCabinet::item(n));
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int flowdev_setTimeFunction(int i, int n)
+    {
+        try {
+            FlowDeviceCabinet::item(i).setTimeFunction(&FuncCabinet::item(n));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/matlab/flowdevicemethods.cpp
+++ b/src/matlab/flowdevicemethods.cpp
@@ -43,16 +43,27 @@ void flowdevicemethods(int nlhs, mxArray* plhs[],
             iok = flowdev_install(i, int(v), m);
             break;
         case 3:
+            // @deprecated To be removed after Cantera 2.5.
             iok = flowdev_setMassFlowRate(i, v);
             break;
         case 4:
-            iok = flowdev_setParameters(i, 1, &v);
+            iok = flowdev_setValveCoeff(i, v);
             break;
         case 5:
+            // @deprecated To be removed after Cantera 2.5.
             iok = flowdev_setFunction(i, int(v));
             break;
         case 7:
             iok = flowdev_setMaster(i, int(v));
+            break;
+        case 8:
+            iok = flowdev_setPressureFunction(i, int(v));
+            break;
+        case 9:
+            iok = flowdev_setTimeFunction(i, int(v));
+            break;
+        case 10:
+            iok = flowdev_setMassFlowCoeff(i, v);
             break;
         default:
             mexErrMsgTxt("unknown job parameter");

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -10,7 +10,8 @@
 namespace Cantera
 {
 
-FlowDevice::FlowDevice() : m_mdot(0.0), m_func(0), m_type(0),
+FlowDevice::FlowDevice() : m_mdot(0.0), m_pfunc(0), m_tfunc(0),
+                           m_coeff(1.0), m_type(0),
                            m_nspin(0), m_nspout(0),
                            m_in(0), m_out(0) {}
 
@@ -45,12 +46,17 @@ bool FlowDevice::install(ReactorBase& in, ReactorBase& out)
     return true;
 }
 
-void FlowDevice::setFunction(Func1* f)
+void FlowDevice::setPressureFunction(Func1* f)
 {
-    m_func = f;
+    m_pfunc = f;
 }
 
-doublereal FlowDevice::outletSpeciesMassFlowRate(size_t k)
+void FlowDevice::setTimeFunction(Func1* g)
+{
+    m_tfunc = g;
+}
+
+double FlowDevice::outletSpeciesMassFlowRate(size_t k)
 {
     if (k >= m_nspout) {
         return 0.0;
@@ -62,7 +68,7 @@ doublereal FlowDevice::outletSpeciesMassFlowRate(size_t k)
     return m_mdot * m_in->massFraction(ki);
 }
 
-doublereal FlowDevice::enthalpy_mass()
+double FlowDevice::enthalpy_mass()
 {
     return m_in->enthalpy_mass();
 }


### PR DESCRIPTION
This PR seeks to clarify the FlowDevice interface; specifically, the implementation of `Valve.set_pressure_coeff` was non-intuitive (misleading function name and partially incorrect doc string)

Please fill in the issue number this pull request is fixing:

Fixes #666 

(also: addresses comment in #587, and prepares fix needed for #665)

Changes proposed in this pull request:

 - differentiate `Valve::setValveCoeff` from `PressureController::setPressureCoeff`
 - introduce `Valve::setValveLift` for time-dependent valve opening/closing
 - introduce `Valve.set_valve_function` to eliminate `Valve.valve_coeff(Func1)` being erroneously applied to `Valve::setFunction`
 - introduce properties `Valve.valve_coeff` / `PressureController.pressure_coeff` in Cython interface    and deprecate `Valve.set_pressure_coeff` / `PressureController.set_pressure_coeff` (which is consistent with coefficient handling used by other `zeroD` objects)
 - deprecate corresponding function calls in clib interface
 - deprecate `FlowDevice.setParameters` (which was only used by MATLAB interface)
