### PR TITLE
[Thermo/YAML] Clarify name of water-IAPWS95

### DIFF
--- a/doc/sphinx/yaml/phases.rst
+++ b/doc/sphinx/yaml/phases.rst
@@ -82,7 +82,7 @@ and optionally reactions that can take place in that phase. The fields of a
     - :ref:`pure-fluid <sec-yaml-pure-fluid>`
     - :ref:`Redlich-Kister <sec-yaml-Redlich-Kister>`
     - :ref:`Redlich-Kwong <sec-yaml-Redlich-Kwong>`
-    - :ref:`water-IAPWS95 <sec-yaml-water-IAPWS95>`
+    - :ref:`liquid-water-IAPWS95 <sec-yaml-liquid-water-IAPWS95>`
 
 ``kinetics``
     String specifying the kinetics model to be used. Supported model strings
@@ -793,10 +793,10 @@ Additional fields:
     The molar density of surface sites
 
 
-.. _sec-yaml-water-IAPWS95:
+.. _sec-yaml-liquid-water-IAPWS95:
 
-``water-IAPWS95``
------------------
+``liquid-water-IAPWS95``
+------------------------
 
 An equation of state for liquid water, as
 `described here <https://cantera.org/documentation/dev/doxygen/html/dc/d86/classCantera_1_1WaterSSTP.html#details>`__.

--- a/doc/sphinx/yaml/species.rst
+++ b/doc/sphinx/yaml/species.rst
@@ -247,7 +247,7 @@ Species equation of state models
     - :ref:`ions-from-neutral-molecule <sec-yaml-eos-ions-from-neutral>`
     - :ref:`molar-volume-temperature-polynomial <sec-yaml-eos-molar-volume-temperature-polynomial>`
     - :ref:`Redlich-Kwong <sec-yaml-eos-redlich-kwong>`
-    - :ref:`water-IAPWS95 <sec-yaml-eos-water-iapws95>`
+    - :ref:`liquid-water-IAPWS95 <sec-yaml-eos-liquid-water-iapws95>`
 
 
 .. _sec-yaml-eos-constant-volume:
@@ -405,7 +405,7 @@ Additional fields:
     coefficients for binary interactions between the two species.
 
 
-.. _sec-yaml-eos-water-iapws95:
+.. _sec-yaml-eos-liquid-water-iapws95:
 
 Water IAPWS95
 -------------

--- a/src/thermo/PDSSFactory.cpp
+++ b/src/thermo/PDSSFactory.cpp
@@ -25,7 +25,7 @@ PDSSFactory::PDSSFactory()
     m_synonyms["constant-volume"] = "constant-incompressible";
     reg("water", []() { return new PDSS_Water(); });
     m_synonyms["waterPDSS"] = m_synonyms["waterIAPWS"] = "water";
-    m_synonyms["water-IAPWS95"] = "water";
+    m_synonyms["liquid-water-IAPWS95"] = "water";
     reg("ions-from-neutral", []() { return new PDSS_IonsFromNeutral(); });
     m_synonyms["IonFromNeutral"] = "ions-from-neutral";
     m_synonyms["ions-from-neutral-molecule"] = "ions-from-neutral";

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -91,7 +91,7 @@ ThermoFactory::ThermoFactory()
     reg("MaskellSolidSolnPhase", []() { return new MaskellSolidSolnPhase(); });
     m_synonyms["Maskell-solid-solution"] = "MaskellSolidSolnPhase";
     reg("PureLiquidWater", []() { return new WaterSSTP(); });
-    m_synonyms["water-IAPWS95"] = "PureLiquidWater";
+    m_synonyms["liquid-water-IAPWS95"] = "PureLiquidWater";
     reg("BinarySolutionTabulatedThermo", []() { return new BinarySolutionTabulatedThermo(); });
     m_synonyms["binary-solution-tabulated"] = "BinarySolutionTabulatedThermo";
 }

--- a/test/data/thermo-models.yaml
+++ b/test/data/thermo-models.yaml
@@ -11,7 +11,7 @@ phases:
   state: {T: 300.0, P: 1 atm}
 
 - name: liquid-water
-  thermo: water-IAPWS95
+  thermo: liquid-water-IAPWS95
   transport: water
   species: [H2O(l)]
 
@@ -412,7 +412,7 @@ dh-electrolyte-species:
 - name: H2O(l)
   composition: {H: 2, O: 1}
   equation-of-state:
-    model: water-IAPWS95
+    model: liquid-water-IAPWS95
 - name: Na+
   composition: {Na: 1, E: -1}
   thermo:
@@ -577,7 +577,7 @@ HMW-species:
     - [7.255750050E+01, -6.624454020E-01, 2.561987460E-03, -4.365919230E-06,
        2.781789810E-09, -4.188654990E+04, -2.882801370E+02]
   equation-of-state:
-    model: water-IAPWS95
+    model: liquid-water-IAPWS95
 
 - name: Na+
   composition: {Na: 1, E: -1}


### PR DESCRIPTION
The `water-IAPWS95` instantiates either `WaterSSTP` or `PDSS_water` objects,
both of which are intended for liquid phases only. Clarify the phase
name to `liquid-water-IAPWS95` to allow a future phase that could
represent the full liquid<->vapor phase space.