### PR TITLE
clarifying coverage dependencies doc

### DIFF
--- a/doc/sphinx/yaml/reactions.rst
+++ b/doc/sphinx/yaml/reactions.rst
@@ -321,7 +321,8 @@ Includes the fields of an :ref:`sec-yaml-elementary` reaction plus:
         Power-law exponent of coverage dependence
 
     ``E``
-        Activation energy dependence on coverage
+        Activation energy dependence on coverage.
+        This is the negative of :math:`{\epsilon}_i` and the Detchem convention
 
 Example::
 


### PR DESCRIPTION
I'm just adding a bit of clarification to make the docs a bit more idiot-proof. This is in response to and should close #1068 