### PR TITLE
Fix MSVC-specific compiler warnings / tweak method names

### DIFF
--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -107,7 +107,7 @@ struct UnitStack
         : stack(units) {}
 
     //! Size of UnitStack
-    int size() const { return stack.size(); }
+    size_t size() const { return stack.size(); }
 
     //! Get standard unit used by UnitStack
     Units standardUnits() const;

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -155,7 +155,7 @@ public:
         R[m_rxn] -= S[m_ic0];
     }
 
-    void resizeCoeffs(const std::map<std::pair<int, int>, size_t>& indices)
+    void resizeCoeffs(const std::map<std::pair<size_t, size_t>, size_t>& indices)
     {
         m_jc0 = indices.at({m_rxn, m_ic0});
     }
@@ -217,7 +217,7 @@ public:
         R[m_rxn] -= (S[m_ic0] + S[m_ic1]);
     }
 
-    void resizeCoeffs(const std::map<std::pair<int, int>, size_t>& indices)
+    void resizeCoeffs(const std::map<std::pair<size_t, size_t>, size_t>& indices)
     {
         m_jc0 = indices.at({m_rxn, m_ic0});
         m_jc1 = indices.at({m_rxn, m_ic1});
@@ -288,7 +288,7 @@ public:
         R[m_rxn] -= (S[m_ic0] + S[m_ic1] + S[m_ic2]);
     }
 
-    void resizeCoeffs(const std::map<std::pair<int, int>, size_t>& indices)
+    void resizeCoeffs(const std::map<std::pair<size_t, size_t>, size_t>& indices)
     {
         m_jc0 = indices.at({m_rxn, m_ic0});
         m_jc1 = indices.at({m_rxn, m_ic1});
@@ -395,7 +395,7 @@ public:
         }
     }
 
-    void resizeCoeffs(const std::map<std::pair<int, int>, size_t>& indices)
+    void resizeCoeffs(const std::map<std::pair<size_t, size_t>, size_t>& indices)
     {
         for (size_t i = 0; i < m_n; i++) {
             m_jc[i] = indices.at({m_rxn, m_ic[i]});
@@ -477,7 +477,7 @@ private:
      */
     vector_fp m_stoich;
 
-    vector_int m_jc; //!< Indices in derivative triplet vector
+    std::vector<size_t> m_jc; //!< Indices in derivative triplet vector
 
     double m_sum_order; //!< Sum of reaction order vector
 };
@@ -635,11 +635,12 @@ public:
         m_values.resize(nCoeffs, 0.);
 
         // Set up index pairs for derivatives
-        std::map<std::pair<int, int>, size_t> indices;
+        std::map<std::pair<size_t, size_t>, size_t> indices;
         size_t n = 0;
         for (int i = 0; i < tmp.outerSize(); i++) {
             for (Eigen::SparseMatrix<double>::InnerIterator it(tmp, i); it; ++it) {
-                indices[{it.row(), it.col()}] = n++;
+                indices[{static_cast<size_t>(it.row()),
+                    static_cast<size_t>(it.col())}] = n++;
             }
         }
         // update reaction setup
@@ -695,7 +696,8 @@ public:
         }
         bool frac = false;
         for (size_t n = 0; n < stoich.size(); n++) {
-            m_coeffList.emplace_back(k[n], rxn, stoich[n]);
+            m_coeffList.emplace_back(
+                static_cast<int>(k[n]), static_cast<int>(rxn), stoich[n]);
             if (fmod(stoich[n], 1.0) || stoich[n] != order[n]) {
                 frac = true;
             }

--- a/include/cantera/kinetics/ThirdBodyCalc.h
+++ b/include/cantera/kinetics/ThirdBodyCalc.h
@@ -107,7 +107,8 @@ public:
             m_species.back().push_back(eff.first);
             m_eff.back().push_back(eff.second - default_efficiency);
             m_efficiencyList.emplace_back(
-                rxnNumber, eff.first, eff.second - default_efficiency);
+                static_cast<int>(rxnNumber),
+                static_cast<int>(eff.first), eff.second - default_efficiency);
         }
     }
 
@@ -127,7 +128,9 @@ public:
         for (size_t i = 0; i < m_default.size(); i++) {
             if (m_default[i] != 0) {
                 for (size_t j = 0; j < nSpc; j++) {
-                    triplets.emplace_back(m_reaction_index[i], j, m_default[i]);
+                    triplets.emplace_back(
+                        static_cast<int>(m_reaction_index[i]),
+                        static_cast<int>(j), m_default[i]);
                 }
             }
         }

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -623,7 +623,7 @@ cdef class Kinetics(_SolutionBase):
                 return _scipy_sparse.csc_matrix(tup, shape=shape)
             return get_dense(self, kin_netRatesOfProgress_ddX)
 
-    property creation_rate_ddT:
+    property creation_rates_ddT:
         """
         Calculate derivatives of species creation rates with respect to temperature
         at constant pressure, molar concentration and mole fractions.
@@ -631,7 +631,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getCreationRates_ddT)
 
-    property creation_rate_ddP:
+    property creation_rates_ddP:
         """
         Calculate derivatives of species creation rates with respect to pressure
         at constant temperature, molar concentration and mole fractions.
@@ -639,7 +639,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getCreationRates_ddP)
 
-    property creation_rate_ddC:
+    property creation_rates_ddC:
         """
         Calculate derivatives of species creation rates with respect to molar
         concentration at constant temperature, pressure and mole fractions.
@@ -647,7 +647,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getCreationRates_ddC)
 
-    property creation_rate_ddX:
+    property creation_rates_ddX:
         """
         Calculate derivatives for species creation rates with respect to species
         concentrations at constant temperature, pressure and molar concentration.
@@ -663,7 +663,7 @@ cdef class Kinetics(_SolutionBase):
                 return _scipy_sparse.csc_matrix(tup, shape=shape)
             return get_dense(self, kin_creationRates_ddX)
 
-    property destruction_rate_ddT:
+    property destruction_rates_ddT:
         """
         Calculate derivatives of species destruction rates with respect to temperature
         at constant pressure, molar concentration and mole fractions.
@@ -671,7 +671,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getDestructionRates_ddT)
 
-    property destruction_rate_ddP:
+    property destruction_rates_ddP:
         """
         Calculate derivatives of species destruction rates with respect to pressure
         at constant temperature, molar concentration and mole fractions.
@@ -679,7 +679,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getDestructionRates_ddP)
 
-    property destruction_rate_ddC:
+    property destruction_rates_ddC:
         """
         Calculate derivatives of species destruction rates with respect to molar
         concentration at constant temperature, pressure and mole fractions.
@@ -687,7 +687,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getDestructionRates_ddC)
 
-    property destruction_rate_ddX:
+    property destruction_rates_ddX:
         """
         Calculate derivatives for species destruction rates with respect to species
         concentrations at constant temperature, pressure and molar concentration.
@@ -703,7 +703,7 @@ cdef class Kinetics(_SolutionBase):
                 return _scipy_sparse.csc_matrix(tup, shape=shape)
             return get_dense(self, kin_destructionRates_ddX)
 
-    property net_production_rate_ddT:
+    property net_production_rates_ddT:
         """
         Calculate derivatives of species net production rates with respect to
         temperature at constant pressure, molar concentration and mole fractions.
@@ -711,7 +711,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getNetProductionRates_ddT)
 
-    property net_production_rate_ddP:
+    property net_production_rates_ddP:
         """
         Calculate derivatives of species net production rates with respect to pressure
         at constant temperature, molar concentration and mole fractions.
@@ -719,7 +719,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getNetProductionRates_ddP)
 
-    property net_production_rate_ddC:
+    property net_production_rates_ddC:
         """
         Calculate derivatives of species net production rates with respect to molar
         density at constant temperature, pressure and mole fractions.
@@ -727,7 +727,7 @@ cdef class Kinetics(_SolutionBase):
         def __get__(self):
             return get_species_array(self, kin_getNetProductionRates_ddC)
 
-    property net_production_rate_ddX:
+    property net_production_rates_ddX:
         """
         Calculate derivatives for species net production rates with respect to species
         concentrations at constant temperature, pressure and molar concentration.

--- a/interfaces/cython/cantera/test/test_jacobian.py
+++ b/interfaces/cython/cantera/test/test_jacobian.py
@@ -327,8 +327,8 @@ class RateExpressionTests:
 
     def test_creation_ddX(self):
         # check derivatives of creation rates with respect to mole fractions
-        drate = self.gas.creation_rate_ddX
-        dratep = self.gas.creation_rate_ddP
+        drate = self.gas.creation_rates_ddX
+        dratep = self.gas.creation_rates_ddP
         for spc_ix in self.rix + self.pix:
             drate_num = self.rate_ddX(spc_ix, "creation")
             ix = drate[:, spc_ix] != 0
@@ -337,8 +337,8 @@ class RateExpressionTests:
 
     def test_destruction_ddX(self):
         # check derivatives of destruction rates with respect to mole fractions
-        drate = self.gas.destruction_rate_ddX
-        dratep = self.gas.destruction_rate_ddP
+        drate = self.gas.destruction_rates_ddX
+        dratep = self.gas.destruction_rates_ddP
         for spc_ix in self.rix + self.pix:
             drate_num = self.rate_ddX(spc_ix, "destruction")
             ix = drate[:, spc_ix] != 0
@@ -347,8 +347,8 @@ class RateExpressionTests:
 
     def test_net_production_ddX(self):
         # check derivatives of destruction rates with respect to mole fractions
-        drate = self.gas.net_production_rate_ddX
-        dratep = self.gas.net_production_rate_ddP
+        drate = self.gas.net_production_rates_ddX
+        dratep = self.gas.net_production_rates_ddP
         for spc_ix in self.rix + self.pix:
             drate_num = self.rate_ddX(spc_ix, "net")
             ix = drate[:, spc_ix] != 0

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -256,7 +256,7 @@ std::string Units::str(bool skip_unity) const
     std::string num = "";
     std::string den = "";
     for (auto const& dim : dims) {
-        int rounded = round(dim.second);
+        int rounded = (int)round(dim.second);
         if (dim.second == 0.) {
             // skip
         } else if (dim.second == 1.) {

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -253,7 +253,7 @@ bool isThreeBody(const Reaction& R)
        if (trunc(reac.second) != reac.second) {
            return false;
        }
-       nreac += reac.second;
+       nreac += (size_t)reac.second;
     }
 
     // ensure that all products have integer stoichiometric coefficients
@@ -262,7 +262,7 @@ bool isThreeBody(const Reaction& R)
        if (trunc(prod.second) != prod.second) {
            return false;
        }
-       nprod += prod.second;
+       nprod += (size_t)prod.second;
     }
 
     // either reactant or product side involves exactly three species

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -253,7 +253,7 @@ bool isThreeBody(const Reaction& R)
        if (trunc(reac.second) != reac.second) {
            return false;
        }
-       nreac += (size_t)reac.second;
+       nreac += static_cast<size_t>(reac.second);
     }
 
     // ensure that all products have integer stoichiometric coefficients
@@ -262,7 +262,7 @@ bool isThreeBody(const Reaction& R)
        if (trunc(prod.second) != prod.second) {
            return false;
        }
-       nprod += (size_t)prod.second;
+       nprod += static_cast<size_t>(prod.second);
     }
 
     // either reactant or product side involves exactly three species

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -177,8 +177,7 @@ void Sim1D::restore(const std::string& fname, const std::string& id,
                     "Saved state '{}' does not contain a domain named '{}'.",
                     id, dom->id());
             }
-            dom->resize(dom->nComponents(),
-                        state[dom->id()]["points"].asDouble());
+            dom->resize(dom->nComponents(), state[dom->id()]["points"].asInt());
         }
         resize();
         m_xlast_ts.clear();

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -268,17 +268,17 @@ void ReactorNet::eval(doublereal t, doublereal* y,
                     "Reactor time derivative evaluation now uses signature "
                     "eval(double t, double* ydot)");
                 m_have_deprecated_eval[n] = true;
-            } catch (NotImplementedError& err) {
+            } catch (NotImplementedError&) {
                 m_reactors[n]->eval(t, m_LHS.data() + m_start[n], m_RHS.data() + m_start[n]);
-                int yEnd = 0;
-                if(n == m_reactors.size()-1){
+                size_t yEnd = 0;
+                if (n == m_reactors.size() - 1) {
                     yEnd = m_RHS.size();
                 } else {
-                    yEnd = m_start[n+1];
+                    yEnd = m_start[n + 1];
                 }
-                    for (int i = m_start[n]; i < yEnd; i++) {
-                     ydot[i] = m_RHS[i]/m_LHS[i];
-                    }
+                for (size_t i = m_start[n]; i < yEnd; i++) {
+                    ydot[i] = m_RHS[i] / m_LHS[i];
+                }
             }
             m_reactors[n]->resetSensitivity(p);
         }
@@ -290,15 +290,15 @@ void ReactorNet::eval(doublereal t, doublereal* y,
                 m_reactors[n]->evalEqs(t, y + m_start[n], ydot + m_start[n], p);
             } else {
                 m_reactors[n]->eval(t, m_LHS.data() + m_start[n], m_RHS.data() + m_start[n]);
-                    int yEnd = 0;
-                if (n == m_reactors.size()-1) {
+                size_t yEnd = 0;
+                if (n == m_reactors.size() - 1) {
                     yEnd = m_RHS.size();
                 } else {
-                    yEnd = m_start[n+1];
+                    yEnd = m_start[n + 1];
                 }
-                    for (int i = m_start[n]; i < yEnd; i++) {
-                        ydot[i] = m_RHS[i]/m_LHS[i];
-                    }
+                for (size_t i = m_start[n]; i < yEnd; i++) {
+                    ydot[i] = m_RHS[i] / m_LHS[i];
+                }
             }
             m_reactors[n]->resetSensitivity(p);
         }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Over the past couple of merges, several windows (MSVC)-specific compiler warnings appeared that were not caught when developing with `g++`. Some of the warnings are quite long, despite being triggered by trivial causes. The following are affected:

- `StoichManager.h` / `ThirdBodyCalc.h` ... `Eigen` uses `int` to index, compared to most internal indices being `size_t`
- Some formatting / type-cast issues in `ReactorNet.h`
- Some other minor issues that resulted in warnings.
- Add missing 's' in derivative accessor names (e.g. `Kinetics.net_production_rates_ddX` instead of `Kinetics.net_production_rate_ddX`), as introduced in #1089

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
