### PR TITLE
Reactor: ensure consistent vector lengths in C++ layer

### DIFF
--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -148,17 +148,23 @@ public:
 
     //! Set absolute step size limits during advance
     //! @param limits array of step size limits with length neq
-    virtual void setAdvanceLimits(const double* limits);
+    void setAdvanceLimits(const double* limits);
+
+    //! Check whether Reactor object uses advance limits
+    //! @returns           True if at least one limit is set, False otherwise
+    bool hasAdvanceLimits() {
+        return m_advancelimits.size();
+    }
 
     //! Retrieve absolute step size limits during advance
     //! @param[out] limits array of step size limits with length neq
     //! @returns           True if at least one limit is set, False otherwise
-    virtual bool getAdvanceLimits(double* limits);
+    bool getAdvanceLimits(double* limits);
 
     //! Set individual step size limit for compoment name *nm*
     //! @param nm component name
     //! @param limit value for step size limit
-    virtual void setAdvanceLimit(const std::string& nm, const double limit);
+    void setAdvanceLimit(const std::string& nm, const double limit);
 
 protected:
     //! Set reaction rate multipliers based on the sensitivity variables in

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -246,10 +246,13 @@ public:
     }
 
     //! Set absolute step size limits during advance
-    virtual void setAdvanceLimits(const double* limits);
+    void setAdvanceLimits(const double* limits);
+
+    //! Check whether ReactorNet object uses advance limits
+    bool hasAdvanceLimits();
 
     //! Retrieve absolute step size limits during advance
-    virtual bool getAdvanceLimits(double* limits);
+    bool getAdvanceLimits(double* limits);
 
 protected:
 

--- a/interfaces/cython/cantera/examples/reactors/reactor1.py
+++ b/interfaces/cython/cantera/examples/reactors/reactor1.py
@@ -1,5 +1,7 @@
 """
 Constant-pressure, adiabatic kinetics simulation.
+
+Requires: Cantera >= 2.5.0
 """
 
 import sys

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -288,7 +288,7 @@ class TestReactor(utilities.CanteraTest):
         n_baseline = integrate()
         n_advance_coarse = integrate(.01)
         n_advance_fine = integrate(.001)
-        n_advance_negative = integrate(-.001)
+        n_advance_negative = integrate(-1.0)
         n_advance_override = integrate(.001, False)
 
         self.assertTrue(n_advance_coarse > n_baseline)

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -151,12 +151,13 @@ double ReactorNet::advance(double time, bool applylimit)
         return time;
     }
 
-    bool limitadvance = getAdvanceLimits(m_advancelimits.data());
-    if (!limitadvance) {
+    if (!hasAdvanceLimits()) {
         // take full step
         advance(time);
         return time;
     }
+
+    getAdvanceLimits(m_advancelimits.data());
 
     // ensure that gradient is available
     while (lastOrder() < 1) {
@@ -311,14 +312,21 @@ void ReactorNet::setAdvanceLimits(const double *limits)
     }
 }
 
+bool ReactorNet::hasAdvanceLimits()
+{
+    bool has_limit = false;
+    for (size_t n = 0; n < m_reactors.size(); n++) {
+        has_limit |= m_reactors[n]->hasAdvanceLimits();
+    }
+    return has_limit;
+}
+
 bool ReactorNet::getAdvanceLimits(double *limits)
 {
     bool has_limit = false;
-
     for (size_t n = 0; n < m_reactors.size(); n++) {
         has_limit |= m_reactors[n]->getAdvanceLimits(limits + m_start[n]);
     }
-
     return has_limit;
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**

- Ensure consistent vector sizes, i.e. `Reactor::m_advancelimits.size()` is `Reactor::m_nv`
- Prevents hard to track segfaults when `m_advancelimits.size()` < `m_nv` in custom additions
- Make functions related to advance limits non-virtual
