### PR TITLE
Address error C2512 when compiling with Visual Studio

### DIFF
--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -101,7 +101,11 @@ class UnitSystem
 {
 public:
     //! Create a unit system with the specified default units
-    UnitSystem(std::initializer_list<std::string> units={});
+    UnitSystem(std::initializer_list<std::string> units);
+
+    //! Default constructor for unit system (needed as VS2019 does not
+    //! recognize an optional argument with a default value)
+    UnitSystem() : UnitSystem({}) {}
 
     //! Set the default units to convert from when explicit units are not
     //! provided. Defaults can be set for mass, length, time, quantity, energy,


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #670

Changes proposed in this pull request:
- Error is avoided by explicitly passing the default argument to the constructor, i.e. `UnitSytem U({});` instead of `UnitSystem U;`.
- The issue appears to be that Visual Studio erroneously doesn't recognize the optional argument. See [Visual Studio: Compiler Error C2512](https://docs.microsoft.com/en-us/cpp/error-messages/compiler-errors-2/compiler-error-c2512?view=vs-2019)

