### PR TITLE
Python wrapper classes for NASA9 and piecewise Gibbs

### DIFF
--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -86,6 +86,9 @@ public:
     void updatePropertiesTemp(const doublereal temp,
                               doublereal* cp_R, doublereal* h_RT,
                               doublereal* s_R) const;
+
+    size_t nCoeffs() const { return 4; }
+
     void reportParameters(size_t& n, int& type,
                           doublereal& tlow, doublereal& thigh,
                           doublereal& pref,

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -127,6 +127,9 @@ public:
                                       doublereal* cp_R,
                                       doublereal* h_RT,
                                       doublereal* s_R) const;
+
+    virtual size_t nCoeffs() const;
+
     virtual void reportParameters(size_t& n, int& type,
                                   doublereal& tlow, doublereal& thigh,
                                   doublereal& pref,

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -57,11 +57,18 @@ public:
      * @param thigh   Maximum temperature
      * @param pref    reference pressure (Pa).
      * @param coeffs  Vector of coefficients used to set the parameters for the
-     *                standard state.
+     *                standard state. The vector has 1 + 11*`nzones` elements
+     *                in the following order:
+     *                - `coeffs[0]`: Number of zones (`nzones`)
+     *                - `coeffs[1 + 11*zone]`: minimum temperature within zone
+     *                - `coeffs[2 + 11*zone]`: maximum temperature within zone
+     *                - `coeffs[3:11 + 11*zone]`: 9 coefficient parameterization
+     *                where `zone` runs from zero to `nzones`-1.
      */
-    Nasa9PolyMultiTempRegion(double tlow, double thigh, double pref, const double* coeffs);
+    Nasa9PolyMultiTempRegion(double tlow, double thigh, double pref,
+                             const double* coeffs);
 
-   //! Set the array of polynomial coefficients for each temperature region
+    //! Set the array of polynomial coefficients for each temperature region
     /*!
      *  @param regions  Map where each key is the minimum temperature for a
      *                  region and each value is the array of 9 polynomial

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -51,7 +51,17 @@ public:
      */
     Nasa9PolyMultiTempRegion(std::vector<Nasa9Poly1*> &regionPts);
 
-    //! Set the array of polynomial coefficients for each temperature region
+    //! Constructor with all input data
+    /*!
+     * @param tlow    Minimum temperature
+     * @param thigh   Maximum temperature
+     * @param pref    reference pressure (Pa).
+     * @param coeffs  Vector of coefficients used to set the parameters for the
+     *                standard state.
+     */
+    Nasa9PolyMultiTempRegion(double tlow, double thigh, double pref, const double* coeffs);
+
+   //! Set the array of polynomial coefficients for each temperature region
     /*!
      *  @param regions  Map where each key is the minimum temperature for a
      *                  region and each value is the array of 9 polynomial

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -75,6 +75,8 @@ public:
                                       doublereal* cp_R, doublereal* h_RT,
                                       doublereal* s_R) const;
 
+    virtual size_t nCoeffs() const;
+
     //! This utility function reports back the type of parameterization and all
     //! of the parameters for the species, index.
     /*!

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -123,6 +123,8 @@ public:
         }
     }
 
+    size_t nCoeffs() const { return 15; }
+
     void reportParameters(size_t& n, int& type,
                           doublereal& tlow, doublereal& thigh,
                           doublereal& pref,

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -306,6 +306,8 @@ public:
         }
     }
 
+    virtual size_t nCoeffs() const { return 15; }
+
     virtual void reportParameters(size_t& n, int& type,
                                   doublereal& tlow, doublereal& thigh,
                                   doublereal& pref,

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -206,11 +206,11 @@ public:
                                       doublereal* h_RT,
                                       doublereal* s_R) const;
 
-    //! This utility function reports back the number of coefficients
+    //! This utility function returns the number of coefficients
     //! for a given type of species parameterization
     virtual size_t nCoeffs() const;
 
-    //! This utility function reports back the type of parameterization and all
+    //! This utility function returns the type of parameterization and all
     //! of the parameters for the species.
     /*!
      * All parameters are output variables

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -206,11 +206,9 @@ public:
                                       doublereal* h_RT,
                                       doublereal* s_R) const;
 
-
     //! This utility function reports back the number of coefficients
     //! for a given type of species parameterization
     virtual size_t nCoeffs() const;
-
 
     //! This utility function reports back the type of parameterization and all
     //! of the parameters for the species.

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -206,6 +206,12 @@ public:
                                       doublereal* h_RT,
                                       doublereal* s_R) const;
 
+
+    //! This utility function reports back the number of coefficients
+    //! for a given type of species parameterization
+    virtual size_t nCoeffs() const;
+
+
     //! This utility function reports back the type of parameterization and all
     //! of the parameters for the species.
     /*!

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -96,6 +96,7 @@ cdef extern from "cantera/thermo/SpeciesThermoInterpType.h":
         double maxTemp()
         double refPressure()
         void reportParameters(size_t&, int&, double&, double&, double&, double* const) except +translate_exception
+        int nCoeffs() except +translate_exception
 
 cdef extern from "cantera/thermo/SpeciesThermoFactory.h":
     cdef CxxSpeciesThermo* CxxNewSpeciesThermo "Cantera::newSpeciesThermoInterpType"\

--- a/interfaces/cython/cantera/speciesthermo.pyx
+++ b/interfaces/cython/cantera/speciesthermo.pyx
@@ -32,7 +32,7 @@ cdef class SpeciesThermo:
         if not init:
             return
 
-        if not self.check_n_coeffs(len(coeffs)):
+        if not self._check_n_coeffs(len(coeffs)):
             raise ValueError("Coefficient array has incorrect length")
         cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(
             coeffs, dtype=np.double)
@@ -79,7 +79,7 @@ cdef class SpeciesThermo:
                                            T_high, P_ref, &data[0])
             return data
 
-    def check_n_coeffs(self, n):
+    def _check_n_coeffs(self, n):
         raise NotImplementedError('Needs to be overloaded')
 
     def cp(self, T):
@@ -118,7 +118,7 @@ cdef class ConstantCp(SpeciesThermo):
     """
     derived_type = SPECIES_THERMO_CONSTANT_CP
 
-    def check_n_coeffs(self, n):
+    def _check_n_coeffs(self, n):
         return n == 4
 
 
@@ -141,7 +141,7 @@ cdef class Mu0Poly(SpeciesThermo):
     """
     derived_type = SPECIES_THERMO_MU0_INTERP
 
-    def check_n_coeffs(self, n):
+    def _check_n_coeffs(self, n):
         return n > 3 and n % 2 == 0
 
 
@@ -166,7 +166,7 @@ cdef class NasaPoly2(SpeciesThermo):
     """
     derived_type = SPECIES_THERMO_NASA2
 
-    def check_n_coeffs(self, n):
+    def _check_n_coeffs(self, n):
         return n == 15
 
 
@@ -191,7 +191,7 @@ cdef class Nasa9PolyMultiTempRegion(SpeciesThermo):
     """
     derived_type = SPECIES_THERMO_NASA9MULTITEMP
 
-    def check_n_coeffs(self, n):
+    def _check_n_coeffs(self, n):
         return n > 11 and ((n - 1) % 11) == 0
 
 
@@ -217,7 +217,7 @@ cdef class ShomatePoly2(SpeciesThermo):
     """
     derived_type = SPECIES_THERMO_SHOMATE2
 
-    def check_n_coeffs(self, n):
+    def _check_n_coeffs(self, n):
         return n == 15
 
 

--- a/interfaces/cython/cantera/speciesthermo.pyx
+++ b/interfaces/cython/cantera/speciesthermo.pyx
@@ -80,6 +80,10 @@ cdef class SpeciesThermo:
             return data
 
     def _check_n_coeffs(self, n):
+        """ 
+        Check whether number of coefficients is compatible with a given 
+        parameterization prior to instantiation of the underlying C++ object.
+        """
         raise NotImplementedError('Needs to be overloaded')
 
     def cp(self, T):
@@ -177,17 +181,14 @@ cdef class Nasa9PolyMultiTempRegion(SpeciesThermo):
     This is a wrapper for the C++ class :ct:`Nasa9PolyMultiTempRegion`.
 
     :param coeffs:
-        An array of 1 + 11*nzones elements, in the following order:
+        An array of 1 + 11*`nzones` elements, in the following order:
 
-            - `coeffs[0]`: Number of zones (nzones)
-            - within each zone
-              - `coeffs[zone][0]`: minimum temperature
-              - `coeffs[zone][1]`: maximum temperature
-              - `coeffs[zone][2:10]`: The 9 coefficients of the parameterization
+            - `coeffs[0]`: Number of zones (`nzones`)
+            - `coeffs[1 + 11*zone]`: minimum temperature within zone
+            - `coeffs[2 + 11*zone]`: maximum temperature within zone
+            - `coeffs[3:11 + 11*zone]`: 9 coefficients of the parameterization
 
-        These coefficients should be provided in their customary units (i.e.
-        such that :math:`c_p^o` is in J/gmol-K and :math:`H^o` is in kJ/gmol,
-        as in the NIST Chemistry WebBook).
+        where `zone` runs from zero to `nzones`-1.
     """
     derived_type = SPECIES_THERMO_NASA9MULTITEMP
 

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1175,7 +1175,7 @@ class TestSpeciesThermo(utilities.CanteraTest):
             self.assertNear(st.cp(T), st2.cp(T))
             self.assertNear(st.h(T), st2.h(T))
             self.assertNear(st.s(T), st2.s(T))
-        
+
     def test_shomate_load(self):
         sol = ct.Solution('thermo-models.yaml', 'molten-salt-Margules')
         st = sol.species(0).thermo
@@ -1200,7 +1200,14 @@ class TestSpeciesThermo(utilities.CanteraTest):
             self.assertNear(st.h(T), st2.h(T))
             self.assertNear(st.s(T), st2.s(T))
 
-    def test_mu0poly_create(self):
+    def test_piecewise_gibbs_load(self):
+        sol = ct.Solution('thermo-models.yaml', 'HMW-NaCl-electrolyte')
+        st = sol.species(1).thermo
+        self.assertIsInstance(st, ct.Mu0Poly)
+        self.assertEqual(st.n_coeffs, len(st.coeffs))
+        self.assertTrue(st._check_n_coeffs(st.n_coeffs))
+
+    def test_piecewise_gibbs_create1(self):
         # use OH- ion data from test/thermo/phaseConstructors.cpp
         h298 = -230.015e6
         T1 = 298.15
@@ -1213,6 +1220,23 @@ class TestSpeciesThermo(utilities.CanteraTest):
         self.assertIsInstance(st2, ct.Mu0Poly)
         self.assertEqual(st2.n_coeffs, len(coeffs))
         self.assertEqual(st2.n_coeffs, len(st2.coeffs))
+
+    def test_piecewise_gibbs_create2(self):
+        sol = ct.Solution('thermo-models.yaml', 'HMW-NaCl-electrolyte')
+        st = sol.species(1).thermo
+        t_min = st.min_temp
+        t_max = st.max_temp
+        p_ref = st.reference_pressure
+        coeffs = st.coeffs
+        st2 = ct.Mu0Poly(t_min, t_max, p_ref, coeffs)
+        self.assertIsInstance(st2, ct.Mu0Poly)
+        self.assertEqual(st.min_temp, t_min)
+        self.assertEqual(st.max_temp, t_max)
+        self.assertEqual(st.reference_pressure, p_ref)
+        for T in [300, 500, 700, 900]:
+            self.assertNear(st.cp(T), st2.cp(T))
+            self.assertNear(st.h(T), st2.h(T))
+            self.assertNear(st.s(T), st2.s(T))
 
 
 class TestQuantity(utilities.CanteraTest):

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1149,6 +1149,15 @@ class TestSpeciesThermo(utilities.CanteraTest):
         self.assertEqual(st.max_temp, 3500)
         self.assertEqual(st.reference_pressure, 101325)
         self.assertArrayNear(self.h2o_coeffs, st.coeffs)
+        self.assertTrue(st.n_coeffs == len(st.coeffs))
+        self.assertTrue(st.check_n_coeffs(st.n_coeffs))
+
+    def test_nasa9(self):
+        gas = ct.Solution('airNASA9.cti')
+        st = gas.species(3).thermo
+        self.assertTrue(isinstance(st, ct.Nasa9PolyMultiTempRegion))
+        self.assertTrue(st.n_coeffs == len(st.coeffs))
+        self.assertTrue(st.check_n_coeffs(st.n_coeffs))
 
 
 class TestQuantity(utilities.CanteraTest):

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1201,7 +1201,8 @@ class TestSpeciesThermo(utilities.CanteraTest):
             self.assertNear(st.s(T), st2.s(T))
 
     def test_piecewise_gibbs_load(self):
-        sol = ct.Solution('thermo-models.yaml', 'HMW-NaCl-electrolyte')
+        # @todo: replace by ct.Solution once issue #595 is resolved
+        sol = ct.ThermoPhase('thermo-models.yaml', 'HMW-NaCl-electrolyte')
         st = sol.species(1).thermo
         self.assertIsInstance(st, ct.Mu0Poly)
         self.assertEqual(st.n_coeffs, len(st.coeffs))
@@ -1222,7 +1223,8 @@ class TestSpeciesThermo(utilities.CanteraTest):
         self.assertEqual(st2.n_coeffs, len(st2.coeffs))
 
     def test_piecewise_gibbs_create2(self):
-        sol = ct.Solution('thermo-models.yaml', 'HMW-NaCl-electrolyte')
+        # @todo: replace by ct.Solution once issue #595 is resolved
+        sol = ct.ThermoPhase('thermo-models.yaml', 'HMW-NaCl-electrolyte')
         st = sol.species(1).thermo
         t_min = st.min_temp
         t_max = st.max_temp

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1150,14 +1150,69 @@ class TestSpeciesThermo(utilities.CanteraTest):
         self.assertEqual(st.reference_pressure, 101325)
         self.assertArrayNear(self.h2o_coeffs, st.coeffs)
         self.assertTrue(st.n_coeffs == len(st.coeffs))
-        self.assertTrue(st.check_n_coeffs(st.n_coeffs))
+        self.assertTrue(st._check_n_coeffs(st.n_coeffs))
 
-    def test_nasa9(self):
+    def test_nasa9_load(self):
         gas = ct.Solution('airNASA9.cti')
         st = gas.species(3).thermo
-        self.assertTrue(isinstance(st, ct.Nasa9PolyMultiTempRegion))
-        self.assertTrue(st.n_coeffs == len(st.coeffs))
-        self.assertTrue(st.check_n_coeffs(st.n_coeffs))
+        self.assertIsInstance(st, ct.Nasa9PolyMultiTempRegion)
+        self.assertEqual(st.n_coeffs, len(st.coeffs))
+        self.assertTrue(st._check_n_coeffs(st.n_coeffs))
+
+    def test_nasa9_create(self):
+        gas = ct.Solution('airNASA9.cti')
+        st = gas.species(3).thermo
+        t_min = st.min_temp
+        t_max = st.max_temp
+        p_ref = st.reference_pressure
+        coeffs = st.coeffs
+        st2 = ct.Nasa9PolyMultiTempRegion(t_min, t_max, p_ref, coeffs)
+        self.assertIsInstance(st2, ct.Nasa9PolyMultiTempRegion)
+        self.assertEqual(st.min_temp, t_min)
+        self.assertEqual(st.max_temp, t_max)
+        self.assertEqual(st.reference_pressure, p_ref)
+        for T in range(300, 20000, 1000):
+            self.assertNear(st.cp(T), st2.cp(T))
+            self.assertNear(st.h(T), st2.h(T))
+            self.assertNear(st.s(T), st2.s(T))
+        
+    def test_shomate_load(self):
+        sol = ct.Solution('thermo-models.yaml', 'molten-salt-Margules')
+        st = sol.species(0).thermo
+        self.assertIsInstance(st, ct.ShomatePoly2)
+        self.assertEqual(st.n_coeffs, len(st.coeffs))
+        self.assertTrue(st._check_n_coeffs(st.n_coeffs))
+
+    def test_shomate_create(self):
+        sol = ct.Solution('thermo-models.yaml', 'molten-salt-Margules')
+        st = sol.species(0).thermo
+        t_min = st.min_temp
+        t_max = st.max_temp
+        p_ref = st.reference_pressure
+        coeffs = st.coeffs
+        st2 = ct.ShomatePoly2(t_min, t_max, p_ref, coeffs)
+        self.assertIsInstance(st2, ct.ShomatePoly2)
+        self.assertEqual(st.min_temp, t_min)
+        self.assertEqual(st.max_temp, t_max)
+        self.assertEqual(st.reference_pressure, p_ref)
+        for T in [300, 500, 700, 900]:
+            self.assertNear(st.cp(T), st2.cp(T))
+            self.assertNear(st.h(T), st2.h(T))
+            self.assertNear(st.s(T), st2.s(T))
+
+    def test_mu0poly_create(self):
+        # use OH- ion data from test/thermo/phaseConstructors.cpp
+        h298 = -230.015e6
+        T1 = 298.15
+        mu1 = -91.50963
+        T2 = 333.15
+        mu2 = -85
+        pref = 101325
+        coeffs = [2, h298, T1, mu1*ct.gas_constant*T1, T2, mu2*ct.gas_constant*T2]
+        st2 = ct.Mu0Poly(200, 3500, pref, coeffs)
+        self.assertIsInstance(st2, ct.Mu0Poly)
+        self.assertEqual(st2.n_coeffs, len(coeffs))
+        self.assertEqual(st2.n_coeffs, len(st2.coeffs))
 
 
 class TestQuantity(utilities.CanteraTest):

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -129,6 +129,11 @@ void Mu0Poly::updatePropertiesTemp(const doublereal T,
     updateProperties(&T, cp_R, h_RT, s_R);
 }
 
+size_t Mu0Poly::nCoeffs() const
+{
+    return 2*m_numIntervals + 2;
+}
+
 void Mu0Poly::reportParameters(size_t& n, int& type,
                                doublereal& tlow, doublereal& thigh,
                                doublereal& pref,

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -131,7 +131,7 @@ void Mu0Poly::updatePropertiesTemp(const doublereal T,
 
 size_t Mu0Poly::nCoeffs() const
 {
-    return 2*m_numIntervals + 2;
+  return 2*m_numIntervals + 4;
 }
 
 void Mu0Poly::reportParameters(size_t& n, int& type,

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -127,6 +127,11 @@ void Nasa9PolyMultiTempRegion::updatePropertiesTemp(const doublereal temp,
     m_regionPts[m_currRegion]->updatePropertiesTemp(temp, cp_R, h_RT, s_R);
 }
 
+size_t Nasa9PolyMultiTempRegion::nCoeffs() const
+{
+    return 11*m_regionPts.size() + 1;
+}
+
 void Nasa9PolyMultiTempRegion::reportParameters(size_t& n, int& type,
         doublereal& tlow, doublereal& thigh,
         doublereal& pref,

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -59,26 +59,17 @@ Nasa9PolyMultiTempRegion::Nasa9PolyMultiTempRegion(vector<Nasa9Poly1*>& regionPt
 
 Nasa9PolyMultiTempRegion::Nasa9PolyMultiTempRegion(double tlow, double thigh, double pref,
                                                    const double* coeffs)
+    : SpeciesThermoInterpType(tlow, thigh, pref)
 {
-    size_t regions = (size_t)coeffs[0];
+    size_t regions = static_cast<size_t>(coeffs[0]);
 
     for (size_t i=0; i<regions; i++) {
-        Nasa9Poly1* poly = new Nasa9Poly1;
-        vector_fp cs;
-        poly->setRefPressure(pref);
-        poly->setMinTemp(coeffs[11*i+1]);
-        poly->setMaxTemp(coeffs[11*i+2]);
-        for (size_t j=11*i+3; j<=11*(i+1); j++) {
-            cs.push_back(coeffs[j]);
-        }
-        poly->setParameters(cs);
+        Nasa9Poly1* poly = new Nasa9Poly1(coeffs[11*i+1], coeffs[11*i+2],
+                                          pref, coeffs + 11*i + 3);
         m_regionPts.emplace_back(poly);
     }
 
     m_lowerTempBounds.resize(regions);
-    m_lowT = tlow;
-    m_highT = thigh;
-    m_Pref = pref;
     for (size_t i = 0; i < m_regionPts.size(); i++) {
         m_lowerTempBounds[i] = m_regionPts[i]->minTemp();
         if (i > 0) {

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -44,6 +44,8 @@ SpeciesThermoInterpType* newSpeciesThermoInterpType(int type, double tlow,
         return new ShomatePoly2(tlow, thigh, pref, coeffs);
     case NASA2:
         return new NasaPoly2(tlow, thigh, pref, coeffs);
+    case NASA9MULTITEMP:
+        return new Nasa9PolyMultiTempRegion(tlow, thigh, pref, coeffs);
     default:
         throw CanteraError("newSpeciesThermoInterpType",
                            "Unknown species thermo type: {}.", type);

--- a/src/thermo/SpeciesThermoInterpType.cpp
+++ b/src/thermo/SpeciesThermoInterpType.cpp
@@ -37,35 +37,30 @@ void SpeciesThermoInterpType::updateProperties(const doublereal* tempPoly,
 void SpeciesThermoInterpType::updatePropertiesTemp(const double temp,
         double* cp_R, double* h_RT, double* s_R) const
 {
-    throw CanteraError("SpeciesThermoInterpType::updatePropertiesTemp",
-                       "Not implemented");
+    throw NotImplementedError("SpeciesThermoInterpType::updatePropertiesTemp");
 }
 
 size_t SpeciesThermoInterpType::nCoeffs() const
 {
-    throw CanteraError("SpeciesThermoInterpType::nCoeffs",
-                       "Not implemented");
+    throw NotImplementedError("SpeciesThermoInterpType::nCoeffs");
 }
 
 void SpeciesThermoInterpType::reportParameters(size_t& index, int& type,
         double& minTemp, double& maxTemp, double& refPressure,
         double* const coeffs) const
 {
-    throw CanteraError("SpeciesThermoInterpType::reportParameters",
-                       "Not implemented");
+    throw NotImplementedError("SpeciesThermoInterpType::reportParameters");
 }
 
 doublereal SpeciesThermoInterpType::reportHf298(doublereal* const h298) const
 {
-    throw CanteraError("SpeciesThermoInterpType::reportHf298",
-                       "Not implemented");
+    throw NotImplementedError("SpeciesThermoInterpType::reportHf298");
 }
 
 void SpeciesThermoInterpType::modifyOneHf298(const size_t k,
                                              const doublereal Hf298New)
 {
-    throw CanteraError("SpeciesThermoInterpType::modifyOneHf298",
-                       "Not implemented");
+    throw NotImplementedError("SpeciesThermoInterpType::modifyOneHf298");
 }
 
 }

--- a/src/thermo/SpeciesThermoInterpType.cpp
+++ b/src/thermo/SpeciesThermoInterpType.cpp
@@ -41,6 +41,12 @@ void SpeciesThermoInterpType::updatePropertiesTemp(const double temp,
                        "Not implemented");
 }
 
+size_t SpeciesThermoInterpType::nCoeffs() const
+{
+    throw CanteraError("SpeciesThermoInterpType::nCoeffs",
+                       "Not implemented");
+}
+
 void SpeciesThermoInterpType::reportParameters(size_t& index, int& type,
         double& minTemp, double& maxTemp, double& refPressure,
         double* const coeffs) const


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes #705

Changes proposed in this pull request:
- Add `Nasa9PolyMultiTempRegion` and `Mu0Poly` class wrappers to `speciesthermo.pyx`
- Add missing C++ constructor for `Nasa9PolyMultiTempRegion`
- Enable variable number of coefficients
- Add unit tests

Note: PR depends on #720 (`piecewise-Gibbs` is affected by #595)