### PR TITLE
[PureFluid] Use pressure criteria to decide phase

### DIFF
--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -140,7 +140,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
 
         # miscellaneous
         string type()
-        string phaseOfMatter()
+        string phaseOfMatter() except +translate_exception
         string report(cbool, double) except +translate_exception
         cbool hasPhaseTransition()
         cbool isPure()

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -243,6 +243,14 @@ class TestPureFluid(utilities.CanteraTest):
         self.water.TQ = 300, 0.4
         self.assertEqual(self.water.phase_of_matter, "liquid-gas-mix")
 
+        # These cases work after fixing GH-786
+        n2 = ct.Nitrogen()
+        n2.TP = 100, 1000
+        self.assertEqual(n2.phase_of_matter, "gas")
+
+        co2 = ct.CarbonDioxide()
+        self.assertEqual(co2.phase_of_matter, "gas")
+
 
 # To minimize errors when transcribing tabulated data, the input units here are:
 # T: K, P: MPa, rho: kg/m3, v: m3/kg, (u,h): kJ/kg, s: kJ/kg-K
@@ -296,7 +304,7 @@ class PureFluidTestCases:
 
     def test_has_phase_transition(self):
         self.assertTrue(self.fluid.has_phase_transition)
-    
+
     def test_consistency_temperature(self):
         for state in self.states:
             dT = 2e-5 * state.T

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -90,7 +90,7 @@ std::string PureFluidPhase::phaseOfMatter() const
         return "supercritical";
     } else if (m_sub->TwoPhase() == 1) {
         return "liquid-gas-mix";
-    } else if (temperature() > satTemperature(pressure())) {
+    } else if (pressure() < m_sub->Ps()) {
         return "gas";
     } else {
         return "liquid";


### PR DESCRIPTION
Use the pressure compared with the saturation pressure to decide gas or
liquid phase, rather than temperature. This change is required because
for some substances, the saturation temperature for low values of the
pressure was outside the limits of the equation of state, resulting
in convergence errors in the saturation solver.

Since phaseOfMatter can throw, we need to translate exceptions in
the Cython interface as well.

Add tests to prevent regression with cases identifed in #786.
Fixes #786.

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review