### PR TITLE
Reduce macOS CI jobs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.5', '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.8', '3.9' ]
         os: ['macos-10.15', 'macos-11.0']
       fail-fast: false
     steps:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Remove Python 3.5 and 3.6 from the macOS CI job, to reduce bottlenecks due to the [limited number of concurrent](https://docs.github.com/en/actions/reference/usage-limits-billing-and-administration) macOS jobs

**If applicable, fill in the issue number this pull request is fixing**

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
