### PR TITLE
[samples] Fix heat release in ic_engine.py

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -513,9 +513,15 @@ class SolutionArray:
             self._indices = list(np.ndindex(self._shape))
             self._output_dummy = self._states[..., 0]
 
+        reserved = self.__dir__()
+
         self._extra = {}
         if isinstance(extra, dict):
             for name, v in extra.items():
+                if name in reserved:
+                    raise ValueError(
+                        "Unable to create extra column '{}': name is already "
+                        "used by SolutionArray objects.".format(name))
                 if not np.shape(v):
                     self._extra[name] = [v]*self._shape[0]
                 elif len(v) == self._shape[0]:
@@ -526,6 +532,10 @@ class SolutionArray:
 
         elif extra and self._shape == (0,):
             for name in extra:
+                if name in reserved:
+                    raise ValueError(
+                        "Unable to create extra column '{}': name is already "
+                        "used by SolutionArray objects.".format(name))
                 self._extra[name] = []
 
         elif extra:

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1641,6 +1641,10 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertArrayNear(col3.T, 900*np.ones(2))
         self.assertArrayNear(row2.T, 900*np.ones(5))
 
+    def test_extra(self):
+        with self.assertRaises(ValueError):
+            states = ct.SolutionArray(self.gas, extra=['creation_rates'])
+        
     def test_append(self):
         states = ct.SolutionArray(self.gas, 5)
         states.TPX = np.linspace(500, 1000, 5), 2e5, 'H2:0.5, O2:0.4'


### PR DESCRIPTION

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #819

**Changes proposed in this pull request**

This commit fixes a bug caused by the recently introduced `heat_release_rate` method of `SolutionArray` objects (PR #810): the new method masked the pre-existing homonymous `extra` column.

The behavior is now corrected
```
In [1]: %run ic_engine.py
Heat release rate per cylinder (estimate):   35.4 kW
Expansion power per cylinder (estimate):     18.5 kW
Efficiency (estimate):                       52.3 %
CO emission (estimate):                       8.8 ppm
```