### PR TITLE
Modify third body efficiencies using modify_reaction

### DIFF
--- a/include/cantera/kinetics/ThirdBodyCalc.h
+++ b/include/cantera/kinetics/ThirdBodyCalc.h
@@ -32,6 +32,22 @@ public:
             m_eff.back().push_back(eff.second - dflt);
         }
     }
+    
+    void modifyEfficiencies(size_t rxnNumber, const std::map<size_t, double>& enhanced,
+                 double dflt=1.0) {
+        auto it = find(m_reaction_index.begin(), m_reaction_index.end(), rxnNumber);
+        if (it != m_reaction_index.end()) {
+            int index = it - m_reaction_index.begin();  
+            for (const auto& eff : enhanced) {
+                auto si = find(m_species[index].begin(), 
+                               m_species[index].end(), eff.first);   
+                if (it != m_reaction_index.end()) {
+                    int j = si - m_species[index].begin();
+                    m_eff[index][j] = (eff.second - m_default[index]);
+                }
+            }
+        }
+    }
 
     void update(const vector_fp& conc, double ctot, double* work) {
         for (size_t i = 0; i < m_species.size(); i++) {

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -395,6 +395,16 @@ void GasKinetics::modifyReaction(size_t i, shared_ptr<Reaction> rNew)
 void GasKinetics::modifyThreeBodyReaction(size_t i, ThreeBodyReaction2& r)
 {
     m_rates.replace(i, r.rate);
+    
+    map<size_t, double> efficiencies;
+    for (const auto& eff : r.third_body.efficiencies) {
+        size_t k = kineticsSpeciesIndex(eff.first);
+        if (k != npos) {
+            efficiencies[k] = eff.second;
+        }
+    }
+    m_3b_concm.modifyEfficiencies(i, efficiencies,
+                       r.third_body.default_efficiency);
 }
 
 void GasKinetics::modifyFalloffReaction(size_t i, FalloffReaction& r)
@@ -403,6 +413,16 @@ void GasKinetics::modifyFalloffReaction(size_t i, FalloffReaction& r)
     m_falloff_high_rates.replace(iFall, r.high_rate);
     m_falloff_low_rates.replace(iFall, r.low_rate);
     m_falloffn.replace(iFall, r.falloff);
+    
+    map<size_t, double> efficiencies;
+    for (const auto& eff : r.third_body.efficiencies) {
+        size_t k = kineticsSpeciesIndex(eff.first);
+        if (k != npos) {
+            efficiencies[k] = eff.second;
+        }
+    }
+    m_falloff_concm.modifyEfficiencies(iFall, efficiencies,
+                       r.third_body.default_efficiency);
 }
 
 void GasKinetics::modifyPlogReaction(size_t i, PlogReaction2& r)


### PR DESCRIPTION
**Changes proposed in this pull request**

Until now, when modifying a reaction using the `modifyReaction` function in C++ (or `modify_reaction` from Python), only the rates are modified, not the third-body efficiencies. Although the composition map that stores the efficiencies can be modified from Python (using get/set function `efficiencies`), these modifications are not taken into account when consequently calculating the reaction rates.

In this pull request, the functionality of `modifyReaction` is extended to also include modifications to third-body efficiencies. This is possible with only a few additions to `GasKinetics.cpp` and `ThirdBodyCalc.h`

For testing, I modified the `add_falloff_reaction` test in `kineticsFromScratch.cpp`: I added a reaction with wrong third-body-efficiencies first, verified that this gives wrong results, then used `modifyReaction` to correct the third-body efficiencies and verify the result is as expected.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
