### PR TITLE
Fix to build Cantera against Sundials 4.0.0 and newer

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1091,7 +1091,7 @@ if env['system_sundials'] == 'y':
 
     # Ignore the minor version, e.g. 2.4.x -> 2.4
     env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
-    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1'):
+    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2'):
         print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
         sys.exit(1)
     print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -51,9 +51,6 @@ public:
         m_maxord = n;
     }
     virtual void setMethod(MethodType t);
-    #if CT_SUNDIALS_VERSION < 40
-        virtual void setIterator(IterType t);
-    #endif
     virtual void setMaxStepSize(double hmax);
     virtual void setMinStepSize(double hmin);
     virtual void setMaxSteps(int nmax);

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -51,7 +51,9 @@ public:
         m_maxord = n;
     }
     virtual void setMethod(MethodType t);
-    virtual void setIterator(IterType t);
+    #if CT_SUNDIALS_VERSION < 40
+        virtual void setIterator(IterType t);
+    #endif
     virtual void setMaxStepSize(double hmax);
     virtual void setMinStepSize(double hmin);
     virtual void setMaxSteps(int nmax);

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -175,10 +175,12 @@ public:
         warn("setMethodType");
     }
 
-    //! Set the linear iterator.
-    virtual void setIterator(IterType t) {
-        warn("setInterator");
-    }
+    #if CT_SUNDIALS_VERSION < 40
+        //! Set the linear iterator.
+        virtual void setIterator(IterType t) {
+            warn("setInterator");
+        }
+    #endif
 
     //! Set the maximum step size
     virtual void setMaxStepSize(double hmax) {

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -175,12 +175,11 @@ public:
         warn("setMethodType");
     }
 
-    #if CT_SUNDIALS_VERSION < 40
-        //! Set the linear iterator.
-        virtual void setIterator(IterType t) {
-            warn("setInterator");
-        }
-    #endif
+    //! Set the linear iterator.
+    //! @deprecated Unused. To be removed after Cantera 2.5.
+    virtual void setIterator(IterType t) {
+        warn_deprecated("Integrator::setIterator", "To be removed after Cantera 2.5.");
+    }
 
     //! Set the maximum step size
     virtual void setMaxStepSize(double hmax) {

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -84,7 +84,9 @@ ImplicitSurfChem::ImplicitSurfChem(
     // numerically, and use a Newton linear iterator
     m_integ->setMethod(BDF_Method);
     m_integ->setProblemType(DENSE + NOJAC);
-    m_integ->setIterator(Newton_Iter);
+    #if CT_SUNDIALS_VERSION < 40
+        m_integ->setIterator(Newton_Iter);
+    #endif
     m_work.resize(ntmax);
 }
 

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -84,9 +84,6 @@ ImplicitSurfChem::ImplicitSurfChem(
     // numerically, and use a Newton linear iterator
     m_integ->setMethod(BDF_Method);
     m_integ->setProblemType(DENSE + NOJAC);
-    #if CT_SUNDIALS_VERSION < 40
-        m_integ->setIterator(Newton_Iter);
-    #endif
     m_work.resize(ntmax);
 }
 

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -89,9 +89,6 @@ CVodesIntegrator::CVodesIntegrator() :
     m_type(DENSE+NOJAC),
     m_itol(CV_SS),
     m_method(CV_BDF),
-    #if CT_SUNDIALS_VERSION < 40
-        m_iter(CV_NEWTON),
-    #endif
     m_maxord(0),
     m_reltol(1.e-9),
     m_abstols(1.e-15),
@@ -229,19 +226,6 @@ void CVodesIntegrator::setMaxErrTestFails(int n)
     }
 }
 
-#if CT_SUNDIALS_VERSION < 40
-    void CVodesIntegrator::setIterator(IterType t)
-    {
-        if (t == Newton_Iter) {
-            m_iter = CV_NEWTON;
-        } else if (t == Functional_Iter) {
-            m_iter = CV_FUNCTIONAL;
-        } else {
-            throw CanteraError("CVodesIntegrator::setIterator", "unknown iterator");
-        }
-    }
-#endif
-
 void CVodesIntegrator::sensInit(double t0, FuncEval& func)
 {
     m_np = func.nparams();
@@ -303,7 +287,7 @@ void CVodesIntegrator::initialize(double t0, FuncEval& func)
     //!        CV_BDF  - Use BDF methods
     //!        CV_NEWTON - use Newton's method
     #if CT_SUNDIALS_VERSION < 40
-        m_cvode_mem = CVodeCreate(m_method, m_iter);
+        m_cvode_mem = CVodeCreate(m_method, CV_NEWTON);
     #else
         m_cvode_mem = CVodeCreate(m_method);
     #endif

--- a/src/numerics/IDA_Solver.cpp
+++ b/src/numerics/IDA_Solver.cpp
@@ -446,7 +446,11 @@ void IDA_Solver::init(doublereal t0)
         #if CT_SUNDIALS_VERSION >= 30
             SUNLinSolFree((SUNLinearSolver) m_linsol);
             SUNMatDestroy((SUNMatrix) m_linsol_matrix);
-            m_linsol_matrix = SUNBandMatrix(N, nu, nl, nu+nl);
+            #if CT_SUNDIALS_VERSION < 40
+                m_linsol_matrix = SUNBandMatrix(N, nu, nl, nu+nl);
+            #else
+                m_linsol_matrix = SUNBandMatrix(N, nu, nl);
+            #endif
             if (m_linsol_matrix == nullptr) {
                 throw CanteraError("IDA_Solver::init",
                     "Unable to create SUNBandMatrix of size {} with bandwidths "

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -28,9 +28,6 @@ ReactorNet::ReactorNet() :
     // numerically, and use a Newton linear iterator
     m_integ->setMethod(BDF_Method);
     m_integ->setProblemType(DENSE + NOJAC);
-    #if CT_SUNDIALS_VERSION < 40
-        m_integ->setIterator(Newton_Iter);
-    #endif
 }
 
 void ReactorNet::setInitialTime(double time)

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -28,7 +28,9 @@ ReactorNet::ReactorNet() :
     // numerically, and use a Newton linear iterator
     m_integ->setMethod(BDF_Method);
     m_integ->setProblemType(DENSE + NOJAC);
-    m_integ->setIterator(Newton_Iter);
+    #if CT_SUNDIALS_VERSION < 40
+        m_integ->setIterator(Newton_Iter);
+    #endif
 }
 
 void ReactorNet::setInitialTime(double time)


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #620

Changes proposed in this pull request:
- Simple fix for `Cantera` compatibility with `Sundials 3.2`;
- Fix to make `Cantera` build against `>=Sundials-4.0`.
