### PR TITLE
`ck2yaml` Strip optional +M from PLOG reactions

### DIFF
--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1323,6 +1323,7 @@ class Parser:
             elif 'plog' in line.lower():
                 # Pressure-dependent Arrhenius parameters
                 parsed = True
+                third_body = False # strip optional third-body collider
                 tokens = tokens[1].split()
                 pdep_arrhenius.append([float(tokens[0].strip()), Arrhenius(
                     A=(float(tokens[1].strip()), kunits),

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -1196,6 +1196,10 @@ class TestReaction(utilities.CanteraTest):
             self.assertNear(gas1.reaction(i).rate(gas1.T, gas1.P),
                             gas1.forward_rate_constants[i])
 
+    def test_plog_invalid_third_body(self):
+        with self.assertRaisesRegex(ct.CanteraError, "Found superfluous"):
+            gas = ct.Solution("pdep-test.yaml", "plog-invalid")
+
     def test_chebyshev(self):
         gas1 = ct.Solution('pdep-test.yaml')
         species = ct.Species.list_from_file("pdep-test.yaml")

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -256,6 +256,11 @@ void Reaction::setRate(shared_ptr<ReactionRate> rate)
         reactants.erase("(+M)");
         products.erase("(+M)");
     }
+
+    if (reactants.count("M") && std::dynamic_pointer_cast<PlogRate>(m_rate)) {
+        throw InputFileError("Reaction::setRate", input, "Found superfluous 'M' in "
+            "pressure-dependent-Arrhenius reaction.");
+    }
 }
 
 std::string Reaction::reactantString() const

--- a/test/data/pdep-test.inp
+++ b/test/data/pdep-test.inp
@@ -112,8 +112,8 @@ P7B                     C   1H   4          G   200.000  3500.000  1000.000    1
 END
 
 REACTIONS
-! Single PLOG reaction
-R1A+R1B=P1+H  1.0 0.0 0.0
+! Single PLOG reaction with optional third-body collider
+R1A+R1B+M=P1+H+M  1.0 0.0 0.0
 PLOG / 0.01 1.2124e+16  -0.5779     10872.7 /
 PLOG / 1    4.9108e+31  -4.8507     24772.8 /
 PLOG / 10   1.2866e+47  -9.0246     39796.5 /

--- a/test/data/pdep-test.yaml
+++ b/test/data/pdep-test.yaml
@@ -23,6 +23,12 @@ phases:
   kinetics: gas
   reactions: [chebyshev-deprecated-rxns]
   state: {T: 300.0, P: 1 atm}
+- name: plog-invalid
+  thermo: ideal-gas
+  species: all
+  kinetics: gas
+  reactions: [plog-invalid-rxns]
+  state: {T: 300.0, P: 1 atm}
 
 species:
 - name: H
@@ -321,3 +327,13 @@ chebyshev-deprecated-rxns:
   - [0.3177, 0.26889, 0.094806, -7.6385e-03]
   - [-0.031285, -0.039412, 0.044375, 0.014458]
   note: Chebyshev reaction written with the deprecated "(+M)" notation
+
+plog-invalid-rxns:
+- equation: R1A + R1B + M <=> P1 + H + M
+  type: pressure-dependent-Arrhenius
+  rate-constants:
+  - {P: 0.01 atm, A: 1.2124e+16, b: -0.5779, Ea: 1.08727e+04}
+  - {P: 1.0 atm, A: 4.9108e+31, b: -4.8507, Ea: 2.47728e+04}
+  - {P: 10.0 atm, A: 1.2866e+47, b: -9.0246, Ea: 3.97965e+04}
+  - {P: 100.0 atm, A: 5.9632e+56, b: -11.529, Ea: 5.25996e+04}
+  note: PLOG Reaction with invalid +M


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Strip 'decorative' `M` from PLOG reaction defined in CHEMKIN (`ck2yaml`)
- Raise exception for superfluous `M` in YAML
- Add unit tests

`cti2yaml` and `ctml2yaml` do not require handling as the legacy formats do not include the optional `+M`. See also: f8c38150d6e129f4f3c1e26ba8103ce2c377a625 (handling of optional `(+M)` for Chebyshev)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1165

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
