### PR TITLE
[Scons] Ignore missing pytest with minimal python module

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1563,21 +1563,6 @@ if env['python_package'] != 'none':
                     "is required.")
                 sys.exit(1)
 
-        pytest_version = versions.get("pytest")
-        if not check_for_pytest:
-            pass
-        elif not pytest_version:
-            logger.error(
-                f"pytest was not found. {pytest_min_version} or newer "
-                "is required.")
-            sys.exit(1)
-        elif pytest_version < pytest_min_version:
-            logger.error(
-                "pytest is an incompatible version: Found "
-                f"{pytest_version}, but {pytest_min_version} or newer "
-                "is required.")
-            sys.exit(1)
-
     python_version = versions["python"]
     if warn_no_python:
         if env["python_package"] == "default":
@@ -1644,6 +1629,21 @@ if env['python_package'] != 'none':
             env["numpy_1_7_API"] = True
         else:
             logger.info(f"Using Cython version {cython_version}")
+
+        pytest_version = versions.get("pytest")
+        if not check_for_pytest:
+            pass
+        elif not pytest_version:
+            logger.error(
+                f"pytest was not found. {pytest_min_version} or newer "
+                "is required.")
+            sys.exit(1)
+        elif pytest_version < pytest_min_version:
+            logger.error(
+                "pytest is an incompatible version: Found "
+                f"{pytest_version}, but {pytest_min_version} or newer "
+                "is required.")
+            sys.exit(1)
 
         if warn_no_full_package:
             msg = ("Unable to build the full Python package because compatible "


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Allow `scons test` to continue without having `pytest` when using the option `python_package=minimal`

**If applicable, fill in the issue number this pull request is fixing**

See comment in #1360. 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
