### PR TITLE
[python/examples] Fix the trap of using perturbed Solution objects

### DIFF
--- a/interfaces/cython/cantera/examples/reactors/surf_pfr.py
+++ b/interfaces/cython/cantera/examples/reactors/surf_pfr.py
@@ -114,12 +114,13 @@ for n in range(NReactors):
 
     if n % 10 == 0:
         print('  {0:10f}  {1:10f}  {2:10f}  {3:10f}'.format(
-            dist, *gas['CH4', 'H2', 'CO'].X))
+            dist, *r.thermo['CH4', 'H2', 'CO'].X))
 
     # write the gas mole fractions and surface coverages vs. distance
     output_data.append(
-        [dist, r.T - 273.15, r.thermo.P/ct.one_atm] + list(gas.X)
-        + list(surf.coverages)
+        [dist, r.T - 273.15, r.thermo.P / ct.one_atm]
+        + list(r.thermo.X)  # use r.thermo.X not gas.X
+        + list(rsurf.kinetics.coverages)  # use rsurf.kinetics.coverages not surf.coverages
     )
 
 with open(output_filename, 'w', newline="") as outfile:


### PR DESCRIPTION
As described by @speth  in
https://groups.google.com/g/cantera-users/c/uf6Trn08WIY/m/V42jpQouHgAJ

> "The issue is that when a Solution object is used inside a ReactorNet, there is no guarantee that the state of the
>  Solution after a call to ReactorNet.advance or ReactorNet.step corresponds exactly to the state of the system at the
>  time indicated by the ReactorNet. The CVODES integrator underlying the ReactorNet just uses the attached Solution
>  objects as “calculators”, and can leave them in arbitrary states that do not correspond to the state of the system at
>  the ReactorNet‘s current time.
> 
>  One case where this occurs is when using the advance method, where CVODES takes arbitrary internal timesteps, governed
>  only by the absolute and relative tolerances on the solution, and then uses interpolation to determine the state at the
>  specified output time. In this case, the Solution objects will never be automatically set to the state corresponding to
>  the output time, but instead will have a state related to the last time reached by the integrator. 
> 
>  Cantera provides accessors for the Solution objects that will automatically synchronize the state to the correct values
>  determined by CVODES, specifically the Reactor.thermo property for bulk phases and the ReactorSurface.kinetics property
>  for interfaces. This problem is exacerbated in the case of surface phases, where the reaction rates are a function of
>  both the bulk and surface states, which may end up in an inconsistent state if only one of the two is correctly
>  synchronized."
> 

In this example, the values being saved (mole fractions and surface coverage) are very nearly
similar (a relative error of about 1e-8) but people build on and copy these examples to do other
things (eg. brute-force sensitivity analyses, or plotting net rates of progress) where we know
that small differences can be very important. So best that the examples do the right thing.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- changed an example to use r.thermo.X not gas.X and rsurf.kinetics.coverages not surf.coverages
- added comments to do this

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes  https://groups.google.com/g/cantera-users/c/uf6Trn08WIY/m/V42jpQouHgAJ

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review


I checked all the other examples in the cantera/examples/reactors folder and they
all looked OK. I didn't check the other folders.