### PR TITLE
[thermo] Throw IndexError for invalid species index

### DIFF
--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -65,6 +65,8 @@ class TestThermoPhase(utilities.CanteraTest):
             self.assertEqual(name, self.phase.species_name(i))
             self.assertEqual(i, self.phase.species_index(name))
             self.assertEqual(i, self.phase.species_index(i))
+        with self.assertRaisesRegex(ct.CanteraError, 'IndexError thrown by Phase::checkSpeciesIndex'):
+            self.phase.species(self.phase.n_species)
 
     def test_elements(self):
         self.assertEqual(self.phase.n_elements, 3)

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -990,6 +990,7 @@ shared_ptr<Species> Phase::species(const std::string& name) const
 
 shared_ptr<Species> Phase::species(size_t k) const
 {
+    checkSpeciesIndex(k);
     return m_species.at(m_speciesNames[k]);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- raise `IndexError` for invalid species
- use existing `checkSpeciesIndex` method

```
In [1]: import cantera as ct
   ...: gas = ct.Solution('gri30.yaml')
   ...: 

In [2]: gas.species(53)
---------------------------------------------------------------------------
CanteraError                              Traceback (most recent call last)
<ipython-input-2-1d8e247355bb> in <module>()
----> 1 gas.species(53)

/src/interfaces/cython/cantera/thermo.pyx in cantera._cantera.ThermoPhase.species()
    592             s._assign(self.thermo.species(stringify(k)))
    593         elif isinstance(k, (int, float)):
--> 594             s._assign(self.thermo.species(<int>k))
    595         else:
    596             raise TypeError("Argument must be a string or a number."

CanteraError: 
***********************************************************************
IndexError thrown by Phase::checkSpeciesIndex:
IndexError: species[53] outside valid range of 0 to 52.
***********************************************************************
```

**If applicable, fill in the issue number this pull request is fixing**

Fixes #948

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
