### PR TITLE
Adding adaptive preconditioner functionality to Cantera

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -56,6 +56,7 @@ David Sondak
 Raymond Speth (@speth), Massachusetts Institute of Technology
 Sergey Torokhov (@band-a-prend)
 Laurien Vandewalle (@lavdwall)
+Anthony Walker (@anthony-walker), Oregon State University
 Bryan Weber (@bryanwweber), University of Connecticut
 Armin Wehrfritz (@awehrfritz)
 Richard West (@rwest), Northeastern University

--- a/doc/example-keywords.txt
+++ b/doc/example-keywords.txt
@@ -26,6 +26,7 @@ plasma
 plotting
 plug flow reactor
 pollutant formation
+preconditioner
 premixed flame
 reaction path analysis
 reactor network

--- a/doc/sphinx/cython/zerodim.rst
+++ b/doc/sphinx/cython/zerodim.rst
@@ -46,6 +46,10 @@ IdealGasReactor
 ^^^^^^^^^^^^^^^
 .. autoclass:: IdealGasReactor(contents=None, *, name=None, energy='on')
 
+IdealGasMoleReactor
+^^^^^^^^^^^^^^^^^^^
+.. autoclass:: IdealGasMoleReactor(contents=None, *, name=None, energy='on')
+
 ConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: ConstPressureReactor(contents=None, *, name=None, energy='on')
@@ -53,6 +57,10 @@ ConstPressureReactor
 IdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: IdealGasConstPressureReactor(contents=None, *, name=None, energy='on')
+
+IdealGasConstPressureMoleReactor
+^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: IdealGasConstPressureMoleReactor(contents=None, *, name=None, energy='on')
 
 FlowReactor
 ^^^^^^^^^^^
@@ -106,3 +114,10 @@ PressureController
 ^^^^^^^^^^^^^^^^^^
 .. autoclass:: PressureController
    :inherited-members:
+
+Preconditioners
+---------------
+
+AdaptivePreconditioner
+^^^^^^^^^^^^^^^^^^^^^^
+.. autoclass:: AdaptivePreconditioner

--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -37,26 +37,32 @@ public:
 
     void setup();
 
-    void solve(const size_t stateSize, double *rhs_vector, double* output);
+    void solve(const size_t stateSize, double* rhs_vector, double* output);
 
-    PreconditionerType preconditionerType() { return PreconditionerType::LEFT_PRECONDITION; }
+    PreconditionerType preconditionerType() {
+        return PreconditionerType::LEFT_PRECONDITION;
+    }
 
     void setValue(size_t row, size_t col, double value);
 
     virtual void stateAdjustment(vector_fp& state);
 
-    //! Transform Jacobian vector and write into
-    //! preconditioner
-    void transformJacobianToPreconditioner();
+    virtual void updatePreconditioner();
 
     //! Prune preconditioner elements
     void prunePreconditioner();
 
     //! Function used to return semi-analytical jacobian matrix
-    Eigen::SparseMatrix<double> getJacobian() {
-        Eigen::SparseMatrix<double> jacobian(m_dim, m_dim);
-        jacobian.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
-        return jacobian;
+    Eigen::SparseMatrix<double> jacobian() {
+        Eigen::SparseMatrix<double> jacobian_mat(m_dim, m_dim);
+        jacobian_mat.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
+        return jacobian_mat;
+    }
+
+    //! Return the internal preconditioner matrix
+    Eigen::SparseMatrix<double> matrix() {
+        updatePreconditioner();
+        return m_precon_matrix;
     }
 
     //! Get the threshold value for setting elements
@@ -90,21 +96,10 @@ public:
     }
 
     //! Print preconditioner contents
-    void printPreconditioner() {
-        std::stringstream ss;
-        Eigen::IOFormat HeavyFmt(Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
-        ss << Eigen::MatrixXd(m_precon_matrix).format(HeavyFmt);
-        writelog(ss.str());
-    }
+    void printPreconditioner();
 
     //! Print jacobian contents
-    void printJacobian() {
-        std::stringstream ss;
-        Eigen::SparseMatrix<double> jacobian(m_dim, m_dim);
-        jacobian.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
-        ss << Eigen::MatrixXd(jacobian);
-        writelog(ss.str());
-    }
+    void printJacobian();
 
 protected:
     //! ilut fill factor

--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -1,0 +1,138 @@
+/**
+ *  @file AdaptivePreconditioner.h Declarations for the class
+ *   AdaptivePreconditioner which is a child class of PreconditionerBase
+ *   for preconditioners used by sundials
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef ADAPTIVEPRECONDITIONER_H
+#define ADAPTIVEPRECONDITIONER_H
+
+#include "cantera/numerics/PreconditionerBase.h"
+#include "cantera/numerics/eigen_sparse.h"
+#include "cantera/base/global.h"
+#include <iostream>
+
+namespace Cantera
+{
+
+//! AdaptivePreconditioner a preconditioner designed for use with large
+//! mechanisms that leverages sparse solvers. It does this by pruning
+//! the preconditioner by a threshold value. It also neglects pressure
+//! dependence and thirdbody contributions in its formation and has a
+//! finite difference approximation for temperature.
+class AdaptivePreconditioner : public PreconditionerBase
+{
+public:
+    AdaptivePreconditioner() {}
+
+    void initialize(size_t networkSize);
+
+    void reset() {
+        m_precon_matrix.setZero();
+        m_jac_trips.clear();
+    };
+
+    void setup();
+
+    void solve(const size_t stateSize, double *rhs_vector, double* output);
+
+    PreconditionerType preconditionerType() { return PreconditionerType::LEFT_PRECONDITION; }
+
+    void setValue(size_t row, size_t col, double value);
+
+    virtual void stateAdjustment(vector_fp& state);
+
+    //! Transform Jacobian vector and write into
+    //! preconditioner
+    void transformJacobianToPreconditioner();
+
+    //! Prune preconditioner elements
+    void prunePreconditioner();
+
+    //! Function used to return semi-analytical jacobian matrix
+    Eigen::SparseMatrix<double> getJacobian() {
+        Eigen::SparseMatrix<double> jacobian(m_dim, m_dim);
+        jacobian.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
+        return jacobian;
+    }
+
+    //! Get the threshold value for setting elements
+    double threshold() { return m_threshold; }
+
+    //! Get ilut fill factor
+    double ilutFillFactor() { return m_fill_factor; }
+
+    //! Get ilut drop tolerance
+    double ilutDropTol() { return m_drop_tol; }
+
+    //! Set the threshold value to compare elements against
+    //! @param threshold double value used in setting by threshold
+    void setThreshold(double threshold) {
+        m_threshold = threshold;
+        m_prune_precon = (threshold <= 0) ? false : true;
+    }
+
+    //! Set drop tolerance for ILUT
+    //! @param droptol double value used in setting solver drop tolerance
+    void setIlutDropTol(double droptol) {
+        m_drop_tol = droptol;
+        m_solver.setDroptol(droptol);
+        }
+
+    //! Set the fill factor for ILUT solver
+    //! @param fillFactor fill in factor for ILUT solver
+    void setIlutFillFactor(int fillFactor) {
+        m_fill_factor = fillFactor;
+        m_solver.setFillfactor(fillFactor);
+    }
+
+    //! Print preconditioner contents
+    void printPreconditioner() {
+        std::stringstream ss;
+        Eigen::IOFormat HeavyFmt(Eigen::FullPrecision, 0, ", ", ";\n", "[", "]", "[", "]");
+        ss << Eigen::MatrixXd(m_precon_matrix).format(HeavyFmt);
+        writelog(ss.str());
+    }
+
+    //! Print jacobian contents
+    void printJacobian() {
+        std::stringstream ss;
+        Eigen::SparseMatrix<double> jacobian(m_dim, m_dim);
+        jacobian.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
+        ss << Eigen::MatrixXd(jacobian);
+        writelog(ss.str());
+    }
+
+protected:
+    //! ilut fill factor
+    double m_fill_factor = 0;
+
+    //! ilut drop tolerance
+    double m_drop_tol = 0;
+
+    //! Vector of triples representing the jacobian used in preconditioning
+    std::vector<Eigen::Triplet<double>> m_jac_trips;
+
+    //! Storage of appropriately sized identity matrix for making the preconditioner
+    Eigen::SparseMatrix<double> m_identity;
+
+    //! Container that is the sparse preconditioner
+    Eigen::SparseMatrix<double> m_precon_matrix;
+
+    //! Solver used in solving the linear system
+    Eigen::IncompleteLUT<double> m_solver;
+
+    //! Minimum value a non-diagonal element must be to be included in
+    //! the preconditioner
+    double m_threshold = 1e-8;
+
+    //! Bool set whether to prune the matrix or not
+    double m_prune_precon = true;
+};
+
+}
+
+#endif

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -58,10 +58,10 @@ public:
     virtual void setMaxErrTestFails(int n);
     virtual AnyMap nonlinearSolverStats() const;
     virtual AnyMap linearSolverStats() const;
-    void setLinearSolverType(std::string linSolverType) {
+    void setLinearSolverType(const std::string& linSolverType) {
         m_type = linSolverType;
     }
-    virtual std::string linearSolverType() {
+    virtual std::string linearSolverType() const {
         return m_type;
     }
     virtual void setBandwidth(int N_Upper, int N_Lower) {
@@ -72,23 +72,7 @@ public:
         return static_cast<int>(m_np);
     }
     virtual double sensitivity(size_t k, size_t p);
-    virtual void setProblemType(int probtype)
-    {
-        warn_deprecated("CVodesIntegrator::setProblemType()",
-            "To be removed. Set linear solver type with setLinearSolverType");
-        if (probtype == DIAG)
-        {
-            setLinearSolverType("DIAG");
-        } else if (probtype == DENSE + NOJAC) {
-            setLinearSolverType("DENSE");
-        } else if (probtype == BAND + NOJAC) {
-            setLinearSolverType("BAND");
-        } else if (probtype == GMRES) {
-            setLinearSolverType("GMRES");
-        } else {
-            setLinearSolverType("Invalid Option");
-        }
-    }
+    virtual void setProblemType(int probtype);
 
     //! Returns a string listing the weighted error estimates associated
     //! with each solution component.

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -35,7 +35,6 @@ public:
     virtual void setTolerances(double reltol, size_t n, double* abstol);
     virtual void setTolerances(double reltol, double abstol);
     virtual void setSensitivityTolerances(double reltol, double abstol);
-    virtual void setProblemType(int probtype);
     virtual void initialize(double t0, FuncEval& func);
     virtual void reinitialize(double t0, FuncEval& func);
     virtual void integrate(double tout);
@@ -57,6 +56,14 @@ public:
     virtual void setMaxSteps(int nmax);
     virtual int maxSteps();
     virtual void setMaxErrTestFails(int n);
+    virtual AnyMap nonlinearSolverStats() const;
+    virtual AnyMap linearSolverStats() const;
+    void setLinearSolverType(std::string linSolverType) {
+        m_type = linSolverType;
+    }
+    virtual std::string linearSolverType() {
+        return m_type;
+    }
     virtual void setBandwidth(int N_Upper, int N_Lower) {
         m_mupper = N_Upper;
         m_mlower = N_Lower;
@@ -65,6 +72,23 @@ public:
         return static_cast<int>(m_np);
     }
     virtual double sensitivity(size_t k, size_t p);
+    virtual void setProblemType(int probtype)
+    {
+        warn_deprecated("CVodesIntegrator::setProblemType()",
+            "To be removed. Set linear solver type with setLinearSolverType");
+        if (probtype == DIAG)
+        {
+            setLinearSolverType("DIAG");
+        } else if (probtype == DENSE + NOJAC) {
+            setLinearSolverType("DENSE");
+        } else if (probtype == BAND + NOJAC) {
+            setLinearSolverType("BAND");
+        } else if (probtype == GMRES) {
+            setLinearSolverType("GMRES");
+        } else {
+            setLinearSolverType("Invalid Option");
+        }
+    }
 
     //! Returns a string listing the weighted error estimates associated
     //! with each solution component.
@@ -93,7 +117,7 @@ private:
     double m_time; //!< The current integrator time
     N_Vector m_y, m_abstol;
     N_Vector m_dky;
-    int m_type;
+    std::string m_type;
     int m_itol;
     int m_method;
     int m_maxord;
@@ -107,7 +131,6 @@ private:
     N_Vector* m_yS;
     size_t m_np;
     int m_mupper, m_mlower;
-
     //! Indicates whether the sensitivities stored in m_yS have been updated
     //! for at the current integrator time.
     bool m_sens_ok;

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -71,6 +71,11 @@ public:
         throw NotImplementedError("FuncEval::preconditionerSolve");
     }
 
+    //! Update the preconditioner based on already computed jacobian values
+    virtual void updatePreconditioner(double gamma) {
+        throw NotImplementedError("FuncEval::updatePreconditioner");
+    }
+
     /*! Preconditioner setup that doesn't throw an error but returns a
      * CVODES flag. It also helps as a first level of polymorphism
      * which identifies the specific FuncEval, e.g., ReactorNet.

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -14,6 +14,7 @@
 
 namespace Cantera
 {
+
 /**
  *  Virtual base class for ODE right-hand-side function evaluators.
  *  Classes derived from FuncEval evaluate the right-hand-side function
@@ -48,6 +49,48 @@ public:
      *      recoverable error; -1 after an unrecoverable error.
      */
     int eval_nothrow(double t, double* y, double* ydot);
+
+    /*! Evaluate the setup processes for the Jacobian preconditioner.
+     * @param[in] t time.
+     * @param[in] y solution vector, length neq()
+     * @param gamma the gamma in M=I-gamma*J
+     * @warning This function is an experimental part of the %Cantera API and may be
+     * changed or removed without notice.
+     */
+    virtual void preconditionerSetup(double t, double* y, double gamma) {
+        throw NotImplementedError("FuncEval::preconditionerSetup");
+    }
+
+    /*! Evaluate the linear system Ax=b where A is the preconditioner.
+     * @param[in] rhs right hand side vector used in linear system
+     * @param[out] output output vector for solution
+     * @warning This function is an experimental part of the %Cantera API and may be
+     * changed or removed without notice.
+     */
+    virtual void preconditionerSolve(double* rhs, double* output) {
+        throw NotImplementedError("FuncEval::preconditionerSolve");
+    }
+
+    /*! Preconditioner setup that doesn't throw an error but returns a
+     * CVODES flag. It also helps as a first level of polymorphism
+     * which identifies the specific FuncEval, e.g., ReactorNet.
+     * @param[in] t time.
+     * @param[in] y solution vector, length neq()
+     * @param gamma the gamma in M=I-gamma*J
+     * @warning This function is an experimental part of the %Cantera API and may be
+     * changed or removed without notice.
+     */
+    int preconditioner_setup_nothrow(double t, double* y, double gamma);
+
+    /*! Preconditioner solve that doesn't throw an error but returns a
+     * CVODES flag. It also helps as a first level of polymorphism
+     * which identifies the specific FuncEval, e.g., ReactorNet.
+     * @param[in] rhs right hand side vector used in linear system
+     * @param[out] output output vector for solution
+     * @warning This function is an experimental part of the %Cantera API and may be
+     * changed or removed without notice.
+     */
+    int preconditioner_solve_nothrow(double* rhs, double* output);
 
     //! Fill in the vector *y* with the current state of the system
     virtual void getState(double* y) {

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -94,7 +94,7 @@ public:
     /*!
      * @param probtype    Type of the problem
      *
-     * @deprecated This funciton is to be removed along with the integer constants used
+     * @deprecated This function is to be removed along with the integer constants used
      * in conditionals to set the problem type currently. This includes DENSE, JAC,
      * NOJAC, BAND, and DIAG
      */
@@ -108,7 +108,7 @@ public:
     /*!
      * @param linSolverType    Type of the linear solver
      */
-    virtual void setLinearSolverType(std::string linSolverType) {
+    virtual void setLinearSolverType(const std::string& linSolverType) {
         warn("setLinearSolverType");
     }
 
@@ -150,7 +150,7 @@ public:
     }
 
     //! Return the integrator problem type
-    virtual std::string linearSolverType() {
+    virtual std::string linearSolverType() const {
         warn("linearSolverType");
         return "";
     }

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -12,8 +12,10 @@
 #ifndef CT_INTEGRATOR_H
 #define CT_INTEGRATOR_H
 #include "FuncEval.h"
+#include "PreconditionerBase.h"
 
 #include "cantera/base/global.h"
+#include "cantera/base/AnyMap.h"
 
 namespace Cantera
 {
@@ -91,9 +93,66 @@ public:
     //! Set the problem type.
     /*!
      * @param probtype    Type of the problem
+     *
+     * @deprecated This funciton is to be removed along with the integer constants used
+     * in conditionals to set the problem type currently. This includes DENSE, JAC,
+     * NOJAC, BAND, and DIAG
      */
     virtual void setProblemType(int probtype) {
+        warn_deprecated("Integrator::setProblemType()",
+            "To be removed. Set linear solver type with setLinearSolverType");
         warn("setProblemType");
+    }
+
+    //! Set the linear solver type.
+    /*!
+     * @param linSolverType    Type of the linear solver
+     */
+    virtual void setLinearSolverType(std::string linSolverType) {
+        warn("setLinearSolverType");
+    }
+
+    //! Set the preconditioner type.
+    /*!
+     * @param prectype    Type of the problem
+     */
+    virtual void setPreconditionerType(PreconditionerType prectype) {
+        warn("setPreconditionerType");
+    }
+
+    //! Set preconditioner used by the linear solver
+    /*!
+     * @param preconditioner preconditioner object used for the linear solver
+     */
+    virtual void setPreconditioner(shared_ptr<PreconditionerBase> preconditioner) {
+        m_preconditioner = preconditioner;
+        m_prec_type = m_preconditioner->preconditionerType();
+    }
+
+    //! Solve a linear system Ax=b where A is the preconditioner
+    /*!
+     * @param[in] stateSize length of the rhs and output vectors
+     * @param[in] rhs right hand side vector used in linear system
+     * @param[out] output output vector for solution
+     */
+    virtual void preconditionerSolve(size_t stateSize, double* rhs, double* output) {
+        m_preconditioner->solve(stateSize, rhs, output);
+    }
+
+    //! Return the preconditioner type
+    virtual PreconditionerType preconditionerType() {
+        return m_prec_type;
+    }
+
+    //! Return preconditioner reference to object
+    virtual shared_ptr<PreconditionerBase> preconditioner() {
+        return m_preconditioner;
+    }
+
+    //! Return the integrator problem type
+    virtual std::string linearSolverType() {
+        warn("linearSolverType");
+        return "";
     }
 
     /**
@@ -218,6 +277,28 @@ public:
         warn("sensitivity");
         return 0.0;
     }
+
+    //! Get nonlinear solver stats from integrator
+    virtual AnyMap nonlinearSolverStats() const {
+        AnyMap stats;
+        warn("nonlinearSolverStats");
+        return stats;
+    }
+
+    //! Get linear solver stats from integrator
+    virtual AnyMap linearSolverStats() const {
+        AnyMap stats;
+        warn("linearSolverStats");
+        return stats;
+    }
+
+protected:
+    //! Pointer to preconditioner object used in integration which is
+    //! set by setPreconditioner and initialized inside of
+    //! ReactorNet::initialize()
+    shared_ptr<PreconditionerBase> m_preconditioner;
+    //! Type of preconditioning used in applyOptions
+    PreconditionerType m_prec_type = PreconditionerType::NO_PRECONDITION;
 
 private:
     doublereal m_dummy;

--- a/include/cantera/numerics/PreconditionerBase.h
+++ b/include/cantera/numerics/PreconditionerBase.h
@@ -40,20 +40,24 @@ public:
         throw NotImplementedError("PreconditionerBase::setValue");
     }
 
-    //! Adjust the state vector based on the preconditioner
+    //! Adjust the state vector based on the preconditioner, e.g., Adaptive
+    //! preconditioning uses a strictly positive composition when preconditioning which
+    //! is handled by this function
     //! @param state a vector containing the state to be updated
     virtual void stateAdjustment(vector_fp& state) {
         throw NotImplementedError("PreconditionerBase::stateAdjustment");
     }
 
     //! Get preconditioner type for CVODES
-    virtual PreconditionerType preconditionerType() { return PreconditionerType::NO_PRECONDITION; };
+    virtual PreconditionerType preconditionerType() {
+        return PreconditionerType::NO_PRECONDITION;
+    };
 
     //! Solve a linear system Ax=b where A is the preconditioner
     //! @param[in] stateSize length of the rhs and output vectors
     //! @param[in] rhs_vector right hand side vector used in linear system
     //! @param[out] output output vector for solution
-    virtual void solve(const size_t stateSize, double *rhs_vector, double* output) {
+    virtual void solve(const size_t stateSize, double* rhs_vector, double* output) {
         throw NotImplementedError("PreconditionerBase::solve");
     };
 
@@ -79,6 +83,11 @@ public:
         throw NotImplementedError("PreconditionerBase::printPreconditioner");
     };
 
+    //! Transform Jacobian vector and write into
+    //! preconditioner, P = (I - gamma * J)
+    virtual void updatePreconditioner() {
+        throw NotImplementedError("PreconditionerBase::updatePreconditioner");
+    }
 
     //! Set gamma used in preconditioning
     //! @param gamma used in M = I - gamma*J

--- a/include/cantera/numerics/PreconditionerBase.h
+++ b/include/cantera/numerics/PreconditionerBase.h
@@ -1,0 +1,116 @@
+/**
+ *  @file PreconditionerBase.h Declarations for the class
+ *   PreconditionerBase which is a virtual base class for
+ *   preconditioning systems.
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef PRECONDITIONERBASE_H
+#define PRECONDITIONERBASE_H
+
+#include "cantera/base/ctexceptions.h"
+
+namespace Cantera
+{
+
+/**
+ * Specifies the preconditioner type used in the integration if any. Not all methods are
+ * supported by all integrators.
+ */
+enum class PreconditionerType {
+    NO_PRECONDITION, //! No preconditioning
+    LEFT_PRECONDITION, //! Left side preconditioning
+    RIGHT_PRECONDITION, //! Right side preconditioning
+    BOTH_PRECONDITION //! Left and right side preconditioning
+};
+
+//! PreconditionerBase serves as an abstract type to extend different preconditioners
+class PreconditionerBase
+{
+public:
+    PreconditionerBase() {}
+
+    //! Set a value at the specified row and column of the jacobian triplet vector
+    //! @param row row in the jacobian matrix
+    //! @param col column in the jacobian matrix
+    //! @param value value of the element at row and col
+    virtual void setValue(size_t row, size_t col, double value) {
+        throw NotImplementedError("PreconditionerBase::setValue");
+    }
+
+    //! Adjust the state vector based on the preconditioner
+    //! @param state a vector containing the state to be updated
+    virtual void stateAdjustment(vector_fp& state) {
+        throw NotImplementedError("PreconditionerBase::stateAdjustment");
+    }
+
+    //! Get preconditioner type for CVODES
+    virtual PreconditionerType preconditionerType() { return PreconditionerType::NO_PRECONDITION; };
+
+    //! Solve a linear system Ax=b where A is the preconditioner
+    //! @param[in] stateSize length of the rhs and output vectors
+    //! @param[in] rhs_vector right hand side vector used in linear system
+    //! @param[out] output output vector for solution
+    virtual void solve(const size_t stateSize, double *rhs_vector, double* output) {
+        throw NotImplementedError("PreconditionerBase::solve");
+    };
+
+    //! Perform preconditioner specific post-reactor setup operations such as factorize.
+    virtual void setup() {
+        throw NotImplementedError("PreconditionerBase::setup");
+    };
+
+    //! Reset preconditioner parameters as needed
+    virtual void reset() {
+        throw NotImplementedError("PreconditionerBase::reset");
+    };
+
+    //! Called during setup for any processes that need
+    //! to be completed prior to setup functions used in sundials.
+    //! @param networkSize the number of variables in the associated reactor network
+    virtual void initialize(size_t networkSize) {
+        throw NotImplementedError("PreconditionerBase::initialize");
+    };
+
+    //! Print preconditioner contents
+    virtual void printPreconditioner() {
+        throw NotImplementedError("PreconditionerBase::printPreconditioner");
+    };
+
+
+    //! Set gamma used in preconditioning
+    //! @param gamma used in M = I - gamma*J
+    virtual void setGamma(double gamma) {
+        m_gamma = gamma;
+    };
+
+    //! Get gamma used in preconditioning
+    virtual double gamma() {
+        return m_gamma;
+    };
+
+    //! Set the absolute tolerance in the solver outside of the network initialization
+    //! @param atol the specified tolerance
+    virtual void setAbsoluteTolerance(double atol) {
+        m_atol = atol;
+    }
+
+protected:
+    //! Dimension of the preconditioner
+    size_t m_dim;
+
+    //! gamma value used in M = I - gamma*J
+    double m_gamma = 1.0;
+
+    //! bool saying whether or not the preconditioner is initialized
+    bool m_init = false;
+
+    //! Absolute tolerance of the ODE solver
+    double m_atol = 0;
+
+};
+
+}
+#endif

--- a/include/cantera/numerics/PreconditionerFactory.h
+++ b/include/cantera/numerics/PreconditionerFactory.h
@@ -39,9 +39,9 @@ private:
 };
 
 //! Create a Preconditioner object of the specified type
-inline PreconditionerBase* newPreconditioner(const std::string& precon)
+inline std::shared_ptr<PreconditionerBase> newPreconditioner(const std::string& precon)
 {
-    return PreconditionerFactory::factory()->create(precon);
+    return std::shared_ptr<PreconditionerBase>(PreconditionerFactory::factory()->create(precon));
 };
 
 }

--- a/include/cantera/numerics/PreconditionerFactory.h
+++ b/include/cantera/numerics/PreconditionerFactory.h
@@ -1,0 +1,49 @@
+//! @file PreconditionerFactory.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef PRECONDITIONER_FACTORY_H
+#define PRECONDITIONER_FACTORY_H
+
+#include "cantera/base/FactoryBase.h"
+
+namespace Cantera
+{
+
+class PreconditionerBase;
+
+//! Factory class to create preconditioner objects
+class PreconditionerFactory : public Factory<PreconditionerBase>
+{
+public:
+    static PreconditionerFactory* factory() {
+        std::unique_lock<std::mutex> lock(precon_mutex);
+        if (!s_factory) {
+            s_factory = new PreconditionerFactory;
+        }
+        return s_factory;
+    };
+
+    //! Delete preconditioner factory
+    virtual void deleteFactory() {
+        std::unique_lock<std::mutex> lock(precon_mutex);
+        delete s_factory;
+        s_factory = 0;
+    };
+
+private:
+    static PreconditionerFactory* s_factory;
+    static std::mutex precon_mutex;
+    PreconditionerFactory();
+};
+
+//! Create a Preconditioner object of the specified type
+inline PreconditionerBase* newPreconditioner(const std::string& precon)
+{
+    return PreconditionerFactory::factory()->create(precon);
+};
+
+}
+
+#endif

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -440,6 +440,10 @@ public:
     //! units = kg / kmol
     const vector_fp& molecularWeights() const;
 
+    //! Return a const reference to the internal vector of molecular weights.
+    //! units = kmol / kg
+    const vector_fp& inverseMolecularWeights() const;
+
     //! Copy the vector of species charges into array charges.
     //!     @param charges Output array of species charges (elem. charge)
     void getCharges(double* charges) const;
@@ -554,6 +558,9 @@ public:
     //! Set the concentrations without ignoring negative concentrations
     virtual void setConcentrationsNoNorm(const double* const conc);
     //! @}
+
+    //! Set the state of the object with moles in [kmol]
+    virtual void setMolesNoTruncate(const double* const N);
 
     //! Elemental mass fraction of element m
     /*!

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -1,0 +1,51 @@
+//! @file IdealGasConstPressureMoleReactor.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_IDEALGASCONSTPRESSMOLE_REACTOR_H
+#define CT_IDEALGASCONSTPRESSMOLE_REACTOR_H
+
+#include "cantera/zeroD/MoleReactor.h"
+
+namespace Cantera
+{
+
+/*!
+ * IdealGasConstPressureMoleReactor is a class for ideal gas constant-pressure reactors
+ * which use a state of moles.
+ */
+class IdealGasConstPressureMoleReactor : public MoleReactor
+{
+public:
+    IdealGasConstPressureMoleReactor() {}
+
+    virtual std::string type() const {
+        return "IdealGasConstPressureMoleReactor";
+    };
+
+    virtual size_t componentIndex(const std::string& nm) const;
+
+    virtual std::string componentName(size_t k);
+
+    virtual void setThermoMgr(ThermoPhase& thermo);
+
+    virtual void getState(double* y);
+
+    virtual void initialize(double t0 = 0.0);
+
+    virtual void eval(double t, double* LHS, double* RHS);
+
+    virtual void updateState(double* y);
+
+    virtual Eigen::SparseMatrix<double> jacobian(double t, double* y);
+
+protected:
+    vector_fp m_hk; //!< Species molar enthalpies
+
+    const int m_sidx = 1;
+};
+
+}
+
+#endif

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -1,0 +1,47 @@
+//! @file IdealGasMoleReactor.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_IDEALGASMOLE_REACTOR_H
+#define CT_IDEALGASMOLE_REACTOR_H
+
+#include "cantera/zeroD/MoleReactor.h"
+
+namespace Cantera
+{
+
+/*!
+ * IdealGasMoleReactor is a class for ideal gas constant-volume reactors which use a
+ * state of moles.
+ */
+class IdealGasMoleReactor : public MoleReactor
+{
+public:
+    IdealGasMoleReactor() {}
+
+    virtual std::string type() const {
+        return "IdealGasMoleReactor";
+    }
+
+    virtual size_t componentIndex(const std::string& nm) const;
+
+    virtual void setThermoMgr(ThermoPhase& thermo);
+
+    virtual void getState(double* y);
+
+    virtual void initialize(double t0 = 0.0);
+
+    virtual void eval(double t, double* LHS, double* RHS);
+
+    virtual void updateState(double* y);
+
+    virtual Eigen::SparseMatrix<double> jacobian(double t, double* y);
+
+protected:
+    vector_fp m_uk; //!< Species molar internal energies
+};
+
+}
+
+#endif

--- a/include/cantera/zeroD/MoleReactor.h
+++ b/include/cantera/zeroD/MoleReactor.h
@@ -1,0 +1,55 @@
+//! @file MoleReactor.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_MOLEREACTOR_H
+#define CT_MOLEREACTOR_H
+
+#include "Reactor.h"
+
+namespace Cantera
+{
+
+/*!
+ * MoleReactor is meant to serve the same purpose as the reactor class but with a state
+ * vector composed of moles. It is currently not functional and only serves as a base
+ * class for other reactors.
+ */
+class MoleReactor : public Reactor
+{
+public:
+    MoleReactor() {}
+
+    virtual std::string type() const {
+        return "MoleReactor";
+    }
+
+    virtual void initialize(double t0 = 0.0);
+
+    virtual void eval(double t, double* LHS, double* RHS) {
+        throw NotImplementedError("MoleReactor::eval()");
+    }
+
+    size_t componentIndex(const std::string& nm) const {
+        throw NotImplementedError("MoleReactor::componentIndex");
+    }
+
+    std::string componentName(size_t k) {
+        throw NotImplementedError("MoleReactor::componentName");
+    }
+
+protected:
+    virtual void evalSurfaces(double* LHS, double* RHS, double* sdot);
+
+    virtual void updateSurfaceState(double* y);
+
+    virtual void getSurfaceInitialConditions(double* y);
+
+    //! const value for the species start index
+    const int m_sidx = 2;
+};
+
+}
+
+#endif

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -7,11 +7,14 @@
 #define CT_REACTOR_H
 
 #include "ReactorBase.h"
+#include "cantera/numerics/eigen_sparse.h"
+
 
 namespace Cantera
 {
 
 class Solution;
+class AnyMap;
 
 /**
  * Class Reactor is a general-purpose class for stirred reactors. The reactor
@@ -153,9 +156,22 @@ public:
     //! @param limit value for step size limit
     void setAdvanceLimit(const std::string& nm, const double limit);
 
+    //! Method to calculate the reactor specific jacobian
+    //! @param t current time of the simulation
+    //! @param y pointer to state vector
+    //! @warning  This method is an experimental part of the %Cantera
+    //! API and may be changed or removed without notice.
+    virtual Eigen::SparseMatrix<double> jacobian(double t, double* y) {
+        throw NotImplementedError("Reactor::jacobian");
+    }
+
+    //! Use this to set the kinetics objects derivative settings
+    virtual void setDerivativeSettings(AnyMap& settings);
+
     //! Set reaction rate multipliers based on the sensitivity variables in
     //! *params*.
     virtual void applySensitivity(double* params);
+
     //! Reset the reaction rate multipliers
     virtual void resetSensitivity(double* params);
 
@@ -217,6 +233,9 @@ protected:
 
     // Data associated each sensitivity parameter
     std::vector<SensitivityParameter> m_sensParams;
+
+    //! Vector of triplets representing the jacobian
+    std::vector<Eigen::Triplet<double>> m_jac_trips;
 };
 }
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -144,6 +144,11 @@ public:
     //! reactor
     ReactorSurface* surface(size_t n);
 
+    //! Return the number of surfaces in a reactor
+    virtual size_t nSurfs() {
+        return m_surfaces.size();
+    }
+
     /**
      * Initialize the reactor. Called automatically by ReactorNet::initialize.
      */

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -39,11 +39,11 @@ public:
     //! Set the type of linear solver used in the integration.
     //! @param linSolverType type of linear solver. Default type: "DENSE"
     //! Other options include: "DIAG", "DENSE", "GMRES", "BAND"
-    void setLinearSolverType(std::string linSolverType = "DENSE");
+    void setLinearSolverType(const std::string& linSolverType="DENSE");
 
     //! Set preconditioner used by the linear solver
     //! @param preconditioner preconditioner object used for the linear solver
-    void setPreconditioner(PreconditionerBase& preconditioner);
+    void setPreconditioner(shared_ptr<PreconditionerBase> preconditioner);
 
     //! Set initial time. Default = 0.0 s. Restarts integration from this time
     //! using the current mixture state as the initial condition.
@@ -96,7 +96,7 @@ public:
     }
 
     //! Problem type of integrator
-    std::string linearSolverType();
+    std::string linearSolverType() const;
 
     /**
      * Advance the state of all reactors in time. Take as many internal
@@ -272,21 +272,8 @@ public:
     //! Retrieve absolute step size limits during advance
     bool getAdvanceLimits(double* limits);
 
-    /*! Evaluate the setup processes for the Jacobian preconditioner.
-     * @param[in] t time.
-     * @param[in] y solution vector, length neq()
-     * @param gamma the gamma in M=I-gamma*J
-     * @warning This function is an experimental part of the %Cantera API and may be
-     * changed or removed without notice.
-     */
     virtual void preconditionerSetup(double t, double* y, double gamma);
 
-    /*! Evaluate the linear system Ax=b where A is the preconditioner.
-     * @param[in] rhs right hand side vector used in linear system
-     * @param[out] output output vector for solution
-     * @warning This function is an experimental part of the %Cantera API and may be
-     * changed or removed without notice.
-     */
     virtual void preconditionerSolve(double* rhs, double* output);
 
     //! Use this to get nonlinear solver stats from Integrator
@@ -300,6 +287,13 @@ public:
     virtual void setDerivativeSettings(AnyMap& settings);
 
 protected:
+    //! Check if surfaces and preconditioning are included, if so throw an error because
+    //! they are currently not supported.
+    virtual void checkPreconditionerSupported();
+
+    //! Update the preconditioner based on the already computed jacobian values
+    virtual void updatePreconditioner(double gamma);
+
     //! Estimate a future state based on current derivatives.
     //! The function is intended for internal use by ReactorNet::advance
     //! and deliberately not exposed in external interfaces.
@@ -340,9 +334,6 @@ protected:
     //! "left hand side" of each governing equation
     vector_fp m_LHS;
     vector_fp m_RHS;
-
-    bool m_checked_eval_deprecation; //!< @todo Remove after Cantera 2.6
-    std::vector<bool> m_have_deprecated_eval; //!< @todo Remove after Cantera 2.6
 };
 }
 

--- a/include/cantera/zerodim.h
+++ b/include/cantera/zerodim.h
@@ -19,6 +19,8 @@
 #include "cantera/zeroD/ConstPressureReactor.h"
 #include "cantera/zeroD/IdealGasReactor.h"
 #include "cantera/zeroD/IdealGasConstPressureReactor.h"
+#include "cantera/zeroD/IdealGasConstPressureMoleReactor.h"
+#include "cantera/zeroD/IdealGasMoleReactor.h"
 
 // flow devices
 #include "cantera/zeroD/flowControllers.h"

--- a/interfaces/cython/cantera/_cantera.pyx
+++ b/interfaces/cython/cantera/_cantera.pyx
@@ -45,3 +45,4 @@ from .transport import *
 from .units import *
 from .yamlwriter import *
 from .constants import *
+from .preconditioners import *

--- a/interfaces/cython/cantera/examples/reactors/preconditioned_integration.py
+++ b/interfaces/cython/cantera/examples/reactors/preconditioned_integration.py
@@ -1,0 +1,96 @@
+# -*- coding: utf-8 -*-
+"""
+Ideal gas, constant-pressure, adiabatic kinetics simulation that compares preconditioned and non-preconditioned integration of nDodecane.
+
+Requires: cantera >= 2.6.0
+Keywords: combustion, reactor network, preconditioner
+"""
+import cantera as ct
+import numpy as np
+import matplotlib.pyplot as plt
+from timeit import default_timer
+
+def integrate_reactor(n_reactors=15, preconditioner=True):
+    """
+        Compare the integrations of a preconditioned reactor network and a
+        non-preconditioned reactor network. Increase the number of reactors in the
+        network with the keyword argument `n_reactors` to see greater differences in
+        performance.
+    """
+    # Use a reduced n-dodecane mechanism with PAH formation pathways
+    gas = ct.Solution('nDodecane_Reitz.yaml', 'nDodecane_IG')
+    # Create multiple reactors and set initial contents
+    gas.TP = 1000, ct.one_atm
+    gas.set_equivalence_ratio(0.75, 'c12h26', 'n2:3.76, o2:1.0')
+    reactors = [ct.IdealGasConstPressureMoleReactor(gas) for n in range(n_reactors)]
+    # set volume for reactors
+    for r in reactors:
+        r.volume = 0.1
+    # Create reactor network
+    sim = ct.ReactorNet(reactors)
+    # Add preconditioner
+    if preconditioner:
+        sim.derivative_settings = {"skip-third-bodies":True, "skip-falloff":True}
+        sim.preconditioner = ct.AdaptivePreconditioner()
+    sim.initialize()
+    # Advance to steady state
+    integ_time = default_timer()
+    # indexs to keep
+    tidx = reactors[0].component_index("temperature")
+    cidx = reactors[0].component_index("c12h26")
+    coidx = reactors[0].component_index("co2")
+    time = []
+    T = []
+    CO2 = []
+    C12H26 = []
+    # advance to steady state manually
+    while (sim.time < 0.1):
+        previous_state = sim.get_state()
+        T.append(previous_state[tidx])
+        CO2.append(previous_state[coidx])
+        C12H26.append(previous_state[cidx])
+        time.append(sim.time)
+        sim.step()
+    integ_time = default_timer() - integ_time
+    # Return time to integrate
+    if preconditioner:
+        print("Preconditioned Integration Time: {:f}".format(integ_time))
+    else:
+        print("Non-preconditioned Integration Time: {:f}".format(integ_time))
+    # Get and output solver stats
+    lin_stats = sim.linear_solver_stats
+    nonlin_stats = sim.nonlinear_solver_stats
+    for key in lin_stats:
+        print(key, lin_stats[key])
+    for key in nonlin_stats:
+        print(key, nonlin_stats[key])
+    print("\n")
+    return time, T, CO2, C12H26
+
+if __name__ == "__main__":
+    # integrate both to steady state
+    timep, Tp, CO2p, C12H26p = integrate_reactor(preconditioner=True)
+    timenp, Tnp, CO2np, C12H26np  = integrate_reactor(preconditioner=False)
+    # plot selected state variables
+    fig, axs = plt.subplots(1, 3)
+    fig.tight_layout()
+    ax1, ax2, ax3 = axs
+    # temperature plot
+    ax1.set_xlabel("Time")
+    ax1.set_ylabel("Temperature")
+    ax1.plot(timenp, Tnp, linewidth=2)
+    ax1.plot(timep, Tp, linewidth=2, linestyle=":")
+    ax1.legend(["Normal", "Preconditioned"])
+    # CO2 plot
+    ax2.set_xlabel("Time")
+    ax2.set_ylabel("CO2")
+    ax2.plot(timenp, CO2np, linewidth=2)
+    ax2.plot(timep, CO2p, linewidth=2, linestyle=":")
+    ax2.legend(["Normal", "Preconditioned"])
+    # C12H26 plot
+    ax3.set_xlabel("Time")
+    ax3.set_ylabel("C12H26")
+    ax3.plot(timenp, C12H26np, linewidth=2)
+    ax3.plot(timep, C12H26p, linewidth=2, linestyle=":")
+    ax3.legend(["Normal", "Preconditioned"])
+    plt.show()

--- a/interfaces/cython/cantera/preconditioners.pxd
+++ b/interfaces/cython/cantera/preconditioners.pxd
@@ -1,0 +1,32 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+#cython: language_level=3
+#distutils: language = c++
+
+from .ctcxx cimport *
+from .func1 cimport *
+
+cdef extern from "cantera/numerics/PreconditionerBase.h" namespace "Cantera":
+    cdef cppclass CxxPreconditionerBase "Cantera::PreconditionerBase":
+        CxxPreconditionerBase()
+
+cdef extern from "cantera/numerics/AdaptivePreconditioner.h" namespace "Cantera":
+    cdef cppclass CxxAdaptivePreconditioner "Cantera::AdaptivePreconditioner" (CxxPreconditionerBase):
+        CxxAdaptivePreconditioner() except +
+        void setThreshold(double threshold)
+        double threshold()
+        void setIlutFillFactor(int fillfactor)
+        double ilutFillFactor()
+        void setIlutDropTol(double droptol)
+        double ilutDropTol()
+        void printPreconditioner()
+
+cdef extern from "cantera/numerics/PreconditionerFactory.h" namespace "Cantera":
+    cdef CxxPreconditionerBase* newPreconditioner(string) except +translate_exception
+
+cdef class PreconditionerBase:
+    cdef CxxPreconditionerBase* pbase
+
+cdef class AdaptivePreconditioner(PreconditionerBase):
+    cdef CxxAdaptivePreconditioner* preconditioner

--- a/interfaces/cython/cantera/preconditioners.pxd
+++ b/interfaces/cython/cantera/preconditioners.pxd
@@ -2,17 +2,17 @@
 # at https://cantera.org/license.txt for license and copyright information.
 
 #cython: language_level=3
-#distutils: language = c++
+#distutils: language=c++
 
 from .ctcxx cimport *
-from .func1 cimport *
 
 cdef extern from "cantera/numerics/PreconditionerBase.h" namespace "Cantera":
     cdef cppclass CxxPreconditionerBase "Cantera::PreconditionerBase":
         CxxPreconditionerBase()
 
 cdef extern from "cantera/numerics/AdaptivePreconditioner.h" namespace "Cantera":
-    cdef cppclass CxxAdaptivePreconditioner "Cantera::AdaptivePreconditioner" (CxxPreconditionerBase):
+    cdef cppclass CxxAdaptivePreconditioner "Cantera::AdaptivePreconditioner" \
+        (CxxPreconditionerBase):
         CxxAdaptivePreconditioner() except +
         void setThreshold(double threshold)
         double threshold()
@@ -23,10 +23,11 @@ cdef extern from "cantera/numerics/AdaptivePreconditioner.h" namespace "Cantera"
         void printPreconditioner()
 
 cdef extern from "cantera/numerics/PreconditionerFactory.h" namespace "Cantera":
-    cdef CxxPreconditionerBase* newPreconditioner(string) except +translate_exception
+    cdef shared_ptr[CxxPreconditionerBase] newPreconditioner(string) except\
+         +translate_exception
 
 cdef class PreconditionerBase:
-    cdef CxxPreconditionerBase* pbase
+    cdef shared_ptr[CxxPreconditionerBase] pbase
 
 cdef class AdaptivePreconditioner(PreconditionerBase):
     cdef CxxAdaptivePreconditioner* preconditioner

--- a/interfaces/cython/cantera/preconditioners.pyx
+++ b/interfaces/cython/cantera/preconditioners.pyx
@@ -18,11 +18,17 @@ cdef class AdaptivePreconditioner(PreconditionerBase):
     precon_linear_solver_type = "GMRES"
 
     def __cinit__(self, *args, **kwargs):
-        self.preconditioner = <CxxAdaptivePreconditioner*>(self.pbase)
+        self.preconditioner = <CxxAdaptivePreconditioner*>(self.pbase.get())
 
     property threshold:
         """
-        Property for setting behavior of preconditioner pruning
+        The threshold of the preconditioner is used to remove or prune any off diagonal
+        elements below the given value inside of the preconditioner. In other words,
+        after the preconditioner is formed by P = (I - gamma * Jac), the off diagonal
+        values within P are compared with the threshold and removed if below it.
+
+        The goal of thresholding is to improve matrix sparsity while still providing a
+        good preconditioner for the system.
 
         Update the threshold to a desired value as:
             >>> precon.threshold = 1e-8
@@ -39,7 +45,10 @@ cdef class AdaptivePreconditioner(PreconditionerBase):
         """
         Property setting the linear solvers fill factor.
 
-        During factorization, after row elimination, only some of the largest elements in the L and U in addition to the diagonal element are kept. The number of elements kept is computed from the fill factor (a ratio) relative to the initial number of nonzero elements.
+        During factorization, after row elimination, only some of the largest elements
+        in the L and U in addition to the diagonal element are kept. The number of
+        elements kept is computed from the fill factor (a ratio) relative to the initial
+        number of nonzero elements.
 
         Update the ILUT fill factor to a desired value as:
             >>> precon.ilut_fill_factor = 2
@@ -56,7 +65,8 @@ cdef class AdaptivePreconditioner(PreconditionerBase):
         """
         Property setting the linear solvers drop tolerance.
 
-        During factorization any element below the product of the drop tolerance and average magnitude is dropped.
+        During factorization any element below the product of the drop tolerance and
+        average magnitude is dropped.
 
         Update the ILUT drop tolerance to a desired value as:
             >>> precon.ilut_drop_tol = 1e-10

--- a/interfaces/cython/cantera/preconditioners.pyx
+++ b/interfaces/cython/cantera/preconditioners.pyx
@@ -1,0 +1,73 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+from ._utils cimport stringify, pystr, dict_to_anymap, anymap_to_dict
+
+cdef class PreconditionerBase:
+    """
+    Common base class for preconditioners.
+    """
+    precon_type = "PreconditionerBase"
+    precon_linear_solver_type = "GMRES"
+
+    def __cinit__(self, *args, **kwargs):
+        self.pbase = newPreconditioner(stringify(self.precon_type))
+
+cdef class AdaptivePreconditioner(PreconditionerBase):
+    precon_type = "Adaptive"
+    precon_linear_solver_type = "GMRES"
+
+    def __cinit__(self, *args, **kwargs):
+        self.preconditioner = <CxxAdaptivePreconditioner*>(self.pbase)
+
+    property threshold:
+        """
+        Property for setting behavior of preconditioner pruning
+
+        Update the threshold to a desired value as:
+            >>> precon.threshold = 1e-8
+
+        Default is 1e-8.
+        """
+        def __get__(self):
+            return self.preconditioner.threshold()
+
+        def __set__(self, val):
+            self.preconditioner.setThreshold(val)
+
+    property ilut_fill_factor:
+        """
+        Property setting the linear solvers fill factor.
+
+        During factorization, after row elimination, only some of the largest elements in the L and U in addition to the diagonal element are kept. The number of elements kept is computed from the fill factor (a ratio) relative to the initial number of nonzero elements.
+
+        Update the ILUT fill factor to a desired value as:
+            >>> precon.ilut_fill_factor = 2
+
+        Default is the state size divided by 4.
+        """
+        def __set__(self, val):
+            self.preconditioner.setIlutFillFactor(val)
+
+        def __get__(self):
+            return self.preconditioner.ilutFillFactor()
+
+    property ilut_drop_tol:
+        """
+        Property setting the linear solvers drop tolerance.
+
+        During factorization any element below the product of the drop tolerance and average magnitude is dropped.
+
+        Update the ILUT drop tolerance to a desired value as:
+            >>> precon.ilut_drop_tol = 1e-10
+
+        Default is 1e-10.
+        """
+        def __set__(self, val):
+            self.preconditioner.setIlutDropTol(val)
+
+        def __get__(self):
+            return self.preconditioner.ilutDropTol()
+
+    def print_contents(self):
+        self.preconditioner.printPreconditioner()

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -7,6 +7,7 @@
 from .ctcxx cimport *
 from .kinetics cimport *
 from .func1 cimport *
+from .preconditioners cimport *
 
 cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxWall "Cantera::Wall"
@@ -157,7 +158,12 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         double sensitivity(string&, size_t, int) except +translate_exception
         size_t nparams()
         string sensitivityParameterName(size_t) except +translate_exception
-
+        void setLinearSolverType(string integratorType) except +translate_exception
+        string linearSolverType()
+        void setPreconditioner(CxxPreconditionerBase& preconditioner)
+        void setDerivativeSettings(CxxAnyMap&)
+        CxxAnyMap linearSolverStats()
+        CxxAnyMap nonlinearSolverStats()
 
 cdef extern from "cantera/zeroD/ReactorDelegator.h" namespace "Cantera":
     cdef cppclass CxxReactorAccessor "Cantera::ReactorAccessor":

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -158,9 +158,9 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         double sensitivity(string&, size_t, int) except +translate_exception
         size_t nparams()
         string sensitivityParameterName(size_t) except +translate_exception
-        void setLinearSolverType(string integratorType) except +translate_exception
+        void setLinearSolverType(string& integratorType) except +translate_exception
         string linearSolverType()
-        void setPreconditioner(CxxPreconditionerBase& preconditioner)
+        void setPreconditioner(shared_ptr[CxxPreconditionerBase] preconditioner)
         void setDerivativeSettings(CxxAnyMap&)
         CxxAnyMap linearSolverStats()
         CxxAnyMap nonlinearSolverStats()

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -1480,7 +1480,7 @@ cdef class ReactorNet:
         """Preconditioner associated with integrator"""
         def __set__(self, PreconditionerBase precon):
             # set preconditioner
-            self.net.setPreconditioner(deref(precon.pbase))
+            self.net.setPreconditioner(precon.pbase)
             # set problem type as default of preconditioner
             self.linear_solver_type = precon.precon_linear_solver_type
 
@@ -1489,10 +1489,12 @@ cdef class ReactorNet:
             The type of linear solver used in integration.
 
             Options for this property include:
-            "DENSE"
-            "GMRES"
-            "BAND"
-            "DIAG"
+
+              - `"DENSE"`
+              - `"GMRES"`
+              - `"BAND"`
+              - `"DIAG"`
+
         """
         def __set__(self, linear_solver_type):
             self.net.setLinearSolverType(stringify(linear_solver_type))
@@ -1517,8 +1519,8 @@ cdef class ReactorNet:
 
     property derivative_settings:
         """
-        Apply derivative settings to all reactors in the network. See also Kinetics.
-        derivative_settings.
+        Apply derivative settings to all reactors in the network.
+        See also `Kinetics.derivative_settings`.
         """
         def __set__(self, settings):
             self.net.setDerivativeSettings(dict_to_anymap(settings))

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -1008,7 +1008,7 @@ class TestConstPressureReactor(utilities.CanteraTest):
             self.net2.advance(t)
             self.assertArrayNear(self.r1.thermo.Y, self.r2.thermo.Y,
                                  rtol=5e-4, atol=1e-6)
-            self.assertNear(self.r1.T, self.r2.T, rtol=1e-5)
+            self.assertNear(self.r1.T, self.r2.T, rtol=5e-5)
             self.assertNear(self.r1.thermo.P, self.r2.thermo.P, rtol=1e-6)
             if surf:
                 self.assertArrayNear(self.surf1.coverages, self.surf2.coverages,

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -1037,6 +1037,51 @@ class TestIdealGasConstPressureReactor(TestConstPressureReactor):
     reactorClass = ct.IdealGasConstPressureReactor
 
 
+class TestIdealGasConstPressureMoleReactor(TestIdealGasConstPressureReactor):
+    reactorClass = ct.IdealGasConstPressureMoleReactor
+
+    def create_reactors(self, **kwargs):
+        super().create_reactors(**kwargs)
+        if "add_surf" not in kwargs.keys():
+            self.net2.preconditioner = ct.AdaptivePreconditioner()
+            self.net2.derivative_settings = {"skip-third-bodies":True, "skip-falloff":True}
+
+    def test_get_solver_type(self):
+        self.create_reactors()
+        self.assertEqual(self.net2.linear_solver_type, "GMRES")
+
+class TestIdealGasMoleReactor(TestReactor):
+    reactorClass = ct.IdealGasMoleReactor
+
+    def test_adaptive_precon_integration(self):
+        # Network one with non-mole reactor
+        net1 = ct.ReactorNet()
+        gas1 = ct.Solution('h2o2.yaml', transport_model=None)
+        gas1.TP = 300, ct.one_atm
+        gas1.set_equivalence_ratio(1, "H2", "O2:1, N2:3.76")
+        r1 = ct.IdealGasReactor(gas1)
+        net1.add_reactor(r1)
+        # Network two with mole reactor and preconditioner
+        net2 = ct.ReactorNet()
+        gas2 = ct.Solution('h2o2.yaml', transport_model=None)
+        gas2.TP = 300, ct.one_atm
+        gas2.set_equivalence_ratio(1, "H2", "O2:1, N2:3.76")
+        r2 = ct.IdealGasMoleReactor(gas2)
+        net2.add_reactor(r2)
+        # add preconditioner
+        net2.preconditioner = ct.AdaptivePreconditioner()
+        net2.derivative_settings = {"skip-third-bodies":True, "skip-falloff":True}
+        # integrate
+        for i in range(1, 11, 1):
+            adv_time = i * 0.1
+            net1.advance(adv_time)
+            net2.advance(adv_time)
+            self.assertNear(r1.T, r2.T)
+            self.assertNear(r1.thermo.density, r2.thermo.density)
+            self.assertNear(r1.thermo.P, r1.thermo.P)
+            self.assertArrayNear(r1.thermo.X, r1.thermo.X)
+
+
 class TestFlowReactor(utilities.CanteraTest):
     gas_def = """
     phases:

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -83,7 +83,7 @@ ImplicitSurfChem::ImplicitSurfChem(
     // use backward differencing, with a full Jacobian computed
     // numerically, and use a Newton linear iterator
     m_integ->setMethod(BDF_Method);
-    m_integ->setProblemType(DENSE + NOJAC);
+    m_integ->setLinearSolverType("DENSE");
     m_work.resize(ntmax);
 }
 

--- a/src/numerics/AdaptivePreconditioner.cpp
+++ b/src/numerics/AdaptivePreconditioner.cpp
@@ -1,0 +1,103 @@
+//! @file AdaptivePreconditioner.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/base/global.h"
+#include "cantera/numerics/AdaptivePreconditioner.h"
+
+namespace Cantera
+{
+
+void AdaptivePreconditioner::setValue(size_t row, size_t col, double value)
+{
+    m_jac_trips.emplace_back(row, col, value);
+}
+
+void AdaptivePreconditioner::stateAdjustment(vector_fp& state) {
+    // Only keep positive composition based on given tol
+    for (size_t i = 0; i < state.size(); i++) {
+        state[i] = std::max(state[i], m_atol);
+    }
+}
+
+void AdaptivePreconditioner::initialize(size_t networkSize)
+{
+    // don't use legacy rate constants
+    use_legacy_rate_constants(false);
+    // reset arrays in case of re-initialization
+    m_jac_trips.clear();
+    // set dimensions of preconditioner from network
+    m_dim = networkSize;
+    // reserve some space for vectors making up SparseMatrix
+    m_jac_trips.reserve(3 * networkSize);
+    // reserve space for preconditioner
+    m_precon_matrix.resize(m_dim, m_dim);
+    // creating sparse identity matrix
+    m_identity.resize(m_dim, m_dim);
+    m_identity.setIdentity();
+    m_identity.makeCompressed();
+    // setting default ILUT parameters
+    if (m_drop_tol == 0) {
+        setIlutDropTol(1e-10);
+    }
+    if (m_drop_tol == 0) {
+        setIlutFillFactor(m_dim/4);
+    }
+    // update initialized status
+    m_init = true;
+}
+
+
+void AdaptivePreconditioner::setup()
+{
+    // make into preconditioner as P = (I - gamma * J_bar)
+    transformJacobianToPreconditioner();
+    // compressing sparse matrix structure
+    m_precon_matrix.makeCompressed();
+    // analyze and factorize
+    m_solver.compute(m_precon_matrix);
+    // check for errors
+    if (m_solver.info() != Eigen::Success) {
+        throw CanteraError("AdaptivePreconditioner::setup",
+                           "error code: {}", m_solver.info());
+    }
+}
+
+void AdaptivePreconditioner::transformJacobianToPreconditioner()
+{
+    // set precon to jacobian
+    m_precon_matrix.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
+    // convert to preconditioner
+    m_precon_matrix = m_identity - m_gamma * m_precon_matrix;
+    // prune by threshold if desired
+    if (m_prune_precon) {
+        prunePreconditioner();
+    }
+}
+
+void AdaptivePreconditioner::prunePreconditioner()
+{
+    for (int k=0; k<m_precon_matrix.outerSize(); ++k) {
+        for (Eigen::SparseMatrix<double>::InnerIterator it(m_precon_matrix, k); it; ++it) {
+            if (std::abs(it.value()) < m_threshold && it.row() != it.col()) {
+                m_precon_matrix.coeffRef(it.row(), it.col()) = 0;
+            }
+        }
+    }
+}
+
+void AdaptivePreconditioner::solve(const size_t stateSize, double *rhs_vector, double* output)
+{
+    // creating vectors in the form of Ax=b
+    Eigen::Map<Eigen::VectorXd> bVector(rhs_vector, stateSize);
+    Eigen::Map<Eigen::VectorXd> xVector(output, stateSize);
+    // solve for xVector
+    xVector = m_solver.solve(bVector);
+    if (m_solver.info() != Eigen::Success) {
+        throw CanteraError("AdaptivePreconditioner::solve",
+                           "error code: {}", m_solver.info());
+    }
+}
+
+}

--- a/src/numerics/FuncEval.cpp
+++ b/src/numerics/FuncEval.cpp
@@ -51,4 +51,70 @@ std::string FuncEval::getErrors() const {
     return errs.str();
 }
 
+int FuncEval::preconditioner_setup_nothrow(double t, double* y, double gamma)
+{
+    try {
+        preconditionerSetup(t, y, gamma);
+    } catch (CanteraError& err) {
+        if (suppressErrors()) {
+            m_errors.push_back(err.what());
+        } else {
+            writelog(err.what());
+        }
+        return 1; // possibly recoverable error
+    } catch (std::exception& err) {
+        if (suppressErrors()) {
+            m_errors.push_back(err.what());
+        } else {
+            writelog("FuncEval::preconditioner_setup_nothrow: unhandled exception:\n");
+            writelog(err.what());
+            writelogendl();
+        }
+        return -1; // unrecoverable error
+    } catch (...) {
+        std::string msg = "FuncEval::preconditioner_setup_nothrow: unhandled exception"
+            " of unknown type\n";
+        if (suppressErrors()) {
+            m_errors.push_back(msg);
+        } else {
+            writelog(msg);
+        }
+        return -1; // unrecoverable error
+    }
+    return 0; // successful evaluation
+}
+
+int FuncEval::preconditioner_solve_nothrow(double* rhs, double* output)
+{
+    try {
+        preconditionerSolve(rhs, output); // perform preconditioner solve
+    } catch (CanteraError& err) {
+        if (suppressErrors()) {
+            m_errors.push_back(err.what());
+        } else {
+            writelog(err.what());
+        }
+        return 1; // possibly recoverable error
+    } catch (std::exception& err) {
+        if (suppressErrors()) {
+            m_errors.push_back(err.what());
+        } else {
+            writelog("FuncEval::preconditioner_solve_nothrow: unhandled exception:\n");
+            writelog(err.what());
+            writelogendl();
+        }
+        return -1; // unrecoverable error
+    } catch (...) {
+        std::string msg = "FuncEval::preconditioner_solve_nothrow: unhandled exception"
+            " of unknown type\n";
+        if (suppressErrors()) {
+            m_errors.push_back(msg);
+        } else {
+            writelog(msg);
+        }
+        return -1; // unrecoverable error
+    }
+    return 0; // successful evaluation
+}
+
 }

--- a/src/numerics/PreconditionerFactory.cpp
+++ b/src/numerics/PreconditionerFactory.cpp
@@ -1,0 +1,22 @@
+//! @file PreconditionerFactory.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/numerics/PreconditionerFactory.h"
+#include "cantera/numerics/AdaptivePreconditioner.h"
+
+
+using namespace std;
+namespace Cantera
+{
+
+PreconditionerFactory* PreconditionerFactory::s_factory = 0;
+std::mutex PreconditionerFactory::precon_mutex;
+
+PreconditionerFactory::PreconditionerFactory()
+{
+    reg("Adaptive", []() { return new AdaptivePreconditioner(); });
+}
+
+}

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -478,6 +478,11 @@ const vector_fp& Phase::molecularWeights() const
     return m_molwts;
 }
 
+const vector_fp& Phase::inverseMolecularWeights() const
+{
+    return m_rmolwts;
+}
+
 void Phase::getCharges(double* charges) const
 {
     copy(m_speciesCharge.begin(), m_speciesCharge.end(), charges);
@@ -603,6 +608,25 @@ void Phase::setConcentrationsNoNorm(const double* const conc)
         m_ym[k] = conc[k] * rsum;
         m_y[k] = m_ym[k] * m_molwts[k];
     }
+    compositionChanged();
+}
+
+void Phase::setMolesNoTruncate(const double* const N)
+{
+    // get total moles
+    copy(N, N + m_kk, m_ym.begin());
+    double totalMoles = accumulate(m_ym.begin(), m_ym.end(), 0.0);
+    // get total mass
+    copy(N, N + m_kk, m_y.begin());
+    transform(m_y.begin(), m_y.end(), m_molwts.begin(), m_y.begin(), multiplies<double>());
+    double totalMass = accumulate(m_y.begin(), m_y.end(), 0.0);
+    // mean molecular weight
+    m_mmw = totalMass/totalMoles;
+    // mass fractions
+    scale(m_y.begin(), m_y.end(), m_y.begin(), 1/totalMass);
+    // moles fractions/m_mmw
+    scale(m_ym.begin(), m_ym.end(), m_ym.begin(), 1/(m_mmw * totalMoles));
+    // composition has changed
     compositionChanged();
 }
 

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -1,0 +1,263 @@
+//! @file IdealGasConstPressureMoleReactor.cpp A constant pressure
+//! zero-dimensional reactor with moles as the state
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/zeroD/IdealGasConstPressureMoleReactor.h"
+#include "cantera/zeroD/FlowDevice.h"
+#include "cantera/zeroD/ReactorNet.h"
+#include "cantera/zeroD/ReactorSurface.h"
+#include "cantera/kinetics/Kinetics.h"
+#include "cantera/thermo/ThermoPhase.h"
+#include "cantera/thermo/SurfPhase.h"
+#include "cantera/base/utilities.h"
+#include <limits>
+
+using namespace std;
+
+namespace Cantera
+{
+
+void IdealGasConstPressureMoleReactor::setThermoMgr(ThermoPhase& thermo)
+{
+    if (thermo.type() != "IdealGas") {
+        throw CanteraError("IdealGasConstPressureMoleReactor::setThermoMgr",
+                           "Incompatible phase type provided");
+    }
+    MoleReactor::setThermoMgr(thermo);
+}
+
+void IdealGasConstPressureMoleReactor::getState(double* y)
+{
+    if (m_thermo == 0) {
+        throw CanteraError("IdealGasConstPressureMoleReactor::getState",
+                           "Error: reactor is empty.");
+    }
+    m_thermo->restoreState(m_state);
+    // get mass for calculations
+    m_mass = m_thermo->density() * m_vol;
+    // set the first component to the temperature
+    y[0] = m_thermo->temperature();
+    // Use inverse molecular weights
+    const double* Y = m_thermo->massFractions();
+    const vector_fp& imw = m_thermo->inverseMolecularWeights();
+    double *ys = y + m_sidx;
+    for (size_t i = 0; i < m_nsp; i++) {
+        ys[i] = m_mass * imw[i] * Y[i];
+    }
+    // set the remaining components to the surface species moles on the walls
+    getSurfaceInitialConditions(y + m_nsp + m_sidx);
+}
+
+void IdealGasConstPressureMoleReactor::initialize(double t0)
+{
+    MoleReactor::initialize(t0);
+    m_nv -= 1; // const pressure system loses 1 more variable from MoleReactor
+    m_hk.resize(m_nsp, 0.0);
+}
+
+void IdealGasConstPressureMoleReactor::updateState(double* y)
+{
+    // the components of y are: [0] the temperature, [1...K+1) are the
+    // moles of each species, and [K+1...] are the moles of surface
+    // species on each wall.
+    m_thermo->setMolesNoTruncate(y + m_sidx);
+    m_thermo->setState_TP(y[0], m_pressure);
+    // get mass
+    const vector_fp& mw = m_thermo->molecularWeights();
+    // calculate mass from moles
+    m_mass = 0;
+    for (size_t i = 0; i < m_nsp; i++) {
+        m_mass += y[i + m_sidx] * mw[i];
+    }
+    m_vol = m_mass / m_thermo->density();
+    updateConnected(false);
+    updateSurfaceState(y + m_nsp + m_sidx);
+}
+
+void IdealGasConstPressureMoleReactor::eval(double time, double* LHS, double* RHS)
+{
+    double& mcpdTdt = RHS[0]; // m * c_p * dT/dt
+    double* dydt = RHS + m_sidx; // kmol per s
+
+    evalWalls(time);
+
+    m_thermo->restoreState(m_state);
+
+    m_thermo->getPartialMolarEnthalpies(&m_hk[0]);
+    const vector_fp& imw = m_thermo->inverseMolecularWeights();
+
+    if (m_chem) {
+        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+    }
+
+    //! evaluate reactor surfaces
+    evalSurfaces(LHS + m_nsp + m_sidx, RHS + m_nsp + m_sidx, m_sdot.data());
+
+    // external heat transfer
+    mcpdTdt += m_Qdot;
+
+    for (size_t n = 0; n < m_nsp; n++) {
+        // heat release from gas phase and surface reactions
+        mcpdTdt -= m_wdot[n] * m_hk[n] * m_vol;
+        mcpdTdt -= m_sdot[n] * m_hk[n];
+        // production in gas phase and from surfaces
+        dydt[n] = m_wdot[n] * m_vol + m_sdot[n];
+    }
+
+    // add terms for outlets
+    for (auto outlet : m_outlet) {
+        for (size_t n = 0; n < m_nsp; n++) {
+            // flow of species into system and dilution by other species
+            dydt[n] -= outlet->outletSpeciesMassFlowRate(n) * imw[n];
+        }
+    }
+
+    // add terms for inlets
+    for (auto inlet : m_inlet) {
+        double mdot = inlet->massFlowRate();
+        mcpdTdt += inlet->enthalpy_mass() * mdot;
+        for (size_t n = 0; n < m_nsp; n++) {
+            double mdot_spec = inlet->outletSpeciesMassFlowRate(n);
+            // flow of species into system and dilution by other species
+            dydt[n] += inlet->outletSpeciesMassFlowRate(n) * imw[n];
+            mcpdTdt -= m_hk[n] * imw[n] * mdot_spec;
+        }
+    }
+
+    if (m_energy) {
+        LHS[0] = m_mass * m_thermo->cp_mass();
+    } else {
+        RHS[0] = 0.0;
+    }
+}
+
+//! Method to calculate the reactor specific jacobian
+Eigen::SparseMatrix<double> IdealGasConstPressureMoleReactor::jacobian(double t, double* y) {
+    // clear former jacobian elements
+    m_jac_trips.clear();
+    // reserve space for jacobian elements in triplet vector
+    if (m_jac_trips.capacity() < m_nv * m_nv)
+    {
+        m_jac_trips.reserve(m_nv * m_nv);
+    }
+    // Determine Species Derivatives
+    // volume / moles * rates portion of equation
+    size_t nspecies = m_thermo->nSpecies();
+    // create sparse structures for rates and volumes
+    Eigen::SparseMatrix<double> rates(nspecies, 1);
+    Eigen::SparseMatrix<double> volumes(1, nspecies);
+    // reserve space for data
+    rates.reserve(nspecies);
+    volumes.reserve(nspecies);
+    // fill sparse structures
+    m_kin->getNetProductionRates(rates.valuePtr()); // "omega dot"
+    std::fill(volumes.valuePtr(), volumes.valuePtr() + nspecies, m_vol);
+    // get ROP derivatives
+    double scalingFactor = m_vol/accumulate(y + m_sidx, y + m_nv, 0.0);
+    Eigen::SparseMatrix<double> speciesDervs = m_kin->netProductionRates_ddX();
+    // sum parts
+    speciesDervs = scalingFactor * speciesDervs + rates * volumes;
+    // add elements to jacobian triplets
+    for (int k=0; k<speciesDervs.outerSize(); ++k) {
+        for (Eigen::SparseMatrix<double>::InnerIterator it(speciesDervs, k); it; ++it) {
+            m_jac_trips.emplace_back(it.row() + m_sidx, it.col() + m_sidx, it.value());
+        }
+    }
+    // Temperature Derivatives
+    if (m_energy) {
+        // getting perturbed state for finite difference
+        double deltaTemp = y[0] * std::numeric_limits<double>::epsilon();
+        // finite difference temperature derivatives
+        vector_fp yNext(m_nv);
+        vector_fp ydotNext(m_nv);
+        vector_fp yCurrent(m_nv);
+        vector_fp ydotCurrent(m_nv);
+        // copy LHS to current and next
+        copy(y, y + m_nv, yCurrent.begin());
+        copy(y, y + m_nv, yNext.begin());
+        // perturb temperature
+        yNext[0] += deltaTemp;
+        // getting perturbed state
+        updateState(yNext.data());
+        eval(t, yNext.data(), ydotNext.data());
+        // reset and get original state
+        updateState(yCurrent.data());
+        eval(t, yCurrent.data(), ydotCurrent.data());
+        // d T_dot/dT
+        m_jac_trips.emplace_back(0, 0, (ydotNext[0] - ydotCurrent[0]) / deltaTemp);
+        // d omega_dot_j/dT
+        for (size_t j = m_sidx; j < m_nv; j++) {
+            m_jac_trips.emplace_back(j, 0, (ydotNext[j] - ydotCurrent[j]) / deltaTemp);
+        }
+        // d T_dot/dnj
+        vector_fp specificHeat(m_nsp);
+        vector_fp netProductionRates(m_nsp);
+        vector_fp enthalpy(m_nsp);
+        // getting physical quantities
+        m_thermo->getPartialMolarCp(specificHeat.data());
+        m_thermo->getPartialMolarEnthalpies(enthalpy.data());
+        m_kin->getNetProductionRates(netProductionRates.data());
+        // getting perturbed changes w.r.t temperature
+        double hkndotksum = 0;
+        double NtotalCp = accumulate(y + m_sidx, y + m_nv, 0.0) * m_thermo->cp_mole();
+        // scale net production rates by  volume to get molar rate
+        scale(netProductionRates.begin(), netProductionRates.end(), netProductionRates.begin(), m_vol);
+        // determine a sum in derivative
+        for (size_t i = 0; i < m_nsp; i++) {
+            hkndotksum += enthalpy[i] * netProductionRates[i];
+        }
+        // determine derivatives
+        // spans columns
+        for (size_t j = 0; j < m_nsp; j++) {
+            double hkdnkdnjSum = 0;
+            // spans rows
+            for (size_t k = 0; k < m_nsp; k++) {
+                hkdnkdnjSum += enthalpy[k] * speciesDervs.coeff(k, j);
+            }
+            // add elements to jacobian triplets
+            m_jac_trips.emplace_back(0, j + m_sidx, (-hkdnkdnjSum * NtotalCp +
+            specificHeat[j] * hkndotksum) / (NtotalCp * NtotalCp));
+        }
+    }
+    Eigen::SparseMatrix<double> jac (m_nv, m_nv);
+    jac.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
+    return jac;
+}
+
+size_t IdealGasConstPressureMoleReactor::componentIndex(const string& nm) const
+{
+    size_t k = speciesIndex(nm);
+    if (k != npos) {
+        return k + m_sidx;
+    } else if (nm == "temperature") {
+        return 0;
+    } else {
+        return npos;
+    }
+}
+
+std::string IdealGasConstPressureMoleReactor::componentName(size_t k) {
+    if (k == 0) {
+        return "temperature";
+    } else if (k >= m_sidx && k < neq()) {
+        k -= m_sidx;
+        if (k < m_thermo->nSpecies()) {
+            return m_thermo->speciesName(k);
+        } else {
+            k -= m_thermo->nSpecies();
+        }
+        for (auto& S : m_surfaces) {
+            ThermoPhase* th = S->thermo();
+            if (k < th->nSpecies()) {
+                return th->speciesName(k);
+            } else {
+                k -= th->nSpecies();
+            }
+        }
+    }
+    throw CanteraError("IdealGasConstPressureMoleReactor::componentName", "Index is out of bounds.");
+}
+
+}

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -1,0 +1,237 @@
+//! @file IdealGasMoleReactor.cpp A constant volume zero-dimensional
+//! reactor with moles as the state
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/zeroD/IdealGasMoleReactor.h"
+#include "cantera/zeroD/FlowDevice.h"
+#include "cantera/zeroD/ReactorNet.h"
+#include "cantera/zeroD/ReactorSurface.h"
+#include "cantera/kinetics/Kinetics.h"
+#include "cantera/thermo/ThermoPhase.h"
+#include "cantera/thermo/SurfPhase.h"
+#include "cantera/base/utilities.h"
+#include <limits>
+
+using namespace std;
+
+namespace Cantera
+{
+
+void IdealGasMoleReactor::setThermoMgr(ThermoPhase& thermo)
+{
+    if (thermo.type() != "IdealGas") {
+        throw CanteraError("IdealGasMoleReactor::setThermoMgr",
+                           "Incompatible phase type provided");
+    }
+    MoleReactor::setThermoMgr(thermo);
+}
+
+void IdealGasMoleReactor::getState(double* y)
+{
+    if (m_thermo == 0) {
+        throw CanteraError("IdealGasMoleReactor::getState",
+                           "Error: reactor is empty.");
+    }
+    m_thermo->restoreState(m_state);
+
+    // get mass for calculations
+    m_mass = m_thermo->density() * m_vol;
+
+    // set the first component to the temperature
+    y[0] = m_thermo->temperature();
+
+    // set the second component to the volume
+    y[1] = m_vol;
+
+    // use inverse molecular weights
+    const double* Y = m_thermo->massFractions();
+    const vector_fp& imw = m_thermo->inverseMolecularWeights();
+    double* ys = y + m_sidx;
+    for (size_t i = 0; i < m_nsp; i++) {
+        ys[i] = m_mass * imw[i] * Y[i];
+    }
+    // set the remaining components to the surface species moles on
+    // the walls
+    getSurfaceInitialConditions(y + m_nsp + m_sidx);
+}
+
+size_t IdealGasMoleReactor::componentIndex(const string& nm) const
+{
+    size_t k = speciesIndex(nm);
+    if (k != npos) {
+        return k + m_sidx;
+    } else if (nm == "temperature") {
+        return 0;
+    } else if (nm == "volume") {
+        return 1;
+    } else {
+        return npos;
+    }
+}
+
+void IdealGasMoleReactor::initialize(double t0)
+{
+    MoleReactor::initialize(t0);
+    m_uk.resize(m_nsp, 0.0);
+}
+
+void IdealGasMoleReactor::updateState(double* y)
+{
+    // the components of y are: [0] the temperature, [1] the volume, [2...K+1) are the
+    // moles of each species, and [K+1...] are the moles of surface
+    // species on each wall.
+    const vector_fp& mw = m_thermo->molecularWeights();
+    // calculate mass from moles
+    m_mass = 0;
+    for (size_t i = 0; i < m_nv - m_sidx; i++) {
+        m_mass += y[i + m_sidx] * mw[i];
+    }
+    m_vol = y[1];
+    // set state
+    m_thermo->setMolesNoTruncate(y + m_sidx);
+    m_thermo->setState_TR(y[0], m_mass / m_vol);
+    updateConnected(true);
+    updateSurfaceState(y + m_nsp + m_sidx);
+}
+
+void IdealGasMoleReactor::eval(double time, double* LHS, double* RHS)
+{
+    double& mcvdTdt = RHS[0]; // m * c_v * dT/dt
+    double* dydt = RHS + m_sidx; // kmol per s
+
+    evalWalls(time);
+
+    m_thermo->restoreState(m_state);
+
+    m_thermo->getPartialMolarIntEnergies(&m_uk[0]);
+    const vector_fp& imw = m_thermo->inverseMolecularWeights();
+
+    if (m_chem) {
+        m_kin->getNetProductionRates(&m_wdot[0]); // "omega dot"
+    }
+
+    // evaluate surfaces
+    evalSurfaces(LHS + m_nsp + m_sidx, RHS + m_nsp + m_sidx, m_sdot.data());
+
+    // external heat transfer and compression work
+    mcvdTdt += - m_pressure * m_vdot + m_Qdot;
+
+    for (size_t n = 0; n < m_nsp; n++) {
+        // heat release from gas phase and surface reactions
+        mcvdTdt -= m_wdot[n] * m_uk[n] * m_vol;
+        mcvdTdt -= m_sdot[n] * m_uk[n];
+        // production in gas phase and from surfaces
+        dydt[n] = (m_wdot[n] * m_vol + m_sdot[n]);
+    }
+
+    // add terms for outlets
+    for (auto outlet : m_outlet) {
+        for (size_t n = 0; n < m_nsp; n++) {
+            // flow of species into system and dilution by other species
+            dydt[n] -= outlet->outletSpeciesMassFlowRate(n) * imw[n];
+        }
+        double mdot = outlet->massFlowRate();
+        mcvdTdt -= mdot * m_pressure * m_vol / m_mass; // flow work
+    }
+
+    // add terms for inlets
+    for (auto inlet : m_inlet) {
+        double mdot = inlet->massFlowRate();
+        mcvdTdt += inlet->enthalpy_mass() * mdot;
+        for (size_t n = 0; n < m_nsp; n++) {
+            double mdot_spec = inlet->outletSpeciesMassFlowRate(n);
+            // flow of species into system and dilution by other species
+            dydt[n] += inlet->outletSpeciesMassFlowRate(n) * imw[n];
+            mcvdTdt -= m_uk[n] * imw[n] * mdot_spec;
+        }
+    }
+
+    RHS[1] = m_vdot;
+    if (m_energy) {
+        LHS[0] = m_mass * m_thermo->cv_mass();
+    } else {
+        RHS[0] = 0;
+    }
+}
+
+Eigen::SparseMatrix<double> IdealGasMoleReactor::jacobian(double t, double* y)
+{
+    // clear former jacobian elements
+    m_jac_trips.clear();
+    // Determine Species Derivatives
+    // get ROP derivatives
+    double scalingFactor = m_vol/accumulate(y + m_sidx, y + m_nv, 0.0);
+    Eigen::SparseMatrix<double> speciesDervs = scalingFactor * m_kin->netProductionRates_ddX();
+    // add to preconditioner
+    for (int k=0; k<speciesDervs.outerSize(); ++k) {
+        for (Eigen::SparseMatrix<double>::InnerIterator it(speciesDervs, k); it; ++it) {
+            m_jac_trips.emplace_back(it.row() + m_sidx, it.col() + m_sidx, it.value());
+        }
+    }
+    // Temperature Derivatives
+    if (m_energy) {
+        // getting perturbed state for finite difference
+        double deltaTemp = y[0] * std::sqrt(std::numeric_limits<double>::epsilon());
+        // finite difference temperature derivatives
+        vector_fp yNext(m_nv);
+        vector_fp ydotNext(m_nv);
+        vector_fp yCurrent(m_nv);
+        vector_fp ydotCurrent(m_nv);
+        // copy y to current and next
+        copy(y, y + m_nv, yCurrent.begin());
+        copy(y, y + m_nv, yNext.begin());
+        // perturb temperature
+        yNext[0] += deltaTemp;
+        // getting perturbed state
+        updateState(yNext.data());
+        eval(t, yNext.data(), ydotNext.data());
+        // reset and get original state
+        updateState(yCurrent.data());
+        eval(t, yCurrent.data(), ydotCurrent.data());
+        // d T_dot/dT
+        m_jac_trips.emplace_back(0, 0, (ydotNext[0] - ydotCurrent[0]) / deltaTemp);
+        // d omega_dot_j/dT
+        for (size_t j = m_sidx; j < m_nv; j++) {
+            m_jac_trips.emplace_back(j, 0, (ydotNext[j] - ydotCurrent[j]) / deltaTemp);
+        }
+        // find derivatives d T_dot/dNj
+        vector_fp specificHeat(m_nsp);
+        vector_fp netProductionRates(m_nsp);
+        vector_fp internal_energy(m_nsp);
+        // getting species data
+        m_thermo->getPartialMolarCp(specificHeat.data());
+        m_thermo->getPartialMolarIntEnergies(internal_energy.data());
+        m_kin->getNetProductionRates(netProductionRates.data());
+        // scale net production rates by  volume to get molar rate
+        scale(netProductionRates.begin(), netProductionRates.end(), netProductionRates.begin(), m_vol);
+        // convert Cp to Cv for ideal gas as Cp - Cv = R
+        for (size_t i = 0; i < specificHeat.size(); i++) {
+            specificHeat[i] -= GasConstant;
+        }
+        // finding a sum inside the derivative
+        double uknkSum = 0;
+        double NtotalCv = accumulate(y + m_sidx, y + m_nv, 0.0) * m_thermo->cv_mole();
+        for (size_t i = 0; i < m_nsp; i++) {
+            uknkSum += internal_energy[i] * netProductionRates[i];
+        }
+        // finding derivatives
+        // spans columns
+        for (size_t j = 0; j < m_nsp; j++) {
+            double ukdnkdnjSum = 0;
+            // spans rows
+            for (size_t k = 0; k < m_nsp; k++) {
+                ukdnkdnjSum += internal_energy[k] * speciesDervs.coeff(k, j);
+            }
+            // set appropriate column of preconditioner
+            m_jac_trips.emplace_back(0, j + m_sidx, (-ukdnkdnjSum * NtotalCv +
+            specificHeat[j] *  uknkSum) / (NtotalCv * NtotalCv));
+        }
+    }
+    Eigen::SparseMatrix<double> jac (m_nv, m_nv);
+    jac.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
+    return jac;
+}
+
+}

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -5,14 +5,9 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/MoleReactor.h"
-#include "cantera/zeroD/FlowDevice.h"
-#include "cantera/zeroD/Wall.h"
 #include "cantera/thermo/SurfPhase.h"
-#include "cantera/zeroD/ReactorNet.h"
 #include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/kinetics/Kinetics.h"
-#include "cantera/base/Solution.h"
-#include "cantera/base/utilities.h"
 
 using namespace std;
 
@@ -23,12 +18,10 @@ void MoleReactor::getSurfaceInitialConditions(double* y)
 {
     size_t loc = 0;
     for (auto& S : m_surfaces) {
-        S->getCoverages(y + loc);
         double area = S->area();
         auto currPhase = S->thermo();
         double tempLoc = currPhase->nSpecies();
         double surfDensity = currPhase->siteDensity();
-        // get coverages
         S->getCoverages(y + loc);
         // convert coverages to moles
         for (size_t i = 0; i < tempLoc; i++) {

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -1,0 +1,90 @@
+//! @file MoleReactor.cpp A zero-dimensional reactor with a moles as the
+//! state
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/zeroD/MoleReactor.h"
+#include "cantera/zeroD/FlowDevice.h"
+#include "cantera/zeroD/Wall.h"
+#include "cantera/thermo/SurfPhase.h"
+#include "cantera/zeroD/ReactorNet.h"
+#include "cantera/zeroD/ReactorSurface.h"
+#include "cantera/kinetics/Kinetics.h"
+#include "cantera/base/Solution.h"
+#include "cantera/base/utilities.h"
+
+using namespace std;
+
+namespace Cantera
+{
+
+void MoleReactor::getSurfaceInitialConditions(double* y)
+{
+    size_t loc = 0;
+    for (auto& S : m_surfaces) {
+        S->getCoverages(y + loc);
+        double area = S->area();
+        auto currPhase = S->thermo();
+        double tempLoc = currPhase->nSpecies();
+        double surfDensity = currPhase->siteDensity();
+        // get coverages
+        S->getCoverages(y + loc);
+        // convert coverages to moles
+        for (size_t i = 0; i < tempLoc; i++) {
+            y[i + loc] = y[i + loc] * area * surfDensity / currPhase->size(i);
+        }
+        loc += tempLoc;
+    }
+}
+
+void MoleReactor::initialize(double t0)
+{
+    Reactor::initialize(t0);
+    m_nv -= 1; // moles gives the state one fewer variables
+}
+
+void MoleReactor::updateSurfaceState(double* y)
+{
+    size_t loc = 0;
+    vector_fp coverages(m_nv_surf, 0.0);
+    for (auto& S : m_surfaces) {
+        auto surf = S->thermo();
+        double invArea = 1/S->area();
+        double invSurfDensity = 1/surf->siteDensity();
+        double tempLoc = surf->nSpecies();
+        for (size_t i = 0; i < tempLoc; i++) {
+            coverages[i + loc] = y[i + loc] * invArea * surf->size(i) * invSurfDensity;
+        }
+        S->setCoverages(coverages.data()+loc);
+        loc += tempLoc;
+    }
+}
+
+void MoleReactor::evalSurfaces(double* LHS, double* RHS, double* sdot)
+{
+    fill(sdot, sdot + m_nsp, 0.0);
+    size_t loc = 0; // offset into ydot
+    for (auto S : m_surfaces) {
+        Kinetics* kin = S->kinetics();
+        SurfPhase* surf = S->thermo();
+        double wallarea = S->area();
+        size_t nk = surf->nSpecies();
+        S->syncState();
+        kin->getNetProductionRates(&m_work[0]);
+        size_t ns = kin->surfacePhaseIndex();
+        size_t surfloc = kin->kineticsSpeciesIndex(0,ns);
+        for (size_t k = 0; k < nk; k++) {
+            RHS[loc + k] = m_work[surfloc + k] * wallarea / surf->size(k);
+        }
+        loc += nk;
+
+        size_t bulkloc = kin->kineticsSpeciesIndex(m_thermo->speciesName(0));
+
+        for (size_t k = 0; k < m_nsp; k++) {
+            sdot[k] += m_work[bulkloc + k] * wallarea;
+        }
+    }
+}
+
+}

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -35,6 +35,11 @@ void Reactor::insert(shared_ptr<Solution> sol) {
     setKineticsMgr(*sol->kinetics());
 }
 
+void Reactor::setDerivativeSettings(AnyMap& settings)
+{
+    m_kin->setDerivativeSettings(settings);
+}
+
 void Reactor::setKineticsMgr(Kinetics& kin)
 {
     m_kin = &kin;

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -9,8 +9,10 @@
 #include "cantera/zeroD/FlowReactor.h"
 #include "cantera/zeroD/ConstPressureReactor.h"
 #include "cantera/zeroD/IdealGasReactor.h"
+#include "cantera/zeroD/IdealGasMoleReactor.h"
 #include "cantera/zeroD/IdealGasConstPressureReactor.h"
 #include "cantera/zeroD/ReactorDelegator.h"
+#include "cantera/zeroD/IdealGasConstPressureMoleReactor.h"
 
 using namespace std;
 namespace Cantera
@@ -36,6 +38,8 @@ ReactorFactory::ReactorFactory()
         []() { return new ReactorDelegator<ConstPressureReactor>(); });
     reg("ExtensibleIdealGasConstPressureReactor",
         []() { return new ReactorDelegator<IdealGasConstPressureReactor>(); });
+    reg("IdealGasConstPressureMoleReactor", []() { return new IdealGasConstPressureMoleReactor(); });
+    reg("IdealGasMoleReactor", []() { return new IdealGasMoleReactor(); });
 }
 
 ReactorBase* ReactorFactory::newReactor(const std::string& reactorType)

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -1,9 +1,9 @@
-#include <cstdio>
-#include <string>
 #include "gtest/gtest.h"
 #include "cantera/thermo.h"
 #include "cantera/kinetics.h"
 #include "cantera/zerodim.h"
+#include "cantera/base/Interface.h"
+#include "cantera/numerics/AdaptivePreconditioner.h"
 
 using namespace Cantera;
 
@@ -12,42 +12,73 @@ using namespace Cantera;
 // adapted from test_reactor.py::test_equilibrium_HP.
 TEST(ZeroDim, test_individual_reactor_initialization)
 {
-    // Initial conditions
+    // initial conditions
     double T0 = 1100.0;
     double P0 = 10 * OneAtm;
     double tol = 1e-7;
     std::string X0 = "H2:1.0, O2:0.5, AR:8.0";
-    // Reactor solution, phase, and kinetics objects
+    // reactor solution, phase, and kinetics objects
     std::shared_ptr<Solution> sol1 = newSolution("h2o2.yaml");
     sol1->thermo()->setState_TPX(T0, P0, X0);
-    // Set up reactor object
+    // set up reactor object
     Reactor reactor1;
     reactor1.insert(sol1);
-    // Initialize reactor prior to integration to ensure no impact
+    // initialize reactor prior to integration to ensure no impact
     reactor1.initialize();
-    // Setup reactor network and integrate
+    // setup reactor network and integrate
     ReactorNet network;
     network.addReactor(reactor1);
+    network.initialize();
     network.advance(1.0);
-    // Secondary gas for comparison
+    // secondary gas for comparison
     std::shared_ptr<Solution> sol2 = newSolution("h2o2.yaml");
     sol2->thermo()->setState_TPX(T0, P0, X0);
     sol2->thermo()->equilibrate("UV");
-    // Secondary reactor for comparison
+    // secondary reactor for comparison
     Reactor reactor2;
     reactor2.insert(sol2);
     reactor2.initialize(0.0);
-    // Get state of reactors
-    std::vector<double> state1 (reactor1.neq());
-    std::vector<double> state2 (reactor2.neq());
+    // get state of reactors
+    vector_fp state1 (reactor1.neq());
+    vector_fp state2 (reactor2.neq());
     reactor1.getState(state1.data());
     reactor2.getState(state2.data());
-    // Compare the reactors.
+    // compare the reactors.
     EXPECT_EQ(reactor1.neq(), reactor2.neq());
-    for (size_t i = 0; i < reactor1.neq(); i++)
-    {
+    for (size_t i = 0; i < reactor1.neq(); i++) {
         EXPECT_NEAR(state1[i], state2[i], tol);
     }
+}
+
+TEST(MoleReactorTestSet, test_mole_reactor_get_state)
+{
+    // setting up solution object and thermo/kinetics pointers
+    double tol = 1e-8;
+    auto sol = newSolution("h2o2.yaml");
+    sol->thermo()->setState_TPY(1000.0, OneAtm, "H2:0.5, O2:0.5");
+    IdealGasConstPressureMoleReactor reactor;
+    reactor.insert(sol);
+    reactor.setInitialVolume(0.5);
+    reactor.setEnergy(false);
+    reactor.initialize();
+    vector_fp state(reactor.neq());
+    vector_fp updatedState(reactor.neq());
+    // test get state
+    const ThermoPhase& thermo = reactor.contents();
+    const vector_fp& imw = thermo.inverseMolecularWeights();
+    // prescribed state
+    double mass = reactor.volume() * thermo.density();
+    size_t H2I = reactor.componentIndex("H2")-1;
+    size_t O2I = reactor.componentIndex("O2")-1;
+    double O2_Moles = imw[O2I] * 0.5 * mass;
+    double  H2_Moles = imw[H2I] * 0.5 * mass;
+    // test getState
+    reactor.getState(state.data());
+    EXPECT_NEAR(state[reactor.componentIndex("H2")], H2_Moles, tol);
+    EXPECT_NEAR(state[reactor.componentIndex("O2")], O2_Moles, tol);
+    // test updateState
+    EXPECT_NEAR(reactor.volume(), 0.5, tol);
+    EXPECT_NEAR(reactor.pressure(), OneAtm, tol);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
This code is adding preconditioning capabilities to Cantera/CVODEs solver interface for reactor networks. It is focused on a specific type of preconditioning but the code is being written with extensibility in mind. It adds Preconditioning capabilities to the numerics portion of cantera which contains a "PreconditionerBase" that is used to write future preconditioners. It also contains a class derived from this called "AdaptivePreconditioner" which is the aforementioned specific preconditioner.

There are also a couple of functions added to specific reactors. IdealGasReactor is one example. Currently, I added a function to evaluate the energy equation which is also done inside of evalEqs but I wanted to avoid touching core Cantera code as much as possible. In the future, I would like to collaborate with the appropriate people to stream line this.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
