### PR TITLE
Fix open WaterPropsIAPWS issues / add WaterSSTP as alternative Water backend

### DIFF
--- a/data/liquidvapor.yaml
+++ b/data/liquidvapor.yaml
@@ -25,7 +25,7 @@ phases:
     T: 300.0
     P: 1.01325e+05
   pure-fluid-name: water
-- name: water-iapws95
+- name: liquid-water-IAPWS95
   elements: [O, H]
   species: [H2O]
   thermo: liquid-water-IAPWS95
@@ -33,9 +33,10 @@ phases:
     T: 300.0
     P: 1.01325e+05
   note: >-
-    Phase definition based on W. Wagner, A. Pruss, "The IAPWS Formulation 1995
-    for the Thermodynamic Properties of Ordinary Water Substance for General and
-    Scientific Use," J. Phys. Chem. Ref. Dat, 31, 387, 2002.
+    Equation of state is based on W. Wagner, A. Pruss, "The IAPWS Formulation
+    1995 for the Thermodynamic Properties of Ordinary Water Substance for
+    General and Scientific Use," J. Phys. Chem. Ref. Dat, 31, 387, 2002.
+    Important: Only liquid and supercritical states are currently implemented
 - name: nitrogen
   thermo: pure-fluid
   elements: [N]
@@ -104,8 +105,8 @@ phases:
     P: 1.01325e+05
   pure-fluid-name: HFC-134a
   note: >-
-    Phase definition based on R. Tillner-Roth and H. D. Baehr, "An International
-    Standard Formulation for The Thermodynamic Properties of
+    Equation of state is based on R. Tillner-Roth and H. D. Baehr, "An
+    International Standard Formulation for The Thermodynamic Properties of
     1,1,1,2-Tetrafluoroethane (HFC-134a) for Temperatures From 170 K to 455 K
     and Pressures up to 70 MPa". J. Phys. Chem. Ref. Data, Vol. 23, No. 5, 1994.
     pp. 657--729.

--- a/data/liquidvapor.yaml
+++ b/data/liquidvapor.yaml
@@ -25,6 +25,18 @@ phases:
     T: 300.0
     P: 1.01325e+05
   pure-fluid-name: water
+- name: liquid-water
+  elements: [O, H]
+  species: [H2O]
+  thermo: liquid-water-IAPWS95
+  transport: water
+  state:
+    T: 300.0
+    P: 1.01325e+05
+  note: |-
+    Phase definition based on "The IAPWS Formulation 1995 for the
+    Thermodynamic Properties of Ordinary Water Substance for General and
+    Scientific Use," J. Phys. Chem. Ref. Dat, 31, 387, 2002.
 - name: nitrogen
   thermo: pure-fluid
   elements: [N]

--- a/data/liquidvapor.yaml
+++ b/data/liquidvapor.yaml
@@ -29,13 +29,12 @@ phases:
   elements: [O, H]
   species: [H2O]
   thermo: liquid-water-IAPWS95
-  transport: water
   state:
     T: 300.0
     P: 1.01325e+05
-  note: |-
-    Phase definition based on "The IAPWS Formulation 1995 for the
-    Thermodynamic Properties of Ordinary Water Substance for General and
+  note: >-
+    Phase definition based on W. Wagner, A. Pruss, "The IAPWS Formulation 1995
+    for the Thermodynamic Properties of Ordinary Water Substance for General and
     Scientific Use," J. Phys. Chem. Ref. Dat, 31, 387, 2002.
 - name: nitrogen
   thermo: pure-fluid
@@ -104,6 +103,12 @@ phases:
     T: 300.0
     P: 1.01325e+05
   pure-fluid-name: HFC-134a
+  note: >-
+    Phase definition based on R. Tillner-Roth and H. D. Baehr, "An International
+    Standard Formulation for The Thermodynamic Properties of
+    1,1,1,2-Tetrafluoroethane (HFC-134a) for Temperatures From 170 K to 455 K
+    and Pressures up to 70 MPa". J. Phys. Chem. Ref. Data, Vol. 23, No. 5, 1994.
+    pp. 657--729.
 - name: hfc134a
   thermo: pure-fluid
   elements: [C, F, H]

--- a/data/liquidvapor.yaml
+++ b/data/liquidvapor.yaml
@@ -25,7 +25,7 @@ phases:
     T: 300.0
     P: 1.01325e+05
   pure-fluid-name: water
-- name: liquid-water
+- name: water-iapws95
   elements: [O, H]
   species: [H2O]
   thermo: liquid-water-IAPWS95

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -83,8 +83,10 @@ class PDSS_Water;
 //! The WaterProps class is used to house several approximation routines for
 //! properties of water.
 /*!
- * This is a helper class for WaterSSTP and is not instantiable on its own
- * (see \ref thermoprops and class \link Cantera::WaterSSTP WaterSSTP\endlink).
+ * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
+ * a complete implementation of a thermo phase by itself (see \ref thermoprops
+ * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
+ * \link Cantera::PDSS_Water PDSS_Water\endlink).
  *
  * The class is also a wrapper around the WaterPropsIAPWS class which provides
  * the calculations for the equation of state properties for water.

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -83,6 +83,9 @@ class PDSS_Water;
 //! The WaterProps class is used to house several approximation routines for
 //! properties of water.
 /*!
+ * This is a helper class for WaterSSTP and is not instantiable on its own
+ * (see \ref thermoprops and class \link Cantera::WaterSSTP WaterSSTP\endlink).
+ *
  * The class is also a wrapper around the WaterPropsIAPWS class which provides
  * the calculations for the equation of state properties for water.
  *

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -37,8 +37,10 @@ namespace Cantera
 
 //! Class for calculating the equation of state of water.
 /*!
- * This is a helper class for WaterSSTP and is not instantiable on its own
- * (see \ref thermoprops and class \link Cantera::WaterSSTP WaterSSTP\endlink).
+ * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
+ * a complete implementation of a thermo phase by itself (see \ref thermoprops
+ * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
+ * \link Cantera::PDSS_Water PDSS_Water\endlink).
  *
  * The reference is W. Wagner, A. Pruss, "The IAPWS Formulation 1995 for the
  * Thermodynamic Properties of Ordinary Water Substance for General and

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -37,6 +37,9 @@ namespace Cantera
 
 //! Class for calculating the equation of state of water.
 /*!
+ * This is a helper class for WaterSSTP and is not instantiable on its own
+ * (see \ref thermoprops and class \link Cantera::WaterSSTP WaterSSTP\endlink).
+ *
  * The reference is W. Wagner, A. Pruss, "The IAPWS Formulation 1995 for the
  * Thermodynamic Properties of Ordinary Water Substance for General and
  * Scientific Use," J. Phys. Chem. Ref. Dat, 31, 387, 2002.

--- a/include/cantera/thermo/WaterPropsIAPWSphi.h
+++ b/include/cantera/thermo/WaterPropsIAPWSphi.h
@@ -20,8 +20,10 @@ namespace Cantera
 
 //! Low level class for the real description of water.
 /*!
- * This is a helper class for WaterSSTP and is not instantiable on its own
- * (see \ref thermoprops and class \link Cantera::WaterSSTP WaterSSTP\endlink).
+ * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
+ * a complete implementation of a thermo phase by itself (see \ref thermoprops
+ * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
+ * \link Cantera::PDSS_Water PDSS_Water\endlink).
  *
  * The reference is W. Wagner, A. Pruss, "The IAPWS Formulation 1995 for the
  * Thermodynamic Properties of Ordinary Water Substance for General and

--- a/include/cantera/thermo/WaterPropsIAPWSphi.h
+++ b/include/cantera/thermo/WaterPropsIAPWSphi.h
@@ -20,6 +20,9 @@ namespace Cantera
 
 //! Low level class for the real description of water.
 /*!
+ * This is a helper class for WaterSSTP and is not instantiable on its own
+ * (see \ref thermoprops and class \link Cantera::WaterSSTP WaterSSTP\endlink).
+ *
  * The reference is W. Wagner, A. Pruss, "The IAPWS Formulation 1995 for the
  * Thermodynamic Properties of Ordinary Water Substance for General and
  * Scientific Use," J. Phys. Chem. Ref. Dat, 31, 387, 2002.

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -140,7 +140,7 @@ public:
     explicit WaterSSTP(XML_Node& phaseRef, const std::string& id = "");
 
     virtual std::string type() const {
-        return "WaterSSTP";
+        return "liquid-water-IAPWS95";
     }
 
     virtual std::string phaseOfMatter() const;
@@ -241,6 +241,12 @@ public:
     }
 
     //! Switch that enables calculations in the gas phase
+    /**
+     *  Since this phase represents a liquid (or supercritical) phase, it is an
+     *  error to return a gas-phase answer. The sole intended use for this
+     *  member function is to check the thermodynamic consistency of the
+     *  underlying WaterProps class with ideal-gas thermo functions.
+     */
     void allowGasPhase(bool flag) { m_allowGasPhase = flag; }
 
 protected:

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -140,7 +140,7 @@ public:
     explicit WaterSSTP(XML_Node& phaseRef, const std::string& id = "");
 
     virtual std::string type() const {
-        return "Water";
+        return "WaterSSTP";
     }
 
     virtual std::string phaseOfMatter() const;

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -238,6 +238,9 @@ public:
         return m_waterProps.get();
     }
 
+    //! Switch that enables calculations in the gas phase
+    void allowGasPhase(bool flag) { m_allowGasPhase = flag; }
+
 protected:
     /**
      * @internal This internal routine must be overridden because it is not

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -20,7 +20,7 @@ namespace Cantera
 class WaterPropsIAPWS;
 class WaterProps;
 //! Class for single-component water. This is designed to cover just the liquid
-//! part of water.
+//! and supercritical phases of water.
 /*!
  * The reference is W. Wagner, A. Pruss, "The IAPWS Formulation 1995 for the
  * Thermodynamic Properties of Ordinary Water Substance for General and
@@ -142,6 +142,8 @@ public:
     virtual std::string type() const {
         return "Water";
     }
+
+    virtual std::string phaseOfMatter() const;
 
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
@@ -281,8 +283,8 @@ private:
     bool m_ready;
 
     /**
-     *  Since this phase represents a liquid phase, it's an error to
-     *  return a gas-phase answer. However, if the below is true, then
+     *  Since this phase represents a liquid (or supercritical) phase, it is an
+     *  error to return a gas-phase answer. However, if the below is true, then
      *  a gas-phase answer is allowed. This is used to check the thermodynamic
      *  consistency with ideal-gas thermo functions for example.
      */

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -247,7 +247,7 @@ public:
      *  member function is to check the thermodynamic consistency of the
      *  underlying WaterProps class with ideal-gas thermo functions.
      */
-    void allowGasPhase(bool flag) { m_allowGasPhase = flag; }
+    void _allowGasPhase(bool flag) { m_allowGasPhase = flag; }
 
 protected:
     /**

--- a/interfaces/cython/cantera/liquidvapor.py
+++ b/interfaces/cython/cantera/liquidvapor.py
@@ -15,6 +15,19 @@ def Water():
     return WaterWithTransport('liquidvapor.yaml', 'water', transport_model='Water')
 
 
+def LiquidWater():
+    """
+    Create a `PureFluid` object using the IAPWS Formulation 1995 for
+    thermodynamic properties and the `WaterTransport` class for viscosity
+    and thermal conductivity.
+    """
+    class WaterWithTransport(PureFluid, _cantera.Transport):
+        __slots__ = ()
+
+    return WaterWithTransport('liquidvapor.yaml', 'liquid-water',
+                              transport_model='Water')
+
+
 def Nitrogen():
     """Create a `PureFluid` object using the equation of state for nitrogen."""
     return PureFluid('liquidvapor.yaml', 'nitrogen')

--- a/interfaces/cython/cantera/liquidvapor.py
+++ b/interfaces/cython/cantera/liquidvapor.py
@@ -8,11 +8,30 @@ def Water():
     """
     Create a `PureFluid` object using the equation of state for water and the
     `WaterTransport` class for viscosity and thermal conductivity.
+
+    The object returned by this method implements an accurate equation of
+    state for water that can be used in the liquid, vapor, saturated
+    liquid/vapor, and supercritical regions of the phase diagram. The
+    equation of state is taken from
+
+    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+    computational equations for forty substances.* Stanford: Stanford
+    University, 1979. Print.
+
+    whereas formulas for transport are taken from
+
+    J. V. Sengers, J. T. R. Watson, *Improved International Formulations for
+    the Viscosity and Thermal Conductivity of Water Substance,* J. Phys. Chem.
+    Ref. Data, 15, 1291, 1986.
+
+    For more details, see classes Cantera::PureFluid, tpx::water and
+    Cantera::WaterTransport in the Cantera C++ source code documentation.
     """
     class WaterWithTransport(PureFluid, _cantera.Transport):
         __slots__ = ()
 
-    return WaterWithTransport('liquidvapor.yaml', 'water', transport_model='Water')
+    return WaterWithTransport('liquidvapor.yaml', 'water',
+                              transport_model='Water')
 
 
 def LiquidWater():
@@ -20,6 +39,23 @@ def LiquidWater():
     Create a `PureFluid` object using the IAPWS Formulation 1995 for
     thermodynamic properties and the `WaterTransport` class for viscosity
     and thermal conductivity.
+
+    The object returned by this method implements an accurate equation of
+    state for water that can be used in the liquid and supercritical regions
+    of the phase diagram. The equation of state is taken from
+
+    W. Wagner, A. Pruss, *The IAPWS Formulation 1995 for the Thermodynamic
+    Properties of Ordinary Water Substance for General and Scientific Use,*
+    J. Phys. Chem. Ref. Dat, 31, 387, 2002.
+
+    whereas formulas for transport are taken from
+
+    J. V. Sengers, J. T. R. Watson, *Improved International Formulations for
+    the Viscosity and Thermal Conductivity of Water Substance,* J. Phys. Chem.
+    Ref. Data, 15, 1291, 1986.
+
+    For more details, see classes Cantera::PureFluid, Cantera::WaterSSTP and
+    Cantera::WaterTransport in the Cantera C++ source code documentation.
     """
     class WaterWithTransport(PureFluid, _cantera.Transport):
         __slots__ = ()
@@ -29,35 +65,135 @@ def LiquidWater():
 
 
 def Nitrogen():
-    """Create a `PureFluid` object using the equation of state for nitrogen."""
+    """
+    Create a `PureFluid` object using the equation of state for nitrogen.
+
+    The object returned by this method implements an accurate equation of
+    state for nitrogen that can be used in the liquid, vapor, saturated
+    liquid/vapor, and supercritical regions of the phase diagram. The
+    equation of state is taken from
+
+    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+    computational equations for forty substances* Stanford: Stanford
+    University, 1979. Print.
+
+    For more details, see classes Cantera::PureFluid and tpx::nitrogen in the
+    Cantera C++ source code documentation.
+    """
     return PureFluid('liquidvapor.yaml', 'nitrogen')
 
 
 def Methane():
-    """Create a `PureFluid` object using the equation of state for methane."""
+    """
+    Create a `PureFluid` object using the equation of state for methane.
+
+    The object returned by this method implements an accurate equation of
+    state for methane that can be used in the liquid, vapor, saturated
+    liquid/vapor, and supercritical regions of the phase diagram.  The
+    equation of state is taken from
+
+    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+    computational equations for forty substances* Stanford: Stanford
+    University, 1979. Print.
+
+    For more details, see classes Cantera::PureFluid and tpx::methane in the
+    Cantera C++ source code documentation.
+    """
     return PureFluid('liquidvapor.yaml', 'methane')
 
 
 def Hydrogen():
-    """Create a `PureFluid` object using the equation of state for hydrogen."""
+    """
+    Create a `PureFluid` object using the equation of state for hydrogen.
+
+    The object returned by this method implements an accurate equation of
+    state for hydrogen that can be used in the liquid, vapor, saturated
+    liquid/vapor, and supercritical regions of the phase diagram. The
+    equation of state is taken from
+
+    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+    computational equations for forty substances* Stanford: Stanford
+    University, 1979. Print.
+
+    For more details, see classes Cantera::PureFluid and tpx::hydrogen in the
+    Cantera C++ source code documentation.
+    """
     return PureFluid('liquidvapor.yaml', 'hydrogen')
 
 
 def Oxygen():
-    """Create a `PureFluid` object using the equation of state for oxygen."""
+    """
+    Create a `PureFluid` object using the equation of state for oxygen.
+
+    The object returned by this method implements an accurate equation of
+    state for oxygen that can be used in the liquid, vapor, saturated
+    liquid/vapor, and supercritical regions of the phase diagram.  The
+    equation of state is taken from
+
+    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+    computational equations for forty substances* Stanford: Stanford
+    University, 1979. Print.
+
+    For more details, see classes Cantera::PureFluid and tpx::oxygen in the
+    Cantera C++ source code documentation.
+    """
     return PureFluid('liquidvapor.yaml', 'oxygen')
 
 
 def Hfc134a():
-    """Create a `PureFluid` object using the equation of state for HFC-134a."""
+    """
+    Create a `PureFluid` object using the equation of state for HFC-134a.
+
+    The object returned by this method implements an accurate equation of
+    state for refrigerant HFC134a (R134a) that can be used in the liquid,
+    vapor, saturated liquid/vapor, and supercritical regions of the phase
+    diagram. Implements the equation of state given in:
+
+    R. Tillner-Roth and H. D. Baehr. *An International Standard Formulation for
+    The Thermodynamic Properties of 1,1,1,2-Tetrafluoroethane (HFC-134a) for
+    Temperatures From 170 K to 455 K and Pressures up to 70 MPa.* J. Phys.
+    Chem. Ref. Data, Vol. 23, No. 5, 1994. pp. 657--729.
+    http://dx.doi.org/10.1063/1.555958
+
+    For more details, see classes Cantera::PureFluid and tpx::HFC134a in the
+    Cantera C++ source code documentation.
+    """
     return PureFluid('liquidvapor.yaml', 'HFC-134a')
 
 
 def CarbonDioxide():
-    """Create a `PureFluid` object using the equation of state for carbon dioxide."""
+    """
+    Create a `PureFluid` object using the equation of state for carbon dioxide.
+
+    The object returned by this method implements an accurate equation of
+    state for carbon dioxide that can be used in the liquid, vapor, saturated
+    liquid/vapor, and supercritical regions of the phase diagram. The
+    equation of state is taken from
+
+    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+    computational equations for forty substances.* Stanford: Stanford
+    University, 1979. Print.
+
+    For more details, see classes Cantera::PureFluid and tpx::CarbonDioxide in
+    the Cantera C++ source code documentation.
+    """
     return PureFluid('liquidvapor.yaml', 'carbon-dioxide')
 
 
 def Heptane():
-    """Create a `PureFluid` object using the equation of state for heptane."""
+    """
+    Create a `PureFluid` object using the equation of state for heptane.
+
+    The object returned by this method implements an accurate equation of
+    state for n-heptane that can be used in the liquid, vapor, saturated
+    liquid/vapor, and supercritical regions of the phase diagram. The
+    equation of state is taken from
+
+    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+    computational equations for forty substances.* Stanford: Stanford
+    University, 1979. Print.
+
+    For more details, see classes Cantera::PureFluid and tpx::Heptane in the
+    Cantera C++ source code documentation.
+    """
     return PureFluid('liquidvapor.yaml', 'heptane')

--- a/interfaces/cython/cantera/liquidvapor.py
+++ b/interfaces/cython/cantera/liquidvapor.py
@@ -4,64 +4,48 @@
 from . import PureFluid, _cantera
 
 
-def Water():
+def Water(backend='default'):
     """
     Create a `PureFluid` object using the equation of state for water and the
     `WaterTransport` class for viscosity and thermal conductivity.
 
-    The object returned by this method implements an accurate equation of
-    state for water that can be used in the liquid, vapor, saturated
-    liquid/vapor, and supercritical regions of the phase diagram. The
-    equation of state is taken from
+    The object returned by this method implements an accurate equation of state
+    for water, where implementations are selected using the *backend* switch.
 
-    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
-    computational equations for forty substances.* Stanford: Stanford
-    University, 1979. Print.
+    For the ``default`` backend, the equation of state is taken from
 
-    whereas formulas for transport are taken from
+        W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+        computational equations for forty substances.* Stanford: Stanford
+        University, 1979. Print.
 
-    J. V. Sengers, J. T. R. Watson, *Improved International Formulations for
-    the Viscosity and Thermal Conductivity of Water Substance,* J. Phys. Chem.
-    Ref. Data, 15, 1291, 1986.
+    which can be used in the liquid, vapor, saturated liquid/vapor, and
+    supercritical regions of the phase diagram.
 
-    For more details, see classes Cantera::PureFluid, tpx::water and
-    Cantera::WaterTransport in the Cantera C++ source code documentation.
+    The ``iapws95`` backend implements an IAPWS (International Association for
+    the Properties of Water and Steam) formulation for thermodynamic properties
+    taken from
+
+        J. V. Sengers, J. T. R. Watson, *Improved International Formulations for
+        the Viscosity and Thermal Conductivity of Water Substance,* J. Phys.
+        Chem. Ref. Data, 15, 1291, 1986.
+
+    which currently only implements liquid and supercritical regions.
+
+    For more details, see classes Cantera::PureFluid, tpx::water,
+    Cantera::WaterSSTP and Cantera::WaterTransport in the Cantera C++ source
+    code documentation.
     """
     class WaterWithTransport(PureFluid, _cantera.Transport):
         __slots__ = ()
 
-    return WaterWithTransport('liquidvapor.yaml', 'water',
-                              transport_model='Water')
+    if backend == 'default':
+        return WaterWithTransport('liquidvapor.yaml', 'water',
+                                  transport_model='Water')
+    if backend == 'iapws95':
+        return WaterWithTransport('liquidvapor.yaml', 'water-iapws95',
+                                  transport_model='Water')
 
-
-def LiquidWater():
-    """
-    Create a `PureFluid` object using the IAPWS Formulation 1995 for
-    thermodynamic properties and the `WaterTransport` class for viscosity
-    and thermal conductivity.
-
-    The object returned by this method implements an accurate equation of
-    state for water that can be used in the liquid and supercritical regions
-    of the phase diagram. The equation of state is taken from
-
-    W. Wagner, A. Pruss, *The IAPWS Formulation 1995 for the Thermodynamic
-    Properties of Ordinary Water Substance for General and Scientific Use,*
-    J. Phys. Chem. Ref. Dat, 31, 387, 2002.
-
-    whereas formulas for transport are taken from
-
-    J. V. Sengers, J. T. R. Watson, *Improved International Formulations for
-    the Viscosity and Thermal Conductivity of Water Substance,* J. Phys. Chem.
-    Ref. Data, 15, 1291, 1986.
-
-    For more details, see classes Cantera::PureFluid, Cantera::WaterSSTP and
-    Cantera::WaterTransport in the Cantera C++ source code documentation.
-    """
-    class WaterWithTransport(PureFluid, _cantera.Transport):
-        __slots__ = ()
-
-    return WaterWithTransport('liquidvapor.yaml', 'liquid-water',
-                              transport_model='Water')
+    raise KeyError("Unknown backend '{}'".format(backend))
 
 
 def Nitrogen():
@@ -73,9 +57,9 @@ def Nitrogen():
     liquid/vapor, and supercritical regions of the phase diagram. The
     equation of state is taken from
 
-    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
-    computational equations for forty substances* Stanford: Stanford
-    University, 1979. Print.
+        W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+        computational equations for forty substances* Stanford: Stanford
+        University, 1979. Print.
 
     For more details, see classes Cantera::PureFluid and tpx::nitrogen in the
     Cantera C++ source code documentation.
@@ -92,9 +76,9 @@ def Methane():
     liquid/vapor, and supercritical regions of the phase diagram.  The
     equation of state is taken from
 
-    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
-    computational equations for forty substances* Stanford: Stanford
-    University, 1979. Print.
+        W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+        computational equations for forty substances* Stanford: Stanford
+        University, 1979. Print.
 
     For more details, see classes Cantera::PureFluid and tpx::methane in the
     Cantera C++ source code documentation.
@@ -111,9 +95,9 @@ def Hydrogen():
     liquid/vapor, and supercritical regions of the phase diagram. The
     equation of state is taken from
 
-    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
-    computational equations for forty substances* Stanford: Stanford
-    University, 1979. Print.
+        W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+        computational equations for forty substances* Stanford: Stanford
+        University, 1979. Print.
 
     For more details, see classes Cantera::PureFluid and tpx::hydrogen in the
     Cantera C++ source code documentation.
@@ -130,9 +114,9 @@ def Oxygen():
     liquid/vapor, and supercritical regions of the phase diagram.  The
     equation of state is taken from
 
-    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
-    computational equations for forty substances* Stanford: Stanford
-    University, 1979. Print.
+        W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+        computational equations for forty substances* Stanford: Stanford
+        University, 1979. Print.
 
     For more details, see classes Cantera::PureFluid and tpx::oxygen in the
     Cantera C++ source code documentation.
@@ -149,11 +133,11 @@ def Hfc134a():
     vapor, saturated liquid/vapor, and supercritical regions of the phase
     diagram. Implements the equation of state given in:
 
-    R. Tillner-Roth and H. D. Baehr. *An International Standard Formulation for
-    The Thermodynamic Properties of 1,1,1,2-Tetrafluoroethane (HFC-134a) for
-    Temperatures From 170 K to 455 K and Pressures up to 70 MPa.* J. Phys.
-    Chem. Ref. Data, Vol. 23, No. 5, 1994. pp. 657--729.
-    http://dx.doi.org/10.1063/1.555958
+        R. Tillner-Roth, H. D. Baehr. *An International Standard Formulation for
+        The Thermodynamic Properties of 1,1,1,2-Tetrafluoroethane (HFC-134a) for
+        Temperatures From 170 K to 455 K and Pressures up to 70 MPa.* J. Phys.
+        Chem. Ref. Data, Vol. 23, No. 5, 1994. pp. 657--729.
+        http://dx.doi.org/10.1063/1.555958
 
     For more details, see classes Cantera::PureFluid and tpx::HFC134a in the
     Cantera C++ source code documentation.
@@ -170,9 +154,9 @@ def CarbonDioxide():
     liquid/vapor, and supercritical regions of the phase diagram. The
     equation of state is taken from
 
-    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
-    computational equations for forty substances.* Stanford: Stanford
-    University, 1979. Print.
+        W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+        computational equations for forty substances.* Stanford: Stanford
+        University, 1979. Print.
 
     For more details, see classes Cantera::PureFluid and tpx::CarbonDioxide in
     the Cantera C++ source code documentation.
@@ -189,9 +173,9 @@ def Heptane():
     liquid/vapor, and supercritical regions of the phase diagram. The
     equation of state is taken from
 
-    W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
-    computational equations for forty substances.* Stanford: Stanford
-    University, 1979. Print.
+        W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
+        computational equations for forty substances.* Stanford: Stanford
+        University, 1979. Print.
 
     For more details, see classes Cantera::PureFluid and tpx::Heptane in the
     Cantera C++ source code documentation.

--- a/interfaces/cython/cantera/liquidvapor.py
+++ b/interfaces/cython/cantera/liquidvapor.py
@@ -4,7 +4,7 @@
 from . import PureFluid, _cantera
 
 
-def Water(backend='default'):
+def Water(backend='Reynolds'):
     """
     Create a `PureFluid` object using the equation of state for water and the
     `WaterTransport` class for viscosity and thermal conductivity.
@@ -12,7 +12,7 @@ def Water(backend='default'):
     The object returned by this method implements an accurate equation of state
     for water, where implementations are selected using the *backend* switch.
 
-    For the ``default`` backend, the equation of state is taken from
+    For the ``Reynolds`` backend, the equation of state is taken from
 
         W. C. Reynolds, *Thermodynamic Properties in SI: graphs, tables, and
         computational equations for forty substances.* Stanford: Stanford
@@ -21,28 +21,34 @@ def Water(backend='default'):
     which can be used in the liquid, vapor, saturated liquid/vapor, and
     supercritical regions of the phase diagram.
 
-    The ``iapws95`` backend implements an IAPWS (International Association for
+    The ``IAPWS95`` backend implements an IAPWS (International Association for
     the Properties of Water and Steam) formulation for thermodynamic properties
     taken from
+
+        W. Wagner, A. Pruss, *The IAPWS Formulation 1995 for the Thermodynamic
+        Properties of Ordinary Water Substance for General and Scientific Use,*
+        J. Phys. Chem. Ref. Dat, 31, 387, 2002.
+
+    which currently only implements liquid and supercritical regions.
+
+    In both cases, formulas for transport are taken from
 
         J. V. Sengers, J. T. R. Watson, *Improved International Formulations for
         the Viscosity and Thermal Conductivity of Water Substance,* J. Phys.
         Chem. Ref. Data, 15, 1291, 1986.
 
-    which currently only implements liquid and supercritical regions.
-
-    For more details, see classes Cantera::PureFluid, tpx::water,
-    Cantera::WaterSSTP and Cantera::WaterTransport in the Cantera C++ source
+    For more details, see classes :ct:PureFluid, tpx::water,
+    :ct:WaterSSTP and :ct:WaterTransport in the Cantera C++ source
     code documentation.
     """
     class WaterWithTransport(PureFluid, _cantera.Transport):
         __slots__ = ()
 
-    if backend == 'default':
+    if backend == 'Reynolds':
         return WaterWithTransport('liquidvapor.yaml', 'water',
                                   transport_model='Water')
-    if backend == 'iapws95':
-        return WaterWithTransport('liquidvapor.yaml', 'water-iapws95',
+    if backend == 'IAPWS95':
+        return WaterWithTransport('liquidvapor.yaml', 'liquid-water-IAPWS95',
                                   transport_model='Water')
 
     raise KeyError("Unknown backend '{}'".format(backend))
@@ -61,7 +67,7 @@ def Nitrogen():
         computational equations for forty substances* Stanford: Stanford
         University, 1979. Print.
 
-    For more details, see classes Cantera::PureFluid and tpx::nitrogen in the
+    For more details, see classes :ct:PureFluid and tpx::nitrogen in the
     Cantera C++ source code documentation.
     """
     return PureFluid('liquidvapor.yaml', 'nitrogen')
@@ -80,7 +86,7 @@ def Methane():
         computational equations for forty substances* Stanford: Stanford
         University, 1979. Print.
 
-    For more details, see classes Cantera::PureFluid and tpx::methane in the
+    For more details, see classes :ct:PureFluid and tpx::methane in the
     Cantera C++ source code documentation.
     """
     return PureFluid('liquidvapor.yaml', 'methane')
@@ -99,7 +105,7 @@ def Hydrogen():
         computational equations for forty substances* Stanford: Stanford
         University, 1979. Print.
 
-    For more details, see classes Cantera::PureFluid and tpx::hydrogen in the
+    For more details, see classes :ct:PureFluid and tpx::hydrogen in the
     Cantera C++ source code documentation.
     """
     return PureFluid('liquidvapor.yaml', 'hydrogen')
@@ -118,7 +124,7 @@ def Oxygen():
         computational equations for forty substances* Stanford: Stanford
         University, 1979. Print.
 
-    For more details, see classes Cantera::PureFluid and tpx::oxygen in the
+    For more details, see classes :ct:PureFluid and tpx::oxygen in the
     Cantera C++ source code documentation.
     """
     return PureFluid('liquidvapor.yaml', 'oxygen')
@@ -139,7 +145,7 @@ def Hfc134a():
         Chem. Ref. Data, Vol. 23, No. 5, 1994. pp. 657--729.
         http://dx.doi.org/10.1063/1.555958
 
-    For more details, see classes Cantera::PureFluid and tpx::HFC134a in the
+    For more details, see classes :ct:PureFluid and tpx::HFC134a in the
     Cantera C++ source code documentation.
     """
     return PureFluid('liquidvapor.yaml', 'HFC-134a')
@@ -158,7 +164,7 @@ def CarbonDioxide():
         computational equations for forty substances.* Stanford: Stanford
         University, 1979. Print.
 
-    For more details, see classes Cantera::PureFluid and tpx::CarbonDioxide in
+    For more details, see classes :ct:PureFluid and tpx::CarbonDioxide in
     the Cantera C++ source code documentation.
     """
     return PureFluid('liquidvapor.yaml', 'carbon-dioxide')
@@ -177,7 +183,7 @@ def Heptane():
         computational equations for forty substances.* Stanford: Stanford
         University, 1979. Print.
 
-    For more details, see classes Cantera::PureFluid and tpx::Heptane in the
+    For more details, see classes :ct:PureFluid and tpx::Heptane in the
     Cantera C++ source code documentation.
     """
     return PureFluid('liquidvapor.yaml', 'heptane')

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -87,6 +87,9 @@ class TestModels(utilities.CanteraTest):
             try:
                 sol = ct.Solution(self.yml_file, ph_name)
                 a = ct.SolutionArray(sol, 10)
+                if ph['thermo'] == 'liquid-water-IAPWS95':
+                    # ensure that phase remains liquid
+                    a.TP = sol.T, sol.critical_pressure
 
                 # assign some state
                 T = 373.15 + 100*np.random.rand(10)

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -841,10 +841,10 @@ class ctml2yamlTest(utilities.CanteraTest):
 
         return ctmlPhase, yamlPhase
 
-    def checkThermo(self, ctmlPhase, yamlPhase, temperatures, tol=1e-7):
+    def checkThermo(self, ctmlPhase, yamlPhase, temperatures, pressure=ct.one_atm, tol=1e-7):
         for T in temperatures:
-            ctmlPhase.TP = T, ct.one_atm
-            yamlPhase.TP = T, ct.one_atm
+            ctmlPhase.TP = T, pressure
+            yamlPhase.TP = T, pressure
             cp_ctml = ctmlPhase.partial_molar_cp
             cp_yaml = yamlPhase.partial_molar_cp
             h_ctml = ctmlPhase.partial_molar_enthalpies
@@ -1134,7 +1134,7 @@ class ctml2yamlTest(utilities.CanteraTest):
             Path(self.test_work_dir).joinpath("liquid-water.yaml"),
         )
         ctmlWater, yamlWater = self.checkConversion("liquid-water")
-        self.checkThermo(ctmlWater, yamlWater, [300, 500, 1300, 2000])
+        self.checkThermo(ctmlWater, yamlWater, [300, 500, 1300, 2000], pressure=22064000.0)
         self.assertEqual(ctmlWater.transport_model, yamlWater.transport_model)
         dens = ctmlWater.density
         for T in [298, 1001, 2400]:

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -361,10 +361,9 @@ class TestPureFluid(utilities.CanteraTest):
         w = ct.Water(backend='default')
         self.assertEqual(w.thermo_model, 'PureFluid')
         w = ct.Water(backend='iapws95')
-        self.assertEqual(w.thermo_model, 'Water')
+        self.assertEqual(w.thermo_model, 'WaterSSTP')
         with self.assertRaisesRegex(KeyError, 'Unknown backend'):
             ct.Water('foobar')
-
 
     def test_water_iapws(self):
         w = ct.Water(backend='iapws95')

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -357,8 +357,17 @@ class TestPureFluid(utilities.CanteraTest):
         co2 = ct.CarbonDioxide()
         self.assertEqual(co2.phase_of_matter, "gas")
 
-    def test_liquidwater(self):
-        w = ct.LiquidWater()
+    def test_water_backends(self):
+        w = ct.Water(backend='default')
+        self.assertEqual(w.thermo_model, 'PureFluid')
+        w = ct.Water(backend='iapws95')
+        self.assertEqual(w.thermo_model, 'Water')
+        with self.assertRaisesRegex(KeyError, 'Unknown backend'):
+            ct.Water('foobar')
+
+
+    def test_water_iapws(self):
+        w = ct.Water(backend='iapws95')
         self.assertNear(w.critical_density, 322.)
         self.assertNear(w.critical_temperature, 647.096)
         self.assertNear(w.critical_pressure, 22064000.0)
@@ -382,9 +391,9 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertEqual(w.phase_of_matter, "liquid")
         w.TP = w.T, w.P_sat
         self.assertEqual(w.phase_of_matter, "liquid")
-        with self.assertRaisesRegex(ct.CanteraError, "violates model assumptions"):
+        with self.assertRaisesRegex(ct.CanteraError, "Not implemented"):
             w.TP = 273.1599999, ct.one_atm
-        with self.assertRaisesRegex(ct.CanteraError, "violates model assumptions"):
+        with self.assertRaisesRegex(ct.CanteraError, "Not implemented"):
             w.TP = 500, ct.one_atm
 
 

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -367,9 +367,11 @@ class TestPureFluid(utilities.CanteraTest):
         # density before updating pressure)
         w.TP = 300, ct.one_atm
         dens = w.density
-        w.TP = 2000, ct.one_atm # supercricial
+        w.TP = 2000, ct.one_atm # supercritical
+        self.assertEqual(w.phase_of_matter, "supercritical")
         w.TP = 300, ct.one_atm # state goes from supercritical -> gas -> liquid
         self.assertNear(w.density, dens)
+        self.assertEqual(w.phase_of_matter, "liquid")
 
         # test setters for critical conditions
         w.TP = w.critical_temperature, w.critical_pressure
@@ -377,6 +379,9 @@ class TestPureFluid(utilities.CanteraTest):
         w.TP = 2000, ct.one_atm # uses current density as initial guess
         w.TP = 273.16, ct.one_atm # uses fixed density as initial guess
         self.assertNear(w.density, 999.84376)
+        self.assertEqual(w.phase_of_matter, "liquid")
+        w.TP = w.T, w.P_sat
+        self.assertEqual(w.phase_of_matter, "liquid")
         with self.assertRaisesRegex(ct.CanteraError, "violates model assumptions"):
             w.TP = 273.1599999, ct.one_atm
         with self.assertRaisesRegex(ct.CanteraError, "violates model assumptions"):

--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -358,15 +358,15 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertEqual(co2.phase_of_matter, "gas")
 
     def test_water_backends(self):
-        w = ct.Water(backend='default')
+        w = ct.Water(backend='Reynolds')
         self.assertEqual(w.thermo_model, 'PureFluid')
-        w = ct.Water(backend='iapws95')
-        self.assertEqual(w.thermo_model, 'WaterSSTP')
+        w = ct.Water(backend='IAPWS95')
+        self.assertEqual(w.thermo_model, 'liquid-water-IAPWS95')
         with self.assertRaisesRegex(KeyError, 'Unknown backend'):
             ct.Water('foobar')
 
     def test_water_iapws(self):
-        w = ct.Water(backend='iapws95')
+        w = ct.Water(backend='IAPWS95')
         self.assertNear(w.critical_density, 322.)
         self.assertNear(w.critical_temperature, 647.096)
         self.assertNear(w.critical_pressure, 22064000.0)
@@ -390,9 +390,9 @@ class TestPureFluid(utilities.CanteraTest):
         self.assertEqual(w.phase_of_matter, "liquid")
         w.TP = w.T, w.P_sat
         self.assertEqual(w.phase_of_matter, "liquid")
-        with self.assertRaisesRegex(ct.CanteraError, "Not implemented"):
+        with self.assertRaisesRegex(ct.CanteraError, "assumes liquid phase"):
             w.TP = 273.1599999, ct.one_atm
-        with self.assertRaisesRegex(ct.CanteraError, "Not implemented"):
+        with self.assertRaisesRegex(ct.CanteraError, "assumes liquid phase"):
             w.TP = 500, ct.one_atm
 
 

--- a/interfaces/matlab/toolbox/HFC134a.m
+++ b/interfaces/matlab/toolbox/HFC134a.m
@@ -2,10 +2,10 @@ function h = HFC134a()
 % HFC134A  Return an object representing refrigerant HFC134a.
 % h = HFC134a()
 % The object returned by this method implements an accurate equation of
-% state for refrigerant HFC134a (R134a)  that can be used in the liquid,
+% state for refrigerant HFC134a (R134a) that can be used in the liquid,
 % vapor, saturated liquid/vapor, and supercritical regions of the phase
 % diagram. Implements the equation of state given in:
-% R. Tillner-Roth and H.D. Baehr. "An International Standard Formulation for
+% R. Tillner-Roth and H. D. Baehr. "An International Standard Formulation for
 % The Thermodynamic Properties of 1,1,1,2-Tetrafluoroethane (HFC-134a) for
 % Temperatures From 170 K to 455 K and Pressures up to 70 MPa". J. Phys.
 % Chem. Ref. Data, Vol. 23, No. 5, 1994. pp. 657--729.

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -135,8 +135,15 @@ void ThermoPhase::setState_TPY(doublereal t, doublereal p, const std::string& y)
 
 void ThermoPhase::setState_TP(doublereal t, doublereal p)
 {
-    setTemperature(t);
-    setPressure(p);
+    double tsave = temperature();
+    double dsave = density();
+    try {
+        setTemperature(t);
+        setPressure(p);
+    } catch (CanteraError&) {
+        setState_TR(tsave, dsave);
+        throw;
+    }
 }
 
 void ThermoPhase::setState_RPX(doublereal rho, doublereal p, const doublereal* x)

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -78,6 +78,15 @@ doublereal WaterPropsIAPWS::pressure() const
 doublereal WaterPropsIAPWS::density(doublereal temperature, doublereal pressure,
                                     int phase, doublereal rhoguess)
 {
+    if (fabs(pressure - P_c) / P_c < 1.e-8 &&
+        fabs(temperature - T_c) / T_c < 1.e-8) {
+        // Catch critical point, as no solution is found otherwise
+        setState_TR(temperature, Rho_c);
+        return Rho_c;
+    } else if (fabs(rhoguess - Rho_c) / Rho_c < 1.e-8) {
+        // Starting a search with the critical density would fail
+        rhoguess *= .9;
+    }
     doublereal deltaGuess = 0.0;
     if (rhoguess == -1.0) {
         if (phase != -1) {
@@ -109,7 +118,7 @@ doublereal WaterPropsIAPWS::density(doublereal temperature, doublereal pressure,
     setState_TR(temperature, rhoguess);
     doublereal delta_retn = m_phi.dfind(p_red, tau, deltaGuess);
     doublereal density_retn;
-    if (delta_retn >0.0) {
+    if (delta_retn > 0.0) {
         delta = delta_retn;
 
         // Dimensionalize the density before returning

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -44,6 +44,13 @@ WaterSSTP::WaterSSTP(XML_Node& phaseRoot, const std::string& id) :
     importPhase(phaseRoot, this);
 }
 
+std::string WaterSSTP::phaseOfMatter() const {
+    const vector<std::string> phases = {
+        "gas", "liquid", "supercritical", "unstable-liquid", "unstable-gas"
+    };
+    return phases[m_sub.phaseState()];
+}
+
 void WaterSSTP::initThermo()
 {
     SingleSpeciesTP::initThermo();

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -282,18 +282,14 @@ void WaterSSTP::setPressure(doublereal p)
             dens = 1000.;
         } else if (!m_allowGasPhase) {
             throw CanteraError("WaterSSTP::setPressure",
-                               "Pressure p = {} lies below the saturation "
-                               "pressure\n(P_sat = {}), which violates model "
-                               "assumptions.", p, pp);
+                               "Not implemented: pressure p = {} lies below\n"
+                               "the saturation pressure (P_sat = {}).", p, pp);
         }
     }
 
     double dd = m_sub.density(T, p, waterState, dens);
     if (dd <= 0.0) {
-        throw CanteraError("WaterSSTP::setPressure",
-                           "error: T = {}, p = {}, psat = {}\n"
-                           "density_guess = {}, density_fail = {}",
-                           T, p, pp, dens, dd);
+        throw CanteraError("WaterSSTP::setPressure", "Error");
     }
     setDensity(dd);
 }
@@ -344,8 +340,8 @@ void WaterSSTP::setTemperature(const doublereal temp)
 {
     if (temp < 273.16) {
         throw CanteraError("WaterSSTP::setTemperature",
-                           "Temperature T = {} lies below the triple point "
-                           "temperature,\nwhich violates model assumptions.",
+                           "Not implemented: temperature T = {} lies below\n"
+                           "the triple point temperature (T_triple = 273.16).",
                            temp);
     }
     Phase::setTemperature(temp);

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -282,8 +282,8 @@ void WaterSSTP::setPressure(doublereal p)
             dens = 1000.;
         } else if (!m_allowGasPhase) {
             throw CanteraError("WaterSSTP::setPressure",
-                               "Not implemented: pressure p = {} lies below\n"
-                               "the saturation pressure (P_sat = {}).", p, pp);
+                "Model assumes liquid phase; pressure p = {} lies below\n"
+                "the saturation pressure (P_sat = {}).", p, pp);
         }
     }
 
@@ -340,9 +340,8 @@ void WaterSSTP::setTemperature(const doublereal temp)
 {
     if (temp < 273.16) {
         throw CanteraError("WaterSSTP::setTemperature",
-                           "Not implemented: temperature T = {} lies below\n"
-                           "the triple point temperature (T_triple = 273.16).",
-                           temp);
+            "Model assumes liquid phase; temperature T = {} lies below\n"
+            "the triple point temperature (T_triple = 273.16).", temp);
     }
     Phase::setTemperature(temp);
     m_sub.setState_TR(temp, density());

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -266,14 +266,14 @@ doublereal WaterSSTP::pressure() const
 void WaterSSTP::setPressure(doublereal p)
 {
     double T = temperature();
-    double dens = 1.;
+    double dens = density();
     double pp = m_sub.psat(T);
     int waterState = WATER_SUPERCRIT;
     if (T < m_sub.Tcrit()) {
         if (p >= pp) {
             waterState = WATER_LIQUID;
             dens = 1000.;
-        } else {
+        } else if (!m_allowGasPhase) {
             throw CanteraError("WaterSSTP::setPressure",
                                "Pressure p = {} lies below the saturation "
                                "pressure\n(P_sat = {}), which violates model "

--- a/src/tpx/HFC134a.h
+++ b/src/tpx/HFC134a.h
@@ -13,7 +13,7 @@ namespace tpx
 //! Equation of state for HFC-134a.
 //!
 //! Implements the equation of state given in:
-//! R. Tillner-Roth and H.D. Baehr. "An International Standard Formulation for
+//! R. Tillner-Roth and H. D. Baehr. "An International Standard Formulation for
 //! The Thermodynamic Properties of 1,1,1,2-Tetrafluoroethane (HFC-134a) for
 //! Temperatures From 170 K to 455 K and Pressures up to 70 MPa". J. Phys.
 //! Chem. Ref. Data, Vol. 23, No. 5, 1994. pp. 657--729.

--- a/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
+++ b/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
@@ -1,4 +1,5 @@
 #include "cantera/thermo/ThermoFactory.h"
+#include "cantera/thermo/WaterSSTP.h"
 #include <iostream>
 
 using namespace std;
@@ -21,6 +22,7 @@ int main()
     double pres;
     try {
         ThermoPhase* w = newPhase("liquid-water.xml");
+        (dynamic_cast<WaterSSTP*>(w))->allowGasPhase(true);
 
         /*
          * Print out the triple point conditions

--- a/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
+++ b/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
@@ -21,7 +21,7 @@ int main()
 #endif
     double pres;
     try {
-        ThermoPhase* w = newPhase("liquid-water.xml");
+        ThermoPhase* w = newPhase("liquidvapor.yaml", "water-iapws95");
         (dynamic_cast<WaterSSTP*>(w))->allowGasPhase(true);
 
         /*

--- a/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
+++ b/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
@@ -22,7 +22,7 @@ int main()
     double pres;
     try {
         ThermoPhase* w = newPhase("liquidvapor.yaml", "liquid-water-IAPWS95");
-        (dynamic_cast<WaterSSTP*>(w))->allowGasPhase(true);
+        (dynamic_cast<WaterSSTP*>(w))->_allowGasPhase(true);
 
         /*
          * Print out the triple point conditions

--- a/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
+++ b/test_problems/cathermo/testWaterTP/testWaterSSTP.cpp
@@ -21,7 +21,7 @@ int main()
 #endif
     double pres;
     try {
-        ThermoPhase* w = newPhase("liquidvapor.yaml", "water-iapws95");
+        ThermoPhase* w = newPhase("liquidvapor.yaml", "liquid-water-IAPWS95");
         (dynamic_cast<WaterSSTP*>(w))->allowGasPhase(true);
 
         /*


### PR DESCRIPTION
There are some open issues with `WaterPropsIAWSS`; adding access to `WaterSSTP` via an alternative backend to the `Water` wrapper facilitates interactions with underlying C++ objects.

The `WaterPropsIAPWS` helper classes implement a highly accurate Industrial Formulation for the equation of state for pure water, which is currently used by `WaterSSTP` and `PDSS_Water` classes. The former is loadable via YAML as part of the `ThermoFactory` approach, but only implements the liquid portion. Per @bryanwweber ’s observations (in #721):

> The `WaterSSTP` phase, as implied by the name in the XML file (`PureLiquidWater`), is intended to represent only the liquid states of water. It is based on the `WaterPropsIAPWS` class, which can represent liquid to vapor states, but the `WaterSSTP` class is used in a few places where liquids only are the assumption. Hypothetically, a different class that implements the full behavior of the EOS could be written using `WaterPropsIAPWS`, but this ain't it.

The current loader is cumbersome and involves a custom input file, e.g.
```
water = ct.PureFluid('test/data/liquid-water.xml')
```
from within the cantera source folder (see #721), i.e. suitable input files aren’t distributed outside the test suite. The proposed change enables loading of the `WaterSSTP` model via
```
water = ct.Water(backend='IAPWS95')
```
while the existing behavior remains the default. Beyond, this PR also fixes some open issues.

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Add phase using `liquid-water-IAPWS95` to `liquidvapor.yaml`
- Add an alternative `backend=iawps95` switch to the existing Python `Water` interface to facilitate usage to the `liquid-water-IAPWS95` thermo model; the existing behavior corresponds to `backend=default`
- Update Python docstrings with information already available in MATLAB wrapper classes
- Clarify role of `WaterSSTP` helper classes (based on @24sharkS 's solution in #809)
- Ensure that state of `WaterSSTP` remains liquid (or supercritical) - this checks the classical criterion for saturated conditions.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #577, fixes #646, fixes #721

**Related Issues**

Cantera/enhancements#6, #809 

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review

**Other thoughts**

1. Short-term, this fixes some issues and (hopefully) helps clarify the IAPWS formulation.
2. Long-term, it may make sense to add [CoolProp](https://github.com/CoolProp/CoolProp) objects as additional alternative `backend` s for existing wrapper objects, see Cantera/enhancements#35.