### PR TITLE
Loosen tolerances in PureFluidTestCases.test_consistency_volume

### DIFF
--- a/interfaces/cython/cantera/test/test_purefluid.py
+++ b/interfaces/cython/cantera/test/test_purefluid.py
@@ -330,7 +330,7 @@ class PureFluidTestCases:
             a2 = self.a(state.T, 1/(V+0.5*dV))
 
             # dP/drho is high for liquids, so relax tolerances
-            tol = 100*self.tol.dAdV if state.phase == 'liquid' else self.tol.dAdV
+            tol = 300*self.tol.dAdV if state.phase == 'liquid' else self.tol.dAdV
 
             # At constant temperature, dA = - p dV
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)


### PR DESCRIPTION
This seems to be required to get this test to pass on the FPUs on Power9 and ARM. See
https://github.com/conda-forge/cantera-feedstock/pull/1
specifically the build failure for
https://github.com/conda-forge/cantera-feedstock/pull/1/commits/22bc536d649d6f8ba392dd83f1e289c84cf37a3e
and the successful build for
https://github.com/conda-forge/cantera-feedstock/pull/1/commits/472b4eb76d3abae6e8d4fb3eaf461e2babc968a4