### PR TITLE
Simple fix for Sundials 5.1 compatibility

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1108,7 +1108,7 @@ if env['system_sundials'] == 'y':
 
     # Ignore the minor version, e.g. 2.4.x -> 2.4
     env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
-    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2','4.0','4.1','5.0'):
+    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2','4.0','4.1','5.0','5.1'):
         print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
         sys.exit(1)
     print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)

--- a/SConstruct
+++ b/SConstruct
@@ -1108,13 +1108,14 @@ if env['system_sundials'] == 'y':
 
     # Ignore the minor version, e.g. 2.4.x -> 2.4
     env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
-    if env['sundials_version'] not in ('2.4','2.5','2.6','2.7','3.0','3.1','3.2','4.0','4.1','5.0','5.1'):
+    sundials_ver = LooseVersion(env['sundials_version'])
+    if sundials_ver < LooseVersion('2.4') or sundials_ver >= LooseVersion('6.0'):
         print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
         sys.exit(1)
     print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)
 
     #Determine whether or not Sundials was built with BLAS/LAPACK
-    if LooseVersion(env['sundials_version']) < LooseVersion('2.6'):
+    if sundials_ver < LooseVersion('2.6'):
         # In Sundials 2.4 / 2.5, SUNDIALS_BLAS_LAPACK is either 0 or 1
         sundials_blas_lapack = get_expression_value(['"sundials/sundials_config.h"'],
                                                        'SUNDIALS_BLAS_LAPACK')
@@ -1606,7 +1607,7 @@ linkSharedLibs = ['cantera_shared']
 
 if env['system_sundials'] == 'y':
     env['sundials_libs'] = ['sundials_cvodes', 'sundials_ida', 'sundials_nvecserial']
-    if env['use_lapack'] and LooseVersion(env['sundials_version']) >= LooseVersion('3.0'):
+    if env['use_lapack'] and sundials_ver >= LooseVersion('3.0'):
         if env.get('has_sundials_lapack'):
             env['sundials_libs'].extend(('sundials_sunlinsollapackdense',
                                          'sundials_sunlinsollapackband'))

--- a/SConstruct
+++ b/SConstruct
@@ -1112,6 +1112,9 @@ if env['system_sundials'] == 'y':
     if sundials_ver < LooseVersion('2.4') or sundials_ver >= LooseVersion('6.0'):
         print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
         sys.exit(1)
+    elif sundials_ver > LooseVersion('5.1'):
+        print("WARNING: Sundials version %r has not been tested." % env['sundials_version'])
+
     print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)
 
     #Determine whether or not Sundials was built with BLAS/LAPACK

--- a/SConstruct
+++ b/SConstruct
@@ -1133,8 +1133,8 @@ if env['system_sundials'] == 'y':
         print('WARNING: External BLAS/LAPACK has been specified for Cantera '
               'but Sundials was built without this support.')
 else: # env['system_sundials'] == 'n'
-    print("""INFO: Using private installation of Sundials version 5.0.""")
-    env['sundials_version'] = '5.0'
+    print("""INFO: Using private installation of Sundials version 5.1.""")
+    env['sundials_version'] = '5.1'
     env['has_sundials_lapack'] = int(env['use_lapack'])
 
 

--- a/ext/sundials_config.h.in
+++ b/ext/sundials_config.h.in
@@ -1,7 +1,7 @@
 /* Minimal set of SUNDIALS configuration variables */
-#define SUNDIALS_VERSION "5.0.0"
+#define SUNDIALS_VERSION "5.1.0"
 #define SUNDIALS_VERSION_MAJOR 5
-#define SUNDIALS_VERSION_MINOR 0
+#define SUNDIALS_VERSION_MINOR 1
 #define SUNDIALS_VERSION_PATCH 0
 #define SUNDIALS_VERSION_LABEL ""
 #define SUNDIALS_F77_FUNC(name,NAME) name ## _


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #

**Changes proposed in this pull request**

The Sundials 5.1 has no any changes in CVODES API in comparison with sundials 4.0, 4.1, 5.0 therefore the compatibility configuration fix is trivial.

```
*****************************
***    Testing Summary    ***
*****************************

Tests passed: 1046
Up-to-date tests skipped: 0
Tests failed: 0

*****************************
```
