### PR TITLE
[1D] Make tolerance setters more flexible

### DIFF
--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -97,18 +97,23 @@ cdef class Domain1D:
         if default is not None:
             self.domain.setSteadyTolerances(default[0], default[1])
 
-        if abs is not None and rel is not None:
+        if abs is not None or rel is not None:
+            if rel is None:
+                rel = self.steady_reltol()
+            if abs is None:
+                abs = self.steady_abstol()
             assert len(abs) == len(rel) == self.n_components
-            for n,(r,a) in enumerate(zip(rel,abs)):
-                self.domain.setSteadyTolerances(r,a,n)
+            for n, (r, a) in enumerate(zip(rel, abs)):
+                self.domain.setSteadyTolerances(r, a, n)
 
         if Y is not None:
             k0 = self.component_index(self.gas.species_name(0))
             for n in range(k0, k0 + self.gas.n_species):
                 self.domain.setSteadyTolerances(Y[0], Y[1], n)
 
-        for name,(lower,upper) in kwargs.items():
-            self.domain.setSteadyTolerances(lower, upper, self.component_index(name))
+        for name, (rtol, atol) in kwargs.items():
+            self.domain.setSteadyTolerances(rtol, atol,
+                                            self.component_index(name))
 
     def set_transient_tolerances(self, *, default=None, Y=None, abs=None,
                                  rel=None, **kwargs):
@@ -127,18 +132,23 @@ cdef class Domain1D:
         if default is not None:
             self.domain.setTransientTolerances(default[0], default[1])
 
-        if abs is not None and rel is not None:
+        if abs is not None or rel is not None:
+            if rel is None:
+                rel = self.transient_reltol()
+            if abs is None:
+                abs = self.transient_abstol()
             assert len(abs) == len(rel) == self.n_components
-            for n,(r,a) in enumerate(zip(rel,abs)):
-                self.domain.setTransientTolerances(r,a,n)
+            for n, (r, a) in enumerate(zip(rel, abs)):
+                self.domain.setTransientTolerances(r, a, n)
 
         if Y is not None:
             k0 = self.component_index(self.gas.species_name(0))
             for n in range(k0, k0 + self.gas.n_species):
                 self.domain.setTransientTolerances(Y[0], Y[1], n)
 
-        for name,(lower,upper) in kwargs.items():
-            self.domain.setTransientTolerances(lower, upper, self.component_index(name))
+        for name, (rtol, atol) in kwargs.items():
+            self.domain.setTransientTolerances(rtol, atol,
+                                               self.component_index(name))
 
     def set_default_tolerances(self):
         """


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #833

**Changes proposed in this pull request**

The docstrings of `Domain1D.set_transient_tolerances` and `Domain1D.set_steady_tolerances` state: [...] keywords *abs* and *rel* can be used to specify arrays for the absolute and relative tolerances for each solution component. The wording of the docstring is ambiguous, as in practice, no action is taken if only one of the keyword arguments is provided (also, no warning is issued).

This commit ensures the expected behavior if only one of the two arguments (abs or rel) is supplied.