### PR TITLE
Access YAML annotations

### DIFF
--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -7,6 +7,7 @@
 #define CT_SOLUTION_H
 
 #include "cantera/base/ctexceptions.h"
+#include "cantera/base/AnyMap.h"
 
 namespace Cantera
 {
@@ -14,7 +15,6 @@ namespace Cantera
 class ThermoPhase;
 class Kinetics;
 class Transport;
-class AnyMap;
 
 //! A container class holding managers for all pieces defining a phase
 class Solution : public std::enable_shared_from_this<Solution>
@@ -39,14 +39,10 @@ public:
     void setName(const std::string& name);
 
     //! Return the description of this Solution object
-    std::string description() const {
-        return m_description;
-    }
+    std::string description() const;
 
     //! Set the description of this Solution object
-    void setDescription(const std::string& desc) {
-        m_description = desc;
-    }
+    void setDescription(const std::string& desc);
 
     //! Set the ThermoPhase object
     void setThermo(shared_ptr<ThermoPhase> thermo);
@@ -74,12 +70,17 @@ public:
 
     AnyMap parameters(bool withInput=false) const;
 
-protected:
-    std::string m_description; //!< Description of Solution object
+    //! Access input data associated with the species thermo definition
+    const AnyMap& input() const;
+    AnyMap& input();
 
+protected:
     shared_ptr<ThermoPhase> m_thermo;  //!< ThermoPhase manager
     shared_ptr<Kinetics> m_kinetics;  //!< Kinetics manager
     shared_ptr<Transport> m_transport;  //!< Transport manager
+
+    //! Additional input fields, e.g. from a YAML input file.
+    AnyMap m_input;
 };
 
 //! Create and initialize a new Solution manager from an input file

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -38,6 +38,16 @@ public:
     //! Set the name of this Solution object
     void setName(const std::string& name);
 
+    //! Return the description of this Solution object
+    std::string description() const {
+        return m_description;
+    }
+
+    //! Set the description of this Solution object
+    void setDescription(const std::string& desc) {
+        m_description = desc;
+    }
+
     //! Set the ThermoPhase object
     void setThermo(shared_ptr<ThermoPhase> thermo);
 
@@ -65,6 +75,8 @@ public:
     AnyMap parameters(bool withInput=false) const;
 
 protected:
+    std::string m_description; //!< Description of Solution object
+
     shared_ptr<ThermoPhase> m_thermo;  //!< ThermoPhase manager
     shared_ptr<Kinetics> m_kinetics;  //!< Kinetics manager
     shared_ptr<Transport> m_transport;  //!< Transport manager

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -75,6 +75,12 @@ public:
         m_valid = valid;
     }
 
+    //! Return annotation string describing the reaction
+    std::string note() const;
+
+    //! Set annotation string describing the reaction
+    void setNote(const std::string& note);
+
     //! Type of the reaction. The valid types are listed in the file,
     //! reaction_defs.h, with constants ending in `RXN`.
     /*!

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -38,6 +38,13 @@ public:
 
     AnyMap parameters(const ThermoPhase* phase=0, bool withInput=true) const;
 
+    //! Return annotation string describing the species. The note is initialized to YAML
+    //! input (if available), and can be changed interactively by the user
+    std::string note() const;
+
+    //! Set annotation string describing the species
+    void setNote(const std::string& note);
+
     //! The name of the species
     std::string name;
 

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -276,6 +276,14 @@ public:
     const AnyMap& input() const;
     AnyMap& input();
 
+    //! Return the annotation string describing the parameterization of
+    //! the species thermo definition. The note is initialized to YAML
+    //! input (if available), and can be changed interactively by the user
+    std::string note() const;
+
+    //! Set the annotation string describing the parameterization
+    void setNote(const std::string& note);
+
 protected:
     //! Store the parameters of the species thermo object such that an identical
     //! species thermo object could be reconstructed using the

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1729,6 +1729,12 @@ public:
     const AnyMap& input() const;
     AnyMap& input();
 
+    //! Return annotation string describing the phase
+    std::string note() const;
+
+    //! Set annotation string describing the phase
+    void setNote(const std::string& note);
+
     //! Set equation of state parameter values from XML entries.
     /*!
      * This method is called by function importPhase() when processing a phase

--- a/include/cantera/transport/TransportData.h
+++ b/include/cantera/transport/TransportData.h
@@ -32,6 +32,12 @@ public:
     //!   stored in the #input attribute.
     AnyMap parameters(bool withInput) const;
 
+    //! Return annotation string describing transport data
+    std::string note() const;
+
+    //! Set annotation string describing transport data
+    void setNote(const std::string& note);
+
     //! Input data used for specific models
     AnyMap input;
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -127,6 +127,8 @@ cdef extern from "cantera/thermo/SpeciesThermoInterpType.h":
         void reportParameters(size_t&, int&, double&, double&, double&, double* const) except +translate_exception
         int nCoeffs() except +translate_exception
         CxxAnyMap parameters(cbool) except +translate_exception
+        string note()
+        void setNote(string)
 
 cdef extern from "cantera/thermo/SpeciesThermoFactory.h":
     cdef CxxSpeciesThermo* CxxNewSpeciesThermo "Cantera::newSpeciesThermoInterpType"\

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -142,6 +142,8 @@ cdef extern from "cantera/thermo/Species.h" namespace "Cantera":
         shared_ptr[CxxTransportData] transport
 
         string name
+        string note()
+        void setNote(string)
         Composition composition
         double charge
         double size

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -75,6 +75,7 @@ cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
         cbool hasKey(string)
         string keys_str()
         void applyUnits()
+        string getString(string, string) except +translate_exception
 
     cdef cppclass CxxAnyValue "Cantera::AnyValue":
         CxxAnyValue()
@@ -157,6 +158,8 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         CxxSolution()
         string name()
         void setName(string)
+        string description()
+        void setDescription(string)
         void setThermo(shared_ptr[CxxThermoPhase])
         void setKinetics(shared_ptr[CxxKinetics])
         void setTransport(shared_ptr[CxxTransport])

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -374,6 +374,8 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         string type()
         void validate() except +translate_exception
         CxxAnyMap parameters(cbool) except +translate_exception
+        string note()
+        void setNote(string)
         int reaction_type
         Composition reactants
         Composition products

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -541,6 +541,8 @@ cdef extern from "cantera/transport/TransportData.h" namespace "Cantera":
     cdef cppclass CxxTransportData "Cantera::TransportData":
         CxxTransportData()
         CxxAnyMap parameters(cbool) except +translate_exception
+        string note()
+        void setNote(string)
 
     cdef cppclass CxxGasTransportData "Cantera::GasTransportData" (CxxTransportData):
         CxxGasTransportData()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -168,6 +168,8 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         void setKinetics(shared_ptr[CxxKinetics])
         void setTransport(shared_ptr[CxxTransport])
         CxxAnyMap parameters(cbool) except +translate_exception
+        string note()
+        void setNote(string)
 
     cdef shared_ptr[CxxSolution] CxxNewSolution "Cantera::Solution::create" ()
 
@@ -183,6 +185,8 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
 
         # miscellaneous
         string type()
+        string note()
+        void setNote(string)
         string phaseOfMatter() except +translate_exception
         void getSpeciesParameters(string, CxxAnyMap&) except +translate_exception
         string report(cbool, double) except +translate_exception

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -164,6 +164,7 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         void setName(string)
         string description()
         void setDescription(string)
+        CxxAnyMap input() except +translate_exception
         void setThermo(shared_ptr[CxxThermoPhase])
         void setKinetics(shared_ptr[CxxKinetics])
         void setTransport(shared_ptr[CxxTransport])

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -244,6 +244,15 @@ cdef class _SolutionBase:
         def __get__(self):
             return anymap_to_dict(self.base.parameters(True))
 
+    property extra:
+        """
+        Retrieve input data not associated with the current state of this Solution,
+        which corresponds to fields at the root level of the YAML input that are not
+        required for the instantiation of Cantera objects.
+        """
+        def __get__(self):
+            return anymap_to_dict(self.base.input())
+
     def write_yaml(self, filename, phases=None, units=None, precision=None,
                    skip_user_defined=None):
         """

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -94,6 +94,16 @@ cdef class _SolutionBase:
         def __get__(self):
             return self._source
 
+    property description:
+        """
+        The description of this object
+        """
+        def __get__(self):
+            return pystr(self.base.description())
+
+        def __set__(self, desc):
+            self.base.setDescription(stringify(desc))
+
     property composite:
         """
         Returns tuple of thermo/kinetics/transport models associated with
@@ -124,6 +134,8 @@ cdef class _SolutionBase:
 
         phaseNode = root[stringify("phases")].getMapWhere(stringify("name"),
                                                           stringify(name))
+        self.description = pystr(root.getString(stringify("description"),
+                                                stringify("")))
 
         # Thermo
         if isinstance(self, ThermoPhase):

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -270,6 +270,13 @@ cdef class Reaction:
         def __set__(self, orders):
             self.reaction.orders = comp_map(orders)
 
+    property note:
+        """ Annotation string describing the reaction. """
+        def __get__(self):
+            return pystr(self.reaction.note())
+        def __set__(self, note):
+            self.reaction.setNote(stringify(note))
+
     property ID:
         """
         Get/Set the identification string for the reaction, which can be used in

--- a/interfaces/cython/cantera/speciesthermo.pyx
+++ b/interfaces/cython/cantera/speciesthermo.pyx
@@ -79,6 +79,13 @@ cdef class SpeciesThermo:
                                            T_high, P_ref, &data[0])
             return data
 
+    property note:
+        """ Annotation string describing the parameterization. """
+        def __get__(self):
+            return pystr(self.spthermo.note())
+        def __set__(self, note):
+            self.spthermo.setNote(stringify(note))
+
     def _check_n_coeffs(self, n):
         """
         Check whether number of coefficients is compatible with a given

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -14,6 +14,13 @@ class TestKinetics(utilities.CanteraTest):
         self.phase.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 0.4]
         self.phase.TP = 800, 2*ct.one_atm
 
+    def test_note(self):
+        self.assertEqual(self.phase.reaction(0).note, "")
+        self.phase.reaction(0).note = "Reaction 1"
+        self.assertEqual(self.phase.reaction(0).note, "Reaction 1")
+        self.phase.reaction(0).note = ""
+        self.assertEqual(self.phase.reaction(0).note, "")
+
     def test_counts(self):
         self.assertEqual(self.phase.n_reactions, 28)
         self.assertEqual(self.phase.n_total_species, 9)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -12,10 +12,10 @@ from . import utilities
 
 class TestThermoPhase(utilities.CanteraTest):
     def setUp(self):
-        self.phase = ct.Solution('h2o2.xml')
+        self.phase = ct.Solution('h2o2.yaml')
 
     def test_source(self):
-        self.assertEqual(self.phase.source, 'h2o2.xml')
+        self.assertEqual(self.phase.source, 'h2o2.yaml')
 
     def test_missing_phases_key(self):
         yaml = '''
@@ -60,7 +60,7 @@ class TestThermoPhase(utilities.CanteraTest):
         self.assertIn('TD', self.phase._partial_states.values())
 
     def test_species(self):
-        self.assertEqual(self.phase.n_species, 9)
+        self.assertEqual(self.phase.n_species, 10)
         for i,name in enumerate(self.phase.species_names):
             self.assertEqual(name, self.phase.species_name(i))
             self.assertEqual(i, self.phase.species_index(name))
@@ -69,7 +69,7 @@ class TestThermoPhase(utilities.CanteraTest):
             self.phase.species(self.phase.n_species)
 
     def test_elements(self):
-        self.assertEqual(self.phase.n_elements, 3)
+        self.assertEqual(self.phase.n_elements, 4)
         for i,symbol in enumerate(self.phase.element_names):
             self.assertEqual(symbol, self.phase.element_name(i))
             self.assertEqual(i, self.phase.element_index(symbol))
@@ -516,12 +516,12 @@ class TestThermoPhase(utilities.CanteraTest):
 
     def test_setState_mass(self):
         self.check_setters(T1 = 500.0, rho1 = 1.5,
-                           Y1 = [0.1, 0.0, 0.0, 0.1, 0.4, 0.2, 0.0, 0.0, 0.2])
+                           Y1 = [0.1, 0.0, 0.0, 0.1, 0.4, 0.2, 0.0, 0.0, 0.0, 0.2])
 
     def test_setState_mole(self):
         self.phase.basis = 'molar'
         self.check_setters(T1 = 750.0, rho1 = 0.02,
-                           Y1 = [0.2, 0.1, 0.0, 0.3, 0.1, 0.0, 0.0, 0.2, 0.1])
+                           Y1 = [0.2, 0.1, 0.0, 0.3, 0.1, 0.0, 0.0, 0.2, 0.0, 0.1])
 
     def test_setters_hold_constant(self):
         props = ('T','P','s','h','u','v','X','Y')

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -17,6 +17,13 @@ class TestThermoPhase(utilities.CanteraTest):
     def test_source(self):
         self.assertEqual(self.phase.source, 'h2o2.yaml')
 
+    def test_thermo_note(self):
+        self.assertEqual(self.phase.note, "")
+        self.phase.note = "something"
+        self.assertEqual(self.phase.note, "something")
+        self.phase.note = ""
+        self.assertEqual(self.phase.note, "")
+
     def test_missing_phases_key(self):
         yaml = '''
         species:
@@ -34,12 +41,14 @@ class TestThermoPhase(utilities.CanteraTest):
             _ = ct.Solution(yaml=yaml)
 
     def test_speciesthermo_note(self):
-        spc = self.phase.species('H2')
-        self.assertEqual(spc.thermo.note, 'TPIS78')
+        spc = self.phase.species("H2")
+        self.assertEqual(spc.thermo.note, "TPIS78")
 
-        spc = self.phase.species('O2')
-        spc.thermo.note = 'oxygen'
-        self.assertEqual(spc.thermo.note, 'oxygen')
+        spc = self.phase.species("O2")
+        spc.thermo.note = "oxygen"
+        self.assertEqual(spc.thermo.note, "oxygen")
+        spc.thermo.note = ""
+        self.assertEqual(spc.thermo.note, "")
 
     def test_base_attributes(self):
         self.assertIsInstance(self.phase.name, str)
@@ -1245,12 +1254,14 @@ class TestSpecies(utilities.CanteraTest):
         self.assertEqual(len(iso), 0)
 
     def test_species_note(self):
-        gas = ct.Solution('nDodecane_Reitz.yaml')
-        self.assertEqual(gas.species('c12h26').note, '-therm')
+        gas = ct.Solution("nDodecane_Reitz.yaml")
+        self.assertEqual(gas.species("c12h26").note, "-therm")
 
-        self.assertEqual(gas.species('c6h12').note, '')
-        gas.species('c6h12').note = 'spam'
-        self.assertEqual(gas.species('c6h12').note, 'spam')
+        self.assertEqual(gas.species("c6h12").note, "")
+        gas.species("c6h12").note = "spam"
+        self.assertEqual(gas.species("c6h12").note, "spam")
+        gas.species("c6h12").note = ""
+        self.assertEqual(gas.species("c6h12").note, "")
 
 
 class TestSpeciesThermo(utilities.CanteraTest):

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -33,6 +33,14 @@ class TestThermoPhase(utilities.CanteraTest):
         with self.assertRaisesRegex(ct.CanteraError, "Key 'phases' not found"):
             _ = ct.Solution(yaml=yaml)
 
+    def test_speciesthermo_note(self):
+        spc = self.phase.species('H2')
+        self.assertEqual(spc.thermo.note, 'TPIS78')
+
+        spc = self.phase.species('O2')
+        spc.thermo.note = 'oxygen'
+        self.assertEqual(spc.thermo.note, 'oxygen')
+
     def test_base_attributes(self):
         self.assertIsInstance(self.phase.name, str)
         self.assertIsInstance(self.phase.phase_of_matter, str)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1236,6 +1236,14 @@ class TestSpecies(utilities.CanteraTest):
         iso = gas.find_isomers({'C':7, 'H':16})
         self.assertEqual(len(iso), 0)
 
+    def test_species_note(self):
+        gas = ct.Solution('nDodecane_Reitz.yaml')
+        self.assertEqual(gas.species('c12h26').note, '-therm')
+
+        self.assertEqual(gas.species('c6h12').note, '')
+        gas.species('c6h12').note = 'spam'
+        self.assertEqual(gas.species('c6h12').note, 'spam')
+
 
 class TestSpeciesThermo(utilities.CanteraTest):
     h2o_coeffs = [

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -11,6 +11,17 @@ class TestTransport(utilities.CanteraTest):
         self.phase.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 0.0, 0.4]
         self.phase.TP = 800, 2*ct.one_atm
 
+    def test_note(self):
+        spc = self.phase.species("HO2")
+        self.assertEqual(spc.transport.note, "*")
+
+        spc = self.phase.species("H2")
+        self.assertEqual(spc.transport.note, "")
+        spc.transport.note = "foobar"
+        self.assertEqual(spc.transport.note, "foobar")
+        spc.transport.note = ""
+        self.assertEqual(spc.transport.note, "")
+
     def test_scalar_properties(self):
         self.assertTrue(self.phase.viscosity > 0.0)
         self.assertTrue(self.phase.thermal_conductivity > 0.0)

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -7,8 +7,8 @@ import copy
 
 class TestTransport(utilities.CanteraTest):
     def setUp(self):
-        self.phase = ct.Solution('h2o2.xml')
-        self.phase.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 0.4]
+        self.phase = ct.Solution('h2o2.yaml')
+        self.phase.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 0.0, 0.4]
         self.phase.TP = 800, 2*ct.one_atm
 
     def test_scalar_properties(self):

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -213,6 +213,13 @@ cdef class Species:
         def __get__(self):
             return pystr(self.species.name)
 
+    property note:
+        """ Annotation string describing the species. """
+        def __get__(self):
+            return pystr(self.species.note())
+        def __set__(self, note):
+            self.species.setNote(stringify(note))
+
     property composition:
         """
         A dict containing the elemental composition of the species. Keys are

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -303,6 +303,13 @@ cdef class ThermoPhase(_SolutionBase):
         def __get__(self):
             return pystr(self.thermo.type())
 
+    property note:
+        """ Annotation string describing the thermo phase. """
+        def __get__(self):
+            return pystr(self.thermo.note())
+        def __set__(self, note):
+            self.thermo.setNote(stringify(note))
+
     property phase_of_matter:
         """
         Get the thermodynamic phase (gas, liquid, etc.) at the current conditions.

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -60,6 +60,13 @@ cdef class GasTransportData:
         def __get__(self):
             return anymap_to_dict(self.data.parameters(True))
 
+    property note:
+        """ Annotation string describing transport data. """
+        def __get__(self):
+            return pystr(self.data.note())
+        def __set__(self, note):
+            self.data.setNote(stringify(note))
+
     property geometry:
         """
         Get/Set the string specifying the molecular geometry. One of `atom`,

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -13,11 +13,14 @@
 #include "cantera/kinetics/KineticsFactory.h"
 #include "cantera/transport/TransportBase.h"
 #include "cantera/transport/TransportFactory.h"
+#include "cantera/base/stringUtils.h"
 
 namespace Cantera
 {
 
-Solution::Solution() {}
+Solution::Solution() :
+    m_description("") {
+}
 
 std::string Solution::name() const {
     if (m_thermo) {
@@ -80,6 +83,17 @@ shared_ptr<Solution> newSolution(const std::string& infile,
 
     // instantiate Solution object
     auto sol = Solution::create();
+
+    // description
+    size_t dot = infile.find_last_of(".");
+    std::string extension;
+    if (dot != npos) {
+        extension = toLowerCopy(infile.substr(dot+1));
+    }
+    if (extension == "yml" || extension == "yaml") {
+        AnyMap root = AnyMap::fromYamlFile(infile);
+        sol->setDescription(root.getString("description", ""));
+    }
 
     // thermo phase
     sol->setThermo(shared_ptr<ThermoPhase>(newPhase(infile, name)));

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -18,8 +18,7 @@
 namespace Cantera
 {
 
-Solution::Solution() :
-    m_description("") {
+Solution::Solution() {
 }
 
 std::string Solution::name() const {
@@ -37,6 +36,18 @@ void Solution::setName(const std::string& name) {
     } else {
         throw CanteraError("Solution::setName",
                            "Requires associated 'ThermoPhase'");
+    }
+}
+
+std::string Solution::description() const {
+    return m_input.getString("description", "");
+}
+
+void Solution::setDescription(const std::string& desc) {
+    if (desc == "") {
+        m_input.erase("description");
+    } else {
+        m_input["description"] = desc;
     }
 }
 
@@ -59,6 +70,16 @@ void Solution::setTransport(shared_ptr<Transport> transport) {
     if (m_transport) {
         m_transport->setRoot(shared_from_this());
     }
+}
+
+const AnyMap& Solution::input() const
+{
+    return m_input;
+}
+
+AnyMap& Solution::input()
+{
+    return m_input;
 }
 
 AnyMap Solution::parameters(bool withInput) const
@@ -92,7 +113,10 @@ shared_ptr<Solution> newSolution(const std::string& infile,
     }
     if (extension == "yml" || extension == "yaml") {
         AnyMap root = AnyMap::fromYamlFile(infile);
-        sol->setDescription(root.getString("description", ""));
+        root.erase("phases");
+        root.erase("species");
+        root.erase("reactions");
+        sol->input() = root;
     }
 
     // thermo phase

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -142,6 +142,20 @@ void Reaction::getParameters(AnyMap& reactionNode) const
     }
 }
 
+std::string Reaction::note() const
+{
+    return input.getString("note", "");
+}
+
+void Reaction::setNote(const std::string& note)
+{
+    if (note == "") {
+        input.erase("note");
+    } else {
+        input["note"] = note;
+    }
+}
+
 std::string Reaction::reactantString() const
 {
     std::ostringstream result;

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -74,6 +74,20 @@ AnyMap Species::parameters(const ThermoPhase* phase, bool withInput) const
     return speciesNode;
 }
 
+std::string Species::note() const
+{
+    return input.getString("note", "");
+}
+
+void Species::setNote(const std::string& note)
+{
+    if (note == "") {
+        input.erase("note");
+    } else {
+        input["note"] = note;
+    }
+}
+
 shared_ptr<Species> newSpecies(const XML_Node& species_node)
 {
     std::string name = species_node["name"];

--- a/src/thermo/SpeciesThermoInterpType.cpp
+++ b/src/thermo/SpeciesThermoInterpType.cpp
@@ -90,4 +90,18 @@ AnyMap& SpeciesThermoInterpType::input()
     return m_input;
 }
 
+std::string SpeciesThermoInterpType::note() const
+{
+    return input().getString("note", "");
+}
+
+void SpeciesThermoInterpType::setNote(const std::string& note)
+{
+    if (note == "") {
+        input().erase("note");
+    } else {
+        input()["note"] = note;
+    }
+}
+
 }

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -1262,6 +1262,20 @@ AnyMap& ThermoPhase::input()
     return m_input;
 }
 
+std::string ThermoPhase::note() const
+{
+    return input().getString("note", "");
+}
+
+void ThermoPhase::setNote(const std::string& note)
+{
+    if (note == "") {
+        input().erase("note");
+    } else {
+        input()["note"] = note;
+    }
+}
+
 void ThermoPhase::setStateFromXML(const XML_Node& state)
 {
     string comp = getChildValue(state,"moleFractions");

--- a/src/transport/TransportData.cpp
+++ b/src/transport/TransportData.cpp
@@ -28,6 +28,20 @@ void TransportData::getParameters(AnyMap &transportNode) const
 {
 }
 
+std::string TransportData::note() const
+{
+    return input.getString("note", "");
+}
+
+void TransportData::setNote(const std::string& note)
+{
+    if (note == "") {
+        input.erase("note");
+    } else {
+        input["note"] = note;
+    }
+}
+
 GasTransportData::GasTransportData()
     : diameter(0.0)
     , well_depth(0.0)

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -10,6 +10,19 @@
 
 using namespace Cantera;
 
+TEST(Reaction, annotation)
+{
+    auto sol = newSolution("gri30.yaml");
+    AnyMap rxn = AnyMap::fromYamlString(
+        "{equation: N + NO <=> N2 + O,"
+        " rate-constant: [-2.70000E+13 cm^3/mol/s, 0, 355 cal/mol],"
+        " negative-A: true,"
+        " note: 'foo bar'}");
+
+    auto R = newReaction(rxn, *(sol->kinetics()));
+    EXPECT_EQ(R->note(), "foo bar");
+}
+
 TEST(Reaction, ElementaryFromYaml)
 {
     auto sol = newSolution("gri30.yaml");

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -719,6 +719,7 @@ TEST(Species, fromYaml)
         "composition: {N: 1, O: 2}\n"
         "units: {length: cm, quantity: mol}\n"
         "molar-volume: 0.536\n"
+        "note: 'spam eggs'\n"
         "thermo:\n"
         "  model: NASA7\n"
         "  temperature-ranges: [200, 1000, 6000]\n"
@@ -726,13 +727,16 @@ TEST(Species, fromYaml)
         "  - [3.944031200E+00, -1.585429000E-03, 1.665781200E-05, -2.047542600E-08,\n"
         "     7.835056400E-12, 2.896617900E+03, 6.311991700E+00]\n"
         "  - [4.884754200E+00, 2.172395600E-03, -8.280690600E-07, 1.574751000E-10,\n"
-        "     -1.051089500E-14, 2.316498300E+03, -1.174169500E-01]\n");
+        "     -1.051089500E-14, 2.316498300E+03, -1.174169500E-01]\n"
+        "  note: '12345'\n");
 
     auto S = newSpecies(spec);
     EXPECT_DOUBLE_EQ(S->thermo->minTemp(), 200);
     EXPECT_EQ(S->composition.at("N"), 1);
     // Check that units directive gets propagated to `input`
     EXPECT_DOUBLE_EQ(S->input.convert("molar-volume", "m^3/kmol"), 0.000536);
+    EXPECT_EQ(S->note(), "spam eggs");
+    EXPECT_EQ(S->thermo->note(), "12345");
 }
 
 } // namespace Cantera

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -47,6 +47,7 @@ TEST(ThermoFromYaml, elementOverride)
     EXPECT_DOUBLE_EQ(thermo->atomicWeight(0), getElementWeight("N"));
     EXPECT_DOUBLE_EQ(thermo->atomicWeight(1), getElementWeight("O"));
     EXPECT_DOUBLE_EQ(thermo->atomicWeight(2), 36);
+    EXPECT_EQ(thermo->note(), "replace Argon with custom element");
 }
 
 TEST(ThermoFromYaml, elementFromDifferentFile)

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -1,4 +1,6 @@
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
+#include "cantera/base/Solution.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/Elements.h"
 #include "cantera/thermo/Species.h"
@@ -18,6 +20,12 @@ shared_ptr<ThermoPhase> newThermo(const std::string& fileName,
 }
 
 } // namespace
+
+TEST(ThermoFromYaml, description)
+{
+    auto sol = newSolution("gri30.yaml");
+    EXPECT_THAT(sol->description(), ::testing::HasSubstr("GRI-Mech Version 3.0 7/30/99"));
+}
 
 TEST(ThermoFromYaml, simpleIdealGas)
 {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/master/CONTRIBUTING.md). -->

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**If applicable, fill in the issue number this pull request is fixing**

Fixes #1013

Addresses annotations discussed in Cantera/enhancements#52

**Changes proposed in this pull request**

- preserve top level `description` field
- preserve `note` fields for `Species`, `SpeciesThermo`, `Reaction`, `TransportData`, and `ThermoPhase`
- ~fix an issue where yaml-cpp does not recognize strings containing integers contained in quotes, e.g. `'1234'`~ … already merged 

**Thoughts:**  `description` and `note` fields are part of the canonical YAML implementation (see `ck2yaml`); the explicit inclusion ensures that Sphinx docstrings are generated.

~Some C++ classes already have a `AnyMap input` attribute, which may be used instead of a `string m_note` as envisioned in the initial draft.~