### PR TITLE
FIX: Update isentropic.py - thermo example

### DIFF
--- a/interfaces/cython/cantera/examples/thermo/isentropic.py
+++ b/interfaces/cython/cantera/examples/thermo/isentropic.py
@@ -69,5 +69,7 @@ if __name__ == "__main__":
         plt.show()
 
     except ImportError:
+        print('Matplotlib not found. Unable to plot results.')
+    except:  # noqa
         print('area ratio,   Mach number,   temperature,   pressure ratio')
         print(data)


### PR DESCRIPTION
The ImportError doesn't notify the user that matplotlib is missing.

It simply prints debugging information which may be more confusing than not catching the error altogether.

This modification notifies the user and then prints debugging info in case of any other exceptions.

`noqa` is used for flake8 if the repository uses it to verify code quality.

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

-
-
-

**If applicable, fill in the issue number this pull request is fixing**

Fixes #

**Checklist**

- [ ] There is a clear use-case for this code change
- [ ] The commit message has a short title & references relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] The pull request is ready for review
