### PR TITLE
Fix missing include in ReactionData.h

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -141,7 +141,7 @@ jobs:
           python3 -m pip install ruamel.yaml scons numpy cython sphinx\<4.0 \
           sphinxcontrib-katex sphinxcontrib-matlabdomain sphinxcontrib-doxylink
       - name: Build Cantera with documentation
-        run: python3 `which scons` build -j2 doxygen_docs=y sphinx_docs=y debug=n optimize=n
+        run: python3 `which scons` build -j2 doxygen_docs=y sphinx_docs=y debug=n optimize=n use_pch=n
       # The known_hosts key is generated with `ssh-keygen -F cantera.org` from a
       # machine that has previously logged in to cantera.org and trusts
       # that it logged in to the right machine

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -11,6 +11,8 @@
 #ifndef CT_REACTIONDATA_H
 #define CT_REACTIONDATA_H
 
+#include "cantera/base/ct_defs.h"
+
 namespace Cantera
 {
 


### PR DESCRIPTION
`std::log` is declared in `<cmath>`, which we usually include via `ct_defs.h`.

Fixes #999.



<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- include `ct_defs.h` in `ReactionData.h`
- Run the 'docs' CI build without using the precompiled header (chosen because it's the fastest CI job, so will be least impacted by the time cost of not using the PCH)

**If applicable, fill in the issue number this pull request is fixing**

Fixes #

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
