### PR TITLE
Fix "catching polymorphic type" GCC 8 warnings

### DIFF
--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -25,7 +25,7 @@ void setLogger(Logger* logwriter)
 {
     try {
         app()->setLogger(logwriter);
-    } catch (std::bad_alloc) {
+    } catch (const std::bad_alloc&) {
         logwriter->error("bad alloc thrown by app()");
     }
 }

--- a/src/equil/vcs_MultiPhaseEquil.cpp
+++ b/src/equil/vcs_MultiPhaseEquil.cpp
@@ -225,7 +225,7 @@ int vcs_MultiPhaseEquil::equilibrate_HP(doublereal Htarget,
                 Tnew = 0.5*Tnow;
             }
             m_mix->setTemperature(Tnew);
-        } catch (CanteraError err) {
+        } catch (const CanteraError& err) {
             if (!estimateEquil) {
                 strt = -1;
             } else {
@@ -351,7 +351,7 @@ int vcs_MultiPhaseEquil::equilibrate_SP(doublereal Starget,
                 Tnew = 0.5*Tnow;
             }
             m_mix->setTemperature(Tnew);
-        } catch (CanteraError err) {
+        } catch (const CanteraError& err) {
             if (!estimateEquil) {
                 strt = -1;
             } else {


### PR DESCRIPTION
The "catching polymorphic type" warnings appear during compilation with GCC 8:
```
src/base/global.cpp: In function ‘void Cantera::setLogger(Cantera::Logger*)’:
src/base/global.cpp:28:19: warning: catching polymorphic type ‘class std::bad_alloc’ by value [-Wcatch-value=]
     } catch (std::bad_alloc) {
                   ^~~~~~~~~
```
```
src/equil/vcs_MultiPhaseEquil.cpp: In member function ‘int Cantera::vcs_MultiPhaseEquil::equilibrate_HP(doublereal, int, double, double, int, int, doublereal, int, int)’:
src/equil/vcs_MultiPhaseEquil.cpp:228:31: warning: catching polymorphic type ‘class Cantera::CanteraError’ by value [-Wcatch-value=]
         } catch (CanteraError err) {
                               ^~~
```
```
src/equil/vcs_MultiPhaseEquil.cpp: In member function ‘int Cantera::vcs_MultiPhaseEquil::equilibrate_SP(doublereal, double, double, int, int, doublereal, int, int)’:
src/equil/vcs_MultiPhaseEquil.cpp:354:31: warning: catching polymorphic type ‘class Cantera::CanteraError’ by value [-Wcatch-value=]
         } catch (CanteraError err) {
                               ^~~
```

Changes proposed in this pull request:
- This commit fix "catching polymorphic type" warnings via caught by reference.
