### PR TITLE
[stub] YAML summary of ReactorNet structure

### DIFF
--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -54,6 +54,9 @@ public:
         return m_type;
     }
 
+    //! Generate self-documenting YAML string.
+    virtual std::string toYAML() const;
+
     //! Mass flow rate (kg/s).
     //! @deprecated The 'time' argument will be removed after Cantera 2.5.
     //!     Evaluating the mass flow rate at times other than the current time
@@ -101,7 +104,7 @@ public:
     }
 
     //! Return a const reference to the downstream reactor.
-    const ReactorBase& out() const {
+    ReactorBase& out() const {
         return *m_out;
     }
 

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -30,7 +30,7 @@ const int Valve_Type = 3;
 class FlowDevice
 {
 public:
-    FlowDevice();
+    FlowDevice(const std::string& name = "(none)");
 
     virtual ~FlowDevice() {}
     FlowDevice(const FlowDevice&) = delete;
@@ -52,6 +52,16 @@ public:
                         "Return string instead of magic number; use "
                         "FlowDevice::typeStr during transition.");
         return m_type;
+    }
+
+    //! Return the name of this flow device
+    std::string name() const {
+        return m_name;
+    }
+
+    //! Set the name of this flow device
+    void setName(const std::string& name) {
+        m_name = name;
     }
 
     //! Generate self-documenting YAML string.
@@ -168,6 +178,8 @@ protected:
     double m_coeff;
 
     int m_type; //!< @deprecated To be removed after Cantera 2.5.
+
+    std::string m_name; //! flow device name
 
 private:
     size_t m_nspin, m_nspout;

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -205,9 +205,6 @@ protected:
     //! Get initial conditions for SurfPhase objects attached to this reactor
     virtual void getSurfaceInitialConditions(double* y);
 
-    //! Pointer to the homogeneous Kinetics object that handles the reactions
-    Kinetics* m_kin;
-
     doublereal m_vdot; //!< net rate of volume change from moving walls [m^3/s]
     doublereal m_Q; //!< net heat transfer through walls [W]
     doublereal m_mass; //!< total mass

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -101,6 +101,9 @@ public:
         throw NotImplementedError("ReactorBase::setChemistry");
     }
 
+    //! Generate self-documenting YAML string.
+    virtual std::string toYAML() const;
+
     //! Set the energy equation on or off.
     virtual void setEnergy(int eflag = 1) {
         throw NotImplementedError("ReactorBase::setEnergy");
@@ -134,6 +137,11 @@ public:
     //! Return the number of Wall objects connected to this reactor.
     size_t nWalls() {
         return m_wall.size();
+    }
+
+    //! Return the number of ReactorSurface objects connected to this reactor.
+    size_t nSurfaces() {
+        return m_surfaces.size();
     }
 
     //! Insert a Wall between this reactor and another reactor.

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -89,7 +89,7 @@ public:
     //! Specify the mixture contained in the reactor. Note that a pointer to
     //! this substance is stored, and as the integration proceeds, the state of
     //! the substance is modified.
-    virtual void setThermoMgr(thermo_t& thermo);
+    virtual void setThermoMgr(ThermoPhase& thermo);
 
     //! Specify chemical kinetics governing the reactor.
     virtual void setKineticsMgr(Kinetics& kin) {
@@ -185,7 +185,7 @@ public:
     virtual void syncState();
 
     //! return a reference to the contents.
-    thermo_t& contents() {
+    ThermoPhase& contents() {
         if (!m_thermo) {
             throw CanteraError("ReactorBase::contents",
                                "Reactor contents not defined.");
@@ -193,7 +193,7 @@ public:
         return *m_thermo;
     }
 
-    const thermo_t& contents() const {
+    const ThermoPhase& contents() const {
         if (!m_thermo) {
             throw CanteraError("ReactorBase::contents",
                                "Reactor contents not defined.");
@@ -269,7 +269,7 @@ protected:
     //! Number of homogeneous species in the mixture
     size_t m_nsp;
 
-    thermo_t* m_thermo;
+    ThermoPhase* m_thermo;
 
     //! Pointer to the homogeneous Kinetics object that handles the reactions
     Kinetics* m_kin;

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -270,6 +270,10 @@ protected:
     size_t m_nsp;
 
     thermo_t* m_thermo;
+
+    //! Pointer to the homogeneous Kinetics object that handles the reactions
+    Kinetics* m_kin;
+
     doublereal m_vol;
     doublereal m_enthalpy;
     doublereal m_intEnergy;

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -31,7 +31,6 @@ public:
     //! @name Methods to set up a simulation.
     //@{
 
-
     //! Set initial time. Default = 0.0 s. Restarts integration from this time
     //! using the current mixture state as the initial condition.
     void setInitialTime(double time);

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -31,6 +31,7 @@ public:
     //! @name Methods to set up a simulation.
     //@{
 
+
     //! Set initial time. Default = 0.0 s. Restarts integration from this time
     //! using the current mixture state as the initial condition.
     void setInitialTime(double time);
@@ -101,6 +102,9 @@ public:
     double step();
 
     //@}
+
+    //! Generate self-documenting YAML string.
+    std::string toYAML() const;
 
     //! Add the reactor *r* to this reactor network.
     void addReactor(Reactor& r);

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -22,6 +22,9 @@ public:
     ReactorSurface(const ReactorSurface&) = delete;
     ReactorSurface& operator=(const ReactorSurface&) = delete;
 
+    //! Generate self-documenting YAML string.
+    virtual std::string toYAML() const;
+
     //! Returns the surface area [m^2]
     double area() const;
 

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -17,10 +17,26 @@ class SurfPhase;
 class ReactorSurface
 {
 public:
-    ReactorSurface();
+    ReactorSurface(const std::string& name = "(none)");
     virtual ~ReactorSurface() {}
     ReactorSurface(const ReactorSurface&) = delete;
     ReactorSurface& operator=(const ReactorSurface&) = delete;
+
+    //! String indicating the wall model implemented. Usually
+    //! corresponds to the name of the derived class.
+    virtual std::string type() const {
+        return "ReactorSurface";
+    }
+
+    //! Return the name of this surface
+    std::string name() const {
+        return m_name;
+    }
+
+    //! Set the name of this surface
+    void setName(const std::string& name) {
+        m_name = name;
+    }
 
     //! Generate self-documenting YAML string.
     virtual std::string toYAML() const;
@@ -93,6 +109,8 @@ protected:
     ReactorBase* m_reactor;
     vector_fp m_cov;
     std::vector<SensitivityParameter> m_params;
+
+    std::string m_name; //! reactor surface name
 };
 
 }

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -28,7 +28,7 @@ const int WallType = 1;
 class WallBase
 {
 public:
-    WallBase();
+    WallBase(const std::string& name = "(none)");
 
     virtual ~WallBase() {}
     WallBase(const WallBase&) = delete;
@@ -38,6 +38,16 @@ public:
     //! corresponds to the name of the derived class.
     virtual std::string type() const {
         return "WallBase";
+    }
+
+    //! Return the name of this wall
+    std::string name() const {
+        return m_name;
+    }
+
+    //! Set the name of this wall
+    void setName(const std::string& name) {
+        m_name = name;
     }
 
     //! Generate self-documenting YAML string.
@@ -109,6 +119,8 @@ protected:
     std::vector<ReactorSurface> m_surf;
 
     double m_area;
+
+    std::string m_name; //! wall name
 };
 
 //! Represents a wall between between two ReactorBase objects.

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -40,6 +40,9 @@ public:
         return "WallBase";
     }
 
+    //! Generate self-documenting YAML string.
+    virtual std::string toYAML() const;
+
     //! Rate of volume change (m^3/s) for the adjacent reactors.
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
@@ -95,7 +98,7 @@ public:
     }
 
     //! Return a reference to the Reactor or Reservoir to the right of the wall.
-    const ReactorBase& right() {
+    ReactorBase& right() const {
         return *m_right;
     }
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -583,6 +583,8 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxWallBase "Cantera::WallBase":
         CxxWallBase()
         string type()
+        string name()
+        void setName(string)
         string toYAML()
         cbool install(CxxReactorBase&, CxxReactorBase&)
         double area()
@@ -612,6 +614,9 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
 
     cdef cppclass CxxReactorSurface "Cantera::ReactorSurface":
         CxxReactorSurface()
+        string type()
+        string name()
+        void setName(string)
         string toYAML()
         double area()
         void setArea(double)
@@ -627,8 +632,10 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxFlowDevice "Cantera::FlowDevice":
         CxxFlowDevice()
         string typeStr()
-        double massFlowRate() except +translate_exception
+        string name()
+        void setName(string)
         string toYAML()
+        double massFlowRate() except +translate_exception
         double massFlowRate(double) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&) except +translate_exception
         void setPressureFunction(CxxFunc1*) except +translate_exception
@@ -1093,7 +1100,6 @@ cdef class WallBase:
     cdef object _heat_flux_func
     cdef ReactorBase _left_reactor
     cdef ReactorBase _right_reactor
-    cdef str name
 
 cdef class Wall(WallBase):
     pass
@@ -1102,7 +1108,6 @@ cdef class FlowDevice:
     cdef CxxFlowDevice* dev
     cdef Func1 _rate_func
     cdef Func1 _time_func
-    cdef str name
     cdef ReactorBase _upstream
     cdef ReactorBase _downstream
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -546,6 +546,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxReactorBase "Cantera::ReactorBase":
         CxxReactorBase()
         string typeStr()
+        string toYAML()
         void setThermoMgr(CxxThermoPhase&) except +translate_exception
         void restoreState() except +translate_exception
         void syncState() except +translate_exception
@@ -582,6 +583,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxWallBase "Cantera::WallBase":
         CxxWallBase()
         string type()
+        string toYAML()
         cbool install(CxxReactorBase&, CxxReactorBase&)
         double area()
         void setArea(double)
@@ -610,6 +612,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
 
     cdef cppclass CxxReactorSurface "Cantera::ReactorSurface":
         CxxReactorSurface()
+        string toYAML()
         double area()
         void setArea(double)
         void setKinetics(CxxKinetics*)
@@ -625,6 +628,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         CxxFlowDevice()
         string typeStr()
         double massFlowRate() except +translate_exception
+        string toYAML()
         double massFlowRate(double) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&) except +translate_exception
         void setPressureFunction(CxxFunc1*) except +translate_exception
@@ -652,6 +656,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxReactorNet "Cantera::ReactorNet":
         CxxReactorNet()
         void addReactor(CxxReactor&)
+        string toYAML()
         double advance(double, cbool) except +translate_exception
         double step() except +translate_exception
         void initialize() except +translate_exception

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -663,7 +663,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxReactorNet "Cantera::ReactorNet":
         CxxReactorNet()
         void addReactor(CxxReactor&)
-        string toYAML()
+        string toYAML() except +translate_exception
         double advance(double, cbool) except +translate_exception
         double step() except +translate_exception
         void initialize() except +translate_exception

--- a/interfaces/cython/cantera/examples/reactors/ic_engine.py
+++ b/interfaces/cython/cantera/examples/reactors/ic_engine.py
@@ -97,12 +97,12 @@ gas = ct.Solution(reaction_mechanism, phase_name)
 
 # define initial state and set up reactor
 gas.TPX = T_inlet, p_inlet, comp_inlet
-cyl = ct.IdealGasReactor(gas)
+cyl = ct.IdealGasReactor(gas, name='Cylinder')
 cyl.volume = V_oT
 
 # define inlet state
 gas.TPX = T_inlet, p_inlet, comp_inlet
-inlet = ct.Reservoir(gas)
+inlet = ct.Reservoir(gas, name='Inlet')
 
 # inlet valve
 inlet_valve = ct.Valve(inlet, cyl)
@@ -113,7 +113,7 @@ inlet_valve.set_time_function(
 
 # define injector state (gaseous!)
 gas.TPX = T_injector, p_injector, comp_injector
-injector = ct.Reservoir(gas)
+injector = ct.Reservoir(gas, name='Fuel')
 
 # injector is modeled as a mass flow controller
 injector_mfc = ct.MassFlowController(injector, cyl)
@@ -125,7 +125,7 @@ injector_mfc.set_time_function(
 
 # define outlet pressure (temperature and composition don't matter)
 gas.TPX = T_ambient, p_outlet, comp_ambient
-outlet = ct.Reservoir(gas)
+outlet = ct.Reservoir(gas, name='Outlet')
 
 # outlet valve
 outlet_valve = ct.Valve(cyl, outlet)
@@ -136,7 +136,7 @@ outlet_valve.set_time_function(
 
 # define ambient pressure (temperature and composition don't matter)
 gas.TPX = T_ambient, p_ambient, comp_ambient
-ambient_air = ct.Reservoir(gas)
+ambient_air = ct.Reservoir(ct.Solution('air.cti'), name='Ambient')
 
 # piston is modeled as a moving wall
 piston = ct.Wall(ambient_air, cyl)

--- a/interfaces/cython/cantera/examples/reactors/ic_engine.py
+++ b/interfaces/cython/cantera/examples/reactors/ic_engine.py
@@ -105,7 +105,7 @@ gas.TPX = T_inlet, p_inlet, comp_inlet
 inlet = ct.Reservoir(gas, name='Inlet')
 
 # inlet valve
-inlet_valve = ct.Valve(inlet, cyl)
+inlet_valve = ct.Valve(inlet, cyl, name='InletValve')
 inlet_delta = np.mod(inlet_close - inlet_open, 4 * np.pi)
 inlet_valve.valve_coeff = inlet_valve_coeff
 inlet_valve.set_time_function(
@@ -116,7 +116,7 @@ gas.TPX = T_injector, p_injector, comp_injector
 injector = ct.Reservoir(gas, name='Fuel')
 
 # injector is modeled as a mass flow controller
-injector_mfc = ct.MassFlowController(injector, cyl)
+injector_mfc = ct.MassFlowController(injector, cyl, name='Injector')
 injector_delta = np.mod(injector_close - injector_open, 4 * np.pi)
 injector_t_open = (injector_close - injector_open) / 2. / np.pi / f
 injector_mfc.mass_flow_coeff = injector_mass / injector_t_open
@@ -128,7 +128,7 @@ gas.TPX = T_ambient, p_outlet, comp_ambient
 outlet = ct.Reservoir(gas, name='Outlet')
 
 # outlet valve
-outlet_valve = ct.Valve(cyl, outlet)
+outlet_valve = ct.Valve(cyl, outlet, name='OutletValve')
 outlet_delta = np.mod(outlet_close - outlet_open, 4 * np.pi)
 outlet_valve.valve_coeff = outlet_valve_coeff
 outlet_valve.set_time_function(
@@ -139,7 +139,7 @@ gas.TPX = T_ambient, p_ambient, comp_ambient
 ambient_air = ct.Reservoir(ct.Solution('air.cti'), name='Ambient')
 
 # piston is modeled as a moving wall
-piston = ct.Wall(ambient_air, cyl)
+piston = ct.Wall(ambient_air, cyl, name='Piston')
 piston.area = A_piston
 piston.set_velocity(piston_speed)
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -410,13 +410,34 @@ cdef class ReactorSurface:
     def __dealloc__(self):
         del self.surface
 
-    def __init__(self, kin=None, Reactor r=None, *, A=None):
+    def __init__(self, kin=None, Reactor r=None, *, name=None, A=None):
+
         if kin is not None:
             self.kinetics = kin
         if r is not None:
             self.install(r)
         if A is not None:
             self.area = A
+
+        if name is not None:
+            self.name = name
+        else:
+            _reactor_counts[self.__class__.__name__] += 1
+            n = _reactor_counts[self.__class__.__name__]
+            self.name = '{0}_{1}'.format(self.__class__.__name__, n)
+
+    property type:
+        """The type of the reactor."""
+        def __get__(self):
+            return pystr(self.surface.type())
+
+    property name:
+        """The name of the reactor."""
+        def __get__(self):
+            return pystr(self.surface.name())
+
+        def __set__(self, name):
+            self.surface.setName(stringify(name))
 
     def to_yaml(self):
         """Return a YAML representation of the ReactorSurface setup."""
@@ -515,12 +536,13 @@ cdef class WallBase:
         self._heat_flux_func = None
 
         self._install(left, right)
+
         if name is not None:
             self.name = name
         else:
-            _reactor_counts['Wall'] += 1
-            n = _reactor_counts['Wall']
-            self.name = 'Wall_{0}'.format(n)
+            _reactor_counts[self.__class__.__name__] += 1
+            n = _reactor_counts[self.__class__.__name__]
+            self.name = '{0}_{1}'.format(self.__class__.__name__, n)
 
         if A is not None:
             self.area = A
@@ -549,6 +571,14 @@ cdef class WallBase:
         """The type of the wall."""
         def __get__(self):
             return pystr(self.wall.type())
+
+    property name:
+        """The name of the reactor."""
+        def __get__(self):
+            return pystr(self.wall.name())
+
+        def __set__(self, name):
+            self.wall.setName(stringify(name))
 
     def to_yaml(self):
         """Return a YAML representation of the WallBase setup."""
@@ -706,6 +736,14 @@ cdef class FlowDevice:
         """The type of the flow device."""
         def __get__(self):
             return pystr(self.dev.typeStr())
+
+    property name:
+        """The name of the reactor."""
+        def __get__(self):
+            return pystr(self.dev.name())
+
+        def __set__(self, name):
+            self.dev.setName(stringify(name))
 
     def to_yaml(self):
         """Return a YAML representation of the FlowDevice setup."""

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -63,6 +63,10 @@ cdef class ReactorBase:
         def __set__(self, name):
             self.rbase.setName(stringify(name))
 
+    def to_yaml(self):
+        """Return a YAML representation of the Reactor setup."""
+        return pystr(self.rbase.toYAML())
+
     def syncState(self):
         """
         Set the state of the Reactor to match that of the associated
@@ -414,6 +418,10 @@ cdef class ReactorSurface:
         if A is not None:
             self.area = A
 
+    def to_yaml(self):
+        """Return a YAML representation of the ReactorSurface setup."""
+        return pystr(self.surface.toYAML())
+
     def install(self, Reactor r):
         r.reactor.addSurface(self.surface)
 
@@ -541,6 +549,10 @@ cdef class WallBase:
         """The type of the wall."""
         def __get__(self):
             return pystr(self.wall.type())
+
+    def to_yaml(self):
+        """Return a YAML representation of the WallBase setup."""
+        return pystr(self.wall.toYAML())
 
     property left:
         """ The left surface of this wall. """
@@ -694,6 +706,10 @@ cdef class FlowDevice:
         """The type of the flow device."""
         def __get__(self):
             return pystr(self.dev.typeStr())
+
+    def to_yaml(self):
+        """Return a YAML representation of the FlowDevice setup."""
+        return pystr(self.dev.toYAML())
 
     def _install(self, ReactorBase upstream, ReactorBase downstream):
         """
@@ -1044,6 +1060,10 @@ cdef class ReactorNet:
         """Add a reactor to the network."""
         self._reactors.append(r)
         self.net.addReactor(deref(r.reactor))
+
+    def to_yaml(self):
+        """Return a YAML representation of the ReactorNet setup."""
+        return pystr(self.net.toYAML())
 
     def advance(self, double t, pybool apply_limit=True):
         """

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -415,21 +415,21 @@ class TestReactor(utilities.CanteraTest):
 
         yaml = YAML()
         yml = yaml.load(self.net.to_yaml())
-        self.assertTrue('ReactorNet' in yml)
-        net = yml['ReactorNet']
+        self.assertTrue('reactor-network' in yml)
+        net = yml['reactor-network']
 
-        self.assertTrue('ReactorBase' in net)
-        reactors = [tuple(n)[0] for n in net['ReactorBase']]
+        self.assertTrue('reactors' in net)
+        reactors = [tuple(n)[0] for n in net['reactors']]
         self.assertTrue(self.r1.name in reactors)
         self.assertTrue(self.r2.name in reactors)
         self.assertTrue(reservoir.name in reactors)
 
-        self.assertTrue('WallBase' in net)
-        walls = [tuple(n)[0] for n in net['WallBase']]
+        self.assertTrue('walls' in net)
+        walls = [tuple(n)[0] for n in net['walls']]
         self.assertTrue(self.w.name in walls)
 
-        self.assertTrue('FlowDevice' in net)
-        devices = [tuple(n)[0] for n in net['FlowDevice']]
+        self.assertTrue('flow-devices' in net)
+        devices = [tuple(n)[0] for n in net['flow-devices']]
         self.assertTrue(mfc.name in devices)
 
         self.r2.name = self.r1.name

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -5,7 +5,10 @@ import os
 
 import numpy as np
 from .utilities import unittest
-from ruamel.yaml import YAML
+try:
+    from ruamel.yaml import YAML
+except:
+    from ruamel_yaml import YAML
 
 import cantera as ct
 from . import utilities

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -6,6 +6,7 @@
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/ReactorBase.h"
 #include "cantera/numerics/Func1.h"
+#include "cantera/base/yaml.h"
 
 namespace Cantera
 {
@@ -44,6 +45,25 @@ bool FlowDevice::install(ReactorBase& in, ReactorBase& out)
         m_out2in.push_back(ki);
     }
     return true;
+}
+
+std::string FlowDevice::toYAML() const
+{
+    YAML::Emitter yml;
+    std::stringstream out;
+
+    // object is not aware of its unique identifier
+    yml << YAML::BeginMap;
+    yml << YAML::Key << "type";
+    yml << YAML::Value << typeStr();
+    yml << YAML::Key << "in";
+    yml << YAML::Value << m_in->name();
+    yml << YAML::Key << "out";
+    yml << YAML::Value << m_out->name();
+    yml << YAML::EndMap;
+
+    out << yml.c_str();
+    return out.str();
 }
 
 void FlowDevice::setPressureFunction(Func1* f)

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -61,8 +61,8 @@ std::string FlowDevice::toYAML() const
     yml << YAML::Key << name();
     yml << YAML::BeginMap;
     yml << YAML::Key << "type" << YAML::Value << typeStr();
-    yml << YAML::Key << "in" << YAML::Value << m_in->name();
-    yml << YAML::Key << "out" << YAML::Value << m_out->name();
+    yml << YAML::Key << "reactors" << YAML::Flow;
+    yml << YAML::BeginSeq << m_in->name() << m_out->name() << YAML::EndSeq;
     yml << YAML::EndMap;
     yml << YAML::EndMap;
 

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -11,10 +11,15 @@
 namespace Cantera
 {
 
-FlowDevice::FlowDevice() : m_mdot(Undef), m_pfunc(0), m_tfunc(0),
-                           m_coeff(1.0), m_type(0),
-                           m_nspin(0), m_nspout(0),
-                           m_in(0), m_out(0) {}
+FlowDevice::FlowDevice(const std::string& name) :
+    m_mdot(Undef),
+    m_pfunc(0), m_tfunc(0),
+    m_coeff(1.0), m_type(0),
+    m_nspin(0), m_nspout(0),
+    m_in(0), m_out(0)
+{
+    m_name = name;
+}
 
 bool FlowDevice::install(ReactorBase& in, ReactorBase& out)
 {
@@ -52,14 +57,13 @@ std::string FlowDevice::toYAML() const
     YAML::Emitter yml;
     std::stringstream out;
 
-    // object is not aware of its unique identifier
     yml << YAML::BeginMap;
-    yml << YAML::Key << "type";
-    yml << YAML::Value << typeStr();
-    yml << YAML::Key << "in";
-    yml << YAML::Value << m_in->name();
-    yml << YAML::Key << "out";
-    yml << YAML::Value << m_out->name();
+    yml << YAML::Key << name();
+    yml << YAML::BeginMap;
+    yml << YAML::Key << "type" << YAML::Value << typeStr();
+    yml << YAML::Key << "in" << YAML::Value << m_in->name();
+    yml << YAML::Key << "out" << YAML::Value << m_out->name();
+    yml << YAML::EndMap;
     yml << YAML::EndMap;
 
     out << yml.c_str();

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -18,7 +18,6 @@ namespace bmt = boost::math::tools;
 namespace Cantera
 {
 Reactor::Reactor() :
-    m_kin(0),
     m_vdot(0.0),
     m_Q(0.0),
     m_mass(0.0),

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -1,3 +1,4 @@
+
 //! @file ReactorBase.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
@@ -7,6 +8,7 @@
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/zeroD/ReactorSurface.h"
+#include "cantera/thermo/SurfPhase.h"
 #include "cantera/base/yaml.h"
 
 using namespace std;
@@ -57,16 +59,13 @@ std::string ReactorBase::toYAML() const
     yml << YAML::BeginMap;
     yml << YAML::Key << "type";
     yml << YAML::Value << typeStr();
-    if (m_thermo) {
-        yml << YAML::Key << "phase";
-        yml << YAML::Value << m_thermo->name();
-        yml << YAML::Key << "thermo.type";
-        yml << YAML::Value << m_thermo->type();
+    yml << YAML::Key << "phases" << YAML::Flow;
+    yml << YAML::BeginSeq;
+    yml << m_thermo->name();
+    for (const auto& s : m_surfaces) {
+        yml << s->thermo()->name();
     }
-    if (m_kin) {
-        yml << YAML::Key << "kinetics.type";
-        yml << YAML::Value << m_kin->kineticsType();
-    }
+    yml << YAML::EndSeq;
     yml << YAML::EndMap;
     yml << YAML::EndMap;
 

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -26,7 +26,7 @@ ReactorBase::ReactorBase(const string& name) :
     m_name = name;
 }
 
-void ReactorBase::setThermoMgr(thermo_t& thermo)
+void ReactorBase::setThermoMgr(ThermoPhase& thermo)
 {
     m_thermo = &thermo;
     m_nsp = m_thermo->nSpecies();

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -7,6 +7,7 @@
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/zeroD/ReactorSurface.h"
+#include "cantera/base/yaml.h"
 
 using namespace std;
 namespace Cantera
@@ -42,6 +43,25 @@ void ReactorBase::syncState()
     if (m_net) {
         m_net->setNeedsReinit();
     }
+}
+
+std::string ReactorBase::toYAML() const
+{
+    YAML::Emitter yml;
+    std::stringstream out;
+
+    yml << YAML::BeginMap;
+    yml << YAML::Key << name();
+    yml << YAML::BeginMap;
+    yml << YAML::Key << "type";
+    yml << YAML::Value << typeStr();
+    yml << YAML::Key << "thermo";
+    yml << YAML::Value << m_thermo->name();
+    yml << YAML::EndMap;
+    yml << YAML::EndMap;
+
+    out << yml.c_str();
+    return out.str();
 }
 
 void ReactorBase::addInlet(FlowDevice& inlet)

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -13,8 +13,10 @@ using namespace std;
 namespace Cantera
 {
 
-ReactorBase::ReactorBase(const string& name) : m_nsp(0),
+ReactorBase::ReactorBase(const string& name) :
+    m_nsp(0),
     m_thermo(0),
+    m_kin(0),
     m_vol(1.0),
     m_enthalpy(0.0),
     m_intEnergy(0.0),
@@ -55,8 +57,16 @@ std::string ReactorBase::toYAML() const
     yml << YAML::BeginMap;
     yml << YAML::Key << "type";
     yml << YAML::Value << typeStr();
-    yml << YAML::Key << "thermo";
-    yml << YAML::Value << m_thermo->name();
+    if (m_thermo) {
+        yml << YAML::Key << "phase";
+        yml << YAML::Value << m_thermo->name();
+        yml << YAML::Key << "thermo.type";
+        yml << YAML::Value << m_thermo->type();
+    }
+    if (m_kin) {
+        yml << YAML::Key << "kinetics.type";
+        yml << YAML::Value << m_kin->kineticsType();
+    }
     yml << YAML::EndMap;
     yml << YAML::EndMap;
 

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -41,14 +41,10 @@ std::string uniqueName(void const *ptr) {
 std::string ReactorNet::toYAML() const
 {
     YAML::Emitter yml;
-    yml.SetIndent(1);
-    std::string name;
     std::stringstream out;
 
-    // components: using generic pointers
+    // components: maps use generic pointers
     std::map<std::string, ReactorBase* > reactors;
-    std::map<std::string, thermo_t* > phases;
-    std::map<std::string, Kinetics* > kinetics; // <-- needed
     std::map<std::string, WallBase* > walls;
     std::map<std::string, FlowDevice*> devices;
     std::map<std::string, ReactorSurface*> surfaces;
@@ -101,45 +97,13 @@ std::string ReactorNet::toYAML() const
 
             ReactorSurface* surface = rb->surface(i);
             surfaces.emplace(uniqueName((void const *)surface), surface);
-
-            // missing: surface phase & kinetics
         }
     }
-
-    // gas phases
-    for (const auto& r : reactors) {
-
-        // missing: kinetics
-        thermo_t& contents = r.second->contents();
-        phases.emplace(uniqueName((void const *)(&contents)), &contents);
-    }
-
-    // // surface phases
-    // for (const auto& s : surfaces) {
-
-    //     missing: kinetics
-    //     SurfPhase* thermo = s.second->thermo();
-    //     phases.emplace(uniqueName((void const *)thermo), thermo);
-    // }
 
     // header
     yml << YAML::BeginMap;
     yml << YAML::Key << "ReactorNet";
     yml << YAML::BeginMap;
-
-    // emit list of thermo phases
-    yml << YAML::Key << "t_thermo";
-    yml << YAML::Value << YAML::BeginSeq;
-    for (const auto& p : phases) {
-        yml << YAML::BeginMap;
-        yml << YAML::Key << p.first;
-        yml << YAML::BeginMap;
-        yml << YAML::Key << "type";
-        yml << YAML::Value << p.second->type();
-        yml << YAML::EndMap;
-        yml << YAML::EndMap;
-    }
-    yml << YAML::EndSeq;
 
     // emit list of reactors
     yml << YAML::Key << "ReactorBase";
@@ -154,10 +118,7 @@ std::string ReactorNet::toYAML() const
         yml << YAML::Key << "WallBase";
         yml << YAML::Value << YAML::BeginSeq;
         for (const auto& w : walls) {
-            yml << YAML::BeginMap;
-            yml << YAML::Key << w.first;
             yml << YAML::Load(w.second->toYAML());
-            yml << YAML::EndMap;
         }
         yml << YAML::EndSeq;
     }
@@ -167,10 +128,7 @@ std::string ReactorNet::toYAML() const
         yml << YAML::Key << "FlowDevice";
         yml << YAML::Value << YAML::BeginSeq;
         for (const auto& d : devices) {
-            yml << YAML::BeginMap;
-            yml << YAML::Key << d.first;
             yml << YAML::Load(d.second->toYAML());
-            yml << YAML::EndMap;
         }
         yml << YAML::EndSeq;
     }
@@ -180,10 +138,7 @@ std::string ReactorNet::toYAML() const
         yml << YAML::Key << "ReactorSurface";
         yml << YAML::Value << YAML::BeginSeq;
         for (const auto& s : surfaces) {
-            yml << YAML::BeginMap;
-            yml << YAML::Key << s.first;
             yml << YAML::Load(s.second->toYAML());
-            yml << YAML::EndMap;
         }
         yml << YAML::EndSeq;
     }

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -48,7 +48,7 @@ std::string ReactorNet::toYAML() const
     std::map<std::string, ReactorBase* > reactors;
     std::map<std::string, WallBase* > walls;
     std::map<std::string, FlowDevice*> devices;
-    std::map<std::string, ReactorSurface*> surfaces;
+    // std::map<std::string, ReactorSurface*> surfaces;
 
     // construct complete maps
     for (auto r=m_reactors.begin(); r!=m_reactors.end(); r++) {
@@ -93,21 +93,21 @@ std::string ReactorNet::toYAML() const
             reactors.emplace(uniqueName((void const *)(&out)), &out);
         }
 
-        // surfaces
-        for (size_t i=0; i<rb->nSurfaces(); i++) {
+        // // surfaces
+        // for (size_t i=0; i<rb->nSurfaces(); i++) {
 
-            ReactorSurface* surface = rb->surface(i);
-            surfaces.emplace(uniqueName((void const *)surface), surface);
-        }
+        //     ReactorSurface* surface = rb->surface(i);
+        //     surfaces.emplace(uniqueName((void const *)surface), surface);
+        // }
     }
 
     // header
     yml << YAML::BeginMap;
-    yml << YAML::Key << "ReactorNet";
+    yml << YAML::Key << "reactor-network";
     yml << YAML::BeginMap;
 
     // emit list of reactors
-    yml << YAML::Key << "ReactorBase";
+    yml << YAML::Key << "reactors";
     yml << YAML::Value << YAML::BeginSeq;
     for (const auto& r : reactors) {
         names.emplace(r.second->name(), r.first);
@@ -122,7 +122,7 @@ std::string ReactorNet::toYAML() const
     // emit list of walls
     names.clear();
     if (walls.size()) {
-        yml << YAML::Key << "WallBase";
+        yml << YAML::Key << "walls";
         yml << YAML::Value << YAML::BeginSeq;
         for (const auto& w : walls) {
             names.emplace(w.second->name(), w.first);
@@ -138,7 +138,7 @@ std::string ReactorNet::toYAML() const
     // emit list of flow devices
     names.clear();
     if (devices.size()) {
-        yml << YAML::Key << "FlowDevice";
+        yml << YAML::Key << "flow-devices";
         yml << YAML::Value << YAML::BeginSeq;
         for (const auto& d : devices) {
             names.emplace(d.second->name(), d.first);
@@ -151,21 +151,21 @@ std::string ReactorNet::toYAML() const
         throw CanteraError("ReactorNet::toYAML", "FlowDevice names are not unique.");
     }
 
-    // emit list of reactor surfaces
-    names.clear();
-    if (surfaces.size()) {
-        yml << YAML::Key << "ReactorSurface";
-        yml << YAML::Value << YAML::BeginSeq;
-        for (const auto& s : surfaces) {
-            names.emplace(s.second->name(), s.first);
-            yml << YAML::Load(s.second->toYAML());
-        }
-        yml << YAML::EndSeq;
-    }
-    if (names.size()!=surfaces.size()) {
-        // this should raise a warning, but an applicable warning system is not in place
-        throw CanteraError("ReactorNet::toYAML", "ReactorSurface names are not unique.");
-    }
+    // // emit list of reactor surfaces
+    // names.clear();
+    // if (surfaces.size()) {
+    //     yml << YAML::Key << "ReactorSurface";
+    //     yml << YAML::Value << YAML::BeginSeq;
+    //     for (const auto& s : surfaces) {
+    //         names.emplace(s.second->name(), s.first);
+    //         yml << YAML::Load(s.second->toYAML());
+    //     }
+    //     yml << YAML::EndSeq;
+    // }
+    // if (names.size()!=surfaces.size()) {
+    //     // this should raise a warning, but an applicable warning system is not in place
+    //     throw CanteraError("ReactorNet::toYAML", "ReactorSurface names are not unique.");
+    // }
 
     // close out
     yml << YAML::EndMap;

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -6,6 +6,7 @@
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/Wall.h"
+#include "cantera/base/yaml.h"
 
 #include <cstdio>
 
@@ -28,6 +29,170 @@ ReactorNet::ReactorNet() :
     // numerically, and use a Newton linear iterator
     m_integ->setMethod(BDF_Method);
     m_integ->setProblemType(DENSE + NOJAC);
+}
+
+std::string uniqueName(void const *ptr) {
+    // use pointer address as unique name
+    std::ostringstream address;
+    address << ptr;
+    return address.str();
+}
+
+std::string ReactorNet::toYAML() const
+{
+    YAML::Emitter yml;
+    yml.SetIndent(1);
+    std::string name;
+    std::stringstream out;
+
+    // components: using generic pointers
+    std::map<std::string, ReactorBase* > reactors;
+    std::map<std::string, thermo_t* > phases;
+    std::map<std::string, Kinetics* > kinetics; // <-- needed
+    std::map<std::string, WallBase* > walls;
+    std::map<std::string, FlowDevice*> devices;
+    std::map<std::string, ReactorSurface*> surfaces;
+
+    // construct complete maps
+    for (auto r=m_reactors.begin(); r!=m_reactors.end(); r++) {
+
+        // insert reactor (emplace ensures that it remains unique)
+        ReactorBase* rb = *r;
+        reactors.emplace(uniqueName((void const *)rb), rb);
+
+        // walls
+        for (size_t i=0; i<rb->nWalls(); i++) {
+
+            // wall has reactor to left and right
+            WallBase& wall = rb->wall(i);
+            walls.emplace(uniqueName((void const *)(&wall)), &wall);
+
+            ReactorBase& rl = wall.left();
+            reactors.emplace(uniqueName((void const *)(&rl)), &rl);
+
+            ReactorBase& rr = wall.right();
+            reactors.emplace(uniqueName((void const *)(&rr)), &rr);
+        }
+
+        // inlets
+        for (size_t i=0; i<rb->nInlets(); i++) {
+
+            // flow devices at inlet have inlets
+            FlowDevice& inlet = rb->inlet(i);
+            devices.emplace(uniqueName((void const *)(&inlet)), &inlet);
+
+            ReactorBase& in = inlet.in();
+            reactors.emplace(uniqueName((void const *)(&in)), &in);
+        }
+
+        // outlets
+        for (size_t i=0; i<rb->nOutlets(); i++) {
+
+            // flow devices at outlet have outlets
+            FlowDevice& outlet = rb->outlet(i);
+            devices.emplace(uniqueName((void const *)(&outlet)), &outlet);
+
+            ReactorBase& out = outlet.out();
+            reactors.emplace(uniqueName((void const *)(&out)), &out);
+        }
+
+        // surfaces
+        for (size_t i=0; i<rb->nSurfaces(); i++) {
+
+            ReactorSurface* surface = rb->surface(i);
+            surfaces.emplace(uniqueName((void const *)surface), surface);
+
+            // missing: surface phase & kinetics
+        }
+    }
+
+    // gas phases
+    for (const auto& r : reactors) {
+
+        // missing: kinetics
+        thermo_t& contents = r.second->contents();
+        phases.emplace(uniqueName((void const *)(&contents)), &contents);
+    }
+
+    // // surface phases
+    // for (const auto& s : surfaces) {
+
+    //     missing: kinetics
+    //     SurfPhase* thermo = s.second->thermo();
+    //     phases.emplace(uniqueName((void const *)thermo), thermo);
+    // }
+
+    // header
+    yml << YAML::BeginMap;
+    yml << YAML::Key << "ReactorNet";
+    yml << YAML::BeginMap;
+
+    // emit list of thermo phases
+    yml << YAML::Key << "t_thermo";
+    yml << YAML::Value << YAML::BeginSeq;
+    for (const auto& p : phases) {
+        yml << YAML::BeginMap;
+        yml << YAML::Key << p.first;
+        yml << YAML::BeginMap;
+        yml << YAML::Key << "type";
+        yml << YAML::Value << p.second->type();
+        yml << YAML::EndMap;
+        yml << YAML::EndMap;
+    }
+    yml << YAML::EndSeq;
+
+    // emit list of reactors
+    yml << YAML::Key << "ReactorBase";
+    yml << YAML::Value << YAML::BeginSeq;
+    for (const auto& r : reactors) {
+        yml << YAML::Load(r.second->toYAML());
+    }
+    yml << YAML::EndSeq;
+
+    // emit list of walls
+    if (walls.size()) {
+        yml << YAML::Key << "WallBase";
+        yml << YAML::Value << YAML::BeginSeq;
+        for (const auto& w : walls) {
+            yml << YAML::BeginMap;
+            yml << YAML::Key << w.first;
+            yml << YAML::Load(w.second->toYAML());
+            yml << YAML::EndMap;
+        }
+        yml << YAML::EndSeq;
+    }
+
+    // emit list of flow devices
+    if (devices.size()) {
+        yml << YAML::Key << "FlowDevice";
+        yml << YAML::Value << YAML::BeginSeq;
+        for (const auto& d : devices) {
+            yml << YAML::BeginMap;
+            yml << YAML::Key << d.first;
+            yml << YAML::Load(d.second->toYAML());
+            yml << YAML::EndMap;
+        }
+        yml << YAML::EndSeq;
+    }
+
+    // emit list of reactor surfaces
+    if (surfaces.size()) {
+        yml << YAML::Key << "ReactorSurface";
+        yml << YAML::Value << YAML::BeginSeq;
+        for (const auto& s : surfaces) {
+            yml << YAML::BeginMap;
+            yml << YAML::Key << s.first;
+            yml << YAML::Load(s.second->toYAML());
+            yml << YAML::EndMap;
+        }
+        yml << YAML::EndSeq;
+    }
+
+    // close out
+    yml << YAML::EndMap;
+    yml << YAML::EndMap;
+    out << yml.c_str();
+    return out.str();
 }
 
 void ReactorNet::setInitialTime(double time)

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -42,6 +42,7 @@ std::string ReactorNet::toYAML() const
 {
     YAML::Emitter yml;
     std::stringstream out;
+    std::map<std::string, std::string> names;
 
     // components: maps use generic pointers
     std::map<std::string, ReactorBase* > reactors;
@@ -109,38 +110,61 @@ std::string ReactorNet::toYAML() const
     yml << YAML::Key << "ReactorBase";
     yml << YAML::Value << YAML::BeginSeq;
     for (const auto& r : reactors) {
+        names.emplace(r.second->name(), r.first);
         yml << YAML::Load(r.second->toYAML());
     }
     yml << YAML::EndSeq;
+    if (names.size()!=reactors.size()) {
+        // this should raise a warning, but an applicable warning system is not in place
+        throw CanteraError("ReactorNet::toYAML", "ReactorBase names are not unique.");
+    }
 
     // emit list of walls
+    names.clear();
     if (walls.size()) {
         yml << YAML::Key << "WallBase";
         yml << YAML::Value << YAML::BeginSeq;
         for (const auto& w : walls) {
+            names.emplace(w.second->name(), w.first);
             yml << YAML::Load(w.second->toYAML());
         }
         yml << YAML::EndSeq;
     }
+    if (names.size()!=walls.size()) {
+        // this should raise a warning, but an applicable warning system is not in place
+        throw CanteraError("ReactorNet::toYAML", "Wall names are not unique.");
+    }
 
     // emit list of flow devices
+    names.clear();
     if (devices.size()) {
         yml << YAML::Key << "FlowDevice";
         yml << YAML::Value << YAML::BeginSeq;
         for (const auto& d : devices) {
+            names.emplace(d.second->name(), d.first);
             yml << YAML::Load(d.second->toYAML());
         }
         yml << YAML::EndSeq;
     }
+    if (names.size()!=devices.size()) {
+        // this should raise a warning, but an applicable warning system is not in place
+        throw CanteraError("ReactorNet::toYAML", "FlowDevice names are not unique.");
+    }
 
     // emit list of reactor surfaces
+    names.clear();
     if (surfaces.size()) {
         yml << YAML::Key << "ReactorSurface";
         yml << YAML::Value << YAML::BeginSeq;
         for (const auto& s : surfaces) {
+            names.emplace(s.second->name(), s.first);
             yml << YAML::Load(s.second->toYAML());
         }
         yml << YAML::EndSeq;
+    }
+    if (names.size()!=surfaces.size()) {
+        // this should raise a warning, but an applicable warning system is not in place
+        throw CanteraError("ReactorNet::toYAML", "ReactorSurface names are not unique.");
     }
 
     // close out

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -7,6 +7,7 @@
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/kinetics/Kinetics.h"
+#include "cantera/base/yaml.h"
 
 namespace Cantera
 {
@@ -17,6 +18,25 @@ ReactorSurface::ReactorSurface()
     , m_kinetics(nullptr)
     , m_reactor(nullptr)
 {
+}
+
+std::string ReactorSurface::toYAML() const
+{
+    YAML::Emitter yml;
+    std::stringstream out;
+
+    // yml << YAML::BeginMap;
+    // yml << YAML::Key << name();
+    yml << YAML::BeginMap;
+    // yml << YAML::Key << "type";
+    // yml << YAML::Value << typeStr();
+    yml << YAML::Key << "thermo";
+    yml << YAML::Value << m_thermo->name();
+    yml << YAML::EndMap;
+    //yml << YAML::EndMap;
+
+    out << yml.c_str();
+    return out.str();
 }
 
 double ReactorSurface::area() const

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -12,12 +12,13 @@
 namespace Cantera
 {
 
-ReactorSurface::ReactorSurface()
-    : m_area(1.0)
-    , m_thermo(nullptr)
-    , m_kinetics(nullptr)
-    , m_reactor(nullptr)
+ReactorSurface::ReactorSurface(const std::string& name) :
+    m_area(1.0),
+    m_thermo(nullptr),
+    m_kinetics(nullptr),
+    m_reactor(nullptr)
 {
+    m_name = name;
 }
 
 std::string ReactorSurface::toYAML() const
@@ -25,15 +26,16 @@ std::string ReactorSurface::toYAML() const
     YAML::Emitter yml;
     std::stringstream out;
 
-    // yml << YAML::BeginMap;
-    // yml << YAML::Key << name();
     yml << YAML::BeginMap;
-    // yml << YAML::Key << "type";
-    // yml << YAML::Value << typeStr();
-    yml << YAML::Key << "thermo";
-    yml << YAML::Value << m_thermo->name();
+    yml << YAML::Key << name();
+    yml << YAML::BeginMap;
+    yml << YAML::Key << "type" << YAML::Value << type();
+    yml << YAML::Key << "reactor" << YAML::Value << m_reactor->name();
+    yml << YAML::Key << "phase" << YAML::Value << m_thermo->name();
+    yml << YAML::Key << "thermo.type" << YAML::Value << m_thermo->type();
+    yml << YAML::Key << "kinetics.type" << YAML::Value << m_kinetics->kineticsType();
     yml << YAML::EndMap;
-    //yml << YAML::EndMap;
+    yml << YAML::EndMap;
 
     out << yml.c_str();
     return out.str();

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -7,6 +7,7 @@
 #include "cantera/numerics/Func1.h"
 #include "cantera/zeroD/Wall.h"
 #include "cantera/thermo/SurfPhase.h"
+#include "cantera/base/yaml.h"
 
 namespace Cantera
 {
@@ -26,6 +27,25 @@ bool WallBase::install(ReactorBase& rleft, ReactorBase& rright)
     m_surf[0].setReactor(&rleft);
     m_surf[1].setReactor(&rright);
     return true;
+}
+
+std::string WallBase::toYAML() const
+{
+    YAML::Emitter yml;
+    std::stringstream out;
+
+    // object is not aware of its unique identifier
+    yml << YAML::BeginMap;
+    yml << YAML::Key << "type";
+    yml << YAML::Value << type();
+    yml << YAML::Key << "left";
+    yml << YAML::Value << m_left->name();
+    yml << YAML::Key << "right";
+    yml << YAML::Value << m_right->name();
+    yml << YAML::EndMap;
+
+    out << yml.c_str();
+    return out.str();
 }
 
 void WallBase::setArea(double a) {

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -42,8 +42,8 @@ std::string WallBase::toYAML() const
     yml << YAML::Key << name();
     yml << YAML::BeginMap;
     yml << YAML::Key << "type" << YAML::Value << type();
-    yml << YAML::Key << "left" << YAML::Value << m_left->name();
-    yml << YAML::Key << "right" << YAML::Value << m_right->name();
+    yml << YAML::Key << "reactors" << YAML::Flow;
+    yml << YAML::BeginSeq << m_left->name() << m_right->name() << YAML::EndSeq;
     yml << YAML::EndMap;
     yml << YAML::EndMap;
 

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -12,7 +12,11 @@
 namespace Cantera
 {
 
-WallBase::WallBase() : m_left(0), m_right(0), m_surf(2), m_area(1.0) {}
+WallBase::WallBase(const std::string& name) :
+    m_left(0), m_right(0), m_surf(2), m_area(1.0)
+{
+    m_name = name;
+}
 
 bool WallBase::install(ReactorBase& rleft, ReactorBase& rright)
 {
@@ -34,14 +38,13 @@ std::string WallBase::toYAML() const
     YAML::Emitter yml;
     std::stringstream out;
 
-    // object is not aware of its unique identifier
     yml << YAML::BeginMap;
-    yml << YAML::Key << "type";
-    yml << YAML::Value << type();
-    yml << YAML::Key << "left";
-    yml << YAML::Value << m_left->name();
-    yml << YAML::Key << "right";
-    yml << YAML::Value << m_right->name();
+    yml << YAML::Key << name();
+    yml << YAML::BeginMap;
+    yml << YAML::Key << "type" << YAML::Value << type();
+    yml << YAML::Key << "left" << YAML::Value << m_left->name();
+    yml << YAML::Key << "right" << YAML::Value << m_right->name();
+    yml << YAML::EndMap;
     yml << YAML::EndMap;
 
     out << yml.c_str();


### PR DESCRIPTION
This PR proposes a self-documenting YAML structure for `ReactorNet` objects that is generated *dynamically* in the C++ layer via `yaml-cpp`. While the initial PR simply displays the structure, the idea can be extended to (re-)create `ReactorNet` objects from YAML files, which would also enable pickling for multiprocessing purposes.

Partially addresses #570

#### Proposed Changes

- Use YAML to illustrate the structure of a `ReactorNet` (native using `yaml-cpp`)
- Incremental changes:
  - Add `type` and `name` attributes to `ReactorSurface`
  - Ensure that automatically generated names are unique (Cython)
  - Ensure that names for `FlowDevice`, `Wall` and `ReactorSurface` are correctly passed between python and C++

#### Illustration

```python
gas = ct.Solution('h2o2.cti')
reactor = ct.Reactor(gas, name='reactor')
reservoir = ct.Reservoir(gas, name='reservoir')
mfc = ct.MassFlowController(reservoir, reactor, name='mfc')
sim = ct.ReactorNet([reactor])
sim()
```
produces
```yaml
reactor-network:
  reactors:
    - reservoir:
        type: Reservoir
        phases: [ohmech]
    - reactor:
        type: Reactor
        phases: [ohmech]
  flow-devices:
    - mfc:
        type: MassFlowController
        reactors: [reservoir, reactor]
```

More involved setups are avaliable in examples, where `ic_engine.py` and `surf_pfr.py` are good test cases as they involve non-trivial `ReactorNet` configurations.

#### Thoughts

An extension of this idea that includes simulation parameters and setup details is straight forward, and would allow for serialization/pickling of `ReactorNet` objects. However, this task remains dependent on some code changes that are beyond the scope of this PR and thus should be handled separately.

Main issues that are beyond the scope of this PR:
- Serialization of `Func1` objects
- Differences in Cython `Solution` handler approach and C++ thermo/kinetics managers.
- The implementation of `ReactorSurface` is an outlier.
