### PR TITLE
[cti2yaml] Add failing test of Motz-Wise option

### DIFF
--- a/doc/sphinx/yaml/phases.rst
+++ b/doc/sphinx/yaml/phases.rst
@@ -115,6 +115,12 @@ and optionally reactions that can take place in that phase. The fields of a
       reactions, where for each section name, that rule is either ``all`` or
       ``declared-species`` and is applied as described above.
 
+``Motz-Wise``
+    Boolean indicating whether the Motz-Wise correction should be applied to
+    sticking reactions. Applicable only to interface phases. The default is
+    ``false``. The value set at the phase level may be overridden on individual
+    reactions.
+
 ``transport``
     String specifying the transport model to be used. Supported model strings
     are:

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1460,6 +1460,8 @@ class ideal_interface(phase):
     def get_yaml(self, out):
         super().get_yaml(out)
         out['site-density'] = applyUnits(self.site_density)
+        if _motz_wise is not None:
+            out['Motz-Wise'] = _motz_wise
 
 
 class edge(ideal_interface):

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -613,6 +613,18 @@ class cti2yamlTest(utilities.CanteraTest):
         self.checkThermo(ctiSurf, yamlSurf, [400, 800, 1600])
         self.checkKinetics(ctiSurf, yamlSurf, [500, 1200], [1e4, 3e5])
 
+    def test_ptcombust_motzwise(self):
+        cti2yaml.convert(Path(self.test_data_dir).joinpath('ptcombust-motzwise.cti'),
+                         Path(self.test_work_dir).joinpath('ptcombust-motzwise.yaml'))
+        ctiGas, yamlGas = self.checkConversion('ptcombust-motzwise')
+        ctiSurf, yamlSurf = self.checkConversion('ptcombust-motzwise', ct.Interface,
+            name='Pt_surf', ctiphases=[ctiGas], yamlphases=[yamlGas])
+
+
+        self.checkKinetics(ctiGas, yamlGas, [500, 1200], [1e4, 3e5])
+        self.checkThermo(ctiSurf, yamlSurf, [400, 800, 1600])
+        self.checkKinetics(ctiSurf, yamlSurf, [900], [101325])
+
     def test_sofc(self):
         cti2yaml.convert(Path(self.cantera_data).joinpath('sofc.cti'),
                          Path(self.test_work_dir).joinpath('sofc.yaml'))


### PR DESCRIPTION
The global Motz-Wise option is not added to the phase specification

The tests on this PR are expected to fail. Creating this so I don't forget to come back and fix it later. If someone else wants to jump in, feel free.