### PR TITLE
Use normal sign convention for reactor heat transfer

### DIFF
--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -204,7 +204,14 @@ protected:
     Kinetics* m_kin;
 
     doublereal m_vdot; //!< net rate of volume change from moving walls [m^3/s]
-    doublereal m_Q; //!< net heat transfer through walls [W]
+
+    //! net heat transfer out of the reactor, through walls [W]
+    //! @deprecated To be removed after Cantera 2.6. Replaced with #m_Qdot, which
+    //!     has the opposite sign convention.
+    double m_Q;
+
+    double m_Qdot; //!< net heat transfer into the reactor, through walls [W]
+
     doublereal m_mass; //!< total mass
     vector_fp m_work;
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -266,6 +266,9 @@ protected:
 
     std::vector<WallBase*> m_wall;
     std::vector<ReactorSurface*> m_surfaces;
+
+    //! Vector of length nWalls(), indicating whether this reactor is on the left (0)
+    //! or right (1) of each wall.
     vector_int m_lr;
     std::string m_name;
 

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -87,7 +87,7 @@ void ConstPressureReactor::evalEqs(doublereal time, doublereal* y,
     }
 
     // external heat transfer
-    double dHdt = - m_Q;
+    double dHdt = m_Qdot;
 
     // add terms for outlets
     for (auto outlet : m_outlet) {

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -89,7 +89,7 @@ void IdealGasConstPressureReactor::evalEqs(doublereal time, doublereal* y,
     }
 
     // external heat transfer
-    mcpdTdt -= m_Q;
+    mcpdTdt += m_Qdot;
 
     for (size_t n = 0; n < m_nsp; n++) {
         // heat release from gas phase and surface reactions

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -92,7 +92,7 @@ void IdealGasReactor::evalEqs(doublereal time, doublereal* y,
     dmdt += mdot_surf;
 
     // compression work and external heat transfer
-    mcvdTdt += - m_pressure * m_vdot - m_Q;
+    mcvdTdt += - m_pressure * m_vdot + m_Qdot;
 
     for (size_t n = 0; n < m_nsp; n++) {
         // heat release from gas phase and surface reactions

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -23,6 +23,7 @@ Reactor::Reactor() :
     m_kin(0),
     m_vdot(0.0),
     m_Q(0.0),
+    m_Qdot(0.0),
     m_mass(0.0),
     m_chem(false),
     m_energy(true),
@@ -230,7 +231,7 @@ void Reactor::evalEqs(doublereal time, doublereal* y,
     //     \dot U = -P\dot V + A \dot q + \dot m_{in} h_{in} - \dot m_{out} h.
     // \f]
     if (m_energy) {
-        ydot[2] = - m_thermo->pressure() * m_vdot - m_Q;
+        ydot[2] = - m_thermo->pressure() * m_vdot + m_Qdot;
     } else {
         ydot[2] = 0.0;
     }
@@ -265,12 +266,13 @@ void Reactor::evalEqs(doublereal time, doublereal* y,
 void Reactor::evalWalls(double t)
 {
     m_vdot = 0.0;
-    m_Q = 0.0;
+    m_Qdot = 0.0;
     for (size_t i = 0; i < m_wall.size(); i++) {
-        int lr = 1 - 2*m_lr[i];
-        m_vdot += lr*m_wall[i]->vdot(t);
-        m_Q += lr*m_wall[i]->Q(t);
+        int f = 2 * m_lr[i] - 1;
+        m_vdot -= f * m_wall[i]->vdot(t);
+        m_Qdot += f * m_wall[i]->Q(t);
     }
+    m_Q = -m_Qdot;
 }
 
 double Reactor::evalSurfaces(double t, double* ydot)


### PR DESCRIPTION
Heat transfer _into_ a system is normally considered positive, and the internal variables used within `Reactor` should reflect this convention.

This does not change the sign convention from the perspective of a wall between two reactors is unchanged, where a positive value indicates heat transfer from the left to the right, which I think is consistent.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Calculate `Reactor::m_Qdot` using the updated sign convention, and use this to set `Reactor::m_Q` following the existing convention
- Use `Reactor::m_Qdot` in calculations for all reactor models instead of `m_Q`
- Deprecate `Reactor::m_Q`

The `Reactor::m_Q` variable is a `protected` member of the `Reactor` class, with no accessor, so this can only affect user-generated classes derived from `Reactor`. However, fixing this is important for #1003, which does introduce a getter/setter pair for this net heat transfer, and using the normal sign convention would prevent some surprising behavior.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
