### PR TITLE
[Python] Fix ATOL in advance_to_steady_state

### DIFF
--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -1415,7 +1415,7 @@ cdef class ReactorNet:
         """
         # get default tolerances:
         if not atol:
-            atol = self.rtol
+            atol = self.atol
         if not residual_threshold:
             residual_threshold = 10. * self.rtol
         if residual_threshold <= self.rtol:


### PR DESCRIPTION
The docstring says that if atol is undefined it should match the solver ATOL,
which makes sense to me. What the code in fact did was `atol = self.rtol`,
which I presume is a typo, so have changed to `atol = self.atol`.

Since RTOL is often ten or more orders of magnitude larger than ATOL,
this could make some significant differences to people trying to use this 
method. 

However, the changes could be bad: if now we can't ever reach the steady state,
or it takes much longer to reach steady state (already a complaint I hear),
folks may complain that this commit just made it a bunch slower and less stable. 

(But at least they're now getting what they ask for, instead of just getting
the wrong answer quicker. ).

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Set `atol = self.atol` in `advance_to_steady_state` as described in the method's docstrings.


**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review

What I haven't yet done is show what effect this has, but opening the PR now for comments.