### PR TITLE
Fix compatibility with SCons 3.x

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,8 +45,8 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas pytest
-        pytest-github-actions-annotate-failures
+      run: python3 -m pip install ruamel.yaml scons==3.1.2 numpy cython h5py pandas
+        pytest pytest-github-actions-annotate-failures
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all -j2 debug=n --debug=time
     - name: Test Cantera

--- a/src/SConscript
+++ b/src/SConscript
@@ -100,7 +100,7 @@ if localenv['layout'] != 'debian':
 
     if env["OS"] == "Darwin":
         localenv.AddPostAction(lib,
-            Action(f"install_name_tool -id @rpath/{lib[0].name} {lib[0].relpath}"))
+            Action(f"install_name_tool -id @rpath/{lib[0].name} {lib[0].get_abspath()}"))
 
     env['cantera_shlib'] = lib
     localenv.Depends(lib, localenv['config_h_target'])


### PR DESCRIPTION
The 'relpath' attribute was only introduced in SCons 4.2.0, which isn't available on all supported build environments (notably, Anaconda, which only has SCons 4.1.0).

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1253

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
