### PR TITLE
Fix ck2yaml problems with surface reactions / coverages

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -50,7 +50,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.8', '3.9' ]
-        os: ['macos-10.15', 'macos-11.0']
+        os: ['macos-10.15']
       fail-fast: false
     steps:
     # Attempt to fix intermittent cloning errors. The error message says something like

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -48,7 +48,7 @@ if localenv['OS'] == 'Darwin':
     # and causes the warnings to appear will be removed in Python 3.9 so no
     # further warnings should be issued. Cython has already implemented a fix
     # in versions higher than 0.29.14.
-    if py_version == LooseVersion("3.8"):
+    if py_version == parse_version("3.8"):
         localenv.Append(CXXFLAGS='-Wno-deprecated-declarations')
 elif localenv['OS'] == 'Windows':
     localenv.Append(LIBPATH=prefix+'/libs')

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1787,6 +1787,9 @@ class Parser:
                             revReaction.line_number = line_number
                             reactions.append(revReaction)
 
+                    for index, reaction in enumerate(reactions):
+                        reaction.index = index + 1
+
                 elif tokens[0].upper().startswith('TRAN'):
                     inHeader = False
                     line, comment = readline()
@@ -1818,9 +1821,6 @@ class Parser:
 
         for h in header:
             self.header_lines.append(h[indent:])
-
-        for index, reaction in enumerate(self.reactions):
-            reaction.index = index + 1
 
         if transportLines:
             self.parse_transport_data(transportLines, path, transport_start_line)

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -462,7 +462,7 @@ class SurfaceRate(KineticsModel):
                 # base reaction
                 if self.rate.Ea[1] != self.rate.parser.output_energy_units:
                     E = '{} {}'.format(E, self.rate.Ea[1])
-                    covdeps[species] = FlowList([A, m, E])
+                covdeps[species] = FlowList([A, m, E])
             output['coverage-dependencies'] = covdeps
 
 

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -428,6 +428,12 @@ class converterTestCommon:
         self.assertEqual(gas.n_reactions, 0)
         self.assertEqual(surf.n_reactions, 15)
 
+        # Coverage dependencies
+        covdeps = surf.reaction(1).coverage_deps
+        self.assertIn('H_Pt', covdeps)
+        self.assertEqual(covdeps['OH_Pt'][1], 1.0)
+        self.assertNear(covdeps['H_Pt'][2], -6e6)
+
     def test_third_body_plus_falloff_reactions(self):
         self.convert('third_body_plus_falloff_reaction.inp')
         gas = ct.Solution('third_body_plus_falloff_reaction' + self.ext)

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -16,7 +16,7 @@ import itertools
 import SCons.Errors
 import SCons
 import SCons.Node.FS
-from distutils.version import LooseVersion, StrictVersion
+from pkg_resources import parse_version
 import distutils.sysconfig
 
 try:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Fix coverage handling in `ck2yaml`
- Fix numbering of surface reactions in `ck2yaml`
- Also fix the latest CI breakage due to the SCons version string `4.1.0.post1` being unparsable by `StrictVersion`
- Also disable macOS 11.0 builds because they just stall and then report failure with no information. Apparently GitHub doesn't have enough runners for these yet? https://github.com/actions/virtual-environments/issues/2486

**If applicable, fill in the issue number this pull request is fixing**

Fixes #956

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
