### PR TITLE
Enabling beta = 0.

### DIFF
--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -1319,9 +1319,11 @@ class reaction(object):
             self._kf = []
 
         if self._type == 'edge' or self._type == 'surface':
-            if self._beta > 0:
+            if self._beta is not None:
                 electro = kfnode.addChild('electrochem')
                 electro['beta'] = repr(self._beta)
+            else:
+                self._beta = 0.0
 
         for kf in self._kf:
             if isinstance(kf, rate_expression):
@@ -1640,7 +1642,7 @@ class surface_reaction(reaction):
                  kf=None,
                  id='',
                  order='',
-                 beta = 0.0,
+                 beta = None,
                  options=[],
                  rate_coeff_type = ''):
         """
@@ -1686,7 +1688,7 @@ class edge_reaction(reaction):
                  kf = None,
                  id = '',
                  order = '',
-                 beta = 0.0,
+                 beta = None,
                  options = [],
                  rate_coeff_type = ''):
         reaction.__init__(self, equation, kf, id, order, options)

--- a/interfaces/cython/cantera/ctml_writer.py
+++ b/interfaces/cython/cantera/ctml_writer.py
@@ -1322,8 +1322,6 @@ class reaction(object):
             if self._beta is not None:
                 electro = kfnode.addChild('electrochem')
                 electro['beta'] = repr(self._beta)
-            else:
-                self._beta = 0.0
 
         for kf in self._kf:
             if isinstance(kf, rate_expression):


### PR DESCRIPTION
**Changes proposed in this pull request**

- For electrochemical reactions, changes the default `beta` value in `ctml_writer.py` to `None`, and checks to see if `beta` has been set to a value that is not `None` to detect an electrochemical reaction.
- Previously, the default was `beta = 0.0` which resulted in electrochemical reactions with `beta = 0.0` not being detected, and therefore handled incorrectly.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #954 

**Checklist**

- [X] There is a clear use-case for this code change
- [X] The commit message has a short title & references relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] The pull request is ready for review
