### PR TITLE
Introduce cantera/core.h for C++ Examples

### DIFF
--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -44,8 +44,12 @@ public:
     //! Set the Kinetics object
     virtual void setKinetics(shared_ptr<Kinetics> kinetics);
 
-    //! Set the Transport object
+    //! Set the Transport object directly
     virtual void setTransport(shared_ptr<Transport> transport);
+
+    //! Set the Transport object by name
+    //! @param model  name of transport model
+    virtual void setTransport(const std::string& model);
 
     //! Accessor for the ThermoPhase pointer
     shared_ptr<ThermoPhase> thermo() {

--- a/include/cantera/core.h
+++ b/include/cantera/core.h
@@ -1,0 +1,18 @@
+/**
+ * @file core.h
+ *
+ * Support for Cantera core calculations from C++ application programs. This
+ * header file includes a minimal set of headers needed to create and use objects
+ * that evaluate thermo properties, chemical kinetics and transport properties.
+ */
+
+#ifndef CT_INCL_CORE_H
+#define CT_INCL_CORE_H
+
+// #include "cantera/base/global.h"
+#include "cantera/base/Solution.h"
+#include "cantera/thermo/ThermoPhase.h"
+#include "cantera/kinetics/Kinetics.h"
+#include "cantera/transport/TransportBase.h"
+
+#endif

--- a/include/cantera/core.h
+++ b/include/cantera/core.h
@@ -9,7 +9,6 @@
 #ifndef CT_INCL_CORE_H
 #define CT_INCL_CORE_H
 
-// #include "cantera/base/global.h"
 #include "cantera/base/Solution.h"
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/kinetics/Kinetics.h"

--- a/include/cantera/onedim.h
+++ b/include/cantera/onedim.h
@@ -11,6 +11,9 @@
 #ifndef CT_INCL_ONEDIM_H
 #define CT_INCL_ONEDIM_H
 
+// Cantera core
+#include "cantera/core.h"
+
 #include "oneD/Sim1D.h"
 #include "oneD/Domain1D.h"
 #include "oneD/Boundary1D.h"

--- a/include/cantera/zerodim.h
+++ b/include/cantera/zerodim.h
@@ -6,6 +6,9 @@
 #ifndef CT_INCL_ZERODIM_H
 #define CT_INCL_ZERODIM_H
 
+// Cantera core
+#include "cantera/core.h"
+
 // reactor network
 #include "cantera/zeroD/ReactorNet.h"
 

--- a/samples/cxx/LiC6_electrode/LiC6_electrode.cpp
+++ b/samples/cxx/LiC6_electrode/LiC6_electrode.cpp
@@ -13,7 +13,7 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#include "cantera/thermo.h"
+#include "cantera/core.h"
 #include <iostream>
 #include <fstream>
 
@@ -21,12 +21,12 @@ using namespace Cantera;
 
 void calc_potentials()
 {
-    suppress_deprecation_warnings();
     double Tk = 273.15 + 25.0;
 
     std::string filename = "LiC6_electrodebulk.yaml";
     std::string phasename = "LiC6_and_Vacancies";
-    std::unique_ptr<ThermoPhase> electrodebulk(newPhase(filename,phasename));
+    auto sol = newSolution(filename, phasename);
+    auto electrodebulk = sol->thermo();
     std::string intercalatingSpeciesName("Li(C6)");
     size_t intercalatingSpeciesIdx = electrodebulk->speciesIndex(intercalatingSpeciesName);
     size_t nsp_tot = electrodebulk->nSpecies();

--- a/samples/cxx/combustor/combustor.cpp
+++ b/samples/cxx/combustor/combustor.cpp
@@ -17,8 +17,6 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
-#include "cantera/thermo/IdealGasPhase.h"
-
 #include <fstream>
 
 using namespace Cantera;

--- a/samples/cxx/custom/custom.cpp
+++ b/samples/cxx/custom/custom.cpp
@@ -13,9 +13,7 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#include "cantera/thermo.h"
-#include "cantera/kinetics.h"
-#include "cantera/base/Solution.h"
+#include "cantera/core.h"
 #include "cantera/numerics/Integrator.h"
 #include <fstream>
 
@@ -75,7 +73,7 @@ public:
         double *massFracs = &y[1];
         double *dTdt = &ydot[0];
         double *dYdt = &ydot[1];
-        
+
         /* ------------------------- UPDATE GAS STATE ------------------------- */
         // the state of the ThermoPhase is updated to reflect the current solution
         // vector, which was calculated by the integrator.
@@ -87,7 +85,7 @@ public:
         double cp = m_gas->cp_mass();
         m_gas->getPartialMolarEnthalpies(&m_hbar[0]);
         m_kinetics->getNetProductionRates(&m_wdot[0]);
-        
+
         /* -------------------------- ENERGY EQUATION ------------------------- */
         // the rate of change of the system temperature is found using the energy
         // equation for a closed-system constant pressure ideal gas:
@@ -110,7 +108,7 @@ public:
             dYdt[k] = m_wdot[k] * m_gas->molecularWeight(k) / rho;
         }
     }
-    
+
     /**
      * Number of equations in the ODE system.
      *   - overridden from FuncEval, called by the integrator during initialization.
@@ -153,7 +151,7 @@ int main() {
     // for each simulation time point.
     // create the csv file, overwriting any existing ones with the same name.
     std::ofstream outputFile("custom_cxx.csv");
-    
+
     // for convenience, a title for each of the state vector's components is written to
     // the first line of the csv file.
     outputFile << "time (s), temp (K)";
@@ -171,7 +169,7 @@ int main() {
     // the new absolute time of the system.
     double tnow = 0.0;
     double tfinal = 1e-3;
-    
+
     /* ------------------- CREATE & INIT ODE INTEGRATOR ------------------- */
     // create an ODE integrator object, which will be used to solve the system of ODES defined
     // in the ReactorODEs class. a C++ interface to the C-implemented SUNDIALS CVODES integrator
@@ -188,7 +186,7 @@ int main() {
     // internally, the integrator will apply settings, allocate needed memory, and populate
     // this memory with the appropriate initial values for the system.
     integrator->initialize(tnow, odes);
-    
+
     /* ----------------------- SIMULATION TIME LOOP ----------------------- */
     while (tnow < tfinal) {
         // advance the simulation to the current absolute time, tnow, using the integrator's

--- a/samples/cxx/demo/demo.cpp
+++ b/samples/cxx/demo/demo.cpp
@@ -18,10 +18,8 @@
 // provide a simplified interface to the Cantera header files. If you need
 // to include core headers directly, use the format "cantera/module/*.h".
 
-#include "cantera/thermo/IdealGasPhase.h" // defines class IdealGasPhase
-#include "cantera/base/Solution.h"
-#include "cantera/kinetics/GasKinetics.h"
-#include "cantera/transport.h" // transport properties
+#include "cantera/core.h"
+#include "cantera/base/global.h" // provides Cantera::writelog
 #include <iostream>
 
 // All Cantera kernel names are in namespace Cantera. You can either
@@ -98,7 +96,8 @@ void demoprog()
 
     // create a transport manager for the gas that computes
     // mixture-averaged properties
-    std::unique_ptr<Transport> tr(newTransportMgr("Mix", sol->thermo().get()));
+    sol->setTransport("mixture-averaged");
+    auto tr = sol->transport();
 
     // print the viscosity, thermal conductivity, and diffusion
     // coefficients

--- a/samples/cxx/flamespeed/flamespeed.cpp
+++ b/samples/cxx/flamespeed/flamespeed.cpp
@@ -13,12 +13,7 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#include "cantera/oneD/Sim1D.h"
-#include "cantera/oneD/Boundary1D.h"
-#include "cantera/oneD/StFlow.h"
-#include "cantera/thermo/IdealGasPhase.h"
-#include "cantera/transport.h"
-#include "cantera/base/Solution.h"
+#include "cantera/onedim.h"
 #include "cantera/base/stringUtils.h"
 #include <fstream>
 
@@ -75,10 +70,8 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
         // specify the objects to use to compute kinetic rates and
         // transport properties
 
-        std::unique_ptr<Transport> trmix(newTransportMgr("Mix", sol->thermo().get()));
-        std::unique_ptr<Transport> trmulti(newTransportMgr("Multi", sol->thermo().get()));
-
-        flow.setTransport(*trmix);
+        sol->setTransport("mixture-averaged");
+        flow.setTransport(*sol->transport());
         flow.setKinetics(*sol->kinetics());
         flow.setPressure(pressure);
 
@@ -145,7 +138,8 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
               flameSpeed_mix);
 
         // now switch to multicomponent transport
-        flow.setTransport(*trmulti);
+        sol->setTransport("multicomponent");
+        flow.setTransport(*sol->transport());
         flame.solve(loglevel, refine_grid);
         double flameSpeed_multi = flame.value(flowdomain,
                                               flow.componentIndex("velocity"),0);

--- a/samples/cxx/gas_transport/gas_transport.cpp
+++ b/samples/cxx/gas_transport/gas_transport.cpp
@@ -16,7 +16,6 @@
 #include "cantera/core.h"
 #include "cantera/base/Array.h"
 
-#include <fstream>
 #include <iostream>
 #include <fstream>
 

--- a/samples/cxx/gas_transport/gas_transport.cpp
+++ b/samples/cxx/gas_transport/gas_transport.cpp
@@ -13,11 +13,10 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#include "cantera/thermo.h"
-#include "cantera/transport.h"
-#include "cantera/base/Solution.h"
+#include "cantera/core.h"
 #include "cantera/base/Array.h"
 
+#include <fstream>
 #include <iostream>
 #include <fstream>
 
@@ -85,18 +84,17 @@ void transport_example()
     // Save transport properties to a file
     write_csv("transport_mix.csv", labels, output);
 
-    // Create a new transport manager for multicomponent properties
-    unique_ptr<Transport> multi(
-        newTransportMgr("multicomponent", sol->thermo().get()));
+    // Switch transport manager to multicomponent properties
+    sol->setTransport("multicomponent");
 
     // Get multicomponent properties at several temperatures
     for (int i = 0; i < ntemps; i++) {
         temp = 500.0 + 100.0*i;
         gas->setState_TP(temp, pres);
         output(0,i) = temp;
-        output(1,i) = multi->viscosity();
-        output(2,i) = multi->thermalConductivity();
-        multi->getThermalDiffCoeffs(&output(3,i));
+        output(1,i) = sol->transport()->viscosity();
+        output(2,i) = sol->transport()->thermalConductivity();
+        sol->transport()->getThermalDiffCoeffs(&output(3,i));
     }
 
     // Save transport properties to a file

--- a/samples/cxx/jacobian/derivative_speed.cpp
+++ b/samples/cxx/jacobian/derivative_speed.cpp
@@ -18,7 +18,6 @@
 #include <iomanip>
 #include <numeric>
 #include "cantera/core.h"
-#include "cantera/numerics/eigen_sparse.h"
 
 using namespace Cantera;
 

--- a/samples/cxx/jacobian/derivative_speed.cpp
+++ b/samples/cxx/jacobian/derivative_speed.cpp
@@ -17,9 +17,7 @@
 #include <iostream>
 #include <iomanip>
 #include <numeric>
-#include "cantera/base/Solution.h"
-#include "cantera/thermo/IdealGasPhase.h"
-#include "cantera/kinetics.h"
+#include "cantera/core.h"
 #include "cantera/numerics/eigen_sparse.h"
 
 using namespace Cantera;

--- a/samples/cxx/kinetics1/kinetics1.cpp
+++ b/samples/cxx/kinetics1/kinetics1.cpp
@@ -13,7 +13,6 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
-#include "cantera/thermo/IdealGasPhase.h"
 #include "cantera/numerics/Integrator.h"
 #include "example_utils.h"
 

--- a/samples/cxx/openmp_ignition/openmp_ignition.cpp
+++ b/samples/cxx/openmp_ignition/openmp_ignition.cpp
@@ -13,7 +13,6 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zerodim.h"
-#include "cantera/thermo/IdealGasPhase.h"
 
 #include <omp.h>
 

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -51,6 +51,18 @@ void Solution::setTransport(shared_ptr<Transport> transport) {
     m_transport = transport;
 }
 
+void Solution::setTransport(const std::string& model) {
+    if (model == "") {
+        setTransport(shared_ptr<Transport>(
+            newDefaultTransportMgr(m_thermo.get())));
+    } else if (model == "None") {
+        setTransport(shared_ptr<Transport>(newTransportMgr("None")));
+    } else {
+        setTransport(shared_ptr<Transport>(
+            newTransportMgr(model, m_thermo.get())));
+    }
+}
+
 void Solution::addAdjacent(shared_ptr<Solution> adjacent) {
     if (m_adjacentByName.count(adjacent->name())) {
         throw CanteraError("Solution::addAdjacent",
@@ -257,16 +269,8 @@ shared_ptr<Solution> newSolution(const AnyMap& phaseNode,
     }
     sol->setKinetics(newKinetics(phases, phaseNode, rootNode));
 
-    // transport
-    if (transport == "") {
-        sol->setTransport(shared_ptr<Transport>(
-            newDefaultTransportMgr(sol->thermo().get())));
-    } else if (transport == "None") {
-        sol->setTransport(shared_ptr<Transport>(newTransportMgr("None")));
-    } else {
-        sol->setTransport(shared_ptr<Transport>(
-            newTransportMgr(transport, sol->thermo().get())));
-    }
+    // set transport model by name
+    sol->setTransport(transport);
 
     // save root-level information (YAML header)
     AnyMap header;

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -55,8 +55,6 @@ void Solution::setTransport(const std::string& model) {
     if (model == "") {
         setTransport(shared_ptr<Transport>(
             newDefaultTransportMgr(m_thermo.get())));
-    } else if (model == "None") {
-        setTransport(shared_ptr<Transport>(newTransportMgr("None")));
     } else {
         setTransport(shared_ptr<Transport>(
             newTransportMgr(model, m_thermo.get())));


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- ~Add relevant headers to `Solution.h`~
- *Edit: Introduce `cantera/core.h`*
- Remove redundant headers from samples

Also:

-  Implement `Solution::setTransport(const std::string&)`

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

In many instances where `newSolution` handles the creation of a `Cantera::Solution` object, the main include needed in C++ would be
``` C++
#include "cantera/core.h"
```

~An alternative would be to introduce a new `core.h` header at the same level as `thermo.h` etc. (I.e. `#include "cantera/core.h"`)~ ... *Edit: this was adopted as an alternative to include common headers in `Solution.h`*

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
