### PR TITLE
Minor fixes in AnyValue and scons

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1410,6 +1410,7 @@ env['debian'] = any(name.endswith('dist-packages') for name in sys.path)
 
 # Directories where things will be after actually being installed. These
 # variables are the ones that are used to populate header files, scripts, etc.
+env['prefix'] = os.path.normpath(env['prefix'])
 env['ct_installroot'] = env['prefix']
 env['ct_libdir'] = pjoin(env['prefix'], env['libdirname'])
 env['ct_bindir'] = pjoin(env['prefix'], 'bin')
@@ -1781,15 +1782,18 @@ def postInstallMessage(target, source, env):
         """.format(**env_dict))
 
     if os.name != 'nt':
+        env['setup_cantera'] = pjoin(env['ct_bindir'], 'setup_cantera')
+        env['setup_cantera_csh'] = pjoin(env['ct_bindir'], 'setup_cantera.csh')
         install_message += textwrap.dedent("""
+
             Setup scripts to configure the environment for Cantera are at:
 
-              setup script (bash)         {ct_bindir!s}/setup_cantera
-              setup script (csh/tcsh)     {ct_bindir!s}/setup_cantera.csh
+              setup script (bash)         {setup_cantera!s}
+              setup script (csh/tcsh)     {setup_cantera_csh!s}
 
             It is recommended that you run the script for your shell by typing:
 
-              source {ct_bindir!s}/setup_cantera
+              source {setup_cantera!s}
 
             before using Cantera, or else include its contents in your shell login script.
         """.format(**env_dict))

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -83,14 +83,13 @@ localenv.Depends(ext, localenv['cantera_staticlib'])
 
 for f in (mglob(localenv, 'cantera', 'py') +
           mglob(localenv, 'cantera/test', 'py') +
-          mglob(localenv, 'cantera/examples/tutorial', 'py') +
-          mglob(localenv, 'cantera/examples/equilibrium', 'py') +
           mglob(localenv, 'cantera/examples/kinetics', 'py') +
-          mglob(localenv, 'cantera/examples/transport', 'py') +
-          mglob(localenv, 'cantera/examples/reactors', 'py') +
+          mglob(localenv, 'cantera/examples/multiphase', 'py') +
           mglob(localenv, 'cantera/examples/onedim', 'py') +
+          mglob(localenv, 'cantera/examples/reactors', 'py') +
           mglob(localenv, 'cantera/examples/surface_chemistry', 'py') +
-          mglob(localenv, 'cantera/examples/misc', 'py')):
+          mglob(localenv, 'cantera/examples/thermo', 'py') +
+          mglob(localenv, 'cantera/examples/transport', 'py')):
     localenv.Depends(mod, f)
 
 # Determine installation path and install the Python module

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -190,7 +190,12 @@ struct convert<Cantera::AnyValue> {
         if (node.IsScalar()) {
             // Scalar nodes are int, doubles, or strings
             std::string nodestr = node.as<std::string>();
-            if (isInt(nodestr)) {
+            if (node.Tag() == "!") {
+                // Prevent quoted strings from being implicitly converted to
+                // numeric types, e.g. the quoted YAML string '12345' should not
+                // be interpreted as an integer
+                target = nodestr;
+            } else if (isInt(nodestr)) {
                 try {
                     target = node.as<long int>();
                 } catch (YAML::BadConversion&) {

--- a/test/data/ch4_ion.yaml
+++ b/test/data/ch4_ion.yaml
@@ -85,7 +85,7 @@ species:
     rotational-relaxation: 4.00
     dispersion-coefficient: 2.995
     quadrupole-polarizability: 3.602
-    note: 121286
+  note: '121286'
 
 - name: H3O+
   composition: {H: 3, O: 1, E: -1}

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -40,6 +40,19 @@ TEST(AnyValue, getMapWhere_initial_list)
     EXPECT_EQ(m["data"].getMapWhere("a", "baz")["x"].asInt(), 4);
 }
 
+TEST(AnyValue, numeric_yaml_string)
+{
+    AnyMap m = AnyMap::fromYamlString(
+        "data: {a: '12345', b: '123.45', 'c': 12345, 'd': 123.45}");
+
+    EXPECT_THROW(m["data"]["a"].asInt(), CanteraError);
+    EXPECT_EQ(m["data"]["a"].asString(), "12345");
+    EXPECT_THROW(m["data"]["b"].asDouble(), CanteraError);
+    EXPECT_EQ(m["data"]["b"].asString(), "123.45");
+    EXPECT_EQ(m["data"]["c"].asInt(), 12345);
+    EXPECT_EQ(m["data"]["d"].asDouble(), 123.45);
+}
+
 TEST(AnyValue, getMapWhere_initial_map)
 {
     AnyMap m = AnyMap::fromYamlString(


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- ensure that a YAML field: `some-field: '12345'` is read as a string by the C++ parser (which currently returns an integer)
- make C++ parser consistent with `ruamel.yaml`
- Also: minor formatting update in scons output (mixed windows/linux style `os.path.sep`s in install message on windows)

This is a minor fix that is left over after closing #881. Also cherry-picking minor fixes from #892 to ensure that fixes of existing features survive.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
