### PR TITLE
Add 'negative_A' option for third body reactions

### DIFF
--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -669,6 +669,12 @@ class ThirdBody(KineticsModel):
         lines[-1] = lines[-1][:-1] + ')'
         return '\n'.join(lines)
 
+    def options(self):
+        if self.arrheniusHigh.A[0] < 0:
+            return ['negative_A']
+        else:
+            return []
+
 
 class Falloff(ThirdBody):
     """

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -264,6 +264,13 @@ class converterTestCommon:
         self.checkKinetics(ref, gas, [300, 800, 1450, 2800], [5e3, 1e5, 2e6],
                            tol=2e-7)
 
+    def test_negative_A_factor(self):
+        self.convert('negative-rate.inp', thermo='dummy-thermo.dat')
+        gas = ct.Solution('negative-rate.cti')  # Validate the mechanism
+        self.assertLess(gas.reaction(4).rate.pre_exponential_factor, 0)
+        self.assertLess(gas.reaction(1).rate.pre_exponential_factor, 0)
+        self.assertLess(gas.reaction(2).rate.pre_exponential_factor, 0)
+
     def test_bad_troe_value(self):
         with self.assertRaises(ValueError):
             self.convert('bad-troe.inp', thermo='dummy-thermo.dat')

--- a/test/data/negative-rate.inp
+++ b/test/data/negative-rate.inp
@@ -1,0 +1,27 @@
+ELEMENTS
+H  C   AR
+END
+
+SPECIES
+H
+AR
+R1A R1B P1 R6
+END
+
+REACTIONS
+
+R1A+R1B=>H+P1              1e12  0.0   20000.0
+  DUPLICATE
+
+H+P1=>R1A+R1B             -5e13 -2.0 5000.0
+
+R1A+R1B=>H+P1              -1e11  0.0   20000.0
+  DUPLICATE
+
+R1A+R1B+M=>R6+M              2e11  0.0   20000.0
+  DUPLICATE
+
+R1A+R1B+M=>R6+M              -1e11  0.0   20000.0
+  DUPLICATE
+
+END


### PR DESCRIPTION
Previously, a set of reactions in chemkin format such as the following...
`R1A+R1B+M=>R6+M              2e11  0.0   20000.0`
`  DUPLICATE`
` `  
`R1A+R1B+M=>R6+M              -1e11  0.0   20000.0`
`DUPLICATE`
...would cause the error below when validating the mechanism.
`***********************************************************************`
`CanteraError thrown by ElementaryReaction::validate:`
`Undeclared negative pre-exponential factor found in reaction 'R1A + R1B + M => R6 + M'`
`***********************************************************************`

This pull request automatically adds the 'negative_A' options to these third body reactions after conversion to cantera format, similar to the implementation with Arrhenius reactions. This does not modify falloff third-body reactions, for which the validator doesn't support negative A-factors. A test is also added.
