### PR TITLE
Remove duplication of string identifiers in `Phase`

### DIFF
--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -670,8 +670,8 @@ inline std::ostream& operator<<(std::ostream& s, MultiPhase& x)
 {
     x.updatePhases();
     for (size_t ip = 0; ip < x.nPhases(); ip++) {
-        if (x.phase(ip).name() != "") {
-            s << "*************** " << x.phase(ip).name() << " *****************" << std::endl;
+        if (x.phase(ip).id() != "") {
+            s << "*************** " << x.phase(ip).id() << " *****************" << std::endl;
         } else {
             s << "*************** Phase " << ip << " *****************" << std::endl;
         }

--- a/include/cantera/equil/vcs_VolPhase.h
+++ b/include/cantera/equil/vcs_VolPhase.h
@@ -92,11 +92,11 @@ public:
     /*!
      * @param phaseNum    index of the phase in the vcs problem
      * @param numSpecies  Number of species in the phase
-     * @param phaseName   String name for the phase
+     * @param phaseID     String identifier for the phase
      * @param molesInert  kmoles of inert in the phase (defaults to zero)
      */
     void resize(const size_t phaseNum, const size_t numSpecies,
-                const size_t numElem, const char* const phaseName,
+                const size_t numElem, const char* const phaseID,
                 const double molesInert = 0.0);
 
     void elemResize(const size_t numElemConstraints);
@@ -623,10 +623,13 @@ private:
     size_t m_numSpecies;
 
 public:
-    //! String name for the phase
-    std::string PhaseName;
+    //! String identifier for the phase
+    std::string PhaseID();
 
 private:
+    //! String identifier of the phase
+    std::string m_phaseID;
+
     //!  Total moles of inert in the phase
     double m_totalMolesInert;
 

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -527,7 +527,7 @@ public:
      *       in the private data structure. All references to the species
      *       properties must employ the ind[] index vector.
      *    4. Initialization of arrays to zero.
-     *    5. Check to see if the problem is well posed (If all the element 
+     *    5. Check to see if the problem is well posed (If all the element
      *       abundances are zero, the algorithm will fail)
      *
      * @param printLvl Print level of the routine
@@ -1354,7 +1354,7 @@ public:
     vector_int m_speciesStatus;
 
     //! Mapping from the species number to the phase number
-    std::vector<size_t> m_phaseID;
+    std::vector<size_t> m_phaseNum;
 
     //! Boolean indicating whether a species belongs to a single-species phase
     // vector<bool> can't be used here because it doesn't work with std::swap

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -66,15 +66,11 @@ namespace Cantera
  * operate on a state vector, which is in general of length (2 + nSpecies()).
  * The first two entries of the state vector are temperature and density.
  *
- * A species name may be referred to via three methods:
- *
- *    -   "speciesName"
- *    -   "PhaseId:speciesName"
- *    -   "phaseName:speciesName"
- *    .
- *
- * The first two methods of naming may not yield a unique species within
- * complicated assemblies of %Cantera Phases.
+ * A species name is referred to via "speciesName", which is unique within a
+ * given phase. Note that within multiphase mixtures ("MultiPhase"), both a
+ * phase name/index as well as species name are required to access information
+ * about a species in a particular phase. For surfaces, the species names are
+ * unique among the phases.
  *
  * @todo
  *   - Make the concept of saving state vectors more general, so that it can

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -304,7 +304,6 @@ class TestThermoPhase(utilities.CanteraTest):
 
         self.phase.name = 'something'
         self.assertEqual(self.phase.name, 'something')
-        self.assertIn('something', self.phase.report())
 
     def test_ID(self):
         self.assertEqual(self.phase.ID, 'ohmech')
@@ -312,6 +311,7 @@ class TestThermoPhase(utilities.CanteraTest):
         self.phase.ID = 'something'
         self.assertEqual(self.phase.ID, 'something')
         self.assertEqual(self.phase.name, 'ohmech')
+        self.assertIn('something', self.phase.report())
 
     def test_badLength(self):
         X = np.zeros(5)

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -287,7 +287,7 @@ extern "C" {
     int thermo_getName(int n, size_t lennm, char* nm)
     {
         try {
-            return static_cast<int>(copyString(ThermoCabinet::item(n).name(), nm, lennm));
+            return static_cast<int>(copyString(ThermoCabinet::item(n).id(), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -296,7 +296,7 @@ extern "C" {
     int thermo_setName(int n, const char* nm)
     {
         try {
-            ThermoCabinet::item(n).setName(nm);
+            ThermoCabinet::item(n).setID(nm);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -55,7 +55,7 @@ void MultiPhase::addPhase(ThermoPhase* p, doublereal moles)
 
     if (!p->compatibleWithMultiPhase()) {
         throw CanteraError("MultiPhase::addPhase", "Phase '{}'' is not "
-            "compatible with MultiPhase equilibrium solver", p->name());
+            "compatible with MultiPhase equilibrium solver", p->id());
     }
 
     // save the pointer to the phase object

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -706,7 +706,7 @@ void MultiPhaseEquil::reportCSV(const std::string& reportFile)
         ThermoPhase& tref = m_mix->phase(iphase);
         ThermoPhase* tp = &tref;
         tp->getMoleFractions(&mf[istart]);
-        string phaseName = tref.name();
+        string phaseID = tref.id();
         double TMolesPhase = phaseMoles(iphase);
         size_t nSpecies = tref.nSpecies();
         activity.resize(nSpecies, 0.0);
@@ -733,7 +733,7 @@ void MultiPhaseEquil::reportCSV(const std::string& reportFile)
             tp->getChemPotentials(mu.data());
 
             if (iphase == 0) {
-                fprintf(FP,"        Name,      Phase,  PhaseMoles,  Mole_Fract, "
+                fprintf(FP,"        Name,    PhaseID,  PhaseMoles,  Mole_Fract, "
                         "Molalities,  ActCoeff,   Activity,"
                         "ChemPot_SS0,   ChemPot,   mole_num,       PMVol, Phase_Volume\n");
 
@@ -746,7 +746,7 @@ void MultiPhaseEquil::reportCSV(const std::string& reportFile)
                 fprintf(FP,"%12s, %11s, %11.3e, %11.3e, %11.3e, %11.3e, %11.3e,"
                         "%11.3e, %11.3e, %11.3e, %11.3e, %11.3e\n",
                         sName.c_str(),
-                        phaseName.c_str(), TMolesPhase,
+                        phaseID.c_str(), TMolesPhase,
                         mf[istart + k], molalities[k], ac[k], activity[k],
                         mu0[k]*1.0E-6, mu[k]*1.0E-6,
                         mf[istart + k] * TMolesPhase,
@@ -754,7 +754,7 @@ void MultiPhaseEquil::reportCSV(const std::string& reportFile)
             }
         } else {
             if (iphase == 0) {
-                fprintf(FP,"        Name,       Phase,  PhaseMoles,  Mole_Fract,  "
+                fprintf(FP,"        Name,     PhaseID,  PhaseMoles,  Mole_Fract,  "
                         "Molalities,   ActCoeff,    Activity,"
                         "  ChemPotSS0,     ChemPot,   mole_num,       PMVol, Phase_Volume\n");
 
@@ -770,7 +770,7 @@ void MultiPhaseEquil::reportCSV(const std::string& reportFile)
                 fprintf(FP,"%12s, %11s, %11.3e, %11.3e, %11.3e, %11.3e, %11.3e, "
                         "%11.3e, %11.3e,% 11.3e, %11.3e, %11.3e\n",
                         sName.c_str(),
-                        phaseName.c_str(), TMolesPhase,
+                        phaseID.c_str(), TMolesPhase,
                         mf[istart + k], molalities[k], ac[k],
                         activity[k], mu0[k]*1.0E-6, mu[k]*1.0E-6,
                         mf[istart + k] * TMolesPhase,

--- a/src/equil/vcs_Gibbs.cpp
+++ b/src/equil/vcs_Gibbs.cpp
@@ -42,7 +42,7 @@ double VCS_SOLVE::vcs_GibbsPhase(size_t iphase, const double* const w,
     double g = 0.0;
     double phaseMols = 0.0;
     for (size_t kspec = 0; kspec < m_numSpeciesRdc; ++kspec) {
-        if (m_phaseID[kspec] == iphase && m_speciesUnknownType[kspec] != VCS_SPECIES_TYPE_INTERFACIALVOLTAGE) {
+        if (m_phaseNum[kspec] == iphase && m_speciesUnknownType[kspec] != VCS_SPECIES_TYPE_INTERFACIALVOLTAGE) {
             g += w[kspec] * fe[kspec];
             phaseMols += w[kspec];
         }

--- a/src/equil/vcs_MultiPhaseEquil.cpp
+++ b/src/equil/vcs_MultiPhaseEquil.cpp
@@ -469,7 +469,7 @@ int vcs_MultiPhaseEquil::equilibrate_TP(int estimateEquil,
             } else {
                 plogf("  %15.3e   %15.3e  ", m_mix->speciesMoles(i), m_mix->moleFraction(i));
                 if (m_mix->speciesMoles(i) <= 0.0) {
-                    size_t iph = m_vsolve.m_phaseID[i];
+                    size_t iph = m_vsolve.m_phaseNum[i];
                     vcs_VolPhase* VPhase = m_vsolve.m_VolPhaseList[iph].get();
                     if (VPhase->nSpecies() > 1) {
                         plogf("     -1.000e+300\n");
@@ -533,7 +533,7 @@ void vcs_MultiPhaseEquil::reportCSV(const std::string& reportFile)
 
     for (size_t iphase = 0; iphase < nphase; iphase++) {
         ThermoPhase& tref = m_mix->phase(iphase);
-        string phaseName = tref.name();
+        string phaseID = tref.id();
         vcs_VolPhase* volP = m_vsolve.m_VolPhaseList[iphase].get();
         double TMolesPhase = volP->totalMoles();
         size_t nSpecies = tref.nSpecies();
@@ -562,7 +562,7 @@ void vcs_MultiPhaseEquil::reportCSV(const std::string& reportFile)
             tref.getChemPotentials(&mu[0]);
 
             if (iphase == 0) {
-                fprintf(FP,"        Name,      Phase,  PhaseMoles,  Mole_Fract, "
+                fprintf(FP,"        Name,    PhaseID,  PhaseMoles,  Mole_Fract, "
                         "Molalities,  ActCoeff,   Activity,"
                         "ChemPot_SS0,   ChemPot,   mole_num,       PMVol, Phase_Volume\n");
 
@@ -575,7 +575,7 @@ void vcs_MultiPhaseEquil::reportCSV(const std::string& reportFile)
                 fprintf(FP,"%12s, %11s, %11.3e, %11.3e, %11.3e, %11.3e, %11.3e,"
                         "%11.3e, %11.3e, %11.3e, %11.3e, %11.3e\n",
                         sName.c_str(),
-                        phaseName.c_str(), TMolesPhase,
+                        phaseID.c_str(), TMolesPhase,
                         tref.moleFraction(k), molalities[k], ac[k], activity[k],
                         mu0[k]*1.0E-6, mu[k]*1.0E-6,
                         tref.moleFraction(k) * TMolesPhase,
@@ -583,7 +583,7 @@ void vcs_MultiPhaseEquil::reportCSV(const std::string& reportFile)
             }
         } else {
             if (iphase == 0) {
-                fprintf(FP,"        Name,       Phase,  PhaseMoles,  Mole_Fract,  "
+                fprintf(FP,"        Name,     PhaseID,  PhaseMoles,  Mole_Fract,  "
                         "Molalities,   ActCoeff,    Activity,"
                         "  ChemPotSS0,     ChemPot,   mole_num,       PMVol, Phase_Volume\n");
 
@@ -599,7 +599,7 @@ void vcs_MultiPhaseEquil::reportCSV(const std::string& reportFile)
                 fprintf(FP,"%12s, %11s, %11.3e, %11.3e, %11.3e, %11.3e, %11.3e, "
                         "%11.3e, %11.3e,% 11.3e, %11.3e, %11.3e\n",
                         sName.c_str(),
-                        phaseName.c_str(), TMolesPhase,
+                        phaseID.c_str(), TMolesPhase,
                         tref.moleFraction(k), molalities[k], ac[k],
                         activity[k], mu0[k]*1.0E-6, mu[k]*1.0E-6,
                         tref.moleFraction(k) * TMolesPhase,

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -28,6 +28,7 @@ vcs_VolPhase::vcs_VolPhase(VCS_SOLVE* owningSolverObject) :
     m_numElemConstraints(0),
     m_elemGlobalIndex(0),
     m_numSpecies(0),
+    m_phaseID("<phase-id>"),
     m_totalMolesInert(0.0),
     m_isIdealSoln(false),
     m_existence(VCS_PHASE_EXIST_NO),
@@ -58,8 +59,13 @@ vcs_VolPhase::~vcs_VolPhase()
     }
 }
 
+std::string vcs_VolPhase::PhaseID()
+{
+    return m_phaseID;
+}
+
 void vcs_VolPhase::resize(const size_t phaseNum, const size_t nspecies,
-                          const size_t numElem, const char* const phaseName,
+                          const size_t numElem, const char* const phaseID,
                           const double molesInert)
 {
     AssertThrowMsg(nspecies > 0, "vcs_VolPhase::resize", "nspecies Error");
@@ -68,17 +74,17 @@ void vcs_VolPhase::resize(const size_t phaseNum, const size_t nspecies,
     m_phiVarIndex = npos;
 
     if (phaseNum == VP_ID_) {
-        if (strcmp(PhaseName.c_str(), phaseName)) {
+        if (strcmp(m_phaseID.c_str(), phaseID)) {
             throw CanteraError("vcs_VolPhase::resize",
-                               "Strings are different: " + PhaseName + " " +
-                               phaseName + " :unknown situation");
+                               "Strings are different: " + m_phaseID + " " +
+                               phaseID + " :unknown situation");
         }
     } else {
         VP_ID_ = phaseNum;
-        if (!phaseName) {
-            PhaseName = fmt::format("Phase_{}", VP_ID_);
+        if (!phaseID) {
+            m_phaseID = fmt::format("Phase_{}", VP_ID_);
         } else {
-            PhaseName = phaseName;
+            m_phaseID = phaseID;
         }
     }
     if (nspecies > 1) {
@@ -589,7 +595,7 @@ void vcs_VolPhase::setPtrThermoPhase(ThermoPhase* tp_ptr)
         if (m_numSpecies != 0) {
             plogf("Warning Nsp != NVolSpeces: %d %d \n", nsp, m_numSpecies);
         }
-        resize(VP_ID_, nsp, nelem, PhaseName.c_str());
+        resize(VP_ID_, nsp, nelem, m_phaseID.c_str());
     }
     TP_ptr->getMoleFractions(&Xmol_[0]);
     creationMoleNumbers_ = Xmol_;

--- a/src/equil/vcs_elem.cpp
+++ b/src/equil/vcs_elem.cpp
@@ -87,7 +87,7 @@ void VCS_SOLVE::vcs_elabPhase(size_t iphase, double* const elemAbundPhase)
     for (size_t j = 0; j < m_nelem; ++j) {
         elemAbundPhase[j] = 0.0;
         for (size_t i = 0; i < m_nsp; ++i) {
-            if (m_speciesUnknownType[i] != VCS_SPECIES_TYPE_INTERFACIALVOLTAGE && m_phaseID[i] == iphase) {
+            if (m_speciesUnknownType[i] != VCS_SPECIES_TYPE_INTERFACIALVOLTAGE && m_phaseNum[i] == iphase) {
                 elemAbundPhase[j] += m_formulaMatrix(i,j) * m_molNumSpecies_old[i];
             }
         }

--- a/src/equil/vcs_inest.cpp
+++ b/src/equil/vcs_inest.cpp
@@ -83,7 +83,7 @@ void VCS_SOLVE::vcs_inest(double* const aw, double* const sa, double* const sm,
     }
     for (size_t kspec = 0; kspec < m_numComponents; ++kspec) {
         if (m_speciesUnknownType[kspec] == VCS_SPECIES_TYPE_MOLNUM) {
-            m_tPhaseMoles_new[m_phaseID[kspec]] += m_molNumSpecies_old[kspec];
+            m_tPhaseMoles_new[m_phaseNum[kspec]] += m_molNumSpecies_old[kspec];
         }
     }
     double TMolesMultiphase = 0.0;
@@ -103,7 +103,7 @@ void VCS_SOLVE::vcs_inest(double* const aw, double* const sa, double* const sm,
     for (size_t kspec = 0; kspec < m_numComponents; ++kspec) {
         if (m_speciesUnknownType[kspec] == VCS_SPECIES_TYPE_MOLNUM) {
             if (! m_SSPhase[kspec]) {
-                size_t iph = m_phaseID[kspec];
+                size_t iph = m_phaseNum[kspec];
                 m_feSpecies_new[kspec] += log(m_molNumSpecies_new[kspec] / m_tPhaseMoles_old[iph]);
             }
         } else {
@@ -140,7 +140,7 @@ void VCS_SOLVE::vcs_inest(double* const aw, double* const sa, double* const sm,
         // the phase exists, it stays. If it doesn't exist in the estimate, it
         // doesn't come into existence here.
         if (! m_SSPhase[kspec]) {
-            size_t iph = m_phaseID[kspec];
+            size_t iph = m_phaseNum[kspec];
             if (m_deltaGRxn_new[irxn] > xtphMax[iph]) {
                 m_deltaGRxn_new[irxn] = 0.8 * xtphMax[iph];
             }

--- a/src/equil/vcs_phaseStability.cpp
+++ b/src/equil/vcs_phaseStability.cpp
@@ -125,7 +125,7 @@ size_t VCS_SOLVE::vcs_popPhaseID(std::vector<size_t> & phasePopPhaseIDs)
         if (existence > 0) {
             if (m_debug_print_lvl >= 2) {
                 plogf("  ---    %18s %5d           NA       %11.3e\n",
-                      Vphase->PhaseName, existence, m_tPhaseMoles_old[iph]);
+                      Vphase->PhaseID(), existence, m_tPhaseMoles_old[iph]);
             }
         } else {
             if (Vphase->m_singleSpecies) {
@@ -154,7 +154,7 @@ size_t VCS_SOLVE::vcs_popPhaseID(std::vector<size_t> & phasePopPhaseIDs)
 
                 if (m_debug_print_lvl >= 2) {
                     plogf("  ---    %18s %5d %10.3g %10.3g %s\n",
-                          Vphase->PhaseName, existence, Fephase,
+                          Vphase->PhaseID(), existence, Fephase,
                           m_tPhaseMoles_old[iph], anote);
                 }
             } else {
@@ -171,13 +171,13 @@ size_t VCS_SOLVE::vcs_popPhaseID(std::vector<size_t> & phasePopPhaseIDs)
                     }
                     if (m_debug_print_lvl >= 2) {
                         plogf("  ---    %18s %5d  %11.3g %11.3g\n",
-                              Vphase->PhaseName, existence, Fephase,
+                              Vphase->PhaseID(), existence, Fephase,
                               m_tPhaseMoles_old[iph]);
                     }
                 } else {
                     if (m_debug_print_lvl >= 2) {
                         plogf("  ---    %18s %5d   blocked  %11.3g\n",
-                              Vphase->PhaseName,
+                              Vphase->PhaseID(),
                               existence, m_tPhaseMoles_old[iph]);
                     }
                 }
@@ -215,7 +215,7 @@ int VCS_SOLVE::vcs_popPhaseRxnStepSizes(const size_t iphasePop)
                    "called for a phase that exists!");
     if (m_debug_print_lvl >= 2) {
         plogf("  ---  vcs_popPhaseRxnStepSizes() called to pop phase %s %d into existence\n",
-              Vphase->PhaseName, iphasePop);
+              Vphase->PhaseID(), iphasePop);
     }
     // Section for a single-species phase
     if (Vphase->m_singleSpecies) {
@@ -307,7 +307,7 @@ int VCS_SOLVE::vcs_popPhaseRxnStepSizes(const size_t iphasePop)
                 }
             } else {
                 if (m_elType[j] == VCS_ELEM_TYPE_ABSPOS) {
-                    size_t jph = m_phaseID[j];
+                    size_t jph = m_phaseNum[j];
                     if ((jph != iphasePop) && (!m_SSPhase[j])) {
                         double fdeltaJ = fabs(deltaJ);
                         if (m_molNumSpecies_old[j] > 0.0) {

--- a/src/equil/vcs_prep.cpp
+++ b/src/equil/vcs_prep.cpp
@@ -16,7 +16,7 @@ void VCS_SOLVE::vcs_SSPhase()
 {
     vector_int numPhSpecies(m_numPhases, 0);
     for (size_t kspec = 0; kspec < m_nsp; ++kspec) {
-        numPhSpecies[m_phaseID[kspec]]++;
+        numPhSpecies[m_phaseNum[kspec]]++;
     }
 
     // Handle the special case of a single species in a phase that has been
@@ -37,7 +37,7 @@ void VCS_SOLVE::vcs_SSPhase()
     // information concerning the phase ID of species. SSPhase = Boolean
     // indicating whether a species is in a single species phase or not.
     for (size_t kspec = 0; kspec < m_nsp; kspec++) {
-        size_t iph = m_phaseID[kspec];
+        size_t iph = m_phaseNum[kspec];
         vcs_VolPhase* Vphase = m_VolPhaseList[iph].get();
         if (Vphase->m_singleSpecies) {
             m_SSPhase[kspec] = true;
@@ -70,7 +70,7 @@ int VCS_SOLVE::vcs_prep(int printLvl)
     }
 
     for (size_t kspec = 0; kspec < m_nsp; ++kspec) {
-        size_t pID = m_phaseID[kspec];
+        size_t pID = m_phaseNum[kspec];
         size_t spPhIndex = m_speciesLocalPhaseIndex[kspec];
         vcs_VolPhase* vPhase = m_VolPhaseList[pID].get();
         vcs_SpeciesProperties* spProp = vPhase->speciesProperty(spPhIndex);

--- a/src/equil/vcs_prob.cpp
+++ b/src/equil/vcs_prob.cpp
@@ -41,12 +41,12 @@ void VCS_SOLVE::prob_report(int print_lvl)
         plogf("\t\tPres = %g atm\n", pres_atm);
         plogf("\n");
         plogf("             Phase IDs of species\n");
-        plogf("            species     phaseID        phaseName   ");
+        plogf("            species     phaseNum       phaseID     ");
         plogf(" Initial_Estimated_Moles   Species_Type\n");
         for (size_t i = 0; i < m_nsp; i++) {
-            vcs_VolPhase* Vphase = m_VolPhaseList[m_phaseID[i]].get();
-            plogf("%16s      %5d   %16s", m_mix->speciesName(i), m_phaseID[i],
-                  Vphase->PhaseName);
+            vcs_VolPhase* Vphase = m_VolPhaseList[m_phaseNum[i]].get();
+            plogf("%16s      %5d   %16s", m_mix->speciesName(i), m_phaseNum[i],
+                  Vphase->PhaseID());
             if (m_doEstimateEquil >= 0) {
                 plogf("             %-10.5g", m_molNumSpecies_old[i]);
             } else {
@@ -65,13 +65,13 @@ void VCS_SOLVE::prob_report(int print_lvl)
         // Printout of the Phase structure information
         writeline('-', 80, true, true);
         plogf("             Information about phases\n");
-        plogf("  PhaseName    PhaseNum SingSpec  GasPhase   "
+        plogf("  PhaseID      PhaseNum SingSpec  GasPhase   "
               " EqnState    NumSpec");
         plogf("  TMolesInert      TKmoles\n");
 
         for (size_t iphase = 0; iphase < m_numPhases; iphase++) {
             vcs_VolPhase* Vphase = m_VolPhaseList[iphase].get();
-            plogf("%16s %5d %5d %8d ", Vphase->PhaseName,
+            plogf("%16s %5d %5d %8d ", Vphase->PhaseID(),
                   Vphase->VP_ID_, Vphase->m_singleSpecies, Vphase->m_gasPhase);
             plogf("%16s %8d %16e ", Vphase->eos_name(),
                   Vphase->nSpecies(), Vphase->totalMolesInert());
@@ -101,7 +101,7 @@ void VCS_SOLVE::prob_report(int print_lvl)
                 size_t kglob = Vphase->spGlobalIndexVCS(kindex);
                 plogf("%16s ", m_mix->speciesName(kglob));
                 if (kindex == 0) {
-                    plogf("%16s", Vphase->PhaseName);
+                    plogf("%16s", Vphase->PhaseID());
                 } else {
                     plogf("                ");
                 }

--- a/src/equil/vcs_report.cpp
+++ b/src/equil/vcs_report.cpp
@@ -84,7 +84,7 @@ int VCS_SOLVE::vcs_report(int iconv)
                 plogf(" Inert Gas Species        ");
             } else {
                 plogf(" Inert Species in phase %16s ",
-                      m_VolPhaseList[i]->PhaseName);
+                      m_VolPhaseList[i]->PhaseID());
             }
             plogf("%14.7E     %14.7E    %12.4E\n", TPhInertMoles[i],
                   TPhInertMoles[i] / m_tPhaseMoles_old[i], 0.0);
@@ -162,7 +162,7 @@ int VCS_SOLVE::vcs_report(int iconv)
         plogf(" %10.10s", m_elementName[j]);
     }
     plogf(" |                     |\n");
-    plogf("    PhaseName     |KMolTarget |");
+    plogf("    PhaseID       |KMolTarget |");
     for (size_t j = 0; j < m_nelem; j++) {
         plogf(" %10.3g", m_elemAbundancesGoal[j]);
     }
@@ -171,7 +171,7 @@ int VCS_SOLVE::vcs_report(int iconv)
     for (size_t iphase = 0; iphase < m_numPhases; iphase++) {
         plogf(" %3d ", iphase);
         vcs_VolPhase* VPhase = m_VolPhaseList[iphase].get();
-        plogf("%-12.12s |",VPhase->PhaseName);
+        plogf("%-12.12s |", VPhase->PhaseID());
         plogf("%10.3e |", m_tPhaseMoles_old[iphase]);
         totalMoles += m_tPhaseMoles_old[iphase];
         if (m_tPhaseMoles_old[iphase] != VPhase->totalMoles() &&
@@ -230,7 +230,7 @@ int VCS_SOLVE::vcs_report(int iconv)
     writeline('-', 147, true, true);
     for (size_t i = 0; i < m_nsp; ++i) {
         size_t j = x_order[i].second;
-        size_t pid = m_phaseID[j];
+        size_t pid = m_phaseNum[j];
         plogf(" %-12.12s", m_speciesName[j]);
         plogf(" %14.7E ", m_molNumSpecies_old[j]);
         plogf("%14.7E  ", m_SSfeSpecies[j]);

--- a/src/equil/vcs_rxnadj.cpp
+++ b/src/equil/vcs_rxnadj.cpp
@@ -60,7 +60,7 @@ size_t VCS_SOLVE::vcs_RxnStepSizes(int& forceComponentCalc, size_t& kSpecial)
                 if (m_deltaGRxn_new[irxn] < -1.0e-4) {
                     // First decide if this species is part of a multiphase that
                     // is nontrivial in size.
-                    size_t iph = m_phaseID[kspec];
+                    size_t iph = m_phaseNum[kspec];
                     double tphmoles = m_tPhaseMoles_old[iph];
                     double trphmoles = tphmoles / m_totalMolNum;
                     vcs_VolPhase* Vphase = m_VolPhaseList[iph].get();
@@ -250,7 +250,7 @@ size_t VCS_SOLVE::vcs_RxnStepSizes(int& forceComponentCalc, size_t& kSpecial)
                             m_deltaMolNumSpecies[j] = dss * m_stoichCoeffRxnMatrix(j,irxn);
                         }
 
-                        iphDel = m_phaseID[k];
+                        iphDel = m_phaseNum[k];
                         kSpecial = k;
 
                         if (k != kspec) {
@@ -315,7 +315,7 @@ double VCS_SOLVE::vcs_Hessian_diag_adj(size_t irxn, double hessianDiag_Ideal)
 double VCS_SOLVE::vcs_Hessian_actCoeff_diag(size_t irxn)
 {
     size_t kspec = m_indexRxnToSpecies[irxn];
-    size_t kph = m_phaseID[kspec];
+    size_t kph = m_phaseNum[kspec];
     double np_kspec = std::max(m_tPhaseMoles_old[kph], 1e-13);
     double* sc_irxn = m_stoichCoeffRxnMatrix.ptrColumn(irxn);
 
@@ -327,14 +327,14 @@ double VCS_SOLVE::vcs_Hessian_actCoeff_diag(size_t irxn)
     for (size_t j = 0; j < m_numComponents; j++) {
         if (!m_SSPhase[j]) {
             for (size_t k = 0; k < m_numComponents; ++k) {
-                if (m_phaseID[k] == m_phaseID[j]) {
-                    double np = m_tPhaseMoles_old[m_phaseID[k]];
+                if (m_phaseNum[k] == m_phaseNum[j]) {
+                    double np = m_tPhaseMoles_old[m_phaseNum[k]];
                     if (np > 0.0) {
                         s += sc_irxn[k] * sc_irxn[j] * m_np_dLnActCoeffdMolNum(j,k) / np;
                     }
                 }
             }
-            if (kph == m_phaseID[j]) {
+            if (kph == m_phaseNum[j]) {
                 s += sc_irxn[j] * (m_np_dLnActCoeffdMolNum(j,kspec) + m_np_dLnActCoeffdMolNum(kspec,j)) / np_kspec;
             }
         }

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -91,7 +91,7 @@ void BinarySolutionTabulatedThermo::initThermo()
             throw InputFileError("BinarySolutionTabulatedThermo::initThermo",
                 m_input["tabulated-species"],
                 "Species '{}' is not in phase '{}'",
-                m_input["tabulated-species"].asString(), name());
+                m_input["tabulated-species"].asString(), id());
         }
         const AnyMap& table = m_input["tabulated-thermo"].as<AnyMap>();
         vector_fp x = table["mole-fractions"].asVector<double>();

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -343,7 +343,7 @@ void LatticeSolidPhase::addLattice(shared_ptr<ThermoPhase> lattice)
 void LatticeSolidPhase::setLatticeStoichiometry(const compositionMap& comp)
 {
     for (size_t i = 0; i < m_lattice.size(); i++) {
-        theta_[i] = getValue(comp, m_lattice[i]->name(), 0.0);
+        theta_[i] = getValue(comp, m_lattice[i]->id(), 0.0);
     }
     // Add in the lattice stoichiometry constraint
     for (size_t i = 1; i < m_lattice.size(); i++) {

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -380,8 +380,8 @@ std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
 {
     fmt::memory_buffer b;
     try {
-        if (name() != "") {
-            format_to(b, "\n  {}:\n", name());
+        if (id() != "") {
+            format_to(b, "\n  {}:\n", id());
         }
         format_to(b, "\n");
         format_to(b, "       temperature    {:12.6g}  K\n", temperature());

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -206,6 +206,11 @@ size_t Phase::speciesIndex(const std::string& nameStr) const
         std::string pn;
         std::string sn = parseSpeciesName(nameStr, pn);
         if (pn == "" || pn == m_name || pn == m_id) {
+            warn_deprecated("Phase::speciesIndex()",
+                            "Retrieval of species indices via "
+                            "'PhaseId:speciesName' or 'phaseName:"
+                            "speciesName to be removed "
+                            "after Cantera 2.5.");
             it = m_speciesIndices.find(nameStr);
             if (it != m_speciesIndices.end()) {
                 return it->second;

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -385,8 +385,8 @@ void PureFluidPhase::setState_Psat(doublereal p, doublereal x)
 std::string PureFluidPhase::report(bool show_thermo, doublereal threshold) const
 {
     fmt::memory_buffer b;
-    if (name() != "") {
-        format_to(b, "\n  {}:\n", name());
+    if (id() != "") {
+        format_to(b, "\n  {}:\n", id());
     }
     format_to(b, "\n");
     format_to(b, "       temperature    {:12.6g}  K\n", temperature());

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -448,6 +448,7 @@ void addSpecies(ThermoPhase& thermo, const AnyValue& names, const AnyValue& spec
 void setupPhase(ThermoPhase& thermo, AnyMap& phaseNode, const AnyMap& rootNode)
 {
     thermo.setName(phaseNode["name"].asString());
+    thermo.setID(phaseNode["name"].asString());
     if (rootNode.hasKey("__file__")) {
         phaseNode["__file__"] = rootNode["__file__"];
     }

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -926,8 +926,8 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
 {
     fmt::memory_buffer b;
     try {
-        if (name() != "") {
-            format_to(b, "\n  {}:\n", name());
+        if (id() != "") {
+            format_to(b, "\n  {}:\n", id());
         }
         format_to(b, "\n");
         format_to(b, "       temperature    {:12.6g}  K\n", temperature());

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -508,14 +508,14 @@ TEST(MargulesVPSSTP, fromScratch)
 TEST(LatticeSolidPhase, fromScratch)
 {
     auto base = make_shared<StoichSubstance>();
-    base->setName("Li7Si3(S)");
+    base->setID("Li7Si3(S)");
     base->setDensity(1390.0);
     auto sLi7Si3 = make_shomate2_species("Li7Si3(S)", "Li:7 Si:3", li7si3_shomate_coeffs);
     base->addSpecies(sLi7Si3);
     base->initThermo();
 
     auto interstital = make_shared<LatticePhase>();
-    interstital->setName("Li7Si3_Interstitial");
+    interstital->setID("Li7Si3_Interstitial");
     auto sLii = make_const_cp_species("Li(i)", "Li:1", 298.15, 0, 2e4, 2e4);
     auto sVac = make_const_cp_species("V(i)", "", 298.15, 8.98e4, 0, 0);
     sLii->extra["molar_volume"] = 0.2;


### PR DESCRIPTION
### Deprecate `Phase::name` in favor of `Phase::id`

Currently, there is a duplication of `Phase::name()` and `Phase::id()`, where the former is supposed to be unique, whereas the latter is consistent with the phase id specified in the input file. In current Cantera, however, the context is always clear, so the differentiation is not needed. 

A differentiation of `name` and `phase_id` does make sense for `Solution` objects in the Python interface (and potentially serialization of `Solution` in C++). To preserve this capability, the `name` is reassigned to the C++ object `Solution` (see #696).

### Further:

Currently, phase name/id can be used when accessing species within a `Phase`, i.e.
```
 * A species name may be referred to via three methods:
 *
 *    -   "speciesName"
 *    -   "PhaseId:speciesName"
 *    -   "phaseName:speciesName"
```
The latter are, however, not used. I.e. per @speth's comment in #696
> I believe that these latter two methods are not actually in use within Cantera, and I'm really not sure that we need or want them. For multiphase mixtures (C++ class MultiPhase, Python class Mixture, you always need to provide both a phase name/index as well as species name in order to look up information about a species in a particular phase. And for surfaces, the usual approach is that the species names are unique among the phases, e.g. H2O is a gas species and H2O(s) is the same species absorbed onto the surface. So at some point, I was planning to deprecate and remove this capability anyway.

### Changes proposed in this pull request:

- Replace references to `Phase::name` by `Phase::id` in equilibrium calculations and thermo phases
- Deprecate alternate access methods for `SpeciesIndex` in Cantera 2.5

### Pending 

At this point, the only instance where `Phase::name` is still required is the Python interface (several tests check `name` rather than `ID`). Once #696 is merged, `name` will be part of the C++ `Solution` object, i.e. `Phase::name()` can be deprecated.