### PR TITLE
Fix bug with electrochemical-legacy

### DIFF
--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -910,6 +910,12 @@ class TestSofcKinetics2(TestSofcKinetics):
     _mech = "sofc2.yaml"
 
 
+@pytest.mark.usefixtures("allow_deprecated")
+class TestSofcKinetics3(TestSofcKinetics):
+    """ Test using legacy framework; included to retain coverage """
+    _mech = "sofc.cti"
+
+
 class TestDuplicateReactions(utilities.CanteraTest):
     infile = 'duplicate-reactions.yaml'
 

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -220,7 +220,7 @@ ReactionFactoryXML::ReactionFactoryXML()
         setupElectrochemicalReaction(*(ElectrochemicalReaction2*)R, node);
         return R;
     });
-    addAlias("interface-legacy", "electrochemical");
+    addAlias("electrochemical-legacy", "electrochemical");
 }
 
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Change alias in ReactionFactory.cpp to enable correct legacy behavior for electrochemical reactions
- Fix problem described in [Cantera Users' Group](https://groups.google.com/g/cantera-users/c/KnHmndNoqu4)

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
