### PR TITLE
Update three body logic

### DIFF
--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -195,7 +195,7 @@ public:
             "To be removed after Cantera 3.0; superseded by getFalloffCoeffs.");
     }
 
-    virtual void getParameters(AnyMap& node) const;
+    virtual void getParameters(AnyMap& node) const override;
 
     //! Evaluate reaction rate
     //! @param shared_data  data shared by all reactions of a given type

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -195,7 +195,10 @@ protected:
     bool m_valid = true;
 
     //! Flag indicating that serialization uses explicit type
-    bool m_explicit_rate = false;
+    bool m_explicit_type = false;
+
+    //! Flag indicating that third body collider is ambiguous
+    bool m_explicit_3rd = false;
 
     //! Flag indicating that object was instantiated from reactant/product compositions
     bool m_from_composition = false;
@@ -239,8 +242,10 @@ public:
     void setParameters(const AnyMap& node);
 
     //! Get third-body efficiencies from AnyMap *node*
+    //! @param node  AnyMap receiving serialized parameters
+    //! @param explicit_3rd  Flag triggering explicit third body efficiency output
     //! @since  New in Cantera 3.0
-    void getParameters(AnyMap& node) const;
+    void getParameters(AnyMap& node, bool explicit_3rd=false) const;
 
     //! Get the third-body efficiency for species *k*
     double efficiency(const std::string& k) const;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -197,7 +197,7 @@ protected:
     //! Flag indicating that serialization uses explicit type
     bool m_explicit_type = false;
 
-    //! Flag indicating that third body collider is ambiguous
+    //! Flag indicating that third body requires explicit serialization
     bool m_explicit_3rd = false;
 
     //! Flag indicating that object was instantiated from reactant/product compositions
@@ -245,7 +245,7 @@ public:
     //! @param node  AnyMap receiving serialized parameters
     //! @param explicit_3rd  Flag triggering explicit third body efficiency output
     //! @since  New in Cantera 3.0
-    void getParameters(AnyMap& node, bool explicit_3rd=false) const;
+    void getParameters(AnyMap& node, bool explicit_3rd) const;
 
     //! Get the third-body efficiency for species *k*
     double efficiency(const std::string& k) const;

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -197,9 +197,6 @@ protected:
     //! Flag indicating that serialization uses explicit type
     bool m_explicit_type = false;
 
-    //! Flag indicating that third body requires explicit serialization
-    bool m_explicit_3rd = false;
-
     //! Flag indicating that object was instantiated from reactant/product compositions
     bool m_from_composition = false;
 
@@ -243,9 +240,8 @@ public:
 
     //! Get third-body efficiencies from AnyMap *node*
     //! @param node  AnyMap receiving serialized parameters
-    //! @param explicit_3rd  Flag triggering explicit third body efficiency output
     //! @since  New in Cantera 3.0
-    void getParameters(AnyMap& node, bool explicit_3rd) const;
+    void getParameters(AnyMap& node) const;
 
     //! Get the third-body efficiency for species *k*
     double efficiency(const std::string& k) const;
@@ -273,6 +269,9 @@ public:
     //! Third body is used by law of mass action
     //! (`true` for three-body reactions, `false` for falloff reactions)
     bool mass_action = true;
+
+    //! Flag indicating whether third body requires explicit serialization
+    bool explicit_3rd = false;
 
 protected:
     //! Name of the third body collider

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1146,7 +1146,7 @@ cdef class Reaction:
 
     def __cinit__(self, reactants=None, products=None, rate=None, *,
                   equation=None, init=True, efficiencies=None,
-                  Kinetics kinetics=None, third_body=None, **kwargs):
+                  Kinetics kinetics=None, third_body=None):
         if kinetics:
             warnings.warn(
                 "Parameter 'kinetics' is no longer used and will be removed after "

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -360,7 +360,9 @@ void Reaction::setEquation(const std::string& equation, const Kinetics* kin)
         }
         third_body = "M";
 
-    } else if (!ba::starts_with(third_body, "(+")) {
+    } else if (third_body != "M" && !ba::starts_with(rate_type, "three-body")
+            && !ba::starts_with(third_body, "(+"))
+    {
         // check for conditions of three-body reactions:
         // - integer stoichiometric conditions
         // - either reactant or product side involves exactly three species

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -38,7 +38,7 @@ Reaction::Reaction(const Composition& reactants_,
 {
     setRate(rate_);
 
-    // ensure safe serialization
+    // set flags ensuring correct serialization output
     bool count = 0;
     for (const auto& reac : reactants) {
         if (products.count(reac.first)) {

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -149,6 +149,49 @@ TEST_F(KineticsFromScratch, multiple_third_bodies3)
     EXPECT_TRUE(R->usesThirdBody());
 }
 
+TEST_F(KineticsFromScratch, multiple_third_bodies4)
+{
+    std::string equation = "H2 + O2 => H2 + O2";
+    auto rate = make_shared<ArrheniusRate>(1.2e11, -1.0, 0.0);
+    auto tbody = make_shared<ThirdBody>("O2");
+    auto R = make_shared<Reaction>(equation, rate, tbody);
+
+    AnyMap input = R->parameters();
+    EXPECT_FALSE(input.hasKey("type"));
+    EXPECT_TRUE(input.hasKey("efficiencies"));
+    auto efficiencies = input["efficiencies"].asMap<double>();
+    EXPECT_EQ(efficiencies.size(), 1);
+    EXPECT_EQ(efficiencies.begin()->first, "O2");
+    EXPECT_TRUE(input.hasKey("default-efficiency"));
+    EXPECT_EQ(input["default-efficiency"].asDouble(), 0.);
+}
+
+TEST_F(KineticsFromScratch, multiple_third_bodies5)
+{
+    std::string equation = "H2 + O2 => H2 + O2";
+    auto rate = make_shared<ArrheniusRate>(1.2e11, -1.0, 0.0);
+    auto tbody = make_shared<ThirdBody>("AR"); // incompatible third body
+    ASSERT_THROW(Reaction(equation, rate, tbody), CanteraError);
+}
+
+TEST_F(KineticsFromScratch, multiple_third_bodies6)
+{
+    Composition reac = parseCompString("H2:1");
+    Composition prod = parseCompString("H2:1");
+    auto rate = make_shared<ArrheniusRate>(1.2e11, -1.0, 0.0);
+    auto tbody = make_shared<ThirdBody>("O2");
+    auto R = make_shared<Reaction>(reac, prod, rate, tbody);
+
+    AnyMap input = R->parameters();
+    EXPECT_FALSE(input.hasKey("type"));
+    EXPECT_TRUE(input.hasKey("efficiencies"));
+    auto efficiencies = input["efficiencies"].asMap<double>();
+    EXPECT_EQ(efficiencies.size(), 1);
+    EXPECT_EQ(efficiencies.begin()->first, "O2");
+    EXPECT_TRUE(input.hasKey("default-efficiency"));
+    EXPECT_EQ(input["default-efficiency"].asDouble(), 0.);
+}
+
 TEST_F(KineticsFromScratch, add_two_temperature_plasma)
 {
     std::string equation = "O + H => O + H";

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -156,6 +156,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies4)
     auto tbody = make_shared<ThirdBody>("O2");
     auto R = make_shared<Reaction>(equation, rate, tbody);
     EXPECT_EQ(R->thirdBody()->name(), "O2");
+    EXPECT_EQ(R->thirdBody()->default_efficiency, 0.);
 
     AnyMap input = R->parameters(false);
     EXPECT_FALSE(input.hasKey("type"));
@@ -163,8 +164,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies4)
     auto efficiencies = input["efficiencies"].asMap<double>();
     EXPECT_EQ(efficiencies.size(), 1);
     EXPECT_EQ(efficiencies.begin()->first, "O2");
-    EXPECT_TRUE(input.hasKey("default-efficiency"));
-    EXPECT_EQ(input["default-efficiency"].asDouble(), 0.);
+    EXPECT_FALSE(input.hasKey("default-efficiency"));
 }
 
 TEST_F(KineticsFromScratch, multiple_third_bodies5)
@@ -183,6 +183,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies6)
     auto tbody = make_shared<ThirdBody>("O2");
     auto R = make_shared<Reaction>(reac, prod, rate, tbody);
     EXPECT_EQ(R->thirdBody()->name(), "O2");
+    EXPECT_EQ(R->thirdBody()->default_efficiency, 0.);
 
     AnyMap input = R->parameters(false);
     EXPECT_FALSE(input.hasKey("type"));
@@ -190,8 +191,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies6)
     auto efficiencies = input["efficiencies"].asMap<double>();
     EXPECT_EQ(efficiencies.size(), 1);
     EXPECT_EQ(efficiencies.begin()->first, "O2");
-    EXPECT_TRUE(input.hasKey("default-efficiency"));
-    EXPECT_EQ(input["default-efficiency"].asDouble(), 0.);
+    EXPECT_FALSE(input.hasKey("default-efficiency"));
 }
 
 TEST_F(KineticsFromScratch, multiple_third_bodies7)

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -155,6 +155,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies4)
     auto rate = make_shared<ArrheniusRate>(1.2e11, -1.0, 0.0);
     auto tbody = make_shared<ThirdBody>("O2");
     auto R = make_shared<Reaction>(equation, rate, tbody);
+    EXPECT_EQ(R->thirdBody()->name(), "O2");
 
     AnyMap input = R->parameters();
     EXPECT_FALSE(input.hasKey("type"));
@@ -181,6 +182,45 @@ TEST_F(KineticsFromScratch, multiple_third_bodies6)
     auto rate = make_shared<ArrheniusRate>(1.2e11, -1.0, 0.0);
     auto tbody = make_shared<ThirdBody>("O2");
     auto R = make_shared<Reaction>(reac, prod, rate, tbody);
+    EXPECT_EQ(R->thirdBody()->name(), "O2");
+
+    AnyMap input = R->parameters();
+    EXPECT_FALSE(input.hasKey("type"));
+    EXPECT_TRUE(input.hasKey("efficiencies"));
+    auto efficiencies = input["efficiencies"].asMap<double>();
+    EXPECT_EQ(efficiencies.size(), 1);
+    EXPECT_EQ(efficiencies.begin()->first, "O2");
+    EXPECT_TRUE(input.hasKey("default-efficiency"));
+    EXPECT_EQ(input["default-efficiency"].asDouble(), 0.);
+}
+
+TEST_F(KineticsFromScratch, multiple_third_bodies7)
+{
+    std::string equation = "CH2OCH + M <=> CH2CHO + M";
+    auto rate = make_shared<ArrheniusRate>(1.2e11, -1.0, 0.0);
+    auto tbody = make_shared<ThirdBody>("O2");
+    auto R = make_shared<Reaction>(equation, rate, tbody);
+    EXPECT_EQ(R->thirdBody()->name(), "M");
+
+    AnyMap input = R->parameters();
+    EXPECT_FALSE(input.hasKey("type"));
+    EXPECT_TRUE(input.hasKey("efficiencies"));
+    auto efficiencies = input["efficiencies"].asMap<double>();
+    EXPECT_EQ(efficiencies.size(), 1);
+    EXPECT_EQ(efficiencies.begin()->first, "O2");
+    EXPECT_TRUE(input.hasKey("default-efficiency"));
+    EXPECT_EQ(input["default-efficiency"].asDouble(), 0.);
+}
+
+TEST_F(KineticsFromScratch, multiple_third_bodies8)
+{
+    std::string equation = "CH2OCH + M <=> CH2CHO + M";
+    auto rate = make_shared<ArrheniusRate>(1.2e11, -1.0, 0.0);
+    auto tbody = make_shared<ThirdBody>();
+    tbody->efficiencies = parseCompString("O2:1");
+    tbody->default_efficiency = 0.;
+    auto R = make_shared<Reaction>(equation, rate, tbody);
+    EXPECT_EQ(R->thirdBody()->name(), "M");
 
     AnyMap input = R->parameters();
     EXPECT_FALSE(input.hasKey("type"));

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -157,7 +157,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies4)
     auto R = make_shared<Reaction>(equation, rate, tbody);
     EXPECT_EQ(R->thirdBody()->name(), "O2");
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_FALSE(input.hasKey("type"));
     EXPECT_TRUE(input.hasKey("efficiencies"));
     auto efficiencies = input["efficiencies"].asMap<double>();
@@ -184,7 +184,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies6)
     auto R = make_shared<Reaction>(reac, prod, rate, tbody);
     EXPECT_EQ(R->thirdBody()->name(), "O2");
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_FALSE(input.hasKey("type"));
     EXPECT_TRUE(input.hasKey("efficiencies"));
     auto efficiencies = input["efficiencies"].asMap<double>();
@@ -202,7 +202,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies7)
     auto R = make_shared<Reaction>(equation, rate, tbody);
     EXPECT_EQ(R->thirdBody()->name(), "M");
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_FALSE(input.hasKey("type"));
     EXPECT_TRUE(input.hasKey("efficiencies"));
     auto efficiencies = input["efficiencies"].asMap<double>();
@@ -222,7 +222,7 @@ TEST_F(KineticsFromScratch, multiple_third_bodies8)
     auto R = make_shared<Reaction>(equation, rate, tbody);
     EXPECT_EQ(R->thirdBody()->name(), "M");
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_FALSE(input.hasKey("type"));
     EXPECT_TRUE(input.hasKey("efficiencies"));
     auto efficiencies = input["efficiencies"].asMap<double>();

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -92,7 +92,7 @@ TEST(Reaction, ThreeBodyFromYaml2)
     const auto& rate = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), 1.2e11);
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_FALSE(input.hasKey("type"));
     EXPECT_TRUE(input.hasKey("efficiencies"));
 
@@ -134,7 +134,7 @@ TEST(Reaction, ThreeBodyFromYaml4)
     const auto& rate = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), 5.0e+9);
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_EQ(input.getString("type", ""), "three-body");
     EXPECT_FALSE(input.hasKey("efficiencies"));
     EXPECT_FALSE(input.hasKey("default-efficiency"));
@@ -168,7 +168,7 @@ TEST(Reaction, ThreeBodyFromYaml6)
     const auto& rate = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), 5.0e+9);
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_FALSE(input.hasKey("type"));
     EXPECT_TRUE(input.hasKey("efficiencies"));
     auto efficiencies = input["efficiencies"].asMap<double>();
@@ -196,7 +196,7 @@ TEST(Reaction, ThreeBodyFromYaml7)
     const auto& rate = std::dynamic_pointer_cast<ArrheniusRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), 5.0e+9);
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_EQ(input.getString("type", ""), "three-body");
     EXPECT_TRUE(input.hasKey("efficiencies"));
     auto efficiencies = input["efficiencies"].asMap<double>();
@@ -454,7 +454,7 @@ TEST(Reaction, ThreeBodyBlowersMaselFromYaml)
     const auto& rate = std::dynamic_pointer_cast<BlowersMaselRate>(R->rate());
     EXPECT_DOUBLE_EQ(rate->preExponentialFactor(), 38.7);
 
-    AnyMap input = R->parameters();
+    AnyMap input = R->parameters(false);
     EXPECT_EQ(input.getString("type", ""), "three-body-Blowers-Masel");
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix cases where three-body detection logic introduced in #1333 fails

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
In [2]: ct.Reaction(
   ...:     equation="CH2OCH + M <=> CH2CHO + M", rate={"A": 5.0e09, "b": 0.0, "Ea": 0.0}
   ...: )
Out[2]: CH2OCH + M <=> CH2CHO + M    <three-body-Arrhenius>
```

plus several edge cases where three-body reactions are explicitly or implicitly defined, e.g.

```
In [3]: gas = ct.Solution("h2o2.yaml")
   ...: _yaml = """
   ...:         equation: H2 + O2 <=> H2 + O2
   ...:         type: three-body-Blowers-Masel # or type: Blowers-Masel
   ...:         rate-constant: {A: 38700, b: 2.7, Ea0: 2.619184e4 cal/mol, w: 4.184e9 cal/mol}
   ...:         efficiencies: {O2: 1}
   ...:         default-efficiency: 0.
   ...:         """
   ...: ct.Reaction.from_yaml(_yaml, gas)
Out[3]: H2 + O2 <=> H2 + O2    <three-body-Blowers-Masel>
```
or
```
In [4]: rxn = ct.Reaction(
   ...:     equation="H2 + O2 <=> H2 + O2",
   ...:     rate={"A": 5.0e09, "b": 0.0, "Ea": 0.0},
   ...:     third_body=ct.ThirdBody("O2"),
   ...: )
   ...: rxn
Out[4]: H2 + O2 <=> H2 + O2    <three-body-Arrhenius>

In [5]: rxn.input_data
Out[5]:
{'equation': 'H2 + O2 <=> H2 + O2',
 'rate-constant': {'A': 5000000000.0, 'b': 0.0, 'Ea': 0.0},
 'efficiencies': {'O2': 1.0},
 'default-efficiency': 0.0}
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
