### PR TITLE
Add `SolutionArray :set_mixture_fraction` method.

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1001,6 +1001,25 @@ class SolutionArray:
             self._phase.set_equivalence_ratio(phi[index], *args, **kwargs)
             self._states[index][:] = self._phase.state
 
+    def set_mixture_fraction(self, mixture_fraction, *args, **kwargs):
+        """
+        See `ThermoPhase.set_mixture_fraction`
+
+        Note that ``mixture_fraction`` either needs to be a scalar value or 
+        dimensions have to be matched to the `SolutionArray`.
+        """
+
+        # broadcast argument shape
+        mixture_fraction, _ = np.broadcast_arrays(mixture_fraction, 
+            self._output_dummy)
+
+        # loop over values
+        for index in self._indices:
+            self._phase.state = self._states[index]
+            self._phase.set_mixture_fraction(mixture_fraction[index], *args, 
+                **kwargs)
+            self._states[index][:] = self._phase.state
+
     def collect_data(self, cols=None, tabular=False, threshold=0, species=None):
         """
         Returns the data specified by ``cols`` in an ordered dictionary, where

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -992,7 +992,9 @@ class SolutionArray:
         to be matched to the `SolutionArray`.
         """
 
-        # If ``phi`` is a scalar, broadcast it to the correct argument shape:
+        # If ``phi`` is lower-dimensional than the SolutionArray's  shape (for 
+        # example, a scalar), broadcast it to have the right number of 
+        # dimensions.
         phi, _ = np.broadcast_arrays(phi, self._output_dummy)
 
         for index in self._indices:
@@ -1008,8 +1010,9 @@ class SolutionArray:
         dimensions have to be matched to the `SolutionArray`.
         """
 
-        # If ``mixture_fraction`` is a scalar, broadcast it to the correct 
-        # argument shape:
+        # If ``mixture_fraction`` is lower-dimensional than the SolutionArray's 
+        # shape (for example, a scalar), broadcast it to have the right number 
+        # of dimensions.
         mixture_fraction, _ = np.broadcast_arrays(mixture_fraction, 
             self._output_dummy)
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -992,10 +992,9 @@ class SolutionArray:
         to be matched to the `SolutionArray`.
         """
 
-        # broadcast argument shape
+        # If ``phi`` is a scalar, broadcast it to the correct argument shape:
         phi, _ = np.broadcast_arrays(phi, self._output_dummy)
 
-        # loop over values
         for index in self._indices:
             self._phase.state = self._states[index]
             self._phase.set_equivalence_ratio(phi[index], *args, **kwargs)
@@ -1009,11 +1008,11 @@ class SolutionArray:
         dimensions have to be matched to the `SolutionArray`.
         """
 
-        # broadcast argument shape
+        # If ``mixture_fraction`` is a scalar, broadcast it to the correct 
+        # argument shape:
         mixture_fraction, _ = np.broadcast_arrays(mixture_fraction, 
             self._output_dummy)
 
-        # loop over values
         for index in self._indices:
             self._phase.state = self._states[index]
             self._phase.set_mixture_fraction(mixture_fraction[index], *args, 

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -2215,7 +2215,7 @@ class TestSolutionArray(utilities.CanteraTest):
         states = ct.SolutionArray(self.gas, 8)
         phi = np.linspace(0.5, 2, 7)
         fuel, oxidizer = "H2:1.0", "O2:1.0"
-        with self.assertRaisesRegex(ValueError, r"shape mismatch:.*\(7,\).*\(8,\)"):
+        with self.assertRaisesRegex(ValueError, r"shape mismatch"):
             states.set_equivalence_ratio(phi, fuel, oxidizer)
 
     def test_set_equivalence_ratio_2d(self):
@@ -2250,7 +2250,7 @@ class TestSolutionArray(utilities.CanteraTest):
         states = ct.SolutionArray(self.gas, 8)
         mixture_fraction = np.linspace(0.5, 1, 7)
         fuel, oxidizer = "H2:1.0", "O2:1.0"
-        with self.assertRaisesRegex(ValueError, r"shape mismatch:.*\(7,\).*\(8,\)"):
+        with self.assertRaisesRegex(ValueError, r"shape mismatch"):
             states.set_mixture_fraction(mixture_fraction, fuel, oxidizer)
 
     def test_set_mixture_fraction_2D(self):

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -2213,6 +2213,32 @@ class TestSolutionArray(utilities.CanteraTest):
         with self.assertRaises(ValueError):
             states.set_equivalence_ratio(phi.reshape((4,2)), *args)
 
+    def test_set_mixture_fraction(self):
+        states = ct.SolutionArray(self.gas, 8)
+        mixture_fraction = np.linspace(.5, 1., 8)
+        args = 'H2:1.0', 'O2:1.0'
+        states.set_mixture_fraction(mixture_fraction, *args)
+        states.set_mixture_fraction(mixture_fraction[0], *args)
+        states.set_mixture_fraction(list(mixture_fraction), *args)
+
+        # Test that the mixture fraction is set correctly:
+        n_H2 = self.gas.species_index('H2')
+        self.assertTrue((states.Y[:, n_H2] - mixture_fraction[:] 
+            == 0.).all())
+
+        with self.assertRaises(ValueError):
+            states.set_mixture_fraction(mixture_fraction[:-1], *args)
+
+        states = ct.SolutionArray(self.gas, (2,4))
+        states.set_mixture_fraction(mixture_fraction.reshape((2,4)), 
+            *args)
+
+        with self.assertRaises(ValueError):
+            states.set_mixture_fraction(mixture_fraction, *args)
+        with self.assertRaises(ValueError):
+            states.set_mixture_fraction(mixture_fraction.reshape(
+                (4,2)), *args)
+
     def test_species_slicing(self):
         states = ct.SolutionArray(self.gas, (2,5))
         states.TPX = np.linspace(500, 1000, 5), 2e5, 'H2:0.5, O2:0.4'


### PR DESCRIPTION
**Changes proposed in this pull request**

- Adds the capability to set the mixture fraction of a solutionArray.

This largely follows the method already implemented for `solutionArray:set_equivalence_ratio`.

**If applicable, fill in the issue number this pull request is fixing**

Addresses Cantera/enchancements#147

As noted in the enhancement request, an example implementation is:
```python
import cantera as ct

yfuel = {'C': 43.41, 'H': 5.82, 'O': 44.32, 'N': 0.25}
yair = {'O2': 23, 'N2': 76, 'Ar': 1}
mixfrac = np.linspace(0.1, 0.9, 20)

gas = ct.Solution('gri30.yaml')
states = ct.SolutionArray(gas, shape=len(mixfrac))
states.TP = 900, ct.one_atm
states.set_mixture_fraction(mixfrac, yfuel, yair, basis='mass')
states.equilibrate('TP')
```


**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
