### PR TITLE
Improve error message for missing phases key

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,14 @@ doc/ctdeploy_key
 *.exe.manifest
 build/
 test/work/
+test_problems/ChemEquil_ionizedGas/ChemEquil_ionizedGas
+test_problems/cathermo/testWaterPDSS/WaterPDSS
+test_problems/cathermo/testWaterTP/WaterSSTP
+test_problems/cxx_ex/cxx_ex
+test_problems/diamondSurf/diamondSurf
+test_problems/pureFluidTest/pureFluid
+test_problems/rankine_democxx/rankine_democxx
+test_problems/surfkin/surfkin
 interfaces/cython/cantera/_cantera.h
 include/cantera/base/config.h
 include/cantera/base/config.h.build

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -17,6 +17,22 @@ class TestThermoPhase(utilities.CanteraTest):
     def test_source(self):
         self.assertEqual(self.phase.source, 'h2o2.xml')
 
+    def test_missing_phases_key(self):
+        yaml = '''
+        species:
+        - name: H
+          composition: {H: 1}
+          thermo:
+            model: NASA7
+            temperature-ranges: [200.0, 1000.0, 6000.0]
+            data:
+            - [2.5, 0.0, 0.0, 0.0, 0.0, 2.547366e+04, -0.44668285]
+            - [2.5, 0.0, 0.0, 0.0, 0.0, 2.547366e+04, -0.44668285]
+            note: L6/94
+        '''
+        with self.assertRaisesRegex(ct.CanteraError, "Key 'phases' not found"):
+            _ = ct.Solution(yaml=yaml)
+
     def test_base_attributes(self):
         self.assertIsInstance(self.phase.name, str)
         self.assertIsInstance(self.phase.phase_of_matter, str)

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -656,6 +656,9 @@ const AnyMap& AnyValue::getMapWhere(const std::string& key, const std::string& v
             throw InputFileError("AnyValue::getMapWhere", *this,
                 "Map does not contain a key where '{}' = '{}'", key, value);
         }
+    } else if (is<void>()) {
+        throw InputFileError("AnyValue::getMapWhere", *this,
+            "Key '{}' not found", m_key);
     } else {
         throw InputFileError("AnyValue::getMapWhere", *this,
             "Element is not a mapping or list of mappings");
@@ -703,6 +706,9 @@ AnyMap& AnyValue::getMapWhere(const std::string& key, const std::string& value,
         child[key] = value;
         operator=(std::move(child));
         return as<AnyMap>();
+    } else if (is<void>()) {
+        throw InputFileError("AnyValue::getMapWhere", *this,
+            "Key '{}' not found", m_key);
     } else {
         throw InputFileError("AnyValue::getMapWhere", *this,
             "Element is not a mapping or list of mappings");

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -1,4 +1,5 @@
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "cantera/base/AnyMap.h"
 
 using namespace Cantera;
@@ -320,6 +321,26 @@ TEST(AnyMap, loadYaml)
     EXPECT_EQ(coeffs.size(), (size_t) 2);
     EXPECT_EQ(coeffs[0].size(), (size_t) 7);
     EXPECT_DOUBLE_EQ(coeffs[1][2], -8.280690600E-07);
+}
+
+TEST(AnyMap, missingKey)
+{
+    AnyMap root = AnyMap::fromYamlFile("ideal-gas.yaml");
+    try {
+        root["spam"].getMapWhere("name", "unknown");
+    } catch (std::exception& ex) {
+        EXPECT_THAT(ex.what(), ::testing::HasSubstr("Key 'spam' not found"));
+    }
+}
+
+TEST(AnyMap, missingKeyAt)
+{
+    AnyMap root = AnyMap::fromYamlFile("ideal-gas.yaml");
+    try {
+        root.at("spam").getMapWhere("name", "unknown");
+    } catch (std::exception& ex) {
+        EXPECT_THAT(ex.what(), ::testing::HasSubstr("Key 'spam' not found"));
+    }
 }
 
 TEST(AnyMap, loadDeprecatedYaml)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #812

**Changes proposed in this pull request**

- Cython `CxxAnyValue& operator[](string)` uses the operator version that adds a key if it is not found (instead of the `const` version that raises an error in C++)
- Use `AnyMap::at` instead (Cython support for C++ `const` Is incomplete)
- Pre-emptively replace operator `[]` by `AnyMap::at` in other instances

The error now points to the actual problem, i.e.
```
In [1]: import cantera as ct

In [2]: yaml = '''
   ...:         species:
   ...:         - name: H
   ...:           composition: {H: 1}
   ...:           thermo:
   ...:             model: NASA7
   ...:             temperature-ranges: [200.0, 1000.0, 6000.0]
   ...:             data:
   ...:             - [2.5, 0.0, 0.0, 0.0, 0.0, 2.547366e+04, -0.44668285]
   ...:             - [2.5, 0.0, 0.0, 0.0, 0.0, 2.547366e+04, -0.44668285]
   ...:             note: L6/94
   ...:         '''

In [3]: ct.Solution(yaml=yaml)
---------------------------------------------------------------------------
CanteraError                              Traceback (most recent call last)
<ipython-input-11-496cc576f3d1> in <module>()
----> 1 ct.Solution(yaml=yaml)

interfaces/cython/cantera/base.pyx in cantera._cantera._SolutionBase.__cinit__()

interfaces/cython/cantera/base.pyx in cantera._cantera._SolutionBase._init_yaml()

CanteraError: 
***********************************************************************
InputFileError thrown by AnyMap::at:
Error on line 2 of input string:
Key 'phases' not found.
Existing keys: species
|  Line |
|     1 | 
>     2 >         species:
                  ^
|     3 |         - name: H
|     4 |           composition: {H: 1}
|     5 |           thermo:
***********************************************************************
```