### PR TITLE
Use YAML for saving and loading 1D flame simulations

### DIFF
--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -659,6 +659,9 @@ public:
     static bool addOrderingRules(const std::string& objectType,
                                  const std::vector<std::vector<std::string>>& specs);
 
+    //! Remove the specified file from the input cache if it is present
+    static void clearCachedFile(const std::string& filename);
+
 private:
     //! The stored data
     std::unordered_map<std::string, AnyValue> m_data;

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -133,6 +133,7 @@ public:
                       integer* diagg, double rdt);
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
+    virtual AnyMap serialize(const double* soln) const;
 
 protected:
     int m_ilr;
@@ -163,6 +164,7 @@ public:
 
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
+    virtual AnyMap serialize(const double* soln) const;
 };
 
 /**
@@ -184,6 +186,7 @@ public:
 
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
+    virtual AnyMap serialize(const double* soln) const;
 };
 
 
@@ -205,6 +208,7 @@ public:
 
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
+    virtual AnyMap serialize(const double* soln) const;
 };
 
 
@@ -233,6 +237,7 @@ public:
                       integer* diagg, double rdt);
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
+    virtual AnyMap serialize(const double* soln) const;
 
 protected:
     size_t m_nsp;
@@ -261,6 +266,7 @@ public:
 
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
+    virtual AnyMap serialize(const double* soln) const;
 
     virtual void showSolution_s(std::ostream& s, const double* x);
 
@@ -296,6 +302,7 @@ public:
 
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
+    virtual AnyMap serialize(const double* soln) const;
 
     virtual void _getInitialSoln(double* x) {
         m_sphase->getCoverages(x);

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -134,6 +134,7 @@ public:
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
     virtual AnyMap serialize(const double* soln) const;
+    virtual void restore(const AnyMap& state, double* soln, int loglevel);
 
 protected:
     int m_ilr;
@@ -238,6 +239,7 @@ public:
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
     virtual AnyMap serialize(const double* soln) const;
+    virtual void restore(const AnyMap& state, double* soln, int loglevel);
 
 protected:
     size_t m_nsp;
@@ -267,6 +269,7 @@ public:
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
     virtual AnyMap serialize(const double* soln) const;
+    virtual void restore(const AnyMap& state, double* soln, int loglevel);
 
     virtual void showSolution_s(std::ostream& s, const double* x);
 
@@ -303,6 +306,7 @@ public:
     virtual XML_Node& save(XML_Node& o, const double* const soln);
     virtual void restore(const XML_Node& dom, double* soln, int loglevel);
     virtual AnyMap serialize(const double* soln) const;
+    virtual void restore(const AnyMap& state, double* soln, int loglevel);
 
     virtual void _getInitialSoln(double* x) {
         m_sphase->getCoverages(x);

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -518,7 +518,6 @@ protected:
 
     //! Identity tag for the domain
     std::string m_id;
-    std::string m_desc;
     std::unique_ptr<Refiner> m_refiner;
     std::vector<std::string> m_name;
     int m_bw;

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -27,6 +27,7 @@ const int cPorousType = 109;
 class MultiJac;
 class OneDim;
 class Refiner;
+class AnyMap;
 class XML_Node;
 
 /**
@@ -339,6 +340,12 @@ public:
      *     Cantera 3.0.
      */
     virtual void restore(const XML_Node& dom, doublereal* soln, int loglevel);
+
+    //! Save the state of this domain as an AnyMap
+    /*!
+     * @param soln local solution vector for this domain
+     */
+    virtual AnyMap serialize(const double* soln) const;
 
     size_t size() const {
         return m_nv*m_points;

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -347,6 +347,15 @@ public:
      */
     virtual AnyMap serialize(const double* soln) const;
 
+    //! Restore the solution for this domain from an AnyMap
+    /*!
+     * @param[in]  state AnyMap defining the state of this domain
+     * @param[out] soln Value of the solution vector, local to this domain
+     * @param[in]  loglevel 0 to suppress all output; 1 to show warnings; 2 for
+     *      verbose output
+     */
+    virtual void restore(const AnyMap& state, double* soln, int loglevel);
+
     size_t size() const {
         return m_nv*m_points;
     }

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -36,6 +36,7 @@ public:
     virtual void setSolvingStage(const size_t phase);
 
     virtual void resize(size_t components, size_t points);
+    virtual bool componentActive(size_t n) const;
 
     virtual void _finalize(const double* x);
     //! set to solve electric field on a point

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -16,6 +16,7 @@ namespace Cantera
 
 class Func1;
 class MultiNewton;
+class AnyMap;
 
 /**
  * Container class for multiple-domain 1D problems. Each domain is
@@ -226,6 +227,8 @@ public:
 
     void save(const std::string& fname, std::string id,
               const std::string& desc, doublereal* sol, int loglevel);
+
+    AnyMap serialize(const double* soln) const;
 
     // options
     void setMinTimeStep(doublereal tmin) {

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -175,7 +175,7 @@ public:
     //! Return the type of flow domain being represented, either "Free Flame" or
     //! "Axisymmetric Stagnation".
     //! @see setFreeFlow setAxisymmetricFlow
-    virtual std::string flowType() {
+    virtual std::string flowType() const {
         if (m_type == cFreeFlow) {
             return "Free Flame";
         } else if (m_type == cAxisymmetricStagnationFlow) {

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -137,6 +137,9 @@ public:
 
     virtual size_t componentIndex(const std::string& name) const;
 
+    //! Returns true if the specified component is an active part of the solver state
+    virtual bool componentActive(size_t n) const;
+
     //! Print the solution.
     virtual void showSolution(const doublereal* x);
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -155,6 +155,8 @@ public:
     virtual void restore(const XML_Node& dom, doublereal* soln,
                          int loglevel);
 
+    virtual AnyMap serialize(const double* soln) const;
+
     //! Set flow configuration for freely-propagating flames, using an internal
     //! point with a fixed temperature as the condition to determine the inlet
     //! mass flux.

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -156,6 +156,7 @@ public:
                          int loglevel);
 
     virtual AnyMap serialize(const double* soln) const;
+    virtual void restore(const AnyMap& state, double* soln, int loglevel);
 
     //! Set flow configuration for freely-propagating flames, using an internal
     //! point with a fixed temperature as the condition to determine the inlet

--- a/interfaces/cython/cantera/examples/onedim/adiabatic_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/adiabatic_flame.py
@@ -34,7 +34,7 @@ try:
     f.write_hdf('adiabatic_flame.h5', group='mix', mode='w',
                 description='solution with mixture-averaged transport')
 except ImportError:
-    f.save('adiabatic_flame.xml', 'mix',
+    f.save('adiabatic_flame.yaml', 'mix',
            'solution with mixture-averaged transport')
 
 f.show_solution()
@@ -49,7 +49,7 @@ try:
     f.write_hdf('adiabatic_flame.h5', group='multi',
                 description='solution with multicomponent transport')
 except ImportError:
-    f.save('adiabatic_flame.xml', 'multi',
+    f.save('adiabatic_flame.yaml', 'multi',
            'solution with multicomponent transport')
 
 # write the velocity, temperature, density, and mole fractions to a CSV file

--- a/interfaces/cython/cantera/examples/onedim/burner_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/burner_flame.py
@@ -28,7 +28,7 @@ try:
     f.write_hdf('burner_flame.h5', group='mix', mode='w',
                 description='solution with mixture-averaged transport')
 except ImportError:
-    f.save('burner_flame.xml', 'mix', 'solution with mixture-averaged transport')
+    f.save('burner_flame.yaml', 'mix', 'solution with mixture-averaged transport')
 
 f.transport_model = 'Multi'
 f.solve(loglevel)  # don't use 'auto' on subsequent solves
@@ -37,6 +37,6 @@ try:
     f.write_hdf('burner_flame.h5', group='multi',
                 description='solution with multicomponent transport')
 except ImportError:
-    f.save('burner_flame.xml', 'multi', 'solution with multicomponent transport')
+    f.save('burner_flame.yaml', 'multi', 'solution with multicomponent transport')
 
 f.write_csv('burner_flame.csv', quiet=False)

--- a/interfaces/cython/cantera/examples/onedim/diffusion_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/diffusion_flame.py
@@ -54,7 +54,7 @@ try:
     # save to HDF container file if h5py is installed
     f.write_hdf('diffusion_flame.h5', mode='w')
 except ImportError:
-    f.save('diffusion_flame.xml')
+    f.save('diffusion_flame.yaml')
 
 # write the velocity, temperature, and mole fractions to a CSV file
 f.write_csv('diffusion_flame.csv', quiet=False)

--- a/interfaces/cython/cantera/examples/onedim/diffusion_flame_batch.py
+++ b/interfaces/cython/cantera/examples/onedim/diffusion_flame_batch.py
@@ -88,10 +88,10 @@ if hdf_output:
                 description=('Initial hydrogen-oxygen counterflow flame '
                              'at 1 bar and low strain rate'))
 else:
-    file_name = 'initial_solution.xml'
+    file_name = 'initial_solution.yaml'
     f.save(os.path.join(data_directory, file_name), name='solution',
-           description='Cantera version ' + ct.__version__ +
-           ', reaction mechanism ' + reaction_mechanism)
+           description='Initial hydrogen-oxygen counterflow flame '
+                       'at 1 bar and low strain rate')
 
 
 # PART 2: BATCH PRESSURE LOOP
@@ -142,10 +142,9 @@ for p in p_range:
             f.write_hdf(file_name, group=group, quiet=False,
                         description='pressure = {0} bar'.format(p))
         else:
-            file_name = 'pressure_loop_' + format(p, '05.1f') + '.xml'
+            file_name = 'pressure_loop_' + format(p, '05.1f') + '.yaml'
             f.save(os.path.join(data_directory, file_name), name='solution', loglevel=1,
-                   description='Cantera version ' + ct.__version__ +
-                   ', reaction mechanism ' + reaction_mechanism)
+                   description='pressure = {0} bar'.format(p))
         p_previous = p
     except ct.CanteraError as e:
         print('Error occurred while solving:', e, 'Try next pressure level')
@@ -176,7 +175,7 @@ exp_mdot_a = 1. / 2.
 if hdf_output:
     f.read_hdf(file_name, group='initial_solution')
 else:
-    file_name = 'initial_solution.xml'
+    file_name = 'initial_solution.yaml'
     f.restore(filename=os.path.join(data_directory, file_name), name='solution', loglevel=0)
 
 # Counter to identify the loop
@@ -207,10 +206,9 @@ while np.max(f.T) > temperature_limit_extinction:
             f.write_hdf(file_name, group=group, quiet=False,
                         description='strain rate iteration {}'.format(n))
         else:
-            file_name = 'strain_loop_' + format(n, '02d') + '.xml'
+            file_name = 'strain_loop_' + format(n, '02d') + '.yaml'
             f.save(os.path.join(data_directory, file_name), name='solution', loglevel=1,
-                   description='Cantera version ' + ct.__version__ +
-                   ', reaction mechanism ' + reaction_mechanism)
+                   description='strain rate iteration {}'.format(n))
     except FlameExtinguished:
         print('Flame extinguished')
         break
@@ -232,7 +230,7 @@ for p in p_selected:
         group = 'pressure_loop/{0:05.1f}'.format(p)
         f.read_hdf(file_name, group=group)
     else:
-        file_name = 'pressure_loop_{0:05.1f}.xml'.format(p)
+        file_name = 'pressure_loop_{0:05.1f}.yaml'.format(p)
         f.restore(filename=os.path.join(data_directory, file_name), name='solution', loglevel=0)
 
     # Plot the temperature profiles for selected pressures
@@ -263,7 +261,7 @@ for n in n_selected:
         group = 'strain_loop/{0:02d}'.format(n)
         f.read_hdf(file_name, group=group)
     else:
-        file_name = 'strain_loop_{0:02d}.xml'.format(n)
+        file_name = 'strain_loop_{0:02d}.yaml'.format(n)
         f.restore(filename=os.path.join(data_directory, file_name),
                   name='solution', loglevel=0)
     a_max = f.strain_rate('max')  # the maximum axial strain rate

--- a/interfaces/cython/cantera/examples/onedim/diffusion_flame_extinction.py
+++ b/interfaces/cython/cantera/examples/onedim/diffusion_flame_extinction.py
@@ -65,10 +65,9 @@ if hdf_output:
                 description=('Initial solution'))
 else:
     # Save to data directory
-    file_name = 'initial_solution.xml'
+    file_name = 'initial_solution.yaml'
     f.save(os.path.join(data_directory, file_name), name='solution',
-           description='Cantera version ' + ct.__version__ +
-           ', reaction mechanism ' + reaction_mechanism)
+           description="Initial solution")
 
 
 # PART 2: COMPUTE EXTINCTION STRAIN
@@ -138,11 +137,10 @@ while True:
             group = 'extinction/{0:04d}'.format(n)
             f.write_hdf(file_name, group=group, quiet=True)
         else:
-            file_name = 'extinction_{0:04d}.xml'.format(n)
+            file_name = 'extinction_{0:04d}.yaml'.format(n)
             f.save(os.path.join(data_directory, file_name),
                    name='solution', loglevel=0,
-                   description='Cantera version ' + ct.__version__ +
-                   ', reaction mechanism ' + reaction_mechanism)
+                   description=f"Solution at alpha = {alpha[-1]}")
         T_max.append(np.max(f.T))
         a_max.append(np.max(np.abs(np.gradient(f.velocity) / np.gradient(f.grid))))
         print('Flame burning at alpha = {:8.4F}. Proceeding to the next iteration, '
@@ -157,7 +155,7 @@ while True:
             group = 'extinction/{0:04d}'.format(n)
             f.write_hdf(file_name, group=group, quiet=True)
         else:
-            file_name = 'extinction_{0:04d}.xml'.format(n)
+            file_name = 'extinction_{0:04d}.yaml'.format(n)
             f.save(os.path.join(data_directory, file_name), name='solution', loglevel=0)
         print('Flame extinguished at alpha = {0:8.4F}.'.format(alpha[-1]),
               'Abortion criterion satisfied.')
@@ -176,7 +174,7 @@ while True:
             group = 'extinction/{0:04d}'.format(n_last_burning)
             f.read_hdf(file_name, group=group)
         else:
-            file_name = 'extinction_{0:04d}.xml'.format(n_last_burning)
+            file_name = 'extinction_{0:04d}.yaml'.format(n_last_burning)
             f.restore(os.path.join(data_directory, file_name),
                       name='solution', loglevel=0)
 
@@ -187,7 +185,7 @@ if hdf_output:
     group = 'extinction/{0:04d}'.format(n_last_burning)
     f.read_hdf(file_name, group=group)
 else:
-    file_name = 'extinction_{0:04d}.xml'.format(n_last_burning)
+    file_name = 'extinction_{0:04d}.yaml'.format(n_last_burning)
     f.restore(os.path.join(data_directory, file_name),
               name='solution', loglevel=0)
 print('----------------------------------------------------------------------')

--- a/interfaces/cython/cantera/examples/onedim/flame_fixed_T.py
+++ b/interfaces/cython/cantera/examples/onedim/flame_fixed_T.py
@@ -63,7 +63,7 @@ try:
     f.write_hdf('flame_fixed_T.h5', group='mix', mode='w',
                 description='solution with mixture-averaged transport')
 except ImportError:
-    f.save('flame_fixed_T.xml','mixav',
+    f.save('flame_fixed_T.yaml','mixav',
            'solution with mixture-averaged transport')
 
 print('\n\n switching to multicomponent transport...\n\n')
@@ -75,7 +75,7 @@ try:
     f.write_hdf('flame_fixed_T.h5', group='multi',
                 description='solution with multicomponent transport')
 except ImportError:
-    f.save('flame_fixed_T.xml','multi',
+    f.save('flame_fixed_T.yaml','multi',
            'solution with  multicomponent transport')
 
 # write the velocity, temperature, density, and mole fractions to a CSV file

--- a/interfaces/cython/cantera/examples/onedim/ion_burner_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/ion_burner_flame.py
@@ -29,6 +29,6 @@ try:
     f.write_hdf('ion_burner_flame.h5', group='ion', mode='w',
                 description='solution with ionized gas transport')
 except ImportError:
-    f.save('ion_burner_flame.xml', 'mix', 'solution with mixture-averaged transport')
+    f.save('ion_burner_flame.yaml', 'mix', 'solution with mixture-averaged transport')
 
 f.write_csv('ion_burner_flame.csv', quiet=False)

--- a/interfaces/cython/cantera/examples/onedim/ion_free_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/ion_free_flame.py
@@ -34,7 +34,7 @@ try:
     f.write_hdf('ion_free_flame.h5', group='ion', mode='w',
                 description='solution with ionized gas transport')
 except ImportError:
-    f.save('ion_free_flame.xml', 'ion', 'solution with ionized gas transport')
+    f.save('ion_free_flame.yaml', 'ion', 'solution with ionized gas transport')
 
 f.show_solution()
 print('mixture-averaged flamespeed = {0:7f} m/s'.format(f.velocity[0]))

--- a/interfaces/cython/cantera/examples/onedim/stagnation_flame.py
+++ b/interfaces/cython/cantera/examples/onedim/stagnation_flame.py
@@ -76,7 +76,7 @@ sim.solve(loglevel, auto=True)
 if hdf_output:
     outfile = 'stagnation_flame.h5'
 else:
-    outfile = 'stagnation_flame.xml'
+    outfile = 'stagnation_flame.yaml'
 if os.path.exists(outfile):
     os.remove(outfile)
 

--- a/interfaces/cython/cantera/examples/surface_chemistry/catalytic_combustion.py
+++ b/interfaces/cython/cantera/examples/surface_chemistry/catalytic_combustion.py
@@ -111,13 +111,13 @@ sim.solve(loglevel)
 # show the solution
 sim.show_solution()
 
-# save the solution in XML format. The 'restore' method can be used to restart
+# save the full solution. The 'restore' method can be used to restart
 # a simulation from a solution stored in this form.
 try:
     sim.write_hdf('catalytic_combustion.h5', group='soln1', mode='w',
                   description='catalytic combustion example')
 except ImportError:
-    sim.save("catalytic_combustion.xml", "soln1")
+    sim.save("catalytic_combustion.yaml", "soln1")
 
 # save selected solution components in a CSV file for plotting in
 # Excel or MATLAB.

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -742,7 +742,7 @@ class TestFreeFlame(utilities.CanteraTest):
         p = 2 * ct.one_atm
         Tin = 400
 
-        filename = self.test_work_path / "onedim-add-species.yaml"
+        filename = self.test_work_path / "onedim-remove-species.yaml"
         # In Python >= 3.8, this can be replaced by the missing_ok argument
         if filename.is_file():
             filename.unlink()

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -627,6 +627,7 @@ class TestFreeFlame(utilities.CanteraTest):
         self.assertArrayNear(V1, V3, 1e-3)
 
         self.assertFalse(self.sim.radiation_enabled)
+        self.assertFalse(self.sim.soret_enabled)
 
         self.sim.restore(filename, "test2", loglevel=0)
         self.assertTrue(self.sim.radiation_enabled)
@@ -690,16 +691,19 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.max_grid_points = 234
         self.solve_fixed_T()
         self.solve_mix(ratio=5, slope=0.5, curve=0.3)
+        self.sim.transport_model = "multicomponent"
+        self.sim.soret_enabled = True
         self.sim.save(filename, "test", loglevel=0)
         T1 = self.sim.T
         Y1 = self.sim.Y
 
-        gas2 = ct.Solution("h2o2-plus.xml")
+        gas2 = ct.Solution("h2o2-plus.xml", transport_model="multicomponent")
         self.sim = ct.FreeFlame(gas2)
         self.sim.restore(filename, "test", loglevel=0)
         T2 = self.sim.T
         Y2 = self.sim.Y
 
+        self.assertTrue(self.sim.soret_enabled)
         self.assertEqual(self.sim.max_grid_points, 234)
         self.assertArrayNear(T1, T2)
         for k1, species in enumerate(gas1.species_names):

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -687,6 +687,7 @@ class TestFreeFlame(utilities.CanteraTest):
 
         self.create_sim(p, Tin, reactants, mech="h2o2.yaml")
         gas1 = self.gas
+        self.sim.max_grid_points = 234
         self.solve_fixed_T()
         self.solve_mix(ratio=5, slope=0.5, curve=0.3)
         self.sim.save(filename, "test", loglevel=0)
@@ -699,6 +700,7 @@ class TestFreeFlame(utilities.CanteraTest):
         T2 = self.sim.T
         Y2 = self.sim.Y
 
+        self.assertEqual(self.sim.max_grid_points, 234)
         self.assertArrayNear(T1, T2)
         for k1, species in enumerate(gas1.species_names):
             k2 = gas2.species_index(species)

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -585,6 +585,8 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.save(filename, "test", loglevel=0)
 
         # Save a second solution to the same file
+        self.sim.radiation_enabled = True
+        self.sim.boundary_emissivities = 0.3, 0.8
         self.sim.save(filename, "test2", loglevel=0)
 
         # Create flame object with dummy initial grid
@@ -623,6 +625,12 @@ class TestFreeFlame(utilities.CanteraTest):
         self.assertArrayNear(Y1, Y3, 3e-3)
         self.assertArrayNear(u1, u3, 1e-3)
         self.assertArrayNear(V1, V3, 1e-3)
+
+        self.assertFalse(self.sim.radiation_enabled)
+
+        self.sim.restore(filename, "test2", loglevel=0)
+        self.assertTrue(self.sim.radiation_enabled)
+        self.assertEqual(self.sim.boundary_emissivities, (0.3, 0.8))
 
     def test_array_properties(self):
         self.create_sim(ct.one_atm, 300, 'H2:1.1, O2:1, AR:5')

--- a/interfaces/matlab/toolbox/1D/CounterFlowDiffusionFlame.m
+++ b/interfaces/matlab/toolbox/1D/CounterFlowDiffusionFlame.m
@@ -166,7 +166,7 @@ zrel = zz/dz;
 %
 
 flame = Stack([left flow right]);
-setProfile(flame, 2, {'u', 'V'}, [zrel; u; v]);
+setProfile(flame, 2, {'velocity', 'spread_rate'}, [zrel; u; v]);
 setProfile(flame, 2, 'T', [zrel; t] );
 for n = 1:nsp
     nm = speciesName(tp_f, n);

--- a/samples/matlab/catcomb.m
+++ b/samples/matlab/catcomb.m
@@ -177,7 +177,7 @@ solve(sim1D, loglevel, refine_grid);
 sim1D
 
 % save the solution
-saveSoln(sim1D,'catcomb.xml','energy',['solution with energy equation']);
+saveSoln(sim1D,'catcomb.yaml','energy',['solution with energy equation']);
 
 %%%%%%%%%% show statistics %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 writeStats(sim1D);

--- a/samples/matlab/catcomb.m
+++ b/samples/matlab/catcomb.m
@@ -125,10 +125,11 @@ setTemperature(surf,tsurf);
 sim1D = Stack([inlt, flow, surf]);
 
 % set the initial profiles.
-setProfile(sim1D, 2, {'u', 'V', 'T'}, [0.0            1.0       % z/zmax
-                                       0.06           0.0       % u
-                                       0.0            0.0       % V
-                                       tinlet         tsurf]);  % T
+setProfile(sim1D, 2, {'velocity', 'spread_rate', 'T'}, ...
+           [0.0            1.0       % z/zmax
+            0.06           0.0       % velocity (u)
+            0.0            0.0       % spread rate (V)
+            tinlet         tsurf]);  % T
 names = speciesNames(gas);
 for k = 1:nSpecies(gas)
   y = massFraction(inlt, k);

--- a/samples/matlab/diffflame.m
+++ b/samples/matlab/diffflame.m
@@ -92,7 +92,7 @@ solve(fl, loglevel, 0);
 enableEnergy(f);
 setRefineCriteria(fl, 2, 200.0, 0.1, 0.2);
 solve(fl, loglevel, refine_grid);
-saveSoln(fl,'c2h6.xml','energy',['solution with energy equation']);
+saveSoln(fl,'c2h6.yaml','energy',['solution with energy equation']);
 %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 % Show statistics of solution and elapsed time.
 %

--- a/samples/matlab/flame.m
+++ b/samples/matlab/flame.m
@@ -60,9 +60,10 @@ if flametype == 0
 else
   t1 = temperature(right);
 end
-setProfile(f, 2, {'u', 'V'}, [0.0            1.0
-                              mdot0/rho0     -mdot1/rho0
-                              0.0            0.0]);
+setProfile(f, 2, {'velocity', 'spread_rate'}, ...
+           [0.0            1.0
+            mdot0/rho0     -mdot1/rho0
+            0.0            0.0]);
 setProfile(f, 2, 'T', [0.0 z1 1.0; t0 2000.0 t1]);
 
 for n = 1:nSpecies(gas)

--- a/samples/matlab/flame1.m
+++ b/samples/matlab/flame1.m
@@ -72,7 +72,7 @@ setMaxJacAge(fl, max_jacobian_age(1),  max_jacobian_age(2));
 
 % if the starting solution is to be read from a previously-saved
 % solution, uncomment this line and edit the file name and solution id.
-%restore(fl,'h2flame2.xml', 'energy')
+%restore(fl,'h2flame.yaml', 'energy')
 
 solve(fl, loglevel, refine_grid);
 
@@ -86,7 +86,7 @@ solve(fl, loglevel, refine_grid);
 enableEnergy(f);
 setRefineCriteria(fl, 2, 200.0, 0.05, 0.1);
 solve(fl, 1, 1);
-saveSoln(fl,'h2fl.xml','energy',['solution with energy equation']);
+saveSoln(fl,'h2flame.yaml','energy',['solution with energy equation']);
 
 %%%%%%%%%% show statistics %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 writeStats(fl);

--- a/samples/matlab/flame2.m
+++ b/samples/matlab/flame2.m
@@ -64,7 +64,7 @@ fl = flame(gas, inlet_o, f, inlet_f);
 
 % if the starting solution is to be read from a previously-saved
 % solution, uncomment this line and edit the file name and solution id.
-%restore(fl,'h2flame2.xml', 'energy')
+%restore(fl,'c2h6-flame.yaml', 'energy')
 
 % solve with fixed temperature profile first
 solve(fl, loglevel, refine_grid);
@@ -79,7 +79,7 @@ solve(fl, loglevel, refine_grid);
 enableEnergy(f);
 setRefineCriteria(fl, 2, 200.0, 0.1, 0.1);
 solve(fl, loglevel, refine_grid);
-saveSoln(fl,'c2h6.xml','energy',['solution with energy equation']);
+saveSoln(fl,'c2h6-flame.yaml','energy',['solution with energy equation']);
 
 %%%%%%%%%% show statistics %%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%%
 writeStats(fl);

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -1657,6 +1657,14 @@ bool AnyMap::addOrderingRules(const string& objectType,
     return true;
 }
 
+void AnyMap::clearCachedFile(const std::string& filename)
+{
+    std::string fullName = findInputFile(filename);
+    if (s_cache.count(fullName)) {
+        s_cache.erase(fullName);
+    }
+}
+
 AnyMap AnyMap::fromYamlString(const std::string& yaml) {
     AnyMap amap;
     try {

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -275,7 +275,7 @@ YAML::Emitter& operator<<(YAML::Emitter& out, const AnyMap& rhs)
             }
 
             if (foundType) {
-                if (width + name.size() + valueStr.size() + 4 > 79) {
+                if (width + name.size() + valueStr.size() + 4 > 87) {
                     out << YAML::Newline;
                     width = 15;
                 }
@@ -308,7 +308,7 @@ void emitFlowVector(YAML::Emitter& out, const vector<double>& v, long int precis
     size_t width = 15; // wild guess, but no better value is available
     for (auto& x : v) {
         string xstr = formatDouble(x, precision);
-        if (width + xstr.size() > 79) {
+        if (width + xstr.size() > 87) {
             out << YAML::Newline;
             width = 15;
         }
@@ -326,7 +326,7 @@ void emitFlowVector(YAML::Emitter& out, const vector<T>& v)
     size_t width = 15; // wild guess, but no better value is available
     for (const auto& x : v) {
         string xstr = fmt::format("{}", x);
-        if (width + xstr.size() > 79) {
+        if (width + xstr.size() > 87) {
             out << YAML::Newline;
             width = 15;
         }

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -876,15 +876,15 @@ AnyMap ReactingSurf1D::serialize(const double* soln) const
     AnyMap state = Boundary1D::serialize(soln);
     state["type"] = "reacting-surface";
     state["temperature"] = m_temp;
+    state["phase"]["name"] = m_sphase->name();
+    AnyValue source =m_sphase->input().getMetadata("filename");
+    state["phase"]["source"] = source.empty() ? "<unknown>" : source.asString();
     AnyMap cov;
     for (size_t k = 0; k < m_nsp; k++) {
         cov[m_sphase->speciesName(k)] = soln[k];
     }
     state["coverages"] = std::move(cov);
 
-    state["phase"]["name"] = m_sphase->name();
-    AnyValue source =m_sphase->input().getMetadata("filename");
-    state["phase"]["source"] = source.empty() ? "<unknown>" : source.asString();
     return state;
 }
 

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -240,6 +240,22 @@ void Inlet1D::restore(const XML_Node& dom, double* soln, int loglevel)
     resize(0, 1);
 }
 
+AnyMap Inlet1D::serialize(const double* soln) const
+{
+    AnyMap state = Boundary1D::serialize(soln);
+    state["type"] = "inlet";
+    state["temperature"] = m_temp;
+    state["mass-flux"] = m_mdot;
+    AnyMap Y;
+    for (size_t k = 0; k < m_nsp; k++) {
+        if (m_yin[k] != 0.0) {
+            Y[m_flow->phase().speciesName(k)] = m_yin[k];
+        }
+    }
+    state["mass-fractions"] = std::move(Y);
+    return state;
+}
+
 // ------------- Empty1D -------------
 
 void Empty1D::init()
@@ -263,6 +279,13 @@ void Empty1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
+}
+
+AnyMap Empty1D::serialize(const double* soln) const
+{
+    AnyMap state = Boundary1D::serialize(soln);
+    state["type"] = "empty";
+    return state;
 }
 
 // -------------- Symm1D --------------
@@ -322,6 +345,13 @@ void Symm1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
+}
+
+AnyMap Symm1D::serialize(const double* soln) const
+{
+    AnyMap state = Boundary1D::serialize(soln);
+    state["type"] = "symmetry";
+    return state;
 }
 
 // -------- Outlet1D --------
@@ -406,6 +436,13 @@ void Outlet1D::restore(const XML_Node& dom, double* soln, int loglevel)
 {
     Domain1D::restore(dom, soln, loglevel);
     resize(0, 1);
+}
+
+AnyMap Outlet1D::serialize(const double* soln) const
+{
+    AnyMap state = Boundary1D::serialize(soln);
+    state["type"] = "outlet";
+    return state;
 }
 
 // -------- OutletRes1D --------
@@ -537,6 +574,21 @@ void OutletRes1D::restore(const XML_Node& dom, double* soln, int loglevel)
     resize(0, 1);
 }
 
+AnyMap OutletRes1D::serialize(const double* soln) const
+{
+    AnyMap state = Boundary1D::serialize(soln);
+    state["type"] = "outlet-reservoir";
+    state["temperature"] = m_temp;
+    AnyMap Y;
+    for (size_t k = 0; k < m_nsp; k++) {
+        if (m_yres[k] != 0.0) {
+            Y[m_flow->phase().speciesName(k)] = m_yres[k];
+        }
+    }
+    state["mass-fractions"] = std::move(Y);
+    return state;
+}
+
 // -------- Surf1D --------
 
 void Surf1D::init()
@@ -582,6 +634,14 @@ void Surf1D::restore(const XML_Node& dom, double* soln, int loglevel)
     Domain1D::restore(dom, soln, loglevel);
     m_temp = getFloat(dom, "temperature");
     resize(0, 1);
+}
+
+AnyMap Surf1D::serialize(const double* soln) const
+{
+    AnyMap state = Boundary1D::serialize(soln);
+    state["type"] = "surface";
+    state["temperature"] = m_temp;
+    return state;
 }
 
 void Surf1D::showSolution_s(std::ostream& s, const double* x)
@@ -757,6 +817,19 @@ void ReactingSurf1D::restore(const XML_Node& dom, double* soln,
     m_sphase->setCoverages(&m_fixed_cov[0]);
 
     resize(m_nsp, 1);
+}
+
+AnyMap ReactingSurf1D::serialize(const double* soln) const
+{
+    AnyMap state = Boundary1D::serialize(soln);
+    state["type"] = "reacting-surface";
+    state["temperature"] = m_temp;
+    AnyMap cov;
+    for (size_t k = 0; k < m_nsp; k++) {
+        cov[m_sphase->speciesName(k)] = soln[k];
+    }
+    state["coverages"] = std::move(cov);
+    return state;
 }
 
 void ReactingSurf1D::showSolution(const double* x)

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -881,6 +881,10 @@ AnyMap ReactingSurf1D::serialize(const double* soln) const
         cov[m_sphase->speciesName(k)] = soln[k];
     }
     state["coverages"] = std::move(cov);
+
+    state["phase"]["name"] = m_sphase->name();
+    AnyValue source =m_sphase->input().getMetadata("filename");
+    state["phase"]["source"] = source.empty() ? "<unknown>" : source.asString();
     return state;
 }
 

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -9,6 +9,7 @@
 #include "cantera/oneD/MultiJac.h"
 #include "cantera/oneD/refine.h"
 #include "cantera/base/ctml.h"
+#include "cantera/base/AnyMap.h"
 
 using namespace std;
 
@@ -164,6 +165,19 @@ void Domain1D::restore(const XML_Node& dom, doublereal* soln, int loglevel)
                                "Got an unexpected array, '" + title + "'");
         }
     }
+}
+
+AnyMap Domain1D::serialize(const double* soln) const
+{
+    AnyMap state;
+    state["id"] = id();
+    if (nComponents()) {
+        state["tolerances"]["absolute"]["transient"] = m_atol_ts;
+        state["tolerances"]["absolute"]["steady"] = m_atol_ss;
+        state["tolerances"]["relative"]["transient"] = m_rtol_ts;
+        state["tolerances"]["relative"]["steady"] = m_rtol_ss;
+    }
+    return state;
 }
 
 void Domain1D::locate()

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -186,7 +186,6 @@ AnyMap Domain1D::serialize(const double* soln) const
         }
     };
     AnyMap state;
-    state["id"] = id();
     state["points"] = static_cast<long int>(nPoints());
     if (nComponents() && nPoints()) {
         state["tolerances"]["absolute"]["transient"] = wrap_tols(m_atol_ts);

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -65,6 +65,15 @@ void IonFlow::resize(size_t components, size_t points){
     m_do_electric_field.resize(m_points,false);
 }
 
+bool IonFlow::componentActive(size_t n) const
+{
+    if (n == c_offset_E) {
+        return true;
+    } else {
+        return StFlow::componentActive(n);
+    }
+}
+
 void IonFlow::updateTransport(double* x, size_t j0, size_t j1)
 {
     StFlow::updateTransport(x,j0,j1);

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -463,12 +463,10 @@ void OneDim::save(const std::string& fname, std::string id,
 
 AnyMap OneDim::serialize(const double* soln) const
 {
-    vector<AnyMap> domains(m_dom.size());
-    for (size_t i = 0; i < m_dom.size(); i++) {
-        domains[i] = m_dom[i]->serialize(soln + start(i));
-    }
     AnyMap state;
-    state["domains"] = std::move(domains);
+    for (size_t i = 0; i < m_dom.size(); i++) {
+        state[m_dom[i]->id()] = m_dom[i]->serialize(soln + start(i));
+    }
     return state;
 }
 

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -7,6 +7,7 @@
 #include "cantera/numerics/Func1.h"
 #include "cantera/base/ctml.h"
 #include "cantera/oneD/MultiNewton.h"
+#include "cantera/base/AnyMap.h"
 
 #include <fstream>
 #include <ctime>
@@ -458,6 +459,17 @@ void OneDim::save(const std::string& fname, std::string id,
     root.write(s);
     s.close();
     debuglog("Solution saved to file "+fname+" as solution "+id+".\n", loglevel);
+}
+
+AnyMap OneDim::serialize(const double* soln) const
+{
+    vector<AnyMap> domains(m_dom.size());
+    for (size_t i = 0; i < m_dom.size(); i++) {
+        domains[i] = m_dom[i]->serialize(soln + start(i));
+    }
+    AnyMap state;
+    state["domains"] = std::move(domains);
+    return state;
 }
 
 }

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -113,6 +113,13 @@ void Sim1D::save(const std::string& fname, const std::string& id,
 
     // Add this simulation to the YAML
     data[id] = serialize(m_x.data());
+    data[id]["description"] = desc;
+
+    // Add a timestamp indicating the current time
+    time_t aclock;
+    ::time(&aclock); // Get time in seconds
+    struct tm* newtime = localtime(&aclock); // Convert time to struct tm form
+    data[id]["timestamp"] = stripnonprint(asctime(newtime));
 
     // If this is not replacing an existing solution, put it at the end
     if (!preexisting) {

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -127,11 +127,11 @@ void Sim1D::save(const std::string& fname, const std::string& id,
     data[id]["date"] = stripnonprint(asctime(newtime));
 
     // Force metadata fields to the top of the file
-    data[id]["description"].setLoc(-5, 0);
-    data[id]["generator"].setLoc(-4, 0);
-    data[id]["cantera-version"].setLoc(-3, 0);
-    data[id]["git-commit"].setLoc(-2, 0);
-    data[id]["date"].setLoc(-1, 0);
+    data[id]["description"].setLoc(-6, 0);
+    data[id]["generator"].setLoc(-5, 0);
+    data[id]["cantera-version"].setLoc(-4, 0);
+    data[id]["git-commit"].setLoc(-3, 0);
+    data[id]["date"].setLoc(-2, 0);
 
     // If this is not replacing an existing solution, put it at the end
     if (!preexisting) {

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -114,6 +114,8 @@ void Sim1D::save(const std::string& fname, const std::string& id,
     // Add this simulation to the YAML
     data[id] = serialize(m_x.data());
     data[id]["description"] = desc;
+    data[id]["generator"] = "Cantera Sim1D";
+    data[id]["cantera-version"] = CANTERA_VERSION;
 
     // Add a timestamp indicating the current time
     time_t aclock;

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -113,15 +113,25 @@ void Sim1D::save(const std::string& fname, const std::string& id,
 
     // Add this simulation to the YAML
     data[id] = serialize(m_x.data());
+
+    // Add metadata
     data[id]["description"] = desc;
     data[id]["generator"] = "Cantera Sim1D";
     data[id]["cantera-version"] = CANTERA_VERSION;
+    data[id]["git-commit"] = gitCommit();
 
     // Add a timestamp indicating the current time
     time_t aclock;
     ::time(&aclock); // Get time in seconds
     struct tm* newtime = localtime(&aclock); // Convert time to struct tm form
-    data[id]["timestamp"] = stripnonprint(asctime(newtime));
+    data[id]["date"] = stripnonprint(asctime(newtime));
+
+    // Force metadata fields to the top of the file
+    data[id]["description"].setLoc(-5, 0);
+    data[id]["generator"].setLoc(-4, 0);
+    data[id]["cantera-version"].setLoc(-3, 0);
+    data[id]["git-commit"].setLoc(-2, 0);
+    data[id]["date"].setLoc(-1, 0);
 
     // If this is not replacing an existing solution, put it at the end
     if (!preexisting) {

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -850,15 +850,6 @@ AnyMap StFlow::serialize(const double* soln) const
     AnyMap state = Domain1D::serialize(soln);
     state["type"] = flowType();
     state["pressure"] = m_press;
-    state["grid"] = m_z;
-
-    vector_fp data(nPoints());
-    for (size_t i = 0; i < nComponents(); i++) {
-        for (size_t j = 0; j < nPoints(); j++) {
-            data[j] = soln[index(i,j)];
-        }
-        state[componentName(i)] = data;
-    }
 
     state["phase"]["name"] = m_thermo->name();
     AnyValue source = m_thermo->input().getMetadata("filename");
@@ -900,6 +891,15 @@ AnyMap StFlow::serialize(const double* soln) const
     if (m_zfixed != Undef) {
         state["fixed-point"]["location"] = m_zfixed;
         state["fixed-point"]["temperature"] = m_tfixed;
+    }
+
+    state["grid"] = m_z;
+    vector_fp data(nPoints());
+    for (size_t i = 0; i < nComponents(); i++) {
+        for (size_t j = 0; j < nPoints(); j++) {
+            data[j] = soln[index(i,j)];
+        }
+        state[componentName(i)] = data;
     }
 
     return state;

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -860,8 +860,11 @@ AnyMap StFlow::serialize(const double* soln) const
         state[componentName(i)] = data;
     }
 
+    state["radiation-enabled"] = m_do_radiation;
     if (m_do_radiation) {
         state["radiative-heat-loss"] = m_qdotRadiation;
+        state["emissivity-left"] = m_epsilon_left;
+        state["emissivity-right"] = m_epsilon_right;
     }
 
     std::set<bool> energy_flags(m_do_energy.begin(), m_do_energy.end());
@@ -928,6 +931,14 @@ void StFlow::restore(const AnyMap& state, double* soln, int loglevel)
             m_do_species.assign(m_thermo->nSpecies(), se.asBool());
         } else {
             m_do_species = se.asVector<bool>(m_thermo->nSpecies());
+        }
+    }
+
+    if (state.hasKey("radiation-enabled")) {
+        m_do_radiation = state["radiation-enabled"].asBool();
+        if (m_do_radiation) {
+            m_epsilon_left = state["emissivity-left"].asDouble();
+            m_epsilon_right = state["emissivity-right"].asDouble();
         }
     }
 

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -860,6 +860,10 @@ AnyMap StFlow::serialize(const double* soln) const
         state[componentName(i)] = data;
     }
 
+    state["phase"]["name"] = m_thermo->name();
+    AnyValue source = m_thermo->input().getMetadata("filename");
+    state["phase"]["source"] = source.empty() ? "<unknown>" : source.asString();
+
     state["radiation-enabled"] = m_do_radiation;
     if (m_do_radiation) {
         state["radiative-heat-loss"] = m_qdotRadiation;

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -878,6 +878,8 @@ AnyMap StFlow::serialize(const double* soln) const
         state["energy-enabled"] = m_do_energy;
     }
 
+    state["Soret-enabled"] = m_do_soret;
+
     std::set<bool> species_flags(m_do_species.begin(), m_do_species.end());
     if (species_flags.size() == 1) {
         state["species-enabled"] = m_do_species[0];
@@ -929,6 +931,10 @@ void StFlow::restore(const AnyMap& state, double* soln, int loglevel)
         } else {
             m_do_energy = ee.asVector<bool>(nPoints());
         }
+    }
+
+    if (state.hasKey("Soret-enabled")) {
+        m_do_soret = state["Soret-enabled"].asBool();
     }
 
     if (state.hasKey("species-enabled")) {

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -792,9 +792,6 @@ XML_Node& StFlow::save(XML_Node& o, const doublereal* const sol)
     XML_Node& flow = Domain1D::save(o, sol);
     flow.addAttribute("type",flowType());
 
-    if (m_desc != "") {
-        addString(flow,"description",m_desc);
-    }
     XML_Node& gv = flow.addChild("grid_data");
     addFloat(flow, "pressure", m_press, "Pa", "pressure");
 

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -888,6 +888,8 @@ AnyMap StFlow::serialize(const double* soln) const
     state["refine-criteria"]["curve"] = m_refiner->maxSlope();
     state["refine-criteria"]["prune"] = m_refiner->prune();
     state["refine-criteria"]["grid-min"] = m_refiner->gridMin();
+    state["refine-criteria"]["max-points"] =
+        static_cast<long int>(m_refiner->maxPoints());
 
     if (m_zfixed != Undef) {
         state["fixed-point"]["location"] = m_zfixed;
@@ -952,6 +954,9 @@ void StFlow::restore(const AnyMap& state, double* soln, int loglevel)
 
         if (criteria.hasKey("grid-min")) {
             m_refiner->setGridMin(criteria["grid-min"].asDouble());
+        }
+        if (criteria.hasKey("max-points")) {
+            m_refiner->setMaxPoints(criteria["max-points"].asInt());
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

In order to move ahead with the deprecation and removal of the XML format, we need a replacement for saving and loading 1D simulation results for all language interfaces. While the HDF5-based format available in the Python module is clearly the best choice for that interface, using YAML is the simplest option for the other interfaces.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Save 1D flame simulations to YAML files
- Load 1D flame simulations from YAML files
- Fix a couple of errors in the Matlab toolbox related to the use of the now-removed component names `u` and `v` (replaced by `velocity` and `spread_rate` in Cantera 2.5.0).

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
