### PR TITLE
Implement recreation of SolutionArray objects from stored data

### DIFF
--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -149,11 +149,16 @@ class TestPureFluid(utilities.CanteraTest):
 
     def test_TPX(self):
         self.water.TX = 400, 0.8
-        T,P,X = self.water.TPX
+        T, P, X = self.water.TPX
         self.assertNear(T, 400)
         self.assertNear(X, 0.8)
-        with self.assertRaises(AttributeError):
-            self.water.TPX = 500, 101325, 0.3
+
+        self.water.TPX = T, P, X
+        self.assertNear(X, 0.8)
+        with self.assertRaises(ValueError):
+            self.water.TPX = T, .999*P, X
+        with self.assertRaises(ValueError):
+            self.water.TPX = T, 1.001*P, X
 
 
 # To minimize errors when transcribing tabulated data, the input units here are:

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -155,10 +155,12 @@ class TestPureFluid(utilities.CanteraTest):
 
         self.water.TPX = T, P, X
         self.assertNear(X, 0.8)
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, 'invalid thermodynamic'):
             self.water.TPX = T, .999*P, X
-        with self.assertRaises(ValueError):
+        with self.assertRaisesRegex(ValueError, 'invalid thermodynamic'):
             self.water.TPX = T, 1.001*P, X
+        with self.assertRaisesRegex(ValueError, 'numeric value is required'):
+            self.water.TPX = T, P, 'spam'
 
 
 # To minimize errors when transcribing tabulated data, the input units here are:

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1561,6 +1561,19 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertTrue(np.allclose(states.P, b.P))
         self.assertTrue(np.allclose(states.X, b.X))
 
+    def test_pandas(self):
+        states = ct.SolutionArray(self.gas, 7)
+        states.TPX = np.linspace(300, 1000, 7), 2e5, 'H2:0.5, O2:0.4'
+        try:
+            # this will run through if pandas is installed
+            df = states.to_pandas()
+            self.assertTrue(df.shape[0]==7)
+        except ImportError as err:
+            # pandas is not installed and correct exception is raised
+            pass
+        except Exception as err:
+            raise(err)
+
     def test_restore(self):
 
         def check(a, b, atol=None):

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1581,7 +1581,12 @@ cdef class PureFluid(ThermoPhase):
             elif np.isclose(X, 0.) or np.isclose(X, 1.):
                 self.TP = T, P
             else:
-                raise ValueError('invalid thermodynamic state')
+                raise ValueError(
+                    'invalid thermodynamic state: the TPX setter '
+                    'received a combination of property values that '
+                    'do not represent a valid state. As an alternative, '
+                    'specify the state using two fully independent '
+                    'properties (e.g. TD)')
 
     property UVX:
         """

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -3,6 +3,7 @@
 
 import warnings
 import weakref
+import numbers as _numbers
 
 cdef enum ThermoBasis:
     mass_basis = 0
@@ -1565,7 +1566,7 @@ cdef class PureFluid(ThermoPhase):
 
     property TPX:
         """
-        Get/Set the temperature [K], pressure [Pa], and vapor fraction of a 
+        Get/Set the temperature [K], pressure [Pa], and vapor fraction of a
         PureFluid.
 
         An Exception is raised if the thermodynamic state is not consistent.
@@ -1576,6 +1577,11 @@ cdef class PureFluid(ThermoPhase):
             T = values[0] if values[0] is not None else self.T
             P = values[1] if values[1] is not None else self.P
             X = values[2] if values[2] is not None else self.X
+            if not isinstance(X, (np.ndarray, _numbers.Number)):
+                raise ValueError(
+                    'a numeric value is required to quanitify '
+                    'the vapor fraction (X)'
+                )
             if np.isclose(P, self.thermo.satPressure(T)):
                 self.TX = T, X
             elif np.isclose(X, 0.) or np.isclose(X, 1.):
@@ -1586,7 +1592,9 @@ cdef class PureFluid(ThermoPhase):
                     'received a combination of property values that '
                     'do not represent a valid state. As an alternative, '
                     'specify the state using two fully independent '
-                    'properties (e.g. TD)')
+                    'properties (e.g. TD) instead of: '
+                    'T={}, P={}, X={}'.format(T, P, X)
+                )
 
     property UVX:
         """

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1564,9 +1564,24 @@ cdef class PureFluid(ThermoPhase):
             return self.T, self.density, self.X
 
     property TPX:
-        """Get the temperature [K], pressure [Pa], and vapor fraction."""
+        """
+        Get/Set the temperature [K], pressure [Pa], and vapor fraction of a 
+        PureFluid.
+
+        An Exception is raised if the thermodynamic state is not consistent.
+        """
         def __get__(self):
             return self.T, self.P, self.X
+        def __set__(self, values):
+            T = values[0] if values[0] is not None else self.T
+            P = values[1] if values[1] is not None else self.P
+            X = values[2] if values[2] is not None else self.X
+            if np.isclose(P, self.thermo.satPressure(T)):
+                self.TX = T, X
+            elif np.isclose(X, 0.) or np.isclose(X, 1.):
+                self.TP = T, P
+            else:
+                raise ValueError('invalid thermodynamic state')
 
     property UVX:
         """


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #543

Changes proposed in this pull request:

This commit implements two new methods for SolutionArray:
* `restore_data` can restore data previously exported by `collect_data`
* `read_csv` restores data previously saved by `write_csv`
* `read_hdf` restores data saved by `write_hdf`

Intended usage is:
```python
# create a SolutionArray, do some manipulations and save results
states = ct.SolutionArray(gas)
...
states.write_csv('some_file.csv')
```
and, at a later point
```python
# restore prior work in a new python session
states = ct.SolutionArray(gas)
states.read_csv('some_file.csv')
```
~~PS: once PR #680 is merged, an equivalent method for `read_hdf` will be added to this PR.~~ Done.