### PR TITLE
[Kinetics] Make output of Pdep error messages consistent

### DIFF
--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -103,7 +103,7 @@ void Plog::validate(const std::string& equation)
             if (k < 0) {
                 format_to(err_reactions,
                           "\nInvalid rate coefficient for reaction '{}'\n"
-                          "at P = {:.5g}, T = {}\n",
+                          "at P = {:.5g}, T = {:.1f}\n",
                           equation, std::exp(iter->first), T[i]);
             }
         }


### PR DESCRIPTION
**Changes proposed in this pull request**

- Use an explicit formatting string for the Pdep error messages

**If applicable, fill in the issue number this pull request is fixing**

Fixes #944

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
