### PR TITLE
Individual Reactor Initialization - Segmentation Fault Fix.

### DIFF
--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -194,7 +194,7 @@ protected:
     //!     calculated from the state, and `false` when the pressure is constant
     //!     or an independent variable.
     //! @param t0 initialization time for the reactor if not obtained from the network
-    virtual void updateConnected(bool updatePressure, double t0 = 0.0);
+    virtual void updateConnected(bool updatePressure, double t0=0.0);
 
     //! Get initial conditions for SurfPhase objects attached to this reactor
     virtual void getSurfaceInitialConditions(double* y);

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -193,8 +193,7 @@ protected:
     //!     `true` for reactors where the pressure is a dependent property,
     //!     calculated from the state, and `false` when the pressure is constant
     //!     or an independent variable.
-    //! @param t0 initialization time for the reactor if not obtained from the network
-    virtual void updateConnected(bool updatePressure, double t0=0.0);
+    virtual void updateConnected(bool updatePressure);
 
     //! Get initial conditions for SurfPhase objects attached to this reactor
     virtual void getSurfaceInitialConditions(double* y);

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -193,7 +193,8 @@ protected:
     //!     `true` for reactors where the pressure is a dependent property,
     //!     calculated from the state, and `false` when the pressure is constant
     //!     or an independent variable.
-    virtual void updateConnected(bool updatePressure);
+    //! @param t0 initialization time for the reactor if not obtained from the network
+    virtual void updateConnected(bool updatePressure, double t0 = 0.0);
 
     //! Get initial conditions for SurfPhase objects attached to this reactor
     virtual void getSurfaceInitialConditions(double* y);

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -88,7 +88,7 @@ void Reactor::initialize(doublereal t0)
     m_thermo->restoreState(m_state);
     m_sdot.resize(m_nsp, 0.0);
     m_wdot.resize(m_nsp, 0.0);
-    updateConnected(true, t0);
+    updateConnected(true);
 
     for (size_t n = 0; n < m_wall.size(); n++) {
         WallBase* W = m_wall[n];
@@ -177,7 +177,7 @@ void Reactor::updateSurfaceState(double* y)
     }
 }
 
-void Reactor::updateConnected(bool updatePressure, double t0) {
+void Reactor::updateConnected(bool updatePressure) {
     // save parameters needed by other connected reactors
     m_enthalpy = m_thermo->enthalpy_mass();
     if (updatePressure) {
@@ -187,7 +187,7 @@ void Reactor::updateConnected(bool updatePressure, double t0) {
     m_thermo->saveState(m_state);
 
     // Update the mass flow rate of connected flow devices
-    double time = (m_net != nullptr) ? m_net->time() : t0;
+    double time = (m_net != nullptr) ? m_net->time() : 0.0;
     for (size_t i = 0; i < m_outlet.size(); i++) {
         m_outlet[i]->updateMassFlowRate(time);
     }

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -88,7 +88,7 @@ void Reactor::initialize(doublereal t0)
     m_thermo->restoreState(m_state);
     m_sdot.resize(m_nsp, 0.0);
     m_wdot.resize(m_nsp, 0.0);
-    updateConnected(true,t0);
+    updateConnected(true, t0);
 
     for (size_t n = 0; n < m_wall.size(); n++) {
         WallBase* W = m_wall[n];
@@ -187,7 +187,7 @@ void Reactor::updateConnected(bool updatePressure, double t0) {
     m_thermo->saveState(m_state);
 
     // Update the mass flow rate of connected flow devices
-    double time = (m_net!=NULL) ? m_net->time() : t0;
+    double time = (m_net != nullptr) ? m_net->time() : t0;
     for (size_t i = 0; i < m_outlet.size(); i++) {
         m_outlet[i]->updateMassFlowRate(time);
     }

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -88,7 +88,7 @@ void Reactor::initialize(doublereal t0)
     m_thermo->restoreState(m_state);
     m_sdot.resize(m_nsp, 0.0);
     m_wdot.resize(m_nsp, 0.0);
-    updateConnected(true);
+    updateConnected(true,t0);
 
     for (size_t n = 0; n < m_wall.size(); n++) {
         WallBase* W = m_wall[n];
@@ -177,7 +177,7 @@ void Reactor::updateSurfaceState(double* y)
     }
 }
 
-void Reactor::updateConnected(bool updatePressure) {
+void Reactor::updateConnected(bool updatePressure, double t0) {
     // save parameters needed by other connected reactors
     m_enthalpy = m_thermo->enthalpy_mass();
     if (updatePressure) {
@@ -187,7 +187,7 @@ void Reactor::updateConnected(bool updatePressure) {
     m_thermo->saveState(m_state);
 
     // Update the mass flow rate of connected flow devices
-    double time = m_net->time();
+    double time = (m_net!=NULL) ? m_net->time() : t0;
     for (size_t i = 0; i < m_outlet.size(); i++) {
         m_outlet[i]->updateMassFlowRate(time);
     }

--- a/test/SConscript
+++ b/test/SConscript
@@ -290,6 +290,7 @@ addTestProgram('thermo', 'thermo')
 addTestProgram('equil', 'equil')
 addTestProgram('kinetics', 'kinetics')
 addTestProgram('transport', 'transport')
+addTestProgram('zeroD', 'zeroD')
 
 python_subtests = ['']
 test_root = '#interfaces/cython/cantera/test'

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -43,10 +43,10 @@ TEST(ZeroDim, test_individual_reactor_initialization)
     reactor2.setThermoMgr(*gas2);
     reactor2.initialize(0);
     // Get state of reactors
-    double *state1 = new double[reactor1.neq()];
-    double *state2 = new double[reactor2.neq()];
-    reactor1.getState(state1);
-    reactor2.getState(state2);
+    std::vector<double> state1 (reactor1.neq());
+    std::vector<double> state2 (reactor2.neq());
+    reactor1.getState(state1.data());
+    reactor2.getState(state2.data());
     // Compare the reactors.
     EXPECT_EQ(reactor1.neq(), reactor2.neq());
     double tol = 1e-14;
@@ -56,8 +56,6 @@ TEST(ZeroDim, test_individual_reactor_initialization)
     {
         EXPECT_NEAR(state1[i], state2[i], tol);
     }
-    delete[] state1;
-    delete[] state2;
 }
 
 int main(int argc, char** argv)

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -14,7 +14,8 @@ TEST(ZeroDim, test_individual_reactor_initialization)
 {
     // Initial conditions
     double T0 = 1100.0;
-    double P0 = 10*OneAtm;
+    double P0 = 10 * OneAtm;
+    double tol = 1e-7;
     std::string X0 = "H2:1.0, O2:0.5, AR:8.0";
     // Reactor solution, phase, and kinetics objects
     std::shared_ptr<Solution> sol1 = newSolution("h2o2.yaml");
@@ -43,10 +44,7 @@ TEST(ZeroDim, test_individual_reactor_initialization)
     reactor2.getState(state2.data());
     // Compare the reactors.
     EXPECT_EQ(reactor1.neq(), reactor2.neq());
-    double tol = 1e-14;
-    EXPECT_NEAR(state1[0], state2[0], tol);
-    EXPECT_NEAR(state1[1], state2[1], tol);
-    for(size_t i = 3; i < reactor1.neq(); i++)
+    for (size_t i = 0; i < reactor1.neq(); i++)
     {
         EXPECT_NEAR(state1[i], state2[i], tol);
     }

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -14,17 +14,14 @@ TEST(ZeroDim, test_individual_reactor_initialization)
 {
     // Initial conditions
     double T0 = 1100.0;
-    double P0 = 1013250;
+    double P0 = 10*OneAtm;
     std::string X0 = "H2:1.0, O2:0.5, AR:8.0";
     // Reactor solution, phase, and kinetics objects
     std::shared_ptr<Solution> sol1 = newSolution("h2o2.yaml");
-    std::shared_ptr<ThermoPhase> gas1 = sol1->thermo();
-    std::shared_ptr<Kinetics> kin1 = sol1->kinetics();
-    gas1->setState_TPX(T0, P0, X0);
+    sol1->thermo()->setState_TPX(T0, P0, X0);
     // Set up reactor object
     Reactor reactor1;
-    reactor1.setKineticsMgr(*kin1);
-    reactor1.setThermoMgr(*gas1);
+    reactor1.insert(sol1);
     // Initialize reactor prior to integration to ensure no impact
     reactor1.initialize();
     // Setup reactor network and integrate
@@ -33,14 +30,11 @@ TEST(ZeroDim, test_individual_reactor_initialization)
     network.advance(1.0);
     // Secondary gas for comparison
     std::shared_ptr<Solution> sol2 = newSolution("h2o2.yaml");
-    std::shared_ptr<ThermoPhase> gas2 = sol2->thermo();
-    std::shared_ptr<Kinetics> kin2 = sol2->kinetics();
-    gas2->setState_TPX(T0, P0, X0);
-    gas2->equilibrate("UV");
+    sol2->thermo()->setState_TPX(T0, P0, X0);
+    sol2->thermo()->equilibrate("UV");
     // Secondary reactor for comparison
     Reactor reactor2;
-    reactor2.setKineticsMgr(*kin2);
-    reactor2.setThermoMgr(*gas2);
+    reactor2.insert(sol2);
     reactor2.initialize(0.0);
     // Get state of reactors
     std::vector<double> state1 (reactor1.neq());

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -7,53 +7,57 @@
 
 using namespace Cantera;
 
-//This test ensures that prior reactor initialization of a reactor does not affect later integration within a network. This example was adapted from test_reactor.py::test_equilibrium_HP.
+// This test ensures that prior reactor initialization of a reactor does
+// not affect later integration within a network. This example was
+// adapted from test_reactor.py::test_equilibrium_HP.
 TEST(ZeroDim, test_individual_reactor_initialization)
 {
-    //Initial conditions
+    // Initial conditions
     double T0 = 1100.0;
     double P0 = 1013250;
     std::string X0 = "H2:1.0, O2:0.5, AR:8.0";
-    //Reactor solution, phase, and kinetics objects
+    // Reactor solution, phase, and kinetics objects
     std::shared_ptr<Solution> sol1 = newSolution("h2o2.yaml");
     std::shared_ptr<ThermoPhase> gas1 = sol1->thermo();
     std::shared_ptr<Kinetics> kin1 = sol1->kinetics();
     gas1->setState_TPX(T0, P0, X0);
-    //Set up reactor object
+    // Set up reactor object
     Reactor reactor1;
     reactor1.setKineticsMgr(*kin1);
     reactor1.setThermoMgr(*gas1);
-    //initialize reactor at arbitrary value
+    // Initialize reactor at arbitrary value prior to integration to ensure no impact
     reactor1.initialize(0.1);
-    //Setup reactor network and integrating
+    // Setup reactor network and integrate
     ReactorNet network;
     network.addReactor(reactor1);
     network.advance(1.0);
-    //Secondary gas for comparison
+    // Secondary gas for comparison
     std::shared_ptr<Solution> sol2 = newSolution("h2o2.yaml");
     std::shared_ptr<ThermoPhase> gas2 = sol2->thermo();
     std::shared_ptr<Kinetics> kin2 = sol2->kinetics();
     gas2->setState_TPX(T0, P0, X0);
     gas2->equilibrate("UV");
-    //Secondary reactor for comparison
+    // Secondary reactor for comparison
     Reactor reactor2;
     reactor2.setKineticsMgr(*kin2);
     reactor2.setThermoMgr(*gas2);
     reactor2.initialize(0);
-    //Get state of reactors
-    double state1 [reactor1.neq()];
-    double state2 [reactor2.neq()];
+    // Get state of reactors
+    double *state1 = new double[reactor1.neq()];
+    double *state2 = new double[reactor2.neq()];
     reactor1.getState(state1);
     reactor2.getState(state2);
-    //Compare the reactors.
+    // Compare the reactors.
     EXPECT_EQ(reactor1.neq(), reactor2.neq());
     double tol = 1e-14;
     EXPECT_NEAR(state1[0], state2[0], tol);
     EXPECT_NEAR(state1[1], state2[1], tol);
-    for(size_t i = 3; i < reactor2.neq(); i++)
+    for(size_t i = 3; i < reactor1.neq(); i++)
     {
         EXPECT_NEAR(state1[i], state2[i], tol);
     }
+    delete[] state1;
+    delete[] state2;
 }
 
 int main(int argc, char** argv)

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -25,8 +25,8 @@ TEST(ZeroDim, test_individual_reactor_initialization)
     Reactor reactor1;
     reactor1.setKineticsMgr(*kin1);
     reactor1.setThermoMgr(*gas1);
-    // Initialize reactor at arbitrary value prior to integration to ensure no impact
-    reactor1.initialize(0.1);
+    // Initialize reactor prior to integration to ensure no impact
+    reactor1.initialize();
     // Setup reactor network and integrate
     ReactorNet network;
     network.addReactor(reactor1);
@@ -41,7 +41,7 @@ TEST(ZeroDim, test_individual_reactor_initialization)
     Reactor reactor2;
     reactor2.setKineticsMgr(*kin2);
     reactor2.setThermoMgr(*gas2);
-    reactor2.initialize(0);
+    reactor2.initialize(0.0);
     // Get state of reactors
     std::vector<double> state1 (reactor1.neq());
     std::vector<double> state2 (reactor2.neq());

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -14,13 +14,13 @@ TEST(ZeroDim, test_individual_reactor_initialization)
     double T0 = 1100.0;
     double P0 = 1013250;
     std::string X0 = "H2:1.0, O2:0.5, AR:8.0";
-    //IdealGasConstPressureReactor solution, phase, and kinetics objects
+    //Reactor solution, phase, and kinetics objects
     std::shared_ptr<Solution> sol1 = newSolution("h2o2.yaml");
     std::shared_ptr<ThermoPhase> gas1 = sol1->thermo();
     std::shared_ptr<Kinetics> kin1 = sol1->kinetics();
     gas1->setState_TPX(T0, P0, X0);
     //Set up reactor object
-    IdealGasConstPressureReactor reactor1;
+    Reactor reactor1;
     reactor1.setKineticsMgr(*kin1);
     reactor1.setThermoMgr(*gas1);
     //initialize reactor at arbitrary value
@@ -34,15 +34,25 @@ TEST(ZeroDim, test_individual_reactor_initialization)
     std::shared_ptr<ThermoPhase> gas2 = sol2->thermo();
     std::shared_ptr<Kinetics> kin2 = sol2->kinetics();
     gas2->setState_TPX(T0, P0, X0);
-    gas2->equilibrate("HP");
-    //Compare the two gases.
-    double tol = 1e-8; //relative tolerance from python assertNear test
-    EXPECT_NEAR(gas1->temperature(), gas2->temperature(), tol);
-    EXPECT_NEAR(gas1->density(), gas2->density(), tol);
-    EXPECT_NEAR(gas1->pressure(), P0, tol);
-    for(size_t i = 0; i < gas1->stateSize()-2; i++)
+    gas2->equilibrate("UV");
+    //Secondary reactor for comparison
+    Reactor reactor2;
+    reactor2.setKineticsMgr(*kin2);
+    reactor2.setThermoMgr(*gas2);
+    reactor2.initialize(0);
+    //Get state of reactors
+    double state1 [reactor1.neq()];
+    double state2 [reactor2.neq()];
+    reactor1.getState(state1);
+    reactor2.getState(state2);
+    //Compare the reactors.
+    EXPECT_EQ(reactor1.neq(), reactor2.neq());
+    double tol = 1e-14;
+    EXPECT_NEAR(state1[0], state2[0], tol);
+    EXPECT_NEAR(state1[1], state2[1], tol);
+    for(size_t i = 3; i < reactor2.neq(); i++)
     {
-        EXPECT_NEAR(gas1->massFraction(i), gas2->massFraction(i), tol);
+        EXPECT_NEAR(state1[i], state2[i], tol);
     }
 }
 

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -1,0 +1,57 @@
+#include <cstdio>
+#include <string>
+#include "gtest/gtest.h"
+#include "cantera/thermo.h"
+#include "cantera/kinetics.h"
+#include "cantera/zerodim.h"
+
+using namespace Cantera;
+
+//This test ensures that prior reactor initialization of a reactor does not affect later integration within a network. This example was adapted from test_reactor.py::test_equilibrium_HP.
+TEST(ZeroDim, test_individual_reactor_initialization)
+{
+    //Initial conditions
+    double T0 = 1100.0;
+    double P0 = 1013250;
+    std::string X0 = "H2:1.0, O2:0.5, AR:8.0";
+    //IdealGasConstPressureReactor solution, phase, and kinetics objects
+    std::shared_ptr<Solution> sol1 = newSolution("h2o2.yaml");
+    std::shared_ptr<ThermoPhase> gas1 = sol1->thermo();
+    std::shared_ptr<Kinetics> kin1 = sol1->kinetics();
+    gas1->setState_TPX(T0, P0, X0);
+    //Set up reactor object
+    IdealGasConstPressureReactor reactor1;
+    reactor1.setKineticsMgr(*kin1);
+    reactor1.setThermoMgr(*gas1);
+    //initialize reactor at arbitrary value
+    reactor1.initialize(0.1);
+    //Setup reactor network and integrating
+    ReactorNet network;
+    network.addReactor(reactor1);
+    network.advance(1.0);
+    //Secondary gas for comparison
+    std::shared_ptr<Solution> sol2 = newSolution("h2o2.yaml");
+    std::shared_ptr<ThermoPhase> gas2 = sol2->thermo();
+    std::shared_ptr<Kinetics> kin2 = sol2->kinetics();
+    gas2->setState_TPX(T0, P0, X0);
+    gas2->equilibrate("HP");
+    //Compare the two gases.
+    double tol = 1e-8; //relative tolerance from python assertNear test
+    EXPECT_NEAR(gas1->temperature(), gas2->temperature(), tol);
+    EXPECT_NEAR(gas1->density(), gas2->density(), tol);
+    EXPECT_NEAR(gas1->pressure(), P0, tol);
+    for(size_t i = 0; i < gas1->stateSize()-2; i++)
+    {
+        EXPECT_NEAR(gas1->massFraction(i), gas2->massFraction(i), tol);
+    }
+}
+
+int main(int argc, char** argv)
+{
+    printf("Running main() from test_zeroD.cpp\n");
+    testing::InitGoogleTest(&argc, argv);
+    Cantera::make_deprecation_warnings_fatal();
+    int result = RUN_ALL_TESTS();
+    Cantera::appdelete();
+    return result;
+}


### PR DESCRIPTION
There was a segmentation fault when calling initialize on an individual reactor, this is a fix for that by setting it to the specified time if a ReactorNet has not been provided or used.

I specifically changed `ReactorNet::updateConnected` in both the .cpp and .h files to accept a time arguement. If the reactor network is not available, it uses the specified or default time value of the reactor specific initialize function.


**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
