### PR TITLE
[Test] Include non-numeric text in test_problems comparisons

### DIFF
--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -234,6 +234,11 @@ def compareTextFiles(env, file1, file2):
         if len(floats1) != len(floats2):
             continue
 
+        # if the lines don't have the same non-numeric text,
+        # we're not going to pass the diff comparison
+        if reFloat.sub('', line1).strip() != reFloat.sub('', line2).strip():
+            continue
+
         allMatch = True
         for j in range(len(floats1)):
             if floats1[j] == floats2[j]:

--- a/test_problems/VCSnonideal/LatticeSolid_LiSi/output_blessed.txt
+++ b/test_problems/VCSnonideal/LatticeSolid_LiSi/output_blessed.txt
@@ -271,7 +271,7 @@ Moles: 1
           pressure   1.0132e+05 Pa
            density   1390 kg/m^3
   mean mol. weight   66.418 kg/kmol
-   phase of matter   unspecified
+   phase of matter   solid
 
                           1 kg             1 kmol     
                      ---------------   ---------------

--- a/test_problems/VCSnonideal/LatticeSolid_LiSi/verbose_blessed.txt
+++ b/test_problems/VCSnonideal/LatticeSolid_LiSi/verbose_blessed.txt
@@ -510,7 +510,7 @@ Moles: 1
           pressure   1.0132e+05 Pa
            density   1390 kg/m^3
   mean mol. weight   66.418 kg/kmol
-   phase of matter   unspecified
+   phase of matter   solid
 
                           1 kg             1 kmol     
                      ---------------   ---------------

--- a/test_problems/VCSnonideal/NaCl_equil/good_out.txt
+++ b/test_problems/VCSnonideal/NaCl_equil/good_out.txt
@@ -349,7 +349,7 @@ Moles: 4.09717
           pressure   1.0132e+05 Pa
            density   1.1354 kg/m^3
   mean mol. weight   27.777 kg/kmol
-   phase of matter   unspecified
+   phase of matter   gas
 
                           1 kg             1 kmol     
                      ---------------   ---------------

--- a/test_problems/VPsilane_test/output_blessed.txt
+++ b/test_problems/VPsilane_test/output_blessed.txt
@@ -35,7 +35,7 @@ For species SI2, discontinuity in s/R detected at Tmid = 1000.0
           pressure   100 Pa
            density   1.8315e-05 kg/m^3
   mean mol. weight   2.2842 kg/kmol
-   phase of matter   unspecified
+   phase of matter   gas
 
                           1 kg             1 kmol
                      ---------------   ---------------

--- a/test_problems/clib_test/output_blessed.txt
+++ b/test_problems/clib_test/output_blessed.txt
@@ -5,7 +5,7 @@
           pressure   36961 Pa
            density   0.05295 kg/m^3
   mean mol. weight   27.26 kg/kmol
-   phase of matter   unspecified
+   phase of matter   gas
 
                           1 kg             1 kmol     
                      ---------------   ---------------

--- a/test_problems/silane_equil/output_blessed.txt
+++ b/test_problems/silane_equil/output_blessed.txt
@@ -1,29 +1,29 @@
-UserWarning: 'NasaPoly2::validate': 
+CanteraWarning: NasaPoly2::validate: 
 For species SI2H6, discontinuity in h/RT detected at Tmid = 1000
 	Value computed using low-temperature polynomial:  19.8328
 	Value computed using high-temperature polynomial: 19.9055
 
-UserWarning: 'NasaPoly2::validate': 
+CanteraWarning: NasaPoly2::validate: 
 For species SI2H6, discontinuity in s/R detected at Tmid = 1000
 	Value computed using low-temperature polynomial:  49.5493
 	Value computed using high-temperature polynomial: 49.7214
 
-UserWarning: 'NasaPoly2::validate': 
+CanteraWarning: NasaPoly2::validate: 
 For species SI3H8, discontinuity in h/RT detected at Tmid = 1000
 	Value computed using low-temperature polynomial:  29.3028
 	Value computed using high-temperature polynomial: 29.4297
 
-UserWarning: 'NasaPoly2::validate': 
+CanteraWarning: NasaPoly2::validate: 
 For species SI3H8, discontinuity in s/R detected at Tmid = 1000
 	Value computed using low-temperature polynomial:  65.9731
 	Value computed using high-temperature polynomial: 66.2781
 
-UserWarning: 'NasaPoly2::validate': 
+CanteraWarning: NasaPoly2::validate: 
 For species SI2, discontinuity in h/RT detected at Tmid = 1000
 	Value computed using low-temperature polynomial:  74.0115
 	Value computed using high-temperature polynomial: 74.0387
 
-UserWarning: 'NasaPoly2::validate': 
+CanteraWarning: NasaPoly2::validate: 
 For species SI2, discontinuity in s/R detected at Tmid = 1000
 	Value computed using low-temperature polynomial:  32.8813
 	Value computed using high-temperature polynomial: 32.9489


### PR DESCRIPTION
- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage

**Changes proposed in this pull request**
The comparison code for the output of "test_problems" tests had an error in its logic where lines where all of the numerical values were nearly identical would get counted as equal, even if other text on those lines was not the same. This even applied to lines with no numerical values.
