### PR TITLE
Implement Func1-derived tabulated functions

### DIFF
--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -275,45 +275,18 @@ public:
 };
 
 
-//! implements a tabulated function
+//! The Tabulated1 class implements a tabulated function
 class Tabulated1 : public Func1
 {
 public:
-    Tabulated1(const std::vector<double>& tvec, const std::vector<double>& fvec,
-               const std::string& method = "linear") :
-        Func1() {
-        if (tvec.size() != fvec.size()) {
-            throw CanteraError("Tabulated1::Tabulated1",
-                               "sizes of vectors do not match ({} vs {}).",
-                               tvec.size(), fvec.size());
-        } else if (tvec.empty()) {
-            throw CanteraError("Tabulated1::Tabulated1",
-                               "vectors must not be empty.");
-        }
-        m_tvec = tvec;
-        m_fvec = fvec;
-        if (method == "linear") {
-            m_isLinear = true;
-        } else if (method == "previous") {
-            m_isLinear = false;
-        } else {
-            throw CanteraError("Tabulated1::Tabulated1",
-                               "interpolation method '{}' is not implemented",
-                               method);
-        }
-    }
-
-    Tabulated1(const Tabulated1& b) :
-        Func1(b) {
-    }
-
-    Tabulated1& operator=(const Tabulated1& right) {
-        if (&right == this) {
-            return *this;
-        }
-        Func1::operator=(right);
-        return *this;
-    }
+    //! Constructor.
+    /*!
+     * @param tvec   Vector of time values
+     * @param fvec   Vector of values
+     * @param method Interpolation method ('linear' or 'previous')
+     */
+    Tabulated1(const vector_fp& tvec, const vector_fp& fvec,
+               const std::string& method = "linear");
 
     virtual std::string write(const std::string& arg) const;
     virtual int ID() const {
@@ -330,19 +303,21 @@ public:
 
     virtual Func1& derivative() const;
 private:
-    std::vector<double> m_tvec;
-    std::vector<double> m_fvec;
-    bool m_isLinear;
+    vector_fp m_tvec; //!< Vector of time values
+    vector_fp m_fvec; //!< Vector of function values
+    bool m_isLinear; //!< Boolean indicating interpolation method
 };
 
 
-/**
- * Constant.
- */
+//! The Const1 class implements a constant
 class Const1 : public Func1
 {
 public:
-    Const1(doublereal A) :
+    //! Constructor.
+    /*!
+     * @param A   Constant
+     */
+    Const1(double A) :
         Func1() {
         m_c = A;
     }

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -9,6 +9,7 @@
 #define CT_FUNC1_H
 
 #include "cantera/base/ct_defs.h"
+#include "cantera/base/ctexceptions.h"
 
 #include <iostream>
 
@@ -32,6 +33,7 @@ const int CosFuncType = 102;
 const int ExpFuncType = 104;
 const int PowFuncType = 106;
 const int ConstFuncType = 110;
+const int TabulatedFuncType = 120;
 
 class TimesConstant1;
 
@@ -123,6 +125,7 @@ Func1& newCompositeFunction(Func1& f1, Func1& f2);
 Func1& newTimesConstFunction(Func1& f1, doublereal c);
 Func1& newPlusConstFunction(Func1& f1, doublereal c);
 
+
 //! implements the sin() function
 /*!
  * The argument to sin() is in radians
@@ -165,7 +168,11 @@ public:
     virtual Func1& derivative() const;
 };
 
-/// cos
+
+//! implements the cos() function
+/*!
+ * The argument to cos() is in radians
+ */
 class Cos1 : public Func1
 {
 public:
@@ -200,7 +207,8 @@ public:
     virtual Func1& derivative() const;
 };
 
-/// exp
+
+//! implements the exponential function
 class Exp1 : public Func1
 {
 public:
@@ -233,7 +241,8 @@ public:
     virtual Func1& derivative() const;
 };
 
-/// pow
+
+//! implements the power function (pow)
 class Pow1 : public Func1
 {
 public:
@@ -264,6 +273,53 @@ public:
     }
     virtual Func1& derivative() const;
 };
+
+
+//! implements a tabulated function
+class Tabulated1 : public Func1
+{
+public:
+    Tabulated1(const std::vector<double>& tvec, const std::vector<double>& fvec) :
+        Func1() {
+        if (tvec.size() != fvec.size()) {
+            throw CanteraError("Tabulated1::Tabulated1",
+                               "sizes of vectors do not match ({} vs {}).",
+                               tvec.size(), fvec.size());
+        } else if (tvec.empty()) {
+            throw CanteraError("Tabulated1::Tabulated1",
+                               "vectors must not be empty.");
+        }
+        m_tvec = tvec;
+        m_fvec = fvec;
+    }
+
+    Tabulated1(const Tabulated1& b) :
+        Func1(b) {
+    }
+
+    Tabulated1& operator=(const Tabulated1& right) {
+        if (&right == this) {
+            return *this;
+        }
+        Func1::operator=(right);
+        return *this;
+    }
+
+    virtual std::string write(const std::string& arg) const;
+    virtual int ID() const {
+        return TabulatedFuncType;
+    }
+    virtual double eval(double t) const;
+    virtual Func1& duplicate() const {
+        return *(new Tabulated1(m_tvec, m_fvec));
+    }
+
+    virtual Func1& derivative() const;
+private:
+    std::vector<double> m_tvec;
+    std::vector<double> m_fvec;
+};
+
 
 /**
  * Constant.

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -279,7 +279,8 @@ public:
 class Tabulated1 : public Func1
 {
 public:
-    Tabulated1(const std::vector<double>& tvec, const std::vector<double>& fvec) :
+    Tabulated1(const std::vector<double>& tvec, const std::vector<double>& fvec,
+               const std::string& method = "linear") :
         Func1() {
         if (tvec.size() != fvec.size()) {
             throw CanteraError("Tabulated1::Tabulated1",
@@ -291,6 +292,15 @@ public:
         }
         m_tvec = tvec;
         m_fvec = fvec;
+        if (method == "linear") {
+            m_isLinear = true;
+        } else if (method == "previous") {
+            m_isLinear = false;
+        } else {
+            throw CanteraError("Tabulated1::Tabulated1",
+                               "interpolation method '{}' is not implemented",
+                               method);
+        }
     }
 
     Tabulated1(const Tabulated1& b) :
@@ -311,13 +321,18 @@ public:
     }
     virtual double eval(double t) const;
     virtual Func1& duplicate() const {
-        return *(new Tabulated1(m_tvec, m_fvec));
+        if (m_isLinear) {
+            return *(new Tabulated1(m_tvec, m_fvec, "linear"));
+        } else {
+            return *(new Tabulated1(m_tvec, m_fvec, "previous"));
+        }
     }
 
     virtual Func1& derivative() const;
 private:
     std::vector<double> m_tvec;
     std::vector<double> m_fvec;
+    bool m_isLinear;
 };
 
 

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -281,11 +281,12 @@ class Tabulated1 : public Func1
 public:
     //! Constructor.
     /*!
-     * @param tvec   Vector of time values
-     * @param fvec   Vector of values
+     * @param n      Size of tabulated value arrays
+     * @param tvals   Pointer to time value array
+     * @param fvals   Pointer to function value array
      * @param method Interpolation method ('linear' or 'previous')
      */
-    Tabulated1(const vector_fp& tvec, const vector_fp& fvec,
+    Tabulated1(size_t n, const double* tvals, const double* fvals,
                const std::string& method = "linear");
 
     virtual std::string write(const std::string& arg) const;
@@ -295,9 +296,11 @@ public:
     virtual double eval(double t) const;
     virtual Func1& duplicate() const {
         if (m_isLinear) {
-            return *(new Tabulated1(m_tvec, m_fvec, "linear"));
+            return *(new Tabulated1(m_tvec.size(), &m_tvec[0], &m_fvec[0],
+                                    "linear"));
         } else {
-            return *(new Tabulated1(m_tvec, m_fvec, "previous"));
+            return *(new Tabulated1(m_tvec.size(), &m_tvec[0], &m_fvec[0],
+                                    "previous"));
         }
     }
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -40,7 +40,7 @@ cdef extern from "cantera/cython/funcWrapper.h":
 
 cdef extern from "cantera/numerics/Func1.h":
     cdef cppclass CxxTabulated1 "Cantera::Tabulated1":
-        CxxTabulated1(vector[double]&, vector[double]&, string) except +translate_exception
+        CxxTabulated1(int, double*, double*, string) except +translate_exception
         double eval(double) except +translate_exception
 
     cdef cppclass CxxConst1 "Cantera::Const1":

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -43,10 +43,6 @@ cdef extern from "cantera/numerics/Func1.h":
         CxxTabulated1(int, double*, double*, string) except +translate_exception
         double eval(double) except +translate_exception
 
-    cdef cppclass CxxConst1 "Cantera::Const1":
-        CxxConst1(double) except +translate_exception
-        double eval(double) except +translate_exception
-
 cdef extern from "cantera/base/xml.h" namespace "Cantera":
     cdef cppclass XML_Node:
         XML_Node* findByName(string)
@@ -1021,7 +1017,8 @@ cdef class Func1:
     cdef object callable
     cdef object exception
     cpdef void _set_callback(self, object) except *
-    cpdef void _set_const(self, double) except *
+
+cdef class TabulatedFunction(Func1):
     cpdef void _set_tables(self, object, object, string) except *
 
 cdef class ReactorBase:

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -38,6 +38,11 @@ cdef extern from "cantera/cython/funcWrapper.h":
         CxxFunc1(callback_wrapper, void*)
         double eval(double) except +translate_exception
 
+cdef extern from "cantera/numerics/Func1.h":
+    cdef cppclass CxxTabulated1 "Cantera::Tabulated1":
+        CxxTabulated1(vector[double]&, vector[double]&) except +translate_exception
+        double eval(double) except +translate_exception
+
 cdef extern from "cantera/base/xml.h" namespace "Cantera":
     cdef cppclass XML_Node:
         XML_Node* findByName(string)
@@ -1011,6 +1016,8 @@ cdef class Func1:
     cdef CxxFunc1* func
     cdef object callable
     cdef object exception
+    cpdef void __set_callback(self, object) except *
+    cpdef void __set_tables(self, object, object) except *
 
 cdef class ReactorBase:
     cdef CxxReactorBase* rbase

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -43,6 +43,10 @@ cdef extern from "cantera/numerics/Func1.h":
         CxxTabulated1(vector[double]&, vector[double]&) except +translate_exception
         double eval(double) except +translate_exception
 
+    cdef cppclass CxxConst1 "Cantera::Const1":
+        CxxConst1(double) except +translate_exception
+        double eval(double) except +translate_exception
+
 cdef extern from "cantera/base/xml.h" namespace "Cantera":
     cdef cppclass XML_Node:
         XML_Node* findByName(string)
@@ -1016,8 +1020,9 @@ cdef class Func1:
     cdef CxxFunc1* func
     cdef object callable
     cdef object exception
-    cpdef void __set_callback(self, object) except *
-    cpdef void __set_tables(self, object, object) except *
+    cpdef void _set_callback(self, object) except *
+    cpdef void _set_const(self, double) except *
+    cpdef void _set_tables(self, object, object) except *
 
 cdef class ReactorBase:
     cdef CxxReactorBase* rbase

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -40,7 +40,7 @@ cdef extern from "cantera/cython/funcWrapper.h":
 
 cdef extern from "cantera/numerics/Func1.h":
     cdef cppclass CxxTabulated1 "Cantera::Tabulated1":
-        CxxTabulated1(vector[double]&, vector[double]&) except +translate_exception
+        CxxTabulated1(vector[double]&, vector[double]&, string) except +translate_exception
         double eval(double) except +translate_exception
 
     cdef cppclass CxxConst1 "Cantera::Const1":
@@ -1022,7 +1022,7 @@ cdef class Func1:
     cdef object exception
     cpdef void _set_callback(self, object) except *
     cpdef void _set_const(self, double) except *
-    cpdef void _set_tables(self, object, object) except *
+    cpdef void _set_tables(self, object, object, string) except *
 
 cdef class ReactorBase:
     cdef CxxReactorBase* rbase

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -2,6 +2,7 @@
 # at https://cantera.org/license.txt for license and copyright information.
 
 import sys
+from numbers import Real as _real
 
 cdef double func_callback(double t, void* obj, void** err):
     """
@@ -46,35 +47,97 @@ cdef class Func1:
         >>> f3(6)
         30.0
 
-    For simplicity, constant functions can be defined by passing the constant
+    For simplicity, constant functions can be defined by passing a constant
     value directly::
 
         >>> f4 = Func1(2.5)
         >>> f4(0.1)
         2.5
 
+    A `Func1` object representing a tabulated function is defined by sample
+    points and corresponding function values. Inputs are specified either by
+    two iterable objects containing sample point location and function values,
+    or a single array that concatenates those inputs in two columns. Between
+    sample points, values are evaluated using a linear interpolation, whereas
+    outside the sample interval, the value at the closest end point is returned.
+    Examples for tabulated `Func1` object are::
+
+        >>> t1 = Func1([[0, 2], [1, 1], [2, 0]])
+        >>> [t1(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
+        [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
+
+        >>> t2 = Func1([0, 1, 2], [2, 1, 0])
+        >>> [t2(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
+        [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
+
+        >>> t3 = Func1(np.array([0, 1, 2]), (2, 1, 0))
+        >>> [t3(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
+        [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
+
     Note that all methods which accept `Func1` objects will also accept the
     callable object and create the wrapper on their own, so it is generally
     unnecessary to explicitly create a `Func1` object.
     """
-    def __cinit__(self, c):
+    def __cinit__(self, *args, **kwargs):
         self.exception = None
-        if hasattr(c, '__call__'):
-            self.callable = c
-        else:
-            try:
-                # calling float() converts numpy arrays of size 1 to scalars
-                k = float(c)
-            except TypeError:
-                if hasattr(c, '__len__') and len(c) == 1:
-                    # Handle lists or tuples with a single element
-                    k = float(c[0])
-                else:
-                    raise TypeError('Func1 must be constructed from a number or'
-                                    ' a callable object')
-            self.callable = lambda t: k
+        self.callable = None
 
+    def __init__(self, *args):
+        if len(args) == 1:
+            c = args[0]
+            if hasattr(c, '__call__'):
+                # callback function
+                self.__set_callback(c)
+            else:
+                arr = np.array(c)
+                try:
+                    if arr.ndim == 0:
+                        # handle constants or unsized numpy arrays
+                        k = float(c)
+                        self.__set_callback(lambda t: k)
+                    elif arr.size == 1:
+                        # handle lists, tuples or numpy arrays with a single element
+                        k = float(c[0])
+                        self.__set_callback(lambda t: k)
+                    elif arr.ndim == 2:
+                        # tabulated function (single argument)
+                        if arr.shape[1] == 2:
+                            time = arr[:, 0]
+                            fval = arr[:, 1]
+                            self.__set_tables(time, fval)
+                        else:
+                            raise ValueError(
+                                "Invalid dimensions: specification of "
+                                "tabulated function with a single array "
+                                "requires two columns")
+                    else:
+                        raise TypeError
+
+                except TypeError:
+                    raise TypeError(
+                        "Func1 must be constructed from a callable object, "
+                        "a number or a numeric array with two columns")
+
+        elif len(args) == 2:
+            # tabulated function (two arguments mimic C++ interface)
+            time, fval = args
+            self.__set_tables(time, fval)
+
+        else:
+            raise ValueError("Invalid number of arguments")
+
+
+    cpdef void __set_callback(self, c) except *:
+        self.callable = c
         self.func = new CxxFunc1(func_callback, <void*>self)
+
+    cpdef void __set_tables(self, time, fval) except *:
+        cdef vector[double] tvec, fvec
+        for t in time:
+            tvec.push_back(t)
+        for f in fval:
+            fvec.push_back(f)
+        self.func = <CxxFunc1*>(new CxxTabulated1(tvec, fvec))
 
     def __dealloc__(self):
         del self.func

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -110,25 +110,32 @@ cdef class TabulatedFunction(Func1):
     by two iterable objects containing sample point location and function
     values, or a single array that concatenates those inputs in two rows or
     columns. Between sample points, values are evaluated based on the optional
-    keyword argument 'method'; options are 'linear' (linear interpolation,
-    default) or 'previous' (nearest previous value). Outside the sample
-    interval, the value at the closest end point is returned.
+    argument ``method``, which has to be supplied as a keyword; options are 
+    ``'linear'`` (linear interpolation, default) or ``'previous'`` (nearest 
+    previous value). Outside the sample interval, the value at the closest end 
+    point is returned.
 
-    Examples for `TabulatedFunction` objects are::
+    Examples for `TabulatedFunction` objects using a single (two-dimensional)
+    array as input are::
 
         >>> t1 = TabulatedFunction([[0, 2], [1, 1], [2, 0]])
         >>> [t1(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
         [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
 
-        >>> t2 = TabulatedFunction([[0, 2], [1, 1], [2, 0]], method='previous')
+        >>> t2 = TabulatedFunction(np.array([0, 1, 2]), (2, 1, 0))
         >>> [t2(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
-        [2.0, 2.0, 2.0, 1.0, 0.0, 0.0]
-
-        >>> t3 = TabulatedFunction([0, 1, 2], [2, 1, 0])
-        >>> [t3(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
         [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
 
-        >>> t4 = TabulatedFunction(np.array([0, 1, 2]), (2, 1, 0))
+    where the optional ``method`` keyword argument changes the type of
+    interpolation from the ``'linear'`` default to ``'previous'``::
+
+        >>> t3 = TabulatedFunction([[0, 2], [1, 1], [2, 0]], method='previous')
+        >>> [t3(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
+        [2.0, 2.0, 2.0, 1.0, 0.0, 0.0]
+
+    Alternatively, a `TabulatedFunction` can be defined using two input arrays::
+
+        >>> t4 = TabulatedFunction([0, 1, 2], [2, 1, 0])
         >>> [t4(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
         [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
     """
@@ -150,9 +157,8 @@ cdef class TabulatedFunction(Func1):
                                      "requires two rows or columns")
                 self._set_tables(time, fval, stringify(method))
             else:
-                raise TypeError(
-                    "'TabulatedFunction' must be constructed from "
-                    "a numeric array with two columns")
+                raise TypeError("'TabulatedFunction' must be constructed from "
+                                "a numeric array with two dimensions")
 
         elif len(args) == 2:
             # tabulated function (two arrays mimic C++ interface)

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -106,68 +106,33 @@ cdef class Func1:
 cdef class TabulatedFunction(Func1):
     """
     A `TabulatedFunction` object representing a tabulated function is defined by
-    sample points and corresponding function values. Inputs are specified either
-    by two iterable objects containing sample point location and function
-    values, or a single array that concatenates those inputs in two rows or
-    columns. Between sample points, values are evaluated based on the optional
-    argument ``method``, which has to be supplied as a keyword; options are 
-    ``'linear'`` (linear interpolation, default) or ``'previous'`` (nearest 
-    previous value). Outside the sample interval, the value at the closest end 
-    point is returned.
+    sample points and corresponding function values. Inputs are specified by
+    two iterable objects containing sample point location and function values.
+    Between sample points, values are evaluated based on the optional argument
+    ``method``; options are ``'linear'`` (linear interpolation, default) or
+    ``'previous'`` (nearest previous value). Outside the sample interval, the
+    value at the closest end point is returned.
 
-    Examples for `TabulatedFunction` objects using a single (two-dimensional)
-    array as input are::
+    Examples for `TabulatedFunction` objects are::
 
-        >>> t1 = TabulatedFunction([[0, 2], [1, 1], [2, 0]])
+        >>> t1 = TabulatedFunction([0, 1, 2], [2, 1, 0])
         >>> [t1(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
         [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
 
-        >>> t2 = TabulatedFunction(np.array([0, 1, 2]), (2, 1, 0))
+        >>> t2 = TabulatedFunction(np.array([0, 1, 2]), np.array([2, 1, 0]))
         >>> [t2(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
         [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
 
-    where the optional ``method`` keyword argument changes the type of
-    interpolation from the ``'linear'`` default to ``'previous'``::
+    The optional ``method`` keyword argument changes the type of interpolation
+    from the ``'linear'`` default to ``'previous'``::
 
-        >>> t3 = TabulatedFunction([[0, 2], [1, 1], [2, 0]], method='previous')
+        >>> t3 = TabulatedFunction([0, 1, 2], [2, 1, 0], method='previous')
         >>> [t3(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
         [2.0, 2.0, 2.0, 1.0, 0.0, 0.0]
-
-    Alternatively, a `TabulatedFunction` can be defined using two input arrays::
-
-        >>> t4 = TabulatedFunction([0, 1, 2], [2, 1, 0])
-        >>> [t4(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]]
-        [2.0, 2.0, 1.5, 0.5, 0.0, 0.0]
     """
 
-    def __init__(self, *args, method='linear'):
-        if len(args) == 1:
-            # tabulated function (single argument)
-            arr = np.array(args[0])
-            if arr.ndim == 2:
-                if arr.shape[1] == 2:
-                    time = arr[:, 0]
-                    fval = arr[:, 1]
-                elif arr.shape[0] == 2:
-                    time = arr[0, :]
-                    fval = arr[1, :]
-                else:
-                    raise ValueError("Invalid dimensions: specification of "
-                                     "tabulated function with a single array "
-                                     "requires two rows or columns")
-                self._set_tables(time, fval, stringify(method))
-            else:
-                raise TypeError("'TabulatedFunction' must be constructed from "
-                                "a numeric array with two dimensions")
-
-        elif len(args) == 2:
-            # tabulated function (two arrays mimic C++ interface)
-            time, fval = args
-            self._set_tables(time, fval, stringify(method))
-
-        else:
-            raise ValueError("Invalid number of arguments (one or two "
-                             "arguments containing tabulated values)")
+    def __init__(self, time, fval, method='linear'):
+        self._set_tables(time, fval, stringify(method))
 
     cpdef void _set_tables(self, time, fval, string method) except *:
         tt = np.asarray(time, dtype=np.double)

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -144,12 +144,19 @@ cdef class Func1:
         self.func = <CxxFunc1*>(new CxxConst1(c))
 
     cpdef void _set_tables(self, time, fval, string method) except *:
-        cdef vector[double] tvec, fvec
-        for t in time:
-            tvec.push_back(t)
-        for f in fval:
-            fvec.push_back(f)
-        self.func = <CxxFunc1*>(new CxxTabulated1(tvec, fvec, method))
+        tsiz = np.asarray(time).size
+        fsiz = np.asarray(fval).size
+        if tsiz != fsiz:
+            raise ValueError("Sizes of arrays do not match "
+                             "({} vs {}).".format(tsiz, fsiz))
+        elif tsiz == 0:
+            raise ValueError("Arrays must not be empty.")
+        cdef np.ndarray[np.double_t, ndim=1] tvec = np.asarray(time,
+                                                               dtype=np.double)
+        cdef np.ndarray[np.double_t, ndim=1] fvec = np.asarray(fval,
+                                                               dtype=np.double)
+        self.func = <CxxFunc1*>(new CxxTabulated1(tsiz, &tvec[0], &fvec[0],
+                                                  method))
 
     def __dealloc__(self):
         del self.func

--- a/interfaces/cython/cantera/test/test_func1.py
+++ b/interfaces/cython/cantera/test/test_func1.py
@@ -103,10 +103,9 @@ class TestFunc1(utilities.CanteraTest):
         self.assertNear(fcn(3), fval[-1])
 
     def test_tabulated5(self):
-        time = 0, 1, 0.5, 2
-        fval = 2, 1, 1, 0
-        with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
-            ct.Func1(time, fval)
+        fcn = ct.Func1([[0, 2], [1, 1], [2, 0]], interpolation='previous')
+        val = np.array([fcn(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]])
+        self.assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
 
     def test_failures(self):
         with self.assertRaisesRegex(ValueError, 'Invalid number of arguments'):
@@ -117,3 +116,10 @@ class TestFunc1(utilities.CanteraTest):
             ct.Func1(range(2), range(3))
         with self.assertRaisesRegex(ct.CanteraError, 'must not be empty'):
             ct.Func1([], [])
+        with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
+            ct.Func1((0, 1, 0.5, 2), (2, 1, 1, 0))
+        with self.assertRaisesRegex(ct.CanteraError, 'not implemented'):
+            ct.Func1((0, 1, 1, 2), (2, 1, 1, 0), interpolation='quadratic')
+        with self.assertRaisesRegex(ct.CanteraError, 'not be empty'):
+            fcn = ct.Func1([], [])
+        

--- a/interfaces/cython/cantera/test/test_func1.py
+++ b/interfaces/cython/cantera/test/test_func1.py
@@ -102,6 +102,12 @@ class TestFunc1(utilities.CanteraTest):
         self.assertNear(fcn(-1), fval[0])
         self.assertNear(fcn(3), fval[-1])
 
+    def test_tabulated5(self):
+        time = 0, 1, 0.5, 2
+        fval = 2, 1, 1, 0
+        with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
+            ct.Func1(time, fval)
+
     def test_failures(self):
         with self.assertRaisesRegex(ValueError, 'Invalid number of arguments'):
             ct.Func1(1, 2, 3)

--- a/interfaces/cython/cantera/test/test_func1.py
+++ b/interfaces/cython/cantera/test/test_func1.py
@@ -119,4 +119,4 @@ class TestFunc1(utilities.CanteraTest):
         with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
             ct.TabulatedFunction((0, 1, 0.5, 2), (2, 1, 1, 0))
         with self.assertRaisesRegex(ct.CanteraError, 'not implemented'):
-            ct.TabulatedFunction((0, 1, 1, 2), (2, 1, 1, 0), method='quadratic')
+            ct.TabulatedFunction((0, 1, 1, 2), (2, 1, 1, 0), method='not implemented')

--- a/interfaces/cython/cantera/test/test_func1.py
+++ b/interfaces/cython/cantera/test/test_func1.py
@@ -107,19 +107,16 @@ class TestFunc1(utilities.CanteraTest):
         val = np.array([fcn(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]])
         self.assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
 
-    def test_failures(self):
+    def test_tabulated_failures(self):
         with self.assertRaisesRegex(ValueError, 'Invalid number of arguments'):
             ct.Func1(1, 2, 3)
         with self.assertRaisesRegex(ValueError, 'Invalid dimensions'):
             ct.Func1(np.zeros((3, 3)))
-        with self.assertRaisesRegex(ct.CanteraError, 'do not match'):
+        with self.assertRaisesRegex(ValueError, 'do not match'):
             ct.Func1(range(2), range(3))
-        with self.assertRaisesRegex(ct.CanteraError, 'must not be empty'):
+        with self.assertRaisesRegex(ValueError, 'must not be empty'):
             ct.Func1([], [])
         with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
             ct.Func1((0, 1, 0.5, 2), (2, 1, 1, 0))
         with self.assertRaisesRegex(ct.CanteraError, 'not implemented'):
             ct.Func1((0, 1, 1, 2), (2, 1, 1, 0), interpolation='quadratic')
-        with self.assertRaisesRegex(ct.CanteraError, 'not be empty'):
-            fcn = ct.Func1([], [])
-        

--- a/interfaces/cython/cantera/test/test_func1.py
+++ b/interfaces/cython/cantera/test/test_func1.py
@@ -75,21 +75,21 @@ class TestFunc1(utilities.CanteraTest):
         arr = np.array([[0, 2], [1, 1], [2, 0]])
         time = arr[:, 0]
         fval = arr[:, 1]
-        fcn = ct.Func1(time, fval)
+        fcn = ct.TabulatedFunction(time, fval)
         for t, f in zip(time, fval):
             self.assertNear(f, fcn(t))
 
     def test_tabulated2(self):
         time = [0, 1, 2]
         fval = [2, 1, 0]
-        fcn = ct.Func1(time, fval)
+        fcn = ct.TabulatedFunction(time, fval)
         for t, f in zip(time, fval):
             self.assertNear(f, fcn(t))
 
     def test_tabulated3(self):
         time = np.array([0, 1, 2])
         fval = np.array([2, 1, 0])
-        fcn = ct.Func1(time, fval)
+        fcn = ct.TabulatedFunction(time, fval)
         tt = .5*(time[1:] + time[:-1])
         ff = .5*(fval[1:] + fval[:-1])
         for t, f in zip(tt, ff):
@@ -98,25 +98,25 @@ class TestFunc1(utilities.CanteraTest):
     def test_tabulated4(self):
         time = 0, 1, 2,
         fval = 2, 1, 0,
-        fcn = ct.Func1(time, fval)
+        fcn = ct.TabulatedFunction(time, fval)
         self.assertNear(fcn(-1), fval[0])
         self.assertNear(fcn(3), fval[-1])
 
     def test_tabulated5(self):
-        fcn = ct.Func1([[0, 2], [1, 1], [2, 0]], interpolation='previous')
+        fcn = ct.TabulatedFunction([[0, 2], [1, 1], [2, 0]], method='previous')
         val = np.array([fcn(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]])
         self.assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
 
     def test_tabulated_failures(self):
         with self.assertRaisesRegex(ValueError, 'Invalid number of arguments'):
-            ct.Func1(1, 2, 3)
+            ct.TabulatedFunction(1, 2, 3)
         with self.assertRaisesRegex(ValueError, 'Invalid dimensions'):
-            ct.Func1(np.zeros((3, 3)))
+            ct.TabulatedFunction(np.zeros((3, 3)))
         with self.assertRaisesRegex(ValueError, 'do not match'):
-            ct.Func1(range(2), range(3))
+            ct.TabulatedFunction(range(2), range(3))
         with self.assertRaisesRegex(ValueError, 'must not be empty'):
-            ct.Func1([], [])
+            ct.TabulatedFunction([], [])
         with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
-            ct.Func1((0, 1, 0.5, 2), (2, 1, 1, 0))
+            ct.TabulatedFunction((0, 1, 0.5, 2), (2, 1, 1, 0))
         with self.assertRaisesRegex(ct.CanteraError, 'not implemented'):
-            ct.Func1((0, 1, 1, 2), (2, 1, 1, 0), interpolation='quadratic')
+            ct.TabulatedFunction((0, 1, 1, 2), (2, 1, 1, 0), method='quadratic')

--- a/interfaces/cython/cantera/test/test_func1.py
+++ b/interfaces/cython/cantera/test/test_func1.py
@@ -70,3 +70,44 @@ class TestFunc1(utilities.CanteraTest):
         f = ct.Func1(np.sin)
         with self.assertRaises(NotImplementedError):
             copy.copy(f)
+
+    def test_tabulated1(self):
+        arr = np.array([[0, 2], [1, 1], [2, 0]])
+        time = arr[:, 0]
+        fval = arr[:, 1]
+        fcn = ct.Func1(time, fval)
+        for t, f in zip(time, fval):
+            self.assertNear(f, fcn(t))
+
+    def test_tabulated2(self):
+        time = [0, 1, 2]
+        fval = [2, 1, 0]
+        fcn = ct.Func1(time, fval)
+        for t, f in zip(time, fval):
+            self.assertNear(f, fcn(t))
+
+    def test_tabulated3(self):
+        time = np.array([0, 1, 2])
+        fval = np.array([2, 1, 0])
+        fcn = ct.Func1(time, fval)
+        tt = .5*(time[1:] + time[:-1])
+        ff = .5*(fval[1:] + fval[:-1])
+        for t, f in zip(tt, ff):
+            self.assertNear(f, fcn(t))
+
+    def test_tabulated4(self):
+        time = 0, 1, 2,
+        fval = 2, 1, 0,
+        fcn = ct.Func1(time, fval)
+        self.assertNear(fcn(-1), fval[0])
+        self.assertNear(fcn(3), fval[-1])
+
+    def test_failures(self):
+        with self.assertRaisesRegex(ValueError, 'Invalid number of arguments'):
+            ct.Func1(1, 2, 3)
+        with self.assertRaisesRegex(ValueError, 'Invalid dimensions'):
+            ct.Func1(np.zeros((3, 3)))
+        with self.assertRaisesRegex(ct.CanteraError, 'do not match'):
+            ct.Func1(range(2), range(3))
+        with self.assertRaisesRegex(ct.CanteraError, 'must not be empty'):
+            ct.Func1([], [])

--- a/interfaces/cython/cantera/test/test_func1.py
+++ b/interfaces/cython/cantera/test/test_func1.py
@@ -87,6 +87,13 @@ class TestFunc1(utilities.CanteraTest):
             self.assertNear(f, fcn(t))
 
     def test_tabulated3(self):
+        time = 0, 1, 2,
+        fval = 2, 1, 0,
+        fcn = ct.TabulatedFunction(time, fval)
+        self.assertNear(fcn(-1), fval[0])
+        self.assertNear(fcn(3), fval[-1])
+
+    def test_tabulated4(self):
         time = np.array([0, 1, 2])
         fval = np.array([2, 1, 0])
         fcn = ct.TabulatedFunction(time, fval)
@@ -95,23 +102,14 @@ class TestFunc1(utilities.CanteraTest):
         for t, f in zip(tt, ff):
             self.assertNear(f, fcn(t))
 
-    def test_tabulated4(self):
-        time = 0, 1, 2,
-        fval = 2, 1, 0,
-        fcn = ct.TabulatedFunction(time, fval)
-        self.assertNear(fcn(-1), fval[0])
-        self.assertNear(fcn(3), fval[-1])
-
     def test_tabulated5(self):
-        fcn = ct.TabulatedFunction([[0, 2], [1, 1], [2, 0]], method='previous')
+        time = [0, 1, 2]
+        fval = [2, 1, 0]
+        fcn = ct.TabulatedFunction(time, fval, method='previous')
         val = np.array([fcn(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]])
         self.assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
 
     def test_tabulated_failures(self):
-        with self.assertRaisesRegex(ValueError, 'Invalid number of arguments'):
-            ct.TabulatedFunction(1, 2, 3)
-        with self.assertRaisesRegex(ValueError, 'Invalid dimensions'):
-            ct.TabulatedFunction(np.zeros((3, 3)))
         with self.assertRaisesRegex(ValueError, 'do not match'):
             ct.TabulatedFunction(range(2), range(3))
         with self.assertRaisesRegex(ValueError, 'must not be empty'):

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -215,25 +215,19 @@ Func1& Pow1::derivative() const
 
 /******************************************************************************/
 
-Tabulated1::Tabulated1(const vector_fp& tvec, const vector_fp& fvec,
+Tabulated1::Tabulated1(size_t n, const double* tvals, const double* fvals,
                        const std::string& method) :
     Func1() {
-    if (tvec.size() != fvec.size()) {
-        throw CanteraError("Tabulated1::Tabulated1",
-                           "sizes of vectors do not match ({} vs {}).",
-                           tvec.size(), fvec.size());
-    } else if (tvec.empty()) {
-        throw CanteraError("Tabulated1::Tabulated1",
-                           "vectors must not be empty.");
-    }
-    for (auto it = std::begin(tvec) + 1; it != std::end(tvec); it++) {
+    m_tvec.resize(n);
+    std::copy(tvals, tvals + n, m_tvec.begin());
+    for (auto it = std::begin(m_tvec) + 1; it != std::end(m_tvec); it++) {
         if (*(it - 1) > *it) {
             throw CanteraError("Tabulated1::Tabulated1",
                                "time values are not increasing monotonically.");
         }
     }
-    m_tvec = tvec;
-    m_fvec = fvec;
+    m_fvec.resize(n);
+    std::copy(fvals, fvals + n, m_fvec.begin());
     if (method == "linear") {
         m_isLinear = true;
     } else if (method == "previous") {
@@ -291,7 +285,7 @@ Func1& Tabulated1::derivative() const {
         dvec.push_back(0.);
         dvec.push_back(0.);
     }
-    return *(new Tabulated1(tvec, dvec, "previous"));
+    return *(new Tabulated1(tvec.size(), &tvec[0], &dvec[0], "previous"));
 }
 
 /******************************************************************************/

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -247,27 +247,24 @@ Tabulated1::Tabulated1(const vector_fp& tvec, const vector_fp& fvec,
 
 double Tabulated1::eval(double t) const {
     size_t siz = m_tvec.size();
-    if (siz) {
-        if (t <= m_tvec[0]) {
-            return m_fvec[0];
-        } else if (t >= m_tvec[siz-1]) {
-            return m_fvec[siz-1];
-        } else {
-            size_t ix = 0;
-            while (t > m_tvec[ix+1]) {
-                ix++;
-            }
-            if (m_isLinear) {
-                double df = m_fvec[ix+1] - m_fvec[ix];
-                df /= m_tvec[ix+1] - m_tvec[ix];
-                df *= t - m_tvec[ix];
-                return m_fvec[ix] + df;
-            } else {
-                return m_fvec[ix];
-            }
-        }
+    // constructor ensures that siz > 0
+    if (t <= m_tvec[0]) {
+        return m_fvec[0];
+    } else if (t >= m_tvec[siz-1]) {
+        return m_fvec[siz-1];
     } else {
-        return 0.;
+        size_t ix = 0;
+        while (t > m_tvec[ix+1]) {
+            ix++;
+        }
+        if (m_isLinear) {
+            double df = m_fvec[ix+1] - m_fvec[ix];
+            df /= m_tvec[ix+1] - m_tvec[ix];
+            df *= t - m_tvec[ix];
+            return m_fvec[ix] + df;
+        } else {
+            return m_fvec[ix];
+        }
     }
 }
 

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -213,6 +213,52 @@ Func1& Pow1::derivative() const
     return *r;
 }
 
+/******************************************************************************/
+
+double Tabulated1::eval(double t) const {
+    size_t siz = m_tvec.size();
+    if (siz) {
+        if (t <= m_tvec[0]) {
+            return m_fvec[0];
+        } else if (t >= m_tvec[siz-1]) {
+            return m_fvec[siz-1];
+        } else {
+            size_t ix = 0;
+            while (t > m_tvec[ix+1]) {
+                ix++;
+            }
+            double df = m_fvec[ix+1] - m_fvec[ix];
+            df /= m_tvec[ix+1] - m_tvec[ix];
+            df *= t - m_tvec[ix];
+            return m_fvec[ix] + df;
+        }
+    } else {
+        return 0.;
+    }
+}
+
+Func1& Tabulated1::derivative() const {
+    std::vector<double> tvec;
+    std::vector<double> dvec;
+    size_t siz = m_tvec.size();
+    if (siz>1) {
+        for (size_t i=1; i<siz; i++) {
+            double d = (m_fvec[i] - m_fvec[i-1]) /
+                (m_tvec[i] - m_tvec[i-1]);
+            tvec.push_back(m_tvec[i-1]);
+            dvec.push_back(d);
+            tvec.push_back(m_tvec[i]);
+            dvec.push_back(d);
+        }
+    } else {
+        tvec.push_back(m_tvec[siz-1]);
+        dvec.push_back(0.);
+    }
+    return *(new Tabulated1(tvec, dvec));
+}
+
+/******************************************************************************/
+
 string Func1::write(const std::string& arg) const
 {
     return fmt::format("<unknown {}>({})", ID(), arg);
@@ -231,6 +277,11 @@ string Pow1::write(const std::string& arg) const
     } else {
         return arg;
     }
+}
+
+string Tabulated1::write(const std::string& arg) const
+{
+    return fmt::format("\\mathrm{{Tabulated}}({})", arg);
 }
 
 string Const1::write(const std::string& arg) const


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes Cantera/enhancements#17

**Changes proposed in this pull request**

- use existing C++ `Func1.h` framework
- create Python interface for new tabulated `Func1` object and add unit tests

Implementing a tabulated function as a class derived from `Func1` allows for a straight-forward integration into the existing framework without further code changes. An implementation in the C++ layer has the advantage that this solution is usable from (or at least can be extended to) all platforms.

**Use case and benchmark**

```
In [1]: import cantera as ct
   ...: import numpy as np
   ...: arr = np.array([[0, 2], [1, 1], [2, 0]])

In [2]: fcn1 = ct.Func1(arr)
   ...: fcn1(1.3)
Out[2]: 0.7

In [3]: fcn2 = ct.Func1(arr, interpolation='previous')
   ...: fcn2(1.3)
Out[3]: 1.0

In [4]: %timeit fcn1(1.3)
The slowest run took 29.33 times longer than the fastest. This could mean that an intermediate result is being cached.
10000000 loops, best of 3: 122 ns per loop

In [5]: time = arr[:, 0]
   ...: fval = arr[:, 1]
   ...: fcn3 = lambda t: np.interp(t, time, fval)

In [6]: %timeit fcn3(1.3)
The slowest run took 9.63 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 5.46 us per loop

In [7]: fcn4 = ct.Func1(fcn3)

In [8]: %timeit fcn4(1.3)
The slowest run took 13.10 times longer than the fastest. This could mean that an intermediate result is being cached.
100000 loops, best of 3: 5.76 us per loop
```