### PR TITLE
Update find_isomers to return dictionary

### DIFF
--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -800,13 +800,13 @@ public:
 
     //! Return a vector with isomers names matching a given composition map
     //!     @param compMap compositionMap of the species.
-    //!     @return A vector of species names for matching species.
-    virtual std::vector<std::string> findIsomers(const compositionMap& compMap) const;
+    //!     @return A map of species names and indices for matching species.
+    virtual std::map<std::string, size_t> findIsomers(const compositionMap& compMap) const;
 
     //! Return a vector with isomers names matching a given composition string
     //!     @param comp String containing a composition map
-    //!     @return A vector of species names for matching species.
-    virtual std::vector<std::string> findIsomers(const std::string& comp) const;
+    //!     @return A map of species names and indices for matching species.
+    virtual std::map<std::string, size_t> findIsomers(const std::string& comp) const;
 
     //! Return the Species object for the named species. Changes to this object
     //! do not affect the ThermoPhase object until the #modifySpecies function

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -197,8 +197,8 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         cbool caseSensitiveSpecies()
         void setCaseSensitiveSpecies(cbool)
         void addSpeciesAlias(string, string) except +translate_exception
-        vector[string] findIsomers(Composition&) except +translate_exception
-        vector[string] findIsomers(string) except +translate_exception
+        stdmap[string, size_t] findIsomers(Composition&) except +translate_exception
+        stdmap[string, size_t] findIsomers(string) except +translate_exception
 
         double molecularWeight(size_t) except +translate_exception
         double meanMolecularWeight()

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1158,15 +1158,27 @@ class TestSpecies(utilities.CanteraTest):
             self.gas.add_species_alias('spam', 'eggs')
 
     def test_isomers(self):
+        def check(iso):
+            self.assertIsInstance(iso, dict)
+            for name, index in iso.items():
+                self.assertIn(name, gas.species_names)
+                self.assertEqual(gas.species_index(name), index)
+
         gas = ct.Solution('nDodecane_Reitz.yaml')
         iso = gas.find_isomers({'C':4, 'H':9, 'O':2})
+        check(iso)
         self.assertTrue(len(iso) == 2)
         iso = gas.find_isomers('C:4, H:9, O:2')
         self.assertTrue(len(iso) == 2)
+        check(iso)
         iso = gas.find_isomers({'C':7, 'H':15})
         self.assertTrue(len(iso) == 1)
+        check(iso)
         iso = gas.find_isomers({'C':7, 'H':16})
         self.assertTrue(len(iso) == 0)
+        check(iso)
+        with self.assertRaisesRegex(ct.CanteraError, 'Invalid'):
+            gas.find_isomers(3)
 
 
 class TestSpeciesThermo(utilities.CanteraTest):
@@ -1644,7 +1656,7 @@ class TestSolutionArray(utilities.CanteraTest):
     def test_extra(self):
         with self.assertRaises(ValueError):
             states = ct.SolutionArray(self.gas, extra=['creation_rates'])
-        
+
     def test_append(self):
         states = ct.SolutionArray(self.gas, 5)
         states.TPX = np.linspace(500, 1000, 5), 2e5, 'H2:0.5, O2:0.4'

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -604,17 +604,20 @@ cdef class ThermoPhase(_SolutionBase):
 
     def find_isomers(self, comp):
         """
-        Find species/isomers matching a composition specified by *comp*.
+        Find species/isomers matching a composition specified by *comp*;
+        returns a dictionary of species names and indices.
+
+        >>> phase.find_isomers('C:1, H:2')
+        {'CH2': 10, 'CH2(S)': 11}
         """
-
         if isinstance(comp, dict):
-            iso = self.thermo.findIsomers(comp_map(comp))
-        elif isinstance(comp, (str, bytes)):
-            iso = self.thermo.findIsomers(stringify(comp))
-        else:
-            raise CanteraError('Invalid composition')
+            return {pystr(item.first): item.second
+                    for item in self.thermo.findIsomers(comp_map(comp))}
+        if isinstance(comp, (str, bytes)):
+            return {pystr(item.first): item.second
+                    for item in self.thermo.findIsomers(stringify(comp))}
 
-        return [pystr(b) for b in iso]
+        raise CanteraError('Invalid composition')
 
     def n_atoms(self, species, element):
         """

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -973,20 +973,20 @@ void Phase::addSpeciesAlias(const std::string& name, const std::string& alias)
     }
 }
 
-vector<std::string> Phase::findIsomers(const compositionMap& compMap) const
+map<std::string, size_t> Phase::findIsomers(const compositionMap& compMap) const
 {
-    vector<std::string> isomerNames;
+    map<std::string, size_t> isomers;
 
     for (const auto& k : m_species) {
         if (k.second->composition == compMap) {
-            isomerNames.emplace_back(k.first);
+            isomers.emplace(k.first, m_speciesIndices.find(k.first)->second);
         }
     }
 
-    return isomerNames;
+    return isomers;
 }
 
-vector<std::string> Phase::findIsomers(const std::string& comp) const
+map<std::string, size_t> Phase::findIsomers(const std::string& comp) const
 {
     return findIsomers(parseCompString(comp));
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->
This simple update addresses a comment by @bryanwweber (see #635)

>  ... `find_isomers` returns species names, not indices, resulting in an additional step for users. I suppose users would have to look up the species name for the indices returned by `species_index` anyways, since the index by itself is not very meaningful

As `find_isomers` was introduced recently and only exists in the development branch, the change of the interface is inconsequential.

**New behavior:**

```
In [1]: import cantera as ct

In [2]: gas = ct.Solution('gri30.yaml')

In [3]: gas.find_isomers('C:1, H:2')
Out[3]: {'CH2': 10, 'CH2(S)': 11}
```

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
