### PR TITLE
Address fmt::format_to memory_buffer deprecation

### DIFF
--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -38,7 +38,18 @@ void format_to(fmt::memory_buffer& b, Args... args) {
 inline std::string to_string(fmt::memory_buffer& b) {
     return b.str();
 }
+#endif
 
+#if !defined(FMT_VERSION) ||  FMT_VERSION < 80000
+template <typename... Args>
+void fmt_append(fmt::memory_buffer& b, Args... args) {
+    format_to(b, args...);
+}
+#else
+template <typename... Args>
+void fmt_append(fmt::memory_buffer& b, Args... args) {
+    format_to(fmt::appender(b), args...);
+}
 #endif
 
 #endif

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -1393,11 +1393,11 @@ std::string AnyMap::keys_str() const
     fmt::memory_buffer b;
     auto iter = this->begin();
     if (iter != this->end()) {
-        format_to(b, "{}", iter->first);
+        fmt_append(b, "{}", iter->first);
         ++iter;
     }
     while (iter != this->end()) {
-        format_to(b, ", {}", iter->first);
+        fmt_append(b, ", {}", iter->first);
         ++iter;
     }
     return to_string(b);
@@ -1756,7 +1756,7 @@ void formatInputFile(fmt::memory_buffer& b, const shared_ptr<AnyMap>& metadata,
         column2 = column;
     }
 
-    format_to(b, "|  Line |\n");
+    fmt_append(b, "|  Line |\n");
     if (!metadata->hasKey("file-contents")) {
         std::ifstream infile(findInputFile(filename));
         std::stringstream buffer;
@@ -1769,15 +1769,15 @@ void formatInputFile(fmt::memory_buffer& b, const shared_ptr<AnyMap>& metadata,
     std::stringstream contents((*metadata)["file-contents"].asString());
     while (std::getline(contents, line)) {
         if (i == lineno || i == lineno2) {
-            format_to(b, "> {: 5d} > {}\n", i+1, line);
-            format_to(b, "{:>{}}\n", "^", column + 11);
+            fmt_append(b, "> {: 5d} > {}\n", i+1, line);
+            fmt_append(b, "{:>{}}\n", "^", column + 11);
             lastShown = i;
         } else if ((lineno + 4 > i && lineno < i + 6) ||
                    (lineno2 + 4 > i && lineno2 < i + 6)) {
             if (lastShown >= 0 && i - lastShown > 1) {
-                format_to(b, "...\n");
+                fmt_append(b, "...\n");
             }
-            format_to(b, "| {: 5d} | {}\n", i+1, line);
+            fmt_append(b, "| {: 5d} | {}\n", i+1, line);
             lastShown = i;
         }
         i++;
@@ -1795,7 +1795,7 @@ std::string InputFileError::formatError(const std::string& message,
     std::string filename = metadata->getString("filename", "input string");
 
     fmt::memory_buffer b;
-    format_to(b, "Error on line {} of {}:\n{}\n", lineno+1, filename, message);
+    fmt_append(b, "Error on line {} of {}:\n{}\n", lineno+1, filename, message);
     formatInputFile(b, metadata, filename, lineno, column);
     return to_string(b);
 }
@@ -1814,16 +1814,15 @@ std::string InputFileError::formatError2(const std::string& message,
 
     fmt::memory_buffer b;
     if (filename1 == filename2) {
-        format_to(b, "Error on lines {} and {} of {}:\n",
-                  std::min(line1, line2) + 1, std::max(line1, line2) + 1,
-                  filename1);
-        format_to(b, "{}\n", message);
+        fmt_append(b, "Error on lines {} and {} of {}:\n",
+                   std::min(line1, line2) + 1, std::max(line1, line2) + 1, filename1);
+        fmt_append(b, "{}\n", message);
         formatInputFile(b, metadata1, filename1, line1, column1, line2, column2);
     } else {
-        format_to(b, "Error on line {} of {} and line {} of {}:\n{}\n",
-                  line1+1, filename1, line2+1, filename2, message);
+        fmt_append(b, "Error on line {} of {} and line {} of {}:\n{}\n",
+                   line1+1, filename1, line2+1, filename2, message);
         formatInputFile(b, metadata1, filename1, line1, column1);
-        format_to(b, "\n");
+        fmt_append(b, "\n");
         formatInputFile(b, metadata2, filename2, line2, column2);
     }
 

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -177,7 +177,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
                 try {
                     kin.addReaction(newReaction(R, kin), false);
                 } catch (CanteraError& err) {
-                    format_to(add_rxn_err, "{}", err.what());
+                    fmt_append(add_rxn_err, "{}", err.what());
                 }
             }
         } else {
@@ -187,7 +187,7 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
                     try {
                         kin.addReaction(newReaction(R, kin), false);
                     } catch (CanteraError& err) {
-                        format_to(add_rxn_err, "{}", err.what());
+                        fmt_append(add_rxn_err, "{}", err.what());
                     }
                 #else
                     kin.addReaction(newReaction(R, kin), false);

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -259,10 +259,10 @@ void Plog::validate(const std::string& equation)
                 k += rates_.at(p).updateRC(log(T[i]), 1.0/T[i]);
             }
             if (k < 0) {
-                format_to(err_reactions,
-                          "\nInvalid rate coefficient for reaction '{}'\n"
-                          "at P = {:.5g}, T = {:.1f}\n",
-                          equation, std::exp(iter->first), T[i]);
+                fmt_append(err_reactions,
+                           "\nInvalid rate coefficient for reaction '{}'\n"
+                           "at P = {:.5g}, T = {:.1f}\n",
+                           equation, std::exp(iter->first), T[i]);
             }
         }
     }

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -568,8 +568,8 @@ string CVodesIntegrator::getErrorInfo(int N)
     sort(weightedErrors.begin(), weightedErrors.end());
     fmt::memory_buffer s;
     for (int i=0; i<N; i++) {
-        format_to(s, "{}: {}\n",
-                get<2>(weightedErrors[i]), get<1>(weightedErrors[i]));
+        fmt_append(s, "{}: {}\n",
+                   get<2>(weightedErrors[i]), get<1>(weightedErrors[i]));
     }
     return to_string(s);
 }

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -381,16 +381,16 @@ std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
     fmt::memory_buffer b;
     try {
         if (name() != "") {
-            format_to(b, "\n  {}:\n", name());
+            fmt_append(b, "\n  {}:\n", name());
         }
-        format_to(b, "\n");
-        format_to(b, "       temperature    {:12.6g}  K\n", temperature());
-        format_to(b, "          pressure    {:12.6g}  Pa\n", pressure());
-        format_to(b, "           density    {:12.6g}  kg/m^3\n", density());
-        format_to(b, "  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
+        fmt_append(b, "\n");
+        fmt_append(b, "       temperature    {:12.6g}  K\n", temperature());
+        fmt_append(b, "          pressure    {:12.6g}  Pa\n", pressure());
+        fmt_append(b, "           density    {:12.6g}  kg/m^3\n", density());
+        fmt_append(b, "  mean mol. weight    {:12.6g}  amu\n", meanMolecularWeight());
 
         doublereal phi = electricPotential();
-        format_to(b, "         potential    {:12.6g}  V\n", phi);
+        fmt_append(b, "         potential    {:12.6g}  V\n", phi);
 
         vector_fp x(m_kk);
         vector_fp molal(m_kk);
@@ -408,49 +408,54 @@ std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
         size_t iHp = speciesIndex("H+");
         if (iHp != npos) {
             double pH = -log(actMolal[iHp]) / log(10.0);
-            format_to(b, "                pH    {:12.4g}\n", pH);
+            fmt_append(b,
+                "                pH    {:12.4g}\n", pH);
         }
 
         if (show_thermo) {
-            format_to(b, "\n");
-            format_to(b, "                          1 kg            1 kmol\n");
-            format_to(b, "                       -----------      ------------\n");
-            format_to(b, "          enthalpy    {:12.6g}     {:12.4g}     J\n",
-                    enthalpy_mass(), enthalpy_mole());
-            format_to(b, "   internal energy    {:12.6g}     {:12.4g}     J\n",
-                    intEnergy_mass(), intEnergy_mole());
-            format_to(b, "           entropy    {:12.6g}     {:12.4g}     J/K\n",
-                    entropy_mass(), entropy_mole());
-            format_to(b, "    Gibbs function    {:12.6g}     {:12.4g}     J\n",
-                    gibbs_mass(), gibbs_mole());
-            format_to(b, " heat capacity c_p    {:12.6g}     {:12.4g}     J/K\n",
-                    cp_mass(), cp_mole());
+            fmt_append(b, "\n");
+            fmt_append(b, "                          1 kg            1 kmol\n");
+            fmt_append(b, "                       -----------      ------------\n");
+            fmt_append(b, "          enthalpy    {:12.6g}     {:12.4g}     J\n",
+                       enthalpy_mass(), enthalpy_mole());
+            fmt_append(b, "   internal energy    {:12.6g}     {:12.4g}     J\n",
+                       intEnergy_mass(), intEnergy_mole());
+            fmt_append(b, "           entropy    {:12.6g}     {:12.4g}     J/K\n",
+                       entropy_mass(), entropy_mole());
+            fmt_append(b, "    Gibbs function    {:12.6g}     {:12.4g}     J\n",
+                       gibbs_mass(), gibbs_mole());
+            fmt_append(b, " heat capacity c_p    {:12.6g}     {:12.4g}     J/K\n",
+                       cp_mass(), cp_mole());
             try {
-                format_to(b, " heat capacity c_v    {:12.6g}     {:12.4g}     J/K\n",
-                        cv_mass(), cv_mole());
+                fmt_append(b, " heat capacity c_v    {:12.6g}     {:12.4g}     J/K\n",
+                           cv_mass(), cv_mole());
             } catch (NotImplementedError&) {
-                format_to(b, " heat capacity c_v    <not implemented>\n");
+                fmt_append(b, " heat capacity c_v    <not implemented>\n");
             }
         }
 
-        format_to(b, "\n");
+        fmt_append(b, "\n");
         int nMinor = 0;
         doublereal xMinor = 0.0;
         if (show_thermo) {
-            format_to(b, "                           X        "
-                    "   Molalities         Chem.Pot.    ChemPotSS    ActCoeffMolal\n");
-            format_to(b, "                                    "
-                    "                      (J/kmol)      (J/kmol)\n");
-            format_to(b, "                     -------------  "
-                    "  ------------     ------------  ------------    ------------\n");
+            fmt_append(b, "                           X        "
+                "   Molalities         Chem.Pot.    ChemPotSS    ActCoeffMolal\n");
+            fmt_append(b, "                                    "
+                "                      (J/kmol)      (J/kmol)\n");
+            fmt_append(b, "                     -------------  "
+                "  ------------     ------------  ------------    ------------\n");
             for (size_t k = 0; k < m_kk; k++) {
                 if (x[k] > threshold) {
                     if (x[k] > SmallNumber) {
-                        format_to(b, "{:>18s}  {:12.6g}     {:12.6g}     {:12.6g}   {:12.6g}   {:12.6g}\n",
-                                speciesName(k), x[k], molal[k], mu[k], muss[k], acMolal[k]);
+                        fmt_append(b,
+                                   "{:>18s}  {:12.6g}     {:12.6g}     {:12.6g}   "
+                                   "{:12.6g}   {:12.6g}\n", speciesName(k),
+                                   x[k], molal[k], mu[k], muss[k], acMolal[k]);
                     } else {
-                        format_to(b, "{:>18s}  {:12.6g}     {:12.6g}          N/A      {:12.6g}   {:12.6g}\n",
-                                speciesName(k), x[k], molal[k], muss[k], acMolal[k]);
+                        fmt_append(b,
+                                   "{:>18s}  {:12.6g}     {:12.6g}          N/A      "
+                                   "{:12.6g}   {:12.6g}\n", speciesName(k),
+                                   x[k], molal[k], muss[k], acMolal[k]);
                     }
                 } else {
                     nMinor++;
@@ -458,13 +463,11 @@ std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
                 }
             }
         } else {
-            format_to(b, "                           X"
-                    "Molalities\n");
-            format_to(b, "                     -------------"
-                    "     ------------\n");
+            fmt_append(b, "                           X            Molalities\n");
+            fmt_append(b, "                     -------------     ------------\n");
             for (size_t k = 0; k < m_kk; k++) {
                 if (x[k] > threshold) {
-                    format_to(b, "{:>18s}   {:12.6g}     {:12.6g}\n",
+                    fmt_append(b, "{:>18s}   {:12.6g}     {:12.6g}\n",
                             speciesName(k), x[k], molal[k]);
                 } else {
                     nMinor++;
@@ -473,7 +476,7 @@ std::string MolalityVPSSTP::report(bool show_thermo, doublereal threshold) const
             }
         }
         if (nMinor) {
-            format_to(b, "     [{:+5d} minor] {:12.6g}\n", nMinor, xMinor);
+            fmt_append(b, "     [{:+5d} minor] {:12.6g}\n", nMinor, xMinor);
         }
     } catch (CanteraError& err) {
         return to_string(b) + err.what();

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -439,26 +439,35 @@ std::string PureFluidPhase::report(bool show_thermo, doublereal threshold) const
     string three_property = "{:>{}}   {:15.5g}   {:15.5g}   {:15.5g}\n";
 
     if (name() != "") {
-        format_to(b, "\n  {}:\n", name());
+        fmt_append(b, "\n  {}:\n", name());
     }
-    format_to(b, "\n");
-    format_to(b, one_property, "temperature", name_width, temperature(), "K");
-    format_to(b, one_property, "pressure", name_width, pressure(), "Pa");
-    format_to(b, one_property, "density", name_width, density(), "kg/m^3");
-    format_to(b, one_property, "mean mol. weight", name_width, meanMolecularWeight(), "kg/kmol");
-    format_to(b, "{:>{}}   {:<.5g}\n", "vapor fraction", name_width, vaporFraction());
-    format_to(b, "{:>{}}   {}\n", "phase of matter", name_width, phaseOfMatter());
+    fmt_append(b, "\n");
+    fmt_append(b, one_property, "temperature", name_width, temperature(), "K");
+    fmt_append(b, one_property, "pressure", name_width, pressure(), "Pa");
+    fmt_append(b, one_property, "density", name_width, density(), "kg/m^3");
+    fmt_append(b, one_property, "mean mol. weight", name_width,
+               meanMolecularWeight(), "kg/kmol");
+    fmt_append(b, "{:>{}}   {:<.5g}\n", "vapor fraction", name_width,
+               vaporFraction());
+    fmt_append(b, "{:>{}}   {}\n", "phase of matter", name_width,
+               phaseOfMatter());
 
     if (show_thermo) {
-        format_to(b, "\n");
-        format_to(b, kg_kmol_header);
-        format_to(b, two_prop_sep);
-        format_to(b, two_property, "enthalpy", name_width, enthalpy_mass(), enthalpy_mole(), "J");
-        format_to(b, two_property, "internal energy", name_width, intEnergy_mass(), intEnergy_mole(), "J");
-        format_to(b, two_property, "entropy", name_width, entropy_mass(), entropy_mole(), "J/K");
-        format_to(b, two_property, "Gibbs function", name_width, gibbs_mass(), gibbs_mole(), "J");
-        format_to(b, two_property, "heat capacity c_p", name_width, cp_mass(), cp_mole(), "J/K");
-        format_to(b, two_property, "heat capacity c_v", name_width, cv_mass(), cv_mole(), "J/K");
+        fmt_append(b, "\n");
+        fmt_append(b, kg_kmol_header);
+        fmt_append(b, two_prop_sep);
+        fmt_append(b, two_property, "enthalpy", name_width,
+                   enthalpy_mass(), enthalpy_mole(), "J");
+        fmt_append(b, two_property, "internal energy", name_width,
+                   intEnergy_mass(), intEnergy_mole(), "J");
+        fmt_append(b, two_property, "entropy", name_width,
+                   entropy_mass(), entropy_mole(), "J/K");
+        fmt_append(b, two_property, "Gibbs function", name_width,
+                   gibbs_mass(), gibbs_mole(), "J");
+        fmt_append(b, two_property, "heat capacity c_p", name_width,
+                   cp_mass(), cp_mole(), "J/K");
+        fmt_append(b, two_property, "heat capacity c_v", name_width,
+                   cv_mass(), cv_mole(), "J/K");
     }
 
     return to_string(b);

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -415,59 +415,49 @@ std::string PureFluidPhase::report(bool show_thermo, doublereal threshold) const
 
     string blank_leader = fmt::format("{:{}}", "", name_width);
 
-    string one_property = "{:>{}}   {:<.5g} {}\n";
+    string one_property = fmt::format("{{:>{}}}   {{:<.5g}} {{}}\n", name_width);
 
     string two_prop_header = "{}   {:^15}   {:^15}\n";
     string kg_kmol_header = fmt::format(
         two_prop_header, blank_leader, "1 kg", "1 kmol"
     );
-    string Y_X_header = fmt::format(
-        two_prop_header, blank_leader, "mass frac. Y", "mole frac. X"
-    );
     string two_prop_sep = fmt::format(
         "{}   {:-^15}   {:-^15}\n", blank_leader, "", ""
     );
-    string two_property = "{:>{}}   {:15.5g}   {:15.5g}  {}\n";
-
-    string three_prop_header = fmt::format(
-        "{}   {:^15}   {:^15}   {:^15}\n", blank_leader, "mass frac. Y",
-        "mole frac. X", "chem. pot. / RT"
+    string two_property = fmt::format(
+        "{{:>{}}}   {{:15.5g}}   {{:15.5g}}  {{}}\n", name_width
     );
-    string three_prop_sep = fmt::format(
-        "{}   {:-^15}   {:-^15}   {:-^15}\n", blank_leader, "", "", ""
-    );
-    string three_property = "{:>{}}   {:15.5g}   {:15.5g}   {:15.5g}\n";
 
     if (name() != "") {
         fmt_append(b, "\n  {}:\n", name());
     }
     fmt_append(b, "\n");
-    fmt_append(b, one_property, "temperature", name_width, temperature(), "K");
-    fmt_append(b, one_property, "pressure", name_width, pressure(), "Pa");
-    fmt_append(b, one_property, "density", name_width, density(), "kg/m^3");
-    fmt_append(b, one_property, "mean mol. weight", name_width,
-               meanMolecularWeight(), "kg/kmol");
-    fmt_append(b, "{:>{}}   {:<.5g}\n", "vapor fraction", name_width,
-               vaporFraction());
-    fmt_append(b, "{:>{}}   {}\n", "phase of matter", name_width,
-               phaseOfMatter());
+    fmt_append(b, one_property, "temperature", temperature(), "K");
+    fmt_append(b, one_property, "pressure", pressure(), "Pa");
+    fmt_append(b, one_property, "density", density(), "kg/m^3");
+    fmt_append(b, one_property,
+               "mean mol. weight", meanMolecularWeight(), "kg/kmol");
+    fmt_append(b, "{:>{}}   {:<.5g}\n",
+               "vapor fraction", name_width, vaporFraction());
+    fmt_append(b, "{:>{}}   {}\n",
+               "phase of matter", name_width, phaseOfMatter());
 
     if (show_thermo) {
         fmt_append(b, "\n");
         fmt_append(b, kg_kmol_header);
         fmt_append(b, two_prop_sep);
-        fmt_append(b, two_property, "enthalpy", name_width,
-                   enthalpy_mass(), enthalpy_mole(), "J");
-        fmt_append(b, two_property, "internal energy", name_width,
-                   intEnergy_mass(), intEnergy_mole(), "J");
-        fmt_append(b, two_property, "entropy", name_width,
-                   entropy_mass(), entropy_mole(), "J/K");
-        fmt_append(b, two_property, "Gibbs function", name_width,
-                   gibbs_mass(), gibbs_mole(), "J");
-        fmt_append(b, two_property, "heat capacity c_p", name_width,
-                   cp_mass(), cp_mole(), "J/K");
-        fmt_append(b, two_property, "heat capacity c_v", name_width,
-                   cv_mass(), cv_mole(), "J/K");
+        fmt_append(b, two_property,
+                   "enthalpy", enthalpy_mass(), enthalpy_mole(), "J");
+        fmt_append(b, two_property,
+                   "internal energy", intEnergy_mass(), intEnergy_mole(), "J");
+        fmt_append(b, two_property,
+                   "entropy", entropy_mass(), entropy_mole(), "J/K");
+        fmt_append(b, two_property,
+                   "Gibbs function", gibbs_mass(), gibbs_mole(), "J");
+        fmt_append(b, two_property,
+                   "heat capacity c_p", cp_mass(), cp_mole(), "J/K");
+        fmt_append(b, two_property,
+                   "heat capacity c_v", cv_mass(), cv_mole(), "J/K");
     }
 
     return to_string(b);

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -933,9 +933,9 @@ void RedlichKwongMFTP::updateMixingExpressions()
         for (size_t k = 0; k < m_kk; k++) {
             if (isnan(b_vec_Curr_[k])) {
                 if (b.size() > 0) {
-                    format_to(b, ", {}", speciesName(k));
+                    fmt_append(b, ", {}", speciesName(k));
                 } else {
-                    format_to(b, "{}", speciesName(k));
+                    fmt_append(b, "{}", speciesName(k));
                 }
             }
         }

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -1409,7 +1409,9 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
 
     string blank_leader = fmt::format("{:{}}", "", name_width);
 
-    string one_property = "{:>{}}   {:<.5g} {}\n";
+    string string_property = fmt::format("{{:>{}}}   {{}}\n", name_width);
+
+    string one_property = fmt::format("{{:>{}}}   {{:<.5g}} {{}}\n", name_width);
 
     string two_prop_header = "{}   {:^15}   {:^15}\n";
     string kg_kmol_header = fmt::format(
@@ -1421,7 +1423,9 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
     string two_prop_sep = fmt::format(
         "{}   {:-^15}   {:-^15}\n", blank_leader, "", ""
     );
-    string two_property = "{:>{}}   {:15.5g}   {:15.5g}  {}\n";
+    string two_property = fmt::format(
+        "{{:>{}}}   {{:15.5g}}   {{:15.5g}}  {{}}\n", name_width
+    );
 
     string three_prop_header = fmt::format(
         "{}   {:^15}   {:^15}   {:^15}\n", blank_leader, "mass frac. Y",
@@ -1430,46 +1434,48 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
     string three_prop_sep = fmt::format(
         "{}   {:-^15}   {:-^15}   {:-^15}\n", blank_leader, "", "", ""
     );
-    string three_property = "{:>{}}   {:15.5g}   {:15.5g}   {:15.5g}\n";
+    string three_property = fmt::format(
+        "{{:>{}}}   {{:15.5g}}   {{:15.5g}}   {{:15.5g}}\n", name_width
+    );
 
     try {
         if (name() != "") {
             fmt_append(b, "\n  {}:\n", name());
         }
         fmt_append(b, "\n");
-        fmt_append(b, one_property, "temperature", name_width, temperature(), "K");
-        fmt_append(b, one_property, "pressure", name_width, pressure(), "Pa");
-        fmt_append(b, one_property, "density", name_width, density(), "kg/m^3");
-        fmt_append(b, one_property, "mean mol. weight",
-            name_width, meanMolecularWeight(), "kg/kmol");
+        fmt_append(b, one_property, "temperature", temperature(), "K");
+        fmt_append(b, one_property, "pressure", pressure(), "Pa");
+        fmt_append(b, one_property, "density", density(), "kg/m^3");
+        fmt_append(b, one_property,
+                   "mean mol. weight", meanMolecularWeight(), "kg/kmol");
 
         double phi = electricPotential();
         if (phi != 0.0) {
-            fmt_append(b, one_property, "potential", name_width, phi, "V");
+            fmt_append(b, one_property, "potential", phi, "V");
         }
 
-        fmt_append(b, "{:>{}}   {}\n", "phase of matter", name_width, phaseOfMatter());
+        fmt_append(b, string_property, "phase of matter", phaseOfMatter());
 
         if (show_thermo) {
             fmt_append(b, "\n");
             fmt_append(b, kg_kmol_header);
             fmt_append(b, two_prop_sep);
-            fmt_append(b, two_property, "enthalpy", name_width,
-                       enthalpy_mass(), enthalpy_mole(), "J");
-            fmt_append(b, two_property, "internal energy", name_width,
-                       intEnergy_mass(), intEnergy_mole(), "J");
-            fmt_append(b, two_property, "entropy", name_width,
-                       entropy_mass(), entropy_mole(), "J/K");
-            fmt_append(b, two_property, "Gibbs function", name_width,
-                       gibbs_mass(), gibbs_mole(), "J");
-            fmt_append(b, two_property, "heat capacity c_p", name_width,
-                       cp_mass(), cp_mole(), "J/K");
+            fmt_append(b, two_property,
+                       "enthalpy", enthalpy_mass(), enthalpy_mole(), "J");
+            fmt_append(b, two_property,
+                       "internal energy", intEnergy_mass(), intEnergy_mole(), "J");
+            fmt_append(b, two_property,
+                       "entropy", entropy_mass(), entropy_mole(), "J/K");
+            fmt_append(b, two_property,
+                       "Gibbs function", gibbs_mass(), gibbs_mole(), "J");
+            fmt_append(b, two_property,
+                       "heat capacity c_p", cp_mass(), cp_mole(), "J/K");
             try {
-                fmt_append(b, two_property, "heat capacity c_v", name_width,
-                           cv_mass(), cv_mole(), "J/K");
+                fmt_append(b, two_property,
+                           "heat capacity c_v", cv_mass(), cv_mole(), "J/K");
             } catch (NotImplementedError&) {
-                fmt_append(b, "{:>{}}   <not implemented>       \n",
-                           "heat capacity c_v", name_width);
+                fmt_append(b, string_property,
+                           "heat capacity c_v", "<not implemented>");
             }
         }
 
@@ -1489,11 +1495,10 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
             for (size_t k = 0; k < m_kk; k++) {
                 if (abs(x[k]) >= threshold) {
                     if (abs(x[k]) > SmallNumber) {
-                        fmt_append(b, three_property, speciesName(k), name_width,
-                                   y[k], x[k], mu[k]/RT());
+                        fmt_append(b, three_property,
+                                   speciesName(k), y[k], x[k], mu[k]/RT());
                     } else {
-                        fmt_append(b, two_property, speciesName(k), name_width,
-                                   y[k], x[k], "");
+                        fmt_append(b, two_property, speciesName(k), y[k], x[k], "");
                     }
                 } else {
                     nMinor++;
@@ -1506,8 +1511,7 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
             fmt_append(b, two_prop_sep);
             for (size_t k = 0; k < m_kk; k++) {
                 if (abs(x[k]) >= threshold) {
-                    fmt_append(b, two_property, speciesName(k), name_width,
-                               y[k], x[k], "");
+                    fmt_append(b, two_property, speciesName(k), y[k], x[k], "");
                 } else {
                     nMinor++;
                     xMinor += x[k];
@@ -1517,7 +1521,7 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
         }
         if (nMinor) {
             string minor = fmt::format("[{:+5d} minor]", nMinor);
-            fmt_append(b, two_property, minor, name_width, yMinor, xMinor, "");
+            fmt_append(b, two_property, minor, yMinor, xMinor, "");
         }
     } catch (CanteraError& err) {
         return to_string(b) + err.what();

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -1434,34 +1434,42 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
 
     try {
         if (name() != "") {
-            format_to(b, "\n  {}:\n", name());
+            fmt_append(b, "\n  {}:\n", name());
         }
-        format_to(b, "\n");
-        format_to(b, one_property, "temperature", name_width, temperature(), "K");
-        format_to(b, one_property, "pressure", name_width, pressure(), "Pa");
-        format_to(b, one_property, "density", name_width, density(), "kg/m^3");
-        format_to(b, one_property, "mean mol. weight", name_width, meanMolecularWeight(), "kg/kmol");
+        fmt_append(b, "\n");
+        fmt_append(b, one_property, "temperature", name_width, temperature(), "K");
+        fmt_append(b, one_property, "pressure", name_width, pressure(), "Pa");
+        fmt_append(b, one_property, "density", name_width, density(), "kg/m^3");
+        fmt_append(b, one_property, "mean mol. weight",
+            name_width, meanMolecularWeight(), "kg/kmol");
 
         double phi = electricPotential();
         if (phi != 0.0) {
-            format_to(b, one_property, "potential", name_width, phi, "V");
+            fmt_append(b, one_property, "potential", name_width, phi, "V");
         }
 
-        format_to(b, "{:>{}}   {}\n", "phase of matter", name_width, phaseOfMatter());
+        fmt_append(b, "{:>{}}   {}\n", "phase of matter", name_width, phaseOfMatter());
 
         if (show_thermo) {
-            format_to(b, "\n");
-            format_to(b, kg_kmol_header);
-            format_to(b, two_prop_sep);
-            format_to(b, two_property, "enthalpy", name_width, enthalpy_mass(), enthalpy_mole(), "J");
-            format_to(b, two_property, "internal energy", name_width, intEnergy_mass(), intEnergy_mole(), "J");
-            format_to(b, two_property, "entropy", name_width, entropy_mass(), entropy_mole(), "J/K");
-            format_to(b, two_property, "Gibbs function", name_width, gibbs_mass(), gibbs_mole(), "J");
-            format_to(b, two_property, "heat capacity c_p", name_width, cp_mass(), cp_mole(), "J/K");
+            fmt_append(b, "\n");
+            fmt_append(b, kg_kmol_header);
+            fmt_append(b, two_prop_sep);
+            fmt_append(b, two_property, "enthalpy", name_width,
+                       enthalpy_mass(), enthalpy_mole(), "J");
+            fmt_append(b, two_property, "internal energy", name_width,
+                       intEnergy_mass(), intEnergy_mole(), "J");
+            fmt_append(b, two_property, "entropy", name_width,
+                       entropy_mass(), entropy_mole(), "J/K");
+            fmt_append(b, two_property, "Gibbs function", name_width,
+                       gibbs_mass(), gibbs_mole(), "J");
+            fmt_append(b, two_property, "heat capacity c_p", name_width,
+                       cp_mass(), cp_mole(), "J/K");
             try {
-                format_to(b, two_property, "heat capacity c_v", name_width, cv_mass(), cv_mole(), "J/K");
+                fmt_append(b, two_property, "heat capacity c_v", name_width,
+                           cv_mass(), cv_mole(), "J/K");
             } catch (NotImplementedError&) {
-                format_to(b, "{:>{}}   <not implemented>       \n", "heat capacity c_v", name_width);
+                fmt_append(b, "{:>{}}   <not implemented>       \n",
+                           "heat capacity c_v", name_width);
             }
         }
 
@@ -1474,16 +1482,18 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
         int nMinor = 0;
         double xMinor = 0.0;
         double yMinor = 0.0;
-        format_to(b, "\n");
+        fmt_append(b, "\n");
         if (show_thermo) {
-            format_to(b, three_prop_header);
-            format_to(b, three_prop_sep);
+            fmt_append(b, three_prop_header);
+            fmt_append(b, three_prop_sep);
             for (size_t k = 0; k < m_kk; k++) {
                 if (abs(x[k]) >= threshold) {
                     if (abs(x[k]) > SmallNumber) {
-                        format_to(b, three_property, speciesName(k), name_width, y[k], x[k], mu[k]/RT());
+                        fmt_append(b, three_property, speciesName(k), name_width,
+                                   y[k], x[k], mu[k]/RT());
                     } else {
-                        format_to(b, two_property, speciesName(k), name_width, y[k], x[k], "");
+                        fmt_append(b, two_property, speciesName(k), name_width,
+                                   y[k], x[k], "");
                     }
                 } else {
                     nMinor++;
@@ -1492,11 +1502,12 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
                 }
             }
         } else {
-            format_to(b, Y_X_header);
-            format_to(b, two_prop_sep);
+            fmt_append(b, Y_X_header);
+            fmt_append(b, two_prop_sep);
             for (size_t k = 0; k < m_kk; k++) {
                 if (abs(x[k]) >= threshold) {
-                    format_to(b, two_property, speciesName(k), name_width, y[k], x[k], "");
+                    fmt_append(b, two_property, speciesName(k), name_width,
+                               y[k], x[k], "");
                 } else {
                     nMinor++;
                     xMinor += x[k];
@@ -1506,7 +1517,7 @@ std::string ThermoPhase::report(bool show_thermo, doublereal threshold) const
         }
         if (nMinor) {
             string minor = fmt::format("[{:+5d} minor]", nMinor);
-            format_to(b, two_property, minor, name_width, yMinor, xMinor, "");
+            fmt_append(b, two_property, minor, name_width, yMinor, xMinor, "");
         }
     } catch (CanteraError& err) {
         return to_string(b) + err.what();

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -844,11 +844,11 @@ void GasTransport::getBinDiffusivityPolynomial(size_t i, size_t j, double* coeff
     }
 }
 
-void GasTransport::getCollisionIntegralPolynomial(size_t i, size_t j, 
-                                                double* astar_coeffs, 
-                                                double* bstar_coeffs, 
-                                                double* cstar_coeffs) const
-{   
+void GasTransport::getCollisionIntegralPolynomial(size_t i, size_t j,
+                                                 double* astar_coeffs,
+                                                 double* bstar_coeffs,
+                                                 double* cstar_coeffs) const
+{
     for (size_t k = 0; k < (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE) + 1; k++) {
         astar_coeffs[k] = m_astar_poly[m_poly[i][j]][k];
         bstar_coeffs[k] = m_bstar_poly[m_poly[i][j]][k];
@@ -861,7 +861,7 @@ void GasTransport::setViscosityPolynomial(size_t i, double* coeffs)
     for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
         m_visccoeffs[i][k] = coeffs[k];
     }
-    
+
     m_visc_ok = false;
     m_spvisc_ok = false;
     m_viscwt_ok = false;
@@ -874,7 +874,7 @@ void GasTransport::setConductivityPolynomial(size_t i, double* coeffs)
     for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
         m_condcoeffs[i][k] = coeffs[k];
     }
-    
+
     m_visc_ok = false;
     m_spvisc_ok = false;
     m_viscwt_ok = false;
@@ -895,7 +895,7 @@ void GasTransport::setBinDiffusivityPolynomial(size_t i, size_t j, double* coeff
     for (size_t k = 0; k < (m_mode == CK_Mode ? 4 : 5); k++) {
         m_diffcoeffs[ic][k] = coeffs[k];
     }
-    
+
     m_visc_ok = false;
     m_spvisc_ok = false;
     m_viscwt_ok = false;
@@ -903,12 +903,12 @@ void GasTransport::setBinDiffusivityPolynomial(size_t i, size_t j, double* coeff
     m_temp = -1;
 }
 
-void GasTransport::setCollisionIntegralPolynomial(size_t i, size_t j, 
-                                                double* astar_coeffs, 
-                                                double* bstar_coeffs, 
-                                                double* cstar_coeffs, bool actualT)
+void GasTransport::setCollisionIntegralPolynomial(size_t i, size_t j,
+                                                  double* astar_coeffs,
+                                                  double* bstar_coeffs,
+                                                  double* cstar_coeffs, bool actualT)
 {
-    int degree = (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE);
+    size_t degree = (m_mode == CK_Mode ? 6 : COLL_INT_POLY_DEGREE);
     vector_fp ca(degree+1), cb(degree+1), cc(degree+1);
 
     for (size_t k = 0; k < degree+1; k++) {
@@ -916,7 +916,7 @@ void GasTransport::setCollisionIntegralPolynomial(size_t i, size_t j,
         cb[k] = bstar_coeffs[k];
         cc[k] = cstar_coeffs[k];
     }
-    
+
     m_astar_poly.push_back(ca);
     m_bstar_poly.push_back(cb);
     m_cstar_poly.push_back(cc);
@@ -926,7 +926,7 @@ void GasTransport::setCollisionIntegralPolynomial(size_t i, size_t j,
         m_star_poly_uses_actualT[i][j] = 1;
         m_star_poly_uses_actualT[j][i] = m_star_poly_uses_actualT[i][j];
     }
-    
+
     m_visc_ok = false;
     m_spvisc_ok = false;
     m_viscwt_ok = false;


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The deprecation is addressed by replacing
```c++
fmt::memory_buffer b;
format_to(b, "The answer is {}.", 42);
```
by
```c++
fmt::memory_buffer b;
format_to(std::back_inserter(b), "The answer is {}.", 42);
```

The fix uses `std::back_inserter` rather than `fmt::appender` as the latter is not available in older versions of `libfmt`. The current GH Actions Sundials runners already use `libfmt v8.0.1` where the deprecation warnings show up.

Also reformatted affected lines to stay within the 88 character line limits.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1098

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
