### PR TITLE
Update to 88 character maximum per line

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -33,8 +33,8 @@
 * Push the changes on your new feature branch to your forked copy of the
   `Cantera/cantera` repository on GitHub.
 
-* Submit a Pull Request on Github, from your forked copy. Check the results 
-  of the continuous-integration tests run using Travis and AppVeyor and resolve 
+* Submit a Pull Request on Github, from your forked copy. Check the results
+  of the continuous-integration tests run using Travis and AppVeyor and resolve
   any issues that arise.
 * Additional discussion of good Git & Github workflow is provided at
   http://matplotlib.org/devel/gitwash/development_workflow.html and
@@ -53,7 +53,7 @@
 * Configure your editor to use 4 spaces per indentation level, and **never to
   use tabs**.
 * Avoid introducing trailing whitespace
-* Limit line lengths to 80 characters when possible
+* Limit line lengths to 88 characters when possible
 * Write comments to explain non-obvious operations
 
 ## C++

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -34,7 +34,7 @@
   `Cantera/cantera` repository on GitHub.
 
 * Submit a Pull Request on Github, from your forked copy. Check the results
-  of the continuous-integration tests run using Travis and AppVeyor and resolve
+  of the continuous-integration tests run using GitHub Actions and resolve
   any issues that arise.
 * Additional discussion of good Git & Github workflow is provided at
   http://matplotlib.org/devel/gitwash/development_workflow.html and


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Update coding style guidelines to 88 characters per line limit (up from 80)

**If applicable, fill in the issue number this pull request is fixing**

N/A

I realize that this is a departure from long-standing practice (and am fine with immediately closing the PR). However, I am still suggesting this as it may prevent some line breaks that I believe make code less readable. Especially with vectors/maps of templated classes in C++ forced line breaks tend to get unwieldy; also, doxygen's inline comments (`//!<`) become more feasible.

The number of characters is arbitrarily inspired by 'black', which I am otherwise not advocating for.

**PS:** I was mulling over whether to open this as an issue (which it really isn't) or a discussion (which appears somewhat off-topic). I ended up with a PR, as this may be the most efficient way to either adopt, reject or tweak the suggestion.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
