### PR TITLE
Small fixes and improvements / sparse coefficient matrices

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -115,7 +115,7 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas scipy pytest
         pytest-github-actions-annotate-failures
     - name: Build Cantera
       run: |

--- a/SConstruct
+++ b/SConstruct
@@ -680,12 +680,13 @@ config_options = [
         False),
     BoolVariable(
         "legacy_rate_constants",
-        """If set to 'false', rate constant calculations will will no longer include
-        third-body concentrations for ThreeBodyReaction objects. For Cantera 2.6, the
-        default is set to 'true' (no change of previous behavior). After Cantera 2.6,
-        the default will be changed to 'false', and rate constant calculations will be
-        consistent with conventional definitions (see Eq. 9.75 in Kee, Coltrin and
-        Glarborg, 'Chemically Reacting Flow', Wiley Interscience, 2003).""",
+        """If enabled, rate constant calculations include third-body concentrations
+        for three-body reactions, which corresponds to the legacy implementation.
+        For Cantera 2.6, the option remains enabled (no change compared to past
+        behavior). After Cantera 2.6, the default will be to disable this option,
+        and rate constant calculations will be consistent with conventional
+        definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
+        Flow', Wiley Interscience, 2003).""",
         True),
 ]
 

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -191,6 +191,12 @@ public:
     NotImplementedError(const std::string& func) :
         CanteraError(func, "Not implemented.") {}
 
+    //! Alternative constructor taking same arguments as @see CanteraError
+    template <typename... Args>
+    NotImplementedError(const std::string& func, const std::string& msg,
+                        const Args&... args) :
+        CanteraError(func, msg, args...) {}
+
     virtual std::string getClass() const {
         return "NotImplementedError";
     }

--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -73,11 +73,10 @@ size_t sparseComponents(const Eigen::SparseMatrix<double>& mat,
     return count;
 }
 
-// Function which passes sparse matrix components to a set of 1D arrays
-#define SPARSE_FUNC(PREFIX, CLASS_NAME, FUNC_NAME) \
-    size_t PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object, \
-    int* rows, int* cols, double* data, size_t length) \
-    { return sparseComponents(object->FUNC_NAME(), rows, cols, data, length); }
+// Function which passes sparse matrix
+#define SPARSE_MATRIX(PREFIX, CLASS_NAME, FUNC_NAME) \
+    Eigen::SparseMatrix<double> PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object) \
+    { return object->FUNC_NAME(); }
 
 // Function which populates a 1D array
 #define ARRAY_FUNC(PREFIX, CLASS_NAME, FUNC_NAME) \
@@ -92,7 +91,7 @@ size_t sparseComponents(const Eigen::SparseMatrix<double>& mat,
 
 #define THERMO_1D(FUNC_NAME) ARRAY_FUNC(thermo, ThermoPhase, FUNC_NAME)
 #define KIN_1D(FUNC_NAME) ARRAY_FUNC(kin, Kinetics, FUNC_NAME)
-#define KIN_SPARSE(FUNC_NAME) SPARSE_FUNC(kin, Kinetics, FUNC_NAME)
+#define KIN_SPARSE_MATRIX(FUNC_NAME) SPARSE_MATRIX(kin, Kinetics, FUNC_NAME)
 #define TRANSPORT_1D(FUNC_NAME) ARRAY_FUNC(tran, Transport, FUNC_NAME)
 #define TRANSPORT_2D(FUNC_NAME) ARRAY_FUNC2(tran, Transport, FUNC_NAME)
 
@@ -120,8 +119,9 @@ THERMO_1D(getCp_R)
 THERMO_1D(getActivities)
 THERMO_1D(getActivityCoefficients)
 
-KIN_SPARSE(reactantStoichCoeffs)
-KIN_SPARSE(productStoichCoeffs)
+KIN_SPARSE_MATRIX(reactantStoichCoeffs)
+KIN_SPARSE_MATRIX(productStoichCoeffs)
+KIN_SPARSE_MATRIX(revProductStoichCoeffs)
 
 KIN_1D(getFwdRatesOfProgress)
 KIN_1D(getRevRatesOfProgress)

--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -81,10 +81,6 @@ void sparseCscData(const Eigen::SparseMatrix<double>& mat,
         throw Cantera::CanteraError("sparseCscData",
             "Invalid input: Eigen matrix is not compressed.");
     }
-    if (mat.IsRowMajor) {
-        throw Cantera::CanteraError("sparseCscData",
-            "Invalid input: Eigen matrix is not in column major format.");
-    }
 
     const double* valuePtr = mat.valuePtr();
     const int* innerPtr = mat.innerIndexPtr();

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -38,7 +38,7 @@ public:
     virtual void getRevRateConstants(double* krev,
                                      bool doIrreversible = false);
 
-    virtual bool addReaction(shared_ptr<Reaction> r);
+    virtual bool addReaction(shared_ptr<Reaction> r, bool finalize=true);
     virtual void modifyReaction(size_t i, shared_ptr<Reaction> rNew);
 
     virtual void resizeSpecies();

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -38,7 +38,7 @@ public:
     virtual void getRevRateConstants(double* krev,
                                      bool doIrreversible = false);
 
-    virtual bool addReaction(shared_ptr<Reaction> r, bool finalize=true);
+    virtual bool addReaction(shared_ptr<Reaction> r, bool resize=true);
     virtual void modifyReaction(size_t i, shared_ptr<Reaction> rNew);
 
     virtual void resizeSpecies();

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -49,7 +49,7 @@ public:
     //! @name Reaction Mechanism Setup Routines
     //! @{
     virtual void init();
-    virtual bool addReaction(shared_ptr<Reaction> r);
+    virtual bool addReaction(shared_ptr<Reaction> r, bool finalize=true);
     virtual void modifyReaction(size_t i, shared_ptr<Reaction> rNew);
     virtual void invalidateCache();
     //@}

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -49,7 +49,7 @@ public:
     //! @name Reaction Mechanism Setup Routines
     //! @{
     virtual void init();
-    virtual bool addReaction(shared_ptr<Reaction> r, bool finalize=true);
+    virtual bool addReaction(shared_ptr<Reaction> r, bool resize=true);
     virtual void modifyReaction(size_t i, shared_ptr<Reaction> rNew);
     virtual void invalidateCache();
     //@}

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -199,7 +199,7 @@ public:
 
     virtual void init();
     virtual void resizeSpecies();
-    virtual bool addReaction(shared_ptr<Reaction> r, bool finalize=true);
+    virtual bool addReaction(shared_ptr<Reaction> r, bool resize=true);
     virtual void modifyReaction(size_t i, shared_ptr<Reaction> rNew);
     //! @}
 

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -199,7 +199,7 @@ public:
 
     virtual void init();
     virtual void resizeSpecies();
-    virtual bool addReaction(shared_ptr<Reaction> r);
+    virtual bool addReaction(shared_ptr<Reaction> r, bool finalize=true);
     virtual void modifyReaction(size_t i, shared_ptr<Reaction> rNew);
     //! @}
 

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -558,6 +558,15 @@ public:
      * @param i   reaction index
      */
     virtual double reactantStoichCoeff(size_t k, size_t i) const;
+
+    /**
+     * Stoichiometric coefficient matrix for reactants.
+     */
+    Eigen::SparseMatrix<double> reactantStoichCoeffs() const
+    {
+        return m_reactantStoich.stoichCoeffs();
+    }
+
     /**
      * Stoichiometric coefficient of species k as a product in reaction i.
      *
@@ -565,6 +574,22 @@ public:
      * @param i   reaction index
      */
     virtual double productStoichCoeff(size_t k, size_t i) const;
+
+    /**
+     * Stoichiometric coefficient matrix for products.
+     */
+    Eigen::SparseMatrix<double> productStoichCoeffs() const
+    {
+        return m_productStoich.stoichCoeffs();
+    }
+
+    /**
+     * Stoichiometric coefficient matrix for products of reversible reactions.
+     */
+    Eigen::SparseMatrix<double> revProductStoichCoeffs() const
+    {
+        return m_revProductStoich.stoichCoeffs();
+    }
 
     //! Reactant order of species k in reaction i.
     /*!

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -136,7 +136,7 @@ public:
     }
 
     //! Finalize Kinetics object and associated objects
-    virtual void finalizeSetup();
+    virtual void resizeReactions();
 
     //! Number of reactions in the reaction mechanism.
     size_t nReactions() const {
@@ -762,11 +762,11 @@ public:
      * Add a single reaction to the mechanism. Derived classes should call the
      * base class method in addition to handling their own specialized behavior.
      *
-     * @param r      Pointer to the Reaction object to be added.
-     * @param finalize  If `true`, finalize Kinetics object.
+     * @param r       Pointer to the Reaction object to be added.
+     * @param resize  If `true`, resizeReactions is called after reaction is added.
      * @return `true` if the reaction is added or `false` if it was skipped
      */
-    virtual bool addReaction(shared_ptr<Reaction> r, bool finalize=true);
+    virtual bool addReaction(shared_ptr<Reaction> r, bool resize=true);
 
     /**
      * Modify the rate expression associated with a reaction. The
@@ -925,8 +925,8 @@ protected:
     StoichManagerN m_revProductStoich;
     //@}
 
-    //! Boolean indicating whether Kinetics object setup is finalized
-    bool m_finalized;
+    //! Boolean indicating whether Kinetics object is fully configured
+    bool m_ready;
 
     //! The number of species in all of the phases
     //! that participate in this kinetics mechanism.

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -896,11 +896,11 @@ protected:
     //! Stoichiometry manager for the reactants for each reaction
     StoichManagerN m_reactantStoich;
 
+    //! Stoichiometry manager for the products for each reaction
+    StoichManagerN m_productStoich;
+
     //! Stoichiometry manager for the products of reversible reactions
     StoichManagerN m_revProductStoich;
-
-    //! Stoichiometry manager for the products of irreversible reactions
-    StoichManagerN m_irrevProductStoich;
     //@}
 
     //! Boolean indicating whether Kinetics object setup is finalized

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -562,8 +562,7 @@ public:
     /**
      * Stoichiometric coefficient matrix for reactants.
      */
-    Eigen::SparseMatrix<double> reactantStoichCoeffs() const
-    {
+    Eigen::SparseMatrix<double> reactantStoichCoeffs() const {
         return m_reactantStoich.stoichCoeffs();
     }
 
@@ -578,16 +577,14 @@ public:
     /**
      * Stoichiometric coefficient matrix for products.
      */
-    Eigen::SparseMatrix<double> productStoichCoeffs() const
-    {
+    Eigen::SparseMatrix<double> productStoichCoeffs() const {
         return m_productStoich.stoichCoeffs();
     }
 
     /**
      * Stoichiometric coefficient matrix for products of reversible reactions.
      */
-    Eigen::SparseMatrix<double> revProductStoichCoeffs() const
-    {
+    Eigen::SparseMatrix<double> revProductStoichCoeffs() const {
         return m_revProductStoich.stoichCoeffs();
     }
 

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -135,6 +135,9 @@ public:
         return "Kinetics";
     }
 
+    //! Finalize Kinetics object and associated objects
+    virtual void finalizeSetup();
+
     //! Number of reactions in the reaction mechanism.
     size_t nReactions() const {
         return m_reactions.size();
@@ -738,9 +741,10 @@ public:
      * base class method in addition to handling their own specialized behavior.
      *
      * @param r      Pointer to the Reaction object to be added.
+     * @param finalize  If `true`, finalize Kinetics object.
      * @return `true` if the reaction is added or `false` if it was skipped
      */
-    virtual bool addReaction(shared_ptr<Reaction> r);
+    virtual bool addReaction(shared_ptr<Reaction> r, bool finalize=true);
 
     /**
      * Modify the rate expression associated with a reaction. The
@@ -898,6 +902,9 @@ protected:
     //! Stoichiometry manager for the products of irreversible reactions
     StoichManagerN m_irrevProductStoich;
     //@}
+
+    //! Boolean indicating whether Kinetics object setup is finalized
+    bool m_finalized;
 
     //! The number of species in all of the phases
     //! that participate in this kinetics mechanism.

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -390,17 +390,17 @@ public:
     ChebyshevRate3() {}
 
     //! Constructor using coefficient array
-    /*!
-     * @param Trange  Valid temperature range (min, max) [K]
-     * @param Prange  Valid pressure range (min, max) [Pa]
-     * @param coeffs  Coefficient array dimensioned `nT` by `nP` where `nT` and
+    /*
+     *  @param Tmin    Minimum temperature [K]
+     *  @param Tmax    Maximum temperature [K]
+     *  @param Pmin    Minimum pressure [Pa]
+     *  @param Pmax    Maximum pressure [Pa]
+     *  @param coeffs  Coefficient array dimensioned `nT` by `nP` where `nT` and
      *      `nP` are the number of temperatures and pressures used in the fit,
      *      respectively.
      */
-    ChebyshevRate3(
-        const std::pair<double, double> Trange,
-        const std::pair<double, double> Prange,
-        const Array2D& coeffs);
+    ChebyshevRate3(double Tmin, double Tmax, double Pmin, double Pmax,
+                   const Array2D& coeffs);
 
     //! Constructor using AnyMap content
     //! @param node  AnyMap containing rate information

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -379,6 +379,9 @@ public:
  * Chebyshev polynomials are not defined outside the interval (-1,1), and
  * therefore extrapolation of rates outside the range of temperatures and
  * pressures for which they are defined is strongly discouraged.
+ *
+ * @TODO  rename to ChebyshevRate when the legacy ChebyshevRate class is removed
+ *      from RxnRates.h after Cantera 2.6.
  */
 class ChebyshevRate3 final : public ReactionRate<ChebyshevData>, public Chebyshev
 {
@@ -386,18 +389,18 @@ public:
     //! Default constructor.
     ChebyshevRate3() {}
 
-    //! Constructor directly from coefficient array
-    /*
-     *  @param Tmin    Minimum temperature [K]
-     *  @param Tmax    Maximum temperature [K]
-     *  @param Pmin    Minimum pressure [Pa]
-     *  @param Pmax    Maximum pressure [Pa]
-     *  @param coeffs  Coefficient array dimensioned `nT` by `nP` where `nT` and
+    //! Constructor using coefficient array
+    /*!
+     * @param Trange  Valid temperature range (min, max) [K]
+     * @param Prange  Valid pressure range (min, max) [Pa]
+     * @param coeffs  Coefficient array dimensioned `nT` by `nP` where `nT` and
      *      `nP` are the number of temperatures and pressures used in the fit,
      *      respectively.
      */
-    ChebyshevRate3(double Tmin, double Tmax, double Pmin, double Pmax,
-                   const Array2D& coeffs);
+    ChebyshevRate3(
+        const std::pair<double, double> Trange,
+        const std::pair<double, double> Prange,
+        const Array2D& coeffs);
 
     //! Constructor using AnyMap content
     //! @param node  AnyMap containing rate information

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -431,12 +431,6 @@ public:
         return updateRC(0., shared_data.m_recipT);
     }
 
-    //! Access the Chebyshev coefficients as 2-dimensional array.
-    const Array2D& coeffs() const;
-
-    //! Set the Chebyshev coefficients as 2-dimensional array.
-    void setCoeffs(const Array2D& coeffs);
-
     virtual void validate(const std::string& equation) override;
 };
 

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -428,6 +428,12 @@ public:
         return updateRC(0., shared_data.m_recipT);
     }
 
+    //! Access the Chebyshev coefficients as 2-dimensional array.
+    const Array2D& coeffs() const;
+
+    //! Set the Chebyshev coefficients as 2-dimensional array.
+    void setCoeffs(const Array2D& coeffs);
+
     virtual void validate(const std::string& equation) override;
 };
 

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -666,24 +666,24 @@ public:
      *  \f$ \alpha_{t,p} = \mathrm{coeffs}[N_P*t + p] \f$ where
      *  \f$ 0 <= t < N_T \f$ and \f$ 0 <= p < N_P \f$.
      *
-     * @deprecated   Behavior to change after Cantera 2.6. For new
-     *               behavior @see getCoeffs().
+     * @deprecated   To be removed after Cantera 2.6. Replaceable by @see data().
      */
     const vector_fp& coeffs() const
     {
-        warn_deprecated("Chebyshev::coeffs", "Behavior to change after Cantera 2.6; "
-            "for new behavior, use getCoeffs().");
+        warn_deprecated("Chebyshev::coeffs", "Deprecated in Cantera 2.6 "
+            "and to be removed thereafter; replaceable by data().");
         return chebCoeffs_;
     }
 
-    //! Access Chebyshev coefficients as 2-dimensional array.
-    const Array2D& getCoeffs() const
+    //! Access Chebyshev coefficients as 2-dimensional array with temperature and
+    //! pressure dimensions corresponding to rows and columns, respecitively.
+    const Array2D& data() const
     {
         return m_coeffs;
     }
 
     //! Set the Chebyshev coefficients as 2-dimensional array.
-    void setCoeffs(const Array2D& coeffs);
+    void setData(const Array2D& coeffs);
 
 protected:
     std::pair<double, double> m_Trange; //!< valid temperature range

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -24,8 +24,6 @@ class AnyValue;
 class AnyMap;
 class UnitSystem;
 class Units;
-class AnyMap;
-class Units;
 
 //! Arrhenius reaction rate type depends only on temperature
 /**
@@ -421,7 +419,8 @@ public:
     //! Return the pressures and Arrhenius expressions which comprise this
     //! reaction.
     /*!
-     * @deprecated   To be removed after Cantera 2.6. Replaceable by getRates.
+     * @deprecated  Behavior to change after Cantera 2.6.
+     *              @see getRates for new behavior.
      */
     std::vector<std::pair<double, Arrhenius> > rates() const;
 
@@ -485,19 +484,6 @@ public:
 
     //! Constructor directly from coefficient array
     /*!
-     * @param Trange  Valid temperature range (min, max) [K]
-     * @param Prange  Valid pressure range (min, max) [Pa]
-     * @param coeffs  Coefficient array dimensioned `nT` by `nP` where `nT` and
-     *      `nP` are the number of temperatures and pressures used in the fit,
-     *      respectively.
-     */
-    Chebyshev(
-        const std::pair<double, double> Trange,
-        const std::pair<double, double> Prange,
-        const Array2D& coeffs);
-
-    //! Constructor directly from coefficient array
-    /*!
      *  @param Tmin    Minimum temperature [K]
      *  @param Tmax    Maximum temperature [K]
      *  @param Pmin    Minimum pressure [Pa]
@@ -505,9 +491,6 @@ public:
      *  @param coeffs  Coefficient array dimensioned `nT` by `nP` where `nT` and
      *      `nP` are the number of temperatures and pressures used in the fit,
      *      respectively.
-     *
-     * @deprecated  Deprecated in Cantera 2.6.
-     *              Use constructor using pairs for range input.
      */
     Chebyshev(double Tmin, double Tmax, double Pmin, double Pmax,
               const Array2D& coeffs);
@@ -530,12 +513,12 @@ public:
 
     //! Set limits for Chebyshev object
     /*!
-     * @param Trange  Temperature range (min, max) [K]
-     * @param Prange  Pressure range (min, max) [Pa]
+     *  @param Tmin    Minimum temperature [K]
+     *  @param Tmax    Maximum temperature [K]
+     *  @param Pmin    Minimum pressure [Pa]
+     *  @param Pmax    Maximum pressure [Pa]
      */
-    void setLimits(
-        const std::pair<double, double> Trange,
-        const std::pair<double, double> Prange);
+    void setLimits(double Tmin, double Tmax, double Pmin, double Pmax);
 
     //! Update concentration-dependent parts of the rate coefficient.
     //! @param c base-10 logarithm of the pressure in Pa
@@ -578,86 +561,32 @@ public:
     }
 
     //! Minimum valid temperature [K]
-    /*!
-     * @deprecated  Deprecated in Cantera 2.6.
-     *              Replaceable with @see temperatureRange()
-     */
-    double Tmin() const
-    {
-        warn_deprecated("Chebyshev::Tmin", "Deprecated in Cantera 2.6; "
-            "replaceable with temperatureRange.");
-        return m_Trange.first;
+    double Tmin() const {
+        return Tmin_;
     }
 
     //! Maximum valid temperature [K]
-    /*!
-     * @deprecated  Deprecated in Cantera 2.6.
-     *              Replaceable with @see temperatureRange()
-     */
-    double Tmax() const
-    {
-        warn_deprecated("Chebyshev::Tmax", "Deprecated in Cantera 2.6; "
-            "replaceable with temperatureRange.");
-        return m_Trange.second;
-    }
-
-    // Range of valid temperatures (min, max) [K]
-    const std::pair<double, double>& temperatureRange() const
-    {
-        return m_Trange;
+    double Tmax() const {
+        return Tmax_;
     }
 
     //! Minimum valid pressure [Pa]
-    /*!
-     * @deprecated  Deprecated in Cantera 2.6.
-     *              Replaceable with @see pressureRange()
-     */
-    double Pmin() const
-    {
-        warn_deprecated("Chebyshev::Pmin", "Deprecated in Cantera 2.6; "
-            "replaceable with pressureRange.");
-        return m_Prange.first;
+    double Pmin() const {
+        return Pmin_;
     }
 
     //! Maximum valid pressure [Pa]
-    /*!
-     * @deprecated  Deprecated in Cantera 2.6.
-     *              Replaceable with @see pressureRange()
-     */
-    double Pmax() const
-    {
-        warn_deprecated("Chebyshev::Pmax", "Deprecated in Cantera 2.6; "
-            "replaceable with pressureRange.");
-        return m_Prange.second;
-    }
-
-    // Range of valid pressures (min, max) [Pa]
-    const std::pair<double, double>& pressureRange() const
-    {
-        return m_Prange;
+    double Pmax() const {
+        return Pmax_;
     }
 
     //! Number of points in the pressure direction
-    /*!
-     * @deprecated  Deprecated in Cantera 2.6.
-     *              Accessible as number of columns of the coefficient matrix
-     */
-    size_t nPressure() const
-    {
-        warn_deprecated("Chebyshev::nPressure", "Deprecated in Cantera 2.6; "
-            "accessible as number of colums of the coefficient matrix.");
+    size_t nPressure() const {
         return m_coeffs.nColumns();
     }
 
     //! Number of points in the temperature direction
-    /*!
-     * @deprecated  Deprecated in Cantera 2.6.
-     *              Accessible as number of rows of the coefficient matrix
-     */
-    size_t nTemperature() const
-    {
-        warn_deprecated("Chebyshev::nTemperature", "Deprecated in Cantera 2.6; "
-            "accessible as number of rows of the coefficient matrix.");
+    size_t nTemperature() const {
         return m_coeffs.nRows();
     }
 
@@ -668,8 +597,7 @@ public:
      *
      * @deprecated   To be removed after Cantera 2.6. Replaceable by @see data().
      */
-    const vector_fp& coeffs() const
-    {
+    const vector_fp& coeffs() const {
         warn_deprecated("Chebyshev::coeffs", "Deprecated in Cantera 2.6 "
             "and to be removed thereafter; replaceable by data().");
         return chebCoeffs_;
@@ -677,8 +605,7 @@ public:
 
     //! Access Chebyshev coefficients as 2-dimensional array with temperature and
     //! pressure dimensions corresponding to rows and columns, respectively.
-    const Array2D& data() const
-    {
+    const Array2D& data() const {
         return m_coeffs;
     }
 
@@ -686,8 +613,8 @@ public:
     void setData(const Array2D& coeffs);
 
 protected:
-    std::pair<double, double> m_Trange; //!< valid temperature range
-    std::pair<double, double> m_Prange; //!< valid pressure range
+    double Tmin_, Tmax_; //!< valid temperature range
+    double Pmin_, Pmax_; //!< valid pressure range
     double TrNum_, TrDen_; //!< terms appearing in the reduced temperature
     double PrNum_, PrDen_; //!< terms appearing in the reduced pressure
 

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -347,7 +347,13 @@ public:
     void getParameters(AnyMap& rateNode, const Units& rate_units) const;
 
     //! Set up Plog object
+    /*!
+     * @deprecated   Deprecated in Cantera 2.6. Renamed to setRates.
+     */
     void setup(const std::multimap<double, Arrhenius>& rates);
+
+    //! Set up Plog object
+    void setRates(const std::multimap<double, Arrhenius>& rates);
 
     //! Update concentration-dependent parts of the rate coefficient.
     //! @param c natural log of the pressure in Pa
@@ -414,7 +420,14 @@ public:
 
     //! Return the pressures and Arrhenius expressions which comprise this
     //! reaction.
+    /*!
+     * @deprecated   To be removed after Cantera 2.6. Replaceable by getRates.
+     */
     std::vector<std::pair<double, Arrhenius> > rates() const;
+
+    //! Return the pressures and Arrhenius expressions which comprise this
+    //! reaction.
+    std::multimap<double, Arrhenius> getRates() const;
 
 protected:
     //! log(p) to (index range) in the rates_ vector

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -676,7 +676,7 @@ public:
     }
 
     //! Access Chebyshev coefficients as 2-dimensional array with temperature and
-    //! pressure dimensions corresponding to rows and columns, respecitively.
+    //! pressure dimensions corresponding to rows and columns, respectively.
     const Array2D& data() const
     {
         return m_coeffs;

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -459,7 +459,7 @@ public:
      * DGG - the problem is that the number of reactions and species are not
      * known initially.
      */
-    StoichManagerN() : m_finalized(false) {
+    StoichManagerN() : m_finalized(true) {
         m_stoichCoeffs.setZero();
         m_stoichCoeffs.resize(0, 0);
     }

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -8,6 +8,7 @@
 #ifndef CT_STOICH_MGR_H
 #define CT_STOICH_MGR_H
 
+#include "cantera/numerics/eigen_sparse.h"
 #include "cantera/base/ctexceptions.h"
 
 namespace Cantera
@@ -458,7 +459,23 @@ public:
      * DGG - the problem is that the number of reactions and species are not
      * known initially.
      */
-    StoichManagerN() {
+    StoichManagerN() : m_finalized(false) {
+        m_stoichCoeffs.setZero();
+        m_stoichCoeffs.resize(0, 0);
+    }
+
+    //! finalize the sparse coefficient matrix setup
+    void finalizeSetup(size_t nSpc, size_t nRxn)
+    {
+        size_t nCoeffs = m_coeffList.size();
+
+        // Stoichiometric coefficient matrix
+        m_stoichCoeffs.setZero();
+        m_stoichCoeffs.resize(nSpc, nRxn);
+        m_stoichCoeffs.reserve(nCoeffs);
+        m_stoichCoeffs.setFromTriplets(m_coeffList.begin(), m_coeffList.end());
+
+        m_finalized = true;
     }
 
     /**
@@ -505,9 +522,9 @@ public:
         }
         bool frac = false;
         for (size_t n = 0; n < stoich.size(); n++) {
+            m_coeffList.push_back(Eigen::Triplet<double>(k[n], rxn, stoich[n]));
             if (fmod(stoich[n], 1.0) || stoich[n] != order[n]) {
                 frac = true;
-                break;
             }
         }
         if (frac || k.size() > 3) {
@@ -538,6 +555,7 @@ public:
                 m_cn_list.emplace_back(rxn, k, order, stoich);
             }
         }
+        m_finalized = false;
     }
 
     void multiply(const doublereal* input, doublereal* output) const {
@@ -575,11 +593,30 @@ public:
         _decrementReactions(m_cn_list.begin(), m_cn_list.end(), input, output);
     }
 
+    //! Return matrix containing stoichiometric coefficients
+    const Eigen::SparseMatrix<double>& stoichCoeffs() const
+    {
+        if (!m_finalized) {
+            // This can happen if a user overrides default behavior:
+            // Kinetics::finalizeSetup is not called after adding reactions via
+            // Kinetics::addReaction with the 'finalize' flag set to 'false'
+            throw CanteraError("StoichManagerN::stoichCoeffs",
+                "The object is not fully configured; make sure to call finalizeSetup.");
+        }
+        return m_stoichCoeffs;
+    }
+
 private:
+    bool m_finalized; //!< Boolean flag indicating whether setup is finalized
+
     std::vector<C1> m_c1_list;
     std::vector<C2> m_c2_list;
     std::vector<C3> m_c3_list;
     std::vector<C_AnyN> m_cn_list;
+
+    //! Sparse matrices for stoichiometric coefficients
+    std::vector<Eigen::Triplet<double>> m_coeffList;
+    Eigen::SparseMatrix<double> m_stoichCoeffs;
 };
 
 }

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -459,13 +459,13 @@ public:
      * DGG - the problem is that the number of reactions and species are not
      * known initially.
      */
-    StoichManagerN() : m_finalized(true) {
+    StoichManagerN() : m_ready(true) {
         m_stoichCoeffs.setZero();
         m_stoichCoeffs.resize(0, 0);
     }
 
-    //! finalize the sparse coefficient matrix setup
-    void finalizeSetup(size_t nSpc, size_t nRxn)
+    //! Resize the sparse coefficient matrix)
+    void resizeCoeffs(size_t nSpc, size_t nRxn)
     {
         size_t nCoeffs = m_coeffList.size();
 
@@ -474,7 +474,7 @@ public:
         m_stoichCoeffs.reserve(nCoeffs);
         m_stoichCoeffs.setFromTriplets(m_coeffList.begin(), m_coeffList.end());
 
-        m_finalized = true;
+        m_ready = true;
     }
 
     /**
@@ -554,7 +554,7 @@ public:
                 m_cn_list.emplace_back(rxn, k, order, stoich);
             }
         }
-        m_finalized = false;
+        m_ready = false;
     }
 
     void multiply(const doublereal* input, doublereal* output) const {
@@ -595,18 +595,18 @@ public:
     //! Return matrix containing stoichiometric coefficients
     const Eigen::SparseMatrix<double>& stoichCoeffs() const
     {
-        if (!m_finalized) {
+        if (!m_ready) {
             // This can happen if a user overrides default behavior:
-            // Kinetics::finalizeSetup is not called after adding reactions via
-            // Kinetics::addReaction with the 'finalize' flag set to 'false'
-            throw CanteraError("StoichManagerN::stoichCoeffs",
-                "The object is not fully configured; make sure to call finalizeSetup.");
+            // Kinetics::resizeReactions is not called after adding reactions via
+            // Kinetics::addReaction with the 'resize' flag set to 'false'
+            throw CanteraError("StoichManagerN::stoichCoeffs", "The object "
+                "is not fully configured; make sure to call resizeCoeffs().");
         }
         return m_stoichCoeffs;
     }
 
 private:
-    bool m_finalized; //!< Boolean flag indicating whether object setup is finalized
+    bool m_ready; //!< Boolean flag indicating whether object is fully configured
 
     std::vector<C1> m_c1_list;
     std::vector<C2> m_c2_list;

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -470,11 +470,9 @@ public:
         size_t nCoeffs = m_coeffList.size();
 
         // Stoichiometric coefficient matrix
-        m_stoichCoeffs.setZero();
         m_stoichCoeffs.resize(nSpc, nRxn);
         m_stoichCoeffs.reserve(nCoeffs);
         m_stoichCoeffs.setFromTriplets(m_coeffList.begin(), m_coeffList.end());
-        m_stoichCoeffs.makeCompressed();
 
         m_finalized = true;
     }
@@ -523,7 +521,7 @@ public:
         }
         bool frac = false;
         for (size_t n = 0; n < stoich.size(); n++) {
-            m_coeffList.push_back(Eigen::Triplet<double>(k[n], rxn, stoich[n]));
+            m_coeffList.emplace_back(k[n], rxn, stoich[n]);
             if (fmod(stoich[n], 1.0) || stoich[n] != order[n]) {
                 frac = true;
             }
@@ -608,7 +606,7 @@ public:
     }
 
 private:
-    bool m_finalized; //!< Boolean flag indicating whether setup is finalized
+    bool m_finalized; //!< Boolean flag indicating whether object setup is finalized
 
     std::vector<C1> m_c1_list;
     std::vector<C2> m_c2_list;
@@ -616,7 +614,7 @@ private:
     std::vector<C_AnyN> m_cn_list;
 
     //! Sparse matrices for stoichiometric coefficients
-    std::vector<Eigen::Triplet<double>> m_coeffList;
+    SparseTriplets m_coeffList;
     Eigen::SparseMatrix<double> m_stoichCoeffs;
 };
 

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -474,6 +474,7 @@ public:
         m_stoichCoeffs.resize(nSpc, nRxn);
         m_stoichCoeffs.reserve(nCoeffs);
         m_stoichCoeffs.setFromTriplets(m_coeffList.begin(), m_coeffList.end());
+        m_stoichCoeffs.makeCompressed();
 
         m_finalized = true;
     }

--- a/include/cantera/numerics/eigen_dense.h
+++ b/include/cantera/numerics/eigen_dense.h
@@ -1,12 +1,25 @@
-#include "cantera/base/ct_defs.h"
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_EIGEN_DENSE_H
+#define CT_EIGEN_DENSE_H
+
+#include "cantera/base/config.h"
 #if CT_USE_SYSTEM_EIGEN
 #include <Eigen/Dense>
 #else
 #include "cantera/ext/Eigen/Dense"
 #endif
 
-namespace Cantera {
-    typedef Eigen::Map<Eigen::MatrixXd> MappedMatrix;
-    typedef Eigen::Map<Eigen::VectorXd> MappedVector;
-    typedef Eigen::Map<const Eigen::VectorXd> ConstMappedVector;
+namespace Cantera
+{
+
+typedef Eigen::Map<Eigen::MatrixXd> MappedMatrix;
+typedef Eigen::Map<const Eigen::MatrixXd> ConstMappedMatrix;
+typedef Eigen::Map<Eigen::VectorXd> MappedVector;
+typedef Eigen::Map<const Eigen::VectorXd> ConstMappedVector;
+typedef Eigen::Map<Eigen::RowVectorXd> MappedRowVector;
+typedef Eigen::Map<const Eigen::RowVectorXd> ConstMappedRowVector;
 }
+
+#endif

--- a/include/cantera/numerics/eigen_sparse.h
+++ b/include/cantera/numerics/eigen_sparse.h
@@ -1,0 +1,19 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_EIGEN_SPARSE_H
+#define CT_EIGEN_SPARSE_H
+
+#include "cantera/base/config.h"
+#if CT_USE_SYSTEM_EIGEN
+#include <Eigen/Sparse>
+#else
+#include "cantera/ext/Eigen/Sparse"
+#endif
+
+namespace Cantera
+{
+typedef std::vector<Eigen::Triplet<double>> SparseTriplets;
+}
+
+#endif

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -49,11 +49,7 @@ cdef extern from "cantera/numerics/eigen_sparse.h" namespace "Eigen":
         size_t nonZeros()
         size_t rows()
         size_t cols()
-        size_t innerSize()
         size_t outerSize()
-        int* outerIndexPtr()
-        int* innerIndexPtr()
-        double* valuePtr()
 
 cdef extern from "cantera/base/xml.h" namespace "Cantera":
     cdef cppclass XML_Node:

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -126,6 +126,9 @@ cdef extern from "cantera/base/Array.h" namespace "Cantera":
         CxxArray2D(size_t, size_t)
         void resize(size_t, size_t)
         double operator()(size_t, size_t)
+        vector[double]& data()
+        size_t nRows()
+        size_t nColumns()
 
 cdef extern from "cantera/thermo/SpeciesThermoInterpType.h":
     cdef cppclass CxxSpeciesThermo "Cantera::SpeciesThermoInterpType":
@@ -394,7 +397,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double Pmax()
         size_t nPressure()
         size_t nTemperature()
-        vector[double]& coeffs()
+        CxxArray2D& coeffs()
 
     cdef cppclass CxxCustomFunc1Rate "Cantera::CustomFunc1Rate" (CxxReactionRateBase):
         CxxCustomFunc1Rate()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -562,8 +562,10 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
         void init() except +translate_exception
         void skipUndeclaredThirdBodies(cbool)
         void addReaction(shared_ptr[CxxReaction]) except +translate_exception
+        void addReaction(shared_ptr[CxxReaction], cbool) except +translate_exception
         void modifyReaction(int, shared_ptr[CxxReaction]) except +translate_exception
         void invalidateCache() except +translate_exception
+        void finalizeSetup()
 
         shared_ptr[CxxReaction] reaction(size_t) except +translate_exception
         cbool isReversible(int) except +translate_exception

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1095,6 +1095,10 @@ cdef extern from "cantera/cython/wrappers.h":
     cdef void kin_getDestructionRates(CxxKinetics*, double*) except +translate_exception
     cdef void kin_getNetProductionRates(CxxKinetics*, double*) except +translate_exception
 
+    # Kinetics sparse matrices
+    cdef size_t kin_reactantStoichCoeffs(CxxKinetics*, int*, int*, double*, size_t) except +translate_exception
+    cdef size_t kin_productStoichCoeffs(CxxKinetics*, int*, int*, double*, size_t) except +translate_exception
+
     # Transport properties
     cdef void tran_getMixDiffCoeffs(CxxTransport*, double*) except +translate_exception
     cdef void tran_getMixDiffCoeffsMass(CxxTransport*, double*) except +translate_exception
@@ -1111,6 +1115,7 @@ ctypedef void (*thermoMethod1d)(CxxThermoPhase*, double*) except +translate_exce
 ctypedef void (*transportMethod1d)(CxxTransport*, double*) except +translate_exception
 ctypedef void (*transportMethod2d)(CxxTransport*, size_t, double*) except +translate_exception
 ctypedef void (*kineticsMethod1d)(CxxKinetics*, double*) except +translate_exception
+ctypedef size_t (*kineticsMethodSparse)(CxxKinetics*, int*, int*, double*, size_t) except +translate_exception
 
 # classes
 cdef class SpeciesThermo:
@@ -1358,6 +1363,8 @@ cdef string stringify(x) except *
 cdef pystr(string x)
 cdef np.ndarray get_species_array(Kinetics kin, kineticsMethod1d method)
 cdef np.ndarray get_reaction_array(Kinetics kin, kineticsMethod1d method)
+cdef np.ndarray get_dense(Kinetics kin, kineticsMethodSparse method, size_t dim, tuple shape)
+cdef tuple get_sparse(Kinetics kin, kineticsMethodSparse method, size_t dim)
 cdef np.ndarray get_transport_1d(Transport tran, transportMethod1d method)
 cdef np.ndarray get_transport_2d(Transport tran, transportMethod2d method)
 cdef CxxIdealGasPhase* getIdealGasPhase(ThermoPhase phase) except *

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -43,6 +43,13 @@ cdef extern from "cantera/numerics/Func1.h":
         CxxTabulated1(int, double*, double*, string) except +translate_exception
         double eval(double) except +translate_exception
 
+cdef extern from "cantera/numerics/eigen_sparse.h" namespace "Eigen":
+    cdef cppclass CxxSparseMatrix "Eigen::SparseMatrix<double>":
+        CxxSparseMatrix()
+        size_t nonZeros()
+        size_t rows()
+        size_t cols()
+
 cdef extern from "cantera/base/xml.h" namespace "Cantera":
     cdef cppclass XML_Node:
         XML_Node* findByName(string)
@@ -1034,6 +1041,8 @@ cdef extern from "cantera/cython/wrappers.h":
 
     cdef void CxxSetLogger "setLogger" (CxxPythonLogger*)
 
+    cdef size_t CxxSparseComponents "sparseComponents" (CxxSparseMatrix, int*, int*, double*, size_t) except +translate_exception
+
     # workaround for Cython assignment limitations
     cdef void CxxArray2D_set(CxxArray2D, size_t, size_t, double)
 
@@ -1089,8 +1098,9 @@ cdef extern from "cantera/cython/wrappers.h":
     cdef void kin_getNetProductionRates(CxxKinetics*, double*) except +translate_exception
 
     # Kinetics sparse matrices
-    cdef size_t kin_reactantStoichCoeffs(CxxKinetics*, int*, int*, double*, size_t) except +translate_exception
-    cdef size_t kin_productStoichCoeffs(CxxKinetics*, int*, int*, double*, size_t) except +translate_exception
+    cdef CxxSparseMatrix kin_reactantStoichCoeffs(CxxKinetics*) except +translate_exception
+    cdef CxxSparseMatrix kin_productStoichCoeffs(CxxKinetics*) except +translate_exception
+    cdef CxxSparseMatrix kin_revProductStoichCoeffs(CxxKinetics*) except +translate_exception
 
     # Transport properties
     cdef void tran_getMixDiffCoeffs(CxxTransport*, double*) except +translate_exception
@@ -1108,7 +1118,7 @@ ctypedef void (*thermoMethod1d)(CxxThermoPhase*, double*) except +translate_exce
 ctypedef void (*transportMethod1d)(CxxTransport*, double*) except +translate_exception
 ctypedef void (*transportMethod2d)(CxxTransport*, size_t, double*) except +translate_exception
 ctypedef void (*kineticsMethod1d)(CxxKinetics*, double*) except +translate_exception
-ctypedef size_t (*kineticsMethodSparse)(CxxKinetics*, int*, int*, double*, size_t) except +translate_exception
+ctypedef CxxSparseMatrix (*kineticsMethodSparse)(CxxKinetics*) except +translate_exception
 
 # classes
 cdef class SpeciesThermo:
@@ -1356,8 +1366,8 @@ cdef string stringify(x) except *
 cdef pystr(string x)
 cdef np.ndarray get_species_array(Kinetics kin, kineticsMethod1d method)
 cdef np.ndarray get_reaction_array(Kinetics kin, kineticsMethod1d method)
-cdef np.ndarray get_dense(Kinetics kin, kineticsMethodSparse method, size_t dim, tuple shape)
-cdef tuple get_sparse(Kinetics kin, kineticsMethodSparse method, size_t dim)
+cdef np.ndarray get_dense(Kinetics kin, kineticsMethodSparse method)
+cdef tuple get_sparse(Kinetics kin, kineticsMethodSparse method)
 cdef np.ndarray get_transport_1d(Transport tran, transportMethod1d method)
 cdef np.ndarray get_transport_2d(Transport tran, transportMethod2d method)
 cdef CxxIdealGasPhase* getIdealGasPhase(ThermoPhase phase) except *

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -573,7 +573,7 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
         void addReaction(shared_ptr[CxxReaction], cbool) except +translate_exception
         void modifyReaction(int, shared_ptr[CxxReaction]) except +translate_exception
         void invalidateCache() except +translate_exception
-        void finalizeSetup()
+        void resizeReactions()
 
         shared_ptr[CxxReaction] reaction(size_t) except +translate_exception
         cbool isReversible(int) except +translate_exception

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -398,9 +398,13 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxChebyshevRate3 "Cantera::ChebyshevRate3" (CxxReactionRateBase):
         CxxChebyshevRate3()
         CxxChebyshevRate3(CxxAnyMap) except +translate_exception
-        CxxChebyshevRate3(pair[double, double], pair[double, double], CxxArray2D)
-        pair[double, double] temperatureRange()
-        pair[double, double] pressureRange()
+        CxxChebyshevRate3(double, double, double, double, CxxArray2D)
+        double Tmin()
+        double Tmax()
+        double Pmin()
+        double Pmax()
+        size_t nTemperature()
+        size_t nPressure()
         CxxArray2D& data()
 
     cdef cppclass CxxCustomFunc1Rate "Cantera::CustomFunc1Rate" (CxxReactionRateBase):
@@ -476,9 +480,13 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxPlog rate
 
     cdef cppclass CxxChebyshev "Cantera::Chebyshev":
-        CxxChebyshev(pair[double, double], pair[double, double], CxxArray2D)
-        pair[double, double] temperatureRange()
-        pair[double, double] pressureRange()
+        CxxChebyshev(double, double, double, double, CxxArray2D)
+        double Tmin()
+        double Tmax()
+        double Pmin()
+        double Pmax()
+        size_t nTemperature()
+        size_t nPressure()
         CxxArray2D& data()
         void update_C(double*)
         double updateRC(double, double)

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -390,13 +390,9 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxChebyshevRate3 "Cantera::ChebyshevRate3" (CxxReactionRateBase):
         CxxChebyshevRate3()
         CxxChebyshevRate3(CxxAnyMap) except +translate_exception
-        CxxChebyshevRate3(double, double, double, double, CxxArray2D)
-        double Tmin()
-        double Tmax()
-        double Pmin()
-        double Pmax()
-        size_t nPressure()
-        size_t nTemperature()
+        CxxChebyshevRate3(pair[double, double], pair[double, double], CxxArray2D)
+        pair[double, double] temperatureRange()
+        pair[double, double] pressureRange()
         CxxArray2D& coeffs()
 
     cdef cppclass CxxCustomFunc1Rate "Cantera::CustomFunc1Rate" (CxxReactionRateBase):
@@ -472,14 +468,11 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxPlog rate
 
     cdef cppclass CxxChebyshev "Cantera::Chebyshev":
-        CxxChebyshev(double, double, double, double, CxxArray2D)
-        double Tmin()
-        double Tmax()
-        double Pmin()
-        double Pmax()
-        size_t nPressure()
-        size_t nTemperature()
+        CxxChebyshev(pair[double, double], pair[double, double], CxxArray2D)
+        pair[double, double] temperatureRange()
+        pair[double, double] pressureRange()
         vector[double]& coeffs()
+        CxxArray2D& getCoeffs()
         void update_C(double*)
         double updateRC(double, double)
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -400,7 +400,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxChebyshevRate3(pair[double, double], pair[double, double], CxxArray2D)
         pair[double, double] temperatureRange()
         pair[double, double] pressureRange()
-        CxxArray2D& coeffs()
+        CxxArray2D& data()
 
     cdef cppclass CxxCustomFunc1Rate "Cantera::CustomFunc1Rate" (CxxReactionRateBase):
         CxxCustomFunc1Rate()
@@ -478,8 +478,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxChebyshev(pair[double, double], pair[double, double], CxxArray2D)
         pair[double, double] temperatureRange()
         pair[double, double] pressureRange()
-        vector[double]& coeffs()
-        CxxArray2D& getCoeffs()
+        CxxArray2D& data()
         void update_C(double*)
         double updateRC(double, double)
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -49,6 +49,11 @@ cdef extern from "cantera/numerics/eigen_sparse.h" namespace "Eigen":
         size_t nonZeros()
         size_t rows()
         size_t cols()
+        size_t innerSize()
+        size_t outerSize()
+        int* outerIndexPtr()
+        int* innerIndexPtr()
+        double* valuePtr()
 
 cdef extern from "cantera/base/xml.h" namespace "Cantera":
     cdef cppclass XML_Node:
@@ -1040,7 +1045,8 @@ cdef extern from "cantera/cython/wrappers.h":
 
     cdef void CxxSetLogger "setLogger" (CxxPythonLogger*)
 
-    cdef size_t CxxSparseComponents "sparseComponents" (CxxSparseMatrix, int*, int*, double*, size_t) except +translate_exception
+    cdef size_t CxxSparseTriplets "sparseTriplets" (CxxSparseMatrix, int*, int*, double*, size_t) except +translate_exception
+    cdef void CxxSparseCscData "sparseCscData" (CxxSparseMatrix, double*, int*, int*) except +translate_exception
 
     # workaround for Cython assignment limitations
     cdef void CxxArray2D_set(CxxArray2D, size_t, size_t, double)

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -392,7 +392,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxPlogRate()
         CxxPlogRate(CxxAnyMap) except +translate_exception
         CxxPlogRate(multimap[double, CxxArrhenius])
-        vector[pair[double, CxxArrhenius]] rates()
+        multimap[double, CxxArrhenius] getRates()
 
     cdef cppclass CxxChebyshevRate3 "Cantera::ChebyshevRate3" (CxxReactionRateBase):
         CxxChebyshevRate3()
@@ -467,7 +467,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
 
     cdef cppclass CxxPlog "Cantera::Plog":
         CxxPlog(multimap[double,CxxArrhenius])
-        vector[pair[double,CxxArrhenius]] rates()
+        multimap[double, CxxArrhenius] getRates()
         void update_C(double*)
         double updateRC(double, double)
 

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -224,7 +224,8 @@ cdef class _SolutionBase:
             self.kinetics.init()
             self.kinetics.skipUndeclaredThirdBodies(True)
             for reaction in reactions:
-                self.kinetics.addReaction(reaction._reaction)
+                self.kinetics.addReaction(reaction._reaction, False)
+            self.kinetics.finalizeSetup()
 
     property input_data:
         """

--- a/interfaces/cython/cantera/base.pyx
+++ b/interfaces/cython/cantera/base.pyx
@@ -225,7 +225,7 @@ cdef class _SolutionBase:
             self.kinetics.skipUndeclaredThirdBodies(True)
             for reaction in reactions:
                 self.kinetics.addReaction(reaction._reaction, False)
-            self.kinetics.finalizeSetup()
+            self.kinetics.resizeReactions()
 
     property input_data:
         """

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -310,12 +310,13 @@ cdef class ChebyshevRate(ReactionRate):
             cdef pair[double,double] limits = self.cxx_object().pressureRange()
             return limits.first, limits.second
 
-    property coeffs:
+    property data:
         """
-        2D array of Chebyshev coefficients of size `(n_temperature, n_pressure)`.
+        2D array of Chebyshev coefficients where rows and columns correspond to
+        temperature and pressure dimensions over which the Chebyshev fit is computed.
         """
         def __get__(self):
-            cdef CxxArray2D cxxcoeffs = self.cxx_object().coeffs()
+            cdef CxxArray2D cxxcoeffs = self.cxx_object().data()
             c = np.fromiter(cxxcoeffs.data(), np.double)
             return c.reshape(cxxcoeffs.nRows(), cxxcoeffs.nColumns(), order="F")
 
@@ -1584,17 +1585,17 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Accessible as number of columns of `ChebyshevRate.coeffs`.
+             Accessible as number of columns of `ChebyshevRate.data`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.getCoeffs().nColumns()
+                return self.cxx_object2().rate.data().nColumns()
 
             warnings.warn(
                 self._deprecation_warning(
-                    "nPressure", new="ChebyshevRate.coeffs.shape[1]"),
+                    "nPressure", new="ChebyshevRate.data.shape[1]"),
                 DeprecationWarning)
-            return self.rate.coeffs.shape[1]
+            return self.rate.data.shape[1]
 
     property nTemperature:
         """
@@ -1602,21 +1603,21 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Accessible as number of rows of `ChebyshevRate.coeffs`.
+             Accessible as number of rows of `ChebyshevRate.data`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.getCoeffs().nRows()
+                return self.cxx_object2().rate.data().nRows()
 
             warnings.warn(
                 self._deprecation_warning(
-                    "nTemperature", new="ChebyshevRate.coeffs.shape[0]"),
+                    "nTemperature", new="ChebyshevRate.data.shape[0]"),
                 DeprecationWarning)
-            return self.rate.coeffs.shape[0]
+            return self.rate.data.shape[0]
 
     cdef _legacy_get_coeffs(self):
         cdef CxxChebyshevReaction2* r = self.cxx_object2()
-        cdef CxxArray2D cxxcoeffs = r.rate.getCoeffs()
+        cdef CxxArray2D cxxcoeffs = r.rate.data()
         c = np.fromiter(cxxcoeffs.data(), np.double)
         return c.reshape(cxxcoeffs.nRows(), cxxcoeffs.nColumns(), order="F")
 
@@ -1626,14 +1627,17 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.coeffs`.
+             Replaced by property `ChebyshevRate.data`.
         """
         def __get__(self):
             if self.uses_legacy:
                 return self._legacy_get_coeffs()
 
-            warnings.warn(self._deprecation_warning("coeffs"), DeprecationWarning)
-            return self.rate.coeffs
+            warnings.warn(
+                self._deprecation_warning(
+                    "coeffs", new="ChebyshevRate.data"),
+                DeprecationWarning)
+            return self.rate.data
 
     cdef _legacy_set_parameters(self, Tmin, Tmax, Pmin, Pmax, coeffs):
         cdef CxxChebyshevReaction2* r = self.cxx_object2()

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -228,9 +228,9 @@ cdef class PlogRate(ReactionRate):
         """
         def __get__(self):
             rates = []
-            cdef vector[pair[double, CxxArrhenius]] cxxrates
+            cdef multimap[double, CxxArrhenius] cxxrates
             cdef pair[double, CxxArrhenius] p_rate
-            cxxrates = self.cxx_object().rates()
+            cxxrates = self.cxx_object().getRates()
             for p_rate in cxxrates:
                 rates.append((p_rate.first, copyArrhenius(&p_rate.second)))
             return rates
@@ -1361,7 +1361,7 @@ cdef class PlogReaction(Reaction):
 
     cdef list _legacy_get_rates(self):
         cdef CxxPlogReaction2* r = self.cxx_object2()
-        cdef vector[pair[double,CxxArrhenius]] cxxrates = r.rate.rates()
+        cdef multimap[double,CxxArrhenius] cxxrates = r.rate.getRates()
         cdef pair[double,CxxArrhenius] p_rate
         rates = []
         for p_rate in cxxrates:

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -258,19 +258,17 @@ cdef class ChebyshevRate(ReactionRate):
     def __cinit__(self, temperature_range=None, pressure_range=None, data=None,
                   input_data=None, init=True):
 
-        cdef pair[double,double] Trange
-        cdef pair[double,double] Prange
         if init:
             if isinstance(input_data, dict):
                 self._rate.reset(new CxxChebyshevRate3(dict_to_anymap(input_data)))
             elif all([arg is not None
                     for arg in [temperature_range, pressure_range, data]]):
-                Trange.first = temperature_range[0]
-                Trange.second = temperature_range[1]
-                Prange.first = pressure_range[0]
-                Prange.second = pressure_range[1]
+                Tmin = temperature_range[0]
+                Tmax = temperature_range[1]
+                Pmin = pressure_range[0]
+                Pmax = pressure_range[1]
                 self._rate.reset(
-                    new CxxChebyshevRate3(Trange, Prange, self._cxxarray2d(data)))
+                    new CxxChebyshevRate3(Tmin, Tmax, Pmin, Pmax, self._cxxarray2d(data)))
             elif all([arg is None
                     for arg in [temperature_range, pressure_range, data, input_data]]):
                 self._rate.reset(new CxxChebyshevRate3(dict_to_anymap({})))
@@ -301,14 +299,28 @@ cdef class ChebyshevRate(ReactionRate):
     property temperature_range:
         """ Valid temperature range [K] for the Chebyshev fit """
         def __get__(self):
-            cdef pair[double,double] limits = self.cxx_object().temperatureRange()
-            return limits.first, limits.second
+            return self.cxx_object().Tmin(), self.cxx_object().Tmax()
 
     property pressure_range:
         """ Valid pressure range [Pa] for the Chebyshev fit """
         def __get__(self):
-            cdef pair[double,double] limits = self.cxx_object().pressureRange()
-            return limits.first, limits.second
+            return self.cxx_object().Pmin(), self.cxx_object().Pmax()
+
+    property n_temperature:
+        """
+        Number of temperatures over which the Chebyshev fit is computed.
+        (same as number of rows of `data` property).
+        """
+        def __get__(self):
+            return self.cxx_object().Pmin(), self.cxx_object().nTemperature()
+
+    property n_pressure:
+        """
+        Number of pressures over which the Chebyshev fit is computed
+        (same as number of columns of `data` property).
+        """
+        def __get__(self):
+            return self.cxx_object().Pmin(), self.cxx_object().nPressure()
 
     property data:
         """
@@ -1518,7 +1530,7 @@ cdef class ChebyshevReaction(Reaction):
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.temperatureRange().first
+                return self.cxx_object2().rate.Tmin()
 
             warnings.warn(
                 self._deprecation_warning(
@@ -1536,7 +1548,7 @@ cdef class ChebyshevReaction(Reaction):
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.temperatureRange().second
+                return self.cxx_object2().rate.Tmax()
 
             warnings.warn(
                 self._deprecation_warning(
@@ -1554,7 +1566,7 @@ cdef class ChebyshevReaction(Reaction):
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.pressureRange().first
+                return self.cxx_object2().rate.Pmin()
 
             warnings.warn(
                 self._deprecation_warning(
@@ -1571,7 +1583,7 @@ cdef class ChebyshevReaction(Reaction):
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.pressureRange().second
+                return self.cxx_object2().rate.Pmax()
 
             warnings.warn(
                 self._deprecation_warning(
@@ -1585,15 +1597,15 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Accessible as number of columns of `ChebyshevRate.data`.
+             Replaced by property `ChebyshevRate.n_pressure`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.data().nColumns()
+                return self.cxx_object2().rate.nPressure()
 
             warnings.warn(
                 self._deprecation_warning(
-                    "nPressure", new="ChebyshevRate.data.shape[1]"),
+                    "nPressure", new="ChebyshevRate.data.n_pressure"),
                 DeprecationWarning)
             return self.rate.data.shape[1]
 
@@ -1603,15 +1615,15 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Accessible as number of rows of `ChebyshevRate.data`.
+             Replaced by property `ChebyshevRate.n_temperature`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.data().nRows()
+                return self.cxx_object2().rate.nTemperature()
 
             warnings.warn(
                 self._deprecation_warning(
-                    "nTemperature", new="ChebyshevRate.data.shape[0]"),
+                    "nTemperature", new="ChebyshevRate.data.n_temperature"),
                 DeprecationWarning)
             return self.rate.data.shape[0]
 
@@ -1651,11 +1663,7 @@ cdef class ChebyshevReaction(Reaction):
             for j, value in enumerate(row):
                 CxxArray2D_set(data, i, j, value)
 
-        cdef pair[double,double] Trange
-        Trange.first, Trange.second = Tmin, Tmax
-        cdef pair[double,double] Prange
-        Prange.first, Prange.second = Pmin, Pmax
-        r.rate = CxxChebyshev(Trange, Prange, data)
+        r.rate = CxxChebyshev(Tmin, Tmax, Pmin, Pmax, data)
 
     def set_parameters(self, Tmin, Tmax, Pmin, Pmax, coeffs):
         """

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -255,17 +255,24 @@ cdef class ChebyshevRate(ReactionRate):
     """
     _reaction_rate_type = "Chebyshev"
 
-    def __cinit__(self, Tmin=None, Tmax=None, Pmin=None, Pmax=None, data=None,
+    def __cinit__(self, temperature_range=None, pressure_range=None, data=None,
                   input_data=None, init=True):
 
+        cdef pair[double,double] Trange
+        cdef pair[double,double] Prange
         if init:
             if isinstance(input_data, dict):
                 self._rate.reset(new CxxChebyshevRate3(dict_to_anymap(input_data)))
-            elif all([arg is not None for arg in [Tmin, Tmax, Pmin, Pmax, data]]):
-                self._rate.reset(new CxxChebyshevRate3(Tmin, Tmax, Pmin, Pmax,
-                                                       self._cxxarray2d(data)))
+            elif all([arg is not None
+                    for arg in [temperature_range, pressure_range, data]]):
+                Trange.first = temperature_range[0]
+                Trange.second = temperature_range[1]
+                Prange.first = pressure_range[0]
+                Prange.second = pressure_range[1]
+                self._rate.reset(
+                    new CxxChebyshevRate3(Trange, Prange, self._cxxarray2d(data)))
             elif all([arg is None
-                    for arg in [Tmin, Tmax, Pmin, Pmax, data, input_data]]):
+                    for arg in [temperature_range, pressure_range, data, input_data]]):
                 self._rate.reset(new CxxChebyshevRate3(dict_to_anymap({})))
             elif input_data:
                 raise TypeError("Invalid parameter 'input_data'")
@@ -291,35 +298,17 @@ cdef class ChebyshevRate(ReactionRate):
     cdef CxxChebyshevRate3* cxx_object(self):
         return <CxxChebyshevRate3*>self.rate
 
-    property Tmin:
-        """ Minimum temperature [K] for the Chebyshev fit """
+    property temperature_range:
+        """ Valid temperature range [K] for the Chebyshev fit """
         def __get__(self):
-            return self.cxx_object().Tmin()
+            cdef pair[double,double] limits = self.cxx_object().temperatureRange()
+            return limits.first, limits.second
 
-    property Tmax:
-        """ Maximum temperature [K] for the Chebyshev fit """
+    property pressure_range:
+        """ Valid pressure range [Pa] for the Chebyshev fit """
         def __get__(self):
-            return self.cxx_object().Tmax()
-
-    property Pmin:
-        """ Minimum pressure [Pa] for the Chebyshev fit """
-        def __get__(self):
-            return self.cxx_object().Pmin()
-
-    property Pmax:
-        """ Maximum pressure [Pa] for the Chebyshev fit """
-        def __get__(self):
-            return self.cxx_object().Pmax()
-
-    property n_pressure:
-        """ Number of pressures over which the Chebyshev fit is computed """
-        def __get__(self):
-            return self.cxx_object().nPressure()
-
-    property n_temperature:
-        """ Number of temperatures over which the Chebyshev fit is computed """
-        def __get__(self):
-            return self.cxx_object().nTemperature()
+            cdef pair[double,double] limits = self.cxx_object().pressureRange()
+            return limits.first, limits.second
 
     property coeffs:
         """
@@ -811,10 +800,14 @@ cdef class Reaction:
     def __str__(self):
         return self.equation
 
-    def _deprecation_warning(self, attr, what="property"):
-        return ("\n{} '{}' to be removed after Cantera 2.6.\nThis {} is moved to "
-                "the {} object accessed via the 'rate' property."
-                ).format(what.capitalize(), attr, what, type(self.rate).__name__)
+    def _deprecation_warning(self, attr, what="property", new=None):
+        if new:
+            return (f"\n{what.capitalize()} '{attr}' to be removed after Cantera 2.6.\n"
+                    f"This {what} is moved to the {type(self.rate).__name__} object "
+                    f"accessed via the 'rate' property as '{new}'.")
+        return (f"\n{what.capitalize()} '{attr}' to be removed after Cantera 2.6.\n"
+                f"This {what} is moved to the {type(self.rate).__name__} object accessed "
+                "via the 'rate' property.")
 
     property uses_legacy:
         """Indicate whether reaction uses a legacy implementation"""
@@ -1447,8 +1440,8 @@ cdef class ChebyshevReaction(Reaction):
 
         rxn = ChebyshevReaction(
             equation="HO2 <=> OH + O",
-            rate={"Tmin": 290.0, "Tmax": 3000.0,
-                  "Pmin": 1e3, "Pmax": 1e8,
+            rate={"temperature-range": [290.0, 3000.0],
+                  "pressure-range": [1e3, 1e8],
                   "data": [[8.2883, -1.1397, -0.12059, 0.016034],
                            [1.9764, 1.0037, 7.2865e-03, -0.030432],
                            [0.3177, 0.26889, 0.094806, -7.6385e-03]]},
@@ -1489,9 +1482,8 @@ cdef class ChebyshevReaction(Reaction):
                 rxn_type += "-legacy"
             spec = {"equation": equation, "type": rxn_type}
             if isinstance(rate, dict):
-                spec["temperature-range"] = [rate["Tmin"], rate["Tmax"]]
-                spec["pressure-range"] = [rate["Pmin"], rate["Pmax"]]
-                spec["data"] = rate["data"]
+                for key, value in rate.items():
+                    spec[key.replace("_", "-")] = value
             elif not legacy and (isinstance(rate, ChebyshevRate) or rate is None):
                 pass
             else:
@@ -1521,14 +1513,17 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.Tmin`.
+             Replaced by property `ChebyshevRate.temperature_range[0]`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.Tmin()
+                return self.cxx_object2().rate.temperatureRange().first
 
-            warnings.warn(self._deprecation_warning("Tmin"), DeprecationWarning)
-            return self.rate.Tmin
+            warnings.warn(
+                self._deprecation_warning(
+                    "Tmin", new="ChebyshevRate.temperature_range[0]"),
+                DeprecationWarning)
+            return self.rate.temperature_range[0]
 
     property Tmax:
         """
@@ -1536,14 +1531,17 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.Tmax`.
+             Replaced by property `ChebyshevRate.temperature_range[1]`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.Tmax()
+                return self.cxx_object2().rate.temperatureRange().second
 
-            warnings.warn(self._deprecation_warning("Tmax"), DeprecationWarning)
-            return self.rate.Tmax
+            warnings.warn(
+                self._deprecation_warning(
+                    "Tmax", new="ChebyshevRate.temperature_range[1]"),
+                DeprecationWarning)
+            return self.rate.temperature_range[1]
 
     property Pmin:
         """
@@ -1551,28 +1549,34 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.Pmin`.
+             Replaced by property `ChebyshevRate.pressure_range[0]`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.Pmin()
+                return self.cxx_object2().rate.pressureRange().first
 
-            warnings.warn(self._deprecation_warning("Pmin"), DeprecationWarning)
-            return self.rate.Pmin
+            warnings.warn(
+                self._deprecation_warning(
+                    "Pmin", new="ChebyshevRate.pressure_range[0]"),
+                DeprecationWarning)
+            return self.rate.pressure_range[0]
 
     property Pmax:
         """ Maximum pressure [Pa] for the Chebyshev fit
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.Pmax`.
+             Replaced by property `ChebyshevRate.pressure_range[1]`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.Pmax()
+                return self.cxx_object2().rate.pressureRange().second
 
-            warnings.warn(self._deprecation_warning("Pmax"), DeprecationWarning)
-            return self.rate.Pmax
+            warnings.warn(
+                self._deprecation_warning(
+                    "Pmax", new="ChebyshevRate.pressure_range[0]"),
+                DeprecationWarning)
+            return self.rate.pressure_range[1]
 
     property nPressure:
         """
@@ -1580,14 +1584,17 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.nPressure`.
+             Accessible as number of columns of `ChebyshevRate.coeffs`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.nPressure()
+                return self.cxx_object2().rate.getCoeffs().nColumns()
 
-            warnings.warn(self._deprecation_warning("nPressure"), DeprecationWarning)
-            return self.rate.n_pressure
+            warnings.warn(
+                self._deprecation_warning(
+                    "nPressure", new="ChebyshevRate.coeffs.shape[1]"),
+                DeprecationWarning)
+            return self.rate.coeffs.shape[1]
 
     property nTemperature:
         """
@@ -1595,20 +1602,23 @@ cdef class ChebyshevReaction(Reaction):
 
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.nTemperature`.
+             Accessible as number of rows of `ChebyshevRate.coeffs`.
         """
         def __get__(self):
             if self.uses_legacy:
-                return self.cxx_object2().rate.nTemperature()
+                return self.cxx_object2().rate.getCoeffs().nRows()
 
             warnings.warn(
-                self._deprecation_warning("nTemperature"), DeprecationWarning)
-            return self.rate.n_temperature
+                self._deprecation_warning(
+                    "nTemperature", new="ChebyshevRate.coeffs.shape[0]"),
+                DeprecationWarning)
+            return self.rate.coeffs.shape[0]
 
     cdef _legacy_get_coeffs(self):
         cdef CxxChebyshevReaction2* r = self.cxx_object2()
-        c = np.fromiter(r.rate.coeffs(), np.double)
-        return c.reshape((r.rate.nTemperature(), r.rate.nPressure()))
+        cdef CxxArray2D cxxcoeffs = r.rate.getCoeffs()
+        c = np.fromiter(cxxcoeffs.data(), np.double)
+        return c.reshape(cxxcoeffs.nRows(), cxxcoeffs.nColumns(), order="F")
 
     property coeffs:
         """
@@ -1637,7 +1647,11 @@ cdef class ChebyshevReaction(Reaction):
             for j, value in enumerate(row):
                 CxxArray2D_set(data, i, j, value)
 
-        r.rate = CxxChebyshev(Tmin, Tmax, Pmin, Pmax, data)
+        cdef pair[double,double] Trange
+        Trange.first, Trange.second = Tmin, Tmax
+        cdef pair[double,double] Prange
+        Prange.first, Prange.second = Pmin, Pmax
+        r.rate = CxxChebyshev(Trange, Prange, data)
 
     def set_parameters(self, Tmin, Tmax, Pmin, Pmax, coeffs):
         """
@@ -1654,7 +1668,11 @@ cdef class ChebyshevReaction(Reaction):
         warnings.warn("Method 'set_parameters' to be removed after Cantera 2.6. "
             "Method is replaceable by assigning a new 'ChebyshevRate' object to the "
             "rate property.", DeprecationWarning)
-        self.rate = ChebyshevRate(Tmin, Tmax, Pmin, Pmax, coeffs)
+        cdef pair[double,double] Trange
+        Trange.first, Trange.second = Tmin, Tmax
+        cdef pair[double,double] Prange
+        Prange.first, Prange.second = Pmin, Pmax
+        self.rate = ChebyshevRate(Trange, Prange, coeffs)
 
     cdef _legacy_call(self, float T, float P):
         cdef CxxChebyshevReaction2* r = self.cxx_object2()

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -154,6 +154,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertEqual(states[0].P, gas.P)
         self.assertArrayNear(states[0].Y, gas.Y)
 
+    @utilities.unittest.skipIf(isinstance(_h5py, ImportError), "h5py is not installed")
     def test_import_no_norm_data(self):
         outfile = self.test_work_path / "solutionarray.h5"
         # In Python >= 3.8, this can be replaced by the missing_ok argument
@@ -469,6 +470,7 @@ class TestRestorePureFluid(utilities.CanteraTest):
         b.restore_data(data)
         check(a, b)
 
+    @utilities.unittest.skipIf(isinstance(_h5py, ImportError), "h5py is not installed")
     def test_import_no_norm_water(self):
         outfile = self.test_work_path / "solutionarray.h5"
         # In Python >= 3.8, this can be replaced by the missing_ok argument

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -39,8 +39,8 @@ class converterTestCommon:
 
         self.assertEqual(ref.element_names, gas.element_names)
         self.assertEqual(ref.species_names, gas.species_names)
-        coeffs_ref = ref.reactant_stoich_coefficients
-        coeffs_gas = gas.reactant_stoich_coefficients
+        coeffs_ref = ref.reactant_stoich_coeffs3
+        coeffs_gas = gas.reactant_stoich_coeffs3
         self.assertEqual(coeffs_gas.shape, coeffs_ref.shape)
         self.assertTrue((coeffs_gas == coeffs_ref).all())
 
@@ -154,7 +154,7 @@ class converterTestCommon:
         self.assertEqual(gas.species_name(8), 'co')
 
         self.assertEqual(gas.n_reactions, 12)
-        nu = gas.product_stoich_coefficients - gas.reactant_stoich_coefficients
+        nu = gas.product_stoich_coeffs3 - gas.reactant_stoich_coeffs3
         self.assertEqual(list(nu[:,0]), [-1, -1, 0, 2, 0, 0, 0, 0, 0])
         self.assertEqual(list(nu[:,1]), [-2, 3, 0, -1, 0, 0, 0, 0, 0])
         self.assertEqual(list(nu[:,2]), [-1, 0, 0, 0, 1, 0, 0, 0, 0])
@@ -233,8 +233,8 @@ class converterTestCommon:
         self.assertEqual(Rr[2], 0.0)
         self.assertEqual(Rr[3], 0.0)
         self.assertEqual(Rr[4], 0.0)
-        Rstoich = gas.reactant_stoich_coefficients
-        Pstoich = gas.product_stoich_coefficients
+        Rstoich = gas.reactant_stoich_coeffs3
+        Pstoich = gas.product_stoich_coeffs3
         self.assertEqual(list(Rstoich[:, 0]), list(Pstoich[:, 1]))
         self.assertEqual(list(Rstoich[:, 1]), list(Pstoich[:, 0]))
         self.assertEqual(list(Rstoich[:, 2]), list(Pstoich[:, 3]))
@@ -289,8 +289,8 @@ class converterTestCommon:
         output = self.convert('float-stoich.inp', thermo='dummy-thermo.dat')
         gas = ct.Solution(output)
 
-        R = gas.reactant_stoich_coefficients
-        P = gas.product_stoich_coefficients
+        R = gas.reactant_stoich_coeffs3
+        P = gas.product_stoich_coeffs3
         self.assertArrayNear(R[:,0], [0, 1.5, 0.5, 0])
         self.assertArrayNear(P[:,0], [1, 0, 0, 1])
         self.assertArrayNear(R[:,1], [1, 0, 0, 1])

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -39,8 +39,8 @@ class converterTestCommon:
 
         self.assertEqual(ref.element_names, gas.element_names)
         self.assertEqual(ref.species_names, gas.species_names)
-        coeffs_ref = ref.reactant_stoich_coeffs()
-        coeffs_gas = gas.reactant_stoich_coeffs()
+        coeffs_ref = ref.reactant_stoich_coefficients
+        coeffs_gas = gas.reactant_stoich_coefficients
         self.assertEqual(coeffs_gas.shape, coeffs_ref.shape)
         self.assertTrue((coeffs_gas == coeffs_ref).all())
 
@@ -154,7 +154,7 @@ class converterTestCommon:
         self.assertEqual(gas.species_name(8), 'co')
 
         self.assertEqual(gas.n_reactions, 12)
-        nu = gas.product_stoich_coeffs() - gas.reactant_stoich_coeffs()
+        nu = gas.product_stoich_coefficients - gas.reactant_stoich_coefficients
         self.assertEqual(list(nu[:,0]), [-1, -1, 0, 2, 0, 0, 0, 0, 0])
         self.assertEqual(list(nu[:,1]), [-2, 3, 0, -1, 0, 0, 0, 0, 0])
         self.assertEqual(list(nu[:,2]), [-1, 0, 0, 0, 1, 0, 0, 0, 0])
@@ -233,8 +233,8 @@ class converterTestCommon:
         self.assertEqual(Rr[2], 0.0)
         self.assertEqual(Rr[3], 0.0)
         self.assertEqual(Rr[4], 0.0)
-        Rstoich = gas.reactant_stoich_coeffs()
-        Pstoich = gas.product_stoich_coeffs()
+        Rstoich = gas.reactant_stoich_coefficients
+        Pstoich = gas.product_stoich_coefficients
         self.assertEqual(list(Rstoich[:, 0]), list(Pstoich[:, 1]))
         self.assertEqual(list(Rstoich[:, 1]), list(Pstoich[:, 0]))
         self.assertEqual(list(Rstoich[:, 2]), list(Pstoich[:, 3]))
@@ -289,8 +289,8 @@ class converterTestCommon:
         output = self.convert('float-stoich.inp', thermo='dummy-thermo.dat')
         gas = ct.Solution(output)
 
-        R = gas.reactant_stoich_coeffs()
-        P = gas.product_stoich_coeffs()
+        R = gas.reactant_stoich_coefficients
+        P = gas.product_stoich_coefficients
         self.assertArrayNear(R[:,0], [0, 1.5, 0.5, 0])
         self.assertArrayNear(P[:,0], [1, 0, 0, 1])
         self.assertArrayNear(R[:,1], [1, 0, 0, 1])

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -143,8 +143,10 @@ class TestKinetics(utilities.CanteraTest):
 
     def test_rate_constants(self):
         self.assertEqual(len(self.phase.forward_rate_constants), self.phase.n_reactions)
-        self.assertArrayNear(self.phase.forward_rate_constants / self.phase.reverse_rate_constants,
-                             self.phase.equilibrium_constants)
+        ix = self.phase.reverse_rate_constants != 0.
+        self.assertArrayNear(
+            self.phase.forward_rate_constants[ix] / self.phase.reverse_rate_constants[ix],
+            self.phase.equilibrium_constants[ix])
 
     def test_species_rates(self):
         nu_p = self.phase.product_stoich_coeffs()

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1481,7 +1481,7 @@ class TestReaction(utilities.CanteraTest):
         r1 = gas.reaction(4)
         r2 = gas.reaction(5)
         r1.rate = ct.ChebyshevRate(
-            r2.rate.temperature_range, r2.rate.pressure_range, r2.rate.coeffs)
+            r2.rate.temperature_range, r2.rate.pressure_range, r2.rate.data)
 
         # rates should be different before calling 'modify_reaction'
         kf = gas.forward_rate_constants

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -98,8 +98,8 @@ class TestKinetics(utilities.CanteraTest):
                     self.assertIn(self.phase.species_name(k), P)
 
     def test_stoich_coeffs(self):
-        nu_r = self.phase.reactant_stoich_coeffs()
-        nu_p = self.phase.product_stoich_coeffs()
+        nu_r = self.phase.reactant_stoich_coefficients
+        nu_p = self.phase.product_stoich_coefficients
 
         def check_reactant(s, i, value):
             k = self.phase.kinetics_species_index(s)
@@ -149,8 +149,8 @@ class TestKinetics(utilities.CanteraTest):
             self.phase.equilibrium_constants[ix])
 
     def test_species_rates(self):
-        nu_p = self.phase.product_stoich_coeffs()
-        nu_r = self.phase.reactant_stoich_coeffs()
+        nu_p = self.phase.product_stoich_coefficients
+        nu_r = self.phase.reactant_stoich_coefficients
         creation = (np.dot(nu_p, self.phase.forward_rates_of_progress) +
                     np.dot(nu_r, self.phase.reverse_rates_of_progress))
         destruction = (np.dot(nu_r, self.phase.forward_rates_of_progress) +
@@ -187,10 +187,10 @@ class KineticsFromReactions(utilities.CanteraTest):
         gas1.TPY = 800, 2*ct.one_atm, 'H2:0.3, O2:0.7, OH:2e-4, O:1e-3, H:5e-5'
         gas2.TPY = gas1.TPY
 
-        self.assertTrue((gas1.reactant_stoich_coeffs() ==
-                         gas2.reactant_stoich_coeffs()).all())
-        self.assertTrue((gas1.product_stoich_coeffs() ==
-                         gas2.product_stoich_coeffs()).all())
+        self.assertTrue((gas1.reactant_stoich_coefficients ==
+                         gas2.reactant_stoich_coefficients).all())
+        self.assertTrue((gas1.product_stoich_coefficients ==
+                         gas2.product_stoich_coefficients).all())
 
         self.assertArrayNear(gas1.delta_gibbs,
                              gas2.delta_gibbs)
@@ -265,10 +265,10 @@ class KineticsFromReactions(utilities.CanteraTest):
 
         self.assertEqual(gas1.n_reactions, gas2.n_reactions)
 
-        self.assertTrue((gas1.reactant_stoich_coeffs() ==
-                         gas2.reactant_stoich_coeffs()).all())
-        self.assertTrue((gas1.product_stoich_coeffs() ==
-                         gas2.product_stoich_coeffs()).all())
+        self.assertTrue((gas1.reactant_stoich_coefficients ==
+                         gas2.reactant_stoich_coefficients).all())
+        self.assertTrue((gas1.product_stoich_coefficients ==
+                         gas2.product_stoich_coefficients).all())
 
         self.assertArrayNear(gas1.delta_gibbs,
                              gas2.delta_gibbs)

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1131,7 +1131,9 @@ class TestReaction(utilities.CanteraTest):
         r = ct.ChebyshevReaction()
         r.reactants = 'R5:1, H:1'
         r.products = 'P5A:1, P5B:1'
-        r.rate = ct.ChebyshevRate(Tmin=300.0, Tmax=2000.0, Pmin=1000, Pmax=10000000,
+        r.rate = ct.ChebyshevRate(
+            temperature_range=(300.0, 2000.0),
+            pressure_range=(1000, 10000000),
             data=[[ 5.28830e+00, -1.13970e+00, -1.20590e-01,  1.60340e-02],
                   [ 1.97640e+00,  1.00370e+00,  7.28650e-03, -3.04320e-02],
                   [ 3.17700e-01,  2.68890e-01,  9.48060e-02, -7.63850e-03],
@@ -1154,7 +1156,9 @@ class TestReaction(utilities.CanteraTest):
         r = ct.ChebyshevReaction()
         r.reactants = 'R5:1, H:1'
         r.products = 'P5A:1, P5B:1'
-        r.rate = ct.ChebyshevRate(Tmin=300.0, Tmax=2000.0, Pmin=1000, Pmax=10000000,
+        r.rate = ct.ChebyshevRate(
+            temperature_range=(300.0, 2000.0),
+            pressure_range=(1000, 10000000),
             data=[[ 5.28830e+00],
                   [ 1.97640e+00],
                   [ 3.17700e-01],
@@ -1176,7 +1180,9 @@ class TestReaction(utilities.CanteraTest):
         r = ct.ChebyshevReaction()
         r.reactants = 'R5:1, H:1'
         r.products = 'P5A:1, P5B:1'
-        r.rate = ct.ChebyshevRate(Tmin=300.0, Tmax=2000.0, Pmin=1000, Pmax=10000000,
+        r.rate = ct.ChebyshevRate(
+            temperature_range=(300.0, 2000.0),
+            pressure_range=(1000, 10000000),
             data=[[ 5.28830e+00, -1.13970e+00, -1.20590e-01,  1.60340e-02]])
 
         gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
@@ -1451,8 +1457,8 @@ class TestReaction(utilities.CanteraTest):
 
         r1 = gas.reaction(4)
         r2 = gas.reaction(5)
-        r1.rate = ct.ChebyshevRate(r2.rate.Tmin, r2.rate.Tmax,
-                                   r2.rate.Pmin, r2.rate.Pmax, r2.rate.coeffs)
+        r1.rate = ct.ChebyshevRate(
+            r2.rate.temperature_range, r2.rate.pressure_range, r2.rate.coeffs)
 
         # rates should be different before calling 'modify_reaction'
         kf = gas.forward_rate_constants

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -330,19 +330,17 @@ class TestChebyshevRate(ReactionRateTests, utilities.CanteraTest):
         """
 
     def setUp(self):
-        self.Tmin = self.gas.reaction(self._index).rate.Tmin
-        self.Tmax = self.gas.reaction(self._index).rate.Tmax
-        self.Pmin = self.gas.reaction(self._index).rate.Pmin
-        self.Pmax = self.gas.reaction(self._index).rate.Pmax
+        self.Trange = self.gas.reaction(self._index).rate.temperature_range
+        self.Prange = self.gas.reaction(self._index).rate.pressure_range
         self.coeffs = self.gas.reaction(self._index).rate.coeffs
-        self.rate = ct.ChebyshevRate(self.Tmin, self.Tmax, self.Pmin, self.Pmax, self.coeffs)
+        self.rate = ct.ChebyshevRate(self.Trange, self.Prange, self.coeffs)
 
     def test_parameters(self):
         # test getters for rate properties
-        self.assertEqual(self.Tmin, self.rate.Tmin)
-        self.assertEqual(self.Tmax, self.rate.Tmax)
-        self.assertEqual(self.Pmin, self.rate.Pmin)
-        self.assertEqual(self.Pmax, self.rate.Pmax)
+        self.assertEqual(self.Trange[0], self.rate.temperature_range[0])
+        self.assertEqual(self.Trange[1], self.rate.temperature_range[1])
+        self.assertEqual(self.Prange[0], self.rate.pressure_range[0])
+        self.assertEqual(self.Prange[1], self.rate.pressure_range[1])
         self.assertTrue(np.all(self.coeffs == self.rate.coeffs))
 
 
@@ -786,7 +784,7 @@ class TestChebyshev(ReactionTests, utilities.CanteraTest):
     _cls = ct.ChebyshevReaction
     _type = "Chebyshev"
     _equation = "HO2 <=> OH + O"
-    _rate = {"Tmin": 290., "Tmax": 3000., "Pmin": 1000., "Pmax": 10000000.0,
+    _rate = {"temperature_range": (290., 3000.), "pressure_range": (1000., 10000000.0),
              "data": [[ 8.2883e+00, -1.1397e+00, -1.2059e-01,  1.6034e-02],
                       [ 1.9764e+00,  1.0037e+00,  7.2865e-03, -3.0432e-02],
                       [ 3.1770e-01,  2.6889e-01,  9.4806e-02, -7.6385e-03]]}
@@ -811,7 +809,8 @@ class TestChebyshev(ReactionTests, utilities.CanteraTest):
             cls._rate_obj = ct.ChebyshevRate(**cls._rate)
         cls._deprecated_getters.update({"coeffs": np.array(cls._rate["data"])})
         cls._deprecated_getters.update(
-            {k: v for k, v in cls._rate.items() if k != "data"})
+            {k: v for k, v in cls._rate.items()
+                if k not in ["data", "temperature_range", "pressure_range"]})
 
 
 class TestChebyshev2(TestChebyshev):

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -525,6 +525,8 @@ class ReactionTests:
         if self._yaml is None:
             return
 
+        ct.suppress_deprecation_warnings() # disable fatal deprecation warnings
+
         rxn = ct.Reaction.from_yaml(self._yaml, kinetics=self.gas)
         for attr, default in self._deprecated_getters.items():
             if self._legacy:
@@ -532,6 +534,8 @@ class ReactionTests:
             else:
                 with self.assertWarnsRegex(DeprecationWarning, "property is moved"):
                     self.check_equal(getattr(rxn, attr), default)
+
+        ct.make_deprecation_warnings_fatal() # re-enable fatal deprecation warnings
 
     def test_deprecated_setters(self):
         # check property setters deprecated in new framework

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -332,8 +332,8 @@ class TestChebyshevRate(ReactionRateTests, utilities.CanteraTest):
     def setUp(self):
         self.Trange = self.gas.reaction(self._index).rate.temperature_range
         self.Prange = self.gas.reaction(self._index).rate.pressure_range
-        self.coeffs = self.gas.reaction(self._index).rate.coeffs
-        self.rate = ct.ChebyshevRate(self.Trange, self.Prange, self.coeffs)
+        self.data = self.gas.reaction(self._index).rate.data
+        self.rate = ct.ChebyshevRate(self.Trange, self.Prange, self.data)
 
     def test_parameters(self):
         # test getters for rate properties
@@ -341,7 +341,7 @@ class TestChebyshevRate(ReactionRateTests, utilities.CanteraTest):
         self.assertEqual(self.Trange[1], self.rate.temperature_range[1])
         self.assertEqual(self.Prange[0], self.rate.pressure_range[0])
         self.assertEqual(self.Prange[1], self.rate.pressure_range[1])
-        self.assertTrue(np.all(self.coeffs == self.rate.coeffs))
+        self.assertTrue(np.all(self.data == self.rate.data))
 
 
 class ReactionTests:
@@ -531,7 +531,11 @@ class ReactionTests:
                 self.check_equal(getattr(rxn, attr), default)
             else:
                 with self.assertWarnsRegex(DeprecationWarning, "property is moved"):
-                    self.check_equal(getattr(rxn, attr), default)
+                    try:
+                        self.check_equal(getattr(rxn, attr), default)
+                    except Exception as err:
+                        print(f"Exception raised when testing getter for '{attr}'")
+                        raise err
 
         ct.make_deprecation_warnings_fatal() # re-enable fatal deprecation warnings
 

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -99,9 +99,9 @@ void BulkKinetics::getRevRateConstants(double* krev, bool doIrreversible)
     }
 }
 
-bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool finalize)
+bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
 {
-    bool added = Kinetics::addReaction(r, finalize);
+    bool added = Kinetics::addReaction(r, resize);
     if (!added) {
         // undeclared species, etc.
         return false;

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -99,9 +99,9 @@ void BulkKinetics::getRevRateConstants(double* krev, bool doIrreversible)
     }
 }
 
-bool BulkKinetics::addReaction(shared_ptr<Reaction> r)
+bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool finalize)
 {
-    bool added = Kinetics::addReaction(r);
+    bool added = Kinetics::addReaction(r, finalize);
     if (!added) {
         // undeclared species, etc.
         return false;

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -264,10 +264,10 @@ void GasKinetics::getFwdRateConstants(double* kfwd)
     }
 }
 
-bool GasKinetics::addReaction(shared_ptr<Reaction> r)
+bool GasKinetics::addReaction(shared_ptr<Reaction> r, bool finalize)
 {
     // operations common to all reaction types
-    bool added = BulkKinetics::addReaction(r);
+    bool added = BulkKinetics::addReaction(r, finalize);
     if (!added) {
         return false;
     } else if (!(r->usesLegacy())) {

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -264,10 +264,10 @@ void GasKinetics::getFwdRateConstants(double* kfwd)
     }
 }
 
-bool GasKinetics::addReaction(shared_ptr<Reaction> r, bool finalize)
+bool GasKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
 {
     // operations common to all reaction types
-    bool added = BulkKinetics::addReaction(r, finalize);
+    bool added = BulkKinetics::addReaction(r, resize);
     if (!added) {
         return false;
     } else if (!(r->usesLegacy())) {

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -477,7 +477,7 @@ void InterfaceKinetics::getDeltaSSEntropy(doublereal* deltaS)
     getReactionDelta(m_grt.data(), deltaS);
 }
 
-bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base)
+bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base, bool finalize)
 {
     if (!m_surf) {
         init();
@@ -505,7 +505,7 @@ bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base)
     }
 
     size_t i = nReactions();
-    bool added = Kinetics::addReaction(r_base);
+    bool added = Kinetics::addReaction(r_base, finalize);
     if (!added) {
         return false;
     }

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -477,7 +477,7 @@ void InterfaceKinetics::getDeltaSSEntropy(doublereal* deltaS)
     getReactionDelta(m_grt.data(), deltaS);
 }
 
-bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base, bool finalize)
+bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base, bool resize)
 {
     if (!m_surf) {
         init();
@@ -505,7 +505,7 @@ bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base, bool finalize)
     }
 
     size_t i = nReactions();
-    bool added = Kinetics::addReaction(r_base, finalize);
+    bool added = Kinetics::addReaction(r_base, resize);
     if (!added) {
         return false;
     }

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -356,14 +356,12 @@ size_t Kinetics::speciesPhaseIndex(size_t k) const
 
 double Kinetics::reactantStoichCoeff(size_t kSpec, size_t irxn) const
 {
-    return getValue(m_reactions[irxn]->reactants, kineticsSpeciesName(kSpec),
-                    0.0);
+    return m_reactantStoich.stoichCoeffs().coeff(kSpec, irxn);
 }
 
 double Kinetics::productStoichCoeff(size_t kSpec, size_t irxn) const
 {
-    return getValue(m_reactions[irxn]->products, kineticsSpeciesName(kSpec),
-                    0.0);
+    return m_productStoich.stoichCoeffs().coeff(kSpec, irxn);
 }
 
 int Kinetics::reactionType(size_t i) const {

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -51,8 +51,8 @@ void Kinetics::finalizeSetup()
 
     // Stoichiometry managers
     m_reactantStoich.finalizeSetup(m_kk, nRxn);
+    m_productStoich.finalizeSetup(m_kk, nRxn);
     m_revProductStoich.finalizeSetup(m_kk, nRxn);
-    m_irrevProductStoich.finalizeSetup(m_kk, nRxn);
 
     m_finalized = true;
 }
@@ -417,8 +417,7 @@ void Kinetics::getReactionDelta(const double* prop, double* deltaProp)
 {
     fill(deltaProp, deltaProp + nReactions(), 0.0);
     // products add
-    m_revProductStoich.incrementReactions(prop, deltaProp);
-    m_irrevProductStoich.incrementReactions(prop, deltaProp);
+    m_productStoich.incrementReactions(prop, deltaProp);
     // reactants subtract
     m_reactantStoich.decrementReactions(prop, deltaProp);
 }
@@ -440,8 +439,7 @@ void Kinetics::getCreationRates(double* cdot)
     fill(cdot, cdot + m_kk, 0.0);
 
     // the forward direction creates product species
-    m_revProductStoich.incrementSpecies(m_ropf.data(), cdot);
-    m_irrevProductStoich.incrementSpecies(m_ropf.data(), cdot);
+    m_productStoich.incrementSpecies(m_ropf.data(), cdot);
 
     // the reverse direction creates reactant species
     m_reactantStoich.incrementSpecies(m_ropr.data(), cdot);
@@ -464,8 +462,7 @@ void Kinetics::getNetProductionRates(doublereal* net)
 
     fill(net, net + m_kk, 0.0);
     // products are created for positive net rate of progress
-    m_revProductStoich.incrementSpecies(m_ropnet.data(), net);
-    m_irrevProductStoich.incrementSpecies(m_ropnet.data(), net);
+    m_productStoich.incrementSpecies(m_ropnet.data(), net);
     // reactants are destroyed for positive net rate of progress
     m_reactantStoich.decrementSpecies(m_ropnet.data(), net);
 }
@@ -576,10 +573,9 @@ bool Kinetics::addReaction(shared_ptr<Reaction> r, bool finalize)
 
     m_reactantStoich.add(irxn, rk, rorder, rstoich);
     // product orders = product stoichiometric coefficients
+    m_productStoich.add(irxn, pk, pstoich, pstoich);
     if (r->reversible) {
         m_revProductStoich.add(irxn, pk, pstoich, pstoich);
-    } else {
-        m_irrevProductStoich.add(irxn, pk, pstoich, pstoich);
     }
 
     m_reactions.push_back(r);

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -24,7 +24,7 @@ using namespace std;
 namespace Cantera
 {
 Kinetics::Kinetics() :
-    m_finalized(false),
+    m_ready(false),
     m_kk(0),
     m_thermo(0),
     m_surfphase(npos),
@@ -45,16 +45,16 @@ void Kinetics::checkReactionIndex(size_t i) const
     }
 }
 
-void Kinetics::finalizeSetup()
+void Kinetics::resizeReactions()
 {
     size_t nRxn = nReactions();
 
     // Stoichiometry managers
-    m_reactantStoich.finalizeSetup(m_kk, nRxn);
-    m_productStoich.finalizeSetup(m_kk, nRxn);
-    m_revProductStoich.finalizeSetup(m_kk, nRxn);
+    m_reactantStoich.resizeCoeffs(m_kk, nRxn);
+    m_productStoich.resizeCoeffs(m_kk, nRxn);
+    m_revProductStoich.resizeCoeffs(m_kk, nRxn);
 
-    m_finalized = true;
+    m_ready = true;
 }
 
 void Kinetics::checkReactionArraySize(size_t ii) const
@@ -509,7 +509,7 @@ void Kinetics::resizeSpecies()
     invalidateCache();
 }
 
-bool Kinetics::addReaction(shared_ptr<Reaction> r, bool finalize)
+bool Kinetics::addReaction(shared_ptr<Reaction> r, bool resize)
 {
     r->validate();
     if (m_kk == 0) {
@@ -585,10 +585,10 @@ bool Kinetics::addReaction(shared_ptr<Reaction> r, bool finalize)
     m_perturb.push_back(1.0);
     m_dH.push_back(0.0);
 
-    if (finalize) {
-        finalizeSetup();
+    if (resize) {
+        resizeReactions();
     } else {
-        m_finalized = false;
+        m_ready = false;
     }
 
     return true;

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -197,7 +197,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
         throw CanteraError("addReactions", to_string(add_rxn_err));
     }
 
-    kin.finalizeSetup();
+    kin.resizeReactions();
 }
 
 }

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -175,7 +175,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
                 rootNode.getString("__file__", ""));
             for (const auto& R : reactions[node].asVector<AnyMap>()) {
                 try {
-                    kin.addReaction(newReaction(R, kin));
+                    kin.addReaction(newReaction(R, kin), false);
                 } catch (CanteraError& err) {
                     format_to(add_rxn_err, "{}", err.what());
                 }
@@ -184,7 +184,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
             // specified section is in the current file
             for (const auto& R : rootNode.at(sections[i]).asVector<AnyMap>()) {
                 try {
-                    kin.addReaction(newReaction(R, kin));
+                    kin.addReaction(newReaction(R, kin), false);
                 } catch (CanteraError& err) {
                     format_to(add_rxn_err, "{}", err.what());
                 }
@@ -196,6 +196,8 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
     if (add_rxn_err.size()) {
         throw CanteraError("addReactions", to_string(add_rxn_err));
     }
+
+    kin.finalizeSetup();
 }
 
 }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -1627,11 +1627,10 @@ void setupChebyshevReaction(ChebyshevReaction2& R, const XML_Node& rxn_node)
             coeffs(t,p) = coeffs_flat[nP*t + p];
         }
     }
-    R.rate = Chebyshev(getFloat(rc, "Tmin", "toSI"),
-                       getFloat(rc, "Tmax", "toSI"),
-                       getFloat(rc, "Pmin", "toSI"),
-                       getFloat(rc, "Pmax", "toSI"),
-                       coeffs);
+    R.rate = Chebyshev(
+        std::make_pair(getFloat(rc, "Tmin", "toSI"), getFloat(rc, "Tmax", "toSI")),
+        std::make_pair(getFloat(rc, "Pmin", "toSI"), getFloat(rc, "Pmax", "toSI")),
+        coeffs);
     setupReaction(R, rxn_node);
 }
 
@@ -1656,11 +1655,12 @@ void setupChebyshevReaction(ChebyshevReaction2&R, const AnyMap& node,
     }
     const UnitSystem& units = node.units();
     coeffs(0, 0) += std::log10(units.convertTo(1.0, R.rate_units));
-    R.rate = Chebyshev(units.convert(T_range[0], "K"),
-                       units.convert(T_range[1], "K"),
-                       units.convert(P_range[0], "Pa"),
-                       units.convert(P_range[1], "Pa"),
-                       coeffs);
+    R.rate = Chebyshev(
+        std::make_pair(
+            units.convert(T_range[0], "K"), units.convert(T_range[1], "K")),
+        std::make_pair(
+            units.convert(P_range[0], "Pa"), units.convert(P_range[1], "Pa")),
+        coeffs);
 }
 
 void setupInterfaceReaction(InterfaceReaction& R, const XML_Node& rxn_node)

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -1627,10 +1627,11 @@ void setupChebyshevReaction(ChebyshevReaction2& R, const XML_Node& rxn_node)
             coeffs(t,p) = coeffs_flat[nP*t + p];
         }
     }
-    R.rate = Chebyshev(
-        std::make_pair(getFloat(rc, "Tmin", "toSI"), getFloat(rc, "Tmax", "toSI")),
-        std::make_pair(getFloat(rc, "Pmin", "toSI"), getFloat(rc, "Pmax", "toSI")),
-        coeffs);
+    R.rate = Chebyshev(getFloat(rc, "Tmin", "toSI"),
+                       getFloat(rc, "Tmax", "toSI"),
+                       getFloat(rc, "Pmin", "toSI"),
+                       getFloat(rc, "Pmax", "toSI"),
+                       coeffs);
     setupReaction(R, rxn_node);
 }
 
@@ -1655,12 +1656,11 @@ void setupChebyshevReaction(ChebyshevReaction2&R, const AnyMap& node,
     }
     const UnitSystem& units = node.units();
     coeffs(0, 0) += std::log10(units.convertTo(1.0, R.rate_units));
-    R.rate = Chebyshev(
-        std::make_pair(
-            units.convert(T_range[0], "K"), units.convert(T_range[1], "K")),
-        std::make_pair(
-            units.convert(P_range[0], "Pa"), units.convert(P_range[1], "Pa")),
-        coeffs);
+    R.rate = Chebyshev(units.convert(T_range[0], "K"),
+                       units.convert(T_range[1], "K"),
+                       units.convert(P_range[0], "Pa"),
+                       units.convert(P_range[1], "Pa"),
+                       coeffs);
 }
 
 void setupInterfaceReaction(InterfaceReaction& R, const XML_Node& rxn_node)

--- a/src/kinetics/ReactionRate.cpp
+++ b/src/kinetics/ReactionRate.cpp
@@ -148,9 +148,10 @@ void PlogRate::getParameters(AnyMap& rateNode, const Units& rate_units) const
     rateNode["type"] = type();
 }
 
-ChebyshevRate3::ChebyshevRate3(double Tmin, double Tmax, double Pmin, double Pmax,
-                               const Array2D& coeffs)
-    : Chebyshev(Tmin, Tmax, Pmin, Pmax, coeffs)
+ChebyshevRate3::ChebyshevRate3(
+    const std::pair<double, double> Trange,
+    const std::pair<double, double> Prange,
+    const Array2D& coeffs) : Chebyshev(Trange, Prange, coeffs)
 {
 }
 

--- a/src/kinetics/ReactionRate.cpp
+++ b/src/kinetics/ReactionRate.cpp
@@ -148,10 +148,9 @@ void PlogRate::getParameters(AnyMap& rateNode, const Units& rate_units) const
     rateNode["type"] = type();
 }
 
-ChebyshevRate3::ChebyshevRate3(
-    const std::pair<double, double> Trange,
-    const std::pair<double, double> Prange,
-    const Array2D& coeffs) : Chebyshev(Trange, Prange, coeffs)
+ChebyshevRate3::ChebyshevRate3(double Tmin, double Tmax, double Pmin, double Pmax,
+                               const Array2D& coeffs)
+    : Chebyshev(Tmin, Tmax, Pmin, Pmax, coeffs)
 {
 }
 

--- a/src/kinetics/ReactionRate.cpp
+++ b/src/kinetics/ReactionRate.cpp
@@ -192,16 +192,6 @@ void ChebyshevRate3::getParameters(AnyMap& rateNode,
     rateNode["type"] = type();
 }
 
-const Array2D& ChebyshevRate3::coeffs() const
-{
-    return ChebyshevRate3::getCoeffs();
-}
-
-void ChebyshevRate3::setCoeffs(const Array2D& coeffs)
-{
-    Chebyshev::setCoeffs(coeffs);
-}
-
 void ChebyshevRate3::validate(const std::string& equation)
 {
 }

--- a/src/kinetics/ReactionRate.cpp
+++ b/src/kinetics/ReactionRate.cpp
@@ -5,6 +5,7 @@
 
 #include "cantera/kinetics/ReactionRate.h"
 #include "cantera/kinetics/MultiRate.h"
+#include "cantera/base/Array.h"
 #include "cantera/numerics/Func1.h"
 
 namespace Cantera
@@ -188,6 +189,16 @@ void ChebyshevRate3::getParameters(AnyMap& rateNode,
     //     when the Chebyshev class is removed from RxnRates.h after Cantera 2.6
     Chebyshev::getParameters(rateNode, rate_units);
     rateNode["type"] = type();
+}
+
+const Array2D& ChebyshevRate3::coeffs() const
+{
+    return ChebyshevRate3::getCoeffs();
+}
+
+void ChebyshevRate3::setCoeffs(const Array2D& coeffs)
+{
+    Chebyshev::setCoeffs(coeffs);
 }
 
 void ChebyshevRate3::validate(const std::string& equation)

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -292,7 +292,7 @@ Chebyshev::Chebyshev(
     const Array2D& coeffs)
 {
     setLimits(Trange, Prange);
-    setCoeffs(coeffs);
+    setData(coeffs);
 }
 
 Chebyshev::Chebyshev(double Tmin, double Tmax, double Pmin, double Pmax,
@@ -301,7 +301,7 @@ Chebyshev::Chebyshev(double Tmin, double Tmax, double Pmin, double Pmax,
     warn_deprecated("Chebyshev", "Deprecated in Cantera 2.6; "
         "replaceable with constructor using pairs for range input.");
     setLimits(std::make_pair(Tmin, Tmax), std::make_pair(Pmin, Pmax));
-    setCoeffs(coeffs);
+    setData(coeffs);
 }
 
 void Chebyshev::setParameters(const AnyMap& node,
@@ -337,16 +337,16 @@ void Chebyshev::setParameters(const AnyMap& node,
         setLimits(std::make_pair(290., 3000.), std::make_pair(1.e-7, 1.e14));
     }
 
-    setCoeffs(coeffs);
+    setData(coeffs);
 }
 
 void Chebyshev::setup(double Tmin, double Tmax, double Pmin, double Pmax,
                       const Array2D& coeffs)
 {
     warn_deprecated("Chebyshev::setup", "Deprecated in Cantera 2.6; "
-        "replaceable with setLimits() and setCoeffs().");
+        "replaceable with setLimits() and setData().");
     setLimits(std::make_pair(Tmin, Tmax), std::make_pair(Pmin, Pmax));
-    setCoeffs(coeffs);
+    setData(coeffs);
 }
 
 void Chebyshev::setLimits(
@@ -367,13 +367,13 @@ void Chebyshev::setLimits(
     m_Prange = Prange;
 }
 
-void Chebyshev::setCoeffs(const Array2D& coeffs)
+void Chebyshev::setData(const Array2D& coeffs)
 {
     m_coeffs = coeffs;
     dotProd_.resize(coeffs.nRows());
 
     // convert to row major for legacy output
-    // note: chebCoeffs_ is not used internally
+    // note: chebCoeffs_ is not used internally (@TODO: remove after Cantera 2.6)
     size_t rows = m_coeffs.nRows();
     size_t cols = m_coeffs.nColumns();
     chebCoeffs_.resize(rows * cols);

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -266,8 +266,8 @@ void Plog::validate(const std::string& equation)
 
 std::vector<std::pair<double, Arrhenius> > Plog::rates() const
 {
-    warn_deprecated("Plog::rates", "To be removed after Cantera 2.6; "
-        "replaceable by getRates().");
+    warn_deprecated("Plog::rates", "Behavior to change after Cantera 2.6; "
+        "see getRates() for new behavior.");
     auto rateMap = getRates();
     return std::vector<std::pair<double, Arrhenius>>(rateMap.begin(), rateMap.end());
 }

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -286,21 +286,10 @@ std::multimap<double, Arrhenius> Plog::getRates() const
     return rateMap;
 }
 
-Chebyshev::Chebyshev(
-    const std::pair<double, double> Trange,
-    const std::pair<double, double> Prange,
-    const Array2D& coeffs)
-{
-    setLimits(Trange, Prange);
-    setData(coeffs);
-}
-
 Chebyshev::Chebyshev(double Tmin, double Tmax, double Pmin, double Pmax,
                      const Array2D& coeffs)
 {
-    warn_deprecated("Chebyshev", "Deprecated in Cantera 2.6; "
-        "replaceable with constructor using pairs for range input.");
-    setLimits(std::make_pair(Tmin, Tmax), std::make_pair(Pmin, Pmax));
+    setLimits(Tmin, Tmax, Pmin, Pmax);
     setData(coeffs);
 }
 
@@ -326,15 +315,13 @@ void Chebyshev::setParameters(const AnyMap& node,
             coeffs(0, 0) += std::log10(units.convertTo(1.0, rate_units));
         }
         setLimits(
-            std::make_pair(
-                units.convert(T_range[0], "K"), units.convert(T_range[1], "K")),
-            std::make_pair(
-                units.convert(P_range[0], "Pa"), units.convert(P_range[1], "Pa")));
+            units.convert(T_range[0], "K"), units.convert(T_range[1], "K"),
+            units.convert(P_range[0], "Pa"), units.convert(P_range[1], "Pa"));
     } else {
         // ensure that reaction rate can be evaluated (but returns NaN)
         coeffs = Array2D(1, 1);
         coeffs(0, 0) = NAN;
-        setLimits(std::make_pair(290., 3000.), std::make_pair(1.e-7, 1.e14));
+        setLimits(290., 3000., 1.e-7, 1.e14);
     }
 
     setData(coeffs);
@@ -345,26 +332,26 @@ void Chebyshev::setup(double Tmin, double Tmax, double Pmin, double Pmax,
 {
     warn_deprecated("Chebyshev::setup", "Deprecated in Cantera 2.6; "
         "replaceable with setLimits() and setData().");
-    setLimits(std::make_pair(Tmin, Tmax), std::make_pair(Pmin, Pmax));
+    setLimits(Tmin, Tmax, Pmin, Pmax);
     setData(coeffs);
 }
 
-void Chebyshev::setLimits(
-    const std::pair<double, double> Trange,
-    const std::pair<double, double> Prange)
+void Chebyshev::setLimits(double Tmin, double Tmax, double Pmin, double Pmax)
 {
-    double logPmin = std::log10(Prange.first);
-    double logPmax = std::log10(Prange.second);
-    double TminInv = 1.0 / Trange.first;
-    double TmaxInv = 1.0 / Trange.second;
+    double logPmin = std::log10(Pmin);
+    double logPmax = std::log10(Pmax);
+    double TminInv = 1.0 / Tmin;
+    double TmaxInv = 1.0 / Tmax;
 
     TrNum_ = - TminInv - TmaxInv;
     TrDen_ = 1.0 / (TmaxInv - TminInv);
     PrNum_ = - logPmin - logPmax;
     PrDen_ = 1.0 / (logPmax - logPmin);
 
-    m_Trange = Trange;
-    m_Prange = Prange;
+    Tmin_ = Tmin;
+    Tmax_ = Tmax;
+    Pmin_ = Pmin;
+    Pmax_ = Pmax;
 }
 
 void Chebyshev::setData(const Array2D& coeffs)
@@ -390,10 +377,8 @@ void Chebyshev::getParameters(AnyMap& rateNode, const Units& rate_units) const
         // Return empty/unmodified AnyMap
         return;
     }
-    rateNode["temperature-range"].setQuantity(
-        {temperatureRange().first, temperatureRange().second}, "K");
-    rateNode["pressure-range"].setQuantity(
-        {pressureRange().first, pressureRange().second}, "Pa");
+    rateNode["temperature-range"].setQuantity({Tmin(), Tmax()}, "K");
+    rateNode["pressure-range"].setQuantity({Pmin(), Pmax()}, "Pa");
     size_t nT = m_coeffs.nRows();
     size_t nP = m_coeffs.nColumns();
     std::vector<vector_fp> coeffs2d(nT, vector_fp(nP));

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -218,6 +218,8 @@ void Plog::setup(const std::multimap<double, Arrhenius>& rates)
 void Plog::setRates(const std::multimap<double, Arrhenius>& rates)
 {
     size_t j = 0;
+    rates_.clear();
+    pressures_.clear();
     rates_.reserve(rates.size());
     // Insert intermediate pressures
     for (const auto& rate : rates) {

--- a/src/kinetics/importKinetics.cpp
+++ b/src/kinetics/importKinetics.cpp
@@ -127,7 +127,7 @@ bool installReactionArrays(const XML_Node& p, Kinetics& kin,
         kin.checkDuplicates();
     }
 
-    kin.finalizeSetup();
+    kin.resizeReactions();
 
     return true;
 }

--- a/src/kinetics/importKinetics.cpp
+++ b/src/kinetics/importKinetics.cpp
@@ -82,7 +82,7 @@ bool installReactionArrays(const XML_Node& p, Kinetics& kin,
         if (incl.empty()) {
             for (size_t i = 0; i < allrxns.size(); i++) {
                 checkElectrochemReaction(p,kin,*allrxns[i]);
-                kin.addReaction(newReaction(*allrxns[i]));
+                kin.addReaction(newReaction(*allrxns[i]), false);
                 ++itot;
             }
         } else {
@@ -114,7 +114,7 @@ bool installReactionArrays(const XML_Node& p, Kinetics& kin,
                         // has surprising results.
                         if ((rxid >= imin) && (rxid <= imax)) {
                             checkElectrochemReaction(p,kin,*r);
-                            kin.addReaction(newReaction(*r));
+                            kin.addReaction(newReaction(*r), false);
                             ++itot;
                         }
                     }
@@ -126,6 +126,8 @@ bool installReactionArrays(const XML_Node& p, Kinetics& kin,
     if (check_for_duplicates) {
         kin.checkDuplicates();
     }
+
+    kin.finalizeSetup();
 
     return true;
 }

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -875,7 +875,7 @@ int MixtureFugacityTP::solveCubic(double T, double pres, double a, double b,
         }
     }
 
-    int nSolnValues; // Represents number of solutions to the cubic equation
+    int nSolnValues = -1; // Represents number of solutions to the cubic equation
     double h2 = 4. * an * an * delta2 * delta2 * delta2; // h^2
     if (delta2 > 0.0) {
         delta = sqrt(delta2);

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -187,8 +187,7 @@ TEST_F(KineticsFromScratch, add_chebyshev_reaction)
     coeffs(2,1) = 2.6889e-01;
     coeffs(2,2) = 9.4806e-02;
     coeffs(2,3) = -7.6385e-03;
-    Chebyshev rate(
-        std::make_pair(290., 3000.), std::make_pair(1000.0, 10000000.0), coeffs);
+    Chebyshev rate(290., 3000., 1000.0, 10000000.0, coeffs);
 
     auto R = make_shared<ChebyshevReaction2>(reac, prod, rate);
     kin.addReaction(R);

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -187,7 +187,8 @@ TEST_F(KineticsFromScratch, add_chebyshev_reaction)
     coeffs(2,1) = 2.6889e-01;
     coeffs(2,2) = 9.4806e-02;
     coeffs(2,3) = -7.6385e-03;
-    Chebyshev rate(290, 3000, 1000.0, 10000000.0, coeffs);
+    Chebyshev rate(
+        std::make_pair(290., 3000.), std::make_pair(1000.0, 10000000.0), coeffs);
 
     auto R = make_shared<ChebyshevReaction2>(reac, prod, rate);
     kin.addReaction(R);

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -167,8 +167,7 @@ TEST_F(KineticsFromScratch3, add_chebyshev_reaction)
     coeffs(2,1) = 2.6889e-01;
     coeffs(2,2) = 9.4806e-02;
     coeffs(2,3) = -7.6385e-03;
-    ChebyshevRate3 rate(
-        std::make_pair(290., 3000.), std::make_pair(1000.0, 10000000.0), coeffs);
+    ChebyshevRate3 rate(290., 3000., 1000.0, 10000000.0, coeffs);
 
     auto R = make_shared<ChebyshevReaction3>(reac, prod, rate);
     kin.addReaction(R);

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -167,7 +167,8 @@ TEST_F(KineticsFromScratch3, add_chebyshev_reaction)
     coeffs(2,1) = 2.6889e-01;
     coeffs(2,2) = 9.4806e-02;
     coeffs(2,3) = -7.6385e-03;
-    ChebyshevRate3 rate(290, 3000, 1000.0, 10000000.0, coeffs);
+    ChebyshevRate3 rate(
+        std::make_pair(290., 3000.), std::make_pair(1000.0, 10000000.0), coeffs);
 
     auto R = make_shared<ChebyshevReaction3>(reac, prod, rate);
     kin.addReaction(R);

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -252,8 +252,8 @@ TEST(Reaction, ChebyshevFromYaml)
     rate->update_C(&logP);
     EXPECT_EQ(rate->data().nRows(), (size_t) 6);
     EXPECT_EQ(rate->data().nColumns(), (size_t) 4);
-    EXPECT_DOUBLE_EQ(rate->temperatureRange().second, 3000);
-    EXPECT_DOUBLE_EQ(rate->pressureRange().first, 1000);
+    EXPECT_DOUBLE_EQ(rate->Tmax(), 3000);
+    EXPECT_DOUBLE_EQ(rate->Pmin(), 1000);
     EXPECT_NEAR(rate->updateRC(std::log(T), 1.0/T), 130512.2773948636, 1e-9);
 }
 
@@ -628,8 +628,7 @@ TEST_F(ReactionToYaml, unconvertible2)
     Array2D coeffs(2, 2, 1.0);
     ChebyshevReaction2 R({{"H2", 1}, {"OH", 1}},
                          {{"H2O", 1}, {"H", 1}},
-                         Chebyshev(std::make_pair(273., 3000.),
-                                   std::make_pair(1.e2, 1.e7), coeffs));
+                         Chebyshev(273., 3000., 1.e2, 1.e7, coeffs));
     UnitSystem U{"g", "cm", "mol"};
     AnyMap params = R.parameters();
     params.setUnits(U);

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -249,10 +249,10 @@ TEST(Reaction, ChebyshevFromYaml)
     double logP = std::log10(2e6);
     double T = 1800;
     rate->update_C(&logP);
-    EXPECT_EQ(rate->nTemperature(), (size_t) 6);
-    EXPECT_EQ(rate->nPressure(), (size_t) 4);
-    EXPECT_DOUBLE_EQ(rate->Tmax(), 3000);
-    EXPECT_DOUBLE_EQ(rate->Pmin(), 1000);
+    EXPECT_EQ(rate->coeffs().nRows(), (size_t) 6);
+    EXPECT_EQ(rate->coeffs().nColumns(), (size_t) 4);
+    EXPECT_DOUBLE_EQ(rate->temperatureRange().second, 3000);
+    EXPECT_DOUBLE_EQ(rate->pressureRange().first, 1000);
     EXPECT_NEAR(rate->updateRC(std::log(T), 1.0/T), 130512.2773948636, 1e-9);
 }
 
@@ -627,7 +627,8 @@ TEST_F(ReactionToYaml, unconvertible2)
     Array2D coeffs(2, 2, 1.0);
     ChebyshevReaction2 R({{"H2", 1}, {"OH", 1}},
                          {{"H2O", 1}, {"H", 1}},
-                         Chebyshev(273, 3000, 1e2, 1e7, coeffs));
+                         Chebyshev(std::make_pair(273., 3000.),
+                                   std::make_pair(1.e2, 1.e7), coeffs));
     UnitSystem U{"g", "cm", "mol"};
     AnyMap params = R.parameters();
     params.setUnits(U);

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -218,7 +218,8 @@ TEST(Reaction, PlogFromYaml)
         "- {P: 1.01325 MPa, A: 1.680000e+16, b: -0.6, Ea: 14754.0}");
 
     auto R = newReaction(rxn, *(sol->kinetics()));
-    const auto& rates = std::dynamic_pointer_cast<PlogRate>(R->rate())->rates();
+    const auto& rateMap = std::dynamic_pointer_cast<PlogRate>(R->rate())->getRates();
+    std::vector<std::pair<double, Arrhenius>> rates(rateMap.begin(), rateMap.end());
     EXPECT_EQ(rates.size(), (size_t) 4);
     EXPECT_NEAR(rates[0].first, 0.039474 * OneAtm, 1e-6);
     EXPECT_NEAR(rates[2].first, OneAtm, 1e-6);

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -250,8 +250,8 @@ TEST(Reaction, ChebyshevFromYaml)
     double logP = std::log10(2e6);
     double T = 1800;
     rate->update_C(&logP);
-    EXPECT_EQ(rate->coeffs().nRows(), (size_t) 6);
-    EXPECT_EQ(rate->coeffs().nColumns(), (size_t) 4);
+    EXPECT_EQ(rate->data().nRows(), (size_t) 6);
+    EXPECT_EQ(rate->data().nColumns(), (size_t) 4);
     EXPECT_DOUBLE_EQ(rate->temperatureRange().second, 3000);
     EXPECT_DOUBLE_EQ(rate->pressureRange().first, 1000);
     EXPECT_NEAR(rate->updateRC(std::log(T), 1.0/T), 130512.2773948636, 1e-9);

--- a/test_problems/surfSolverTest/surfaceSolver2.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver2.cpp
@@ -174,7 +174,7 @@ int main(int argc, char** argv)
         nr = iKin_ptr->nReactions();
         cout << "Number of reactions = " << nr << endl;
 
-        double x[MSSIZE], p = OneAtm;
+        double x[MSSIZE];
 
         /*
          *  Set-up the Surface Problem


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR contains several minor updates that fix small issues accumulated over several PR's (or address inconsistencies that were left over from the 2.5 code base). 

- Make `Plog` interface consistent: existing code mixed `std::vector<std::pair>` and `std::multimap` (deprecate `std::multimap` versions)
- Make `Chebyshev` interface consistent: existing code mixed `Array2D` and `vector_fp` (deprecate `vector_fp` versions)
- Update internal `Chebyshev` routines to consistently use column major arrays
- Fix warnings in compilation and test suite
- Clarify docstring for SCons `legacy_rate_constants`
- Allow for custom C++ `NotImplementedError` messages (allows for more granular user feedback)
- Renamed `eigen_dense.h` to `eigen_defs.h` (prepares for use of sparse matrices)
- Implement sparse stoichiometric coefficient matrices (`StoichManagerN`) via `Eigen::SparseMatrix`
- Expose sparse stoichiometric coefficient matrices to Python API via `scipy.sparse`

Most of these changes are straight-forward; some are meant to preempt questions that may arise in the context of #1051 and #1081. Specifically, the sparse interface is a preamble to sparse Jacobian output for the Python API in #1081.

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

Almost all updates are internal. The main API change allows for sparse matrix output (implemented for stoichiometric coefficients):

```
In [1]: import cantera as ct
   ...: gas = ct.Solution("test/data/kineticsfromscratch.yaml")

In [2]: gas.reactant_stoich_coefficients
Out[2]: 
array([[0., 0., 0., 0., 0., 0.],
       [1., 2., 0., 0., 0., 0.],
       [1., 0., 0., 1., 0., 0.],
       [0., 0., 0., 0., 0., 1.],
       [0., 0., 2., 0., 0., 0.],
       [0., 0., 0., 1., 0., 1.],
       [0., 0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 1., 0.]])

In [3]: ct.use_sparse() # enable sparse output via scipy.sparse

In [4]: gas.reactant_stoich_coefficients
Out[4]: 
<9x6 sparse matrix of type '<class 'numpy.float64'>'
	with 9 stored elements in COOrdinate format>

In [5]: print(gas.reactant_stoich_coefficients)
  (1, 0)	1.0
  (2, 0)	1.0
  (1, 1)	2.0
  (4, 2)	2.0
  (2, 3)	1.0
  (5, 3)	1.0
  (8, 4)	1.0
  (3, 5)	1.0
  (5, 5)	1.0

In [6]: gas.reactant_stoich_coefficients.toarray()
Out[6]: 
array([[0., 0., 0., 0., 0., 0.],
       [1., 2., 0., 0., 0., 0.],
       [1., 0., 0., 1., 0., 0.],
       [0., 0., 0., 0., 0., 1.],
       [0., 0., 2., 0., 0., 0.],
       [0., 0., 0., 1., 0., 1.],
       [0., 0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 0., 0.],
       [0., 0., 0., 0., 1., 0.]])
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review

**Other thoughts**

I also considered using `Eigen::MatrixXd` for the external `Chebyshev` interface (2-D matrix of coefficients), but ended up staying closer to the previous implementation.

~For simplicity, the `Eigen::SparseMatrix` interface to Python is implemented using a C preprocessor; the alternative would be to expose some `Eigen` classes in `_cantera.pxd`.~
