### PR TITLE
Minor unittest updates

### DIFF
--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -349,7 +349,7 @@ class TestRestoreIdealGas(utilities.CanteraTest):
         b = ct.SolutionArray(self.gas)
         b.restore_data(data)
         check(a, b)
-        self.assertTrue(len(b._extra) == 0)
+        self.assertEqual(len(b._extra), 0)
 
 
 class TestRestorePureFluid(utilities.CanteraTest):

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -156,9 +156,9 @@ class TestSolutionArrayIO(utilities.CanteraTest):
 
         b = ct.SolutionArray(self.gas)
         b.read_csv(outfile)
-        self.assertTrue(np.allclose(states.T, b.T))
-        self.assertTrue(np.allclose(states.P, b.P))
-        self.assertTrue(np.allclose(states.X, b.X))
+        self.assertArrayNear(states.T, b.T)
+        self.assertArrayNear(states.P, b.P)
+        self.assertArrayNear(states.X, b.X)
 
     def test_write_csv_str_column(self):
         states = ct.SolutionArray(self.gas, 3, extra={'spam': 'eggs'})
@@ -200,11 +200,11 @@ class TestSolutionArrayIO(utilities.CanteraTest):
 
         b = ct.SolutionArray(self.gas)
         attr = b.read_hdf(outfile)
-        self.assertTrue(np.allclose(states.T, b.T))
-        self.assertTrue(np.allclose(states.P, b.P))
-        self.assertTrue(np.allclose(states.X, b.X))
-        self.assertTrue(np.allclose(states.foo, b.foo))
-        self.assertTrue(np.allclose(states.bar, b.bar))
+        self.assertArrayNear(states.T, b.T)
+        self.assertArrayNear(states.P, b.P)
+        self.assertArrayNear(states.X, b.X)
+        self.assertArrayNear(states.foo, b.foo)
+        self.assertArrayNear(states.bar, b.bar)
         self.assertEqual(b.meta['spam'], 'eggs')
         self.assertEqual(b.meta['hello'], 'world')
         self.assertEqual(attr['foobar'], 'spam and eggs')
@@ -227,7 +227,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
 
         states.write_hdf(outfile, group='foo/bar/baz')
         c.read_hdf(outfile, group='foo/bar/baz')
-        self.assertTrue(np.allclose(states.T, c.T))
+        self.assertArrayNear(states.T, c.T)
 
     def test_write_hdf_str_column(self):
         states = ct.SolutionArray(self.gas, 3, extra={'spam': 'eggs'})
@@ -279,8 +279,8 @@ class TestRestoreIdealGas(utilities.CanteraTest):
         # skip concentrations
         b = ct.SolutionArray(self.gas)
         b.restore_data({'T': data['T'], 'density': data['density']})
-        self.assertTrue(np.allclose(a.T, b.T))
-        self.assertTrue(np.allclose(a.density, b.density))
+        self.assertArrayNear(a.T, b.T)
+        self.assertArrayNear(a.density, b.density)
         self.assertFalse(np.allclose(a.X, b.X))
 
         # wrong data shape

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -81,15 +81,10 @@ class TestPureFluid(utilities.CanteraTest):
             self.water.Q = 0.3
 
     def test_X_deprecated(self):
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with self.assertWarnsRegex(DeprecationWarning, "after Cantera 2.5"):
             X = self.water.X
+        with self.assertWarnsRegex(DeprecationWarning, "after Cantera 2.5"):
             self.water.TX = 300, 1
-
-            self.assertEqual(len(w), 2)
-            for warning in w:
-                self.assertTrue(issubclass(warning.category, DeprecationWarning))
-                self.assertIn("after Cantera 2.5", str(warning.message))
 
     def test_set_minmax(self):
         self.water.TP = self.water.min_temp, 101325

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -291,10 +291,10 @@ class TestReactor(utilities.CanteraTest):
         n_advance_negative = integrate(-1.0)
         n_advance_override = integrate(.001, False)
 
-        self.assertTrue(n_advance_coarse > n_baseline)
-        self.assertTrue(n_advance_fine > n_advance_coarse)
-        self.assertTrue(n_advance_negative == n_baseline)
-        self.assertTrue(n_advance_override == n_baseline)
+        self.assertGreater(n_advance_coarse, n_baseline)
+        self.assertGreater(n_advance_fine, n_advance_coarse)
+        self.assertEqual(n_advance_negative, n_baseline)
+        self.assertEqual(n_advance_override, n_baseline)
 
     def test_heat_transfer1(self):
         # Connected reactors reach thermal equilibrium after some time
@@ -629,7 +629,7 @@ class TestReactor(utilities.CanteraTest):
             warnings.simplefilter("always")
             valve.set_valve_coeff(k)
 
-            self.assertTrue(len(w) == 1)
+            self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertTrue("To be removed after Cantera 2.5. "
                             in str(w[-1].message))
@@ -640,7 +640,7 @@ class TestReactor(utilities.CanteraTest):
             warnings.simplefilter("always")
             valve.set_valve_function(lambda t: t>.01)
 
-            self.assertTrue(len(w) == 1)
+            self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertTrue("To be removed after Cantera 2.5. "
                             in str(w[-1].message))
@@ -724,7 +724,7 @@ class TestReactor(utilities.CanteraTest):
             warnings.simplefilter("always")
             p.set_pressure_coeff(2.)
 
-            self.assertTrue(len(w) == 1)
+            self.assertEqual(len(w), 1)
             self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
             self.assertTrue("To be removed after Cantera 2.5. "
                             in str(w[-1].message))

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -150,16 +150,8 @@ class TestReactor(utilities.CanteraTest):
         dt_max = 0.07
         t = tStart
 
-        with warnings.catch_warnings(record=True) as w:
-
-            # cause all warnings to always be triggered.
-            warnings.simplefilter("always")
+        with self.assertWarnsRegex(DeprecationWarning, "after Cantera 2.5"):
             self.net.set_max_time_step(dt_max)
-
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("To be removed after Cantera 2.5. ",
-                          str(w[-1].message))
 
         self.net.max_time_step = dt_max
         self.assertEqual(self.net.max_time_step, dt_max)
@@ -623,27 +615,11 @@ class TestReactor(utilities.CanteraTest):
         valve = ct.Valve(self.r1, self.r2)
         k = 2e-5
 
-        with warnings.catch_warnings(record=True) as w:
-
-            # cause all warnings to always be triggered.
-            warnings.simplefilter("always")
+        with self.assertWarnsRegex(DeprecationWarning, "after Cantera 2.5"):
             valve.set_valve_coeff(k)
 
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertTrue("To be removed after Cantera 2.5. "
-                            in str(w[-1].message))
-
-        with warnings.catch_warnings(record=True) as w:
-
-            # cause all warnings to always be triggered.
-            warnings.simplefilter("always")
+        with self.assertWarnsRegex(DeprecationWarning, "after Cantera 2.5"):
             valve.set_valve_function(lambda t: t>.01)
-
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertTrue("To be removed after Cantera 2.5. "
-                            in str(w[-1].message))
 
     def test_valve_errors(self):
         self.make_reactors()
@@ -718,16 +694,8 @@ class TestReactor(utilities.CanteraTest):
 
         p = ct.PressureController(self.r1, self.r2, master=mfc, K=0.5)
 
-        with warnings.catch_warnings(record=True) as w:
-
-            # cause all warnings to always be triggered.
-            warnings.simplefilter("always")
+        with self.assertWarnsRegex(DeprecationWarning, "after Cantera 2.5"):
             p.set_pressure_coeff(2.)
-
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertTrue("To be removed after Cantera 2.5. "
-                            in str(w[-1].message))
 
     def test_pressure_controller_errors(self):
         self.make_reactors()

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1243,7 +1243,7 @@ class TestSpecies(utilities.CanteraTest):
 
     def test_alias(self):
         self.gas.add_species_alias('H2', 'hydrogen')
-        self.assertTrue(self.gas.species_index('hydrogen') == 0)
+        self.assertEqual(self.gas.species_index('hydrogen'), 0)
         self.gas.X = 'hydrogen:.5, O2:.5'
         self.assertNear(self.gas.X[0], 0.5)
         with self.assertRaisesRegex(ct.CanteraError, 'Invalid alias'):
@@ -1254,13 +1254,13 @@ class TestSpecies(utilities.CanteraTest):
     def test_isomers(self):
         gas = ct.Solution('nDodecane_Reitz.yaml')
         iso = gas.find_isomers({'C':4, 'H':9, 'O':2})
-        self.assertTrue(len(iso) == 2)
+        self.assertEqual(len(iso), 2)
         iso = gas.find_isomers('C:4, H:9, O:2')
-        self.assertTrue(len(iso) == 2)
+        self.assertEqual(len(iso), 2)
         iso = gas.find_isomers({'C':7, 'H':15})
-        self.assertTrue(len(iso) == 1)
+        self.assertEqual(len(iso), 1)
         iso = gas.find_isomers({'C':7, 'H':16})
-        self.assertTrue(len(iso) == 0)
+        self.assertEqual(len(iso), 0)
 
 
 class TestSpeciesThermo(utilities.CanteraTest):
@@ -1306,7 +1306,7 @@ class TestSpeciesThermo(utilities.CanteraTest):
         self.assertEqual(st.max_temp, 3500)
         self.assertEqual(st.reference_pressure, 101325)
         self.assertArrayNear(self.h2o_coeffs, st.coeffs)
-        self.assertTrue(st.n_coeffs == len(st.coeffs))
+        self.assertEqual(st.n_coeffs, len(st.coeffs))
         self.assertTrue(st._check_n_coeffs(st.n_coeffs))
 
     def test_nasa9_load(self):
@@ -1502,7 +1502,7 @@ class TestMisc(utilities.CanteraTest):
     def test_case_sensitive_names(self):
         gas = ct.Solution('h2o2.xml')
         self.assertFalse(gas.case_sensitive_species_names)
-        self.assertTrue(gas.species_index('h2') == 0)
+        self.assertEqual(gas.species_index('h2'), 0)
         gas.X = 'h2:.5, o2:.5'
         self.assertNear(gas.X[0], 0.5)
         gas.Y = 'h2:.5, o2:.5'

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1850,7 +1850,7 @@ class TestSolutionArray(utilities.CanteraTest):
         states.sort('T')
         self.assertFalse((states.t[1:] - states.t[:-1] > 0).all())
         self.assertTrue((states.T[1:] - states.T[:-1] > 0).all())
-        self.assertTrue(np.allclose(states.P, P))
+        self.assertArrayNear(states.P, P)
 
         states.sort('T', reverse=True)
         self.assertTrue((states.T[1:] - states.T[:-1] < 0).all())

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -423,31 +423,15 @@ class TestThermoPhase(utilities.CanteraTest):
 
     def test_phase(self):
         self.assertEqual(self.phase.name, 'ohmech')
-
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with self.assertWarnsRegex(DeprecationWarning, "after Cantera 2.5"):
             self.assertEqual(self.phase.ID, 'ohmech')
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("To be removed after Cantera 2.5. ",
-                          str(w[-1].message))
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with self.assertWarnsRegex(DeprecationWarning, "after Cantera 2.5"):
             self.phase.ID = 'something'
-            self.assertEqual(self.phase.name, 'something')
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, DeprecationWarning))
-            self.assertIn("To be removed after Cantera 2.5. ",
-                          str(w[-1].message))
+        self.assertEqual(self.phase.name, 'something')
 
-        with warnings.catch_warnings(record=True) as w:
-            warnings.simplefilter("always")
+        with self.assertWarnsRegex(FutureWarning, "Keyword 'name' replaces 'phaseid'"):
             gas = ct.Solution('h2o2.cti', phaseid='ohmech')
-            self.assertEqual(len(w), 1)
-            self.assertTrue(issubclass(w[-1].category, FutureWarning))
-            self.assertIn("Keyword 'name' replaces 'phaseid'",
-                          str(w[-1].message))
 
     def test_badLength(self):
         X = np.zeros(5)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Update some non-ideal checks in various unit-tests (mainly introduced by myself). The PR will not affect functionality whatsoever.

- Use `assertEqual(a, b)` rather than `assertTrue(a == b)`
- Use `assertArrayNear(a, b)` rather than `assertTrue(np.allclose(a, b))`
- Simplify checks for warnings

**If applicable, fill in the issue number this pull request is fixing**

Fixes: N/A

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
