### PR TITLE
Limit ci runtime / cancel redundant jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,6 +1,8 @@
 name: CI
 
 on:
+  repository_dispatch:
+    types: [test]
   push:
     # Build on tags that look like releases
     tags:
@@ -18,11 +20,13 @@ jobs:
   ubuntu-multiple-pythons:
     name: Ubuntu 18.04 with Python ${{ matrix.python-version }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [ '3.5', '3.6', '3.7', '3.8' ]
       fail-fast: false
     steps:
+    - uses: technote-space/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
@@ -46,11 +50,13 @@ jobs:
   macos-multiple-pythons:
     name: macOS with Python ${{ matrix.python-version }}
     runs-on: macos-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         python-version: [ '3.5', '3.6', '3.7', '3.8' ]
       fail-fast: false
     steps:
+    - uses: technote-space/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
@@ -78,8 +84,10 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
+    timeout-minutes: 360
     needs: [ubuntu-multiple-pythons]
     steps:
+    - uses: technote-space/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
@@ -110,7 +118,9 @@ jobs:
   docs:
     name: Build docs
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
+      - uses: technote-space/auto-cancel-redundant-job@v1
       - uses: actions/checkout@v2
         name: Checkout the repository
         with:
@@ -155,7 +165,9 @@ jobs:
     # Ubuntu 18.04 using Python 2 to run SCons and the system Python 3 for the interface
     name: Python 2 running SCons on Ubuntu 18.04
     runs-on: ubuntu-18.04
+    timeout-minutes: 60
     steps:
+      - uses: technote-space/auto-cancel-redundant-job@v1
       - uses: actions/checkout@v2
         name: Checkout the repository
         with:
@@ -212,11 +224,13 @@ jobs:
   multiple-sundials:
     name: Sundials ${{ matrix.sundials-ver }}
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     strategy:
       matrix:
         sundials-ver: [ 2, 3, 4, 5.3 ]
       fail-fast: false
     steps:
+      - uses: technote-space/auto-cancel-redundant-job@v1
       - uses: actions/checkout@v2
         name: Checkout the repository
         with:
@@ -246,7 +260,9 @@ jobs:
   cython-latest:
     name: Test pre-release version of Cython
     runs-on: ubuntu-latest
+    timeout-minutes: 60
     steps:
+    - uses: technote-space/auto-cancel-redundant-job@v1
     - uses: actions/checkout@v2
       name: Checkout the repository
       with:
@@ -272,6 +288,7 @@ jobs:
   windows:
     name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
     strategy:
       matrix:
         os: ['windows-2019']
@@ -294,6 +311,7 @@ jobs:
             python-version: '3.8'
       fail-fast: false
     steps:
+      - uses: technote-space/auto-cancel-redundant-job@v1
       - uses: actions/checkout@v2
         name: Checkout the repository
         with:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Same as #894 (after force-pushing while PR was closed I can no longer reopen)

- reduce time-out limit
- cancel redundant jobs

**If applicable, fill in the issue number this pull request is fixing**

Fixes #893 

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**Thoughts**

* https://github.com/technote-space/auto-cancel-redundant-job
* https://docs.github.com/en/actions/reference/events-that-trigger-workflows#repository_dispatch

Per @bryanwweber's comment 

> One of the things I've seen in some of the Issues on these actions is is that the person doing the push has to have enough rights to cancel the workflow run in the GUI for them to work correctly. I saw a few comments recommending alternate actions that appeared to work better, but I can't recall where anymore