### PR TITLE
Fix Chebyshev rate evaluation with only 1 point in T or P

### DIFF
--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -364,13 +364,13 @@ public:
     //! @param c base-10 logarithm of the pressure in Pa
     void update_C(const doublereal* c) {
         double Pr = (2 * c[0] + PrNum_) * PrDen_;
-        double Cnm1 = 1;
-        double Cn = Pr;
+        double Cnm1 = Pr;
+        double Cn = 1;
         double Cnp1;
         for (size_t j = 0; j < nT_; j++) {
-            dotProd_[j] = chebCoeffs_[nP_*j] + Pr * chebCoeffs_[nP_*j+1];
+            dotProd_[j] = chebCoeffs_[nP_*j];
         }
-        for (size_t i = 2; i < nP_; i++) {
+        for (size_t i = 1; i < nP_; i++) {
             Cnp1 = 2 * Pr * Cn - Cnm1;
             for (size_t j = 0; j < nT_; j++) {
                 dotProd_[j] += Cnp1 * chebCoeffs_[nP_*j + i];
@@ -387,11 +387,11 @@ public:
      */
     doublereal updateRC(doublereal logT, doublereal recipT) const {
         double Tr = (2 * recipT + TrNum_) * TrDen_;
-        double Cnm1 = 1;
-        double Cn = Tr;
+        double Cnm1 = Tr;
+        double Cn = 1;
         double Cnp1;
-        double logk = dotProd_[0] + Tr * dotProd_[1];
-        for (size_t i = 2; i < nT_; i++) {
+        double logk = dotProd_[0];
+        for (size_t i = 1; i < nT_; i++) {
             Cnp1 = 2 * Tr * Cn - Cnm1;
             logk += Cnp1 * dotProd_[i];
             Cnm1 = Cn;

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -1592,6 +1592,12 @@ class chebyshev_reaction(reaction):
             del self._r['m)']
             del self._p['m)']
 
+        nP = len(self.coeffs[0])
+        for line in self.coeffs:
+            if len(line) != nP:
+                raise CTI_Error('Each row of Chebyshev coefficients must '
+                    'contain the same number of values.')
+
     def build(self, p):
         r = reaction.build(self, p)
         kfnode = r.child('rateCoeff')

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -991,6 +991,34 @@ class TestReaction(utilities.CanteraTest):
             self.assertNear(gas1.reaction(i)(gas1.T, gas1.P),
                             gas1.forward_rate_constants[i])
 
+    def test_chebyshev_bad_shape_cti(self):
+        with self.assertRaisesRegex(ct.CanteraError, "same number"):
+            r = ct.Reaction.fromCti('''
+                chebyshev_reaction('R5 + H (+ M) <=> P5A + P5B (+M)',
+                   Tmin=300.0, Tmax=2000.0,
+                   Pmin=(0.00986, 'atm'), Pmax=(98.6, 'atm'),
+                   coeffs=[[ 8.28830e+00, -1.13970e+00, -1.20590e-01],
+                           [ 1.97640e+00,  1.00370e+00,  7.28650e-03, -3.04320e-02],
+                           [ 3.17700e-01,  2.68890e-01,  9.48060e-02, -7.63850e-03],
+                           [-3.12850e-02, -3.94120e-02,  4.43750e-02,  1.44580e-02]])''')
+
+    def test_chebyshev_bad_shape_yaml(self):
+        species = ct.Species.listFromFile('pdep-test.xml')
+        gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
+                          species=species, reactions=[])
+
+        with self.assertRaisesRegex(ct.CanteraError, "Inconsistent"):
+            r = ct.Reaction.fromYaml('''
+                equation: R5 + H (+ M) <=> P5A + P5B (+M)
+                type: Chebyshev
+                temperature-range: [300.0, 2000.0]
+                pressure-range: [9.86e-03 atm, 98.6 atm]
+                data:
+                - [8.2883, -1.1397, -0.12059, 0.016034]
+                - [1.9764, 1.0037, 7.2865e-03]
+                - [0.3177, 0.26889, 0.094806, -7.6385e-03]
+                - [-0.031285, -0.039412, 0.044375, 0.014458]''', gas)
+
     def test_interface(self):
         surf_species = ct.Species.listFromFile('ptcombust.xml')
         gas = ct.Solution('ptcombust.xml', 'gas')

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -759,6 +759,10 @@ void setupChebyshevReaction(ChebyshevReaction&R, const AnyMap& node,
     auto& vcoeffs = node["data"].asVector<vector_fp>();
     Array2D coeffs(vcoeffs.size(), vcoeffs[0].size());
     for (size_t i = 0; i < coeffs.nRows(); i++) {
+        if (vcoeffs[i].size() != vcoeffs[0].size()) {
+            throw InputFileError("setupChebyshevReaction", node["data"],
+                "Inconsistent number of coefficients in row {} of matrix", i + 1);
+        }
         for (size_t j = 0; j < coeffs.nColumns(); j++) {
             coeffs(i, j) = vcoeffs[i][j];
         }


### PR DESCRIPTION
The Chebyshev rate evaluation code assumed that the Chebyshev polynomials were of degree 2 or higher in both the temperature and pressure dimension. This fixes evaluation in the case where either (or both) are of degree 1.

Also adds some checks to make sure that the same number of values is specified in each row of the coefficient matrix in the input file.

Fixes an issue identified in a [post on the User's Group](https://groups.google.com/forum/?fromgroups=#!topic/cantera-users/MCyr0NDU_CY).