### PR TITLE
Preamble to InterfaceKinetics refactoring

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -348,6 +348,34 @@ jobs:
     - name: Test Cantera
       run: python3 `which scons` test show_long_tests=yes verbose_tests=yes
 
+  check-deprecations:
+    name: Run test suite without legacy typedefs
+    runs-on: ubuntu-latest
+    steps:
+    - uses: actions/checkout@v2
+      name: Checkout the repository
+      with:
+        submodules: recursive
+    - name: Setup Python
+      uses: actions/setup-python@v2
+      with:
+        python-version: 3.8
+        architecture: x64
+    - name: Install Apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install libboost-dev gfortran libopenmpi-dev
+    - name: Upgrade pip
+      run: python3 -m pip install -U pip setuptools wheel
+    - name: Install Python dependencies
+      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
+        pytest-github-actions-annotate-failures
+    - name: Build Cantera
+      run: python3 `which scons` build env_vars=all -j2 debug=n --debug=time no_legacy_reactions=y
+    - name: Test Cantera
+      run:
+        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
+
   windows:
     name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
@@ -517,7 +545,7 @@ jobs:
     - name: Set Up Python
       uses: actions/setup-python@v2
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: 3.8
         architecture: x64
     - name: Install Python dependencies
       run: |

--- a/SConstruct
+++ b/SConstruct
@@ -584,6 +584,13 @@ config_options = [
            definitions (see Eq. 9.75 in Kee, Coltrin and Glarborg, 'Chemically Reacting
            Flow', Wiley Interscience, 2003).""",
         True),
+    BoolOption(
+        "no_legacy_reactions",
+        """If disabled (default), legacy 'Reaction' and associated rate objects that
+           are deprecated in Cantera 2.6 are used. If disabled, internal objects will
+           use new objects introduced in Cantera 2.6. The flag is used for testing
+           purposes only and has no effect on results.""",
+        False),
 ]
 
 config = Configuration()
@@ -1759,6 +1766,7 @@ cdefine("CT_USE_SYSTEM_EIGEN_PREFIXED", "system_eigen_prefixed")
 cdefine('CT_USE_SYSTEM_FMT', 'system_fmt')
 cdefine('CT_USE_SYSTEM_YAMLCPP', 'system_yamlcpp')
 cdefine('CT_USE_DEMANGLE', 'has_demangle')
+cdefine("CT_NO_LEGACY_REACTIONS_26", "no_legacy_reactions")
 
 config_h_build = env.Command('build/src/config.h.build',
                              'include/cantera/base/config.h.in',

--- a/SConstruct
+++ b/SConstruct
@@ -586,10 +586,10 @@ config_options = [
         True),
     BoolOption(
         "no_legacy_reactions",
-        """If disabled (default), legacy 'Reaction' and associated rate objects that
-           are deprecated in Cantera 2.6 are used. If disabled, internal objects will
-           use new objects introduced in Cantera 2.6. The flag is used for testing
-           purposes only and has no effect on results.""",
+        """If disabled ('no'/default), legacy 'Reaction' and associated rate objects
+           that are deprecated in Cantera 2.6 are used. If enabled ('yes'), internal
+           objects will use new objects introduced in Cantera 2.6. The flag is used
+           for testing purposes only and has no effect on results.""",
         False),
 ]
 

--- a/doc/sphinx/cython/kinetics.rst
+++ b/doc/sphinx/cython/kinetics.rst
@@ -71,11 +71,16 @@ BlowersMaselInterfaceReaction
    :no-undoc-members:
 
 Reaction Rates
----------------------------------------
+--------------
 
 ReactionRate
 ^^^^^^^^^^^^
 .. autoclass:: ReactionRate()
+
+ArrheniusTypeRate
+^^^^^^^^^^^^^^^^^
+.. autoclass:: ArrheniusTypeRate(input_data)
+   :no-undoc-members:
 
 ArrheniusRate
 ^^^^^^^^^^^^^
@@ -85,6 +90,11 @@ ArrheniusRate
 BlowersMaselRate
 ^^^^^^^^^^^^^^^^
 .. autoclass:: BlowersMaselRate(A, b, Ea, w)
+   :no-undoc-members:
+
+TwoTempPlasmaRate
+^^^^^^^^^^^^^^^^^
+.. autoclass:: TwoTempPlasmaRate(A, b, Ea_gas, Ea_electron)
    :no-undoc-members:
 
 FalloffRate

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -82,4 +82,7 @@ typedef int ftnlen;       // Fortran hidden string length type
 //    Use legacy rate constant by default
 {CT_LEGACY_RATE_CONSTANTS!s}
 
+//    Do not use reactions deprecated in Cantera 2.6
+{CT_NO_LEGACY_REACTIONS_26!s}
+
 #endif

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -71,10 +71,6 @@ public:
     //! Return parameters
     void getRateParameters(AnyMap& node) const;
 
-    //! Return parameters - required for legacy framework
-    //! @todo: merge with single-parameter version after removal of old framework
-    virtual void getParameters(AnyMap& node, const Units& rate_units) const;
-
     //! Check rate expression
     void checkRate(const std::string& equation, const AnyMap& node);
 

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -75,11 +75,17 @@ public:
     void checkRate(const std::string& equation, const AnyMap& node);
 
     //! Evaluate reaction rate
+    /*!
+     *  @internal  Non-virtual method that should not be overloaded
+     */
     double evalRate(double logT, double recipT) const {
         return m_A * std::exp(m_b * logT - m_Ea_R * recipT);
     }
 
     //! Evaluate natural logarithm of the rate constant.
+    /*!
+     *  @internal  Non-virtual method that should not be overloaded
+     */
     double evalLog(double logT, double recipT) const {
         return m_logA + m_b * logT - m_Ea_R * recipT;
     }
@@ -189,7 +195,7 @@ public:
 
     virtual void getParameters(AnyMap& node) const override;
 
-    void check(const std::string& equation, const AnyMap& node) {
+    void check(const std::string& equation, const AnyMap& node) override {
         checkRate(equation, node);
     }
 
@@ -208,11 +214,6 @@ public:
      */
     virtual double ddTScaledFromStruct(const ReactionData& shared_data) const {
         return (m_Ea_R * shared_data.recipT + m_b) * shared_data.recipT;
-    }
-
-    //! Return the activation energy *Ea* [J/kmol]
-    double activationEnergy() const {
-        return m_Ea_R * GasConstant;
     }
 
     //! Return the activation energy divided by the gas constant (i.e. the
@@ -282,7 +283,7 @@ public:
 
     virtual void getParameters(AnyMap& node) const override;
 
-    void check(const std::string& equation, const AnyMap& node) {
+    void check(const std::string& equation, const AnyMap& node) override {
         checkRate(equation, node);
     }
 
@@ -389,7 +390,7 @@ public:
 
     virtual void getParameters(AnyMap& node) const;
 
-    void check(const std::string& equation, const AnyMap& node) {
+    void check(const std::string& equation, const AnyMap& node) override {
         checkRate(equation, node);
     }
 
@@ -402,7 +403,7 @@ public:
     void updateFromStruct(const BlowersMaselData& shared_data) {
         if (shared_data.ready) {
             m_deltaH_R = 0.;
-            for (const auto& item : m_multipliers) {
+            for (const auto& item : m_stoich_coeffs) {
                 m_deltaH_R += shared_data.grt[item.first] * item.second;
             }
             m_deltaH_R /= GasConstant;
@@ -461,7 +462,7 @@ public:
 
 protected:
     //! Pairs of species indices and multiplers to calculate enthalpy change
-    std::vector<std::pair<size_t, double>> m_multipliers;
+    std::vector<std::pair<size_t, double>> m_stoich_coeffs;
 
     double m_deltaH_R; //!< enthalpy change of reaction (in temperature units)
 };

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -173,7 +173,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<ArrheniusRate, ArrheniusData>);
+        return unique_ptr<MultiRateBase>(new MultiRate<ArrheniusRate, ArrheniusData>);
     }
 
     //! Identifier of reaction rate type
@@ -257,7 +257,7 @@ public:
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
         return unique_ptr<MultiRateBase>(
-            new MultiBulkRate<TwoTempPlasmaRate, TwoTempPlasmaData>);
+            new MultiRate<TwoTempPlasmaRate, TwoTempPlasmaData>);
     }
 
     //! Constructor based on AnyMap content
@@ -370,7 +370,7 @@ public:
 
     unique_ptr<MultiRateBase> newMultiRate() const {
         return unique_ptr<MultiRateBase>(
-            new MultiBulkRate<BlowersMaselRate, BlowersMaselData>);
+            new MultiRate<BlowersMaselRate, BlowersMaselData>);
     }
 
     //! Constructor based on AnyMap content

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -26,6 +26,16 @@ class AnyMap;
  */
 
 //! Base class for Arrhenius-type Parameterizations
+/*!
+ * This base class provides a minimally functional interface that allows for parameter
+ * access from derived classes as well as classes that use Arrhenius-type expressions
+ * internally, for example FalloffRate and PlogRate.
+ *
+ * @todo supersedes Arrhenius2 and will replace Arrhenius(2) after Cantera 2.6,
+ *      The class should be renamed to Arrhenius after removal of Arrhenius2. The new
+ *      behavior can be forced in self-compiled Cantera installations by defining
+ *      CT_NO_LEGACY_REACTIONS_26 via the 'no_legacy_reactions' option in SCons.
+ */
 class ArrheniusBase
 {
 public:
@@ -138,16 +148,6 @@ protected:
     std::string m_b_str = "b"; //!< The string for temperature exponent
     std::string m_Ea_str = "Ea"; //!< The string for activation energy
     Units m_rate_units; //!< Reaction rate units
-};
-
-
-/*!
- * @todo supersedes Arrhenius2: replace existing instances with this class, rename,
- *      and deprecate Arrhenius3.
- */
-class Arrhenius3 final : public ArrheniusBase
-{
-    using ArrheniusBase::ArrheniusBase; // inherit constructors
 };
 
 

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -99,10 +99,11 @@ public:
         return m_b;
     }
 
-    //! Return the intrinsic activation energy *Ea* [J/kmol]
+    //! Return the activation energy *Ea* [J/kmol]
     //! The value corresponds to the constant specified by input parameters;
-    //! in the simplest case, this is equal to the activation energy itself
-    double intrinsicActivationEnergy() const {
+    //! class specializations may provide alternate definitions that describe
+    //! an effective activation energy that depends on the thermodynamic state.
+    double activationEnergy() const {
         return m_Ea_R * GasConstant;
     }
 
@@ -423,7 +424,7 @@ public:
      */
     virtual double ddTScaledFromStruct(const BlowersMaselData& shared_data) const;
 
-    //! Return the actual activation energy (a function of the delta H of reaction)
+    //! Return the effective activation energy (a function of the delta H of reaction)
     //! divided by the gas constant (i.e. the activation temperature) [K]
     double activationEnergy_R(double deltaH_R) const {
         if (deltaH_R < -4 * m_Ea_R) {
@@ -438,17 +439,12 @@ public:
             (vp * vp - 4 * m_w_R * m_w_R + deltaH_R * deltaH_R); // in Kelvin
     }
 
-    //! Return the actual activation energy [J/kmol]
+    //! Return the effective activation energy [J/kmol]
     /*!
      *  @param deltaH  Enthalpy change of reaction [J/kmol]
      */
-    double activationEnergy(double deltaH) const {
+    double effectiveActivationEnergy(double deltaH) const {
         return activationEnergy_R(deltaH / GasConstant) * GasConstant;
-    }
-
-    //! Return the intrinsic activation energy [J/kmol]
-    double activationEnergy0() const {
-        return m_Ea_R * GasConstant;
     }
 
     //! Return the bond dissociation energy *w* [J/kmol]

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -66,6 +66,16 @@ public:
 
     void check(const std::string& equation, const AnyMap& node);
 
+    //! Evaluate reaction rate
+    double evalRate(double logT, double recipT) const {
+        return m_A * std::exp(m_b * logT - m_Ea_R * recipT);
+    }
+
+    //! Evaluate natural logarithm of the rate constant.
+    double evalLog(double logT, double recipT) const {
+        return m_logA + m_b * logT - m_Ea_R * recipT;
+    }
+
     //! Return the pre-exponential factor *A* (in m, kmol, s to powers depending
     //! on the reaction order)
     double preExponentialFactor() const {
@@ -120,6 +130,7 @@ protected:
     double m_A; //!< Pre-exponential factor
     double m_b; //!< Temperature exponent
     double m_Ea_R; //!< Activation energy (in temperature units)
+    double m_logA; //!< Logarithm of pre-exponential factor
     double m_order; //!< Reaction order
     std::string m_A_str = "A"; //!< The string for temperature exponent
     std::string m_b_str = "b"; //!< The string for temperature exponent

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -364,7 +364,7 @@ public:
      */
     BlowersMaselRate(double A, double b, double Ea0, double w);
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
+    unique_ptr<MultiRateBase> newMultiRate() const override {
         return unique_ptr<MultiRateBase>(
             new MultiRate<BlowersMaselRate, BlowersMaselData>);
     }
@@ -377,7 +377,7 @@ public:
     }
 
     //! Identifier of reaction rate type
-    virtual const std::string type() const {
+    virtual const std::string type() const override {
         return "Blowers-Masel";
     }
 
@@ -386,9 +386,10 @@ public:
      *  @param node  AnyMap containing rate information
      *  @param rate_units  Unit definitions specific to rate information
      */
-    virtual void setParameters(const AnyMap& node, const UnitStack& rate_units);
+    virtual void setParameters(
+        const AnyMap& node, const UnitStack& rate_units) override;
 
-    virtual void getParameters(AnyMap& node) const;
+    virtual void getParameters(AnyMap& node) const override;
 
     void check(const std::string& equation, const AnyMap& node) override {
         checkRate(equation, node);

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -26,7 +26,7 @@ class AnyMap;
  */
 
 //! Base class for Arrhenius-type Parameterizations
-class ArrheniusBase : public ReactionRate
+class ArrheniusBase
 {
 public:
     //! Default constructor.
@@ -58,13 +58,15 @@ public:
                                    const UnitSystem& units,
                                    const UnitStack& rate_units);
 
-    virtual void getParameters(AnyMap& node) const;
+    //! Return parameters
+    virtual void getRateParameters(AnyMap& node) const;
 
     //! Return parameters - required for legacy framework
     //! @todo: merge with single-parameter version after removal of old framework
     virtual void getParameters(AnyMap& node, const Units& rate_units) const;
 
-    void check(const std::string& equation, const AnyMap& node);
+    //! Check rate expression
+    void checkRate(const std::string& equation, const AnyMap& node);
 
     //! Evaluate reaction rate
     double evalRate(double logT, double recipT) const {
@@ -139,6 +141,16 @@ protected:
 };
 
 
+/*!
+ * @todo supersedes Arrhenius2: replace existing instances with this class, rename,
+ *      and deprecate Arrhenius3.
+ */
+class Arrhenius3 final : public ArrheniusBase
+{
+    using ArrheniusBase::ArrheniusBase; // inherit constructors
+};
+
+
 //! Arrhenius reaction rate type depends only on temperature
 /*!
  * A reaction rate coefficient of the following form.
@@ -147,12 +159,9 @@ protected:
  *        k_f =  A T^b \exp (-Ea/RT)
  *   \f]
  *
- * @todo supersedes Arrhenius: replace existing instances with this class, rename,
- *      and deprecate Arrhenius3.
- *
  * @ingroup arrheniusGroup
  */
-class ArrheniusRate final : public ArrheniusBase
+class ArrheniusRate final : public ArrheniusBase, public ReactionRate
 {
 public:
     ArrheniusRate() = default;
@@ -180,6 +189,10 @@ public:
     virtual void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
     virtual void getParameters(AnyMap& node) const override;
+
+    void check(const std::string& equation, const AnyMap& node) {
+        checkRate(equation, node);
+    }
 
     //! Evaluate reaction rate
     //! @param shared_data  data shared by all reactions of a given type
@@ -227,7 +240,7 @@ public:
  * doi: 10.1088/0963-0252/1/3/011
  * @ingroup arrheniusGroup
  */
-class TwoTempPlasmaRate final : public ArrheniusBase
+class TwoTempPlasmaRate final : public ArrheniusBase, public ReactionRate
 {
 public:
     TwoTempPlasmaRate();
@@ -271,6 +284,10 @@ public:
     virtual void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
     virtual void getParameters(AnyMap& node) const override;
+
+    void check(const std::string& equation, const AnyMap& node) {
+        checkRate(equation, node);
+    }
 
     double evalFromStruct(const TwoTempPlasmaData& shared_data) {
         return m_A * std::exp(m_b * shared_data.logTe -
@@ -334,7 +351,7 @@ protected:
  *
  * @ingroup arrheniusGroup
  */
-class BlowersMaselRate final : public ArrheniusBase
+class BlowersMaselRate final : public ArrheniusBase, public ReactionRate
 {
 public:
     //! Default constructor.
@@ -380,6 +397,10 @@ public:
     virtual void setParameters(const AnyMap& node, const UnitStack& rate_units);
 
     virtual void getParameters(AnyMap& node) const;
+
+    void check(const std::string& equation, const AnyMap& node) {
+        checkRate(equation, node);
+    }
 
     double evalFromStruct(const BlowersMaselData& shared_data) {
         double deltaH_R;

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -58,7 +58,7 @@ protected:
     std::vector<unique_ptr<MultiRateBase>> m_bulk_rates;
     std::map<std::string, size_t> m_bulk_types; //!< Mapping of rate handlers
 
-    Rate1<Arrhenius> m_rates; //!< @deprecated (legacy only)
+    Rate1<Arrhenius2> m_rates; //!< @deprecated (legacy only)
     std::vector<size_t> m_revindex; //!< Indices of reversible reactions
     std::vector<size_t> m_irrev; //!< Indices of irreversible reactions
 

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -44,7 +44,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<CustomFunc1Rate, ArrheniusData>);
+        return unique_ptr<MultiRateBase>(new MultiRate<CustomFunc1Rate, ArrheniusData>);
     }
 
     const std::string type() const override { return "custom-rate-function"; }

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -102,10 +102,10 @@ public:
     //! Evaluate falloff function at current conditions
     double evalF(double T, double conc3b) {
         updateTemp(T, m_work.data());
-        FalloffData data;
-        data.update(T);
-        m_rc_low = m_lowRate.evalRate(data.logT, data.recipT);
-        m_rc_high = m_highRate.evalRate(data.logT, data.recipT);
+        double logT = std::log(T);
+        double recipT = 1. / T;
+        m_rc_low = m_lowRate.evalRate(logT, recipT);
+        m_rc_high = m_highRate.evalRate(logT, recipT);
         double pr = conc3b * m_rc_low / (m_rc_high + SmallNumber);
         return F(pr, m_work.data());
     }

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -244,7 +244,7 @@ public:
 
     unique_ptr<MultiRateBase> newMultiRate() const {
         return unique_ptr<MultiRateBase>(
-            new MultiBulkRate<LindemannRate, FalloffData>);
+            new MultiRate<LindemannRate, FalloffData>);
     }
 
     virtual const std::string type() const {
@@ -304,7 +304,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<TroeRate, FalloffData>);
+        return unique_ptr<MultiRateBase>(new MultiRate<TroeRate, FalloffData>);
     }
 
     //! Set coefficients used by parameterization
@@ -406,7 +406,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<SriRate, FalloffData>);
+        return unique_ptr<MultiRateBase>(new MultiRate<SriRate, FalloffData>);
     }
 
     //! Set coefficients used by parameterization
@@ -516,7 +516,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<TsangRate, FalloffData>);
+        return unique_ptr<MultiRateBase>(new MultiRate<TsangRate, FalloffData>);
     }
 
     //! Set coefficients used by parameterization

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -104,8 +104,8 @@ public:
         updateTemp(T, m_work.data());
         FalloffData data;
         data.update(T);
-        m_rc_low = m_lowRate.evalFromStruct(data);
-        m_rc_high = m_highRate.evalFromStruct(data);
+        m_rc_low = m_lowRate.evalRate(data.logT, data.recipT);
+        m_rc_high = m_highRate.evalRate(data.logT, data.recipT);
         double pr = conc3b * m_rc_low / (m_rc_high + SmallNumber);
         return F(pr, m_work.data());
     }
@@ -143,8 +143,8 @@ public:
     //! @param shared_data  data shared by all reactions of a given type
     virtual double evalFromStruct(const FalloffData& shared_data) {
         updateTemp(shared_data.temperature, m_work.data());
-        m_rc_low = m_lowRate.evalFromStruct(shared_data);
-        m_rc_high = m_highRate.evalFromStruct(shared_data);
+        m_rc_low = m_lowRate.evalRate(shared_data.logT, shared_data.recipT);
+        m_rc_high = m_highRate.evalRate(shared_data.logT, shared_data.recipT);
         double thirdBodyConcentration;
         if (shared_data.ready) {
             thirdBodyConcentration = shared_data.conc_3b[m_rate_index];
@@ -188,24 +188,24 @@ public:
     }
 
     //! Get reaction rate in the low-pressure limit
-    ArrheniusRate& lowRate() {
+    ArrheniusBase& lowRate() {
         return m_lowRate;
     }
 
     //! Set reaction rate in the low-pressure limit
-    void setLowRate(const ArrheniusRate& low);
+    void setLowRate(const ArrheniusBase& low);
 
     //! Get reaction rate in the high-pressure limit
-    ArrheniusRate& highRate() {
+    ArrheniusBase& highRate() {
         return m_highRate;
     }
 
     //! Set reaction rate in the high-pressure limit
-    void setHighRate(const ArrheniusRate& high);
+    void setHighRate(const ArrheniusBase& high);
 
 protected:
-    ArrheniusRate m_lowRate; //!< The reaction rate in the low-pressure limit
-    ArrheniusRate m_highRate; //!< The reaction rate in the high-pressure limit
+    ArrheniusBase m_lowRate; //!< The reaction rate in the low-pressure limit
+    ArrheniusBase m_highRate; //!< The reaction rate in the high-pressure limit
 
     bool m_chemicallyActivated; //!< Flag labeling reaction as chemically activated
     bool m_negativeA_ok; //!< Flag indicating whether negative A values are permitted
@@ -234,7 +234,7 @@ public:
     }
 
     LindemannRate(
-        const ArrheniusRate& low, const ArrheniusRate& high, const vector_fp& c)
+        const ArrheniusBase& low, const ArrheniusBase& high, const vector_fp& c)
         : LindemannRate()
     {
         m_lowRate = low;
@@ -295,7 +295,7 @@ public:
         setParameters(node, rate_units);
     }
 
-    TroeRate(const ArrheniusRate& low, const ArrheniusRate& high, const vector_fp& c)
+    TroeRate(const ArrheniusBase& low, const ArrheniusBase& high, const vector_fp& c)
         : TroeRate()
     {
         m_lowRate = low;
@@ -397,7 +397,7 @@ public:
         setParameters(node, rate_units);
     }
 
-    SriRate(const ArrheniusRate& low, const ArrheniusRate& high, const vector_fp& c)
+    SriRate(const ArrheniusBase& low, const ArrheniusBase& high, const vector_fp& c)
         : SriRate()
     {
         m_lowRate = low;
@@ -507,7 +507,7 @@ public:
         setParameters(node, rate_units);
     }
 
-    TsangRate(const ArrheniusRate& low, const ArrheniusRate& high, const vector_fp& c)
+    TsangRate(const ArrheniusBase& low, const ArrheniusBase& high, const vector_fp& c)
         : TsangRate()
     {
         m_lowRate = low;

--- a/include/cantera/kinetics/FalloffFactory.h
+++ b/include/cantera/kinetics/FalloffFactory.h
@@ -29,6 +29,9 @@ namespace Cantera
  * @endcode
  *
  * @ingroup falloffGroup
+ *
+ * @deprecated  Deprecated in Cantera 2.6 and removed thereafter. Replaced by
+ *      FalloffRate objects managed by MultiRate evaluators.
  */
 class FalloffFactory : public Factory<Falloff>
 {

--- a/include/cantera/kinetics/FalloffFactory.h
+++ b/include/cantera/kinetics/FalloffFactory.h
@@ -3,6 +3,9 @@
  *  Parameterizations for reaction falloff functions. Used by classes
  *  that implement gas-phase kinetics (GasKinetics, GRI_30_Kinetics)
  *  (see \ref falloffGroup and class \link Cantera::FalloffRate FalloffRate\endlink).
+ *
+ *  @deprecated  Deprecated in Cantera 2.6 and removed thereafter. Replaced by
+ *      FalloffRate objects managed by MultiRate evaluators.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/kinetics/FalloffMgr.h
+++ b/include/cantera/kinetics/FalloffMgr.h
@@ -1,5 +1,8 @@
 /**
  *  @file FalloffMgr.h
+ *
+ *  @deprecated  Deprecated in Cantera 2.6 and removed thereafter. Replaced by
+ *      FalloffRate objects managed by MultiRate evaluators.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/kinetics/FalloffMgr.h
+++ b/include/cantera/kinetics/FalloffMgr.h
@@ -21,6 +21,9 @@ namespace Cantera
 /**
  *  A falloff manager that implements any set of falloff functions.
  *  @ingroup falloffGroup
+ *
+ *  @deprecated  Deprecated in Cantera 2.6 and removed thereafter. Replaced by
+ *      FalloffRate objects managed by MultiRate evaluators.
  */
 class FalloffMgr
 {

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -156,10 +156,10 @@ protected:
     std::map<size_t, size_t> m_rfallindx; //!< @deprecated (legacy only)
 
     //! Rate expressions for falloff reactions at the low-pressure limit
-    Rate1<Arrhenius> m_falloff_low_rates; //!< @deprecated (legacy only)
+    Rate1<Arrhenius2> m_falloff_low_rates; //!< @deprecated (legacy only)
 
     //! Rate expressions for falloff reactions at the high-pressure limit
-    Rate1<Arrhenius> m_falloff_high_rates; //!< @deprecated (legacy only)
+    Rate1<Arrhenius2> m_falloff_high_rates; //!< @deprecated (legacy only)
 
     FalloffMgr m_falloffn; //!< @deprecated (legacy only)
 

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -167,7 +167,7 @@ protected:
     ThirdBodyCalc m_falloff_concm; //!< @deprecated (legacy only)
 
     Rate1<Plog> m_plog_rates; //!< @deprecated (legacy only)
-    Rate1<Chebyshev> m_cheb_rates; //!< @deprecated (legacy only)
+    Rate1<ChebyshevRate> m_cheb_rates; //!< @deprecated (legacy only)
 
     //! @name Reaction rate data
     //!@{

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -203,7 +203,7 @@ protected:
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
     void addThreeBodyReaction(ThreeBodyReaction2& r);
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
-    void addFalloffReaction(FalloffReaction& r);
+    void addFalloffReaction(FalloffReaction2& r);
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
     void addPlogReaction(PlogReaction2& r);
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
@@ -212,7 +212,7 @@ protected:
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
     void modifyThreeBodyReaction(size_t i, ThreeBodyReaction2& r);
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
-    void modifyFalloffReaction(size_t i, FalloffReaction& r);
+    void modifyFalloffReaction(size_t i, FalloffReaction2& r);
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)
     void modifyPlogReaction(size_t i, PlogReaction2& r);
     //! @deprecated To be removed after Cantera 2.6 (replaced by MultiRate approach)

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -17,7 +17,7 @@ namespace Cantera
 
 //! A class template handling all reaction rates specific to `BulkKinetics`.
 template <class RateType, class DataType>
-class MultiBulkRate final : public MultiRateBase
+class MultiRate final : public MultiRateBase
 {
     CT_DEFINE_HAS_MEMBER(has_update, updateFromStruct)
     CT_DEFINE_HAS_MEMBER(has_ddT, ddTScaledFromStruct)
@@ -27,7 +27,7 @@ class MultiBulkRate final : public MultiRateBase
 public:
     virtual std::string type() override {
         if (!m_rxn_rates.size()) {
-            throw CanteraError("MultiBulkRate::type",
+            throw CanteraError("MultiRate::type",
                  "Cannot determine type of empty rate handler.");
         }
         return m_rxn_rates.at(0).second.type();
@@ -41,12 +41,12 @@ public:
 
     virtual bool replace(const size_t rxn_index, ReactionRate& rate) override {
         if (!m_rxn_rates.size()) {
-            throw CanteraError("MultiBulkRate::replace",
+            throw CanteraError("MultiRate::replace",
                  "Invalid operation: cannot replace rate object "
                  "in empty rate handler.");
         }
         if (rate.type() != type()) {
-            throw CanteraError("MultiBulkRate::replace",
+            throw CanteraError("MultiRate::replace",
                  "Invalid operation: cannot replace rate object of type '{}' "
                  "with a new rate of type '{}'.", type(), rate.type());
         }

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -15,7 +15,7 @@
 namespace Cantera
 {
 
-//! A class template handling all reaction rates specific to `BulkKinetics`.
+//! A class template handling ReactionRate specializations.
 template <class RateType, class DataType>
 class MultiRate final : public MultiRateBase
 {
@@ -108,8 +108,8 @@ public:
         _update();
     }
 
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override {
-        bool changed = m_shared.update(bulk, kin);
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override {
+        bool changed = m_shared.update(phase, kin);
         if (changed) {
             // call helper function only if needed: implementation depends on whether
             // ReactionRate::updateFromStruct is defined

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -174,6 +174,7 @@ protected:
         // perturb conditions
         double dTinv = 1. / (m_shared.temperature * deltaT);
         m_shared.perturbTemperature(deltaT);
+        _update();
 
         // apply numerical derivative
         for (auto& rxn : m_rxn_rates) {
@@ -185,6 +186,7 @@ protected:
 
         // revert changes
         m_shared.restore();
+        _update();
     }
 
     //! Helper function to process third-body derivatives for rate data that
@@ -194,6 +196,7 @@ protected:
     void _process_ddM(double* rop, const double* kf, double deltaM, bool overwrite) {
         double dMinv = 1. / deltaM;
         m_shared.perturbThirdBodies(deltaM);
+        _update();
 
         for (auto& rxn : m_rxn_rates) {
             if (kf[rxn.first] != 0. && m_shared.conc_3b[rxn.first] > 0.) {
@@ -207,6 +210,7 @@ protected:
 
         // revert changes
         m_shared.restore();
+        _update();
     }
 
     //! Helper function for rate data that do not implement `perturbThirdBodies`
@@ -229,6 +233,7 @@ protected:
     void _process_ddP(double* rop, const double* kf, double deltaP) {
         double dPinv = 1. / (m_shared.pressure * deltaP);
         m_shared.perturbPressure(deltaP);
+        _update();
 
         for (auto& rxn : m_rxn_rates) {
             if (kf[rxn.first] != 0.) {
@@ -239,6 +244,7 @@ protected:
 
         // revert changes
         m_shared.restore();
+        _update();
     }
 
     //! Helper function for rate data that do not implement `perturbPressure`

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -21,12 +21,7 @@ class Kinetics;
 /**
  * Because this class has no template parameters, the Kinetics object can store all of
  * these rate coefficient evaluators as a `vector<shared_ptr<MultiRateBase>>`. All of
- * the actual implementation for this capability is done in the MultiBulkRate class.
- *
- * @todo At the moment, implemented methods are specific to BulkKinetics,
- *     which can be updated using information of a single ThermoPhase.
- *     InterfaceKinetics will require access to an entire Kinetics object
- *     or the underlying `vector<ThermoPhase*>` vector (e.g. `m_thermo`).
+ * the actual implementation for this capability is done in the MultiRate class.
  */
 class MultiRateBase
 {

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -97,10 +97,12 @@ public:
 
     //! Update data common to reaction rates of a specific type.
     //! This update mechanism is used by Kinetics reaction rate evaluators.
-    //! @param bulk  object representing bulk phase
+    //! @param phase  object representing reacting phase
     //! @param kin  object representing kinetics
-    //! @returns flag indicating reaction rates need to be re-evaluated
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) = 0;
+    //! @returns  flag indicating whether reaction rates need to be re-evaluated
+    //!
+    //! @todo remove Kinetics argument (which is no longer necessary)
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) = 0;
 
     //! Get the rate for a single reaction. Used to implement ReactionRate::eval,
     //! which allows for the evaluation of a reaction rate expression outside of

--- a/include/cantera/kinetics/RateCoeffMgr.h
+++ b/include/cantera/kinetics/RateCoeffMgr.h
@@ -19,6 +19,9 @@ namespace Cantera
 /**
  * This rate coefficient manager supports one parameterization of
  * the rate constant of any type.
+ *
+ *  @deprecated  Deprecated in Cantera 2.6 and removed thereafter. Replaced by
+ *      ReactionRate objects managed by MultiRate evaluators.
  */
 template<class R>
 class Rate1

--- a/include/cantera/kinetics/RateCoeffMgr.h
+++ b/include/cantera/kinetics/RateCoeffMgr.h
@@ -1,5 +1,8 @@
 /**
  *  @file RateCoeffMgr.h
+ *
+ *  @deprecated  Deprecated in Cantera 2.6 and removed thereafter. Replaced by
+ *      ReactionRate objects managed by MultiRate evaluators.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -467,7 +467,7 @@ class BlowersMaselInterfaceReaction : public Reaction
 public:
     BlowersMaselInterfaceReaction();
     BlowersMaselInterfaceReaction(const Composition& reactants, const Composition& products,
-                      const BlowersMasel2& rate, bool isStick=false);
+                      const BMSurfaceArrhenius& rate, bool isStick=false);
     virtual void getParameters(AnyMap& reactionNode) const;
     virtual void validate();
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
@@ -477,7 +477,7 @@ public:
         return "surface-Blowers-Masel";
     }
 
-    BlowersMasel2 rate;
+    BMSurfaceArrhenius rate;
 
     bool allow_negative_pre_exponential_factor;
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -377,14 +377,14 @@ class ChebyshevReaction2 : public Reaction
 public:
     ChebyshevReaction2();
     ChebyshevReaction2(const Composition& reactants, const Composition& products,
-                       const Chebyshev& rate);
+                       const ChebyshevRate& rate);
     virtual void getParameters(AnyMap& reactionNode) const;
 
     virtual std::string type() const {
         return "Chebyshev-legacy";
     }
 
-    Chebyshev rate;
+    ChebyshevRate rate;
 };
 
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -208,7 +208,7 @@ class ElementaryReaction2 : public Reaction
 public:
     ElementaryReaction2();
     ElementaryReaction2(const Composition& reactants, const Composition products,
-                        const Arrhenius& rate);
+                        const Arrhenius2& rate);
 
     virtual void validate();
     using Reaction::validate;
@@ -218,7 +218,7 @@ public:
         return "elementary-legacy";
     }
 
-    Arrhenius rate;
+    Arrhenius2 rate;
     bool allow_negative_pre_exponential_factor;
 };
 
@@ -260,7 +260,7 @@ class ThreeBodyReaction2 : public ElementaryReaction2
 public:
     ThreeBodyReaction2();
     ThreeBodyReaction2(const Composition& reactants, const Composition& products,
-                       const Arrhenius& rate, const ThirdBody& tbody);
+                       const Arrhenius2& rate, const ThirdBody& tbody);
 
     virtual std::string type() const {
         return "three-body-legacy";
@@ -288,7 +288,7 @@ class FalloffReaction2 : public Reaction
 public:
     FalloffReaction2();
     FalloffReaction2(const Composition& reactants, const Composition& products,
-                     const Arrhenius& low_rate, const Arrhenius& high_rate,
+                     const Arrhenius2& low_rate, const Arrhenius2& high_rate,
                      const ThirdBody& tbody);
 
     virtual std::string type() const {
@@ -304,10 +304,10 @@ public:
     virtual void getParameters(AnyMap& reactionNode) const;
 
     //! The rate constant in the low-pressure limit
-    Arrhenius low_rate;
+    Arrhenius2 low_rate;
 
     //! The rate constant in the high-pressure limit
-    Arrhenius high_rate;
+    Arrhenius2 high_rate;
 
     //! Relative efficiencies of third-body species in enhancing the reaction rate
     ThirdBody third_body;
@@ -337,8 +337,8 @@ class ChemicallyActivatedReaction2 : public FalloffReaction2
 public:
     ChemicallyActivatedReaction2();
     ChemicallyActivatedReaction2(const Composition& reactants,
-        const Composition& products, const Arrhenius& low_rate,
-        const Arrhenius& high_rate, const ThirdBody& tbody);
+        const Composition& products, const Arrhenius2& low_rate,
+        const Arrhenius2& high_rate, const ThirdBody& tbody);
 
     virtual std::string type() const {
         return "chemically-activated-legacy";
@@ -410,7 +410,7 @@ class InterfaceReaction : public ElementaryReaction2
 public:
     InterfaceReaction();
     InterfaceReaction(const Composition& reactants, const Composition& products,
-                      const Arrhenius& rate, bool isStick=false);
+                      const Arrhenius2& rate, bool isStick=false);
     virtual void calculateRateCoeffUnits(const Kinetics& kin);
     virtual void getParameters(AnyMap& reactionNode) const;
     virtual void checkBalance(const Kinetics& kin) const;
@@ -450,7 +450,7 @@ class ElectrochemicalReaction : public InterfaceReaction
 public:
     ElectrochemicalReaction();
     ElectrochemicalReaction(const Composition& reactants,
-                            const Composition& products, const Arrhenius& rate);
+                            const Composition& products, const Arrhenius2& rate);
     virtual void getParameters(AnyMap& reactionNode) const;
 
     //! Forward value of the apparent Electrochemical transfer coefficient

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -244,7 +244,7 @@ protected:
 //! Data container holding shared data specific to ChebyshevRate
 /**
  * The data container `ChebyshevData` holds precalculated data common to
- * all `ChebyshevRate3` objects.
+ * all `ChebyshevRate` objects.
  */
 struct ChebyshevData : public ReactionData
 {

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -139,18 +139,17 @@ struct BlowersMaselData : public ReactionData
     virtual void update(double T, double deltaH) override;
 
     virtual void resize(size_t n_species, size_t n_reactions) override {
-        m_grt.resize(n_species, 0.);
-        dH.resize(n_reactions, 0.);
+        grt.resize(n_species, 0.);
         ready = true;
     }
 
     bool ready; //!< boolean indicating whether vectors are accessible
     double density; //!< used to determine if updates are needed
-    vector_fp dH; //!< enthalpy change for each reaction
+    double dH_direct; //!< enthalpy change for each reaction (for testing)
+    vector_fp grt; //!< partial molar enthalpies
 
 protected:
     int m_state_mf_number; //!< integer that is incremented when composition changes
-    vector_fp m_grt; //!< work vector holding partial molar enthalpies
 };
 
 

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -45,13 +45,15 @@ struct ReactionData
      */
     virtual void update(double T, double extra);
 
-    //! Update data container based on *bulk* phase state
+    //! Update data container based on thermodynamic phase state
     /**
      * This update mechanism is used by Kinetics reaction rate evaluators.
      * @returns  A boolean element indicating whether the `evalFromStruct` method
      *      needs to be called (assuming previously-calculated values were cached)
+     *
+     * @todo  Remove Kinetics argument
      */
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) = 0;
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) = 0;
 
     //! Perturb temperature of data container
     /**
@@ -90,7 +92,7 @@ protected:
  */
 struct ArrheniusData : public ReactionData
 {
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin);
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin);
     using ReactionData::update;
 };
 
@@ -104,7 +106,7 @@ struct TwoTempPlasmaData : public ReactionData
 {
     TwoTempPlasmaData() : electronTemp(1.), logTe(0.), recipTe(1.) {}
 
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
 
     virtual void update(double T) override;
 
@@ -132,7 +134,7 @@ struct BlowersMaselData : public ReactionData
 {
     BlowersMaselData();
 
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
 
     virtual void update(double T) override;
 
@@ -162,7 +164,7 @@ struct FalloffData : public ReactionData
 {
     FalloffData();
 
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
 
     virtual void update(double T) override;
 
@@ -216,7 +218,7 @@ struct PlogData : public ReactionData
         logP = std::log(P);
     }
 
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
 
     //! Perturb pressure of data container
     /**
@@ -257,7 +259,7 @@ struct ChebyshevData : public ReactionData
         log10P = std::log10(P);
     }
 
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
 
     //! Perturb pressure of data container
     /**

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -16,6 +16,9 @@
 namespace Cantera
 {
 
+
+class Reaction;
+
 //! Abstract base class for reaction rate definitions; this base class is used by
 //! user-facing APIs to access reaction rate objects
 //!
@@ -107,6 +110,14 @@ public:
     //! Set reaction rate index within kinetics evaluator
     void setRateIndex(size_t idx) {
         m_rate_index = idx;
+    }
+
+    //! Set context of reaction rate evaluation
+    //! @param rxn  Reaction object associated with rate
+    //! @param kin  Kinetics object used for rate evaluation
+    //! This method allows for passing of information when a ReactionRate is added
+    //! to Kinetics a MultiRate reaction evaluator.
+    virtual void setContext(const Reaction& rxn, const Kinetics& kin) {
     }
 
     //! Evaluate reaction rate based on temperature

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -25,7 +25,9 @@ class Reaction;
 //! In addition to the pure virtual methods declared in this class, complete derived
 //! classes must implement the method `evalFromStruct(const DataType& shared_data)`,
 //! where `DataType` is a container for parameters needed to evaluate reactions of that
-//! type.
+//! type. In addition, derived classes may also implement the method
+//! `updateFromStruct(const DataType& shared_data)` to update buffered data that
+//! is specific to a given reaction rate.
 //!
 //! The calculation of derivatives (or Jacobians) relies on the following methods:
 //!  -  Derived classes may implement the method

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -64,7 +64,7 @@ public:
     //!
     //! ```.cpp
     //! unique_ptr<MultiRateBase> newMultiRate() const override {
-    //!     return unique_ptr<MultiRateBase>(new MultiBulkRate<RateType, DataType>);
+    //!     return unique_ptr<MultiRateBase>(new MultiRate<RateType, DataType>);
     //! ```
     //!
     //! where `RateType` is the derived class name and `DataType` is the corresponding

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -400,17 +400,17 @@ typedef PlogRate Plog;
  * \f$ (T_\mathrm{min}, T_\mathrm{max}) \f$ and
  * \f$ (P_\mathrm{min}, P_\mathrm{max}) \f$ to (-1, 1).
  *
- * A ChebyshevRate3 rate expression is specified in terms of the coefficient matrix
+ * A ChebyshevRate rate expression is specified in terms of the coefficient matrix
  * \f$ \alpha \f$ and the temperature and pressure ranges. Note that the
  * Chebyshev polynomials are not defined outside the interval (-1,1), and
  * therefore extrapolation of rates outside the range of temperatures and
  * pressures for which they are defined is strongly discouraged.
  */
-class ChebyshevRate3 final : public ReactionRate
+class ChebyshevRate final : public ReactionRate
 {
 public:
     //! Default constructor.
-    ChebyshevRate3() : m_log10P(NAN), m_rate_units(Units(0.)) {}
+    ChebyshevRate() : m_log10P(NAN), m_rate_units(Units(0.)) {}
 
     //! Constructor directly from coefficient array
     /*!
@@ -422,18 +422,18 @@ public:
      *      `nP` are the number of temperatures and pressures used in the fit,
      *      respectively.
      */
-    ChebyshevRate3(double Tmin, double Tmax, double Pmin, double Pmax,
-                   const Array2D& coeffs);
+    ChebyshevRate(double Tmin, double Tmax, double Pmin, double Pmax,
+                  const Array2D& coeffs);
 
-    ChebyshevRate3(const AnyMap& node, const UnitStack& rate_units={})
-        : ChebyshevRate3()
+    ChebyshevRate(const AnyMap& node, const UnitStack& rate_units={})
+        : ChebyshevRate()
     {
         setParameters(node, rate_units);
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const {
         return unique_ptr<MultiRateBase>(
-            new MultiRate<ChebyshevRate3, ChebyshevData>);
+            new MultiRate<ChebyshevRate, ChebyshevData>);
     }
 
     const std::string type() const { return "Chebyshev"; }
@@ -461,7 +461,7 @@ public:
         return updateRC(0., shared_data.recipT);
     }
 
-    //! Set up ChebyshevRate3 object
+    //! Set up ChebyshevRate object
     /*!
      * @deprecated   Deprecated in Cantera 2.6. Replaceable with
      *               @see setLimits() and @see setCoeffs().
@@ -469,7 +469,7 @@ public:
     void setup(double Tmin, double Tmax, double Pmin, double Pmax,
                   const Array2D& coeffs);
 
-    //! Set limits for ChebyshevRate3 object
+    //! Set limits for ChebyshevRate object
     /*!
      *  @param Tmin    Minimum temperature [K]
      *  @param Tmax    Maximum temperature [K]
@@ -549,7 +549,7 @@ public:
         return m_coeffs.nRows();
     }
 
-    //! Access the ChebyshevRate3 coefficients.
+    //! Access the ChebyshevRate coefficients.
     /*!
      *  \f$ \alpha_{t,p} = \mathrm{coeffs}[N_P*t + p] \f$ where
      *  \f$ 0 <= t < N_T \f$ and \f$ 0 <= p < N_P \f$.
@@ -557,7 +557,7 @@ public:
      * @deprecated   To be removed after Cantera 2.6. Replaceable by @see data().
      */
     const vector_fp& coeffs() const {
-        warn_deprecated("ChebyshevRate3::coeffs", "Deprecated in Cantera 2.6 "
+        warn_deprecated("ChebyshevRate::coeffs", "Deprecated in Cantera 2.6 "
             "and to be removed thereafter; replaceable by data().");
         return chebCoeffs_;
     }
@@ -585,7 +585,6 @@ protected:
     Units m_rate_units; //!< Reaction rate units
 };
 
-typedef ChebyshevRate3 Chebyshev;
 
 /**
  * A Blowers Masel rate with coverage-dependent terms.

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -48,6 +48,9 @@ public:
     ///     order and the dimensionality (surface or bulk).
     /// @param b Temperature exponent. Non-dimensional.
     /// @param E Activation energy in temperature units. Kelvin.
+    ///
+    /// @todo  Add deprecation warning pointing out change of activation
+    ///     energy units.
     Arrhenius2(doublereal A, doublereal b, doublereal E);
 
     //! Constructor based on AnyMap content

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -223,7 +223,7 @@ public:
     explicit PlogRate(const std::multimap<double, ArrheniusBase>& rates);
 
     //! Constructor using legacy Arrhenius2 framework
-    PlogRate(const std::multimap<double, Arrhenius2>& rates);
+    explicit PlogRate(const std::multimap<double, Arrhenius2>& rates);
 
     PlogRate(const AnyMap& node, const UnitStack& rate_units={}) : PlogRate() {
         setParameters(node, rate_units);
@@ -357,7 +357,7 @@ public:
      * @deprecated  Behavior to change after Cantera 2.6.
      *              @see getRates for new behavior.
      */
-    std::vector<std::pair<double, Arrhenius2> > rates() const;
+    std::vector<std::pair<double, Arrhenius2>> rates() const;
 
     //! Return the pressures and Arrhenius expressions which comprise this
     //! reaction.
@@ -365,7 +365,7 @@ public:
 
 protected:
     //! log(p) to (index range) in the rates_ vector
-    std::map<double, std::pair<size_t, size_t> > pressures_;
+    std::map<double, std::pair<size_t, size_t>> pressures_;
 
     // Rate expressions which are referenced by the indices stored in pressures_
     std::vector<ArrheniusBase> rates_;

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -54,6 +54,8 @@ public:
     Arrhenius2(const AnyValue& rate,
                const UnitSystem& units, const Units& rate_units);
 
+    Arrhenius2(const ArrheniusBase& other);
+
     void setRateParameters(const AnyValue& rate,
                            const UnitSystem& units, const Units& rate_units);
     using ArrheniusBase::setRateParameters;
@@ -218,7 +220,10 @@ public:
     PlogRate();
 
     //! Constructor from Arrhenius rate expressions at a set of pressures
-    explicit PlogRate(const std::multimap<double, Arrhenius>& rates);
+    explicit PlogRate(const std::multimap<double, ArrheniusBase>& rates);
+
+    //! Constructor using legacy Arrhenius2 framework
+    PlogRate(const std::multimap<double, Arrhenius2>& rates);
 
     PlogRate(const AnyMap& node, const UnitStack& rate_units={}) : PlogRate() {
         setParameters(node, rate_units);
@@ -265,12 +270,12 @@ public:
 
     //! Set up Plog object
     /*!
-     * @deprecated   Deprecated in Cantera 2.6. Renamed to setRates.
+     * @deprecated   Deprecated in Cantera 2.6. Replaced by setRates.
      */
-    void setup(const std::multimap<double, Arrhenius>& rates);
+    void setup(const std::multimap<double, Arrhenius2>& rates);
 
     //! Set up Plog object
-    void setRates(const std::multimap<double, Arrhenius>& rates);
+    void setRates(const std::multimap<double, ArrheniusBase>& rates);
 
     //! Update concentration-dependent parts of the rate coefficient.
     //! @param c natural log of the pressure in Pa
@@ -345,18 +350,18 @@ public:
      * @deprecated  Behavior to change after Cantera 2.6.
      *              @see getRates for new behavior.
      */
-    std::vector<std::pair<double, Arrhenius> > rates() const;
+    std::vector<std::pair<double, Arrhenius2> > rates() const;
 
     //! Return the pressures and Arrhenius expressions which comprise this
     //! reaction.
-    std::multimap<double, Arrhenius> getRates() const;
+    std::multimap<double, ArrheniusBase> getRates() const;
 
 protected:
     //! log(p) to (index range) in the rates_ vector
     std::map<double, std::pair<size_t, size_t> > pressures_;
 
     // Rate expressions which are referenced by the indices stored in pressures_
-    std::vector<Arrhenius> rates_;
+    std::vector<ArrheniusBase> rates_;
 
     double logP_; //!< log(p) at the current state
     double logP1_, logP2_; //!< log(p) at the lower / upper pressure reference

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -58,6 +58,9 @@ public:
                            const UnitSystem& units, const Units& rate_units);
     using ArrheniusBase::setRateParameters;
 
+    //! Return parameters - two-parameter version
+    void getParameters(AnyMap& node, const Units& rate_units) const;
+
     //! Update concentration-dependent parts of the rate coefficient.
     /*!
      *   For this class, there are no concentration-dependent parts, so this
@@ -87,15 +90,6 @@ public:
     //! activation temperature) [K]
     doublereal activationEnergy_R() const {
         return m_Ea_R;
-    }
-
-    const std::string type() const {
-        return "Arrhenius";
-    }
-
-    // The following methods are unused but required by the base class
-    unique_ptr<MultiRateBase> newMultiRate() const {
-        throw NotImplementedError("Arrhenius2::newMultiRate");
     }
 };
 

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -346,7 +346,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiBulkRate<PlogRate, PlogData>);
+        return unique_ptr<MultiRateBase>(new MultiRate<PlogRate, PlogData>);
     }
 
     //! Identifier of reaction rate type
@@ -549,7 +549,7 @@ public:
 
     unique_ptr<MultiRateBase> newMultiRate() const {
         return unique_ptr<MultiRateBase>(
-            new MultiBulkRate<ChebyshevRate3, ChebyshevData>);
+            new MultiRate<ChebyshevRate3, ChebyshevData>);
     }
 
     const std::string type() const { return "Chebyshev"; }

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -193,7 +193,7 @@ protected:
 
 
 #ifdef CT_NO_LEGACY_REACTIONS_26
-typedef Arrhenius3 Arrhenius;
+typedef ArrheniusBase Arrhenius;
 #else
 typedef Arrhenius2 Arrhenius;
 #endif

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -97,9 +97,6 @@ public:
     unique_ptr<MultiRateBase> newMultiRate() const {
         throw NotImplementedError("Arrhenius2::newMultiRate");
     }
-
-protected:
-    double m_logA;
 };
 
 //! Blowers Masel reaction rate type depends on the enthalpy of reaction
@@ -431,21 +428,21 @@ public:
     doublereal updateRC(doublereal logT, doublereal recipT) const {
         double log_k1, log_k2;
         if (ilow1_ == ilow2_) {
-            log_k1 = rates_[ilow1_].updateLog(logT, recipT);
+            log_k1 = rates_[ilow1_].evalLog(logT, recipT);
         } else {
             double k = 1e-300; // non-zero to make log(k) finite
             for (size_t i = ilow1_; i < ilow2_; i++) {
-                k += rates_[i].updateRC(logT, recipT);
+                k += rates_[i].evalRate(logT, recipT);
             }
             log_k1 = std::log(k);
         }
 
         if (ihigh1_ == ihigh2_) {
-            log_k2 = rates_[ihigh1_].updateLog(logT, recipT);
+            log_k2 = rates_[ihigh1_].evalLog(logT, recipT);
         } else {
             double k = 1e-300; // non-zero to make log(k) finite
             for (size_t i = ihigh1_; i < ihigh2_; i++) {
-                k += rates_[i].updateRC(logT, recipT);
+                k += rates_[i].evalRate(logT, recipT);
             }
             log_k2 = std::log(k);
         }

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -257,14 +257,21 @@ public:
         return getParameters(rateNode, Units(0));
     }
 
+    //! Update information specific to reaction
+    /*!
+     *  @param shared_data  data shared by all reactions of a given type
+     */
+    void updateFromStruct(const PlogData& shared_data) {
+        if (shared_data.logP != logP_) {
+            update_C(&shared_data.logP);
+        }
+    }
+
     //! Evaluate reaction rate
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
     double evalFromStruct(const PlogData& shared_data) {
-        if (shared_data.logP != logP_) {
-            update_C(&shared_data.logP);
-        }
         return updateRC(shared_data.logT, shared_data.recipT);
     }
 
@@ -454,10 +461,17 @@ public:
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
-    double evalFromStruct(const ChebyshevData& shared_data) {
+    void updateFromStruct(const ChebyshevData& shared_data) {
         if (shared_data.log10P != m_log10P) {
             update_C(&shared_data.log10P);
         }
+    }
+
+    //! Evaluate reaction rate
+    /*!
+     *  @param shared_data  data shared by all reactions of a given type
+     */
+    double evalFromStruct(const ChebyshevData& shared_data) {
         return updateRC(0., shared_data.recipT);
     }
 

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -306,7 +306,7 @@ protected:
 
 
 #ifdef CT_NO_LEGACY_REACTIONS_26
-typedef ArrheniusRate Arrhenius;
+typedef Arrhenius3 Arrhenius;
 typedef BlowersMaselRate BlowersMasel;
 #else
 typedef Arrhenius2 Arrhenius;

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -525,10 +525,10 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxPlogRate(multimap[double, CxxArrheniusBase])
         multimap[double, CxxArrheniusBase] getRates()
 
-    cdef cppclass CxxChebyshevRate3 "Cantera::ChebyshevRate3" (CxxReactionRate):
-        CxxChebyshevRate3()
-        CxxChebyshevRate3(CxxAnyMap) except +translate_exception
-        CxxChebyshevRate3(double, double, double, double, CxxArray2D)
+    cdef cppclass CxxChebyshevRate "Cantera::ChebyshevRate" (CxxReactionRate):
+        CxxChebyshevRate()
+        CxxChebyshevRate(CxxAnyMap) except +translate_exception
+        CxxChebyshevRate(double, double, double, double, CxxArray2D)
         double Tmin()
         double Tmax()
         double Pmin()
@@ -615,7 +615,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxPlogReaction2 "Cantera::PlogReaction2" (CxxReaction):
         CxxPlog rate
 
-    cdef cppclass CxxChebyshev "Cantera::ChebyshevRate3":
+    cdef cppclass CxxChebyshev "Cantera::ChebyshevRate":
         CxxChebyshev(double, double, double, double, CxxArray2D)
         double Tmin()
         double Tmax()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -464,6 +464,8 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double preExponentialFactor()
         double temperatureExponent()
         double intrinsicActivationEnergy()
+        cbool allowNegativePreExponentialFactor()
+        void setAllowNegativePreExponentialFactor(bool)
 
     cdef cppclass CxxArrhenius2 "Cantera::Arrhenius2" (CxxArrheniusBase):
         CxxArrhenius2(double, double, double)
@@ -482,8 +484,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxArrheniusRate(CxxAnyMap) except +translate_exception
         CxxArrheniusRate(double, double, double)
         double activationEnergy()
-        cbool allowNegativePreExponentialFactor()
-        void setAllowNegativePreExponentialFactor(bool)
 
     cdef cppclass CxxTwoTempPlasmaRate "Cantera::TwoTempPlasmaRate" (CxxReactionRate, CxxArrheniusBase):
         CxxTwoTempPlasmaRate()
@@ -491,8 +491,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxTwoTempPlasmaRate(double, double, double, double)
         double activationEnergy()
         double activationElectronEnergy()
-        cbool allowNegativePreExponentialFactor()
-        void setAllowNegativePreExponentialFactor(bool)
 
     cdef cppclass CxxBlowersMaselRate "Cantera::BlowersMaselRate" (CxxReactionRate, CxxArrheniusBase):
         CxxBlowersMaselRate()
@@ -501,8 +499,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double activationEnergy(double)
         double activationEnergy0()
         double bondEnergy()
-        cbool allowNegativePreExponentialFactor()
-        void setAllowNegativePreExponentialFactor(bool)
 
     cdef cppclass CxxFalloffRate "Cantera::FalloffRate" (CxxReactionRate):
         CxxFalloffRate()
@@ -520,16 +516,16 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double evalF(double, double) except +translate_exception
 
     cdef cppclass CxxLindemannRate "Cantera::LindemannRate" (CxxFalloffRate):
-        CxxLindemannRate()
+        CxxLindemannRate(CxxAnyMap) except +translate_exception
 
     cdef cppclass CxxTroeRate "Cantera::TroeRate" (CxxFalloffRate):
-        CxxTroeRate()
+        CxxTroeRate(CxxAnyMap) except +translate_exception
 
     cdef cppclass CxxSriRate "Cantera::SriRate" (CxxFalloffRate):
-        CxxSriRate()
+        CxxSriRate(CxxAnyMap) except +translate_exception
 
     cdef cppclass CxxTsangRate "Cantera::TsangRate" (CxxFalloffRate):
-        CxxTsangRate()
+        CxxTsangRate(CxxAnyMap) except +translate_exception
 
     cdef cppclass CxxPlogRate "Cantera::PlogRate" (CxxReactionRate):
         CxxPlogRate()
@@ -1393,6 +1389,9 @@ cdef class ReactionRate:
     @staticmethod
     cdef wrap(shared_ptr[CxxReactionRate])
     cdef set_cxx_object(self)
+
+cdef class _ArrheniusTypeRate(ReactionRate):
+    cdef CxxArrheniusBase* base
 
 cdef class FalloffRate(ReactionRate):
     cdef CxxFalloffRate* falloff

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -507,10 +507,10 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         void setAllowNegativePreExponentialFactor(bool)
         cbool chemicallyActivated()
         void setChemicallyActivated(bool)
-        CxxArrheniusRate& lowRate()
-        void setLowRate(CxxArrheniusRate&) except +translate_exception
-        CxxArrheniusRate& highRate()
-        void setHighRate(CxxArrheniusRate&) except +translate_exception
+        CxxArrheniusBase& lowRate()
+        void setLowRate(CxxArrheniusBase&) except +translate_exception
+        CxxArrheniusBase& highRate()
+        void setHighRate(CxxArrheniusBase&) except +translate_exception
         void getFalloffCoeffs(vector[double]&)
         void setFalloffCoeffs(vector[double]&) except +translate_exception
         double evalF(double, double) except +translate_exception
@@ -1412,12 +1412,11 @@ cdef class CustomReaction(Reaction):
 
 cdef class Arrhenius:
     cdef CxxArrhenius2* legacy # used by legacy objects only
-    cdef CxxArrheniusRate* rate # used by new objects only
     cdef CxxArrheniusBase* base
     cdef cbool own_rate
     cdef Reaction reaction # parent reaction, to prevent garbage collection
     @staticmethod
-    cdef wrap(CxxArrheniusRate*)
+    cdef wrap(CxxArrheniusBase*)
 
 cdef class BlowersMasel:
     cdef CxxBlowersMasel2* rate

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -522,8 +522,8 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxPlogRate "Cantera::PlogRate" (CxxReactionRate):
         CxxPlogRate()
         CxxPlogRate(CxxAnyMap) except +translate_exception
-        CxxPlogRate(multimap[double, CxxArrhenius2])
-        multimap[double, CxxArrhenius2] getRates()
+        CxxPlogRate(multimap[double, CxxArrheniusBase])
+        multimap[double, CxxArrheniusBase] getRates()
 
     cdef cppclass CxxChebyshevRate3 "Cantera::ChebyshevRate3" (CxxReactionRate):
         CxxChebyshevRate3()
@@ -608,7 +608,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
 
     cdef cppclass CxxPlog "Cantera::Plog":
         CxxPlog(multimap[double,CxxArrhenius2])
-        multimap[double, CxxArrhenius2] getRates()
+        vector[pair[double, CxxArrhenius2]] rates()
         void update_C(double*)
         double updateRC(double, double)
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -638,7 +638,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxChebyshevReaction2 "Cantera::ChebyshevReaction2" (CxxReaction):
         CxxChebyshev rate
 
-    cdef cppclass CxxBlowersMasel2 "Cantera::BlowersMasel2":
+    cdef cppclass CxxBlowersMasel2 "Cantera::BMSurfaceArrhenius":
         CxxBlowersMasel2()
         CxxBlowersMasel2(double, double, double, double)
         double updateRC(double, double, double)

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -463,14 +463,12 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double evalRate(double, double)
         double preExponentialFactor()
         double temperatureExponent()
-        double intrinsicActivationEnergy()
+        double activationEnergy()
         cbool allowNegativePreExponentialFactor()
         void setAllowNegativePreExponentialFactor(bool)
 
     cdef cppclass CxxArrhenius2 "Cantera::Arrhenius2" (CxxArrheniusBase):
         CxxArrhenius2(double, double, double)
-        double activationEnergy_R()
-        double updateRC(double, double)
 
     cdef cppclass CxxReactionRate "Cantera::ReactionRate":
         CxxReactionRate()
@@ -480,24 +478,18 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxAnyMap parameters() except +translate_exception
 
     cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxReactionRate, CxxArrheniusBase):
-        CxxArrheniusRate()
         CxxArrheniusRate(CxxAnyMap) except +translate_exception
         CxxArrheniusRate(double, double, double)
-        double activationEnergy()
 
     cdef cppclass CxxTwoTempPlasmaRate "Cantera::TwoTempPlasmaRate" (CxxReactionRate, CxxArrheniusBase):
-        CxxTwoTempPlasmaRate()
         CxxTwoTempPlasmaRate(CxxAnyMap) except +translate_exception
         CxxTwoTempPlasmaRate(double, double, double, double)
-        double activationEnergy()
         double activationElectronEnergy()
 
     cdef cppclass CxxBlowersMaselRate "Cantera::BlowersMaselRate" (CxxReactionRate, CxxArrheniusBase):
-        CxxBlowersMaselRate()
         CxxBlowersMaselRate(CxxAnyMap) except +translate_exception
         CxxBlowersMaselRate(double, double, double, double)
-        double activationEnergy(double)
-        double activationEnergy0()
+        double effectiveActivationEnergy(double)
         double bondEnergy()
 
     cdef cppclass CxxFalloffRate "Cantera::FalloffRate" (CxxReactionRate):

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -460,7 +460,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxArrheniusBase "Cantera::ArrheniusBase":
         CxxArrheniusBase()
         CxxArrheniusBase(double, double, double)
-        double eval(double) except +translate_exception
+        double evalRate(double, double)
         double preExponentialFactor()
         double temperatureExponent()
         double intrinsicActivationEnergy()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1382,7 +1382,7 @@ cdef class ReactionRate:
     cdef wrap(shared_ptr[CxxReactionRate])
     cdef set_cxx_object(self)
 
-cdef class _ArrheniusTypeRate(ReactionRate):
+cdef class ArrheniusTypeRate(ReactionRate):
     cdef CxxArrheniusBase* base
 
 cdef class FalloffRate(ReactionRate):

--- a/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
+++ b/interfaces/cython/cantera/examples/kinetics/blowers_masel.py
@@ -95,7 +95,7 @@ def change_species_enthalpy(gas, species_name, dH):
 
 # Plot the activation energy change of reaction 2 with respect to the
 # enthalpy change
-E0 = gas.reaction(1).rate.intrinsic_activation_energy
+E0 = gas.reaction(1).rate.activation_energy
 upper_limit_enthalpy = 5 * E0
 lower_limit_enthalpy = -5 * E0
 
@@ -103,7 +103,7 @@ Ea_list = []
 deltaH_list = np.linspace(lower_limit_enthalpy, upper_limit_enthalpy, 100)
 for deltaH in deltaH_list:
     delta_enthalpy = change_species_enthalpy(gas, "H", deltaH - gas.delta_enthalpy[1])
-    Ea_list.append(gas.reaction(1).rate.activation_energy(delta_enthalpy))
+    Ea_list.append(gas.reaction(1).rate.effective_activation_energy(delta_enthalpy))
 
 plt.figure()
 plt.plot(deltaH_list, Ea_list)

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -548,7 +548,7 @@ cdef class ChebyshevRate(ReactionRate):
 
         if init:
             if isinstance(input_data, dict):
-                self._rate.reset(new CxxChebyshevRate3(dict_to_anymap(input_data)))
+                self._rate.reset(new CxxChebyshevRate(dict_to_anymap(input_data)))
             elif all([arg is not None
                     for arg in [temperature_range, pressure_range, data]]):
                 Tmin = temperature_range[0]
@@ -556,10 +556,10 @@ cdef class ChebyshevRate(ReactionRate):
                 Pmin = pressure_range[0]
                 Pmax = pressure_range[1]
                 self._rate.reset(
-                    new CxxChebyshevRate3(Tmin, Tmax, Pmin, Pmax, self._cxxarray2d(data)))
+                    new CxxChebyshevRate(Tmin, Tmax, Pmin, Pmax, self._cxxarray2d(data)))
             elif all([arg is None
                     for arg in [temperature_range, pressure_range, data, input_data]]):
-                self._rate.reset(new CxxChebyshevRate3(dict_to_anymap({})))
+                self._rate.reset(new CxxChebyshevRate(dict_to_anymap({})))
             elif input_data:
                 raise TypeError("Invalid parameter 'input_data'")
             else:
@@ -587,8 +587,8 @@ cdef class ChebyshevRate(ReactionRate):
 
         return data
 
-    cdef CxxChebyshevRate3* cxx_object(self):
-        return <CxxChebyshevRate3*>self.rate
+    cdef CxxChebyshevRate* cxx_object(self):
+        return <CxxChebyshevRate*>self.rate
 
     property temperature_range:
         """ Valid temperature range [K] for the Chebyshev fit """

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -163,6 +163,13 @@ cdef class _ArrheniusTypeRate(ReactionRate):
         def __get__(self):
             return self.base.temperatureExponent()
 
+    property activation_energy:
+        """
+        The activation energy ``E`` [J/kmol].
+        """
+        def __get__(self):
+            return self.base.activationEnergy()
+
     property allow_negative_pre_exponential_factor:
         """
         Get/Set whether the rate coefficient is allowed to have a negative
@@ -207,13 +214,6 @@ cdef class ArrheniusRate(_ArrheniusTypeRate):
     cdef CxxArrheniusRate* cxx_object(self):
         return <CxxArrheniusRate*>self.rate
 
-    property activation_energy:
-        """
-        The activation energy ``E`` [J/kmol].
-        """
-        def __get__(self):
-            return self.cxx_object().activationEnergy()
-
 
 cdef class BlowersMaselRate(_ArrheniusTypeRate):
     r"""
@@ -248,19 +248,12 @@ cdef class BlowersMaselRate(_ArrheniusTypeRate):
     cdef CxxBlowersMaselRate* cxx_object(self):
         return <CxxBlowersMaselRate*>self.rate
 
-    def activation_energy(self, double deltaH):
+    def effective_activation_energy(self, double deltaH):
         """
-        The activation energy ``E`` [J/kmol], based on enthalpy change of reaction
-        ``deltaH`` (in [J/kmol])
+        The effective activation energy ``E`` [J/kmol], based on enthalpy change of
+        reaction ``deltaH`` (in [J/kmol])
         """
-        return self.cxx_object().activationEnergy(deltaH)
-
-    property intrinsic_activation_energy:
-        """
-        The intrinsic activation energy ``E0`` [J/kmol].
-        """
-        def __get__(self):
-            return self.cxx_object().activationEnergy0()
+        return self.cxx_object().effectiveActivationEnergy(deltaH)
 
     property bond_energy:
         """
@@ -312,13 +305,6 @@ cdef class TwoTempPlasmaRate(_ArrheniusTypeRate):
 
     cdef CxxTwoTempPlasmaRate* cxx_object(self):
         return <CxxTwoTempPlasmaRate*>self.rate
-
-    property activation_energy:
-        """
-        The activation energy :math:`E_{a,g}` [J/kmol].
-        """
-        def __get__(self):
-            return self.cxx_object().activationEnergy()
 
     property activation_electron_energy:
         """
@@ -549,7 +535,7 @@ cdef class PlogRate(ReactionRate):
                     item.second = CxxArrhenius2(
                         rate.base.preExponentialFactor(),
                         rate.base.temperatureExponent(),
-                        rate.base.intrinsicActivationEnergy() / gas_constant
+                        rate.base.activationEnergy() / gas_constant
                     )
                 ratemap.insert(item)
 
@@ -1505,7 +1491,7 @@ cdef class Arrhenius:
         The activation energy ``E`` [J/kmol].
         """
         def __get__(self):
-            return self.base.intrinsicActivationEnergy()
+            return self.base.activationEnergy()
 
     def __repr__(self):
         return 'Arrhenius(A={:g}, b={:g}, E={:g})'.format(
@@ -1527,7 +1513,7 @@ cdef wrapArrhenius(CxxArrheniusBase* rate, Reaction reaction):
 
 cdef copyArrhenius(CxxArrhenius2* rate):
     r = Arrhenius(rate.preExponentialFactor(), rate.temperatureExponent(),
-                  rate.intrinsicActivationEnergy())
+                  rate.activationEnergy())
     return r
 
 
@@ -2143,7 +2129,7 @@ cdef class PlogReaction(Reaction):
                 item.second = CxxArrhenius2(
                     rate.base.preExponentialFactor(),
                     rate.base.temperatureExponent(),
-                    rate.base.intrinsicActivationEnergy() / gas_constant
+                    rate.base.activationEnergy() / gas_constant
                 )
             ratemap.insert(item)
 
@@ -2383,9 +2369,9 @@ cdef class BlowersMasel:
         def __get__(self):
             return self.rate.temperatureExponent()
 
-    def activation_energy(self, float dH):
+    def effective_activation_energy(self, float dH):
         """
-        The activation energy ``E`` [J/kmol]
+        The effective activation energy ``E`` [J/kmol]
 
         :param dH: The enthalpy of reaction [J/kmol] at the current temperature
         """

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -120,18 +120,19 @@ cdef class ReactionRate:
             return anymap_to_dict(self.rate.parameters())
 
 
-cdef class _ArrheniusTypeRate(ReactionRate):
+cdef class ArrheniusTypeRate(ReactionRate):
     """
     Base class collecting commonly used features of Arrhenius-type rate objects.
+    Objects should be instantiated by specialized classes, for example `ArrheniusRate`,
+    `BlowersMaselRate` and `TwoTempPlasmaRate`.
     """
     _reaction_rate_type = None
 
     def _cinit(self, input_data, **kwargs):
-        """Helper function called by __cinit__
-
-        The method is used as a uniform interface for object construction.
-        A separate method is necessary as Cython does not support overloading
-        of special methods such as __cinit__.
+        """
+        Helper function called by __cinit__. The method is used as a uniform interface
+        for object construction. A separate method is necessary as Cython does not
+        support overloading of special methods such as __cinit__.
         """
         if self._reaction_rate_type is None:
             raise TypeError(
@@ -186,7 +187,7 @@ cdef class _ArrheniusTypeRate(ReactionRate):
             self.base.setAllowNegativePreExponentialFactor(allow)
 
 
-cdef class ArrheniusRate(_ArrheniusTypeRate):
+cdef class ArrheniusRate(ArrheniusTypeRate):
     r"""
     A reaction rate coefficient which depends on temperature only and follows
     the modified Arrhenius form:
@@ -220,7 +221,7 @@ cdef class ArrheniusRate(_ArrheniusTypeRate):
         return <CxxArrheniusRate*>self.rate
 
 
-cdef class BlowersMaselRate(_ArrheniusTypeRate):
+cdef class BlowersMaselRate(ArrheniusTypeRate):
     r"""
     A reaction rate coefficient which depends on temperature and enthalpy change
     of the reaction follows the Blowers-Masel approximation and modified Arrhenius form
@@ -269,7 +270,7 @@ cdef class BlowersMaselRate(_ArrheniusTypeRate):
             return self.cxx_object().bondEnergy()
 
 
-cdef class TwoTempPlasmaRate(_ArrheniusTypeRate):
+cdef class TwoTempPlasmaRate(ArrheniusTypeRate):
     r"""
     A reaction rate coefficient which depends on both gas and electron temperature
     with the form similar to the modified Arrhenius form. Specifically, the temperature

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -583,7 +583,7 @@ cdef class PlogRate(ReactionRate):
                     item.second = CxxArrhenius2(
                         rate.rate.preExponentialFactor(),
                         rate.rate.temperatureExponent(),
-                        rate.rate.activationEnergy() / gas_constant
+                        rate.rate.intrinsicActivationEnergy() / gas_constant
                     )
                 ratemap.insert(item)
 
@@ -1550,7 +1550,7 @@ cdef class Arrhenius:
 
     def __call__(self, float T):
         if self.rate != NULL:
-            return self.base.eval(T)
+            return self.base.evalRate(np.log(T), 1/T)
         else:
             return self.legacy.updateRC(np.log(T), 1/T)
 
@@ -1570,7 +1570,7 @@ cdef wrapArrhenius(CxxArrheniusBase* rate, Reaction reaction):
 
 cdef copyArrhenius(CxxArrhenius2* rate):
     r = Arrhenius(rate.preExponentialFactor(), rate.temperatureExponent(),
-                  rate.activationEnergy_R() * gas_constant)
+                  rate.intrinsicActivationEnergy())
     return r
 
 
@@ -2186,7 +2186,7 @@ cdef class PlogReaction(Reaction):
                 item.second = CxxArrhenius2(
                     rate.rate.preExponentialFactor(),
                     rate.rate.temperatureExponent(),
-                    rate.rate.activationEnergy() / gas_constant
+                    rate.rate.intrinsicActivationEnergy() / gas_constant
                 )
             ratemap.insert(item)
 

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -127,7 +127,12 @@ cdef class _ArrheniusTypeRate(ReactionRate):
     _reaction_rate_type = None
 
     def _cinit(self, input_data, **kwargs):
-        """Helper function called by __cinit__"""
+        """Helper function called by __cinit__
+
+        The method is used as a uniform interface for object construction.
+        A separate method is necessary as Cython does not support overloading
+        of special methods such as __cinit__.
+        """
         if self._reaction_rate_type is None:
             raise TypeError(
                 f"Base class '{self.__class__.__name__}' cannot be instantiated "
@@ -143,7 +148,7 @@ cdef class _ArrheniusTypeRate(ReactionRate):
             raise TypeError("Invalid parameter 'input_data'")
         else:
             par_list = [f"'{k}'" for k in kwargs]
-            par_string = ", ".join([par_list[:-1]])
+            par_string = ", ".join(par_list[:-1])
             par_string += f" or {par_list[-1]}"
             raise TypeError(f"Invalid parameters {par_string}")
         self.set_cxx_object()

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -332,7 +332,7 @@ class TestBlowersMaselRate(ReactionRateTests, utilities.CanteraTest):
         rate = self.from_parts()
         self.assertEqual(self._parts["A"], rate.pre_exponential_factor)
         self.assertEqual(self._parts["b"], rate.temperature_exponent)
-        self.assertNear(self._parts["Ea0"], rate.intrinsic_activation_energy)
+        self.assertNear(self._parts["Ea0"], rate.activation_energy)
         self.assertNear(self._parts["w"], rate.bond_energy)
         self.check_rate(rate)
 

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -83,7 +83,7 @@ void ArrheniusBase::setRateParameters(
     }
 }
 
-void ArrheniusBase::getParameters(AnyMap& node) const
+void ArrheniusBase::getRateParameters(AnyMap& node) const
 {
     getParameters(node, m_rate_units);
 }
@@ -108,16 +108,16 @@ void ArrheniusBase::getParameters(AnyMap& node, const Units& rate_units) const
     node.setFlowStyle();
 }
 
-void ArrheniusBase::check(const std::string& equation, const AnyMap& node)
+void ArrheniusBase::checkRate(const std::string& equation, const AnyMap& node)
 {
     if (!m_negativeA_ok && m_A < 0) {
         if (equation == "") {
-            throw CanteraError("ArrheniusBase::check",
+            throw CanteraError("ArrheniusBase::checkRate",
                 "Detected negative pre-exponential factor (A={}).\n"
                 "Enable 'allowNegativePreExponentialFactor' to suppress "
                 "this message.", m_A);
         }
-        throw InputFileError("ArrheniusBase::check", node,
+        throw InputFileError("ArrheniusBase::checkRate", node,
             "Undeclared negative pre-exponential factor found in reaction '{}'",
             equation);
     }
@@ -140,7 +140,7 @@ void ArrheniusRate::getParameters(AnyMap& rateNode) const
         rateNode["negative-A"] = true;
     }
     AnyMap node;
-    ArrheniusBase::getParameters(node);
+    ArrheniusBase::getRateParameters(node);
     if (!node.empty()) {
         // Arrhenius object is configured
         rateNode["rate-constant"] = std::move(node);
@@ -222,7 +222,7 @@ void TwoTempPlasmaRate::getParameters(AnyMap& rateNode) const
         rateNode["negative-A"] = true;
     }
     AnyMap node;
-    ArrheniusBase::getParameters(node);
+    ArrheniusBase::getRateParameters(node);
     if (!node.empty()) {
         // object is configured
         node["Ea-electron"].setQuantity(m_EE_R, "K", true);
@@ -301,7 +301,7 @@ void BlowersMaselRate::getParameters(AnyMap& rateNode) const
         rateNode["negative-A"] = true;
     }
     AnyMap node;
-    ArrheniusBase::getParameters(node);
+    ArrheniusBase::getRateParameters(node);
     if (!node.empty()) {
         // object is configured
         node["w"].setQuantity(m_w_R, "K", true);

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -91,16 +91,11 @@ void ArrheniusBase::setRateParameters(
 
 void ArrheniusBase::getRateParameters(AnyMap& node) const
 {
-    getParameters(node, m_rate_units);
-}
-
-void ArrheniusBase::getParameters(AnyMap& node, const Units& rate_units) const
-{
     if (std::isnan(m_A)) {
         // Return empty/unmodified AnyMap
         return;
-    } else if (rate_units.factor() != 0.0) {
-        node[m_A_str].setQuantity(m_A, rate_units);
+    } else if (m_rate_units.factor() != 0.0) {
+        node[m_A_str].setQuantity(m_A, m_rate_units);
     } else {
         node[m_A_str] = m_A;
         // This can't be converted to a different unit system because the dimensions of
@@ -114,6 +109,7 @@ void ArrheniusBase::getParameters(AnyMap& node, const Units& rate_units) const
         node[m_E4_str].setQuantity(m_E4_R, "K", true);
     }
     node.setFlowStyle();
+
 }
 
 void ArrheniusBase::checkRate(const std::string& equation, const AnyMap& node)

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -15,6 +15,7 @@ ArrheniusBase::ArrheniusBase()
     , m_A(NAN)
     , m_b(NAN)
     , m_Ea_R(NAN)
+    , m_logA(NAN)
     , m_order(NAN)
     , m_rate_units(Units(0.))
 {
@@ -28,6 +29,9 @@ ArrheniusBase::ArrheniusBase(double A, double b, double Ea)
     , m_order(NAN)
     , m_rate_units(Units(0.))
 {
+    if (m_A > 0.0) {
+        m_logA = std::log(m_A);
+    }
 }
 
 void ArrheniusBase::setRateParameters(
@@ -73,6 +77,9 @@ void ArrheniusBase::setRateParameters(
         } else {
             m_Ea_R = NAN;
         }
+    }
+    if (m_A > 0.0) {
+        m_logA = std::log(m_A);
     }
 }
 

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -239,12 +239,12 @@ void BlowersMaselRate::getParameters(AnyMap& rateNode) const
 
 void BlowersMaselRate::setContext(const Reaction& rxn, const Kinetics& kin)
 {
-    m_multipliers.clear();
+    m_stoich_coeffs.clear();
     for (const auto& sp : rxn.reactants) {
-        m_multipliers.emplace_back(kin.kineticsSpeciesIndex(sp.first), -sp.second);
+        m_stoich_coeffs.emplace_back(kin.kineticsSpeciesIndex(sp.first), -sp.second);
     }
     for (const auto& sp : rxn.products) {
-        m_multipliers.emplace_back(kin.kineticsSpeciesIndex(sp.first), sp.second);
+        m_stoich_coeffs.emplace_back(kin.kineticsSpeciesIndex(sp.first), sp.second);
     }
 }
 

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -143,7 +143,7 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
 
         // Set index of rate to number of reaction within kinetics
         rate->setRateIndex(nReactions() - 1);
-        rate->setContext(*r.get(), *this);
+        rate->setContext(*r, *this);
 
         // Add reaction rate to evaluator
         size_t index = m_bulk_types[rate->type()];
@@ -200,7 +200,7 @@ void BulkKinetics::modifyReaction(size_t i, shared_ptr<Reaction> rNew)
         // Replace reaction rate to evaluator
         size_t index = m_bulk_types[rate->type()];
         rate->setRateIndex(i);
-        rate->setContext(*rNew.get(), *this);
+        rate->setContext(*rNew, *this);
 
         m_bulk_rates[index]->replace(i, *rate);
     }

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -134,7 +134,7 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
 
     if (!(r->usesLegacy())) {
         shared_ptr<ReactionRate> rate = r->rate();
-        // If necessary, add new MultiBulkRate evaluator
+        // If necessary, add new MultiRate evaluator
         if (m_bulk_types.find(rate->type()) == m_bulk_types.end()) {
             m_bulk_types[rate->type()] = m_bulk_rates.size();
             m_bulk_rates.push_back(rate->newMultiRate());
@@ -190,7 +190,7 @@ void BulkKinetics::modifyReaction(size_t i, shared_ptr<Reaction> rNew)
 
     if (!(rNew->usesLegacy())) {
         shared_ptr<ReactionRate> rate = rNew->rate();
-        // Ensure that MultiBulkRate evaluator is available
+        // Ensure that MultiRate evaluator is available
         if (m_bulk_types.find(rate->type()) == m_bulk_types.end()) {
             throw CanteraError("BulkKinetics::modifyReaction",
                  "Evaluator not available for type '{}'.", rate->type());

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -143,6 +143,7 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
 
         // Set index of rate to number of reaction within kinetics
         rate->setRateIndex(nReactions() - 1);
+        rate->setContext(*r.get(), *this);
 
         // Add reaction rate to evaluator
         size_t index = m_bulk_types[rate->type()];
@@ -198,7 +199,9 @@ void BulkKinetics::modifyReaction(size_t i, shared_ptr<Reaction> rNew)
 
         // Replace reaction rate to evaluator
         size_t index = m_bulk_types[rate->type()];
-        rNew->rate()->setRateIndex(i);
+        rate->setRateIndex(i);
+        rate->setContext(*rNew.get(), *this);
+
         m_bulk_rates[index]->replace(i, *rate);
     }
 }

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -25,7 +25,7 @@ void FalloffRate::setLowRate(const ArrheniusRate& low)
 {
     ArrheniusRate _low = low;
     _low.setAllowNegativePreExponentialFactor(m_negativeA_ok);
-    _low.check("", AnyMap());
+    _low.checkRate("", AnyMap());
     if (_low.preExponentialFactor() * m_highRate.preExponentialFactor() < 0.) {
         throw CanteraError("FalloffRate::setLowRate",
             "Detected inconsistent rate definitions;\nhigh and low "
@@ -38,7 +38,7 @@ void FalloffRate::setHighRate(const ArrheniusRate& high)
 {
     ArrheniusRate _high = high;
     _high.setAllowNegativePreExponentialFactor(m_negativeA_ok);
-    _high.check("", AnyMap());
+    _high.checkRate("", AnyMap());
     if (m_lowRate.preExponentialFactor() * _high.preExponentialFactor() < 0.) {
         throw CanteraError("FalloffRate::setHighRate",
             "Detected inconsistent rate definitions;\nhigh and low "
@@ -105,21 +105,21 @@ void FalloffRate::getParameters(AnyMap& node) const
         node["negative-A"] = true;
     }
     AnyMap rNode;
-    m_lowRate.getParameters(rNode);
+    m_lowRate.getRateParameters(rNode);
     if (!rNode.empty()) {
-        node["low-P-rate-constant"] = rNode["rate-constant"];
+        node["low-P-rate-constant"] = std::move(rNode);
     }
     rNode.clear();
-    m_highRate.getParameters(rNode);
+    m_highRate.getRateParameters(rNode);
     if (!rNode.empty()) {
-        node["high-P-rate-constant"] = rNode["rate-constant"];
+        node["high-P-rate-constant"] = std::move(rNode);
     }
 }
 
 void FalloffRate::check(const std::string& equation, const AnyMap& node)
 {
-    m_lowRate.check(equation, node);
-    m_highRate.check(equation, node);
+    m_lowRate.checkRate(equation, node);
+    m_highRate.checkRate(equation, node);
 
     double lowA = m_lowRate.preExponentialFactor();
     double highA = m_highRate.preExponentialFactor();

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -21,9 +21,9 @@ void FalloffRate::init(const vector_fp& c)
     setFalloffCoeffs(c);
 }
 
-void FalloffRate::setLowRate(const ArrheniusRate& low)
+void FalloffRate::setLowRate(const ArrheniusBase& low)
 {
-    ArrheniusRate _low = low;
+    ArrheniusBase _low = low;
     _low.setAllowNegativePreExponentialFactor(m_negativeA_ok);
     _low.checkRate("", AnyMap());
     if (_low.preExponentialFactor() * m_highRate.preExponentialFactor() < 0.) {
@@ -34,9 +34,9 @@ void FalloffRate::setLowRate(const ArrheniusRate& low)
     m_lowRate = std::move(_low);
 }
 
-void FalloffRate::setHighRate(const ArrheniusRate& high)
+void FalloffRate::setHighRate(const ArrheniusBase& high)
 {
-    ArrheniusRate _high = high;
+    ArrheniusBase _high = high;
     _high.setAllowNegativePreExponentialFactor(m_negativeA_ok);
     _high.checkRate("", AnyMap());
     if (m_lowRate.preExponentialFactor() * _high.preExponentialFactor() < 0.) {
@@ -83,12 +83,12 @@ void FalloffRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
         }
     }
     if (node.hasKey("low-P-rate-constant")) {
-        m_lowRate = ArrheniusRate(
+        m_lowRate = ArrheniusBase(
             node["low-P-rate-constant"], node.units(), low_rate_units);
         m_lowRate.setAllowNegativePreExponentialFactor(m_negativeA_ok);
     }
     if (node.hasKey("high-P-rate-constant")) {
-        m_highRate = ArrheniusRate(
+        m_highRate = ArrheniusBase(
             node["high-P-rate-constant"], node.units(), high_rate_units);
         m_highRate.setAllowNegativePreExponentialFactor(m_negativeA_ok);
     }

--- a/src/kinetics/FalloffFactory.cpp
+++ b/src/kinetics/FalloffFactory.cpp
@@ -1,5 +1,8 @@
 /**
  *  @file FalloffFactory.cpp
+ *
+ *  @deprecated  Deprecated in Cantera 2.6 and removed thereafter. Replaced by
+ *      FalloffRate objects managed by MultiRate evaluators.
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -63,7 +63,7 @@ void GasKinetics::update_rates_T()
         m_ROP_ok = false;
     }
 
-    // loop over MultiBulkRate evaluators for each reaction type
+    // loop over MultiRate evaluators for each reaction type
     for (auto& rates : m_bulk_rates) {
         bool changed = rates->update(thermo(), *this);
         if (changed) {

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -602,7 +602,7 @@ bool GasKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
     return true;
 }
 
-void GasKinetics::addFalloffReaction(FalloffReaction& r)
+void GasKinetics::addFalloffReaction(FalloffReaction2& r)
 {
     // install high and low rate coeff calculators and extend the high and low
     // rate coeff value vectors
@@ -695,7 +695,7 @@ void GasKinetics::modifyThreeBodyReaction(size_t i, ThreeBodyReaction2& r)
     m_rates.replace(i, r.rate);
 }
 
-void GasKinetics::modifyFalloffReaction(size_t i, FalloffReaction& r)
+void GasKinetics::modifyFalloffReaction(size_t i, FalloffReaction2& r)
 {
     size_t iFall = m_rfallindx[i];
     m_falloff_high_rates.replace(iFall, r.high_rate);

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -216,7 +216,7 @@ void Reaction::setRate(shared_ptr<ReactionRate> rate)
         m_rate = rate;
     }
 
-    if (reactants.count("(+M)") && std::dynamic_pointer_cast<ChebyshevRate3>(m_rate)) {
+    if (reactants.count("(+M)") && std::dynamic_pointer_cast<ChebyshevRate>(m_rate)) {
         warn_deprecated("Chebyshev reaction equation", input, "Specifying '(+M)' "
             "in the reaction equation for Chebyshev reactions is deprecated.");
         // remove optional third body notation
@@ -769,7 +769,7 @@ ChebyshevReaction2::ChebyshevReaction2()
 
 ChebyshevReaction2::ChebyshevReaction2(const Composition& reactants_,
                                        const Composition& products_,
-                                       const Chebyshev& rate_)
+                                       const ChebyshevRate& rate_)
     : Reaction(reactants_, products_)
     , rate(rate_)
 {
@@ -1849,11 +1849,11 @@ void setupChebyshevReaction(ChebyshevReaction2& R, const XML_Node& rxn_node)
             coeffs(t,p) = coeffs_flat[nP*t + p];
         }
     }
-    R.rate = Chebyshev(getFloat(rc, "Tmin", "toSI"),
-                       getFloat(rc, "Tmax", "toSI"),
-                       getFloat(rc, "Pmin", "toSI"),
-                       getFloat(rc, "Pmax", "toSI"),
-                       coeffs);
+    R.rate = ChebyshevRate(getFloat(rc, "Tmin", "toSI"),
+                           getFloat(rc, "Tmax", "toSI"),
+                           getFloat(rc, "Pmin", "toSI"),
+                           getFloat(rc, "Pmax", "toSI"),
+                           coeffs);
     setupReaction(R, rxn_node);
 }
 
@@ -1878,11 +1878,11 @@ void setupChebyshevReaction(ChebyshevReaction2&R, const AnyMap& node,
     }
     const UnitSystem& units = node.units();
     coeffs(0, 0) += std::log10(units.convertTo(1.0, R.rate_units));
-    R.rate = Chebyshev(units.convert(T_range[0], "K"),
-                       units.convert(T_range[1], "K"),
-                       units.convert(P_range[0], "Pa"),
-                       units.convert(P_range[1], "Pa"),
-                       coeffs);
+    R.rate = ChebyshevRate(units.convert(T_range[0], "K"),
+                           units.convert(T_range[1], "K"),
+                           units.convert(P_range[0], "Pa"),
+                           units.convert(P_range[1], "Pa"),
+                           coeffs);
 }
 
 void setupInterfaceReaction(InterfaceReaction& R, const XML_Node& rxn_node)

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -474,7 +474,7 @@ bool Reaction::checkSpecies(const Kinetics& kin) const
 
 ElementaryReaction2::ElementaryReaction2(const Composition& reactants_,
                                          const Composition products_,
-                                         const Arrhenius& rate_)
+                                         const Arrhenius2& rate_)
     : Reaction(reactants_, products_)
     , rate(rate_)
     , allow_negative_pre_exponential_factor(false)
@@ -545,7 +545,7 @@ ThreeBodyReaction2::ThreeBodyReaction2()
 
 ThreeBodyReaction2::ThreeBodyReaction2(const Composition& reactants_,
                                        const Composition& products_,
-                                       const Arrhenius& rate_,
+                                       const Arrhenius2& rate_,
                                        const ThirdBody& tbody)
     : ElementaryReaction2(reactants_, products_, rate_)
     , third_body(tbody)
@@ -626,7 +626,7 @@ FalloffReaction2::FalloffReaction2()
 
 FalloffReaction2::FalloffReaction2(
         const Composition& reactants_, const Composition& products_,
-        const Arrhenius& low_rate_, const Arrhenius& high_rate_,
+        const Arrhenius2& low_rate_, const Arrhenius2& high_rate_,
         const ThirdBody& tbody)
     : Reaction(reactants_, products_)
     , low_rate(low_rate_)
@@ -719,7 +719,7 @@ ChemicallyActivatedReaction2::ChemicallyActivatedReaction2()
 
 ChemicallyActivatedReaction2::ChemicallyActivatedReaction2(
         const Composition& reactants_, const Composition& products_,
-        const Arrhenius& low_rate_, const Arrhenius& high_rate_,
+        const Arrhenius2& low_rate_, const Arrhenius2& high_rate_,
         const ThirdBody& tbody)
     : FalloffReaction2(reactants_, products_, low_rate_, high_rate_, tbody)
 {
@@ -792,7 +792,7 @@ InterfaceReaction::InterfaceReaction()
 
 InterfaceReaction::InterfaceReaction(const Composition& reactants_,
                                      const Composition& products_,
-                                     const Arrhenius& rate_,
+                                     const Arrhenius2& rate_,
                                      bool isStick)
     : ElementaryReaction2(reactants_, products_, rate_)
     , is_sticking_coefficient(isStick)
@@ -891,7 +891,7 @@ ElectrochemicalReaction::ElectrochemicalReaction()
 
 ElectrochemicalReaction::ElectrochemicalReaction(const Composition& reactants_,
                                                  const Composition& products_,
-                                                 const Arrhenius& rate_)
+                                                 const Arrhenius2& rate_)
     : InterfaceReaction(reactants_, products_, rate_)
     , beta(0.5)
     , exchange_current_density_formulation(false)
@@ -1335,16 +1335,16 @@ CustomFunc1Reaction::CustomFunc1Reaction(const AnyMap& node, const Kinetics& kin
     }
 }
 
-Arrhenius readArrhenius(const XML_Node& arrhenius_node)
+Arrhenius2 readArrhenius(const XML_Node& arrhenius_node)
 {
-    return Arrhenius(getFloat(arrhenius_node, "A", "toSI"),
-                     getFloat(arrhenius_node, "b"),
-                     getFloat(arrhenius_node, "E", "actEnergy") / GasConstant);
+    return Arrhenius2(getFloat(arrhenius_node, "A", "toSI"),
+                      getFloat(arrhenius_node, "b"),
+                      getFloat(arrhenius_node, "E", "actEnergy") / GasConstant);
 }
 
-Arrhenius readArrhenius(const Reaction& R, const AnyValue& rate,
-                        const Kinetics& kin, const UnitSystem& units,
-                        int pressure_dependence=0)
+Arrhenius2 readArrhenius(const Reaction& R, const AnyValue& rate,
+                         const Kinetics& kin, const UnitSystem& units,
+                         int pressure_dependence=0)
 {
     double A, b, Ta;
     Units rc_units = R.rate_units;
@@ -1363,7 +1363,7 @@ Arrhenius readArrhenius(const Reaction& R, const AnyValue& rate,
         b = rate_vec[1].asDouble();
         Ta = units.convertActivationEnergy(rate_vec[2], "K");
     }
-    return Arrhenius(A, b, Ta);
+    return Arrhenius2(A, b, Ta);
 }
 
 //! Parse falloff parameters, given a rateCoeff node
@@ -1808,7 +1808,7 @@ void setupChemicallyActivatedReaction(ChemicallyActivatedReaction2& R,
 void setupPlogReaction(PlogReaction2& R, const XML_Node& rxn_node)
 {
     XML_Node& rc = rxn_node.child("rateCoeff");
-    std::multimap<double, Arrhenius> rates;
+    std::multimap<double, Arrhenius2> rates;
     for (size_t m = 0; m < rc.nChildren(); m++) {
         const XML_Node& node = rc.child(m);
         rates.insert({getFloat(node, "P", "toSI"), readArrhenius(node)});
@@ -1820,7 +1820,7 @@ void setupPlogReaction(PlogReaction2& R, const XML_Node& rxn_node)
 void setupPlogReaction(PlogReaction2& R, const AnyMap& node, const Kinetics& kin)
 {
     setupReaction(R, node, kin);
-    std::multimap<double, Arrhenius> rates;
+    std::multimap<double, Arrhenius2> rates;
     for (const auto& rate : node.at("rate-constants").asVector<AnyMap>()) {
         rates.insert({rate.convert("P", "Pa"),
                       readArrhenius(R, AnyValue(rate), kin, node.units())});

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -917,10 +917,11 @@ BlowersMaselInterfaceReaction::BlowersMaselInterfaceReaction()
     reaction_type = BMINTERFACE_RXN;
 }
 
-BlowersMaselInterfaceReaction::BlowersMaselInterfaceReaction(const Composition& reactants_,
-                                         const Composition& products_,
-                                         const BlowersMasel2& rate_,
-                                         bool isStick)
+BlowersMaselInterfaceReaction::BlowersMaselInterfaceReaction(
+    const Composition& reactants_,
+    const Composition& products_,
+    const BMSurfaceArrhenius& rate_,
+    bool isStick)
     : Reaction(reactants_, products_)
     , rate(rate_)
     , allow_negative_pre_exponential_factor(false)
@@ -1467,7 +1468,7 @@ void readEfficiencies(ThirdBody& tbody, const AnyMap& node)
     tbody.setEfficiencies(node);
 }
 
-BlowersMasel2 readBlowersMasel(const Reaction& R, const AnyValue& rate,
+BMSurfaceArrhenius readBlowersMasel(const Reaction& R, const AnyValue& rate,
                         const Kinetics& kin, const UnitSystem& units,
                         int pressure_dependence=0)
 {
@@ -1490,7 +1491,7 @@ BlowersMasel2 readBlowersMasel(const Reaction& R, const AnyValue& rate,
         Ta0 = units.convertActivationEnergy(rate_vec[2], "K");
         w = units.convertActivationEnergy(rate_vec[3], "K");
     }
-    return BlowersMasel2(A, b, Ta0, w);
+    return BMSurfaceArrhenius(A, b, Ta0, w);
 }
 
 bool detectEfficiencies(ThreeBodyReaction2& R)

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -37,9 +37,9 @@ void ReactionData::restore()
     m_temperature_buf = -1.;
 }
 
-bool ArrheniusData::update(const ThermoPhase& bulk, const Kinetics& kin)
+bool ArrheniusData::update(const ThermoPhase& phase, const Kinetics& kin)
 {
-    double T = bulk.temperature();
+    double T = phase.temperature();
     if (T == temperature) {
         return false;
     }
@@ -47,10 +47,10 @@ bool ArrheniusData::update(const ThermoPhase& bulk, const Kinetics& kin)
     return true;
 }
 
-bool TwoTempPlasmaData::update(const ThermoPhase& bulk, const Kinetics& kin)
+bool TwoTempPlasmaData::update(const ThermoPhase& phase, const Kinetics& kin)
 {
-    double T = bulk.temperature();
-    double Te = bulk.electronTemperature();
+    double T = phase.temperature();
+    double Te = phase.electronTemperature();
     bool changed = false;
     if (T != temperature) {
         ReactionData::update(T);
@@ -107,11 +107,11 @@ void BlowersMaselData::update(double T, double deltaH)
     dH_direct = deltaH;
 }
 
-bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
+bool BlowersMaselData::update(const ThermoPhase& phase, const Kinetics& kin)
 {
-    double rho = bulk.density();
-    int mf = bulk.stateMFNumber();
-    double T = bulk.temperature();
+    double rho = phase.density();
+    int mf = phase.stateMFNumber();
+    double T = phase.temperature();
     bool changed = false;
     if (T != temperature) {
         ReactionData::update(T);
@@ -120,7 +120,7 @@ bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
     if (changed || rho != density || mf != m_state_mf_number) {
         density = rho;
         m_state_mf_number = mf;
-        bulk.getPartialMolarEnthalpies(grt.data());
+        phase.getPartialMolarEnthalpies(grt.data());
         changed = true;
     }
     return changed;
@@ -148,11 +148,11 @@ void FalloffData::update(double T, double M)
     conc_3b[0] = M;
 }
 
-bool FalloffData::update(const ThermoPhase& bulk, const Kinetics& kin)
+bool FalloffData::update(const ThermoPhase& phase, const Kinetics& kin)
 {
-    double rho_m = bulk.molarDensity();
-    int mf = bulk.stateMFNumber();
-    double T = bulk.temperature();
+    double rho_m = phase.molarDensity();
+    int mf = phase.stateMFNumber();
+    double T = phase.temperature();
     bool changed = false;
     if (T != temperature) {
         ReactionData::update(T);
@@ -197,10 +197,10 @@ void PlogData::update(double T)
         "Missing state information: 'PlogData' requires pressure.");
 }
 
-bool PlogData::update(const ThermoPhase& bulk, const Kinetics& kin)
+bool PlogData::update(const ThermoPhase& phase, const Kinetics& kin)
 {
-    double T = bulk.temperature();
-    double P = bulk.pressure();
+    double T = phase.temperature();
+    double P = phase.pressure();
     if (P != pressure || T != temperature) {
         update(T, P);
         return true;
@@ -235,10 +235,10 @@ void ChebyshevData::update(double T)
         "Missing state information: 'ChebyshevData' requires pressure.");
 }
 
-bool ChebyshevData::update(const ThermoPhase& bulk, const Kinetics& kin)
+bool ChebyshevData::update(const ThermoPhase& phase, const Kinetics& kin)
 {
-    double T = bulk.temperature();
-    double P = bulk.pressure();
+    double T = phase.temperature();
+    double P = phase.pressure();
     if (P != pressure || T != temperature) {
         update(T, P);
         return true;

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -85,9 +85,9 @@ void TwoTempPlasmaData::updateTe(double Te)
 BlowersMaselData::BlowersMaselData()
     : ready(false)
     , density(NAN)
+    , dH_direct(NAN)
     , m_state_mf_number(-1)
 {
-    dH.resize(1, NAN);
 }
 
 void BlowersMaselData::update(double T)
@@ -98,8 +98,13 @@ void BlowersMaselData::update(double T)
 
 void BlowersMaselData::update(double T, double deltaH)
 {
+    if (ready) {
+        throw CanteraError("BlowersMaselData::update",
+            "Direct setting of enthalpy change is only possible while rate object\n"
+            "and associated reaction are not added to a Kinetics object.");
+    }
     ReactionData::update(T);
-    dH[0] = deltaH;
+    dH_direct = deltaH;
 }
 
 bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
@@ -115,8 +120,7 @@ bool BlowersMaselData::update(const ThermoPhase& bulk, const Kinetics& kin)
     if (changed || rho != density || mf != m_state_mf_number) {
         density = rho;
         m_state_mf_number = mf;
-        bulk.getPartialMolarEnthalpies(m_grt.data());
-        kin.getReactionDelta(m_grt.data(), dH.data());
+        bulk.getPartialMolarEnthalpies(grt.data());
         changed = true;
     }
     return changed;

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -33,7 +33,7 @@ ReactionFactory::ReactionFactory()
 
     // register elementary reactions (old framework)
     reg("elementary-legacy", [](const AnyMap& node, const Kinetics& kin) {
-        ElementaryReaction* R = new ElementaryReaction2();
+        ElementaryReaction2* R = new ElementaryReaction2();
         if (!node.empty()) {
             setupElementaryReaction(*R, node, kin);
         }
@@ -49,7 +49,7 @@ ReactionFactory::ReactionFactory()
 
     // register three-body reactions (old framework)
     reg("three-body-legacy", [](const AnyMap& node, const Kinetics& kin) {
-        ThreeBodyReaction* R = new ThreeBodyReaction2();
+        ThreeBodyReaction2* R = new ThreeBodyReaction2();
         if (!node.empty()) {
             setupThreeBodyReaction(*R, node, kin);
         }
@@ -73,7 +73,7 @@ ReactionFactory::ReactionFactory()
 
     // register falloff reactions
     reg("chemically-activated-legacy", [](const AnyMap& node, const Kinetics& kin) {
-        FalloffReaction2* R = new ChemicallyActivatedReaction();
+        FalloffReaction2* R = new ChemicallyActivatedReaction2();
         if (!node.empty()) {
             setupFalloffReaction(*R, node, kin);
         }
@@ -88,7 +88,7 @@ ReactionFactory::ReactionFactory()
 
     // register pressure-dependent-Arrhenius reactions (old framework)
     reg("pressure-dependent-Arrhenius-legacy", [](const AnyMap& node, const Kinetics& kin) {
-        PlogReaction* R = new PlogReaction2();
+        PlogReaction2* R = new PlogReaction2();
         if (!node.empty()) {
             setupPlogReaction(*R, node, kin);
         }
@@ -99,7 +99,7 @@ ReactionFactory::ReactionFactory()
     addAlias("reaction", "Chebyshev");
     addAlias("reaction", "chebyshev");
     reg("Chebyshev-legacy", [](const AnyMap& node, const Kinetics& kin) {
-        ChebyshevReaction* R = new ChebyshevReaction2();
+        ChebyshevReaction2* R = new ChebyshevReaction2();
         if (!node.empty()) {
             setupChebyshevReaction(*R, node, kin);
         }
@@ -183,8 +183,8 @@ ReactionFactoryXML::ReactionFactoryXML()
 
     // register falloff reactions
     reg("chemically-activated-legacy", [](const XML_Node& node) {
-        Reaction* R = new ChemicallyActivatedReaction();
-        setupChemicallyActivatedReaction(*(ChemicallyActivatedReaction*)R, node);
+        Reaction* R = new ChemicallyActivatedReaction2();
+        setupChemicallyActivatedReaction(*(ChemicallyActivatedReaction2*)R, node);
         return R;
     });
     addAlias("chemically-activated-legacy", "chemically-activated");

--- a/src/kinetics/ReactionRateFactory.cpp
+++ b/src/kinetics/ReactionRateFactory.cpp
@@ -66,7 +66,7 @@ ReactionRateFactory::ReactionRateFactory()
 
     // ChebyshevRate evaluator
     reg("Chebyshev", [](const AnyMap& node, const UnitStack& rate_units) {
-        return new ChebyshevRate3(node, rate_units);
+        return new ChebyshevRate(node, rate_units);
     });
 
     // CustomFunc1Rate evaluator

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -40,46 +40,6 @@ void Arrhenius2::setRateParameters(const AnyValue& rate,
     }
 }
 
-BlowersMasel2::BlowersMasel2()
-    : m_logA(-1.0E300)
-    , m_b(0.0)
-    , m_A(0.0)
-    , m_w(0.0)
-    , m_E0(0.0)
-{
-}
-
-BlowersMasel2::BlowersMasel2(double A, double b, double E0, double w)
-    : m_b(b)
-    , m_A(A)
-    , m_w(w)
-    , m_E0(E0)
-{
-    if (m_A  <= 0.0) {
-        m_logA = -1.0E300;
-    } else {
-        m_logA = std::log(m_A);
-    }
-}
-
-void BlowersMasel2::getParameters(AnyMap& rateNode, const Units& rate_units) const
-{
-    if (rate_units.factor() != 0.0) {
-        rateNode["A"].setQuantity(preExponentialFactor(), rate_units);
-    } else {
-        rateNode["A"] = preExponentialFactor();
-        // This can't be converted to a different unit system because the dimensions of
-        // the rate constant were not set. Can occur if the reaction was created outside
-        // the context of a Kinetics object and never added to a Kinetics object.
-        rateNode["__unconvertible__"] = true;
-    }
-
-    rateNode["b"] = temperatureExponent();
-    rateNode["Ea0"].setQuantity(activationEnergy_R0(), "K", true);
-    rateNode["w"].setQuantity(bondEnergy(), "K", true);
-    rateNode.setFlowStyle();
-}
-
 SurfaceArrhenius::SurfaceArrhenius()
     : m_b(0.0)
     , m_E(0.0)
@@ -401,6 +361,24 @@ BMSurfaceArrhenius::BMSurfaceArrhenius(double A, double b, double Ta, double w)
     , m_ecov(0.0)
     , m_mcov(0.0)
 {
+}
+
+void BMSurfaceArrhenius::getParameters(AnyMap& rateNode, const Units& rate_units) const
+{
+    if (rate_units.factor() != 0.0) {
+        rateNode["A"].setQuantity(preExponentialFactor(), rate_units);
+    } else {
+        rateNode["A"] = preExponentialFactor();
+        // This can't be converted to a different unit system because the dimensions of
+        // the rate constant were not set. Can occur if the reaction was created outside
+        // the context of a Kinetics object and never added to a Kinetics object.
+        rateNode["__unconvertible__"] = true;
+    }
+
+    rateNode["b"] = temperatureExponent();
+    rateNode["Ea0"].setQuantity(activationEnergy_R0(), "K", true);
+    rateNode["w"].setQuantity(bondEnergy(), "K", true);
+    rateNode.setFlowStyle();
 }
 
 void BMSurfaceArrhenius::addCoverageDependence(size_t k, double a,

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -52,7 +52,7 @@ void Arrhenius2::getParameters(AnyMap& node, const Units& rate_units) const
     if (rate_units.factor() != 0.0) {
         node["A"].setQuantity(m_A, rate_units);
     } else {
-        node["A"] = m_A;
+        node["A"] = preExponentialFactor();
         // This can't be converted to a different unit system because the dimensions of
         // the rate constant were not set. Can occur if the reaction was created outside
         // the context of a Kinetics object and never added to a Kinetics object.

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -10,10 +10,10 @@ namespace Cantera
 {
 Arrhenius2::Arrhenius2()
     : ArrheniusBase()
-    , m_logA(-1.0E300)
 {
     m_b = 0.0;
     m_A = 0.0;
+    m_logA = -1.0E300;
 }
 
 Arrhenius2::Arrhenius2(doublereal A, doublereal b, doublereal E)
@@ -21,8 +21,6 @@ Arrhenius2::Arrhenius2(doublereal A, doublereal b, doublereal E)
 {
     if (m_A  <= 0.0) {
         m_logA = -1.0E300;
-    } else {
-        m_logA = std::log(m_A);
     }
 }
 
@@ -39,8 +37,6 @@ void Arrhenius2::setRateParameters(const AnyValue& rate,
     ArrheniusBase::setRateParameters(rate, units, units_stack);
     if (m_A <= 0.0) {
         m_logA = -1.0E300;
-    } else {
-        m_logA = std::log(m_A);
     }
 }
 

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -252,14 +252,14 @@ std::multimap<double, ArrheniusBase> PlogRate::getRates() const
     return rateMap;
 }
 
-ChebyshevRate3::ChebyshevRate3(double Tmin, double Tmax, double Pmin, double Pmax,
-                               const Array2D& coeffs) : ChebyshevRate3()
+ChebyshevRate::ChebyshevRate(double Tmin, double Tmax, double Pmin, double Pmax,
+                             const Array2D& coeffs) : ChebyshevRate()
 {
     setLimits(Tmin, Tmax, Pmin, Pmax);
     setData(coeffs);
 }
 
-void ChebyshevRate3::setParameters(const AnyMap& node, const UnitStack& units)
+void ChebyshevRate::setParameters(const AnyMap& node, const UnitStack& units)
 {
     m_rate_units = units.product();
     const UnitSystem& unit_system = node.units();
@@ -271,7 +271,7 @@ void ChebyshevRate3::setParameters(const AnyMap& node, const UnitStack& units)
         coeffs = Array2D(vcoeffs.size(), vcoeffs[0].size());
         for (size_t i = 0; i < coeffs.nRows(); i++) {
             if (vcoeffs[i].size() != vcoeffs[0].size()) {
-                throw InputFileError("ChebyshevRate3::setParameters", node["data"],
+                throw InputFileError("ChebyshevRate::setParameters", node["data"],
                     "Inconsistent number of coefficients in row {} of matrix", i + 1);
             }
             for (size_t j = 0; j < coeffs.nColumns(); j++) {
@@ -297,16 +297,16 @@ void ChebyshevRate3::setParameters(const AnyMap& node, const UnitStack& units)
     setData(coeffs);
 }
 
-void ChebyshevRate3::setup(double Tmin, double Tmax, double Pmin, double Pmax,
-                      const Array2D& coeffs)
+void ChebyshevRate::setup(double Tmin, double Tmax, double Pmin, double Pmax,
+                          const Array2D& coeffs)
 {
-    warn_deprecated("ChebyshevRate3::setup", "Deprecated in Cantera 2.6; "
+    warn_deprecated("ChebyshevRate::setup", "Deprecated in Cantera 2.6; "
         "replaceable with setLimits() and setData().");
     setLimits(Tmin, Tmax, Pmin, Pmax);
     setData(coeffs);
 }
 
-void ChebyshevRate3::setLimits(double Tmin, double Tmax, double Pmin, double Pmax)
+void ChebyshevRate::setLimits(double Tmin, double Tmax, double Pmin, double Pmax)
 {
     double logPmin = std::log10(Pmin);
     double logPmax = std::log10(Pmax);
@@ -324,7 +324,7 @@ void ChebyshevRate3::setLimits(double Tmin, double Tmax, double Pmin, double Pma
     Pmax_ = Pmax;
 }
 
-void ChebyshevRate3::setData(const Array2D& coeffs)
+void ChebyshevRate::setData(const Array2D& coeffs)
 {
     m_coeffs = coeffs;
     dotProd_.resize(coeffs.nRows());
@@ -341,7 +341,7 @@ void ChebyshevRate3::setData(const Array2D& coeffs)
     }
 }
 
-void ChebyshevRate3::getParameters(AnyMap& rateNode) const
+void ChebyshevRate::getParameters(AnyMap& rateNode) const
 {
     rateNode["type"] = type();
     if (!m_coeffs.data().size() || std::isnan(m_coeffs(0, 0))) {
@@ -366,7 +366,7 @@ void ChebyshevRate3::getParameters(AnyMap& rateNode) const
             coeffs.asVector<vector_fp>()[0][0] += \
                 std::log10(units.convertFrom(1.0, rate_units2));
         } else if (units.getDelta(UnitSystem()).size()) {
-            throw CanteraError("ChebyshevRate3::getParameters lambda",
+            throw CanteraError("ChebyshevRate::getParameters lambda",
                 "Cannot convert rate constant with unknown dimensions to a "
                 "non-default unit system");
         }

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -40,6 +40,22 @@ void Arrhenius2::setRateParameters(const AnyValue& rate,
     }
 }
 
+void Arrhenius2::getParameters(AnyMap& node, const Units& rate_units) const
+{
+    if (rate_units.factor() != 0.0) {
+        node["A"].setQuantity(m_A, rate_units);
+    } else {
+        node["A"] = m_A;
+        // This can't be converted to a different unit system because the dimensions of
+        // the rate constant were not set. Can occur if the reaction was created outside
+        // the context of a Kinetics object and never added to a Kinetics object.
+        node["__unconvertible__"] = true;
+    }
+    node["b"] = m_b;
+    node["Ea"].setQuantity(m_Ea_R, "K", true);
+    node.setFlowStyle();
+}
+
 SurfaceArrhenius::SurfaceArrhenius()
     : m_b(0.0)
     , m_E(0.0)

--- a/src/kinetics/RxnRates.cpp
+++ b/src/kinetics/RxnRates.cpp
@@ -169,7 +169,7 @@ void PlogRate::getParameters(AnyMap& rateNode, const Units& rate_units) const
         AnyMap rateNode_;
         rateNode_["P"].setQuantity(r.first, "Pa");
         if (rate_units.factor() == 0) {
-            r.second.getParameters(rateNode_);
+            r.second.getRateParameters(rateNode_);
         } else {
             r.second.getParameters(rateNode_, rate_units);
         }

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -54,7 +54,7 @@ TEST_F(KineticsFromScratch, add_elementary_reaction)
     // reaction('O + H2 <=> H + OH', [3.870000e+01, 2.7, 6260.0])
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    Arrhenius rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
 
     kin.addReaction(R);
@@ -68,7 +68,7 @@ TEST_F(KineticsFromScratch, add_three_body_reaction)
     //                     efficiencies='AR:0.83 H2:2.4 H2O:15.4')
     Composition reac = parseCompString("O:2");
     Composition prod = parseCompString("O2:1");
-    Arrhenius rate(1.2e11, -1.0, 0.0);
+    Arrhenius2 rate(1.2e11, -1.0, 0.0);
     ThirdBody tbody;
     tbody.efficiencies = parseCompString("AR:0.83 H2:2.4 H2O:15.4");
     auto R = make_shared<ThreeBodyReaction2>(reac, prod, rate, tbody);
@@ -81,7 +81,7 @@ TEST_F(KineticsFromScratch, undefined_third_body)
 {
     Composition reac = parseCompString("O:2");
     Composition prod = parseCompString("O2:1");
-    Arrhenius rate(1.2e11, -1.0, 0.0);
+    Arrhenius2 rate(1.2e11, -1.0, 0.0);
     ThirdBody tbody;
     tbody.efficiencies = parseCompString("H2:0.1 CO2:0.83");
     auto R = make_shared<ThreeBodyReaction2>(reac, prod, rate, tbody);
@@ -93,7 +93,7 @@ TEST_F(KineticsFromScratch, skip_undefined_third_body)
 {
     Composition reac = parseCompString("O:2");
     Composition prod = parseCompString("O2:1");
-    Arrhenius rate(1.2e11, -1.0, 0.0);
+    Arrhenius2 rate(1.2e11, -1.0, 0.0);
     ThirdBody tbody;
     tbody.efficiencies = parseCompString("H2:0.1 CO2:0.83");
     auto R = make_shared<ThreeBodyReaction2>(reac, prod, rate, tbody);
@@ -114,8 +114,8 @@ TEST_F(KineticsFromScratch, add_falloff_reaction)
     //                  falloff=Troe(A=0.7346, T3=94.0, T1=1756.0, T2=5182.0))
     Composition reac = parseCompString("OH:2");
     Composition prod = parseCompString("H2O2:1");
-    Arrhenius high_rate(7.4e10, -0.37, 0.0);
-    Arrhenius low_rate(2.3e12, -0.9, -1700.0 / GasConst_cal_mol_K);
+    Arrhenius2 high_rate(7.4e10, -0.37, 0.0);
+    Arrhenius2 low_rate(2.3e12, -0.9, -1700.0 / GasConst_cal_mol_K);
     vector_fp falloff_params { 0.7346, 94.0, 1756.0, 5182.0 };
     ThirdBody tbody;
     tbody.efficiencies = parseCompString("AR:0.7 H2:2.0 H2O:6.0");
@@ -135,11 +135,11 @@ TEST_F(KineticsFromScratch, add_plog_reaction)
     //                [(100.0, 'atm'), 5.963200e+56, -11.529, 52599.6])
     Composition reac = parseCompString("H2:1, O2:1");
     Composition prod = parseCompString("OH:2");
-    std::multimap<double, Arrhenius> rates {
-        { 0.01*101325, Arrhenius(1.212400e+16, -0.5779, 10872.7 / GasConst_cal_mol_K) },
-        { 1.0*101325, Arrhenius(4.910800e+31, -4.8507, 24772.8 / GasConst_cal_mol_K) },
-        { 10.0*101325, Arrhenius(1.286600e+47, -9.0246, 39796.5 / GasConst_cal_mol_K) },
-        { 100.0*101325, Arrhenius(5.963200e+56, -11.529, 52599.6 / GasConst_cal_mol_K) }
+    std::multimap<double, Arrhenius2> rates {
+        { 0.01*101325, Arrhenius2(1.212400e+16, -0.5779, 10872.7 / GasConst_cal_mol_K) },
+        { 1.0*101325, Arrhenius2(4.910800e+31, -4.8507, 24772.8 / GasConst_cal_mol_K) },
+        { 10.0*101325, Arrhenius2(1.286600e+47, -9.0246, 39796.5 / GasConst_cal_mol_K) },
+        { 100.0*101325, Arrhenius2(5.963200e+56, -11.529, 52599.6 / GasConst_cal_mol_K) }
     };
 
     auto R = make_shared<PlogReaction2>(reac, prod, Plog(rates));
@@ -151,11 +151,11 @@ TEST_F(KineticsFromScratch, plog_invalid_rate)
 {
     Composition reac = parseCompString("H2:1, O2:1");
     Composition prod = parseCompString("OH:2");
-    std::multimap<double, Arrhenius> rates {
-        { 0.01*101325, Arrhenius(1.2124e+16, -0.5779, 10872.7 / GasConst_cal_mol_K) },
-        { 10.0*101325, Arrhenius(1e15, -1, 10000 / GasConst_cal_mol_K) },
-        { 10.0*101325, Arrhenius(-2e20, -2.0, 20000 / GasConst_cal_mol_K) },
-        { 100.0*101325, Arrhenius(5.9632e+56, -11.529, 52599.6 / GasConst_cal_mol_K) }
+    std::multimap<double, Arrhenius2> rates {
+        { 0.01*101325, Arrhenius2(1.2124e+16, -0.5779, 10872.7 / GasConst_cal_mol_K) },
+        { 10.0*101325, Arrhenius2(1e15, -1, 10000 / GasConst_cal_mol_K) },
+        { 10.0*101325, Arrhenius2(-2e20, -2.0, 20000 / GasConst_cal_mol_K) },
+        { 100.0*101325, Arrhenius2(5.9632e+56, -11.529, 52599.6 / GasConst_cal_mol_K) }
     };
 
     auto R = make_shared<PlogReaction2>(reac, prod, Plog(rates));
@@ -198,7 +198,7 @@ TEST_F(KineticsFromScratch, undeclared_species)
 {
     Composition reac = parseCompString("CO:1 OH:1");
     Composition prod = parseCompString("CO2:1 H:1");
-    Arrhenius rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
 
     ASSERT_THROW(kin.addReaction(R), CanteraError);
@@ -209,7 +209,7 @@ TEST_F(KineticsFromScratch, skip_undeclared_species)
 {
     Composition reac = parseCompString("CO:1 OH:1");
     Composition prod = parseCompString("CO2:1 H:1");
-    Arrhenius rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
 
     kin.skipUndeclaredSpecies(true);
@@ -221,7 +221,7 @@ TEST_F(KineticsFromScratch, negative_A_error)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    Arrhenius rate(-3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(-3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
 
     ASSERT_THROW(kin.addReaction(R), CanteraError);
@@ -232,7 +232,7 @@ TEST_F(KineticsFromScratch, allow_negative_A)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    Arrhenius rate(-3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(-3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
     R->allow_negative_pre_exponential_factor = true;
 
@@ -244,7 +244,7 @@ TEST_F(KineticsFromScratch, invalid_reversible_with_orders)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    Arrhenius rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
     R->orders["H2"] = 0.5;
 
@@ -256,7 +256,7 @@ TEST_F(KineticsFromScratch, negative_order_override)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    Arrhenius rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
     R->reversible = false;
     R->allow_negative_orders = true;
@@ -270,7 +270,7 @@ TEST_F(KineticsFromScratch, invalid_negative_orders)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    Arrhenius rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
     R->reversible = false;
     R->orders["H2"] = - 0.5;
@@ -283,7 +283,7 @@ TEST_F(KineticsFromScratch, nonreactant_order_override)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    Arrhenius rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
     R->reversible = false;
     R->allow_nonreactant_orders = true;
@@ -297,7 +297,7 @@ TEST_F(KineticsFromScratch, invalid_nonreactant_order)
 {
     Composition reac = parseCompString("O:1 H2:1");
     Composition prod = parseCompString("H:1 OH:1");
-    Arrhenius rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
+    Arrhenius2 rate(3.87e1, 2.7, 6260.0 / GasConst_cal_mol_K);
     auto R = make_shared<ElementaryReaction2>(reac, prod, rate);
     R->reversible = false;
     R->orders["OH"] = 0.5;
@@ -359,7 +359,7 @@ TEST_F(InterfaceKineticsFromScratch, add_surface_reaction)
     //                   [5.00000E+22, 0, 100.0], id = 'metal-rxn4')
     Composition reac = parseCompString("H(m):1 O(m):1");
     Composition prod = parseCompString("OH(m):1 (m):1");
-    Arrhenius rate(5e21, 0, 100.0e6 / GasConstant); // kJ/mol -> J/kmol
+    Arrhenius2 rate(5e21, 0, 100.0e6 / GasConstant); // kJ/mol -> J/kmol
 
     auto R = make_shared<InterfaceReaction>(reac, prod, rate);
     kin.addReaction(R);
@@ -373,7 +373,7 @@ TEST_F(InterfaceKineticsFromScratch, add_sticking_reaction)
     //                   stick(0.1, 0, 0), id = 'metal-rxn1')
     Composition reac = parseCompString("H2:1 (m):2");
     Composition prod = parseCompString("H(m):2");
-    Arrhenius rate(0.1, 0, 0.0);
+    Arrhenius2 rate(0.1, 0, 0.0);
 
     auto R = make_shared<InterfaceReaction>(reac, prod, rate, true);
     kin.addReaction(R);
@@ -384,7 +384,7 @@ TEST_F(InterfaceKineticsFromScratch, unbalanced_sites)
 {
     Composition reac = parseCompString("H(m):1 O(m):1");
     Composition prod = parseCompString("OH(m):1");
-    Arrhenius rate(5e21, 0, 100.0e6 / GasConstant);
+    Arrhenius2 rate(5e21, 0, 100.0e6 / GasConstant);
 
     auto R = make_shared<InterfaceReaction>(reac, prod, rate);
     ASSERT_THROW(kin.addReaction(R), CanteraError);

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -187,7 +187,7 @@ TEST_F(KineticsFromScratch, add_chebyshev_reaction)
     coeffs(2,1) = 2.6889e-01;
     coeffs(2,2) = 9.4806e-02;
     coeffs(2,3) = -7.6385e-03;
-    Chebyshev rate(290., 3000., 1000.0, 10000000.0, coeffs);
+    ChebyshevRate rate(290., 3000., 1000.0, 10000000.0, coeffs);
 
     auto R = make_shared<ChebyshevReaction2>(reac, prod, rate);
     kin.addReaction(R);

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -136,11 +136,11 @@ TEST_F(KineticsFromScratch3, add_plog_reaction)
     //                [(100.0, 'atm'), 5.963200e+56, -11.529, 52599.6])
     Composition reac = parseCompString("H2:1, O2:1");
     Composition prod = parseCompString("OH:2");
-    std::multimap<double, Arrhenius> rates {
-        { 0.01*101325, Arrhenius(1.212400e+16, -0.5779, 10872.7 / GasConst_cal_mol_K) },
-        { 1.0*101325, Arrhenius(4.910800e+31, -4.8507, 24772.8 / GasConst_cal_mol_K) },
-        { 10.0*101325, Arrhenius(1.286600e+47, -9.0246, 39796.5 / GasConst_cal_mol_K) },
-        { 100.0*101325, Arrhenius(5.963200e+56, -11.529, 52599.6 / GasConst_cal_mol_K) }
+    std::multimap<double, ArrheniusBase> rates {
+        { 0.01*101325, ArrheniusBase(1.212400e+16, -0.5779, 10872.7 * 4184.0) },
+        { 1.0*101325, ArrheniusBase(4.910800e+31, -4.8507, 24772.8 * 4184.0) },
+        { 10.0*101325, ArrheniusBase(1.286600e+47, -9.0246, 39796.5 * 4184.0) },
+        { 100.0*101325, ArrheniusBase(5.963200e+56, -11.529, 52599.6 * 4184.0) }
     };
 
     auto R = make_shared<Reaction>(reac, prod, make_shared<PlogRate>(rates));
@@ -152,11 +152,11 @@ TEST_F(KineticsFromScratch3, plog_invalid_rate)
 {
     Composition reac = parseCompString("H2:1, O2:1");
     Composition prod = parseCompString("OH:2");
-    std::multimap<double, Arrhenius> rates {
-        { 0.01*101325, Arrhenius(1.2124e+16, -0.5779, 10872.7 / GasConst_cal_mol_K) },
-        { 10.0*101325, Arrhenius(1e15, -1, 10000 / GasConst_cal_mol_K) },
-        { 10.0*101325, Arrhenius(-2e20, -2.0, 20000 / GasConst_cal_mol_K) },
-        { 100.0*101325, Arrhenius(5.9632e+56, -11.529, 52599.6 / GasConst_cal_mol_K) }
+    std::multimap<double, ArrheniusBase> rates {
+        { 0.01*101325, ArrheniusBase(1.2124e+16, -0.5779, 10872.7 * 4184.0) },
+        { 10.0*101325, ArrheniusBase(1e15, -1, 10000 * 4184.0) },
+        { 10.0*101325, ArrheniusBase(-2e20, -2.0, 20000 * 4184.0) },
+        { 100.0*101325, ArrheniusBase(5.9632e+56, -11.529, 52599.6 * 4184.0) }
     };
 
     auto R = make_shared<Reaction>(reac, prod, make_shared<PlogRate>(rates));

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -188,7 +188,7 @@ TEST_F(KineticsFromScratch3, add_chebyshev_reaction)
     coeffs(2,1) = 2.6889e-01;
     coeffs(2,2) = 9.4806e-02;
     coeffs(2,3) = -7.6385e-03;
-    auto rate = make_shared<ChebyshevRate3>(290., 3000., 1000.0, 10000000.0, coeffs);
+    auto rate = make_shared<ChebyshevRate>(290., 3000., 1000.0, 10000000.0, coeffs);
 
     auto R = make_shared<Reaction>(reac, prod, rate);
     kin.addReaction(R);

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -135,7 +135,7 @@ TEST(Reaction, FalloffFromYaml1)
     const auto rate = std::dynamic_pointer_cast<SriRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->highRate().preExponentialFactor(), 7.91E+10);
     EXPECT_DOUBLE_EQ(rate->lowRate().preExponentialFactor(), 6.37E+14);
-    EXPECT_DOUBLE_EQ(rate->lowRate().intrinsicActivationEnergy(), 56640);
+    EXPECT_DOUBLE_EQ(rate->lowRate().activationEnergy(), 56640);
 }
 
 TEST(Reaction, FalloffFromYaml2)
@@ -156,7 +156,7 @@ TEST(Reaction, FalloffFromYaml2)
     const auto rate = std::dynamic_pointer_cast<TroeRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->highRate().preExponentialFactor(), 6e11);
     EXPECT_DOUBLE_EQ(rate->lowRate().preExponentialFactor(), 1.04e20);
-    EXPECT_DOUBLE_EQ(rate->lowRate().intrinsicActivationEnergy(), 1600);
+    EXPECT_DOUBLE_EQ(rate->lowRate().activationEnergy(), 1600);
     vector_fp params(4);
     rate->getFalloffCoeffs(params);
     EXPECT_DOUBLE_EQ(params[0], 0.562);
@@ -184,8 +184,8 @@ TEST(Reaction, FalloffFromYaml3)
     const auto rate = std::dynamic_pointer_cast<TsangRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->highRate().preExponentialFactor(), 8.3e17);
     EXPECT_DOUBLE_EQ(rate->lowRate().preExponentialFactor(), 3.57e26);
-    EXPECT_DOUBLE_EQ(rate->highRate().intrinsicActivationEnergy(), 123800.0);
-    EXPECT_DOUBLE_EQ(rate->lowRate().intrinsicActivationEnergy(), 124900.0);
+    EXPECT_DOUBLE_EQ(rate->highRate().activationEnergy(), 123800.0);
+    EXPECT_DOUBLE_EQ(rate->lowRate().activationEnergy(), 124900.0);
     vector_fp params(2);
     rate->getFalloffCoeffs(params);
     EXPECT_DOUBLE_EQ(params[0], 0.95);
@@ -287,7 +287,7 @@ TEST(Reaction, BlowersMaselFromYaml)
         / (vp * vp - 4 * w * w + H_mid * H_mid );
     const auto& rate = std::dynamic_pointer_cast<BlowersMaselRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), -38.7);
-    EXPECT_DOUBLE_EQ(rate->activationEnergy0(), E_intrinsic);
+    EXPECT_DOUBLE_EQ(rate->activationEnergy(), E_intrinsic);
     EXPECT_DOUBLE_EQ(rate->bondEnergy(), w);
     EXPECT_DOUBLE_EQ(rate->activationEnergy_R(H_big_R), H_big_R);
     EXPECT_DOUBLE_EQ(rate->activationEnergy_R(H_small_R), 0);

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -252,7 +252,7 @@ TEST(Reaction, ChebyshevFromYaml)
 
     auto R = newReaction(rxn, *(sol->kinetics()));
     EXPECT_EQ(R->reactants.size(), (size_t) 1);
-    const auto& rate = std::dynamic_pointer_cast<ChebyshevRate3>(R->rate());
+    const auto& rate = std::dynamic_pointer_cast<ChebyshevRate>(R->rate());
     double logP = std::log10(2e6);
     double T = 1800;
     rate->update_C(&logP);
@@ -594,7 +594,7 @@ TEST_F(ReactionToYaml, Chebyshev)
     soln = newSolution("pdep-test.yaml");
     soln->thermo()->setState_TPY(1000, 2e5, "R6:1, P6A:2, P6B:0.3");
     duplicateReaction(5);
-    EXPECT_TRUE(std::dynamic_pointer_cast<ChebyshevRate3>(duplicate->rate()));
+    EXPECT_TRUE(std::dynamic_pointer_cast<ChebyshevRate>(duplicate->rate()));
     compareReactions();
 }
 
@@ -647,7 +647,7 @@ TEST_F(ReactionToYaml, unconvertible2)
     Array2D coeffs(2, 2, 1.0);
     ChebyshevReaction2 R({{"H2", 1}, {"OH", 1}},
                          {{"H2O", 1}, {"H", 1}},
-                         Chebyshev(273., 3000., 1.e2, 1.e7, coeffs));
+                         ChebyshevRate(273., 3000., 1.e2, 1.e7, coeffs));
     UnitSystem U{"g", "cm", "mol"};
     AnyMap params = R.parameters();
     params.setUnits(U);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR seeks to address several issues that came up while working on #1181.

- Fix compilation errors if `NO_LEGACY_REACTIONS_26` is set
- Streamline nomenclature for `activationEnergy` in the context of `BlowersMasel` ... use `effectiveActivationEnergy` for version that includes dependency on thermodynamic state (same will be introduced for `ReactionRate` classes that handle interface reactions).
- Limit use of `Arrhenius` ... clarify as `Arrhenius2` in legacy framework and make it equivalent with `ArrheniusBase` in new framework (`ArrheniusBase` should be renamed to `Arrhenius` after Cantera 2.6).  *Note: Defining a reduced `Arrhenius(Base)` class will also allow for additional templated classes - see e.g. Cantera/enhancements#133.*
- Remove leftover '3' from `ChebyshevRate(3)`
- Calculate `deltaH` within `BlowersMasel` without requiring associated `Kinetics` object

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

* Preamble to #1181 
* Closes Cantera/enhancements#131

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

This PR will allow to disable legacy reactions (actually `typedef`s) from `SCons` as
```
$ scons build no_legacy_reactions=y
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
