### PR TITLE
Added access functions to polynomial fits of gas transport properties

### DIFF
--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -115,6 +115,24 @@ public:
      */
     virtual void getMixDiffCoeffsMass(doublereal* const d);
 
+    //! Return the polynomial fits to the viscosity of each species
+    const std::vector<vector_fp> viscosityPolynomials() const
+    {
+        return m_visccoeffs;
+    }
+
+    //! Return the temperature fits of the heat conduction
+    const std::vector<vector_fp> conductivityPolynomials() const
+    {
+        return m_condcoeffs;
+    }
+
+    //! Return the polynomial fits to the binary diffusivity of each species
+    const std::vector<vector_fp> binDiffusivityPolynomials() const
+    {
+        return m_diffcoeffs;
+    }
+
     virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
 
 protected:

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -116,12 +116,15 @@ public:
     virtual void getMixDiffCoeffsMass(doublereal* const d);
 
     //! Return the polynomial fits to the viscosity of species i
+    //! @see fitProperties()
     virtual void getViscosityPolynomials(size_t i, double* coeffs) const;
 
     //! Return the temperature fits of the heat conductivity of species i
+    //! @see fitProperties()
     virtual void getConductivityPolynomials(size_t i, double* coeffs) const;
 
     //! Return the polynomial fits to the binary diffusivity of species pair (i, j)
+    //! @see fitDiffCoeffs()
     virtual void getBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs) const;
 
     virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -115,23 +115,14 @@ public:
      */
     virtual void getMixDiffCoeffsMass(doublereal* const d);
 
-    //! Return the polynomial fits to the viscosity of each species
-    const std::vector<vector_fp> viscosityPolynomials() const
-    {
-        return m_visccoeffs;
-    }
+    //! Return the polynomial fits to the viscosity of species i
+    virtual void getViscosityPolynomials(size_t i, double* coeffs) const;
 
-    //! Return the temperature fits of the heat conduction
-    const std::vector<vector_fp> conductivityPolynomials() const
-    {
-        return m_condcoeffs;
-    }
+    //! Return the temperature fits of the heat conductivity of species i
+    virtual void getConductivityPolynomials(size_t i, double* coeffs) const;
 
-    //! Return the polynomial fits to the binary diffusivity of each species
-    const std::vector<vector_fp> binDiffusivityPolynomials() const
-    {
-        return m_diffcoeffs;
-    }
+    //! Return the polynomial fits to the binary diffusivity of species pair (i, j)
+    virtual void getBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs) const;
 
     virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
 

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -828,9 +828,9 @@ void GasTransport::getBinDiffusivityPolynomials(size_t i, size_t j, double* coef
 {
     size_t mi = (j >= i? i : j);
     size_t mj = (j >= i? j : i);
-    int ic = 0;
+    size_t ic = 0;
     for (size_t ii = 0; ii < mi; ii++) {
-        ic += m_nsp-ii;
+        ic += m_nsp - ii;
     }
     ic += mj - mi;
 

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -810,4 +810,33 @@ void GasTransport::getBinDiffCorrection(double t, MMCollisionInt& integrals,
           (q2*xk*xk + q1*xj*xj + q12*xk*xj);
 }
 
+void GasTransport::getViscosityPolynomials(size_t i, double* coeffs) const
+{
+    for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
+        coeffs[k] = m_visccoeffs[i][k];
+    }
+}
+
+void GasTransport::getConductivityPolynomials(size_t i, double* coeffs) const
+{
+    for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
+        coeffs[k] = m_condcoeffs[i][k];
+    }
+}
+
+void GasTransport::getBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs) const
+{
+    size_t mi = (j >= i? i : j);
+    size_t mj = (j >= i? j : i);
+    int ic = 0;
+    for (size_t ii = 0; ii < mi; ii++) {
+        ic += m_nsp-ii;
+    }
+    ic += mj - mi;
+
+    for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
+        coeffs[k] = m_diffcoeffs[ic][k];
+    }
+}
+
 }

--- a/test/transport/transportPolynomials.cpp
+++ b/test/transport/transportPolynomials.cpp
@@ -10,15 +10,19 @@ class TransportPolynomialsTest : public testing::Test
 {
 public:
     TransportPolynomialsTest() {
-        phase.reset(newPhase("gri30.yaml"));
+        phase.reset(newPhase("h2o2.yaml"));
+        tran.init(phase.get(), 0);
+        ck_tran.init(phase.get(), CK_Mode);
     }
 
     void check_viscosity_poly(const std::string& speciek, const vector_fp& visc_coeff_expected, int cmode) {
-        MixTransport tran;
-        tran.init(phase.get(), cmode);
         size_t k = phase->speciesIndex(speciek);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
-        tran.getViscosityPolynomials(k, &coeffs[0]);
+        if (cmode == CK_Mode) {
+            ck_tran.getViscosityPolynomials(k, &coeffs[0]);
+        } else {
+            tran.getViscosityPolynomials(k, &coeffs[0]);
+        }
         for (size_t i = 0; i < visc_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], visc_coeff_expected[i], 1e-5);
         }
@@ -29,53 +33,61 @@ public:
         tran.init(phase.get(), cmode);
         size_t k = phase->speciesIndex(speciek);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
-        tran.getConductivityPolynomials(k, &coeffs[0]);
+        if (cmode == CK_Mode) {
+            ck_tran.getConductivityPolynomials(k, &coeffs[0]);
+        } else {
+            tran.getConductivityPolynomials(k, &coeffs[0]);
+        }
         for (size_t i = 0; i < cond_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], cond_coeff_expected[i], 1e-5);
         }
     }
 
     void check_bindiff_poly(const std::string& speciek, const std::string& speciej, const vector_fp& bindiff_coeff_expected, int cmode) {
-        MixTransport tran;
-        tran.init(phase.get(), cmode);
         size_t k = phase->speciesIndex(speciek);
         size_t j = phase->speciesIndex(speciej);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
-        tran.getBinDiffusivityPolynomials(k, j, &coeffs[0]);
+        if (cmode == CK_Mode) {
+            ck_tran.getBinDiffusivityPolynomials(k, j, &coeffs[0]);
+        } else {
+            tran.getBinDiffusivityPolynomials(k, j, &coeffs[0]);
+        }
         for (size_t i = 0; i < bindiff_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], bindiff_coeff_expected[i], 1e-5);
         }
     }
 
     std::unique_ptr<ThermoPhase> phase;
+    MixTransport tran;
+    MixTransport ck_tran;
 };
 
 
 
 TEST_F(TransportPolynomialsTest, viscosityPolynomials)
 {
-    check_viscosity_poly("H2", {-0.00044135741, 0.00054143229, -0.00010356811, 9.67388e-06, -3.32304e-07}, 0);
-    check_viscosity_poly("O2", {-0.00628086, 0.0036755258, -0.00069891557, 6.0422681e-05, -1.9517881e-06}, 0);
-    check_viscosity_poly("H2O", {0.01283557, -0.0070486222, 0.0014476475, -0.00012428231, 3.86979e-06}, 0);
-    check_viscosity_poly("H2", {-15.80391, 0.853653, -0.028234165, 0.00126934}, CK_Mode);
-    check_viscosity_poly("O2", {-19.450466, 2.6764033, -0.27227259, 0.012162949}, CK_Mode);
-    check_viscosity_poly("H2O", {-14.902224, -0.528783, 0.3032122, -0.018641952}, CK_Mode);
+    check_viscosity_poly("H2", {-0.0003286235158, 0.0004740294433, -8.852339014e-05, 8.188000383e-06, -2.775116847e-07}, 0);
+    check_viscosity_poly("O2", {-0.006186428072, 0.003618824512, -0.0006861983405, 5.91601271e-05, -1.904977178e-06}, 0);
+    check_viscosity_poly("H2O", {0.009686030092, -0.005171558465, 0.001029793739, -8.310407406e-05, 2.354033086e-06}, 0);
+    check_viscosity_poly("H2", {-15.74843779, 0.8286882329, -0.0245136295, 0.001085683251}, CK_Mode);
+    check_viscosity_poly("O2", {-19.07096138, 2.50635136, -0.2470281853, 0.01092118192}, CK_Mode);
+    check_viscosity_poly("H2O", {-15.36038093, -0.324024089, 0.2728840212, -0.01715300254}, CK_Mode);
 }
 
 TEST_F(TransportPolynomialsTest, conductivityPolynomials)
 {
-    check_cond_poly("H2", vector_fp({-1.0486523, 0.622758, -0.13650987, 0.01318645, -0.00047094451}), 0);
-    check_cond_poly("O2", vector_fp({0.1259865, -0.0751831, 0.016766921, -0.0016427659, 6.02148e-05}), 0);
-    check_cond_poly("H2O", vector_fp({-0.33407864, 0.20877084, -0.0484958, 0.0049524531, -0.00018565441}), 0);
-    check_cond_poly("H2", vector_fp({-1.86328, -0.650749, 0.14256814, -0.003901962}), CK_Mode);
-    check_cond_poly("O2", vector_fp({-13.457014, 2.8963447, -0.272143, 0.011597346}), CK_Mode);
-    check_cond_poly("H2O", vector_fp({8.676, -7.62436, 1.33959, -0.066989854}), CK_Mode);
+    check_cond_poly("H2", vector_fp({-0.9677034329, 0.574433766, -0.1257371151, 0.01212356977, -0.0004317820758}), 0);
+    check_cond_poly("O2", vector_fp({0.106895521, -0.06376711344, 0.01421775618, -0.001390841153, 5.091744389e-05}), 0);
+    check_cond_poly("H2O", vector_fp({-0.4100422806, 0.2548542901, -0.05893633847, 0.005999369421, -0.0002248571694}), 0);
+    check_cond_poly("H2", vector_fp({0.4732693668, -1.700244996, 0.2987141261, -0.01159868465}), CK_Mode);
+    check_cond_poly("O2", vector_fp({-14.49659725, 3.36457572, -0.3419869392, 0.01504842571}), CK_Mode);
+    check_cond_poly("H2O", vector_fp({10.32430752, -8.362450552, 1.449100507, -0.07237437923}), CK_Mode);
 }
 
 TEST_F(TransportPolynomialsTest, binDiffusivityPolynomials)
 {
-    check_bindiff_poly("H2", "H2O", vector_fp({-0.00796698, 0.0029745048, -0.00023517416, -3.66864e-06, 9.44696e-07}), 0);
-    check_bindiff_poly("O2", "O2", vector_fp({-0.0031017126, 0.0016181327, -0.000286911, 2.347239e-05, -7.01879e-07}), 0);
-    check_bindiff_poly("H2O", "O2",  vector_fp({ -18.805519, 5.5532975, -0.48501682, 0.020188987}), CK_Mode);
-    check_bindiff_poly("H2", "O2", vector_fp({-9.45132, 2.5185864, -0.11599084, 0.0051866062}), CK_Mode);
+    check_bindiff_poly("H2", "H2O", vector_fp({-0.009701326278, 0.004014323899, -0.0004679109588, 1.938085266e-05, 9.241023548e-08}), 0);
+    check_bindiff_poly("O2", "O2", vector_fp({-0.003127289937, 0.001633232189, -0.0002902324473, 2.379515419e-05, -7.135754459e-07}), 0);
+    check_bindiff_poly("H2O", "O2",  vector_fp({-18.63036291, 5.475482371, -0.4735550509, 0.01962919378}), CK_Mode);
+    check_bindiff_poly("H2", "O2", vector_fp({-9.272394946, 2.438367828, -0.1040764365, 0.00460028674}), CK_Mode);
 }

--- a/test/transport/transportPolynomials.cpp
+++ b/test/transport/transportPolynomials.cpp
@@ -10,12 +10,12 @@ class TransportPolynomialsTest : public testing::Test
 {
 public:
     TransportPolynomialsTest() {
-        phase = newPhase("gri30.cti");
+        phase.reset(newPhase("gri30.yaml"));
     }
 
     void check_viscosity_poly(const std::string& speciek, const vector_fp& visc_coeff_expected, int cmode) {
         MixTransport tran;
-        tran.init(phase, cmode);
+        tran.init(phase.get(), cmode);
         size_t k = phase->speciesIndex(speciek);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
         tran.getViscosityPolynomials(k, &coeffs[0]);
@@ -26,7 +26,7 @@ public:
 
     void check_cond_poly(const std::string& speciek, const vector_fp& cond_coeff_expected, int cmode) {
         MixTransport tran;
-        tran.init(phase, cmode);
+        tran.init(phase.get(), cmode);
         size_t k = phase->speciesIndex(speciek);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
         tran.getConductivityPolynomials(k, &coeffs[0]);
@@ -37,7 +37,7 @@ public:
 
     void check_bindiff_poly(const std::string& speciek, const std::string& speciej, const vector_fp& bindiff_coeff_expected, int cmode) {
         MixTransport tran;
-        tran.init(phase, cmode);
+        tran.init(phase.get(), cmode);
         size_t k = phase->speciesIndex(speciek);
         size_t j = phase->speciesIndex(speciej);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
@@ -47,29 +47,29 @@ public:
         }
     }
 
-    ThermoPhase* phase;
+    std::unique_ptr<ThermoPhase> phase;
 };
 
 
 
 TEST_F(TransportPolynomialsTest, viscosityPolynomials)
 {
-    check_viscosity_poly("H2", {-0.00044135741,0.00054143229,-0.00010356811,9.67388e-06,-3.32304e-07}, 0);
-    check_viscosity_poly("O2", {-0.00628086,0.0036755258,-0.00069891557,6.0422681e-05,-1.9517881e-06}, 0);
-    check_viscosity_poly("H2O", {0.01283557,-0.0070486222,0.0014476475,-0.00012428231,3.86979e-06}, 0);
-    check_viscosity_poly("H2", {-15.80391,0.853653,-0.028234165,0.00126934}, CK_Mode);
-    check_viscosity_poly("O2", {-19.450466,2.6764033,-0.27227259,0.012162949}, CK_Mode);
-    check_viscosity_poly("H2O", {-14.902224,-0.528783,0.3032122,-0.018641952}, CK_Mode);
+    check_viscosity_poly("H2", {-0.00044135741, 0.00054143229, -0.00010356811, 9.67388e-06, -3.32304e-07}, 0);
+    check_viscosity_poly("O2", {-0.00628086, 0.0036755258, -0.00069891557, 6.0422681e-05, -1.9517881e-06}, 0);
+    check_viscosity_poly("H2O", {0.01283557, -0.0070486222, 0.0014476475, -0.00012428231, 3.86979e-06}, 0);
+    check_viscosity_poly("H2", {-15.80391, 0.853653, -0.028234165, 0.00126934}, CK_Mode);
+    check_viscosity_poly("O2", {-19.450466, 2.6764033, -0.27227259, 0.012162949}, CK_Mode);
+    check_viscosity_poly("H2O", {-14.902224, -0.528783, 0.3032122, -0.018641952}, CK_Mode);
 }
 
 TEST_F(TransportPolynomialsTest, conductivityPolynomials)
 {
-    check_cond_poly("H2", vector_fp({-1.0486523,0.622758,-0.13650987,0.01318645,-0.00047094451}), 0);
-    check_cond_poly("O2", vector_fp({0.1259865,-0.0751831,0.016766921,-0.0016427659,6.02148e-05}), 0);
-    check_cond_poly("H2O", vector_fp({ -0.33407864,0.20877084,-0.0484958,0.0049524531,-0.00018565441}), 0);
-    check_cond_poly("H2", vector_fp({-1.86328,-0.650749,0.14256814,-0.003901962}), CK_Mode);
-    check_cond_poly("O2", vector_fp({-13.457014,2.8963447,-0.272143,0.011597346}), CK_Mode);
-    check_cond_poly("H2O", vector_fp({8.676,-7.62436,1.33959,-0.066989854}), CK_Mode);
+    check_cond_poly("H2", vector_fp({-1.0486523, 0.622758, -0.13650987, 0.01318645, -0.00047094451}), 0);
+    check_cond_poly("O2", vector_fp({0.1259865, -0.0751831, 0.016766921, -0.0016427659, 6.02148e-05}), 0);
+    check_cond_poly("H2O", vector_fp({-0.33407864, 0.20877084, -0.0484958, 0.0049524531, -0.00018565441}), 0);
+    check_cond_poly("H2", vector_fp({-1.86328, -0.650749, 0.14256814, -0.003901962}), CK_Mode);
+    check_cond_poly("O2", vector_fp({-13.457014, 2.8963447, -0.272143, 0.011597346}), CK_Mode);
+    check_cond_poly("H2O", vector_fp({8.676, -7.62436, 1.33959, -0.066989854}), CK_Mode);
 }
 
 TEST_F(TransportPolynomialsTest, binDiffusivityPolynomials)

--- a/test/transport/transportPolynomials.cpp
+++ b/test/transport/transportPolynomials.cpp
@@ -17,8 +17,8 @@ public:
         MixTransport tran;
         tran.init(phase, cmode);
         size_t k = phase->speciesIndex(speciek);
-        double coeffs[(cmode == CK_Mode ? 4 : 5)];
-        tran.getViscosityPolynomials(k, coeffs);
+        vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
+        tran.getViscosityPolynomials(k, &coeffs[0]);
         for (size_t i = 0; i < visc_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], visc_coeff_expected[i], 1e-5);
         }
@@ -28,8 +28,8 @@ public:
         MixTransport tran;
         tran.init(phase, cmode);
         size_t k = phase->speciesIndex(speciek);
-        double coeffs[(cmode == CK_Mode ? 4 : 5)];
-        tran.getConductivityPolynomials(k, coeffs);
+        vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
+        tran.getConductivityPolynomials(k, &coeffs[0]);
         for (size_t i = 0; i < cond_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], cond_coeff_expected[i], 1e-5);
         }
@@ -40,8 +40,8 @@ public:
         tran.init(phase, cmode);
         size_t k = phase->speciesIndex(speciek);
         size_t j = phase->speciesIndex(speciej);
-        double coeffs[(cmode == CK_Mode ? 4 : 5)];
-        tran.getBinDiffusivityPolynomials(k, j, coeffs);
+        vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
+        tran.getBinDiffusivityPolynomials(k, j, &coeffs[0]);
         for (size_t i = 0; i < bindiff_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], bindiff_coeff_expected[i], 1e-5);
         }

--- a/test/transport/transportPolynomials.cpp
+++ b/test/transport/transportPolynomials.cpp
@@ -13,34 +13,34 @@ public:
         phase = newPhase("gri30.cti");
     }
 
-    void check_viscosity_poly(const std::string& speciek, const vector_fp& visc_coeff_expected, int mode) {
+    void check_viscosity_poly(const std::string& speciek, const vector_fp& visc_coeff_expected, int cmode) {
         MixTransport tran;
-        tran.init(phase, mode);
+        tran.init(phase, cmode);
         size_t k = phase->speciesIndex(speciek);
-        double coeffs[(mode == CK_Mode ? 4 : 5)];
+        double coeffs[(cmode == CK_Mode ? 4 : 5)];
         tran.getViscosityPolynomials(k, coeffs);
         for (size_t i = 0; i < visc_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], visc_coeff_expected[i], 1e-5);
         }
     }
 
-    void check_cond_poly(const std::string& speciek, const vector_fp& cond_coeff_expected, int mode) {
+    void check_cond_poly(const std::string& speciek, const vector_fp& cond_coeff_expected, int cmode) {
         MixTransport tran;
-        tran.init(phase, mode);
+        tran.init(phase, cmode);
         size_t k = phase->speciesIndex(speciek);
-        double coeffs[(mode == CK_Mode ? 4 : 5)];
+        double coeffs[(cmode == CK_Mode ? 4 : 5)];
         tran.getConductivityPolynomials(k, coeffs);
         for (size_t i = 0; i < cond_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], cond_coeff_expected[i], 1e-5);
         }
     }
 
-    void check_bindiff_poly(const std::string& speciek, const std::string& speciej, const vector_fp& bindiff_coeff_expected, int mode) {
+    void check_bindiff_poly(const std::string& speciek, const std::string& speciej, const vector_fp& bindiff_coeff_expected, int cmode) {
         MixTransport tran;
-        tran.init(phase, mode);
+        tran.init(phase, cmode);
         size_t k = phase->speciesIndex(speciek);
         size_t j = phase->speciesIndex(speciej);
-        double coeffs[(mode == CK_Mode ? 4 : 5)];
+        double coeffs[(cmode == CK_Mode ? 4 : 5)];
         tran.getBinDiffusivityPolynomials(k, j, coeffs);
         for (size_t i = 0; i < bindiff_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], bindiff_coeff_expected[i], 1e-5);

--- a/test/transport/transportPolynomials.cpp
+++ b/test/transport/transportPolynomials.cpp
@@ -1,0 +1,87 @@
+#include "gtest/gtest.h"
+
+#include "cantera/transport/TransportFactory.h"
+#include "cantera/thermo/ThermoFactory.h"
+#include "cantera/transport/MixTransport.h"
+
+using namespace Cantera;
+
+class TransportPolynomialsTest : public testing::Test
+{
+public:
+    TransportPolynomialsTest() {
+        phase = newPhase("gri30.cti");
+    }
+
+    void check_viscosity_poly(const std::string speciek, vector_fp visc_coeff_expected, int mode) {
+        MixTransport tran;
+        tran.init(phase, mode);
+        size_t k = phase->speciesIndex(speciek);
+        for (size_t i = 0; i<visc_coeff_expected.size(); i++) { 
+            EXPECT_FLOAT_EQ(tran.viscosityPolynomials()[k][i], visc_coeff_expected[i]);
+        }
+    }
+
+    void check_cond_poly(const std::string speciek, vector_fp cond_coeff_expected, int mode) {
+        MixTransport tran;
+        tran.init(phase, mode);
+        size_t k = phase->speciesIndex(speciek);
+        for (size_t i = 0; i<cond_coeff_expected.size(); i++) {
+            EXPECT_FLOAT_EQ(tran.conductivityPolynomials()[k][i], cond_coeff_expected[i]);
+        }
+    }
+
+    void check_bindiff_poly(const std::string speciek, const std::string speciej, vector_fp bindiff_coeff_expected, int mode) {
+        size_t k = phase->speciesIndex(speciek);
+        size_t j = phase->speciesIndex(speciej);
+        MixTransport tran;
+        tran.init(phase, mode);
+        int ic = 0;
+        if (k < j) {
+            for (size_t kk = 0; kk < k; kk++) {
+                for (size_t jj = kk; jj < phase->nSpecies(); jj++) { ic++;}
+            }
+            for (size_t jj = k; jj < j; jj++) { ic++;}
+        } else {
+            for (size_t jj = 0; jj < j; jj++) {
+                for (size_t kk = jj; kk < phase->nSpecies(); kk++) { ic++;}
+            }
+            for (size_t kk = j; kk < k; kk++) { ic++;}
+        }    
+        for (size_t i = 0; i<bindiff_coeff_expected.size(); i++) {
+            EXPECT_FLOAT_EQ(tran.binDiffusivityPolynomials()[ic][i], bindiff_coeff_expected[i]);
+        }
+    }
+
+    ThermoPhase* phase;
+};
+
+
+
+TEST_F(TransportPolynomialsTest, viscosityPolynomials)
+{
+    check_viscosity_poly("H2", {-0.00044135741,0.00054143229,-0.00010356811,9.67388e-06,-3.32304e-07}, 0);
+    check_viscosity_poly("O2", {-0.00628086,0.0036755258,-0.00069891557,6.0422681e-05,-1.9517881e-06}, 0);
+    check_viscosity_poly("H2O", {0.01283557,-0.0070486222,0.0014476475,-0.00012428231,3.86979e-06}, 0);
+    check_viscosity_poly("H2", {-15.80391,0.853653,-0.028234165,0.00126934}, 10);
+    check_viscosity_poly("O2", {-19.450466,2.6764033,-0.27227259,0.012162949}, 10);
+    check_viscosity_poly("H2O", {-14.902224,-0.528783,0.3032122,-0.018641952}, 10);
+}
+
+TEST_F(TransportPolynomialsTest, conductivityPolynomials)
+{
+    check_cond_poly("H2", vector_fp({-1.0486523,0.622758,-0.13650987,0.01318645,-0.00047094451}), 0);
+    check_cond_poly("O2", vector_fp({0.1259865,-0.0751831,0.016766921,-0.0016427659,6.02148e-05}), 0);
+    check_cond_poly("H2O", vector_fp({ -0.33407864,0.20877084,-0.0484958,0.0049524531,-0.00018565441}), 0);
+    check_cond_poly("H2", vector_fp({-1.86328,-0.650749,0.14256814,-0.003901962}), 10);
+    check_cond_poly("O2", vector_fp({-13.457014,2.8963447,-0.272143,0.011597346}), 10);
+    check_cond_poly("H2O", vector_fp({8.676,-7.62436,1.33959,-0.066989854}), 10);
+}
+
+TEST_F(TransportPolynomialsTest, binDiffusivityPolynomials)
+{
+    check_bindiff_poly("H2", "H2O", vector_fp({-0.00796698, 0.0029745048, -0.00023517416, -3.66864e-06, 9.44696e-07}), 0);
+    check_bindiff_poly("O2", "O2", vector_fp({-0.0031017126, 0.0016181327, -0.000286911, 2.347239e-05, -7.01879e-07}), 0);
+    check_bindiff_poly("H2O", "O2",  vector_fp({ -18.805519, 5.5532975, -0.48501682, 0.020188987}), 10);
+    check_bindiff_poly("H2", "O2", vector_fp({-9.45132, 2.5185864, -0.11599084, 0.0051866062}), 10);
+}

--- a/test/transport/transportPolynomials.cpp
+++ b/test/transport/transportPolynomials.cpp
@@ -13,43 +13,37 @@ public:
         phase = newPhase("gri30.cti");
     }
 
-    void check_viscosity_poly(const std::string speciek, vector_fp visc_coeff_expected, int mode) {
+    void check_viscosity_poly(const std::string& speciek, const vector_fp& visc_coeff_expected, int mode) {
         MixTransport tran;
         tran.init(phase, mode);
         size_t k = phase->speciesIndex(speciek);
-        for (size_t i = 0; i<visc_coeff_expected.size(); i++) { 
-            EXPECT_FLOAT_EQ(tran.viscosityPolynomials()[k][i], visc_coeff_expected[i]);
+        double coeffs[(mode == CK_Mode ? 4 : 5)];
+        tran.getViscosityPolynomials(k, coeffs);
+        for (size_t i = 0; i < visc_coeff_expected.size(); i++) {
+            EXPECT_NEAR(coeffs[i], visc_coeff_expected[i], 1e-5);
         }
     }
 
-    void check_cond_poly(const std::string speciek, vector_fp cond_coeff_expected, int mode) {
+    void check_cond_poly(const std::string& speciek, const vector_fp& cond_coeff_expected, int mode) {
         MixTransport tran;
         tran.init(phase, mode);
         size_t k = phase->speciesIndex(speciek);
-        for (size_t i = 0; i<cond_coeff_expected.size(); i++) {
-            EXPECT_FLOAT_EQ(tran.conductivityPolynomials()[k][i], cond_coeff_expected[i]);
+        double coeffs[(mode == CK_Mode ? 4 : 5)];
+        tran.getConductivityPolynomials(k, coeffs);
+        for (size_t i = 0; i < cond_coeff_expected.size(); i++) {
+            EXPECT_NEAR(coeffs[i], cond_coeff_expected[i], 1e-5);
         }
     }
 
-    void check_bindiff_poly(const std::string speciek, const std::string speciej, vector_fp bindiff_coeff_expected, int mode) {
+    void check_bindiff_poly(const std::string& speciek, const std::string& speciej, const vector_fp& bindiff_coeff_expected, int mode) {
+        MixTransport tran;
+        tran.init(phase, mode);
         size_t k = phase->speciesIndex(speciek);
         size_t j = phase->speciesIndex(speciej);
-        MixTransport tran;
-        tran.init(phase, mode);
-        int ic = 0;
-        if (k < j) {
-            for (size_t kk = 0; kk < k; kk++) {
-                for (size_t jj = kk; jj < phase->nSpecies(); jj++) { ic++;}
-            }
-            for (size_t jj = k; jj < j; jj++) { ic++;}
-        } else {
-            for (size_t jj = 0; jj < j; jj++) {
-                for (size_t kk = jj; kk < phase->nSpecies(); kk++) { ic++;}
-            }
-            for (size_t kk = j; kk < k; kk++) { ic++;}
-        }    
-        for (size_t i = 0; i<bindiff_coeff_expected.size(); i++) {
-            EXPECT_FLOAT_EQ(tran.binDiffusivityPolynomials()[ic][i], bindiff_coeff_expected[i]);
+        double coeffs[(mode == CK_Mode ? 4 : 5)];
+        tran.getBinDiffusivityPolynomials(k, j, coeffs);
+        for (size_t i = 0; i < bindiff_coeff_expected.size(); i++) {
+            EXPECT_NEAR(coeffs[i], bindiff_coeff_expected[i], 1e-5);
         }
     }
 
@@ -63,9 +57,9 @@ TEST_F(TransportPolynomialsTest, viscosityPolynomials)
     check_viscosity_poly("H2", {-0.00044135741,0.00054143229,-0.00010356811,9.67388e-06,-3.32304e-07}, 0);
     check_viscosity_poly("O2", {-0.00628086,0.0036755258,-0.00069891557,6.0422681e-05,-1.9517881e-06}, 0);
     check_viscosity_poly("H2O", {0.01283557,-0.0070486222,0.0014476475,-0.00012428231,3.86979e-06}, 0);
-    check_viscosity_poly("H2", {-15.80391,0.853653,-0.028234165,0.00126934}, 10);
-    check_viscosity_poly("O2", {-19.450466,2.6764033,-0.27227259,0.012162949}, 10);
-    check_viscosity_poly("H2O", {-14.902224,-0.528783,0.3032122,-0.018641952}, 10);
+    check_viscosity_poly("H2", {-15.80391,0.853653,-0.028234165,0.00126934}, CK_Mode);
+    check_viscosity_poly("O2", {-19.450466,2.6764033,-0.27227259,0.012162949}, CK_Mode);
+    check_viscosity_poly("H2O", {-14.902224,-0.528783,0.3032122,-0.018641952}, CK_Mode);
 }
 
 TEST_F(TransportPolynomialsTest, conductivityPolynomials)
@@ -73,15 +67,15 @@ TEST_F(TransportPolynomialsTest, conductivityPolynomials)
     check_cond_poly("H2", vector_fp({-1.0486523,0.622758,-0.13650987,0.01318645,-0.00047094451}), 0);
     check_cond_poly("O2", vector_fp({0.1259865,-0.0751831,0.016766921,-0.0016427659,6.02148e-05}), 0);
     check_cond_poly("H2O", vector_fp({ -0.33407864,0.20877084,-0.0484958,0.0049524531,-0.00018565441}), 0);
-    check_cond_poly("H2", vector_fp({-1.86328,-0.650749,0.14256814,-0.003901962}), 10);
-    check_cond_poly("O2", vector_fp({-13.457014,2.8963447,-0.272143,0.011597346}), 10);
-    check_cond_poly("H2O", vector_fp({8.676,-7.62436,1.33959,-0.066989854}), 10);
+    check_cond_poly("H2", vector_fp({-1.86328,-0.650749,0.14256814,-0.003901962}), CK_Mode);
+    check_cond_poly("O2", vector_fp({-13.457014,2.8963447,-0.272143,0.011597346}), CK_Mode);
+    check_cond_poly("H2O", vector_fp({8.676,-7.62436,1.33959,-0.066989854}), CK_Mode);
 }
 
 TEST_F(TransportPolynomialsTest, binDiffusivityPolynomials)
 {
     check_bindiff_poly("H2", "H2O", vector_fp({-0.00796698, 0.0029745048, -0.00023517416, -3.66864e-06, 9.44696e-07}), 0);
     check_bindiff_poly("O2", "O2", vector_fp({-0.0031017126, 0.0016181327, -0.000286911, 2.347239e-05, -7.01879e-07}), 0);
-    check_bindiff_poly("H2O", "O2",  vector_fp({ -18.805519, 5.5532975, -0.48501682, 0.020188987}), 10);
-    check_bindiff_poly("H2", "O2", vector_fp({-9.45132, 2.5185864, -0.11599084, 0.0051866062}), 10);
+    check_bindiff_poly("H2O", "O2",  vector_fp({ -18.805519, 5.5532975, -0.48501682, 0.020188987}), CK_Mode);
+    check_bindiff_poly("H2", "O2", vector_fp({-9.45132, 2.5185864, -0.11599084, 0.0051866062}), CK_Mode);
 }


### PR DESCRIPTION
**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes issue 40 in Cantera/enhancements repo

**Changes proposed in this pull request**

- Added const access functions to the polynomial fits of viscosity, conductivity and binary diffusivity
