### PR TITLE
Fix missing files in MSI

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1690,6 +1690,22 @@ env['debian'] = any(name.endswith('dist-packages') for name in sys.path)
 selected_options = set(line.split("=")[0].strip()
     for line in cantera_conf.splitlines())
 
+# Always set the stage directory before building an MSI installer
+if "msi" in COMMAND_LINE_TARGETS:
+    COMMAND_LINE_TARGETS.append("install")
+    env["stage_dir"] = "stage"
+    env["prefix"] = "."
+    selected_options.add("prefix")
+    selected_options.add("stage_dir")
+    env["python_package"] = "none"
+elif env["layout"] == "debian":
+    COMMAND_LINE_TARGETS.append("install")
+    env["stage_dir"] = "stage/cantera"
+    env["PYTHON_INSTALLER"] = "debian"
+    env["INSTALL_MANPAGES"] = False
+else:
+    env["PYTHON_INSTALLER"] = "direct"
+
 env["default_prefix"] = True
 if "prefix" in selected_options:
     env["default_prefix"] = False
@@ -1753,19 +1769,6 @@ else:
     else:
         env["ct_matlab_dir"] = pjoin(
             env["prefix"], env["libdirname"], "cantera", "matlab", "toolbox")
-
-# Always set the stage directory before building an MSI installer
-if 'msi' in COMMAND_LINE_TARGETS:
-    COMMAND_LINE_TARGETS.append('install')
-    env['stage_dir'] = 'stage'
-    env['prefix'] = '.'
-elif env['layout'] == 'debian':
-    COMMAND_LINE_TARGETS.append('install')
-    env['stage_dir'] = 'stage/cantera'
-    env['PYTHON_INSTALLER'] = 'debian'
-    env['INSTALL_MANPAGES'] = False
-else:
-    env['PYTHON_INSTALLER'] = 'direct'
 
 
 addInstallActions = ('install' in COMMAND_LINE_TARGETS or


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix builds of the MSI installer so they actually contain the data files, samples, and Matlab toolbox

**If applicable, fill in the issue number this pull request is fixing**

Fixes problems introduced by some changes that were incorrectly modifying "prefix" and ignoring the stage directory when the stage directory was being specified internally by the SCons `msi` target rather than directly as a command line option.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
