### PR TITLE
Check for valid component name when setting advance limits

### DIFF
--- a/interfaces/cython/cantera/test/test_reactor.py
+++ b/interfaces/cython/cantera/test/test_reactor.py
@@ -2,6 +2,7 @@ import math
 import re
 
 import numpy as np
+import pytest
 from .utilities import unittest
 
 import cantera as ct
@@ -290,6 +291,12 @@ class TestReactor(utilities.CanteraTest):
         self.assertNear(self.net.time, 10.0)
         self.assertNear(self.r1.T, self.r2.T, 5e-7)
         self.assertNotAlmostEqual(self.r1.thermo.P, self.r2.thermo.P)
+
+    def test_advance_limits_invalid(self):
+        self.make_reactors(n_reactors=1)
+
+        with pytest.raises(ct.CanteraError, match="No component named 'spam'"):
+            self.r1.set_advance_limit("spam", 0.1)
 
     def test_heat_transfer2(self):
         # Result should be the same if (m * cp) / (U * A) is held constant

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -472,6 +472,9 @@ bool Reactor::getAdvanceLimits(double *limits)
 void Reactor::setAdvanceLimit(const string& nm, const double limit)
 {
     size_t k = componentIndex(nm);
+    if (k == npos) {
+        throw CanteraError("Reactor::setAdvanceLimit", "No component named '{}'", nm);
+    }
 
     if (m_thermo == 0) {
         throw CanteraError("Reactor::setAdvanceLimit",


### PR DESCRIPTION
The `Reactor::componentIndex` function returns `npos` when an unknown component is specified, rather than throwing an error. This condition needs to be checked when setting an advance limit to avoid writing to invalid memory locations.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1213

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
