### PR TITLE
Add sticking coefficients to CTI API docs

### DIFF
--- a/doc/sphinx/cti/classes.rst
+++ b/doc/sphinx/cti/classes.rst
@@ -119,6 +119,9 @@ Reactions
 .. autoclass:: edge_reaction
    :no-undoc-members:
 
+.. autoclass:: stick
+   :no-undoc-members:
+
 Falloff Parameterizations
 -------------------------
 

--- a/doc/sphinx/yaml/phases.rst
+++ b/doc/sphinx/yaml/phases.rst
@@ -76,13 +76,13 @@ and optionally reactions that can take place in that phase. The fields of a
     - :ref:`ideal-surface <sec-yaml-ideal-surface>`
     - :ref:`ions-from-neutral-molecule <sec-yaml-ions-from-neutral-molecule>`
     - :ref:`lattice <sec-yaml-lattice>`
+    - :ref:`liquid-water-IAPWS95 <sec-yaml-liquid-water-IAPWS95>`
     - :ref:`Margules <sec-yaml-Margules>`
     - :ref:`Maskell-solid-solution <sec-yaml-Maskell-solid-solution>`
     - :ref:`electron-cloud <sec-yaml-electron-cloud>`
     - :ref:`pure-fluid <sec-yaml-pure-fluid>`
     - :ref:`Redlich-Kister <sec-yaml-Redlich-Kister>`
     - :ref:`Redlich-Kwong <sec-yaml-Redlich-Kwong>`
-    - :ref:`liquid-water-IAPWS95 <sec-yaml-liquid-water-IAPWS95>`
 
 ``kinetics``
     String specifying the kinetics model to be used. Supported model strings
@@ -584,6 +584,20 @@ Additional fields:
     ``unity``, ``species-molar-volume``, or ``solvent-molar-volume``.
 
 
+.. _sec-yaml-ideal-surface:
+
+``ideal-surface``
+-----------------
+
+An ideal surface phase, as
+`described here <https://cantera.org/documentation/dev/doxygen/html/d2/d95/classCantera_1_1SurfPhase.html#details>`__.
+
+Additional fields:
+
+``site-density``
+    The molar density of surface sites
+
+
 .. _sec-yaml-ions-from-neutral-molecule:
 
 ``ions-from-neutral-molecule``
@@ -625,6 +639,15 @@ Additional fields:
 
 ``site-density``
     The molar density of lattice sites
+
+
+.. _sec-yaml-liquid-water-IAPWS95:
+
+``liquid-water-IAPWS95``
+------------------------
+
+An equation of state for liquid water, as
+`described here <https://cantera.org/documentation/dev/doxygen/html/dc/d86/classCantera_1_1WaterSSTP.html#details>`__.
 
 
 .. _sec-yaml-Margules:
@@ -777,26 +800,3 @@ A multi-species Redlich-Kwong phase as
 
 The parameters for each species are contained in the corresponding species
 entries.
-
-
-.. _sec-yaml-ideal-surface:
-
-``ideal-surface``
------------------
-
-An ideal surface phase, as
-`described here <https://cantera.org/documentation/dev/doxygen/html/d2/d95/classCantera_1_1SurfPhase.html#details>`__.
-
-Additional fields:
-
-``site-density``
-    The molar density of surface sites
-
-
-.. _sec-yaml-liquid-water-IAPWS95:
-
-``liquid-water-IAPWS95``
-------------------------
-
-An equation of state for liquid water, as
-`described here <https://cantera.org/documentation/dev/doxygen/html/dc/d86/classCantera_1_1WaterSSTP.html#details>`__.

--- a/doc/sphinx/yaml/species.rst
+++ b/doc/sphinx/yaml/species.rst
@@ -245,9 +245,9 @@ Species equation of state models
     - :ref:`HKFT <sec-yaml-eos-hkft>`
     - :ref:`ideal-gas <sec-yaml-eos-ideal-gas>`
     - :ref:`ions-from-neutral-molecule <sec-yaml-eos-ions-from-neutral>`
+    - :ref:`liquid-water-IAPWS95 <sec-yaml-eos-liquid-water-iapws95>`
     - :ref:`molar-volume-temperature-polynomial <sec-yaml-eos-molar-volume-temperature-polynomial>`
     - :ref:`Redlich-Kwong <sec-yaml-eos-redlich-kwong>`
-    - :ref:`liquid-water-IAPWS95 <sec-yaml-eos-liquid-water-iapws95>`
 
 
 .. _sec-yaml-eos-constant-volume:
@@ -369,6 +369,15 @@ Example::
       multipliers: {KCl(l): 1.2}
 
 
+.. _sec-yaml-eos-liquid-water-iapws95:
+
+Liquid Water IAPWS95
+--------------------
+
+A detailed equation of state for liquid water as
+`described here <https://cantera.org/documentation/dev/doxygen/html/de/d64/classCantera_1_1PDSS__Water.html#details>`__.
+
+
 .. _sec-yaml-eos-molar-volume-temperature-polynomial:
 
 Molar volume temperature polynomial
@@ -403,15 +412,6 @@ Additional fields:
 ``binary-a``
     Mapping where the keys are species and the values are the ``a``
     coefficients for binary interactions between the two species.
-
-
-.. _sec-yaml-eos-liquid-water-iapws95:
-
-Water IAPWS95
--------------
-
-A detailed equation of state for liquid water as
-`described here <https://cantera.org/documentation/dev/doxygen/html/de/d64/classCantera_1_1PDSS__Water.html#details>`__.
 
 
 .. _sec-yaml-species-transport:

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -591,6 +591,10 @@ class Arrhenius:
 
 
 class stick(Arrhenius):
+    """
+    A rate expression for a surface reaction given as a sticking probability,
+    parameterized using a modified Arrhenius expression.
+    """
     def __init__(self, *args, **kwargs):
         """
         :param motz_wise:

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -1082,6 +1082,10 @@ class Arrhenius(rate_expression):
                 addFloat(c, 'e', cov[3], fmt = '%f', defunits = _ue)
 
 class stick(Arrhenius):
+    """
+    A rate expression for a surface reaction given as a sticking probability,
+    parameterized using a modified Arrhenius expression.
+    """
     def __init__(self, *args, **kwargs):
         """
         :param motz_wise: 'True' if the Motz & Wise correction should be used,


### PR DESCRIPTION
The `stick` entry was missing from the CTI API docs. This adds it, and a short docstring to the `stick` class for both `ctml_writer` and `cti2yaml`.