### PR TITLE
[CI] Condition adding the SSH key to main branch

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -138,6 +138,7 @@ jobs:
       # machine that has previously logged in to cantera.org and trusts
       # that it logged in to the right machine
       - name: Set up SSH key and host for deploy
+        if: github.event_name == 'push' && github.repository_owner == 'Cantera' && github.ref == 'master'
         uses: shimataro/ssh-key-action@v2
         with:
           key: ${{ secrets.CTDEPLOY_KEY }}


### PR DESCRIPTION
Secrets are not available to branches from forked repos, so the SSH
setup step has to be skipped unless the main branch is being used.

Fixes #882

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review