### PR TITLE
Increase rtol in thermoToYaml for ppcle64/aarch64 systems

### DIFF
--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -342,7 +342,7 @@ public:
                              input1);
         skip_cp = false;
         skip_activities = false;
-        rtol = 1e-14;
+        rtol = 1.2e-14;
     }
 
     void compareThermo(double T, double P, const std::string& X="") {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

`rtol` for `thermoToYaml` increased by 20% to allow tests to pass on ppcle64 and aarch64 builds

Problem was identified while building v2.6.0 for Fedora Linux 35+; no issue was present in v2.6.0b2:
Relevant logs from v2.6.0 builds:
https://download.copr.fedorainfracloud.org/results/fuller/cantera-test/fedora-rawhide-aarch64/04357916-cantera/builder-live.log.gz
https://download.copr.fedorainfracloud.org/results/fuller/cantera-test/fedora-rawhide-ppc64le/04357916-cantera/builder-live.log.gz

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
