### PR TITLE
Fix broken links to website in docstrings.

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -66,8 +66,8 @@ class Solution(ThermoPhase, Kinetics, Transport):
     models.
 
     For non-trivial uses cases of this functionality, see the examples
-    `extract_submechanism.py <https://cantera.org/examples/python/extract_submechanism.py.html>`_
-    and `mechanism_reduction.py <https://cantera.org/examples/python/mechanism_reduction.py.html>`_.
+    `extract_submechanism.py <https://cantera.org/examples/python/kinetics/extract_submechanism.py.html>`_
+    and `mechanism_reduction.py <https://cantera.org/examples/python/kinetics/mechanism_reduction.py.html>`_.
 
     In addition, `Solution` objects can be constructed by passing the text of
     the CTI or XML phase definition in directly, using the ``source`` keyword


### PR DESCRIPTION
The examples were reorganized and there are a couple of links to them in the docstrings.
This tiny PR just fixes the links that I came across.