### PR TITLE
Add species alias

### DIFF
--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -703,6 +703,19 @@ public:
      */
     virtual void modifySpecies(size_t k, shared_ptr<Species> spec);
 
+    //! Add a species alias (i.e. user-defined alternative species name).
+    //! Aliases are case-sensitive.
+    //!     @param name original species name std::string.
+    //!     @param alias alternate name std::string.
+    //!     @return `true` if the alias was successfully added
+    //!             (i.e. the original species name is found)
+    void addSpeciesAlias(const std::string& name, const std::string& alias);
+
+    //! Return a vector with isomers names matching a given composition map
+    //!     @param compMap compositionMap of the species.
+    //!     @return A vector of species names for matching species.
+    virtual std::vector<std::string> findIsomers(const compositionMap& compMap) const;
+
     //! Return the Species object for the named species. Changes to this object
     //! do not affect the ThermoPhase object until the #modifySpecies function
     //! is called.

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -716,6 +716,11 @@ public:
     //!     @return A vector of species names for matching species.
     virtual std::vector<std::string> findIsomers(const compositionMap& compMap) const;
 
+    //! Return a vector with isomers names matching a given composition string
+    //!     @param comp String containing a composition map
+    //!     @return A vector of species names for matching species.
+    virtual std::vector<std::string> findIsomers(const std::string& comp) const;
+
     //! Return the Species object for the named species. Changes to this object
     //! do not affect the ThermoPhase object until the #modifySpecies function
     //! is called.

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -185,6 +185,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         void setCaseSensitiveSpecies(cbool)
         void addSpeciesAlias(string, string) except +translate_exception
         vector[string] findIsomers(Composition&) except +translate_exception
+        vector[string] findIsomers(string) except +translate_exception
 
         double molecularWeight(size_t) except +translate_exception
         double meanMolecularWeight()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -183,6 +183,8 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         void getAtoms(size_t, double*) except +translate_exception
         cbool caseSensitiveSpecies()
         void setCaseSensitiveSpecies(cbool)
+        void addSpeciesAlias(string, string) except +translate_exception
+        vector[string] findIsomers(Composition&) except +translate_exception
 
         double molecularWeight(size_t) except +translate_exception
         double meanMolecularWeight()

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1145,12 +1145,16 @@ class TestSpecies(utilities.CanteraTest):
         self.assertTrue(self.gas.species_index('hydrogen') == 0)
         self.gas.X = 'hydrogen:.5, O2:.5'
         self.assertNear(self.gas.X[0], 0.5)
+        with self.assertRaisesRegex(ct.CanteraError, 'Invalid alias'):
+            self.gas.add_species_alias('H2', 'O2')
         with self.assertRaisesRegex(ct.CanteraError, 'Unable to add alias'):
             self.gas.add_species_alias('spam', 'eggs')
 
     def test_isomers(self):
         gas = ct.Solution('nDodecane_Reitz.yaml')
         iso = gas.find_isomers({'C':4, 'H':9, 'O':2})
+        self.assertTrue(len(iso) == 2)
+        iso = gas.find_isomers('C:4, H:9, O:2')
         self.assertTrue(len(iso) == 2)
         iso = gas.find_isomers({'C':7, 'H':15})
         self.assertTrue(len(iso) == 1)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1140,6 +1140,23 @@ class TestSpecies(utilities.CanteraTest):
         with self.assertRaisesRegex(ct.CanteraError, 'modifySpecies'):
             self.gas.modify_species(self.gas.species_index('H2'), copy)
 
+    def test_alias(self):
+        self.gas.add_species_alias('H2', 'hydrogen')
+        self.assertTrue(self.gas.species_index('hydrogen') == 0)
+        self.gas.X = 'hydrogen:.5, O2:.5'
+        self.assertNear(self.gas.X[0], 0.5)
+        with self.assertRaisesRegex(ct.CanteraError, 'Unable to add alias'):
+            self.gas.add_species_alias('spam', 'eggs')
+
+    def test_isomers(self):
+        gas = ct.Solution('nDodecane_Reitz.yaml')
+        iso = gas.find_isomers({'C':4, 'H':9, 'O':2})
+        self.assertTrue(len(iso) == 2)
+        iso = gas.find_isomers({'C':7, 'H':15})
+        self.assertTrue(len(iso) == 1)
+        iso = gas.find_isomers({'C':7, 'H':16})
+        self.assertTrue(len(iso) == 0)
+
 
 class TestSpeciesThermo(utilities.CanteraTest):
     h2o_coeffs = [

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -524,6 +524,22 @@ cdef class ThermoPhase(_SolutionBase):
         if self.kinetics:
             self.kinetics.invalidateCache()
 
+    def add_species_alias(self, name, alias):
+        """
+        Add the alternate species name *alias* for an original species *name*.
+        """
+        self.thermo.addSpeciesAlias(stringify(name), stringify(alias))
+
+    def find_isomers(self, comp):
+        """
+        Find species/isomers matching a composition specified by *comp*.
+        """
+
+        assert isinstance(comp, dict), 'Composition needs to be specified as dictionary'
+        iso = self.thermo.findIsomers(comp_map(comp))
+
+        return [pystr(b) for b in iso]
+
     def n_atoms(self, species, element):
         """
         Number of atoms of element *element* in species *species*. The element

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -535,8 +535,12 @@ cdef class ThermoPhase(_SolutionBase):
         Find species/isomers matching a composition specified by *comp*.
         """
 
-        assert isinstance(comp, dict), 'Composition needs to be specified as dictionary'
-        iso = self.thermo.findIsomers(comp_map(comp))
+        if isinstance(comp, dict):
+            iso = self.thermo.findIsomers(comp_map(comp))
+        elif isinstance(comp, (str, bytes)):
+            iso = self.thermo.findIsomers(stringify(comp))
+        else:
+            raise CanteraError('Invalid composition')
 
         return [pystr(b) for b in iso]
 

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -881,6 +881,11 @@ vector<std::string> Phase::findIsomers(const compositionMap& compMap) const
     return isomerNames;
 }
 
+vector<std::string> Phase::findIsomers(const std::string& comp) const
+{
+    return findIsomers(parseCompString(comp));
+}
+
 shared_ptr<Species> Phase::species(const std::string& name) const
 {
     size_t k = speciesIndex(name);

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -852,6 +852,35 @@ void Phase::modifySpecies(size_t k, shared_ptr<Species> spec)
     invalidateCache();
 }
 
+void Phase::addSpeciesAlias(const std::string& name, const std::string& alias)
+{
+    if (speciesIndex(alias) != npos) {
+        throw CanteraError("Phase::addSpeciesAlias",
+            "Invalid alias '{}': species already exists", alias);
+    }
+    size_t k = speciesIndex(name);
+    if (k != npos) {
+        m_speciesIndices[alias] = k;
+    } else {
+        throw CanteraError("Phase::addSpeciesAlias",
+            "Unable to add alias '{}' "
+            "(original species '{}' not found).", alias, name);
+    }
+}
+
+vector<std::string> Phase::findIsomers(const compositionMap& compMap) const
+{
+    vector<std::string> isomerNames;
+
+    for (const auto& k : m_species) {
+        if (k.second->composition == compMap) {
+            isomerNames.emplace_back(k.first);
+        }
+    }
+
+    return isomerNames;
+}
+
 shared_ptr<Species> Phase::species(const std::string& name) const
 {
     size_t k = speciesIndex(name);


### PR DESCRIPTION
This PR adds utility functions that facilitate selection of species and isomers. Functions are defined in the C++ layer and broken out using the Cython interface.

Changes proposed in this pull request:
- `add_species_alias` allows for alternate species names/shorthands
- `find_isomers` returns a list of isomers for a given composition

Usage:
```python
In [1]: import cantera as ct

In [2]: gas = ct.Solution('nDodecane_Reitz.yaml')

In [3]: gas.find_isomers({'C':4, 'H':9, 'O':2})
Out[3]: ['c4h8ooh', 'c4h9o2']

In [4]: gas.find_isomers({'C':7, 'H':16})
Out[4]: []

In [5]: gas.find_isomers('C:1, H:4')
Out[5]: ['ch4']

In [6]: gas.add_species_alias('ch4', 'Methane')

In [7]: gas.species_index('Methane') == gas.species_index('ch4')
Out[7]: True

In [8]: gas.X = 'Methane:1.'

In [9]: gas.X[gas.species_index('ch4')]
Out[9]: 1.0
```
PS: the implementation of `findIsomers` is analogous to #635; this PR explicitly does not address the overloading of `speciesIndex` (which could be simplified based on this PR).