### PR TITLE
Fix misleading error message from invalid reaction

### DIFF
--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -175,11 +175,10 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
         }
     }
 
-    kin.checkDuplicates();
     if (add_rxn_err.size()) {
         throw CanteraError("addReactions", to_string(add_rxn_err));
     }
-
+    kin.checkDuplicates();
     kin.resizeReactions();
 }
 

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -153,11 +153,15 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
             AnyMap reactions = AnyMap::fromYamlFile(fileName,
                 rootNode.getString("__file__", ""));
             for (const auto& R : reactions[node].asVector<AnyMap>()) {
-                try {
+                #ifdef NDEBUG
+                    try {
+                        kin.addReaction(newReaction(R, kin), false);
+                    } catch (CanteraError& err) {
+                        fmt_append(add_rxn_err, "{}", err.what());
+                    }
+                #else
                     kin.addReaction(newReaction(R, kin), false);
-                } catch (CanteraError& err) {
-                    fmt_append(add_rxn_err, "{}", err.what());
-                }
+                #endif
             }
         } else {
             // specified section is in the current file

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -668,6 +668,20 @@ class TestInvalidInput(utilities.CanteraTest):
             """
         check_raises(gas_def, "is not configured", line=11)
 
+    def test_failing_invalid_duplicate(self):
+        # Make sure that the error we get is for the invalid reaction, not for the
+        # missing duplicate
+        gas_def = self._gas_def + """
+            reactions:
+            - equation: O + H2 <=> H + OH
+              rate-constant: {A: 3.87e+04, b: 2.7, Ea: 6260.0}
+              duplicate: true
+            - equation: O + H2 <=> H + OH
+              rate-constant: {A: -3.87e+04, b: 2.7, Ea: 6260.0}
+              duplicate: true
+            """
+        check_raises(gas_def, "negative pre-exponential factor", line=14)
+
 
 class TestEmptyKinetics(utilities.CanteraTest):
     def test_empty(self):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Raise exceptions resulting from invalid reactions before checking for issues with duplicate reactions.
- Use the "fast-fail in debug mode" strategy for all possible sources of reactions

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1353

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
