### PR TITLE
Proof-of-concept: Modify reaction rates in memory

### DIFF
--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -72,10 +72,17 @@ public:
         return m_A;
     }
 
+    //! Set the pre-exponential factor *A* (in m, kmol, s to powers depending
+    //! on the reaction order)
+    void setPreExponentialFactor(double A);
+
     //! Return the temperature exponent *b*
     double temperatureExponent() const {
         return m_b;
     }
+
+    //! Set the temperature exponent *b*
+    void setTemperatureExponent(double b);
 
     //! Return the intrinsic activation energy *Ea* [J/kmol]
     //! The value corresponds to the constant specified by input parameters;
@@ -83,6 +90,9 @@ public:
     double intrinsicActivationEnergy() const {
         return m_Ea_R * GasConstant;
     }
+
+    //! Set the activation energy *Ea* [J/kmol]
+    void setIntrinsicActivationEnergy(double Ea);
 
     // Return units of the reaction rate expression
     const Units& rateUnits() const {
@@ -188,6 +198,11 @@ public:
     //! Return the activation energy *Ea* [J/kmol]
     double activationEnergy() const {
         return m_Ea_R * GasConstant;
+    }
+
+    //! Set the activation energy *Ea* [J/kmol]
+    void setActivationEnergy(double Ea) {
+        setIntrinsicActivationEnergy(Ea);
     }
 
     //! Return the activation energy divided by the gas constant (i.e. the

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -152,8 +152,8 @@ public:
         setParameters(node, rate_units);
     }
 
-    unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<ArrheniusRate, ArrheniusData>);
+    shared_ptr<MultiRateBase> newMultiRate() const override {
+        return shared_ptr<MultiRateBase>(new MultiBulkRate<ArrheniusRate, ArrheniusData>);
     }
 
     //! Identifier of reaction rate type
@@ -231,8 +231,8 @@ public:
      */
     TwoTempPlasmaRate(double A, double b, double Ea, double EE);
 
-    unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(
+    shared_ptr<MultiRateBase> newMultiRate() const override {
+        return shared_ptr<MultiRateBase>(
             new MultiBulkRate<TwoTempPlasmaRate, TwoTempPlasmaData>);
     }
 
@@ -340,8 +340,8 @@ public:
      */
     BlowersMaselRate(double A, double b, double Ea0, double w);
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(
+    shared_ptr<MultiRateBase> newMultiRate() const {
+        return shared_ptr<MultiRateBase>(
             new MultiBulkRate<BlowersMaselRate, BlowersMaselData>);
     }
 

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -55,7 +55,7 @@ protected:
     virtual void modifyElementaryReaction(size_t i, ElementaryReaction2& rNew);
 
     //! Vector of rate handlers
-    std::vector<unique_ptr<MultiRateBase>> m_bulk_rates;
+    std::vector<shared_ptr<MultiRateBase>> m_bulk_rates;
     std::map<std::string, size_t> m_bulk_types; //!< Mapping of rate handlers
 
     Rate1<Arrhenius> m_rates; //!< @deprecated (legacy only)

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -43,8 +43,8 @@ public:
         setParameters(node, rate_units);
     }
 
-    unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<CustomFunc1Rate, ArrheniusData>);
+    shared_ptr<MultiRateBase> newMultiRate() const override {
+        return shared_ptr<MultiRateBase>(new MultiBulkRate<CustomFunc1Rate, ArrheniusData>);
     }
 
     const std::string type() const override { return "custom-rate-function"; }

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -242,8 +242,8 @@ public:
         setFalloffCoeffs(c);
     }
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(
+    shared_ptr<MultiRateBase> newMultiRate() const {
+        return shared_ptr<MultiRateBase>(
             new MultiBulkRate<LindemannRate, FalloffData>);
     }
 
@@ -303,8 +303,8 @@ public:
         setFalloffCoeffs(c);
     }
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<TroeRate, FalloffData>);
+    shared_ptr<MultiRateBase> newMultiRate() const {
+        return shared_ptr<MultiRateBase>(new MultiBulkRate<TroeRate, FalloffData>);
     }
 
     //! Set coefficients used by parameterization
@@ -405,8 +405,8 @@ public:
         setFalloffCoeffs(c);
     }
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<SriRate, FalloffData>);
+    shared_ptr<MultiRateBase> newMultiRate() const {
+        return shared_ptr<MultiRateBase>(new MultiBulkRate<SriRate, FalloffData>);
     }
 
     //! Set coefficients used by parameterization
@@ -515,8 +515,8 @@ public:
         setFalloffCoeffs(c);
     }
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<TsangRate, FalloffData>);
+    shared_ptr<MultiRateBase> newMultiRate() const {
+        return shared_ptr<MultiRateBase>(new MultiBulkRate<TsangRate, FalloffData>);
     }
 
     //! Set coefficients used by parameterization

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -96,6 +96,10 @@ public:
         m_shared.invalidateCache();
     }
 
+    virtual void invalidateCache() override {
+        m_shared.invalidateCache();
+    }
+
     virtual ReactionRate& rate(size_t rxn_index) override {
         size_t j = m_indices[rxn_index];
         return dynamic_cast<ReactionRate&>(m_rxn_rates.at(j).second);

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -39,17 +39,21 @@ public:
     //! Add reaction rate object to the evaluator
     //! @param rxn_index  index of reaction
     //! @param rate  reaction rate object
-    virtual void add(size_t rxn_index, ReactionRate& rate) = 0;
+    virtual void add(size_t rxn_index, shared_ptr<ReactionRate>& rate) = 0;
 
     //! Replace reaction rate object handled by the evaluator
     //! @param rxn_index  index of reaction
     //! @param rate  reaction rate object
-    virtual bool replace(size_t rxn_index, ReactionRate& rate) = 0;
+    virtual bool replace(size_t rxn_index, shared_ptr<ReactionRate>& rate) = 0;
 
     //! Update number of species and reactions
     //! @param n_species  number of species
     //! @param n_reactions  number of reactions
     virtual void resize(size_t n_species, size_t n_reactions) = 0;
+
+    //! Access reaction rate object handled by evaluator
+    //! @param rxn_index  index of reaction
+    virtual ReactionRate& rate(size_t rxn_index) = 0;
 
     //! Evaluate all rate constants handled by the evaluator
     //! @param kf  array of rate constants

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -51,6 +51,9 @@ public:
     //! @param n_reactions  number of reactions
     virtual void resize(size_t n_species, size_t n_reactions) = 0;
 
+    //! Force shared data and reaction rates to be updated next time
+    virtual void invalidateCache() = 0;
+
     //! Access reaction rate object handled by evaluator
     //! @param rxn_index  index of reaction
     virtual ReactionRate& rate(size_t rxn_index) = 0;

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -134,7 +134,9 @@ public:
     //! Kinetics reaction rate evaluators.
     double eval(double T) {
         _evaluator().update(T);
-        return _evaluator().evalSingle(*this);
+        double ret = _evaluator().evalSingle(*this);
+        _evaluator().invalidateCache();
+        return ret;
     }
 
     //! Evaluate reaction rate based on temperature and an extra parameter.
@@ -147,7 +149,9 @@ public:
     //! Kinetics reaction rate evaluators.
     double eval(double T, double extra) {
         _evaluator().update(T, extra);
-        return _evaluator().evalSingle(*this);
+        double ret = _evaluator().evalSingle(*this);
+        _evaluator().invalidateCache();
+        return ret;
     }
 
 protected:

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -109,6 +109,24 @@ public:
         m_rate_index = idx;
     }
 
+    //! Return boolean indicating whether reaction rate object is linked to
+    //! a MultiRateBase evaluator
+    bool linked() {
+        return m_rate_index != npos;
+    }
+
+    //! Link reaction to MultiRateBase evaluator
+    void linkEvaluator(size_t index, const shared_ptr<MultiRateBase> evaluator) {
+        m_rate_index = index;
+        m_evaluator = evaluator;
+    }
+
+    //! Release (unlink) reaction from MultiRateBase evaluator
+    void releaseEvaluator() {
+        m_rate_index = npos;
+        m_evaluator.reset();
+    }
+
     //! Evaluate reaction rate based on temperature
     //! @param T  temperature [K]
     //! Used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
@@ -159,6 +177,7 @@ private:
         return *m_evaluator;
     }
 
+protected:
     shared_ptr<MultiRateBase> m_evaluator;
 };
 

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -63,13 +63,13 @@ public:
     //! Derived classes usually implement this as:
     //!
     //! ```.cpp
-    //! unique_ptr<MultiRateBase> newMultiRate() const override {
-    //!     return unique_ptr<MultiRateBase>(new MultiBulkRate<RateType, DataType>);
+    //! shared_ptr<MultiRateBase> newMultiRate() const override {
+    //!     return shared_ptr<MultiRateBase>(new MultiBulkRate<RateType, DataType>);
     //! ```
     //!
     //! where `RateType` is the derived class name and `DataType` is the corresponding
     //! container for parameters needed to evaluate reactions of that type.
-    virtual unique_ptr<MultiRateBase> newMultiRate() const = 0;
+    virtual shared_ptr<MultiRateBase> newMultiRate() const = 0;
 
     virtual const std::string type() const = 0;
 
@@ -159,7 +159,7 @@ private:
         return *m_evaluator;
     }
 
-    unique_ptr<MultiRateBase> m_evaluator;
+    shared_ptr<MultiRateBase> m_evaluator;
 };
 
 }

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -94,7 +94,7 @@ public:
     }
 
     // The following methods are unused but required by the base class
-    unique_ptr<MultiRateBase> newMultiRate() const {
+    shared_ptr<MultiRateBase> newMultiRate() const {
         throw NotImplementedError("Arrhenius2::newMultiRate");
     }
 
@@ -146,7 +146,7 @@ public:
 
     BlowersMasel2(double A, double b, double E0, double w);
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
+    shared_ptr<MultiRateBase> newMultiRate() const {
         throw NotImplementedError("BlowersMasel2::newMultiRate");
     }
 
@@ -348,8 +348,8 @@ public:
         setParameters(node, rate_units);
     }
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<PlogRate, PlogData>);
+    shared_ptr<MultiRateBase> newMultiRate() const {
+        return shared_ptr<MultiRateBase>(new MultiBulkRate<PlogRate, PlogData>);
     }
 
     //! Identifier of reaction rate type
@@ -550,8 +550,8 @@ public:
         setParameters(node, rate_units);
     }
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(
+    shared_ptr<MultiRateBase> newMultiRate() const {
+        return shared_ptr<MultiRateBase>(
             new MultiBulkRate<ChebyshevRate3, ChebyshevData>);
     }
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -454,8 +454,11 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxArrheniusBase(double, double, double)
         double eval(double) except +translate_exception
         double preExponentialFactor()
+        void setPreExponentialFactor(double)
         double temperatureExponent()
+        void setTemperatureExponent(double)
         double intrinsicActivationEnergy()
+        void setIntrinsicActivationEnergy(double)
 
     cdef cppclass CxxArrhenius2 "Cantera::Arrhenius2" (CxxArrheniusBase):
         CxxArrhenius2(double, double, double)
@@ -476,6 +479,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double activationEnergy()
         cbool allowNegativePreExponentialFactor()
         void setAllowNegativePreExponentialFactor(bool)
+        void setActivationEnergy(double)
 
     cdef cppclass CxxTwoTempPlasmaRate "Cantera::TwoTempPlasmaRate" (CxxReactionRate, CxxArrheniusBase):
         CxxTwoTempPlasmaRate()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -471,6 +471,8 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double eval(double) except +translate_exception
         double eval(double, double) except +translate_exception
         CxxAnyMap parameters() except +translate_exception
+        cbool linked()
+        void releaseEvaluator()
 
     cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxReactionRate, CxxArrheniusBase):
         CxxArrheniusRate()

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -248,6 +248,11 @@ cdef class _SolutionBase:
         if not kinetics:
             kinetics = "none"
 
+        for r in reactions:
+            if not r.uses_legacy and r.rate._linked:
+                # release link to MultiRate evaluator
+                r.rate._release_evaluator()
+
         cdef ThermoPhase phase
         cdef Reaction reaction
         if isinstance(self, Kinetics):

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -157,6 +157,8 @@ cdef class ArrheniusRate(ReactionRate):
         The pre-exponential factor ``A`` in units of m, kmol, and s raised to
         powers depending on the reaction order.
         """
+        def __set__(self, float A):
+            self.cxx_object().setPreExponentialFactor(A)
         def __get__(self):
             return self.cxx_object().preExponentialFactor()
 
@@ -164,13 +166,17 @@ cdef class ArrheniusRate(ReactionRate):
         """
         The temperature exponent ``b``.
         """
+        def __set__(self, float b):
+            self.cxx_object().setTemperatureExponent(b)
         def __get__(self):
             return self.cxx_object().temperatureExponent()
 
     property activation_energy:
         """
-        The activation energy ``E`` [J/kmol].
+        The activation energy ``Ea`` [J/kmol].
         """
+        def __set__(self, float Ea):
+            self.cxx_object().setActivationEnergy(Ea)
         def __get__(self):
             return self.cxx_object().activationEnergy()
 

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -33,6 +33,15 @@ cdef class ReactionRate:
         def __get__(self):
             return pystr(self.rate.type())
 
+    property _linked:
+        """Return boolean indicating whether rate object is linked to a Kinetics object"""
+        def __get__(self):
+            return pybool(self.rate.linked())
+
+    def _release_evaluator(self):
+        """Release rate object from evaluator"""
+        self.rate.releaseEvaluator()
+
     @staticmethod
     cdef wrap(shared_ptr[CxxReactionRate] rate):
         """

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1491,7 +1491,7 @@ class TestReaction(utilities.CanteraTest):
         r2 = gas.reaction(53)
         self.assertEqual(r2.rate.type, "Troe")
         self.assertEqual(r1.efficiencies, r2.efficiencies)
-        r2.rate = r1.rate
+        r2.rate = ct.ReactionRate.from_dict(r1.rate.input_data)
 
         gas.modify_reaction(53, r2)
         kf = gas.forward_rate_constants

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -116,6 +116,40 @@ void ArrheniusBase::check(const std::string& equation, const AnyMap& node)
     }
 }
 
+void ArrheniusBase::setPreExponentialFactor(double A)
+{
+    m_A = A;
+    if (!m_evaluator || !linked()) {
+        return;
+    }
+    dynamic_cast<ArrheniusBase&>(
+        m_evaluator->rate(m_rate_index)).setPreExponentialFactor(A);
+    m_evaluator->invalidateCache();
+}
+
+void ArrheniusBase::setTemperatureExponent(double b)
+{
+    m_b = b;
+    if (!m_evaluator || !linked()) {
+        return;
+    }
+    dynamic_cast<ArrheniusBase&>(
+        m_evaluator->rate(m_rate_index)).setTemperatureExponent(b);
+    m_evaluator->invalidateCache();
+}
+
+void ArrheniusBase::setIntrinsicActivationEnergy(double Ea)
+{
+    m_Ea_R = Ea / GasConstant;
+    if (!m_evaluator || !linked()) {
+        return;
+    }
+    dynamic_cast<ArrheniusBase&>(
+        m_evaluator->rate(m_rate_index)).setIntrinsicActivationEnergy(Ea);
+    m_evaluator->invalidateCache();
+}
+
+
 void ArrheniusRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
 {
     m_negativeA_ok = node.getBool("negative-A", false);

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -141,12 +141,13 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
             m_bulk_rates.back()->resize(m_kk, nReactions());
         }
 
-        // Set index of rate to number of reaction within kinetics
-        rate->setRateIndex(nReactions() - 1);
-
         // Add reaction rate to evaluator
+        size_t rxn_index = nReactions() - 1;
         size_t index = m_bulk_types[rate->type()];
-        m_bulk_rates[index]->add(nReactions() - 1, *rate);
+        m_bulk_rates[index]->add(rxn_index, rate);
+
+        // Set index of rate to number of reaction within kinetics
+        rate->linkEvaluator(rxn_index, m_bulk_rates[index]);
 
         // Add reaction to third-body evaluator
         if (r->thirdBody() != nullptr) {
@@ -193,13 +194,13 @@ void BulkKinetics::modifyReaction(size_t i, shared_ptr<Reaction> rNew)
         // Ensure that MultiBulkRate evaluator is available
         if (m_bulk_types.find(rate->type()) == m_bulk_types.end()) {
             throw CanteraError("BulkKinetics::modifyReaction",
-                 "Evaluator not available for type '{}'.", rate->type());
+                "Evaluator not available for type '{}'.", rate->type());
         }
 
         // Replace reaction rate to evaluator
         size_t index = m_bulk_types[rate->type()];
-        rNew->rate()->setRateIndex(i);
-        m_bulk_rates[index]->replace(i, *rate);
+        m_bulk_rates[index]->replace(i, rate);
+        rate->linkEvaluator(i, m_bulk_rates[index]);
     }
 }
 

--- a/test/general/test_serialization.cpp
+++ b/test/general/test_serialization.cpp
@@ -281,6 +281,7 @@ TEST(YamlWriter, multipleReactionSections)
     // this phase will require its own "reactions" section
     auto R = original3->kinetics()->reaction(3);
     R->duplicate = true;
+    R->rate()->releaseEvaluator(); // unlink from kinetics object
     original3->kinetics()->addReaction(R);
     original2->setName("ohmech2");
     original3->setName("ohmech3");


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR builds on #995 ~(and will be rebased once #995 is merged, i.e. 80ish commits are not specific to this PR)~.

- Allow for modifications of rate parameters without having to 'modify' reactions
- Proof-of-concept implemented for `ArrheniusRate`

Addresses Cantera/enhancements#87.

**If applicable, provide an example illustrating new features this pull request is introducing**

```
In [1]: import cantera as ct
   ...: rxn = gas.reaction(0)
   ...: rxn
Out[1]: <ElementaryReaction: H2 + O <=> H + OH>

In [2]: gas.forward_rate_constants
Out[2]: 
array([5.19544737e+03, 1.34865000e+07, 2.55079922e+09, 4.25372812e+01,
       5.48180502e+06, 0.00000000e+00, 3.00385071e-09, 3.82748853e+09,
       5.81796100e+17, 1.93894637e+14, 9.91318424e+06])

In [3]: A = rxn.rate.pre_exponential_factor
   ...: A
Out[3]: 38.7

In [4]: rxn.rate.pre_exponential_factor = 2 * A
   ...: gas.reaction(0).rate.pre_exponential_factor
Out[4]: 77.4000015258789

In [5]: gas.forward_rate_constants
Out[5]: 
array([1.03908950e+04, 1.34865000e+07, 2.55079922e+09, 4.25372812e+01,
       5.48180502e+06, 0.00000000e+00, 3.00385071e-09, 3.82748853e+09,
       5.81796100e+17, 1.93894637e+14, 9.91318424e+06])
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
