### PR TITLE
Fix some 1D solver errors

### DIFF
--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -205,10 +205,12 @@ class TestFreeFlame(utilities.CanteraTest):
                         width=0.1)
 
         self.sim.set_refine_criteria(ratio=4, slope=0.8, curve=0.8)
+        self.sim.flame.set_steady_tolerances(T=(2e-4, 1e-8))
         self.sim.solve(refine_grid=True, auto=True, loglevel=0)
+
         self.assertNear(self.sim.velocity[0], 17.02, 1e-1)
         self.assertLess(self.sim.grid[-1], 2.0) # grid should not be too wide
-
+        self.assertEqual(self.sim.flame.tolerances("T"), (2e-4, 1e-8))
 
     @utilities.slow_test
     def test_converge_adiabatic(self):


### PR DESCRIPTION
**Changes proposed in this pull request**

* Fixed an error in the error handler for singular Jacobians where the wrong domain was being identified as containing the  problematic row, that ultimately resulted in an integer divide by zero error instead of a `CanteraError` identifying which domain, grid point, and solution component the row corresponded to. This fixes a regression introduced in e8194afeb.
* Fix some cases where the solution involves large values of lambda and the initial guess of lambda = 0 was leading to singular Jacobians. A reasonable initial guess for lambda can be obtained by noting the proportionality between lambda and rho*V**2 in the radial momentum equation.
* Fix use of user-specified solver tolerances after internal solver restarts, e.g. automatic grid expansion of `FreeFlame`

**If applicable, fill in the issue number this pull request is fixing**

Resolves #1067

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
