### PR TITLE
Fix some compilation issues and bump to 2.5.0rc1

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -90,7 +90,7 @@ possible.
 Development Site
 ================
 
-The current development version is 2.5.0b1. The current stable version is
+The current development version is 2.5.0rc1. The current stable version is
 2.4.0. The `latest Cantera source code <https://github.com/Cantera/cantera>`_,
 the `issue tracker <https://github.com/Cantera/cantera/issues>`_ for bugs and
 enhancement requests, `downloads of Cantera releases and binary installers

--- a/SConstruct
+++ b/SConstruct
@@ -719,7 +719,7 @@ for arg in ARGUMENTS:
         print('Encountered unexpected command line argument: %r' % arg)
         sys.exit(1)
 
-env['cantera_version'] = "2.5.0b1"
+env['cantera_version'] = "2.5.0rc1"
 # For use where pre-release tags are not permitted (MSI, sonames)
 env['cantera_pure_version'] = re.match(r'(\d+\.\d+\.\d+)', env['cantera_version']).group(0)
 env['cantera_short_version'] = re.match(r'(\d+\.\d+)', env['cantera_version']).group(0)

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -34,7 +34,7 @@ PROJECT_NAME           = Cantera
 # This could be handy for archiving the generated documentation or
 # if some version control system is used.
 
-PROJECT_NUMBER         = 2.5.0b1
+PROJECT_NUMBER         = 2.5.0rc1
 
 # The OUTPUT_DIRECTORY tag is used to specify the (relative or absolute)
 # base path where the generated documentation will be put.

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -73,7 +73,8 @@ if env['system_sundials'] == 'n':
                                   '#ext/sundials/include/%s/%s' % (subdir, header.name),
                                   Copy('$TARGET', '$SOURCE')))
 
-    # Compile Sundials source files
+    # Compile Sundials source files. Skip files related to the Sundials Fortran
+    # interface, which start with 'fsun'.
     subdirs = ['sundials', 'nvector/serial', 'cvodes', 'ida', 'sunmatrix/band',
                'sunmatrix/dense', 'sunmatrix/sparse', 'sunlinsol/dense',
                'sunlinsol/band','sunlinsol/spgmr', 'sunnonlinsol/newton']
@@ -82,7 +83,8 @@ if env['system_sundials'] == 'n':
 
     for subdir in subdirs:
         libraryTargets.extend(localenv.SharedObject(
-            [f for f in mglob(localenv, 'sundials/src/'+subdir, 'c')]))
+            [f for f in mglob(localenv, 'sundials/src/'+subdir, 'c')
+             if not f.name.startswith('fsun')]))
 
 if not env['system_yamlcpp']:
     localenv = prep_default(env)

--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -12,9 +12,9 @@
 #define FMT_HEADER_ONLY
 
 //! Versions 6.2.0 and 6.2.1 of fmtlib do not include this define before they
-//! include windows.h, breaking builds on Windows. As of May 23, 2020 the fix
-//! is committed to the master branch of fmtlib but hasn't been released.
-#ifdef _WIN32
+//! include windows.h, breaking builds on Windows. Fixed in fmtlib 7.0.0 and
+//! newer. https://github.com/fmtlib/fmt/pull/1616
+#if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
 #if CT_USE_SYSTEM_FMT

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -39,17 +39,16 @@ info = getCommandOutput(localenv['python_cmd'], '-c', script)
 module_ext, inc, pylib, prefix, py_version, numpy_include = info.splitlines()[-6:]
 localenv.Prepend(CPPPATH=[Dir('#include'), inc, numpy_include])
 localenv.Prepend(LIBS=localenv['cantera_libs'])
+
+# Don't print deprecation warnings for internal Python changes.
+# Only applies to Python 3.8. The field that is deprecated in Python 3.8
+# and causes the warnings to appear will be removed in Python 3.9 so no
+# further warnings should be issued.
+if localenv['HAS_CLANG'] and parse_version(py_version) == parse_version('3.8'):
+    localenv.Append(CXXFLAGS='-Wno-deprecated-declarations')
+
 if localenv['OS'] == 'Darwin':
     localenv.Append(LINKFLAGS='-undefined dynamic_lookup')
-
-    # Don't print deprecation warnings for internal Python changes.
-    # It seems that only clang on macOS prints these deprecation warnings.
-    # Only applies to Python 3.8. The field that is deprecated in Python 3.8
-    # and causes the warnings to appear will be removed in Python 3.9 so no
-    # further warnings should be issued. Cython has already implemented a fix
-    # in versions higher than 0.29.14.
-    if py_version == parse_version("3.8"):
-        localenv.Append(CXXFLAGS='-Wno-deprecated-declarations')
 elif localenv['OS'] == 'Windows':
     localenv.Append(LIBPATH=prefix+'/libs')
     if localenv['toolchain'] == 'mingw':

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1898,7 +1898,7 @@ class Parser:
             metadata = BlockMap([
                 ('generator', 'ck2yaml'),
                 ('input-files', FlowList(files)),
-                ('cantera-version', '2.5.0b1'),
+                ('cantera-version', '2.5.0rc1'),
                 ('date', formatdate(localtime=True)),
             ])
             if desc.strip():

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1640,7 +1640,7 @@ def convert(filename=None, output_name=None, text=None):
         # information regarding conversion
         metadata = BlockMap([
             ('generator', 'cti2yaml'),
-            ('cantera-version', '2.5.0b1'),
+            ('cantera-version', '2.5.0rc1'),
             ('date', formatdate(localtime=True)),
         ])
         if filename is not None:

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -2620,7 +2620,7 @@ def convert(
     metadata = BlockMap(
         {
             "generator": "ctml2yaml",
-            "cantera-version": "2.5.0b1",
+            "cantera-version": "2.5.0rc1",
             "date": formatdate(localtime=True),
         }
     )

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -9,8 +9,8 @@ localenv['mak_stdlib'] = ['-l' + lib for lib in env['cxx_stdlib']]
 samples = [('ctlib', ['ctlib.f']),
            ('isentropic', ['isentropic.f'])]
 
-ftn_demo = localenv.Object('demo_ftnlib.cpp',
-                           CPPPATH=['#include', localenv['boost_inc_dir'],
+ftn_demo = localenv.SharedObject('demo_ftnlib.cpp',
+                                 CPPPATH=['#include', localenv['boost_inc_dir'],
                                     localenv['extra_inc_dirs']])
 for program_name, fortran_sources in samples:
     buildSample(localenv.Program, program_name,

--- a/samples/f77/SConstruct.in
+++ b/samples/f77/SConstruct.in
@@ -12,7 +12,7 @@ env.Append(FFLAGS='-g',
            LINKFLAGS=@tmpl_cantera_linkflags@,
            FRAMEWORKS=@tmpl_cantera_frameworks@)
 
-ctlib = env.Object('demo_ftnlib.cpp')
+ctlib = env.SharedObject('demo_ftnlib.cpp')
 
 demo = env.Program('demo', [ctlib, 'demo.f'],
                    LINK='@FORTRAN_LINK@')

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -40,7 +40,7 @@ static std::mutex xml_mutex;
 
 int get_modified_time(const std::string& path) {
 #ifdef _WIN32
-    HANDLE hFile = CreateFile(path.c_str(), NULL, NULL,
+    HANDLE hFile = CreateFile(path.c_str(), 0, 0,
                               NULL, OPEN_EXISTING, 0, NULL);
     if (hFile == INVALID_HANDLE_VALUE) {
         throw CanteraError("get_modified_time", "Couldn't open file:" + path);


### PR DESCRIPTION
**Changes proposed in this pull request**

- Skip compilation of Sundials Fortran interface files to fix errors about duplicate symbols encountered on macOS and with MinGW
- Fix an issue compiling Fortran samples with gfortran when Cantera is compiled with clang
- Fix some compiler warnings
- Bump version for release candidate

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
