### PR TITLE
Resolve Yaml paper cuts

### DIFF
--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1172,7 +1172,7 @@ class TestSpecies(utilities.CanteraTest):
         S = ct.Species.listFromCti((self.cantera_data_path / "h2o2.cti").read_text())
         self.assertEqual(S[3].name, self.gas.species_name(3))
 
-    def test_listFomYaml(self):
+    def test_list_from_yaml(self):
         yaml = '''
         - name: H2O
           composition: {H: 2, O: 1}
@@ -1186,13 +1186,35 @@ class TestSpecies(utilities.CanteraTest):
         self.assertEqual(species[1].composition, {'H': 1, 'O': 2})
         self.assertNear(species[0].thermo.h(300), 100)
 
-    def test_listFromYaml_section(self):
+    def test_list_from_yaml_section(self):
         species = ct.Species.list_from_yaml(
             (self.test_data_path / "ideal-gas.yaml").read_text(),
             'species')
 
         self.assertEqual(species[0].name, 'O2')
         self.assertEqual(species[1].composition, {'N': 1, 'O': 1})
+
+    def test_from_yaml(self):
+        yaml = """
+        name: H2O
+        composition: {H: 2, O: 1}
+        thermo: {model: constant-cp, h0: 100}
+        """
+        species = ct.Species.from_yaml(yaml)
+        self.assertEqual(species.name, 'H2O')
+        self.assertEqual(species.composition, {'H': 2, 'O': 1})
+        self.assertNear(species.thermo.h(300), 100)
+
+    def test_from_dict(self):
+        data = {
+            "name": "H2O",
+            "composition": {"H": 2, "O": 1},
+            "thermo": {"model": "constant-cp", "h0": 100},
+        }
+        species = ct.Species.from_dict(data)
+        self.assertEqual(species.name, 'H2O')
+        self.assertEqual(species.composition, {'H': 2, 'O': 1})
+        self.assertNear(species.thermo.h(300), 100)
 
     @utilities.allow_deprecated
     def test_listFromXml(self):

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -123,9 +123,24 @@ cdef class Species:
     @staticmethod
     def from_yaml(text):
         """
-        Create a Species object from its YAML string representation.
+        Create a `Species` object from its YAML string representation.
         """
         cxx_species = CxxNewSpecies(AnyMapFromYamlString(stringify(text)))
+        species = Species(init=False)
+        species._assign(cxx_species)
+        return species
+
+    @staticmethod
+    def from_dict(data):
+        """
+        Create a `Species` object from a dictionary corresponding to its YAML
+        representation.
+
+        :param data:
+            A dictionary corresponding to the YAML representation.
+        """
+        cdef CxxAnyMap any_map = dict_to_anymap(data)
+        cxx_species = CxxNewSpecies(any_map)
         species = Species(init=False)
         species._assign(cxx_species)
         return species


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR aims to address remaining points raised in #1053

- Add `Species.from_dict` creation (in analogy to `Reaction.from_dict`)
- Add ability to pass YAML syntax to `anymap_from_dict`
- Address some YAML code formatting in Sphinx

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1053

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

E.g. mixing YAML syntax when defining a species:
```python
data = {
    "name": "H2O",
    "composition": "{H: 2, O: 1}",
    "thermo": "{model: constant-cp, h0: 100}", # value is formatted as YAML code
}
species = ct.Species.from_dict(data)
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
