### PR TITLE
Handle species thermo temperature limits, and minor fixes

### DIFF
--- a/data/nasa.yaml
+++ b/data/nasa.yaml
@@ -16,6 +16,11 @@ cantera-version: 2.5.0a3
 date: Wed, 11 Dec 2019 16:59:09 -0500
 input-files: [nasa.cti]
 
+deprecated: >-
+  The file 'nasa.yaml' is deprecated and will be removed after Cantera 2.5.
+  All of the same data is available in the more specific nasa_gas.yaml and
+  nasa_condensed.yaml files.
+
 species:
 - name: Electron
   composition: {E: 1}

--- a/doc/sphinx/yaml/species.rst
+++ b/doc/sphinx/yaml/species.rst
@@ -181,6 +181,14 @@ Additional fields of a ``constant-cp`` thermo entry are:
 ``cp0``
     The heat capacity at constant pressure. Defaults to 0.0.
 
+``T-min``
+    The minimum temperature at which this thermo data should be used.
+    Defaults to 0.0.
+
+``T-max``
+    The maximum temperature at which this thermo data should be used.
+    Defaults to infinity.
+
 Example::
 
     thermo:
@@ -213,6 +221,14 @@ Additional fields of a ``piecewise-Gibbs`` entry are:
     energy can be either in molar units (if ``dimensionless`` is ``false``) or
     nondimensionalized by the corresponding temperature (if ``dimensionless`` is
     ``true``). A value must be provided at :math:`T^\circ = 298.15` K.
+
+``T-min``
+    The minimum temperature at which this thermo data should be used.
+    Defaults to 0.0.
+
+``T-max``
+    The maximum temperature at which this thermo data should be used.
+    Defaults to infinity.
 
 Example::
 

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -205,8 +205,8 @@ protected:
 /*!
  * Given two rate expressions at two specific pressures:
  *
- *   * \f$ P_1: k_1(T) = A_1 T^{b_1} e^{E_1 / RT} \f$
- *   * \f$ P_2: k_2(T) = A_2 T^{b_2} e^{E_2 / RT} \f$
+ *   * \f$ P_1: k_1(T) = A_1 T^{b_1} e^{-E_1 / RT} \f$
+ *   * \f$ P_2: k_2(T) = A_2 T^{b_2} e^{-E_2 / RT} \f$
  *
  * The rate at an intermediate pressure \f$ P_1 < P < P_2 \f$ is computed as
  * \f[

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -600,7 +600,7 @@ public:
     //@}
 
     virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void setToEquilState(const doublereal* lambda_RT);
+    virtual void setToEquilState(const doublereal* mu_RT);
 
 protected:
     //! Reference state pressure

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -487,6 +487,8 @@ class const_cp(thermo):
         self.h0 = h0
         self.s0 = s0
         self.cp0 = cp0
+        self.tmin = tmin
+        self.tmax = tmax
 
     def get_yaml(self, out):
         super().get_yaml(out)
@@ -498,6 +500,10 @@ class const_cp(thermo):
             out['s0'] = applyUnits(self.s0)
         if self.cp0 is not None:
             out['cp0'] = applyUnits(self.cp0)
+        if self.tmin is not None:
+            out['T-min'] = applyUnits(self.tmin)
+        if self.tmax is not None:
+            out['T-max'] = applyUnits(self.tmax)
 
 
 class gas_transport:

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -1585,6 +1585,13 @@ class SpeciesThermo:
                 tag = "T0"
             thermo_attribs[tag] = get_float_or_quantity(node)
 
+        tmin = const_cp_node.get('Tmin')
+        if tmin is not None and tmin != '100.0':
+            thermo_attribs['T-min'] = float(tmin)
+        tmax = const_cp_node.get('Tmax')
+        if tmax is not None and tmin != '5000.0':
+            thermo_attribs['T-max'] = float(tmax)
+
         return thermo_attribs
 
     def Mu0(
@@ -1612,6 +1619,12 @@ class SpeciesThermo:
                 "The 'Mu0' node must contain an 'H298' node.", Mu0_node
             )
         thermo_attribs["h0"] = get_float_or_quantity(H298_node)
+        tmin = Mu0_node.get('Tmin')
+        if tmin is not None:
+            thermo_attribs['T-min'] = float(tmin)
+        tmax = Mu0_node.get('Tmax')
+        if tmax is not None:
+            thermo_attribs['T-max'] = float(tmax)
         for float_node in Mu0_node.iterfind("floatArray"):
             title = float_node.get("title")
             if title == "Mu0Values":

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -14,7 +14,8 @@ namespace Cantera
 {
 
 ConstCpPoly::ConstCpPoly()
-    : m_t0(0.0)
+    : SpeciesThermoInterpType(0.0, std::numeric_limits<double>::infinity(), 0.0)
+    , m_t0(0.0)
     , m_cp0_R(0.0)
     , m_h0_R(0.0)
     , m_s0_R(0.0)

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -18,7 +18,8 @@ using namespace std;
 namespace Cantera
 {
 Mu0Poly::Mu0Poly()
-    : m_numIntervals(0)
+    : SpeciesThermoInterpType(0.0, std::numeric_limits<double>::infinity(), 0.0)
+    , m_numIntervals(0)
     , m_H298(0.0)
 {
 }

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -295,6 +295,12 @@ static SpeciesThermoInterpType* newConstCpThermoFromXML(XML_Node& f)
 void setupConstCp(ConstCpPoly& thermo, const AnyMap& node)
 {
     setupSpeciesThermo(thermo, node);
+    if (node.hasKey("T-min")) {
+        thermo.setMinTemp(node.convert("T-min", "K"));
+    }
+    if (node.hasKey("T-max")) {
+        thermo.setMaxTemp(node.convert("T-max", "K"));
+    }
     double T0 = node.convert("T0", "K", 298.15);
     double h0 = node.convert("h0", "J/kmol", 0.0);
     double s0 = node.convert("s0", "J/kmol/K", 0.0);
@@ -370,6 +376,12 @@ void setupNasa9Poly(Nasa9PolyMultiTempRegion& thermo, const AnyMap& node)
 void setupMu0(Mu0Poly& thermo, const AnyMap& node)
 {
     setupSpeciesThermo(thermo, node);
+    if (node.hasKey("T-min")) {
+        thermo.setMinTemp(node.convert("T-min", "K"));
+    }
+    if (node.hasKey("T-max")) {
+        thermo.setMaxTemp(node.convert("T-max", "K"));
+    }
     bool dimensionless = node.getBool("dimensionless", false);
     double h0 = node.convert("h0", "J/kmol", 0.0);
     map<double, double> T_mu;

--- a/test/data/HMW_NaCl_sp1977_alt.xml
+++ b/test/data/HMW_NaCl_sp1977_alt.xml
@@ -191,7 +191,7 @@
           <molarVolume> 0.0 </molarVolume>
       </standardState>
       <thermo>
-        <Mu0 Pref="100000.0" Tmax="625.15." Tmin="273.15">
+        <Mu0 Pref="100000.0" Tmax="625.15" Tmin="273.15">
          <H298 units="cal/mol"> 0.0  </H298>
          <numPoints> 3            </numPoints>
          <floatArray size="3" title="Mu0Values" units="Dimensionless">

--- a/test/data/IdealMolalSolnPhaseExample.xml
+++ b/test/data/IdealMolalSolnPhaseExample.xml
@@ -130,7 +130,7 @@
         <molarVolume> 0.0 </molarVolume>
       </standardState>
       <thermo>
-        <Mu0 Pref="100000.0" Tmax="625.15." Tmin="273.15">
+        <Mu0 Pref="100000.0" Tmax="625.15" Tmin="273.15">
           <H298 units="cal/mol"> 0.0  </H298>
           <numPoints> 3            </numPoints>
           <floatArray size="3" title="Mu0Values" units="Dimensionless">

--- a/test/thermo/thermoParameterizations.cpp
+++ b/test/thermo/thermoParameterizations.cpp
@@ -210,13 +210,17 @@ TEST(SpeciesThermo, ConstCpPolyFromYaml) {
         "T0: 1000 K\n"
         "h0: 9.22 kcal/mol\n"
         "s0: -3.02 cal/mol/K\n"
-        "cp0: 5.95 cal/mol/K\n");
+        "cp0: 5.95 cal/mol/K\n"
+        "T-min: 200 K\n"
+        "T-max: 2000 K\n");
     double cp_R, h_RT, s_R;
     auto st = newSpeciesThermo(data);
     st->updatePropertiesTemp(1100, &cp_R, &h_RT, &s_R);
     EXPECT_DOUBLE_EQ(cp_R * GasConst_cal_mol_K, 5.95);
     EXPECT_DOUBLE_EQ(h_RT * GasConst_cal_mol_K * 1100, 9.22e3 + 100 * 5.95);
     EXPECT_DOUBLE_EQ(s_R * GasConst_cal_mol_K, -3.02 + 5.95 * log(1100.0/1000.0));
+    EXPECT_DOUBLE_EQ(st->minTemp(), 200);
+    EXPECT_DOUBLE_EQ(st->maxTemp(), 2000);
 }
 
 TEST(SpeciesThermo, Mu0PolyFromYaml) {
@@ -224,11 +228,14 @@ TEST(SpeciesThermo, Mu0PolyFromYaml) {
         "{model: piecewise-Gibbs,"
         " h0: -890 kJ/mol,"
         " dimensionless: true,"
-        " data: {298.15: -363.2104, 323.15: -300}}");
+        " data: {298.15: -363.2104, 323.15: -300},"
+        " T-min: 273.15, T-max: 350 K}");
     auto st = newSpeciesThermo(data);
     double cp_R, h_RT, s_R;
     st->updatePropertiesTemp(310, &cp_R, &h_RT, &s_R);
     EXPECT_DOUBLE_EQ(cp_R, -11226.315743743922);
     EXPECT_DOUBLE_EQ(h_RT, -774.43302435932878);
     EXPECT_DOUBLE_EQ(s_R, -433.36374417010006);
+    EXPECT_DOUBLE_EQ(st->minTemp(), 273.15);
+    EXPECT_DOUBLE_EQ(st->maxTemp(), 350);
 }

--- a/test_problems/VCSnonideal/NaCl_equil/HMW_NaCl.xml
+++ b/test_problems/VCSnonideal/NaCl_equil/HMW_NaCl.xml
@@ -191,7 +191,7 @@
           <molarVolume> 0.0 </molarVolume>
       </standardState>
       <thermo>
-        <Mu0 Pref="100000.0" Tmax="625.15." Tmin="273.15">
+        <Mu0 Pref="100000.0" Tmax="625.15" Tmin="273.15">
          <H298 units="cal/mol"> 0.0  </H298>
          <numPoints> 3            </numPoints>
          <floatArray size="3" title="Mu0Values" units="Dimensionless">

--- a/test_problems/cathermo/HMW_graph_GvI/HMW_NaCl.xml
+++ b/test_problems/cathermo/HMW_graph_GvI/HMW_NaCl.xml
@@ -191,7 +191,7 @@
           <molarVolume> 0.0 </molarVolume>
       </standardState>
       <thermo>
-        <Mu0 Pref="100000.0" Tmax="625.15." Tmin="273.15">
+        <Mu0 Pref="100000.0" Tmax="625.15" Tmin="273.15">
          <H298 units="cal/mol"> 0.0  </H298>
          <numPoints> 3            </numPoints>
          <floatArray size="3" title="Mu0Values" units="Dimensionless">


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Set default max temperature for `constant-cp` and `piecewise-Gibbs` species thermo to infinity (instead of 0)
- Read min and max temperatures for these species thermo types from YAML input files
- Include these min and max temperatures when converting from CTI or XML input files
- Deprecate `nasa.yaml`, in favor of the more specific `nasa_gas.yaml` and `nasa_condensed.yaml` files
- Fix a couple of typos

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
