### PR TITLE
Make rate constant calculation consistent with Kee, et al.

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -680,8 +680,12 @@ config_options = [
         False),
     BoolVariable(
         "legacy_rate_constants",
-        """If set to false, rate constant calculations will not use legacy
-        definition by default.""",
+        """If set to 'false', rate constant calculations will will no longer include
+        third-body concentrations for ThreeBodyReaction objects. For Cantera 2.6, the
+        default is set to 'true' (no change of previous behavior). After Cantera 2.6,
+        the default will be changed to 'false', and rate constant calculations will be
+        consistent with conventional definitions (see Eq. 9.75 in Kee, Coltrin and
+        Glarborg, 'Chemically Reacting Flow', Wiley Interscience, 2003).""",
         True),
 ]
 

--- a/SConstruct
+++ b/SConstruct
@@ -678,6 +678,11 @@ config_options = [
         "verbose_tests",
         """If enabled, verbose test output will be shown.""",
         False),
+    BoolVariable(
+        "legacy_rate_constants",
+        """If set to false, rate constant calculations will not use legacy
+        definition by default.""",
+        True),
 ]
 
 opts.AddVariables(*config_options)
@@ -1577,6 +1582,11 @@ if env.get('has_sundials_lapack') and env['use_lapack']:
     configh['CT_SUNDIALS_USE_LAPACK'] = 1
 else:
     configh['CT_SUNDIALS_USE_LAPACK'] = 0
+
+if env['legacy_rate_constants']:
+    configh['CT_LEGACY_RATE_CONSTANTS'] = 1
+else:
+    configh['CT_LEGACY_RATE_CONSTANTS'] = 0
 
 cdefine('LAPACK_FTN_STRING_LEN_AT_END', 'lapack_ftn_string_len_at_end')
 cdefine('LAPACK_FTN_TRAILING_UNDERSCORE', 'lapack_ftn_trailing_underscore')

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -78,4 +78,7 @@ typedef int ftnlen;       // Fortran hidden string length type
 //    built to use this option
 {CT_SUNDIALS_USE_LAPACK!s}
 
+//    Use legacy rate constant by default
+{CT_LEGACY_RATE_CONSTANTS!s}
+
 #endif

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -221,6 +221,12 @@ void suppress_thermo_warnings(bool suppress=true);
 //! @copydoc Application::thermo_warnings_suppressed
 bool thermo_warnings_suppressed();
 
+//! @copydoc Application::use_legacy_rate_constants
+void use_legacy_rate_constants(bool legacy=true);
+
+//! @copydoc Application::legacy_rate_constants_used
+bool legacy_rate_constants_used();
+
 //! @copydoc Application::Messages::setLogger
 void setLogger(Logger* logwriter);
 

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -164,6 +164,7 @@ extern "C" {
     CANTERA_CAPI int ct_getCanteraVersion(int buflen, char* buf);
     CANTERA_CAPI int ct_getGitCommit(int buflen, char* buf);
     CANTERA_CAPI int ct_suppress_thermo_warnings(int suppress);
+    CANTERA_CAPI int ct_use_legacy_rate_constants(int legacy);
     CANTERA_CAPI int ct_clearStorage();
 
     CANTERA_CAPI int ct_ck2cti(const char* in_file, const char* db_file,

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -35,7 +35,7 @@ public:
     virtual void getDeltaSSEnthalpy(doublereal* deltaH);
     virtual void getDeltaSSEntropy(doublereal* deltaS);
 
-    virtual void getRevRateConstants(doublereal* krev,
+    virtual void getRevRateConstants(double* krev,
                                      bool doIrreversible = false);
 
     virtual bool addReaction(shared_ptr<Reaction> r);

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -43,7 +43,7 @@ public:
     //! @{
 
     virtual void getEquilibriumConstants(doublereal* kc);
-    virtual void getFwdRateConstants(doublereal* kfwd);
+    virtual void getFwdRateConstants(double* kfwd);
 
     //! @}
     //! @name Reaction Mechanism Setup Routines

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -650,11 +650,13 @@ public:
      * @param kfwd    Output vector containing the forward reaction rate
      *                constants. Length: nReactions().
      *
-     * @deprecated  Behavior to change after Cantera 2.6; results will no longer
-     *              include third-body concentrations for ThreeBodyReaction objects.
-     *              Going forward, results are consistent with conventional definitions
-     *              (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
-     *              Flow', Wiley Interscience, 2003).
+     * @deprecated  Behavior to change after Cantera 2.6; for Cantera 2.6, rate
+     *              constants of three-body reactions are multiplied with third-body
+     *              concentrations (no change to legacy behavior). After Cantera 2.6,
+     *              results will no longer include third-body concentrations and be
+     *              consistent with conventional definitions (see Eq. 9.75 in
+     *              Kee, Coltrin and Glarborg, 'Chemically eacting Flow', Wiley
+     *              Interscience, 2003).
      *              For new behavior, set 'Cantera::use_legacy_rate_constants(false)'.
      */
     virtual void getFwdRateConstants(double* kfwd) {
@@ -674,11 +676,13 @@ public:
      * @param doIrreversible boolean indicating whether irreversible reactions
      *                       should be included.
      *
-     * @deprecated  Behavior to change after Cantera 2.6; results will no longer
-     *              include third-body concentrations for ThreeBodyReaction objects.
-     *              Going forward, results are consistent with conventional definitions
-     *              (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
-     *              Flow', Wiley Interscience, 2003).
+     * @deprecated  Behavior to change after Cantera 2.6; for Cantera 2.6, rate
+     *              constants of three-body reactions are multiplied with third-body
+     *              concentrations (no change to legacy behavior). After Cantera 2.6,
+     *              results will no longer include third-body concentrations and be
+     *              consistent with conventional definitions (see Eq. 9.75 in
+     *              Kee, Coltrin and Glarborg, 'Chemically eacting Flow', Wiley
+     *              Interscience, 2003).
      *              For new behavior, set 'Cantera::use_legacy_rate_constants(false)'.
      */
     virtual void getRevRateConstants(double* krev,

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -649,8 +649,15 @@ public:
      *
      * @param kfwd    Output vector containing the forward reaction rate
      *                constants. Length: nReactions().
+     *
+     * @deprecated  Behavior to change after Cantera 2.6; results will no longer
+     *              include third-body concentrations for ThreeBodyReaction objects.
+     *              Going forward, results are consistent with conventional definitions
+     *              (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
+     *              Flow', Wiley Interscience, 2003).
+     *              For new behavior, set 'Cantera::use_legacy_rate_constants(false)'.
      */
-    virtual void getFwdRateConstants(doublereal* kfwd) {
+    virtual void getFwdRateConstants(double* kfwd) {
         throw NotImplementedError("Kinetics::getFwdRateConstants");
     }
 
@@ -666,10 +673,17 @@ public:
      * @param krev   Output vector of reverse rate constants
      * @param doIrreversible boolean indicating whether irreversible reactions
      *                       should be included.
+     *
+     * @deprecated  Behavior to change after Cantera 2.6; results will no longer
+     *              include third-body concentrations for ThreeBodyReaction objects.
+     *              Going forward, results are consistent with conventional definitions
+     *              (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
+     *              Flow', Wiley Interscience, 2003).
+     *              For new behavior, set 'Cantera::use_legacy_rate_constants(false)'.
      */
-    virtual void getRevRateConstants(doublereal* krev,
+    virtual void getRevRateConstants(double* krev,
                                      bool doIrreversible = false) {
-        throw NotImplementedError("Kinetics::getFwdRateConstants");
+        throw NotImplementedError("Kinetics::getRevRateConstants");
     }
 
     //! @}

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -112,6 +112,7 @@ cdef extern from "cantera/base/global.h" namespace "Cantera":
     cdef void Cxx_make_deprecation_warnings_fatal "Cantera::make_deprecation_warnings_fatal" ()
     cdef void Cxx_suppress_deprecation_warnings "Cantera::suppress_deprecation_warnings" ()
     cdef void Cxx_suppress_thermo_warnings "Cantera::suppress_thermo_warnings" (cbool)
+    cdef void Cxx_use_legacy_rate_constants "Cantera::use_legacy_rate_constants" (cbool)
     cdef string CxxGitCommit "Cantera::gitCommit" ()
 
 cdef extern from "<memory>":

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -301,6 +301,15 @@ cdef class Kinetics(_SolutionBase):
         all temperature-dependent, pressure-dependent, and third body
         contributions. Units are a combination of kmol, m^3 and s, that depend
         on the rate expression for the reaction.
+
+        .. deprecated:: 2.6
+
+            Behavior to change after Cantera 2.6; results will no longer
+            include third-body concentrations for ThreeBodyReaction objects.
+            Going forward, results are consistent with conventional definitions
+            (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
+            Flow', Wiley Interscience, 2003).
+            For new behavior, run 'ct.use_legacy_rate_constants(False)'.
         """
         def __get__(self):
             return get_reaction_array(self, kin_getFwdRateConstants)
@@ -311,6 +320,15 @@ cdef class Kinetics(_SolutionBase):
         all temperature-dependent, pressure-dependent, and third body
         contributions. Units are a combination of kmol, m^3 and s, that depend
         on the rate expression for the reaction.
+
+        .. deprecated:: 2.6
+
+            Behavior to change after Cantera 2.6; results will no longer
+            include third-body concentrations for ThreeBodyReaction objects.
+            Going forward, results are consistent with conventional definitions
+            (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
+            Flow', Wiley Interscience, 2003).
+            For new behavior, run 'ct.use_legacy_rate_constants(False)'.
         """
         def __get__(self):
             return get_reaction_array(self, kin_getRevRateConstants)

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -304,12 +304,13 @@ cdef class Kinetics(_SolutionBase):
 
         .. deprecated:: 2.6
 
-            Behavior to change after Cantera 2.6; results will no longer
-            include third-body concentrations for ThreeBodyReaction objects.
-            Going forward, results are consistent with conventional definitions
-            (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
-            Flow', Wiley Interscience, 2003).
-            For new behavior, run 'ct.use_legacy_rate_constants(False)'.
+            Behavior to change after Cantera 2.6; for Cantera 2.6, rate constants of
+            three-body reactions are multiplied with third-body concentrations
+            (no change to legacy behavior). After Cantera 2.6, results will no longer
+            include third-body concentrations and be consistent with conventional
+            definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically
+            Reacting Flow', Wiley Interscience, 2003).
+            To switch to new behavior, run 'cantera.use_legacy_rate_constants(False)'.
         """
         def __get__(self):
             return get_reaction_array(self, kin_getFwdRateConstants)
@@ -323,12 +324,13 @@ cdef class Kinetics(_SolutionBase):
 
         .. deprecated:: 2.6
 
-            Behavior to change after Cantera 2.6; results will no longer
-            include third-body concentrations for ThreeBodyReaction objects.
-            Going forward, results are consistent with conventional definitions
-            (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
-            Flow', Wiley Interscience, 2003).
-            For new behavior, run 'ct.use_legacy_rate_constants(False)'.
+            Behavior to change after Cantera 2.6; for Cantera 2.6, rate constants of
+            three-body reactions are multiplied with third-body concentrations
+            (no change to legacy behavior). After Cantera 2.6, results will no longer
+            include third-body concentrations and be consistent with conventional
+            definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically
+            Reacting Flow', Wiley Interscience, 2003).
+            To switch to new behavior, run 'cantera.use_legacy_rate_constants(False)'.
         """
         def __get__(self):
             return get_reaction_array(self, kin_getRevRateConstants)

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -48,10 +48,23 @@ class TestKinetics(utilities.CanteraTest):
         self.assertArrayNear(0.5 * rev_rates0, rev_rates2)
 
     def test_legacy_reaction_rate(self):
-        ct.use_legacy_rate_constants(True)
+        ct.use_legacy_rate_constants(True) # set to False for test suite
         with self.assertRaisesRegex(ct.CanteraError, "Deprecated: Behavior to change"):
             self.phase.forward_rate_constants
+
+        ct.suppress_deprecation_warnings() # disable fatal deprecation warnings
+        fwd_rates_legacy = self.phase.forward_rate_constants
+
         ct.use_legacy_rate_constants(False)
+        ct.make_deprecation_warnings_fatal() # re-enable fatal deprecation warnings
+
+        fwd_rates = self.phase.forward_rate_constants
+        ix_3b = np.array([self.phase.reaction_type_str(i) == "three-body"
+            for i in range(self.phase.n_reactions)])
+        ix_other = ix_3b == False
+
+        self.assertArrayNear(fwd_rates_legacy[ix_other], fwd_rates[ix_other])
+        self.assertFalse((fwd_rates_legacy[ix_3b] == fwd_rates[ix_3b]).any())
 
     def test_reaction_type(self):
         self.assertIn(self.phase.reaction_type_str(0), ["three-body", "three-body-legacy"])

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -47,6 +47,12 @@ class TestKinetics(utilities.CanteraTest):
         self.assertArrayNear(0.5 * fwd_rates0, fwd_rates2)
         self.assertArrayNear(0.5 * rev_rates0, rev_rates2)
 
+    def test_legacy_reaction_rate(self):
+        ct.use_legacy_rate_constants(True)
+        with self.assertRaisesRegex(ct.CanteraError, "Deprecated: Behavior to change"):
+            self.phase.forward_rate_constants
+        ct.use_legacy_rate_constants(False)
+
     def test_reaction_type(self):
         self.assertIn(self.phase.reaction_type_str(0), ["three-body", "three-body-legacy"])
         self.assertIn(self.phase.reaction_type_str(2), ["elementary", "elementary-legacy"])

--- a/interfaces/cython/cantera/test/utilities.py
+++ b/interfaces/cython/cantera/test/utilities.py
@@ -51,6 +51,7 @@ class CanteraTest(unittest.TestCase):
             cls.using_tempfile = True
 
         cantera.make_deprecation_warnings_fatal()
+        cantera.use_legacy_rate_constants(False)
         cantera.add_directory(cls.test_work_path)
         cls.test_data_path = TEST_DATA_PATH
         cls.cantera_data_path = CANTERA_DATA_PATH

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -56,6 +56,9 @@ def suppress_deprecation_warnings():
 def suppress_thermo_warnings(pybool suppress=True):
     Cxx_suppress_thermo_warnings(suppress)
 
+def use_legacy_rate_constants(pybool legacy):
+    Cxx_use_legacy_rate_constants(legacy)
+
 cdef Composition comp_map(X) except *:
     if isinstance(X, (str, bytes)):
         return parseCompString(stringify(X))

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -57,6 +57,25 @@ def suppress_thermo_warnings(pybool suppress=True):
     Cxx_suppress_thermo_warnings(suppress)
 
 def use_legacy_rate_constants(pybool legacy):
+    """
+    Set definition used for rate constant calculation.
+
+    If set to 'False', rate constants of three-body reactions are consistent with
+    conventional definitions. If set to 'True', output for rate constants of
+    three-body reactions is multipied by third-body concentrations (legacy behavior).
+    For the pre-compiled Cantera 2.6 distribution, the default value is set to 'True',
+    which implies no change compared to previous behavior. For user-compiled Cantera,
+    the default behavior can be changed by the SCons flag 'legacy_rate_constants'.
+
+    .. deprecated:: 2.6
+
+        Behavior to change after Cantera 2.6; for Cantera 2.6, rate constants of
+        three-body reactions are multiplied with third-body concentrations
+        (no change to legacy behavior). After Cantera 2.6, results will no longer
+        include third-body concentrations and be consistent with conventional
+        definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically
+        Reacting Flow', Wiley Interscience, 2003).
+    """
     Cxx_use_legacy_rate_constants(legacy)
 
 cdef Composition comp_map(X) except *:

--- a/interfaces/matlab/toolbox/@Kinetics/fwdRateConstants.m
+++ b/interfaces/matlab/toolbox/@Kinetics/fwdRateConstants.m
@@ -6,6 +6,13 @@ function kf = fwdRateConstants(a)
 % third body contributions. Units are a combination of kmol, m^3 and s, that
 % depend on the rate expression for the reaction.
 %
+% Warning:  Behavior to change after Cantera 2.6; results will no longer
+%           include third-body concentrations for ThreeBodyReaction objects.
+%           Going forward, results are consistent with conventional definitions
+%           (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
+%           Flow', Wiley Interscience, 2003).
+%           For new behavior, run 'useLegacyRateConstants(0)'.
+%
 % see also: :mat:func:`revRateConstants`, :mat:func:`equil_Kc`
 %
 % :param a:

--- a/interfaces/matlab/toolbox/@Kinetics/fwdRateConstants.m
+++ b/interfaces/matlab/toolbox/@Kinetics/fwdRateConstants.m
@@ -6,12 +6,15 @@ function kf = fwdRateConstants(a)
 % third body contributions. Units are a combination of kmol, m^3 and s, that
 % depend on the rate expression for the reaction.
 %
-% Warning:  Behavior to change after Cantera 2.6; results will no longer
-%           include third-body concentrations for ThreeBodyReaction objects.
-%           Going forward, results are consistent with conventional definitions
-%           (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
-%           Flow', Wiley Interscience, 2003).
-%           For new behavior, run 'useLegacyRateConstants(0)'.
+% Deprecated 2.6:
+%
+%     Behavior to change after Cantera 2.6; for Cantera 2.6, rate constants of
+%     three-body reactions are multiplied with third-body concentrations
+%     (no change to legacy behavior). After Cantera 2.6, results will no longer
+%     include third-body concentrations and be consistent with conventional
+%     definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically
+%     Reacting Flow', Wiley Interscience, 2003).
+%     To switch to new behavior, run 'useLegacyRateConstants(0)'.
 %
 % see also: :mat:func:`revRateConstants`, :mat:func:`equil_Kc`
 %

--- a/interfaces/matlab/toolbox/@Kinetics/revRateConstants.m
+++ b/interfaces/matlab/toolbox/@Kinetics/revRateConstants.m
@@ -6,12 +6,15 @@ function kr = revRateConstants(a)
 % third body contributions. Units are a combination of kmol, m^3 and s, that
 % depend on the rate expression for the reaction.
 %
-% Warning:  Behavior to change after Cantera 2.6; results will no longer
-%           include third-body concentrations for ThreeBodyReaction objects.
-%           Going forward, results are consistent with conventional definitions
-%           (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
-%           Flow', Wiley Interscience, 2003).
-%           For new behavior, run 'useLegacyRateConstants(0)'.
+% Deprecated 2.6:
+%
+%     Behavior to change after Cantera 2.6; for Cantera 2.6, rate constants of
+%     three-body reactions are multiplied with third-body concentrations
+%     (no change to legacy behavior). After Cantera 2.6, results will no longer
+%     include third-body concentrations and be consistent with conventional
+%     definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically
+%     Reacting Flow', Wiley Interscience, 2003).
+%     To switch to new behavior, run 'useLegacyRateConstants(0)'.
 %
 % See also: :mat:func:`fwdRateConstants`, :mat:func:`equil_KC`
 %

--- a/interfaces/matlab/toolbox/@Kinetics/revRateConstants.m
+++ b/interfaces/matlab/toolbox/@Kinetics/revRateConstants.m
@@ -6,6 +6,13 @@ function kr = revRateConstants(a)
 % third body contributions. Units are a combination of kmol, m^3 and s, that
 % depend on the rate expression for the reaction.
 %
+% Warning:  Behavior to change after Cantera 2.6; results will no longer
+%           include third-body concentrations for ThreeBodyReaction objects.
+%           Going forward, results are consistent with conventional definitions
+%           (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
+%           Flow', Wiley Interscience, 2003).
+%           For new behavior, run 'useLegacyRateConstants(0)'.
+%
 % See also: :mat:func:`fwdRateConstants`, :mat:func:`equil_KC`
 %
 % :param a:

--- a/interfaces/matlab/toolbox/useLegacyRateConstants.m
+++ b/interfaces/matlab/toolbox/useLegacyRateConstants.m
@@ -1,9 +1,22 @@
 function v = useLegacyRateConstants(legacy)
 % USELEGACYRATECONSTANTS  Set definition used for rate constant calculation
-% useLegacyRateConstants(1)
+% useLegacyRateConstants(0)
 %
-% If set to 1 (true), rate constants include third-body concentrations for
-% ThreeBodyReaction objects.
+% If set to 0 (false), rate constants of three-body reactions are consistent with
+% conventional definitions. If set to 1 (true), output for rate constants of
+% three-body reactions is multipied by third-body concentrations (legacy behavior).
+% For the pre-compiled Cantera 2.6 distribution, the default value is set to 1 (true),
+% which implies no change compared to previous behavior. For user-compiled Cantera,
+% the default behavior can be changed by the SCons flag 'legacy_rate_constants'.
+%
+% Deprecated 2.6:
+%
+%     Behavior to change after Cantera 2.6; for Cantera 2.6, rate constants of
+%     three-body reactions are multiplied with third-body concentrations
+%     (no change to legacy behavior). After Cantera 2.6, results will no longer
+%     include third-body concentrations and be consistent with conventional
+%     definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically
+%     Reacting Flow', Wiley Interscience, 2003).
 %
 % See also: :mat:func:`fwdRateConstants`, :mat:func:`revRateConstants`.
 %

--- a/interfaces/matlab/toolbox/useLegacyRateConstants.m
+++ b/interfaces/matlab/toolbox/useLegacyRateConstants.m
@@ -1,0 +1,11 @@
+function v = useLegacyRateConstants(legacy)
+% USELEGACYRATECONSTANTS  Set definition used for rate constant calculation
+% useLegacyRateConstants(1)
+%
+% If set to 1 (true), rate constants include third-body concentrations for
+% ThreeBodyReaction objects.
+%
+% See also: :mat:func:`fwdRateConstants`, :mat:func:`revRateConstants`.
+%
+
+ctmethods(0, 8, legacy);

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -126,7 +126,8 @@ void Application::ThreadMessages::removeThreadMessages()
 Application::Application() :
     m_suppress_deprecation_warnings(false),
     m_fatal_deprecation_warnings(false),
-    m_suppress_thermo_warnings(false)
+    m_suppress_thermo_warnings(false),
+    m_use_legacy_rate_constants(true)
 {
     // install a default logwriter that writes to standard
     // output / standard error

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -127,7 +127,11 @@ Application::Application() :
     m_suppress_deprecation_warnings(false),
     m_fatal_deprecation_warnings(false),
     m_suppress_thermo_warnings(false),
+#if CT_LEGACY_RATE_CONSTANTS
     m_use_legacy_rate_constants(true)
+#else
+    m_use_legacy_rate_constants(false)
+#endif
 {
     // install a default logwriter that writes to standard
     // output / standard error

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -365,6 +365,20 @@ public:
         return m_suppress_thermo_warnings;
     }
 
+    //! Use definition of rate constants that includes third-body concentrations
+    //! for ThreeBodyReaction objects.
+    /*!
+     * @deprecated  Used for deprecation purposes, @see Kinetics::getFwdRateConstants()
+     */
+    void use_legacy_rate_constants(bool legacy=true) {
+        m_use_legacy_rate_constants = legacy;
+    }
+
+    //! Returns `true` if legacy rate constant definition should be used
+    bool legacy_rate_constants_used() {
+        return m_use_legacy_rate_constants;
+    }
+
     //! @copydoc Messages::setLogger
     void setLogger(Logger* logwriter) {
         pMessenger->setLogger(logwriter);
@@ -425,6 +439,7 @@ protected:
     bool m_suppress_deprecation_warnings;
     bool m_fatal_deprecation_warnings;
     bool m_suppress_thermo_warnings;
+    bool m_use_legacy_rate_constants;
 
     ThreadMessages pMessenger;
 

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -365,10 +365,24 @@ public:
         return m_suppress_thermo_warnings;
     }
 
-    //! Use definition of rate constants that includes third-body concentrations
-    //! for ThreeBodyReaction objects.
+    //! Set definition used for rate constant calculation.
+    //! @see Kinetics::getFwdRateConstants()
     /*!
-     * @deprecated  Used for deprecation purposes, @see Kinetics::getFwdRateConstants()
+     * If set to 'false', rate constants of three-body reactions are consistent with
+     * conventional definitions. If set to 'true', output for rate constants of
+     * three-body reactions is multipied by third-body concentrations (legacy
+     * behavior). For the pre-compiled Cantera 2.6 distribution, the default value is
+     * set to 'true', which implies no change compared to previous behavior. For
+     * user-compiled Cantera, the default behavior can be changed by the SCons flag
+     * 'legacy_rate_constants'.
+     *
+     * @deprecated  Behavior to change after Cantera 2.6; for Cantera 2.6, rate
+     *              constants of three-body reactions are multiplied with third-body
+     *              concentrations (no change to legacy behavior). After Cantera 2.6,
+     *              results will no longer include third-body concentrations and be
+     *              consistent with conventional definitions (see Eq. 9.75 in
+     *              Kee, Coltrin and Glarborg, 'Chemically eacting Flow', Wiley
+     *              Interscience, 2003).
      */
     void use_legacy_rate_constants(bool legacy=true) {
         m_use_legacy_rate_constants = legacy;

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -81,6 +81,16 @@ bool thermo_warnings_suppressed()
     return app()->thermo_warnings_suppressed();
 }
 
+void use_legacy_rate_constants(bool legacy)
+{
+    app()->use_legacy_rate_constants(legacy);
+}
+
+bool legacy_rate_constants_used()
+{
+    return app()->legacy_rate_constants_used();
+}
+
 // **************** Global Data ****************
 
 Unit* Unit::s_u = 0;

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1494,6 +1494,16 @@ extern "C" {
         }
     }
 
+    int ct_use_legacy_rate_constants(int legacy)
+    {
+        try {
+            use_legacy_rate_constants(legacy != 0);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int ct_setLogWriter(void* logger)
     {
         try {

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -80,7 +80,7 @@ void BulkKinetics::getDeltaSSEntropy(doublereal* deltaS)
     getReactionDelta(m_grt.data(), deltaS);
 }
 
-void BulkKinetics::getRevRateConstants(doublereal* krev, bool doIrreversible)
+void BulkKinetics::getRevRateConstants(double* krev, bool doIrreversible)
 {
     // go get the forward rate constants. -> note, we don't really care about
     // speed or redundancy in these informational routines.

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -237,9 +237,11 @@ void GasKinetics::getFwdRateConstants(double* kfwd)
 
     if (legacy_rate_constants_used()) {
         warn_deprecated("GasKinetics::getFwdRateConstants",
-            "Behavior to change after Cantera 2.6;\nresults will no longer "
-            "include third-body concentrations for ThreeBodyReaction objects.\n"
-            "Set 'use_legacy_rate_constants' to false for new behavior.");
+            "Behavior to change after Cantera 2.6;\nresults will no longer include "
+            "third-body concentrations for three-body reactions.\nTo switch to new "
+            "behavior, use 'cantera.use_legacy_rate_constants(False)' (Python),\n"
+            "'useLegacyRateConstants(0)' (MATLAB), 'Cantera::use_legacy_rate_constants"
+            "(false)' (C++),\nor 'ct_use_legacy_rate_constants(0)' (clib).");
 
         // multiply ropf by enhanced 3b conc for all 3b rxns
         if (!concm_3b_values.empty()) {

--- a/src/matlab/ctfunctions.cpp
+++ b/src/matlab/ctfunctions.cpp
@@ -33,7 +33,7 @@ void ctfunctions(int nlhs, mxArray* plhs[],
                  int nrhs, const mxArray* prhs[])
 {
     int job = getInt(prhs[1]);
-    int iok = 0, dbg, validate;
+    int iok = 0, dbg, validate, legacy;
     char* infile, *dbfile, *trfile, *idtag, *sep;
     int buflen = 0;
     char* output_buf = 0;
@@ -104,6 +104,12 @@ void ctfunctions(int nlhs, mxArray* plhs[],
         output_buf = (char*)mxCalloc(buflen, sizeof(char));
         iok = ct_getGitCommit(buflen, output_buf);
         plhs[0] = mxCreateString(output_buf);
+        return;
+
+        // set definition used for rate constant calculation
+    case 8:
+        legacy = getInt(prhs[2]);
+        iok = ct_use_legacy_rate_constants(legacy);
         return;
 
     default:

--- a/test/general/string_processing.cpp
+++ b/test/general/string_processing.cpp
@@ -118,6 +118,7 @@ int main(int argc, char** argv)
     printf("Running main() from string_processing.cpp\n");
     testing::InitGoogleTest(&argc, argv);
     Cantera::make_deprecation_warnings_fatal();
+    Cantera::use_legacy_rate_constants(false);
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();
     return result;

--- a/test/kinetics/pdep.cpp
+++ b/test/kinetics/pdep.cpp
@@ -225,6 +225,7 @@ int main(int argc, char** argv)
 {
     printf("Running main() from pdep.cpp\n");
     Cantera::make_deprecation_warnings_fatal();
+    Cantera::use_legacy_rate_constants(false);
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The current implementation of `GasKinetics::getFwdRateConstants` is not consistent with textbook definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, Chemically Reacting Flow). An implementation consistent with Eq. 9.75 multiplies the effective third-body concentration only for the calculation of rates-of-progress. Falloff reactions are a separate case as they use a modified rate constant, which does include third-body concentrations.

As implemented, the calculation is separate from `updateROP` (i.e. no change from previous approach). The affected methods mainly serve informational purposes (see comment in `BulkKinetics::getRevRateConstants`), so there is no expected impact on performance. 

The deprecation uses a global flag to make a transition minimally intrusive. This is important, as rate constants are used extensively in the test suite. 

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1083

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

The proposed change deprecates the old behavior and includes a global switch to facilitate the transition:
```
In [1]: import cantera as ct
   ...: gas = ct.Solution("h2o2.yaml")
   ...: gas.TPX = 300, ct.one_atm, 'H2:1, O2:3'
   ...: gas.equilibrate('HP')
   ...: 

In [2]: gas.forward_rate_constants
DeprecationWarning: GasKinetics::getFwdRateConstants: Behavior to change after Cantera 2.6;
results will no longer include third-body concentrations for ThreeBodyReaction objects.
Set 'use_legacy_rate_constants' to false for new behavior.
Out[2]: 
array([1.66615789e+06, 3.30877601e+06, 8.13054905e+09, 2.00000000e+10,
       1.63880887e+10, 2.03131173e+05, 6.47691445e+06, 5.46151483e+07,
       0.00000000e+00, 0.00000000e+00, 2.65917764e+09, 1.97800108e+06,
       1.07713432e+03, 6.84832674e+06, 5.01798085e+07, 3.38149587e+09,
       3.47031524e+10, 7.21665842e+10, 1.54550508e+10, 4.22813794e+09,
       9.91305045e+09, 2.98116515e+07, 5.58903179e+09, 1.63414930e+10,
       1.80587269e+09, 1.50070437e+12, 1.91961755e+08, 2.38275715e+10,
       7.93037160e+10])

In [3]: ct.use_legacy_rate_constants(False)

In [4]: gas.forward_rate_constants
Out[4]: 
array([5.70210643e+07, 2.37587768e+08, 8.13054905e+09, 2.00000000e+10,
       1.63880887e+10, 3.88376134e+09, 1.57529678e+09, 3.35697020e+10,
       1.96912098e+09, 1.53667243e+09, 2.65917764e+09, 4.75175536e+08,
       9.12756539e+08, 4.20938686e+09, 4.96741937e+09, 3.38149587e+09,
       3.47031524e+10, 7.21665842e+10, 1.54550508e+10, 4.22813794e+09,
       9.91305045e+09, 2.98116515e+07, 5.58903179e+09, 1.63414930e+10,
       1.80587269e+09, 1.50070437e+12, 1.91961755e+08, 2.38275715e+10,
       7.93037160e+10])
```

This change further clarifies a current discrepancy between outputs of `ReactionRate` and `forward_rate_constants` for three-body reactions, e.g.
```
In [5]: ix = 0
   ...: gas.reaction(ix)
   ...: 
Out[5]: <ThreeBodyReaction: 2 O + M <=> O2 + M>

In [6]: ct.use_legacy_rate_constants(True) # current implementation

In [7]: gas.reaction(ix).rate(gas.T) # this evaluates the standard Arrhenius reaction rate
Out[7]: 57021064.2631974

In [8]: gas.forward_rate_constants[ix]
Out[8]: 1666157.893731073

In [9]: ct.use_legacy_rate_constants(False) # proposed implementation

In [10]: gas.reaction(ix).rate(gas.T)
Out[10]: 57021064.2631974

In [11]: gas.forward_rate_constants[ix]
Out[11]: 57021064.2631974
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review

**Additional thoughts**

The default behavior would presumably switch to the standard definition with Cantera 3.0. There is no reason to remove the flag at that point in case there should be concerns about back-ward compatibility of existing scripts.

**Further context**

The current definition affects temperature derivatives for the calculation of Jacobians (e.g. #1081), where a spurious dependency is created due to the inclusion of `M` *concentrations* in the rate constant calculation.