### PR TITLE
Fix logic error in CanteraTest.assertNear

### DIFF
--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -614,7 +614,7 @@ cdef extern from "cantera/transport/TransportBase.h" namespace "Cantera":
     cdef cppclass CxxTransport "Cantera::Transport":
         CxxTransport(CxxThermoPhase*)
         string transportType()
-        cbool CKMode()
+        cbool CKMode() except +translate_exception
         double viscosity() except +translate_exception
         double thermalConductivity() except +translate_exception
         double electricalConductivity() except +translate_exception

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -1150,6 +1150,7 @@ class ctml2yamlTest(utilities.CanteraTest):
         ctmlWater, yamlWater = self.checkConversion("liquid-water")
         self.checkThermo(ctmlWater, yamlWater, [300, 500, 1300, 2000], pressure=22064000.0)
         self.assertEqual(ctmlWater.transport_model, yamlWater.transport_model)
+        ctmlWater.TP = yamlWater.TP = 300, 22064000.0
         dens = ctmlWater.density
         for T in [298, 1001, 2400]:
             ctmlWater.TD = T, dens

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1121,12 +1121,15 @@ class TestReaction(utilities.CanteraTest):
         r = ct.PlogReaction()
         r.reactants = {'R1A':1, 'R1B':1}
         r.products = {'P1':1, 'H':1}
-        r.rate.rates = [
+        # @todo: Fix so chained setter works, i.e. r.rate.rates = ...
+        rate = r.rate
+        rate.rates = [
             (0.01*ct.one_atm, ct.Arrhenius(1.2124e13, -0.5779, 10872.7*4184)),
             (1.0*ct.one_atm, ct.Arrhenius(4.9108e28, -4.8507, 24772.8*4184)),
             (10.0*ct.one_atm, ct.Arrhenius(1.2866e44, -9.0246, 39796.5*4184)),
             (100.0*ct.one_atm, ct.Arrhenius(5.9632e53, -11.529, 52599.6*4184))
         ]
+        r.rate = rate
 
         gas2 = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                            species=species, reactions=[r])

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -477,17 +477,17 @@ class ReactionTests:
             return
         rxn = self._cls(equation=self._equation, kinetics=self.gas,
                         legacy=self._legacy, **self._kwargs)
-        if self._legacy:
-            self.assertNear(rxn.rate(self.gas.T), 0.)
-        else:
-            self.assertTrue(np.isnan(rxn.rate(self.gas.T, self.gas.P)))
-
         gas2 = ct.Solution(thermo="IdealGas", kinetics="GasKinetics",
                            species=self.species, reactions=[rxn])
         gas2.TPX = self.gas.TPX
 
-        self.assertNear(gas2.forward_rate_constants[0], 0.)
-        self.assertNear(gas2.net_rates_of_progress[0], 0.)
+        if self._legacy:
+            self.assertNear(rxn.rate(self.gas.T), 0.)
+            self.assertNear(gas2.forward_rate_constants[0], 0.)
+            self.assertNear(gas2.net_rates_of_progress[0], 0.)
+        else:
+            self.assertTrue(np.isnan(rxn.rate(self.gas.T, self.gas.P)))
+            self.assertTrue(np.isnan(gas2.forward_rate_constants[0]))
 
     def test_replace_rate(self):
         # check replacing reaction rate expression

--- a/interfaces/cython/cantera/test/utilities.py
+++ b/interfaces/cython/cantera/test/utilities.py
@@ -70,7 +70,7 @@ class CanteraTest(unittest.TestCase):
 
     def assertNear(self, a, b, rtol=1e-8, atol=1e-12, msg=None):
         cmp = 2 * abs(a - b)/(abs(a) + abs(b) + 2 * atol / rtol)
-        if cmp > rtol:
+        if not cmp < rtol:
             message = ('AssertNear: %.14g - %.14g = %.14g\n' % (a, b, a-b) +
                        'Relative error of %10e exceeds rtol = %10e' % (cmp, rtol))
             if msg:
@@ -88,12 +88,12 @@ class CanteraTest(unittest.TestCase):
             a = A[i]
             b = B[i]
             cmp = 2 * abs(a - b)/(abs(a) + abs(b) + 2 * atol / rtol)
-            if cmp > rtol:
+            if not cmp < rtol:
                 message = ('AssertNear: {:.14g} - {:.14g} = {:.14g}\n'.format(a, b, a-b) +
                            'Relative error for element {} of {:10e} exceeds rtol = {:10e}'.format(i, cmp, rtol))
                 if msg:
                     message = msg + '\n' + message
-                if cmp > worst[0]:
+                if not cmp < worst[0]:
                     worst = cmp, message
 
         if worst[0]:

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -183,11 +183,15 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
         } else {
             // specified section is in the current file
             for (const auto& R : rootNode.at(sections[i]).asVector<AnyMap>()) {
-                try {
+                #ifdef NDEBUG
+                    try {
+                        kin.addReaction(newReaction(R, kin), false);
+                    } catch (CanteraError& err) {
+                        format_to(add_rxn_err, "{}", err.what());
+                    }
+                #else
                     kin.addReaction(newReaction(R, kin), false);
-                } catch (CanteraError& err) {
-                    format_to(add_rxn_err, "{}", err.what());
-                }
+                #endif
             }
         }
     }

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -43,14 +43,19 @@ void Arrhenius::setParameters(const AnyValue& rate,
         m_E = NAN;
     } else if (rate.is<AnyMap>()) {
         auto& rate_map = rate.as<AnyMap>();
-        if (rate_units.factor() == 0 && rate_map["A"].is<std::string>()) {
+        if (rate_units.factor() == 0) {
             // A zero rate units factor is used as a sentinel to detect
             // stand-alone reaction rate objects
-            throw InputFileError("Arrhenius::setParameters", rate_map,
-                "Specification of units is not supported for pre-exponential factor "
-                "when\ncreating a standalone 'ReactionRate' object.");
+            if (rate_map["A"].is<std::string>()) {
+                throw InputFileError("Arrhenius::setParameters", rate_map,
+                    "Specification of units is not supported for pre-exponential "
+                    "factor when\ncreating a standalone 'ReactionRate' object.");
+            } else {
+                m_A = rate_map["A"].asDouble();
+            }
+        } else {
+            m_A = units.convert(rate_map["A"], rate_units);
         }
-        m_A = units.convert(rate_map["A"], rate_units);
         m_b = rate_map["b"].asDouble();
         m_E = units.convertActivationEnergy(rate_map["Ea"], "K");
     } else {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This fixes an issue I found while trying to explore the changes in #1101 where I realized that some problems weren't getting caught by the tests even though they were clearly covered by the test cases.

- Fix logic error in `assertNear` and `assertArrayNear` functions that caused `inf` and `nan` inputs to unexpectedly pass
- Modify tests that were failing as a result of this

Plus two more minor updates:

- Fix exception specification of `Transport::CKMode` in Cython module
- Fail after the first problem adding a reaction when compiling with optimizations disabled

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
