### PR TITLE
Add missing array properties to SolutionArray and FlameBase

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -463,7 +463,7 @@ class SolutionArray:
 
     _scalar = [
         # From ThermoPhase
-        'mean_molecular_weight', 'P', 'T', 'density', 'density_mass',
+        'mean_molecular_weight', 'P', 'T', 'Te', 'density', 'density_mass',
         'density_mole', 'v', 'volume_mass', 'volume_mole', 'u',
         'int_energy_mole', 'int_energy_mass', 'h', 'enthalpy_mole',
         'enthalpy_mass', 's', 'entropy_mole', 'entropy_mass', 'g', 'gibbs_mole',
@@ -484,18 +484,25 @@ class SolutionArray:
         'chemical_potentials', 'electrochemical_potentials', 'partial_molar_cp',
         'partial_molar_volumes', 'standard_enthalpies_RT',
         'standard_entropies_R', 'standard_int_energies_RT', 'standard_gibbs_RT',
-        'standard_cp_R',
+        'standard_cp_R', 'activities', 'activity_coefficients',
         # From Transport
         'mix_diff_coeffs', 'mix_diff_coeffs_mass', 'mix_diff_coeffs_mole',
-        'thermal_diff_coeffs'
+        'thermal_diff_coeffs', 'mobilities', 'species_viscosities',
     ]
 
     # From Kinetics (differs from Solution.n_species for Interface phases)
     _n_total_species = [
         'creation_rates', 'destruction_rates', 'net_production_rates',
+        'creation_rates_ddC', 'creation_rates_ddP', 'creation_rates_ddT',
+        'destruction_rates_ddC', 'destruction_rates_ddP', 'destruction_rates_ddT',
+        'net_production_rates_ddC', 'net_production_rates_ddP',
+        'net_production_rates_ddT'
     ]
 
-    _n_species2 = ['multi_diff_coeffs', 'binary_diff_coeffs']
+    _n_species2 = [
+        'multi_diff_coeffs', 'binary_diff_coeffs', 'creation_rates_ddX',
+        'destruction_rates_ddX', 'net_production_rates_ddX'
+    ]
 
     _n_reactions = [
         'forward_rates_of_progress', 'reverse_rates_of_progress',
@@ -504,6 +511,13 @@ class SolutionArray:
         'delta_enthalpy', 'delta_gibbs', 'delta_entropy',
         'delta_standard_enthalpy', 'delta_standard_gibbs',
         'delta_standard_entropy', 'heat_production_rates',
+        'forward_rate_constants_ddC', 'forward_rate_constants_ddP',
+        'forward_rate_constants_ddT', 'forward_rates_of_progress_ddC',
+        'forward_rates_of_progress_ddP', 'forward_rates_of_progress_ddT',
+        'net_rates_of_progress_ddC', 'net_rates_of_progress_ddP',
+        'net_rates_of_progress_ddT', 'reverse_rates_of_progress_ddC',
+        'reverse_rates_of_progress_ddP', 'reverse_rates_of_progress_ddP',
+        'reverse_rates_of_progress_ddT', 'third_body_concentrations',
     ]
     _call_scalar = ['elemental_mass_fraction', 'elemental_mole_fraction']
 
@@ -519,7 +533,8 @@ class SolutionArray:
         'kinetics_species_index', 'reaction', 'reactions', 'modify_reaction',
         'multiplier', 'set_multiplier', 'reaction_equations',
         'reactant_stoich_coeff', 'product_stoich_coeff',
-        'reactant_stoich_coeffs', 'product_stoich_coeffs',
+        'reactant_stoich_coeffs', 'product_stoich_coeffs', 'product_stoich_coeffs3',
+        'reactant_stoich_coeffs3', 'product_stoich_coeffs_reversible',
         # from Transport
         'transport_model',
     ]

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -711,7 +711,8 @@ for _attr in ['density', 'density_mass', 'density_mole', 'volume_mass',
               'entropy_mass', 'g', 'gibbs_mole', 'gibbs_mass', 'cv',
               'cv_mole', 'cv_mass', 'cp', 'cp_mole', 'cp_mass',
               'isothermal_compressibility', 'thermal_expansion_coeff',
-              'viscosity', 'thermal_conductivity', 'heat_release_rate']:
+              'viscosity', 'thermal_conductivity', 'heat_release_rate',
+              'mean_molecular_weight']:
     setattr(FlameBase, _attr, _array_property(_attr))
 FlameBase.volume = _array_property('v') # avoid confusion with velocity gradient 'V'
 FlameBase.int_energy = _array_property('u') # avoid collision with velocity 'u'
@@ -723,8 +724,13 @@ for _attr in ['X', 'Y', 'concentrations', 'partial_molar_enthalpies',
               'partial_molar_volumes', 'standard_enthalpies_RT',
               'standard_entropies_R', 'standard_int_energies_RT',
               'standard_gibbs_RT', 'standard_cp_R', 'creation_rates',
-              'destruction_rates', 'net_production_rates', 'mix_diff_coeffs',
-              'mix_diff_coeffs_mass', 'mix_diff_coeffs_mole', 'thermal_diff_coeffs']:
+              'destruction_rates', 'net_production_rates', 'creation_rates_ddC',
+              'creation_rates_ddP', 'creation_rates_ddT', 'destruction_rates_ddC',
+              'destruction_rates_ddP', 'destruction_rates_ddT',
+              'net_production_rates_ddC', 'net_production_rates_ddP',
+              'net_production_rates_ddT', 'mix_diff_coeffs', 'mix_diff_coeffs_mass',
+              'mix_diff_coeffs_mole', 'thermal_diff_coeffs', 'activities',
+              'activity_coefficients', 'mobilities', 'species_viscosities']:
     setattr(FlameBase, _attr, _array_property(_attr, 'n_species'))
 
 # Remove misleading examples and references to setters that don't exist
@@ -738,7 +744,14 @@ for _attr in ['forward_rates_of_progress', 'reverse_rates_of_progress', 'net_rat
               'equilibrium_constants', 'forward_rate_constants', 'reverse_rate_constants',
               'delta_enthalpy', 'delta_gibbs', 'delta_entropy',
               'delta_standard_enthalpy', 'delta_standard_gibbs',
-              'delta_standard_entropy', 'heat_production_rates']:
+              'delta_standard_entropy', 'heat_production_rates',
+              'third_body_concentrations', 'forward_rate_constants_ddC',
+              'forward_rate_constants_ddP', 'forward_rate_constants_ddT',
+              'forward_rates_of_progress_ddC', 'forward_rates_of_progress_ddP',
+              'forward_rates_of_progress_ddT', 'net_rates_of_progress_ddC',
+              'net_rates_of_progress_ddP', 'net_rates_of_progress_ddT',
+              'reverse_rates_of_progress_ddC', 'reverse_rates_of_progress_ddP',
+              'reverse_rates_of_progress_ddT']:
     setattr(FlameBase, _attr, _array_property(_attr, 'n_reactions'))
 
 

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -1449,6 +1449,18 @@ class CounterflowDiffusionFlame(FlameBase):
             vals[i] = self.gas.mixture_fraction(Yf, Yo, 'mass', m)
         return vals
 
+    @property
+    def equivalence_ratio(self):
+        Yf = [self.solution(k, 0) for k in self.gas.species_names]
+        Yo = [self.solution(k, self.flame.n_points-1) for k in self.gas.species_names]
+
+        vals = np.empty(self.flame.n_points)
+        for i in range(self.flame.n_points):
+            self.set_gas_state(i)
+            vals[i] = self.gas.equivalence_ratio(Yf, Yo, "mass")
+        return vals
+
+
 class ImpingingJet(FlameBase):
     """An axisymmetric flow impinging on a surface at normal incidence."""
     __slots__ = ('inlet', 'flame', 'surface')

--- a/interfaces/cython/cantera/test/test_convert.py
+++ b/interfaces/cython/cantera/test/test_convert.py
@@ -31,7 +31,7 @@ class ck2yamlTest(utilities.CanteraTest):
             output.unlink()
         ck2yaml.convert_mech(inputFile, thermo_file=thermo,
             transport_file=transport, surface_file=surface, out_name=output,
-            extra_file=extra, **kwargs)
+            extra_file=extra, quiet=True, **kwargs)
         return output
 
     def checkConversion(self, refFile, testFile):

--- a/interfaces/cython/cantera/test/test_onedim.py
+++ b/interfaces/cython/cantera/test/test_onedim.py
@@ -1019,6 +1019,12 @@ class TestDiffusionFlame(utilities.CanteraTest):
         self.assertTrue(all(Z >= 0))
         self.assertTrue(all(Z <= 1.0))
 
+    def test_equivalence_ratio(self):
+        self.create_sim(p=ct.one_atm)
+        phi = self.sim.equivalence_ratio
+        assert phi[0] == np.inf
+        assert np.isclose(phi[-1], 0.0)
+
 class TestCounterflowPremixedFlame(utilities.CanteraTest):
     # Note: to re-create the reference file:
     # (1) set PYTHONPATH to build/python.


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add array properties that were missing from the `FlameBase` and `SolutionArray` classes. Most of these are the derivatives of the reaction rates / rates of progress, but there were a few others as well, such as `FlameBase.mean_molecular_weight`
- Add unit tests that check that all `property`s of the `Solution` object are extended to the corresponding array form in the `FlameBase` and `Solution` classes, except for those that are specifically excluded. This will prevent new properties of the `Solution` class from being neglected in the future.
- Add the `equivalence_ratio` property to `CounterflowDiffusionFlame`

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
