### PR TITLE
Remove in-tree-build flag from pip

### DIFF
--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -107,7 +107,7 @@ ext = localenv.LoadableModule(f"cantera/_cantera{module_ext}",
                               obj, LIBPREFIX="", SHLIBSUFFIX=module_ext,
                               SHLIBPREFIX="", LIBSUFFIXES=[module_ext])
 
-build_cmd = ("$python_cmd_esc -m pip wheel -v --no-build-isolation --use-feature=in-tree-build --no-deps "
+build_cmd = ("$python_cmd_esc -m pip wheel -v --no-build-isolation --no-deps "
              "--wheel-dir=build/python/dist build/python")
 plat = info['plat'].replace('-', '_').replace('.', '_')
 wheel_name = (f"Cantera-{env['cantera_version']}-cp{py_version_nodot}"
@@ -172,7 +172,7 @@ if env["stage_dir"]:
 
     install_cmd.append(f"--root={stage_dir.resolve()}")
 
-install_cmd.extend(("--no-build-isolation", "--use-feature=in-tree-build", "--no-deps", "-v", "--force-reinstall",
+install_cmd.extend(("--no-build-isolation", "--no-deps", "-v", "--force-reinstall",
                     "build/python"))
 if localenv['PYTHON_INSTALLER'] == 'direct':
     mod_inst = install(localenv.Command, 'dummy', mod,


### PR DESCRIPTION
This flag doesn't work with pip versions older than 21.1, but Cantera builds fine without it.

The indicated behavior becomes default in 21.3 anyway, and then starts generating warnings of its own in pip 22.0.


<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1269

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
