### PR TITLE
Conditional rate updates for MultiRate reactions

### DIFF
--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -67,7 +67,8 @@ public:
     //! Update data common to reaction rates of a specific type
     //! @param bulk  object representing bulk phase
     //! @param kin  object representing kinetics
-    virtual void update(const ThermoPhase& bulk, const Kinetics& kin) = 0;
+    //! @returns flag indicating reaction rates need to be re-evaluated
+    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) = 0;
 
     //! Get the rate for a single reaction. Used to implement ReactionRate::eval.
     virtual double evalSingle(ReactionRate& rate) = 0;

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -60,8 +60,10 @@ void GasKinetics::update_rates_T()
         //      KineticsAddSpecies - add_species_sequential)
         //      a work-around is to call GasKinetics::invalidateCache()
         for (auto& rates : m_bulk_rates) {
-            rates->update(thermo(), *this);
-            rates->getRateConstants(m_rfn.data());
+            bool changed = rates->update(thermo(), *this);
+            if (changed) {
+                rates->getRateConstants(m_rfn.data());
+            }
         }
 
         // P-log reactions (legacy)

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -983,6 +983,7 @@ bool Phase::ready() const
 }
 
 void Phase::invalidateCache() {
+    m_stateNum++;
     m_cache.clear();
 }
 

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -427,9 +427,6 @@ public:
         p.setState_TPX(1200, 5*OneAtm, X);
         p_ref.setState_TPX(1200, 5*OneAtm, X);
 
-        // need to invalidate cache to force update
-        kin_ref->invalidateCache();
-
         vector_fp k(kin.nReactions()), k_ref(kin_ref->nReactions());
         vector_fp w(kin.nTotalSpecies()), w_ref(kin_ref->nTotalSpecies());
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Use the `RateData::update` method (executed once per reaction type) to determine whether or not both `updateFromStruct` and `evalFromStruct` need to be called for all reactions of that type.
- Remove other conditions that could cause evaluation of `BulkKinetics::m_bulk_rates` to be skipped incorrectly

**If applicable, provide an example illustrating new features this pull request is introducing**

The timing results from `custom_reactions.py` show an improvement compared to the "legacy" framework, with the new framework now outperforming the "legacy" one.

- Current `main` branch:
  - New framework (YAML): 257.54 ms (T_final=2736.60)
  - One Python reaction: 273.18 ms (T_final=2736.60) ... +6.07%
  - Old framework (XML): 253.31 ms (T_final=2736.60) ... -1.64%

- This PR:
  - New framework (YAML): 248.20 ms (T_final=2736.60)
  - One Python reaction: 268.20 ms (T_final=2736.60) ... +8.06%
  - Old framework (XML): 254.35 ms (T_final=2736.60) ... +2.48%

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
