### PR TITLE
[1D] Disable free flame domain width check when auto=False

### DIFF
--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -513,7 +513,8 @@ class FreeFlame(FlameBase):
 
         for _ in range(12):
             try:
-                return super().solve(loglevel, refine_grid, auto)
+                super().solve(loglevel, refine_grid, auto)
+                break
             except DomainTooNarrow:
                 self.flame.grid *= 2
                 if loglevel > 0:

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -170,6 +170,13 @@ class TestFreeFlame(utilities.CanteraTest):
         Tad = self.gas.T
         self.assertNear(Tad, self.sim.T[-1], 2e-2)
 
+        # Re-solving with auto=False should not trigger a DomainTooNarrow
+        # exception, and should leave domain width constant
+        self.sim.flame.grid *= 0.3
+        old_width = self.sim.grid[-1]
+        self.sim.solve(loglevel=0, refine_grid=True, auto=False)
+        self.assertNear(self.sim.grid[-1], old_width)
+
     def test_auto_width2(self):
         self.create_sim(p=ct.one_atm, Tin=400, reactants='H2:0.8, O2:0.5',
                         width=0.1)


### PR DESCRIPTION
Solving with `auto=True` and then solving with `auto=False` would leave the domain width check in place, but without the logic for automatically increasing the domain width, resulting in unexpected solver failures.

Resolves an issue reported on the [Cantera Users' Group](https://groups.google.com/forum/#!topic/cantera-users/1wZbEZ1SkQ0).