### PR TITLE
FEAT: Added additional tools for Fortran calling codes

### DIFF
--- a/include/cantera/base/NoExitLogger.h
+++ b/include/cantera/base/NoExitLogger.h
@@ -9,23 +9,18 @@
 #include <string>
 #include "cantera/base/logger.h"
 
-using namespace std;
-
-static std::string ss = "print \"\"\" ";
-
 namespace Cantera {
-
-  /// Logger that doesn't exit when an error is thrown.
-  /// @ingroup textlogs
-  class NoExitLogger : public Logger {
-  public:
+/// Logger that doesn't exit when an error is thrown.
+/// @ingroup textlogs
+class NoExitLogger : public Logger {
+public:
     NoExitLogger() {}
     virtual ~NoExitLogger() {}
 
     virtual void error(const std::string& msg)
     {
-      std::cerr << msg << std::endl;
+       std::cerr << msg << std::endl;
     }
-  };
+};
 }
 #endif

--- a/include/cantera/base/NoExitLogger.h
+++ b/include/cantera/base/NoExitLogger.h
@@ -1,0 +1,31 @@
+//! @file NoExitLogger.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef NOEXITLOGGER_H
+#define NOEXITLOGGER_H
+
+#include <string>
+#include "cantera/base/logger.h"
+
+using namespace std;
+
+static std::string ss = "print \"\"\" ";
+
+namespace Cantera {
+
+  /// Logger that doesn't exit when an error is thrown.
+  /// @ingroup textlogs
+  class NoExitLogger : public Logger {
+  public:
+    NoExitLogger() {}
+    virtual ~NoExitLogger() {}
+
+    virtual void error(const std::string& msg)
+    {
+      std::cerr << msg << std::endl;
+    }
+  };
+}
+#endif

--- a/samples/f90/demo.f90
+++ b/samples/f90/demo.f90
@@ -58,6 +58,7 @@ subroutine demo(gas, MAXSP, MAXRXNS)
 
   double precision q(MAXRXNS), qf(MAXRXNS), qr(MAXRXNS)
   double precision diff(MAXSP)
+  double precision molar_cp(MAXSP), molar_h(MAXSP), g_rt(MAXSP)
 
   character*80 eq
   character*20 name
@@ -117,6 +118,18 @@ subroutine demo(gas, MAXSP, MAXRXNS)
      call getSpeciesName(gas, k, name)
      write(*,40) name, diff(k)
 40   format(' ',a20,e14.5,' m2/s')
+  end do
+
+  ! Thermodynamic properties
+  CALL getPartialMolarCp(gas, molar_cp)
+  CALL getPartialMolarEnthalpies(gas, molar_h)
+  CALL getGibbs_RT(gas, g_rt)
+
+  write(*,*) 'Species molar cp, molar enthalpy, normalized Gibbs free energy'
+  do k = 1, nsp
+     call getSpeciesName(gas, k, name)
+     write(*,50) name, molar_cp(k), molar_h(k), g_rt(k)
+50   format(' ',a20,g14.5,' J/kmol-K',g14.5,' J/kmol',g14.5,'-')
   end do
 
   return

--- a/src/fortran/cantera.f90
+++ b/src/fortran/cantera.f90
@@ -111,6 +111,10 @@ MODULE CANTERA
      MODULE PROCEDURE ctfunc_getCanteraError
   END INTERFACE getCanteraError
 
+  INTERFACE turnOffExitOnError
+     MODULE PROCEDURE ctfunc_TurnOffExitOnError
+  END INTERFACE turnOffExitOnError
+
   INTERFACE getCp_R
      MODULE PROCEDURE ctthermo_getCp_R
   END INTERFACE getCp_R
@@ -130,6 +134,10 @@ MODULE CANTERA
   INTERFACE getEnthalpies_RT
      MODULE PROCEDURE ctthermo_getEnthalpies_RT
   END INTERFACE getEnthalpies_RT
+
+  INTERFACE getGibbs_RT
+     MODULE PROCEDURE ctthermo_getGibbs_RT
+  END INTERFACE getGibbs_RT
 
   INTERFACE getEntropies_R
      MODULE PROCEDURE ctthermo_getEntropies_R
@@ -182,6 +190,14 @@ MODULE CANTERA
   INTERFACE getPartialMolarIntEnergies
      MODULE PROCEDURE ctthermo_getPartialMolarIntEnerg_R
   END INTERFACE getPartialMolarIntEnergies
+
+  INTERFACE getPartialMolarCp
+     MODULE PROCEDURE ctthermo_getPartialMolarCp
+  END INTERFACE getPartialMolarCp
+
+  INTERFACE getPartialMolarEnthalpies
+     MODULE PROCEDURE ctthermo_getPartialMolarEnthalpies
+  END INTERFACE getPartialMolarEnthalpies
 
   INTERFACE getReactionString
      MODULE PROCEDURE ctkin_getReactionString
@@ -342,6 +358,10 @@ MODULE CANTERA
   INTERFACE setMassFractionsByName
      MODULE PROCEDURE ctthermo_setMassFractionsByName
   END INTERFACE setMassFractionsByName
+
+  INTERFACE setMassFractions_NoNorm
+     MODULE PROCEDURE ctthermo_setMassFractions_NoNorm
+  END INTERFACE setMassFractions_NoNorm
 
   INTERFACE setMoleFractions
      MODULE PROCEDURE ctthermo_setMoleFractions

--- a/src/fortran/cantera.f90
+++ b/src/fortran/cantera.f90
@@ -359,10 +359,6 @@ MODULE CANTERA
      MODULE PROCEDURE ctthermo_setMassFractionsByName
   END INTERFACE setMassFractionsByName
 
-  INTERFACE setMassFractions_NoNorm
-     MODULE PROCEDURE ctthermo_setMassFractions_NoNorm
-  END INTERFACE setMassFractions_NoNorm
-
   INTERFACE setMoleFractions
      MODULE PROCEDURE ctthermo_setMoleFractions
   END INTERFACE setMoleFractions

--- a/src/fortran/cantera_funcs.f90
+++ b/src/fortran/cantera_funcs.f90
@@ -86,10 +86,9 @@ module cantera_funcs
       ierr = ctgetCanteraError(buf)
     end subroutine ctfunc_getCanteraError
 
-    subroutine ctfunc_turnOffExitOnError(self)
+    subroutine ctfunc_turnOffExitOnError()
       implicit none
-      type(phase_t), intent(inout) :: self
-      self%err = ctturnOffExitOnError(self%thermo_id)
+      call ctturnOffExitOnError()
     end subroutine ctfunc_turnOffExitOnError
 
     subroutine ctfunc_addCanteraDirectory(self, buf)

--- a/src/fortran/cantera_funcs.f90
+++ b/src/fortran/cantera_funcs.f90
@@ -86,6 +86,12 @@ module cantera_funcs
       ierr = ctgetCanteraError(buf)
     end subroutine ctfunc_getCanteraError
 
+    subroutine ctfunc_turnOffExitOnError(self)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      self%err = ctturnOffExitOnError(self%thermo_id)
+    end subroutine ctfunc_turnOffExitOnError
+
     subroutine ctfunc_addCanteraDirectory(self, buf)
       implicit none
       type(phase_t), intent(inout) :: self

--- a/src/fortran/cantera_thermo.f90
+++ b/src/fortran/cantera_thermo.f90
@@ -217,13 +217,6 @@ contains
       self%err = phase_setmassfractionsbyname(self%thermo_id, y)
     end subroutine ctthermo_setmassfractionsbyname
 
-    subroutine ctthermo_setMassFractions_NoNorm(self, x)
-      implicit none
-      type(phase_t), intent(inout) :: self
-      double precision, intent(in) :: x(self%nsp)
-      self%err = phase_setMassFractions(self%thermo_id, x, 0)
-    end subroutine ctthermo_setMassFractions_NoNorm
-
     subroutine ctthermo_getAtomicWeights(self, atw)
       implicit none
       type(phase_t), intent(inout) :: self
@@ -556,7 +549,7 @@ contains
       implicit none
       type(phase_t), intent(inout) :: self
       double precision, intent(out) :: grt(self%nsp)
-      self%err = th_getpartialmolarenthalpies(self%thermo_id, grt)
+      self%err = th_getgibbs_rt(self%thermo_id, grt)
     end subroutine ctthermo_getGibbs_RT
 
     subroutine ctthermo_getEntropies_R(self, s_r)

--- a/src/fortran/cantera_thermo.f90
+++ b/src/fortran/cantera_thermo.f90
@@ -217,6 +217,13 @@ contains
       self%err = phase_setmassfractionsbyname(self%thermo_id, y)
     end subroutine ctthermo_setmassfractionsbyname
 
+    subroutine ctthermo_setMassFractions_NoNorm(self, x)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(in) :: x(self%nsp)
+      self%err = phase_setMassFractions(self%thermo_id, x, 0)
+    end subroutine ctthermo_setMassFractions_NoNorm
+
     subroutine ctthermo_getAtomicWeights(self, atw)
       implicit none
       type(phase_t), intent(inout) :: self
@@ -545,6 +552,13 @@ contains
       self%err = th_getenthalpies_rt(self%thermo_id, h_rt)
     end subroutine ctthermo_getenthalpies_rt
 
+    subroutine ctthermo_getGibbs_RT(self, grt)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(out) :: grt(self%nsp)
+      self%err = th_getpartialmolarenthalpies(self%thermo_id, grt)
+    end subroutine ctthermo_getGibbs_RT
+
     subroutine ctthermo_getEntropies_R(self, s_r)
       implicit none
       type(phase_t), intent(inout) :: self
@@ -567,4 +581,17 @@ contains
       self%err = th_getpartialmolarintenergies_r(self%thermo_id, ie)
     end subroutine ctthermo_getPartialMolarIntEnerg_R
 
+    subroutine ctthermo_getPartialMolarCp(self, cpbar)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(out) :: cpbar(self%nsp)
+      self%err = th_getpartialmolarcp(self%thermo_id, cpbar)
+    end subroutine ctthermo_getPartialMolarCp
+
+    subroutine ctthermo_getPartialMolarEnthalpies(self, hbar)
+      implicit none
+      type(phase_t), intent(inout) :: self
+      double precision, intent(out) :: hbar(self%nsp)
+      self%err = th_getpartialmolarenthalpies(self%thermo_id, hbar)
+    end subroutine ctthermo_getPartialMolarEnthalpies
 end module cantera_thermo

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -15,6 +15,7 @@
 #include "cantera/transport/TransportFactory.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/ctml.h"
+#include "cantera/base/NoExitLogger.h"
 #include "cantera/base/stringUtils.h"
 #include "cantera/kinetics/importKinetics.h"
 #include "clib/Cabinet.h"
@@ -86,6 +87,12 @@ extern "C" {
         std::string smsg = f2string(msg, msglen);
         throw CanteraError(sproc, smsg);
         return -1;
+    }
+
+    status_t ctturnoffexitonerror_(integer* buflen) {
+      Cantera::Logger* noexitlog = new Cantera::NoExitLogger;
+      setLogger(noexitlog);
+      return 0;
     }
 
     //--------------- Phase ---------------------//
@@ -614,6 +621,17 @@ extern "C" {
         return 0;
     }
 
+    status_t th_getgibbs_rt_(const integer* n,
+                             doublereal* grt) {
+      try {
+        thermo_t* thrm = _fth(n);
+        thrm->getGibbs_RT(grt);
+      } catch(...) {
+        return handleAllExceptions(-1, ERR);
+      }
+      return 0;
+    }
+
     status_t th_getentropies_r_(const integer* n, doublereal* s_r)
     {
         try {
@@ -645,6 +663,28 @@ extern "C" {
             return handleAllExceptions(-1, ERR);
         }
         return 0;
+    }
+
+    status_t th_getpartialmolarenthalpies_(const integer* n,
+                                           doublereal* hbar) {
+      try {
+        thermo_t* thrm = _fth(n);
+        thrm->getPartialMolarEnthalpies(hbar);
+      } catch(...) {
+        return handleAllExceptions(-1, ERR);
+      }
+      return 0;
+    }
+
+    status_t th_getpartialmolarcp_(const integer* n,
+                                   doublereal* cpbar) {
+      try {
+        thermo_t* thrm = _fth(n);
+        thrm->getPartialMolarCp(cpbar);
+      } catch(...) {
+        return handleAllExceptions(-1, ERR);
+      }
+      return 0;
     }
 
     //-------------- Kinetics ------------------//

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -89,10 +89,9 @@ extern "C" {
         return -1;
     }
 
-    status_t ctturnoffexitonerror_(integer* buflen) {
+    void ctturnoffexitonerror_() {
       Cantera::Logger* noexitlog = new Cantera::NoExitLogger;
       setLogger(noexitlog);
-      return 0;
     }
 
     //--------------- Phase ---------------------//
@@ -131,7 +130,7 @@ extern "C" {
         }
     }
 
-    doublereal phase_temperature_(const integer* n)
+    double phase_temperature_(const integer* n)
     {
         try {
             return _fph(n)->temperature();
@@ -140,7 +139,7 @@ extern "C" {
         }
     }
 
-    status_t phase_settemperature_(const integer* n, doublereal* t)
+    status_t phase_settemperature_(const integer* n, double* t)
     {
         try {
             _fph(n)->setTemperature(*t);
@@ -150,7 +149,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal phase_density_(const integer* n)
+    double phase_density_(const integer* n)
     {
         try {
             return _fph(n)->density();
@@ -159,7 +158,7 @@ extern "C" {
         }
     }
 
-    status_t phase_setdensity_(const integer* n, doublereal* rho)
+    status_t phase_setdensity_(const integer* n, double* rho)
     {
         try {
             _fph(n)->setDensity(*rho);
@@ -169,7 +168,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal phase_molardensity_(const integer* n)
+    double phase_molardensity_(const integer* n)
     {
         try {
             return _fph(n)->molarDensity();
@@ -178,7 +177,7 @@ extern "C" {
         }
     }
 
-    doublereal phase_meanmolecularweight_(const integer* n)
+    double phase_meanmolecularweight_(const integer* n)
     {
         try {
             return _fph(n)->meanMolecularWeight();
@@ -207,7 +206,7 @@ extern "C" {
         }
     }
 
-    status_t phase_getmolefractions_(const integer* n, doublereal* x)
+    status_t phase_getmolefractions_(const integer* n, double* x)
     {
         try {
             _fph(n)->getMoleFractions(x);
@@ -217,7 +216,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal phase_molefraction_(const integer* n, integer* k)
+    double phase_molefraction_(const integer* n, integer* k)
     {
         try {
             return _fph(n)->moleFraction(*k-1);
@@ -227,7 +226,7 @@ extern "C" {
 
     }
 
-    status_t phase_getmassfractions_(const integer* n, doublereal* y)
+    status_t phase_getmassfractions_(const integer* n, double* y)
     {
         try {
             ThermoPhase* p = _fph(n);
@@ -238,7 +237,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal phase_massfraction_(const integer* n, integer* k)
+    double phase_massfraction_(const integer* n, integer* k)
     {
         try {
             return _fph(n)->massFraction(*k-1);
@@ -273,7 +272,7 @@ extern "C" {
         return 0;
     }
 
-    status_t phase_setmassfractions_(const integer* n, doublereal* y, const integer* norm)
+    status_t phase_setmassfractions_(const integer* n, double* y, const integer* norm)
     {
         try {
             ThermoPhase* p = _fph(n);
@@ -299,7 +298,7 @@ extern "C" {
         return 0;
     }
 
-    status_t phase_getatomicweights_(const integer* n, doublereal* atw)
+    status_t phase_getatomicweights_(const integer* n, double* atw)
     {
         try {
             ThermoPhase* p = _fph(n);
@@ -311,7 +310,7 @@ extern "C" {
         return 0;
     }
 
-    status_t phase_getmolecularweights_(const integer* n, doublereal* mw)
+    status_t phase_getmolecularweights_(const integer* n, double* mw)
     {
         try {
             ThermoPhase* p = _fph(n);
@@ -353,7 +352,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal phase_natoms_(const integer* n, integer* k, integer* m)
+    double phase_natoms_(const integer* n, integer* k, integer* m)
     {
         try {
             return _fph(n)->nAtoms(*k-1,*m-1);
@@ -395,7 +394,7 @@ extern "C" {
         }
     }
 
-    doublereal th_enthalpy_mole_(const integer* n)
+    double th_enthalpy_mole_(const integer* n)
     {
         try {
             return _fth(n)->enthalpy_mole();
@@ -404,7 +403,7 @@ extern "C" {
         }
     }
 
-    doublereal th_intenergy_mole_(const integer* n)
+    double th_intenergy_mole_(const integer* n)
     {
         try {
             return _fth(n)->intEnergy_mole();
@@ -413,7 +412,7 @@ extern "C" {
         }
     }
 
-    doublereal th_entropy_mole_(const integer* n)
+    double th_entropy_mole_(const integer* n)
     {
         try {
             return _fth(n)->entropy_mole();
@@ -422,7 +421,7 @@ extern "C" {
         }
     }
 
-    doublereal th_gibbs_mole_(const integer* n)
+    double th_gibbs_mole_(const integer* n)
     {
         try {
             return _fth(n)->gibbs_mole();
@@ -431,7 +430,7 @@ extern "C" {
         }
     }
 
-    doublereal th_cp_mole_(const integer* n)
+    double th_cp_mole_(const integer* n)
     {
         try {
             return _fth(n)->cp_mole();
@@ -440,7 +439,7 @@ extern "C" {
         }
     }
 
-    doublereal th_cv_mole_(const integer* n)
+    double th_cv_mole_(const integer* n)
     {
         try {
             return _fth(n)->cv_mole();
@@ -449,7 +448,7 @@ extern "C" {
         }
     }
 
-    doublereal th_pressure_(const integer* n)
+    double th_pressure_(const integer* n)
     {
         try {
             return _fth(n)->pressure();
@@ -458,7 +457,7 @@ extern "C" {
         }
     }
 
-    doublereal th_enthalpy_mass_(const integer* n)
+    double th_enthalpy_mass_(const integer* n)
     {
         try {
             return _fth(n)->enthalpy_mass();
@@ -467,7 +466,7 @@ extern "C" {
         }
     }
 
-    doublereal th_intenergy_mass_(const integer* n)
+    double th_intenergy_mass_(const integer* n)
     {
         try {
             return _fth(n)->intEnergy_mass();
@@ -476,7 +475,7 @@ extern "C" {
         }
     }
 
-    doublereal th_entropy_mass_(const integer* n)
+    double th_entropy_mass_(const integer* n)
     {
         try {
             return _fth(n)->entropy_mass();
@@ -485,7 +484,7 @@ extern "C" {
         }
     }
 
-    doublereal th_gibbs_mass_(const integer* n)
+    double th_gibbs_mass_(const integer* n)
     {
         try {
             return _fth(n)->gibbs_mass();
@@ -494,7 +493,7 @@ extern "C" {
         }
     }
 
-    doublereal th_cp_mass_(const integer* n)
+    double th_cp_mass_(const integer* n)
     {
         try {
             return _fth(n)->cp_mass();
@@ -503,7 +502,7 @@ extern "C" {
         }
     }
 
-    doublereal th_cv_mass_(const integer* n)
+    double th_cv_mass_(const integer* n)
     {
         try {
             return _fth(n)->cv_mass();
@@ -512,7 +511,7 @@ extern "C" {
         }
     }
 
-    status_t th_chempotentials_(const integer* n, doublereal* murt)
+    status_t th_chempotentials_(const integer* n, double* murt)
     {
         try {
             ThermoPhase* thrm = _fth(n);
@@ -523,7 +522,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_setpressure_(const integer* n, doublereal* p)
+    status_t th_setpressure_(const integer* n, double* p)
     {
         try {
             _fth(n)->setPressure(*p);
@@ -533,7 +532,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_set_hp_(const integer* n, doublereal* v1, doublereal* v2)
+    status_t th_set_hp_(const integer* n, double* v1, double* v2)
     {
         try {
             _fth(n)->setState_HP(*v1, *v2);
@@ -543,7 +542,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_set_uv_(const integer* n, doublereal* v1, doublereal* v2)
+    status_t th_set_uv_(const integer* n, double* v1, double* v2)
     {
         try {
             _fth(n)->setState_UV(*v1, *v2);
@@ -553,7 +552,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_set_sv_(const integer* n, doublereal* v1, doublereal* v2)
+    status_t th_set_sv_(const integer* n, double* v1, double* v2)
     {
         try {
             _fth(n)->setState_SV(*v1, *v2);
@@ -563,7 +562,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_set_sp_(const integer* n, doublereal* v1, doublereal* v2)
+    status_t th_set_sp_(const integer* n, double* v1, double* v2)
     {
         try {
             _fth(n)->setState_SP(*v1, *v2);
@@ -573,7 +572,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_equil_(const integer* n, char* XY, char* solver, doublereal* rtol, int* max_steps, int* max_iter, int* estimate_equil, int* log_level, ftnlen lenxy, ftnlen lensolver)
+    status_t th_equil_(const integer* n, char* XY, char* solver, double* rtol, int* max_steps, int* max_iter, int* estimate_equil, int* log_level, ftnlen lenxy, ftnlen lensolver)
     {
         try {
             _fth(n)->equilibrate(f2string(XY,lenxy), f2string(solver,lensolver), *rtol, *max_steps, *max_iter, *estimate_equil, *log_level);
@@ -583,7 +582,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal th_refpressure_(const integer* n)
+    double th_refpressure_(const integer* n)
     {
         try {
             return _fth(n)->refPressure();
@@ -592,7 +591,7 @@ extern "C" {
         }
     }
 
-    doublereal th_mintemp_(const integer* n, integer* k)
+    double th_mintemp_(const integer* n, integer* k)
     {
         try {
             return _fth(n)->minTemp(*k-1);
@@ -601,7 +600,7 @@ extern "C" {
         }
     }
 
-    doublereal th_maxtemp_(const integer* n, integer* k)
+    double th_maxtemp_(const integer* n, integer* k)
     {
         try {
             return _fth(n)->maxTemp(*k-1);
@@ -610,7 +609,7 @@ extern "C" {
         }
     }
 
-    status_t th_getenthalpies_rt_(const integer* n, doublereal* h_rt)
+    status_t th_getenthalpies_rt_(const integer* n, double* h_rt)
     {
         try {
             ThermoPhase* thrm = _fth(n);
@@ -621,18 +620,17 @@ extern "C" {
         return 0;
     }
 
-    status_t th_getgibbs_rt_(const integer* n,
-                             doublereal* grt) {
+    status_t th_getgibbs_rt_(const integer* n, double* g_rt) {
       try {
-        thermo_t* thrm = _fth(n);
-        thrm->getGibbs_RT(grt);
+        ThermoPhase* thrm = _fth(n);
+        thrm->getGibbs_RT(g_rt);
       } catch(...) {
         return handleAllExceptions(-1, ERR);
       }
       return 0;
     }
 
-    status_t th_getentropies_r_(const integer* n, doublereal* s_r)
+    status_t th_getentropies_r_(const integer* n, double* s_r)
     {
         try {
             ThermoPhase* thrm = _fth(n);
@@ -643,7 +641,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_getcp_r_(const integer* n, integer* lenm, doublereal* cp_r)
+    status_t th_getcp_r_(const integer* n, integer* lenm, double* cp_r)
     {
         try {
             ThermoPhase* thrm = _fth(n);
@@ -654,7 +652,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_getpartialmolarintenergies_r_(const integer* n, doublereal* ie)
+    status_t th_getpartialmolarintenergies_r_(const integer* n, double* ie)
     {
         try {
             ThermoPhase* thrm = _fth(n);
@@ -665,8 +663,7 @@ extern "C" {
         return 0;
     }
 
-    status_t th_getpartialmolarenthalpies_(const integer* n,
-                                           doublereal* hbar) {
+    status_t th_getpartialmolarenthalpies_(const integer* n, double* hbar) {
       try {
         thermo_t* thrm = _fth(n);
         thrm->getPartialMolarEnthalpies(hbar);
@@ -676,8 +673,7 @@ extern "C" {
       return 0;
     }
 
-    status_t th_getpartialmolarcp_(const integer* n,
-                                   doublereal* cpbar) {
+    status_t th_getpartialmolarcp_(const integer* n, double* cpbar) {
       try {
         thermo_t* thrm = _fth(n);
         thrm->getPartialMolarCp(cpbar);
@@ -816,7 +812,7 @@ extern "C" {
         }
     }
 
-    doublereal kin_reactantstoichcoeff_(const integer* n, integer* k, integer* i)
+    double kin_reactantstoichcoeff_(const integer* n, integer* k, integer* i)
     {
         try {
             return _fkin(n)->reactantStoichCoeff(*k-1,*i-1);
@@ -825,7 +821,7 @@ extern "C" {
         }
     }
 
-    doublereal kin_productstoichcoeff_(const integer* n, integer* k, integer* i)
+    double kin_productstoichcoeff_(const integer* n, integer* k, integer* i)
     {
         try {
             return _fkin(n)->productStoichCoeff(*k-1,*i-1);
@@ -843,7 +839,7 @@ extern "C" {
         }
     }
 
-    status_t kin_getfwdratesofprogress_(const integer* n, doublereal* fwdROP)
+    status_t kin_getfwdratesofprogress_(const integer* n, double* fwdROP)
     {
         try {
             Kinetics* k = _fkin(n);
@@ -854,7 +850,7 @@ extern "C" {
         return 0;
     }
 
-    status_t kin_getrevratesofprogress_(const integer* n, doublereal* revROP)
+    status_t kin_getrevratesofprogress_(const integer* n, double* revROP)
     {
         try {
             Kinetics* k = _fkin(n);
@@ -874,7 +870,7 @@ extern "C" {
         }
     }
 
-    status_t kin_getnetratesofprogress_(const integer* n, doublereal* netROP)
+    status_t kin_getnetratesofprogress_(const integer* n, double* netROP)
     {
         try {
             Kinetics* k = _fkin(n);
@@ -885,7 +881,7 @@ extern "C" {
         return 0;
     }
 
-    status_t kin_getcreationrates_(const integer* n, doublereal* cdot)
+    status_t kin_getcreationrates_(const integer* n, double* cdot)
     {
         try {
             Kinetics* k = _fkin(n);
@@ -896,7 +892,7 @@ extern "C" {
         return 0;
     }
 
-    status_t kin_getdestructionrates_(const integer* n, doublereal* ddot)
+    status_t kin_getdestructionrates_(const integer* n, double* ddot)
     {
         try {
             Kinetics* k = _fkin(n);
@@ -907,7 +903,7 @@ extern "C" {
         return 0;
     }
 
-    status_t kin_getnetproductionrates_(const integer* n, doublereal* wdot)
+    status_t kin_getnetproductionrates_(const integer* n, double* wdot)
     {
         try {
             Kinetics* k = _fkin(n);
@@ -918,7 +914,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal kin_multiplier_(const integer* n, integer* i)
+    double kin_multiplier_(const integer* n, integer* i)
     {
         try {
             return _fkin(n)->multiplier(*i);
@@ -927,7 +923,7 @@ extern "C" {
         }
     }
 
-    status_t kin_getequilibriumconstants_(const integer* n, doublereal* kc)
+    status_t kin_getequilibriumconstants_(const integer* n, double* kc)
     {
         try {
             Kinetics* k = _fkin(n);
@@ -954,7 +950,7 @@ extern "C" {
         return 0;
     }
 
-    status_t kin_setmultiplier_(const integer* n, integer* i, doublereal* v)
+    status_t kin_setmultiplier_(const integer* n, integer* i, double* v)
     {
         try {
             _fkin(n)->setMultiplier(*i-1,*v);
@@ -964,7 +960,7 @@ extern "C" {
         return 0;
     }
 
-    status_t kin_advancecoverages_(const integer* n, doublereal* tstep)
+    status_t kin_advancecoverages_(const integer* n, double* tstep)
     {
         try {
             Kinetics* k = _fkin(n);
@@ -1006,7 +1002,7 @@ extern "C" {
         }
     }
 
-    doublereal trans_viscosity_(const integer* n)
+    double trans_viscosity_(const integer* n)
     {
         try {
             return _ftrans(n)->viscosity();
@@ -1015,7 +1011,7 @@ extern "C" {
         }
     }
 
-    doublereal trans_electricalconductivity_(const integer* n)
+    double trans_electricalconductivity_(const integer* n)
     {
         try {
             return _ftrans(n)->electricalConductivity();
@@ -1024,7 +1020,7 @@ extern "C" {
         }
     }
 
-    doublereal trans_thermalconductivity_(const integer* n)
+    double trans_thermalconductivity_(const integer* n)
     {
         try {
             return _ftrans(n)->thermalConductivity();
@@ -1033,7 +1029,7 @@ extern "C" {
         }
     }
 
-    status_t trans_getthermaldiffcoeffs_(const integer* n, doublereal* dt)
+    status_t trans_getthermaldiffcoeffs_(const integer* n, double* dt)
     {
         try {
             _ftrans(n)->getThermalDiffCoeffs(dt);
@@ -1043,7 +1039,7 @@ extern "C" {
         }
     }
 
-    status_t trans_getmixdiffcoeffs_(const integer* n, doublereal* d)
+    status_t trans_getmixdiffcoeffs_(const integer* n, double* d)
     {
         try {
             _ftrans(n)->getMixDiffCoeffs(d);
@@ -1053,7 +1049,7 @@ extern "C" {
         }
     }
 
-    status_t trans_getmixdiffcoeffsmass_(const integer* n, doublereal* d)
+    status_t trans_getmixdiffcoeffsmass_(const integer* n, double* d)
     {
         try {
             _ftrans(n)->getMixDiffCoeffsMass(d);
@@ -1063,7 +1059,7 @@ extern "C" {
         }
     }
 
-    status_t trans_getmixdiffcoeffsmole_(const integer* n, doublereal* d)
+    status_t trans_getmixdiffcoeffsmole_(const integer* n, double* d)
     {
         try {
             _ftrans(n)->getMixDiffCoeffsMole(d);
@@ -1073,7 +1069,7 @@ extern "C" {
         }
     }
 
-    status_t trans_getbindiffcoeffs_(const integer* n, integer* ld, doublereal* d)
+    status_t trans_getbindiffcoeffs_(const integer* n, integer* ld, double* d)
     {
         try {
             _ftrans(n)->getBinaryDiffCoeffs(*ld,d);
@@ -1083,7 +1079,7 @@ extern "C" {
         }
     }
 
-    status_t trans_getmultidiffcoeffs_(const integer* n, integer* ld, doublereal* d)
+    status_t trans_getmultidiffcoeffs_(const integer* n, integer* ld, double* d)
     {
         try {
             _ftrans(n)->getMultiDiffCoeffs(*ld,d);
@@ -1093,7 +1089,7 @@ extern "C" {
         }
     }
 
-    status_t trans_setparameters_(const integer* n, integer* type, integer* k, doublereal* d)
+    status_t trans_setparameters_(const integer* n, integer* type, integer* k, double* d)
     {
         try {
             _ftrans(n)->setParameters(*type, *k, d);

--- a/src/fortran/fct_interface.f90
+++ b/src/fortran/fct_interface.f90
@@ -4,14 +4,14 @@
 module fct
 interface
 
-   subroutine cantera_error(proc, msg)
-     character*(*), intent(in) :: proc
-     character*(*), intent(in) :: msg
-   end subroutine cantera_error
+    subroutine cantera_error(proc, msg)
+        character*(*), intent(in) :: proc
+        character*(*), intent(in) :: msg
+    end subroutine cantera_error
 
-   integer function phase_nelements(n)
-     integer, intent(in) :: n
-   end function phase_nelements
+    integer function phase_nelements(n)
+        integer, intent(in) :: n
+    end function phase_nelements
 
     integer function phase_nspecies(n)
         integer, intent(in) :: n
@@ -254,8 +254,8 @@ interface
     end function th_getenthalpies_rt
 
     integer function th_getgibbs_rt(n, grt)
-      integer, intent(in) :: n
-      double precision, intent(out) :: grt(*)
+        integer, intent(in) :: n
+        double precision, intent(out) :: grt(*)
     end function th_getgibbs_rt
 
     integer function th_getentropies_r(n, s_r)
@@ -275,13 +275,13 @@ interface
     end function th_getpartialmolarintenergies_r
 
     integer function th_getpartialmolarcp(n, cpbar)
-      integer, intent(in) :: n
-      double precision, intent(out) :: cpbar(*)
+        integer, intent(in) :: n
+        double precision, intent(out) :: cpbar(*)
     end function th_getpartialmolarcp
 
     integer function th_getpartialmolarenthalpies(n, hbar)
-      integer, intent(in) :: n
-      double precision, intent(out) :: hbar(*)
+        integer, intent(in) :: n
+        double precision, intent(out) :: hbar(*)
     end function th_getpartialmolarenthalpies
 
     integer function kin_newfromfile(filename, id, reactingPhase, neighbor1, neighbor2, neighbor3, neighbor4)
@@ -487,9 +487,8 @@ interface
         character*(*), intent(out) :: buf
     end function ctgetCanteraError
 
-    integer function ctturnOffExitOnError(id)
-      integer, intent(in) :: id
-    end function ctturnOffExitOnError
+    subroutine ctturnOffExitOnError()
+    end subroutine ctturnOffExitOnError
 
     integer function ctaddCanteraDirectory(buflen, buf)
         integer, intent(in) :: buflen

--- a/src/fortran/fct_interface.f90
+++ b/src/fortran/fct_interface.f90
@@ -253,6 +253,11 @@ interface
         double precision, intent(out) :: h_rt(*)
     end function th_getenthalpies_rt
 
+    integer function th_getgibbs_rt(n, grt)
+      integer, intent(in) :: n
+      double precision, intent(out) :: grt(*)
+    end function th_getgibbs_rt
+
     integer function th_getentropies_r(n, s_r)
         integer, intent(in) :: n
         double precision, intent(out) :: s_r(*)
@@ -268,6 +273,16 @@ interface
         integer, intent(in) :: n
         double precision, intent(out) :: ie(*)
     end function th_getpartialmolarintenergies_r
+
+    integer function th_getpartialmolarcp(n, cpbar)
+      integer, intent(in) :: n
+      double precision, intent(out) :: cpbar(*)
+    end function th_getpartialmolarcp
+
+    integer function th_getpartialmolarenthalpies(n, hbar)
+      integer, intent(in) :: n
+      double precision, intent(out) :: hbar(*)
+    end function th_getpartialmolarenthalpies
 
     integer function kin_newfromfile(filename, id, reactingPhase, neighbor1, neighbor2, neighbor3, neighbor4)
         character*(*), intent(in) :: filename
@@ -471,6 +486,10 @@ interface
     integer function ctgetCanteraError(buf)
         character*(*), intent(out) :: buf
     end function ctgetCanteraError
+
+    integer function ctturnOffExitOnError(id)
+      integer, intent(in) :: id
+    end function ctturnOffExitOnError
 
     integer function ctaddCanteraDirectory(buflen, buf)
         integer, intent(in) :: buflen

--- a/test_problems/fortran/f90_demo_blessed.txt
+++ b/test_problems/fortran/f90_demo_blessed.txt
@@ -67,3 +67,14 @@ Thermal conductivity:     0.16396      W/m/K
  H2O2                   0.97012E-03 m2/s
  AR                     0.75972E-03 m2/s
  N2                     0.97802E-03 m2/s
+ Species molar cp, molar enthalpy, normalized Gibbs free energy
+ H2                      36617.     J/kmol-K   0.81393E+08 J/kmol   -20.604    -
+ H                       20786.     J/kmol-K   0.27002E+09 J/kmol   -7.8028    -
+ O                       20896.     J/kmol-K   0.30159E+09 J/kmol   -12.099    -
+ O2                      39570.     J/kmol-K   0.90189E+08 J/kmol   -30.018    -
+ OH                      36680.     J/kmol-K   0.12182E+09 J/kmol   -25.365    -
+ H2O                     56098.     J/kmol-K  -0.12540E+09 J/kmol   -39.436    -
+ HO2                     59581.     J/kmol-K   0.14047E+09 J/kmol   -34.100    -
+ H2O2                    77993.     J/kmol-K   0.32003E+08 J/kmol   -43.168    -
+ AR                      20786.     J/kmol-K   0.52023E+08 J/kmol   -21.976    -
+ N2                      36896.     J/kmol-K   0.85374E+08 J/kmol   -28.119    -


### PR DESCRIPTION
This wraps a few additional functions into Fortran that we use in our calling code, and also adds a new feature -- an error logger that does not exit from within Cantera so a calling code can handle errors that arise. Mostly useful for Fortran calling codes that cannot catch exceptions. 