### PR TITLE
Add yaml-cpp to the shared libraries if building with system yaml-cpp

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1620,6 +1620,10 @@ else:
 linkLibs.extend(env['sundials_libs'])
 linkSharedLibs.extend(env['sundials_libs'])
 
+if env['system_yamlcpp']:
+    linkLibs.append('yaml-cpp')
+    linkSharedLibs.append('yaml-cpp')
+
 #  Add LAPACK and BLAS to the link line
 if env['blas_lapack_libs']:
     linkLibs.extend(env['blas_lapack_libs'])

--- a/src/SConscript
+++ b/src/SConscript
@@ -84,8 +84,6 @@ if (localenv['system_sundials'] == 'y'):
 if localenv['blas_lapack_libs']:
     localenv.Append(LIBS=localenv['blas_lapack_libs'],
                     LIBPATH=localenv['blas_lapack_dir'])
-if localenv['system_fmt']:
-    localenv.Append(LIBS='fmt')
 
 if localenv['system_yamlcpp']:
     localenv.Append(LIBS=['yaml-cpp'])

--- a/src/SConscript
+++ b/src/SConscript
@@ -87,6 +87,9 @@ if localenv['blas_lapack_libs']:
 if localenv['system_fmt']:
     localenv.Append(LIBS='fmt')
 
+if localenv['system_yamlcpp']:
+    localenv.Append(LIBS=['yaml-cpp'])
+
 # Build the Cantera shared library
 if localenv['layout'] != 'debian':
     if localenv['renamed_shared_libraries']:


### PR DESCRIPTION
Fixes #668

Changes proposed in this pull request:
- If building Cantera with system_yamlcpp=y the yaml-cpp library needs to be specified in the linker flags.