### PR TITLE
Make test_mass_flow_controller more robust

### DIFF
--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -443,7 +443,13 @@ class TestReactor(utilities.CanteraTest):
         reservoir = ct.Reservoir(gas2)
 
         mfc = ct.MassFlowController(reservoir, self.r1)
-        mfc.mass_flow_rate = lambda t: 0.1 if 0.2 <= t < 1.2 else 0.0
+        # Triangular pulse with area = 0.1
+        def mdot(t):
+            if 0.2 <= t < 1.2:
+                return 0.2 - 0.4 * abs(t - 0.7)
+            else:
+                return 0.0
+        mfc.mass_flow_rate = mdot
         self.assertEqual(mfc.mass_flow_coeff, 1.)
 
         self.assertEqual(mfc.type, type(mfc).__name__)
@@ -462,10 +468,10 @@ class TestReactor(utilities.CanteraTest):
 
         self.net.advance(0.1)
         self.assertNear(mfc.mass_flow_rate, 0.)
-        self.net.advance(0.2)
-        self.assertNear(mfc.mass_flow_rate, 0.1)
-        self.net.advance(1.1)
-        self.assertNear(mfc.mass_flow_rate, 0.1)
+        self.net.advance(0.3)
+        self.assertNear(mfc.mass_flow_rate, 0.04)
+        self.net.advance(1.0)
+        self.assertNear(mfc.mass_flow_rate, 0.08)
         self.net.advance(1.2)
         self.assertNear(mfc.mass_flow_rate, 0.)
 

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -442,6 +442,13 @@ class TestReactor(utilities.CanteraTest):
         gas2.TPX = 300, 10*101325, 'H2:1.0'
         reservoir = ct.Reservoir(gas2)
 
+        # Apply a mass flow rate that is not a smooth function of time. This
+        # demonstrates the accuracy that can be achieved by having the mass flow rate
+        # evaluated simultaneously with the rest of the governing equations, as opposed
+        # to doing only between integrator time steps. In the latter case, larger
+        # errors would be introduced when the integrator steps past the times where the
+        # function's behavior changes and can't dynamically reduce the steps size for
+        # the already-completed steps.
         mfc = ct.MassFlowController(reservoir, self.r1)
         # Triangular pulse with area = 0.1
         def mdot(t):


### PR DESCRIPTION

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

This is an alternative to #1035 and #1039.

As I noted in #1033, this test is (deliberately) somewhat rough on the ODE solver. We are providing a mass flow rate function that's a square wave, so it has detect that it's not resolving something at the point where the square wave switches and (repeatedly) reduce the timestep.

This change modifies the test so that the imposed mass flow rate is at least continuous, if not smooth (we still want the ODE solver to have _something_ to chew on). I ran the GH Actions for this 4 times and haven't seen a failure yet, so I think this may be a more reliable solution than getting into a fight with OpenBLAS.

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Replace square wave mass flow rate with triangle wave in test_mass_flow_controller

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1033

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
