### PR TITLE
Fix error in exchange current density conversion

### DIFF
--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1215,3 +1215,29 @@ class TestReaction(utilities.CanteraTest):
 
         # M&W toggled on (locally) for reaction 9
         self.assertNear(2.0 * k1[9], k2[9]) # sticking coefficient = 1.0
+
+class TestButlerVolmer(utilities.CanteraTest):
+
+    def test_pressure_dependence(self):
+        infile = 'butler-volmer-test.yaml'
+        
+        gas = ct.Solution(infile,'gas')
+        Pt = ct.Solution(infile,'metal')
+        Naf = ct.Solution(infile,'electrolyte')
+        tpb = ct.Interface(infile,'tpb',[gas,Pt,Naf])
+        phases = {gas,Pt,Naf,tpb}
+
+        TP1 = 300, ct.one_atm
+        for ph in phases:
+            ph.TP = TP1
+
+        k1 = tpb.forward_rate_constants[0]
+
+        TP2 = 300., 10*ct.one_atm
+        for ph in phases:
+            ph.TP = TP2
+        
+        k2 = tpb.forward_rate_constants[0]
+
+        self.assertNear(k1,k2)
+

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -269,7 +269,7 @@ void InterfaceKinetics::convertExchangeCurrentDensityFormulation(doublereal* con
                 //  Calculate the term and modify the forward reaction
                 double tmp = exp(- m_beta[i] * m_deltaG0[irxn]
                                  / thermo(reactionPhaseIndex()).RT());
-                tmp *= 1.0 / m_ProdStanConcReac[irxn] / Faraday;
+                tmp *= 1.0 / pow(m_ProdStanConcReac[irxn],m_beta[i]) / Faraday;
                 kfwd[irxn] *= tmp;
             }
             //  If BVform is nonzero we don't need to do anything.
@@ -284,8 +284,8 @@ void InterfaceKinetics::convertExchangeCurrentDensityFormulation(doublereal* con
                 // constant so that it's in the exchange current density
                 // formulation format
                 double tmp = exp(m_beta[i] * m_deltaG0[irxn]
-                                 * thermo(reactionPhaseIndex()).RT());
-                tmp *= Faraday * m_ProdStanConcReac[irxn];
+                                 / thermo(reactionPhaseIndex()).RT());
+                tmp *= Faraday * pow(m_ProdStanConcReac[irxn],m_beta[i]);
                 kfwd[irxn] *= tmp;
             }
         }

--- a/test/data/butler-volmer-test.yaml
+++ b/test/data/butler-volmer-test.yaml
@@ -1,0 +1,81 @@
+
+units: {length: cm, time: s, quantity: mol, activation-energy: J/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [H, O]
+  species:
+  - gri30.yaml/species: [H2, H2O]
+  transport: mixture-averaged
+  state:
+    T: 300.
+    P: 1.01325e+05
+    X: {H2: 0.95, H2O: 0.05}
+- name: metal
+  thermo: electron-cloud
+  elements: [E]
+  species: [electron]
+  state:
+    T: 300.
+    X: {electron: 1.0}
+  density: 9.0 kg/m^3
+- name: electrolyte
+  thermo: ideal-condensed
+  elements: [H, E]
+  species: [H(elyte), Vac(elyte)]
+  state:
+    T: 300.
+    P: 1.01325e+05
+    X: {H(elyte): 1.0, Vac(elyte): 1e-5}
+- name: tpb
+  thermo: edge
+  elements: [H]
+  species: [(tpb)]
+  kinetics: edge
+  reactions: [tpb-reactions]
+  state:
+    T: 300.
+    coverages: {(tpb): 1.0}
+  site-density: 2.7e-9
+
+species:
+- name: electron
+  composition: {E: 1}
+  thermo:
+    model: constant-cp
+    h0: 0.0 kcal/mol
+- name: Vac(elyte)
+  composition: {}
+  thermo:
+    model: constant-cp
+    h0: 0.0 kJ/mol
+  equation-of-state:
+    model: constant-volume
+    molar-volume: 88.063 cm^3/mol
+  note: A bulk electrolyte vacancy
+- name: H(elyte)
+  composition: {H: 1, E: -1}
+  thermo:
+    model: constant-cp
+    h0: -50.0 kJ/mol
+    s0: 0.0 J/K/mol
+  equation-of-state:
+    model: constant-volume
+    molar-volume: 88.063 cm^3/mol
+  note: A bulk electrolyte proton
+- name: (tpb)
+  composition: {}
+  thermo:
+    model: constant-cp
+  note: dummy species
+
+# In this global reaction, two electrons from the bulk Oxide species are
+# transferred to the metal, while the oxygen reacts with H2 in the gas
+# phase to creata a gas phase H2O molecule.
+tpb-reactions:
+- equation: H2 + 2 Vac(elyte) <=> 2 H(elyte) + 2 electron 
+  id: edge-f1
+  rate-constant: {A: 2.0e+10, b: 0.0, Ea: 0.0 kJ/mol}
+  exchange-current-density-formulation: true
+  beta: 0.5


### PR DESCRIPTION
-Fixes issue #841, wherein
`InterfaceKinetics`::`convertExchangeCurrentDensityFormulation` incorrectly
returned pressure-dependent rate constants, due to a mising `m_beta`
exponent in the standard concentration product.
-Also adds a test to the python test suite to ensure that a specified
rate constant remains appropriately pressure-independent.
-Caught an error in the conversion from rate constant back to exchange
current, wherein dG^0 was multiplied rather than divided by RT.

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #841

**Changes proposed in this pull request**

- Raise `m_ProdStanConcReac` to the power `m_beta` in `InterfaceKinetics`::`convertExchangeCurrentDensityFormulation` when converting between exchange current density and k_fwd.
-Adds a test to test the pressure dependende of f_fwd as converted from exchange current density.
-Corrects a separate typo in `InterfaceKinetics`::`convertExchangeCurrentDensityFormulation`.
