### PR TITLE
Fix reactor mass flow rate

### DIFF
--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -53,7 +53,8 @@ extern "C" {
     CANTERA_CAPI int flowdev_del(int i);
     CANTERA_CAPI int flowdev_install(int i, int n, int m);
     CANTERA_CAPI int flowdev_setMaster(int i, int n);
-    CANTERA_CAPI double flowdev_massFlowRate(int i, double time);
+    CANTERA_CAPI double flowdev_massFlowRate2(int i);
+    CANTERA_CAPI double flowdev_massFlowRate(int i, double time); //!< @deprecated To be changed after Cantera 2.5.
     CANTERA_CAPI int flowdev_setMassFlowRate(int i, double mdot);
     CANTERA_CAPI int flowdev_setParameters(int i, int n, const double* v);  //!< @deprecated To be removed after Cantera 2.5.
     CANTERA_CAPI int flowdev_setMassFlowCoeff(int i, double v);

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -9,6 +9,7 @@
 #include "cantera/base/ct_defs.h"
 #include "cantera/base/global.h"
 #include "cantera/base/stringUtils.h"
+#include "cantera/base/ctexceptions.h"
 
 namespace Cantera
 {
@@ -54,11 +55,22 @@ public:
     }
 
     //! Mass flow rate (kg/s).
+    //! @deprecated The 'time' argument will be removed after Cantera 2.5.
+    //!     Evaluating the mass flow rate at times other than the current time
+    //!     for the reactor network may lead to subtly incorrect results.
     double massFlowRate(double time = -999.0) {
         if (time != -999.0) {
+            warn_deprecated("FlowDevice::massFlowRate", "The 'time' argument"
+                " is deprecated and will be removed after Cantera 2.5.");
             updateMassFlowRate(time);
         }
-        return m_mdot;
+
+        if (m_mdot == Undef) {
+            throw CanteraError("FlowDevice::massFlowRate",
+                               "Flow device is not ready. Try initializing the reactor network.");
+        } else {
+            return m_mdot;
+        }
     }
 
     //! Update the mass flow rate at time 'time'. This must be overloaded in

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -200,6 +200,14 @@ protected:
     //! Update the state of SurfPhase objects attached to this reactor
     virtual void updateSurfaceState(double* y);
 
+    //! Update the state information needed by connected reactors and flow
+    //! devices. Called from updateState().
+    //! @param updatePressure  Indicates whether to update #m_pressure. Should
+    //!     `true` for reactors where the pressure is a dependent property,
+    //!     calculated from the state, and `false` when the pressure is constant
+    //!     or an independent variable.
+    virtual void updateConnected(bool updatePressure);
+
     //! Get initial conditions for SurfPhase objects attached to this reactor
     virtual void getSurfaceInitialConditions(double* y);
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -184,12 +184,6 @@ protected:
     //! @param t     the current time
     virtual void evalWalls(double t);
 
-    //! Evaluate inlet and outlet mass flow rates. This is called in evalEqs()
-    //! before setting the state of #m_thermo, since calling the mass flow rate
-    //! functions may modify ThermoPhase objects that are shared with other
-    //! reactors.
-    virtual void evalFlowDevices(double t);
-
     //! Evaluate terms related to surface reactions. Calculates #m_sdot and rate
     //! of change in surface species coverages.
     //! @param t          the current time

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -269,12 +269,6 @@ protected:
     vector_fp m_state;
     std::vector<FlowDevice*> m_inlet, m_outlet;
 
-    //! Temporary storage for mass flow rates from each inlet FlowDevice
-    vector_fp m_mdot_in;
-
-    //! Temporary storage for mass flow rates from each outlet FlowDevice
-    vector_fp m_mdot_out;
-
     std::vector<WallBase*> m_wall;
     std::vector<ReactorSurface*> m_surfaces;
     vector_int m_lr;

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -25,10 +25,6 @@ public:
         return "MassFlowController";
     }
 
-    virtual bool ready() {
-        return FlowDevice::ready() && m_mdot >= 0.0;
-    }
-
     //! Set the fixed mass flow rate (kg/s) through the mass flow controller.
     void setMassFlowRate(double mdot);
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -613,6 +613,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxFlowDevice "Cantera::FlowDevice":
         CxxFlowDevice()
         string typeStr()
+        double massFlowRate() except +translate_exception
         double massFlowRate(double) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&) except +translate_exception
         void setPressureFunction(CxxFunc1*) except +translate_exception

--- a/interfaces/cython/cantera/examples/reactors/ic_engine.py
+++ b/interfaces/cython/cantera/examples/reactors/ic_engine.py
@@ -174,8 +174,8 @@ while sim.time < t_stop:
     states.append(cyl.thermo.state,
                   t=sim.time, ca=crank_angle(sim.time),
                   V=cyl.volume, m=cyl.mass,
-                  mdot_in=inlet_valve.mdot(sim.time),
-                  mdot_out=outlet_valve.mdot(sim.time),
+                  mdot_in=inlet_valve.mass_flow_rate,
+                  mdot_out=outlet_valve.mass_flow_rate,
                   dWv_dt=dWv_dt)
 
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -707,10 +707,26 @@ cdef class FlowDevice:
         self._upstream = upstream
         self._downstream = downstream
 
-    def mdot(self, double t):
+    property mass_flow_rate:
+        def __get__(self):
+            """
+            The mass flow rate [kg/s] through this device at the current reactor
+            network time.
+            """
+            return self.dev.massFlowRate()
+
+    def mdot(self, double t=-999):
         """
         The mass flow rate [kg/s] through this device at time *t* [s].
+
+        .. deprecated:: 2.5
+
+             To be removed after Cantera 2.5. Replaced with the
+             `mass_flow_rate` property.
         """
+        warnings.warn("To be removed after Cantera 2.5. "
+                "Replaced by property 'mass_flow_rate'", DeprecationWarning)
+
         return self.dev.massFlowRate(t)
 
     def set_pressure_function(self, k):
@@ -799,7 +815,8 @@ cdef class MassFlowController(FlowDevice):
     property mass_flow_rate:
         r"""
         Set the mass flow rate [kg/s] through this controller to be either
-        a constant or an arbitrary function of time. See `Func1`.
+        a constant or an arbitrary function of time. See `Func1`, or get its
+        current value.
 
         Note that depending on the argument type, this method either changes
         the property `mass_flow_coeff` or calls the `set_time_function` method.
@@ -807,6 +824,9 @@ cdef class MassFlowController(FlowDevice):
         >>> mfc.mass_flow_rate = 0.3
         >>> mfc.mass_flow_rate = lambda t: 2.5 * exp(-10 * (t - 0.5)**2)
         """
+        def __get__(self):
+            return self.dev.massFlowRate()
+
         def __set__(self, m):
             if isinstance(m, _numbers.Real):
                 (<CxxMassFlowController*>self.dev).setMassFlowRate(m)

--- a/interfaces/matlab/toolbox/@FlowDevice/massFlowRate.m
+++ b/interfaces/matlab/toolbox/@FlowDevice/massFlowRate.m
@@ -9,4 +9,10 @@ function mdot = massFlowRate(f, time)
 %     The mass flow rate through the :mat:func:`FlowDevice` at the given time
 %
 
-mdot = flowdevicemethods(21, f.index, time);
+if nargin == 1
+    mdot = flowdevicemethods(21, f.index);
+else
+    warning(['"time" argument to massFlowRate is deprecated and will be' ...
+            ' removed after Cantera 2.5.'])
+    mdot = flowdevicemethods(21, f.index, time);
+end

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -413,7 +413,19 @@ extern "C" {
     double flowdev_massFlowRate(int i, double time)
     {
         try {
+            warn_deprecated("flowdev_massFlowRate(int i, double time)",
+                "To be changed after Cantera 2.5. 'time' argument will be "
+                "removed. Use flowdev_massFlowRate2(int i) during transition.");
             return FlowDeviceCabinet::item(i).massFlowRate(time);
+        } catch (...) {
+            return handleAllExceptions(DERR, DERR);
+        }
+    }
+
+    double flowdev_massFlowRate2(int i)
+    {
+        try {
+            return FlowDeviceCabinet::item(i).massFlowRate();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }

--- a/src/matlab/flowdevicemethods.cpp
+++ b/src/matlab/flowdevicemethods.cpp
@@ -79,7 +79,11 @@ void flowdevicemethods(int nlhs, mxArray* plhs[],
         // options that return a value of type 'double'
         switch (job) {
         case 21:
-            r = flowdev_massFlowRate(i, v);
+            if (v == Undef) {
+                r = flowdev_massFlowRate2(i);
+            } else {
+                r = flowdev_massFlowRate(i, v);
+            }
             break;
         default:
             mexErrMsgTxt("unknown job parameter");

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -55,11 +55,7 @@ void ConstPressureReactor::updateState(doublereal* y)
     }
     m_vol = m_mass / m_thermo->density();
     updateSurfaceState(y + m_nsp + 2);
-
-    // save parameters needed by other connected reactors
-    m_enthalpy = m_thermo->enthalpy_mass();
-    m_intEnergy = m_thermo->intEnergy_mass();
-    m_thermo->saveState(m_state);
+    updateConnected(false);
 }
 
 void ConstPressureReactor::evalEqs(doublereal time, doublereal* y,

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -64,7 +64,6 @@ void ConstPressureReactor::evalEqs(doublereal time, doublereal* y,
     double dmdt = 0.0; // dm/dt (gas phase)
     double* dYdt = ydot + 2;
 
-    evalFlowDevices(time);
     evalWalls(time);
     applySensitivity(params);
 
@@ -90,20 +89,22 @@ void ConstPressureReactor::evalEqs(doublereal time, doublereal* y,
     double dHdt = - m_Q;
 
     // add terms for outlets
-    for (size_t i = 0; i < m_outlet.size(); i++) {
-        dmdt -= m_mdot_out[i];
-        dHdt -= m_mdot_out[i] * m_enthalpy;
+    for (auto outlet : m_outlet) {
+        double mdot = outlet->massFlowRate();
+        dmdt -= mdot;
+        dHdt -= mdot * m_enthalpy;
     }
 
     // add terms for inlets
-    for (size_t i = 0; i < m_inlet.size(); i++) {
-        dmdt += m_mdot_in[i]; // mass flow into system
+    for (auto inlet : m_inlet) {
+        double mdot = inlet->massFlowRate();
+        dmdt += mdot; // mass flow into system
         for (size_t n = 0; n < m_nsp; n++) {
-            double mdot_spec = m_inlet[i]->outletSpeciesMassFlowRate(n);
+            double mdot_spec = inlet->outletSpeciesMassFlowRate(n);
             // flow of species into system and dilution by other species
-            dYdt[n] += (mdot_spec - m_mdot_in[i] * Y[n]) / m_mass;
+            dYdt[n] += (mdot_spec - mdot * Y[n]) / m_mass;
         }
-        dHdt += m_mdot_in[i] * m_inlet[i]->enthalpy_mass();
+        dHdt += mdot * inlet->enthalpy_mass();
     }
 
     ydot[0] = dmdt;

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -10,7 +10,7 @@
 namespace Cantera
 {
 
-FlowDevice::FlowDevice() : m_mdot(0.0), m_pfunc(0), m_tfunc(0),
+FlowDevice::FlowDevice() : m_mdot(Undef), m_pfunc(0), m_tfunc(0),
                            m_coeff(1.0), m_type(0),
                            m_nspin(0), m_nspout(0),
                            m_in(0), m_out(0) {}

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -5,6 +5,7 @@
 
 #include "cantera/zeroD/IdealGasConstPressureReactor.h"
 #include "cantera/zeroD/FlowDevice.h"
+#include "cantera/zeroD/ReactorNet.h"
 
 using namespace std;
 
@@ -60,11 +61,7 @@ void IdealGasConstPressureReactor::updateState(doublereal* y)
     m_thermo->setState_TP(y[1], m_pressure);
     m_vol = m_mass / m_thermo->density();
     updateSurfaceState(y + m_nsp + 2);
-
-    // save parameters needed by other connected reactors
-    m_enthalpy = m_thermo->enthalpy_mass();
-    m_intEnergy = m_thermo->intEnergy_mass();
-    m_thermo->saveState(m_state);
+    updateConnected(false);
 }
 
 void IdealGasConstPressureReactor::evalEqs(doublereal time, doublereal* y,

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -65,12 +65,7 @@ void IdealGasReactor::updateState(doublereal* y)
     m_thermo->setMassFractions_NoNorm(y+3);
     m_thermo->setState_TR(y[2], m_mass / m_vol);
     updateSurfaceState(y + m_nsp + 3);
-
-    // save parameters needed by other connected reactors
-    m_enthalpy = m_thermo->enthalpy_mass();
-    m_pressure = m_thermo->pressure();
-    m_intEnergy = m_thermo->intEnergy_mass();
-    m_thermo->saveState(m_state);
+    updateConnected(true);
 }
 
 void IdealGasReactor::evalEqs(doublereal time, doublereal* y,

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -272,10 +272,12 @@ void Reactor::evalWalls(double t)
 void Reactor::evalFlowDevices(double t)
 {
     for (size_t i = 0; i < m_outlet.size(); i++) {
-        m_mdot_out[i] = m_outlet[i]->massFlowRate(t);
+        m_outlet[i]->updateMassFlowRate(t);
+        m_mdot_out[i] = m_outlet[i]->massFlowRate();
     }
     for (size_t i = 0; i < m_inlet.size(); i++) {
-        m_mdot_in[i] = m_inlet[i]->massFlowRate(t);
+        m_inlet[i]->updateMassFlowRate(t);
+        m_mdot_in[i] = m_inlet[i]->massFlowRate();
     }
 }
 

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -47,13 +47,11 @@ void ReactorBase::syncState()
 void ReactorBase::addInlet(FlowDevice& inlet)
 {
     m_inlet.push_back(&inlet);
-    m_mdot_in.push_back(0.0);
 }
 
 void ReactorBase::addOutlet(FlowDevice& outlet)
 {
     m_outlet.push_back(&outlet);
-    m_mdot_out.push_back(0.0);
 }
 
 void ReactorBase::addWall(WallBase& w, int lr)

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -233,6 +233,7 @@ void ReactorNet::addReactor(Reactor& r)
 void ReactorNet::eval(doublereal t, doublereal* y,
                       doublereal* ydot, doublereal* p)
 {
+    m_time = t; // This will be replaced at the end of the timestep
     updateState(y);
     for (size_t n = 0; n < m_reactors.size(); n++) {
         m_reactors[n]->evalEqs(t, y + m_start[n], ydot + m_start[n], p);

--- a/src/zeroD/flowControllers.cpp
+++ b/src/zeroD/flowControllers.cpp
@@ -52,7 +52,8 @@ void PressureController::updateMassFlowRate(double time)
     } else {
         mdot *= delta_P;
     }
-    mdot += m_master->massFlowRate(time);
+    m_master->updateMassFlowRate(time);
+    mdot += m_master->massFlowRate();
     m_mdot = std::max(mdot, 0.0);
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**

This PR comes from my attempts to get repeatable output from the `combustor.cpp` sample in #883. I separated these changes out to avoid bloating that PR.

- Ensure that the mass flow rate returned by `FlowDevice` objects is correct after a call to `ReactorNet::advance`, and not the value at some later time that the integrator reached.
- Deprecate the `time` argument to `FlowDevice::massFlowRate` (and equivalent methods in the various language interfaces), since getting the value at any time other than the current integrator time may not be correct.
- Remove a few variables / functions that are no longer necessary as a result of the above changes.

**Checklist**

- [X] There is a clear use-case for this code change
- [X] The commit message has a short title & references relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] The pull request is ready for review

