### PR TITLE
Gas transport polynomial fits in Python

### DIFF
--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -60,31 +60,20 @@ void CxxArray2D_set(Cantera::Array2D& array, size_t i, size_t j, double value)
     { object->FUNC_NAME(dim, data); }
 
 // Function which populates a 1D array, extra arguments
-#define ARRAY_FUNC1_1SPEC(PREFIX, CLASS_NAME, FUNC_NAME) \
+#define ARRAY_POLY(PREFIX, CLASS_NAME, FUNC_NAME) \
     void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, double* data) \
     { object->FUNC_NAME(i, data); }
     
-#define ARRAY_FUNC1_2SPEC(PREFIX, CLASS_NAME, FUNC_NAME) \
+#define ARRAY_POLY_BINARY(PREFIX, CLASS_NAME, FUNC_NAME) \
     void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, size_t j, double* data) \
     { object->FUNC_NAME(i, j, data); }
-    
-#define ARRAY_FUNC3_2SPEC(PREFIX, CLASS_NAME, FUNC_NAME) \
-    void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, size_t j, double* dataA, double* dataB, double* dataC) \
-    { object->FUNC_NAME(i, j, dataA, dataB, dataC); }
-    
-#define ARRAY_FUNC3_2SPEC_BOOL(PREFIX, CLASS_NAME, FUNC_NAME) \
-    void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, size_t j, double* dataA, double* dataB, double* dataC, bool flag) \
-    { object->FUNC_NAME(i, j, dataA, dataB, dataC, flag); }
-
 
 #define THERMO_1D(FUNC_NAME) ARRAY_FUNC(thermo, ThermoPhase, FUNC_NAME)
 #define KIN_1D(FUNC_NAME) ARRAY_FUNC(kin, Kinetics, FUNC_NAME)
 #define TRANSPORT_1D(FUNC_NAME) ARRAY_FUNC(tran, Transport, FUNC_NAME)
 #define TRANSPORT_2D(FUNC_NAME) ARRAY_FUNC2(tran, Transport, FUNC_NAME)
-#define TRANSPORT_POLY_1SPECIE(FUNC_NAME) ARRAY_FUNC1_1SPEC(tran, Transport, FUNC_NAME)
-#define TRANSPORT_POLY_2SPECIE(FUNC_NAME) ARRAY_FUNC1_2SPEC(tran, Transport, FUNC_NAME)
-#define TRANSPORT_3POLY_2SPECIE(FUNC_NAME) ARRAY_FUNC3_2SPEC(tran, Transport, FUNC_NAME)
-#define TRANSPORT_3POLY_2SPECIE_BOOL(FUNC_NAME) ARRAY_FUNC3_2SPEC_BOOL(tran, Transport, FUNC_NAME)
+#define TRANSPORT_POLY(FUNC_NAME) ARRAY_POLY(tran, Transport, FUNC_NAME)
+#define TRANSPORT_POLY_BINARY(FUNC_NAME) ARRAY_POLY_BINARY(tran, Transport, FUNC_NAME)
 
 THERMO_1D(getMassFractions)
 THERMO_1D(setMassFractions)
@@ -139,11 +128,9 @@ TRANSPORT_1D(getMobilities)
 TRANSPORT_2D(getMultiDiffCoeffs)
 TRANSPORT_2D(getBinaryDiffCoeffs)
 
-TRANSPORT_POLY_1SPECIE(getViscosityPolynomials)
-TRANSPORT_POLY_1SPECIE(setViscosityPolynomials)
-TRANSPORT_POLY_1SPECIE(getConductivityPolynomials)
-TRANSPORT_POLY_1SPECIE(setConductivityPolynomials)
-TRANSPORT_POLY_2SPECIE(getBinDiffusivityPolynomials)
-TRANSPORT_POLY_2SPECIE(setBinDiffusivityPolynomials)
-TRANSPORT_3POLY_2SPECIE(getCollisionIntegralPolynomials)
-TRANSPORT_3POLY_2SPECIE_BOOL(setCollisionIntegralPolynomials)
+TRANSPORT_POLY(getViscosityPolynomial)
+TRANSPORT_POLY(setViscosityPolynomial)
+TRANSPORT_POLY(getConductivityPolynomial)
+TRANSPORT_POLY(setConductivityPolynomial)
+TRANSPORT_POLY_BINARY(getBinDiffusivityPolynomial)
+TRANSPORT_POLY_BINARY(setBinDiffusivityPolynomial)

--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -59,11 +59,32 @@ void CxxArray2D_set(Cantera::Array2D& array, size_t i, size_t j, double value)
     void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t dim, double* data) \
     { object->FUNC_NAME(dim, data); }
 
+// Function which populates a 1D array, extra arguments
+#define ARRAY_FUNC1_1SPEC(PREFIX, CLASS_NAME, FUNC_NAME) \
+    void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, double* data) \
+    { object->FUNC_NAME(i, data); }
+    
+#define ARRAY_FUNC1_2SPEC(PREFIX, CLASS_NAME, FUNC_NAME) \
+    void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, size_t j, double* data) \
+    { object->FUNC_NAME(i, j, data); }
+    
+#define ARRAY_FUNC3_2SPEC(PREFIX, CLASS_NAME, FUNC_NAME) \
+    void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, size_t j, double* dataA, double* dataB, double* dataC) \
+    { object->FUNC_NAME(i, j, dataA, dataB, dataC); }
+    
+#define ARRAY_FUNC3_2SPEC_BOOL(PREFIX, CLASS_NAME, FUNC_NAME) \
+    void PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, size_t i, size_t j, double* dataA, double* dataB, double* dataC, bool flag) \
+    { object->FUNC_NAME(i, j, dataA, dataB, dataC, flag); }
+
 
 #define THERMO_1D(FUNC_NAME) ARRAY_FUNC(thermo, ThermoPhase, FUNC_NAME)
 #define KIN_1D(FUNC_NAME) ARRAY_FUNC(kin, Kinetics, FUNC_NAME)
 #define TRANSPORT_1D(FUNC_NAME) ARRAY_FUNC(tran, Transport, FUNC_NAME)
 #define TRANSPORT_2D(FUNC_NAME) ARRAY_FUNC2(tran, Transport, FUNC_NAME)
+#define TRANSPORT_POLY_1SPECIE(FUNC_NAME) ARRAY_FUNC1_1SPEC(tran, Transport, FUNC_NAME)
+#define TRANSPORT_POLY_2SPECIE(FUNC_NAME) ARRAY_FUNC1_2SPEC(tran, Transport, FUNC_NAME)
+#define TRANSPORT_3POLY_2SPECIE(FUNC_NAME) ARRAY_FUNC3_2SPEC(tran, Transport, FUNC_NAME)
+#define TRANSPORT_3POLY_2SPECIE_BOOL(FUNC_NAME) ARRAY_FUNC3_2SPEC_BOOL(tran, Transport, FUNC_NAME)
 
 THERMO_1D(getMassFractions)
 THERMO_1D(setMassFractions)
@@ -117,3 +138,12 @@ TRANSPORT_1D(getMobilities)
 
 TRANSPORT_2D(getMultiDiffCoeffs)
 TRANSPORT_2D(getBinaryDiffCoeffs)
+
+TRANSPORT_POLY_1SPECIE(getViscosityPolynomials)
+TRANSPORT_POLY_1SPECIE(setViscosityPolynomials)
+TRANSPORT_POLY_1SPECIE(getConductivityPolynomials)
+TRANSPORT_POLY_1SPECIE(setConductivityPolynomials)
+TRANSPORT_POLY_2SPECIE(getBinDiffusivityPolynomials)
+TRANSPORT_POLY_2SPECIE(setBinDiffusivityPolynomials)
+TRANSPORT_3POLY_2SPECIE(getCollisionIntegralPolynomials)
+TRANSPORT_3POLY_2SPECIE_BOOL(setCollisionIntegralPolynomials)

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -117,36 +117,36 @@ public:
 
     //! Return the polynomial fits to the viscosity of species i
     //! @see fitProperties()
-    virtual void getViscosityPolynomials(size_t i, double* coeffs) const;
+    virtual void getViscosityPolynomial(size_t i, double* coeffs) const;
 
     //! Return the temperature fits of the heat conductivity of species i
     //! @see fitProperties()
-    virtual void getConductivityPolynomials(size_t i, double* coeffs) const;
+    virtual void getConductivityPolynomial(size_t i, double* coeffs) const;
 
     //! Return the polynomial fits to the binary diffusivity of species pair (i, j)
     //! @see fitDiffCoeffs()
-    virtual void getBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs) const;
+    virtual void getBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) const;
 
     //! Return the polynomial fits to the collision integral of species pair (i, j)
     //! @see fitCollisionIntegrals()
-    virtual void getCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+    virtual void getCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs) const;
 
     //! Modify the polynomial fits to the viscosity of species i
     //! @see fitProperties()
-    virtual void setViscosityPolynomials(size_t i, double* coeffs);
+    virtual void setViscosityPolynomial(size_t i, double* coeffs);
 
     //! Modify the temperature fits of the heat conductivity of species i
     //! @see fitProperties()
-    virtual void setConductivityPolynomials(size_t i, double* coeffs);
+    virtual void setConductivityPolynomial(size_t i, double* coeffs);
 
     //! Modify the polynomial fits to the binary diffusivity of species pair (i, j)
     //! @see fitDiffCoeffs()
-    virtual void setBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs);
+    virtual void setBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs);
 
     //! Modify the polynomial fits to the collision integral of species pair (i, j)
     //! @see fitCollisionIntegrals()
-    virtual void setCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+    virtual void setCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs, bool actualT);
 
     virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -151,6 +151,8 @@ public:
 
     virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
     
+    //! Boolean indicating the form of the transport properties polynomial fits.
+    //! Returns true if the Chemkin form is used.
     bool CKMode() const {
         return m_mode == CK_Mode;
     }

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -127,7 +127,33 @@ public:
     //! @see fitDiffCoeffs()
     virtual void getBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs) const;
 
+    //! Return the polynomial fits to the collision integral of species pair (i, j)
+    //! @see fitCollisionIntegrals()
+    virtual void getCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+                                                double* bstar_coeffs, double* cstar_coeffs) const;
+
+    //! Modify the polynomial fits to the viscosity of species i
+    //! @see fitProperties()
+    virtual void setViscosityPolynomials(size_t i, double* coeffs);
+
+    //! Modify the temperature fits of the heat conductivity of species i
+    //! @see fitProperties()
+    virtual void setConductivityPolynomials(size_t i, double* coeffs);
+
+    //! Modify the polynomial fits to the binary diffusivity of species pair (i, j)
+    //! @see fitDiffCoeffs()
+    virtual void setBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs);
+
+    //! Modify the polynomial fits to the collision integral of species pair (i, j)
+    //! @see fitCollisionIntegrals()
+    virtual void setCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+                                                double* bstar_coeffs, double* cstar_coeffs, bool actualT);
+
     virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
+    
+    bool CKMode() const {
+        return m_mode == CK_Mode;
+    }
 
 protected:
     GasTransport(ThermoPhase* thermo=0);
@@ -386,6 +412,10 @@ protected:
      * (i,j).
      */
     std::vector<vector_fp> m_omega22_poly;
+    
+    //! Flag to indicate for which (i,j) interaction pairs the 
+    //! actual temperature is used instead of the reduced temperature
+    std::vector<vector_int> m_star_poly_actualT;
 
     //! Fit for astar collision integral
     /*!

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -415,7 +415,7 @@ protected:
     
     //! Flag to indicate for which (i,j) interaction pairs the 
     //! actual temperature is used instead of the reduced temperature
-    std::vector<vector_int> m_star_poly_actualT;
+    std::vector<vector_int> m_star_poly_uses_actualT;
 
     //! Fit for astar collision integral
     /*!

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -129,8 +129,10 @@ public:
 
     //! Return the polynomial fits to the collision integral of species pair (i, j)
     //! @see fitCollisionIntegrals()
-    virtual void getCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
-                                                double* bstar_coeffs, double* cstar_coeffs) const;
+    virtual void getCollisionIntegralPolynomial(size_t i, size_t j, 
+                                                double* astar_coeffs, 
+                                                double* bstar_coeffs, 
+                                                double* cstar_coeffs) const;
 
     //! Modify the polynomial fits to the viscosity of species i
     //! @see fitProperties()
@@ -146,8 +148,10 @@ public:
 
     //! Modify the polynomial fits to the collision integral of species pair (i, j)
     //! @see fitCollisionIntegrals()
-    virtual void setCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
-                                                double* bstar_coeffs, double* cstar_coeffs, bool actualT);
+    virtual void setCollisionIntegralPolynomial(size_t i, size_t j, 
+                                                double* astar_coeffs, 
+                                                double* bstar_coeffs, 
+                                                double* cstar_coeffs, bool actualT);
 
     virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
     

--- a/include/cantera/transport/MultiTransport.h
+++ b/include/cantera/transport/MultiTransport.h
@@ -133,9 +133,6 @@ protected:
     //! Dense matrix for cstar
     DenseMatrix m_cstar;
 
-    //! Dense matrix for omega22
-    DenseMatrix m_om22;
-
     vector_fp m_cinternal;
 
     vector_fp m_sqrt_eps_k;

--- a/include/cantera/transport/TransportBase.h
+++ b/include/cantera/transport/TransportBase.h
@@ -585,6 +585,41 @@ public:
         throw NotImplementedError("Transport::getMixDiffCoeffsMass");
     }
 
+    //! Get/set the polynomial fits to the transport properties
+    virtual void getViscosityPolynomials(size_t i, double* coeffs) const{
+        throw NotImplementedError("Transport::getViscosityPolynomials");
+    }
+
+    virtual void getConductivityPolynomials(size_t i, double* coeffs) const{
+        throw NotImplementedError("Transport::getConductivityPolynomials");
+    }
+    
+    virtual void getBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs) const{
+        throw NotImplementedError("Transport::getBinDiffusivityPolynomials");
+    }
+    
+    virtual void getCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+                                                double* bstar_coeffs, double* cstar_coeffs) const{
+        throw NotImplementedError("Transport::getCollisionIntegralPolynomials");
+    }
+    
+    virtual void setViscosityPolynomials(size_t i, double* coeffs){
+        throw NotImplementedError("Transport::setViscosityPolynomials");
+    }
+    
+    virtual void setConductivityPolynomials(size_t i, double* coeffs){
+        throw NotImplementedError("Transport::setConductivityPolynomials");
+    }
+    
+    virtual void setBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs){
+        throw NotImplementedError("Transport::setBinDiffusivityPolynomials");
+    }
+    
+    virtual void setCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+                                                double* bstar_coeffs, double* cstar_coeffs, bool flag){
+        throw NotImplementedError("Transport::setCollisionIntegralPolynomials");
+    }
+
     //! Set model parameters for derived classes
     /*!
      * This method may be derived in subclasses to set model-specific
@@ -667,6 +702,10 @@ public:
 
     //! Set root Solution holding all phase information
     virtual void setRoot(std::shared_ptr<Solution> root);
+    
+    virtual bool CKMode() const {
+        throw NotImplementedError("Transport::CK_Mode");
+    }
 
 protected:
     //! Enable the transport object for use.

--- a/include/cantera/transport/TransportBase.h
+++ b/include/cantera/transport/TransportBase.h
@@ -585,36 +585,43 @@ public:
         throw NotImplementedError("Transport::getMixDiffCoeffsMass");
     }
 
-    //! Get/set the polynomial fits to the transport properties
+    //! Return the polynomial fits to the viscosity of species i
     virtual void getViscosityPolynomial(size_t i, double* coeffs) const{
         throw NotImplementedError("Transport::getViscosityPolynomial");
     }
 
+    //! Return the temperature fits of the heat conductivity of species i
     virtual void getConductivityPolynomial(size_t i, double* coeffs) const{
         throw NotImplementedError("Transport::getConductivityPolynomial");
     }
     
+    //! Return the polynomial fits to the binary diffusivity of species pair (i, j)
     virtual void getBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) const{
         throw NotImplementedError("Transport::getBinDiffusivityPolynomial");
     }
     
+    //! Return the polynomial fits to the collision integral of species pair (i, j)
     virtual void getCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs) const{
         throw NotImplementedError("Transport::getCollisionIntegralPolynomial");
     }
     
+    //! Modify the polynomial fits to the viscosity of species i
     virtual void setViscosityPolynomial(size_t i, double* coeffs){
         throw NotImplementedError("Transport::setViscosityPolynomial");
     }
     
+    //! Modify the temperature fits of the heat conductivity of species i
     virtual void setConductivityPolynomial(size_t i, double* coeffs){
         throw NotImplementedError("Transport::setConductivityPolynomial");
     }
     
+    //! Modify the polynomial fits to the binary diffusivity of species pair (i, j)
     virtual void setBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs){
         throw NotImplementedError("Transport::setBinDiffusivityPolynomial");
     }
     
+    //! Modify the polynomial fits to the collision integral of species pair (i, j)
     virtual void setCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs, bool flag){
         throw NotImplementedError("Transport::setCollisionIntegralPolynomial");

--- a/include/cantera/transport/TransportBase.h
+++ b/include/cantera/transport/TransportBase.h
@@ -710,6 +710,8 @@ public:
     //! Set root Solution holding all phase information
     virtual void setRoot(std::shared_ptr<Solution> root);
     
+    //! Boolean indicating the form of the transport properties polynomial fits.
+    //! Returns true if the Chemkin form is used.
     virtual bool CKMode() const {
         throw NotImplementedError("Transport::CK_Mode");
     }

--- a/include/cantera/transport/TransportBase.h
+++ b/include/cantera/transport/TransportBase.h
@@ -586,38 +586,38 @@ public:
     }
 
     //! Get/set the polynomial fits to the transport properties
-    virtual void getViscosityPolynomials(size_t i, double* coeffs) const{
-        throw NotImplementedError("Transport::getViscosityPolynomials");
+    virtual void getViscosityPolynomial(size_t i, double* coeffs) const{
+        throw NotImplementedError("Transport::getViscosityPolynomial");
     }
 
-    virtual void getConductivityPolynomials(size_t i, double* coeffs) const{
-        throw NotImplementedError("Transport::getConductivityPolynomials");
+    virtual void getConductivityPolynomial(size_t i, double* coeffs) const{
+        throw NotImplementedError("Transport::getConductivityPolynomial");
     }
     
-    virtual void getBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs) const{
-        throw NotImplementedError("Transport::getBinDiffusivityPolynomials");
+    virtual void getBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) const{
+        throw NotImplementedError("Transport::getBinDiffusivityPolynomial");
     }
     
-    virtual void getCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+    virtual void getCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs) const{
-        throw NotImplementedError("Transport::getCollisionIntegralPolynomials");
+        throw NotImplementedError("Transport::getCollisionIntegralPolynomial");
     }
     
-    virtual void setViscosityPolynomials(size_t i, double* coeffs){
-        throw NotImplementedError("Transport::setViscosityPolynomials");
+    virtual void setViscosityPolynomial(size_t i, double* coeffs){
+        throw NotImplementedError("Transport::setViscosityPolynomial");
     }
     
-    virtual void setConductivityPolynomials(size_t i, double* coeffs){
-        throw NotImplementedError("Transport::setConductivityPolynomials");
+    virtual void setConductivityPolynomial(size_t i, double* coeffs){
+        throw NotImplementedError("Transport::setConductivityPolynomial");
     }
     
-    virtual void setBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs){
-        throw NotImplementedError("Transport::setBinDiffusivityPolynomials");
+    virtual void setBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs){
+        throw NotImplementedError("Transport::setBinDiffusivityPolynomial");
     }
     
-    virtual void setCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+    virtual void setCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs, bool flag){
-        throw NotImplementedError("Transport::setCollisionIntegralPolynomials");
+        throw NotImplementedError("Transport::setCollisionIntegralPolynomial");
     }
 
     //! Set model parameters for derived classes

--- a/include/cantera/transport/TransportBase.h
+++ b/include/cantera/transport/TransportBase.h
@@ -601,8 +601,10 @@ public:
     }
     
     //! Return the polynomial fits to the collision integral of species pair (i, j)
-    virtual void getCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
-                                                double* bstar_coeffs, double* cstar_coeffs) const{
+    virtual void getCollisionIntegralPolynomial(size_t i, size_t j, 
+                                                double* astar_coeffs, 
+                                                double* bstar_coeffs, 
+                                                double* cstar_coeffs) const{
         throw NotImplementedError("Transport::getCollisionIntegralPolynomial");
     }
     
@@ -622,8 +624,10 @@ public:
     }
     
     //! Modify the polynomial fits to the collision integral of species pair (i, j)
-    virtual void setCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
-                                                double* bstar_coeffs, double* cstar_coeffs, bool flag){
+    virtual void setCollisionIntegralPolynomial(size_t i, size_t j, 
+                                                double* astar_coeffs, 
+                                                double* bstar_coeffs, 
+                                                double* cstar_coeffs, bool flag){
         throw NotImplementedError("Transport::setCollisionIntegralPolynomial");
     }
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -586,6 +586,8 @@ cdef extern from "cantera/transport/TransportBase.h" namespace "Cantera":
         double thermalConductivity() except +translate_exception
         double electricalConductivity() except +translate_exception
         void getSpeciesViscosities(double*) except +translate_exception
+        void getCollisionIntegralPolynomial(size_t i, size_t j, double* dataA, double* dataB, double* dataC) except +translate_exception
+        void setCollisionIntegralPolynomial(size_t i, size_t j, double* dataA, double* dataB, double* dataC, cbool flag) except +translate_exception
 
 
 cdef extern from "cantera/transport/DustyGasTransport.h" namespace "Cantera":
@@ -1097,20 +1099,20 @@ cdef extern from "cantera/cython/wrappers.h":
     cdef void tran_getMultiDiffCoeffs(CxxTransport*, size_t, double*) except +translate_exception
     cdef void tran_getBinaryDiffCoeffs(CxxTransport*, size_t, double*) except +translate_exception
 
-    cdef void tran_getViscosityPolynomials(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_getConductivityPolynomials(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_getBinDiffusivityPolynomials(CxxTransport*, size_t, size_t, double*) except +translate_exception
-    cdef void tran_getCollisionIntegralPolynomials(CxxTransport*, size_t, size_t, double*, double*, double*) except +translate_exception
+    cdef void tran_getViscosityPolynomial(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_getConductivityPolynomial(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_getBinDiffusivityPolynomial(CxxTransport*, size_t, size_t, double*) except +translate_exception
 
-    cdef void tran_setViscosityPolynomials(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_setConductivityPolynomials(CxxTransport*, size_t, double*) except +translate_exception
-    cdef void tran_setBinDiffusivityPolynomials(CxxTransport*, size_t, size_t, double*) except +translate_exception
-    cdef void tran_setCollisionIntegralPolynomials(CxxTransport*, size_t, size_t, double*, double*, double*, bool) except +translate_exception
+    cdef void tran_setViscosityPolynomial(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_setConductivityPolynomial(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_setBinDiffusivityPolynomial(CxxTransport*, size_t, size_t, double*) except +translate_exception
 
 # typedefs
 ctypedef void (*thermoMethod1d)(CxxThermoPhase*, double*) except +translate_exception
 ctypedef void (*transportMethod1d)(CxxTransport*, double*) except +translate_exception
 ctypedef void (*transportMethod2d)(CxxTransport*, size_t, double*) except +translate_exception
+ctypedef void (*transportPolyMethod1i)(CxxTransport*, size_t, double*) except +translate_exception
+ctypedef void (*transportPolyMethod2i)(CxxTransport*, size_t, size_t, double*) except +translate_exception
 ctypedef void (*kineticsMethod1d)(CxxKinetics*, double*) except +translate_exception
 
 # classes
@@ -1374,6 +1376,8 @@ cdef np.ndarray get_species_array(Kinetics kin, kineticsMethod1d method)
 cdef np.ndarray get_reaction_array(Kinetics kin, kineticsMethod1d method)
 cdef np.ndarray get_transport_1d(Transport tran, transportMethod1d method)
 cdef np.ndarray get_transport_2d(Transport tran, transportMethod2d method)
+cdef np.ndarray get_transport_polynomial(Transport tran, transportPolyMethod1i method, int index, int n_coeffs)
+cdef np.ndarray get_binary_transport_polynomial(Transport tran, transportPolyMethod2i method, int indexi, int indexj, int n_coeffs)
 cdef CxxIdealGasPhase* getIdealGasPhase(ThermoPhase phase) except *
 cdef wrapSpeciesThermo(shared_ptr[CxxSpeciesThermo] spthermo)
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -581,6 +581,7 @@ cdef extern from "cantera/transport/TransportBase.h" namespace "Cantera":
     cdef cppclass CxxTransport "Cantera::Transport":
         CxxTransport(CxxThermoPhase*)
         string transportType()
+        cbool CKMode()
         double viscosity() except +translate_exception
         double thermalConductivity() except +translate_exception
         double electricalConductivity() except +translate_exception
@@ -1095,6 +1096,16 @@ cdef extern from "cantera/cython/wrappers.h":
 
     cdef void tran_getMultiDiffCoeffs(CxxTransport*, size_t, double*) except +translate_exception
     cdef void tran_getBinaryDiffCoeffs(CxxTransport*, size_t, double*) except +translate_exception
+
+    cdef void tran_getViscosityPolynomials(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_getConductivityPolynomials(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_getBinDiffusivityPolynomials(CxxTransport*, size_t, size_t, double*) except +translate_exception
+    cdef void tran_getCollisionIntegralPolynomials(CxxTransport*, size_t, size_t, double*, double*, double*) except +translate_exception
+
+    cdef void tran_setViscosityPolynomials(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_setConductivityPolynomials(CxxTransport*, size_t, double*) except +translate_exception
+    cdef void tran_setBinDiffusivityPolynomials(CxxTransport*, size_t, size_t, double*) except +translate_exception
+    cdef void tran_setCollisionIntegralPolynomials(CxxTransport*, size_t, size_t, double*, double*, double*, bool) except +translate_exception
 
 # typedefs
 ctypedef void (*thermoMethod1d)(CxxThermoPhase*, double*) except +translate_exception

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -165,6 +165,7 @@ class TestTransport(utilities.CanteraTest):
         visc2_h2 = self.phase['H2'].species_viscosities[0]
         self.phase.modify_viscosity_polynomial(self.phase.species_index('H2'), mu_poly_h2)
         visc3_h2 = self.phase['H2'].species_viscosities[0]
+        self.assertTrue(visc1_h2o != visc1_h2)
         self.assertEqual(visc1_h2o, visc2_h2)
         self.assertEqual(visc1_h2, visc3_h2)
                             
@@ -179,22 +180,11 @@ class TestTransport(utilities.CanteraTest):
         cond2_h2 = self.phase.thermal_conductivity
         self.phase.modify_thermal_conductivity_polynomial(self.phase.species_index('H2'), lambda_poly_h2)
         cond3_h2 = self.phase.thermal_conductivity
+        self.assertTrue(cond1_o2 != cond1_h2)
         self.assertEqual(cond1_o2, cond2_h2)
         self.assertEqual(cond1_h2, cond3_h2)
                             
-    def test_transport_polynomial_fits_collision(self):
-        astar1, bstar1, cstar1 = self.phase.collision_integral_polynomials(self.phase.species_index('O2'),
-                                                                        self.phase.species_index('H2'))
-        self.phase.modify_collision_integral_polynomials(self.phase.species_index('O2'), 
-                                                        self.phase.species_index('H2'), 
-                                                        astar1, bstar1, cstar1)
-        astar2, bstar2, cstar2 = self.phase.collision_integral_polynomials(self.phase.species_index('O2'),
-                                                                        self.phase.species_index('H2'))
-        self.assertEqual(astar1, astar2)
-        self.assertEqual(bstar1, bstar2)
-        self.assertEqual(cstar1, cstar2)
-                            
-    def test_transport_polynomial_fits_collision(self):
+    def test_transport_polynomial_fits_diffusion(self):
         D12 = self.phase.binary_diff_coeffs[1, 2]
         D23 = self.phase.binary_diff_coeffs[2, 3]
         bd_poly_12 = self.phase.binary_diff_coeffs_polynomial(1, 2)
@@ -207,6 +197,7 @@ class TestTransport(utilities.CanteraTest):
         self.phase.modify_binary_diff_coeffs_polynomial(2, 3, bd_poly_23)
         D12new = self.phase.binary_diff_coeffs[1, 2]
         D23new = self.phase.binary_diff_coeffs[2, 3]
+        self.assertTrue(D12 != D23)
         self.assertEqual(D12, D23mod)
         self.assertEqual(D23, D12mod)
         self.assertEqual(D12, D12new)

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -158,12 +158,12 @@ class TestTransport(utilities.CanteraTest):
                             
     def test_transport_polynomial_fits_viscosity(self):
         visc1_h2o = self.phase['H2O'].species_viscosities[0]
-        mu_poly_h2o = self.phase.viscosity_polynomial(self.phase.species_index('H2O'))        
+        mu_poly_h2o = self.phase.get_viscosity_polynomial(self.phase.species_index('H2O'))        
         visc1_h2 = self.phase['H2'].species_viscosities[0]
-        mu_poly_h2 = self.phase.viscosity_polynomial(self.phase.species_index('H2'))
-        self.phase.modify_viscosity_polynomial(self.phase.species_index('H2'), mu_poly_h2o)
+        mu_poly_h2 = self.phase.get_viscosity_polynomial(self.phase.species_index('H2'))
+        self.phase.set_viscosity_polynomial(self.phase.species_index('H2'), mu_poly_h2o)
         visc2_h2 = self.phase['H2'].species_viscosities[0]
-        self.phase.modify_viscosity_polynomial(self.phase.species_index('H2'), mu_poly_h2)
+        self.phase.set_viscosity_polynomial(self.phase.species_index('H2'), mu_poly_h2)
         visc3_h2 = self.phase['H2'].species_viscosities[0]
         self.assertTrue(visc1_h2o != visc1_h2)
         self.assertEqual(visc1_h2o, visc2_h2)
@@ -172,13 +172,13 @@ class TestTransport(utilities.CanteraTest):
     def test_transport_polynomial_fits_conductivity(self):
         self.phase.X = {'O2': 1}
         cond1_o2 = self.phase.thermal_conductivity
-        lambda_poly_o2 = self.phase.thermal_conductivity_polynomial(self.phase.species_index('O2'))  
+        lambda_poly_o2 = self.phase.get_thermal_conductivity_polynomial(self.phase.species_index('O2'))  
         self.phase.X = {'H2': 1}      
         cond1_h2 = self.phase.thermal_conductivity
-        lambda_poly_h2 = self.phase.thermal_conductivity_polynomial(self.phase.species_index('H2'))
-        self.phase.modify_thermal_conductivity_polynomial(self.phase.species_index('H2'), lambda_poly_o2)
+        lambda_poly_h2 = self.phase.get_thermal_conductivity_polynomial(self.phase.species_index('H2'))
+        self.phase.set_thermal_conductivity_polynomial(self.phase.species_index('H2'), lambda_poly_o2)
         cond2_h2 = self.phase.thermal_conductivity
-        self.phase.modify_thermal_conductivity_polynomial(self.phase.species_index('H2'), lambda_poly_h2)
+        self.phase.set_thermal_conductivity_polynomial(self.phase.species_index('H2'), lambda_poly_h2)
         cond3_h2 = self.phase.thermal_conductivity
         self.assertTrue(cond1_o2 != cond1_h2)
         self.assertEqual(cond1_o2, cond2_h2)
@@ -187,14 +187,14 @@ class TestTransport(utilities.CanteraTest):
     def test_transport_polynomial_fits_diffusion(self):
         D12 = self.phase.binary_diff_coeffs[1, 2]
         D23 = self.phase.binary_diff_coeffs[2, 3]
-        bd_poly_12 = self.phase.binary_diff_coeffs_polynomial(1, 2)
-        bd_poly_23 = self.phase.binary_diff_coeffs_polynomial(2, 3)
-        self.phase.modify_binary_diff_coeffs_polynomial(1, 2, bd_poly_23)
-        self.phase.modify_binary_diff_coeffs_polynomial(2, 3, bd_poly_12)
+        bd_poly_12 = self.phase.get_binary_diff_coeffs_polynomial(1, 2)
+        bd_poly_23 = self.phase.get_binary_diff_coeffs_polynomial(2, 3)
+        self.phase.set_binary_diff_coeffs_polynomial(1, 2, bd_poly_23)
+        self.phase.set_binary_diff_coeffs_polynomial(2, 3, bd_poly_12)
         D12mod = self.phase.binary_diff_coeffs[1, 2]
         D23mod = self.phase.binary_diff_coeffs[2, 3]
-        self.phase.modify_binary_diff_coeffs_polynomial(1, 2, bd_poly_12)
-        self.phase.modify_binary_diff_coeffs_polynomial(2, 3, bd_poly_23)
+        self.phase.set_binary_diff_coeffs_polynomial(1, 2, bd_poly_12)
+        self.phase.set_binary_diff_coeffs_polynomial(2, 3, bd_poly_23)
         D12new = self.phase.binary_diff_coeffs[1, 2]
         D23new = self.phase.binary_diff_coeffs[2, 3]
         self.assertTrue(D12 != D23)

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -275,69 +275,74 @@ cdef class Transport(_SolutionBase):
     def get_viscosity_polynomial(self, i):
         """Get the polynomial fit to the logarithm of temperature for 
         the viscosity of species i."""
-        n_coeffs = 4 if self.transport.CKMode() else 5
-        return get_transport_polynomial(self, tran_getViscosityPolynomial, i, n_coeffs)
+        n_values = 4 if self.transport.CKMode() else 5
+        return get_transport_polynomial(self, tran_getViscosityPolynomial, i, n_values)
 
     def get_thermal_conductivity_polynomial(self, i):
         """Get the polynomial fit to the logarithm of temperature for 
         the thermal conductivity of species i."""
-        n_coeffs = 4 if self.transport.CKMode() else 5
-        return get_transport_polynomial(self, tran_getConductivityPolynomial, i, n_coeffs)
+        n_values = 4 if self.transport.CKMode() else 5
+        return get_transport_polynomial(self, tran_getConductivityPolynomial, i, n_values)
 
     def get_binary_diff_coeffs_polynomial(self, i, j):
         """Get the polynomial fit to the logarithm of temperature for 
         the binary diffusion coefficient of species i and j."""
-        n_coeffs = 4 if self.transport.CKMode() else 5
-        return get_binary_transport_polynomial(self, tran_getBinDiffusivityPolynomial, i, j, n_coeffs)
+        n_values = 4 if self.transport.CKMode() else 5
+        return get_binary_transport_polynomial(self, tran_getBinDiffusivityPolynomial, i, j, n_values)
 
     def get_collision_integral_polynomials(self, i, j):
         """Get the polynomial fit to the logarithm of temperature for 
         the collision integral of species i and j."""
-        cdef np.ndarray[np.double_t, ndim=1] adata = np.empty(7 if self.transport.CKMode() else 9)
-        cdef np.ndarray[np.double_t, ndim=1] bdata = np.empty(7 if self.transport.CKMode() else 9)
-        cdef np.ndarray[np.double_t, ndim=1] cdata = np.empty(7 if self.transport.CKMode() else 9)
+        n_values = 7 if self.transport.CKMode() else 9
+        cdef np.ndarray[np.double_t, ndim=1] adata = np.empty(n_values)
+        cdef np.ndarray[np.double_t, ndim=1] bdata = np.empty(n_values)
+        cdef np.ndarray[np.double_t, ndim=1] cdata = np.empty(n_values)
         self.transport.getCollisionIntegralPolynomial(i, j, &adata[0], &bdata[0], &cdata[0])
         return adata, bdata, cdata
 
     def set_viscosity_polynomial(self, i, values):
         """Set the polynomial fit to the logarithm of temperature for 
         the viscosity of species i."""
-        if len(values) != (4 if self.transport.CKMode() else 5):
-            msg = "Got {}. Expected {}".format(len(values), (4 if self.transport.CKMode() else 5))
-            raise ValueError('Array has incorrect length. ' + msg + '.')
+        n_values = 4 if self.transport.CKMode() else 5
+        if len(values) != n_values:
+            raise ValueError(
+                f"Array has incorrect length: expected {n_values} but received {len(values)}.")
         cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
         tran_setViscosityPolynomial(self.transport, i, &data[0])
 
     def set_thermal_conductivity_polynomial(self, i, values):
         """Set the polynomial fit to the logarithm of temperature for 
         the thermal conductivity of species i."""
-        if len(values) != (4 if self.transport.CKMode() else 5):
-            msg = "Got {}. Expected {}".format(len(values), (4 if self.transport.CKMode() else 5))
-            raise ValueError('Array has incorrect length. ' + msg + '.')
+        n_values = 4 if self.transport.CKMode() else 5
+        if len(values) != n_values:
+            raise ValueError(
+                f"Array has incorrect length: expected {n_values} but received {len(values)}.")
         cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
         tran_setConductivityPolynomial(self.transport, i, &data[0])
 
     def set_binary_diff_coeffs_polynomial(self, i, j, values):
         """Set the polynomial fit to the logarithm of temperature for 
         the binary diffusion coefficient of species i and j."""
-        if len(values) != (4 if self.transport.CKMode() else 5):
-            msg = "Got {}. Expected {}".format(len(values), (4 if self.transport.CKMode() else 5))
-            raise ValueError('Array has incorrect length. ' + msg + '.')
+        n_values = 4 if self.transport.CKMode() else 5
+        if len(values) != n_values:
+            raise ValueError(
+                f"Array has incorrect length: expected {n_values} but received {len(values)}.")
         cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
         tran_setBinDiffusivityPolynomial(self.transport, i, j, &data[0])
 
     def set_collision_integral_polynomial(self, i, j, avalues, bvalues, cvalues, actualT=True):
         """Get the polynomial fit to the logarithm of temperature for 
         the collision integral of species i and j."""
-        if len(avalues) != (7 if self.transport.CKMode() else 9):
-            msg = "Got {}. Expected {}".format(len(avalues), (7 if self.transport.CKMode() else 9))
-            raise ValueError('Array has incorrect length. ' + msg + '.')
-        if len(bvalues) != (7 if self.transport.CKMode() else 9):
-            msg = "Got {}. Expected {}".format(len(bvalues), (7 if self.transport.CKMode() else 9))
-            raise ValueError('Array has incorrect length. ' + msg + '.')
-        if len(cvalues) != (7 if self.transport.CKMode() else 9):
-            msg = "Got {}. Expected {}".format(len(cvalues), (7 if self.transport.CKMode() else 9))
-            raise ValueError('Array has incorrect length. ' + msg + '.')
+        n_values = 7 if self.transport.CKMode() else 9
+        if len(avalues) != n_values:
+            raise ValueError(
+                f"Array has incorrect length: expected {n_values} but received {len(avalues)}.")
+        if len(bvalues) != n_values:
+            raise ValueError(
+                f"Array has incorrect length: expected {n_values} but received {len(bvalues)}.")
+        if len(cvalues) != n_values:
+            raise ValueError(
+                f"Array has incorrect length: expected {n_values} but received {len(cvalues)}.")
         cdef np.ndarray[np.double_t, ndim=1] adata = np.ascontiguousarray(avalues, dtype=np.double)
         cdef np.ndarray[np.double_t, ndim=1] bdata = np.ascontiguousarray(bvalues, dtype=np.double)
         cdef np.ndarray[np.double_t, ndim=1] cdata = np.ascontiguousarray(cvalues, dtype=np.double)

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -25,7 +25,8 @@ cdef np.ndarray get_transport_polynomial(
     return data
     
 cdef np.ndarray get_binary_transport_polynomial(
-        Transport tran, transportPolyMethod2i method, int indexi, int indexj, int n_coeffs):
+        Transport tran, transportPolyMethod2i method, int indexi, int indexj, 
+        int n_coeffs):
     cdef np.ndarray[np.double_t, ndim=1] data = np.empty(n_coeffs)
     method(tran.transport, indexi, indexj, &data[0])
     return data
@@ -282,13 +283,15 @@ cdef class Transport(_SolutionBase):
         """Get the polynomial fit to the logarithm of temperature for 
         the thermal conductivity of species i."""
         n_values = 4 if self.transport.CKMode() else 5
-        return get_transport_polynomial(self, tran_getConductivityPolynomial, i, n_values)
+        return get_transport_polynomial(self, tran_getConductivityPolynomial, i, 
+                                        n_values)
 
     def get_binary_diff_coeffs_polynomial(self, i, j):
         """Get the polynomial fit to the logarithm of temperature for 
         the binary diffusion coefficient of species i and j."""
         n_values = 4 if self.transport.CKMode() else 5
-        return get_binary_transport_polynomial(self, tran_getBinDiffusivityPolynomial, i, j, n_values)
+        return get_binary_transport_polynomial(self, tran_getBinDiffusivityPolynomial, 
+                                               i, j, n_values)
 
     def get_collision_integral_polynomials(self, i, j):
         """Get the polynomial fit to the logarithm of temperature for 
@@ -297,7 +300,8 @@ cdef class Transport(_SolutionBase):
         cdef np.ndarray[np.double_t, ndim=1] adata = np.empty(n_values)
         cdef np.ndarray[np.double_t, ndim=1] bdata = np.empty(n_values)
         cdef np.ndarray[np.double_t, ndim=1] cdata = np.empty(n_values)
-        self.transport.getCollisionIntegralPolynomial(i, j, &adata[0], &bdata[0], &cdata[0])
+        self.transport.getCollisionIntegralPolynomial(i, j, &adata[0], &bdata[0], 
+                                                      &cdata[0])
         return adata, bdata, cdata
 
     def set_viscosity_polynomial(self, i, values):
@@ -306,8 +310,10 @@ cdef class Transport(_SolutionBase):
         n_values = 4 if self.transport.CKMode() else 5
         if len(values) != n_values:
             raise ValueError(
-                f"Array has incorrect length: expected {n_values} but received {len(values)}.")
-        cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
+                f"""Array has incorrect length: expected {n_values} but 
+                received {len(values)}.""")
+        cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, 
+                                                                        dtype=np.double)
         tran_setViscosityPolynomial(self.transport, i, &data[0])
 
     def set_thermal_conductivity_polynomial(self, i, values):
@@ -316,8 +322,10 @@ cdef class Transport(_SolutionBase):
         n_values = 4 if self.transport.CKMode() else 5
         if len(values) != n_values:
             raise ValueError(
-                f"Array has incorrect length: expected {n_values} but received {len(values)}.")
-        cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
+                f"""Array has incorrect length: expected {n_values} but 
+                received {len(values)}.""")
+        cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, 
+                                                                        dtype=np.double)
         tran_setConductivityPolynomial(self.transport, i, &data[0])
 
     def set_binary_diff_coeffs_polynomial(self, i, j, values):
@@ -326,27 +334,37 @@ cdef class Transport(_SolutionBase):
         n_values = 4 if self.transport.CKMode() else 5
         if len(values) != n_values:
             raise ValueError(
-                f"Array has incorrect length: expected {n_values} but received {len(values)}.")
-        cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
+                f"""Array has incorrect length: expected {n_values} but 
+                received {len(values)}.""")
+        cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, 
+                                                                        dtype=np.double)
         tran_setBinDiffusivityPolynomial(self.transport, i, j, &data[0])
 
-    def set_collision_integral_polynomial(self, i, j, avalues, bvalues, cvalues, actualT=True):
+    def set_collision_integral_polynomial(self, i, j, avalues, bvalues, cvalues, 
+                                          actualT=True):
         """Get the polynomial fit to the logarithm of temperature for 
         the collision integral of species i and j."""
         n_values = 7 if self.transport.CKMode() else 9
         if len(avalues) != n_values:
             raise ValueError(
-                f"Array has incorrect length: expected {n_values} but received {len(avalues)}.")
+                f"""Array has incorrect length: expected {n_values} but 
+                received {len(avalues)}.""")
         if len(bvalues) != n_values:
             raise ValueError(
-                f"Array has incorrect length: expected {n_values} but received {len(bvalues)}.")
+                f"""Array has incorrect length: expected {n_values} but 
+                received {len(bvalues)}.""")
         if len(cvalues) != n_values:
             raise ValueError(
-                f"Array has incorrect length: expected {n_values} but received {len(cvalues)}.")
-        cdef np.ndarray[np.double_t, ndim=1] adata = np.ascontiguousarray(avalues, dtype=np.double)
-        cdef np.ndarray[np.double_t, ndim=1] bdata = np.ascontiguousarray(bvalues, dtype=np.double)
-        cdef np.ndarray[np.double_t, ndim=1] cdata = np.ascontiguousarray(cvalues, dtype=np.double)
-        self.transport.setCollisionIntegralPolynomial(i, j, &adata[0], &bdata[0], &cdata[0], actualT)
+                f"""Array has incorrect length: expected {n_values} but 
+                received {len(cvalues)}.""")
+        cdef np.ndarray[np.double_t, ndim=1] adata = np.ascontiguousarray(avalues, 
+                                                                        dtype=np.double)
+        cdef np.ndarray[np.double_t, ndim=1] bdata = np.ascontiguousarray(bvalues, 
+                                                                        dtype=np.double)
+        cdef np.ndarray[np.double_t, ndim=1] cdata = np.ascontiguousarray(cvalues, 
+                                                                        dtype=np.double)
+        self.transport.setCollisionIntegralPolynomial(i, j, &adata[0], &bdata[0], 
+                                                      &cdata[0], actualT)
 
 cdef class DustyGasTransport(Transport):
     """

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -17,6 +17,18 @@ cdef np.ndarray get_transport_2d(Transport tran, transportMethod2d method):
     cdef np.ndarray[np.double_t, ndim=2] data = np.empty((kk, kk))
     method(tran.transport, kk, &data[0,0])
     return data
+    
+cdef np.ndarray get_transport_polynomial(
+        Transport tran, transportPolyMethod1i method, int index, int n_coeffs):
+    cdef np.ndarray[np.double_t, ndim=1] data = np.empty(n_coeffs)
+    method(tran.transport, index, &data[0])
+    return data
+    
+cdef np.ndarray get_binary_transport_polynomial(
+        Transport tran, transportPolyMethod2i method, int indexi, int indexj, int n_coeffs):
+    cdef np.ndarray[np.double_t, ndim=1] data = np.empty(n_coeffs)
+    method(tran.transport, indexi, indexj, &data[0])
+    return data
 
 cdef class GasTransportData:
     """
@@ -260,64 +272,61 @@ cdef class Transport(_SolutionBase):
         def __get__(self):
             return get_transport_1d(self, tran_getMobilities)
 
-    def viscosity_polynomial(self, i):
+    def get_viscosity_polynomial(self, i):
         """Get the polynomial fit to the logarithm of temperature for 
         the viscosity of species i."""
-        cdef np.ndarray[np.double_t, ndim=1] data = np.empty(4 if self.transport.CKMode() else 5)
-        tran_getViscosityPolynomials(self.transport, i, &data[0])
-        return data
+        n_coeffs = 4 if self.transport.CKMode() else 5
+        return get_transport_polynomial(self, tran_getViscosityPolynomial, i, n_coeffs)
 
-    def thermal_conductivity_polynomial(self, i):
+    def get_thermal_conductivity_polynomial(self, i):
         """Get the polynomial fit to the logarithm of temperature for 
         the thermal conductivity of species i."""
-        cdef np.ndarray[np.double_t, ndim=1] data = np.empty(4 if self.transport.CKMode() else 5)
-        tran_getConductivityPolynomials(self.transport, i, &data[0])
-        return data
+        n_coeffs = 4 if self.transport.CKMode() else 5
+        return get_transport_polynomial(self, tran_getConductivityPolynomial, i, n_coeffs)
 
-    def binary_diff_coeffs_polynomial(self, i, j):
+    def get_binary_diff_coeffs_polynomial(self, i, j):
         """Get the polynomial fit to the logarithm of temperature for 
         the binary diffusion coefficient of species i and j."""
-        cdef np.ndarray[np.double_t, ndim=1] data = np.empty(4 if self.transport.CKMode() else 5)
-        tran_getBinDiffusivityPolynomials(self.transport, i, j, &data[0])
-        return data
+        n_coeffs = 4 if self.transport.CKMode() else 5
+        return get_binary_transport_polynomial(self, tran_getBinDiffusivityPolynomial, i, j, n_coeffs)
 
-    def collision_integral_polynomials(self, i, j):
+    def get_collision_integral_polynomials(self, i, j):
         """Get the polynomial fit to the logarithm of temperature for 
         the collision integral of species i and j."""
         cdef np.ndarray[np.double_t, ndim=1] adata = np.empty(7 if self.transport.CKMode() else 9)
         cdef np.ndarray[np.double_t, ndim=1] bdata = np.empty(7 if self.transport.CKMode() else 9)
         cdef np.ndarray[np.double_t, ndim=1] cdata = np.empty(7 if self.transport.CKMode() else 9)
-        tran_getCollisionIntegralPolynomials(self.transport, i, j, &adata[0], &bdata[0], &cdata[0])
+        self.transport.getCollisionIntegralPolynomial(i, j, &adata[0], &bdata[0], &cdata[0])
         return adata, bdata, cdata
 
-    def modify_viscosity_polynomial(self, i, values):
+    def set_viscosity_polynomial(self, i, values):
         """Set the polynomial fit to the logarithm of temperature for 
         the viscosity of species i."""
         if len(values) != (4 if self.transport.CKMode() else 5):
             msg = "Got {}. Expected {}".format(len(values), (4 if self.transport.CKMode() else 5))
             raise ValueError('Array has incorrect length. ' + msg + '.')
         cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
-        tran_setViscosityPolynomials(self.transport, i, &data[0])
+        tran_setViscosityPolynomial(self.transport, i, &data[0])
 
-    def modify_thermal_conductivity_polynomial(self, i, values):
+    def set_thermal_conductivity_polynomial(self, i, values):
         """Set the polynomial fit to the logarithm of temperature for 
         the thermal conductivity of species i."""
         if len(values) != (4 if self.transport.CKMode() else 5):
             msg = "Got {}. Expected {}".format(len(values), (4 if self.transport.CKMode() else 5))
             raise ValueError('Array has incorrect length. ' + msg + '.')
         cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
-        tran_setConductivityPolynomials(self.transport, i, &data[0])
+        tran_setConductivityPolynomial(self.transport, i, &data[0])
 
-    def modify_binary_diff_coeffs_polynomial(self, i, j, values):
+    def set_binary_diff_coeffs_polynomial(self, i, j, values):
         """Set the polynomial fit to the logarithm of temperature for 
         the binary diffusion coefficient of species i and j."""
         if len(values) != (4 if self.transport.CKMode() else 5):
             msg = "Got {}. Expected {}".format(len(values), (4 if self.transport.CKMode() else 5))
             raise ValueError('Array has incorrect length. ' + msg + '.')
         cdef np.ndarray[np.double_t, ndim=1] data = np.ascontiguousarray(values, dtype=np.double)
-        tran_setBinDiffusivityPolynomials(self.transport, i, j, &data[0])
+        tran_setBinDiffusivityPolynomial(self.transport, i, j, &data[0])
 
-    def modify_collision_integral_polynomials(self, i, j, avalues, bvalues, cvalues, actualT=True):
+    def set_collision_integral_polynomial(self, i, j, avalues, bvalues, cvalues, actualT=True):
         """Get the polynomial fit to the logarithm of temperature for 
         the collision integral of species i and j."""
         if len(avalues) != (7 if self.transport.CKMode() else 9):
@@ -332,7 +341,7 @@ cdef class Transport(_SolutionBase):
         cdef np.ndarray[np.double_t, ndim=1] adata = np.ascontiguousarray(avalues, dtype=np.double)
         cdef np.ndarray[np.double_t, ndim=1] bdata = np.ascontiguousarray(bvalues, dtype=np.double)
         cdef np.ndarray[np.double_t, ndim=1] cdata = np.ascontiguousarray(cvalues, dtype=np.double)
-        tran_setCollisionIntegralPolynomials(self.transport, i, j, &adata[0], &bdata[0], &cdata[0], actualT)
+        self.transport.setCollisionIntegralPolynomial(i, j, &adata[0], &bdata[0], &cdata[0], actualT)
 
 cdef class DustyGasTransport(Transport):
     """

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -319,7 +319,7 @@ void GasTransport::setupCollisionParameters()
     m_polar.resize(m_nsp, false);
     m_alpha.resize(m_nsp, 0.0);
     m_poly.resize(m_nsp);
-    m_star_poly_actualT.resize(m_nsp);
+    m_star_poly_uses_actualT.resize(m_nsp);
     m_sigma.resize(m_nsp);
     m_eps.resize(m_nsp);
     m_w_ac.resize(m_nsp);
@@ -331,7 +331,7 @@ void GasTransport::setupCollisionParameters()
 
     for (size_t i = 0; i < m_nsp; i++) {
         m_poly[i].resize(m_nsp);
-        m_star_poly_actualT[i].resize(m_nsp);
+        m_star_poly_uses_actualT[i].resize(m_nsp);
     }
 
     double f_eps, f_sigma;
@@ -492,15 +492,15 @@ void GasTransport::fitCollisionIntegrals(MMCollisionInt& integrals)
                 m_bstar_poly.push_back(cb);
                 m_cstar_poly.push_back(cc);
                 m_poly[i][j] = static_cast<int>(m_astar_poly.size()) - 1;
-                m_star_poly_actualT[i][j] = 0;
+                m_star_poly_uses_actualT[i][j] = 0;
                 fitlist.push_back(dstar);
             } else {
                 // delta* found in fitlist, so just point to this polynomial
                 m_poly[i][j] = static_cast<int>((dptr - fitlist.begin()));
-                m_star_poly_actualT[i][j] = 0;
+                m_star_poly_uses_actualT[i][j] = 0;
             }
             m_poly[j][i] = m_poly[i][j];
-            m_star_poly_actualT[j][i] = m_star_poly_actualT[i][j];
+            m_star_poly_uses_actualT[j][i] = m_star_poly_uses_actualT[i][j];
         }
     }
 }
@@ -919,8 +919,8 @@ void GasTransport::setCollisionIntegralPolynomial(size_t i, size_t j, double* as
     m_poly[i][j] = static_cast<int>(m_astar_poly.size()) - 1;
     m_poly[j][i] = m_poly[i][j];
     if (actualT) {
-        m_star_poly_actualT[i][j] = 1;
-        m_star_poly_actualT[j][i] = m_star_poly_actualT[i][j];
+        m_star_poly_uses_actualT[i][j] = 1;
+        m_star_poly_uses_actualT[j][i] = m_star_poly_uses_actualT[i][j];
     }
     
     m_visc_ok = false;

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -815,21 +815,21 @@ void GasTransport::getBinDiffCorrection(double t, MMCollisionInt& integrals,
           (q2*xk*xk + q1*xj*xj + q12*xk*xj);
 }
 
-void GasTransport::getViscosityPolynomials(size_t i, double* coeffs) const
+void GasTransport::getViscosityPolynomial(size_t i, double* coeffs) const
 {
     for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
         coeffs[k] = m_visccoeffs[i][k];
     }
 }
 
-void GasTransport::getConductivityPolynomials(size_t i, double* coeffs) const
+void GasTransport::getConductivityPolynomial(size_t i, double* coeffs) const
 {
     for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
         coeffs[k] = m_condcoeffs[i][k];
     }
 }
 
-void GasTransport::getBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs) const
+void GasTransport::getBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) const
 {
     size_t mi = (j >= i? i : j);
     size_t mj = (j >= i? j : i);
@@ -844,7 +844,7 @@ void GasTransport::getBinDiffusivityPolynomials(size_t i, size_t j, double* coef
     }
 }
 
-void GasTransport::getCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+void GasTransport::getCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs) const
 {   
     for (size_t k = 0; k < (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE)+1; k++) {
@@ -854,7 +854,7 @@ void GasTransport::getCollisionIntegralPolynomials(size_t i, size_t j, double* a
     }
 }
 
-void GasTransport::setViscosityPolynomials(size_t i, double* coeffs)
+void GasTransport::setViscosityPolynomial(size_t i, double* coeffs)
 {
     for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
         m_visccoeffs[i][k] = coeffs[k];
@@ -865,12 +865,9 @@ void GasTransport::setViscosityPolynomials(size_t i, double* coeffs)
     m_viscwt_ok = false;
     m_bindiff_ok = false;
     m_temp = -1;
-    
-    std::cout << "Modified viscosity polynomial for species " 
-        << m_thermo->speciesName(i) << std::endl;
 }
 
-void GasTransport::setConductivityPolynomials(size_t i, double* coeffs)
+void GasTransport::setConductivityPolynomial(size_t i, double* coeffs)
 {
     for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
         m_condcoeffs[i][k] = coeffs[k];
@@ -881,12 +878,9 @@ void GasTransport::setConductivityPolynomials(size_t i, double* coeffs)
     m_viscwt_ok = false;
     m_bindiff_ok = false;
     m_temp = -1;
-    
-    std::cout << "Modified thermal conductivity polynomial for species " 
-        << m_thermo->speciesName(i) << std::endl;
 }
 
-void GasTransport::setBinDiffusivityPolynomials(size_t i, size_t j, double* coeffs)
+void GasTransport::setBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs)
 {
     size_t mi = (j >= i? i : j);
     size_t mj = (j >= i? j : i);
@@ -905,12 +899,9 @@ void GasTransport::setBinDiffusivityPolynomials(size_t i, size_t j, double* coef
     m_viscwt_ok = false;
     m_bindiff_ok = false;
     m_temp = -1;
-    
-    std::cout << "Modified binary diffusion coefficient polynomial for species " 
-        << m_thermo->speciesName(i) << " and " << m_thermo->speciesName(j) << std::endl;
 }
 
-void GasTransport::setCollisionIntegralPolynomials(size_t i, size_t j, double* astar_coeffs, 
+void GasTransport::setCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs, bool actualT)
 {
     int degree = (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE);
@@ -937,9 +928,6 @@ void GasTransport::setCollisionIntegralPolynomials(size_t i, size_t j, double* a
     m_viscwt_ok = false;
     m_bindiff_ok = false;
     m_temp = -1;
-    
-    std::cout << "Modified collision polynomials for species " 
-        << m_thermo->speciesName(i) << " and " << m_thermo->speciesName(j) << std::endl;
 }
 
 }

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -847,7 +847,7 @@ void GasTransport::getBinDiffusivityPolynomial(size_t i, size_t j, double* coeff
 void GasTransport::getCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
                                                 double* bstar_coeffs, double* cstar_coeffs) const
 {   
-    for (size_t k = 0; k < (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE)+1; k++) {
+    for (size_t k = 0; k < (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE) + 1; k++) {
         astar_coeffs[k] = m_astar_poly[m_poly[i][j]][k];
         bstar_coeffs[k] = m_bstar_poly[m_poly[i][j]][k];
         cstar_coeffs[k] = m_cstar_poly[m_poly[i][j]][k];

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -844,8 +844,10 @@ void GasTransport::getBinDiffusivityPolynomial(size_t i, size_t j, double* coeff
     }
 }
 
-void GasTransport::getCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
-                                                double* bstar_coeffs, double* cstar_coeffs) const
+void GasTransport::getCollisionIntegralPolynomial(size_t i, size_t j, 
+                                                double* astar_coeffs, 
+                                                double* bstar_coeffs, 
+                                                double* cstar_coeffs) const
 {   
     for (size_t k = 0; k < (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE) + 1; k++) {
         astar_coeffs[k] = m_astar_poly[m_poly[i][j]][k];
@@ -901,8 +903,10 @@ void GasTransport::setBinDiffusivityPolynomial(size_t i, size_t j, double* coeff
     m_temp = -1;
 }
 
-void GasTransport::setCollisionIntegralPolynomial(size_t i, size_t j, double* astar_coeffs, 
-                                                double* bstar_coeffs, double* cstar_coeffs, bool actualT)
+void GasTransport::setCollisionIntegralPolynomial(size_t i, size_t j, 
+                                                double* astar_coeffs, 
+                                                double* bstar_coeffs, 
+                                                double* cstar_coeffs, bool actualT)
 {
     int degree = (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE);
     vector_fp ca(degree+1), cb(degree+1), cc(degree+1);

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -52,7 +52,6 @@ void MultiTransport::init(ThermoPhase* thermo, int mode, int log_level)
     m_frot_298.resize(m_nsp);
     m_rotrelax.resize(m_nsp);
     m_cinternal.resize(m_nsp);
-    //m_om22.resize(m_nsp, m_nsp);
     m_astar.resize(m_nsp, m_nsp);
     m_bstar.resize(m_nsp, m_nsp);
     m_cstar.resize(m_nsp, m_nsp);
@@ -434,20 +433,17 @@ void MultiTransport::updateThermal_T()
     // evaluate polynomial fits for A*, B*, C*
     for (size_t i = 0; i < m_nsp; i++) {
         for (size_t j = i; j < m_nsp; j++) {
-            double z = m_star_poly_actualT[i][j] == 1? m_logt : m_logt - m_log_eps_k(i,j);
+            double z = m_star_poly_uses_actualT[i][j] == 1 ? m_logt : m_logt - m_log_eps_k(i,j);
             int ipoly = m_poly[i][j];
             if (m_mode == CK_Mode) {
-                //m_om22(i,j) = poly6(z, m_omega22_poly[ipoly].data());
                 m_astar(i,j) = poly6(z, m_astar_poly[ipoly].data());
                 m_bstar(i,j) = poly6(z, m_bstar_poly[ipoly].data());
                 m_cstar(i,j) = poly6(z, m_cstar_poly[ipoly].data());
             } else {
-                //m_om22(i,j) = poly8(z, m_omega22_poly[ipoly].data());
                 m_astar(i,j) = poly8(z, m_astar_poly[ipoly].data());
                 m_bstar(i,j) = poly8(z, m_bstar_poly[ipoly].data());
                 m_cstar(i,j) = poly8(z, m_cstar_poly[ipoly].data());
             }
-            //m_om22(j,i) = m_om22(i,j);
             m_astar(j,i) = m_astar(i,j);
             m_bstar(j,i) = m_bstar(i,j);
             m_cstar(j,i) = m_cstar(i,j);

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -52,7 +52,7 @@ void MultiTransport::init(ThermoPhase* thermo, int mode, int log_level)
     m_frot_298.resize(m_nsp);
     m_rotrelax.resize(m_nsp);
     m_cinternal.resize(m_nsp);
-    m_om22.resize(m_nsp, m_nsp);
+    //m_om22.resize(m_nsp, m_nsp);
     m_astar.resize(m_nsp, m_nsp);
     m_bstar.resize(m_nsp, m_nsp);
     m_cstar.resize(m_nsp, m_nsp);
@@ -389,6 +389,7 @@ void MultiTransport::getMultiDiffCoeffs(const size_t ld, doublereal* const d)
                           (m_Lmatrix(i,j) - m_Lmatrix(i,i));
         }
     }
+    
 }
 
 void MultiTransport::update_T()
@@ -433,20 +434,20 @@ void MultiTransport::updateThermal_T()
     // evaluate polynomial fits for A*, B*, C*
     for (size_t i = 0; i < m_nsp; i++) {
         for (size_t j = i; j < m_nsp; j++) {
-            double z = m_logt - m_log_eps_k(i,j);
+            double z = m_star_poly_actualT[i][j] == 1? m_logt : m_logt - m_log_eps_k(i,j);
             int ipoly = m_poly[i][j];
             if (m_mode == CK_Mode) {
-                m_om22(i,j) = poly6(z, m_omega22_poly[ipoly].data());
+                //m_om22(i,j) = poly6(z, m_omega22_poly[ipoly].data());
                 m_astar(i,j) = poly6(z, m_astar_poly[ipoly].data());
                 m_bstar(i,j) = poly6(z, m_bstar_poly[ipoly].data());
                 m_cstar(i,j) = poly6(z, m_cstar_poly[ipoly].data());
             } else {
-                m_om22(i,j) = poly8(z, m_omega22_poly[ipoly].data());
+                //m_om22(i,j) = poly8(z, m_omega22_poly[ipoly].data());
                 m_astar(i,j) = poly8(z, m_astar_poly[ipoly].data());
                 m_bstar(i,j) = poly8(z, m_bstar_poly[ipoly].data());
                 m_cstar(i,j) = poly8(z, m_cstar_poly[ipoly].data());
             }
-            m_om22(j,i) = m_om22(i,j);
+            //m_om22(j,i) = m_om22(i,j);
             m_astar(j,i) = m_astar(i,j);
             m_bstar(j,i) = m_bstar(i,j);
             m_cstar(j,i) = m_cstar(i,j);

--- a/test/transport/transportPolynomials.cpp
+++ b/test/transport/transportPolynomials.cpp
@@ -19,9 +19,9 @@ public:
         size_t k = phase->speciesIndex(speciek);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
         if (cmode == CK_Mode) {
-            ck_tran.getViscosityPolynomials(k, &coeffs[0]);
+            ck_tran.getViscosityPolynomial(k, &coeffs[0]);
         } else {
-            tran.getViscosityPolynomials(k, &coeffs[0]);
+            tran.getViscosityPolynomial(k, &coeffs[0]);
         }
         for (size_t i = 0; i < visc_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], visc_coeff_expected[i], 1e-5);
@@ -34,9 +34,9 @@ public:
         size_t k = phase->speciesIndex(speciek);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
         if (cmode == CK_Mode) {
-            ck_tran.getConductivityPolynomials(k, &coeffs[0]);
+            ck_tran.getConductivityPolynomial(k, &coeffs[0]);
         } else {
-            tran.getConductivityPolynomials(k, &coeffs[0]);
+            tran.getConductivityPolynomial(k, &coeffs[0]);
         }
         for (size_t i = 0; i < cond_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], cond_coeff_expected[i], 1e-5);
@@ -48,9 +48,9 @@ public:
         size_t j = phase->speciesIndex(speciej);
         vector_fp coeffs (cmode == CK_Mode ? 4 : 5);
         if (cmode == CK_Mode) {
-            ck_tran.getBinDiffusivityPolynomials(k, j, &coeffs[0]);
+            ck_tran.getBinDiffusivityPolynomial(k, j, &coeffs[0]);
         } else {
-            tran.getBinDiffusivityPolynomials(k, j, &coeffs[0]);
+            tran.getBinDiffusivityPolynomial(k, j, &coeffs[0]);
         }
         for (size_t i = 0; i < bindiff_coeff_expected.size(); i++) {
             EXPECT_NEAR(coeffs[i], bindiff_coeff_expected[i], 1e-5);


### PR DESCRIPTION
Some modifications that allow accessing and modifying the gas transport properties polynomial fits, also from the python interface.

This is an addition to the earlier pull request #817 and more specifically, a reply to the suggestion of @ischoegl to make the access functions to the transport polynomials also available in the python interface (see https://github.com/Cantera/cantera/pull/817#issuecomment-817332657). 

Next to _access_ to the polynomial fits, I also added the possibility to _modify_ the polynomial coefficients. This in C++ as well as Python. Reason: there is literature that reports the polynomial fits to the transport properties explicitly (as function of log(T) or log(Tr)), rather than in terms of the classic L-J parameters. If this is important, the user now has the option to change the polynomial fits for some species or species pairs, after calculating them from the L-J parameters when first reading the *.cti or *.yaml input file. If the option to modify the polynomial fits is not OK for the public repo, I can remove those modification functions, and limit this pull request only to the access functions in the Python interface.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
