### PR TITLE
[Doc] Fix missing Python class member documentation

### DIFF
--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -24,7 +24,7 @@ sys.path.append(os.path.abspath('./exts'))
 # -- General configuration -----------------------------------------------------
 
 # If your documentation needs a minimal Sphinx version, state it here.
-#needs_sphinx = '1.0'
+needs_sphinx = '2.0'
 
 # Add any Sphinx extension module names here, as strings. They can be extensions
 # coming with Sphinx (named 'sphinx.ext.*') or your custom ones.
@@ -43,7 +43,11 @@ extensions = [
               'sphinx.ext.intersphinx',
               ]
 
-autodoc_default_flags = ['members','show-inheritance','undoc-members']
+autodoc_default_options = {
+    'members': True,
+    'show-inheritance': True,
+    'undoc-members': True
+}
 
 autoclass_content = 'both'
 


### PR DESCRIPTION
Sphinx 1.8 deprecated the 'autodoc_default_flags' option. It appears to have stopped working without warning in more recent versions, which means that the API docs don't include any of the member functions / member variables for any of the Python classes.

<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Use `autodoc_default_options` instead
- Set the minimum Sphinx version to 2.0, since that's what this option requires

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
