### PR TITLE
[Scons/Install] fix passing 'python_prefix' variable into installation path

### DIFF
--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -101,11 +101,11 @@ elif localenv['python_prefix']:
         extra = ''
     elif localenv['OS'] == 'Darwin':
         extra = localenv.subst(' --prefix=${python_prefix}')
-    elif localenv['libdirname'] == 'lib64':
-        # 64-bit RHEL / Fedora
+    elif localenv['libdirname'] != 'lib':
+        # 64-bit RHEL / Fedora etc. or e.g. x32 Gentoo profile
         extra = localenv.subst(
             ' --prefix=${python_prefix}'
-            ' --install-lib=${python_prefix}/lib64/python{}/site-packages'.format(py_version))
+            ' --install-lib=${{python_prefix}}/${{libdirname}}/python{}/site-packages'.format(py_version))
     else:
         extra = '--user'
         localenv.AppendENVPath(


### PR DESCRIPTION
The `${python_prefix}` substring for installation prefix path
was accepted as mapping key for `.format()` function resulting in
a `KeyError` failure of `cantera/interfaces/cython/SConscript` script
in case of `env[libdirname] == 'lib64'`. The issue is resolved by
escaping the `{` and `}` characters by their doubling, i.e. using the 
`${{python_prefix}}` instead of `${python_prefix}` in the place 
where `.format()` function is applied.

Moreover the early applied pull request [[661]] didn't take into account
the additional setting of installation prefix path in the cases
when `libdirname` takes values different from `lib64`.

This patch resolves both those issues.

[661]: https://github.com/Cantera/cantera/pull/661

Changes proposed in this pull request:
- Fix the passing `${python_prefix}` substring as mapping key of `.format()` function;
- Fix the passing value of user defined `libdirname` variable into python module installation path
in case when `libdirname` value different from `lib64`.
