### PR TITLE
[Cython] Fix deprecation warning in NumPy 1.20

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -540,10 +540,10 @@ class SolutionArray:
                 elif (self._shape[0] == 1
                       or np.array(v).shape[:len(self._shape)] == self._shape):
                     arr = np.array(v)
-                    if arr.dtype == np.object:
+                    if arr.dtype == object:
                         raise ValueError(
                             "Unable to create extra column '{}': data type "
-                            "'np.object' is not supported.".format(name))
+                            "'object' is not supported.".format(name))
                     if self._shape[0] == 1 and len(arr) > 1:
                         arr = arr[np.newaxis, :]
                     self._extra[name] = arr

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1787,7 +1787,7 @@ class TestSolutionArray(utilities.CanteraTest):
 
     def test_extra_no_objects(self):
         with self.assertRaisesRegex(ValueError, "not supported"):
-            prop = np.array([0, [1, 2], (3, 4)], dtype=np.object)
+            prop = np.array([0, [1, 2], (3, 4)], dtype=object)
             states = ct.SolutionArray(self.gas, 3, extra={"prop": prop})
 
     def test_extra_reserved_names(self):


### PR DESCRIPTION
NumPy 1.20 deprecates `numpy` namespace aliases to built-in types, such as `int`, `float`, and `object`. The preference is to use the built-in type instead, which should cause no changes. Explicit specification of the precision with `numpy.float64` is still supported and does not need to be changed. See: https://github.com/numpy/numpy/releases/tag/v1.20.0 and https://github.com/numpy/numpy/pull/14882

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
