### PR TITLE
Updated URL in references to Cantera's license.

### DIFF
--- a/include/cantera/Edge.h
+++ b/include/cantera/Edge.h
@@ -1,7 +1,7 @@
 //! @file Edge.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CXX_EDGE
 #define CXX_EDGE

--- a/include/cantera/IdealGasMix.h
+++ b/include/cantera/IdealGasMix.h
@@ -1,7 +1,7 @@
 //! @file IdealGasMix.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CXX_IDEALGASMIX
 #define CXX_IDEALGASMIX

--- a/include/cantera/IncompressibleSolid.h
+++ b/include/cantera/IncompressibleSolid.h
@@ -1,7 +1,7 @@
 //! @file IncompressibleSolid.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CXX_INCOMPRESSIBLE
 #define CXX_INCOMPRESSIBLE

--- a/include/cantera/Interface.h
+++ b/include/cantera/Interface.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CXX_INTERFACE
 #define CXX_INTERFACE

--- a/include/cantera/Metal.h
+++ b/include/cantera/Metal.h
@@ -1,7 +1,7 @@
 //! @file Metal.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CXX_METAL
 #define CXX_METAL

--- a/include/cantera/PureFluid.h
+++ b/include/cantera/PureFluid.h
@@ -1,7 +1,7 @@
 //! @file PureFluid.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CXX_PUREFLUID
 #define CXX_PUREFLUID

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -1,7 +1,7 @@
 //! @file AnyMap.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at https://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ANYMAP_H
 #define CT_ANYMAP_H

--- a/include/cantera/base/Array.h
+++ b/include/cantera/base/Array.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ARRAY_H
 #define CT_ARRAY_H

--- a/include/cantera/base/FactoryBase.h
+++ b/include/cantera/base/FactoryBase.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FACTORY_BASE
 #define CT_FACTORY_BASE

--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at https://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_UNITS_H
 #define CT_UNITS_H

--- a/include/cantera/base/ValueCache.h
+++ b/include/cantera/base/ValueCache.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_VALUECACHE_H
 #define CT_VALUECACHE_H

--- a/include/cantera/base/clockWC.h
+++ b/include/cantera/base/clockWC.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CLOCKWC_H
 #define CT_CLOCKWC_H

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CTEXCEPTIONS_H
 #define CT_CTEXCEPTIONS_H

--- a/include/cantera/base/ctml.h
+++ b/include/cantera/base/ctml.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CTML_H
 #define CT_CTML_H

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -14,7 +14,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_GLOBAL_H
 #define CT_GLOBAL_H

--- a/include/cantera/base/logger.h
+++ b/include/cantera/base/logger.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_LOGGER_H
 #define CT_LOGGER_H

--- a/include/cantera/base/plots.h
+++ b/include/cantera/base/plots.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PLOTS_H
 #define CT_PLOTS_H

--- a/include/cantera/base/stringUtils.h
+++ b/include/cantera/base/stringUtils.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_STRINGUTILS_H
 #define CT_STRINGUTILS_H

--- a/include/cantera/base/utilities.h
+++ b/include/cantera/base/utilities.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 /**
  * @defgroup utils Templated Utility Functions

--- a/include/cantera/base/xml.h
+++ b/include/cantera/base/xml.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_XML_H
 #define CT_XML_H

--- a/include/cantera/clib/clib_defs.h
+++ b/include/cantera/clib/clib_defs.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_DEFS_H
 #define CTC_DEFS_H

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_CT_H
 #define CTC_CT_H

--- a/include/cantera/clib/ctfunc.h
+++ b/include/cantera/clib/ctfunc.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_FUNC1_H
 #define CTC_FUNC1_H

--- a/include/cantera/clib/ctmultiphase.h
+++ b/include/cantera/clib/ctmultiphase.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_MULTIPHASE_H
 #define CTC_MULTIPHASE_H

--- a/include/cantera/clib/ctonedim.h
+++ b/include/cantera/clib/ctonedim.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_ONEDIM_H
 #define CTC_ONEDIM_H

--- a/include/cantera/clib/ctrpath.h
+++ b/include/cantera/clib/ctrpath.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_RXNPATH_H
 #define CTC_RXNPATH_H

--- a/include/cantera/clib/ctsurf.h
+++ b/include/cantera/clib/ctsurf.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_SURF_H
 #define CTC_SURF_H

--- a/include/cantera/clib/ctxml.h
+++ b/include/cantera/clib/ctxml.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CTC_XML_H
 #define CTC_XML_H

--- a/include/cantera/cython/funcWrapper.h
+++ b/include/cantera/cython/funcWrapper.h
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CYTHON_FUNC_WRAPPER
 #define CT_CYTHON_FUNC_WRAPPER

--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/logger.h"
 #include "cantera/thermo/ThermoPhase.h"

--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CHEM_EQUIL_H
 #define CT_CHEM_EQUIL_H

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTIPHASE_H
 #define CT_MULTIPHASE_H

--- a/include/cantera/equil/MultiPhaseEquil.h
+++ b/include/cantera/equil/MultiPhaseEquil.h
@@ -1,7 +1,7 @@
 //! @file MultiPhaseEquil.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTIPHASE_EQUIL
 #define CT_MULTIPHASE_EQUIL

--- a/include/cantera/equil/vcs_MultiPhaseEquil.h
+++ b/include/cantera/equil/vcs_MultiPhaseEquil.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef VCS_MULTIPHASEEQUIL_H
 #define VCS_MULTIPHASEEQUIL_H

--- a/include/cantera/equil/vcs_SpeciesProperties.h
+++ b/include/cantera/equil/vcs_SpeciesProperties.h
@@ -1,7 +1,7 @@
 //! @file vcs_SpeciesProperties.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef VCS_SPECIES_PROPERTIES_H
 #define VCS_SPECIES_PROPERTIES_H

--- a/include/cantera/equil/vcs_VolPhase.h
+++ b/include/cantera/equil/vcs_VolPhase.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef VCS_VOLPHASE_H
 #define VCS_VOLPHASE_H

--- a/include/cantera/equil/vcs_defs.h
+++ b/include/cantera/equil/vcs_defs.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef VCS_DEFS_H
 #define VCS_DEFS_H

--- a/include/cantera/equil/vcs_internal.h
+++ b/include/cantera/equil/vcs_internal.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef _VCS_INTERNAL_H
 #define _VCS_INTERNAL_H

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef _VCS_SOLVE_H
 #define _VCS_SOLVE_H

--- a/include/cantera/equil/vcs_species_thermo.h
+++ b/include/cantera/equil/vcs_species_thermo.h
@@ -1,7 +1,7 @@
 //! @file vcs_species_thermo.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef VCS_SPECIES_THERMO_H
 #define VCS_SPECIES_THERMO_H

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_BULKKINETICS_H
 #define CT_BULKKINETICS_H

--- a/include/cantera/kinetics/EdgeKinetics.h
+++ b/include/cantera/kinetics/EdgeKinetics.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_EDGEKINETICS_H
 #define CT_EDGEKINETICS_H

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FALLOFF_H
 #define CT_FALLOFF_H

--- a/include/cantera/kinetics/FalloffFactory.h
+++ b/include/cantera/kinetics/FalloffFactory.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_NEWFALLOFF_H
 #define CT_NEWFALLOFF_H

--- a/include/cantera/kinetics/FalloffMgr.h
+++ b/include/cantera/kinetics/FalloffMgr.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FALLOFFMGR_H
 #define CT_FALLOFFMGR_H

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_GASKINETICS_H
 #define CT_GASKINETICS_H

--- a/include/cantera/kinetics/Group.h
+++ b/include/cantera/kinetics/Group.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RXNPATH_GROUP
 #define CT_RXNPATH_GROUP

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IMPSURFCHEM_H
 #define CT_IMPSURFCHEM_H

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IFACEKINETICS_H
 #define CT_IFACEKINETICS_H

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_KINETICS_H
 #define CT_KINETICS_H

--- a/include/cantera/kinetics/KineticsFactory.h
+++ b/include/cantera/kinetics/KineticsFactory.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef KINETICS_FACTORY_H
 #define KINETICS_FACTORY_H

--- a/include/cantera/kinetics/RateCoeffMgr.h
+++ b/include/cantera/kinetics/RateCoeffMgr.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RATECOEFF_MGR_H
 #define CT_RATECOEFF_MGR_H

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REACTION_H
 #define CT_REACTION_H

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RXNPATH_H
 #define CT_RXNPATH_H

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RXNRATES_H
 #define CT_RXNRATES_H

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_STOICH_MGR_H
 #define CT_STOICH_MGR_H

--- a/include/cantera/kinetics/ThirdBodyCalc.h
+++ b/include/cantera/kinetics/ThirdBodyCalc.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_THIRDBODYCALC_H
 #define CT_THIRDBODYCALC_H

--- a/include/cantera/kinetics/importKinetics.h
+++ b/include/cantera/kinetics/importKinetics.h
@@ -11,7 +11,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IMPORTKINETICS_H
 #define CT_IMPORTKINETICS_H

--- a/include/cantera/kinetics/reaction_defs.h
+++ b/include/cantera/kinetics/reaction_defs.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RXN_DEFS_H
 #define CT_RXN_DEFS_H

--- a/include/cantera/kinetics/solveSP.h
+++ b/include/cantera/kinetics/solveSP.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef SOLVESP_H
 #define SOLVESP_H

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_BANDMATRIX_H
 #define CT_BANDMATRIX_H

--- a/include/cantera/numerics/DAE_Solver.h
+++ b/include/cantera/numerics/DAE_Solver.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DAE_Solver_H
 #define CT_DAE_Solver_H

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DENSEMATRIX_H
 #define CT_DENSEMATRIX_H

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FUNC1_H
 #define CT_FUNC1_H

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FUNCEVAL_H
 #define CT_FUNCEVAL_H

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_GENERALMATRIX_H
 #define CT_GENERALMATRIX_H

--- a/include/cantera/numerics/IDA_Solver.h
+++ b/include/cantera/numerics/IDA_Solver.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDA_SOLVER_H
 #define CT_IDA_SOLVER_H

--- a/include/cantera/numerics/ResidEval.h
+++ b/include/cantera/numerics/ResidEval.h
@@ -1,7 +1,7 @@
 //! @file ResidEval.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RESIDEVAL_H
 #define CT_RESIDEVAL_H

--- a/include/cantera/numerics/ResidJacEval.h
+++ b/include/cantera/numerics/ResidJacEval.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_RESIDJACEVAL_H
 #define CT_RESIDJACEVAL_H

--- a/include/cantera/numerics/ctlapack.h
+++ b/include/cantera/numerics/ctlapack.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CTLAPACK_H
 #define CT_CTLAPACK_H

--- a/include/cantera/numerics/funcs.h
+++ b/include/cantera/numerics/funcs.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FUNCS_H
 #define CT_FUNCS_H

--- a/include/cantera/numerics/polyfit.h
+++ b/include/cantera/numerics/polyfit.h
@@ -1,7 +1,7 @@
 //! @file polyfit.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_POLYFIT_H
 #define CT_POLYFIT_H

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -1,7 +1,7 @@
  //! @file Domain1D.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DOMAIN1D_H
 #define CT_DOMAIN1D_H

--- a/include/cantera/oneD/Inlet1D.h
+++ b/include/cantera/oneD/Inlet1D.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_BDRY1D_H
 #define CT_BDRY1D_H

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -1,7 +1,7 @@
 //! @file IonFlow.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IONFLOW_H
 #define CT_IONFLOW_H

--- a/include/cantera/oneD/MultiJac.h
+++ b/include/cantera/oneD/MultiJac.h
@@ -1,7 +1,7 @@
 //! @file MultiJac.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTIJAC_H
 #define CT_MULTIJAC_H

--- a/include/cantera/oneD/MultiNewton.h
+++ b/include/cantera/oneD/MultiNewton.h
@@ -1,7 +1,7 @@
 //! @file MultiNewton.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTINEWTON_H
 #define CT_MULTINEWTON_H

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ONEDIM_H
 #define CT_ONEDIM_H

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SIM1D_H
 #define CT_SIM1D_H

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -1,7 +1,7 @@
 //! @file StFlow.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_STFLOW_H
 #define CT_STFLOW_H

--- a/include/cantera/oneD/refine.h
+++ b/include/cantera/oneD/refine.h
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REFINE_H
 #define CT_REFINE_H

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at https://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_BINARYSOLUTIONTABULATEDTHERMO_H
 #define CT_BINARYSOLUTIONTABULATEDTHERMO_H

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CONSTCPPOLY_H
 #define CT_CONSTCPPOLY_H

--- a/include/cantera/thermo/ConstDensityThermo.h
+++ b/include/cantera/thermo/ConstDensityThermo.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CONSTRHOTHERMO_H
 #define CT_CONSTRHOTHERMO_H

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -9,7 +9,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DEBYEHUCKEL_H
 #define CT_DEBYEHUCKEL_H

--- a/include/cantera/thermo/EdgePhase.h
+++ b/include/cantera/thermo/EdgePhase.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_EDGEPHASE_H
 #define CT_EDGEPHASE_H

--- a/include/cantera/thermo/FixedChemPotSSTP.h
+++ b/include/cantera/thermo/FixedChemPotSSTP.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_FIXEDCHEMPOTSSTP_H
 #define CT_FIXEDCHEMPOTSSTP_H

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_GIBBSEXCESSVPSSTP_H
 #define CT_GIBBSEXCESSVPSSTP_H

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -10,7 +10,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_HMWSOLN_H
 #define CT_HMWSOLN_H

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDEALGASPHASE_H
 #define CT_IDEALGASPHASE_H

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -13,7 +13,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDEALMOLALSOLN_H
 #define CT_IDEALMOLALSOLN_H

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -8,7 +8,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDEALSOLIDSOLNPHASE_H
 #define CT_IDEALSOLIDSOLNPHASE_H

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -8,7 +8,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IDEALSOLNGASVPSS_H
 #define CT_IDEALSOLNGASVPSS_H

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_IONSFROMNEUTRALVPSSTP_H
 #define CT_IONSFROMNEUTRALVPSSTP_H

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_LATTICE_H
 #define CT_LATTICE_H

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_LATTICESOLID_H
 #define CT_LATTICESOLID_H

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MARGULESVPSSTP_H
 #define CT_MARGULESVPSSTP_H

--- a/include/cantera/thermo/MaskellSolidSolnPhase.h
+++ b/include/cantera/thermo/MaskellSolidSolnPhase.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MASKELLSOLIDSOLNPHASE_H
 #define CT_MASKELLSOLIDSOLNPHASE_H

--- a/include/cantera/thermo/MetalPhase.h
+++ b/include/cantera/thermo/MetalPhase.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_METALPHASE_H
 #define CT_METALPHASE_H

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MIXTUREFUGACITYTP_H
 #define CT_MIXTUREFUGACITYTP_H

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -13,7 +13,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MOLALITYVPSSTP_H
 #define CT_MOLALITYVPSSTP_H

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MU0POLY_H
 #define CT_MU0POLY_H

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTISPECIESTHERMO_H
 #define CT_MULTISPECIESTHERMO_H

--- a/include/cantera/thermo/Nasa9Poly1.h
+++ b/include/cantera/thermo/Nasa9Poly1.h
@@ -9,7 +9,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_NASA9POLY1_H
 #define CT_NASA9POLY1_H

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -11,7 +11,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_NASA9POLYMULTITEMPREGION_H
 #define CT_NASA9POLYMULTITEMPREGION_H

--- a/include/cantera/thermo/NasaPoly1.h
+++ b/include/cantera/thermo/NasaPoly1.h
@@ -9,7 +9,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_NASAPOLY1_H
 #define CT_NASAPOLY1_H

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -9,7 +9,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_NASAPOLY2_H
 #define CT_NASAPOLY2_H

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PDSS_H
 #define CT_PDSS_H

--- a/include/cantera/thermo/PDSSFactory.h
+++ b/include/cantera/thermo/PDSSFactory.h
@@ -1,7 +1,7 @@
 //! @file PDSSFactory.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef PDSS_FACTORY_H
 #define PDSS_FACTORY_H

--- a/include/cantera/thermo/PDSS_ConstVol.h
+++ b/include/cantera/thermo/PDSS_ConstVol.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PDSS_CONSTVOL_H
 #define CT_PDSS_CONSTVOL_H

--- a/include/cantera/thermo/PDSS_HKFT.h
+++ b/include/cantera/thermo/PDSS_HKFT.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PDSS_HKFT_H
 #define CT_PDSS_HKFT_H

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PDSS_IDEALGAS_H
 #define CT_PDSS_IDEALGAS_H

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PDSS_IONSFROMNEUTRAL_H
 #define CT_PDSS_IONSFROMNEUTRAL_H

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PDSS_SSVOL_H
 #define CT_PDSS_SSVOL_H

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PDSS_WATER_H
 #define CT_PDSS_WATER_H

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_PHASE_H
 #define CT_PHASE_H

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -9,7 +9,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_EOS_TPX_H
 #define CT_EOS_TPX_H

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REDLICHKISTERVPSSTP_H
 #define CT_REDLICHKISTERVPSSTP_H

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -1,7 +1,7 @@
 //! @file RedlichKwongMFTP.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REDLICHKWONGMFTP_H
 #define CT_REDLICHKWONGMFTP_H

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -9,7 +9,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SHOMATEPOLY1_H
 #define CT_SHOMATEPOLY1_H

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SINGLESPECIESTP_H
 #define CT_SINGLESPECIESTP_H

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -1,7 +1,7 @@
 //! @file Species.h Declaration for class Cantera::Species.
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SPECIES_H
 #define CT_SPECIES_H

--- a/include/cantera/thermo/SpeciesThermoFactory.h
+++ b/include/cantera/thermo/SpeciesThermoFactory.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef SPECIESTHERMO_FACTORY_H
 #define SPECIESTHERMO_FACTORY_H

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SPECIESTHERMOINTERPTYPE_H
 #define CT_SPECIESTHERMOINTERPTYPE_H

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_STOICHSUBSTANCE_H
 #define CT_STOICHSUBSTANCE_H

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_SURFPHASE_H
 #define CT_SURFPHASE_H

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef THERMO_FACTORY_H
 #define THERMO_FACTORY_H

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_THERMOPHASE_H
 #define CT_THERMOPHASE_H

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_VPSTANDARDSTATETP_H
 #define CT_VPSTANDARDSTATETP_H

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_WATERPROPS_H
 #define CT_WATERPROPS_H

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef WATERPROPSIAPWS_H
 #define WATERPROPSIAPWS_H

--- a/include/cantera/thermo/WaterPropsIAPWSphi.h
+++ b/include/cantera/thermo/WaterPropsIAPWSphi.h
@@ -8,7 +8,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef WATERPROPSIAPWSPHI_H
 #define WATERPROPSIAPWSPHI_H

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_WATERSSTP_H
 #define CT_WATERSSTP_H

--- a/include/cantera/thermo/electrolytes.h
+++ b/include/cantera/thermo/electrolytes.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ELECTROLYTES_H
 #define CT_ELECTROLYTES_H

--- a/include/cantera/thermo/speciesThermoTypes.h
+++ b/include/cantera/thermo/speciesThermoTypes.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef SPECIES_THERMO_TYPES_H
 #define SPECIES_THERMO_TYPES_H

--- a/include/cantera/tpx/Sub.h
+++ b/include/cantera/tpx/Sub.h
@@ -1,7 +1,7 @@
 //! @file Sub.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_SUB_H
 #define TPX_SUB_H

--- a/include/cantera/transport/DustyGasTransport.h
+++ b/include/cantera/transport/DustyGasTransport.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_DUSTYGASTRAN_H
 #define CT_DUSTYGASTRAN_H

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_GAS_TRANSPORT_H
 #define CT_GAS_TRANSPORT_H

--- a/include/cantera/transport/HighPressureGasTransport.h
+++ b/include/cantera/transport/HighPressureGasTransport.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_HIGHPRESSUREGASTRAN_H
 #define CT_HIGHPRESSUREGASTRAN_H

--- a/include/cantera/transport/IonGasTransport.h
+++ b/include/cantera/transport/IonGasTransport.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_ION_GAS_TRANSPORT_H
 #define CT_ION_GAS_TRANSPORT_H

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MIXTRAN_H
 #define CT_MIXTRAN_H

--- a/include/cantera/transport/MultiTransport.h
+++ b/include/cantera/transport/MultiTransport.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MULTITRAN_H
 #define CT_MULTITRAN_H

--- a/include/cantera/transport/TransportBase.h
+++ b/include/cantera/transport/TransportBase.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 /**
  * @defgroup tranprops Transport Properties for Species in Phases

--- a/include/cantera/transport/TransportData.h
+++ b/include/cantera/transport/TransportData.h
@@ -1,7 +1,7 @@
 //! @file TransportData.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_TRANSPORTDATA_H
 #define CT_TRANSPORTDATA_H

--- a/include/cantera/transport/TransportFactory.h
+++ b/include/cantera/transport/TransportFactory.h
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_TRANSPORTFACTORY_H
 #define CT_TRANSPORTFACTORY_H

--- a/include/cantera/transport/TransportParams.h
+++ b/include/cantera/transport/TransportParams.h
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_TRANSPORTPARAMS_H
 #define CT_TRANSPORTPARAMS_H

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_UNITYLEWISTRAN_H
 #define CT_UNITYLEWISTRAN_H

--- a/include/cantera/transport/WaterTransport.h
+++ b/include/cantera/transport/WaterTransport.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_WATERTRAN_H
 #define CT_WATERTRAN_H

--- a/include/cantera/zeroD/ConstPressureReactor.h
+++ b/include/cantera/zeroD/ConstPressureReactor.h
@@ -1,7 +1,7 @@
 //! @file ConstPressureReactor.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CONSTP_REACTOR_H
 #define CT_CONSTP_REACTOR_H

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -1,7 +1,7 @@
 //! @file ReactorSurface.h Header file for class ReactorSurface
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_REACTOR_SURFACE_H
 #define CT_REACTOR_SURFACE_H

--- a/interfaces/cython/cantera/__init__.py
+++ b/interfaces/cython/cantera/__init__.py
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 from ._cantera import *
 from ._cantera import __version__, __sundials_version__, __git_commit__

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 cdef class _SolutionBase:
     def __cinit__(self, infile='', phaseid='', phases=(), origin=None,

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -2,7 +2,7 @@
 # encoding: utf-8
 
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at https://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 """
 ck2yaml.py: Convert Chemkin-format mechanisms to Cantera YAML input files

--- a/interfaces/cython/cantera/constants.pyx
+++ b/interfaces/cython/cantera/constants.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 cdef extern from "cantera/base/ct_defs.h" namespace "Cantera":
     cdef double CxxAvogadro "Cantera::Avogadro"

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1,7 +1,7 @@
 #!/usr/bin/env python
 
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at https://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 """
 cti2yaml.py: Convert legacy CTI input files to YAML

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -17,7 +17,7 @@
 # This will produce CTML file 'infile.xml'
 
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 from __future__ import print_function
 

--- a/interfaces/cython/cantera/examples/onedim/diffusion_flame_batch.py
+++ b/interfaces/cython/cantera/examples/onedim/diffusion_flame_batch.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 """
 This example creates two batches of counterflow diffusion flame simulations.

--- a/interfaces/cython/cantera/examples/onedim/diffusion_flame_extinction.py
+++ b/interfaces/cython/cantera/examples/onedim/diffusion_flame_extinction.py
@@ -1,7 +1,7 @@
 # -*- coding: utf-8 -*-
 
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 """
 This example computes the extinction point of a counterflow diffusion flame.

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 import sys
 

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 # NOTE: These cdef functions cannot be members of Kinetics because they would
 # cause "layout conflicts" when creating derived classes with multiple bases,

--- a/interfaces/cython/cantera/liquidvapor.py
+++ b/interfaces/cython/cantera/liquidvapor.py
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 from . import PureFluid, _cantera
 

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 import warnings
 

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 import numpy as np
 from ._cantera import *

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 from .interrupts import no_op
 import warnings

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 cdef extern from "cantera/kinetics/reaction_defs.h" namespace "Cantera":
     cdef int ELEMENTARY_RXN

--- a/interfaces/cython/cantera/reactionpath.pyx
+++ b/interfaces/cython/cantera/reactionpath.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 cdef class ReactionPathDiagram:
     def __cinit__(self, *args, **kwargs):

--- a/interfaces/cython/cantera/speciesthermo.pyx
+++ b/interfaces/cython/cantera/speciesthermo.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 cdef extern from "cantera/thermo/speciesThermoTypes.h" namespace "Cantera":
     cdef int SPECIES_THERMO_CONSTANT_CP "CONSTANT_CP"

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 import warnings
 import weakref

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 # NOTE: These cdef functions cannot be members of Transport because they would
 # cause "layout conflicts" when creating derived classes with multiple bases,

--- a/interfaces/cython/cantera/utils.py
+++ b/interfaces/cython/cantera/utils.py
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 import os
 import inspect as _inspect

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -1,5 +1,5 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
-# at http://www.cantera.org/license.txt for license and copyright information.
+# at https://cantera.org/license.txt for license and copyright information.
 
 import sys
 import os

--- a/samples/cxx/kinetics1/kinetics1.cpp
+++ b/samples/cxx/kinetics1/kinetics1.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
 #include "cantera/IdealGasMix.h"

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -1,7 +1,7 @@
 //! @file AnyMap.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/AnyMap.h"
 #include "application.h"

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -1,7 +1,7 @@
 //! @file Units.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at https://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/Units.h"
 #include "cantera/base/ctexceptions.h"

--- a/src/base/ValueCache.cpp
+++ b/src/base/ValueCache.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ValueCache.h"
 #include <mutex>

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -1,7 +1,7 @@
 //! @file application.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "application.h"
 

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -1,7 +1,7 @@
 //! @file application.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_BASE_APPLICATION_H
 #define CT_BASE_APPLICATION_H

--- a/src/base/checkFinite.cpp
+++ b/src/base/checkFinite.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/base/stringUtils.h"

--- a/src/base/clockWC.cpp
+++ b/src/base/clockWC.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include <time.h>
 #include "cantera/base/clockWC.h"

--- a/src/base/ct2ctml.cpp
+++ b/src/base/ct2ctml.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/base/stringUtils.h"

--- a/src/base/ctexceptions.cpp
+++ b/src/base/ctexceptions.cpp
@@ -1,7 +1,7 @@
 //! @file ctexceptions.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctexceptions.h"
 #include "application.h"

--- a/src/base/ctml.cpp
+++ b/src/base/ctml.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/base/stringUtils.h"

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -1,7 +1,7 @@
 //! @file global.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/FactoryBase.h"
 #include "cantera/base/xml.h"

--- a/src/base/plots.cpp
+++ b/src/base/plots.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/plots.h"
 

--- a/src/base/stringUtils.cpp
+++ b/src/base/stringUtils.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 //@{
 #include "cantera/base/ct_defs.h"

--- a/src/base/units.h
+++ b/src/base/units.h
@@ -8,7 +8,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at https://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_UNITS_H
 #define CT_UNITS_H

--- a/src/base/xml.cpp
+++ b/src/base/xml.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/xml.h"
 #include "cantera/base/stringUtils.h"

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CABINET_H
 #define CT_CABINET_H

--- a/src/clib/clib_utils.h
+++ b/src/clib/clib_utils.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_CLIB_UTILS_H
 #define CT_CLIB_UTILS_H

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -9,7 +9,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #define CANTERA_USE_INTERNAL
 #include "cantera/clib/ct.h"

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctfunc.h"

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctmultiphase.h"

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #define CANTERA_USE_INTERNAL
 

--- a/src/clib/ctrpath.cpp
+++ b/src/clib/ctrpath.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctrpath.h"

--- a/src/clib/ctsurf.cpp
+++ b/src/clib/ctsurf.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 // clib header information
 #define CANTERA_USE_INTERNAL

--- a/src/clib/ctxml.cpp
+++ b/src/clib/ctxml.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctxml.h"

--- a/src/equil/BasisOptimize.cpp
+++ b/src/equil/BasisOptimize.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/MultiPhase.h"
 

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/ChemEquil.h"
 #include "cantera/base/stringUtils.h"

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/ChemEquil.h"
 #include "cantera/equil/MultiPhase.h"

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/MultiPhaseEquil.h"
 #include "cantera/thermo/MolalityVPSSTP.h"

--- a/src/equil/vcs_Gibbs.cpp
+++ b/src/equil/vcs_Gibbs.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_MultiPhaseEquil.cpp
+++ b/src/equil/vcs_MultiPhaseEquil.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_MultiPhaseEquil.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_SpeciesProperties.cpp
+++ b/src/equil/vcs_SpeciesProperties.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_SpeciesProperties.h"
 

--- a/src/equil/vcs_TP.cpp
+++ b/src/equil/vcs_TP.cpp
@@ -1,7 +1,7 @@
 //! @file vcs_TP.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_VolPhase.h"
 #include "cantera/equil/vcs_species_thermo.h"

--- a/src/equil/vcs_elem.cpp
+++ b/src/equil/vcs_elem.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/base/ctexceptions.h"

--- a/src/equil/vcs_elem_rearrange.cpp
+++ b/src/equil/vcs_elem_rearrange.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_inest.cpp
+++ b/src/equil/vcs_inest.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_phaseStability.cpp
+++ b/src/equil/vcs_phaseStability.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_prep.cpp
+++ b/src/equil/vcs_prep.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_prob.cpp
+++ b/src/equil/vcs_prob.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_VolPhase.h"
 #include "cantera/equil/vcs_species_thermo.h"

--- a/src/equil/vcs_report.cpp
+++ b/src/equil/vcs_report.cpp
@@ -1,7 +1,7 @@
 //! @file vcs_report.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_rxnadj.cpp
+++ b/src/equil/vcs_rxnadj.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_setMolesLinProg.cpp
+++ b/src/equil/vcs_setMolesLinProg.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 

--- a/src/equil/vcs_solve.cpp
+++ b/src/equil/vcs_solve.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/base/ctexceptions.h"

--- a/src/equil/vcs_solve_TP.cpp
+++ b/src/equil/vcs_solve_TP.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_solve.h"
 #include "cantera/equil/vcs_VolPhase.h"

--- a/src/equil/vcs_species_thermo.cpp
+++ b/src/equil/vcs_species_thermo.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_species_thermo.h"
 #include "cantera/equil/vcs_defs.h"

--- a/src/equil/vcs_util.cpp
+++ b/src/equil/vcs_util.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_internal.h"
 #include "cantera/equil/vcs_defs.h"

--- a/src/fortran/cantera.f90
+++ b/src/fortran/cantera.f90
@@ -4,7 +4,7 @@
 ! argument types.
 
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 MODULE CANTERA
 

--- a/src/fortran/cantera_funcs.f90
+++ b/src/fortran/cantera_funcs.f90
@@ -1,5 +1,5 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 module cantera_funcs
 

--- a/src/fortran/cantera_iface.f90
+++ b/src/fortran/cantera_iface.f90
@@ -1,5 +1,5 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 module cantera_iface
 

--- a/src/fortran/cantera_kinetics.f90
+++ b/src/fortran/cantera_kinetics.f90
@@ -1,5 +1,5 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 module cantera_kinetics
 

--- a/src/fortran/cantera_thermo.f90
+++ b/src/fortran/cantera_thermo.f90
@@ -1,5 +1,5 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 module cantera_thermo
 

--- a/src/fortran/cantera_transport.f90
+++ b/src/fortran/cantera_transport.f90
@@ -1,5 +1,5 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 module cantera_transport
 

--- a/src/fortran/cantera_xml.f90
+++ b/src/fortran/cantera_xml.f90
@@ -1,5 +1,5 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 module cantera_xml
 

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -8,7 +8,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 // Cantera includes
 #include "cantera/kinetics/KineticsFactory.h"

--- a/src/fortran/fct_interface.f90
+++ b/src/fortran/fct_interface.f90
@@ -1,5 +1,5 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 module fct
 interface

--- a/src/fortran/fctxml.cpp
+++ b/src/fortran/fctxml.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "clib/clib_utils.h"
 #include "cantera/base/ctml.h"

--- a/src/fortran/fctxml_interface.f90
+++ b/src/fortran/fctxml_interface.f90
@@ -1,5 +1,5 @@
 ! This file is part of Cantera. See License.txt in the top-level directory or
-! at http://www.cantera.org/license.txt for license and copyright information.
+! at https://cantera.org/license.txt for license and copyright information.
 
 module fctxml
 interface

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/BulkKinetics.h"
 #include "cantera/kinetics/Reaction.h"

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/ctexceptions.h"

--- a/src/kinetics/FalloffFactory.cpp
+++ b/src/kinetics/FalloffFactory.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/FalloffFactory.h"
 #include "cantera/kinetics/reaction_defs.h"

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/GasKinetics.h"
 

--- a/src/kinetics/Group.cpp
+++ b/src/kinetics/Group.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/Group.h"
 #include <iostream>

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/ImplicitSurfChem.h"
 #include "cantera/kinetics/solveSP.h"

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/InterfaceKinetics.h"
 #include "cantera/kinetics/RateCoeffMgr.h"

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/Kinetics.h"
 #include "cantera/kinetics/Reaction.h"

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/KineticsFactory.h"
 #include "cantera/kinetics/GasKinetics.h"

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/Reaction.h"
 #include "cantera/kinetics/FalloffFactory.h"

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/ReactionPath.h"
 #include "cantera/kinetics/reaction_defs.h"

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -1,7 +1,7 @@
 //! @file RxnRates.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/RxnRates.h"
 #include "cantera/base/Array.h"

--- a/src/kinetics/importKinetics.cpp
+++ b/src/kinetics/importKinetics.cpp
@@ -11,7 +11,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/importKinetics.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/kinetics/solveSP.cpp
+++ b/src/kinetics/solveSP.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/solveSP.h"
 #include "cantera/thermo/SurfPhase.h"

--- a/src/matlab/ctfunctions.cpp
+++ b/src/matlab/ctfunctions.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include <string.h>
 #include <iostream>

--- a/src/matlab/ctmatutils.h
+++ b/src/matlab/ctmatutils.h
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MATUTILS_H
 #define CT_MATUTILS_H

--- a/src/matlab/ctmethods.cpp
+++ b/src/matlab/ctmethods.cpp
@@ -10,7 +10,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include <string>
 

--- a/src/matlab/funcmethods.cpp
+++ b/src/matlab/funcmethods.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "ctmatutils.h"
 #include "cantera/clib/ctfunc.h"

--- a/src/matlab/kineticsmethods.cpp
+++ b/src/matlab/kineticsmethods.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "ctmatutils.h"
 #include "cantera/clib/ct.h"

--- a/src/matlab/mixturemethods.cpp
+++ b/src/matlab/mixturemethods.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include <iostream>
 #include <vector>

--- a/src/matlab/mllogger.h
+++ b/src/matlab/mllogger.h
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef MLLOGGER_H
 #define MLLOGGER_H

--- a/src/matlab/onedimmethods.cpp
+++ b/src/matlab/onedimmethods.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include <iostream>
 #include <string>

--- a/src/matlab/phasemethods.cpp
+++ b/src/matlab/phasemethods.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "ctmatutils.h"
 #include "cantera/clib/ct.h"

--- a/src/matlab/reactornetmethods.cpp
+++ b/src/matlab/reactornetmethods.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/clib/ctreactor.h"
 #include "cantera/clib/ct.h"

--- a/src/matlab/reactorsurfacemethods.cpp
+++ b/src/matlab/reactorsurfacemethods.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/clib/ctreactor.h"
 #include "cantera/clib/ct.h"

--- a/src/matlab/surfmethods.cpp
+++ b/src/matlab/surfmethods.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include <iostream>
 #include <string>

--- a/src/matlab/thermomethods.cpp
+++ b/src/matlab/thermomethods.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/clib/ct.h"
 #include "ctmatutils.h"

--- a/src/matlab/transportmethods.cpp
+++ b/src/matlab/transportmethods.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include <fstream>
 

--- a/src/matlab/xmlmethods.cpp
+++ b/src/matlab/xmlmethods.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/clib/ctxml.h"
 #include "cantera/clib/ct.h"

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -1,7 +1,7 @@
 //! @file BandMatrix.cpp Banded matrices.
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/BandMatrix.h"
 #include "cantera/base/utilities.h"

--- a/src/numerics/DAE_solvers.cpp
+++ b/src/numerics/DAE_solvers.cpp
@@ -1,7 +1,7 @@
 //! @file DAE_solvers.cpp Factory routine for picking the DAE solver package
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/numerics/DAE_Solver.h"

--- a/src/numerics/DenseMatrix.cpp
+++ b/src/numerics/DenseMatrix.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/DenseMatrix.h"
 #include "cantera/base/stringUtils.h"

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -1,7 +1,7 @@
 //! @file Func1.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/Func1.h"
 #include "cantera/base/stringUtils.h"

--- a/src/numerics/IDA_Solver.cpp
+++ b/src/numerics/IDA_Solver.cpp
@@ -1,7 +1,7 @@
 //! @file IDA_Solver.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/IDA_Solver.h"
 #include "cantera/base/stringUtils.h"

--- a/src/numerics/ODE_integrators.cpp
+++ b/src/numerics/ODE_integrators.cpp
@@ -1,7 +1,7 @@
 //! @file ODE_integrators.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/numerics/Integrator.h"

--- a/src/numerics/ResidJacEval.cpp
+++ b/src/numerics/ResidJacEval.cpp
@@ -1,7 +1,7 @@
 //! @file ResidJacEval.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/numerics/ResidJacEval.h"

--- a/src/numerics/funcs.cpp
+++ b/src/numerics/funcs.cpp
@@ -1,7 +1,7 @@
 //! @file funcs.cpp file containing miscellaneous numerical functions.
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/funcs.h"
 

--- a/src/numerics/polyfit.cpp
+++ b/src/numerics/polyfit.cpp
@@ -1,7 +1,7 @@
 //! @file polyfit.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/numerics/polyfit.h"
 #include "cantera/numerics/eigen_dense.h"

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/Domain1D.h"
 #include "cantera/oneD/MultiJac.h"

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -1,7 +1,7 @@
 //! @file IonFlow.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/IonFlow.h"
 #include "cantera/oneD/StFlow.h"

--- a/src/oneD/MultiJac.cpp
+++ b/src/oneD/MultiJac.cpp
@@ -1,7 +1,7 @@
 //! @file MultiJac.cpp Implementation file for class MultiJac
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/MultiJac.h"
 #include <ctime>

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -1,7 +1,7 @@
 //! @file MultiNewton.cpp Damped Newton solver for 1D multi-domain problems
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/MultiNewton.h"
 #include "cantera/base/utilities.h"

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -1,7 +1,7 @@
 //! @file OneDim.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/OneDim.h"
 #include "cantera/numerics/Func1.h"

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/Sim1D.h"
 #include "cantera/oneD/MultiJac.h"

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -1,7 +1,7 @@
 //! @file StFlow.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/StFlow.h"
 #include "cantera/base/ctml.h"

--- a/src/oneD/boundaries1D.cpp
+++ b/src/oneD/boundaries1D.cpp
@@ -1,7 +1,7 @@
 //! @file boundaries1D.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/Inlet1D.h"
 #include "cantera/oneD/OneDim.h"

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -1,7 +1,7 @@
 //! @file refine.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/oneD/refine.h"
 #include "cantera/oneD/StFlow.h"

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at https://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/BinarySolutionTabulatedThermo.h"
 #include "cantera/thermo/PDSS.h"

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/ConstCpPoly.h"
 

--- a/src/thermo/ConstDensityThermo.cpp
+++ b/src/thermo/ConstDensityThermo.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/ConstDensityThermo.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -9,7 +9,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/DebyeHuckel.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/FixedChemPotSSTP.cpp
+++ b/src/thermo/FixedChemPotSSTP.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/FixedChemPotSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/GibbsExcessVPSSTP.cpp
+++ b/src/thermo/GibbsExcessVPSSTP.cpp
@@ -11,7 +11,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/GibbsExcessVPSSTP.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -13,7 +13,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/HMWSoln.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/IdealGasPhase.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -13,7 +13,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/IdealMolalSoln.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/IdealSolidSolnPhase.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -8,7 +8,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/IdealSolnGasVPSS.h"
 #include "cantera/thermo/PDSS.h"

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -12,7 +12,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/IonsFromNeutralVPSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/LatticePhase.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/LatticeSolidPhase.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MargulesVPSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/MaskellSolidSolnPhase.cpp
+++ b/src/thermo/MaskellSolidSolnPhase.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MaskellSolidSolnPhase.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MixtureFugacityTP.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MolalityVPSSTP.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/Mu0Poly.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/MultiSpeciesThermo.cpp
+++ b/src/thermo/MultiSpeciesThermo.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/MultiSpeciesThermo.h"
 #include "cantera/thermo/SpeciesThermoFactory.h"

--- a/src/thermo/Nasa9Poly1.cpp
+++ b/src/thermo/Nasa9Poly1.cpp
@@ -10,7 +10,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/Nasa9Poly1.h"
 

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -12,7 +12,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctexceptions.h"
 #include "cantera/thermo/Nasa9PolyMultiTempRegion.h"

--- a/src/thermo/NasaPoly2.cpp
+++ b/src/thermo/NasaPoly2.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/NasaPoly2.h"
 #include "cantera/base/global.h"

--- a/src/thermo/PDSS.cpp
+++ b/src/thermo/PDSS.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS.h"

--- a/src/thermo/PDSSFactory.cpp
+++ b/src/thermo/PDSSFactory.cpp
@@ -1,7 +1,7 @@
 //! @file PDSSFactory.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/PDSSFactory.h"
 #include "cantera/thermo/PDSS_IdealGas.h"

--- a/src/thermo/PDSS_ConstVol.cpp
+++ b/src/thermo/PDSS_ConstVol.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_ConstVol.h"

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_HKFT.h"

--- a/src/thermo/PDSS_IdealGas.cpp
+++ b/src/thermo/PDSS_IdealGas.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_IdealGas.h"

--- a/src/thermo/PDSS_IonsFromNeutral.cpp
+++ b/src/thermo/PDSS_IonsFromNeutral.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/PDSS_IonsFromNeutral.h"
 #include "cantera/thermo/IonsFromNeutralVPSSTP.h"

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_SSVol.h"

--- a/src/thermo/PDSS_Water.cpp
+++ b/src/thermo/PDSS_Water.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctml.h"
 #include "cantera/thermo/PDSS_Water.h"

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/Phase.h"
 #include "cantera/base/utilities.h"

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/xml.h"
 #include "cantera/thermo/PureFluidPhase.h"

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/RedlichKisterVPSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -1,7 +1,7 @@
 //! @file RedlichKwongMFTP.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/RedlichKwongMFTP.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/SingleSpeciesTP.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/Species.h"
 #include "cantera/thermo/SpeciesThermoInterpType.h"

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/SpeciesThermoFactory.h"
 #include "cantera/thermo/MultiSpeciesThermo.h"

--- a/src/thermo/SpeciesThermoInterpType.cpp
+++ b/src/thermo/SpeciesThermoInterpType.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/SpeciesThermoInterpType.h"
 #include "cantera/thermo/PDSS.h"

--- a/src/thermo/StoichSubstance.cpp
+++ b/src/thermo/StoichSubstance.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/StoichSubstance.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/thermo/EdgePhase.h"

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/ThermoFactory.h"
 

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/base/stringUtils.h"

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -7,7 +7,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/VPStandardStateTP.h"
 #include "cantera/thermo/PDSS.h"

--- a/src/thermo/WaterProps.cpp
+++ b/src/thermo/WaterProps.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/WaterProps.h"
 #include "cantera/base/ctml.h"

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/WaterPropsIAPWS.h"
 #include "cantera/base/ctexceptions.h"

--- a/src/thermo/WaterPropsIAPWSphi.cpp
+++ b/src/thermo/WaterPropsIAPWSphi.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/WaterPropsIAPWSphi.h"
 #include "cantera/base/global.h"

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/thermo/WaterSSTP.h"
 #include "cantera/thermo/ThermoFactory.h"

--- a/src/tpx/CarbonDioxide.cpp
+++ b/src/tpx/CarbonDioxide.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "CarbonDioxide.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/CarbonDioxide.h
+++ b/src/tpx/CarbonDioxide.h
@@ -1,7 +1,7 @@
 //! @file CarbonDioxide.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_CARBONDIOXIDE_H
 #define TPX_CARBONDIOXIDE_H

--- a/src/tpx/HFC134a.cpp
+++ b/src/tpx/HFC134a.cpp
@@ -1,7 +1,7 @@
 //! @file HFC134a.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "HFC134a.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/HFC134a.h
+++ b/src/tpx/HFC134a.h
@@ -1,7 +1,7 @@
 //! @file HFC134a.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_HFC134_H
 #define TPX_HFC134_H

--- a/src/tpx/Heptane.cpp
+++ b/src/tpx/Heptane.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "Heptane.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/Heptane.h
+++ b/src/tpx/Heptane.h
@@ -1,7 +1,7 @@
 //! @file Heptane.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_HEPTANE_H
 #define TPX_HEPTANE_H

--- a/src/tpx/Hydrogen.cpp
+++ b/src/tpx/Hydrogen.cpp
@@ -1,7 +1,7 @@
 //! @file Hydrogen.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "Hydrogen.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/Hydrogen.h
+++ b/src/tpx/Hydrogen.h
@@ -1,7 +1,7 @@
 //! @file Hydrogen.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_HYDROGEN_H
 #define TPX_HYDROGEN_H

--- a/src/tpx/Methane.cpp
+++ b/src/tpx/Methane.cpp
@@ -1,7 +1,7 @@
 //! @file Methane.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "Methane.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/Methane.h
+++ b/src/tpx/Methane.h
@@ -1,7 +1,7 @@
 //! @file Methane.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_METHANE_H
 #define TPX_METHANE_H

--- a/src/tpx/Nitrogen.cpp
+++ b/src/tpx/Nitrogen.cpp
@@ -1,7 +1,7 @@
 //! @file Nitrogen.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "Nitrogen.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/Nitrogen.h
+++ b/src/tpx/Nitrogen.h
@@ -1,7 +1,7 @@
 //! @file Nitrogen.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_NITROGEN_H
 #define TPX_NITROGEN_H

--- a/src/tpx/Oxygen.cpp
+++ b/src/tpx/Oxygen.cpp
@@ -1,7 +1,7 @@
 //! @file Oxygen.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "Oxygen.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/Oxygen.h
+++ b/src/tpx/Oxygen.h
@@ -1,7 +1,7 @@
 //! @file Oxygen.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_OXYGEN_H
 #define TPX_OXYGEN_H

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -5,7 +5,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/tpx/Sub.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/Water.cpp
+++ b/src/tpx/Water.cpp
@@ -1,7 +1,7 @@
 //! @file Water.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "Water.h"
 #include "cantera/base/stringUtils.h"

--- a/src/tpx/Water.h
+++ b/src/tpx/Water.h
@@ -1,7 +1,7 @@
 //! @file Water.h
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TPX_WATER_H
 #define TPX_WATER_H

--- a/src/tpx/utils.cpp
+++ b/src/tpx/utils.cpp
@@ -1,7 +1,7 @@
 //! @file utils.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/tpx/utils.h"
 #include "cantera/base/stringUtils.h"

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/DustyGasTransport.h"
 #include "cantera/base/stringUtils.h"

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -1,7 +1,7 @@
 //! @file GasTransport.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/GasTransport.h"
 #include "MMCollisionInt.h"

--- a/src/transport/HighPressureGasTransport.cpp
+++ b/src/transport/HighPressureGasTransport.cpp
@@ -11,7 +11,7 @@
  **/
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/HighPressureGasTransport.h"
 #include "cantera/numerics/ctlapack.h"

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -1,7 +1,7 @@
 //! @file IonGasTransport.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/IonGasTransport.h"
 #include "cantera/numerics/polyfit.h"

--- a/src/transport/MMCollisionInt.cpp
+++ b/src/transport/MMCollisionInt.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "MMCollisionInt.h"
 #include "cantera/base/utilities.h"

--- a/src/transport/MMCollisionInt.h
+++ b/src/transport/MMCollisionInt.h
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef CT_MMCOLLISIONINT_H
 #define CT_MMCOLLISIONINT_H

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/MixTransport.h"
 #include "cantera/base/stringUtils.h"

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/MultiTransport.h"
 #include "cantera/thermo/IdealGasPhase.h"

--- a/src/transport/TransportBase.cpp
+++ b/src/transport/TransportBase.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/TransportBase.h"
 

--- a/src/transport/TransportData.cpp
+++ b/src/transport/TransportData.cpp
@@ -1,7 +1,7 @@
 //! @file TransportData.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/TransportData.h"
 #include "cantera/thermo/Species.h"

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -1,7 +1,7 @@
 //! @file TransportFactory.cpp Implementation file for class TransportFactory.
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 // known transport models
 #include "cantera/transport/MultiTransport.h"

--- a/src/transport/TransportParams.cpp
+++ b/src/transport/TransportParams.cpp
@@ -6,7 +6,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/TransportParams.h"
 

--- a/src/transport/WaterTransport.cpp
+++ b/src/transport/WaterTransport.cpp
@@ -1,7 +1,7 @@
 //! @file WaterTransport.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport/WaterTransport.h"
 #include "cantera/thermo/VPStandardStateTP.h"

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -1,7 +1,7 @@
 //! @file ConstPressureReactor.cpp A constant pressure zero-dimensional reactor
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/ConstPressureReactor.h"
 #include "cantera/zeroD/FlowDevice.h"

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -1,7 +1,7 @@
 //! @file FlowDevice.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/ReactorBase.h"

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -1,7 +1,7 @@
 //! @file FlowReactor.cpp A steady-state plug flow reactor
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/FlowReactor.h"
 #include "cantera/base/global.h"

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -1,7 +1,7 @@
 //! @file ConstPressureReactor.cpp A constant pressure zero-dimensional reactor
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/IdealGasConstPressureReactor.h"
 #include "cantera/zeroD/FlowDevice.h"

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -1,7 +1,7 @@
 //! @file IdealGasReactor.cpp A zero-dimensional reactor
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/IdealGasReactor.h"
 #include "cantera/zeroD/FlowDevice.h"

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -1,7 +1,7 @@
 //! @file ReactorSurface.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/zeroD/ReactorNet.h"

--- a/test_problems/CpJump/CpJump.cpp
+++ b/test_problems/CpJump/CpJump.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/IdealGasMix.h"
 

--- a/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
+++ b/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/equil/vcs_MultiPhaseEquil.h"
 

--- a/test_problems/VPsilane_test/silane_equil.cpp
+++ b/test_problems/VPsilane_test/silane_equil.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/IdealGasMix.h"
 #include "cantera/thermo/IdealSolnGasVPSS.h"

--- a/test_problems/cathermo/VPissp/ISSPTester.cpp
+++ b/test_problems/cathermo/VPissp/ISSPTester.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 //  Example
 //

--- a/test_problems/cathermo/ims/IMSTester.cpp
+++ b/test_problems/cathermo/ims/IMSTester.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 //  Example
 //

--- a/test_problems/cathermo/issp/ISSPTester.cpp
+++ b/test_problems/cathermo/issp/ISSPTester.cpp
@@ -3,7 +3,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 //  Example
 //

--- a/test_problems/cxx_ex/equil_example1.cpp
+++ b/test_problems/cxx_ex/equil_example1.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "example_utils.h"
 

--- a/test_problems/cxx_ex/kinetics_example1.cpp
+++ b/test_problems/cxx_ex/kinetics_example1.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
 #include "cantera/IdealGasMix.h"

--- a/test_problems/cxx_ex/kinetics_example3.cpp
+++ b/test_problems/cxx_ex/kinetics_example3.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
 #include "cantera/IdealGasMix.h"

--- a/test_problems/cxx_ex/rxnpath_example1.cpp
+++ b/test_problems/cxx_ex/rxnpath_example1.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
 #include "example_utils.h"

--- a/test_problems/cxx_ex/transport_example1.cpp
+++ b/test_problems/cxx_ex/transport_example1.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport.h"
 #include "example_utils.h"

--- a/test_problems/cxx_ex/transport_example2.cpp
+++ b/test_problems/cxx_ex/transport_example2.cpp
@@ -5,7 +5,7 @@
 /////////////////////////////////////////////////////////////
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/transport.h"
 #include "example_utils.h"

--- a/test_problems/shared/TemperatureTable.h
+++ b/test_problems/shared/TemperatureTable.h
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #ifndef TEMPERATURE_TABLE_H
 #define TEMPERATURE_TABLE_H

--- a/test_problems/silane_equil/silane_equil.cpp
+++ b/test_problems/silane_equil/silane_equil.cpp
@@ -1,5 +1,5 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/IdealGasMix.h"
 

--- a/test_problems/surfSolverTest/surfaceSolver.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 //  Example
 //

--- a/test_problems/surfSolverTest/surfaceSolver2.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver2.cpp
@@ -4,7 +4,7 @@
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
-// at http://www.cantera.org/license.txt for license and copyright information.
+// at https://cantera.org/license.txt for license and copyright information.
 
 //  Example
 //


### PR DESCRIPTION
Changes proposed in this pull request:
- Updated URL in references to Cantera's license, from http://www.cantera.org/license.txt to https://cantera.org/license.txt
