### PR TITLE
Avoid C/C++ math constants specified as #define

### DIFF
--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -1,12 +1,11 @@
 /**
  * @file ct_defs.h
- * This file contains definitions of terms that are used in internal
- * routines and are unlikely to need modifying (text for module physConstants (see \ref physConstants) is found here).
- * This file is included
- * in every file that is in the Cantera Namespace.
+ * This file contains definitions of constants, types and terms that are used
+ * in internal routines and are unlikely to need modifying.
  *
- * All physical constants are stored here.
- * The module physConstants is defined here.
+ * All physical constants are stored here (see module \ref physConstants).
+ *
+ * This file is included in every file within the Cantera namespace.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -51,6 +51,9 @@ using std::isnan; // workaround for bug in libstdc++ 4.8
 //! Pi
 const double Pi = 3.14159265358979323846;
 
+//! Sqrt(2)
+const double Sqrt2 = 1.41421356237309504880;
+
 /*!
  * @name Defined Constants
  * These constants are defined by CODATA to have a particular value.

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -11,9 +11,6 @@
 
 #include <boost/math/tools/roots.hpp>
 
-#define _USE_MATH_DEFINES
-#include <math.h>
-
 using namespace std;
 namespace bmt = boost::math::tools;
 
@@ -107,12 +104,12 @@ double PengRobinson::cp_mole() const
     _updateReferenceStateThermo();
     double T = temperature();
     double mv = molarVolume();
-    double vpb = mv + (1 + M_SQRT2)*m_b;
-    double vmb = mv + (1 - M_SQRT2)*m_b;
+    double vpb = mv + (1 + Sqrt2) * m_b;
+    double vmb = mv + (1 - Sqrt2) * m_b;
     calculatePressureDerivatives();
     double cpref = GasConstant * mean_X(m_cp0_R);
     double dHdT_V = cpref + mv * m_dpdT - GasConstant
-                    + 1.0 / (2.0 * M_SQRT2 * m_b) * log(vpb / vmb) * T * d2aAlpha_dT2();
+                    + 1.0 / (2.0 * Sqrt2 * m_b) * log(vpb / vmb) * T * d2aAlpha_dT2();
     return dHdT_V - (mv + T * m_dpdT / m_dpdV) * m_dpdT;
 }
 
@@ -144,8 +141,8 @@ double PengRobinson::standardConcentration(size_t k) const
 void PengRobinson::getActivityCoefficients(double* ac) const
 {
     double mv = molarVolume();
-    double vpb2 = mv + (1 + M_SQRT2)*m_b;
-    double vmb2 = mv + (1 - M_SQRT2)*m_b;
+    double vpb2 = mv + (1 + Sqrt2) * m_b;
+    double vmb2 = mv + (1 - Sqrt2) * m_b;
     double vmb = mv - m_b;
     double pres = pressure();
 
@@ -156,7 +153,7 @@ void PengRobinson::getActivityCoefficients(double* ac) const
         }
     }
     double num = 0;
-    double denom = 2 * M_SQRT2 * m_b * m_b;
+    double denom = 2 * Sqrt2 * m_b * m_b;
     double denom2 = m_b * (mv * mv + 2 * mv * m_b - m_b * m_b);
     double RTkelvin = RT();
     for (size_t k = 0; k < m_kk; k++) {
@@ -185,8 +182,8 @@ void PengRobinson::getChemPotentials(double* mu) const
 
     double mv = molarVolume();
     double vmb = mv - m_b;
-    double vpb2 = mv + (1 + M_SQRT2)*m_b;
-    double vmb2 = mv + (1 - M_SQRT2)*m_b;
+    double vpb2 = mv + (1 + Sqrt2) * m_b;
+    double vmb2 = mv + (1 - Sqrt2) * m_b;
 
     for (size_t k = 0; k < m_kk; k++) {
         m_pp[k] = 0.0;
@@ -196,7 +193,7 @@ void PengRobinson::getChemPotentials(double* mu) const
     }
     double pres = pressure();
     double refP = refPressure();
-    double denom = 2 * M_SQRT2 * m_b * m_b;
+    double denom = 2 * Sqrt2 * m_b * m_b;
     double denom2 = m_b * (mv * mv + 2 * mv * m_b - m_b * m_b);
 
     for (size_t k = 0; k < m_kk; k++) {
@@ -223,8 +220,8 @@ void PengRobinson::getPartialMolarEnthalpies(double* hbar) const
     double T = temperature();
     double mv = molarVolume();
     double vmb = mv - m_b;
-    double vpb2 = mv + (1 + M_SQRT2)*m_b;
-    double vmb2 = mv + (1 - M_SQRT2)*m_b;
+    double vpb2 = mv + (1 + Sqrt2) * m_b;
+    double vmb2 = mv + (1 - Sqrt2) * m_b;
     double daAlphadT = daAlpha_dT();
 
     for (size_t k = 0; k < m_kk; k++) {
@@ -248,13 +245,13 @@ void PengRobinson::getPartialMolarEnthalpies(double* hbar) const
     double fac = T * daAlphadT - m_aAlpha_mix;
     calculatePressureDerivatives();
     double fac2 = mv + T * m_dpdT / m_dpdV;
-    double fac3 = 2 * M_SQRT2 * m_b * m_b;
+    double fac3 = 2 * Sqrt2 * m_b * m_b;
     double fac4 = 0;
     for (size_t k = 0; k < m_kk; k++) {
         fac4 = T*tmp[k] -2 * m_pp[k];
         double hE_v = mv * m_dpdni[k] - RTkelvin - m_b_coeffs[k] / fac3  * log(vpb2 / vmb2) * fac
-                     + (mv * m_b_coeffs[k]) /(m_b * denom) * fac 
-                     + 1/(2 * M_SQRT2 * m_b) * log(vpb2 / vmb2) * fac4;
+                     + (mv * m_b_coeffs[k]) /(m_b * denom) * fac
+                     + 1/(2 * Sqrt2 * m_b) * log(vpb2 / vmb2) * fac4;
         hbar[k] = hbar[k] + hE_v;
         hbar[k] -= fac2 * m_dpdni[k];
     }
@@ -414,7 +411,7 @@ vector<double> PengRobinson::getCoeff(const std::string& iName)
             break;
         }
     }
-    // If the species is not present in the database, throw an error 
+    // If the species is not present in the database, throw an error
     if(isnan(spCoeff[0]))
     {
         throw CanteraError("PengRobinson::getCoeff",
@@ -475,9 +472,9 @@ double PengRobinson::sresid() const
     double hh = m_b / molarV;
     double zz = z();
     double alpha_1 = daAlpha_dT();
-    double vpb = molarV + (1.0 + M_SQRT2) * m_b;
-    double vmb = molarV + (1.0 - M_SQRT2) * m_b;
-    double fac = alpha_1 / (2.0 * M_SQRT2 * m_b);
+    double vpb = molarV + (1.0 + Sqrt2) * m_b;
+    double vmb = molarV + (1.0 - Sqrt2) * m_b;
+    double fac = alpha_1 / (2.0 * Sqrt2 * m_b);
     double sresid_mol_R = log(zz*(1.0 - hh)) + fac * log(vpb / vmb) / GasConstant;
     return GasConstant * sresid_mol_R;
 }
@@ -488,9 +485,9 @@ double PengRobinson::hresid() const
     double zz = z();
     double aAlpha_1 = daAlpha_dT();
     double T = temperature();
-    double vpb = molarV + (1 + M_SQRT2) * m_b;
-    double vmb = molarV + (1 - M_SQRT2) * m_b;
-    double fac = 1 / (2.0 * M_SQRT2 * m_b);
+    double vpb = molarV + (1 + Sqrt2) * m_b;
+    double vmb = molarV + (1 - Sqrt2) * m_b;
+    double fac = 1 / (2.0 * Sqrt2 * m_b);
     return GasConstant * T * (zz - 1.0) + fac * log(vpb / vmb) * (T * aAlpha_1 - m_aAlpha_mix);
 }
 
@@ -694,7 +691,7 @@ double PengRobinson::daAlpha_dT() const
     //Calculate mixture derivative
     for (size_t i = 0; i < m_kk; i++) {
         for (size_t j = 0; j < m_kk; j++) {
-            daAlphadT += moleFractions_[i] * moleFractions_[j] * 0.5 * m_aAlpha_binary(i, j) 
+            daAlphadT += moleFractions_[i] * moleFractions_[j] * 0.5 * m_aAlpha_binary(i, j)
                                              * (m_dalphadT[i] / m_alpha[i] + m_dalphadT[j] / m_alpha[j]);
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Switch from math constants defined in C-library `math.h` to a regular `const double` definition - `M_SQRT2` was the only constant used.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1108

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review

**Other context**

Per [stackoverflow](https://stackoverflow.com/questions/10694255/cmath-vs-math-h-and-similar-c-prefixed-vs-h-extension-headers) comment there may be some quirks related to what version is included (i.e. `<cmath>` vs `<math.h>`):

> `<math.h>` and any `<xxx.h>` headers are not standard C++, despite being supported on every major implementation. However, since they are deprecated, there is no guarantee of what is inside those headers when you include them on your implementation. In fact, it has been observed on certain implementations that they provide functions that behave differently to the `<cxxx>` versions.

As there is only a single constant used (`M_SQRT2`), the proposed fix is likely more economical.