### PR TITLE
Add get/set equivalenceRatio/mixtureFraction functions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,7 +18,7 @@ Steven DeCaluwe (@decaluwe), Colorado School of Mines
 Vishesh Devgan (@vdevgan)
 Thomas Fiala (@thomasfiala), Technische Universität München
 David Fronczek
-@g3bk47
+Thorsten Zirwes, Karlsruhe Institute of Technology
 Matteo Giani (@MarcDuQuesne)
 Dave Goodwin, California Institute of Technology
 John Hewson (@jchewson), Sandia National Laboratory

--- a/AUTHORS
+++ b/AUTHORS
@@ -18,7 +18,6 @@ Steven DeCaluwe (@decaluwe), Colorado School of Mines
 Vishesh Devgan (@vdevgan)
 Thomas Fiala (@thomasfiala), Technische Universität München
 David Fronczek
-Thorsten Zirwes, Karlsruhe Institute of Technology
 Matteo Giani (@MarcDuQuesne)
 Dave Goodwin, California Institute of Technology
 John Hewson (@jchewson), Sandia National Laboratory
@@ -51,3 +50,4 @@ Laurien Vandewalle (@lavdwall)
 Bryan Weber (@bryanwweber), University of Connecticut
 Armin Wehrfritz (@awehrfritz)
 Richard West (@rwest), Northeastern University
+Thorsten Zirwes (@g3bk47), Karlsruhe Institute of Technology

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1401,6 +1401,8 @@ public:
      * @internal
      */
     virtual MultiSpeciesThermo& speciesThermo(int k = -1);
+    
+    virtual const MultiSpeciesThermo& speciesThermo(int k = -1) const;
 
     /**
      * @internal

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -695,6 +695,12 @@ MultiSpeciesThermo& ThermoPhase::speciesThermo(int k)
     return m_spthermo;
 }
 
+const MultiSpeciesThermo& ThermoPhase::speciesThermo(int k) const
+{
+    return m_spthermo;
+}
+
+
 void ThermoPhase::initThermoFile(const std::string& inputFile,
                                  const std::string& id)
 {


### PR DESCRIPTION
**Changes proposed in this pull request**

- bring get/set equivalence ratio functions to C++ interface
- add get/set (Bilger) mixture fraction function and stoichiometric air to fuel ratio functions to C++ and python interface (mixture fraction is commonly used in combustion modeling and has been requested in the past https://groups.google.com/forum/#!searchin/cantera-users/bilger|sort:date/cantera-users/VenkSlGjnb4/PRFCLKcJBAAJ)
- fix current behavior of get_equivalence_ratio: it is now consistent for arbitrary fuel and oxidizer compositions and is independent of reaction progress (e.g. it is the same in the unburnt and burnt state).

In the C++ interface, all functions take the fuel and oxidizder compositions as const double*, vector_fp, std::string and compositionMap. All functions have a "*_X" and "*_Y" suffix version for providing the fuel and oxidizer composition either as mole or mass fractions. The "getEquivalenceRatio" function has a special case where the fuel and oxidizer composition is not specified: this computes the equivalence ratio purely from the elemental composition.

At the moment, get_equivalence_ratio and set_equivalence_ratio functions from the python interface default to the *_X versions to keep the current behaviour the same.

For further discussion, see:
https://github.com/Cantera/enhancements/issues/28
https://groups.google.com/forum/embed/#!topic/cantera-users/owoAebI6rr8
https://groups.google.com/forum/embed/#!topic/cantera-users/gs-wHjo18Do