### PR TITLE
Fix documentation bug for YAML format

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -63,7 +63,7 @@ class Solution(ThermoPhase, Kinetics, Transport):
     directly in Python::
 
         spec = ct.Species.listFromFile('gri30.yaml')
-        rxns = ct.Reaction.listFromFile('gri30.yaml')
+        rxns = ct.Reaction.listFromFile('gri30.yaml', gas)
         gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                           species=spec, reactions=rxns, name='my_custom_name')
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -63,14 +63,17 @@ class Solution(ThermoPhase, Kinetics, Transport):
     directly in Python::
 
         spec = ct.Species.listFromFile('gri30.yaml')
-        rxns = ct.Reaction.listFromFile('gri30.yaml', gas)
+        spec_gas = ct.Solution(thermo='IdealGas', species=spec)
+        rxns = ct.Reaction.listFromFile('gri30.yaml', spec_gas)
         gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                           species=spec, reactions=rxns, name='my_custom_name')
 
     where the ``thermo`` and ``kinetics`` keyword arguments are strings
     specifying the thermodynamic and kinetics model, respectively, and
     ``species`` and ``reactions`` keyword arguments are lists of `Species` and
-    `Reaction` objects, respectively.
+    `Reaction` objects, respectively. Note that importing the reactions from a
+    YAML input file requires a `Kinetics` object containing the species, as
+    shown.
 
     Types of underlying models that form the composite `Solution` object are
     queried using the ``thermo_model``, ``kinetics_model`` and


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Fixes the `Reaction.listFromFile` example syntax in the `Solution` docs by adding the required second argument (using the `gas` object created in a previous code example.)

  I'm not sure if this is the best solution: it has the downside of requiring `gas` to already be initialized to a `Kinetics` object with the appropriate species, which doesn't seem super useful. I'm new to Cantera, but I couldn't find an easy way to make a "dummy" Kinetics object. Is there a better way to do this?

  Maybe the example should just be removed? 


**If applicable, fill in the issue number this pull request is fixing**

Fixes #1001

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
