### PR TITLE
Updates to fortran interface

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -412,7 +412,7 @@ config_options = [
     PathVariable(
         'FORTRAN',
         """The Fortran (90) compiler. If unspecified, the builder will look for
-           a compatible compiler (gfortran, ifort, g95) in the 'PATH' environment
+           a compatible compiler (pgfortran, gfortran, ifort, g95) in the 'PATH' environment
            variable. Used only for compiling the Fortran 90 interface.""",
         '', PathVariable.PathAccept),
     ('FORTRANFLAGS',
@@ -1171,7 +1171,7 @@ if env['f90_interface'] in ('y','default'):
     if env['FORTRAN']:
         foundF90 = check_fortran(env['FORTRAN'], True)
 
-    for compiler in ('gfortran', 'ifort', 'g95'):
+    for compiler in ('pgfortran', 'gfortran', 'ifort', 'g95'):
         if foundF90:
             break
         foundF90 = check_fortran(compiler)
@@ -1188,7 +1188,9 @@ if env['f90_interface'] in ('y','default'):
             env['FORTRAN'] = ''
             print("INFO: Skipping compilation of the Fortran 90 interface.")
 
-if 'gfortran' in env['FORTRAN']:
+if 'pgfortran' in env['FORTRAN']:
+    env['FORTRANMODDIRPREFIX'] = '-module '
+elif 'gfortran' in env['FORTRAN']:
     env['FORTRANMODDIRPREFIX'] = '-J'
 elif 'g95' in env['FORTRAN']:
     env['FORTRANMODDIRPREFIX'] = '-fmod='

--- a/src/fortran/SConscript
+++ b/src/fortran/SConscript
@@ -7,7 +7,7 @@ localenv.Prepend(CPPPATH=['#include', '#src'])
 
 f90_src = mglob(localenv, '.', 'f90', 'cpp')
 
-artifacts = localenv.Object(f90_src,
+artifacts = localenv.SharedObject(f90_src,
                             F90PATH=['#build/src/fortran'])
 mods = [o for o in artifacts if o.path.endswith('.mod')]
 objects = [o for o in artifacts if not o.path.endswith('.mod')]
@@ -18,6 +18,23 @@ lib = build(localenv.Library(target='../../lib/cantera_fortran',
 
 install('$inst_libdir', lib)
 install('$inst_incdir', mods)
-#
-#  We are only building the static fortran library here. This is probably ok
-#
+
+# Build the Cantera Fortran interface shared library
+if localenv['layout'] != 'debian':
+    if localenv['renamed_shared_libraries']:
+        sharedName = '../../lib/cantera_fortran_shared'
+    else:
+        sharedName = '../../lib/cantera_fortran'
+
+    if localenv['versioned_shared_library']:
+        shlib = build(localenv.SharedLibrary(target=sharedName, source=objects,
+                                             SPAWN=getSpawn(localenv),
+                                             SHLIBVERSION=localenv['cantera_pure_version'],
+                                             LIBS=list(env['cantera_libs'])))
+        install(localenv.InstallVersionedLib, '$inst_libdir', shlib)
+    else:
+        shlib = build(localenv.SharedLibrary(target=sharedName, source=objects,
+                                             SPAWN=getSpawn(localenv),
+                                             LIBS=list(env['cantera_libs'])))
+        install('$inst_libdir', shlib)
+    localenv.Depends(shlib, localenv['config_h_target'])

--- a/src/fortran/cantera.f90
+++ b/src/fortran/cantera.f90
@@ -180,6 +180,10 @@ MODULE CANTERA
      MODULE PROCEDURE ctkin_getNetRatesOfProgress
   END INTERFACE getNetRatesOfProgress
 
+  INTERFACE getPartialMolarIntEnergies
+     MODULE PROCEDURE ctthermo_getPartialMolarIntEnerg_R
+  END INTERFACE getPartialMolarIntEnergies
+
   INTERFACE getReactionString
      MODULE PROCEDURE ctkin_getReactionString
   END INTERFACE getReactionString
@@ -377,10 +381,20 @@ MODULE CANTERA
      MODULE PROCEDURE ctstring_setState_TPX
   END INTERFACE setState_TPX
 
+  INTERFACE setState_TRX
+     MODULE PROCEDURE ctthermo_setState_TRX
+     MODULE PROCEDURE ctstring_setState_TRX
+  END INTERFACE setState_TRX
+
   INTERFACE setState_TRY
      MODULE PROCEDURE ctthermo_setState_TRY
      MODULE PROCEDURE ctstring_setState_TRY
   END INTERFACE setState_TRY
+
+  INTERFACE setState_TPY
+     MODULE PROCEDURE ctthermo_setState_TPY
+     MODULE PROCEDURE ctstring_setState_TPY
+  END INTERFACE setState_TPY
 
   INTERFACE setState_UV
      MODULE PROCEDURE ctthermo_setState_UV

--- a/src/fortran/cantera_thermo.f90
+++ b/src/fortran/cantera_thermo.f90
@@ -376,6 +376,28 @@ contains
       call ctthermo_setPressure(self, p)
     end subroutine ctstring_setState_TPX
 
+    subroutine ctthermo_setState_TRX(self, t, rho, x)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(in) :: t
+      double precision, intent(in) :: rho
+      double precision, intent(in) :: x(*)
+      call ctthermo_setTemperature(self, t)
+      call ctthermo_setMoleFractions(self, x)
+      call ctthermo_setDensity(self, rho)
+    end subroutine ctthermo_setState_TRX
+
+    subroutine ctstring_setState_TRX(self, t, rho, x)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(in) :: t
+      double precision, intent(in) :: rho
+      character*(*), intent(in) :: x
+      call ctthermo_setTemperature(self, t)
+      call ctthermo_setMoleFractionsByName(self, x)
+      call ctthermo_setDensity(self, rho)
+    end subroutine ctstring_setState_TRX
+
     subroutine ctthermo_setState_TRY(self, t, rho, y)
       implicit none
       type(phase_t), intent(inout) :: self
@@ -397,6 +419,28 @@ contains
       call ctthermo_setMassFractionsByName(self, y)
       call ctthermo_setDensity(self, rho)
     end subroutine ctstring_setState_TRY
+
+    subroutine ctthermo_setState_TPY(self, t, p, y)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(in) :: t
+      double precision, intent(in) :: p
+      double precision, intent(in) :: y(*)
+      call ctthermo_setTemperature(self, t)
+      call ctthermo_setMassFractions(self, y)
+      call ctthermo_setPressure(self, p)
+    end subroutine ctthermo_setState_TPY
+
+    subroutine ctstring_setState_TPY(self, t, p, y)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(in) :: t
+      double precision, intent(in) :: p
+      character*(*), intent(in) :: y
+      call ctthermo_setTemperature(self, t)
+      call ctthermo_setMassFractionsByName(self, y)
+      call ctthermo_setPressure(self, p)
+    end subroutine ctstring_setState_TPY
 
 
     subroutine ctthermo_setState_HP(self, h, p)
@@ -479,5 +523,12 @@ contains
       double precision, intent(out) :: cp_r(self%nsp)
       self%err = th_getcp_r(self%thermo_id, lenm, cp_r)
     end subroutine ctthermo_getcp_r
+
+    subroutine ctthermo_getPartialMolarIntEnerg_R(self, ie)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(out) :: ie(self%nsp)
+      self%err = th_getpartialmolarintenergies_r(self%thermo_id, ie)
+    end subroutine ctthermo_getPartialMolarIntEnerg_R
 
 end module cantera_thermo

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -635,6 +635,17 @@ extern "C" {
         return 0;
     }
 
+    status_t th_getpartialmolarintenergies_r_(const integer* n, doublereal* ie)
+    {
+        try {
+            thermo_t* thrm = _fth(n);
+            thrm->getPartialMolarIntEnergies(ie);
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+        return 0;
+    }
+
     //-------------- Kinetics ------------------//
 
     integer kin_newfromfile_(const char* filename, const char* phasename,

--- a/src/fortran/fct_interface.f90
+++ b/src/fortran/fct_interface.f90
@@ -258,6 +258,11 @@ interface
         double precision, intent(out) :: cp_r(*)
     end function th_getcp_r
 
+    integer function th_getpartialmolarintenergies_r(n, ie)
+        integer, intent(in) :: n
+        double precision, intent(out) :: ie(*)
+    end function th_getpartialmolarintenergies_r
+
     integer function kin_newfromfile(filename, id, reactingPhase, neighbor1, neighbor2, neighbor3, neighbor4)
         character*(*), intent(in) :: filename
         character*(*), intent(in) :: id


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #

**Changes proposed in this pull request**

- Add `getPartialMolarIntEnergies`, `setState_TRX`, and `setState_TPY` to the Fortran
interface.
- Allow the option of compiling with the PGI fortran compiler pgfortran. This requires unsetting the thread_flags option e.g. on the command line using the option `thread_flags='' `.
