### PR TITLE
[Python] Disable warnings for extinct flame

### DIFF
--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -1280,28 +1280,28 @@ class CounterflowDiffusionFlame(FlameBase):
         if loglevel > 0:
             if self.extinct():
                 print('WARNING: Flame is extinct.')
+            else:
+                # Check if the flame is very thick
+                # crude width estimate based on temperature
+                z_flame = self.grid[self.T > np.max(self.T) / 2]
+                flame_width = z_flame[-1] - z_flame[0]
+                domain_width = self.grid[-1] - self.grid[0]
+                if flame_width / domain_width > 0.4:
+                    print('WARNING: The flame is thick compared to the domain '
+                          'size. The flame might be affected by the plug-flow '
+                          'boundary conditions. Consider increasing the inlet mass '
+                          'fluxes or using a larger domain.')
 
-            # Check if the flame is very thick
-            # crude width estimate based on temperature
-            z_flame = self.grid[self.T > np.max(self.T) / 2]
-            flame_width = z_flame[-1] - z_flame[0]
-            domain_width = self.grid[-1] - self.grid[0]
-            if flame_width / domain_width > 0.4:
-                print('WARNING: The flame is thick compared to the domain '
-                      'size. The flame might be affected by the plug-flow '
-                      'boundary conditions. Consider increasing the inlet mass '
-                      'fluxes or using a larger domain.')
-
-            # Check if the temperature peak is close to a boundary
-            z_center = (self.grid[np.argmax(self.T)] - self.grid[0]) / domain_width
-            if z_center < 0.25:
-                print('WARNING: The flame temperature peak is close to the '
-                      'fuel inlet. Consider increasing the ratio of the '
-                      'fuel inlet mass flux to the oxidizer inlet mass flux.')
-            if z_center > 0.75:
-                print('WARNING: The flame temperature peak is close to the '
-                      'oxidizer inlet. Consider increasing the ratio of the '
-                      'oxidizer inlet mass flux to the fuel inlet mass flux.')
+                # Check if the temperature peak is close to a boundary
+                z_center = (self.grid[np.argmax(self.T)] - self.grid[0]) / domain_width
+                if z_center < 0.25:
+                    print('WARNING: The flame temperature peak is close to the '
+                          'fuel inlet. Consider increasing the ratio of the '
+                          'fuel inlet mass flux to the oxidizer inlet mass flux.')
+                if z_center > 0.75:
+                    print('WARNING: The flame temperature peak is close to the '
+                          'oxidizer inlet. Consider increasing the ratio of the '
+                          'oxidizer inlet mass flux to the fuel inlet mass flux.')
 
     def strain_rate(self, definition, fuel=None, oxidizer='O2', stoich=None):
         r"""


### PR DESCRIPTION
**Changes proposed in this pull request**

Currently, each counterflow flame solution that is extinct will print a warning that the flame is too thick. Since the temperature-based checks for flame thickness and width do not make sense for an extinct flame, disable the warnings in that case.

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
