### PR TITLE
[SCons] Fix converter scripts for python_package = 'none'

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2185,10 +2185,11 @@ if any(target.startswith('test') for target in COMMAND_LINE_TARGETS):
 
     if env['python_package'] == 'none':
         # copy scripts from the full Cython module
+        # (skipping 'yaml2ck', which depends on the full Python module)
         test_py_int = env.Command('#build/python_local/cantera/__init__.py',
                                   '#interfaces/python_minimal/cantera/__init__.py',
                                   Copy('$TARGET', '$SOURCE'))
-        for script in ["ck2yaml", "ctml2yaml", "yaml2ck"]:
+        for script in ["ck2yaml", "ctml2yaml", "cti2yaml"]:
             s = env.Command('#build/python_local/cantera/{}.py'.format(script),
                             '#interfaces/cython/cantera/{}.py'.format(script),
                             Copy('$TARGET', '$SOURCE'))


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Fix minor issue for SCons option `python_package=none`.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
