### PR TITLE
Fix typo in docstring

### DIFF
--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1144,7 +1144,7 @@ cdef class ThermoPhase(_SolutionBase):
             return self.thermo.entropy_mole()
 
     property entropy_mass:
-        """Specific entropy [J/kg]."""
+        """Specific entropy [J/kg/K]."""
         def __get__(self):
             return self.thermo.entropy_mass()
 


### PR DESCRIPTION
Units of mass-specific entropy (`entropy_mass`) are updated to J/kg/K

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Fix typo (which affects documentation via sphinx)

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
