### PR TITLE
[Input] Improve handling of YAML null values

### DIFF
--- a/include/cantera/base/AnyMap.inl.h
+++ b/include/cantera/base/AnyMap.inl.h
@@ -26,7 +26,7 @@ const T &AnyValue::as() const {
         if (m_value->type() == typeid(void)) {
             // Values that have not been set are of type 'void'
             throw InputFileError("AnyValue::as", *this,
-                "Key '{}' not found", m_key);
+                "Key '{}' not found or contains no value", m_key);
         } else {
             throw InputFileError("AnyValue::as", *this,
                 "Key '{}' contains a '{}',\nnot a '{}'",
@@ -48,7 +48,7 @@ T &AnyValue::as() {
         if (m_value->type() == typeid(void)) {
             // Values that have not been set are of type 'void'
             throw InputFileError("AnyValue::as", *this,
-                "Key '{}' not found", m_key);
+                "Key '{}' not found or contains no value", m_key);
         } else {
             throw InputFileError("AnyValue::as", *this,
                 "Key '{}' contains a '{}',\nnot a '{}'",

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -245,6 +245,9 @@ struct convert<Cantera::AnyValue> {
         } else if (node.IsMap()) {
             target = node.as<AnyMap>();
             return true;
+        } else if (node.IsNull()) {
+            target = Empty;
+            return true;
         }
         return false;
     }

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -292,6 +292,23 @@ TEST(AnyMap, iterators)
     EXPECT_TRUE(std::find(keys.begin(), keys.end(), "bar") != keys.end());
 }
 
+TEST(AnyMap, null_values)
+{
+    AnyMap m = AnyMap::fromYamlString(
+        "{a: 1, b: ~, c: , d: 5}"
+    );
+    EXPECT_EQ(m.size(), (size_t) 4);
+    EXPECT_TRUE(m.at("c").is<void>());
+
+    try {
+        m.at("b").asString();
+        FAIL();
+    } catch (CanteraError& err) {
+        EXPECT_THAT(err.what(),
+                    testing::HasSubstr("Key 'b' not found or contains no value"));
+    }
+}
+
 TEST(AnyMap, loadYaml)
 {
     AnyMap m = AnyMap::fromYamlString(


### PR DESCRIPTION
**Changes proposed in this pull request**

- YAML documents containing null values no longer generate `bad conversion` errors while parsing.
- Modify error messages generated by null values to indicate that the error can be caused by either a missing key or a key with no value.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
