### PR TITLE
[SCons] Add info on git hash to SCons output

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -854,6 +854,7 @@ env['cantera_short_version'] = re.match(r'(\d+\.\d+)', env['cantera_version']).g
 
 try:
     env["git_commit"] = get_command_output("git", "rev-parse", "--short", "HEAD")
+    logger.info(f"Building Cantera from git commit '{env['git_commit']}'")
 except subprocess.CalledProcessError:
     env["git_commit"] = "unknown"
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Add git hash at the beginning of the SCons build log:
```
$ scons build
scons: Reading SConscript files ...
INFO: SCons is using the following Python interpreter: /usr/bin/python3
INFO: Building Cantera based on git commit 'fcff59292'
[...]
```
Replaces #1175

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
