### PR TITLE
Fix invalid unchecked cast to StFlow

### DIFF
--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -42,13 +42,19 @@ void Boundary1D::_init(size_t n)
     // check for left and right flow objects
     if (m_index > 0) {
         Domain1D& r = container().domain(m_index-1);
-        if (!r.isConnector()) { // flow domain
-            m_flow_left = (StFlow*)&r;
-            m_left_nv = m_flow_left->nComponents();
-            m_left_points = m_flow_left->nPoints();
+        if (!r.isConnector()) { // multi-point domain
+            m_left_nv = r.nComponents();
+            if (m_left_nv > c_offset_Y) {
+                m_left_nsp = m_left_nv - c_offset_Y;
+            } else {
+                m_left_nsp = 0;
+            }
             m_left_loc = container().start(m_index-1);
-            m_left_nsp = m_left_nv - c_offset_Y;
-            m_phase_left = &m_flow_left->phase();
+            m_left_points = r.nPoints();
+            m_flow_left = dynamic_cast<StFlow*>(&r);
+            if (m_flow_left != nullptr) {
+                m_phase_left = &m_flow_left->phase();
+            }
         } else {
             throw CanteraError("Boundary1D::_init",
                 "Boundary domains can only be connected on the left to flow "
@@ -59,12 +65,18 @@ void Boundary1D::_init(size_t n)
     // if this is not the last domain, see what is connected on the right
     if (m_index + 1 < container().nDomains()) {
         Domain1D& r = container().domain(m_index+1);
-        if (!r.isConnector()) { // flow domain
-            m_flow_right = (StFlow*)&r;
-            m_right_nv = m_flow_right->nComponents();
+        if (!r.isConnector()) { // multi-point domain
+            m_right_nv = r.nComponents();
+            if (m_right_nv > c_offset_Y) {
+                m_right_nsp = m_right_nv - c_offset_Y;
+            } else {
+                m_right_nsp = 0;
+            }
             m_right_loc = container().start(m_index+1);
-            m_right_nsp = m_right_nv - c_offset_Y;
-            m_phase_right = &m_flow_right->phase();
+            m_flow_right = dynamic_cast<StFlow*>(&r);
+            if (m_flow_right != nullptr) {
+                m_phase_right = &m_flow_right->phase();
+            }
         } else {
             throw CanteraError("Boundary1D::_init",
                 "Boundary domains can only be connected on the right to flow "


### PR DESCRIPTION
The domain between two boundaries isn't necessarily an StFlow object,
as exemplified by the Blasius BVP sample code.

Fixes #1224

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Replace unchecked C-style casts to `StFlow*` with `dynamic_cast`
- Partial fix for logic calculating number of species in a boundary domain

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1224

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
