### PR TITLE
Support file I/O for string columns in SolutionArray

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -963,8 +963,7 @@ class SolutionArray:
             data_dict = OrderedDict()
             for label in data.dtype.names:
                 if data[label].dtype.type == np.bytes_:
-                    dtype = '<U' + str(data[label].dtype)[2:]
-                    data_dict[label] = data[label].astype(dtype)
+                    data_dict[label] = data[label].astype('U')
                 else:
                     data_dict[label] = data[label]
         else:
@@ -1127,8 +1126,7 @@ class SolutionArray:
                 dgroup.attrs[key] = val
             for header, value in data.items():
                 if value.dtype.type == np.str_:
-                    dtype = '|S' + str(value.dtype)[2:]
-                    dgroup.create_dataset(header, data=value.astype(dtype),
+                    dgroup.create_dataset(header, data=value.astype('S'),
                                           **hdf_kwargs)
                 else:
                     dgroup.create_dataset(header, data=value, **hdf_kwargs)
@@ -1222,8 +1220,7 @@ class SolutionArray:
                 if name == 'phase':
                     continue
                 elif value.dtype.type == np.bytes_:
-                    dtype = '<U' + str(value.dtype)[2:]
-                    data[name] = np.array(value).astype(dtype)
+                    data[name] = np.array(value).astype('U')
                 else:
                     data[name] = np.array(value)
 
@@ -1327,7 +1324,10 @@ def _make_functions():
         return np.empty(self._shape)
 
     def empty_strings(self):
-        return np.empty(self._shape, dtype='<U50')
+        # The maximum length of strings assigned by built-in methods is
+        # currently limited to 50 characters; an attempt to assign longer
+        # character arrays will result in truncated strings.
+        return np.empty(self._shape, dtype='U50')
 
     def empty_species(self):
         return np.empty(self._shape + (self._phase.n_selected_species,))

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -448,6 +448,7 @@ class SolutionArray:
         # From Transport
         'viscosity', 'electrical_conductivity', 'thermal_conductivity',
     ]
+    _strings = ['phase_of_matter']
     _n_species = [
         # from ThermoPhase
         'Y', 'X', 'concentrations', 'partial_molar_enthalpies',
@@ -1326,6 +1327,9 @@ def _make_functions():
     def empty_scalar(self):
         return np.empty(self._shape)
 
+    def empty_strings(self):
+        return np.empty(self._shape, dtype='<U14')
+
     def empty_species(self):
         return np.empty(self._shape + (self._phase.n_selected_species,))
 
@@ -1351,6 +1355,9 @@ def _make_functions():
 
     for name in SolutionArray._scalar:
         setattr(SolutionArray, name, make_prop(name, empty_scalar, Solution))
+
+    for name in SolutionArray._strings:
+        setattr(SolutionArray, name, make_prop(name, empty_strings, Solution))
 
     for name in SolutionArray._n_species:
         setattr(SolutionArray, name, make_prop(name, empty_species, Solution))

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -4,7 +4,6 @@
 from ._cantera import *
 import numpy as np
 from collections import OrderedDict
-from distutils import version
 import csv as _csv
 
 import pkg_resources
@@ -957,14 +956,14 @@ class SolutionArray:
         using `restore_data`. This method allows for recreation of data
         previously exported by `write_csv`.
         """
-        if version.LooseVersion(np.__version__) < version.LooseVersion("1.14"):
+        if np.lib.NumpyVersion(np.__version__) < "1.14.0":
             # bytestring needs to be converted for columns containing strings
             data = np.genfromtxt(filename, delimiter=',',
                                  dtype=None, names=True)
             data_dict = OrderedDict()
             for label in data.dtype.names:
                 if data[label].dtype.type == np.bytes_:
-                    dtype = '<U' + data[label].dtype.__str__()[2:]
+                    dtype = '<U' + str(data[label].dtype)[2:]
                     data_dict[label] = data[label].astype(dtype)
                 else:
                     data_dict[label] = data[label]
@@ -1128,7 +1127,7 @@ class SolutionArray:
                 dgroup.attrs[key] = val
             for header, value in data.items():
                 if value.dtype.type == np.str_:
-                    dtype = '|S' + value.dtype.__str__()[2:]
+                    dtype = '|S' + str(value.dtype)[2:]
                     dgroup.create_dataset(header, data=value.astype(dtype),
                                           **hdf_kwargs)
                 else:
@@ -1221,9 +1220,9 @@ class SolutionArray:
             data = OrderedDict()
             for name, value in dgroup.items():
                 if name == 'phase':
-                    pass
+                    continue
                 elif value.dtype.type == np.bytes_:
-                    dtype = '<U' + value.dtype.__str__()[2:]
+                    dtype = '<U' + str(value.dtype)[2:]
                     data[name] = np.array(value).astype(dtype)
                 else:
                     data[name] = np.array(value)
@@ -1328,7 +1327,7 @@ def _make_functions():
         return np.empty(self._shape)
 
     def empty_strings(self):
-        return np.empty(self._shape, dtype='<U14')
+        return np.empty(self._shape, dtype='<U50')
 
     def empty_species(self):
         return np.empty(self._shape + (self._phase.n_selected_species,))

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -168,7 +168,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
 
         b = ct.SolutionArray(self.gas, extra={'spam'})
         b.read_csv(outfile)
-        self.assertTrue((states.spam == b.spam).all())
+        self.assertEqual(list(states.spam), list(b.spam))
 
     @utilities.unittest.skipIf(isinstance(_pandas, ImportError), "pandas is not installed")
     def test_to_pandas(self):
@@ -237,7 +237,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
 
         b = ct.SolutionArray(self.gas, extra={'spam'})
         b.read_hdf(outfile)
-        self.assertTrue((states.spam == b.spam).all())
+        self.assertEqual(list(states.spam), list(b.spam))
 
 
 class TestRestoreIdealGas(utilities.CanteraTest):

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -168,7 +168,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
 
         b = ct.SolutionArray(self.gas, extra={'spam'})
         b.read_csv(outfile)
-        self.assertTrue((states.spam == b.spam).all)
+        self.assertTrue((states.spam == b.spam).all())
 
     @utilities.unittest.skipIf(isinstance(_pandas, ImportError), "pandas is not installed")
     def test_to_pandas(self):
@@ -228,6 +228,17 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         states.write_hdf(outfile, group='foo/bar/baz')
         c.read_hdf(outfile, group='foo/bar/baz')
         self.assertTrue(np.allclose(states.T, c.T))
+
+    def test_write_hdf_str_column(self):
+        states = ct.SolutionArray(self.gas, 3, extra={'spam': 'eggs'})
+
+        outfile = pjoin(self.test_work_dir, 'solutionarray.h5')
+        states.write_hdf(outfile, mode='w')
+
+        b = ct.SolutionArray(self.gas, extra={'spam'})
+        b.read_hdf(outfile)
+        self.assertTrue((states.spam == b.spam).all())
+
 
 class TestRestoreIdealGas(utilities.CanteraTest):
     """ Test restoring of the IdealGas class """

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -160,6 +160,16 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertTrue(np.allclose(states.P, b.P))
         self.assertTrue(np.allclose(states.X, b.X))
 
+    def test_write_csv_str_column(self):
+        states = ct.SolutionArray(self.gas, 3, extra={'spam': 'eggs'})
+
+        outfile = pjoin(self.test_work_dir, 'solutionarray.csv')
+        states.write_csv(outfile)
+
+        b = ct.SolutionArray(self.gas, extra={'spam'})
+        b.read_csv(outfile)
+        self.assertTrue((states.spam == b.spam).all)
+
     @utilities.unittest.skipIf(isinstance(_pandas, ImportError), "pandas is not installed")
     def test_to_pandas(self):
 

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1794,8 +1794,8 @@ class TestSolutionArray(utilities.CanteraTest):
         P = [101325, 101325, 101325, water.critical_pressure*2]
         states[:4].TP = T, P
         states[4].TQ = 300, .4
-        pom = np.array(['liquid', 'gas', 'supercritical', 'supercritical', 'liquid-gas-mix'])
-        self.assertTrue((states.phase_of_matter == pom).all())
+        pom = ['liquid', 'gas', 'supercritical', 'supercritical', 'liquid-gas-mix']
+        self.assertEqual(list(states.phase_of_matter), pom)
 
     def test_purefluid_getters(self):
         N = 11

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1787,6 +1787,16 @@ class TestSolutionArray(utilities.CanteraTest):
         states.TP = np.linspace(400, 500, 5), 101325
         self.assertArrayNear(states.Q.squeeze(), np.ones(5))
 
+    def test_phase_of_matter(self):
+        water = ct.Water()
+        states = ct.SolutionArray(water, 5)
+        T = [300, 500, water.critical_temperature*2, 300]
+        P = [101325, 101325, 101325, water.critical_pressure*2]
+        states[:4].TP = T, P
+        states[4].TQ = 300, .4
+        pom = np.array(['liquid', 'gas', 'supercritical', 'supercritical', 'liquid-gas-mix'])
+        self.assertTrue((states.phase_of_matter == pom).all())
+
     def test_purefluid_getters(self):
         N = 11
         water = ct.Water()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Enable CSV import of string columns
- Enable HDF export/import of string columns
- Add `phase_of_matter` to `SolutionArray`

**If applicable, fill in the issue number this pull request is fixing**

Fixes #896

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
