### PR TITLE
add thermo sensitivity to ReactorSurface

### DIFF
--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -76,6 +76,10 @@ public:
     //! sensitivity parameters. This function is called within
     //! ReactorNet::eval() before the reaction rates are evaluated.
     void setSensitivityParameters(const double* params);
+    
+    //! Add a sensitivity parameter associated with the enthalpy formation of
+    //! species *k* (in the homogeneous phase)
+    virtual void addSensitivitySpeciesEnthalpy(size_t k);
 
     //! Set reaction rate multipliers back to their initial values. This
     //! function is called within ReactorNet::eval() after all rates have been

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -759,6 +759,8 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void setCoverages(Composition&) except +translate_exception
         void syncCoverages()
         void addSensitivityReaction(size_t) except +translate_exception
+        void addSensitivitySpeciesEnthalpy(size_t) except +translate_exception
+
         size_t nSensParams()
 
     # flow devices

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -465,6 +465,14 @@ cdef class ReactorSurface:
         The Surface must be installed on a reactor and part of a network first.
         """
         self.surface.addSensitivityReaction(m)
+    
+    def add_sensitivity_species_enthalpy(self, int k):
+        """
+        Specifies that the sensitivity of the state variables with respect to
+        species *k* should be computed. The reactor must be part of a network
+        first.
+        """
+        self.surface.addSensitivitySpeciesEnthalpy(k)
 
 
 cdef class WallBase:

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -91,6 +91,21 @@ void ReactorSurface::addSensitivityReaction(size_t i)
         SensitivityParameter{i, p, 1.0, SensParameterType::reaction});
 }
 
+void ReactorSurface::addSensitivitySpeciesEnthalpy(size_t k)
+{
+    if (k >= m_thermo->nSpecies()) {
+        throw CanteraError("Reactor::addSensitivitySpeciesEnthalpy",
+                           "Species index out of range ({})", k);
+    }
+
+    size_t p = m_reactor->network().registerSensitivityParameter(
+        "surf: " + m_thermo->speciesName(k) + " enthalpy",
+        0.0, GasConstant * 298.15);
+    m_params.emplace_back(
+        SensitivityParameter{k, p, m_thermo->Hf298SS(k),
+                             SensParameterType::enthalpy});
+}
+
 void ReactorSurface::setSensitivityParameters(const double* params)
 {
     for (auto& p : m_params) {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- [x] Sensitivity of the standard state Enthalpy of formation is added to the ReactorSurface cpp class. currently the surface reactor can only perform kinetic sensitivity.
- [x] The add_sensitivity_species_enthalpy() python function is added to the ReactorSurface Python class
- [ ] add unit tests for the sensitivity

**If applicable, fill in the issue number this pull request is fixing**

No issue # was found. 

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] The pull request is ready for review