### PR TITLE
Simple fix for Sundials 5.0 compatibility

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1103,7 +1103,7 @@ if env['system_sundials'] == 'y':
 
     # Ignore the minor version, e.g. 2.4.x -> 2.4
     env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
-    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2','4.0','4.1'):
+    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2','4.0','4.1','5.0'):
         print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
         sys.exit(1)
     print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)


### PR DESCRIPTION
Sundials 5.0.0 was released on 21 oct 2019 and has the same API for CVODES
as Sundials 4.x so the compatibility fix is trivial by addition of '5.0'
to the supported `sundials_version` list within SConstruct.

