### PR TITLE
Perform a comprehensive set of thermodynamic consistency tests for all thermo models

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -434,7 +434,7 @@ jobs:
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
     strategy:
       matrix:
-        vs-toolset: ['14.0', '14.2']
+        vs-toolset: ['14.2']
         python-version: [ "3.7", "3.9", "3.10" ]
       fail-fast: false
     steps:

--- a/SConstruct
+++ b/SConstruct
@@ -158,8 +158,7 @@ windows_options = [
     Option(
         "msvc_version",
         """Version of Visual Studio to use. The default is the newest
-           installed version. Specify '12.0' for Visual Studio 2013, '14.0' for
-           Visual Studio 2015, '14.1' ('14.1x') Visual Studio 2017, '14.2'
+           installed version. Specify '14.1' ('14.1x') Visual Studio 2017, '14.2'
            ('14.2x') for Visual Studio 2019, or '14.3' ('14.3x') for
            Visual Studio 2022. For version numbers in parentheses,
            'x' is a placeholder for a minor version number. Windows MSVC only.""",

--- a/doc/sphinx/yaml/phases.rst
+++ b/doc/sphinx/yaml/phases.rst
@@ -210,7 +210,7 @@ Phase thermodynamic models
 A phase implementing tabulated standard state thermodynamics for one species in
 a binary solution, as `described here <https://cantera.org/documentation/dev/doxygen/html/de/ddf/classCantera_1_1BinarySolutionTabulatedThermo.html#details>`__.
 
-Includes the fields of :ref:`sec-yaml-ideal-molal-solution`, plus:
+Includes the fields of :ref:`sec-yaml-ideal-condensed`, plus:
 
 ``tabulated-species``
     The name of the species to which the tabulated enthalpy and entropy is

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -95,6 +95,9 @@ public:
     //! Method overridden by derived classes to format the error message
     virtual std::string getMessage() const;
 
+    //! Get the name of the method that threw the exception
+    virtual std::string getMethod() const;
+
     //! Method overridden by derived classes to indicate their type
     virtual std::string getClass() const {
         return "CanteraError";

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -295,6 +295,19 @@ public:
      */
     virtual void getPartialMolarEnthalpies(doublereal* hbar) const;
 
+    //! Returns an array of partial molar internal energies for the species in the
+    //! mixture.
+    /*!
+     * Units (J/kmol). For this phase, the partial molar internal energies are equal to
+     * the species standard state internal energies (which are equal to the reference
+     * state internal energies)
+     *  \f[
+     * \bar u_k(T,P) = \hat u^{ref}_k(T)
+     * \f]
+     * @param hbar   Output vector of partial molar internal energies, length #m_kk
+     */
+    virtual void getPartialMolarIntEnergies(doublereal* hbar) const;
+
     //! Returns an array of partial molar entropies of the species in the
     //! solution. Units: J/kmol.
     /*!

--- a/include/cantera/thermo/MetalPhase.h
+++ b/include/cantera/thermo/MetalPhase.h
@@ -37,7 +37,7 @@ public:
         return 0.0;
     }
     virtual doublereal intEnergy_mole() const {
-        return 0.0;
+        return - pressure() * molarVolume();
     }
     virtual doublereal entropy_mole() const {
         return 0.0;

--- a/src/base/ctexceptions.cpp
+++ b/src/base/ctexceptions.cpp
@@ -47,6 +47,11 @@ std::string CanteraError::getMessage() const
     return msg_;
 }
 
+std::string CanteraError::getMethod() const
+{
+    return procedure_;
+}
+
 std::string ArraySizeError::getMessage() const
 {
     return fmt::format("Array size ({}) too small. Must be at least {}.",

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -65,7 +65,7 @@ doublereal IdealMolalSoln::enthalpy_mole() const
 
 doublereal IdealMolalSoln::intEnergy_mole() const
 {
-    getPartialMolarEnthalpies(m_tmpV.data());
+    getPartialMolarIntEnergies(m_tmpV.data());
     return mean_X(m_tmpV);
 }
 
@@ -245,6 +245,14 @@ void IdealMolalSoln::getPartialMolarEnthalpies(doublereal* hbar) const
     getEnthalpy_RT(hbar);
     for (size_t k = 0; k < m_kk; k++) {
         hbar[k] *= RT();
+    }
+}
+
+void IdealMolalSoln::getPartialMolarIntEnergies(double* ubar) const
+{
+    getIntEnergy_RT(ubar);
+    for (size_t k = 0; k < m_kk; k++) {
+        ubar[k] *= RT();
     }
 }
 

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -241,25 +241,25 @@ void PureFluidPhase::getGibbs_RT(doublereal* grt) const
 
 void PureFluidPhase::getEnthalpy_RT_ref(doublereal* hrt) const
 {
-    double psave = pressure();
+    double rhoSave = density();
     double t = temperature();
     double plow = 1.0E-8;
     Set(tpx::PropertyPair::TP, t, plow);
     getEnthalpy_RT(hrt);
-    Set(tpx::PropertyPair::TP, t, psave);
+    Set(tpx::PropertyPair::TV, t, 1 / rhoSave);
 
 }
 
 void PureFluidPhase::getGibbs_RT_ref(doublereal* grt) const
 {
-    double psave = pressure();
+    double rhoSave = density();
     double t = temperature();
     double pref = refPressure();
     double plow = 1.0E-8;
     Set(tpx::PropertyPair::TP, t, plow);
     getGibbs_RT(grt);
     grt[0] += log(pref/plow);
-    Set(tpx::PropertyPair::TP, t, psave);
+    Set(tpx::PropertyPair::TV, t, 1 / rhoSave);
 }
 
 void PureFluidPhase::getGibbs_ref(doublereal* g) const
@@ -270,14 +270,14 @@ void PureFluidPhase::getGibbs_ref(doublereal* g) const
 
 void PureFluidPhase::getEntropy_R_ref(doublereal* er) const
 {
-    double psave = pressure();
+    double rhoSave = density();
     double t = temperature();
     double pref = refPressure();
     double plow = 1.0E-8;
     Set(tpx::PropertyPair::TP, t, plow);
     getEntropy_R(er);
     er[0] -= log(pref/plow);
-    Set(tpx::PropertyPair::TP, t, psave);
+    Set(tpx::PropertyPair::TV, t, 1 / rhoSave);
 }
 
 doublereal PureFluidPhase::critTemperature() const

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -99,3 +99,15 @@ electron-cloud:
   - {T: 300, P: 1 atm}
   - {T: 400, P: 1 atm}
   - {T: 500, P: 10 atm}
+
+# The Python test_purefluid.py test suite contains a much more extensive set of tests
+# for the pure substance models
+nitrogen-purefluid:
+  setup:
+    file: liquidvapor.yaml
+    phase: nitrogen
+  states:
+  - {T: 300, P: 1 atm}
+  - {T: 70, P: 1 atm}
+  - {T: 80, P: 100 atm}
+  - {T: 80, density: 100 kg/m^3}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -228,3 +228,33 @@ fixed-stoichiometry:
   - {T: 300, P: 1 atm}
   - {T: 300, P: 10 atm}
   - {T: 500, P: 10 atm}
+
+ideal-surface:
+  setup:
+    file: surface-phases.yaml
+    phase: Pt-surf
+    atol_v: 1e-7
+    known-failures:
+      h_eq_u_plus_Pv: "Definition of volume is unclear. See GitHub Issue #1312"
+      gk_eq_hk_minus_T_times_sk:
+        "Implementation of s_k is incorrect. See GitHub Issue #1313"
+      s_eq_sum_sk_Xk:
+        "Implementation of s_k is incorrect. See GitHub Issue #1313"
+      g_eq_sum_gk_Xk:
+        "chemPotentials does not protect against inf. See GitHub Issue #1314"
+  states:
+  - {T: 800, P: 1 atm, coverages: {Pt(s): 0.5, H(s): 0.4, O(s): 0.1}}
+  - {T: 800, P: 5 atm, coverages: {H(s): 1.0}}
+  - {T: 300, P: 20 atm, coverages: {Pt(s): 1.0}}
+  - {T: 600, P: 5 atm, coverages: {Pt(s): 0.1, O(s): 0.9}}
+
+ideal-edge:
+  setup:
+    file: surface-phases.yaml
+    phase: TPB
+    atol_v: 1e3  # site density of 5e-18 kmol/m = linear molar volume of 2e17 m/kmol
+    known-failures:
+      h_eq_u_plus_Pv: "Definition of volume is unclear. See GitHub Issue #1312"
+  states:
+  - {T: 300, P: 1 atm}
+  - {T: 900, P: 20 atm}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -206,3 +206,37 @@ margules:
   - {T: 900, P: 1 atm, X: {KCl(L): 0.2, LiCl(L): 0.8}}
   - {T: 1000, P: 10 atm, X: {KCl(L): 0.99, LiCl(L): 0.01}}
   - {T: 1400, P: 20 atm, X: {KCl(L): 2.0e-5, LiCl(L): 1}}
+
+lattice:
+  setup:
+    file: thermo-models.yaml
+    phase: Li7Si3-interstitial
+    known-failures:
+      hk0_eq_uk0_plus_p_vk0: getIntEnergy_RT is not implemented
+      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
+      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
+      _sum_.+_Xk: "Implementation is wrong. See GitHub Issue #1309"
+      gk_eq_hk_minus_T_times_sk: "Implementation is wrong. See GitHub Issue #1309"
+      standard_gibbs_nondim: "Implementation is wrong. See GitHub Issue #1309"
+  states:
+  - {T: 725.0 K, P: 1.0 atm, X: {Li(i): 0.2, V(i): 0.8}}
+  - {T: 825.0 K, P: 50.0 bar, X: {Li(i): 0.7, V(i): 0.3}}
+  - {T: 925.0 K, P: 50.0 bar, X: {Li(i): 1.0, V(i): 0.0}}
+
+compound-lattice:
+  setup:
+    file: thermo-models.yaml
+    phase: Li7Si3_and_interstitials
+    known-failures:
+      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
+      u_eq_sum_uk_Xk:  getPartialMolarIntEnergies is not implemented
+      hk0_eq_uk0_plus_p_vk0: getEnthalpy_RT is not implemented
+      cpk0_eq_dhk0dT: getEnthalpy_RT is not implemented
+      gk0_eq_hk0_minus_T_sk0: getEnthalpy_RT is not implemented
+      standard_gibbs_nondim: getGibbs_RT is not implemented
+      _sum_.+_Xk: "LatticePhase implementation is wrong. See GitHub Issue #1309"
+      h_eq_u_plus_Pv: "Implementation is inconsistent. See GitHub Issue #1310"
+      gk_eq_hk_minus_T_times_sk: "Implementation is inconsistent. See GitHub Issue #1310"
+  states:
+  - {T: 725.0 K, P: 1.0 atm}
+  - {T: 825.0 K, P: 50.0 bar}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -372,3 +372,16 @@ ions-from-neutral-molecule:
   states:
   - {T: 300, P: 1 atm, X: {K+: 0.1, Cl-: 0.1}}
   - {T: 500, P: 5 bar, X: {K+: 0.1, Cl-: 0.1}}
+
+HMW-electrolyte:
+  setup:
+    file: HMW_NaCl.yaml
+    known-failures:
+      cp_eq_dhdT: "Moderate discrepancies. See GitHub Issue #1324"
+      cp_eq_dsdT_const_p_times_T: "Moderate discrepancies. See GitHub Issue #1324"
+      dsdP_const_T_eq_minus_dV_dT_const_P: "Moderate discrepancies. See GitHub Issue #1324"
+      activity_coeffs: "Major discrepancies for all solute species. See GitHub Issue #1324"
+  states:
+  - {T: 300, P: 1 atm, molalities: {Na+: 9.4, Cl-: 9.4, H+: 1.05e-05, OH-: 1.0e-05}}
+  - {T: 330, P: 1 atm, molalities: {Na+: 9.4, Cl-: 9.4, H+: 1.05e-04, OH-: 1.0e-04}}
+  - {T: 330, P: 10 atm, molalities: {Na+: 5.0, Cl-: 4.8, H+: 1.0e-07, OH-: 0.2}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -103,7 +103,10 @@ electron-cloud:
       hk_eq_uk_plus_P_times_vk: partialMolarIntEnergies is not implemented
       gk_eq_hk_minus_T_times_sk: partialMolarEntropies is not implemented
       .+_eq_sum_.+k_Xk: partialMolar IntEnergies/Entropies/Volumes not implemented
-
+      gk0_eq_hk0_minus_T_sk0: getGibbs_RT is not implemented
+      standard_gibbs_nondim: getGibbs_RT is not implemented
+      hk0_eq_uk0_plus_p_vk0: getIntEnergy_RT is not implemented
+      cpk0_eq_dhk0dT: getCp_R is not implemented
   states:
   - {T: 300, P: 1 atm}
   - {T: 400, P: 1 atm}
@@ -119,6 +122,8 @@ nitrogen-purefluid:
     known-failures:
       cv_eq_.+/3: cv not defined in two-phase region
       cp_eq_sum_cpk_Xk: cp is inf in the two-phase region
+      hk0_eq_uk0_plus_p_vk0: getIntEnergy_RT is not implemented
+      cpk0_eq_dhk0dT: getCp_R is not implemented
   states:
   - {T: 300, P: 1 atm}
   - {T: 70, P: 1 atm}
@@ -133,6 +138,7 @@ plasma:
       cp_eq_.+/1: Test does not account for distinct electron temperature
       cv_eq_.+/1: Test does not account for distinct electron temperature
       c._eq_dsdT_const_._times_T: Test does not account for distinct electron temperature
+      cpk0_eq_dhk0dT: Test does not account for distinct electron temperature
   states:
   - {T: 300, P: 1 atm, X: {O2: 1.0, O2-: 1e-5, E: 1e-5}}
   - {T: 300, P: 1 atm, X: {E: 1.0}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -1,15 +1,36 @@
 # Parameters for test cases defined in test/thermo/consistency.cpp
 
 ideal-gas-h2o2:
-  input: {file: h2o2.yaml}
+  setup: {file: h2o2.yaml}
   states:
   - {T: 300, P: 101325, X: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
   - {T: 300, P: 101325, Y: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
   - {T: 400, density: 5 g/cm^3 , X: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
 
 redlich-kwong:
-  input: {file: co2_RK_example.yaml}
+  setup: {file: co2_RK_example.yaml}
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
   - {T: 600, P: 200 bar, X: {CO2: 0.4, CH4: 0.2, H2O: 0.4}}
+
+peng-robinson:
+  setup: {file: co2_PR_example.yaml}
+  states:
+  - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
+  - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
+  - {T: 600, P: 200 bar, X: {CO2: 0.4, CH4: 0.2, H2O: 0.4}}
+
+ideal-molal-solution:
+  setup:
+    file: thermo-models.yaml
+    phase: ideal-molal-aqueous
+    known-failures:
+      g_eq_h_minus_Ts:
+        "Implementations of g and s are inconsistent. See GitHub Issue #1300"
+      gk_eq_hk_minus_T_times_sk:
+        "Implementations of g and s are inconsistent. See GitHub Issue #1300"
+  states:
+  - {T: 300, P: 101325, molalities: {CH4(aq): 0.01, H2S(aq): 0.03, CO2(aq): 0.1}}
+  - {T: 300, P: 2 atm, molalities: {CH4(aq): 0.1, H2S(aq): 0.01, CO2(aq): 0.1}}
+  - {T: 340, P: 5 atm, molalities: {CH4(aq): 0.1, H2S(aq): 0.01, CO2(aq): 0.1}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -219,3 +219,12 @@ compound-lattice:
   - {T: 725.0 K, P: 1.0 atm}
   - {T: 825.0 K, P: 50.0 bar}
   - {T: 825.0 K, P: 50.0 bar, X: {Li7Si3(s): 0.3, Li(i): 0.5, V(i): 0.2}}
+
+fixed-stoichiometry:
+  setup:
+    file: thermo-models.yaml
+    phase: KCl(s)
+  states:
+  - {T: 300, P: 1 atm}
+  - {T: 300, P: 10 atm}
+  - {T: 500, P: 10 atm}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -36,7 +36,9 @@ ideal-molal-solution:
         "Implementations of g and s are inconsistent. See GitHub Issue #1300"
       gk_eq_hk_minus_T_times_sk:
         "Implementations of g and s are inconsistent. See GitHub Issue #1300"
-      cv_eq_dudT: cv not implemented
+      cv_eq_.+: cv not implemented
+      cp_eq_dsdT_const_p_times_T:
+        "Implementation of cp and s are inconsistent. See GitHub Issue #1300"
   states:
   - {T: 300, P: 101325, molalities: {CH4(aq): 0.01, H2S(aq): 0.03, CO2(aq): 0.1}}
   - {T: 300, P: 2 atm, molalities: {CH4(aq): 0.1, H2S(aq): 0.01, CO2(aq): 0.1}}
@@ -115,7 +117,7 @@ nitrogen-purefluid:
     phase: nitrogen
     rtol_fd: 1e-5
     known-failures:
-      cv_eq_dudT/3: cv not defined in two-phase region
+      cv_eq_.+/3: cv not defined in two-phase region
       cp_eq_sum_cpk_Xk: cp is inf in the two-phase region
   states:
   - {T: 300, P: 1 atm}
@@ -128,8 +130,9 @@ plasma:
     file: oxygen-plasma.yaml
     phase: discretized-electron-energy-plasma
     known-failures:
-      cp_eq_dhdT/1: Test does not account for distinct electron temperature
-      cv_eq_dudT/1: Test does not account for distinct electron temperature
+      cp_eq_.+/1: Test does not account for distinct electron temperature
+      cv_eq_.+/1: Test does not account for distinct electron temperature
+      c._eq_dsdT_const_._times_T: Test does not account for distinct electron temperature
   states:
   - {T: 300, P: 1 atm, X: {O2: 1.0, O2-: 1e-5, E: 1e-5}}
   - {T: 300, P: 1 atm, X: {E: 1.0}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -35,6 +35,7 @@ ideal-molal-solution:
       cv_eq_.+: cv not implemented
       cp_eq_dsdT_const_p_times_T:
         "Implementation of cp and s are inconsistent. See GitHub Issue #1300"
+      activity_coeffs: "Activity coeffs are incorrect. See GitHub Issue #1311"
   states:
   - {T: 300, P: 101325, molalities: {CH4(aq): 0.01, H2S(aq): 0.03, CO2(aq): 0.1}}
   - {T: 300, P: 2 atm, molalities: {CH4(aq): 0.1, H2S(aq): 0.01, CO2(aq): 0.1}}
@@ -76,6 +77,10 @@ binary-solution-tabulated:
       h_eq_sum_hk_Xk: "Inconsistent results. See GitHub Issue #1302"
       s_eq_sum_sk_Xk: "Problems near composition limit. See GitHub Issue #1303"
       gk_eq_hk_minus_T_times_sk: "Problems near composition limit. See GitHub Issue #1303"
+      gk0_eq_hk0_minus_T_times_sk0/[34]:
+        "Problems near composition limit. See GitHub Issue #1303"
+      chem_potentials_to_activities/3:
+        "Problems near composition limit. See GitHub Issue #1303"
   states:
   - {T: 300, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
   - {T: 320, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
@@ -130,6 +135,8 @@ debye-huckel-dilute:
     phase: debye-huckel-dilute
     known-failures: &debye-huckel-failures
       cv_eq_.+: cv not implemented
+      activity_coeffs: "Activity coeffs are incorrect. See GitHub Issue #1311"
+
   states: &debye-huckel-states
   - {T: 300, P: 1 atm,
      molalities: {Na+: 9.3549, Cl-: 9.3549, H+: 1.05e-08, OH-: 1.3765e-06,
@@ -191,6 +198,7 @@ lattice:
       _sum_.+_Xk: "Implementation is wrong. See GitHub Issue #1309"
       gk_eq_hk_minus_T_times_sk: "Implementation is wrong. See GitHub Issue #1309"
       standard_gibbs_nondim: "Implementation is wrong. See GitHub Issue #1309"
+      chem_potentials_to_activities: "Implementation is wrong. See GitHub Issue #1309"
   states:
   - {T: 725.0 K, P: 1.0 atm, X: {Li(i): 0.2, V(i): 0.8}}
   - {T: 825.0 K, P: 50.0 bar, X: {Li(i): 0.7, V(i): 0.3}}
@@ -204,6 +212,10 @@ compound-lattice:
       _sum_.+_Xk: "LatticePhase implementation is wrong. See GitHub Issue #1309"
       h_eq_u_plus_Pv: "Implementation is inconsistent. See GitHub Issue #1310"
       gk_eq_hk_minus_T_times_sk: "Implementation is inconsistent. See GitHub Issue #1310"
+      chem_potentials_to_activities:
+        "LatticePhase implementation is wrong. See GitHub Issue #1309"
+      activity_coeffs: "See GitHub Issue #1309"
   states:
   - {T: 725.0 K, P: 1.0 atm}
   - {T: 825.0 K, P: 50.0 bar}
+  - {T: 825.0 K, P: 50.0 bar, X: {Li7Si3(s): 0.3, Li(i): 0.5, V(i): 0.2}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -10,8 +10,6 @@ ideal-gas-h2o2:
 redlich-kwong:
   setup:
     file: co2_RK_example.yaml
-    known-failures:
-      cp_eq_sum_cpk_Xk: getPartialMolarCp not implemented
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
@@ -20,8 +18,6 @@ redlich-kwong:
 peng-robinson:
   setup:
     file: co2_PR_example.yaml
-    known-failures:
-      cp_eq_sum_cpk_Xk: getPartialMolarCp not implemented
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
@@ -49,8 +45,6 @@ ideal-condensed-1:
     file: thermo-models.yaml
     phase: IdealSolidSolnPhase
     known-failures:
-      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
-      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
       g_eq_h_minus_Ts: "Inconsistent result when P != 1 atm. See GitHub Issue #1301"
       g_eq_sum_gk_Xk: "Inconsistent result when P != 1 atm. See GitHub Issue #1301"
   states:
@@ -64,8 +58,6 @@ ideal-condensed-2:
     file: thermo-models.yaml
     phase: IdealSolidSolnPhase2
     known-failures:
-      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
-      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
       g_eq_h_minus_Ts: "Inconsistent result when P != 1 atm. See GitHub Issue #1301"
       g_eq_sum_gk_Xk: "Inconsistent result when P != 1 atm. See GitHub Issue #1301"
   states:
@@ -78,8 +70,6 @@ binary-solution-tabulated:
     file: BinarySolutionTabulatedThermo.yaml
     phase: anode
     known-failures:
-      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
-      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
       g_eq_h_minus_Ts: "Inconsistent results when P != 1 atm. See GitHub Issue #1301"
       g_eq_sum_gk_Xk: "Inconsistent results when P != 1 atm. See GitHub Issue #1301"
       v_eq_sum_vk_Xk: "Inconsistent results. See GitHub Issue #1302"
@@ -99,14 +89,6 @@ electron-cloud:
   setup:
     file: thermo-models.yaml
     phase: Metal
-    known-failures:
-      hk_eq_uk_plus_P_times_vk: partialMolarIntEnergies is not implemented
-      gk_eq_hk_minus_T_times_sk: partialMolarEntropies is not implemented
-      .+_eq_sum_.+k_Xk: partialMolar IntEnergies/Entropies/Volumes not implemented
-      gk0_eq_hk0_minus_T_sk0: getGibbs_RT is not implemented
-      standard_gibbs_nondim: getGibbs_RT is not implemented
-      hk0_eq_uk0_plus_p_vk0: getIntEnergy_RT is not implemented
-      cpk0_eq_dhk0dT: getCp_R is not implemented
   states:
   - {T: 300, P: 1 atm}
   - {T: 400, P: 1 atm}
@@ -122,8 +104,6 @@ nitrogen-purefluid:
     known-failures:
       cv_eq_.+/3: cv not defined in two-phase region
       cp_eq_sum_cpk_Xk: cp is inf in the two-phase region
-      hk0_eq_uk0_plus_p_vk0: getIntEnergy_RT is not implemented
-      cpk0_eq_dhk0dT: getCp_R is not implemented
   states:
   - {T: 300, P: 1 atm}
   - {T: 70, P: 1 atm}
@@ -150,8 +130,6 @@ debye-huckel-dilute:
     phase: debye-huckel-dilute
     known-failures: &debye-huckel-failures
       cv_eq_.+: cv not implemented
-      u_eq_sum_uk_Xk: partialMolarIntEnergies not implemented
-      hk_eq_uk_plus_P_times_vk: partialMolarIntEnergies not implemented
   states: &debye-huckel-states
   - {T: 300, P: 1 atm,
      molalities: {Na+: 9.3549, Cl-: 9.3549, H+: 1.05e-08, OH-: 1.3765e-06,
@@ -199,8 +177,6 @@ margules:
   setup:
     file: LiKCl_liquid.yaml
     known-failures:
-      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
-      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
       cv_eq.+: "Implementation of cv is incorrect. See GitHub Issue #1308"
   states:
   - {T: 900, P: 1 atm, X: {KCl(L): 0.2, LiCl(L): 0.8}}
@@ -212,9 +188,6 @@ lattice:
     file: thermo-models.yaml
     phase: Li7Si3-interstitial
     known-failures:
-      hk0_eq_uk0_plus_p_vk0: getIntEnergy_RT is not implemented
-      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
-      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
       _sum_.+_Xk: "Implementation is wrong. See GitHub Issue #1309"
       gk_eq_hk_minus_T_times_sk: "Implementation is wrong. See GitHub Issue #1309"
       standard_gibbs_nondim: "Implementation is wrong. See GitHub Issue #1309"
@@ -228,12 +201,6 @@ compound-lattice:
     file: thermo-models.yaml
     phase: Li7Si3_and_interstitials
     known-failures:
-      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
-      u_eq_sum_uk_Xk:  getPartialMolarIntEnergies is not implemented
-      hk0_eq_uk0_plus_p_vk0: getEnthalpy_RT is not implemented
-      cpk0_eq_dhk0dT: getEnthalpy_RT is not implemented
-      gk0_eq_hk0_minus_T_sk0: getEnthalpy_RT is not implemented
-      standard_gibbs_nondim: getGibbs_RT is not implemented
       _sum_.+_Xk: "LatticePhase implementation is wrong. See GitHub Issue #1309"
       h_eq_u_plus_Pv: "Implementation is inconsistent. See GitHub Issue #1310"
       gk_eq_hk_minus_T_times_sk: "Implementation is inconsistent. See GitHub Issue #1310"

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -111,3 +111,12 @@ nitrogen-purefluid:
   - {T: 70, P: 1 atm}
   - {T: 80, P: 100 atm}
   - {T: 80, density: 100 kg/m^3}
+
+plasma:
+  setup:
+    file: oxygen-plasma.yaml
+    phase: discretized-electron-energy-plasma
+  states:
+  - {T: 300, P: 1 atm, X: {O2: 1.0, O2-: 1e-5, E: 1e-5}}
+  - {T: 300, P: 1 atm, X: {E: 1.0}}
+  - {T: 3500, P: 10 atm, X: {O2: 1.0, O2-: 2e-5, E: 2e-5}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -63,3 +63,25 @@ ideal-condensed-2:
   - {T: 300, P: 0.1 atm, X: {sp1: 1.0}}
   - {T: 400, P: 0.1 atm, X: {sp1: 0.01, sp2: 0.03, sp3: 0.94}}
   - {T: 500, P: 2 bar, X: {sp1: 0.1, sp2: 0.89, sp3: 0.01}}
+
+binary-solution-tabulated:
+  setup:
+    file: BinarySolutionTabulatedThermo.yaml
+    phase: anode
+    known-failures:
+      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
+      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
+      g_eq_h_minus_Ts: "Inconsistent results when P != 1 atm. See GitHub Issue #1301"
+      g_eq_sum_gk_Xk: "Inconsistent results when P != 1 atm. See GitHub Issue #1301"
+      v_eq_sum_vk_Xk: "Inconsistent results. See GitHub Issue #1302"
+      h_eq_sum_hk_Xk: "Inconsistent results. See GitHub Issue #1302"
+      s_eq_sum_sk_Xk: "Problems near composition limit. See GitHub Issue #1303"
+      gk_eq_hk_minus_T_times_sk: "Problems near composition limit. See GitHub Issue #1303"
+  states:
+  - {T: 300, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
+  - {T: 320, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
+  - {T: 340, P: 10 atm, X: {"Li[anode]": 0.6, "V[anode]": 0.4}}
+  - {T: 300, P: 5 atm, X: {"Li[anode]": 0.0, "V[anode]": 1.0}}
+  - {T: 300, P: 1 atm, X: {"Li[anode]": 1.0, "V[anode]": 0.0}}
+  - {T: 300, P: 5 atm, X: {"Li[anode]": 1.0e-10, "V[anode]": 1.0}}
+  - {T: 300, P: 1 atm, X: {"Li[anode]": 1.0, "V[anode]": 1.0e-10}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -10,6 +10,7 @@ ideal-gas-h2o2:
 redlich-kwong:
   setup:
     file: co2_RK_example.yaml
+    rtol_fd: 1e-5
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
@@ -18,6 +19,7 @@ redlich-kwong:
 peng-robinson:
   setup:
     file: co2_PR_example.yaml
+    rtol_fd: 1e-5
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
@@ -105,10 +107,11 @@ nitrogen-purefluid:
   setup:
     file: liquidvapor.yaml
     phase: nitrogen
-    rtol_fd: 1e-5
+    rtol_fd: 2e-3  # agreement for Maxwell relations is limited
     known-failures:
       cv_eq_.+/3: cv not defined in two-phase region
       cp_eq_sum_cpk_Xk: cp is inf in the two-phase region
+      dsdP_const_T_eq_minus_dV_dT_const_P/3: Can't set TP in two-phase region
   states:
   - {T: 300, P: 1 atm}
   - {T: 70, P: 1 atm}
@@ -242,6 +245,8 @@ ideal-surface:
         "Implementation of s_k is incorrect. See GitHub Issue #1313"
       g_eq_sum_gk_Xk:
         "chemPotentials does not protect against inf. See GitHub Issue #1314"
+      dSdv_const_T_eq_dPdT_const_V:
+        "Compressibility of phase leads to inconsistent results. See GitHub Issue #1312"
   states:
   - {T: 800, P: 1 atm, coverages: {Pt(s): 0.5, H(s): 0.4, O(s): 0.1}}
   - {T: 800, P: 5 atm, coverages: {H(s): 1.0}}
@@ -255,6 +260,8 @@ ideal-edge:
     atol_v: 1e3  # site density of 5e-18 kmol/m = linear molar volume of 2e17 m/kmol
     known-failures:
       h_eq_u_plus_Pv: "Definition of volume is unclear. See GitHub Issue #1312"
+      dSdv_const_T_eq_dPdT_const_V:
+        "Compressibility of phase leads to inconsistent results. See GitHub Issue #1312"
   states:
   - {T: 300, P: 1 atm}
   - {T: 900, P: 20 atm}
@@ -263,6 +270,7 @@ liquid-water-IAPWS95:
   setup:
     file: liquidvapor.yaml
     phase: liquid-water-IAPWS95
+    rtol_fd: 5e-3  # Limited agreement for Maxwell relations
     known-failures:
       h_eq_u_plus_Pv: "Error in internal energy calculation. See GitHub Issue #1315"
       hk_eq_uk_plus_P_times_vk:

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -359,3 +359,16 @@ Maskell-solid-solution:
   - {T: 330, P: 10 atm, X: {H(s): 0.3, He(s): 0.7}}
   - {T: 280, P: 20 atm, X: {H(s): 1.0, He(s): 0.0}}
   - {T: 380, P: 5 atm, X: {H(s): 0.0, He(s): 1.0}}
+
+ions-from-neutral-molecule:
+  setup:
+    file: thermo-models.yaml
+    phase: ions-from-neutral-molecule
+    known-failures:
+      g_eq_h_minus_Ts: "Inconsistent results. See GitHub Issue #1322"
+      gk_eq_hk_minus_T_sk: "Inconsistent results. See GitHub Issue #1322"
+      v_eq_sum_vk_Xk: "Inconsistent results. See GitHub Issue #1322"
+      chem_potentials_to_activities: "Inconsistent results. See GitHub Issue #1322"
+  states:
+  - {T: 300, P: 1 atm, X: {K+: 0.1, Cl-: 0.1}}
+  - {T: 500, P: 5 bar, X: {K+: 0.1, Cl-: 0.1}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -10,6 +10,8 @@ ideal-gas-h2o2:
 redlich-kwong:
   setup:
     file: co2_RK_example.yaml
+    known-failures:
+      cp_eq_sum_cpk_Xk: getPartialMolarCp not implemented
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
@@ -18,6 +20,8 @@ redlich-kwong:
 peng-robinson:
   setup:
     file: co2_PR_example.yaml
+    known-failures:
+      cp_eq_sum_cpk_Xk: getPartialMolarCp not implemented
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
@@ -96,7 +100,7 @@ electron-cloud:
     known-failures:
       hk_eq_uk_plus_P_times_vk: partialMolarIntEnergies is not implemented
       gk_eq_hk_minus_T_times_sk: partialMolarEntropies is not implemented
-      "[usv]_eq_sum_[usv]k_Xk": partialMolar IntEnergies/Entropies/Volumes not implemented
+      .+_eq_sum_.+k_Xk: partialMolar IntEnergies/Entropies/Volumes not implemented
 
   states:
   - {T: 300, P: 1 atm}
@@ -112,6 +116,7 @@ nitrogen-purefluid:
     rtol_fd: 1e-5
     known-failures:
       cv_eq_dudT/3: cv not defined in two-phase region
+      cp_eq_sum_cpk_Xk: cp is inf in the two-phase region
   states:
   - {T: 300, P: 1 atm}
   - {T: 70, P: 1 atm}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -1,4 +1,34 @@
 # Parameters for test cases defined in test/thermo/consistency.cpp
+#
+# Each top-level entry here corresponds to a Googletest "test suite" instantiation,
+# using the INSTANTIATE_TEST_SUITE_P macro.
+#
+# Each of these entries has two keys, 'setup' and 'states'. The 'setup' map defines the
+# phase to be loaded, information on cases that are known to fail, and optional
+# tolerance parameters that are used in some tests. Within the 'setup' map, the
+# following keys are recognized:
+# - file: the name of the input file, read from the usual data paths (which
+#   includes test/data when running the test suite)
+# - phase: The name of the phase to read. Optional - by default, the first phase
+#   in the file is used.
+# - known-failures: A map where the keys identify tests that should be skipped because
+#   they are known to fail and the values are messages to be printed in the test log
+#   explaining why the test has been skipped. The keys are regular expressions that are
+#   searched for in the test names (second argument to TEST_P) defined in
+#   consistency.cpp. The test name is suffixed with '/N' where 'N' is the (zero-indexed)
+#   index into the 'states' array and can be used to skip specific test instances. Where
+#   possible, known failures should reference GitHub Issue numbers documenting known
+#   errors. This mechanism is not used to handle test cases that raise
+#   NotImplementedError; Those tests should be skipped automatically.
+# - atol: An absolute tolerance used for tests comparing molar energy-like quantities.
+#   Default 1.0e-5.
+# - atol_v: An absolute tolerance used for tests comparing molar volumes.
+#   Default 1.0e-11.
+# - rtol_fd: A relative tolerance used in some finite difference tests. Default 1.0e-6.
+#
+# The 'states' key defines a list of maps, where each map provides a complete state
+# definition for the phase. The map is passed directly to ThermoPhase::setState(), and
+# supports setting the state using any of the variables supported there.
 
 ideal-gas-h2o2:
   setup: {file: h2o2.yaml}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -85,3 +85,17 @@ binary-solution-tabulated:
   - {T: 300, P: 1 atm, X: {"Li[anode]": 1.0, "V[anode]": 0.0}}
   - {T: 300, P: 5 atm, X: {"Li[anode]": 1.0e-10, "V[anode]": 1.0}}
   - {T: 300, P: 1 atm, X: {"Li[anode]": 1.0, "V[anode]": 1.0e-10}}
+
+electron-cloud:
+  setup:
+    file: thermo-models.yaml
+    phase: Metal
+    known-failures:
+      hk_eq_uk_plus_P_times_vk: partialMolarIntEnergies is not implemented
+      gk_eq_hk_minus_T_times_sk: partialMolarEntropies is not implemented
+      "[usv]_eq_sum_[usv]k_Xk": partialMolar IntEnergies/Entropies/Volumes not implemented
+
+  states:
+  - {T: 300, P: 1 atm}
+  - {T: 400, P: 1 atm}
+  - {T: 500, P: 10 atm}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -83,6 +83,8 @@ binary-solution-tabulated:
         "Problems near composition limit. See GitHub Issue #1303"
       chem_potentials_to_activities/3:
         "Problems near composition limit. See GitHub Issue #1303"
+      gRef_eq_hRef_minus_T_sRef/[34]:
+        "Problems near composition limit. See GitHub Issue #1303"
   states:
   - {T: 300, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
   - {T: 320, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
@@ -127,6 +129,7 @@ plasma:
       cv_eq_.+/1: Test does not account for distinct electron temperature
       c._eq_dsdT_const_._times_T: Test does not account for distinct electron temperature
       cpk0_eq_dhk0dT: Test does not account for distinct electron temperature
+      cpRef_eq_dhRefdT: Test does not account for distinct electron temperature
   states:
   - {T: 300, P: 1 atm, X: {O2: 1.0, O2-: 1e-5, E: 1e-5}}
   - {T: 300, P: 1 atm, X: {E: 1.0}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -34,3 +34,32 @@ ideal-molal-solution:
   - {T: 300, P: 101325, molalities: {CH4(aq): 0.01, H2S(aq): 0.03, CO2(aq): 0.1}}
   - {T: 300, P: 2 atm, molalities: {CH4(aq): 0.1, H2S(aq): 0.01, CO2(aq): 0.1}}
   - {T: 340, P: 5 atm, molalities: {CH4(aq): 0.1, H2S(aq): 0.01, CO2(aq): 0.1}}
+
+ideal-condensed-1:
+  setup:
+    file: thermo-models.yaml
+    phase: IdealSolidSolnPhase
+    known-failures:
+      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
+      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
+      g_eq_h_minus_Ts: "Inconsistent result when P != 1 atm. See GitHub Issue #1301"
+      g_eq_sum_gk_Xk: "Inconsistent result when P != 1 atm. See GitHub Issue #1301"
+  states:
+  - {T: 300, P: 0.1 atm, X: {sp1: 1.0}}
+  - {T: 300, P: 1 atm, X: {sp1: 0.6, sp2: 0.4}}
+  - {T: 400, P: 0.1 atm, X: {sp1: 0.01, sp2: 0.03, sp3: 0.94}}
+  - {T: 500, P: 2 bar, X: {sp1: 0.1, sp2: 0.89, sp3: 0.01}}
+
+ideal-condensed-2:
+  setup:
+    file: thermo-models.yaml
+    phase: IdealSolidSolnPhase2
+    known-failures:
+      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
+      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
+      g_eq_h_minus_Ts: "Inconsistent result when P != 1 atm. See GitHub Issue #1301"
+      g_eq_sum_gk_Xk: "Inconsistent result when P != 1 atm. See GitHub Issue #1301"
+  states:
+  - {T: 300, P: 0.1 atm, X: {sp1: 1.0}}
+  - {T: 400, P: 0.1 atm, X: {sp1: 0.01, sp2: 0.03, sp3: 0.94}}
+  - {T: 500, P: 2 bar, X: {sp1: 0.1, sp2: 0.89, sp3: 0.01}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -188,3 +188,15 @@ debye-huckel-beta_ij:
     phase: debye-huckel-beta_ij
     known-failures: *debye-huckel-failures
   states: *debye-huckel-states
+
+margules:
+  setup:
+    file: LiKCl_liquid.yaml
+    known-failures:
+      hk_eq_uk_plus_P_times_vk: getPartialMolarIntEnergies is not implemented
+      u_eq_sum_uk_Xk: getPartialMolarIntEnergies is not implemented
+      cv_eq.+: "Implementation of cv is incorrect. See GitHub Issue #1308"
+  states:
+  - {T: 900, P: 1 atm, X: {KCl(L): 0.2, LiCl(L): 0.8}}
+  - {T: 1000, P: 10 atm, X: {KCl(L): 0.99, LiCl(L): 0.01}}
+  - {T: 1400, P: 20 atm, X: {KCl(L): 2.0e-5, LiCl(L): 1}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -11,5 +11,5 @@ redlich-kwong:
   input: {file: co2_RK_example.yaml}
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
-  - {T: 300, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
+  - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
   - {T: 600, P: 200 bar, X: {CO2: 0.4, CH4: 0.2, H2O: 0.4}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -326,3 +326,36 @@ Redlich-Kister:
   - {T: 440, P: 1 atm, X: {Li(C6): 0.75, V(C6): 0.25}}
   - {T: 350, P: 10 atm, X: {Li(C6): 1.0, V(C6): 0.0}}
   - {T: 350, P: 10 atm, X: {Li(C6): 0.0, V(C6): 1.0}}
+
+Maskell-solid-solution:
+  setup:
+    file: thermo-models.yaml
+    phase: MaskellSolidSoln
+    known-failures:
+      g_eq_sum_gk_Xk: "Inconsistent implementation. See GitHub Issue #1321"
+      hk0_eq_uk0_plus_p_vk0/[234]:
+        "Inconsistent except at P = 1 atm. See GitHub Issue #1321"
+      cpk0_eq_dhk0dT/[234]:
+        "Inconsistent except at P = 1 atm. See GitHub Issue #1321"
+      standard_gibbs_nondim/[234]:
+        "Inconsistent except at P = 1 atm. See GitHub Issue #1321"
+      g_eq_h_minus_Ts/[34]:
+        "Generates NaN at limiting composition. See GitHub Issue #1321"
+      dsdP_const_T_eq_minus_dV_dT_const_P/[34]:
+        "Generates NaN at limiting composition. See GitHub Issue #1321"
+      chem_potentials_to_activities/[34]:
+        "Generates NaN at limiting composition. See GitHub Issue #1321"
+      activity_coeffs/[34]:
+        "Generates NaN at limiting composition. See GitHub Issue #1321"
+      activity_concentrations/[34]:
+        "Generates NaN at limiting composition. See GitHub Issue #1321"
+      log_activity_coeffs/[34]:
+        "Generates NaN at limiting composition. See GitHub Issue #1321"
+      h_eq_u_plus_Pv/4:
+        "Generates NaN at limiting composition. See GitHub Issue #1321"
+  states:
+  - {T: 300, P: 1 atm, X: {H(s): 0.3, He(s): 0.7}}
+  - {T: 340, P: 1 atm, X: {H(s): 0.3, He(s): 0.7}}
+  - {T: 330, P: 10 atm, X: {H(s): 0.3, He(s): 0.7}}
+  - {T: 280, P: 20 atm, X: {H(s): 1.0, He(s): 0.0}}
+  - {T: 380, P: 5 atm, X: {H(s): 0.0, He(s): 1.0}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -137,3 +137,54 @@ plasma:
   - {T: 300, P: 1 atm, X: {O2: 1.0, O2-: 1e-5, E: 1e-5}}
   - {T: 300, P: 1 atm, X: {E: 1.0}}
   - {T: 3500, P: 10 atm, X: {O2: 1.0, O2-: 2e-5, E: 2e-5}}
+
+debye-huckel-dilute:
+  setup:
+    file: debye-huckel-all.yaml
+    phase: debye-huckel-dilute
+    known-failures: &debye-huckel-failures
+      cv_eq_.+: cv not implemented
+      u_eq_sum_uk_Xk: partialMolarIntEnergies not implemented
+      hk_eq_uk_plus_P_times_vk: partialMolarIntEnergies not implemented
+  states: &debye-huckel-states
+  - {T: 300, P: 1 atm,
+     molalities: {Na+: 9.3549, Cl-: 9.3549, H+: 1.05e-08, OH-: 1.3765e-06,
+                  NaCl(aq): 0.98492, NaOH(aq): 3.8836e-06, NaH3SiO4(aq): 6.8798e-05,
+                  SiO2(aq): 3.0179e-05, H3SiO4-: 1.0231e-06}}
+  - {T: 300, P: 1 atm,
+     molalities: {Na+: 4.1, Cl-: 4.1, H+: 1.05e-07, OH-: 1.3765e-05,
+                  NaCl(aq): 2.2, NaOH(aq): 3.8836e-03}}
+  - {T: 320, P: 1 atm,
+     molalities: {Na+: 9.3549, Cl-: 9.3549, H+: 1.05e-06, OH-: 2.0e-05,
+                  NaCl(aq): 0.98492, NaOH(aq): 3.8836e-06}}
+  - {T: 320, P: 20 atm,
+     molalities: {Na+: 9.3549, Cl-: 9.3549, H+: 1.05e-08, OH-: 1.3765e-06,
+                  NaCl(aq): 0.98492, NaOH(aq): 3.8836e-06}}
+
+debye-huckel-B-dot-ak:
+  setup:
+    file: debye-huckel-all.yaml
+    phase: debye-huckel-B-dot-ak
+    known-failures: *debye-huckel-failures
+  states: *debye-huckel-states
+
+debye-huckel-B-dot-a:
+  setup:
+    file: debye-huckel-all.yaml
+    phase: debye-huckel-B-dot-a
+    known-failures: *debye-huckel-failures
+  states: *debye-huckel-states
+
+debye-huckel-pitzer-beta_ij:
+  setup:
+    file: debye-huckel-all.yaml
+    phase: debye-huckel-pitzer-beta_ij
+    known-failures: *debye-huckel-failures
+  states: *debye-huckel-states
+
+debye-huckel-beta_ij:
+  setup:
+    file: debye-huckel-all.yaml
+    phase: debye-huckel-beta_ij
+    known-failures: *debye-huckel-failures
+  states: *debye-huckel-states

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -314,3 +314,15 @@ ideal-solution-VPSS-HKFT:
   - {T: 360, P: 5 atm, X: {H2O(L): 0.6, Na+: 0.2, Cl-: 0.2}}
   - {T: 330, P: 10 atm, X: {H2O(L): 0.9, Na+: 0.05, Cl-: 0.05, H+: 1e-7, OH-: 1e-7}}
   - {T: 320, P: 1 atm, X: {H2O(L): 1.0, Na+: 0.01, Cl-: 0.05, H+: 0.04}}
+
+Redlich-Kister:
+  setup:
+    file: thermo-models.yaml
+    phase: Redlich-Kister-LiC6
+    known-failures:
+      c[vp]_eq_.+: "Implementation of cv is incorrect. See GitHub Issue #1320"
+  states:
+  - {T: 300, P: 1 atm, X: {Li(C6): 0.85, V(C6): 0.15}}
+  - {T: 440, P: 1 atm, X: {Li(C6): 0.75, V(C6): 0.25}}
+  - {T: 350, P: 10 atm, X: {Li(C6): 1.0, V(C6): 0.0}}
+  - {T: 350, P: 10 atm, X: {Li(C6): 0.0, V(C6): 1.0}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -258,3 +258,20 @@ ideal-edge:
   states:
   - {T: 300, P: 1 atm}
   - {T: 900, P: 20 atm}
+
+liquid-water-IAPWS95:
+  setup:
+    file: liquidvapor.yaml
+    phase: liquid-water-IAPWS95
+    known-failures:
+      h_eq_u_plus_Pv: "Error in internal energy calculation. See GitHub Issue #1315"
+      hk_eq_uk_plus_P_times_vk:
+        "Error in internal energy calculation. See GitHub Issue #1315"
+      cv_eq_dudT: "Error in internal energy calculation. See GitHub Issue #1315"
+      hk0_eq_uk0_plus_p_vk0:
+        "Error in internal energy calculation. See GitHub Issue #1315"
+      log_standard_concentrations: Not implemented
+  states:
+  - {T: 300, P: 1 atm}
+  - {T: 360, P: 1 atm}
+  - {T: 450, P: 100 atm}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -283,3 +283,31 @@ liquid-water-IAPWS95:
   - {T: 300, P: 1 atm}
   - {T: 360, P: 1 atm}
   - {T: 450, P: 100 atm}
+
+ideal-solution-VPSS-simple:
+  setup:
+    file: IdealSolidSolnPhaseExample.yaml
+    phase: VpssSolidSolutionExample
+    known-failures:
+      cv_eq_dudT: "Implementation of cv is incorrect. See GitHub Issue #1317"
+      cv_eq_dsdT_const_v_times_T:
+        "Implementation of cv is incorrect. See GitHub Issue #1317"
+  states:
+  - {T: 300, P: 1 atm, X: {C2H2-graph: 0.2, C-graph: 0.5, H2-solute: 0.3}}
+  - {T: 400, P: 1 atm, X: {C2H2-graph: 1.0}}
+  - {T: 500, P: 10 atm, X: {C-graph: 0.6, H2-solute: 0.4}}
+
+ideal-solution-VPSS-HKFT:
+  setup:
+    file: pdss_hkft.yaml
+    known-failures:
+      cv_eq_dudT: "Implementation of cv is incorrect. See GitHub Issue #1317"
+      cv_eq_dsdT_const_v_times_T:
+        "Implementation of cv is incorrect. See GitHub Issue #1317"
+      dsdP_const_T_eq_minus_dV_dT_const_P:
+        "Implementation of cv is incorrect. See GitHub Issue #1318"
+  states:
+  - {T: 300, P: 1 atm, X: {H2O(L): 0.9, Na+: 0.05, Cl-: 0.05, H+: 1e-7, OH-: 1e-7}}
+  - {T: 360, P: 5 atm, X: {H2O(L): 0.6, Na+: 0.2, Cl-: 0.2}}
+  - {T: 330, P: 10 atm, X: {H2O(L): 0.9, Na+: 0.05, Cl-: 0.05, H+: 1e-7, OH-: 1e-7}}
+  - {T: 320, P: 1 atm, X: {H2O(L): 1.0, Na+: 0.01, Cl-: 0.05, H+: 0.04}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -32,7 +32,7 @@ ideal-molal-solution:
     known-failures:
       g_eq_h_minus_Ts:
         "Implementations of g and s are inconsistent. See GitHub Issue #1300"
-      gk_eq_hk_minus_T_times_sk:
+      gk_eq_hk_minus_T_sk:
         "Implementations of g and s are inconsistent. See GitHub Issue #1300"
       cv_eq_.+: cv not implemented
       cp_eq_dsdT_const_p_times_T:
@@ -78,8 +78,8 @@ binary-solution-tabulated:
       v_eq_sum_vk_Xk: "Inconsistent results. See GitHub Issue #1302"
       h_eq_sum_hk_Xk: "Inconsistent results. See GitHub Issue #1302"
       s_eq_sum_sk_Xk: "Problems near composition limit. See GitHub Issue #1303"
-      gk_eq_hk_minus_T_times_sk: "Problems near composition limit. See GitHub Issue #1303"
-      gk0_eq_hk0_minus_T_times_sk0/[34]:
+      gk_eq_hk_minus_T_sk: "Problems near composition limit. See GitHub Issue #1303"
+      gk0_eq_hk0_minus_T_sk0/[34]:
         "Problems near composition limit. See GitHub Issue #1303"
       chem_potentials_to_activities/3:
         "Problems near composition limit. See GitHub Issue #1303"
@@ -199,7 +199,7 @@ lattice:
     phase: Li7Si3-interstitial
     known-failures:
       _sum_.+_Xk: "Implementation is wrong. See GitHub Issue #1309"
-      gk_eq_hk_minus_T_times_sk: "Implementation is wrong. See GitHub Issue #1309"
+      gk_eq_hk_minus_T_sk: "Implementation is wrong. See GitHub Issue #1309"
       standard_gibbs_nondim: "Implementation is wrong. See GitHub Issue #1309"
       chem_potentials_to_activities: "Implementation is wrong. See GitHub Issue #1309"
   states:
@@ -214,7 +214,7 @@ compound-lattice:
     known-failures:
       _sum_.+_Xk: "LatticePhase implementation is wrong. See GitHub Issue #1309"
       h_eq_u_plus_Pv: "Implementation is inconsistent. See GitHub Issue #1310"
-      gk_eq_hk_minus_T_times_sk: "Implementation is inconsistent. See GitHub Issue #1310"
+      gk_eq_hk_minus_T_sk: "Implementation is inconsistent. See GitHub Issue #1310"
       chem_potentials_to_activities:
         "LatticePhase implementation is wrong. See GitHub Issue #1309"
       activity_coeffs: "See GitHub Issue #1309"
@@ -239,7 +239,7 @@ ideal-surface:
     atol_v: 1e-7
     known-failures:
       h_eq_u_plus_Pv: "Definition of volume is unclear. See GitHub Issue #1312"
-      gk_eq_hk_minus_T_times_sk:
+      gk_eq_hk_minus_T_sk:
         "Implementation of s_k is incorrect. See GitHub Issue #1313"
       s_eq_sum_sk_Xk:
         "Implementation of s_k is incorrect. See GitHub Issue #1313"
@@ -273,7 +273,7 @@ liquid-water-IAPWS95:
     rtol_fd: 5e-3  # Limited agreement for Maxwell relations
     known-failures:
       h_eq_u_plus_Pv: "Error in internal energy calculation. See GitHub Issue #1315"
-      hk_eq_uk_plus_P_times_vk:
+      hk_eq_uk_plus_P_vk:
         "Error in internal energy calculation. See GitHub Issue #1315"
       cv_eq_dudT: "Error in internal energy calculation. See GitHub Issue #1315"
       hk0_eq_uk0_plus_p_vk0:

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -1,0 +1,15 @@
+# Parameters for test cases defined in test/thermo/consistency.cpp
+
+ideal-gas-h2o2:
+  input: {file: h2o2.yaml}
+  states:
+  - {T: 300, P: 101325, X: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
+  - {T: 300, P: 101325, Y: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
+  - {T: 400, density: 5 g/cm^3 , X: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
+
+redlich-kwong:
+  input: {file: co2_RK_example.yaml}
+  states:
+  - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
+  - {T: 300, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
+  - {T: 600, P: 200 bar, X: {CO2: 0.4, CH4: 0.2, H2O: 0.4}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -8,14 +8,16 @@ ideal-gas-h2o2:
   - {T: 400, density: 5 g/cm^3 , X: {H2: 0.1, O2: 0.7, H2O2: 0.1}}
 
 redlich-kwong:
-  setup: {file: co2_RK_example.yaml}
+  setup:
+    file: co2_RK_example.yaml
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
   - {T: 600, P: 200 bar, X: {CO2: 0.4, CH4: 0.2, H2O: 0.4}}
 
 peng-robinson:
-  setup: {file: co2_PR_example.yaml}
+  setup:
+    file: co2_PR_example.yaml
   states:
   - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
@@ -106,6 +108,7 @@ nitrogen-purefluid:
   setup:
     file: liquidvapor.yaml
     phase: nitrogen
+    rtol_fd: 1e-5
   states:
   - {T: 300, P: 1 atm}
   - {T: 70, P: 1 atm}
@@ -116,6 +119,8 @@ plasma:
   setup:
     file: oxygen-plasma.yaml
     phase: discretized-electron-energy-plasma
+    known-failures:
+      cp_eq_dhdT/1: Test does not account for distinct electron temperature
   states:
   - {T: 300, P: 1 atm, X: {O2: 1.0, O2-: 1e-5, E: 1e-5}}
   - {T: 300, P: 1 atm, X: {E: 1.0}}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -32,6 +32,7 @@ ideal-molal-solution:
         "Implementations of g and s are inconsistent. See GitHub Issue #1300"
       gk_eq_hk_minus_T_times_sk:
         "Implementations of g and s are inconsistent. See GitHub Issue #1300"
+      cv_eq_dudT: cv not implemented
   states:
   - {T: 300, P: 101325, molalities: {CH4(aq): 0.01, H2S(aq): 0.03, CO2(aq): 0.1}}
   - {T: 300, P: 2 atm, molalities: {CH4(aq): 0.1, H2S(aq): 0.01, CO2(aq): 0.1}}
@@ -109,6 +110,8 @@ nitrogen-purefluid:
     file: liquidvapor.yaml
     phase: nitrogen
     rtol_fd: 1e-5
+    known-failures:
+      cv_eq_dudT/3: cv not defined in two-phase region
   states:
   - {T: 300, P: 1 atm}
   - {T: 70, P: 1 atm}
@@ -121,6 +124,7 @@ plasma:
     phase: discretized-electron-energy-plasma
     known-failures:
       cp_eq_dhdT/1: Test does not account for distinct electron temperature
+      cv_eq_dudT/1: Test does not account for distinct electron temperature
   states:
   - {T: 300, P: 1 atm, X: {O2: 1.0, O2-: 1e-5, E: 1e-5}}
   - {T: 300, P: 1 atm, X: {E: 1.0}}

--- a/test/thermo/BinarySolutionTabulatedThermo_Test.cpp
+++ b/test/thermo/BinarySolutionTabulatedThermo_Test.cpp
@@ -22,12 +22,6 @@ public:
     std::unique_ptr<ThermoPhase> test_phase;
 };
 
-TEST_F(BinarySolutionTabulatedThermo_Test,construct_from_yaml)
-{
-    BinarySolutionTabulatedThermo* BinarySolutionTabulatedThermo_phase = dynamic_cast<BinarySolutionTabulatedThermo*>(test_phase.get());
-    EXPECT_TRUE(BinarySolutionTabulatedThermo_phase != NULL);
-}
-
 TEST_F(BinarySolutionTabulatedThermo_Test,interp_h)
 {
     test_phase->setState_TP(298.15, 101325.);
@@ -120,22 +114,6 @@ TEST_F(BinarySolutionTabulatedThermo_Test,chem_potentials)
     }
 }
 
-
-TEST_F(BinarySolutionTabulatedThermo_Test,mole_fractions)
-{
-    test_phase->setState_TP(298.15,101325.);
-    double xmin = 0.10;
-    double xmax = 0.75;
-    int numSteps= 9;
-    double dx = (xmax-xmin)/(numSteps-1);
-    vector_fp molefracs(2);
-    for (int i = 0; i < numSteps; ++i)
-    {
-        set_defect_X(xmin + i*dx);
-        test_phase->getMoleFractions(&molefracs[0]);
-        EXPECT_NEAR(xmin + i*dx, molefracs[0], 1.e-6);
-    }
-}
 
 TEST_F(BinarySolutionTabulatedThermo_Test,partialMolarEntropies)
 {

--- a/test/thermo/MaskellSolidSolnPhase_Test.cpp
+++ b/test/thermo/MaskellSolidSolnPhase_Test.cpp
@@ -81,56 +81,11 @@ TEST_F(MaskellSolidSolnPhase_Test, partialMolarVolumes)
     EXPECT_EQ(0.01, pmv[1]);
 }
 
-TEST_F(MaskellSolidSolnPhase_Test, activityCoeffs)
-{
-    setup("MaskellSolidSolnPhase_valid.yaml");
-    test_phase->setState_TP(298., 1.);
-    set_r(0.5);
-
-    // Test that mu0 + RT log(activityCoeff * MoleFrac) == mu
-    const double RT = GasConstant * 298.;
-    vector_fp mu0(2);
-    vector_fp activityCoeffs(2);
-    vector_fp chemPotentials(2);
-    for(int i=0; i < 9; ++i)
-    {
-        const double r = 0.1 * (i+1);
-        set_r(r);
-        test_phase->getChemPotentials(&chemPotentials[0]);
-        test_phase->getActivityCoefficients(&activityCoeffs[0]);
-        test_phase->getStandardChemPotentials(&mu0[0]);
-        EXPECT_NEAR(chemPotentials[0], mu0[0] + RT*std::log(activityCoeffs[0] * r), 1.e-6);
-        EXPECT_NEAR(chemPotentials[1], mu0[1] + RT*std::log(activityCoeffs[1] * (1-r)), 1.e-6);
-    }
-}
-
 TEST_F(MaskellSolidSolnPhase_Test, standardConcentrations)
 {
     setup("MaskellSolidSolnPhase_valid.yaml");
     EXPECT_DOUBLE_EQ(1.0, test_phase->standardConcentration(0));
     EXPECT_DOUBLE_EQ(1.0, test_phase->standardConcentration(1));
-}
-
-TEST_F(MaskellSolidSolnPhase_Test, activityConcentrations)
-{
-    setup("MaskellSolidSolnPhase_valid.yaml");
-
-    // Check to make sure activityConcentration_i == standardConcentration_i * gamma_i * X_i
-    vector_fp standardConcs(2);
-    vector_fp activityCoeffs(2);
-    vector_fp activityConcentrations(2);
-    for(int i=0; i < 9; ++i)
-    {
-        const double r = 0.1 * (i+1);
-        set_r(r);
-        test_phase->getActivityCoefficients(&activityCoeffs[0]);
-        standardConcs[0] = test_phase->standardConcentration(0);
-        standardConcs[1] = test_phase->standardConcentration(1);
-        test_phase->getActivityConcentrations(&activityConcentrations[0]);
-
-        EXPECT_NEAR(standardConcs[0] * r * activityCoeffs[0], activityConcentrations[0], 1.e-6);
-        EXPECT_NEAR(standardConcs[1] * (1-r) * activityCoeffs[1], activityConcentrations[1], 1.e-6);
-    }
 }
 
 TEST_F(MaskellSolidSolnPhase_Test, fromScratch) {

--- a/test/thermo/RedlichKisterTest.cpp
+++ b/test/thermo/RedlichKisterTest.cpp
@@ -40,13 +40,6 @@ public:
     std::unique_ptr<ThermoPhase> test_phase;
 };
 
-TEST_F(RedlichKister_Test, construct_from_file)
-{
-    setup();
-    RedlichKisterVPSSTP* redlich_kister_phase = dynamic_cast<RedlichKisterVPSSTP*>(test_phase.get());
-    ASSERT_TRUE(redlich_kister_phase != NULL);
-}
-
 TEST_F(RedlichKister_Test, chem_potentials)
 {
     setup();
@@ -96,64 +89,11 @@ TEST_F(RedlichKister_Test, dlnActivities)
     }
 }
 
-TEST_F(RedlichKister_Test, activityCoeffs)
-{
-    setup();
-    test_phase->setState_TP(298., 1.);
-
-    // Test that mu0 + RT log(activityCoeff * MoleFrac) == mu
-    const double RT = GasConstant * 298.;
-    vector_fp mu0(2);
-    vector_fp activityCoeffs(2);
-    vector_fp chemPotentials(2);
-    double xmin = 0.6;
-    double xmax = 0.9;
-    int numSteps = 9;
-    double dx = (xmax-xmin)/(numSteps-1);
-
-    for(int i=0; i < numSteps; ++i)
-    {
-        const double r = xmin + i*dx;
-        set_r(r);
-        test_phase->getChemPotentials(&chemPotentials[0]);
-        test_phase->getActivityCoefficients(&activityCoeffs[0]);
-        test_phase->getStandardChemPotentials(&mu0[0]);
-        EXPECT_NEAR(chemPotentials[0], mu0[0] + RT*std::log(activityCoeffs[0] * r), 1.e-6);
-        EXPECT_NEAR(chemPotentials[1], mu0[1] + RT*std::log(activityCoeffs[1] * (1-r)), 1.e-6);
-    }
-}
-
 TEST_F(RedlichKister_Test, standardConcentrations)
 {
     setup();
     EXPECT_DOUBLE_EQ(1.0, test_phase->standardConcentration(0));
     EXPECT_DOUBLE_EQ(1.0, test_phase->standardConcentration(1));
-}
-
-TEST_F(RedlichKister_Test, activityConcentrations)
-{
-    setup();
-    // Check to make sure activityConcentration_i == standardConcentration_i * gamma_i * X_i
-    vector_fp standardConcs(2);
-    vector_fp activityCoeffs(2);
-    vector_fp activityConcentrations(2);
-    double xmin = 0.6;
-    double xmax = 0.9;
-    int numSteps = 9;
-    double dx = (xmax-xmin)/(numSteps-1);
-
-    for(int i=0; i < 9; ++i)
-    {
-        const double r = xmin + i*dx;
-        set_r(r);
-        test_phase->getActivityCoefficients(&activityCoeffs[0]);
-        standardConcs[0] = test_phase->standardConcentration(0);
-        standardConcs[1] = test_phase->standardConcentration(1);
-        test_phase->getActivityConcentrations(&activityConcentrations[0]);
-
-        EXPECT_NEAR(standardConcs[0] * r * activityCoeffs[0], activityConcentrations[0], 1.e-6);
-        EXPECT_NEAR(standardConcs[1] * (1-r) * activityCoeffs[1], activityConcentrations[1], 1.e-6);
-    }
 }
 
 TEST_F(RedlichKister_Test, fromScratch)

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -44,6 +44,7 @@ public:
             cache[key].reset(newPhase(key.first, key.second));
         }
         atol = setup.getDouble("atol", 1e-5);
+        atol_v = setup.getDouble("atol_v", 1e-11);
 
         phase = cache[key];
         phase->setState(state);
@@ -70,7 +71,7 @@ public:
     shared_ptr<ThermoPhase> phase;
     size_t nsp;
     double T, p;
-    double atol;
+    double atol, atol_v;
 };
 
 map<pair<string, string>, shared_ptr<ThermoPhase>> TestConsistency::cache = {};
@@ -143,7 +144,7 @@ TEST_P(TestConsistency, v_eq_sum_vk_Xk)
 {
     vector_fp vk(nsp);
     phase->getPartialMolarVolumes(vk.data());
-    EXPECT_NEAR(phase->molarVolume(), phase->mean_X(vk), atol);
+    EXPECT_NEAR(phase->molarVolume(), phase->mean_X(vk), atol_v);
 }
 
 INSTANTIATE_TEST_SUITE_P(IdealGas, TestConsistency,
@@ -180,6 +181,12 @@ INSTANTIATE_TEST_SUITE_P(IdealSolidSolnPhase2, TestConsistency,
     testing::Combine(
         testing::Values(getSetup("ideal-condensed-2")),
         testing::ValuesIn(getStates("ideal-condensed-2")))
+);
+
+INSTANTIATE_TEST_SUITE_P(BinarySolutionTabulated, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("binary-solution-tabulated")),
+        testing::ValuesIn(getStates("binary-solution-tabulated")))
 );
 
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -517,4 +517,11 @@ INSTANTIATE_TEST_SUITE_P(IdealEdge, TestConsistency,
         testing::ValuesIn(getStates("ideal-edge")))
 );
 
+INSTANTIATE_TEST_SUITE_P(LiquidWaterIapws95, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("liquid-water-IAPWS95")),
+        testing::ValuesIn(getStates("liquid-water-IAPWS95")))
+);
+
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -100,9 +100,13 @@ TEST_P(TestConsistency, g_eq_h_minus_Ts) {
 TEST_P(TestConsistency, hk_eq_uk_plus_P_times_vk)
 {
     vector_fp hk(nsp), uk(nsp), vk(nsp);
-    phase->getPartialMolarEnthalpies(hk.data());
-    phase->getPartialMolarIntEnergies(uk.data());
-    phase->getPartialMolarVolumes(vk.data());
+    try {
+        phase->getPartialMolarEnthalpies(hk.data());
+        phase->getPartialMolarIntEnergies(uk.data());
+        phase->getPartialMolarVolumes(vk.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     for (size_t k = 0; k < nsp; k++) {
         EXPECT_NEAR(hk[k], uk[k] + p * vk[k], atol) << "k = " << k;
     }
@@ -111,9 +115,13 @@ TEST_P(TestConsistency, hk_eq_uk_plus_P_times_vk)
 TEST_P(TestConsistency, gk_eq_hk_minus_T_times_sk)
 {
     vector_fp gk(nsp), hk(nsp), sk(nsp);
-    phase->getChemPotentials(gk.data());
-    phase->getPartialMolarEnthalpies(hk.data());
-    phase->getPartialMolarEntropies(sk.data());
+    try {
+        phase->getChemPotentials(gk.data());
+        phase->getPartialMolarEnthalpies(hk.data());
+        phase->getPartialMolarEntropies(sk.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     for (size_t k = 0; k < nsp; k++) {
         EXPECT_NEAR(gk[k], hk[k] - T * sk[k], atol) << "k = " << k;
     }
@@ -122,42 +130,66 @@ TEST_P(TestConsistency, gk_eq_hk_minus_T_times_sk)
 TEST_P(TestConsistency, h_eq_sum_hk_Xk)
 {
     vector_fp hk(nsp);
-    phase->getPartialMolarEnthalpies(hk.data());
+    try {
+        phase->getPartialMolarEnthalpies(hk.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     EXPECT_NEAR(phase->enthalpy_mole(), phase->mean_X(hk), atol);
 }
 
 TEST_P(TestConsistency, u_eq_sum_uk_Xk)
 {
     vector_fp uk(nsp);
-    phase->getPartialMolarIntEnergies(uk.data());
+    try {
+        phase->getPartialMolarIntEnergies(uk.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     EXPECT_NEAR(phase->intEnergy_mole(), phase->mean_X(uk), atol);
 }
 
 TEST_P(TestConsistency, g_eq_sum_gk_Xk)
 {
     vector_fp gk(nsp);
-    phase->getChemPotentials(gk.data());
+    try {
+        phase->getChemPotentials(gk.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     EXPECT_NEAR(phase->gibbs_mole(), phase->mean_X(gk), atol);
 }
 
 TEST_P(TestConsistency, s_eq_sum_sk_Xk)
 {
     vector_fp sk(nsp);
-    phase->getPartialMolarEntropies(sk.data());
+    try {
+        phase->getPartialMolarEntropies(sk.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     EXPECT_NEAR(phase->entropy_mole(), phase->mean_X(sk), atol);
 }
 
 TEST_P(TestConsistency, v_eq_sum_vk_Xk)
 {
     vector_fp vk(nsp);
-    phase->getPartialMolarVolumes(vk.data());
+    try {
+        phase->getPartialMolarVolumes(vk.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     EXPECT_NEAR(phase->molarVolume(), phase->mean_X(vk), atol_v);
 }
 
 TEST_P(TestConsistency, cp_eq_sum_cpk_Xk)
 {
     vector_fp cpk(nsp);
-    phase->getPartialMolarCp(cpk.data());
+    try {
+        phase->getPartialMolarCp(cpk.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     EXPECT_NEAR(phase->cp_mole(), phase->mean_X(cpk), atol);
 }
 
@@ -228,9 +260,13 @@ TEST_P(TestConsistency, cv_eq_dsdT_const_v_times_T)
 TEST_P(TestConsistency, hk0_eq_uk0_plus_p_vk0)
 {
     vector_fp h0(nsp), u0(nsp), v0(nsp);
-    phase->getEnthalpy_RT(h0.data());
-    phase->getIntEnergy_RT(u0.data());
-    phase->getStandardVolumes(v0.data());
+    try {
+        phase->getEnthalpy_RT(h0.data());
+        phase->getIntEnergy_RT(u0.data());
+        phase->getStandardVolumes(v0.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     double RT = phase->RT();
     for (size_t k = 0; k < nsp; k++) {
         EXPECT_NEAR(h0[k] * RT, u0[k] * RT + p * v0[k], atol) << "k = " << k;
@@ -240,9 +276,13 @@ TEST_P(TestConsistency, hk0_eq_uk0_plus_p_vk0)
 TEST_P(TestConsistency, gk0_eq_hk0_minus_T_sk0)
 {
     vector_fp g0(nsp), h0(nsp), s0(nsp);
-    phase->getEnthalpy_RT(h0.data());
-    phase->getGibbs_RT(g0.data());
-    phase->getEntropy_R(s0.data());
+    try {
+        phase->getEnthalpy_RT(h0.data());
+        phase->getGibbs_RT(g0.data());
+        phase->getEntropy_R(s0.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     double RT = phase->RT();
     for (size_t k = 0; k < nsp; k++) {
         EXPECT_NEAR(g0[k] * RT ,
@@ -253,8 +293,12 @@ TEST_P(TestConsistency, gk0_eq_hk0_minus_T_sk0)
 TEST_P(TestConsistency, cpk0_eq_dhk0dT)
 {
     vector_fp h1(nsp), h2(nsp), cp1(nsp), cp2(nsp);
-    phase->getEnthalpy_RT(h1.data());
-    phase->getCp_R(cp1.data());
+    try {
+        phase->getEnthalpy_RT(h1.data());
+        phase->getCp_R(cp1.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     double T1 = phase->temperature();
     double dT = 1e-5 * phase->temperature();
     phase->setState_TP(T1 + dT, phase->pressure());
@@ -271,8 +315,12 @@ TEST_P(TestConsistency, cpk0_eq_dhk0dT)
 TEST_P(TestConsistency, standard_gibbs_nondim)
 {
     vector_fp g0_RT(nsp), mu0(nsp);
-    phase->getGibbs_RT(g0_RT.data());
-    phase->getStandardChemPotentials(mu0.data());
+    try {
+        phase->getGibbs_RT(g0_RT.data());
+        phase->getStandardChemPotentials(mu0.data());
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     double RT = phase->RT();
     for (size_t k = 0; k < nsp; k++) {
         EXPECT_NEAR(g0_RT[k] * RT , mu0[k], atol);

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -99,7 +99,7 @@ TEST_P(TestConsistency, g_eq_h_minus_Ts) {
     EXPECT_NEAR(g, h - T * s, atol);
 }
 
-TEST_P(TestConsistency, hk_eq_uk_plus_P_times_vk)
+TEST_P(TestConsistency, hk_eq_uk_plus_P_vk)
 {
     vector_fp hk(nsp), uk(nsp), vk(nsp);
     try {
@@ -114,7 +114,7 @@ TEST_P(TestConsistency, hk_eq_uk_plus_P_times_vk)
     }
 }
 
-TEST_P(TestConsistency, gk_eq_hk_minus_T_times_sk)
+TEST_P(TestConsistency, gk_eq_hk_minus_T_sk)
 {
     vector_fp gk(nsp), hk(nsp), sk(nsp);
     try {
@@ -205,7 +205,7 @@ TEST_P(TestConsistency, cp_eq_dhdT)
     double h2 = phase->enthalpy_mole();
     double cp2 = phase->cp_mole();
     double cp_mid = 0.5 * (cp1 + cp2);
-    double cp_fd = (h2 - h1)/dT;
+    double cp_fd = (h2 - h1) / dT;
     EXPECT_NEAR(cp_fd, cp_mid, max({rtol_fd * cp_mid, rtol_fd * cp_fd, atol}));
 }
 
@@ -223,7 +223,7 @@ TEST_P(TestConsistency, cv_eq_dudT)
     double u2 = phase->intEnergy_mole();
     double cv2 = phase->cv_mole();
     double cv_mid = 0.5 * (cv1 + cv2);
-    double cv_fd = (u2 - u1)/dT;
+    double cv_fd = (u2 - u1) / dT;
     EXPECT_NEAR(cv_fd, cv_mid, max({rtol_fd * cv_mid, rtol_fd * cv_fd, atol}));
 }
 
@@ -362,7 +362,7 @@ TEST_P(TestConsistency, standard_gibbs_nondim)
         GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
     }
     for (size_t k = 0; k < nsp; k++) {
-        EXPECT_NEAR(g0_RT[k] * RT , mu0[k], atol);
+        EXPECT_NEAR(g0_RT[k] * RT , mu0[k], atol) << "k = " << k;
     }
 }
 

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -189,4 +189,10 @@ INSTANTIATE_TEST_SUITE_P(BinarySolutionTabulated, TestConsistency,
         testing::ValuesIn(getStates("binary-solution-tabulated")))
 );
 
+INSTANTIATE_TEST_SUITE_P(ElectronCloud, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("electron-cloud")),
+        testing::ValuesIn(getStates("electron-cloud")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -197,8 +197,13 @@ TEST_P(TestConsistency, cp_eq_sum_cpk_Xk)
 
 TEST_P(TestConsistency, cp_eq_dhdT)
 {
-    double h1 = phase->enthalpy_mole();
-    double cp1 = phase->cp_mole();
+    double h1, cp1;
+    try {
+        h1 = phase->enthalpy_mole();
+        cp1 = phase->cp_mole();
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     double T1 = phase->temperature();
     double dT = 1e-5 * phase->temperature();
     phase->setState_TP(T1 + dT, phase->pressure());
@@ -211,8 +216,13 @@ TEST_P(TestConsistency, cp_eq_dhdT)
 
 TEST_P(TestConsistency, cv_eq_dudT)
 {
-    double u1 = phase->intEnergy_mole();
-    double cv1 = phase->cv_mole();
+    double u1, cv1;
+    try {
+        u1 = phase->intEnergy_mole();
+        cv1 = phase->cv_mole();
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     double T1 = phase->temperature();
     double dT = 1e-5 * phase->temperature();
     if (phase->isCompressible()) {
@@ -229,8 +239,13 @@ TEST_P(TestConsistency, cv_eq_dudT)
 
 TEST_P(TestConsistency, cp_eq_dsdT_const_p_times_T)
 {
-    double s1 = phase->entropy_mole();
-    double cp1 = phase->cp_mole();
+    double s1, cp1;
+    try {
+        s1 = phase->entropy_mole();
+        cp1 = phase->cp_mole();
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     double T1 = phase->temperature();
     double dT = 1e-4 * phase->temperature();
     phase->setState_TP(T1 + dT, phase->pressure());
@@ -243,8 +258,13 @@ TEST_P(TestConsistency, cp_eq_dsdT_const_p_times_T)
 
 TEST_P(TestConsistency, cv_eq_dsdT_const_v_times_T)
 {
-    double s1 = phase->entropy_mole();
-    double cv1 = phase->cv_mole();
+    double s1, cv1;
+    try {
+        s1 = phase->entropy_mole();
+        cv1 = phase->cv_mole();
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
     double T1 = phase->temperature();
     double dT = 1e-4 * phase->temperature();
     if (phase->isCompressible()) {
@@ -634,6 +654,12 @@ INSTANTIATE_TEST_SUITE_P(RedlichKister, TestConsistency,
     testing::Combine(
         testing::Values(getSetup("Redlich-Kister")),
         testing::ValuesIn(getStates("Redlich-Kister")))
+);
+
+INSTANTIATE_TEST_SUITE_P(MaskellSolidSolution, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("Maskell-solid-solution")),
+        testing::ValuesIn(getStates("Maskell-solid-solution")))
 );
 
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -188,6 +188,38 @@ TEST_P(TestConsistency, cv_eq_dudT)
     EXPECT_NEAR(cv_fd, cv_mid, max({rtol_fd * cv_mid, rtol_fd * cv_fd, atol}));
 }
 
+TEST_P(TestConsistency, cp_eq_dsdT_const_p_times_T)
+{
+    double s1 = phase->entropy_mole();
+    double cp1 = phase->cp_mole();
+    double T1 = phase->temperature();
+    double dT = 1e-4 * phase->temperature();
+    phase->setState_TP(T1 + dT, phase->pressure());
+    double s2 = phase->entropy_mole();
+    double cp2 = phase->cp_mole();
+    double cp_mid = 0.5 * (cp1 + cp2);
+    double cp_fd = (T1 + dT/2) * (s2 - s1) / dT;
+    EXPECT_NEAR(cp_fd, cp_mid, max({rtol_fd * cp_mid, rtol_fd * cp_fd, atol}));
+}
+
+TEST_P(TestConsistency, cv_eq_dsdT_const_v_times_T)
+{
+    double s1 = phase->entropy_mole();
+    double cv1 = phase->cv_mole();
+    double T1 = phase->temperature();
+    double dT = 1e-4 * phase->temperature();
+    if (phase->isCompressible()) {
+        phase->setState_TR(T1 + dT, phase->density());
+    } else {
+        phase->setTemperature(T1 + dT);
+    }
+    double s2 = phase->entropy_mole();
+    double cv2 = phase->cv_mole();
+    double cv_mid = 0.5 * (cv1 + cv2);
+    double cv_fd = (T1 + dT/2) * (s2 - s1) / dT;
+    EXPECT_NEAR(cv_fd, cv_mid, max({rtol_fd * cv_mid, rtol_fd * cv_fd, atol}));
+}
+
 INSTANTIATE_TEST_SUITE_P(IdealGas, TestConsistency,
     testing::Combine(
         testing::Values(getSetup("ideal-gas-h2o2")),

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -170,4 +170,16 @@ INSTANTIATE_TEST_SUITE_P(IdealMolalSolution, TestConsistency,
         testing::ValuesIn(getStates("ideal-molal-solution")))
 );
 
+INSTANTIATE_TEST_SUITE_P(IdealSolidSolnPhase1, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("ideal-condensed-1")),
+        testing::ValuesIn(getStates("ideal-condensed-1")))
+);
+
+INSTANTIATE_TEST_SUITE_P(IdealSolidSolnPhase2, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("ideal-condensed-2")),
+        testing::ValuesIn(getStates("ideal-condensed-2")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -499,4 +499,10 @@ INSTANTIATE_TEST_SUITE_P(CompoundLattice, TestConsistency,
         testing::ValuesIn(getStates("compound-lattice")))
 );
 
+INSTANTIATE_TEST_SUITE_P(FixedStoichiometry, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("fixed-stoichiometry")),
+        testing::ValuesIn(getStates("fixed-stoichiometry")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -505,4 +505,16 @@ INSTANTIATE_TEST_SUITE_P(FixedStoichiometry, TestConsistency,
         testing::ValuesIn(getStates("fixed-stoichiometry")))
 );
 
+INSTANTIATE_TEST_SUITE_P(IdealSurface, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("ideal-surface")),
+        testing::ValuesIn(getStates("ideal-surface")))
+);
+
+INSTANTIATE_TEST_SUITE_P(IdealEdge, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("ideal-edge")),
+        testing::ValuesIn(getStates("ideal-edge")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -163,6 +163,24 @@ TEST_P(TestConsistency, cp_eq_dhdT)
     EXPECT_NEAR(cp_fd, cp_mid, max({rtol_fd * cp_mid, rtol_fd * cp_fd, atol}));
 }
 
+TEST_P(TestConsistency, cv_eq_dudT)
+{
+    double u1 = phase->intEnergy_mole();
+    double cv1 = phase->cv_mole();
+    double T1 = phase->temperature();
+    double dT = 1e-5 * phase->temperature();
+    if (phase->isCompressible()) {
+        phase->setState_TR(T1 + dT, phase->density());
+    } else {
+        phase->setTemperature(T1 + dT);
+    }
+    double u2 = phase->intEnergy_mole();
+    double cv2 = phase->cv_mole();
+    double cv_mid = 0.5 * (cv1 + cv2);
+    double cv_fd = (u2 - u1)/dT;
+    EXPECT_NEAR(cv_fd, cv_mid, max({rtol_fd * cv_mid, rtol_fd * cv_fd, atol}));
+}
+
 INSTANTIATE_TEST_SUITE_P(IdealGas, TestConsistency,
     testing::Combine(
         testing::Values(getSetup("ideal-gas-h2o2")),

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -280,4 +280,34 @@ INSTANTIATE_TEST_SUITE_P(PlasmaPhase, TestConsistency,
         testing::ValuesIn(getStates("plasma")))
 );
 
+INSTANTIATE_TEST_SUITE_P(DebyeHuckelDilute, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("debye-huckel-dilute")),
+        testing::ValuesIn(getStates("debye-huckel-dilute")))
+);
+
+INSTANTIATE_TEST_SUITE_P(DebyeHuckel_b_dot_ak, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("debye-huckel-B-dot-ak")),
+        testing::ValuesIn(getStates("debye-huckel-B-dot-ak")))
+);
+
+INSTANTIATE_TEST_SUITE_P(DebyeHuckel_b_dot_a, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("debye-huckel-B-dot-a")),
+        testing::ValuesIn(getStates("debye-huckel-B-dot-a")))
+);
+
+INSTANTIATE_TEST_SUITE_P(DebyeHuckel_pitzer_beta_ij, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("debye-huckel-pitzer-beta_ij")),
+        testing::ValuesIn(getStates("debye-huckel-pitzer-beta_ij")))
+);
+
+INSTANTIATE_TEST_SUITE_P(DebyeHuckel_beta_ij, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("debye-huckel-beta_ij")),
+        testing::ValuesIn(getStates("debye-huckel-beta_ij")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -662,4 +662,10 @@ INSTANTIATE_TEST_SUITE_P(MaskellSolidSolution, TestConsistency,
         testing::ValuesIn(getStates("Maskell-solid-solution")))
 );
 
+INSTANTIATE_TEST_SUITE_P(IonsFromNeutralMolecule, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("ions-from-neutral-molecule")),
+        testing::ValuesIn(getStates("ions-from-neutral-molecule")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -2,6 +2,7 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/Solution.h"
+#include "cantera/base/utilities.h"
 
 using namespace std;
 
@@ -29,11 +30,21 @@ public:
         if (cache.count(key) == 0) {
             cache[key].reset(newPhase(key.first, key.second));
         }
+        atol = inp.getDouble("atol", 1e-5);
+
         phase = cache[key];
         phase->setState(state);
+        nsp = phase->nSpecies();
+        p = phase->pressure();
+        T = phase->temperature();
     }
+
     static map<pair<string, string>, shared_ptr<ThermoPhase>> cache;
+
     shared_ptr<ThermoPhase> phase;
+    size_t nsp;
+    double T, p;
+    double atol;
 };
 
 map<pair<string, string>, shared_ptr<ThermoPhase>> TestConsistency::cache = {};
@@ -42,16 +53,71 @@ TEST_P(TestConsistency, h_eq_u_plus_Pv) {
     double h = phase->enthalpy_mole();
     double u = phase->intEnergy_mole();
     double v = phase->molarVolume();
-    double p = phase->pressure();
-    EXPECT_NEAR(h, u + p*v, 1e-10*p*v);
+    EXPECT_NEAR(h, u + p * v, atol);
 }
 
 TEST_P(TestConsistency, g_eq_h_minus_Ts) {
     double g = phase->gibbs_mole();
     double h = phase->enthalpy_mole();
-    double T = phase->temperature();
     double s = phase->entropy_mole();
-    EXPECT_NEAR(g, h - T*s, 1e-10*T*s);
+    EXPECT_NEAR(g, h - T * s, atol);
+}
+
+TEST_P(TestConsistency, hk_eq_uk_plus_P_times_vk)
+{
+    vector_fp hk(nsp), uk(nsp), vk(nsp);
+    phase->getPartialMolarEnthalpies(hk.data());
+    phase->getPartialMolarIntEnergies(uk.data());
+    phase->getPartialMolarVolumes(vk.data());
+    for (size_t k = 0; k < nsp; k++) {
+        EXPECT_NEAR(hk[k], uk[k] + p * vk[k], atol);
+    }
+}
+
+TEST_P(TestConsistency, gk_eq_hk_minus_T_times_sk)
+{
+    vector_fp gk(nsp), hk(nsp), sk(nsp);
+    phase->getChemPotentials(gk.data());
+    phase->getPartialMolarEnthalpies(hk.data());
+    phase->getPartialMolarEntropies(sk.data());
+    for (size_t k = 0; k < nsp; k++) {
+        EXPECT_NEAR(gk[k], hk[k] - T * sk[k], atol);
+    }
+}
+
+TEST_P(TestConsistency, h_eq_sum_hk_Xk)
+{
+    vector_fp hk(nsp);
+    phase->getPartialMolarEnthalpies(hk.data());
+    EXPECT_NEAR(phase->enthalpy_mole(), phase->mean_X(hk), atol);
+}
+
+TEST_P(TestConsistency, u_eq_sum_uk_Xk)
+{
+    vector_fp uk(nsp);
+    phase->getPartialMolarIntEnergies(uk.data());
+    EXPECT_NEAR(phase->intEnergy_mole(), phase->mean_X(uk), atol);
+}
+
+TEST_P(TestConsistency, g_eq_sum_gk_Xk)
+{
+    vector_fp gk(nsp);
+    phase->getChemPotentials(gk.data());
+    EXPECT_NEAR(phase->gibbs_mole(), phase->mean_X(gk), atol);
+}
+
+TEST_P(TestConsistency, s_eq_sum_sk_Xk)
+{
+    vector_fp sk(nsp);
+    phase->getPartialMolarEntropies(sk.data());
+    EXPECT_NEAR(phase->entropy_mole(), phase->mean_X(sk), atol);
+}
+
+TEST_P(TestConsistency, v_eq_sum_vk_Xk)
+{
+    vector_fp vk(nsp);
+    phase->getPartialMolarVolumes(vk.data());
+    EXPECT_NEAR(phase->molarVolume(), phase->mean_X(vk), atol);
 }
 
 INSTANTIATE_TEST_SUITE_P(IdealGas, TestConsistency,

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -1,0 +1,69 @@
+#include "gtest/gtest.h"
+#include "cantera/thermo/ThermoPhase.h"
+#include "cantera/thermo/ThermoFactory.h"
+#include "cantera/base/Solution.h"
+
+using namespace std;
+
+namespace Cantera
+{
+
+vector<AnyMap> getStates(const string& name) {
+    static AnyMap cases = AnyMap::fromYamlFile("consistency-cases.yaml");
+    return cases[name]["states"].asVector<AnyMap>();
+}
+
+AnyMap getSetup(const string& name) {
+    static AnyMap cases = AnyMap::fromYamlFile("consistency-cases.yaml");
+    return cases[name]["input"].as<AnyMap>();
+}
+
+class TestConsistency : public testing::TestWithParam<std::tuple<AnyMap, AnyMap>>
+{
+public:
+    TestConsistency() {
+        auto param = GetParam();
+        AnyMap inp = get<0>(param);
+        AnyMap state = get<1>(param);
+        pair<string, string> key = {inp["file"].asString(), inp.getString("phase", "")};
+        if (cache.count(key) == 0) {
+            cache[key].reset(newPhase(key.first, key.second));
+        }
+        phase = cache[key];
+        phase->setState(state);
+    }
+    static map<pair<string, string>, shared_ptr<ThermoPhase>> cache;
+    shared_ptr<ThermoPhase> phase;
+};
+
+map<pair<string, string>, shared_ptr<ThermoPhase>> TestConsistency::cache = {};
+
+TEST_P(TestConsistency, h_eq_u_plus_Pv) {
+    double h = phase->enthalpy_mole();
+    double u = phase->intEnergy_mole();
+    double v = phase->molarVolume();
+    double p = phase->pressure();
+    EXPECT_NEAR(h, u + p*v, 1e-10*p*v);
+}
+
+TEST_P(TestConsistency, g_eq_h_minus_Ts) {
+    double g = phase->gibbs_mole();
+    double h = phase->enthalpy_mole();
+    double T = phase->temperature();
+    double s = phase->entropy_mole();
+    EXPECT_NEAR(g, h - T*s, 1e-10*T*s);
+}
+
+INSTANTIATE_TEST_SUITE_P(IdealGas, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("ideal-gas-h2o2")),
+        testing::ValuesIn(getStates("ideal-gas-h2o2")))
+);
+
+INSTANTIATE_TEST_SUITE_P(RedlichKwong, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("redlich-kwong")),
+        testing::ValuesIn(getStates("redlich-kwong")))
+);
+
+}

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -149,6 +149,13 @@ TEST_P(TestConsistency, v_eq_sum_vk_Xk)
     EXPECT_NEAR(phase->molarVolume(), phase->mean_X(vk), atol_v);
 }
 
+TEST_P(TestConsistency, cp_eq_sum_cpk_Xk)
+{
+    vector_fp cpk(nsp);
+    phase->getPartialMolarCp(cpk.data());
+    EXPECT_NEAR(phase->cp_mole(), phase->mean_X(cpk), atol);
+}
+
 TEST_P(TestConsistency, cp_eq_dhdT)
 {
     double h1 = phase->enthalpy_mole();

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -375,4 +375,16 @@ INSTANTIATE_TEST_SUITE_P(Margules, TestConsistency,
         testing::ValuesIn(getStates("margules")))
 );
 
+INSTANTIATE_TEST_SUITE_P(Lattice, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("lattice")),
+        testing::ValuesIn(getStates("lattice")))
+);
+
+INSTANTIATE_TEST_SUITE_P(CompoundLattice, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("compound-lattice")),
+        testing::ValuesIn(getStates("compound-lattice")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -668,4 +668,10 @@ INSTANTIATE_TEST_SUITE_P(IonsFromNeutralMolecule, TestConsistency,
         testing::ValuesIn(getStates("ions-from-neutral-molecule")))
 );
 
+INSTANTIATE_TEST_SUITE_P(HMWSoln, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("HMW-electrolyte")),
+        testing::ValuesIn(getStates("HMW-electrolyte")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -195,4 +195,10 @@ INSTANTIATE_TEST_SUITE_P(ElectronCloud, TestConsistency,
         testing::ValuesIn(getStates("electron-cloud")))
 );
 
+INSTANTIATE_TEST_SUITE_P(NitrogenPureFluid, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("nitrogen-purefluid")),
+        testing::ValuesIn(getStates("nitrogen-purefluid")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -23,11 +23,16 @@ AnyMap getSetup(const string& name) {
 // For more informative output about failing test cases
 std::ostream& operator<<(std::ostream& s, const AnyMap& m)
 {
-    if (m.hasKey("file")) {
+    if (m.hasKey("phase")) {
         s << fmt::format("file: {}, phase: {}",
-                         m["file"].asString(), m.getString("phase", "<default>"));
+                         m["file"].asString(), m["phase"].asString());
+    } else if (m.hasKey("file")) {
+        s << fmt::format("file: {}", m["file"].asString());
     } else {
-        s << "\n" << m.toYamlString();
+        AnyMap out = m;
+        out.setFlowStyle();
+        s << "state: "
+          << boost::algorithm::replace_all_copy(out.toYamlString(), "\n", " ");
     }
     return s;
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -19,6 +19,18 @@ AnyMap getSetup(const string& name) {
     return cases[name]["input"].as<AnyMap>();
 }
 
+// For more informative output about failing test cases
+std::ostream& operator<<(std::ostream& s, const AnyMap& m)
+{
+    if (m.hasKey("file")) {
+        s << fmt::format("file: {}, phase: {}",
+                         m["file"].asString(), m.getString("phase", "<default>"));
+    } else {
+        s << "\n" << m.toYamlString();
+    }
+    return s;
+}
+
 class TestConsistency : public testing::TestWithParam<std::tuple<AnyMap, AnyMap>>
 {
 public:
@@ -70,7 +82,7 @@ TEST_P(TestConsistency, hk_eq_uk_plus_P_times_vk)
     phase->getPartialMolarIntEnergies(uk.data());
     phase->getPartialMolarVolumes(vk.data());
     for (size_t k = 0; k < nsp; k++) {
-        EXPECT_NEAR(hk[k], uk[k] + p * vk[k], atol);
+        EXPECT_NEAR(hk[k], uk[k] + p * vk[k], atol) << "k = " << k;
     }
 }
 
@@ -81,7 +93,7 @@ TEST_P(TestConsistency, gk_eq_hk_minus_T_times_sk)
     phase->getPartialMolarEnthalpies(hk.data());
     phase->getPartialMolarEntropies(sk.data());
     for (size_t k = 0; k < nsp; k++) {
-        EXPECT_NEAR(gk[k], hk[k] - T * sk[k], atol);
+        EXPECT_NEAR(gk[k], hk[k] - T * sk[k], atol) << "k = " << k;
     }
 }
 

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -315,4 +315,10 @@ INSTANTIATE_TEST_SUITE_P(DebyeHuckel_beta_ij, TestConsistency,
         testing::ValuesIn(getStates("debye-huckel-beta_ij")))
 );
 
+INSTANTIATE_TEST_SUITE_P(Margules, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("margules")),
+        testing::ValuesIn(getStates("margules")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -630,4 +630,10 @@ INSTANTIATE_TEST_SUITE_P(IdealSolnVPSS_HKFT, TestConsistency,
         testing::ValuesIn(getStates("ideal-solution-VPSS-HKFT")))
 );
 
+INSTANTIATE_TEST_SUITE_P(RedlichKister, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("Redlich-Kister")),
+        testing::ValuesIn(getStates("Redlich-Kister")))
+);
+
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -563,5 +563,16 @@ INSTANTIATE_TEST_SUITE_P(LiquidWaterIapws95, TestConsistency,
         testing::ValuesIn(getStates("liquid-water-IAPWS95")))
 );
 
+INSTANTIATE_TEST_SUITE_P(IdealSolnVPSS_simple, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("ideal-solution-VPSS-simple")),
+        testing::ValuesIn(getStates("ideal-solution-VPSS-simple")))
+);
+
+INSTANTIATE_TEST_SUITE_P(IdealSolnVPSS_HKFT, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("ideal-solution-VPSS-HKFT")),
+        testing::ValuesIn(getStates("ideal-solution-VPSS-HKFT")))
+);
 
 }

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -201,4 +201,10 @@ INSTANTIATE_TEST_SUITE_P(NitrogenPureFluid, TestConsistency,
         testing::ValuesIn(getStates("nitrogen-purefluid")))
 );
 
+INSTANTIATE_TEST_SUITE_P(PlasmaPhase, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("plasma")),
+        testing::ValuesIn(getStates("plasma")))
+);
+
 }

--- a/test_problems/cathermo/ims/output_blessed.txt
+++ b/test_problems/cathermo/ims/output_blessed.txt
@@ -1,5 +1,5 @@
 molar enthalpy   =      0.013282 J kg-1
-molar intEnergy  =      0.013282 J kg-1
+molar intEnergy  =   -1.5185e+05 J kg-1
 molar entropy    =        93.635 J kg-1 K-1
 molar gibbs      =   -3.8986e+07 J kg-1
 molar Cp         =         28836 J kg-1 K-1


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Introduce a uniform set of thermodynamic consistency tests that can be performed for all thermo models with a minimal amount of code duplication, totaling nearly 2000 distinct unit tests.
- Provide options for skipping certain tests for specific thermo models when there are known failures
- Specific tests are skipped automatically if a method raises a `NotImplementedError`
- Bump the version of Googletest used, which also bumps the minimum version of Visual Studio to 2017 (though the oldest version we can test on is 2019, due to a SCons bug).
- Remove a number of now-redundant ad hoc tests of thermodynamic consistency

I've already uncovered several bugs using these tests, and have created issues for the ones that aren't being resolved as part of this PR (all of which tag this PR).

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Resolves Cantera/enhancements#114

**If applicable, provide an example illustrating new features this pull request is introducing**

All of the configuration for a set of consistency tests is specified in a YAML file, `consistency-tests.yaml`:
```yaml
binary-solution-tabulated:
  setup:
    file: thermo-models.yaml
    phase: graphite-anode
    known-failures:
      g_eq_h_minus_Ts: Inconsistent results when P != 1 atm (states 2 and 3)
      g_eq_sum_gk_Xk: Inconsistent result when P != 1 atm (states 2 and 3)
  states:
  - {T: 300, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
  - {T: 320, P: 1 atm, X: {"Li[anode]": 0.3, "V[anode]": 0.7}}
  - {T: 300, P: 10 atm, X: {"Li[anode]": 0.6, "V[anode]": 0.4}}
  - {T: 300, P: 10 atm, X: {"Li[anode]": 0.0, "V[anode]": 1.0}}
```

And there is just a short block of code to create the parameterized test suite:
```c++
INSTANTIATE_TEST_SUITE_P(BinarySolutionTabulated, TestConsistency,
    testing::Combine(
        testing::Values(getSetup("binary-solution-tabulated")),
        testing::ValuesIn(getStates("binary-solution-tabulated")))
);
```

Which runs a set of different tests for each of the specified state vectors. Failing tests show the information about the particular case that is failing, e.g.:
```
[ RUN      ] BinarySolutionTabulated/TestConsistency.h_eq_sum_hk_Xk/0
[       OK ] BinarySolutionTabulated/TestConsistency.h_eq_sum_hk_Xk/0 (0 ms)
[ RUN      ] BinarySolutionTabulated/TestConsistency.h_eq_sum_hk_Xk/1
[       OK ] BinarySolutionTabulated/TestConsistency.h_eq_sum_hk_Xk/1 (0 ms)
[ RUN      ] BinarySolutionTabulated/TestConsistency.h_eq_sum_hk_Xk/2
[       OK ] BinarySolutionTabulated/TestConsistency.h_eq_sum_hk_Xk/2 (0 ms)
[ RUN      ] BinarySolutionTabulated/TestConsistency.h_eq_sum_hk_Xk/3
test/thermo/consistency.cpp:118: Failure
The difference between phase->enthalpy_mole() and phase->mean_X(hk) is 7.232221142950948, which exceeds atol, where
phase->enthalpy_mole() evaluates to 13068.183201924798,
phase->mean_X(hk) evaluates to 13060.950980781847, and
atol evaluates to 1.0000000000000001e-05.
[  FAILED  ] BinarySolutionTabulated/TestConsistency.h_eq_sum_hk_Xk/3, where GetParam() = (file: thermo-models.yaml,
phase: graphite-anode, state: {T: 300, P: 10 atm, X: {Li[anode]: 0.0, V[anode]: 1.0}}) (0 ms)
```


<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
