### PR TITLE
Fix tests when not building the Python package + other minor fixes

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -89,7 +89,7 @@ possible.
 Development Site
 ================
 
-The current development version is 2.6.0a2. The current stable version is
+The current development version is 2.6.0a3. The current stable version is
 2.5.1. The `latest Cantera source code <https://github.com/Cantera/cantera>`_,
 the `issue tracker <https://github.com/Cantera/cantera/issues>`_ for bugs and
 enhancement requests, `downloads of Cantera releases and binary installers

--- a/SConstruct
+++ b/SConstruct
@@ -1504,7 +1504,7 @@ if env["stage_dir"]:
     instRoot = Path.cwd().joinpath(env["stage_dir"], stage_prefix)
 
     if env["python_prefix"]:
-        stage_py_prefix = Path(env["python_prefix"])
+        stage_py_prefix = Path(env.subst("$python_prefix"))
         if stage_py_prefix.is_absolute():
             stage_py_prefix = Path(*stage_py_prefix.parts[1:])
         env["python_prefix"] = Path.cwd().joinpath(env["stage_dir"], stage_py_prefix)

--- a/SConstruct
+++ b/SConstruct
@@ -720,7 +720,7 @@ for arg in ARGUMENTS:
         print('Encountered unexpected command line argument: %r' % arg)
         sys.exit(1)
 
-env["cantera_version"] = "2.6.0a2"
+env["cantera_version"] = "2.6.0a3"
 # For use where pre-release tags are not permitted (MSI, sonames)
 env['cantera_pure_version'] = re.match(r'(\d+\.\d+\.\d+)', env['cantera_version']).group(0)
 env['cantera_short_version'] = re.match(r'(\d+\.\d+)', env['cantera_version']).group(0)

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = Cantera
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 2.6.0a2
+PROJECT_NUMBER         = 2.6.0a3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/include/cantera/kinetics/KineticsFactory.h
+++ b/include/cantera/kinetics/KineticsFactory.h
@@ -15,13 +15,17 @@
 namespace Cantera
 {
 
+//! @deprecated Unused. To be removed after Cantera 2.6.
 class UnknownKineticsModel : public CanteraError
 {
 public:
     UnknownKineticsModel(const std::string& proc, const std::string& kineticsModel) :
         CanteraError(proc, "Specified Kinetics model "
                      + kineticsModel +
-                     " does not match any known type.") {}
+                     " does not match any known type.") {
+        warn_deprecated("class UnknownKineticsModel",
+            "Unused. To be removed after Cantera 2.6.");
+    }
 };
 
 /**

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -92,7 +92,7 @@ public:
         return false;
     }
 
-    virtual void resizeSpecies(size_t n_species)
+    virtual void resizeSpecies(size_t n_species) override
     {
         m_shared.resizeSpecies(n_species);
     }

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -29,6 +29,8 @@ namespace Cantera
 /*!
  * This particular error class may be caught, if the application may have other
  * models that the main Cantera application doesn't know about.
+ *
+ * @deprecated Unused. To be removed after Cantera 2.6.
  */
 class UnknownThermoPhaseModel : public CanteraError
 {
@@ -42,7 +44,10 @@ public:
                             const std::string& thermoModel) :
         CanteraError(proc, "Specified ThermoPhase model "
                      + thermoModel +
-                     " does not match any known type.") {}
+                     " does not match any known type.") {
+        warn_deprecated("class UnknownThermoPhaseModel",
+            "Unused. To be removed after Cantera 2.6.");
+    }
 };
 
 
@@ -75,7 +80,7 @@ public:
      * @param model  String to look up the model against
      * @returns a pointer to a new ThermoPhase instance matching the model
      *   string. Returns NULL if something went wrong. Throws an exception
-     *   UnknownThermoPhaseModel if the string wasn't matched.
+     *   if the string wasn't matched.
      */
     virtual ThermoPhase* newThermoPhase(const std::string& model);
 

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1905,7 +1905,7 @@ class Parser:
             metadata = BlockMap([
                 ('generator', 'ck2yaml'),
                 ('input-files', FlowList(files)),
-                ('cantera-version', '2.6.0a2'),
+                ('cantera-version', '2.6.0a3'),
                 ('date', formatdate(localtime=True)),
             ])
             if desc.strip():

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1625,7 +1625,7 @@ def convert(filename=None, output_name=None, text=None):
         # information regarding conversion
         metadata = BlockMap([
             ('generator', 'cti2yaml'),
-            ('cantera-version', '2.6.0a2'),
+            ('cantera-version', '2.6.0a3'),
             ('date', formatdate(localtime=True)),
         ])
         if filename is not None:

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -2629,7 +2629,7 @@ def convert(
     metadata = BlockMap(
         {
             "generator": "ctml2yaml",
-            "cantera-version": "2.6.0a2",
+            "cantera-version": "2.6.0a3",
             "date": formatdate(localtime=True),
         }
     )

--- a/test/SConscript
+++ b/test/SConscript
@@ -96,6 +96,8 @@ def addTestProgram(subdir, progName, env_vars={}):
     testenv['ENV'].update(env_vars)
     if env["skip_slow_tests"]:
         testenv.Append(CPPDEFINES=["CT_SKIP_SLOW"])
+    if env["python_package"] == "none":
+        testenv.Append(CPPDEFINES=["CT_NO_PYTHON"])
     program = testenv.Program(pjoin(subdir, progName),
                               multi_glob(testenv, subdir, 'cpp'))
     passedFile = File(pjoin(str(program[0].dir), '%s.passed' % program[0].name))

--- a/test/kinetics/rates.cpp
+++ b/test/kinetics/rates.cpp
@@ -9,6 +9,7 @@
 namespace Cantera
 {
 
+#ifndef CT_NO_PYTHON
 TEST(FracCoeff, ConvertFracCoeff)
 {
     IdealGasPhase thermo1("../data/frac.cti", "gas");
@@ -33,6 +34,7 @@ TEST(FracCoeff, ConvertFracCoeff)
         }
     }
 }
+#endif
 
 class FracCoeffTest : public testing::Test
 {
@@ -181,11 +183,13 @@ public:
     size_t nRxn, nSpec;
 };
 
+#ifndef CT_NO_PYTHON
 TEST_F(NegativePreexponentialFactor, fromCti)
 {
     setup("../data/noxNeg.cti");
     testNetProductionRates();
 }
+#endif
 
 TEST_F(NegativePreexponentialFactor, fromYaml)
 {

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -118,6 +118,7 @@ TEST(IonsFromNeutralConstructor, fromScratch)
     EXPECT_NEAR(mu[1], -2.88157316e+06, 1e-1);
 }
 
+#ifndef CT_NO_PYTHON
 class CtiConversionTest : public testing::Test
 {
 public:
@@ -177,6 +178,7 @@ TEST_F(ChemkinConversionTest, FailedConversion) {
     ASSERT_THROW(ck2cti("h2o2_missingThermo.inp"),
                  CanteraError);
 }
+#endif
 
 class ConstructFromScratch : public testing::Test
 {

--- a/test/transport/transportFromScratch.cpp
+++ b/test/transport/transportFromScratch.cpp
@@ -38,11 +38,12 @@ public:
         sO2->transport = tO2;
         sH2O->transport = tH2O;
 
-        std::string phase_def = "ideal_gas(name='test', elements='O H',"
-            "species='gri30: H2 O2 H2O')";
+        AnyMap phase_def = AnyMap::fromYamlString(
+            "name: test\n"
+            "thermo: ideal-gas\n"
+            "species: [{gri30.yaml/species: [H2, O2, H2O]}]");
 
-        XML_Node* fxml = get_XML_from_string(phase_def);
-        ref.reset(newPhase(*fxml->findByName("phase")));
+        ref = newPhase(phase_def);
         test.reset(new IdealGasPhase());
 
         test->addElement("O");
@@ -58,8 +59,8 @@ public:
 
     shared_ptr<Species> sH2, sO2, sH2O;
     shared_ptr<GasTransportData> tH2, tO2, tH2O;
-    shared_ptr<ThermoPhase> ref;
-    shared_ptr<ThermoPhase> test;
+    unique_ptr<ThermoPhase> ref;
+    unique_ptr<ThermoPhase> test;
 };
 
 TEST_F(TransportFromScratch, binaryDiffCoeffs)

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -200,8 +200,9 @@ CompileAndTest('CpJump', 'CpJump', 'CpJump', 'output_blessed.txt')
 
 diamond = CompileAndTest('diamondSurf-yaml', 'diamondSurf', 'diamondSurf',
     'runDiamond_blessed.out', options='diamond.yaml')
-Test('diamondSurf-cti', 'diamondSurf', diamond.program, 'runDiamond_blessed.out',
-     options='diamond.cti')  # @TODO: remove after Cantera 2.6
+if env["python_package"] != "none":
+    Test('diamondSurf-cti', 'diamondSurf', diamond.program, 'runDiamond_blessed.out',
+        options='diamond.cti')  # @TODO: remove after Cantera 2.6
 Test('diamondSurf-xml', 'diamondSurf', diamond.program, 'runDiamond_blessed.out',
      options='diamond.xml')  # @TODO: remove after Cantera 2.6
 


### PR DESCRIPTION
**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Disable tests that require the mechanism conversion scripts when no Python package is being built
- Fix installation of the Python package to the `stage_dir` location (fixes regression from c7a5d1885e6)
- Fix a compiler warning raised by Clang
- Deprecate the unused `UnknownThermoPhaseModel` and `UnknownKineticsModel` exception classes

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1095 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
