### PR TITLE
Fix/deprecate 'from_pandas' interface

### DIFF
--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -472,7 +472,8 @@ class FlameBase(Sim1D):
 
     def from_pandas(self, df, restore_boundaries=True, settings=None):
         """
-        Restore the solution vector from a `pandas.DataFrame`.
+        Restore the solution vector from a `pandas.DataFrame`; currently disabled
+        (`save`/`restore` or `write_hdf`/`read_hdf` should be used as alternatives).
 
         :param df:
             `pandas.DataFrame` containing data to be restored
@@ -488,10 +489,9 @@ class FlameBase(Sim1D):
         requires a working *pandas* installation. The package ``pandas`` can be
         installed using pip or conda.
         """
-        arr = SolutionArray(self.gas, extra=self.other_components())
-        arr.from_pandas(df)
-        self.from_solution_array(arr, restore_boundaries=restore_boundaries,
-                                 settings=settings)
+        # @todo: Discuss implementation that allows for restoration of boundaries
+        raise NotImplementedError(
+            "Use 'save'/'restore' or 'write_hdf'/'read_hdf' as alternatives.")
 
     def write_hdf(self, filename, *args, group=None, species='X', mode='a',
                   description=None, compression=None, compression_opts=None,


### PR DESCRIPTION
*pandas* dataframes do not include information on boundaries and thus cannot
be used to recreate all information required to restore a simulation object.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- fix `from_pandas` keyword arguments
- deprecate `from_pandas` as it does not allow for a complete restoration of the object

Note that this API was used for a previous implementation of a pandas-based HDF export/import route, which has since been refactored.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1235

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
