### PR TITLE
Fix RPATH related issues

### DIFF
--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -40,7 +40,7 @@ import site
 vars = get_config_vars()
 vars["plat"] = get_platform()
 vars["numpy_include"] = numpy.get_include()
-vars["site_packages"] = site.getsitepackages()
+vars["site_packages"] = [d for d in site.getsitepackages() if d.endswith("-packages")]
 vars["user_site_packages"] = site.getusersitepackages()
 print(json.dumps(vars))
 """

--- a/platform/posix/Cantera.mak.in
+++ b/platform/posix/Cantera.mak.in
@@ -32,7 +32,7 @@ CANTERA_CORE_INCLUDES=-I$(CANTERA_INSTALL_ROOT)/include
 CANTERA_EXTRA_INCLUDES=@mak_extra_includes@ 
 
 # Required Cantera libraries
-CANTERA_CORE_LIBS=@mak_threadflags@ -L@ct_libdir@ @mak_corelibs@
+CANTERA_CORE_LIBS=@mak_threadflags@ -L@ct_libdir@ @mak_corelibs@ -Wl,-rpath,@ct_libdir@
 
 CANTERA_CORE_LIBS_DEP = @ct_libdir@/libcantera.a
 

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -36,18 +36,20 @@ pc_cflags = list(localenv['CXXFLAGS'])
 
 localenv['mak_corelibs'] = ' '.join('-l' + lib for lib in localenv['cantera_libs'])
 
-localenv['mak_extra_includes'] = ' '.join('-I%s' % s for s in localenv['extra_inc_dirs'])
-pc_incdirs.extend(localenv['extra_inc_dirs'])
+localenv["mak_extra_includes"] = " ".join(
+    f"-I{dir}" for dir in localenv["extra_inc_dirs"])
+pc_incdirs.extend(localenv["extra_inc_dirs"])
 
-localenv['mak_extra_libdirs'] = ' '.join('-L%s' % s for s in localenv['extra_lib_dirs'])
-pc_libdirs.extend(localenv['extra_lib_dirs'])
+localenv["mak_extra_libdirs"] = " ".join(
+    f"-L{dir} -Wl,-rpath,{dir}" for dir in localenv["extra_lib_dirs"])
+pc_libdirs.extend(localenv["extra_lib_dirs"])
 
 localenv['mak_stdlib'] = ''.join('-l' + lib for lib in env['cxx_stdlib'])
 
 if localenv['system_sundials']:
     # Add links to the sundials environment
-    localenv['mak_sundials_libs'] = ' '.join('-l%s' % s
-                                             for s in localenv['sundials_libs'])
+    localenv["mak_sundials_libs"] = " ".join(
+        f"-l{lib}" for lib in localenv["sundials_libs"])
     if localenv['sundials_libdir']:
         localenv['mak_sundials_libdir'] = '-L' + localenv['sundials_libdir']
         pc_libdirs.append(localenv['sundials_libdir'])
@@ -67,7 +69,7 @@ else:
     localenv['mak_boost_include'] = ''
 
 # Handle BLAS/LAPACK linkage
-blas_lapack_libs = ' '.join('-l%s' % s for s in localenv['blas_lapack_libs'])
+blas_lapack_libs = " ".join(f"-l{lib}" for lib in localenv["blas_lapack_libs"])
 if localenv['blas_lapack_dir']:
     localenv['mak_blas_lapack_libs'] = '-L{} {}'.format(localenv['blas_lapack_dir'],
                                                         blas_lapack_libs)

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -37,6 +37,8 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     # TODO: Accelerate is only used if other BLAS/LAPACK are not used
     if env["OS"] == "Darwin":
         localenv["cmake_extra"] += "find_library(ACCELERATE_FRAMEWORK Accelerate)"
+        localenv.Append(
+            LINKFLAGS=env.subst("${RPATHPREFIX}${ct_libdir}${RPATHSUFFIX}"))
 
     localenv.Append(LIBS=env['cantera_libs'])
     localenv.Prepend(CPPPATH=['#include'])

--- a/src/SConscript
+++ b/src/SConscript
@@ -97,5 +97,10 @@ if localenv['layout'] != 'debian':
         lib = build(localenv.SharedLibrary(sharedName, libraryTargets,
                                            SPAWN=get_spawn(localenv)))
         install('$inst_libdir', lib)
+
+    if env["OS"] == "Darwin":
+        localenv.AddPostAction(lib,
+            Action(f"install_name_tool -id @rpath/{lib[0].name} {lib[0].relpath}"))
+
     env['cantera_shlib'] = lib
     localenv.Depends(lib, localenv['config_h_target'])


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Set the Cantera shared library to use RPATH on macOS. Previously, the embedded path just pointed to the build directory, which would never work. Now, linking to this library will work if you specify the `-Wl,-rpath,/path/to/lib` option when linking an application against this library.
- Update `Cantera.mak` to add rpath flags when linking to Cantera or other libraries. This helps whenever these are shared libraries but not in standard system locations, for instance when linking against libraries in a conda installation. 
- Fix an unrelated issue reported in the Users' Group (see https://groups.google.com/g/cantera-users/c/3PsUAFqeEhw) related to the fix applied for #1230 in #1239. 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
