### PR TITLE
Pickle serialization of Solution objects

### DIFF
--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -130,7 +130,7 @@ public:
     //! Each class derived from Kinetics should override this method to return
     //! a meaningful identifier.
     virtual std::string kineticsType() const {
-        return "Kinetics";
+        return "None";
     }
 
     //! Finalize Kinetics object and associated objects

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -664,7 +664,8 @@ public:
      *  \rho, Y_1, \dots, Y_K) \f$. Alternatively, it returns a stored value.
      */
     virtual double pressure() const {
-        throw NotImplementedError("Phase::pressure");
+        throw NotImplementedError("Phase::pressure",
+            "Not implemented for thermo model '{}'", type());
     }
 
     //! Density (kg/m^3).
@@ -703,7 +704,8 @@ public:
      *  @param p input Pressure (Pa)
      */
     virtual void setPressure(double p) {
-        throw NotImplementedError("Phase::setPressure");
+        throw NotImplementedError("Phase::setPressure",
+            "Not implemented for thermo model '{}'", type());
     }
 
     //! Set the internally stored temperature of the phase (K).

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -111,7 +111,7 @@ public:
     //! @{
 
     virtual std::string type() const {
-        return "ThermoPhase";
+        return "None";
     }
 
     //! String indicating the mechanical phase of the matter in this Phase.

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1246,6 +1246,7 @@ cdef class _SolutionBase:
     cdef int thermo_basis
     cdef np.ndarray _selected_species
     cdef object parent
+    cdef public object _references
 
 cdef class Species:
     cdef shared_ptr[CxxSpecies] _species
@@ -1261,7 +1262,6 @@ cdef class ThermoPhase(_SolutionBase):
     cpdef int species_index(self, species) except *
     cdef np.ndarray _getArray1(self, thermoMethod1d method)
     cdef void _setArray1(self, thermoMethod1d method, values) except *
-    cdef public object _references
 
 cdef class InterfacePhase(ThermoPhase):
     cdef CxxSurfPhase* surf

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -18,6 +18,9 @@ cdef class _SolutionBase:
                         thermo=thermo, species=species, kinetics=kinetics,
                         reactions=reactions, **kwargs)
             return
+        elif any([infile, source, adjacent, origin, source, yaml,
+                  thermo, species, kinetics, reactions, kwargs]):
+            raise ValueError("Arguments are insufficient to define a phase")
 
         self._base = CxxNewSolution()
         self.base = self._base.get()
@@ -89,10 +92,8 @@ cdef class _SolutionBase:
         # Parse inputs
         if infile or source:
             self._init_cti_xml(infile, name, adjacent, source)
-        elif thermo and species:
-            self._init_parts(thermo, species, kinetics, adjacent, reactions)
         else:
-            raise ValueError("Arguments are insufficient to define a phase")
+            self._init_parts(thermo, species, kinetics, adjacent, reactions)
 
         self._selected_species = np.ndarray(0, dtype=np.uint64)
 

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -283,14 +283,14 @@ cdef class _SolutionBase:
         """
         self.base.header().clear()
 
-    def write_yaml(self, filename, phases=None, units=None, precision=None,
+    def write_yaml(self, filename=None, phases=None, units=None, precision=None,
                    skip_user_defined=None, header=True):
         """
         Write the definition for this phase, any additional phases specified,
         and their species and reactions to the specified file.
 
         :param filename:
-            The name of the output file
+            The name of the output file; if ``None``, a YAML string is returned
         :param phases:
             Additional ThermoPhase / Solution objects to be included in the
             output file
@@ -328,6 +328,8 @@ cdef class _SolutionBase:
             Y.precision = precision
         if skip_user_defined is not None:
             Y.skip_user_defined = skip_user_defined
+        if filename is None:
+            return Y.to_string()
         Y.to_file(filename)
 
     def __getitem__(self, selection):

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -10,6 +10,7 @@ cdef class _SolutionBase:
                   kinetics=None, reactions=(), **kwargs):
 
         # run instantiation only if valid sources are specified
+        self._references = None
         if origin or infile or source or yaml or (thermo and species):
 
             self._cinit(infile=infile, name=name, adjacent=adjacent,

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -16,6 +16,19 @@ cdef class _SolutionBase:
                         origin=origin, source=source, yaml=yaml,
                         thermo=thermo, species=species, kinetics=kinetics,
                         reactions=reactions, **kwargs)
+            return
+
+        self._base = CxxNewSolution()
+        self.base = self._base.get()
+        self.base.setSource(stringify("none"))
+
+        self.base.setThermo(newThermo(stringify("none")))
+        self.thermo = self.base.thermo().get()
+        self.base.setKinetics(newKinetics(stringify("none")))
+        self.kinetics = self.base.kinetics().get()
+        self.base.setTransport(newTransport(NULL, stringify("none")))
+        self.transport = self.base.transport().get()
+        self._selected_species = np.ndarray(0, dtype=np.uint64)
 
     def _cinit(self, infile='', name='', adjacent=(), origin=None,
                   source=None, yaml=None, thermo=None, species=(),

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -384,15 +384,12 @@ cdef class _SolutionBase:
         if self.kinetics.nTotalSpecies() > self.thermo.nSpecies():
             raise NotImplementedError(
                 "Pickling of Interface objects is not implemented.")
-        transport_model = pystr(self.transport.transportType())
-        return self.write_yaml(), self.state, transport_model
+        return self.write_yaml()
 
     def __setstate__(self, pkl):
         """Restore Solution from pickled information."""
-        yml, state, transport_model = pkl
-        self._cinit(yaml=yml, transport_model=transport_model)
-
-        self.state = state
+        yml = pkl
+        self._cinit(yaml=yml)
 
     def __copy__(self):
         raise NotImplementedError('Solution object is not copyable')

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -177,6 +177,9 @@ cdef class _SolutionBase:
             self.base.setKinetics(newKinetics(stringify("none")))
         self.kinetics = self.base.kinetics().get()
 
+        # Transport
+        self.transport = self.base.transport().get()
+
     def _init_cti_xml(self, infile, name, adjacent, source):
         """
         Instantiate a set of new Cantera C++ objects from a CTI or XML
@@ -381,12 +384,14 @@ cdef class _SolutionBase:
         if self.kinetics.nTotalSpecies() > self.thermo.nSpecies():
             raise NotImplementedError(
                 "Pickling of Interface objects is not implemented.")
-        return self.write_yaml(), self.state
+        transport_model = pystr(self.transport.transportType())
+        return self.write_yaml(), self.state, transport_model
 
     def __setstate__(self, pkl):
         """Restore Solution from pickled information."""
-        yml, state = pkl
-        self._cinit(yaml=yml)
+        yml, state, transport_model = pkl
+        self._cinit(yaml=yml, transport_model=transport_model)
+
         self.state = state
 
     def __copy__(self):

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -25,7 +25,7 @@ else:
     import pandas as _pandas
 
 
-class Solution(ThermoPhase, Kinetics, Transport):
+class Solution(Transport, Kinetics, ThermoPhase):
     """
     A class for chemically-reacting solutions. Instances can be created to
     represent any type of solution -- a mixture of gases, a liquid solution, or
@@ -101,7 +101,7 @@ class Solution(ThermoPhase, Kinetics, Transport):
     __slots__ = ()
 
 
-class Interface(InterfacePhase, InterfaceKinetics):
+class Interface(InterfaceKinetics, InterfacePhase):
     """
     Two-dimensional interfaces.
 
@@ -121,7 +121,7 @@ class Interface(InterfacePhase, InterfaceKinetics):
     __slots__ = ('_phase_indices',)
 
 
-class DustyGas(ThermoPhase, Kinetics, DustyGasTransport):
+class DustyGas(DustyGasTransport, Kinetics, ThermoPhase):
     """
     A composite class which models a gas in a stationary, solid, porous medium.
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1375,6 +1375,12 @@ class SolutionArray:
 
         return root_attrs
 
+    def __reduce__(self):
+        raise NotImplementedError('SolutionArray object is not picklable')
+
+    def __copy__(self):
+        raise NotImplementedError('SolutionArray object is not copyable')
+
 
 def _state2_prop(name, doc_source):
     # Factory for creating properties which consist of a tuple of two variables,

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -64,6 +64,13 @@ cdef class Kinetics(_SolutionBase):
     of progress, species production rates, and other quantities pertaining to
     a reaction mechanism.
     """
+    def __init__(self, *args, **kwargs):
+        super().__init__(*args, **kwargs)
+        if self._references is None:
+            raise ValueError(
+                "Cannot instantiate stand-alone 'Kinetics' object as it requires an "
+                "associated thermo phase.\nAll 'Kinetics' methods should be accessed "
+                "from a 'Solution' object.")
 
     property kinetics_model:
         """

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -8,6 +8,8 @@ from ctypes import c_int
 # e.g. class Solution. [Cython 0.16]
 cdef np.ndarray get_species_array(Kinetics kin, kineticsMethod1d method):
     cdef np.ndarray[np.double_t, ndim=1] data = np.empty(kin.n_total_species)
+    if kin.n_total_species == 0:
+        return data
     method(kin.kinetics, &data[0])
     # @todo: Fix _selected_species to work with interface kinetics
     if kin._selected_species.size:
@@ -17,6 +19,8 @@ cdef np.ndarray get_species_array(Kinetics kin, kineticsMethod1d method):
 
 cdef np.ndarray get_reaction_array(Kinetics kin, kineticsMethod1d method):
     cdef np.ndarray[np.double_t, ndim=1] data = np.empty(kin.n_reactions)
+    if kin.n_reactions == 0:
+        return data
     method(kin.kinetics, &data[0])
     return data
 

--- a/interfaces/cython/cantera/liquidvapor.py
+++ b/interfaces/cython/cantera/liquidvapor.py
@@ -41,7 +41,7 @@ def Water(backend='Reynolds'):
     :ct:WaterSSTP and :ct:WaterTransport in the Cantera C++ source
     code documentation.
     """
-    class WaterWithTransport(PureFluid, _cantera.Transport):
+    class WaterWithTransport(_cantera.Transport, PureFluid):
         __slots__ = ()
 
     if backend == 'Reynolds':

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -740,11 +740,6 @@ class TestThermoPhase(utilities.CanteraTest):
         self.assertNear(self.phase.min_temp, 300.0)
         self.assertNear(self.phase.max_temp, 3500.0)
 
-    def test_unpicklable(self):
-        import pickle
-        with self.assertRaises(NotImplementedError):
-            pickle.dumps(self.phase)
-
     def test_uncopyable(self):
         import copy
         with self.assertRaises(NotImplementedError):

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -330,6 +330,9 @@ cdef class ThermoPhase(_SolutionBase):
         super().__init__(*args, **kwargs)
         if 'source' not in kwargs:
             self.thermo_basis = mass_basis
+        # In composite objects, the ThermoPhase constructor needs to be called first
+        # to prevent instantiation of stand-alone 'Kinetics' or 'Transport' objects.
+        # The following is used as a sentinel.
         self._references = weakref.WeakKeyDictionary()
 
     property thermo_model:

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -168,6 +168,7 @@ cdef class Transport(_SolutionBase):
     # The signature of this function causes warnings for Sphinx documentation
     def __init__(self, *args, **kwargs):
         if self.transport == NULL:
+            # @todo ... after removal of CTI/XML, this should be handled by base.pyx
             if 'transport_model' not in kwargs:
                 self.base.setTransport(newTransport(self.thermo, stringify("default")))
             else:

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -179,6 +179,11 @@ cdef class Transport(_SolutionBase):
             self.transport = self.base.transport().get()
 
         super().__init__(*args, **kwargs)
+        if self._references is None:
+            raise ValueError(
+                "Cannot instantiate stand-alone 'Transport' object as it requires an "
+                "associated thermo phase.\nAll 'Transport' methods should be accessed "
+                "from a 'Solution' object.")
 
     property transport_model:
         """

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -42,6 +42,7 @@ Kinetics* KineticsFactory::newKinetics(XML_Node& phaseData,
 KineticsFactory::KineticsFactory() {
     reg("none", []() { return new Kinetics(); });
     addAlias("none", "Kinetics");
+    addAlias("none", "None");
     reg("gas", []() { return new GasKinetics(); });
     addAlias("gas", "gaskinetics");
     addAlias("gas", "Gas");
@@ -106,7 +107,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
     vector<string> sections, rules;
 
     if (phaseNode.hasKey("reactions")) {
-        if (kin.kineticsType() == "Kinetics") {
+        if (kin.kineticsType() == "None") {
             throw InputFileError("addReactions", phaseNode["reactions"],
                 "Phase entry includes a 'reactions' field but does not "
                 "specify a kinetics model.");
@@ -137,7 +138,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
                 rules.push_back(item.begin()->second.asString());
             }
         }
-    } else if (kin.kineticsType() != "Kinetics") {
+    } else if (kin.kineticsType() != "None") {
         if (rootNode.hasKey("reactions")) {
             // Default behavior is to add all reactions from the 'reactions'
             // section, if a 'kinetics' model has been specified

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -48,6 +48,9 @@ std::mutex ThermoFactory::thermo_mutex;
 
 ThermoFactory::ThermoFactory()
 {
+    reg("none", []() { return new ThermoPhase(); });
+    addAlias("none", "ThermoPhase");
+    addAlias("none", "None");
     reg("ideal-gas", []() { return new IdealGasPhase(); });
     addAlias("ideal-gas", "IdealGas");
     reg("ideal-surface", []() { return new SurfPhase(); });

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -1403,6 +1403,11 @@ void ThermoPhase::getdlnActCoeffdlnN_numderiv(const size_t ld, doublereal* const
 
 std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
 {
+    if (type() == "None") {
+        throw NotImplementedError("ThermoPhase::report",
+            "Not implemented for thermo model 'None'");
+    }
+
     fmt::memory_buffer b;
     // This is the width of the first column of names in the report.
     int name_width = 18;

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -29,10 +29,10 @@ std::mutex TransportFactory::transport_mutex;
 
 TransportFactory::TransportFactory()
 {
-    reg("", []() { return new Transport(); });
-    addAlias("", "Transport");
-    addAlias("", "None");
-    addAlias("", "none");
+    reg("none", []() { return new Transport(); });
+    addAlias("none", "Transport");
+    addAlias("none", "None");
+    addAlias("none", "");
     reg("unity-Lewis-number", []() { return new UnityLewisTransport(); });
     addAlias("unity-Lewis-number", "UnityLewis");
     reg("mixture-averaged", []() { return new MixTransport(); });
@@ -63,7 +63,7 @@ void TransportFactory::deleteFactory()
 Transport* TransportFactory::newTransport(const std::string& transportModel,
         ThermoPhase* phase, int log_level)
 {
-    if (transportModel != "DustyGas" && canonicalize(transportModel) == "") {
+    if (transportModel != "DustyGas" && canonicalize(transportModel) == "none") {
         return create(transportModel);
     }
     if (!phase) {

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -404,7 +404,7 @@ TEST(KineticsFromYaml, NoKineticsModelOrReactionsField1)
 {
     auto soln = newSolution("phase-reaction-spec1.yaml",
                             "nokinetics-noreactions");
-    EXPECT_EQ(soln->kinetics()->kineticsType(), "Kinetics");
+    EXPECT_EQ(soln->kinetics()->kineticsType(), "None");
     EXPECT_EQ(soln->kinetics()->nReactions(), (size_t) 0);
 }
 
@@ -412,7 +412,7 @@ TEST(KineticsFromYaml, NoKineticsModelOrReactionsField2)
 {
     auto soln = newSolution("phase-reaction-spec2.yaml",
                             "nokinetics-noreactions");
-    EXPECT_EQ(soln->kinetics()->kineticsType(), "Kinetics");
+    EXPECT_EQ(soln->kinetics()->kineticsType(), "None");
     EXPECT_EQ(soln->kinetics()->nReactions(), (size_t) 0);
 }
 


### PR DESCRIPTION
Pickle support for `Solution` objects would facilitate __multiprocessing applications__, where each thread/process is working with a separate copy of a Solution object. The approach is comparable to constructing the object from an input file plus setting phase and state vector.

Closes Cantera/enhancements#10

~The PR illustrates a __rudimentary implementation__ (XML/CTI support only), which *should not be considered for adoption* (at least not in its present form).~ … **now replaced by a permanent solution using YAML serialization**

It allows for the following scenario (obviously, multiprocessing applications are more relevant):
```python
import cantera as ct
import pickle

gas = ct.Solution('h2o2.cti', 'ohmech-multi')
gas.TPX = 500, 500000, 'H2:.75, O2:.25'
pickle.dump(gas, open('gas.pkl', 'wb'))
```
Recreating the object in a separate session via
```python
import pickle
gas = pickle.load(open('gas.pkl','rb'))
gas()
```
yields:
```
 ohmech-multi:

       temperature             500  K
          pressure          500000  Pa
           density         1.14397  kg/m^3
  mean mol. weight          9.5115  amu

                          1 kg            1 kmol
                       -----------      ------------
          enthalpy      6.2484e+05        5.943e+06     J
   internal energy      1.8776e+05        1.786e+06     J
           entropy           16391        1.559e+05     J/K
    Gibbs function     -7.5708e+06       -7.201e+07     J
 heat capacity c_p          3127.2        2.974e+04     J/K
 heat capacity c_v            2253        2.143e+04     J/K

                           X                 Y          Chem. Pot. / RT
                     -------------     ------------     ------------
                H2           0.75         0.158965         -14.8055
                O2           0.25         0.841035           -24.87
     [   +7 minor]              0                0

```
~The current implementation for pickling/unpickling makes use of the static XML tree that is retained after creation of a `Solution` from CTI/XML files. A more useful (but significantly more involved) implementation would generate YAML strings dynamically.~

Changes proposed in this pull request:
- ~N/A: at least at this point, the PR serves for illustration purposes only~

Known issues:
- ~The current implementation will fail if the `Solution` object is changed after instantiation (e.g. species are added, etc.)~
- ~Unpickling requires that an empty constructor, i.e. `_SolutionBase()` is allowed. While this works fine for `pickle.load`, an attempt for `gas = Solution()` results in a segmentation fault.~ ... *fixed*