### PR TITLE
[SCons] Add newline in nested reST lists

### DIFF
--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -211,7 +211,7 @@ class Option:
             comment = "toolchain"
         else:
             comment = "platform"
-        out = [f"{level1}{title}: {comment} dependent"]
+        out = [f"{level1}{title}: {comment} dependent\n"]
 
         # Compiler/toolchain options
         if comment in ["compiler", "toolchain"]:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

The reST output introduced in #1137 is missing a newline between nested lists, which is fixed by this PR. Fix is needed for Cantera/cantera-website#160.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
