### PR TITLE
Refactor SConstruct option handling / extract scons options v2

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,16 @@ jobs:
           sphinxcontrib-katex sphinxcontrib-matlabdomain sphinxcontrib-doxylink
       - name: Build Cantera with documentation
         run: python3 `which scons` build -j2 doxygen_docs=y sphinx_docs=y debug=n optimize=n use_pch=n
+      - name: Ensure 'scons help' options work
+        run: |
+          python3 `which scons` help --options
+          python3 `which scons` help --list-options
+          python3 `which scons` help --option=prefix
+      - name: Parse configuration options from SConstruct as reST
+        run: |
+          python3 `which scons` help --restructured-text --dev --output=config-options-dev.rst
+          mkdir build/docs/scons
+          mv config-options-dev.rst build/docs/scons/
       - name: Create archive for docs output
         run: |
           cd build

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -158,6 +158,15 @@ jobs:
           sphinxcontrib-katex sphinxcontrib-matlabdomain sphinxcontrib-doxylink
       - name: Build Cantera with documentation
         run: python3 `which scons` build -j2 doxygen_docs=y sphinx_docs=y debug=n optimize=n use_pch=n
+      - name: Create archive for docs output
+        run: |
+          cd build
+          tar -czf docs.tar.gz docs
+      - name: Store archive of docs output
+        uses: actions/upload-artifact@v2
+        with:
+          path: build/docs.tar.gz
+          retention-days: 2
       # The known_hosts key is generated with `ssh-keygen -F cantera.org` from a
       # machine that has previously logged in to cantera.org and trusts
       # that it logged in to the right machine

--- a/SConstruct
+++ b/SConstruct
@@ -326,7 +326,12 @@ defaults.debug_link_flags = {"cl": "/DEBUG", "default": ""}
 defaults.no_debug_link_flags = ""
 defaults.warning_flags = {"cl": "/W3", "icc": "-Wcheck", "default": "-Wall"}
 defaults.build_pch = {"icc": False, "default": True}
-
+defaults.pch_flags = {
+    "cl": "/FIpch/system.h",
+    "gcc": "-include src/pch/system.h",
+    "clang": "-include-pch src/pch/system.h.gch",
+    "default": "",
+}
 defaults.thread_flags = {"Windows": "", "macOS": "", "default": "-pthread"}
 defaults.fs_layout = {"Windows": "compact", "default": "standard"}
 defaults.python_prefix = {"Windows": "", "default": "$prefix"}
@@ -335,7 +340,6 @@ defaults.env_vars = "PATH,LD_LIBRARY_PATH,PYTHONPATH"
 defaults.versioned_shared_library = {"mingw": False, "default": True}
 defaults.sphinx_options = "-W --keep-going"
 
-env['pch_flags'] = []
 env['openmp_flag'] = ['-fopenmp'] # used to generate sample build scripts
 
 env['using_apple_clang'] = False
@@ -350,11 +354,9 @@ if 'gcc' in env.subst('$CC') or 'gnu-cc' in env.subst('$CC'):
     if env['OS'] == 'Cygwin':
         defaults.select("Cygwin")
     defaults.select("gcc")
-    env['pch_flags'] = ['-include', 'src/pch/system.h']
 
 elif env['CC'] == 'cl': # Visual Studio
     defaults.select("cl")
-    env['pch_flags'] = ['/FIpch/system.h']
     env['openmp_flag'] = ['/openmp']
 
 elif 'icc' in env.subst('$CC'):
@@ -363,7 +365,6 @@ elif 'icc' in env.subst('$CC'):
 
 elif 'clang' in env.subst('$CC'):
     defaults.select("clang")
-    env['pch_flags'] = ['-include-pch', 'src/pch/system.h.gch']
 
 else:
     print("WARNING: Unrecognized C compiler '%s'" % env['CC'])
@@ -583,6 +584,10 @@ config_options = [
         'use_pch',
         """Use a precompiled-header to speed up compilation""",
         defaults.build_pch),
+    (
+        'pch_flags',
+        """Compiler flags when using precompiled-header.""",
+        defaults.pch_flags),
     (
         'cxx_flags',
         """Compiler flags passed to the C++ compiler only. Separate multiple
@@ -886,6 +891,7 @@ env['LINKFLAGS'] += listify(env['thread_flags'])
 env['CPPDEFINES'] = {}
 
 env['warning_flags'] = listify(env['warning_flags'])
+env["pch_flags"] = listify(env["pch_flags"])
 
 if env['optimize']:
     env['CCFLAGS'] += listify(env['optimize_flags'])

--- a/SConstruct
+++ b/SConstruct
@@ -195,8 +195,10 @@ if os.name == 'nt':
         (
             "msvc_version",
             """Version of Visual Studio to use. The default is the newest
-                installed version. Specify '12.0' for Visual Studio 2013 or '14.0'
-                for Visual Studio 2015. Windows MSVC only.""",
+               installed version. Specify '12.0' for Visual Studio 2013, '14.0' for
+               Visual Studio 2015, '14.1' ('14.1x') Visual Studio 2017, or '14.2'
+               ('14.2x') for Visual Studio 2019. For version numbers in parentheses,
+               'x' is a placeholder for a minor version number. Windows MSVC only.""",
             ""),
         EnumVariable(
             "target_arch",
@@ -216,7 +218,7 @@ if os.name == 'nt':
         EnumVariable(
             "toolchain",
             """The preferred compiler toolchain. If MSVC is not on the path but
-            'g++' is on he path, 'mingw' is used as a backup. Windows only.""",
+               'g++' is on the path, 'mingw' is used as a backup. Windows only.""",
             defaults.toolchain, ("msvc", "mingw", "intel")))
     opts.AddVariables(windows_compiler_options[-1])
     opts.Update(pickCompilerEnv)
@@ -444,7 +446,7 @@ config_options = [
         'matlab_path',
         """Path to the MATLAB install directory. This should be the directory
            containing the 'extern', 'bin', etc. subdirectories. Typical values
-           are: "C:/Program Files/MATLAB/R2011a" on Windows,
+           are: "C:\Program Files\MATLAB\R2021a" on Windows,
            "/Applications/MATLAB_R2011a.app" on macOS, or
            "/opt/MATLAB/R2011a" on Linux.""",
         '', PathVariable.PathAccept),
@@ -501,7 +503,7 @@ config_options = [
         'system_fmt',
         """Select whether to use the fmt library from a system installation
            ('y'), from a Git submodule ('n'), or to decide automatically
-           ('default').  If you do not want to use the Git submodule and fmt
+           ('default'). If you do not want to use the Git submodule and fmt
            is not installed directly into system include and library
            directories, then you will need to add those directories to
            'extra_inc_dirs' and 'extra_lib_dirs'. This installation of fmt

--- a/SConstruct
+++ b/SConstruct
@@ -64,6 +64,11 @@ if not COMMAND_LINE_TARGETS:
     logger.info(__doc__, print_level=False)
     sys.exit(0)
 
+if parse_version(SCons.__version__) < parse_version("3.0.0"):
+    logger.info("Cantera requires SCons with a minimum version of 3.0.0. Exiting.",
+                print_level=False)
+    sys.exit(0)
+
 valid_commands = ("build", "clean", "install", "uninstall",
                   "help", "msi", "samples", "sphinx", "doxygen", "dump")
 
@@ -378,10 +383,8 @@ if env['OS'] == 'Windows':
 elif env["OS"] == "Darwin":
     defaults.select("macOS")
 
-# InstallVersionedLib only fully functional in SCons >= 2.4.0
 # SHLIBVERSION fails with MinGW: http://scons.tigris.org/issues/show_bug.cgi?id=3035
-if (env['toolchain'] == 'mingw'
-    or parse_version(SCons.__version__) < parse_version('2.4.0')):
+if (env["toolchain"] == "mingw"):
     defaults.select("mingw")
 
 defaults.select("default")

--- a/SConstruct
+++ b/SConstruct
@@ -156,11 +156,12 @@ if os.name == 'nt':
         defaultToolchain = 'msvc'
 
     windows_compiler_options.extend([
-        ('msvc_version',
-         """Version of Visual Studio to use. The default is the newest
-            installed version. Specify '12.0' for Visual Studio 2013 or '14.0'
-            for Visual Studio 2015.""",
-         ''),
+        (
+            "msvc_version",
+            """Version of Visual Studio to use. The default is the newest
+                installed version. Specify '12.0' for Visual Studio 2013 or '14.0'
+                for Visual Studio 2015.""",
+            ""),
         EnumVariable(
             'target_arch',
             """Target architecture. The default is the same architecture as the
@@ -356,28 +357,29 @@ config_options = [
     PathVariable(
         'libdirname',
         """Set this to the directory where Cantera libraries should be installed.
-           Some distributions (for example, Fedora/RHEL) use 'lib64' instead of 'lib' on 64-bit systems
-           or could use some other library directory name instead of 'lib' depends
-           on architecture and profile (for example, Gentoo 'libx32' on x32 profile).
-           If user didn't set 'libdirname' configuration variable set it to default value 'lib'""",
+           Some distributions (for example, Fedora/RHEL) use 'lib64' instead of 'lib'
+           on 64-bit systems or could use some other library directory name instead of
+           'lib' depends on architecture and profile (for example, Gentoo 'libx32' on
+           x32 profile). If the user didn't set the 'libdirname' configuration
+           variable, set it to the default value 'lib'""",
         'lib', PathVariable.PathAccept),
     EnumVariable(
         'python_package',
-        """If you plan to work in Python, then you need the ``full`` Cantera Python
+        """If you plan to work in Python, then you need the 'full' Cantera Python
            package. If, on the other hand, you will only use Cantera from some
            other language (for example, MATLAB or Fortran 90/95) and only need Python
-           to process CTI files, then you only need a ``minimal`` subset of the
-           package and Cython and NumPy are not necessary. The ``none`` option
+           to process YAML files, then you only need a 'minimal' subset of the
+           package and Cython and NumPy are not necessary. The 'none' option
            doesn't install any components of the Python interface. The default
            behavior is to build the full Python module for whichever version of
            Python is running SCons if the required prerequisites (NumPy and
-           Cython) are installed. Note: ``y`` is a synonym for ``full`` and ``n``
-           is a synonym for ``none``.""",
+           Cython) are installed. Note: 'y' is a synonym for 'full' and 'n'
+           is a synonym for 'none'.""",
         'default', ('full', 'minimal', 'none', 'n', 'y', 'default')),
     PathVariable(
         'python_cmd',
         """Cantera needs to know where to find the Python interpreter. If
-           PYTHON_CMD is not set, then the configuration process will use the
+           'PYTHON_CMD' is not set, then the configuration process will use the
            same Python interpreter being used by SCons.""",
         sys.executable, PathVariable.PathAccept),
     PathVariable(
@@ -418,9 +420,10 @@ config_options = [
            a compatible compiler (pgfortran, gfortran, ifort, g95) in the 'PATH' environment
            variable. Used only for compiling the Fortran 90 interface.""",
         '', PathVariable.PathAccept),
-    ('FORTRANFLAGS',
-     'Compilation options for the Fortran (90) compiler.',
-     '-O3'),
+    (
+        "FORTRANFLAGS",
+        """Compilation options for the Fortran (90) compiler.""",
+        "-O3"),
     BoolVariable(
         'coverage',
         """Enable collection of code coverage information with gcov.
@@ -506,13 +509,13 @@ config_options = [
         'blas_lapack_dir',
         """Directory containing the libraries specified by 'blas_lapack_libs'. Not
            needed if the libraries are installed in a standard location, for example,
-           ``/usr/lib``.""",
+           '/usr/lib'.""",
         '', PathVariable.PathAccept),
     EnumVariable(
         'lapack_names',
         """Set depending on whether the procedure names in the specified
            libraries are lowercase or uppercase. If you don't know, run 'nm' on
-           the library file (for example, 'nm libblas.a').""",
+           the library file (for example, "nm libblas.a").""",
         'lower', ('lower','upper')),
     BoolVariable(
         'lapack_ftn_trailing_underscore',
@@ -535,7 +538,7 @@ config_options = [
     (
         'env_vars',
         """Environment variables to propagate through to SCons. Either the
-           string "all" or a comma separated list of variable names, for example,
+           string 'all' or a comma separated list of variable names, for example,
            'LD_LIBRARY_PATH,HOME'.""",
         defaults.env_vars),
     BoolVariable(
@@ -655,7 +658,7 @@ config_options = [
         """The layout of the directory structure. 'standard' installs files to
            several subdirectories under 'prefix', for example, 'prefix/bin',
            'prefix/include/cantera', 'prefix/lib' etc. This layout is best used in
-           conjunction with "prefix'='/usr/local'". 'compact' puts all installed
+           conjunction with "prefix='/usr/local'". 'compact' puts all installed
            files in the subdirectory defined by 'prefix'. This layout is best
            with a prefix like '/opt/cantera'. 'debian' installs to the stage
            directory in a layout used for generating Debian packages.""",

--- a/SConstruct
+++ b/SConstruct
@@ -742,7 +742,8 @@ if "help" in COMMAND_LINE_TARGETS:
         help(env, opts)
         sys.exit(0)
 
-    message = config.help(include_header=True, env=env)
+    option = ARGUMENTS.get("option")
+    message = config.help(option, env=env)
     logger.info(message, print_level=False)
     sys.exit(0)
 

--- a/SConstruct
+++ b/SConstruct
@@ -74,7 +74,7 @@ if os.name not in ["nt", "posix"]:
     sys.exit(1)
 
 valid_commands = ("build", "clean", "install", "uninstall",
-                  "help", "msi", "samples", "sphinx", "doxygen", "dump", "get-options")
+                  "help", "msi", "samples", "sphinx", "doxygen", "dump")
 
 for command in COMMAND_LINE_TARGETS:
     if command not in valid_commands and not command.startswith('test'):
@@ -557,6 +557,9 @@ config = Configuration()
 
 if "help" in COMMAND_LINE_TARGETS:
     AddOption(
+        "--list-options", dest="list",
+        action="store_true", help="List available options")
+    AddOption(
         "--restructured-text", dest="rest",
         action="store_true", help="Format defaults as ReST")
     AddOption(
@@ -572,28 +575,37 @@ if "help" in COMMAND_LINE_TARGETS:
         "--output", dest="output", nargs=1, type="string",
         action="store", help="Output file (ReST only)")
 
+    list = GetOption("list")
     rest = GetOption("rest")
     defaults = GetOption("defaults") is not None
 
-    if defaults or rest:
+    if defaults or rest or list:
 
         config.add(windows_options)
         config.add(config_options)
         option = GetOption("option")
+
+        if list:
+            # show formatted list of options
+            logger.info("\nConfiguration options for building Cantera:", print_level=False)
+            logger.info(config.list_options(), print_level=False)
+            sys.exit(0)
 
         if defaults:
             try:
                 logger.info(config.help(option), print_level=False)
                 sys.exit(0)
             except KeyError as err:
-                logger.error(f"{err}")
+                message = "Run 'scons help --list-options' to see available options."
+                logger.error(f"{err}.\n{message}")
                 sys.exit(1)
 
         dev = GetOption("dev") is not None
         try:
             message = config.to_rest(option, dev=dev)
         except KeyError as err:
-            logger.error(f"{err}")
+            message = "Run 'scons help --list-options' to see available options."
+            logger.error(f"{err}.\n{message}")
             sys.exit(1)
 
         output = GetOption("output")
@@ -767,7 +779,8 @@ if "help" in COMMAND_LINE_TARGETS:
         logger.info(config.help(option, env=env), print_level=False)
         sys.exit(0)
     except KeyError as err:
-        logger.error(f"{err}")
+        message = "Run 'scons help --list-options' to see available options."
+        logger.error(f"{err}.\n{message}")
         sys.exit(1)
 
 if 'doxygen' in COMMAND_LINE_TARGETS:

--- a/SConstruct
+++ b/SConstruct
@@ -555,35 +555,45 @@ config_options = [
 
 config = Configuration()
 
-if "get-options" in COMMAND_LINE_TARGETS:
+if "help" in COMMAND_LINE_TARGETS:
 
-    invalid_args = set(ARGUMENTS.keys()) - {"dev", "output"}
+    invalid_args = set(ARGUMENTS.keys()) - {"all", "dev", "rest", "option", "output"}
     if invalid_args:
         logger.error(
             f"Unrecognized command line options: {invalid_args};"
             "valid options are 'dev' and 'output'.", print_level=False)
         sys.exit(1)
 
-    dev = ARGUMENTS.get("dev") in ["True", "y", "yes"]
+    yes = ["y", "yes", "true", "True"]
+    help = ARGUMENTS.get("all") in yes and ARGUMENTS.get("rest") not in yes
+    rest = ARGUMENTS.get("rest") in yes
 
-    config.add(windows_options)
-    config.add(config_options)
-    message = config.to_rest(dev=dev, include_header=True)
+    if help or rest:
 
-    output = ARGUMENTS.get("output", None)
-    if output:
-        output_file = Path(output).with_suffix(".rst")
-        with open(output_file, "w+") as fid:
-            fid.write(message)
+        config.add(windows_options)
+        config.add(config_options)
+        option = ARGUMENTS.get("option")
 
-        logger.info(f"Done writing output options to '{output_file}'.",
-                    print_level=False)
+        if help:
+            logger.info(config.help(option), print_level=False)
+            sys.exit(0)
 
-    else:
-        logger.info(message, print_level=False)
+        dev = ARGUMENTS.get("dev") in yes
+        message = config.to_rest(option, dev=dev)
 
-    sys.exit(0)
+        output = ARGUMENTS.get("output", None)
+        if output:
+            output_file = Path(output).with_suffix(".rst")
+            with open(output_file, "w+") as fid:
+                fid.write(message)
 
+            logger.info(f"Done writing output options to '{output_file}'.",
+                        print_level=False)
+
+        else:
+            logger.info(message, print_level=False)
+
+        sys.exit(0)
 
 # **************************************
 # *** Read user-configurable options ***

--- a/SConstruct
+++ b/SConstruct
@@ -76,7 +76,7 @@ from buildutils import *
 
 if not COMMAND_LINE_TARGETS:
     # Print usage help
-    logger.error("Missing command argument: type 'scons help' for information")
+    logger.error("Missing command argument: type 'scons help' for information.")
     sys.exit(1)
 
 if parse_version(SCons.__version__) < parse_version("3.0.0"):

--- a/SConstruct
+++ b/SConstruct
@@ -135,16 +135,11 @@ if "test-clean" in COMMAND_LINE_TARGETS:
     remove_directory("test/work")
     remove_directory("build/python_local")
 
-# ******************************************************
-# *** Set system-dependent defaults for some options ***
-# ******************************************************
-
 logger.info("SCons is using the following Python interpreter: {}", sys.executable)
 
-
-# *****************************************
-# *** Specify user-configurable options ***
-# *****************************************
+# ******************************************
+# *** Specify defaults for SCons options ***
+# ******************************************
 
 windows_compiler_options = [
     Option(
@@ -559,14 +554,32 @@ config_options = [
 
 if "get-options" in COMMAND_LINE_TARGETS:
 
-    dev = False
-    message = [];
+    invalid_args = set(ARGUMENTS.keys()) - {"dev", "output"}
+    if invalid_args:
+        logger.error(
+            f"Unrecognized command line options: {invalid_args};"
+            "valid options are 'dev' and 'output'.", print_level=False)
+        sys.exit(1)
+
+    dev = ARGUMENTS.get("dev") in ["True", "y", "yes"]
+    message = []
     for config in [windows_compiler_options, compiler_options, config_options]:
 
         for option in config:
             message.append(option.to_rest(dev=dev))
 
-    logger.info("\n".join(message), print_level=False)
+    output = ARGUMENTS.get("output", None)
+    if output:
+        output_file = Path(output).with_suffix(".rst")
+        with open(output_file, "w+") as fid:
+            fid.write("\n".join(message))
+
+        logger.info(f"Done writing output options to '{output_file}'.",
+                    print_level=False)
+
+    else:
+        logger.info("\n".join(message), print_level=False)
+
     sys.exit(0)
 
 

--- a/SConstruct
+++ b/SConstruct
@@ -737,11 +737,6 @@ for option in opts.keys():
             env[option] = modified
 
 if "help" in COMMAND_LINE_TARGETS:
-
-    if ARGUMENTS.get("old") in ["True", "y", "yes"]:
-        help(env, opts)
-        sys.exit(0)
-
     option = ARGUMENTS.get("option")
     message = config.help(option, env=env)
     logger.info(message, print_level=False)

--- a/SConstruct
+++ b/SConstruct
@@ -25,7 +25,7 @@ Basic usage:
     'scons test-NAME' - Run the test named "NAME".
 
     'scons <command> dump' - Dump the state of the SCons environment to the
-                             screen instead of doing <command>, e.g.
+                             screen instead of doing <command>, for example
                              'scons build dump'. For debugging purposes.
 
     'scons samples' - Compile the C++ and Fortran samples.
@@ -35,7 +35,20 @@ Basic usage:
     'scons sphinx' - Build the Sphinx documentation
 
     'scons doxygen' - Build the Doxygen documentation
+
+Additional help command options:
+    'scons help --list-options' - List all available configuration options.
+
+    'scons help --option=<opt>' - Print the description of a specific option
+                                  with name <opt>, for example
+                                  'scons help --option=prefix'
 """
+# Note that 'scons help' supports additional command options that are intended for
+# internal use (debugging or reST parsing of options) and thus are not listed above:
+#  --defaults ... list default values for all supported platforms
+#  --restructured-text ... format configuration as reST
+#  --dev ... add '-dev' to reST output
+#  --output=<fname> ... send output to file (reST only)
 
 # This f-string is deliberately here to trigger a SyntaxError when
 # SConstruct is parsed by Python 2. This seems to be the most robust
@@ -561,7 +574,7 @@ if "help" in COMMAND_LINE_TARGETS:
         action="store_true", help="List available options")
     AddOption(
         "--restructured-text", dest="rest",
-        action="store_true", help="Format defaults as ReST")
+        action="store_true", help="Format defaults as reST")
     AddOption(
         "--option", dest="option", nargs=1, type="string",
         action="store", help="Output help for specific option")
@@ -573,7 +586,7 @@ if "help" in COMMAND_LINE_TARGETS:
         action="store_true", help="Append -dev (ReST only)")
     AddOption(
         "--output", dest="output", nargs=1, type="string",
-        action="store", help="Output file (ReST only)")
+        action="store", help="Output file (reST only)")
 
     list = GetOption("list")
     rest = GetOption("rest")

--- a/SConstruct
+++ b/SConstruct
@@ -556,6 +556,10 @@ config_options = [
         True),
 ]
 
+windows_compiler_options = Configuration(windows_compiler_options)
+compiler_options = Configuration(compiler_options)
+config_options = Configuration(config_options)
+
 if "get-options" in COMMAND_LINE_TARGETS:
 
     invalid_args = set(ARGUMENTS.keys()) - {"dev", "output"}
@@ -566,11 +570,10 @@ if "get-options" in COMMAND_LINE_TARGETS:
         sys.exit(1)
 
     dev = ARGUMENTS.get("dev") in ["True", "y", "yes"]
-    message = []
-    for config in [windows_compiler_options, compiler_options, config_options]:
 
-        for option in config:
-            message.append(option.to_rest(dev=dev))
+    message = windows_compiler_options.to_rest(dev=dev, include_header=True)
+    message += compiler_options.to_rest(dev=dev)
+    message += config_options.to_rest(dev=dev)
 
     output = ARGUMENTS.get("output", None)
     if output:
@@ -591,9 +594,6 @@ if "get-options" in COMMAND_LINE_TARGETS:
 # *** Read user-configurable options ***
 # **************************************
 
-compiler_options = Configuration(compiler_options)
-config_options = Configuration(config_options)
-
 opts = Variables("cantera.conf")
 
 extraEnvArgs = {}
@@ -601,7 +601,6 @@ extraEnvArgs = {}
 if os.name == "nt":
     config_options["prefix"].default = pjoin(os.environ["ProgramFiles"], "Cantera")
 
-    windows_compiler_options = Configuration(windows_compiler_options)
     windows_compiler_options.select("Windows")
 
     # On Windows, target the same architecture as the current copy of Python,
@@ -747,7 +746,16 @@ for option in opts.keys():
             env[option] = modified
 
 if "help" in COMMAND_LINE_TARGETS:
-    help(env, opts)
+
+    if ARGUMENTS.get("old") in ["True", "y", "yes"]:
+        help(env, opts)
+        sys.exit(0)
+
+    message = windows_compiler_options.help(include_header=True, env=env)
+    message += compiler_options.help(env=env)
+    message += config_options.help(env=env)
+
+    logger.info("\n".join(message), print_level=False)
     sys.exit(0)
 
 if 'doxygen' in COMMAND_LINE_TARGETS:

--- a/SConstruct
+++ b/SConstruct
@@ -69,6 +69,10 @@ if parse_version(SCons.__version__) < parse_version("3.0.0"):
                 print_level=False)
     sys.exit(0)
 
+if os.name not in ["nt", "posix"]:
+    print(f"Error: Unrecognized operating system '{os.name}'")
+    sys.exit(1)
+
 valid_commands = ("build", "clean", "install", "uninstall",
                   "help", "msi", "samples", "sphinx", "doxygen", "dump", "get-options")
 
@@ -660,33 +664,29 @@ env["OS_BITS"] = int(platform.architecture()[0][:2])
 if "cygwin" in env["OS"].lower():
     env["OS"] = "Cygwin" # remove Windows version suffix
 
-# Fixes a linker error in Windows
-if os.name == "nt" and "TMP" in os.environ:
-    env["ENV"]["TMP"] = os.environ["TMP"]
-
-# Fixes issues with Python subprocesses. See http://bugs.python.org/issue13524
-if os.name == "nt":
-    env["ENV"]["SystemRoot"] = os.environ["SystemRoot"]
+if "FRAMEWORKS" not in env:
+    env["FRAMEWORKS"] = []
 
 # Needed for Matlab to source ~/.matlab7rc.sh
 if "HOME" in os.environ:
     env["ENV"]["HOME"] = os.environ["HOME"]
 
-# Fix an issue with Unicode sneaking into the environment on Windows
 if os.name == "nt":
+    env["INSTALL_MANPAGES"] = False
+
+    # Fixes a linker error in Windows
+    if "TMP" in os.environ:
+        env["ENV"]["TMP"] = os.environ["TMP"]
+
+    # Fixes issues with Python subprocesses. See http://bugs.python.org/issue13524
+    env["ENV"]["SystemRoot"] = os.environ["SystemRoot"]
+
+    # Fix an issue with Unicode sneaking into the environment on Windows
     for key,val in env["ENV"].items():
         env["ENV"][key] = str(val)
 
-if "FRAMEWORKS" not in env:
-    env["FRAMEWORKS"] = []
-
-if os.name == "posix":
-    env["INSTALL_MANPAGES"] = True
-elif os.name == "nt":
-    env["INSTALL_MANPAGES"] = False
 else:
-    print(f"Error: Unrecognized operating system '{os.name}'")
-    sys.exit(1)
+    env["INSTALL_MANPAGES"] = True
 
 add_RegressionTest(env)
 

--- a/SConstruct
+++ b/SConstruct
@@ -80,12 +80,11 @@ if not COMMAND_LINE_TARGETS:
     sys.exit(1)
 
 if parse_version(SCons.__version__) < parse_version("3.0.0"):
-    logger.info("Cantera requires SCons with a minimum version of 3.0.0. Exiting.",
-                print_level=False)
-    sys.exit(0)
+    logger.error("Cantera requires SCons with a minimum version of 3.0.0. Exiting.")
+    sys.exit(1)
 
 if os.name not in ["nt", "posix"]:
-    print(f"Error: Unrecognized operating system '{os.name}'")
+    logger.error(f"Error: Unrecognized operating system '{os.name}'")
     sys.exit(1)
 
 valid_commands = ("build", "clean", "install", "uninstall",
@@ -164,21 +163,21 @@ windows_options = [
     Option(
         "msvc_version",
         """Version of Visual Studio to use. The default is the newest
-            installed version. Specify '12.0' for Visual Studio 2013, '14.0' for
-            Visual Studio 2015, '14.1' ('14.1x') Visual Studio 2017, or '14.2'
-            ('14.2x') for Visual Studio 2019. For version numbers in parentheses,
-            'x' is a placeholder for a minor version number. Windows MSVC only.""",
+           installed version. Specify '12.0' for Visual Studio 2013, '14.0' for
+           Visual Studio 2015, '14.1' ('14.1x') Visual Studio 2017, or '14.2'
+           ('14.2x') for Visual Studio 2019. For version numbers in parentheses,
+           'x' is a placeholder for a minor version number. Windows MSVC only.""",
         ""),
     EnumOption(
         "target_arch",
         """Target architecture. The default is the same architecture as the
-            installed version of Python. Windows only.""",
+           installed version of Python. Windows only.""",
         {"Windows": "amd64"},
         ("amd64", "x86")),
     EnumOption(
         "toolchain",
         """The preferred compiler toolchain. If MSVC is not on the path but
-            'g++' is on the path, 'mingw' is used as a backup. Windows only.""",
+           'g++' is on the path, 'mingw' is used as a backup. Windows only.""",
         {"Windows": "msvc"},
         ("msvc", "mingw", "intel")),
 ]
@@ -186,10 +185,10 @@ windows_options = [
 config_options = [
     Option(
         "CXX",
-        """The C++ compiler to use.""",
+        "The C++ compiler to use.",
         "${CXX}"),
     Option(
-        'cxx_flags',
+        "cxx_flags",
         """Compiler flags passed to the C++ compiler only. Separate multiple
            options with spaces, for example, "cxx_flags='-g -Wextra -O3 --std=c++11'"
            """,
@@ -200,12 +199,12 @@ config_options = [
         }),
     Option(
         "CC",
-        """The C compiler to use. This is only used to compile CVODE.""",
+        "The C compiler to use. This is only used to compile CVODE.",
         "${CC}"),
     Option(
         "cc_flags",
         """Compiler flags passed to both the C and C++ compilers, regardless of
-            optimization level.""",
+           optimization level.""",
         {
             "cl": "/MD /nologo /D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS",
             "icc": "-vec-report0 -diag-disable 1478",
@@ -219,16 +218,16 @@ config_options = [
         {"Windows": "$ProgramFiles\Cantera", "default": "/usr/local"},
         PathVariable.PathAccept),
     PathOption(
-        'libdirname',
+        "libdirname",
         """Set this to the directory where Cantera libraries should be installed.
            Some distributions (for example, Fedora/RHEL) use 'lib64' instead of 'lib'
            on 64-bit systems or could use some other library directory name instead of
-           'lib' depends on architecture and profile (for example, Gentoo 'libx32' on
+           'lib', depending on architecture and profile (for example, Gentoo 'libx32' on
            x32 profile). If the user didn't set the 'libdirname' configuration
            variable, set it to the default value 'lib'""",
-        'lib', PathVariable.PathAccept),
+        "lib", PathVariable.PathAccept),
     EnumOption(
-        'python_package',
+        "python_package",
         """If you plan to work in Python, then you need the 'full' Cantera Python
            package. If, on the other hand, you will only use Cantera from some
            other language (for example, MATLAB or Fortran 90/95) and only need Python
@@ -239,16 +238,16 @@ config_options = [
            Python is running SCons if the required prerequisites (NumPy and
            Cython) are installed. Note: 'y' is a synonym for 'full' and 'n'
            is a synonym for 'none'.""",
-        'default', ('full', 'minimal', 'none', 'n', 'y', 'default')),
+        "default", ("full", "minimal", "none", "n", "y", "default")),
     PathOption(
-        'python_cmd',
+        "python_cmd",
         """Cantera needs to know where to find the Python interpreter. If
            'PYTHON_CMD' is not set, then the configuration process will use the
            same Python interpreter being used by SCons.""",
         "${PYTHON_CMD}",
         PathVariable.PathAccept),
     PathOption(
-        'python_prefix',
+        "python_prefix",
         """Use this option if you want to install the Cantera Python package to
            an alternate location. On Unix-like systems, the default is the same
            as the 'prefix' option. If the 'python_prefix' option is set to
@@ -259,70 +258,70 @@ config_options = [
         {"Windows": "", "default": "$prefix"},
         PathVariable.PathAccept),
     EnumOption(
-        'matlab_toolbox',
+        "matlab_toolbox",
         """This variable controls whether the MATLAB toolbox will be built. If
            set to 'y', you will also need to set the value of the 'matlab_path'
            variable. If set to 'default', the MATLAB toolbox will be built if
            'matlab_path' is set.""",
-        'default', ('y', 'n', 'default')),
+        "default", ("y", "n", "default")),
     PathOption(
-        'matlab_path',
+        "matlab_path",
         """Path to the MATLAB install directory. This should be the directory
            containing the 'extern', 'bin', etc. subdirectories. Typical values
-           are: "C:\Program Files\MATLAB\R2021a" on Windows,
-           "/Applications/MATLAB_R2011a.app" on macOS, or
-           "/opt/MATLAB/R2011a" on Linux.""",
-        '', PathVariable.PathAccept),
+           are: "C:\\Program Files\\MATLAB\\R2021a" on Windows,
+           "/Applications/MATLAB_R2021a.app" on macOS, or
+           "/opt/MATLAB/R2021a" on Linux.""",
+        "", PathVariable.PathAccept),
     EnumOption(
-        'f90_interface',
+        "f90_interface",
         """This variable controls whether the Fortran 90/95 interface will be
            built. If set to 'default', the builder will look for a compatible
            Fortran compiler in the 'PATH' environment variable, and compile
            the Fortran 90 interface if one is found.""",
-        'default', ('y', 'n', 'default')),
+        "default", ("y", "n", "default")),
     PathOption(
-        'FORTRAN',
+        "FORTRAN",
         """The Fortran (90) compiler. If unspecified, the builder will look for
            a compatible compiler (pgfortran, gfortran, ifort, g95) in the 'PATH' environment
            variable. Used only for compiling the Fortran 90 interface.""",
-        '', PathVariable.PathAccept),
+        "", PathVariable.PathAccept),
     Option(
         "FORTRANFLAGS",
-        """Compilation options for the Fortran (90) compiler.""",
+        "Compilation options for the Fortran (90) compiler.",
         "-O3"),
     BoolOption(
-        'coverage',
+        "coverage",
         """Enable collection of code coverage information with gcov.
            Available only when compiling with gcc.""",
         False),
     BoolOption(
-        'doxygen_docs',
-        """Build HTML documentation for the C++ interface using Doxygen.""",
+        "doxygen_docs",
+        "Build HTML documentation for the C++ interface using Doxygen.",
         False),
     BoolOption(
-        'sphinx_docs',
-        """Build HTML documentation for Cantera using Sphinx.""",
+        "sphinx_docs",
+        "Build HTML documentation for Cantera using Sphinx.",
         False),
     PathOption(
-        'sphinx_cmd',
-        """Command to use for building the Sphinx documentation.""",
-        'sphinx-build', PathVariable.PathAccept),
+        "sphinx_cmd",
+        "Command to use for building the Sphinx documentation.",
+        "sphinx-build", PathVariable.PathAccept),
     Option(
         "sphinx_options",
         """Options passed to the 'sphinx_cmd' command line. Separate multiple
            options with spaces, for example, "-W --keep-going".""",
         "-W --keep-going"),
     EnumOption(
-        'system_eigen',
+        "system_eigen",
         """Select whether to use Eigen from a system installation ('y'), from a
            Git submodule ('n'), or to decide automatically ('default'). If Eigen
            is not installed directly into a system include directory, for example, it is
            installed in '/opt/include/eigen3/Eigen', then you will need to add
            '/opt/include/eigen3' to 'extra_inc_dirs'.
            """,
-        'default', ('default', 'y', 'n')),
+        "default", ("default", "y", "n")),
     EnumOption(
-        'system_fmt',
+        "system_fmt",
         """Select whether to use the fmt library from a system installation
            ('y'), from a Git submodule ('n'), or to decide automatically
            ('default'). If you do not want to use the Git submodule and fmt
@@ -331,37 +330,37 @@ config_options = [
            'extra_inc_dirs' and 'extra_lib_dirs'. This installation of fmt
            must include the shared version of the library, for example,
            'libfmt.so'.""",
-        'default', ('default', 'y', 'n')),
+        "default", ("default", "y", "n")),
     EnumOption(
-        'system_yamlcpp',
+        "system_yamlcpp",
         """Select whether to use the yaml-cpp library from a system installation
            ('y'), from a Git submodule ('n'), or to decide automatically
            ('default'). If yaml-cpp is not installed directly into system
            include and library directories, then you will need to add those
            directories to 'extra_inc_dirs' and 'extra_lib_dirs'.""",
-        'default', ('default', 'y', 'n')),
+        "default", ("default", "y", "n")),
     EnumOption(
-        'system_sundials',
+        "system_sundials",
         """Select whether to use SUNDIALS from a system installation ('y'), from
            a Git submodule ('n'), or to decide automatically ('default').
            Specifying 'sundials_include' or 'sundials_libdir' changes the
            default to 'y'.""",
-        'default', ('default', 'y', 'n')),
+        "default", ("default", "y", "n")),
     PathOption(
-        'sundials_include',
+        "sundials_include",
         """The directory where the SUNDIALS header files are installed. This
            should be the directory that contains the "cvodes", "nvector", etc.
            subdirectories. Not needed if the headers are installed in a
            standard location, for example, '/usr/include'.""",
-        '', PathVariable.PathAccept),
+        "", PathVariable.PathAccept),
     PathOption(
-        'sundials_libdir',
+        "sundials_libdir",
         """The directory where the SUNDIALS static libraries are installed.
            Not needed if the libraries are installed in a standard location,
            for example, '/usr/lib'.""",
-        '', PathVariable.PathAccept),
+        "", PathVariable.PathAccept),
     Option(
-        'blas_lapack_libs',
+        "blas_lapack_libs",
         """Cantera can use BLAS and LAPACK libraries available on your system if
            you have optimized versions available (for example, Intel MKL). Otherwise,
            Cantera will use Eigen for linear algebra support. To use BLAS
@@ -369,50 +368,50 @@ config_options = [
            that should be passed to the linker, separated by commas, for example,
            "lapack,blas" or "lapack,f77blas,cblas,atlas". Eigen is required
            whether or not BLAS/LAPACK are used.""",
-        ''),
+        ""),
     PathOption(
-        'blas_lapack_dir',
+        "blas_lapack_dir",
         """Directory containing the libraries specified by 'blas_lapack_libs'. Not
            needed if the libraries are installed in a standard location, for example,
            '/usr/lib'.""",
-        '', PathVariable.PathAccept),
+        "", PathVariable.PathAccept),
     EnumOption(
-        'lapack_names',
+        "lapack_names",
         """Set depending on whether the procedure names in the specified
            libraries are lowercase or uppercase. If you don't know, run 'nm' on
            the library file (for example, "nm libblas.a").""",
-        'lower', ('lower','upper')),
+        "lower", ("lower", "upper")),
     BoolOption(
-        'lapack_ftn_trailing_underscore',
+        "lapack_ftn_trailing_underscore",
         """Controls whether the LAPACK functions have a trailing underscore
            in the Fortran libraries.""",
         True),
     BoolOption(
-        'lapack_ftn_string_len_at_end',
+        "lapack_ftn_string_len_at_end",
         """Controls whether the LAPACK functions have the string length
            argument at the end of the argument list ('yes') or after
            each argument ('no') in the Fortran libraries.""",
         True),
     EnumOption(
-        'googletest',
+        "googletest",
         """Select whether to use gtest/gmock from system
            installation ('system'), from a Git submodule ('submodule'), to decide
            automatically ('default') or don't look for gtest/gmock ('none')
            and don't run tests that depend on gtest/gmock.""",
-        'default', ('default', 'system', 'submodule', 'none')),
+        "default", ("default", "system", "submodule", "none")),
     Option(
-        'env_vars',
+        "env_vars",
         """Environment variables to propagate through to SCons. Either the
            string 'all' or a comma separated list of variable names, for example,
            'LD_LIBRARY_PATH,HOME'.""",
         "PATH,LD_LIBRARY_PATH,PYTHONPATH"),
     BoolOption(
-        'use_pch',
-        """Use a precompiled-header to speed up compilation""",
+        "use_pch",
+        "Use a precompiled-header to speed up compilation",
         {"icc": False, "default": True}),
     Option(
-        'pch_flags',
-        """Compiler flags when using precompiled-header.""",
+        "pch_flags",
+        "Compiler flags when using precompiled-header.",
         {
             "cl": "/FIpch/system.h",
             "gcc": "-include src/pch/system.h",
@@ -420,84 +419,84 @@ config_options = [
             "default": "",
         }),
     Option(
-        'thread_flags',
-        """Compiler and linker flags for POSIX multithreading support.""",
+        "thread_flags",
+        "Compiler and linker flags for POSIX multithreading support.",
         {"Windows": "", "macOS": "", "default": "-pthread"}),
     BoolOption(
-        'optimize',
+        "optimize",
         """Enable extra compiler optimizations specified by the
            'optimize_flags' variable, instead of the flags specified by the
            'no_optimize_flags' variable.""",
         True),
     Option(
-        'optimize_flags',
-        """Additional compiler flags passed to the C/C++ compiler when 'optimize=yes'.""",
+        "optimize_flags",
+        "Additional compiler flags passed to the C/C++ compiler when 'optimize=yes'.",
         {"cl": "/O2", "gcc": "-O3 -Wno-inline", "default": "-O3"}),
     Option(
-        'no_optimize_flags',
-        """Additional compiler flags passed to the C/C++ compiler when 'optimize=no'.""",
+        "no_optimize_flags",
+        "Additional compiler flags passed to the C/C++ compiler when 'optimize=no'.",
         {"cl": "/Od /Ob0", "default": "-O0"}),
     BoolOption(
-        'debug',
-        """Enable compiler debugging symbols.""",
+        "debug",
+        "Enable compiler debugging symbols.",
         True),
     Option(
-        'debug_flags',
-        """Additional compiler flags passed to the C/C++ compiler when 'debug=yes'.""",
+        "debug_flags",
+        "Additional compiler flags passed to the C/C++ compiler when 'debug=yes'.",
         {"cl": "/Zi /Fd${TARGET}.pdb", "default": "-g"}),
     Option(
-        'no_debug_flags',
-        """Additional compiler flags passed to the C/C++ compiler when 'debug=no'.""",
+        "no_debug_flags",
+        "Additional compiler flags passed to the C/C++ compiler when 'debug=no'.",
         ""),
     Option(
-        'debug_linker_flags',
-        """Additional options passed to the linker when 'debug=yes'.""",
+        "debug_linker_flags",
+        "Additional options passed to the linker when 'debug=yes'.",
         {"cl": "/DEBUG", "default": ""}),
     Option(
-        'no_debug_linker_flags',
-        """Additional options passed to the linker when 'debug=no'.""",
+        "no_debug_linker_flags",
+        "Additional options passed to the linker when 'debug=no'.",
         ""),
     Option(
-        'warning_flags',
+        "warning_flags",
         """Additional compiler flags passed to the C/C++ compiler to enable
            extra warnings. Used only when compiling source code that is part
            of Cantera (for example, excluding code in the 'ext' directory).""",
         {"cl": "/W3", "icc": "-Wcheck", "default": "-Wall"}),
     Option(
-        'extra_inc_dirs',
+        "extra_inc_dirs",
         """Additional directories to search for header files, with multiple
-        directories separated by colons (*nix, macOS) or semicolons (Windows)""",
-        ''),
+           directories separated by colons (*nix, macOS) or semicolons (Windows)""",
+        ""),
     Option(
-        'extra_lib_dirs',
+        "extra_lib_dirs",
         """Additional directories to search for libraries, with multiple
-        directories separated by colons (*nix, macOS) or semicolons (Windows)""",
-        ''),
+           directories separated by colons (*nix, macOS) or semicolons (Windows)""",
+        ""),
     PathOption(
-        'boost_inc_dir',
+        "boost_inc_dir",
         """Location of the Boost header files. Not needed if the headers are
            installed in a standard location, for example, '/usr/include'.""",
         "",
         PathVariable.PathAccept),
     PathOption(
-        'stage_dir',
+        "stage_dir",
         """Directory relative to the Cantera source directory to be
            used as a staging area for building for example, a Debian
            package. If specified, 'scons install' will install files
            to 'stage_dir/prefix/...'.""",
-        '',
+        "",
         PathVariable.PathAccept),
     BoolOption(
-        'VERBOSE',
-        """Create verbose output about what SCons is doing.""",
+        "VERBOSE",
+        "Create verbose output about what SCons is doing.",
         False),
     Option(
-        'gtest_flags',
+        "gtest_flags",
         """Additional options passed to each GTest test suite, for example,
            '--gtest_filter=*pattern*'. Separate multiple options with spaces.""",
-        ''),
+        ""),
     BoolOption(
-        'renamed_shared_libraries',
+        "renamed_shared_libraries",
         """If this option is turned on, the shared libraries that are created
            will be renamed to have a '_shared' extension added to their base name.
            If not, the base names will be the same as the static libraries.
@@ -506,14 +505,14 @@ config_options = [
            the '-static' linking flag.""",
         True),
     BoolOption(
-        'versioned_shared_library',
+        "versioned_shared_library",
         """If enabled, create a versioned shared library, with symlinks to the
            more generic library name, for example, 'libcantera_shared.so.2.5.0' as the
            actual library and 'libcantera_shared.so' and 'libcantera_shared.so.2'
            as symlinks.""",
         {"mingw": False, "default": True}),
     BoolOption(
-        'use_rpath_linkage',
+        "use_rpath_linkage",
         """If enabled, link to all shared libraries using 'rpath', i.e., a fixed
            run-time search path for dynamic library loading.""",
         True),
@@ -528,7 +527,7 @@ config_options = [
             "default": "-fopenmp",
         }),
     EnumOption(
-        'layout',
+        "layout",
         """The layout of the directory structure. 'standard' installs files to
            several subdirectories under 'prefix', for example, 'prefix/bin',
            'prefix/include/cantera', 'prefix/lib' etc. This layout is best used in
@@ -537,10 +536,10 @@ config_options = [
            with a prefix like '/opt/cantera'. 'debian' installs to the stage
            directory in a layout used for generating Debian packages.""",
         {"Windows": "compact", "default": "standard"},
-        ('standard','compact','debian')),
+        ("standard", "compact", "debian")),
     BoolOption(
         "fast_fail_tests",
-        """If enabled, tests will exit at the first failure.""",
+        "If enabled, tests will exit at the first failure.",
         False),
     BoolOption(
         "skip_slow_tests",
@@ -550,21 +549,21 @@ config_options = [
         False),
     BoolOption(
         "show_long_tests",
-        """If enabled, duration of slowest tests will be shown.""",
+        "If enabled, duration of slowest tests will be shown.",
         False),
     BoolOption(
         "verbose_tests",
-        """If enabled, verbose test output will be shown.""",
+        "If enabled, verbose test output will be shown.",
         False),
     BoolOption(
         "legacy_rate_constants",
         """If enabled, rate constant calculations include third-body concentrations
-        for three-body reactions, which corresponds to the legacy implementation.
-        For Cantera 2.6, the option remains enabled (no change compared to past
-        behavior). After Cantera 2.6, the default will be to disable this option,
-        and rate constant calculations will be consistent with conventional
-        definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
-        Flow', Wiley Interscience, 2003).""",
+           for three-body reactions, which corresponds to the legacy implementation.
+           For Cantera 2.6, the option remains enabled (no change compared to past
+           behavior). After Cantera 2.6, the default will be to disable this option,
+           and rate constant calculations will be consistent with conventional
+           definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
+           Flow', Wiley Interscience, 2003).""",
         True),
 ]
 
@@ -588,7 +587,7 @@ if "help" in COMMAND_LINE_TARGETS:
         action="store_true", help="All defaults (CLI only)")
     AddOption(
         "--dev", dest="dev",
-        action="store_true", help="Append -dev (ReST only)")
+        action="store_true", help="Append -dev (reST only)")
     AddOption(
         "--output", dest="output", nargs=1, type="string",
         action="store", help="Output file (reST only)")
@@ -671,7 +670,7 @@ if os.name == "nt":
     if "64 bit" not in sys.version:
         config["target_arch"].default = "x86"
 
-    opts.AddVariables(*config.to_scons(["msvc_version", "target_arch"]))
+    opts.AddVariables(*config.to_scons(("msvc_version", "target_arch")))
 
     windows_compiler_env = Environment()
     opts.Update(windows_compiler_env)
@@ -697,7 +696,7 @@ if os.name == "nt":
     elif windows_compiler_env["toolchain"] == "mingw":
         toolchain = ["mingw", "f90"]
         extraEnvArgs["F77"] = None
-        # Next line fixes http://scons.tigris.org/issues/show_bug.cgi?id=2683
+        # Next line fixes https://github.com/SCons/scons/issues/2683
         extraEnvArgs["WINDOWS_INSERT_DEF"] = 1
 
     elif windows_compiler_env["toolchain"] == "intel":
@@ -821,7 +820,7 @@ if 'sphinx' in COMMAND_LINE_TARGETS:
 
 for arg in ARGUMENTS:
     if arg not in config:
-        print('Encountered unexpected command line argument: %r' % arg)
+        logger.error(f"Encountered unexpected command line option: '{arg}'")
         sys.exit(1)
 
 env["cantera_version"] = "2.6.0a3"

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -37,7 +37,13 @@ if TYPE_CHECKING:
 
 
 class Option:
-    """Object corresponding to SCons configuration option"""
+    """Object corresponding to SCons configuration option.
+
+    The purpose of this class is to collect system-dependent default parameters for
+    SCons configuration options, which are made available to both help text and
+    reST documentation. The class works in conjunction with the `Configuration` class
+    to select and convert system-dependent parameters to SCons configuration options.
+    """
 
     def __init__(self,
             name: str,
@@ -281,8 +287,11 @@ class EnumOption(Option):
 
 class Configuration:
     """
-    Class enabling selection of options based on attribute dictionary entries that
-    allow for differentiation between platform/compiler dependent options.
+    Class enabling selection of options based on a dictionary of `Option` objects
+    that allows for a differentiation between platform/compiler dependent options.
+
+    In addition, the class facilitiates the generation of formatted help text and
+    reST documentation.
     """
 
     header = [

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -240,6 +240,9 @@ class Option:
         out += self._build_description(backticks=False, indent=4)
         out += self._build_defaults(self.default, backticks=False, indent=2, hanging=2)
 
+        if env is None:
+            return out
+
         # Get the actual value in the current environment
         actual = env.subst(f"${self.name!s}") if self.name in env else None
 
@@ -358,14 +361,18 @@ class Configuration:
 
         return out
 
-    def to_rest(self, dev: bool=False, include_header: bool=False) -> str:
+    def to_rest(self, option: str=None, dev: bool=False) -> str:
         """Convert description of configuration options to restructured text (ReST)"""
-        message = []
-        if include_header:
-            message.append("Options List")
-            message.append(f"{'':^<{len(message[-1])}}")
-            message.append("")
-            message = ["\n".join(message)]
+        if option is None:
+            pass
+        elif option in self.options:
+            return "\n" + self.options[option].to_rest(dev=dev)
+        else:
+            raise KeyError(f"Unknown option '{option}'.")
+
+        message = ["Options List"]
+        message.append(f"{'':^<{len(message[-1])}}")
+        message.append("")
         for key in self:
             message.append(self.options[key].to_rest(dev=dev))
 
@@ -376,9 +383,9 @@ class Configuration:
         if option is None:
             pass
         elif option in self.options:
-            return self.options[option].help(env=env)
+            return "\n" + self.options[option].help(env=env)
         else:
-            raise KeyError(f"Unknown option '{option}''.")
+            raise KeyError(f"Unknown option '{option}'.")
 
         message = self.header
         message.append(f"{'':->80}")

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -371,14 +371,18 @@ class Configuration:
 
         return "\n".join(message)
 
-    def help(self, env: "SCEnvironment"=None, include_header: bool=False) -> List[str]:
+    def help(self, option: str=None, env: "SCEnvironment"=None) -> List[str]:
         """Convert configuration help for command line interface (CLI) output"""
-        message = []
-        if include_header:
-            message.extend(self.header)
-            message.append(f"{'':->80}")
-            message.append("")
-            message = ["\n".join(message)]
+        if option is None:
+            pass
+        elif option in self.options:
+            return self.options[option].help(env=env)
+        else:
+            raise KeyError(f"Unknown option '{option}''.")
+
+        message = self.header
+        message.append(f"{'':->80}")
+        message.append("")
 
         for key in self:
             message.append(self.options[key].help(env=env))

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -321,6 +321,35 @@ class Configuration:
                 raise TypeError(f"Invalid option with type '{type(item)}'")
             self.options[item.name] = item
 
+    def list_options(self):
+        """Create formatted list of available configuration options"""
+        options = list(self.options.keys())
+
+        # create alphabetically sorted list
+        options.sort()
+        n_columns = 3
+        n_rows = len(options) // n_columns
+        n_extra = len(options) % n_columns
+        if n_extra:
+            # add one additional row to fit all options
+            n_rows += 1
+            options.extend([""] * (n_columns - n_extra))
+
+        # get width of individual columns
+        max_len = [
+            max([len(options[row + col * n_rows]) + 3
+                for row in range(n_rows)])
+            for col in range(n_columns)]
+
+        # format options as alphabetically ordered columns
+        out = []
+        for row in range(n_rows):
+            line = []
+            for col in range(n_columns):
+                line.append(f"{options[row + col * n_rows]:{max_len[col]}}")
+            out.append("".join(line))
+        return "\n".join(out)
+
     def __getitem__(self, key: str) -> Union[str, bool, dict]:
         """Make class subscriptable"""
         return self.options[key]
@@ -368,7 +397,7 @@ class Configuration:
         elif option in self.options:
             return "\n" + self.options[option].to_rest(dev=dev)
         else:
-            raise KeyError(f"Unknown option '{option}'.")
+            raise KeyError(f"Unknown option '{option}'")
 
         message = ["Options List"]
         message.append(f"{'':^<{len(message[-1])}}")
@@ -385,7 +414,7 @@ class Configuration:
         elif option in self.options:
             return "\n" + self.options[option].help(env=env)
         else:
-            raise KeyError(f"Unknown option '{option}'.")
+            raise KeyError(f"Unknown option '{option}'")
 
         message = self.header
         message.append(f"{'':->80}")

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -22,7 +22,7 @@ except ImportError:
 __all__ = ("Option", "PathOption", "BoolOption", "EnumOption", "Configuration",
            "logger", "remove_directory", "remove_file", "test_results",
            "add_RegressionTest", "get_command_output", "listify", "which",
-           "ConfigBuilder", "multi_glob", "get_spawn", "help", "quoted")
+           "ConfigBuilder", "multi_glob", "get_spawn", "quoted")
 
 if TYPE_CHECKING:
     from typing import Iterable, TypeVar
@@ -1047,92 +1047,6 @@ def which(program: str) -> bool:
             if exe_file.exists() and os.access(exe_file, os.X_OK):
                 return True
     return False
-
-
-def help(env: "SCEnvironment", options: "SCVariables") -> None:
-    """Print help about configuration options and exit.
-
-    Print a nicely formatted description of a SCons configuration
-    option, its permitted values, default value, and current value
-    if different from the default.
-    """
-
-    message = [
-        textwrap.dedent(
-            """
-                **************************************************
-                *   Configuration options for building Cantera   *
-                **************************************************
-
-        The following options can be passed to SCons to customize the Cantera
-        build process. They should be given in the form:
-
-            scons build option1=value1 option2=value2
-
-        Variables set in this way will be stored in the 'cantera.conf' file and reused
-        automatically on subsequent invocations of scons. Alternatively, the
-        configuration options can be entered directly into 'cantera.conf' before
-        running 'scons build'. The format of this file is:
-
-            option1 = 'value1'
-            option2 = 'value2'
-
-                **************************************************"""
-        )
-    ]
-
-    option_wrapper = textwrap.TextWrapper(
-        initial_indent=4 * " ",
-        subsequent_indent=4 * " ",
-        width=72,
-    )
-    for opt in options.options:
-        # Extract the help description from the permitted values. Original format
-        # is in the format: "Help text (value1|value2)" for EnumVariable and
-        # BoolVariable types or "Help text" for other Variables
-        if opt.help.endswith(")"):
-            help, values = opt.help.rsplit("(", maxsplit=1)
-            values = values.rstrip(")").strip().replace("|", " | ")
-            if not values:
-                values = "string"
-        else:
-            help = opt.help
-            values = "string"
-
-        # First line: "* option-name: [ choice1 | choice2 ]"
-        lines = [f"* {opt.key}: [ {values} ]"]
-
-        # Help text, wrapped and indented 4 spaces
-        lines.extend(option_wrapper.wrap(re.sub(r"\s+", " ", help)))
-
-        # Fix the representation of Boolean options, which are stored as
-        # Python bool types
-        default = opt.default
-        if default is True:
-            default = "yes"
-        elif default is False:
-            default = "no"
-
-        lines.append(f"    - default: {default!r}")
-
-        # Get the actual value in the current environment
-        if opt.key in env:
-            actual = env.subst(f"${opt.key!s}")
-        else:
-            actual = None
-
-        # Fix the representation of Boolean options to match the default values
-        if actual == "True":
-            actual = "yes"
-        elif actual == "False":
-            actual = "no"
-
-        # Print the value if it differs from the default
-        if actual != default:
-            lines.append(f"    - actual: {actual!r}")
-        message.append("\n".join(lines))
-
-    logger.info("\n\n".join(message), print_level=False)
 
 
 def listify(value: "Union[str, Iterable]") -> "List[str]":


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Refactor `SConstruct`
- Implement `scons help --restructured-text` to create ReST output
- Refactor `scons help` to avoid redundant parsers
- Implement help on individual option via `scons help --option=<name_of_option>`
- Replaces #1136

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Addresses Cantera/cantera-website#26

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
$ scons help --restructured-text
[...]
$ scons help --restructured-text --dev --output=config-options-dev.rst
[...]
```
or
```
$ scons help --restructured-text --option=prefix
scons: Reading SConscript files ...
INFO: SCons is using the following Python interpreter: /usr/bin/python3

.. _prefix:

*  ``prefix``: [ ``path/to/prefix`` ]
   Set this to the directory where Cantera should be installed. On Windows
   systems, ``$ProgramFiles`` typically refers to ``"C:\Program Files"``.

   -  default: platform dependent
      -  Windows: ``'$ProgramFiles\Cantera'``
      -  Otherwise: ``'/usr/local'``
```
Further
```
$ scons help --option=CXX
scons: Reading SConscript files ...
INFO: SCons is using the following Python interpreter: /usr/bin/python3

* CXX: [ string ]
    The C++ compiler to use.
    - default: '${CXX}'
    - actual: 'g++'
```
and
```
$ scons help --defaults --option=cc_flags
scons: Reading SConscript files ...
INFO: SCons is using the following Python interpreter: /usr/bin/python3

* cc_flags: [ string ]
    Compiler flags passed to both the C and C++ compilers, regardless of
    optimization level.
    - default: compiler dependent
      - If using MSVC: '/MD /nologo /D_SCL_SECURE_NO_WARNINGS /D_CRT_SECURE_NO_WARNINGS'
      - If using ICC: '-vec-report0 -diag-disable 1478'
      - If using Clang: '-fcolor-diagnostics'
      - Otherwise: ''
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
