### PR TITLE
Fix Redlich-Kwong equilibrium calculations

### DIFF
--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -596,7 +596,7 @@ public:
     virtual bool addSpecies(shared_ptr<Species> spec);
     virtual void initThermo();
     virtual void initThermoXML(XML_Node& phaseNode, const std::string& id);
-    virtual void setToEquilState(const doublereal* lambda_RT);
+    virtual void setToEquilState(const doublereal* mu_RT);
 
     //! Set the form for the standard and generalized concentrations
     /*!

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -176,7 +176,6 @@ public:
 
     virtual bool addSpecies(shared_ptr<Species> spec);
     virtual void setParametersFromXML(const XML_Node& thermoNode);
-    virtual void setToEquilState(const doublereal* lambda_RT);
     virtual void initThermoXML(XML_Node& phaseNode, const std::string& id);
     virtual void initThermo();
 

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1457,10 +1457,10 @@ public:
      * temperature is unchanged.  Any phase (ideal or not) that
      * implements this method can be equilibrated by ChemEquil.
      *
-     * @param lambda_RT Input vector of dimensionless element potentials
-     *                  The length is equal to nElements().
+     * @param mu_RT Input vector of dimensionless chemical potentials
+     *                  The length is equal to nSpecies().
      */
-    virtual void setToEquilState(const doublereal* lambda_RT) {
+    virtual void setToEquilState(const doublereal* mu_RT) {
         throw NotImplementedError("ThermoPhase::setToEquilState");
     }
 

--- a/interfaces/cython/cantera/test/test_equilibrium.py
+++ b/interfaces/cython/cantera/test/test_equilibrium.py
@@ -216,3 +216,13 @@ class TestEquil_GasCarbon(utilities.CanteraTest):
 
     def test_vcs_est(self):
         self.solve('vcs', estimate_equil=-1)
+
+
+class Test_IdealSolidSolnPhase_Equil(utilities.CanteraTest):
+    def test_equil(self):
+        gas = ct.ThermoPhase('IdealSolidSolnPhaseExample.xml')
+        gas.TPX = 500, ct.one_atm, 'C2H2-graph: 1.0'
+
+        gas.equilibrate('TP', solver='element_potential')
+        self.assertNear(gas['C-graph'].X[0], 2.0 / 3.0)
+        self.assertNear(gas['H2-solute'].X[0], 1.0 / 3.0)

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -518,36 +518,6 @@ doublereal RedlichKwongMFTP::critDensity() const
     return mmw / vc;
 }
 
-void RedlichKwongMFTP::setToEquilState(const doublereal* mu_RT)
-{
-    double tmp, tmp2;
-    _updateReferenceStateThermo();
-    getGibbs_RT_ref(m_tmpV.data());
-
-    // Within the method, we protect against inf results if the exponent is too
-    // high.
-    //
-    // If it is too low, we set the partial pressure to zero. This capability is
-    // needed by the elemental potential method.
-    doublereal pres = 0.0;
-    double m_p0 = refPressure();
-    for (size_t k = 0; k < m_kk; k++) {
-        tmp = -m_tmpV[k] + mu_RT[k];
-        if (tmp < -600.) {
-            m_pp[k] = 0.0;
-        } else if (tmp > 500.0) {
-            tmp2 = tmp / 500.;
-            tmp2 *= tmp2;
-            m_pp[k] = m_p0 * exp(500.) * tmp2;
-        } else {
-            m_pp[k] = m_p0 * exp(tmp);
-        }
-        pres += m_pp[k];
-    }
-    // set state
-    setState_PX(pres, &m_pp[0]);
-}
-
 bool RedlichKwongMFTP::addSpecies(shared_ptr<Species> spec)
 {
     bool added = MixtureFugacityTP::addSpecies(spec);


### PR DESCRIPTION
**Changes proposed in this pull request**

- Fix documentation of `ThermoPhase::setToEquilState`: The values passed into this function are the nondimensional (species) chemical potentials, not the element potentials. The method `ChemEquil::setToEquilState` already handles calculation of the chemical potentials from the element potentials.
- Fix use of element potential method with `IdealSolidSolnPhase`: The implementation of  `IdealSolidSolnPhase::setToEquilState` incorrectly used the input array as the element potentials rather than the species chemical potentials. The modified implementation corresponds to that of the `IdealGasPhase` class. The previous implementation seems to generally have resulted in an exception being raised, which normally results in falling back to the Gibbs solver, so this shouldn't have been producing incorrect results.
- Remove incorrect `RedlichKwongMFTP::setToEquilState` implementation: The inversion of setting the mole fractions based on the chemical potentials is not obvious for non-ideal phases, and the implementation here based on an ideal phase leads to incorrect equilibrium solutions.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #847. 

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
