### PR TITLE
Rename Inlet1d.h / Bdry1d

### DIFF
--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -42,12 +42,12 @@ public:
     }
 
     /// Set the temperature.
-    virtual void setTemperature(doublereal t) {
+    virtual void setTemperature(double t) {
         m_temp = t;
     }
 
     /// Temperature [K].
-    virtual doublereal temperature() {
+    virtual double temperature() {
         return m_temp;
     }
 
@@ -61,26 +61,26 @@ public:
     }
 
     /// Set the mole fractions by specifying an array.
-    virtual void setMoleFractions(const doublereal* xin) {
+    virtual void setMoleFractions(const double* xin) {
         throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
     /// Mass fraction of species k.
-    virtual doublereal massFraction(size_t k) {
+    virtual double massFraction(size_t k) {
         throw NotImplementedError("Boundary1D::massFraction");
     }
 
     /// Set the total mass flow rate.
-    virtual void setMdot(doublereal mdot) {
+    virtual void setMdot(double mdot) {
         m_mdot = mdot;
     }
 
     /// The total mass flow rate [kg/m2/s].
-    virtual doublereal mdot() {
+    virtual double mdot() {
         return m_mdot;
     }
 
-    virtual void setupGrid(size_t n, const doublereal* z) {}
+    virtual void setupGrid(size_t n, const double* z) {}
 
 protected:
     void _init(size_t n);
@@ -93,7 +93,7 @@ protected:
     size_t m_sp_left, m_sp_right;
     size_t m_start_left, m_start_right;
     ThermoPhase* m_phase_left, *m_phase_right;
-    doublereal m_temp, m_mdot;
+    double m_temp, m_mdot;
 };
 
 
@@ -107,7 +107,7 @@ public:
     Inlet1D();
 
     /// set spreading rate
-    virtual void setSpreadRate(doublereal V0) {
+    virtual void setSpreadRate(double V0) {
         m_V0 = V0;
         needJacUpdate();
     }
@@ -124,19 +124,19 @@ public:
     }
 
     virtual void setMoleFractions(const std::string& xin);
-    virtual void setMoleFractions(const doublereal* xin);
-    virtual doublereal massFraction(size_t k) {
+    virtual void setMoleFractions(const double* xin);
+    virtual double massFraction(size_t k) {
         return m_yin[k];
     }
     virtual void init();
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      integer* diagg, double rdt);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 
 protected:
     int m_ilr;
-    doublereal m_V0;
+    double m_V0;
     size_t m_nsp;
     vector_fp m_yin;
     std::string m_xstr;
@@ -154,15 +154,15 @@ public:
         m_type = cEmptyType;
     }
 
-    virtual void showSolution(const doublereal* x) {}
+    virtual void showSolution(const double* x) {}
 
     virtual void init();
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      integer* diagg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 };
 
 /**
@@ -179,11 +179,11 @@ public:
 
     virtual void init();
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      integer* diagg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 };
 
 
@@ -200,11 +200,11 @@ public:
 
     virtual void init();
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      integer* diagg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 };
 
 
@@ -217,22 +217,22 @@ class OutletRes1D : public Boundary1D
 public:
     OutletRes1D();
 
-    virtual void showSolution(const doublereal* x) {}
+    virtual void showSolution(const double* x) {}
 
     virtual size_t nSpecies() {
         return m_nsp;
     }
 
     virtual void setMoleFractions(const std::string& xin);
-    virtual void setMoleFractions(const doublereal* xin);
-    virtual doublereal massFraction(size_t k) {
+    virtual void setMoleFractions(const double* xin);
+    virtual double massFraction(size_t k) {
         return m_yres[k];
     }
     virtual void init();
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      integer* diagg, double rdt);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 
 protected:
     size_t m_nsp;
@@ -256,15 +256,15 @@ public:
 
     virtual void init();
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      integer* diagg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 
     virtual void showSolution_s(std::ostream& s, const double* x);
 
-    virtual void showSolution(const doublereal* x) {
+    virtual void showSolution(const double* x) {
         writelog("    Temperature: {:10.4g} K \n\n", m_temp);
     }
 };
@@ -289,21 +289,21 @@ public:
     virtual void init();
     virtual void resetBadValues(double* xg);
 
-    virtual void eval(size_t jg, doublereal* xg, doublereal* rg,
-                      integer* diagg, doublereal rdt);
+    virtual void eval(size_t jg, double* xg, double* rg,
+                      integer* diagg, double rdt);
 
-    virtual XML_Node& save(XML_Node& o, const doublereal* const soln);
-    virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+    virtual XML_Node& save(XML_Node& o, const double* const soln);
+    virtual void restore(const XML_Node& dom, double* soln, int loglevel);
 
-    virtual void _getInitialSoln(doublereal* x) {
+    virtual void _getInitialSoln(double* x) {
         m_sphase->getCoverages(x);
     }
 
-    virtual void _finalize(const doublereal* x) {
+    virtual void _finalize(const double* x) {
         std::copy(x, x+m_nsp, m_fixed_cov.begin());
     }
 
-    virtual void showSolution(const doublereal* x);
+    virtual void showSolution(const double* x);
 
 protected:
     InterfaceKinetics* m_kin;

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -1,5 +1,5 @@
 /**
- * @file Inlet1D.h
+ * @file Boundary1D.h
  *
  * Boundary objects for one-dimensional simulations.
  */
@@ -7,8 +7,8 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#ifndef CT_BDRY1D_H
-#define CT_BDRY1D_H
+#ifndef CT_BOUNDARY1D_H
+#define CT_BOUNDARY1D_H
 
 #include "Domain1D.h"
 #include "cantera/thermo/SurfPhase.h"
@@ -32,10 +32,10 @@ const int RightInlet = -1;
  * exceptions.
  * @ingroup onedim
  */
-class Bdry1D : public Domain1D
+class Boundary1D : public Domain1D
 {
 public:
-    Bdry1D();
+    Boundary1D();
 
     virtual void init() {
         _init(1);
@@ -57,17 +57,17 @@ public:
 
     /// Set the mole fractions by specifying a std::string.
     virtual void setMoleFractions(const std::string& xin) {
-        throw NotImplementedError("Bdry1D::setMoleFractions");
+        throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
     /// Set the mole fractions by specifying an array.
     virtual void setMoleFractions(const doublereal* xin) {
-        throw NotImplementedError("Bdry1D::setMoleFractions");
+        throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
     /// Mass fraction of species k.
     virtual doublereal massFraction(size_t k) {
-        throw NotImplementedError("Bdry1D::massFraction");
+        throw NotImplementedError("Boundary1D::massFraction");
     }
 
     /// Set the total mass flow rate.
@@ -101,7 +101,7 @@ protected:
  * An inlet.
  * @ingroup onedim
  */
-class Inlet1D : public Bdry1D
+class Inlet1D : public Boundary1D
 {
 public:
     Inlet1D();
@@ -147,10 +147,10 @@ protected:
  * A terminator that does nothing.
  * @ingroup onedim
  */
-class Empty1D : public Bdry1D
+class Empty1D : public Boundary1D
 {
 public:
-    Empty1D() : Bdry1D() {
+    Empty1D() : Boundary1D() {
         m_type = cEmptyType;
     }
 
@@ -170,10 +170,10 @@ public:
  * zero axial gradients.
  * @ingroup onedim
  */
-class Symm1D : public Bdry1D
+class Symm1D : public Boundary1D
 {
 public:
-    Symm1D() : Bdry1D() {
+    Symm1D() : Boundary1D() {
         m_type = cSymmType;
     }
 
@@ -191,10 +191,10 @@ public:
  * An outlet.
  * @ingroup onedim
  */
-class Outlet1D : public Bdry1D
+class Outlet1D : public Boundary1D
 {
 public:
-    Outlet1D() : Bdry1D() {
+    Outlet1D() : Boundary1D() {
         m_type = cOutletType;
     }
 
@@ -212,7 +212,7 @@ public:
  * An outlet with specified composition.
  * @ingroup onedim
  */
-class OutletRes1D : public Bdry1D
+class OutletRes1D : public Boundary1D
 {
 public:
     OutletRes1D();
@@ -247,10 +247,10 @@ protected:
  * condition is imposed for the species.
  * @ingroup onedim
  */
-class Surf1D : public Bdry1D
+class Surf1D : public Boundary1D
 {
 public:
-    Surf1D() : Bdry1D() {
+    Surf1D() : Boundary1D() {
         m_type = cSurfType;
     }
 
@@ -273,7 +273,7 @@ public:
  * A reacting surface.
  * @ingroup onedim
  */
-class ReactingSurf1D : public Bdry1D
+class ReactingSurf1D : public Boundary1D
 {
 public:
     ReactingSurf1D();

--- a/include/cantera/oneD/Inlet1D.h
+++ b/include/cantera/oneD/Inlet1D.h
@@ -1,0 +1,36 @@
+/**
+ * @file Inlet1D.h
+ *
+ * Boundary objects for one-dimensional simulations.
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_BDRY1D_H
+#define CT_BDRY1D_H
+
+#pragma message("warning: Inlet1D.h is renamed to Boundary1D.h and will be removed after Cantera 2.5.")
+
+#include "Boundary1D.h"
+
+namespace Cantera
+{
+
+/*!
+ * Renamed base class for boundaries between one-dimensional spatial domains.
+ * @deprecated To be removed after Cantera 2.5.
+ */
+class Bdry1D : public Boundary1D
+{
+public:
+    Bdry1D() : Boundary1D() {
+        warn_deprecated("Bdry1D::Bdry1D()",
+                        "To be removed after Cantera 2.5. "
+                        "Class renamed to Boundary1D.");
+    }
+};
+
+}
+
+#endif

--- a/include/cantera/onedim.h
+++ b/include/cantera/onedim.h
@@ -13,7 +13,7 @@
 
 #include "oneD/Sim1D.h"
 #include "oneD/Domain1D.h"
-#include "oneD/Inlet1D.h"
+#include "oneD/Boundary1D.h"
 #include "oneD/StFlow.h"
 
 #endif

--- a/include/cantera/onedim.h
+++ b/include/cantera/onedim.h
@@ -14,6 +14,7 @@
 #include "oneD/Sim1D.h"
 #include "oneD/Domain1D.h"
 #include "oneD/Boundary1D.h"
+#include "oneD/Inlet1D.h"
 #include "oneD/StFlow.h"
 
 #endif

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -707,8 +707,8 @@ cdef extern from "cantera/oneD/Domain1D.h":
         string& id()
 
 
-cdef extern from "cantera/oneD/Inlet1D.h":
-    cdef cppclass CxxBdry1D "Cantera::Bdry1D":
+cdef extern from "cantera/oneD/Boundary1D.h":
+    cdef cppclass CxxBoundary1D "Cantera::Boundary1D":
         double temperature()
         void setTemperature(double)
         double mdot()
@@ -1090,7 +1090,7 @@ cdef class Domain1D:
     cdef public pybool have_user_tolerances
 
 cdef class Boundary1D(Domain1D):
-    cdef CxxBdry1D* boundary
+    cdef CxxBoundary1D* boundary
 
 cdef class Inlet1D(Boundary1D):
     cdef CxxInlet1D* inlet

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -310,7 +310,7 @@ cdef class Inlet1D(Boundary1D):
     """
     def __cinit__(self, *args, **kwargs):
         self.inlet = new CxxInlet1D()
-        self.boundary = <CxxBdry1D*>(self.inlet)
+        self.boundary = <CxxBoundary1D*>(self.inlet)
 
     def __dealloc__(self):
         del self.inlet
@@ -332,7 +332,7 @@ cdef class Outlet1D(Boundary1D):
     """
     def __cinit__(self, *args, **kwargs):
         self.outlet = new CxxOutlet1D()
-        self.boundary = <CxxBdry1D*>(self.outlet)
+        self.boundary = <CxxBoundary1D*>(self.outlet)
 
     def __dealloc__(self):
         del self.outlet
@@ -344,7 +344,7 @@ cdef class OutletReservoir1D(Boundary1D):
     """
     def __cinit__(self, *args, **kwargs):
         self.outlet = new CxxOutletRes1D()
-        self.boundary = <CxxBdry1D*>(self.outlet)
+        self.boundary = <CxxBoundary1D*>(self.outlet)
 
     def __dealloc__(self):
         del self.outlet
@@ -354,7 +354,7 @@ cdef class SymmetryPlane1D(Boundary1D):
     """A symmetry plane."""
     def __cinit__(self, *args, **kwargs):
         self.symm = new CxxSymm1D()
-        self.boundary = <CxxBdry1D*>(self.symm)
+        self.boundary = <CxxBoundary1D*>(self.symm)
 
     def __dealloc__(self):
         del self.symm
@@ -364,7 +364,7 @@ cdef class Surface1D(Boundary1D):
     """A solid surface."""
     def __cinit__(self, *args, **kwargs):
         self.surf = new CxxSurf1D()
-        self.boundary = <CxxBdry1D*>(self.surf)
+        self.boundary = <CxxBoundary1D*>(self.surf)
 
     def __dealloc__(self):
         del self.surf
@@ -374,7 +374,7 @@ cdef class ReactingSurface1D(Boundary1D):
     """A reacting solid surface."""
     def __cinit__(self, *args, **kwargs):
         self.surf = new CxxReactingSurf1D()
-        self.boundary = <CxxBdry1D*>(self.surf)
+        self.boundary = <CxxBoundary1D*>(self.surf)
 
     def __dealloc__(self):
         del self.surf

--- a/samples/cxx/flamespeed/flamespeed.cpp
+++ b/samples/cxx/flamespeed/flamespeed.cpp
@@ -4,7 +4,7 @@
  */
 
 #include "cantera/oneD/Sim1D.h"
-#include "cantera/oneD/Inlet1D.h"
+#include "cantera/oneD/Boundary1D.h"
 #include "cantera/oneD/StFlow.h"
 #include "cantera/thermo/IdealGasPhase.h"
 #include "cantera/transport.h"

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -11,7 +11,7 @@
 
 // Cantera includes
 #include "cantera/oneD/Sim1D.h"
-#include "cantera/oneD/Inlet1D.h"
+#include "cantera/oneD/Boundary1D.h"
 #include "cantera/transport/TransportBase.h"
 #include "Cabinet.h"
 
@@ -278,7 +278,7 @@ extern "C" {
     int bdry_setMdot(int i, double mdot)
     {
         try {
-            DomainCabinet::get<Bdry1D>(i).setMdot(mdot);
+            DomainCabinet::get<Boundary1D>(i).setMdot(mdot);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -288,7 +288,7 @@ extern "C" {
     int bdry_setTemperature(int i, double t)
     {
         try {
-            DomainCabinet::get<Bdry1D>(i).setTemperature(t);
+            DomainCabinet::get<Boundary1D>(i).setTemperature(t);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -298,7 +298,7 @@ extern "C" {
     int bdry_setMoleFractions(int i, const char* x)
     {
         try {
-            DomainCabinet::get<Bdry1D>(i).setMoleFractions(x);
+            DomainCabinet::get<Boundary1D>(i).setMoleFractions(x);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -308,7 +308,7 @@ extern "C" {
     double bdry_temperature(int i)
     {
         try {
-            return DomainCabinet::get<Bdry1D>(i).temperature();
+            return DomainCabinet::get<Boundary1D>(i).temperature();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -317,7 +317,7 @@ extern "C" {
     double bdry_massFraction(int i, int k)
     {
         try {
-            return DomainCabinet::get<Bdry1D>(i).massFraction(k);
+            return DomainCabinet::get<Boundary1D>(i).massFraction(k);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -326,7 +326,7 @@ extern "C" {
     double bdry_mdot(int i)
     {
         try {
-            return DomainCabinet::get<Bdry1D>(i).mdot();
+            return DomainCabinet::get<Boundary1D>(i).mdot();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -1,9 +1,9 @@
-//! @file boundaries1D.cpp
+//! @file Boundary1D.cpp
 
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#include "cantera/oneD/Inlet1D.h"
+#include "cantera/oneD/Boundary1D.h"
 #include "cantera/oneD/OneDim.h"
 #include "cantera/base/ctml.h"
 #include "cantera/oneD/StFlow.h"
@@ -13,7 +13,7 @@ using namespace std;
 namespace Cantera
 {
 
-Bdry1D::Bdry1D() : Domain1D(1, 1, 0.0),
+Boundary1D::Boundary1D() : Domain1D(1, 1, 0.0),
     m_flow_left(0), m_flow_right(0),
     m_ilr(0), m_left_nv(0), m_right_nv(0),
     m_left_loc(0), m_right_loc(0),
@@ -26,10 +26,10 @@ Bdry1D::Bdry1D() : Domain1D(1, 1, 0.0),
     m_type = cConnectorType;
 }
 
-void Bdry1D::_init(size_t n)
+void Boundary1D::_init(size_t n)
 {
     if (m_index == npos) {
-        throw CanteraError("Bdry1D::_init",
+        throw CanteraError("Boundary1D::_init",
                            "install in container before calling init.");
     }
 
@@ -50,7 +50,7 @@ void Bdry1D::_init(size_t n)
             m_left_nsp = m_left_nv - c_offset_Y;
             m_phase_left = &m_flow_left->phase();
         } else {
-            throw CanteraError("Bdry1D::_init",
+            throw CanteraError("Boundary1D::_init",
                 "Boundary domains can only be connected on the left to flow "
                 "domains, not type {} domains.", r.domainType());
         }
@@ -66,7 +66,7 @@ void Bdry1D::_init(size_t n)
             m_right_nsp = m_right_nv - c_offset_Y;
             m_phase_right = &m_flow_right->phase();
         } else {
-            throw CanteraError("Bdry1D::_init",
+            throw CanteraError("Boundary1D::_init",
                 "Boundary domains can only be connected on the right to flow "
                 "domains, not type {} domains.", r.domainType());
         }

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -110,7 +110,7 @@ void Inlet1D::setMoleFractions(const std::string& xin)
     }
 }
 
-void Inlet1D::setMoleFractions(const doublereal* xin)
+void Inlet1D::setMoleFractions(const double* xin)
 {
     if (m_flow) {
         m_flow->phase().setMoleFractions(xin);
@@ -146,8 +146,8 @@ void Inlet1D::init()
     }
 }
 
-void Inlet1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-                   integer* diagg, doublereal rdt)
+void Inlet1D::eval(size_t jg, double* xg, double* rg,
+                   integer* diagg, double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
@@ -207,7 +207,7 @@ void Inlet1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 }
 
-XML_Node& Inlet1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Inlet1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& inlt = Domain1D::save(o, soln);
     inlt.addAttribute("type","inlet");
@@ -220,7 +220,7 @@ XML_Node& Inlet1D::save(XML_Node& o, const doublereal* const soln)
     return inlt;
 }
 
-void Inlet1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Inlet1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     m_mdot = getFloat(dom, "mdot");
@@ -247,19 +247,19 @@ void Empty1D::init()
     _init(0);
 }
 
-void Empty1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-     integer* diagg, doublereal rdt)
+void Empty1D::eval(size_t jg, double* xg, double* rg,
+     integer* diagg, double rdt)
 {
 }
 
-XML_Node& Empty1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Empty1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& symm = Domain1D::save(o, soln);
     symm.addAttribute("type","empty");
     return symm;
 }
 
-void Empty1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Empty1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
@@ -272,16 +272,16 @@ void Symm1D::init()
     _init(0);
 }
 
-void Symm1D::eval(size_t jg, doublereal* xg, doublereal* rg, integer* diagg,
-                  doublereal rdt)
+void Symm1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
+                  double rdt)
 {
     if (jg != npos && (jg + 2< firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
     integer* diag = diagg + loc();
 
     if (m_flow_right) {
@@ -311,14 +311,14 @@ void Symm1D::eval(size_t jg, doublereal* xg, doublereal* rg, integer* diagg,
     }
 }
 
-XML_Node& Symm1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Symm1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& symm = Domain1D::save(o, soln);
     symm.addAttribute("type","symmetry");
     return symm;
 }
 
-void Symm1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Symm1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
@@ -346,16 +346,16 @@ void Outlet1D::init()
     }
 }
 
-void Outlet1D::eval(size_t jg, doublereal* xg, doublereal* rg, integer* diagg,
-                    doublereal rdt)
+void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
+                    double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
     integer* diag = diagg + loc();
 
     if (m_flow_right) {
@@ -395,14 +395,14 @@ void Outlet1D::eval(size_t jg, doublereal* xg, doublereal* rg, integer* diagg,
     }
 }
 
-XML_Node& Outlet1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Outlet1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& outlt = Domain1D::save(o, soln);
     outlt.addAttribute("type","outlet");
     return outlt;
 }
 
-void Outlet1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Outlet1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
@@ -420,7 +420,7 @@ void OutletRes1D::setMoleFractions(const std::string& xres)
     }
 }
 
-void OutletRes1D::setMoleFractions(const doublereal* xres)
+void OutletRes1D::setMoleFractions(const double* xres)
 {
     if (m_flow) {
         m_flow->phase().setMoleFractions(xres);
@@ -450,16 +450,16 @@ void OutletRes1D::init()
     }
 }
 
-void OutletRes1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-                       integer* diagg, doublereal rdt)
+void OutletRes1D::eval(size_t jg, double* xg, double* rg,
+                       integer* diagg, double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
     integer* diag = diagg + loc();
 
     if (m_flow_right) {
@@ -506,7 +506,7 @@ void OutletRes1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 }
 
-XML_Node& OutletRes1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& OutletRes1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& outlt = Domain1D::save(o, soln);
     outlt.addAttribute("type","outletres");
@@ -518,7 +518,7 @@ XML_Node& OutletRes1D::save(XML_Node& o, const doublereal* const soln)
     return outlt;
 }
 
-void OutletRes1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void OutletRes1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     m_temp = getFloat(dom, "temperature");
@@ -544,16 +544,16 @@ void Surf1D::init()
     _init(0);
 }
 
-void Surf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-                  integer* diagg, doublereal rdt)
+void Surf1D::eval(size_t jg, double* xg, double* rg,
+                  integer* diagg, double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
 
     if (m_flow_right) {
         double* rb = r;
@@ -569,7 +569,7 @@ void Surf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 }
 
-XML_Node& Surf1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& Surf1D::save(XML_Node& o, const double* const soln)
 {
     XML_Node& inlt = Domain1D::save(o, soln);
     inlt.addAttribute("type","surface");
@@ -577,7 +577,7 @@ XML_Node& Surf1D::save(XML_Node& o, const doublereal* const soln)
     return inlt;
 }
 
-void Surf1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
+void Surf1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     m_temp = getFloat(dom, "temperature");
@@ -637,20 +637,20 @@ void ReactingSurf1D::resetBadValues(double* xg) {
     m_sphase->getCoverages(x);
 }
 
-void ReactingSurf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
-                          integer* diagg, doublereal rdt)
+void ReactingSurf1D::eval(size_t jg, double* xg, double* rg,
+                          integer* diagg, double rdt)
 {
     if (jg != npos && (jg + 2 < firstPoint() || jg > lastPoint() + 2)) {
         return;
     }
 
     // start of local part of global arrays
-    doublereal* x = xg + loc();
-    doublereal* r = rg + loc();
+    double* x = xg + loc();
+    double* r = rg + loc();
     integer* diag = diagg + loc();
 
     // set the coverages
-    doublereal sum = 0.0;
+    double sum = 0.0;
     for (size_t k = 0; k < m_nsp; k++) {
         m_work[k] = x[k];
         sum += x[k];
@@ -675,11 +675,11 @@ void ReactingSurf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 
     m_kin->getNetProductionRates(m_work.data());
-    doublereal rs0 = 1.0/m_sphase->siteDensity();
+    double rs0 = 1.0/m_sphase->siteDensity();
     size_t ioffset = m_kin->kineticsSpeciesIndex(0, m_surfindex);
 
     if (m_enabled) {
-        doublereal maxx = -1.0;
+        double maxx = -1.0;
         for (size_t k = 0; k < m_nsp; k++) {
             r[k] = m_work[k + ioffset] * m_sphase->size(k) * rs0;
             r[k] -= rdt*(x[k] - prevSoln(k,0));
@@ -715,9 +715,9 @@ void ReactingSurf1D::eval(size_t jg, doublereal* xg, doublereal* rg,
     }
 }
 
-XML_Node& ReactingSurf1D::save(XML_Node& o, const doublereal* const soln)
+XML_Node& ReactingSurf1D::save(XML_Node& o, const double* const soln)
 {
-    const doublereal* s = soln + loc();
+    const double* s = soln + loc();
     XML_Node& dom = Domain1D::save(o, soln);
     dom.addAttribute("type","surface");
     addFloat(dom, "temperature", m_temp, "K");
@@ -727,7 +727,7 @@ XML_Node& ReactingSurf1D::save(XML_Node& o, const doublereal* const soln)
     return dom;
 }
 
-void ReactingSurf1D::restore(const XML_Node& dom, doublereal* soln,
+void ReactingSurf1D::restore(const XML_Node& dom, double* soln,
                              int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Resolves “small” project idea (see [1D Flame Development Ideas](https://github.com/Cantera/cantera/projects/2)):

> Make class and file names clear and consistent: `Inlet1D.h` should be named `Boundary1D.h`, and class `Bdry1D` should be named `Boundary1D`.

**Changes proposed in this pull request**

While the `Boundary1D.h` diff does not show a good overview, individual commits do: 
* 162d5fbeefc038550aa3d93bf8316ed17d3edac7 (which renames `Brdy1D` to `Boundary1D`, etc.), 
* 62dd18a2f9730f56d8dfea61b342aa12f85394e3 (handling of deprecation) and 
* 86892fa8f199f369232e698ac1680a0ffabf0b57 (which replaces `doublereal` by `double`; since entire files are renamed, I felt like this was an appropriate occasion).
