### PR TITLE
[Cython] Add pure-Python import of 'interrupts'

### DIFF
--- a/interfaces/cython/cantera/__init__.py
+++ b/interfaces/cython/cantera/__init__.py
@@ -7,6 +7,7 @@ from .composite import *
 from .liquidvapor import *
 from .onedim import *
 from .utils import *
+import cantera.interrupts  # Helps with standalone packaging (PyInstaller etc.)
 
 import os
 import sys


### PR DESCRIPTION
**Changes proposed in this pull request**

Tools for creating standalone Python applications, such as PyInstaller,
can fail to pick up the dependence on the 'cantera.interrupts' module because
it is only imported and used from Cython. Explicitly importing this module
from another pure-Python module causes these tools to correctly see that the
interrupts module needs to be included in the application.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #914.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
