### PR TITLE
Correctly pass arguments to equilibrate from fortran to cpp

### DIFF
--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -565,10 +565,10 @@ extern "C" {
         return 0;
     }
 
-    status_t th_equil_(const integer* n, char* XY, char* solver, double rtol, int max_steps, int max_iter, int estimate_equil, int log_level, ftnlen lensolver, ftnlen lenxy)
+    status_t th_equil_(const integer* n, char* XY, char* solver, doublereal* rtol, int* max_steps, int* max_iter, int* estimate_equil, int* log_level, ftnlen lenxy, ftnlen lensolver)
     {
         try {
-            _fth(n)->equilibrate(f2string(XY,lenxy), f2string(solver,lensolver), rtol, max_steps, max_iter, estimate_equil, log_level);
+            _fth(n)->equilibrate(f2string(XY,lenxy), f2string(solver,lensolver), *rtol, *max_steps, *max_iter, *estimate_equil, *log_level);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #



-Sorry, I broke this... As per the title, the c++ end was receiving rubbish from fortran.

