### PR TITLE
Implement serialization of Peng-Robinson phases

### DIFF
--- a/data/critical-properties.yaml
+++ b/data/critical-properties.yaml
@@ -10,8 +10,19 @@ description: |-
 
   Critical pressures are given in Pa. Critical volumes are given in m^3/kmol.
 
-  These critical properties have been compiled from various sources by
+source: |-
+  Initial database of critical properties compiled from various sources by
   C. Karakaya (https://orcid.org/0000-0001-5102-5476)
+
+  Additional data sources:
+
+  Lemmon, E W; Bell, I H; Huber, M L; and McLinden, M O. (2022). "Thermophysical
+      Properties of Fluid Systems" in NIST Chemistry WebBook, NIST Standard Reference
+      Database Number 69, Eds. P J  Linstrom and W G Mallard, National Institute of
+      Standards and Technology, Gaithersburg MD, 20899, https://doi.org/10.18434/T4D303.
+
+  Yaws, C L. (2001). Matheson Gas Data Book. 7th Edition McGraw-Hill.
+      ISBN 978-0-07-135854-5.
 
 input-files: critProperties.xml
 cantera-version: 2.6.0a3
@@ -82,8 +93,7 @@ species:
     critical-compressibility: 0.275
     acentric-factor: 0.228
     source: |-
-      The acentric factor is taken from Yaws, Carl L. (2001).
-      Matheson Gas Data Book. McGraw-Hill.
+      The acentric factor is taken from Yaws (2001).
 - name: COS
   descriptive-name: carbonyl-sulfide
   molecular-weight: 60.07
@@ -6272,10 +6282,16 @@ species:
   critical-parameters:
     critical-temperature: 154.58
     critical-pressure: 5.043e+06
-    acentric-factor: 0.741
+    acentric-factor: 0.022
+    source: |-
+      The acentric factor is calculated using the pure fluid saturation data from
+      Lemmon et al. (2022).
 - name: N2
   descriptive-name: nitrogen
   critical-parameters:
     critical-temperature: 126.2
     critical-pressure: 3.39e+06
-    acentric-factor: 0.741
+    acentric-factor: 0.038
+    source: |-
+      The acentric factor is calculated using the pure fluid saturation data from
+      Lemmon et al. (2022).

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -492,14 +492,6 @@ public:
     virtual void getActivityConcentrations(double* c) const;
 
 protected:
-    //! Calculate the pressure given the temperature and the molar volume
-    /*!
-     * @param   TKelvin   temperature in kelvin
-     * @param   molarVol  molar volume ( m3/kmol)
-     * @returns the pressure.
-     */
-    virtual doublereal pressureCalc(doublereal TKelvin, doublereal molarVol) const;
-
     //! Calculate the pressure and the pressure derivative given the temperature
     //! and the molar volume
     /*!

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -52,7 +52,8 @@ public:
      * mechanical equation of state \f$ P(T, \rho, Y_1, \dots, Y_K) \f$.
      *
      * \f[
-     *    P = \frac{RT}{v-b_{mix}} - \frac{\left(\alpha a\right)_{mix}}{v^2 + 2b_{mix}v - b_{mix}^2}
+     *    P = \frac{RT}{v-b_{mix}}
+     *        - \frac{\left(\alpha a\right)_{mix}}{v^2 + 2b_{mix}v - b_{mix}^2}
      * \f]
      *
      * where:
@@ -64,8 +65,11 @@ public:
      *  and
      *
      * \f[
-     *    \kappa = \left(0.37464 + 1.54226\omega - 0.26992\omega^2\right), \qquad \qquad \text{For } \omega <= 0.491 \\
-     *    \kappa = \left(0.379642 + 1.487503\omega - 0.164423\omega^2 +  0.016667\omega^3 \right), \qquad \text{For } \omega > 0.491
+     *    \kappa = \left(0.37464 + 1.54226\omega - 0.26992\omega^2\right),
+     *        \qquad \qquad \text{For } \omega <= 0.491 \\
+     *
+     *    \kappa = \left(0.379642 + 1.487503\omega - 0.164423\omega^2 + 0.016667\omega^3 \right),
+     *        \qquad \text{For } \omega > 0.491
      * \f]
      *
      * Coefficients \f$ a_{mix}, b_{mix} \f$ and \f$(a \alpha)_{mix}\f$ are calculated as
@@ -79,7 +83,8 @@ public:
      * \f]
      *
      * \f[
-     *   {a \alpha}_{mix} = \sum_i \sum_j X_i X_j {a \alpha}_{i, j} = \sum_i \sum_j X_i X_j \sqrt{a_i a_j} \sqrt{\alpha_i \alpha_j}
+     *   {a \alpha}_{mix} = \sum_i \sum_j X_i X_j {a \alpha}_{i, j}
+     *       = \sum_i \sum_j X_i X_j \sqrt{a_i a_j} \sqrt{\alpha_i \alpha_j}
      * \f]
      */
     virtual double pressure() const;
@@ -176,12 +181,12 @@ protected:
     virtual double sresid() const;
     virtual double hresid() const;
 
-    virtual double liquidVolEst(double TKelvin, double& pres) const;
-    virtual double densityCalc(double TKelvin, double pressure, int phase, double rhoguess);
+    virtual double liquidVolEst(double T, double& pres) const;
+    virtual double densityCalc(double T, double pressure, int phase, double rhoguess);
 
     virtual double densSpinodalLiquid() const;
     virtual double densSpinodalGas() const;
-    virtual double dpdVCalc(double TKelvin, double molarVol, double& presCalc) const;
+    virtual double dpdVCalc(double T, double molarVol, double& presCalc) const;
 
     // Special functions not inherited from MixtureFugacityTP
 
@@ -248,16 +253,16 @@ protected:
      */
     double m_aAlpha_mix;
 
-    // Vectors required to store species-specific a_coeff, b_coeff, alpha, kappa and other derivatives.
-    // Length = m_kk
+    // Vectors required to store species-specific a_coeff, b_coeff, alpha, kappa
+    // and other derivatives. Length = m_kk.
     vector_fp m_b_coeffs;
     vector_fp m_kappa;
     mutable vector_fp m_dalphadT;
     mutable vector_fp m_d2alphadT2;
     vector_fp m_alpha;
 
-    // Matrices for Binary coefficients a_{i,j} and {a*alpha}_{i.j} are saved in an Array form.
-    // Length =  (m_kk, m_kk)
+    // Matrices for Binary coefficients a_{i,j} and {a*alpha}_{i.j} are saved in an
+    // array form. Size = (m_kk, m_kk).
     Array2D m_a_coeffs;
     Array2D m_aAlpha_binary;
 

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -32,7 +32,7 @@ public:
                           const std::string& id="");
 
     virtual std::string type() const {
-        return "PengRobinson";
+        return "Peng-Robinson";
     }
 
     //! @name Molar Thermodynamic properties
@@ -155,6 +155,8 @@ public:
 
     virtual bool addSpecies(shared_ptr<Species> spec);
     virtual void initThermo();
+    virtual void getSpeciesParameters(const std::string& name,
+                                      AnyMap& speciesNode) const;
 
     //! Set the pure fluid interaction parameters for a species
     /*!
@@ -257,6 +259,7 @@ protected:
     // and other derivatives. Length = m_kk.
     vector_fp m_b_coeffs;
     vector_fp m_kappa;
+    vector_fp m_acentric; //!< acentric factor for each species, length #m_kk
     mutable vector_fp m_dalphadT;
     mutable vector_fp m_d2alphadT2;
     vector_fp m_alpha;
@@ -265,6 +268,9 @@ protected:
     // array form. Size = (m_kk, m_kk).
     Array2D m_a_coeffs;
     Array2D m_aAlpha_binary;
+
+    //! Explicitly-specified binary interaction parameters, to enable serialization
+    std::map<std::string, std::map<std::string, double>> m_binaryParameters;
 
     int m_NSolns;
 
@@ -296,6 +302,10 @@ protected:
      *  other mole number kept constant
      */
     mutable vector_fp m_dpdni;
+
+    enum class CoeffSource { EoS, CritProps, Database };
+    //! For each species, specifies the source of the a, b, and omega coefficients
+    std::vector<CoeffSource> m_coeffSource;
 
 private:
     //! Omega constant: a0 (= omega_a) used in Peng-Robinson equation of state

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -279,9 +279,9 @@ protected:
     //! Explicitly-specified binary interaction parameters
     std::map<std::string, std::map<std::string, std::pair<double, double>>> m_binaryParameters;
 
-    //! For each species, true if the a and b coefficients were determined from
-    //! the critical properties database
-    std::vector<bool> m_coeffs_from_db;
+    enum class CoeffSource { EoS, CritProps, Database };
+    //! For each species, specifies the source of the a and b coefficients
+    std::vector<CoeffSource> m_coeffSource;
 
     int NSolns_;
 

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1630,8 +1630,7 @@ public:
      * @param id  Optional parameter identifying the name of the phase. If
      *            blank, the first phase definition encountered will be used.
      */
-    virtual void initThermoFile(const std::string& inputFile,
-                                const std::string& id);
+    void initThermoFile(const std::string& inputFile, const std::string& id);
 
     //!Import and initialize a ThermoPhase object using an XML tree.
     /*!

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -762,11 +762,6 @@ doublereal MixtureFugacityTP::calculatePsat(doublereal TKelvin, doublereal& mola
     return pres;
 }
 
-doublereal MixtureFugacityTP::pressureCalc(doublereal TKelvin, doublereal molarVol) const
-{
-    throw NotImplementedError("MixtureFugacityTP::pressureCalc");
-}
-
 doublereal MixtureFugacityTP::dpdVCalc(doublereal TKelvin, doublereal molarVol, doublereal& presCalc) const
 {
     throw NotImplementedError("MixtureFugacityTP::dpdVCalc");

--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -388,6 +388,16 @@ TEST_F(ThermoYamlRoundTrip, RedlichKwong)
     compareThermo(500, 6e5, "c12h26: 0.2, o2: 0.1, co2: 0.4, c2h2: 0.3");
 }
 
+TEST_F(ThermoYamlRoundTrip, RedlichKwong_crit_props)
+{
+    roundtrip("thermo-models.yaml", "CO2-RK-params");
+    compareThermo(400, 1e6, "CO2:0.8, H2O:0.1, H2:0.1");
+    auto params = duplicate->species("CO2")->parameters(duplicate.get());
+    params.applyUnits();
+    double Tc = params["critical-parameters"]["critical-temperature"].asDouble();
+    EXPECT_NEAR(Tc, 304.128, 1e-3);
+}
+
 TEST_F(ThermoYamlRoundTrip, PengRobinson)
 {
     roundtrip("co2_PR_example.yaml");

--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -2,6 +2,7 @@
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/base/YamlWriter.h"
+#include "cantera/thermo/Species.h"
 
 using namespace Cantera;
 typedef std::vector<std::string> strvec;
@@ -385,6 +386,23 @@ TEST_F(ThermoYamlRoundTrip, RedlichKwong)
 {
     roundtrip("nDodecane_Reitz.yaml", "nDodecane_RK");
     compareThermo(500, 6e5, "c12h26: 0.2, o2: 0.1, co2: 0.4, c2h2: 0.3");
+}
+
+TEST_F(ThermoYamlRoundTrip, PengRobinson)
+{
+    roundtrip("co2_PR_example.yaml");
+    compareThermo(400, 20e5, "CO2:0.9, H2O:0.07, CH4:0.03");
+}
+
+TEST_F(ThermoYamlRoundTrip, PengRobinson_crit_props)
+{
+    roundtrip("thermo-models.yaml", "CO2-PR-params");
+    // rtol = 1e-13;
+    compareThermo(400, 1e6, "CO2:0.8, H2O:0.1, H2:0.1");
+    auto params = duplicate->species("CO2")->parameters(duplicate.get());
+    params.applyUnits();
+    double Tc = params["critical-parameters"]["critical-temperature"].asDouble();
+    EXPECT_NEAR(Tc, 304.128, 1e-3);
 }
 
 TEST_F(ThermoYamlRoundTrip, BinarySolutionTabulated)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Implement serialization of Peng-Robinson phases
- Update Redlich-Kwong serialization to save critical parameters for species where those were provided instead of R-K specific parameters
- Some formatting cleanup of the `PengRobinson` class
- Fix incorrect acentric factors for O2 and N2 in `critical-properties.yaml`

**If applicable, provide an example illustrating new features this pull request is introducing**
```python
import cantera as ct
p = ct.Solution('test/data/thermo-models.yaml', 'CO2-PR')
print(p.write_yaml(skip_user_defined=True))
```
```yaml
...
species:
  - name: CO2
    composition: {C: 1.0, O: 2.0}
    thermo:
      model: NASA7
      temperature-ranges: [200.0, 1000.0, 3500.0]
      data:
        - [2.35677352, 8.98459677e-03, -7.12356269e-06, 2.45919022e-09,
        -1.43699548e-13, -4.83719697e+04, 9.90105222]
        - [3.85746029, 4.41437026e-03, -2.21481404e-06, 5.23490188e-10,
        -4.72084164e-14, -4.8759166e+04, 2.27163806]
    equation-of-state:
      model: Peng-Robinson
      a: 3.958134e+05
      b: 0.0266275
      acentric-factor: 0.228
      binary-a:
        H2O: 7.897e+06
...
```

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
