### PR TITLE
Update default pytest output

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -43,7 +43,8 @@ jobs:
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all -j2 debug=n --debug=time
     - name: Test Cantera
-      run: python3 `which scons` test --debug=time
+      run:
+        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
       env:
         GITHUB_ACTIONS: "true"
 
@@ -83,7 +84,8 @@ jobs:
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all -j3 debug=n --debug=time
     - name: Test Cantera
-      run: python3 `which scons` test --debug=time
+      run:
+        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
       env:
         GITHUB_ACTIONS: "true"
 
@@ -117,7 +119,8 @@ jobs:
         python3 `which scons` build blas_lapack_libs=lapack,blas coverage=y \
         optimize=n skip_slow_tests=y no_optimize_flags=-DNDEBUG env_vars=all -j2 --debug=time
     - name: Test Cantera
-      run: python3 `which scons` test --debug=time
+      run:
+        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
       env:
         GITHUB_ACTIONS: "true"
     - name: Upload Coverage to Codecov
@@ -246,7 +249,7 @@ jobs:
           extra_lib_dirs=$CONDA_PREFIX/lib system_fmt=y system_eigen=y system_yamlcpp=y \
           system_sundials=y blas_lapack_libs='lapack,blas' -j2 VERBOSE=True debug=n
       - name: Test Cantera
-        run: scons test
+        run: scons test show_long_tests=yes verbose_tests=yes
 
   cython-latest:
     name: Test pre-release version of Cython
@@ -272,7 +275,7 @@ jobs:
     - name: Build Cantera
       run: python3 `which scons` build blas_lapack_libs=lapack,blas python_package='full' -j2 debug=n
     - name: Test Cantera
-      run: python3 `which scons` test
+      run: python3 `which scons` test show_long_tests=yes verbose_tests=yes
 
   windows:
     name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}
@@ -338,6 +341,6 @@ jobs:
           msvc_version=${{ matrix.vs-toolset }} f90_interface=n --debug=time
         shell: cmd
       - name: Test Cantera
-        run: scons test --debug=time
+        run: scons test show_long_tests=yes verbose_tests=yes --debug=time
         env:
           GITHUB_ACTIONS: "true"

--- a/SConstruct
+++ b/SConstruct
@@ -390,7 +390,7 @@ config_options = [
            To install to the current user's 'site-packages' directory, use
            'python_prefix=USER'.""",
         defaults.python_prefix, PathVariable.PathAccept),
-     EnumVariable(
+    EnumVariable(
         'matlab_toolbox',
         """This variable controls whether the MATLAB toolbox will be built. If
            set to 'y', you will also need to set the value of the 'matlab_path'
@@ -663,14 +663,17 @@ config_options = [
     BoolVariable(
         "fast_fail_tests",
         """If enabled, tests will exit at the first failure.""",
-        False,
-    ),
+        False),
     BoolVariable(
         "skip_slow_tests",
         """If enabled, skip a subset of tests that are known to have long runtimes.
            Skipping these may be desirable when running with options that cause tests
            to run slowly, like disabling optimization or activating code profiling.""",
-        False)
+        False),
+    BoolVariable(
+        "show_long_tests",
+        """If enabled, duration of slowest tests will be shown.""",
+        False),
 ]
 
 opts.AddVariables(*config_options)

--- a/SConstruct
+++ b/SConstruct
@@ -674,6 +674,10 @@ config_options = [
         "show_long_tests",
         """If enabled, duration of slowest tests will be shown.""",
         False),
+    BoolVariable(
+        "verbose_tests",
+        """If enabled, verbose test output will be shown.""",
+        False),
 ]
 
 opts.AddVariables(*config_options)

--- a/test/SConscript
+++ b/test/SConscript
@@ -144,6 +144,8 @@ def addPythonTest(testname, subdir, script, interpreter, outfile,
             cmdargs.insert(0, "fast_fail")
         if env["show_long_tests"]:
             cmdargs.insert(0, "show_long")
+        if env["verbose_tests"]:
+            cmdargs.insert(0, "verbose")
         if env["skip_slow_tests"]:
             environ["CT_SKIP_SLOW"] = "1"
 

--- a/test/SConscript
+++ b/test/SConscript
@@ -3,6 +3,7 @@ import subprocess
 from xml.etree import ElementTree
 from os.path import join as pjoin
 import time
+import sys
 
 from buildutils import *
 
@@ -141,6 +142,8 @@ def addPythonTest(testname, subdir, script, interpreter, outfile,
         cmdargs = args.split()
         if env["fast_fail_tests"]:
             cmdargs.insert(0, "fast_fail")
+        if env["show_long_tests"]:
+            cmdargs.insert(0, "show_long")
         if env["skip_slow_tests"]:
             environ["CT_SKIP_SLOW"] = "1"
 

--- a/test/python/runCythonTests.py
+++ b/test/python/runCythonTests.py
@@ -71,11 +71,15 @@ if __name__ == '__main__':
     subset_start = 1
     fast_fail = False
     show_long = False
+    verbose = False
     if "fast_fail" in sys.argv:
         fast_fail = True
         subset_start += 1
     if "show_long" in sys.argv:
         show_long = True
+        subset_start += 1
+    if "verbose" in sys.argv:
+        verbose = True
         subset_start += 1
 
     if pytest is not None:
@@ -87,11 +91,13 @@ if __name__ == '__main__':
         if not subsets:
             subsets.append(str(base))
 
-        pytest_args = ["-v", "-raP", "--junitxml=pytest.xml"]
+        pytest_args = ["-raP", "--junitxml=pytest.xml"]
         if show_long:
             pytest_args += ["--durations=50"]
         if fast_fail:
             pytest_args.insert(0, "-x")
+        if verbose:
+            pytest_args.insert(0, "-v")
 
         ret_code = pytest.main(pytest_args + subsets)
         sys.exit(ret_code)

--- a/test/python/runCythonTests.py
+++ b/test/python/runCythonTests.py
@@ -98,6 +98,8 @@ if __name__ == '__main__':
             pytest_args.insert(0, "-x")
         if verbose:
             pytest_args.insert(0, "-v")
+        else:
+            pytest_args.append("--log-level=ERROR")
 
         ret_code = pytest.main(pytest_args + subsets)
         sys.exit(ret_code)

--- a/test/python/runCythonTests.py
+++ b/test/python/runCythonTests.py
@@ -68,12 +68,15 @@ if __name__ == '__main__':
     print('* INFO: Git commit:', cantera.__git_commit__, '\n')
     sys.stdout.flush()
 
-    if len(sys.argv) > 1 and sys.argv[1] == "fast_fail":
+    subset_start = 1
+    fast_fail = False
+    show_long = False
+    if "fast_fail" in sys.argv:
         fast_fail = True
-        subset_start = 2
-    else:
-        fast_fail = False
-        subset_start = 1
+        subset_start += 1
+    if "show_long" in sys.argv:
+        show_long = True
+        subset_start += 1
 
     if pytest is not None:
         base = Path(cantera.__file__).parent.joinpath('test')
@@ -84,7 +87,9 @@ if __name__ == '__main__':
         if not subsets:
             subsets.append(str(base))
 
-        pytest_args = ["-v", "-raP", "--durations=50", "--junitxml=pytest.xml"]
+        pytest_args = ["-v", "-raP", "--junitxml=pytest.xml"]
+        if show_long:
+            pytest_args += ["--durations=50"]
         if fast_fail:
             pytest_args.insert(0, "-x")
 

--- a/test/python/runCythonTests.py
+++ b/test/python/runCythonTests.py
@@ -84,7 +84,7 @@ if __name__ == '__main__':
         if not subsets:
             subsets.append(str(base))
 
-        pytest_args = ["-raP", "--durations=50", "--junitxml=pytest.xml"]
+        pytest_args = ["-v", "-raP", "--durations=50", "--junitxml=pytest.xml"]
         if fast_fail:
             pytest_args.insert(0, "-x")
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your PR against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Switch `pytest` output to verbose (`-v` option) 
- Hide information on longest runs by default
- Implement boolean SCons variable `show_long_tests`

The rationale for switching to verbose output is that segfaults are difficult to locate with the progress bar. Further, the longest running tests can still be displayed using
```
scons test-python-reaction show_long_tests=yes
```

While `test_convert.py` (`scons test-python-convert`) creates numerous `WARNING` messages from captured log calls - which may confuse some users - I am leaving those for another PR as those may or may not be a feature.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #1026

**Checklist**

- [x] There is a clear use-case for this code change
- [x] The commit message has a short title & references relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
