### PR TITLE
[CI] Bump macOS version for testing

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -94,7 +94,7 @@ jobs:
     strategy:
       matrix:
         python-version: [ '3.7', '3.9', '3.10' ]
-        os: ['macos-10.15']
+        os: ['macos-11', 'macos-12']
       fail-fast: false
     steps:
     # Attempt to fix intermittent cloning errors. The error message says something like

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -89,12 +89,11 @@ jobs:
 
   macos-multiple-pythons:
     name: macOS with Python ${{ matrix.python-version }}
-    runs-on: ${{ matrix.os }}
+    runs-on: macos-11
     timeout-minutes: 90
     strategy:
       matrix:
         python-version: [ '3.7', '3.9', '3.10' ]
-        os: ['macos-11', 'macos-12']
       fail-fast: false
     steps:
     # Attempt to fix intermittent cloning errors. The error message says something like


### PR DESCRIPTION
Per the changelog, macOS-10.15 support will be dropped in August, 2022.

https://github.blog/changelog/2022-07-20-github-actions-the-macos-10-15-actions-runner-image-is-being-deprecated-and-will-be-removed-by-8-30-22/

I'm not sure whether we'll want to have macOS 11 _and_ 12, or just one of them. I also considered dropping Ubuntu 18.04 and adding Ubuntu 22.04 (see [here](https://github.com/actions/virtual-environments#available-environments) for supported versions) but figured that could be deferred.

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
