### PR TITLE
Fix AppVeyor Breakage

### DIFF
--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -66,7 +66,7 @@ cdef class _SolutionBase:
         self.base.setThermo(self._thermo)
         self.base.setKinetics(self._kinetics)
 
-        self._selected_species = np.ndarray(0, dtype=np.integer)
+        self._selected_species = np.ndarray(0, dtype=np.uint64)
 
     def __init__(self, *args, **kwargs):
         if isinstance(self, Transport):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #878

**Changes proposed in this pull request**

- Fix deprecation in `np.array`, where `dtype` no longer supports `np.integer`.
- Use `np.uint64` instead (i.e. in analogy to C++ `size_t`)