### PR TITLE
Fix script installation path on Fedora 36

### DIFF
--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -138,7 +138,7 @@ elif localenv['python_prefix']:
     elif localenv['libdirname'] != 'lib':
         # 64-bit RHEL / Fedora etc. or e.g. x32 Gentoo profile
         extra = localenv.subst(
-            ' --prefix=${{python_prefix}}'
+            ' --prefix=${{python_prefix}} --install-scripts=${{python_prefix}}/bin'
             ' --install-lib=${{python_prefix}}/${{libdirname}}/python{}/site-packages'.format(py_version_short))
     else:
         extra = '--user'


### PR DESCRIPTION


<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make sure that scripts get installed to the same prefix as the Cantera Python module (e.g. `/usr`) instead of having the scripts installed under `/usr/local` on systems that use `lib64` as the library directory name.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1149

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
