### PR TITLE
YAML surface phase requires kinetics model

### DIFF
--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -124,11 +124,6 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
     vector<string> sections, rules;
 
     if (phaseNode.hasKey("reactions")) {
-        if (kin.kineticsType() == "None") {
-            throw InputFileError("addReactions", phaseNode["reactions"],
-                "Phase entry includes a 'reactions' field but does not "
-                "specify a kinetics model.");
-        }
         const auto& reactionsNode = phaseNode.at("reactions");
         if (reactionsNode.is<string>()) {
             if (rootNode.hasKey("reactions")) {
@@ -156,7 +151,10 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
             }
         }
     } else if (kin.kineticsType() != "None") {
-        if (rootNode.hasKey("reactions")) {
+        if (!phaseNode.hasKey("kinetics")) {
+            // Do nothing - default surface or edge kinetics require separate detection
+            // while not adding reactions
+        } else if (rootNode.hasKey("reactions")) {
             // Default behavior is to add all reactions from the 'reactions'
             // section, if a 'kinetics' model has been specified
             sections.push_back("reactions");

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -119,6 +119,11 @@ ThermoPhase* newPhase(XML_Node& xmlphase)
 
 unique_ptr<ThermoPhase> newPhase(const AnyMap& phaseNode, const AnyMap& rootNode)
 {
+    if (!phaseNode.hasKey("kinetics") && phaseNode.hasKey("reactions")) {
+        throw InputFileError("newPhase", phaseNode["reactions"],
+            "Phase entry includes a 'reactions' field but does not "
+            "specify a kinetics model.");
+    }
     unique_ptr<ThermoPhase> t(newThermoPhase(phaseNode["thermo"].asString()));
     setupPhase(*t, phaseNode, rootNode);
     return t;
@@ -138,9 +143,7 @@ ThermoPhase* newPhase(const std::string& infile, std::string id)
     if (extension == "yml" || extension == "yaml") {
         AnyMap root = AnyMap::fromYamlFile(infile);
         AnyMap& phase = root["phases"].getMapWhere("name", id);
-        unique_ptr<ThermoPhase> t(newThermoPhase(phase["thermo"].asString()));
-        setupPhase(*t, phase, root);
-        return t.release();
+        return newPhase(phase, root).release();
     } else {
         XML_Node* root = get_XML_File(infile);
         XML_Node* xphase = get_XML_NameID("phase", "#"+id, root);

--- a/test/data/phase-reaction-spec1.yaml
+++ b/test/data/phase-reaction-spec1.yaml
@@ -24,6 +24,18 @@ phases:
   kinetics: gas
   reactions: all
 
+  # should work fine (kinetics model with no reactions)
+- name: kinetics-no-reaction-section3
+  thermo: ideal-surface
+  species: [{ptcombust.yaml/species: all}]
+  state: {T: 300, P: 1 atm}
+
+  # should be an error
+- name: kinetics-no-reaction-section4
+  species: [{gri30.yaml/species: [O2, H2, H2O]}]
+  thermo: ideal-gas
+  reactions: none
+
   # should be an error
 - name: nokinetics-reactions
   species: [{gri30.yaml/species: [O2, H2, H2O]}]

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -463,6 +463,21 @@ TEST(KineticsFromYaml, KineticsModelWithoutReactionsSection2)
                  InputFileError);
 }
 
+TEST(KineticsFromYaml, KineticsModelWithoutReactionsSection3)
+{
+    auto soln = newSolution("phase-reaction-spec1.yaml",
+                            "kinetics-no-reaction-section3");
+    EXPECT_EQ(soln->kinetics()->kineticsType(), "Surf");
+    EXPECT_EQ(soln->kinetics()->nReactions(), (size_t) 0);
+}
+
+TEST(KineticsFromYaml, KineticsModelWithoutReactionsSection4)
+{
+    EXPECT_THROW(newSolution("phase-reaction-spec1.yaml",
+                             "kinetics-no-reaction-section4"),
+                 InputFileError);
+}
+
 TEST(KineticsFromYaml, KineticsModelWithoutReactionsField)
 {
     auto soln = newSolution("phase-reaction-spec2.yaml",


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make default kinetics type dependent on phase dimensions

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1244

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

*updated ...*

For the YAML input (say, `test.yaml`):
```yaml
phases:
- name: test
  thermo: ideal-surface
  species: [{ptcombust.yaml/species: all}]
  state: {T: 300, P: 1 atm}
```
Importing in Python yields:

```
>>> import cantera as ct
>>> p = ct.Interface("test.yaml")
>>> p.reactions()
[]
>>> p.species_names
['PT(S)', 'H(S)', 'H2O(S)', 'OH(S)', 'CO(S)', 'CO2(S)', 'CH3(S)', 'CH2(S)s', 'CH(S)', 'C(S)', 'O(S)']
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review