### PR TITLE
Fix pressure dependence in IdealSolidSolnPhase::getPartialMolarEnthalpies

### DIFF
--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -194,7 +194,7 @@ void IdealSolidSolnPhase::getActivityCoefficients(doublereal* ac) const
 
 void IdealSolidSolnPhase::getChemPotentials(doublereal* mu) const
 {
-    doublereal delta_p = m_Pcurrent - m_Pref;
+    double delta_p = m_Pcurrent - m_Pref;
     const vector_fp& g_RT = gibbs_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
@@ -205,7 +205,7 @@ void IdealSolidSolnPhase::getChemPotentials(doublereal* mu) const
 
 void IdealSolidSolnPhase::getChemPotentials_RT(doublereal* mu) const
 {
-    doublereal delta_pdRT = (m_Pcurrent - m_Pref) / (temperature() * GasConstant);
+    double delta_pdRT = (m_Pcurrent - m_Pref) / (temperature() * GasConstant);
     const vector_fp& g_RT = gibbs_RT_ref();
     for (size_t k = 0; k < m_kk; k++) {
         double xx = std::max(SmallNumber, moleFraction(k));
@@ -249,7 +249,7 @@ void IdealSolidSolnPhase::getPartialMolarVolumes(doublereal* vbar) const
 void IdealSolidSolnPhase::getPureGibbs(doublereal* gpure) const
 {
     const vector_fp& gibbsrt = gibbs_RT_ref();
-    doublereal delta_p = (m_Pcurrent - m_Pref);
+    double delta_p = (m_Pcurrent - m_Pref);
     for (size_t k = 0; k < m_kk; k++) {
         gpure[k] = RT() * gibbsrt[k] + delta_p * m_speciesMolarVolume[k];
     }
@@ -494,7 +494,12 @@ void IdealSolidSolnPhase::initThermoXML(XML_Node& phaseNode, const std::string& 
 void IdealSolidSolnPhase::setToEquilState(const doublereal* mu_RT)
 {
     const vector_fp& grt = gibbs_RT_ref();
-
+    
+    // Within the method, we protect against inf results if the exponent is too
+    // high.
+    //
+    // If it is too low, we set the partial pressure to zero. This capability is
+    // needed by the elemental potential method.
     doublereal pres = 0.0;
     double m_p0 = refPressure();
     for (size_t k = 0; k < m_kk; k++) {

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -219,7 +219,11 @@ void IdealSolidSolnPhase::getChemPotentials_RT(doublereal* mu) const
 void IdealSolidSolnPhase::getPartialMolarEnthalpies(doublereal* hbar) const
 {
     const vector_fp& _h = enthalpy_RT_ref();
-    scale(_h.begin(), _h.end(), hbar, RT());
+    double delta_p = m_Pcurrent - m_Pref;
+    for (size_t k = 0; k < m_kk; k++) {
+        hbar[k] = _h[k]*RT() + delta_p * m_speciesMolarVolume[k];
+    }
+    // scale(_h.begin(), _h.end(), hbar, RT());
 }
 
 void IdealSolidSolnPhase::getPartialMolarEntropies(doublereal* sbar) const

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -383,6 +383,28 @@ TEST(ThermoFromYaml, IdealSolidSolnPhase)
     EXPECT_NEAR(thermo->density(), 10.1787080, 1e-6);
     EXPECT_NEAR(thermo->enthalpy_mass(), -15642788.8547624, 1e-4);
     EXPECT_NEAR(thermo->gibbs_mole(), -313642312.7114608, 1e-4);
+
+    // Test that molar enthalpy equals sum(h_k*X_k). Test first at default 
+    // pressure:
+    double h_avg = 0;
+    size_t N = thermo->nSpecies();
+    vector_fp X_k(N);
+    vector_fp h_k(N);
+    thermo->getMoleFractions(X_k.data());
+    thermo->getPartialMolarEnthalpies(h_k.data());
+    for (size_t k = 0; k < N; k++) {
+        h_avg += X_k[k]*h_k[k];
+    }
+    EXPECT_NEAR(thermo->enthalpy_mole(), h_avg, 1e-6);
+
+    // Now test the pressure dependence, by repeating at 2 atm:
+    thermo->setState_TP(298, 2*OneAtm);
+    thermo->getPartialMolarEnthalpies(h_k.data());
+    h_avg = 0;
+    for (size_t k = 0; k < N; k++) {
+        h_avg += X_k[k]*h_k[k];
+    }
+    EXPECT_NEAR(thermo->enthalpy_mole(), h_avg, 1e-6);
 }
 
 TEST(ThermoFromYaml, Lattice)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Adds proper pressure dependence to IdealSolidSolnPhase::getPartialMolarEnthalpies

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1080 

**If applicable, provide an example illustrating new features this pull request is introducing**
 Previously, the partial molar enthalpies had no pressure dependence for this class.  As a check, the sum of partial molar enthalpy times mole fraction should equal the average phase molar enthalpy.  Prior to this change:
```python
import cantera as ct
import numpy as np

gas = ct.Solution('IdealSolidSolnPhaseExample.yaml',"solidSolutionExample")

# At standard pressure: h_mole = sum(X_k*h_k)
h_mole = gas.enthalpy_mole
h_check = np.dot(gas.partial_molar_enthalpies, gas.X)
print(h_mole - h_check)
0

# At non-standard pressure, h_mole shows the correct pressure dependence, but the partial molar enthalpies do not:
gas.TP = None, 3*ct.one_atm
h_mole = gas.enthalpy_mole
h_check = np.dot(gas.partial_molar_enthalpies, gas.X)
print(h_mole, h_check)
303975
```

With the implemented correction:
```python
import cantera as ct
import numpy as np

gas = ct.Solution('IdealSolidSolnPhaseExample.yaml',"solidSolutionExample")

# At standard pressure: h_mole = sum(X_k*h_k)
h_mole = gas.enthalpy_mole
h_check = np.dot(gas.partial_molar_enthalpies, gas.X)
print(h_mole - h_check)
0

# At non-standard pressure, h_mole shows the correct pressure dependence, but the partial molar enthalpies do not:
gas.TP = None, 3*ct.one_atm
h_mole = gas.enthalpy_mole
h_check = np.dot(gas.partial_molar_enthalpies, gas.X)
print(h_mole, h_check)
0
```
<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
