### PR TITLE
Ensure consistent extra columns in SolutionArray

### DIFF
--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1754,7 +1754,19 @@ class TestSolutionArray(utilities.CanteraTest):
         with self.assertRaisesRegex(ValueError, "Initial values for extra properties"):
             ct.SolutionArray(self.gas, 3, extra=np.array(["prop", "prop2"]))
 
-    def test_extra_wrong_shape(self):
+    def test_extra_create_multidim(self):
+        # requires matching first dimensions
+        extra_val = [[1, 2, 3] for i in range(5)]
+        states = ct.SolutionArray(self.gas, 5, extra={"prop": extra_val})
+        self.assertEqual(states.prop.shape, (5, 3,))
+        states = ct.SolutionArray(self.gas, 5, extra={"prop": np.array(extra_val)})
+        self.assertEqual(states.prop.shape, (5, 3,))
+        states = ct.SolutionArray(self.gas, (3, 4,), extra={"prop": np.ones((3, 4, 5,))})
+        self.assertEqual(states.prop.shape, (3, 4, 5,))
+        states = ct.SolutionArray(self.gas, 1, extra={"prop": extra_val[0]})
+        self.assertEqual(states.prop.shape, (1, 3,))
+        states = ct.SolutionArray(self.gas, 1, extra={"prop": [2]})
+        self.assertEqual(states.prop.shape, (1,))
         with self.assertRaisesRegex(ValueError, "Unable to map"):
             ct.SolutionArray(self.gas, (3, 3), extra={"prop": np.arange(3)})
 
@@ -1771,6 +1783,11 @@ class TestSolutionArray(utilities.CanteraTest):
         with self.assertRaisesRegex(TypeError, "is not a string"):
             ct.SolutionArray(self.gas, extra=[1])
 
+    def test_extra_no_objects(self):
+        with self.assertRaisesRegex(ValueError, "not supported"):
+            prop = np.array([0, [1, 2], (3, 4)], dtype=np.object)
+            states = ct.SolutionArray(self.gas, 3, extra={"prop": prop})
+
     def test_extra_reserved_names(self):
         with self.assertRaisesRegex(ValueError, "name is already used"):
             ct.SolutionArray(self.gas, extra=["creation_rates"])
@@ -1782,6 +1799,16 @@ class TestSolutionArray(utilities.CanteraTest):
         states = ct.SolutionArray(self.gas, extra="prop")
         self.assertEqual(states.prop.shape, (0,))
 
+    def test_extra_setattr(self):
+        states = ct.SolutionArray(self.gas, 7, extra={'prop': range(7)})
+        states.prop = 0
+        self.assertArrayNear(states.prop, np.zeros((7,)))
+        mod_array = np.linspace(0, 10, 7)
+        states.prop = mod_array
+        self.assertArrayNear(states.prop, mod_array)
+        with self.assertRaisesRegex(ValueError, "Incompatible shapes"):
+            states.prop = [1, 2]
+
     def test_assign_to_slice(self):
         states = ct.SolutionArray(self.gas, 7, extra={'prop': range(7)})
         array = np.arange(7)
@@ -1790,6 +1817,13 @@ class TestSolutionArray(utilities.CanteraTest):
         states.prop[3:5] = [0, 1]
         array_mod = np.array([0, -5, 2, 0, 1, 5, 6])
         self.assertArrayNear(states.prop, array_mod)
+        # assign to multi-dimensional extra
+        extra_val = [[1, 2, 3] for i in range(5)]
+        states = ct.SolutionArray(self.gas, 5, extra={"prop": extra_val})
+        states.prop[:, 1] = -1
+        self.assertArrayNear(states.prop[:, 1], -1 * np.ones((5,)))
+        states.prop[2, :] = -2
+        self.assertArrayNear(states.prop[2, :], -2 * np.ones((3,)))
 
     def test_extra_create_by_ndarray(self):
         properties_array = np.array(["prop1", "prop2", "prop3"])
@@ -1838,6 +1872,10 @@ class TestSolutionArray(utilities.CanteraTest):
         # NumPy converts to the existing type of the array
         self.assertEqual(states.prop[-1], "100")
         self.assertEqual(states.prop.shape, (7,))
+        # two-dimensional input array
+        states = ct.SolutionArray(self.gas, 1, extra={"prop": [1, 2, 3]})
+        states.append(T=1100, P=3e5, X="AR:1.0", prop=['a', 'b', 'c'])
+        self.assertEqual(states._shape, (2,))
 
     def test_append_failures(self):
         states = ct.SolutionArray(self.gas, 5, extra={"prop": "value"})
@@ -1860,6 +1898,19 @@ class TestSolutionArray(utilities.CanteraTest):
             states.append(T=1100, P=3e5, I="AR:1.0", prop="value2")
         # Failing to append a state shouldn't change the size
         self.assertEqual(states._shape, (5,))
+
+        with self.assertRaisesRegex(ValueError, "incompatible value"):
+            # prop has incompatible dimensions
+            states.append(T=1100, P=3e5, X="AR:1.0", prop=[1, 2, 3])
+        # Failing to append a state shouldn't change the size
+        self.assertEqual(states._shape, (5,))
+
+        states = ct.SolutionArray(self.gas, 1, extra={"prop": [1, 2, 3]})
+        with self.assertRaisesRegex(ValueError, "does not match"):
+            # prop has incorrect dimensions
+            states.append(T=1100, P=3e5, X="AR:1.0", prop=['a', 'b'])
+        # Failing to append a state shouldn't change the size
+        self.assertEqual(states._shape, (1,))
 
     def test_purefluid(self):
         water = ct.Water()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Fix bugs in beta release of 2.5.0b1
- Ensure that dimensions of `extra` columns are consistent
- Enable multi-dimensional `extra` 'columns' (e.g. 2D arrays similar to what already exists for other `SolutionArray` attributes)
- Like the existing code, this PR takes advantage of NumPy for on-the-fly adjustments of data types.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #895, fixes #930

**Illustration**

```
In [2]: gas = ct.Solution("air.yaml")
   ...: states = ct.SolutionArray(gas, 3, extra={"prop": [5, 6, 7]})
   ...: states.append(TPX=(1100, 3e5, "AR:1.0"), prop=[1, 2, 3]) # <--- Fix #895
   ...: 
---------------------------------------------------------------------------
[...]
ValueError: Encountered incompatible value '[1, 2, 3]' for extra column 'prop'.

In [3]: states.prop = ‘spam’ # <--- overwrite individual entries / Fix #930
   ...: states.prop
   ...: 
Out[3]: array([‘spam’, ‘spam’, ‘spam’], dtype=‘<U4’)

In [4]: states.prop = np.ones((3,4)) # <--- enable multi-dimensional extra 'columns'
   ...: states.prop
   ...: 
Out[4]: 
array([[1., 1., 1., 1.],
       [1., 1., 1., 1.],
       [1., 1., 1., 1.]])

In [5]: states.prop = [1, 2, 3, 4] # <--- ensure that dimensions are consistent
---------------------------------------------------------------------------
[...]
ValueError: Incompatible shapes for extra column 'prop': cannot assign value with shape (4,) to SolutionArray with shape (3,)
```

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
