### PR TITLE
Fix minimal python

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -164,7 +164,7 @@ jobs:
         run: |
           sudo apt-get install libboost-dev gfortran scons python3-numpy \
           python3-pip python3-setuptools python3-h5py python3-pandas \
-          python3-ruamel.yaml cython libsundials-dev liblapack-dev \
+          python3-ruamel.yaml python-numpy cython3 libsundials-dev liblapack-dev \
           libblas-dev
       - name: Build Cantera
         run: scons build python_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas -j2

--- a/SConstruct
+++ b/SConstruct
@@ -1347,11 +1347,6 @@ if env['python_package'] != 'none':
                         ruamel_yaml_version, ruamel_min_version))
                 sys.exit(1)
 
-        if len(info) > expected_output_lines:
-            print("WARNING: Unexpected output while checking Python "
-                  "dependency versions:")
-            print('| ' + '\n| '.join(info[expected_output_lines:]))
-
     if warn_no_python:
         if env['python_package'] == 'default':
             print('WARNING: Not building the Python package because the Python '
@@ -1370,7 +1365,17 @@ if env['python_package'] != 'none':
         elif env["python_package"] == "default":
             print(msg.format("WARNING", python_version, python_min_version))
             env["python_package"] = "none"
+    elif env['python_package'] == 'minimal':
+        # If the minimal package was specified, no further checking
+        # needs to be done
+        print('INFO: Building the minimal Python package for Python {}'.format(python_version))
     else:
+
+        if len(info) > expected_output_lines:
+            print("WARNING: Unexpected output while checking Python "
+                  "dependency versions:")
+            print('| ' + '\n| '.join(info[expected_output_lines:]))
+
         warn_no_full_package = False
         if python_version >= LooseVersion("3.8"):
             # Reset the minimum Cython version if the Python version is 3.8 or higher


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Fixes the minimal Python builder. If Cython and NumPy are installed, the full package is built even if 'minimal' is specified. This is now fixed so `'minimal'` actually builds the minimal interface.
- Fix installing Cython and NumPy on the Ubuntu 18.04/Python 2 builder

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
