### PR TITLE
GitHub runners for Windows 2022

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -298,6 +298,8 @@ jobs:
     name: Sundials ${{ matrix.sundials-ver }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
+    env:
+      PYTHON_VERSION: 3.8
     defaults:
       run:
         shell: bash -l {0}
@@ -313,7 +315,7 @@ jobs:
       - uses: conda-incubator/setup-miniconda@v2
         with:
           auto-update-conda: true
-          python-version: 3.8
+          python-version: ${{ env.PYTHON_VERSION }}
           miniforge-version: latest
           activate-environment: test
         name: Set up conda
@@ -331,11 +333,23 @@ jobs:
       - name: Test Cantera
         run: scons test show_long_tests=yes verbose_tests=yes
       - name: Test Install
+        # spot-check installation locations
         run: |
           scons install
-          python -c 'import cantera as ct; print(ct.__version__)'
+          test -f ${CONDA_PREFIX}/lib/libcantera_shared.so
+          test -f ${CONDA_PREFIX}/include/cantera/base/Solution.h
+          test -f ${CONDA_PREFIX}/bin/ck2yaml
+          test -f ${CONDA_PREFIX}/share/cantera/data/gri30.yaml
+          test -d ${CONDA_PREFIX}/share/cantera/samples
+          test -d ${CONDA_PREFIX}/lib/python${{ env.PYTHON_VERSION }}/site-packages/cantera
+      - name: Test Essentials
+        # ensure that Python package loads and converter scripts work
+        run: |
+          python -c 'import cantera as ct; import sys; sys.exit(0) if ct.__version__.startswith("2.6.0") else sys.exit(1)'
           ck2yaml --input=test/data/h2o2.inp --output=h2o2-test.yaml
+          test -f h2o2-test.yaml
           cti2yaml test/data/air-no-reactions.cti air-no-reaction-test.yaml
+          test -f air-no-reaction-test.yaml
 
   cython-latest:
     name: Test pre-release version of Cython
@@ -406,7 +420,7 @@ jobs:
       matrix:
         os: ["windows-2022"]
         vs-toolset: ["14.3"] # 'cl' is not recognized for earlier toolsets
-        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+        python-version: [ "3.7", "3.9", "3.10" ]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -426,20 +440,33 @@ jobs:
       # See https://github.com/conda-forge/boost-cpp-feedstock/issues/41 for why we
       # use boost-cpp rather than boost from conda-forge
       run: |
-        mamba install -q scons numpy cython ruamel_yaml boost-cpp eigen yaml-cpp h5py pandas pytest
+        mamba install -q scons numpy cython ruamel.yaml boost-cpp eigen yaml-cpp h5py pandas pytest
       shell: pwsh
     - name: Build Cantera
-      run: scons build CXX=cl CC=cl system_eigen=y system_yamlcpp=y VERBOSE=True
+      run: scons build system_eigen=y system_yamlcpp=y VERBOSE=True
         msvc_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j2
       shell: pwsh
     - name: Test Cantera
       run: scons test show_long_tests=yes verbose_tests=yes --debug=time
       shell: pwsh
     - name: Test Install
+      # spot-check installation locations
       run: |
         scons install
-        python -c 'import cantera as ct; print(ct.__version__)'
-      shell: pwsh
+        test -f ${CONDA_PREFIX}/Library/lib/cantera_shared.dll
+        test -f ${CONDA_PREFIX}/Library/include/cantera/base/Solution.h
+        test -f ${CONDA_PREFIX}/Scripts/ck2yaml
+        test -f ${CONDA_PREFIX}/share/cantera/data/gri30.yaml
+        test -d ${CONDA_PREFIX}/share/cantera/samples
+        test -d ${CONDA_PREFIX}/Lib/site-packages/cantera
+    - name: Test Essentials
+      # ensure that Python package loads and converter scripts work
+      run: |
+        python -c 'import cantera as ct; import sys; sys.exit(0) if ct.__version__.startswith("2.6.0") else sys.exit(1)'
+        ck2yaml --input=test/data/h2o2.inp --output=h2o2-test.yaml
+        test -f h2o2-test.yaml
+        cti2yaml test/data/air-no-reactions.cti air-no-reaction-test.yaml
+        test -f air-no-reaction-test.yaml
 
   windows:
     name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}
@@ -452,7 +479,7 @@ jobs:
       matrix:
         os: ['windows-2019']
         vs-toolset: ['14.0', '14.2']
-        python-version: [ '3.6', '3.9', '3.10' ]
+        python-version: [ "3.7", "3.9", "3.10" ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -402,41 +402,32 @@ jobs:
         python-version: [ "3.7", "3.8", "3.9", "3.10" ]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v2
-        name: Checkout the repository
-        with:
-          submodules: recursive
-      - name: Cache conda
-        uses: actions/cache@v2
-        env:
-          CACHE_NUMBER: 0
-        with:
-          path: ~/conda_pkgs_dir
-          key:
-            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}
-      - uses: conda-incubator/setup-miniconda@v2
-        with:
-          auto-update-conda: true
-          python-version: ${{ matrix.python-version }}
-          activate-environment: test
-          miniforge-version: latest
-          channels: conda-forge,defaults
-          channel-priority: strict
-          use-only-tar-bz2: true
-        name: Set up conda
-      - name: Install conda dependencies
-        # See https://github.com/conda-forge/boost-cpp-feedstock/issues/41 for why we
-        # use boost-cpp rather than boost from conda-forge
-        run: |
-          conda install -q scons numpy cython ruamel_yaml boost-cpp eigen yaml-cpp h5py pandas pytest
-        shell: pwsh
-      - name: Build Cantera
-        run: scons build CXX=cl CC=cl system_eigen=y system_yamlcpp=y VERBOSE=True
-          msvc_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j2
-        shell: cmd /C CALL {0}
-      - name: Test Cantera
-        run: scons test show_long_tests=yes verbose_tests=yes --debug=time
-        shell: cmd /C CALL {0}
+    - uses: actions/checkout@v2
+      name: Checkout the repository
+      with:
+        submodules: recursive
+    - name: Set up conda
+      uses: conda-incubator/setup-miniconda@v2
+      with:
+        auto-update-conda: true
+        python-version: ${{ matrix.python-version }}
+        mamba-version: "*"
+        activate-environment: test
+        channels: conda-forge,defaults
+        channel-priority: true
+    - name: Install conda dependencies
+      # See https://github.com/conda-forge/boost-cpp-feedstock/issues/41 for why we
+      # use boost-cpp rather than boost from conda-forge
+      run: |
+        mamba install -q scons numpy cython ruamel_yaml boost-cpp eigen yaml-cpp h5py pandas pytest
+      shell: pwsh
+    - name: Build Cantera
+      run: scons build CXX=cl CC=cl system_eigen=y system_yamlcpp=y VERBOSE=True
+        msvc_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j2
+      shell: pwsh
+    - name: Test Cantera
+      run: scons test show_long_tests=yes verbose_tests=yes --debug=time
+      shell: pwsh
 
   windows:
     name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -388,6 +388,56 @@ jobs:
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
 
+  windows-2022:
+    name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    defaults:
+      run:
+        shell: bash -l {0}
+    strategy:
+      matrix:
+        os: ["windows-2022"]
+        vs-toolset: ["14.3"] # 'cl' is not recognized for earlier toolsets
+        python-version: [ "3.7", "3.8", "3.9", "3.10" ]
+      fail-fast: false
+    steps:
+      - uses: actions/checkout@v2
+        name: Checkout the repository
+        with:
+          submodules: recursive
+      - name: Cache conda
+        uses: actions/cache@v2
+        env:
+          CACHE_NUMBER: 0
+        with:
+          path: ~/conda_pkgs_dir
+          key:
+            ${{ runner.os }}-conda-${{ env.CACHE_NUMBER }}
+      - uses: conda-incubator/setup-miniconda@v2
+        with:
+          auto-update-conda: true
+          python-version: ${{ matrix.python-version }}
+          activate-environment: test
+          miniforge-version: latest
+          channels: conda-forge,defaults
+          channel-priority: strict
+          use-only-tar-bz2: true
+        name: Set up conda
+      - name: Install conda dependencies
+        # See https://github.com/conda-forge/boost-cpp-feedstock/issues/41 for why we
+        # use boost-cpp rather than boost from conda-forge
+        run: |
+          conda install -q scons numpy cython ruamel_yaml boost-cpp eigen yaml-cpp h5py pandas pytest
+        shell: pwsh
+      - name: Build Cantera
+        run: scons build CXX=cl CC=cl system_eigen=y system_yamlcpp=y VERBOSE=True
+          msvc_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j2
+        shell: cmd /C CALL {0}
+      - name: Test Cantera
+        run: scons test show_long_tests=yes verbose_tests=yes --debug=time
+        shell: cmd /C CALL {0}
+
   windows:
     name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}
     runs-on: ${{ matrix.os }}
@@ -400,21 +450,6 @@ jobs:
         os: ['windows-2019']
         vs-toolset: ['14.0', '14.2']
         python-version: [ '3.6', '3.9', '3.10' ]
-        # Must use windows-2016 image because it installs VS2017 (MSVC 14.1)
-        # Scons cannot find MSVC 14.1 when VS2019 is installed
-        include:
-          - os: 'windows-2016'
-            vs-toolset: '14.1'
-            python-version: '3.6'
-          - os: 'windows-2016'
-            vs-toolset: '14.1'
-            python-version: '3.7'
-          - os: 'windows-2016'
-            vs-toolset: '14.1'
-            python-version: '3.8'
-          - os: 'windows-2016'
-            vs-toolset: '14.1'
-            python-version: '3.9'
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -315,6 +315,7 @@ jobs:
           auto-update-conda: true
           python-version: 3.8
           miniforge-version: latest
+          activate-environment: test
         name: Set up conda
       - name: Install conda dependencies
         # See https://github.com/conda-forge/boost-cpp-feedstock/issues/41 for why we
@@ -329,6 +330,12 @@ jobs:
           optimize_flags='-O3 -ffast-math -fno-finite-math-only'
       - name: Test Cantera
         run: scons test show_long_tests=yes verbose_tests=yes
+      - name: Test Install
+        run: |
+          scons install
+          python -c 'import cantera as ct; print(ct.__version__)'
+          ck2yaml --input=test/data/h2o2.inp --output=h2o2-test.yaml
+          cti2yaml test/data/air-no-reactions.cti air-no-reaction-test.yaml
 
   cython-latest:
     name: Test pre-release version of Cython
@@ -427,6 +434,11 @@ jobs:
       shell: pwsh
     - name: Test Cantera
       run: scons test show_long_tests=yes verbose_tests=yes --debug=time
+      shell: pwsh
+    - name: Test Install
+      run: |
+        scons install
+        python -c 'import cantera as ct; print(ct.__version__)'
       shell: pwsh
 
   windows:

--- a/SConstruct
+++ b/SConstruct
@@ -169,8 +169,9 @@ windows_options = [
         "msvc_version",
         """Version of Visual Studio to use. The default is the newest
            installed version. Specify '12.0' for Visual Studio 2013, '14.0' for
-           Visual Studio 2015, '14.1' ('14.1x') Visual Studio 2017, or '14.2'
-           ('14.2x') for Visual Studio 2019. For version numbers in parentheses,
+           Visual Studio 2015, '14.1' ('14.1x') Visual Studio 2017, '14.2'
+           ('14.2x') for Visual Studio 2019, or '14.3' ('14.3x') for
+           Visual Studio 2022. For version numbers in parentheses,
            'x' is a placeholder for a minor version number. Windows MSVC only.""",
         ""),
     EnumOption(


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Migrate GH environment from `windows-2016` to `windows-2022`
- Switch to `conda` driven compilation environment
- Retain `windows-2019` without changes
- Add basic tests for `scons install` in `conda`-based runners

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1199 

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review

**Other**

~#1192 prevents some tests for `conda`-based installations on windows.~