### PR TITLE
[SCons] Check for minimum version of ruamel.yaml

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -37,7 +37,7 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons numpy cython h5py
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas
     - name: Build Cantera
       run: python3 `which scons` build -j2
     - name: Test Cantera
@@ -65,7 +65,7 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons numpy cython h5py
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas
     - name: Build Cantera
       run: python3 `which scons` build -j2
     - name: Test Cantera
@@ -95,7 +95,7 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons numpy cython h5py
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas
     - name: Build Cantera
       run: |
         python3 `which scons` build blas_lapack_libs=lapack,blas coverage=y \
@@ -166,6 +166,7 @@ jobs:
           python3-pip python3-setuptools libsundials-serial-dev liblapack-dev \
           libblas-dev
       - name: Install Python dependencies
+        # Don't include Pandas here due to install errors
         run: |
           sudo -H /usr/bin/python3 -m pip install ruamel.yaml cython h5py
       - name: Build Cantera
@@ -196,7 +197,7 @@ jobs:
         shell: bash -l {0}
         run: |
           conda install -q sundials=${{ matrix.sundials-ver}} scons numpy ruamel_yaml \
-          cython libboost fmt eigen yaml-cpp h5py
+          cython libboost fmt eigen yaml-cpp h5py pandas
       - name: Build Cantera
         run: |
           scons build extra_inc_dirs=$CONDA_PREFIX/include:$CONDA_PREFIX/include/eigen3 \
@@ -226,7 +227,7 @@ jobs:
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
       run: |
-        python3 -m pip install ruamel.yaml scons numpy h5py;
+        python3 -m pip install ruamel.yaml scons numpy h5py pandas;
         python3 -m pip install https://github.com/cython/cython/archive/master.zip --install-option='--no-cython-compile';
     - name: Build Cantera
       run: python3 `which scons` build blas_lapack_libs=lapack,blas python_package='full' -j2
@@ -270,7 +271,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip setuptools
-          python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py
+          python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas
       - name: Build Cantera
         run: |
           scons build -j2 boost_inc_dir=%BOOST_ROOT_1_69_0% debug=n VERBOSE=y python_package=full ^

--- a/SConstruct
+++ b/SConstruct
@@ -1229,6 +1229,8 @@ env['python_cmd_esc'] = quoted(env['python_cmd'])
 
 # Python Package Settings
 python_min_version = LooseVersion('3.5')
+# The string is used to set python_requires in setup.py.in
+env['py_min_ver_str'] = str(python_min_version)
 # Note: cython_min_version is redefined below if the Python version is 3.8 or higher
 cython_min_version = LooseVersion('0.23')
 numpy_min_version = LooseVersion('1.12.0')

--- a/SConstruct
+++ b/SConstruct
@@ -1231,7 +1231,7 @@ env['python_cmd_esc'] = quoted(env['python_cmd'])
 python_min_version = LooseVersion('3.5')
 # Note: cython_min_version is redefined below if the Python version is 3.8 or higher
 cython_min_version = LooseVersion('0.23')
-numpy_min_test_version = LooseVersion('1.8.1')
+numpy_min_version = LooseVersion('1.12.0')
 
 # We choose ruamel.yaml 0.15.34 as the minimum version
 # since it is the highest version available in the Ubuntu
@@ -1383,10 +1383,11 @@ if env['python_package'] != 'none':
         if numpy_version == LooseVersion('0.0.0'):
             print("NumPy not found.")
             warn_no_full_package = True
-        elif numpy_version < numpy_min_test_version:
-            print("WARNING: The installed version of Numpy is not tested and "
-                  "support is not guaranteed. Found {0} but {1} or newer is preferred".format(
-                  numpy_version, numpy_min_test_version))
+        elif numpy_version < numpy_min_version:
+            print("WARNING: NumPy is an incompatible version: "
+                  "Found {0} but {1} or newer is required".format(
+                  numpy_version, numpy_min_version))
+            warn_no_full_package = True
         else:
             print('INFO: Using NumPy version {0}.'.format(numpy_version))
 
@@ -1396,7 +1397,7 @@ if env['python_package'] != 'none':
         elif cython_version < cython_min_version:
             print("WARNING: Cython is an incompatible version: "
                   "Found {0} but {1} or newer is required.".format(
-                    cython_version, cython_min_version))
+                  cython_version, cython_min_version))
             warn_no_full_package = True
         else:
             print('INFO: Using Cython version {0}.'.format(cython_version))

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -43,13 +43,11 @@ used to add to the file description, or to define custom fields that are
 included in the YAML output.
 """
 
-from collections import defaultdict, OrderedDict
 import logging
 import os.path
 import sys
 import numpy as np
 import re
-import itertools
 import getopt
 import textwrap
 from email.utils import formatdate
@@ -58,6 +56,21 @@ try:
     import ruamel_yaml as yaml
 except ImportError:
     from ruamel import yaml
+
+# yaml.version_info is a tuple with the three parts of the version
+yaml_version = yaml.version_info
+# We choose ruamel.yaml 0.15.34 as the minimum version
+# since it is the highest version available in the Ubuntu
+# 18.04 repositories and seems to work. Older versions such as
+# 0.13.14 on CentOS7 and 0.10.23 on Ubuntu 16.04 raise an exception
+# that they are missing the RoundTripRepresenter
+yaml_min_version = (0, 15, 34)
+if yaml_version < yaml_min_version:
+    raise RuntimeError(
+        "The minimum supported version of ruamel.yaml is 0.15.34. If you "
+        "installed ruamel.yaml from your operating system's package manager, "
+        "please install an updated version using pip or conda."
+    )
 
 BlockMap = yaml.comments.CommentedMap
 

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -24,6 +24,21 @@ try:
 except ImportError:
     from ruamel import yaml
 
+# yaml.version_info is a tuple with the three parts of the version
+yaml_version = yaml.version_info
+# We choose ruamel.yaml 0.15.34 as the minimum version
+# since it is the highest version available in the Ubuntu
+# 18.04 repositories and seems to work. Older versions such as
+# 0.13.14 on CentOS7 and 0.10.23 on Ubuntu 16.04 raise an exception
+# that they are missing the RoundTripRepresenter
+yaml_min_version = (0, 15, 34)
+if yaml_version < yaml_min_version:
+    raise RuntimeError(
+        "The minimum supported version of ruamel.yaml is 0.15.34. If you "
+        "installed ruamel.yaml from your operating system's package manager, "
+        "please install an updated version using pip or conda."
+    )
+
 
 def _printerr(*args):
     # All debug and error output should go to stderr

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -24,12 +24,27 @@ import copy
 from typing import Any, Dict, Union, Iterable, Optional, List, Tuple
 from typing import TYPE_CHECKING
 
+import numpy as np
+
 try:
     import ruamel_yaml as yaml  # type: ignore
 except ImportError:
     from ruamel import yaml
 
-import numpy as np
+# yaml.version_info is a tuple with the three parts of the version
+yaml_version = yaml.version_info
+# We choose ruamel.yaml 0.15.34 as the minimum version
+# since it is the highest version available in the Ubuntu
+# 18.04 repositories and seems to work. Older versions such as
+# 0.13.14 on CentOS7 and 0.10.23 on Ubuntu 16.04 raise an exception
+# that they are missing the RoundTripRepresenter
+yaml_min_version = (0, 15, 34)
+if yaml_version < yaml_min_version:
+    raise RuntimeError(
+        "The minimum supported version of ruamel.yaml is 0.15.34. If you "
+        "installed ruamel.yaml from your operating system's package manager, "
+        "please install an updated version using pip or conda."
+    )
 
 if TYPE_CHECKING:
     # This is available in the built-in typing module in Python 3.8

--- a/interfaces/cython/setup.py.in
+++ b/interfaces/cython/setup.py.in
@@ -60,7 +60,7 @@ setup(
     author="Raymond Speth",
     author_email="speth@mit.edu",
     url="https://cantera.org",
-    packages = [
+    packages=[
         'cantera',
         'cantera.data',
         'cantera.test',
@@ -92,12 +92,12 @@ setup(
         'Programming Language :: Python :: 3.8',
         'Topic :: Scientific/Engineering :: Chemistry',
     ],
-    package_data = {
+    package_data={
         'cantera.data': ['*.*', '*/*.*'],
         'cantera.test.data': ['*.*', '*/*.*'],
         'cantera.examples': ['*/*.*'],
         'cantera': ["@py_extension@", '*.pxd'],
     },
     zip_safe=False,
-    python_requires=">=3.5",
+    python_requires=">=@py_min_ver_str@",
 )


### PR DESCRIPTION
To run the tests of the converter scripts, ruamel.yaml must be installed
with a minumum version at least 0.15.94. We aren't sure what the true
minimum version is, but 0.15.94 was released in April 2019 so is
probably widely released enough to count. Note that the version
available from the Ubuntu 16.04 repositories is not new

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**If applicable, fill in the issue number this pull request is fixing**

Fixes #831

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
