### PR TITLE
SolutionArray/ flamebase importers allow unnormalized and/or negative mass/mole fractions

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -5,6 +5,7 @@ years. If you've been left off, please report the omission on the Github issue
 tracker.
 
 Rounak Agarwal (@agarwalrounak)
+David Akinpelu (@DavidAkinpelu), Louisiana State University
 Emil Atz (@EmilAtz)
 Philip Berndt
 Wolfgang Bessler (@wbessler), Offenburg University of Applied Science

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -652,7 +652,8 @@ class SolutionArray:
 
         By default, the mass or mole fractions will be normalized so they sum to 1.0.
         If this is not desired, the ``normalize`` argument can be set to ``False``.
-        In this case, the mass or mole fractions must be specified as an array::
+        In this case, the mass or mole fractions must be specified as an array.
+        For example::
 
             mystates.append(T=300, P=101325, X=gas.X - 1e-16, normalize=False)
         """
@@ -689,7 +690,7 @@ class SolutionArray:
                 )
             if normalize or attr[-1] == "Q":
                 setattr(self._phase, attr, value)
-            if not normalize:
+            elif not normalize:
                 if attr[-1] == "X":
                     self._phase.set_unnormalized_mole_fractions(value[-1])
                     attr = attr[:-1]
@@ -710,7 +711,7 @@ class SolutionArray:
                 ) from None
             if normalize or attr[-1] == "Q":
                 setattr(self._phase, attr, list(kwargs.values()))
-            if not normalize:
+            elif not normalize:
                 if attr[-1] == "X":
                     self._phase.set_unnormalized_mole_fractions(kwargs.pop("X"))
                     attr = attr[:-1]
@@ -939,7 +940,7 @@ class SolutionArray:
             for i in self._indices:
                 setattr(self._phase, mode, [st[i, ...] for st in state_data])
                 self._states[i] = self._phase.state
-        if not normalize:
+        elif not normalize:
             for i in self._indices:
                 if mode[-1] == "X":
                     self._phase.set_unnormalized_mole_fractions([st[i, ...] for \

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -368,12 +368,12 @@ class SolutionArray:
         >>> states.equilibrate('HP')
         >>> states.T # -> adiabatic flame temperature at various equivalence ratios
 
-    To append a state with unnormalized and/or negative mass/mole fractions, the mole/mass fractions
+    To append a state with non-normalized and/or negative mass/mole fractions, the mole/mass fractions
     must be specified as an array::
 
         >>> states = ct.SolutionArray(gas)
         >>> states.append(T=300., P=ct.one_atm, X = gas.X -1.e-16, normalize = False)
-        >>> states.X # -> unnormalized mole fractions
+        >>> states.X # -> non-normalized mole fractions
 
     `SolutionArray` objects can also be 'sliced' like Numpy arrays, which can be
     used both for accessing and setting properties::
@@ -657,7 +657,7 @@ class SolutionArray:
 
               mystates.append(T=300, P=101325, X={'O2':1.0, 'N2':3.76})
 
-        To specify unnormalize mass/mole fractions, the normalize argument should
+        To specify non-normalized mass/mole fractions, the normalize argument should
         be set to false. This is only applicable when the mole/mass fractions are
         specified as an array::
 
@@ -923,7 +923,7 @@ class SolutionArray:
             self._output_dummy = self._indices
             self._shape = (rows,)
 
-        # use unnormalized state setters for Three property setter only
+        # use non-normalized state setters for Three property setter only
         if mode in {"TPX", "TPY", "HPX", "HPY", "SPX", "SPY",
                     "TDX", "TDY", "TPX", "TPY", "UVX", "UVY",
                     "DPX", "DPY","HPX", "HPY", "SPX", "SPY",

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -682,7 +682,17 @@ class SolutionArray:
             extra_temp[name] = kwargs.pop(name)
 
         if state is not None:
-            self._phase.state = state
+            mode = "".join(self._phase._native_state)
+            if normalize or mode[-1] == "Q":
+                if len(mode) == 3:
+                    state_data = (state[0], state[1], state[2:])
+                elif len(mode) == 2:
+                    state_data = (state[0], state[1:])
+                else:
+                    state_data = state
+                setattr(self._phase, mode, state_data)
+            else:
+                self._phase.state = state
 
         # Non normalize form must be set using the mass fractions as the
         # mole fractions are not in the native_state setter.

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -368,6 +368,13 @@ class SolutionArray:
         >>> states.equilibrate('HP')
         >>> states.T # -> adiabatic flame temperature at various equivalence ratios
 
+    To append a state with unnormalized and/or negative mass/mole fractions, the mole/mass fractions
+    must be specified as an array::
+
+        >>> states = ct.SolutionArray(gas)
+        >>> states.append(T=300., P=ct.one_atm, X = gas.X -1.e-16, normalize = False)
+        >>> states.X # -> unnormalized mole fractions
+
     `SolutionArray` objects can also be 'sliced' like Numpy arrays, which can be
     used both for accessing and setting properties::
 
@@ -649,6 +656,12 @@ class SolutionArray:
           the full-state setters::
 
               mystates.append(T=300, P=101325, X={'O2':1.0, 'N2':3.76})
+
+        To specify unnormalize mass/mole fractions, the normalize argument should
+        be set to false. This is only applicable when the mole/mass fractions are
+        specified as an array::
+
+            mystates.append(T=300, P=101325, X=gas.X - 1e-16, normalize=False)
         """
         if len(self._shape) != 1:
             raise IndexError("Can only append to 1D SolutionArray")

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -412,8 +412,8 @@ class FlameBase(Sim1D):
         n_points = np.array(states[0]).size
         if n_points:
             arr = SolutionArray(self.phase(domain), n_points,
-                                extra=other_cols, meta=meta)
-            arr.TPY = states
+                                extra=other_cols, meta=meta)       
+            arr.TPY_NoNorm = states
             return arr
         else:
             return SolutionArray(self.phase(domain), meta=meta)

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -412,8 +412,8 @@ class FlameBase(Sim1D):
         n_points = np.array(states[0]).size
         if n_points:
             arr = SolutionArray(self.phase(domain), n_points,
-                                extra=other_cols, meta=meta)       
-            arr.TPY_NoNorm = states
+                                extra=other_cols, meta=meta)
+            arr.TPY = states
             return arr
         else:
             return SolutionArray(self.phase(domain), meta=meta)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -135,6 +135,15 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertIn('X', collected)
         self.assertEqual(collected['X'].shape, (0, self.gas.n_species))
 
+    def test_append_state(self):
+        gas = ct.Solution("h2o2.yaml")
+        gas.TPX = 300, ct.one_atm, 'H2:0.5, O2:0.4'
+        states = ct.SolutionArray(gas)
+        states.append(gas.state)
+        self.assertEqual(states[0].T, gas.T)
+        self.assertEqual(states[0].P, gas.P)
+        self.assertArrayNear(states[0].X, gas.X)
+
     def test_append_no_norm_data(self):
         gas = ct.Solution("h2o2.yaml")
         gas.TP = 300, ct.one_atm
@@ -144,25 +153,6 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertEqual(states[0].T, gas.T)
         self.assertEqual(states[0].P, gas.P)
         self.assertArrayNear(states[0].Y, gas.Y)
-
-    def test_append_no_norm_state(self):
-        gas = ct.Solution("h2o2.yaml")
-        gas.TP = 300, ct.one_atm
-        gas.set_unnormalized_mass_fractions(np.full(gas.n_species, 0.3))
-        states = ct.SolutionArray(gas)
-        states.append(gas.state, normalize=False)
-        self.assertEqual(states[0].T, gas.T)
-        self.assertEqual(states[0].P, gas.P)
-        self.assertArrayNear(states[0].Y, gas.Y)
-
-    def test_append_norm_state(self):
-        gas = ct.Solution("h2o2.yaml")
-        gas.TPX = 300, ct.one_atm, 'H2:0.5, O2:0.4'
-        states = ct.SolutionArray(gas)
-        states.append(gas.state)
-        self.assertEqual(states[0].T, gas.T)
-        self.assertEqual(states[0].P, gas.P)
-        self.assertArrayNear(states[0].X, gas.X)
 
     def test_import_no_norm_data(self):
         outfile = pjoin(self.test_work_dir, "solutionarray.h5")

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -136,7 +136,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertEqual(collected['X'].shape, (0, self.gas.n_species))
 
     def test_append_no_norm_data(self):
-        gas = ct.Solution('h2o2.yaml')
+        gas = ct.Solution("h2o2.yaml")
         gas.TP = 300, ct.one_atm
         gas.X = gas.X - 1.e-16
         states = ct.SolutionArray(gas)
@@ -146,16 +146,16 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertArrayNear(states[0].X, gas.X)
 
     def test_import_no_norm_data(self):
-        outfile = pjoin(self.test_work_dir, 'solutionarray.h5')
+        outfile = pjoin(self.test_work_dir, "solutionarray.h5")
         if os.path.exists(outfile):
             os.remove(outfile)
 
-        gas = ct.Solution('h2o2.yaml')
+        gas = ct.Solution("h2o2.yaml")
         gas.set_unnormalized_mole_fractions(gas.X - 1e-16)
         states = ct.SolutionArray(gas, 5)
         states.write_hdf(outfile)
 
-        gas_new = ct.Solution('h2o2.yaml')
+        gas_new = ct.Solution("h2o2.yaml")
         b = ct.SolutionArray(gas_new)
         b.read_hdf(outfile)
         self.assertArrayNear(states.T, b.T)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -155,9 +155,10 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertArrayNear(states[0].Y, gas.Y)
 
     def test_import_no_norm_data(self):
-        outfile = pjoin(self.test_work_dir, "solutionarray.h5")
-        if os.path.exists(outfile):
-            os.remove(outfile)
+        outfile = self.test_work_path / "solutionarray.h5"
+        # In Python >= 3.8, this can be replaced by the missing_ok argument
+        if outfile.is_file():
+            outfile.unlink()
 
         gas = ct.Solution("h2o2.yaml")
         gas.set_unnormalized_mole_fractions(np.full(gas.n_species, 0.3))
@@ -454,9 +455,10 @@ class TestRestorePureFluid(utilities.CanteraTest):
         check(a, b)
 
     def test_import_no_norm_water(self):
-        outfile = pjoin(self.test_work_dir, "solutionarray.h5")
-        if os.path.exists(outfile):
-            os.remove(outfile)
+        outfile = self.test_work_path / "solutionarray.h5"
+        # In Python >= 3.8, this can be replaced by the missing_ok argument
+        if outfile.is_file():
+            outfile.unlink()
 
         w = ct.Water()
         w.TQ = 300, 0.5
@@ -465,7 +467,7 @@ class TestRestorePureFluid(utilities.CanteraTest):
 
         w_new = ct.Water()
         c = ct.SolutionArray(w_new)
-        c.read_hdf(outfile)
+        c.read_hdf(outfile, normalize=False)
         self.assertArrayNear(states.T, c.T)
         self.assertArrayNear(states.P, c.P)
         self.assertArrayNear(states.Q, c.Q)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -135,7 +135,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertIn('X', collected)
         self.assertEqual(collected['X'].shape, (0, self.gas.n_species))
 
-    def test_append_unnormalized_data(self):
+    def test_append_no_norm_data(self):
         gas = ct.Solution('h2o2.yaml')
         gas.TP = 300, ct.one_atm
         gas.X = gas.X - 1.e-16
@@ -145,7 +145,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertEqual(states[0].P, gas.P)
         self.assertArrayNear(states[0].X, gas.X)
 
-    def test_import_unnormalized_data(self):
+    def test_import_no_norm_data(self):
         outfile = pjoin(self.test_work_dir, 'solutionarray.h5')
         if os.path.exists(outfile):
             os.remove(outfile)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -145,6 +145,14 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertEqual(states[0].P, gas.P)
         self.assertArrayNear(states[0].X, gas.X)
 
+        w = ct.Water()
+        states = ct.SolutionArray(w)
+        w.TQ = 300, 0.5
+        states.append(w.state)
+        self.assertEqual(states[0].T, w.T)
+        self.assertEqual(states[0].P, w.P)
+        self.assertEqual(states[0].Q, w.Q)
+
     def test_import_no_norm_data(self):
         outfile = pjoin(self.test_work_dir, "solutionarray.h5")
         if os.path.exists(outfile):
@@ -153,14 +161,26 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         gas = ct.Solution("h2o2.yaml")
         gas.set_unnormalized_mole_fractions(gas.X - 1e-16)
         states = ct.SolutionArray(gas, 5)
-        states.write_hdf(outfile)
+        states.write_hdf(outfile, group="mole fraction")
 
         gas_new = ct.Solution("h2o2.yaml")
         b = ct.SolutionArray(gas_new)
-        b.read_hdf(outfile)
+        b.read_hdf(outfile, group="mole fraction")
         self.assertArrayNear(states.T, b.T)
         self.assertArrayNear(states.P, b.P)
         self.assertArrayNear(states.X, b.X)
+
+        w = ct.Water()
+        w.TQ = 300, 0.5
+        states = ct.SolutionArray(w, 5)
+        states.write_hdf(outfile, group="vapor fraction")
+
+        w_new = ct.Water()
+        c = ct.SolutionArray(w_new)
+        c.read_hdf(outfile, group="vapor fraction")
+        self.assertArrayNear(states.T, c.T)
+        self.assertArrayNear(states.P, c.P)
+        self.assertArrayNear(states.Q, c.Q)
 
     def test_write_csv(self):
         states = ct.SolutionArray(self.gas, 7)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -145,6 +145,25 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertEqual(states[0].P, gas.P)
         self.assertArrayNear(states[0].Y, gas.Y)
 
+    def test_append_no_norm_state(self):
+        gas = ct.Solution("h2o2.yaml")
+        gas.TP = 300, ct.one_atm
+        gas.set_unnormalized_mass_fractions(np.full(gas.n_species, 0.3))
+        states = ct.SolutionArray(gas)
+        states.append(gas.state, normalize=False)
+        self.assertEqual(states[0].T, gas.T)
+        self.assertEqual(states[0].P, gas.P)
+        self.assertArrayNear(states[0].Y, gas.Y)
+
+    def test_append_norm_state(self):
+        gas = ct.Solution("h2o2.yaml")
+        gas.TPX = 300, ct.one_atm, 'H2:0.5, O2:0.4'
+        states = ct.SolutionArray(gas)
+        states.append(gas.state)
+        self.assertEqual(states[0].T, gas.T)
+        self.assertEqual(states[0].P, gas.P)
+        self.assertArrayNear(states[0].X, gas.X)
+
     def test_import_no_norm_data(self):
         outfile = pjoin(self.test_work_dir, "solutionarray.h5")
         if os.path.exists(outfile):

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -272,7 +272,7 @@ class TestFreeFlame(utilities.CanteraTest):
     def test_solution_array_output(self):
         self.run_mix(phi=1.0, T=300, width=2.0, p=1.0, refine=False)
 
-        flow = self.sim.to_solution_array()
+        flow = self.sim.to_solution_array(normalize=True)
         self.assertArrayNear(self.sim.grid, flow.grid)
         self.assertArrayNear(self.sim.T, flow.T)
         for k in flow._extra.keys():
@@ -291,7 +291,7 @@ class TestFreeFlame(utilities.CanteraTest):
 
     def test_restart(self):
         self.run_mix(phi=1.0, T=300, width=2.0, p=1.0, refine=False)
-        arr = self.sim.to_solution_array()
+        arr = self.sim.to_solution_array(normalize=False)
 
         reactants = {'H2': 0.9, 'O2': 0.5, 'AR': 2}
         self.create_sim(1.1 * ct.one_atm, 500, reactants, 2.0)
@@ -657,7 +657,7 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.write_hdf(filename, description=desc)
 
         f = ct.FreeFlame(self.gas)
-        meta = f.read_hdf(filename)
+        meta = f.read_hdf(filename, normalize=False)
         self.assertArrayNear(f.grid, self.sim.grid)
         self.assertArrayNear(f.T, self.sim.T)
         self.assertEqual(meta['description'], desc)

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -694,19 +694,6 @@ cdef class ThermoPhase(_SolutionBase):
             else:
                 self._setArray1(thermo_setMassFractions, Y)
 
-    property Y_no_norm:
-        """
-        Set the unnormalized mass fractions. Can only be set as an array.
-
-             >>> phase.Y = [0.1, 0, -0.1, 0.4, 0, 0, 0, 0, 0.5]
-        """
-        def __set__(self, Y):
-            if len(Y) == self.n_species:
-                self.set_unnormalized_mass_fractions(Y)
-            else:
-                msg = "Got {}. Expected {}".format(len(Y), self.n_species)
-                raise ValueError('Array has incorrect length. ' + msg + '.')
-
     property X:
         """
         Get/Set the species mole fractions. Can be set as an array, as a dictionary,
@@ -727,19 +714,6 @@ cdef class ThermoPhase(_SolutionBase):
                 self.thermo.setMoleFractionsByName(comp_map(X))
             else:
                 self._setArray1(thermo_setMoleFractions, X)
-
-    property X_no_norm:
-        """
-        Set the unnormalized mole fractions. Can only be set as an array.
-
-             >>> phase.X = [0.1, 0, -0.1, 0.4, 0, 0, 0, 0, 0.5]
-        """
-        def __set__(self, X):
-            if len(X) == self.n_species:
-                self.set_unnormalized_mole_fractions(X)
-            else:
-                msg = "Got {}. Expected {}".format(len(X), self.n_species)
-                raise ValueError('Array has incorrect length. ' + msg + '.')
 
     property concentrations:
         """Get/Set the species concentrations [kmol/m^3]."""

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -694,6 +694,19 @@ cdef class ThermoPhase(_SolutionBase):
             else:
                 self._setArray1(thermo_setMassFractions, Y)
 
+    property Y_no_norm:
+        """
+        Set the unnormalized mass fractions. Can only be set as an array.
+
+             >>> phase.Y = [0.1, 0, -0.1, 0.4, 0, 0, 0, 0, 0.5]
+        """
+        def __set__(self, Y):
+            if len(Y) == self.n_species:
+                self.set_unnormalized_mass_fractions(Y)
+            else:
+                msg = "Got {}. Expected {}".format(len(Y), self.n_species)
+                raise ValueError('Array has incorrect length. ' + msg + '.')
+
     property X:
         """
         Get/Set the species mole fractions. Can be set as an array, as a dictionary,
@@ -714,6 +727,19 @@ cdef class ThermoPhase(_SolutionBase):
                 self.thermo.setMoleFractionsByName(comp_map(X))
             else:
                 self._setArray1(thermo_setMoleFractions, X)
+
+    property X_no_norm:
+        """
+        Set the unnormalized mole fractions. Can only be set as an array.
+
+             >>> phase.X = [0.1, 0, -0.1, 0.4, 0, 0, 0, 0, 0.5]
+        """
+        def __set__(self, X):
+            if len(X) == self.n_species:
+                self.set_unnormalized_mole_fractions(X)
+            else:
+                msg = "Got {}. Expected {}".format(len(X), self.n_species)
+                raise ValueError('Array has incorrect length. ' + msg + '.')
 
     property concentrations:
         """Get/Set the species concentrations [kmol/m^3]."""
@@ -1207,6 +1233,20 @@ cdef class ThermoPhase(_SolutionBase):
             self.X = values[2]
             self.thermo.setState_TR(T, D * self._mass_factor())
 
+    property TDY_NoNorm:
+        """
+        Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and unnormalized mass
+        fractions.
+        """
+        def __get__(self):
+            return self.T, self.density, self.Y
+        def __set__(self, values):
+            assert len(values) == 3, 'incorrect number of values'
+            T = values[0] if values[0] is not None else self.T
+            D = values[1] if values[1] is not None else self.density
+            self.Y_no_norm = values[2]
+            self.thermo.setState_TR(T, D * self._mass_factor())
+
     property TDY:
         """
         Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and mass
@@ -1242,6 +1282,17 @@ cdef class ThermoPhase(_SolutionBase):
             self.X = values[2]
             self.thermo.setState_TP(T, P)
 
+    property TPX_NoNorm:
+        """Get/Set temperature [K], pressure [Pa], and unnormalized mole fractions."""
+        def __get__(self):
+            return self.T, self.P, self.X
+        def __set__(self, values):
+            assert len(values) == 3, 'incorrect number of values'
+            T = values[0] if values[0] is not None else self.T
+            P = values[1] if values[1] is not None else self.P
+            self.X_no_norm = values[2]
+            self.thermo.setState_TP(T, P)
+
     property TPY:
         """Get/Set temperature [K], pressure [Pa], and mass fractions."""
         def __get__(self):
@@ -1251,6 +1302,17 @@ cdef class ThermoPhase(_SolutionBase):
             T = values[0] if values[0] is not None else self.T
             P = values[1] if values[1] is not None else self.P
             self.Y = values[2]
+            self.thermo.setState_TP(T, P)
+
+    property TPY_NoNorm:
+        """Get/Set temperature [K], pressure [Pa], and unnormalized mass fractions."""
+        def __get__(self):
+            return self.T, self.P, self.Y
+        def __set__(self, values):
+            assert len(values) == 3, 'incorrect number of values'
+            T = values[0] if values[0] is not None else self.T
+            P = values[1] if values[1] is not None else self.P
+            self.Y_no_norm = values[2]
             self.thermo.setState_TP(T, P)
 
     property UV:

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1233,20 +1233,6 @@ cdef class ThermoPhase(_SolutionBase):
             self.X = values[2]
             self.thermo.setState_TR(T, D * self._mass_factor())
 
-    property TDY_NoNorm:
-        """
-        Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and unnormalized mass
-        fractions.
-        """
-        def __get__(self):
-            return self.T, self.density, self.Y
-        def __set__(self, values):
-            assert len(values) == 3, 'incorrect number of values'
-            T = values[0] if values[0] is not None else self.T
-            D = values[1] if values[1] is not None else self.density
-            self.Y_no_norm = values[2]
-            self.thermo.setState_TR(T, D * self._mass_factor())
-
     property TDY:
         """
         Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and mass
@@ -1282,17 +1268,6 @@ cdef class ThermoPhase(_SolutionBase):
             self.X = values[2]
             self.thermo.setState_TP(T, P)
 
-    property TPX_NoNorm:
-        """Get/Set temperature [K], pressure [Pa], and unnormalized mole fractions."""
-        def __get__(self):
-            return self.T, self.P, self.X
-        def __set__(self, values):
-            assert len(values) == 3, 'incorrect number of values'
-            T = values[0] if values[0] is not None else self.T
-            P = values[1] if values[1] is not None else self.P
-            self.X_no_norm = values[2]
-            self.thermo.setState_TP(T, P)
-
     property TPY:
         """Get/Set temperature [K], pressure [Pa], and mass fractions."""
         def __get__(self):
@@ -1302,17 +1277,6 @@ cdef class ThermoPhase(_SolutionBase):
             T = values[0] if values[0] is not None else self.T
             P = values[1] if values[1] is not None else self.P
             self.Y = values[2]
-            self.thermo.setState_TP(T, P)
-
-    property TPY_NoNorm:
-        """Get/Set temperature [K], pressure [Pa], and unnormalized mass fractions."""
-        def __get__(self):
-            return self.T, self.P, self.Y
-        def __set__(self, values):
-            assert len(values) == 3, 'incorrect number of values'
-            T = values[0] if values[0] is not None else self.T
-            P = values[1] if values[1] is not None else self.P
-            self.Y_no_norm = values[2]
             self.thermo.setState_TP(T, P)
 
     property UV:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

-  `SolutionArray`/ `Flambase` importers allow negative values for mass and mole fractions
- `SolutionArray` appends `Solution` object with unnormalized mass/mole fractions

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number 'SolutionArray truncates negative values' are referenced as #1016 . To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1016 

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

Operating system: Windows 10
Python Version: 3.9.2
Cantera version: 2.6.0a1
```
In [1]: import cantera as ct
   ...: gas = ct.Solution('h2o2.yaml')
   ...: gas.set_unnormalized_mole_fractions(gas.X - 1e-16)
   ...: arr = ct.SolutionArray(gas, 5)

In [2]: arr.X
Out[2]: 
array([[ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16],
       [ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16],
       [ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16],
       [ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16],
       [ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16]])
In [3]: arr.write_hdf('test.h5') # save to HDF
Out[3]: 'group0'

In [4]: gas_new = ct.Solution('h2o2.yaml')
   ...: arr_new = ct.SolutionArray(gas_new)
In [5]: arr_new.read_hdf('test.h5') # load from HDF
   ...: arr_new.X
Out[5]: 
array([[ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16],
       [ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16],
       [ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16],
       [ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16],
       [ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16]])

In[6]: gas1 = ct.Solution('h2o2.yaml')
   ...: states = ct.SolutionArray(gas1)    
   ...: states.append(T=300., P=ct.one_atm, X = gas.X -1.e-16, normalize = False)    
In[7]: states.X
Out[7]:
array([[ 1.e+00, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16, -1.e-16,
        -1.e-16, -1.e-16, -1.e-16]])
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
