### PR TITLE
Proof-of-Concept: Eliminate reaction specializations

### DIFF
--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -71,6 +71,33 @@ public:
     //! Return parameters
     void getRateParameters(AnyMap& node) const;
 
+    virtual void setParameters(
+        const AnyMap& node, const UnitStack& rate_units) override
+    {
+        ReactionRate::setParameters(node, rate_units);
+        m_negativeA_ok = node.getBool("negative-A", false);
+        if (!node.hasKey("rate-constant")) {
+            setRateParameters(AnyValue(), node.units(), rate_units);
+            return;
+        }
+        setRateParameters(node["rate-constant"], node.units(), rate_units);
+    }
+
+    virtual void getParameters(AnyMap& node) const override {
+        if (m_negativeA_ok) {
+            node["negative-A"] = true;
+        }
+        AnyMap rateNode;
+        getRateParameters(rateNode);
+        if (!rateNode.empty()) {
+            // RateType object is configured
+            node["rate-constant"] = std::move(rateNode);
+        }
+        if (type() != "Arrhenius") {
+            node["type"] = type();
+        }
+    }
+
     //! Check rate expression
     virtual void check(const std::string& equation, const AnyMap& node) override;
 

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -1,3 +1,8 @@
+/**
+ * @file Arrhenius.h
+ * Header for reaction rates that involve Arrhenius-type kinetics.
+ */
+
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
@@ -403,56 +408,6 @@ protected:
 
     double m_deltaH_R; //!< enthalpy change of reaction (in temperature units)
 };
-
-
-//! A class template for bulk phase reaction rate specifications
-template <class RateType, class DataType>
-class BulkRate : public RateType
-{
-public:
-    BulkRate() = default;
-    using RateType::RateType; // inherit constructors
-
-    //! Constructor based on AnyMap content
-    BulkRate(const AnyMap& node, const UnitStack& rate_units={}) {
-        setParameters(node, rate_units);
-    }
-
-    unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(
-            new MultiRate<BulkRate<RateType, DataType>, DataType>);
-    }
-
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override
-    {
-        RateType::m_negativeA_ok = node.getBool("negative-A", false);
-        if (!node.hasKey("rate-constant")) {
-            RateType::setRateParameters(AnyValue(), node.units(), rate_units);
-            return;
-        }
-        RateType::setRateParameters(node["rate-constant"], node.units(), rate_units);
-    }
-
-    virtual void getParameters(AnyMap& node) const override {
-        if (RateType::m_negativeA_ok) {
-            node["negative-A"] = true;
-        }
-        AnyMap rateNode;
-        RateType::getRateParameters(rateNode);
-        if (!rateNode.empty()) {
-            // RateType object is configured
-            node["rate-constant"] = std::move(rateNode);
-        }
-        if (RateType::type() != "Arrhenius") {
-            node["type"] = RateType::type();
-        }
-    }
-};
-
-typedef BulkRate<Arrhenius3, ArrheniusData> ArrheniusRate;
-typedef BulkRate<TwoTempPlasma, TwoTempPlasmaData> TwoTempPlasmaRate;
-typedef BulkRate<BlowersMasel, BlowersMaselData> BlowersMaselRate;
 
 }
 

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -215,7 +215,7 @@ public:
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
-    double evalFromStruct(const ArrheniusData& shared_data) const {
+    double evalFromStruct(const ReactionData& shared_data) const {
         return m_A * std::exp(m_b * shared_data.logT - m_Ea_R * shared_data.recipT);
     }
 
@@ -224,7 +224,7 @@ public:
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
-    double ddTScaledFromStruct(const ArrheniusData& shared_data) const {
+    double ddTScaledFromStruct(const ReactionData& shared_data) const {
         return (m_Ea_R * shared_data.recipT + m_b) * shared_data.recipT;
     }
 };
@@ -357,11 +357,12 @@ public:
     }
 
     //! Update information specific to reaction
-    void updateFromStruct(const BlowersMaselData& shared_data) {
+    void updateFromStruct(const BulkData& shared_data) {
         if (shared_data.ready) {
             m_deltaH_R = 0.;
             for (const auto& item : m_stoich_coeffs) {
-                m_deltaH_R += shared_data.partial_molar_enthalpies[item.first] * item.second;
+                m_deltaH_R +=
+                    shared_data.partialMolarEnthalpies[item.first] * item.second;
             }
             m_deltaH_R /= GasConstant;
         }
@@ -371,7 +372,7 @@ public:
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
-    double evalFromStruct(const BlowersMaselData& shared_data) const {
+    double evalFromStruct(const BulkData& shared_data) const {
         double Ea_R = effectiveActivationEnergy_R(m_deltaH_R);
         return m_A * std::exp(m_b * shared_data.logT - Ea_R * shared_data.recipT);
     }
@@ -382,7 +383,7 @@ public:
      *  enthalpy. A corresponding warning is raised.
      *  @param shared_data  data shared by all reactions of a given type
      */
-    double ddTScaledFromStruct(const BlowersMaselData& shared_data) const;
+    double ddTScaledFromStruct(const BulkData& shared_data) const;
 
 protected:
     //! Return the effective activation energy (a function of the delta H of reaction)

--- a/include/cantera/kinetics/BulkRate.h
+++ b/include/cantera/kinetics/BulkRate.h
@@ -58,12 +58,22 @@ public:
     void getParameters(AnyMap& node) const;
 
     //! Get third-body collision efficiency parameters
-    //! @param efficiencies  AnyMap receiving coverage information
-    void getEfficiencies(AnyMap& efficiencies) const;
+    Composition efficiencies() const {
+        return m_efficiencies;
+    }
+
+    //! Set third-body collision efficiency parameters
+    //! @param efficiencies  Composition holding efficiency data
+    void setEfficiencies(const Composition& efficiencies);
 
     //! Get the default efficiency
     double defaultEfficiency() const {
         return m_defaultEfficiency;
+    }
+
+    //! Set the default efficiency
+    void setDefaultEfficiency(double defaultEfficiency) {
+        m_defaultEfficiency = defaultEfficiency;
     }
 
     //! Get the third-body efficiency for species *k*

--- a/include/cantera/kinetics/BulkRate.h
+++ b/include/cantera/kinetics/BulkRate.h
@@ -32,31 +32,8 @@ public:
             new MultiRate<BulkRate<RateType, DataType>, DataType>);
     }
 
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override
-    {
-        RateType::m_negativeA_ok = node.getBool("negative-A", false);
-        if (!node.hasKey("rate-constant")) {
-            RateType::setRateParameters(AnyValue(), node.units(), rate_units);
-            return;
-        }
-        RateType::setRateParameters(node["rate-constant"], node.units(), rate_units);
-    }
-
-    virtual void getParameters(AnyMap& node) const override {
-        if (RateType::m_negativeA_ok) {
-            node["negative-A"] = true;
-        }
-        AnyMap rateNode;
-        RateType::getRateParameters(rateNode);
-        if (!rateNode.empty()) {
-            // RateType object is configured
-            node["rate-constant"] = std::move(rateNode);
-        }
-        if (RateType::type() != "Arrhenius") {
-            node["type"] = RateType::type();
-        }
-    }
+    using RateType::setParameters;
+    using RateType::getParameters;
 };
 
 typedef BulkRate<Arrhenius3, ArrheniusData> ArrheniusRate;

--- a/include/cantera/kinetics/BulkRate.h
+++ b/include/cantera/kinetics/BulkRate.h
@@ -1,0 +1,68 @@
+/**
+ * @file BulkRate.h
+ * Header for reaction rates that occur in bulk phases.
+ */
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_BULKRATE_H
+#define CT_BULKRATE_H
+
+#include "Arrhenius.h"
+
+namespace Cantera
+{
+
+//! A class template for bulk phase reaction rate specifications
+template <class RateType, class DataType>
+class BulkRate : public RateType
+{
+public:
+    BulkRate() = default;
+    using RateType::RateType; // inherit constructors
+
+    //! Constructor based on AnyMap content
+    BulkRate(const AnyMap& node, const UnitStack& rate_units={}) {
+        setParameters(node, rate_units);
+    }
+
+    unique_ptr<MultiRateBase> newMultiRate() const override {
+        return unique_ptr<MultiRateBase>(
+            new MultiRate<BulkRate<RateType, DataType>, DataType>);
+    }
+
+    virtual void setParameters(
+        const AnyMap& node, const UnitStack& rate_units) override
+    {
+        RateType::m_negativeA_ok = node.getBool("negative-A", false);
+        if (!node.hasKey("rate-constant")) {
+            RateType::setRateParameters(AnyValue(), node.units(), rate_units);
+            return;
+        }
+        RateType::setRateParameters(node["rate-constant"], node.units(), rate_units);
+    }
+
+    virtual void getParameters(AnyMap& node) const override {
+        if (RateType::m_negativeA_ok) {
+            node["negative-A"] = true;
+        }
+        AnyMap rateNode;
+        RateType::getRateParameters(rateNode);
+        if (!rateNode.empty()) {
+            // RateType object is configured
+            node["rate-constant"] = std::move(rateNode);
+        }
+        if (RateType::type() != "Arrhenius") {
+            node["type"] = RateType::type();
+        }
+    }
+};
+
+typedef BulkRate<Arrhenius3, ArrheniusData> ArrheniusRate;
+typedef BulkRate<TwoTempPlasma, TwoTempPlasmaData> TwoTempPlasmaRate;
+typedef BulkRate<BlowersMasel, BlowersMaselData> BlowersMaselRate;
+
+}
+
+#endif

--- a/include/cantera/kinetics/BulkRate.h
+++ b/include/cantera/kinetics/BulkRate.h
@@ -69,6 +69,14 @@ public:
     //! Get the third-body efficiency for species *k*
     double efficiency(const std::string& k) const;
 
+    //! Get the third-body efficiency for species *k*
+    void getEfficiencyMap(std::map<size_t, double>& eff) const;
+
+    //! Get flag indicating whether third-body participates in the law of mass action
+    bool massAction() const {
+        return m_massAction;
+    }
+
     //! Build rate-specific parameters based on Reaction and Kinetics context
     //! @param rxn  Associated reaction object
     //! @param kin  Kinetics object holding the rate evaluator
@@ -79,7 +87,7 @@ public:
     void updateFromStruct(const BulkData& shared_data) {
         if (shared_data.ready) {
             m_thirdBodyConc = m_defaultEfficiency * shared_data.molarDensity;
-            for (const auto& eff : m_efficiencies) {
+            for (const auto& eff : m_efficiencyMap) {
                 m_thirdBodyConc += shared_data.concentrations[eff.first] * eff.second;
             }
         }
@@ -88,14 +96,6 @@ public:
     //! Third-body concentration
     double thirdBodyConcentration() const {
         return m_thirdBodyConc;
-    }
-
-    //! Apply correction
-    double applyCorrection(double value) const {
-        if (m_massAction) {
-            return value * m_thirdBodyConc;
-        }
-        return value;
     }
 
 protected:
@@ -111,11 +111,11 @@ protected:
     //! (`true` for three-body reactions, `false` for falloff reactions)
     bool m_massAction;
 
-    Composition m_efficiencyMap; //!< Map of species to third body efficiency
+    Composition m_efficiencies; //!< Composition defining third body efficiency
 
 private:
     //! Vector of pairs containing indices and efficiencies
-    std::vector<std::pair<size_t, double>> m_efficiencies;
+    std::vector<std::pair<size_t, double>> m_efficiencyMap;
 };
 
 
@@ -170,7 +170,7 @@ public:
     //! Evaluate reaction rate
     //! @param shared_data  data shared by all reactions of a given type
     double evalFromStruct(const DataType& shared_data) const {
-        return applyCorrection(RateType::evalFromStruct(shared_data));
+        return RateType::evalFromStruct(shared_data);
     }
 
 protected:

--- a/include/cantera/kinetics/BulkRate.h
+++ b/include/cantera/kinetics/BulkRate.h
@@ -10,6 +10,7 @@
 #define CT_BULKRATE_H
 
 #include "Arrhenius.h"
+#include "Custom.h"
 
 namespace Cantera
 {
@@ -40,6 +41,7 @@ public:
 using ArrheniusRate = BulkRate<Arrhenius3, ReactionData>;
 using TwoTempPlasmaRate = BulkRate<TwoTempPlasma, TwoTempPlasmaData>;
 using BlowersMaselRate = BulkRate<BlowersMasel, BulkData>;
+using CustomFunc1Rate = BulkRate<CustomFunc1Base, ReactionData>;
 
 
 class ThreeBodyBase

--- a/include/cantera/kinetics/BulkRate.h
+++ b/include/cantera/kinetics/BulkRate.h
@@ -36,9 +36,138 @@ public:
     using RateType::getParameters;
 };
 
-typedef BulkRate<Arrhenius3, ArrheniusData> ArrheniusRate;
-typedef BulkRate<TwoTempPlasma, TwoTempPlasmaData> TwoTempPlasmaRate;
-typedef BulkRate<BlowersMasel, BlowersMaselData> BlowersMaselRate;
+
+using ArrheniusRate = BulkRate<Arrhenius3, ArrheniusData>;
+using TwoTempPlasmaRate = BulkRate<TwoTempPlasma, TwoTempPlasmaData>;
+using BlowersMaselRate = BulkRate<BlowersMasel, BlowersMaselData>;
+
+
+class ThreeBodyBase
+{
+public:
+    ThreeBodyBase();
+
+    //! Set third-body collision efficiency parameters
+    //! @param node  Coverage dependencies
+    void setEfficiencies(const AnyMap& node);
+
+    //! Get third-body collision efficiency parameters
+    //! @param node  AnyMap receiving coverage information
+    void getEfficiencies(AnyMap& node) const;
+
+    //! Get the third-body efficiency for species *k*
+    double efficiency(const std::string& k) const;
+
+    //! Build rate-specific parameters based on Reaction and Kinetics context
+    //! @param rxn  Associated reaction object
+    //! @param kin  Kinetics object holding the rate evaluator
+    void setContext(const Reaction& rxn, const Kinetics& kin);
+
+    //! Update reaction rate parameters
+    //! @param shared_data  data shared by all reactions of a given type
+    void updateFromStruct(const ReactionData& shared_data) {}
+
+    //! Apply correction
+    double applyCorrection(double value) {
+        if (m_massAction) {
+            return value * m_threeBodyConc;
+        }
+        return value;
+    }
+
+protected:
+    double m_threeBodyConc; //!< Effective third-body concentration
+
+    //! The default third body efficiency for species not listed in
+    double m_defaultEfficiency;
+
+    //! Input explicitly specifies collision partner
+    bool m_specifiedCollisionPartner;
+
+    //! Third body is used by law of mass action
+    //! (`true` for three-body reactions, `false` for falloff reactions)
+    bool m_massAction;
+
+    Composition m_efficiencyMap; //!< Map of species to third body efficiency
+
+private:
+    //! Vector of pairs containing indices and efficiencies
+    std::vector<std::pair<size_t, double>> m_efficiencies;
+};
+
+
+template <class RateType, class DataType>
+class ThreeBodyRate : public RateType, public ThreeBodyBase
+{
+    CT_DEFINE_HAS_MEMBER(has_update, updateFromStruct)
+
+public:
+    ThreeBodyRate() = default;
+    using RateType::RateType; // inherit constructors
+
+    //! Constructor based on AnyMap content
+    ThreeBodyRate(const AnyMap& node, const UnitStack& rate_units={}) {
+        setParameters(node, rate_units);
+    }
+
+    unique_ptr<MultiRateBase> newMultiRate() const override {
+        return unique_ptr<MultiRateBase>(
+            new MultiRate<ThreeBodyRate<RateType, DataType>, DataType>);
+    }
+
+    virtual const std::string type() const override {
+        return "three-body-" + RateType::type();
+    }
+
+    virtual void setParameters(
+        const AnyMap& node, const UnitStack& rate_units) override
+    {
+        RateType::setParameters(node, rate_units);
+        ThreeBodyBase::setEfficiencies(node);
+    }
+
+    virtual void getParameters(AnyMap& node) const override {
+        RateType::getParameters(node);
+        node["type"] = type();
+        ThreeBodyBase::getEfficiencies(node);
+    }
+
+    virtual void setContext(const Reaction& rxn, const Kinetics& kin) override {
+        RateType::setContext(rxn, kin);
+        ThreeBodyBase::setContext(rxn, kin);
+    }
+
+    //! Update reaction rate parameters
+    //! @param shared_data  data shared by all reactions of a given type
+    void updateFromStruct(const DataType& shared_data) {
+        _update(shared_data);
+        ThreeBodyBase::updateFromStruct(shared_data);
+    }
+
+    //! Evaluate reaction rate
+    //! @param shared_data  data shared by all reactions of a given type
+    double evalFromStruct(const DataType& shared_data) const {
+        return applyCorrection(RateType::evalFromStruct(shared_data));
+    }
+
+protected:
+    //! Helper function to process updates for rate types that implement the
+    //! `updateFromStruct` method.
+    template <typename T=RateType,
+        typename std::enable_if<has_update<T>::value, bool>::type = true>
+    void _update(const DataType& shared_data) {
+        T::updateFromStruct(shared_data);
+    }
+
+    //! Helper function for rate types that do not implement `updateFromStruct`.
+    //! Does nothing, but exists to allow generic implementations of update().
+    template <typename T=RateType,
+        typename std::enable_if<!has_update<T>::value, bool>::type = true>
+    void _update(const DataType& shared_data) {
+    }
+};
+
+using ThreeBodyArrheniusRate = ThreeBodyRate<Arrhenius3, ArrheniusData>;
 
 }
 

--- a/include/cantera/kinetics/BulkRate.h
+++ b/include/cantera/kinetics/BulkRate.h
@@ -37,9 +37,9 @@ public:
 };
 
 
-using ArrheniusRate = BulkRate<Arrhenius3, ArrheniusData>;
+using ArrheniusRate = BulkRate<Arrhenius3, ReactionData>;
 using TwoTempPlasmaRate = BulkRate<TwoTempPlasma, TwoTempPlasmaData>;
-using BlowersMaselRate = BulkRate<BlowersMasel, BlowersMaselData>;
+using BlowersMaselRate = BulkRate<BlowersMasel, BulkData>;
 
 
 class ThreeBodyBase
@@ -89,7 +89,7 @@ public:
     }
 
     //! Apply correction
-    double applyCorrection(double value) {
+    double applyCorrection(double value) const {
         if (m_massAction) {
             return value * m_thirdBodyConc;
         }
@@ -189,6 +189,7 @@ protected:
 };
 
 using ThreeBodyArrheniusRate = ThreeBodyRate<Arrhenius3, BulkData>;
+using ThreeBodyBlowersMaselRate = ThreeBodyRate<BlowersMasel, BulkData>;
 
 }
 

--- a/include/cantera/kinetics/BulkRate.h
+++ b/include/cantera/kinetics/BulkRate.h
@@ -108,6 +108,16 @@ public:
         return m_thirdBodyConc;
     }
 
+    //! Get flag indicating whether collision partner is explicitly specified
+    bool specifiedCollisionPartner() {
+        return m_specifiedCollisionPartner;
+    }
+
+    //! Set flag indicating whether collision partner is explicitly specified
+    void setSpecifiedCollisionPartner(bool specified) {
+        m_specifiedCollisionPartner = specified;
+    }
+
 protected:
     double m_thirdBodyConc; //!< Effective third-body concentration
 

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -33,24 +33,14 @@ class Func1;
  * @warning This class is an experimental part of the %Cantera API and
  *    may be changed or removed without notice.
  */
-class CustomFunc1Rate final : public ReactionRate
+class CustomFunc1Base : public ReactionRate
 {
 public:
-    CustomFunc1Rate();
-    CustomFunc1Rate(const AnyMap& node, const UnitStack& rate_units)
-        : CustomFunc1Rate()
-    {
-        setParameters(node, rate_units);
-    }
-
-    unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiRate<CustomFunc1Rate, ReactionData>);
-    }
+    CustomFunc1Base() = default;
 
     const std::string type() const override { return "custom-rate-function"; }
 
     void getParameters(AnyMap& rateNode, const Units& rate_units=Units(0.)) const;
-    using ReactionRate::getParameters;
 
     //! Update information specific to reaction
     /*!
@@ -66,7 +56,7 @@ public:
     void setRateFunction(shared_ptr<Func1> f);
 
 protected:
-    shared_ptr<Func1> m_ratefunc;
+    shared_ptr<Func1> m_ratefunc = 0;
 };
 
 

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -44,7 +44,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiRate<CustomFunc1Rate, ArrheniusData>);
+        return unique_ptr<MultiRateBase>(new MultiRate<CustomFunc1Rate, ReactionData>);
     }
 
     const std::string type() const override { return "custom-rate-function"; }
@@ -56,7 +56,7 @@ public:
     /*!
      *  @param shared_data  data shared by all reactions of a given type
      */
-    double evalFromStruct(const ArrheniusData& shared_data) const;
+    double evalFromStruct(const ReactionData& shared_data) const;
 
     //! Set custom rate
     /**

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -260,25 +260,12 @@ public:
             setCoverageDependencies(
                 node["coverage-dependencies"].as<AnyMap>(), node.units());
         }
-        RateType::m_negativeA_ok = node.getBool("negative-A", false);
-        if (!node.hasKey("rate-constant")) {
-            RateType::setRateParameters(AnyValue(), node.units(), rate_units);
-            return;
-        }
-        RateType::setRateParameters(node["rate-constant"], node.units(), rate_units);
+        RateType::setParameters(node, rate_units);
     }
 
     virtual void getParameters(AnyMap& node) const override {
+        RateType::getParameters(node);
         node["type"] = type();
-        if (RateType::m_negativeA_ok) {
-            node["negative-A"] = true;
-        }
-        AnyMap rateNode;
-        RateType::getRateParameters(rateNode);
-        if (!rateNode.empty()) {
-            // RateType object is configured
-            node["rate-constant"] = std::move(rateNode);
-        }
         if (!m_cov.empty()) {
             AnyMap deps;
             getCoverageDependencies(deps);

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -76,7 +76,7 @@ public:
     //! @param shared_data  data shared by all reactions of a given type
     void updateFromStruct(const CoverageData& shared_data) {
         if (shared_data.ready) {
-            m_siteDensity = shared_data.density;
+            m_siteDensity = shared_data.siteDensity;
         }
         if (m_indices.size() != m_cov.size()) {
             // object is not set up correctly (setSpecies needs to be run)

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -112,6 +112,9 @@ public:
     //! @param kin  Kinetics object
     void checkBalance(const Kinetics& kin) const;
 
+    //! Check whether reaction contains third-body collision partner
+    bool checkThreeBody() const;
+
     //! Verify that all species involved in the reaction are defined in the Kinetics
     //! object. The function returns true if all species are found, and raises an
     //! exception unless the kinetics object is configured to skip undeclared species,

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -479,31 +479,6 @@ public:
 };
 
 
-//! A reaction with a non-reacting third body "M" that acts to add or remove
-//! energy from the reacting species
-class ThreeBodyReaction3 : public Reaction
-{
-public:
-    ThreeBodyReaction3();
-    ThreeBodyReaction3(const Composition& reactants, const Composition& products,
-                       const ArrheniusRate& rate, const ThirdBody& tbody);
-
-    ThreeBodyReaction3(const AnyMap& node, const Kinetics& kin);
-
-    virtual std::string type() const {
-        return "three-body";
-    }
-
-    virtual void setEquation(const std::string& equation, const Kinetics* kin=0);
-    bool detectEfficiencies();
-    virtual void setParameters(const AnyMap& node, const Kinetics& kin);
-    virtual void getParameters(AnyMap& reactionNode) const;
-
-    virtual std::string reactantString() const;
-    virtual std::string productString() const;
-};
-
-
 //! A falloff reaction that is first-order in [M] at low pressure, like a third-body
 //! reaction, but zeroth-order in [M] as pressure increases.
 //! In addition, the class supports chemically-activated reactions where the rate
@@ -552,7 +527,6 @@ public:
 
 
 #ifdef CT_NO_LEGACY_REACTIONS_26
-typedef ThreeBodyReaction3 ThreeBodyReaction;
 typedef FalloffReaction3 FalloffReaction;
 #else
 typedef ElementaryReaction2 ElementaryReaction;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -12,6 +12,7 @@
 #include "cantera/kinetics/ReactionRate.h"
 #include "cantera/kinetics/RxnRates.h"
 #include "cantera/base/Units.h"
+#include "BulkRate.h"
 #include "InterfaceRate.h"
 #include "Custom.h"
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -115,6 +115,10 @@ public:
     //! Check whether reaction contains third-body collision partner
     bool checkThreeBody() const;
 
+    //! Strip third-body name/synbol from reactant and product composition
+    //! @param detect  Run detection of unmarked third-body collider
+    bool stripThirdBody(bool detect=true);
+
     //! Verify that all species involved in the reaction are defined in the Kinetics
     //! object. The function returns true if all species are found, and raises an
     //! exception unless the kinetics object is configured to skip undeclared species,
@@ -192,6 +196,9 @@ protected:
 
     //! Flag indicating whether reaction is set up correctly
     bool m_valid;
+
+    //! Name or placeholder of third body species
+    std::string m_thirdBodyCollider;
 
     //! @internal  Helper function returning vector of undeclared third body species
     //! and a boolean expression indicating whether the third body is specified.

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -119,6 +119,10 @@ public:
     //! @param detect  Run detection of unmarked third-body collider
     bool stripThirdBody(bool detect=true);
 
+    std::string thirdBodyCollider() const {
+        return m_thirdBodyCollider;
+    }
+
     //! Verify that all species involved in the reaction are defined in the Kinetics
     //! object. The function returns true if all species are found, and raises an
     //! exception unless the kinetics object is configured to skip undeclared species,

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -116,8 +116,7 @@ public:
     bool checkThreeBody() const;
 
     //! Strip third-body name/synbol from reactant and product composition
-    //! @param detect  Run detection of unmarked third-body collider
-    bool stripThirdBody(bool detect=true);
+    bool stripThirdBody();
 
     std::string thirdBodyCollider() const {
         return m_thirdBodyCollider;

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -167,6 +167,37 @@ protected:
 };
 
 
+//! Data container holding shared generic data specific to BulkRate
+/**
+ *  The data container `BulkData` holds generic precalculated data common to all
+ *  templated `BulkData<>` objects.
+ */
+struct BulkData : public ReactionData
+{
+    BulkData();
+
+    virtual void update(double T) override;
+
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
+
+    using ReactionData::update;
+
+    virtual void resize(size_t n_species, size_t n_reactions) override {
+        concentrations.resize(n_species, 0.);
+        partialMolarEnthalpies.resize(n_species, 0.);
+        ready = true;
+    }
+
+    bool ready; //!< boolean indicating whether vectors are accessible
+    double molarDensity; //!< total molar density (concentration)
+    vector_fp concentrations; //!< species concentrations
+    vector_fp partialMolarEnthalpies; //!< partial molar enthalpies
+
+protected:
+    int m_state_mf_number; //!< integer that is incremented when composition changes
+};
+
+
 //! Data container holding shared data specific to Falloff rates
 /**
  * The data container `FalloffData` holds precalculated data common to

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -604,6 +604,7 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
 
     cdef cppclass CxxReaction "Cantera::Reaction":
         CxxReaction()
+        CxxReaction(Composition&, Composition&, shared_ptr[CxxReactionRate]) except +translate_exception
 
         string reactantString()
         string productString()
@@ -695,9 +696,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         cbool is_sticking_coefficient
         cbool use_motz_wise_correction
         string sticking_species
-
-    cdef cppclass CxxThreeBodyReaction3 "Cantera::ThreeBodyReaction3" (CxxReaction):
-        CxxThreeBodyReaction3()
 
     cdef cppclass CxxFalloffReaction3 "Cantera::FalloffReaction3" (CxxReaction):
         CxxFalloffReaction3()

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -546,6 +546,18 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
         CxxCustomFunc1Rate()
         void setRateFunction(shared_ptr[CxxFunc1]) except +translate_exception
 
+    cdef cppclass CxxThreeBodyBase "Cantera::ThreeBodyBase":
+        Composition efficiencies()
+        void setEfficiencies(Composition&) except +translate_exception
+        void efficiency(string&) except +translate_exception
+        double defaultEfficiency()
+        void setDefaultEfficiency(double)
+
+    cdef cppclass CxxThreeBodyArrheniusRate "Cantera::ThreeBodyArrheniusRate" (CxxReactionRate, CxxArrhenius, CxxThreeBodyBase):
+        CxxThreeBodyArrheniusRate()
+        CxxThreeBodyArrheniusRate(CxxAnyMap) except +translate_exception
+        CxxThreeBodyArrheniusRate(double, double, double)
+
     cdef cppclass CxxCoverageBase "Cantera::CoverageBase":
         void getCoverageDependencies(CxxAnyMap)
         void setCoverageDependencies(CxxAnyMap) except +translate_exception
@@ -1406,6 +1418,9 @@ cdef class FalloffRate(ReactionRate):
 cdef class CustomRate(ReactionRate):
     cdef CxxCustomFunc1Rate* cxx_object(self)
     cdef Func1 _rate_func
+
+cdef class ThreeBodyRateBase(ArrheniusRateBase):
+    cdef CxxThreeBodyBase* threebody
 
 cdef class InterfaceRateBase(ArrheniusRateBase):
     cdef CxxCoverageBase* coverage

--- a/interfaces/cython/cantera/test/test_jacobian.py
+++ b/interfaces/cython/cantera/test/test_jacobian.py
@@ -395,7 +395,7 @@ class TestThreeBody(HydrogenOxygen, utilities.CanteraTest):
     # Three body reaction with default efficiency
     rxn_idx = 1
     equation = "H + O + M <=> OH + M"
-    rate_type = "Arrhenius"
+    rate_type = "three-body-Arrhenius"
 
     @classmethod
     def setUpClass(cls):
@@ -463,7 +463,7 @@ class TestThreeBodyNoDefault(EdgeCases, utilities.CanteraTest):
     # Three body reaction without default efficiency
     rxn_idx = 4
     equation = "H + O + M <=> OH + M"
-    rate_type = "Arrhenius"
+    rate_type = "three-body-Arrhenius"
 
     @classmethod
     def setUpClass(cls):

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -317,7 +317,7 @@ class TestBlowersMaselRate(ReactionRateTests, utilities.CanteraTest):
 
     def eval(self, rate):
         rate.delta_enthalpy = self.soln.delta_enthalpy[self._index]
-        with pytest.warns(UserWarning, match="BlowersMaselData::update"):
+        with pytest.warns(UserWarning, match="BulkData::update"):
             return rate(self.soln.T)
 
     def test_from_parts(self):
@@ -1365,7 +1365,7 @@ class TestBlowersMasel(ReactionTests, utilities.CanteraTest):
 
     def eval_rate(self, rate):
         rate.delta_enthalpy = self.soln.delta_enthalpy[self._index]
-        with pytest.warns(UserWarning, match="BlowersMaselData::update"):
+        with pytest.warns(UserWarning, match="BulkData::update"):
             return rate(self.soln.T)
 
 

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -175,7 +175,7 @@ BlowersMasel::BlowersMasel(double A, double b, double Ea0, double w)
     m_E4_R = w / GasConstant;
 }
 
-double BlowersMasel::ddTScaledFromStruct(const BlowersMaselData& shared_data) const
+double BlowersMasel::ddTScaledFromStruct(const BulkData& shared_data) const
 {
     warn_user("BlowersMasel::ddTScaledFromStruct",
         "Temperature derivative does not consider changes of reaction enthalpy.");

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -156,6 +156,15 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
         if (r->thirdBody() != nullptr) {
             addThirdBody(r);
         }
+        const auto threeBody = std::dynamic_pointer_cast<ThreeBodyArrheniusRate>(rate);
+        if (threeBody) {
+            // preliminary proof-of-concept uses ThirdBodyCalc3
+            std::map<size_t, double> efficiencies;
+            threeBody->getEfficiencyMap(efficiencies);
+            m_multi_concm.install(
+                nReactions() - 1, efficiencies,
+                threeBody->defaultEfficiency(), threeBody->massAction());
+        }
     }
 
     m_concm.push_back(NAN);

--- a/src/kinetics/BulkRate.cpp
+++ b/src/kinetics/BulkRate.cpp
@@ -1,0 +1,59 @@
+//! @file BulkRate.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/kinetics/BulkRate.h"
+#include "cantera/kinetics/Kinetics.h"
+// #include "cantera/thermo/ThermoPhase.h"
+// #include "cantera/thermo/SurfPhase.h"
+#include "cantera/base/AnyMap.h"
+
+namespace Cantera
+{
+
+ThreeBodyBase::ThreeBodyBase()
+    : m_threeBodyConc(NAN)
+    , m_defaultEfficiency(1.)
+    , m_specifiedCollisionPartner(false)
+    , m_massAction(false)
+{}
+
+void ThreeBodyBase::setEfficiencies(const AnyMap& node)
+{
+    m_defaultEfficiency = node.getDouble("default-efficiency", 1.0);
+    if (node.hasKey("efficiencies")) {
+        m_efficiencyMap = node["efficiencies"].asMap<double>();
+    }
+}
+
+void ThreeBodyBase::getEfficiencies(AnyMap& node) const
+{
+    if (!m_specifiedCollisionPartner) {
+        node["efficiencies"] = m_efficiencies;
+        node["efficiencies"].setFlowStyle();
+        if (m_defaultEfficiency != 1.0) {
+            node["default-efficiency"] = m_defaultEfficiency;
+        }
+    }
+}
+
+double ThreeBodyBase::efficiency(const std::string& k) const {
+    return getValue(m_efficiencyMap, k, m_defaultEfficiency);
+}
+
+void ThreeBodyBase::setContext(const Reaction& rxn, const Kinetics& kin)
+{
+    for (const auto& eff : m_efficiencyMap) {
+        size_t k = kin.kineticsSpeciesIndex(eff.first);
+        if (k != npos) {
+            m_efficiencies.emplace_back(k, eff.second);
+        } else if (!kin.skipUndeclaredThirdBodies()) {
+            throw CanteraError("ThreeBodyBase::setContext",
+                "Found third-body efficiency for undeclared species '{}' "
+                "while adding reaction '{}'", eff.first, rxn.equation());
+        }
+    }
+}
+
+}

--- a/src/kinetics/BulkRate.cpp
+++ b/src/kinetics/BulkRate.cpp
@@ -40,12 +40,13 @@ void ThreeBodyBase::getParameters(AnyMap& node) const
     }
 }
 
-void ThreeBodyBase::getEfficiencies(AnyMap& efficiencies) const
+void ThreeBodyBase::setEfficiencies(const Composition& efficiencies)
 {
-    efficiencies.clear();
-    for (const auto& eff : m_efficiencies) {
-        efficiencies[eff.first] = eff.second;
+    if (m_efficiencyMap.size()) {
+        throw CanteraError("ThreeBodyBase::setEfficiencies",
+            "Unable to set efficiencies once they have been processed.");
     }
+    m_efficiencies = efficiencies;
 }
 
 void ThreeBodyBase::getEfficiencyMap(std::map<size_t, double>& eff) const

--- a/src/kinetics/BulkRate.cpp
+++ b/src/kinetics/BulkRate.cpp
@@ -23,13 +23,16 @@ void ThreeBodyBase::setParameters(const AnyMap& node)
     if (node.hasKey("efficiencies")) {
         m_efficiencyMap = node["efficiencies"].asMap<double>();
     }
+    m_specifiedCollisionPartner = node.getBool("specified-collider", false);
 }
 
 void ThreeBodyBase::getParameters(AnyMap& node) const
 {
     if (!m_specifiedCollisionPartner) {
-        node["efficiencies"] = m_efficiencyMap;
-        node["efficiencies"].setFlowStyle();
+        if (m_efficiencyMap.size()) {
+            node["efficiencies"] = m_efficiencyMap;
+            node["efficiencies"].setFlowStyle();
+        }
         if (m_defaultEfficiency != 1.0) {
             node["default-efficiency"] = m_defaultEfficiency;
         }

--- a/src/kinetics/Custom.cpp
+++ b/src/kinetics/Custom.cpp
@@ -9,17 +9,12 @@
 namespace Cantera
 {
 
-CustomFunc1Rate::CustomFunc1Rate()
-    : m_ratefunc(0)
-{
-}
-
-void CustomFunc1Rate::setRateFunction(shared_ptr<Func1> f)
+void CustomFunc1Base::setRateFunction(shared_ptr<Func1> f)
 {
     m_ratefunc = f;
 }
 
-double CustomFunc1Rate::evalFromStruct(const ReactionData& shared_data) const
+double CustomFunc1Base::evalFromStruct(const ReactionData& shared_data) const
 {
     if (m_ratefunc) {
         return m_ratefunc->eval(shared_data.temperature);
@@ -27,9 +22,9 @@ double CustomFunc1Rate::evalFromStruct(const ReactionData& shared_data) const
     return NAN;
 }
 
-void CustomFunc1Rate::getParameters(AnyMap& rateNode, const Units& rate_units) const
+void CustomFunc1Base::getParameters(AnyMap& rateNode, const Units& rate_units) const
 {
-    throw NotImplementedError("CustomFunc1Rate::getParameters",
+    throw NotImplementedError("CustomFunc1Base::getParameters",
                               "Not implemented by '{}' object.", type());
 }
 

--- a/src/kinetics/Custom.cpp
+++ b/src/kinetics/Custom.cpp
@@ -19,7 +19,7 @@ void CustomFunc1Rate::setRateFunction(shared_ptr<Func1> f)
     m_ratefunc = f;
 }
 
-double CustomFunc1Rate::evalFromStruct(const ArrheniusData& shared_data) const
+double CustomFunc1Rate::evalFromStruct(const ReactionData& shared_data) const
 {
     if (m_ratefunc) {
         return m_ratefunc->eval(shared_data.temperature);

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -758,6 +758,14 @@ void Kinetics::modifyReaction(size_t i, shared_ptr<Reaction> rNew)
             rOld->type(), rNew->type());
     }
 
+    if (!(rNew->usesLegacy())) {
+        if (rNew->rate()->type() != rOld->rate()->type()) {
+            throw CanteraError("Kinetics::modifyReaction",
+                "ReactionRate types are different: {} != {}.",
+                rOld->rate()->type(), rNew->rate()->type());
+        }
+    }
+
     if (rNew->reactants != rOld->reactants) {
         throw CanteraError("Kinetics::modifyReaction",
             "Reactants are different: '{}' != '{}'.",

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -183,22 +183,6 @@ std::pair<size_t, size_t> Kinetics::checkDuplicates(bool throw_err) const
                 if (thirdBodyOk) {
                     continue; // No overlap in third body efficiencies
                 }
-            } else if (R.type() == "three-body") {
-                ThirdBody& tb1 = *(dynamic_cast<ThreeBodyReaction3&>(R).thirdBody());
-                ThirdBody& tb2 = *(dynamic_cast<ThreeBodyReaction3&>(other).thirdBody());
-                bool thirdBodyOk = true;
-                for (size_t k = 0; k < nTotalSpecies(); k++) {
-                    string s = kineticsSpeciesName(k);
-                    if (tb1.efficiency(s) * tb2.efficiency(s) != 0.0) {
-                        // non-zero third body efficiencies for species `s` in
-                        // both reactions
-                        thirdBodyOk = false;
-                        break;
-                    }
-                }
-                if (thirdBodyOk) {
-                    continue; // No overlap in third body efficiencies
-                }
             } else if (R.type() == "three-body-legacy") {
                 ThirdBody& tb1 = dynamic_cast<ThreeBodyReaction2&>(R).third_body;
                 ThirdBody& tb2 = dynamic_cast<ThreeBodyReaction2&>(other).third_body;

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -215,6 +215,25 @@ std::pair<size_t, size_t> Kinetics::checkDuplicates(bool throw_err) const
                 if (thirdBodyOk) {
                     continue; // No overlap in third body efficiencies
                 }
+            } else if (R.thirdBodyCollider() != "") {
+                auto tb1 = std::dynamic_pointer_cast<ThreeBodyArrheniusRate>(R.rate());
+                auto tb2 = std::dynamic_pointer_cast<ThreeBodyArrheniusRate>(other.rate());
+                if (!tb1 || !tb2) {
+                    continue;
+                }
+                bool thirdBodyOk = true;
+                for (size_t k = 0; k < nTotalSpecies(); k++) {
+                    string s = kineticsSpeciesName(k);
+                    if (tb1->efficiency(s) * tb2->efficiency(s) != 0.0) {
+                        // non-zero third body efficiencies for species `s` in
+                        // both reactions
+                        thirdBodyOk = false;
+                        break;
+                    }
+                }
+                if (thirdBodyOk) {
+                    continue; // No overlap in third body efficiencies
+                }
             }
             if (throw_err) {
                 throw InputFileError("Kinetics::checkDuplicates",

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -418,7 +418,7 @@ UnitStack Reaction::calculateRateCoeffUnits3(const Kinetics& kin)
         }
     }
 
-    if (m_third_body) {
+    if (m_third_body || m_thirdBodyCollider != "") {
         // Account for third-body collision partner as the last entry
         rate_units.join(-1);
     }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -471,6 +471,44 @@ void Reaction::checkBalance(const Kinetics& kin) const
     }
 }
 
+bool Reaction::checkThreeBody() const
+{
+    // detect explicitly specified collision partner
+    size_t found = 0;
+    for (const auto& reac : reactants) {
+        auto prod = products.find(reac.first);
+        if (prod != products.end() &&
+            trunc(reac.second) == reac.second && trunc(prod->second) == prod->second) {
+            // candidate species with integer stoichiometric coefficients on both sides
+            found += 1;
+        }
+    }
+    if (found != 1) {
+        return false;
+    }
+
+    // ensure that all reactants have integer stoichiometric coefficients
+    size_t nreac = 0;
+    for (const auto& reac : reactants) {
+       if (trunc(reac.second) != reac.second) {
+           return false;
+       }
+       nreac += static_cast<size_t>(reac.second);
+    }
+
+    // ensure that all products have integer stoichiometric coefficients
+    size_t nprod = 0;
+    for (const auto& prod : products) {
+       if (trunc(prod.second) != prod.second) {
+           return false;
+       }
+       nprod += static_cast<size_t>(prod.second);
+    }
+
+    // either reactant or product side involves exactly three species
+    return (nreac == 3) || (nprod == 3);
+}
+
 bool Reaction::checkSpecies(const Kinetics& kin) const
 {
     // Check for undeclared species

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -244,9 +244,11 @@ void Reaction::getParameters(AnyMap& reactionNode) const
         // strip information not needed for reconstruction
         if (reactionNode.hasKey("type")) {
             std::string type = reactionNode["type"].asString();
-            if (boost::algorithm::starts_with(type, "Arrhenius")) {
-                reactionNode.erase("type");
-            } else if (boost::algorithm::starts_with(type, "Blowers-Masel")) {
+            if (boost::algorithm::ends_with(type, "Arrhenius")) {
+                if (!boost::algorithm::starts_with(type, "pressure-dependent-")) {
+                    reactionNode.erase("type");
+                }
+            } else if (boost::algorithm::ends_with(type, "Blowers-Masel")) {
                 reactionNode["type"] = "Blowers-Masel";
             }
         }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -445,6 +445,11 @@ std::pair<std::vector<std::string>, bool> Reaction::undeclaredThirdBodies(
     if (m_third_body) {
         updateUndeclared(undeclared, m_third_body->efficiencies, kin);
         return std::make_pair(undeclared, m_third_body->specified_collision_partner);
+    } else if (std::dynamic_pointer_cast<const ThreeBodyArrheniusRate>(m_rate)) {
+        // @todo  this needs a more generic approach
+        auto threeBody = std::dynamic_pointer_cast<const ThreeBodyArrheniusRate>(m_rate);
+        updateUndeclared(undeclared, threeBody->efficiencies(), kin);
+        return std::make_pair(undeclared, m_thirdBodyCollider != "M");
     }
     return std::make_pair(undeclared, false);
 }

--- a/src/kinetics/ReactionData.cpp
+++ b/src/kinetics/ReactionData.cpp
@@ -121,6 +121,39 @@ bool BlowersMaselData::update(const ThermoPhase& phase, const Kinetics& kin)
     return changed;
 }
 
+BulkData::BulkData()
+    : ready(false)
+    , molarDensity(NAN)
+    , m_state_mf_number(-1)
+{
+}
+
+void BulkData::update(double T) {
+    warn_user("BulkData::update",
+        "This method does not updates partial molar enthalpies or concentrations.");
+    ReactionData::update(T);
+}
+
+bool BulkData::update(const ThermoPhase& phase, const Kinetics& kin)
+{
+    double ctot = phase.molarDensity();
+    int mf = phase.stateMFNumber();
+    double T = phase.temperature();
+    bool changed = false;
+    if (T != temperature) {
+        ReactionData::update(T);
+        changed = true;
+    }
+    if (changed || ctot != molarDensity || mf != m_state_mf_number) {
+        molarDensity = ctot;
+        m_state_mf_number = mf;
+        phase.getConcentrations(concentrations.data());
+        phase.getPartialMolarEnthalpies(partialMolarEnthalpies.data());
+        changed = true;
+    }
+    return changed;
+}
+
 FalloffData::FalloffData()
     : ready(false)
     , molar_density(NAN)

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -111,6 +111,9 @@ ReactionFactory::ReactionFactory()
         return new CustomFunc1Reaction(node, kin);
     });
 
+    addAlias("reaction", "three-body-Arrhenius");
+    addAlias("reaction", "three-body-Blowers-Masel");
+
     // register interface reactions
     reg("interface", [](const AnyMap& node, const Kinetics& kin) {
         InterfaceReaction2* R = new InterfaceReaction2();

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -40,12 +40,10 @@ ReactionFactory::ReactionFactory()
         return R;
     });
 
-    // register three-body reactions
-    reg("three-body", [](const AnyMap& node, const Kinetics& kin) {
-        return new ThreeBodyReaction3(node, kin);
-    });
-    addAlias("three-body", "threebody");
-    addAlias("three-body", "three_body");
+    addAlias("reaction", "three-body-Arrhenius");
+    addAlias("reaction", "three-body");
+    addAlias("reaction", "three_body");
+    addAlias("reaction", "threebody");
 
     // register three-body reactions (old framework)
     reg("three-body-legacy", [](const AnyMap& node, const Kinetics& kin) {
@@ -110,9 +108,6 @@ ReactionFactory::ReactionFactory()
     reg("custom-rate-function", [](const AnyMap& node, const Kinetics& kin) {
         return new CustomFunc1Reaction(node, kin);
     });
-
-    addAlias("reaction", "three-body-Arrhenius");
-    addAlias("reaction", "three-body-Blowers-Masel");
 
     // register interface reactions
     reg("interface", [](const AnyMap& node, const Kinetics& kin) {
@@ -294,15 +289,6 @@ unique_ptr<Reaction> newReaction(const AnyMap& rxn_node, const Kinetics& kin)
     size_t nDim = kin.thermo(kin.reactionPhaseIndex()).nDim();
     if (rxn_node.hasKey("type")) {
         type = rxn_node["type"].asString();
-    } else if (nDim == 3) {
-        // Reaction type is not specified
-        // See if this is a three-body reaction with a specified collision partner
-        ElementaryReaction2 testReaction;
-        parseReactionEquation(testReaction, rxn_node["equation"].asString(),
-                              rxn_node, &kin);
-        if (testReaction.checkThreeBody()) {
-            type = "three-body";
-        }
     }
 
     if (nDim < 3 && type == "elementary") {

--- a/src/kinetics/ReactionRateFactory.cpp
+++ b/src/kinetics/ReactionRateFactory.cpp
@@ -27,12 +27,12 @@ ReactionRateFactory::ReactionRateFactory()
     });
     addAlias("Arrhenius", "");
     addAlias("Arrhenius", "elementary");
-    addAlias("Arrhenius", "three-body");
 
     // ArrheniusRate evaluator with third-body collider
     reg("three-body-Arrhenius", [](const AnyMap& node, const UnitStack& rate_units) {
         return new ThreeBodyArrheniusRate(node, rate_units);
     });
+    addAlias("three-body-Arrhenius", "three-body");
 
     // TwoTempPlasmaRate evaluator
     reg("two-temperature-plasma", [](const AnyMap& node, const UnitStack& rate_units) {

--- a/src/kinetics/ReactionRateFactory.cpp
+++ b/src/kinetics/ReactionRateFactory.cpp
@@ -29,6 +29,11 @@ ReactionRateFactory::ReactionRateFactory()
     addAlias("Arrhenius", "elementary");
     addAlias("Arrhenius", "three-body");
 
+    // ArrheniusRate evaluator with third-body collider
+    reg("three-body-Arrhenius", [](const AnyMap& node, const UnitStack& rate_units) {
+        return new ThreeBodyArrheniusRate(node, rate_units);
+    });
+
     // TwoTempPlasmaRate evaluator
     reg("two-temperature-plasma", [](const AnyMap& node, const UnitStack& rate_units) {
         return new TwoTempPlasmaRate(node, rate_units);
@@ -37,6 +42,11 @@ ReactionRateFactory::ReactionRateFactory()
     // BlowersMaselRate evaluator
     reg("Blowers-Masel", [](const AnyMap& node, const UnitStack& rate_units) {
         return new BlowersMaselRate(node, rate_units);
+    });
+
+    // BlowersMaselRate evaluator with third-body collider
+    reg("three-body-Blowers-Masel", [](const AnyMap& node, const UnitStack& rate_units) {
+        return new ThreeBodyBlowersMaselRate(node, rate_units);
     });
 
     // Lindemann falloff evaluator

--- a/test/kinetics/kineticsFromScratch3.cpp
+++ b/test/kinetics/kineticsFromScratch3.cpp
@@ -73,10 +73,9 @@ TEST_F(KineticsFromScratch3, add_three_body_reaction)
     //     efficiencies: {AR: 0.83, H2: 2.4, H2O: 15.4}
     Composition reac = parseCompString("O:2");
     Composition prod = parseCompString("O2:1");
-    ArrheniusRate rate(1.2e11, -1.0, 0.0);
-    ThirdBody tbody;
-    tbody.efficiencies = parseCompString("AR:0.83 H2:2.4 H2O:15.4");
-    auto R = make_shared<ThreeBodyReaction3>(reac, prod, rate, tbody);
+    auto rate = make_shared<ThreeBodyArrheniusRate>(1.2e11, -1.0, 0.0);
+    rate->setEfficiencies(parseCompString("AR:0.83 H2:2.4 H2O:15.4"));
+    auto R = make_shared<Reaction>(reac, prod, rate);
 
     kin.addReaction(R);
     check_rates(1);
@@ -86,10 +85,9 @@ TEST_F(KineticsFromScratch3, undefined_third_body)
 {
     Composition reac = parseCompString("O:2");
     Composition prod = parseCompString("O2:1");
-    ArrheniusRate rate(1.2e11, -1.0, 0.0);
-    ThirdBody tbody;
-    tbody.efficiencies = parseCompString("H2:0.1 CO2:0.83");
-    auto R = make_shared<ThreeBodyReaction3>(reac, prod, rate, tbody);
+    auto rate = make_shared<ThreeBodyArrheniusRate>(1.2e11, -1.0, 0.0);
+    rate->setEfficiencies(parseCompString("H2:0.1 CO2:0.83"));
+    auto R = make_shared<Reaction>(reac, prod, rate);
 
     ASSERT_THROW(kin.addReaction(R), CanteraError);
 }
@@ -98,10 +96,9 @@ TEST_F(KineticsFromScratch3, skip_undefined_third_body)
 {
     Composition reac = parseCompString("O:2");
     Composition prod = parseCompString("O2:1");
-    ArrheniusRate rate(1.2e11, -1.0, 0.0);
-    ThirdBody tbody;
-    tbody.efficiencies = parseCompString("H2:0.1 CO2:0.83");
-    auto R = make_shared<ThreeBodyReaction3>(reac, prod, rate, tbody);
+    auto rate = make_shared<ThreeBodyArrheniusRate>(1.2e11, -1.0, 0.0);
+    rate->setEfficiencies(parseCompString("H2:0.1 CO2:0.83"));
+    auto R = make_shared<Reaction>(reac, prod, rate);
 
     kin.skipUndeclaredThirdBodies(true);
     kin.addReaction(R);

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -79,11 +79,10 @@ TEST(Reaction, ThreeBodyFromYaml3)
 
     auto R = newReaction(rxn, *(sol->kinetics()));
     EXPECT_EQ(R->reactants.count("M"), (size_t) 0);
-    EXPECT_EQ(R->type(), "three-body");
-    EXPECT_DOUBLE_EQ(R->thirdBody()->efficiencies["H2O"], 5.0);
-    EXPECT_DOUBLE_EQ(R->thirdBody()->default_efficiency, 1.0);
-
-    const auto& rate = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
+    EXPECT_EQ(R->type(), "reaction");
+    const auto& rate = std::dynamic_pointer_cast<ThreeBodyArrheniusRate>(R->rate());
+    EXPECT_DOUBLE_EQ(rate->efficiencies()["H2O"], 5.0);
+    EXPECT_DOUBLE_EQ(rate->defaultEfficiency(), 1.0);
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), 1.2e11);
 }
 
@@ -539,7 +538,7 @@ TEST_F(ReactionToYaml, threeBody)
     soln = newSolution("h2o2.yaml", "", "None");
     soln->thermo()->setState_TPY(1000, 2e5, "H2:1.0, O2:0.5, O:1e-8, OH:3e-8, H:2e-7");
     duplicateReaction(1);
-    EXPECT_TRUE(std::dynamic_pointer_cast<ThreeBodyReaction3>(duplicate));
+    EXPECT_TRUE(std::dynamic_pointer_cast<ThreeBodyArrheniusRate>(duplicate->rate()));
     compareReactions();
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Remove remaining specializations per Cantera/enhancements#142

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Create `ThreeBodyArrheniusRate` specialization for  `three-body-Arrhenius`
- Eliminate `ThreeBodyReaction` in C++ and Python
- :construction:  

Once fully implemented, this PR will allow for a deprecation of `ReactionFactory`.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#142, closes Cantera/enhancements#133, interferes with #1143

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review

**Thoughts**

Due to the introduction of `BulkRate.h`, this PR has some minor conflicts with #1217