### PR TITLE
add Tsang closed-form falloff

### DIFF
--- a/AUTHORS
+++ b/AUTHORS
@@ -19,6 +19,7 @@ Steven DeCaluwe (@decaluwe), Colorado School of Mines
 Vishesh Devgan (@vdevgan)
 Thomas Fiala (@thomasfiala), Technische Universität München
 David Fronczek
+Mark E. Fuller (@mefuller), Technion
 Matteo Giani (@MarcDuQuesne)
 Dave Goodwin, California Institute of Technology
 John Hewson (@jchewson), Sandia National Laboratory

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -165,4 +165,52 @@ void SRI::getParameters(AnyMap& reactionNode) const
     reactionNode["SRI"] = std::move(params);
 }
 
+void Tsang::init(const vector_fp& c)
+{
+    if (c.size() != 1 && c.size() != 2) {
+        throw CanteraError("Tsang::init",
+            "Incorrect number of parameters. 1 or 2 required. Received {}.",
+            c.size());
+    }
+    m_a = c[0];
+
+    if (c.size() == 2) {
+        m_b = c[1];
+    }
+    else {
+        m_b = 0.0;
+    }
+}
+
+void Tsang::updateTemp(double T, double* work) const
+{
+    double Fcent = m_a + (m_b * T);
+    *work = log10(std::max(Fcent, SmallNumber));
+}
+
+double Tsang::F(double pr, const double* work) const
+{   //identical to Troe::F
+    double lpr = log10(std::max(pr,SmallNumber));
+    double cc = -0.4 - 0.67 * (*work);
+    double nn = 0.75 - 1.27 * (*work);
+    double f1 = (lpr + cc)/ (nn - 0.14 * (lpr + cc));
+    double lgf = (*work) / (1.0 + f1 * f1);
+    return pow(10.0, lgf);
+}
+
+void Tsang::getParameters(double* params) const {
+    params[0] = m_a;
+    params[1] = m_b;
+}
+
+void Tsang::getParameters(AnyMap& reactionNode) const
+{
+    AnyMap params;
+    params["A"] = m_a;
+    params["B"] = m_b;
+
+    params.setFlowStyle();
+    reactionNode["Tsang"] = std::move(params);
+}
+
 }

--- a/src/kinetics/FalloffFactory.cpp
+++ b/src/kinetics/FalloffFactory.cpp
@@ -20,6 +20,7 @@ FalloffFactory::FalloffFactory()
     addAlias("Lindemann", "Simple");
     reg("Troe", []() { return new Troe(); });
     reg("SRI", []() { return new SRI(); });
+    reg("Tsang", []() { return new Tsang(); });
 }
 
 Falloff* FalloffFactory::newFalloff(const std::string& type, const vector_fp& c)

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -1181,6 +1181,12 @@ void readFalloff(FalloffReaction& R, const XML_Node& rc_node)
                 "3 or 5 parameters, but {} were given", np);
         }
         R.falloff = newFalloff("SRI", falloff_parameters);
+    } else if (caseInsensitiveEquals(falloff["type"], "tsang")) {
+        if (np != 2) {
+            throw CanteraError("readFalloff", "Tsang parameterization takes "
+                "2 parameters, but {} were given", np);
+        }
+        R.falloff = newFalloff("Tsang", falloff_parameters);
     } else {
         throw CanteraError("readFalloff", "Unrecognized falloff type: '{}'",
                            falloff["type"]);
@@ -1214,6 +1220,13 @@ void readFalloff(FalloffReaction& R, const AnyMap& node)
             params.push_back(f["E"].asDouble());
         }
         R.falloff = newFalloff("SRI", params);
+    } else if (node.hasKey("Tsang")) {
+        auto& f = node["Tsang"].as<AnyMap>();
+        vector_fp params{
+            f["A"].asDouble(),
+            f["B"].asDouble()
+        };
+        R.falloff = newFalloff("Tsang", params);
     } else {
         R.falloff = newFalloff("Lindemann", {});
     }

--- a/test/data/tsang-falloff.yaml
+++ b/test/data/tsang-falloff.yaml
@@ -1,0 +1,57 @@
+description: |-
+  Sample reactions in the Tsang falloff format for testing.
+  From Lucassen et al. 2011 (doi: 10.1016/j.combustflame.2011.02.010)
+
+generator: cti2yaml
+cantera-version: 2.6.0a2
+date: Mon, 30 Aug 2021 16:33:51 +0300
+input-files: [Lucassen-2011.cti]
+
+units: {length: cm, quantity: mol, activation-energy: cal/mol}
+
+phases:
+- name: gas
+  thermo: ideal-gas
+  elements: [H, C, O, N, Ar]
+  species:
+  - gri30.yaml/species: [H, NO, OH, CN, HCN, CO2, H2O, N2, N2O]
+  - species: [HONO]
+  kinetics: gas
+  reactions: all
+  transport: mixture-averaged
+  state:
+    T: 300.0
+    P: 1.01325e+05
+
+species:
+- name: HONO
+  composition: {H: 1, N: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [2.290413, 0.01409922, -1.367872e-05, 7.49878e-09, -1.876905e-12,
+      -1.043195e+04, 13.28077]
+    - [5.486893, 4.218065e-03, -1.649143e-06, 2.971877e-10, -2.021148e-14,
+      -1.126865e+04, -2.997002]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.828
+    well-depth: 232.4
+    rotational-relaxation: 1.0
+  note: '31787'
+
+reactions:
+- equation: NO + OH (+ M) <=> HONO (+ M)  # Reaction 761
+  type: falloff
+  low-P-rate-constant: {A: 5.08e+23, b: -2.51, Ea: -67.6}
+  high-P-rate-constant: {A: 1.988e+12, b: -0.05, Ea: -721.0}
+  Tsang: {A: 0.62, B: 0.0}
+  efficiencies: {CO2: 1.5, H2O: 8.3, N2: 1.0, N2O: 5.0}
+- equation: HCN (+ M) <=> H + CN (+ M)  # Reaction 762
+  type: falloff
+  low-P-rate-constant: {A: 3.57e+26, b: -2.6, Ea: 1.249e+05}
+  high-P-rate-constant: {A: 8.3e+17, b: -0.93, Ea: 1.238e+05}
+  Tsang: {A: 0.95, B: -1.0e-04}
+  efficiencies: {CO2: 1.6, H2O: 5.0, N2: 1.0, N2O: 5.0}


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**
Add Wing Tsang's falloff rate expression (explicit value of F_cent provided with one or two parameters for calculation of F via Troe falloff)

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add `Tsang` falloff where `F_cent = A + B*T`
- Falloff parameter `F` is calculated from `F_cent` according to Troe
- Allows for insertion of rates in the format specified by Tsang and coworkers in various databases, e.g. doi: 10.1063/1.555890

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
