### PR TITLE
Prevent standalone Kinetics and Transport objects in Python

### DIFF
--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -119,7 +119,9 @@ cdef class _SolutionBase:
             self._thermo = newPhase(phaseNode, root)
             self.thermo = self._thermo.get()
         else:
-            self.thermo = NULL
+            msg = ("Cannot instantiate a standalone '{}' object; use "
+                   "'Solution' instead").format(type(self).__name__)
+            raise NotImplementedError(msg)
 
         # Kinetics
         cdef vector[CxxThermoPhase*] v
@@ -159,7 +161,9 @@ cdef class _SolutionBase:
             self.thermo = newPhase(deref(phaseNode))
             self._thermo.reset(self.thermo)
         else:
-            self.thermo = NULL
+            msg = ("Cannot instantiate a standalone '{}' object; use "
+                   "'Solution' instead").format(type(self).__name__)
+            raise NotImplementedError(msg)
 
         # Kinetics
         cdef vector[CxxThermoPhase*] v


### PR DESCRIPTION
**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #844

**Changes proposed in this pull request**

- Prevent instantiation of `Kinetics` and `Transport` objects in Python
- Both require (limited) information on species, which is currently handled by `ThermoPhase`
