### PR TITLE
Documentation & deprecation updates related to input files

### DIFF
--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -322,8 +322,8 @@ std::vector<AnyMap>& AnyValue::asVector<AnyMap>(size_t nMin, size_t nMax);
  *     breakfast["waffle"].asDouble();
  * } except (std::exception& err) {
  *     // Exception will be thrown.
- *     // 'breakfast' will have an empty key named "waffle" unless `breakfast`
- *     // is a `const AnyMap`.
+ *     // 'breakfast' will have an empty key named 'waffle' unless 'breakfast'
+ *     // is a 'const AnyMap'.
  * }
  *
  * try {

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -503,6 +503,9 @@ public:
      * After being processed, the `units` nodes are removed, so this function
      * should be called only once, on the root AnyMap. This function is called
      * automatically by the fromYamlFile() and fromYamlString() constructors.
+     *
+     * @warning This function is an experimental part of the %Cantera API and
+     *     may be changed or removed without notice.
      */
     void applyUnits(const UnitSystem& units);
 

--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -142,6 +142,9 @@ public:
 
     //! Convert `value` from this unit system (defined by `setDefaults`) to the
     //! specified units.
+    //!
+    //! @warning This function is an experimental part of the %Cantera API and
+    //!    may be changed or removed without notice.
     double convert(double value, const std::string& dest) const;
     double convert(double value, const Units& dest) const;
 
@@ -167,6 +170,9 @@ public:
 
     //! Convert `value` from the default activation energy units to the
     //! specified units
+    //!
+    //! @warning This function is an experimental part of the %Cantera API and
+    //!    may be changed or removed without notice.
     double convertActivationEnergy(double value, const std::string& dest) const;
 
     //! Convert a generic AnyValue node to the units specified in `dest`. If the

--- a/include/cantera/base/ctml.h
+++ b/include/cantera/base/ctml.h
@@ -57,6 +57,9 @@ class Array2D;
  *                      special double, Undef, which means to ignore the entry.
  * @param maxval        Maximum allowed value of the float. The default is the
  *                      special double, Undef, which means to ignore the entry.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void addFloat(XML_Node& node, const std::string& titleString,
               const doublereal value, const std::string& unitsString="",
@@ -104,6 +107,9 @@ void addFloat(XML_Node& node, const std::string& titleString,
  * @param maxval        Maximum allowed value of the int. This is an optional
  *                      parameter. The default is the special double,
  *                      Undef, which means to ignore the entry.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void addFloatArray(XML_Node& node, const std::string& titleString,
                    const size_t n, const doublereal* const values,
@@ -152,6 +158,9 @@ void addFloatArray(XML_Node& node, const std::string& titleString,
  * @param maxval      Maximum allowed value of the int. This is an optional
  *                    parameter. The default is the special double,
  *                    Undef, which means to ignore the entry.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void addNamedFloatArray(XML_Node& parentNode, const std::string& name, const size_t n,
                         const doublereal* const vals, const std::string units = "",
@@ -183,6 +192,9 @@ void addNamedFloatArray(XML_Node& parentNode, const std::string& name, const siz
  * @param valueString Value string to be used in the new XML node.
  * @param titleString String name of the title attribute
  * @param typeString  String type. This is an optional parameter.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void addString(XML_Node& node, const std::string& titleString,
                const std::string& valueString, const std::string& typeString="");
@@ -235,6 +247,9 @@ void addString(XML_Node& node, const std::string& titleString,
  * @param  nodeName     XML Name of the XML node to read. The default value for
  *                      the node name is floatArray
  * @returns the number of floats read into v.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 size_t getFloatArray(const XML_Node& node, vector_fp & v,
                      const bool convert=true, const std::string& unitsString="",
@@ -248,6 +263,9 @@ size_t getFloatArray(const XML_Node& node, vector_fp & v,
  *
  * @param node   Node to get the value from
  * @param v      Output vector containing the string tokens
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void getStringArray(const XML_Node& node, std::vector<std::string>& v);
 
@@ -267,6 +285,9 @@ void getStringArray(const XML_Node& node, std::vector<std::string>& v);
  *
  *  @param node Current node
  *  @param m    Output Map containing the pairs of values found in the XML Node
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void getMap(const XML_Node& node, std::map<std::string, std::string>& m);
 
@@ -296,6 +317,9 @@ void getMap(const XML_Node& node, std::map<std::string, std::string>& m);
  *  @param key              Vector of keys for each entry
  *  @param val              Vector of values for each entry
  *  @returns the number of pairs found
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 int getPairs(const XML_Node& node, std::vector<std::string>& key,
              std::vector<std::string>& val);
@@ -336,6 +360,9 @@ int getPairs(const XML_Node& node, std::vector<std::string>& key,
  *                      true.
  * @param matrixSymmetric  If true entries are made so that the matrix is always
  *                      symmetric. Default is false.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void getMatrixValues(const XML_Node& node,
                      const std::vector<std::string>& keyStringRow,
@@ -372,6 +399,9 @@ void getMatrixValues(const XML_Node& node,
  *
  * @param node     Current XML node to get the values from
  * @param v        Output map of the results.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void getIntegers(const XML_Node& node, std::map<std::string,int>& v);
 
@@ -404,6 +434,9 @@ void getIntegers(const XML_Node& node, std::map<std::string,int>& v);
  * @param type   String type. Currently known types are "toSI" and "actEnergy",
  *               and "" , for no conversion. The default value is "",
  *               which implies that no conversion is allowed.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 doublereal getFloat(const XML_Node& parent, const std::string& name,
                     const std::string& type="");
@@ -437,6 +470,9 @@ doublereal getFloat(const XML_Node& parent, const std::string& name,
  * @param type   String type. Currently known types are "toSI" and "actEnergy",
  *               and "" , for no conversion. The default value is "",
  *               which implies that no conversion is allowed.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 doublereal getFloatCurrent(const XML_Node& currXML, const std::string& type="");
 
@@ -468,6 +504,9 @@ doublereal getFloatCurrent(const XML_Node& currXML, const std::string& type="");
  *               "", which implies that no conversion is allowed.
  *
  * @returns true if the child element named "name" exists
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 bool getOptionalFloat(const XML_Node& parent, const std::string& name,
                       doublereal& fltRtn, const std::string& type="");
@@ -495,6 +534,9 @@ bool getOptionalFloat(const XML_Node& parent, const std::string& name,
  *
  * @param parent reference to the XML_Node object of the parent XML element
  * @param name   Name of the XML child element
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 int getInteger(const XML_Node& parent, const std::string& name);
 
@@ -523,6 +565,9 @@ int getInteger(const XML_Node& parent, const std::string& name);
  * @param nodeName   Name of the XML child element
  * @param modelName  On return this contains the contents of the model attribute
  * @return True if the nodeName XML node exists. False otherwise.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 bool getOptionalModel(const XML_Node& parent, const std::string& nodeName,
                       std::string& modelName);
@@ -533,6 +578,9 @@ bool getOptionalModel(const XML_Node& parent, const std::string& nodeName,
  * @param node   Current node from which to conduct the search
  * @param title  Name of the title attribute
  * @returns a pointer to the matched child node. Returns 0 if no node is found.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 XML_Node* getByTitle(const XML_Node& node, const std::string& title);
 
@@ -565,6 +613,9 @@ XML_Node* getByTitle(const XML_Node& node, const std::string& title);
  *                      variable
  * @param typeString    String type. This is an optional output variable. It
  *                      is filled with the attribute "type" of the XML entry.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void getString(const XML_Node& node, const std::string& titleString,
                std::string& valueString, std::string& typeString);
@@ -591,6 +642,9 @@ void getString(const XML_Node& node, const std::string& titleString,
  * @param parent     parent reference to the XML_Node object of the parent XML element
  * @param nameString Name of the child XML_Node to read the value from.
  * @return           String value of the child XML_Node
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 std::string getChildValue(const XML_Node& parent,
                           const std::string& nameString);
@@ -601,6 +655,9 @@ std::string getChildValue(const XML_Node& parent,
  * @param   debug   Turn on debug printing
  *
  * @ingroup inputfiles
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void ct2ctml(const char* file, const int debug = 0);
 
@@ -610,6 +667,9 @@ void ct2ctml(const char* file, const int debug = 0);
  * @return  String containing the XML representation of the input file
  *
  * @ingroup inputfiles
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 std::string ct2ctml_string(const std::string& file);
 
@@ -619,6 +679,9 @@ std::string ct2ctml_string(const std::string& file);
  * @return  String containing the XML representation of the input
  *
  * @ingroup inputfiles
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 std::string ct_string2ctml_string(const std::string& cti);
 
@@ -628,6 +691,9 @@ std::string ct_string2ctml_string(const std::string& cti);
  * @param thermo_file     optional input file containing thermo data
  * @param transport_file  optional input file containing transport parameters
  * @param id_tag          id of the phase
+ *
+ * @deprecated The CTI input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void ck2cti(const std::string& in_file, const std::string& thermo_file="",
             const std::string& transport_file="",

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -56,23 +56,28 @@ class Logger;
  *
  * Additional directories may be added by calling function addDirectory.
  *
- * There are currently two different types of input files within %Cantera:
- *  - CTI: A human-readable input file written using Python syntax which
+ * There are currently three different types of input files within %Cantera. The
+ * YAML format is new in Cantera 2.5, and replaces both the CTI and CTML (XML)
+ * formats, which are deprecated and will be removed in Cantera 3.0. The scripts
+ * `cti2yaml.py` and `ctml2yaml.py` can be used to convert legacy input files to
+ * the YAML format.
+ *
+ *  - YAML: A human-readable input file written using YAML syntax which
  *    defines species, phases, and reactions, and contains thermodynamic,
- *    chemical kinetic, and transport data needed by %Cantera. Some options for
- *    non-ideal equations of state available in the CTML format have not yet
+ *    chemical kinetic, and transport data needed by %Cantera.
+ *
+ *  - CTI: A human-readable input file written using Python syntax. Some options
+ *    for non-ideal equations of state available in the CTML format have not
  *    been implemented for the CTI format.
  *
  *  - CTML: This is an XML file laid out in such a way that %Cantera can
  *    interpret the contents directly. Given a file in CTI format, %Cantera will
  *    convert the CTI file into the CTML format on-the-fly using a Python script
  *    (ctml_writer). This process is done in-memory without writing any new
- *    files to disk. Explicit use of the CTML format is not recommended unless
- *    using features not available in CTI or working on a computer where Python
- *    is not available.
+ *    files to disk. Explicit use of the CTML format is not recommended.
  *
- * %Cantera provides a converter (ck2cti) for converting Chemkin-format
- * gas-phase mechanisms to the CTI format.
+ * %Cantera provides converters (`ck2yaml` and `ckcti`) for converting
+ * Chemkin-format mechanisms to the YAML and CTI formats, respectively.
  *
  * Other input routines in other modules:
  *   @see importKinetics()

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -257,6 +257,9 @@ void close_XML_File(const std::string& file);
  * @param root    If the file string is empty, searches for the XML element with
  *                matching ID attribute are carried out from this XML node.
  * @returns the XML_Node, if found. Returns null if not found.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 XML_Node* get_XML_Node(const std::string& file_ID, XML_Node* root);
 
@@ -279,6 +282,9 @@ XML_Node* get_XML_Node(const std::string& file_ID, XML_Node* root);
  * @param root    If the file string is empty, searches for the XML element with
  *                matching ID attribute are carried out from this XML node.
  * @returns the XML_Node, if found. Returns null if not found.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 XML_Node* get_XML_NameID(const std::string& nameTarget,
                          const std::string& file_ID,

--- a/include/cantera/base/xml.h
+++ b/include/cantera/base/xml.h
@@ -23,6 +23,9 @@ namespace Cantera
 //!  Class XML_Reader reads an XML file into an XML_Node object.
 /*!
  *   Class XML_Reader is designed for internal use.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 class XML_Reader
 {
@@ -93,6 +96,9 @@ public:
 /*!
  * There are routines for adding to the tree, querying and searching the tree,
  * and for writing the tree out to an output file.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 class XML_Node
 {
@@ -703,6 +709,9 @@ protected:
  *  @param phaseId      id of the phase to search for
  *  @returns the XML_Node pointer if the phase is found. If the phase is not
  *           found, it returns 0
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 XML_Node* findXMLPhase(XML_Node* root, const std::string& phaseId);
 

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -900,10 +900,10 @@ protected:
     std::vector<size_t> m_start;
 
     /**
-     * Mapping of the phase id, i.e., the id attribute in the XML phase element
-     * to the position of the phase within the kinetics object. Positions start
-     * with the value of 1. The member function, phaseIndex() decrements by one
-     * before returning the index value, so that missing phases return -1.
+     * Mapping of the phase name to the position of the phase within the
+     * kinetics object. Positions start with the value of 1. The member
+     * function, phaseIndex() decrements by one before returning the index
+     * value, so that missing phases return -1.
      */
     std::map<std::string, size_t> m_phaseindex;
 

--- a/include/cantera/kinetics/KineticsFactory.h
+++ b/include/cantera/kinetics/KineticsFactory.h
@@ -61,6 +61,9 @@ public:
      *              the reactions occur, and the subsequent phases (if any)
      *              are e.g. bulk phases adjacent to a reacting surface.
      * @return Pointer to the new kinetics manager.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual Kinetics* newKinetics(XML_Node& phase, std::vector<ThermoPhase*> th);
 
@@ -77,6 +80,9 @@ private:
 
 /**
  *  Create a new kinetics manager.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 inline Kinetics* newKineticsMgr(XML_Node& phase, std::vector<ThermoPhase*> th)
 {

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -260,6 +260,9 @@ public:
 };
 
 //! Create a new Reaction object for the reaction defined in `rxn_node`
+//!
+//! @deprecated The XML input format is deprecated and will be removed in
+//!     Cantera 3.0.
 shared_ptr<Reaction> newReaction(const XML_Node& rxn_node);
 
 //! Create a new Reaction object using the specified parameters
@@ -283,6 +286,9 @@ unique_ptr<Reaction> newReaction(const AnyMap& rxn_node, const Kinetics& kin);
 //!   - The rate constants are expressed in (kmol, meter, second) units
 //!   - A `units` directive is included **and** all reactions take place in
 //!     bulk (e.g. gas) phases
+//!
+//! @deprecated The XML input format is deprecated and will be removed in
+//!     Cantera 3.0.
 std::vector<shared_ptr<Reaction> > getReactions(const XML_Node& node);
 
 //! Create Reaction objects for each item (an AnyMap) in `items`. The species

--- a/include/cantera/kinetics/importKinetics.h
+++ b/include/cantera/kinetics/importKinetics.h
@@ -38,6 +38,9 @@ namespace Cantera
  *    On return, if reaction instantiation goes correctly, return true.
  *    If there is a problem, return false.
  *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
+ *
  * @ingroup kineticsmgr
  */
 bool installReactionArrays(const XML_Node& p, Kinetics& kin,
@@ -74,6 +77,9 @@ bool installReactionArrays(const XML_Node& p, Kinetics& kin,
  *              initialized with the kinetics mechanism. Inherited Kinetics
  *              classes should be used here.
  *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
+ *
  * @ingroup kineticsmgr
  */
 bool importKinetics(const XML_Node& phase, std::vector<ThermoPhase*> th,
@@ -105,6 +111,9 @@ bool importKinetics(const XML_Node& phase, std::vector<ThermoPhase*> th,
  *        ok =  buildSolutionFromXML(root, "gri30_mix", "phase", th, kin)
  * @endcode
  *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
+ *
  * @ingroup inputfiles
  * @see importKinetics()
  */
@@ -126,7 +135,10 @@ bool buildSolutionFromXML(XML_Node& root, const std::string& id,
  * @param kin   This is a pointer to a kinetics manager class.
  * @param r     This is the reaction node that is being evaluated
  * @return      The function always returns true.
-*/
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
+ */
 bool checkElectrochemReaction(const XML_Node& p, Kinetics& kin, const XML_Node& r);
 
 

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -320,6 +320,9 @@ public:
      *             out which part of the solution vector pertains to this
      *             object.
      * @return     XML_Node created to represent this domain
+     *
+     * @deprecated The XML output format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual XML_Node& save(XML_Node& o, const doublereal* const sol);
 
@@ -333,6 +336,9 @@ public:
      * @param soln Current value of the solution vector, local to this object.
      * @param loglevel 0 to suppress all output; 1 to show warnings; 2 for
      *      verbose output
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -146,6 +146,9 @@ public:
      *  @param sol  Current value of the solution vector. The object will pick
      *              out which part of the solution vector pertains to this
      *              object.
+     *
+     * @deprecated The XML output format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual XML_Node& save(XML_Node& o, const doublereal* const sol);
 

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -136,6 +136,9 @@ public:
      *               named phase with id, "id", on input to this routine.
      * @param id     The name of this phase. This is used to look up
      *               the phase in the XML datafile.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     BinarySolutionTabulatedThermo(XML_Node& root, const std::string& id="");
 

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -117,14 +117,14 @@ public:
     BinarySolutionTabulatedThermo();
 
     //! Construct and initialize an BinarySolutionTabulatedThermo ThermoPhase object
-    //! directly from an ASCII input file
+    //! directly from an input file
     /*!
      * This constructor will also fully initialize the object.
      *
-     * @param infile File name for the XML datafile containing information
+     * @param infile File name for the input file containing information
      *               for this phase
      * @param id     The name of this phase. This is used to look up
-     *               the phase in the XML datafile.
+     *               the phase in the input file.
      */
     BinarySolutionTabulatedThermo(const std::string& infile, const std::string& id="");
 

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -565,7 +565,7 @@ public:
 
     //! Full constructor for creating the phase.
     /*!
-     *  @param inputFile  File name containing the XML description of the phase
+     *  @param inputFile  File name containing the definition of the phase
      *  @param id         id attribute containing the name of the phase.
      */
     DebyeHuckel(const std::string& inputFile, const std::string& id = "");

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -574,6 +574,9 @@ public:
     /*!
      *  @param phaseRef XML phase node containing the description of the phase
      *  @param id       id attribute containing the name of the phase.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     DebyeHuckel(XML_Node& phaseRef, const std::string& id = "");
 

--- a/include/cantera/thermo/EdgePhase.h
+++ b/include/cantera/thermo/EdgePhase.h
@@ -57,6 +57,9 @@ public:
      *       <site_density units="mol/cm"> 3e-15 </site_density>
      *    </thermo>
      * @endcode
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setParametersFromXML(const XML_Node& thermoData);
 };

--- a/include/cantera/thermo/FixedChemPotSSTP.h
+++ b/include/cantera/thermo/FixedChemPotSSTP.h
@@ -142,6 +142,10 @@ namespace Cantera
  * identifies the phase as being a FixedChemPotSSTP object.
  *
  * @ingroup thermoprops
+ *
+ * @deprecated To be removed after Cantera 2.5. Use the `fixed-stoichiometry`
+ *     thermo model (class StoichSubstance) with a `constant-cp` species thermo
+ *     model, `h0` set to the desired chemical potential, and `s0` set to 0.
  */
 class FixedChemPotSSTP : public SingleSpeciesTP
 {

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1046,9 +1046,9 @@ public:
     //! directly from an ASCII input file
     /*!
      *  This constructor is a shell that calls the routine initThermo(), with
-     *  a reference to the XML database to get the info for the phase.
+     *  a reference to the parsed input file to get the info for the phase.
      *
-     * @param inputFile Name of the input file containing the phase XML data
+     * @param inputFile Name of the input file containing the phase definition
      *                  to set up the object
      * @param id        ID of the phase in the input file. Defaults to the
      *                  empty string.

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1061,6 +1061,9 @@ public:
      *  @param phaseRef XML phase node containing the description of the phase
      *  @param id     id attribute containing the name of the phase.
      *                (default is the empty string)
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     HMWSoln(XML_Node& phaseRef, const std::string& id = "");
 
@@ -1518,6 +1521,9 @@ public:
      *             describe the species in the phase.
      * @param id   ID of the phase. If nonnull, a check is done to see if
      *             phaseNode is pointing to the phase with the correct id.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void initThermoXML(XML_Node& phaseNode, const std::string& id);
 

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -306,6 +306,9 @@ public:
      *  @param phaseRef XML phase node containing the description of the phase
      *  @param id     id attribute containing the name of the phase.
      *                (default is the empty string)
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     IdealGasPhase(XML_Node& phaseRef, const std::string& id = "");
 

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -293,7 +293,7 @@ public:
     //! Construct and initialize an IdealGasPhase ThermoPhase object
     //! directly from an ASCII input file
     /*!
-     * @param inputFile Name of the input file containing the phase XML data
+     * @param inputFile Name of the input file containing the phase definition
      *                  to set up the object
      * @param id        ID of the phase in the input file. Defaults to the
      *                  empty string.

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -100,6 +100,9 @@ public:
      *  @param phaseRef    reference for an XML_Node tree that contains
      *                     the information necessary to initialize the phase.
      *  @param id          id of the phase within the input file
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     IdealMolalSoln(XML_Node& phaseRef, const std::string& id = "");
 

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -30,7 +30,7 @@ namespace Cantera
  *
  * The generalized concentrations can have three different forms depending on
  * the value of the member attribute #m_formGC, which is supplied in the
- * constructor and in the XML file. The value and form of the generalized
+ * constructor and in the input file. The value and form of the generalized
  * concentration will affect reaction rate constants involving species in this
  * phase.
  *
@@ -43,7 +43,7 @@ public:
      * Constructor for IdealSolidSolnPhase.
      * The generalized concentrations can have three different forms
      * depending on the value of the member attribute #m_formGC, which
-     * is supplied in the constructor or read from the XML data file.
+     * is supplied in the constructor or read from the input file.
      *
      * @param formCG This parameter initializes the #m_formGC variable.
      */
@@ -55,12 +55,12 @@ public:
      * This constructor will also fully initialize the object.
      * The generalized concentrations can have three different forms
      * depending on the value of the member attribute #m_formGC, which
-     * is supplied in the constructor or read from the XML data file.
+     * is supplied in the constructor or read from the input file.
      *
-     * @param infile File name for the XML datafile containing information
+     * @param infile File name for the input file containing information
      *               for this phase
      * @param id     The name of this phase. This is used to look up
-     *               the phase in the XML datafile.
+     *               the phase in the input file.
      * @param formCG This parameter initializes the #m_formGC variable.
      */
     IdealSolidSolnPhase(const std::string& infile, const std::string& id="", int formCG=0);

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -78,6 +78,9 @@ public:
      * @param id     The name of this phase. This is used to look up
      *               the phase in the XML datafile.
      * @param formCG This parameter initializes the #m_formGC variable.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     IdealSolidSolnPhase(XML_Node& root, const std::string& id="", int formCG=0);
 

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -37,7 +37,7 @@ public:
 
     IdealSolnGasVPSS();
 
-    /// Create an object from an XML input file
+    /// Create an object from an input file
     IdealSolnGasVPSS(const std::string& infile, std::string id="");
 
     //@}

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -75,16 +75,11 @@ public:
      */
     IonsFromNeutralVPSSTP();
 
-    //! Construct and initialize an IonsFromNeutralVPSSTP object directly from
-    //! an ASCII input file
+    //! Construct an IonsFromNeutralVPSSTP object from an input file
     /*!
-     * This constructor is a shell around the routine initThermo(), with a
-     * reference to the XML database to get the info for the phase.
-     *
-     * @param inputFile Name of the input file containing the phase XML data
-     *     to set up the object
-     * @param id        ID of the phase in the input file. Defaults to the
-     *     empty string.
+     * @param inputFile Name of the input file containing the phase definition
+     * @param id        name (ID) of the phase in the input file. If empty, the
+     *                  first phase definition in the input file will be used.
      */
     IonsFromNeutralVPSSTP(const std::string& inputFile,
                           const std::string& id = "");

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -95,6 +95,9 @@ public:
      * @param phaseRoot XML phase node containing the description of the phase
      * @param id     id attribute containing the name of the phase.
      *               (default is the empty string)
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     IonsFromNeutralVPSSTP(XML_Node& phaseRoot, const std::string& id = "");
 

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -244,6 +244,9 @@ public:
     /*!
      * @param phaseRef  XML node referencing the lattice phase.
      * @param id        string id of the phase name
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     LatticePhase(XML_Node& phaseRef, const std::string& id = "");
 

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -643,6 +643,9 @@ public:
      *   </thermo>
      * </phase>
      * @endcode
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setParametersFromXML(const XML_Node& eosdata);
     //@}

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -216,19 +216,11 @@ class MargulesVPSSTP : public GibbsExcessVPSSTP
 public:
     MargulesVPSSTP();
 
-    //! Construct and initialize a MargulesVPSSTP ThermoPhase object directly
-    //! from an XML input file
+    //! Construct a MargulesVPSSTP object from an input file
     /*!
-     * Working constructors
-     *
-     * The two constructors below are the normal way the phase initializes
-     * itself. They are shells that call the routine initThermo(), with a
-     * reference to the XML database to get the info for the phase.
-     *
-     * @param inputFile Name of the input file containing the phase XML data
-     *                  to set up the object
-     * @param id        ID of the phase in the input file. Defaults to the
-     *                  empty string.
+     * @param inputFile Name of the input file containing the phase definition
+     * @param id        name (ID) of the phase in the input file. If empty, the
+     *                  first phase definition in the input file will be used.
      */
     MargulesVPSSTP(const std::string& inputFile, const std::string& id = "");
 

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -238,6 +238,9 @@ public:
      *  @param phaseRef XML phase node containing the description of the phase
      *  @param id     id attribute containing the name of the phase.
      *                (default is the empty string)
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     MargulesVPSSTP(XML_Node& phaseRef, const std::string& id = "");
 

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -200,7 +200,7 @@ namespace Cantera
  * \f]
  *
  * where we can use the concept of microscopic reversibility to write the
- * reverse rate constant in terms of the forward reate constant and the
+ * reverse rate constant in terms of the forward rate constant and the
  * concentration equilibrium constant, \f$ K_c \f$.
  *
  * \f[

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -464,6 +464,9 @@ public:
      *
      * @param state An XML_Node object corresponding to the "state" entry for
      *              this phase in the input file.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setStateFromXML(const XML_Node& state);
 

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -170,6 +170,9 @@ protected:
  * @param Mu0Node Pointer to the XML element containing the Mu0 information.
  *
  * @ingroup spthermo
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 Mu0Poly* newMu0ThermoFromXML(const XML_Node& Mu0Node);
 }

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -189,7 +189,7 @@ public:
     bool ready(size_t nSpecies);
 
 private:
-    //! Provide the SpeciesthermoInterpType object
+    //! Provide the SpeciesThermoInterpType object
     /*!
      * @param k  species index
      * @return pointer to the SpeciesThermoInterpType object.

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -436,6 +436,9 @@ public:
     /*!
      * This is a cascading call, where each level should call the the parent
      * level. This function is called before initThermo()
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setParametersFromXML(const XML_Node& speciesNode) {}
 

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -112,6 +112,9 @@ public:
     /*!
      *  The XML_Node for the phase contains all of the input data used to set up
      *  the model for the phase during its initialization.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     XML_Node& xml() const;
 
@@ -123,6 +126,9 @@ public:
      *  construction operations.
      *
      *  @param xmlPhase Reference to the XML node corresponding to the phase
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     void setXMLdata(XML_Node& xmlPhase);
 

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -951,8 +951,9 @@ private:
     std::string m_id;
 
     //! Name of the phase.
-    //! Initially, this is the value of the ID attribute of the XML phase node.
-    //! It may be changed to another value during the course of a calculation.
+    //! Initially, this is the name specified in the YAML or CTI input file, or
+    //! the value of the ID attribute of the XML phase node. It may be changed
+    //! to another value during the course of a calculation.
     std::string m_name;
 
     doublereal m_temp; //!< Temperature (K). This is an independent variable

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -69,7 +69,7 @@ namespace Cantera
  * operate on a state vector, which by default uses the first two entries for
  * temperature and density (compressible substances) or temperature and
  * pressure (incompressible substances). If the substance is not pure in a
- * thermodyanmic sense (i.e. it may contain multiple species), the state also
+ * thermodynamic sense (that is, it may contain multiple species), the state also
  * contains nSpecies() entries that specify the composition by corresponding
  * mass fractions. Default definitions can be overloaded by derived classes.
  * For any phase, the native definition of its thermodynamic state is defined

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -222,13 +222,11 @@ public:
      */
     RedlichKisterVPSSTP();
 
-    //! Construct and initialize a RedlichKisterVPSSTP ThermoPhase object
-    //! directly from an XML input file
+    //! Construct a RedlichKisterVPSSTP object from an input file
     /*!
-     * @param inputFile Name of the input file containing the phase XML data
-     *                  to set up the object
-     * @param id        ID of the phase in the input file. Defaults to the
-     *                  empty string.
+     * @param inputFile Name of the input file containing the phase definition
+     * @param id        name (ID) of the phase in the input file. If empty, the
+     *                  first phase definition in the input file will be used.
      */
     RedlichKisterVPSSTP(const std::string& inputFile, const std::string& id = "");
 

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -238,6 +238,9 @@ public:
      *  @param phaseRef XML phase node containing the description of the phase
      *  @param id     id attribute containing the name of the phase.
      *                (default is the empty string)
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     RedlichKisterVPSSTP(XML_Node& phaseRef, const std::string& id = "");
 

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -202,7 +202,7 @@ namespace Cantera
  * \f]
  *
  * where we can use the concept of microscopic reversibility to write the
- * reverse rate constant in terms of the forward reate constant and the
+ * reverse rate constant in terms of the forward rate constant and the
  * concentration equilibrium constant, \f$ K_c \f$.
  *
  * \f[

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -41,6 +41,9 @@ public:
      *  @param phaseRef XML phase node containing the description of the phase
      *  @param id       id attribute containing the name of the phase.  (default
      *      is the empty string)
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     RedlichKwongMFTP(XML_Node& phaseRef, const std::string& id = "");
 

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -25,13 +25,11 @@ public:
     //! Base constructor.
     RedlichKwongMFTP();
 
-    //! Construct and initialize a RedlichKwongMFTP object directly from an
-    //! ASCII input file
+    //! Construct a RedlichKwongMFTP object from an input file
     /*!
-     * @param infile    Name of the input file containing the phase XML data
-     *                  to set up the object
-     * @param id        ID of the phase in the input file. Defaults to the empty
-     *     string.
+     * @param inputFile Name of the input file containing the phase definition
+     * @param id        name (ID) of the phase in the input file. If empty, the
+     *                  first phase definition in the input file will be used.
      */
     RedlichKwongMFTP(const std::string& infile, const std::string& id="");
 

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -63,6 +63,9 @@ public:
 };
 
 //! Create a new Species object from a 'species' XML_Node.
+//!
+//! @deprecated The XML input format is deprecated and will be removed in
+//!     Cantera 3.0.
 shared_ptr<Species> newSpecies(const XML_Node& species_node);
 
 //! Create a new Species object from an AnyMap specification
@@ -77,6 +80,9 @@ unique_ptr<Species> newSpecies(const AnyMap& node);
 //! This function can be used in combination with get_XML_File and
 //! get_XML_from_string to get Species objects from either a file or a string,
 //! respectively, where the string or file is formatted as either CTI or XML.
+//!
+//! @deprecated The XML input format is deprecated and will be removed in
+//!     Cantera 3.0.
 std::vector<shared_ptr<Species> > getSpecies(const XML_Node& node);
 
 //! Generate Species objects for each item (an AnyMap) in `items`.

--- a/include/cantera/thermo/SpeciesThermoFactory.h
+++ b/include/cantera/thermo/SpeciesThermoFactory.h
@@ -48,6 +48,9 @@ SpeciesThermoInterpType* newSpeciesThermoInterpType(const std::string& type,
  *  @param thermoNode 'thermo' XML_Node (child of the 'species' node) with child
  *      nodes representing parameterizations for one or more temperature ranges
  *  @returns the pointer to the newly allocated SpeciesThermoInterpType object
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 SpeciesThermoInterpType* newSpeciesThermoInterpType(const XML_Node& thermoNode);
 

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -166,6 +166,9 @@ public:
     /*!
      *  @param phaseRef XML node pointing to a StoichSubstance description
      *  @param id       Id of the phase.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     StoichSubstance(XML_Node& phaseRef, const std::string& id = "");
 
@@ -338,6 +341,9 @@ public:
      *     </thermo>
      *   </phase>
      *   @endcode
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setParametersFromXML(const XML_Node& eosdata);
 };

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -162,6 +162,9 @@ public:
     //! XML database
     /*!
      *  @param xmlphase XML node pointing to a SurfPhase description
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     SurfPhase(XML_Node& xmlphase);
 
@@ -282,6 +285,9 @@ public:
      *       <site_density units="mol/cm2"> 3e-09 </site_density>
      *    </thermo>
      * @endcode
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setParametersFromXML(const XML_Node& thermoData);
     virtual void initThermo();
@@ -303,6 +309,9 @@ public:
      *      <coverages>c6H*:0.1, c6HH:0.9</coverages>
      *   </state>
      * @endcode
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setStateFromXML(const XML_Node& state);
 

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -116,6 +116,9 @@ inline ThermoPhase* newThermoPhase(const std::string& model)
  * @return  A pointer to the completed and initialized ThermoPhase object.
  *
  * @ingroup inputfiles
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 ThermoPhase* newPhase(XML_Node& phase);
 
@@ -195,6 +198,9 @@ ThermoPhase* newPhase(const std::string& infile, std::string id="");
  *              ThermoPhase object here, especially for those objects which are
  *              part of the Cantera Kernel.
  * @ingroup thermoprops
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 void importPhase(XML_Node& phase, ThermoPhase* th);
 
@@ -211,6 +217,9 @@ void setupPhase(ThermoPhase& phase, AnyMap& phaseNode,
                 const AnyMap& rootNode=AnyMap());
 
 //! Add the elements given in an XML_Node tree to the specified phase
+//!
+//! @deprecated The XML input format is deprecated and will be removed in
+//!     Cantera 3.0.
 void installElements(Phase& th, const XML_Node& phaseNode);
 
 //!  Search an XML tree for species data.
@@ -222,6 +231,9 @@ void installElements(Phase& th, const XML_Node& phaseNode);
  * @param kname String containing the name of the species.
  * @param phaseSpeciesData   Pointer to the XML speciesData element
  *              containing the species data for that phase.
+ *
+ * @deprecated The XML input format is deprecated and will be removed in
+ *     Cantera 3.0.
  */
 const XML_Node* speciesXML_Node(const std::string& kname,
                                 const XML_Node* phaseSpeciesData);

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -133,14 +133,17 @@ ThermoPhase* newPhase(XML_Node& phase);
 unique_ptr<ThermoPhase> newPhase(AnyMap& phaseNode,
                                  const AnyMap& rootNode=AnyMap());
 
-//! Create and Initialize a ThermoPhase object from an XML input file.
+//! Create and Initialize a ThermoPhase object from an input file.
 /*!
- * This routine is a wrapper around the newPhase(XML_Node) routine which does
- * the work. The wrapper locates the input phase XML_Node in a file, and then
- * instantiates the object, returning the pointer to the ThermoPhase object.
+ * For YAML input files, this function uses AnyMap::fromYamlFile() to read the
+ * input file, newThermoPhase() to create an empty ThermoPhase of the
+ * appropriate type, and setupPhase() to initialize the phase.
+ *
+ * For CTI and XML input files, this function uses get_XML_File() to read the
+ * input file and newPhase(XML_Node) to create and initialize the phase.
  *
  * @param infile name of the input file
- * @param id     name of the phase id in the file.
+ * @param id     name (id) of the phase in the file.
  *               If this is blank, the first phase in the file is used.
  * @returns an initialized ThermoPhase object.
  */

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1469,7 +1469,7 @@ public:
      * initThermoXML(), which is called from importPhase(), just prior to
      * returning from function importPhase().
      *
-     * When importing from an AnyMap phase desciption (or from a YAML file),
+     * When importing from an AnyMap phase description (or from a YAML file),
      * this method is responsible for setting model parameters from the data
      * stored in #m_input.
      */

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1412,14 +1412,14 @@ public:
 
     /**
      * @internal
-     * Initialize a ThermoPhase object using a ctml file.
+     * Initialize a ThermoPhase object using an input file.
      *
      * Used to implement constructors for derived classes which take a
-     * a CTML filename and phase name as arguments.
+     * file name and phase name as arguments.
      *
-     * @param inputFile XML file containing the description of the phase
+     * @param inputFile Input file containing the description of the phase
      * @param id  Optional parameter identifying the name of the phase. If
-     *            blank, the first XML phase element encountered will be used.
+     *            blank, the first phase definition encountered will be used.
      */
     virtual void initThermoFile(const std::string& inputFile,
                                 const std::string& id);

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1386,11 +1386,17 @@ public:
      * @param k      Species index
      * @param data   Pointer to the XML_Node data containing
      *               information about the species in the phase.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     void saveSpeciesData(const size_t k, const XML_Node* const data);
 
     //!  Return a pointer to the vector of XML nodes containing the species
     //!  data for this phase.
+    //!
+    //! @deprecated The XML input format is deprecated and will be removed in
+    //!     Cantera 3.0.
     const std::vector<const XML_Node*> & speciesData() const;
 
     //! Return a changeable reference to the calculation manager for species
@@ -1441,6 +1447,9 @@ public:
      *     phase.
      * @param id   ID of the phase. If nonnull, a check is done to see if
      *             phaseNode is pointing to the phase with the correct id.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void initThermoXML(XML_Node& phaseNode, const std::string& id);
 
@@ -1503,6 +1512,9 @@ public:
      *
      * @param eosdata An XML_Node object corresponding to
      *                the "thermo" entry for this phase in the input file.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setParametersFromXML(const XML_Node& eosdata) {}
 
@@ -1514,6 +1526,9 @@ public:
      *
      * @param state AN XML_Node object corresponding to the "state" entry for
      *              this phase in the input file.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     virtual void setStateFromXML(const XML_Node& state);
 
@@ -1654,6 +1669,9 @@ protected:
      * This is used to access data needed to construct the transport manager and
      * other properties later in the initialization process. We create a copy of
      * the XML_Node data read in here. Therefore, we own this data.
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     std::vector<const XML_Node*> m_speciesData;
 

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -133,6 +133,9 @@ public:
     /*!
      * @param phaseRef  XML node referencing the water phase.
      * @param id        string id of the phase name
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     explicit WaterSSTP(XML_Node& phaseRef, const std::string& id = "");
 

--- a/include/cantera/transport/TransportData.h
+++ b/include/cantera/transport/TransportData.h
@@ -89,6 +89,9 @@ public:
 };
 
 //! Create a new TransportData object from a 'transport' XML_Node.
+//!
+//! @deprecated The XML input format is deprecated and will be removed in
+//!     Cantera 3.0.
 shared_ptr<TransportData> newTransportData(const XML_Node& transport_node);
 
 //! Create a new TransportData object from an AnyMap specification

--- a/include/cantera/transport/TransportParams.h
+++ b/include/cantera/transport/TransportParams.h
@@ -1,6 +1,6 @@
 /**
  *  @file TransportParams.h
- *  Class that holds the data that is read in from the XML file, and which is used for
+ *  Class that holds the data that is read in from the input file, and which is used for
  *  processing of the transport object
  *  (see \ref tranprops and \link Cantera::TransportParams TransportParams \endlink).
  */

--- a/include/cantera/transport/TransportParams.h
+++ b/include/cantera/transport/TransportParams.h
@@ -20,6 +20,8 @@ namespace Cantera
 //! Base structure to hold transport model parameters.
 /*!
  * This structure is used by TransportFactory.
+ *
+ * @deprecated Unused. To be removed after Cantera 2.5.
  */
 class TransportParams
 {

--- a/interfaces/cython/cantera/ck2cti.py
+++ b/interfaces/cython/cantera/ck2cti.py
@@ -28,6 +28,11 @@
 """
 This module contains functions for converting Chemkin-format input files to
 Cantera input files (CTI).
+
+.. deprecated:: 2.5
+
+    The CTI input file format is deprecated and will be removed in Cantera 3.0.
+    Use `ck2yaml.py` to convert Chemkin-format input files to the YAML format.
 """
 
 from __future__ import print_function

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -75,7 +75,7 @@ class Solution(ThermoPhase, Kinetics, Transport):
     Types of underlying models that form the composite `Solution` object are
     queried using the ``thermo_model``, ``kinetics_model`` and
     ``transport_model`` attributes; further, the ``composite`` attribute is a
-    shorthand returning a tuple containing the types of the three contitutive
+    shorthand returning a tuple containing the types of the three constitutive
     models.
 
     For non-trivial uses cases of this functionality, see the examples

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1419,11 +1419,11 @@ class lattice(phase):
         self.site_density = site_density
 
         if name == '':
-            raise CTI_Error('sublattice name must be specified')
+            raise InputError('sublattice name must be specified')
         if species == '':
-            raise CTI_Error('sublattice species must be specified')
+            raise InputError('sublattice species must be specified')
         if site_density is None:
-            raise CTI_Error('sublattice '+name
+            raise InputError('sublattice '+name
                             +' site density must be specified')
 
     def get_yaml(self, out):

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -15,6 +15,13 @@
 # python ctml_writer.py infile.cti
 #
 # This will produce CTML file 'infile.xml'
+#
+# .. deprecated:: 2.5
+#
+#    The CTI and XML input file formats are deprecated and will be removed in
+#    Cantera 3.0. Use `cti2yaml.py` to convert CTI input files to the YAML
+#    format.
+#
 
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -21,20 +21,39 @@ cdef class Reaction:
     :param products:
         Value used to set `products`
 
-    The static methods `listFromFile`, `listFromCti`, and `listFromXml` can be
-    used to create lists of `Reaction` objects from existing definitions in the
-    CTI or XML format. All of the following will produce a list of the 325
-    reactions which make up the GRI 3.0 mechanism::
+    The static methods `listFromFile`, `listFromYaml`, `listFromCti`, and
+    `listFromXml` can be used to create lists of `Reaction` objects from
+    existing definitions in the YAML, CTI, or XML formats. All of the following
+    will produce a list of the 325 reactions which make up the GRI 3.0
+    mechanism::
 
-        R = ct.Reaction.listFromFile('gri30.cti')
+        R = ct.Reaction.listFromFile('gri30.yaml', gas)
         R = ct.Reaction.listFromCti(open('path/to/gri30.cti').read())
         R = ct.Reaction.listFromXml(open('path/to/gri30.xml').read())
 
-    The methods `fromCti` and `fromXml` can be used to create individual
-    `Reaction` objects from definitions in these formats. In the case of using
-    CTI definitions, it is important to verify that either the pre-exponential
-    factor and activation energy are supplied in SI units, or that they have
-    their units specified::
+    where `gas` is a `Solution` object with the appropriate thermodynamic model,
+    which is the `ideal-gas` model in this case.
+
+    The static method `listFromYaml` can be used to create lists of `Reaction`
+    objects from a YAML list::
+
+        rxns = '''
+          - equation: O + H2 <=> H + OH
+            rate-constant: {A: 3.87e+04, b: 2.7, Ea: 6260.0}
+          - equation: O + HO2 <=> OH + O2
+            rate-constant: {A: 2.0e+13, b: 0.0, Ea: 0.0}
+        '''
+        R = ct.Reaction.listFromYaml(rxns, gas)
+
+    The methods `fromYaml`, `fromCti`, and `fromXml` can be used to create
+    individual `Reaction` objects from definitions in these formats. In the case
+    of using YAML or CTI definitions, it is important to verify that either the
+    pre-exponential factor and activation energy are supplied in SI units, or
+    that they have their units specified::
+
+        R = ct.Reaction.fromYaml('''{equation: O + H2 <=> H + OH,
+                rate-constant: {A: 3.87e+04 cm^3/mol/s, b: 2.7, Ea: 6260 cal/mol}}''',
+                gas)
 
         R = ct.Reaction.fromCti('''reaction('O + H2 <=> H + OH',
                 [3.87e1, 2.7, 2.619184e7])''')

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -61,6 +61,10 @@ cdef class Reaction:
     def fromCti(text):
         """
         Create a Reaction object from its CTI string representation.
+
+        .. deprecated:: 2.5
+
+            The CTI input format is deprecated and will be removed in Cantera 3.0.
         """
         cxx_reactions = CxxGetReactions(deref(CxxGetXmlFromString(stringify(text))))
         assert cxx_reactions.size() == 1, cxx_reactions.size()
@@ -70,6 +74,10 @@ cdef class Reaction:
     def fromXml(text):
         """
         Create a Reaction object from its XML string representation.
+
+        .. deprecated:: 2.5
+
+            The XML input format is deprecated and will be removed in Cantera 3.0.
         """
         cxx_reaction = CxxNewReaction(deref(CxxGetXmlFromString(stringify(text))))
         return wrapReaction(cxx_reaction)
@@ -104,6 +112,11 @@ cdef class Reaction:
         In the case of an XML file, the ``<reactions>`` nodes are assumed to be
         children of the ``<reactionsData>`` node in a document with a ``<ctml>``
         root node, as in the XML files produced by conversion from CTI files.
+
+        .. deprecated:: 2.5
+
+            The CTI and XML input formats are deprecated and will be removed in
+            Cantera 3.0.
         """
         if filename.lower().split('.')[-1] in ('yml', 'yaml'):
             if kinetics is None:
@@ -122,6 +135,10 @@ cdef class Reaction:
         XML string. The ``<reaction>`` nodes are assumed to be children of the
         ``<reactionData>`` node in a document with a ``<ctml>`` root node, as in
         the XML files produced by conversion from CTI files.
+
+        .. deprecated:: 2.5
+
+            The XML input format is deprecated and will be removed in Cantera 3.0.
         """
         cxx_reactions = CxxGetReactions(deref(CxxGetXmlFromString(stringify(text))))
         return [wrapReaction(r) for r in cxx_reactions]
@@ -131,6 +148,10 @@ cdef class Reaction:
         """
         Create a list of `Reaction` objects from all the reactions defined in a
         CTI string.
+
+        .. deprecated:: 2.5
+
+            The CTI input format is deprecated and will be removed in Cantera 3.0.
         """
         # Currently identical to listFromXml since get_XML_from_string is able
         # to distinguish between CTI and XML.

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -154,7 +154,7 @@ class TestKinetics(utilities.CanteraTest):
 class KineticsFromReactions(utilities.CanteraTest):
     """
     Test for Kinetics objects which are constructed directly from Reaction
-    objects instead of from CTI/XML files.
+    objects instead of from input files.
     """
     def test_idealgas(self):
         gas1 = ct.Solution('h2o2.xml')

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -82,6 +82,10 @@ cdef class Species:
     def fromCti(text):
         """
         Create a Species object from its CTI string representation.
+
+        .. deprecated:: 2.5
+
+            The CTI input format is deprecated and will be removed in Cantera 3.0.
         """
         cxx_species = CxxGetSpecies(deref(CxxGetXmlFromString(stringify(text))))
         assert cxx_species.size() == 1, cxx_species.size()
@@ -93,6 +97,10 @@ cdef class Species:
     def fromXml(text):
         """
         Create a Species object from its XML string representation.
+
+        .. deprecated:: 2.5
+
+            The XML input format is deprecated and will be removed in Cantera 3.0.
         """
         cxx_species = CxxNewSpecies(deref(CxxGetXmlFromString(stringify(text))))
         species = Species(init=False)
@@ -122,6 +130,11 @@ cdef class Species:
         In the case of an XML file, the ``<species>`` nodes are assumed to be
         children of the ``<speciesData>`` node in a document with a ``<ctml>``
         root node, as in the XML files produced by conversion from CTI files.
+
+        .. deprecated:: 2.5
+
+            The CTI and XML input formats are deprecated and will be removed in
+            Cantera 3.0.
         """
         if filename.lower().split('.')[-1] in ('yml', 'yaml'):
             root = AnyMapFromYamlFile(stringify(filename))
@@ -143,6 +156,10 @@ cdef class Species:
         string. The ``<species>`` nodes are assumed to be children of the
         ``<speciesData>`` node in a document with a ``<ctml>`` root node, as in
         the XML files produced by conversion from CTI files.
+
+        .. deprecated:: 2.5
+
+            The XML input format is deprecated and will be removed in Cantera 3.0.
         """
         cxx_species = CxxGetSpecies(deref(CxxGetXmlFromString(stringify(text))))
         species = []
@@ -157,6 +174,10 @@ cdef class Species:
         """
         Create a list of Species objects from all the species defined in a CTI
         string.
+
+        .. deprecated:: 2.5
+
+            The CTI input format is deprecated and will be removed in Cantera 3.0.
         """
         # Currently identical to listFromXml since get_XML_from_string is able
         # to distinguish between CTI and XML.

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -291,6 +291,9 @@ public:
      *
      * @param file String containing the relative or absolute file name
      * @param debug Debug flag
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     XML_Node* get_XML_File(const std::string& file, int debug=0);
 
@@ -302,6 +305,9 @@ public:
      * stored in the cache.
      * @param text    CTI or CTML string
      * @return        Root of the corresponding XML tree
+     *
+     * @deprecated The XML input format is deprecated and will be removed in
+     *     Cantera 3.0.
      */
     XML_Node* get_XML_from_string(const std::string& text);
 
@@ -411,6 +417,9 @@ protected:
     //! Current vector of XML file trees that have been previously parsed
     //! The second element of the value is used to store the last-modified time
     //! for the file, to enable change detection.
+    //!
+    //! @deprecated The XML input format is deprecated and will be removed in
+    //!     Cantera 3.0.
     std::map<std::string, std::pair<XML_Node*, int> > xmlfiles;
     //! Vector of deprecation warnings that have been emitted (to suppress
     //! duplicates)

--- a/src/transport/TransportParams.cpp
+++ b/src/transport/TransportParams.cpp
@@ -25,6 +25,8 @@ TransportParams::TransportParams() :
     mode_(0),
     log_level(-1)
 {
+    warn_deprecated("class TransportParams",
+                    "Unused. To be removed after Cantera 2.5");
 }
 
 } // End of namespace Cantera


### PR DESCRIPTION
**Changes proposed in this pull request**
- Soft deprecation (mark as deprecated but no warnings yet) of all XML and CTI related functionality
- Generalize some documentation to apply to the YAML format
- Mark some features of `AnyMap` and `UnitSystem` as experimental and subject to change
- Clean up a few other minor things in preparation for the 2.5 release

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

