### PR TITLE
Add support for SUNDIALS 5.5-5.7 compiled with LAPACK

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1034,10 +1034,11 @@ env['HAS_OPENMP'] = conf.CheckCXXHeader('omp.h', '""')
 boost_version_source = get_expression_value(['<boost/version.hpp>'], 'BOOST_LIB_VERSION')
 retcode, boost_lib_version = conf.TryRun(boost_version_source, '.cpp')
 env['BOOST_LIB_VERSION'] = '.'.join(boost_lib_version.strip().split('_'))
-print('INFO: Found Boost version {0}'.format(env['BOOST_LIB_VERSION']))
 if not env['BOOST_LIB_VERSION']:
     config_error("Boost could not be found. Install Boost headers or set"
                  " 'boost_inc_dir' to point to the boost headers.")
+else:
+    print('INFO: Found Boost version {0}'.format(env['BOOST_LIB_VERSION']))
 # demangle is availble in Boost 1.55 or newer
 env['has_demangle'] = conf.CheckDeclaration("boost::core::demangle",
                                 '#include <boost/core/demangle.hpp>', 'C++')

--- a/SConstruct
+++ b/SConstruct
@@ -1029,7 +1029,7 @@ else:
     env['cxx_stdlib'] = []
 
 env['HAS_CLANG'] = conf.CheckDeclaration('__clang__', '', 'C++')
-env['HAS_OPENMP'] = conf.CheckCXXHeader('omp.h', '""')
+env['HAS_OPENMP'] = conf.CheckLibWithHeader("omp", "omp.h", language="C++")
 
 boost_version_source = get_expression_value(['<boost/version.hpp>'], 'BOOST_LIB_VERSION')
 retcode, boost_lib_version = conf.TryRun(boost_version_source, '.cpp')

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -10,19 +10,11 @@
 #if CT_USE_LAPACK
     #include "cantera/numerics/ctlapack.h"
 #else
-    #if CT_SUNDIALS_USE_LAPACK
-        #if CT_SUNDIALS_VERSION >= 30
-            #include "sunlinsol/sunlinsol_lapackband.h"
-        #else
-            #include "cvodes/cvodes_lapack.h"
-        #endif
+    #if CT_SUNDIALS_VERSION >= 30
+        #include "sunlinsol/sunlinsol_band.h"
     #else
-        #if CT_SUNDIALS_VERSION >= 30
-            #include "sunlinsol/sunlinsol_band.h"
-        #else
-            #include "cvodes/cvodes_dense.h"
-            #include "cvodes/cvodes_band.h"
-        #endif
+        #include "cvodes/cvodes_dense.h"
+        #include "cvodes/cvodes_band.h"
     #endif
 #endif
 

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -392,7 +392,11 @@ void CVodesIntegrator::applyOptions()
         CVDiag(m_cvode_mem);
     } else if (m_type == GMRES) {
         #if CT_SUNDIALS_VERSION >= 30
-            m_linsol = SUNSPGMR(m_y, PREC_NONE, 0);
+            # if CT_SUNDIALS_VERSION >= 40
+                m_linsol = SUNLinSol_SPGMR(m_y, PREC_NONE, 0);
+            # else
+                m_linsol = SUNSPGMR(m_y, PREC_NONE, 0);
+            #endif
             CVSpilsSetLinearSolver(m_cvode_mem, (SUNLinearSolver) m_linsol);
         #else
             CVSpgmr(m_cvode_mem, PREC_NONE, 0);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Support for system SUNDIALS 5.5-5.7 with LAPACK. The preprocessor define indicating LAPACK support in SUNDIALS was changed with version 5.5.
- Fix that the Boost version message is printed even if Boost isn't found
- Simplify preprocessor logic in `BandMatrix.cpp`
- Fix deprecation warning about SunLinSol_SPGMR
- Fix error when `omp.h` is installed, but the library cannot be found by the linker (for example, omp installed by Homebrew, the Homebrew path on the search path, but using Apple's compilers).

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
