### PR TITLE
Fix test failure when re-running purefluid tests 

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -157,8 +157,8 @@ development of Cantera through NumFOCUS.
     :width: 675px
     :align: middle
 
-.. |travisci| image:: https://travis-ci.org/Cantera/cantera.svg?branch=master
-    :target: https://travis-ci.org/Cantera/cantera
+.. |travisci| image:: https://travis-ci.com/Cantera/cantera.svg?branch=master
+    :target: https://travis-ci.com/Cantera/cantera
 
 .. |appveyor| image:: https://ci.appveyor.com/api/projects/status/auhd35qn9cdmkpoj?svg=true
     :target: https://ci.appveyor.com/project/Cantera/cantera

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -668,13 +668,17 @@ class cti2yamlTest(utilities.CanteraTest):
         self.checkKinetics(cti_tpb, yaml_tpb, [900, 1000, 1100], [1e5])
 
     def test_liquidvapor(self):
+        output_file = Path(self.test_work_dir).joinpath('liquidvapor.yaml')
         cti2yaml.convert(Path(self.cantera_data).joinpath('liquidvapor.cti'),
-                         Path(self.test_work_dir).joinpath('liquidvapor.yaml'))
+                         output_file)
         for name in ['water', 'nitrogen', 'methane', 'hydrogen', 'oxygen',
                      'hfc134a', 'carbondioxide', 'heptane']:
             ctiPhase, yamlPhase = self.checkConversion('liquidvapor', name=name)
             self.checkThermo(ctiPhase, yamlPhase,
                              [1.3 * ctiPhase.min_temp, 0.7 * ctiPhase.max_temp])
+        # The output file must be removed after this test because it shadows
+        # a file distributed with Cantera that is used in other tests.
+        output_file.unlink()
 
     def test_Redlich_Kwong_CO2(self):
         cti2yaml.convert(Path(self.test_data_dir).joinpath('co2_RK_example.cti'),
@@ -894,15 +898,18 @@ class ctml2yamlTest(utilities.CanteraTest):
         self.checkKinetics(ctml_tpb, yaml_tpb, [900, 1000, 1100], [1e5])
 
     def test_liquidvapor(self):
+        output_file = Path(self.test_work_dir).joinpath('liquidvapor.yaml')
         ctml2yaml.convert(
-            Path(self.cantera_data).joinpath('liquidvapor.xml'),
-            Path(self.test_work_dir).joinpath('liquidvapor.yaml'),
+            Path(self.cantera_data).joinpath('liquidvapor.xml'), output_file,
         )
         for name in ['water', 'nitrogen', 'methane', 'hydrogen', 'oxygen',
                      'hfc134a', 'carbondioxide', 'heptane']:
             ctmlPhase, yamlPhase = self.checkConversion('liquidvapor', name=name)
             self.checkThermo(ctmlPhase, yamlPhase,
                              [1.3 * ctmlPhase.min_temp, 0.7 * ctmlPhase.max_temp])
+        # The output file must be removed after this test because it shadows
+        # a file distributed with Cantera that is used in other tests.
+        output_file.unlink()
 
     def test_Redlich_Kwong_CO2(self):
         ctml2yaml.convert(


### PR DESCRIPTION
**Changes proposed in this pull request**

The `liquidvapor.yaml` generated by the test suite from the XML or CTI input files is not the same as the one in the Cantera data directory because new names for some of the phase names have been added (such as `carbon-dioxide` instead of `carbondioxide`) which are not in the old input files.

Testing errors would occur when the generated `liquidvapor.yaml` was then read instead of the version from the Cantera data directory, which would happen when re-running the test suite, since normally the pure fluid tests run before the conversion tests.

Also, update Travis badge to reflect migration from .org to .com.

**Checklist**

- [X] There is a clear use-case for this code change
- [X] The commit message has a short title & references relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] The pull request is ready for review
