### PR TITLE
Improve YAML formatting

### DIFF
--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -542,12 +542,11 @@ class TestSolutionSerialization(utilities.CanteraTest):
             # Check that items are ordered as expected
             self.assertEqual(
                 list(data),
-                ['name', 'thermo', 'elements', 'species', 'state', 'custom-field']
+                ["name", "thermo", "elements", "species", "state",
+                 "custom-field", "literal-string"]
             )
-            self.assertEqual(
-                list(data['custom-field']),
-                ['first', 'second', 'last']
-            )
+            self.assertEqual(list(data["custom-field"]), ["first", "second", "last"])
+            self.assertEqual(data["literal-string"], "spam\nand\neggs\n")
 
     def test_input_data_debye_huckel(self):
         soln = ct.Solution('thermo-models.yaml', 'debye-huckel-B-dot-ak')

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -157,6 +157,9 @@ long int getPrecision(const Cantera::AnyValue& precisionSource)
 
 string formatDouble(double x, long int precision)
 {
+    // This function ensures that trailing zeros resulting from round-off error
+    // are removed. Values are only rounded if at least three digits are removed,
+    // or the displayed value has multiple trailing zeros.
     if (x == 0.0) {
         return "0.0";
     }
@@ -178,6 +181,8 @@ string formatDouble(double x, long int precision)
         // Value ending in '00x' and should be rounded down
     } else if (s0[last - 2] == '9' && s0[last - 1] == '9' && s0[last] > '4') {
         // Value ending in '99y' and should be rounded up
+    } else if (s0[last - 1] == '0' && s0[last] == '0') {
+        // Remove trailing zeros
     } else {
         // Value should not be rounded / do not round last digit
         return s0;
@@ -319,9 +324,8 @@ YAML::Emitter& operator<<(YAML::Emitter& out, const AnyMap& rhs)
     return out;
 }
 
-//! Emit YAML string. In case the input string includes a newline character `\n`,
-//! a YAML literal string is emitted; otherwise, the output is a regular string.
-void emitString(YAML::Emitter& out, const string str0) {
+//! Write YAML strings spanning multiple lines if input includes endline '\n'
+void emitString(YAML::Emitter& out, const string& str0) {
     size_t endline = str0.rfind('\n');
     if (endline == std::string::npos) {
         out << str0;

--- a/test/data/ideal-gas.yaml
+++ b/test/data/ideal-gas.yaml
@@ -8,6 +8,10 @@ phases:
     first: true
     second: [3.0, 5.0]
     last: [100, 200, 300]
+  literal-string: |
+    spam
+    and
+    eggs
   species: [O2, NO, N2]
   state: {T: 500.0, P: 10 atm, X: {O2: 0.21, N2: 0.79}}
 
@@ -94,6 +98,9 @@ species:
     - [3.282537840E+00, 1.483087540E-03, -7.579666690E-07, 2.094705550E-10,
        -2.167177940E-14, -1.088457720E+03, 5.453231290E+00]
     note: "TPIS89"
+  another-literal-string: |
+    foo
+    bar
 
 - name: NO
   composition: {N: 1, O: 1}

--- a/test/general/test_serialization.cpp
+++ b/test/general/test_serialization.cpp
@@ -10,6 +10,63 @@
 #include "cantera/transport/TransportData.h"
 
 using namespace Cantera;
+using namespace YAML;
+
+TEST(YamlWriter, formatDouble)
+{
+    AnyMap m;
+    int count;
+    float delta;
+
+    // check least significant digit
+    // default precision is 15 (see AnyMap.cpp::getPrecicion)
+    delta = 1.e-15;
+    count = 0;
+    for (int i = -9; i < 10; i += 2) {
+        m["a"] = 4. + i * delta;
+        if (i < -5 || i > 4) {
+            // round away from 4.
+            EXPECT_NE(m.toYamlString(), "a: 4.0\n");
+        } else {
+            // round towards 4.
+            EXPECT_EQ(m.toYamlString(), "a: 4.0\n");
+            count++;
+        }
+    }
+    EXPECT_EQ(count, 5); // only checking even multiples of delta
+
+    // check edge cases
+    m["a"] = -1061.793215682400;
+    EXPECT_EQ(m.toYamlString(), "a: -1061.7932156824\n");
+}
+
+TEST(YamlWriter, formatDoubleExp)
+{
+    AnyMap m;
+    int count;
+    float delta;
+
+    // check least significant digit
+    // default precision is 15 (see AnyMap.cpp::getPrecicion)
+    delta = 1.e-5;
+    count = 0;
+    for (int i = -9; i < 10; i += 2) {
+        m["a"] = 4.e10 + i * delta;
+        if (i < -5 || i > 4) {
+            // round away from 4.
+            EXPECT_NE(m.toYamlString(), "a: 4.0e+10\n");
+        } else {
+            // round towards 4.
+            EXPECT_EQ(m.toYamlString(), "a: 4.0e+10\n");
+            count++;
+        }
+    }
+    EXPECT_EQ(count, 5); // only checking even multiples of delta
+
+    // check edge cases
+    m["a"] = 1.629771953878800e+13;
+    EXPECT_EQ(m.toYamlString(), "a: 1.6297719538788e+13\n");
+}
 
 TEST(YamlWriter, thermoDef)
 {

--- a/test/general/test_serialization.cpp
+++ b/test/general/test_serialization.cpp
@@ -58,6 +58,26 @@ TEST(YamlWriter, userDefinedFields)
     EXPECT_FALSE(spec2->transport->input.hasKey("bogus-field"));
 }
 
+TEST(YamlWriter, literalStrings)
+{
+    auto original = newSolution("ideal-gas.yaml", "simple");
+    YamlWriter writer;
+    writer.addPhase(original);
+    writer.toYamlFile("generated-literal.yaml");
+    auto duplicate = newSolution("generated-literal.yaml");
+    auto thermo1 = original->thermo();
+    auto thermo2 = duplicate->thermo();
+
+    EXPECT_EQ(thermo1->input()["literal-string"].asString(),
+              thermo2->input()["literal-string"].asString());
+
+    auto spec1 = thermo1->species("O2");
+    auto spec2 = thermo2->species("O2");
+
+    EXPECT_EQ(spec1->input["another-literal-string"].asString(),
+              spec2->input["another-literal-string"].asString());
+}
+
 TEST(YamlWriter, sharedSpecies)
 {
     auto original1 = newSolution("ideal-gas.yaml", "simple");


### PR DESCRIPTION
Leverage `fmt::format` to appropriately round values.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Update rounding rules for `double` emitter
- Implement multi-line strings

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1128 (together with improved formatting documentation introduced in #1112)

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

_(A) Rounding of floating point values_

Ensure that floating point values are properly rounded, e.g.
```
<       - {P: 10.0, A: 1.2866e+47, b: -9.0246, Ea: 2.00263761648836e+04}
<       - {P: 100.0, A: 5.9632e+56, b: -11.529, Ea: 2.64691461742217e+04}
---
>       - {P: 9.99999999999999, A: 1.2866e+47, b: -9.0246,
>       Ea: 2.00263761648836e+04}
>       - {P: 99.9999999999999, A: 5.9632e+56, b: -11.529,
>       Ea: 2.64691461742217e+04}
```

_(B) Serialization of lines spanning multiple lines (aka 'Literal' ~or folded strings~)_

Strings that contain `'\n'` are written as multiple lines, e.g. `"spam\nand\neggs"` becomes:
```yaml
literal-string: |
  spam
  and
  eggs
```
which leverages `YAML::Literal`. At the moment, there doesn't appear to be a way to skip the trailing `\n` in the equivalent string that is written (i.e. there is no `|-` rather than `|` in `yaml-cpp` for the first line as far as I can tell).

FWIW, here's a [demo](https://yaml-multiline.info/) illustrating different literal/folded multiline string versions in YAML. `yaml-cpp` appears to only support one version.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
