### PR TITLE
[Kinetics] Move heat_release_rate to Python Kinetics class.

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -430,6 +430,8 @@ class SolutionArray:
         'critical_temperature', 'critical_pressure', 'critical_density',
         'P_sat', 'T_sat', 'isothermal_compressibility',
         'thermal_expansion_coeff', 'electric_potential',
+        # From Kinetics
+        'heat_release_rate',
         # From Transport
         'viscosity', 'electrical_conductivity', 'thermal_conductivity',
     ]
@@ -459,7 +461,7 @@ class SolutionArray:
         'forward_rate_constants', 'reverse_rate_constants',
         'delta_enthalpy', 'delta_gibbs', 'delta_entropy',
         'delta_standard_enthalpy', 'delta_standard_gibbs',
-        'delta_standard_entropy'
+        'delta_standard_entropy', 'heat_production_rates',
     ]
     _call_scalar = ['elemental_mass_fraction', 'elemental_mole_fraction']
 

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -365,6 +365,26 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_reaction_array(self, kin_getDeltaSSEntropy)
 
+    property heat_release_rate:
+        """
+        Get the total volumetric heat release rate [W/m^3].
+        """
+        def __get__(self):
+            return - np.sum(self.partial_molar_enthalpies *
+                            self.net_production_rates, 0)
+
+    property heat_production_rates:
+        """
+        Get the volumetric heat production rates [W/m^3] on a per-reaction
+        basis. The sum over all reactions results in the total volumetric heat
+        release rate.
+        Example: C. K. Law: Combustion Physics (2006), Fig. 7.8.6
+
+        >>> gas.heat_production_rates[1]  # heat production rate of the 2nd reaction
+        """
+        def __get__(self):
+            return - self.net_rates_of_progress * self.delta_enthalpy
+
 
 cdef class InterfaceKinetics(Kinetics):
     """

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -250,26 +250,6 @@ class FlameBase(Sim1D):
         self.gas.set_unnormalized_mass_fractions(Y)
         self.gas.TP = self.value(self.flame, 'T', point), self.P
 
-    @property
-    def heat_release_rate(self):
-        """
-        Get the total volumetric heat release rate [W/m^3].
-        """
-        return - np.sum(self.partial_molar_enthalpies *
-                        self.net_production_rates, 0)
-
-    @property
-    def heat_production_rates(self):
-        """
-        Get the volumetric heat production rates [W/m^3] on a per-reaction
-        basis. The sum over all reactions results in the total volumetric heat
-        release rate.
-        Example: C. K. Law: Combustion Physics (2006), Fig. 7.8.6
-
-        >>> f.heat_production_rates[2]  # heat production rate of the 2nd reaction
-        """
-        return - self.net_rates_of_progress * self.delta_standard_enthalpy
-
     def write_csv(self, filename, species='X', quiet=True):
         """
         Write the velocity, temperature, density, and species profiles
@@ -356,7 +336,7 @@ for _attr in ['density', 'density_mass', 'density_mole', 'volume_mass',
               'entropy_mass', 'g', 'gibbs_mole', 'gibbs_mass', 'cv',
               'cv_mole', 'cv_mass', 'cp', 'cp_mole', 'cp_mass',
               'isothermal_compressibility', 'thermal_expansion_coeff',
-              'viscosity', 'thermal_conductivity']:
+              'viscosity', 'thermal_conductivity', 'heat_release_rate']:
     setattr(FlameBase, _attr, _array_property(_attr))
 FlameBase.volume = _array_property('v') # avoid confusion with velocity gradient 'V'
 FlameBase.int_energy = _array_property('u') # avoid collision with velocity 'u'
@@ -377,7 +357,7 @@ for _attr in ['forward_rates_of_progress', 'reverse_rates_of_progress', 'net_rat
               'equilibrium_constants', 'forward_rate_constants', 'reverse_rate_constants',
               'delta_enthalpy', 'delta_gibbs', 'delta_entropy',
               'delta_standard_enthalpy', 'delta_standard_gibbs',
-              'delta_standard_entropy']:
+              'delta_standard_entropy', 'heat_production_rates']:
     setattr(FlameBase, _attr, _array_property(_attr, 'n_reactions'))
 
 

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -119,6 +119,11 @@ class TestKinetics(utilities.CanteraTest):
         self.assertArrayNear(self.phase.forward_rates_of_progress - self.phase.reverse_rates_of_progress,
                              self.phase.net_rates_of_progress)
 
+    def test_heat_release(self):
+        hrr = - self.phase.partial_molar_enthalpies.dot(self.phase.net_production_rates)
+        self.assertNear(hrr, self.phase.heat_release_rate)
+        self.assertNear(hrr, sum(self.phase.heat_production_rates))
+
     def test_rate_constants(self):
         self.assertEqual(len(self.phase.forward_rate_constants), self.phase.n_reactions)
         self.assertArrayNear(self.phase.forward_rate_constants / self.phase.reverse_rate_constants,


### PR DESCRIPTION
While `heat_release_rate` and `heat_production_rates` are defined for 1D objects, no corresponding calls are available for 0D simulations. Moving the definition to `kinetics.pyx` enables these methods to be used for all `Solution` (or `SolutionArray`) objects.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review