### PR TITLE
Deprecate redundant ThermoPhase classes

### DIFF
--- a/doc/sphinx/yaml/phases.rst
+++ b/doc/sphinx/yaml/phases.rst
@@ -378,6 +378,10 @@ Example::
 A phase defined by a fixed value of the chemical potential, as
 `described here <https://cantera.org/documentation/dev/doxygen/html/d6/db0/classCantera_1_1FixedChemPotSSTP.html#details>`__.
 
+.. deprecated:: 2.5
+   Use class StoichSubstance with a constant-cp species thermo model, with 'h0'
+   set to the desired chemical potential and 's0' set to 0.
+
 Additional fields:
 
 ``chemical-potential``

--- a/doc/sphinx/yaml/phases.rst
+++ b/doc/sphinx/yaml/phases.rst
@@ -538,6 +538,9 @@ The ideal gas model as
 The ideal gas model, using variable pressure standard state methods as
 `described here <https://cantera.org/documentation/dev/doxygen/html/dc/ddb/classCantera_1_1IdealSolnGasVPSS.html#details>`__.
 
+.. deprecated:: 2.5
+   Use the ``ideal-gas`` model instead.
+
 
 .. _sec-yaml-ideal-molal-solution:
 

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -23,6 +23,9 @@ namespace Cantera
  *
  * An ideal solution or an ideal gas approximation of a phase. Uses variable
  * pressure standard state methods for calculating thermodynamic properties.
+ *
+ * @deprecated "Gas" mode to be removed after Cantera 2.5. Use IdealGasPhase for
+ *     ideal gas phases instead.
  */
 class IdealSolnGasVPSS : public VPStandardStateTP
 {
@@ -62,7 +65,11 @@ public:
     }
 
     //! Set this phase to represent an ideal gas
-    void setGasMode() { m_idealGas = true; }
+    void setGasMode() {
+        warn_deprecated("IdealSolnGasVPSS::setGasMode",
+            "To be removed after Cantera 2.5. Use class IdealGasPhase instead.");
+        m_idealGas = true;
+    }
 
     //! Set this phase to represent an ideal liquid or solid solution
     void setSolnMode() { m_idealGas = false; }

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -1187,7 +1187,9 @@ class ctml2yamlTest(utilities.CanteraTest):
             Path(self.test_data_dir).joinpath("pdss_hkft.xml"),
             Path(self.test_work_dir).joinpath("pdss_hkft.yaml"),
         )
-
+        # @todo Remove "gas" mode test after Cantera 2.5 - "gas" mode of class
+        #     IdealSolnGasVPSS is deprecated
+        ct.suppress_deprecation_warnings()
         for name in ["vpss_gas_pdss_hkft_phase", "vpss_soln_pdss_hkft_phase"]:
             ctmlPhase = ct.ThermoPhase("pdss_hkft.xml", name=name)
             yamlPhase = ct.ThermoPhase("pdss_hkft.yaml", name=name)
@@ -1200,6 +1202,7 @@ class ctml2yamlTest(utilities.CanteraTest):
             self.assertEqual(ctmlPhase.element_names, yamlPhase.element_names)
             self.assertEqual(ctmlPhase.species_names, yamlPhase.species_names)
             self.checkThermo(ctmlPhase, yamlPhase, [300, 500])
+        ct.make_deprecation_warnings_fatal()
 
     def test_lattice_solid(self):
         ctml2yaml.convert(

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -1054,13 +1054,16 @@ class ctml2yamlTest(utilities.CanteraTest):
         self.checkThermo(ctmlGas, yamlGas, [300, 500, 1300, 2000])
         self.checkKinetics(ctmlGas, yamlGas, [900, 1800], [2e5, 20e5])
 
+    # @todo Remove after Cantera 2.5 - class FixedChemPotSSTP is deprecated
     def test_fixed_chemical_potential_thermo(self):
+        ct.suppress_deprecation_warnings()
         ctml2yaml.convert(
             Path(self.test_data_dir).joinpath("LiFixed.xml"),
             Path(self.test_work_dir).joinpath("LiFixed.yaml"),
         )
         ctmlGas, yamlGas = self.checkConversion("LiFixed")
         self.checkThermo(ctmlGas, yamlGas, [300, 500, 1300, 2000])
+        ct.make_deprecation_warnings_fatal()
 
     def test_water_IAPWS95_thermo(self):
         ctml2yaml.convert(

--- a/src/thermo/FixedChemPotSSTP.cpp
+++ b/src/thermo/FixedChemPotSSTP.cpp
@@ -23,22 +23,34 @@ namespace Cantera
 FixedChemPotSSTP::FixedChemPotSSTP() :
     chemPot_(0.0)
 {
+    warn_deprecated("class FixedChemPotSSTP", "To be removed after Cantera 2.5. "
+        "Use class StoichSubstance with a constant-cp species thermo model, "
+        "with 'h0' set to the desired chemical potential and 's0' set to 0.");
 }
 
 FixedChemPotSSTP::FixedChemPotSSTP(const std::string& infile, const std::string& id_) :
     chemPot_(0.0)
 {
+    warn_deprecated("class FixedChemPotSSTP", "To be removed after Cantera 2.5. "
+        "Use class StoichSubstance with a constant-cp species thermo model, "
+        "with 'h0' set to the desired chemical potential and 's0' set to 0.");
     initThermoFile(infile, id_);
 }
 FixedChemPotSSTP::FixedChemPotSSTP(XML_Node& xmlphase, const std::string& id_) :
     chemPot_(0.0)
 {
+    warn_deprecated("class FixedChemPotSSTP", "To be removed after Cantera 2.5. "
+        "Use class StoichSubstance with a constant-cp species thermo model, "
+        "with 'h0' set to the desired chemical potential and 's0' set to 0.");
     importPhase(xmlphase, this);
 }
 
 FixedChemPotSSTP::FixedChemPotSSTP(const std::string& Ename, doublereal val) :
     chemPot_(0.0)
 {
+    warn_deprecated("class FixedChemPotSSTP", "To be removed after Cantera 2.5. "
+        "Use class StoichSubstance with a constant-cp species thermo model, "
+        "with 'h0' set to the desired chemical potential and 's0' set to 0.");
     std::string pname = Ename + "Fixed";
     setName(pname);
     setNDim(3);

--- a/test/data/thermo-models.yaml
+++ b/test/data/thermo-models.yaml
@@ -93,6 +93,8 @@ phases:
   species: [KCl(l)]
   thermo: Margules
 
+# todo: Remove after Cantera 2.5 - the "gas" moode of class IdealSolnGasVPSS is
+# deprecated.
 - name: IdealSolnGas-gas
   thermo: ideal-gas-VPSS
   species: [{gas-species: [H2O, H2, O2]}]

--- a/test/data/thermo-models.yaml
+++ b/test/data/thermo-models.yaml
@@ -15,6 +15,7 @@ phases:
   transport: water
   species: [H2O(l)]
 
+# @todo Remove after Cantera 2.5 - class FixedChemPotSSTP is deprecated
 - name: Li-fixed
   thermo: fixed-chemical-potential
   species: [Li]

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -77,27 +77,31 @@ shared_ptr<Species> make_const_cp_species(const std::string& name,
     return species;
 }
 
-
+//! @todo Remove after Cantera 2.5 - class FixedChemPotSSTP is deprecated
 class FixedChemPotSstpConstructorTest : public testing::Test
 {
 };
 
 TEST_F(FixedChemPotSstpConstructorTest, fromXML)
 {
+    suppress_deprecation_warnings();
     std::unique_ptr<ThermoPhase> p(newPhase("../data/LiFixed.xml"));
     ASSERT_EQ((int) p->nSpecies(), 1);
     double mu;
     p->getChemPotentials(&mu);
     ASSERT_DOUBLE_EQ(-2.3e7, mu);
+    make_deprecation_warnings_fatal();
 }
 
 TEST_F(FixedChemPotSstpConstructorTest, SimpleConstructor)
 {
+    suppress_deprecation_warnings();
     FixedChemPotSSTP p("Li", -2.3e7);
     ASSERT_EQ((int) p.nSpecies(), 1);
     double mu;
     p.getChemPotentials(&mu);
     ASSERT_DOUBLE_EQ(-2.3e7, mu);
+    make_deprecation_warnings_fatal();
 }
 
 TEST(IonsFromNeutralConstructor, fromXML)

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -344,8 +344,11 @@ TEST_F(ConstructFromScratch, RedlichKwongMFTP_missing_coeffs)
     EXPECT_THROW(p.setState_TP(300, 200e5), CanteraError);
 }
 
+//! @todo Remove after Cantera 2.5 - "gas" mode of IdealSolnGasVPSS is
+//!     deprecated
 TEST_F(ConstructFromScratch, IdealSolnGasVPSS_gas)
 {
+    suppress_deprecation_warnings();
     IdealSolnGasVPSS p;
     p.addSpecies(sH2O);
     p.addSpecies(sH2);
@@ -367,6 +370,7 @@ TEST_F(ConstructFromScratch, IdealSolnGasVPSS_gas)
     EXPECT_NEAR(p.temperature(), 479.929, 1e-3); // based on h2o2.cti
     EXPECT_NEAR(p.moleFraction("H2O"), 0.01, 1e-4);
     EXPECT_NEAR(p.moleFraction("H2"), 0.0, 1e-4);
+    make_deprecation_warnings_fatal();
 }
 
 TEST(PureFluidFromScratch, CarbonDioxide)

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -234,9 +234,13 @@ TEST(ThermoFromYaml, IonsFromNeutral_fromString)
     EXPECT_NEAR(mu[1], -2.88157316e+06, 1e-1);
 }
 
+//! @todo Remove after Cantera 2.5 - "gas" mode of IdealSolnGasVPSS is
+//!     deprecated
 TEST(ThermoFromYaml, IdealSolnGas_gas)
 {
+    suppress_deprecation_warnings();
     auto thermo = newThermo("thermo-models.yaml", "IdealSolnGas-gas");
+    make_deprecation_warnings_fatal();
     thermo->equilibrate("HP");
     EXPECT_NEAR(thermo->temperature(), 479.929, 1e-3); // based on h2o2.cti
     EXPECT_NEAR(thermo->moleFraction("H2O"), 0.01, 1e-4);

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -120,13 +120,16 @@ TEST(ThermoFromYaml, WaterSSTP)
     EXPECT_NEAR(thermo->enthalpy_mass(), -15649685.52296013, 1e-6);
 }
 
+//! @todo Remove after Cantera 2.5 - class FixedChemPotSSTP is deprecated
 TEST(ThermoFromYaml, FixedChemPot)
 {
+    suppress_deprecation_warnings();
     auto thermo = newThermo("thermo-models.yaml", "Li-fixed");
     EXPECT_EQ(thermo->nSpecies(), (size_t) 1);
     double mu;
     thermo->getChemPotentials(&mu);
     EXPECT_DOUBLE_EQ(mu, -2.3e7);
+    make_deprecation_warnings_fatal();
 }
 
 TEST(ThermoFromYaml, Margules)

--- a/test_problems/VCSnonideal/LatticeSolid_LiSi/Li7Si3_ls.xml
+++ b/test_problems/VCSnonideal/LatticeSolid_LiSi/Li7Si3_ls.xml
@@ -25,7 +25,7 @@
          <transport model="None"/>
          <kinetics model="none"/>
        </phase>
-           
+
        <!-- phase Li7Si3_Interstitial  -->
 
        <phase dim="3" id="Li7Si3_Interstitial">
@@ -54,6 +54,18 @@
    
      </thermo>
    </phase> 
+
+   <phase dim="3" id="LiFixed">
+     <elementArray datasrc="elements.xml">
+        Li
+     </elementArray>
+     <speciesArray datasrc="#species_LiSi(S)"> LiFixed </speciesArray>
+     <thermo model="StoichSubstance">
+       <density units="g/cm3"> 0.534 </density>
+     </thermo>
+     <transport model="None"/>
+     <kinetics model="none"/>
+   </phase>
 
           
    <!-- species definitions     -->
@@ -148,6 +160,18 @@
       </thermo>
     </species>
 
+    <!-- species Li_Fixed  -->
+    <species name="LiFixed">
+      <atomArray> Li:1 </atomArray>
+      <thermo>
+        <const_cp Pref="1 bar" Tmax="5000.0" Tmin="100.0">
+           <t0 units="K">298.15</t0>
+           <h0 units="J/kmol"> -2.3e7 </h0>
+           <s0 units="J/mol/K"> 0.0 </s0>
+           <cp0 units="J/mol/K"> 0.0 </cp0>
+        </const_cp>
+      </thermo>
+    </species>
 
  
     </speciesData>

--- a/test_problems/VCSnonideal/LatticeSolid_LiSi/output_blessed.txt
+++ b/test_problems/VCSnonideal/LatticeSolid_LiSi/output_blessed.txt
@@ -5,7 +5,6 @@ um_li_chempot = -1.65555e+08
 Trying VCS equilibrium solver
 Unknown Cantera EOS to VCSnonideal: 'Margules'
 Unknown Cantera EOS to VCSnonideal: 'LatticeSolid'
-Unknown Cantera EOS to VCSnonideal: 'FixedChemPot'
 
 ================================================================================
 ================ Cantera_to_vprob: START OF PROBLEM STATEMENT ====================
@@ -24,7 +23,7 @@ Unknown Cantera EOS to VCSnonideal: 'FixedChemPot'
   PhaseName    PhaseNum SingSpec GasPhase EqnState NumSpec  TMolesInert       Tmoles(kmol)
 MoltenSalt_electrolyte     0     0        0 UnkType:      -1        2     0.000000e+00     1.000000e+01
 Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0.000000e+00     1.000000e+00
-         LiFixed     2     1        0 UnkType:      -1        1     0.000000e+00     1.000000e+02
+         LiFixed     2     1        0       Stoich Sub        1     0.000000e+00     1.000000e+02
 
 ================================================================================
 ================ Cantera_to_vprob: END OF PROBLEM STATEMENT ====================
@@ -49,7 +48,7 @@ Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0
   PhaseName    PhaseNum SingSpec GasPhase EqnState NumSpec  TMolesInert       Tmoles(kmol)
 MoltenSalt_electrolyte     0     0        0 UnkType:      -1        2     0.000000e+00     1.000000e+01
 Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0.000000e+00     1.000000e+00
-         LiFixed     2     1        0 UnkType:      -1        1     0.000000e+00     1.000000e+02
+         LiFixed     2     1        0       Stoich Sub        1     0.000000e+00     1.000000e+02
 
 ================================================================================
 ==================== Cantera_to_vprob: END OF PROBLEM STATEMENT ====================
@@ -78,7 +77,7 @@ Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0
   PhaseName    PhaseNum SingSpec  GasPhase    EqnState    NumSpec  TMolesInert      TKmoles
 MoltenSalt_electrolyte     0     0        0 UnkType:      -1        2     0.000000e+00     1.000000e+01
 Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0.000000e+00     1.000000e+00
-         LiFixed     2     1        0 UnkType:      -1        1     0.000000e+00     1.000000e+02
+         LiFixed     2     1        0       Stoich Sub        1     0.000000e+00     1.000000e+02
 
 Elemental Abundances:             Target_kmol    ElemType ElActive
                           Li  1.105050000000E+02    0         1
@@ -145,7 +144,7 @@ VCS CALCULATION METHOD
 --------------------------------------------------------------------------------
 		Temperature  =         6.3e+02 Kelvin
 		Pressure     =      1.0132e+05 Pa 
-		total Volume =         0.35041 m**3
+		total Volume =          1.6501 m**3
 
 
 --------------------------------------------------------------------------------
@@ -295,14 +294,14 @@ Moles: 100.005
 
        temperature   625.15 K
           pressure   1.0132e+05 Pa
-           density   0.001 kg/m^3
+           density   534 kg/m^3
   mean mol. weight   6.94 kg/kmol
    phase of matter   unspecified
 
                           1 kg             1 kmol     
                      ---------------   ---------------
           enthalpy       -2.3855e+07       -1.6556e+08  J
-   internal energy       -1.2399e+14       -8.6052e+14  J
+   internal energy       -2.3855e+07       -1.6556e+08  J
            entropy                 0                 0  J/K
     Gibbs function       -2.3855e+07       -1.6556e+08  J
  heat capacity c_p                 0                 0  J/K

--- a/test_problems/VCSnonideal/LatticeSolid_LiSi/verbose_blessed.txt
+++ b/test_problems/VCSnonideal/LatticeSolid_LiSi/verbose_blessed.txt
@@ -10,7 +10,6 @@ Unknown Cantera EOS to VCSnonideal: 'LatticeSolid'
 vcs_Cantera_convert: Species Type 8 not known 
 vcs_Cantera_convert: Species Type 1 not known 
 vcs_Cantera_convert: Species Type 1 not known 
-Unknown Cantera EOS to VCSnonideal: 'FixedChemPot'
 vcs_Cantera_convert: Species Type 1 not known 
 
 ================================================================================
@@ -30,7 +29,7 @@ vcs_Cantera_convert: Species Type 1 not known
   PhaseName    PhaseNum SingSpec GasPhase EqnState NumSpec  TMolesInert       Tmoles(kmol)
 MoltenSalt_electrolyte     0     0        0 UnkType:      -1        2     0.000000e+00     1.000000e+01
 Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0.000000e+00     1.000000e+00
-         LiFixed     2     1        0 UnkType:      -1        1     0.000000e+00     1.000000e+02
+         LiFixed     2     1        0       Stoich Sub        1     0.000000e+00     1.000000e+02
 
 ================================================================================
 ================ Cantera_to_vprob: END OF PROBLEM STATEMENT ====================
@@ -55,7 +54,7 @@ Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0
   PhaseName    PhaseNum SingSpec GasPhase EqnState NumSpec  TMolesInert       Tmoles(kmol)
 MoltenSalt_electrolyte     0     0        0 UnkType:      -1        2     0.000000e+00     1.000000e+01
 Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0.000000e+00     1.000000e+00
-         LiFixed     2     1        0 UnkType:      -1        1     0.000000e+00     1.000000e+02
+         LiFixed     2     1        0       Stoich Sub        1     0.000000e+00     1.000000e+02
 
 ================================================================================
 ==================== Cantera_to_vprob: END OF PROBLEM STATEMENT ====================
@@ -84,7 +83,7 @@ Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0
   PhaseName    PhaseNum SingSpec  GasPhase    EqnState    NumSpec  TMolesInert      TKmoles
 MoltenSalt_electrolyte     0     0        0 UnkType:      -1        2     0.000000e+00     1.000000e+01
 Li7Si3_and_Interstitials(S)     1     0        0 UnkType:      -1        3     0.000000e+00     1.000000e+00
-         LiFixed     2     1        0 UnkType:      -1        1     0.000000e+00     1.000000e+02
+         LiFixed     2     1        0       Stoich Sub        1     0.000000e+00     1.000000e+02
 
 Elemental Abundances:             Target_kmol    ElemType ElActive
                           Li  1.105050000000E+02    0         1
@@ -343,7 +342,7 @@ VCS CALCULATION METHOD
    --- Total tentative Dimensionless Gibbs Free Energy = -4.1206857517346E+03
    --- subroutine FORCE: Beginning Slope = -1.39826e-19
    --- subroutine FORCE: End Slope       = 9.31017e-32
-   --- subroutine FORCE produced no adjustments (al = 1)
+   --- subroutine FORCE produced no adjustments, s2 < 0
    -------------------------------------------------------------------------------------------------------
    --- Summary of the Update  (all species):
    ---      Species Status Initial_KMoles Final_KMoles Initial_Mu/RT     Mu/RT     Init_Del_G/RT   Delta_G/RT
@@ -384,7 +383,7 @@ VCS CALCULATION METHOD
 --------------------------------------------------------------------------------
 		Temperature  =         6.3e+02 Kelvin
 		Pressure     =      1.0132e+05 Pa 
-		total Volume =         0.35041 m**3
+		total Volume =          1.6501 m**3
 
 
 --------------------------------------------------------------------------------
@@ -534,14 +533,14 @@ Moles: 100.005
 
        temperature   625.15 K
           pressure   1.0132e+05 Pa
-           density   0.001 kg/m^3
+           density   534 kg/m^3
   mean mol. weight   6.94 kg/kmol
    phase of matter   unspecified
 
                           1 kg             1 kmol     
                      ---------------   ---------------
           enthalpy       -2.3855e+07       -1.6556e+08  J
-   internal energy       -1.2399e+14       -8.6052e+14  J
+   internal energy       -2.3855e+07       -1.6556e+08  J
            entropy                 0                 0  J/K
     Gibbs function       -2.3855e+07       -1.6556e+08  J
  heat capacity c_p                 0                 0  J/K

--- a/test_problems/VPsilane_test/silane_equil.cpp
+++ b/test_problems/VPsilane_test/silane_equil.cpp
@@ -9,12 +9,15 @@
 using namespace std;
 using namespace Cantera;
 
+//! @todo Remove this test after Cantera 2.5 - "gas" mode of class
+//!     IdealSolnGasVPSS is deprecated
 int main(int argc, char** argv)
 {
 #if defined(_MSC_VER) && _MSC_VER < 1900
     _set_output_format(_TWO_DIGIT_EXPONENT);
 #endif
     try {
+        suppress_deprecation_warnings();
         IdealSolnGasVPSS gg("silane.xml", "silane");
         ThermoPhase* g = &gg;
         cout.precision(4);


### PR DESCRIPTION
- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage

**Changes proposed in this pull request**
- Deprecate the "gas" mode of `IdealSolnGasVPSS` - this mode duplicates the more widely-used `IdealGasPhase` class.
- Deprecate `FixedChemPotSSTP` - this class can be easily replaced using the `StoichSubstance` class with a `ConstCpPoly` species thermo object.