### PR TITLE
[Kinetics] Fix issue 717, Add check for sticking coefficient more than 1

### DIFF
--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -221,6 +221,9 @@ void warn_user(const std::string& method, const std::string& msg,
 //! @copydoc Application::make_deprecation_warnings_fatal
 void make_deprecation_warnings_fatal();
 
+//! @copydoc Application::make_warnings_fatal
+void make_warnings_fatal();
+
 //! @copydoc Application::suppress_thermo_warnings
 void suppress_thermo_warnings(bool suppress=true);
 

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -893,6 +893,11 @@ public:
         m_root = root;
     }
 
+    //! Calculate the reaction enthalpy of a reaction which
+    //! has not necessarily been added into the Kinetics object
+    virtual double reactionEnthalpy(const Composition& reactants,
+                                    const Composition& products);
+
 protected:
     //! Cache for saved calculations within each Kinetics object.
     ValueCache m_cache;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -67,6 +67,10 @@ public:
     //! valid.
     virtual void validate();
 
+    //! Perform validation checks that need access to a complete Kinetics objects, for
+    // example to retrieve information about reactant / product species.
+    virtual void validate(Kinetics& kin) {}
+
     //! Return the parameters such that an identical Reaction could be reconstructed
     //! using the newReaction() function. Behavior specific to derived classes is
     //! handled by the getParameters() method.
@@ -197,7 +201,9 @@ public:
     ElementaryReaction2();
     ElementaryReaction2(const Composition& reactants, const Composition products,
                         const Arrhenius& rate);
+
     virtual void validate();
+    using Reaction::validate;
     virtual void getParameters(AnyMap& reactionNode) const;
 
     virtual std::string type() const {
@@ -283,7 +289,9 @@ public:
 
     virtual std::string reactantString() const;
     virtual std::string productString() const;
+
     virtual void validate();
+    using Reaction::validate;
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
 
@@ -347,6 +355,7 @@ public:
     }
 
     virtual void validate();
+    using Reaction::validate;
     virtual void getParameters(AnyMap& reactionNode) const;
 
     Plog rate;
@@ -396,6 +405,9 @@ public:
                       const Arrhenius& rate, bool isStick=false);
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
+
+    virtual void validate(Kinetics& kin);
+    using Reaction::validate;
 
     virtual std::string type() const {
         return "interface";
@@ -450,6 +462,7 @@ public:
     virtual void getParameters(AnyMap& reactionNode) const;
     virtual void validate();
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
+    virtual void validate(Kinetics& kin);
 
     virtual std::string type() const {
         return "surface-Blowers-Masel";
@@ -717,5 +730,4 @@ void setupElectrochemicalReaction(ElectrochemicalReaction&,
 void setupBlowersMaselInterfaceReaction(BlowersMaselInterfaceReaction&,
                                         const AnyMap&, const Kinetics&);
 }
-
 #endif

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -131,6 +131,7 @@ cdef extern from "cantera/base/global.h" namespace "Cantera":
     cdef XML_Node* CxxGetXmlFile "Cantera::get_XML_File" (string) except +translate_exception
     cdef XML_Node* CxxGetXmlFromString "Cantera::get_XML_from_string" (string) except +translate_exception
     cdef void Cxx_make_deprecation_warnings_fatal "Cantera::make_deprecation_warnings_fatal" ()
+    cdef void Cxx_make_warnings_fatal "Cantera::make_warnings_fatal" ()
     cdef void Cxx_suppress_deprecation_warnings "Cantera::suppress_deprecation_warnings" ()
     cdef void Cxx_suppress_thermo_warnings "Cantera::suppress_thermo_warnings" (cbool)
     cdef void Cxx_use_legacy_rate_constants "Cantera::use_legacy_rate_constants" (cbool)

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -470,6 +470,23 @@ class KineticsRepeatability(utilities.CanteraTest):
             for msg in err_msg:
                 self.assertIn(msg, err_msg_list)
 
+    def test_sticking_coeff_err(self):
+        err_msg = ("Sticking coefficient is greater than 1 for reaction \'O2 \+ 2 PT\(S\) => 2 O\(S\)\'",
+                   "at T = 200.0",
+                   "at T = 500.0",
+                   "at T = 1000.0",
+                   "at T = 2000.0",
+                   "at T = 5000.0",
+                   "at T = 10000.0",
+                   "Sticking coefficient is greater than 1 for reaction",
+                   "CanteraError thrown by InterfaceReaction::validate:",
+                   "CanteraError thrown by BlowersMaselInterfaceReaction::validate:"
+                   )
+        ct.make_warnings_fatal()
+        for err in err_msg:
+            with self.assertRaisesRegex(ct.CanteraError, err):
+                gas = ct.Solution('sticking_coeff_check.yaml')
+                surface = ct.Interface('sticking_coeff_check.yaml', 'Pt_surf', [gas])
 
 class TestUndeclared(utilities.CanteraTest):
 

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -70,6 +70,9 @@ def make_deprecation_warnings_fatal():
                             message='.*Cantera.*')  # for warnings in Cython code
     Cxx_make_deprecation_warnings_fatal()
 
+def make_warnings_fatal():# for warnings in Cython code
+    Cxx_make_warnings_fatal()
+
 def suppress_deprecation_warnings():
     warnings.filterwarnings('ignore', category=DeprecationWarning,
                             module='cantera')  # for warnings in Python code

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -127,6 +127,7 @@ Application::Application() :
     m_suppress_deprecation_warnings(false),
     m_fatal_deprecation_warnings(false),
     m_suppress_thermo_warnings(false),
+    m_fatal_warnings(false),
 #if CT_LEGACY_RATE_CONSTANTS
     m_use_legacy_rate_constants(true)
 #else
@@ -182,6 +183,9 @@ void Application::warn_deprecated(const std::string& method,
 void Application::warn_user(const std::string& method,
                             const std::string& extra)
 {
+    if (m_fatal_warnings) {
+        throw CanteraError(method, extra);
+    }
     writelog(fmt::format("CanteraWarning: {}: {}", method, extra));
     writelogendl();
 }

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -354,6 +354,12 @@ public:
     //! information can be specified in *extra*.
     void warn_user(const std::string& method, const std::string& extra="");
 
+    //! Turns Cantera warnings into exceptions. Activated within the test
+    //! suite to make sure that your warning message are being raised.
+    void make_warnings_fatal() {
+        m_fatal_warnings = true;
+    }
+
     //! Globally disable printing of warnings about problematic thermo data,
     //! e.g. NASA polynomials with discontinuities at the midpoint temperature.
     void suppress_thermo_warnings(bool suppress=true) {
@@ -453,6 +459,7 @@ protected:
     bool m_suppress_deprecation_warnings;
     bool m_fatal_deprecation_warnings;
     bool m_suppress_thermo_warnings;
+    bool m_fatal_warnings;
     bool m_use_legacy_rate_constants;
 
     ThreadMessages pMessenger;

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -71,6 +71,11 @@ void make_deprecation_warnings_fatal()
     app()->make_deprecation_warnings_fatal();
 }
 
+void make_warnings_fatal()
+{
+    app()->make_warnings_fatal();
+}
+
 void suppress_thermo_warnings(bool suppress)
 {
     app()->suppress_thermo_warnings(suppress);

--- a/test/data/sticking_coeff_check.yaml
+++ b/test/data/sticking_coeff_check.yaml
@@ -1,0 +1,56 @@
+units: {length: cm, quantity: mol, activation-energy: J/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [O, H, C, N, Ar]
+  species:
+  - gri30.yaml/species: [ O2, OH]
+  skip-undeclared-elements: true
+  kinetics: gas
+  reactions:
+  - gri30.yaml/reactions: declared-species
+  transport: mixture-averaged
+- name: Pt_surf
+  thermo: ideal-surface
+  elements: [Pt, H, O, C]
+  species: [{Pt-surf-species: all}]
+  kinetics: surface
+  reactions: [Pt-reactions]
+
+Pt-surf-species:
+- name: PT(S)
+  composition: {Pt: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 3000.0]
+    data:
+    - [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+    - [0.0, 0.0, 0.0, 0.0, 0.0, 0.0, 0.0]
+- name: OH(S)
+  composition: {O: 1, H: 1, Pt: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 3000.0]
+    data:
+    - [-2.0340881, 9.3662683e-03, 6.6275214e-07, -5.2074887e-09, 1.7088735e-12,
+      -2.5319949e+04, 8.9863186]
+    - [1.8249973, 3.2501565e-03, -3.1197541e-07, -3.4603206e-10, 7.9171472e-14,
+      -2.6685492e+04, -12.280891]
+- name: O(S)
+  composition: {O: 1, Pt: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 3000.0]
+    data:
+    - [-0.94986904, 7.4042305e-03, -1.0451424e-06, -6.112042e-09, 3.3787992e-12,
+      -1.3209912e+04, 3.6137905]
+    - [1.945418, 9.1761647e-04, -1.1226719e-07, -9.9099624e-11, 2.4307699e-14,
+      -1.4005187e+04, -11.531663]
+
+Pt-reactions:
+- equation: O2 + 2 PT(S) => 2 O(S)  # Reaction 1
+  sticking-coefficient: {A: 2.0, b: 0, Ea: 0}
+- equation: OH + PT(S) => OH(S)  # Reaction 2
+  type: Blowers-Masel
+  sticking-coefficient: {A: 2.0, b: 0, Ea0: 0, w: 100000}


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- This pull request fixes issue #717, which checks if the sticking coefficient gamma is more than 1.  The check is conducted at
6 different temperature points from 200K to 10000K for `InterfaceReaction` and `BlowersMaselInterfaceReaction`. Any temperature point with sticking coefficient more than 1 will be added into error message. 

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #717 

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
