### PR TITLE
cti2yaml: fix issues with composition strings and kinetics model of "None"

### DIFF
--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -208,7 +208,7 @@ def units(length = '', quantity = '', mass = '', time = '',
 
 def get_composition(atoms):
     if isinstance(atoms, dict): return atoms
-    a = atoms.replace(',',' ')
+    a = atoms.replace(",", " ").replace(": ", ":")
     toks = a.split()
     d = OrderedDict()
     for t in toks:

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -305,7 +305,7 @@ class species:
         else:
             self.thermo = const_cp()
 
-        self.transport = transport
+        self.transport = None if transport == "None" else transport
         self.standard_state = standardState
 
         self.rk_pure = {}
@@ -1155,7 +1155,7 @@ class phase:
             else:
                 out['reactions'] = [BlockMap([(r[0], r[1])]) for r in self.reactions]
 
-        if self.transport and self.transport != 'None':
+        if self.transport:
             out['transport'] = _newNames[self.transport]
 
         if self.comment:
@@ -1185,8 +1185,8 @@ class ideal_gas(phase):
 
         phase.__init__(self, name, elements, species, note, reactions,
                        initial_state, options)
-        self.kinetics = kinetics
-        self.transport = transport
+        self.kinetics = None if kinetics == "None" else kinetics
+        self.transport = None if transport == "None" else transport
         self.thermo_model = 'ideal-gas'
 
 
@@ -1209,7 +1209,7 @@ class stoichiometric_solid(phase):
         self.density = density
         if self.density is None:
             raise InputError('density must be specified.')
-        self.transport = None if transport == 'None' else transport
+        self.transport = None if transport == "None" else transport
 
     def get_yaml(self, out):
         super().get_yaml(out)
@@ -1304,8 +1304,8 @@ class RedlichKwongMFTP(phase):
         phase.__init__(self,name, elements, species, note, reactions,
                        initial_state,options)
         self.thermo_model = 'Redlich-Kwong'
-        self.kinetics = kinetics
-        self.transport = None if transport == 'None' else transport
+        self.kinetics = None if kinetics == "None" else kinetics
+        self.transport = None if transport == "None" else transport
         self.activity_coefficients = activity_coefficients
 
     def get_yaml(self, out):
@@ -1348,7 +1348,7 @@ class IdealSolidSolution(phase):
         self.standard_concentration = standard_concentration
         if self.standard_concentration is None:
             raise InputError('In phase {}: standard_concentration must be specified.', name)
-        self.transport = None if transport == 'None' else transport
+        self.transport = None if transport == "None" else transport
 
     def get_yaml(self, out):
         super().get_yaml(out)
@@ -1460,8 +1460,8 @@ class ideal_interface(phase):
         phase.__init__(self, name, elements, species, note, reactions,
                        initial_state, options)
         self.thermo_model = 'ideal-surface'
-        self.kinetics = kinetics
-        self.transport = None if transport == 'None' else transport
+        self.kinetics = None if kinetics == "None" else kinetics
+        self.transport = None if transport == "None" else transport
         self.site_density = site_density
 
     def get_yaml(self, out):

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1147,6 +1147,11 @@ class phase:
                     hits.append(reaction)
                 else:
                     misses.append(reaction)
+
+            if not hits:
+                _printerr("WARNING: Unable to generate field '{}'\nfrom reaction "
+                          "specification '{}' ".format(name, self.reactions[i][1]))
+
             _reactions[name] = hits
             _reactions["reactions"] = misses
             self.reactions[i] = [name, "all"]


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Handle `transport`/`kinetics` models specified as `None` consistently
- Allow for spaces in CTI composition definition (e.g. `N2: 0.9` rather than `N2:0.9`)
- Allow for specification of exact reaction id's

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1009

**If applicable, provide an example illustrating new features this pull request is introducing**

see conversion of `Mayur-ISSP.cti` atttached to #1009. The result after applying this fix is [Mayur-ISSP.yaml.txt](https://github.com/Cantera/cantera/files/7401901/Mayur-ISSP.yaml.txt)

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
