### PR TITLE
Fix matlab compilation failure

### DIFF
--- a/src/matlab/flowdevicemethods.cpp
+++ b/src/matlab/flowdevicemethods.cpp
@@ -71,11 +71,7 @@ void flowdevicemethods(int nlhs, mxArray* plhs[],
         // options that return a value of type 'double'
         switch (job) {
         case 21:
-            if (v == Undef) {
-                r = flowdev_massFlowRate2(i);
-            } else {
-                r = flowdev_massFlowRate(i, v);
-            }
+            r = flowdev_massFlowRate(i);
             break;
         default:
             mexErrMsgTxt("unknown job parameter");

--- a/src/matlab/flowdevicemethods.cpp
+++ b/src/matlab/flowdevicemethods.cpp
@@ -20,7 +20,7 @@ void flowdevicemethods(int nlhs, mxArray* plhs[],
     if (job == 0) {
         char* type = getString(prhs[2]);
 
-        n = flowdev_new2(type);
+        n = flowdev_new(type);
         plhs[0] = mxCreateNumericMatrix(1,1,mxDOUBLE_CLASS,mxREAL);
         double* h = mxGetPr(plhs[0]);
         *h = double(n);

--- a/src/matlab/reactormethods.cpp
+++ b/src/matlab/reactormethods.cpp
@@ -24,7 +24,7 @@ void reactormethods(int nlhs, mxArray* plhs[],
     if (job == 0) {
         char* type = getString(prhs[2]);
 
-        n = reactor_new2(type);
+        n = reactor_new(type);
         plhs[0] = mxCreateNumericMatrix(1,1,mxDOUBLE_CLASS,mxREAL);
         double* h = mxGetPr(plhs[0]);
         *h = double(n);

--- a/src/matlab/wallmethods.cpp
+++ b/src/matlab/wallmethods.cpp
@@ -23,7 +23,7 @@ void wallmethods(int nlhs, mxArray* plhs[],
     // constructor
     if (job == 0) {
         char* type = getString(prhs[2]);
-        n = wall_new2(type);
+        n = wall_new(type);
         plhs[0] = mxCreateNumericMatrix(1,1,mxDOUBLE_CLASS,mxREAL);
         double* h = mxGetPr(plhs[0]);
         *h = double(n);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**If applicable, fill in the issue number this pull request is fixing**

Fixes #978

fwiw (I don't think that the test suite captures relevant portions)
```
-------- Matlab test results --------
Test suite: C:\Users\ischo\GitHub\cantera\test\matlab
18-Feb-2021 12:04:40


C:\Users\ischo\GitHub\cantera\test\matlab

   TestImport
      testImportCTI ..................... passed in     0.849990 seconds
      testImportXML ..................... passed in     0.544212 seconds
   TestImport ........................... passed in     1.403145 seconds


   TestThermo
      testSetState ...................... passed in     0.194706 seconds
      test_nAtoms ....................... passed in     0.036164 seconds
      testSpecies ....................... passed in     0.027792 seconds
      testElements ...................... passed in     0.025729 seconds
      testCounts ........................ passed in     0.003548 seconds
   TestThermo ........................... passed in     0.296454 seconds

C:\Users\ischo\GitHub\cantera\test\matlab  passed in     1.709341 seconds


------ end Matlab test results ------
```

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
