### PR TITLE
[SCons] Fix type reference and missing import

### DIFF
--- a/interfaces/python_minimal/SConscript
+++ b/interfaces/python_minimal/SConscript
@@ -1,5 +1,5 @@
 """Minimal Python Module"""
-from os.path import join as pjoin
+from os.path import join as pjoin, normpath
 from buildutils import *
 
 Import('env', 'build', 'install')

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -838,7 +838,7 @@ def get_spawn(env: "SCEnvironment"):
     if "cmd.exe" not in env["SHELL"] or env.subst("$CXX") == "cl":
         return env["SPAWN"]
 
-    def our_spawn(sh: str, escape: str, cmd: str, args: str, environ: Dict[str, str]):
+    def our_spawn(sh: str, escape: str, cmd: str, args: str, environ: "Dict[str, str]"):
         newargs = " ".join(args[1:])
         cmdline = cmd + " " + newargs
         startupinfo = subprocess.STARTUPINFO()  # type: ignore


### PR DESCRIPTION
In #1012, normapth was no longer exported from buildutils, but I missed
adding that import in the builder for python_minimal. In addition, Dict
is only available while type checking in buildutils, so it should be
quoted as a forward reference.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
