### PR TITLE
[SCons] Fix stage directory from appearing in setup_cantera

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1503,14 +1503,6 @@ if env["stage_dir"]:
         stage_prefix = Path(*stage_prefix.parts[1:])
 
     instRoot = Path.cwd().joinpath(env["stage_dir"], stage_prefix)
-
-    if env["python_prefix"]:
-        stage_py_prefix = Path(env.subst("$python_prefix"))
-        if stage_py_prefix.is_absolute():
-            stage_py_prefix = Path(*stage_py_prefix.parts[1:])
-        env["python_prefix"] = Path.cwd().joinpath(env["stage_dir"], stage_py_prefix)
-    else:
-        env["python_prefix"] = Path.cwd().joinpath(env["stage_dir"])
 else:
     instRoot = env["prefix"]
 

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -2,6 +2,7 @@
 import re
 from os.path import join as pjoin
 from os.path import normpath
+from pathlib import Path
 from pkg_resources import parse_version
 from buildutils import *
 
@@ -122,6 +123,14 @@ else:
     # Install Python module in the default location
     extra = ''
 
+if env["stage_dir"]:
+    # Get the absolute path to the stage directory. If the stage directory is a relative
+    # path, consider it to be relative to the root of the Cantera source directory,
+    # which is two directories up from the current working directory of this SConscript
+    # file.
+    stage_absolute = Path.cwd().parents[1].joinpath(env['stage_dir']).resolve()
+    extra += f" --root={stage_absolute}"
+
 env['python_module_loc'] = '<unspecified>'
 if localenv['PYTHON_INSTALLER'] == 'direct':
     mod_inst = install(localenv.Command, 'dummy', mod,
@@ -134,9 +143,9 @@ if localenv['PYTHON_INSTALLER'] == 'direct':
         for filename in open('build/python-installed-files.txt').readlines():
             filename = filename.strip()
             if filename.endswith(check):
-                filename = filename.replace(check, '')
-                global_env['python_module_loc'] = normpath(filename)
+                global_env["python_module_loc"] = normpath(filename.replace(check, ""))
                 break
+
     localenv.AlwaysBuild(localenv.AddPostAction(mod_inst, find_module_dir))
     env['install_python_action'] = mod_inst
 elif localenv['PYTHON_INSTALLER'] == 'debian':

--- a/interfaces/python_minimal/SConscript
+++ b/interfaces/python_minimal/SConscript
@@ -1,5 +1,6 @@
 """Minimal Python Module"""
 from os.path import join as pjoin, normpath
+from pathlib import Path
 from buildutils import *
 
 Import('env', 'build', 'install')
@@ -49,6 +50,15 @@ if localenv['PYTHON_INSTALLER'] == 'direct':
     else:
         # Install Python module in the default location
         extra = ''
+
+if env["stage_dir"]:
+    # Get the absolute path to the stage directory. If the stage directory is a relative
+    # path, consider it to be relative to the root of the Cantera source directory,
+    # which is two directories up from the current working directory of this SConscript
+    # file.
+    stage_absolute = Path.cwd().parents[1].joinpath(env["stage_dir"]).resolve()
+    extra += f" --root={stage_absolute}"
+
     mod_inst = install(localenv.Command, 'dummy', mod,
                        build_cmd + ' install ' + extra +
                        ' --record=../../build/python-installed-files.txt' +


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix setting the SCons variable `python_module_loc` to remove the stage directory prefix so that doesn't show up in the `setup_cantera` script or the post-install message.
- Changes how the Python module is installed to a "staging directory" to avoid the staging directory name from ending up in the `.pyc` files.

On this second point, I'm hoping we're finally using the `--root` option to `setuptools` correctly. Previously (#296) we had tried using it in some cases and not been able to get it to do what we wanted.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1094

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
