### PR TITLE
C++ error message cleanup

### DIFF
--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -62,8 +62,12 @@ class CanteraError : public std::exception
 public:
     //! Normal Constructor for the CanteraError base class
     /*!
-     * @param procedure String name for the function within which the error was
-     *             generated.
+     * @param procedure Name of the function within which the error was
+     *             generated. For member functions, this should be written as
+     *             `ClassName::functionName`. For constructors, this should be
+     *             `ClassName::ClassName`. Arguments can be specified to
+     *             disambiguate overloaded functions, e.g.
+     *             `ClassName::functionName(int, int)`.
      * @param msg  Descriptive string describing the type of error message. This
      *     can be a fmt-style format string (i.e. using curly braces to indicate
      *     fields), which will be used with additional arguments to generate a
@@ -182,6 +186,8 @@ private:
 class NotImplementedError : public CanteraError
 {
 public:
+    //! @param func Name of the unimplemented function, e.g.
+    //!     `ClassName::functionName`
     NotImplementedError(const std::string& func) :
         CanteraError(func, "Not implemented.") {}
 

--- a/include/cantera/numerics/ResidEval.h
+++ b/include/cantera/numerics/ResidEval.h
@@ -83,7 +83,7 @@ public:
     virtual int eval(const doublereal t, const doublereal* const y,
                      const doublereal* const ydot,
                      doublereal* const r) {
-        throw CanteraError("ResidEval::eval()", "base class called");
+        throw NotImplementedError("ResidEval::eval");
     }
 
     virtual int evalSS(const doublereal t, const doublereal* const y,
@@ -117,7 +117,7 @@ public:
     virtual int getInitialConditions(const doublereal t0, doublereal* const y,
                                      doublereal* const ydot) {
         initSizes();
-        throw CanteraError("ResidEval::GetInitialConditions()", "base class called");
+        throw NotImplementedError("ResidEval::GetInitialConditions");
         return 1;
     }
 

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -139,7 +139,7 @@ public:
     //! Throws an exception if n is greater than nComponents()-1
     void checkComponentIndex(size_t n) const {
         if (n >= m_nv) {
-            throw IndexError("checkComponentIndex", "points", n, m_nv-1);
+            throw IndexError("Domain1D::checkComponentIndex", "points", n, m_nv-1);
         }
     }
 
@@ -148,7 +148,7 @@ public:
     //! which take an array pointer.
     void checkComponentArraySize(size_t nn) const {
         if (m_nv > nn) {
-            throw ArraySizeError("checkComponentArraySize", nn, m_nv);
+            throw ArraySizeError("Domain1D::checkComponentArraySize", nn, m_nv);
         }
     }
 
@@ -161,7 +161,7 @@ public:
     //! Throws an exception if n is greater than nPoints()-1
     void checkPointIndex(size_t n) const {
         if (n >= m_points) {
-            throw IndexError("checkPointIndex", "points", n, m_points-1);
+            throw IndexError("Domain1D::checkPointIndex", "points", n, m_points-1);
         }
     }
 
@@ -170,7 +170,7 @@ public:
     //! which take an array pointer.
     void checkPointArraySize(size_t nn) const {
         if (m_points > nn) {
-            throw ArraySizeError("checkPointArraySize", nn, m_points);
+            throw ArraySizeError("Domain1D::checkPointArraySize", nn, m_points);
         }
     }
 

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -66,7 +66,8 @@ public:
     //! Throws an exception if n is greater than nDomains()-1
     void checkDomainIndex(size_t n) const {
         if (n >= m_dom.size()) {
-            throw IndexError("checkDomainIndex", "domains", n, m_dom.size()-1);
+            throw IndexError("OneDim::checkDomainIndex", "domains", n,
+                             m_dom.size()-1);
         }
     }
 
@@ -75,7 +76,8 @@ public:
     //! which take an array pointer.
     void checkDomainArraySize(size_t nn) const {
         if (m_dom.size() > nn) {
-            throw ArraySizeError("checkDomainArraySize", nn, m_dom.size());
+            throw ArraySizeError("OneDim::checkDomainArraySize", nn,
+                                 m_dom.size());
         }
     }
 

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -261,8 +261,7 @@ public:
      *  Resets changes made by modifyOneHf298().
      */
     virtual void resetHf298() {
-        throw CanteraError("SpeciesThermoInterpType::resetHf298",
-                           "Not implemented");
+        throw NotImplementedError("SpeciesThermoInterpType::resetHf298");
     }
 
 protected:

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -269,7 +269,7 @@ public:
      * \f]
      */
     virtual doublereal thermalExpansionCoeff() const {
-        throw NotImplementedError("ThermoPhase::thermalExpansionCoeff()");
+        throw NotImplementedError("ThermoPhase::thermalExpansionCoeff");
     }
 
     /**
@@ -699,7 +699,7 @@ public:
      *               Length: m_kk
      */
     virtual void getCp_R_ref(doublereal* cprt) const {
-        throw NotImplementedError("ThermoPhase::getCp_R_ref()");
+        throw NotImplementedError("ThermoPhase::getCp_R_ref");
     }
 
     //! Get the molar volumes of the species reference states at the current

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1337,7 +1337,7 @@ public:
      * @param x  Fraction of vapor
      */
     virtual void setState_Tsat(doublereal t, doublereal x) {
-        throw NotImplementedError("ThermoPhase::setState_sat");
+        throw NotImplementedError("ThermoPhase::setState_Tsat");
     }
 
     //! Set the state to a saturated system at a particular pressure
@@ -1346,7 +1346,7 @@ public:
      * @param x  Fraction of vapor
      */
     virtual void setState_Psat(doublereal p, doublereal x) {
-        throw NotImplementedError("ThermoPhase::setState_sat");
+        throw NotImplementedError("ThermoPhase::setState_Psat");
     }
 
     //@}

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -23,7 +23,7 @@ std::string Solution::name() const {
     if (m_thermo) {
         return m_thermo->name();
     } else {
-        throw CanteraError("Solution::name()",
+        throw CanteraError("Solution::name",
                            "Requires associated 'ThermoPhase'");
     }
 }
@@ -32,7 +32,7 @@ void Solution::setName(const std::string& name) {
     if (m_thermo) {
         m_thermo->setName(name);
     } else {
-        throw CanteraError("Solution::setName()",
+        throw CanteraError("Solution::setName",
                            "Requires associated 'ThermoPhase'");
     }
 }

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -357,7 +357,7 @@ static std::pair<double, std::string> split_unit(const AnyValue& v) {
         std::string val_units = v.asString();
         size_t space = val_units.find(" ");
         if (space == npos) {
-            throw CanteraError("UnitSystem::convert",
+            throw CanteraError("split_unit (UnitSystem)",
                 "Couldn't parse '{}' as a space-separated value/unit pair\n",
                 val_units);
         }

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -447,7 +447,7 @@ std::string Application::findInputFile(const std::string& name)
         msg += "    a) move the missing files into the local directory;\n";
         msg += "    b) define environment variable CANTERA_DATA to\n";
         msg += "         point to the directory containing the file.";
-        throw CanteraError("findInputFile", msg);
+        throw CanteraError("Application::findInputFile", msg);
     }
 
     return name;

--- a/src/base/ct2ctml.cpp
+++ b/src/base/ct2ctml.cpp
@@ -138,7 +138,7 @@ static std::string call_ctml_writer(const std::string& text, bool isfile)
         message << "Error executing python while converting input file:\n";
         message << "Python command was: '" << pypath() << "'\n";
         message << err.what() << std::endl;
-        throw CanteraError("ct2ctml_string", message.str());
+        throw CanteraError("call_ctml_writer", message.str());
     }
 
     if (python_exit_code != 0) {
@@ -154,7 +154,7 @@ static std::string call_ctml_writer(const std::string& text, bool isfile)
         } else {
             message << "The command did not produce any output." << endl;
         }
-        throw CanteraError("ct2ctml_string", message.str());
+        throw CanteraError("call_ctml_writer", message.str());
     }
 
     if (error_output.size() > 0) {
@@ -228,7 +228,7 @@ void ck2cti(const std::string& in_file, const std::string& thermo_file,
         message << "Error executing python while converting input file:\n";
         message << "Python command was: '" << pypath() << "'\n";
         message << err.what() << std::endl;
-        throw CanteraError("ct2ctml", message.str());
+        throw CanteraError("ck2cti", message.str());
     }
 
     if (python_exit_code != 0) {

--- a/src/base/stringUtils.cpp
+++ b/src/base/stringUtils.cpp
@@ -205,12 +205,13 @@ std::string parseSpeciesName(const std::string& nameStr, std::string& phaseName)
             s = s.substr(icolon+1, s.size());
             icolon = s.find(':');
             if (icolon != std::string::npos) {
-                throw CanteraError("parseSpeciesName()", "two colons in name: " + nameStr);
+                throw CanteraError("parseSpeciesName",
+                                   "two colons in name: '{}'", nameStr);
             }
         }
         if (iend != std::string::npos) {
-            throw CanteraError("parseSpeciesName()",
-                               "Species name has \" ;/\n/\t\" in the middle of it: " + nameStr);
+            throw CanteraError("parseSpeciesName", "Species name has "
+                               "\" ;/\n/\t\" in the middle of it: '{}'", nameStr);
         }
     }
     return s;

--- a/src/base/units.h
+++ b/src/base/units.h
@@ -121,7 +121,7 @@ public:
             // tok is not one of the entries in map m_u, then
             // m_u[tok] returns 0.0. Check for this.
             if (fctr == 0) {
-                throw CanteraError("toSI","unknown unit: "+tsub);
+                throw CanteraError("Unit::toSI", "unknown unit: '{}'", tsub);
             }
             if (action == '-') {
                 f *= fctr;

--- a/src/base/xml.cpp
+++ b/src/base/xml.cpp
@@ -580,7 +580,7 @@ void XML_Node::_require(const std::string& a, const std::string& v) const
     }
     string msg="XML_Node "+name()+" is required to have an attribute named " + a +
                " with the value \"" + v +"\", but instead the value is \"" + attrib(a);
-    throw CanteraError("XML_Node::require", msg);
+    throw CanteraError("XML_Node::_require", msg);
 }
 
 XML_Node* XML_Node::findNameID(const std::string& nameTarget,

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -132,7 +132,7 @@ public:
             }
             data[n] = data[0];
         } else {
-            throw Cantera::CanteraError("Cabinet<M>::del",
+            throw Cantera::CanteraError("Cabinet::del",
                                         "Attempt made to delete an already-deleted object.");
         }
     }

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -157,7 +157,7 @@ extern "C" {
             MultiPhase& mix = mixCabinet::item(i);
             mix.checkPhaseIndex(n);
             if (v < 0.0) {
-                throw CanteraError("setPhaseMoles",
+                throw CanteraError("mix_setPhaseMoles",
                                    "Mole number must be non-negative.");
             }
             mix.setPhaseMoles(n, v);
@@ -194,7 +194,7 @@ extern "C" {
     {
         try {
             if (t < 0.0) {
-                throw CanteraError("setTemperature",
+                throw CanteraError("mix_setTemperature",
                                    "Temperature must be positive.");
             }
             mixCabinet::item(i).setTemperature(t);
@@ -255,7 +255,7 @@ extern "C" {
     {
         try {
             if (p < 0.0) {
-                throw CanteraError("setPressure",
+                throw CanteraError("mix_setPressure",
                                    "Pressure must be positive.");
             }
             mixCabinet::item(i).setPressure(p);

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -390,7 +390,8 @@ extern "C" {
             bool ok = FlowDeviceCabinet::item(i).install(ReactorCabinet::item(n),
                       ReactorCabinet::item(m));
             if (!ok) {
-                throw CanteraError("install","Could not install flow device.");
+                throw CanteraError("flowdev_install",
+                                   "Could not install flow device.");
             }
             return 0;
         } catch (...) {

--- a/src/clib/ctxml.cpp
+++ b/src/clib/ctxml.cpp
@@ -182,7 +182,7 @@ extern "C" {
             if (c) {
                 return XmlCabinet::add(c);
             } else {
-                throw CanteraError("xml_find_id","id not found: "+string(id));
+                throw CanteraError("xml_findID", "id not found: '{}'", id);
             }
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -197,8 +197,7 @@ extern "C" {
             if (c) {
                 return XmlCabinet::add(c);
             } else {
-                throw CanteraError("xml_findByName","name "+string(nm)
-                                   +" not found");
+                throw CanteraError("xml_findByName", "name '{}' not found", nm);
             }
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -325,7 +325,7 @@ int ChemEquil::equilibrate(thermo_t& s, const char* XYstr,
 
     // Check Compatibility
     if (m_mm != s.nElements() || m_kk != s.nSpecies()) {
-        throw CanteraError("ChemEquil::equilibrate ERROR",
+        throw CanteraError("ChemEquil::equilibrate",
                            "Input ThermoPhase is incompatible with initialization");
     }
 
@@ -367,7 +367,8 @@ int ChemEquil::equilibrate(thermo_t& s, const char* XYstr,
         m_p2 = [](ThermoPhase& s) { return s.density(); };
         break;
     default:
-        throw CanteraError("equilibrate","illegal property pair.");
+        throw CanteraError("ChemEquil::equilibrate",
+                           "illegal property pair '{}'", XYstr);
     }
     // If the temperature is one of the specified variables, and
     // it is outside the valid range, throw an exception.
@@ -404,7 +405,7 @@ int ChemEquil::equilibrate(thermo_t& s, const char* XYstr,
         }
     }
     if (tmp <= 0.0) {
-        throw CanteraError("ChemEquil",
+        throw CanteraError("ChemEquil::equilibrate",
                            "Element Abundance Vector is zeroed");
     }
 
@@ -628,7 +629,7 @@ int ChemEquil::equilibrate(thermo_t& s, const char* XYstr,
             info = solve(jac, res_trial.data());
         } catch (CanteraError& err) {
             s.restoreState(state);
-            throw CanteraError("equilibrate",
+            throw CanteraError("ChemEquil::equilibrate",
                                "Jacobian is singular. \nTry adding more species, "
                                "changing the elemental composition slightly, \nor removing "
                                "unused elements.\n\n" + err.getMessage());
@@ -670,7 +671,7 @@ int ChemEquil::equilibrate(thermo_t& s, const char* XYstr,
             fail++;
             if (fail > 3) {
                 s.restoreState(state);
-                throw CanteraError("equilibrate",
+                throw CanteraError("ChemEquil::equilibrate",
                                    "Cannot find an acceptable Newton damping coefficient.");
             }
         } else {

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -1258,7 +1258,7 @@ int ChemEquil::estimateEP_Brinkley(thermo_t& s, vector_fp& x,
                 solve(a1, resid.data());
             } catch (CanteraError& err) {
                 s.restoreState(state);
-                throw CanteraError("equilibrate:estimateEP_Brinkley()",
+                throw CanteraError("ChemEquil::estimateEP_Brinkley",
                                    "Jacobian is singular. \nTry adding more species, "
                                    "changing the elemental composition slightly, \nor removing "
                                    "unused elements.\n\n" + err.getMessage());

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -49,7 +49,7 @@ void MultiPhase::addPhases(std::vector<ThermoPhase*>& phases,
 void MultiPhase::addPhase(ThermoPhase* p, doublereal moles)
 {
     if (m_init) {
-        throw CanteraError("addPhase",
+        throw CanteraError("MultiPhase::addPhase",
                            "phases cannot be added after init() has been called.");
     }
 
@@ -170,14 +170,14 @@ ThermoPhase& MultiPhase::phase(size_t n)
 void MultiPhase::checkPhaseIndex(size_t m) const
 {
     if (m >= nPhases()) {
-        throw IndexError("checkPhaseIndex", "phase", m, nPhases()-1);
+        throw IndexError("MultiPhase::checkPhaseIndex", "phase", m, nPhases()-1);
     }
 }
 
 void MultiPhase::checkPhaseArraySize(size_t mm) const
 {
     if (nPhases() > mm) {
-        throw ArraySizeError("checkPhaseIndex", mm, nPhases());
+        throw ArraySizeError("MultiPhase::checkPhaseIndex", mm, nPhases());
     }
 }
 
@@ -716,14 +716,14 @@ void MultiPhase::setTemperature(const doublereal T)
 void MultiPhase::checkElementIndex(size_t m) const
 {
     if (m >= m_nel) {
-        throw IndexError("checkElementIndex", "elements", m, m_nel-1);
+        throw IndexError("MultiPhase::checkElementIndex", "elements", m, m_nel-1);
     }
 }
 
 void MultiPhase::checkElementArraySize(size_t mm) const
 {
     if (m_nel > mm) {
-        throw ArraySizeError("checkElementArraySize", mm, m_nel);
+        throw ArraySizeError("MultiPhase::checkElementArraySize", mm, m_nel);
     }
 }
 
@@ -745,14 +745,14 @@ size_t MultiPhase::elementIndex(const std::string& name) const
 void MultiPhase::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_nsp) {
-        throw IndexError("checkSpeciesIndex", "species", k, m_nsp-1);
+        throw IndexError("MultiPhase::checkSpeciesIndex", "species", k, m_nsp-1);
     }
 }
 
 void MultiPhase::checkSpeciesArraySize(size_t kk) const
 {
     if (m_nsp > kk) {
-        throw ArraySizeError("checkSpeciesArraySize", kk, m_nsp);
+        throw ArraySizeError("MultiPhase::checkSpeciesArraySize", kk, m_nsp);
     }
 }
 

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -80,7 +80,7 @@ MultiPhaseEquil::MultiPhaseEquil(MultiPhase* mix, bool start, int loglevel) : m_
                 !m_mix->tempOK(ip)) {
             m_incl_species[k] = 0;
             if (m_mix->speciesMoles(k) > 0.0) {
-                throw CanteraError("MultiPhaseEquil",
+                throw CanteraError("MultiPhaseEquil::MultiPhaseEquil",
                                    "condensed-phase species"+ m_mix->speciesName(k)
                                    + " is excluded since its thermo properties are \n"
                                    "not valid at this temperature, but it has "

--- a/src/equil/vcs_MultiPhaseEquil.cpp
+++ b/src/equil/vcs_MultiPhaseEquil.cpp
@@ -407,7 +407,7 @@ int vcs_MultiPhaseEquil::equilibrate(int XY, int estimateEquil,
         return equilibrate_TV(XY, xtarget, estimateEquil,
                                   printLvl, err, maxsteps, loglevel);
     } else {
-        throw CanteraError(" vcs_MultiPhaseEquil::equilibrate",
+        throw CanteraError("vcs_MultiPhaseEquil::equilibrate",
                            "Unsupported Option");
     }
 }

--- a/src/equil/vcs_MultiPhaseEquil.cpp
+++ b/src/equil/vcs_MultiPhaseEquil.cpp
@@ -237,7 +237,7 @@ int vcs_MultiPhaseEquil::equilibrate_HP(doublereal Htarget,
             }
         }
     }
-    throw CanteraError("MultiPhase::equilibrate_HP",
+    throw CanteraError("vcs_MultiPhaseEquil::equilibrate_HP",
                        "No convergence for T");
 }
 
@@ -363,7 +363,7 @@ int vcs_MultiPhaseEquil::equilibrate_SP(doublereal Starget,
             }
         }
     }
-    throw CanteraError("MultiPhase::equilibrate_SP",
+    throw CanteraError("vcs_MultiPhaseEquil::equilibrate_SP",
                        "No convergence for T");
 }
 
@@ -425,11 +425,11 @@ int vcs_MultiPhaseEquil::equilibrate_TP(int estimateEquil,
     // Check obvious bounds on the temperature and pressure NOTE, we may want to
     // do more here with the real bounds given by the ThermoPhase objects.
     if (m_mix->temperature() <= 0.0) {
-        throw CanteraError("vcs_MultiPhaseEquil::equilibrate",
+        throw CanteraError("vcs_MultiPhaseEquil::equilibrate_TP",
                            "Temperature less than zero on input");
     }
     if (m_mix->pressure() <= 0.0) {
-        throw CanteraError("vcs_MultiPhaseEquil::equilibrate",
+        throw CanteraError("vcs_MultiPhaseEquil::equilibrate_TP",
                            "Pressure less than zero on input");
     }
 

--- a/src/equil/vcs_elem_rearrange.cpp
+++ b/src/equil/vcs_elem_rearrange.cpp
@@ -61,7 +61,7 @@ int VCS_SOLVE::vcs_elem_rearrange(double* const aw, double* const sa,
                 }
             }
             if (k == m_nelem) {
-                throw CanteraError("vcs_elem_rearrange",
+                throw CanteraError("VCS_SOLVE::vcs_elem_rearrange",
                         "Shouldn't be here. Algorithm misfired.");
             }
 

--- a/src/equil/vcs_prob.cpp
+++ b/src/equil/vcs_prob.cpp
@@ -169,7 +169,7 @@ size_t VCS_SOLVE::addOnePhaseSpecies(vcs_VolPhase* volPhase, size_t k, size_t kT
 {
     if (kT > m_nsp) {
         // Need to expand the number of species here
-        throw CanteraError("VCS_PROB::addOnePhaseSpecies", "Shouldn't be here");
+        throw CanteraError("VCS_SOLVE::addOnePhaseSpecies", "Shouldn't be here");
     }
     const Array2D& fm = volPhase->getFormulaMatrix();
     for (size_t eVP = 0; eVP < volPhase->nElemConstraints(); eVP++) {

--- a/src/equil/vcs_solve.cpp
+++ b/src/equil/vcs_solve.cpp
@@ -55,13 +55,13 @@ VCS_SOLVE::VCS_SOLVE(MultiPhase* mphase, int printLvl) :
     string ser = "VCS_SOLVE: ERROR:\n\t";
     if (m_nsp <= 0) {
         plogf("%s Number of species is nonpositive\n", ser);
-        throw CanteraError("VCS_SOLVE()", ser +
+        throw CanteraError("VCS_SOLVE::VCS_SOLVE", ser +
                            " Number of species is nonpositive\n");
     }
     if (m_numPhases <= 0) {
         plogf("%s Number of phases is nonpositive\n", ser);
-        throw CanteraError("VCS_SOLVE()", ser +
-                           " Number of species is nonpositive\n");
+        throw CanteraError("VCS_SOLVE::VCS_SOLVE", ser +
+                           " Number of phases is nonpositive\n");
     }
 
     /*

--- a/src/equil/vcs_solve.cpp
+++ b/src/equil/vcs_solve.cpp
@@ -189,7 +189,7 @@ VCS_SOLVE::VCS_SOLVE(MultiPhase* mphase, int printLvl) :
         } else if (eos == "IdealSolidSoln") {
             VolPhase->m_eqnState = VCS_EOS_IDEAL_SOLN;
         } else if (eos == "Surf" || eos == "Edge") {
-            throw CanteraError("VCSnonideal",
+            throw CanteraError("VCS_SOLVE::VCS_SOLVE",
                                "Surface/edge phase not handled yet.");
         } else {
             if (m_printLvl > 1) {
@@ -231,7 +231,7 @@ VCS_SOLVE::VCS_SOLVE(MultiPhase* mphase, int printLvl) :
              } else if (m_speciesUnknownType[kT] == VCS_SPECIES_TYPE_INTERFACIALVOLTAGE) {
                 m_molNumSpecies_old[kT] = tPhase->electricPotential();
              } else {
-               throw CanteraError(" vcs_Cantera_to_vsolve() ERROR",
+               throw CanteraError("VCS_SOLVE::VCS_SOLVE",
                                   "Unknown species type: {}", m_speciesUnknownType[kT]);
              }
 
@@ -425,7 +425,7 @@ VCS_SOLVE::VCS_SOLVE(MultiPhase* mphase, int printLvl) :
         if (m_elType[i] == VCS_ELEM_TYPE_CHARGENEUTRALITY) {
             if (m_elemAbundancesGoal[i] != 0.0) {
                 if (fabs(m_elemAbundancesGoal[i]) > 1.0E-9) {
-                    throw CanteraError("VCS_SOLVE::vcs_prob_specifyFully",
+                    throw CanteraError("VCS_SOLVE::VCS_SOLVE",
                             "Charge neutrality condition {} is signicantly "
                             "nonzero, {}. Giving up",
                             m_elementName[i], m_elemAbundancesGoal[i]);

--- a/src/fortran/fctxml.cpp
+++ b/src/fortran/fctxml.cpp
@@ -203,7 +203,8 @@ extern "C" {
             if (c) {
                 return XmlCabinet::add(c);
             } else {
-                throw CanteraError("fxml_find_id","id not found: "+f2string(id, idlen));
+                throw CanteraError("fxml_findid", "id not found: '{}'",
+                                   f2string(id, idlen));
             }
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -219,8 +220,8 @@ extern "C" {
             if (c) {
                 return XmlCabinet::add(c);
             } else {
-                throw CanteraError("fxml_findByName","name "+f2string(nm, nmlen)
-                                   +" not found");
+                throw CanteraError("fxml_findByName", "name '{}' not found",
+                                   f2string(nm, nmlen));
             }
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -43,7 +43,7 @@ ImplicitSurfChem::ImplicitSurfChem(
         m_vecKinPtrs.push_back(kinPtr);
         size_t ns = k[n]->surfacePhaseIndex();
         if (ns == npos) {
-            throw CanteraError("ImplicitSurfChem",
+            throw CanteraError("ImplicitSurfChem::ImplicitSurfChem",
                                "kinetics manager contains no surface phase");
         }
         m_surfindex.push_back(ns);

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -571,7 +571,7 @@ bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base)
         } else {
             m_ctrxn_BVform.push_back(0);
             if (re->film_resistivity > 0.0) {
-                throw CanteraError("InterfaceKinetics::addReaction()",
+                throw CanteraError("InterfaceKinetics::addReaction",
                                    "film resistivity set for elementary reaction");
             }
         }
@@ -825,7 +825,7 @@ void InterfaceKinetics::setPhaseExistence(const size_t iphase, const int exists)
 int InterfaceKinetics::phaseExistence(const size_t iphase) const
 {
     if (iphase >= m_thermo.size()) {
-        throw CanteraError("InterfaceKinetics:phaseExistence()", "out of bounds");
+        throw CanteraError("InterfaceKinetics:phaseExistence", "out of bounds");
     }
     return m_phaseExists[iphase];
 }
@@ -833,7 +833,7 @@ int InterfaceKinetics::phaseExistence(const size_t iphase) const
 int InterfaceKinetics::phaseStability(const size_t iphase) const
 {
     if (iphase >= m_thermo.size()) {
-        throw CanteraError("InterfaceKinetics:phaseStability()", "out of bounds");
+        throw CanteraError("InterfaceKinetics:phaseStability", "out of bounds");
     }
     return m_phaseIsStable[iphase];
 }

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -803,9 +803,7 @@ void InterfaceKinetics::solvePseudoSteadyStateProblem(
 
 void InterfaceKinetics::setPhaseExistence(const size_t iphase, const int exists)
 {
-    if (iphase >= m_thermo.size()) {
-        throw CanteraError("InterfaceKinetics:setPhaseExistence", "out of bounds");
-    }
+    checkPhaseIndex(iphase);
     if (exists) {
         if (!m_phaseExists[iphase]) {
             m_phaseExistsCheck--;
@@ -824,25 +822,19 @@ void InterfaceKinetics::setPhaseExistence(const size_t iphase, const int exists)
 
 int InterfaceKinetics::phaseExistence(const size_t iphase) const
 {
-    if (iphase >= m_thermo.size()) {
-        throw CanteraError("InterfaceKinetics:phaseExistence", "out of bounds");
-    }
+    checkPhaseIndex(iphase);
     return m_phaseExists[iphase];
 }
 
 int InterfaceKinetics::phaseStability(const size_t iphase) const
 {
-    if (iphase >= m_thermo.size()) {
-        throw CanteraError("InterfaceKinetics:phaseStability", "out of bounds");
-    }
+    checkPhaseIndex(iphase);
     return m_phaseIsStable[iphase];
 }
 
 void InterfaceKinetics::setPhaseStability(const size_t iphase, const int isStable)
 {
-    if (iphase >= m_thermo.size()) {
-        throw CanteraError("InterfaceKinetics:setPhaseStability", "out of bounds");
-    }
+    checkPhaseIndex(iphase);
     if (isStable) {
         m_phaseIsStable[iphase] = true;
     } else {

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -137,7 +137,8 @@ void InterfaceKinetics::updateKc()
         for (size_t i = 0; i < m_revindex.size(); i++) {
             size_t irxn = m_revindex[i];
             if (irxn == npos || irxn >= nReactions()) {
-                throw CanteraError("InterfaceKinetics", "illegal value: irxn = {}", irxn);
+                throw CanteraError("InterfaceKinetics::updateKc",
+                                   "illegal value: irxn = {}", irxn);
             }
             // WARNING this may overflow HKM
             m_rkcn[irxn] = exp(m_rkcn[irxn]*rrt);
@@ -639,7 +640,7 @@ SurfaceArrhenius InterfaceKinetics::buildSurfaceArrhenius(
                 if (iPhase != iInterface) {
                     // Non-interface species. There should be exactly one of these
                     if (foundStick) {
-                        throw CanteraError("InterfaceKinetics::addReaction",
+                        throw CanteraError("InterfaceKinetics::buildSurfaceArrhenius",
                             "Multiple non-interface species found"
                             "in sticking reaction: '" + r.equation() + "'");
                     }
@@ -648,7 +649,7 @@ SurfaceArrhenius InterfaceKinetics::buildSurfaceArrhenius(
                 }
             }
             if (!foundStick) {
-                throw CanteraError("InterfaceKinetics::addReaction",
+                throw CanteraError("InterfaceKinetics::buildSurfaceArrhenius",
                     "No non-interface species found"
                     "in sticking reaction: '" + r.equation() + "'");
             }
@@ -726,13 +727,15 @@ void InterfaceKinetics::addPhase(thermo_t& thermo)
 void InterfaceKinetics::init()
 {
     size_t ks = reactionPhaseIndex();
-    if (ks == npos) throw CanteraError("InterfaceKinetics::finalize",
-                                           "no surface phase is present.");
+    if (ks == npos) {
+        throw CanteraError("InterfaceKinetics::init",
+                           "no surface phase is present.");
+    }
 
     // Check to see that the interface routine has a dimension of 2
     m_surf = (SurfPhase*)&thermo(ks);
     if (m_surf->nDim() != m_nDim) {
-        throw CanteraError("InterfaceKinetics::finalize",
+        throw CanteraError("InterfaceKinetics::init",
                            "expected interface dimension = 2, but got dimension = {}",
                            m_surf->nDim());
     }

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -34,42 +34,44 @@ Kinetics::~Kinetics() {}
 void Kinetics::checkReactionIndex(size_t i) const
 {
     if (i >= nReactions()) {
-        throw IndexError("checkReactionIndex", "reactions", i, nReactions()-1);
+        throw IndexError("Kinetics::checkReactionIndex", "reactions", i,
+                         nReactions()-1);
     }
 }
 
 void Kinetics::checkReactionArraySize(size_t ii) const
 {
     if (nReactions() > ii) {
-        throw ArraySizeError("checkReactionArraySize", ii, nReactions());
+        throw ArraySizeError("Kinetics::checkReactionArraySize", ii,
+                             nReactions());
     }
 }
 
 void Kinetics::checkPhaseIndex(size_t m) const
 {
     if (m >= nPhases()) {
-        throw IndexError("checkPhaseIndex", "phase", m, nPhases()-1);
+        throw IndexError("Kinetics::checkPhaseIndex", "phase", m, nPhases()-1);
     }
 }
 
 void Kinetics::checkPhaseArraySize(size_t mm) const
 {
     if (nPhases() > mm) {
-        throw ArraySizeError("checkPhaseArraySize", mm, nPhases());
+        throw ArraySizeError("Kinetics::checkPhaseArraySize", mm, nPhases());
     }
 }
 
 void Kinetics::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_kk) {
-        throw IndexError("checkSpeciesIndex", "species", k, m_kk-1);
+        throw IndexError("Kinetics::checkSpeciesIndex", "species", k, m_kk-1);
     }
 }
 
 void Kinetics::checkSpeciesArraySize(size_t kk) const
 {
     if (m_kk > kk) {
-        throw ArraySizeError("checkSpeciesArraySize", kk, m_kk);
+        throw ArraySizeError("Kinetics::checkSpeciesArraySize", kk, m_kk);
     }
 }
 
@@ -258,7 +260,7 @@ void Kinetics::checkReactionBalance(const Reaction& R)
     if (!ok) {
         msg = "The following reaction is unbalanced: " + R.equation() + "\n" +
               "  Element    Reactants    Products\n" + msg;
-        throw CanteraError("checkReactionBalance", msg);
+        throw CanteraError("Kinetics::checkReactionBalance", msg);
     }
 }
 
@@ -326,7 +328,7 @@ thermo_t& Kinetics::speciesPhase(const std::string& nm)
             return thermo(n);
         }
     }
-    throw CanteraError("speciesPhase", "unknown species "+nm);
+    throw CanteraError("Kinetics::speciesPhase", "unknown species '{}'", nm);
 }
 
 const thermo_t& Kinetics::speciesPhase(const std::string& nm) const
@@ -336,7 +338,7 @@ const thermo_t& Kinetics::speciesPhase(const std::string& nm) const
             return *thermo;
         }
     }
-    throw CanteraError("speciesPhase", "unknown species "+nm);
+    throw CanteraError("Kinetics::speciesPhase", "unknown species '{}'", nm);
 }
 
 size_t Kinetics::speciesPhaseIndex(size_t k) const
@@ -346,7 +348,8 @@ size_t Kinetics::speciesPhaseIndex(size_t k) const
             return n;
         }
     }
-    throw CanteraError("speciesPhaseIndex", "illegal species index: {}", k);
+    throw CanteraError("Kinetics::speciesPhaseIndex",
+                       "illegal species index: {}", k);
 }
 
 double Kinetics::reactantStoichCoeff(size_t kSpec, size_t irxn) const

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -136,7 +136,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
         } else if (rules[i] == "declared-species") {
             kin.skipUndeclaredSpecies(true);
         } else if (rules[i] != "none") {
-            throw InputFileError("setupKinetics", phaseNode.at("reactions"),
+            throw InputFileError("addReactions", phaseNode.at("reactions"),
                 "Unknown rule '{}' for adding species from the '{}' section.",
                 rules[i], sections[i]);
         }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -483,11 +483,11 @@ void parseReactionEquation(Reaction& R, const AnyValue& equation,
                 try {
                     stoich = fpValueCheck(tokens[i-2]);
                 } catch (CanteraError& err) {
-                    throw InputFileError("fpValueCheck", equation,
+                    throw InputFileError("parseReactionEquation", equation,
                         err.getMessage());
                 }
             } else {
-                throw InputFileError("setupReaction", equation,
+                throw InputFileError("parseReactionEquation", equation,
                     "Error parsing reaction string '{}'.\n"
                     "Current token: '{}'\nlast_used: '{}'",
                     equation.asString(), tokens[i],

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -22,7 +22,7 @@ void SpeciesNode::addPath(Path* path)
     } else if (path->end() == this) {
         m_in += path->flow();
     } else {
-        throw CanteraError("addPath","path added to wrong node");
+        throw CanteraError("SpeciesNode::addPath", "path added to wrong node");
     }
 }
 

--- a/src/kinetics/solveSP.cpp
+++ b/src/kinetics/solveSP.cpp
@@ -44,12 +44,12 @@ solveSP::solveSP(ImplicitSurfChem* surfChemPtr, int bulkFunc) :
             m_indexKinObjSurfPhase.push_back(n);
             m_kinObjPhaseIDSurfPhase.push_back(surfPhaseIndex);
         } else {
-            throw CanteraError("solveSP",
+            throw CanteraError("solveSP::solveSP",
                                "InterfaceKinetics object has no surface phase");
         }
         SurfPhase* sp = dynamic_cast<SurfPhase*>(&kin->thermo(surfPhaseIndex));
         if (!sp) {
-            throw CanteraError("solveSP",
+            throw CanteraError("solveSP::solveSP",
                                "Inconsistent ThermoPhase object within "
                                "InterfaceKinetics object");
         }

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -346,7 +346,7 @@ doublereal BandMatrix::rcond(doublereal a1norm)
     work_.resize(3 * m_n);
 
     if (m_factored != 1) {
-        throw CanteraError("BandMatrix::rcond()", "matrix isn't factored correctly");
+        throw CanteraError("BandMatrix::rcond", "matrix isn't factored correctly");
     }
 
 #if CT_USE_LAPACK
@@ -355,7 +355,7 @@ doublereal BandMatrix::rcond(doublereal a1norm)
     double rcond = ct_dgbcon('1', m_n, m_kl, m_ku, ludata.data(),
         ldab, m_ipiv->data.data(), a1norm, work_.data(), iwork_.data(), rinfo);
     if (rinfo != 0) {
-        throw CanteraError("BandMatrix::rcond()", "DGBCON returned INFO = {}", rinfo);
+        throw CanteraError("BandMatrix::rcond", "DGBCON returned INFO = {}", rinfo);
     }
     return rcond;
 #else

--- a/src/numerics/DenseMatrix.cpp
+++ b/src/numerics/DenseMatrix.cpp
@@ -181,10 +181,11 @@ int solve(DenseMatrix& A, double* b, size_t nrhs, size_t ldb)
                   A.nRows(), &A.ipiv()[0], b, ldb, info);
         if (info != 0) {
             if (A.m_printLevel) {
-                writelogf("solve(DenseMatrix& A, double* b): DGETRS returned INFO = %d\n", info);
+                writelog("solve(DenseMatrix& A, double* b): DGETRS returned INFO = {}\n", info);
             }
             if (info < 0 || !A.m_useReturnErrorCode) {
-                throw CanteraError("solve(DenseMatrix& A, double* b)", "DGETRS returned INFO = {}", info);
+                throw CanteraError("solve(DenseMatrix& A, double* b)",
+                                   "DGETRS returned INFO = {}", info);
             }
         }
     #else
@@ -240,10 +241,10 @@ int invert(DenseMatrix& A, size_t nn)
                   &A.ipiv()[0], info);
         if (info != 0) {
             if (A.m_printLevel) {
-                writelogf("invert(DenseMatrix& A, int nn): DGETRS returned INFO = %d\n", info);
+                writelogf("invert(DenseMatrix& A, size_t nn): DGETRS returned INFO = %d\n", info);
             }
             if (! A.m_useReturnErrorCode) {
-                throw CanteraError("invert(DenseMatrix& A, int nn)", "DGETRS returned INFO = {}", info);
+                throw CanteraError("invert(DenseMatrix& A, size_t nn)", "DGETRS returned INFO = {}", info);
             }
             return info;
         }
@@ -254,10 +255,10 @@ int invert(DenseMatrix& A, size_t nn)
                   &A.ipiv()[0], &work[0], lwork, info);
         if (info != 0) {
             if (A.m_printLevel) {
-                writelogf("invert(DenseMatrix& A, int nn): DGETRS returned INFO = %d\n", info);
+                writelogf("invert(DenseMatrix& A, size_t nn): DGETRS returned INFO = %d\n", info);
             }
             if (! A.m_useReturnErrorCode) {
-                throw CanteraError("invert(DenseMatrix& A, int nn)", "DGETRI returned INFO={}", info);
+                throw CanteraError("invert(DenseMatrix& A, size_t nn)", "DGETRI returned INFO={}", info);
             }
         }
     #else

--- a/src/numerics/ResidJacEval.cpp
+++ b/src/numerics/ResidJacEval.cpp
@@ -123,8 +123,7 @@ int ResidJacEval::evalResidNJ(const doublereal t, const doublereal deltaT,
                               const ResidEval_Type_Enum evalType,
                               const int id_x, const doublereal delta_x)
 {
-    throw CanteraError("ResidJacEval::evalResidNJ()", "Not implemented\n");
-    return 1;
+    throw NotImplementedError("ResidJacEval::evalResidNJ");
 }
 
 int ResidJacEval::eval(const doublereal t, const doublereal* const y, const doublereal* const ydot,
@@ -150,8 +149,7 @@ int ResidJacEval::evalJacobianDP(const doublereal t, const doublereal delta_t,
                                  doublereal* const* jac_colPts,
                                  doublereal* const resid)
 {
-    throw CanteraError("ResidJacEval::evalJacobianDP()", "Not implemented\n");
-    return 1;
+    throw NotImplementedError("ResidJacEval::evalJacobianDP");
 }
 
 }

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -251,9 +251,7 @@ void Domain1D::_getInitialSoln(doublereal* x)
 
 doublereal Domain1D::initialValue(size_t n, size_t j)
 {
-    throw CanteraError("Domain1D::initialValue",
-                       "base class method called!");
-    return 0.0;
+    throw NotImplementedError("Domain1D::initialValue");
 }
 
 } // namespace

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -160,7 +160,7 @@ void IonFlow::setSolvingStage(const size_t stage)
     if (stage == 1 || stage == 2) {
         m_stage = stage;
     } else {
-        throw CanteraError("IonFlow::updateDiffFluxes",
+        throw CanteraError("IonFlow::setSolvingStage",
                     "solution stage must be set to: "
                     "1) frozenIonMethod, "
                     "2) electricFieldEqnMethod");

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -191,7 +191,7 @@ void StFlow::setGasAtMidpoint(const doublereal* x, size_t j)
 void StFlow::_finalize(const doublereal* x)
 {
     if (!m_do_multicomponent && m_do_soret) {
-        throw CanteraError("_finalize",
+        throw CanteraError("StFlow::_finalize",
             "Thermal diffusion (the Soret effect) is enabled, and requires "
             "using a multicomponent transport model.");
     }
@@ -870,10 +870,10 @@ void StFlow::solveEnergyEqn(size_t j)
 void StFlow::setBoundaryEmissivities(doublereal e_left, doublereal e_right)
 {
     if (e_left < 0 || e_left > 1) {
-        throw CanteraError("setBoundaryEmissivities",
+        throw CanteraError("StFlow::setBoundaryEmissivities",
             "The left boundary emissivity must be between 0.0 and 1.0!");
     } else if (e_right < 0 || e_right > 1) {
-        throw CanteraError("setBoundaryEmissivities",
+        throw CanteraError("StFlow::setBoundaryEmissivities",
             "The right boundary emissivity must be between 0.0 and 1.0!");
     } else {
         m_epsilon_left = e_left;

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -119,7 +119,7 @@ void DebyeHuckel::setDensity(doublereal rho)
 {
     double dens = density();
     if (rho != dens) {
-        throw CanteraError("Idea;MolalSoln::setDensity",
+        throw CanteraError("DebyeHuckel::setDensity",
                            "Density is not an independent variable");
     }
 }
@@ -128,7 +128,7 @@ void DebyeHuckel::setMolarDensity(const doublereal conc)
 {
     double concI = molarDensity();
     if (conc != concI) {
-        throw CanteraError("Idea;MolalSoln::setMolarDensity",
+        throw CanteraError("DebyeHuckel::setMolarDensity",
                            "molarDensity/density is not an independent variable");
     }
 }

--- a/src/thermo/FixedChemPotSSTP.cpp
+++ b/src/thermo/FixedChemPotSSTP.cpp
@@ -202,7 +202,7 @@ void FixedChemPotSSTP::initThermoXML(XML_Node& phaseNode, const std::string& id_
     XML_Node& tnode = phaseNode.child("thermo");
     std::string model = tnode["model"];
     if (model != "StoichSubstance" && model != "FixedChemPot" && model != "StoichSubstanceSSTP") {
-        throw CanteraError("FixedChemPotSSTP::initThermoXML()",
+        throw CanteraError("FixedChemPotSSTP::initThermoXML",
                            "thermo model attribute must be FixedChemPot or StoichSubstance or StoichSubstanceSSTP");
     }
 

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -142,7 +142,7 @@ doublereal IdealMolalSoln::thermalExpansionCoeff() const
 void IdealMolalSoln::setDensity(const doublereal rho)
 {
     if (rho != density()) {
-        throw CanteraError("Idea;MolalSoln::setDensity",
+        throw CanteraError("IdealMolalSoln::setDensity",
                            "Density is not an independent variable");
     }
 }
@@ -359,13 +359,13 @@ void IdealMolalSoln::initThermoXML(XML_Node& phaseNode, const std::string& id_)
     MolalityVPSSTP::initThermoXML(phaseNode, id_);
 
     if (id_.size() > 0 && phaseNode.id() != id_) {
-        throw CanteraError("IdealMolalSoln::initThermo",
+        throw CanteraError("IdealMolalSoln::initThermoXML",
                            "phasenode and Id are incompatible");
     }
 
     // Find the Thermo XML node
     if (!phaseNode.hasChild("thermo")) {
-        throw CanteraError("IdealMolalSoln::initThermo",
+        throw CanteraError("IdealMolalSoln::initThermoXML",
                            "no thermo XML node");
     }
     XML_Node& thermoNode = phaseNode.child("thermo");
@@ -463,7 +463,7 @@ void IdealMolalSoln::setStandardConcentrationModel(const std::string& model)
                || caseInsensitiveEquals(model, "solvent_volume")) {
         m_formGC = 2;
     } else {
-        throw CanteraError("IdealSolnGasVPSS::setStandardConcentrationModel",
+        throw CanteraError("IdealMolalSoln::setStandardConcentrationModel",
                            "Unknown standard concentration model '{}'", model);
     }
 }

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -605,8 +605,8 @@ void IdealMolalSoln::calcIMSCutoffParams_()
         }
     }
     if (!converged) {
-        throw CanteraError(" IdealMolalSoln::calcCutoffParams_()",
-                           " failed to converge on the f polynomial");
+        throw CanteraError("IdealMolalSoln::calcCutoffParams_",
+                           "failed to converge on the f polynomial");
     }
     converged = false;
     double f_0 = IMS_afCut_ + IMS_efCut_;
@@ -628,8 +628,8 @@ void IdealMolalSoln::calcIMSCutoffParams_()
         }
     }
     if (!converged) {
-        throw CanteraError(" IdealMolalSoln::calcCutoffParams_()",
-                           " failed to converge on the g polynomial");
+        throw CanteraError("IdealMolalSoln::calcCutoffParams_",
+                           "failed to converge on the g polynomial");
     }
 }
 

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -25,8 +25,8 @@ IdealSolidSolnPhase::IdealSolidSolnPhase(int formGC) :
     m_Pcurrent(OneAtm)
 {
     if (formGC < 0 || formGC > 2) {
-        throw CanteraError(" IdealSolidSolnPhase Constructor",
-                           " Illegal value of formGC");
+        throw CanteraError("IdealSolidSolnPhase::IdealSolidSolnPhase",
+                           "Illegal value of formGC");
     }
 }
 
@@ -37,8 +37,8 @@ IdealSolidSolnPhase::IdealSolidSolnPhase(const std::string& inputFile,
     m_Pcurrent(OneAtm)
 {
     if (formGC < 0 || formGC > 2) {
-        throw CanteraError(" IdealSolidSolnPhase Constructor",
-                           " Illegal value of formGC");
+        throw CanteraError("IdealSolidSolnPhase::IdealSolidSolnPhase",
+                           "Illegal value of formGC");
     }
     initThermoFile(inputFile, id_);
 }
@@ -50,8 +50,8 @@ IdealSolidSolnPhase::IdealSolidSolnPhase(XML_Node& root, const std::string& id_,
     m_Pcurrent(OneAtm)
 {
     if (formGC < 0 || formGC > 2) {
-        throw CanteraError(" IdealSolidSolnPhase Constructor",
-                           " Illegal value of formGC");
+        throw CanteraError("IdealSolidSolnPhase::IdealSolidSolnPhase",
+                           "Illegal value of formGC");
     }
     importPhase(root, this);
 }

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -372,7 +372,7 @@ bool IdealSolidSolnPhase::addSpecies(shared_ptr<Species> spec)
         if (spec->input.hasKey("equation-of-state")) {
             auto& eos = spec->input["equation-of-state"].as<AnyMap>();
             if (eos.getString("model", "") != "constant-volume") {
-                throw CanteraError("IdealSolidSolnPhase::initThermo",
+                throw CanteraError("IdealSolidSolnPhase::addSpecies",
                     "ideal-condensed model requires constant-volume "
                     "species model for species '{}'", spec->name);
             }
@@ -384,7 +384,7 @@ bool IdealSolidSolnPhase::addSpecies(shared_ptr<Species> spec)
             } else if (eos.hasKey("molar-volume")) {
                 mv = eos.convert("molar-volume", "m^3/kmol");
             } else {
-                throw CanteraError("IdealSolidSolnPhase::initThermo",
+                throw CanteraError("IdealSolidSolnPhase::addSpecies",
                     "equation-of-state entry for species '{}' is missing "
                     "'density', 'molar-volume', or 'molar-density' "
                     "specification", spec->name);

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -37,8 +37,9 @@ IdealSolnGasVPSS::IdealSolnGasVPSS(const std::string& infile, std::string id_) :
     }
     XML_Node* xphase = get_XML_NameID("phase", std::string("#")+id_, root);
     if (!xphase) {
-        throw CanteraError("newPhase",
-                           "Couldn't find phase named \"" + id_ + "\" in file, " + infile);
+        throw CanteraError("IdealSolnGasVPSS::IdealSolnGasVPSS",
+                           "Couldn't find phase named '{} in file '{}'",
+                           id_, infile);
     }
     importPhase(*xphase, this);
 }
@@ -323,7 +324,7 @@ void IdealSolnGasVPSS::setParametersFromXML(const XML_Node& thermoNode)
     } else if (model == "IdealSolnVPSS") {
         setSolnMode();
     } else {
-        throw CanteraError("IdealSolnGasVPSS::initThermoXML",
+        throw CanteraError("IdealSolnGasVPSS::setParametersFromXML",
                            "Unknown thermo model : " + model);
     }
 }

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -117,10 +117,8 @@ doublereal IdealSolnGasVPSS::isothermalCompressibility() const
     if (m_idealGas) {
         return 1.0 / m_Pcurrent;
     } else {
-        throw CanteraError("IdealSolnGasVPSS::isothermalCompressibility() ",
-                           "not implemented");
+        throw NotImplementedError("IdealSolnGasVPSS::isothermalCompressibility");
     }
-    return 0.0;
 }
 
 Units IdealSolnGasVPSS::standardConcentrationUnits() const

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -150,14 +150,11 @@ void IonsFromNeutralVPSSTP::getChemPotentials(doublereal* mu) const
         break;
 
     case cIonSolnType_SINGLECATION:
-        throw CanteraError("eosType", "Unknown type");
-        break;
+        throw CanteraError("IonsFromNeutralVPSSTP::getChemPotentials", "Unknown type");
     case cIonSolnType_MULTICATIONANION:
-        throw CanteraError("eosType", "Unknown type");
-        break;
+        throw CanteraError("IonsFromNeutralVPSSTP::getChemPotentials", "Unknown type");
     default:
-        throw CanteraError("eosType", "Unknown type");
-        break;
+        throw CanteraError("IonsFromNeutralVPSSTP::getChemPotentials", "Unknown type");
     }
 }
 
@@ -620,14 +617,14 @@ void IonsFromNeutralVPSSTP::setParametersFromXML(const XML_Node& thermoNode)
     GibbsExcessVPSSTP::setParametersFromXML(thermoNode);
     // Find the Neutral Molecule Phase
     if (!thermoNode.hasChild("neutralMoleculePhase")) {
-        throw CanteraError("IonsFromNeutralVPSSTP::initThermoXML",
+        throw CanteraError("IonsFromNeutralVPSSTP::setParametersFromXML",
                            "no neutralMoleculePhase XML node");
     }
     XML_Node& neutralMoleculeNode = thermoNode.child("neutralMoleculePhase");
 
     XML_Node* neut_ptr = get_XML_Node(neutralMoleculeNode["datasrc"], 0);
     if (!neut_ptr) {
-        throw CanteraError("IonsFromNeutralVPSSTP::initThermoXML",
+        throw CanteraError("IonsFromNeutralVPSSTP::setParametersFromXML",
                            "neut_ptr = 0");
     }
 
@@ -722,13 +719,13 @@ void IonsFromNeutralVPSSTP::getdlnActCoeffds(const doublereal dTds, const double
         break;
 
     case cIonSolnType_SINGLECATION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeffds", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::getdlnActCoeffds", "Unimplemented type");
         break;
     case cIonSolnType_MULTICATIONANION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeffds", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::getdlnActCoeffds", "Unimplemented type");
         break;
     default:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeffds", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::getdlnActCoeffds", "Unimplemented type");
         break;
     }
 }
@@ -772,13 +769,13 @@ void IonsFromNeutralVPSSTP::s_update_dlnActCoeffdT() const
         break;
 
     case cIonSolnType_SINGLECATION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeffdT", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeffdT", "Unimplemented type");
         break;
     case cIonSolnType_MULTICATIONANION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeffdT", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeffdT", "Unimplemented type");
         break;
     default:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeffdT", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeffdT", "Unimplemented type");
         break;
     }
 }
@@ -822,13 +819,13 @@ void IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnX_diag() const
         break;
 
     case cIonSolnType_SINGLECATION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnX_diag()", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnX_diag", "Unimplemented type");
         break;
     case cIonSolnType_MULTICATIONANION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnX_diag()", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnX_diag", "Unimplemented type");
         break;
     default:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnX_diag()", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnX_diag", "Unimplemented type");
         break;
     }
 }
@@ -872,13 +869,13 @@ void IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN_diag() const
         break;
 
     case cIonSolnType_SINGLECATION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnN_diag()", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN_diag", "Unimplemented type");
         break;
     case cIonSolnType_MULTICATIONANION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnN_diag()", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN_diag", "Unimplemented type");
         break;
     default:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnN_diag()", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN_diag", "Unimplemented type");
         break;
     }
 }
@@ -951,13 +948,13 @@ void IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN() const
         break;
 
     case cIonSolnType_SINGLECATION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnN", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN", "Unimplemented type");
         break;
     case cIonSolnType_MULTICATIONANION:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnN", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN", "Unimplemented type");
         break;
     default:
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_lnActCoeff_dlnN", "Unimplemented type");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN", "Unimplemented type");
         break;
     }
 }

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -887,7 +887,7 @@ void IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN() const
     dlnActCoeffdlnN_.zero();
     // Get the activity coefficients of the neutral molecules
     if (!geThermo) {
-        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN()", "dynamic cast failed");
+        throw CanteraError("IonsFromNeutralVPSSTP::s_update_dlnActCoeff_dlnN", "dynamic cast failed");
     }
     size_t nsp_ge = geThermo->nSpecies();
     geThermo->getdlnActCoeffdlnN(nsp_ge, &dlnActCoeffdlnN_NeutralMolecule_(0,0));

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -246,7 +246,7 @@ bool LatticePhase::addSpecies(shared_ptr<Species> spec)
         if (spec->input.hasKey("equation-of-state")) {
             auto& eos = spec->input["equation-of-state"].as<AnyMap>();
             if (eos.getString("model", "") != "constant-volume") {
-                throw CanteraError("LatticePhase::initThermo",
+                throw CanteraError("LatticePhase::addSpecies",
                     "lattice model requires constant-volume species model "
                     "for species '{}'", spec->name);
             }

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -202,7 +202,7 @@ void LatticeSolidPhase::getMoleFractions(doublereal* const x) const
         m_lattice[n]->getMoleFractions(&m_x[strt]);
         for (size_t k = 0; k < nsp; k++) {
             if (fabs((x + strt)[k] - m_x[strt+k]) > 1.0E-14) {
-                throw CanteraError("LatticeSolidPhase::getMoleFractions()",
+                throw CanteraError("LatticeSolidPhase::getMoleFractions",
                                    "internal error");
             }
         }

--- a/src/thermo/MaskellSolidSolnPhase.cpp
+++ b/src/thermo/MaskellSolidSolnPhase.cpp
@@ -141,17 +141,17 @@ void MaskellSolidSolnPhase::getChemPotentials_RT(doublereal* mu) const
 
 void MaskellSolidSolnPhase::getPartialMolarEnthalpies(doublereal* hbar) const
 {
-    throw CanteraError("MaskellSolidSolnPhase::getPartialMolarEnthalpies()", "Not yet implemented.");
+    throw NotImplementedError("MaskellSolidSolnPhase::getPartialMolarEnthalpies");
 }
 
 void MaskellSolidSolnPhase::getPartialMolarEntropies(doublereal* sbar) const
 {
-    throw CanteraError("MaskellSolidSolnPhase::getPartialMolarEntropies()", "Not yet implemented.");
+    throw NotImplementedError("MaskellSolidSolnPhase::getPartialMolarEntropies");
 }
 
 void MaskellSolidSolnPhase::getPartialMolarCp(doublereal* cpbar) const
 {
-    throw CanteraError("MaskellSolidSolnPhase::getPartialMolarCp()", "Not yet implemented.");
+    throw NotImplementedError("MaskellSolidSolnPhase::getPartialMolarCp");
 }
 
 void MaskellSolidSolnPhase::getPartialMolarVolumes(doublereal* vbar) const

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -339,12 +339,12 @@ doublereal MixtureFugacityTP::z() const
 
 doublereal MixtureFugacityTP::sresid() const
 {
-    throw CanteraError("MixtureFugacityTP::sresid()", "Base Class: not implemented");
+    throw NotImplementedError("MixtureFugacityTP::sresid");
 }
 
 doublereal MixtureFugacityTP::hresid() const
 {
-    throw CanteraError("MixtureFugacityTP::hresid()", "Base Class: not implemented");
+    throw NotImplementedError("MixtureFugacityTP::hresid");
 }
 
 doublereal MixtureFugacityTP::psatEst(doublereal TKelvin) const
@@ -360,7 +360,7 @@ doublereal MixtureFugacityTP::psatEst(doublereal TKelvin) const
 
 doublereal MixtureFugacityTP::liquidVolEst(doublereal TKelvin, doublereal& pres) const
 {
-    throw CanteraError("MixtureFugacityTP::liquidVolEst()", "unimplemented");
+    throw NotImplementedError("MixtureFugacityTP::liquidVolEst");
 }
 
 doublereal MixtureFugacityTP::densityCalc(doublereal TKelvin, doublereal presPa,
@@ -575,12 +575,12 @@ int MixtureFugacityTP::phaseState(bool checkState) const
 
 doublereal MixtureFugacityTP::densSpinodalLiquid() const
 {
-    throw CanteraError("MixtureFugacityTP::densSpinodalLiquid", "unimplemented");
+    throw NotImplementedError("MixtureFugacityTP::densSpinodalLiquid");
 }
 
 doublereal MixtureFugacityTP::densSpinodalGas() const
 {
-    throw CanteraError("MixtureFugacityTP::densSpinodalGas", "unimplemented");
+    throw NotImplementedError("MixtureFugacityTP::densSpinodalGas");
 }
 
 doublereal MixtureFugacityTP::satPressure(doublereal TKelvin)
@@ -782,12 +782,12 @@ doublereal MixtureFugacityTP::calculatePsat(doublereal TKelvin, doublereal& mola
 
 doublereal MixtureFugacityTP::pressureCalc(doublereal TKelvin, doublereal molarVol) const
 {
-    throw CanteraError("MixtureFugacityTP::pressureCalc", "unimplemented");
+    throw NotImplementedError("MixtureFugacityTP::pressureCalc");
 }
 
 doublereal MixtureFugacityTP::dpdVCalc(doublereal TKelvin, doublereal molarVol, doublereal& presCalc) const
 {
-    throw CanteraError("MixtureFugacityTP::dpdVCalc", "unimplemented");
+    throw NotImplementedError("MixtureFugacityTP::dpdVCalc");
 }
 
 void MixtureFugacityTP::_updateReferenceStateThermo() const

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -246,8 +246,7 @@ void MixtureFugacityTP::setMoleFractions_NoState(const doublereal* const x)
 
 void MixtureFugacityTP::calcDensity()
 {
-    throw NotImplementedError("MixtureFugacityTP::calcDensity() "
-                              "called, but EOS for phase is not known");
+    throw NotImplementedError("MixtureFugacityTP::calcDensity");
 }
 
 void MixtureFugacityTP::setState_TP(doublereal t, doublereal pres)
@@ -277,10 +276,10 @@ void MixtureFugacityTP::setState_TP(doublereal t, doublereal pres)
                     Phase::setDensity(rho);
                     iState_ = phaseState(true);
                 } else {
-                    throw CanteraError("MixtureFugacityTP::setState_TP()", "neg rho");
+                    throw CanteraError("MixtureFugacityTP::setState_TP", "neg rho");
                 }
             } else {
-                throw CanteraError("MixtureFugacityTP::setState_TP()", "neg rho");
+                throw CanteraError("MixtureFugacityTP::setState_TP", "neg rho");
             }
         }
     } else if (forcedState_ == FLUID_GAS) {
@@ -292,10 +291,10 @@ void MixtureFugacityTP::setState_TP(doublereal t, doublereal pres)
                 Phase::setDensity(rho);
                 iState_ = phaseState(true);
                 if (iState_ >= FLUID_LIQUID_0) {
-                    throw CanteraError("MixtureFugacityTP::setState_TP()", "wrong state");
+                    throw CanteraError("MixtureFugacityTP::setState_TP", "wrong state");
                 }
             } else {
-                throw CanteraError("MixtureFugacityTP::setState_TP()", "neg rho");
+                throw CanteraError("MixtureFugacityTP::setState_TP", "neg rho");
             }
         }
     } else if (forcedState_ > FLUID_LIQUID_0) {
@@ -306,10 +305,10 @@ void MixtureFugacityTP::setState_TP(doublereal t, doublereal pres)
                 Phase::setDensity(rho);
                 iState_ = phaseState(true);
                 if (iState_ == FLUID_GAS) {
-                    throw CanteraError("MixtureFugacityTP::setState_TP()", "wrong state");
+                    throw CanteraError("MixtureFugacityTP::setState_TP", "wrong state");
                 }
             } else {
-                throw CanteraError("MixtureFugacityTP::setState_TP()", "neg rho");
+                throw CanteraError("MixtureFugacityTP::setState_TP", "neg rho");
             }
         }
     }
@@ -492,7 +491,7 @@ doublereal MixtureFugacityTP::densityCalc(doublereal TKelvin, doublereal presPa,
     double densBase = 0.0;
     if (! conv) {
         molarVolBase = 0.0;
-        throw CanteraError("MixtureFugacityTP::densityCalc()", "Process did not converge");
+        throw CanteraError("MixtureFugacityTP::densityCalc", "Process did not converge");
     } else {
         densBase = mmw / molarVolBase;
     }
@@ -806,7 +805,7 @@ void MixtureFugacityTP::_updateReferenceStateThermo() const
         }
         doublereal pref = refPressure();
         if (pref <= 0.0) {
-            throw CanteraError("MixtureFugacityTP::_updateReferenceStateThermo()", "neg ref pressure");
+            throw CanteraError("MixtureFugacityTP::_updateReferenceStateThermo", "neg ref pressure");
         }
     }
 }

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -53,9 +53,9 @@ int MolalityVPSSTP::pHScale() const
 void MolalityVPSSTP::setMoleFSolventMin(doublereal xmolSolventMIN)
 {
     if (xmolSolventMIN <= 0.0) {
-        throw CanteraError("MolalityVPSSTP::setSolute ", "trouble");
+        throw CanteraError("MolalityVPSSTP::setMoleFSolventMin ", "trouble");
     } else if (xmolSolventMIN > 0.9) {
-        throw CanteraError("MolalityVPSSTP::setSolute ", "trouble");
+        throw CanteraError("MolalityVPSSTP::setMoleFSolventMin ", "trouble");
     }
     m_xmolSolventMIN = xmolSolventMIN;
 }

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -57,7 +57,8 @@ void Mu0Poly::setParameters(double h0, const std::map<double, double>& T_mu)
         m_mu0_R_int.push_back(row.second / GasConstant);
     }
     if (iT298 == npos) {
-        throw CanteraError("Mu0Poly", "One temperature has to be 298.15");
+        throw CanteraError("Mu0Poly::setParameters",
+                           "One temperature has to be 298.15");
     }
 
     // Resize according to the number of points
@@ -171,7 +172,7 @@ Mu0Poly* newMu0ThermoFromXML(const XML_Node& Mu0Node)
     vector_fp cValues(numPoints);
     const XML_Node* valNode_ptr = getByTitle(Mu0Node, "Mu0Values");
     if (!valNode_ptr) {
-        throw CanteraError("installMu0ThermoFromXML", "missing Mu0Values");
+        throw CanteraError("newMu0ThermoFromXML", "missing Mu0Values");
     }
     getFloatArray(*valNode_ptr, cValues, true, "actEnergy");
 
@@ -182,18 +183,17 @@ Mu0Poly* newMu0ThermoFromXML(const XML_Node& Mu0Node)
         dimensionlessMu0Values = true;
     }
     if (cValues.size() != numPoints) {
-        throw CanteraError("installMu0ThermoFromXML", "numPoints inconsistent");
+        throw CanteraError("newMu0ThermoFromXML", "numPoints inconsistent");
     }
 
     vector_fp cTemperatures(numPoints);
     const XML_Node* tempNode_ptr = getByTitle(Mu0Node, "Mu0Temperatures");
     if (!tempNode_ptr) {
-        throw CanteraError("installMu0ThermoFromXML",
-                           "missing Mu0Temperatures");
+        throw CanteraError("newMu0ThermoFromXML", "missing Mu0Temperatures");
     }
     getFloatArray(*tempNode_ptr, cTemperatures, false);
     if (cTemperatures.size() != numPoints) {
-        throw CanteraError("installMu0ThermoFromXML", "numPoints inconsistent");
+        throw CanteraError("newMu0ThermoFromXML", "numPoints inconsistent");
     }
 
     // Fix up dimensionless Mu0 values if input

--- a/src/thermo/PDSS.cpp
+++ b/src/thermo/PDSS.cpp
@@ -26,87 +26,87 @@ PDSS::PDSS() :
 
 doublereal PDSS::enthalpy_mole() const
 {
-    throw NotImplementedError("PDSS::enthalpy_mole()");
+    throw NotImplementedError("PDSS::enthalpy_mole");
 }
 
 doublereal PDSS::enthalpy_RT() const
 {
-    throw NotImplementedError("PDSS::enthalpy_RT()");
+    throw NotImplementedError("PDSS::enthalpy_RT");
 }
 
 doublereal PDSS::intEnergy_mole() const
 {
-    throw NotImplementedError("PDSS::intEnergy_mole()");
+    throw NotImplementedError("PDSS::intEnergy_mole");
 }
 
 doublereal PDSS::entropy_mole() const
 {
-    throw NotImplementedError("PDSS::entropy_mole()");
+    throw NotImplementedError("PDSS::entropy_mole");
 }
 
 doublereal PDSS::entropy_R() const
 {
-    throw NotImplementedError("PDSS::entropy_R()");
+    throw NotImplementedError("PDSS::entropy_R");
 }
 
 doublereal PDSS::gibbs_mole() const
 {
-    throw NotImplementedError("PDSS::gibbs_mole()");
+    throw NotImplementedError("PDSS::gibbs_mole");
 }
 
 doublereal PDSS::gibbs_RT() const
 {
-    throw NotImplementedError("PDSS::gibbs_RT()");
+    throw NotImplementedError("PDSS::gibbs_RT");
 }
 
 doublereal PDSS::cp_mole() const
 {
-    throw NotImplementedError("PDSS::cp_mole()");
+    throw NotImplementedError("PDSS::cp_mole");
 }
 
 doublereal PDSS::cp_R() const
 {
-    throw NotImplementedError("PDSS::cp_R()");
+    throw NotImplementedError("PDSS::cp_R");
 }
 
 doublereal PDSS::molarVolume() const
 {
-    throw NotImplementedError("PDSS::molarVolume()");
+    throw NotImplementedError("PDSS::molarVolume");
 }
 
 doublereal PDSS::density() const
 {
-    throw NotImplementedError("PDSS::density()");
+    throw NotImplementedError("PDSS::density");
 }
 
 doublereal PDSS::cv_mole() const
 {
-    throw NotImplementedError("PDSS::cv_mole()");
+    throw NotImplementedError("PDSS::cv_mole");
 }
 
 doublereal PDSS::gibbs_RT_ref() const
 {
-    throw NotImplementedError("PDSS::gibbs_RT_ref()");
+    throw NotImplementedError("PDSS::gibbs_RT_ref");
 }
 
 doublereal PDSS::enthalpy_RT_ref() const
 {
-    throw NotImplementedError("PDSS::enthalpy_RT_ref()");
+    throw NotImplementedError("PDSS::enthalpy_RT_ref");
 }
 
 doublereal PDSS::entropy_R_ref() const
 {
-    throw NotImplementedError("PDSS::entropy_RT_ref()");
+    throw NotImplementedError("PDSS::entropy_RT_ref");
 }
 
 doublereal PDSS::cp_R_ref() const
 {
-    throw NotImplementedError("PDSS::entropy_RT_ref()");
+    throw NotImplementedError("PDSS::entropy_RT_ref");
 }
 
 doublereal PDSS::molarVolume_ref() const
 {
-    throw NotImplementedError("PDSS::molarVolume_ref()");
+    throw NotImplementedError("PDSS::molarVolume_ref");
 }
 
 doublereal PDSS::enthalpyDelp_mole() const
@@ -136,22 +136,22 @@ doublereal PDSS::pressure() const
 
 doublereal PDSS::thermalExpansionCoeff() const
 {
-    throw NotImplementedError("PDSS::thermalExpansionCoeff()");
+    throw NotImplementedError("PDSS::thermalExpansionCoeff");
 }
 
 doublereal PDSS::critTemperature() const
 {
-    throw NotImplementedError("PDSS::critTemperature()");
+    throw NotImplementedError("PDSS::critTemperature");
 }
 
 doublereal PDSS::critPressure() const
 {
-    throw NotImplementedError("PDSS::critPressure()");
+    throw NotImplementedError("PDSS::critPressure");
 }
 
 doublereal PDSS::critDensity() const
 {
-    throw NotImplementedError("PDSS::critDensity()");
+    throw NotImplementedError("PDSS::critDensity");
 }
 
 void PDSS::setPressure(doublereal pres)
@@ -180,17 +180,17 @@ void PDSS::setMolecularWeight(doublereal mw)
 
 void PDSS::setState_TP(doublereal temp, doublereal pres)
 {
-    throw NotImplementedError("PDSS::setState_TP()");
+    throw NotImplementedError("PDSS::setState_TP");
 }
 
 void PDSS::setState_TR(doublereal temp, doublereal rho)
 {
-    throw NotImplementedError("PDSS::setState_TR()");
+    throw NotImplementedError("PDSS::setState_TR");
 }
 
 doublereal PDSS::satPressure(doublereal t)
 {
-    throw NotImplementedError("PDSS::satPressure()");
+    throw NotImplementedError("PDSS::satPressure");
 }
 
 void PDSS::reportParams(size_t& kindex, int& type,

--- a/src/thermo/PDSS_ConstVol.cpp
+++ b/src/thermo/PDSS_ConstVol.cpp
@@ -26,12 +26,14 @@ void PDSS_ConstVol::setParametersFromXML(const XML_Node& speciesNode)
 
     const XML_Node* ss = speciesNode.findByName("standardState");
     if (!ss) {
-        throw CanteraError("PDSS_ConstVol::constructPDSSXML",
-                           "no standardState Node for species " + speciesNode.name());
+        throw CanteraError("PDSS_ConstVol::setParametersFromXML",
+                           "no standardState Node for species '{}'",
+                           speciesNode.name());
     }
     if (ss->attrib("model") != "constant_incompressible") {
-        throw CanteraError("PDSS_ConstVol::initThermoXML",
-                           "standardState model for species isn't constant_incompressible: " + speciesNode.name());
+        throw CanteraError("PDSS_ConstVol::setParametersFromXML",
+                           "standardState model for species '{}' isn't "
+                           "'constant_incompressible'", speciesNode.name());
     }
 
     setMolarVolume(getFloat(*ss, "molarVolume", "toSI"));

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -634,7 +634,7 @@ doublereal PDSS_HKFT::f(const doublereal temp, const doublereal pres, const int 
         fac2 = - (3.0 * af_coeff[1] * p2 + 4.0 * af_coeff[2] * p3)/ 1.0E5;
         return fac1 * fac2;
     } else {
-        throw CanteraError("HKFT_PDSS::gg", "unimplemented");
+        throw NotImplementedError("PDSS_HKFT::f");
     }
 }
 
@@ -686,7 +686,7 @@ doublereal PDSS_HKFT::g(const doublereal temp, const doublereal pres, const int 
         doublereal beta = m_waterSS->isothermalCompressibility();
         return - bfunc * gval * dens * beta / (1.0 - dens);
     } else {
-        throw CanteraError("HKFT_PDSS::g", "unimplemented");
+        throw NotImplementedError("PDSS_HKFT::g");
     }
     return 0.0;
 }

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -379,18 +379,18 @@ void PDSS_HKFT::setParametersFromXML(const XML_Node& speciesNode)
 
     const XML_Node* tn = speciesNode.findByName("thermo");
     if (!tn) {
-        throw CanteraError("PDSS_HKFT::constructPDSSXML",
-                           "no thermo Node for species " + speciesNode.name());
+        throw CanteraError("PDSS_HKFT::setParametersFromXML",
+                           "no thermo Node for species '{}'", speciesNode.name());
     }
     if (!caseInsensitiveEquals(tn->attrib("model"), "hkft")) {
-        throw CanteraError("PDSS_HKFT::initThermoXML",
-                           "thermo model for species isn't hkft: "
-                           + speciesNode.name());
+        throw CanteraError("PDSS_HKFT::setParametersFromXML",
+                           "thermo model for species '{}' isn't 'hkft'",
+                           speciesNode.name());
     }
     const XML_Node* hh = tn->findByName("HKFT");
     if (!hh) {
-        throw CanteraError("PDSS_HKFT::constructPDSSXML",
-                           "no Thermo::HKFT Node for species " + speciesNode.name());
+        throw CanteraError("PDSS_HKFT::setParametersFromXML",
+                           "no Thermo::HKFT Node for species '{}'", speciesNode.name());
     }
 
     // go get the attributes
@@ -427,13 +427,14 @@ void PDSS_HKFT::setParametersFromXML(const XML_Node& speciesNode)
 
     const XML_Node* ss = speciesNode.findByName("standardState");
     if (!ss) {
-        throw CanteraError("PDSS_HKFT::constructPDSSXML",
-                           "no standardState Node for species " + speciesNode.name());
+        throw CanteraError("PDSS_HKFT::setParametersFromXML",
+                           "no 'standardState' Node for species '{}'",
+                           speciesNode.name());
     }
     if (!caseInsensitiveEquals(ss->attrib("model"), "hkft")) {
-        throw CanteraError("PDSS_HKFT::initThermoXML",
-                           "standardState model for species isn't hkft: "
-                           + speciesNode.name());
+        throw CanteraError("PDSS_HKFT::setParametersFromXML",
+                           "standardState model for species '{}' isn't 'hkft'",
+                           speciesNode.name());
     }
     double a[4] = {getFloat(*ss, "a1", "toSI"), getFloat(*ss, "a2", "toSI"),
                    getFloat(*ss, "a3", "toSI"), getFloat(*ss, "a4", "toSI")};
@@ -446,7 +447,7 @@ void PDSS_HKFT::setParametersFromXML(const XML_Node& speciesNode)
 
     int isum = hasDGO + hasDHO + hasSO;
     if (isum < 2) {
-        throw CanteraError("PDSS_HKFT::constructPDSSXML",
+        throw CanteraError("PDSS_HKFT::setParametersFromXML",
                            "Missing 2 or more of DG0_f_Pr_Tr, DH0_f_Pr_Tr, or S0_f_Pr_Tr fields. "
                            "Need to supply at least two of these fields");
     }

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -310,7 +310,7 @@ void PDSS_HKFT::initThermo()
     if (fabs(Hcalc -DHjmol) > 100.* toSI("cal/gmol")) {
         std::string sname = m_tp->speciesName(m_spindex);
         if (s_InputInconsistencyErrorExit) {
-            throw CanteraError("PDSS_HKFT::initThermo()", "For {}, DHjmol is"
+            throw CanteraError("PDSS_HKFT::initThermo", "For {}, DHjmol is"
                 " not consistent with G and S: {} vs {} cal gmol-1",
                 sname, Hcalc/toSI("cal/gmol"), m_deltaH_formation_tr_pr);
         } else {

--- a/src/thermo/PDSS_IdealGas.cpp
+++ b/src/thermo/PDSS_IdealGas.cpp
@@ -40,7 +40,7 @@ doublereal PDSS_IdealGas::cv_mole() const
 
 doublereal PDSS_IdealGas::pressure() const
 {
-    throw CanteraError("PDSS_IdealGas::pressure()", "unimplemented");
+    throw NotImplementedError("PDSS_IdealGas::pressure");
 }
 
 void PDSS_IdealGas::setPressure(doublereal p)

--- a/src/thermo/PDSS_IonsFromNeutral.cpp
+++ b/src/thermo/PDSS_IonsFromNeutral.cpp
@@ -44,18 +44,19 @@ void PDSS_IonsFromNeutral::setParametersFromXML(const XML_Node& speciesNode)
     PDSS::setParametersFromXML(speciesNode);
     const XML_Node* tn = speciesNode.findByName("thermo");
     if (!tn) {
-        throw CanteraError("PDSS_IonsFromNeutral::constructPDSSXML",
-                           "no thermo Node for species " + speciesNode.name());
+        throw CanteraError("PDSS_IonsFromNeutral::setParametersFromXML",
+                           "no 'thermo' Node for species '{}'", speciesNode.name());
     }
     if (!caseInsensitiveEquals(tn->attrib("model"), "ionfromneutral")) {
-        throw CanteraError("PDSS_IonsFromNeutral::constructPDSSXML",
-                           "thermo model for species isn't IonsFromNeutral: "
-                           + speciesNode.name());
+        throw CanteraError("PDSS_IonsFromNeutral::setParametersFromXML",
+                           "thermo model for species '{}' isn't 'IonsFromNeutral'",
+                           speciesNode.name());
     }
     const XML_Node* nsm = tn->findByName("neutralSpeciesMultipliers");
     if (!nsm) {
-        throw CanteraError("PDSS_IonsFromNeutral::constructPDSSXML",
-                           "no Thermo::neutralSpeciesMultipliers Node for species " + speciesNode.name());
+        throw CanteraError("PDSS_IonsFromNeutral::setParametersFromXML",
+                           "no 'Thermo::neutralSpeciesMultipliers' Node for species '{}'",
+                           speciesNode.name());
     }
 
     for (auto& species_mult : parseCompString(nsm->value())) {

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -120,7 +120,7 @@ void PDSS_SSVol::calcMolarVolume()
         dVdT_ = - m_mw / dens2 * ddensdT;
         d2VdT2_ = 2.0 * m_mw / (dens2 * dens) * ddensdT * ddensdT - m_mw / dens2 * d2densdT2;
     } else {
-        throw CanteraError("PDSS_SSVol::calcMolarVolume", "unimplemented");
+        throw NotImplementedError("PDSS_SSVol::calcMolarVolume");
     }
 }
 

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -28,23 +28,25 @@ void PDSS_SSVol::setParametersFromXML(const XML_Node& speciesNode)
 
     const XML_Node* ss = speciesNode.findByName("standardState");
     if (!ss) {
-        throw CanteraError("PDSS_SSVol::constructPDSSXML",
-                           "no standardState Node for species " + speciesNode.name());
+        throw CanteraError("PDSS_SSVol::setParametersFromXML",
+                           "no 'standardState' Node for species '{}'",
+                           speciesNode.name());
     }
     std::string model = ss->attrib("model");
     vector_fp coeffs;
     getFloatArray(*ss, coeffs, true, "toSI", "volumeTemperaturePolynomial");
     if (coeffs.size() != 4) {
         throw CanteraError("PDSS_SSVol::setParametersFromXML",
-                           " Didn't get 4 density polynomial numbers for species " + speciesNode.name());
+                           "Didn't get 4 density polynomial numbers for species '{}'",
+                           speciesNode.name());
     }
     if (model == "temperature_polynomial") {
         setVolumePolynomial(coeffs.data());
     } else if (model == "density_temperature_polynomial") {
         setDensityPolynomial(coeffs.data());
     } else {
-        throw CanteraError("PDSS_SSVol::constructPDSSXML",
-                           "Unknown standardState model '{}'' for species '{}'",
+        throw CanteraError("PDSS_SSVol::setParametersFromXML",
+                           "Unknown 'standardState' model '{}' for species '{}'",
                            model, speciesNode.name());
     }
 }

--- a/src/thermo/PDSS_Water.cpp
+++ b/src/thermo/PDSS_Water.cpp
@@ -153,7 +153,7 @@ void PDSS_Water::setPressure(doublereal p)
 
     doublereal dd = m_sub.density(T, p, waterState, dens);
     if (dd <= 0.0) {
-        throw CanteraError("PDSS_Water:setPressure()",
+        throw CanteraError("PDSS_Water:setPressure",
             "Failed to set water SS state: T = {} K and p = {} Pa", T, p);
     }
     m_dens = dd;

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -59,10 +59,10 @@ void Phase::setXMLdata(XML_Node& xmlPhase)
     }
     m_xml = findXMLPhase(root_xml, xmlPhase.id());
     if (!m_xml) {
-        throw CanteraError("Phase::setXMLdata()", "XML 'phase' node not found");
+        throw CanteraError("Phase::setXMLdata", "XML 'phase' node not found");
     }
     if (&m_xml->root() != root_xml) {
-        throw CanteraError("Phase::setXMLdata()", "Root XML node not found");
+        throw CanteraError("Phase::setXMLdata", "Root XML node not found");
     }
 }
 
@@ -100,14 +100,14 @@ size_t Phase::nElements() const
 void Phase::checkElementIndex(size_t m) const
 {
     if (m >= m_mm) {
-        throw IndexError("checkElementIndex", "elements", m, m_mm-1);
+        throw IndexError("Phase::checkElementIndex", "elements", m, m_mm-1);
     }
 }
 
 void Phase::checkElementArraySize(size_t mm) const
 {
     if (m_mm > mm) {
-        throw ArraySizeError("checkElementArraySize", mm, m_mm);
+        throw ArraySizeError("Phase::checkElementArraySize", mm, m_mm);
     }
 }
 
@@ -212,7 +212,7 @@ size_t Phase::speciesIndex(const std::string& nameStr) const
         std::string pn;
         std::string sn = parseSpeciesName(nameStr, pn);
         if (pn == "" || pn == m_name || pn == m_id) {
-            warn_deprecated("Phase::speciesIndex()",
+            warn_deprecated("Phase::speciesIndex",
                 "Retrieval of species indices via 'PhaseId:speciesName' or "
                 "'phaseName:speciesName' to be removed after Cantera 2.5.");
             it = m_speciesIndices.find(nameStr);
@@ -240,14 +240,14 @@ const vector<string>& Phase::speciesNames() const
 void Phase::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_kk) {
-        throw IndexError("checkSpeciesIndex", "species", k, m_kk-1);
+        throw IndexError("Phase::checkSpeciesIndex", "species", k, m_kk-1);
     }
 }
 
 void Phase::checkSpeciesArraySize(size_t kk) const
 {
     if (m_kk > kk) {
-        throw ArraySizeError("checkSpeciesArraySize", kk, m_kk);
+        throw ArraySizeError("Phase::checkSpeciesArraySize", kk, m_kk);
     }
 }
 

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -892,7 +892,7 @@ shared_ptr<Species> Phase::species(const std::string& name) const
     if (k != npos) {
         return m_species.at(speciesName(k));
     } else {
-        throw CanteraError("Phase::setMassFractionsByName",
+        throw CanteraError("Phase::species",
                            "Unknown species '{}'", name);
     }
 }

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -1179,7 +1179,7 @@ int RedlichKwongMFTP::NicholsSolve(double TKelvin, double pres, doublereal a, do
     Vroot[1] = 0.0;
     Vroot[2] = 0.0;
     if (TKelvin <= 0.0) {
-        throw CanteraError("RedlichKwongMFTP::NicholsSolve()", "neg temperature");
+        throw CanteraError("RedlichKwongMFTP::NicholsSolve", "neg temperature");
     }
 
     // Derive the coefficients of the cubic polynomial to solve.
@@ -1236,7 +1236,7 @@ int RedlichKwongMFTP::NicholsSolve(double TKelvin, double pres, doublereal a, do
     if (fabs(fabs(h) - fabs(yN)) < 1.0E-10) {
         if (desc != 0.0) {
             // this is for getting to other cases
-            throw CanteraError("NicholsSolve()", "numerical issues");
+            throw CanteraError("RedlichKwongMFTP::NicholsSolve", "numerical issues");
         }
         desc = 0.0;
     }
@@ -1306,14 +1306,14 @@ int RedlichKwongMFTP::NicholsSolve(double TKelvin, double pres, doublereal a, do
             if (yN > 0.0) {
                 tmp = pow(yN/(2*an), 1./3.);
                 if (fabs(tmp - delta) > 1.0E-9) {
-                    throw CanteraError("RedlichKwongMFTP::NicholsSolve()", "unexpected");
+                    throw CanteraError("RedlichKwongMFTP::NicholsSolve", "unexpected");
                 }
                 Vroot[1] = xN + delta;
                 Vroot[0] = xN - 2.0*delta; // liquid phase root
             } else {
                 tmp = pow(yN/(2*an), 1./3.);
                 if (fabs(tmp - delta) > 1.0E-9) {
-                    throw CanteraError("RedlichKwongMFTP::NicholsSolve()", "unexpected");
+                    throw CanteraError("RedlichKwongMFTP::NicholsSolve", "unexpected");
                 }
                 delta = -delta;
                 Vroot[0] = xN + delta;

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -731,12 +731,12 @@ vector<double> RedlichKwongMFTP::getCoeff(const std::string& iName)
                 }
                 if (vParams <= 0.0) //Assuming that Pc and Tc are non zero.
                 {
-                    throw CanteraError("RedlichKwongMFTP::GetCoeff",
+                    throw CanteraError("RedlichKwongMFTP::getCoeff",
                                        "Critical Temperature must be positive ");
                 }
                 T_crit = vParams;
             } else {
-                throw CanteraError("RedlichKwongMFTP::GetCoeff",
+                throw CanteraError("RedlichKwongMFTP::getCoeff",
                                    "Critical Temperature not in database ");
             }
             if (acNodeDoc.hasChild("Pc")) {
@@ -749,12 +749,12 @@ vector<double> RedlichKwongMFTP::getCoeff(const std::string& iName)
                 }
                 if (vParams <= 0.0) //Assuming that Pc and Tc are non zero.
                 {
-                    throw CanteraError("RedlichKwongMFTP::GetCoeff",
+                    throw CanteraError("RedlichKwongMFTP::getCoeff",
                                        "Critical Pressure must be positive ");
                 }
                 P_crit = vParams;
             } else {
-                throw CanteraError("RedlichKwongMFTP::GetCoeff",
+                throw CanteraError("RedlichKwongMFTP::getCoeff",
                                    "Critical Pressure not in database ");
             }
 

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -187,7 +187,8 @@ void SingleSpeciesTP::setState_HP(doublereal h, doublereal p,
             return;
         }
     }
-    throw CanteraError("setState_HP","no convergence. dt = {}", dt);
+    throw CanteraError("SingleSpeciesTP::setState_HP",
+                       "no convergence. dt = {}", dt);
 }
 
 void SingleSpeciesTP::setState_UV(doublereal u, doublereal v,
@@ -206,8 +207,8 @@ void SingleSpeciesTP::setState_UV(doublereal u, doublereal v,
             return;
         }
     }
-    throw CanteraError("setState_UV", "no convergence. dt = {}\n"
-                       "u = {} v = {}\n", dt, u, v);
+    throw CanteraError("SingleSpeciesTP::setState_UV",
+                       "no convergence. dt = {}\nu = {} v = {}", dt, u, v);
 }
 
 void SingleSpeciesTP::setState_SP(doublereal s, doublereal p,
@@ -222,7 +223,8 @@ void SingleSpeciesTP::setState_SP(doublereal s, doublereal p,
             return;
         }
     }
-    throw CanteraError("setState_SP","no convergence. dt = {}", dt);
+    throw CanteraError("SingleSpeciesTP::setState_SP",
+                       "no convergence. dt = {}", dt);
 }
 
 void SingleSpeciesTP::setState_SV(doublereal s, doublereal v,
@@ -241,7 +243,8 @@ void SingleSpeciesTP::setState_SV(doublereal s, doublereal v,
             return;
         }
     }
-    throw CanteraError("setState_SV","no convergence. dt = {}", dt);
+    throw CanteraError("SingleSpeciesTP::setState_SV",
+                       "no convergence. dt = {}", dt);
 }
 
 bool SingleSpeciesTP::addSpecies(shared_ptr<Species> spec)

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -133,7 +133,7 @@ static SpeciesThermoInterpType* newNasaThermoFromXML(vector<XML_Node*> nodes)
         getFloatArray(nodes[1]->child("floatArray"), c0, false);
         getFloatArray(f0.child("floatArray"), c1, false);
     } else {
-        throw CanteraError("installNasaThermo",
+        throw CanteraError("newNasaThermoFromXML",
                            "non-continuous temperature ranges.");
     }
 
@@ -218,7 +218,7 @@ static SpeciesThermoInterpType* newShomateThermoFromXML(
         } else {
             if(c0.size() != 7)
             {
-              throw CanteraError("installShomateThermoFromXML",
+              throw CanteraError("newShomateThermoFromXML",
                                  "Shomate thermo requires 7 coefficients in float array.");
             }
             c1.resize(7,0.0);
@@ -231,12 +231,12 @@ static SpeciesThermoInterpType* newShomateThermoFromXML(
         getFloatArray(nodes[1]->child("floatArray"), c0, false);
         getFloatArray(nodes[0]->child("floatArray"), c1, false);
     } else {
-        throw CanteraError("installShomateThermoFromXML",
+        throw CanteraError("newShomateThermoFromXML",
                            "non-continuous temperature ranges.");
     }
     if(c0.size() != 7 || c1.size() != 7)
     {
-      throw CanteraError("installShomateThermoFromXML",
+      throw CanteraError("newShomateThermoFromXML",
                          "Shomate thermo requires 7 coefficients in float array.");
     }
     vector_fp c(15);
@@ -331,7 +331,7 @@ static SpeciesThermoInterpType* newNasa9ThermoFromXML(
 
             getFloatArray(fptr.child("floatArray"), cPoly, false);
             if (cPoly.size() != 9) {
-                throw CanteraError("installNasa9ThermoFromXML",
+                throw CanteraError("newNasa9ThermoFromXML",
                                    "Expected 9 coeff polynomial");
             }
             regionPtrs.push_back(new Nasa9Poly1(tmin, tmax, pref, &cPoly[0]));

--- a/src/thermo/StoichSubstance.cpp
+++ b/src/thermo/StoichSubstance.cpp
@@ -123,7 +123,7 @@ void StoichSubstance::initThermo()
 {
     // Make sure there is one and only one species in this phase.
     if (m_kk != 1) {
-        throw CanteraError("initThermo",
+        throw CanteraError("StoichSubstance::initThermo",
                            "stoichiometric substances may only contain one species.");
     }
 

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -343,9 +343,9 @@ void importPhase(XML_Node& phase, ThermoPhase* th)
         // local file containing the phase element, or may be in another file.
         XML_Node* db = get_XML_Node(speciesArray["datasrc"], &phase.root());
         if (db == 0) {
-            throw CanteraError("importPhase()",
-                               " Can not find XML node for species database: "
-                               + speciesArray["datasrc"]);
+            throw CanteraError("importPhase",
+                               "Can not find XML node for species database: {}",
+                               speciesArray["datasrc"]);
         }
 
         // add this node to the list of species database nodes.
@@ -364,7 +364,7 @@ void importPhase(XML_Node& phase, ThermoPhase* th)
 
     size_t nsp = spDataNodeList.size();
     if (ssConvention == cSS_CONVENTION_SLAVE && nsp > 0) {
-        throw CanteraError("importPhase()", "For Slave standard states, "
+        throw CanteraError("importPhase", "For Slave standard states, "
             "number of species must be zero: {}", nsp);
     }
     for (size_t k = 0; k < nsp; k++) {
@@ -636,7 +636,7 @@ const XML_Node* speciesXML_Node(const std::string& kname,
     }
     string jname = phaseSpeciesData->name();
     if (jname != "speciesData") {
-        throw CanteraError("speciesXML_Node()",
+        throw CanteraError("speciesXML_Node",
                            "Unexpected phaseSpeciesData name: " + jname);
     }
     vector<XML_Node*> xspecies = phaseSpeciesData->getChildren("species");

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -222,8 +222,8 @@ static void formSpeciesXMLNodeList(std::vector<XML_Node*> &spDataNodeList,
                     // Find the species in the database by name.
                     auto iter = speciesNodes.find(stemp);
                     if (iter == speciesNodes.end()) {
-                        throw CanteraError("importPhase","no data for species, \""
-                                           + stemp + "\"");
+                        throw CanteraError("formSpeciesXMLNodeList",
+                            "no data for species, \"{}\"", stemp);
                     }
                     spNamesList.push_back(stemp);
                     spDataNodeList.push_back(iter->second);
@@ -603,8 +603,8 @@ void installElements(Phase& th, const XML_Node& phaseNode)
             e = dbe->findByAttr("name",enames[i]);
         }
         if (!e) {
-            throw CanteraError("addElementsFromXML","no data for element "
-                               +enames[i]);
+            throw CanteraError("installElements", "no data for element '{}'",
+                               enames[i]);
         }
 
         // Add the element

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -311,13 +311,13 @@ void ThermoPhase::setState_HPorUV(double Htarget, double p,
     if (doUV) {
         doublereal v = p;
         if (v < 1.0E-300) {
-            throw CanteraError("setState_HPorUV (UV)",
+            throw CanteraError("ThermoPhase::setState_HPorUV (UV)",
                                "Input specific volume is too small or negative. v = {}", v);
         }
         setDensity(1.0/v);
     } else {
         if (p < 1.0E-300) {
-            throw CanteraError("setState_HPorUV (HP)",
+            throw CanteraError("ThermoPhase::setState_HPorUV (HP)",
                                "Input pressure is too small or negative. p = {}", p);
         }
         setPressure(p);
@@ -486,9 +486,9 @@ void ThermoPhase::setState_HPorUV(double Htarget, double p,
             Tunstable);
     }
     if (doUV) {
-        throw CanteraError("setState_HPorUV (UV)", ErrString);
+        throw CanteraError("ThermoPhase::setState_HPorUV (UV)", ErrString);
     } else {
-        throw CanteraError("setState_HPorUV (HP)", ErrString);
+        throw CanteraError("ThermoPhase::setState_HPorUV (HP)", ErrString);
     }
 }
 
@@ -510,13 +510,13 @@ void ThermoPhase::setState_SPorSV(double Starget, double p,
     if (doSV) {
         v = p;
         if (v < 1.0E-300) {
-            throw CanteraError("setState_SPorSV (SV)",
+            throw CanteraError("ThermoPhase::setState_SPorSV (SV)",
                 "Input specific volume is too small or negative. v = {}", v);
         }
         setDensity(1.0/v);
     } else {
         if (p < 1.0E-300) {
-            throw CanteraError("setState_SPorSV (SP)",
+            throw CanteraError("ThermoPhase::setState_SPorSV (SP)",
                 "Input pressure is too small or negative. p = {}", p);
         }
         setPressure(p);
@@ -669,9 +669,9 @@ void ThermoPhase::setState_SPorSV(double Starget, double p,
                      Tunstable);
     }
     if (doSV) {
-        throw CanteraError("setState_SPorSV (SV)", ErrString);
+        throw CanteraError("ThermoPhase::setState_SPorSV (SV)", ErrString);
     } else {
-        throw CanteraError("setState_SPorSV (SP)", ErrString);
+        throw CanteraError("ThermoPhase::setState_SPorSV (SP)", ErrString);
     }
 }
 

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -202,8 +202,7 @@ void VPStandardStateTP::setPressure(doublereal p)
 
 void VPStandardStateTP::calcDensity()
 {
-    throw NotImplementedError("VPStandardStateTP::calcDensity() called, "
-                              "but EOS for phase is not known");
+    throw NotImplementedError("VPStandardStateTP::calcDensity");
 }
 
 void VPStandardStateTP::setState_TP(doublereal t, doublereal pres)

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -142,10 +142,10 @@ doublereal WaterPropsIAPWS::density_const(doublereal pressure,
                     // relatively high -> convergence from above seems robust.
                     rhoguess = 1000.;
                 } else if (phase == WATER_UNSTABLELIQUID || phase == WATER_UNSTABLEGAS) {
-                    throw CanteraError("WaterPropsIAPWS::density",
+                    throw CanteraError("WaterPropsIAPWS::density_const",
                                        "Unstable Branch finder is untested");
                 } else {
-                    throw CanteraError("WaterPropsIAPWS::density",
+                    throw CanteraError("WaterPropsIAPWS::density_const",
                                        "unknown state: {}", phase);
                 }
             }

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -470,7 +470,7 @@ doublereal WaterPropsIAPWS::densSpinodalWater() const
     }
 
     if (!conv) {
-        throw CanteraError("WaterPropsIAPWS::densSpinodalWater()",
+        throw CanteraError("WaterPropsIAPWS::densSpinodalWater",
                            "convergence failure");
     }
     // Restore the original delta
@@ -557,7 +557,7 @@ doublereal WaterPropsIAPWS::densSpinodalSteam() const
     }
 
     if (!conv) {
-        throw CanteraError("WaterPropsIAPWS::densSpinodalSteam()",
+        throw CanteraError("WaterPropsIAPWS::densSpinodalSteam",
                            "convergence failure");
     }
     // Restore the original delta

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -276,7 +276,7 @@ void WaterSSTP::setPressure(doublereal p)
     }
     doublereal dd = m_sub.density(T, p, waterState, dens);
     if (dd <= 0.0) {
-        throw CanteraError("setPressure", "error");
+        throw CanteraError("WaterSSTP::setPressure", "error");
     }
     setDensity(dd);
 }

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -130,7 +130,7 @@ void WaterSSTP::getGibbs_RT(doublereal* grt) const
 {
     *grt = (m_sub.Gibbs() + EW_Offset) / RT() - SW_Offset / GasConstant;
     if (!m_ready) {
-        throw CanteraError("waterSSTP::", "Phase not ready");
+        throw CanteraError("waterSSTP::getGibbs_RT", "Phase not ready");
     }
 }
 
@@ -138,7 +138,8 @@ void WaterSSTP::getStandardChemPotentials(doublereal* gss) const
 {
     *gss = (m_sub.Gibbs() + EW_Offset - SW_Offset*temperature());
     if (!m_ready) {
-        throw CanteraError("waterSSTP::", "Phase not ready");
+        throw CanteraError("waterSSTP::getStandardChemPotentials",
+                           "Phase not ready");
     }
 }
 
@@ -164,7 +165,7 @@ void WaterSSTP::getEnthalpy_RT_ref(doublereal* hrt) const
     }
     doublereal dd = m_sub.density(T, OneAtm, waterState, dens);
     if (dd <= 0.0) {
-        throw CanteraError("setPressure", "error");
+        throw CanteraError("WaterSSTP::getEnthalpy_RT_ref", "error");
     }
     doublereal h = m_sub.enthalpy();
     *hrt = (h + EW_Offset) / RT();
@@ -183,7 +184,7 @@ void WaterSSTP::getGibbs_RT_ref(doublereal* grt) const
     }
     doublereal dd = m_sub.density(T, OneAtm, waterState, dens);
     if (dd <= 0.0) {
-        throw CanteraError("setPressure", "error");
+        throw CanteraError("WaterSSTP::getGibbs_RT_ref", "error");
     }
     m_sub.setState_TR(T, dd);
     doublereal g = m_sub.Gibbs();
@@ -212,7 +213,7 @@ void WaterSSTP::getEntropy_R_ref(doublereal* sr) const
     doublereal dd = m_sub.density(T, OneAtm, waterState, dens);
 
     if (dd <= 0.0) {
-        throw CanteraError("setPressure", "error");
+        throw CanteraError("WaterSSTP::getEntropy_R_ref", "error");
     }
     m_sub.setState_TR(T, dd);
 
@@ -234,7 +235,7 @@ void WaterSSTP::getCp_R_ref(doublereal* cpr) const
     doublereal dd = m_sub.density(T, OneAtm, waterState, dens);
     m_sub.setState_TR(T, dd);
     if (dd <= 0.0) {
-        throw CanteraError("setPressure", "error");
+        throw CanteraError("WaterSSTP::getCp_R_ref", "error");
     }
     doublereal cp = m_sub.cp();
     *cpr = cp / GasConstant;
@@ -253,7 +254,7 @@ void WaterSSTP::getStandardVolumes_ref(doublereal* vol) const
     }
     doublereal dd = m_sub.density(T, OneAtm, waterState, dens);
     if (dd <= 0.0) {
-        throw CanteraError("setPressure", "error");
+        throw CanteraError("WaterSSTP::getStandardVolumes_ref", "error");
     }
     *vol = meanMolecularWeight() /dd;
     dd = m_sub.density(T, p, waterState, dens);

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -497,7 +497,7 @@ void Substance::update_sat()
         }
 
         if (i >= 20) {
-            throw CanteraError("substance::update_sat","no convergence");
+            throw CanteraError("Substance::update_sat", "no convergence");
         } else {
             Pst = pp;
             Tslast = T;

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -167,7 +167,7 @@ void GasTransport::getBinaryDiffCoeffs(const size_t ld, doublereal* const d)
         updateDiff_T();
     }
     if (ld < m_nsp) {
-        throw CanteraError(" MixTransport::getBinaryDiffCoeffs()", "ld is too small");
+        throw CanteraError("GasTransport::getBinaryDiffCoeffs", "ld is too small");
     }
     doublereal rp = 1.0/m_thermo->pressure();
     for (size_t i = 0; i < m_nsp; i++) {

--- a/src/transport/HighPressureGasTransport.cpp
+++ b/src/transport/HighPressureGasTransport.cpp
@@ -148,7 +148,8 @@ void HighPressureGasTransport::getBinaryDiffCoeffs(const size_t ld, doublereal* 
     updateDiff_T();
     //}
     if (ld < nsp) {
-        throw CanteraError("HighPressureTransport::getBinaryDiffCoeffs()", "ld is too small");
+        throw CanteraError("HighPressureGasTransport::getBinaryDiffCoeffs",
+                           "ld is too small");
     }
     doublereal rp = 1.0/m_thermo->pressure();
     for (size_t i = 0; i < nsp; i++) {
@@ -215,7 +216,7 @@ void HighPressureGasTransport::getMultiDiffCoeffs(const size_t ld, doublereal* c
     updateDiff_T();
 
     if (ld < m_nsp) {
-        throw CanteraError("HighPressureTransport::getMultiDiffCoeffs()",
+        throw CanteraError("HighPressureGasTransport::getMultiDiffCoeffs",
                            "ld is too small");
     }
     for (size_t i = 0; i < m_nsp; i++) {

--- a/src/transport/HighPressureGasTransport.cpp
+++ b/src/transport/HighPressureGasTransport.cpp
@@ -130,8 +130,7 @@ void HighPressureGasTransport::getThermalDiffCoeffs(doublereal* const dt)
     // for (size_t k = 0; k < m_nsp; k++) {
     // dt[k] = c * m_mw[k] * m_molefracs[k] * m_a[k];
     // }
-    throw CanteraError("HighPressureGasTransport::getThermalDiffCoeffs",
-                       "Not yet implemented.");
+    throw NotImplementedError("HighPressureGasTransport::getThermalDiffCoeffs");
 }
 
 void HighPressureGasTransport::getBinaryDiffCoeffs(const size_t ld, doublereal* const d)
@@ -194,8 +193,7 @@ void HighPressureGasTransport::getMultiDiffCoeffs(const size_t ld, doublereal* c
 {
     // Not currently implemented.  m_Lmatrix inversion returns NaN.  Needs to be
     //   fixed.  --SCD - 2-28-2014
-    throw CanteraError("HighPressureTransport:getMultiDiffCoeffs()",
-                       "Routine not yet implemented");
+    throw NotImplementedError("HighPressureGasTransport:getMultiDiffCoeffs");
     // Calculate the multi-component Stefan-Maxwell diffusion coefficients,
     // based on the Takahashi-correlation-corrected binary diffusion coefficients.
 

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -21,7 +21,7 @@ void IonGasTransport::init(thermo_t* thermo, int mode, int log_level)
     m_nsp = m_thermo->nSpecies();
     m_mode = mode;
     if (m_mode == CK_Mode) {
-        throw CanteraError("IonGasTransport::init(thermo, mode, log_level)",
+        throw CanteraError("IonGasTransport::init",
                            "mode = CK_Mode, which is an outdated lower-order fit.");
     }
     m_log_level = log_level;
@@ -308,7 +308,7 @@ double IonGasTransport::omega11_n64(const double tstar, const double gamma)
     double logtstar = log(tstar);
     double om11 = 0.0;
     if (tstar < 0.01) {
-        throw CanteraError("IonGasTransport::omega11_n64(tstar, gamma)",
+        throw CanteraError("IonGasTransport::omega11_n64",
                            "tstar = {} is smaller than 0.01", tstar);
     } else if (tstar <= 0.04) {
         // for interval 0.01 to 0.04, SSE = 0.006; R^2 = 1; RMSE = 0.020
@@ -329,7 +329,7 @@ double IonGasTransport::omega11_n64(const double tstar, const double gamma)
               + (0.000614 - 0.00285 * gamma) * pow(logtstar,4)
               + 0.000238 * pow(logtstar,5);
     } else {
-        throw CanteraError("IonGasTransport::omega11_n64(tstar, gamma)",
+        throw CanteraError("IonGasTransport::omega11_n64",
                            "tstar = {} is larger than 1000", tstar);
     }
     return om11;

--- a/src/transport/TransportBase.cpp
+++ b/src/transport/TransportBase.cpp
@@ -34,14 +34,14 @@ void Transport::setNDim(const int ndim)
 void Transport::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_nsp) {
-        throw IndexError("checkSpeciesIndex", "species", k, m_nsp-1);
+        throw IndexError("Transport::checkSpeciesIndex", "species", k, m_nsp-1);
     }
 }
 
 void Transport::checkSpeciesArraySize(size_t kk) const
 {
     if (m_nsp > kk) {
-        throw ArraySizeError("checkSpeciesArraySize", kk, m_nsp);
+        throw ArraySizeError("Transport::checkSpeciesArraySize", kk, m_nsp);
     }
 }
 

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -26,6 +26,7 @@ TransportFactory* TransportFactory::s_factory = 0;
 std::mutex TransportFactory::transport_mutex;
 
 //! Exception thrown if an error is encountered while reading the transport database
+//! @deprecated Unused. To be removed after Cantera 2.5.
 class TransportDBError : public CanteraError
 {
 public:
@@ -36,6 +37,8 @@ public:
      */
     TransportDBError(size_t linenum, const std::string& msg) :
         CanteraError("getTransportData", "error reading transport data: " + msg + "\n") {
+            warn_deprecated("class TransportDBError",
+                "Unused. To be removed after Cantera 2.5.");
     }
 };
 

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -16,7 +16,7 @@ namespace Cantera
 void ConstPressureReactor::getState(double* y)
 {
     if (m_thermo == 0) {
-        throw CanteraError("getState",
+        throw CanteraError("ConstPressureReactor::getState",
                            "Error: reactor is empty.");
     }
     m_thermo->restoreState(m_state);

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -26,7 +26,7 @@ FlowReactor::FlowReactor() :
 void FlowReactor::getState(double* y)
 {
     if (m_thermo == 0) {
-        throw CanteraError("getState",
+        throw CanteraError("FlowReactor::getState",
                            "Error: reactor is empty.");
     }
     m_thermo->restoreState(m_state);

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -16,7 +16,7 @@ void IdealGasConstPressureReactor::setThermoMgr(ThermoPhase& thermo)
     //! @TODO: Add a method to ThermoPhase that indicates whether a given
     //! subclass is compatible with this reactor model
     if (thermo.type() != "IdealGas") {
-        throw CanteraError("IdealGasReactor::setThermoMgr",
+        throw CanteraError("IdealGasConstPressureReactor::setThermoMgr",
                            "Incompatible phase type provided");
     }
     Reactor::setThermoMgr(thermo);
@@ -25,7 +25,7 @@ void IdealGasConstPressureReactor::setThermoMgr(ThermoPhase& thermo)
 void IdealGasConstPressureReactor::getState(double* y)
 {
     if (m_thermo == 0) {
-        throw CanteraError("getState",
+        throw CanteraError("IdealGasConstPressureReactor::getState",
                            "Error: reactor is empty.");
     }
     m_thermo->restoreState(m_state);

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -26,7 +26,7 @@ void IdealGasReactor::setThermoMgr(ThermoPhase& thermo)
 void IdealGasReactor::getState(double* y)
 {
     if (m_thermo == 0) {
-        throw CanteraError("getState",
+        throw CanteraError("IdealGasReactor::getState",
                            "Error: reactor is empty.");
     }
     m_thermo->restoreState(m_state);

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -442,7 +442,7 @@ void Reactor::resetSensitivity(double* params)
 void Reactor::setAdvanceLimits(const double *limits)
 {
     if (m_thermo == 0) {
-        throw CanteraError("getState",
+        throw CanteraError("Reactor::setAdvanceLimits",
                            "Error: reactor is empty.");
     }
     for (size_t j = 0; j < m_nv; j++) {
@@ -467,7 +467,7 @@ void Reactor::setAdvanceLimit(const string& nm, const double limit)
     size_t k = componentIndex(nm);
 
     if (m_thermo == 0) {
-        throw CanteraError("getState",
+        throw CanteraError("Reactor::setAdvanceLimit",
                            "Error: reactor is empty.");
     }
     if (m_nv == 0) {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -40,7 +40,7 @@ void Reactor::setKineticsMgr(Kinetics& kin)
 void Reactor::getState(double* y)
 {
     if (m_thermo == 0) {
-        throw CanteraError("getState",
+        throw CanteraError("Reactor::getState",
                            "Error: reactor is empty.");
     }
     m_thermo->restoreState(m_state);

--- a/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
+++ b/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
@@ -43,7 +43,7 @@ void testProblem()
     XML_Node* xc = get_XML_File("ReactionSurf.xml");
     XML_Node* xg = xc->findNameID("phase", "reaction_surface");
     if (!xg) {
-        throw CanteraError("couldn't find file", "");
+        throw CanteraError("testProblem", "couldn't find file");
     }
     unique_ptr<ThermoPhase> surfTP(newPhase(*xg));
     unique_ptr<ThermoPhase> gasTP(newPhase("gas.xml"));


### PR DESCRIPTION
I had noticed a few instances where calls to `CanteraError` referenced the wrong method name (usually due to copy-paste), and decided to do a full pass over all of the places where `CanteraError` and related exceptions are thrown to fix these errors, updating them to always include both the class name and method name, as well as normalizing a few variations on the formatting.

This also updates the documentation for the `CanteraError` class to specify how the method name should be written.