### PR TITLE
[SCons] Skip OpenMP test/sample when omp.h is not available

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1052,6 +1052,7 @@ else:
     env['cxx_stdlib'] = []
 
 env['HAS_CLANG'] = conf.CheckDeclaration('__clang__', '', 'C++')
+env['HAS_OPENMP'] = conf.CheckCXXHeader('omp.h', '""')
 
 boost_version_source = get_expression_value(['<boost/version.hpp>'], 'BOOST_LIB_VERSION')
 retcode, boost_lib_version = conf.TryRun(boost_version_source, '.cpp')

--- a/SConstruct
+++ b/SConstruct
@@ -265,7 +265,7 @@ env['using_apple_clang'] = False
 # Check if this is actually Apple's clang on macOS
 if env['OS'] == 'Darwin':
     result = subprocess.check_output([env.subst('$CC'), '--version']).decode('utf-8')
-    if 'clang' in result.lower() and 'Xcode' in result:
+    if 'clang' in result.lower() and ('Xcode' in result or 'Apple' in result):
         env['using_apple_clang'] = True
         env['openmp_flag'].insert(0, '-Xpreprocessor')
 

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -36,8 +36,11 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     localenv.Append(LIBS=env['cantera_libs'])
     localenv.Prepend(CPPPATH=['#include'])
 
-    buildSample(localenv.Program, pjoin(subdir, name),
-                mglob(localenv, subdir, *extensions))
+    if openmp and not env['HAS_OPENMP']:
+        print("INFO: Skipping sample {} because 'omp.h' was not found.".format(name))
+    else:
+        buildSample(localenv.Program, pjoin(subdir, name),
+                    mglob(localenv, subdir, *extensions))
 
     # Note: These Makefiles and SConstruct files are automatically installed
     # by the "RecursiveInstall" that grabs everything in the cxx directory.

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -248,10 +248,11 @@ Test('cxx-gas-transport', 'cxx_samples',
 Test('cxx-LiC6-electrode', 'cxx_samples',
      '#build/samples/cxx/LiC6_electrode/LiC6_electrode', None,
      comparisons=[('LiC6_electrode_blessed.csv', 'LiC6_electrode_output.csv')])
-Test('cxx-openmp-ignition', 'cxx_samples',
-     '#build/samples/cxx/openmp_ignition/openmp_ignition',
-     'opmenmp_ignition_blessed.txt',
-     ignoreLines=['Running on'])
+if env['HAS_OPENMP']:
+    Test('cxx-openmp-ignition', 'cxx_samples',
+        '#build/samples/cxx/openmp_ignition/openmp_ignition',
+        'opmenmp_ignition_blessed.txt',
+        ignoreLines=['Running on'])
 Test('cxx-rankine', 'cxx_samples', '#build/samples/cxx/rankine/rankine',
      'rankine_blessed.txt')
 


### PR DESCRIPTION
**Changes proposed in this pull request**

- Check for `omp.h` and skip the running the test and building the sample that require it

**If applicable, fill in the issue number this pull request is fixing**

Fixes #933 

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
