### PR TITLE
Fix memory error when deallocating Python reaction rate wrappers

### DIFF
--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1130,10 +1130,12 @@ cdef class CustomReaction(Reaction):
 
 cdef class Arrhenius:
     cdef CxxArrhenius* rate
+    cdef cbool own_rate
     cdef Reaction reaction # parent reaction, to prevent garbage collection
 
 cdef class BlowersMasel:
     cdef CxxBlowersMasel* rate
+    cdef cbool own_rate
     cdef Reaction reaction
 
 cdef class Falloff:

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -351,10 +351,13 @@ cdef class Arrhenius:
     def __cinit__(self, A=0, b=0, E=0, init=True):
         if init:
             self.rate = new CxxArrhenius(A, b, E / gas_constant)
+            self.own_rate = True
             self.reaction = None
+        else:
+            self.own_rate = False
 
     def __dealloc__(self):
-        if self.reaction is None:
+        if self.own_rate:
             del self.rate
 
     property pre_exponential_factor:
@@ -920,10 +923,13 @@ cdef class BlowersMasel:
     def __cinit__(self, A=0, b=0, E0=0, w=0, init=True):
         if init:
             self.rate = new CxxBlowersMasel(A, b, E0 / gas_constant, w / gas_constant)
+            self.own_rate = True
             self.reaction = None
+        else:
+            self.own_rate = False
 
     def __dealloc__(self):
-        if self.reaction is None:
+        if self.own_rate:
             del self.rate
 
     property pre_exponential_factor:


### PR DESCRIPTION
Using the value of member variables that are Python objects in `__dealloc__` is not reliable, because they may have already been
deleted by the time `__dealloc__` is called [[Cython docs]](https://cython.readthedocs.io/en/latest/src/userguide/special_methods.html#finalization-method-dealloc). Instead, we need a C data member to check for whether or not the rate object owns the underlying C++ object and should delete it.

The only way I've been able to trigger this bug is interactively in IPython, when trying to access members of the rate object with tab autocompletion. I think the reason for this is that this scenario ends up invoking the garbage collector, rather than having objects just get deleted when their reference counts go to zero, and that ends up behaving differently. I'm honestly surprised I didn't run into this before -- this is the way this has worked as long as this information has been accessible in Cython.

**Changes proposed in this pull request**

- Add C++ boolean `own_rate` to Cython `Arrhenius` and `BlowersMasel` classes and use this when checking whether to delete the pointer to the corresponding C++ objects.

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review