### PR TITLE
Update to full C++11 standard

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -67,10 +67,8 @@
 * Class names use `InitialCapsNames`
 * Methods use `camelCaseNames`
 * Do not indent the contents of namespaces
-* Code may make use of most C++11 features, with the exceptions of delegating
-  constructors, inheriting constructors, and non-static data member
-  initializers. These limitations are needed to keep the minimum required
-  compiler versions at GCC 4.6, Clang 3.1, Visual Studio 2013 and Intel 14.0.
+* Code should follow the C++11 standard, with minimum required compiler versions
+  GCC 4.8, Clang 3.4, MSVC 14.0 (2015) and Intel 15.0.
 * Avoid manual memory management (i.e. `new` and `delete`), preferring to use
   standard library containers, as well as `std::unique_ptr` and
   `std::shared_ptr` when dynamic allocation is required.

--- a/SConstruct
+++ b/SConstruct
@@ -287,9 +287,9 @@ if 'gcc' in env.subst('$CC') or 'gnu-cc' in env.subst('$CC'):
     defaults.optimizeCcFlags += ' -Wno-inline'
     if env['OS'] == 'Cygwin':
         # See http://stackoverflow.com/questions/18784112
-        defaults.cxxFlags = '-std=gnu++0x'
+        defaults.cxxFlags = '-std=gnu++11'
     else:
-        defaults.cxxFlags = '-std=c++0x'
+        defaults.cxxFlags = '-std=c++11'
     defaults.buildPch = True
     env['pch_flags'] = ['-include', 'src/pch/system.h']
 
@@ -307,7 +307,7 @@ elif env['CC'] == 'cl': # Visual Studio
     env['openmp_flag'] = ['/openmp']
 
 elif 'icc' in env.subst('$CC'):
-    defaults.cxxFlags = '-std=c++0x'
+    defaults.cxxFlags = '-std=c++11'
     defaults.ccFlags = '-vec-report0 -diag-disable 1478'
     defaults.warningFlags = '-Wcheck'
     env['openmp_flag'] = ['-openmp']


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Update compiler versions in `CONTRIBUTING.md` 
- update compiler specification in `SConstruct` (replace `-std=c++0x` by `-std=c++11`)
- ~add recommendations for whitespace use~ ... created a separate PR (#1121)

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review

**Thoughts**

* MSVC uses C++14 by default (can be specified via `/std:c++14` after Visual Studio 2015 Update 3 - see [here](https://docs.microsoft.com/en-us/cpp/build/reference/std-specify-language-standard-version?view=msvc-160))
* Not sure whether the Cygwin work-around (`-std=gnu++11`) is still necessary ... *probably yes*