### PR TITLE
Eliminate unnecessary specialized Reaction types

### DIFF
--- a/doc/sphinx/cython/kinetics.rst
+++ b/doc/sphinx/cython/kinetics.rst
@@ -60,11 +60,6 @@ ChebyshevReaction
 .. autoclass:: ChebyshevReaction(reactants='', products='')
    :no-undoc-members:
 
-BlowersMaselReaction
-^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: BlowersMaselReaction(reactants='', products='')
-   :no-undoc-members:
-
 InterfaceReaction
 ^^^^^^^^^^^^^^^^^
 .. autoclass:: InterfaceReaction(reactants='', products='')

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -58,6 +58,8 @@ protected:
     shared_ptr<AnyMap> m_metadata;
 
     friend class InputFileError;
+    friend void warn_deprecated(const std::string& source, const AnyBase& node,
+                                const std::string& message);
 };
 
 class AnyMap;
@@ -739,6 +741,10 @@ protected:
         int line1, int column1, const shared_ptr<AnyMap>& metadata1,
         int line2, int column2, const shared_ptr<AnyMap>& metadata2);
 };
+
+//! A deprecation warning for syntax in an input file
+void warn_deprecated(const std::string& source, const AnyBase& node,
+                     const std::string& message);
 
 }
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -537,22 +537,6 @@ public:
 };
 
 
-//! A reaction with rate parameters for Blowers-Masel approximation
-class BlowersMaselReaction: public Reaction
-{
-public:
-    BlowersMaselReaction();
-    BlowersMaselReaction(const Composition& reactants, const Composition& products,
-                         const BlowersMaselRate& rate);
-
-    BlowersMaselReaction(const AnyMap& node, const Kinetics& kin);
-
-    virtual std::string type() const {
-        return "Blowers-Masel";
-    }
-};
-
-
 //! A falloff reaction that is first-order in [M] at low pressure, like a third-body
 //! reaction, but zeroth-order in [M] as pressure increases.
 //! In addition, the class supports chemically-activated reactions where the rate

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -31,8 +31,8 @@ class Reaction
 {
 public:
     Reaction();
-    Reaction(const Composition& reactants,
-             const Composition& products);
+    Reaction(const Composition& reactants, const Composition& products,
+             shared_ptr<ReactionRate> rate={});
 
     //! @deprecated To be removed after Cantera 2.6.
     explicit Reaction(int type);
@@ -51,7 +51,7 @@ public:
     std::string equation() const;
 
     //! The type of reaction
-    virtual std::string type() const = 0; // pure virtual function
+    virtual std::string type() const;
 
     //! Calculate the units of the rate constant. These are determined by the units
     //! of the standard concentration of the reactant species' phases and the phase
@@ -495,26 +495,9 @@ public:
 };
 
 
-//! A reaction which follows mass-action kinetics with a modified Arrhenius
-//! reaction rate.
-class ElementaryReaction3 : public Reaction
-{
-public:
-    ElementaryReaction3();
-    ElementaryReaction3(const Composition& reactants, const Composition& products,
-                        const ArrheniusRate& rate);
-
-    ElementaryReaction3(const AnyMap& node, const Kinetics& kin);
-
-    virtual std::string type() const {
-        return "elementary";
-    }
-};
-
-
 //! A reaction with a non-reacting third body "M" that acts to add or remove
 //! energy from the reacting species
-class ThreeBodyReaction3 : public ElementaryReaction3
+class ThreeBodyReaction3 : public Reaction
 {
 public:
     ThreeBodyReaction3();
@@ -655,7 +638,6 @@ public:
 
 
 #ifdef CT_NO_LEGACY_REACTIONS_26
-typedef ElementaryReaction3 ElementaryReaction;
 typedef ThreeBodyReaction3 ThreeBodyReaction;
 typedef FalloffReaction3 FalloffReaction;
 typedef PlogReaction3 PlogReaction;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -562,25 +562,6 @@ public:
 };
 
 
-//! A pressure-dependent reaction parameterized by a bi-variate Chebyshev
-//! polynomial in temperature and pressure
-class ChebyshevReaction3 : public Reaction
-{
-public:
-    ChebyshevReaction3();
-    ChebyshevReaction3(const Composition& reactants, const Composition& products,
-                       const ChebyshevRate3& rate);
-
-    ChebyshevReaction3(const AnyMap& node, const Kinetics& kin);
-
-    virtual std::string type() const {
-        return "Chebyshev";
-    }
-
-    virtual void setParameters(const AnyMap& node, const Kinetics& kin);
-};
-
-
 //! A reaction which follows mass-action kinetics with a custom reaction rate
 //! defined in Python.
 /**
@@ -605,7 +586,6 @@ public:
 #ifdef CT_NO_LEGACY_REACTIONS_26
 typedef ThreeBodyReaction3 ThreeBodyReaction;
 typedef FalloffReaction3 FalloffReaction;
-typedef ChebyshevReaction3 ChebyshevReaction;
 #else
 typedef ElementaryReaction2 ElementaryReaction;
 typedef ThreeBodyReaction2 ThreeBodyReaction;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -54,6 +54,10 @@ public:
     //! The chemical equation for this reaction
     std::string equation() const;
 
+    //! Set the reactants and products based on the reaction equation. If a Kinetics
+    //! object is provided, it is used to check that all reactants and products exist.
+    virtual void setEquation(const std::string& equation, const Kinetics* kin=0);
+
     //! The type of reaction
     virtual std::string type() const;
 
@@ -514,6 +518,7 @@ public:
         return "three-body";
     }
 
+    virtual void setEquation(const std::string& equation, const Kinetics* kin=0);
     bool detectEfficiencies();
     virtual void setParameters(const AnyMap& node, const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
@@ -558,6 +563,7 @@ public:
 
     virtual std::string type() const;
 
+    virtual void setEquation(const std::string& equation, const Kinetics* kin);
     virtual void setParameters(const AnyMap& node, const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
 
@@ -630,8 +636,8 @@ std::vector<shared_ptr<Reaction>> getReactions(const AnyValue& items,
                                                Kinetics& kinetics);
 
 //! Parse reaction equation
-void parseReactionEquation(Reaction& R, const AnyValue& equation,
-                           const Kinetics& kin);
+void parseReactionEquation(Reaction& R, const std::string& equation,
+                           const AnyBase& reactionNode, const Kinetics* kin);
 
 // declarations of setup functions
 void setupReaction(Reaction& R, const XML_Node& rxn_node);

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -578,25 +578,6 @@ public:
 };
 
 
-//! A pressure-dependent reaction parameterized by logarithmically interpolating
-//! between Arrhenius rate expressions at various pressures.
-class PlogReaction3 : public Reaction
-{
-public:
-    PlogReaction3();
-    PlogReaction3(const Composition& reactants, const Composition& products,
-                  const PlogRate& rate);
-
-    PlogReaction3(const AnyMap& node, const Kinetics& kin);
-
-    virtual std::string type() const {
-        return "pressure-dependent-Arrhenius";
-    }
-
-    virtual void setParameters(const AnyMap& node, const Kinetics& kin);
-};
-
-
 //! A pressure-dependent reaction parameterized by a bi-variate Chebyshev
 //! polynomial in temperature and pressure
 class ChebyshevReaction3 : public Reaction
@@ -640,7 +621,6 @@ public:
 #ifdef CT_NO_LEGACY_REACTIONS_26
 typedef ThreeBodyReaction3 ThreeBodyReaction;
 typedef FalloffReaction3 FalloffReaction;
-typedef PlogReaction3 PlogReaction;
 typedef ChebyshevReaction3 ChebyshevReaction;
 #else
 typedef ElementaryReaction2 ElementaryReaction;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -34,6 +34,10 @@ public:
     Reaction(const Composition& reactants, const Composition& products,
              shared_ptr<ReactionRate> rate={});
 
+    //! Construct a Reaction and it's corresponding ReactionRate based on AnyMap (YAML)
+    //! input.
+    Reaction(const AnyMap& node, const Kinetics& kin);
+
     //! @deprecated To be removed after Cantera 2.6.
     explicit Reaction(int type);
     //! @deprecated To be removed after Cantera 2.6.

--- a/include/cantera/kinetics/ReactionFactory.h
+++ b/include/cantera/kinetics/ReactionFactory.h
@@ -97,6 +97,7 @@ private:
 //! Create a new empty Reaction object
 /*!
  * @param type string identifying type of reaction.
+ * @deprecated To be removed after Cantera 2.6. Only used for legacy reaction types.
  */
 unique_ptr<Reaction> newReaction(const std::string& type);
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -678,9 +678,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxTwoTempPlasmaReaction "Cantera::TwoTempPlasmaReaction"(CxxReaction):
         CxxTwoTempPlasmaReaction()
 
-    cdef cppclass CxxBlowersMaselReaction "Cantera::BlowersMaselReaction"(CxxReaction):
-        CxxBlowersMaselReaction()
-
     cdef cppclass CxxFalloffReaction3 "Cantera::FalloffReaction3" (CxxReaction):
         CxxFalloffReaction3()
         shared_ptr[CxxThirdBody] thirdBody()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -671,10 +671,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         cbool use_motz_wise_correction
         string sticking_species
 
-    cdef cppclass CxxElementaryReaction3 "Cantera::ElementaryReaction3" (CxxReaction):
-        CxxElementaryReaction3()
-
-    cdef cppclass CxxThreeBodyReaction3 "Cantera::ThreeBodyReaction3" (CxxElementaryReaction3):
+    cdef cppclass CxxThreeBodyReaction3 "Cantera::ThreeBodyReaction3" (CxxReaction):
         CxxThreeBodyReaction3()
         shared_ptr[CxxThirdBody] thirdBody()
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -685,9 +685,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxFalloffReaction3()
         shared_ptr[CxxThirdBody] thirdBody()
 
-    cdef cppclass CxxPlogReaction3 "Cantera::PlogReaction3" (CxxReaction):
-        CxxPlogReaction3()
-
     cdef cppclass CxxChebyshevReaction3 "Cantera::ChebyshevReaction3" (CxxReaction):
         CxxChebyshevReaction3()
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -682,9 +682,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxFalloffReaction3()
         shared_ptr[CxxThirdBody] thirdBody()
 
-    cdef cppclass CxxChebyshevReaction3 "Cantera::ChebyshevReaction3" (CxxReaction):
-        CxxChebyshevReaction3()
-
     cdef cppclass CxxCustomFunc1Reaction "Cantera::CustomFunc1Reaction" (CxxReaction):
         CxxCustomFunc1Reaction()
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -553,12 +553,20 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxCustomFunc1Rate()
         void setRateFunction(shared_ptr[CxxFunc1]) except +translate_exception
 
+    cdef cppclass CxxThirdBody "Cantera::ThirdBody":
+        CxxThirdBody()
+        CxxThirdBody(double)
+        double efficiency(string)
+        Composition efficiencies
+        double default_efficiency
+
     cdef cppclass CxxReaction "Cantera::Reaction":
         CxxReaction()
 
         string reactantString()
         string productString()
         string equation()
+        void setEquation(const string&) except +translate_exception
         string type()
         void validate() except +translate_exception
         CxxAnyMap parameters(cbool) except +translate_exception
@@ -572,6 +580,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         cbool duplicate
         cbool allow_nonreactant_orders
         cbool allow_negative_orders
+        shared_ptr[CxxThirdBody] thirdBody()
         cbool usesLegacy()
         CxxUnits rate_units
 
@@ -582,13 +591,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxElementaryReaction2()
         CxxArrhenius2 rate
         cbool allow_negative_pre_exponential_factor
-
-    cdef cppclass CxxThirdBody "Cantera::ThirdBody":
-        CxxThirdBody()
-        CxxThirdBody(double)
-        double efficiency(string)
-        Composition efficiencies
-        double default_efficiency
 
     cdef cppclass CxxThreeBodyReaction2 "Cantera::ThreeBodyReaction2" (CxxElementaryReaction2):
         CxxThreeBodyReaction2()
@@ -673,14 +675,12 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
 
     cdef cppclass CxxThreeBodyReaction3 "Cantera::ThreeBodyReaction3" (CxxReaction):
         CxxThreeBodyReaction3()
-        shared_ptr[CxxThirdBody] thirdBody()
 
     cdef cppclass CxxTwoTempPlasmaReaction "Cantera::TwoTempPlasmaReaction"(CxxReaction):
         CxxTwoTempPlasmaReaction()
 
     cdef cppclass CxxFalloffReaction3 "Cantera::FalloffReaction3" (CxxReaction):
         CxxFalloffReaction3()
-        shared_ptr[CxxThirdBody] thirdBody()
 
     cdef cppclass CxxCustomFunc1Reaction "Cantera::CustomFunc1Reaction" (CxxReaction):
         CxxCustomFunc1Reaction()

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -528,9 +528,6 @@ class Chebyshev(KineticsModel):
         self.coeffs = coeffs
         self.quantity_units = quantity_units
 
-    def reaction_string_suffix(self, species):
-        return ' (+{})'.format(species if species else 'M')
-
     def reduce(self, output):
         output['type'] = 'Chebyshev'
         output['temperature-range'] = FlowList([self.Tmin, self.Tmax])

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -64,7 +64,7 @@ class Solution(Transport, Kinetics, ThermoPhase):
 
         spec = ct.Species.listFromFile('gri30.yaml')
         spec_gas = ct.Solution(thermo='IdealGas', species=spec)
-        rxns = ct.Reaction.listFromFile('gri30.yaml', spec_gas)
+        rxns = ct.Reaction.list_from_file("gri30.yaml", spec_gas)
         gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                           species=spec, reactions=rxns, name='my_custom_name')
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -62,7 +62,7 @@ class Solution(Transport, Kinetics, ThermoPhase):
     objects which can themselves either be imported from input files or defined
     directly in Python::
 
-        spec = ct.Species.listFromFile('gri30.yaml')
+        spec = ct.Species.list_from_file("gri30.yaml")
         spec_gas = ct.Solution(thermo='IdealGas', species=spec)
         rxns = ct.Reaction.list_from_file("gri30.yaml", spec_gas)
         gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -867,6 +867,8 @@ class chebyshev_reaction(reaction):
             ``id``, ``order``, and ``options`` may be specified as keyword
             arguments, with the same meanings as for class `reaction`.
         """
+        # Remove deprecated '(+M)' third body notation
+        equation = re.sub(r" *\( *\+ *M *\)", "", equation)
         super().__init__(equation, None, **kwargs)
         self.type = 'Chebyshev'
         self.Pmin = Pmin

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -2054,10 +2054,11 @@ class Reaction:
         elif reaction_type in ["plog", "pdep_arrhenius"]:
             reaction_type = "plog"
         elif reaction_type == "chebyshev":
-            # There's only one way to spell Chebyshev, so no need to change anything
-            # However, we need to catch this case so it doesn't raise the TypeError
-            # in the else clause
-            pass
+            # Remove deprecated '(+M)' third body notation
+            self.attribs["equation"] = re.sub(r" *\( *\+ *M *\)", "",
+                                              self.attribs["equation"])
+            # There's only one way to spell Chebyshev, so no need to change the
+            # reaction_type.
         elif reaction_type in [
             "interface",
             "edge",

--- a/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
+++ b/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
@@ -23,7 +23,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 #Create an elementary reaction O+H2<=>H+OH
-r1 = ct.ElementaryReaction({'O':1, 'H2':1}, {'H':1, 'OH':1})
+r1 = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1})
 r1.rate = ct.ArrheniusRate(3.87e1, 2.7, 6260*1000*4.184)
 
 #Create a Blowers-Masel reaction O+H2<=>H+OH

--- a/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
+++ b/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
@@ -27,12 +27,12 @@ r1 = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1})
 r1.rate = ct.ArrheniusRate(3.87e1, 2.7, 6260*1000*4.184)
 
 #Create a Blowers-Masel reaction O+H2<=>H+OH
-r2 = ct.BlowersMaselReaction({'O':1, 'H2':1}, {'H':1, 'OH':1})
+r2 = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1})
 r2.rate = ct.BlowersMaselRate(3.87e1, 2.7, 6260*1000*4.184, 1e9)
 
 #Create a Blowers-Masel reaction with same parameters with r2
 #reaction equation is H+CH4<=>CH3+H2
-r3 = ct.BlowersMaselReaction({'H':1, 'CH4':1}, {'CH3':1, 'H2':1})
+r3 = ct.Reaction({"H":1, "CH4":1}, {"CH3":1, "H2":1})
 r3.rate = ct.BlowersMaselRate(3.87e1, 2.7, 6260*1000*4.184, 1e9)
 
 gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',

--- a/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
+++ b/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
@@ -23,17 +23,17 @@ import numpy as np
 import matplotlib.pyplot as plt
 
 #Create an elementary reaction O+H2<=>H+OH
-r1 = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1})
-r1.rate = ct.ArrheniusRate(3.87e1, 2.7, 6260*1000*4.184)
+r1 = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1},
+                 ct.ArrheniusRate(3.87e1, 2.7, 6260*1000*4.184))
 
 #Create a Blowers-Masel reaction O+H2<=>H+OH
-r2 = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1})
-r2.rate = ct.BlowersMaselRate(3.87e1, 2.7, 6260*1000*4.184, 1e9)
+r2 = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1},
+                 ct.BlowersMaselRate(3.87e1, 2.7, 6260*1000*4.184, 1e9))
 
 #Create a Blowers-Masel reaction with same parameters with r2
 #reaction equation is H+CH4<=>CH3+H2
-r3 = ct.Reaction({"H":1, "CH4":1}, {"CH3":1, "H2":1})
-r3.rate = ct.BlowersMaselRate(3.87e1, 2.7, 6260*1000*4.184, 1e9)
+r3 = ct.Reaction({"H":1, "CH4":1}, {"CH3":1, "H2":1},
+                 ct.BlowersMaselRate(3.87e1, 2.7, 6260*1000*4.184, 1e9))
 
 gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                    species=ct.Solution('gri30.yaml').species(), reactions=[r1, r2, r3])

--- a/interfaces/cython/cantera/examples/kinetics/extract_submechanism.py
+++ b/interfaces/cython/cantera/examples/kinetics/extract_submechanism.py
@@ -15,7 +15,7 @@ import cantera as ct
 import matplotlib.pyplot as plt
 
 input_file = 'gri30.yaml'
-all_species = ct.Species.listFromFile(input_file)
+all_species = ct.Species.list_from_file(input_file)
 species = []
 
 # Filter species

--- a/interfaces/cython/cantera/examples/kinetics/extract_submechanism.py
+++ b/interfaces/cython/cantera/examples/kinetics/extract_submechanism.py
@@ -38,7 +38,7 @@ print('Species: {0}'.format(', '.join(S.name for S in species)))
 
 # Filter reactions, keeping only those that only involve the selected species
 ref_phase = ct.Solution(thermo='ideal-gas', kinetics='gas', species=all_species)
-all_reactions = ct.Reaction.listFromFile(input_file, ref_phase)
+all_reactions = ct.Reaction.list_from_file(input_file, ref_phase)
 reactions = []
 
 print('\nReactions:')

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -738,13 +738,13 @@ cdef class Reaction:
     :param products:
         Value used to set `products`
 
-    The static methods `listFromFile`, `list_from_yaml`, `listFromCti`, and
+    The static methods `list_from_file`, `list_from_yaml`, `listFromCti`, and
     `listFromXml` can be used to create lists of `Reaction` objects from
     existing definitions in the YAML, CTI, or XML formats. All of the following
     will produce a list of the 325 reactions which make up the GRI 3.0
     mechanism::
 
-        R = ct.Reaction.listFromFile("gri30.yaml", gas)
+        R = ct.Reaction.list_from_file("gri30.yaml", gas)
         R = ct.Reaction.listFromCti(open("path/to/gri30.cti").read())
         R = ct.Reaction.listFromXml(open("path/to/gri30.xml").read())
 
@@ -984,7 +984,14 @@ cdef class Reaction:
 
             The CTI and XML input formats are deprecated and will be removed in
             Cantera 3.0.
+
+        .. deprecated:: 2.6
+
+            To be removed after Cantera 2.6. Replaced by 'Reaction.list_from_file'.
         """
+        warnings.warn("Static method 'listFromFile' is renamed to 'list_from_file'."
+            " The old name will be removed after Cantera 2.6.", DeprecationWarning)
+
         if filename.lower().split('.')[-1] in ('yml', 'yaml'):
             if kinetics is None:
                 raise ValueError("A Kinetics object is required.")
@@ -993,6 +1000,20 @@ cdef class Reaction:
                                             deref(kinetics.kinetics))
         else:
             cxx_reactions = CxxGetReactions(deref(CxxGetXmlFile(stringify(filename))))
+        return [Reaction.wrap(r) for r in cxx_reactions]
+
+    @staticmethod
+    def list_from_file(filename, Kinetics kinetics, section="reactions"):
+        """
+        Create a list of Reaction objects from all of the reactions defined in a
+        YAML file. Reactions from the section ``section`` will be returned.
+
+        Directories on Cantera's input file path will be searched for the
+        specified file.
+        """
+        root = AnyMapFromYamlFile(stringify(filename))
+        cxx_reactions = CxxGetReactions(root[stringify(section)],
+                                        deref(kinetics.kinetics))
         return [Reaction.wrap(r) for r in cxx_reactions]
 
     @staticmethod

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -2276,7 +2276,7 @@ cdef class BlowersMasel:
     A reaction rate coefficient which depends on temperature and enthalpy change
     of the reaction follows Blowers-Masel approximation and modified Arrhenius form
     described in `Arrhenius`. The functions are used by reactions defined using
-    `BlowersMaselReaction` and `BlowersMaselInterfaceReaction`.
+    `BlowersMaselInterfaceReaction`.
     """
     def __cinit__(self, A=0, b=0, E0=0, w=0, init=True):
         if init:
@@ -2344,58 +2344,6 @@ cdef wrapBlowersMasel(CxxBlowersMasel2* rate, Reaction reaction):
     r.rate = rate
     r.reaction = reaction
     return r
-
-
-cdef class BlowersMaselReaction(Reaction):
-    """
-    A reaction which follows mass-action kinetics with Blowers Masel
-    reaction rate.
-
-    An example for the definition of an `BlowersMaselReaction` object is given as::
-
-        rxn = BlowersMaselReaction(
-            equation="O + H2 <=> H + OH",
-            rate={"A": 38.7, "b": 2.7, "Ea0": 1.0958665856e8, "w": 1.7505856e13},
-            kinetics=gas)
-
-    The YAML description corresponding to this reaction is::
-
-        equation: O + H2 <=> H + OH
-        type: Blowers-Masel
-        rate-constant: {A: 38700 cm^3/mol/s, b: 2.7, Ea0: 2.619184e4 cal/mol, w: 4.184e9 cal/mol}
-    """
-    _reaction_type = "Blowers-Masel"
-
-    def __init__(self, equation=None, rate=None, Kinetics kinetics=None,
-                 init=True, **kwargs):
-
-        if init and equation and kinetics:
-
-            rxn_type = self._reaction_type
-            spec = {"equation": equation, "type": rxn_type}
-            if isinstance(rate, dict):
-                spec["rate-constant"] = rate
-            elif rate is None or isinstance(rate, BlowersMaselRate):
-                pass
-            else:
-                raise TypeError("Invalid rate definition")
-
-            self._reaction = CxxNewReaction(dict_to_anymap(spec),
-                                            deref(kinetics.kinetics))
-            self.reaction = self._reaction.get()
-
-            if isinstance(rate, BlowersMaselRate):
-                self.rate = rate
-
-    property rate:
-        """ Get/Set the `BlowersMaselRate` rate coefficients for this reaction. """
-        def __get__(self):
-            cdef CxxBlowersMaselReaction* r = <CxxBlowersMaselReaction*>self.reaction
-            return BlowersMaselRate.wrap(r.rate())
-        def __set__(self, rate):
-            cdef CxxBlowersMaselReaction* r = <CxxBlowersMaselReaction*>self.reaction
-            cdef BlowersMaselRate rate_ = rate
-            r.setRate(rate_._rate)
 
 
 cdef class TwoTempPlasmaReaction(Reaction):

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -737,6 +737,24 @@ cdef class Reaction:
         Value used to set `reactants`
     :param products:
         Value used to set `products`
+    :param rate:
+        The rate parameterization for the reaction, given as one of the following:
+
+           - a `ReactionRate` object
+           - a `dict` containing the parameters needed to construct a `ReactionRate`
+             object, with keys corresponding to the YAML format
+           - a `dict` containing Arrhenius parameters (``A``, ``b``, and ``Ea``)
+    :param equation:
+        The reaction equation, used to set the reactants and products if values for
+        those arguments are not provided.
+
+    Examples::
+
+        R = ct.Reaction({"O": 1, "H2": 1}, {"H": 1, "OH": 1},
+                        ct.ArrheniusRate(38.7, 2.7, 26191840.0))
+        R = ct.Reaction(equation="O + H2 <=> H + OH",
+                        rate={"A": 38.7, "b", 2.7, "Ea": 26191840.0})
+        R = ct.Reaction(equation="HO2 <=> OH + O", rate=ChebyshevRate(...))
 
     The static methods `list_from_file`, `list_from_yaml`, `listFromCti`, and
     `listFromXml` can be used to create lists of `Reaction` objects from

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -795,11 +795,14 @@ cdef class Reaction:
             if products:
                 self.products = products
 
-    def __init__(self, equation=None, rate=None, Kinetics kinetics=None,
-                 init=True, legacy=False, **kwargs):
+    def __init__(self, reactants=None, products=None, *, equation=None, rate=None,
+                 Kinetics kinetics=None, init=True, legacy=False, **kwargs):
 
         if legacy:
             return
+
+        if reactants and products and not equation:
+            equation = self.equation
 
         if init and equation and kinetics:
             rxn_type = self._reaction_type
@@ -808,6 +811,8 @@ cdef class Reaction:
                 # Arrhenius-like rates
                 spec["rate-constant"] = rate
                 rate = None
+            elif isinstance(rate, ReactionRate):
+                spec["type"] = rate.type
 
             self._reaction = CxxNewReaction(dict_to_anymap(spec),
                                             deref(kinetics.kinetics))
@@ -1245,6 +1250,160 @@ cdef class Reaction:
                 self.rate.rates = rates
             else:
                 raise TypeError("only valid for reactions with PlogRate rates")
+
+    property Tmin:
+        """
+        Minimum temperature [K] for the Chebyshev fit
+
+        .. deprecated:: 2.6
+             This property is for temporary backwards-compatibility with the deprecated
+             `ChebyshevReaction` class. Replaced by `Reaction.rate.temperature_range[0]`
+             for reactions where the rate is a a `ChebyshevRate`.
+        """
+        def __get__(self):
+            if isinstance(self.rate, ChebyshevRate):
+                warnings.warn(
+                    self._deprecation_warning(
+                        "Tmin", new="ChebyshevRate.temperature_range[0]"),
+                    DeprecationWarning)
+                return self.rate.temperature_range[0]
+            else:
+                raise TypeError("only valid for reactions with ChebyshevRate rates")
+
+    property Tmax:
+        """
+        Maximum temperature [K] for the Chebyshev fit
+
+        .. deprecated:: 2.6
+             This property is for temporary backwards-compatibility with the deprecated
+             `ChebyshevReaction` class. Replaced by `Reaction.rate.temperature_range[1]`
+             for reactions where the rate is a a `ChebyshevRate`.
+        """
+        def __get__(self):
+            if isinstance(self.rate, ChebyshevRate):
+                warnings.warn(
+                    self._deprecation_warning(
+                        "Tmax", new="ChebyshevRate.temperature_range[1]"),
+                    DeprecationWarning)
+                return self.rate.temperature_range[1]
+            else:
+                raise TypeError("only valid for reactions with ChebyshevRate rates")
+
+    property Pmin:
+        """
+        Minimum pressure [Pa] for the Chebyshev fit
+
+        .. deprecated:: 2.6
+             This property is for temporary backwards-compatibility with the deprecated
+             `ChebyshevReaction` class. Replaced by `Reaction.rate.pressure_range[0]`
+             for reactions where the rate is a a `ChebyshevRate`.
+        """
+        def __get__(self):
+            if isinstance(self.rate, ChebyshevRate):
+                warnings.warn(
+                    self._deprecation_warning(
+                        "Pmin", new="ChebyshevRate.pressure_range[0]"),
+                    DeprecationWarning)
+                return self.rate.pressure_range[0]
+            else:
+                raise TypeError("only valid for reactions with ChebyshevRate rates")
+
+    property Pmax:
+        """
+        Maximum pressure [K] for the Chebyshev fit
+
+        .. deprecated:: 2.6
+             This property is for temporary backwards-compatibility with the deprecated
+             `ChebyshevReaction` class. Replaced by `Reaction.rate.pressure_range[1]`
+             for reactions where the rate is a a `ChebyshevRate`.
+        """
+        def __get__(self):
+            if isinstance(self.rate, ChebyshevRate):
+                warnings.warn(
+                    self._deprecation_warning(
+                        "Pmax", new="ChebyshevRate.pressure_range[1]"),
+                    DeprecationWarning)
+                return self.rate.pressure_range[1]
+            else:
+                raise TypeError("only valid for reactions with ChebyshevRate rates")
+
+    property nPressure:
+        """
+        Number of pressures over which the Chebyshev fit is computed
+
+        .. deprecated:: 2.6
+             This property is for temporary backwards-compatibility with the deprecated
+             `ChebyshevReaction` class. Replaced by `Reaction.rate.n_pressure`
+             for reactions where the rate is a a `ChebyshevRate`.
+        """
+        def __get__(self):
+            if isinstance(self.rate, ChebyshevRate):
+                warnings.warn(
+                    self._deprecation_warning(
+                        "nPressure", new="ChebyshevRate.n_pressure"),
+                    DeprecationWarning)
+                return self.rate.n_pressure
+            else:
+                raise TypeError("only valid for reactions with ChebyshevRate rates")
+
+    property nTemperature:
+        """
+        Number of temperatures over which the Chebyshev fit is computed
+
+        .. deprecated:: 2.6
+             This property is for temporary backwards-compatibility with the deprecated
+             `ChebyshevReaction` class. Replaced by `Reaction.rate.n_temperature`
+             for reactions where the rate is a a `ChebyshevRate`.
+        """
+        def __get__(self):
+            if isinstance(self.rate, ChebyshevRate):
+                warnings.warn(
+                    self._deprecation_warning(
+                        "nTemperature", new="ChebyshevRate.n_temperature"),
+                    DeprecationWarning)
+                return self.rate.n_temperature
+            else:
+                raise TypeError("only valid for reactions with ChebyshevRate rates")
+
+    property coeffs:
+        """
+        2D array of Chebyshev coefficients of size `(n_temperature, n_pressure)`.
+
+        .. deprecated:: 2.6
+             This property is for temporary backwards-compatibility with the deprecated
+             `ChebyshevReaction` class. Replaced by `Reaction.rate.data`
+             for reactions where the rate is a a `ChebyshevRate`.
+        """
+        def __get__(self):
+            if isinstance(self.rate, ChebyshevRate):
+                warnings.warn(
+                    self._deprecation_warning("coeffs", new="ChebyshevRate.data"),
+                    DeprecationWarning)
+                return self.rate.data
+            else:
+                raise TypeError("only valid for reactions with ChebyshevRate rates")
+
+    def set_parameters(self, Tmin, Tmax, Pmin, Pmax, coeffs):
+        """
+        For Chebyshev reactions, simultaneously set values for `Tmin`, `Tmax`, `Pmin`,
+        `Pmax`, and `coeffs`.
+
+        .. deprecated:: 2.6
+             This property is for temporary backwards-compatibility with the deprecated
+             `ChebyshevReaction` class. Replaced by `ChebyshevRate` constructor
+             for reactions where the rate is a a `ChebyshevRate`.
+        """
+        cdef pair[double,double] Trange
+        cdef pair[double,double] Prange
+        if isinstance(self.rate, ChebyshevRate):
+            warnings.warn("Method 'set_parameters' to be removed after Cantera 2.6. "
+                "Method is replaceable by assigning a new 'ChebyshevRate' object to "
+                "the rate property.", DeprecationWarning)
+            Trange.first, Trange.second = Tmin, Tmax
+            Prange.first, Prange.second = Pmin, Pmax
+            self.rate = ChebyshevRate(Trange, Prange, coeffs)
+        else:
+            raise TypeError("only valid for reactions with ChebyshevRate rates")
 
     def __call__(self, T, extra=None):
         """
@@ -2032,55 +2191,37 @@ cdef class ChebyshevReaction(Reaction):
         - [8.2883, -1.1397, -0.12059, 0.016034]
         - [1.9764, 1.0037, 7.2865e-03, -0.030432]
         - [0.3177, 0.26889, 0.094806, -7.6385e-03]
+
+    .. deprecated:: 2.6
+        To be deprecated with version 2.6, and removed thereafter.
+        Replaced by passing a `ChebyshevRate` object as the 'rate' argument to
+        the 'Reaction' class.
     """
     _reaction_type = "Chebyshev"
     _has_legacy = True
-    _hybrid = True
-
-    cdef CxxChebyshevReaction3* cxx_object(self):
-        if self.uses_legacy:
-            raise AttributeError("Incorrect accessor for updated implementation")
-        return <CxxChebyshevReaction3*>self.reaction
+    _hybrid = False
 
     cdef CxxChebyshevReaction2* cxx_object2(self):
-        if not self.uses_legacy:
-            raise AttributeError("Incorrect accessor for legacy implementation")
         return <CxxChebyshevReaction2*>self.reaction
 
     def __init__(self, equation=None, rate=None, Kinetics kinetics=None,
-                 init=True, legacy=False, **kwargs):
+                 init=True, **kwargs):
 
         if init and equation and kinetics:
-
-            rxn_type = self._reaction_type
-            if legacy:
-                rxn_type += "-legacy"
+            warnings.warn("Class 'ChebyshevReaction' to be removed after Cantera 2.6.\n"
+                "These reactions can be constructed by passing a 'ChebyshevRate' object"
+                "as the 'rate' argument to the 'Reaction' class.")
+            rxn_type = self._reaction_type + "-legacy"
             spec = {"equation": equation, "type": rxn_type}
             if isinstance(rate, dict):
                 for key, value in rate.items():
                     spec[key.replace("_", "-")] = value
-            elif not legacy and (isinstance(rate, ChebyshevRate) or rate is None):
-                pass
             else:
                 raise TypeError("Invalid rate definition")
 
             self._reaction = CxxNewReaction(dict_to_anymap(spec),
                                             deref(kinetics.kinetics))
             self.reaction = self._reaction.get()
-
-            if not legacy and isinstance(rate, ChebyshevRate):
-                self.rate = rate
-
-    property rate:
-        """ Get/Set the `ChebyshevRate` rate coefficients for this reaction. """
-        def __get__(self):
-            if self.uses_legacy:
-                raise AttributeError("Legacy implementation does not use rate property.")
-            return ChebyshevRate.wrap(self.cxx_object().rate())
-        def __set__(self, ChebyshevRate rate):
-            if self.uses_legacy:
-                raise AttributeError("Legacy implementation does not use rate property.")
-            self.cxx_object().setRate(rate._rate)
 
     property Tmin:
         """
@@ -2091,14 +2232,7 @@ cdef class ChebyshevReaction(Reaction):
              Replaced by property `ChebyshevRate.temperature_range[0]`.
         """
         def __get__(self):
-            if self.uses_legacy:
-                return self.cxx_object2().rate.Tmin()
-
-            warnings.warn(
-                self._deprecation_warning(
-                    "Tmin", new="ChebyshevRate.temperature_range[0]"),
-                DeprecationWarning)
-            return self.rate.temperature_range[0]
+            return self.cxx_object2().rate.Tmin()
 
     property Tmax:
         """
@@ -2109,14 +2243,7 @@ cdef class ChebyshevReaction(Reaction):
              Replaced by property `ChebyshevRate.temperature_range[1]`.
         """
         def __get__(self):
-            if self.uses_legacy:
-                return self.cxx_object2().rate.Tmax()
-
-            warnings.warn(
-                self._deprecation_warning(
-                    "Tmax", new="ChebyshevRate.temperature_range[1]"),
-                DeprecationWarning)
-            return self.rate.temperature_range[1]
+            return self.cxx_object2().rate.Tmax()
 
     property Pmin:
         """
@@ -2127,14 +2254,7 @@ cdef class ChebyshevReaction(Reaction):
              Replaced by property `ChebyshevRate.pressure_range[0]`.
         """
         def __get__(self):
-            if self.uses_legacy:
-                return self.cxx_object2().rate.Pmin()
-
-            warnings.warn(
-                self._deprecation_warning(
-                    "Pmin", new="ChebyshevRate.pressure_range[0]"),
-                DeprecationWarning)
-            return self.rate.pressure_range[0]
+            return self.cxx_object2().rate.Pmin()
 
     property Pmax:
         """ Maximum pressure [Pa] for the Chebyshev fit
@@ -2144,14 +2264,7 @@ cdef class ChebyshevReaction(Reaction):
              Replaced by property `ChebyshevRate.pressure_range[1]`.
         """
         def __get__(self):
-            if self.uses_legacy:
-                return self.cxx_object2().rate.Pmax()
-
-            warnings.warn(
-                self._deprecation_warning(
-                    "Pmax", new="ChebyshevRate.pressure_range[0]"),
-                DeprecationWarning)
-            return self.rate.pressure_range[1]
+            return self.cxx_object2().rate.Pmax()
 
     property nPressure:
         """
@@ -2162,14 +2275,7 @@ cdef class ChebyshevReaction(Reaction):
              Replaced by property `ChebyshevRate.n_pressure`.
         """
         def __get__(self):
-            if self.uses_legacy:
-                return self.cxx_object2().rate.nPressure()
-
-            warnings.warn(
-                self._deprecation_warning(
-                    "nPressure", new="ChebyshevRate.data.n_pressure"),
-                DeprecationWarning)
-            return self.rate.data.shape[1]
+            return self.cxx_object2().rate.nPressure()
 
     property nTemperature:
         """
@@ -2180,20 +2286,7 @@ cdef class ChebyshevReaction(Reaction):
              Replaced by property `ChebyshevRate.n_temperature`.
         """
         def __get__(self):
-            if self.uses_legacy:
-                return self.cxx_object2().rate.nTemperature()
-
-            warnings.warn(
-                self._deprecation_warning(
-                    "nTemperature", new="ChebyshevRate.data.n_temperature"),
-                DeprecationWarning)
-            return self.rate.data.shape[0]
-
-    cdef _legacy_get_coeffs(self):
-        cdef CxxChebyshevReaction2* r = self.cxx_object2()
-        cdef CxxArray2D cxxcoeffs = r.rate.data()
-        c = np.fromiter(cxxcoeffs.data(), np.double)
-        return c.reshape(cxxcoeffs.nRows(), cxxcoeffs.nColumns(), order="F")
+            return self.cxx_object2().rate.nTemperature()
 
     property coeffs:
         """
@@ -2204,16 +2297,20 @@ cdef class ChebyshevReaction(Reaction):
              Replaced by property `ChebyshevRate.data`.
         """
         def __get__(self):
-            if self.uses_legacy:
-                return self._legacy_get_coeffs()
+            cdef CxxChebyshevReaction2* r = self.cxx_object2()
+            cdef CxxArray2D cxxcoeffs = r.rate.data()
+            c = np.fromiter(cxxcoeffs.data(), np.double)
+            return c.reshape(cxxcoeffs.nRows(), cxxcoeffs.nColumns(), order="F")
 
-            warnings.warn(
-                self._deprecation_warning(
-                    "coeffs", new="ChebyshevRate.data"),
-                DeprecationWarning)
-            return self.rate.data
+    def set_parameters(self, Tmin, Tmax, Pmin, Pmax, coeffs):
+        """
+        Simultaneously set values for `Tmin`, `Tmax`, `Pmin`, `Pmax`, and
+        `coeffs`.
 
-    cdef _legacy_set_parameters(self, Tmin, Tmax, Pmin, Pmax, coeffs):
+        .. deprecated:: 2.6
+             To be deprecated with version 2.6, and removed thereafter.
+             Replaced by `ChebyshevRate` constructor.
+        """
         cdef CxxChebyshevReaction2* r = self.cxx_object2()
 
         cdef CxxArray2D data
@@ -2227,28 +2324,12 @@ cdef class ChebyshevReaction(Reaction):
 
         r.rate = CxxChebyshev(Tmin, Tmax, Pmin, Pmax, data)
 
-    def set_parameters(self, Tmin, Tmax, Pmin, Pmax, coeffs):
+    def __call__(self, float T, float P):
         """
-        Simultaneously set values for `Tmin`, `Tmax`, `Pmin`, `Pmax`, and
-        `coeffs`.
-
         .. deprecated:: 2.6
              To be deprecated with version 2.6, and removed thereafter.
-             Replaced by `ChebyshevRate` constructor.
+             Replaceable by call to `rate` property.
         """
-        if self.uses_legacy:
-            return self._legacy_set_parameters(Tmin, Tmax, Pmin, Pmax, coeffs)
-
-        warnings.warn("Method 'set_parameters' to be removed after Cantera 2.6. "
-            "Method is replaceable by assigning a new 'ChebyshevRate' object to the "
-            "rate property.", DeprecationWarning)
-        cdef pair[double,double] Trange
-        Trange.first, Trange.second = Tmin, Tmax
-        cdef pair[double,double] Prange
-        Prange.first, Prange.second = Pmin, Pmax
-        self.rate = ChebyshevRate(Trange, Prange, coeffs)
-
-    cdef _legacy_call(self, float T, float P):
         cdef CxxChebyshevReaction2* r = self.cxx_object2()
         cdef double logT = np.log(T)
         cdef double recipT = 1/T
@@ -2256,19 +2337,6 @@ cdef class ChebyshevReaction(Reaction):
 
         r.rate.update_C(&logP)
         return r.rate.updateRC(logT, recipT)
-
-    def __call__(self, float T, float P):
-        """
-        .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaceable by call to `rate` property.
-        """
-        if self.uses_legacy:
-            return self._legacy_call(T, P)
-
-        warnings.warn(
-            self._deprecation_warning("__call__", "method"), DeprecationWarning)
-        return self.rate(T, P)
 
 
 cdef class BlowersMasel:

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -661,7 +661,7 @@ cdef class ChebyshevRate(ReactionRate):
         (same as number of rows of `data` property).
         """
         def __get__(self):
-            return self.cxx_object().Pmin(), self.cxx_object().nTemperature()
+            return self.cxx_object().nTemperature()
 
     property n_pressure:
         """
@@ -669,7 +669,7 @@ cdef class ChebyshevRate(ReactionRate):
         (same as number of columns of `data` property).
         """
         def __get__(self):
-            return self.cxx_object().Pmin(), self.cxx_object().nPressure()
+            return self.cxx_object().nPressure()
 
     property data:
         """

--- a/interfaces/cython/cantera/test/test_jacobian.py
+++ b/interfaces/cython/cantera/test/test_jacobian.py
@@ -14,7 +14,7 @@ class RateExpressionTests:
     orders = None
     ix3b = [] # three-body indices
     equation = None
-    reaction_type = None
+    rate_type = None
 
     @classmethod
     def setUpClass(cls):
@@ -45,7 +45,7 @@ class RateExpressionTests:
     def test_input(self):
         # ensure that correct equation is referenced
         self.assertEqual(self.equation, self.rxn.equation)
-        self.assertEqual(self.reaction_type, self.rxn.reaction_type)
+        self.assertEqual(self.rate_type, self.rxn.rate.type)
 
     def rop_ddX(self, spc_ix, mode, const_t=True, rtol_deltac=1e-5, atol_deltac=1e-20):
         # numerical derivative for rates-of-progress with respect to mole fractions
@@ -371,21 +371,21 @@ class TestElementaryRev(HydrogenOxygen, utilities.CanteraTest):
     # Standard elementary reaction with two reactants
     rxn_idx = 2
     equation = "H2 + O <=> H + OH"
-    reaction_type = "elementary"
+    rate_type = "Arrhenius"
 
 
 class TestElementarySelf(HydrogenOxygen, utilities.CanteraTest):
     # Elementary reaction with reactant reacting with itself
     rxn_idx = 27
     equation = "2 HO2 <=> H2O2 + O2"
-    reaction_type = "elementary"
+    rate_type = "Arrhenius"
 
 
 class TestFalloff(HydrogenOxygen, utilities.CanteraTest):
     # Fall-off reaction
     rxn_idx = 21
     equation = "2 OH (+M) <=> H2O2 (+M)"
-    reaction_type = "falloff"
+    rate_type = "Troe"
     rtol = 1e-4
 
 
@@ -393,7 +393,7 @@ class TestThreeBody(HydrogenOxygen, utilities.CanteraTest):
     # Three body reaction with default efficiency
     rxn_idx = 1
     equation = "H + O + M <=> OH + M"
-    reaction_type = "three-body"
+    rate_type = "Arrhenius"
 
     @classmethod
     def setUpClass(cls):
@@ -432,21 +432,21 @@ class TestElementaryIrr(EdgeCases, utilities.CanteraTest):
     # Irreversible elementary reaction with two reactants
     rxn_idx = 0
     equation = "HO2 + O => O2 + OH"
-    reaction_type = "elementary"
+    rate_type = "Arrhenius"
 
 
 class TestElementaryOne(EdgeCases, utilities.CanteraTest):
     # Three-body reaction with single reactant species
     rxn_idx = 1
     equation = "H2 <=> 2 H"
-    reaction_type = "elementary"
+    rate_type = "Arrhenius"
 
 
 class TestElementaryThree(EdgeCases, utilities.CanteraTest):
     # Elementary reaction with three reactants
     rxn_idx = 2
     equation = "2 H + O <=> H2O"
-    reaction_type = "elementary"
+    rate_type = "Arrhenius"
 
 
 class TestElementaryFrac(EdgeCases, utilities.CanteraTest):
@@ -454,14 +454,14 @@ class TestElementaryFrac(EdgeCases, utilities.CanteraTest):
     rxn_idx = 3
     orders = {"H2": 0.8, "O2": 1.0, "OH": 2.0}
     equation = "0.7 H2 + 0.2 O2 + 0.6 OH => H2O"
-    reaction_type = "elementary"
+    rate_type = "Arrhenius"
 
 
 class TestThreeBodyNoDefault(EdgeCases, utilities.CanteraTest):
     # Three body reaction without default efficiency
     rxn_idx = 4
     equation = "H + O + M <=> OH + M"
-    reaction_type = "three-body"
+    rate_type = "Arrhenius"
 
     @classmethod
     def setUpClass(cls):
@@ -494,21 +494,21 @@ class TestPlog(FromScratchCases, utilities.CanteraTest):
     # Plog reaction
     rxn_idx = 3
     equation = "H2 + O2 <=> 2 OH"
-    reaction_type = "pressure-dependent-Arrhenius"
+    rate_type = "pressure-dependent-Arrhenius"
 
 
 class TestChebyshev(FromScratchCases, utilities.CanteraTest):
     # Chebyshev reaction
     rxn_idx = 4
     equation = "HO2 <=> O + OH"
-    reaction_type = "Chebyshev"
+    rate_type = "Chebyshev"
 
 
 class TestBlowersMasel(FromScratchCases, utilities.CanteraTest):
     # Blowers-Masel
     rxn_idx = 6
     equation = "H2 + O <=> H + OH"
-    reaction_type = "Blowers-Masel"
+    rate_type = "Blowers-Masel"
 
     @utilities.unittest.skip("change of reaction enthalpy is not considered")
     def test_forward_rop_ddT(self):

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -77,7 +77,7 @@ class TestKinetics(utilities.CanteraTest):
 
     def test_reaction_type(self):
         self.assertIn(self.phase.reaction_type_str(0), ["three-body", "three-body-legacy"])
-        self.assertIn(self.phase.reaction_type_str(2), ["elementary", "elementary-legacy"])
+        self.assertIn(self.phase.reaction_type_str(2), ["reaction", "elementary-legacy"])
         self.assertEqual(self.phase.reaction_type_str(21), "falloff")
 
         with self.assertRaisesRegex(ValueError, 'out of range'):
@@ -1061,7 +1061,7 @@ class TestReaction(utilities.CanteraTest):
         self.assertEqual(data['equation'], R.equation)
 
     def test_input_data_from_scratch(self):
-        r = ct.ElementaryReaction({'O':1, 'H2':1}, {'H':1, 'OH':1})
+        r = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1})
         r.rate = ct.ArrheniusRate(3.87e1, 2.7, 2.6e7)
         data = r.input_data
         self.assertNear(data['rate-constant']['A'], 3.87e1)
@@ -1072,7 +1072,7 @@ class TestReaction(utilities.CanteraTest):
         self.assertIn('OH', terms)
 
     def test_elementary(self):
-        r = ct.ElementaryReaction({'O':1, 'H2':1}, {'H':1, 'OH':1})
+        r = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1})
         r.rate = ct.ArrheniusRate(3.87e1, 2.7, 6260*1000*4.184)
 
         gas2 = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
@@ -1090,7 +1090,7 @@ class TestReaction(utilities.CanteraTest):
 
     def test_negative_A(self):
         species = ct.Species.listFromFile("gri30.yaml")
-        r = ct.ElementaryReaction('NH:1, NO:1', 'N2O:1, H:1')
+        r = ct.Reaction("NH:1, NO:1", "N2O:1, H:1")
         r.rate = ct.ArrheniusRate(-2.16e13, -0.23, 0)
 
         self.assertFalse(r.rate.allow_negative_pre_exponential_factor)
@@ -1435,7 +1435,7 @@ class TestReaction(utilities.CanteraTest):
     def test_modify_invalid(self):
         # different reaction type
         tbr = self.gas.reaction(0)
-        R2 = ct.ElementaryReaction(tbr.reactants, tbr.products)
+        R2 = ct.Reaction(tbr.reactants, tbr.products)
         R2.rate = tbr.rate
         with self.assertRaisesRegex(ct.CanteraError, 'types are different'):
             self.gas.modify_reaction(0, R2)

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1196,7 +1196,7 @@ class TestReaction(utilities.CanteraTest):
         gas1 = ct.Solution('pdep-test.yaml')
         species = ct.Species.listFromFile('pdep-test.yaml')
 
-        r = ct.ChebyshevReaction()
+        r = ct.Reaction()
         r.reactants = 'R5:1, H:1'
         r.products = 'P5A:1, P5B:1'
         r.rate = ct.ChebyshevRate(
@@ -1221,7 +1221,7 @@ class TestReaction(utilities.CanteraTest):
 
     def test_chebyshev_single_P(self):
         species = ct.Species.listFromFile('pdep-test.yaml')
-        r = ct.ChebyshevReaction()
+        r = ct.Reaction()
         r.reactants = 'R5:1, H:1'
         r.products = 'P5A:1, P5B:1'
         r.rate = ct.ChebyshevRate(
@@ -1245,7 +1245,7 @@ class TestReaction(utilities.CanteraTest):
 
     def test_chebyshev_single_T(self):
         species = ct.Species.listFromFile('pdep-test.yaml')
-        r = ct.ChebyshevReaction()
+        r = ct.Reaction()
         r.reactants = 'R5:1, H:1'
         r.products = 'P5A:1, P5B:1'
         r.rate = ct.ChebyshevRate(

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -202,7 +202,7 @@ class KineticsFromReactions(utilities.CanteraTest):
         gas1 = ct.Solution("h2o2.yaml")
 
         S = ct.Species.listFromFile("h2o2.yaml")
-        R = ct.Reaction.listFromFile("h2o2.yaml", gas1)
+        R = ct.Reaction.list_from_file("h2o2.yaml", gas1)
         gas2 = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                            species=S, reactions=R)
 
@@ -226,7 +226,7 @@ class KineticsFromReactions(utilities.CanteraTest):
         gas = ct.Solution("ptcombust.yaml", "gas")
         surf1 = ct.Interface("ptcombust.yaml", "Pt_surf", [gas])
         surf_species = ct.Species.listFromFile("ptcombust.yaml")
-        reactions = ct.Reaction.listFromFile("ptcombust.yaml", surf1)
+        reactions = ct.Reaction.list_from_file("ptcombust.yaml", surf1)
 
         surf2 = ct.Interface(thermo='Surface', kinetics='interface',
                              species=surf_species, reactions=reactions,
@@ -273,7 +273,7 @@ class KineticsFromReactions(utilities.CanteraTest):
         gas1 = ct.Solution('h2o2.yaml', transport_model=None)
 
         S = ct.Species.listFromFile('h2o2.yaml')
-        R = ct.Reaction.listFromFile('h2o2.yaml', gas1)
+        R = ct.Reaction.list_from_file("h2o2.yaml", gas1)
         gas2 = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                            species=S, reactions=R[:5])
 
@@ -1002,7 +1002,7 @@ class TestReaction(utilities.CanteraTest):
         self.assertNotIn('H2O', r)
 
     def test_listFromFile(self):
-        R = ct.Reaction.listFromFile('h2o2.yaml', self.gas)
+        R = ct.Reaction.list_from_file("h2o2.yaml", self.gas)
         eq1 = [r.equation for r in R]
         eq2 = [r.equation for r in self.gas.reactions()]
         self.assertEqual(eq1, eq2)

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1163,18 +1163,15 @@ class TestReaction(utilities.CanteraTest):
         gas1 = ct.Solution('pdep-test.yaml')
         species = ct.Species.listFromFile('pdep-test.yaml')
 
-        r = ct.PlogReaction()
+        r = ct.Reaction()
         r.reactants = {'R1A':1, 'R1B':1}
         r.products = {'P1':1, 'H':1}
-        # @todo: Fix so chained setter works, i.e. r.rate.rates = ...
-        rate = r.rate
-        rate.rates = [
+        r.rate = ct.PlogRate([
             (0.01*ct.one_atm, ct.Arrhenius(1.2124e13, -0.5779, 10872.7*4184)),
             (1.0*ct.one_atm, ct.Arrhenius(4.9108e28, -4.8507, 24772.8*4184)),
             (10.0*ct.one_atm, ct.Arrhenius(1.2866e44, -9.0246, 39796.5*4184)),
             (100.0*ct.one_atm, ct.Arrhenius(5.9632e53, -11.529, 52599.6*4184))
-        ]
-        r.rate = rate
+        ])
 
         gas2 = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                            species=species, reactions=[r])

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -201,7 +201,7 @@ class KineticsFromReactions(utilities.CanteraTest):
     def test_idealgas(self):
         gas1 = ct.Solution("h2o2.yaml")
 
-        S = ct.Species.listFromFile("h2o2.yaml")
+        S = ct.Species.list_from_file("h2o2.yaml")
         R = ct.Reaction.list_from_file("h2o2.yaml", gas1)
         gas2 = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                            species=S, reactions=R)
@@ -225,7 +225,7 @@ class KineticsFromReactions(utilities.CanteraTest):
     def test_surface(self):
         gas = ct.Solution("ptcombust.yaml", "gas")
         surf1 = ct.Interface("ptcombust.yaml", "Pt_surf", [gas])
-        surf_species = ct.Species.listFromFile("ptcombust.yaml")
+        surf_species = ct.Species.list_from_file("ptcombust.yaml")
         reactions = ct.Reaction.list_from_file("ptcombust.yaml", surf1)
 
         surf2 = ct.Interface(thermo='Surface', kinetics='interface',
@@ -272,7 +272,7 @@ class KineticsFromReactions(utilities.CanteraTest):
     def test_add_reaction(self):
         gas1 = ct.Solution('h2o2.yaml', transport_model=None)
 
-        S = ct.Species.listFromFile('h2o2.yaml')
+        S = ct.Species.list_from_file("h2o2.yaml")
         R = ct.Reaction.list_from_file("h2o2.yaml", gas1)
         gas2 = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                            species=S, reactions=R[:5])
@@ -428,7 +428,7 @@ class KineticsRepeatability(utilities.CanteraTest):
         gas.equilibrate('TP')
         gas.TP = gas.T + 20, None
 
-        S = {sp.name: sp for sp in ct.Species.listFromFile("gri30.yaml")}
+        S = {sp.name: sp for sp in ct.Species.list_from_file("gri30.yaml")}
         w1 = gas.net_rates_of_progress
 
         OH = gas.species('OH')
@@ -955,7 +955,7 @@ class TestReaction(utilities.CanteraTest):
         self.gas = ct.Solution('h2o2.yaml', transport_model=None)
         self.gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
         self.gas.TP = 900, 2*ct.one_atm
-        self.species = ct.Species.listFromFile('h2o2.yaml')
+        self.species = ct.Species.list_from_file("h2o2.yaml")
 
     @utilities.allow_deprecated
     def test_fromCti(self):
@@ -1089,7 +1089,7 @@ class TestReaction(utilities.CanteraTest):
         self.assertNear(R.rate(self.gas.T), self.gas.forward_rate_constants[2])
 
     def test_negative_A(self):
-        species = ct.Species.listFromFile("gri30.yaml")
+        species = ct.Species.list_from_file("gri30.yaml")
         r = ct.Reaction("NH:1, NO:1", "N2O:1, H:1")
         r.rate = ct.ArrheniusRate(-2.16e13, -0.23, 0)
 
@@ -1104,7 +1104,7 @@ class TestReaction(utilities.CanteraTest):
                           species=species, reactions=[r])
 
     def test_negative_A_falloff(self):
-        species = ct.Species.listFromFile('gri30.yaml')
+        species = ct.Species.list_from_file("gri30.yaml")
         r = ct.FalloffReaction('NH:1, NO:1', 'N2O:1, H:1')
         low_rate = ct.Arrhenius(2.16e13, -0.23, 0)
         high_rate = ct.Arrhenius(-8.16e12, -0.5, 0)
@@ -1161,7 +1161,7 @@ class TestReaction(utilities.CanteraTest):
 
     def test_plog(self):
         gas1 = ct.Solution('pdep-test.yaml')
-        species = ct.Species.listFromFile('pdep-test.yaml')
+        species = ct.Species.list_from_file("pdep-test.yaml")
 
         r = ct.Reaction()
         r.reactants = {'R1A':1, 'R1B':1}
@@ -1194,7 +1194,7 @@ class TestReaction(utilities.CanteraTest):
 
     def test_chebyshev(self):
         gas1 = ct.Solution('pdep-test.yaml')
-        species = ct.Species.listFromFile('pdep-test.yaml')
+        species = ct.Species.list_from_file("pdep-test.yaml")
 
         r = ct.Reaction()
         r.reactants = 'R5:1, H:1'
@@ -1220,7 +1220,7 @@ class TestReaction(utilities.CanteraTest):
                             gas1.net_rates_of_progress[4])
 
     def test_chebyshev_single_P(self):
-        species = ct.Species.listFromFile('pdep-test.yaml')
+        species = ct.Species.list_from_file("pdep-test.yaml")
         r = ct.Reaction()
         r.reactants = 'R5:1, H:1'
         r.products = 'P5A:1, P5B:1'
@@ -1244,7 +1244,7 @@ class TestReaction(utilities.CanteraTest):
             self.assertNear(k1, k2)
 
     def test_chebyshev_single_T(self):
-        species = ct.Species.listFromFile('pdep-test.yaml')
+        species = ct.Species.list_from_file("pdep-test.yaml")
         r = ct.Reaction()
         r.reactants = 'R5:1, H:1'
         r.products = 'P5A:1, P5B:1'
@@ -1283,7 +1283,7 @@ class TestReaction(utilities.CanteraTest):
                            [-3.12850e-02, -3.94120e-02,  4.43750e-02,  1.44580e-02]])''')
 
     def test_chebyshev_bad_shape_yaml(self):
-        species = ct.Species.listFromFile('pdep-test.yaml')
+        species = ct.Species.list_from_file("pdep-test.yaml")
         gas = ct.Solution(thermo='IdealGas', kinetics='GasKinetics',
                           species=species, reactions=[])
 
@@ -1379,7 +1379,7 @@ class TestReaction(utilities.CanteraTest):
         self.assertNear(A*gas.T**b*np.exp(0/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
 
     def test_interface(self):
-        surf_species = ct.Species.listFromFile("ptcombust.yaml")
+        surf_species = ct.Species.list_from_file("ptcombust.yaml")
         gas = ct.Solution("ptcombust.yaml", "gas")
         surf1 = ct.Interface("ptcombust.yaml", "Pt_surf", [gas])
         r1 = ct.InterfaceReaction()

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1300,7 +1300,7 @@ class TestReaction(utilities.CanteraTest):
                 - [-0.031285, -0.039412, 0.044375, 0.014458]''', gas)
 
     def test_BlowersMasel(self):
-        r = ct.BlowersMaselReaction({'O':1, 'H2':1}, {'H':1, 'OH':1})
+        r = ct.Reaction({'O':1, 'H2':1}, {'H':1, 'OH':1})
         r.rate = ct.BlowersMaselRate(3.87e1, 2.7, 6260*1000*4.184, 1e9*1000*4.184)
 
         gas1 = ct.Solution('BM_test.yaml')
@@ -1326,7 +1326,7 @@ class TestReaction(utilities.CanteraTest):
 
     def test_negative_A_blowersmasel(self):
         species = ct.Solution('BM_test.yaml').species()
-        r = ct.BlowersMaselReaction({'O':1, 'H2':1}, {'H':1, 'OH':1})
+        r = ct.Reaction({'O':1, 'H2':1}, {'H':1, 'OH':1})
         r.rate = ct.BlowersMaselRate(-3.87e1, 2.7, 6260*1000*4.184, 1e9)
 
         self.assertFalse(r.rate.allow_negative_pre_exponential_factor)

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1289,7 +1289,7 @@ class TestReaction(utilities.CanteraTest):
 
         with self.assertRaisesRegex(ct.CanteraError, "Inconsistent"):
             r = ct.Reaction.from_yaml('''
-                equation: R5 + H (+ M) <=> P5A + P5B (+M)
+                equation: R5 + H <=> P5A + P5B
                 type: Chebyshev
                 temperature-range: [300.0, 2000.0]
                 pressure-range: [9.86e-03 atm, 98.6 atm]
@@ -1298,6 +1298,10 @@ class TestReaction(utilities.CanteraTest):
                 - [1.9764, 1.0037, 7.2865e-03]
                 - [0.3177, 0.26889, 0.094806, -7.6385e-03]
                 - [-0.031285, -0.039412, 0.044375, 0.014458]''', gas)
+
+    def test_chebyshev_deprecated_third_body(self):
+        with self.assertRaisesRegex(ct.CanteraError, "in the reaction equation"):
+            gas = ct.Solution("pdep-test.yaml", "chebyshev-deprecated")
 
     def test_BlowersMasel(self):
         r = ct.Reaction({'O':1, 'H2':1}, {'H':1, 'OH':1})

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -748,7 +748,11 @@ class ReactionTests:
     def from_parts(self):
         # create reaction rate object from parts
         orig = self.gas.reaction(self._index)
-        rxn = self._cls(orig.reactants, orig.products, legacy=self._legacy)
+        if self._rate_cls:
+            rxn = self._cls(orig.reactants, orig.products, rate=self._rate_cls(),
+                            legacy=self._legacy)
+        else:
+            rxn = self._cls(orig.reactants, orig.products, legacy=self._legacy)
         rxn.rate = self._rate_obj
         return rxn
 
@@ -1411,19 +1415,25 @@ class TestChebyshev2(ReactionTests, utilities.CanteraTest):
     @classmethod
     def setUpClass(cls):
         ReactionTests.setUpClass()
-        if not cls._legacy:
-            cls._rate_obj = ct.ChebyshevRate(**cls._rate)
-        cls._deprecated_getters.update({"coeffs": np.array(cls._rate["data"])})
+        cls._deprecated_getters.update({"coeffs": np.array(TestChebyshev2._rate["data"])})
         cls._deprecated_getters.update(
-            {k: v for k, v in cls._rate.items()
+            {k: v for k, v in TestChebyshev2._rate.items()
                 if k not in ["data", "temperature_range", "pressure_range"]})
 
 
 class TestChebyshev(TestChebyshev2):
     # test updated version of Chebyshev reaction
 
-    _rxn_type = "Chebyshev"
+    _cls = ct.Reaction
+    _rate_cls = ct.ChebyshevRate
+    _rxn_type = "reaction"
     _rate_type = "Chebyshev"
+    _rate = None
+    _rate_obj = ct.ChebyshevRate(
+        temperature_range=(290., 3000.), pressure_range=(1000., 10000000.0),
+        data=[[ 8.2883e+00, -1.1397e+00, -1.2059e-01,  1.6034e-02],
+              [ 1.9764e+00,  1.0037e+00,  7.2865e-03, -3.0432e-02],
+              [ 3.1770e-01,  2.6889e-01,  9.4806e-02, -7.6385e-03]])
     _legacy = False
     _yaml = """
         equation: HO2 <=> OH + O

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -975,6 +975,7 @@ class TestElementary2(ReactionTests, utilities.CanteraTest):
 class TestElementary(TestElementary2):
     # test updated version of elementary reaction
 
+    _cls = ct.Reaction
     _type = "elementary"
     _legacy = False
     _yaml = """

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -692,6 +692,8 @@ class TestChebyshevRate(ReactionRateTests, utilities.CanteraTest):
         self.assertEqual(pressure_range[0], rate.pressure_range[0])
         self.assertEqual(pressure_range[1], rate.pressure_range[1])
         self.assertTrue(np.all(self._parts["data"] == rate.data))
+        self.assertEqual(rate.n_pressure, rate.data.shape[1])
+        self.assertEqual(rate.n_temperature, rate.data.shape[0])
 
 
 class ReactionTests:

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -1330,12 +1330,6 @@ class TestPlog2(ReactionTests, utilities.CanteraTest):
         """
     _deprecated_callers = {(1000., ct.one_atm): 530968934612.9017}
 
-    @classmethod
-    def setUpClass(cls):
-        ReactionTests.setUpClass()
-        if not cls._legacy:
-            cls._rate_obj = ct.PlogRate(cls._rate)
-
     def check_rates(self, rates, other):
         # helper function used by deprecation tests
         self.assertEqual(len(rates), len(other))
@@ -1353,11 +1347,11 @@ class TestPlog2(ReactionTests, utilities.CanteraTest):
             self.check_rates(rxn.rates, self._rate)
         else:
             with self.assertWarnsRegex(DeprecationWarning, "property is moved"):
-                self.check_rates(rxn.rates, self._rate)
+                self.check_rates(rxn.rates, TestPlog2._rate)
 
     def test_deprecated_setters(self):
         # overload default tester for deprecated property setters
-        rate = ct.PlogRate(self._rate)
+        rate = ct.PlogRate(TestPlog2._rate)
         rates = rate.rates
 
         rxn = self.from_yaml()
@@ -1368,7 +1362,7 @@ class TestPlog2(ReactionTests, utilities.CanteraTest):
             with self.assertWarnsRegex(DeprecationWarning, "Setter is replaceable"):
                 rxn.rates = rates
             with self.assertWarnsRegex(DeprecationWarning, "property is moved"):
-                self.check_rates(rxn.rates, self._rate)
+                self.check_rates(rxn.rates, TestPlog2._rate)
 
 
 class TestPlog(TestPlog2):
@@ -1376,6 +1370,13 @@ class TestPlog(TestPlog2):
 
     _cls = ct.Reaction
     _rate_cls = ct.PlogRate
+    _rate = {
+        "type": "pressure-dependent-Arrhenius",
+        "rate-constants":
+             [{"P": 1013.25, "A": 1.2124e+16, "b": -0.5779, "Ea": 45491376.8},
+              {"P": 101325., "A": 4.9108e+31, "b": -4.8507, "Ea": 103649395.2},
+              {"P": 1013250., "A": 1.2866e+47, "b": -9.0246, "Ea": 166508556.0},
+              {"P": 10132500., "A": 5.9632e+56, "b": -11.529, "Ea": 220076726.4}]}
     _rxn_type = "reaction"
     _rate_type = "pressure-dependent-Arrhenius"
     _legacy = False
@@ -1388,6 +1389,11 @@ class TestPlog(TestPlog2):
         - {P: 10.0 atm, A: 1.2866e+47, b: -9.0246, Ea: 3.97965e+04 cal/mol}
         - {P: 100.0 atm, A: 5.9632e+56, b: -11.529, Ea: 5.25996e+04 cal/mol}
         """
+
+    @classmethod
+    def setUpClass(cls):
+        ReactionTests.setUpClass()
+        cls._rate_obj = ct.ReactionRate.from_dict(cls._rate)
 
     def eval_rate(self, rate):
         return rate(self.gas.T, self.gas.P)

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -698,6 +698,7 @@ class ReactionTests:
     # test suite for reaction expressions
 
     _cls = None # reaction object to be tested
+    _rate_cls = None # corresponding reaction rate type
     _equation = None # reaction equation string
     _rate = None # parameters for reaction rate object constructor
     _rate_obj = None # reaction rate object
@@ -841,7 +842,7 @@ class ReactionTests:
         # check behavior for instantiation from keywords / no rate
         if self._rate_obj is None:
             return
-        rxn = self.from_rate(None)
+        rxn = self.from_rate(self._rate_cls() if self._rate_cls else None)
         if self._legacy:
             self.assertNear(rxn.rate(self.gas.T), 0.)
         else:
@@ -1354,6 +1355,8 @@ class TestPlog2(ReactionTests, utilities.CanteraTest):
 class TestPlog(TestPlog2):
     # test updated version of Plog reaction
 
+    _cls = ct.Reaction
+    _rate_cls = ct.PlogRate
     _type = "pressure-dependent-Arrhenius"
     _legacy = False
     _yaml = """

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -320,10 +320,10 @@ class TestThermoPhase(utilities.CanteraTest):
         self.assertNear(sum(gas['O2','N2'].X), 1.0)
 
     def test_set_equivalence_ratio_sulfur(self):
-        sulfur_species = [k for k in ct.Species.listFromFile("nasa_gas.yaml")
+        sulfur_species = [k for k in ct.Species.list_from_file("nasa_gas.yaml")
                           if k.name in ("SO", "SO2")]
         gas = ct.Solution(thermo="ideal-gas",
-                          species=ct.Species.listFromFile("gri30.yaml") + sulfur_species)
+                          species=ct.Species.list_from_file("gri30.yaml") + sulfur_species)
         fuel = "CH3:0.5, SO:0.25, OH:0.125, N2:0.125"
         ox = "O2:0.5, SO2:0.25, CO2:0.125, CH:0.125"
 
@@ -356,10 +356,10 @@ class TestThermoPhase(utilities.CanteraTest):
             gas.set_equivalence_ratio(phi, 'CH4:0.8, CH3OH:0.2', 'O2:1.0, N2:3.76')
             self.assertNear(phi, gas.equivalence_ratio('CH4:0.8, CH3OH:0.2', 'O2:1.0, N2:3.76'))
         # Check sulfur species
-        sulfur_species = [k for k in ct.Species.listFromFile("nasa_gas.yaml")
+        sulfur_species = [k for k in ct.Species.list_from_file("nasa_gas.yaml")
                           if k.name in ("SO", "SO2")]
         gas = ct.Solution(thermo="ideal-gas", kinetics="gas",
-                          species=ct.Species.listFromFile("gri30.yaml") + sulfur_species)
+                          species=ct.Species.list_from_file("gri30.yaml") + sulfur_species)
         for phi in np.linspace(0.5, 2.0, 5):
             gas.set_equivalence_ratio(phi, 'CH3:0.5, SO:0.25, OH:0.125, N2:0.125', 'O2:0.5, SO2:0.25, CO2:0.125')
             self.assertNear(phi, gas.equivalence_ratio('CH3:0.5, SO:0.25, OH:0.125, N2:0.125', 'O2:0.5, SO2:0.25, CO2:0.125'))
@@ -1045,7 +1045,7 @@ ideal_gas(name='spam', elements='O H',
         gas1.TPX = 350, 101325, 'H2:0.3, O2:0.7'
         gas1.equilibrate('HP')
 
-        species = ct.Species.listFromFile('h2o2.yaml')
+        species = ct.Species.list_from_file("h2o2.yaml")
         gas2 = ct.ThermoPhase(thermo='IdealGas', species=species)
         gas2.TPX = 350, 101325, 'H2:0.3, O2:0.7'
         gas2.equilibrate('HP')
@@ -1164,7 +1164,7 @@ class TestSpecies(utilities.CanteraTest):
         self.assertEqual(S[3].name, self.gas.species_name(3))
 
     def test_listfromFile_yaml(self):
-        S = ct.Species.listFromFile('h2o2.yaml')
+        S = ct.Species.list_from_file("h2o2.yaml")
         self.assertEqual({sp.name for sp in S}, set(self.gas.species_names))
 
     @utilities.allow_deprecated
@@ -1200,7 +1200,7 @@ class TestSpecies(utilities.CanteraTest):
         self.assertEqual(S[4].name, self.gas.species_name(4))
 
     def test_modify_thermo(self):
-        S = {sp.name: sp for sp in ct.Species.listFromFile("h2o2.yaml")}
+        S = {sp.name: sp for sp in ct.Species.list_from_file("h2o2.yaml")}
         self.gas.TPX = 400, 2*ct.one_atm, 'H2:1.0'
         g0 = self.gas.gibbs_mole
 
@@ -1212,7 +1212,7 @@ class TestSpecies(utilities.CanteraTest):
         self.assertNear(g0, self.gas.gibbs_mole)
 
     def test_modify_thermo_invalid(self):
-        S = {sp.name: sp for sp in ct.Species.listFromFile("h2o2.yaml")}
+        S = {sp.name: sp for sp in ct.Species.list_from_file("h2o2.yaml")}
 
         orig = S['H2']
         thermo = orig.thermo

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -43,7 +43,7 @@ cdef class Species:
     Either of the following will produce a list of 53 `Species` objects
     containing the species defined in the GRI 3.0 mechanism::
 
-        S = ct.Species.listFromFile('gri30.yaml')
+        S = ct.Species.list_from_file("gri30.yaml")
 
         import pathlib
         S = ct.Species.listFromYaml(
@@ -148,7 +148,14 @@ cdef class Species:
 
             The CTI and XML input formats are deprecated and will be removed in
             Cantera 3.0.
+
+        .. deprecated:: 2.6
+
+            To be removed after Cantera 2.6. Replaced by 'Species.list_from_file'.
         """
+        warnings.warn("Static method 'listFromFile' is renamed to 'list_from_file'."
+            " The old name will be removed after Cantera 2.6.", DeprecationWarning)
+
         if filename.lower().split('.')[-1] in ('yml', 'yaml'):
             root = AnyMapFromYamlFile(stringify(filename))
             cxx_species = CxxGetSpecies(root[stringify(section)])
@@ -157,6 +164,21 @@ cdef class Species:
 
         species = []
         for a in cxx_species:
+            b = Species(init=False)
+            b._assign(a)
+            species.append(b)
+        return species
+
+    @staticmethod
+    def list_from_file(filename, section="species"):
+        """
+        Create a list of Species objects from all of the species defined in the section
+        *section* of a YAML file. Directories on Cantera's input file path will be
+        searched for the specified file.
+        """
+        root = AnyMapFromYamlFile(stringify(filename))
+        species = []
+        for a in CxxGetSpecies(root[stringify(section)]):
             b = Species(init=False)
             b._assign(a)
             species.append(b)

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -1898,4 +1898,21 @@ std::string InputFileError::formatError2(const std::string& message,
     return to_string(b);
 }
 
+void warn_deprecated(const std::string& source, const AnyBase& node,
+                     const std::string& message)
+{
+    if (!node.m_metadata) {
+        warn_deprecated(source, message);
+        return;
+    }
+
+    std::string filename = node.m_metadata->getString("filename", "input string");
+    fmt::memory_buffer b;
+    fmt_append(b, message);
+    fmt_append(b, "\n");
+    fmt_append(b, "On line {} of {}:\n", node.m_line+1, filename);
+    formatInputFile(b, node.m_metadata, filename, node.m_line, node.m_column);
+    warn_deprecated(source, to_string(b));
+}
+
 }

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -140,6 +140,10 @@ std::pair<size_t, size_t> Kinetics::checkDuplicates(bool throw_err) const
                 continue;
             } else if (R.type() != other.type()) {
                 continue; // different reaction types
+            } else if (R.rate() && other.rate()
+                       && R.rate()->type() != other.rate()->type())
+            {
+                continue; // different rate parameterizations
             }
             doublereal c = checkDuplicateStoich(net_stoich[i], net_stoich[m]);
             if (c == 0) {

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -1301,41 +1301,6 @@ void FalloffReaction3::getParameters(AnyMap& reactionNode) const
     }
 }
 
-PlogReaction3::PlogReaction3()
-{
-    setRate(newReactionRate(type()));
-}
-
-PlogReaction3::PlogReaction3(const Composition& reactants,
-                             const Composition& products, const PlogRate& rate)
-    : Reaction(reactants, products)
-{
-    m_rate.reset(new PlogRate(rate));
-}
-
-PlogReaction3::PlogReaction3(const AnyMap& node, const Kinetics& kin)
-{
-    if (!node.empty()) {
-        setParameters(node, kin);
-        setRate(newReactionRate(node, calculateRateCoeffUnits3(kin)));
-    } else {
-        setRate(newReactionRate(type()));
-    }
-}
-
-void PlogReaction3::setParameters(const AnyMap& node, const Kinetics& kin)
-{
-    if (node.empty()) {
-        // empty node: used by newReaction() factory loader
-        return;
-    }
-    Reaction::setParameters(node, kin);
-
-    // remove optional third body notation
-    reactants.erase("(+M)");
-    products.erase("(+M)");
-}
-
 ChebyshevReaction3::ChebyshevReaction3()
 {
     setRate(newReactionRate(type()));

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -54,6 +54,18 @@ Reaction::Reaction(const Composition& reactants_,
 {
 }
 
+Reaction::Reaction(const AnyMap& node, const Kinetics& kin)
+    : Reaction()
+{
+    setParameters(node, kin);
+    if (kin.nPhases()) {
+        setRate(newReactionRate(node, calculateRateCoeffUnits3(kin)));
+    } else {
+        // @deprecated This route is only used for legacy reaction types.
+        setRate(newReactionRate(node));
+    }
+}
+
 Reaction::Reaction(int type)
     : reaction_type(type)
     , reversible(true)

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -245,15 +245,7 @@ std::string Reaction::equation() const
 
 std::string Reaction::type() const
 {
-    if (m_rate) {
-        if (m_rate->type() == "Arrhenius") {
-            return "elementary"; // @todo: Find a fix for this special case
-        } else {
-            return m_rate->type();
-        }
-    } else {
-        return "undefined";
-    }
+    return "reaction";
 }
 
 void Reaction::calculateRateCoeffUnits(const Kinetics& kin)
@@ -1144,29 +1136,6 @@ void TwoTempPlasmaReaction::validate()
     if (reversible) {
         throw InputFileError("Reaction::validate", input,
             "TwoTempPlasmaReaction may only be given for irreversible reactions");
-    }
-}
-
-BlowersMaselReaction::BlowersMaselReaction()
-{
-    setRate(newReactionRate(type()));
-}
-
-BlowersMaselReaction::BlowersMaselReaction(
-        const Composition& reactants, const Composition& products,
-        const BlowersMaselRate& rate)
-    : Reaction(reactants, products)
-{
-    m_rate.reset(new BlowersMaselRate(rate));
-}
-
-BlowersMaselReaction::BlowersMaselReaction(const AnyMap& node, const Kinetics& kin)
-{
-    if (!node.empty()) {
-        setParameters(node, kin);
-        setRate(newReactionRate(node, calculateRateCoeffUnits3(kin)));
-    } else {
-        setRate(newReactionRate(type()));
     }
 }
 

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -202,6 +202,14 @@ void Reaction::setRate(shared_ptr<ReactionRate> rate)
     } else {
         m_rate = rate;
     }
+
+    if (reactants.count("(+M)") && std::dynamic_pointer_cast<ChebyshevRate3>(m_rate)) {
+        warn_deprecated("Chebyshev reaction equation", input, "Specifying '(+M)' "
+            "in the reaction equation for Chebyshev reactions is deprecated.");
+        // remove optional third body notation
+        reactants.erase("(+M)");
+        products.erase("(+M)");
+    }
 }
 
 std::string Reaction::reactantString() const
@@ -1267,46 +1275,6 @@ void FalloffReaction3::getParameters(AnyMap& reactionNode) const
         if (m_third_body->default_efficiency != 1.0) {
             reactionNode["default-efficiency"] = m_third_body->default_efficiency;
         }
-    }
-}
-
-ChebyshevReaction3::ChebyshevReaction3()
-{
-    setRate(newReactionRate(type()));
-}
-
-ChebyshevReaction3::ChebyshevReaction3(const Composition& reactants,
-                                       const Composition& products,
-                                       const ChebyshevRate3& rate)
-    : Reaction(reactants, products)
-{
-    m_rate.reset(new ChebyshevRate3(rate));
-}
-
-ChebyshevReaction3::ChebyshevReaction3(const AnyMap& node, const Kinetics& kin)
-{
-    if (!node.empty()) {
-        setParameters(node, kin);
-        setRate(newReactionRate(node, calculateRateCoeffUnits3(kin)));
-    } else {
-        setRate(newReactionRate(type()));
-    }
-}
-
-void ChebyshevReaction3::setParameters(const AnyMap& node, const Kinetics& kin)
-{
-    if (node.empty()) {
-        // empty node: used by newReaction() factory loader
-        return;
-    }
-    Reaction::setParameters(node, kin);
-
-    if (reactants.count("(+M)")) {
-        warn_deprecated("Chebyshev reaction equation", input, "Specifying '(+M)' "
-            "in the reaction equation for Chebyshev reactions is deprecated.");
-        // remove optional third body notation
-        reactants.erase("(+M)");
-        products.erase("(+M)");
     }
 }
 

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -1301,9 +1301,13 @@ void ChebyshevReaction3::setParameters(const AnyMap& node, const Kinetics& kin)
     }
     Reaction::setParameters(node, kin);
 
-    // remove optional third body notation
-    reactants.erase("(+M)");
-    products.erase("(+M)");
+    if (reactants.count("(+M)")) {
+        warn_deprecated("Chebyshev reaction equation", input, "Specifying '(+M)' "
+            "in the reaction equation for Chebyshev reactions is deprecated.");
+        // remove optional third body notation
+        reactants.erase("(+M)");
+        products.erase("(+M)");
+    }
 }
 
 CustomFunc1Reaction::CustomFunc1Reaction()

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -8,6 +8,7 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/kinetics/Reaction.h"
 #include "cantera/kinetics/ReactionFactory.h"
+#include "cantera/kinetics/ReactionRateFactory.h"
 #include "cantera/kinetics/Kinetics.h"
 #include "cantera/base/ctml.h"
 #include "cantera/base/AnyMap.h"
@@ -23,7 +24,14 @@ ReactionFactory::ReactionFactory()
 {
     // register elementary reactions
     reg("elementary", [](const AnyMap& node, const Kinetics& kin) {
-        return new ElementaryReaction3(node, kin);
+        unique_ptr<Reaction> R(new Reaction());
+        R->setParameters(node, kin);
+        if (kin.nPhases()) {
+            R->setRate(newReactionRate(node, R->calculateRateCoeffUnits3(kin)));
+        } else {
+            R->setRate(newReactionRate(node));
+        }
+        return R.release();
     });
     addAlias("elementary", "arrhenius");
     addAlias("elementary", "");

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -339,7 +339,8 @@ unique_ptr<Reaction> newReaction(const AnyMap& rxn_node, const Kinetics& kin)
         // Reaction type is not specified
         // See if this is a three-body reaction with a specified collision partner
         ElementaryReaction2 testReaction;
-        parseReactionEquation(testReaction, rxn_node["equation"], kin);
+        parseReactionEquation(testReaction, rxn_node["equation"].asString(),
+                              rxn_node, &kin);
         if (isThreeBody(testReaction)) {
             type = "three-body";
         }
@@ -349,7 +350,8 @@ unique_ptr<Reaction> newReaction(const AnyMap& rxn_node, const Kinetics& kin)
         // See if this is an electrochemical reaction: type of
         // receiving reaction object is unimportant in this case
         ElementaryReaction2 testReaction;
-        parseReactionEquation(testReaction, rxn_node["equation"], kin);
+        parseReactionEquation(testReaction, rxn_node["equation"].asString(),
+                              rxn_node, &kin);
         if (isElectrochemicalReaction(testReaction, kin)) {
             type = "electrochemical";
         } else {

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -23,7 +23,7 @@ std::mutex ReactionFactory::reaction_mutex;
 ReactionFactory::ReactionFactory()
 {
     // register elementary reactions
-    reg("elementary", [](const AnyMap& node, const Kinetics& kin) {
+    reg("reaction", [](const AnyMap& node, const Kinetics& kin) {
         unique_ptr<Reaction> R(new Reaction());
         R->setParameters(node, kin);
         if (kin.nPhases()) {
@@ -33,8 +33,9 @@ ReactionFactory::ReactionFactory()
         }
         return R.release();
     });
-    addAlias("elementary", "arrhenius");
-    addAlias("elementary", "");
+    addAlias("reaction", "elementary");
+    addAlias("reaction", "arrhenius");
+    addAlias("reaction", "");
 
     // register elementary reactions (old framework)
     reg("elementary-legacy", [](const AnyMap& node, const Kinetics& kin) {
@@ -87,12 +88,9 @@ ReactionFactory::ReactionFactory()
     addAlias("chemically-activated-legacy", "chemact");
     addAlias("chemically-activated-legacy", "chemically_activated");
 
-    // register pressure-dependent-Arrhenius reactions
-    reg("pressure-dependent-Arrhenius", [](const AnyMap& node, const Kinetics& kin) {
-        return new PlogReaction3(node, kin);
-    });
-    addAlias("pressure-dependent-Arrhenius", "plog");
-    addAlias("pressure-dependent-Arrhenius", "pdep_arrhenius");
+    addAlias("reaction", "pressure-dependent-Arrhenius");
+    addAlias("reaction", "plog");
+    addAlias("reaction", "pdep_arrhenius");
 
     // register pressure-dependent-Arrhenius reactions (old framework)
     reg("pressure-dependent-Arrhenius-legacy", [](const AnyMap& node, const Kinetics& kin) {

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -35,6 +35,7 @@ ReactionFactory::ReactionFactory()
     });
     addAlias("reaction", "elementary");
     addAlias("reaction", "arrhenius");
+    addAlias("reaction", "Arrhenius");
     addAlias("reaction", "");
 
     // register elementary reactions (old framework)
@@ -102,10 +103,8 @@ ReactionFactory::ReactionFactory()
     });
 
     // register Chebyshev reactions
-    reg("Chebyshev", [](const AnyMap& node, const Kinetics& kin) {
-        return new ChebyshevReaction3(node, kin);
-    });
-    addAlias("Chebyshev", "chebyshev");
+    addAlias("reaction", "Chebyshev");
+    addAlias("reaction", "chebyshev");
     reg("Chebyshev-legacy", [](const AnyMap& node, const Kinetics& kin) {
         ChebyshevReaction* R = new ChebyshevReaction2();
         if (!node.empty()) {

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -144,10 +144,7 @@ ReactionFactory::ReactionFactory()
         return new TwoTempPlasmaReaction(node, kin);
     });
 
-    // register Blowers Masel reactions
-    reg("Blowers-Masel", [](const AnyMap& node, const Kinetics& kin) {
-        return new BlowersMaselReaction(node, kin);
-    });
+    addAlias("reaction", "Blowers-Masel");
 
     // register surface Blowers Masel reactions
     reg("surface-Blowers-Masel", [](const AnyMap& node, const Kinetics& kin) {

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -24,14 +24,7 @@ ReactionFactory::ReactionFactory()
 {
     // register elementary reactions
     reg("reaction", [](const AnyMap& node, const Kinetics& kin) {
-        unique_ptr<Reaction> R(new Reaction());
-        R->setParameters(node, kin);
-        if (kin.nPhases()) {
-            R->setRate(newReactionRate(node, R->calculateRateCoeffUnits3(kin)));
-        } else {
-            R->setRate(newReactionRate(node));
-        }
-        return R.release();
+        return new Reaction(node, kin);
     });
     addAlias("reaction", "elementary");
     addAlias("reaction", "arrhenius");

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -461,7 +461,7 @@ void setupPhase(ThermoPhase& thermo, const AnyMap& phaseNode, const AnyMap& root
         string filename = phaseNode.getString("__file__",
             rootNode.getString("__file__", "unknown file"));
         string method = fmt::format("{}/{}", filename, phaseNode["name"].asString());
-        warn_deprecated(method, msg);
+        warn_deprecated(method, phaseNode, msg);
     }
 
     // Add elements

--- a/test/data/kineticsfromscratch.yaml
+++ b/test/data/kineticsfromscratch.yaml
@@ -24,7 +24,6 @@ phases:
 reactions:
 - equation: O + H2 <=> H + OH  # Reaction 1
   rate-constant: {A: 38.7, b: 2.7, Ea: 6260.0}
-  duplicate: true  # duplicate of Reaction 7
 - equation: 2 O + M <=> O2 + M  # Reaction 2
   type: three-body
   rate-constant: {A: 1.2e+11, b: -1.0, Ea: 0.0}
@@ -56,7 +55,6 @@ reactions:
 - equation: O + H2 <=> H + OH  # Reaction 7
   type: Blowers-Masel
   rate-constant: {A: 38700, b: 2.7, Ea0: 2.619184e4, w: 4.184e9}
-  duplicate: true  # duplicate of Reaction 1
 - equation: 2 OH (+ M) <=> H2O2 (+ M)  # Reaction 8
   duplicate: true
   type: falloff

--- a/test/data/kineticsfromscratch.yaml
+++ b/test/data/kineticsfromscratch.yaml
@@ -24,6 +24,7 @@ phases:
 reactions:
 - equation: O + H2 <=> H + OH  # Reaction 1
   rate-constant: {A: 38.7, b: 2.7, Ea: 6260.0}
+  duplicate: true  # duplicate of Reaction 7
 - equation: 2 O + M <=> O2 + M  # Reaction 2
   type: three-body
   rate-constant: {A: 1.2e+11, b: -1.0, Ea: 0.0}
@@ -55,6 +56,7 @@ reactions:
 - equation: O + H2 <=> H + OH  # Reaction 7
   type: Blowers-Masel
   rate-constant: {A: 38700, b: 2.7, Ea0: 2.619184e4, w: 4.184e9}
+  duplicate: true  # duplicate of Reaction 1
 - equation: 2 OH (+ M) <=> H2O2 (+ M)  # Reaction 8
   duplicate: true
   type: falloff

--- a/test/data/pdep-test.yaml
+++ b/test/data/pdep-test.yaml
@@ -17,6 +17,12 @@ phases:
     P5B, R6, P6A, P6B, R7, P7A, P7B]
   kinetics: gas
   state: {T: 300.0, P: 1 atm}
+- name: chebyshev-deprecated
+  thermo: ideal-gas
+  species: all
+  kinetics: gas
+  reactions: [chebyshev-deprecated-rxns]
+  state: {T: 300.0, P: 1 atm}
 
 species:
 - name: H
@@ -269,7 +275,7 @@ reactions:
   - {P: 10.0 atm, A: 2.889338e-17 cm^3/molec/s, b: 1.98, Ea: 4521.0}
   note: Degenerate PLOG with a single rate expression and custom quantity
     units
-- equation: R5 + H (+M) <=> P5A + P5B (+M)  # Reaction 5
+- equation: R5 + H <=> P5A + P5B  # Reaction 5
   type: Chebyshev
   temperature-range: [300.0, 2000.0]
   pressure-range: [0.009869232667160128 atm, 98.69232667160128 atm]
@@ -279,7 +285,7 @@ reactions:
   - [0.3177, 0.26889, 0.094806, -7.6385e-03]
   - [-0.031285, -0.039412, 0.044375, 0.014458]
   note: Bimolecular CHEB
-- equation: R6 (+M) <=> P6A + P6B (+M)  # Reaction 6
+- equation: R6 <=> P6A + P6B  # Reaction 6
   type: Chebyshev
   temperature-range: [290.0, 3000.0]
   pressure-range: [0.009869232667160128 atm, 98.69232667160128 atm]
@@ -291,7 +297,7 @@ reactions:
   - [-0.22621, 0.16919, 4.8581e-03, -2.3803e-03]
   - [-0.14322, 0.077111, 0.012708, -6.4154e-04]
   note: Unimolecular decomposition CHEB
-- equation: R7 + H (+M) <=> P7A + P7B (+M)  # Reaction 7
+- equation: R7 + H <=> P7A + P7B  # Reaction 7
   type: Chebyshev
   temperature-range: [300.0, 2000.0]
   pressure-range: [0.009869232667160128 atm, 98.69232667160128 atm]
@@ -302,3 +308,16 @@ reactions:
   - [0.3177, 0.26889, 0.094806, -7.6385e-03]
   - [-0.031285, -0.039412, 0.044375, 0.014458]
   note: Bimolecular CHEB with local quantity units
+
+chebyshev-deprecated-rxns:
+- equation: R7 + H (+M) <=> P7A + P7B (+M)
+  type: Chebyshev
+  temperature-range: [300.0, 2000.0]
+  pressure-range: [0.009869232667160128 atm, 98.69232667160128 atm]
+  units: {quantity: molec}
+  data:
+  - [8.2883, -1.1397, -0.12059, 0.016034]
+  - [1.9764, 1.0037, 7.2865e-03, -0.030432]
+  - [0.3177, 0.26889, 0.094806, -7.6385e-03]
+  - [-0.031285, -0.039412, 0.044375, 0.014458]
+  note: Chebyshev reaction written with the deprecated "(+M)" notation

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -188,9 +188,9 @@ TEST_F(KineticsFromScratch3, add_chebyshev_reaction)
     coeffs(2,1) = 2.6889e-01;
     coeffs(2,2) = 9.4806e-02;
     coeffs(2,3) = -7.6385e-03;
-    ChebyshevRate3 rate(290., 3000., 1000.0, 10000000.0, coeffs);
+    auto rate = make_shared<ChebyshevRate3>(290., 3000., 1000.0, 10000000.0, coeffs);
 
-    auto R = make_shared<ChebyshevReaction3>(reac, prod, rate);
+    auto R = make_shared<Reaction>(reac, prod, rate);
     kin.addReaction(R);
     check_rates(4);
 }

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -143,7 +143,7 @@ TEST_F(KineticsFromScratch3, add_plog_reaction)
         { 100.0*101325, Arrhenius(5.963200e+56, -11.529, 52599.6 / GasConst_cal_mol_K) }
     };
 
-    auto R = make_shared<PlogReaction3>(reac, prod, PlogRate(rates));
+    auto R = make_shared<Reaction>(reac, prod, make_shared<PlogRate>(rates));
     kin.addReaction(R);
     check_rates(3);
 }
@@ -159,7 +159,7 @@ TEST_F(KineticsFromScratch3, plog_invalid_rate)
         { 100.0*101325, Arrhenius(5.9632e+56, -11.529, 52599.6 / GasConst_cal_mol_K) }
     };
 
-    auto R = make_shared<PlogReaction3>(reac, prod, PlogRate(rates));
+    auto R = make_shared<Reaction>(reac, prod, make_shared<PlogRate>(rates));
     ASSERT_THROW(kin.addReaction(R), CanteraError);
 }
 

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -56,8 +56,8 @@ TEST_F(KineticsFromScratch3, add_elementary_reaction)
     // reaction('O + H2 <=> H + OH', [3.870000e+01, 2.7, 6260.0])
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    ArrheniusRate rate(3.87e1, 2.7, 2.619184e+07);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(3.87e1, 2.7, 2.619184e+07);
+    auto R = make_shared<Reaction>(reac, prod, rate);
 
     kin.addReaction(R);
     check_rates(0);
@@ -199,8 +199,8 @@ TEST_F(KineticsFromScratch3, undeclared_species)
 {
     Composition reac = parseCompString("CO:1 OH:1");
     Composition prod = parseCompString("CO2:1 H:1");
-    ArrheniusRate rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
 
     ASSERT_THROW(kin.addReaction(R), CanteraError);
     ASSERT_EQ((size_t) 0, kin.nReactions());
@@ -210,8 +210,8 @@ TEST_F(KineticsFromScratch3, skip_undeclared_species)
 {
     Composition reac = parseCompString("CO:1 OH:1");
     Composition prod = parseCompString("CO2:1 H:1");
-    ArrheniusRate rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
 
     kin.skipUndeclaredSpecies(true);
     kin.addReaction(R);
@@ -222,8 +222,8 @@ TEST_F(KineticsFromScratch3, negative_A_error)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    ArrheniusRate rate(-3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(-3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
 
     ASSERT_THROW(kin.addReaction(R), CanteraError);
     ASSERT_EQ((size_t) 0, kin.nReactions());
@@ -233,8 +233,8 @@ TEST_F(KineticsFromScratch3, allow_negative_A)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    ArrheniusRate rate(-3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(-3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
     auto rr = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
     rr->setAllowNegativePreExponentialFactor(true);
 
@@ -246,8 +246,8 @@ TEST_F(KineticsFromScratch3, invalid_reversible_with_orders)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    ArrheniusRate rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
     R->orders["H2"] = 0.5;
 
     ASSERT_THROW(kin.addReaction(R), CanteraError);
@@ -258,8 +258,8 @@ TEST_F(KineticsFromScratch3, negative_order_override)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    ArrheniusRate rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
     R->reversible = false;
     R->allow_negative_orders = true;
     R->orders["H2"] = - 0.5;
@@ -272,8 +272,8 @@ TEST_F(KineticsFromScratch3, invalid_negative_orders)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    ArrheniusRate rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
     R->reversible = false;
     R->orders["H2"] = - 0.5;
 
@@ -285,8 +285,8 @@ TEST_F(KineticsFromScratch3, nonreactant_order_override)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    ArrheniusRate rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
     R->reversible = false;
     R->allow_nonreactant_orders = true;
     R->orders["OH"] = 0.5;
@@ -299,8 +299,8 @@ TEST_F(KineticsFromScratch3, invalid_nonreactant_order)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    ArrheniusRate rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
-    auto R = make_shared<ElementaryReaction3>(reac, prod, rate);
+    auto rate = make_shared<ArrheniusRate>(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    auto R = make_shared<Reaction>(reac, prod, rate);
     R->reversible = false;
     R->orders["OH"] = 0.5;
 

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -20,9 +20,7 @@ TEST(ReactionRate, ModifyArrheniusRate)
         " negative-A: true}");
 
     auto R = newReaction(rxn, *(sol->kinetics()));
-    auto& ER = dynamic_cast<ElementaryReaction3&>(*R);
-
-    const auto& rr = std::dynamic_pointer_cast<ArrheniusRate>(ER.rate());
+    const auto& rr = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
     EXPECT_TRUE(rr->allowNegativePreExponentialFactor());
     rr->setAllowNegativePreExponentialFactor(false);
     EXPECT_FALSE(rr->allowNegativePreExponentialFactor());
@@ -329,8 +327,7 @@ TEST(Kinetics, GasKineticsFromYaml1)
     EXPECT_EQ(R->reactants.at("NO"), 1);
     EXPECT_EQ(R->products.at("N2"), 1);
     EXPECT_EQ(R->id, "NOx-R1");
-    const auto& ER = std::dynamic_pointer_cast<ElementaryReaction3>(R);
-    const auto& rate = std::dynamic_pointer_cast<ArrheniusRate>(ER->rate());
+    const auto& rate = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), 2.7e10);
 }
 
@@ -526,7 +523,7 @@ TEST_F(ReactionToYaml, elementary)
     soln = newSolution("h2o2.yaml", "", "None");
     soln->thermo()->setState_TPY(1000, 2e5, "H2:1.0, O2:0.5, O:1e-8, OH:3e-8");
     duplicateReaction(2);
-    EXPECT_TRUE(std::dynamic_pointer_cast<ElementaryReaction3>(duplicate));
+    EXPECT_EQ(duplicate->type(), "elementary");
     compareReactions();
 }
 

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -37,7 +37,8 @@ TEST(Reaction, ElementaryFromYaml3)
     auto R = newReaction(rxn, *(sol->kinetics()));
     EXPECT_EQ(R->reactants.at("NO"), 1);
     EXPECT_EQ(R->products.at("N2"), 1);
-    EXPECT_EQ(R->type(), "elementary");
+    EXPECT_EQ(R->type(), "reaction");
+    EXPECT_EQ(R->rate()->type(), "Arrhenius");
     EXPECT_FALSE(R->allow_negative_orders);
 
     const auto& rate = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
@@ -523,7 +524,8 @@ TEST_F(ReactionToYaml, elementary)
     soln = newSolution("h2o2.yaml", "", "None");
     soln->thermo()->setState_TPY(1000, 2e5, "H2:1.0, O2:0.5, O:1e-8, OH:3e-8");
     duplicateReaction(2);
-    EXPECT_EQ(duplicate->type(), "elementary");
+    EXPECT_EQ(duplicate->type(), "reaction");
+    EXPECT_EQ(duplicate->rate()->type(), "Arrhenius");
     compareReactions();
 }
 
@@ -657,7 +659,7 @@ TEST_F(ReactionToYaml, BlowersMasel)
     soln = newSolution("BM_test.yaml", "gas");
     soln->thermo()->setState_TPY(1100, 0.1 * OneAtm, "O:0.01, H2:0.8, O2:0.19");
     duplicateReaction(0);
-    EXPECT_TRUE(std::dynamic_pointer_cast<BlowersMaselReaction>(duplicate));
+    EXPECT_TRUE(std::dynamic_pointer_cast<BlowersMaselRate>(duplicate->rate()));
     compareReactions();
 }
 

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -581,7 +581,7 @@ TEST_F(ReactionToYaml, pdepArrhenius)
     soln = newSolution("pdep-test.yaml");
     soln->thermo()->setState_TPY(1000, 2e5, "R2:1, H:0.1, P2A:2, P2B:0.3");
     duplicateReaction(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<PlogReaction3>(duplicate));
+    EXPECT_TRUE(std::dynamic_pointer_cast<PlogRate>(duplicate->rate()));
     compareReactions();
     soln->thermo()->setState_TPY(1100, 1e3, "R2:1, H:0.2, P2A:2, P2B:0.3");
     compareReactions();

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -594,7 +594,7 @@ TEST_F(ReactionToYaml, Chebyshev)
     soln = newSolution("pdep-test.yaml");
     soln->thermo()->setState_TPY(1000, 2e5, "R6:1, P6A:2, P6B:0.3");
     duplicateReaction(5);
-    EXPECT_TRUE(std::dynamic_pointer_cast<ChebyshevReaction3>(duplicate));
+    EXPECT_TRUE(std::dynamic_pointer_cast<ChebyshevRate3>(duplicate->rate()));
     compareReactions();
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

With the introduction of the `ReactionRate` class, most of the behavior that is specialized for particular kinds of reactions is contained in those classes, but we still have a (more or less) 1:1 correspondence with classes derived from `Reaction`, even though many of them don't have any unique behavior.

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Eliminate unnecessary specializations of C++ `Reaction` class.
  - So far, this covers `ElementaryReaction`, `PlogReaction`, and `BlowersMaselReaction`, and should be easily expandable to cover `CustomFunc1Reaction` and `TwoTempPlasmaReaction`.
  - The C++ `ThreeBodyReaction`, `FalloffReaction` and `ChebyshevReaction` do implement some specialized behaviors, mostly around parsing and representing the reaction equation, so I think they need to stay for now.

- In the Python module, my goal is to eliminate all the specializations of `Reaction`, at least for homogeneous phase reactions (I think `InterfaceReaction` will probably need to stay)
  - This would be more or less analogous to how we handle the `ThermoPhase` class in Python -- with a few exceptions, there aren't wrappers for different `ThermoPhase` types. Right now, I'm a bit stuck based on one of the routes that's been introduced for constructing `Reaction` objects.

**If applicable, provide an example illustrating new features this pull request is introducing**

Before this PR, a `PlogReaction` could be created in one step as:
```python
R = PlogReaction(
    equation="H2 + O2 <=> 2 OH",
    rate=[(1013.25, Arrhenius(1.2124e+16, -0.5779, 45491376.8)),
          (101325., Arrhenius(4.9108e+31, -4.8507, 103649395.2)),
          (1013250., Arrhenius(1.2866e+47, -9.0246, 166508556.0)),
          (10132500., Arrhenius(5.9632e+56, -11.529, 220076726.4))],
    kinetics=gas)
```
Or in a two steps:
```python
R = PlogReaction({"H2": 1, "O2": 1}, {"OH": 2})
R.rate = PlogRate(
    [(1013.25, Arrhenius(1.2124e+16, -0.5779, 45491376.8)),
     (101325., Arrhenius(4.9108e+31, -4.8507, 103649395.2)),
     (1013250., Arrhenius(1.2866e+47, -9.0246, 166508556.0)),
     (10132500., Arrhenius(5.9632e+56, -11.529, 220076726.4))]
```

With this PR, the first example becomes:
```python
R = Reaction(
    equation="H2 + O2 <=> 2 OH",
    rate=PlogRate([(1013.25, Arrhenius(1.2124e+16, -0.5779, 45491376.8)),
          (101325., Arrhenius(4.9108e+31, -4.8507, 103649395.2)),
          (1013250., Arrhenius(1.2866e+47, -9.0246, 166508556.0)),
          (10132500., Arrhenius(5.9632e+56, -11.529, 220076726.4))]),
    kinetics=gas)
```
which is pretty similar.

The second case becomes:
```python
R = ct.Reaction({"H2": 1, "O2": 1}, {"OH": 2})
R.rate = ct.PlogRate(
    [(1013.25, ct.Arrhenius(1.2124e+16, -0.5779, 45491376.8)),
     (101325., ct.Arrhenius(4.9108e+31, -4.8507, 103649395.2)),
     (1013250., ct.Arrhenius(1.2866e+47, -9.0246, 166508556.0)),
     (10132500., ct.Arrhenius(5.9632e+56, -11.529, 220076726.4))])
```
This is fine in the case of `PlogRate`, where the base C++ reaction type is just `Reaction` but presents a problem for the reaction types where we still need C++ specializations of the `Reaction` class, as there's no information about the rate type available in the initial constructor.

What I'm wondering is whether we need this second constructor, where no rate information is provided. Would it make sense require specifying at least an empty `ReactionRate` object of the correct type here, e.g.
```python
R = ct.Reaction({"H2": 1, "O2": 1}, {"OH": 2}, rate=ct.PlogRate())
```
I'm also wondering if there's a good way to clean up the split between specifying the reactants and products separately versus specifying the reaction equation in these constructors.

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
