### PR TITLE
output the production rate for every species in oneD premixed flame

### DIFF
--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -264,10 +264,11 @@ public:
         return m_kExcessRight;
     }
 
-protected:
     doublereal wdot(size_t k, size_t j) const {
         return m_wdot(k,j);
     }
+
+protected:
 
     //! Write the net production rates at point `j` into array `m_wdot`
     void getWdot(doublereal* x, size_t j) {

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -759,6 +759,7 @@ cdef extern from "cantera/oneD/StFlow.h":
         cbool withSoret()
         void setFreeFlow()
         void setAxisymmetricFlow()
+        double wdot(size_t, size_t) except +translate_exception
 
 
 cdef extern from "cantera/oneD/IonFlow.h":

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -531,6 +531,8 @@ cdef class IdealGasFlow(_FlowBase):
     def __cinit__(self, _SolutionBase thermo, *args, **kwargs):
         gas = getIdealGasPhase(thermo)
         self.flow = new CxxStFlow(gas, thermo.n_species, 2)
+    def wdot(self, species, point):
+        return self.flow.wdot(species, point)
 
 
 cdef class IonFlow(_FlowBase):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #

**Changes proposed in this pull request**

- For the purpose of premixed FGM model, we need several species reaction rates to build the source term of reaction progress variable.
