### PR TITLE
Add Reaction factory

### DIFF
--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -67,6 +67,18 @@ public:
     //! reactions.
     virtual void update_rates_C();
 
+    //! register a function that adds a reaction
+    void reg_addRxn(const std::string& name,
+                    std::function<void(shared_ptr<Reaction>)> f) {
+        m_addRxn[name] = f;
+    }
+
+    //! register a function that modifies a reaction
+    void reg_modRxn(const std::string& name,
+                    std::function<void(size_t, shared_ptr<Reaction>)> f) {
+        m_modRxn[name] = f;
+    }
+
 protected:
     //! Reaction index of each falloff reaction
     std::vector<size_t> m_fallindx;
@@ -117,6 +129,14 @@ protected:
 
     //! Update the equilibrium constants in molar units.
     void updateKc();
+
+    //! map functions adding reactions
+    std::unordered_map<std::string,
+        std::function<void(shared_ptr<Reaction>)>> m_addRxn;
+
+    //! map functions modifying reactions
+    std::unordered_map<std::string,
+        std::function<void(size_t, shared_ptr<Reaction>)>> m_modRxn;
 };
 
 }

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -28,6 +28,12 @@ public:
              const Composition& products);
     virtual ~Reaction() {}
 
+    virtual void setup(const XML_Node& rxn_node) {
+    }
+
+    virtual void setup(const AnyMap& node, const Kinetics& kin) {
+    }
+
     //! The reactant side of the chemical equation for this reaction
     virtual std::string reactantString() const;
 
@@ -88,6 +94,9 @@ public:
                        const Arrhenius& rate);
     virtual void validate();
 
+    virtual void setup(const XML_Node& rxn_node);
+    virtual void setup(const AnyMap& node, const Kinetics& kin);
+
     Arrhenius rate;
     bool allow_negative_pre_exponential_factor;
 };
@@ -119,6 +128,10 @@ public:
     ThreeBodyReaction();
     ThreeBodyReaction(const Composition& reactants, const Composition& products,
                       const Arrhenius& rate, const ThirdBody& tbody);
+
+    virtual void setup(const XML_Node& rxn_node);
+    virtual void setup(const AnyMap& node, const Kinetics& kin);
+
     virtual std::string reactantString() const;
     virtual std::string productString() const;
 
@@ -136,6 +149,10 @@ public:
     FalloffReaction(const Composition& reactants, const Composition& products,
                     const Arrhenius& low_rate, const Arrhenius& high_rate,
                     const ThirdBody& tbody);
+
+    virtual void setup(const XML_Node& rxn_node);
+    virtual void setup(const AnyMap& node, const Kinetics& kin);
+
     virtual std::string reactantString() const;
     virtual std::string productString() const;
     virtual void validate();
@@ -165,6 +182,8 @@ public:
     ChemicallyActivatedReaction(const Composition& reactants,
         const Composition& products, const Arrhenius& low_rate,
         const Arrhenius& high_rate, const ThirdBody& tbody);
+
+    virtual void setup(const XML_Node& rxn_node);
 };
 
 //! A pressure-dependent reaction parameterized by logarithmically interpolating
@@ -175,6 +194,10 @@ public:
     PlogReaction();
     PlogReaction(const Composition& reactants, const Composition& products,
                  const Plog& rate);
+
+    virtual void setup(const XML_Node& rxn_node);
+    virtual void setup(const AnyMap& node, const Kinetics& kin);
+
     virtual void validate();
     Plog rate;
 };
@@ -187,6 +210,9 @@ public:
     ChebyshevReaction();
     ChebyshevReaction(const Composition& reactants, const Composition& products,
                       const ChebyshevRate& rate);
+
+    virtual void setup(const XML_Node& rxn_node);
+    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     ChebyshevRate rate;
 };
@@ -213,6 +239,9 @@ public:
     InterfaceReaction();
     InterfaceReaction(const Composition& reactants, const Composition& products,
                       const Arrhenius& rate, bool isStick=false);
+
+    virtual void setup(const XML_Node& rxn_node);
+    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     //! Adjustments to the Arrhenius rate expression dependent on surface
     //! species coverages. Three coverage parameters (a, E, m) are used for each
@@ -243,6 +272,9 @@ public:
     ElectrochemicalReaction(const Composition& reactants,
                             const Composition& products, const Arrhenius& rate);
 
+    virtual void setup(const XML_Node& rxn_node);
+    virtual void setup(const AnyMap& node, const Kinetics& kin);
+
     //! Film Resistivity value
     /*!
      *  For Butler Volmer reactions, a common addition to the formulation is to
@@ -258,12 +290,6 @@ public:
 
     bool exchange_current_density_formulation;
 };
-
-//! Create a new Reaction object for the reaction defined in `rxn_node`
-shared_ptr<Reaction> newReaction(const XML_Node& rxn_node);
-
-//! Create a new Reaction object using the specified parameters
-unique_ptr<Reaction> newReaction(const AnyMap& rxn_node, const Kinetics& kin);
 
 //! Create Reaction objects for all `<reaction>` nodes in an XML document.
 //!
@@ -290,6 +316,13 @@ std::vector<shared_ptr<Reaction> > getReactions(const XML_Node& node);
 //! Kinetics object `kinetics`.
 std::vector<shared_ptr<Reaction>> getReactions(const AnyValue& items,
                                                Kinetics& kinetics);
+
+//! Check whether reaction is an electrochemical reaction
+bool isElectrochemicalReaction(Reaction& R, const Kinetics& kin);
+
+//! Parse reaction equation
+void parseReactionEquation(Reaction& R, const AnyValue& equation,
+                           const Kinetics& kin);
 }
 
 #endif

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -28,10 +28,14 @@ public:
              const Composition& products);
     virtual ~Reaction() {}
 
+    //! set up reaction based on XML node (overloaded)
     virtual void setup(const XML_Node& rxn_node) {
+        throw NotImplementedError("Reaction::setup");
     }
 
+    //! set up reaction based on AnyMap node (overloaded)
     virtual void setup(const AnyMap& node, const Kinetics& kin) {
+        throw NotImplementedError("Reaction::setup");
     }
 
     //! The reactant side of the chemical equation for this reaction
@@ -42,6 +46,11 @@ public:
 
     //! The chemical equation for this reaction
     std::string equation() const;
+
+    //! The type of reaction
+    virtual std::string type() const {
+        return "<reaction>";
+    }
 
     //! Ensure that the rate constant and other parameters for this reaction are
     //! valid.
@@ -94,6 +103,9 @@ public:
                        const Arrhenius& rate);
     virtual void validate();
 
+    virtual std::string type() const {
+        return "elementary";
+    }
     virtual void setup(const XML_Node& rxn_node);
     virtual void setup(const AnyMap& node, const Kinetics& kin);
 
@@ -129,6 +141,9 @@ public:
     ThreeBodyReaction(const Composition& reactants, const Composition& products,
                       const Arrhenius& rate, const ThirdBody& tbody);
 
+    virtual std::string type() const {
+        return "three-body";
+    }
     virtual void setup(const XML_Node& rxn_node);
     virtual void setup(const AnyMap& node, const Kinetics& kin);
 
@@ -150,6 +165,9 @@ public:
                     const Arrhenius& low_rate, const Arrhenius& high_rate,
                     const ThirdBody& tbody);
 
+    virtual std::string type() const {
+        return "falloff";
+    }
     virtual void setup(const XML_Node& rxn_node);
     virtual void setup(const AnyMap& node, const Kinetics& kin);
 
@@ -183,6 +201,9 @@ public:
         const Composition& products, const Arrhenius& low_rate,
         const Arrhenius& high_rate, const ThirdBody& tbody);
 
+    virtual std::string type() const {
+        return "chemically-activated";
+    }
     virtual void setup(const XML_Node& rxn_node);
 };
 
@@ -195,6 +216,9 @@ public:
     PlogReaction(const Composition& reactants, const Composition& products,
                  const Plog& rate);
 
+    virtual std::string type() const {
+        return "pressure-dependent-Arrhenius";
+    }
     virtual void setup(const XML_Node& rxn_node);
     virtual void setup(const AnyMap& node, const Kinetics& kin);
 
@@ -211,6 +235,9 @@ public:
     ChebyshevReaction(const Composition& reactants, const Composition& products,
                       const ChebyshevRate& rate);
 
+    virtual std::string type() const {
+        return "Chebyshev";
+    }
     virtual void setup(const XML_Node& rxn_node);
     virtual void setup(const AnyMap& node, const Kinetics& kin);
 
@@ -240,6 +267,9 @@ public:
     InterfaceReaction(const Composition& reactants, const Composition& products,
                       const Arrhenius& rate, bool isStick=false);
 
+    virtual std::string type() const {
+        return "interface";
+    }
     virtual void setup(const XML_Node& rxn_node);
     virtual void setup(const AnyMap& node, const Kinetics& kin);
 
@@ -272,6 +302,9 @@ public:
     ElectrochemicalReaction(const Composition& reactants,
                             const Composition& products, const Arrhenius& rate);
 
+    virtual std::string type() const {
+        return "electrochemical";
+    }
     virtual void setup(const XML_Node& rxn_node);
     virtual void setup(const AnyMap& node, const Kinetics& kin);
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -28,16 +28,6 @@ public:
              const Composition& products);
     virtual ~Reaction() {}
 
-    //! set up reaction based on XML node (overloaded)
-    virtual void setup(const XML_Node& rxn_node) {
-        throw NotImplementedError("Reaction::setup");
-    }
-
-    //! set up reaction based on AnyMap node (overloaded)
-    virtual void setup(const AnyMap& node, const Kinetics& kin) {
-        throw NotImplementedError("Reaction::setup");
-    }
-
     //! The reactant side of the chemical equation for this reaction
     virtual std::string reactantString() const;
 
@@ -106,8 +96,6 @@ public:
     virtual std::string type() const {
         return "elementary";
     }
-    virtual void setup(const XML_Node& rxn_node);
-    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     Arrhenius rate;
     bool allow_negative_pre_exponential_factor;
@@ -144,8 +132,6 @@ public:
     virtual std::string type() const {
         return "three-body";
     }
-    virtual void setup(const XML_Node& rxn_node);
-    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     virtual std::string reactantString() const;
     virtual std::string productString() const;
@@ -168,8 +154,6 @@ public:
     virtual std::string type() const {
         return "falloff";
     }
-    virtual void setup(const XML_Node& rxn_node);
-    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     virtual std::string reactantString() const;
     virtual std::string productString() const;
@@ -204,7 +188,6 @@ public:
     virtual std::string type() const {
         return "chemically-activated";
     }
-    virtual void setup(const XML_Node& rxn_node);
 };
 
 //! A pressure-dependent reaction parameterized by logarithmically interpolating
@@ -219,8 +202,6 @@ public:
     virtual std::string type() const {
         return "pressure-dependent-Arrhenius";
     }
-    virtual void setup(const XML_Node& rxn_node);
-    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     virtual void validate();
     Plog rate;
@@ -238,8 +219,6 @@ public:
     virtual std::string type() const {
         return "Chebyshev";
     }
-    virtual void setup(const XML_Node& rxn_node);
-    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     ChebyshevRate rate;
 };
@@ -270,8 +249,6 @@ public:
     virtual std::string type() const {
         return "interface";
     }
-    virtual void setup(const XML_Node& rxn_node);
-    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     //! Adjustments to the Arrhenius rate expression dependent on surface
     //! species coverages. Three coverage parameters (a, E, m) are used for each
@@ -305,8 +282,6 @@ public:
     virtual std::string type() const {
         return "electrochemical";
     }
-    virtual void setup(const XML_Node& rxn_node);
-    virtual void setup(const AnyMap& node, const Kinetics& kin);
 
     //! Film Resistivity value
     /*!

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -325,9 +325,6 @@ std::vector<shared_ptr<Reaction> > getReactions(const XML_Node& node);
 std::vector<shared_ptr<Reaction>> getReactions(const AnyValue& items,
                                                Kinetics& kinetics);
 
-//! Check whether reaction is an electrochemical reaction
-bool isElectrochemicalReaction(Reaction& R, const Kinetics& kin);
-
 //! Parse reaction equation
 void parseReactionEquation(Reaction& R, const AnyValue& equation,
                            const Kinetics& kin);

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -331,6 +331,39 @@ bool isElectrochemicalReaction(Reaction& R, const Kinetics& kin);
 //! Parse reaction equation
 void parseReactionEquation(Reaction& R, const AnyValue& equation,
                            const Kinetics& kin);
+
+// declarations of setup functions
+void setupElementaryReaction(ElementaryReaction&, const XML_Node&);
+void setupElementaryReaction(ElementaryReaction&, const AnyMap&,
+                             const Kinetics&);
+
+void setupThreeBodyReaction(ThreeBodyReaction&, const XML_Node&);
+void setupThreeBodyReaction(ThreeBodyReaction&, const AnyMap&,
+                            const Kinetics&);
+
+void setupFalloffReaction(FalloffReaction&, const XML_Node&);
+void setupFalloffReaction(FalloffReaction&, const AnyMap&,
+                          const Kinetics&);
+
+void setupChemicallyActivatedReaction(ChemicallyActivatedReaction&,
+                                      const XML_Node&);
+
+void setupPlogReaction(PlogReaction&, const XML_Node&);
+void setupPlogReaction(PlogReaction&, const AnyMap&, const Kinetics&);
+
+void setupChebyshevReaction(ChebyshevReaction&, const XML_Node&);
+void setupChebyshevReaction(ChebyshevReaction&, const AnyMap&,
+                            const Kinetics&);
+
+void setupInterfaceReaction(InterfaceReaction&, const XML_Node&);
+void setupInterfaceReaction(InterfaceReaction&, const AnyMap&,
+                            const Kinetics&);
+
+void setupElectrochemicalReaction(ElectrochemicalReaction&,
+                                  const XML_Node&);
+void setupElectrochemicalReaction(ElectrochemicalReaction&,
+                                  const AnyMap&, const Kinetics&);
+
 }
 
 #endif

--- a/include/cantera/kinetics/ReactionFactory.h
+++ b/include/cantera/kinetics/ReactionFactory.h
@@ -49,6 +49,8 @@ public:
         s_factory = 0;
     }
 
+    virtual Reaction* newReaction(const std::string& type);
+
     //! Return a pointer to a new reaction function calculator.
     /*!
      * @param type Integer flag specifying the type of reaction function. The
@@ -114,6 +116,9 @@ private:
     std::unordered_map<std::string,
         std::function<void(Reaction*, const AnyMap&, const Kinetics&)>> m_anymap_setup;
 };
+
+//! Create a new empty Reaction object
+unique_ptr<Reaction> newReaction(const std::string& type);
 
 //! Create a new Reaction object for the reaction defined in `rxn_node`
 unique_ptr<Reaction> newReaction(const XML_Node& rxn_node);

--- a/include/cantera/kinetics/ReactionFactory.h
+++ b/include/cantera/kinetics/ReactionFactory.h
@@ -1,0 +1,84 @@
+/**
+ *  @file ReactionFactory.h
+ *  Parameterizations for reaction reaction functions. Used by classes
+ *  that implement gas-phase kinetics (GasKinetics, GRI_30_Kinetics)
+ *  (see \ref reactionGroup and class \link Cantera::Reaction Reaction\endlink).
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_NEWREACTION_H
+#define CT_NEWREACTION_H
+
+#include "cantera/base/FactoryBase.h"
+#include "cantera/kinetics/Reaction.h"
+
+namespace Cantera
+{
+
+/**
+ * Factory class to construct reaction function calculators.
+ * The reaction factory is accessed through static method factory:
+ *
+ * @code
+ * Reaction* f = ReactionFactory::factory()->newReaction(type, c)
+ * @endcode
+ *
+ * @ingroup reactionGroup
+ */
+class ReactionFactory : public Factory<Reaction>
+{
+public:
+    /**
+     * Return a pointer to the factory. On the first call, a new instance is
+     * created. Since there is no need to instantiate more than one factory,
+     * on all subsequent calls, a pointer to the existing factory is returned.
+     */
+    static ReactionFactory* factory() {
+        std::unique_lock<std::mutex> lock(reaction_mutex);
+        if (!s_factory) {
+            s_factory = new ReactionFactory;
+        }
+        return s_factory;
+    }
+
+    virtual void deleteFactory() {
+        std::unique_lock<std::mutex> lock(reaction_mutex);
+        delete s_factory;
+        s_factory = 0;
+    }
+
+    //! Return a pointer to a new reaction function calculator.
+    /*!
+     * @param type Integer flag specifying the type of reaction function. The
+     *              standard types are defined in file reaction_defs.h. A
+     *              factory class derived from ReactionFactory may define other
+     *              types as well.
+     * @param c    input vector of doubles which populates the reaction
+     *             parameterization.
+     * @returns    a pointer to a new Reaction class.
+     */
+    virtual Reaction* newReaction(const XML_Node& rxn_node);
+
+    virtual Reaction* newReaction(const AnyMap& rxn_node,
+                                  const Kinetics& kin);
+private:
+    //! Pointer to the single instance of the factory
+    static ReactionFactory* s_factory;
+
+    //! default constructor, which is defined as private
+    ReactionFactory();
+
+    //!  Mutex for use when calling the factory
+    static std::mutex reaction_mutex;
+};
+
+//! Create a new Reaction object for the reaction defined in `rxn_node`
+unique_ptr<Reaction> newReaction(const XML_Node& rxn_node);
+
+//! Create a new Reaction object using the specified parameters
+unique_ptr<Reaction> newReaction(const AnyMap& rxn_node,
+                                 const Kinetics& kin);
+}
+#endif

--- a/include/cantera/kinetics/ReactionFactory.h
+++ b/include/cantera/kinetics/ReactionFactory.h
@@ -1,7 +1,7 @@
 /**
  *  @file ReactionFactory.h
- *  Parameterizations for reaction reaction functions. Used by classes
- *  that implement gas-phase kinetics (GasKinetics, GRI_30_Kinetics)
+ *  Factory class for reaction functions. Used by classes
+ *  that implement kinetics
  *  (see \ref reactionGroup and class \link Cantera::Reaction Reaction\endlink).
  */
 
@@ -48,23 +48,6 @@ public:
         delete s_factory;
         s_factory = 0;
     }
-
-    virtual Reaction* newReaction(const std::string& type);
-
-    //! Return a pointer to a new reaction function calculator.
-    /*!
-     * @param type Integer flag specifying the type of reaction function. The
-     *              standard types are defined in file reaction_defs.h. A
-     *              factory class derived from ReactionFactory may define other
-     *              types as well.
-     * @param c    input vector of doubles which populates the reaction
-     *             parameterization.
-     * @returns    a pointer to a new Reaction class.
-     */
-    virtual Reaction* newReaction(const XML_Node& rxn_node);
-
-    virtual Reaction* newReaction(const AnyMap& rxn_node,
-                                  const Kinetics& kin);
 
     void setup_XML(std::string name,
                    Reaction* R, const XML_Node& rxn_node) {
@@ -118,13 +101,23 @@ private:
 };
 
 //! Create a new empty Reaction object
+/*!
+ * @param type string identifying type of reaction.
+ */
 unique_ptr<Reaction> newReaction(const std::string& type);
 
 //! Create a new Reaction object for the reaction defined in `rxn_node`
+/*!
+ * @param rxn_node XML node describing reaction.
+ */
 unique_ptr<Reaction> newReaction(const XML_Node& rxn_node);
 
 //! Create a new Reaction object using the specified parameters
-unique_ptr<Reaction> newReaction(const AnyMap& rxn_node,
+/*!
+ * @param node AnyMap node describing reaction.
+ * @param kin kinetics manager
+ */
+unique_ptr<Reaction> newReaction(const AnyMap& node,
                                  const Kinetics& kin);
 }
 #endif

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -279,6 +279,7 @@ cdef extern from "cantera/thermo/SurfPhase.h":
 
 
 cdef extern from "cantera/kinetics/ReactionFactory.h" namespace "Cantera":
+    cdef shared_ptr[CxxReaction] CxxNewReaction "Cantera::newReaction" (string) except +translate_exception
     cdef shared_ptr[CxxReaction] CxxNewReaction "newReaction" (XML_Node&) except +translate_exception
     cdef shared_ptr[CxxReaction] CxxNewReaction "newReaction" (CxxAnyMap&, CxxKinetics&) except +translate_exception
 
@@ -303,8 +304,8 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         string reactantString()
         string productString()
         string equation()
+        string type()
         void validate() except +translate_exception
-        int reaction_type
         Composition reactants
         Composition products
         Composition orders
@@ -980,7 +981,8 @@ cdef class InterfacePhase(ThermoPhase):
 cdef class Reaction:
     cdef shared_ptr[CxxReaction] _reaction
     cdef CxxReaction* reaction
-    cdef _assign(self, shared_ptr[CxxReaction] other)
+    @staticmethod
+    cdef wrap(shared_ptr[CxxReaction])
 
 cdef class Arrhenius:
     cdef CxxArrhenius* rate
@@ -1153,7 +1155,6 @@ cdef np.ndarray get_transport_1d(Transport tran, transportMethod1d method)
 cdef np.ndarray get_transport_2d(Transport tran, transportMethod2d method)
 cdef CxxIdealGasPhase* getIdealGasPhase(ThermoPhase phase) except *
 cdef wrapSpeciesThermo(shared_ptr[CxxSpeciesThermo] spthermo)
-cdef Reaction wrapReaction(shared_ptr[CxxReaction] reaction)
 
 cdef extern from "cantera/thermo/Elements.h" namespace "Cantera":
     double getElementWeight(string ename) except +translate_exception

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -278,9 +278,11 @@ cdef extern from "cantera/thermo/SurfPhase.h":
         void getCoverages(double*) except +translate_exception
 
 
-cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
+cdef extern from "cantera/kinetics/ReactionFactory.h" namespace "Cantera":
     cdef shared_ptr[CxxReaction] CxxNewReaction "newReaction" (XML_Node&) except +translate_exception
     cdef shared_ptr[CxxReaction] CxxNewReaction "newReaction" (CxxAnyMap&, CxxKinetics&) except +translate_exception
+
+cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef vector[shared_ptr[CxxReaction]] CxxGetReactions "getReactions" (XML_Node&) except +translate_exception
     cdef vector[shared_ptr[CxxReaction]] CxxGetReactions "getReactions" (CxxAnyValue&, CxxKinetics&) except +translate_exception
 

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -105,7 +105,7 @@ cdef class Kinetics(_SolutionBase):
         ``i_reaction``. Changes to this object do not affect the `Kinetics` or
         `Solution` object until the `modify_reaction` function is called.
         """
-        return wrapReaction(self.kinetics.reaction(i_reaction))
+        return Reaction.wrap(self.kinetics.reaction(i_reaction))
 
     def reactions(self):
         """

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1,15 +1,6 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-cdef extern from "cantera/kinetics/reaction_defs.h" namespace "Cantera":
-    cdef int ELEMENTARY_RXN
-    cdef int THREE_BODY_RXN
-    cdef int FALLOFF_RXN
-    cdef int PLOG_RXN
-    cdef int CHEBYSHEV_RXN
-    cdef int CHEMACT_RXN
-    cdef int INTERFACE_RXN
-
 
 cdef class Reaction:
     """
@@ -42,20 +33,45 @@ cdef class Reaction:
         R = ct.Reaction.fromCti('''reaction('O + H2 <=> H + OH',
                         [(3.87e4, 'cm3/mol/s'), 2.7, (6260, 'cal/mol')])''')
     """
-    reaction_type = 0
+    reaction_type = ""
 
     def __cinit__(self, reactants='', products='', init=True, **kwargs):
+
         if init:
-            self._reaction.reset(newReaction(self.reaction_type))
+            self._reaction = CxxNewReaction(stringify((self.reaction_type)))
             self.reaction = self._reaction.get()
             if reactants:
                 self.reactants = reactants
             if products:
                 self.products = products
 
-    cdef _assign(self, shared_ptr[CxxReaction] other):
-        self._reaction = other
-        self.reaction = self._reaction.get()
+    @staticmethod
+    def _all_reaction_objects():
+        """
+        Retrieve all objects derived from Reaction
+        """
+        def all_subclasses(cls):
+            return set(cls.__subclasses__()).union(
+                [s for c in cls.__subclasses__() for s in all_subclasses(c)])
+
+        return {getattr(c, 'reaction_type'): c for c in all_subclasses(Reaction)}
+
+    @staticmethod
+    cdef wrap(shared_ptr[CxxReaction] reaction):
+        """
+        Wrap a C++ Reaction object with a Python object of the correct derived type.
+        """
+        # identify class
+        classes = Reaction._all_reaction_objects()
+        rxn_type = pystr(reaction.get().type())
+        cls = classes.get(rxn_type, Reaction)
+
+        # wrap C++ reaction
+        cdef Reaction R
+        R = cls(init=False)
+        R._reaction = reaction
+        R.reaction = R._reaction.get()
+        return R
 
     @staticmethod
     def fromCti(text):
@@ -64,7 +80,7 @@ cdef class Reaction:
         """
         cxx_reactions = CxxGetReactions(deref(CxxGetXmlFromString(stringify(text))))
         assert cxx_reactions.size() == 1, cxx_reactions.size()
-        return wrapReaction(cxx_reactions[0])
+        return Reaction.wrap(cxx_reactions[0])
 
     @staticmethod
     def fromXml(text):
@@ -72,7 +88,7 @@ cdef class Reaction:
         Create a Reaction object from its XML string representation.
         """
         cxx_reaction = CxxNewReaction(deref(CxxGetXmlFromString(stringify(text))))
-        return wrapReaction(cxx_reaction)
+        return Reaction.wrap(cxx_reaction)
 
     @staticmethod
     def fromYaml(text, Kinetics kinetics):
@@ -87,7 +103,7 @@ cdef class Reaction:
         """
         cxx_reaction = CxxNewReaction(AnyMapFromYamlString(stringify(text)),
                                       deref(kinetics.kinetics))
-        return wrapReaction(cxx_reaction)
+        return Reaction.wrap(cxx_reaction)
 
     @staticmethod
     def listFromFile(filename, Kinetics kinetics=None, section='reactions'):
@@ -113,7 +129,7 @@ cdef class Reaction:
                                             deref(kinetics.kinetics))
         else:
             cxx_reactions = CxxGetReactions(deref(CxxGetXmlFile(stringify(filename))))
-        return [wrapReaction(r) for r in cxx_reactions]
+        return [Reaction.wrap(r) for r in cxx_reactions]
 
     @staticmethod
     def listFromXml(text):
@@ -124,7 +140,7 @@ cdef class Reaction:
         the XML files produced by conversion from CTI files.
         """
         cxx_reactions = CxxGetReactions(deref(CxxGetXmlFromString(stringify(text))))
-        return [wrapReaction(r) for r in cxx_reactions]
+        return [Reaction.wrap(r) for r in cxx_reactions]
 
     @staticmethod
     def listFromCti(text):
@@ -135,7 +151,7 @@ cdef class Reaction:
         # Currently identical to listFromXml since get_XML_from_string is able
         # to distinguish between CTI and XML.
         cxx_reactions = CxxGetReactions(deref(CxxGetXmlFromString(stringify(text))))
-        return [wrapReaction(r) for r in cxx_reactions]
+        return [Reaction.wrap(r) for r in cxx_reactions]
 
     @staticmethod
     def listFromYaml(text, Kinetics kinetics):
@@ -146,7 +162,7 @@ cdef class Reaction:
         root = AnyMapFromYamlString(stringify(text))
         cxx_reactions = CxxGetReactions(root[stringify("items")],
                                         deref(kinetics.kinetics))
-        return [wrapReaction(r) for r in cxx_reactions]
+        return [Reaction.wrap(r) for r in cxx_reactions]
 
     property reactant_string:
         """
@@ -340,7 +356,7 @@ cdef class ElementaryReaction(Reaction):
     A reaction which follows mass-action kinetics with a modified Arrhenius
     reaction rate.
     """
-    reaction_type = ELEMENTARY_RXN
+    reaction_type = "elementary"
 
     property rate:
         """ Get/Set the `Arrhenius` rate coefficient for this reaction. """
@@ -369,7 +385,7 @@ cdef class ThreeBodyReaction(ElementaryReaction):
     A reaction with a non-reacting third body "M" that acts to add or remove
     energy from the reacting species.
     """
-    reaction_type = THREE_BODY_RXN
+    reaction_type = "three-body"
 
     cdef CxxThreeBodyReaction* tbr(self):
         return <CxxThreeBodyReaction*>self.reaction
@@ -498,7 +514,7 @@ cdef class FalloffReaction(Reaction):
     A reaction that is first-order in [M] at low pressure, like a third-body
     reaction, but zeroth-order in [M] as pressure increases.
     """
-    reaction_type = FALLOFF_RXN
+    reaction_type = "falloff"
 
     cdef CxxFalloffReaction* frxn(self):
         return <CxxFalloffReaction*>self.reaction
@@ -563,7 +579,7 @@ cdef class ChemicallyActivatedReaction(FalloffReaction):
     that the forward rate constant is written as being proportional to the low-
     pressure rate constant.
     """
-    reaction_type = CHEMACT_RXN
+    reaction_type = "chemically-activated"
 
 
 cdef class PlogReaction(Reaction):
@@ -571,7 +587,7 @@ cdef class PlogReaction(Reaction):
     A pressure-dependent reaction parameterized by logarithmically interpolating
     between Arrhenius rate expressions at various pressures.
     """
-    reaction_type = PLOG_RXN
+    reaction_type = "pressure-dependent-Arrhenius"
 
     property rates:
         """
@@ -614,7 +630,7 @@ cdef class ChebyshevReaction(Reaction):
     A pressure-dependent reaction parameterized by a bivariate Chebyshev
     polynomial in temperature and pressure.
     """
-    reaction_type = CHEBYSHEV_RXN
+    reaction_type = "Chebyshev"
 
     property Tmin:
         """ Minimum temperature [K] for the Chebyshev fit """
@@ -691,7 +707,7 @@ cdef class ChebyshevReaction(Reaction):
 
 cdef class InterfaceReaction(ElementaryReaction):
     """ A reaction occurring on an `Interface` (i.e. a surface or an edge) """
-    reaction_type = INTERFACE_RXN
+    reaction_type = "interface"
 
     property coverage_deps:
         """
@@ -757,51 +773,3 @@ cdef class InterfaceReaction(ElementaryReaction):
         def __set__(self, species):
             cdef CxxInterfaceReaction* r = <CxxInterfaceReaction*>self.reaction
             r.sticking_species = stringify(species)
-
-
-cdef Reaction wrapReaction(shared_ptr[CxxReaction] reaction):
-    """
-    Wrap a C++ Reaction object with a Python object of the correct derived type.
-    """
-    cdef int reaction_type = reaction.get().reaction_type
-
-    if reaction_type == ELEMENTARY_RXN:
-        R = ElementaryReaction(init=False)
-    elif reaction_type == THREE_BODY_RXN:
-        R = ThreeBodyReaction(init=False)
-    elif reaction_type == FALLOFF_RXN:
-        R = FalloffReaction(init=False)
-    elif reaction_type == CHEMACT_RXN:
-        R = ChemicallyActivatedReaction(init=False)
-    elif reaction_type == PLOG_RXN:
-        R = PlogReaction(init=False)
-    elif reaction_type == CHEBYSHEV_RXN:
-        R = ChebyshevReaction(init=False)
-    elif reaction_type == INTERFACE_RXN:
-        R = InterfaceReaction(init=False)
-    else:
-        R = Reaction(init=False)
-
-    R._assign(reaction)
-    return R
-
-cdef CxxReaction* newReaction(int reaction_type):
-    """
-    Create a new C++ Reaction object of the specified type
-    """
-    if reaction_type == ELEMENTARY_RXN:
-        return new CxxElementaryReaction()
-    elif reaction_type == THREE_BODY_RXN:
-        return new CxxThreeBodyReaction()
-    elif reaction_type == FALLOFF_RXN:
-        return new CxxFalloffReaction()
-    elif reaction_type == CHEMACT_RXN:
-        return new CxxChemicallyActivatedReaction()
-    elif reaction_type == PLOG_RXN:
-        return new CxxPlogReaction()
-    elif reaction_type == CHEBYSHEV_RXN:
-        return new CxxChebyshevReaction()
-    elif reaction_type == INTERFACE_RXN:
-        return new CxxInterfaceReaction()
-    else:
-        return new CxxReaction(0)

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -10,6 +10,7 @@
 #include "cantera/kinetics/InterfaceKinetics.h"
 #include "cantera/kinetics/EdgeKinetics.h"
 #include "cantera/kinetics/importKinetics.h"
+#include "cantera/kinetics/ReactionFactory.h"
 #include "cantera/base/xml.h"
 
 using namespace std;

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -6,6 +6,7 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/kinetics/Reaction.h"
+#include "cantera/kinetics/ReactionFactory.h"
 #include "cantera/kinetics/FalloffFactory.h"
 #include "cantera/kinetics/Kinetics.h"
 #include "cantera/base/ctml.h"
@@ -20,6 +21,31 @@ namespace ba = boost::algorithm;
 
 namespace Cantera
 {
+
+// forward declarations
+void setupElementaryReaction(ElementaryReaction&, const XML_Node&);
+void setupElementaryReaction(ElementaryReaction&, const AnyMap&,
+                             const Kinetics&);
+void setupThreeBodyReaction(ThreeBodyReaction&, const XML_Node&);
+void setupThreeBodyReaction(ThreeBodyReaction&, const AnyMap&,
+                            const Kinetics&);
+void setupFalloffReaction(FalloffReaction&, const XML_Node&);
+void setupFalloffReaction(FalloffReaction&, const AnyMap&,
+                          const Kinetics&);
+void setupChemicallyActivatedReaction(ChemicallyActivatedReaction&,
+                                      const XML_Node&);
+void setupPlogReaction(PlogReaction&, const XML_Node&);
+void setupPlogReaction(PlogReaction&, const AnyMap&, const Kinetics&);
+void setupChebyshevReaction(ChebyshevReaction&, const XML_Node&);
+void setupChebyshevReaction(ChebyshevReaction&, const AnyMap&,
+                            const Kinetics&);
+void setupInterfaceReaction(InterfaceReaction&, const XML_Node&);
+void setupInterfaceReaction(InterfaceReaction&, const AnyMap&,
+                            const Kinetics&);
+void setupElectrochemicalReaction(ElectrochemicalReaction&,
+                                  const XML_Node&);
+void setupElectrochemicalReaction(ElectrochemicalReaction&,
+                                  const AnyMap&, const Kinetics&);
 
 Reaction::Reaction(int type)
     : reaction_type(type)
@@ -128,6 +154,14 @@ void ElementaryReaction::validate()
     }
 }
 
+void ElementaryReaction::setup(const XML_Node& rxn_node) {
+    setupElementaryReaction(*this, rxn_node);
+}
+
+void ElementaryReaction::setup(const AnyMap& node, const Kinetics& kin) {
+    setupElementaryReaction(*this, node, kin);
+}
+
 ThirdBody::ThirdBody(double default_eff)
     : default_efficiency(default_eff)
 {
@@ -146,6 +180,14 @@ ThreeBodyReaction::ThreeBodyReaction(const Composition& reactants_,
     , third_body(tbody)
 {
     reaction_type = THREE_BODY_RXN;
+}
+
+void ThreeBodyReaction::setup(const XML_Node& rxn_node) {
+    setupThreeBodyReaction(*this, rxn_node);
+}
+
+void ThreeBodyReaction::setup(const AnyMap& node, const Kinetics& kin) {
+    setupThreeBodyReaction(*this, node, kin);
 }
 
 std::string ThreeBodyReaction::reactantString() const {
@@ -172,6 +214,14 @@ FalloffReaction::FalloffReaction(
     , third_body(tbody)
     , falloff(new Falloff())
 {
+}
+
+void FalloffReaction::setup(const XML_Node& rxn_node) {
+    setupFalloffReaction(*this, rxn_node);
+}
+
+void FalloffReaction::setup(const AnyMap& node, const Kinetics& kin) {
+    setupFalloffReaction(*this, node, kin);
 }
 
 std::string FalloffReaction::reactantString() const {
@@ -217,6 +267,10 @@ ChemicallyActivatedReaction::ChemicallyActivatedReaction(
     reaction_type = CHEMACT_RXN;
 }
 
+void ChemicallyActivatedReaction::setup(const XML_Node& rxn_node) {
+    setupChemicallyActivatedReaction(*this, rxn_node);
+}
+
 PlogReaction::PlogReaction()
     : Reaction(PLOG_RXN)
 {
@@ -227,6 +281,14 @@ PlogReaction::PlogReaction(const Composition& reactants_,
     : Reaction(PLOG_RXN, reactants_, products_)
     , rate(rate_)
 {
+}
+
+void PlogReaction::setup(const XML_Node& rxn_node) {
+    setupPlogReaction(*this, rxn_node);
+}
+
+void PlogReaction::setup(const AnyMap& node, const Kinetics& kin) {
+    setupPlogReaction(*this, node, kin);
 }
 
 ChebyshevReaction::ChebyshevReaction()
@@ -240,6 +302,14 @@ ChebyshevReaction::ChebyshevReaction(const Composition& reactants_,
     : Reaction(CHEBYSHEV_RXN, reactants_, products_)
     , rate(rate_)
 {
+}
+
+void ChebyshevReaction::setup(const XML_Node& rxn_node) {
+    setupChebyshevReaction(*this, rxn_node);
+}
+
+void ChebyshevReaction::setup(const AnyMap& node, const Kinetics& kin) {
+    setupChebyshevReaction(*this, node, kin);
 }
 
 InterfaceReaction::InterfaceReaction()
@@ -260,6 +330,14 @@ InterfaceReaction::InterfaceReaction(const Composition& reactants_,
     reaction_type = INTERFACE_RXN;
 }
 
+void InterfaceReaction::setup(const XML_Node& rxn_node) {
+    setupInterfaceReaction(*this, rxn_node);
+}
+
+void InterfaceReaction::setup(const AnyMap& node, const Kinetics& kin) {
+    setupInterfaceReaction(*this, node, kin);
+}
+
 ElectrochemicalReaction::ElectrochemicalReaction()
     : film_resistivity(0.0)
     , beta(0.5)
@@ -275,6 +353,14 @@ ElectrochemicalReaction::ElectrochemicalReaction(const Composition& reactants_,
     , beta(0.5)
     , exchange_current_density_formulation(false)
 {
+}
+
+void ElectrochemicalReaction::setup(const XML_Node& rxn_node) {
+    setupElectrochemicalReaction(*this, rxn_node);
+}
+
+void ElectrochemicalReaction::setup(const AnyMap& node, const Kinetics& kin) {
+    setupElectrochemicalReaction(*this, node, kin);
 }
 
 Arrhenius readArrhenius(const XML_Node& arrhenius_node)
@@ -994,112 +1080,6 @@ bool isElectrochemicalReaction(Reaction& R, const Kinetics& kin)
         }
     }
     return false;
-}
-
-shared_ptr<Reaction> newReaction(const XML_Node& rxn_node)
-{
-    std::string type = toLowerCopy(rxn_node["type"]);
-
-    // Modify the reaction type for interface reactions which contain
-    // electrochemical reaction data
-    if (rxn_node.child("rateCoeff").hasChild("electrochem")
-        && (type == "edge" || type == "surface")) {
-        type = "electrochemical";
-    }
-
-    // Create a new Reaction object of the appropriate type
-    if (type == "elementary" || type == "arrhenius" || type == "") {
-        auto R = make_shared<ElementaryReaction>();
-        setupElementaryReaction(*R, rxn_node);
-        return R;
-    } else if (type == "threebody" || type == "three_body") {
-        auto R = make_shared<ThreeBodyReaction>();
-        setupThreeBodyReaction(*R, rxn_node);
-        return R;
-    } else if (type == "falloff") {
-        auto R = make_shared<FalloffReaction>();
-        setupFalloffReaction(*R, rxn_node);
-        return R;
-    } else if (type == "chemact" || type == "chemically_activated") {
-        auto R = make_shared<ChemicallyActivatedReaction>();
-        setupChemicallyActivatedReaction(*R, rxn_node);
-        return R;
-    } else if (type == "plog" || type == "pdep_arrhenius") {
-        auto R = make_shared<PlogReaction>();
-        setupPlogReaction(*R, rxn_node);
-        return R;
-    } else if (type == "chebyshev") {
-        auto R = make_shared<ChebyshevReaction>();
-        setupChebyshevReaction(*R, rxn_node);
-        return R;
-    } else if (type == "interface" || type == "surface" || type == "edge" ||
-               type == "global") {
-        auto R = make_shared<InterfaceReaction>();
-        setupInterfaceReaction(*R, rxn_node);
-        return R;
-    } else if (type == "electrochemical" ||
-               type == "butlervolmer_noactivitycoeffs" ||
-               type == "butlervolmer" ||
-               type == "surfaceaffinity") {
-        auto R = make_shared<ElectrochemicalReaction>();
-        setupElectrochemicalReaction(*R, rxn_node);
-        return R;
-    } else {
-        throw CanteraError("newReaction",
-            "Unknown reaction type '" + rxn_node["type"] + "'");
-    }
-}
-
-unique_ptr<Reaction> newReaction(const AnyMap& node, const Kinetics& kin)
-{
-    std::string type = "elementary";
-    if (node.hasKey("type")) {
-        type = node["type"].asString();
-    }
-
-    if (kin.thermo(kin.reactionPhaseIndex()).nDim() < 3) {
-        // See if this is an electrochemical reaction
-        Reaction testReaction(0);
-        parseReactionEquation(testReaction, node["equation"], kin);
-        if (isElectrochemicalReaction(testReaction, kin)) {
-            unique_ptr<ElectrochemicalReaction> R(new ElectrochemicalReaction());
-            setupElectrochemicalReaction(*R, node, kin);
-            return unique_ptr<Reaction>(move(R));
-        } else {
-            unique_ptr<InterfaceReaction> R(new InterfaceReaction());
-            setupInterfaceReaction(*R, node, kin);
-            return unique_ptr<Reaction>(move(R));
-        }
-    }
-
-    if (type == "elementary") {
-        unique_ptr<ElementaryReaction> R(new ElementaryReaction());
-        setupElementaryReaction(*R, node, kin);
-        return unique_ptr<Reaction>(move(R));
-    } else if (type == "three-body") {
-        unique_ptr<ThreeBodyReaction> R(new ThreeBodyReaction());
-        setupThreeBodyReaction(*R, node, kin);
-        return unique_ptr<Reaction>(move(R));
-    } else if (type == "falloff") {
-        unique_ptr<FalloffReaction> R(new FalloffReaction());
-        setupFalloffReaction(*R, node, kin);
-        return unique_ptr<Reaction>(move(R));
-    } else if (type == "chemically-activated") {
-        unique_ptr<ChemicallyActivatedReaction> R(new ChemicallyActivatedReaction());
-        setupFalloffReaction(*R, node, kin);
-        return unique_ptr<Reaction>(move(R));
-    } else if (type == "pressure-dependent-Arrhenius") {
-        unique_ptr<PlogReaction> R(new PlogReaction());
-        setupPlogReaction(*R, node, kin);
-        return unique_ptr<Reaction>(move(R));
-    } else if (type == "Chebyshev") {
-        unique_ptr<ChebyshevReaction> R(new ChebyshevReaction());
-        setupChebyshevReaction(*R, node, kin);
-        return unique_ptr<Reaction>(move(R));
-    } else {
-        throw InputFileError("newReaction", node["type"],
-            "Unknown reaction type '{}'", type);
-    }
 }
 
 std::vector<shared_ptr<Reaction> > getReactions(const XML_Node& node)

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -22,30 +22,6 @@ namespace ba = boost::algorithm;
 namespace Cantera
 {
 
-// forward declarations
-void setupElementaryReaction(ElementaryReaction&, const XML_Node&);
-void setupElementaryReaction(ElementaryReaction&, const AnyMap&,
-                             const Kinetics&);
-void setupThreeBodyReaction(ThreeBodyReaction&, const XML_Node&);
-void setupThreeBodyReaction(ThreeBodyReaction&, const AnyMap&,
-                            const Kinetics&);
-void setupFalloffReaction(FalloffReaction&, const XML_Node&);
-void setupFalloffReaction(FalloffReaction&, const AnyMap&,
-                          const Kinetics&);
-void setupChemicallyActivatedReaction(ChemicallyActivatedReaction&,
-                                      const XML_Node&);
-void setupPlogReaction(PlogReaction&, const XML_Node&);
-void setupPlogReaction(PlogReaction&, const AnyMap&, const Kinetics&);
-void setupChebyshevReaction(ChebyshevReaction&, const XML_Node&);
-void setupChebyshevReaction(ChebyshevReaction&, const AnyMap&,
-                            const Kinetics&);
-void setupInterfaceReaction(InterfaceReaction&, const XML_Node&);
-void setupInterfaceReaction(InterfaceReaction&, const AnyMap&,
-                            const Kinetics&);
-void setupElectrochemicalReaction(ElectrochemicalReaction&,
-                                  const XML_Node&);
-void setupElectrochemicalReaction(ElectrochemicalReaction&,
-                                  const AnyMap&, const Kinetics&);
 
 Reaction::Reaction(int type)
     : reaction_type(type)
@@ -154,14 +130,6 @@ void ElementaryReaction::validate()
     }
 }
 
-void ElementaryReaction::setup(const XML_Node& rxn_node) {
-    setupElementaryReaction(*this, rxn_node);
-}
-
-void ElementaryReaction::setup(const AnyMap& node, const Kinetics& kin) {
-    setupElementaryReaction(*this, node, kin);
-}
-
 ThirdBody::ThirdBody(double default_eff)
     : default_efficiency(default_eff)
 {
@@ -180,14 +148,6 @@ ThreeBodyReaction::ThreeBodyReaction(const Composition& reactants_,
     , third_body(tbody)
 {
     reaction_type = THREE_BODY_RXN;
-}
-
-void ThreeBodyReaction::setup(const XML_Node& rxn_node) {
-    setupThreeBodyReaction(*this, rxn_node);
-}
-
-void ThreeBodyReaction::setup(const AnyMap& node, const Kinetics& kin) {
-    setupThreeBodyReaction(*this, node, kin);
 }
 
 std::string ThreeBodyReaction::reactantString() const {
@@ -214,14 +174,6 @@ FalloffReaction::FalloffReaction(
     , third_body(tbody)
     , falloff(new Falloff())
 {
-}
-
-void FalloffReaction::setup(const XML_Node& rxn_node) {
-    setupFalloffReaction(*this, rxn_node);
-}
-
-void FalloffReaction::setup(const AnyMap& node, const Kinetics& kin) {
-    setupFalloffReaction(*this, node, kin);
 }
 
 std::string FalloffReaction::reactantString() const {
@@ -267,10 +219,6 @@ ChemicallyActivatedReaction::ChemicallyActivatedReaction(
     reaction_type = CHEMACT_RXN;
 }
 
-void ChemicallyActivatedReaction::setup(const XML_Node& rxn_node) {
-    setupChemicallyActivatedReaction(*this, rxn_node);
-}
-
 PlogReaction::PlogReaction()
     : Reaction(PLOG_RXN)
 {
@@ -281,14 +229,6 @@ PlogReaction::PlogReaction(const Composition& reactants_,
     : Reaction(PLOG_RXN, reactants_, products_)
     , rate(rate_)
 {
-}
-
-void PlogReaction::setup(const XML_Node& rxn_node) {
-    setupPlogReaction(*this, rxn_node);
-}
-
-void PlogReaction::setup(const AnyMap& node, const Kinetics& kin) {
-    setupPlogReaction(*this, node, kin);
 }
 
 ChebyshevReaction::ChebyshevReaction()
@@ -302,14 +242,6 @@ ChebyshevReaction::ChebyshevReaction(const Composition& reactants_,
     : Reaction(CHEBYSHEV_RXN, reactants_, products_)
     , rate(rate_)
 {
-}
-
-void ChebyshevReaction::setup(const XML_Node& rxn_node) {
-    setupChebyshevReaction(*this, rxn_node);
-}
-
-void ChebyshevReaction::setup(const AnyMap& node, const Kinetics& kin) {
-    setupChebyshevReaction(*this, node, kin);
 }
 
 InterfaceReaction::InterfaceReaction()
@@ -330,14 +262,6 @@ InterfaceReaction::InterfaceReaction(const Composition& reactants_,
     reaction_type = INTERFACE_RXN;
 }
 
-void InterfaceReaction::setup(const XML_Node& rxn_node) {
-    setupInterfaceReaction(*this, rxn_node);
-}
-
-void InterfaceReaction::setup(const AnyMap& node, const Kinetics& kin) {
-    setupInterfaceReaction(*this, node, kin);
-}
-
 ElectrochemicalReaction::ElectrochemicalReaction()
     : film_resistivity(0.0)
     , beta(0.5)
@@ -353,14 +277,6 @@ ElectrochemicalReaction::ElectrochemicalReaction(const Composition& reactants_,
     , beta(0.5)
     , exchange_current_density_formulation(false)
 {
-}
-
-void ElectrochemicalReaction::setup(const XML_Node& rxn_node) {
-    setupElectrochemicalReaction(*this, rxn_node);
-}
-
-void ElectrochemicalReaction::setup(const AnyMap& node, const Kinetics& kin) {
-    setupElectrochemicalReaction(*this, node, kin);
 }
 
 Arrhenius readArrhenius(const XML_Node& arrhenius_node)

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -22,7 +22,6 @@ namespace ba = boost::algorithm;
 namespace Cantera
 {
 
-
 Reaction::Reaction(int type)
     : reaction_type(type)
     , reversible(true)

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -968,35 +968,6 @@ void setupElectrochemicalReaction(ElectrochemicalReaction& R,
         "exchange-current-density-formulation", false);
 }
 
-bool isElectrochemicalReaction(Reaction& R, const Kinetics& kin)
-{
-    vector_fp e_counter(kin.nPhases(), 0.0);
-
-    // Find the number of electrons in the products for each phase
-    for (const auto& sp : R.products) {
-        size_t kkin = kin.kineticsSpeciesIndex(sp.first);
-        size_t i = kin.speciesPhaseIndex(kkin);
-        size_t kphase = kin.thermo(i).speciesIndex(sp.first);
-        e_counter[i] += sp.second * kin.thermo(i).charge(kphase);
-    }
-
-    // Subtract the number of electrons in the reactants for each phase
-    for (const auto& sp : R.reactants) {
-        size_t kkin = kin.kineticsSpeciesIndex(sp.first);
-        size_t i = kin.speciesPhaseIndex(kkin);
-        size_t kphase = kin.thermo(i).speciesIndex(sp.first);
-        e_counter[i] -= sp.second * kin.thermo(i).charge(kphase);
-    }
-
-    // If the electrons change phases then the reaction is electrochemical
-    for (double delta_e : e_counter) {
-        if (std::abs(delta_e) > 1e-4) {
-            return true;
-        }
-    }
-    return false;
-}
-
 std::vector<shared_ptr<Reaction> > getReactions(const XML_Node& node)
 {
     std::vector<shared_ptr<Reaction> > all_reactions;

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -1,0 +1,111 @@
+/**
+ *  @file ReactionFactory.cpp
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/kinetics/Reaction.h"
+#include "cantera/kinetics/ReactionFactory.h"
+#include "cantera/kinetics/Kinetics.h"
+#include "cantera/base/ctml.h"
+#include "cantera/base/AnyMap.h"
+
+namespace Cantera
+{
+
+ReactionFactory* ReactionFactory::s_factory = 0;
+std::mutex ReactionFactory::reaction_mutex;
+
+ReactionFactory::ReactionFactory()
+{
+    reg("elementary", []() { return new ElementaryReaction(); });
+    m_synonyms["arrhenius"] = "elementary";
+    m_synonyms[""] = "elementary";
+    reg("three-body", []() { return new ThreeBodyReaction(); });
+    m_synonyms["threebody"] = "three-body";
+    m_synonyms["three_body"] = "three-body";
+    reg("falloff", []() { return new FalloffReaction(); });
+    reg("chemically-activated", []() { return new ChemicallyActivatedReaction(); });
+    m_synonyms["chemact"] = "chemically-activated";
+    m_synonyms["chemically_activated"] = "chemically-activated";
+    reg("pressure-dependent-arrhenius", []() { return new PlogReaction(); });
+    m_synonyms["plog"] = "pressure-dependent-arrhenius";
+    m_synonyms["pdep_arrhenius"] = "pressure-dependent-arrhenius";
+    reg("chebyshev", []() { return new ChebyshevReaction(); });
+    reg("interface", []() { return new InterfaceReaction(); });
+    m_synonyms["surface"] = "interface";
+    m_synonyms["edge"] = "interface";
+    m_synonyms["global"] = "interface";
+    reg("electrochemical", []() { return new ElectrochemicalReaction(); });
+    m_synonyms["butlervolmer_noactivitycoeffs"] = "electrochemical";
+    m_synonyms["butlervolmer"] = "electrochemical";
+    m_synonyms["surfaceaffinity"] = "electrochemical";
+}
+
+Reaction* ReactionFactory::newReaction(const XML_Node& rxn_node)
+{
+    std::string type = toLowerCopy(rxn_node["type"]);
+
+    // Modify the reaction type for interface reactions which contain
+    // electrochemical reaction data
+    if (rxn_node.child("rateCoeff").hasChild("electrochem")
+        && (type == "edge" || type == "surface")) {
+        type = "electrochemical";
+    }
+
+    Reaction* R;
+    try {
+        R = create(type);
+    } catch (CanteraError& err) {
+        throw CanteraError("newReaction",
+            "Unknown reaction type '" + rxn_node["type"] + "'");
+    }
+    R->setup(rxn_node);
+    return R;
+}
+
+Reaction* ReactionFactory::newReaction(const AnyMap& node,
+                                       const Kinetics& kin)
+{
+    std::string type = "elementary";
+    if (node.hasKey("type")) {
+        type = toLowerCopy(node["type"].asString());
+    }
+
+    if (kin.thermo().nDim() < 3) {
+        // See if this is an electrochemical reaction
+        Reaction testReaction(0);
+        parseReactionEquation(testReaction, node["equation"], kin);
+        if (isElectrochemicalReaction(testReaction, kin)) {
+            type = "electrochemical";
+        } else {
+            type = "interface";
+        }
+    }
+
+    Reaction* R;
+    try {
+        R = create(type);
+    } catch (CanteraError& err) {
+        throw InputFileError("newReaction", node["type"],
+            "Unknown reaction type '{}'", type);
+    }
+    R->setup(node, kin);
+    return R;
+}
+
+unique_ptr<Reaction> newReaction(const XML_Node& rxn_node)
+{
+    unique_ptr<Reaction> R(ReactionFactory::factory()->newReaction(rxn_node));
+    return R;
+}
+
+unique_ptr<Reaction> newReaction(const AnyMap& rxn_node,
+                                 const Kinetics& kin)
+{
+    unique_ptr<Reaction> R(ReactionFactory::factory()->newReaction(rxn_node, kin));
+    return R;
+}
+
+}

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -21,8 +21,8 @@ ReactionFactory::ReactionFactory()
 {
     // register elementary reactions
     reg("elementary", []() { return new ElementaryReaction(); });
-    m_synonyms["arrhenius"] = "elementary";
-    m_synonyms[""] = "elementary";
+    addAlias("elementary", "arrhenius");
+    addAlias("elementary", "");
     reg_XML("elementary",
             [](Reaction* R, const XML_Node& node) {
                 setupElementaryReaction(*(ElementaryReaction*)R, node);
@@ -34,8 +34,8 @@ ReactionFactory::ReactionFactory()
 
     // register three-body reactions
     reg("three-body", []() { return new ThreeBodyReaction(); });
-    m_synonyms["threebody"] = "three-body";
-    m_synonyms["three_body"] = "three-body";
+    addAlias("three-body", "threebody");
+    addAlias("three-body", "three_body");
     reg_XML("three-body",
             [](Reaction* R, const XML_Node& node) {
                 setupThreeBodyReaction(*(ThreeBodyReaction*)R, node);
@@ -58,8 +58,8 @@ ReactionFactory::ReactionFactory()
 
     // register falloff reactions
     reg("chemically-activated", []() { return new ChemicallyActivatedReaction(); });
-    m_synonyms["chemact"] = "chemically-activated";
-    m_synonyms["chemically_activated"] = "chemically-activated";
+    addAlias("chemically-activated", "chemact");
+    addAlias("chemically-activated", "chemically_activated");
     reg_XML("chemically-activated",
             [](Reaction* R, const XML_Node& node) {
                 setupChemicallyActivatedReaction(*(ChemicallyActivatedReaction*)R, node);
@@ -71,8 +71,8 @@ ReactionFactory::ReactionFactory()
 
     // register pressure-depdendent-Arrhenius reactions
     reg("pressure-dependent-Arrhenius", []() { return new PlogReaction(); });
-    m_synonyms["plog"] = "pressure-dependent-Arrhenius";
-    m_synonyms["pdep_arrhenius"] = "pressure-dependent-Arrhenius";
+    addAlias("pressure-dependent-Arrhenius", "plog");
+    addAlias("pressure-dependent-Arrhenius", "pdep_arrhenius");
     reg_XML("pressure-dependent-Arrhenius",
             [](Reaction* R, const XML_Node& node) {
                 setupPlogReaction(*(PlogReaction*)R, node);
@@ -84,7 +84,7 @@ ReactionFactory::ReactionFactory()
 
     // register Chebyshev reactions
     reg("Chebyshev", []() { return new ChebyshevReaction(); });
-    m_synonyms["chebyshev"] = "Chebyshev";
+    addAlias("Chebyshev", "chebyshev");
     reg_XML("Chebyshev",
             [](Reaction* R, const XML_Node& node) {
                 setupChebyshevReaction(*(ChebyshevReaction*)R, node);
@@ -96,9 +96,9 @@ ReactionFactory::ReactionFactory()
 
     // register interface reactions
     reg("interface", []() { return new InterfaceReaction(); });
-    m_synonyms["surface"] = "interface";
-    m_synonyms["edge"] = "interface";
-    m_synonyms["global"] = "interface";
+    addAlias("interface", "surface");
+    addAlias("interface", "edge");
+    addAlias("interface", "global");
     reg_XML("interface",
             [](Reaction* R, const XML_Node& node) {
                 setupInterfaceReaction(*(InterfaceReaction*)R, node);
@@ -110,9 +110,9 @@ ReactionFactory::ReactionFactory()
 
     // register electrochemical reactions
     reg("electrochemical", []() { return new ElectrochemicalReaction(); });
-    m_synonyms["butlervolmer_noactivitycoeffs"] = "electrochemical";
-    m_synonyms["butlervolmer"] = "electrochemical";
-    m_synonyms["surfaceaffinity"] = "electrochemical";
+    addAlias("electrochemical", "butlervolmer_noactivitycoeffs");
+    addAlias("electrochemical", "butlervolmer");
+    addAlias("electrochemical", "surfaceaffinity");
     reg_XML("electrochemical",
             [](Reaction* R, const XML_Node& node) {
                 setupElectrochemicalReaction(*(ElectrochemicalReaction*)R, node);

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -19,28 +19,132 @@ std::mutex ReactionFactory::reaction_mutex;
 
 ReactionFactory::ReactionFactory()
 {
+    // register elementary reactions
     reg("elementary", []() { return new ElementaryReaction(); });
     m_synonyms["arrhenius"] = "elementary";
     m_synonyms[""] = "elementary";
+    void setupElementaryReaction(ElementaryReaction&, const XML_Node&);
+    reg_XML("elementary",
+            [](Reaction* R, const XML_Node& node) {
+                setupElementaryReaction(*(ElementaryReaction*)R, node);
+            });
+    void setupElementaryReaction(ElementaryReaction&, const AnyMap&,
+                                 const Kinetics&);
+    reg_AnyMap("elementary",
+               [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
+                   setupElementaryReaction(*(ElementaryReaction*)R, node, kin);
+               });
+
+    // register three-body reactions
     reg("three-body", []() { return new ThreeBodyReaction(); });
     m_synonyms["threebody"] = "three-body";
     m_synonyms["three_body"] = "three-body";
+    void setupThreeBodyReaction(ThreeBodyReaction&, const XML_Node&);
+    reg_XML("three-body",
+            [](Reaction* R, const XML_Node& node) {
+                setupThreeBodyReaction(*(ThreeBodyReaction*)R, node);
+            });
+    void setupThreeBodyReaction(ThreeBodyReaction&, const AnyMap&,
+                                const Kinetics&);
+    reg_AnyMap("three-body",
+               [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
+                   setupThreeBodyReaction(*(ThreeBodyReaction*)R, node, kin);
+               });
+
+    // register falloff reactions
     reg("falloff", []() { return new FalloffReaction(); });
+    void setupFalloffReaction(FalloffReaction&, const XML_Node&);
+    reg_XML("falloff",
+            [](Reaction* R, const XML_Node& node) {
+                setupFalloffReaction(*(FalloffReaction*)R, node);
+            });
+    void setupFalloffReaction(FalloffReaction&, const AnyMap&,
+                              const Kinetics&);
+    reg_AnyMap("falloff",
+               [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
+                   setupFalloffReaction(*(FalloffReaction*)R, node, kin);
+               });
+
+    // register falloff reactions
     reg("chemically-activated", []() { return new ChemicallyActivatedReaction(); });
     m_synonyms["chemact"] = "chemically-activated";
     m_synonyms["chemically_activated"] = "chemically-activated";
-    reg("pressure-dependent-arrhenius", []() { return new PlogReaction(); });
-    m_synonyms["plog"] = "pressure-dependent-arrhenius";
-    m_synonyms["pdep_arrhenius"] = "pressure-dependent-arrhenius";
-    reg("chebyshev", []() { return new ChebyshevReaction(); });
+    void setupChemicallyActivatedReaction(ChemicallyActivatedReaction&,
+                                          const XML_Node&);
+    reg_XML("chemically-activated",
+            [](Reaction* R, const XML_Node& node) {
+                setupChemicallyActivatedReaction(*(ChemicallyActivatedReaction*)R, node);
+            });
+    reg_AnyMap("chemically-activated",
+               [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
+                   setupFalloffReaction(*(FalloffReaction*)R, node, kin);
+               });
+
+    // register pressure-depdendent-Arrhenius reactions
+    reg("pressure-dependent-Arrhenius", []() { return new PlogReaction(); });
+    m_synonyms["pressure-dependent-arrhenius"] = "pressure-dependent-Arrhenius";
+    m_synonyms["plog"] = "pressure-dependent-Arrhenius";
+    m_synonyms["pdep_arrhenius"] = "pressure-dependent-Arrhenius";
+    void setupPlogReaction(PlogReaction&, const XML_Node&);
+    reg_XML("pressure-dependent-Arrhenius",
+            [](Reaction* R, const XML_Node& node) {
+                setupPlogReaction(*(PlogReaction*)R, node);
+            });
+    void setupPlogReaction(PlogReaction&, const AnyMap&, const Kinetics&);
+    reg_AnyMap("pressure-dependent-Arrhenius",
+               [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
+                   setupPlogReaction(*(PlogReaction*)R, node, kin);
+               });
+
+    // register Chebyshev reactions
+    reg("Chebyshev", []() { return new ChebyshevReaction(); });
+    m_synonyms["chebyshev"] = "Chebyshev";
+    void setupChebyshevReaction(ChebyshevReaction&, const XML_Node&);
+    reg_XML("Chebyshev",
+            [](Reaction* R, const XML_Node& node) {
+                setupChebyshevReaction(*(ChebyshevReaction*)R, node);
+            });
+    void setupChebyshevReaction(ChebyshevReaction&, const AnyMap&,
+                                const Kinetics&);
+    reg_AnyMap("Chebyshev",
+               [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
+                   setupChebyshevReaction(*(ChebyshevReaction*)R, node, kin);
+               });
+
+    // register interface reactions
     reg("interface", []() { return new InterfaceReaction(); });
     m_synonyms["surface"] = "interface";
     m_synonyms["edge"] = "interface";
     m_synonyms["global"] = "interface";
+    void setupInterfaceReaction(InterfaceReaction&, const XML_Node&);
+    reg_XML("interface",
+            [](Reaction* R, const XML_Node& node) {
+                setupInterfaceReaction(*(InterfaceReaction*)R, node);
+            });
+    void setupInterfaceReaction(InterfaceReaction&, const AnyMap&,
+                                const Kinetics&);
+    reg_AnyMap("interface",
+               [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
+                   setupInterfaceReaction(*(InterfaceReaction*)R, node, kin);
+               });
+
+    // register electrochemical reactions
     reg("electrochemical", []() { return new ElectrochemicalReaction(); });
     m_synonyms["butlervolmer_noactivitycoeffs"] = "electrochemical";
     m_synonyms["butlervolmer"] = "electrochemical";
     m_synonyms["surfaceaffinity"] = "electrochemical";
+    void setupElectrochemicalReaction(ElectrochemicalReaction&,
+                                      const XML_Node&);
+    reg_XML("electrochemical",
+            [](Reaction* R, const XML_Node& node) {
+                setupElectrochemicalReaction(*(ElectrochemicalReaction*)R, node);
+            });
+    void setupElectrochemicalReaction(ElectrochemicalReaction&,
+                                      const AnyMap&, const Kinetics&);
+    reg_AnyMap("electrochemical",
+               [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
+                   setupElectrochemicalReaction(*(ElectrochemicalReaction*)R, node, kin);
+               });
 }
 
 Reaction* ReactionFactory::newReaction(const XML_Node& rxn_node)
@@ -61,7 +165,7 @@ Reaction* ReactionFactory::newReaction(const XML_Node& rxn_node)
         throw CanteraError("newReaction",
             "Unknown reaction type '" + rxn_node["type"] + "'");
     }
-    R->setup(rxn_node);
+    setup_XML(R->type(), R, rxn_node);
     return R;
 }
 
@@ -70,7 +174,7 @@ Reaction* ReactionFactory::newReaction(const AnyMap& node,
 {
     std::string type = "elementary";
     if (node.hasKey("type")) {
-        type = toLowerCopy(node["type"].asString());
+        type = node["type"].asString();
     }
 
     if (kin.thermo().nDim() < 3) {
@@ -88,10 +192,10 @@ Reaction* ReactionFactory::newReaction(const AnyMap& node,
     try {
         R = create(type);
     } catch (CanteraError& err) {
-        throw InputFileError("newReaction", node["type"],
+        throw InputFileError("ReactionFactory::newReaction", node["type"],
             "Unknown reaction type '{}'", type);
     }
-    R->setup(node, kin);
+    setup_AnyMap(type, R, node, kin);
     return R;
 }
 

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -147,6 +147,12 @@ ReactionFactory::ReactionFactory()
                });
 }
 
+Reaction* ReactionFactory::newReaction(const std::string& type)
+{
+    Reaction* R = create(toLowerCopy(type));
+    return R;
+}
+
 Reaction* ReactionFactory::newReaction(const XML_Node& rxn_node)
 {
     std::string type = toLowerCopy(rxn_node["type"]);
@@ -196,6 +202,12 @@ Reaction* ReactionFactory::newReaction(const AnyMap& node,
             "Unknown reaction type '{}'", type);
     }
     setup_AnyMap(type, R, node, kin);
+    return R;
+}
+
+unique_ptr<Reaction> newReaction(const std::string& type)
+{
+    unique_ptr<Reaction> R(ReactionFactory::factory()->newReaction(type));
     return R;
 }
 

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -1,4 +1,4 @@
-/**
+ /**
  *  @file ReactionFactory.cpp
  */
 
@@ -23,13 +23,10 @@ ReactionFactory::ReactionFactory()
     reg("elementary", []() { return new ElementaryReaction(); });
     m_synonyms["arrhenius"] = "elementary";
     m_synonyms[""] = "elementary";
-    void setupElementaryReaction(ElementaryReaction&, const XML_Node&);
     reg_XML("elementary",
             [](Reaction* R, const XML_Node& node) {
                 setupElementaryReaction(*(ElementaryReaction*)R, node);
             });
-    void setupElementaryReaction(ElementaryReaction&, const AnyMap&,
-                                 const Kinetics&);
     reg_AnyMap("elementary",
                [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
                    setupElementaryReaction(*(ElementaryReaction*)R, node, kin);
@@ -39,13 +36,10 @@ ReactionFactory::ReactionFactory()
     reg("three-body", []() { return new ThreeBodyReaction(); });
     m_synonyms["threebody"] = "three-body";
     m_synonyms["three_body"] = "three-body";
-    void setupThreeBodyReaction(ThreeBodyReaction&, const XML_Node&);
     reg_XML("three-body",
             [](Reaction* R, const XML_Node& node) {
                 setupThreeBodyReaction(*(ThreeBodyReaction*)R, node);
             });
-    void setupThreeBodyReaction(ThreeBodyReaction&, const AnyMap&,
-                                const Kinetics&);
     reg_AnyMap("three-body",
                [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
                    setupThreeBodyReaction(*(ThreeBodyReaction*)R, node, kin);
@@ -53,13 +47,10 @@ ReactionFactory::ReactionFactory()
 
     // register falloff reactions
     reg("falloff", []() { return new FalloffReaction(); });
-    void setupFalloffReaction(FalloffReaction&, const XML_Node&);
     reg_XML("falloff",
             [](Reaction* R, const XML_Node& node) {
                 setupFalloffReaction(*(FalloffReaction*)R, node);
             });
-    void setupFalloffReaction(FalloffReaction&, const AnyMap&,
-                              const Kinetics&);
     reg_AnyMap("falloff",
                [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
                    setupFalloffReaction(*(FalloffReaction*)R, node, kin);
@@ -69,8 +60,6 @@ ReactionFactory::ReactionFactory()
     reg("chemically-activated", []() { return new ChemicallyActivatedReaction(); });
     m_synonyms["chemact"] = "chemically-activated";
     m_synonyms["chemically_activated"] = "chemically-activated";
-    void setupChemicallyActivatedReaction(ChemicallyActivatedReaction&,
-                                          const XML_Node&);
     reg_XML("chemically-activated",
             [](Reaction* R, const XML_Node& node) {
                 setupChemicallyActivatedReaction(*(ChemicallyActivatedReaction*)R, node);
@@ -82,15 +71,12 @@ ReactionFactory::ReactionFactory()
 
     // register pressure-depdendent-Arrhenius reactions
     reg("pressure-dependent-Arrhenius", []() { return new PlogReaction(); });
-    m_synonyms["pressure-dependent-arrhenius"] = "pressure-dependent-Arrhenius";
     m_synonyms["plog"] = "pressure-dependent-Arrhenius";
     m_synonyms["pdep_arrhenius"] = "pressure-dependent-Arrhenius";
-    void setupPlogReaction(PlogReaction&, const XML_Node&);
     reg_XML("pressure-dependent-Arrhenius",
             [](Reaction* R, const XML_Node& node) {
                 setupPlogReaction(*(PlogReaction*)R, node);
             });
-    void setupPlogReaction(PlogReaction&, const AnyMap&, const Kinetics&);
     reg_AnyMap("pressure-dependent-Arrhenius",
                [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
                    setupPlogReaction(*(PlogReaction*)R, node, kin);
@@ -99,13 +85,10 @@ ReactionFactory::ReactionFactory()
     // register Chebyshev reactions
     reg("Chebyshev", []() { return new ChebyshevReaction(); });
     m_synonyms["chebyshev"] = "Chebyshev";
-    void setupChebyshevReaction(ChebyshevReaction&, const XML_Node&);
     reg_XML("Chebyshev",
             [](Reaction* R, const XML_Node& node) {
                 setupChebyshevReaction(*(ChebyshevReaction*)R, node);
             });
-    void setupChebyshevReaction(ChebyshevReaction&, const AnyMap&,
-                                const Kinetics&);
     reg_AnyMap("Chebyshev",
                [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
                    setupChebyshevReaction(*(ChebyshevReaction*)R, node, kin);
@@ -116,13 +99,10 @@ ReactionFactory::ReactionFactory()
     m_synonyms["surface"] = "interface";
     m_synonyms["edge"] = "interface";
     m_synonyms["global"] = "interface";
-    void setupInterfaceReaction(InterfaceReaction&, const XML_Node&);
     reg_XML("interface",
             [](Reaction* R, const XML_Node& node) {
                 setupInterfaceReaction(*(InterfaceReaction*)R, node);
             });
-    void setupInterfaceReaction(InterfaceReaction&, const AnyMap&,
-                                const Kinetics&);
     reg_AnyMap("interface",
                [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
                    setupInterfaceReaction(*(InterfaceReaction*)R, node, kin);
@@ -133,27 +113,23 @@ ReactionFactory::ReactionFactory()
     m_synonyms["butlervolmer_noactivitycoeffs"] = "electrochemical";
     m_synonyms["butlervolmer"] = "electrochemical";
     m_synonyms["surfaceaffinity"] = "electrochemical";
-    void setupElectrochemicalReaction(ElectrochemicalReaction&,
-                                      const XML_Node&);
     reg_XML("electrochemical",
             [](Reaction* R, const XML_Node& node) {
                 setupElectrochemicalReaction(*(ElectrochemicalReaction*)R, node);
             });
-    void setupElectrochemicalReaction(ElectrochemicalReaction&,
-                                      const AnyMap&, const Kinetics&);
     reg_AnyMap("electrochemical",
                [](Reaction* R, const AnyMap& node, const Kinetics& kin) {
                    setupElectrochemicalReaction(*(ElectrochemicalReaction*)R, node, kin);
                });
 }
 
-Reaction* ReactionFactory::newReaction(const std::string& type)
+unique_ptr<Reaction> newReaction(const std::string& type)
 {
-    Reaction* R = create(toLowerCopy(type));
+    unique_ptr<Reaction> R(ReactionFactory::factory()->create(type));
     return R;
 }
 
-Reaction* ReactionFactory::newReaction(const XML_Node& rxn_node)
+unique_ptr<Reaction> newReaction(const XML_Node& rxn_node)
 {
     std::string type = toLowerCopy(rxn_node["type"]);
 
@@ -166,17 +142,18 @@ Reaction* ReactionFactory::newReaction(const XML_Node& rxn_node)
 
     Reaction* R;
     try {
-        R = create(type);
+        R = ReactionFactory::factory()->create(type);
     } catch (CanteraError& err) {
         throw CanteraError("newReaction",
             "Unknown reaction type '" + rxn_node["type"] + "'");
     }
-    setup_XML(R->type(), R, rxn_node);
-    return R;
+    ReactionFactory::factory()->setup_XML(R->type(), R, rxn_node);
+
+    return unique_ptr<Reaction>(R);
 }
 
-Reaction* ReactionFactory::newReaction(const AnyMap& node,
-                                       const Kinetics& kin)
+unique_ptr<Reaction> newReaction(const AnyMap& node,
+                                 const Kinetics& kin)
 {
     std::string type = "elementary";
     if (node.hasKey("type")) {
@@ -196,32 +173,14 @@ Reaction* ReactionFactory::newReaction(const AnyMap& node,
 
     Reaction* R;
     try {
-        R = create(type);
+        R = ReactionFactory::factory()->create(type);
     } catch (CanteraError& err) {
         throw InputFileError("ReactionFactory::newReaction", node["type"],
             "Unknown reaction type '{}'", type);
     }
-    setup_AnyMap(type, R, node, kin);
-    return R;
-}
+    ReactionFactory::factory()->setup_AnyMap(type, R, node, kin);
 
-unique_ptr<Reaction> newReaction(const std::string& type)
-{
-    unique_ptr<Reaction> R(ReactionFactory::factory()->newReaction(type));
-    return R;
-}
-
-unique_ptr<Reaction> newReaction(const XML_Node& rxn_node)
-{
-    unique_ptr<Reaction> R(ReactionFactory::factory()->newReaction(rxn_node));
-    return R;
-}
-
-unique_ptr<Reaction> newReaction(const AnyMap& rxn_node,
-                                 const Kinetics& kin)
-{
-    unique_ptr<Reaction> R(ReactionFactory::factory()->newReaction(rxn_node, kin));
-    return R;
+    return unique_ptr<Reaction>(R);
 }
 
 }

--- a/src/kinetics/importKinetics.cpp
+++ b/src/kinetics/importKinetics.cpp
@@ -16,6 +16,7 @@
 #include "cantera/kinetics/importKinetics.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/kinetics/Reaction.h"
+#include "cantera/kinetics/ReactionFactory.h"
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/ctml.h"
 #include "cantera/base/yaml.h"

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -3,6 +3,7 @@
 #include "cantera/kinetics/GasKinetics.h"
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/kinetics/KineticsFactory.h"
+#include "cantera/kinetics/ReactionFactory.h"
 #include "cantera/thermo/ThermoFactory.h"
 
 using namespace Cantera;


### PR DESCRIPTION
**Changes proposed in this pull request**

- Add `ReactionFactory` in C++
- Replace hard-coded instantiation and setup in C++ and Python
- Remove magic numbers from Python interface

**Approach**

The main philosophy is to replace hard-coded reaction instantiation by an extendable `ReactionFactory` approach. None of this affects calculated outcomes. I.e. this PR repackages what's already there, with the difference that it becomes very simple to add additional reaction types.

Example: `GasKinetics` becomes fully flexible, i.e. someone can define a new reaction type externally and link it against cantera (`ctwrap` approach, where new C++ lambda functions are registered for an existing cantera factory object).

**Implementation**

* Replace magic number referenced function calls by name-mapped C++ lambda functions calls (which are mainly used for setup; actual kinetics calculations involve templated functions, i.e. there is no change from the current implementation whatsoever)
* C++ lambda functions recycle existing code directly