### PR TITLE
Update setup_cantera.in

### DIFF
--- a/platform/posix/setup_cantera.in
+++ b/platform/posix/setup_cantera.in
@@ -20,7 +20,7 @@ export PYTHON_CMD
 PATH=@ct_bindir@:$PATH
 export PATH
 
-if [ "@python_cmd@" != `which python` ]; then
+if [ "@python_cmd@" != "`which python`" ]; then
    alias ctpython=@python_cmd@
 fi
 


### PR DESCRIPTION
**Changes proposed in this pull request**
Added double quotes per #1050 to mitigate error when `which python` returns nothing.
Other functions in file look good.

Closes #1050

**If applicable, provide an example illustrating new features this pull request is introducing**
Was checked in a terminal to verify that absent quotes, for `which` not returning a path, error `unary operator expected` returned (test script attached)

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
