### PR TITLE
Add references field to yaml input standard

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1589,6 +1589,32 @@ for yaml in mglob(env, "data", "yaml"):
     dest = pjoin("build", "data", yaml.name)
     build(env.Command(dest, yaml.path, Copy("$TARGET", "$SOURCE")))
 
+# Copy Chemkin input files
+ck_sources = [
+    dict(input='data/inputs/gri30.inp',
+         thermo='data/thermo/gri30_thermo.dat',
+         transport='data/transport/gri30_tran.dat',
+         bibtex='data/bibtex/gri30.bib'),
+    dict(input='data/inputs/air.inp',
+         transport='data/transport/gri30_tran.dat'),
+    dict(input='data/inputs/argon.inp',
+         thermo='data/thermo/gri30_thermo.dat',
+         transport='data/transport/gri30_tran.dat'),
+    dict(input='data/inputs/airNASA9.inp',
+         thermo='data/thermo/airDataNASA9.dat',
+         bibtex='data/bibtex/nasa9.bib'),
+    dict(input='data/inputs/h2o2.inp',
+         transport='data/transport/gri30_tran.dat'),
+    dict(thermo='data/thermo/nasathermo.dat',
+         bibtex='data/bibtex/nasa7.bib')
+]
+
+for mech in ck_sources:
+    for key in ['input', 'thermo', 'transport', 'bibtex']:
+        if key in mech:
+            build(env.Command('build/chemkin/{}'.format(mech[key].split('/')[-1]),
+                              mech[key], Copy('$TARGET', '$SOURCE')))
+
 if addInstallActions:
     # Put headers in place
     headerBase = 'include/cantera'

--- a/data/bibtex/gri30.bib
+++ b/data/bibtex/gri30.bib
@@ -1,0 +1,9 @@
+@misc{gri30,
+    title = "GRI-Mech 3.0",
+    author = "Gregory P. Smith and David M. Golden and Michael Frenklach and
+              Nigel W. Moriarty and Boris Eiteneer and Mikhail Goldenberg and
+              C. Thomas Bowman and Ronald K. Hanson and Soonho Song and
+              William C. {Gardiner Jr.} and Vitali V. Lissianski and Zhiwei Qin",
+    year = 1999,
+    howpublished = "\url{http://combustion.berkeley.edu/gri-mech/version30/text30.html}"
+}

--- a/data/bibtex/nasa7.bib
+++ b/data/bibtex/nasa7.bib
@@ -1,0 +1,20 @@
+@misc{nasa7,
+    title = "NASA thermodynamic database",
+    note = "7-term polynomial coefficients in 1971 format",
+    howpublished = "\url{https://shepherd.caltech.edu/EDL/PublicResources/sdt/cti/NASA7/nasa7.dat}"
+}
+@techreport{gordon1971,
+    title = "Computer Program for Calculation of Complex Chemical Equilibrium
+             Composition, Rocket Performance, Incident and Reflected Shocks and
+             Chapman-Jouguet Detonations",
+    author = "S. Gordon and B. J. McBride",
+    year = 1971,
+    number = "NASA SP-273"
+}
+@techreport{mcbride1993,
+    title = "Coefficients for Calculating Thermodynamic and Transport Properties
+             of Individual Species",
+    author = "B. J. McBride and S. Gordon and M. A. Reno",
+    year = 1993,
+    number = "NASA TM-4513"
+}

--- a/data/bibtex/nasa9.bib
+++ b/data/bibtex/nasa9.bib
@@ -1,0 +1,12 @@
+@misc{nasa9,
+    title = "NASA thermodynamic database",
+    note = "9-term coefficients in 1996 format",
+    howpublished = "\url{https://shepherd.caltech.edu/EDL/PublicResources/sdt/cti/NASA7/nasa7.dat}"
+}
+@techreport{mcbride2002,
+    title = "Nasa Glenn coefficients for Calculating Thermodynamic Properties
+             of Individual Species",
+    author = "B. J. McBride and M. J. Zehe and S. Gordon",
+    year = 2002,
+    number = "NASA TP2002-211556"
+}

--- a/data/inputs/air.inp
+++ b/data/inputs/air.inp
@@ -1,3 +1,5 @@
+! Ideal gas properties of air. Includes several reactions among
+! the included species.
 ELEMENTS
 O  N  AR
 END

--- a/data/inputs/argon.inp
+++ b/data/inputs/argon.inp
@@ -1,3 +1,5 @@
+! Pure argon phase. Thermo and transport properties are taken
+! from GRI-Mech 3.0.
 ELEMENTS
 AR
 END

--- a/data/inputs/h2o2.inp
+++ b/data/inputs/h2o2.inp
@@ -1,3 +1,4 @@
+! Hydrogen-Oxygen submechanism extracted from GRI-Mech 3.0.
 ELEMENTS
 O  H  AR
 END

--- a/data/inputs/silane.inp
+++ b/data/inputs/silane.inp
@@ -1,3 +1,5 @@
+! Source unknown. Data originially added by Dave Goodwin in an early
+! version of Cantera.
 ELEMENTS
 SI H HE 
 END

--- a/data/thermo/nasathermo.dat
+++ b/data/thermo/nasathermo.dat
@@ -1,5 +1,3 @@
-THERMO NO_TMID
- 300.0   1000.0   5000.0
 !
 ! This is the NASA thermodynamic database, which is available for download
 ! from http://www.galcit.caltech.edu/EDL/public/thermo.html. The original 
@@ -14,6 +12,8 @@ THERMO NO_TMID
 ! Report TM-4513, October 1993.
 !-----------------------------------------------------------------------------
 !
+THERMO NO_TMID
+ 300.0   1000.0   5000.0
 Electron gas      L10/92E  1.   0.   0.   0.G   200.000  6000.0005.48579903-04 1
  2.50000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00 0.00000000E+00    2
 -7.45375000E+02-1.17246902E+01 2.50000000E+00 0.00000000E+00 0.00000000E+00    3

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -26,6 +26,10 @@ testFiles = localenv.RecursiveInstall('#interfaces/cython/cantera/test/data',
                                       '#test/data')
 build(testFiles)
 
+ckFiles = localenv.RecursiveInstall('#interfaces/cython/cantera/examples/input',
+                                    '#build/chemkin')
+build(ckFiles)
+
 inputFiles = ['inputs/h2o2.inp', 'inputs/gri30.inp',
               'transport/gri30_tran.dat', 'thermo/gri30_thermo.dat']
 for f in inputFiles:
@@ -96,6 +100,7 @@ for f in (mglob(localenv, 'cantera', 'py') +
           mglob(localenv, 'cantera/examples/reactors', 'py') +
           mglob(localenv, 'cantera/examples/onedim', 'py') +
           mglob(localenv, 'cantera/examples/surface_chemistry', 'py') +
+          mglob(localenv, 'cantera/examples/input', 'py') +
           mglob(localenv, 'cantera/examples/misc', 'py')):
     localenv.Depends(mod, f)
 

--- a/interfaces/cython/cantera/examples/input/ck2yaml_demo.py
+++ b/interfaces/cython/cantera/examples/input/ck2yaml_demo.py
@@ -1,0 +1,60 @@
+"""
+Illustrate conversion of chemkin input files to cantera yaml input files.
+
+The script runs the conversion utility `ck2yaml` as a shell command. The
+following GRI-3.0 derived input files are re-created:
+ * gri30.yaml (without deprecated phases)
+ * h2o2.yaml
+ * air.yaml
+ * argon.yaml
+ * airNASA9.yaml
+ * nasa.yaml
+
+Requires: cantera >= 2.5.0
+"""
+
+import subprocess
+
+opt = {}
+
+# options for gri30.yaml
+opt['gri30'] = ["--input=gri30.inp", "--output=gri30.yaml",
+                "--thermo=gri30_thermo.dat", "--transport=gri30_tran.dat",
+                "--name=gri30", "--bibtex=gri30.bib"]
+
+# options for h2o2.yaml
+opt['h2o2'] = ["--input=h2o2.inp", "--output=h2o2.yaml",
+               "--transport=gri30_tran.dat",
+               "--name=ohmech"]
+
+# options for air.yaml
+opt['air'] = ["--input=air.inp", "--output=air.yaml",
+              "--transport=gri30_tran.dat",
+              "--name=air"]
+
+# options for argon.yaml (the --quiet option suppresses warnings about
+# unexpected/unused species in thermo data)
+opt['argon'] = ["--input=argon.inp", "--output=argon.yaml",
+                "--thermo=gri30_thermo.dat", "--transport=gri30_tran.dat",
+                "--name=argon", "--quiet"]
+
+# options for airNASA9.yaml
+opt['airNASA9'] = ["--input=airNASA9.inp", "--output=airNASA9.yaml",
+                   "--thermo=airDataNASA9.dat",
+                   "--name=airNASA9", "--bibtex=nasa9.bib"]
+
+# options for nasa.yaml
+opt['nasa'] = ["--thermo=nasathermo.dat", "--output=nasa.yaml",
+               "--bibtex=nasa7.bib", "--permissive"]
+
+# display help text
+print('Executing shell command:')
+print('ck2yaml --help\n')
+subprocess.run(['ck2yaml', '--help'])
+
+for o in opt:
+
+    # print command
+    print('\nExecuting shell command to create `{}.yaml`:'.format(o))
+    print('ck2yaml {}\n'.format(' '.join(opt[o])))
+    subprocess.run(['ck2yaml'] + opt[o])

--- a/interfaces/cython/cantera/test/data/test.bib
+++ b/interfaces/cython/cantera/test/data/test.bib
@@ -1,0 +1,25 @@
+@article{mrx05,
+auTHor = "Mr. X",
+Title = {Something Great},
+publisher = "nob" # "ody",
+YEAR = 2005,
+}
+@article{xy06,
+auTHor = "Mr. X and Ms. Y",
+Title = {Something Even Greater},
+publisher = "nob" # "ody",
+note = "{\textsc{Bib}\TeX}" # "ing",
+howpublished = "\url{http://www.bibtex.org/Format/}",
+YEAR = 2006
+}
+@article{    xyz_2006  ,
+auTHor = "Mr. X and Ms. Y and Mr. {Z Jr.}",
+Title = {Also Great},
+publisher = "nob" # "ody",
+note = "{\textsc{Bib}\TeX}" # "ing",
+howpublished = "\url{http://www.bibtex.org/Format/}",
+YEAR = 2006, }
+@misc{ patashnik-bibtexing,
+       author = "Oren Patashnik",
+       title = "BIBTEXing",
+       year = "1988" }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below (for further questions, refer to the [contributing guide](https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md)). -->

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**Please fill in the issue number this pull request is fixing**

Fixes Cantera/enhancements#15, fixes #339

**Changes proposed in this pull request**

- Add `references` field to YAML input standard
- Entries are generated from `BibTeX` formatted files (passed as `--bibtex=` option to `ck2yaml`) 
- Add references to `gri30.yaml` for illustration:

```yaml
references:
  gri30:  # @misc
    title: GRI-Mech 3.0
    author: Gregory P. Smith, David M. Golden, Michael Frenklach, Nigel
      W. Moriarty, Boris Eiteneer, Mikhail Goldenberg, C. Thomas Bowman,
      Ronald K. Hanson, Soonho Song, William C. Gardiner Jr., Vitali V.
      Lissianski and Zhiwei Qin
    year: 1999
    howpublished: |-
      \url{http://combustion.berkeley.edu/gri-mech/version30/text30.html}
```
