### PR TITLE
Fix data path for Python module & fix YAML "reactions: none" option

### DIFF
--- a/interfaces/cython/cantera/__init__.py
+++ b/interfaces/cython/cantera/__init__.py
@@ -11,6 +11,7 @@ from .utils import *
 import os
 import sys
 add_directory(os.path.join(os.path.dirname(__file__), 'data'))
+add_directory('.')  # Move current working directory to the front of the path
 
 # Python interpreter used for converting mechanisms
 if 'PYTHON_CMD' not in os.environ:

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -113,7 +113,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
                 // 'reactions' section, if it exists
                 sections.push_back("reactions");
                 rules.push_back(reactionsNode.asString());
-            } else {
+            } else if (reactionsNode.asString() != "none") {
                 throw InputFileError("addReactions", reactionsNode,
                     "Phase entry implies existence of 'reactions' section "
                     "which does not exist in the current input file.");
@@ -153,7 +153,9 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
             kin.skipUndeclaredSpecies(false);
         } else if (rules[i] == "declared-species") {
             kin.skipUndeclaredSpecies(true);
-        } else if (rules[i] != "none") {
+        } else if (rules[i] == "none") {
+            continue;
+        } else {
             throw InputFileError("addReactions", phaseNode.at("reactions"),
                 "Unknown rule '{}' for adding species from the '{}' section.",
                 rules[i], sections[i]);

--- a/test/data/phase-reaction-spec1.yaml
+++ b/test/data/phase-reaction-spec1.yaml
@@ -4,6 +4,13 @@ phases:
   species: [{gri30.yaml/species: [O2, H2, H2O]}]
   thermo: ideal-gas
 
+  # should work fine (kinetics model with no reactions)
+- name: kinetics-reactions-none
+  species: [{gri30.yaml/species: [O2, H2, H2O]}]
+  thermo: ideal-gas
+  kinetics: gas
+  reactions: none
+
   # should be an error
 - name: kinetics-no-reaction-section1
   species: [{gri30.yaml/species: [O2, H2, H2O]}]

--- a/test/data/phase-reaction-spec2.yaml
+++ b/test/data/phase-reaction-spec2.yaml
@@ -10,6 +10,13 @@ phases:
   thermo: ideal-gas
   kinetics: gas
 
+  # should work fine (no reactions)
+- name: kinetics-reactions-none
+  species: [{gri30.yaml/species: [O2, H2, H2O]}]
+  thermo: ideal-gas
+  kinetics: gas
+  reactions: none
+
   # should be an error
 - name: nokinetics-reactions
   species: [{gri30.yaml/species: [O2, H2, H2O]}]

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -268,6 +268,22 @@ TEST(KineticsFromYaml, NoKineticsModelOrReactionsField2)
     EXPECT_EQ(soln->kinetics()->nReactions(), (size_t) 0);
 }
 
+TEST(KineticsFromYaml, KineticsModelWithReactionsNone1)
+{
+    auto soln = newSolution("phase-reaction-spec1.yaml",
+                            "kinetics-reactions-none");
+    EXPECT_EQ(soln->kinetics()->kineticsType(), "Gas");
+    EXPECT_EQ(soln->kinetics()->nReactions(), (size_t) 0);
+}
+
+TEST(KineticsFromYaml, KineticsModelWithReactionsNone2)
+{
+    auto soln = newSolution("phase-reaction-spec2.yaml",
+                            "kinetics-reactions-none");
+    EXPECT_EQ(soln->kinetics()->kineticsType(), "Gas");
+    EXPECT_EQ(soln->kinetics()->nReactions(), (size_t) 0);
+}
+
 TEST(KineticsFromYaml, KineticsModelWithoutReactionsSection1)
 {
     EXPECT_THROW(newSolution("phase-reaction-spec1.yaml",


### PR DESCRIPTION
**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #788

**Changes proposed in this pull request**

- Moves the current working directory ahead of 'data' in the search path when using the Python module
- Fix logic for using the "reactions: none" option when there is no "reactions" section in the YAML file