### PR TITLE
Translate warnings to Python

### DIFF
--- a/License.txt
+++ b/License.txt
@@ -6,7 +6,7 @@ Copyright (c) 2009 Sandia Corporation. Under the terms of
 Contract AC04-94AL85000 with Sandia Corporation, the U.S. Government
 retains certain rights in this software.
 
-Copyright (c) 2011-2021, Cantera Developers.
+Copyright (c) 2011-2022, Cantera Developers.
 All rights reserved.
 
 Redistribution and use in source and binary forms, with or without

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -116,7 +116,7 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Cantera'
-copyright = '2001-2021, Cantera Developers'
+copyright = "2001-2022, Cantera Developers"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -195,6 +195,22 @@ void writeline(char repeat, size_t count,
 //! helper function passing deprecation warning to global handler
 void _warn_deprecated(const std::string& method, const std::string& extra="");
 
+//! Print a deprecation warning raised from *method*. @see Application::warn_deprecated
+/*!
+ * @param method  method name
+ * @param msg  Python-style format string with the following arguments
+ * @param args  arguments for the format string
+ */
+template <typename... Args>
+void warn_deprecated(const std::string& method, const std::string& msg,
+                     const Args&... args) {
+    if (sizeof...(args) == 0) {
+        _warn_deprecated(method, msg);
+    } else {
+        _warn_deprecated(method, fmt::format(msg, args...));
+    }
+}
+
 //! @copydoc Application::suppress_deprecation_warnings
 void suppress_deprecation_warnings();
 
@@ -232,22 +248,6 @@ void warn_user(const std::string& method, const std::string& msg,
         _warn("Cantera", method, msg);
     } else {
         _warn("Cantera", method, fmt::format(msg, args...));
-    }
-}
-
-//! Print a deprecation warning raised from *method*. @see Application::warn_deprecated
-/*!
- * @param method  method name
- * @param msg  Python-style format string with the following arguments
- * @param args  arguments for the format string
- */
-template <typename... Args>
-void warn_deprecated(const std::string& method, const std::string& msg,
-                     const Args&... args) {
-    if (sizeof...(args) == 0) {
-        _warn_deprecated(method, msg);
-    } else {
-        _warn_deprecated(method, fmt::format(msg, args...));
     }
 }
 

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -219,7 +219,7 @@ void warn(const std::string& warning, const std::string& method,
     }
 }
 
-//! Print a user warning raised from *method*.
+//! Print a user warning raised from *method* as `CanteraWarning`.
 /*!
  * @param method  method name
  * @param msg  Python-style format string with the following arguments
@@ -229,9 +229,9 @@ template <typename... Args>
 void warn_user(const std::string& method, const std::string& msg,
                const Args&... args) {
     if (sizeof...(args) == 0) {
-        _warn("User", method, msg);
+        _warn("Cantera", method, msg);
     } else {
-        _warn("User", method, fmt::format(msg, args...));
+        _warn("Cantera", method, fmt::format(msg, args...));
     }
 }
 

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -192,18 +192,35 @@ void writelogendl();
 void writeline(char repeat, size_t count,
                bool endl_after=true, bool endl_before=false);
 
-//! @copydoc Application::warn_deprecated
-void warn_deprecated(const std::string& method, const std::string& extra="");
+//! helper function passing deprecation warning to global handler
+void _warn_deprecated(const std::string& method, const std::string& extra="");
 
 //! @copydoc Application::suppress_deprecation_warnings
 void suppress_deprecation_warnings();
 
-//! helper function passing user warning to global handler
-void _warn_user(const std::string& method, const std::string& extra);
+//! helper function passing generic warning to global handler
+void _warn(const std::string& warning,
+           const std::string& method, const std::string& extra);
 
+//! Print a generic warning raised from *method*. @see Application::warn
 /*!
- * Print a user warning raised from *method*.
- *
+ * @param warning  type of warning; @see Logger::warn
+ * @param method  method name
+ * @param msg  Python-style format string with the following arguments
+ * @param args  arguments for the format string
+ */
+template <typename... Args>
+void warn(const std::string& warning, const std::string& method,
+          const std::string& msg, const Args&... args) {
+    if (sizeof...(args) == 0) {
+        _warn(warning, method, msg);
+    } else {
+        _warn(warning, method, fmt::format(msg, args...));
+    }
+}
+
+//! Print a user warning raised from *method*.
+/*!
  * @param method  method name
  * @param msg  Python-style format string with the following arguments
  * @param args  arguments for the format string
@@ -212,9 +229,25 @@ template <typename... Args>
 void warn_user(const std::string& method, const std::string& msg,
                const Args&... args) {
     if (sizeof...(args) == 0) {
-        _warn_user(method, msg);
+        _warn("User", method, msg);
     } else {
-        _warn_user(method, fmt::format(msg, args...));
+        _warn("User", method, fmt::format(msg, args...));
+    }
+}
+
+//! Print a deprecation warning raised from *method*. @see Application::warn_deprecated
+/*!
+ * @param method  method name
+ * @param msg  Python-style format string with the following arguments
+ * @param args  arguments for the format string
+ */
+template <typename... Args>
+void warn_deprecated(const std::string& method, const std::string& msg,
+                     const Args&... args) {
+    if (sizeof...(args) == 0) {
+        _warn_deprecated(method, msg);
+    } else {
+        _warn_deprecated(method, fmt::format(msg, args...));
     }
 }
 

--- a/include/cantera/base/logger.h
+++ b/include/cantera/base/logger.h
@@ -74,13 +74,7 @@ public:
      * @param msg      String message to be written to cout
      */
     virtual void warn(const std::string& warning, const std::string& msg) {
-
-        std::clog << warning << "Warning: " << msg;
-    }
-
-    //! Write an end of line character to the warning and flush output.
-    virtual void warnendl() {
-        std::clog << std::endl;
+        std::clog << warning << "Warning: " << msg << std::endl;
     }
 
     //! Write an error message and quit.

--- a/include/cantera/base/logger.h
+++ b/include/cantera/base/logger.h
@@ -67,6 +67,22 @@ public:
         std::cout << std::endl;
     }
 
+    //! Write a warning message.
+    /*!
+     * The default behavior is to write to the logging output.
+     * @param warning  String specifying type of warning; @see Logger::warn
+     * @param msg      String message to be written to cout
+     */
+    virtual void warn(const std::string& warning, const std::string& msg) {
+
+        std::clog << warning << "Warning: " << msg;
+    }
+
+    //! Write an end of line character to the warning and flush output.
+    virtual void warnendl() {
+        std::clog << std::endl;
+    }
+
     //! Write an error message and quit.
     /*!
      * The default behavior is to write to the standard error stream, and then

--- a/include/cantera/cython/wrappers.h
+++ b/include/cantera/cython/wrappers.h
@@ -63,8 +63,6 @@ public:
         }
     }
 
-    virtual void warnendl() {}
-
     virtual void error(const std::string& msg) {
         PyErr_SetString(PyExc_RuntimeError, msg.c_str());
     }

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -173,9 +173,6 @@ cdef extern from "cantera/base/global.h" namespace "Cantera":
     cdef XML_Node* CxxGetXmlFile "Cantera::get_XML_File" (string) except +translate_exception
     cdef XML_Node* CxxGetXmlFromString "Cantera::get_XML_from_string" (string) except +translate_exception
     cdef void Cxx_make_deprecation_warnings_fatal "Cantera::make_deprecation_warnings_fatal" ()
-    cdef void Cxx_make_warnings_fatal "Cantera::make_warnings_fatal" ()
-    cdef void Cxx_suppress_warnings "Cantera::suppress_warnings" ()
-    cdef cbool Cxx_warnings_suppressed "Cantera::warnings_suppressed" ()
     cdef void Cxx_suppress_deprecation_warnings "Cantera::suppress_deprecation_warnings" ()
     cdef void Cxx_suppress_thermo_warnings "Cantera::suppress_thermo_warnings" (cbool)
     cdef void Cxx_use_legacy_rate_constants "Cantera::use_legacy_rate_constants" (cbool)

--- a/interfaces/cython/cantera/examples/kinetics/custom_reactions.py
+++ b/interfaces/cython/cantera/examples/kinetics/custom_reactions.py
@@ -9,6 +9,7 @@ Requires: cantera >= 2.6.0
 from timeit import default_timer
 import numpy as np
 from math import exp
+import warnings
 
 import cantera as ct
 
@@ -29,9 +30,12 @@ custom_reactions[2] = ct.CustomReaction(
 gas1 = ct.Solution(thermo='ideal-gas', kinetics='gas',
                    species=species, reactions=custom_reactions)
 
-# old framework - use xml input
+# old framework - use xml input (to be removed after Cantera 2.6)
 
-gas2 = ct.Solution(mech.replace('.yaml', '.xml'))
+with warnings.catch_warnings():
+    # suppress warning: XML input is deprecated
+    warnings.simplefilter("ignore")
+    gas2 = ct.Solution(mech.replace(".yaml", ".xml"))
 
 # construct test case - simulate ignition
 

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -2,8 +2,10 @@ import itertools
 from pathlib import Path
 import logging
 import io
+import pytest
 
 from . import utilities
+from .utilities import allow_deprecated
 import cantera as ct
 from cantera import ck2cti, ck2yaml, cti2yaml, ctml2yaml
 
@@ -534,8 +536,10 @@ class ck2yamlTest(converterTestCommon, utilities.CanteraTest):
         with self.assertRaisesRegex(self.InputError, 'Element amounts can have no more than 3 digits.'):
             self.convert('big_element_num_err.inp')
 
+
+@pytest.mark.usefixtures("allow_deprecated")
 class CtmlConverterTest(utilities.CanteraTest):
-    @utilities.allow_deprecated
+
     def test_sofc(self):
         gas_a, anode_bulk, oxide_a = ct.import_phases(
             'sofc.cti',
@@ -546,14 +550,12 @@ class CtmlConverterTest(utilities.CanteraTest):
         self.assertNear(oxide_a.density_mole, 17.6)
 
     @utilities.slow_test
-    @utilities.allow_deprecated
     def test_diamond(self):
         gas, solid = ct.import_phases('diamond.cti', ['gas','diamond'])
         face = ct.Interface('diamond.cti', 'diamond_100', [gas, solid])
 
         self.assertNear(face.site_density, 3e-8)
 
-    @utilities.allow_deprecated
     def test_invalid(self):
         try:
             gas = ct.Solution('invalid.cti')
@@ -562,13 +564,11 @@ class CtmlConverterTest(utilities.CanteraTest):
 
         self.assertIn('already contains', err.args[0])
 
-    @utilities.allow_deprecated
     def test_noninteger_atomicity(self):
         gas = ct.Solution('noninteger-atomicity.cti')
         self.assertNear(gas.molecular_weights[gas.species_index('CnHm')],
                         10.65*gas.atomic_weight('C') + 21.8*gas.atomic_weight('H'))
 
-    @utilities.allow_deprecated
     def test_reaction_orders(self):
         gas = ct.Solution('reaction-orders.cti')
         self.assertEqual(gas.n_reactions, 1)
@@ -578,7 +578,6 @@ class CtmlConverterTest(utilities.CanteraTest):
         self.assertTrue(R.allow_negative_orders)
         self.assertNear(R.orders.get('H2'), -0.25)
 
-    @utilities.allow_deprecated
     def test_long_source_input(self):
         """
         Here we are testing if passing a very long string will result in a
@@ -593,7 +592,6 @@ class CtmlConverterTest(utilities.CanteraTest):
 
         self.assertEqual(gas.n_reactions, gas2.n_reactions)
 
-    @utilities.allow_deprecated
     def test_short_source_input(self):
         """
         Here we are testing if passing a short string will result in a Solution

--- a/interfaces/cython/cantera/test/test_jacobian.py
+++ b/interfaces/cython/cantera/test/test_jacobian.py
@@ -3,6 +3,7 @@ import pytest
 
 import cantera as ct
 from . import utilities
+from .utilities import has_temperature_derivative_warnings
 
 
 class RateExpressionTests:
@@ -481,15 +482,15 @@ class FromScratchCases(RateExpressionTests):
         cls.gas.TP = 2000, 5 * ct.one_atm
         super().setUpClass()
 
-    @utilities.has_temperature_derivative_warnings
+    @pytest.mark.usefixtures("has_temperature_derivative_warnings")
     def test_forward_rop_ddT(self):
         super().test_forward_rop_ddT()
 
-    @utilities.has_temperature_derivative_warnings
+    @pytest.mark.usefixtures("has_temperature_derivative_warnings")
     def test_reverse_rop_ddT(self):
         super().test_reverse_rop_ddT()
 
-    @utilities.has_temperature_derivative_warnings
+    @pytest.mark.usefixtures("has_temperature_derivative_warnings")
     def test_net_rop_ddT(self):
         super().test_net_rop_ddT()
 

--- a/interfaces/cython/cantera/test/test_jacobian.py
+++ b/interfaces/cython/cantera/test/test_jacobian.py
@@ -1,4 +1,5 @@
 import numpy as np
+import pytest
 
 import cantera as ct
 from . import utilities
@@ -478,17 +479,20 @@ class FromScratchCases(RateExpressionTests):
         #   species: [AR, O, H2, H, OH, O2, H2O, H2O2, HO2]
         cls.gas.X = [0.1, 3e-4, 5e-5, 6e-6, 3e-3, 0.6, 0.25, 1e-6, 2e-5]
         cls.gas.TP = 2000, 5 * ct.one_atm
-
-        # suppress user warning (e.g. temperature derivative of Blowers-Masel)
-        cls.warnings_suppressed = ct.warnings_suppressed()
-        ct.suppress_warnings()
-
         super().setUpClass()
 
-    @classmethod
-    def tearDownClass(cls):
-        if not cls.warnings_suppressed:
-            ct.make_warnings_fatal()
+    @utilities.has_temperature_derivative_warnings
+    def test_forward_rop_ddT(self):
+        super().test_forward_rop_ddT()
+
+    @utilities.has_temperature_derivative_warnings
+    def test_reverse_rop_ddT(self):
+        super().test_reverse_rop_ddT()
+
+    @utilities.has_temperature_derivative_warnings
+    def test_net_rop_ddT(self):
+        super().test_net_rop_ddT()
+
 
 class TestPlog(FromScratchCases, utilities.CanteraTest):
     # Plog reaction
@@ -510,15 +514,15 @@ class TestBlowersMasel(FromScratchCases, utilities.CanteraTest):
     equation = "H2 + O <=> H + OH"
     rate_type = "Blowers-Masel"
 
-    @utilities.unittest.skip("change of reaction enthalpy is not considered")
+    @pytest.mark.xfail(reason="Change of reaction enthalpy is not considered")
     def test_forward_rop_ddT(self):
         super().test_forward_rop_ddT()
 
-    @utilities.unittest.skip("change of reaction enthalpy is not considered")
+    @pytest.mark.xfail(reason="Change of reaction enthalpy is not considered")
     def test_reverse_rop_ddT(self):
         super().test_reverse_rop_ddT()
 
-    @utilities.unittest.skip("change of reaction enthalpy is not considered")
+    @pytest.mark.xfail(reason="Change of reaction enthalpy is not considered")
     def test_net_rop_ddT(self):
         super().test_net_rop_ddT()
 

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -2,6 +2,7 @@ import numpy as np
 import re
 import itertools
 import pkg_resources
+import pytest
 
 import cantera as ct
 from . import utilities
@@ -476,14 +477,11 @@ class KineticsRepeatability(utilities.CanteraTest):
                    "at T = 5000.0",
                    "at T = 10000.0",
                    "Sticking coefficient is greater than 1 for reaction",
-                   "CanteraError thrown by InterfaceReaction::validate:",
+                   "InterfaceReaction::validate:",
                    )
-        if not ct.debug_mode_enabled():
-            err_msg += ("CanteraError thrown by BlowersMaselInterfaceReaction::validate:",)
 
-        ct.make_warnings_fatal()
         for err in err_msg:
-            with self.assertRaisesRegex(ct.CanteraError, err):
+            with pytest.warns(UserWarning, match=err):
                 gas = ct.Solution('sticking_coeff_check.yaml')
                 surface = ct.Interface('sticking_coeff_check.yaml', 'Pt_surf', [gas])
 

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -6,6 +6,7 @@ import pytest
 
 import cantera as ct
 from . import utilities
+from .utilities import allow_deprecated
 
 # avoid explicit dependence of cantera on scipy
 try:
@@ -948,14 +949,14 @@ class TestDuplicateReactions(utilities.CanteraTest):
 
 class TestReaction(utilities.CanteraTest):
     @classmethod
-    def setUpClass(self):
+    def setUpClass(cls):
         utilities.CanteraTest.setUpClass()
-        self.gas = ct.Solution('h2o2.yaml', transport_model=None)
-        self.gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
-        self.gas.TP = 900, 2*ct.one_atm
-        self.species = ct.Species.list_from_file("h2o2.yaml")
+        cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
+        cls.gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
+        cls.gas.TP = 900, 2*ct.one_atm
+        cls.species = ct.Species.list_from_file("h2o2.yaml")
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_fromCti(self):
         r = ct.Reaction.fromCti('''three_body_reaction('2 O + M <=> O2 + M',
             [1.200000e+11, -1.0, 0.0], efficiencies='AR:0.83 H2:2.4 H2O:15.4')''')
@@ -969,7 +970,7 @@ class TestReaction(utilities.CanteraTest):
         self.assertIn('O2', r)
         self.assertNotIn('H2O', r)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_fromXml(self):
         import xml.etree.ElementTree as ET
         root = ET.parse(self.cantera_data_path / "h2o2.xml").getroot()
@@ -1005,7 +1006,7 @@ class TestReaction(utilities.CanteraTest):
         eq2 = [r.equation for r in self.gas.reactions()]
         self.assertEqual(eq1, eq2)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_listFromCti(self):
         gas = ct.Solution("h2o2.xml", transport_model=None)
         R = ct.Reaction.listFromCti((self.cantera_data_path / "h2o2.cti").read_text())
@@ -1013,7 +1014,7 @@ class TestReaction(utilities.CanteraTest):
         eq2 = [r.equation for r in gas.reactions()]
         self.assertEqual(eq1, eq2)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_listFromXml(self):
         gas = ct.Solution("h2o2.xml", transport_model=None)
         R = ct.Reaction.listFromXml((self.cantera_data_path / "h2o2.xml").read_text())

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -1,6 +1,8 @@
 import cantera as ct
 from . import utilities
 import numpy as np
+from .utilities import allow_deprecated
+import pytest
 
 from cantera.composite import _h5py
 
@@ -503,7 +505,7 @@ class TestFreeFlame(utilities.CanteraTest):
         # TODO: check that the solution is actually correct (i.e. that the
         # residual satisfies the error tolerances) on the new grid.
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_save_restore_xml(self):
         reactants = 'H2:1.1, O2:1, AR:5'
         p = 2 * ct.one_atm
@@ -647,7 +649,7 @@ class TestFreeFlame(utilities.CanteraTest):
                     getattr(self.sim, attr)
 
     @utilities.slow_test
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_save_restore_add_species_xml(self):
         reactants = 'H2:1.1, O2:1, AR:5'
         p = 2 * ct.one_atm
@@ -713,7 +715,7 @@ class TestFreeFlame(utilities.CanteraTest):
             self.assertArrayNear(Y1[k1], Y2[k2])
 
     @utilities.slow_test
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_save_restore_remove_species_xml(self):
         reactants = 'H2:1.1, O2:1, AR:5'
         p = 2 * ct.one_atm

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -5,6 +5,7 @@ import textwrap
 import cantera as ct
 import numpy as np
 from . import utilities
+from .utilities import has_temperature_derivative_warnings
 import pytest
 
 
@@ -214,7 +215,7 @@ class ReactionRateTests:
         with self.assertRaisesRegex(Exception, "not supported"):
             ct.ReactionRate.from_yaml(yaml)
 
-    @utilities.has_temperature_derivative_warnings
+    @pytest.mark.usefixtures("has_temperature_derivative_warnings")
     def test_derivative_ddT(self):
         # check temperature derivative against numerical derivative
         deltaT = self.gas.derivative_settings["rtol-delta"]
@@ -273,7 +274,7 @@ class TestArrheniusRate(ReactionRateTests, utilities.CanteraTest):
         with self.assertRaisesRegex(Exception, "not supported"):
             ct.ReactionRate.from_yaml(yaml)
 
-    @utilities.has_temperature_derivative_warnings
+    @pytest.mark.usefixtures("has_temperature_derivative_warnings")
     def test_derivative_ddT_exact(self):
         # check exact derivative against analytical and numerical derivatives
         rate = self.from_parts()
@@ -414,7 +415,7 @@ class FalloffRateTests(ReactionRateTests):
         for n in self._n_data:
             rate.falloff_coeffs = np.random.rand(n)
 
-    @utilities.has_temperature_derivative_warnings
+    @pytest.mark.usefixtures("has_temperature_derivative_warnings")
     def test_derivative_ddT(self):
         pert = self.gas.derivative_settings["rtol-delta"]
         deltaT = self.gas.T * pert

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -4,6 +4,8 @@ import gc
 
 import cantera as ct
 from . import utilities
+from .utilities import allow_deprecated
+import pytest
 
 
 class TestThermoPhase(utilities.CanteraTest):
@@ -1136,7 +1138,7 @@ class ImportTest(utilities.CanteraTest):
         self.assertEqual(gas.n_species, nSpec)
         self.assertEqual(gas.n_elements, nElem)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_import_phase_cti(self):
         gas1 = ct.Solution('air-no-reactions.cti', 'air')
         self.check(gas1, 'air', 300, 101325, 8, 3)
@@ -1144,13 +1146,13 @@ class ImportTest(utilities.CanteraTest):
         gas2 = ct.Solution('air-no-reactions.cti', 'notair')
         self.check(gas2, 'notair', 900, 5*101325, 7, 2)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_import_phase_cti2(self):
         # This should import the first phase, i.e. 'air'
         gas = ct.Solution('air-no-reactions.cti')
         self.check(gas, 'air', 300, 101325, 8, 3)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_import_phase_xml(self):
         gas1 = ct.Solution('air-no-reactions.xml', 'air')
         self.check(gas1, 'air', 300, 101325, 8, 3)
@@ -1158,7 +1160,7 @@ class ImportTest(utilities.CanteraTest):
         gas2 = ct.Solution('air-no-reactions.xml', 'notair')
         self.check(gas2, 'notair', 900, 5*101325, 7, 2)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_import_phase_cti_text(self):
         cti_def = """
 ideal_gas(name='spam', elements='O H',
@@ -1169,7 +1171,7 @@ ideal_gas(name='spam', elements='O H',
         gas = ct.Solution(source=cti_def)
         self.check(gas, 'spam', 350, 2e6, 8, 2)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_import_phase_xml_text(self):
         xml_def = """
 <?xml version="1.0"?>
@@ -1206,7 +1208,7 @@ ideal_gas(name='spam', elements='O H',
         self.assertNear(gas1.T, gas2.T)
         self.assertArrayNear(gas1.X, gas2.X)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_checkReactionBalance(self):
         with self.assertRaisesRegex(ct.CanteraError, 'reaction is unbalanced'):
             ct.Solution('h2o2_unbalancedReaction.xml')
@@ -1262,7 +1264,7 @@ class TestSpecies(utilities.CanteraTest):
             s = self.gas.species(name)
             self.assertEqual(s.name, name)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_fromCti(self):
         h2_cti = """
             species(
@@ -1291,7 +1293,7 @@ class TestSpecies(utilities.CanteraTest):
         self.assertEqual(s1.composition, s2.composition)
         self.assertEqual(s1.thermo.cp(350), s2.thermo.cp(350))
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_fromXml(self):
         import xml.etree.ElementTree as ET
         root = ET.parse(self.cantera_data_path / "h2o2.xml").getroot()
@@ -1305,12 +1307,12 @@ class TestSpecies(utilities.CanteraTest):
         self.assertEqual(s1.composition, s2.composition)
         self.assertEqual(s1.thermo.cp(350), s2.thermo.cp(350))
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_listFromFile_cti(self):
         S = ct.Species.listFromFile('h2o2.cti')
         self.assertEqual(S[3].name, self.gas.species_name(3))
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_listFromFile_xml(self):
         S = ct.Species.listFromFile('h2o2.xml')
         self.assertEqual(S[3].name, self.gas.species_name(3))
@@ -1319,7 +1321,7 @@ class TestSpecies(utilities.CanteraTest):
         S = ct.Species.list_from_file("h2o2.yaml")
         self.assertEqual({sp.name for sp in S}, set(self.gas.species_names))
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_listFromCti(self):
         S = ct.Species.listFromCti((self.cantera_data_path / "h2o2.cti").read_text())
         self.assertEqual(S[3].name, self.gas.species_name(3))
@@ -1368,7 +1370,7 @@ class TestSpecies(utilities.CanteraTest):
         self.assertEqual(species.composition, {'H': 2, 'O': 1})
         self.assertNear(species.thermo.h(300), 100)
 
-    @utilities.allow_deprecated
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_listFromXml(self):
         S = ct.Species.listFromXml((self.cantera_data_path / "h2o2.xml").read_text())
         self.assertEqual(S[4].name, self.gas.species_name(4))

--- a/interfaces/cython/cantera/test/test_transport.py
+++ b/interfaces/cython/cantera/test/test_transport.py
@@ -2,7 +2,9 @@ import numpy as np
 
 import cantera as ct
 from . import utilities
+from .utilities import allow_deprecated
 import copy
+import pytest
 
 
 class TestTransport(utilities.CanteraTest):
@@ -205,8 +207,10 @@ class TestTransport(utilities.CanteraTest):
         self.assertEqual(D12, D12new)
         self.assertEqual(D23, D23new)
 
+
+@pytest.mark.usefixtures("allow_deprecated")
 class TestIonTransport(utilities.CanteraTest):
-    @utilities.allow_deprecated
+
     def setUp(self):
         self.p = ct.one_atm
         self.T = 2237

--- a/interfaces/cython/cantera/test/utilities.py
+++ b/interfaces/cython/cantera/test/utilities.py
@@ -4,6 +4,7 @@ import warnings
 import tempfile
 import unittest
 from pathlib import Path, PurePath
+import pytest
 
 try:
     from ruamel import yaml
@@ -24,6 +25,14 @@ def allow_deprecated(test):
             test(*args, **kwargs)
         finally:
             cantera.make_deprecation_warnings_fatal()
+
+    return wrapper
+
+def has_temperature_derivative_warnings(test):
+    def wrapper(*args, **kwargs):
+        with pytest.warns(UserWarning, match="ddTScaledFromStruct"):
+            # test warning raised for BlowersMasel and TwoTempPlasma derivatives
+            test(*args, **kwargs)
 
     return wrapper
 

--- a/interfaces/cython/cantera/test/utilities.py
+++ b/interfaces/cython/cantera/test/utilities.py
@@ -18,23 +18,20 @@ slow_test = unittest.skipIf(environ.get("CT_SKIP_SLOW", "0") == "1", "slow test"
 TEST_DATA_PATH = Path(__file__).parent / "data"
 CANTERA_DATA_PATH = Path(__file__).parents[1] / "data"
 
-def allow_deprecated(test):
-    def wrapper(*args, **kwargs):
-        cantera.suppress_deprecation_warnings()
-        try:
-            test(*args, **kwargs)
-        finally:
-            cantera.make_deprecation_warnings_fatal()
 
-    return wrapper
+@pytest.fixture
+def allow_deprecated():
+    cantera.suppress_deprecation_warnings()
+    yield
+    cantera.make_deprecation_warnings_fatal()
 
-def has_temperature_derivative_warnings(test):
-    def wrapper(*args, **kwargs):
-        with pytest.warns(UserWarning, match="ddTScaledFromStruct"):
-            # test warning raised for BlowersMasel and TwoTempPlasma derivatives
-            test(*args, **kwargs)
 
-    return wrapper
+@pytest.fixture
+def has_temperature_derivative_warnings():
+    with pytest.warns(UserWarning, match="ddTScaledFromStruct"):
+        # test warning raised for BlowersMasel and TwoTempPlasma derivatives
+        yield
+
 
 def load_yaml(yml_file):
     # Load YAML data from file using the "safe" loading option.
@@ -47,6 +44,7 @@ def load_yaml(yml_file):
             # Ensure that  the loader remains backward-compatible with legacy
             # ruamel.yaml versions (prior to 0.17.0).
             return yaml.safe_load(stream)
+
 
 class CanteraTest(unittest.TestCase):
     @classmethod

--- a/interfaces/cython/cantera/utils.pyx
+++ b/interfaces/cython/cantera/utils.pyx
@@ -70,15 +70,6 @@ def make_deprecation_warnings_fatal():
                             message='.*Cantera.*')  # for warnings in Cython code
     Cxx_make_deprecation_warnings_fatal()
 
-def suppress_warnings(): # for warnings in C++ code
-    Cxx_suppress_warnings()
-
-def warnings_suppressed(): # for warnings in C++ code
-    return Cxx_warnings_suppressed()
-
-def make_warnings_fatal():# for warnings in Cython code
-    Cxx_make_warnings_fatal()
-
 def suppress_deprecation_warnings():
     warnings.filterwarnings('ignore', category=DeprecationWarning,
                             module='cantera')  # for warnings in Python code

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -97,6 +97,16 @@ void Application::Messages::writelogendl()
     logwriter->writeendl();
 }
 
+void Application::Messages::warnlog(const std::string& warning, const std::string& msg)
+{
+    logwriter->warn(warning, msg);
+}
+
+void Application::Messages::warnlogendl()
+{
+    logwriter->warnendl();
+}
+
 //! Mutex for access to string messages
 static std::mutex msg_mutex;
 
@@ -177,20 +187,21 @@ void Application::warn_deprecated(const std::string& method,
         return;
     }
     warnings.insert(method);
-    writelog(fmt::format("DeprecationWarning: {}: {}", method, extra));
-    writelogendl();
+    warnlog("Deprecation", fmt::format("{}: {}", method, extra));
+    warnlogendl();
 }
 
-void Application::warn_user(const std::string& method,
-                            const std::string& extra)
+void Application::warn(const std::string& warning,
+                       const std::string& method,
+                       const std::string& extra)
 {
     if (m_fatal_warnings) {
         throw CanteraError(method, extra);
     } else if (m_suppress_warnings) {
         return;
     }
-    writelog(fmt::format("CanteraWarning: {}: {}", method, extra));
-    writelogendl();
+    warnlog(warning, fmt::format("{}: {}", method, extra));
+    warnlogendl();
 }
 
 void Application::thread_complete()

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -102,11 +102,6 @@ void Application::Messages::warnlog(const std::string& warning, const std::strin
     logwriter->warn(warning, msg);
 }
 
-void Application::Messages::warnlogendl()
-{
-    logwriter->warnendl();
-}
-
 //! Mutex for access to string messages
 static std::mutex msg_mutex;
 
@@ -188,7 +183,6 @@ void Application::warn_deprecated(const std::string& method,
     }
     warnings.insert(method);
     warnlog("Deprecation", fmt::format("{}: {}", method, extra));
-    warnlogendl();
 }
 
 void Application::warn(const std::string& warning,
@@ -201,7 +195,6 @@ void Application::warn(const std::string& warning,
         return;
     }
     warnlog(warning, fmt::format("{}: {}", method, extra));
-    warnlogendl();
 }
 
 void Application::thread_complete()

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -145,9 +145,6 @@ protected:
          */
         void warnlog(const std::string& warning, const std::string& msg);
 
-        //! Write an end of line character to the screen and flush output
-        void warnlogendl();
-
         //! Install a logger.
         /*!
          * Called by the language interfaces to install an appropriate logger.
@@ -345,11 +342,6 @@ public:
     //! @copydoc Messages::warnlog
     void warnlog(const std::string& warning, const std::string& msg) {
         pMessenger->warnlog(warning, msg);
-    }
-
-    //! Write an endl to the screen and flush output
-    void warnlogendl() {
-        pMessenger->warnlogendl();
     }
 
     //! Print a warning indicating that *method* is deprecated. Additional

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -137,6 +137,17 @@ protected:
         //! Write an end of line character to the screen and flush output
         void writelogendl();
 
+        //!  Write a warning message to the screen.
+        /*!
+         * @param warning  String specifying type of warning; @see Logger::warn
+         * @param msg  String to be written to the screen
+         * @ingroup textlogs
+         */
+        void warnlog(const std::string& warning, const std::string& msg);
+
+        //! Write an end of line character to the screen and flush output
+        void warnlogendl();
+
         //! Install a logger.
         /*!
          * Called by the language interfaces to install an appropriate logger.
@@ -331,6 +342,16 @@ public:
         pMessenger->writelogendl();
     }
 
+    //! @copydoc Messages::warnlog
+    void warnlog(const std::string& warning, const std::string& msg) {
+        pMessenger->warnlog(warning, msg);
+    }
+
+    //! Write an endl to the screen and flush output
+    void warnlogendl() {
+        pMessenger->warnlogendl();
+    }
+
     //! Print a warning indicating that *method* is deprecated. Additional
     //! information (removal version, alternatives) can be specified in
     //! *extra*. Deprecation warnings are printed once per method per
@@ -350,9 +371,12 @@ public:
         m_fatal_deprecation_warnings = true;
     }
 
-    //! Print a user warning arising during usage of *method*. Additional
-    //! information can be specified in *extra*.
-    void warn_user(const std::string& method, const std::string& extra="");
+    //! Generate a general purpose warning; repeated warnings are not suppressed
+    //! @param warning  Warning type; @see Logger::warn
+    //! @param method  Name of method triggering the warning
+    //! @param extra  Additional information printed for the warning
+    void warn(const std::string& warning,
+              const std::string& method, const std::string& extra="");
 
     //! Globally disable printing of (user) warnings. Used primarily to
     //! prevent certain tests from failing.

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -55,14 +55,15 @@ void writeline(char repeat, size_t count, bool endl_after, bool endl_before)
     }
 }
 
-void warn_deprecated(const std::string& method, const std::string& extra)
+void _warn_deprecated(const std::string& method, const std::string& extra)
 {
     app()->warn_deprecated(method, extra);
 }
 
-void _warn_user(const std::string& method, const std::string& extra)
+void _warn(const std::string& warning,
+           const std::string& method, const std::string& extra)
 {
-    app()->warn_user(method, extra);
+    app()->warn(warning, method, extra);
 }
 
 void suppress_deprecation_warnings()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Translate warnings raised in C++ to Python warnings: `warn_deprecated` is raised as `DeprecationWarning` and `warn_user` is raised as `UserWarning` (on C++ the output is changed from `CanteraWarning` to `UserWarning` for consistency)
- Update year in License

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#136

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
>>> import cantera as ct
>>> gas = ct.Solution("h2o2.cti")
<stdin>:1: DeprecationWarning: XML_Node::build: 
The CTI and XML input file formats are deprecated and will be removed in
Cantera 3.0. Use 'cti2yaml.py' or 'ctml2yaml.py' to convert CTI or XML input
files to the YAML format. See https://cantera.org/tutorials/legacy2yaml.html
for more information.
```
and
```
>>> import warnings
>>> import cantera as ct
>>> with warnings.catch_warnings():
...     warnings.simplefilter("ignore")
...     gas = ct.Solution("gri30.cti")
... 
>>> gas
<cantera.composite.Solution object at 0x7f630d950dc0>
```

Another nice thing is that users will be pointed to the line in existing Python code where the warning is invoked, e.g.
```
In [1]: %run custom_reactions.py
/work/GitHub/cantera/interfaces/cython/cantera/examples/kinetics/custom_reactions.py:34: DeprecationWarning: XML_Node::build: 
The CTI and XML input file formats are deprecated and will be removed in
Cantera 3.0. Use 'cti2yaml.py' or 'ctml2yaml.py' to convert CTI or XML input
files to the YAML format. See https://cantera.org/tutorials/legacy2yaml.html
for more information.
```
(this is from an instance where a `DeprecationWarning` in an example was previously not caught by the test suite; this is also addressed in this PR)

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
