### PR TITLE
[CI] Reduce timeout limit

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -18,6 +18,7 @@ jobs:
   ubuntu-multiple-pythons:
     name: Ubuntu 18.04 with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [ '3.5', '3.6', '3.7', '3.8' ]
@@ -46,6 +47,7 @@ jobs:
   macos-multiple-pythons:
     name: macOS with Python ${{ matrix.python-version }}
     runs-on: macos-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [ '3.5', '3.6', '3.7', '3.8' ]
@@ -78,6 +80,7 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 90
     needs: [ubuntu-multiple-pythons]
     steps:
     - uses: actions/checkout@v2
@@ -110,6 +113,7 @@ jobs:
   docs:
     name: Build docs
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
         name: Checkout the repository
@@ -155,6 +159,7 @@ jobs:
     # Ubuntu 16.04 using Python 2 to run SCons and the system Python 3 for the interface
     name: Python 2 running SCons on Ubuntu 16.04
     runs-on: ubuntu-16.04
+    timeout-minutes: 60
     steps:
       - uses: actions/checkout@v2
         name: Checkout the repository
@@ -176,6 +181,7 @@ jobs:
   multiple-sundials:
     name: Sundials ${{ matrix.sundials-ver }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         sundials-ver: [ 2, 3, 4, 5.3 ]
@@ -210,6 +216,7 @@ jobs:
   cython-latest:
     name: Test pre-release version of Cython
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
     - uses: actions/checkout@v2
       name: Checkout the repository
@@ -236,6 +243,7 @@ jobs:
   windows:
     name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: ['windows-2019']

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -24,6 +24,7 @@ jobs:
         python-version: [ '3.5', '3.6', '3.7', '3.8' ]
       fail-fast: false
     steps:
+    - uses: technote-space/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
@@ -53,6 +54,7 @@ jobs:
         python-version: [ '3.5', '3.6', '3.7', '3.8' ]
       fail-fast: false
     steps:
+    - uses: technote-space/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
@@ -80,9 +82,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    timeout-minutes: 90
+    timeout-minutes: 180
     needs: [ubuntu-multiple-pythons]
     steps:
+    - uses: technote-space/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
@@ -115,6 +118,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+      - uses: technote-space/auto-cancel-redundant-job@v1
       - uses: actions/checkout@v2
         name: Checkout the repository
         with:
@@ -161,6 +165,7 @@ jobs:
     runs-on: ubuntu-16.04
     timeout-minutes: 60
     steps:
+      - uses: technote-space/auto-cancel-redundant-job@v1
       - uses: actions/checkout@v2
         name: Checkout the repository
         with:
@@ -187,6 +192,7 @@ jobs:
         sundials-ver: [ 2, 3, 4, 5.3 ]
       fail-fast: false
     steps:
+      - uses: technote-space/auto-cancel-redundant-job@v1
       - uses: actions/checkout@v2
         name: Checkout the repository
         with:
@@ -218,6 +224,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 60
     steps:
+    - uses: technote-space/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
@@ -266,6 +273,7 @@ jobs:
             python-version: '3.8'
       fail-fast: false
     steps:
+      - uses: technote-space/auto-cancel-redundant-job@v1
       - uses: actions/checkout@v2
         name: Checkout the repository
         with:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

The current timeout limit for CI runners is the default (360 minutes)

- Coverage run limited to 90 minutes
- All other runs limited to 60 minutes

**If applicable, fill in the issue number this pull request is fixing**

Fixes #893

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
