### PR TITLE
Update detection of skipped/undeclared species

### DIFF
--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -857,6 +857,10 @@ protected:
     //! Check that the specified reaction is balanced (same number of atoms for
     //! each element in the reactants and products). Raises an exception if the
     //! reaction is not balanced.
+    /*!
+     * @deprecated To be removed in Cantera 2.6.
+     *             Replaceable by Reaction::checkBalance.
+     */
     void checkReactionBalance(const Reaction& R);
 
     //! @name Stoichiometry management

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -141,11 +141,13 @@ protected:
     //! Flag indicating whether reaction is set up correctly
     bool m_valid;
 
-    //! @internal  Helper function returning vector of undeclared third body species.
+    //! @internal  Helper function returning vector of undeclared third body species
+    //! and a boolean expression indicating whether the third body is specified.
     //! The function is used by the checkSpecies method and only needed as long as
     //! there is no unified approach to handle third body collision partners.
     //! @param kin  Kinetics object
-    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
+    virtual std::pair<std::vector<std::string>, bool>
+        undeclaredThirdBodies(const Kinetics& kin) const;
 };
 
 
@@ -235,7 +237,8 @@ public:
     bool specified_collision_partner = false; //!< Input specifies collision partner
 
 protected:
-    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
+    virtual std::pair<std::vector<std::string>, bool>
+        undeclaredThirdBodies(const Kinetics& kin) const;
 };
 
 //! A reaction that is first-order in [M] at low pressure, like a third-body
@@ -278,7 +281,8 @@ public:
     Units low_rate_units;
 
 protected:
-    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
+    virtual std::pair<std::vector<std::string>, bool> undeclaredThirdBodies(
+        const Kinetics& kin) const;
 };
 
 //! A reaction where the rate decreases as pressure increases due to collisional

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -75,6 +75,18 @@ public:
         m_valid = valid;
     }
 
+    //! Return vector containing list of undeclared species
+    //! @param kin  Kinetics object
+    std::vector<std::string> undeclaredSpecies(const Kinetics& kin) const;
+
+    //! Return vector containing list of undeclared third body species
+    //! @param kin  Kinetics object
+    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
+
+    //! Return vector containing list of undeclared reaction order species
+    //! @param kin  Kinetics object
+    std::vector<std::string> undeclaredOrders(const Kinetics& kin) const;
+
     //! Type of the reaction. The valid types are listed in the file,
     //! reaction_defs.h, with constants ending in `RXN`.
     /*!
@@ -209,6 +221,8 @@ public:
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
 
+    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
+
     //! Relative efficiencies of third-body species in enhancing the reaction
     //! rate.
     ThirdBody third_body;
@@ -235,6 +249,8 @@ public:
     virtual void validate();
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
+
+    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
 
     //! The rate constant in the low-pressure limit
     Arrhenius low_rate;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -75,6 +75,12 @@ public:
         m_valid = valid;
     }
 
+    //! Check that the specified reaction is balanced (same number of atoms for
+    //! each element in the reactants and products). Raises an exception if the
+    //! reaction is not balanced. Used by checkSpecies.
+    //! @param kin  Kinetics object
+    void checkBalance(const Kinetics& kin) const;
+
     //! Verify that all species involved in the reaction are defined in the Kinetics
     //! object. The function returns true if all species are found, and raises an
     //! exception unless the kinetics object is configured to skip undeclared species,

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -75,17 +75,12 @@ public:
         m_valid = valid;
     }
 
-    //! Return vector containing list of undeclared species
+    //! Verify that all species involved in the reaction are defined in the Kinetics
+    //! object. The function returns true if all species are found, and raises an
+    //! exception unless the kinetics object is configured to skip undeclared species,
+    //! in which case false is returned.
     //! @param kin  Kinetics object
-    std::vector<std::string> undeclaredSpecies(const Kinetics& kin) const;
-
-    //! Return vector containing list of undeclared third body species
-    //! @param kin  Kinetics object
-    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
-
-    //! Return vector containing list of undeclared reaction order species
-    //! @param kin  Kinetics object
-    std::vector<std::string> undeclaredOrders(const Kinetics& kin) const;
+    bool checkSpecies(const Kinetics& kin) const;
 
     //! Type of the reaction. The valid types are listed in the file,
     //! reaction_defs.h, with constants ending in `RXN`.
@@ -139,6 +134,12 @@ protected:
 
     //! Flag indicating whether reaction is set up correctly
     bool m_valid;
+
+    //! @internal  Helper function returning vector of undeclared third body species.
+    //! The function is used by the checkSpecies method and only needed as long as
+    //! there is no unified approach to handle third body collision partners.
+    //! @param kin  Kinetics object
+    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
 };
 
 
@@ -221,13 +222,14 @@ public:
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
 
-    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
-
     //! Relative efficiencies of third-body species in enhancing the reaction
     //! rate.
     ThirdBody third_body;
 
     bool specified_collision_partner = false; //!< Input specifies collision partner
+
+protected:
+    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
 };
 
 //! A reaction that is first-order in [M] at low pressure, like a third-body
@@ -250,8 +252,6 @@ public:
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
 
-    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
-
     //! The rate constant in the low-pressure limit
     Arrhenius low_rate;
 
@@ -270,6 +270,9 @@ public:
     //! The units of the low-pressure rate constant. The units of the
     //! high-pressure rate constant are stored in #rate_units.
     Units low_rate_units;
+
+protected:
+    virtual std::vector<std::string> undeclaredThirdBodies(const Kinetics& kin) const;
 };
 
 //! A reaction where the rate decreases as pressure increases due to collisional

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -457,7 +457,7 @@ class TestUndeclared(utilities.CanteraTest):
         with self.assertRaisesRegex(ct.CanteraError, "three-body reaction with undeclared"):
             ct.Solution(yaml=gas_def)
 
-    def test_skip_undeclared_third_bodies(self):
+    def test_skip_undeclared_third_bodies1(self):
 
         gas_def = self._gas_def + """
               reactions:
@@ -466,7 +466,29 @@ class TestUndeclared(utilities.CanteraTest):
             """
 
         gas = ct.Solution(yaml=gas_def)
-        self.assertEqual(gas.n_reactions, 2)
+        self.assertEqual(gas.n_reactions, 3)
+
+    def test_skip_undeclared_third_bodies2(self):
+
+        gas_def = """
+            phases:
+            - name: gas
+              species:
+              - h2o2.yaml/species: [H, O2, HO2]
+              thermo: ideal-gas
+              skip-undeclared-third-bodies: true
+              kinetics: gas
+              reactions:
+              - h2o2.yaml/reactions: declared-species
+            """
+
+        gas = ct.Solution(yaml=gas_def)
+        found = False
+        for rxn in gas.reactions():
+            if rxn.equation == "H + O2 + M <=> HO2 + M":
+                found = True
+                break
+        self.assertTrue(found)
 
     def test_skip_undeclared_orders(self):
 

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -413,7 +413,7 @@ class KineticsRepeatability(utilities.CanteraTest):
                    "at P = 1.0132e+05, T = 1000.0",
                    "Invalid rate coefficient for reaction 'CH2CHOO <=> CH3 + CO2'",
                    "at P = 1.0132e+05, T = 500.0",
-                   "InputFileError thrown by Kinetics::checkReactionBalance:",
+                   "InputFileError thrown by Reaction::checkBalance:",
                    "The following reaction is unbalanced: H2O2 + OH <=> 2 H2O + HO2")
         try:
             ct.Solution('addReactions_err_test.yaml')

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -1253,7 +1253,7 @@ class TestIonFreeFlame(utilities.CanteraTest):
         width = 0.03
 
         # Solution object used to compute mixture properties
-        self.gas = ct.Solution('ch4_ion.cti')
+        self.gas = ct.Solution('ch4_ion.yaml')
         self.gas.TPX = Tin, p, reactants
         self.sim = ct.IonFreeFlame(self.gas, width=width)
         self.sim.set_refine_criteria(ratio=4, slope=0.8, curve=1.0)
@@ -1279,7 +1279,7 @@ class TestIonBurnerFlame(utilities.CanteraTest):
         width = 0.01
 
         # Solution object used to compute mixture properties
-        self.gas = ct.Solution('ch4_ion.cti')
+        self.gas = ct.Solution('ch4_ion.yaml')
         self.gas.TPX = Tburner, p, reactants
         self.sim = ct.IonBurnerFlame(self.gas, width=width)
         self.sim.set_refine_criteria(ratio=4, slope=0.1, curve=0.1)

--- a/src/base/ctexceptions.cpp
+++ b/src/base/ctexceptions.cpp
@@ -14,7 +14,8 @@ namespace Cantera
 
 // *** Exceptions ***
 
-static const char* stars = "***********************************************************************\n";
+static const char* stars = ("*****************************************"
+                            "**************************************\n");
 
 CanteraError::CanteraError(const std::string& procedure) :
     procedure_(procedure)

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -288,10 +288,6 @@ void GasKinetics::addFalloffReaction(FalloffReaction& r)
         size_t k = kineticsSpeciesIndex(eff.first);
         if (k != npos) {
             efficiencies[k] = eff.second;
-        } else if (!m_skipUndeclaredThirdBodies) {
-            throw CanteraError("GasKinetics::addFalloffReaction", "Found "
-                "third-body efficiency for undefined species '" + eff.first +
-                "' while adding reaction '" + r.equation() + "'");
         }
     }
     m_falloff_concm.install(nfall, efficiencies,
@@ -311,10 +307,6 @@ void GasKinetics::addThreeBodyReaction(ThreeBodyReaction& r)
         size_t k = kineticsSpeciesIndex(eff.first);
         if (k != npos) {
             efficiencies[k] = eff.second;
-        } else if (!m_skipUndeclaredThirdBodies) {
-            throw CanteraError("GasKinetics::addThreeBodyReaction", "Found "
-                "third-body efficiency for undefined species '" + eff.first +
-                "' while adding reaction '" + r.equation() + "'");
         }
     }
     m_3b_concm.install(nReactions()-1, efficiencies,

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -223,7 +223,8 @@ void Reaction::calculateRateCoeffUnits(const Kinetics& kin)
 }
 
 void updateUndeclared(std::vector<std::string>& undeclared,
-                      const Composition& comp, const Kinetics& kin) {
+                      const Composition& comp, const Kinetics& kin)
+{
     for (const auto& sp: comp) {
         if (kin.kineticsSpeciesIndex(sp.first) == npos) {
             undeclared.emplace_back(sp.first);
@@ -232,13 +233,14 @@ void updateUndeclared(std::vector<std::string>& undeclared,
 }
 
 std::pair<std::vector<std::string>, bool> Reaction::undeclaredThirdBodies(
-        const Kinetics& kin) const {
+        const Kinetics& kin) const
+{
     std::vector<std::string> undeclared;
     return std::make_pair(undeclared, false);
 }
 
-void Reaction::checkBalance(const Kinetics& kin) const {
-
+void Reaction::checkBalance(const Kinetics& kin) const
+{
     Composition balr, balp;
 
     // iterate over products and reactants
@@ -280,8 +282,8 @@ void Reaction::checkBalance(const Kinetics& kin) const {
     }
 }
 
-bool Reaction::checkSpecies(const Kinetics& kin) const {
-
+bool Reaction::checkSpecies(const Kinetics& kin) const
+{
     // Check for undeclared species
     std::vector<std::string> undeclared;
     updateUndeclared(undeclared, reactants, kin);
@@ -336,7 +338,6 @@ bool Reaction::checkSpecies(const Kinetics& kin) const {
         }
     }
 
-    //
     checkBalance(kin);
 
     return true;
@@ -406,7 +407,8 @@ ThreeBodyReaction::ThreeBodyReaction(const Composition& reactants_,
     reaction_type = THREE_BODY_RXN;
 }
 
-std::string ThreeBodyReaction::reactantString() const {
+std::string ThreeBodyReaction::reactantString() const
+{
     if (specified_collision_partner) {
         return ElementaryReaction::reactantString() + " + "
             + third_body.efficiencies.begin()->first;
@@ -415,7 +417,8 @@ std::string ThreeBodyReaction::reactantString() const {
     }
 }
 
-std::string ThreeBodyReaction::productString() const {
+std::string ThreeBodyReaction::productString() const
+{
     if (specified_collision_partner) {
         return ElementaryReaction::productString() + " + "
             + third_body.efficiencies.begin()->first;
@@ -459,7 +462,8 @@ void ThreeBodyReaction::getParameters(AnyMap& reactionNode) const
 }
 
 std::pair<std::vector<std::string>, bool> ThreeBodyReaction::undeclaredThirdBodies(
-        const Kinetics& kin) const {
+        const Kinetics& kin) const
+{
     std::vector<std::string> undeclared;
     updateUndeclared(undeclared, third_body.efficiencies, kin);
     return std::make_pair(undeclared, specified_collision_partner);
@@ -489,7 +493,8 @@ FalloffReaction::FalloffReaction(
     reaction_type = FALLOFF_RXN;
 }
 
-std::string FalloffReaction::reactantString() const {
+std::string FalloffReaction::reactantString() const
+{
     if (third_body.default_efficiency == 0 &&
         third_body.efficiencies.size() == 1) {
         return Reaction::reactantString() + " (+" +
@@ -499,7 +504,8 @@ std::string FalloffReaction::reactantString() const {
     }
 }
 
-std::string FalloffReaction::productString() const {
+std::string FalloffReaction::productString() const
+{
     if (third_body.default_efficiency == 0 &&
         third_body.efficiencies.size() == 1) {
         return Reaction::productString() + " (+" +
@@ -509,7 +515,8 @@ std::string FalloffReaction::productString() const {
     }
 }
 
-void FalloffReaction::validate() {
+void FalloffReaction::validate()
+{
     Reaction::validate();
     if (!allow_negative_pre_exponential_factor &&
         (low_rate.preExponentialFactor() < 0 ||
@@ -552,7 +559,8 @@ void FalloffReaction::getParameters(AnyMap& reactionNode) const
 }
 
 std::pair<std::vector<std::string>, bool> FalloffReaction::undeclaredThirdBodies(
-        const Kinetics& kin) const {
+        const Kinetics& kin) const
+{
     std::vector<std::string> undeclared;
     updateUndeclared(undeclared, third_body.efficiencies, kin);
     return std::make_pair(undeclared, false);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Fix skipping of undeclared species with specific third body detection
- Streamline detection of undeclared species in other cases 
- Output all missing species, not just first
- Update formatting for `Reaction::validate`

~While `IonBurnerFlame` does act up, this is not the first time. I have skipped those tests for the time being.~

**If applicable, fill in the issue number this pull request is fixing**

Fixes #1024

E.g. if `skip-undeclared-third-bodies=false`, the error is formatted as
```
*******************************************************************************
InputFileError thrown by Reaction::checkSpecies:
Error on line 215 of /src/build/python/cantera/data/h2o2.yaml:
Reaction 'H + O2 + N2 <=> HO2 + N2'
is a three-body reaction with undeclared species: 'N2'
|  Line |
|   210 |   efficiencies: {O2: 0.0, H2O: 0.0, N2: 0.0, AR: 0.0}
|   211 | - equation: H + 2 O2 <=> HO2 + O2  # Reaction 7
|   212 |   rate-constant: {A: 2.08e+19, b: -1.24, Ea: 0.0}
|   213 | - equation: H + O2 + H2O <=> HO2 + H2O  # Reaction 8
|   214 |   rate-constant: {A: 1.126e+19, b: -0.76, Ea: 0.0}
>   215 > - equation: H + O2 + N2 <=> HO2 + N2  # Reaction 9
            ^
|   216 |   rate-constant: {A: 2.6e+19, b: -1.24, Ea: 0.0}
|   217 | - equation: H + O2 + AR <=> HO2 + AR  # Reaction 10
|   218 |   rate-constant: {A: 7.0e+17, b: -0.8, Ea: 0.0}
*******************************************************************************
```

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
