### PR TITLE
Enforce third-body concentration as argument to falloff_function

### DIFF
--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -418,12 +418,11 @@ cdef class FalloffRate(ReactionRate):
         def __set__(self, cbool activated):
             self.falloff.setChemicallyActivated(activated)
 
-    def falloff_function(self, double temperature, conc3b=None):
+    def falloff_function(self, double temperature, double conc3b):
         """
-        Evaluate the falloff function
+        Evaluate the falloff function based on temperature and third-body
+        concentration.
         """
-        if conc3b is None:
-            conc3b = self.third_body_concentration
         return self.falloff.evalF(temperature, conc3b)
 
 

--- a/interfaces/cython/cantera/test/test_reaction.py
+++ b/interfaces/cython/cantera/test/test_reaction.py
@@ -486,6 +486,11 @@ class TestLindemannRate(FalloffRateTests, utilities.CanteraTest):
         high-P-rate-constant: {A: 7.4e+10, b: -0.37, Ea: 0.0}
         """
 
+    def test_falloff_function(self):
+        rate = self.from_parts()
+        # Falloff-function for Lindemann is unity by definition
+        assert np.isclose(rate.falloff_function(300, 0.), 1.)
+
 
 class TestTroeRate(FalloffRateTests, utilities.CanteraTest):
     # test Troe rate expressions


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make third-body-concentration mandatory

The method is new in 2.6, and simply breaks out C++ code to the Python API.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1254

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
