### PR TITLE
Fix building for Python 3.8

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1201,6 +1201,7 @@ env['python_cmd_esc'] = quoted(env['python_cmd'])
 
 # Python Package Settings
 python_min_version = LooseVersion('3.5')
+# Note: cython_min_version is redefined below if the Python version is 3.8 or higher
 cython_min_version = LooseVersion('0.23')
 numpy_min_test_version = LooseVersion('1.8.1')
 
@@ -1293,6 +1294,15 @@ if env['python_package'] != 'none':
                 "Found {0} but {1} or newer is required".format(
                 python_version, python_min_version))
             warn_no_full_package = True
+        elif python_version >= LooseVersion("3.8"):
+            # Reset the minimum Cython version if the Python version is 3.8 or higher
+            # Due to internal changes in the CPython API, more recent versions of
+            # Cython are necessary to build for Python 3.8. There is nothing Cantera
+            # can do about this, the changes in CPython are handled by Cython. This
+            # version bump is used to produce a more useful/actionable error message
+            # for users than the compilation errors that result from using
+            # Cython < 0.29.12.
+            cython_min_version = LooseVersion("0.29.12")
 
         if numpy_version == LooseVersion('0.0.0'):
             print("NumPy not found.")

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -47,6 +47,15 @@ localenv.Prepend(CPPPATH=[Dir('#include'), inc, numpy_include])
 localenv.Prepend(LIBS=localenv['cantera_libs'])
 if localenv['OS'] == 'Darwin':
     localenv.Append(LINKFLAGS='-undefined dynamic_lookup')
+
+    # Don't print deprecation warnings for internal Python changes.
+    # It seems that only clang on macOS prints these deprecation warnings.
+    # Only applies to Python 3.8. The field that is deprecated in Python 3.8
+    # and causes the warnings to appear will be removed in Python 3.9 so no
+    # further warnings should be issued. Cython has already implemented a fix
+    # in versions higher than 0.29.14.
+    if py_version == LooseVersion("3.8"):
+        localenv.Append(CXXFLAGS='-Wno-deprecated-declarations')
 elif localenv['OS'] == 'Windows':
     localenv.Append(LIBPATH=prefix+'/libs')
     if localenv['toolchain'] == 'mingw':


### PR DESCRIPTION
Thanks for contributing code! Please include a description of your change and
check your PR against the list below (for further questions, refer to the
[contributing guide](https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md)).

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage

**Changes proposed in this pull request**

- Bump the minimum Cython version when building for Python 3.8
- Disable deprecation warnings on macOS when compiling `_cantera.cpp` that are caused by a deprecated feature that Cython handles
