### PR TITLE
[SCons] Implement script to extract options from SConstruct

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -163,6 +163,15 @@ jobs:
           python3 site_scons/scons2rst.py --dev SConstruct config-options
           mkdir build/docs/scons
           mv config-options-dev.rst build/docs/scons/
+      - name: Create archive for docs output
+        run: |
+          cd build
+          tar -czf docs.tar.gz docs
+      - name: Store archive of docs output
+        uses: actions/upload-artifact@v2
+        with:
+          path: build/docs.tar.gz
+          retention-days: 2
       # The known_hosts key is generated with `ssh-keygen -F cantera.org` from a
       # machine that has previously logged in to cantera.org and trusts
       # that it logged in to the right machine

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,11 @@ jobs:
           sphinxcontrib-katex sphinxcontrib-matlabdomain sphinxcontrib-doxylink
       - name: Build Cantera with documentation
         run: python3 `which scons` build -j2 doxygen_docs=y sphinx_docs=y debug=n optimize=n use_pch=n
+      - name: Capture configuration options from SConstruct
+        run: |
+          python3 site_scons/scons2rst.py --dev SConstruct config-options
+          mkdir build/docs/scons
+          mv config-options-dev.rst build/docs/scons/
       # The known_hosts key is generated with `ssh-keygen -F cantera.org` from a
       # machine that has previously logged in to cantera.org and trusts
       # that it logged in to the right machine

--- a/SConstruct
+++ b/SConstruct
@@ -326,7 +326,12 @@ defaults.debug_link_flags = {"cl": "/DEBUG", "default": ""}
 defaults.no_debug_link_flags = ""
 defaults.warning_flags = {"cl": "/W3", "icc": "-Wcheck", "default": "-Wall"}
 defaults.build_pch = {"icc": False, "default": True}
-
+defaults.pch_flags = {
+    "cl": "/FIpch/system.h",
+    "gcc": "-include src/pch/system.h",
+    "clang": "-include-pch src/pch/system.h.gch",
+    "default": "",
+}
 defaults.thread_flags = {"Windows": "", "macOS": "", "default": "-pthread"}
 defaults.fs_layout = {"Windows": "compact", "default": "standard"}
 defaults.python_prefix = {"Windows": "", "default": "$prefix"}
@@ -335,7 +340,6 @@ defaults.env_vars = "PATH,LD_LIBRARY_PATH,PYTHONPATH"
 defaults.versioned_shared_library = {"mingw": False, "default": True}
 defaults.sphinx_options = "-W --keep-going"
 
-env['pch_flags'] = []
 env['openmp_flag'] = ['-fopenmp'] # used to generate sample build scripts
 
 env['using_apple_clang'] = False
@@ -350,11 +354,9 @@ if 'gcc' in env.subst('$CC') or 'gnu-cc' in env.subst('$CC'):
     if env['OS'] == 'Cygwin':
         defaults.select("Cygwin")
     defaults.select("gcc")
-    env['pch_flags'] = ['-include', 'src/pch/system.h']
 
 elif env['CC'] == 'cl': # Visual Studio
     defaults.select("cl")
-    env['pch_flags'] = ['/FIpch/system.h']
     env['openmp_flag'] = ['/openmp']
 
 elif 'icc' in env.subst('$CC'):
@@ -363,7 +365,6 @@ elif 'icc' in env.subst('$CC'):
 
 elif 'clang' in env.subst('$CC'):
     defaults.select("clang")
-    env['pch_flags'] = ['-include-pch', 'src/pch/system.h.gch']
 
 else:
     print("WARNING: Unrecognized C compiler '%s'" % env['CC'])
@@ -583,6 +584,10 @@ config_options = [
         'use_pch',
         """Use a precompiled-header to speed up compilation""",
         defaults.build_pch),
+    (
+        'pch_flags',
+        """Compiler flags when using precompiled-header.""",
+        defaults.pch_flags),
     (
         'cxx_flags',
         """Compiler flags passed to the C++ compiler only. Separate multiple
@@ -886,6 +891,7 @@ env['LINKFLAGS'] += listify(env['thread_flags'])
 env['CPPDEFINES'] = {}
 
 env['warning_flags'] = listify(env['warning_flags'])
+env["pch_flags"] = listify(env["pch_flags"])
 
 if env['optimize']:
     env['CCFLAGS'] += listify(env['optimize_flags'])

--- a/SConstruct
+++ b/SConstruct
@@ -195,8 +195,10 @@ if os.name == 'nt':
         (
             "msvc_version",
             """Version of Visual Studio to use. The default is the newest
-                installed version. Specify '12.0' for Visual Studio 2013 or '14.0'
-                for Visual Studio 2015. Windows MSVC only.""",
+               installed version. Specify '12.0' for Visual Studio 2013, '14.0' for
+               Visual Studio 2015, '14.1' ('14.1x') Visual Studio 2017, or '14.2'
+               ('14.2x') for Visual Studio 2019. For version numbers in parentheses,
+               'x' is a placeholder for a minor version number. Windows MSVC only.""",
             ""),
         EnumVariable(
             "target_arch",
@@ -216,7 +218,7 @@ if os.name == 'nt':
         EnumVariable(
             "toolchain",
             """The preferred compiler toolchain. If MSVC is not on the path but
-            'g++' is on he path, 'mingw' is used as a backup. Windows only.""",
+               'g++' is on the path, 'mingw' is used as a backup. Windows only.""",
             defaults.toolchain, ("msvc", "mingw", "intel")))
     opts.AddVariables(windows_compiler_options[-1])
     opts.Update(pickCompilerEnv)
@@ -444,7 +446,7 @@ config_options = [
         'matlab_path',
         """Path to the MATLAB install directory. This should be the directory
            containing the 'extern', 'bin', etc. subdirectories. Typical values
-           are: "C:/Program Files/MATLAB/R2011a" on Windows,
+           are: "C:\Program Files\MATLAB\R2021a" on Windows,
            "/Applications/MATLAB_R2011a.app" on macOS, or
            "/opt/MATLAB/R2011a" on Linux.""",
         '', PathVariable.PathAccept),
@@ -501,7 +503,7 @@ config_options = [
         'system_fmt',
         """Select whether to use the fmt library from a system installation
            ('y'), from a Git submodule ('n'), or to decide automatically
-           ('default').  If you do not want to use the Git submodule and fmt
+           ('default'). If you do not want to use the Git submodule and fmt
            is not installed directly into system include and library
            directories, then you will need to add those directories to
            'extra_inc_dirs' and 'extra_lib_dirs'. This installation of fmt

--- a/SConstruct
+++ b/SConstruct
@@ -64,6 +64,11 @@ if not COMMAND_LINE_TARGETS:
     logger.info(__doc__, print_level=False)
     sys.exit(0)
 
+if parse_version(SCons.__version__) < parse_version("3.0.0"):
+    logger.info("Cantera requires SCons with a minimum version of 3.0.0. Exiting.",
+                print_level=False)
+    sys.exit(0)
+
 valid_commands = ("build", "clean", "install", "uninstall",
                   "help", "msi", "samples", "sphinx", "doxygen", "dump")
 
@@ -378,10 +383,8 @@ if env['OS'] == 'Windows':
 elif env["OS"] == "Darwin":
     defaults.select("macOS")
 
-# InstallVersionedLib only fully functional in SCons >= 2.4.0
 # SHLIBVERSION fails with MinGW: http://scons.tigris.org/issues/show_bug.cgi?id=3035
-if (env['toolchain'] == 'mingw'
-    or parse_version(SCons.__version__) < parse_version('2.4.0')):
+if (env["toolchain"] == "mingw"):
     defaults.select("mingw")
 
 defaults.select("default")

--- a/SConstruct
+++ b/SConstruct
@@ -156,11 +156,12 @@ if os.name == 'nt':
         defaultToolchain = 'msvc'
 
     windows_compiler_options.extend([
-        ('msvc_version',
-         """Version of Visual Studio to use. The default is the newest
-            installed version. Specify '12.0' for Visual Studio 2013 or '14.0'
-            for Visual Studio 2015.""",
-         ''),
+        (
+            "msvc_version",
+            """Version of Visual Studio to use. The default is the newest
+                installed version. Specify '12.0' for Visual Studio 2013 or '14.0'
+                for Visual Studio 2015.""",
+            ""),
         EnumVariable(
             'target_arch',
             """Target architecture. The default is the same architecture as the
@@ -356,28 +357,29 @@ config_options = [
     PathVariable(
         'libdirname',
         """Set this to the directory where Cantera libraries should be installed.
-           Some distributions (for example, Fedora/RHEL) use 'lib64' instead of 'lib' on 64-bit systems
-           or could use some other library directory name instead of 'lib' depends
-           on architecture and profile (for example, Gentoo 'libx32' on x32 profile).
-           If user didn't set 'libdirname' configuration variable set it to default value 'lib'""",
+           Some distributions (for example, Fedora/RHEL) use 'lib64' instead of 'lib'
+           on 64-bit systems or could use some other library directory name instead of
+           'lib' depends on architecture and profile (for example, Gentoo 'libx32' on
+           x32 profile). If the user didn't set the 'libdirname' configuration
+           variable, set it to the default value 'lib'""",
         'lib', PathVariable.PathAccept),
     EnumVariable(
         'python_package',
-        """If you plan to work in Python, then you need the ``full`` Cantera Python
+        """If you plan to work in Python, then you need the 'full' Cantera Python
            package. If, on the other hand, you will only use Cantera from some
            other language (for example, MATLAB or Fortran 90/95) and only need Python
-           to process CTI files, then you only need a ``minimal`` subset of the
-           package and Cython and NumPy are not necessary. The ``none`` option
+           to process YAML files, then you only need a 'minimal' subset of the
+           package and Cython and NumPy are not necessary. The 'none' option
            doesn't install any components of the Python interface. The default
            behavior is to build the full Python module for whichever version of
            Python is running SCons if the required prerequisites (NumPy and
-           Cython) are installed. Note: ``y`` is a synonym for ``full`` and ``n``
-           is a synonym for ``none``.""",
+           Cython) are installed. Note: 'y' is a synonym for 'full' and 'n'
+           is a synonym for 'none'.""",
         'default', ('full', 'minimal', 'none', 'n', 'y', 'default')),
     PathVariable(
         'python_cmd',
         """Cantera needs to know where to find the Python interpreter. If
-           PYTHON_CMD is not set, then the configuration process will use the
+           'PYTHON_CMD' is not set, then the configuration process will use the
            same Python interpreter being used by SCons.""",
         sys.executable, PathVariable.PathAccept),
     PathVariable(
@@ -418,9 +420,10 @@ config_options = [
            a compatible compiler (pgfortran, gfortran, ifort, g95) in the 'PATH' environment
            variable. Used only for compiling the Fortran 90 interface.""",
         '', PathVariable.PathAccept),
-    ('FORTRANFLAGS',
-     'Compilation options for the Fortran (90) compiler.',
-     '-O3'),
+    (
+        "FORTRANFLAGS",
+        """Compilation options for the Fortran (90) compiler.""",
+        "-O3"),
     BoolVariable(
         'coverage',
         """Enable collection of code coverage information with gcov.
@@ -506,13 +509,13 @@ config_options = [
         'blas_lapack_dir',
         """Directory containing the libraries specified by 'blas_lapack_libs'. Not
            needed if the libraries are installed in a standard location, for example,
-           ``/usr/lib``.""",
+           '/usr/lib'.""",
         '', PathVariable.PathAccept),
     EnumVariable(
         'lapack_names',
         """Set depending on whether the procedure names in the specified
            libraries are lowercase or uppercase. If you don't know, run 'nm' on
-           the library file (for example, 'nm libblas.a').""",
+           the library file (for example, "nm libblas.a").""",
         'lower', ('lower','upper')),
     BoolVariable(
         'lapack_ftn_trailing_underscore',
@@ -535,7 +538,7 @@ config_options = [
     (
         'env_vars',
         """Environment variables to propagate through to SCons. Either the
-           string "all" or a comma separated list of variable names, for example,
+           string 'all' or a comma separated list of variable names, for example,
            'LD_LIBRARY_PATH,HOME'.""",
         defaults.env_vars),
     BoolVariable(
@@ -655,7 +658,7 @@ config_options = [
         """The layout of the directory structure. 'standard' installs files to
            several subdirectories under 'prefix', for example, 'prefix/bin',
            'prefix/include/cantera', 'prefix/lib' etc. This layout is best used in
-           conjunction with "prefix'='/usr/local'". 'compact' puts all installed
+           conjunction with "prefix='/usr/local'". 'compact' puts all installed
            files in the subdirectory defined by 'prefix'. This layout is best
            with a prefix like '/opt/cantera'. 'debian' installs to the stage
            directory in a layout used for generating Debian packages.""",

--- a/site_scons/scons2rst.py
+++ b/site_scons/scons2rst.py
@@ -1,0 +1,263 @@
+#!/usr/bin/env python3
+# encoding: utf-8
+
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+"""
+scons2rst.py: Extract SCons configuration options from SConstruct
+"""
+
+import ast
+import re
+import argparse
+import pathlib
+
+
+def deblank(string):
+    """
+    Remove whitespace before and after line breaks
+    """
+    out = [s.strip() for s in string.split("\n")]
+    if not len(out[-1]):
+        out = out[:-1]
+    return "\n".join(out)
+
+
+def convert(item):
+    """
+    Convert AST objects to human-readable strings (or list of strings)
+    """
+    if isinstance(item, list):
+        return [convert(sub) for sub in item]
+
+    if isinstance(item, (ast.Tuple, ast.List)):
+        return [convert(sub) for sub in item.elts]
+
+    if isinstance(item, ast.Str):
+        return deblank(item.s)
+
+    if isinstance(item, (ast.NameConstant)):
+        if isinstance(item.value, bool):
+            return "True" if item.value else "False"
+        raise ValueError(f"Unable to process constant '{item}'")
+
+    if isinstance(item, ast.Attribute):
+        if isinstance(item.value, ast.Name):
+            return f"{item.value.id}.{item.attr}"
+        raise ValueError(f"Unable to process attribute '{item}'")
+
+    if isinstance(item, ast.Subscript):
+        if isinstance(item.value, ast.Name) and isinstance(item.slice.value, ast.Str):
+                return f"{item.value.id}[{item.slice.value.s}]"
+        raise ValueError(f"Unable to process subscript '{item}'")
+
+    if isinstance(item, ast.Name):
+        return item.id
+
+    raise ValueError(f"Unable to process item of type '{type(item)}'")
+
+
+class Option:
+    """
+    Object corresponding to SCons configuration option
+    """
+
+    def __init__(self, item):
+        if isinstance(item, (ast.Tuple, ast.List)):
+            self.func = None
+            self._assign(convert(item))
+            return
+
+        if isinstance(item, ast.Call):
+            self.func = item.func.id
+            self._assign(convert(item.args))
+            return
+
+        raise ValueError(f"Unable to process item of type '{type(item)}'")
+
+    def _assign(self, args):
+        self.name = args[0]
+        self.description = args[1]
+        self.default = args[2]
+        self.choices = args[3] if len(args) > 3 else None
+
+    @property
+    def args(self):
+        """
+        Arguments of the SCons configuration option
+        """
+        if self.choices is None:
+            return self.name, self.description, self.default
+        return self.name, self.description, self.default, self.choices
+
+    def to_rest(self, dev=False, indent=3):
+        """
+        Convert option to restructured text
+        """
+        tag = self.name.replace("_", "-").lower()
+        if dev:
+            tag += "-dev"
+
+        if self.func == "PathVariable":
+            choices = f"``path/to/{self.name}``"
+            default = self.default
+        elif isinstance(self.choices, list):
+            choices = self.choices
+            for yes_no in ["n", "y"]:
+                if yes_no in choices:
+                    # ensure correct order
+                    choices.remove(yes_no)
+                    choices = [yes_no] + choices
+            choices = " | ".join([f"``{c}``" for c in choices])
+            default = self.default
+        elif self.default in ["True", "False"]:
+            choices = "``yes`` | ``no``"
+            default = "yes" if self.default == "True" else "no"
+        elif self.func == "BoolVariable":
+            choices = "``yes`` | ``no``"
+            default = self.default
+        else:
+            choices = "``string``"
+            default = self.default
+
+        if default.startswith("defaults.") or default.startswith("sys."):
+            default = "''"
+        else:
+            default = f"'{default}'"
+
+        # assemble description
+        tab = " " * indent
+        linebreak = "\n" + tab
+        description = linebreak.join(self.description.split("\n"))
+        pat = r'"([a-zA-Z0-9\-\+_.,: =/\'\\]+)"'
+        double_quoted = []
+        for item in re.findall(pat, description):
+            # enclose double-quoted strings in '``'
+            found = f'"{item}"'
+            double_quoted += [found]
+            replacement = f"``{found}``"
+            description = description.replace(found, replacement)
+        pat = r"\'([a-zA-Z0-9\-\+_.,:=/\\]+)\'"
+        for item in re.findall(pat, description):
+            # replace "'" for single-quoted words by '``'; do not replace "'" when
+            # whitespace is enclosed or if word is part of double-quoted string
+            if any([item in dq for dq in double_quoted]):
+                continue
+            found = f"'{item}'"
+            replacement = found.replace("'", "``")
+            description = description.replace(found, replacement)
+        pat = r"\*([a-zA-Z0-9\-\+_., :=/\'\\]+)"
+        asterisks = re.findall(pat, description)
+        if len(asterisks) == 1:
+            # catch unbalanced '*', for example in '*nix'
+            found = f"*{asterisks[0]}"
+            replacement = f"\{found}"
+            description = description.replace(found, replacement)
+
+        # assemble output
+        out = f".. _{tag}:\n\n"
+        out += f"*  ``{self.name}``: [ {choices} ]\n"
+        out += f"{tab}{description}\n\n"
+        out += f"{tab}- default: ``{default}``\n"
+
+        return out
+
+    def __repr__(self):
+        if self.func is None:
+            return f"{self.args}"
+        return f"{self.func}{self.args}"
+
+
+def parse(input_file, output_file, dev):
+    """Parse SConstruct and extract configuration"""
+
+    with open(input_file, "r") as fid:
+        code = fid.read()
+
+    tree = ast.parse(code)
+
+    names = ["windows_compiler_options", "compiler_options", "config_options"]
+    options = {name: [] for name in names}
+
+    for node in ast.walk(tree):
+
+        if isinstance(node, ast.Assign) and isinstance(node.targets[0], ast.Name) \
+                and len(node.targets) == 1:
+            # option is assigned as list
+            name = node.targets[0].id
+            if name not in names:
+                continue
+
+            if isinstance(node.value, ast.List):
+                for item in node.value.elts:
+                    options[name].append(Option(item))
+                continue
+
+            if isinstance(node.value, ast.Call):
+                continue
+
+            raise ValueError(f"Unable to process node {node.value} (name='{name}')")
+
+        elif isinstance(node, ast.Call) and isinstance(node.func, ast.Attribute) \
+                and isinstance(node.func.value, ast.Name):
+            # option is appended to list via 'append' or 'extend'
+            if node.func.attr not in ["append", "extend"]:
+                continue
+
+            name = node.func.value.id
+            if name not in names:
+                continue
+
+            for arg in node.args:
+                if isinstance(arg, ast.List):
+                    for item in arg.elts:
+                        options[name].append(Option(item))
+                    continue
+
+                if isinstance(arg, ast.Call):
+                    options[name].append(Option(arg))
+                    continue
+
+                raise ValueError(f"Unable to process node {node}")
+
+    with open(output_file, "w+") as fid:
+        for config in names:
+            for option in options[config]:
+                fid.write(option.to_rest(dev=dev))
+                fid.write("\n")
+
+    print(f"Done writing output to '{output_file}'.")
+
+def main():
+    parser = argparse.ArgumentParser(
+        description="Extract configuration options from SConstruct",
+    )
+    parser.add_argument(
+        "input",
+        nargs="?",
+        help="The input SConstruct file. Optional.",
+        default="SConstruct")
+    parser.add_argument(
+        "output",
+        nargs="?",
+        help="The output ReST filename. Optional.",
+        default="config-options")
+    parser.add_argument(
+        "--dev",
+        action="store_true",
+        default=False,
+        help="Append '-dev' to filename and Sphinx references.")
+
+    args = parser.parse_args()
+    input_file = pathlib.Path(args.input)
+    output_file = args.output
+    if args.dev:
+        output_file += "-dev"
+    output_file = pathlib.Path(output_file).with_suffix(".rst")
+
+    parse(input_file, output_file, args.dev)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Implement `scons2rst.py`, which extracts options from `SConstruct` via AST
- Refactor `SConstruct` in order to provide access to platform/compiler dependent defaults
- `SConstruct` options (including platform/compiler dependent defaults) are extracted and written to a ReST file

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Addresses cantera/cantera-website#26

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
$ python scons2rst.py 
$ python scons2rst.py --dev SConstruct
```

An example for generated output for the development branch is [config-options.rst.txt](https://github.com/Cantera/cantera/files/7447402/config-options.rst.txt)

At the moment, platform-dependent options are described as `<platform dependent>`.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
