### PR TITLE
Add cantera version and commit to HDF output

### DIFF
--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -1,12 +1,14 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-import numpy as np
-from ._cantera import *
-from .composite import Solution, SolutionArray
 from math import erf
 from os import path
 from email.utils import formatdate
+import numpy as np
+
+from ._cantera import *
+from .composite import Solution, SolutionArray
+from . import __version__, __git_commit__
 
 
 class FlameBase(Sim1D):
@@ -564,6 +566,8 @@ class FlameBase(Sim1D):
         cols = ('extra', 'T', 'D', species)
         meta = self.settings
         meta['date'] = formatdate(localtime=True)
+        meta['cantera_version'] = __version__
+        meta['git_commit'] = __git_commit__
         if description is not None:
             meta['description'] = description
         for i in range(3):

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -653,6 +653,8 @@ class TestFreeFlame(utilities.CanteraTest):
         k = self.gas.species_index('H2')
         self.assertArrayNear(f.X[k, :], self.sim.X[k, :])
         self.assertArrayNear(f.inlet.X, self.sim.inlet.X)
+        self.assertEqual(meta['cantera_version'], ct.__version__)
+        self.assertEqual(meta['git_commit'], ct.__git_commit__)
 
         settings = self.sim.settings
         for k, v in f.settings.items():


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**Changes proposed in this pull request**

Minor addendum to #840 ... when retrieving old simulation data, it may be of interest to identify the cantera version used for its generation.

- Add Cantera version to HDF output