### PR TITLE
[Doc/cti2yaml] Add Sphinx docs page for cti2yaml

### DIFF
--- a/doc/sphinx/yaml/cti_conversion.rst
+++ b/doc/sphinx/yaml/cti_conversion.rst
@@ -1,0 +1,5 @@
+***********************
+CTI to YAML conversion
+***********************
+
+.. automodule:: cantera.cti2yaml

--- a/doc/sphinx/yaml/index.rst
+++ b/doc/sphinx/yaml/index.rst
@@ -11,4 +11,5 @@ YAML Input File Reference
    elements
    species
    reactions
+   cti_conversion
    ctml_conversion

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -153,7 +153,7 @@ def validate(species = 'yes', reactions = 'yes'):
     pass
 
 def dataset(nm):
-    "Set the dataset name. Invoke this to change the name of the XML file."
+    "Set the dataset name. Invoke this to change the name of the YAML file."
     global _name
     _name = nm
 


### PR DESCRIPTION
Thanks for contributing code! Please include a description of your change and
check your PR against the list below (for further questions, refer to the
[contributing guide](https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md)).

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage

**Changes proposed in this pull request**

- Add a docs page for the `cti2yaml.py` script. No docstrings were harmed in the making of this PR (well, except one that retained an old reference to the `ctml_writer` lineage of this converter). In other words, the `autodoc` capabilities of Sphinx are leveraged to pull in the whole `cti2yaml.py` module. I thought that having a documentation page here might prompt us to update the docstrings as necessary, but they seemed mostly complete to me anyways.