### PR TITLE
Include explicit git commit hash in config.h

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1721,6 +1721,7 @@ configh = {}
 
 configh['CANTERA_VERSION'] = quoted(env['cantera_version'])
 configh['CANTERA_SHORT_VERSION'] = quoted(env['cantera_short_version'])
+configh["CANTERA_GIT_COMMIT"] = quoted(env["git_commit"])
 
 # Conditional defines
 def cdefine(definevar, configvar, comp=True, value=1):

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -8,6 +8,9 @@
 // Just the major + minor version (i.e. 2.2 instead of 2.2.0)
 {CANTERA_SHORT_VERSION!s}
 
+// Cantera git commit hash from which Cantera was compiled
+{CANTERA_GIT_COMMIT!s}
+
 //------------------------ Fortran settings -------------------//
 
 // define types doublereal, integer, and ftnlen to match the

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -106,6 +106,7 @@ void appdelete();
 void thread_complete();
 
 //! Returns the hash of the git commit from which Cantera was compiled, if known
+//! @deprecated Replaced by CANTERA_GIT_COMMIT. To be removed after Cantera 2.6.
 std::string gitCommit();
 
 //! Returns root directory where %Cantera is installed

--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -15,6 +15,11 @@ std::string get_cantera_version()
     return std::string(CANTERA_VERSION);
 }
 
+std::string get_cantera_git_commit()
+{
+    return std::string(CANTERA_GIT_COMMIT);
+}
+
 int get_sundials_version()
 {
     return CT_SUNDIALS_VERSION;

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -179,7 +179,6 @@ cdef extern from "cantera/base/global.h" namespace "Cantera":
     cdef void Cxx_suppress_deprecation_warnings "Cantera::suppress_deprecation_warnings" ()
     cdef void Cxx_suppress_thermo_warnings "Cantera::suppress_thermo_warnings" (cbool)
     cdef void Cxx_use_legacy_rate_constants "Cantera::use_legacy_rate_constants" (cbool)
-    cdef string CxxGitCommit "Cantera::gitCommit" ()
     cdef cbool CxxDebugModeEnabled "Cantera::debugModeEnabled" ()
 
 cdef extern from "<memory>":
@@ -1207,6 +1206,7 @@ cdef extern from "cantera/kinetics/ReactionPath.h":
 cdef extern from "cantera/cython/wrappers.h":
     # config definitions
     cdef string get_cantera_version()
+    cdef string get_cantera_git_commit()
     cdef int get_sundials_version()
 
     cdef cppclass CxxPythonLogger "PythonLogger":

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -42,7 +42,7 @@ __sundials_version__ = '.'.join(str(get_sundials_version()))
 
 __version__ = pystr(get_cantera_version())
 
-__git_commit__ = pystr(CxxGitCommit())
+__git_commit__ = pystr(get_cantera_git_commit())
 
 _USE_SPARSE = False
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -12,20 +12,14 @@ def applicationSetup(env, subdir, extensions):
     env.Append(CPPDEFINES={'CANTERA_DATA': escaped_datadir})
     return defaultSetup(env, subdir, extensions)
 
-def globalSetup(env, subdir, extensions):
-    # Add #define variables unique to global.cpp
-    env.Append(CPPDEFINES={'GIT_COMMIT': '\\"{0}\\"'.format(env['git_commit'])})
-    return defaultSetup(env, subdir, extensions)
-
 def baseSetup(env, subdir, extensions):
     # All files in base except for application.cpp
     return [f for f in defaultSetup(env, subdir, extensions)
-            if f.name != 'application.cpp' and f.name != 'global.cpp']
+            if f.name != "application.cpp"]
 
 # (subdir, (file extensions), (extra setup(env)))
 libs = [('base', ['cpp'], baseSetup),
         ('base', ['^application.cpp'], applicationSetup),
-        ('base', ['^global.cpp'], globalSetup),
         ('thermo', ['cpp'], defaultSetup),
         ('tpx', ['cpp'], defaultSetup),
         ('equil', ['cpp','c'], defaultSetup),

--- a/src/base/YamlWriter.cpp
+++ b/src/base/YamlWriter.cpp
@@ -56,7 +56,7 @@ std::string YamlWriter::toYamlString() const
     }
     output["generator"] = "YamlWriter";
     output["cantera-version"] = CANTERA_VERSION;
-    output["git-commit"] = gitCommit();
+    output["git-commit"] = CANTERA_GIT_COMMIT;
     time_t now = std::chrono::system_clock::to_time_t(std::chrono::system_clock::now());
     output["date"] = trimCopy(std::ctime(&now));
     if (hasDescription) {

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -129,6 +129,8 @@ void thread_complete()
 
 std::string gitCommit()
 {
+    warn_deprecated("gitCommit",
+        "Replaced by 'CANTERA_GIT_COMMIT'. To be removed after Cantera 2.6.");
     return CANTERA_GIT_COMMIT;
 }
 

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -129,11 +129,7 @@ void thread_complete()
 
 std::string gitCommit()
 {
-#ifdef GIT_COMMIT
-    return GIT_COMMIT;
-#else
-    return "unknown";
-#endif
+    return CANTERA_GIT_COMMIT;
 }
 
 XML_Node* get_XML_File(const std::string& file, int debug)

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1478,7 +1478,7 @@ extern "C" {
     int ct_getGitCommit(int buflen, char* buf)
     {
         try {
-            return static_cast<int>(copyString(gitCommit(), buf, buflen));
+            return static_cast<int>(copyString(CANTERA_GIT_COMMIT, buf, buflen));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -118,7 +118,7 @@ void Sim1D::save(const std::string& fname, const std::string& id,
     data[id]["description"] = desc;
     data[id]["generator"] = "Cantera Sim1D";
     data[id]["cantera-version"] = CANTERA_VERSION;
-    data[id]["git-commit"] = gitCommit();
+    data[id]["git-commit"] = CANTERA_GIT_COMMIT;
 
     // Add a timestamp indicating the current time
     time_t aclock;


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

During compilation, the git commit hash is currently passed through the commandline:
```
g++ -o build/src/base/global.os -c -std=c++11 -pthread -O3 -Wno-inline -Wall -include src/pch/system.h -fPIC -DNDEBUG -DGIT_COMMIT=\"fcff59292\" -Iinclude -Iinclude/cantera/ext -Ibuild/src src/base/global.cpp
```
which is, however, hard to locate. As an example, the git hash for the last successful build for #1174 would have been much easier to find.

The proposed change adds a `CANTERA_GIT_COMMIT` to the configuration summary, e.g.
```
ConfigBuilder(["build/src/config.h.build"], ["include/cantera/base/config.h.in"])
INFO: Generating build/src/config.h.build with the following settings:
    CANTERA_GIT_COMMIT                  "fcff59292"
    CANTERA_SHORT_VERSION               "2.6"
    CANTERA_VERSION                     "2.6.0a4"
[...]
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
