### PR TITLE
Fixes Indexed assignment of extra columns in SolutionArray

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -151,10 +151,10 @@ jobs:
           --exclude='/doxygen/xml' --delete --delete-excluded \
           "${DOCS_OUTPUT_DIR}" ${RSYNC_USER}@${RSYNC_SERVER}:${RSYNC_DEST}
 
-  ubuntu-1604-py2:
-    # Ubuntu 16.04 using Python 2 to run SCons and the system Python 3 for the interface
-    name: Python 2 running SCons on Ubuntu 16.04
-    runs-on: ubuntu-16.04
+  ubuntu-1804-py2:
+    # Ubuntu 18.04 using Python 2 to run SCons and the system Python 3 for the interface
+    name: Python 2 running SCons on Ubuntu 18.04
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@v2
         name: Checkout the repository
@@ -163,12 +163,9 @@ jobs:
       - name: Install Apt dependencies
         run: |
           sudo apt-get install libboost-dev gfortran scons python3-numpy \
-          python3-pip python3-setuptools libsundials-serial-dev liblapack-dev \
+          python3-pip python3-setuptools python3-h5py python3-pandas \
+          python3-ruamel.yaml cython libsundials-dev liblapack-dev \
           libblas-dev
-      - name: Install Python dependencies
-        # Don't include Pandas here due to install errors
-        run: |
-          sudo -H /usr/bin/python3 -m pip install ruamel.yaml cython h5py
       - name: Build Cantera
         run: scons build python_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas -j2
       - name: Test Cantera

--- a/AUTHORS
+++ b/AUTHORS
@@ -44,6 +44,7 @@ Jeff Santner (@jsantner)
 Satyam Saxena (@CyberDrudge)
 Ingmar Schoegl (@ischoegl), Louisiana State University
 Santosh Shanbhogue (@santoshshanbhogue), Massachusetts Institute of Technology
+Harsh Sinha (@sin-ha)
 David Sondak
 Raymond Speth (@speth), Massachusetts Institute of Technology
 Sergey Torokhov (@band-a-prend)

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -624,7 +624,9 @@ class SolutionArray:
             raise IndexError("Can only append to 1D SolutionArray")
 
         for name, value in self._extra.items():
-            np.append(value, kwargs.pop(name))
+            value = list(value)
+            value.append(kwargs.pop(name))
+            value = np.array(value)
 
         if state is not None:
             self._phase.state = state

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -574,7 +574,7 @@ class SolutionArray:
 
     def __getattr__(self, name):
         if name in self._extra:
-            return np.array(self._extra[name])
+            return self._extra[name]
         else:
             raise AttributeError("'{}' object has no attribute '{}'".format(
                 self.__class__.__name__, name))

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -632,6 +632,16 @@ class SolutionArray:
                 "'{}'".format(", ".join(missing_extra_kwargs))
             )
 
+        # For the checks of the state below, the kwargs dictionary can
+        # only contain keywords that match properties of the state. Here
+        # we pop any kwargs that have to do with the extra items so they
+        # aren't included in that check. They are put into a temporary
+        # storage so that appending can be done at the end of the function
+        # all at once.
+        extra_temp = {}
+        for name in self._extra:
+            extra_temp[name] = kwargs.pop(name)
+
         if state is not None:
             self._phase.state = state
 
@@ -655,6 +665,12 @@ class SolutionArray:
 
         self._states.append(self._phase.state)
         self._indices.append(len(self._indices))
+        for name, value in self._extra.items():
+            # Casting to a list before appending is ~5x faster than using
+            # np.append when appending a single item.
+            v = value.tolist()
+            v.append(extra_temp.pop(name))
+            self._extra[name] = np.array(v)
         self._shape = (len(self._indices),)
 
     @property

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -540,13 +540,12 @@ class SolutionArray:
                         "Unable to create extra column '{}': name is already "
                         "used by SolutionArray objects.".format(name))
                 if not np.shape(v):
-                    self._extra[name] = np.array([v]).reshape(self._shape)
-                elif len(v) == self._shape or np.array(v).shape == self._shape:
+                    self._extra[name] = np.full(self._shape, v)
+                elif np.array(v).shape == self._shape:
                     self._extra[name] = np.array(v)
                 else:
                     raise ValueError("Unable to map extra SolutionArray "
-                                     "input for named {!r}".format(name))
-
+                                     "input named {!r}".format(name))
         elif extra is not None:
             try:
                 iter_extra = iter(extra)

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -544,21 +544,21 @@ class SolutionArray:
                 elif len(v) == self._shape or np.array(v).shape == self._shape:
                     self._extra[name] = np.array(v)
                 else:
-                    raise ValueError("Unable to map extra SolutionArray"
+                    raise ValueError("Unable to map extra SolutionArray "
                                      "input for named {!r}".format(name))
 
         elif extra is not None:
             try:
-                iterator = iter(extra)
+                iter_extra = iter(extra)
             except TypeError :
                 raise ValueError(
-                    "Extra properties can be created by passing an iterable"
-                    " of names for the properties, if the SolutionArray is not initially"
-                    " empty. If you want to supply initial values for the properties, use"
-                    " a dictionary whose keys are the names of the properties and values "
-                    " are the initial values.") from None
+                    "Extra properties can be created by passing an iterable "
+                    "of names for the properties, if the SolutionArray is not initially "
+                    "empty. If you want to supply initial values for the properties, use "
+                    "a dictionary whose keys are the names of the properties and values "
+                    "are the initial values.") from None
 
-            for name in extra:
+            for name in iter_extra:
                 if isinstance(name, str):
                     if name in reserved:
                         raise ValueError(
@@ -567,7 +567,7 @@ class SolutionArray:
                     self._extra[name] = np.empty(self._shape)
 
                 else:
-                    raise ValueError(
+                    raise TypeError(
                         "Unable to create extra column, passed value {}: "
                         "is not a string".format(name))
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -905,7 +905,6 @@ class SolutionArray:
         if tabular and len(self._shape) != 1:
             raise AttributeError("Tabular output of collect_data only works "
                                  "for 1D SolutionArray")
-        out = OrderedDict()
 
         # Create default columns (including complete state information)
         if cols is None:
@@ -929,7 +928,6 @@ class SolutionArray:
 
         def split(c, d):
             """ Split attribute arrays into columns for tabular output """
-            single_species = False
             # Determine labels for the items in the current group of columns
             if c in self._n_species:
                 collabels = ['{}_{}'.format(c, s) for s in self.species_names]

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -634,15 +634,19 @@ class SolutionArray:
         elif len(kwargs) == 1:
             attr, value = next(iter(kwargs.items()))
             if frozenset(attr) not in self._phase._full_states:
-                raise KeyError("{} does not specify a full thermodynamic state")
+                raise KeyError(
+                    "'{}' does not specify a full thermodynamic state".format(attr)
+                )
             setattr(self._phase, attr, value)
 
         else:
             try:
                 attr = self._phase._full_states[frozenset(kwargs)]
             except KeyError:
-                raise KeyError("{} is not a valid combination of properties "
-                    "for setting the thermodynamic state".format(tuple(kwargs)))
+                raise KeyError(
+                    "{} is not a valid combination of properties for setting "
+                    "the thermodynamic state".format(tuple(kwargs))
+                ) from None
             setattr(self._phase, attr, [kwargs[a] for a in attr])
 
         self._states.append(self._phase.state)

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -623,10 +623,14 @@ class SolutionArray:
         if len(self._shape) != 1:
             raise IndexError("Can only append to 1D SolutionArray")
 
-        for name, value in self._extra.items():
-            value = list(value)
-            value.append(kwargs.pop(name))
-            value = np.array(value)
+        # This check must go before we start appending to any arrays so that
+        # array lengths don't get out of sync.
+        missing_extra_kwargs = self._extra.keys() - kwargs.keys()
+        if missing_extra_kwargs:
+            raise TypeError(
+                "Missing keyword arguments for extra values: "
+                "'{}'".format(", ".join(missing_extra_kwargs))
+            )
 
         if state is not None:
             self._phase.state = state

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -544,6 +544,10 @@ class SolutionArray:
                     raise ValueError("Unable to map extra SolutionArray "
                                      "input named {!r}".format(name))
         elif extra is not None:
+            if self._shape != (0,):
+                raise ValueError("Initial values for extra properties must be "
+                                 "supplied in a dictionary if the SolutionArray "
+                                 "is not initially empty.")
             if isinstance(extra, np.ndarray):
                 extra = extra.flatten()
             elif isinstance(extra, str):
@@ -551,7 +555,7 @@ class SolutionArray:
 
             try:
                 iter_extra = iter(extra)
-            except TypeError :
+            except TypeError:
                 raise ValueError(
                     "Extra properties can be created by passing an iterable "
                     "of names for the properties. If you want to supply initial "
@@ -568,7 +572,7 @@ class SolutionArray:
                     raise ValueError(
                         "Unable to create extra column '{}': name is already "
                         "used by SolutionArray objects.".format(name))
-                self._extra[name] = np.empty(self._shape)
+                self._extra[name] = np.empty(shape=(0,))
 
         if meta is None:
             self._meta = {}

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -670,7 +670,7 @@ class SolutionArray:
             indices = indices[::-1]
         self._states = [self._states[ix] for ix in indices]
         for k, v in self._extra.items():
-            self._extra[k] = np.array(v)[indices]
+            self._extra[k] = v[indices]
 
     def equilibrate(self, *args, **kwargs):
         """ See `ThermoPhase.equilibrate` """

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -530,9 +530,6 @@ class SolutionArray:
 
         self._extra = OrderedDict()
 
-        if isinstance(extra, str):
-            extra = [extra]
-
         if isinstance(extra, dict):
             for name, v in extra.items():
                 if name in reserved:
@@ -547,28 +544,31 @@ class SolutionArray:
                     raise ValueError("Unable to map extra SolutionArray "
                                      "input named {!r}".format(name))
         elif extra is not None:
+            if isinstance(extra, np.ndarray):
+                extra = extra.flatten()
+            elif isinstance(extra, str):
+                extra = [extra]
+
             try:
                 iter_extra = iter(extra)
             except TypeError :
                 raise ValueError(
                     "Extra properties can be created by passing an iterable "
-                    "of names for the properties, if the SolutionArray is not initially "
-                    "empty. If you want to supply initial values for the properties, use "
-                    "a dictionary whose keys are the names of the properties and values "
-                    "are the initial values.") from None
+                    "of names for the properties. If you want to supply initial "
+                    "values for the properties, use a dictionary whose keys are "
+                    "the names of the properties and values are the initial "
+                    "values.") from None
 
             for name in iter_extra:
-                if isinstance(name, str):
-                    if name in reserved:
-                        raise ValueError(
-                            "Unable to create extra column '{}': name is already "
-                            "used by SolutionArray objects.".format(name))
-                    self._extra[name] = np.empty(self._shape)
-
-                else:
+                if not isinstance(name, str):
                     raise TypeError(
-                        "Unable to create extra column, passed value {}: "
+                        "Unable to create extra column, passed value '{!r}' "
                         "is not a string".format(name))
+                if name in reserved:
+                    raise ValueError(
+                        "Unable to create extra column '{}': name is already "
+                        "used by SolutionArray objects.".format(name))
+                self._extra[name] = np.empty(self._shape)
 
         if meta is None:
             self._meta = {}

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1745,6 +1745,15 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertEqual(states.prop.shape, (2, 2))
         self.assertArrayNear(states.prop, np.array(((3, 3), (3, 3))))
 
+    def test_extra_not_empty(self):
+        """Test that a non-empty SolutionArray raises a ValueError if
+           initial values for properties are not supplied.
+        """
+        with self.assertRaisesRegex(ValueError, "Initial values for extra properties"):
+            ct.SolutionArray(self.gas, 3, extra=["prop"])
+        with self.assertRaisesRegex(ValueError, "Initial values for extra properties"):
+            ct.SolutionArray(self.gas, 3, extra=np.array(["prop", "prop2"]))
+
     def test_extra_wrong_shape(self):
         with self.assertRaisesRegex(ValueError, "Unable to map"):
             ct.SolutionArray(self.gas, (3, 3), extra={"prop": np.arange(3)})
@@ -1784,10 +1793,10 @@ class TestSolutionArray(utilities.CanteraTest):
 
     def test_extra_create_by_ndarray(self):
         properties_array = np.array(["prop1", "prop2", "prop3"])
-        states = ct.SolutionArray(self.gas, shape=(2, 6, 9), extra=properties_array)
-        self.assertEqual(states.prop1.shape, (2, 6, 9))
-        self.assertEqual(states.prop2.shape, (2, 6, 9))
-        self.assertEqual(states.prop3.shape, (2, 6, 9))
+        states = ct.SolutionArray(self.gas, shape=(0,), extra=properties_array)
+        self.assertEqual(states.prop1.shape, (0,))
+        self.assertEqual(states.prop2.shape, (0,))
+        self.assertEqual(states.prop3.shape, (0,))
         # Ensure that a 2-dimensional array is flattened
         properties_array = np.array((["prop1"], ["prop2"]))
         states = ct.SolutionArray(self.gas, extra=properties_array)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1734,6 +1734,36 @@ class TestSolutionArray(utilities.CanteraTest):
 
         with self.assertRaises(ValueError):
             states = ct.SolutionArray(self.gas, extra=['creation_rates'])
+        states = ct.SolutionArray(self.gas, shape=(0, 0), extra=("prop1"))
+        self.assertEqual(states.prop1.shape, (0, 0))
+
+    def test_extra1(self):
+        states = ct.SolutionArray(self.gas, 7, extra={'prop': range(7)})
+        array = np.array(range(7))
+        self.assertArrayNear(states.prop, array)
+        states.prop[1] = -5
+        states.prop[3:5] = [0, 1]
+        array_mod = np.array([0, -5,  2,  0,  1,  5,  6])
+        self.assertArrayNear(states.prop, array_mod)
+
+    def test_extra2(self):
+        states = ct.SolutionArray(self.gas, shape=(5, 9), extra=["prop1", "prop2"])
+        self.assertEqual(states.prop1.shape, (5, 9))
+        states1 = ct.SolutionArray(self.gas, shape=(0, 0, 0), extra="prop1")
+        self.assertEqual(states1.prop1.shape, (0, 0, 0))
+
+    def test_extra3(self):
+        states2 = ct.SolutionArray(self.gas, shape=(2, 6, 9), extra="prop1")
+        self.assertEqual(states2.prop1.shape, (2, 6, 9))
+
+    def test_extra4(self):
+        states3 = ct.SolutionArray(self.gas, shape=(2, 6, 9), extra=("prop1", "prop2", "prop3"))
+        self.assertEqual(states3.prop3.shape, (2, 6, 9))
+
+    def test_extra5(self):
+        properties_array = np.array(["prop1", "prop2", "prop3"])
+        states4 = ct.SolutionArray(self.gas, shape=(2, 6, 9), extra=properties_array)
+        self.assertEqual(states4.prop2.shape, (2, 6, 9))
 
     def test_append(self):
         states = ct.SolutionArray(self.gas, 5)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1789,6 +1789,18 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertNear(states.P[-1], 1e4)
         self.assertNear(states.T[-1], 300)
 
+    def test_append_with_extra(self):
+        states = ct.SolutionArray(self.gas, 5, extra={"prop": "value"})
+        states.TPX = np.linspace(500, 1000, 5), 2e5, 'H2:0.5, O2:0.4'
+        self.assertEqual(states._shape, (5,))
+        states.append(T=1100, P=3e5, X="AR:1.0", prop="value2")
+        self.assertEqual(states.prop[-1], "value2")
+        self.assertEqual(states.prop.shape, (6,))
+        states.append(T=1100, P=3e5, X="AR:1.0", prop=100)
+        # NumPy converts to the existing type of the array
+        self.assertEqual(states.prop[-1], "100")
+        self.assertEqual(states.prop.shape, (7,))
+
     def test_append_failures(self):
         states = ct.SolutionArray(self.gas, 5, extra={"prop": "value"})
         states.TPX = np.linspace(500, 1000, 5), 2e5, 'H2:0.5, O2:0.4'

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1789,6 +1789,28 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertNear(states.P[-1], 1e4)
         self.assertNear(states.T[-1], 300)
 
+    def test_append_failures(self):
+        states = ct.SolutionArray(self.gas, 5, extra={"prop": "value"})
+        states.TPX = np.linspace(500, 1000, 5), 2e5, 'H2:0.5, O2:0.4'
+        self.assertEqual(states._shape, (5,))
+
+        with self.assertRaisesRegex(TypeError, "Missing keyword arguments for extra"):
+            states.append(T=1100, P=3e5, X="AR:1.0")
+        # Failing to append a state shouldn't change the size
+        self.assertEqual(states._shape, (5,))
+
+        with self.assertRaisesRegex(KeyError, "does not specify"):
+            # I is not a valid property
+            states.append(TPI=(1100, 3e5, "AR:1.0"), prop="value2")
+        # Failing to append a state shouldn't change the size
+        self.assertEqual(states._shape, (5,))
+
+        with self.assertRaisesRegex(KeyError, "is not a valid"):
+            # I is not a valid property
+            states.append(T=1100, P=3e5, I="AR:1.0", prop="value2")
+        # Failing to append a state shouldn't change the size
+        self.assertEqual(states._shape, (5,))
+
     def test_purefluid(self):
         water = ct.Water()
         states = ct.SolutionArray(water, 5)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1737,13 +1737,13 @@ class TestSolutionArray(utilities.CanteraTest):
         states = ct.SolutionArray(self.gas, shape=(0, 0), extra=("prop1"))
         self.assertEqual(states.prop1.shape, (0, 0))
 
-    def test_extra1(self):
+    def test_assign_to_slice(self):
         states = ct.SolutionArray(self.gas, 7, extra={'prop': range(7)})
-        array = np.array(range(7))
+        array = np.arange(7)
         self.assertArrayNear(states.prop, array)
         states.prop[1] = -5
         states.prop[3:5] = [0, 1]
-        array_mod = np.array([0, -5,  2,  0,  1,  5,  6])
+        array_mod = np.array([0, -5, 2, 0, 1, 5, 6])
         self.assertArrayNear(states.prop, array_mod)
 
     def test_extra2(self):

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1769,6 +1769,10 @@ class TestSolutionArray(utilities.CanteraTest):
         with self.assertRaisesRegex(ValueError, "name is already used"):
             ct.SolutionArray(self.gas, extra={"creation_rates": 0})
 
+    def test_extra_create_by_string(self):
+        states = ct.SolutionArray(self.gas, extra="prop")
+        self.assertEqual(states.prop.shape, (0,))
+
     def test_assign_to_slice(self):
         states = ct.SolutionArray(self.gas, 7, extra={'prop': range(7)})
         array = np.arange(7)
@@ -1778,24 +1782,17 @@ class TestSolutionArray(utilities.CanteraTest):
         array_mod = np.array([0, -5, 2, 0, 1, 5, 6])
         self.assertArrayNear(states.prop, array_mod)
 
-    def test_extra2(self):
-        states = ct.SolutionArray(self.gas, shape=(5, 9), extra=["prop1", "prop2"])
-        self.assertEqual(states.prop1.shape, (5, 9))
-        states1 = ct.SolutionArray(self.gas, shape=(0, 0, 0), extra="prop1")
-        self.assertEqual(states1.prop1.shape, (0, 0, 0))
-
-    def test_extra3(self):
-        states2 = ct.SolutionArray(self.gas, shape=(2, 6, 9), extra="prop1")
-        self.assertEqual(states2.prop1.shape, (2, 6, 9))
-
-    def test_extra4(self):
-        states3 = ct.SolutionArray(self.gas, shape=(2, 6, 9), extra=("prop1", "prop2", "prop3"))
-        self.assertEqual(states3.prop3.shape, (2, 6, 9))
-
-    def test_extra5(self):
+    def test_extra_create_by_ndarray(self):
         properties_array = np.array(["prop1", "prop2", "prop3"])
-        states4 = ct.SolutionArray(self.gas, shape=(2, 6, 9), extra=properties_array)
-        self.assertEqual(states4.prop2.shape, (2, 6, 9))
+        states = ct.SolutionArray(self.gas, shape=(2, 6, 9), extra=properties_array)
+        self.assertEqual(states.prop1.shape, (2, 6, 9))
+        self.assertEqual(states.prop2.shape, (2, 6, 9))
+        self.assertEqual(states.prop3.shape, (2, 6, 9))
+        # Ensure that a 2-dimensional array is flattened
+        properties_array = np.array((["prop1"], ["prop2"]))
+        states = ct.SolutionArray(self.gas, extra=properties_array)
+        self.assertEqual(states.prop1.shape, (0,))
+        self.assertEqual(states.prop2.shape, (0,))
 
     def test_append(self):
         states = ct.SolutionArray(self.gas, 5)
@@ -1815,7 +1812,7 @@ class TestSolutionArray(utilities.CanteraTest):
 
         self.gas.TPX = 300, 1e4, 'O2:0.5, AR:0.5'
         HPY = self.gas.HPY
-        self.gas.TPX = 1200, 5e5, 'O2:0.3, AR:0.7' # to make sure it gets changed
+        self.gas.TPX = 1200, 5e5, 'O2:0.3, AR:0.7'  # to make sure it gets changed
         states.append(HPY=HPY)
         self.assertEqual(states.cp_mass.shape, (8,))
         self.assertNear(states.P[-1], 1e4)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [X] There is a clear use-case for this code change
- [X] The commit message has a short title & references relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #829 

**Changes proposed in this pull request**

-Earlier the self._extra[name] was initialised as a list but when the set item method was called it returned a `np.array()` copy of it 
-So I propose to initialise the init method with the np.array and amended other methods to abide with it
-I think that this would be a better implementation.
- This solves item assignment as the original object gets passed instead of the copy
