### PR TITLE
Update composite.py

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -928,7 +928,7 @@ class SolutionArray:
         # ensure that SolutionArray accommodates dimensions
         if self._shape == (0,):
             self._states = [self._phase.state] * rows
-            self._indices = range(rows)
+            self._indices = list(range(rows))
             self._output_dummy = self._indices
             self._shape = (rows,)
 


### PR DESCRIPTION
use a list object instead of range object for SolutionArray._indices, to continue using the append function with Python 3 (which has no longer an append function for range objects).

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

-
-
-

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1085

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
