### PR TITLE
Improve performance of Arrhenius rate evaluations

### DIFF
--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -39,7 +39,7 @@ public:
         m_shared.invalidateCache();
     }
 
-    virtual bool replace(const size_t rxn_index, ReactionRate& rate) override {
+    virtual void replace(const size_t rxn_index, ReactionRate& rate) override {
         if (!m_rxn_rates.size()) {
             throw CanteraError("MultiRate::replace",
                  "Invalid operation: cannot replace rate object "
@@ -54,9 +54,7 @@ public:
         if (m_indices.find(rxn_index) != m_indices.end()) {
             size_t j = m_indices[rxn_index];
             m_rxn_rates.at(j).second = dynamic_cast<RateType&>(rate);
-            return true;
         }
-        return false;
     }
 
     virtual void resize(size_t n_species, size_t n_reactions) override {

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -17,7 +17,7 @@ namespace Cantera
 
 //! A class template handling ReactionRate specializations.
 template <class RateType, class DataType>
-class MultiRate final : public MultiRateBase
+class MultiRate : public MultiRateBase
 {
     CT_DEFINE_HAS_MEMBER(has_update, updateFromStruct)
     CT_DEFINE_HAS_MEMBER(has_ddT, ddTScaledFromStruct)

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -39,7 +39,7 @@ public:
     //! Replace reaction rate object handled by the evaluator
     //! @param rxn_index  index of reaction
     //! @param rate  reaction rate object
-    virtual bool replace(size_t rxn_index, ReactionRate& rate) = 0;
+    virtual void replace(size_t rxn_index, ReactionRate& rate) = 0;
 
     //! Update number of species and reactions
     //! @param n_species  number of species

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -151,6 +151,9 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
         // Add reaction rate to evaluator
         size_t index = m_bulk_types[rate->type()];
         m_bulk_rates[index]->add(nReactions() - 1, *rate);
+        if (resize) {
+            m_bulk_rates[index]->resize(nReactions(), nTotalSpecies());
+        }
 
         // Add reaction to third-body evaluator
         if (r->thirdBody() != nullptr) {

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -548,6 +548,9 @@ bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base, bool resize)
         // Add reaction rate to evaluator
         size_t index = m_interface_types[rate->type()];
         m_interface_rates[index]->add(nReactions() - 1, *rate);
+        if (resize) {
+            m_interface_rates[index]->resize(nReactions(), nTotalSpecies());
+        }
 
     } else if (r_base->reaction_type == BMINTERFACE_RXN) {
         throw NotImplementedError("InterfaceKinetics::addReaction");

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -40,11 +40,11 @@ public:
 
         kin.getFwdRateConstants(&k[0]);
         kin_ref->getFwdRateConstants(&k_ref[0]);
-        EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
+        EXPECT_NEAR(k_ref[iRef], k[0], 1e-14 * k_ref[iRef]);
 
         kin.getRevRateConstants(&k[0]);
         kin_ref->getRevRateConstants(&k_ref[0]);
-        EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
+        EXPECT_NEAR(k_ref[iRef], k[0], 1e-14 * k_ref[iRef]);
     }
 };
 
@@ -344,11 +344,11 @@ public:
 
         kin.getFwdRateConstants(&k[0]);
         kin_ref->getFwdRateConstants(&k_ref[0]);
-        EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
+        EXPECT_NEAR(k_ref[iRef], k[0], 1e-14 * k_ref[iRef]);
 
         kin.getRevRateConstants(&k[0]);
         kin_ref->getRevRateConstants(&k_ref[0]);
-        EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
+        EXPECT_NEAR(k_ref[iRef], k[0], 1e-14 * k_ref[iRef]);
     }
 };
 
@@ -433,32 +433,37 @@ public:
         kin.getFwdRateConstants(k.data());
         kin_ref->getFwdRateConstants(k_ref.data());
         for (size_t i = 0; i < kin.nReactions(); i++) {
-            EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
+            EXPECT_NEAR(k_ref[i], k[i], 1e-14 * k_ref[i])
+                << "i = " << i << "; N = " << N;
         }
 
         kin.getFwdRatesOfProgress(k.data());
         kin_ref->getFwdRatesOfProgress(k_ref.data());
         for (size_t i = 0; i < kin.nReactions(); i++) {
-            EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
+            EXPECT_NEAR(k_ref[i], k[i], 1e-14 * k_ref[i])
+                << "i = " << i << "; N = " << N;
         }
 
         kin.getRevRateConstants(k.data());
         kin_ref->getRevRateConstants(k_ref.data());
         for (size_t i = 0; i < kin.nReactions(); i++) {
-            EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
+            EXPECT_NEAR(k_ref[i], k[i], 1e-14 * k_ref[i])
+                << "i = " << i << "; N = " << N;
         }
 
         kin.getRevRatesOfProgress(k.data());
         kin_ref->getRevRatesOfProgress(k_ref.data());
         for (size_t i = 0; i < kin.nReactions(); i++) {
-            EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
+            EXPECT_NEAR(k_ref[i], k[i], 1e-14 * k_ref[i])
+                << "i = " << i << "; N = " << N;
         }
 
         kin.getCreationRates(w.data());
         kin_ref->getCreationRates(w_ref.data());
         for (size_t i = 0; i < kin.nTotalSpecies(); i++) {
             size_t iref = p_ref.speciesIndex(p.speciesName(i));
-            EXPECT_DOUBLE_EQ(w_ref[iref], w[i]) << "sp = " << p.speciesName(i) << "; N = " << N;
+            EXPECT_NEAR(w_ref[iref], w[i], 1e-14 * w_ref[iref])
+                << "sp = " << p.speciesName(i) << "; N = " << N;
         }
     }
 };

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -42,11 +42,11 @@ public:
 
         kin.getFwdRateConstants(&k[0]);
         kin_ref->getFwdRateConstants(&k_ref[0]);
-        EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
+        EXPECT_NEAR(k_ref[iRef], k[0], 1e-14 * k_ref[iRef]);
 
         kin.getRevRateConstants(&k[0]);
         kin_ref->getRevRateConstants(&k_ref[0]);
-        EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
+        EXPECT_NEAR(k_ref[iRef], k[0], 1e-14 * k_ref[iRef]);
     }
 };
 
@@ -354,11 +354,11 @@ public:
 
         kin.getFwdRateConstants(&k[0]);
         kin_ref->getFwdRateConstants(&k_ref[0]);
-        EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
+        EXPECT_NEAR(k_ref[iRef], k[0], 1e-14 * k_ref[iRef]);
 
         kin.getRevRateConstants(&k[0]);
         kin_ref->getRevRateConstants(&k_ref[0]);
-        EXPECT_DOUBLE_EQ(k_ref[iRef], k[0]);
+        EXPECT_NEAR(k_ref[iRef], k[0], 1e-14 * k_ref[iRef]);
     }
 };
 
@@ -447,13 +447,15 @@ public:
         kin.getFwdRateConstants(k.data());
         kin_ref->getFwdRateConstants(k_ref.data());
         for (size_t i = 0; i < kin.nReactions(); i++) {
-            EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
+            EXPECT_NEAR(k_ref[i], k[i], 1e-14 * k_ref[i])
+                << "i = " << i << "; N = " << N;
         }
 
         kin.getFwdRatesOfProgress(k.data());
         kin_ref->getFwdRatesOfProgress(k_ref.data());
         for (size_t i = 0; i < kin.nReactions(); i++) {
-            EXPECT_DOUBLE_EQ(k_ref[i], k[i]) << "i = " << i << "; N = " << N;
+            EXPECT_NEAR(k_ref[i], k[i], 1e-14 * k_ref[i])
+                << "i = " << i << "; N = " << N;
         }
 
         kin.getRevRateConstants(k.data());
@@ -472,7 +474,8 @@ public:
         kin_ref->getCreationRates(w_ref.data());
         for (size_t i = 0; i < kin.nTotalSpecies(); i++) {
             size_t iref = p_ref.speciesIndex(p.speciesName(i));
-            EXPECT_NEAR(w_ref[iref], w[i], w_ref[iref]*1e-12) << "sp = " << p.speciesName(i) << "; N = " << N;
+            EXPECT_NEAR(w_ref[iref], w[i], w_ref[iref]*1e-12)
+                << "sp = " << p.speciesName(i) << "; N = " << N;
         }
     }
 };


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

- Use Eigen to vectorize rate evaluations
- Only do calculations for rates that are actually temperature-dependent

**If applicable, provide an example illustrating new features this pull request is introducing**

Testing this on a couple of different machines shows a 7-9% speed increase for an adiabatic flame speed calculation using GRI 3.0 (using a modified version of `adiabatic_flame.py`, and about a 4% speed increase for the `custom-reactions.py` benchmark:

Before:
```
Average time of 100 simulation runs for 'gri30.yaml' (CH4)
- New framework (YAML): 59.38 ms (T_final=2736.60)
- One Python reaction: 60.01 ms (T_final=2736.60) ... +1.07%
- Old framework (XML): 59.07 ms (T_final=2736.60) ... -0.52%
```
After
```
Average time of 100 simulation runs for 'gri30.yaml' (CH4)
- New framework (YAML): 57.02 ms (T_final=2736.60)
- One Python reaction: 57.67 ms (T_final=2736.60) ... +1.14%
- Old framework (XML): 59.04 ms (T_final=2736.60) ... +3.53%
```

The bulk of the benefit seems to come from skipping rate updates for rates that are constant (for reference, there are 100 such rates in the GRI 3.0 mechanism). I'm not quite sure why vectorizing the the rate evaluation for the remaining reactions has so little impact.

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
