### PR TITLE
Fix some issues with Fortran samples

### DIFF
--- a/samples/cxx/SConstruct.in
+++ b/samples/cxx/SConstruct.in
@@ -5,6 +5,7 @@ env.Append(CCFLAGS=@tmpl_compiler_flags@,
            CPPPATH=@tmpl_cantera_incdirs@,
            LIBS=@tmpl_cantera_libs@,
            LIBPATH=@tmpl_cantera_libdirs@,
+           RPATH=@tmpl_cantera_libdirs@,
            LINKFLAGS=@tmpl_cantera_linkflags@,
            FRAMEWORKS=@tmpl_cantera_frameworks@)
 

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -21,7 +21,8 @@ for program_name, fortran_sources in samples:
                 fortran_sources + ftn_demo,
                 CPPPATH=['#build/src/fortran', '#include'],
                 LIBS=env['cantera_libs']+['cantera_fortran']+stdlib,
-                LIBPATH=[env['sundials_libdir'], '#build/lib'],
+                LIBPATH=[env['sundials_libdir'], localenv['blas_lapack_dir'],
+                         '#build/lib'],
                 LINK='$F77')
 
 # Generate SConstruct file to be installed

--- a/samples/f77/SConstruct.in
+++ b/samples/f77/SConstruct.in
@@ -8,6 +8,7 @@ env.Append(FFLAGS='-g',
            CPPPATH=@tmpl_cantera_incdirs@,
            LIBS=@tmpl_cantera_libs@,
            LIBPATH=@tmpl_cantera_libdirs@,
+           RPATH=@tmpl_cantera_libdirs@,
            LINKFLAGS=@tmpl_cantera_linkflags@,
            FRAMEWORKS=@tmpl_cantera_frameworks@)
 

--- a/samples/f77/ctlib.f
+++ b/samples/f77/ctlib.f
@@ -63,6 +63,8 @@ c     CTINDX: get the number of elements, species, and reactions
 
       subroutine ctindx(ickwrk, rckwrk, mm, kk, ii)
       implicit double precision (a-h,o-z)
+      integer ickwrk(*)
+      double precision rckwrk(*)
       mm = nElements()
       kk = nSpecies()
       ii = nReactions()

--- a/samples/f90/SConscript
+++ b/samples/f90/SConscript
@@ -17,7 +17,8 @@ for programName, sources in samples:
     buildSample(localenv.Program, programName, sources,
                 F90PATH='#build/src/fortran',
                 LIBS=['cantera_fortran']+env['cantera_libs']+stdlib,
-                LIBPATH=[env['sundials_libdir'], '#build/lib'])
+                LIBPATH=[env['sundials_libdir'], env['blas_lapack_dir'],
+                         '#build/lib'])
 
     # Generate SConstruct files to be installed
     incdirs = [pjoin(localenv['ct_incroot'], 'cantera')] + localenv['extra_inc_dirs']

--- a/samples/f90/SConstruct.in
+++ b/samples/f90/SConstruct.in
@@ -6,6 +6,7 @@ env.Append(FFLAGS='-g',
            F90PATH=@tmpl_cantera_incdirs@,
            LIBS=@tmpl_cantera_libs@,
            LIBPATH=@tmpl_cantera_libdirs@,
+           RPATH=@tmpl_cantera_libdirs@,
            LINKFLAGS=@tmpl_cantera_linkflags@,
            FRAMEWORKS=@tmpl_cantera_frameworks@)
 


### PR DESCRIPTION
- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & ~~`scons test`~~ `scons samples`) and unit tests address code coverage

I ran into some issues while using the conda-packaged MKL to provide BLAS/LAPACK support that affected the ability to build the samples using the `scons samples` command.

Also, we now use `rpath` in the generated `SConstruct` files for the samples, so that it isn't necessary to specify `LD_LIBRARY_PATH` when running the compiled binaries.