### PR TITLE
Fix AnyValue test failures with old Boost versions

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1052,7 +1052,7 @@ if not env['BOOST_LIB_VERSION']:
                  " 'boost_inc_dir' to point to the boost headers.")
 else:
     print('INFO: Found Boost version {0}'.format(env['BOOST_LIB_VERSION']))
-# demangle is availble in Boost 1.55 or newer
+# demangle is available in Boost 1.56 or newer
 env['has_demangle'] = conf.CheckDeclaration("boost::core::demangle",
                                 '#include <boost/core/demangle.hpp>', 'C++')
 

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -488,8 +488,10 @@ struct convert<Cantera::AnyValue> {
 namespace Cantera {
 
 std::map<std::string, std::string> AnyValue::s_typenames = {
+    {typeid(void).name(), "void"},
     {typeid(double).name(), "double"},
     {typeid(long int).name(), "long int"},
+    {typeid(bool).name(), "bool"},
     {typeid(std::string).name(), "string"},
     {typeid(vector<AnyValue>).name(), "vector<AnyValue>"},
     {typeid(vector<AnyMap>).name(), "vector<AnyMap>"},


### PR DESCRIPTION
Without Boost, the string versions of certain typenames are compiler-dependent. 

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make sure we use consistent names for all of the types where we end up checking for the names in the test suite.
- correct comment indicating the minimum version of Boost that has the demangle function.

**If applicable, fill in the issue number this pull request is fixing**

Fixes #1040

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
