### PR TITLE
Use logging consistently in SCons

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -343,7 +343,7 @@ jobs:
       - name: Build Cantera
         run: |
           scons build system_fmt=y system_eigen=y system_yamlcpp=y system_sundials=y \
-          blas_lapack_libs='lapack,blas' -j2 VERBOSE=True debug=n \
+          blas_lapack_libs='lapack,blas' -j2 logging=debug debug=n \
           optimize_flags='-O3 -ffast-math -fno-finite-math-only'
       - name: Test Cantera
         run: scons test show_long_tests=yes verbose_tests=yes
@@ -400,7 +400,7 @@ jobs:
         mamba install -q scons numpy cython ruamel.yaml boost-cpp eigen yaml-cpp h5py pandas pytest
       shell: pwsh
     - name: Build Cantera
-      run: scons build system_eigen=y system_yamlcpp=y VERBOSE=True
+      run: scons build system_eigen=y system_yamlcpp=y logging=debug
         msvc_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j2
       shell: pwsh
     - name: Test Cantera
@@ -469,7 +469,7 @@ jobs:
           rm $BOOST_ROOT/download.7z
         shell: bash
       - name: Build Cantera
-        run: scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n VERBOSE=y
+        run: scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n logging=debug
           python_package=full env_vars=PYTHONPATH,GITHUB_ACTIONS
           msvc_version=${{ matrix.vs-toolset }} f90_interface=n --debug=time
         shell: cmd
@@ -609,7 +609,7 @@ jobs:
         rm $BOOST_ROOT/download.7z
       shell: bash
     - name: Build Cantera
-      run: scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n VERBOSE=y
+      run: scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n logging=debug
         python_package=full env_vars=PYTHONPATH,GITHUB_ACTIONS
         toolchain=mingw f90_interface=n --debug=time
       shell: cmd

--- a/SConstruct
+++ b/SConstruct
@@ -101,10 +101,20 @@ valid_commands = ("build", "clean", "install", "uninstall",
                   "help", "msi", "samples", "sphinx", "doxygen", "dump",
                   "sdist")
 
+# set default logging level
+if GetOption("silent"):
+    logger.logger.setLevel("ERROR")
+else:
+    logger.logger.setLevel("WARNING")
+
 for command in COMMAND_LINE_TARGETS:
     if command not in valid_commands and not command.startswith('test'):
         logger.error("Unrecognized command line target: {!r}", command)
         sys.exit(1)
+
+    # update default logging level
+    if command in ["build"] and not GetOption("silent"):
+        logger.logger.setLevel("INFO")
 
 if "clean" in COMMAND_LINE_TARGETS:
     remove_directory("build")
@@ -512,7 +522,7 @@ config_options = [
     EnumOption(
         "logging",
         """Select logging level for SCons output. """,
-        "info", ("debug", "info", "warning", "error")),
+        "default", ("debug", "info", "warning", "error", "default")),
     Option(
         "gtest_flags",
         """Additional options passed to each GTest test suite, for example,
@@ -885,7 +895,8 @@ logger.info(textwrap.indent(cantera_conf, "    "), print_level=False)
 # ********************************************
 
 loglevel = env["logging"]
-logger.logger.setLevel(loglevel.upper())
+if loglevel != "default":
+    logger.logger.setLevel(loglevel.upper())
 
 if env["VERBOSE"]:
     # @todo: Remove after Cantera 3.0

--- a/SConstruct
+++ b/SConstruct
@@ -2024,16 +2024,20 @@ if env['f90_interface'] == 'y':
 build_samples = Alias('samples', sampleTargets)
 
 def postBuildMessage(target, source, env):
-    print("*******************************************************")
-    print("Compilation completed successfully.\n")
-    print("- To run the test suite, type 'scons test'.")
-    print("- To list available tests, type 'scons test-help'.")
-    if env['googletest'] == 'none':
-        print("  WARNING: You set the 'googletest' to 'none' and all its tests will be skipped.")
-    print("- To install, type 'scons install'.")
+    build_message = [
+        f"\n{' Compilation completed successfully ':*^88}\n",
+        "- To run the test suite, type 'scons test'.",
+        "- To list available tests, type 'scons test-help'.",
+    ]
+    if env["googletest"] == "none":
+        build_message.append("  WARNING: You set the 'googletest' to 'none' "
+            "and all its tests will be skipped.")
+    build_message.append("- To install, type 'scons install'.")
     if os.name == 'nt':
-        print("- To create a Windows MSI installer, type 'scons msi'.")
-    print("*******************************************************")
+        build_message.append("- To create a Windows MSI installer, type 'scons msi'.")
+    build_message.append(f"\n{'*' * 88}\n")
+
+    logger.info("\n".join(build_message), print_level=False)
 
 finish_build = env.Command('finish_build', [], postBuildMessage)
 env.Depends(finish_build, buildTargets)

--- a/SConstruct
+++ b/SConstruct
@@ -909,15 +909,6 @@ elif env['env_vars']:
             logger.warning(f"failed to propagate environment variable '{repr(name)}'\n"
                 "Edit cantera.conf or the build command line to fix this.")
 
-# @todo: Remove this Warning after Cantera 2.5
-if os.pathsep == ';':
-    for dirs in (env['extra_inc_dirs'], env['extra_lib_dirs']):
-        if re.search(r':\w:', dirs):
-            print('ERROR: Multiple entries in "extra_inc_dirs" and "extra_lib_dirs" '
-                  'should be separated by semicolons (;) on Windows. Use of OS-specific '
-                  'path separator introduced in Cantera 2.5.')
-            sys.exit(1)
-
 env['extra_inc_dirs'] = [d for d in env['extra_inc_dirs'].split(os.pathsep) if d]
 env['extra_lib_dirs'] = [d for d in env['extra_lib_dirs'].split(os.pathsep) if d]
 

--- a/SConstruct
+++ b/SConstruct
@@ -142,7 +142,7 @@ if "clean" in COMMAND_LINE_TARGETS:
     for name in Path("interfaces/matlab/toolbox").glob("ctmethods.*"):
         remove_file(name)
 
-    logger.status("Done removing output files.")
+    logger.status("Done removing output files.", print_level=False)
 
     if COMMAND_LINE_TARGETS == ["clean"]:
         # Just exit if there's nothing else to do
@@ -809,7 +809,7 @@ elif "clang" in env.subst("$CC"):
 
 else:
     logger.error(f"Unrecognized C compiler {env['CC']!r}")
-    exit(1)
+    sys.exit(1)
 
 if env["OS"] == "Windows":
     config.select("Windows")
@@ -921,8 +921,8 @@ elif env['env_vars']:
                 env['ENV'][name] = os.environ[name]
             logger.debug(f"Propagating environment variable {name}={env['ENV'][name]}")
         elif name not in config["env_vars"].default.split(','):
-            logger.warning(f"failed to propagate environment variable {name!r}\n"
-                "Edit cantera.conf or the build command line to fix this.")
+            logger.warning(f"Failed to propagate environment variable {name!r}\n"
+                           "Edit cantera.conf or the build command line to fix this.")
 
 env['extra_inc_dirs'] = [d for d in env['extra_inc_dirs'].split(os.pathsep) if d]
 env['extra_lib_dirs'] = [d for d in env['extra_lib_dirs'].split(os.pathsep) if d]
@@ -1042,9 +1042,9 @@ def config_error(message):
     if env["logging"].lower() == "debug":
         logger.error(message)
         debug_message = [
-            f"\n{' Contents of config.log: ':*^88}",
+            f"\n{' Contents of config.log: ':*^88}\n",
             open("config.log").read().strip(),
-            f"{' End of config.log ':*^88}",
+            f"\n{' End of config.log ':*^88}",
         ]
         logger.debug("\n".join(debug_message), print_level=False)
     else:
@@ -1337,12 +1337,12 @@ if env['system_sundials'] == 'y':
     env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
     sundials_ver = parse_version(env['sundials_version'])
     if sundials_ver < parse_version("2.4") or sundials_ver >= parse_version("7.0"):
-        logger.error(f"Sundials version {env['sundials_version']} is not supported.")
+        logger.error(f"Sundials version {env['sundials_version']!r} is not supported.")
         sys.exit(1)
     elif sundials_ver > parse_version("6.0"):
-        logger.warning(f"Sundials version {env['sundials_version']} has not been tested.")
+        logger.warning(f"Sundials version {env['sundials_version']!r} has not been tested.")
 
-    logger.info("Using system installation of Sundials version {sundials_version}.")
+    logger.info(f"Using system installation of Sundials version {sundials_version!r}.")
 
     # Determine whether or not Sundials was built with BLAS/LAPACK
     if sundials_ver < parse_version('2.6'):
@@ -1376,7 +1376,7 @@ if env['system_sundials'] == 'y':
     # library, but Sundials was configured without this support, print a Warning.
     if not env['has_sundials_lapack'] and env['use_lapack']:
         logger.warning("External BLAS/LAPACK has been specified for Cantera "
-              "but Sundials was built without this support.")
+                       "but Sundials was built without this support.")
 else: # env['system_sundials'] == 'n'
     logger.info("Using private installation of Sundials version 5.3.")
     env['sundials_version'] = '5.3'
@@ -1401,7 +1401,7 @@ end program main
             return True
         else:
             logger.warning(f"Unable to use {compiler!r} to compile the Fortran "
-                  "interface. See config.log for details.")
+                           "interface. See config.log for details.")
             return False
     elif expected:
         logger.error(f"Could not find specified Fortran compiler: {compiler!r}")
@@ -1451,9 +1451,9 @@ env['FORTRANMODDIR'] = '${TARGET.dir}'
 env = conf.Finish()
 
 debug_message = [
-    f"\n{' begin config.log ':-^88}",
+    f"\n{' begin config.log ':-^88}\n",
     open("config.log").read().strip(),
-    f"{' end config.log ':-^88}\n",
+    f"\n{' end config.log ':-^88}\n",
 ]
 logger.debug("\n".join(debug_message), print_level=False)
 
@@ -1796,7 +1796,7 @@ else:
 # Prevent setting Cantera installation path to source directory
 if os.path.abspath(instRoot) == Dir('.').abspath:
     logger.error("cannot install Cantera into source directory.")
-    exit(1)
+    sys.exit(1)
 
 if env['layout'] == 'debian':
     base = pjoin(os.getcwd(), 'debian')

--- a/SConstruct
+++ b/SConstruct
@@ -93,7 +93,7 @@ if not COMMAND_LINE_TARGETS:
     sys.exit(1)
 
 if os.name not in ["nt", "posix"]:
-    logger.error(f"Error: Unrecognized operating system '{os.name}'")
+    logger.error(f"Unrecognized operating system {os.name!r}")
     sys.exit(1)
 
 valid_commands = ("build", "clean", "install", "uninstall",
@@ -108,7 +108,7 @@ else:
 
 for command in COMMAND_LINE_TARGETS:
     if command not in valid_commands and not command.startswith('test'):
-        logger.error("Unrecognized command line target: {!r}", command)
+        logger.error(f"Unrecognized command line target: {command!r}")
         sys.exit(1)
 
     # update default logging level
@@ -674,7 +674,7 @@ if "help" in COMMAND_LINE_TARGETS:
             with open(output_file, "w+") as fid:
                 fid.write(message)
 
-            logger.status(f"Done writing output options to '{output_file}'.",
+            logger.status(f"Done writing output options to {output_file!r}.",
                           print_level=False)
 
         else:
@@ -808,7 +808,8 @@ elif "clang" in env.subst("$CC"):
     config.select("clang")
 
 else:
-    logger.warning(f"Unrecognized C compiler '{env['CC']}'")
+    logger.error(f"Unrecognized C compiler {env['CC']!r}")
+    exit(1)
 
 if env["OS"] == "Windows":
     config.select("Windows")
@@ -873,7 +874,7 @@ if "sdist" in COMMAND_LINE_TARGETS:
 
 for arg in ARGUMENTS:
     if arg not in config:
-        logger.error(f"Encountered unexpected command line option: '{arg}'")
+        logger.error(f"Encountered unexpected command line option: {arg!r}")
         sys.exit(1)
 
 env["cantera_version"] = "3.0.0a1"
@@ -883,7 +884,7 @@ env['cantera_short_version'] = re.match(r'(\d+\.\d+)', env['cantera_version']).g
 
 try:
     env["git_commit"] = get_command_output("git", "rev-parse", "--short", "HEAD")
-    logger.info(f"Building Cantera from git commit '{env['git_commit']}'")
+    logger.info(f"Building Cantera from git commit {env['git_commit']!r}")
 except (subprocess.CalledProcessError, FileNotFoundError):
     env["git_commit"] = "unknown"
 
@@ -920,7 +921,7 @@ elif env['env_vars']:
                 env['ENV'][name] = os.environ[name]
             logger.debug(f"Propagating environment variable {name}={env['ENV'][name]}")
         elif name not in config["env_vars"].default.split(','):
-            logger.warning(f"failed to propagate environment variable '{repr(name)}'\n"
+            logger.warning(f"failed to propagate environment variable {name!r}\n"
                 "Edit cantera.conf or the build command line to fix this.")
 
 env['extra_inc_dirs'] = [d for d in env['extra_inc_dirs'].split(os.pathsep) if d]
@@ -1399,11 +1400,11 @@ end program main
         if success and 'Hello, world!' in output:
             return True
         else:
-            logger.warning(f"Unable to use '{compiler}' to compile the Fortran "
+            logger.warning(f"Unable to use {compiler!r} to compile the Fortran "
                   "interface. See config.log for details.")
             return False
     elif expected:
-        logger.error(f"Could not find specified Fortran compiler: '{compiler}'")
+        logger.error(f"Could not find specified Fortran compiler: {compiler!r}")
         sys.exit(1)
 
     return False
@@ -1421,7 +1422,7 @@ if env['f90_interface'] in ('y','default'):
         foundF90 = check_fortran(compiler)
 
     if foundF90:
-        logger.info(f"Using '{env['FORTRAN']}' to build the Fortran 90 interface")
+        logger.info(f"Using {env['FORTRAN']!r} to build the Fortran 90 interface")
         env['f90_interface'] = 'y'
     else:
         if env['f90_interface'] == 'y':
@@ -1562,11 +1563,11 @@ if env['python_package'] != 'none':
         if env["python_package"] == "default":
             logger.warning(
                 "Not building the Python package because the Python interpreter "
-                f"'{env['python_cmd']!r}' could not be found.")
+                f"{env['python_cmd']!r} could not be found.")
             env["python_package"] = "none"
         else:
             logger.error(
-                f"Could not execute the Python interpreter '{env['python_cmd']!r}'")
+                f"Could not execute the Python interpreter {env['python_cmd']!r}")
             sys.exit(1)
     elif python_version < python_min_version:
         if env["python_package"] in ("minimal", "full", "default"):
@@ -1680,7 +1681,7 @@ if env["matlab_toolbox"] == "y":
     if not (os.path.isdir(matlab_path) and
             os.path.isdir(pjoin(matlab_path, "extern"))):
         logger.error(
-            f"Path set for 'matlab_path' is not correct. Path was '{matlab_path}'")
+            f"Path set for 'matlab_path' is not correct. Path was {matlab_path!r}")
         sys.exit(1)
 
 

--- a/SConstruct
+++ b/SConstruct
@@ -2054,12 +2054,7 @@ def postInstallMessage(target, source, env):
         "data files": "ct_datadir",
         "input file converters": "ct_pyscriptdir",
     }
-    install_message = textwrap.dedent("""
-        Cantera has been successfully installed.
-
-        File locations:
-        """
-    ).splitlines()
+    install_message = ["File locations:\n"]
     locations_message = "  {name:<28}{location}"
     for name, location in locations.items():
         install_message.append(locations_message.format(
@@ -2096,12 +2091,12 @@ def postInstallMessage(target, source, env):
               {matlab_ctpath_loc!s}
         """.format(**env_dict)))
 
-    install_message.append("")
-
-    logger.info(
-        textwrap.indent("\n".join(install_message), 4*" "),
-        print_level=False
-    )
+    install_message = [
+        f"\n{' Cantera has been successfully installed ':*^88}\n",
+        "\n".join(install_message),
+        f"\n{'*' * 88}\n",
+    ]
+    logger.info("\n".join(install_message), print_level=False)
 
 finish_install = env.Command("finish_install", [], postInstallMessage)
 env.Depends(finish_install, installTargets)

--- a/SConstruct
+++ b/SConstruct
@@ -2,6 +2,7 @@
 SCons build script for Cantera
 
 Basic usage:
+
     'scons help' - Show this help message.
 
     'scons build' - Compile Cantera and the language interfaces using
@@ -24,10 +25,6 @@ Basic usage:
 
     'scons test-NAME' - Run the test named "NAME".
 
-    'scons <command> dump' - Dump the state of the SCons environment to the
-                             screen instead of doing <command>, for example
-                             'scons build dump'. For debugging purposes.
-
     'scons samples' - Compile the C++ and Fortran samples.
 
     'scons msi' - Build a Windows installer (.msi) for Cantera.
@@ -36,7 +33,8 @@ Basic usage:
 
     'scons doxygen' - Build the Doxygen documentation
 
-Additional help command options:
+Additional command options:
+
     'scons help --options' - Print a description of user-specifiable options.
 
     'scons help --list-options' - Print formatted list of available options.
@@ -44,6 +42,11 @@ Additional help command options:
     'scons help --option=<opt>' - Print the description of a specific option
                                   with name <opt>, for example
                                   'scons help --option=prefix'
+
+    'scons <command> -j<X>' - Short form of '--jobs=<X>'. Run the <command> using '<X>'
+                              parallel jobs, for example 'scons build -j4'
+
+    'scons <command> -s' - Short form of '--silent' (or '--quiet'). Suppresses output.
 """
 # Note that 'scons help' supports additional command options that are intended for
 # internal use (debugging or reST parsing of options) and thus are not listed above:
@@ -51,6 +54,11 @@ Additional help command options:
 #  --restructured-text ... format configuration as reST
 #  --dev ... add '-dev' to reST output
 #  --output=<fname> ... send output to file (reST only)
+#
+# Other features not listed above:
+# 'scons <command> dump' - Dump the state of the SCons environment to the
+#                          screen instead of doing <command>, for example
+#                          'scons build dump'. For debugging purposes.
 
 # This f-string is deliberately here to trigger a SyntaxError when
 # SConstruct is parsed by Python 2. This seems to be the most robust

--- a/SConstruct
+++ b/SConstruct
@@ -521,7 +521,10 @@ config_options = [
         False),
     EnumOption(
         "logging",
-        """Select logging level for SCons output. """,
+        """Select logging level for SCons output. By default, logging messages use
+           the 'info' level for 'scons build' and the 'warning' level for all other
+           commands. In case the SCons option '--silent' is passed, all messages below
+           the 'error' level are suppressed.""",
         "default", ("debug", "info", "warning", "error", "default")),
     Option(
         "gtest_flags",

--- a/SConstruct
+++ b/SConstruct
@@ -77,9 +77,9 @@ import SCons
 # ensure that Python version is sufficient for build process
 python_version = "{v.major}.{v.minor}".format(v=sys.version_info)
 if parse_version(python_version) < parse_version(python_min_build_support):
-    print(
-        f"ERROR: Cantera must be built using Python {python_min_build_support} or "
-        f"higher; Python {python_version} is not supported.", file=sys.stderr)
+    logger.error(
+        f"Cantera must be built using Python {python_min_build_support} or "
+        f"higher; Python {python_version} is not supported.")
     sys.exit(1)
 
 from buildutils import *
@@ -133,7 +133,7 @@ if "clean" in COMMAND_LINE_TARGETS:
     for name in Path("interfaces/matlab/toolbox").glob("ctmethods.*"):
         remove_file(name)
 
-    print("Done removing output files.")
+    logger.info("Done removing output files.")
 
     if COMMAND_LINE_TARGETS == ["clean"]:
         # Just exit if there's nothing else to do
@@ -148,7 +148,7 @@ if "test-clean" in COMMAND_LINE_TARGETS:
 
 logger.info(
     f"SCons {SCons.__version__} is using the following Python interpreter:\n"
-    f"{sys.executable} (Python {python_version})")
+    f"    {sys.executable} (Python {python_version})")
 
 # ******************************************
 # *** Specify defaults for SCons options ***
@@ -789,7 +789,7 @@ elif "clang" in env.subst("$CC"):
     config.select("clang")
 
 else:
-    print(f"WARNING: Unrecognized C compiler '{env['CC']}'")
+    logger.warning(f"Unrecognized C compiler '{env['CC']}'")
 
 if env["OS"] == "Windows":
     config.select("Windows")
@@ -814,7 +814,7 @@ for option in opts.keys():
     if isinstance(original, str):
         modified = os.path.expandvars(os.path.expanduser(env[option]))
         if original != modified:
-            print('INFO: Expanding {!r} to {!r}'.format(original, modified))
+            logger.info(f"Expanding {original:!r} to {modified:!r}")
             env[option] = modified
 
 if "help" in COMMAND_LINE_TARGETS:
@@ -891,10 +891,10 @@ elif env['env_vars']:
             else:
                 env['ENV'][name] = os.environ[name]
             if env['VERBOSE']:
-                print('Propagating environment variable {0}={1}'.format(name, env['ENV'][name]))
+                logger.info(f"Propagating environment variable {name}={env['ENV'][name]}")
         elif name not in config["env_vars"].default.split(','):
-            print('WARNING: failed to propagate environment variable', repr(name))
-            print('         Edit cantera.conf or the build command line to fix this.')
+            logger.warning(f"failed to propagate environment variable '{repr(name)}'\n"
+                "Edit cantera.conf or the build command line to fix this.")
 
 # @todo: Remove this Warning after Cantera 2.5
 if os.pathsep == ';':
@@ -1013,20 +1013,21 @@ if env['coverage']:
         env.Append(LINKFLAGS=['-fprofile-arcs', '-ftest-coverage'])
 
     else:
-        print('Error: coverage testing is only available with GCC.')
+        logger.error("Coverage testing is only available with GCC.")
         exit(0)
 
 if env['toolchain'] == 'mingw':
     env.Append(LINKFLAGS=['-static-libgcc', '-static-libstdc++'])
 
 def config_error(message):
-    print('ERROR:', message)
+    error_message = [message]
     if env['VERBOSE']:
-        print('*' * 25, 'Contents of config.log:', '*' * 25)
-        print(open('config.log').read())
-        print('*' * 28, 'End of config.log', '*' * 28)
+        error_message.append(f"\n{' Contents of config.log: ':*^88}")
+        error_message.append(open("config.log").read().strip())
+        error_message.append(f"{' End of config.log ':*^88}")
     else:
-        print("See 'config.log' for details.")
+        error_message.append("See 'config.log' for details.")
+    logger.error("\n".join(error_message))
     sys.exit(1)
 
 conf = Configure(env, custom_tests={'CheckStatement': CheckStatement})
@@ -1076,7 +1077,7 @@ if nan_works.strip() != "1":
 if env['system_fmt'] in ('y', 'default'):
     if conf.CheckCXXHeader('fmt/ostream.h', '""'):
         env['system_fmt'] = True
-        print("""INFO: Using system installation of fmt library.""")
+        logger.info("Using system installation of fmt library.")
 
     elif env['system_fmt'] == 'y':
         config_error('Expected system installation of fmt library, but it '
@@ -1084,7 +1085,7 @@ if env['system_fmt'] in ('y', 'default'):
 
 if env['system_fmt'] in ('n', 'default'):
     env['system_fmt'] = False
-    print("""INFO: Using private installation of fmt library.""")
+    logger.info("Using private installation of fmt library.")
     if not os.path.exists('ext/fmt/include/fmt/ostream.h'):
         if not os.path.exists('.git'):
             config_error('fmt is missing. Install source in ext/fmt.')
@@ -1106,17 +1107,17 @@ try:
     fmt_lib_version = divmod(float(fmt_lib_version.strip()), 10000)
     (fmt_maj, (fmt_min, fmt_pat)) = fmt_lib_version[0], divmod(fmt_lib_version[1], 100)
     env['FMT_VERSION'] = '{major:.0f}.{minor:.0f}.{patch:.0f}'.format(major=fmt_maj, minor=fmt_min, patch=fmt_pat)
-    print('INFO: Found fmt version {}'.format(env['FMT_VERSION']))
+    logger.info(f"Found fmt version {env['FMT_VERSION']}")
 except ValueError:
     env['FMT_VERSION'] = '0.0.0'
-    print('INFO: Could not find version of fmt')
+    logger.info("INFO: Could not find version of fmt")
 
 # Check for yaml-cpp library and checkout submodule if needed
 if env['system_yamlcpp'] in ('y', 'default'):
     # We need the Mark() function, which was added in version 0.5.3
     if conf.CheckStatement('YAML::Node().Mark()', '#include "yaml-cpp/yaml.h"'):
         env['system_yamlcpp'] = True
-        print("""INFO: Using system installation of yaml-cpp library.""")
+        logger.info("Using system installation of yaml-cpp library.")
 
     elif env['system_yamlcpp'] == 'y':
         config_error("Expected system installation of yaml-cpp library, but it "
@@ -1124,7 +1125,7 @@ if env['system_yamlcpp'] in ('y', 'default'):
 
 if env['system_yamlcpp'] in ('n', 'default'):
     env['system_yamlcpp'] = False
-    print("""INFO: Using private installation of yaml-cpp library.""")
+    logger.info("Using private installation of yaml-cpp library.")
     if not os.path.exists('ext/yaml-cpp/include/yaml-cpp/yaml.h'):
         if not os.path.exists('.git'):
             config_error('yaml-cpp is missing. Install source in ext/yaml-cpp.')
@@ -1145,7 +1146,7 @@ if env['googletest'] in ('system', 'default'):
     has_gmock = conf.CheckCXXHeader('gmock/gmock.h', '""')
     if has_gtest and has_gmock:
         env['googletest'] = 'system'
-        print("""INFO: Using system installation of Googletest""")
+        logger.info("Using system installation of Googletest")
     elif env['googletest'] == 'system':
         config_error('Expected system installation of Googletest-1.8.0, but it '
                      'could not be found.')
@@ -1167,22 +1168,22 @@ if env['googletest'] in ('submodule', 'default'):
             config_error('Googletest not found and submodule checkout failed.\n'
                          'Try manually checking out the submodule with:\n\n'
                          '    git submodule update --init --recursive ext/googletest\n')
-    print("""INFO: Using Googletest from Git submodule""")
+    logger.info("Using Googletest from Git submodule")
 
 if env['googletest'] == 'none':
-    print("""INFO: Not using Googletest -- unable to run complete test suite""")
+    logger.info("Not using Googletest -- unable to run complete test suite")
 
 # Check for Eigen and checkout submodule if needed
 if env["system_eigen"] in ("y", "default"):
     if conf.CheckCXXHeader("eigen3/Eigen/Dense", "<>"):
         env["system_eigen"] = True
         env["system_eigen_prefixed"] = True
-        print("""INFO: Using system installation of Eigen.""")
+        logger.info("Using system installation of Eigen.")
         eigen_include = "<eigen3/Eigen/Core>"
     elif conf.CheckCXXHeader("Eigen/Dense", "<>"):
         env["system_eigen"] = True
         env["system_eigen_prefixed"] = False
-        print("""INFO: Using system installation of Eigen.""")
+        logger.info("Using system installation of Eigen.")
         eigen_include = "<Eigen/Core>"
     elif env["system_eigen"] == "y":
         config_error("Expected system installation of Eigen, but it "
@@ -1190,7 +1191,7 @@ if env["system_eigen"] in ("y", "default"):
 
 if env["system_eigen"] in ("n", "default"):
     env["system_eigen"] = False
-    print("""INFO: Using private installation of Eigen.""")
+    logger.info("Using private installation of Eigen.")
     if not os.path.exists("ext/eigen/Eigen/Dense"):
         if not os.path.exists(".git"):
             config_error("Eigen is missing. Install Eigen in ext/eigen.")
@@ -1210,7 +1211,7 @@ eigen_versions = 'QUOTE(EIGEN_WORLD_VERSION) "." QUOTE(EIGEN_MAJOR_VERSION) "." 
 eigen_version_source = get_expression_value([eigen_include], eigen_versions)
 retcode, eigen_lib_version = conf.TryRun(eigen_version_source, ".cpp")
 env["EIGEN_LIB_VERSION"] = eigen_lib_version.strip()
-print("INFO: Found Eigen version {}".format(env["EIGEN_LIB_VERSION"]))
+logger.info(f"Found Eigen version {env['EIGEN_LIB_VERSION']}")
 
 # Determine which standard library to link to when using Fortran to
 # compile code that links to Cantera
@@ -1241,7 +1242,7 @@ if not env['BOOST_LIB_VERSION']:
     config_error("Boost could not be found. Install Boost headers or set"
                  " 'boost_inc_dir' to point to the boost headers.")
 else:
-    print('INFO: Found Boost version {0}'.format(env['BOOST_LIB_VERSION']))
+    logger.info(f"Found Boost version {env['BOOST_LIB_VERSION']}")
 # demangle is available in Boost 1.56 or newer
 env['has_demangle'] = conf.CheckDeclaration("boost::core::demangle",
                                 '#include <boost/core/demangle.hpp>', 'C++')
@@ -1313,12 +1314,12 @@ if env['system_sundials'] == 'y':
     env['sundials_version'] = '.'.join(sundials_version.split('.')[:2])
     sundials_ver = parse_version(env['sundials_version'])
     if sundials_ver < parse_version("2.4") or sundials_ver >= parse_version("7.0"):
-        print("""ERROR: Sundials version %r is not supported.""" % env['sundials_version'])
+        logger.error(f"Sundials version {env['sundials_version']} is not supported.")
         sys.exit(1)
     elif sundials_ver > parse_version("6.0"):
-        print("WARNING: Sundials version %r has not been tested." % env['sundials_version'])
+        logger.warning(f"Sundials version {env['sundials_version']} has not been tested.")
 
-    print("""INFO: Using system installation of Sundials version %s.""" % sundials_version)
+    logger.info("Using system installation of Sundials version {sundials_version}.")
 
     # Determine whether or not Sundials was built with BLAS/LAPACK
     if sundials_ver < parse_version('2.6'):
@@ -1351,10 +1352,10 @@ if env['system_sundials'] == 'y':
     # In the case where a user is trying to link Cantera to an external BLAS/LAPACK
     # library, but Sundials was configured without this support, print a Warning.
     if not env['has_sundials_lapack'] and env['use_lapack']:
-        print('WARNING: External BLAS/LAPACK has been specified for Cantera '
-              'but Sundials was built without this support.')
+        logger.warning("External BLAS/LAPACK has been specified for Cantera "
+              "but Sundials was built without this support.")
 else: # env['system_sundials'] == 'n'
-    print("""INFO: Using private installation of Sundials version 5.3.""")
+    logger.info("Using private installation of Sundials version 5.3.")
     env['sundials_version'] = '5.3'
     env['has_sundials_lapack'] = int(env['use_lapack'])
 
@@ -1376,11 +1377,11 @@ end program main
         if success and 'Hello, world!' in output:
             return True
         else:
-            print("WARNING: Unable to use '%s' to compile the Fortran "
-                  "interface. See config.log for details." % compiler)
+            logger.warning(f"Unable to use '{compiler}' to compile the Fortran "
+                  "interface. See config.log for details.")
             return False
     elif expected:
-        print("ERROR: Couldn't find specified Fortran compiler: '%s'" % compiler)
+        logger.error(f"Could not find specified Fortran compiler: '{compiler}'")
         sys.exit(1)
 
     return False
@@ -1398,16 +1399,16 @@ if env['f90_interface'] in ('y','default'):
         foundF90 = check_fortran(compiler)
 
     if foundF90:
-        print("INFO: Using '%s' to build the Fortran 90 interface" % env['FORTRAN'])
+        logger.info(f"Using '{env['FORTRAN']}' to build the Fortran 90 interface")
         env['f90_interface'] = 'y'
     else:
         if env['f90_interface'] == 'y':
-            print("ERROR: Couldn't find a suitable Fortran compiler to build the Fortran 90 interface.")
+            logger.error("Could not find a suitable Fortran compiler to build the Fortran 90 interface.")
             sys.exit(1)
         else:
             env['f90_interface'] = 'n'
             env['FORTRAN'] = ''
-            print("INFO: Skipping compilation of the Fortran 90 interface.")
+            logger.info("Skipping compilation of the Fortran 90 interface.")
 
 if 'pgfortran' in env['FORTRAN']:
     env['FORTRANMODDIRPREFIX'] = '-module '
@@ -1427,9 +1428,12 @@ env['FORTRANMODDIR'] = '${TARGET.dir}'
 env = conf.Finish()
 
 if env['VERBOSE']:
-    print('-------------------- begin config.log --------------------')
-    print(open('config.log').read())
-    print('--------------------- end config.log ---------------------')
+    message = [
+        f"\n{' begin config.log ':-^88}",
+        open("config.log").read().strip(),
+        f"{' end config.log ':-^88}\n",
+    ]
+    logger.info("\n".join(message), print_level=False)
 
 env['python_cmd_esc'] = quoted(env['python_cmd'])
 
@@ -1510,13 +1514,11 @@ if env['python_package'] != 'none':
         info = get_command_output(env["python_cmd"], "-c", script).splitlines()
     except OSError as err:
         if env['VERBOSE']:
-            print('Error checking for Python:')
-            print(err)
+            logger.warning(f"Error checking for Python:\n{err}")
         warn_no_python = True
     except subprocess.CalledProcessError as err:
         if env['VERBOSE']:
-            print('Error checking for Python:')
-            print(err, err.output)
+            logger.warning(f"Error checking for Python:\n{err} {err.output}")
         warn_no_python = True
     else:
         warn_no_python = False
@@ -1773,7 +1775,7 @@ else:
 
 # Prevent setting Cantera installation path to source directory
 if os.path.abspath(instRoot) == Dir('.').abspath:
-    print('ERROR: cannot install Cantera into source directory.')
+    logger.error("cannot install Cantera into source directory.")
     exit(1)
 
 if env['layout'] == 'debian':
@@ -2035,10 +2037,6 @@ build_cantera = Alias('build', finish_build)
 Default('build')
 
 def postInstallMessage(target, source, env):
-    # Only needed because Python 2 doesn't support textwrap.indent
-    def indent(inp_str, indent):
-        return '\n'.join([indent + spl for spl in inp_str.splitlines()])
-
     env_dict = env.Dictionary()
     locations = {
         "library files": "ct_libdir",

--- a/SConstruct
+++ b/SConstruct
@@ -64,7 +64,6 @@ Additional command options:
 # SConstruct is parsed by Python 2. This seems to be the most robust
 # and simplest option that will reliably trigger an error in Python 2
 # and provide actionable feedback for users.
-python_min_build_support = "3.7"
 f"""
 Cantera must be built using Python 3.7 or higher. You can invoke SCons by executing
     python3 `which scons`
@@ -82,23 +81,15 @@ from os.path import join as pjoin
 from pkg_resources import parse_version
 import SCons
 
-# ensure that Python version is sufficient for build process
-python_version = "{v.major}.{v.minor}".format(v=sys.version_info)
-if parse_version(python_version) < parse_version(python_min_build_support):
-    logger.error(
-        f"Cantera must be built using Python {python_min_build_support} or "
-        f"higher; Python {python_version} is not supported.")
-    sys.exit(1)
+# ensure that Python and SCons versions are sufficient for the build process
+EnsurePythonVersion(3, 7)
+EnsureSConsVersion(3, 0, 0)
 
 from buildutils import *
 
 if not COMMAND_LINE_TARGETS:
     # Print usage help
     logger.error("Missing command argument: type 'scons help' for information.")
-    sys.exit(1)
-
-if parse_version(SCons.__version__) < parse_version("3.0.0"):
-    logger.error("Cantera requires SCons with a minimum version of 3.0.0. Exiting.")
     sys.exit(1)
 
 if os.name not in ["nt", "posix"]:
@@ -121,7 +112,7 @@ for command in COMMAND_LINE_TARGETS:
         sys.exit(1)
 
     # update default logging level
-    if command in ["build"] and not GetOption("silent"):
+    if command in ["build", "dump"] and not GetOption("silent"):
         logger.logger.setLevel("INFO")
 
 if "clean" in COMMAND_LINE_TARGETS:
@@ -164,6 +155,7 @@ if "test-clean" in COMMAND_LINE_TARGETS:
     remove_directory("test/work")
     remove_directory("build/python_local")
 
+python_version = f"{sys.version_info.major}.{sys.version_info.minor}"
 logger.info(
     f"SCons {SCons.__version__} is using the following Python interpreter:\n"
     f"    {sys.executable} (Python {python_version})", print_level=False)

--- a/SConstruct
+++ b/SConstruct
@@ -143,7 +143,7 @@ if "clean" in COMMAND_LINE_TARGETS:
     for name in Path("interfaces/matlab/toolbox").glob("ctmethods.*"):
         remove_file(name)
 
-    logger.info("Done removing output files.")
+    logger.status("Done removing output files.")
 
     if COMMAND_LINE_TARGETS == ["clean"]:
         # Just exit if there's nothing else to do
@@ -158,7 +158,7 @@ if "test-clean" in COMMAND_LINE_TARGETS:
 
 logger.info(
     f"SCons {SCons.__version__} is using the following Python interpreter:\n"
-    f"    {sys.executable} (Python {python_version})")
+    f"    {sys.executable} (Python {python_version})", print_level=False)
 
 # ******************************************
 # *** Specify defaults for SCons options ***
@@ -629,7 +629,7 @@ if "help" in COMMAND_LINE_TARGETS:
 
     if not (list or rest or defaults or options or option):
         # show basic help information
-        logger.info(__doc__, print_level=False)
+        logger.status(__doc__, print_level=False)
         sys.exit(0)
 
     if defaults or rest or list:
@@ -639,15 +639,15 @@ if "help" in COMMAND_LINE_TARGETS:
 
         if list:
             # show formatted list of options
-            logger.info("\nConfiguration options for building Cantera:", print_level=False)
-            logger.info(config.list_options(), print_level=False)
+            logger.status("\nConfiguration options for building Cantera:\n", print_level=False)
+            logger.status(config.list_options() + "\n", print_level=False)
             sys.exit(0)
 
         if defaults:
             try:
                 # print default values: if option is None, show description for all
                 # available options, otherwise show description for specified option
-                logger.info(config.help(option), print_level=False)
+                logger.status(config.help(option), print_level=False)
                 sys.exit(0)
             except KeyError as err:
                 message = "Run 'scons help --list-options' to see available options."
@@ -671,11 +671,11 @@ if "help" in COMMAND_LINE_TARGETS:
             with open(output_file, "w+") as fid:
                 fid.write(message)
 
-            logger.info(f"Done writing output options to '{output_file}'.",
-                        print_level=False)
+            logger.status(f"Done writing output options to '{output_file}'.",
+                          print_level=False)
 
         else:
-            logger.info(message, print_level=False)
+            logger.status(message, print_level=False)
 
         sys.exit(0)
 
@@ -838,7 +838,7 @@ if "help" in COMMAND_LINE_TARGETS:
     try:
         # print configuration: if option is None, description is shown for all
         # options; otherwise description is shown for specified option
-        logger.info(config.help(option, env=env), print_level=False)
+        logger.status(config.help(option, env=env), print_level=False)
         sys.exit(0)
     except KeyError as err:
         message = "Run 'scons help --list-options' to see available options."
@@ -2048,7 +2048,7 @@ def postBuildMessage(target, source, env):
         build_message.append("- To create a Windows MSI installer, type 'scons msi'.")
     build_message.append(f"\n{'*' * 88}\n")
 
-    logger.info("\n".join(build_message), print_level=False)
+    logger.status("\n".join(build_message), print_level=False)
 
 finish_build = env.Command('finish_build', [], postBuildMessage)
 env.Depends(finish_build, buildTargets)
@@ -2107,7 +2107,7 @@ def postInstallMessage(target, source, env):
         "\n".join(install_message),
         f"\n{'*' * 88}\n",
     ]
-    logger.info("\n".join(install_message), print_level=False)
+    logger.status("\n".join(install_message), print_level=False)
 
 finish_install = env.Command("finish_install", [], postInstallMessage)
 env.Depends(finish_install, installTargets)

--- a/SConstruct
+++ b/SConstruct
@@ -505,8 +505,14 @@ config_options = [
         PathVariable.PathAccept),
     BoolOption(
         "VERBOSE",
-        "Create verbose output about what SCons is doing.",
+        """Create verbose output about what SCons is doing. Deprecated in Cantera 3.0
+           and to be removed thereafter; replaceable by 'logging=debug'.
+           """,
         False),
+    EnumOption(
+        "logging",
+        """Select logging level for SCons output. """,
+        "info", ("debug", "info", "warning", "error")),
     Option(
         "gtest_flags",
         """Additional options passed to each GTest test suite, for example,
@@ -878,6 +884,14 @@ logger.info(textwrap.indent(cantera_conf, "    "), print_level=False)
 # *** Configure system-specific properties ***
 # ********************************************
 
+loglevel = env["logging"]
+logger.logger.setLevel(loglevel.upper())
+
+if env["VERBOSE"]:
+    # @todo: Remove after Cantera 3.0
+    logger.warning("Option 'VERBOSE' is deprecated: replaceable by 'logging=debug'")
+    logger.logger.setLevel("DEBUG")
+
 # Copy in external environment variables
 if env['env_vars'] == 'all':
     env['ENV'].update(os.environ)
@@ -890,8 +904,7 @@ elif env['env_vars']:
                 env.AppendENVPath('PATH', os.environ['PATH'])
             else:
                 env['ENV'][name] = os.environ[name]
-            if env['VERBOSE']:
-                logger.info(f"Propagating environment variable {name}={env['ENV'][name]}")
+            logger.debug(f"Propagating environment variable {name}={env['ENV'][name]}")
         elif name not in config["env_vars"].default.split(','):
             logger.warning(f"failed to propagate environment variable '{repr(name)}'\n"
                 "Edit cantera.conf or the build command line to fix this.")
@@ -1020,14 +1033,18 @@ if env['toolchain'] == 'mingw':
     env.Append(LINKFLAGS=['-static-libgcc', '-static-libstdc++'])
 
 def config_error(message):
-    error_message = [message]
-    if env['VERBOSE']:
-        error_message.append(f"\n{' Contents of config.log: ':*^88}")
-        error_message.append(open("config.log").read().strip())
-        error_message.append(f"{' End of config.log ':*^88}")
+    if env["logging"].lower() == "debug":
+        logger.error(message)
+        debug_message = [
+            f"\n{' Contents of config.log: ':*^88}",
+            open("config.log").read().strip(),
+            f"{' End of config.log ':*^88}",
+        ]
+        logger.debug("\n".join(debug_message), print_level=False)
     else:
-        error_message.append("See 'config.log' for details.")
-    logger.error("\n".join(error_message))
+        error_message = [message]
+        error_message.append("\nSee 'config.log' for details.")
+        logger.error("\n".join(error_message))
     sys.exit(1)
 
 conf = Configure(env, custom_tests={'CheckStatement': CheckStatement})
@@ -1427,13 +1444,12 @@ env['FORTRANMODDIR'] = '${TARGET.dir}'
 
 env = conf.Finish()
 
-if env['VERBOSE']:
-    message = [
-        f"\n{' begin config.log ':-^88}",
-        open("config.log").read().strip(),
-        f"{' end config.log ':-^88}\n",
-    ]
-    logger.info("\n".join(message), print_level=False)
+debug_message = [
+    f"\n{' begin config.log ':-^88}",
+    open("config.log").read().strip(),
+    f"{' end config.log ':-^88}\n",
+]
+logger.debug("\n".join(debug_message), print_level=False)
 
 env['python_cmd_esc'] = quoted(env['python_cmd'])
 
@@ -1513,12 +1529,10 @@ if env['python_package'] != 'none':
     try:
         info = get_command_output(env["python_cmd"], "-c", script).splitlines()
     except OSError as err:
-        if env['VERBOSE']:
-            logger.warning(f"Error checking for Python:\n{err}")
+        logger.debug(f"Error checking for Python:\n{err}")
         warn_no_python = True
     except subprocess.CalledProcessError as err:
-        if env['VERBOSE']:
-            logger.warning(f"Error checking for Python:\n{err} {err.output}")
+        logger.debug(f"Error checking for Python:\n{err} {err.output}")
         warn_no_python = True
     else:
         warn_no_python = False

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -31,7 +31,7 @@ def extract_matlab_docstring(mfile, level):
     elif level == 1:
         docstring = "    .. mat:function:: "
     else:
-        logger.error(f"Unknown level for MATLAB documentation.")
+        logger.error("Unknown level for MATLAB documentation.")
         sys.exit(1)
 
     # The leader is the number of spaces at the beginning of a regular line

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -31,7 +31,7 @@ def extract_matlab_docstring(mfile, level):
     elif level == 1:
         docstring = "    .. mat:function:: "
     else:
-        print("Unknown level for MATLAB documentation.")
+        logger.error(f"Unknown level for MATLAB documentation.")
         sys.exit(1)
 
     # The leader is the number of spaces at the beginning of a regular line
@@ -81,7 +81,7 @@ def get_function_name(function_string):
     elif function_string.startswith('classdef '):
         sig = function_string[len('classdef '):]
     else:
-        print("Unknown function declaration in MATLAB document", function_string)
+        logger.error(f"Unknown function declaration in MATLAB document: {function_string}")
         sys.exit(1)
 
     # Split the function signature on the equals sign, if it exists.

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -44,7 +44,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     localenv.Prepend(CPPPATH=['#include'])
 
     if openmp and not env['HAS_OPENMP']:
-        print("INFO: Skipping sample {} because 'omp.h' was not found.".format(name))
+        logger.info(f"Skipping sample {name} because 'omp.h' was not found.")
     else:
         buildSample(localenv.Program, pjoin(subdir, name),
                     multi_glob(localenv, subdir, *extensions))

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -44,7 +44,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     localenv.Prepend(CPPPATH=['#include'])
 
     if openmp and not env['HAS_OPENMP']:
-        logger.info(f"Skipping sample {name} because 'omp.h' was not found.")
+        logger.info(f"Skipping sample {name!r} because 'omp.h' was not found.")
     else:
         buildSample(localenv.Program, pjoin(subdir, name),
                     multi_glob(localenv, subdir, *extensions))

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -468,15 +468,15 @@ class LevelAdapter(logging.LoggerAdapter):
     def status(self, message, *args, **kws):
         # custom logger adapted from https://stackoverflow.com/questions/2183233
         if self.isEnabledFor(LOGGING_STATUS_NUM):
-            # logger takes its '*args' as 'args'.
             msg, kwargs = self.process(message, kws)
+            # logger takes its '*args' as 'args'
             self._log(LOGGING_STATUS_NUM, msg, args, **kwargs)
 
     def failed(self, message, *args, **kws):
         # custom logger adapted from https://stackoverflow.com/questions/2183233
         if self.isEnabledFor(LOGGING_FAILED_NUM):
-            # logger takes its '*args' as 'args'.
             msg, kwargs = self.process(message, kws)
+            # logger takes its '*args' as 'args'
             self._log(LOGGING_FAILED_NUM, msg, args, **kwargs)
 
     def process(self, msg, kwargs):

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -439,7 +439,9 @@ class Configuration:
         return "\n".join(message)
 
 
-# Add custom logging level
+# Add custom logging levels
+LOGGING_STATUS_NUM = 32
+logging.addLevelName(LOGGING_STATUS_NUM, "STATUS")
 LOGGING_FAILED_NUM = 42
 logging.addLevelName(LOGGING_FAILED_NUM, "FAILED")
 
@@ -460,13 +462,22 @@ class LevelAdapter(logging.LoggerAdapter):
     """
     def __init__(self, logger):
         self.logger = logger
+        self.logger.status = self.status
         self.logger.failed = self.failed
+
+    def status(self, message, *args, **kws):
+        # custom logger adapted from https://stackoverflow.com/questions/2183233
+        if self.isEnabledFor(LOGGING_STATUS_NUM):
+            # logger takes its '*args' as 'args'.
+            msg, kwargs = self.process(message, kws)
+            self._log(LOGGING_STATUS_NUM, msg, args, **kwargs)
 
     def failed(self, message, *args, **kws):
         # custom logger adapted from https://stackoverflow.com/questions/2183233
         if self.isEnabledFor(LOGGING_FAILED_NUM):
             # logger takes its '*args' as 'args'.
-            self._log(LOGGING_FAILED_NUM, message, args, **kws)
+            msg, kwargs = self.process(message, kws)
+            self._log(LOGGING_FAILED_NUM, msg, args, **kwargs)
 
     def process(self, msg, kwargs):
         """Pop the value of ``print_level`` into the ``extra`` dictionary.

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -661,32 +661,25 @@ class TestResults:
         Note that the three arguments are not used here but are required by SCons,
         and they must be keyword arguments.
         """
-        values = {
-            "passed": sum(self.passed.values()),
-            "failed": sum(self.failed.values()),
-            "skipped": len(self.tests),
-        }
-        message = textwrap.dedent(
-            """
-            *****************************
-            ***    Testing Summary    ***
-            *****************************
+        message = [textwrap.dedent(
+            f"""
+            {' Testing Summary ':*^88}
 
-            Tests passed: {passed!s}
-            Up-to-date tests skipped: {skipped!s}
-            Tests failed: {failed!s}
-            """
-        ).format_map(values)
+            Tests passed: {sum(self.passed.values())!s}
+            Up-to-date tests skipped: {len(self.tests)!s}
+            Tests failed: {sum(self.failed.values())!s}
+            """)]
         if self.failed:
-            message = (message + "Failed tests:" +
-                       "".join("\n    - " + n for n in self.failed) +
-                       "\n")
-        message = message + "*****************************"
+            message.append("Failed tests:")
+            for failed in self.failed:
+                message.append(f"    - {failed}")
+            message.append("")
+        message.append(f"{'*' * 88}\n")
+        message = "\n".join(message)
+        logger.status(message, print_level=False)
         if self.failed:
-            logger.error("One or more tests failed.\n" + message, print_level=False)
+            logger.failed("One or more tests failed.")
             sys.exit(1)
-        else:
-            logger.info(message, print_level=False)
 
 
 test_results = TestResults()

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -439,6 +439,11 @@ class Configuration:
         return "\n".join(message)
 
 
+# Add custom logging level
+LOGGING_FAILED_NUM = 42
+logging.addLevelName(LOGGING_FAILED_NUM, "FAILED")
+
+
 class LevelAdapter(logging.LoggerAdapter):
     """This adapter processes the ``print_level`` keyword-argument to log functions.
 
@@ -455,6 +460,13 @@ class LevelAdapter(logging.LoggerAdapter):
     """
     def __init__(self, logger):
         self.logger = logger
+        self.logger.failed = self.failed
+
+    def failed(self, message, *args, **kws):
+        # custom logger adapted from https://stackoverflow.com/questions/2183233
+        if self.isEnabledFor(LOGGING_FAILED_NUM):
+            # logger takes its '*args' as 'args'.
+            self._log(LOGGING_FAILED_NUM, message, args, **kws)
 
     def process(self, msg, kwargs):
         """Pop the value of ``print_level`` into the ``extra`` dictionary.

--- a/test/SConscript
+++ b/test/SConscript
@@ -68,7 +68,7 @@ def addTestProgram(subdir, progName, env_vars={}):
         code = subprocess.call(cmd, env=env['ENV'], cwd=workDir)
 
         if code:
-            print("FAILED: Test '{0}' exited with code {1}".format(progName, code))
+            logger.failed(f"Test '{progName}' exited with code {code}")
             if env["fast_fail_tests"]:
                 sys.exit(1)
         else:
@@ -136,7 +136,6 @@ def addPythonTest(testname, subdir, script, interpreter,
 
         environ = dict(env['ENV'])
         for k,v in env_vars.items():
-            print(k,v)
             environ[k] = v
 
         cmdargs = args.split()
@@ -237,9 +236,12 @@ def addMatlabTest(script, testName, dependencies=None, env_vars=()):
                 ' ***no results for entire test suite***'] = 100
             return
 
-        print('-------- Matlab test results --------')
-        print(results)
-        print('------ end Matlab test results ------')
+        matlab_test_message = [
+            f"{' Matlab test results ':-^88}",
+            results,
+            f"{' end Matlab test results ':-^88}",
+        ]
+        logger.info("\n".join(matlab_test_message))
 
         passed = True
         for line in results.split('\n'):

--- a/test/SConscript
+++ b/test/SConscript
@@ -68,7 +68,7 @@ def addTestProgram(subdir, progName, env_vars={}):
         code = subprocess.call(cmd, env=env['ENV'], cwd=workDir)
 
         if code:
-            logger.failed(f"Test '{progName}' exited with code {code}")
+            logger.failed(f"Test {progName!r} exited with code {code}")
             if env["fast_fail_tests"]:
                 sys.exit(1)
         else:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Replace `print` by appropriate `logging` level
- Deprecate SCons `VERBOSE` option in favor of `logging` option
- Reduce verbosity of SCons output for commands other than `scons build`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes N/A

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
$ scons build logging=debug
```
and
```
$ scons help --option=logging
scons: Reading SConscript files ...

* logging: [ 'debug' | 'info' | 'warning' | 'error' | 'default' ]
    Select logging level for SCons output. By default, logging messages use the
    'info' level for 'scons build' and the 'warning' level for all other
    commands. In case the SCons option '--silent' is passed, all messages below
    the 'error' level are suppressed.
    - default: 'default'
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
