### PR TITLE
Add reminder to follow CONTRIBUTING guide to PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -15,4 +15,5 @@ Fixes #
 - [ ] There is a clear use-case for this code change
 - [ ] The commit message has a short title & references relevant issues
 - [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
+- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
 - [ ] The pull request is ready for review


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Add a checkbox to remind contributors of code style guidelines

Committers may ignore or delete those check boxes, but another reminder won't hurt.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] The pull request is ready for review
