### PR TITLE
Update ReactionData and consolidate update strategies

### DIFF
--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -272,10 +272,13 @@ public:
     virtual void getParameters(AnyMap& node) const;
 
     double evalFromStruct(const BlowersMaselData& shared_data) {
-        if (shared_data.ready && m_rate_index != npos) {
-            m_deltaH_R = shared_data.dH[m_rate_index] / GasConstant;
+        double deltaH_R;
+        if (!shared_data.ready || m_rate_index == npos) {
+            deltaH_R = shared_data.dH[0] / GasConstant;
+        } else {
+            deltaH_R = shared_data.dH[m_rate_index] / GasConstant;
         }
-        double Ea_R = activationEnergy_R(m_deltaH_R);
+        double Ea_R = activationEnergy_R(deltaH_R);
         return m_A * std::exp(m_b * shared_data.logT - Ea_R * shared_data.recipT);
     }
 
@@ -295,8 +298,11 @@ public:
     }
 
     //! Return the actual activation energy [J/kmol]
-    double activationEnergy() const {
-        return activationEnergy_R(m_deltaH_R) * GasConstant;
+    /*!
+     *  @param deltaH  Enthalpy change of reaction [J/kmol]
+     */
+    double activationEnergy(double deltaH) const {
+        return activationEnergy_R(deltaH / GasConstant) * GasConstant;
     }
 
     //! Return the intrinsic activation energy [J/kmol]
@@ -309,22 +315,8 @@ public:
         return m_w_R * GasConstant;
     }
 
-    //! Enthalpy change of reaction used to adjust activation energy [J/kmol]
-    double deltaH() const {
-        return m_deltaH_R * GasConstant;
-    }
-
-    //! Set enthalpy change without a Kinetics object (for testing purposes).
-    //! Once the object is linked to a Kinetics object, the enthalpy change
-    //! is set during the update method, which will overwrite this value.
-    void setDeltaH(double dH) {
-        m_deltaH_R = dH / GasConstant;
-    }
-
 protected:
     double m_w_R; //!< Bond dissociation energy (in temperature units)
-
-    double m_deltaH_R; //!< Delta H of the reaction (in temperature units)
 };
 
 }

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -273,10 +273,10 @@ public:
 
     double evalFromStruct(const BlowersMaselData& shared_data) {
         double deltaH_R;
-        if (!shared_data.ready || m_rate_index == npos) {
-            deltaH_R = shared_data.dH[0] / GasConstant;
-        } else {
+        if (shared_data.ready) {
             deltaH_R = shared_data.dH[m_rate_index] / GasConstant;
+        } else {
+            deltaH_R = shared_data.dH[0] / GasConstant;
         }
         double Ea_R = activationEnergy_R(deltaH_R);
         return m_A * std::exp(m_b * shared_data.logT - Ea_R * shared_data.recipT);

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -271,13 +271,10 @@ public:
 
     virtual void getParameters(AnyMap& node) const;
 
-    void updateFromStruct(const BlowersMaselData& shared_data) {
+    double evalFromStruct(const BlowersMaselData& shared_data) {
         if (shared_data.ready && m_rate_index != npos) {
             m_deltaH_R = shared_data.dH[m_rate_index] / GasConstant;
         }
-    }
-
-    double evalFromStruct(const BlowersMaselData& shared_data) {
         double Ea_R = activationEnergy_R(m_deltaH_R);
         return m_A * std::exp(m_b * shared_data.logT - Ea_R * shared_data.recipT);
     }

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -169,7 +169,7 @@ public:
 
     //! Evaluate reaction rate
     //! @param shared_data  data shared by all reactions of a given type
-    double evalFromStruct(const ArrheniusData& shared_data) const {
+    double evalFromStruct(const ReactionData& shared_data) const {
         return m_A * std::exp(m_b * shared_data.logT - m_Ea_R * shared_data.recipT);
     }
 
@@ -178,7 +178,7 @@ public:
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
-    virtual double ddTScaledFromStruct(const ArrheniusData& shared_data) const {
+    virtual double ddTScaledFromStruct(const ReactionData& shared_data) const {
         return (m_Ea_R * shared_data.recipT + m_b) * shared_data.recipT;
     }
 
@@ -272,7 +272,7 @@ public:
     virtual void getParameters(AnyMap& node) const;
 
     void updateFromStruct(const BlowersMaselData& shared_data) {
-        if (shared_data.finalized && m_rate_index != npos) {
+        if (shared_data.ready && m_rate_index != npos) {
             m_deltaH_R = shared_data.dH[m_rate_index] / GasConstant;
         }
     }

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -174,12 +174,12 @@ public:
     }
 
     //! Evaluate derivative of reaction rate with respect to temperature
+    //! divided by reaction rate
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
-    virtual double ddTFromStruct(const ArrheniusData& shared_data) const {
-        return m_A * (m_b + m_Ea_R * shared_data.recipT) *
-            std::exp((m_b - 1) * shared_data.logT - m_Ea_R * shared_data.recipT);
+    virtual double ddTScaledFromStruct(const ArrheniusData& shared_data) const {
+        return (m_Ea_R * shared_data.recipT + m_b) * shared_data.recipT;
     }
 
     //! Return the activation energy *Ea* [J/kmol]

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -317,9 +317,9 @@ public:
         return m_deltaH_R * GasConstant;
     }
 
-    //! Set enthalpy change without Kinetics object. In most cases, the enthalpy
-    //! change is set during the update method, which, however, requires the
-    //! object to be linked to a Kinetics object.
+    //! Set enthalpy change without a Kinetics object (for testing purposes).
+    //! Once the object is linked to a Kinetics object, the enthalpy change
+    //! is set during the update method, which will overwrite this value.
     void setDeltaH(double dH) {
         m_deltaH_R = dH / GasConstant;
     }

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -44,7 +44,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<CustomFunc1Rate, CustomFunc1Data>);
+        return unique_ptr<MultiRateBase>(new MultiBulkRate<CustomFunc1Rate, ArrheniusData>);
     }
 
     const std::string type() const override { return "custom-rate-function"; }
@@ -56,7 +56,7 @@ public:
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
-    double evalFromStruct(const CustomFunc1Data& shared_data) const;
+    double evalFromStruct(const ArrheniusData& shared_data) const;
 
     //! Set custom rate
     /**

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -183,7 +183,9 @@ public:
         return m_thirdBodyConcentration;
     }
 
-    //! Set buffered value of third-body concentration
+    //! Set third-body concentration without a Kinetics object (for testing purposes).
+    //! Once the object is linked to a Kinetics object, the third-body concentration
+    //! is set during the update method, which will overwrite this value.
     void setThirdBodyConcentration(double value) {
         m_thirdBodyConcentration = value;
     }

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -144,7 +144,7 @@ public:
         updateTemp(shared_data.temperature, m_work.data());
         m_rc_low = m_lowRate.evalFromStruct(shared_data);
         m_rc_high = m_highRate.evalFromStruct(shared_data);
-        if (shared_data.finalized && m_rate_index != npos) {
+        if (shared_data.ready && m_rate_index != npos) {
             m_thirdBodyConcentration = shared_data.conc_3b[m_rate_index];
         }
     }

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -146,10 +146,10 @@ public:
         m_rc_low = m_lowRate.evalFromStruct(shared_data);
         m_rc_high = m_highRate.evalFromStruct(shared_data);
         double thirdBodyConcentration;
-        if (!shared_data.ready || m_rate_index == npos) {
-            thirdBodyConcentration = shared_data.conc_3b[0];
-        } else {
+        if (shared_data.ready) {
             thirdBodyConcentration = shared_data.conc_3b[m_rate_index];
+        } else {
+            thirdBodyConcentration = shared_data.conc_3b[0];
         }
         double pr = thirdBodyConcentration * m_rc_low / (m_rc_high + SmallNumber);
 

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -32,7 +32,6 @@ public:
     FalloffRate()
         : m_chemicallyActivated(false)
         , m_negativeA_ok(false)
-        , m_thirdBodyConcentration(NAN)
         , m_rc_low(NAN)
         , m_rc_high(NAN)
     {
@@ -146,10 +145,13 @@ public:
         updateTemp(shared_data.temperature, m_work.data());
         m_rc_low = m_lowRate.evalFromStruct(shared_data);
         m_rc_high = m_highRate.evalFromStruct(shared_data);
-        if (shared_data.ready && m_rate_index != npos) {
-            m_thirdBodyConcentration = shared_data.conc_3b[m_rate_index];
+        double thirdBodyConcentration;
+        if (!shared_data.ready || m_rate_index == npos) {
+            thirdBodyConcentration = shared_data.conc_3b[0];
+        } else {
+            thirdBodyConcentration = shared_data.conc_3b[m_rate_index];
         }
-        double pr = m_thirdBodyConcentration * m_rc_low / (m_rc_high + SmallNumber);
+        double pr = thirdBodyConcentration * m_rc_low / (m_rc_high + SmallNumber);
 
         // Apply falloff function
         if (m_chemicallyActivated) {
@@ -173,18 +175,6 @@ public:
     //! Set flag indicating whether negative A values are permitted
     void setAllowNegativePreExponentialFactor(bool value) {
         m_negativeA_ok = value;
-    }
-
-    //! Get buffered value of third-body concentration
-    double thirdBodyConcentration() const {
-        return m_thirdBodyConcentration;
-    }
-
-    //! Set third-body concentration without a Kinetics object (for testing purposes).
-    //! Once the object is linked to a Kinetics object, the third-body concentration
-    //! is set during the update method, which will overwrite this value.
-    void setThirdBodyConcentration(double value) {
-        m_thirdBodyConcentration = value;
     }
 
     //! Get flag indicating whether reaction is chemically activated
@@ -219,13 +209,10 @@ protected:
 
     bool m_chemicallyActivated; //!< Flag labeling reaction as chemically activated
     bool m_negativeA_ok; //!< Flag indicating whether negative A values are permitted
-    double m_thirdBodyConcentration; //!< third-body concentration
 
     double m_rc_low; //!< Evaluated reaction rate in the low-pressure limit
     double m_rc_high; //!< Evaluated reaction rate in the high-pressure limit
     vector_fp m_work; //!< Work vector
-
-    double m_conc_3b; //!< Third body concentration
 };
 
 

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -102,9 +102,11 @@ public:
 
     //! Evaluate falloff function at current conditions
     double evalF(double T, double conc3b) {
+        updateTemp(T, m_work.data());
         FalloffData data;
         data.update(T);
-        updateFromStruct(data);
+        m_rc_low = m_lowRate.evalFromStruct(data);
+        m_rc_high = m_highRate.evalFromStruct(data);
         double pr = conc3b * m_rc_low / (m_rc_high + SmallNumber);
         return F(pr, m_work.data());
     }
@@ -138,20 +140,15 @@ public:
 
     virtual void getParameters(AnyMap& node) const;
 
-    //! Update information specific to reaction
+    //! Evaluate reaction rate
     //! @param shared_data  data shared by all reactions of a given type
-    virtual void updateFromStruct(const FalloffData& shared_data) {
+    virtual double evalFromStruct(const FalloffData& shared_data) {
         updateTemp(shared_data.temperature, m_work.data());
         m_rc_low = m_lowRate.evalFromStruct(shared_data);
         m_rc_high = m_highRate.evalFromStruct(shared_data);
         if (shared_data.ready && m_rate_index != npos) {
             m_thirdBodyConcentration = shared_data.conc_3b[m_rate_index];
         }
-    }
-
-    //! Evaluate reaction rate
-    //! @param shared_data  data shared by all reactions of a given type
-    virtual double evalFromStruct(const FalloffData& shared_data) const {
         double pr = m_thirdBodyConcentration * m_rc_low / (m_rc_high + SmallNumber);
 
         // Apply falloff function

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -38,7 +38,10 @@ public:
         return "Gas";
     }
 
-    virtual void getThirdBodyConcentrations(double* concm) const;
+    virtual void getThirdBodyConcentrations(double* concm);
+    virtual const vector_fp& thirdBodyConcentrations() const {
+        return m_concm;
+    }
 
     //! @}
     //! @name Reaction Rates Of Progress

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -67,6 +67,61 @@ public:
     //! reactions.
     virtual void update_rates_C();
 
+private:
+    //! @name Internal service methods
+    /*!
+     * These methods are for @internal use, and seek to avoid code duplication
+     * while evaluating terms used for rate constants, rates of progress, and
+     * their derivatives. Frequently used methods are defined in the header
+     * file and use raw data pointers to allow inlining and avoid overhead.
+     */
+    //! @{
+
+    //! Calculate rate coefficients
+    void processFwdRateCoefficients(double* ropf)
+    {
+        update_rates_C();
+        update_rates_T();
+
+        // copy rate coefficients into ropf
+        copy(m_rfn.begin(), m_rfn.end(), ropf);
+
+        if (m_falloff_high_rates.nReactions()) {
+            processFalloffReactions(ropf);
+        }
+
+        // Scale the forward rate coefficient by the perturbation factor
+        for (size_t i = 0; i < nReactions(); ++i) {
+            ropf[i] *= m_perturb[i];
+        }
+    }
+
+    //! Multiply rate with third-body collider concentrations
+    void processThirdBodies(double* rop)
+    {
+        // multiply rop by enhanced 3b conc for all 3b rxns
+        if (!concm_3b_values.empty()) {
+            m_3b_concm.multiply(rop, concm_3b_values.data());
+        }
+
+        // reactions involving third body
+        if (!m_concm.empty()) {
+            m_multi_concm.multiply(rop, m_concm.data());
+        }
+    }
+
+    //! Multiply rate with inverse equilibrium constant
+    void processEquilibriumConstants(double* rop)
+    {
+        // For reverse rates computed from thermochemistry, multiply the forward
+        // rate coefficients by the reciprocals of the equilibrium constants
+        for (size_t i = 0; i < nReactions(); ++i) {
+            rop[i] *= m_rkcn[i];
+        }
+    }
+
+    //! @}
+
 protected:
     //! Reaction index of each falloff reaction
     std::vector<size_t> m_fallindx; //!< @deprecated (legacy only)
@@ -106,7 +161,7 @@ protected:
     // transitional reaction types that are marked as '-legacy'
 
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
-    void processFalloffReactions();
+    void processFalloffReactions(double* ropf);
 
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
     void addThreeBodyReaction(ThreeBodyReaction2& r);

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -70,62 +70,26 @@ public:
     //! reactions.
     virtual void update_rates_C();
 
-private:
+protected:
     //! @name Internal service methods
     /*!
      * These methods are for @internal use, and seek to avoid code duplication
      * while evaluating terms used for rate constants, rates of progress, and
-     * their derivatives. Frequently used methods are defined in the header
-     * file and use raw data pointers to allow inlining and avoid overhead.
+     * their derivatives.
      */
     //! @{
 
     //! Calculate rate coefficients
-    void processFwdRateCoefficients(double* ropf)
-    {
-        update_rates_C();
-        update_rates_T();
-
-        // copy rate coefficients into ropf
-        copy(m_rfn.begin(), m_rfn.end(), ropf);
-
-        if (m_falloff_high_rates.nReactions()) {
-            processFalloffReactions(ropf);
-        }
-
-        // Scale the forward rate coefficient by the perturbation factor
-        for (size_t i = 0; i < nReactions(); ++i) {
-            ropf[i] *= m_perturb[i];
-        }
-    }
+    void processFwdRateCoefficients(double* ropf);
 
     //! Multiply rate with third-body collider concentrations
-    void processThirdBodies(double* rop)
-    {
-        // multiply rop by enhanced 3b conc for all 3b rxns
-        if (!concm_3b_values.empty()) {
-            m_3b_concm.multiply(rop, concm_3b_values.data());
-        }
-
-        // reactions involving third body
-        if (!m_concm.empty()) {
-            m_multi_concm.multiply(rop, m_concm.data());
-        }
-    }
+    void processThirdBodies(double* rop);
 
     //! Multiply rate with inverse equilibrium constant
-    void processEquilibriumConstants(double* rop)
-    {
-        // For reverse rates computed from thermochemistry, multiply the forward
-        // rate coefficients by the reciprocals of the equilibrium constants
-        for (size_t i = 0; i < nReactions(); ++i) {
-            rop[i] *= m_rkcn[i];
-        }
-    }
+    void processEquilibriumConstants(double* rop);
 
     //! @}
 
-protected:
     //! Reaction index of each falloff reaction
     std::vector<size_t> m_fallindx; //!< @deprecated (legacy only)
 

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -513,15 +513,25 @@ public:
     }
 
     /**
-     * Return the vector of values of effective concentrations of third-body
+     * Return a vector of values of effective concentrations of third-body
      * collision partners of any reaction. Entries for reactions not involving
      * third-body collision parters are not defined and set to not-a-number.
      *
      * @param concm  Output vector of effective third-body concentrations.
      *      Length: nReactions().
      */
-    virtual void getThirdBodyConcentrations(double* concm) const {
+    virtual void getThirdBodyConcentrations(double* concm) {
         throw NotImplementedError("Kinetics::getThirdBodyConcentrations",
+            "Not applicable/implemented for Kinetics object of type '{}'",
+            kineticsType());
+    }
+
+    /**
+     * Provide direct access to current third-body concentration values.
+     * @see getThirdBodyConcentrations.
+     */
+    virtual const vector_fp& thirdBodyConcentrations() const {
+        throw NotImplementedError("Kinetics::thirdBodyConcentrations",
             "Not applicable/implemented for Kinetics object of type '{}'",
             kineticsType());
     }

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -79,8 +79,7 @@ public:
 
     virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override {
         // update common data once for each reaction type
-        std::pair<bool, bool> changed = m_shared.update(bulk, kin);
-        return changed.second;
+        return m_shared.update(bulk, kin);
     }
 
     virtual double evalSingle(ReactionRate& rate) override

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -72,14 +72,9 @@ public:
         m_shared.update(T);
     }
 
-    virtual void update(double T, double P) override {
+    virtual void update(double T, double extra) override {
         // update common data once for each reaction type
-        m_shared.update(T, P);
-    }
-
-    virtual void update(double T, double P, double extra) override {
-        // update common data once for each reaction type
-        m_shared.update(T, P, extra);
+        m_shared.update(T, extra);
     }
 
     virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override {

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -21,7 +21,7 @@ template <class RateType, class DataType>
 class MultiBulkRate final : public MultiRateBase
 {
     CT_DEFINE_HAS_MEMBER(has_update, updateFromStruct)
-    CT_DEFINE_HAS_MEMBER(has_ddT, ddTFromStruct)
+    CT_DEFINE_HAS_MEMBER(has_ddT, ddTScaledFromStruct)
 
 public:
     virtual std::string type() override {
@@ -101,7 +101,7 @@ public:
     {
         RateType& R = static_cast<RateType&>(rate);
         _updateRate(R);
-        return _get_ddT(R);
+        return R.evalFromStruct(m_shared) * _get_ddTScaled(R);
     }
 
 protected:
@@ -133,17 +133,18 @@ protected:
     void _updateRate(RateType& rate) {
     }
 
-    //! Helper function to evaluate temperature derivative for rate types that implement
-    //! the `ddTFromStruct` method.
+    //! Helper function to evaluate temperature derivative for rate types that
+    //! implement the `ddTScaledFromStruct` method.
     template <typename T=RateType, typename std::enable_if<has_ddT<T>::value, bool>::type = true>
-    double _get_ddT(RateType& rate) {
-        return rate.ddTFromStruct(m_shared);
+    double _get_ddTScaled(RateType& rate) {
+        return rate.ddTScaledFromStruct(m_shared);
     }
 
-    //! Helper function for rate types that do not implement `ddTFromStruct`
+    //! Helper function for rate types that do not implement `ddTScaledFromStruct`
     template <typename T=RateType, typename std::enable_if<!has_ddT<T>::value, bool>::type = true>
-    double _get_ddT(RateType& rate) {
-        throw NotImplementedError("ReactionRate::ddTFromStruct", "For rate of type {}", rate.type());
+    double _get_ddTScaled(RateType& rate) {
+        throw NotImplementedError("ReactionRate::ddTScaledFromStruct",
+            "For rate of type {}", rate.type());
     }
 
     //! Vector of pairs of reaction rates indices and reaction rates

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -77,6 +77,11 @@ public:
         m_shared.update(T, P);
     }
 
+    virtual void update(double T, double P, double extra) override {
+        // update common data once for each reaction type
+        m_shared.update(T, P, extra);
+    }
+
     virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override {
         // update common data once for each reaction type
         return m_shared.update(bulk, kin);

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -93,27 +93,7 @@ public:
         return R.evalFromStruct(m_shared);
     }
 
-    virtual double ddTSingle(ReactionRate& rate) override
-    {
-        RateType& R = static_cast<RateType&>(rate);
-        return R.evalFromStruct(m_shared) * _get_ddTScaled(R);
-    }
-
 protected:
-    //! Helper function to evaluate temperature derivative for rate types that
-    //! implement the `ddTScaledFromStruct` method.
-    template <typename T=RateType, typename std::enable_if<has_ddT<T>::value, bool>::type = true>
-    double _get_ddTScaled(RateType& rate) {
-        return rate.ddTScaledFromStruct(m_shared);
-    }
-
-    //! Helper function for rate types that do not implement `ddTScaledFromStruct`
-    template <typename T=RateType, typename std::enable_if<!has_ddT<T>::value, bool>::type = true>
-    double _get_ddTScaled(RateType& rate) {
-        throw NotImplementedError("ReactionRate::ddTScaledFromStruct",
-            "For rate of type {}", rate.type());
-    }
-
     //! Vector of pairs of reaction rates indices and reaction rates
     std::vector<std::pair<size_t, RateType>> m_rxn_rates;
     std::map<size_t, size_t> m_indices; //! Mapping of indices

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -68,17 +68,14 @@ public:
     }
 
     virtual void update(double T) override {
-        // update common data once for each reaction type
         m_shared.update(T);
     }
 
     virtual void update(double T, double extra) override {
-        // update common data once for each reaction type
         m_shared.update(T, extra);
     }
 
     virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override {
-        // update common data once for each reaction type
         return m_shared.update(bulk, kin);
     }
 

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -55,22 +55,27 @@ public:
     //! @param kf  array of rate constants
     virtual void getRateConstants(double* kf) = 0;
 
-    //! Update common reaction rate data based on temperature
+    //! Update common reaction rate data based on temperature.
+    //! Only used in conjunction with evalSingle and ReactionRate::eval
     //! @param T  temperature [K]
     virtual void update(double T) = 0;
 
-    //! Update common reaction rate data based on temperature and extra parameter
+    //! Update common reaction rate data based on temperature and extra parameter.
+    //! Only used in conjunction with evalSingle and ReactionRate::eval
     //! @param T  temperature [K]
     //! @param extra  extra parameter (depends on parameterization)
     virtual void update(double T, double extra) = 0;
 
-    //! Update data common to reaction rates of a specific type
+    //! Update data common to reaction rates of a specific type.
+    //! This update mechanism is used by Kinetics reaction rate evaluators.
     //! @param bulk  object representing bulk phase
     //! @param kin  object representing kinetics
     //! @returns flag indicating reaction rates need to be re-evaluated
     virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) = 0;
 
-    //! Get the rate for a single reaction. Used to implement ReactionRate::eval.
+    //! Get the rate for a single reaction. Used to implement ReactionRate::eval,
+    //! which allows for the evaluation of a reaction rate expression outside of
+    //! Kinetics reaction rate evaluators. Mainly used for testing purposes.
     virtual double evalSingle(ReactionRate& rate) = 0;
 };
 

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -78,10 +78,6 @@ public:
 
     //! Get the rate for a single reaction. Used to implement ReactionRate::eval.
     virtual double evalSingle(ReactionRate& rate) = 0;
-
-    //! Get the derivative of the rate with respect to temperature for a single
-    //! reaction. Used to implement ReactionRate::ddT.
-    virtual double ddTSingle(ReactionRate& rate) = 0;
 };
 
 } // end namespace Cantera

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -64,6 +64,12 @@ public:
     //! @param P  pressure [Pa]
     virtual void update(double T, double P) = 0;
 
+    //! Update common reaction rate data based on temperature and pressure
+    //! @param T  temperature [K]
+    //! @param P  pressure [Pa]
+    //! @param extra  extra parameter (depends on parameterization)
+    virtual void update(double T, double P, double extra) = 0;
+
     //! Update data common to reaction rates of a specific type
     //! @param bulk  object representing bulk phase
     //! @param kin  object representing kinetics

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -59,16 +59,10 @@ public:
     //! @param T  temperature [K]
     virtual void update(double T) = 0;
 
-    //! Update common reaction rate data based on temperature and pressure
+    //! Update common reaction rate data based on temperature and extra parameter
     //! @param T  temperature [K]
-    //! @param P  pressure [Pa]
-    virtual void update(double T, double P) = 0;
-
-    //! Update common reaction rate data based on temperature and pressure
-    //! @param T  temperature [K]
-    //! @param P  pressure [Pa]
     //! @param extra  extra parameter (depends on parameterization)
-    virtual void update(double T, double P, double extra) = 0;
+    virtual void update(double T, double extra) = 0;
 
     //! Update data common to reaction rates of a specific type
     //! @param bulk  object representing bulk phase

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -38,6 +38,10 @@ struct ReactionData
         pressure = P;
     }
 
+    //! Update data container based on temperature *T*, pressure *P* and an
+    //! *extra* parameter
+    virtual void update(double T, double P, double extra);
+
     //! Update data container based on *bulk* phase state
     //! @returns A boolean element indicating whether the `evalFromStruct` method
     //!      needs to be called (assuming previously-calculated values were cached)
@@ -144,6 +148,7 @@ protected:
 struct PlogData final : public ReactionData
 {
     PlogData() : logP(0.) {}
+    using ReactionData::update;
 
     virtual void update(double T) override;
 
@@ -173,6 +178,7 @@ struct PlogData final : public ReactionData
 struct ChebyshevData final : public ReactionData
 {
     ChebyshevData() : log10P(0.) {}
+    using ReactionData::update;
 
     virtual void update(double T) override;
 

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -23,7 +23,7 @@ class Kinetics;
  */
 struct ReactionData
 {
-    ReactionData() : temperature(1.), logT(0.), recipT(1.) {}
+    ReactionData() : temperature(1.), pressure(NAN), logT(0.), recipT(1.) {}
 
     //! Update data container based on temperature *T*
     virtual void update(double T) {
@@ -35,6 +35,7 @@ struct ReactionData
     //! Update data container based on temperature *T* and pressure *P*
     virtual void update(double T, double P) {
         update(T);
+        pressure = P;
     }
 
     //! Update data container based on *bulk* phase state
@@ -57,6 +58,7 @@ struct ReactionData
     }
 
     double temperature; //!< temperature
+    double pressure; //!< pressure
     double logT; //!< logarithm of temperature
     double recipT; //!< inverse of temperature
 };
@@ -143,7 +145,7 @@ protected:
  */
 struct PlogData final : public ReactionData
 {
-    PlogData() : pressure(NAN), logP(0.) {}
+    PlogData() : logP(0.) {}
 
     virtual void update(double T) override;
 
@@ -161,7 +163,6 @@ struct PlogData final : public ReactionData
         pressure = NAN;
     }
 
-    double pressure; //!< Pressure [Pa]
     double logP; //!< logarithm of pressure
 };
 
@@ -173,7 +174,7 @@ struct PlogData final : public ReactionData
  */
 struct ChebyshevData final : public ReactionData
 {
-    ChebyshevData() : pressure(NAN), log10P(0.) {}
+    ChebyshevData() : log10P(0.) {}
 
     virtual void update(double T) override;
 
@@ -191,7 +192,6 @@ struct ChebyshevData final : public ReactionData
         pressure = NAN;
     }
 
-    double pressure; //!< Pressure [Pa]
     double log10P; //!< base 10 logarithm of pressure
 };
 

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -34,7 +34,7 @@ struct ReactionData
 
     //! Update data container based on temperature *T* and pressure *P*
     virtual void update(double T, double P) {
-        update(T);
+        ReactionData::update(T);
         pressure = P;
     }
 
@@ -115,11 +115,16 @@ protected:
  */
 struct FalloffData final : public ReactionData
 {
-    FalloffData() : ready(false), molar_density(NAN), m_state_mf_number(-1) {}
+    FalloffData();
 
     virtual bool update(const ThermoPhase& bulk,
                         const Kinetics& kin) override;
-    using ReactionData::update;
+
+    virtual void update(double T) override;
+
+    virtual void update(double T, double P) override;
+
+    virtual void update(double T, double P, double M) override;
 
     virtual void resize(size_t n_species, size_t n_reactions) override {
         conc_3b.resize(n_reactions, NAN);

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -23,7 +23,7 @@ class Kinetics;
  */
 struct ReactionData
 {
-    ReactionData() : temperature(1.), pressure(NAN), logT(0.), recipT(1.) {}
+    ReactionData() : temperature(1.), logT(0.), recipT(1.) {}
 
     //! Update data container based on temperature *T*
     virtual void update(double T) {
@@ -32,15 +32,8 @@ struct ReactionData
         recipT = 1./T;
     }
 
-    //! Update data container based on temperature *T* and pressure *P*
-    virtual void update(double T, double P) {
-        ReactionData::update(T);
-        pressure = P;
-    }
-
-    //! Update data container based on temperature *T*, pressure *P* and an
-    //! *extra* parameter
-    virtual void update(double T, double P, double extra);
+    //! Update data container based on temperature *T* and an *extra* parameter
+    virtual void update(double T, double extra);
 
     //! Update data container based on *bulk* phase state
     //! @returns A boolean element indicating whether the `evalFromStruct` method
@@ -60,7 +53,6 @@ struct ReactionData
     }
 
     double temperature; //!< temperature
-    double pressure; //!< pressure
     double logT; //!< logarithm of temperature
     double recipT; //!< inverse of temperature
 };
@@ -93,9 +85,7 @@ struct BlowersMaselData final : public ReactionData
 
     virtual void update(double T) override;
 
-    virtual void update(double T, double P) override;
-
-    virtual void update(double T, double P, double deltaH) override;
+    virtual void update(double T, double deltaH) override;
 
     virtual void resize(size_t n_species, size_t n_reactions) override {
         m_grt.resize(n_species, 0.);
@@ -127,9 +117,7 @@ struct FalloffData final : public ReactionData
 
     virtual void update(double T) override;
 
-    virtual void update(double T, double P) override;
-
-    virtual void update(double T, double P, double M) override;
+    virtual void update(double T, double M) override;
 
     virtual void resize(size_t n_species, size_t n_reactions) override {
         conc_3b.resize(n_reactions, NAN);
@@ -157,7 +145,7 @@ protected:
  */
 struct PlogData final : public ReactionData
 {
-    PlogData() : logP(0.) {}
+    PlogData() : pressure(NAN), logP(0.) {}
     using ReactionData::update;
 
     virtual void update(double T) override;
@@ -176,6 +164,7 @@ struct PlogData final : public ReactionData
         pressure = NAN;
     }
 
+    double pressure; //!< pressure
     double logP; //!< logarithm of pressure
 };
 
@@ -187,7 +176,7 @@ struct PlogData final : public ReactionData
  */
 struct ChebyshevData final : public ReactionData
 {
-    ChebyshevData() : log10P(0.) {}
+    ChebyshevData() : pressure(NAN), log10P(0.) {}
     using ReactionData::update;
 
     virtual void update(double T) override;
@@ -206,6 +195,7 @@ struct ChebyshevData final : public ReactionData
         pressure = NAN;
     }
 
+    double pressure; //!< pressure
     double log10P; //!< base 10 logarithm of pressure
 };
 

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -86,11 +86,16 @@ struct ArrheniusData final : public ReactionData
  */
 struct BlowersMaselData final : public ReactionData
 {
-    BlowersMaselData() : ready(false), density(NAN), m_state_mf_number(-1) {}
+    BlowersMaselData();
 
     virtual bool update(const ThermoPhase& bulk,
                         const Kinetics& kin) override;
-    using ReactionData::update;
+
+    virtual void update(double T) override;
+
+    virtual void update(double T, double P) override;
+
+    virtual void update(double T, double P, double deltaH) override;
 
     virtual void resize(size_t n_species, size_t n_reactions) override {
         m_grt.resize(n_species, 0.);

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -195,15 +195,6 @@ struct ChebyshevData final : public ReactionData
     double log10P; //!< base 10 logarithm of pressure
 };
 
-
-//! Data container holding shared data specific to CustomFunc1Rate
-struct CustomFunc1Data final : public ReactionData
-{
-    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
-                                  const Kinetics& kin) override;
-    using ReactionData::update;
-};
-
 }
 
 #endif

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -29,7 +29,7 @@ struct ReactionData
     /**
      * Only used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
      * This method allows for testing of a reaction rate expression outside of
-     * Kinetics reaction rate evaluators. Mainly used for testing purposes.
+     * Kinetics reaction rate evaluators.
      */
     virtual void update(double T) {
         temperature = T;
@@ -41,7 +41,7 @@ struct ReactionData
     /**
      * Only used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
      * This method allows for testing of a reaction rate expression outside of
-     * Kinetics reaction rate evaluators. Mainly used for testing purposes.
+     * Kinetics reaction rate evaluators.
      */
     virtual void update(double T, double extra);
 
@@ -51,8 +51,7 @@ struct ReactionData
      * @returns A boolean element indicating whether the `evalFromStruct` method
      *      needs to be called (assuming previously-calculated values were cached)
      */
-    virtual bool update(const ThermoPhase& bulk,
-                        const Kinetics& kin) = 0;
+    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) = 0;
 
     //! Update number of species and reactions
     virtual void resize(size_t n_species, size_t n_reactions) {}
@@ -76,10 +75,9 @@ struct ReactionData
  * The data container `ArrheniusData` holds precalculated data common to
  * all `ArrheniusRate` objects.
  */
-struct ArrheniusData final : public ReactionData
+struct ArrheniusData : public ReactionData
 {
-    virtual bool update(const ThermoPhase& bulk,
-                        const Kinetics& kin);
+    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin);
     using ReactionData::update;
 };
 
@@ -89,12 +87,11 @@ struct ArrheniusData final : public ReactionData
  * The data container `BlowersMaselData` holds precalculated data common to
  * all `BlowersMaselRate` objects.
  */
-struct BlowersMaselData final : public ReactionData
+struct BlowersMaselData : public ReactionData
 {
     BlowersMaselData();
 
-    virtual bool update(const ThermoPhase& bulk,
-                        const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
 
     virtual void update(double T) override;
 
@@ -121,12 +118,11 @@ protected:
  * The data container `FalloffData` holds precalculated data common to
  * all Falloff related reaction rate classes.
  */
-struct FalloffData final : public ReactionData
+struct FalloffData : public ReactionData
 {
     FalloffData();
 
-    virtual bool update(const ThermoPhase& bulk,
-                        const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
 
     virtual void update(double T) override;
 
@@ -156,10 +152,9 @@ protected:
  * The data container `PlogData` holds precalculated data common to
  * all `PlogRate` objects.
  */
-struct PlogData final : public ReactionData
+struct PlogData : public ReactionData
 {
     PlogData() : pressure(NAN), logP(0.) {}
-    using ReactionData::update;
 
     virtual void update(double T) override;
 
@@ -169,8 +164,7 @@ struct PlogData final : public ReactionData
         logP = std::log(P);
     }
 
-    virtual bool update(const ThermoPhase& bulk,
-                        const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
 
     virtual void invalidateCache() override {
         ReactionData::invalidateCache();
@@ -187,10 +181,9 @@ struct PlogData final : public ReactionData
  * The data container `ChebyshevData` holds precalculated data common to
  * all `ChebyshevRate3` objects.
  */
-struct ChebyshevData final : public ReactionData
+struct ChebyshevData : public ReactionData
 {
     ChebyshevData() : pressure(NAN), log10P(0.) {}
-    using ReactionData::update;
 
     virtual void update(double T) override;
 
@@ -200,8 +193,7 @@ struct ChebyshevData final : public ReactionData
         log10P = std::log10(P);
     }
 
-    virtual bool update(const ThermoPhase& bulk,
-                        const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
 
     virtual void invalidateCache() override {
         ReactionData::invalidateCache();

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -26,6 +26,11 @@ struct ReactionData
     ReactionData() : temperature(1.), logT(0.), recipT(1.) {}
 
     //! Update data container based on temperature *T*
+    /**
+     * Only used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
+     * This method allows for testing of a reaction rate expression outside of
+     * Kinetics reaction rate evaluators. Mainly used for testing purposes.
+     */
     virtual void update(double T) {
         temperature = T;
         logT = std::log(T);
@@ -33,11 +38,19 @@ struct ReactionData
     }
 
     //! Update data container based on temperature *T* and an *extra* parameter
+    /**
+     * Only used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
+     * This method allows for testing of a reaction rate expression outside of
+     * Kinetics reaction rate evaluators. Mainly used for testing purposes.
+     */
     virtual void update(double T, double extra);
 
     //! Update data container based on *bulk* phase state
-    //! @returns A boolean element indicating whether the `evalFromStruct` method
-    //!      needs to be called (assuming previously-calculated values were cached)
+    /**
+     * This update mechanism is used by Kinetics reaction rate evaluators.
+     * @returns A boolean element indicating whether the `evalFromStruct` method
+     *      needs to be called (assuming previously-calculated values were cached)
+     */
     virtual bool update(const ThermoPhase& bulk,
                         const Kinetics& kin) = 0;
 

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -17,46 +17,61 @@ class ThermoPhase;
 class Kinetics;
 
 
-//! Data container holding shared data specific to ArrheniusRate
+//! Data container holding shared data used for ReactionRate calculation
 /**
- * The data container `ArrheniusData` holds precalculated data common to
- * all `ArrheniusRate` objects.
+ * The base class defines variables and methods used by all specializations.
  */
-struct ArrheniusData
+struct ReactionData
 {
-    ArrheniusData() : temperature(1.), logT(0.), recipT(1.) {}
+    ReactionData() : temperature(1.), logT(0.), recipT(1.) {}
 
     //! Update data container based on temperature *T*
-    void update(double T) {
+    virtual void update(double T) {
         temperature = T;
         logT = std::log(T);
         recipT = 1./T;
     }
 
     //! Update data container based on temperature *T* and pressure *P*
-    void update(double T, double P) { update(T); }
+    virtual void update(double T, double P) {
+        update(T);
+    }
 
     //! Update data container based on *bulk* phase state
-    //! @returns A pair where the first element indicates whether the `updateFromStruct`
-    //!      function for individual reactions needs to be called, and the second
-    //!      element indicates whether the `evalFromStruct` method needs to be called
-    //!      (assuming previously-calculated values were cached)
-    std::pair<bool, bool> update(const ThermoPhase& bulk, const Kinetics& kin);
+    //! @returns A pair where the first element indicates whether the
+    //!      `updateFromStruct` function for individual reactions needs to be called,
+    //!      and the second element indicates whether the `evalFromStruct` method
+    //!      needs to be called (assuming previously-calculated values were cached)
+    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
+                                         const Kinetics& kin) = 0;
 
-    //! Update number of species and reactions; unused
-    void resize(size_t n_species, size_t n_reactions) {}
+    //! Update number of species and reactions
+    virtual void resize(size_t n_species, size_t n_reactions) {}
 
     //! Force shared data and reaction rates to be updated next time. This is called by
     //! functions that change quantities affecting rate calculations that are normally
     //! assumed to be constant, like the reaction rate parameters or the number of
     //! reactions.
-    void invalidateCache() {
+    virtual void invalidateCache() {
         temperature = NAN;
     }
 
     double temperature; //!< temperature
     double logT; //!< logarithm of temperature
-    double recipT;  //!< inverse of temperature
+    double recipT; //!< inverse of temperature
+};
+
+
+//! Data container holding shared data specific to ArrheniusRate
+/**
+ * The data container `ArrheniusData` holds precalculated data common to
+ * all `ArrheniusRate` objects.
+ */
+struct ArrheniusData final : public ReactionData
+{
+    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
+                                         const Kinetics& kin);
+    using ReactionData::update;
 };
 
 
@@ -65,43 +80,26 @@ struct ArrheniusData
  * The data container `BlowersMaselData` holds precalculated data common to
  * all `BlowersMaselRate` objects.
  */
-struct BlowersMaselData
+struct BlowersMaselData final : public ReactionData
 {
-    BlowersMaselData();
+    BlowersMaselData() : ready(false), density(NAN), m_state_mf_number(-1) {}
 
-    //! Update data container based on temperature *T*
-    void update(double T);
+    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
+                                         const Kinetics& kin) override;
+    using ReactionData::update;
 
-    //! Update data container based on temperature *T* and pressure *P*
-    void update(double T, double P) {
-        update(T);
-    }
-
-    //! Update data container based on *bulk* phase state and *kin* kinetics
-    std::pair<bool, bool> update(const ThermoPhase& bulk, const Kinetics& kin);
-
-    //! Finalize setup
-    void resize(size_t n_species, size_t n_reactions) {
+    virtual void resize(size_t n_species, size_t n_reactions) override {
         m_grt.resize(n_species, 0.);
         dH.resize(n_reactions, 0.);
-        finalized = true;
+        ready = true;
     }
 
-    void invalidateCache() {
-        temperature = NAN;
-    }
-
-    double temperature; //!< temperature
-    double logT; //!< logarithm of temperature
-    double recipT; //!< inverse of temperature
+    bool ready; //!< boolean indicating whether vectors are accessible
     double density; //!< used to determine if updates are needed
-    int state_mf_number; //!< integer that is incremented when composition changes
-
-
-    bool finalized; //!< boolean indicating whether vectors are accessible
     vector_fp dH; //!< enthalpy change for each reaction
 
 protected:
+    int m_state_mf_number; //!< integer that is incremented when composition changes
     vector_fp m_grt; //!< work vector holding partial molar enthalpies
 };
 
@@ -111,29 +109,30 @@ protected:
  * The data container `FalloffData` holds precalculated data common to
  * all Falloff related reaction rate classes.
  */
-struct FalloffData : public ArrheniusData
+struct FalloffData final : public ReactionData
 {
-    FalloffData() : finalized(false), molar_density(NAN), state_mf_number(-1) {}
+    FalloffData() : ready(false), molar_density(NAN), m_state_mf_number(-1) {}
 
-    //! Update data container based on *bulk* phase state and *kin* kinetics
-    std::pair<bool, bool> update(const ThermoPhase& bulk, const Kinetics& kin);
-    using ArrheniusData::update;
+    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
+                                         const Kinetics& kin) override;
+    using ReactionData::update;
 
-    //! Finalize setup
-    void resize(size_t n_species, size_t n_reactions) {
+    virtual void resize(size_t n_species, size_t n_reactions) override {
         conc_3b.resize(n_reactions, NAN);
-        finalized = true;
+        ready = true;
     }
 
-    void invalidateCache() {
-        ArrheniusData::invalidateCache();
+    virtual void invalidateCache() override {
+        ReactionData::invalidateCache();
         molar_density = NAN;
     }
 
-    bool finalized; //!< boolean indicating whether vectors are accessible
-    vector_fp conc_3b; //!< vector of effective third-body concentrations
+    bool ready; //!< boolean indicating whether vectors are accessible
     double molar_density; //!< used to determine if updates are needed
-    int state_mf_number; //!< integer that is incremented when composition changes
+    vector_fp conc_3b; //!< vector of effective third-body concentrations
+
+protected:
+    int m_state_mf_number; //!< integer that is incremented when composition changes
 };
 
 
@@ -142,36 +141,26 @@ struct FalloffData : public ArrheniusData
  * The data container `PlogData` holds precalculated data common to
  * all `PlogRate` objects.
  */
-struct PlogData
+struct PlogData final : public ReactionData
 {
-    PlogData() : temperature(1.), logT(0.), recipT(1.), pressure(NAN), logP(0.) {}
+    PlogData() : pressure(NAN), logP(0.) {}
 
-    //! Update data container based on temperature *T* (raises exception)
-    void update(double T);
+    virtual void update(double T) override;
 
-    //! Update data container based on temperature *T* and *P*
-    void update(double T, double P) {
-        temperature = T;
-        logT = std::log(T);
-        recipT = 1./T;
+    virtual void update(double T, double P) override {
+        ReactionData::update(T);
         pressure = P;
         logP = std::log(P);
     }
 
-    //! Update data container based on *bulk* phase state
-    std::pair<bool, bool> update(const ThermoPhase& bulk, const Kinetics& kin);
+    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
+                                         const Kinetics& kin) override;
 
-    //! Update number of species and reactions; unused
-    void resize(size_t n_species, size_t n_reactions) {}
-
-    void invalidateCache() {
-        temperature = NAN;
+    virtual void invalidateCache() override {
+        ReactionData::invalidateCache();
         pressure = NAN;
     }
 
-    double temperature; //!< temperature
-    double logT; //!< logarithm of temperature
-    double recipT; //!< inverse of temperature
     double pressure; //!< Pressure [Pa]
     double logP; //!< logarithm of pressure
 };
@@ -182,62 +171,37 @@ struct PlogData
  * The data container `ChebyshevData` holds precalculated data common to
  * all `ChebyshevRate3` objects.
  */
-struct ChebyshevData
+struct ChebyshevData final : public ReactionData
 {
-    ChebyshevData() : temperature(1.), recipT(1.), pressure(NAN), log10P(0.) {}
+    ChebyshevData() : pressure(NAN), log10P(0.) {}
 
-    //! Update data container based on temperature *T* (raises exception)
-    void update(double T);
+    virtual void update(double T) override;
 
-    //! Update data container based on temperature *T* and *P*
-    void update(double T, double P)
-    {
-        temperature = T;
-        recipT = 1./T;
+    virtual void update(double T, double P) override {
+        ReactionData::update(T);
         pressure = P;
         log10P = std::log10(P);
     }
 
-    //! Update data container based on *bulk* phase state
-    std::pair<bool, bool> update(const ThermoPhase& bulk, const Kinetics& kin);
+    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
+                                         const Kinetics& kin) override;
 
-    //! Update number of species and reactions; unused
-    void resize(size_t n_species, size_t n_reactions) {}
-
-    void invalidateCache() {
-        temperature = NAN;
+    virtual void invalidateCache() override {
+        ReactionData::invalidateCache();
         pressure = NAN;
     }
 
-    double temperature; //!< temperature
-    double recipT; //!< inverse of temperature
     double pressure; //!< Pressure [Pa]
     double log10P; //!< base 10 logarithm of pressure
 };
 
 
 //! Data container holding shared data specific to CustomFunc1Rate
-struct CustomFunc1Data
+struct CustomFunc1Data final : public ReactionData
 {
-    CustomFunc1Data() : temperature(1.) {}
-
-    //! Update data container based on temperature *T*
-    void update(double T) { temperature = T; }
-
-    //! Update data container based on temperature *T* and pressure *P*
-    void update(double T, double P) { update(T); }
-
-    //! Update data container based on *bulk* phase state
-    std::pair<bool, bool> update(const ThermoPhase& bulk, const Kinetics& kin);
-
-    //! Update number of species and reactions; unused
-    void resize(size_t n_species, size_t n_reactions) {}
-
-    void invalidateCache() {
-        temperature = NAN;
-    }
-
-    double temperature; //!< temperature
+    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
+                                  const Kinetics& kin) override;
+    using ReactionData::update;
 };
 
 }

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -39,12 +39,10 @@ struct ReactionData
     }
 
     //! Update data container based on *bulk* phase state
-    //! @returns A pair where the first element indicates whether the
-    //!      `updateFromStruct` function for individual reactions needs to be called,
-    //!      and the second element indicates whether the `evalFromStruct` method
+    //! @returns A boolean element indicating whether the `evalFromStruct` method
     //!      needs to be called (assuming previously-calculated values were cached)
-    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
-                                         const Kinetics& kin) = 0;
+    virtual bool update(const ThermoPhase& bulk,
+                        const Kinetics& kin) = 0;
 
     //! Update number of species and reactions
     virtual void resize(size_t n_species, size_t n_reactions) {}
@@ -71,8 +69,8 @@ struct ReactionData
  */
 struct ArrheniusData final : public ReactionData
 {
-    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
-                                         const Kinetics& kin);
+    virtual bool update(const ThermoPhase& bulk,
+                        const Kinetics& kin);
     using ReactionData::update;
 };
 
@@ -86,8 +84,8 @@ struct BlowersMaselData final : public ReactionData
 {
     BlowersMaselData() : ready(false), density(NAN), m_state_mf_number(-1) {}
 
-    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
-                                         const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& bulk,
+                        const Kinetics& kin) override;
     using ReactionData::update;
 
     virtual void resize(size_t n_species, size_t n_reactions) override {
@@ -115,8 +113,8 @@ struct FalloffData final : public ReactionData
 {
     FalloffData() : ready(false), molar_density(NAN), m_state_mf_number(-1) {}
 
-    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
-                                         const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& bulk,
+                        const Kinetics& kin) override;
     using ReactionData::update;
 
     virtual void resize(size_t n_species, size_t n_reactions) override {
@@ -155,8 +153,8 @@ struct PlogData final : public ReactionData
         logP = std::log(P);
     }
 
-    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
-                                         const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& bulk,
+                        const Kinetics& kin) override;
 
     virtual void invalidateCache() override {
         ReactionData::invalidateCache();
@@ -184,8 +182,8 @@ struct ChebyshevData final : public ReactionData
         log10P = std::log10(P);
     }
 
-    virtual std::pair<bool, bool> update(const ThermoPhase& bulk,
-                                         const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& bulk,
+                        const Kinetics& kin) override;
 
     virtual void invalidateCache() override {
         ReactionData::invalidateCache();

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -1,8 +1,5 @@
 /**
  * @file ReactionRate.h
- *
- * @warning This file is an experimental part of the %Cantera API and
- *    may be changed or removed without notice.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
@@ -104,10 +101,6 @@ public:
 
     //! Evaluate reaction rate based on temperature
     //! @param T  temperature [K]
-    /**
-     * @warning This method is an experimental part of the %Cantera API and
-     *      may be changed or removed without notice.
-     * */
     double eval(double T) {
         _evaluator().update(T);
         return _evaluator().evalSingle(*this);
@@ -116,69 +109,18 @@ public:
     //! Evaluate reaction rate based on temperature and pressure
     //! @param T  temperature [K]
     //! @param P  pressure [Pa]
-    /**
-     * @warning This method is an experimental part of the %Cantera API and
-     *      may be changed or removed without notice.
-     * */
     double eval(double T, double P) {
         _evaluator().update(T, P);
         return _evaluator().evalSingle(*this);
     }
 
-    //! Evaluate reaction rate based on temperature and pressure
+    //! Evaluate reaction rate based on temperature, pressure and extra parameter
     //! @param T  temperature [K]
     //! @param P  pressure [Pa]
-    //! @param extra  extra parameter
-    /**
-     * @warning This method is an experimental part of the %Cantera API and
-     *      may be changed or removed without notice.
-     * */
+    //! @param extra  extra parameter (used by some parameterizations)
     double eval(double T, double P, double extra) {
         _evaluator().update(T, P, extra);
         return _evaluator().evalSingle(*this);
-    }
-
-    //! Evaluate reaction rate based on bulk phase
-    //! @param bulk  object representing bulk phase
-    //! @param kin  object representing kinetics (not required for all rate types)
-    double eval(const ThermoPhase& bulk, const Kinetics& kin) {
-        _evaluator().update(bulk, kin);
-        return _evaluator().evalSingle(*this);
-    }
-
-    //! Evaluate reaction rate derivative based on temperature
-    //! @param T  temperature [K]
-    /**
-     * @warning This method is an experimental part of the %Cantera API and
-     *      may be changed or removed without notice.
-     * */
-    double ddT(double T) {
-        _evaluator().update(T);
-        return _evaluator().ddTSingle(*this);
-    }
-
-    //! Evaluate reaction rate derivative based on temperature and pressure
-    //! @param T  temperature [K]
-    //! @param P  pressure [Pa]
-    /**
-     * @warning This method is an experimental part of the %Cantera API and
-     *      may be changed or removed without notice.
-     * */
-    double ddT(double T, double P) {
-        _evaluator().update(T, P);
-        return _evaluator().ddTSingle(*this);
-    }
-
-    //! Evaluate reaction rate derivative based on bulk phase
-    //! @param bulk  object representing bulk phase
-    //! @param kin  object representing kinetics (not required for all rate types)
-    /**
-     * @warning This method is an experimental part of the %Cantera API and
-     *      may be changed or removed without notice.
-     * */
-    double ddT(const ThermoPhase& bulk, const Kinetics& kin) {
-        _evaluator().update(bulk, kin);
-        return _evaluator().ddTSingle(*this);
     }
 
 protected:

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -29,7 +29,7 @@ namespace Cantera
 //!
 //! Derived classes may also implement the methods
 //! `updateFromStruct(const DataType& shared_data)` and
-//! `ddTFromStruct(const DataType& shared_data)`.
+//! `ddTScaledFromStruct(const DataType& shared_data)`.
 class ReactionRate
 {
 public:

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -125,6 +125,19 @@ public:
         return _evaluator().evalSingle(*this);
     }
 
+    //! Evaluate reaction rate based on temperature and pressure
+    //! @param T  temperature [K]
+    //! @param P  pressure [Pa]
+    //! @param extra  extra parameter
+    /**
+     * @warning This method is an experimental part of the %Cantera API and
+     *      may be changed or removed without notice.
+     * */
+    double eval(double T, double P, double extra) {
+        _evaluator().update(T, P, extra);
+        return _evaluator().evalSingle(*this);
+    }
+
     //! Evaluate reaction rate based on bulk phase
     //! @param bulk  object representing bulk phase
     //! @param kin  object representing kinetics (not required for all rate types)

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -27,8 +27,7 @@ namespace Cantera
 //! where `DataType` is a container for parameters needed to evaluate reactions of that
 //! type.
 //!
-//! Derived classes may also implement the methods
-//! `updateFromStruct(const DataType& shared_data)` and
+//! Derived classes may also implement the method
 //! `ddTScaledFromStruct(const DataType& shared_data)`.
 class ReactionRate
 {

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -106,20 +106,13 @@ public:
         return _evaluator().evalSingle(*this);
     }
 
-    //! Evaluate reaction rate based on temperature and pressure
+    //! Evaluate reaction rate based on temperature and an extra parameter.
+    //! Specific rate parameterizations may require an additional parameter, which
+    //! is specific to the derived ReactionRate object.
     //! @param T  temperature [K]
-    //! @param P  pressure [Pa]
-    double eval(double T, double P) {
-        _evaluator().update(T, P);
-        return _evaluator().evalSingle(*this);
-    }
-
-    //! Evaluate reaction rate based on temperature, pressure and extra parameter
-    //! @param T  temperature [K]
-    //! @param P  pressure [Pa]
-    //! @param extra  extra parameter (used by some parameterizations)
-    double eval(double T, double P, double extra) {
-        _evaluator().update(T, P, extra);
+    //! @param extra  extra parameter used by parameterization
+    double eval(double T, double extra) {
+        _evaluator().update(T, extra);
         return _evaluator().evalSingle(*this);
     }
 

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -101,6 +101,9 @@ public:
 
     //! Evaluate reaction rate based on temperature
     //! @param T  temperature [K]
+    //! Used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
+    //! This method allows for testing of a reaction rate expression outside of
+    //! Kinetics reaction rate evaluators. Mainly used for testing purposes.
     double eval(double T) {
         _evaluator().update(T);
         return _evaluator().evalSingle(*this);
@@ -111,6 +114,9 @@ public:
     //! is specific to the derived ReactionRate object.
     //! @param T  temperature [K]
     //! @param extra  extra parameter used by parameterization
+    //! Used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
+    //! This method allows for testing of a reaction rate expression outside of
+    //! Kinetics reaction rate evaluators. Mainly used for testing purposes.
     double eval(double T, double extra) {
         _evaluator().update(T, extra);
         return _evaluator().evalSingle(*this);

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -103,7 +103,7 @@ public:
     //! @param T  temperature [K]
     //! Used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
     //! This method allows for testing of a reaction rate expression outside of
-    //! Kinetics reaction rate evaluators. Mainly used for testing purposes.
+    //! Kinetics reaction rate evaluators.
     double eval(double T) {
         _evaluator().update(T);
         return _evaluator().evalSingle(*this);
@@ -116,7 +116,7 @@ public:
     //! @param extra  extra parameter used by parameterization
     //! Used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.
     //! This method allows for testing of a reaction rate expression outside of
-    //! Kinetics reaction rate evaluators. Mainly used for testing purposes.
+    //! Kinetics reaction rate evaluators.
     double eval(double T, double extra) {
         _evaluator().update(T, extra);
         return _evaluator().evalSingle(*this);

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -417,13 +417,15 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         cbool allowNegativePreExponentialFactor()
         void setAllowNegativePreExponentialFactor(bool)
 
-    cdef cppclass CxxBlowersMaselRate "Cantera::BlowersMaselRate" (CxxArrheniusRate):
+    cdef cppclass CxxBlowersMaselRate "Cantera::BlowersMaselRate" (CxxReactionRate, CxxArrheniusBase):
         CxxBlowersMaselRate()
         CxxBlowersMaselRate(CxxAnyMap) except +translate_exception
         CxxBlowersMaselRate(double, double, double, double)
         double activationEnergy(double)
         double activationEnergy0()
         double bondEnergy()
+        cbool allowNegativePreExponentialFactor()
+        void setAllowNegativePreExponentialFactor(bool)
 
     cdef cppclass CxxFalloffRate "Cantera::FalloffRate" (CxxReactionRate):
         CxxFalloffRate()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -431,8 +431,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxFalloffRate(CxxAnyMap) except +translate_exception
         cbool allowNegativePreExponentialFactor()
         void setAllowNegativePreExponentialFactor(bool)
-        double thirdBodyConcentration()
-        void setThirdBodyConcentration(double)
         cbool chemicallyActivated()
         void setChemicallyActivated(bool)
         CxxArrheniusRate& lowRate()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -404,7 +404,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         string type()
         double eval(double) except +translate_exception
         double eval(double, double) except +translate_exception
-        double eval(double, double, double) except +translate_exception
         CxxAnyMap parameters() except +translate_exception
 
     cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxReactionRate, CxxArrheniusBase):

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -404,6 +404,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         string type()
         double eval(double) except +translate_exception
         double eval(double, double) except +translate_exception
+        double eval(double, double, double) except +translate_exception
         double ddT(double) except +translate_exception
         double ddT(double, double) except +translate_exception
         CxxAnyMap parameters() except +translate_exception

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -405,8 +405,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double eval(double) except +translate_exception
         double eval(double, double) except +translate_exception
         double eval(double, double, double) except +translate_exception
-        double ddT(double) except +translate_exception
-        double ddT(double, double) except +translate_exception
         CxxAnyMap parameters() except +translate_exception
 
     cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxReactionRate, CxxArrheniusBase):

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -421,10 +421,9 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxBlowersMaselRate()
         CxxBlowersMaselRate(CxxAnyMap) except +translate_exception
         CxxBlowersMaselRate(double, double, double, double)
+        double activationEnergy(double)
         double activationEnergy0()
         double bondEnergy()
-        double deltaH()
-        void setDeltaH(double)
 
     cdef cppclass CxxFalloffRate "Cantera::FalloffRate" (CxxReactionRate):
         CxxFalloffRate()

--- a/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
+++ b/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
@@ -91,7 +91,7 @@ def change_species_enthalpy(gas, species_name, dH):
                             species.thermo.reference_pressure, perturbed_coeffs)
 
     gas.modify_species(index, species)
-    gas.reaction(1).rate.delta_enthalpy = gas.delta_enthalpy[1]
+    return gas.delta_enthalpy[1]
 
 # Plot the activation energy change of reaction 2 with respect to the
 # enthalpy change
@@ -102,8 +102,8 @@ lower_limit_enthalpy = -5 * E0
 Ea_list = []
 deltaH_list = np.linspace(lower_limit_enthalpy, upper_limit_enthalpy, 100)
 for deltaH in deltaH_list:
-    change_species_enthalpy(gas, 'H', deltaH - gas.delta_enthalpy[1])
-    Ea_list.append(gas.reaction(1).rate.activation_energy)
+    delta_enthalpy = change_species_enthalpy(gas, "H", deltaH - gas.delta_enthalpy[1])
+    Ea_list.append(gas.reaction(1).rate.activation_energy(delta_enthalpy))
 
 plt.figure()
 plt.plot(deltaH_list, Ea_list)

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -31,9 +31,6 @@ cdef class ReactionRate:
         For rate expressions that are dependent of pressure, an omission of pressure
         will raise an exception. Rate expressions that require an extra parameter
         require specification of all three parameters.
-
-        Warning: this method is an experimental part of the Cantera API and
-            may be changed or removed without notice.
         """
         if pressure and extra:
             return self.rate.eval(temperature, pressure, extra)
@@ -127,15 +124,6 @@ cdef class ReactionRate:
         any_map = AnyMapFromYamlString(stringify(text))
         cxx_rate = CxxNewReactionRate(any_map)
         return ReactionRate.wrap(cxx_rate)
-
-    def ddT(self, double temperature, pressure=None):
-        """
-        Evaluate derivative of rate expression with respect to temperature.
-        """
-        if pressure:
-            return self.rate.ddT(temperature, pressure)
-        else:
-            return self.rate.ddT(temperature)
 
     property input_data:
         """

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -22,17 +22,25 @@ cdef class ReactionRate:
     def __repr__(self):
         return f"<{type(self).__name__} at {id(self):0x}>"
 
-    def __call__(self, double temperature, pressure=None):
+    def __call__(self, double temperature, pressure=None, extra=None):
         """
-        Evaluate rate expression based on temperature and pressure. For rate
-        expressions that are dependent of pressure, an omission of pressure
-        will raise an exception.
+        Evaluate rate expression based on temperature, pressure, and an optional
+        extra parameter that is required for some ReactionRate parameterizations
+        (examples: `FalloffRate`, `BlowersMaselRate`).
+
+        For rate expressions that are dependent of pressure, an omission of pressure
+        will raise an exception. Rate expressions that require an extra parameter
+        require specification of all three parameters.
 
         Warning: this method is an experimental part of the Cantera API and
             may be changed or removed without notice.
         """
-        if pressure:
+        if pressure and extra:
+            return self.rate.eval(temperature, pressure, extra)
+        elif pressure:
             return self.rate.eval(temperature, pressure)
+        elif extra:
+            raise ValueError("Required argument 'pressure' is missing.")
         else:
             return self.rate.eval(temperature)
 

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -251,12 +251,12 @@ cdef class BlowersMaselRate(ReactionRate):
         def __get__(self):
             return self.cxx_object().temperatureExponent()
 
-    property activation_energy:
+    def activation_energy(self, double deltaH):
         """
-        The activation energy ``E`` [J/kmol].
+        The activation energy ``E`` [J/kmol], based on enthalpy change of reaction
+        ``deltaH`` (in [J/kmol])
         """
-        def __get__(self):
-            return self.cxx_object().activationEnergy()
+        return self.cxx_object().activationEnergy(deltaH)
 
     property intrinsic_activation_energy:
         """
@@ -272,19 +272,6 @@ cdef class BlowersMaselRate(ReactionRate):
         """
         def __get__(self):
             return self.cxx_object().bondEnergy()
-
-    property delta_enthalpy:
-        """
-        Enthalpy change of reaction used to adjust activation energy [J/kmol]
-
-        Note: this method does not update the internal state; once a `BlowersMaselRate`
-        evaluator is linked to a `Kinetics` object, the enthalpy change is updated
-        automatically, which will overwrite a value assigned by the setter.
-        """
-        def __get__(self):
-            return self.cxx_object().deltaH()
-        def __set__(self, double delta):
-            self.cxx_object().setDeltaH(delta)
 
     property allow_negative_pre_exponential_factor:
         """

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -268,6 +268,10 @@ cdef class BlowersMaselRate(ReactionRate):
     property delta_enthalpy:
         """
         Enthalpy change of reaction used to adjust activation energy [J/kmol]
+
+        Note: this method does not update the internal state; once a `BlowersMaselRate`
+        evaluator is linked to a `Kinetics` object, the enthalpy change is updated
+        automatically, which will overwrite a value assigned by the setter.
         """
         def __get__(self):
             return self.cxx_object().deltaH()
@@ -375,7 +379,9 @@ cdef class FalloffRate(ReactionRate):
         Get/Set the effective third-body concentration used for the reaction
         rate calculation.
 
-        Note: this method does not update internal state
+        Note: this method does not update the internal state; once a `FalloffRate`
+        evaluator is linked to a `Kinetics` object, the third-body concentration is
+        updated automatically, which will overwrite a value assigned by the setter.
         """
         def __get__(self):
             return self.falloff.thirdBodyConcentration()

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -382,20 +382,6 @@ cdef class FalloffRate(ReactionRate):
         def __set__(self, cbool activated):
             self.falloff.setChemicallyActivated(activated)
 
-    property third_body_concentration:
-        """
-        Get/Set the effective third-body concentration used for the reaction
-        rate calculation.
-
-        Note: this method does not update the internal state; once a `FalloffRate`
-        evaluator is linked to a `Kinetics` object, the third-body concentration is
-        updated automatically, which will overwrite a value assigned by the setter.
-        """
-        def __get__(self):
-            return self.falloff.thirdBodyConcentration()
-        def __set__(self, double conc):
-            self.falloff.setThirdBodyConcentration(conc)
-
     def falloff_function(self, double temperature, conc3b=None):
         """
         Evaluate the falloff function

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1284,8 +1284,8 @@ class TestReaction(utilities.CanteraTest):
     def test_Blowers_Masel_rate(self):
         gas = ct.Solution('BM_test.yaml')
         R = gas.reaction(0)
-        R.rate.delta_enthalpy = gas.delta_enthalpy[0]
-        self.assertNear(R.rate(gas.T), gas.forward_rate_constants[0], rtol=1e-7)
+        delta_enthalpy = gas.delta_enthalpy[0]
+        self.assertNear(R.rate(gas.T, delta_enthalpy), gas.forward_rate_constants[0], rtol=1e-7)
 
     def test_negative_A_blowersmasel(self):
         species = ct.Solution('BM_test.yaml').species()
@@ -1313,10 +1313,7 @@ class TestReaction(utilities.CanteraTest):
         deltaH = gas.delta_enthalpy[0]
         E = ((w + deltaH / 2) * (vp - 2 * w + deltaH) ** 2 /
             (vp ** 2 - 4 * w ** 2 + deltaH ** 2))
-        # work-around: internal rates are not linked
-        # (i.e. reaction rate object holds a copy of the rate object)
-        gas.reaction(0).rate.delta_enthalpy = gas.delta_enthalpy[0]
-        self.assertNear(E, gas.reaction(0).rate.activation_energy)
+        self.assertNear(E, gas.reaction(0).rate.activation_energy(deltaH))
 
         deltaH_high = 10 * gas.reaction(0).rate.intrinsic_activation_energy
         deltaH_low = -20 * gas.reaction(0).rate.intrinsic_activation_energy
@@ -1328,8 +1325,7 @@ class TestReaction(utilities.CanteraTest):
         species.thermo = ct.NasaPoly2(species.thermo.min_temp, species.thermo.max_temp,
                             species.thermo.reference_pressure, perturbed_coeffs)
         gas.modify_species(index, species)
-        gas.reaction(0).rate.delta_enthalpy = deltaH_high
-        self.assertEqual(deltaH_high, gas.reaction(0).rate.activation_energy)
+        self.assertEqual(deltaH_high, gas.reaction(0).rate.activation_energy(deltaH_high))
         self.assertNear(A*gas.T**b*np.exp(-deltaH_high/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
 
         perturbed_coeffs = species.thermo.coeffs.copy()
@@ -1338,8 +1334,7 @@ class TestReaction(utilities.CanteraTest):
         species.thermo = ct.NasaPoly2(species.thermo.min_temp, species.thermo.max_temp,
                             species.thermo.reference_pressure, perturbed_coeffs)
         gas.modify_species(index, species)
-        gas.reaction(0).rate.delta_enthalpy = deltaH_low
-        self.assertEqual(0, gas.reaction(0).rate.activation_energy)
+        self.assertEqual(0, gas.reaction(0).rate.activation_energy(deltaH_low))
         self.assertNear(A*gas.T**b*np.exp(0/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
 
     def test_interface(self):
@@ -1507,10 +1502,10 @@ class TestReaction(utilities.CanteraTest):
         gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
         gas.TP = self.gas.TP
         R = gas.reaction(0)
-        R.rate.delta_enthalpy = gas.delta_enthalpy[0]
+        delta_enthalpy = gas.delta_enthalpy[0]
         A1 = R.rate.pre_exponential_factor
         b1 = R.rate.temperature_exponent
-        Ta1 = R.rate.activation_energy / ct.gas_constant
+        Ta1 = R.rate.activation_energy(delta_enthalpy) / ct.gas_constant
         T = gas.T
         self.assertNear(A1 * T**b1 * np.exp(-Ta1 / T), gas.forward_rate_constants[0])
 
@@ -1520,8 +1515,8 @@ class TestReaction(utilities.CanteraTest):
         Ta_intrinsic = R.rate.intrinsic_activation_energy * 1.2
         w = R.rate.bond_energy * 0.8
         R.rate = ct.BlowersMaselRate(A2, b2, Ta_intrinsic, w)
-        R.rate.delta_enthalpy = gas.delta_enthalpy[0]
-        Ta2 = R.rate.activation_energy / ct.gas_constant
+        delta_enthalpy = gas.delta_enthalpy[0]
+        Ta2 = R.rate.activation_energy(delta_enthalpy) / ct.gas_constant
         gas.modify_reaction(0, R)
         self.assertNear(A2 * T**b2 * np.exp(-Ta2 / T), gas.forward_rate_constants[0])
 

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -138,14 +138,12 @@ void ArrheniusRate::getParameters(AnyMap& rateNode) const
 
 BlowersMaselRate::BlowersMaselRate()
     : m_w_R(NAN)
-    , m_deltaH_R(NAN)
 {
 }
 
 BlowersMaselRate::BlowersMaselRate(double A, double b, double Ea0, double w)
     : ArrheniusBase(A, b, Ea0)
     , m_w_R(w / GasConstant)
-    , m_deltaH_R(NAN)
 {
 }
 

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -197,6 +197,7 @@ void BulkKinetics::modifyReaction(size_t i, shared_ptr<Reaction> rNew)
 
         // Replace reaction rate to evaluator
         size_t index = m_bulk_types[rate->type()];
+        rNew->rate()->setRateIndex(i);
         m_bulk_rates[index]->replace(i, *rate);
     }
 }

--- a/src/kinetics/Custom.cpp
+++ b/src/kinetics/Custom.cpp
@@ -19,7 +19,7 @@ void CustomFunc1Rate::setRateFunction(shared_ptr<Func1> f)
     m_ratefunc = f;
 }
 
-double CustomFunc1Rate::evalFromStruct(const CustomFunc1Data& shared_data) const
+double CustomFunc1Rate::evalFromStruct(const ArrheniusData& shared_data) const
 {
     if (m_ratefunc) {
         return m_ratefunc->eval(shared_data.temperature);

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -19,10 +19,9 @@ GasKinetics::GasKinetics(ThermoPhase* thermo) :
 {
 }
 
-void GasKinetics::getThirdBodyConcentrations(double* concm) const
+void GasKinetics::getThirdBodyConcentrations(double* concm)
 {
-    // @todo ... address/reassess, as correctness of values is subject to
-    //      update_rates_C having been called with the current thermo state.
+    updateROP();
     std::copy(m_concm.begin(), m_concm.end(), concm);
 }
 

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -52,9 +52,6 @@ void BlowersMaselData::update(double T, double P)
 
 void BlowersMaselData::update(double T, double P, double deltaH)
 {
-    if (ready) {
-        throw CanteraError("BlowersMaselData::update", "This should not be reachable.");
-    }
     ReactionData::update(T, P);
     dH[0] = deltaH;
 }
@@ -104,9 +101,6 @@ void FalloffData::update(double T, double P)
 
 void FalloffData::update(double T, double P, double M)
 {
-    if (ready) {
-        throw CanteraError("FalloffData::update", "This should not be reachable.");
-    }
     ReactionData::update(T, P);
     conc_3b[0] = M;
 }

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -85,13 +85,4 @@ std::pair<bool, bool> ChebyshevData::update(const ThermoPhase& bulk,
     return changed;
 }
 
-std::pair<bool, bool> CustomFunc1Data::update(const ThermoPhase& bulk,
-                                              const Kinetics& kin)
-{
-    double T = bulk.temperature();
-    std::pair<bool, bool> changed { false, T != temperature };
-    temperature = T;
-    return changed;
-}
-
 }

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -11,16 +11,15 @@
 namespace Cantera
 {
 
-void ReactionData::update(double T, double P, double extra)
+void ReactionData::update(double T, double extra)
 {
     throw NotImplementedError("ReactionData::update",
-        "Update with extra argument not implemented.");
+        "ReactionData type does not use extra argument.");
 }
 
 bool ArrheniusData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double T = bulk.temperature();
-    pressure = bulk.pressure();
     if (T == temperature) {
         return false;
     }
@@ -39,20 +38,12 @@ BlowersMaselData::BlowersMaselData()
 void BlowersMaselData::update(double T)
 {
     throw CanteraError("BlowersMaselData::update",
-        "Missing state information: reaction type requires temperature, "
-        "pressure\nand enthalpy change.");
+        "Missing state information: 'BlowersMaselData' requires enthalpy change.");
 }
 
-void BlowersMaselData::update(double T, double P)
+void BlowersMaselData::update(double T, double deltaH)
 {
-    throw CanteraError("BlowersMaselData::update",
-        "Missing state information: reaction type requires temperature, "
-        "pressure\nand enthalpy change.");
-}
-
-void BlowersMaselData::update(double T, double P, double deltaH)
-{
-    ReactionData::update(T, P);
+    ReactionData::update(T);
     dH[0] = deltaH;
 }
 
@@ -73,7 +64,6 @@ bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
         kin.getReactionDelta(m_grt.data(), dH.data());
         changed = true;
     }
-    pressure = bulk.pressure();
     return changed;
 }
 
@@ -88,20 +78,12 @@ FalloffData::FalloffData()
 void FalloffData::update(double T)
 {
     throw CanteraError("FalloffData::update",
-        "Missing state information: reaction type requires temperature, "
-        "pressure\nand third-body concentration.");
+        "Missing state information: 'FalloffData' requires third-body concentration.");
 }
 
-void FalloffData::update(double T, double P)
+void FalloffData::update(double T, double M)
 {
-    throw CanteraError("FalloffData::update",
-        "Missing state information: reaction type requires temperature, "
-        "pressure\nand third-body concentration.");
-}
-
-void FalloffData::update(double T, double P, double M)
-{
-    ReactionData::update(T, P);
+    ReactionData::update(T);
     conc_3b[0] = M;
 }
 
@@ -122,14 +104,13 @@ bool FalloffData::update(const ThermoPhase& bulk, const Kinetics& kin)
         std::copy(concm.begin(), concm.end(), conc_3b.begin());
         changed = true;
     }
-    pressure = bulk.pressure();
     return changed;
 }
 
 void PlogData::update(double T)
 {
     throw CanteraError("PlogData::update",
-        "Missing state information: reaction type requires pressure.");
+        "Missing state information: 'PlogData' requires pressure.");
 }
 
 bool PlogData::update(const ThermoPhase& bulk, const Kinetics& kin)
@@ -146,7 +127,7 @@ bool PlogData::update(const ThermoPhase& bulk, const Kinetics& kin)
 void ChebyshevData::update(double T)
 {
     throw CanteraError("ChebyshevData::update",
-        "Missing state information: reaction type requires pressure.");
+        "Missing state information: 'ChebyshevData' requires pressure.");
 }
 
 bool ChebyshevData::update(const ThermoPhase& bulk, const Kinetics& kin)

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -11,6 +11,12 @@
 namespace Cantera
 {
 
+void ReactionData::update(double T, double P, double extra)
+{
+    throw NotImplementedError("ReactionData::update",
+        "Update with extra argument not implemented.");
+}
+
 bool ArrheniusData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double T = bulk.temperature();

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -17,6 +17,7 @@ std::pair<bool, bool> ArrheniusData::update(const ThermoPhase& bulk,
     double T = bulk.temperature();
     std::pair<bool, bool> changed{ false, T != temperature };
     update(T);
+    pressure = bulk.pressure();
     return changed;
 }
 
@@ -35,6 +36,7 @@ std::pair<bool, bool> BlowersMaselData::update(const ThermoPhase& bulk,
         changed.first = changed.second = true;
     }
     update(T);
+    pressure = bulk.pressure();
     return changed;
 }
 
@@ -51,6 +53,7 @@ std::pair<bool, bool> FalloffData::update(const ThermoPhase& bulk, const Kinetic
         changed.first = changed.second = true;
     }
     update(T);
+    pressure = bulk.pressure();
     return changed;
 }
 

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -118,7 +118,8 @@ bool FalloffData::update(const ThermoPhase& bulk, const Kinetics& kin)
     if (rho_m != molar_density || mf != m_state_mf_number) {
         molar_density = rho_m;
         m_state_mf_number = mf;
-        kin.getThirdBodyConcentrations(conc_3b.data());
+        auto& concm = kin.thirdBodyConcentrations();
+        std::copy(concm.begin(), concm.end(), conc_3b.begin());
         changed = true;
     }
     pressure = bulk.pressure();

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -11,48 +11,54 @@
 namespace Cantera
 {
 
-std::pair<bool, bool> ArrheniusData::update(const ThermoPhase& bulk,
-                                            const Kinetics& kin)
+bool ArrheniusData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double T = bulk.temperature();
-    std::pair<bool, bool> changed{ false, T != temperature };
-    update(T);
     pressure = bulk.pressure();
-    return changed;
+    if (T == temperature) {
+        return false;
+    }
+    update(T);
+    return true;
 }
 
-std::pair<bool, bool> BlowersMaselData::update(const ThermoPhase& bulk,
-                                               const Kinetics& kin)
+bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double rho = bulk.density();
     int mf = bulk.stateMFNumber();
     double T = bulk.temperature();
-    std::pair<bool, bool> changed { false, T != temperature };
-    if (T != temperature || rho != density || mf != m_state_mf_number) {
+    bool changed = false;
+    if (T != temperature) {
+        update(T);
+        changed = true;
+    }
+    if (changed || rho != density || mf != m_state_mf_number) {
         density = rho;
         m_state_mf_number = mf;
         bulk.getPartialMolarEnthalpies(m_grt.data());
         kin.getReactionDelta(m_grt.data(), dH.data());
-        changed.first = changed.second = true;
+        changed = true;
     }
-    update(T);
     pressure = bulk.pressure();
     return changed;
 }
 
-std::pair<bool, bool> FalloffData::update(const ThermoPhase& bulk, const Kinetics& kin)
+bool FalloffData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double rho_m = bulk.molarDensity();
     int mf = bulk.stateMFNumber();
     double T = bulk.temperature();
-    std::pair<bool, bool> changed { false, T != temperature };
+    bool changed = false;
+    if (T != temperature) {
+        update(T);
+        changed = true;
+    }
     if (rho_m != molar_density || mf != m_state_mf_number) {
         molar_density = rho_m;
         m_state_mf_number = mf;
         kin.getThirdBodyConcentrations(conc_3b.data());
-        changed.first = changed.second = true;
+        changed = true;
     }
-    update(T);
     pressure = bulk.pressure();
     return changed;
 }
@@ -63,13 +69,15 @@ void PlogData::update(double T)
         "Missing state information: reaction type requires pressure.");
 }
 
-std::pair<bool, bool> PlogData::update(const ThermoPhase& bulk, const Kinetics& kin)
+bool PlogData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double T = bulk.temperature();
     double P = bulk.pressure();
-    std::pair<bool, bool> changed{ P != pressure, P != pressure || T != temperature };
-    update(T, P);
-    return changed;
+    if (P != pressure || T != temperature) {
+        update(T, P);
+        return true;
+    }
+    return false;
 }
 
 void ChebyshevData::update(double T)
@@ -78,14 +86,15 @@ void ChebyshevData::update(double T)
         "Missing state information: reaction type requires pressure.");
 }
 
-std::pair<bool, bool> ChebyshevData::update(const ThermoPhase& bulk,
-                                            const Kinetics& kin)
+bool ChebyshevData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double T = bulk.temperature();
     double P = bulk.pressure();
-    std::pair<bool, bool> changed{ P != pressure, P != pressure || T != temperature };
-    update(T, P);
-    return changed;
+    if (P != pressure || T != temperature) {
+        update(T, P);
+        return true;
+    }
+    return false;
 }
 
 }

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -49,6 +49,37 @@ bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
     return changed;
 }
 
+FalloffData::FalloffData()
+    : ready(false)
+    , molar_density(NAN)
+    , m_state_mf_number(-1)
+{
+    conc_3b.resize(1, NAN);
+}
+
+void FalloffData::update(double T)
+{
+    throw CanteraError("FalloffData::update",
+        "Missing state information: reaction type requires temperature, "
+        "pressure\nand third-body concentration.");
+}
+
+void FalloffData::update(double T, double P)
+{
+    throw CanteraError("FalloffData::update",
+        "Missing state information: reaction type requires temperature, "
+        "pressure\nand third-body concentration.");
+}
+
+void FalloffData::update(double T, double P, double M)
+{
+    if (ready) {
+        throw CanteraError("FalloffData::update", "This should not be reachable.");
+    }
+    ReactionData::update(T, P);
+    conc_3b[0] = M;
+}
+
 bool FalloffData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double rho_m = bulk.molarDensity();
@@ -56,7 +87,7 @@ bool FalloffData::update(const ThermoPhase& bulk, const Kinetics& kin)
     double T = bulk.temperature();
     bool changed = false;
     if (T != temperature) {
-        update(T);
+        ReactionData::update(T);
         changed = true;
     }
     if (rho_m != molar_density || mf != m_state_mf_number) {

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -28,6 +28,37 @@ bool ArrheniusData::update(const ThermoPhase& bulk, const Kinetics& kin)
     return true;
 }
 
+BlowersMaselData::BlowersMaselData()
+    : ready(false)
+    , density(NAN)
+    , m_state_mf_number(-1)
+{
+    dH.resize(1, NAN);
+}
+
+void BlowersMaselData::update(double T)
+{
+    throw CanteraError("BlowersMaselData::update",
+        "Missing state information: reaction type requires temperature, "
+        "pressure\nand enthalpy change.");
+}
+
+void BlowersMaselData::update(double T, double P)
+{
+    throw CanteraError("BlowersMaselData::update",
+        "Missing state information: reaction type requires temperature, "
+        "pressure\nand enthalpy change.");
+}
+
+void BlowersMaselData::update(double T, double P, double deltaH)
+{
+    if (ready) {
+        throw CanteraError("BlowersMaselData::update", "This should not be reachable.");
+    }
+    ReactionData::update(T, P);
+    dH[0] = deltaH;
+}
+
 bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
 {
     double rho = bulk.density();
@@ -35,7 +66,7 @@ bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
     double T = bulk.temperature();
     bool changed = false;
     if (T != temperature) {
-        update(T);
+        ReactionData::update(T);
         changed = true;
     }
     if (changed || rho != density || mf != m_state_mf_number) {

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -20,23 +20,6 @@ std::pair<bool, bool> ArrheniusData::update(const ThermoPhase& bulk,
     return changed;
 }
 
-void BlowersMaselData::update(double T)
-{
-    temperature = T;
-    logT = std::log(T);
-    recipT = 1./T;
-}
-
-BlowersMaselData::BlowersMaselData()
-    : temperature(1.)
-    , logT(0.)
-    , recipT(1.)
-    , density(NAN)
-    , state_mf_number(-1)
-    , finalized(false)
-{
-}
-
 std::pair<bool, bool> BlowersMaselData::update(const ThermoPhase& bulk,
                                                const Kinetics& kin)
 {
@@ -44,9 +27,9 @@ std::pair<bool, bool> BlowersMaselData::update(const ThermoPhase& bulk,
     int mf = bulk.stateMFNumber();
     double T = bulk.temperature();
     std::pair<bool, bool> changed { false, T != temperature };
-    if (T != temperature || rho != density || mf != state_mf_number) {
+    if (T != temperature || rho != density || mf != m_state_mf_number) {
         density = rho;
-        state_mf_number = mf;
+        m_state_mf_number = mf;
         bulk.getPartialMolarEnthalpies(m_grt.data());
         kin.getReactionDelta(m_grt.data(), dH.data());
         changed.first = changed.second = true;
@@ -61,9 +44,9 @@ std::pair<bool, bool> FalloffData::update(const ThermoPhase& bulk, const Kinetic
     int mf = bulk.stateMFNumber();
     double T = bulk.temperature();
     std::pair<bool, bool> changed { false, T != temperature };
-    if (rho_m != molar_density || mf != state_mf_number) {
+    if (rho_m != molar_density || mf != m_state_mf_number) {
         molar_density = rho_m;
-        state_mf_number = mf;
+        m_state_mf_number = mf;
         kin.getThirdBodyConcentrations(conc_3b.data());
         changed.first = changed.second = true;
     }
@@ -92,7 +75,8 @@ void ChebyshevData::update(double T)
         "Missing state information: reaction type requires pressure.");
 }
 
-std::pair<bool, bool> ChebyshevData::update(const ThermoPhase& bulk, const Kinetics& kin)
+std::pair<bool, bool> ChebyshevData::update(const ThermoPhase& bulk,
+                                            const Kinetics& kin)
 {
     double T = bulk.temperature();
     double P = bulk.pressure();
@@ -101,7 +85,8 @@ std::pair<bool, bool> ChebyshevData::update(const ThermoPhase& bulk, const Kinet
     return changed;
 }
 
-std::pair<bool, bool> CustomFunc1Data::update(const ThermoPhase& bulk, const Kinetics& kin)
+std::pair<bool, bool> CustomFunc1Data::update(const ThermoPhase& bulk,
+                                              const Kinetics& kin)
 {
     double T = bulk.temperature();
     std::pair<bool, bool> changed { false, T != temperature };


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- implement inheritance for `ReactionData`
- remove `updateFromStruct`
- split `GasKinetics::updateROP` into multiple segments
- some preparatory work for a rebase of #1089
- replace buffer strategy for `FalloffReaction::thirdBodyConcentration` and `BlowersMasel::deltaH` by `ReactionData` avenue
- remove service methods that are no longer necessary
- remove access to `ddT` from rate objects (to be superseded by jacobian evaluators in #1089)

The PR further expands on ideas introduced in #1151

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

With this PR:
```
$ PYTHONPATH=build/python python interfaces/cython/cantera/examples/kinetics/custom_reactions.py
Average time of 100 simulation runs for 'gri30.yaml' (CH4)
- New framework (YAML): 109.55 ms (T_final=2736.60)
- One Python reaction: 118.21 ms (T_final=2736.60) ... +7.90%
- Old framework (XML): 116.51 ms (T_final=2736.60) ... +6.35%
```
compared to current `main`:
```
$ PYTHONPATH=build/python python interfaces/cython/cantera/examples/kinetics/custom_reactions.py
Average time of 100 simulation runs for 'gri30.yaml' (CH4)
- New framework (YAML): 109.40 ms (T_final=2736.60)
- One Python reaction: 117.50 ms (T_final=2736.60) ... +7.41%
- Old framework (XML): 117.32 ms (T_final=2736.60) ... +7.24%
```
I ran the speed tests several times; there appears to be no noticeable impact of the code reorganization on performance. At least on my machine, run-to-run variations are within 1-2 ms, so things are overall consistent. 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
