### PR TITLE
Deprecate undocumented Butler-Volmer reaction options

### DIFF
--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -375,6 +375,7 @@ public:
      */
     int phaseStability(const size_t iphase) const;
 
+    //! @deprecated To be removed after Cantera 2.5.
     virtual void determineFwdOrdersBV(ElectrochemicalReaction& r, vector_fp& fwdFullorders);
 
 protected:
@@ -533,6 +534,7 @@ protected:
      *                            directly.
      *    m_ctrxn_BVform[i] = 2;  this means that the irxn reaction is calculated via the BV format
      *                            directly, using concentrations instead of activity concentrations.
+     * @deprecated To be removed after Cantera 2.5.
      */
     std::vector<size_t> m_ctrxn_BVform;
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -249,6 +249,7 @@ public:
      *  add an electrical resistance to the formulation. The resistance modifies
      *  the electrical current flow in both directions. Only valid for Butler-
      *  Volmer formulations. Units are in ohms m2. Default = 0.0 ohms m2.
+     *  @deprecated Unused. To be removed after Cantera 2.5.
      */
     doublereal film_resistivity;
 

--- a/include/cantera/kinetics/reaction_defs.h
+++ b/include/cantera/kinetics/reaction_defs.h
@@ -79,18 +79,21 @@ const int INTERFACE_RXN = 20;
 //!  This is a surface reaction that is formulated using the Butler-Volmer
 //!  formulation and using concentrations instead of activity concentrations
 //!  for its exchange current density formula.
+//!  @deprecated To be removed after Cantera 2.5.
 const int BUTLERVOLMER_NOACTIVITYCOEFFS_RXN = 25;
 
 //!  This is a surface reaction that is formulated using the Butler-Volmer
 //!  formulation. Note the B-V equations can be derived from the forward
 //!  and reverse rate constants for a single step reaction. However, there
 //!  are some advantages to using the formulation directly.
+//!  @deprecated To be removed after Cantera 2.5.
 const int BUTLERVOLMER_RXN = 26;
 
 //!  This is a surface reaction that is formulated using the affinity
 //!  representation, common in the geochemistry community.
 //!  This is generally a global non-mass action reaction with an additional functional
 //!  form dependence on delta G of reaction.
+//!  @deprecated To be removed after Cantera 2.5.
 const int SURFACEAFFINITY_RXN = 27;
 
 /**
@@ -104,6 +107,7 @@ const int EDGE_RXN = 22;
 /**
  * A global reaction. These may have non-mass action reaction orders,
  * and are not allowed to be reversible.
+ * @deprecated To be removed after Cantera 2.5.
  */
 const int GLOBAL_RXN = 30;
 

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -860,12 +860,20 @@ void setupElectrochemicalReaction(ElectrochemicalReaction& R,
     std::string type = toLowerCopy(rxn_node["type"]);
     if (type == "butlervolmer") {
         R.reaction_type = BUTLERVOLMER_RXN;
+        warn_deprecated("reaction type 'ButlerVolmer'",
+            "To be removed after Cantera 2.5.");
     } else if (type == "butlervolmer_noactivitycoeffs") {
         R.reaction_type = BUTLERVOLMER_NOACTIVITYCOEFFS_RXN;
+        warn_deprecated("reaction type 'butlervolmer_noactivitycoeffs'",
+            "To be removed after Cantera 2.5.");
     } else if (type == "surfaceaffinity") {
         R.reaction_type = SURFACEAFFINITY_RXN;
+        warn_deprecated("reaction type 'surfaceaffinity'",
+            "To be removed after Cantera 2.5.");
     } else if (type == "global") {
         R.reaction_type = GLOBAL_RXN;
+        warn_deprecated("reaction type 'global'",
+            "To be removed after Cantera 2.5.");
     }
 
     XML_Node& rc = rxn_node.child("rateCoeff");
@@ -884,6 +892,10 @@ void setupElectrochemicalReaction(ElectrochemicalReaction& R,
         R.beta = fpValueCheck(rc.child("electrochem")["beta"]);
     }
 
+    if (rxn_node.hasChild("filmResistivity")) {
+        warn_deprecated("reaction filmResistivity",
+            "Not implemented. To be removed after Cantera 2.5.");
+    }
     getOptionalFloat(rxn_node, "filmResistivity", R.film_resistivity);
     setupInterfaceReaction(R, rxn_node);
 
@@ -908,6 +920,8 @@ void setupElectrochemicalReaction(ElectrochemicalReaction& R,
 
     // For affinity reactions, fill in the global reaction formulation terms
     if (rxn_node.hasChild("reactionOrderFormulation")) {
+        warn_deprecated("reactionOrderFormulation",
+            "To be removed after Cantera 2.5.");
         Composition initial_orders = R.orders;
         R.orders.clear();
         R.allow_nonreactant_orders = true;


### PR DESCRIPTION
As mentioned in #749, I believe that there are implementation issues that prevent most if not all of it from being used at present (for both 2.4.0 and the current master branch) due to two mutually-exclusive conditions: (a) we don't currently allow reactant orders to be specified for reversible reactions and (b) Butler-Volmer reactions are required to be reversible and involve manipulating the reaction orders.

I think the easiest path forward to supporting these Butler-Volmer and other reaction types is to deprecate and remove these non-functional versions, and re-consider implementation after the next release.