### PR TITLE
Deprecate magic numbers for RxnRates.h and Falloff.h

### DIFF
--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -5,6 +5,7 @@
 #define CT_FALLOFF_H
 
 #include "cantera/kinetics/reaction_defs.h"
+#include "cantera/base/global.h"
 
 namespace Cantera
 {
@@ -74,8 +75,18 @@ public:
         return 0;
     }
 
+    //! Return a string representing the type of the Falloff parameterization.
+    virtual std::string type() const {
+        return "Lindemann";
+    }
+
     //! Return an integer representing the type of the Falloff parameterization.
+    /*!
+     * @deprecated To be removed after Cantera 2.5.
+     */
     virtual int getType() const {
+        warn_deprecated("Falloff::getType()",
+            "Replaced by Falloff::type(). To be removed after Cantera 2.5.");
         return SIMPLE_FALLOFF;
     }
 
@@ -146,7 +157,13 @@ public:
         return 1;
     }
 
+    virtual std::string type() const {
+        return "Troe";
+    }
+
     virtual int getType() const {
+        warn_deprecated("Troe::getType()",
+            "Replaced by Troe::type(). To be removed after Cantera 2.5.");
         return TROE_FALLOFF;
     }
 
@@ -220,7 +237,13 @@ public:
         return 2;
     }
 
+    virtual std::string type() const {
+        return "SRI";
+    }
+
     virtual int getType() const {
+        warn_deprecated("SRI::getType()",
+            "Replaced by SRI::type(). To be removed after Cantera 2.5.");
         return SRI_FALLOFF;
     }
 

--- a/include/cantera/kinetics/FalloffFactory.h
+++ b/include/cantera/kinetics/FalloffFactory.h
@@ -58,8 +58,22 @@ public:
      * @param c    input vector of doubles which populates the falloff
      *             parameterization.
      * @returns    a pointer to a new Falloff class.
+     *
+     * @deprecated To be removed after Cantera 2.5.
      */
     virtual Falloff* newFalloff(int type, const vector_fp& c);
+
+    //! Return a pointer to a new falloff function calculator.
+    /*!
+     * @param type String identifier specifying the type of falloff function.
+     *             The standard types match class names defined in Falloff.h.
+     *             A factory class derived from FalloffFactory may define
+     *             other types as well.
+     * @param c    input vector of doubles which populates the falloff
+     *             parameterization.
+     * @returns    a pointer to a new Falloff class.
+     */
+    virtual Falloff* newFalloff(const std::string& type, const vector_fp& c);
 
 private:
     //! Pointer to the single instance of the factory
@@ -73,7 +87,13 @@ private:
 };
 
 //! @copydoc FalloffFactory::newFalloff
+/*!
+ * @deprecated To be removed after Cantera 2.5.
+ */
 shared_ptr<Falloff> newFalloff(int type, const vector_fp& c);
+
+//! @copydoc FalloffFactory::newFalloff
+shared_ptr<Falloff> newFalloff(const std::string& type, const vector_fp& c);
 
 }
 #endif

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -11,6 +11,7 @@
 #include "cantera/kinetics/reaction_defs.h"
 #include "cantera/base/ctexceptions.h"
 #include "cantera/base/stringUtils.h"
+#include "cantera/base/global.h"
 
 #include <iostream>
 
@@ -31,7 +32,12 @@ class Arrhenius
 {
 public:
     //! return the rate coefficient type.
+    /*!
+     * @deprecated To be removed after Cantera 2.5.
+     */
     static int type() {
+        warn_deprecated("Arrhenius::type()",
+            "To be removed after Cantera 2.5.");
         return ARRHENIUS_REACTION_RATECOEFF_TYPE;
     }
 
@@ -119,7 +125,12 @@ class SurfaceArrhenius
 {
 
 public:
+    /*!
+     * @deprecated To be removed after Cantera 2.5.
+     */
     static int type() {
+        warn_deprecated("SurfaceArrhenius::type()",
+            "To be removed after Cantera 2.5.");
         return SURF_ARRHENIUS_REACTION_RATECOEFF_TYPE;
     }
 
@@ -211,7 +222,12 @@ class Plog
 {
 public:
     //! return the rate coefficient type.
+    /*!
+     * @deprecated To be removed after Cantera 2.5.
+     */
     static int type() {
+        warn_deprecated("Plog::type()",
+            "To be removed after Cantera 2.5.");
         return PLOG_REACTION_RATECOEFF_TYPE;
     }
 
@@ -340,7 +356,12 @@ class ChebyshevRate
 {
 public:
     //! return the rate coefficient type.
+    /*!
+     * @deprecated To be removed after Cantera 2.5.
+     */
     static int type() {
+        warn_deprecated("ChebyshevRate::type()",
+            "To be removed after Cantera 2.5.");
         return CHEBYSHEV_REACTION_RATECOEFF_TYPE;
     }
 

--- a/include/cantera/kinetics/reaction_defs.h
+++ b/include/cantera/kinetics/reaction_defs.h
@@ -134,6 +134,9 @@ const int CHEBYSHEV_REACTION_RATECOEFF_TYPE = 8;
 //@}
 
 /** @name Falloff Function Types
+ *
+ * Magic numbers
+ * @deprecated To be removed after Cantera 2.5.
  */
 //@{
 const int SIMPLE_FALLOFF = 100;

--- a/include/cantera/kinetics/reaction_defs.h
+++ b/include/cantera/kinetics/reaction_defs.h
@@ -116,6 +116,9 @@ const int GLOBAL_RXN = 30;
  *
  * Note that not all of these are currently implemented!
  * @todo Finish implementing reaction rate types.
+ *
+ * Magic numbers
+ * @deprecated To be removed after Cantera 2.5.
  */
 //@{
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -324,7 +324,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         size_t workSize()
 
         size_t nParameters()
-        int getType()
+        string type()
         void getParameters(double*)
 
     cdef cppclass CxxFalloffReaction "Cantera::FalloffReaction" (CxxReaction):
@@ -375,7 +375,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         string sticking_species
 
 cdef extern from "cantera/kinetics/FalloffFactory.h" namespace "Cantera":
-    cdef shared_ptr[CxxFalloff] CxxNewFalloff "Cantera::newFalloff" (int, vector[double]) except +
+    cdef shared_ptr[CxxFalloff] CxxNewFalloff "Cantera::newFalloff" (string, vector[double]) except +translate_exception
 
 cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
     cdef cppclass CxxKinetics "Cantera::Kinetics":

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -875,6 +875,7 @@ class TestReaction(utilities.CanteraTest):
         r.low_rate = ct.Arrhenius(2.3e12, -0.9, -1700*1000*4.184)
         r.falloff = ct.TroeFalloff((0.7346, 94, 1756, 5182))
         r.efficiencies = {'AR':0.7, 'H2':2.0, 'H2O':6.0}
+        self.assertEqual(r.falloff.type, "Troe")
 
         gas2 = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                            species=self.species, reactions=[r])
@@ -1099,9 +1100,12 @@ class TestReaction(utilities.CanteraTest):
     def test_modify_falloff(self):
         gas = ct.Solution('gri30.xml')
         gas.TPX = 1100, 3 * ct.one_atm, 'CH4:1.0, O2:0.4, CO2:0.1, H2O:0.05'
+        r0 = gas.reaction(11)
+        self.assertEqual(r0.falloff.type, "Lindemann")
         # these two reactions happen to have the same third-body efficiencies
         r1 = gas.reaction(49)
         r2 = gas.reaction(53)
+        self.assertEqual(r2.falloff.type, "Troe")
         self.assertEqual(r1.efficiencies, r2.efficiencies)
         r2.high_rate = r1.high_rate
         r2.low_rate = r1.low_rate

--- a/src/kinetics/FalloffFactory.cpp
+++ b/src/kinetics/FalloffFactory.cpp
@@ -16,13 +16,17 @@ std::mutex FalloffFactory::falloff_mutex;
 
 FalloffFactory::FalloffFactory()
 {
-    reg("Simple", []() { return new Falloff(); });
+    reg("Lindemann", []() { return new Falloff(); });
+    m_synonyms["Simple"] = "Lindemann";
     reg("Troe", []() { return new Troe(); });
     reg("SRI", []() { return new SRI(); });
 }
 
 Falloff* FalloffFactory::newFalloff(int type, const vector_fp& c)
 {
+    warn_deprecated("FalloffFactory::newFalloff",
+        "Instantiation using magic numbers is deprecated; use string "
+        "identifier instead. To be removed after Cantera 2.5.");
     static const std::unordered_map<int, std::string> types {
         {SIMPLE_FALLOFF, "Simple"},
         {TROE_FALLOFF, "Troe"},
@@ -34,7 +38,20 @@ Falloff* FalloffFactory::newFalloff(int type, const vector_fp& c)
     return f;
 }
 
+Falloff* FalloffFactory::newFalloff(const std::string& type, const vector_fp& c)
+{
+    Falloff* f = create(type);
+    f->init(c);
+    return f;
+}
+
 shared_ptr<Falloff> newFalloff(int type, const vector_fp& c)
+{
+    shared_ptr<Falloff> f(FalloffFactory::factory()->newFalloff(type, c));
+    return f;
+}
+
+shared_ptr<Falloff> newFalloff(const std::string& type, const vector_fp& c)
 {
     shared_ptr<Falloff> f(FalloffFactory::factory()->newFalloff(type, c));
     return f;

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -359,30 +359,28 @@ void readFalloff(FalloffReaction& R, const XML_Node& rc_node)
         falloff_parameters.push_back(fpValueCheck(p[n]));
     }
 
-    int falloff_type = 0;
     if (caseInsensitiveEquals(falloff["type"], "lindemann")) {
-        falloff_type = SIMPLE_FALLOFF;
         if (np != 0) {
             throw CanteraError("readFalloff", "Lindemann parameterization "
                 "takes no parameters, but {} were given", np);
         }
+        R.falloff = newFalloff("Lindemann", falloff_parameters);
     } else if (caseInsensitiveEquals(falloff["type"], "troe")) {
-        falloff_type = TROE_FALLOFF;
         if (np != 3 && np != 4) {
             throw CanteraError("readFalloff", "Troe parameterization takes "
                 "3 or 4 parameters, but {} were given", np);
         }
+        R.falloff = newFalloff("Troe", falloff_parameters);
     } else if (caseInsensitiveEquals(falloff["type"], "sri")) {
-        falloff_type = SRI_FALLOFF;
         if (np != 3 && np != 5) {
             throw CanteraError("readFalloff", "SRI parameterization takes "
                 "3 or 5 parameters, but {} were given", np);
         }
+        R.falloff = newFalloff("SRI", falloff_parameters);
     } else {
         throw CanteraError("readFalloff", "Unrecognized falloff type: '{}'",
                            falloff["type"]);
     }
-    R.falloff = newFalloff(falloff_type, falloff_parameters);
 }
 
 void readFalloff(FalloffReaction& R, const AnyMap& node)
@@ -395,7 +393,7 @@ void readFalloff(FalloffReaction& R, const AnyMap& node)
             f["T1"].asDouble(),
             f.getDouble("T2", 0.0)
         };
-        R.falloff = newFalloff(TROE_FALLOFF, params);
+        R.falloff = newFalloff("Troe", params);
     } else if (node.hasKey("SRI")) {
         auto& f = node["SRI"].as<AnyMap>();
         vector_fp params{
@@ -405,9 +403,9 @@ void readFalloff(FalloffReaction& R, const AnyMap& node)
             f.getDouble("D", 1.0),
             f.getDouble("E", 0.0)
         };
-        R.falloff = newFalloff(SRI_FALLOFF, params);
+        R.falloff = newFalloff("SRI", params);
     } else {
-        R.falloff = newFalloff(SIMPLE_FALLOFF, {});
+        R.falloff = newFalloff("Lindemann", {});
     }
 }
 

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -118,7 +118,7 @@ TEST_F(KineticsFromScratch, add_falloff_reaction)
     ThirdBody tbody;
     tbody.efficiencies = parseCompString("AR:0.7 H2:2.0 H2O:6.0");
     auto R = make_shared<FalloffReaction>(reac, prod, low_rate, high_rate, tbody);
-    R->falloff = newFalloff(TROE_FALLOFF, falloff_params);
+    R->falloff = newFalloff("Troe", falloff_params);
     kin.addReaction(R);
     check_rates(2);
 }


### PR DESCRIPTION
Changes proposed in this pull request:
* Deprecate unused magic number `int type()` methods in `RxnRates.h`. 
* Deprecate magic numbers `int getType()` and introduce `string type()` in `Falloff.h`

I am leaving the remaining magic numbers for kinetics objects as they are, as it may make sense to convert handling of various types to factories instead of having things hard-coded (this is more elaborate and should be handled by a separate PR).