### PR TITLE
Reduce precision in select tests to pass on alternate architectures

### DIFF
--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -368,20 +368,20 @@ public:
         kin.getRevRateConstants(k.data());
         kin_ref->getRevRateConstants(k_ref.data());
         for (size_t i = 0; i < kin.nReactions(); i++) {
-            EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
+            EXPECT_NEAR(k_ref[i], k[i], k_ref[i]*1e-12) << "i = " << i << "; N = " << N;
         }
 
         kin.getRevRatesOfProgress(k.data());
         kin_ref->getRevRatesOfProgress(k_ref.data());
         for (size_t i = 0; i < kin.nReactions(); i++) {
-            EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
+            EXPECT_NEAR(k_ref[i], k[i], k_ref[i]*1e-12) << "i = " << i << "; N = " << N;
         }
 
         kin.getCreationRates(w.data());
         kin_ref->getCreationRates(w_ref.data());
         for (size_t i = 0; i < kin.nTotalSpecies(); i++) {
             size_t iref = p_ref.speciesIndex(p.speciesName(i));
-            EXPECT_DOUBLE_EQ(w_ref[iref], w[i]) << "sp = " << p.speciesName(i) << "; N = " << N;
+            EXPECT_NEAR(w_ref[iref], w[i], w_ref[i]*1e-12) << "sp = " << p.speciesName(i) << "; N = " << N;
         }
     }
 };

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -381,7 +381,7 @@ public:
         kin_ref->getCreationRates(w_ref.data());
         for (size_t i = 0; i < kin.nTotalSpecies(); i++) {
             size_t iref = p_ref.speciesIndex(p.speciesName(i));
-            EXPECT_NEAR(w_ref[iref], w[i], w_ref[i]*1e-12) << "sp = " << p.speciesName(i) << "; N = " << N;
+            EXPECT_NEAR(w_ref[iref], w[i], w_ref[iref]*1e-12) << "sp = " << p.speciesName(i) << "; N = " << N;
         }
     }
 };

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -261,7 +261,7 @@ TEST(Reaction, ChebyshevFromYaml)
     EXPECT_EQ(rate->data().nColumns(), (size_t) 4);
     EXPECT_DOUBLE_EQ(rate->Tmax(), 3000);
     EXPECT_DOUBLE_EQ(rate->Pmin(), 1000);
-    EXPECT_NEAR(rate->updateRC(std::log(T), 1.0/T), 130512.2773948636, 1e-9);
+    EXPECT_NEAR(rate->updateRC(std::log(T), 1.0/T), 130512.2773948636, 2e-9);
 }
 
 TEST(Reaction, BlowersMaselFromYaml)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**
Following on the discussion in #1174, minor changes in test tolerances are introduced to allow tests to pass on non-x86_64 architectures
- Replace `EQ` with `NEAR` on several kinetics tests which were affecting all alternate architectures (https://copr.fedorainfracloud.org/coprs/fuller/Cantera/build/3192999/)
- Increase test tolerances from 1e-9 to 2e-9 in Chebyshev tests for which 32-bit i386 systems had errors of 1.6e-9 (https://copr.fedorainfracloud.org/coprs/fuller/cantera-test/build/3195208/)

**If applicable, fill in the issue number this pull request is fixing**
This closes #1174 as it corrects test/build failures with the following exceptions:
Test failures for s390x architecture and build failure on ppc64le (F36/Rawhide only) are identified there as originating outside of Cantera and will be addressed upstream.

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
