### PR TITLE
Expose C++ Units to Python

### DIFF
--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -109,6 +109,9 @@ public:
     //! recognize an optional argument with a default value)
     UnitSystem() : UnitSystem({}) {}
 
+    //! Return default units used by the unit system
+    std::map<std::string, std::string> defaults() const;
+
     //! Set the default units to convert from when explicit units are not
     //! provided. Defaults can be set for mass, length, time, quantity, energy,
     //! and pressure. Conversion using the pressure or energy units is done only

--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -49,6 +49,11 @@ public:
     Units& operator*=(const Units& other);
 
     //! Provide a string representation of these Units
+    //! @param leading_one  print '1' if no units are in the numerator
+    std::string unit_str(bool leading_one=true) const;
+
+    //! Provide a string representation of these Units that includes the
+    //! conversion factor
     std::string str() const;
 
     //! Raise these Units to a power, changing both the conversion factor and

--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -35,7 +35,8 @@ public:
                    double quantity=0);
 
     //! Create an object with the specified dimensions
-    explicit Units(const std::string& name);
+    //! @param force_unity  ensure that conversion factor is equal to one
+    explicit Units(const std::string& name, bool force_unity=false);
 
     //! Returns `true` if the specified Units are dimensionally consistent
     bool convertible(const Units& other) const;
@@ -49,12 +50,8 @@ public:
     Units& operator*=(const Units& other);
 
     //! Provide a string representation of these Units
-    //! @param leading_one  print '1' if no units are in the numerator
-    std::string unit_str(bool leading_one=true) const;
-
-    //! Provide a string representation of these Units that includes the
-    //! conversion factor
-    std::string str() const;
+    //! @param skip_unity  do not print '1' if conversion factor is equal to one
+    std::string str(bool skip_unity=true) const;
 
     //! Raise these Units to a power, changing both the conversion factor and
     //! the dimensions of these Units.

--- a/include/cantera/base/YamlWriter.h
+++ b/include/cantera/base/YamlWriter.h
@@ -59,6 +59,12 @@ public:
     //!     corresponding units supported by the UnitSystem class.
     void setUnits(const std::map<std::string, std::string>& units={});
 
+    //! Set the units to be used in the output file. Dimensions not specified
+    //! will use Cantera's defaults.
+    //! @param units  A UnitSystem object specifying dimensions (mass, length, time,
+    //!     quantity, pressure, energy, activation-energy).
+    void setUnitSystem(const UnitSystem& units=UnitSystem());
+
 protected:
     std::vector<shared_ptr<Solution>> m_phases;
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -53,8 +53,7 @@ cdef extern from "cantera/base/Units.h" namespace "Cantera":
     cdef cppclass CxxUnits "Cantera::Units":
         CxxUnits()
         CxxUnits(CxxUnits)
-        CxxUnits(string) except +translate_exception
-        string unit_str()
+        CxxUnits(string, cbool) except +translate_exception
         string str()
         double factor()
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -647,7 +647,7 @@ cdef extern from "cantera/base/YamlWriter.h" namespace "Cantera":
         void toYamlFile(string&) except +translate_exception
         void setPrecision(int)
         void skipUserDefined(cbool)
-        void setUnitSystem(CxxUnitSystem) except +translate_exception
+        void setUnitSystem(CxxUnitSystem&) except +translate_exception
 
 cdef extern from "cantera/equil/MultiPhase.h" namespace "Cantera":
     cdef cppclass CxxMultiPhase "Cantera::MultiPhase":

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -54,6 +54,7 @@ cdef extern from "cantera/base/Units.h" namespace "Cantera":
         CxxUnits()
         CxxUnits(CxxUnits)
         CxxUnits(string) except +translate_exception
+        string unit_str()
         string str()
         double factor()
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -49,6 +49,10 @@ cdef extern from "cantera/base/xml.h" namespace "Cantera":
         XML_Node* findID(string)
         int nChildren()
 
+cdef extern from "cantera/base/Units.h" namespace "Cantera":
+    cdef cppclass CxxUnits "Cantera::Units":
+        string str()
+
 cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
     cdef cppclass CxxAnyValue "Cantera::AnyValue"
 
@@ -208,6 +212,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         size_t stateSize()
         void saveState(size_t, double*) except +translate_exception
         void restoreState(size_t, double*) except +translate_exception
+        CxxUnits standardConcentrationUnits() except +translate_exception
 
         # initialization
         void addUndefinedElements() except +translate_exception
@@ -420,6 +425,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         cbool allow_nonreactant_orders
         cbool allow_negative_orders
         cbool usesLegacy()
+        CxxUnits rate_units
 
     cdef cppclass CxxElementaryReaction2 "Cantera::ElementaryReaction2" (CxxReaction):
         CxxElementaryReaction2()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -51,6 +51,9 @@ cdef extern from "cantera/base/xml.h" namespace "Cantera":
 
 cdef extern from "cantera/base/Units.h" namespace "Cantera":
     cdef cppclass CxxUnits "Cantera::Units":
+        CxxUnits()
+        CxxUnits(CxxUnits)
+        CxxUnits(string) except +translate_exception
         string str()
 
 cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
@@ -1114,6 +1117,11 @@ ctypedef void (*transportMethod2d)(CxxTransport*, size_t, double*) except +trans
 ctypedef void (*kineticsMethod1d)(CxxKinetics*, double*) except +translate_exception
 
 # classes
+cdef class Units:
+    cdef CxxUnits units
+    @staticmethod
+    cdef copy(CxxUnits)
+
 cdef class SpeciesThermo:
     cdef shared_ptr[CxxSpeciesThermo] _spthermo
     cdef CxxSpeciesThermo* spthermo

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -57,6 +57,11 @@ cdef extern from "cantera/base/Units.h" namespace "Cantera":
         string str()
         double factor()
 
+    cdef cppclass CxxUnitSystem "Cantera::UnitSystem":
+        CxxUnitSystem()
+        stdmap[string, string] defaults()
+        void setDefaults(stdmap[string, string]&) except +translate_exception
+
 cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
     cdef cppclass CxxAnyValue "Cantera::AnyValue"
 
@@ -1122,6 +1127,9 @@ cdef class Units:
     cdef CxxUnits units
     @staticmethod
     cdef copy(CxxUnits)
+
+cdef class UnitSystem:
+    cdef CxxUnitSystem unitsystem
 
 cdef class SpeciesThermo:
     cdef shared_ptr[CxxSpeciesThermo] _spthermo

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -648,7 +648,7 @@ cdef extern from "cantera/base/YamlWriter.h" namespace "Cantera":
         void toYamlFile(string&) except +translate_exception
         void setPrecision(int)
         void skipUserDefined(cbool)
-        void setUnits(stdmap[string, string]&) except +translate_exception
+        void setUnitSystem(CxxUnitSystem) except +translate_exception
 
 cdef extern from "cantera/equil/MultiPhase.h" namespace "Cantera":
     cdef cppclass CxxMultiPhase "Cantera::MultiPhase":
@@ -1223,6 +1223,8 @@ cdef class DustyGasTransport(Transport):
 cdef class YamlWriter:
     cdef shared_ptr[CxxYamlWriter] _writer
     cdef CxxYamlWriter* writer
+    @staticmethod
+    cdef CxxUnitSystem _get_unitsystem(UnitSystem units)
 
 cdef class Mixture:
     cdef CxxMultiPhase* mix

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -55,6 +55,7 @@ cdef extern from "cantera/base/Units.h" namespace "Cantera":
         CxxUnits(CxxUnits)
         CxxUnits(string) except +translate_exception
         string str()
+        double factor()
 
 cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
     cdef cppclass CxxAnyValue "Cantera::AnyValue"

--- a/interfaces/cython/cantera/_cantera.pyx
+++ b/interfaces/cython/cantera/_cantera.pyx
@@ -12,6 +12,7 @@ from ._cantera cimport *
 include "utils.pyx"
 include "constants.pyx"
 include "func1.pyx"
+include "units.pyx"
 
 include "base.pyx"
 include "speciesthermo.pyx"

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -263,8 +263,8 @@ cdef class _SolutionBase:
             Additional ThermoPhase / Solution objects to be included in the
             output file
         :param units:
-            A dictionary of the units to be used for each dimension. See
-            `YamlWriter.output_units`.
+            A `UnitSystem` object or dictionary of the units to be used for
+            each dimension. See `YamlWriter.output_units`.
         :param precision:
             For output floating point values, the maximum number of digits to
             the right of the decimal point. The default is 15 digits.

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -823,6 +823,12 @@ cdef class Reaction:
         def __get__(self):
             return self.reaction.usesLegacy()
 
+    property rate_coeff_units:
+        """Get string representation of reaction rate coefficient units"""
+        def __get__(self):
+            cdef CxxUnits rate_units = self.reaction.rate_units
+            return pystr(rate_units.str())
+
 
 cdef class Arrhenius:
     r"""

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -824,10 +824,10 @@ cdef class Reaction:
             return self.reaction.usesLegacy()
 
     property rate_coeff_units:
-        """Get string representation of reaction rate coefficient units"""
+        """Get reaction rate coefficient units"""
         def __get__(self):
             cdef CxxUnits rate_units = self.reaction.rate_units
-            return pystr(rate_units.str())
+            return Units.copy(rate_units)
 
 
 cdef class Arrhenius:

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -580,7 +580,7 @@ class TestSolutionSerialization(utilities.CanteraTest):
                              gas2.forward_rate_constants)
         self.assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
 
-    def test_yaml_outunits(self):
+    def test_yaml_outunits1(self):
         gas = ct.Solution('h2o2.yaml')
         gas.TPX = 500, ct.one_atm, 'H2: 1.0, O2: 1.0'
         gas.equilibrate('HP')
@@ -590,6 +590,30 @@ class TestSolutionSerialization(utilities.CanteraTest):
         generated = utilities.load_yaml("h2o2-generated.yaml")
         original = utilities.load_yaml(self.cantera_data_path / "h2o2.yaml")
         self.assertEqual(generated['units'], units)
+
+        for r1, r2 in zip(original['reactions'], generated['reactions']):
+            if 'rate-constant' in r1:
+                self.assertNear(r1['rate-constant']['A'], r2['rate-constant']['A'])
+                self.assertNear(r1['rate-constant']['Ea'], r2['rate-constant']['Ea'])
+
+        gas2 = ct.Solution("h2o2-generated.yaml")
+        self.assertArrayNear(gas.concentrations, gas2.concentrations)
+        self.assertArrayNear(gas.partial_molar_enthalpies,
+                             gas2.partial_molar_enthalpies)
+        self.assertArrayNear(gas.forward_rate_constants,
+                             gas2.forward_rate_constants)
+        self.assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
+
+    def test_yaml_outunits2(self):
+        gas = ct.Solution('h2o2.yaml')
+        gas.TPX = 500, ct.one_atm, 'H2: 1.0, O2: 1.0'
+        gas.equilibrate('HP')
+        gas.TP = 1500, ct.one_atm
+        units = {'length': 'cm', 'quantity': 'mol', 'energy': 'cal'}
+        system = ct.UnitSystem(units)
+        gas.write_yaml('h2o2-generated.yaml', units=system)
+        generated = utilities.load_yaml("h2o2-generated.yaml")
+        original = utilities.load_yaml(self.cantera_data_path / "h2o2.yaml")
 
         for r1, r2 in zip(original['reactions'], generated['reactions']):
             if 'rate-constant' in r1:

--- a/interfaces/cython/cantera/test/test_utils.py
+++ b/interfaces/cython/cantera/test/test_utils.py
@@ -5,6 +5,63 @@ from . import utilities
 
 from cantera._cantera import _py_to_any_to_py
 
+
+class TestUnitSystem(utilities.CanteraTest):
+
+    def test_default(self):
+        units = ct.UnitSystem().units
+        checks = {
+            "activation-energy": "J/kmol",
+            "current": "A",
+            "energy": "J",
+            "length": "m",
+            "mass": "kg",
+            "pressure": "Pa",
+            "quantity": "kmol",
+            "temperature": "K",
+            "time": "s",
+        }
+        for dim, unit in units.items():
+            self.assertIn(dim, checks)
+            self.assertEqual(checks[dim], unit)
+
+    def test_cgs(self):
+        system = ct.UnitSystem({
+            "length": "cm", "mass": "g", "time": "s",
+            "quantity": "mol", "pressure": "dyn/cm^2", "energy": "erg",
+            "activation-energy": "cal/mol"})
+        units = system.units
+        checks = {
+            "activation-energy": "cal/mol",
+            "current": "A",
+            "energy": "erg",
+            "length": "cm",
+            "mass": "g",
+            "pressure": "dyn/cm^2",
+            "quantity": "mol",
+            "temperature": "K",
+            "time": "s",
+        }
+        for dim, unit in units.items():
+            self.assertIn(dim, checks)
+            self.assertEqual(checks[dim], unit)
+
+    def test_activation_energy(self):
+        system = ct.UnitSystem({"activation-energy": "eV"})
+        units = system.units
+        self.assertEqual(units["activation-energy"], "eV")
+
+        system = ct.UnitSystem({"activation-energy": "K"})
+        units = system.units
+        self.assertEqual(units["activation-energy"], "K")
+
+    def test_raises(self):
+        with self.assertRaisesRegex(ct.CanteraError, "non-unity conversion factor"):
+            ct.UnitSystem({"temperature": "2 K"})
+        with self.assertRaisesRegex(ct.CanteraError, "non-unity conversion factor"):
+            ct.UnitSystem({"current": "2 A"})
+
+
 class TestPyToAnyValue(utilities.CanteraTest):
 
     def check_conversion(self, value, check_type=None):

--- a/interfaces/cython/cantera/test/test_utils.py
+++ b/interfaces/cython/cantera/test/test_utils.py
@@ -11,7 +11,7 @@ class TestUnitSystem(utilities.CanteraTest):
     def test_default(self):
         units = ct.UnitSystem().units
         checks = {
-            "activation-energy": "J/kmol",
+            "activation-energy": "J / kmol",
             "current": "A",
             "energy": "J",
             "length": "m",
@@ -28,16 +28,16 @@ class TestUnitSystem(utilities.CanteraTest):
     def test_cgs(self):
         system = ct.UnitSystem({
             "length": "cm", "mass": "g", "time": "s",
-            "quantity": "mol", "pressure": "dyn/cm^2", "energy": "erg",
-            "activation-energy": "cal/mol"})
+            "quantity": "mol", "pressure": "dyn / cm^2", "energy": "erg",
+            "activation-energy": "cal / mol"})
         units = system.units
         checks = {
-            "activation-energy": "cal/mol",
+            "activation-energy": "cal / mol",
             "current": "A",
             "energy": "erg",
             "length": "cm",
             "mass": "g",
-            "pressure": "dyn/cm^2",
+            "pressure": "dyn / cm^2",
             "quantity": "mol",
             "temperature": "K",
             "time": "s",

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1574,7 +1574,7 @@ cdef class ThermoPhase(_SolutionBase):
         """Get standard concentration units for this phase."""
         def __get__(self):
             cdef CxxUnits units = self.thermo.standardConcentrationUnits()
-            return pystr(units.str())
+            return Units.copy(units)
 
 
 cdef class InterfacePhase(ThermoPhase):

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1570,6 +1570,12 @@ cdef class ThermoPhase(_SolutionBase):
         def __set__(self, double value):
             self.thermo.setElectricPotential(value)
 
+    property standard_concentration_units:
+        """Get standard concentration units for this phase."""
+        def __get__(self):
+            cdef CxxUnits units = self.thermo.standardConcentrationUnits()
+            return pystr(units.str())
+
 
 cdef class InterfacePhase(ThermoPhase):
     """ A class representing a surface or edge phase"""

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -46,6 +46,7 @@ cdef class Units:
         units.units = CxxUnits(other)
         return units
 
+
 cdef class UnitSystem:
     """
     Unit conversion utility

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -31,30 +31,26 @@ cdef class Units:
 
 cdef class UnitSystem:
     """
-    Unit conversion utility
+    Unit system used for YAML input and output.
 
-    Provides functions for converting dimensional values from a given unit system.
-    The main use is for converting values specified in input files to Cantera's
+    The `UnitSystem` class is used to specify dimensional values for a given unit
+    system. The main use is for converting values specified in input files to Cantera's
     native unit system, which is SI units except for the use of kmol as the base
     unit of quantity, i.e. kilogram, meter, second, kelvin, ampere, and kmol.
-
-    Special functions for converting activation energies allow these values to be
-    expressed as either energy per quantity, energy (e.g. eV), or temperature by
-    applying a factor of the Avogadro number or the gas constant where needed.
 
     The default unit system used by Cantera is SI+kmol::
 
         ct.UnitSystem({
             "length": "m", "mass": "kg", "time": "s",
             "quantity": "kmol", "pressure": "Pa", "energy": "J",
-            "temperature": "K", "current": "A", "activation-energy": "J/kmol"})
+            "temperature": "K", "current": "A", "activation-energy": "J / kmol"})
 
     A CGS+mol unit system with activation energy units of cal/mol is created as::
 
         ct.UnitSystem({
             "length": "cm", "mass": "g", "time": "s",
-            "quantity": "mol", "pressure": "dyn/cm^2", "energy": "erg",
-            "temperature": "K", "current": "A", "activation-energy": "cal/mol"})
+            "quantity": "mol", "pressure": "dyn / cm^2", "energy": "erg",
+            "temperature": "K", "current": "A", "activation-energy": "cal / mol"})
 
     Defaults for dimensions not specified will be left unchanged. Accordingly,
     the default unit system is retrieved as::

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -13,14 +13,13 @@ cdef class Units:
             self.units = CxxUnits()
 
     def __repr__(self):
-        return f"<{pystr(self.units.str())} at {id(self):0x}>"
+        return f"<Units({pystr(self.units.str())}) at {id(self):0x}>"
 
     @staticmethod
     cdef copy(CxxUnits other):
         """
         Copy a C++ Units object to a Python object.
         """
-        # copy C++ Units object
         cdef Units units = Units(init=False)
         units.units = CxxUnits(other)
         return units

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -76,8 +76,7 @@ cdef class UnitSystem:
             self.units = units
 
     def __repr__(self):
-        units = f"{self.units}".replace(",", ",\n")
-        return f"<UnitSystem at {id(self):0x}> with\n{units}"
+        return f"<UnitSystem at {id(self):0x}>"
 
     property units:
         """

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -15,11 +15,16 @@ cdef class Units:
     def __repr__(self):
         return f"<Units({pystr(self.units.str())}) at {id(self):0x}>"
 
+    property factor:
+        """
+        Return the factor for converting from this unit to Cantera's base units.
+        """
+        def __get__(self):
+            return self.units.factor()
+
     @staticmethod
     cdef copy(CxxUnits other):
-        """
-        Copy a C++ Units object to a Python object.
-        """
+        """Copy a C++ Units object to a Python object."""
         cdef Units units = Units(init=False)
         units.units = CxxUnits(other)
         return units

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -16,18 +16,9 @@ cdef class Units:
     """
     def __cinit__(self, name=None):
         if name:
-            self.units = CxxUnits(stringify(name))
-            if abs(self.units.factor() - 1.) > np.nextafter(0, 1):
-                raise ValueError(
-                    "The creation of 'Units' objects that require a conversion "
-                    "factor\nwith respect to Cantera's default unit system is not "
-                    f"supported:\ninput '{name}' is equivalent to "
-                    f"'{pystr(self.units.str())}' where the conversion factor is "
-                    f"'{self.units.factor()}'")
+            self.units = CxxUnits(stringify(name), True)
 
     def __repr__(self):
-        if abs(self.units.factor() - 1.) < np.nextafter(0, 1):
-            return f"<Units({pystr(self.units.unit_str())}) at {id(self):0x}>"
         return f"<Units({pystr(self.units.str())}) at {id(self):0x}>"
 
     @staticmethod

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -3,10 +3,27 @@
 
 cdef class Units:
     """
-    A class for handling C++ units
+    A representation of the units associated with a dimensional quantity.
+
+    Used for converting quantities between unit systems and checking for dimensional
+    consistency. `Units` objects are mainly used within the `UnitSystem` class to
+    convert values from a user-specified Unit system to Cantera's base units
+    (SI + kmol).
+
+    String representations of units can be written using multiplication, division,
+    and exponentiation. Spaces are ignored. Positive, negative, and decimal exponents
+    are permitted. Examples are::
+
+        ct.Units("kg*m/s^2")
+        ct.Units("J/kmol")
+        ct.Units("m*s^-2")
+        ct.Units("J/kg/K")
+        ct.Units("4184.0 J/kmol")
+
+    Metric prefixes are recognized for all units, for example ``nm``, ``hPa``, ``mg``,
+    ``EJ``, ``mL``, ``kcal``. In addition, a numeric scaling factor can be provided.
     """
     def __cinit__(self, name=None, init=True):
-
         if init and name:
             self.units = CxxUnits(stringify(name))
         elif init:
@@ -28,3 +45,58 @@ cdef class Units:
         cdef Units units = Units(init=False)
         units.units = CxxUnits(other)
         return units
+
+cdef class UnitSystem:
+    """
+    Unit conversion utility
+
+    Provides functions for converting dimensional values from a given unit system.
+    The main use is for converting values specified in input files to Cantera's
+    native unit system, which is SI units except for the use of kmol as the base
+    unit of quantity, i.e. kilogram, meter, second, kelvin, ampere, and kmol.
+
+    Special functions for converting activation energies allow these values to be
+    expressed as either energy per quantity, energy (e.g. eV), or temperature by
+    applying a factor of the Avogadro number or the gas constant where needed.
+
+    The default unit system used by Cantera is SI+kmol::
+
+        ct.UnitSystem({
+            "length": "m", "mass": "kg", "time": "s",
+            "quantity": "kmol", "pressure": "Pa", "energy": "J",
+            "temperature": "K", "current": "A", "activation-energy": "J/kmol"})
+
+    A CGS+mol unit system with activation energy units of cal/mol is created as::
+
+        ct.UnitSystem({
+            "length": "cm", "mass": "g", "time": "s",
+            "quantity": "mol", "pressure": "dyn/cm^2", "energy": "erg",
+            "temperature": "K", "current": "A", "activation-energy": "cal/mol"})
+
+    Defaults for dimensions not specified will be left unchanged. Accordingly,
+    the default unit system is retrieved as::
+
+        ct.UnitSystem()
+    """
+    def __cinit__(self, units=None):
+        self.unitsystem = CxxUnitSystem()
+        if units:
+            self.units = units
+
+    def __repr__(self):
+        units = f"{self.units}".replace(",", ",\n")
+        return f"<UnitSystem at {id(self):0x}> with\n{units}"
+
+    property units:
+        """
+        Units used by the unit system
+        """
+        def __get__(self):
+            cdef stdmap[string, string] cxxunits = self.unitsystem.defaults()
+            cdef pair[string, string] item
+            return {pystr(item.first): pystr(item.second) for item in cxxunits}
+        def __set__(self, units):
+            cdef stdmap[string, string] cxxunits
+            for dimension, unit in units.items():
+                cxxunits[stringify(dimension)] = stringify(unit)
+            self.unitsystem.setDefaults(cxxunits)

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -1,0 +1,26 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+cdef class Units:
+    """
+    A class for handling C++ units
+    """
+    def __cinit__(self, name=None, init=True):
+
+        if init and name:
+            self.units = CxxUnits(stringify(name))
+        elif init:
+            self.units = CxxUnits()
+
+    def __repr__(self):
+        return f"<{pystr(self.units.str())} at {id(self):0x}>"
+
+    @staticmethod
+    cdef copy(CxxUnits other):
+        """
+        Copy a C++ Units object to a Python object.
+        """
+        # copy C++ Units object
+        cdef Units units = Units(init=False)
+        units.units = CxxUnits(other)
+        return units

--- a/interfaces/cython/cantera/yamlwriter.pyx
+++ b/interfaces/cython/cantera/yamlwriter.pyx
@@ -50,18 +50,19 @@ cdef class YamlWriter:
         will use Cantera's defaults.
 
         :param units:
-            A UnitSystem object or map where keys are dimensions (mass, length, time,
+            A `UnitSystem` object or map where keys are dimensions (mass, length, time,
             quantity, pressure, energy, activation-energy), and the values are
             corresponding units such as kg, mm, s, kmol, Pa, cal, and eV.
         """
         def __set__(self, units):
-            if isinstance(units, UnitSystem):
-                defaults = UnitSystem().units
-                units = {k: v for k, v in units.units.items() if defaults[k] != v}
-            cdef stdmap[string, string] cxxunits
-            for dimension, unit in units.items():
-                cxxunits[stringify(dimension)] = stringify(unit)
-            self.writer.setUnits(cxxunits)
+            if not isinstance(units, UnitSystem):
+                units = UnitSystem(units)
+            cdef CxxUnitSystem cxxunits = YamlWriter._get_unitsystem(units)
+            self.writer.setUnitSystem(cxxunits)
+
+    @staticmethod
+    cdef CxxUnitSystem _get_unitsystem(UnitSystem units):
+        return units.unitsystem
 
     def __reduce__(self):
         raise NotImplementedError('YamlWriter object is not picklable')

--- a/interfaces/cython/cantera/yamlwriter.pyx
+++ b/interfaces/cython/cantera/yamlwriter.pyx
@@ -50,11 +50,14 @@ cdef class YamlWriter:
         will use Cantera's defaults.
 
         :param units:
-            A map where keys are dimensions (mass, length, time, quantity,
-            pressure, energy, activation-energy), and the values are
+            A UnitSystem object or map where keys are dimensions (mass, length, time,
+            quantity, pressure, energy, activation-energy), and the values are
             corresponding units such as kg, mm, s, kmol, Pa, cal, and eV.
         """
         def __set__(self, units):
+            if isinstance(units, UnitSystem):
+                defaults = UnitSystem().units
+                units = {k: v for k, v in units.units.items() if defaults[k] != v}
             cdef stdmap[string, string] cxxunits
             for dimension, unit in units.items():
                 cxxunits[stringify(dimension)] = stringify(unit)

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -320,9 +320,18 @@ void UnitSystem::setDefaults(std::initializer_list<std::string> units)
         } else if (unit.convertible(knownUnits.at("J"))) {
             m_energy_factor = unit.factor();
             m_defaults["energy"] = name;
-        } else if (unit.convertible(knownUnits.at("K"))
-                   || unit.convertible(knownUnits.at("A"))) {
-            // Do nothing -- no other scales are supported for temperature and current
+        } else if (unit.convertible(knownUnits.at("K"))) {
+            // Do nothing -- no other scales are supported for temperature
+            if (unit.factor() != 1.) {
+                throw CanteraError("UnitSystem::setDefaults", "Temperature scales "
+                    "with non-unity conversion factor from Kelvin are not supported.");
+            }
+        } else if (unit.convertible(knownUnits.at("A"))) {
+            // Do nothing -- no other scales are supported for current
+            if (unit.factor() != 1.) {
+                throw CanteraError("UnitSystem::setDefaults", "Current scales "
+                    "with non-unity conversion factor from Ampere are not supported.");
+            }
         } else {
             throw CanteraError("UnitSystem::setDefaults",
                 "Unable to match unit '{}' to a basic dimension", name);
@@ -347,10 +356,18 @@ void UnitSystem::setDefaults(const std::map<std::string, std::string>& units)
         } else if (name == "time" && unit.convertible(knownUnits.at("s"))) {
             m_time_factor = unit.factor();
             m_defaults["time"] = item.second;
-        } else if (name == "temperature" && item.second == "K") {
+        } else if (name == "temperature" && unit.convertible(knownUnits.at("K"))) {
             // do nothing - no other temperature scales are supported
-        } else if (name == "current" && item.second == "A") {
+            if (unit.factor() != 1.) {
+                throw CanteraError("UnitSystem::setDefaults", "Temperature scales "
+                    "with non-unity conversion factor from Kelvin are not supported.");
+            }
+        } else if (name == "current" && unit.convertible(knownUnits.at("A"))) {
             // do nothing - no other current scales are supported
+            if (unit.factor() != 1.) {
+                throw CanteraError("UnitSystem::setDefaults", "Current scales "
+                    "with non-unity conversion factor from Ampere are not supported.");
+            }
         } else if (name == "quantity" && unit.convertible(knownUnits.at("kmol"))) {
             m_quantity_factor = unit.factor();
             m_defaults["quantity"] = item.second;

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -326,6 +326,18 @@ std::map<std::string, std::string> UnitSystem::defaults() const
             }
         }
     }
+
+    // Overwrite entries that have buffered defaults
+    for (const auto& defaults : m_defaults) {
+        out[defaults.first] = defaults.second;
+    }
+
+    // Ensure compact output for activation energy
+    if (m_defaults.find("activation-energy") == m_defaults.end()) {
+        out["activation-energy"] = fmt::format(
+            "{}/{}", out["energy"], out["quantity"]);
+    }
+
     return out;
 }
 

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -267,9 +267,9 @@ std::string Units::str() const {
     }
 
     if (out.size()) {
-        return fmt::format("Units({} {})", factor, out.substr(3));
+        return fmt::format("{} {}", factor, out.substr(3));
     }
-    return fmt::format("Units({})", factor);
+    return factor;
 }
 
 bool Units::operator==(const Units& other) const
@@ -403,7 +403,8 @@ double UnitSystem::convert(double value, const Units& src,
 {
     if (!src.convertible(dest)) {
         throw CanteraError("UnitSystem::convert",
-            "Incompatible units:\n    {} and\n    {}", src.str(), dest.str());
+            "Incompatible units:\n    Units({}) and\n    Units({})",
+            src.str(), dest.str());
     }
     return value * src.factor() / dest.factor();
 }

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -229,6 +229,7 @@ std::string Units::str() const {
         {"A", m_current_dim},
         {"kmol", m_quantity_dim},
     };
+
     std::string out = "";
     for (auto const& dim : dims) {
         int rounded = roundf(dim.second);
@@ -243,10 +244,18 @@ std::string Units::str() const {
         }
     }
 
-    if (out.size()) {
-        return fmt::format("Units({} {})", m_factor, out.substr(3));
+    std::string factor;
+    if (m_factor == roundf(m_factor)) {
+        // ensure that fmt::format does not round to integer
+        factor = fmt::format("{:.1f}", m_factor);
+    } else {
+        factor = fmt::format("{}", m_factor);
     }
-    return fmt::format("Units({})", m_factor);
+
+    if (out.size()) {
+        return fmt::format("Units({} {})", factor, out.substr(3));
+    }
+    return fmt::format("Units({})", factor);
 }
 
 bool Units::operator==(const Units& other) const

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -9,6 +9,7 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/AnyMap.h"
 #include "cantera/base/utilities.h"
+#include <regex>
 
 namespace {
 using namespace Cantera;
@@ -141,6 +142,19 @@ Units::Units(const std::string& name)
     , m_energy_dim(0)
 {
     size_t start = 0;
+
+    // Determine factor
+    std::regex regexp("[+-]?([0-9]+([.][0-9]*)?|[.][0-9]+)");
+    std::smatch matched;
+    std::regex_search(name, matched, regexp);
+    if (matched.size()) {
+        std::string factor = *matched.begin();
+        if (name.find(factor) == 0) {
+            m_factor = fpValueCheck(factor);
+            start = factor.size();
+        }
+    }
+
     while (true) {
         // Split into groups of the form 'unit^exponent'
         size_t stop = name.find_first_of("*/", start);

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -246,18 +246,29 @@ std::string Units::str() const {
         {"kmol", m_quantity_dim},
     };
 
+    std::string num = "";
     std::string out = "";
     for (auto const& dim : dims) {
         int rounded = roundf(dim.second);
-        if (dim.second == 1.) {
-            out.append(fmt::format(" * {}", dim.first));
-        } else if (dim.second == 0.) {
+        if (dim.second == 0.) {
             // skip
+        } else if (dim.second == 1.) {
+            num.append(fmt::format(" * {}", dim.first));
+        } else if (dim.second == -1.) {
+            out.append(fmt::format(" / {}", dim.first));
+        } else if (dim.second == rounded && rounded > 0) {
+            num.append(fmt::format(" * {}^{}", dim.first, rounded));
         } else if (dim.second == rounded) {
-            out.append(fmt::format(" * {}^{}", dim.first, rounded));
+            out.append(fmt::format(" / {}^{}", dim.first, -rounded));
+        } else if (dim.second > 0) {
+            num.append(fmt::format(" * {}^{}", dim.first, dim.second));
         } else {
-            out.append(fmt::format(" * {}^{}", dim.first, dim.second));
+            out.append(fmt::format(" / {}^{}", dim.first, -dim.second));
         }
+    }
+    if (num.size()) {
+        // concatenate numerator and denominator (skipping leading '*')
+        out = fmt::format("{}{}", num.substr(2), out);
     }
 
     std::string factor;
@@ -269,7 +280,7 @@ std::string Units::str() const {
     }
 
     if (out.size()) {
-        return fmt::format("{} {}", factor, out.substr(3));
+        return fmt::format("{}{}", factor, out);
     }
     return factor;
 }

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -327,46 +327,31 @@ UnitSystem::UnitSystem(std::initializer_list<std::string> units)
 std::map<std::string, std::string> UnitSystem::defaults() const
 {
     // Unit system defaults
-    std::map<std::string, Units> units{
-        {"mass", Units(m_mass_factor, 1)},
-        {"length", Units(m_length_factor, 0, 1)},
-        {"time", Units(m_time_factor, 0, 0, 1)},
-        {"quantity", Units(m_quantity_factor, 0, 0, 0, 0, 0, 1)},
-        {"pressure", Units(m_pressure_factor, 1, -1, -2)},
-        {"energy", Units(m_energy_factor, 1, 2, -2)},
-        {"temperature", Units(1.0, 0, 0, 0, 1)},
-        {"current", Units(1.0, 0, 0, 0, 0, 1)},
-        {"activation-energy", Units(m_activation_energy_factor, 1, 2, -2, 0, 0, -1)},
+    std::map<std::string, std::string> units{
+        {"mass", "kg"},
+        {"length", "m"},
+        {"time", "s"},
+        {"quantity", "kmol"},
+        {"pressure", "Pa"},
+        {"energy", "J"},
+        {"temperature", "K"},
+        {"current", "A"},
+        {"activation-energy", "J / kmol"},
     };
 
-    // Retrieve known units
-    // (replace combinations of base units used by the default system by known
-    // secondary units, e.g. 'kg / m / s^2' is replaced by 'Pa')
-    std::map<std::string, std::string> out;
-    for (const auto& unit : units) {
-        out[unit.first] = unit.second.str();
-        for (const auto& known : knownUnits) {
-            if (unit.second == known.second) {
-                // Units are known: use abbreviation
-                out[unit.first] = known.first;
-            }
-        }
-    }
-
-    // Overwrite entries that have non-unity conversion factors
-    // (replace units deviating from default unit system with buffered values)
+    // Overwrite entries that have conversion factors
     for (const auto& defaults : m_defaults) {
-        out[defaults.first] = defaults.second;
+        units[defaults.first] = defaults.second;
     }
 
-    // Ensure compact output for activation energy
-    // (use appropriate abbreviations for activation energy)
-    if (m_defaults.find("activation-energy") == m_defaults.end()) {
-        out["activation-energy"] = fmt::format(
-            "{} / {}", out["energy"], out["quantity"]);
+    // Activation energy follows specified energy and quantity units
+    // unless given explicitly
+    if (!m_defaults.count("activation-energy")) {
+        units["activation-energy"] = fmt::format(
+            "{} / {}", units["energy"], units["quantity"]);
     }
 
-    return out;
+    return units;
 }
 
 void UnitSystem::setDefaults(std::initializer_list<std::string> units)

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -24,6 +24,7 @@ const std::map<std::string, Units> knownUnits{
 
     // Length [L]
     {"m", Units(1.0, 0, 1, 0)},
+    {"cm", Units(.01, 0, 1, 0)},
     {"micron", Units(1e-6, 0, 1, 0)},
     {"angstrom", Units(1e-10, 0, 1, 0)},
     {"Å", Units(1e-10, 0, 1, 0)},
@@ -78,6 +79,7 @@ const std::map<std::string, Units> knownUnits{
 
     //! Activation energy units [M*L^2/T^2/Q]
     {"J/kmol", Units(1.0, 1, 2, -2, 0, 0, -1)},
+    {"cal/mol", Units(4184.0, 1, 2, -2, 0, 0, -1)},
 };
 
 const std::map<std::string, double> prefixes{
@@ -296,6 +298,35 @@ UnitSystem::UnitSystem(std::initializer_list<std::string> units)
     , m_explicit_activation_energy(false)
 {
     setDefaults(units);
+}
+
+std::map<std::string, std::string> UnitSystem::defaults() const
+{
+    // Unit system defaults
+    std::map<std::string, Units> units{
+        {"mass", Units(m_mass_factor, 1)},
+        {"length", Units(m_length_factor, 0, 1)},
+        {"time", Units(m_time_factor, 0, 0, 1)},
+        {"quantity", Units(m_quantity_factor, 0, 0, 0, 0, 0, 1)},
+        {"pressure", Units(m_pressure_factor, 1, -1, -2)},
+        {"energy", Units(m_energy_factor, 1, 2, -2)},
+        {"temperature", Units(1.0, 0, 0, 0, 1)},
+        {"current", Units(1.0, 0, 0, 0, 0, 1)},
+        {"activation-energy", Units(m_activation_energy_factor, 1, 2, -2, 0, 0, -1)},
+    };
+
+    // Retrieve known units (if applicable)
+    std::map<std::string, std::string> out;
+    for (const auto& unit : units) {
+        out[unit.first] = unit.second.str();
+        for (const auto& known : knownUnits) {
+            if (unit.second == known.second) {
+                // Units are known: use abbreviation
+                out[unit.first] = known.first;
+            }
+        }
+    }
+    return out;
 }
 
 void UnitSystem::setDefaults(std::initializer_list<std::string> units)

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -339,7 +339,9 @@ std::map<std::string, std::string> UnitSystem::defaults() const
         {"activation-energy", Units(m_activation_energy_factor, 1, 2, -2, 0, 0, -1)},
     };
 
-    // Retrieve known units (if applicable)
+    // Retrieve known units
+    // (replace combinations of base units used by the default system by known
+    // secondary units, e.g. 'kg / m / s^2' is replaced by 'Pa')
     std::map<std::string, std::string> out;
     for (const auto& unit : units) {
         out[unit.first] = unit.second.str();
@@ -351,12 +353,14 @@ std::map<std::string, std::string> UnitSystem::defaults() const
         }
     }
 
-    // Overwrite entries that have buffered defaults
+    // Overwrite entries that have non-unity conversion factors
+    // (replace units deviating from default unit system with buffered values)
     for (const auto& defaults : m_defaults) {
         out[defaults.first] = defaults.second;
     }
 
     // Ensure compact output for activation energy
+    // (use appropriate abbreviations for activation energy)
     if (m_defaults.find("activation-energy") == m_defaults.end()) {
         out["activation-energy"] = fmt::format(
             "{} / {}", out["energy"], out["quantity"]);

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -226,7 +226,8 @@ Units& Units::operator*=(const Units& other)
     return *this;
 }
 
-Units Units::pow(double exponent) const {
+Units Units::pow(double exponent) const
+{
     return Units(std::pow(m_factor, exponent),
                  m_mass_dim * exponent,
                  m_length_dim * exponent,
@@ -236,7 +237,8 @@ Units Units::pow(double exponent) const {
                  m_quantity_dim * exponent);
 }
 
-std::string Units::str() const {
+std::string Units::unit_str(bool leading_one) const
+{
     std::map<std::string, double> dims{
         {"kg", m_mass_dim},
         {"m", m_length_dim},
@@ -268,9 +270,20 @@ std::string Units::str() const {
     }
     if (num.size()) {
         // concatenate numerator and denominator (skipping leading '*')
-        out = fmt::format("{}{}", num.substr(2), out);
+        out = fmt::format("{}{}", num.substr(3), out);
+    } else if (leading_one) {
+        // print '1' as the numerator is empty
+        out = fmt::format("1{}", out);
+    } else if (out.size()) {
+        out = out.substr(1);
     }
 
+    return out;
+}
+
+std::string Units::str() const
+{
+    std::string out = unit_str(false);
     std::string factor;
     if (m_factor == roundf(m_factor)) {
         // ensure that fmt::format does not round to integer
@@ -280,7 +293,7 @@ std::string Units::str() const {
     }
 
     if (out.size()) {
-        return fmt::format("{}{}", factor, out);
+        return fmt::format("{} {}", factor, out);
     }
     return factor;
 }

--- a/src/base/YamlWriter.cpp
+++ b/src/base/YamlWriter.cpp
@@ -160,4 +160,9 @@ void YamlWriter::setUnits(const std::map<std::string, std::string>& units)
     m_output_units.setDefaults(units);
 }
 
+void YamlWriter::setUnitSystem(const UnitSystem& units)
+{
+    m_output_units = units;
+}
+
 }

--- a/test/general/test_serialization.cpp
+++ b/test/general/test_serialization.cpp
@@ -114,11 +114,14 @@ TEST(YamlWriter, reaction_units_from_Yaml)
     YamlWriter writer;
     writer.addPhase(original);
     writer.setPrecision(14);
-    writer.setUnits({
+    auto units = UnitSystem();
+    std::map<std::string, std::string> defaults{
         {"activation-energy", "K"},
         {"quantity", "mol"},
         {"length", "cm"}
-    });
+    };
+    units.setDefaults(defaults);
+    writer.setUnitSystem(units);
     writer.toYamlFile("generated-h2o2-outunits.yaml");
     auto duplicate = newSolution("generated-h2o2-outunits.yaml", "", "None");
 

--- a/test/general/test_units.cpp
+++ b/test/general/test_units.cpp
@@ -5,33 +5,32 @@
 using namespace Cantera;
 
 TEST(Units, from_string) {
-    EXPECT_EQ(Units("").str(), "1.0");
-    EXPECT_EQ(Units("1.").str(), "1.0");
-    EXPECT_EQ(Units("2").str(), "2.0");
-    EXPECT_EQ(Units("kg").str(), "1.0 kg");
-    EXPECT_EQ(Units("1.0 kg^0.5").str(), "1.0 kg^0.5");
-    EXPECT_EQ(Units("kg / m^3").str(), "1.0 kg / m^3");
+    EXPECT_EQ(Units("").str(), "1");
+    EXPECT_EQ(Units("1.").str(), "1");
+    EXPECT_EQ(Units("kg").str(), "kg");
+    EXPECT_EQ(Units("1.0 kg^0.5").str(), "kg^0.5");
+    EXPECT_EQ(Units("kg / m^3").str(), "kg / m^3");
+    EXPECT_EQ(Units("1 / s").str(), "1 / s");
+    EXPECT_EQ(Units("0.001 m^3").factor(), 0.001);
     EXPECT_EQ(Units("0.001 m^3").str(), "0.001 m^3");
 }
 
-TEST(Units, from_string_short) {
-    EXPECT_EQ(Units("").unit_str(), "1");
-    EXPECT_EQ(Units("").unit_str(false), "");
-    EXPECT_EQ(Units("1.").unit_str(), "1");
-    EXPECT_EQ(Units("kg").unit_str(), "kg");
-    EXPECT_EQ(Units("1.0 kg^0.5").unit_str(), "kg^0.5");
-    EXPECT_EQ(Units("kg / m^3").unit_str(), "kg / m^3");
-    EXPECT_EQ(Units("1 / s").unit_str(), "1 / s");
+TEST(Units, from_string_long) {
+    EXPECT_EQ(Units("").str(false), "1.0");
+    EXPECT_EQ(Units("1.").str(false), "1.0");
+    EXPECT_EQ(Units("2").str(false), "2.0");
+    EXPECT_EQ(Units("kg").str(false), "1.0 kg");
+    EXPECT_EQ(Units("1.0 kg^0.5").str(false), "1.0 kg^0.5");
+    EXPECT_EQ(Units("kg / m^3").str(false), "1.0 kg / m^3");
 }
 
-TEST(Units, copy_construct) {
-    EXPECT_EQ(Units(Units(1.)).str(), "1.0");
-    EXPECT_EQ(Units(Units(1., 1.)).str(), "1.0 kg");
-    EXPECT_EQ(Units(Units(1., 2.)).str(), "1.0 kg^2");
-    EXPECT_EQ(Units(Units(1., .5)).str(), "1.0 kg^0.5");
-    EXPECT_EQ(Units(Units(1., -1.)).str(), "1.0 / kg");
-    EXPECT_EQ(Units(Units(1., 1., -3.)).str(), "1.0 kg / m^3");
-    EXPECT_EQ(Units(Units(.001, 0., 3.)).str(), "0.001 m^3");
+TEST(Units, from_string_fail) {
+    EXPECT_THROW(Units("2", true), CanteraError);
+    EXPECT_THROW(Units("1 cal", true), CanteraError);
+    EXPECT_THROW(Units("1 atm", true), CanteraError);
+    EXPECT_THROW(Units("1 bar", true), CanteraError);
+    EXPECT_THROW(Units("1 kJ", true), CanteraError);
+    EXPECT_THROW(Units("0.001 m^3", true), CanteraError);
 }
 
 TEST(Units, convert_to_base_units) {

--- a/test/general/test_units.cpp
+++ b/test/general/test_units.cpp
@@ -4,6 +4,36 @@
 
 using namespace Cantera;
 
+TEST(Units, from_string) {
+    EXPECT_EQ(Units("").str(), "1.0");
+    EXPECT_EQ(Units("1.").str(), "1.0");
+    EXPECT_EQ(Units("2").str(), "2.0");
+    EXPECT_EQ(Units("kg").str(), "1.0 kg");
+    EXPECT_EQ(Units("1.0 kg^0.5").str(), "1.0 kg^0.5");
+    EXPECT_EQ(Units("kg / m^3").str(), "1.0 kg / m^3");
+    EXPECT_EQ(Units("0.001 m^3").str(), "0.001 m^3");
+}
+
+TEST(Units, from_string_short) {
+    EXPECT_EQ(Units("").unit_str(), "1");
+    EXPECT_EQ(Units("").unit_str(false), "");
+    EXPECT_EQ(Units("1.").unit_str(), "1");
+    EXPECT_EQ(Units("kg").unit_str(), "kg");
+    EXPECT_EQ(Units("1.0 kg^0.5").unit_str(), "kg^0.5");
+    EXPECT_EQ(Units("kg / m^3").unit_str(), "kg / m^3");
+    EXPECT_EQ(Units("1 / s").unit_str(), "1 / s");
+}
+
+TEST(Units, copy_construct) {
+    EXPECT_EQ(Units(Units(1.)).str(), "1.0");
+    EXPECT_EQ(Units(Units(1., 1.)).str(), "1.0 kg");
+    EXPECT_EQ(Units(Units(1., 2.)).str(), "1.0 kg^2");
+    EXPECT_EQ(Units(Units(1., .5)).str(), "1.0 kg^0.5");
+    EXPECT_EQ(Units(Units(1., -1.)).str(), "1.0 / kg");
+    EXPECT_EQ(Units(Units(1., 1., -3.)).str(), "1.0 kg / m^3");
+    EXPECT_EQ(Units(Units(.001, 0., 3.)).str(), "0.001 m^3");
+}
+
 TEST(Units, convert_to_base_units) {
     UnitSystem U;
     EXPECT_DOUBLE_EQ(U.convert(1.0, "Pa", "kg/m/s^2"), 1.0);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Shorten `Units::str()` output
- Expose `CxxUnits` to Cython interface
- Implement Python API for `Units`
- Expose `Reaction.rate_coeff_units` and `ThermoPhase.standard_concentration_units`
- Expose `UnitSystem` to Python

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

The new feature can be used as follows:
```
In [1]: import cantera as ct
   ...: gas = ct.Solution("gri30.yaml")
   ...: gas.reaction(0)
   ...:
Out[1]: <ThreeBodyReaction: 2 O + M <=> O2 + M>

In [2]: gas.reaction(0).rate_coeff_units
Out[2]: <Units(1.0 m^6 / kmol^2 / s) at 7f928bee69f0>

In [3]: gas.standard_concentration_units
Out[3]: <Units(1.0 kmol / m^3) at 7f928bee6ab0>

In [4]: ct.Units("Pa")
Out[4]: <Units(1.0 kg / m / s^2) at 7f928bee6cf0>

In [5]: ct.UnitSystem().defaults
Out[5]: 
{'activation-energy': 'J/kmol',
 'current': 'A',
 'energy': 'J',
 'length': 'm',
 'mass': 'kg',
 'pressure': 'Pa',
 'quantity': 'kmol',
 'temperature': 'K',
 'time': 's'}
```
**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review

**Other thoughts**

This PR seeks to expose units used in the C++ layer, rather than facilitating conversion of alternative units as proposed in #991.