### PR TITLE
Differentiate quality from mole fraction in Python

### DIFF
--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -296,6 +296,11 @@ public:
         return false;
     }
 
+    //! Return whether phase represents a substance with phase transitions
+    virtual bool hasPhaseTransition() const {
+        return false;
+    }
+
     //! Return whether phase represents a compressible substance
     virtual bool isCompressible() const {
         return true;

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -325,6 +325,7 @@ public:
     //!    "V": specific volume
     //!    "H": specific enthalpy
     //!    "S": specific entropy
+    //!    "Q": vapor fraction
     virtual std::vector<std::string> fullStates() const;
 
     //! Return a vector of settable partial property sets within a phase.

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -47,6 +47,10 @@ public:
         return true;
     }
 
+    virtual bool hasPhaseTransition() const {
+        return true;
+    }
+
     virtual std::vector<std::string> fullStates() const;
     virtual std::vector<std::string> partialStates() const;
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -141,6 +141,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         # miscellaneous
         string type()
         string report(cbool, double) except +translate_exception
+        cbool hasPhaseTransition()
         cbool isPure()
         cbool isCompressible()
         stdmap[string, size_t] nativeState() except +translate_exception

--- a/interfaces/cython/cantera/examples/thermo/rankine.py
+++ b/interfaces/cython/cantera/examples/thermo/rankine.py
@@ -1,5 +1,7 @@
 """
 A Rankine vapor power cycle
+
+Requires: Cantera >= 2.5.0
 """
 
 import cantera as ct
@@ -48,7 +50,7 @@ if __name__ == '__main__':
     w = ct.Water()
 
     # start with saturated liquid water at 300 K
-    w.TX = 300.0, 0.0
+    w.TQ = 300.0, 0.0
     h1 = w.h
     p1 = w.P
     printState(1, w)
@@ -60,7 +62,7 @@ if __name__ == '__main__':
 
     # heat it at constant pressure until it reaches the saturated vapor state
     # at this pressure
-    w.PX = p_max, 1.0
+    w.PQ = p_max, 1.0
     h3 = w.h
     heat_added = h3 - h2
     printState(3, w)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -36,6 +36,11 @@ class TestModels(utilities.CanteraTest):
                 self.assertEqual(sol.T, T0)
                 self.assertEqual(sol.P, p0)
 
+                if sol.thermo_model in ('PureFluid'):
+                    self.assertTrue(sol.has_phase_transition)
+                else:
+                    self.assertFalse(sol.has_phase_transition)
+
                 if not sol.is_compressible:
                     with self.assertRaisesRegex(ct.CanteraError,
                                                 'Density is not an independent'):
@@ -241,6 +246,8 @@ class TestRestorePureFluid(utilities.CanteraTest):
             self.assertArrayNear(a.P, b.P)
             self.assertArrayNear(a.Q, b.Q)
 
+        self.assertTrue(self.water.has_phase_transition)
+            
         # benchmark
         a = ct.SolutionArray(self.water, 10)
         a.TQ = 373.15, np.linspace(0., 1., 10)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -36,7 +36,7 @@ class TestModels(utilities.CanteraTest):
                 self.assertEqual(sol.T, T0)
                 self.assertEqual(sol.P, p0)
 
-                if sol.thermo_model in ('PureFluid'):
+                if sol.thermo_model in ('PureFluid',):
                     self.assertTrue(sol.has_phase_transition)
                 else:
                     self.assertFalse(sol.has_phase_transition)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -239,21 +239,21 @@ class TestRestorePureFluid(utilities.CanteraTest):
         def check(a, b):
             self.assertArrayNear(a.T, b.T)
             self.assertArrayNear(a.P, b.P)
-            self.assertArrayNear(a.X, b.X)
+            self.assertArrayNear(a.Q, b.Q)
 
         # benchmark
         a = ct.SolutionArray(self.water, 10)
-        a.TX = 373.15, np.linspace(0., 1., 10)
+        a.TQ = 373.15, np.linspace(0., 1., 10)
 
         # complete data
-        cols = ('T', 'P', 'X')
+        cols = ('T', 'P', 'Q')
         data, labels = a.collect_data(cols=cols)
         b = ct.SolutionArray(self.water)
         b.restore_data(data, labels)
         check(a, b)
 
         # partial data
-        cols = ('T', 'X')
+        cols = ('T', 'Q')
         data, labels = a.collect_data(cols=cols)
         b = ct.SolutionArray(self.water)
         b.restore_data(data, labels)

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -4,8 +4,6 @@ import numpy as np
 import cantera as ct
 from . import utilities
 
-import warnings
-
 
 class TestPureFluid(utilities.CanteraTest):
     """ Test functionality of the PureFluid class """
@@ -171,78 +169,34 @@ class TestPureFluid(utilities.CanteraTest):
 
     def test_deprecated_X(self):
 
-        # cause all warnings to always be triggered.
-        warnings.simplefilter("always")
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'TQ'"):
             self.water.TX = 400, 0.8
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'TQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'Q'"):
             X = self.water.X
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'Q'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'Q'"):
             self.water.X = X
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'Q'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'TPQ'"):
             T, P, X = self.water.TPX
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'TPQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'TPQ'"):
             self.water.TPX = T, P, X
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'TPQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'TQ'"):
             T, X = self.water.TX
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'TQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'TQ'"):
             self.water.TX = T, X
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'TQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'PQ'"):
             P, X = self.water.PX
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'PQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'PQ'"):
             self.water.PX = P, X
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'PQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'TDQ'"):
             T, D, X = self.water.TDX
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'TDQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'UVQ'"):
             U, V, X = self.water.UVX
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'UVQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'HPQ'"):
             H, P, X = self.water.HPX
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'HPQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'SPQ'"):
             S, P, X = self.water.SPX
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'SPQ'", str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
+        with self.assertWarnsRegex(DeprecationWarning, "renamed to 'SVQ'"):
             S, V, X = self.water.SVX
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("renamed to 'SVQ'", str(w[-1].message))
 
 
 # To minimize errors when transcribing tabulated data, the input units here are:

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -65,7 +65,7 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertNotIn('TPY', self.water._full_states.values())
         self.assertIn('TQ', self.water._partial_states.values())
 
-    def test_set_X(self):
+    def test_set_Q(self):
         self.water.TQ = 500, 0.0
         p = self.water.P
         self.water.Q = 0.8
@@ -295,6 +295,9 @@ class PureFluidTestCases:
         self.fluid.TD = T, rho
         return self.fluid.u - T * self.fluid.s
 
+    def test_has_phase_transition(self):
+        self.assertTrue(self.fluid.has_phase_transition)
+    
     def test_consistency_temperature(self):
         for state in self.states:
             dT = 2e-5 * state.T

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -4,6 +4,8 @@ import numpy as np
 import cantera as ct
 from . import utilities
 
+import warnings
+
 
 class TestPureFluid(utilities.CanteraTest):
     """ Test functionality of the PureFluid class """
@@ -21,13 +23,13 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertNear(co2.max_temp, 1500.0)
 
     def test_set_state(self):
-        self.water.PX = 101325, 0.5
+        self.water.PQ = 101325, 0.5
         self.assertNear(self.water.P, 101325)
-        self.assertNear(self.water.X, 0.5)
+        self.assertNear(self.water.Q, 0.5)
 
-        self.water.TX = 500, 0.8
+        self.water.TQ = 500, 0.8
         self.assertNear(self.water.T, 500)
-        self.assertNear(self.water.X, 0.8)
+        self.assertNear(self.water.Q, 0.8)
 
     def test_substance_set(self):
         self.water.TV = 400, 1.45
@@ -61,23 +63,23 @@ class TestPureFluid(utilities.CanteraTest):
     def test_states(self):
         self.assertEqual(self.water._native_state, ('T', 'D'))
         self.assertNotIn('TPY', self.water._full_states.values())
-        self.assertIn('TX', self.water._partial_states.values())
+        self.assertIn('TQ', self.water._partial_states.values())
 
     def test_set_X(self):
-        self.water.TX = 500, 0.0
+        self.water.TQ = 500, 0.0
         p = self.water.P
-        self.water.X = 0.8
+        self.water.Q = 0.8
         self.assertNear(self.water.P, p)
         self.assertNear(self.water.T, 500)
-        self.assertNear(self.water.X, 0.8)
+        self.assertNear(self.water.Q, 0.8)
 
         self.water.TP = 650, 101325
         with self.assertRaises(ct.CanteraError):
-            self.water.X = 0.1
+            self.water.Q = 0.1
 
         self.water.TP = 300, 101325
         with self.assertRaises(ValueError):
-            self.water.X = 0.3
+            self.water.Q = 0.3
 
     def test_set_minmax(self):
         self.water.TP = self.water.min_temp, 101325
@@ -115,13 +117,13 @@ class TestPureFluid(utilities.CanteraTest):
 
     def test_properties_near_sat1(self):
         for T in [340,390,420]:
-            self.water.TX = T, 0.0
+            self.water.TQ = T, 0.0
             P = self.water.P
             self.check_fd_properties(T, P+0.01, T, P+0.5, 1e-4)
 
     def test_properties_near_sat2(self):
         for T in [340,390,420]:
-            self.water.TX = T, 0.0
+            self.water.TQ = T, 0.0
             P = self.water.P
             self.check_fd_properties(T, P-0.01, T, P-0.5, 1e-4)
 
@@ -147,25 +149,100 @@ class TestPureFluid(utilities.CanteraTest):
             self.assertNear(T * self.water.thermal_expansion_coeff, 1.0, 1e-2)
 
     def test_fd_properties_twophase(self):
-        self.water.TX = 400, 0.1
+        self.water.TQ = 400, 0.1
         self.assertEqual(self.water.cp, np.inf)
         self.assertEqual(self.water.isothermal_compressibility, np.inf)
         self.assertEqual(self.water.thermal_expansion_coeff, np.inf)
 
-    def test_TPX(self):
-        self.water.TX = 400, 0.8
-        T, P, X = self.water.TPX
+    def test_TPQ(self):
+        self.water.TQ = 400, 0.8
+        T, P, Q = self.water.TPQ
         self.assertNear(T, 400)
-        self.assertNear(X, 0.8)
+        self.assertNear(Q, 0.8)
 
-        self.water.TPX = T, P, X
-        self.assertNear(X, 0.8)
+        self.water.TPQ = T, P, Q
+        self.assertNear(Q, 0.8)
         with self.assertRaisesRegex(ValueError, 'invalid thermodynamic'):
-            self.water.TPX = T, .999*P, X
+            self.water.TPQ = T, .999*P, Q
         with self.assertRaisesRegex(ValueError, 'invalid thermodynamic'):
-            self.water.TPX = T, 1.001*P, X
+            self.water.TPQ = T, 1.001*P, Q
         with self.assertRaisesRegex(ValueError, 'numeric value is required'):
-            self.water.TPX = T, P, 'spam'
+            self.water.TPQ = T, P, 'spam'
+
+    def test_deprecated_X(self):
+
+        # cause all warnings to always be triggered.
+        warnings.simplefilter("always")
+
+        with warnings.catch_warnings(record=True) as w:
+            self.water.TX = 400, 0.8
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'TQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            X = self.water.X
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'Q'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            self.water.X = X
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'Q'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            T, P, X = self.water.TPX
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'TPQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            self.water.TPX = T, P, X
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'TPQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            T, X = self.water.TX
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'TQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            self.water.TX = T, X
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'TQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            P, X = self.water.PX
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'PQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            self.water.PX = P, X
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'PQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            T, D, X = self.water.TDX
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'TDQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            U, V, X = self.water.UVX
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'UVQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            H, P, X = self.water.HPX
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'HPQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            S, P, X = self.water.SPX
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'SPQ'", str(w[-1].message))
+
+        with warnings.catch_warnings(record=True) as w:
+            S, V, X = self.water.SVX
+            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
+            self.assertIn("renamed to 'SVQ'", str(w[-1].message))
 
 
 # To minimize errors when transcribing tabulated data, the input units here are:
@@ -255,16 +332,16 @@ class PureFluidTestCases:
                 continue
 
             dT = 1e-6 * state.T
-            self.fluid.TX = state.T, 0
+            self.fluid.TQ = state.T, 0
             p1 = self.fluid.P
             vf = 1.0 / self.fluid.density
             hf = self.fluid.h
             sf = self.fluid.s
 
-            self.fluid.TX = state.T + dT, 0
+            self.fluid.TQ = state.T + dT, 0
             p2 = self.fluid.P
 
-            self.fluid.TX = state.T, 1
+            self.fluid.TQ = state.T, 1
             vg = 1.0 / self.fluid.density
             hg = self.fluid.h
             sg = self.fluid.s

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -1710,9 +1710,9 @@ class PureFluidReactorTest(utilities.CanteraTest):
             net.advance(t)
             states.append(TD=r1.thermo.TD, t=net.time)
 
-        self.assertEqual(states.X[0], 0)
-        self.assertEqual(states.X[-1], 1)
-        self.assertNear(states.X[30], 0.54806, 1e-4)
+        self.assertEqual(states.Q[0], 0)
+        self.assertEqual(states.Q[-1], 1)
+        self.assertNear(states.Q[30], 0.54806, 1e-4)
 
     def test_Reactor_2(self):
         phase = ct.PureFluid('liquidvapor.xml', 'carbondioxide')
@@ -1735,9 +1735,9 @@ class PureFluidReactorTest(utilities.CanteraTest):
             net.advance(t)
             states.append(TD=r1.thermo.TD, t=net.time)
 
-        self.assertEqual(states.X[0], 0)
-        self.assertEqual(states.X[-1], 1)
-        self.assertNear(states.X[20], 0.644865, 1e-4)
+        self.assertEqual(states.Q[0], 0)
+        self.assertEqual(states.Q[-1], 1)
+        self.assertNear(states.Q[20], 0.644865, 1e-4)
 
 
     def test_ConstPressureReactor(self):
@@ -1759,8 +1759,8 @@ class PureFluidReactorTest(utilities.CanteraTest):
             net.advance(t)
             states.append(TD=r1.thermo.TD, t=t)
 
-        self.assertEqual(states.X[1], 0)
-        self.assertEqual(states.X[-2], 1)
+        self.assertEqual(states.Q[1], 0)
+        self.assertEqual(states.Q[-2], 1)
         for i in range(3,7):
             self.assertNear(states.T[i], states.T[2])
 

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1533,6 +1533,20 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertEqual(P.shape, (4,))
         self.assertEqual(Y.shape, (4, self.gas.n_species))
 
+    def test_idealgas_getters(self):
+        N = 11
+        states = ct.SolutionArray(self.gas, N)
+        getters = 'TDPUVHSXY'  # omit getters that contain Q
+
+        # obtain setters from thermo objects
+        all_getters = [k for k in dir(self.gas)
+                       if not set(k) - set(getters) and len(k)>1]
+
+        # ensure that getters do not raise attribute errors
+        for g in all_getters:
+            out = getattr(states, g)
+            self.assertEqual(len(out), len(g))
+
     def test_properties_onedim(self):
         N = 11
         states = ct.SolutionArray(self.gas, N)
@@ -1658,6 +1672,21 @@ class TestSolutionArray(utilities.CanteraTest):
 
         states.TP = np.linspace(400, 500, 5), 101325
         self.assertArrayNear(states.Q.squeeze(), np.ones(5))
+
+    def test_purefluid_getters(self):
+        N = 11
+        water = ct.Water()
+        states = ct.SolutionArray(water, N)
+        getters = 'TDPUVHSQ'  # omit getters that contain X or Y
+
+        # obtain setters from thermo objects
+        all_getters = [k for k in dir(water)
+                       if not set(k) - set(getters) and len(k)>1]
+
+        # ensure that getters do not raise attribute errors
+        for g in all_getters:
+            out = getattr(states, g)
+            self.assertEqual(len(out), len(g))
 
     def test_sort(self):
         np.random.seed(0)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1650,14 +1650,14 @@ class TestSolutionArray(utilities.CanteraTest):
     def test_purefluid(self):
         water = ct.Water()
         states = ct.SolutionArray(water, 5)
-        states.TX = 400, np.linspace(0, 1, 5)
+        states.TQ = 400, np.linspace(0, 1, 5)
 
         P = states.P
         for i in range(1, 5):
             self.assertNear(P[0], P[i])
 
         states.TP = np.linspace(400, 500, 5), 101325
-        self.assertArrayNear(states.X.squeeze(), np.ones(5))
+        self.assertArrayNear(states.Q.squeeze(), np.ones(5))
 
     def test_sort(self):
         np.random.seed(0)

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -292,6 +292,13 @@ cdef class ThermoPhase(_SolutionBase):
         def __get__(self):
             return self.thermo.isPure()
 
+    property has_phase_transition:
+        """
+        Returns true if the phase represents a substance with phase transitions
+        """
+        def __get__(self):
+            return self.thermo.hasPhaseTransition()
+
     property is_compressible:
         """
         Returns true if the density of the phase is an independent variable defining

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1534,33 +1534,88 @@ cdef class PureFluid(ThermoPhase):
         """
         Get/Set vapor fraction (quality). Can be set only when in the two-phase
         region.
+
+        .. deprecated:: 2.5
+
+             Behavior changes after version 2.5, when `X` will refer to mole 
+             fraction. Renamed to `Q`.
+        """
+        def __get__(self):
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'Q'", DeprecationWarning)
+            return self.Q
+        def __set__(self, X):
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'Q'", DeprecationWarning)
+            self.Q = X
+
+    property Q:
+        """
+        Get/Set vapor fraction (quality). Can be set only when in the two-phase
+        region.
         """
         def __get__(self):
             return self.thermo.vaporFraction()
-        def __set__(self, X):
+        def __set__(self, Q):
             if (self.P >= self.critical_pressure or
                 abs(self.P-self.P_sat)/self.P > 1e-4):
                 raise ValueError('Cannot set vapor quality outside the'
                                  'two-phase region')
-            self.thermo.setState_Psat(self.P, X)
+            self.thermo.setState_Psat(self.P, Q)
 
     property TX:
+        """Get/Set the temperature [K] and vapor fraction of a two-phase state.
+
+        .. deprecated:: 2.5
+
+             To be deprecated with version 2.5, and removed thereafter.
+             Renamed to `TQ`.
+        """
+        def __get__(self):
+            warnings.warn("To be removed after Cantera 2.5. "
+                          "Attribute renamed to 'TQ'", DeprecationWarning)
+            return self.TQ
+        def __set__(self, values):
+            warnings.warn("To be removed after Cantera 2.5. "
+                          "Attribute renamed to 'TQ'", DeprecationWarning)
+            self.TQ = values
+
+    property TQ:
         """Get/Set the temperature [K] and vapor fraction of a two-phase state."""
         def __get__(self):
-            return self.T, self.X
+            return self.T, self.Q
         def __set__(self, values):
             T = values[0] if values[0] is not None else self.T
-            X = values[1] if values[1] is not None else self.X
-            self.thermo.setState_Tsat(T, X)
+            Q = values[1] if values[1] is not None else self.Q
+            self.thermo.setState_Tsat(T, Q)
 
     property PX:
+        """Get/Set the pressure [Pa] and vapor fraction of a two-phase state.
+
+        .. deprecated:: 2.5
+
+             To be deprecated with version 2.5, and removed thereafter.
+             Renamed to `PQ`.
+        """
+        def __get__(self):
+            warnings.warn("To be removed after Cantera 2.5. "
+                          "Attribute renamed to 'PQ'", DeprecationWarning)
+            return self.PQ
+        def __set__(self, values):
+            warnings.warn("To be removed after Cantera 2.5. "
+                          "Attribute renamed to 'PQ'", DeprecationWarning)
+            self.PQ = values
+
+    property PQ:
         """Get/Set the pressure [Pa] and vapor fraction of a two-phase state."""
         def __get__(self):
-            return self.P, self.X
+            return self.P, self.Q
         def __set__(self, values):
             P = values[0] if values[0] is not None else self.P
-            X = values[1] if values[1] is not None else self.X
-            self.thermo.setState_Psat(P, X)
+            Q = values[1] if values[1] is not None else self.Q
+            self.thermo.setState_Psat(P, Q)
 
     property ST:
         """Get/Set the entropy [J/kg/K] and temperature [K] of a PureFluid."""
@@ -1647,9 +1702,25 @@ cdef class PureFluid(ThermoPhase):
         """
         Get the temperature [K], density [kg/m^3 or kmol/m^3], and vapor
         fraction.
+
+        .. deprecated:: 2.5
+
+             Behavior changes after version 2.5, when `X` will refer to mole 
+             fraction. Renamed to `TDQ`.
         """
         def __get__(self):
-            return self.T, self.density, self.X
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'TDQ'", DeprecationWarning)
+            return self.TDQ
+
+    property TDQ:
+        """
+        Get the temperature [K], density [kg/m^3 or kmol/m^3], and vapor
+        fraction.
+        """
+        def __get__(self):
+            return self.T, self.density, self.Q
 
     property TPX:
         """
@@ -1657,66 +1728,165 @@ cdef class PureFluid(ThermoPhase):
         PureFluid.
 
         An Exception is raised if the thermodynamic state is not consistent.
+
+        .. deprecated:: 2.5
+
+             Behavior changes after version 2.5, when `X` will refer to mole 
+             fraction. Renamed to `TPQ`.
         """
         def __get__(self):
-            return self.T, self.P, self.X
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'TPQ'", DeprecationWarning)
+            return self.TPQ
+        def __set__(self, values):
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'TPQ'", DeprecationWarning)
+            self.TPQ = values
+
+    property TPQ:
+        """
+        Get/Set the temperature [K], pressure [Pa], and vapor fraction of a
+        PureFluid.
+
+        An Exception is raised if the thermodynamic state is not consistent.
+        """
+        def __get__(self):
+            return self.T, self.P, self.Q
         def __set__(self, values):
             T = values[0] if values[0] is not None else self.T
             P = values[1] if values[1] is not None else self.P
-            X = values[2] if values[2] is not None else self.X
-            if not isinstance(X, (np.ndarray, _numbers.Number)):
+            Q = values[2] if values[2] is not None else self.Q
+            if not isinstance(Q, (np.ndarray, _numbers.Number)):
                 raise ValueError(
                     'a numeric value is required to quanitify '
-                    'the vapor fraction (X)'
+                    'the vapor fraction (Q)'
                 )
             if np.isclose(P, self.thermo.satPressure(T)):
-                self.TX = T, X
-            elif np.isclose(X, 0.) or np.isclose(X, 1.):
+                self.TQ = T, Q
+            elif np.isclose(Q, 0.) or np.isclose(Q, 1.):
                 self.TP = T, P
             else:
                 raise ValueError(
-                    'invalid thermodynamic state: the TPX setter '
+                    'invalid thermodynamic state: the TPQ setter '
                     'received a combination of property values that '
                     'do not represent a valid state. As an alternative, '
                     'specify the state using two fully independent '
                     'properties (e.g. TD) instead of: '
-                    'T={}, P={}, X={}'.format(T, P, X)
+                    'T={}, P={}, Q={}'.format(T, P, Q)
                 )
 
     property UVX:
         """
         Get the internal energy [J/kg or J/kmol], specific volume
         [m^3/kg or m^3/kmol], and vapor fraction.
+
+        .. deprecated:: 2.5
+
+             Behavior changes after version 2.5, when `X` will refer to mole 
+             fraction. Renamed to `UVQ`.
         """
         def __get__(self):
-            return self.u, self.v, self.X
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'UVQ'", DeprecationWarning)
+            return self.UVQ
+
+    property UVQ:
+        """
+        Get the internal energy [J/kg or J/kmol], specific volume
+        [m^3/kg or m^3/kmol], and vapor fraction.
+        """
+        def __get__(self):
+            return self.u, self.v, self.Q
 
     property DPX:
+        """Get the density [kg/m^3], pressure [Pa], and vapor fraction.
+
+        .. deprecated:: 2.5
+
+             Behavior changes after version 2.5, when `X` will refer to mole 
+             fraction. Renamed to `DPQ`.
+        """
+        def __get__(self):
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'DPQ'", DeprecationWarning)
+            return self.DPQ
+
+    property DPQ:
         """Get the density [kg/m^3], pressure [Pa], and vapor fraction."""
         def __get__(self):
-            return self.density, self.P, self.X
+            return self.density, self.P, self.Q
 
     property HPX:
         """
         Get the enthalpy [J/kg or J/kmol], pressure [Pa] and vapor fraction.
+
+        .. deprecated:: 2.5
+
+             Behavior changes after version 2.5, when `X` will refer to mole 
+             fraction. Renamed to `HPQ`.
         """
         def __get__(self):
-            return self.h, self.P, self.X
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'HPQ'", DeprecationWarning)
+            return self.HPQ
+
+    property HPQ:
+        """
+        Get the enthalpy [J/kg or J/kmol], pressure [Pa] and vapor fraction.
+        """
+        def __get__(self):
+            return self.h, self.P, self.Q
 
     property SPX:
         """
         Get the entropy [J/kg/K or J/kmol/K], pressure [Pa], and vapor fraction.
+
+        .. deprecated:: 2.5
+
+             Behavior changes after version 2.5, when `X` will refer to mole 
+             fraction. Renamed to `SPQ`.
         """
         def __get__(self):
-            return self.s, self.P, self.X
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'SPQ'", DeprecationWarning)
+            return self.SPQ
+
+    property SPQ:
+        """
+        Get the entropy [J/kg/K or J/kmol/K], pressure [Pa], and vapor fraction.
+        """
+        def __get__(self):
+            return self.s, self.P, self.Q
 
     property SVX:
         """
         Get the entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
         m^3/kmol], and vapor fraction.
+
+        .. deprecated:: 2.5
+
+             Behavior changes after version 2.5, when `X` will refer to mole 
+             fraction. Renamed to `SVQ`.
         """
         def __get__(self):
-            return self.s, self.v, self.X
+            warnings.warn("Behavior changes after Cantera 2.5, "
+                          "when 'X' will refer to mole fraction. "
+                          "Attribute renamed to 'SVQ'", DeprecationWarning)
+            return self.SVQ
+
+    property SVQ:
+        """
+        Get the entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
+        m^3/kmol], and vapor fraction.
+        """
+        def __get__(self):
+            return self.s, self.v, self.Q
 
 
 class Element:

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1651,7 +1651,7 @@ cdef class PureFluid(ThermoPhase):
         a PureFluid.
         """
         def __get__(self):
-            return self.p, self.v
+            return self.P, self.v
         def __set__(self, values):
             P = values[0] if values[0] is not None else self.P
             V = values[1] if values[1] is not None else self.v

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -84,7 +84,7 @@ std::vector<std::string> PureFluidPhase::fullStates() const
 
 std::vector<std::string> PureFluidPhase::partialStates() const
 {
-    return {"TP", "TX", "PX"};
+    return {"TP", "TQ", "PQ"};
 }
 
 double PureFluidPhase::minTemp(size_t k) const

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -79,7 +79,7 @@ void PureFluidPhase::setParametersFromXML(const XML_Node& eosdata)
 std::vector<std::string> PureFluidPhase::fullStates() const
 {
     return {"TD", "UV", "DP", "HP", "SP", "SV",
-            "ST", "TV", "PV", "UP", "VH", "TH", "SH"};
+            "ST", "TV", "PV", "UP", "VH", "TH", "SH", "TPQ"};
 }
 
 std::vector<std::string> PureFluidPhase::partialStates() const


### PR DESCRIPTION
Please fill in the issue number this pull request is fixing:

Fixes: N/A; but follows discussion in review of #687:

> > [...] it may make sense to use Q for quality at some point in the future. [...]

> This would also be consistent with other naming conventions that have been adopted in the Python module, e.g. D for density instead of R for Rho. [...]

Changes proposed in this pull request:
- Use `Q` instead of `X` for quality (vapor fraction) 
- Deprecate all instances using `X` in `PureFluid`
- ~In `SolutionArray.collect`, the species name is appended in labels, i.e. `Q_H2O`~

I.e.
```python
In [1]: import cantera as ct

In [2]: w = ct.Water()

In [3]: w.TX = 400, .5
DeprecationWarning: To be removed after Cantera 2.5. Attribute renamed to 'TQ'

In [4]: w.TQ
Out[4]: (400.0, 0.5)
```

