### PR TITLE
Fix `SolutionArray` extra slice

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -617,14 +617,15 @@ class SolutionArray:
 
     def __getitem__(self, index):
         states = self._states[index]
+        extra = OrderedDict({key: val[index] for key, val in self._extra.items()})
         if(isinstance(states, list)):
             num_rows = len(states)
             if num_rows == 0:
                 states = None
-            return SolutionArray(self._phase, num_rows, states)
+            return SolutionArray(self._phase, num_rows, states, extra=extra)
         else:
             shape = states.shape[:-1]
-            return SolutionArray(self._phase, shape, states)
+            return SolutionArray(self._phase, shape, states, extra=extra)
 
     def __getattr__(self, name):
         if name in self._extra:

--- a/interfaces/cython/cantera/test/test_composite.py
+++ b/interfaces/cython/cantera/test/test_composite.py
@@ -224,6 +224,14 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertIn('X', collected)
         self.assertEqual(collected['X'].shape, (0, self.gas.n_species))
 
+    def test_getitem(self):
+        states = ct.SolutionArray(self.gas, 10, extra={"index": range(10)})
+        for ix, state in enumerate(states):
+            assert state.index == ix
+
+        assert list(states[:2].index) == [0, 1]
+        assert list(states[100:102].index) == [] # outside of range
+
     def test_append_state(self):
         gas = ct.Solution("h2o2.yaml")
         gas.TPX = 300, ct.one_atm, 'H2:0.5, O2:0.4'


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1203

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
In [1]: import cantera as ct
   ...: import numpy as np
   ...: 
   ...: gas = ct.Solution("gri30.yaml")
   ...: 
   ...: T = np.arange(900, 1000, 50)
   ...: estimated_ignition_delay_times = np.ones_like(T) * 0.005
   ...: ignition_delays = ct.SolutionArray(
   ...:     gas, shape=T.shape, extra={"tau": estimated_ignition_delay_times}
   ...: )
   ...: ignition_delays.TP = T, 40.0 * 101325.0
   ...: for state in ignition_delays:
   ...:     print(state.tau)
0.005
0.005
```
**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
