### PR TITLE
Add set_equivalence_ratio to SolutionArray objects

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -565,6 +565,23 @@ class SolutionArray:
             self._phase.equilibrate(*args, **kwargs)
             self._states[index][:] = self._phase.state
 
+    def set_equivalence_ratio(self, phi, *args, **kwargs):
+        """
+        See `ThermoPhase.set_equivalence_ratio`
+
+        Note that *phi* either needs to be a scalar value or dimensions have
+        to be matched to the SolutionArray.
+        """
+
+        # broadcast argument shape
+        phi, _ = np.broadcast_arrays(phi, self._output_dummy)
+
+        # loop over values
+        for index in self._indices:
+            self._phase.state = self._states[index]
+            self._phase.set_equivalence_ratio(phi[index], *args, **kwargs)
+            self._states[index][:] = self._phase.state
+
     def collect_data(self, cols=('extra','T','density','Y'), threshold=0,
                      species='Y'):
         """

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1474,6 +1474,25 @@ class TestSolutionArray(utilities.CanteraTest):
         states.TP = np.linspace(400, 500, 5), 101325
         self.assertArrayNear(states.X.squeeze(), np.ones(5))
 
+    def test_set_equivalence_ratio(self):
+        states = ct.SolutionArray(self.gas, 8)
+        phi = np.linspace(.5, 2., 8)
+        args = 'H2:1.0', 'O2:1.0'
+        states.set_equivalence_ratio(phi, *args)
+        states.set_equivalence_ratio(phi[0], *args)
+        states.set_equivalence_ratio(list(phi), *args)
+
+        with self.assertRaises(ValueError):
+            states.set_equivalence_ratio(phi[:-1], *args)
+
+        states = ct.SolutionArray(self.gas, (2,4))
+        states.set_equivalence_ratio(phi.reshape((2,4)), *args)
+
+        with self.assertRaises(ValueError):
+            states.set_equivalence_ratio(phi, *args)
+        with self.assertRaises(ValueError):
+            states.set_equivalence_ratio(phi.reshape((4,2)), *args)
+
     def test_species_slicing(self):
         states = ct.SolutionArray(self.gas, (2,5))
         states.TPX = np.linspace(500, 1000, 5), 2e5, 'H2:0.5, O2:0.4'


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #604

Changes proposed in this pull request:
- Wrap `ThermoPhase.set_equivalence_ratio`, and check dimensions
- Add unit test
