### PR TITLE
Add dilution options to equivalence ratio functions

### DIFF
--- a/interfaces/cython/cantera/examples/thermo/equivalenceRatio.py
+++ b/interfaces/cython/cantera/examples/thermo/equivalenceRatio.py
@@ -9,20 +9,23 @@ import cantera as ct
 
 gas = ct.Solution('gri30.yaml')
 
+# Define the oxidizer composition, here air with 21 mol-% O2 and 79 mol-% N2
+air = "O2:0.21,N2:0.79"
+
 # Set the mixture composition according to the stoichiometric mixture
 # (equivalence ratio phi = 1). The fuel composition in this example
-# is set to 100 mol-% CH4 and the oxidizer to 21 mol-% O2 and
-# 79 mol-% N2.
-gas.set_equivalence_ratio(phi=1.0, fuel="CH4:1", oxidizer="O2:0.21,N2:0.79")
+# is set to 100 mol-% CH4 and the oxidizer to 21 mol-% O2 and 79 mol-% N2.
+# This function changes the composition of the gas object and keeps temperature
+# and pressure constant
+gas.set_equivalence_ratio(phi=1.0, fuel="CH4:1", oxidizer=air)
 
-# The following is a short hand notation and equivalent to the call above
-gas.set_equivalence_ratio(1.0, "CH4", "O2:0.21,N2:0.79")
-
-# By default, the composition of fuel and oxidizer are interpreted as mole
+# if fuel or oxidizer consist of a single species, a short hand notation can be
+# used, for example fuel="CH4" is equivalent to fuel="CH4:1".
+# By default, the compositions of fuel and oxidizer are interpreted as mole
 # fractions. If the compositions are given in mass fractions, an
 # additional argument can be provided. Here, the fuel is 100 mass-% CH4
-# and the oxidizer is 23.3 mass-% O2 and 76.7 mass-% N2.
-gas.set_equivalence_ratio(1.0, "CH4", "O2:0.233,N2:0.767", basis='mass')
+# and the oxidizer is 23.3 mass-% O2 and 76.7 mass-% N2
+gas.set_equivalence_ratio(1.0, fuel="CH4:1", oxidizer="O2:0.233,N2:0.767", basis='mass')
 
 # This function can be used to compute the equivalence ratio for any mixture.
 # The first two arguments specify the compositions of the fuel and oxidizer.
@@ -30,7 +33,7 @@ gas.set_equivalence_ratio(1.0, "CH4", "O2:0.233,N2:0.767", basis='mass')
 # are provided in terms of mass or mole fractions. Default is mole fractions.
 # Note that for all functions shown here, the compositions are normalized
 # internally so the species fractions do not have to sum to unity
-phi = gas.equivalence_ratio(fuel="CH4", oxidizer="O2:233,N2:767", basis='mass')
+phi = gas.equivalence_ratio(fuel="CH4:1", oxidizer="O2:233,N2:767", basis='mass')
 print(f"phi = {phi:1.3f}")
 
 # If the compositions of fuel and oxidizer are unknown, the function can
@@ -45,13 +48,16 @@ print(f"phi = {phi:1.3f}")
 # The mixture fraction is always kg fuel / (kg fuel + kg oxidizer), independent
 # of the basis argument. For example, the mixture fraction Z can be computed as
 # follows. Again, the compositions by default are interpreted as mole fractions
-Z = gas.mixture_fraction(fuel="CH4", oxidizer="O2:0.21,N2:0.79")
+Z = gas.mixture_fraction(fuel="CH4:1", oxidizer=air)
 print(f"Z = {Z:1.3f}")
+
 # By default, the mixture fraction is the Bilger mixture fraction. Instead,
 # a mixture fraction based on a single element can be used. In this example,
 # the following two ways of computing Z are the same:
-Z = gas.mixture_fraction(fuel="CH4", oxidizer="O2:0.21,N2:0.79", element="Bilger")
-Z = gas.mixture_fraction(fuel="CH4", oxidizer="O2:0.21,N2:0.79", element="C")
+Z = gas.mixture_fraction(fuel="CH4:1", oxidizer=air, element="Bilger")
+print(f"Z(Bilger mixture fraction) = {Z:1.3f}")
+Z = gas.mixture_fraction(fuel="CH4:1", oxidizer=air, element="C")
+print(f"Z(mixture fraction based on C) = {Z:1.3f}")
 
 # Since the fuel in this example is pure methane and the oxidizer is air,
 # the mixture fraction is the same as the mass fraction of methane in the mixture
@@ -60,24 +66,24 @@ print(f"mass fraction of CH4 = {gas['CH4'].Y[0]:1.3f}")
 # To set a mixture according to the mixture fraction, the following function
 # can be used. In this example, the final fuel/oxidizer mixture
 # contains 5.5 mass-% CH4:
-Z = gas.set_mixture_fraction(0.055, fuel="CH4", oxidizer="O2:0.21,N2:0.79")
-print(f"mass fraction of CH4 = {gas['CH4'].Y[0]:1.3f}")
+gas.set_mixture_fraction(0.055, fuel="CH4:1", oxidizer=air)
+print(f"Z = {gas['CH4'].Y[0]:1.3f}")
 
 # Mixture fraction and equivalence ratio are invariant to the reaction progress.
 # For example, they stay constant if the mixture composition changes to the burnt
-# state or for any intermediate state
-fuel = "CH4:1"
-oxidizer = "O2:0.21,N2:0.79"
-gas.set_equivalence_ratio(1, fuel, oxidizer)
+# state or for any intermediate state. Fuel and oxidizer composition for all functions
+# shown in this example can be given as string, dictionary or numpy array
+fuel = {"CH4":1} # provide the fuel composition as dictionary instead of string
+gas.set_equivalence_ratio(1, fuel, air)
 gas.equilibrate('HP')
-phi_burnt = gas.equivalence_ratio(fuel, oxidizer)
-Z_burnt = gas.mixture_fraction(fuel, oxidizer)
+phi_burnt = gas.equivalence_ratio(fuel, air)
+Z_burnt = gas.mixture_fraction(fuel, air)
 print(f"phi(burnt) = {phi_burnt:1.3f}")
 print(f"Z(burnt) = {Z_burnt:1.3f}")
 
 # If fuel and oxidizer compositions are specified consistently, then
 # equivalence_ratio and set_equivalence_ratio are consistent as well, as
-# shown in the following example
+# shown in the following example with arbitrary fuel and oxidizer compositions:
 gas.set_equivalence_ratio(2.5, fuel="CH4:1,O2:0.01,CO:0.05,N2:0.1",
                           oxidizer="O2:0.2,N2:0.8,CO2:0.05,CH4:0.01")
 
@@ -98,20 +104,29 @@ print(f"phi = {phi:1.3f}")
 # hydrogen and oxygen and then dilute it with H2O. In this example, the final mixture
 # consists of 30 mol-% H2O and 70 mol-% of the H2/O2 mixture at phi=2
 gas.set_equivalence_ratio(2.0, "H2:1", "O2:1", diluent="H2O", fraction={"diluent":0.3})
-print(f"mole fraction of H2O = {gas['H2O'].X[0]:1.3f}") # final mixture contains 30 mol-% H2O
+print(f"mole fraction of H2O = {gas['H2O'].X[0]:1.3f}") # mixture contains 30 mol-% H2O
 print(f"ratio of H2/O2: {gas['H2'].X[0] / gas['O2'].X[0]:1.3f}") # according to phi=2
 
 # Another option is to specify the fuel or oxidizer fraction in the final mixture.
 # The following example creates a mixture with equivalence ratio 2 from pure
 # hydrogen and oxygen (same as above) and then dilutes it with a mixture of 50 mass-%
-# CO2 and 50 mass-% H2O so that the mass fraction of the fuel in the final mixture is 0.1
+# CO2 and 50 mass-% H2O so that the mass fraction of fuel in the final mixture is 0.1
 gas.set_equivalence_ratio(2.0, "H2", "O2", diluent="CO2:0.5,H2O:0.5",
                           fraction={"fuel":0.1}, basis="mass")
-print(f"mole fraction of H2O = {gas['H2'].Y[0]:1.3f}") # final mixture contains 10 mass-% fuel
+print(f"mole fraction of H2 = {gas['H2'].Y[0]:1.3f}") # mixture contains 10 mass-% fuel
 
 # To compute the equivalence ratio given a diluted mixture, a list of
 # species names can be provided which will be considered for computing phi.
 # In this example, the diluents H2O and CO2 are ignored and only H2 and O2 are
 # considered to get the equivalence ratio
 phi = gas.equivalence_ratio(fuel="H2", oxidizer="O2", include_species=["H2", "O2"])
+print(f"phi = {phi:1.3f}") # prints 2
+
+# If instead the diluent should be included in the computation of the equivalence ratio,
+# the mixture can be set in the following way. Assume the fuel is diluted with
+# 50 mol-% H2O:
+gas.set_equivalence_ratio(2.0, fuel="H2:0.5,H2O:0.5", oxidizer=air)
+
+# This creates a mixture with the specified equivalence ratio including the diluent:
+phi = gas.equivalence_ratio(fuel="H2:0.5,H2O:0.5", oxidizer=air)
 print(f"phi = {phi:1.3f}") # prints 2

--- a/interfaces/cython/cantera/examples/thermo/equivalenceRatio.py
+++ b/interfaces/cython/cantera/examples/thermo/equivalenceRatio.py
@@ -2,52 +2,115 @@
 This example demonstrates how to set a mixture according to equivalence ratio
 and mixture fraction.
 
-Requires: cantera >= 2.5.0
+Requires: cantera >= 2.6.0
 """
 
 import cantera as ct
 
 gas = ct.Solution('gri30.yaml')
 
-# fuel and oxidizer compositions
-fuel = "CH4"
-oxidizer = "O2:0.21,N2:0.79"
+# Set the mixture composition according to the stoichiometric mixture
+# (equivalence ratio phi = 1). The fuel composition in this example
+# is set to 100 mol-% CH4 and the oxidizer to 21 mol-% O2 and
+# 79 mol-% N2.
+gas.set_equivalence_ratio(phi=1.0, fuel="CH4:1", oxidizer="O2:0.21,N2:0.79")
 
-gas.TP = 300, ct.one_atm
+# The following is a short hand notation and equivalent to the call above
+gas.set_equivalence_ratio(1.0, "CH4", "O2:0.21,N2:0.79")
 
-# set the mixture composition according to the stoichiometric mixture
-# (equivalence ratio = 1)
-gas.set_equivalence_ratio(1, fuel, oxidizer)
+# By default, the composition of fuel and oxidizer are interpreted as mole
+# fractions. If the compositions are given in mass fractions, an
+# additional argument can be provided. Here, the fuel is 100 mass-% CH4
+# and the oxidizer is 23.3 mass-% O2 and 76.7 mass-% N2.
+gas.set_equivalence_ratio(1.0, "CH4", "O2:0.233,N2:0.767", basis='mass')
 
 # This function can be used to compute the equivalence ratio for any mixture.
-# An optional argument "basis" indicates if fuel and oxidizer compositions are
-# provided in terms of mass or mole fractions. Default is mole fractions.
-# If fuel and oxidizer are given in mass fractions, use basis='mass'
-phi = gas.equivalence_ratio(fuel, oxidizer)
+# The first two arguments specify the compositions of the fuel and oxidizer.
+# An optional third argument "basis" indicates if fuel and oxidizer compositions
+# are provided in terms of mass or mole fractions. Default is mole fractions.
+# Note that for all functions shown here, the compositions are normalized
+# internally so the species fractions do not have to sum to unity
+phi = gas.equivalence_ratio(fuel="CH4", oxidizer="O2:233,N2:767", basis='mass')
 print("phi = {:1.3f}".format(phi))
 
-# The equivalence ratio can also be computed from the elemental composition
-# assuming that there is no oxygen in the fuel and no C,H and S elements
-# in the oxidizer so that the composition of fuel and oxidizer can be omitted
+# If the compositions of fuel and oxidizer are unknown, the function can
+# be called without arguments. This assumes that all C, H and S atoms come from
+# the fuel and all O atoms from the oxidizer. In this example, the fuel was set
+# to be pre CH4 and the oxidizer O2:0.233,N2:0.767 so that the assumption is true
+# and the same equivalence ratio as above is computed
 phi = gas.equivalence_ratio()
-
-# In this example, the result is the same as above
 print("phi = {:1.3f}".format(phi))
 
-# the mixture fraction Z can be computed as follows:
-Z = gas.mixture_fraction(fuel, oxidizer)
+# Instead of working with equivalence ratio, mixture fraction can be used.
+# The mixture fraction is always kg fuel / (kg fuel + kg oxidizer), independent
+# of the basis argument. For example, the mixture fraction Z can be computed as
+# follows. Again, the compositions by default are interpreted as mole fractions
+Z = gas.mixture_fraction(fuel="CH4", oxidizer="O2:0.21,N2:0.79")
 print("Z = {:1.3f}".format(Z))
+# By default, the mixture fraction is the Bilger mixture fraction. Instead,
+# a mixture fraction based on a single element can be used. In this example,
+# the following two ways of computing Z are the same:
+Z = gas.mixture_fraction(fuel="CH4", oxidizer="O2:0.21,N2:0.79", element="Bilger")
+Z = gas.mixture_fraction(fuel="CH4", oxidizer="O2:0.21,N2:0.79", element="C")
 
-# The mixture fraction is kg fuel / (kg fuel + kg oxidizer). Since the fuel in
-# this example is pure methane and the oxidizer is air, the mixture fraction
-# is the same as the mass fraction of methane in the mixture
+# Since the fuel in this example is pure methane and the oxidizer is air,
+# the mixture fraction is the same as the mass fraction of methane in the mixture
+print("mass fraction of CH4 = {:1.3f}".format(gas["CH4"].Y[0]))
+
+# To set a mixture according to the mixture fraction, the following function
+# can be used. In this example, the final fuel/oxidizer mixture
+# contains 5.5 mass-% CH4:
+Z = gas.set_mixture_fraction(0.055, fuel="CH4", oxidizer="O2:0.21,N2:0.79")
 print("mass fraction of CH4 = {:1.3f}".format(gas["CH4"].Y[0]))
 
 # Mixture fraction and equivalence ratio are invariant to the reaction progress.
 # For example, they stay constant if the mixture composition changes to the burnt
-# state
+# state or for any intermediate state
+fuel = "CH4:1"
+oxidizer = "O2:0.21,N2:0.79"
+gas.set_equivalence_ratio(1, fuel, oxidizer)
 gas.equilibrate('HP')
 phi_burnt = gas.equivalence_ratio(fuel, oxidizer)
 Z_burnt = gas.mixture_fraction(fuel, oxidizer)
 print("phi(burnt) = {:1.3f}".format(phi_burnt))
 print("Z(burnt) = {:1.3f}".format(Z_burnt))
+
+# If fuel and oxidizer compositions are specified consistently, then
+# equivalence_ratio and set_equivalence_ratio are consistent as well, as
+# shown in the following example
+gas.set_equivalence_ratio(2.5,fuel="CH4:1,O2:0.01,CO:0.05,N2:0.1",
+        oxidizer="O2:0.2,N2:0.8,CO2:0.05,CH4:0.01")
+
+phi = gas.equivalence_ratio(fuel="CH4:1,O2:0.01,CO:0.05,N2:0.1",
+        oxidizer="O2:0.2,N2:0.8,CO2:0.05,CH4:0.01")
+print("phi = {:1.3f}".format(phi)) # prints 2.5
+
+# Without specifying the fuel and oxidizer compositions, it is assumed that
+# all C, H and S atoms come from the fuel and all O atoms from the oxidizer,
+# which is not true for this example. Therefore, the following call gives a
+# different equivalence ratio based on that assumption
+phi = gas.equivalence_ratio()
+print("phi = {:1.3f}".format(phi))
+
+# After computing the mixture composition for a certain equivalence ratio given
+# a fuel and mixture composition, the mixture can optionally be diluted. The
+# following function will first create a mixture with equivalence ratio 2 from pure
+# hydrogen and oxygen and then dilute it with H2O. In this example, the final mixture
+# consists of 30 mol-% H2O and 70 mol-% of the H2/O2 mixture at phi=2
+gas.set_equivalence_ratio(2.0, "H2:1", "O2:1", fraction={"diluent":0.3}, diluent="H2O")
+print("mole fraction of H2O = {:1.3f}".format(gas["H2O"].X[0])) # final mixture contains 30 mol-% H2O
+print("ratio of H2/O2: {:1.3f}".format(gas["H2"].X[0]/gas["O2"].X[0])) # according to phi=2
+
+# Another option is to specify the fuel or oxidizer fraction in the final mixture.
+# The following example creates a mixture with equivalence ratio 2 from pure
+# hydrogen and oxygen (same as above) and then dilutes it with a mixture of 50 mass-%
+# CO2 and 50 mass-% H2O so that the mass fraction of the fuel in the final mixture is 0.1
+gas.set_equivalence_ratio(2.0, "H2", "O2", fraction={"fuel":0.1}, diluent="CO2:0.5,H2O:0.5", basis="mass")
+print("mole fraction of H2O = {:1.3f}".format(gas["H2"].Y[0])) # final mixture contains 10 mass-% fuel
+
+# To compute the equivalence ratio given a diluted mixture, a list of
+# species names can be provided which will be considered for computing phi.
+# In this example, the diluents H2O and CO2 are ignored and only H2 and O2 are
+# considered to get the equivalence ratio
+phi = gas.equivalence_ratio(fuel="H2", oxidizer="O2", include_species=["H2","O2"])
+print("phi = {:1.3f}".format(phi)) # prints 2

--- a/interfaces/cython/cantera/examples/thermo/equivalenceRatio.py
+++ b/interfaces/cython/cantera/examples/thermo/equivalenceRatio.py
@@ -19,7 +19,7 @@ air = "O2:0.21,N2:0.79"
 # and pressure constant
 gas.set_equivalence_ratio(phi=1.0, fuel="CH4:1", oxidizer=air)
 
-# if fuel or oxidizer consist of a single species, a short hand notation can be
+# If fuel or oxidizer consist of a single species, a short hand notation can be
 # used, for example fuel="CH4" is equivalent to fuel="CH4:1".
 # By default, the compositions of fuel and oxidizer are interpreted as mole
 # fractions. If the compositions are given in mass fractions, an
@@ -67,11 +67,11 @@ print(f"mass fraction of CH4 = {gas['CH4'].Y[0]:1.3f}")
 # can be used. In this example, the final fuel/oxidizer mixture
 # contains 5.5 mass-% CH4:
 gas.set_mixture_fraction(0.055, fuel="CH4:1", oxidizer=air)
-print(f"Z = {gas['CH4'].Y[0]:1.3f}")
+print(f"mass fraction of CH4 = {gas['CH4'].Y[0]:1.3f}")
 
 # Mixture fraction and equivalence ratio are invariant to the reaction progress.
 # For example, they stay constant if the mixture composition changes to the burnt
-# state or for any intermediate state. Fuel and oxidizer composition for all functions
+# state or for any intermediate state. Fuel and oxidizer compositions for all functions
 # shown in this example can be given as string, dictionary or numpy array
 fuel = {"CH4":1} # provide the fuel composition as dictionary instead of string
 gas.set_equivalence_ratio(1, fuel, air)

--- a/interfaces/cython/cantera/examples/thermo/equivalenceRatio.py
+++ b/interfaces/cython/cantera/examples/thermo/equivalenceRatio.py
@@ -31,7 +31,7 @@ gas.set_equivalence_ratio(1.0, "CH4", "O2:0.233,N2:0.767", basis='mass')
 # Note that for all functions shown here, the compositions are normalized
 # internally so the species fractions do not have to sum to unity
 phi = gas.equivalence_ratio(fuel="CH4", oxidizer="O2:233,N2:767", basis='mass')
-print("phi = {:1.3f}".format(phi))
+print(f"phi = {phi:1.3f}")
 
 # If the compositions of fuel and oxidizer are unknown, the function can
 # be called without arguments. This assumes that all C, H and S atoms come from
@@ -39,14 +39,14 @@ print("phi = {:1.3f}".format(phi))
 # to be pre CH4 and the oxidizer O2:0.233,N2:0.767 so that the assumption is true
 # and the same equivalence ratio as above is computed
 phi = gas.equivalence_ratio()
-print("phi = {:1.3f}".format(phi))
+print(f"phi = {phi:1.3f}")
 
 # Instead of working with equivalence ratio, mixture fraction can be used.
 # The mixture fraction is always kg fuel / (kg fuel + kg oxidizer), independent
 # of the basis argument. For example, the mixture fraction Z can be computed as
 # follows. Again, the compositions by default are interpreted as mole fractions
 Z = gas.mixture_fraction(fuel="CH4", oxidizer="O2:0.21,N2:0.79")
-print("Z = {:1.3f}".format(Z))
+print(f"Z = {Z:1.3f}")
 # By default, the mixture fraction is the Bilger mixture fraction. Instead,
 # a mixture fraction based on a single element can be used. In this example,
 # the following two ways of computing Z are the same:
@@ -55,13 +55,13 @@ Z = gas.mixture_fraction(fuel="CH4", oxidizer="O2:0.21,N2:0.79", element="C")
 
 # Since the fuel in this example is pure methane and the oxidizer is air,
 # the mixture fraction is the same as the mass fraction of methane in the mixture
-print("mass fraction of CH4 = {:1.3f}".format(gas["CH4"].Y[0]))
+print(f"mass fraction of CH4 = {gas['CH4'].Y[0]:1.3f}")
 
 # To set a mixture according to the mixture fraction, the following function
 # can be used. In this example, the final fuel/oxidizer mixture
 # contains 5.5 mass-% CH4:
 Z = gas.set_mixture_fraction(0.055, fuel="CH4", oxidizer="O2:0.21,N2:0.79")
-print("mass fraction of CH4 = {:1.3f}".format(gas["CH4"].Y[0]))
+print(f"mass fraction of CH4 = {gas['CH4'].Y[0]:1.3f}")
 
 # Mixture fraction and equivalence ratio are invariant to the reaction progress.
 # For example, they stay constant if the mixture composition changes to the burnt
@@ -72,45 +72,46 @@ gas.set_equivalence_ratio(1, fuel, oxidizer)
 gas.equilibrate('HP')
 phi_burnt = gas.equivalence_ratio(fuel, oxidizer)
 Z_burnt = gas.mixture_fraction(fuel, oxidizer)
-print("phi(burnt) = {:1.3f}".format(phi_burnt))
-print("Z(burnt) = {:1.3f}".format(Z_burnt))
+print(f"phi(burnt) = {phi_burnt:1.3f}")
+print(f"Z(burnt) = {Z_burnt:1.3f}")
 
 # If fuel and oxidizer compositions are specified consistently, then
 # equivalence_ratio and set_equivalence_ratio are consistent as well, as
 # shown in the following example
-gas.set_equivalence_ratio(2.5,fuel="CH4:1,O2:0.01,CO:0.05,N2:0.1",
-        oxidizer="O2:0.2,N2:0.8,CO2:0.05,CH4:0.01")
+gas.set_equivalence_ratio(2.5, fuel="CH4:1,O2:0.01,CO:0.05,N2:0.1",
+                          oxidizer="O2:0.2,N2:0.8,CO2:0.05,CH4:0.01")
 
 phi = gas.equivalence_ratio(fuel="CH4:1,O2:0.01,CO:0.05,N2:0.1",
-        oxidizer="O2:0.2,N2:0.8,CO2:0.05,CH4:0.01")
-print("phi = {:1.3f}".format(phi)) # prints 2.5
+                            oxidizer="O2:0.2,N2:0.8,CO2:0.05,CH4:0.01")
+print(f"phi = {phi:1.3f}") # prints 2.5
 
 # Without specifying the fuel and oxidizer compositions, it is assumed that
 # all C, H and S atoms come from the fuel and all O atoms from the oxidizer,
 # which is not true for this example. Therefore, the following call gives a
 # different equivalence ratio based on that assumption
 phi = gas.equivalence_ratio()
-print("phi = {:1.3f}".format(phi))
+print(f"phi = {phi:1.3f}")
 
 # After computing the mixture composition for a certain equivalence ratio given
 # a fuel and mixture composition, the mixture can optionally be diluted. The
 # following function will first create a mixture with equivalence ratio 2 from pure
 # hydrogen and oxygen and then dilute it with H2O. In this example, the final mixture
 # consists of 30 mol-% H2O and 70 mol-% of the H2/O2 mixture at phi=2
-gas.set_equivalence_ratio(2.0, "H2:1", "O2:1", fraction={"diluent":0.3}, diluent="H2O")
-print("mole fraction of H2O = {:1.3f}".format(gas["H2O"].X[0])) # final mixture contains 30 mol-% H2O
-print("ratio of H2/O2: {:1.3f}".format(gas["H2"].X[0]/gas["O2"].X[0])) # according to phi=2
+gas.set_equivalence_ratio(2.0, "H2:1", "O2:1", diluent="H2O", fraction={"diluent":0.3})
+print(f"mole fraction of H2O = {gas['H2O'].X[0]:1.3f}") # final mixture contains 30 mol-% H2O
+print(f"ratio of H2/O2: {gas['H2'].X[0] / gas['O2'].X[0]:1.3f}") # according to phi=2
 
 # Another option is to specify the fuel or oxidizer fraction in the final mixture.
 # The following example creates a mixture with equivalence ratio 2 from pure
 # hydrogen and oxygen (same as above) and then dilutes it with a mixture of 50 mass-%
 # CO2 and 50 mass-% H2O so that the mass fraction of the fuel in the final mixture is 0.1
-gas.set_equivalence_ratio(2.0, "H2", "O2", fraction={"fuel":0.1}, diluent="CO2:0.5,H2O:0.5", basis="mass")
-print("mole fraction of H2O = {:1.3f}".format(gas["H2"].Y[0])) # final mixture contains 10 mass-% fuel
+gas.set_equivalence_ratio(2.0, "H2", "O2", diluent="CO2:0.5,H2O:0.5",
+                          fraction={"fuel":0.1}, basis="mass")
+print(f"mole fraction of H2O = {gas['H2'].Y[0]:1.3f}") # final mixture contains 10 mass-% fuel
 
 # To compute the equivalence ratio given a diluted mixture, a list of
 # species names can be provided which will be considered for computing phi.
 # In this example, the diluents H2O and CO2 are ignored and only H2 and O2 are
 # considered to get the equivalence ratio
-phi = gas.equivalence_ratio(fuel="H2", oxidizer="O2", include_species=["H2","O2"])
-print("phi = {:1.3f}".format(phi)) # prints 2
+phi = gas.equivalence_ratio(fuel="H2", oxidizer="O2", include_species=["H2", "O2"])
+print(f"phi = {phi:1.3f}") # prints 2

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -427,48 +427,46 @@ class TestThermoPhase(utilities.CanteraTest):
 
         gas.X = "H2:4,O2:1,CO:3,CO2:4,N2:5,CH4:6"
         state = gas.state
-        self.assertNear(gas.equivalence_ratio(include_species=["H2","O2"]), 2)
-        self.assertNear(gas.equivalence_ratio("H2","O2",include_species=["H2","O2"]), 2)
-        for k in range(state.size):
-            self.assertNear(state[k], gas.state[k])
+        self.assertNear(gas.equivalence_ratio(include_species=["H2", "O2"]), 2)
+        self.assertNear(gas.equivalence_ratio("H2", "O2", include_species=["H2", "O2"]), 2)
+        self.assertArrayNear(state, gas.state)
 
         def test_simple_dilution(fraction,basis):
-            if isinstance(fraction,str):
-                fractiontype = fraction[:fraction.find(":")]
+            if isinstance(fraction, str):
+                fraction_type = fraction[:fraction.find(":")]
             else:
-                fractiontype = list(fraction.keys())[0]
+                fraction_type = list(fraction.keys())[0]
 
             M_H2 = gas.molecular_weights[gas.species_index("H2")]
             M_O2 = gas.molecular_weights[gas.species_index("O2")]
 
-            gas.set_equivalence_ratio(2, "H2","O2", fraction=fraction, diluent="CO2", basis=basis)
-            if basis=="mole" and fractiontype=="diluent":
-                self.assertNear(gas["H2"].X[0], (1-0.3)*0.8)
-                self.assertNear(gas["O2"].X[0], (1-0.3)*0.2)
+            gas.set_equivalence_ratio(2, "H2", "O2", fraction=fraction, diluent="CO2", basis=basis)
+            if basis == "mole" and fraction_type == "diluent":
+                self.assertNear(gas["H2"].X[0], (1 - 0.3) * 0.8)
+                self.assertNear(gas["O2"].X[0], (1 - 0.3) * 0.2)
                 self.assertNear(gas["CO2"].X[0], 0.3)
-            elif basis=="mass" and fractiontype=="diluent":
-                self.assertNear(gas["H2"].Y[0]/gas["O2"].Y[0], 4*M_H2/M_O2)
+            elif basis == "mass" and fraction_type == "diluent":
+                self.assertNear(gas["H2"].Y[0] / gas["O2"].Y[0], 4 * M_H2 / M_O2)
                 self.assertNear(gas["CO2"].Y[0], 0.3)
-            elif basis=="mole" and fractiontype=="fuel":
+            elif basis == "mole" and fraction_type == "fuel":
                 self.assertNear(gas["H2"].X[0], 0.1)
-                self.assertNear(gas["O2"].X[0], 0.1/4)
-                self.assertNear(gas["CO2"].X[0], 1-0.1-0.1/4)
-            elif basis=="mass" and fractiontype=="fuel":
+                self.assertNear(gas["O2"].X[0], 0.1 / 4)
+                self.assertNear(gas["CO2"].X[0], 1 - 0.1 - 0.1 / 4)
+            elif basis == "mass" and fraction_type == "fuel":
                 self.assertNear(gas["H2"].Y[0], 0.1)
-                self.assertNear(gas["H2"].Y[0]/gas["O2"].Y[0], 4*M_H2/M_O2)
-            elif basis=="mole" and fractiontype=="oxidizer":
-                self.assertNear(gas["H2"].X[0], 0.1*4)
+                self.assertNear(gas["H2"].Y[0] / gas["O2"].Y[0], 4 * M_H2 / M_O2)
+            elif basis == "mole" and fraction_type == "oxidizer":
+                self.assertNear(gas["H2"].X[0], 0.1 * 4)
                 self.assertNear(gas["O2"].X[0], 0.1)
-                self.assertNear(gas["CO2"].X[0], 1-0.1-0.1*4)
-            elif basis=="mass" and fractiontype=="oxidizer":
+                self.assertNear(gas["CO2"].X[0], 1 - 0.1 - 0.1 * 4)
+            elif basis == "mass" and fraction_type == "oxidizer":
                 self.assertNear(gas["O2"].Y[0], 0.1)
-                self.assertNear(gas["H2"].Y[0]/gas["O2"].Y[0], 4*M_H2/M_O2)
+                self.assertNear(gas["H2"].Y[0] / gas["O2"].Y[0], 4 * M_H2 / M_O2)
 
             state = gas.state
-            self.assertNear(gas.equivalence_ratio("H2","O2", include_species=["H2","O2"], basis=basis), 2)
-            self.assertNear(gas.equivalence_ratio(include_species=["H2","O2"], basis=basis), 2)
-            for k in range(state.size):
-                self.assertNear(state[k], gas.state[k])
+            self.assertNear(gas.equivalence_ratio("H2", "O2", include_species=["H2", "O2"], basis=basis), 2)
+            self.assertNear(gas.equivalence_ratio(include_species=["H2", "O2"], basis=basis), 2)
+            self.assertArrayNear(state, gas.state)
 
         # brute force all possible input combinations
         test_simple_dilution("diluent:0.3",   "mole")
@@ -485,7 +483,6 @@ class TestThermoPhase(utilities.CanteraTest):
         test_simple_dilution({"oxidizer":0.1}, "mole")
         test_simple_dilution("oxidizer:0.1",   "mass")
         test_simple_dilution({"oxidizer":0.1}, "mass")
-
 
     def test_equivalence_ratio_arbitrary_dilution(self):
         fuel = "CH4:1,O2:0.01,N2:0.1,CO:0.05,CO2:0.02"
@@ -509,28 +506,24 @@ class TestThermoPhase(utilities.CanteraTest):
         gas.set_equivalence_ratio(2, fuel, oxidizer)
         X_Mix = gas.X
         gas.set_equivalence_ratio(2, fuel,oxidizer, fraction="diluent:0.6", diluent=diluent)
-        X_expected = X_Mix*0.4 + 0.6*X_diluent
-        for k in range(gas.n_species):
-            self.assertNear(gas.X[k], X_expected[k])
+        X_expected = X_Mix * 0.4 + 0.6 * X_diluent
+        self.assertArrayNear(gas.X, X_expected)
 
         gas.set_equivalence_ratio(2, fuel, oxidizer, basis="mass")
         Y_Mix = gas.Y
-        gas.set_equivalence_ratio(2, fuel,oxidizer, fraction="diluent:0.6", diluent=diluent, basis="mass")
-        Y_expected = Y_Mix*0.4 + 0.6*Y_diluent
-        for k in range(gas.n_species):
-            self.assertNear(gas.Y[k], Y_expected[k])
+        gas.set_equivalence_ratio(2, fuel, oxidizer, fraction="diluent:0.6", diluent=diluent, basis="mass")
+        Y_expected = Y_Mix * 0.4 + 0.6 * Y_diluent
+        self.assertArrayNear(gas.Y, Y_expected)
 
         gas.set_equivalence_ratio(0.8, fuel, oxidizer, basis="mass")
-        AFR = gas.stoich_air_fuel_ratio(fuel,oxidizer,basis="mass")/0.8
+        AFR = gas.stoich_air_fuel_ratio(fuel, oxidizer, basis="mass") / 0.8
         gas.set_equivalence_ratio(0.8, fuel, oxidizer, fraction="fuel:0.05", diluent=diluent, basis="mass")
-        Y_expected = 0.05*( (Y_fuel + Y_oxidizer*AFR)) + Y_diluent*(1-(0.05+0.05*AFR))
-        for k in range(gas.n_species):
-            self.assertNear(gas.Y[k], Y_expected[k])
+        Y_expected = 0.05 * (Y_fuel + Y_oxidizer*AFR) + Y_diluent * (1 - (0.05 + 0.05 * AFR))
+        self.assertArrayNear(gas.Y, Y_expected)
 
         gas.set_equivalence_ratio(0.8, fuel, oxidizer, fraction="oxidizer:0.05", diluent=diluent, basis="mass")
-        Y_expected = 0.05/AFR*( (Y_fuel + Y_oxidizer*AFR)) + Y_diluent*(1-0.05/AFR*(1+AFR))
-        for k in range(gas.n_species):
-            self.assertNear(gas.Y[k], Y_expected[k])
+        Y_expected = 0.05 / AFR * (Y_fuel + Y_oxidizer * AFR) + Y_diluent * (1 - 0.05 / AFR * (1 + AFR))
+        self.assertArrayNear(gas.Y, Y_expected)
 
         gas.X = fuel
         M_fuel = gas.mean_molecular_weight
@@ -538,17 +531,15 @@ class TestThermoPhase(utilities.CanteraTest):
         M_oxidizer = gas.mean_molecular_weight
 
         gas.set_equivalence_ratio(0.8, fuel, oxidizer)
-        AFR = M_fuel/M_oxidizer*gas.stoich_air_fuel_ratio(fuel,oxidizer)/0.8
+        AFR = M_fuel / M_oxidizer * gas.stoich_air_fuel_ratio(fuel, oxidizer) / 0.8
 
         gas.set_equivalence_ratio(0.8, fuel, oxidizer, fraction="fuel:0.05", diluent=diluent)
-        X_expected = 0.05*( (X_fuel + X_oxidizer*AFR)) + X_diluent*(1-(0.05+0.05*AFR))
-        for k in range(gas.n_species):
-            self.assertNear(gas.X[k], X_expected[k])
+        X_expected = 0.05 * (X_fuel + X_oxidizer * AFR) + X_diluent * (1 - (0.05 + 0.05 * AFR))
+        self.assertArrayNear(gas.X, X_expected)
 
         gas.set_equivalence_ratio(0.8, fuel, oxidizer, fraction="oxidizer:0.05", diluent=diluent)
-        X_expected = 0.05/AFR*( (X_fuel + X_oxidizer*AFR)) + X_diluent*(1-0.05/AFR*(1+AFR))
-        for k in range(gas.n_species):
-            self.assertNear(gas.X[k], X_expected[k])
+        X_expected = 0.05 / AFR * (X_fuel + X_oxidizer * AFR) + X_diluent * (1 - 0.05 / AFR * (1 + AFR))
+        self.assertArrayNear(gas.X, X_expected)
 
     def test_full_report(self):
         report = self.phase.report(threshold=0.0)

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -542,13 +542,13 @@ class TestThermoPhase(utilities.CanteraTest):
         AFR = gas.stoich_air_fuel_ratio(fuel, oxidizer, basis="mass") / phi
         gas.set_equivalence_ratio(phi, fuel, oxidizer, fraction={"fuel": fraction},
                                   diluent=diluent, basis="mass")
-        Y_expected = Y_expected = fraction * (Y_fuel + AFR * Y_oxidizer) \
+        Y_expected = fraction * (Y_fuel + AFR * Y_oxidizer) \
                      + (1 - fraction * (1 + AFR)) * Y_diluent
         self.assertArrayNear(gas.Y, Y_expected)
 
         gas.set_equivalence_ratio(phi, fuel, oxidizer, fraction={"oxidizer": fraction},
                                   diluent=diluent, basis="mass")
-        Y_expected = Y_expected = fraction * (Y_fuel / AFR + Y_oxidizer) \
+        Y_expected = fraction * (Y_fuel / AFR + Y_oxidizer) \
                      + (1 - fraction * (1 + 1 / AFR)) * Y_diluent
         self.assertArrayNear(gas.Y, Y_expected)
 

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -422,6 +422,134 @@ class TestThermoPhase(utilities.CanteraTest):
 
         test_equil_results(gas, fuel, ox, Y_Cf, Y_Of, Y_Co, Y_Oo, 'mass')
 
+    def test_equivalence_ratio_simple_dilution(self):
+        gas = ct.Solution("gri30.yaml")
+
+        gas.X = "H2:4,O2:1,CO:3,CO2:4,N2:5,CH4:6"
+        state = gas.state
+        self.assertNear(gas.equivalence_ratio(include_species=["H2","O2"]), 2)
+        self.assertNear(gas.equivalence_ratio("H2","O2",include_species=["H2","O2"]), 2)
+        for k in range(state.size):
+            self.assertNear(state[k], gas.state[k])
+
+        def test_simple_dilution(fraction,basis):
+            if isinstance(fraction,str):
+                fractiontype = fraction[:fraction.find(":")]
+            else:
+                fractiontype = list(fraction.keys())[0]
+
+            M_H2 = gas.molecular_weights[gas.species_index("H2")]
+            M_O2 = gas.molecular_weights[gas.species_index("O2")]
+
+            gas.set_equivalence_ratio(2, "H2","O2", fraction=fraction, diluent="CO2", basis=basis)
+            if basis=="mole" and fractiontype=="diluent":
+                self.assertNear(gas["H2"].X[0], (1-0.3)*0.8)
+                self.assertNear(gas["O2"].X[0], (1-0.3)*0.2)
+                self.assertNear(gas["CO2"].X[0], 0.3)
+            elif basis=="mass" and fractiontype=="diluent":
+                self.assertNear(gas["H2"].Y[0]/gas["O2"].Y[0], 4*M_H2/M_O2)
+                self.assertNear(gas["CO2"].Y[0], 0.3)
+            elif basis=="mole" and fractiontype=="fuel":
+                self.assertNear(gas["H2"].X[0], 0.1)
+                self.assertNear(gas["O2"].X[0], 0.1/4)
+                self.assertNear(gas["CO2"].X[0], 1-0.1-0.1/4)
+            elif basis=="mass" and fractiontype=="fuel":
+                self.assertNear(gas["H2"].Y[0], 0.1)
+                self.assertNear(gas["H2"].Y[0]/gas["O2"].Y[0], 4*M_H2/M_O2)
+            elif basis=="mole" and fractiontype=="oxidizer":
+                self.assertNear(gas["H2"].X[0], 0.1*4)
+                self.assertNear(gas["O2"].X[0], 0.1)
+                self.assertNear(gas["CO2"].X[0], 1-0.1-0.1*4)
+            elif basis=="mass" and fractiontype=="oxidizer":
+                self.assertNear(gas["O2"].Y[0], 0.1)
+                self.assertNear(gas["H2"].Y[0]/gas["O2"].Y[0], 4*M_H2/M_O2)
+
+            state = gas.state
+            self.assertNear(gas.equivalence_ratio("H2","O2", include_species=["H2","O2"], basis=basis), 2)
+            self.assertNear(gas.equivalence_ratio(include_species=["H2","O2"], basis=basis), 2)
+            for k in range(state.size):
+                self.assertNear(state[k], gas.state[k])
+
+        # brute force all possible input combinations
+        test_simple_dilution("diluent:0.3",   "mole")
+        test_simple_dilution({"diluent":0.3}, "mole")
+        test_simple_dilution("diluent:0.3",   "mass")
+        test_simple_dilution({"diluent":0.3}, "mass")
+
+        test_simple_dilution("fuel:0.1",   "mole")
+        test_simple_dilution({"fuel":0.1}, "mole")
+        test_simple_dilution("fuel:0.1",   "mass")
+        test_simple_dilution({"fuel":0.1}, "mass")
+
+        test_simple_dilution("oxidizer:0.1",    "mole")
+        test_simple_dilution({"oxidizer":0.1}, "mole")
+        test_simple_dilution("oxidizer:0.1",   "mass")
+        test_simple_dilution({"oxidizer":0.1}, "mass")
+
+
+    def test_equivalence_ratio_arbitrary_dilution(self):
+        fuel = "CH4:1,O2:0.01,N2:0.1,CO:0.05,CO2:0.02"
+        oxidizer = "O2:0.8,N2:0.2,CO:0.01,CH4:0.005,CO2:0.03"
+        diluent = "CO2:1,CO:0.025,N2:0.3,CH4:0.07,O2:0.09"
+        gas = ct.Solution("gri30.yaml")
+
+        gas.X = fuel
+        X_fuel = gas.X
+        gas.Y = fuel
+        Y_fuel = gas.Y
+        gas.X = oxidizer
+        X_oxidizer = gas.X
+        gas.Y = oxidizer
+        Y_oxidizer = gas.Y
+        gas.X = diluent
+        X_diluent = gas.X
+        gas.Y = diluent
+        Y_diluent = gas.Y
+
+        gas.set_equivalence_ratio(2, fuel, oxidizer)
+        X_Mix = gas.X
+        gas.set_equivalence_ratio(2, fuel,oxidizer, fraction="diluent:0.6", diluent=diluent)
+        X_expected = X_Mix*0.4 + 0.6*X_diluent
+        for k in range(gas.n_species):
+            self.assertNear(gas.X[k], X_expected[k])
+
+        gas.set_equivalence_ratio(2, fuel, oxidizer, basis="mass")
+        Y_Mix = gas.Y
+        gas.set_equivalence_ratio(2, fuel,oxidizer, fraction="diluent:0.6", diluent=diluent, basis="mass")
+        Y_expected = Y_Mix*0.4 + 0.6*Y_diluent
+        for k in range(gas.n_species):
+            self.assertNear(gas.Y[k], Y_expected[k])
+
+        gas.set_equivalence_ratio(0.8, fuel, oxidizer, basis="mass")
+        AFR = gas.stoich_air_fuel_ratio(fuel,oxidizer,basis="mass")/0.8
+        gas.set_equivalence_ratio(0.8, fuel, oxidizer, fraction="fuel:0.05", diluent=diluent, basis="mass")
+        Y_expected = 0.05*( (Y_fuel + Y_oxidizer*AFR)) + Y_diluent*(1-(0.05+0.05*AFR))
+        for k in range(gas.n_species):
+            self.assertNear(gas.Y[k], Y_expected[k])
+
+        gas.set_equivalence_ratio(0.8, fuel, oxidizer, fraction="oxidizer:0.05", diluent=diluent, basis="mass")
+        Y_expected = 0.05/AFR*( (Y_fuel + Y_oxidizer*AFR)) + Y_diluent*(1-0.05/AFR*(1+AFR))
+        for k in range(gas.n_species):
+            self.assertNear(gas.Y[k], Y_expected[k])
+
+        gas.X = fuel
+        M_fuel = gas.mean_molecular_weight
+        gas.X = oxidizer
+        M_oxidizer = gas.mean_molecular_weight
+
+        gas.set_equivalence_ratio(0.8, fuel, oxidizer)
+        AFR = M_fuel/M_oxidizer*gas.stoich_air_fuel_ratio(fuel,oxidizer)/0.8
+
+        gas.set_equivalence_ratio(0.8, fuel, oxidizer, fraction="fuel:0.05", diluent=diluent)
+        X_expected = 0.05*( (X_fuel + X_oxidizer*AFR)) + X_diluent*(1-(0.05+0.05*AFR))
+        for k in range(gas.n_species):
+            self.assertNear(gas.X[k], X_expected[k])
+
+        gas.set_equivalence_ratio(0.8, fuel, oxidizer, fraction="oxidizer:0.05", diluent=diluent)
+        X_expected = 0.05/AFR*( (X_fuel + X_oxidizer*AFR)) + X_diluent*(1-0.05/AFR*(1+AFR))
+        for k in range(gas.n_species):
+            self.assertNear(gas.X[k], X_expected[k])
+
     def test_full_report(self):
         report = self.phase.report(threshold=0.0)
         self.assertIn(self.phase.name, report)

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -819,9 +819,9 @@ cdef class ThermoPhase(_SolutionBase):
         N ends up as N2). The ``basis`` determines the fuel and oxidizer
         compositions: ``basis='mole'`` means mole fractions (default),
         ``basis='mass'`` means mass fractions. The fuel/oxidizer mixture can be
-        be diluted by a ``diluent`` based on a mixing ``fraction``, specifying
-        the amount of diluent, fuel or oxidizer in the mixture. For more
-        information, see `Python example
+        be diluted by a ``diluent`` based on a mixing ``fraction``. The amount of
+        diluent is quantified as a fraction of fuel, oxidizer or the fuel/oxidizer
+        mixture. For more information, see `Python example
         <https://cantera.org/examples/python/thermo/equivalenceRatio.py.html>`_ ::
 
             >>> gas.set_equivalence_ratio(0.5, 'CH4', 'O2:1.0, N2:3.76', basis='mole')
@@ -857,12 +857,10 @@ cdef class ThermoPhase(_SolutionBase):
             dilution or ``fraction=None``. May be given as string or dictionary (for
             example ``fraction={"fuel":0.7})``
         """
-        cdef np.ndarray[np.double_t, ndim=1] fuel_comp = \
-                np.ascontiguousarray(self.__composition_to_array(fuel, basis),
-                                     dtype=np.double)
-        cdef np.ndarray[np.double_t, ndim=1] ox_comp = \
-                np.ascontiguousarray(self.__composition_to_array(oxidizer, basis),
-                                     dtype=np.double)
+        cdef np.ndarray[np.double_t, ndim=1] fuel_comp = np.ascontiguousarray(
+                self.__composition_to_array(fuel, basis), dtype=np.double)
+        cdef np.ndarray[np.double_t, ndim=1] ox_comp = np.ascontiguousarray(
+                self.__composition_to_array(oxidizer, basis), dtype=np.double)
 
         self.thermo.setEquivalenceRatio(phi, &fuel_comp[0], &ox_comp[0],
                                         ThermoBasis.mass if basis == "mass"
@@ -897,9 +895,8 @@ cdef class ThermoPhase(_SolutionBase):
             raise ValueError("The fraction must specify 'fuel', 'oxidizer' or "
                              "'diluent'")
 
-        cdef np.ndarray[np.double_t, ndim=1] diluent_comp = \
-                np.ascontiguousarray(self.__composition_to_array(diluent, basis),
-                                     dtype=np.double)
+        cdef np.ndarray[np.double_t, ndim=1] diluent_comp = np.ascontiguousarray(
+                self.__composition_to_array(diluent, basis), dtype=np.double)
 
         # this function changes the composition and fixes temperature and pressure
         T, P = self.T, self.P
@@ -1039,12 +1036,10 @@ cdef class ThermoPhase(_SolutionBase):
                 self.TPY = T_orig, P_orig, Y_orig
             return phi
 
-        cdef np.ndarray[np.double_t, ndim=1] f = \
-                np.ascontiguousarray(self.__composition_to_array(fuel, basis),
-                                     dtype=np.double)
-        cdef np.ndarray[np.double_t, ndim=1] o = \
-                np.ascontiguousarray(self.__composition_to_array(oxidizer, basis),
-                                     dtype=np.double)
+        cdef np.ndarray[np.double_t, ndim=1] f = np.ascontiguousarray(
+                self.__composition_to_array(fuel, basis), dtype=np.double)
+        cdef np.ndarray[np.double_t, ndim=1] o = np.ascontiguousarray(
+                self.__composition_to_array(oxidizer, basis), dtype=np.double)
 
         phi = self.thermo.equivalenceRatio(&f[0], &o[0],
                                            ThermoBasis.mass if basis=="mass"

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -885,7 +885,7 @@ cdef class ThermoPhase(_SolutionBase):
 
         if len(fraction_dict) != 1:
             raise ValueError("Invalid format for the fraction. Must be provided for "
-                             "as fraction='fuel:0.1'")
+                             "example as fraction='fuel:0.1'")
 
         fraction_type  = list(fraction_dict.keys())[0]
         fraction_value = float(list(fraction_dict.values())[0])


### PR DESCRIPTION
Two changes are proposed in this PR:
1. add a new argument to `equivalence_ratio` to allow users to ignore certain species, e.g. as a result of dilution with an inert species
2. add two new arguments to `set_equivalence_ratio` to dilute a mixture after the mixture composition based on equivalence ratio has been determined.

All changes are backward compatible. Discussion on these changes can be found here:
https://github.com/Cantera/enhancements/issues/108 
https://github.com/Cantera/cantera/pull/521
https://www.google.com/search?q=cantera+users+group&rlz=1C1GCEB_enDE918DE918&oq=canter&aqs=chrome.0.69i59l3j69i57j69i60l3j69i65.6761j0j7&sourceid=chrome&ie=UTF-8

The first change is used like this:
`gas.equivalence_ratio(fuel="H2", oxidizer="O2:0.21,N2:0.79", include_species=["H2","O2"])`
This computes the equivalence ratio as before, but ignores all species except H2 and O2

The second change is used like this:
`gas.set_equivalence_ratio(2.0, "H2", "O2:0.21,N2:0.79", fraction="diluant:0.1", diluant="H2O")`
This first creates a mixture of H2 and air with equivalence ratio 2 and then dilutes it with H2O so that the mole fraction of the diluant in the final mixture is 0.1. Similar options exist to fix the fuel and oxygen fraction in the final mixture.

Comprehensive descriptions have been added to the examples in `interfaces/cython/cantera/examples/thermo/equivalenceRatio.py` to showcase these additions to Cantera.