### PR TITLE
Fix using reactors with both surface and gas phase chemistry with YAML input

### DIFF
--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -1048,9 +1048,9 @@ class TestSurfaceKinetics(utilities.CanteraTest):
     def make_reactors(self):
         self.net = ct.ReactorNet()
 
-        self.gas = ct.Solution('diamond.xml', 'gas')
-        self.solid = ct.Solution('diamond.xml', 'diamond')
-        self.interface = ct.Interface('diamond.xml', 'diamond_100',
+        self.gas = ct.Solution('diamond.yaml', 'gas')
+        self.solid = ct.Solution('diamond.yaml', 'diamond')
+        self.interface = ct.Interface('diamond.yaml', 'diamond_100',
                                       (self.gas, self.solid))
         self.gas.TPX = None, 1.0e3, 'H:0.002, H2:1, CH4:0.01, CH3:0.0002'
         self.r1 = ct.IdealGasReactor(self.gas)

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -94,10 +94,6 @@ void Reactor::initialize(doublereal t0)
         m_nv += S->thermo()->nSpecies();
         size_t nt = S->kinetics()->nTotalSpecies();
         maxnt = std::max(maxnt, nt);
-        if (m_chem && &m_kin->thermo(0) != &S->kinetics()->thermo(0)) {
-            throw CanteraError("Reactor::initialize",
-                "First phase of all kinetics managers must be the gas.");
-        }
     }
     m_work.resize(maxnt);
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Remove check that gas phase is the first phase in a reactor surface `InterfaceKinetics` object
- Change a regression test to exercise the case where this condition is not met

The functions for creating `InterfaceKinetics` objects from YAML input files results in having the surface (reacting) phase as the first phase, in contrast to the functions for creating these objects from CTI/XML files, which put the surface last. This led to a few errors as identified by @ischoegl, which were fixed by @bryanwweber in #905.

However, there was actually a check in `Reactor::initialize` that was meant to make sure that the `InterfaceKinetics` object was ordered such that the gas phase came first, as would occur with CTI input files. It just turns out that the examples which were exercising this only include reactors where there are no gas phase reactions, and this check was erroneously not running in that case. But thanks to #905, we can remove it now. I noticed this problem while trying to run the Matlab `surfreactor.m` example.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
