### PR TITLE
Fix member groupings in doxygen

### DIFF
--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -55,11 +55,10 @@ const double Pi = 3.14159265358979323846;
 const double Sqrt2 = 1.41421356237309504880;
 
 //! @}
-/*!
- * @name Defined Constants
- * These constants are defined by CODATA to have a particular value.
- * https://physics.nist.gov/cuu/Constants/index.html
- */
+//! @name Defined Constants
+//!
+//! These constants are defined by CODATA to have a particular value.
+//! https://physics.nist.gov/cuu/Constants/index.html
 //! @{
 
 //! Avogadro's Number \f$ N_{\mathrm{A}} \f$ [number/kmol]
@@ -84,11 +83,9 @@ const double OneAtm = 1.01325e5;
 const double OneBar = 1.0E5;
 
 //! @}
-
-/*!
- * @name Measured Constants
- * These constants are measured and reported by CODATA
- */
+//! @name Measured Constants
+//!
+//! These constants are measured and reported by CODATA
 //! @{
 
 //! Fine structure constant \f$ \alpha \f$ []
@@ -98,11 +95,9 @@ const double fineStructureConstant = 7.2973525693e-3;
 const double ElectronMass = 9.1093837015e-31;
 
 //! @}
-
-/*!
- * @name Derived Constants
- * These constants are found from the defined and measured constants
- */
+//! @name Derived Constants
+//!
+//! These constants are found from the defined and measured constants
 //! @{
 
 //! Reduced Planck constant \f$ \hbar \f$ [m2-kg/s]
@@ -134,13 +129,12 @@ const double permeability_0 = 2 * fineStructureConstant * Planck / (ElectronChar
 const double epsilon_0 = 1.0 / (lightSpeed * lightSpeed * permeability_0);
 
 //! @}
-
-/*!
- * @name Thermodynamic Equilibrium Constraints
- * Integer numbers representing pairs of thermodynamic variables
- * which are held constant during equilibration.
- */
+//! @name Thermodynamic Equilibrium Constraints
+//!
+//! Integer numbers representing pairs of thermodynamic variables
+//! which are held constant during equilibration.
 //! @{
+
 const int TV = 100, HP = 101, SP = 102, PV = 103, TP = 104, UV = 105,
           ST = 106, SV = 107, UP = 108, VH = 109, TH = 110, SH = 111,
           PX = 112, TX = 113;

--- a/include/cantera/equil/vcs_defs.h
+++ b/include/cantera/equil/vcs_defs.h
@@ -29,12 +29,10 @@ namespace Cantera
 #define VCS_SSVOL_IDEALGAS 0
 #define VCS_SSVOL_CONSTANT 1
 
-/*!
- * @name  Sizes of Phases and Cutoff Mole Numbers
- *
- *      All size parameters are listed here
- * @{
- */
+//! @name  Sizes of Phases and Cutoff Mole Numbers
+//!
+//! All size parameters are listed here
+//! @{
 
 //! Cutoff relative mole fraction value, below which species are deleted from
 //! the equilibrium problem.
@@ -208,16 +206,12 @@ namespace Cantera
 #define VCS_PHASE_EXIST_ZEROEDPHASE -6
 
 //! @}
-
-/*!
- * @name Types of Element Constraint Equations
- *
- * There may be several different types of element constraints handled by the
- * equilibrium program.  These defines are used to assign each constraint to one
- * category.
- * @{
- */
-
+//! @name Types of Element Constraint Equations
+//!
+//! There may be several different types of element constraints handled by the
+//! equilibrium program.  These defines are used to assign each constraint to one
+//! category.
+//! @{
 
 //! An element constraint that is current turned off
 #define VCS_ELEM_TYPE_TURNEDOFF -1
@@ -275,12 +269,11 @@ namespace Cantera
  * currently there are none
  */
 #define VCS_ELEM_TYPE_OTHERCONSTRAINT 6
-//! @}
 
-/*!
- * @name  Types of Species Unknowns in the problem
- * @{
- */
+//! @}
+//! @name  Types of Species Unknowns in the problem
+//! @{
+
 //! Unknown refers to mole number of a single species
 #define VCS_SPECIES_TYPE_MOLNUM 0
 
@@ -291,13 +284,13 @@ namespace Cantera
  * for example if the open circuit voltage is sought after.
  */
 #define VCS_SPECIES_TYPE_INTERFACIALVOLTAGE -5
-//! @}
 
-/*!
- * @name  Types of State Calculations within VCS. These values determine where
- *        the results are stored within the VCS_SOLVE object.
- * @{
- */
+//! @}
+//! @name  Types of State Calculations within VCS
+//!
+//! These values determine where the results are stored within the VCS_SOLVE object.
+//! @{
+
 //! State Calculation is currently in an unknown state
 #define VCS_STATECALC_UNKNOWN -1
 //! State Calculation based on the old or base mole numbers

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -91,11 +91,10 @@ public:
 
 protected:
     //! @name Internal service methods
-    /*!
-     * These methods are for @internal use, and seek to avoid code duplication
-     * while evaluating terms used for rate constants, rates of progress, and
-     * their derivatives.
-     */
+    //!
+    //! These methods are for @internal use, and seek to avoid code duplication
+    //! while evaluating terms used for rate constants, rates of progress, and
+    //! their derivatives.
     //! @{
 
     //! Calculate rate coefficients
@@ -170,7 +169,8 @@ protected:
     Rate1<ChebyshevRate> m_cheb_rates; //!< @deprecated (legacy only)
 
     //! @name Reaction rate data
-    //!@{
+    //! @{
+
     doublereal m_logStandConc;
     vector_fp m_rfn_low; //!< @deprecated (legacy only)
     vector_fp m_rfn_high; //!< @deprecated (legacy only)
@@ -180,7 +180,7 @@ protected:
     vector_fp concm_3b_values; //!< @deprecated (legacy only)
     vector_fp concm_falloff_values; //!< @deprecated (legacy only)
 
-    //!@}
+    //! @}
 
     //! Buffers for partial rop results with length nReactions()
     vector_fp m_rbuf0;

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -569,31 +569,30 @@ public:
 
     //! @}
     //! @name Routines to Calculate Derivatives (Jacobians)
-    /*!
-     * Derivatives are calculated with respect to temperature, pressure, molar
-     * concentrations and species mole fractions for forward/reverse/net rates of
-     * progress as well as creation/destruction and net production of species.
-     *
-     * The following suffixes are used to indicate derivatives:
-     *  - `_ddT`: derivative with respect to temperature (a vector)
-     *  - `_ddP`: derivative with respect to pressure (a vector)
-     *  - `_ddC`: derivative with respect to molar concentration (a vector)
-     *  - `_ddX`: derivative with respect to species mole fractions (a matrix)
-     *
-     * Settings for derivative evaluation are set by keyword/value pairs using
-     * the methods @see getDerivativeSettings and @see setDerivativeSettings.
-     *
-     * For GasKinetics, the following keyword/value pairs are supported:
-     *  - `skip-third-bodies` (boolean) ... if `false` (default), third body
-     *    concentrations are considered for the evaluation of jacobians
-     *  - `skip-falloff` (boolean) ... if `false` (default), third-body effects
-     *    on rate constants are considered for the evaluation of derivatives.
-     *  - `rtol-delta` (double) ... relative tolerance used to perturb properties
-     *    when calculating numerical derivatives. The default value is 1e-8.
-     *
-     * @warning  The calculation of derivatives is an experimental part of the
-     *      %Cantera API and may be changed or removed without notice.
-     */
+    //!
+    //! Derivatives are calculated with respect to temperature, pressure, molar
+    //! concentrations and species mole fractions for forward/reverse/net rates of
+    //! progress as well as creation/destruction and net production of species.
+    //!
+    //! The following suffixes are used to indicate derivatives:
+    //!  - `_ddT`: derivative with respect to temperature (a vector)
+    //!  - `_ddP`: derivative with respect to pressure (a vector)
+    //!  - `_ddC`: derivative with respect to molar concentration (a vector)
+    //!  - `_ddX`: derivative with respect to species mole fractions (a matrix)
+    //!
+    //! Settings for derivative evaluation are set by keyword/value pairs using
+    //! the methods @see getDerivativeSettings and @see setDerivativeSettings.
+    //!
+    //! For GasKinetics, the following keyword/value pairs are supported:
+    //!  - `skip-third-bodies` (boolean) ... if `false` (default), third body
+    //!    concentrations are considered for the evaluation of jacobians
+    //!  - `skip-falloff` (boolean) ... if `false` (default), third-body effects
+    //!    on rate constants are considered for the evaluation of derivatives.
+    //!  - `rtol-delta` (double) ... relative tolerance used to perturb properties
+    //!    when calculating numerical derivatives. The default value is 1e-8.
+    //!
+    //! @warning  The calculation of derivatives is an experimental part of the
+    //!      %Cantera API and may be changed or removed without notice.
     //! @{
 
     /**
@@ -1189,15 +1188,14 @@ public:
 
     //! @}
     //! @name Altering Reaction Rates
-    /*!
-     * These methods alter reaction rates. They are designed primarily for
-     * carrying out sensitivity analysis, but may be used for any purpose
-     * requiring dynamic alteration of rate constants. For each reaction, a
-     * real-valued multiplier may be defined that multiplies the reaction rate
-     * coefficient. The multiplier may be set to zero to completely remove a
-     * reaction from the mechanism.
-     * @{
-     */
+    //!
+    //! These methods alter reaction rates. They are designed primarily for
+    //! carrying out sensitivity analysis, but may be used for any purpose
+    //! requiring dynamic alteration of rate constants. For each reaction, a
+    //! real-valued multiplier may be defined that multiplies the reaction rate
+    //! coefficient. The multiplier may be set to zero to completely remove a
+    //! reaction from the mechanism.
+    //! @{
 
     //! The current value of the multiplier for reaction i.
     /*!
@@ -1289,12 +1287,11 @@ protected:
     void checkReactionBalance(const Reaction& R);
 
     //! @name Stoichiometry management
-    /*!
-     *  These objects and functions handle turning reaction extents into species
-     *  production rates and also handle turning thermo properties into reaction
-     *  thermo properties.
-     *  @{
-     */
+    //!
+    //! These objects and functions handle turning reaction extents into species
+    //! production rates and also handle turning thermo properties into reaction
+    //! thermo properties.
+    //! @{
 
     //! Stoichiometry manager for the reactants for each reaction
     StoichManagerN m_reactantStoich;

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -39,11 +39,10 @@ public:
     doublereal value; ///< May be used to set node appearance
     bool visible; ///< Visible on graph;
 
-    /**
-     *  @name References.
-     * Return a reference to a path object connecting this node
-     *  to another node.
-     */
+    //! @name References
+    //!
+    //! Return a reference to a path object connecting this node
+    //! to another node.
     //! @{
     Path* path(int n) {
         return m_paths[n];

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -37,11 +37,9 @@ public:
      */
     Sim1D(std::vector<Domain1D*>& domains);
 
-    /**
-     * @name Setting initial values
-     *
-     * These methods are used to set the initial values of solution components.
-     */
+    //! @name Setting initial values
+    //!
+    //! These methods are used to set the initial values of solution components.
     //! @{
 
     /// Set initial guess for one component for all domains

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -370,6 +370,7 @@ protected:
     //! @}
 
     //! @name convective spatial derivatives.
+    //!
     //! These use upwind differencing, assuming u(z) is negative
     //! @{
     doublereal dVdz(const doublereal* x, size_t j) const {

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -20,22 +20,21 @@
 namespace Cantera
 {
 
-/*!
- * @name Formats for the Activity Coefficients
- *
- *   These are possible formats for the molality-based activity coefficients.
- */
+//! @name Formats for the Activity Coefficients
+//!
+//! These are possible formats for the molality-based activity coefficients.
 //! @{
+
 #define DHFORM_DILUTE_LIMIT 0
 #define DHFORM_BDOT_AK 1
 #define DHFORM_BDOT_ACOMMON 2
 #define DHFORM_BETAIJ 3
 #define DHFORM_PITZER_BETAIJ 4
+
 //! @}
-/*!
- * @name  Acceptable ways to calculate the value of A_Debye
- */
+//! @name  Acceptable ways to calculate the value of A_Debye
 //! @{
+
 #define A_DEBYE_CONST 0
 #define A_DEBYE_WATER 1
 //! @}

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -33,7 +33,7 @@ namespace Cantera
 #define DHFORM_PITZER_BETAIJ 4
 //! @}
 /*!
- *  @name  Acceptable ways to calculate the value of A_Debye
+ * @name  Acceptable ways to calculate the value of A_Debye
  */
 //! @{
 #define A_DEBYE_CONST 0
@@ -599,30 +599,28 @@ public:
     virtual doublereal cp_mole() const;
 
     //! @}
-    /** @name Mechanical Equation of State Properties
-     * In this equation of state implementation, the density is a function only
-     * of the mole fractions. Therefore, it can't be an independent variable.
-     * Instead, the pressure is used as the independent variable. Functions
-     * which try to set the thermodynamic state by calling setDensity() will
-     * cause an exception to be thrown.
-     * @{
-     */
+    //! @name Mechanical Equation of State Properties
+    //!
+    //! In this equation of state implementation, the density is a function only
+    //! of the mole fractions. Therefore, it can't be an independent variable.
+    //! Instead, the pressure is used as the independent variable. Functions
+    //! which try to set the thermodynamic state by calling setDensity() will
+    //! cause an exception to be thrown.
+    //! @{
 
 protected:
     virtual void calcDensity();
 
 public:
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-     * quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
-     * which depends only on temperature and the pressure. Activity is assumed
-     * to be molality-based here.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
+    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! which depends only on temperature and the pressure. Activity is assumed
+    //! to be molality-based here.
+    //! @{
 
     virtual void getActivityConcentrations(doublereal* c) const;
 
@@ -665,7 +663,7 @@ public:
     virtual void getMolalityActivityCoefficients(doublereal* acMolality) const;
 
     //! @}
-    //! @name  Partial Molar Properties of the Solution
+    //! @name Partial Molar Properties of the Solution
     //! @{
 
     //! Get the species chemical potentials. Units: J/kmol.

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -15,14 +15,12 @@
 namespace Cantera
 {
 
-/*!
- * @name Types of Element Constraint Equations
- *
- * There may be several different types of element constraints handled by the
- * equilibrium program and by Cantera in other contexts. These defines are used
- * to assign each constraint to one category.
- * @{
- */
+//! @name Types of Element Constraint Equations
+//!
+//! There may be several different types of element constraints handled by the
+//! equilibrium program and by Cantera in other contexts. These defines are used
+//! to assign each constraint to one category.
+//! @{
 
 //! An element constraint that is current turned off
 #define CT_ELEM_TYPE_TURNEDOFF -1

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -118,16 +118,14 @@ protected:
     void calcDensity();
 
 public:
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-     * quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
-     * which depends only on temperature and pressure.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
+    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! which depends only on temperature and pressure.
+    //! @{
 
     virtual Units standardConcentrationUnits() const;
     virtual void getActivityConcentrations(doublereal* c) const;
@@ -205,7 +203,7 @@ public:
     }
 
     //! @}
-    /// @name  Partial Molar Properties of the Solution
+    //! @name Partial Molar Properties of the Solution
     //! @{
 
     //! Return an array of partial molar volumes for the

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1120,16 +1120,15 @@ public:
      */
     virtual doublereal cv_mole() const;
 
-    //!@}
+    //! @}
     //! @name Mechanical Equation of State Properties
-    /*!
-     * In this equation of state implementation, the density is a function
-     * only of the mole fractions. Therefore, it can't be an independent
-     * variable. Instead, the pressure is used as the independent variable.
-     * Functions which try to set the thermodynamic state by calling
-     * setDensity() will cause an exception to be thrown.
-     */
-    //!@{
+    //!
+    //! In this equation of state implementation, the density is a function
+    //! only of the mole fractions. Therefore, it can't be an independent
+    //! variable. Instead, the pressure is used as the independent variable.
+    //! Functions which try to set the thermodynamic state by calling
+    //! setDensity() will cause an exception to be thrown.
+    //! @{
 
 protected:
     /**
@@ -1156,17 +1155,15 @@ protected:
     void calcDensity();
 
 public:
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-     * quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
-     * which depends only on temperature and the pressure. Activity is assumed
-     * to be molality-based here.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
+    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! which depends only on temperature and the pressure. Activity is assumed
+    //! to be molality-based here.
+    //! @{
 
     //! This method returns an array of generalized activity concentrations
     /*!

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -21,40 +21,38 @@
 namespace Cantera
 {
 
-/*!
- * @name Temperature Dependence of the Pitzer Coefficients
- *
- * Note, the temperature dependence of the Gibbs free energy also depends on the
- * temperature dependence of the standard state and the temperature dependence
- * of the Debye-Huckel constant, which includes the dielectric constant and the
- * density. Therefore, this expression defines only part of the temperature
- * dependence for the mixture thermodynamic functions.
- *
- *  PITZER_TEMP_CONSTANT
- *     All coefficients are considered constant wrt temperature
- *  PITZER_TEMP_LINEAR
- *     All coefficients are assumed to have a linear dependence
- *     wrt to temperature.
- *  PITZER_TEMP_COMPLEX1
- *     All coefficients are assumed to have a complex functional
- *     based dependence wrt temperature;  See:
- *    (Silvester, Pitzer, J. Phys. Chem. 81, 19 1822 (1977)).
- *
- *       beta0 = q0 + q3(1/T - 1/Tr) + q4(ln(T/Tr)) +
- *               q1(T - Tr) + q2(T**2 - Tr**2)
- */
+//! @name Temperature Dependence of the Pitzer Coefficients
+//!
+//! Note, the temperature dependence of the Gibbs free energy also depends on the
+//! temperature dependence of the standard state and the temperature dependence
+//! of the Debye-Huckel constant, which includes the dielectric constant and the
+//! density. Therefore, this expression defines only part of the temperature
+//! dependence for the mixture thermodynamic functions.
+//!
+//!  PITZER_TEMP_CONSTANT
+//!     All coefficients are considered constant wrt temperature
+//!  PITZER_TEMP_LINEAR
+//!     All coefficients are assumed to have a linear dependence
+//!     wrt to temperature.
+//!  PITZER_TEMP_COMPLEX1
+//!     All coefficients are assumed to have a complex functional
+//!     based dependence wrt temperature;  See:
+//!    (Silvester, Pitzer, J. Phys. Chem. 81, 19 1822 (1977)).
+//!
+//!       beta0 = q0 + q3(1/T - 1/Tr) + q4(ln(T/Tr)) +
+//!               q1(T - Tr) + q2(T**2 - Tr**2)
 //! @{
+
 #define PITZER_TEMP_CONSTANT 0
 #define PITZER_TEMP_LINEAR 1
 #define PITZER_TEMP_COMPLEX1 2
-//! @}
 
-/*!
- * @name ways to calculate the value of A_Debye
- *
- * These defines determine the way A_Debye is calculated
- */
+//! @}
+//! @name ways to calculate the value of A_Debye
+//!
+//! These defines determine the way A_Debye is calculated
 //! @{
+
 #define A_DEBYE_CONST 0
 #define A_DEBYE_WATER 1
 //! @}

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -433,37 +433,34 @@ public:
     }
 
     //! @}
-
-    /**
-     * @name Chemical Potentials and Activities
-     *
-     * The activity \f$a_k\f$ of a species in solution is
-     * related to the chemical potential by
-     * \f[
-     *  \mu_k(T,P,X_k) = \mu_k^0(T,P)
-     * + \hat R T \log a_k.
-     *  \f]
-     * The quantity \f$\mu_k^0(T,P)\f$ is the standard state chemical potential
-     * at unit activity. It may depend on the pressure and the temperature.
-     * However, it may not depend on the mole fractions of the species in the
-     * solution.
-     *
-     * The activities are related to the generalized concentrations, \f$\tilde
-     * C_k\f$, and standard concentrations, \f$C^0_k\f$, by the following
-     * formula:
-     *
-     *  \f[
-     *  a_k = \frac{\tilde C_k}{C^0_k}
-     *  \f]
-     * The generalized concentrations are used in the kinetics classes to
-     * describe the rates of progress of reactions involving the species. Their
-     * formulation depends upon the specification of the rate constants for
-     * reaction, especially the units used in specifying the rate constants. The
-     * bridge between the thermodynamic equilibrium expressions that use a_k and
-     * the kinetics expressions which use the generalized concentrations is
-     * provided by the multiplicative factor of the standard concentrations.
-     * @{
-     */
+    //! @name Chemical Potentials and Activities
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is
+    //! related to the chemical potential by
+    //! \f[
+    //!  \mu_k(T,P,X_k) = \mu_k^0(T,P)
+    //! + \hat R T \log a_k.
+    //!  \f]
+    //! The quantity \f$\mu_k^0(T,P)\f$ is the standard state chemical potential
+    //! at unit activity. It may depend on the pressure and the temperature.
+    //! However, it may not depend on the mole fractions of the species in the
+    //! solution.
+    //!
+    //! The activities are related to the generalized concentrations, \f$\tilde
+    //! C_k\f$, and standard concentrations, \f$C^0_k\f$, by the following
+    //! formula:
+    //!
+    //!  \f[
+    //!  a_k = \frac{\tilde C_k}{C^0_k}
+    //!  \f]
+    //! The generalized concentrations are used in the kinetics classes to
+    //! describe the rates of progress of reactions involving the species. Their
+    //! formulation depends upon the specification of the rate constants for
+    //! reaction, especially the units used in specifying the rate constants. The
+    //! bridge between the thermodynamic equilibrium expressions that use a_k and
+    //! the kinetics expressions which use the generalized concentrations is
+    //! provided by the multiplicative factor of the standard concentrations.
+    //! @{
 
     //! This method returns the array of generalized concentrations.
     /*!
@@ -503,7 +500,7 @@ public:
     virtual void getActivityCoefficients(doublereal* ac) const;
 
     //! @}
-    /// @name Partial Molar Properties of the Solution
+    //! @name Partial Molar Properties of the Solution
     //! @{
 
     virtual void getChemPotentials(doublereal* mu) const;
@@ -514,7 +511,7 @@ public:
     virtual void getPartialMolarVolumes(doublereal* vbar) const;
 
     //! @}
-    /// @name  Properties of the Standard State of the Species in the Solution
+    //! @name  Properties of the Standard State of the Species in the Solution
     //! @{
 
     virtual void getStandardChemPotentials(doublereal* mu) const;
@@ -527,7 +524,7 @@ public:
     virtual void getStandardVolumes(doublereal* vol) const;
 
     //! @}
-    /// @name Thermodynamic Values for the Species Reference States
+    //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
     virtual void getEnthalpy_RT_ref(doublereal* hrt) const;
@@ -539,7 +536,7 @@ public:
     virtual void getStandardVolumes_ref(doublereal* vol) const;
 
     //! @}
-    /// @name NonVirtual Internal methods to Return References to Reference State Thermo
+    //! @name NonVirtual Internal methods to Return References to Reference State Thermo
     //! @{
 
     //! Returns a reference to the dimensionless reference state enthalpy vector.

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -184,14 +184,13 @@ public:
     virtual doublereal cp_mole() const;
 
     //! @}
-    /** @name Mechanical Equation of State Properties
-     *
-     * In this equation of state implementation, the density is a function only
-     * of the mole fractions. Therefore, it can't be an independent variable.
-     * Instead, the pressure is used as the independent variable. Functions
-     * which try to set the thermodynamic state by calling setDensity() will
-     * cause an exception to be thrown.
-     */
+    //! @name Mechanical Equation of State Properties
+    //!
+    //! In this equation of state implementation, the density is a function only
+    //! of the mole fractions. Therefore, it can't be an independent variable.
+    //! Instead, the pressure is used as the independent variable. Functions
+    //! which try to set the thermodynamic state by calling setDensity() will
+    //! cause an exception to be thrown.
     //! @{
 
 protected:
@@ -241,16 +240,14 @@ public:
      */
     virtual doublereal thermalExpansionCoeff() const;
 
-    /**
-     * @}
-     * @name Activities and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-     * quantity \f$\mu_k^0(T)\f$ is the chemical potential at unit activity,
-     * which depends only on temperature and the pressure.
-     * @{
-     */
+    //! @}
+    //! @name Activities and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
+    //! quantity \f$\mu_k^0(T)\f$ is the chemical potential at unit activity,
+    //! which depends only on temperature and the pressure.
+    //! @{
 
     virtual Units standardConcentrationUnits() const;
     virtual void getActivityConcentrations(doublereal* c) const;
@@ -279,7 +276,7 @@ public:
     virtual void getMolalityActivityCoefficients(doublereal* acMolality) const;
 
     //! @}
-    /// @name  Partial Molar Properties of the Solution
+    //! @name  Partial Molar Properties of the Solution
     //! @{
 
     //!Get the species chemical potentials: Units: J/kmol.
@@ -469,8 +466,7 @@ public:
     //! function at the zero solvent point. Default value is 0.0
     doublereal IMS_slopegCut_;
 
-    //! @name Parameters in the polyExp cutoff treatment having to do with rate
-    //!     of exp decay
+    //! @name Parameters in the polyExp cutoff having to do with rate of exp decay
     //! @{
     doublereal IMS_cCut_;
     doublereal IMS_dfCut_;

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -176,14 +176,13 @@ public:
     }
 
     //! @}
-    /** @name Mechanical Equation of State Properties
-     *
-     * In this equation of state implementation, the density is a function only
-     * of the mole fractions. Therefore, it can't be an independent variable.
-     * Instead, the pressure is used as the independent variable. Functions
-     * which try to set the thermodynamic state by calling setDensity() will
-     * cause an exception to be thrown.
-     */
+    //! @name Mechanical Equation of State Properties
+    //!
+    //! In this equation of state implementation, the density is a function only
+    //! of the mole fractions. Therefore, it can't be an independent variable.
+    //! Instead, the pressure is used as the independent variable. Functions
+    //! which try to set the thermodynamic state by calling setDensity() will
+    //! cause an exception to be thrown.
     //! @{
 
     /**
@@ -224,37 +223,34 @@ public:
     virtual void calcDensity();
 
     //! @}
-
-    /**
-     * @name Chemical Potentials and Activities
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by
-     * \f[
-     *  \mu_k(T,P,X_k) = \mu_k^0(T,P)
-     * + \hat R T \log a_k.
-     *  \f]
-     * The quantity \f$\mu_k^0(T,P)\f$ is the standard state chemical potential
-     * at unit activity. It may depend on the pressure and the temperature.
-     * However, it may not depend on the mole fractions of the species in the
-     * solid solution.
-     *
-     * The activities are related to the generalized concentrations, \f$\tilde
-     * C_k\f$, and standard concentrations, \f$C^0_k\f$, by the following
-     * formula:
-     *
-     *  \f[
-     *  a_k = \frac{\tilde C_k}{C^0_k}
-     *  \f]
-     * The generalized concentrations are used in the kinetics classes to
-     * describe the rates of progress of reactions involving the species. Their
-     * formulation depends upon the specification of the rate constants for
-     * reaction, especially the units used in specifying the rate constants. The
-     * bridge between the thermodynamic equilibrium expressions that use a_k and
-     * the kinetics expressions which use the generalized concentrations is
-     * provided by the multiplicative factor of the standard concentrations.
-     * @{
-     */
+    //! @name Chemical Potentials and Activities
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by
+    //! \f[
+    //!  \mu_k(T,P,X_k) = \mu_k^0(T,P)
+    //! + \hat R T \log a_k.
+    //!  \f]
+    //! The quantity \f$\mu_k^0(T,P)\f$ is the standard state chemical potential
+    //! at unit activity. It may depend on the pressure and the temperature.
+    //! However, it may not depend on the mole fractions of the species in the
+    //! solid solution.
+    //!
+    //! The activities are related to the generalized concentrations, \f$\tilde
+    //! C_k\f$, and standard concentrations, \f$C^0_k\f$, by the following
+    //! formula:
+    //!
+    //!  \f[
+    //!  a_k = \frac{\tilde C_k}{C^0_k}
+    //!  \f]
+    //! The generalized concentrations are used in the kinetics classes to
+    //! describe the rates of progress of reactions involving the species. Their
+    //! formulation depends upon the specification of the rate constants for
+    //! reaction, especially the units used in specifying the rate constants. The
+    //! bridge between the thermodynamic equilibrium expressions that use a_k and
+    //! the kinetics expressions which use the generalized concentrations is
+    //! provided by the multiplicative factor of the standard concentrations.
+    //! @{
 
     virtual Units standardConcentrationUnits() const;
 
@@ -348,7 +344,7 @@ public:
     virtual void getChemPotentials_RT(doublereal* mu) const;
 
     //! @}
-    /// @name  Partial Molar Properties of the Solution
+    //! @name  Partial Molar Properties of the Solution
     //! @{
 
     //! Returns an array of partial molar enthalpies for the species in the
@@ -410,7 +406,7 @@ public:
     virtual void getPartialMolarVolumes(doublereal* vbar) const;
 
     //! @}
-    /// @name  Properties of the Standard State of the Species in the Solution
+    //! @name  Properties of the Standard State of the Species in the Solution
     //! @{
 
     /**
@@ -508,7 +504,7 @@ public:
     virtual void getStandardVolumes(doublereal* vol) const;
 
     //! @}
-    /// @name Thermodynamic Values for the Species Reference States
+    //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
     virtual void getEnthalpy_RT_ref(doublereal* hrt) const;

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -123,12 +123,11 @@ public:
 
 public:
     //! @name Initialization Methods - For Internal use
-    /*!
-     * The following methods are used in the process of constructing the phase
-     * and setting its parameters from a specification in an input file. They
-     * are not normally used in application programs. To see how they are used,
-     * see importPhase().
-     */
+    //!
+    //! The following methods are used in the process of constructing the phase
+    //! and setting its parameters from a specification in an input file. They
+    //! are not normally used in application programs. To see how they are used,
+    //! see importPhase().
     //! @{
 
     virtual bool addSpecies(shared_ptr<Species> spec);

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -115,17 +115,15 @@ public:
     virtual doublereal cp_mole() const;
     virtual doublereal cv_mole() const;
 
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is
-     * related to the chemical potential by \f[ \mu_k = \mu_k^0(T)
-     * + \hat R T \log a_k. \f] The quantity \f$\mu_k^0(T,P)\f$ is
-     * the chemical potential at unit activity, which depends only
-     * on temperature and pressure.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is
+    //! related to the chemical potential by \f[ \mu_k = \mu_k^0(T)
+    //! + \hat R T \log a_k. \f] The quantity \f$\mu_k^0(T,P)\f$ is
+    //! the chemical potential at unit activity, which depends only
+    //! on temperature and pressure.
+    //! @{
 
     virtual void getActivityCoefficients(doublereal* ac) const;
 
@@ -235,11 +233,10 @@ public:
         anion=anionList_;
     }
 
-    /**
-     * @name Setting the State
-     * These methods set all or part of the thermodynamic state.
-     * @{
-     */
+    //! @name Setting the State
+    //!
+    //! These methods set all or part of the thermodynamic state.
+    //! @{
 
     virtual void calcDensity();
 

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -308,13 +308,12 @@ public:
 
     //! @}
     //! @name Mechanical Equation of State Properties
-    /*!
-     * In this equation of state implementation, the density is a function only
-     * of the mole fractions. Therefore, it can't be an independent variable.
-     * Instead, the pressure is used as the independent variable. Functions
-     * which try to set the thermodynamic state by calling setDensity() may
-     * cause an exception to be thrown.
-     */
+    //!
+    //! In this equation of state implementation, the density is a function only
+    //! of the mole fractions. Therefore, it can't be an independent variable.
+    //! Instead, the pressure is used as the independent variable. Functions
+    //! which try to set the thermodynamic state by calling setDensity() may
+    //! cause an exception to be thrown.
     //! @{
 
     //! Pressure. Units: Pa.
@@ -356,14 +355,13 @@ public:
     doublereal calcDensity();
 
     //! @}
-    /// @name Activities, Standard States, and Activity Concentrations
-    /**
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-     * quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
-     * which depends only on temperature and the pressure. Activity is assumed
-     * to be molality-based here.
-     */
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
+    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! which depends only on temperature and the pressure. Activity is assumed
+    //! to be molality-based here.
     //! @{
 
     virtual Units standardConcentrationUnits() const;
@@ -396,7 +394,7 @@ public:
     virtual void getActivityCoefficients(doublereal* ac) const;
 
     //! @}
-    /// @name  Partial Molar Properties of the Solution
+    //! @name  Partial Molar Properties of the Solution
     //! @{
 
     //! Get the species chemical potentials. Units: J/kmol.
@@ -550,7 +548,7 @@ public:
     virtual void getStandardVolumes(doublereal* vol) const;
 
     //! @}
-    /// @name Thermodynamic Values for the Species Reference States
+    //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
     const vector_fp& enthalpy_RT_ref() const;

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -416,7 +416,7 @@ public:
     virtual doublereal standardConcentration(size_t k=0) const;
     virtual doublereal logStandardConc(size_t k=0) const;
 
-    /// @name Thermodynamic Values for the Species Reference States
+    //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
     virtual void getGibbs_RT_ref(doublereal* grt) const;

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -248,21 +248,19 @@ public:
     virtual doublereal cp_mole() const;
     virtual doublereal cv_mole() const;
 
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-     * quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
-     * which depends only on temperature and pressure.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
+    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! which depends only on temperature and pressure.
+    //! @{
 
     virtual void getLnActivityCoefficients(doublereal* lnac) const;
 
     //! @}
-    /// @name  Partial Molar Properties of the Solution
+    //! @name  Partial Molar Properties of the Solution
     //! @{
 
     virtual void getChemPotentials(doublereal* mu) const;
@@ -341,12 +339,14 @@ public:
 
     virtual void getdlnActCoeffdT(doublereal* dlnActCoeffdT) const;
 
-    /// @}
-    /// @name Initialization The following methods are used in the process of
-    ///     constructing the phase and setting its parameters from a
-    ///     specification in an input file. They are not normally used in
-    ///     application programs. To see how they are used, see importPhase()
-    /// @{
+    //! @}
+    //! @name Initialization
+    //!
+    //! The following methods are used in the process of constructing the phase
+    //! and setting its parameters from a specification in an input file. They
+    //! are not normally used in application programs. To see how they are used,
+    //! see importPhase()
+    //! @{
 
     virtual void initThermo();
     virtual void getParameters(AnyMap& phaseNode) const;

--- a/include/cantera/thermo/MaskellSolidSolnPhase.h
+++ b/include/cantera/thermo/MaskellSolidSolnPhase.h
@@ -45,14 +45,13 @@ public:
     virtual doublereal entropy_mole() const;
 
     //! @}
-    /** @name Mechanical Equation of State Properties
-     *
-     * In this equation of state implementation, the density is a function only
-     * of the mole fractions. Therefore, it can't be an independent variable.
-     * Instead, the pressure is used as the independent variable. Functions
-     * which try to set the thermodynamic state by calling setDensity() will
-     * cause an exception to be thrown.
-     */
+    //! @name Mechanical Equation of State Properties
+    //!
+    //! In this equation of state implementation, the density is a function only
+    //! of the mole fractions. Therefore, it can't be an independent variable.
+    //! Instead, the pressure is used as the independent variable. Functions
+    //! which try to set the thermodynamic state by calling setDensity() will
+    //! cause an exception to be thrown.
     //! @{
 
     /**

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -145,14 +145,12 @@ public:
     virtual void getChemPotentials_RT(doublereal* mu) const;
 
     //! @}
-    /*!
-     * @name  Properties of the Standard State of the Species in the Solution
-     *
-     * Within MixtureFugacityTP, these properties are calculated via a common
-     * routine, _updateStandardStateThermo(), which must be overloaded in
-     * inherited objects. The values are cached within this object, and are not
-     * recalculated unless the temperature or pressure changes.
-     */
+    //! @name  Properties of the Standard State of the Species in the Solution
+    //!
+    //! Within MixtureFugacityTP, these properties are calculated via a common
+    //! routine, _updateStandardStateThermo(), which must be overloaded in
+    //! inherited objects. The values are cached within this object, and are not
+    //! recalculated unless the temperature or pressure changes.
     //! @{
 
     //! Get the array of chemical potentials at unit activity.
@@ -302,14 +300,13 @@ protected:
     mutable vector_fp m_tmpV;
 public:
 
-    /// @name Thermodynamic Values for the Species Reference States
-    /*!
-     * There are also temporary variables for holding the species reference-
-     * state values of Cp, H, S, and V at the last temperature and reference
-     * pressure called. These functions are not recalculated if a new call is
-     * made using the previous temperature. All calculations are done within the
-     * routine _updateRefStateThermo().
-     */
+    //! @name Thermodynamic Values for the Species Reference States
+    //!
+    //! There are also temporary variables for holding the species reference-
+    //! state values of Cp, H, S, and V at the last temperature and reference
+    //! pressure called. These functions are not recalculated if a new call is
+    //! made using the previous temperature. All calculations are done within the
+    //! routine _updateRefStateThermo().
     //! @{
 
     virtual void getEnthalpy_RT_ref(doublereal* hrt) const;
@@ -334,12 +331,11 @@ public:
 
     //! @}
     //! @name Initialization Methods - For Internal use
-    /*!
-     * The following methods are used in the process of constructing
-     * the phase and setting its parameters from a specification in an
-     * input file. They are not normally used in application programs.
-     * To see how they are used, see importPhase().
-     */
+    //!
+    //! The following methods are used in the process of constructing
+    //! the phase and setting its parameters from a specification in an
+    //! input file. They are not normally used in application programs.
+    //! To see how they are used, see importPhase().
     //! @{
     virtual bool addSpecies(shared_ptr<Species> spec);
     virtual void setStateFromXML(const XML_Node& state);

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -327,16 +327,14 @@ public:
      */
     void setMolalitiesByName(const std::string& name);
 
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-     * quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
-     * which depends only on temperature and pressure.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
+    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! which depends only on temperature and pressure.
+    //! @{
 
     /**
      *  We set the convention to molality here.
@@ -471,10 +469,11 @@ public:
     virtual void setStateFromXML(const XML_Node& state);
 
     //! @name Initialization
-    /// The following methods are used in the process of constructing the phase
-    /// and setting its parameters from a specification in an input file. They
-    /// are not normally used in application programs. To see how they are used,
-    /// see importPhase().
+    //!
+    //! The following methods are used in the process of constructing the phase
+    //! and setting its parameters from a specification in an input file. They
+    //! are not normally used in application programs. To see how they are used,
+    //! see importPhase().
     //! @{
 
     virtual bool addSpecies(shared_ptr<Species> spec);

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -158,10 +158,9 @@ public:
     PDSS& operator=(const PDSS& b) = delete;
     virtual ~PDSS() {}
 
-     //! @}
-     //! @name Molar Thermodynamic Properties of the Species Standard State in
-     //!     the Solution
-     //! @{
+    //! @}
+    //! @name Molar Thermodynamic Properties of the Species Standard State
+    //! @{
 
     //! Return the molar enthalpy in units of J kmol-1
     /*!
@@ -317,7 +316,7 @@ public:
     virtual doublereal molarVolume_ref() const;
 
     //! @}
-    //!  @name Mechanical Equation of State Properties
+    //! @name Mechanical Equation of State Properties
     //! @{
 
     //! Returns the pressure (Pa)

--- a/include/cantera/thermo/PDSS_ConstVol.h
+++ b/include/cantera/thermo/PDSS_ConstVol.h
@@ -25,8 +25,7 @@ public:
     //! Default Constructor
     PDSS_ConstVol();
 
-    //! @name Molar Thermodynamic Properties of the Species Standard State in
-    //!     the Solution
+    //! @name Molar Thermodynamic Properties of the Species Standard State
     //! @{
 
     // See PDSS.h for documentation of functions overridden from Class PDSS

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -27,7 +27,7 @@ public:
     //! Default Constructor
     PDSS_IdealGas();
 
-    //! @name Molar Thermodynamic Properties of the Species Standard State in the Solution
+    //! @name Molar Thermodynamic Properties of the Species Standard State
     //! @{
 
     // See PDSS.h for documentation of functions overridden from Class PDSS

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -38,7 +38,7 @@ public:
     //! Default constructor
     PDSS_IonsFromNeutral();
 
-    //! @name  Molar Thermodynamic Properties of the Species Standard State in the Solution
+    //! @name  Molar Thermodynamic Properties of the Species Standard State
     //! @{
 
     // See PDSS.h for documentation of functions overridden from Class PDSS

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -138,7 +138,7 @@ public:
     //! Default Constructor
     PDSS_SSVol();
 
-    //! @name  Molar Thermodynamic Properties of the Species Standard State in the Solution
+    //! @name  Molar Thermodynamic Properties of the Species Standard State
     //! @{
 
     // See PDSS.h for documentation of functions overridden from Class PDSS

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -52,7 +52,7 @@ public:
     //! Default constructor
     PDSS_Water();
 
-    //! @name  Molar Thermodynamic Properties of the Species Standard State in the Solution
+    //! @name  Molar Thermodynamic Properties of the Species Standard State
     //! @{
 
     // See PDSS.h for documentation of functions overridden from Class PDSS

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -145,12 +145,11 @@ public:
     virtual double speciesCritTemperature(double a, double b) const;
 
     //! @name Initialization Methods - For Internal use
-    /*!
-     * The following methods are used in the process of constructing
-     * the phase and setting its parameters from a specification in an
-     * input file. They are not normally used in application programs.
-     * To see how they are used, see importPhase().
-     */
+    //!
+    //! The following methods are used in the process of constructing
+    //! the phase and setting its parameters from a specification in an
+    //! input file. They are not normally used in application programs.
+    //! To see how they are used, see importPhase().
     //! @{
 
     virtual bool addSpecies(shared_ptr<Species> spec);

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -134,19 +134,19 @@ public:
      */
     void setXMLdata(XML_Node& xmlPhase);
 
-    /*! @name Name
-     * Class Phase uses the string name to identify a phase. The name is the
-     * value of the corresponding key in the phase map (in YAML), name (in
-     * CTI), or id (in XML) that is used to initialize a phase when it is read.
-     *
-     * However, the name field may be changed to another value during the
-     * course of a calculation. For example, if duplicates of a phase object
-     * are instantiated and used in multiple places (such as a ReactorNet), they
-     * will have the same constitutive input, that is, the names of the phases will
-     * be the same. Note that this is not a problem for Cantera internally;
-     * however, a user may want to rename phase objects in order to clarify.
-     */
-    //!@{
+    //! @name Name
+    //!
+    //! Class Phase uses the string name to identify a phase. The name is the
+    //! value of the corresponding key in the phase map (in YAML), name (in
+    //! CTI), or id (in XML) that is used to initialize a phase when it is read.
+    //!
+    //! However, the name field may be changed to another value during the
+    //! course of a calculation. For example, if duplicates of a phase object
+    //! are instantiated and used in multiple places (such as a ReactorNet), they
+    //! will have the same constitutive input, that is, the names of the phases will
+    //! be the same. Note that this is not a problem for Cantera internally;
+    //! however, a user may want to rename phase objects in order to clarify.
+    //! @{
 
     //! Return the name of the phase.
     /*!
@@ -165,10 +165,10 @@ public:
         return "Phase";
     }
 
-    //!@} end group Name
+    //! @} end group Name
 
     //! @name Element and Species Information
-    //!@{
+    //! @{
 
     //! Name of the element with index m.
     //!     @param m  Element index.
@@ -283,7 +283,7 @@ public:
     //! which take an array pointer.
     void checkSpeciesArraySize(size_t kk) const;
 
-    //!@} end group Element and Species Information
+    //! @} end group Element and Species Information
 
     //! Return whether phase represents a pure (single species) substance
     virtual bool isPure() const {
@@ -357,14 +357,14 @@ public:
     //!     @param state      Vector of state conditions.
     virtual void restoreState(size_t lenstate, const doublereal* state);
 
-    /*! @name Set thermodynamic state
-     * Set the internal thermodynamic state by setting the internally stored
-     * temperature, density and species composition. Note that the composition
-     * is always set first.
-     *
-     * Temperature and density are held constant if not explicitly set.
-     */
-    //!@{
+    //! @name Set Thermodynamic State
+    //!
+    //! Set the internal thermodynamic state by setting the internally stored
+    //! temperature, density and species composition. Note that the composition
+    //! is always set first.
+    //!
+    //! Temperature and density are held constant if not explicitly set.
+    //! @{
 
     //! Set the species mole fractions by name.
     //! Species not listed by name in \c xMap are set to zero.
@@ -446,7 +446,7 @@ public:
     //!     @param y    vector of species mass fractions, length m_kk
     void setState_RY(doublereal rho, doublereal* y);
 
-    //!@} end group set thermo state
+    //! @} end group set thermo state
 
     //! Molecular weight of species \c k.
     //!     @param k   index of species \c k
@@ -758,6 +758,7 @@ public:
 
     //! @}
     //! @name Adding Elements and Species
+    //!
     //! These methods are used to add new elements or species. These are not
     //! usually called by user programs.
     //!
@@ -846,7 +847,7 @@ public:
         error, ignore, add
     }; };
 
-    //!@} end group adding species and elements
+    //! @} end group adding species and elements
 
     //!  Returns a bool indicating whether the object is ready for use
     /*!

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -121,13 +121,12 @@ public:
     //! Returns a reference to the substance object
     tpx::Substance& TPX_Substance();
 
-    /// @name Properties of the Standard State of the Species in the Solution
-    /*!
-     *  The standard state of the pure fluid is defined as the real properties
-     *  of the pure fluid at the most stable state of the fluid at the current
-     *  temperature and pressure of the solution. With this definition, the
-     *  activity of the fluid is always then defined to be equal to one.
-     */
+    //! @name Properties of the Standard State of the Species in the Solution
+    //!
+    //! The standard state of the pure fluid is defined as the real properties
+    //! of the pure fluid at the most stable state of the fluid at the current
+    //! temperature and pressure of the solution. With this definition, the
+    //! activity of the fluid is always then defined to be equal to one.
     //! @{
 
     virtual void getStandardChemPotentials(doublereal* mu) const;
@@ -136,11 +135,10 @@ public:
     virtual void getGibbs_RT(doublereal* grt) const;
 
     //! @}
-    /// @name Thermodynamic Values for the Species Reference States
-    /*!
-     * The species reference state for pure fluids is defined as an ideal gas at
-     * the reference pressure and current temperature of the fluid.
-     */
+    //! @name Thermodynamic Values for the Species Reference States
+    //!
+    //! The species reference state for pure fluids is defined as an ideal gas at
+    //! the reference pressure and current temperature of the fluid.
     //! @{
 
     virtual void getEnthalpy_RT_ref(doublereal* hrt) const;
@@ -149,12 +147,10 @@ public:
     virtual void getEntropy_R_ref(doublereal* er) const;
 
     //! @}
-    /**
-     * @name Setting the State
-     *
-     * These methods set all or part of the thermodynamic state.
-     * @{
-     */
+    //! @name Setting the State
+    //!
+    //! These methods set all or part of the thermodynamic state.
+    //! @{
 
     virtual void setState_HP(double h, double p, double tol=1e-9);
     virtual void setState_UV(double u, double v, double tol=1e-9);

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -250,17 +250,15 @@ public:
     virtual doublereal cp_mole() const;
     virtual doublereal cv_mole() const;
 
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is
-     * related to the chemical potential by \f[ \mu_k = \mu_k^0(T)
-     * + \hat R T \log a_k. \f] The quantity \f$\mu_k^0(T,P)\f$ is
-     * the chemical potential at unit activity, which depends only
-     * on temperature and pressure.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is
+    //! related to the chemical potential by \f[ \mu_k = \mu_k^0(T)
+    //! + \hat R T \log a_k. \f] The quantity \f$\mu_k^0(T,P)\f$ is
+    //! the chemical potential at unit activity, which depends only
+    //! on temperature and pressure.
+    //! @{
 
     virtual void getLnActivityCoefficients(doublereal* lnac) const;
 
@@ -345,11 +343,12 @@ public:
 
     virtual void getdlnActCoeffdT(doublereal* dlnActCoeffdT) const;
 
-    /// @name Initialization
-    /// The following methods are used in the process of constructing
-    /// the phase and setting its parameters from a specification in an
-    /// input file. They are not normally used in application programs.
-    /// To see how they are used, see importPhase().
+    //! @name Initialization
+    //!
+    //! The following methods are used in the process of constructing
+    //! the phase and setting its parameters from a specification in an
+    //! input file. They are not normally used in application programs.
+    //! To see how they are used, see importPhase().
 
     virtual void initThermo();
     virtual void getParameters(AnyMap& phaseNode) const;

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -96,7 +96,7 @@ public:
      */
     virtual void getActivityCoefficients(doublereal* ac) const;
 
-    /// @name  Partial Molar Properties of the Solution
+    //! @name  Partial Molar Properties of the Solution
     //! @{
 
     //! Get the array of non-dimensional species chemical potentials.
@@ -125,12 +125,11 @@ public:
 
 public:
     //! @name Initialization Methods - For Internal use
-    /*!
-     * The following methods are used in the process of constructing
-     * the phase and setting its parameters from a specification in an
-     * input file. They are not normally used in application programs.
-     * To see how they are used, see importPhase().
-     */
+    //!
+    //! The following methods are used in the process of constructing
+    //! the phase and setting its parameters from a specification in an
+    //! input file. They are not normally used in application programs.
+    //! To see how they are used, see importPhase().
     //! @{
 
     virtual bool addSpecies(shared_ptr<Species> spec);

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -67,14 +67,12 @@ public:
         return true;
     }
 
-    /**
-     * @name  Molar Thermodynamic Properties of the Solution
-     *
-     * These functions are resolved at this level, by reference to the partial
-     * molar functions and standard state functions for species 0. Derived
-     * classes don't need to supply entries for these functions.
-     * @{
-     */
+    //! @name  Molar Thermodynamic Properties of the Solution
+    //!
+    //! These functions are resolved at this level, by reference to the partial
+    //! molar functions and standard state functions for species 0. Derived
+    //! classes don't need to supply entries for these functions.
+    //! @{
 
     virtual doublereal enthalpy_mole() const;
     virtual doublereal intEnergy_mole() const;
@@ -83,16 +81,14 @@ public:
     virtual doublereal cp_mole() const;
     virtual doublereal cv_mole() const;
 
-    /**
-     * @}
-     * @name Activities, Standard State, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f]
-     * The quantity \f$\mu_k^0(T)\f$ is the chemical potential at unit activity,
-     * which depends only on temperature.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard State, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f]
+    //! The quantity \f$\mu_k^0(T)\f$ is the chemical potential at unit activity,
+    //! which depends only on temperature.
+    //! @{
 
     /**
      * Get the array of non-dimensional activities at the current solution
@@ -111,11 +107,11 @@ public:
     }
 
     //! @}
-    /// @name  Partial Molar Properties of the Solution
-    ///
-    /// These functions are resolved at this level, by reference to the partial
-    /// molar functions and standard state functions for species 0. Derived
-    /// classes don't need to supply entries for these functions.
+    //! @name  Partial Molar Properties of the Solution
+    //!
+    //! These functions are resolved at this level, by reference to the partial
+    //! molar functions and standard state functions for species 0. Derived
+    //! classes don't need to supply entries for these functions.
     //! @{
 
     //! Get the array of non-dimensional species chemical potentials. These are
@@ -189,11 +185,12 @@ public:
     virtual void getPartialMolarVolumes(doublereal* vbar) const;
 
     //! @}
-    /// @name  Properties of the Standard State of the Species in the Solution
-    /// These functions are the primary way real properties are
-    /// supplied to derived thermodynamics classes of SingleSpeciesTP.
-    /// These functions must be supplied in derived classes. They
-    /// are not resolved at the SingleSpeciesTP level.
+    //! @name  Properties of the Standard State of the Species in the Solution
+    //!
+    //! These functions are the primary way real properties are
+    //! supplied to derived thermodynamics classes of SingleSpeciesTP.
+    //! These functions must be supplied in derived classes. They
+    //! are not resolved at the SingleSpeciesTP level.
     //! @{
 
     virtual void getPureGibbs(doublereal* gpure) const;
@@ -212,11 +209,11 @@ public:
     virtual void getStandardVolumes(doublereal* vbar) const;
 
     //! @}
-    /// @name Thermodynamic Values for the Species Reference State
-    ///
-    /// Almost all functions in this group are resolved by this class. The
-    /// internal energy function is not given by this class, since it would
-    /// involve a specification of the equation of state.
+    //! @name Thermodynamic Values for the Species Reference State
+    //!
+    //! Almost all functions in this group are resolved by this class. The
+    //! internal energy function is not given by this class, since it would
+    //! involve a specification of the equation of state.
     //! @{
 
     virtual void getEnthalpy_RT_ref(doublereal* hrt) const;
@@ -226,12 +223,10 @@ public:
     virtual void getCp_R_ref(doublereal* cprt) const;
 
     //! @}
-    /**
-     * @name Setting the State
-     *
-     * These methods set all or part of the thermodynamic state.
-     * @{
-     */
+    //! @name Setting the State
+    //!
+    //! These methods set all or part of the thermodynamic state.
+    //! @{
 
     //! Mass fractions are fixed, with Y[0] = 1.0.
     virtual void setMassFractions(const doublereal* const y) {};

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -204,14 +204,12 @@ public:
     virtual doublereal isothermalCompressibility() const;
     virtual doublereal thermalExpansionCoeff() const;
 
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     *  This section is largely handled by parent classes, since there
-     *  is only one species. Therefore, the activity is equal to one.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! This section is largely handled by parent classes, since there
+    //! is only one species. Therefore, the activity is equal to one.
+    //! @{
 
     virtual Units standardConcentrationUnits() const;
 

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -295,13 +295,11 @@ public:
         throw NotImplementedError("ThermoPhase::thermalExpansionCoeff");
     }
 
-    /**
-     * @}
-     * @name Electric Potential
-     *
-     * The phase may be at some non-zero electrical potential. These methods
-     * set or get the value of the electric potential.
-     */
+    //! @}
+    //! @name Electric Potential
+    //!
+    //! The phase may be at some non-zero electrical potential. These methods
+    //! set or get the value of the electric potential.
     //! @{
 
     //! Set the electric potential of this phase (V).
@@ -327,17 +325,15 @@ public:
         return m_phi;
     }
 
-    /**
-     * @}
-     * @name Activities, Standard States, and Activity Concentrations
-     *
-     * The activity \f$a_k\f$ of a species in solution is related to the
-     * chemical potential by \f[ \mu_k = \mu_k^0(T,P) + \hat R T \log a_k. \f]
-     * The quantity \f$\mu_k^0(T,P)\f$ is the standard chemical potential at
-     * unit activity, which depends on temperature and pressure, but not on
-     * composition. The activity is dimensionless.
-     * @{
-     */
+    //! @}
+    //! @name Activities, Standard States, and Activity Concentrations
+    //!
+    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! chemical potential by \f[ \mu_k = \mu_k^0(T,P) + \hat R T \log a_k. \f]
+    //! The quantity \f$\mu_k^0(T,P)\f$ is the standard chemical potential at
+    //! unit activity, which depends on temperature and pressure, but not on
+    //! composition. The activity is dimensionless.
+    //! @{
 
     //! This method returns the convention used in specification of the
     //! activities, of which there are currently two, molar- and molality-based
@@ -783,12 +779,10 @@ public:
         return temperature() * GasConstant;
     }
 
-    /**
-     * @name Setting the State
-     *
-     * These methods set all or part of the thermodynamic state.
-     * @{
-     */
+    //! @name Setting the State
+    //!
+    //! These methods set all or part of the thermodynamic state.
+    //! @{
 
     //! Set the temperature (K), pressure (Pa), and mole fractions.
     /*!
@@ -1410,11 +1404,10 @@ private:
     double o2Present(const double* y) const;
 
 public:
-    /**
-     * @name Chemical Equilibrium
-     * Chemical equilibrium.
-     * @{
-     */
+    //! @name Chemical Equilibrium
+    //!
+    //! Chemical equilibrium.
+    //! @{
 
     //! Equilibrate a ThermoPhase object
     /*!
@@ -1475,9 +1468,10 @@ public:
     }
 
     //! @}
-    /// @name Critical State Properties.
-    /// These methods are only implemented by subclasses that implement
-    /// liquid-vapor equations of state.
+    //! @name Critical State Properties
+    //!
+    //! These methods are only implemented by subclasses that implement
+    //! liquid-vapor equations of state.
     //! @{
 
     /// Critical temperature (K).
@@ -1506,12 +1500,10 @@ public:
     }
 
     //! @}
-
-    /** @name Saturation Properties.
-     *
-     *  These methods are only implemented by subclasses that implement full
-     *  liquid-vapor equations of state.
-     */
+    //! @name Saturation Properties
+    //!
+    //! These methods are only implemented by subclasses that implement full
+    //! liquid-vapor equations of state.
     //! @{
 
     //! Return the saturation temperature given the pressure
@@ -1572,14 +1564,12 @@ public:
     void setState_TPQ(double T, double P, double Q);
 
     //! @}
-
     //! @name Initialization Methods - For Internal Use (ThermoPhase)
-    /*!
-     * The following methods are used in the process of constructing
-     * the phase and setting its parameters from a specification in an
-     * input file. They are not normally used in application programs.
-     * To see how they are used, see importPhase().
-     */
+    //!
+    //! The following methods are used in the process of constructing
+    //! the phase and setting its parameters from a specification in an
+    //! input file. They are not normally used in application programs.
+    //! To see how they are used, see importPhase().
     //! @{
 
     virtual bool addSpecies(shared_ptr<Species> spec);

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -19,20 +19,18 @@
 namespace Cantera
 {
 
-/*!
- * @name CONSTANTS - Specification of the Molality convention
- */
+//! @name CONSTANTS - Specification of the Molality convention
 //! @{
+
 //! Standard state uses the molar convention
 const int cAC_CONVENTION_MOLAR = 0;
 //! Standard state uses the molality convention
 const int cAC_CONVENTION_MOLALITY = 1;
-//! @}
 
-/*!
- * @name CONSTANTS - Specification of the SS convention
- */
+//! @}
+//! @name CONSTANTS - Specification of the SS convention
 //! @{
+
 //! Standard state uses the molar convention
 const int cSS_CONVENTION_TEMPERATURE = 0;
 //! Standard state uses the molality convention

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -80,14 +80,12 @@ public:
     virtual void getChemPotentials_RT(doublereal* mu) const;
 
     //! @}
-    /*!
-     * @name  Properties of the Standard State of the Species in the Solution
-     *
-     *  Within VPStandardStateTP, these properties are calculated via a common
-     *  routine, _updateStandardStateThermo(), which must be overloaded in
-     *  inherited objects. The values are cached within this object, and are not
-     *  recalculated unless the temperature or pressure changes.
-     */
+    //! @name  Properties of the Standard State of the Species in the Solution
+    //!
+    //! Within VPStandardStateTP, these properties are calculated via a common
+    //! routine, _updateStandardStateThermo(), which must be overloaded in
+    //! inherited objects. The values are cached within this object, and are not
+    //! recalculated unless the temperature or pressure changes.
     //! @{
 
     virtual void getStandardChemPotentials(doublereal* mu) const;
@@ -214,14 +212,13 @@ protected:
     virtual void _updateStandardStateThermo() const;
 
 public:
-    /// @name Thermodynamic Values for the Species Reference States
-    /*!
-     * There are also temporary variables for holding the species reference-
-     * state values of Cp, H, S, and V at the last temperature and reference
-     * pressure called. These functions are not recalculated if a new call is
-     * made using the previous temperature. All calculations are done within the
-     * routine _updateRefStateThermo().
-     */
+    //! @name Thermodynamic Values for the Species Reference States
+    //!
+    //! There are also temporary variables for holding the species reference-
+    //! state values of Cp, H, S, and V at the last temperature and reference
+    //! pressure called. These functions are not recalculated if a new call is
+    //! made using the previous temperature. All calculations are done within the
+    //! routine _updateRefStateThermo().
     //! @{
 
     virtual void getEnthalpy_RT_ref(doublereal* hrt) const;
@@ -235,15 +232,14 @@ public:
     virtual void getEntropy_R_ref(doublereal* er) const;
     virtual void getCp_R_ref(doublereal* cprt) const;
     virtual void getStandardVolumes_ref(doublereal* vol) const;
-    //! @}
 
+    //! @}
     //! @name Initialization Methods - For Internal use
-    /*!
-     * The following methods are used in the process of constructing
-     * the phase and setting its parameters from a specification in an
-     * input file. They are not normally used in application programs.
-     * To see how they are used, see importPhase().
-     */
+    //!
+    //! The following methods are used in the process of constructing
+    //! the phase and setting its parameters from a specification in an
+    //! input file. They are not normally used in application programs.
+    //! To see how they are used, see importPhase().
     //! @{
 
     virtual void initThermo();

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -15,19 +15,18 @@
 
 namespace Cantera
 {
-/**
- * @name Names for the phase regions
- *
- * These constants are defined and used in the interface to describe the
- * location of where we are in (T,rho) space.
- *
- * WATER_UNSTABLELIQUID indicates that we are in the unstable region, inside the
- * spinodal curve where dpdrho < 0.0 amongst other properties. The difference
- * between WATER_UNSTABLELIQUID and WATER_UNSTABLEGAS is that
- *     for WATER_UNSTABLELIQUID  d2pdrho2 > 0   and dpdrho < 0.0
- *     for WATER_UNSTABLEGAS     d2pdrho2 < 0   and dpdrho < 0.0
- */
+//! @name Names for the phase regions
+//!
+//! These constants are defined and used in the interface to describe the
+//! location of where we are in (T,rho) space.
+//!
+//! WATER_UNSTABLELIQUID indicates that we are in the unstable region, inside the
+//! spinodal curve where dpdrho < 0.0 amongst other properties. The difference
+//! between WATER_UNSTABLELIQUID and WATER_UNSTABLEGAS is that
+//!     for WATER_UNSTABLELIQUID  d2pdrho2 > 0   and dpdrho < 0.0
+//!     for WATER_UNSTABLEGAS     d2pdrho2 < 0   and dpdrho < 0.0
 //@{
+
 #define WATER_GAS 0
 #define WATER_LIQUID 1
 #define WATER_SUPERCRIT 2

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -146,11 +146,10 @@ public:
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference State
-    /*!
-     *  All functions in this group need to be overridden, because the
-     *  m_spthermo MultiSpeciesThermo function is not adequate for the real
-     *  equation of state.
-     */
+    //!
+    //! All functions in this group need to be overridden, because the
+    //! m_spthermo MultiSpeciesThermo function is not adequate for the real
+    //! equation of state.
     //! @{
 
     virtual void getEnthalpy_RT_ref(doublereal* hrt) const;

--- a/include/cantera/transport/TransportBase.h
+++ b/include/cantera/transport/TransportBase.h
@@ -196,9 +196,7 @@ public:
     //! pointer.
     void checkSpeciesArraySize(size_t kk) const;
 
-    /**
-     * @name Transport Properties
-     */
+    //! @name Transport Properties
     //! @{
 
     /*!
@@ -576,7 +574,7 @@ public:
      * @param[in] ld  The dimension of the inner loop of d (usually equal to m_nsp)
      * @param[out] d  flat vector of diffusion coefficients, fortran ordering.
      *            d[ld*j+i] is the D_ij diffusion coefficient (the diffusion
-     *            coefficient for species i due to concentration gradients in 
+     *            coefficient for species i due to concentration gradients in
      *            species j). Units: m^2/s
      */
     virtual void getMultiDiffCoeffs(const size_t ld, doublereal* const d) {
@@ -715,11 +713,10 @@ public:
         return m_velocityBasis;
     }
 
-    /**
-     * @name Transport manager construction
-     * These methods are used during construction.
-     * @{
-     */
+    //! @name Transport manager construction
+    //!
+    //! These methods are used during construction.
+    //! @{
 
     //! Initialize a transport manager
     /*!

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -78,7 +78,7 @@ public:
         m_name = name;
     }
 
-    //! @name Methods to set up a simulation.
+    //! @name Methods to set up a simulation
     //! @{
 
     //! Set the initial reactor volume. By default, the volume is 1.0 m^3.
@@ -192,11 +192,10 @@ public:
     //! on the outlet mass flow rates and the mass of the reactor contents.
     doublereal residenceTime();
 
-    /**
-     * @name Solution components.
-     * The values returned are those after the last call to ReactorNet::advance
-     * or ReactorNet::step.
-     */
+    //! @name Solution components
+    //!
+    //! The values returned are those after the last call to ReactorNet::advance
+    //! or ReactorNet::step.
     //! @{
 
     //! Returns the current volume (m^3) of the reactor.

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -31,7 +31,7 @@ public:
     ReactorNet(const ReactorNet&) = delete;
     ReactorNet& operator=(const ReactorNet&) = delete;
 
-    //! @name Methods to set up a simulation.
+    //! @name Methods to set up a simulation
     //! @{
 
     //! Set initial time. Default = 0.0 s. Restarts integration from this time


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Update formatting of doxygen member groupings
- Update formatting of doxygen module groupings

Per [#1275](https://github.com/Cantera/cantera/issues/1275#issuecomment-1118962304), there are two working  formatting variants of member grouping commonly found (while others don't work and don't produce the expected output). This PR consistently applies the following
```C++
\\! @name GroupName
\\! description of the grouping
\\! @{
[...]
\\! @}
```

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1275

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
