### PR TITLE
Add vapor fraction as option for setting state in YAML files

### DIFF
--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1344,6 +1344,18 @@ public:
         throw NotImplementedError("ThermoPhase::setState_Psat");
     }
 
+    //! Set the temperature, pressure, and vapor fraction (quality).
+    /*!
+     * An exception is thrown if the thermodynamic state is not consistent. That
+     * is, if the vapor fraction is not 0 or 1, the pressure and temperature
+     * must fall on the saturation line.
+     *
+     * @param T    Temperature (K)
+     * @param P    Pressure (Pa)
+     * @param Q    vapor fraction
+     */
+    void setState_TPQ(double T, double P, double Q);
+
     //@}
 
     //! @name Initialization Methods - For Internal Use (ThermoPhase)

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1346,9 +1346,15 @@ public:
 
     //! Set the temperature, pressure, and vapor fraction (quality).
     /*!
-     * An exception is thrown if the thermodynamic state is not consistent. That
-     * is, if the vapor fraction is not 0 or 1, the pressure and temperature
-     * must fall on the saturation line.
+     * An exception is thrown if the thermodynamic state is not consistent.
+     *
+     * For temperatures below the critical temperature, if the vapor fraction is
+     * not 0 or 1, the pressure and temperature must fall on the saturation
+     * line.
+     *
+     * Above the critical temperature, the vapor fraction must be 1 if the
+     * pressure is less than the critical pressure. Above the critical pressure,
+     * the vapor fraction is not defined, and its value is ignored.
      *
      * @param T    Temperature (K)
      * @param P    Pressure (Pa)

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -261,6 +261,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
 
         void setState_Tsat(double T, double x) except +translate_exception
         void setState_Psat(double P, double x) except +translate_exception
+        void setState_TPQ(double T, double P, double Q) except +translate_exception
 
 
 cdef extern from "cantera/thermo/IdealGasPhase.h":

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -160,11 +160,11 @@ class TestPureFluid(utilities.CanteraTest):
 
         self.water.TPQ = T, P, Q
         self.assertNear(Q, 0.8)
-        with self.assertRaisesRegex(ValueError, 'invalid thermodynamic'):
+        with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
             self.water.TPQ = T, .999*P, Q
-        with self.assertRaisesRegex(ValueError, 'invalid thermodynamic'):
+        with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
             self.water.TPQ = T, 1.001*P, Q
-        with self.assertRaisesRegex(ValueError, 'numeric value is required'):
+        with self.assertRaises(TypeError):
             self.water.TPQ = T, P, 'spam'
 
     def test_deprecated_X(self):

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -158,14 +158,26 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertNear(T, 400)
         self.assertNear(Q, 0.8)
 
+        # a supercritical state
+        self.water.TPQ = 800, 3e7, 1
+        self.assertNear(self.water.T, 800)
+        self.assertNear(self.water.P, 3e7)
+
         self.water.TPQ = T, P, Q
-        self.assertNear(Q, 0.8)
+        self.assertNear(self.water.Q, 0.8)
         with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
             self.water.TPQ = T, .999*P, Q
         with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
             self.water.TPQ = T, 1.001*P, Q
         with self.assertRaises(TypeError):
             self.water.TPQ = T, P, 'spam'
+
+        self.water.TPQ = 500, 1e5, 1  # superheated steam
+        self.assertNear(self.water.P, 1e5)
+        with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
+            self.water.TPQ = 500, 1e5, 0  # vapor fraction should be 1 (T < Tc)
+        with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
+            self.water.TPQ = 700, 1e5, 0  # vapor fraction should be 1 (T > Tc)
 
     def test_deprecated_X(self):
 

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1690,6 +1690,27 @@ class TestSolutionArray(utilities.CanteraTest):
             out = getattr(states, g)
             self.assertEqual(len(out), len(g))
 
+    def test_purefluid_yaml_state(self):
+        yaml = """
+        phases:
+        - name: water
+          thermo: pure-fluid
+          species: [{{liquidvapor.yaml/species: [H2O]}}]
+          state: {{T: {T}, P: 101325, Q: {Q}}}
+          pure-fluid-name: water
+        """
+        w = ct.PureFluid(yaml=yaml.format(T=373.177233, Q=0.5))
+        self.assertNear(w.Q, 0.5)
+
+        with self.assertRaisesRegex(ct.CanteraError, "setState"):
+            ct.PureFluid(yaml=yaml.format(T=373, Q=0.5))
+
+        w = ct.PureFluid(yaml=yaml.format(T=370, Q=0.0))
+        self.assertNear(w.P, 101325)
+
+        with self.assertRaisesRegex(ct.CanteraError, "setState"):
+            ct.PureFluid(yaml=yaml.format(T=370, Q=1.0))
+
     def test_sort(self):
         np.random.seed(0)
         t = np.random.random(101)

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1772,24 +1772,7 @@ cdef class PureFluid(ThermoPhase):
             T = values[0] if values[0] is not None else self.T
             P = values[1] if values[1] is not None else self.P
             Q = values[2] if values[2] is not None else self.Q
-            if not isinstance(Q, (np.ndarray, _numbers.Number)):
-                raise ValueError(
-                    'a numeric value is required to quantify '
-                    'the vapor fraction (Q)'
-                )
-            if np.isclose(P, self.thermo.satPressure(T)):
-                self.TQ = T, Q
-            elif np.isclose(Q, 0.) or np.isclose(Q, 1.):
-                self.TP = T, P
-            else:
-                raise ValueError(
-                    'invalid thermodynamic state: the TPQ setter '
-                    'received a combination of property values that '
-                    'do not represent a valid state. As an alternative, '
-                    'specify the state using two fully independent '
-                    'properties (e.g. TD) instead of: '
-                    'T={}, P={}, Q={}'.format(T, P, Q)
-                )
+            self.thermo.setState_TPQ(T, P, Q)
 
     property UVX:
         """

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -23,7 +23,7 @@ namespace Cantera
 {
 
 PureFluidPhase::PureFluidPhase() :
-    m_subflag(0),
+    m_subflag(-1),
     m_mw(-1.0),
     m_verbose(false)
 {
@@ -40,10 +40,7 @@ void PureFluidPhase::initThermo()
     } else {
         m_sub.reset(tpx::GetSub(m_subflag));
     }
-    if (!m_sub) {
-        throw CanteraError("PureFluidPhase::initThermo",
-                           "could not create new substance object.");
-    }
+
     m_mw = m_sub->MolWt();
     setMolecularWeight(0,m_mw);
 

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -738,6 +738,18 @@ void ThermoPhase::initThermo()
 
 void ThermoPhase::setState_TPQ(double T, double P, double Q)
 {
+    if (T > critTemperature()) {
+        if (P > critPressure() || Q == 1) {
+            setState_TP(T, P);
+            return;
+        } else {
+            throw CanteraError("ThermoPhase::setState_TPQ",
+                "Temperature ({}), pressure ({}) and vapor fraction ({}) "
+                "are inconsistent, above the critical temperature.",
+                T, P, Q);
+        }
+    }
+
     double Psat = satPressure(T);
     if (std::abs(Psat / P - 1) < 1e-6) {
         setState_Tsat(T, Q);

--- a/src/tpx/utils.cpp
+++ b/src/tpx/utils.cpp
@@ -61,7 +61,8 @@ Substance* GetSub(int isub)
     } else if (isub == 8) {
         return new Heptane;
     } else {
-        return 0;
+        throw Cantera::CanteraError("tpx::GetSub", "No substance definition "
+            "known for id '{}'.", isub);
     }
 }
 

--- a/test/data/thermo-models.yaml
+++ b/test/data/thermo-models.yaml
@@ -179,6 +179,12 @@ phases:
   thermo: pure-fluid
   pure-fluid-name: nitrogen
 
+- name: CO2-purefluid
+  species: [{rk-species: [CO2]}]
+  thermo: pure-fluid
+  pure-fluid-name: carbondioxide
+  state: {T: 275, vapor-fraction: 0.1}
+
 - name: const-density
   thermo: constant-density
   density: 0.7 g/cm^3

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -341,6 +341,19 @@ TEST(ThermoFromYaml, PureFluid_CO2)
     EXPECT_NEAR(thermo->density(), 513.27928388, 1e-6);
 }
 
+TEST(ThermoFromYaml, PureFluid_Unknown)
+{
+    AnyMap root = AnyMap::fromYamlString(
+        "phases:\n"
+        "- name: unknown-purefluid\n"
+        "  species: [N2]\n"
+        "  thermo: pure-fluid\n"
+        "  pure-fluid-name: unknown-purefluid\n"
+    );
+    AnyMap& phase = root["phases"].getMapWhere("name", "unknown-purefluid");
+    EXPECT_THROW(newPhase(phase, root), CanteraError);
+}
+
 TEST(ThermoFromYaml, ConstDensityThermo)
 {
     suppress_deprecation_warnings();

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -334,6 +334,13 @@ TEST(ThermoFromYaml, PureFluid_nitrogen)
     EXPECT_NEAR(thermo->gibbs_mole(), -17654454.0912211, 1e-6);
 }
 
+TEST(ThermoFromYaml, PureFluid_CO2)
+{
+    auto thermo = newThermo("thermo-models.yaml", "CO2-purefluid");
+    EXPECT_NEAR(thermo->vaporFraction(), 0.1, 1e-6);
+    EXPECT_NEAR(thermo->density(), 513.27928388, 1e-6);
+}
+
 TEST(ThermoFromYaml, ConstDensityThermo)
 {
     suppress_deprecation_warnings();


### PR DESCRIPTION
- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage

**Please fill in the issue number this pull request is fixing**

Addressing a question from @ischoegl in on https://github.com/Cantera/cantera-website/pull/91.

**Changes proposed in this pull request**
* Allows (T, Q), (P, Q), and (T, P, Q) as `state` definitions for pure fluid phases. For the last one, requires the three variables to be self-consistent.
* Fixes an issue that I ran into where leaving the `pure-fluid-name` out of the phase definition gave you a `water` object instead of throwing an exception.
