### PR TITLE
Make species charge an accessible phase property

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -482,8 +482,8 @@ class SolutionArray:
         'name', 'ID', 'source', 'basis', 'n_elements', 'element_index',
         'element_name', 'element_names', 'atomic_weight', 'atomic_weights',
         'n_species', 'species_name', 'species_names', 'species_index',
-        'species', 'n_atoms', 'molecular_weights', 'min_temp', 'max_temp',
-        'reference_pressure',
+        'species', 'n_atoms', 'molecular_weights', 'electrical_charges',
+        'min_temp', 'max_temp', 'reference_pressure',
         # From Kinetics
         'n_total_species', 'n_reactions', 'n_phases', 'reaction_phase_index',
         'kinetics_species_index', 'reaction', 'reactions', 'modify_reaction',

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -134,6 +134,15 @@ class TestThermoPhase(utilities.CanteraTest):
                 test_weight += aw * self.phase.n_atoms(i,j)
             self.assertNear(test_weight, mw)
 
+    def test_charges(self):
+        gas = ct.Solution('ch4_ion.yaml')
+        charges = gas.electrical_charges
+        test = {'E': -1., 'N2': 0., 'H3O+': 1.}
+        for species, charge in test.items():
+            self.assertIn(species, gas.species_names)
+            index = gas.species_index(species)
+            self.assertEqual(charges[index], charge)
+
     def test_setComposition(self):
         X = np.zeros(self.phase.n_species)
         X[2] = 1.0
@@ -1657,7 +1666,7 @@ class TestSolutionArray(utilities.CanteraTest):
         states = ct.SolutionArray(self.gas, 10, extra=extra)
         keys = list(states._extra.keys())
         self.assertEqual(keys[0], 'grid')
-        
+
         with self.assertRaises(ValueError):
             states = ct.SolutionArray(self.gas, extra=['creation_rates'])
 

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -660,6 +660,12 @@ cdef class ThermoPhase(_SolutionBase):
         def __get__(self):
             return self._getArray1(thermo_getMolecularWeights)
 
+    property electrical_charges:
+        """Array of species electrical charges, in units of elementary charge."""
+        def __get__(self):
+            return np.array([self.species(spc).charge
+                             for spc in self.species_names])
+
     property mean_molecular_weight:
         """The mean molecular weight (molar mass) [kg/kmol]."""
         def __get__(self):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes Cantera/enhancements#50 

**Changes proposed in this pull request**

- Add `ThermoPhase.electrical_charges` property to Python interface
- Consistent with `molecular_weights`, the property returns a `np.ndarray`

**Thoughts**

The initial version of this PR is meant to be a starting point for discussion. 

* The array is already defined in C++ as `Phase::m_speciesCharge` ... it is straight-forward to thread this array through the Cython interface (I used the comprehension for the time being).
* It is also debatable whether to use `electrical_charges`, `species_charges` or other for the property name (on further thought, `species_charges` may be preferable, but I'll leave things as they are for discussion).

I am leaving the box 'ready for review' unchecked until the discussion has converged.