### PR TITLE
Prevent inadvertent attribute assignment in Quantity

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -195,6 +195,8 @@ class Quantity:
         >>> q3.P
         101325.0
     """
+    __slots__ = ("state", "_phase", "_id", "mass", "constant")
+
     def __init__(self, phase, mass=None, moles=None, constant='UV'):
         self.state = phase.TDY
         self._phase = phase

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1445,6 +1445,11 @@ class TestQuantity(utilities.CanteraTest):
         q1.equilibrate('HP')
         self.assertNear(q1.T, T2)
 
+    def test_invalid_setter(self):
+        q1 = ct.Quantity(self.gas, mass =3)
+        with self.assertRaises(AttributeError):
+            q1.HPQ = self.gas.H, self.gas.P, 1
+
     def test_incompatible(self):
         gas2 = ct.Solution('h2o2.yaml', transport_model=None)
         q1 = ct.Quantity(self.gas)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add a '__slots__' definition to the Quantity class so trying to set the state using a property that doesn't exist for a particular
phase model (e.g. `HPQ`) will not fail silently

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1093

**If applicable, provide an example illustrating new features this pull request is introducing**

```python
gas = ct.Solution("h2o2.yaml")
q1 = ct.Quantity(gas, mass=1)
q1.HPQ = gas.H, gas.P, 1  # raises AttributeError
```

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
