### PR TITLE
Reliable input file errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,7 @@ interfaces/matlab/Contents.m
 stage/
 .sconsign.dblite
 .sconf_temp
+.vs
 .vscode
 .ipynb_checkpoints/
 cantera.conf*

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -158,6 +158,10 @@ public:
         m_negativeA_ok = value;
     }
 
+    virtual bool ready() const override {
+        return m_ready;
+    }
+
 protected:
     bool m_negativeA_ok = false; //!< Permissible negative A values
     double m_A = NAN; //!< Pre-exponential factor
@@ -171,6 +175,7 @@ protected:
     std::string m_Ea_str = "Ea"; //!< The string for activation energy
     std::string m_E4_str = ""; //!< The string for an optional 4th parameter
     Units m_rate_units = Units(0.); //!< Reaction rate units
+    bool m_ready = false; //!< Flag indicating object status
 };
 
 //! Arrhenius reaction rate type depends only on temperature

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -170,7 +170,7 @@ protected:
     std::string m_b_str = "b"; //!< The string for temperature exponent
     std::string m_Ea_str = "Ea"; //!< The string for activation energy
     std::string m_E4_str = ""; //!< The string for an optional 4th parameter
-    Units m_rate_units {0.}; //!< Reaction rate units
+    Units m_rate_units{0.}; //!< Reaction rate units
 };
 
 //! Arrhenius reaction rate type depends only on temperature

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -52,7 +52,7 @@ class ArrheniusBase : public ReactionRate
 {
 public:
     //! Default constructor.
-    ArrheniusBase();
+    ArrheniusBase() {}
 
     //! Constructor.
     /*!
@@ -71,7 +71,6 @@ public:
     }
 
     explicit ArrheniusBase(const AnyMap& node, const UnitStack& rate_units={})
-        : ArrheniusBase()
     {
         setParameters(node, rate_units);
     }
@@ -160,18 +159,18 @@ public:
     }
 
 protected:
-    bool m_negativeA_ok; //!< Flag indicating whether negative A values are permitted
-    double m_A; //!< Pre-exponential factor
-    double m_b; //!< Temperature exponent
-    double m_Ea_R; //!< Activation energy (in temperature units)
-    double m_E4_R; //!< Optional 4th energy parameter (in temperature units)
-    double m_logA; //!< Logarithm of pre-exponential factor
-    double m_order; //!< Reaction order
+    bool m_negativeA_ok = false; //!< Permissible negative A values
+    double m_A = NAN; //!< Pre-exponential factor
+    double m_b = NAN; //!< Temperature exponent
+    double m_Ea_R = 0.; //!< Activation energy (in temperature units)
+    double m_E4_R = 0.; //!< Optional 4th energy parameter (in temperature units)
+    double m_logA = NAN; //!< Logarithm of pre-exponential factor
+    double m_order = NAN; //!< Reaction order
     std::string m_A_str = "A"; //!< The string for temperature exponent
     std::string m_b_str = "b"; //!< The string for temperature exponent
     std::string m_Ea_str = "Ea"; //!< The string for activation energy
     std::string m_E4_str = ""; //!< The string for an optional 4th parameter
-    Units m_rate_units; //!< Reaction rate units
+    Units m_rate_units = Units(0.); //!< Reaction rate units
 };
 
 //! Arrhenius reaction rate type depends only on temperature

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -158,10 +158,6 @@ public:
         m_negativeA_ok = value;
     }
 
-    virtual bool ready() const override {
-        return m_ready;
-    }
-
 protected:
     bool m_negativeA_ok = false; //!< Permissible negative A values
     double m_A = NAN; //!< Pre-exponential factor
@@ -170,12 +166,11 @@ protected:
     double m_E4_R = 0.; //!< Optional 4th energy parameter (in temperature units)
     double m_logA = NAN; //!< Logarithm of pre-exponential factor
     double m_order = NAN; //!< Reaction order
-    std::string m_A_str = "A"; //!< The string for temperature exponent
+    std::string m_A_str = "A"; //!< The string for the pre-exponential factor
     std::string m_b_str = "b"; //!< The string for temperature exponent
     std::string m_Ea_str = "Ea"; //!< The string for activation energy
     std::string m_E4_str = ""; //!< The string for an optional 4th parameter
-    Units m_rate_units = Units(0.); //!< Reaction rate units
-    bool m_ready = false; //!< Flag indicating object status
+    Units m_rate_units {0.}; //!< Reaction rate units
 };
 
 //! Arrhenius reaction rate type depends only on temperature

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -94,7 +94,7 @@ public:
     virtual void getParameters(AnyMap& node) const override;
 
     //! Check rate expression
-    virtual void check(const std::string& equation, const AnyMap& node) override;
+    virtual void check(const std::string& equation) override;
 
     virtual void validate(const std::string& equation, const Kinetics& kin) override;
 

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -121,9 +121,9 @@ public:
     //! Perform object setup based on AnyMap node information
     /*!
      *  @param node  AnyMap containing rate information
-     *  @param units  Unit definitions specific to rate information
+     *  @param rate_units  Unit definitions specific to rate information
      */
-    void setParameters(const AnyMap& node, const UnitStack& units);
+    void setParameters(const AnyMap& node, const UnitStack& rate_units);
 
     void getParameters(AnyMap& rateNode) const;
 

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -228,6 +228,10 @@ public:
     //! Set the Chebyshev coefficients as 2-dimensional array.
     void setData(const Array2D& coeffs);
 
+    virtual bool ready() const override {
+        return m_ready;
+    }
+
 protected:
     double m_log10P; //!< value detecting updates
     double Tmin_, Tmax_; //!< valid temperature range
@@ -239,6 +243,7 @@ protected:
     vector_fp dotProd_; //!< dot product of coeffs with the reduced pressure polynomial
 
     Units m_rate_units; //!< Reaction rate units
+    bool m_ready = false; //!< Flag indicating object status
 };
 
 }

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -228,10 +228,6 @@ public:
     //! Set the Chebyshev coefficients as 2-dimensional array.
     void setData(const Array2D& coeffs);
 
-    virtual bool ready() const override {
-        return m_ready;
-    }
-
 protected:
     double m_log10P; //!< value detecting updates
     double Tmin_, Tmax_; //!< valid temperature range
@@ -243,7 +239,6 @@ protected:
     vector_fp dotProd_; //!< dot product of coeffs with the reduced pressure polynomial
 
     Units m_rate_units; //!< Reaction rate units
-    bool m_ready = false; //!< Flag indicating object status
 };
 
 }

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -258,6 +258,10 @@ public:
     //! Set reaction rate in the high-pressure limit
     void setHighRate(const ArrheniusRate& high);
 
+    virtual bool ready() const override {
+        return m_ready;
+    }
+
 protected:
     ArrheniusRate m_lowRate; //!< The reaction rate in the low-pressure limit
     ArrheniusRate m_highRate; //!< The reaction rate in the high-pressure limit
@@ -268,6 +272,7 @@ protected:
     double m_rc_low; //!< Evaluated reaction rate in the low-pressure limit
     double m_rc_high; //!< Evaluated reaction rate in the high-pressure limit
     vector_fp m_work; //!< Work vector
+    bool m_ready = false; //!< Flag indicating object status
 };
 
 

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -258,10 +258,6 @@ public:
     //! Set reaction rate in the high-pressure limit
     void setHighRate(const ArrheniusRate& high);
 
-    virtual bool ready() const override {
-        return m_ready;
-    }
-
 protected:
     ArrheniusRate m_lowRate; //!< The reaction rate in the low-pressure limit
     ArrheniusRate m_highRate; //!< The reaction rate in the high-pressure limit
@@ -272,7 +268,6 @@ protected:
     double m_rc_low; //!< Evaluated reaction rate in the low-pressure limit
     double m_rc_high; //!< Evaluated reaction rate in the high-pressure limit
     vector_fp m_work; //!< Work vector
-    bool m_ready = false; //!< Flag indicating object status
 };
 
 

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -219,7 +219,7 @@ public:
         return pr * m_rc_high;
     }
 
-    void check(const std::string& equation, const AnyMap& node);
+    virtual void check(const std::string& equation) override;
     virtual void validate(const std::string& equation, const Kinetics& kin);
 
     //! Get flag indicating whether negative A values are permitted

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -523,13 +523,13 @@ public:
         for (size_t i=0; i < 6; i++) {
             double k = RateType::evalRate(log(T[i]), 1 / T[i]);
             if (k > 1) {
-                fmt_append(err_reactions,
-                    "\n Sticking coefficient is greater than 1 for reaction '{}'\n"
-                    " at T = {:.1f}\n", equation, T[i]);
+                fmt_append(err_reactions, "at T = {:.1f}\n", T[i]);
             }
         }
         if (err_reactions.size()) {
-            warn_user("StickingRate::validate", to_string(err_reactions));
+            warn_user("StickingRate::validate",
+                "\nSticking coefficient is greater than 1 for reaction '{}'\n{}",
+                equation, to_string(err_reactions));
         }
     }
 

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -95,9 +95,9 @@ public:
     //! Perform object setup based on AnyMap node information
     /*!
      *  @param node  AnyMap containing rate information
-     *  @param units  Unit definitions specific to rate information
+     *  @param rate_units  Unit definitions specific to rate information
      */
-    void setParameters(const AnyMap& node, const UnitStack& units);
+    void setParameters(const AnyMap& node, const UnitStack& rate_units);
 
     void getParameters(AnyMap& rateNode, const Units& rate_units) const;
     void getParameters(AnyMap& rateNode) const {

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -181,6 +181,10 @@ public:
     //! reaction.
     std::multimap<double, ArrheniusRate> getRates() const;
 
+    virtual bool ready() const override {
+        return rates_.size() && !(rates_.size() > 1 && !rates_[1].ready());
+    }
+
 protected:
     //! log(p) to (index range) in the rates_ vector
     std::map<double, std::pair<size_t, size_t>> pressures_;

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -181,10 +181,6 @@ public:
     //! reaction.
     std::multimap<double, ArrheniusRate> getRates() const;
 
-    virtual bool ready() const override {
-        return rates_.size() && !(rates_.size() > 1 && !rates_[1].ready());
-    }
-
 protected:
     //! log(p) to (index range) in the rates_ vector
     std::map<double, std::pair<size_t, size_t>> pressures_;

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -100,7 +100,16 @@ public:
     }
 
     //! Check basic syntax and settings of reaction rate expression
-    virtual void check(const std::string& equation, const AnyMap& node) {}
+    virtual void check(const std::string& equation) {}
+
+    //! Check basic syntax and settings of reaction rate expression
+    //! @deprecated  To be removed after Cantera 3.0.
+    //!              Superseded by single-parameter version
+    void check(const std::string& equation, const AnyMap& node) {
+        warn_deprecated("ReactionRate::check",
+            "To be removed after Cantera 3.0; superseded by single-parameter version.");
+        check(equation);
+    }
 
     //! Validate the reaction rate expression
     virtual void validate(const std::string& equation, const Kinetics& kin) {}

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -52,6 +52,7 @@ public:
     ReactionRate(const ReactionRate& other)
         : m_input(other.m_input)
         , m_rate_index(other.m_rate_index)
+        , m_valid(other.m_valid)
     {}
 
     ReactionRate& operator=(const ReactionRate& other) {
@@ -60,6 +61,7 @@ public:
         }
         m_input = other.m_input;
         m_rate_index = other.m_rate_index;
+        m_valid = other.m_valid;
         return *this;
     }
 
@@ -178,9 +180,9 @@ public:
         return _evaluator().evalSingle(*this);
     }
 
-    //! Get flag indicating whether object is initialized and ready to use
-    virtual bool ready() const {
-        return true;
+    //! Get flag indicating whether reaction rate is set up correctly
+    bool valid() const {
+        return m_valid;
     }
 
 protected:
@@ -198,6 +200,9 @@ protected:
 
     //! Index of reaction rate within kinetics evaluator
     size_t m_rate_index = npos;
+
+    //! Flag indicating whether reaction rate is set up correctly
+    bool m_valid = false;
 
 private:
     //! Return an object that be used to evaluate the rate by converting general input

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -45,7 +45,7 @@ class Reaction;
 class ReactionRate
 {
 public:
-    ReactionRate() : m_rate_index(npos) {}
+    ReactionRate() {}
 
     // Copy constructor and assignment operator need to be defined because of the
     // #m_evaluator member that can't (and shouldn't) be copied.
@@ -178,6 +178,11 @@ public:
         return _evaluator().evalSingle(*this);
     }
 
+    //! Get flag indicating whether object is initialized and ready to use
+    virtual bool ready() const {
+        return true;
+    }
+
 protected:
     //! Get parameters
     //! @param node  AnyMap containing rate information
@@ -192,7 +197,7 @@ protected:
     AnyMap m_input;
 
     //! Index of reaction rate within kinetics evaluator
-    size_t m_rate_index;
+    size_t m_rate_index = npos;
 
 private:
     //! Return an object that be used to evaluate the rate by converting general input

--- a/interfaces/cython/cantera/reaction.pxd
+++ b/interfaces/cython/cantera/reaction.pxd
@@ -24,7 +24,6 @@ cdef extern from "<map>" namespace "std":
 
 
 cdef extern from "cantera/kinetics/ReactionRateFactory.h" namespace "Cantera":
-    cdef shared_ptr[CxxReactionRate] CxxNewReactionRate "newReactionRate" (string) except +translate_exception
     cdef shared_ptr[CxxReactionRate] CxxNewReactionRate "newReactionRate" (CxxAnyMap&) except +translate_exception
 
 

--- a/interfaces/cython/cantera/test/test_kinetics.py
+++ b/interfaces/cython/cantera/test/test_kinetics.py
@@ -485,9 +485,11 @@ def check_raises(yaml, err_msg, line):
     err_msg = [err_msg]
     err_msg.append("InputFileError thrown by ")
     err_msg.append(f"Error on line {line} of ")
+    with pytest.raises(ct.CanteraError) as ex:
+        ct.Solution(yaml=yaml)
+    msg = str(ex.value)
     for err in err_msg:
-        with pytest.raises(ct.CanteraError, match=err):
-            ct.Solution(yaml=yaml)
+        assert err in msg
 
 
 class TestUndeclared(utilities.CanteraTest):

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -624,18 +624,26 @@ static std::pair<double, std::string> split_unit(const AnyValue& v) {
 
 double UnitSystem::convert(const AnyValue& v, const std::string& dest) const
 {
-    return convert(v, Units(dest));
+    try {
+        return convert(v, Units(dest));
+    } catch (CanteraError& err) {
+        throw InputFileError("UnitSystem::convert", v, err.getMessage());
+    }
 }
 
 double UnitSystem::convert(const AnyValue& v, const Units& dest) const
 {
-    auto val_units = split_unit(v);
-    if (val_units.second.empty()) {
-        // Just a value, so convert using default units
-        return convertTo(val_units.first, dest);
-    } else {
-        // Both source and destination units are explicit
-        return convert(val_units.first, Units(val_units.second), dest);
+    try {
+        auto val_units = split_unit(v);
+        if (val_units.second.empty()) {
+            // Just a value, so convert using default units
+            return convertTo(val_units.first, dest);
+        } else {
+            // Both source and destination units are explicit
+            return convert(val_units.first, Units(val_units.second), dest);
+        }
+    } catch (CanteraError& err) {
+        throw InputFileError("UnitSystem::convert", v, err.getMessage());
     }
 }
 
@@ -727,13 +735,18 @@ double UnitSystem::convertActivationEnergyFrom(double value,
 double UnitSystem::convertActivationEnergy(const AnyValue& v,
                                            const std::string& dest) const
 {
-    auto val_units = split_unit(v);
-    if (val_units.second.empty()) {
-        // Just a value, so convert using default units
-        return convertActivationEnergyTo(val_units.first, dest);
-    } else {
-        // Both source and destination units are explicit
-        return convertActivationEnergy(val_units.first, val_units.second, dest);
+    try {
+        auto val_units = split_unit(v);
+        if (val_units.second.empty()) {
+            // Just a value, so convert using default units
+            return convertActivationEnergyTo(val_units.first, dest);
+        } else {
+            // Both source and destination units are explicit
+            return convertActivationEnergy(val_units.first, val_units.second, dest);
+        }
+    } catch (CanteraError& err) {
+        throw InputFileError(
+            "UnitSystem::convertActivationEnergy", v, err.getMessage());
     }
 }
 

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -13,11 +13,11 @@ ArrheniusBase::ArrheniusBase(double A, double b, double Ea)
     : m_A(A)
     , m_b(b)
     , m_Ea_R(Ea / GasConstant)
-    , m_ready(true)
 {
     if (m_A > 0.0) {
         m_logA = std::log(m_A);
     }
+    m_valid = true;
 }
 
 void ArrheniusBase::setRateParameters(
@@ -71,12 +71,12 @@ void ArrheniusBase::setRateParameters(
     if (m_A > 0.0) {
         m_logA = std::log(m_A);
     }
-    m_ready = true;
+    m_valid = true;
 }
 
 void ArrheniusBase::getRateParameters(AnyMap& node) const
 {
-    if (!ready()) {
+    if (!valid()) {
         // Return empty/unmodified AnyMap
         return;
     } else if (m_rate_units.factor() != 0.0) {
@@ -139,7 +139,7 @@ void ArrheniusBase::check(const std::string& equation)
 
 void ArrheniusBase::validate(const std::string& equation, const Kinetics& kin)
 {
-    if (!ready()) {
+    if (!valid()) {
         throw InputFileError("ArrheniusBase::validate", m_input,
             "Rate object for reaction '{}' is not configured.", equation);
     }

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -120,7 +120,7 @@ void ArrheniusBase::getParameters(AnyMap& node) const {
     }
 }
 
-void ArrheniusBase::check(const std::string& equation, const AnyMap& node)
+void ArrheniusBase::check(const std::string& equation)
 {
     if (!m_negativeA_ok && m_A < 0) {
         if (equation == "") {
@@ -129,7 +129,7 @@ void ArrheniusBase::check(const std::string& equation, const AnyMap& node)
                 "Enable 'allowNegativePreExponentialFactor' to suppress "
                 "this message.", m_A);
         }
-        throw InputFileError("ArrheniusBase::check", node,
+        throw InputFileError("ArrheniusBase::check", m_input,
             "Undeclared negative pre-exponential factor found in reaction '{}'",
             equation);
     }

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -13,6 +13,7 @@ ArrheniusBase::ArrheniusBase(double A, double b, double Ea)
     : m_A(A)
     , m_b(b)
     , m_Ea_R(Ea / GasConstant)
+    , m_ready(true)
 {
     if (m_A > 0.0) {
         m_logA = std::log(m_A);
@@ -70,11 +71,12 @@ void ArrheniusBase::setRateParameters(
     if (m_A > 0.0) {
         m_logA = std::log(m_A);
     }
+    m_ready = true;
 }
 
 void ArrheniusBase::getRateParameters(AnyMap& node) const
 {
-    if (std::isnan(m_A)) {
+    if (!ready()) {
         // Return empty/unmodified AnyMap
         return;
     } else if (m_rate_units.factor() != 0.0) {
@@ -137,7 +139,7 @@ void ArrheniusBase::check(const std::string& equation)
 
 void ArrheniusBase::validate(const std::string& equation, const Kinetics& kin)
 {
-    if (isnan(m_A) || isnan(m_b)) {
+    if (!ready()) {
         throw InputFileError("ArrheniusBase::validate", m_input,
             "Rate object for reaction '{}' is not configured.", equation);
     }

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -41,7 +41,7 @@ void ArrheniusBase::setRateParameters(
             // A zero rate units factor is used as a sentinel to detect
             // stand-alone reaction rate objects
             if (rate_map[m_A_str].is<std::string>()) {
-                throw InputFileError("Arrhenius::setRateParameters", rate_map,
+                throw InputFileError("ArrheniusBase::setRateParameters", rate_map,
                     "Specification of units is not supported for pre-exponential "
                     "factor when\ncreating a standalone 'ReactionRate' object.");
             }
@@ -138,7 +138,7 @@ void ArrheniusBase::check(const std::string& equation, const AnyMap& node)
 void ArrheniusBase::validate(const std::string& equation, const Kinetics& kin)
 {
     if (isnan(m_A) || isnan(m_b)) {
-        throw CanteraError("ArrheniusBase::validate",
+        throw InputFileError("ArrheniusBase::validate", m_input,
             "Rate object for reaction '{}' is not configured.", equation);
     }
 }

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -9,26 +9,10 @@
 namespace Cantera
 {
 
-ArrheniusBase::ArrheniusBase()
-    : m_negativeA_ok(false)
-    , m_A(NAN)
-    , m_b(NAN)
-    , m_Ea_R(0.)
-    , m_E4_R(0.)
-    , m_logA(NAN)
-    , m_order(NAN)
-    , m_rate_units(Units(0.))
-{
-}
-
 ArrheniusBase::ArrheniusBase(double A, double b, double Ea)
-    : m_negativeA_ok(false)
-    , m_A(A)
+    : m_A(A)
     , m_b(b)
     , m_Ea_R(Ea / GasConstant)
-    , m_E4_R(0.)
-    , m_order(NAN)
-    , m_rate_units(Units(0.))
 {
     if (m_A > 0.0) {
         m_logA = std::log(m_A);

--- a/src/kinetics/ChebyshevRate.cpp
+++ b/src/kinetics/ChebyshevRate.cpp
@@ -84,7 +84,7 @@ void ChebyshevRate::setParameters(const AnyMap& node, const UnitStack& rate_unit
             unit_system.convert(P_range[1], "Pa")
         );
     } else {
-        setLimits(290., 3000., 1.e-7, 1.e14);
+        setLimits(290., 3000., Tiny, 1. / Tiny);
     }
     setData(coeffs);
 }
@@ -109,7 +109,7 @@ void ChebyshevRate::setLimits(double Tmin, double Tmax, double Pmin, double Pmax
 
 void ChebyshevRate::setData(const Array2D& coeffs)
 {
-    m_valid = coeffs.data().size();
+    m_valid = !coeffs.data().empty();
     if (m_valid) {
         m_coeffs = coeffs;
     } else {

--- a/src/kinetics/ChebyshevRate.cpp
+++ b/src/kinetics/ChebyshevRate.cpp
@@ -54,9 +54,10 @@ ChebyshevRate::ChebyshevRate(double Tmin, double Tmax, double Pmin, double Pmax,
     setData(coeffs);
 }
 
-void ChebyshevRate::setParameters(const AnyMap& node, const UnitStack& units)
+void ChebyshevRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
 {
-    m_rate_units = units.product();
+    ReactionRate::setParameters(node, rate_units);
+    m_rate_units = rate_units.product();
     const UnitSystem& unit_system = node.units();
     Array2D coeffs;
     if (node.hasKey("data")) {
@@ -154,7 +155,7 @@ void ChebyshevRate::getParameters(AnyMap& rateNode) const
 void ChebyshevRate::validate(const std::string& equation, const Kinetics& kin)
 {
     if (m_coeffs.data().empty() || isnan(m_coeffs(0, 0))) {
-        throw CanteraError("ChebyshevRate::validate",
+        throw InputFileError("ChebyshevRate::validate", m_input,
             "Rate object for reaction '{}' is not configured.", equation);
     }
 }

--- a/src/kinetics/Custom.cpp
+++ b/src/kinetics/Custom.cpp
@@ -17,6 +17,7 @@ CustomFunc1Rate::CustomFunc1Rate()
 void CustomFunc1Rate::setRateFunction(shared_ptr<Func1> f)
 {
     m_ratefunc = f;
+    m_valid = true;
 }
 
 void CustomFunc1Rate::validate(const std::string& equation, const Kinetics& kin)

--- a/src/kinetics/Custom.cpp
+++ b/src/kinetics/Custom.cpp
@@ -22,7 +22,7 @@ void CustomFunc1Rate::setRateFunction(shared_ptr<Func1> f)
 void CustomFunc1Rate::validate(const std::string& equation, const Kinetics& kin)
 {
     if (!m_ratefunc) {
-        throw CanteraError("CustomFunc1Rate::validate",
+        throw InputFileError("CustomFunc1Rate::validate", m_input,
             "Rate object for reaction '{}' is not configured.", equation);
     }
 }

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -131,6 +131,7 @@ void FalloffRate::getFalloffCoeffs(vector_fp& c) const
 
 void FalloffRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
 {
+    ReactionRate::setParameters(node, rate_units);
     if (node.empty()) {
         return;
     }

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -189,14 +189,11 @@ void FalloffRate::check(const std::string& equation)
 {
     m_lowRate.check(equation);
     m_highRate.check(equation);
-
-    double lowA = m_lowRate.preExponentialFactor();
-    double highA = m_highRate.preExponentialFactor();
-    if (std::isnan(lowA) || std::isnan(highA)) {
+    if (!m_lowRate.ready() || !m_highRate.ready()) {
         // arrhenius rates are not initialized
         return;
     }
-    if (lowA * highA < 0) {
+    if (m_lowRate.preExponentialFactor() * m_highRate.preExponentialFactor() < 0) {
         throw InputFileError("FalloffRate::check", m_input,
             "Inconsistent rate definitions found in reaction '{}';\nhigh and low "
             "rate pre-exponential factors must have the same sign.", equation);

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -118,10 +118,11 @@ void FalloffRate::setHighRate(const ArrheniusRate& high)
 void FalloffRate::setFalloffCoeffs(const vector_fp& c)
 {
     if (c.size() != 0) {
-        throw CanteraError("FalloffRate::setFalloffCoeffs",
+        throw InputFileError("FalloffRate::setFalloffCoeffs", m_input,
             "Incorrect number of parameters. 0 required. Received {}.",
             c.size());
     }
+    m_ready = true;
 }
 
 void FalloffRate::getFalloffCoeffs(vector_fp& c) const
@@ -209,7 +210,7 @@ void FalloffRate::validate(const std::string& equation, const Kinetics& kin)
 void TroeRate::setFalloffCoeffs(const vector_fp& c)
 {
     if (c.size() != 3 && c.size() != 4) {
-        throw CanteraError("TroeRate::setFalloffCoeffs",
+        throw InputFileError("TroeRate::setFalloffCoeffs", m_input,
             "Incorrect number of coefficients. 3 or 4 required. Received {}.",
             c.size());
     }
@@ -240,6 +241,7 @@ void TroeRate::setFalloffCoeffs(const vector_fp& c)
     } else {
         m_t2 = 0.;
     }
+    m_ready = true;
 }
 
 void TroeRate::getFalloffCoeffs(vector_fp& c) const
@@ -310,7 +312,7 @@ void TroeRate::getParameters(AnyMap& node) const
     FalloffRate::getParameters(node);
 
     AnyMap params;
-    if (std::isnan(m_a)) {
+    if (!ready()) {
         // pass
     } else if (m_lowRate.rateUnits().factor() != 0.0) {
         params["A"] = m_a;
@@ -334,14 +336,14 @@ void TroeRate::getParameters(AnyMap& node) const
 void SriRate::setFalloffCoeffs(const vector_fp& c)
 {
     if (c.size() != 3 && c.size() != 5) {
-        throw CanteraError("SriRate::setFalloffCoeffs",
+        throw InputFileError("SriRate::setFalloffCoeffs", m_input,
             "Incorrect number of coefficients. 3 or 5 required. Received {}.",
             c.size());
     }
 
     if (c[2] < 0.0) {
-        throw CanteraError("SriRate::setFalloffCoeffs()",
-                           "m_c parameter is less than zero: {}", c[2]);
+        throw InputFileError("SriRate::setFalloffCoeffs()", m_input,
+                             "m_c parameter is less than zero: {}", c[2]);
     }
     m_a = c[0];
     m_b = c[1];
@@ -349,8 +351,8 @@ void SriRate::setFalloffCoeffs(const vector_fp& c)
 
     if (c.size() == 5) {
         if (c[3] < 0.0) {
-            throw CanteraError("SriRate::setFalloffCoeffs()",
-                               "m_d parameter is less than zero: {}", c[3]);
+            throw InputFileError("SriRate::setFalloffCoeffs()", m_input,
+                                 "m_d parameter is less than zero: {}", c[3]);
         }
         m_d = c[3];
         m_e = c[4];
@@ -358,6 +360,7 @@ void SriRate::setFalloffCoeffs(const vector_fp& c)
         m_d = 1.0;
         m_e = 0.0;
     }
+    m_ready = true;
 }
 
 void SriRate::getFalloffCoeffs(vector_fp& c) const
@@ -431,7 +434,7 @@ void SriRate::getParameters(AnyMap& node) const
     FalloffRate::getParameters(node);
 
     AnyMap params;
-    if (std::isnan(m_a)) {
+    if (!ready()) {
         // pass
     } else if (m_lowRate.rateUnits().factor() != 0.0) {
         params["A"] = m_a;
@@ -457,7 +460,7 @@ void SriRate::getParameters(AnyMap& node) const
 void TsangRate::setFalloffCoeffs(const vector_fp& c)
 {
     if (c.size() != 1 && c.size() != 2) {
-        throw CanteraError("TsangRate::init",
+        throw InputFileError("TsangRate::init", m_input,
             "Incorrect number of coefficients. 1 or 2 required. Received {}.",
             c.size());
     }
@@ -469,6 +472,7 @@ void TsangRate::setFalloffCoeffs(const vector_fp& c)
     else {
         m_b = 0.0;
     }
+    m_ready = true;
 }
 
 void TsangRate::getFalloffCoeffs(vector_fp& c) const
@@ -528,7 +532,7 @@ void TsangRate::getParameters(AnyMap& node) const
     FalloffRate::getParameters(node);
 
     AnyMap params;
-    if (std::isnan(m_a)) {
+    if (!ready()) {
         // pass
     } else {
         // Parameters do not have unit system (yet)

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -203,8 +203,12 @@ void FalloffRate::check(const std::string& equation)
 
 void FalloffRate::validate(const std::string& equation, const Kinetics& kin)
 {
-    m_lowRate.validate(equation, kin);
-    m_highRate.validate(equation, kin);
+    try {
+        m_lowRate.validate(equation, kin);
+        m_highRate.validate(equation, kin);
+    } catch (CanteraError& err) {
+        throw InputFileError("FalloffRate::validate", m_input, err.getMessage());
+    }
 }
 
 void TroeRate::setFalloffCoeffs(const vector_fp& c)

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -93,7 +93,7 @@ void FalloffRate::setLowRate(const ArrheniusRate& low)
 {
     ArrheniusRate _low = low;
     _low.setAllowNegativePreExponentialFactor(m_negativeA_ok);
-    _low.check("", AnyMap());
+    _low.check(m_input.getString("equation", ""));
     if (_low.preExponentialFactor() * m_highRate.preExponentialFactor() < 0.) {
         throw CanteraError("FalloffRate::setLowRate",
             "Detected inconsistent rate definitions;\nhigh and low "
@@ -106,7 +106,7 @@ void FalloffRate::setHighRate(const ArrheniusRate& high)
 {
     ArrheniusRate _high = high;
     _high.setAllowNegativePreExponentialFactor(m_negativeA_ok);
-    _high.check("", AnyMap());
+    _high.check(m_input.getString("equation", ""));
     if (m_lowRate.preExponentialFactor() * _high.preExponentialFactor() < 0.) {
         throw CanteraError("FalloffRate::setHighRate",
             "Detected inconsistent rate definitions;\nhigh and low "
@@ -185,10 +185,10 @@ void FalloffRate::getParameters(AnyMap& node) const
     }
 }
 
-void FalloffRate::check(const std::string& equation, const AnyMap& node)
+void FalloffRate::check(const std::string& equation)
 {
-    m_lowRate.check(equation, node);
-    m_highRate.check(equation, node);
+    m_lowRate.check(equation);
+    m_highRate.check(equation);
 
     double lowA = m_lowRate.preExponentialFactor();
     double highA = m_highRate.preExponentialFactor();
@@ -197,7 +197,7 @@ void FalloffRate::check(const std::string& equation, const AnyMap& node)
         return;
     }
     if (lowA * highA < 0) {
-        throw InputFileError("FalloffRate::check", node,
+        throw InputFileError("FalloffRate::check", m_input,
             "Inconsistent rate definitions found in reaction '{}';\nhigh and low "
             "rate pre-exponential factors must have the same sign.", equation);
     }

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -122,7 +122,7 @@ void FalloffRate::setFalloffCoeffs(const vector_fp& c)
             "Incorrect number of parameters. 0 required. Received {}.",
             c.size());
     }
-    m_ready = true;
+    m_valid = true;
 }
 
 void FalloffRate::getFalloffCoeffs(vector_fp& c) const
@@ -190,7 +190,7 @@ void FalloffRate::check(const std::string& equation)
 {
     m_lowRate.check(equation);
     m_highRate.check(equation);
-    if (!m_lowRate.ready() || !m_highRate.ready()) {
+    if (!m_lowRate.valid() || !m_highRate.valid()) {
         // arrhenius rates are not initialized
         return;
     }
@@ -245,7 +245,7 @@ void TroeRate::setFalloffCoeffs(const vector_fp& c)
     } else {
         m_t2 = 0.;
     }
-    m_ready = true;
+    m_valid = true;
 }
 
 void TroeRate::getFalloffCoeffs(vector_fp& c) const
@@ -316,7 +316,7 @@ void TroeRate::getParameters(AnyMap& node) const
     FalloffRate::getParameters(node);
 
     AnyMap params;
-    if (!ready()) {
+    if (!valid()) {
         // pass
     } else if (m_lowRate.rateUnits().factor() != 0.0) {
         params["A"] = m_a;
@@ -364,7 +364,7 @@ void SriRate::setFalloffCoeffs(const vector_fp& c)
         m_d = 1.0;
         m_e = 0.0;
     }
-    m_ready = true;
+    m_valid = true;
 }
 
 void SriRate::getFalloffCoeffs(vector_fp& c) const
@@ -438,7 +438,7 @@ void SriRate::getParameters(AnyMap& node) const
     FalloffRate::getParameters(node);
 
     AnyMap params;
-    if (!ready()) {
+    if (!valid()) {
         // pass
     } else if (m_lowRate.rateUnits().factor() != 0.0) {
         params["A"] = m_a;
@@ -476,7 +476,7 @@ void TsangRate::setFalloffCoeffs(const vector_fp& c)
     else {
         m_b = 0.0;
     }
-    m_ready = true;
+    m_valid = true;
 }
 
 void TsangRate::getFalloffCoeffs(vector_fp& c) const
@@ -536,7 +536,7 @@ void TsangRate::getParameters(AnyMap& node) const
     FalloffRate::getParameters(node);
 
     AnyMap params;
-    if (!ready()) {
+    if (!valid()) {
         // pass
     } else {
         // Parameters do not have unit system (yet)

--- a/src/kinetics/PlogRate.cpp
+++ b/src/kinetics/PlogRate.cpp
@@ -64,8 +64,9 @@ PlogRate::PlogRate(const std::multimap<double, ArrheniusRate>& rates)
     setRates(rates);
 }
 
-void PlogRate::setParameters(const AnyMap& node, const UnitStack& units)
+void PlogRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
 {
+    ReactionRate::setParameters(node, rate_units);
     std::multimap<double, ArrheniusRate> multi_rates;
     if (!node.hasKey("rate-constants")) {
          // ensure that reaction rate can be evaluated (but returns NaN)
@@ -75,7 +76,7 @@ void PlogRate::setParameters(const AnyMap& node, const UnitStack& units)
         auto& rates = node["rate-constants"].asVector<AnyMap>();
         for (const auto& rate : rates) {
             multi_rates.insert({rate.convert("P", "Pa"),
-                ArrheniusRate(AnyValue(rate), node.units(), units)});
+                ArrheniusRate(AnyValue(rate), node.units(), rate_units)});
         }
     }
     setRates(multi_rates);

--- a/src/kinetics/PlogRate.cpp
+++ b/src/kinetics/PlogRate.cpp
@@ -100,7 +100,7 @@ void PlogRate::setRates(const std::multimap<double, ArrheniusRate>& rates)
     size_t j = 0;
     rates_.clear();
     pressures_.clear();
-    m_valid = rates.size();
+    m_valid = !rates.empty();
     rates_.reserve(rates.size());
     // Insert intermediate pressures
     for (const auto& rate : rates) {
@@ -118,10 +118,8 @@ void PlogRate::setRates(const std::multimap<double, ArrheniusRate>& rates)
     }
     if (!m_valid) {
         // ensure that reaction rate can be evaluated (but returns NaN)
-        rates_.reserve(2);
-        pressures_[std::log(1.e-7)] = {0, 1};
-        rates_.push_back(ArrheniusRate());
-        pressures_[std::log(1.e14)] = {1, 2};
+        rates_.reserve(1);
+        pressures_[std::log(OneBar)] = {0, 0};
         rates_.push_back(ArrheniusRate());
     }
 

--- a/src/kinetics/PlogRate.cpp
+++ b/src/kinetics/PlogRate.cpp
@@ -86,9 +86,7 @@ void PlogRate::getParameters(AnyMap& rateNode, const Units& rate_units) const
 {
     std::vector<AnyMap> rateList;
     rateNode["type"] = type();
-    if (!rates_.size()
-        || (rates_.size() > 1 && std::isnan(rates_[1].preExponentialFactor())))
-    {
+    if (!ready()) {
         // object not fully set up
         return;
     }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -120,7 +120,7 @@ void Reaction::check()
 
     // Check reaction rate evaluator to ensure changes introduced after object
     // instantiation are considered.
-    m_rate->check(equation(), input);
+    m_rate->check(equation());
 }
 
 AnyMap Reaction::parameters(bool withInput) const

--- a/src/kinetics/TwoTempPlasmaRate.cpp
+++ b/src/kinetics/TwoTempPlasmaRate.cpp
@@ -46,7 +46,6 @@ void TwoTempPlasmaData::updateTe(double Te)
 }
 
 TwoTempPlasmaRate::TwoTempPlasmaRate()
-    : ArrheniusBase()
 {
     m_Ea_str = "Ea-gas";
     m_E4_str = "Ea-electron";


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Address `InputFileError` issues
- Simplify `ReactionRate::check`
- Avoid `NAN` as sentinel values for `ReactionRate` initialization status (see `--fast-math` enhancement issue)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1281, closes #1283, partially addresses Cantera/enhancements#125

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

Loading the following YAML
```yaml
phases:
- name: gas
  thermo: ideal-gas
  species: [{h2o2.yaml/species: all}]
  kinetics: gas
  reactions: all
  state: {T: 300.0, P: 1 atm, X: {O2: 0.21, N2: 0.79}}

reactions:
- equation: O + H2 <=> H + OH
  rate-constant: {A: 3.87e+04 cm^6/mol^2/s, b: 2.7, Ea: 6260.0}
- equation: 2 OH (+M) <=> H2O2 (+M)
  type: falloff
- equation: CH3 + OH => CH3O + H
  rate-constant: {A: 1.0, b: 0, Ea: 0}
```
results in the following error:
```
CanteraError:
*******************************************************************************
CanteraError thrown by addReactions:

*******************************************************************************
InputFileError thrown by UnitSystem::convert:
Error on line 11 of ./test.yaml:
Incompatible units:
    Units(1.0000000000000002e-06 m^6 / kmol^2 / s) and
    Units(m^3 / kmol / s)
|  Line |
|     6 |   reactions: all
|     7 |   state: {T: 300.0, P: 1 atm, X: {O2: 0.21, N2: 0.79}}
|     8 |
|     9 | reactions:
|    10 | - equation: O + H2 <=> H + OH
>    11 >   rate-constant: {A: 3.87e+04 cm^6/mol^2/s, b: 2.7, Ea: 6260.0}
                               ^
|    12 | - equation: 2 OH (+M) <=> H2O2 (+M)
|    13 |   type: falloff
|    14 | - equation: CH3 + OH => CH3O + H
*******************************************************************************

*******************************************************************************
InputFileError thrown by FalloffRate::validate:
Error on line 12 of ./test.yaml:
Rate object for reaction '2 OH (+M) <=> H2O2 (+M)' is not configured.
|  Line |
|     7 |   state: {T: 300.0, P: 1 atm, X: {O2: 0.21, N2: 0.79}}
|     8 |
|     9 | reactions:
|    10 | - equation: O + H2 <=> H + OH
|    11 |   rate-constant: {A: 3.87e+04 cm^6/mol^2/s, b: 2.7, Ea: 6260.0}
>    12 > - equation: 2 OH (+M) <=> H2O2 (+M)
            ^
|    13 |   type: falloff
|    14 | - equation: CH3 + OH => CH3O + H
|    15 |   rate-constant: {A: 1.0, b: 0, Ea: 0}
*******************************************************************************

*******************************************************************************
InputFileError thrown by Reaction::checkSpecies:
Error on line 14 of ./test.yaml:
Reaction 'CH3 + OH => CH3O + H'
contains undeclared species: 'CH3', 'CH3O'
|  Line |
|     9 | reactions:
|    10 | - equation: O + H2 <=> H + OH
|    11 |   rate-constant: {A: 3.87e+04 cm^6/mol^2/s, b: 2.7, Ea: 6260.0}
|    12 | - equation: 2 OH (+M) <=> H2O2 (+M)
|    13 |   type: falloff
>    14 > - equation: CH3 + OH => CH3O + H
            ^
|    15 |   rate-constant: {A: 1.0, b: 0, Ea: 0}
*******************************************************************************
*******************************************************************************
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
