### PR TITLE
Fix edge cases for saturated PureFluid states / illustrate saturated water properties

### DIFF
--- a/include/cantera/tpx/Sub.h
+++ b/include/cantera/tpx/Sub.h
@@ -146,8 +146,10 @@ public:
     //! is returned if v > Vcrit.
     double x();
 
-    //! Returns 1 if the current state is a liquid/vapor mixture, 0 otherwise
-    int TwoPhase();
+    //! Returns 1 if the current state is a liquid/vapor mixture, 0 otherwise.
+    //! By default, saturated vapor and saturated liquid are included; setting
+    //! the flag *strict* to true will exclude the boundaries.
+    int TwoPhase(bool strict=false);
     //! @}
 
     virtual double Pp()=0;

--- a/interfaces/cython/cantera/examples/thermo/vapordome.py
+++ b/interfaces/cython/cantera/examples/thermo/vapordome.py
@@ -1,0 +1,94 @@
+"""
+This example generates a saturated steam table and plots the vapor dome. The
+steam table corresponds to data typically found in thermodynamic text books
+and uses the same customary units.
+
+Requires: Cantera >= 2.5.0, matplotlib >= 2.0, pandas >= 1.1.0, numpy >= 1.12
+"""
+
+import cantera as ct
+import pandas as pd
+import numpy as np
+from matplotlib import pyplot as plt
+
+w = ct.Water()
+
+# create colums
+columns = ['T', 'P',
+           'vf', 'vfg', 'vg',
+           'uf', 'ufg', 'ug',
+           'hf', 'hfg', 'hg',
+           'sf', 'sfg', 'sg']
+
+# temperatures correspond to Engineering Thermodynamics, Moran et al. (9th ed),
+# Table A-2; additional data points are added close to the critical point;
+# w.min_temp is equal to the triple point temperature
+degc = np.hstack([np.array([w.min_temp - 273.15, 4, 5, 6, 8]),
+                  np.arange(10, 37), np.array([38]),
+                  np.arange(40, 100, 5), np.arange(100, 300, 10),
+                  np.arange(300, 380, 20), np.arange(370, 374),
+                  np.array([w.critical_temperature - 273.15])])
+
+df = pd.DataFrame(0, index=np.arange(len(degc)), columns=columns)
+df.T = degc
+
+arr = ct.SolutionArray(w, len(degc))
+
+# saturated vapor data
+arr.TQ = degc + 273.15, 1
+df.P = arr.P_sat / 1.e5
+df.vg = arr.v
+df.ug = arr.int_energy_mass / 1.e3
+df.hg = arr.enthalpy_mass / 1.e3
+df.sg = arr.entropy_mass / 1.e3
+
+# saturated liquid data
+arr.TQ = degc + 273.15, 0
+df.vf = arr.v
+df.uf = arr.int_energy_mass / 1.e3
+df.hf = arr.enthalpy_mass / 1.e3
+df.sf = arr.entropy_mass / 1.e3
+
+# delta values
+df.vfg = df.vg - df.vf
+df.ufg = df.ug - df.uf
+df.hfg = df.hg - df.hf
+df.sfg = df.sg - df.sf
+
+# reference state (triple point; liquid state)
+w.TQ = w.min_temp, 0
+uf0 = w.int_energy_mass / 1.e3
+hf0 = w.enthalpy_mass / 1.e3
+sf0 = w.entropy_mass / 1.e3
+pv0 = w.P * w.v / 1.e3
+
+# change reference state
+df.ug -= uf0
+df.uf -= uf0
+df.hg -= hf0 - pv0
+df.hf -= hf0 - pv0
+df.sg -= sf0
+df.sf -= sf0
+
+# print and write saturated steam table to csv file
+print(df)
+df.to_csv('saturated_steam_T.csv', index=False)
+
+# illustrate the vapor dome in a P-v diagram
+plt.semilogx(df.vf.values, df.P.values, label='Saturated liquid')
+plt.semilogx(df.vg.values, df.P.values, label='Saturated vapor')
+plt.semilogx(df.vg.values[-1], df.P.values[-1], 'o', label='Critical point')
+plt.xlabel(r'Specific volume - $v$ ($\mathrm{m^3/kg}$)')
+plt.ylabel(r'Presssure - $P$ (bar)')
+plt.legend()
+
+# illustrate the vapor dome in a T-s diagram
+plt.figure()
+plt.plot(df.sf.values, df['T'].values, label='Saturated liquid')
+plt.plot(df.sg.values, df['T'].values, label='Saturated vapor')
+plt.plot(df.sg.values[-1], df['T'].values[-1], 'o', label='Critical point')
+plt.xlabel(r'Specific entropy - $s$ ($\mathrm{kJ/kg-K}$)')
+plt.ylabel(r'Temperature - $T$ (${}^\circ C$)')
+plt.legend()
+
+plt.show()

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -180,9 +180,9 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertNear(self.water.T, self.water.critical_temperature)
 
         # Supercritical
-        with self.assertRaisesRegex(ct.CanteraError, 'above the critical point'):
+        with self.assertRaisesRegex(ct.CanteraError, 'supercritical'):
             self.water.TQ = 1.001 * self.water.critical_temperature, 0.
-        with self.assertRaisesRegex(ct.CanteraError, 'above the critical point'):
+        with self.assertRaisesRegex(ct.CanteraError, 'supercritical'):
             self.water.PQ = 1.001 * self.water.critical_pressure, 0.
 
         # Q negative
@@ -201,6 +201,27 @@ class TestPureFluid(utilities.CanteraTest):
         self.water.TP = 300, ct.one_atm
         with self.assertRaisesRegex(ct.CanteraError, 'Saturated mixture detected'):
             self.water.TP = 300, self.water.P_sat
+
+        # Saturated vapor
+        self.water.TQ = 373.15, 1.
+        self.assertEqual(self.water.phase_of_matter, 'gas')
+        self.assertFalse(np.isinf(self.water.cp_mass))
+        self.assertFalse(np.isinf(self.water.thermal_expansion_coeff))
+        self.assertFalse(np.isinf(self.water.isothermal_compressibility))
+
+        # Saturated mixture
+        self.water.TQ = 373.15, .5
+        self.assertEqual(self.water.phase_of_matter, 'liquid-gas-mix')
+        self.assertTrue(np.isinf(self.water.cp_mass))
+        self.assertTrue(np.isinf(self.water.thermal_expansion_coeff))
+        self.assertTrue(np.isinf(self.water.isothermal_compressibility))
+
+        # Saturated liquid
+        self.water.TQ = 373.15, 0.
+        self.assertEqual(self.water.phase_of_matter, 'liquid')
+        self.assertFalse(np.isinf(self.water.cp_mass))
+        self.assertFalse(np.isinf(self.water.thermal_expansion_coeff))
+        self.assertFalse(np.isinf(self.water.isothermal_compressibility))
 
     def test_saturation_near_limits(self):
         # Low temperature limit (triple point)

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -259,9 +259,10 @@ class TestPureFluid(utilities.CanteraTest):
         with self.assertRaisesRegex(ct.CanteraError, 'Illegal temperature'):
             self.water.TP = .999 * self.water.min_temp, ct.one_atm
             self.water.P_sat
-        with self.assertRaisesRegex(ct.CanteraError, 'Illegal pressure value'):
-            self.water.TP = 300, .999 * psat
-            self.water.T_sat
+        # Test disabled pending fix of GitHub issue #605
+        # with self.assertRaisesRegex(ct.CanteraError, 'Illegal pressure value'):
+        #     self.water.TP = 300, .999 * psat
+        #     self.water.T_sat
 
     def test_TPQ(self):
         self.water.TQ = 400, 0.8

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -197,6 +197,11 @@ class TestPureFluid(utilities.CanteraTest):
         with self.assertRaisesRegex(ct.CanteraError, 'Invalid vapor fraction'):
             self.water.PQ = ct.one_atm, 1.001
 
+    def test_saturated_mixture(self):
+        self.water.TP = 300, ct.one_atm
+        with self.assertRaisesRegex(ct.CanteraError, 'Saturated mixture detected'):
+            self.water.TP = 300, self.water.P_sat
+
     def test_saturation_near_limits(self):
         # Low temperature limit (triple point)
         self.water.TP = 300, ct.one_atm

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -274,7 +274,7 @@ class TestPureFluid(utilities.CanteraTest):
         with self.assertRaisesRegex(ct.CanteraError, 'Illegal temperature'):
             self.water.TP = .999 * self.water.min_temp, ct.one_atm
             self.water.P_sat
-        # Test disabled pending fix of GitHub issue #605
+        # @TODO: test disabled pending fix of GitHub issue #605
         # with self.assertRaisesRegex(ct.CanteraError, 'Illegal pressure value'):
         #     self.water.TP = 300, .999 * psat
         #     self.water.T_sat

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -200,7 +200,7 @@ class TestPureFluid(utilities.CanteraTest):
 
         # Saturated vapor
         self.water.TQ = 373.15, 1.
-        self.assertEqual(self.water.phase_of_matter, 'gas')
+        self.assertEqual(self.water.phase_of_matter, 'liquid-gas-mix')
         w.TP = self.water.T, .999 * self.water.P_sat
         self.assertNear(self.water.cp, w.cp, 1.e-3)
         self.assertNear(self.water.cv, w.cv, 1.e-3)
@@ -217,7 +217,7 @@ class TestPureFluid(utilities.CanteraTest):
 
         # Saturated liquid
         self.water.TQ = 373.15, 0.
-        self.assertEqual(self.water.phase_of_matter, 'liquid')
+        self.assertEqual(self.water.phase_of_matter, 'liquid-gas-mix')
         w.TP = self.water.T, 1.001 * self.water.P_sat
         self.assertNear(self.water.cp, w.cp, 1.e-3)
         self.assertNear(self.water.cv, w.cv, 1.e-3)

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -90,7 +90,7 @@ std::string PureFluidPhase::phaseOfMatter() const
         return "supercritical";
     } else if (m_sub->TwoPhase() == 1) {
         return "liquid-gas-mix";
-    } else if (pressure() < m_sub->Ps()) {
+    } else if (m_sub->x() == 1) {
         return "gas";
     } else {
         return "liquid";

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -90,7 +90,7 @@ std::string PureFluidPhase::phaseOfMatter() const
         return "supercritical";
     } else if (m_sub->TwoPhase() == 1) {
         return "liquid-gas-mix";
-    } else if (m_sub->x() == 1) {
+    } else if (pressure() < m_sub->Ps()) {
         return "gas";
     } else {
         return "liquid";

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -290,8 +290,13 @@ double Substance::x()
 double Substance::Tsat(double p)
 {
     double Tsave = T;
-    T = Tmin();
-    if (p < Ps() || p > Pcrit()) {
+    if (p <= 0. || p > Pcrit()) {
+        // TODO: this check should also fail below the triple point pressure
+        // (calculated as Ps() for Tmin() as it is not available as a numerical
+        // parameter). A bug causing low-temperature TP setters to fail for
+        // Heptane (GitHub issue #605) prevents this at the moment.
+        // Without this check, a calculation attempt fails with the less
+        // meaningful error "No convergence" below.
         throw CanteraError("Substance::Tsat",
                            "Illegal pressure value: {}", p);
     }

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -327,15 +327,17 @@ void Substance::Set(PropertyPair::type XY, double x0, double y0)
                x0, y0, TolAbsP, TolAbsV, TolRel, TolRel);
         break;
     case PropertyPair::TP:
+        set_T(x0);
         if (x0 < Tcrit()) {
-            set_T(x0);
-            if (y0 < Ps()) {
+            if (fabs(y0 - Ps()) / y0 < TolRel) {
+                throw CanteraError("Substance::Set",
+                                   "Saturated mixture detected: use vapor "
+                                   "fraction to specify state instead");
+            } else if (y0 < Ps()) {
                 Set(PropertyPair::TX, x0, 1.0);
             } else {
                 Set(PropertyPair::TX, x0, 0.0);
             }
-        } else {
-            set_T(x0);
         }
         set_xy(propertyFlag::T, propertyFlag::P,
                x0, y0, TolAbsT, TolAbsP, TolRel, TolRel);

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -431,33 +431,34 @@ void Substance::Set(PropertyPair::type XY, double x0, double y0)
         break;
     case PropertyPair::PX:
         temp = Tmin();
+        set_T(temp);
         if (y0 > 1.0 || y0 < 0.0) {
             throw CanteraError("Substance::Set",
                                "Invalid vapor fraction, {}", y0);
-        } else if (x0 < Ps() || x0 > Pcrit()) {
+        }
+        if (x0 < Ps() || x0 > Pcrit()) {
             throw CanteraError("Substance::Set",
                                "Illegal pressure value: {} (supercritical "
-                               "or below triple line)", x0);
-        } else {
-            temp = Tsat(x0);
-            set_T(temp);
-            update_sat();
-            Rho = 1.0/((1.0 - y0)/Rhf + y0/Rhv);
+                               "or below triple point)", x0);
         }
+        temp = Tsat(x0);
+        set_T(temp);
+        update_sat();
+        Rho = 1.0/((1.0 - y0)/Rhf + y0/Rhv);
         break;
     case PropertyPair::TX:
         if (y0 > 1.0 || y0 < 0.0) {
             throw CanteraError("Substance::Set",
                                "Invalid vapor fraction, {}", y0);
-        } else if (x0 < Tmin() || x0 > Tcrit()) {
+        }
+        if (x0 < Tmin() || x0 > Tcrit()) {
             throw CanteraError("Substance::Set",
                                "Illegal temperature value: {} "
-                               "(supercritical of below triple line)", x0);
-        } else {
-            set_T(x0);
-            update_sat();
-            Rho = 1.0/((1.0 - y0)/Rhf + y0/Rhv);
+                               "(supercritical or below triple point)", x0);
         }
+        set_T(x0);
+        update_sat();
+        Rho = 1.0/((1.0 - y0)/Rhf + y0/Rhv);
         break;
     default:
         throw CanteraError("Substance::Set", "Invalid input.");

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -54,6 +54,13 @@ const double DeltaT = 0.000001;
 
 double Substance::cv()
 {
+    if (TwoPhase()) {
+        // While cv can be calculated for the two-phase region (the state can
+        // always be continuously varied along an isochor on a T-v diagram),
+        // this calculation is currently not implemented
+        return std::numeric_limits<double>::quiet_NaN();
+    }
+
     double Tsave = T, dt = 1.e-4*T;
     double x0 = x();
     double T1 = std::max(Tmin(), Tsave - dt);

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -294,7 +294,7 @@ double Substance::Tsat(double p)
 {
     double Tsave = T;
     if (p <= 0. || p > Pcrit()) {
-        // TODO: this check should also fail below the triple point pressure
+        // @TODO: this check should also fail below the triple point pressure
         // (calculated as Ps() for Tmin() as it is not available as a numerical
         // parameter). A bug causing low-temperature TP setters to fail for
         // Heptane (GitHub issue #605) prevents this at the moment.

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -54,14 +54,14 @@ const double DeltaT = 0.000001;
 
 double Substance::cv()
 {
-    if (TwoPhase()) {
+    if (TwoPhase(true)) {
         // While cv can be calculated for the two-phase region (the state can
         // always be continuously varied along an isochor on a T-v diagram),
         // this calculation is currently not implemented
         return std::numeric_limits<double>::quiet_NaN();
     }
 
-    double Tsave = T, dt = 1.e-4*T;
+    double Tsave = T, dt = 1.e-4 * T;
     double x0 = x();
     double T1 = std::max(Tmin(), Tsave - dt);
     double T2 = std::min(Tmax(), Tsave + dt);
@@ -92,7 +92,7 @@ double Substance::cv()
 
 double Substance::cp()
 {
-    if (TwoPhase()) {
+    if (TwoPhase(true)) {
         // In the two-phase region, cp is infinite
         return std::numeric_limits<double>::infinity();
     }
@@ -144,7 +144,7 @@ double Substance::cp()
 
 double Substance::thermalExpansionCoeff()
 {
-    if (TwoPhase()) {
+    if (TwoPhase(true)) {
         // In the two-phase region, the thermal expansion coefficient is
         // infinite
         return std::numeric_limits<double>::infinity();
@@ -197,7 +197,7 @@ double Substance::thermalExpansionCoeff()
 
 double Substance::isothermalCompressibility()
 {
-    if (TwoPhase()) {
+    if (TwoPhase(true)) {
         // In the two-phase region, the isothermal compressibility is infinite
         return std::numeric_limits<double>::infinity();
     }
@@ -260,13 +260,16 @@ double Substance::dPsdT()
     return dpdt;
 }
 
-int Substance::TwoPhase()
+int Substance::TwoPhase(bool strict)
 {
     if (T >= Tcrit()) {
         return 0;
     }
     update_sat();
-    return ((Rho < Rhf) && (Rho > Rhv) ? 1 : 0);
+    if (strict) {
+        return ((Rho > Rhv) && (Rho < Rhf) ? 1 : 0);
+    }
+    return ((Rho >= Rhv) && (Rho <= Rhf) ? 1 : 0);
 }
 
 double Substance::x()

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -202,8 +202,16 @@ double Substance::dPsdT()
 {
     double tsave = T;
     double ps1 = Ps();
-    T += DeltaT;
-    double dpdt = (Ps() - ps1)/DeltaT;
+    double dpdt;
+    if (T + DeltaT < Tcrit()) {
+        T += DeltaT;
+        dpdt = (Ps() - ps1)/DeltaT;
+    } else if (T - DeltaT > Tmin()) {
+        T -= DeltaT;
+        dpdt = (ps1 - Ps())/DeltaT;
+    } else {
+        throw CanteraError("Substance::dPsdT", "Illegal temperature value");
+    }
     T = tsave;
     return dpdt;
 }
@@ -445,7 +453,7 @@ double Substance::Ps()
 
 void Substance::update_sat()
 {
-    if ((T != Tslast) && (T < Tcrit())) {
+    if ((T != Tslast) && (T <= Tcrit())) {
         double Rho_save = Rho;
         double pp = Psat();
         double lps = log(pp);

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -255,20 +255,13 @@ double Substance::Tsat(double p)
 
     int LoopCount = 0;
     double tol = 1.e-6*p;
-    if (T < Tmin()) {
-        T = 0.5*(Tcrit() - Tmin());
-    }
-    if (T >= Tcrit()) {
+    if (T < Tmin() || T > Tcrit()) {
         T = 0.5*(Tcrit() - Tmin());
     }
     double dp = 10*tol;
     while (fabs(dp) > tol) {
-        if (T > Tcrit()) {
-            T = Tcrit() - 0.001;
-        }
-        if (T < Tmin()) {
-            T = Tmin() + 0.001;
-        }
+        T = std::min(T, Tcrit());
+        T = std::max(T, Tmin());
         dp = p - Ps();
         double dt = dp/dPsdT();
         double dta = fabs(dt);
@@ -280,7 +273,7 @@ double Substance::Tsat(double p)
         LoopCount++;
         if (LoopCount > 100) {
             T = Tsave;
-            throw CanteraError("Substance::Tsat", "No convergence");
+            throw CanteraError("Substance::Tsat", "No convergence: p = {}", p);
         }
     }
     double tsat = T;
@@ -385,9 +378,9 @@ void Substance::Set(PropertyPair::type XY, double x0, double y0)
         if (y0 > 1.0 || y0 < 0.0) {
             throw CanteraError("Substance::Set",
                                "Invalid vapor fraction, {}", y0);
-        } else if (x0 >= Pcrit()) {
+        } else if (x0 > Pcrit()) {
             throw CanteraError("Substance::Set",
-                               "Vapor fraction can only be set below the "
+                               "Vapor fraction cannot be set above the "
                                "critical point");
         } else {
             temp = Tsat(x0);
@@ -400,9 +393,9 @@ void Substance::Set(PropertyPair::type XY, double x0, double y0)
         if (y0 > 1.0 || y0 < 0.0) {
             throw CanteraError("Substance::Set",
                                "Invalid vapor fraction, {}", y0);
-        } else if (x0 >= Tcrit()) {
+        } else if (x0 > Tcrit()) {
             throw CanteraError("Substance::Set",
-                               "Vapor fraction can only be set below the "
+                               "Vapor fraction cannot be set above the "
                                "critical point");
         } else {
             set_T(x0);

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -370,14 +370,15 @@ void Substance::Set(PropertyPair::type XY, double x0, double y0)
                x0, y0, TolAbsS, TolAbsH, TolRel, TolRel);
         break;
     case PropertyPair::PX:
-        temp = Tsat(x0);
         if (y0 > 1.0 || y0 < 0.0) {
             throw CanteraError("Substance::Set",
                                "Invalid vapor fraction, {}", y0);
-        } else if (temp >= Tcrit()) {
+        } else if (x0 >= Pcrit()) {
             throw CanteraError("Substance::Set",
-                               "Can't set vapor fraction above the critical point");
+                               "Vapor fraction can only be set below the "
+                               "critical point");
         } else {
+            temp = Tsat(x0);
             set_T(temp);
             update_sat();
             Rho = 1.0/((1.0 - y0)/Rhf + y0/Rhv);
@@ -389,7 +390,8 @@ void Substance::Set(PropertyPair::type XY, double x0, double y0)
                                "Invalid vapor fraction, {}", y0);
         } else if (x0 >= Tcrit()) {
             throw CanteraError("Substance::Set",
-                               "Can't set vapor fraction above the critical point");
+                               "Vapor fraction can only be set below the "
+                               "critical point");
         } else {
             set_T(x0);
             update_sat();

--- a/src/tpx/Water.cpp
+++ b/src/tpx/Water.cpp
@@ -176,7 +176,7 @@ double water::ldens()
 {
     double sum=0;
     int i;
-    if ((T < Tmn) || (T >= Tc)) {
+    if ((T < Tmn) || (T > Tc)) {
         throw CanteraError("water::ldens",
                            "Temperature out of range. T = {}", T);
     }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- fix `TQ`/`PQ` assignment at critical point
- add example illustrating saturated water properties / vapor dome
- fix various bugs for edge case calculations (critical point / triple point)
- disable `TP` setter for saturated mixtures

**If applicable, fill in the issue number this pull request is fixing**

Fixes #906, fixes #915, fixes #917, fixes #919, fixes #920

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**Thoughts**

I generated a digital version of a saturated steam table for an exam; i am including it here as it could be considered as an example and potentially expanded upon (otherwise I’ll simply drop it).