### PR TITLE
[Input] Make accessing input file data outside of phase node easier

### DIFF
--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -273,6 +273,8 @@ public:
     void setNeutralMoleculePhase(shared_ptr<ThermoPhase> neutral);
     shared_ptr<ThermoPhase> getNeutralMoleculePhase();
 
+    virtual void setParameters(const AnyMap& phaseNode,
+                               const AnyMap& rootNode=AnyMap());
     virtual void initThermo();
     virtual void setParametersFromXML(const XML_Node& thermoNode);
 
@@ -398,6 +400,10 @@ protected:
 
     //! This is a pointer to the neutral Molecule Phase
     shared_ptr<ThermoPhase> neutralMoleculePhase_;
+
+    //! Root node of the AnyMap which contains this phase definition.
+    //! Used to look up the phase definition for the embedded neutral phase.
+    AnyMap m_rootNode;
 
 private:
     GibbsExcessVPSSTP* geThermo;

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -431,6 +431,8 @@ public:
     //! Set the lattice stoichiometric coefficients, \f$ \theta_i \f$
     void setLatticeStoichiometry(const compositionMap& comp);
 
+    virtual void setParameters(const AnyMap& phaseNode,
+                               const AnyMap& rootNode=AnyMap());
     virtual void initThermo();
 
     virtual void setParametersFromXML(const XML_Node& eosdata);
@@ -470,6 +472,10 @@ protected:
     mutable vector_fp tmpV_;
 
     std::vector<size_t> lkstart_;
+
+    //! Root node of the AnyMap which contains this phase definition.
+    //! Used to look up the phase definitions for the constituent phases.
+    AnyMap m_rootNode;
 
 private:
     //! Update the reference thermodynamic functions

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1495,8 +1495,11 @@ public:
     virtual void getParameters(int& n, doublereal* const c) const {
     }
 
-    //! Set equation of state parameters from an AnyMap phase description
-    void setParameters(const AnyMap& phaseNode);
+    //! Set equation of state parameters from an AnyMap phase description.
+    //! Phases that need additional parameters from the root node should
+    //! override this method.
+    virtual void setParameters(const AnyMap& phaseNode,
+                               const AnyMap& rootNode=AnyMap());
 
     //! Access input data associated with the phase description
     const AnyMap& input() const;

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -291,26 +291,20 @@ void LatticeSolidPhase::getGibbs_ref(doublereal* g) const
     }
 }
 
+void LatticeSolidPhase::setParameters(const AnyMap& phaseNode,
+                                      const AnyMap& rootNode)
+{
+    ThermoPhase::setParameters(phaseNode, rootNode);
+    m_rootNode = rootNode;
+}
+
 void LatticeSolidPhase::initThermo()
 {
     if (m_input.hasKey("composition")) {
-        AnyMap infile;
-        if (m_input.hasKey("__file__")) {
-            infile = AnyMap::fromYamlFile(m_input["__file__"].asString());
-        } else {
-            auto& text = m_input.getMetadata("file-contents");
-            if (text.is<std::string>()) {
-                infile = AnyMap::fromYamlString(text.asString());
-            } else {
-                throw InputFileError("LatticeSolidPhase::initThermo",
-                    m_input["composition"],
-                    "Unable to locate phase definitions for component phases");
-            }
-        }
         compositionMap composition = m_input["composition"].asMap<double>();
         for (auto& item : composition) {
-            AnyMap& node = infile["phases"].getMapWhere("name", item.first);
-            addLattice(newPhase(node, infile));
+            AnyMap& node = m_rootNode["phases"].getMapWhere("name", item.first);
+            addLattice(newPhase(node, m_rootNode));
         }
         setLatticeStoichiometry(composition);
     }

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -580,7 +580,7 @@ void setupPhase(ThermoPhase& thermo, AnyMap& phaseNode, const AnyMap& rootNode)
         }
     }
 
-    thermo.setParameters(phaseNode);
+    thermo.setParameters(phaseNode, rootNode);
     thermo.initThermo();
 
     if (phaseNode.hasKey("state")) {

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -818,7 +818,7 @@ const std::vector<const XML_Node*> & ThermoPhase::speciesData() const
     return m_speciesData;
 }
 
-void ThermoPhase::setParameters(const AnyMap& phaseNode)
+void ThermoPhase::setParameters(const AnyMap& phaseNode, const AnyMap& rootNode)
 {
     m_input = phaseNode;
 }


### PR DESCRIPTION
Some phase types utilize information in the input file that is contained outside the phase definition (e.g. phase definitions for nested phases). This change to `ThermoPhase::setParameters` makes it easier for those phases to have access to the full input
file definition without re-reading and reparsing the YAML file.

While I had originally thought that these cases were only in some of the dustier corners of Cantera, this also comes up in the new `PlasmaPhase` type being introduced in #700, so I think it's worth having a cleaner interface for this capability.

- [X] There is a clear use-case for this code change
- [X] The commit message has a short title & references relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] The pull request is ready for review
