### PR TITLE
Fix CustomRate segfaults and remove CustomReaction

### DIFF
--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -68,7 +68,7 @@ public:
     void setRateFunction(shared_ptr<Func1> f);
 
 protected:
-    shared_ptr<Func1> m_ratefunc;
+    shared_ptr<Func1> m_ratefunc = 0;
 };
 
 

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -68,7 +68,7 @@ public:
     void setRateFunction(shared_ptr<Func1> f);
 
 protected:
-    shared_ptr<Func1> m_ratefunc = 0;
+    shared_ptr<Func1> m_ratefunc;
 };
 
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -31,7 +31,7 @@ class ThirdBody;
 class Reaction
 {
 public:
-    Reaction();
+    Reaction() {}
     Reaction(const Composition& reactants, const Composition& products,
              shared_ptr<ReactionRate> rate={});
 
@@ -147,17 +147,17 @@ public:
     std::string id;
 
     //! True if the current reaction is reversible. False otherwise
-    bool reversible;
+    bool reversible = true;
 
     //! True if the current reaction is marked as duplicate
-    bool duplicate;
+    bool duplicate = false;
 
     //! True if reaction orders can be specified for non-reactant species.
     //! Default is `false`.
-    bool allow_nonreactant_orders;
+    bool allow_nonreactant_orders = false;
 
     //! True if negative reaction orders are allowed. Default is `false`.
-    bool allow_negative_orders;
+    bool allow_negative_orders = false;
 
     //! Input data used for specific models
     AnyMap input;
@@ -165,7 +165,7 @@ public:
     //! The units of the rate constant. These are determined by the units of the
     //! standard concentration of the reactant species' phases of the phase
     //! where the reaction occurs.
-    Units rate_units;
+    Units rate_units{0.0};
 
     //! Get reaction rate pointer
     shared_ptr<ReactionRate> rate() {
@@ -187,7 +187,7 @@ protected:
     virtual void getParameters(AnyMap& reactionNode) const;
 
     //! Flag indicating whether reaction is set up correctly
-    bool m_valid;
+    bool m_valid = true;
 
     //! Helper function returning vector of undeclared third body species
     //! and a boolean expression indicating whether the third body is specified.

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -287,27 +287,6 @@ public:
 };
 
 
-//! A reaction which follows mass-action kinetics with a custom reaction rate
-//! defined in Python.
-/**
- * @warning This class is an experimental part of the %Cantera API and
- *    may be changed or removed without notice.
- */
-class CustomFunc1Reaction : public Reaction
-{
-public:
-    CustomFunc1Reaction();
-    CustomFunc1Reaction(const Composition& reactants, const Composition& products,
-                        const CustomFunc1Rate& rate);
-
-    CustomFunc1Reaction(const AnyMap& node, const Kinetics& kin);
-
-    virtual std::string type() const {
-        return "custom-rate-function";
-    }
-};
-
-
 //! Create a new empty Reaction object
 /*!
  * @param type string identifying type of reaction.

--- a/interfaces/cython/cantera/examples/kinetics/custom_reactions.py
+++ b/interfaces/cython/cantera/examples/kinetics/custom_reactions.py
@@ -23,7 +23,7 @@ reactions = gas0.reactions()
 
 # construct custom reactions: replace 2nd reaction with equivalent custom reaction
 custom_reactions = [r for r in reactions]
-custom_reactions[2] = ct.CustomReaction(
+custom_reactions[2] = ct.Reaction(
     equation='H2 + O <=> H + OH',
     rate=lambda T: 38.7 * T**2.7 * exp(-3150.15428/T),
     kinetics=gas0)

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -70,6 +70,9 @@ cdef class Kinetics(_SolutionBase):
     of progress, species production rates, and other quantities pertaining to
     a reaction mechanism.
     """
+    #: List holding references to CustomRate objects (prevents garbage collection)
+    _custom_rates = []
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
         if self._references is None:
@@ -181,6 +184,9 @@ cdef class Kinetics(_SolutionBase):
     def add_reaction(self, Reaction rxn):
         """ Add a new reaction to this phase. """
         self.kinetics.addReaction(rxn._reaction)
+        if isinstance(rxn.rate, CustomRate):
+            # prevent garbage collection
+            self._custom_rates.append(rxn.rate)
 
     def multiplier(self, int i_reaction):
         """

--- a/interfaces/cython/cantera/reaction.pxd
+++ b/interfaces/cython/cantera/reaction.pxd
@@ -238,9 +238,6 @@ cdef extern from "cantera/kinetics/Reaction.h" namespace "Cantera":
     cdef cppclass CxxFalloffReaction "Cantera::FalloffReaction" (CxxReaction):
         CxxFalloffReaction()
 
-    cdef cppclass CxxCustomFunc1Reaction "Cantera::CustomFunc1Reaction" (CxxReaction):
-        CxxCustomFunc1Reaction()
-
 
 cdef class ReactionRate:
     cdef shared_ptr[CxxReactionRate] _rate
@@ -258,7 +255,7 @@ cdef class FalloffRate(ReactionRate):
 
 cdef class CustomRate(ReactionRate):
     cdef CxxCustomFunc1Rate* cxx_object(self)
-    cdef Func1 _rate_func
+    cdef Func1 _rate_func  # prevent premature garbage collection
 
 cdef class InterfaceRateBase(ArrheniusRateBase):
     cdef CxxInterfaceRateBase* interface
@@ -271,9 +268,7 @@ cdef class Reaction:
     cdef CxxReaction* reaction
     @staticmethod
     cdef wrap(shared_ptr[CxxReaction])
-
-cdef class CustomReaction(Reaction):
-    cdef CustomRate _rate
+    cdef ReactionRate _rate
 
 cdef class Arrhenius:
     cdef CxxArrheniusRate* base

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -671,7 +671,8 @@ cdef class CustomRate(ReactionRate):
             try:
                 self.set_rate_function(k)
             except Exception:
-                raise TypeError(f"Cannot convert input with type '{type(k)}' to rate expression.")
+                raise TypeError(
+                    f"Cannot convert input with type '{type(k)}' to rate expression.")
 
     cdef CxxCustomFunc1Rate* cxx_object(self):
         return <CxxCustomFunc1Rate*>self.rate

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -3,6 +3,7 @@
 
 cimport numpy as np
 import numpy as np
+import warnings
 from cython.operator cimport dereference as deref
 
 from .kinetics cimport Kinetics

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -795,29 +795,6 @@ void FalloffReaction::getParameters(AnyMap& reactionNode) const
     }
 }
 
-CustomFunc1Reaction::CustomFunc1Reaction()
-{
-    setRate(newReactionRate(type()));
-}
-
-CustomFunc1Reaction::CustomFunc1Reaction(const Composition& reactants,
-                                         const Composition& products,
-                                         const CustomFunc1Rate& rate)
-    : Reaction(reactants, products)
-{
-    m_rate.reset(new CustomFunc1Rate(rate));
-}
-
-CustomFunc1Reaction::CustomFunc1Reaction(const AnyMap& node, const Kinetics& kin)
-{
-    if (!node.empty()) {
-        setParameters(node, kin);
-        setRate(newReactionRate(node, calculateRateCoeffUnits(kin)));
-    } else {
-        setRate(newReactionRate(type()));
-    }
-}
-
 bool isThreeBody(const Reaction& R)
 {
     // detect explicitly specified collision partner

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -26,27 +26,11 @@ namespace ba = boost::algorithm;
 namespace Cantera
 {
 
-Reaction::Reaction()
-    : reversible(true)
-    , duplicate(false)
-    , allow_nonreactant_orders(false)
-    , allow_negative_orders(false)
-    , rate_units(0.0)
-    , m_valid(true)
-{
-}
-
 Reaction::Reaction(const Composition& reactants_,
                    const Composition& products_,
                    shared_ptr<ReactionRate> rate_)
     : reactants(reactants_)
     , products(products_)
-    , reversible(true)
-    , duplicate(false)
-    , allow_nonreactant_orders(false)
-    , allow_negative_orders(false)
-    , rate_units(0.0)
-    , m_valid(true)
     , m_rate(rate_)
 {
 }
@@ -657,7 +641,6 @@ std::string ThreeBodyReaction::productString() const
 }
 
 FalloffReaction::FalloffReaction()
-    : Reaction()
 {
     m_third_body.reset(new ThirdBody);
     m_third_body->mass_action = false;

--- a/src/kinetics/ReactionFactory.cpp
+++ b/src/kinetics/ReactionFactory.cpp
@@ -54,9 +54,7 @@ ReactionFactory::ReactionFactory()
     addAlias("reaction", "chebyshev");
 
     // register custom reactions specified by Func1 objects
-    reg("custom-rate-function", [](const AnyMap& node, const Kinetics& kin) {
-        return new CustomFunc1Reaction(node, kin);
-    });
+    addAlias("reaction", "custom-rate-function");
 
     addAlias("reaction", "interface-Arrhenius");
     addAlias("reaction", "sticking-Arrhenius");


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Remove `CustomReaction` specialization
- Fix segfaults caused by temporary Python objects

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1282, partially addresses Cantera/enhancements#142

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
