### PR TITLE
Implement custom HDF storage structure

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -36,13 +36,14 @@ before_script: |
       bash miniconda.sh -b -p $HOME/miniconda
       source $HOME/miniconda/etc/profile.d/conda.sh && conda activate
       conda config --set always_yes yes --set changeps1 no
-      conda install -q numpy cython scons boost ruamel_yaml
+      conda install -q numpy cython scons boost ruamel_yaml h5py
       conda install -q -c conda-forge openmp
   else
       pip3 install --user --upgrade pip
       pip3 install --user --upgrade setuptools wheel
       pip3 install --user cython
       pip3 install --user ruamel.yaml==0.15.94  # Need a version compatible with Python 3.4
+      pip3 install --user h5py
 
       # Install packages for the documentation
       pip3 install --user sphinx sphinxcontrib-matlabdomain sphinxcontrib-doxylink

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -9,6 +9,7 @@ install:
     C:\Python37-x64\Scripts\pip.exe install --no-warn-script-location cython
     C:\Python37-x64\Scripts\pip.exe install pypiwin32
     C:\Python37-x64\Scripts\pip.exe install ruamel.yaml
+    C:\Python37-x64\Scripts\pip.exe install h5py
 
 build_script:
 - cmd: C:\Python37-x64\Scripts\scons build -j2 boost_inc_dir=C:\Libraries\boost_1_62_0 debug=n VERBOSE=y python_package=full

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -37,6 +37,12 @@ public:
     //! Set the name of this Solution object
     void setName(const std::string& name);
 
+    //! Return the source of this Solution object
+    std::string source() const { return m_source; }
+
+    //! Set the source of this Solution object
+    void setSource(const std::string& source) { m_source = source; }
+
     //! Set the ThermoPhase object
     void setThermo(shared_ptr<ThermoPhase> thermo);
 
@@ -62,6 +68,8 @@ public:
     }
 
 protected:
+    std::string m_source; //!< Source of Solution (e.g. file name)
+
     shared_ptr<ThermoPhase> m_thermo;  //!< ThermoPhase manager
     shared_ptr<Kinetics> m_kinetics;  //!< Kinetics manager
     shared_ptr<Transport> m_transport;  //!< Transport manager

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -37,12 +37,6 @@ public:
     //! Set the name of this Solution object
     void setName(const std::string& name);
 
-    //! Return the source of this Solution object
-    std::string source() const { return m_source; }
-
-    //! Set the source of this Solution object
-    void setSource(const std::string& source) { m_source = source; }
-
     //! Set the ThermoPhase object
     void setThermo(shared_ptr<ThermoPhase> thermo);
 
@@ -68,8 +62,6 @@ public:
     }
 
 protected:
-    std::string m_source; //!< Source of Solution (e.g. file name)
-
     shared_ptr<ThermoPhase> m_thermo;  //!< ThermoPhase manager
     shared_ptr<Kinetics> m_kinetics;  //!< Kinetics manager
     shared_ptr<Transport> m_transport;  //!< Transport manager

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -132,6 +132,8 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         CxxSolution()
         string name()
         void setName(string)
+        string source()
+        void setSource(string)
         void setThermo(shared_ptr[CxxThermoPhase])
         void setKinetics(shared_ptr[CxxKinetics])
         void setTransport(shared_ptr[CxxTransport])

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1126,6 +1126,8 @@ cdef class Surface1D(Boundary1D):
 
 cdef class ReactingSurface1D(Boundary1D):
     cdef CxxReactingSurf1D* surf
+    cdef Kinetics _surface
+    cdef object _weakref_proxy2
 
 cdef class _FlowBase(Domain1D):
     cdef CxxStFlow* flow

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1126,8 +1126,7 @@ cdef class Surface1D(Boundary1D):
 
 cdef class ReactingSurface1D(Boundary1D):
     cdef CxxReactingSurf1D* surf
-    cdef Kinetics _surface
-    cdef object _weakref_proxy2
+    cdef public Kinetics surface
 
 cdef class _FlowBase(Domain1D):
     cdef CxxStFlow* flow

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -132,8 +132,6 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         CxxSolution()
         string name()
         void setName(string)
-        string source()
-        void setSource(string)
         void setThermo(shared_ptr[CxxThermoPhase])
         void setKinetics(shared_ptr[CxxKinetics])
         void setTransport(shared_ptr[CxxTransport])
@@ -967,6 +965,7 @@ cdef class GasTransportData:
 cdef class _SolutionBase:
     cdef shared_ptr[CxxSolution] _base
     cdef CxxSolution* base
+    cdef str _source
     cdef shared_ptr[CxxThermoPhase] _thermo
     cdef CxxThermoPhase* thermo
     cdef shared_ptr[CxxKinetics] _kinetics

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -85,6 +85,13 @@ cdef class _SolutionBase:
         def __set__(self, name):
             self.base.setName(stringify(name))
 
+    property source:
+        """
+        The source of this object (e.g. a file name)
+        """
+        def __get__(self):
+            return pystr(self.base.source())
+
     property composite:
         """
         Returns tuple of thermo/kinetics/transport models associated with
@@ -108,8 +115,10 @@ cdef class _SolutionBase:
         cdef CxxAnyMap root
         if infile:
             root = AnyMapFromYamlFile(stringify(infile))
+            self.base.setSource(stringify(infile))
         elif source:
             root = AnyMapFromYamlString(stringify(source))
+            self.base.setSource(stringify('custom YAML'))
 
         phaseNode = root[stringify("phases")].getMapWhere(stringify("name"),
                                                           stringify(name))
@@ -142,8 +151,10 @@ cdef class _SolutionBase:
         """
         if infile:
             rootNode = CxxGetXmlFile(stringify(infile))
+            self.base.setSource(stringify(infile))
         elif source:
             rootNode = CxxGetXmlFromString(stringify(source))
+            self.base.setSource(stringify('custom CTI/XML'))
 
         # Get XML data
         cdef XML_Node* phaseNode
@@ -180,6 +191,7 @@ cdef class _SolutionBase:
         Instantiate a set of new Cantera C++ objects based on a string defining
         the model type and a list of Species objects.
         """
+        self.base.setSource(stringify('custom parts'))
         self.thermo = newThermoPhase(stringify(thermo))
         self._thermo.reset(self.thermo)
         self.thermo.addUndefinedElements()

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -35,6 +35,7 @@ cdef class _SolutionBase:
             self.kinetics = other.kinetics
             self.transport = other.transport
             self._base = other._base
+            self._source = other._source
             self._thermo = other._thermo
             self._kinetics = other._kinetics
             self._transport = other._transport
@@ -45,6 +46,7 @@ cdef class _SolutionBase:
 
         # Assign base and set managers to NULL
         self._base = CxxNewSolution()
+        self._source = None
         self.base = self._base.get()
         self.thermo = NULL
         self.kinetics = NULL
@@ -87,10 +89,10 @@ cdef class _SolutionBase:
 
     property source:
         """
-        The source of this object (e.g. a file name)
+        The source of this object (such as a file name).
         """
         def __get__(self):
-            return pystr(self.base.source())
+            return self._source
 
     property composite:
         """
@@ -115,10 +117,10 @@ cdef class _SolutionBase:
         cdef CxxAnyMap root
         if infile:
             root = AnyMapFromYamlFile(stringify(infile))
-            self.base.setSource(stringify(infile))
+            self._source = infile
         elif source:
             root = AnyMapFromYamlString(stringify(source))
-            self.base.setSource(stringify('custom YAML'))
+            self._source = 'custom YAML'
 
         phaseNode = root[stringify("phases")].getMapWhere(stringify("name"),
                                                           stringify(name))
@@ -151,10 +153,10 @@ cdef class _SolutionBase:
         """
         if infile:
             rootNode = CxxGetXmlFile(stringify(infile))
-            self.base.setSource(stringify(infile))
+            self._source = infile
         elif source:
             rootNode = CxxGetXmlFromString(stringify(source))
-            self.base.setSource(stringify('custom CTI/XML'))
+            self._source = 'custom CTI/XML'
 
         # Get XML data
         cdef XML_Node* phaseNode
@@ -191,7 +193,7 @@ cdef class _SolutionBase:
         Instantiate a set of new Cantera C++ objects based on a string defining
         the model type and a list of Species objects.
         """
-        self.base.setSource(stringify('custom parts'))
+        self._source = 'custom parts'
         self.thermo = newThermoPhase(stringify(thermo))
         self._thermo.reset(self.thermo)
         self.thermo.addUndefinedElements()

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -551,9 +551,9 @@ class SolutionArray:
                 self._extra[name] = []
 
         elif extra:
-            raise ValueError("Initial values for extra properties must be"
-                " supplied in a dict if the SolutionArray is not initially"
-                " empty")
+            raise ValueError("Initial values for extra properties must be "
+                             "supplied in a dict if the SolutionArray is not "
+                             "initially empty")
 
         self._meta = meta
 
@@ -940,20 +940,28 @@ class SolutionArray:
         Note that it is possible to write multiple data entries to a single HDF
         container file, where *group* is used to differentiate data.
 
-        :param filename: name of the HDF container file; typical file extensions
-            are `.hdf`, `.hdf5` or `.h5`.
-        :param cols: A list of any properties of the solution being exported.
-        :param group: Identifier for the group in the container file. A group
-            may contain multiple `SolutionArray` objects.
-        :param attrs: Dictionary of user-defined group attributes.
-        :param mode: Mode to open the file {'a' (default), 'w', 'r+}.
-        :param append: If False, the content of a pre-existing group is deleted
-            before writing the `SolutionArray` in the first position. If True,
-            the current `SolutionArray` objects is appended to the group.
-        :param compression: pre-defined h5py compression filters {None, 'gzip',
-            'lzf', 'szip'} used for data compression.
-        :param compression_opts: Options for the h5py compression filter; for
-            'gzip', this corresponds to the compression level {None, 0-9}.
+        :param filename:
+            Name of the HDF container file; typical file extensions are `.hdf`,
+            `.hdf5` or `.h5`.
+        :param cols:
+            A list of any properties of the solution being exported.
+        :param group:
+            Identifier for the group in the container file. A group may contain
+            multiple `SolutionArray` objects.
+        :param attrs:
+            Dictionary of user-defined group attributes.
+        :param mode:
+            Mode to open the file {'a' (default), 'w', 'r+}.
+        :param append:
+            If False, the content of a pre-existing group is deleted before
+            writing the `SolutionArray` in the first position. If True, the
+            current `SolutionArray` objects is appended to the group.
+        :param compression:
+            Pre-defined h5py compression filters {None, 'gzip', 'lzf', 'szip'}
+            used for data compression.
+        :param compression_opts:
+            Options for the h5py compression filter; for 'gzip', this
+            corresponds to the compression level {None, 0-9}.
 
         Arguments *compression*, and *compression_opts* are mapped to parameters
         for `h5py.create_dataset`; in both cases, the choices of `None` results
@@ -981,7 +989,8 @@ class SolutionArray:
             msg = "HDF group with group identifier '{}' exists in '{}': {}"
             if not group:
                 # add group with default name
-                root = hdf.create_group('group{}'.format(len(hdf.keys())))
+                group = 'group{}'.format(len(hdf.keys()))
+                root = hdf.create_group(group)
                 count = 0
             elif group not in hdf.keys():
                 # add group with custom name
@@ -1014,6 +1023,8 @@ class SolutionArray:
             sol = sub.create_group('solution')
             sol.attrs['name'] = self.name
             sol.attrs['source'] = self.source
+
+        return group, sub_name
 
     def read_hdf(self, filename, group=None, index=0, force=False):
         """
@@ -1060,7 +1071,7 @@ class SolutionArray:
             if not len(sub_names):
                 msg = "HDF group '{}' does not contain valid data"
                 raise IOError(msg.format(group))
-            elif index  > len(sub_names) - 1:
+            elif index > len(sub_names) - 1:
                 msg = ("Index '{}' exceeds the number of data sets stored "
                        "within HDF group '{}' ('{}')")
                 raise IOError(msg.format(index, group, len(sub_names)))

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1040,7 +1040,9 @@ class SolutionArray:
             Dictionary of user-defined attributes added at the group level
             (typically used in conjunction with a subgroup argument).
         :param mode:
-            Mode used by h5py to open the file {'a' (default), 'w', 'r+'}.
+            Mode h5py uses to open the output file {'a' to read/write if file
+            exists, create otherwise (default); 'w' to create file, truncate if
+            exists; 'r+' to read/write, file must exist}.
         :param append:
             If False, the content of a pre-existing group is deleted before
             writing the `SolutionArray` in the first position. If True, the

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -3,6 +3,7 @@
 
 from ._cantera import *
 import numpy as np
+from collections import OrderedDict
 import csv as _csv
 
 import pkg_resources
@@ -524,7 +525,7 @@ class SolutionArray:
 
         reserved = self.__dir__()
 
-        self._extra = {}
+        self._extra = OrderedDict()
         if isinstance(extra, dict):
             for name, v in extra.items():
                 if name in reserved:

--- a/interfaces/cython/cantera/examples/onedim/adiabatic_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/adiabatic_flame.py
@@ -7,10 +7,9 @@ Requires: cantera >= 2.5.0
 
 import cantera as ct
 try:
-    import pandas as pd
-    import tables
+    import h5py as h5
 except:
-    pd = None
+    h5 = None
 
 # Simulation parameters
 p = ct.one_atm  # pressure [Pa]
@@ -34,8 +33,9 @@ f.transport_model = 'Mix'
 f.solve(loglevel=loglevel, auto=True)
 
 # Solve with the energy equation enabled
-if pd:
-    f.write_hdf('h2_adiabatic.h5', key='mix', mode='w')
+if h5:
+    f.write_hdf('h2_adiabatic.h5', group='mix', mode='w',
+                description='solution with mixture-averaged transport')
 else:
     f.save('h2_adiabatic.xml', 'mix',
            'solution with mixture-averaged transport')
@@ -48,8 +48,9 @@ f.transport_model = 'Multi'
 f.solve(loglevel)  # don't use 'auto' on subsequent solves
 f.show_solution()
 print('multicomponent flamespeed = {0:7f} m/s'.format(f.velocity[0]))
-if pd:
-    f.write_hdf('h2_adiabatic.h5', key='multi')
+if h5:
+    f.write_hdf('h2_adiabatic.h5', group='multi',
+                description='solution with multicomponent transport')
 else:
     f.save('h2_adiabatic.xml', 'multi',
            'solution with multicomponent transport')

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -536,6 +536,7 @@ class FlameBase(Sim1D):
         for i in range(3):
             arr = self.to_solution_array(domain=self.domains[i])
             group, sub = arr.write_hdf(filename, group=group, cols=cols,
+                                       name=self.domains[i].name,
                                        attrs=meta, mode=mode, append=(i > 0),
                                        compression=compression,
                                        compression_opts=compression_opts)
@@ -569,7 +570,8 @@ class FlameBase(Sim1D):
 
         for d in domains:
             arr = SolutionArray(self.phase(d), extra=self.extra(d))
-            meta = arr.read_hdf(filename, group=group, index=d)
+            meta = arr.read_hdf(filename, group=group,
+                                name=self.domains[d].name)
             self.from_solution_array(arr, domain=d)
 
         self.settings = meta

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -814,7 +814,7 @@ for _attr in ['forward_rates_of_progress', 'reverse_rates_of_progress', 'net_rat
 
 class FreeFlame(FlameBase):
     """A freely-propagating flat flame."""
-    __slots__ = ('inlet', 'outlet', 'flame')
+    __slots__ = ('inlet', 'flame', 'outlet')
     _extra = ('grid', 'velocity')
 
     def __init__(self, gas, grid=None, width=None):
@@ -1026,7 +1026,7 @@ class IonFlameBase(FlameBase):
 
 class IonFreeFlame(IonFlameBase, FreeFlame):
     """A freely-propagating flame with ionized gas."""
-    __slots__ = ('inlet', 'outlet', 'flame')
+    __slots__ = ('inlet', 'flame', 'outlet')
     _extra = ('grid', 'velocity', 'eField')
 
     def __init__(self, gas, grid=None, width=None):

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -502,6 +502,7 @@ class FlameBase(Sim1D):
                                  settings=settings)
 
     def write_hdf(self, filename, group=None, species='X', mode='a',
+                  description=None,
                   compression=None, compression_opts=None, quiet=True):
         """
         Write the solution vector to a HDF container file. Note that it is
@@ -519,6 +520,8 @@ class FlameBase(Sim1D):
             mole fractions or ``Y`` for mass fractions.
         :param mode:
             Mode to open the file {'a' (default), 'w', 'r+}.
+        :param description:
+            Custom comment describing the dataset to be stored.
         :param compression:
             Pre-defined h5py compression filters {None, 'gzip', 'lzf', 'szip'}
             used for data compression.
@@ -533,6 +536,8 @@ class FlameBase(Sim1D):
         cols = ('extra', 'T', 'D', species)
         meta = self.settings
         meta['date'] = formatdate(localtime=True)
+        if description is not None:
+            meta['description'] = description
         for i in range(3):
             arr = self.to_solution_array(domain=self.domains[i])
             group, sub = arr.write_hdf(filename, group=group, cols=cols,
@@ -576,10 +581,12 @@ class FlameBase(Sim1D):
 
         self.settings = meta
 
+        return meta
+
     @property
     def settings(self):
         """ Return a dictionary listing simulation settings """
-        out = {'configuration': type(self).__name__}
+        out = {'Sim1D_type': type(self).__name__}
         out['transport_model'] = self.transport_model
         out['energy_enabled'] = self.energy_enabled
         out['soret_enabled'] = self.soret_enabled

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -80,10 +80,10 @@ class FlameBase(Sim1D):
         :param data:
             Restart data, which are typically based on an earlier simulation
             result. Restart data may be specified using a `SolutionArray`,
-            pandas' DataFrame, or previously saved CSV or HDF container files. 
-            Note that restart data do not overwrite boundary conditions. 
-            DataFrame and HDF input require working installations of pandas and 
-            PyTables. These packages can be installed using pip (`pandas` and 
+            pandas' DataFrame, or previously saved CSV or HDF container files.
+            Note that restart data do not overwrite boundary conditions.
+            DataFrame and HDF input require working installations of pandas and
+            PyTables. These packages can be installed using pip (`pandas` and
             `tables`) or conda (`pandas` and `pytables`).
         :param key:
             Group identifier within a HDF container file (only used in
@@ -388,6 +388,10 @@ class FlameBase(Sim1D):
 
         if not quiet:
             print("Solution saved to '{0}'.".format(filename))
+
+    def collect_data(self, domain):
+
+        return super().collect_data(domain, self._extra)
 
     def to_solution_array(self):
         """

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -256,8 +256,8 @@ cdef class Domain1D:
         """
         def __get__(self):
             out = {
-                'name': self.name,
-                'source': type(self).__name__}
+                'Domain1D_type': type(self).__name__,
+                'name': self.name}
 
             return out
 

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -399,6 +399,11 @@ cdef class ReactingSurface1D(Boundary1D):
         self.surf = new CxxReactingSurf1D()
         self.boundary = <CxxBdry1D*>(self.surf)
 
+    def __init__(self, *args, **kwargs):
+        self._weakref_proxy2 = _WeakrefProxy()
+        super().__init__(*args, **kwargs)
+        self._surface = None
+
     def __dealloc__(self):
         del self.surf
 
@@ -408,11 +413,17 @@ cdef class ReactingSurface1D(Boundary1D):
             raise TypeError('Kinetics object must be derived from '
                             'InterfaceKinetics.')
         self.surf.setKineticsMgr(<CxxInterfaceKinetics*>kin.kinetics)
+        self._surface = kin
+        self._surface._references[self._weakref_proxy2] = True
 
     property coverage_enabled:
         """Controls whether or not to solve the surface coverage equations."""
         def __set__(self, value):
             self.surf.enableCoverageEquations(<cbool>value)
+
+    property surface:
+        def __get__(self):
+            return self._surface
 
 
 cdef class _FlowBase(Domain1D):
@@ -962,11 +973,13 @@ cdef class Sim1D:
             for e in extra:
                if e == 'velocity':
                    extra_cols[e] = dom.mdot/self.gas.density
+               elif e not in {'lambda'}:
+                   extra_cols[e] = getattr(dom, e)
 
             return self.gas.TPY, extra_cols, meta
 
         elif isinstance(dom, ReactingSurface1D):
-            raise NotImplementedError("@todo")
+            return dom.surface.TPY, extra_cols, meta
 
         elif isinstance(dom, Boundary1D):
             return ([], [], []), extra_cols, meta
@@ -1021,7 +1034,7 @@ cdef class Sim1D:
             dom.mdot = extra_cols['velocity'] * self.gas.density
 
         elif isinstance(dom, ReactingSurface1D):
-            raise NotImplementedError("@todo")
+            dom.surface.TPY = T, P, Y
 
         elif isinstance(dom, Boundary1D):
             pass

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -26,6 +26,13 @@ cdef class Domain1D:
         self.gas._references[self._weakref_proxy] = True
         self.set_default_tolerances()
 
+    property phase:
+        """
+        Phase describing the domain (i.e. gas phase or surface phase).
+        """
+        def __get__(self):
+            return self.gas
+
     property index:
         """
         Index of this domain in a stack. Returns -1 if this domain is not part
@@ -252,7 +259,8 @@ cdef class Domain1D:
 
     property settings:
         """
-        Metadata
+        Return comprehensive dictionary describing type, name, and simulation
+        settings that are specific to domain types.
         """
         def __get__(self):
             out = {
@@ -400,12 +408,16 @@ cdef class ReactingSurface1D(Boundary1D):
         self.boundary = <CxxBdry1D*>(self.surf)
 
     def __init__(self, *args, **kwargs):
-        self._weakref_proxy2 = _WeakrefProxy()
+        self._weakref_proxy = _WeakrefProxy()
         super().__init__(*args, **kwargs)
-        self._surface = None
+        self.surface = None
 
     def __dealloc__(self):
         del self.surf
+
+    property phase:
+        def __get__(self):
+            return self.surface
 
     def set_kinetics(self, Kinetics kin):
         """Set the kinetics manager (surface reaction mechanism object)."""
@@ -413,17 +425,13 @@ cdef class ReactingSurface1D(Boundary1D):
             raise TypeError('Kinetics object must be derived from '
                             'InterfaceKinetics.')
         self.surf.setKineticsMgr(<CxxInterfaceKinetics*>kin.kinetics)
-        self._surface = kin
-        self._surface._references[self._weakref_proxy2] = True
+        self.surface = kin
+        self.surface._references[self._weakref_proxy] = True
 
     property coverage_enabled:
         """Controls whether or not to solve the surface coverage equations."""
         def __set__(self, value):
             self.surf.enableCoverageEquations(<cbool>value)
-
-    property surface:
-        def __get__(self):
-            return self._surface
 
 
 cdef class _FlowBase(Domain1D):
@@ -501,9 +509,6 @@ cdef class _FlowBase(Domain1D):
         del self.flow
 
     property settings:
-        """
-        Metadata
-        """
         def __get__(self):
             out = super().settings
 
@@ -722,6 +727,19 @@ cdef class Sim1D:
         self._initialized = False
         self._initial_guess_args = ()
         self._initial_guess_kwargs = {}
+
+    def phase(self, domain=None):
+        """
+        Return phase describing a domain (i.e. gas phase or surface phase).
+
+        :param domain: Index of domain within `Sim1D.domains` list; the default
+            is to return the phase of the parent `Sim1D` object.
+        """
+        if domain is None:
+            return self.gas
+
+        dom = self.domains[self.domain_index(domain)]
+        return dom.phase
 
     def set_interrupt(self, f):
         """
@@ -948,11 +966,7 @@ cdef class Sim1D:
             n_points = dom.n_points
 
             # retrieve gas state
-            T = self.profile(self.flame, 'T')
-            P = dom.P
-            k0 = self.flame.component_index(self.gas.species_name(0))
-            Y = [self.profile(self.flame, k)
-                 for k in range(k0, k0 + self.gas.n_species)]
+            states = self.T, self.P, self.Y.T
 
             # create extra columns
             for e in extra:
@@ -963,7 +977,6 @@ cdef class Sim1D:
             if self.radiation_enabled:
                 extra_cols['qdot'] = self.radiative_heat_loss
 
-            states = T, P, np.vstack(Y).T
             return states, extra_cols, meta
 
         elif isinstance(dom, Inlet1D):
@@ -972,7 +985,7 @@ cdef class Sim1D:
             # create extra columns
             for e in extra:
                if e == 'velocity':
-                   extra_cols[e] = dom.mdot/self.gas.density
+                   extra_cols[e] = dom.mdot / self.gas.density
                elif e not in {'lambda'}:
                    extra_cols[e] = getattr(dom, e)
 
@@ -990,7 +1003,7 @@ cdef class Sim1D:
 
     def restore_data(self, domain, states, extra_cols, meta):
         """
-        Restore data vector of domain *domain* from `SolutionArray` *arr*.
+        Restore data vector of domain *domain* from `SolutionArray` *states*.
 
         Derived classes set default values for *domain* and *extra*, where
         defaults describe flow domain and essential non-thermodynamic solution
@@ -1033,14 +1046,15 @@ cdef class Sim1D:
             dom.Y = Y
             dom.mdot = extra_cols['velocity'] * self.gas.density
 
+        elif isinstance(dom, (Outlet1D, OutletReservoir1D,
+                              SymmetryPlane1D, Surface1D)):
+            pass
+
         elif isinstance(dom, ReactingSurface1D):
             dom.surface.TPY = T, P, Y
 
-        elif isinstance(dom, Boundary1D):
-            pass
-
         else:
-            msg = ("Export of '{}' is not implemented")
+            msg = ("Import of '{}' is not implemented")
             raise NotImplementedError(msg.format(type(self).__name__))
 
     def show_solution(self):

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -969,7 +969,7 @@ cdef class Sim1D:
             raise NotImplementedError("@todo")
 
         elif isinstance(dom, Boundary1D):
-            return self.gas.TPY, extra_cols, meta
+            return ([], [], []), extra_cols, meta
 
         else:
             msg = ("Export of '{}' is not implemented")

--- a/interfaces/cython/cantera/onedim.pyx
+++ b/interfaces/cython/cantera/onedim.pyx
@@ -97,18 +97,23 @@ cdef class Domain1D:
         if default is not None:
             self.domain.setSteadyTolerances(default[0], default[1])
 
-        if abs is not None and rel is not None:
+        if abs is not None or rel is not None:
+            if rel is None:
+                rel = self.steady_reltol()
+            if abs is None:
+                abs = self.steady_abstol()
             assert len(abs) == len(rel) == self.n_components
-            for n,(r,a) in enumerate(zip(rel,abs)):
-                self.domain.setSteadyTolerances(r,a,n)
+            for n, (r, a) in enumerate(zip(rel, abs)):
+                self.domain.setSteadyTolerances(r, a, n)
 
         if Y is not None:
             k0 = self.component_index(self.gas.species_name(0))
             for n in range(k0, k0 + self.gas.n_species):
                 self.domain.setSteadyTolerances(Y[0], Y[1], n)
 
-        for name,(lower,upper) in kwargs.items():
-            self.domain.setSteadyTolerances(lower, upper, self.component_index(name))
+        for name, (rtol, atol) in kwargs.items():
+            self.domain.setSteadyTolerances(rtol, atol,
+                                            self.component_index(name))
 
     def set_transient_tolerances(self, *, default=None, Y=None, abs=None,
                                  rel=None, **kwargs):
@@ -127,18 +132,23 @@ cdef class Domain1D:
         if default is not None:
             self.domain.setTransientTolerances(default[0], default[1])
 
-        if abs is not None and rel is not None:
+        if abs is not None or rel is not None:
+            if rel is None:
+                rel = self.transient_reltol()
+            if abs is None:
+                abs = self.transient_abstol()
             assert len(abs) == len(rel) == self.n_components
-            for n,(r,a) in enumerate(zip(rel,abs)):
-                self.domain.setTransientTolerances(r,a,n)
+            for n, (r, a) in enumerate(zip(rel, abs)):
+                self.domain.setTransientTolerances(r, a, n)
 
         if Y is not None:
             k0 = self.component_index(self.gas.species_name(0))
             for n in range(k0, k0 + self.gas.n_species):
                 self.domain.setTransientTolerances(Y[0], Y[1], n)
 
-        for name,(lower,upper) in kwargs.items():
-            self.domain.setTransientTolerances(lower, upper, self.component_index(name))
+        for name, (rtol, atol) in kwargs.items():
+            self.domain.setTransientTolerances(rtol, atol,
+                                               self.component_index(name))
 
     def set_default_tolerances(self):
         """

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -257,8 +257,7 @@ class TestRestoreIdealGas(utilities.CanteraTest):
 
         # skip concentrations
         b = ct.SolutionArray(self.gas)
-        b.restore_data(OrderedDict([tup for i, tup in enumerate(data.items())
-                                    if i < 2]))
+        b.restore_data({'T': data['T'], 'density': data['density']})
         self.assertTrue(np.allclose(a.T, b.T))
         self.assertTrue(np.allclose(a.density, b.density))
         self.assertFalse(np.allclose(a.X, b.X))

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -172,7 +172,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         try:
             # this will run through if pandas is installed
             df = states.to_pandas()
-            self.assertTrue(df.shape[0]==7)
+            self.assertEqual(df.shape[0], 7)
         except ImportError as err:
             # pandas is not installed and correct exception is raised
             pass

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -213,8 +213,11 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         with self.assertRaisesRegex(IOError, 'phases do not match'):
             c.read_hdf(outfile, group='group1')
         with self.assertRaisesRegex(IOError, 'does not contain data'):
-            c.read_hdf(outfile, name='foo')
+            c.read_hdf(outfile, subgroup='foo')
 
+        states.write_hdf(outfile, group='foo/bar/baz')
+        c.read_hdf(outfile, group='foo/bar/baz')
+        self.assertTrue(np.allclose(states.T, c.T))
 
 class TestRestoreIdealGas(utilities.CanteraTest):
     """ Test restoring of the IdealGas class """

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -268,7 +268,7 @@ class TestRestoreIdealGas(utilities.CanteraTest):
 
         # wrong data shape
         b = ct.SolutionArray(self.gas)
-        with self.assertRaises(TypeError):
+        with self.assertRaises(ValueError):
             b.restore_data(OrderedDict([(k, v[np.newaxis, :])
                                         for k, v in data.items()]))
 
@@ -310,6 +310,7 @@ class TestRestoreIdealGas(utilities.CanteraTest):
             b.restore_data(data)
 
         # inconsistent species
+        data_mod = a.collect_data(tabular=True)
         val = data_mod.pop('Y_AR')
         data_mod['Y_invalid'] = val
         b = ct.SolutionArray(self.gas)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -218,8 +218,8 @@ class TestSolutionArrayIO(utilities.CanteraTest):
             c.read_hdf(outfile, group='eggs')
         with self.assertRaisesRegex(IOError, 'phases do not match'):
             c.read_hdf(outfile, group='group1')
-        with self.assertRaisesRegex(IOError, 'exceeds the number'):
-            c.read_hdf(outfile, index=1)
+        with self.assertRaisesRegex(IOError, 'does not contain data'):
+            c.read_hdf(outfile, name='foo')
 
 
 class TestRestoreIdealGas(utilities.CanteraTest):

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -4,15 +4,7 @@ import numpy as np
 import os
 from os.path import join as pjoin
 
-import pkg_resources
-
-# avoid explicit dependence of cantera on h5py
-try:
-    pkg_resources.get_distribution('h5py')
-except pkg_resources.DistributionNotFound:
-    _h5py = ImportError('Method requires a working h5py installation.')
-else:
-    import h5py as _h5py
+from cantera.composite import _h5py
 
 
 class TestOnedim(utilities.CanteraTest):
@@ -643,6 +635,7 @@ class TestFreeFlame(utilities.CanteraTest):
         k = self.gas.species_index('H2')
         self.assertArrayNear(data.X[:, k], self.sim.X[k, :])
 
+    @utilities.unittest.skipIf(isinstance(_h5py, ImportError), "h5py is not installed")
     def test_write_hdf(self):
         filename = pjoin(self.test_work_dir, 'onedim-write_hdf.h5')
         if os.path.exists(filename):
@@ -1122,7 +1115,7 @@ class TestImpingingJet(utilities.CanteraTest):
     def run_reacting_surface(self, xch4, tsurf, mdot, width):
         # Simplified version of the example 'catalytic_combustion.py'
         tinlet = 300.0  # inlet temperature
-        comp = {'CH4': xch4, 'O2':0.21, 'N2':0.79}
+        comp = {'CH4': xch4, 'O2': 0.21, 'N2': 0.79}
         sim = self.create_reacting_surface(comp, tsurf, tinlet, width)
         sim.set_refine_criteria(10.0, 0.3, 0.4, 0.0)
 
@@ -1141,13 +1134,13 @@ class TestImpingingJet(utilities.CanteraTest):
     def test_reacting_surface_case1(self):
         self.run_reacting_surface(xch4=0.095, tsurf=900.0, mdot=0.06, width=0.1)
 
-
     def test_reacting_surface_case2(self):
         self.run_reacting_surface(xch4=0.07, tsurf=1200.0, mdot=0.2, width=0.05)
 
     def test_reacting_surface_case3(self):
         self.run_reacting_surface(xch4=0.2, tsurf=800.0, mdot=0.1, width=0.2)
 
+    @utilities.unittest.skipIf(isinstance(_h5py, ImportError), "h5py is not installed")
     def test_write_hdf(self):
         filename = pjoin(self.test_work_dir, 'impingingjet-write_hdf.h5')
         if os.path.exists(filename):

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -303,7 +303,30 @@ class TestFreeFlame(utilities.CanteraTest):
             self.assertNear(rhou_j, rhou, 1e-4)
 
     def test_settings(self):
-        self.run_mix(phi=1.0, T=300, width=2.0, p=1.0, refine=False)
+        reactants = {'H2': 1., 'O2': 0.5, 'AR': 2}
+        self.create_sim(ct.one_atm, 300, reactants, 2.0)
+        self.sim.set_initial_guess()
+
+        # FlowBase specific settings
+        flame_settings = self.sim.flame.settings
+        keys = ['emissivity_left', 'emissivity_right',
+                'steady_abstol', 'steady_reltol',
+                'transient_abstol', 'transient_reltol']
+        for k in keys:
+            self.assertIn(k, flame_settings)
+
+        changed = {'emissivity_left': .12,
+                   'emissivity_right': .21,
+                   'steady_abstol': 2.53e-9,
+                   'steady_reltol_H2': 1.3e-8}
+        flame_settings.update(changed)
+
+        self.sim.flame.settings = flame_settings
+        changed_settings = self.sim.flame.settings
+        for key, val in changed.items():
+            self.assertEqual(changed_settings[key], val)
+
+        # Sim1D specific settings
         settings = self.sim.settings
 
         keys = ['configuration', 'transport_model',

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -323,7 +323,8 @@ class TestFreeFlame(utilities.CanteraTest):
 
         # FlowBase specific settings
         flame_settings = sim.flame.settings
-        keys = ['emissivity_left', 'emissivity_right',
+        keys = ['Domain1D_type',
+                'emissivity_left', 'emissivity_right',
                 'steady_abstol', 'steady_reltol',
                 'transient_abstol', 'transient_reltol']
         for k in keys:
@@ -343,7 +344,7 @@ class TestFreeFlame(utilities.CanteraTest):
         # Sim1D specific settings
         settings = sim.settings
 
-        keys = ['configuration', 'transport_model',
+        keys = ['Sim1D_type', 'transport_model',
                 'energy_enabled', 'soret_enabled', 'radiation_enabled',
                 'fixed_temperature',
                 'ratio', 'slope', 'curve', 'prune',
@@ -648,12 +649,14 @@ class TestFreeFlame(utilities.CanteraTest):
             os.remove(filename)
 
         self.run_mix(phi=1.1, T=350, width=2.0, p=2.0, refine=False)
-        self.sim.write_hdf(filename)
+        desc = 'mixture-averaged simulation'
+        self.sim.write_hdf(filename, description=desc)
 
         f = ct.FreeFlame(self.gas)
-        f.read_hdf(filename)
+        meta = f.read_hdf(filename)
         self.assertArrayNear(f.grid, self.sim.grid)
         self.assertArrayNear(f.T, self.sim.T)
+        self.assertEqual(meta['description'], desc)
         k = self.gas.species_index('H2')
         self.assertArrayNear(f.X[k, :], self.sim.X[k, :])
         self.assertArrayNear(f.inlet.X, self.sim.inlet.X)

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -331,13 +331,9 @@ class TestFreeFlame(utilities.CanteraTest):
 
         keys = ['configuration', 'transport_model',
                 'energy_enabled', 'soret_enabled', 'radiation_enabled',
-                'emissivity_left', 'emissivity_right',
                 'fixed_temperature',
                 'ratio', 'slope', 'curve', 'prune',
-                'max_time_step_count',
-                'max_grid_points',
-                'steady_abstol', 'steady_reltol',
-                'transient_abstol', 'transient_reltol']
+                'max_time_step_count', 'max_grid_points']
         for k in keys:
             self.assertIn(k, settings)
 
@@ -349,8 +345,8 @@ class TestFreeFlame(utilities.CanteraTest):
         settings.update(changed)
 
         self.sim.settings = settings
-        for k, v in changed.items():
-            self.assertEqual(getattr(self.sim, k), v)
+        for key, val in changed.items():
+            self.assertEqual(getattr(self.sim, key), val)
 
     def test_mixture_averaged_case1(self):
         self.run_mix(phi=0.65, T=300, width=0.03, p=1.0, refine=True)

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -280,7 +280,7 @@ class TestFreeFlame(utilities.CanteraTest):
         self.assertArrayNear(self.sim.grid, flow.grid)
         self.assertArrayNear(self.sim.T, flow.T)
         for k in flow._extra.keys():
-            self.assertIn(k, self.sim._extra)
+            self.assertIn(k, self.sim._other)
 
         f2 = ct.FreeFlame(self.gas)
         f2.from_solution_array(flow)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1778,36 +1778,6 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertArrayNear(states('OH','O').partial_molar_cp,
                              states.partial_molar_cp[...,kk])
 
-    def test_write_csv(self):
-        states = ct.SolutionArray(self.gas, 7)
-        states.TPX = np.linspace(300, 1000, 7), 2e5, 'H2:0.5, O2:0.4'
-        states.equilibrate('HP')
-
-        outfile = pjoin(self.test_work_dir, 'solutionarray.csv')
-        states.write_csv(outfile)
-
-        data = np.genfromtxt(outfile, names=True, delimiter=',')
-        self.assertEqual(len(data), 7)
-        self.assertEqual(len(data.dtype), self.gas.n_species + 2)
-        self.assertIn('Y_H2', data.dtype.fields)
-
-        b = ct.SolutionArray(self.gas)
-        b.read_csv(outfile)
-        self.assertTrue(np.allclose(states.T, b.T))
-        self.assertTrue(np.allclose(states.P, b.P))
-        self.assertTrue(np.allclose(states.X, b.X))
-
-    def test_pandas(self):
-        states = ct.SolutionArray(self.gas, 7)
-        states.TPX = np.linspace(300, 1000, 7), 2e5, 'H2:0.5, O2:0.4'
-        try:
-            # this will run through if pandas is installed
-            df = states.to_pandas()
-            self.assertTrue(df.shape[0]==7)
-        except ImportError as err:
-            # pandas is not installed and correct exception is raised
-            pass
-
     def test_slice_SolutionArray(self):
         soln = ct.SolutionArray(self.gas, 10)
         arr = soln[2:9:3]

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1529,6 +1529,12 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertEqual(states.reaction_equation(10),
                          self.gas.reaction_equation(10))
 
+    def test_meta(self):
+        meta = {'foo': 'bar', 'spam': 'eggs'}
+        states = ct.SolutionArray(self.gas, 3, meta=meta)
+        self.assertEqual(states.meta['foo'], 'bar')
+        self.assertEqual(states.meta['spam'], 'eggs')
+
     def test_get_state(self):
         states = ct.SolutionArray(self.gas, 4)
         H, P = states.HP

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -13,6 +13,9 @@ class TestThermoPhase(utilities.CanteraTest):
     def setUp(self):
         self.phase = ct.Solution('h2o2.xml')
 
+    def test_source(self):
+        self.assertEqual(self.phase.source, 'h2o2.xml')
+
     def test_base_attributes(self):
         self.assertIsInstance(self.phase.name, str)
         self.assertIsInstance(self.phase.phase_of_matter, str)
@@ -1644,7 +1647,7 @@ class TestSolutionArray(utilities.CanteraTest):
     def test_extra(self):
         with self.assertRaises(ValueError):
             states = ct.SolutionArray(self.gas, extra=['creation_rates'])
-        
+
     def test_append(self):
         states = ct.SolutionArray(self.gas, 5)
         states.TPX = np.linspace(500, 1000, 5), 2e5, 'H2:0.5, O2:0.4'

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1,5 +1,6 @@
 from os.path import join as pjoin
 from pathlib import Path
+from collections import OrderedDict
 import os
 import numpy as np
 import gc
@@ -1651,6 +1652,12 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertArrayNear(row2.T, 900*np.ones(5))
 
     def test_extra(self):
+        extra = OrderedDict([('grid', np.arange(10)),
+                             ('velocity', np.random.rand(10))])
+        states = ct.SolutionArray(self.gas, 10, extra=extra)
+        keys = list(states._extra.keys())
+        self.assertEqual(keys[0], 'grid')
+        
         with self.assertRaises(ValueError):
             states = ct.SolutionArray(self.gas, extra=['creation_rates'])
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #830, fixes #832 (PR supersedes #834), fixes #833 (PR incorporates #836).

**Changes proposed in this pull request**

- The previously implemented `SolutionArray` HDF output option uses the `pandas` library to write HDF5 files. However, `pandas` introduces an additional layer of abstraction beyond the native structure of HDF5 datasets.
- A simpler, more direct structure ensures HDF output portability to other languages such as Matlab or C++.
- Add `meta` attribute to `SolutionArray` to facilitate storage and restoration of meta data (e.g. settings of `Domain1D` objects).

This PR proposes the following implementation for a single `SolutionArray`:
```
some_group_name/d0/solution/attrs['name'] = 'gri30'
some_group_name/d0/solution/attrs['source'] = 'gri30.xml
some_group_name/d0/T
some_group_name/d0/density
some_group_name/d0/Y_H2
some_group_name/d0/Y_H
...
```
For `FlameBase` output, the intermediate layer `d{}` allows for multiple `SolutionArrays` to be stored in a single group. 
```
some_group_name/attrs['type`] = 'FreeFlame'
some_group_name/attrs[<setting1>] = ...
some_group_name/attrs[<setting2>] = ...
... 
some_group_name/d0/attrs['type'] = 'Inlet1D'
some_group_name/d0/solution/attrs['name'] = 'ohmech'
some_group_name/d0/solution/attrs['source'] = 'h2o2.yaml'
some_group_name/d0/T
some_group_name/d0/density
some_group_name/d0/Y_H2
some_group_name/d0/Y_H
...
some_group_name/d1/attrs['type'] = 'Domain1D'
some_group_name/d1/solution/attrs['name'] = 'ohmech'
some_group_name/d1/solution/attrs['source'] = 'h2o2.yaml'
some_group_name/d1/T
some_group_name/d1/density
some_group_name/d1/Y_H2
some_group_name/d1/Y_H
...
some_group_name/d2/attrs['type'] = 'Outlet1D'
some_group_name/d2/solution/attrs['name'] = 'ohmech'
some_group_name/d2/solution/attrs['source'] = 'h2o2.yaml'
```