### PR TITLE
[1D/Test] Improve IonBurnerFlame test case

### DIFF
--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -1251,15 +1251,12 @@ class TestIonBurnerFlame(utilities.CanteraTest):
         self.gas = ct.Solution('ch4_ion.cti')
         self.gas.TPX = Tburner, p, reactants
         self.sim = ct.IonBurnerFlame(self.gas, width=width)
-        self.sim.set_refine_criteria(ratio=4, slope=0.4, curve=0.6)
+        self.sim.set_refine_criteria(ratio=4, slope=0.1, curve=0.1)
         self.sim.burner.mdot = self.gas.density * 0.15
         self.sim.transport_model = 'Ion'
 
-        # stage one
-        self.sim.solve(loglevel=0, auto=True)
-
-        #stage two
-        self.sim.solve(loglevel=0, stage=2, enable_energy=True)
+        self.sim.solve(loglevel=0, stage=2, auto=True)
 
         # Regression test
-        self.assertNear(max(self.sim.E), 552.33, 1e-2)
+        self.assertNear(max(self.sim.E), 591.76, 1e-2)
+        self.assertNear(max(self.sim.X[self.gas.species_index('E')]), 8.024e-9, 1e-2)


### PR DESCRIPTION
**Changes proposed in this pull request**

- For the burner-stabilized flame, directly solving the "stage 2" case with drift fluxes for ionized species seems to converge more quickly.
- Tighter grid refinement tolerances are needed to accurately resolve
the peak in the electrif field strength.
- Added another check for the peak in the electron mole fraction.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #935

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
