### PR TITLE
[Thermo] Avoid NaN in entropy with small negative mass fractions

### DIFF
--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -625,7 +625,7 @@ doublereal Phase::sum_xlogx() const
 {
     double sumxlogx = 0;
     for (size_t k = 0; k < m_kk; k++) {
-        sumxlogx += m_ym[k] * std::log(m_ym[k] + Tiny);
+        sumxlogx += m_ym[k] * std::log(std::max(m_ym[k], SmallNumber));
     }
     return m_mmw * sumxlogx + std::log(m_mmw);
 }


### PR DESCRIPTION
Avoid NaN results in entropy_mole calculations when there are small negative
mass fractions. Consistent with the approach used elsewhere,
e.g. IdealGasPhase::getPartialMolarEntropies.

This is a result of investigating the issue brought up by @ischoegl in #682.