### PR TITLE
Fix issues when using _GLIBCXX_ASSERTIONS

### DIFF
--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -83,7 +83,13 @@ public:
 
     /// The index of the start of domain i in the solution vector.
     size_t start(size_t i) const {
-        return m_dom[i]->loc();
+        if (m_dom[i]->nComponents()) {
+            return m_dom[i]->loc();
+        } else {
+            // Special case for domains with no solution components to avoid
+            // spurious out-of-bounds memory access
+            return 0;
+        }
     }
 
     /// Total solution vector length;

--- a/src/equil/vcs_prep.cpp
+++ b/src/equil/vcs_prep.cpp
@@ -191,7 +191,7 @@ int VCS_SOLVE::vcs_prep(int printLvl)
 
     // Check to see if the current problem is well posed.
     double sum = 0.0;
-    for (size_t e = 0; e < m_nelem; e++) {
+    for (size_t e = 0; e < m_mix->nElements(); e++) {
         sum += m_mix->elementMoles(e);
     }
     if (sum < 1.0E-20) {

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -113,10 +113,10 @@ XML_Node& Domain1D::save(XML_Node& o, const doublereal* const sol)
     d.addAttribute("points", nPoints());
     d.addAttribute("components", nComponents());
     d.addAttribute("id", id());
-    addFloatArray(d, "abstol_transient", nComponents(), &m_atol_ts[0]);
-    addFloatArray(d, "reltol_transient", nComponents(), &m_rtol_ts[0]);
-    addFloatArray(d, "abstol_steady", nComponents(), &m_atol_ss[0]);
-    addFloatArray(d, "reltol_steady", nComponents(), &m_rtol_ss[0]);
+    addFloatArray(d, "abstol_transient", nComponents(), m_atol_ts.data());
+    addFloatArray(d, "reltol_transient", nComponents(), m_rtol_ts.data());
+    addFloatArray(d, "abstol_steady", nComponents(), m_atol_ss.data());
+    addFloatArray(d, "reltol_steady", nComponents(), m_rtol_ss.data());
     return d;
 }
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -133,7 +133,7 @@ void Sim1D::restore(const std::string& fname, const std::string& id,
     resize();
     m_xlast_ts.clear();
     for (size_t m = 0; m < nDomains(); m++) {
-        domain(m).restore(*xd[m], &m_x[domain(m).loc()], loglevel);
+        domain(m).restore(*xd[m], &m_x[start(m)], loglevel);
     }
     finalize();
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Allow Cantera to successfully run with the `_GLIBCXX_ASSERTIONS` macro enabled
- Fix a couple of instances of spurious out-of-bounds memory access in the 1D solver
- Fix a case of out-of-bounds memory access in the VCS equilibrium solver

**If applicable, fill in the issue number this pull request is fixing**

Fixes #901

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
