### PR TITLE
Deprecate redundant kinetics methods in Python API

### DIFF
--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -700,12 +700,6 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
         void resizeReactions()
 
         shared_ptr[CxxReaction] reaction(size_t) except +translate_exception
-        cbool isReversible(int) except +translate_exception
-        int reactionType(int) except +translate_exception
-        string reactionTypeStr(int) except +translate_exception
-        string reactionString(int) except +translate_exception
-        string reactantString(int) except +translate_exception
-        string productString(int) except +translate_exception
         double reactantStoichCoeff(int, int) except +translate_exception
         double productStoichCoeff(int, int) except +translate_exception
 

--- a/interfaces/cython/cantera/examples/onedim/flamespeed_sensitivity.py
+++ b/interfaces/cython/cantera/examples/onedim/flamespeed_sensitivity.py
@@ -34,4 +34,4 @@ print('Rxn #   k/S*dS/dk    Reaction Equation')
 print('-----   ----------   ----------------------------------')
 for m in range(gas.n_reactions):
     print('{: 5d}   {: 10.3e}   {}'.format(
-          m, sens[m], gas.reaction_equation(m)))
+          m, sens[m], gas.reaction(m).equation))

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -207,18 +207,18 @@ cdef class Kinetics(_SolutionBase):
         Type code of reaction ``i_reaction``.
 
         .. deprecated:: 2.6
-        """
-        warnings.warn("Behavior changes after Cantera 2.6, "
-                      "when function will return a type string. "
-                      "Use method 'reaction_type_str' during "
-                      "transition instead.", DeprecationWarning)
-        self._check_reaction_index(i_reaction)
-        return self.kinetics.reactionType(i_reaction)
 
-    def reaction_type_str(self, int i_reaction):
-        """Type of reaction ``i_reaction``."""
-        self._check_reaction_index(i_reaction)
-        return pystr(self.kinetics.reactionTypeStr(i_reaction))
+            Replaced by properties ``Reaction.type`` and/or ``Reaction.rate.type``.
+            Example: ``gas.reaction_type(0)`` is replaced by
+            ``gas.reaction(0).reaction_type``
+        """
+        rxn = self.reaction(i_reaction)
+        if not rxn.uses_legacy:
+            warnings.warn(
+                "Class method 'reaction_type' is deprecated and will be "
+                "removed after Cantera 2.6.\nReplaceable by property 'reaction_type' "
+                "of the corresponding reaction object.", DeprecationWarning)
+        return rxn.type
 
     def reaction_equation(self, int i_reaction):
         """The equation for the specified reaction. See also `reaction_equations`."""

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -176,9 +176,22 @@ cdef class Kinetics(_SolutionBase):
         self.kinetics.addReaction(rxn._reaction)
 
     def is_reversible(self, int i_reaction):
-        """True if reaction ``i_reaction`` is reversible."""
-        self._check_reaction_index(i_reaction)
-        return self.kinetics.isReversible(i_reaction)
+        """
+        True if reaction ``i_reaction`` is reversible.
+
+        .. deprecated:: 2.6
+
+            Replaced by property ``Reaction.reversible``.
+            Example: ``gas.is_reversible(0)`` is replaced by
+            ``gas.reaction(0).reversible``
+        """
+        rxn = self.reaction(i_reaction)
+        if not rxn.uses_legacy:
+            warnings.warn(
+                "Class method 'is_reversible' is deprecated and will be removed "
+                "after Cantera 2.6.\nReplaceable by property 'reversible' of the "
+                "corresponding\nreaction object.", DeprecationWarning)
+        return rxn.reversible
 
     def multiplier(self, int i_reaction):
         """
@@ -221,19 +234,56 @@ cdef class Kinetics(_SolutionBase):
         return rxn.type
 
     def reaction_equation(self, int i_reaction):
-        """The equation for the specified reaction. See also `reaction_equations`."""
-        self._check_reaction_index(i_reaction)
-        return pystr(self.kinetics.reactionString(i_reaction))
+        """
+        The equation for the specified reaction. See also `reaction_equations`.
+
+        .. deprecated:: 2.6
+
+            Replaced by property ``Reaction.equation``.
+            Example: ``gas.reaction_equation(0)`` is replaced by
+            ``gas.reaction(0).equation``
+        """
+        rxn = self.reaction(i_reaction)
+        if not rxn.uses_legacy:
+            warnings.warn(
+                "Class method 'reaction_equation' is deprecated and will be "
+                "removed after Cantera 2.6.\nReplaceable by property 'equation' of the "
+                "corresponding reaction object.", DeprecationWarning)
+        return rxn.equation
 
     def reactants(self, int i_reaction):
-        """The reactants portion of the reaction equation"""
-        self._check_reaction_index(i_reaction)
-        return pystr(self.kinetics.reactantString(i_reaction))
+        """
+        The reactants portion of the reaction equation
+
+        .. deprecated:: 2.6
+
+            Replaced by property ``Reaction.reactants``.
+            Example: ``gas.reactants(0)`` is replaced by ``gas.reaction(0).reactants``
+        """
+        rxn = self.reaction(i_reaction)
+        if not rxn.uses_legacy:
+            warnings.warn(
+                "Class method 'reactants' is deprecated and will be removed "
+                "after Cantera 2.6.\nReplaceable by property 'reactant_string' of "
+                "the corresponding reaction object.", DeprecationWarning)
+        return rxn.reactant_string
 
     def products(self, int i_reaction):
-        """The products portion of the reaction equation"""
-        self._check_reaction_index(i_reaction)
-        return pystr(self.kinetics.productString(i_reaction))
+        """
+        The products portion of the reaction equation
+
+        .. deprecated:: 2.6
+
+            Replaced by property ``Reaction.products``.
+            Example: ``gas.products(0)`` is replaced by ``gas.reaction(0).products``
+        """
+        rxn = self.reaction(i_reaction)
+        if not rxn.uses_legacy:
+            warnings.warn(
+                "Class method 'products' is deprecated and will be removed "
+                "after Cantera 2.6.\nReplaceable by property 'product_string' of "
+                "the corresponding reaction object.", DeprecationWarning)
+        return rxn.product_string
 
     def reaction_equations(self, indices=None):
         """
@@ -249,9 +299,9 @@ cdef class Kinetics(_SolutionBase):
         See also `reaction_equation`.
         """
         if indices is None:
-            return [self.reaction_equation(i) for i in range(self.n_reactions)]
+            return [self.reaction(i).equation for i in range(self.n_reactions)]
         else:
-            return [self.reaction_equation(i) for i in indices]
+            return [self.reaction(i).equation for i in indices]
 
     def reactant_stoich_coeff(self, k_spec, int i_reaction):
         """

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -186,11 +186,10 @@ cdef class Kinetics(_SolutionBase):
             ``gas.reaction(0).reversible``
         """
         rxn = self.reaction(i_reaction)
-        if not rxn.uses_legacy:
-            warnings.warn(
-                "Class method 'is_reversible' is deprecated and will be removed "
-                "after Cantera 2.6.\nReplaceable by property 'reversible' of the "
-                "corresponding\nreaction object.", DeprecationWarning)
+        warnings.warn(
+            "Class method 'is_reversible' is deprecated and will be removed "
+            "after Cantera 2.6.\nReplaceable by property 'reversible' of the "
+            "corresponding\nreaction object.", DeprecationWarning)
         return rxn.reversible
 
     def multiplier(self, int i_reaction):
@@ -221,16 +220,17 @@ cdef class Kinetics(_SolutionBase):
 
         .. deprecated:: 2.6
 
-            Replaced by properties ``Reaction.type`` and/or ``Reaction.rate.type``.
+            Replaced by properties ``Reaction.type`` and/ ``Reaction.rate.type``.
             Example: ``gas.reaction_type(0)`` is replaced by
-            ``gas.reaction(0).reaction_type``
+            ``gas.reaction(0).reaction_type`` and ``gas.reaction(0).rate.type``
         """
         rxn = self.reaction(i_reaction)
         if not rxn.uses_legacy:
             warnings.warn(
                 "Class method 'reaction_type' is deprecated and will be "
                 "removed after Cantera 2.6.\nReplaceable by property 'reaction_type' "
-                "of the corresponding reaction object.", DeprecationWarning)
+                "of the corresponding reaction object (or property 'type' of the\n"
+                "associated 'rate').", DeprecationWarning)
         return rxn.type
 
     def reaction_equation(self, int i_reaction):
@@ -244,11 +244,10 @@ cdef class Kinetics(_SolutionBase):
             ``gas.reaction(0).equation``
         """
         rxn = self.reaction(i_reaction)
-        if not rxn.uses_legacy:
-            warnings.warn(
-                "Class method 'reaction_equation' is deprecated and will be "
-                "removed after Cantera 2.6.\nReplaceable by property 'equation' of the "
-                "corresponding reaction object.", DeprecationWarning)
+        warnings.warn(
+            "Class method 'reaction_equation' is deprecated and will be "
+            "removed after Cantera 2.6.\nReplaceable by property 'equation' of the "
+            "corresponding reaction object.", DeprecationWarning)
         return rxn.equation
 
     def reactants(self, int i_reaction):
@@ -261,11 +260,10 @@ cdef class Kinetics(_SolutionBase):
             Example: ``gas.reactants(0)`` is replaced by ``gas.reaction(0).reactants``
         """
         rxn = self.reaction(i_reaction)
-        if not rxn.uses_legacy:
-            warnings.warn(
-                "Class method 'reactants' is deprecated and will be removed "
-                "after Cantera 2.6.\nReplaceable by property 'reactant_string' of "
-                "the corresponding reaction object.", DeprecationWarning)
+        warnings.warn(
+            "Class method 'reactants' is deprecated and will be removed "
+            "after Cantera 2.6.\nReplaceable by property 'reactant_string' of "
+            "the corresponding reaction object.", DeprecationWarning)
         return rxn.reactant_string
 
     def products(self, int i_reaction):
@@ -278,11 +276,10 @@ cdef class Kinetics(_SolutionBase):
             Example: ``gas.products(0)`` is replaced by ``gas.reaction(0).products``
         """
         rxn = self.reaction(i_reaction)
-        if not rxn.uses_legacy:
-            warnings.warn(
-                "Class method 'products' is deprecated and will be removed "
-                "after Cantera 2.6.\nReplaceable by property 'product_string' of "
-                "the corresponding reaction object.", DeprecationWarning)
+        warnings.warn(
+            "Class method 'products' is deprecated and will be removed "
+            "after Cantera 2.6.\nReplaceable by property 'product_string' of "
+            "the corresponding reaction object.", DeprecationWarning)
         return rxn.product_string
 
     def reaction_equations(self, indices=None):

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -181,15 +181,15 @@ cdef class Kinetics(_SolutionBase):
 
         .. deprecated:: 2.6
 
-            Replaced by property ``Reaction.reversible``.
+            Replaced by property `Reaction.reversible`.
             Example: ``gas.is_reversible(0)`` is replaced by
             ``gas.reaction(0).reversible``
         """
         rxn = self.reaction(i_reaction)
         warnings.warn(
-            "Class method 'is_reversible' is deprecated and will be removed "
-            "after Cantera 2.6.\nReplaceable by property 'reversible' of the "
-            "corresponding\nreaction object.", DeprecationWarning)
+            "'is_reversible' is deprecated and will be removed after Cantera 2.6.\n"
+            "Replaceable by property 'reversible' of the corresponding "
+            "reaction object.", DeprecationWarning)
         return rxn.reversible
 
     def multiplier(self, int i_reaction):
@@ -220,16 +220,16 @@ cdef class Kinetics(_SolutionBase):
 
         .. deprecated:: 2.6
 
-            Replaced by properties ``Reaction.type`` and/ ``Reaction.rate.type``.
+            Replaced by properties `Reaction.type` and `Reaction.rate.type`.
             Example: ``gas.reaction_type(0)`` is replaced by
             ``gas.reaction(0).reaction_type`` and ``gas.reaction(0).rate.type``
         """
         rxn = self.reaction(i_reaction)
         if not rxn.uses_legacy:
             warnings.warn(
-                "Class method 'reaction_type' is deprecated and will be "
-                "removed after Cantera 2.6.\nReplaceable by property 'reaction_type' "
-                "of the corresponding reaction object (or property 'type' of the\n"
+                "'reaction_type' is deprecated and will be removed after "
+                "Cantera 2.6.\nReplaceable by property 'reaction_type' of the "
+                "corresponding reaction object (or property 'type' of the\n"
                 "associated 'rate').", DeprecationWarning)
         return rxn.type
 
@@ -239,15 +239,15 @@ cdef class Kinetics(_SolutionBase):
 
         .. deprecated:: 2.6
 
-            Replaced by property ``Reaction.equation``.
+            Replaced by property `Reaction.equation`.
             Example: ``gas.reaction_equation(0)`` is replaced by
             ``gas.reaction(0).equation``
         """
         rxn = self.reaction(i_reaction)
         warnings.warn(
-            "Class method 'reaction_equation' is deprecated and will be "
-            "removed after Cantera 2.6.\nReplaceable by property 'equation' of the "
-            "corresponding reaction object.", DeprecationWarning)
+            "'reaction_equation' is deprecated and will be removed after "
+            "Cantera 2.6.\nReplaceable by property 'equation' of the corresponding "
+            "reaction object.", DeprecationWarning)
         return rxn.equation
 
     def reactants(self, int i_reaction):
@@ -256,14 +256,14 @@ cdef class Kinetics(_SolutionBase):
 
         .. deprecated:: 2.6
 
-            Replaced by property ``Reaction.reactants``.
+            Replaced by property `Reaction.reactants`.
             Example: ``gas.reactants(0)`` is replaced by ``gas.reaction(0).reactants``
         """
         rxn = self.reaction(i_reaction)
         warnings.warn(
-            "Class method 'reactants' is deprecated and will be removed "
-            "after Cantera 2.6.\nReplaceable by property 'reactant_string' of "
-            "the corresponding reaction object.", DeprecationWarning)
+            "'reactants' is deprecated and will be removed after Cantera 2.6.\n"
+            "Replaceable by property 'reactant_string' of the corresponding "
+            "reaction object.", DeprecationWarning)
         return rxn.reactant_string
 
     def products(self, int i_reaction):
@@ -272,14 +272,14 @@ cdef class Kinetics(_SolutionBase):
 
         .. deprecated:: 2.6
 
-            Replaced by property ``Reaction.products``.
+            Replaced by property `Reaction.products`.
             Example: ``gas.products(0)`` is replaced by ``gas.reaction(0).products``
         """
         rxn = self.reaction(i_reaction)
         warnings.warn(
-            "Class method 'products' is deprecated and will be removed "
-            "after Cantera 2.6.\nReplaceable by property 'product_string' of "
-            "the corresponding reaction object.", DeprecationWarning)
+            "'products' is deprecated and will be removed after Cantera 2.6.\n"
+            "Replaceable by property 'product_string' of the corresponding "
+            "reaction object.", DeprecationWarning)
         return rxn.product_string
 
     def reaction_equations(self, indices=None):
@@ -296,7 +296,7 @@ cdef class Kinetics(_SolutionBase):
         See also `reaction_equation`.
         """
         if indices is None:
-            return [self.reaction(i).equation for i in range(self.n_reactions)]
+            return list(r.equation for r in self.reactions())
         else:
             return [self.reaction(i).equation for i in indices]
 

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -875,8 +875,9 @@ cdef class Reaction:
         Create a `Reaction` object from its YAML string representation.
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by `Reaction.from_yaml`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by `Reaction.from_yaml`.
         """
         warnings.warn("Class method 'fromYaml' is renamed to 'from_yaml' "
             "and will be removed after Cantera 2.6.", DeprecationWarning)
@@ -1002,8 +1003,9 @@ cdef class Reaction:
         YAML string.
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by `Reaction.list_from_yaml`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by `Reaction.list_from_yaml`.
         """
         warnings.warn("Class method 'listFromYaml' is renamed to 'list_from_yaml' "
             "and will be removed after Cantera 2.6.", DeprecationWarning)
@@ -1175,8 +1177,9 @@ cdef class Reaction:
         pre-exponential factor.
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ArrheniusRate.allow_negative_pre_exponential_factor`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ArrheniusRate.allow_negative_pre_exponential_factor`.
         """
         def __get__(self):
             if self.uses_legacy:
@@ -1201,9 +1204,10 @@ cdef class Reaction:
         as a list of (pressure, rate) tuples.
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `PlogReaction` class. Replaced by ``Reaction.rate.rates`` for reactions
-              where the rate is a `PlogRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `PlogReaction` class. Replaced by ``Reaction.rate.rates`` for reactions
+            where the rate is a `PlogRate`.
         """
         def __get__(self):
             if isinstance(self.rate, PlogRate):
@@ -1226,9 +1230,10 @@ cdef class Reaction:
         Minimum temperature [K] for the Chebyshev fit
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `ChebyshevReaction` class. Replaced by ``Reaction.rate.temperature_range[0]``
-             for reactions where the rate is a a `ChebyshevRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `ChebyshevReaction` class. Replaced by ``Reaction.rate.temperature_range[0]``
+            for reactions where the rate is a a `ChebyshevRate`.
         """
         def __get__(self):
             if isinstance(self.rate, ChebyshevRate):
@@ -1245,9 +1250,10 @@ cdef class Reaction:
         Maximum temperature [K] for the Chebyshev fit
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `ChebyshevReaction` class. Replaced by ``Reaction.rate.temperature_range[1]``
-             for reactions where the rate is a a `ChebyshevRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `ChebyshevReaction` class. Replaced by ``Reaction.rate.temperature_range[1]``
+            for reactions where the rate is a a `ChebyshevRate`.
         """
         def __get__(self):
             if isinstance(self.rate, ChebyshevRate):
@@ -1264,9 +1270,10 @@ cdef class Reaction:
         Minimum pressure [Pa] for the Chebyshev fit
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `ChebyshevReaction` class. Replaced by ``Reaction.rate.pressure_range[0]``
-             for reactions where the rate is a a `ChebyshevRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `ChebyshevReaction` class. Replaced by ``Reaction.rate.pressure_range[0]``
+            for reactions where the rate is a a `ChebyshevRate`.
         """
         def __get__(self):
             if isinstance(self.rate, ChebyshevRate):
@@ -1283,9 +1290,10 @@ cdef class Reaction:
         Maximum pressure [K] for the Chebyshev fit
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `ChebyshevReaction` class. Replaced by ``Reaction.rate.pressure_range[1]``
-             for reactions where the rate is a a `ChebyshevRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `ChebyshevReaction` class. Replaced by ``Reaction.rate.pressure_range[1]``
+            for reactions where the rate is a a `ChebyshevRate`.
         """
         def __get__(self):
             if isinstance(self.rate, ChebyshevRate):
@@ -1302,9 +1310,10 @@ cdef class Reaction:
         Number of pressures over which the Chebyshev fit is computed
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `ChebyshevReaction` class. Replaced by `Reaction.rate.n_pressure`
-             for reactions where the rate is a a `ChebyshevRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `ChebyshevReaction` class. Replaced by `Reaction.rate.n_pressure`
+            for reactions where the rate is a a `ChebyshevRate`.
         """
         def __get__(self):
             if isinstance(self.rate, ChebyshevRate):
@@ -1321,9 +1330,10 @@ cdef class Reaction:
         Number of temperatures over which the Chebyshev fit is computed
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `ChebyshevReaction` class. Replaced by ``Reaction.rate.n_temperature``
-             for reactions where the rate is a a `ChebyshevRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `ChebyshevReaction` class. Replaced by ``Reaction.rate.n_temperature``
+            for reactions where the rate is a a `ChebyshevRate`.
         """
         def __get__(self):
             if isinstance(self.rate, ChebyshevRate):
@@ -1340,9 +1350,10 @@ cdef class Reaction:
         2D array of Chebyshev coefficients of size ``(n_temperature, n_pressure)``.
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `ChebyshevReaction` class. Replaced by ``Reaction.rate.data``
-             for reactions where the rate is a a `ChebyshevRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `ChebyshevReaction` class. Replaced by ``Reaction.rate.data``
+            for reactions where the rate is a a `ChebyshevRate`.
         """
         def __get__(self):
             if isinstance(self.rate, ChebyshevRate):
@@ -1359,9 +1370,10 @@ cdef class Reaction:
         `Pmax`, and `coeffs`.
 
         .. deprecated:: 2.6
-             This property is for temporary backwards-compatibility with the deprecated
-             `ChebyshevReaction` class. Replaced by `ChebyshevRate` constructor
-             for reactions where the rate is a a `ChebyshevRate`.
+
+            This property is for temporary backwards-compatibility with the deprecated
+            `ChebyshevReaction` class. Replaced by `ChebyshevRate` constructor
+            for reactions where the rate is a a `ChebyshevRate`.
         """
         cdef pair[double,double] Trange
         cdef pair[double,double] Prange
@@ -1378,6 +1390,7 @@ cdef class Reaction:
     def __call__(self, T, extra=None):
         """
         .. deprecated:: 2.6
+
             To be removed after Cantera 2.6.
             Replaced by `Reaction.rate(T)` or `Reaction.rate(T, P)`
         """
@@ -1539,6 +1552,7 @@ cdef class ElementaryReaction(Reaction):
         rate-constant: {A: 3.87e+04 cm^3/mol/s, b: 2.7, Ea: 6260.0 cal/mol}
 
     .. deprecated:: 2.6
+
         To be removed after Cantera 2.6. Capabilities merged directly into the base
         `Reaction` class.
     """
@@ -1615,8 +1629,9 @@ cdef class ElementaryReaction(Reaction):
         pre-exponential factor.
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ArrheniusRate.allow_negative_pre_exponential_factor`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ArrheniusRate.allow_negative_pre_exponential_factor`.
         """
         def __get__(self):
             if self.uses_legacy:
@@ -2012,8 +2027,9 @@ cdef class FalloffReaction(Reaction):
         pre-exponential factor.
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `FalloffRate.allow_negative_pre_exponential_factor`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `FalloffRate.allow_negative_pre_exponential_factor`.
         """
         def __get__(self):
             if self.uses_legacy:
@@ -2075,6 +2091,7 @@ cdef class PlogReaction(Reaction):
         - {P: 100.0 atm, A: 5.9632e+56, b: -11.529, Ea: 5.25996e+04 cal/mol}or.
 
     .. deprecated:: 2.6
+
             To be deprecated with version 2.6, and removed thereafter.
             Implemented by the `Reaction` class with a `PlogRate` reaction rate.
     """
@@ -2191,6 +2208,7 @@ cdef class ChebyshevReaction(Reaction):
         - [0.3177, 0.26889, 0.094806, -7.6385e-03]
 
     .. deprecated:: 2.6
+
         To be deprecated with version 2.6, and removed thereafter.
         Replaced by passing a `ChebyshevRate` object as the 'rate' argument to
         the 'Reaction' class.
@@ -2226,8 +2244,9 @@ cdef class ChebyshevReaction(Reaction):
         Minimum temperature [K] for the Chebyshev fit
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.temperature_range[0]`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ChebyshevRate.temperature_range[0]`.
         """
         def __get__(self):
             return self.cxx_object2().rate.Tmin()
@@ -2237,8 +2256,9 @@ cdef class ChebyshevReaction(Reaction):
         Maximum temperature [K] for the Chebyshev fit
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.temperature_range[1]`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ChebyshevRate.temperature_range[1]`.
         """
         def __get__(self):
             return self.cxx_object2().rate.Tmax()
@@ -2248,8 +2268,9 @@ cdef class ChebyshevReaction(Reaction):
         Minimum pressure [Pa] for the Chebyshev fit
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.pressure_range[0]`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ChebyshevRate.pressure_range[0]`.
         """
         def __get__(self):
             return self.cxx_object2().rate.Pmin()
@@ -2258,8 +2279,9 @@ cdef class ChebyshevReaction(Reaction):
         """ Maximum pressure [Pa] for the Chebyshev fit
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.pressure_range[1]`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ChebyshevRate.pressure_range[1]`.
         """
         def __get__(self):
             return self.cxx_object2().rate.Pmax()
@@ -2269,8 +2291,9 @@ cdef class ChebyshevReaction(Reaction):
         Number of pressures over which the Chebyshev fit is computed
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.n_pressure`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ChebyshevRate.n_pressure`.
         """
         def __get__(self):
             return self.cxx_object2().rate.nPressure()
@@ -2280,8 +2303,9 @@ cdef class ChebyshevReaction(Reaction):
         Number of temperatures over which the Chebyshev fit is computed
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.n_temperature`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ChebyshevRate.n_temperature`.
         """
         def __get__(self):
             return self.cxx_object2().rate.nTemperature()
@@ -2291,8 +2315,9 @@ cdef class ChebyshevReaction(Reaction):
         2D array of Chebyshev coefficients of size `(n_temperature, n_pressure)`.
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by property `ChebyshevRate.data`.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by property `ChebyshevRate.data`.
         """
         def __get__(self):
             cdef CxxChebyshevReaction2* r = self.cxx_object2()
@@ -2306,8 +2331,9 @@ cdef class ChebyshevReaction(Reaction):
         `coeffs`.
 
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaced by `ChebyshevRate` constructor.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaced by `ChebyshevRate` constructor.
         """
         cdef CxxChebyshevReaction2* r = self.cxx_object2()
 
@@ -2325,8 +2351,9 @@ cdef class ChebyshevReaction(Reaction):
     def __call__(self, float T, float P):
         """
         .. deprecated:: 2.6
-             To be deprecated with version 2.6, and removed thereafter.
-             Replaceable by call to `rate` property.
+
+            To be deprecated with version 2.6, and removed thereafter.
+            Replaceable by call to `rate` property.
         """
         cdef CxxChebyshevReaction2* r = self.cxx_object2()
         cdef double logT = np.log(T)

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1426,7 +1426,10 @@ cdef class Reaction:
         self.reaction.input.clear()
 
     def __repr__(self):
-        return f"<{self.__class__.__name__}: {self.equation}>"
+        if self.uses_legacy:
+            return f"<{self.__class__.__name__}: {self.equation}>"
+        else:
+            return f"{self.equation}    <{self.__class__.__name__}({self.rate.type})>"
 
     def __str__(self):
         return self.equation

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -659,8 +659,8 @@ class TestSolutionSerialization(utilities.CanteraTest):
         self.assertEqual(generated['phases'][0]['transport'], 'mixture-averaged')
         for i, species in enumerate(generated['species']):
             self.assertEqual(species['composition'], gas.species(i).composition)
-        for i, reaction in enumerate(generated['reactions']):
-            self.assertEqual(reaction['equation'], gas.reaction(i).equation)
+        for blessed, generated in zip(gas.reactions(), generated["reactions"]):
+            assert blessed.equation == generated["equation"]
 
         gas2 = ct.Solution("h2o2-generated.yaml")
         self.assertArrayNear(gas.concentrations, gas2.concentrations)

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -660,7 +660,7 @@ class TestSolutionSerialization(utilities.CanteraTest):
         for i, species in enumerate(generated['species']):
             self.assertEqual(species['composition'], gas.species(i).composition)
         for i, reaction in enumerate(generated['reactions']):
-            self.assertEqual(reaction['equation'], gas.reaction_equation(i))
+            self.assertEqual(reaction['equation'], gas.reaction(i).equation)
 
         gas2 = ct.Solution("h2o2-generated.yaml")
         self.assertArrayNear(gas.concentrations, gas2.concentrations)

--- a/interfaces/cython/cantera/test/test_jacobian.py
+++ b/interfaces/cython/cantera/test/test_jacobian.py
@@ -578,7 +578,7 @@ class FullTests:
                 drop_ = drop[i, ix] + dropp[i] * self.gas.P
                 self.assertArrayNear(drop_, drop_num[i, ix], self.rtol)
             except AssertionError as err:
-                print(i, self.gas.reaction(i).reaction_type)
+                print(i, self.gas.reaction(i).rate.type)
                 print(self.gas.reaction(i))
                 print(np.vstack([drop[i, ix], drop_num[i, ix]]).T)
                 raise err
@@ -596,7 +596,7 @@ class FullTests:
                 drop_ = drop[i, ix] + dropp[i] * self.gas.P
                 self.assertArrayNear(drop_, drop_num[i, ix], self.rtol)
             except AssertionError as err:
-                print(i, self.gas.reaction(i).reaction_type)
+                print(i, self.gas.reaction(i).rate.type)
                 print(self.gas.reaction(i))
                 print(np.vstack([drop[i, ix], drop_num[i, ix]]).T)
                 raise err
@@ -615,7 +615,7 @@ class FullTests:
                 self.assertArrayNear(drop_, drop_num[i, ix], self.rtol)
             except AssertionError as err:
                 if self.gas.reaction(i).reversible:
-                    print(i, self.gas.reaction(i).reaction_type)
+                    print(i, self.gas.reaction(i).rate.type)
                     print(self.gas.reaction(i))
                     print(np.vstack([drop[i, ix], drop_num[i, ix]]).T)
                     raise err
@@ -663,7 +663,7 @@ class FullTests:
             self.assertArrayNear(drop, drop_num, self.rtol)
         except AssertionError as err:
             i = np.argmax(2 * (drop - drop_num) / (drop + drop_num + 2e-4))
-            print(i, self.gas.reaction(i).reaction_type)
+            print(i, self.gas.reaction(i).rate.type)
             print(self.gas.reaction(i))
             print(drop[i])
             print(drop_num[i])

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -68,8 +68,7 @@ class TestKinetics(utilities.CanteraTest):
         ct.make_deprecation_warnings_fatal() # re-enable fatal deprecation warnings
 
         fwd_rates = self.phase.forward_rate_constants
-        ix_3b = np.array([self.phase.reaction(i).reaction_type == "three-body"
-            for i in range(self.phase.n_reactions)])
+        ix_3b = np.array([r.reaction_type == "three-body" for r in self.phase.reactions()])
         ix_other = ix_3b == False
 
         self.assertArrayNear(fwd_rates_legacy[ix_other], fwd_rates[ix_other])

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -29,7 +29,7 @@ class TestKinetics(utilities.CanteraTest):
 
     def test_is_reversible(self):
         for i in range(self.phase.n_reactions):
-            self.assertTrue(self.phase.is_reversible(i))
+            self.assertTrue(self.phase.reaction(i).reversible)
 
     def test_multiplier(self):
         fwd_rates0 = self.phase.forward_rates_of_progress
@@ -68,7 +68,7 @@ class TestKinetics(utilities.CanteraTest):
         ct.make_deprecation_warnings_fatal() # re-enable fatal deprecation warnings
 
         fwd_rates = self.phase.forward_rate_constants
-        ix_3b = np.array([self.phase.reaction_type_str(i) == "three-body"
+        ix_3b = np.array([self.phase.reaction(i).reaction_type == "three-body"
             for i in range(self.phase.n_reactions)])
         ix_other = ix_3b == False
 
@@ -76,19 +76,20 @@ class TestKinetics(utilities.CanteraTest):
         self.assertFalse((fwd_rates_legacy[ix_3b] == fwd_rates[ix_3b]).any())
 
     def test_reaction_type(self):
-        self.assertIn(self.phase.reaction_type_str(0), ["three-body", "three-body-legacy"])
-        self.assertIn(self.phase.reaction_type_str(2), ["reaction", "elementary-legacy"])
-        self.assertEqual(self.phase.reaction_type_str(21), "falloff")
+        self.assertIn(self.phase.reaction(0).reaction_type, "three-body")
+        self.assertIn(self.phase.reaction(2).reaction_type, "reaction")
+        self.assertIn(self.phase.reaction(2).rate.type, "Arrhenius")
+        self.assertEqual(self.phase.reaction(21).reaction_type, "falloff")
 
-        with self.assertRaisesRegex(ValueError, 'out of range'):
-            self.phase.reaction_type_str(33)
-        with self.assertRaisesRegex(ValueError, 'out of range'):
-            self.phase.reaction_type_str(-2)
+        with self.assertRaisesRegex(ct.CanteraError, "outside valid range"):
+            self.phase.reaction(33).reaction_type
+        with self.assertRaisesRegex(ct.CanteraError, "outside valid range"):
+            self.phase.reaction(-2).reaction_type
 
     def test_reaction_equations(self):
         self.assertEqual(self.phase.n_reactions,
                          len(self.phase.reaction_equations()))
-        r,p = [x.split() for x in self.phase.reaction_equation(18).split('<=>')]
+        r,p = [x.split() for x in self.phase.reaction(18).equation.split('<=>')]
         self.assertIn('H', r)
         self.assertIn('H2O2', r)
         self.assertIn('HO2', p)
@@ -96,10 +97,10 @@ class TestKinetics(utilities.CanteraTest):
 
     def test_reactants_products(self):
         for i in range(self.phase.n_reactions):
-            R = self.phase.reactants(i)
-            P = self.phase.products(i)
-            self.assertTrue(self.phase.reaction_equation(i).startswith(R))
-            self.assertTrue(self.phase.reaction_equation(i).endswith(P))
+            R = self.phase.reaction(i).reactant_string
+            P = self.phase.reaction(i).product_string
+            self.assertTrue(self.phase.reaction(i).equation.startswith(R))
+            self.assertTrue(self.phase.reaction(i).equation.endswith(P))
             for k in range(self.phase.n_species):
                 if self.phase.reactant_stoich_coeff(k,i) != 0:
                     self.assertIn(self.phase.species_name(k), R)

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -784,7 +784,7 @@ class ReactionTests:
         # helper function that checks evaluation of reaction rates
         ix = self._index
         if check_legacy:
-            self.assertEqual(gas2.reaction_type_str(0), self._rxn_type)
+            self.assertEqual(gas2.reaction(0).reaction_type, self._rxn_type)
         self.assertNear(gas2.forward_rate_constants[0],
                         self.gas.forward_rate_constants[ix])
         self.assertNear(gas2.net_rates_of_progress[0],

--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -1273,7 +1273,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
                 rname, comp = net.sensitivity_parameter_name(i).split(': ')
                 self.assertEqual(reactor.name, rname)
                 if kind == 'r':
-                    self.assertEqual(gas.reaction_equation(p), comp)
+                    self.assertEqual(gas.reaction(p).equation, comp)
                 elif kind == 's':
                     self.assertEqual(p + ' enthalpy', comp)
 
@@ -1335,7 +1335,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
                 r.add_sensitivity_reaction(p)
             S.append(integrate(rA1, net1))
 
-            pname = lambda r,i: '%s: %s' % (r.name, gas.reaction_equation(i))
+            pname = lambda r,i: '%s: %s' % (r.name, gas.reaction(i).equation)
             for i,(r,p) in enumerate(params1):
                 self.assertEqual(pname(r,p), net1.sensitivity_parameter_name(i))
 

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1649,8 +1649,8 @@ class TestSolutionArray(utilities.CanteraTest):
     def test_passthrough(self):
         states = ct.SolutionArray(self.gas, 3)
         self.assertEqual(states.n_species, self.gas.n_species)
-        self.assertEqual(states.reaction_equation(10),
-                         self.gas.reaction_equation(10))
+        self.assertEqual(states.reaction(10).equation,
+                         self.gas.reaction(10).equation)
 
     def test_meta(self):
         meta = {'foo': 'bar', 'spam': 'eggs'}


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Deprecate redundant / unpythonic methods that mimic the C-API (all alternative methods already exist):
  - `Kinetics.reaction_type(i)` -> `Kinetics.reaction(i).reaction_type`
  - `Kinetics.is_reversible(i)` -> `Kinetics.reaction(i).reversible`
  - `Kinetics.reaction_equation(i)` -> `Kinetics.reaction(i).equation`
  - `Kinetics.reactants(i)` -> `Kinetics.reaction(i).reactant_string`
  - `Kinetics.products(i)` -> `Kinetics.reaction(i).product_string`
- Improve rendering of `Reaction.__repr__`, where essential information was lost in #1183
- Fix indentation and blank lines for Sphinx docstring deprecation information

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

After #1183, several reactions no longer show specialized information (which is held by the `ReactionRate`), where specifically no identifiable information is shown for `Chebyshev` and `pressure-dependent-Arrhenius` (Plog) (as well as the new `Blowers-Masel` and `two-temperature-plasma` types), e.g.

```
in [1]: import cantera as ct
   ...: gas = ct.Solution("test/data/kineticsfromscratch.yaml")
   ...: gas.reactions()
Out[1]: 
[<Reaction: H2 + O <=> H + OH>,
 <ThreeBodyReaction: 2 O + M <=> O2 + M>,
 <FalloffReaction: 2 OH (+M) <=> H2O2 (+M)>,
 <Reaction: H2 + O2 <=> 2 OH>,
 <Reaction: HO2 <=> O + OH>,
 <ThreeBodyReaction: H + O2 + O2 <=> HO2 + O2>,
 <Reaction: H2 + O <=> H + OH>,
 <FalloffReaction: 2 OH (+M) <=> H2O2 (+M)>,
 <FalloffReaction: H + HO2 (+M) <=> H2 + O2 (+M)>,
 <FalloffReaction: H + HO2 (+M) <=> H2 + O2 (+M)>,
 <ChemicallyActivatedReaction: H2O + OH (+M) <=> H2 + HO2 (+M)>,
 <Reaction: H + O => H + O>,
 <Reaction: O + OH => O + OH>]
```

This PR reformats `Reaction.__repr__` to always include information for the rate specialization.

```
In [1]: import cantera as ct
   ...: gas = ct.Solution("test/data/kineticsfromscratch.yaml")
   ...: gas.reactions()
Out[1]: 
[H2 + O <=> H + OH    <Reaction(Arrhenius)>,
 2 O + M <=> O2 + M    <ThreeBodyReaction(Arrhenius)>,
 2 OH (+M) <=> H2O2 (+M)    <FalloffReaction(Troe)>,
 H2 + O2 <=> 2 OH    <Reaction(pressure-dependent-Arrhenius)>,
 HO2 <=> O + OH    <Reaction(Chebyshev)>,
 H + O2 + O2 <=> HO2 + O2    <ThreeBodyReaction(Arrhenius)>,
 H2 + O <=> H + OH    <Reaction(Blowers-Masel)>,
 2 OH (+M) <=> H2O2 (+M)    <FalloffReaction(Lindemann)>,
 H + HO2 (+M) <=> H2 + O2 (+M)    <FalloffReaction(SRI)>,
 H + HO2 (+M) <=> H2 + O2 (+M)    <FalloffReaction(Tsang)>,
 H2O + OH (+M) <=> H2 + HO2 (+M)    <ChemicallyActivatedReaction(Lindemann)>,
 H + O => H + O    <Reaction(two-temperature-plasma)>,
 O + OH => O + OH    <Reaction(two-temperature-plasma)>]
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
