### PR TITLE
[Units] Add Cython interface for some functions

### DIFF
--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -62,7 +62,7 @@ public:
     bool operator==(const Units& other) const;
 
     //! Return dimension of primary unit component
-    //! ("mass", "length", "time", "temperature", "current" or "quantity")
+    //! ("mass", "length", "time", "temperature", "current", or "quantity")
     double dimension(const std::string& primary) const;
 
 private:

--- a/interfaces/cython/cantera/_cantera.pxd
+++ b/interfaces/cython/cantera/_cantera.pxd
@@ -100,6 +100,7 @@ cdef extern from "cantera/base/Units.h" namespace "Cantera":
         CxxUnits(string, cbool) except +translate_exception
         string str()
         double factor()
+        double dimension(string) except +translate_exception
 
     cdef cppclass CxxUnitSystem "Cantera::UnitSystem":
         CxxUnitSystem()

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -670,7 +670,7 @@ class SolutionArray:
     def shape(self) -> tuple[int, ...]:
         """The shape of the SolutionArray.
 
-        .. versionadded: 3.0
+        .. versionadded:: 3.0
 
         :return: A tuple of integers with the number of elements in each dimension.
         """
@@ -680,7 +680,7 @@ class SolutionArray:
     def size(self) -> int:
         """The number of elements in the SolutionArray.
 
-        .. versionadded: 3.0
+        .. versionadded:: 3.0
         """
         return np.prod(self.shape)
 

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -732,10 +732,10 @@ cdef class ThermoPhase(_SolutionBase):
         :param basis:
             Determines if ``fuel`` and ``oxidizer`` are given in mole
             fractions (``basis='mole'``) or mass fractions (``basis='mass'``)
-        :param: diluent:
+        :param diluent:
             Optional parameter. Required if dilution is used. Specifies the composition
             of the diluent in mole/mass fractions as a string, array or dict
-        :param: fraction:
+        :param fraction:
             Optional parameter. Dilutes the fuel/oxidizer mixture with the diluent
             according to ``fraction``. Fraction can refer to the fraction of diluent in
             the  mixture (for example ``fraction="diluent:0.7`` will create a mixture

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -1,5 +1,6 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
+from typing import Dict
 
 cdef class Units:
     """
@@ -20,6 +21,29 @@ cdef class Units:
 
     def __repr__(self):
         return f"<Units({pystr(self.units.str())}) at {id(self):0x}>"
+
+    def __str__(self):
+        return pystr(self.units.str())
+
+    def dimension(self, primary):
+        return self.units.dimension(stringify(primary))
+
+    @property
+    def dimensions(self) -> Dict[str, str]:
+        """A dictionary of the primary unit components to their dimensions.
+
+        .. versionadded: 3.0
+        """
+        dimensions = ("mass", "length", "time", "temperature", "current", "quantity")
+        return {d: self.dimension(d) for d in dimensions}
+
+    @property
+    def factor(self) -> float:
+        """The factor required to convert from this unit to Cantera's base units.
+
+        .. versionadded: 3.0
+        """
+        return self.units.factor()
 
     @staticmethod
     cdef copy(CxxUnits other):

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -19,20 +19,29 @@ cdef class Units:
         if name:
             self.units = CxxUnits(stringify(name), True)
 
-    def __repr__(self):
-        return f"<Units({pystr(self.units.str())}) at {id(self):0x}>"
+    def __repr__(self) -> str:
+        return f"<Units({str(self)}) at {id(self):0x}>"
 
-    def __str__(self):
+    def __str__(self) -> str:
         return pystr(self.units.str())
 
-    def dimension(self, primary):
+    def dimension(self, primary: str) -> float:
+        """The dimension of the given unit component.
+
+        .. versionadded:: 3.0
+
+        :param primary:
+            A string with the desired unit component. One of ``"mass"``,
+            ``"length"``, ``"time"``, ``"temperature"``, ``"current"``, or
+            ``"quantity"``.
+        """
         return self.units.dimension(stringify(primary))
 
     @property
     def dimensions(self) -> Dict[str, str]:
         """A dictionary of the primary unit components to their dimensions.
 
-        .. versionadded: 3.0
+        .. versionadded:: 3.0
         """
         dimensions = ("mass", "length", "time", "temperature", "current", "quantity")
         return {d: self.dimension(d) for d in dimensions}
@@ -41,7 +50,7 @@ cdef class Units:
     def factor(self) -> float:
         """The factor required to convert from this unit to Cantera's base units.
 
-        .. versionadded: 3.0
+        .. versionadded:: 3.0
         """
         return self.units.factor()
 


### PR DESCRIPTION
These functions are chosen for their potential utility. Setting units is
not enabled by this interface because it is meant to be handled
internally. However, these methods can help to determine the unit
factors for reaction rates.
