### PR TITLE
[cti2yaml] Add failing ch4_ion test

### DIFF
--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1098,6 +1098,9 @@ class phase:
         if 'skip_undeclared_elements' in self.options:
             out['skip-undeclared-elements'] = True
 
+        if 'skip_undeclared_third_bodies' in self.options:
+            out['skip-undeclared-third-bodies'] = True
+
         # Convert reaction pattern matching to use of multiple reaction sections
         for i in range(len(self.reactions)):
             spec = self.reactions[i][1]

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -98,7 +98,7 @@ _newNames = {
     'Edge': 'edge',
     'Mix': 'mixture-averaged',
     'Multi': 'multicomponent',
-    'Ion': 'ion',
+    'Ion': 'ionized-gas',
     'molar_volume': 'species-molar-volume',
     'solvent_volume': 'solvent-molar-volume',
     'unity': 'unity'

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -762,3 +762,11 @@ class cti2yamlTest(utilities.CanteraTest):
         ctiMetal.electric_potential = yamlMetal.electric_potential = 2.2
         ctiElyt.electric_potential = yamlElyt.electric_potential = 0
         self.checkKinetics(ctiCathodeInt, yamlCathodeInt, [300], [1e5])
+
+    def test_ch4_ion(self):
+        cti2yaml.convert(Path(self.test_data_dir).joinpath("ch4_ion.cti"),
+                          Path(self.test_work_dir).joinpath("ch4_ion.yaml"))
+        ctiGas, yamlGas = self.checkConversion("ch4_ion")
+        self.checkThermo(ctiGas, yamlGas, [300, 500, 1300, 2000])
+        self.checkKinetics(ctiGas, yamlGas, [900, 1800], [2e5, 20e5])
+        self.checkTransport(ctiGas, yamlGas, [298, 1001, 2400])


### PR DESCRIPTION
Changes proposed in this pull request:
- Adds a test converting `ch4_ion.cti` to YAML format. The test fails because the phase option `'skip_undeclared_third_bodies'` is not handled

Just documenting this failure here so I don't forget while working on the `ctml2yaml`, and also to ask whether this is expected or not. Someone else can work up a fix if they want, or I'll get to it in a bit.
