### PR TITLE
Collect build/test timing information and fix some bugs

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -81,7 +81,7 @@ jobs:
       run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
         pytest-github-actions-annotate-failures
     - name: Build Cantera
-      run: python3 `which scons` build env_vars=all -j2 debug=n --debug=time
+      run: python3 `which scons` build env_vars=all -j3 debug=n --debug=time
     - name: Test Cantera
       run: python3 `which scons` test --debug=time
       env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,7 @@ jobs:
       run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
         pytest-github-actions-annotate-failures
     - name: Build Cantera
-      run: python3 `which scons` build -j2 debug=n --debug=time
+      run: python3 `which scons` build env_vars=all -j2 debug=n --debug=time
     - name: Test Cantera
       run: python3 `which scons` test --debug=time
       env:
@@ -81,7 +81,7 @@ jobs:
       run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
         pytest-github-actions-annotate-failures
     - name: Build Cantera
-      run: python3 `which scons` build -j2 debug=n --debug=time
+      run: python3 `which scons` build env_vars=all -j2 debug=n --debug=time
     - name: Test Cantera
       run: python3 `which scons` test --debug=time
       env:
@@ -115,7 +115,7 @@ jobs:
     - name: Build Cantera
       run: |
         python3 `which scons` build blas_lapack_libs=lapack,blas coverage=y \
-        optimize=n no_optimize_flags=-DNDEBUG -j2 --debug=time
+        optimize=n no_optimize_flags=-DNDEBUG env_vars=all -j2 --debug=time
     - name: Test Cantera
       run: python3 `which scons` test --debug=time
       env:
@@ -354,8 +354,8 @@ jobs:
           rm $BOOST_ROOT/download.7z
         shell: bash
       - name: Build Cantera
-        run: |
-          scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n VERBOSE=y python_package=full ^
+        run: scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n VERBOSE=y
+          python_package=full env_vars=PYTHONPATH,GITHUB_ACTIONS
           msvc_version=${{ matrix.vs-toolset }} f90_interface=n --debug=time
         shell: cmd
       - name: Test Cantera

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,6 @@ jobs:
   coverage:
     name: Coverage
     runs-on: ubuntu-latest
-    needs: [ubuntu-multiple-pythons]
     steps:
     - uses: actions/checkout@v2
       name: Checkout the repository

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,9 +41,9 @@ jobs:
       run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
         pytest-github-actions-annotate-failures
     - name: Build Cantera
-      run: python3 `which scons` build -j2 debug=n
+      run: python3 `which scons` build -j2 debug=n --debug=time
     - name: Test Cantera
-      run: python3 `which scons` test
+      run: python3 `which scons` test --debug=time
       env:
         GITHUB_ACTIONS: "true"
 
@@ -81,9 +81,9 @@ jobs:
       run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
         pytest-github-actions-annotate-failures
     - name: Build Cantera
-      run: python3 `which scons` build -j2 debug=n
+      run: python3 `which scons` build -j2 debug=n --debug=time
     - name: Test Cantera
-      run: python3 `which scons` test
+      run: python3 `which scons` test --debug=time
       env:
         GITHUB_ACTIONS: "true"
 
@@ -116,9 +116,9 @@ jobs:
     - name: Build Cantera
       run: |
         python3 `which scons` build blas_lapack_libs=lapack,blas coverage=y \
-        optimize=n no_optimize_flags=-DNDEBUG -j2
+        optimize=n no_optimize_flags=-DNDEBUG -j2 --debug=time
     - name: Test Cantera
-      run: python3 `which scons` test
+      run: python3 `which scons` test --debug=time
       env:
         GITHUB_ACTIONS: "true"
     - name: Upload Coverage to Codecov
@@ -189,7 +189,8 @@ jobs:
           python3-ruamel.yaml python-numpy cython3 libsundials-dev liblapack-dev \
           libblas-dev
       - name: Build Cantera
-        run: scons build python_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas -j2 debug=n
+        run: scons build python_cmd=/usr/bin/python3 blas_lapack_libs=lapack,blas -j2
+          debug=n --debug=time
       - name: Test Cantera
         run: scons test
 
@@ -356,9 +357,9 @@ jobs:
       - name: Build Cantera
         run: |
           scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n VERBOSE=y python_package=full ^
-          msvc_version=${{ matrix.vs-toolset }} f90_interface=n
+          msvc_version=${{ matrix.vs-toolset }} f90_interface=n --debug=time
         shell: cmd
       - name: Test Cantera
-        run: scons test
+        run: scons test --debug=time
         env:
           GITHUB_ACTIONS: "true"

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -38,11 +38,14 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
+        pytest-github-actions-annotate-failures
     - name: Build Cantera
       run: python3 `which scons` build -j2 debug=n
     - name: Test Cantera
       run: python3 `which scons` test
+      env:
+        GITHUB_ACTIONS: "true"
 
   macos-multiple-pythons:
     name: macOS with Python ${{ matrix.python-version }}
@@ -75,11 +78,14 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip 'setuptools>=47.0.0,<48' wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
+        pytest-github-actions-annotate-failures
     - name: Build Cantera
       run: python3 `which scons` build -j2 debug=n
     - name: Test Cantera
       run: python3 `which scons` test
+      env:
+        GITHUB_ACTIONS: "true"
 
   # Coverage is its own job because macOS builds of the samples
   # use Homebrew gfortran which is not compatible for coverage
@@ -105,13 +111,16 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
+        pytest-github-actions-annotate-failures
     - name: Build Cantera
       run: |
         python3 `which scons` build blas_lapack_libs=lapack,blas coverage=y \
         optimize=n no_optimize_flags=-DNDEBUG -j2
     - name: Test Cantera
       run: python3 `which scons` test
+      env:
+        GITHUB_ACTIONS: "true"
     - name: Upload Coverage to Codecov
       run: bash <(curl -s https://codecov.io/bash)
       env:
@@ -326,7 +335,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip 'setuptools>=47.0.0,<48'
-          python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas
+          python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas pytest pytest-github-actions-annotate-failures
       - name: Restore Boost cache
         uses: actions/cache@v2
         id: cache-boost
@@ -351,3 +360,5 @@ jobs:
         shell: cmd
       - name: Test Cantera
         run: scons test
+        env:
+          GITHUB_ACTIONS: "true"

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -1613,6 +1613,8 @@ class CounterflowTwinPremixedFlame(FlameBase):
         `FlameBase.set_initial_guess`).
         """
         super().set_initial_guess(data=data, group=group)
+        if data:
+            return
 
         Yu = self.reactants.Y
         Tu = self.reactants.T

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -823,7 +823,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
 
     def run_extinction(self, mdot_fuel, mdot_ox, T_ox, width, P):
         self.create_sim(fuel='H2:1.0', oxidizer='O2:1.0', p=ct.one_atm*P,
-                        mdot_fuel=mdot_fuel, mdot_ox=mdot_ox, width=width)
+                        mdot_fuel=mdot_fuel, mdot_ox=mdot_ox, T_ox=T_ox, width=width)
         self.sim.solve(loglevel=0, auto=True)
         self.assertFalse(self.sim.extinct())
 

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -1442,6 +1442,8 @@ class TestReactorSensitivities(utilities.CanteraTest):
         dtdp = ((t[-1] - tig)*S[-1,:]*Tf - np.trapz(S*T[:,None], t, axis=0))/(Tf-To)
         return dtdp
 
+    # See https://github.com/Cantera/enhancements/issues/55
+    @unittest.skip("Integration of sensitivity ODEs is unreliable")
     def test_ignition_delay_sensitivity(self):
         species = ('H2', 'H', 'O2', 'H2O2', 'H2O', 'OH', 'HO2')
         dtigdh_cvodes = self.calc_dtdh(species)

--- a/interfaces/cython/cantera/test/utilities.py
+++ b/interfaces/cython/cantera/test/utilities.py
@@ -20,6 +20,7 @@ class CanteraTest(unittest.TestCase):
                                                 '..', '..', '..', '..'))
         if os.path.exists(os.path.join(root_dir, 'SConstruct')):
             cls.test_work_dir = os.path.join(root_dir, 'test', 'work', 'python')
+            cls.using_tempfile = False
             try:
                 os.makedirs(cls.test_work_dir)
             except OSError as e:
@@ -31,6 +32,7 @@ class CanteraTest(unittest.TestCase):
                     raise
         else:
             cls.test_work_dir = tempfile.mkdtemp()
+            cls.using_tempfile = True
 
         cantera.make_deprecation_warnings_fatal()
         cantera.add_directory(cls.test_work_dir)
@@ -41,7 +43,7 @@ class CanteraTest(unittest.TestCase):
     @classmethod
     def tearDownClass(cls):
         # Remove the working directory after testing, but only if its a temp directory
-        if tempfile.tempdir is not None:
+        if getattr(cls, "using_tempfile", False):
             try:
                 shutil.rmtree(cls.test_work_dir)
             except OSError:

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -39,6 +39,7 @@ bool isFloat(const std::string& val)
     int numDot = 0;
     int numExp = 0;
     int istart = 0;
+    int numDigit = 0;
     char ch = str[0];
     if (ch == '+' || ch == '-') {
         istart = 1;
@@ -49,6 +50,7 @@ bool isFloat(const std::string& val)
     for (size_t i = istart; i < str.size(); i++) {
         ch = str[i];
         if (isdigit(ch)) {
+            numDigit++;
         } else if (ch == '.') {
             numDot++;
             if (numDot > 1) {
@@ -59,7 +61,7 @@ bool isFloat(const std::string& val)
             }
         } else if (ch == 'e' || ch == 'E') {
             numExp++;
-            if (numExp > 1 || i == str.size() - 1) {
+            if (numExp > 1 || numDigit == 0 || i == str.size() - 1) {
                 return false;
             }
             ch = str[i+1];

--- a/src/base/units.h
+++ b/src/base/units.h
@@ -10,8 +10,8 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#ifndef CT_UNITS_H
-#define CT_UNITS_H
+#ifndef CT_LEGACY_UNITS_H
+#define CT_LEGACY_UNITS_H
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/base/ctexceptions.h"

--- a/src/base/units.h
+++ b/src/base/units.h
@@ -3,8 +3,6 @@
  * Header for units conversion utilities, which are used to translate
  * user input from input files (See \ref inputfiles and
  * class \link Cantera::Unit Unit\endlink).
- *
- * This header is included only by file misc.cpp.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/pch/system.h
+++ b/src/pch/system.h
@@ -15,5 +15,6 @@
 
 #include <boost/algorithm/string.hpp>
 #include "cantera/base/fmt.h"
+#include "cantera/base/AnyMap.h"
 
 #endif

--- a/test/SConscript
+++ b/test/SConscript
@@ -115,14 +115,18 @@ def addPythonTest(testname, subdir, script, interpreter, outfile,
     Create targets for running and resetting a test script.
     """
     def scriptRunner(target, source, env):
+        unittest_outfile = File("#test/work/python-results.txt").abspath
+        pytest_outfile = File("#test/work/pytest.xml").abspath
         """Scons Action to run a test script using the specified interpreter"""
         workDir = Dir('#test/work').abspath
         passedFile = target[0]
         testResults.tests.pop(passedFile.name, None)
         if not os.path.isdir(workDir):
             os.mkdir(workDir)
-        if os.path.exists(outfile):
-            os.remove(outfile)
+        if os.path.exists(unittest_outfile):
+            os.remove(unittest_outfile)
+        if os.path.exists(pytest_outfile):
+            os.remove(pytest_outfile)
 
         environ = dict(env['ENV'])
         for k,v in env_vars.items():
@@ -145,7 +149,7 @@ def addPythonTest(testname, subdir, script, interpreter, outfile,
             sys.exit(1)
 
         failures = 0
-        if os.path.exists(outfile):
+        if os.path.exists(unittest_outfile):
             # Determine individual test status
             for line in open(outfile):
                 status, name = line.strip().split(': ', 1)
@@ -154,6 +158,18 @@ def addPythonTest(testname, subdir, script, interpreter, outfile,
                 elif status in ('FAIL', 'ERROR'):
                     testResults.failed[':'.join((testname,name))] = 1
                     failures += 1
+        elif os.path.exists(pytest_outfile):
+            results = ElementTree.parse(pytest_outfile)
+            for test in results.findall('.//testcase'):
+                class_name = test.get('classname')
+                if class_name.startswith("build.python.cantera.test."):
+                    class_name = class_name[26:]
+                test_name = "python: {}.{}".format(class_name, test.get('name'))
+                if test.findall('failure'):
+                    testResults.failed[test_name] = 1
+                    failures += 1
+                else:
+                    testResults.passed[test_name] = 1
 
         if code and failures == 0:
             # Failure, but unable to determine status of individual tests. This

--- a/test/python/runCythonTests.py
+++ b/test/python/runCythonTests.py
@@ -84,11 +84,12 @@ if __name__ == '__main__':
         if not subsets:
             subsets.append(str(base))
 
-        pytest_args = ["-raP", "--durations=50"]
+        pytest_args = ["-raP", "--durations=50", "--junitxml=pytest.xml"]
         if fast_fail:
             pytest_args.insert(0, "-x")
 
-        sys.exit(pytest.main(pytest_args + subsets))
+        ret_code = pytest.main(pytest_args + subsets)
+        sys.exit(ret_code)
     else:
         loader = unittest.TestLoader()
         runner = unittest.TextTestRunner(

--- a/test/python/runCythonTests.py
+++ b/test/python/runCythonTests.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         if not subsets:
             subsets.append(str(base))
 
-        pytest_args = []
+        pytest_args = ["-raP", "--durations=50"]
         if fast_fail:
             pytest_args.insert(0, "-x")
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Use `pytest` to run Python tests if it is installed
- Collect timing information for SCons commands and Python tests
- Start coverage tests immediately, rather than waiting for Ubuntu tests to finish
- Fix some diffusion flame extinction cases that weren't using the correct inlet temperature
- Fix `set_initial_guess` for `CounterFlowTwinPremixedFlame` so it doesn't overwrite deliberately-set profiles
- Disable the `test_ignition_delay_sensitivity` - it's a never-ending source of trouble, and the problems with it are already documented in Cantera/enhancements#55
- Speed up compilation a bit by adding `AnyMap.h` to the precompiled header.

*Note: I removed a bunch of changes from this PR that started to make material changes to the test suite, for the sake of getting something we can merge sooner and get back to having the CI servers working.*

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
