### PR TITLE
Pass *_NUM_THREADS through SCons environment

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -216,6 +216,8 @@ jobs:
   multiple-sundials:
     name: Sundials ${{ matrix.sundials-ver }}
     runs-on: ubuntu-latest
+    env:
+      OPENBLAS_NUM_THREADS: "1"
     defaults:
       run:
         shell: bash -l {0}

--- a/SConstruct
+++ b/SConstruct
@@ -335,7 +335,7 @@ else:
     defaults.versionedSharedLibrary = True
 
 defaults.fsLayout = 'compact' if env['OS'] == 'Windows' else 'standard'
-defaults.env_vars = 'PATH,LD_LIBRARY_PATH,PYTHONPATH'
+defaults.env_vars = "PATH,LD_LIBRARY_PATH,PYTHONPATH,*_NUM_THREADS"
 
 defaults.python_prefix = '$prefix' if env['OS'] != 'Windows' else ''
 
@@ -738,6 +738,12 @@ elif env['env_vars']:
                 env['ENV'][name] = os.environ[name]
             if env['VERBOSE']:
                 print('Propagating environment variable {0}={1}'.format(name, env['ENV'][name]))
+        elif name == "*_NUM_THREADS":
+            r = re.compile("^." + name)
+            for n in filter(r.match, os.environ.keys()):
+                env['ENV'][n] = os.environ[n]
+                if env['VERBOSE']:
+                    print('Propagating environment variable {0}={1}'.format(n, env['ENV'][n]))
         elif name not in defaults.env_vars.split(','):
             print('WARNING: failed to propagate environment variable', repr(name))
             print('         Edit cantera.conf or the build command line to fix this.')

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -437,6 +437,8 @@ class TestReactor(utilities.CanteraTest):
         self.assertNear(U2a + Q, U2b, 1e-6)
 
     def test_mass_flow_controller(self):
+        import os
+        self.assertEqual(os.environ["OPENBLAS_NUM_THREADS"], "1")
         self.make_reactors(n_reactors=1)
         gas2 = ct.Solution('h2o2.yaml', transport_model=None)
         gas2.TPX = 300, 10*101325, 'H2:1.0'


### PR DESCRIPTION
**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Pass any environment variables that match the regex `^.*_NUM_THREADS` through to the SCons environment. This behavior is enabled by default, by specifying `*_NUM_THREADS` in `defaults.env_vars`. I wasn't sure whether to put the complete regex into the defaults, or leave it as the pseudo-regex syntax, so I left it as the latter. The passthrough behavior is only enabled if the string is exactly `*_NUM_THREADS`.
- Disable multithreading with OpenBLAS

**If applicable, fill in the issue number this pull request is fixing**

Closes #1033, Alternative to #1035

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
