### PR TITLE
Add --extra option to ck2yaml

### DIFF
--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -39,8 +39,8 @@ duplicate transport data) to be ignored. The '--name=<name>' option
 is used to override default phase names (i.e. 'gas').
 
 The '--extra=<filename>' option takes a YAML file as input. This option can be
-used to specify an alternative file description, or to define custom fields that
-are included in the YAML output.
+used to add to the file description, or to define custom fields that are 
+included in the YAML output.
 """
 
 from collections import defaultdict, OrderedDict
@@ -1355,7 +1355,9 @@ class Parser:
         # replace header lines
         if 'description' in yml:
             if isinstance(yml['description'], str):
-                self.header_lines = yml.pop('description').split('\n')
+                if self.header_lines:
+                    self.header_lines += ['']
+                self.header_lines += yml.pop('description').split('\n')
             else:
                 raise InputError("The alternate description provided in "
                     "'{}' needs to be a string".format(path))

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1388,10 +1388,13 @@ class Parser:
             line, comment = readline()
             advance = True
             inHeader = True
+            header = []
+            indent = 80
             while line is not None:
                 tokens = line.split() or ['']
                 if inHeader and not line.strip():
-                    self.header_lines.append(comment.rstrip())
+                    header.append(comment.rstrip())
+                    indent = min(indent, re.search('[^ ]', comment).start())
 
                 if tokens[0].upper().startswith('ELEM'):
                     inHeader = False
@@ -1773,6 +1776,9 @@ class Parser:
                 else:
                     advance = True
 
+        for h in header:
+            self.header_lines.append(h[indent:])
+            
         self.check_duplicate_reactions()
 
         for index, reaction in enumerate(self.reactions):

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -39,7 +39,7 @@ duplicate transport data) to be ignored. The '--name=<name>' option
 is used to override default phase names (i.e. 'gas').
 
 The '--extra=<filename>' option takes a YAML file as input. This option can be
-used to add to the file description, or to define custom fields that are 
+used to add to the file description, or to define custom fields that are
 included in the YAML output.
 """
 
@@ -1350,7 +1350,7 @@ class Parser:
         if reserved:
             raise InputError("The YAML file '{}' provided as '--extra' input "
                 "must not redefine reserved field name: "
-                "{}".format(path, reserved))
+                "'{}'".format(path, reserved))
 
         # replace header lines
         if 'description' in yml:
@@ -1780,7 +1780,7 @@ class Parser:
 
         for h in header:
             self.header_lines.append(h[indent:])
-            
+
         self.check_duplicate_reactions()
 
         for index, reaction in enumerate(self.reactions):
@@ -2132,7 +2132,7 @@ def main(argv):
     if '--id' in options:
         phase_name = options.get('--id', 'gas')
         logging.warning("\nFutureWarning: "
-                        "option '--id=...' is superseded by '--name=...'")
+                        "Option '--id=...' will be replaced by '--name=...'")
     else:
         phase_name = options.get('--name', 'gas')
 
@@ -2141,10 +2141,7 @@ def main(argv):
               ' must be provided.\nRun "ck2yaml.py --help" to see usage help.')
         sys.exit(1)
 
-    if '--extra' in options:
-        extra_file = options['--extra']
-    else:
-        extra_file = None
+    extra_file = options.get('--extra')
 
     if '--output' in options:
         out_name = options['--output']

--- a/interfaces/cython/cantera/test/data/extra.yaml
+++ b/interfaces/cython/cantera/test/data/extra.yaml
@@ -1,0 +1,9 @@
+description: |-
+  This is an alternative description.
+
+foo:
+- spam
+- eggs
+
+bar:
+  spam: eggs

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -454,9 +454,8 @@ class ck2yamlTest(converterTestCommon, utilities.CanteraTest):
         with open(output, 'rt', encoding="utf-8") as stream:
             yml = yaml.safe_load(stream)
 
-        desc = yml['description']
-        self.assertEqual(yml['description'],
-                         'This is an alternative description.')
+        desc = yml['description'].split('\n')[-1]
+        self.assertEqual(desc, 'This is an alternative description.')
         for key in ['foo', 'bar']:
             self.assertIn(key, yml.keys())
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Addresses Cantera/enhancements#15, #339

Alternative to #777

**Changes proposed in this pull request**

The `--extra` option takes a YAML file as input and adds the following abilities:
- specify alternate description string
- copy (user-defined) custom fields to YAML output

**Example**
```
ck2yaml --input=gri30.inp --output=gri30.yaml \
--thermo=gri30_thermo.dat --transport=gri30_tran.dat --name=gri30 --extra=extra.yaml
```
with `extra.yaml` being
```yaml
description: |-
  Updated webpage at http://combustion.berkeley.edu/gri-mech/version30/text30.html

foo:
- spam
- eggs

bar:
  spam: eggs
```
(the `description` is *different* from the original header due to the added last line)

While not addressed directly, references (i.e. #339) can be easily added by specifying an *alternate* `description` field in the `--extra` file.