### PR TITLE
changes default preconditioner threshold to zero

### DIFF
--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -122,7 +122,7 @@ protected:
 
     //! Minimum value a non-diagonal element must be to be included in
     //! the preconditioner
-    double m_threshold = 1e-8;
+    double m_threshold = 0.0;
 
     //! Bool set whether to prune the matrix or not
     double m_prune_precon = true;

--- a/interfaces/cython/cantera/preconditioners.pyx
+++ b/interfaces/cython/cantera/preconditioners.pyx
@@ -33,7 +33,7 @@ cdef class AdaptivePreconditioner(PreconditionerBase):
         Update the threshold to a desired value as:
             >>> precon.threshold = 1e-8
 
-        Default is 1e-8.
+        Default is 0.0.
         """
         def __get__(self):
             return self.preconditioner.threshold()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This pull request makes one small, simple change: the default threshold for using the adaptive preconditioner is now 0.0, rather than the (arbitrary) 1e-8. 

@anthony-walker's study showed that using no threshold often leads to as good—and sometimes better—performance than an arbitrary threshold value, and setting a non-zero value should only be done intentionally by someone trying to tune for optimal performance.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
