### PR TITLE
Handle deprecation warnings from all sources consistently in Python

### DIFF
--- a/interfaces/cython/cantera/__init__.py
+++ b/interfaces/cython/cantera/__init__.py
@@ -10,6 +10,9 @@ from .utils import *
 
 import os
 import sys
+import warnings
+
+warnings.filterwarnings('default', module='cantera')
 add_directory(os.path.join(os.path.dirname(__file__), 'data'))
 
 # Python interpreter used for converting mechanisms

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -73,8 +73,6 @@ class TestModels(utilities.CanteraTest):
             self.assertArrayNear(a.P, b.P)
             self.assertArrayNear(a.X, b.X)
 
-        warnings.simplefilter("always")
-
         for ph in self.yml['phases']:
 
             skipped = ['pure-fluid']

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -1,5 +1,6 @@
 import itertools
 import numpy as np
+import warnings
 
 import cantera as ct
 from . import utilities
@@ -78,6 +79,17 @@ class TestPureFluid(utilities.CanteraTest):
         self.water.TP = 300, 101325
         with self.assertRaises(ValueError):
             self.water.Q = 0.3
+
+    def test_X_deprecated(self):
+        with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
+            X = self.water.X
+            self.water.TPX = 300, 101325, 1
+
+            self.assertEqual(len(w), 2)
+            for warning in w:
+                self.assertTrue(issubclass(warning.category, DeprecationWarning))
+                self.assertIn("after Cantera 2.5", str(warning.message))
 
     def test_set_minmax(self):
         self.water.TP = self.water.min_temp, 101325

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -329,9 +329,9 @@ class TestThermoPhase(utilities.CanteraTest):
 
     def test_phase(self):
         self.assertEqual(self.phase.name, 'ohmech')
-        warnings.simplefilter("always")
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             self.assertEqual(self.phase.ID, 'ohmech')
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
@@ -339,6 +339,7 @@ class TestThermoPhase(utilities.CanteraTest):
                           str(w[-1].message))
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             self.phase.ID = 'something'
             self.assertEqual(self.phase.name, 'something')
             self.assertEqual(len(w), 1)
@@ -347,6 +348,7 @@ class TestThermoPhase(utilities.CanteraTest):
                           str(w[-1].message))
 
         with warnings.catch_warnings(record=True) as w:
+            warnings.simplefilter("always")
             gas = ct.Solution('h2o2.cti', phaseid='ohmech')
             self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, FutureWarning))

--- a/interfaces/cython/cantera/test/utilities.py
+++ b/interfaces/cython/cantera/test/utilities.py
@@ -32,6 +32,7 @@ class CanteraTest(unittest.TestCase):
         else:
             cls.test_work_dir = tempfile.mkdtemp()
 
+        cantera.make_deprecation_warnings_fatal()
         cantera.add_directory(cls.test_work_dir)
         cls.test_data_dir = os.path.abspath(os.path.join(os.path.dirname(__file__), 'data'))
         cls.cantera_data = os.path.abspath(os.path.join(

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -3,6 +3,7 @@
 
 import sys
 import os
+import warnings
 from cpython.ref cimport PyObject
 
 cdef CxxPythonLogger* _logger = new CxxPythonLogger()
@@ -38,9 +39,17 @@ def appdelete():
     CxxAppdelete()
 
 def make_deprecation_warnings_fatal():
+    warnings.filterwarnings('error', category=DeprecationWarning,
+                            module='cantera')  # for warnings in Python code
+    warnings.filterwarnings('error', category=DeprecationWarning,
+                            message='.*Cantera.*')  # for warnings in Cython code
     Cxx_make_deprecation_warnings_fatal()
 
 def suppress_deprecation_warnings():
+    warnings.filterwarnings('ignore', category=DeprecationWarning,
+                            module='cantera')  # for warnings in Python code
+    warnings.filterwarnings('ignore', category=DeprecationWarning,
+                            message='.*Cantera.*')  # for warnings in Cython code
     Cxx_suppress_deprecation_warnings()
 
 def suppress_thermo_warnings(pybool suppress=True):

--- a/test/python/runCythonTests.py
+++ b/test/python/runCythonTests.py
@@ -20,9 +20,7 @@ a single test:
 
 import sys
 import os
-import warnings
 
-warnings.simplefilter('default')
 cantera_root = os.path.relpath(__file__).split(os.sep)[:-1] + ['..', '..']
 module_path = os.path.abspath(os.sep.join(cantera_root + ['build']))
 

--- a/test/python/runCythonTests.py
+++ b/test/python/runCythonTests.py
@@ -36,8 +36,6 @@ from cantera.test.utilities import unittest
 import cantera
 import cantera.test
 
-cantera.make_deprecation_warnings_fatal()
-
 class TestResult(unittest.TextTestResult):
     def __init__(self, *args, **kwargs):
         unittest.TextTestResult.__init__(self, *args, **kwargs)


### PR DESCRIPTION
**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #791

**Changes proposed in this pull request**

Since deprecation warnings issued from C++ and from Cython code are shown by default, set deprecation warnings issued from Python code to do the same.

Also, modify handling of Cython- and Python- issued deprecation warnings when calling the `make_deprecation_warnings_fatal` and `suppress_deprecation_warnings` functions.
