### PR TITLE
Bug fix: CK_Multi recognized as multicomponent transport method in fl…

### DIFF
--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -153,7 +153,7 @@ void StFlow::resetBadValues(double* xg)
 void StFlow::setTransport(Transport& trans)
 {
     m_trans = &trans;
-    m_do_multicomponent = (m_trans->transportType() == "Multi");
+    m_do_multicomponent = (m_trans->transportType() == "Multi" || m_trans->transportType() == "CK_Multi");
 
     m_diff.resize(m_nsp*m_points);
     if (m_do_multicomponent) {


### PR DESCRIPTION
This is a minor fix to make sure that the Chemkin-type multi-component transport type (CK_Multi) is treated properly by the 1D flame models.

Best regards,
Laurien 