### PR TITLE
Fix coverage consistency issue in getMixDiffCoeffsMole

### DIFF
--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -28,7 +28,6 @@ class TestTransport(utilities.CanteraTest):
         self.assertTrue(all(np.diff(Dkm_prime) < 2*eps))
         self.assertNear(Dkm_prime[0], alpha)
 
-
     def test_mixtureAveraged(self):
         self.assertEqual(self.phase.transport_model, 'Mix')
         Dkm1 = self.phase.mix_diff_coeffs
@@ -46,6 +45,15 @@ class TestTransport(utilities.CanteraTest):
         self.assertArrayNear(Dkm1c, Dkm2c)
         self.assertArrayNear(Dbin1, Dbin2)
         self.assertArrayNear(Dbin1, Dbin1.T)
+
+    def test_mixDiffCoeffsMole(self):
+        # This test is mainly to make code coverage in GasTransport.cpp
+        # consistent by always covering the path where the binary diffusion
+        # coefficients need to be updated
+        Dkm1 = self.phase.mix_diff_coeffs_mole
+        self.phase.TP = self.phase.T + 1, None
+        Dkm2 = self.phase.mix_diff_coeffs_mole
+        self.assertTrue(all(Dkm2 > Dkm1))
 
     def test_CK_mode(self):
         mu_ct = self.phase.viscosity


### PR DESCRIPTION
Fixes #703

As mentioned in my comment on #703, I'm not sure how the code path corresponding to `m_bindiff_ok == false` is getting executed. This adds a test that will always exercise the code path in question, so at least the coverage will be consistent.

I think the only way to ascertain that this is working correctly will be if the issue goes away on other PR builds after this is merged.