### PR TITLE
[Species] Add molecular weight attribute

### DIFF
--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -92,41 +92,15 @@ const std::vector<std::string>& elementSymbols();
 //! @since New in version 3.0
 const std::vector<std::string>& elementNames();
 
-//! Get a map with the element symbols as keys and weights as values.
+//! Get a map with the element and isotope symbols and names as keys and weights as
+//! values.
 /*!
  * This is a constant in the application so it is only generated once
  * when it is first needed.
  *
  * @since New in version 3.0
  */
-const std::map<std::string, double>& elementSymbolToWeight();
-
-//! Get a map with the element names as keys and weights as values.
-/*!
- * This is a constant in the application so it is only generated once
- * when it is first needed.
- *
- * @since New in version 3.0
- */
-const std::map<std::string, double>& elementNameToWeight();
-
-//! Get a map with the isotope symbols as keys and weights as values.
-/*!
- * This is a constant in the application so it is only generated once
- * when it is first needed.
- *
- * @since New in version 3.0
- */
-const std::map<std::string, double>& isotopeSymbolToWeight();
-
-//! Get a map with the isotope names as keys and weights as values.
-/*!
- * This is a constant in the application so it is only generated once
- * when it is first needed.
- *
- * @since New in version 3.0
- */
-const std::map<std::string, double>& isotopeNameToWeight();
+const std::map<std::string, double>& elementWeights();
 
 //! Get the atomic weight of an element.
 /*!

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -84,6 +84,40 @@ namespace Cantera
 //! stable state at 298.15 K and 1 bar.
 #define ENTROPY298_UNKNOWN -123456789.
 
+//! Get a vector of the atomic symbols of the elements defined in Cantera.
+const std::vector<std::string>& elementSymbols();
+
+//! Get a vector of the names of the elements defined in Cantera.
+const std::vector<std::string>& elementNames();
+
+//! Get a map with the element symbols as keys and weights as values.
+/*!
+ * This is a constant in the application so it is only generated once
+ * when it is first needed.
+ */
+const std::map<std::string, double>& elementSymbolToWeight();
+
+//! Get a map with the element names as keys and weights as values.
+/*!
+ * This is a constant in the application so it is only generated once
+ * when it is first needed.
+ */
+const std::map<std::string, double>& elementNameToWeight();
+
+//! Get a map with the isotope symbols as keys and weights as values.
+/*!
+ * This is a constant in the application so it is only generated once
+ * when it is first needed.
+ */
+const std::map<std::string, double>& isotopeSymbolToWeight();
+
+//! Get a map with the isotope names as keys and weights as values.
+/*!
+ * This is a constant in the application so it is only generated once
+ * when it is first needed.
+ */
+const std::map<std::string, double>& isotopeNameToWeight();
+
 //! Get the atomic weight of an element.
 /*!
  * Get the atomic weight of an element defined in Cantera by its symbol

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -175,11 +175,11 @@ int getAtomicNumber(const std::string& ename);
 
 //! Get the number of named elements defined in Cantera.
 //! This array excludes named isotopes
-int numElementsDefined();
+size_t numElementsDefined();
 
 //! Get the number of named isotopes defined in Cantera.
 //! This array excludes the named elements
-int numIsotopesDefined();
+size_t numIsotopesDefined();
 
 } // namespace
 

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -85,11 +85,11 @@ namespace Cantera
 #define ENTROPY298_UNKNOWN -123456789.
 
 //! Get a vector of the atomic symbols of the elements defined in Cantera.
-//! @since 3.0
+//! @since New in version 3.0
 const std::vector<std::string>& elementSymbols();
 
 //! Get a vector of the names of the elements defined in Cantera.
-//! @since 3.0
+//! @since New in version 3.0
 const std::vector<std::string>& elementNames();
 
 //! Get a map with the element symbols as keys and weights as values.
@@ -97,7 +97,7 @@ const std::vector<std::string>& elementNames();
  * This is a constant in the application so it is only generated once
  * when it is first needed.
  *
- * @since 3.0
+ * @since New in version 3.0
  */
 const std::map<std::string, double>& elementSymbolToWeight();
 
@@ -106,7 +106,7 @@ const std::map<std::string, double>& elementSymbolToWeight();
  * This is a constant in the application so it is only generated once
  * when it is first needed.
  *
- * @since 3.0
+ * @since New in version 3.0
  */
 const std::map<std::string, double>& elementNameToWeight();
 
@@ -115,7 +115,7 @@ const std::map<std::string, double>& elementNameToWeight();
  * This is a constant in the application so it is only generated once
  * when it is first needed.
  *
- * @since 3.0
+ * @since New in version 3.0
  */
 const std::map<std::string, double>& isotopeSymbolToWeight();
 
@@ -124,7 +124,7 @@ const std::map<std::string, double>& isotopeSymbolToWeight();
  * This is a constant in the application so it is only generated once
  * when it is first needed.
  *
- * @since 3.0
+ * @since New in version 3.0
  */
 const std::map<std::string, double>& isotopeNameToWeight();
 

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -85,15 +85,19 @@ namespace Cantera
 #define ENTROPY298_UNKNOWN -123456789.
 
 //! Get a vector of the atomic symbols of the elements defined in Cantera.
+//! @since 3.0
 const std::vector<std::string>& elementSymbols();
 
 //! Get a vector of the names of the elements defined in Cantera.
+//! @since 3.0
 const std::vector<std::string>& elementNames();
 
 //! Get a map with the element symbols as keys and weights as values.
 /*!
  * This is a constant in the application so it is only generated once
  * when it is first needed.
+ *
+ * @since 3.0
  */
 const std::map<std::string, double>& elementSymbolToWeight();
 
@@ -101,6 +105,8 @@ const std::map<std::string, double>& elementSymbolToWeight();
 /*!
  * This is a constant in the application so it is only generated once
  * when it is first needed.
+ *
+ * @since 3.0
  */
 const std::map<std::string, double>& elementNameToWeight();
 
@@ -108,6 +114,8 @@ const std::map<std::string, double>& elementNameToWeight();
 /*!
  * This is a constant in the application so it is only generated once
  * when it is first needed.
+ *
+ * @since 3.0
  */
 const std::map<std::string, double>& isotopeSymbolToWeight();
 
@@ -115,6 +123,8 @@ const std::map<std::string, double>& isotopeSymbolToWeight();
 /*!
  * This is a constant in the application so it is only generated once
  * when it is first needed.
+ *
+ * @since 3.0
  */
 const std::map<std::string, double>& isotopeNameToWeight();
 
@@ -209,10 +219,12 @@ int getAtomicNumber(const std::string& ename);
 
 //! Get the number of named elements defined in Cantera.
 //! This array excludes named isotopes
+//! @since Type is `size_t` in Cantera 3.0
 size_t numElementsDefined();
 
 //! Get the number of named isotopes defined in Cantera.
 //! This array excludes the named elements
+//! @since Type is `size_t` in Cantera 3.0
 size_t numIsotopesDefined();
 
 } // namespace

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -76,7 +76,7 @@ public:
      *
      * @since New in version 3.0
      */
-    void setMolecularWeight(double weight, bool compute=false);
+    void setMolecularWeight(double weight);
 
     shared_ptr<TransportData> transport;
 

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -52,6 +52,13 @@ public:
     double size;
 
     //! The molecular weight [amu] of the species.
+    /*!
+     * Calculates and sets the molecular weight from the elemental composition of the
+     * species and element definitions in Elements.cpp, if the molcular weight is
+     * Undef.
+     *
+     * @since 3.0
+     */
     const double molecularWeight();
 
     //! Set the molecular weight of the species.
@@ -61,9 +68,13 @@ public:
      * method the first time the molecularWeight method is called if the species has
      * not been added to a phase.
      *
+     * @since 3.0
+     *
      * @param weight: The weight of this species to assign, unless `compute` is `true`
      * @param compute: If `true`, the weight will be computed from standard element
      * weights from Elements.cpp, and the value of `weight` is ignored.
+     * @exception If the molecular weight has already been set and the updated value
+     * is not close to the existing value.
      */
     void setMolecularWeight(double weight, bool compute=false);
 

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -54,27 +54,27 @@ public:
     //! The molecular weight [amu] of the species.
     /*!
      * Calculates and sets the molecular weight from the elemental composition of the
-     * species and element definitions in Elements.cpp, if the molcular weight is
+     * species and element definitions in Elements.cpp, if the molecular weight is
      * Undef.
      *
-     * @since 3.0
+     * @since New in version 3.0
      */
-    const double molecularWeight();
+    double molecularWeight();
 
     //! Set the molecular weight of the species.
     /*!
      * Since phases can have custom element weights, the phase will always call this
      * method when a species is added to that phase. The species may also call this
-     * method the first time the molecularWeight method is called if the species has
+     * method the first time the molecularWeight() method is called if the species has
      * not been added to a phase.
-     *
-     * @since 3.0
      *
      * @param weight: The weight of this species to assign, unless `compute` is `true`
      * @param compute: If `true`, the weight will be computed from standard element
      * weights from Elements.cpp, and the value of `weight` is ignored.
-     * @exception If the molecular weight has already been set and the updated value
+     * @exception CanteraError If the molecular weight has already been set and the updated value
      * is not close to the existing value.
+     *
+     * @since New in version 3.0
      */
     void setMolecularWeight(double weight, bool compute=false);
 

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -51,6 +51,22 @@ public:
     //! species, where it represents the number of sites occupied.
     double size;
 
+    //! The molecular weight [amu] of the species.
+    const double molecularWeight();
+
+    //! Set the molecular weight of the species.
+    /*!
+     * Since phases can have custom element weights, the phase will always call this
+     * method when a species is added to that phase. The species may also call this
+     * method the first time the molecularWeight method is called if the species has
+     * not been added to a phase.
+     *
+     * @param weight: The weight of this species to assign, unless `compute` is `true`
+     * @param compute: If `true`, the weight will be computed from standard element
+     * weights from Elements.cpp, and the value of `weight` is ignored.
+     */
+    void setMolecularWeight(double weight, bool compute=false);
+
     shared_ptr<TransportData> transport;
 
     //! Thermodynamic data for the species
@@ -58,6 +74,12 @@ public:
 
     //! Input parameters used to define a species, for example from a YAML input file.
     AnyMap input;
+
+protected:
+
+    //! The molecular weight of the species, in atomic mass units. Includes
+    //! electron mass for charged species.
+    double m_molecularWeight = Undef;
 };
 
 //! Create a new Species object from an AnyMap specification
@@ -65,7 +87,6 @@ unique_ptr<Species> newSpecies(const AnyMap& node);
 
 //! Generate Species objects for each item (an AnyMap) in `items`.
 std::vector<shared_ptr<Species>> getSpecies(const AnyValue& items);
-
 }
 
 #endif

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -68,11 +68,7 @@ public:
      * method the first time the molecularWeight() method is called if the species has
      * not been added to a phase.
      *
-     * @param weight: The weight of this species to assign, unless `compute` is `true`
-     * @param compute: If `true`, the weight will be computed from standard element
-     * weights from Elements.cpp, and the value of `weight` is ignored.
-     * @exception CanteraError If the molecular weight has already been set and the updated value
-     * is not close to the existing value.
+     * @param weight: The weight of this species to assign
      *
      * @since New in version 3.0
      */
@@ -98,6 +94,7 @@ unique_ptr<Species> newSpecies(const AnyMap& node);
 
 //! Generate Species objects for each item (an AnyMap) in `items`.
 std::vector<shared_ptr<Species>> getSpecies(const AnyValue& items);
+
 }
 
 #endif

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -233,6 +233,7 @@ cdef extern from "cantera/thermo/Species.h" namespace "Cantera":
         Composition composition
         double charge
         double size
+        double molecularWeight() except +translate_exception
         CxxAnyMap parameters(CxxThermoPhase*) except +translate_exception
         CxxAnyMap input
 

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -1563,6 +1563,8 @@ cdef wrapSpeciesThermo(shared_ptr[CxxSpeciesThermo] spthermo)
 cdef int assign_delegates(object, CxxDelegator*) except -1
 
 cdef extern from "cantera/thermo/Elements.h" namespace "Cantera":
+    vector[string] elementSymbols()
+    vector[string] elementNames()
     double getElementWeight(string ename) except +translate_exception
     double getElementWeight(int atomicNumber) except +translate_exception
     int numElementsDefined()

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1251,7 +1251,9 @@ class TestSpecies(utilities.CanteraTest):
         gas = ct.Solution("ideal-gas.yaml", "element-override")
         # Check that the molecular weight stored in the phase definition is the same
         # as the one on the element
-        self.assertNear(gas["AR"].molecular_weights[0], gas.species("AR").molecular_weight)
+        self.assertNear(
+            gas["AR"].molecular_weights[0], gas.species("AR").molecular_weight
+        )
         # Check that the custom value is actually used
         self.assertNear(gas.species("AR").molecular_weight, 36.0)
 
@@ -1286,13 +1288,14 @@ class TestSpecies(utilities.CanteraTest):
         with pytest.raises(ct.CanteraError, match="Molecular weight.*changed"):
             gas.add_species(s)
 
-    def test_species_cant_be_added_to_phase_custom_element(self):
+    def test_species_can_be_added_to_phase_custom_element(self):
         s = ct.Species.from_dict({
             "name": "AR2",
             "composition": {"Ar": 2},
             "thermo": {"model": "constant-cp", "h0": 100}
         })
-        # DO NOT access the molecular weight to make sure it's not been computed by the Species
+        # DO NOT access the molecular weight to make sure it's not been computed by the
+        # Species
         gas = ct.Solution("ideal-gas.yaml", "element-override")
         gas.add_species(s)
         self.assertNear(

--- a/interfaces/cython/cantera/test/test_thermo.py
+++ b/interfaces/cython/cantera/test/test_thermo.py
@@ -1232,6 +1232,19 @@ class TestSpecies(utilities.CanteraTest):
         self.assertEqual(len(c), 2)
         self.assertEqual(c['C'], 1)
         self.assertEqual(c['H'], 4)
+        self.assertNear(s.molecular_weight, 16.043)
+
+    def test_molecular_weight_with_electron(self):
+        yaml = """
+            name: Li+[elyt]
+            composition: {Li: 1, E: -1}
+            thermo:
+              model: constant-cp
+              h0: -278.49 kJ/mol
+              s0: 13.4 J/mol/K
+        """
+        s = ct.Species.from_yaml(yaml)
+        assert np.isclose(s.molecular_weight, 6.939451420091127)
 
     def test_defaults(self):
         s = ct.Species('H2')

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -179,7 +179,7 @@ cdef class Species:
     property molecular_weight:
         """The molecular weight [amu] of the species.
 
-        ..versionadded:: 3.0
+        .. versionadded:: 3.0
         """
         def __get__(self):
             return self.species.molecularWeight()

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -176,6 +176,11 @@ cdef class Species:
         def __get__(self):
             return self.species.size
 
+    property molecular_weight:
+        """ The molecular weight [amu] of the species. """
+        def __get__(self):
+            return self.species.molecularWeight()
+
     property thermo:
         """
         Get/Set the species reference-state thermodynamic data, as an instance
@@ -2054,6 +2059,7 @@ def _element_symbols():
 def _element_names():
     names = elementNames()
     return tuple(pystr(n) for n in names)
+
 
 class Element:
     """

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -2050,7 +2050,9 @@ cdef class PureFluid(ThermoPhase):
         def __get__(self):
             return self.s, self.v, self.Q
 
-
+# TODO: Remove these helper methods when support for Python 3.8 is dropped. Python 3.9
+# allows the classmethod and property decorators to be chained, so these can be
+# implemented as properties in the Element class.
 def _element_symbols():
     syms = elementSymbols()
     return tuple(pystr(s) for s in syms)

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -2046,6 +2046,15 @@ cdef class PureFluid(ThermoPhase):
             return self.s, self.v, self.Q
 
 
+def _element_symbols():
+    syms = elementSymbols()
+    return tuple(pystr(s) for s in syms)
+
+
+def _element_names():
+    names = elementNames()
+    return tuple(pystr(n) for n in names)
+
 class Element:
     """
     An element or a named isotope defined in Cantera.
@@ -2092,13 +2101,11 @@ class Element:
 
     #: A list of the symbols of all the elements (not isotopes) defined
     #: in Cantera
-    element_symbols = [pystr(getElementSymbol(<int>(m+1)))
-                       for m in range(num_elements_defined)]
+    element_symbols = _element_symbols()
 
     #: A list of the names of all the elements (not isotopes) defined
     #: in Cantera
-    element_names = [pystr(getElementName(<int>m+1))
-                     for m in range(num_elements_defined)]
+    element_names = _element_names()
 
     def __init__(self, arg):
         if isinstance(arg, (str, bytes)):

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -177,7 +177,10 @@ cdef class Species:
             return self.species.size
 
     property molecular_weight:
-        """ The molecular weight [amu] of the species. """
+        """The molecular weight [amu] of the species.
+
+        ..versionadded:: 3.0
+        """
         def __get__(self):
             return self.species.molecularWeight()
 

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -208,7 +208,7 @@ static vector<isotopeWeightData> isotopeWeightTable {
 // allows elementSymbols() to return a const reference to the data.
 vector<string> elementVectorsFromSymbols() {
 	vector<string> values;
-    for (const auto& atom: atomicWeightTable) {
+    for (const auto& atom : atomicWeightTable) {
         values.push_back(atom.symbol);
     }
     return values;
@@ -223,7 +223,7 @@ const vector<string>& elementSymbols() {
 // allows elementNames() to return a const reference to the data.
 vector<string> elementVectorsFromNames() {
     vector<string> values;
-    for (const auto& atom: atomicWeightTable) {
+    for (const auto& atom : atomicWeightTable) {
         values.push_back(atom.fullName);
     }
     return values;
@@ -241,7 +241,7 @@ map<string, double> mapAtomicWeights() {
         symMap.emplace(atom.symbol, atom.atomicWeight);
         symMap.emplace(atom.fullName, atom.atomicWeight);
     }
-    for (auto const& isotope: isotopeWeightTable) {
+    for (auto const& isotope : isotopeWeightTable) {
         symMap.emplace(isotope.symbol, isotope.atomicWeight);
         symMap.emplace(isotope.fullName, isotope.atomicWeight);
     }

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -226,19 +226,24 @@ double getElementWeight(const std::string& ename)
         throw CanteraError("getElementWeight",
             "element '{}' has no stable isotopes", ename);
     }
-    for (int i = 0; i < numIsotopes; i++) {
-        if (symbol == isotopeWeightTable[i].symbol) {
-            return isotopeWeightTable[i].atomicWeight;
-        } else if (name == isotopeWeightTable[i].fullName) {
-            return isotopeWeightTable[i].atomicWeight;
+    search = isotopeSymbolMap.find(symbol);
+    if (search != isotopeSymbolMap.end()) {
+        elementWeight = search->second;
+    } else {
+        search = isotopeNameMap.find(name);
+        if (search != isotopeNameMap.end()) {
+            elementWeight = search->second;
         }
+    }
+    if (elementWeight > 0.0) {
+        return elementWeight;
     }
     throw CanteraError("getElementWeight", "element not found: " + ename);
 }
 
 double getElementWeight(int atomicNumber)
 {
-    int num = numElementsDefined();
+    size_t num = numElementsDefined();
     if (atomicNumber > num || atomicNumber < 1) {
         throw IndexError("getElementWeight", "atomicWeightTable", atomicNumber, num);
     }
@@ -270,7 +275,7 @@ string getElementSymbol(const std::string& ename)
 
 string getElementSymbol(int atomicNumber)
 {
-    int num = numElementsDefined();
+    size_t num = numElementsDefined();
     if (atomicNumber > num || atomicNumber < 1) {
         throw IndexError("getElementSymbol", "atomicWeightTable", atomicNumber,
                          num);
@@ -298,7 +303,7 @@ string getElementName(const std::string& ename)
 
 string getElementName(int atomicNumber)
 {
-    int num = numElementsDefined();
+    size_t num = numElementsDefined();
     if (atomicNumber > num || atomicNumber < 1) {
         throw IndexError("getElementName", "atomicWeightTable", atomicNumber,
                          num);
@@ -308,8 +313,8 @@ string getElementName(int atomicNumber)
 
 int getAtomicNumber(const std::string& ename)
 {
-    int numElements = numElementsDefined();
-    int numIsotopes = numIsotopesDefined();
+    size_t numElements = numElementsDefined();
+    size_t numIsotopes = numIsotopesDefined();
     string symbol = trimCopy(ename);
     string name = toLowerCopy(symbol);
     for (int i = 0; i < numElements; i++) {
@@ -329,12 +334,12 @@ int getAtomicNumber(const std::string& ename)
     throw CanteraError("getAtomicNumber", "element not found: " + ename);
 }
 
-int numElementsDefined()
+size_t numElementsDefined()
 {
     return sizeof(atomicWeightTable) / sizeof(struct atomicWeightData);
 }
 
-int numIsotopesDefined()
+size_t numIsotopesDefined()
 {
     return sizeof(isotopeWeightTable) / sizeof(struct isotopeWeightData);
 }

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -234,59 +234,37 @@ const vector<string>& elementNames() {
     return values;
 }
 
-template<typename T>
-map<string, double> mapAtomicWeights(vector<T> data, bool symbol, bool name) {
+map<string, double> mapAtomicWeights() {
     map<string, double> symMap;
 
-    for (auto const& atom : data) {
-        if (symbol) {
-            symMap.emplace(atom.symbol, atom.atomicWeight);
-        } else if (name) {
-            symMap.emplace(atom.fullName, atom.atomicWeight);
-        }
+    for (auto const& atom : atomicWeightTable) {
+        symMap.emplace(atom.symbol, atom.atomicWeight);
+        symMap.emplace(atom.fullName, atom.atomicWeight);
+    }
+    for (auto const& isotope: isotopeWeightTable) {
+        symMap.emplace(isotope.symbol, isotope.atomicWeight);
+        symMap.emplace(isotope.fullName, isotope.atomicWeight);
     }
     return symMap;
 }
 
-const map<string, double>& elementSymbolToWeight() {
-    const static map<string, double> symMap = mapAtomicWeights(atomicWeightTable,
-                                                               true, false);
-    return symMap;
-}
-
-const map<string, double>& elementNameToWeight() {
-    const static map<string, double> symMap = mapAtomicWeights(atomicWeightTable,
-                                                               false, true);
-    return symMap;
-}
-
-const map<string, double>& isotopeSymbolToWeight() {
-    const static map<string, double> symMap = mapAtomicWeights(isotopeWeightTable,
-                                                               true, false);
-    return symMap;
-}
-
-const map<string, double>& isotopeNameToWeight() {
-    const static map<string, double> symMap = mapAtomicWeights(isotopeWeightTable,
-                                                               false, true);
+const map<string, double>& elementWeights() {
+    const static map<string, double> symMap = mapAtomicWeights();
     return symMap;
 }
 
 double getElementWeight(const std::string& ename)
 {
-    const auto& elementSymbolMap = elementSymbolToWeight();
-    const auto& elementNameMap = elementNameToWeight();
-    const auto& isotopeSymbolMap = isotopeSymbolToWeight();
-    const auto& isotopeNameMap = isotopeNameToWeight();
+    const auto& elementMap = elementWeights();
     double elementWeight = 0.0;
     string symbol = trimCopy(ename);
-    string name = toLowerCopy(symbol);
-    auto search = elementSymbolMap.find(symbol);
-    if (search != elementSymbolMap.end()) {
+    auto search = elementMap.find(symbol);
+    if (search != elementMap.end()) {
         elementWeight = search->second;
     } else {
-        search = elementNameMap.find(name);
-        if (search != elementNameMap.end()) {
+        string name = toLowerCopy(symbol);
+        search = elementMap.find(name);
+        if (search != elementMap.end()) {
             elementWeight = search->second;
         }
     }
@@ -295,18 +273,6 @@ double getElementWeight(const std::string& ename)
     } else if (elementWeight < 0.0) {
         throw CanteraError("getElementWeight",
             "element '{}' has no stable isotopes", ename);
-    }
-    search = isotopeSymbolMap.find(symbol);
-    if (search != isotopeSymbolMap.end()) {
-        elementWeight = search->second;
-    } else {
-        search = isotopeNameMap.find(name);
-        if (search != isotopeNameMap.end()) {
-            elementWeight = search->second;
-        }
-    }
-    if (elementWeight > 0.0) {
-        return elementWeight;
     }
     throw CanteraError("getElementWeight", "element not found: " + ename);
 }

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -846,6 +846,7 @@ bool Phase::addSpecies(shared_ptr<Species> spec) {
     wt = std::max(wt, Tiny);
     m_molwts.push_back(wt);
     m_rmolwts.push_back(1.0/wt);
+    spec->setMolecularWeight(wt);
     m_kk++;
 
     // Ensure that the Phase has a valid mass fraction vector that sums to

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -834,8 +834,6 @@ bool Phase::addSpecies(shared_ptr<Species> spec) {
     // weight to avoid dividing by zero.
     wt = std::max(wt, Tiny);
 
-    // Since this method can throw, all the modifications of the member variables
-    // should be done after this method call to avoid inconsistent state.
     spec->setMolecularWeight(wt);
 
     m_molwts.push_back(wt);

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -37,7 +37,7 @@ Species::~Species()
 {
 }
 
-const double Species::molecularWeight() {
+double Species::molecularWeight() {
     if (m_molecularWeight == Undef) {
         setMolecularWeight(-1.0, true);
     }

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -39,14 +39,7 @@ Species::~Species()
 
 double Species::molecularWeight() {
     if (m_molecularWeight == Undef) {
-        setMolecularWeight(-1.0, true);
-    }
-    return m_molecularWeight;
-}
-
-void Species::setMolecularWeight(double weight, bool compute) {
-    if (compute) {
-        weight = 0.0;
+        double weight = 0.0;
         const auto& elements = elementSymbolToWeight();
         const auto& isotopes = isotopeSymbolToWeight();
         for (const auto& comp : composition) {
@@ -64,9 +57,15 @@ void Species::setMolecularWeight(double weight, bool compute) {
                 }
             }
         }
+        setMolecularWeight(weight);
     }
+    return m_molecularWeight;
+}
+
+void Species::setMolecularWeight(double weight) {
     if (m_molecularWeight != Undef) {
-        double weight_cmp = fabs(weight - m_molecularWeight) / max(weight, m_molecularWeight);
+        double maxWeight = max(weight, m_molecularWeight);
+        double weight_cmp = fabs(weight - m_molecularWeight) / maxWeight;
         if (weight_cmp > 1.0e-9) {
             throw CanteraError(
                 "Species::setMolecularWeight",

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -40,8 +40,7 @@ Species::~Species()
 double Species::molecularWeight() {
     if (m_molecularWeight == Undef) {
         double weight = 0.0;
-        const auto& elements = elementSymbolToWeight();
-        const auto& isotopes = isotopeSymbolToWeight();
+        const auto& elements = elementWeights();
         for (const auto& comp : composition) {
             auto search = elements.find(comp.first);
             if (search != elements.end()) {
@@ -50,11 +49,6 @@ double Species::molecularWeight() {
                         "element '{}' has no stable isotopes", comp.first);
                 }
                 weight += search->second * comp.second;
-            } else {
-                search = isotopes.find(comp.first);
-                if (search != isotopes.end() && search->second > 0) {
-                    weight += search->second * comp.second;
-                }
             }
         }
         setMolecularWeight(weight);
@@ -67,9 +61,12 @@ void Species::setMolecularWeight(double weight) {
         double maxWeight = max(weight, m_molecularWeight);
         double weight_cmp = fabs(weight - m_molecularWeight) / maxWeight;
         if (weight_cmp > 1.0e-9) {
-            throw CanteraError(
+            warn_user(
                 "Species::setMolecularWeight",
-                "Molecular weight of a species cannot be changed."
+                "Molecular weight of species '{}' is changing from {} to {}.",
+                this->name,
+                m_molecularWeight,
+                weight
             );
         }
     }


### PR DESCRIPTION
The molecular weight is computed for each species when it is created.
The Phase private attribute m_mwt is not changed.

This will be useful in general, but specifically for #1185. This does _not_ need to go in for 2.6.

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
