### PR TITLE
Update supported SUNDIALS versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -329,7 +329,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        sundials-ver: [ 2, 3, 4, 5.8, 6.0 ]
+        sundials-ver: [ 3, 4, 5.8, 6.0 ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -329,7 +329,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        sundials-ver: [ 3, 4, 5.8, 6.0 ]
+        sundials-ver: [ 3, 4, 5.8, 6.2 ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/SConstruct
+++ b/SConstruct
@@ -1335,7 +1335,7 @@ if env['system_sundials'] == 'y':
     if sundials_ver < parse_version("3.0") or sundials_ver >= parse_version("7.0"):
         logger.error(f"Sundials version {env['sundials_version']!r} is not supported.")
         sys.exit(1)
-    elif sundials_ver > parse_version("6.0"):
+    elif sundials_ver > parse_version("6.2"):
         logger.warning(f"Sundials version {env['sundials_version']!r} has not been tested.")
 
     logger.info(f"Using system installation of Sundials version {sundials_version!r}.")

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -10,12 +10,7 @@
 #if CT_USE_LAPACK
     #include "cantera/numerics/ctlapack.h"
 #else
-    #if CT_SUNDIALS_VERSION >= 30
-        #include "sunlinsol/sunlinsol_band.h"
-    #else
-        #include "cvodes/cvodes_dense.h"
-        #include "cvodes/cvodes_band.h"
-    #endif
+    #include "sunlinsol/sunlinsol_band.h"
 #endif
 
 #include <cstring>
@@ -31,12 +26,8 @@ namespace Cantera
 struct BandMatrix::PivData {
 #if CT_USE_LAPACK
     vector_int data;
-#elif CT_SUNDIALS_VERSION >= 30
-    std::vector<sunindextype> data;
-#elif CT_SUNDIALS_VERSION >= 25
-    std::vector<long int> data;
 #else
-    std::vector<int> data;
+    std::vector<sunindextype> data;
 #endif
 };
 


### PR DESCRIPTION
Since Ubuntu 20.04 has SUNDIALS 3.1.2, and is the oldest Ubuntu version we are likely to support in Cantera 3.0, we can now drop support for SUNDIALS 2.x, simplifying some of the crazy `#ifdef`s in the code that uses SUNDIALS.

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Drop support for SUNDIALS 2.x
- Include the latest SUNDIALS release (6.2.0) in CI testing

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
