### PR TITLE
Introduce BulkRate class template

### DIFF
--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -166,25 +166,29 @@ public:
     }
 
     //! Evaluate reaction rate
-    //! @internal  Non-virtual method that should not be overloaded
     double evalRate(double logT, double recipT) const {
         return m_A * std::exp(m_b * logT - m_Ea_R * recipT);
     }
 
     //! Evaluate natural logarithm of the rate constant.
-    //! @internal  Non-virtual method that should not be overloaded
     double evalLog(double logT, double recipT) const {
         return m_logA + m_b * logT - m_Ea_R * recipT;
     }
 
     //! Evaluate reaction rate
-    double evalRate(const ArrheniusData& shared_data) const {
+    /*!
+     *  @param shared_data  data shared by all reactions of a given type
+     */
+    double evalFromStruct(const ArrheniusData& shared_data) const {
         return m_A * std::exp(m_b * shared_data.logT - m_Ea_R * shared_data.recipT);
     }
 
     //! Evaluate derivative of reaction rate with respect to temperature
     //! divided by reaction rate
-    double ddTScaled(const ArrheniusData& shared_data) const {
+    /*!
+     *  @param shared_data  data shared by all reactions of a given type
+     */
+    double ddTScaledFromStruct(const ArrheniusData& shared_data) const {
         return (m_Ea_R * shared_data.recipT + m_b) * shared_data.recipT;
     }
 };
@@ -228,12 +232,13 @@ public:
         return "two-temperature-plasma";
     }
 
-    //! Context
     virtual void setContext(const Reaction& rxn, const Kinetics& kin) override;
 
     //! Evaluate reaction rate
-    //! @internal  Non-virtual method that should not be overloaded
-    double evalRate(const TwoTempPlasmaData& shared_data) const {
+    /*!
+     *  @param shared_data  data shared by all reactions of a given type
+     */
+    double evalFromStruct(const TwoTempPlasmaData& shared_data) const {
         // m_E4_R is the electron activation (in temperature units)
         return m_A * std::exp(m_b * shared_data.logTe -
                               m_Ea_R * shared_data.recipT +
@@ -246,9 +251,9 @@ public:
     /*!
      *  This method does not consider changes of electron temperature.
      *  A corresponding warning is raised.
-     *  @internal  Non-virtual method that should not be overloaded
+     *  @param shared_data  data shared by all reactions of a given type
      */
-    double ddTScaled(const TwoTempPlasmaData& shared_data) const;
+    double ddTScaledFromStruct(const TwoTempPlasmaData& shared_data) const;
 
     //! Return the electron activation energy *Ea* [J/kmol]
     double activationElectronEnergy() const {
@@ -313,7 +318,6 @@ public:
         return "Blowers-Masel";
     }
 
-    //! Set context
     virtual void setContext(const Reaction& rxn, const Kinetics& kin) override;
 
     //! Update information specific to reaction
@@ -330,20 +334,21 @@ public:
     }
 
     //! Evaluate reaction rate
-    //! @internal  Non-virtual method that should not be overloaded
-    double evalRate(const BlowersMaselData& shared_data) const {
+    /*!
+     *  @param shared_data  data shared by all reactions of a given type
+     */
+    double evalFromStruct(const BlowersMaselData& shared_data) const {
         double Ea_R = effectiveActivationEnergy_R(m_deltaH_R);
         return m_A * std::exp(m_b * shared_data.logT - Ea_R * shared_data.recipT);
     }
 
-    //! Evaluate derivative of reaction rate with respect to temperature
     //! divided by reaction rate
     /*!
      *  This method does not consider potential changes due to a changed reaction
      *  enthalpy. A corresponding warning is raised.
-     *  @internal  Non-virtual method that should not be overloaded
+     *  @param shared_data  data shared by all reactions of a given type
      */
-    double ddTScaled(const BlowersMaselData& shared_data) const;
+    double ddTScaledFromStruct(const BlowersMaselData& shared_data) const;
 
     //! Return the effective activation energy (a function of the delta H of reaction)
     //! divided by the gas constant (i.e. the activation temperature) [K]
@@ -384,7 +389,7 @@ protected:
 
 //! A class template for bulk phase reaction rate specifications
 template <class RateType, class DataType>
-class BulkRate final : public RateType
+class BulkRate : public RateType
 {
 public:
     BulkRate() = default;
@@ -424,23 +429,6 @@ public:
         if (RateType::type() != "Arrhenius") {
             node["type"] = RateType::type();
         }
-    }
-
-    //! Evaluate reaction rate
-    /*!
-     *  @param shared_data  data shared by all reactions of a given type
-     */
-    double evalFromStruct(const DataType& shared_data) const {
-        return RateType::evalRate(shared_data);
-    }
-
-    //! Evaluate derivative of reaction rate with respect to temperature
-    //! divided by reaction rate
-    /*!
-     *  @param shared_data  data shared by all reactions of a given type
-     */
-    double ddTScaledFromStruct(const DataType& shared_data) const {
-        return RateType::ddTScaled(shared_data);
     }
 };
 

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -232,9 +232,8 @@ public:
         return "two-temperature-plasma";
     }
 
-    //! Context (unused)
-    void setRateContext(const Reaction& rxn, const Kinetics& kin) {
-    }
+    //! Context
+    void setRateContext(const Reaction& rxn, const Kinetics& kin);
 
     //! Evaluate reaction rate
     //! @internal  Non-virtual method that should not be overloaded

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -69,22 +69,6 @@ public:
     //! Check rate expression
     void checkRate(const std::string& equation, const AnyMap& node);
 
-    //! Evaluate reaction rate
-    /*!
-     *  @internal  Non-virtual method that should not be overloaded
-     */
-    double evalRate(double logT, double recipT) const {
-        return m_A * std::exp(m_b * logT - m_Ea_R * recipT);
-    }
-
-    //! Evaluate natural logarithm of the rate constant.
-    /*!
-     *  @internal  Non-virtual method that should not be overloaded
-     */
-    double evalLog(double logT, double recipT) const {
-        return m_logA + m_b * logT - m_Ea_R * recipT;
-    }
-
     //! Return the pre-exponential factor *A* (in m, kmol, s to powers depending
     //! on the reaction order)
     double preExponentialFactor() const {
@@ -175,6 +159,22 @@ public:
         return "Arrhenius";
     }
 
+    //! Evaluate reaction rate
+    /*!
+     *  @internal  Non-virtual method that should not be overloaded
+     */
+    double evalRate(double logT, double recipT) const {
+        return m_A * std::exp(m_b * logT - m_Ea_R * recipT);
+    }
+
+    //! Evaluate natural logarithm of the rate constant.
+    /*!
+     *  @internal  Non-virtual method that should not be overloaded
+     */
+    double evalLog(double logT, double recipT) const {
+        return m_logA + m_b * logT - m_Ea_R * recipT;
+    }
+
     //! Evaluate derivative of reaction rate with respect to temperature
     //! divided by reaction rate
     /*!
@@ -222,11 +222,6 @@ public:
         return Arrhenius3::rateType();
     }
 
-    //! Perform object setup based on AnyMap node information
-    /*!
-     *  @param node  AnyMap containing rate information
-     *  @param rate_units  Unit definitions specific to rate information
-     */
     virtual void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
     virtual void getParameters(AnyMap& node) const override;

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -188,24 +188,24 @@ public:
     }
 
     //! Get reaction rate in the low-pressure limit
-    ArrheniusBase& lowRate() {
+    Arrhenius3& lowRate() {
         return m_lowRate;
     }
 
     //! Set reaction rate in the low-pressure limit
-    void setLowRate(const ArrheniusBase& low);
+    void setLowRate(const Arrhenius3& low);
 
     //! Get reaction rate in the high-pressure limit
-    ArrheniusBase& highRate() {
+    Arrhenius3& highRate() {
         return m_highRate;
     }
 
     //! Set reaction rate in the high-pressure limit
-    void setHighRate(const ArrheniusBase& high);
+    void setHighRate(const Arrhenius3& high);
 
 protected:
-    ArrheniusBase m_lowRate; //!< The reaction rate in the low-pressure limit
-    ArrheniusBase m_highRate; //!< The reaction rate in the high-pressure limit
+    Arrhenius3 m_lowRate; //!< The reaction rate in the low-pressure limit
+    Arrhenius3 m_highRate; //!< The reaction rate in the high-pressure limit
 
     bool m_chemicallyActivated; //!< Flag labeling reaction as chemically activated
     bool m_negativeA_ok; //!< Flag indicating whether negative A values are permitted
@@ -234,7 +234,7 @@ public:
     }
 
     LindemannRate(
-        const ArrheniusBase& low, const ArrheniusBase& high, const vector_fp& c)
+        const Arrhenius3& low, const Arrhenius3& high, const vector_fp& c)
         : LindemannRate()
     {
         m_lowRate = low;
@@ -295,7 +295,7 @@ public:
         setParameters(node, rate_units);
     }
 
-    TroeRate(const ArrheniusBase& low, const ArrheniusBase& high, const vector_fp& c)
+    TroeRate(const Arrhenius3& low, const Arrhenius3& high, const vector_fp& c)
         : TroeRate()
     {
         m_lowRate = low;
@@ -397,7 +397,7 @@ public:
         setParameters(node, rate_units);
     }
 
-    SriRate(const ArrheniusBase& low, const ArrheniusBase& high, const vector_fp& c)
+    SriRate(const Arrhenius3& low, const Arrhenius3& high, const vector_fp& c)
         : SriRate()
     {
         m_lowRate = low;
@@ -507,7 +507,7 @@ public:
         setParameters(node, rate_units);
     }
 
-    TsangRate(const ArrheniusBase& low, const ArrheniusBase& high, const vector_fp& c)
+    TsangRate(const Arrhenius3& low, const Arrhenius3& high, const vector_fp& c)
         : TsangRate()
     {
         m_lowRate = low;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -528,24 +528,6 @@ public:
 };
 
 
-//! A reaction for two-temperature-plasma reaction rate
-class TwoTempPlasmaReaction: public Reaction
-{
-public:
-    TwoTempPlasmaReaction();
-    TwoTempPlasmaReaction(const Composition& reactants, const Composition& products,
-                  const TwoTempPlasmaRate& rate);
-
-    TwoTempPlasmaReaction(const AnyMap& node, const Kinetics& kin);
-
-    virtual std::string type() const {
-        return "two-temperature-plasma";
-    }
-
-    virtual void validate();
-};
-
-
 //! A falloff reaction that is first-order in [M] at low pressure, like a third-body
 //! reaction, but zeroth-order in [M] as pressure increases.
 //! In addition, the class supports chemically-activated reactions where the rate

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -117,8 +117,8 @@ public:
     //! Set context of reaction rate evaluation
     //! @param rxn  Reaction object associated with rate
     //! @param kin  Kinetics object used for rate evaluation
-    //! This method allows for passing of information when a ReactionRate is added
-    //! to Kinetics a MultiRate reaction evaluator.
+    //! This method allows for passing of information specific to the associated
+    //! reaction when a ReactionRate object is added a MultiRate reaction evaluator.
     virtual void setContext(const Reaction& rxn, const Kinetics& kin) {
     }
 

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -74,8 +74,12 @@ public:
     //!
     //! where `RateType` is the derived class name and `DataType` is the corresponding
     //! container for parameters needed to evaluate reactions of that type.
-    virtual unique_ptr<MultiRateBase> newMultiRate() const = 0;
+    virtual unique_ptr<MultiRateBase> newMultiRate() const {
+        throw NotImplementedError("ReactionRate::newMultiRate",
+            "Not implemented by '{}' object.", type());
+    }
 
+    //! String identifying reaction rate specialization
     virtual const std::string type() const = 0;
 
     //! Set parameters

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -36,7 +36,7 @@ class Func1;
  *        k_f =  A T^b \exp (-E/RT)
  *   \f]
  */
-class Arrhenius2 : public ArrheniusBase
+class Arrhenius2 : public Arrhenius3
 {
 public:
     //! Default constructor.
@@ -57,11 +57,12 @@ public:
     Arrhenius2(const AnyValue& rate,
                const UnitSystem& units, const Units& rate_units);
 
-    Arrhenius2(const ArrheniusBase& other);
+    //! Converting constructor (to facilitate back-ward compatibility)
+    Arrhenius2(const Arrhenius3& other);
 
     void setRateParameters(const AnyValue& rate,
                            const UnitSystem& units, const Units& rate_units);
-    using ArrheniusBase::setRateParameters;
+    using Arrhenius3::setRateParameters;
 
     //! Return parameters - two-parameter version
     void getParameters(AnyMap& node, const Units& rate_units) const;
@@ -89,12 +90,6 @@ public:
      */
     doublereal updateRC(doublereal logT, doublereal recipT) const {
         return m_A * std::exp(m_b*logT - m_Ea_R*recipT);
-    }
-
-    //! Return the activation energy divided by the gas constant (i.e. the
-    //! activation temperature) [K]
-    doublereal activationEnergy_R() const {
-        return m_Ea_R;
     }
 };
 
@@ -192,7 +187,7 @@ protected:
 
 
 #ifdef CT_NO_LEGACY_REACTIONS_26
-typedef ArrheniusBase Arrhenius;
+typedef Arrhenius3 Arrhenius;
 #else
 typedef Arrhenius2 Arrhenius;
 #endif
@@ -223,7 +218,7 @@ public:
     PlogRate();
 
     //! Constructor from Arrhenius rate expressions at a set of pressures
-    explicit PlogRate(const std::multimap<double, ArrheniusBase>& rates);
+    explicit PlogRate(const std::multimap<double, Arrhenius3>& rates);
 
     //! Constructor using legacy Arrhenius2 framework
     explicit PlogRate(const std::multimap<double, Arrhenius2>& rates);
@@ -285,7 +280,7 @@ public:
     void setup(const std::multimap<double, Arrhenius2>& rates);
 
     //! Set up Plog object
-    void setRates(const std::multimap<double, ArrheniusBase>& rates);
+    void setRates(const std::multimap<double, Arrhenius3>& rates);
 
     //! Update concentration-dependent parts of the rate coefficient.
     //! @param c natural log of the pressure in Pa
@@ -364,14 +359,14 @@ public:
 
     //! Return the pressures and Arrhenius expressions which comprise this
     //! reaction.
-    std::multimap<double, ArrheniusBase> getRates() const;
+    std::multimap<double, Arrhenius3> getRates() const;
 
 protected:
     //! log(p) to (index range) in the rates_ vector
     std::map<double, std::pair<size_t, size_t>> pressures_;
 
     // Rate expressions which are referenced by the indices stored in pressures_
-    std::vector<ArrheniusBase> rates_;
+    std::vector<Arrhenius3> rates_;
 
     double logP_; //!< log(p) at the current state
     double logP1_, logP2_; //!< log(p) at the lower / upper pressure reference

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -36,7 +36,7 @@ class Func1;
  *        k_f =  A T^b \exp (-E/RT)
  *   \f]
  */
-class Arrhenius2 : public Arrhenius3
+class Arrhenius2 final : public Arrhenius3
 {
 public:
     //! Default constructor.
@@ -90,6 +90,10 @@ public:
      */
     doublereal updateRC(doublereal logT, doublereal recipT) const {
         return m_A * std::exp(m_b*logT - m_Ea_R*recipT);
+    }
+
+    virtual const std::string type() const override {
+        return "Arrhenius2";
     }
 };
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -457,7 +457,14 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef vector[shared_ptr[CxxReaction]] CxxGetReactions "getReactions" (XML_Node&) except +translate_exception
     cdef vector[shared_ptr[CxxReaction]] CxxGetReactions "getReactions" (CxxAnyValue&, CxxKinetics&) except +translate_exception
 
-    cdef cppclass CxxArrheniusBase "Cantera::ArrheniusBase":
+    cdef cppclass CxxReactionRate "Cantera::ReactionRate":
+        CxxReactionRate()
+        string type()
+        double eval(double) except +translate_exception
+        double eval(double, double) except +translate_exception
+        CxxAnyMap parameters() except +translate_exception
+
+    cdef cppclass CxxArrheniusBase "Cantera::ArrheniusBase" (CxxReactionRate):
         CxxArrheniusBase()
         double preExponentialFactor()
         double temperatureExponent()
@@ -472,23 +479,16 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxArrhenius2 "Cantera::Arrhenius2" (CxxArrhenius):
         CxxArrhenius2(double, double, double)
 
-    cdef cppclass CxxReactionRate "Cantera::ReactionRate":
-        CxxReactionRate()
-        string type()
-        double eval(double) except +translate_exception
-        double eval(double, double) except +translate_exception
-        CxxAnyMap parameters() except +translate_exception
-
-    cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxReactionRate, CxxArrhenius):
+    cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxArrhenius):
         CxxArrheniusRate(CxxAnyMap) except +translate_exception
         CxxArrheniusRate(double, double, double)
 
-    cdef cppclass CxxTwoTempPlasmaRate "Cantera::TwoTempPlasmaRate" (CxxReactionRate, CxxArrheniusBase):
+    cdef cppclass CxxTwoTempPlasmaRate "Cantera::TwoTempPlasmaRate" (CxxArrheniusBase):
         CxxTwoTempPlasmaRate(CxxAnyMap) except +translate_exception
         CxxTwoTempPlasmaRate(double, double, double, double)
         double activationElectronEnergy()
 
-    cdef cppclass CxxBlowersMaselRate "Cantera::BlowersMaselRate" (CxxReactionRate, CxxArrheniusBase):
+    cdef cppclass CxxBlowersMaselRate "Cantera::BlowersMaselRate" (CxxArrheniusBase):
         CxxBlowersMaselRate(CxxAnyMap) except +translate_exception
         CxxBlowersMaselRate(double, double, double, double)
         double effectiveActivationEnergy(double)

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -459,15 +459,17 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
 
     cdef cppclass CxxArrheniusBase "Cantera::ArrheniusBase":
         CxxArrheniusBase()
-        CxxArrheniusBase(double, double, double)
-        double evalRate(double, double)
         double preExponentialFactor()
         double temperatureExponent()
         double activationEnergy()
         cbool allowNegativePreExponentialFactor()
         void setAllowNegativePreExponentialFactor(bool)
 
-    cdef cppclass CxxArrhenius2 "Cantera::Arrhenius2" (CxxArrheniusBase):
+    cdef cppclass CxxArrhenius "Cantera::Arrhenius3" (CxxArrheniusBase):
+        CxxArrhenius(double, double, double)
+        double evalRate(double, double)
+
+    cdef cppclass CxxArrhenius2 "Cantera::Arrhenius2" (CxxArrhenius):
         CxxArrhenius2(double, double, double)
 
     cdef cppclass CxxReactionRate "Cantera::ReactionRate":
@@ -477,7 +479,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         double eval(double, double) except +translate_exception
         CxxAnyMap parameters() except +translate_exception
 
-    cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxReactionRate, CxxArrheniusBase):
+    cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxReactionRate, CxxArrhenius):
         CxxArrheniusRate(CxxAnyMap) except +translate_exception
         CxxArrheniusRate(double, double, double)
 
@@ -499,10 +501,10 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         void setAllowNegativePreExponentialFactor(bool)
         cbool chemicallyActivated()
         void setChemicallyActivated(bool)
-        CxxArrheniusBase& lowRate()
-        void setLowRate(CxxArrheniusBase&) except +translate_exception
-        CxxArrheniusBase& highRate()
-        void setHighRate(CxxArrheniusBase&) except +translate_exception
+        CxxArrhenius& lowRate()
+        void setLowRate(CxxArrhenius&) except +translate_exception
+        CxxArrhenius& highRate()
+        void setHighRate(CxxArrhenius&) except +translate_exception
         void getFalloffCoeffs(vector[double]&)
         void setFalloffCoeffs(vector[double]&) except +translate_exception
         double evalF(double, double) except +translate_exception
@@ -522,8 +524,8 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxPlogRate "Cantera::PlogRate" (CxxReactionRate):
         CxxPlogRate()
         CxxPlogRate(CxxAnyMap) except +translate_exception
-        CxxPlogRate(multimap[double, CxxArrheniusBase])
-        multimap[double, CxxArrheniusBase] getRates()
+        CxxPlogRate(multimap[double, CxxArrhenius])
+        multimap[double, CxxArrhenius] getRates()
 
     cdef cppclass CxxChebyshevRate "Cantera::ChebyshevRate" (CxxReactionRate):
         CxxChebyshevRate()
@@ -1404,11 +1406,11 @@ cdef class CustomReaction(Reaction):
 
 cdef class Arrhenius:
     cdef CxxArrhenius2* legacy # used by legacy objects only
-    cdef CxxArrheniusBase* base
+    cdef CxxArrhenius* base
     cdef cbool own_rate
     cdef Reaction reaction # parent reaction, to prevent garbage collection
     @staticmethod
-    cdef wrap(CxxArrheniusBase*)
+    cdef wrap(CxxArrhenius*)
 
 cdef class BlowersMasel:
     cdef CxxBlowersMasel2* rate

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -666,9 +666,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxThreeBodyReaction3 "Cantera::ThreeBodyReaction3" (CxxReaction):
         CxxThreeBodyReaction3()
 
-    cdef cppclass CxxTwoTempPlasmaReaction "Cantera::TwoTempPlasmaReaction"(CxxReaction):
-        CxxTwoTempPlasmaReaction()
-
     cdef cppclass CxxFalloffReaction3 "Cantera::FalloffReaction3" (CxxReaction):
         CxxFalloffReaction3()
 

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -214,8 +214,8 @@ cdef class ArrheniusRate(ArrheniusTypeRate):
 
     cdef set_cxx_object(self):
         self.rate = self._rate.get()
-        # CxxArrheniusBase does not have a common base with CxxReactionRate
-        self.base = <CxxArrheniusBase*>self.cxx_object()
+        # CxxArrhenius does not have a common base with CxxReactionRate
+        self.base = <CxxArrhenius*>self.cxx_object()
 
     cdef CxxArrheniusRate* cxx_object(self):
         return <CxxArrheniusRate*>self.rate
@@ -522,17 +522,17 @@ cdef class PlogRate(ReactionRate):
         """
         def __get__(self):
             rates = []
-            cdef multimap[double, CxxArrheniusBase] cxxrates
-            cdef pair[double, CxxArrheniusBase] p_rate
+            cdef multimap[double, CxxArrhenius] cxxrates
+            cdef pair[double, CxxArrhenius] p_rate
             cxxrates = self.cxx_object().getRates()
             for p_rate in cxxrates:
-                rates.append((p_rate.first, copyArrheniusBase(&p_rate.second)))
+                rates.append((p_rate.first, copyArrhenius(&p_rate.second)))
             return rates
 
         def __set__(self, rates):
-            cdef multimap[double, CxxArrheniusBase] ratemap
+            cdef multimap[double, CxxArrhenius] ratemap
             cdef Arrhenius rate
-            cdef pair[double, CxxArrheniusBase] item
+            cdef pair[double, CxxArrhenius] item
             for p, rate in rates:
                 item.first = p
                 item.second = deref(rate.base)
@@ -1453,7 +1453,7 @@ cdef class Arrhenius:
     """
     def __cinit__(self, A=0, b=0, E=0, init=True):
         if init:
-            self.base = new CxxArrheniusBase(A, b, E)
+            self.base = new CxxArrhenius(A, b, E)
             self.own_rate = True
             self.reaction = None
         else:
@@ -1464,7 +1464,7 @@ cdef class Arrhenius:
             del self.base
 
     @staticmethod
-    cdef wrap(CxxArrheniusBase* rate):
+    cdef wrap(CxxArrhenius* rate):
         r = Arrhenius(init=False)
         r.base = rate
         r.reaction = None
@@ -1501,7 +1501,7 @@ cdef class Arrhenius:
         return self.base.evalRate(np.log(T), 1/T)
 
 
-cdef wrapArrhenius(CxxArrheniusBase* rate, Reaction reaction):
+cdef wrapArrhenius(CxxArrhenius* rate, Reaction reaction):
     r = Arrhenius(init=False)
     r.base = rate
     if reaction.uses_legacy:
@@ -1510,12 +1510,12 @@ cdef wrapArrhenius(CxxArrheniusBase* rate, Reaction reaction):
     r.reaction = reaction
     return r
 
-cdef copyArrhenius(CxxArrhenius2* rate):
+cdef copyArrhenius2(CxxArrhenius2* rate):
     r = Arrhenius(rate.preExponentialFactor(), rate.temperatureExponent(),
                   rate.activationEnergy())
     return r
 
-cdef copyArrheniusBase(CxxArrheniusBase* rate):
+cdef copyArrhenius(CxxArrhenius* rate):
     r = Arrhenius(rate.preExponentialFactor(), rate.temperatureExponent(),
                   rate.activationEnergy())
     return r
@@ -2118,7 +2118,7 @@ cdef class PlogReaction(Reaction):
         cdef pair[double,CxxArrhenius2] p_rate
         rates = []
         for p_rate in cxxrates:
-            rates.append((p_rate.first,copyArrhenius(&p_rate.second)))
+            rates.append((p_rate.first,copyArrhenius2(&p_rate.second)))
         return rates
 
     cdef _legacy_set_rates(self, list rates):

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -214,8 +214,7 @@ cdef class ArrheniusRate(ArrheniusTypeRate):
 
     cdef set_cxx_object(self):
         self.rate = self._rate.get()
-        # CxxArrhenius does not have a common base with CxxReactionRate
-        self.base = <CxxArrhenius*>self.cxx_object()
+        self.base = <CxxArrhenius*>self.rate
 
     cdef CxxArrheniusRate* cxx_object(self):
         return <CxxArrheniusRate*>self.rate
@@ -248,8 +247,7 @@ cdef class BlowersMaselRate(ArrheniusTypeRate):
 
     cdef set_cxx_object(self):
         self.rate = self._rate.get()
-        # CxxArrheniusBase does not have a common base with CxxReactionRate
-        self.base = <CxxArrheniusBase*>self.cxx_object()
+        self.base = <CxxArrheniusBase*>self.rate
 
     cdef CxxBlowersMaselRate* cxx_object(self):
         return <CxxBlowersMaselRate*>self.rate
@@ -309,8 +307,7 @@ cdef class TwoTempPlasmaRate(ArrheniusTypeRate):
 
     cdef set_cxx_object(self):
         self.rate = self._rate.get()
-        # CxxArrheniusBase does not have a common base with CxxReactionRate
-        self.base = <CxxArrheniusBase*>self.cxx_object()
+        self.base = <CxxArrheniusBase*>self.rate
 
     cdef CxxTwoTempPlasmaRate* cxx_object(self):
         return <CxxTwoTempPlasmaRate*>self.rate

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -290,6 +290,9 @@ cdef class TwoTempPlasmaRate(ArrheniusTypeRate):
     def __cinit__(self, A=None, b=None, Ea_gas=0.0, Ea_electron=0.0,
             input_data=None, init=True):
         if init:
+            if A is None and b is None:
+                Ea_gas = None
+                Ea_electron = None
             self._cinit(input_data, A=A, b=b, Ea_gas=Ea_gas, Ea_electron=Ea_electron)
 
     def __call__(self, double temperature, double elec_temp):
@@ -2412,62 +2415,6 @@ cdef wrapBlowersMasel(CxxBlowersMasel2* rate, Reaction reaction):
     r.rate = rate
     r.reaction = reaction
     return r
-
-
-cdef class TwoTempPlasmaReaction(Reaction):
-    """
-    A reaction which rate coefficient depends on both gas and electron temperature
-
-    An example for the definition of an `TwoTempPlasmaReaction` object is given as::
-
-        rxn = TwoTempPlasmaReaction(
-            equation="O2 + E <=> O2-",
-            rate={"A": 17283, "b": -3.1, "Ea-gas": -5820088, "Ea-electron": 10808733},
-            kinetics=gas)
-
-    The YAML description corresponding to this reaction is::
-
-        equation: O2 + E <=> O2-
-        type: two-temperature-plasma
-        rate-constant: {A: 17283, b: -3.1, Ea-gas: -700 K, Ea-electron: 1300 K}
-    """
-    _reaction_type = "two-temperature-plasma"
-
-    def __init__(self, reactants=None, products=None, rate=None, *, equation=None,
-                 Kinetics kinetics=None, init=True, **kwargs):
-
-        if reactants and products and not equation:
-            equation = self.equation
-
-        if init and equation and kinetics:
-            rxn_type = self._reaction_type
-            spec = {"equation": equation, "type": rxn_type}
-            if isinstance(rate, dict):
-                replaced_rate = {}
-                for key, value in rate.items():
-                    replaced_rate[key.replace("_", "-")] = value
-                spec["rate-constant"] = replaced_rate
-            elif rate is None or isinstance(rate, TwoTempPlasmaRate):
-                pass
-            else:
-                raise TypeError("Invalid rate definition")
-
-            self._reaction = CxxNewReaction(dict_to_anymap(spec),
-                                            deref(kinetics.kinetics))
-            self.reaction = self._reaction.get()
-
-        if isinstance(rate, TwoTempPlasmaRate):
-            self.rate = rate
-
-    property rate:
-        """ Get/Set the `TwoTempPlasmaRate` rate coefficients for this reaction. """
-        def __get__(self):
-            cdef CxxTwoTempPlasmaReaction* r = <CxxTwoTempPlasmaReaction*>self.reaction
-            return TwoTempPlasmaRate.wrap(r.rate())
-        def __set__(self, rate):
-            cdef CxxTwoTempPlasmaReaction* r = <CxxTwoTempPlasmaReaction*>self.reaction
-            cdef TwoTempPlasmaRate rate_ = rate
-            r.setRate(rate_._rate)
 
 
 cdef class InterfaceReaction(ElementaryReaction):

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -126,14 +126,14 @@ void ArrheniusBase::checkRate(const std::string& equation, const AnyMap& node)
     }
 }
 
-TwoTempPlasmaRate::TwoTempPlasmaRate()
+TwoTempPlasma::TwoTempPlasma()
     : ArrheniusBase()
 {
     m_Ea_str = "Ea-gas";
     m_E4_str = "Ea-electron";
 }
 
-TwoTempPlasmaRate::TwoTempPlasmaRate(double A, double b, double Ea, double EE)
+TwoTempPlasma::TwoTempPlasma(double A, double b, double Ea, double EE)
     : ArrheniusBase(A, b, Ea)
 {
     m_Ea_str = "Ea-gas";
@@ -141,28 +141,11 @@ TwoTempPlasmaRate::TwoTempPlasmaRate(double A, double b, double Ea, double EE)
     m_E4_R = EE / GasConstant;
 }
 
-void TwoTempPlasmaRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
+double TwoTempPlasma::ddTScaled(const TwoTempPlasmaData& shared_data) const
 {
-    m_negativeA_ok = node.getBool("negative-A", false);
-    if (!node.hasKey("rate-constant")) {
-        setRateParameters(AnyValue(), node.units(), rate_units);
-        return;
-    }
-    setRateParameters(node["rate-constant"], node.units(), rate_units);
-}
-
-void TwoTempPlasmaRate::getParameters(AnyMap& rateNode) const
-{
-    if (m_negativeA_ok) {
-        rateNode["negative-A"] = true;
-    }
-    AnyMap node;
-    ArrheniusBase::getRateParameters(node);
-    if (!node.empty()) {
-        // object is configured
-        rateNode["rate-constant"] = std::move(node);
-    }
-    rateNode["type"] = type();
+    warn_user("TwoTempPlasma::ddTScaled",
+        "Temperature derivative does not consider changes of electron temperature.");
+    return (m_Ea_R - m_E4_R) * shared_data.recipT * shared_data.recipT;
 }
 
 BlowersMasel::BlowersMasel()

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -141,16 +141,16 @@ TwoTempPlasma::TwoTempPlasma(double A, double b, double Ea, double EE)
     m_E4_R = EE / GasConstant;
 }
 
-double TwoTempPlasma::ddTScaled(const TwoTempPlasmaData& shared_data) const
+double TwoTempPlasma::ddTScaledFromStruct(const TwoTempPlasmaData& shared_data) const
 {
-    warn_user("TwoTempPlasma::ddTScaled",
+    warn_user("TwoTempPlasma::ddTScaledFromStruct",
         "Temperature derivative does not consider changes of electron temperature.");
     return (m_Ea_R - m_E4_R) * shared_data.recipT * shared_data.recipT;
 }
 
 void TwoTempPlasma::setContext(const Reaction& rxn, const Kinetics& kin)
 {
-    // TwoTempPlasmaReaction is for a non-equilirium plasma, and the reverse rate
+    // TwoTempPlasmaReaction is for a non-equilibrium plasma, and the reverse rate
     // cannot be calculated from the conventional thermochemistry.
     // @todo implement the reversible rate for non-equilibrium plasma
     if (rxn.reversible) {
@@ -175,7 +175,7 @@ BlowersMasel::BlowersMasel(double A, double b, double Ea0, double w)
     m_E4_R = w / GasConstant;
 }
 
-double BlowersMasel::ddTScaled(const BlowersMaselData& shared_data) const
+double BlowersMasel::ddTScaledFromStruct(const BlowersMaselData& shared_data) const
 {
     warn_user("BlowersMasel::ddTScaledFromStruct",
         "Temperature derivative does not consider changes of reaction enthalpy.");

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -181,36 +181,12 @@ BlowersMasel::BlowersMasel(double A, double b, double Ea0, double w)
     m_E4_R = w / GasConstant;
 }
 
-double BlowersMasel::ddTScaled(double logT, double recipT) const
+double BlowersMasel::ddTScaled(const BlowersMaselData& shared_data) const
 {
-    warn_user("BlowersMaselRate::ddTScaledFromStruct",
+    warn_user("BlowersMasel::ddTScaledFromStruct",
         "Temperature derivative does not consider changes of reaction enthalpy.");
-    double Ea_R = activationEnergy_R(m_deltaH_R);
-    return m_A * std::exp(m_b * logT - Ea_R * recipT);
-}
-
-void BlowersMaselRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
-{
-    m_negativeA_ok = node.getBool("negative-A", false);
-    if (!node.hasKey("rate-constant")) {
-        setRateParameters(AnyValue(), node.units(), rate_units);
-        return;
-    }
-    setRateParameters(node["rate-constant"], node.units(), rate_units);
-}
-
-void BlowersMaselRate::getParameters(AnyMap& rateNode) const
-{
-    if (m_negativeA_ok) {
-        rateNode["negative-A"] = true;
-    }
-    AnyMap node;
-    ArrheniusBase::getRateParameters(node);
-    if (!node.empty()) {
-        // object is configured
-        rateNode["rate-constant"] = std::move(node);
-    }
-    rateNode["type"] = type();
+    double Ea_R = effectiveActivationEnergy_R(m_deltaH_R);
+    return (Ea_R * shared_data.recipT + m_b) * shared_data.recipT;
 }
 
 void BlowersMasel::setRateContext(const Reaction& rxn, const Kinetics& kin)

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -111,16 +111,16 @@ void ArrheniusBase::getRateParameters(AnyMap& node) const
 
 }
 
-void ArrheniusBase::checkRate(const std::string& equation, const AnyMap& node)
+void ArrheniusBase::check(const std::string& equation, const AnyMap& node)
 {
     if (!m_negativeA_ok && m_A < 0) {
         if (equation == "") {
-            throw CanteraError("ArrheniusBase::checkRate",
+            throw CanteraError("ArrheniusBase::check",
                 "Detected negative pre-exponential factor (A={}).\n"
                 "Enable 'allowNegativePreExponentialFactor' to suppress "
                 "this message.", m_A);
         }
-        throw InputFileError("ArrheniusBase::checkRate", node,
+        throw InputFileError("ArrheniusBase::check", node,
             "Undeclared negative pre-exponential factor found in reaction '{}'",
             equation);
     }
@@ -148,13 +148,13 @@ double TwoTempPlasma::ddTScaled(const TwoTempPlasmaData& shared_data) const
     return (m_Ea_R - m_E4_R) * shared_data.recipT * shared_data.recipT;
 }
 
-void TwoTempPlasma::setRateContext(const Reaction& rxn, const Kinetics& kin)
+void TwoTempPlasma::setContext(const Reaction& rxn, const Kinetics& kin)
 {
     // TwoTempPlasmaReaction is for a non-equilirium plasma, and the reverse rate
     // cannot be calculated from the conventional thermochemistry.
     // @todo implement the reversible rate for non-equilibrium plasma
     if (rxn.reversible) {
-        throw InputFileError("TwoTempPlasma::setRateContext", rxn.input,
+        throw InputFileError("TwoTempPlasma::setContext", rxn.input,
             "TwoTempPlasmaRate does not support reversible reactions");
     }
 }
@@ -183,7 +183,7 @@ double BlowersMasel::ddTScaled(const BlowersMaselData& shared_data) const
     return (Ea_R * shared_data.recipT + m_b) * shared_data.recipT;
 }
 
-void BlowersMasel::setRateContext(const Reaction& rxn, const Kinetics& kin)
+void BlowersMasel::setContext(const Reaction& rxn, const Kinetics& kin)
 {
     m_stoich_coeffs.clear();
     for (const auto& sp : rxn.reactants) {

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -126,30 +126,6 @@ void ArrheniusBase::checkRate(const std::string& equation, const AnyMap& node)
     }
 }
 
-void ArrheniusRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
-{
-    m_negativeA_ok = node.getBool("negative-A", false);
-    if (!node.hasKey("rate-constant")) {
-        ArrheniusBase::setRateParameters(AnyValue(), node.units(), rate_units);
-        return;
-    }
-
-    ArrheniusBase::setRateParameters(node["rate-constant"], node.units(), rate_units);
-}
-
-void ArrheniusRate::getParameters(AnyMap& rateNode) const
-{
-    if (m_negativeA_ok) {
-        rateNode["negative-A"] = true;
-    }
-    AnyMap node;
-    ArrheniusBase::getRateParameters(node);
-    if (!node.empty()) {
-        // Arrhenius object is configured
-        rateNode["rate-constant"] = std::move(node);
-    }
-}
-
 TwoTempPlasmaRate::TwoTempPlasmaRate()
     : ArrheniusBase()
 {

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -189,14 +189,14 @@ void TwoTempPlasmaRate::getParameters(AnyMap& rateNode) const
     rateNode["type"] = type();
 }
 
-BlowersMaselRate::BlowersMaselRate()
+BlowersMasel::BlowersMasel()
     : m_deltaH_R(0.)
 {
     m_Ea_str = "Ea0";
     m_E4_str = "w";
 }
 
-BlowersMaselRate::BlowersMaselRate(double A, double b, double Ea0, double w)
+BlowersMasel::BlowersMasel(double A, double b, double Ea0, double w)
     : ArrheniusBase(A, b, Ea0)
     , m_deltaH_R(0.)
 {
@@ -205,12 +205,12 @@ BlowersMaselRate::BlowersMaselRate(double A, double b, double Ea0, double w)
     m_E4_R = w / GasConstant;
 }
 
-double BlowersMaselRate::ddTScaledFromStruct(const BlowersMaselData& shared_data) const
+double BlowersMasel::ddTScaled(double logT, double recipT) const
 {
     warn_user("BlowersMaselRate::ddTScaledFromStruct",
         "Temperature derivative does not consider changes of reaction enthalpy.");
     double Ea_R = activationEnergy_R(m_deltaH_R);
-    return m_A * std::exp(m_b * shared_data.logT - Ea_R * shared_data.recipT);
+    return m_A * std::exp(m_b * logT - Ea_R * recipT);
 }
 
 void BlowersMaselRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
@@ -237,7 +237,7 @@ void BlowersMaselRate::getParameters(AnyMap& rateNode) const
     rateNode["type"] = type();
 }
 
-void BlowersMaselRate::setContext(const Reaction& rxn, const Kinetics& kin)
+void BlowersMasel::setRateContext(const Reaction& rxn, const Kinetics& kin)
 {
     m_stoich_coeffs.clear();
     for (const auto& sp : rxn.reactants) {

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -148,6 +148,17 @@ double TwoTempPlasma::ddTScaled(const TwoTempPlasmaData& shared_data) const
     return (m_Ea_R - m_E4_R) * shared_data.recipT * shared_data.recipT;
 }
 
+void TwoTempPlasma::setRateContext(const Reaction& rxn, const Kinetics& kin)
+{
+    // TwoTempPlasmaReaction is for a non-equilirium plasma, and the reverse rate
+    // cannot be calculated from the conventional thermochemistry.
+    // @todo implement the reversible rate for non-equilibrium plasma
+    if (rxn.reversible) {
+        throw InputFileError("TwoTempPlasma::setRateContext", rxn.input,
+            "TwoTempPlasmaRate does not support reversible reactions");
+    }
+}
+
 BlowersMasel::BlowersMasel()
     : m_deltaH_R(0.)
 {

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -21,9 +21,9 @@ void FalloffRate::init(const vector_fp& c)
     setFalloffCoeffs(c);
 }
 
-void FalloffRate::setLowRate(const ArrheniusBase& low)
+void FalloffRate::setLowRate(const Arrhenius3& low)
 {
-    ArrheniusBase _low = low;
+    Arrhenius3 _low = low;
     _low.setAllowNegativePreExponentialFactor(m_negativeA_ok);
     _low.checkRate("", AnyMap());
     if (_low.preExponentialFactor() * m_highRate.preExponentialFactor() < 0.) {
@@ -34,9 +34,9 @@ void FalloffRate::setLowRate(const ArrheniusBase& low)
     m_lowRate = std::move(_low);
 }
 
-void FalloffRate::setHighRate(const ArrheniusBase& high)
+void FalloffRate::setHighRate(const Arrhenius3& high)
 {
-    ArrheniusBase _high = high;
+    Arrhenius3 _high = high;
     _high.setAllowNegativePreExponentialFactor(m_negativeA_ok);
     _high.checkRate("", AnyMap());
     if (m_lowRate.preExponentialFactor() * _high.preExponentialFactor() < 0.) {
@@ -83,12 +83,12 @@ void FalloffRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
         }
     }
     if (node.hasKey("low-P-rate-constant")) {
-        m_lowRate = ArrheniusBase(
+        m_lowRate = Arrhenius3(
             node["low-P-rate-constant"], node.units(), low_rate_units);
         m_lowRate.setAllowNegativePreExponentialFactor(m_negativeA_ok);
     }
     if (node.hasKey("high-P-rate-constant")) {
-        m_highRate = ArrheniusBase(
+        m_highRate = Arrhenius3(
             node["high-P-rate-constant"], node.units(), high_rate_units);
         m_highRate.setAllowNegativePreExponentialFactor(m_negativeA_ok);
     }

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -25,7 +25,7 @@ void FalloffRate::setLowRate(const Arrhenius3& low)
 {
     Arrhenius3 _low = low;
     _low.setAllowNegativePreExponentialFactor(m_negativeA_ok);
-    _low.checkRate("", AnyMap());
+    _low.check("", AnyMap());
     if (_low.preExponentialFactor() * m_highRate.preExponentialFactor() < 0.) {
         throw CanteraError("FalloffRate::setLowRate",
             "Detected inconsistent rate definitions;\nhigh and low "
@@ -38,7 +38,7 @@ void FalloffRate::setHighRate(const Arrhenius3& high)
 {
     Arrhenius3 _high = high;
     _high.setAllowNegativePreExponentialFactor(m_negativeA_ok);
-    _high.checkRate("", AnyMap());
+    _high.check("", AnyMap());
     if (m_lowRate.preExponentialFactor() * _high.preExponentialFactor() < 0.) {
         throw CanteraError("FalloffRate::setHighRate",
             "Detected inconsistent rate definitions;\nhigh and low "
@@ -118,8 +118,8 @@ void FalloffRate::getParameters(AnyMap& node) const
 
 void FalloffRate::check(const std::string& equation, const AnyMap& node)
 {
-    m_lowRate.checkRate(equation, node);
-    m_highRate.checkRate(equation, node);
+    m_lowRate.check(equation, node);
+    m_highRate.check(equation, node);
 
     double lowA = m_lowRate.preExponentialFactor();
     double highA = m_highRate.preExponentialFactor();

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -1138,41 +1138,6 @@ std::string ThreeBodyReaction3::productString() const
     }
 }
 
-TwoTempPlasmaReaction::TwoTempPlasmaReaction()
-{
-    setRate(newReactionRate(type()));
-}
-
-TwoTempPlasmaReaction::TwoTempPlasmaReaction(
-        const Composition& reactants, const Composition& products,
-        const TwoTempPlasmaRate& rate)
-    : Reaction(reactants, products)
-{
-    m_rate.reset(new TwoTempPlasmaRate(rate));
-}
-
-TwoTempPlasmaReaction::TwoTempPlasmaReaction(const AnyMap& node, const Kinetics& kin)
-{
-    if (!node.empty()) {
-        setParameters(node, kin);
-        setRate(newReactionRate(node, calculateRateCoeffUnits3(kin)));
-    } else {
-        setRate(newReactionRate(type()));
-    }
-}
-
-void TwoTempPlasmaReaction::validate()
-{
-    Reaction::validate();
-    // TwoTempPlasmaReaction is for a non-equilirium plasma, and the reverse rate
-    // cannot be calculated from the conventional thermochemistry.
-    // @todo implement the reversible rate for non-equilibrium plasma
-    if (reversible) {
-        throw InputFileError("Reaction::validate", input,
-            "TwoTempPlasmaReaction may only be given for irreversible reactions");
-    }
-}
-
 FalloffReaction3::FalloffReaction3()
     : Reaction()
 {

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -131,10 +131,7 @@ ReactionFactory::ReactionFactory()
         return R;
     });
 
-    // register electron-temprature reactions
-    reg("two-temperature-plasma", [](const AnyMap& node, const Kinetics& kin) {
-        return new TwoTempPlasmaReaction(node, kin);
-    });
+    addAlias("reaction", "two-temperature-plasma");
 
     addAlias("reaction", "Blowers-Masel");
 

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -136,11 +136,11 @@ TEST_F(KineticsFromScratch3, add_plog_reaction)
     //                [(100.0, 'atm'), 5.963200e+56, -11.529, 52599.6])
     Composition reac = parseCompString("H2:1, O2:1");
     Composition prod = parseCompString("OH:2");
-    std::multimap<double, ArrheniusBase> rates {
-        { 0.01*101325, ArrheniusBase(1.212400e+16, -0.5779, 10872.7 * 4184.0) },
-        { 1.0*101325, ArrheniusBase(4.910800e+31, -4.8507, 24772.8 * 4184.0) },
-        { 10.0*101325, ArrheniusBase(1.286600e+47, -9.0246, 39796.5 * 4184.0) },
-        { 100.0*101325, ArrheniusBase(5.963200e+56, -11.529, 52599.6 * 4184.0) }
+    std::multimap<double, Arrhenius3> rates {
+        { 0.01*101325, Arrhenius3(1.212400e+16, -0.5779, 10872.7 * 4184.0) },
+        { 1.0*101325, Arrhenius3(4.910800e+31, -4.8507, 24772.8 * 4184.0) },
+        { 10.0*101325, Arrhenius3(1.286600e+47, -9.0246, 39796.5 * 4184.0) },
+        { 100.0*101325, Arrhenius3(5.963200e+56, -11.529, 52599.6 * 4184.0) }
     };
 
     auto R = make_shared<Reaction>(reac, prod, make_shared<PlogRate>(rates));
@@ -152,11 +152,11 @@ TEST_F(KineticsFromScratch3, plog_invalid_rate)
 {
     Composition reac = parseCompString("H2:1, O2:1");
     Composition prod = parseCompString("OH:2");
-    std::multimap<double, ArrheniusBase> rates {
-        { 0.01*101325, ArrheniusBase(1.2124e+16, -0.5779, 10872.7 * 4184.0) },
-        { 10.0*101325, ArrheniusBase(1e15, -1, 10000 * 4184.0) },
-        { 10.0*101325, ArrheniusBase(-2e20, -2.0, 20000 * 4184.0) },
-        { 100.0*101325, ArrheniusBase(5.9632e+56, -11.529, 52599.6 * 4184.0) }
+    std::multimap<double, Arrhenius3> rates {
+        { 0.01*101325, Arrhenius3(1.2124e+16, -0.5779, 10872.7 * 4184.0) },
+        { 10.0*101325, Arrhenius3(1e15, -1, 10000 * 4184.0) },
+        { 10.0*101325, Arrhenius3(-2e20, -2.0, 20000 * 4184.0) },
+        { 100.0*101325, Arrhenius3(5.9632e+56, -11.529, 52599.6 * 4184.0) }
     };
 
     auto R = make_shared<Reaction>(reac, prod, make_shared<PlogRate>(rates));

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -289,9 +289,9 @@ TEST(Reaction, BlowersMaselFromYaml)
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), -38.7);
     EXPECT_DOUBLE_EQ(rate->activationEnergy(), E_intrinsic);
     EXPECT_DOUBLE_EQ(rate->bondEnergy(), w);
-    EXPECT_DOUBLE_EQ(rate->activationEnergy_R(H_big_R), H_big_R);
-    EXPECT_DOUBLE_EQ(rate->activationEnergy_R(H_small_R), 0);
-    EXPECT_NEAR(rate->activationEnergy_R(H_mid_R), Ea / GasConstant, 1e-7);
+    EXPECT_DOUBLE_EQ(rate->effectiveActivationEnergy_R(H_big_R), H_big_R);
+    EXPECT_DOUBLE_EQ(rate->effectiveActivationEnergy_R(H_small_R), 0);
+    EXPECT_NEAR(rate->effectiveActivationEnergy_R(H_mid_R), Ea / GasConstant, 1e-7);
     EXPECT_TRUE(rate->allowNegativePreExponentialFactor());
     EXPECT_FALSE(R->allow_negative_orders);
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The clear separation of `ArrheniusBase` and `ArrheniusRate` introduced in #1184 created an opening for the creation of class templates that can be further developed in #1181. Specifically, this PR introduces `BulkRate<RateType,DataType>`, along with stripped-down classes `Arrhenius3`,  `TwoTempPlasma` and `BlowersMasel`.

The pre-existing classes are now defined as `typedef`'s as:
```C++
typedef BulkRate<Arrhenius3, ArrheniusData> ArrheniusRate;
typedef BulkRate<BlowersMasel, BlowersMaselData> BlowersMaselRate;
typedef BulkRate<TwoTempPlasma, TwoTempPlasmaData> TwoTempPlasmaRate;
```

Beyond, additional streamlining targets the elimination of `TwoTempPlasmaReaction`, as well as some updates in `test_reaction.py`.

It is anticipated that the definition of  `Arrhenius3` and `BlowersMasel` will facilitate the introduction of class templates `InterfaceRate<>` and `StickingRate<>` in #1181. In addition, there is a potential use of `Arrhenius3` for a `ThreeBodyRate<>` template in a future resolution of Cantera/enhancements#133.

Also: eliminate multiple inheritance; while this allowed avoiding several `virtual` methods, multiple inheritance in combination with templates resulted in a small speed penalty, although the origin is inconclusive. While elimination of multiple inheritance shows a small improvement, tests on windows/MSVC indicate that #1184 did not introduce any noticeable regressions.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
