### PR TITLE
Support legacy ruamel.yaml loaders

### DIFF
--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1375,9 +1375,15 @@ class Parser:
         """
         Load YAML-formatted entries from ``path`` on disk.
         """
-        yaml_ = yaml.YAML()
-        with open(path, 'rt', encoding="utf-8") as stream:
-            yml = yaml_.load(stream)
+        try:
+            yaml_ = yaml.YAML(typ="rt")
+            with open(path, 'rt', encoding="utf-8") as stream:
+                yml = yaml_.load(stream)
+        except yaml.constructor.ConstructorError:
+            with open(path, "rt", encoding="utf-8") as stream:
+                # Ensure that the loader remains backward-compatible with legacy
+                # ruamel.yaml versions (prior to 0.17.0).
+                yml = yaml.round_trip_load(stream)
 
         # do not overwrite reserved field names
         reserved = {'generator', 'input-files', 'cantera-version', 'date',

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -455,7 +455,7 @@ class ReactionTests:
         if isinstance(one, (list, tuple, np.ndarray)):
             self.assertArrayNear(one, two)
         else:
-            self.assertEqual(one, two)
+            self.assertNear(one, two)
 
     def test_deprecated_getters(self):
         # check property getters deprecated in new framework

--- a/interfaces/cython/cantera/test/utilities.py
+++ b/interfaces/cython/cantera/test/utilities.py
@@ -18,12 +18,17 @@ TEST_DATA_PATH = Path(__file__).parent / "data"
 CANTERA_DATA_PATH = Path(__file__).parents[1] / "data"
 
 
-def load_yaml(yml_file, typ="safe"):
-    # Load YAML data from file. The YAML loader defaults to "safe".
-    yaml_ = yaml.YAML(typ=typ)
-    with open(yml_file, "rt", encoding="utf-8") as stream:
-        return yaml_.load(stream)
-
+def load_yaml(yml_file):
+    # Load YAML data from file using the "safe" loading option.
+    try:
+        yaml_ = yaml.YAML(typ="safe")
+        with open(yml_file, "rt", encoding="utf-8") as stream:
+            return yaml_.load(stream)
+    except yaml.constructor.ConstructorError:
+        with open(yml_file, "rt", encoding="utf-8") as stream:
+            # Ensure that  the loader remains backward-compatible with legacy
+            # ruamel.yaml versions (prior to 0.17.0).
+            return yaml.safe_load(stream)
 
 class CanteraTest(unittest.TestCase):
     @classmethod


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

A recent change in #1049 replaces a deprecated YAML loader. However, the replacement loader was only implemented for the most recent ruamel.yaml versions.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Support ruamel.yaml prior to 0.17.0

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1059

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
