### PR TITLE
Update apt repositories before installing dependencies

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -34,7 +34,9 @@ jobs:
         python-version: ${{ matrix.python-version }}
         architecture: x64
     - name: Install Apt dependencies
-      run: sudo apt-get install libboost-dev gfortran
+      run: |
+        sudo apt update
+        sudo apt install libboost-dev gfortran
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
@@ -106,7 +108,8 @@ jobs:
         architecture: x64
     - name: Install Apt dependencies
       run: |
-        sudo apt-get install libboost-dev gfortran liblapack-dev libblas-dev libsundials-dev
+        sudo apt update
+        sudo apt install libboost-dev gfortran liblapack-dev libblas-dev libsundials-dev
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
@@ -141,7 +144,9 @@ jobs:
           python-version: '3.8'
           architecture: x64
       - name: Install Apt dependencies
-        run: sudo apt-get install libboost-dev doxygen graphviz
+        run: |
+          sudo apt update
+          sudo apt install libboost-dev doxygen graphviz
       - name: Upgrade pip
         run: python3 -m pip install -U pip setuptools wheel
       - name: Install Python dependencies
@@ -189,7 +194,9 @@ jobs:
           python-version: ${{ matrix.python-version }}
           architecture: x64
       - name: Install Apt dependencies
-        run: sudo apt-get install libboost-dev gfortran graphviz liblapack-dev libblas-dev
+        run: |
+          sudo apt update
+          sudo apt install libboost-dev gfortran graphviz liblapack-dev libblas-dev
       - name: Upgrade pip
         run: python3 -m pip install -U pip setuptools wheel
       - name: Install Python dependencies
@@ -262,7 +269,9 @@ jobs:
         python-version: '3.8'
         architecture: x64
     - name: Install Apt dependencies
-      run: sudo apt-get install libboost-dev liblapack-dev libblas-dev
+      run: |
+        sudo apt update
+        sudo apt install libboost-dev liblapack-dev libblas-dev
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies


### PR DESCRIPTION
This should fix some transient CI failures (e.g. #995) when package versions are removed from the remote repositories.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Run `apt update` before `apt install ...`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1055

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
