### PR TITLE
Add thermal conductivity to DustyGas in python.

### DIFF
--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -526,6 +526,7 @@ cdef extern from "cantera/transport/DustyGasTransport.h" namespace "Cantera":
         void setMeanParticleDiameter(double) except +translate_exception
         void setPermeability(double) except +translate_exception
         void getMolarFluxes(double*, double*, double, double*) except +translate_exception
+        CxxTransport& gasTransport() except +translate_exception
 
 
 cdef extern from "cantera/transport/TransportData.h" namespace "Cantera":

--- a/interfaces/cython/cantera/examples/transport/dusty_gas.py
+++ b/interfaces/cython/cantera/examples/transport/dusty_gas.py
@@ -4,7 +4,7 @@ Dusty Gas transport model.
 The Dusty Gas model is a multicomponent transport model for gas transport
 through the pores of a stationary porous medium. This example shows how to
 create a transport manager that implements the Dusty Gas model and use it to
-compute the multicomponent diffusion coefficients.
+compute the multicomponent diffusion coefficients and thermal conductivity.
 
 Requires:  cantera >= 2.5.0
 """
@@ -28,6 +28,9 @@ g.mean_particle_diameter = 1.5e-6  # lengths in meters
 
 # print the multicomponent diffusion coefficients
 print(g.multi_diff_coeffs)
+
+# print the thermal conductivity of the gas phase
+print(g.thermal_conductivity)
 
 # compute molar species fluxes
 T1, rho1, Y1 = g.TDY

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -309,6 +309,11 @@ class TestDustyGas(utilities.CanteraTest):
         # Not sure why the following condition is not satisfied:
         # self.assertNear(sum(fluxes1) / sum(abs(fluxes1)), 0.0)
 
+    def test_thermal_conductivity(self):
+        gas1 = ct.Solution('h2o2.xml', transport_model='multicomponent')
+        gas1.TPX = self.phase.TPX
+
+        self.assertEqual(self.phase.thermal_conductivity, gas1.thermal_conductivity)
 
 class TestWaterTransport(utilities.CanteraTest):
     """

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -182,7 +182,11 @@ cdef class Transport(_SolutionBase):
             return self.transport.electricalConductivity()
 
     property thermal_conductivity:
-        """Thermal conductivity. [W/m/K]."""
+        """
+        Thermal conductivity. [W/m/K]
+        Returns thermal conductivity of the ideal gas object using the multicomponent
+        model. The value is not specific to the dusty gas model.
+        """
         def __get__(self):
             return self.transport.thermalConductivity()
 

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -276,6 +276,11 @@ cdef class DustyGasTransport(Transport):
         def __set__(self, value):
             (<CxxDustyGasTransport*>self.transport).setPermeability(value)
 
+    property thermal_conductivity:
+        def __get__(self):
+            return (<CxxDustyGasTransport*>self.transport).gasTransport().thermalConductivity()
+
+
     def molar_fluxes(self, T1, T2, rho1, rho2, Y1, Y2, delta):
         """
         Get the molar fluxes [kmol/m^2/s], given the thermodynamic state at


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Thermal conductivity can now be calculated using the DustyGas class in python
-
-

**If applicable, fill in the issue number this pull request is fixing**

Fixes #

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
