### PR TITLE
Add optional parameters when calling equilibrate in fortran

### DIFF
--- a/src/fortran/cantera_thermo.f90
+++ b/src/fortran/cantera_thermo.f90
@@ -475,11 +475,47 @@ contains
       self%err = th_set_sp(self%thermo_id, s, p)
     end subroutine ctthermo_setstate_sp
 
-    subroutine ctthermo_equilibrate(self, XY)
+    subroutine ctthermo_equilibrate(self, XY, solver, rtol, max_steps, max_iter, estimate_equil, log_level)
       implicit none
       type(phase_t), intent(inout) :: self
       character*(*), intent(in) :: XY
-      self%err = th_equil(self%thermo_id, XY)
+      character*(*), intent(in), optional :: solver
+      double precision, intent(in), optional :: rtol
+      integer, intent(in), optional :: max_steps
+      integer, intent(in), optional :: max_iter
+      integer, intent(in), optional :: estimate_equil
+      integer, intent(in), optional :: log_level
+      character*(50) :: solver_
+      double precision :: rtol_
+      integer :: max_steps_
+      integer :: max_iter_
+      integer :: estimate_equil_
+      integer :: log_level_
+      solver_ = 'auto'
+      rtol_ = 1e-9
+      max_steps_ = 50000
+      max_iter_ = 100
+      estimate_equil_ = 0
+      log_level_ = 0
+      if(present(solver)) then
+          solver_ = solver
+      endif
+      if(present(rtol)) then
+          rtol_ = rtol
+      endif
+      if(present(max_steps)) then
+          max_steps_ = max_steps
+      endif
+      if(present(max_iter)) then
+          max_iter_ = max_iter
+      endif
+      if(present(estimate_equil)) then
+          estimate_equil_ = estimate_equil
+      endif
+      if(present(log_level)) then
+          log_level_ = log_level
+      endif
+      self%err = th_equil(self%thermo_id, XY, trim(solver_), rtol_, max_steps_, max_iter_, estimate_equil_, log_level_)
     end subroutine ctthermo_equilibrate
 
     double precision function ctthermo_refPressure(self)

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -565,10 +565,10 @@ extern "C" {
         return 0;
     }
 
-    status_t th_equil_(const integer* n, char* XY, ftnlen lenxy)
+    status_t th_equil_(const integer* n, char* XY, char* solver, double rtol, int max_steps, int max_iter, int estimate_equil, int log_level, ftnlen lensolver, ftnlen lenxy)
     {
         try {
-            _fth(n)->equilibrate(f2string(XY,lenxy));
+            _fth(n)->equilibrate(f2string(XY,lenxy), f2string(solver,lensolver), rtol, max_steps, max_iter, estimate_equil, log_level);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/fortran/fct_interface.f90
+++ b/src/fortran/fct_interface.f90
@@ -223,9 +223,15 @@ interface
         double precision, intent(in) :: v2
     end function th_set_sp
 
-    integer function th_equil(n, XY)
+    integer function th_equil(n, XY, solver, rtol, max_steps, max_iter, estimate_equil, log_level)
         integer, intent(in) :: n
         character*(*), intent(in) :: XY
+        character*(*), intent(in) :: solver
+        double precision, intent(in) :: rtol
+        integer, intent(in) :: max_steps
+        integer, intent(in) :: max_iter
+        integer, intent(in) :: estimate_equil
+        integer, intent(in) :: log_level
     end function th_equil
 
     double precision function th_refpressure(n)


### PR DESCRIPTION
Allow setting the equilibrium chemistry solver, relative tolerance, max
steps, max number of iterations, whether to estimate the equilibrium
state and set the log level.

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [ ] There is a clear use-case for this code change
- [ ] The commit message has a short title & references relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #

**Changes proposed in this pull request**

- Provide the option of providing different relative tolerances, maximum steps and iterations for equilibrium chemistry from the fortran interface
