### PR TITLE
[thermo] Ensure ordered extra columns in SolutionArray CSV output

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -3,6 +3,7 @@
 
 from ._cantera import *
 import numpy as np
+from collections import OrderedDict
 import csv as _csv
 
 # avoid explicit dependence of cantera on pandas
@@ -515,7 +516,7 @@ class SolutionArray:
 
         reserved = self.__dir__()
 
-        self._extra = {}
+        self._extra = OrderedDict()
         if isinstance(extra, dict):
             for name, v in extra.items():
                 if name in reserved:

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -4,6 +4,7 @@
 import numpy as np
 from ._cantera import *
 from .composite import Solution, SolutionArray
+from collections import OrderedDict
 from math import erf
 from os import path
 from email.utils import formatdate
@@ -401,7 +402,7 @@ class FlameBase(Sim1D):
          * ``eField``: electric field strength (if applicable)
         """
         # create extra columns
-        extra = {}
+        extra = OrderedDict()
         for e in self._extra:
             if e == 'grid':
                 val = self.grid

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1,5 +1,6 @@
 from os.path import join as pjoin
 from pathlib import Path
+from collections import OrderedDict
 import os
 import numpy as np
 import gc
@@ -1642,6 +1643,12 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertArrayNear(row2.T, 900*np.ones(5))
 
     def test_extra(self):
+        extra = OrderedDict([('grid', np.arange(10)),
+                             ('velocity', np.random.rand(10))])
+        states = ct.SolutionArray(self.gas, 10, extra=extra)
+        keys = list(states._extra.keys())
+        self.assertEqual(keys[0], 'grid')
+        
         with self.assertRaises(ValueError):
             states = ct.SolutionArray(self.gas, extra=['creation_rates'])
         


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #832

**Changes proposed in this pull request**

Ensure that extra columns of `SolutionArray` CSV output preserve order (resolves issue on Python systems where `dict` does not enforce order).