### PR TITLE
Implement Python dict to C++ AnyMap conversion

### DIFF
--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -119,6 +119,9 @@ public:
     //! Returns a string specifying the type of the held value.
     std::string type_str() const;
 
+    //! Return boolean indicating whether AnyValue is empty.
+    bool isEmpty() const;
+
     //! Returns `true` if the held value is of the specified type.
     template<class T>
     bool is() const;
@@ -427,6 +430,9 @@ public:
     //! Get the value of the item stored in `key`. Raises an exception if the
     //! value does not exist.
     const AnyValue& at(const std::string& key) const;
+
+    //! Return boolean indicating whether AnyMap is empty.
+    bool isEmpty() const;
 
     //! Returns `true` if the map contains an item named `key`.
     bool hasKey(const std::string& key) const;

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -72,6 +72,7 @@ cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
         Iterator end()
         OrderedProxy ordered() except +translate_exception
         CxxAnyValue& operator[](string) except +translate_exception
+        cbool isEmpty()
         cbool hasKey(string)
         string keys_str()
         void applyUnits()
@@ -89,6 +90,7 @@ cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
         CxxAnyMap& getMapWhere(string, string) except +translate_exception
         T& asType "as" [T]() except +translate_exception
         string type_str()
+        cbool isEmpty()
         cbool isType "is" [T]()
         cbool isScalar()
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -78,6 +78,12 @@ cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
 
     cdef cppclass CxxAnyValue "Cantera::AnyValue":
         CxxAnyValue()
+        CxxAnyValue& operator=(string) except +translate_exception
+        CxxAnyValue& operator=(double) except +translate_exception
+        CxxAnyValue& operator=(cbool) except +translate_exception
+        CxxAnyValue& operator=(int) except +translate_exception
+        CxxAnyValue& operator=(long) except +translate_exception
+        CxxAnyValue& operator=[T](vector[T]) except +translate_exception
         unordered_map[string, CxxAnyMap*] asMap(string) except +translate_exception
         CxxAnyMap& getMapWhere(string, string) except +translate_exception
         T& asType "as" [T]() except +translate_exception

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -83,6 +83,7 @@ cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
         CxxAnyValue& operator=(cbool) except +translate_exception
         CxxAnyValue& operator=(int) except +translate_exception
         CxxAnyValue& operator=(long) except +translate_exception
+        CxxAnyValue& operator=(CxxAnyMap) except +translate_exception
         CxxAnyValue& operator=[T](vector[T]) except +translate_exception
         unordered_map[string, CxxAnyMap*] asMap(string) except +translate_exception
         CxxAnyMap& getMapWhere(string, string) except +translate_exception

--- a/interfaces/cython/cantera/test/__init__.py
+++ b/interfaces/cython/cantera/test/__init__.py
@@ -13,6 +13,7 @@ from .test_reaction import *
 from .test_reactor import *
 from .test_thermo import *
 from .test_transport import *
+from .test_utils import *
 
 cantera.add_directory(os.path.join(os.path.dirname(__file__), 'data'))
 cantera.add_directory(os.path.join(os.path.dirname(__file__), '..', 'examples', 'surface_chemistry'))

--- a/interfaces/cython/cantera/test/test_utils.py
+++ b/interfaces/cython/cantera/test/test_utils.py
@@ -29,7 +29,7 @@ class TestPyToAnyValue(utilities.CanteraTest):
         self.assertEqual(out, [])
 
     def test_set(self):
-        self.check_raises({'a', 'b'}, NotImplementedError, "Python sets")
+        self.check_raises({'a', 'b'}, NotImplementedError, "Python set")
 
     def test_empty_list(self):
         self.check_conversion([])
@@ -65,7 +65,7 @@ class TestPyToAnyValue(utilities.CanteraTest):
         self.check_conversion([True, False])
 
     def test_list_various(self):
-        self.check_conversion([True, 'spam', 3, 4.])
+        self.check_conversion([True, 'spam', 3, 4., {'foo': 'bar'}])
 
     def test_tuple(self):
         self.check_inexact_conversion((True, 'spam', 3, 4.))
@@ -78,7 +78,7 @@ class TestPyToAnyValue(utilities.CanteraTest):
 
     def test_ndarray3(self):
         self.check_raises(np.random.randn(3, 2, 4),
-            NotImplementedError, 'Cannot process float')
+            NotImplementedError, 'cannot process float')
 
     def test_nested_string(self):
         self.check_conversion([['spam', 'eggs'], ['foo', 'bar']])
@@ -94,19 +94,27 @@ class TestPyToAnyValue(utilities.CanteraTest):
 
     def test_raises_string(self):
         self.check_raises([[['spam', 'eggs'], ['foo', 'bar']]],
-            NotImplementedError, 'Cannot process string')
+            NotImplementedError, 'cannot process string')
+
+    def test_raises_named(self):
+        self.check_raises({'abcd': [[['spam', 'eggs'], ['foo', 'bar']]]},
+            NotImplementedError, "value with key 'abcd'")
 
     def test_raises_int(self):
         self.check_raises([[[1, 2, 3], [4, 5, 6]]],
-            NotImplementedError, 'Cannot process integer')
+            NotImplementedError, 'cannot process integer')
 
     def test_raises_float(self):
         self.check_raises([[[1., 2., 3.], [4., 5., 6.]]],
-            NotImplementedError, 'Cannot process float')
+            NotImplementedError, 'cannot process float')
 
     def test_raises_bool(self):
         self.check_raises([[[True, False], [False, True]]],
-            NotImplementedError, 'Cannot process boolean')
+            NotImplementedError, 'cannot process boolean')
+
+    def test_multi_dict(self):
+        vv = [{'a': [['spam', 'eggs'], ['foo', 'bar']], 'b': {'c': 4}}, {'d': 3}]
+        self.check_conversion(vv)
 
     def test_inhomogeneous(self):
         self.check_raises([[1, 2], ['a', 'b']], NotImplementedError, 'inhomogeneous')

--- a/interfaces/cython/cantera/test/test_utils.py
+++ b/interfaces/cython/cantera/test/test_utils.py
@@ -1,0 +1,124 @@
+import numpy as np
+
+import cantera as ct
+from . import utilities
+from .utilities import unittest
+
+from cantera._cantera import _py_to_any_to_py, _dict_to_any_to_dict
+
+class TestPyToAnyValue(utilities.CanteraTest):
+
+    def check_conversion(self, value):
+        out = _py_to_any_to_py(value)
+        self.assertEqual(out, value)
+
+    def check_inexact_conversion(self, value):
+        out = _py_to_any_to_py(value)
+        if isinstance(value, np.ndarray):
+            self.assertEqual(out, value.tolist())
+        else:
+            self.assertEqual(out, list(value))
+
+    def check_raises(self, value, ee, regex):
+        with self.assertRaisesRegex(ee, regex):
+            _py_to_any_to_py(value)
+
+    def test_none(self):
+        self.check_raises(None, NotImplementedError, "'None'")
+
+    def test_set(self):
+        self.check_raises({'a', 'b'}, NotImplementedError, "Python sets")
+
+    def test_empty1(self):
+        self.check_raises([], NotImplementedError, "empty sequences")
+
+    def test_empty2(self):
+        self.check_raises(np.ndarray((0,)), NotImplementedError, "empty sequences")
+
+    def test_scalar_string(self):
+        self.check_conversion('spam')
+
+    def test_scalar_int(self):
+        self.check_conversion(3)
+
+    def test_scalar_float(self):
+        self.check_conversion(3.1415)
+
+    def test_scalar_bool(self):
+        self.check_conversion(True)
+
+    def test_list_string(self):
+        self.check_conversion(['spam', 'eggs'])
+
+    def test_list_int(self):
+        self.check_conversion([1, 2, 3])
+
+    def test_list_float(self):
+        self.check_conversion([1., 2., 3.])
+
+    def test_list_bool(self):
+        self.check_conversion([True, False])
+
+    def test_list_various(self):
+        self.check_conversion([True, 'spam', 3, 4.])
+
+    def test_tuple(self):
+        self.check_inexact_conversion((True, 'spam', 3, 4.))
+
+    def test_ndarray1(self):
+        self.check_inexact_conversion(np.random.randn(10))
+
+    def test_ndarray2(self):
+        self.check_inexact_conversion(np.random.randn(3, 2))
+
+    def test_ndarray3(self):
+        self.check_raises(np.random.randn(3, 2, 4),
+            NotImplementedError, 'Cannot process float')
+
+    def test_nested_string(self):
+        self.check_conversion([['spam', 'eggs'], ['foo', 'bar']])
+
+    def test_nested_int(self):
+        self.check_conversion([[1, 2, 3], [4, 5, 6]])
+
+    def test_nested_float(self):
+        self.check_conversion([[1., 2., 3.], [4., 5., 6.]])
+
+    def test_nested_bool(self):
+        self.check_conversion([[True, False], [False, True]])
+
+    def test_raises_string(self):
+        self.check_raises([[['spam', 'eggs'], ['foo', 'bar']]],
+            NotImplementedError, 'Cannot process string')
+
+    def test_raises_int(self):
+        self.check_raises([[[1, 2, 3], [4, 5, 6]]],
+            NotImplementedError, 'Cannot process integer')
+
+    def test_raises_float(self):
+        self.check_raises([[[1., 2., 3.], [4., 5., 6.]]],
+            NotImplementedError, 'Cannot process float')
+
+    def test_raises_bool(self):
+        self.check_raises([[[True, False], [False, True]]],
+            NotImplementedError, 'Cannot process boolean')
+
+    def test_inhomogeneous(self):
+        self.check_raises([[1, 2], ['a', 'b']], NotImplementedError, 'inhomogeneous')
+
+    def test_ragged(self):
+        self.check_raises([[1, 2, 3], [4]], NotImplementedError, 'ragged')
+
+    def test_dict1(self):
+        self.check_conversion({'a': 1, 'b': 2., 'c': 'eggs', 'd': True})
+
+    def test_dict2(self):
+        dd = {'a': 1, 'b': 2., 'c': 'eggs', 'd': True}
+        self.assertEqual(dd, _dict_to_any_to_dict(dd))
+
+    def test_nested_dict1(self):
+        self.check_conversion({'a': 1, 'b': 2., 'c': {'d': 'eggs'}})
+
+    def test_nested_dict2(self):
+        dd = {'a': 1, 'b': 2., 'c': {'d': [1, 2, 3]}}
+        self.assertEqual(dd, _dict_to_any_to_dict(dd))

--- a/interfaces/cython/cantera/test/test_utils.py
+++ b/interfaces/cython/cantera/test/test_utils.py
@@ -98,7 +98,7 @@ class TestPyToAnyValue(utilities.CanteraTest):
 
     def test_raises_named(self):
         self.check_raises({'abcd': [[['spam', 'eggs'], ['foo', 'bar']]]},
-            NotImplementedError, "value with key 'abcd'")
+            NotImplementedError, "with key 'abcd'")
 
     def test_raises_int(self):
         self.check_raises([[[1, 2, 3], [4, 5, 6]]],

--- a/interfaces/cython/cantera/test/test_utils.py
+++ b/interfaces/cython/cantera/test/test_utils.py
@@ -2,7 +2,6 @@ import numpy as np
 
 import cantera as ct
 from . import utilities
-from .utilities import unittest
 
 from cantera._cantera import _py_to_any_to_py
 
@@ -28,13 +27,11 @@ class TestPyToAnyValue(utilities.CanteraTest):
             _py_to_any_to_py(value)
 
     def test_none(self):
-        out, held_type = _py_to_any_to_py(None)
-        self.assertEqual(out, None)
-        self.assertEqual(held_type, "void")
+        self.check_conversion(None, "void")
 
     def test_set(self):
         # Sets are converted to lists
-        self.check_inexact_conversion({'a', 'b'}, 'vector<string>')
+        self.check_inexact_conversion({"a", "b"}, "vector<string>")
 
     def test_empty_list(self):
         self.check_conversion([])
@@ -46,72 +43,71 @@ class TestPyToAnyValue(utilities.CanteraTest):
         self.check_conversion({})
 
     def test_scalar_string(self):
-        self.check_conversion('spam', 'string')
+        self.check_conversion("spam", "string")
 
     def test_scalar_int(self):
-        self.check_conversion(3, 'long int')
+        self.check_conversion(3, "long int")
 
     def test_scalar_float(self):
-        self.check_conversion(3.1415, 'double')
+        self.check_conversion(3.1415, "double")
 
     def test_scalar_bool(self):
-        self.check_conversion(True, 'bool')
+        self.check_conversion(True, "bool")
 
     def test_list_string(self):
-        self.check_conversion(['spam', 'eggs'], 'vector<string>')
+        self.check_conversion(["spam", "eggs"], "vector<string>")
 
     def test_list_int(self):
-        self.check_conversion([1, 2, 3], 'vector<long int>')
+        self.check_conversion([1, 2, 3], "vector<long int>")
 
     def test_list_float(self):
-        self.check_conversion([1., 2., 3.], 'vector<double>')
+        self.check_conversion([1., 2., 3.], "vector<double>")
 
     def test_list_bool(self):
-        self.check_conversion([True, False], 'vector<bool>')
+        self.check_conversion([True, False], "vector<bool>")
 
     def test_list_various(self):
-        self.check_conversion([True, 'spam', 3, 4., {'foo': 'bar'}],
-                              'vector<AnyValue>')
+        self.check_conversion([True, "spam", 3, 4., {"foo": "bar"}],
+                              "vector<AnyValue>")
 
     def test_tuple(self):
-        self.check_inexact_conversion((True, 'spam', 3, 4.), 'vector<AnyValue>')
+        self.check_inexact_conversion((True, "spam", 3, 4.), "vector<AnyValue>")
 
     def test_ndarray1(self):
-        self.check_inexact_conversion(np.random.randn(10), 'vector<double>')
+        self.check_inexact_conversion(np.random.randn(10), "vector<double>")
 
     def test_ndarray2(self):
-        self.check_inexact_conversion(np.random.randn(3, 2), 'vector<vector<double>>')
+        self.check_inexact_conversion(np.random.randn(3, 2), "vector<vector<double>>")
 
     def test_ndarray3(self):
         # Each inner AnyValue holds a vector<vector<double>>
-        self.check_inexact_conversion(np.random.randn(3, 2, 4), 'vector<AnyValue>')
+        self.check_inexact_conversion(np.random.randn(3, 2, 4), "vector<AnyValue>")
 
     def test_nested_string(self):
-        self.check_conversion([['spam', 'eggs'], ['foo', 'bar']],
-                              'vector<vector<string>>')
+        self.check_conversion([["spam", "eggs"], ["foo", "bar"]],
+                              "vector<vector<string>>")
 
     def test_nested_int(self):
-        self.check_conversion([[1, 2, 3], [4, 5, 6]], 'vector<vector<long int>>')
+        self.check_conversion([[1, 2, 3], [4, 5, 6]], "vector<vector<long int>>")
 
     def test_nested_float(self):
-        self.check_conversion([[1., 2., 3.], [4., 5., 6.]], 'vector<vector<double>>')
+        self.check_conversion([[1., 2., 3.], [4., 5., 6.]], "vector<vector<double>>")
 
     def test_nested_bool(self):
-        self.check_conversion([[True, False], [False, True]], 'vector<vector<bool>>')
+        self.check_conversion([[True, False], [False, True]], "vector<vector<bool>>")
 
     def test_multi_dict(self):
-        vv = [{'a': [['spam', 'eggs'], ['foo', 'bar']], 'b': {'c': 4}}, {'d': 3}]
-        self.check_conversion(vv, 'vector<AnyMap>')
+        vv = [{"a": [["spam", "eggs"], ["foo", "bar"]], "b": {"c": 4}}, {"d": 3}]
+        self.check_conversion(vv, "vector<AnyMap>")
 
     def test_dict(self):
-        self.check_conversion({'a': 1, 'b': 2., 'c': 'eggs', 'd': True}, 'AnyMap')
+        self.check_conversion({"a": 1, "b": 2., "c": "eggs", "d": True}, "AnyMap")
 
     def test_nested_dict(self):
-        self.check_conversion({'a': 1, 'b': 2., 'c': {'d': 'eggs'}}, 'AnyMap')
+        self.check_conversion({"a": 1, "b": 2., "c": {"d": "eggs"}}, "AnyMap")
 
     def test_unconvertible(self):
-        class Foo: pass
-        self.check_raises(Foo(), ct.CanteraError, "Unable to convert")
+        self.check_raises(object(), ct.CanteraError, "Unable to convert")
 
     def test_unconvertible2(self):
         self.check_raises([3+4j, 1-2j], ct.CanteraError, "Unable to convert")

--- a/interfaces/cython/cantera/test/test_utils.py
+++ b/interfaces/cython/cantera/test/test_utils.py
@@ -4,7 +4,7 @@ import cantera as ct
 from . import utilities
 from .utilities import unittest
 
-from cantera._cantera import _py_to_any_to_py, _dict_to_any_to_dict
+from cantera._cantera import _py_to_any_to_py
 
 class TestPyToAnyValue(utilities.CanteraTest):
 
@@ -24,16 +24,21 @@ class TestPyToAnyValue(utilities.CanteraTest):
             _py_to_any_to_py(value)
 
     def test_none(self):
-        self.check_raises(None, NotImplementedError, "'None'")
+        # None is converted to []
+        out = _py_to_any_to_py(None)
+        self.assertEqual(out, [])
 
     def test_set(self):
         self.check_raises({'a', 'b'}, NotImplementedError, "Python sets")
 
-    def test_empty1(self):
-        self.check_raises([], NotImplementedError, "empty sequences")
+    def test_empty_list(self):
+        self.check_conversion([])
 
-    def test_empty2(self):
-        self.check_raises(np.ndarray((0,)), NotImplementedError, "empty sequences")
+    def test_empty_ndarray(self):
+        self.check_inexact_conversion(np.ndarray((0,)))
+
+    def test_empty_dict(self):
+        self.check_conversion({})
 
     def test_scalar_string(self):
         self.check_conversion('spam')
@@ -109,16 +114,8 @@ class TestPyToAnyValue(utilities.CanteraTest):
     def test_ragged(self):
         self.check_raises([[1, 2, 3], [4]], NotImplementedError, 'ragged')
 
-    def test_dict1(self):
+    def test_dict(self):
         self.check_conversion({'a': 1, 'b': 2., 'c': 'eggs', 'd': True})
 
-    def test_dict2(self):
-        dd = {'a': 1, 'b': 2., 'c': 'eggs', 'd': True}
-        self.assertEqual(dd, _dict_to_any_to_dict(dd))
-
-    def test_nested_dict1(self):
+    def test_nested_dict(self):
         self.check_conversion({'a': 1, 'b': 2., 'c': {'d': 'eggs'}})
-
-    def test_nested_dict2(self):
-        dd = {'a': 1, 'b': 2., 'c': {'d': [1, 2, 3]}}
-        self.assertEqual(dd, _dict_to_any_to_dict(dd))

--- a/interfaces/cython/cantera/test/test_utils.py
+++ b/interfaces/cython/cantera/test/test_utils.py
@@ -8,28 +8,33 @@ from cantera._cantera import _py_to_any_to_py
 
 class TestPyToAnyValue(utilities.CanteraTest):
 
-    def check_conversion(self, value):
-        out = _py_to_any_to_py(value)
+    def check_conversion(self, value, check_type=None):
+        out, held_type = _py_to_any_to_py(value)
         self.assertEqual(out, value)
+        if check_type is not None:
+            self.assertEqual(held_type, check_type)
 
-    def check_inexact_conversion(self, value):
-        out = _py_to_any_to_py(value)
+    def check_inexact_conversion(self, value, check_type=None):
+        out, held_type = _py_to_any_to_py(value)
         if isinstance(value, np.ndarray):
             self.assertEqual(out, value.tolist())
         else:
             self.assertEqual(out, list(value))
+        if check_type is not None:
+            self.assertEqual(held_type, check_type)
 
     def check_raises(self, value, ee, regex):
         with self.assertRaisesRegex(ee, regex):
             _py_to_any_to_py(value)
 
     def test_none(self):
-        # None is converted to []
-        out = _py_to_any_to_py(None)
-        self.assertEqual(out, [])
+        out, held_type = _py_to_any_to_py(None)
+        self.assertEqual(out, None)
+        self.assertEqual(held_type, "void")
 
     def test_set(self):
-        self.check_raises({'a', 'b'}, NotImplementedError, "Python set")
+        # Sets are converted to lists
+        self.check_inexact_conversion({'a', 'b'}, 'vector<string>')
 
     def test_empty_list(self):
         self.check_conversion([])
@@ -41,89 +46,72 @@ class TestPyToAnyValue(utilities.CanteraTest):
         self.check_conversion({})
 
     def test_scalar_string(self):
-        self.check_conversion('spam')
+        self.check_conversion('spam', 'string')
 
     def test_scalar_int(self):
-        self.check_conversion(3)
+        self.check_conversion(3, 'long int')
 
     def test_scalar_float(self):
-        self.check_conversion(3.1415)
+        self.check_conversion(3.1415, 'double')
 
     def test_scalar_bool(self):
-        self.check_conversion(True)
+        self.check_conversion(True, 'bool')
 
     def test_list_string(self):
-        self.check_conversion(['spam', 'eggs'])
+        self.check_conversion(['spam', 'eggs'], 'vector<string>')
 
     def test_list_int(self):
-        self.check_conversion([1, 2, 3])
+        self.check_conversion([1, 2, 3], 'vector<long int>')
 
     def test_list_float(self):
-        self.check_conversion([1., 2., 3.])
+        self.check_conversion([1., 2., 3.], 'vector<double>')
 
     def test_list_bool(self):
-        self.check_conversion([True, False])
+        self.check_conversion([True, False], 'vector<bool>')
 
     def test_list_various(self):
-        self.check_conversion([True, 'spam', 3, 4., {'foo': 'bar'}])
+        self.check_conversion([True, 'spam', 3, 4., {'foo': 'bar'}],
+                              'vector<AnyValue>')
 
     def test_tuple(self):
-        self.check_inexact_conversion((True, 'spam', 3, 4.))
+        self.check_inexact_conversion((True, 'spam', 3, 4.), 'vector<AnyValue>')
 
     def test_ndarray1(self):
-        self.check_inexact_conversion(np.random.randn(10))
+        self.check_inexact_conversion(np.random.randn(10), 'vector<double>')
 
     def test_ndarray2(self):
-        self.check_inexact_conversion(np.random.randn(3, 2))
+        self.check_inexact_conversion(np.random.randn(3, 2), 'vector<vector<double>>')
 
     def test_ndarray3(self):
-        self.check_raises(np.random.randn(3, 2, 4),
-            NotImplementedError, 'cannot process float')
+        # Each inner AnyValue holds a vector<vector<double>>
+        self.check_inexact_conversion(np.random.randn(3, 2, 4), 'vector<AnyValue>')
 
     def test_nested_string(self):
-        self.check_conversion([['spam', 'eggs'], ['foo', 'bar']])
+        self.check_conversion([['spam', 'eggs'], ['foo', 'bar']],
+                              'vector<vector<string>>')
 
     def test_nested_int(self):
-        self.check_conversion([[1, 2, 3], [4, 5, 6]])
+        self.check_conversion([[1, 2, 3], [4, 5, 6]], 'vector<vector<long int>>')
 
     def test_nested_float(self):
-        self.check_conversion([[1., 2., 3.], [4., 5., 6.]])
+        self.check_conversion([[1., 2., 3.], [4., 5., 6.]], 'vector<vector<double>>')
 
     def test_nested_bool(self):
-        self.check_conversion([[True, False], [False, True]])
-
-    def test_raises_string(self):
-        self.check_raises([[['spam', 'eggs'], ['foo', 'bar']]],
-            NotImplementedError, 'cannot process string')
-
-    def test_raises_named(self):
-        self.check_raises({'abcd': [[['spam', 'eggs'], ['foo', 'bar']]]},
-            NotImplementedError, "with key 'abcd'")
-
-    def test_raises_int(self):
-        self.check_raises([[[1, 2, 3], [4, 5, 6]]],
-            NotImplementedError, 'cannot process integer')
-
-    def test_raises_float(self):
-        self.check_raises([[[1., 2., 3.], [4., 5., 6.]]],
-            NotImplementedError, 'cannot process float')
-
-    def test_raises_bool(self):
-        self.check_raises([[[True, False], [False, True]]],
-            NotImplementedError, 'cannot process boolean')
+        self.check_conversion([[True, False], [False, True]], 'vector<vector<bool>>')
 
     def test_multi_dict(self):
         vv = [{'a': [['spam', 'eggs'], ['foo', 'bar']], 'b': {'c': 4}}, {'d': 3}]
-        self.check_conversion(vv)
-
-    def test_inhomogeneous(self):
-        self.check_raises([[1, 2], ['a', 'b']], NotImplementedError, 'inhomogeneous')
-
-    def test_ragged(self):
-        self.check_raises([[1, 2, 3], [4]], NotImplementedError, 'ragged')
+        self.check_conversion(vv, 'vector<AnyMap>')
 
     def test_dict(self):
-        self.check_conversion({'a': 1, 'b': 2., 'c': 'eggs', 'd': True})
+        self.check_conversion({'a': 1, 'b': 2., 'c': 'eggs', 'd': True}, 'AnyMap')
 
     def test_nested_dict(self):
-        self.check_conversion({'a': 1, 'b': 2., 'c': {'d': 'eggs'}})
+        self.check_conversion({'a': 1, 'b': 2., 'c': {'d': 'eggs'}}, 'AnyMap')
+
+    def test_unconvertible(self):
+        class Foo: pass
+        self.check_raises(Foo(), ct.CanteraError, "Unable to convert")
+
+    def test_unconvertible2(self):
+        self.check_raises([3+4j, 1-2j], ct.CanteraError, "Unable to convert")

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -155,8 +155,12 @@ cdef get_types(item):
         itype = set()
         for i in item:
             if isinstance(i, dict):
+                # Treat all classes derived from dict as equivalent, and
+                # convertible to AnyMap
                 itype.add(dict)
             elif isinstance(i, (list, tuple)):
+                # Treat all classes derived from list or tuple as equivalent,
+                # and convertible to std::vector
                 itype.add(list)
             elif type(i) == bool:
                 itype.add(bool)  # otherwise bools will get counted as integers

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -86,6 +86,8 @@ cdef anyvalue_to_python(string name, CxxAnyValue& v):
         elif v.isType[double]():
             return v.asType[double]()
         elif v.isType[long]():
+            # 'long' is equivalent to 'long int'
+            # Cython requires the former in this context
             return v.asType[long]()
         elif v.isType[cbool]():
             return v.asType[cbool]()

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -130,7 +130,7 @@ cdef anymap_to_dict(CxxAnyMap& m):
     return {pystr(item.first): anyvalue_to_python(item.first, item.second)
             for item in m.ordered()}
 
-cdef CxxAnyMap dict_to_anymap(data):
+cdef CxxAnyMap dict_to_anymap(data) except *:
     cdef CxxAnyMap m
     for k, v in data.items():
         m[stringify(k)] = python_to_anyvalue(v, k)
@@ -229,21 +229,21 @@ cdef CxxAnyValue python_to_anyvalue(item, name=None) except *:
     elif item is None:
         pass  # None corresponds to "empty" AnyValue
     elif name is not None:
-        raise CanteraError("Unable to convert item of type '{}'"
-            " with key '{}' to AnyValue".format(type(item), name))
+        raise CanteraError("Unable to convert item of type {!r}"
+            " with key {!r} to AnyValue".format(type(item), name))
     else:
-        raise CanteraError("Unable to convert item of type '{}'"
+        raise CanteraError("Unable to convert item of type {!r}"
             " to AnyValue".format(type(item)))
     return v
 
 # Helper functions for converting specific types to AnyValue
 
-cdef vector[CxxAnyValue] list_to_anyvalue(data):
+cdef vector[CxxAnyValue] list_to_anyvalue(data) except *:
     cdef vector[CxxAnyValue] v
     v.resize(len(data))
     cdef size_t i
     for i, item in enumerate(data):
-        v[i] = python_to_anyvalue(item, "<list item>")
+        v[i] = python_to_anyvalue(item)
     return v
 
 cdef vector[double] list_double_to_anyvalue(data):
@@ -278,7 +278,7 @@ cdef vector[string] list_string_to_anyvalue(data):
         v[i] = stringify(item)
     return v
 
-cdef vector[CxxAnyMap] list_dict_to_anyvalue(data):
+cdef vector[CxxAnyMap] list_dict_to_anyvalue(data) except *:
     cdef vector[CxxAnyMap] v
     v.resize(len(data))
     cdef size_t i
@@ -330,4 +330,4 @@ def _py_to_any_to_py(dd):
     # @internal  used for testing purposes only
     cdef string name = stringify("test")
     cdef CxxAnyValue vv = python_to_anyvalue(dd)
-    return anyvalue_to_python(name, vv)
+    return anyvalue_to_python(name, vv), pystr(vv.type_str())

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -126,7 +126,11 @@ cdef CxxAnyValue python_to_anyvalue(string name, v) except *:
     cdef CxxAnyMap a
     cdef CxxAnyValue b
 
-    if isinstance(v, dict):
+    if v is None:
+        raise NotImplementedError("Cannot process 'None'.")
+    elif isinstance(v, set):
+        raise NotImplementedError("Cannot process Python sets.")
+    elif isinstance(v, dict):
         a = dict_to_anymap(v)
         b = a
         return b
@@ -138,7 +142,9 @@ cdef CxxAnyValue python_to_anyvalue(string name, v) except *:
     if not is_scalar(v):
         # ensure that data are homogeneous
         # (np.array converts inhomogeneous sequences to string arrays)
-        if isinstance(v, np.ndarray):
+        if not len(v):
+            raise NotImplementedError("Cannot process empty sequences.")
+        elif isinstance(v, np.ndarray):
             pass
         elif is_scalar(v[0]):
             all_same = all([type(val) == type(v[0]) for val in v])
@@ -171,7 +177,7 @@ cdef CxxAnyValue python_to_anyvalue(string name, v) except *:
     cdef string v_string
     cdef vector[string] vv_string
     cdef vector[vector[string]] vvv_string
-    if isinstance(v, str) or (vv.ndim and isinstance(vv[0], str)):
+    if isinstance(v, str) or (vv.ndim and isinstance(vv.ravel()[0], str)):
         if vv.ndim == 0:
             v_string = stringify(v)
             b = v_string
@@ -195,7 +201,7 @@ cdef CxxAnyValue python_to_anyvalue(string name, v) except *:
     cdef double v_double
     cdef vector[double] vv_double
     cdef vector[vector[double]] vvv_double
-    if vv.dtype == np.float:
+    if vv.dtype == float:
         if vv.ndim == 0:
             v_double = v
             b = v_double
@@ -219,7 +225,7 @@ cdef CxxAnyValue python_to_anyvalue(string name, v) except *:
     cdef long v_int
     cdef vector[long] vv_int
     cdef vector[vector[long]] vvv_int
-    if vv.dtype == np.int:
+    if vv.dtype == int:
         if vv.ndim == 0:
             v_int = v
             b = v_int
@@ -243,7 +249,7 @@ cdef CxxAnyValue python_to_anyvalue(string name, v) except *:
     cdef cbool v_bool
     cdef vector[cbool] vv_bool
     cdef vector[vector[cbool]] vvv_bool
-    if vv.dtype == np.bool:
+    if vv.dtype == bool:
         if vv.ndim == 0:
             v_bool = v
             b = v_bool

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -489,7 +489,16 @@ std::map<std::string, std::string> AnyValue::s_typenames = {
     {typeid(double).name(), "double"},
     {typeid(long int).name(), "long int"},
     {typeid(std::string).name(), "string"},
-    {typeid(std::vector<double>).name(), "vector<double>"},
+    {typeid(vector<AnyValue>).name(), "vector<AnyValue>"},
+    {typeid(vector<AnyMap>).name(), "vector<AnyMap>"},
+    {typeid(vector<double>).name(), "vector<double>"},
+    {typeid(vector<long int>).name(), "vector<long int>"},
+    {typeid(vector<bool>).name(), "vector<bool>"},
+    {typeid(vector<string>).name(), "vector<string>"},
+    {typeid(vector<vector<double>>).name(), "vector<vector<double>>"},
+    {typeid(vector<vector<long int>>).name(), "vector<vector<long int>>"},
+    {typeid(vector<vector<bool>>).name(), "vector<vector<bool>>"},
+    {typeid(vector<vector<string>>).name(), "vector<vector<string>>"},
     {typeid(AnyMap).name(), "AnyMap"},
 };
 

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -618,6 +618,10 @@ std::string AnyValue::type_str() const {
     return demangle(type());
 }
 
+bool AnyValue::isEmpty() const {
+    return m_value->empty();
+}
+
 bool AnyValue::isScalar() const {
     return is<double>() || is<long int>() || is<std::string>() || is<bool>();
 }
@@ -1339,6 +1343,11 @@ const AnyValue& AnyMap::at(const std::string& key) const
         throw InputFileError("AnyMap::at", *this,
             "Key '{}' not found.\nExisting keys: {}", key, keys_str());
     }
+}
+
+bool AnyMap::isEmpty() const
+{
+    return m_data.size() == 0;
 }
 
 bool AnyMap::hasKey(const std::string& key) const


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This PR adds the ability to create C++ `AnyMap` and `AnyValue` objects from the Python interface, where `dict_to_anymap`/`python_to_anyvalue` mirrors recently introduced `anymap_to_dict`/`anyvalue_to_python` (see PR #984). The following uses are anticipated:

* Instantiation of core objects from the Python API, e.g. reactions, see Cantera/enhancements#84
* Serialization of `--extra` fields in YAML serialization, see #1013
* Creation of user-data attached to various Cantera objects, see Cantera/enhancements#56

The new service functions enable the use of C++ constructors (or other C++ functions) that take `AnyMap` or `AnyValue` as an argument from the Cython layer. Round-trip conversion is covered by unit tests via a hidden helper function `cantera._cantera._py_to_any_to_py` in a new `test_utils.py` job. Beyond, the functions are not accessible from the Python API, as they are internal service functions that facilitate the transfer of data from Python to the C++ layer.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
