### PR TITLE
[SCons] Fix 'KeyError' for ' --prefix=${python_prefix}'

### DIFF
--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -109,7 +109,7 @@ elif localenv['python_prefix']:
     elif localenv['libdirname'] != 'lib':
         # 64-bit RHEL / Fedora etc. or e.g. x32 Gentoo profile
         extra = localenv.subst(
-            ' --prefix=${python_prefix}'
+            ' --prefix=${{python_prefix}}'
             ' --install-lib=${{python_prefix}}/${{libdirname}}/python{}/site-packages'.format(py_version))
     else:
         extra = '--user'


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes # https://github.com/Cantera/cantera/commit/582eb42#commitcomment-37960551

**Changes proposed in this pull request**

The `.format()` method is applied after concatenation of two parts of string
in `localenv.subst()` function so the `{python_prefix}` in the first sunstring
was assumed as `format` mapping key instead of env variable `${python_prefix}`.
