### PR TITLE
Add Python 3.10 to the CI runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -262,7 +262,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        sundials-ver: [ 2, 3, 4, 5.7 ]
+        sundials-ver: [ 2, 3, 4, 5.8 ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -112,20 +112,33 @@ jobs:
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
       run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas scipy pytest
-        pytest-github-actions-annotate-failures
+        pytest-github-actions-annotate-failures gcovr
     - name: Build Cantera
       run: |
         python3 `which scons` build blas_lapack_libs=lapack,blas coverage=y \
-        optimize=n skip_slow_tests=y no_optimize_flags=-DNDEBUG env_vars=all -j2 --debug=time
+        optimize=n skip_slow_tests=y no_optimize_flags='-DNDEBUG -O0' \
+        FORTRANFLAGS='-O0' env_vars=all -j2 --debug=time
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
-      env:
-        GITHUB_ACTIONS: "true"
+    - name: Process coverage files
+      run: |
+        gcovr --root . --exclude-unreachable-branches --exclude-throw-branches \
+        --exclude-directories '\.sconf_temp' --exclude-directories 'build/ext$' \
+        --exclude '.*ext.*' --exclude '(.+/)?_cantera\.cpp$' --exclude '^test.*' \
+        --xml coverage.xml --html-details htmlcoverage.html --txt
+    - name: Archive code coverage results
+      uses: actions/upload-artifact@v2
+      with:
+        name: code-coverage-report
+        path: htmlcoverage*
+        retention-days: 5
     - name: Upload Coverage to Codecov
-      run: bash <(curl -s https://codecov.io/bash)
-      env:
-        CODECOV_TOKEN: ${{ secrets.CODECOV_TOKEN }}
+      uses: codecov/codecov-action@v2
+      with:
+        verbose: true
+        files: ./coverage.xml
+        fail_ci_if_error: true
 
   docs:
     name: Build docs

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.6', '3.9', '3.10' ]
         os: ['ubuntu-18.04', 'ubuntu-20.04']
       fail-fast: false
     steps:
@@ -36,7 +36,7 @@ jobs:
     - name: Install Apt dependencies
       run: |
         sudo apt update
-        sudo apt install libboost-dev gfortran
+        sudo apt install libboost-dev gfortran libopenmpi-dev
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
@@ -47,15 +47,13 @@ jobs:
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
-      env:
-        GITHUB_ACTIONS: "true"
 
   macos-multiple-pythons:
     name: macOS with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
     strategy:
       matrix:
-        python-version: [ '3.7', '3.8', '3.9' ]
+        python-version: [ '3.7', '3.9', '3.10' ]
         os: ['macos-10.15']
       fail-fast: false
     steps:
@@ -88,8 +86,6 @@ jobs:
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
-      env:
-        GITHUB_ACTIONS: "true"
 
   # Coverage is its own job because macOS builds of the samples
   # use Homebrew gfortran which is not compatible for coverage
@@ -203,7 +199,7 @@ jobs:
     runs-on: ubuntu-18.04
     strategy:
       matrix:
-        python-version: ['3.6', '3.7', '3.8', '3.9']
+        python-version: ['3.6', '3.9', '3.10']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -315,7 +311,7 @@ jobs:
       matrix:
         os: ['windows-2019']
         vs-toolset: ['14.0', '14.2']
-        python-version: [ '3.6', '3.7', '3.8', '3.9' ]
+        python-version: [ '3.6', '3.9', '3.10' ]
         # Must use windows-2016 image because it installs VS2017 (MSVC 14.1)
         # Scons cannot find MSVC 14.1 when VS2019 is installed
         include:
@@ -370,8 +366,6 @@ jobs:
         shell: cmd
       - name: Test Cantera
         run: scons test show_long_tests=yes verbose_tests=yes --debug=time
-        env:
-          GITHUB_ACTIONS: "true"
 
   # Adapted from https://www.scivision.dev/intel-oneapi-github-actions/
   linux-intel-oneapi:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -185,6 +185,7 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: build/docs.tar.gz
+          name: docs
           retention-days: 2
       # The known_hosts key is generated with `ssh-keygen -F cantera.org` from a
       # machine that has previously logged in to cantera.org and trusts
@@ -247,6 +248,8 @@ jobs:
         uses: actions/upload-artifact@v2
         with:
           path: results.txt
+          retention-days: 2
+          name: example-results
         # Run this step if the job was successful or failed, but not if it was cancelled
         # Using always() would run this step if the job was cancelled as well.
         if: failure() || success()

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -48,6 +48,36 @@ jobs:
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
 
+  clang-compiler:
+    name: LLVM/Clang with Python 3.8
+    runs-on: ubuntu-20.04
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout the repository
+      with:
+        submodules: recursive
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+    - name: Install Apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install libboost-dev gfortran libomp-dev libomp5
+    - name: Upgrade pip
+      run: python3 -m pip install -U pip setuptools wheel
+    - name: Install Python dependencies
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
+        pytest-github-actions-annotate-failures
+    - name: Build Cantera
+      run: python3 `which scons` build env_vars=all
+        CXX=clang++-12 CC=clang-12 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
+        -j2 debug=n --debug=time
+    - name: Test Cantera
+      run:
+        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
+
   macos-multiple-pythons:
     name: macOS with Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -167,12 +167,12 @@ def generate_license(target, source, env):
 
 
 localenv["license_files"] = license_files
-license = build(localenv.Command("LICENSE.txt", license_files.values(),
+license = build(localenv.Command("LICENSE.txt", list(license_files.values()),
                                  generate_license))
 env["license_target"] = license
 install('$inst_docdir', license)
 
 if env['OS'] == 'Windows':
     # RTF version is required for Windows installer
-    build(localenv.Command("LICENSE.rtf", license_files.values(),
+    build(localenv.Command("LICENSE.rtf", list(license_files.values()),
                            generate_license))


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- [x] Add Python 3.10 to the CI runners
- [x] Clean up the workflow file
- [x] Use the new Codecov action instead of the Bash script. The Bash script is deprecated and possible insecure.
- [x] Add OpenMP to test the samples
- [ ] ~Add Fedora test runner and fix #1149~
- [x] Fix #1147 
- [X] Replace SUNDIALS 5.7 with 5.8
- [x] Add the clang compiler as a job? Clang-9 is installed on Ubuntu 18.04 runners

I decided not to look into #1149 at this time because I suspect that's related to `setuptools` and how it processes arguments. I think that needs some more discussion in the issue before we try to tackle a fix for it.

Otherwise, I think the changes above are fairly self-explanatory. The only fly in the ointment is the change in coverage, due to using `gcovr` to collect coverage from the runs, rather than letting CodeCov handle it magically. 🤷 The reason seems to be how branches are counted. Doesn't seem to be much to do, and we only use the coverage metric as a relative number anyways (as in, did it go up or down for a given PR), so the change here is unfortunate but not terrible.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review

As discussed in [#1075](https://github.com/Cantera/cantera/pull/1075#issuecomment-980061291)