### PR TITLE
Make Fortran compiler and options consistent

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1147,6 +1147,10 @@ else: # env['system_sundials'] == 'n'
     env['sundials_version'] = '5.3'
     env['has_sundials_lapack'] = int(env['use_lapack'])
 
+def set_fortran(pattern, value):
+    # Set compiler / flags for all Fortran versions to be the same
+    for version in ("FORTRAN", "F77", "F90", "F95", "F03", "F08"):
+        env[pattern.format(version)] = value
 
 # Try to find a working Fortran compiler:
 def check_fortran(compiler, expected=False):
@@ -1156,7 +1160,7 @@ program main
 end program main
     '''
     if which(compiler):
-        env['F77'] = env['F90'] = env['F95'] = env['F03'] = env['FORTRAN'] = compiler
+        set_fortran("{}", compiler)
         success, output = conf.TryRun(hello_world, '.f90')
         if success and 'Hello, world!' in output:
             return True
@@ -1170,7 +1174,7 @@ end program main
 
     return False
 
-env['F77FLAGS'] = env['F90FLAGS'] = env['F95FLAGS'] = env['F03FLAGS'] = env['FORTRANFLAGS']
+set_fortran("{}FLAGS", env["FORTRANFLAGS"])
 
 if env['f90_interface'] in ('y','default'):
     foundF90 = False
@@ -1203,8 +1207,8 @@ elif 'g95' in env['FORTRAN']:
 elif 'ifort' in env['FORTRAN']:
     env['FORTRANMODDIRPREFIX'] = '-module '
 
-env['F77'] = env['F90'] = env['F95'] = env['F03'] = env['FORTRAN']
-
+set_fortran("{}", env["FORTRAN"])
+set_fortran("SH{}", env["FORTRAN"])
 env['FORTRANMODDIR'] = '${TARGET.dir}'
 
 env = conf.Finish()


### PR DESCRIPTION
In some cases, the setting of "SHF90" (the compiler to use for compiling shared objects from F90 code) does not inherit the setting of "F90" (the compiler to use for compiling normal objects from F90 code). For example, see the following extract from `scons dump` from [this Users' Group post](https://groups.google.com/g/cantera-users/c/iLEUj8A-u8E).
```
  'F03': 'gfortran',
  'F03FLAGS': '-O3',
  'F08': 'gfortran',
  'F08FLAGS': [],
  'F77': 'gfortran',
  'F77FLAGS': '-O3',
  'F90': 'gfortran',
  'F90FLAGS': '-O3',
  'F95': 'gfortran',
  'F95FLAGS': '-O3',
  'SHF03': '$F03',
  'SHF03FLAGS': ['$F03FLAGS'],
  'SHF08': '$F08',
  'SHF08FLAGS': ['$F08FLAGS'],
  'SHF77': '$F77',
  'SHF77FLAGS': ['$F77FLAGS'],
  'SHF90': 'f90',
  'SHF90FLAGS': ['$F90FLAGS'],
  'SHF95': '$F95',
  'SHF95FLAGS': ['$F95FLAGS'],
  'SHFORTRAN': 'f90',
```

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Explicitly set values of SCons variables for `SHF90`, `SHFORTRAN`, etc.
- Set compiler / flags for `F08` to match other Fortran versions

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
