### PR TITLE
[Test/Reactor] Adjust tolerance for species sensitivity test

### DIFF
--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -1419,7 +1419,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
         gas.set_equivalence_ratio(0.4, 'H2', 'O2:1.0, AR:4.0')
         r = ct.IdealGasReactor(gas)
         net = ct.ReactorNet([r])
-        net.rtol_sensitivity = 1e-5
+        net.rtol_sensitivity = 2e-5
         return gas, r, net
 
     def calc_tig(self, species, dH):


### PR DESCRIPTION
Previous tightening of integration tolerances in 9832c88 seems to generate integrator failures for some configurations.

**Changes proposed in this pull request**

- Reduce integration tolerance for test of ignition delay to species enthalpy of formation

**If applicable, fill in the issue number this pull request is fixing**

Fixes #937

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
