### PR TITLE
[Thermo] Provide const access for speciesThermo()

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -18,7 +18,7 @@ Steven DeCaluwe (@decaluwe), Colorado School of Mines
 Vishesh Devgan (@vdevgan)
 Thomas Fiala (@thomasfiala), Technische Universität München
 David Fronczek
-@g3bk47
+Thorsten Zirwes, Karlsruhe Institute of Technology
 Matteo Giani (@MarcDuQuesne)
 Dave Goodwin, California Institute of Technology
 John Hewson (@jchewson), Sandia National Laboratory

--- a/AUTHORS
+++ b/AUTHORS
@@ -18,7 +18,6 @@ Steven DeCaluwe (@decaluwe), Colorado School of Mines
 Vishesh Devgan (@vdevgan)
 Thomas Fiala (@thomasfiala), Technische Universität München
 David Fronczek
-Thorsten Zirwes, Karlsruhe Institute of Technology
 Matteo Giani (@MarcDuQuesne)
 Dave Goodwin, California Institute of Technology
 John Hewson (@jchewson), Sandia National Laboratory
@@ -51,3 +50,4 @@ Laurien Vandewalle (@lavdwall)
 Bryan Weber (@bryanwweber), University of Connecticut
 Armin Wehrfritz (@awehrfritz)
 Richard West (@rwest), Northeastern University
+Thorsten Zirwes (@g3bk47), Karlsruhe Institute of Technology

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1401,6 +1401,8 @@ public:
      * @internal
      */
     virtual MultiSpeciesThermo& speciesThermo(int k = -1);
+    
+    virtual const MultiSpeciesThermo& speciesThermo(int k = -1) const;
 
     /**
      * @internal

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -695,6 +695,12 @@ MultiSpeciesThermo& ThermoPhase::speciesThermo(int k)
     return m_spthermo;
 }
 
+const MultiSpeciesThermo& ThermoPhase::speciesThermo(int k) const
+{
+    return m_spthermo;
+}
+
+
 void ThermoPhase::initThermoFile(const std::string& inputFile,
                                  const std::string& id)
 {


### PR DESCRIPTION
Provide const access for speciesThermo() member function in case the in case the actual thermo object is only available as const reference and the user wants information about the species thermo.