### PR TITLE
Add auto-detection of Intel MKL and OpenBLAS

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -41,7 +41,8 @@ jobs:
     - name: Install Apt dependencies
       run: |
         sudo apt update
-        sudo apt install libboost-dev gfortran libopenmpi-dev libpython3-dev
+        sudo apt install libboost-dev gfortran libopenmpi-dev libpython3-dev \
+        libblas-dev liblapack-dev
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
@@ -73,7 +74,7 @@ jobs:
     - name: Install Apt dependencies
       run: |
         sudo apt update
-        sudo apt install libboost-dev gfortran libomp-dev libomp5
+        sudo apt install libboost-dev gfortran libomp-dev libomp5 libopenblas-dev
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
@@ -410,8 +411,8 @@ jobs:
     - name: Install conda dependencies
       # See https://github.com/conda-forge/boost-cpp-feedstock/issues/41 for why we
       # use boost-cpp rather than boost from conda-forge
-      run: |
-        mamba install -q scons numpy cython ruamel.yaml boost-cpp eigen yaml-cpp h5py pandas pytest
+      run: mamba install -q scons numpy cython ruamel.yaml boost-cpp eigen yaml-cpp
+        h5py pandas pytest mkl mkl-devel
       shell: pwsh
     - name: Install typing_extensions for Python 3.7
       if: matrix.python-version == '3.7'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -541,7 +541,8 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
     - name: Build Cantera
-      run: python3 `which scons` build env_vars=all CC=icx CXX=icpx FORTRAN=ifx -j2 debug=n --debug=time
+      run: python3 `which scons` build env_vars=all CC=icx CXX=icpx -j2 debug=n
+        --debug=time f90_interface=n # FORTRAN=ifx
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
@@ -586,7 +587,8 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
     - name: Build Cantera
-      run: python3 `which scons` build env_vars=all CC=icc CXX=icpc FORTRAN=ifort -j2 debug=n --debug=time
+      run: python3 `which scons` build env_vars=all CC=icc CXX=icpc -j2 debug=n
+        --debug=time f90_interface=n # FORTRAN=ifort
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The following priority is used:

1. Use Intel MKL if installed 
2. Use OpenBLAS if installed
3. Use `lapack,blas` if installed
4. Use prior behavior

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#144

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->
```
$ scons build locate_lapack=auto
[...]
INFO: Using private installation of Sundials version 5.3.
Checking for C library mkl_rt... (cached) yes
INFO: Using MKL 2022.0.1 for Intel(R) 64 architecture
INFO: Skipping compilation of the Fortran 90 interface.
[...]
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
