### PR TITLE
Eliminate infrequently used doxygen commenting style

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -66,7 +66,9 @@
 ## C++
 
 * All classes, member variables, and methods should have Doxygen-style comments
-  (for example, comment lines starting with `//!` or comment blocks starting with `/*!`)
+  (for example, comment lines starting with `//!` or comment blocks starting with
+  `/*!`; do not use `///` or `/**` in new code)
+* Doxygen-style groupings should bracket code using `//! @{` and `//! @}`
 * Avoid defining non-trivial functions in header files
 * Header files should include an 'include guard'
 * Protected and private member variable names are generally prefixed with

--- a/include/cantera/base/Array.h
+++ b/include/cantera/base/Array.h
@@ -184,42 +184,42 @@ public:
         return m_data[m_nrows*j + i];
     }
 
-    /// Number of rows
+    //! Number of rows
     size_t nRows() const {
         return m_nrows;
     }
 
-    /// Number of columns
+    //! Number of columns
     size_t nColumns() const {
         return m_ncols;
     }
 
-    /// Return an iterator pointing to the first element
+    //! Return an iterator pointing to the first element
     iterator begin() {
         return m_data.begin();
     }
 
-    /// Return an iterator pointing past the last element
+    //! Return an iterator pointing past the last element
     iterator end() {
         return m_data.end();
     }
 
-    /// Return a const iterator pointing to the first element
+    //! Return a const iterator pointing to the first element
     const_iterator begin() const {
         return m_data.begin();
     }
 
-    /// Return a const iterator pointing to past the last element
+    //! Return a const iterator pointing to past the last element
     const_iterator end() const {
         return m_data.end();
     }
 
-    /// Return a reference to the data vector
+    //! Return a reference to the data vector
     vector_fp& data() {
         return m_data;
     }
 
-    /// Return a const reference to the data vector
+    //! Return a const reference to the data vector
     const vector_fp& data() const {
         return m_data;
     }

--- a/include/cantera/base/NoExitLogger.h
+++ b/include/cantera/base/NoExitLogger.h
@@ -10,8 +10,8 @@
 #include "cantera/base/logger.h"
 
 namespace Cantera {
-/// Logger that doesn't exit when an error is thrown.
-/// @ingroup textlogs
+//! Logger that doesn't exit when an error is thrown.
+//! @ingroup textlogs
 class NoExitLogger : public Logger {
 public:
     NoExitLogger() {}

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -73,7 +73,7 @@ const double Planck = 6.62607015e-34;
 //! Elementary charge \f$ e \f$ [C]
 const double ElectronCharge = 1.602176634e-19;
 
-/// Speed of Light in a vacuum \f$ c \f$ [m/s]
+//! Speed of Light in a vacuum \f$ c \f$ [m/s]
 const double lightSpeed = 299792458.0;
 
 //! One atmosphere [Pa]

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -286,8 +286,8 @@ void setLogger(Logger* logwriter);
  */
 doublereal toSI(const std::string& unit);
 
-/// Return the conversion factor to convert activation energy unit
-/// std::string 'unit' to Kelvin.
+//! Return the conversion factor to convert activation energy unit
+//! std::string 'unit' to Kelvin.
 /*!
  * @param unit  String containing the activation energy units
  * @deprecated To be removed after Cantera 2.6. Used only with XML input.

--- a/include/cantera/base/logger.h
+++ b/include/cantera/base/logger.h
@@ -17,26 +17,26 @@
 namespace Cantera
 {
 
-/// Base class for 'loggers' that write text messages to log files.
-///
-/// This class is used to direct log messages to application- or environment-
-/// specific output. The default is to simply print the messages to the standard
-/// output stream or standard error stream, but classes may be derived from
-/// Logger that implement other output options. This is important when Cantera
-/// is used in applications that do not display the standard output, such as
-/// MATLAB. The Cantera MATLAB interface derives a class from Logger that
-/// implements these methods with MATLAB-specific procedures, insuring that the
-/// messages will be passed through to the user. It would also be possible to
-/// derive a class that displayed the messages in a pop-up window, or redirected
-/// them to a file, etc.
-///
-/// To install a logger, call function setLogger (global.h / misc.cpp).
-///
-/// See the files Cantera/python/src/pylogger.h and
-/// Cantera/matlab/cantera/private/mllogger.h for examples of
-/// deriving logger classes.
-/// @ingroup textlogs
-///
+//! Base class for 'loggers' that write text messages to log files.
+//!
+//! This class is used to direct log messages to application- or environment-
+//! specific output. The default is to simply print the messages to the standard
+//! output stream or standard error stream, but classes may be derived from
+//! Logger that implement other output options. This is important when Cantera
+//! is used in applications that do not display the standard output, such as
+//! MATLAB. The Cantera MATLAB interface derives a class from Logger that
+//! implements these methods with MATLAB-specific procedures, insuring that the
+//! messages will be passed through to the user. It would also be possible to
+//! derive a class that displayed the messages in a pop-up window, or redirected
+//! them to a file, etc.
+//!
+//! To install a logger, call function setLogger (global.h / misc.cpp).
+//!
+//! See the files Cantera/python/src/pylogger.h and
+//! Cantera/matlab/cantera/private/mllogger.h for examples of
+//! deriving logger classes.
+//! @ingroup textlogs
+//!
 class Logger
 {
 public:

--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -16,7 +16,7 @@ namespace Cantera
 
 class DenseMatrix;
 class ThermoPhase;
-/// map property strings to integers
+//! map property strings to integers
 int _equilflag(const char* xy);
 
 /**
@@ -29,10 +29,10 @@ public:
         iterations(0),
         maxStepSize(10.0), propertyPair(TP), contin(false) {}
 
-    doublereal relTolerance; ///< Relative tolerance
-    doublereal absElemTol; ///< Abs Tol in element number
-    int maxIterations; ///< Maximum number of iterations
-    int iterations; ///< Iteration counter
+    doublereal relTolerance; //! < Relative tolerance
+    doublereal absElemTol; //! < Abs Tol in element number
+    int maxIterations; //! < Maximum number of iterations
+    int iterations; //! < Iteration counter
 
     /**
      * Maximum step size. Largest change in any element potential or

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -151,7 +151,7 @@ public:
      */
     doublereal nAtoms(const size_t kGlob, const size_t mGlob) const;
 
-    /// Returns the global Species mole fractions.
+    //! Returns the global Species mole fractions.
     /*!
      *   Write the array of species mole
      *   fractions into array \c x. The mole fractions are
@@ -195,7 +195,7 @@ public:
      */
     void setPhaseMoles(const size_t n, const doublereal moles);
 
-    /// Return a reference to phase n.
+    //! Return a reference to phase n.
     /*!
      *  The state of phase n is also updated to match the state stored locally
      *  in the mixture object.
@@ -243,16 +243,16 @@ public:
      */
     size_t speciesIndex(const std::string& speciesName, const std::string& phaseName);
 
-    /// Minimum temperature for which all solution phases have valid thermo
-    /// data. Stoichiometric phases are not considered, since they may have
-    /// thermo data only valid for conditions for which they are stable.
+    //! Minimum temperature for which all solution phases have valid thermo
+    //! data. Stoichiometric phases are not considered, since they may have
+    //! thermo data only valid for conditions for which they are stable.
     doublereal minTemp() const {
         return m_Tmin;
     }
 
-    /// Maximum temperature for which all solution phases have valid thermo
-    /// data. Stoichiometric phases are not considered, since they may have
-    /// thermo data only valid for conditions for which they are stable.
+    //! Maximum temperature for which all solution phases have valid thermo
+    //! data. Stoichiometric phases are not considered, since they may have
+    //! thermo data only valid for conditions for which they are stable.
     doublereal maxTemp() const {
         return m_Tmax;
     }
@@ -260,7 +260,7 @@ public:
     //! Total charge summed over all phases (Coulombs).
     doublereal charge() const;
 
-    /// Charge (Coulombs) of phase with index \a p.
+    //! Charge (Coulombs) of phase with index \a p.
     /*!
      *  The net charge is computed as \f[ Q_p = N_p \sum_k F z_k X_k \f]
      *  where the sum runs only over species in phase \a p.
@@ -288,7 +288,7 @@ public:
      */
     void getChemPotentials(doublereal* mu) const;
 
-    /// Returns a vector of Valid chemical potentials.
+    //! Returns a vector of Valid chemical potentials.
     /*!
      * Write into array \a mu the chemical potentials of all species with
      * thermo data valid for the current temperature [J/kmol]. For other
@@ -365,7 +365,7 @@ public:
                      double rtol=1e-9, int max_steps=50000, int max_iter=100,
                      int estimate_equil=0, int log_level=0);
 
-    /// Set the temperature [K].
+    //! Set the temperature [K].
     /*!
      * @param T   value of the temperature (Kelvin)
      */
@@ -387,12 +387,12 @@ public:
      */
     void setState_TPMoles(const doublereal T, const doublereal Pres, const doublereal* Moles);
 
-    /// Pressure [Pa].
+    //! Pressure [Pa].
     doublereal pressure() const {
         return m_press;
     }
 
-    /// The total mixture volume [m^3].
+    //! The total mixture volume [m^3].
     /*!
      * Returns the cumulative sum of the volumes of all the phases in the
      * mixture.

--- a/include/cantera/kinetics/Group.h
+++ b/include/cantera/kinetics/Group.h
@@ -109,7 +109,7 @@ public:
         return m_comp.size();
     }
 
-    /// Number of atoms in the group (>= 0)
+    //! Number of atoms in the group (>= 0)
     int nAtoms() const {
         int sum = 0;
         for (size_t m = 0; m < m_comp.size(); m++) {
@@ -117,7 +117,7 @@ public:
         }
         return sum;
     }
-    /// Number of atoms of element m (positive or negative)
+    //! Number of atoms of element m (positive or negative)
     int nAtoms(size_t m) const {
         if (m_comp.empty()) {
             return 0;

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -26,72 +26,72 @@ class AnyMap;
  * @defgroup chemkinetics Chemical Kinetics
  */
 
-/// @defgroup kineticsmgr Kinetics Managers
-/// @section kinmodman Models and Managers
-///
-/// A kinetics manager is a C++ class that implements a kinetics model; a
-/// kinetics model is a set of mathematical equation describing how various
-/// kinetic quantities are to be computed -- reaction rates, species production
-/// rates, etc. Many different kinetics models might be defined to handle
-/// different types of kinetic processes. For example, one kinetics model might
-/// use expressions valid for elementary reactions in ideal gas mixtures. It
-/// might, for example, require the reaction orders to be integral and equal to
-/// the forward stoichiometric coefficients, require that each reaction be
-/// reversible with a reverse rate satisfying detailed balance, include
-/// pressure-dependent unimolecular reactions, etc. Another kinetics model might
-/// be designed for heterogeneous chemistry at interfaces, and might allow
-/// empirical reaction orders, coverage-dependent activation energies,
-/// irreversible reactions, and include effects of potential differences across
-/// the interface on reaction rates.
-///
-/// A kinetics manager implements a kinetics model. Since the model equations
-/// may be complex and expensive to evaluate, a kinetics manager may adopt
-/// various strategies to 'manage' the computation and evaluate the expressions
-/// efficiently. For example, if there are rate coefficients or other quantities
-/// that depend only on temperature, a manager class may choose to store these
-/// quantities internally, and re-evaluate them only when the temperature has
-/// actually changed. Or a manager designed for use with reaction mechanisms
-/// with a few repeated activation energies might precompute the terms \f$
-/// exp(-E/RT) \f$, instead of evaluating the exponential repeatedly for each
-/// reaction. There are many other possible 'management styles', each of which
-/// might be better suited to some reaction mechanisms than others.
-///
-/// But however a manager structures the internal computation, the tasks the
-/// manager class must perform are, for the most part, the same. It must be able
-/// to compute reaction rates, species production rates, equilibrium constants,
-/// etc. Therefore, all kinetics manager classes should have a common set of
-/// public methods, but differ in how they implement these methods.
-///
-/// A kinetics manager computes reaction rates of progress, species production
-/// rates, equilibrium constants, and similar quantities for a reaction
-/// mechanism. All kinetics manager classes derive from class Kinetics, which
-/// defines a common public interface for all kinetics managers. Each derived
-/// class overloads the virtual methods of Kinetics to implement a particular
-/// kinetics model.
-///
-/// For example, class GasKinetics implements reaction rate expressions
-/// appropriate for homogeneous reactions in ideal gas mixtures, and class
-/// InterfaceKinetics implements expressions appropriate for heterogeneous
-/// mechanisms at interfaces, including how to handle reactions involving
-/// charged species of phases with different electric potentials --- something
-/// that class GasKinetics doesn't deal with at all.
-///
-/// Many of the methods of class Kinetics write into arrays the values of some
-/// quantity for each species, for example the net production rate. These
-/// methods always write the results into flat arrays, ordered by phase in the
-/// order the phase was added, and within a phase in the order the species were
-/// added to the phase (which is the same ordering as in the input file).
-/// Example: suppose a heterogeneous mechanism involves three phases -- a bulk
-/// phase 'a', another bulk phase 'b', and the surface phase 'a:b' at the a/b
-/// interface. Phase 'a' contains 12 species, phase 'b' contains 3, and at the
-/// interface there are 5 adsorbed species defined in phase 'a:b'. Then methods
-/// like getNetProductionRates(doublereal* net) will write and output array of
-/// length 20, beginning at the location pointed to by 'net'. The first 12
-/// values will be the net production rates for all 12 species of phase 'a'
-/// (even if some do not participate in the reactions), the next 3 will be for
-/// phase 'b', and finally the net production rates for the surface species will
-/// occupy the last 5 locations.
-/// @ingroup chemkinetics
+//! @defgroup kineticsmgr Kinetics Managers
+//! @section kinmodman Models and Managers
+//!
+//! A kinetics manager is a C++ class that implements a kinetics model; a
+//! kinetics model is a set of mathematical equation describing how various
+//! kinetic quantities are to be computed -- reaction rates, species production
+//! rates, etc. Many different kinetics models might be defined to handle
+//! different types of kinetic processes. For example, one kinetics model might
+//! use expressions valid for elementary reactions in ideal gas mixtures. It
+//! might, for example, require the reaction orders to be integral and equal to
+//! the forward stoichiometric coefficients, require that each reaction be
+//! reversible with a reverse rate satisfying detailed balance, include
+//! pressure-dependent unimolecular reactions, etc. Another kinetics model might
+//! be designed for heterogeneous chemistry at interfaces, and might allow
+//! empirical reaction orders, coverage-dependent activation energies,
+//! irreversible reactions, and include effects of potential differences across
+//! the interface on reaction rates.
+//!
+//! A kinetics manager implements a kinetics model. Since the model equations
+//! may be complex and expensive to evaluate, a kinetics manager may adopt
+//! various strategies to 'manage' the computation and evaluate the expressions
+//! efficiently. For example, if there are rate coefficients or other quantities
+//! that depend only on temperature, a manager class may choose to store these
+//! quantities internally, and re-evaluate them only when the temperature has
+//! actually changed. Or a manager designed for use with reaction mechanisms
+//! with a few repeated activation energies might precompute the terms \f$
+//! exp(-E/RT) \f$, instead of evaluating the exponential repeatedly for each
+//! reaction. There are many other possible 'management styles', each of which
+//! might be better suited to some reaction mechanisms than others.
+//!
+//! But however a manager structures the internal computation, the tasks the
+//! manager class must perform are, for the most part, the same. It must be able
+//! to compute reaction rates, species production rates, equilibrium constants,
+//! etc. Therefore, all kinetics manager classes should have a common set of
+//! public methods, but differ in how they implement these methods.
+//!
+//! A kinetics manager computes reaction rates of progress, species production
+//! rates, equilibrium constants, and similar quantities for a reaction
+//! mechanism. All kinetics manager classes derive from class Kinetics, which
+//! defines a common public interface for all kinetics managers. Each derived
+//! class overloads the virtual methods of Kinetics to implement a particular
+//! kinetics model.
+//!
+//! For example, class GasKinetics implements reaction rate expressions
+//! appropriate for homogeneous reactions in ideal gas mixtures, and class
+//! InterfaceKinetics implements expressions appropriate for heterogeneous
+//! mechanisms at interfaces, including how to handle reactions involving
+//! charged species of phases with different electric potentials --- something
+//! that class GasKinetics doesn't deal with at all.
+//!
+//! Many of the methods of class Kinetics write into arrays the values of some
+//! quantity for each species, for example the net production rate. These
+//! methods always write the results into flat arrays, ordered by phase in the
+//! order the phase was added, and within a phase in the order the species were
+//! added to the phase (which is the same ordering as in the input file).
+//! Example: suppose a heterogeneous mechanism involves three phases -- a bulk
+//! phase 'a', another bulk phase 'b', and the surface phase 'a:b' at the a/b
+//! interface. Phase 'a' contains 12 species, phase 'b' contains 3, and at the
+//! interface there are 5 adsorbed species defined in phase 'a:b'. Then methods
+//! like getNetProductionRates(doublereal* net) will write and output array of
+//! length 20, beginning at the location pointed to by 'net'. The first 12
+//! values will be the net production rates for all 12 species of phase 'a'
+//! (even if some do not participate in the reactions), the next 3 will be for
+//! phase 'b', and finally the net production rates for the surface species will
+//! occupy the last 5 locations.
+//! @ingroup chemkinetics
 
 
 //! Public interface for kinetics managers.
@@ -116,7 +116,7 @@ public:
     //! @name Constructors and General Information about Mechanism
     //! @{
 
-    /// Default constructor.
+    //! Default constructor.
     Kinetics();
 
     virtual ~Kinetics();
@@ -1313,8 +1313,8 @@ protected:
     //! that participate in this kinetics mechanism.
     size_t m_kk;
 
-    /// Vector of perturbation factors for each reaction's rate of
-    /// progress vector. It is initialized to one.
+    //! Vector of perturbation factors for each reaction's rate of
+    //! progress vector. It is initialized to one.
     vector_fp m_perturb;
 
     //! Vector of Reaction objects represented by this Kinetics manager

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -26,18 +26,18 @@ class Path;
 class SpeciesNode
 {
 public:
-    /// Default constructor
+    //! Default constructor
     SpeciesNode() : number(npos), value(0.0),
         visible(false), m_in(0.0), m_out(0.0) {}
 
-    /// Destructor
+    //! Destructor
     virtual ~SpeciesNode() {}
 
     // public attributes
-    size_t number; ///< Species number
-    std::string name; ///< Label on graph
-    doublereal value; ///< May be used to set node appearance
-    bool visible; ///< Visible on graph;
+    size_t number; //! < Species number
+    std::string name; //! < Label on graph
+    doublereal value; //! < May be used to set node appearance
+    bool visible; //! < Visible on graph;
 
     //! @name References
     //!
@@ -52,12 +52,12 @@ public:
     }
     //! @}
 
-    /// Total number of paths to or from this node
+    //! Total number of paths to or from this node
     int nPaths() const {
         return static_cast<int>(m_paths.size());
     }
 
-    /// add a path to or from this node
+    //! add a path to or from this node
     void addPath(Path* path);
 
     doublereal outflow() {
@@ -89,7 +89,7 @@ public:
      */
     Path(SpeciesNode* begin, SpeciesNode* end);
 
-    /// Destructor
+    //! Destructor
     virtual ~Path() {}
 
     /**
@@ -99,7 +99,7 @@ public:
     void addReaction(size_t rxnNumber, doublereal value,
                      const std::string& label = "");
 
-    /// Upstream node.
+    //! Upstream node.
     const SpeciesNode* begin() const {
         return m_a;
     }
@@ -107,7 +107,7 @@ public:
         return m_a;
     }
 
-    /// Downstream node.
+    //! Downstream node.
     const SpeciesNode* end() const {
         return m_b;
     }
@@ -123,7 +123,7 @@ public:
         return (n == m_a ? m_b : (n == m_b ? m_a : 0));
     }
 
-    /// The total flow in this path
+    //! The total flow in this path
     doublereal flow() {
         return m_total;
     }
@@ -131,12 +131,12 @@ public:
         m_total = v;
     }
 
-    ///  Number of reactions contributing to this path
+    //!  Number of reactions contributing to this path
     int nReactions() {
         return static_cast<int>(m_rxn.size());
     }
 
-    ///  Map from reaction number to flow from that reaction in this path.
+    //!  Map from reaction number to flow from that reaction in this path.
     const rxn_path_map& reactionMap() {
         return m_rxn;
     }
@@ -168,22 +168,22 @@ public:
      */
     virtual ~ReactionPathDiagram();
 
-    /// The largest one-way flow value in any path
+    //! The largest one-way flow value in any path
     doublereal maxFlow() {
         return m_flxmax;
     }
 
-    /// The net flow from node \c k1 to node \c k2
+    //! The net flow from node \c k1 to node \c k2
     doublereal netFlow(size_t k1, size_t k2) {
         return flow(k1, k2) - flow(k2, k1);
     }
 
-    /// The one-way flow from node \c k1 to node \c k2
+    //! The one-way flow from node \c k1 to node \c k2
     doublereal flow(size_t k1, size_t k2) {
         return (m_paths[k1][k2] ? m_paths[k1][k2]->flow() : 0.0);
     }
 
-    /// True if a node for species k exists
+    //! True if a node for species k exists
     bool hasNode(size_t k) {
         return (m_nodes[k] != 0);
     }

--- a/include/cantera/kinetics/RxnRates.h
+++ b/include/cantera/kinetics/RxnRates.h
@@ -44,15 +44,15 @@ public:
     //! Default constructor.
     Arrhenius2();
 
-    /// Constructor.
-    /// @param A pre-exponential. The unit system is
-    ///     (kmol, m, s). The actual units depend on the reaction
-    ///     order and the dimensionality (surface or bulk).
-    /// @param b Temperature exponent. Non-dimensional.
-    /// @param E Activation energy in temperature units. Kelvin.
-    ///
-    /// @todo  Add deprecation warning pointing out change of activation
-    ///     energy units.
+    //! Constructor.
+    //! @param A pre-exponential. The unit system is
+    //!     (kmol, m, s). The actual units depend on the reaction
+    //!     order and the dimensionality (surface or bulk).
+    //! @param b Temperature exponent. Non-dimensional.
+    //! @param E Activation energy in temperature units. Kelvin.
+    //!
+    //! @todo  Add deprecation warning pointing out change of activation
+    //!     energy units.
     Arrhenius2(doublereal A, doublereal b, doublereal E);
 
     //! Constructor based on AnyMap content

--- a/include/cantera/kinetics/reaction_defs.h
+++ b/include/cantera/kinetics/reaction_defs.h
@@ -19,7 +19,7 @@ namespace Cantera
 const int INVALID_RXN = 0;
 const int NONE = 0;
 
-/// @name Reaction Types
+//! @name Reaction Types
 
 //! @{
 

--- a/include/cantera/numerics/DAE_Solver.h
+++ b/include/cantera/numerics/DAE_Solver.h
@@ -194,7 +194,7 @@ public:
         return 0;
     }
 
-    /// Number of equations.
+    //! Number of equations.
     int nEquations() const {
         return m_resid.nEquations();
     }
@@ -219,7 +219,7 @@ public:
         return 0.0;
     }
 
-    /// the current value of solution component k.
+    //! the current value of solution component k.
     virtual doublereal solution(int k) const {
         warn("solution");
         return 0.0;
@@ -230,7 +230,7 @@ public:
         return &m_dummy;
     }
 
-    /// the current value of the derivative of solution component k.
+    //! the current value of the derivative of solution component k.
     virtual doublereal derivative(int k) const {
         warn("derivative");
         return 0.0;

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -63,7 +63,7 @@ public:
     //! Calls method eval to evaluate the function
     doublereal operator()(doublereal t) const;
 
-    /// Evaluate the function.
+    //! Evaluate the function.
     virtual doublereal eval(doublereal t) const;
 
     //! Creates a derivative to the current function

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -41,12 +41,12 @@ public:
         _init(1);
     }
 
-    /// Set the temperature.
+    //! Set the temperature.
     virtual void setTemperature(double t) {
         m_temp = t;
     }
 
-    /// Temperature [K].
+    //! Temperature [K].
     virtual double temperature() {
         return m_temp;
     }
@@ -55,27 +55,27 @@ public:
         return 0;
     }
 
-    /// Set the mole fractions by specifying a std::string.
+    //! Set the mole fractions by specifying a std::string.
     virtual void setMoleFractions(const std::string& xin) {
         throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
-    /// Set the mole fractions by specifying an array.
+    //! Set the mole fractions by specifying an array.
     virtual void setMoleFractions(const double* xin) {
         throw NotImplementedError("Boundary1D::setMoleFractions");
     }
 
-    /// Mass fraction of species k.
+    //! Mass fraction of species k.
     virtual double massFraction(size_t k) {
         throw NotImplementedError("Boundary1D::massFraction");
     }
 
-    /// Set the total mass flow rate.
+    //! Set the total mass flow rate.
     virtual void setMdot(double mdot) {
         m_mdot = mdot;
     }
 
-    /// The total mass flow rate [kg/m2/s].
+    //! The total mass flow rate [kg/m2/s].
     virtual double mdot() {
         return m_mdot;
     }
@@ -106,13 +106,13 @@ class Inlet1D : public Boundary1D
 public:
     Inlet1D();
 
-    /// set spreading rate
+    //! set spreading rate
     virtual void setSpreadRate(double V0) {
         m_V0 = V0;
         needJacUpdate();
     }
 
-    /// spreading rate
+    //! spreading rate
     virtual double spreadRate() {
         return m_V0;
     }

--- a/include/cantera/oneD/MultiNewton.h
+++ b/include/cantera/oneD/MultiNewton.h
@@ -64,12 +64,12 @@ public:
     int solve(doublereal* x0, doublereal* x1, OneDim& r, MultiJac& jac,
               int loglevel);
 
-    /// Set options.
+    //! Set options.
     void setOptions(int maxJacAge = 5) {
         m_maxAge = maxJacAge;
     }
 
-    /// Change the problem size.
+    //! Change the problem size.
     void resize(size_t points);
 
 protected:

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -34,13 +34,13 @@ public:
     OneDim(const OneDim&) = delete;
     OneDim& operator=(const OneDim&) = delete;
 
-    /// Add a domain. Domains are added left-to-right.
+    //! Add a domain. Domains are added left-to-right.
     void addDomain(Domain1D* d);
 
     //! Return a reference to the Jacobian evaluator.
     MultiJac& jacobian();
 
-    /// Return a reference to the Newton iterator.
+    //! Return a reference to the Newton iterator.
     MultiNewton& newton();
 
     /**
@@ -51,12 +51,12 @@ public:
      */
     int solve(doublereal* x0, doublereal* x1, int loglevel);
 
-    /// Number of domains.
+    //! Number of domains.
     size_t nDomains() const {
         return m_dom.size();
     }
 
-    /// Return a reference to domain i.
+    //! Return a reference to domain i.
     Domain1D& domain(size_t i) const {
         return *m_dom[i];
     }
@@ -82,7 +82,7 @@ public:
         }
     }
 
-    /// The index of the start of domain i in the solution vector.
+    //! The index of the start of domain i in the solution vector.
     size_t start(size_t i) const {
         if (m_dom[i]->nComponents()) {
             return m_dom[i]->loc();
@@ -93,22 +93,22 @@ public:
         }
     }
 
-    /// Total solution vector length;
+    //! Total solution vector length;
     size_t size() const {
         return m_size;
     }
 
-    /// Pointer to left-most domain (first added).
+    //! Pointer to left-most domain (first added).
     Domain1D* left() {
         return m_dom[0];
     }
 
-    /// Pointer to right-most domain (last added).
+    //! Pointer to right-most domain (last added).
     Domain1D* right() {
         return m_dom.back();
     }
 
-    /// Number of solution components at global point jg.
+    //! Number of solution components at global point jg.
     size_t nVars(size_t jg) {
         return m_nvars[jg];
     }
@@ -123,7 +123,7 @@ public:
     //! component of the global solution vector
     std::tuple<std::string, size_t, std::string> component(size_t i);
 
-    /// Jacobian bandwidth.
+    //! Jacobian bandwidth.
     size_t bandwidth() const {
         return m_bw;
     }
@@ -135,7 +135,7 @@ public:
      */
     void init();
 
-    /// Total number of points.
+    //! Total number of points.
     size_t points() {
         return m_pts;
     }
@@ -147,7 +147,7 @@ public:
      */
     doublereal ssnorm(doublereal* x, doublereal* r);
 
-    /// Reciprocal of the time step.
+    //! Reciprocal of the time step.
     doublereal rdt() const {
         return m_rdt;
     }
@@ -155,12 +155,12 @@ public:
     //! Prepare for time stepping beginning with solution *x* and timestep *dt*.
     void initTimeInteg(doublereal dt, doublereal* x);
 
-    /// True if transient mode.
+    //! True if transient mode.
     bool transient() const {
         return (m_rdt != 0.0);
     }
 
-    /// True if steady mode.
+    //! True if steady mode.
     bool steady() const {
         return (m_rdt == 0.0);
     }

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -42,7 +42,7 @@ public:
     //! These methods are used to set the initial values of solution components.
     //! @{
 
-    /// Set initial guess for one component for all domains
+    //! Set initial guess for one component for all domains
     /**
      * @param component component name
      * @param locs A vector of relative positions, beginning with 0.0 at the
@@ -91,7 +91,7 @@ public:
     void setProfile(size_t dom, size_t comp, const vector_fp& pos,
                     const vector_fp& values);
 
-    /// Set component 'comp' of domain 'dom' to value 'v' at all points.
+    //! Set component 'comp' of domain 'dom' to value 'v' at all points.
     void setFlatProfile(size_t dom, size_t comp, doublereal v);
 
     //! @}
@@ -102,7 +102,7 @@ public:
     void saveResidual(const std::string& fname, const std::string& id,
                       const std::string& desc, int loglevel=1);
 
-    /// Print to stream s the current solution for all domains.
+    //! Print to stream s the current solution for all domains.
     void showSolution(std::ostream& s);
     void showSolution();
 
@@ -123,7 +123,7 @@ public:
         OneDim::eval(npos, m_x.data(), resid, rdt, 0);
     }
 
-    /// Refine the grid in all domains.
+    //! Refine the grid in all domains.
     int refine(int loglevel=0);
 
     //! Add node for fixed temperature point of freely propagating flame
@@ -253,7 +253,7 @@ protected:
     Func1* m_steady_callback;
 
 private:
-    /// Calls method _finalize in each domain.
+    //! Calls method _finalize in each domain.
     void finalize();
 
     //! Wrapper around the Newton solver

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -577,7 +577,7 @@ public:
 
     virtual doublereal enthalpy_mole() const;
 
-    /// Molar entropy. Units: J/kmol/K.
+    //! Molar entropy. Units: J/kmol/K.
     /**
      * For an ideal, constant partial molar volume solution mixture with
      * pure species phases which exhibit zero volume expansivity:

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1061,7 +1061,7 @@ public:
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    /// Molar enthalpy. Units: J/kmol.
+    //! Molar enthalpy. Units: J/kmol.
     /**
      * Molar enthalpy of the solution. Units: J/kmol.
      *      (HKM -> Bump up to Parent object)
@@ -1085,7 +1085,7 @@ public:
      */
     virtual doublereal relative_molal_enthalpy() const;
 
-    /// Molar entropy. Units: J/kmol/K.
+    //! Molar entropy. Units: J/kmol/K.
     /**
      * Molar entropy of the solution. Units: J/kmol/K. For an ideal, constant
      * partial molar volume solution mixture with pure species phases which
@@ -1104,7 +1104,7 @@ public:
      */
     virtual doublereal entropy_mole() const;
 
-    /// Molar Gibbs function. Units: J/kmol.
+    //! Molar Gibbs function. Units: J/kmol.
     /*!
      *      (HKM -> Bump up to Parent object)
      */
@@ -1112,7 +1112,7 @@ public:
 
     virtual doublereal cp_mole() const;
 
-    /// Molar heat capacity at constant volume. Units: J/kmol/K.
+    //! Molar heat capacity at constant volume. Units: J/kmol/K.
     /*!
      *      (HKM -> Bump up to Parent object)
      */

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -27,7 +27,7 @@ namespace Cantera
 class IdealSolnGasVPSS : public VPStandardStateTP
 {
 public:
-    /// Create an object from an input file
+    //! Create an object from an input file
     explicit IdealSolnGasVPSS(const std::string& infile="", std::string id="");
 
     //! @name  Utilities (IdealSolnGasVPSS)

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -181,7 +181,7 @@ namespace Cantera
 class MolalityVPSSTP : public VPStandardStateTP
 {
 public:
-    /// Default Constructor
+    //! Default Constructor
     /*!
      * This doesn't do much more than initialize constants with default values
      * for water at 25C. Water molecular weight comes from the default

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -269,7 +269,7 @@ public:
     //! Return a const reference to the vector of species names
     const std::vector<std::string>& speciesNames() const;
 
-    /// Returns the number of species in the phase
+    //! Returns the number of species in the phase
     size_t nSpecies() const {
         return m_kk;
     }

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -233,32 +233,32 @@ public:
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    /// Molar enthalpy. Units: J/kmol.
+    //! Molar enthalpy. Units: J/kmol.
     virtual doublereal enthalpy_mole() const {
         throw NotImplementedError("ThermoPhase::enthalpy_mole");
     }
 
-    /// Molar internal energy. Units: J/kmol.
+    //! Molar internal energy. Units: J/kmol.
     virtual doublereal intEnergy_mole() const {
         return enthalpy_mole() - pressure()* molarVolume();
     }
 
-    /// Molar entropy. Units: J/kmol/K.
+    //! Molar entropy. Units: J/kmol/K.
     virtual doublereal entropy_mole() const {
         throw NotImplementedError("ThermoPhase::entropy_mole");
     }
 
-    /// Molar Gibbs function. Units: J/kmol.
+    //! Molar Gibbs function. Units: J/kmol.
     virtual doublereal gibbs_mole() const {
         return enthalpy_mole() - temperature()*entropy_mole();
     }
 
-    /// Molar heat capacity at constant pressure. Units: J/kmol/K.
+    //! Molar heat capacity at constant pressure. Units: J/kmol/K.
     virtual doublereal cp_mole() const {
         throw NotImplementedError("ThermoPhase::cp_mole");
     }
 
-    /// Molar heat capacity at constant volume. Units: J/kmol/K.
+    //! Molar heat capacity at constant volume. Units: J/kmol/K.
     virtual doublereal cv_mole() const {
         throw NotImplementedError("ThermoPhase::cv_mole");
     }
@@ -1472,27 +1472,27 @@ public:
     //! liquid-vapor equations of state.
     //! @{
 
-    /// Critical temperature (K).
+    //! Critical temperature (K).
     virtual doublereal critTemperature() const {
         throw NotImplementedError("ThermoPhase::critTemperature");
     }
 
-    /// Critical pressure (Pa).
+    //! Critical pressure (Pa).
     virtual doublereal critPressure() const {
         throw NotImplementedError("ThermoPhase::critPressure");
     }
 
-    /// Critical volume (m3/kmol).
+    //! Critical volume (m3/kmol).
     virtual doublereal critVolume() const {
         throw NotImplementedError("ThermoPhase::critVolume");
     }
 
-    /// Critical compressibility (unitless).
+    //! Critical compressibility (unitless).
     virtual doublereal critCompressibility() const {
         throw NotImplementedError("ThermoPhase::critCompressibility");
     }
 
-    /// Critical density (kg/m3).
+    //! Critical density (kg/m3).
     virtual doublereal critDensity() const {
         throw NotImplementedError("ThermoPhase::critDensity");
     }

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -45,7 +45,7 @@ class VPStandardStateTP : public ThermoPhase
 public:
     //! @name Constructors and Duplicators for VPStandardStateTP
 
-    /// Constructor.
+    //! Constructor.
     VPStandardStateTP();
 
     virtual ~VPStandardStateTP();

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -55,9 +55,9 @@ public:
         throw NotImplementedError("MassFlowController::setPressureFunction");
     }
 
-    /// If a function of time has been specified for mdot, then update the
-    /// stored mass flow rate. Otherwise, mdot is a constant, and does not
-    /// need updating.
+    //! If a function of time has been specified for mdot, then update the
+    //! stored mass flow rate. Otherwise, mdot is a constant, and does not
+    //! need updating.
     virtual void updateMassFlowRate(double time);
 };
 
@@ -160,7 +160,7 @@ public:
         return m_coeff;
     }
 
-    /// Compute the current mass flow rate, based on the pressure difference.
+    //! Compute the current mass flow rate, based on the pressure difference.
     virtual void updateMassFlowRate(double time);
 };
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

C++ doxygen documentation allows for several commenting styles. While other C and C++ styles are frequently used in the Cantera code base, the variant `///` is used infrequently. In order to improve consistency, this PR eliminates `///` in favor of the `//!` commenting variant.

I also noticed that `/*!` is much more frequently used than `/**`, but replacing the latter would be somewhat more intrusive.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
