### PR TITLE
Direct pip to build in place and not in /tmp

### DIFF
--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -107,7 +107,7 @@ ext = localenv.LoadableModule(f"cantera/_cantera{module_ext}",
                               obj, LIBPREFIX="", SHLIBSUFFIX=module_ext,
                               SHLIBPREFIX="", LIBSUFFIXES=[module_ext])
 
-build_cmd = ("$python_cmd_esc -m pip wheel -v --no-build-isolation --no-deps "
+build_cmd = ("$python_cmd_esc -m pip wheel -v --no-build-isolation --use-feature=in-tree-build --no-deps "
              "--wheel-dir=build/python/dist build/python")
 plat = info['plat'].replace('-', '_').replace('.', '_')
 wheel_name = (f"Cantera-{env['cantera_version']}-cp{py_version_nodot}"
@@ -172,7 +172,7 @@ if env["stage_dir"]:
 
     install_cmd.append(f"--root={stage_dir.resolve()}")
 
-install_cmd.extend(("--no-build-isolation", "--no-deps", "-v", "--force-reinstall",
+install_cmd.extend(("--no-build-isolation", "--use-feature=in-tree-build", "--no-deps", "-v", "--force-reinstall",
                     "build/python"))
 if localenv['PYTHON_INSTALLER'] == 'direct':
     mod_inst = install(localenv.Command, 'dummy', mod,


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**
This will direct pip to build in place and not in a temporary directory. Future versions of pip will not be building in a temporary directory according to a depreciation warning:

`  DEPRECATION: A future pip version will change local packages to be built in-place without first copying to a temporary directory. We recommend you use --use-feature=in-tree-build to test your packages with this new behavior before it becomes the default.
   pip 21.3 will remove support for this functionality. You can find discussion regarding this at https://github.com/pypa/pip/issues/7555.`

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add the `--use-feature=in-tree-build ` to pip in the `SConscript` file for the python build


**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1260 

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [X ] Commit messages have short titles and reference relevant issues
- [X ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
