### PR TITLE
[SCons] Change prefix default if conda is detected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -313,9 +313,8 @@ jobs:
           cython boost-cpp fmt eigen yaml-cpp h5py pandas libgomp openblas pytest
       - name: Build Cantera
         run: |
-          scons build extra_inc_dirs=$CONDA_PREFIX/include:$CONDA_PREFIX/include/eigen3 \
-          extra_lib_dirs=$CONDA_PREFIX/lib system_fmt=y system_eigen=y system_yamlcpp=y \
-          system_sundials=y blas_lapack_libs='lapack,blas' -j2 VERBOSE=True debug=n \
+          scons build system_fmt=y system_eigen=y system_yamlcpp=y system_sundials=y \
+          blas_lapack_libs='lapack,blas' -j2 VERBOSE=True debug=n \
           optimize_flags='-O3 -ffast-math -fno-finite-math-only'
       - name: Test Cantera
         run: scons test show_long_tests=yes verbose_tests=yes

--- a/SConstruct
+++ b/SConstruct
@@ -218,8 +218,10 @@ config_options = [
     PathOption(
         "prefix",
         """Set this to the directory where Cantera should be installed. If the Python
-           executable found during compilation is managed by 'conda', the
-           installation 'prefix' will default to the corresponding environment. On
+           executable found during compilation is managed by 'conda', the installation
+           'prefix' defaults to the corresponding environment and the 'conda' layout
+           will be used for installation (specifying any of the options 'prefix',
+           'python_prefix', 'python_cmd' or 'layout' will override this default). On
            Windows systems, '$ProgramFiles' typically refers to "C:\Program Files".""",
         {"Windows": "$ProgramFiles\Cantera", "default": "/usr/local"},
         PathVariable.PathAccept),
@@ -485,12 +487,16 @@ config_options = [
     Option(
         "extra_inc_dirs",
         """Additional directories to search for header files, with multiple
-           directories separated by colons (*nix, macOS) or semicolons (Windows)""",
+           directories separated by colons (*nix, macOS) or semicolons (Windows).
+           If an active 'conda' environment is detected, the corresponding include
+           path is automatically added.""",
         ""),
     Option(
         "extra_lib_dirs",
         """Additional directories to search for libraries, with multiple
-           directories separated by colons (*nix, macOS) or semicolons (Windows)""",
+           directories separated by colons (*nix, macOS) or semicolons (Windows).
+           If an active 'conda' environment is detected, the corresponding library
+           path is automatically added.""",
         ""),
     PathOption(
         "boost_inc_dir",
@@ -552,12 +558,15 @@ config_options = [
         """The layout of the directory structure. 'standard' installs files to
            several subdirectories under 'prefix', for example, 'prefix/bin',
            'prefix/include/cantera', 'prefix/lib' etc. This layout is best used in
-           conjunction with "prefix='/usr/local'". 'compact' puts all installed
-           files in the subdirectory defined by 'prefix'. This layout is best
-           with a prefix like '/opt/cantera'. 'debian' installs to the stage
-           directory in a layout used for generating Debian packages. If the Python
-           executable found during compilation is managed by 'conda', the layout
-           will default to 'conda' irrespective of operating system.""",
+           conjunction with "prefix='/usr/local'". 'compact' puts all installed files
+           in the subdirectory defined by 'prefix'. This layout is best with a prefix
+           like '/opt/cantera'. 'debian' installs to the stage directory in a layout
+           used for generating Debian packages. If the Python executable found during
+           compilation is managed by 'conda', the layout will default to 'conda'
+           irrespective of operating system. For the 'conda' layout, the Python package
+           as well as all libraries and header files are installed into the active
+           'conda' environment. Input data, samples, and other files are installed in
+           the 'shared/cantera' subdirectory of the active 'conda' environment.""",
         {"Windows": "compact", "default": "standard"},
         ("standard", "compact", "debian", "conda")),
     BoolOption(


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The default installation `prefix` is changed only when:

1. `prefix` is not set AND
2. `python_prefix` is not set AND
3. `python_cmd` is not set AND
4. `$CONDA_PREFIX` is set AND
5. the Python running SCons is located in `$CONDA_PREFIX`

**Also:** add `conda` include/library folders if conda is used (as long as `extra_inc_dirs` and `extra_lib_dirs` are not set.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#76

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
[...]
postInstallMessage(["finish_install"], [])

Cantera has been successfully installed.

File locations:

  applications                C:\Users\<user>\miniconda3\envs\cantera-dev\Scripts
  library files               C:\Users\<user>\miniconda3\envs\cantera-dev\Library\lib
  C++ headers                 C:\Users\<user>\miniconda3\envs\cantera-dev\Library\include
  samples                     C:\Users\<user>\miniconda3\envs\cantera-dev\share\cantera\samples
  data files                  C:\Users\<user>\miniconda3\envs\cantera-dev\share\cantera\data
  Python package (cantera)    C:\Users\<user>\miniconda3\envs\cantera-dev\Lib\site-packages
  Python samples              C:\Users\<user>\miniconda3\envs\cantera-dev\Lib\site-packages\cantera\examples

scons: done building targets.
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review