### PR TITLE
Fix conda example packaging

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -580,6 +580,15 @@ config_options = [
         {"Windows": "compact", "default": "standard"},
         ("standard", "compact", "debian", "conda")),
     BoolOption(
+        "package_build",
+        """Used in combination with packaging tools (example: 'conda-build'). If
+           enabled, the installed package will be independent from host and build
+           environments, with all external library and include paths removed. Packaged
+           C++ and Fortran samples assume that users will compile with local SDKs, which
+           should be backwards compatible with the tools used for the build process.
+        """,
+        False),
+    BoolOption(
         "fast_fail_tests",
         "If enabled, tests will exit at the first failure.",
         False),

--- a/platform/posix/Cantera.mak.in
+++ b/platform/posix/Cantera.mak.in
@@ -1,35 +1,36 @@
 ###############################################################################
 # Include Snippet for Makefiles
 #
-#    To create Cantera C++ applications from the install environment
-#    include this file into your Makefile environment by putting
-#    the line "include Cantera.mak" in your Makefile.
+#   To create Cantera C++ applications from the install environment
+#   include this file into your Makefile environment by putting
+#   the line "include Cantera.mak" in your Makefile.
 #
-#  Main Variables:
+# Main Variables:
 #
-#      CANTERA_INCLUDES = Variable containing the include path
-#      CANTERA_LIBS = List of libraries to include on the link line
+#   CANTERA_INCLUDES = Variable containing the include path
+#   CANTERA_LIBS = List of libraries to include on the link line
 #
-#      CANTERA_FORTRAN_LIBS = list of libraries to link for Fortran programs
-#      CANTERA_FORTRAN_MODS = Directory containing the F90 .mod files
+#   CANTERA_FORTRAN_LIBS = list of libraries to link for Fortran programs
+#   CANTERA_FORTRAN_MODS = Directory containing the F90 .mod files
 #
 
 CANTERA_VERSION=@cantera_version@
 
 ###############################################################################
-#        CANTERA CORE
+#   CANTERA CORE
 ###############################################################################
 
 # The directory where Cantera include files may be found.
-#  Include files in application programs should start with:
-#     #include "cantera/thermo.h"
-#     #include "cantera/kernel/HMWSoln.h"
+#
+# Include files in application programs should start with:
+#   #include "cantera/core.h"
+#   #include "cantera/onedim.h"
 
 CANTERA_INSTALL_ROOT=@ct_installroot@
 
 CANTERA_CORE_INCLUDES=-I$(CANTERA_INSTALL_ROOT)/include
 
-CANTERA_EXTRA_INCLUDES=@mak_extra_includes@ 
+CANTERA_EXTRA_INCLUDES=@mak_extra_includes@
 
 # Required Cantera libraries
 CANTERA_CORE_LIBS=@mak_threadflags@ -L@ct_libdir@ @mak_corelibs@ -Wl,-rpath,@ct_libdir@
@@ -45,26 +46,26 @@ CANTERA_FORTRAN_MODS=$(CANTERA_INSTALL_ROOT)/include/cantera
 CANTERA_FORTRAN_SYSLIBS=@mak_fort_threadflags@ @mak_stdlib@
 
 ###############################################################################
-#            BOOST
+#   BOOST
 ###############################################################################
 
 CANTERA_BOOST_INCLUDES=@mak_boost_include@
 
 ###############################################################################
-#         CVODE/SUNDIALS LINKAGE
+#   CVODE/SUNDIALS LINKAGE
 ###############################################################################
 
 CANTERA_SUNDIALS_INCLUDE=@mak_sundials_include@
 CANTERA_SUNDIALS_LIBS=@mak_sundials_libdir@ @mak_sundials_libs@
 
 ###############################################################################
-#         BLAS LAPACK LINKAGE
+#   BLAS LAPACK LINKAGE
 ###############################################################################
 
 CANTERA_BLAS_LAPACK_LIBS=@mak_blas_lapack_libs@
 
 ###############################################################################
-#      COMBINATIONS OF INCLUDES AND LIBS
+#   COMBINATIONS OF INCLUDES AND LIBS
 ###############################################################################
 
 CANTERA_INCLUDES=$(CANTERA_CORE_INCLUDES) $(CANTERA_SUNDIALS_INCLUDE) \
@@ -89,5 +90,5 @@ CANTERA_FORTRAN_LIBS=$(CANTERA_CORE_FTN) \
                      $(CANTERA_BLAS_LAPACK_LIBS) $(CANTERA_FORTRAN_SYSLIBS)
 
 ###############################################################################
-#  END
+#   END
 ###############################################################################

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -1,4 +1,4 @@
-import sys
+import os
 
 from buildutils import *
 
@@ -19,45 +19,50 @@ pc_libdirs = []
 pc_incdirs = []
 pc_cflags = list(localenv['CXXFLAGS'])
 
-localenv['mak_corelibs'] = ' '.join('-l' + lib for lib in localenv['cantera_libs'])
+localenv["mak_corelibs"] = " ".join(f"-l{lib}" for lib in localenv["cantera_libs"])
 
-localenv["mak_extra_includes"] = " ".join(
-    f"-I{dir}" for dir in localenv["extra_inc_dirs"])
-pc_incdirs.extend(localenv["extra_inc_dirs"])
+if localenv["package_build"]:
+    # folders outside of conda environment are not transferable
+    localenv["mak_extra_includes"] = ""
+    localenv["mak_extra_libdirs"] = ""
+else:
+    localenv["mak_extra_includes"] = " ".join(
+        f"-I{dir}" for dir in localenv["extra_inc_dirs"])
+    pc_incdirs.extend(localenv["extra_inc_dirs"])
 
-localenv["mak_extra_libdirs"] = " ".join(
-    f"-L{dir} -Wl,-rpath,{dir}" for dir in localenv["extra_lib_dirs"])
-pc_libdirs.extend(localenv["extra_lib_dirs"])
+    localenv["mak_extra_libdirs"] = " ".join(
+        f"-L{dir} -Wl,-rpath,{dir}" for dir in localenv["extra_lib_dirs"])
+    pc_libdirs.extend(localenv["extra_lib_dirs"])
 
-localenv['mak_stdlib'] = ''.join('-l' + lib for lib in env['cxx_stdlib'])
+localenv["mak_stdlib"] = " ".join(f"-l{lib}" for lib in env["cxx_stdlib"])
 
 if localenv['system_sundials']:
     # Add links to the sundials environment
     localenv["mak_sundials_libs"] = " ".join(
         f"-l{lib}" for lib in localenv["sundials_libs"])
-    if localenv['sundials_libdir']:
-        localenv['mak_sundials_libdir'] = '-L' + localenv['sundials_libdir']
+    if localenv["sundials_libdir"] and not localenv["package_build"]:
+        localenv["mak_sundials_libdir"] = f"-L{localenv['sundials_libdir']}"
         pc_libdirs.append(localenv['sundials_libdir'])
     else:
         localenv['mak_sundials_libdir'] = ''
 
-    if localenv['sundials_include']:
-        localenv['mak_sundials_include'] = '-I' + localenv['sundials_include']
+    if localenv["sundials_include"] and not localenv["package_build"]:
+        localenv["mak_sundials_include"] = f"-I{localenv['sundials_include']}"
         pc_incdirs.append(localenv['sundials_include'])
     else:
         localenv['mak_sundials_include'] = ''
 
-if localenv['boost_inc_dir']:
-    localenv['mak_boost_include'] = '-I' + localenv['boost_inc_dir']
+if localenv["boost_inc_dir"] and not localenv["package_build"]:
+    localenv["mak_boost_include"] = f"-I{localenv['boost_inc_dir']}"
     pc_incdirs.append(localenv['boost_inc_dir'])
 else:
     localenv['mak_boost_include'] = ''
 
 # Handle BLAS/LAPACK linkage
 blas_lapack_libs = " ".join(f"-l{lib}" for lib in localenv["blas_lapack_libs"])
-if localenv['blas_lapack_dir']:
-    localenv['mak_blas_lapack_libs'] = '-L{} {}'.format(localenv['blas_lapack_dir'],
-                                                        blas_lapack_libs)
+if localenv["blas_lapack_dir"] and not localenv["package_build"]:
+    localenv["mak_blas_lapack_libs"] = (
+        f"-L{localenv['blas_lapack_dir']} {blas_lapack_libs}")
 else:
     localenv['mak_blas_lapack_libs'] = blas_lapack_libs
 
@@ -73,15 +78,31 @@ if '-pthread' in localenv['thread_flags']:
 else:
     localenv['mak_fort_threadflags'] = ''
 
+if localenv["package_build"]:
+    # Remove sysroot flags in templated output files. This only applies to the
+    # conda package for now.
+    # Users should compile against their local SDKs, which should be backwards
+    # compatible with the SDK used for building.
+    cc_flags = []
+    for flag in localenv["CCFLAGS"]:
+        if not flag.startswith(("-isysroot", "-mmacosx", "/App")):
+            cc_flags.append(flag)
+    localenv["CCFLAGS"] = cc_flags
+    cc_flags = []
+    for flag in localenv["CXXFLAGS"]:
+        if not flag.startswith(("-isysroot", "-mmacosx", "/App")):
+            cc_flags.append(flag)
+    localenv["CXXFLAGS"] = cc_flags
+
 mak = build(localenv.SubstFile('Cantera.mak', 'Cantera.mak.in'))
 install('$inst_incdir', mak)
 
 # Generate cantera.pc for use with pkg-config
-localenv['pc_prefix'] = localenv['prefix']
-localenv['pc_libdirs'] = ' '.join('-L' + d for d in pc_libdirs)
-localenv['pc_libs'] = ' '.join('-l' + lib for lib in pc_libs)
-localenv['pc_incdirs'] = ' '.join('-I' + d for d in pc_incdirs)
-localenv['pc_cflags'] = ' '.join(pc_cflags)
+localenv["pc_prefix"] = localenv["prefix"]
+localenv["pc_libdirs"] = " ".join(f"-L{dir}" for dir in pc_libdirs)
+localenv["pc_libs"] = " ".join(f"-l{lib}" for lib in pc_libs)
+localenv["pc_incdirs"] = " ".join(f"-I{dir}" for dir in pc_incdirs)
+localenv["pc_cflags"] = " ".join(pc_cflags)
 
-pc = build(localenv.SubstFile('cantera.pc', 'cantera.pc.in'))
-install('$inst_libdir/pkgconfig', pc)
+pc = build(localenv.SubstFile("cantera.pc", "cantera.pc.in"))
+install("$inst_libdir/pkgconfig", pc)

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -83,16 +83,10 @@ if localenv["package_build"]:
     # conda package for now.
     # Users should compile against their local SDKs, which should be backwards
     # compatible with the SDK used for building.
-    cc_flags = []
-    for flag in localenv["CCFLAGS"]:
-        if not flag.startswith(("-isysroot", "-mmacosx", "/App")):
-            cc_flags.append(flag)
-    localenv["CCFLAGS"] = cc_flags
-    cc_flags = []
-    for flag in localenv["CXXFLAGS"]:
-        if not flag.startswith(("-isysroot", "-mmacosx", "/App")):
-            cc_flags.append(flag)
-    localenv["CXXFLAGS"] = cc_flags
+    excludes = (
+        "-isysroot", "-mmacosx", "-march", "-mtune", "-fdebug-prefix-map")
+    localenv["CCFLAGS"] = compiler_flag_list(localenv["CCFLAGS"], excludes)
+    localenv["CXXFLAGS"] = compiler_flag_list(localenv["CXXFLAGS"], excludes)
 
 mak = build(localenv.SubstFile('Cantera.mak', 'Cantera.mak.in'))
 install('$inst_incdir', mak)

--- a/platform/posix/cantera.pc.in
+++ b/platform/posix/cantera.pc.in
@@ -5,7 +5,7 @@ includedir=${prefix}/include
 
 Name: Cantera
 Description: Cantera library
-URL: http://www.cantera.org
+URL: https://cantera.org
 Version: @cantera_version@
 
 Libs: -L${libdir} @pc_libdirs@ @pc_libs@

--- a/samples/cxx/Makefile.in
+++ b/samples/cxx/Makefile.in
@@ -17,4 +17,4 @@ clean:
 	$(RM) $(OBJS) @tmpl_progname@
 
 dist-clean: clean
-	$(RM) *~ 
+	$(RM) *~

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -52,22 +52,41 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     # Note: These Makefiles and SConstruct files are automatically installed
     # by the "RecursiveInstall" that grabs everything in the cxx directory.
 
-    incdirs = (localenv['ct_incroot'], localenv['sundials_include'],
-               localenv['boost_inc_dir']) + tuple(localenv['extra_inc_dirs'])
-    libdirs = ((localenv['ct_libdir'], localenv['sundials_libdir'],
-               localenv['blas_lapack_dir']) + tuple(localenv['extra_lib_dirs']))
-    # Remove sysroot and macOS min version flags in templated output files
-    # Users should compile against their local SDKs, which should be backwards
-    # compatible with the SDK used for building. This only applies to the
-    # conda package for now.
-    if env['OS'] == 'Darwin' and os.environ.get('CONDA_BUILD', False):
-        ccFlags = []
-        for flag in localenv['CCFLAGS'] + localenv['CXXFLAGS']:
-            if not flag.startswith(('-isysroot', '-mmacosx', '/App')):
-                ccFlags.append(flag)
+    incdirs = [localenv["ct_incroot"]]
+    libdirs = [localenv["ct_libdir"]]
+    if localenv["package_build"]:
+        # Remove sysroot flags in templated output files. This only applies to the
+        # conda package for now.
+        # Users should compile against their local SDKs, which should be backwards
+        # compatible with the SDK used for building.
+        def split_compiler_flags(flags, excludes=[]):
+            """
+            Separate concatenated compiler flags in flag list.
+            Entries listed in 'exclude' are omitted.
+            """
+            flags = " ".join(flags)
+            flags = f" {flags}".split(" -")[1:]
+            # split concatenated entries
+            flags = [f"-{flag}" for flag in flags]
+            cc_flags = []
+            for flag in flags:
+                if not flag.startswith(excludes) and flag not in cc_flags:
+                    cc_flags.append(flag)
+            return cc_flags
+
+        excludes = (
+            "-isysroot", "-mmacosx", "-march", "-mtune", "-fdebug-prefix-map")
+        cc_flags = split_compiler_flags(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
+            excludes)
     else:
-        ccFlags = localenv['CCFLAGS'] + localenv['CXXFLAGS']
-    localenv['tmpl_compiler_flags'] = repr(ccFlags)
+        incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
+        incdirs.extend(localenv["extra_inc_dirs"])
+        libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
+        libdirs.extend(localenv["extra_lib_dirs"])
+
+        cc_flags = localenv["CCFLAGS"] + localenv["CXXFLAGS"]
+
+    localenv["tmpl_compiler_flags"] = repr(cc_flags)
     localenv['tmpl_cantera_frameworks'] = repr(localenv['FRAMEWORKS'])
     localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])
     localenv['cmake_cantera_incdirs'] = ' '.join(quoted(x) for x in incdirs if x)
@@ -90,12 +109,19 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
         env_args.append('MSVC_VERSION={0!r}'.format(localenv['MSVC_VERSION']))
     localenv['tmpl_env_args'] = ', '.join(env_args)
 
-    # If this is a conda build on macOS, we do not want to specify the conda
-    # compilers from the build environment, because those won't be installed
-    # on the user's system.
-    if env['OS'] == 'Darwin' and os.environ.get('CONDA_BUILD', False):
-        localenv['CXX'] = 'clang++'
-        localenv['CC'] = 'clang'
+    if localenv["package_build"]:
+        # We do not want to specify the conda compilers from the build environment,
+        # because those won't be installed on the user's system.
+        if localenv["OS"] == "Darwin":
+            localenv["CXX"] = "clang++"
+            localenv["CC"] = "clang"
+        elif localenv["OS"] == "Windows":
+            # compilation needs the Visual Studio Command Prompt
+            localenv["CXX"] = "cl"
+            localenv["CC"] = "cl"
+        else:
+            localenv["CXX"] = "g++"
+            localenv["CC"] = "gcc"
 
     sconstruct = localenv.SubstFile(pjoin(subdir, 'SConstruct'), 'SConstruct.in')
     install(pjoin('$inst_sampledir', 'cxx', subdir), sconstruct)
@@ -106,7 +132,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
 
     ## Generate Makefiles to be installed
     mak_path = pjoin(localenv['ct_incroot'], 'cantera', 'Cantera.mak')
-    localenv['mak_compiler_flags'] = ' '.join(ccFlags)
+    localenv["mak_compiler_flags"] = " ".join(cc_flags)
     if ' ' in mak_path:
         # There is no reasonable way to handle spaces in Makefile 'include'
         # statement, so we fall back to using the relative path instead

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -59,24 +59,9 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
         # conda package for now.
         # Users should compile against their local SDKs, which should be backwards
         # compatible with the SDK used for building.
-        def split_compiler_flags(flags, excludes=[]):
-            """
-            Separate concatenated compiler flags in flag list.
-            Entries listed in 'exclude' are omitted.
-            """
-            flags = " ".join(flags)
-            flags = f" {flags}".split(" -")[1:]
-            # split concatenated entries
-            flags = [f"-{flag}" for flag in flags]
-            cc_flags = []
-            for flag in flags:
-                if not flag.startswith(excludes) and flag not in cc_flags:
-                    cc_flags.append(flag)
-            return cc_flags
-
         excludes = (
             "-isysroot", "-mmacosx", "-march", "-mtune", "-fdebug-prefix-map")
-        cc_flags = split_compiler_flags(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
+        cc_flags = compiler_flag_list(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
             excludes)
     else:
         incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])

--- a/samples/f77/Makefile.in
+++ b/samples/f77/Makefile.in
@@ -1,6 +1,6 @@
 include @tmpl_Cantera_dot_mak@
 
-FC=@F77@
+F77=@F77@
 RM=rm -f
 FFLAGS=-g
 LDFLAGS=
@@ -12,7 +12,7 @@ OBJS=isentropic.o demo_ftnlib.o
 all: isentropic
 
 isentropic: $(OBJS)
-	$(F77) $(LDFLAGS) -o isentropic $(OBJS) $(LDLIBS)
+	$(F77) $(LDFLAGS) -o isentropic $(OBJS) $(LDLIBS) $(CANTERA_LIBS)
 
 clean:
 	$(RM) $(OBJS)

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -23,11 +23,15 @@ for program_name, fortran_sources in samples:
                 LINK='$FORTRAN_LINK')
 
 # Generate SConstruct file to be installed
-incdirs = (localenv['ct_incroot'], localenv['sundials_include'],
-           localenv['boost_inc_dir']) + tuple(localenv['extra_inc_dirs'])
+incdirs = [localenv["ct_incroot"]]
+libdirs = [localenv["ct_libdir"]]
+if not localenv["package_build"]:
+    incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
+    incdirs.extend(localenv["extra_inc_dirs"])
+    libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
+    libdirs.extend(localenv["extra_lib_dirs"])
+
 libs = ['cantera_fortran'] + localenv['cantera_libs'] + env['cxx_stdlib']
-libdirs = ((localenv['ct_libdir'], localenv['sundials_libdir'],
-            localenv['blas_lapack_dir']) + tuple(localenv['extra_lib_dirs']))
 linkflags = ('-g', localenv['thread_flags'])
 
 mak_path = pjoin(localenv['ct_incroot'], 'cantera', 'Cantera.mak')
@@ -42,6 +46,20 @@ localenv['tmpl_cantera_libs'] = repr(libs)
 localenv['tmpl_cantera_libdirs'] = repr([x for x in libdirs if x])
 localenv['tmpl_cantera_linkflags'] = repr([x for x in linkflags if x])
 localenv['tmpl_cantera_frameworks'] = repr(localenv['FRAMEWORKS'])
+
+if localenv["package_build"]:
+    # We do not want to specify the conda compilers from the build environment,
+    # because those won't be installed on the user's system.
+    if localenv["OS"] == "Darwin":
+        localenv["F77"] = "gfortran"
+        localenv["CC"] = "clang"
+    elif env["OS"] == "Windows":
+        # compilation needs the Visual Studio Command Prompt
+        localenv["F77"] = "ifx"
+        localenv["CC"] = "cl"
+    else:
+        localenv["F77"] = "gfortran"
+        localenv["CC"] = "gcc"
 
 sconstruct = localenv.SubstFile('SConstruct', 'SConstruct.in')
 

--- a/samples/f90/Makefile.in
+++ b/samples/f90/Makefile.in
@@ -13,7 +13,7 @@ OBJS=$(subst .f90,.o,$(SRCS))
 all: @make_target@
 
 @make_target@: $(OBJS)
-	$(F90) $(LDFLAGS) -o @make_target@ $(OBJS) $(LDLIBS)
+	$(F90) $(LDFLAGS) -o @make_target@ $(OBJS) $(LDLIBS) $(CANTERA_LIBS)
 
 %.o : %.f90
 	$(F90) -c $< @FORTRANMODDIRPREFIX@$(F90MODDIR) $(F90FLAGS)

--- a/samples/f90/SConscript
+++ b/samples/f90/SConscript
@@ -18,10 +18,15 @@ for programName, sources in samples:
                 LINK='$FORTRAN_LINK')
 
     # Generate SConstruct files to be installed
-    incdirs = [pjoin(localenv['ct_incroot'], 'cantera')] + localenv['extra_inc_dirs']
+    incdirs = [pjoin(localenv["ct_incroot"], "cantera")] # path to fortran .mod
+    libdirs = [localenv["ct_libdir"]]
+    if not localenv["package_build"]:
+        incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
+        incdirs.extend(localenv["extra_inc_dirs"])
+        libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
+        libdirs.extend(localenv["extra_lib_dirs"])
+
     libs = ['cantera_fortran'] + localenv['cantera_libs'] + env['cxx_stdlib']
-    libdirs = ((localenv['ct_libdir'], localenv['sundials_libdir'],
-                localenv['blas_lapack_dir']) + tuple(localenv['extra_lib_dirs']))
     linkflags = ('-g', localenv['thread_flags'])
 
     mak_path = pjoin(localenv['ct_incroot'], 'cantera', 'Cantera.mak')

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -25,7 +25,7 @@ __all__ = ("Option", "PathOption", "BoolOption", "EnumOption", "Configuration",
            "logger", "remove_directory", "remove_file", "test_results",
            "add_RegressionTest", "get_command_output", "listify", "which",
            "ConfigBuilder", "multi_glob", "get_spawn", "quoted",
-           "get_pip_install_location")
+           "get_pip_install_location", "compiler_flag_list")
 
 if TYPE_CHECKING:
     from typing import Iterable, TypeVar, Union, List, Dict, Tuple, Optional, \
@@ -1090,6 +1090,27 @@ def add_RegressionTest(env: "SCEnvironment") -> None:
     env["BUILDERS"]["RegressionTest"] = env.Builder(
         action=env.Action(regression_test, regression_test_message)
     )
+
+
+def compiler_flag_list(
+        flags: "Union[str, Iterable]",
+        excludes: "Optional[Iterable]" = []
+    ) -> "List[str]":
+    """
+    Separate concatenated compiler flags in ``flags``.
+    Entries listed in ``excludes`` are omitted.
+    """
+    if not isinstance(flags, str):
+        flags = " ".join(flags)
+    # split concatenated entries
+    flags = f" {flags}".split(" -")[1:]
+    flags = [f"-{flag}" for flag in flags]
+    cc_flags = []
+    excludes = tuple(excludes)
+    for flag in flags:
+        if not flag.startswith(excludes) and flag not in cc_flags:
+            cc_flags.append(flag)
+    return cc_flags
 
 
 def quoted(s: str) -> str:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add SCons option `package_build` 
- If selected (i.e. `package_build=y`), exclude 'include' and 'library' paths outside of build and host enviroments in development sample `Makefile`'s and `SConstruct`'s, as well as `include/cantera/Cantera.mak` and `/lib/pkgconfig/cantera.pc`
- Fix Fortran Makefiles

PR ensures that `libcantera-devel` packages all C++ and Fortran examples without referencing the build environment.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/conda-recipes#37

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

With an updated `conda-recipes` using the SCons flag `package_build=y`, the following will work
```
$ conda create -y -n ct-env make scons cmake
$ conda activate ct-env
$ conda install -y -c cantera libcantera-devel
```

C++ examples can be compiled with preconfigured build tools:
```
$ cd path/to/conda/envs/ct-env/shared/cantera/samples/cxx/demo
$ make
$ scons
$ cmake . && cmake --build .
```
Same for Fortran F90 (and F77):
```
$ cd path/to/conda/envs/ct-env/shared/cantera/samples/f90
$ make
$ scons
$ cmake . && cmake --build .
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
