### PR TITLE
make explicit py_version_short

### DIFF
--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -136,7 +136,7 @@ elif localenv['python_prefix']:
         # 64-bit RHEL / Fedora etc. or e.g. x32 Gentoo profile
         extra = localenv.subst(
             ' --prefix=${{python_prefix}}'
-            ' --install-lib=${{python_prefix}}/${{libdirname}}/python{}/site-packages'.format(py_version))
+            ' --install-lib=${{python_prefix}}/${{libdirname}}/python{}/site-packages'.format(py_version_short))
     else:
         extra = '--user'
         localenv.AppendENVPath(
@@ -178,4 +178,4 @@ elif localenv['PYTHON_INSTALLER'] == 'debian':
 elif localenv['PYTHON_INSTALLER'] == 'binary':
     install(localenv.Command, 'dummy', mod,
             build_cmd + ' bdist_msi --dist-dir=../..' +
-            ' --target-version=' + py_version)
+            ' --target-version=' + py_version_short)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**
Remote builds on COPR were failing for Fedora/RHEL due to the variable `py_version` not being found (see #1146). 
This is remediated by using the previously-defined `py_version_short` instead, which is the correct format for Fedora and Red Hat systems.
Exactly why this only affected remote builds is unknown, but the fix made here builds and tests fine on a local F35 setup and in COPR for F33/F34/F35/Rawhide.
Remote (COPR) builds for EPEL 8/CentOS Stream 8 now also pass on the python version (i.e. #1146 is fixed), but fail on error reported in #1147.

Closes #1146 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
