### PR TITLE
Fix python_minimal interface to install Cantera YAML tools

### DIFF
--- a/interfaces/python_minimal/.gitignore
+++ b/interfaces/python_minimal/.gitignore
@@ -2,6 +2,9 @@ setup*.py
 scripts/*
 cantera/ck2cti.py
 cantera/ctml_writer.py
+cantera/ck2yaml.py
+cantera/cti2yaml.py
+cantera/ctml2yaml.py
 build
 dist
 Cantera_minimal.egg-info

--- a/interfaces/python_minimal/SConscript
+++ b/interfaces/python_minimal/SConscript
@@ -8,7 +8,7 @@ localenv = env.Clone()
 make_setup = build(localenv.SubstFile('setup.py', 'setup.py.in'))
 
 # copy scripts from the full Cython module
-for script in ['ctml_writer', 'ck2cti']:
+for script in ['ctml_writer', 'ck2cti', 'ck2yaml', 'cti2yaml', 'ctml2yaml']:
     # The actual script
     s = build(env.Command('cantera/{}.py'.format(script),
                           '#interfaces/cython/cantera/{}.py'.format(script),

--- a/interfaces/python_minimal/cantera/__init__.py
+++ b/interfaces/python_minimal/cantera/__init__.py
@@ -1,2 +1,5 @@
 from . import ck2cti
 from . import ctml_writer
+from . import ck2yaml
+from . import cti2yaml
+from . import ctml2yaml

--- a/interfaces/python_minimal/setup.py.in
+++ b/interfaces/python_minimal/setup.py.in
@@ -12,6 +12,9 @@ setup(name="Cantera_minimal",
         'console_scripts': [
             'ck2cti=cantera.ck2cti:script_entry_point',
             'ctml_writer=cantera.ctml_writer:main',
+            'ck2yaml=cantera.ck2yaml:script_entry_point',
+            'cti2yaml=cantera.cti2yaml:main',
+            'ctml2yaml=cantera.ctml2yaml:main',
         ],
       },
 )


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

The python_minimal SConscript did't copy cantera yaml tools (ck2yaml.py, cti2yaml.py, ctml2yaml.py) to python_minimal directory and therefore didn's install these scripts if `Python Minimal` interface is chosen to build.

This patch should fix this issue.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
