### PR TITLE
Some fixes for IonFlame issues

### DIFF
--- a/interfaces/cython/cantera/examples/onedim/ion_burner_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/ion_burner_flame.py
@@ -1,9 +1,10 @@
 """
 A burner-stabilized premixed methane-air flame with charged species.
 
-Requires: cantera >= 2.5.0
+Requires: cantera >= 2.5.0, matplotlib >= 2.0
 """
 
+import sys
 import cantera as ct
 
 p = ct.one_atm
@@ -21,14 +22,39 @@ f.burner.mdot = mdot
 f.set_refine_criteria(ratio=3.0, slope=0.05, curve=0.1)
 f.show_solution()
 
-f.transport_model = 'Ion'
 f.solve(loglevel, auto=True)
-f.solve(loglevel=loglevel, stage=2, enable_energy=True)
 try:
     # save to HDF container file if h5py is installed
-    f.write_hdf('ion_burner_flame.h5', group='ion', mode='w',
-                description='solution with ionized gas transport')
+    f.write_hdf('ion_burner_flame.h5', group='frozenIon', mode='w',
+                description='solution with ionized gas transport - stage 1')
 except ImportError:
-    f.save('ion_burner_flame.xml', 'mix', 'solution with mixture-averaged transport')
+    pass
+
+f.solve(loglevel=loglevel, stage=2, enable_energy=True)
+try:
+    f.write_hdf('ion_burner_flame.h5', group='ion',
+                description='solution with ionized gas transport - stage 2')
+except ImportError:
+    f.save('ion_burner_flame.xml', 'mix', 'solution with ionized gas transport')
 
 f.write_csv('ion_burner_flame.csv', quiet=False)
+
+if '--plot' in sys.argv:
+    import matplotlib.pyplot as plt
+
+    arr = f.to_solution_array()
+
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, sharex=True)
+    ax1.plot(f.grid, f.heat_release_rate)
+    ax1.set_ylabel(r'$\dot{q}$ [W/m${^3}$]')
+    for s in ['H3O+', 'HCO+', 'E']:
+        ax2.plot(f.grid, arr(s).X, label=s)
+    ax2.legend()
+    ax2.set_ylabel('X [-]')
+    ax3.plot(f.grid, f.E)
+    ax3.set_xlabel('Distance from burner [m]')
+    ax3.set_ylabel('E [V/m]')
+    ax3.set_xlim([0, .005])
+
+    fig.tight_layout()
+    plt.show()

--- a/interfaces/cython/cantera/examples/onedim/ion_free_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/ion_free_flame.py
@@ -1,9 +1,10 @@
 """
 A freely-propagating, premixed methane-air flat flame with charged species.
 
-Requires: cantera >= 2.5.0
+Requires: cantera >= 2.5.0, matplotlib >= 2.0
 """
 
+import sys
 import cantera as ct
 
 # Simulation parameters
@@ -25,14 +26,19 @@ f.show_solution()
 
 # stage one
 f.solve(loglevel=loglevel, auto=True)
+try:
+    # save to HDF container file if h5py is installed
+    f.write_hdf('ion_free_flame.h5', group='frozenIon', mode='w',
+                description='solution with ionized gas transport - stage 1')
+except ImportError:
+    pass
 
 # stage two
 f.solve(loglevel=loglevel, stage=2, enable_energy=True)
 
 try:
-    # save to HDF container file if h5py is installed
-    f.write_hdf('ion_free_flame.h5', group='ion', mode='w',
-                description='solution with ionized gas transport')
+    f.write_hdf('ion_free_flame.h5', group='ion',
+                description='solution with ionized gas transport - stage 2')
 except ImportError:
     f.save('ion_free_flame.xml', 'ion', 'solution with ionized gas transport')
 
@@ -41,3 +47,23 @@ print('mixture-averaged flamespeed = {0:7f} m/s'.format(f.velocity[0]))
 
 # write the velocity, temperature, density, and mole fractions to a CSV file
 f.write_csv('ion_free_flame.csv', quiet=False)
+
+if '--plot' in sys.argv:
+    import matplotlib.pyplot as plt
+
+    arr = f.to_solution_array()
+
+    fig, (ax1, ax2, ax3) = plt.subplots(3, 1, sharex=True)
+    ax1.plot(f.grid, f.heat_release_rate)
+    ax1.set_ylabel(r'$\dot{q}$ [W/m${^3}$]')
+    for s in ['H3O+', 'HCO+', 'E']:
+        ax2.plot(f.grid, arr(s).X, label=s)
+    ax2.legend()
+    ax2.set_ylabel('X [-]')
+    ax3.plot(f.grid, f.E)
+    ax3.set_xlabel('Axial location [m]')
+    ax3.set_ylabel('E [V/m]')
+    ax3.set_xlim([.016, .022])
+
+    fig.tight_layout()
+    plt.show()

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -938,7 +938,7 @@ class IonFlameBase(FlameBase):
         if stage == 1:
             super().solve(loglevel, refine_grid, auto)
         if stage == 2:
-            self.poisson_enabled = True
+            self.electric_field_enabled = True
             super().solve(loglevel, refine_grid, auto)
 
 

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -177,12 +177,6 @@ void IonFlow::evalResidual(double* x, double* rsd, int* diag,
 
     for (size_t j = jmin; j <= jmax; j++) {
         if (j == 0) {
-            // enforcing the flux for charged species is difficult
-            // since charged species are also affected by electric
-            // force, so Neumann boundary condition is used.
-            for (size_t k : m_kCharge) {
-                rsd[index(c_offset_Y + k, 0)] = Y(x,k,0) - Y(x,k,1);
-            }
             rsd[index(c_offset_E, j)] = E(x,0);
             diag[index(c_offset_E, j)] = 0;
         } else if (j == m_points - 1) {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- ~Apply band-aid fix to `ion_burner_flame.py` - a reduction of domain size makes the example more stable; there is no apparent reason for simulations to fail on a larger domain, which points at underlying issues that should be fixed at a later point~ __cherry-picked to #905__
- ~Fix `ch4_ion.yaml` that did not match `ch4_ion.cti`~ __cherry-picked to #905__
- Fix apparent glitch that results in the Poisson solver not being activated (Edit: *the fix has no effect as it affects C++ code that is not used*)
- Remove upstream von Neumann boundary condition for ionized species (see also #700)
- Add optional plots to `IonFlow`-based examples
- ~Fix export of `_other` columns from `IonFlow` (i.e. grid, etc.)~ __cherry-picked to #905__

Additional issues that surfaced while reviewing code are listed in #913 - changes are more extensive and should be handled by a separate PR (potentially after the release of 2.5).

**PS:** After cherry-picking 3 fixes into #905, the remaining changes are not worth keeping this PR open.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #909

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review