### PR TITLE
Preconditioned solver improvements

### DIFF
--- a/include/cantera/cython/kinetics_utils.h
+++ b/include/cantera/cython/kinetics_utils.h
@@ -53,25 +53,11 @@ inline void sparseCscData(const Eigen::SparseMatrix<double>& mat,
     }
 }
 
-// Function which passes sparse matrix
-#define SPARSE_MATRIX(PREFIX, CLASS_NAME, FUNC_NAME) \
-    inline Eigen::SparseMatrix<double> PREFIX ## _ ## FUNC_NAME(Cantera::CLASS_NAME* object) \
-    { return object->FUNC_NAME(); }
-
-#define KIN_SPARSE_MATRIX(FUNC_NAME) SPARSE_MATRIX(kin, Kinetics, FUNC_NAME)
 #define KIN_1D(FUNC_NAME) ARRAY_FUNC(kin, Kinetics, FUNC_NAME)
-
-KIN_SPARSE_MATRIX(reactantStoichCoeffs)
-KIN_SPARSE_MATRIX(productStoichCoeffs)
-KIN_SPARSE_MATRIX(revProductStoichCoeffs)
 
 KIN_1D(getFwdRatesOfProgress)
 KIN_1D(getRevRatesOfProgress)
 KIN_1D(getNetRatesOfProgress)
-
-KIN_SPARSE_MATRIX(fwdRatesOfProgress_ddX)
-KIN_SPARSE_MATRIX(revRatesOfProgress_ddX)
-KIN_SPARSE_MATRIX(netRatesOfProgress_ddX)
 
 KIN_1D(getFwdRateConstants_ddT)
 KIN_1D(getFwdRateConstants_ddP)
@@ -105,10 +91,6 @@ KIN_1D(getThirdBodyConcentrations)
 KIN_1D(getCreationRates)
 KIN_1D(getDestructionRates)
 KIN_1D(getNetProductionRates)
-
-KIN_SPARSE_MATRIX(creationRates_ddX)
-KIN_SPARSE_MATRIX(destructionRates_ddX)
-KIN_SPARSE_MATRIX(netProductionRates_ddX)
 
 KIN_1D(getCreationRates_ddT)
 KIN_1D(getDestructionRates_ddT)

--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -26,7 +26,7 @@ namespace Cantera
 class AdaptivePreconditioner : public PreconditionerBase
 {
 public:
-    AdaptivePreconditioner() {}
+    AdaptivePreconditioner();
 
     void initialize(size_t networkSize) override;
 
@@ -38,10 +38,6 @@ public:
     void setup() override;
 
     void solve(const size_t stateSize, double* rhs_vector, double* output) override;
-
-    PreconditionerType preconditionerType() override {
-        return PreconditionerType::LEFT_PRECONDITION;
-    }
 
     void setValue(size_t row, size_t col, double value) override;
 

--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -28,26 +28,26 @@ class AdaptivePreconditioner : public PreconditionerBase
 public:
     AdaptivePreconditioner() {}
 
-    void initialize(size_t networkSize);
+    void initialize(size_t networkSize) override;
 
-    void reset() {
+    void reset() override {
         m_precon_matrix.setZero();
         m_jac_trips.clear();
     };
 
-    void setup();
+    void setup() override;
 
-    void solve(const size_t stateSize, double* rhs_vector, double* output);
+    void solve(const size_t stateSize, double* rhs_vector, double* output) override;
 
-    PreconditionerType preconditionerType() {
+    PreconditionerType preconditionerType() override {
         return PreconditionerType::LEFT_PRECONDITION;
     }
 
-    void setValue(size_t row, size_t col, double value);
+    void setValue(size_t row, size_t col, double value) override;
 
-    virtual void stateAdjustment(vector_fp& state);
+    virtual void stateAdjustment(vector_fp& state) override;
 
-    virtual void updatePreconditioner();
+    virtual void updatePreconditioner() override;
 
     //! Prune preconditioner elements
     void prunePreconditioner();
@@ -96,7 +96,7 @@ public:
     }
 
     //! Print preconditioner contents
-    void printPreconditioner();
+    void printPreconditioner() override;
 
     //! Print jacobian contents
     void printJacobian();

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -56,8 +56,7 @@ public:
     virtual void setMaxSteps(int nmax);
     virtual int maxSteps();
     virtual void setMaxErrTestFails(int n);
-    virtual AnyMap nonlinearSolverStats() const;
-    virtual AnyMap linearSolverStats() const;
+    virtual AnyMap solverStats() const;
     void setLinearSolverType(const std::string& linSolverType) {
         m_type = linSolverType;
     }

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -278,17 +278,10 @@ public:
         return 0.0;
     }
 
-    //! Get nonlinear solver stats from integrator
-    virtual AnyMap nonlinearSolverStats() const {
+    //! Get solver stats from integrator
+    virtual AnyMap solverStats() const {
         AnyMap stats;
-        warn("nonlinearSolverStats");
-        return stats;
-    }
-
-    //! Get linear solver stats from integrator
-    virtual AnyMap linearSolverStats() const {
-        AnyMap stats;
-        warn("linearSolverStats");
+        warn("solverStats");
         return stats;
     }
 

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -118,7 +118,18 @@ public:
      */
     virtual void setPreconditioner(shared_ptr<PreconditionerBase> preconditioner) {
         m_preconditioner = preconditioner;
-        m_prec_side = m_preconditioner->preconditionerSide();
+        if (preconditioner->preconditionerSide() == "none") {
+            m_prec_side = PreconditionerSide::NO_PRECONDITION;
+        } else if (preconditioner->preconditionerSide() == "left") {
+            m_prec_side = PreconditionerSide::LEFT_PRECONDITION;
+        } else if (preconditioner->preconditionerSide() == "right") {
+            m_prec_side = PreconditionerSide::RIGHT_PRECONDITION;
+        } else if (preconditioner->preconditionerSide() == "both") {
+            m_prec_side = PreconditionerSide::BOTH_PRECONDITION;
+        } else {
+            throw CanteraError("Integrator::setPreconditioner",
+                "Invalid option '{}'", preconditioner->preconditionerSide());
+        }
     }
 
     //! Solve a linear system Ax=b where A is the preconditioner

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -112,21 +112,13 @@ public:
         warn("setLinearSolverType");
     }
 
-    //! Set the preconditioner type.
-    /*!
-     * @param prectype    Type of the problem
-     */
-    virtual void setPreconditionerType(PreconditionerType prectype) {
-        warn("setPreconditionerType");
-    }
-
     //! Set preconditioner used by the linear solver
     /*!
      * @param preconditioner preconditioner object used for the linear solver
      */
     virtual void setPreconditioner(shared_ptr<PreconditionerBase> preconditioner) {
         m_preconditioner = preconditioner;
-        m_prec_type = m_preconditioner->preconditionerType();
+        m_prec_side = m_preconditioner->preconditionerSide();
     }
 
     //! Solve a linear system Ax=b where A is the preconditioner
@@ -139,9 +131,9 @@ public:
         m_preconditioner->solve(stateSize, rhs, output);
     }
 
-    //! Return the preconditioner type
-    virtual PreconditionerType preconditionerType() {
-        return m_prec_type;
+    //! Return the side of the system on which the preconditioner is applied
+    virtual PreconditionerSide preconditionerSide() {
+        return m_prec_side;
     }
 
     //! Return preconditioner reference to object
@@ -291,7 +283,7 @@ protected:
     //! ReactorNet::initialize()
     shared_ptr<PreconditionerBase> m_preconditioner;
     //! Type of preconditioning used in applyOptions
-    PreconditionerType m_prec_type = PreconditionerType::NO_PRECONDITION;
+    PreconditionerSide m_prec_side = PreconditionerSide::NO_PRECONDITION;
 
 private:
     doublereal m_dummy;

--- a/include/cantera/numerics/PreconditionerBase.h
+++ b/include/cantera/numerics/PreconditionerBase.h
@@ -16,10 +16,10 @@ namespace Cantera
 {
 
 /**
- * Specifies the preconditioner type used in the integration if any. Not all methods are
- * supported by all integrators.
+ * Specifies the side of the system on which the preconditioner is applied. Not all
+ * methods are supported by all integrators.
  */
-enum class PreconditionerType {
+enum class PreconditionerSide {
     NO_PRECONDITION, //! No preconditioning
     LEFT_PRECONDITION, //! Left side preconditioning
     RIGHT_PRECONDITION, //! Right side preconditioning
@@ -50,10 +50,25 @@ public:
         throw NotImplementedError("PreconditionerBase::stateAdjustment");
     }
 
-    //! Get preconditioner type for CVODES
-    virtual PreconditionerType preconditionerType() {
-        return PreconditionerType::NO_PRECONDITION;
+    //! Get preconditioner application side for CVODES
+    PreconditionerSide preconditionerSide() {
+        return m_precon_side;
     };
+
+    virtual void setPreconditionerSide(const std::string& preconSide) {
+        if (preconSide == "none") {
+            m_precon_side = PreconditionerSide::NO_PRECONDITION;
+        } else if (preconSide == "left") {
+            m_precon_side = PreconditionerSide::LEFT_PRECONDITION;
+        } else if (preconSide == "right") {
+            m_precon_side = PreconditionerSide::RIGHT_PRECONDITION;
+        } else if (preconSide == "both") {
+            m_precon_side = PreconditionerSide::BOTH_PRECONDITION;
+        } else {
+            throw CanteraError("PreconditionerBase::setPreconditionerSide",
+                               "Invalid option '{}'", preconSide);
+        }
+    }
 
     //! Solve a linear system Ax=b where A is the preconditioner
     //! @param[in] stateSize length of the rhs and output vectors
@@ -121,6 +136,7 @@ protected:
     //! Absolute tolerance of the ODE solver
     double m_atol = 0;
 
+    PreconditionerSide m_precon_side = PreconditionerSide::NO_PRECONDITION;
 };
 
 }

--- a/include/cantera/numerics/PreconditionerBase.h
+++ b/include/cantera/numerics/PreconditionerBase.h
@@ -51,23 +51,12 @@ public:
     }
 
     //! Get preconditioner application side for CVODES
-    PreconditionerSide preconditionerSide() {
+    std::string preconditionerSide() const {
         return m_precon_side;
-    };
+    }
 
     virtual void setPreconditionerSide(const std::string& preconSide) {
-        if (preconSide == "none") {
-            m_precon_side = PreconditionerSide::NO_PRECONDITION;
-        } else if (preconSide == "left") {
-            m_precon_side = PreconditionerSide::LEFT_PRECONDITION;
-        } else if (preconSide == "right") {
-            m_precon_side = PreconditionerSide::RIGHT_PRECONDITION;
-        } else if (preconSide == "both") {
-            m_precon_side = PreconditionerSide::BOTH_PRECONDITION;
-        } else {
-            throw CanteraError("PreconditionerBase::setPreconditionerSide",
-                               "Invalid option '{}'", preconSide);
-        }
+        m_precon_side = preconSide;
     }
 
     //! Solve a linear system Ax=b where A is the preconditioner
@@ -136,7 +125,7 @@ protected:
     //! Absolute tolerance of the ODE solver
     double m_atol = 0;
 
-    PreconditionerSide m_precon_side = PreconditionerSide::NO_PRECONDITION;
+    std::string m_precon_side = "none";
 };
 
 }

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -38,7 +38,7 @@ public:
 
     virtual void updateState(double* y);
 
-    virtual Eigen::SparseMatrix<double> jacobian(double t, double* y);
+    virtual Eigen::SparseMatrix<double> jacobian();
 
 protected:
     vector_fp m_hk; //!< Species molar enthalpies

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -38,6 +38,11 @@ public:
 
     virtual void updateState(double* y);
 
+    //! Calculate an approximate Jacobian to accelerate preconditioned solvers
+
+    //! Neglects derivatives with respect to mole fractions that would generate a
+    //! fully-dense Jacobian. Currently also neglects terms related to interactions
+    //! between reactors, for example via inlets and outlets.
     virtual Eigen::SparseMatrix<double> jacobian();
 
 protected:

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -26,6 +26,8 @@ public:
 
     virtual size_t componentIndex(const std::string& nm) const;
 
+    virtual std::string componentName(size_t k);
+
     virtual void setThermoMgr(ThermoPhase& thermo);
 
     virtual void getState(double* y);

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -36,7 +36,7 @@ public:
 
     virtual void updateState(double* y);
 
-    virtual Eigen::SparseMatrix<double> jacobian(double t, double* y);
+    virtual Eigen::SparseMatrix<double> jacobian();
 
 protected:
     vector_fp m_uk; //!< Species molar internal energies

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -38,6 +38,11 @@ public:
 
     virtual void updateState(double* y);
 
+    //! Calculate an approximate Jacobian to accelerate preconditioned solvers
+
+    //! Neglects derivatives with respect to mole fractions that would generate a
+    //! fully-dense Jacobian. Currently, also neglects terms related to interactions
+    //! between reactors, for example via inlets and outlets.
     virtual Eigen::SparseMatrix<double> jacobian();
 
 protected:

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -163,6 +163,15 @@ public:
         throw NotImplementedError("Reactor::jacobian");
     }
 
+    //! Calculate the reactor-specific Jacobian using a finite difference method.
+    //!
+    //! This method is used only for informational purposes. Jacobian calculations
+    //! for the full reactor system are handled internally by CVODES.
+    //!
+    //! @warning  This method is an experimental part of the %Cantera
+    //! API and may be changed or removed without notice.
+    Eigen::SparseMatrix<double> finiteDifferenceJacobian();
+
     //! Use this to set the kinetics objects derivative settings
     virtual void setDerivativeSettings(AnyMap& settings);
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -157,11 +157,9 @@ public:
     void setAdvanceLimit(const std::string& nm, const double limit);
 
     //! Method to calculate the reactor specific jacobian
-    //! @param t current time of the simulation
-    //! @param y pointer to state vector
     //! @warning  This method is an experimental part of the %Cantera
     //! API and may be changed or removed without notice.
-    virtual Eigen::SparseMatrix<double> jacobian(double t, double* y) {
+    virtual Eigen::SparseMatrix<double> jacobian() {
         throw NotImplementedError("Reactor::jacobian");
     }
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -157,6 +157,10 @@ public:
     void setAdvanceLimit(const std::string& nm, const double limit);
 
     //! Method to calculate the reactor specific jacobian
+    //! @warning Depending on the particular implementation, this may return an
+    //! approximate Jacobian intended only for use in forming a preconditioner for
+    //! iterative solvers.
+    //!
     //! @warning  This method is an experimental part of the %Cantera
     //! API and may be changed or removed without notice.
     virtual Eigen::SparseMatrix<double> jacobian() {

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -276,11 +276,8 @@ public:
 
     virtual void preconditionerSolve(double* rhs, double* output);
 
-    //! Use this to get nonlinear solver stats from Integrator
-    AnyMap nonlinearSolverStats() const;
-
-    //! Get linear solver stats from integrator
-    AnyMap linearSolverStats() const;
+    //! Get solver stats from integrator
+    AnyMap solverStats() const;
 
     //! Set derivative settings of all reactors
     //! @param settings the settings map propagated to all reactors and kinetics objects

--- a/interfaces/cython/cantera/kinetics.pxd
+++ b/interfaces/cython/cantera/kinetics.pxd
@@ -51,6 +51,19 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
         void getDerivativeSettings(CxxAnyMap&) except +translate_exception
         void setDerivativeSettings(CxxAnyMap&) except +translate_exception
 
+        # Kinetics sparse matrices
+        CxxSparseMatrix reactantStoichCoeffs() except +translate_exception
+        CxxSparseMatrix productStoichCoeffs() except +translate_exception
+        CxxSparseMatrix revProductStoichCoeffs() except +translate_exception
+
+        CxxSparseMatrix fwdRatesOfProgress_ddX() except +translate_exception
+        CxxSparseMatrix revRatesOfProgress_ddX() except +translate_exception
+        CxxSparseMatrix netRatesOfProgress_ddX() except +translate_exception
+
+        CxxSparseMatrix creationRates_ddX() except +translate_exception
+        CxxSparseMatrix destructionRates_ddX() except +translate_exception
+        CxxSparseMatrix netProductionRates_ddX() except +translate_exception
+
 
 cdef extern from "cantera/kinetics/InterfaceKinetics.h":
     cdef cppclass CxxInterfaceKinetics "Cantera::InterfaceKinetics":
@@ -113,18 +126,6 @@ cdef extern from "cantera/cython/kinetics_utils.h":
     cdef void kin_getDestructionRates_ddC(CxxKinetics*, double*) except +translate_exception
     cdef void kin_getNetProductionRates_ddC(CxxKinetics*, double*) except +translate_exception
 
-    # Kinetics sparse matrices
-    cdef CxxSparseMatrix kin_reactantStoichCoeffs(CxxKinetics*) except +translate_exception
-    cdef CxxSparseMatrix kin_productStoichCoeffs(CxxKinetics*) except +translate_exception
-    cdef CxxSparseMatrix kin_revProductStoichCoeffs(CxxKinetics*) except +translate_exception
-
-    cdef CxxSparseMatrix kin_fwdRatesOfProgress_ddX(CxxKinetics*) except +translate_exception
-    cdef CxxSparseMatrix kin_revRatesOfProgress_ddX(CxxKinetics*) except +translate_exception
-    cdef CxxSparseMatrix kin_netRatesOfProgress_ddX(CxxKinetics*) except +translate_exception
-
-    cdef CxxSparseMatrix kin_creationRates_ddX(CxxKinetics*) except +translate_exception
-    cdef CxxSparseMatrix kin_destructionRates_ddX(CxxKinetics*) except +translate_exception
-    cdef CxxSparseMatrix kin_netProductionRates_ddX(CxxKinetics*) except +translate_exception
 
 
 ctypedef void (*kineticsMethod1d)(CxxKinetics*, double*) except +translate_exception
@@ -138,5 +139,4 @@ cdef class InterfaceKinetics(Kinetics):
 
 cdef np.ndarray get_species_array(Kinetics kin, kineticsMethod1d method)
 cdef np.ndarray get_reaction_array(Kinetics kin, kineticsMethod1d method)
-cdef np.ndarray get_dense(Kinetics kin, kineticsMethodSparse method)
-cdef tuple get_sparse(Kinetics kin, kineticsMethodSparse method)
+cdef get_from_sparse(CxxSparseMatrix&, int, int)

--- a/interfaces/cython/cantera/preconditioners.pxd
+++ b/interfaces/cython/cantera/preconditioners.pxd
@@ -9,7 +9,7 @@ from .ctcxx cimport *
 cdef extern from "cantera/numerics/PreconditionerBase.h" namespace "Cantera":
     cdef cppclass CxxPreconditionerBase "Cantera::PreconditionerBase":
         CxxPreconditionerBase()
-        int preconditionerSide()
+        string preconditionerSide()
         void setPreconditionerSide(string) except +translate_exception
 
 cdef extern from "cantera/numerics/AdaptivePreconditioner.h" namespace "Cantera":

--- a/interfaces/cython/cantera/preconditioners.pxd
+++ b/interfaces/cython/cantera/preconditioners.pxd
@@ -9,6 +9,8 @@ from .ctcxx cimport *
 cdef extern from "cantera/numerics/PreconditionerBase.h" namespace "Cantera":
     cdef cppclass CxxPreconditionerBase "Cantera::PreconditionerBase":
         CxxPreconditionerBase()
+        int preconditionerSide()
+        void setPreconditionerSide(string) except +translate_exception
 
 cdef extern from "cantera/numerics/AdaptivePreconditioner.h" namespace "Cantera":
     cdef cppclass CxxAdaptivePreconditioner "Cantera::AdaptivePreconditioner" \

--- a/interfaces/cython/cantera/preconditioners.pyx
+++ b/interfaces/cython/cantera/preconditioners.pyx
@@ -20,15 +20,7 @@ cdef class PreconditionerBase:
         by all solver types.
         """
         def __get__(self):
-            cdef int side = <int>self.pbase.get().preconditionerSide()
-            if side == 0:
-                return "none"
-            elif side == 1:
-                return "left"
-            elif side == 2:
-                return "right"
-            elif side == 3:
-                return "both"
+            return pystr(self.pbase.get().preconditionerSide())
 
         def __set__(self, side):
             self.pbase.get().setPreconditionerSide(stringify(side))

--- a/interfaces/cython/cantera/preconditioners.pyx
+++ b/interfaces/cython/cantera/preconditioners.pyx
@@ -13,6 +13,26 @@ cdef class PreconditionerBase:
     def __cinit__(self, *args, **kwargs):
         self.pbase = newPreconditioner(stringify(self.precon_type))
 
+    property side:
+        """
+        Get/Set the side of the system matrix where the preconditioner is applied.
+        Options are "none", "left", "right", or "both". Not all options are supported
+        by all solver types.
+        """
+        def __get__(self):
+            cdef int side = <int>self.pbase.get().preconditionerSide()
+            if side == 0:
+                return "none"
+            elif side == 1:
+                return "left"
+            elif side == 2:
+                return "right"
+            elif side == 3:
+                return "both"
+
+        def __set__(self, side):
+            self.pbase.get().setPreconditionerSide(stringify(side))
+
 cdef class AdaptivePreconditioner(PreconditionerBase):
     precon_type = "Adaptive"
     precon_linear_solver_type = "GMRES"

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -43,6 +43,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         size_t neq()
         void getState(double*) except +translate_exception
         CxxSparseMatrix jacobian() except +translate_exception
+        CxxSparseMatrix finiteDifferenceJacobian() except +translate_exception
         void addSurface(CxxReactorSurface*)
         void setAdvanceLimit(string&, double) except +translate_exception
         void addSensitivityReaction(size_t) except +translate_exception

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -42,6 +42,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         string componentName(size_t) except +translate_exception
         size_t neq()
         void getState(double*) except +translate_exception
+        CxxSparseMatrix jacobian() except +translate_exception
         void addSurface(CxxReactorSurface*)
         void setAdvanceLimit(string&, double) except +translate_exception
         void addSensitivityReaction(size_t) except +translate_exception

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -162,8 +162,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         string linearSolverType()
         void setPreconditioner(shared_ptr[CxxPreconditionerBase] preconditioner)
         void setDerivativeSettings(CxxAnyMap&)
-        CxxAnyMap linearSolverStats()
-        CxxAnyMap nonlinearSolverStats()
+        CxxAnyMap solverStats()
 
 cdef extern from "cantera/zeroD/ReactorDelegator.h" namespace "Cantera":
     cdef cppclass CxxReactorAccessor "Cantera::ReactorAccessor":

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -334,6 +334,16 @@ cdef class Reactor(ReactorBase):
         return y
 
     property jacobian:
+        """
+        Get the local, reactor-specific Jacobian or an approximation thereof
+
+        **Warning**: Depending on the particular implementation, this may return an
+        approximate Jacobian intended only for use in forming a preconditioner for
+        iterative solvers, excluding terms that would generate a fully-dense Jacobian.
+
+        **Warning**: This method is an experimental part of the Cantera API and may be
+        changed or removed without notice.
+        """
         def __get__(self):
             return get_from_sparse(self.reactor.jacobian(), self.n_vars, self.n_vars)
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -1503,18 +1503,11 @@ cdef class ReactorNet:
             return pystr(self.net.linearSolverType())
 
 
-    property linear_solver_stats:
-        """Linear solver stats from integrator"""
+    property solver_stats:
+        """ODE solver stats from integrator"""
         def __get__(self):
             cdef CxxAnyMap stats
-            stats = self.net.linearSolverStats()
-            return anymap_to_dict(stats)
-
-    property nonlinear_solver_stats:
-        """Nonlinear solver stats from integrator"""
-        def __get__(self):
-            cdef CxxAnyMap stats
-            stats = self.net.nonlinearSolverStats()
+            stats = self.net.solverStats()
             return anymap_to_dict(stats)
 
     property derivative_settings:

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -337,6 +337,17 @@ cdef class Reactor(ReactorBase):
         def __get__(self):
             return get_from_sparse(self.reactor.jacobian(), self.n_vars, self.n_vars)
 
+    property finite_difference_jacobian:
+        """
+        Get the reactor-specific Jacobian, calculated using a finite difference method.
+
+        **Warning:** this property is an experimental part of the Cantera API and
+        may be changed or removed without notice.
+        """
+        def __get__(self):
+            return get_from_sparse(self.reactor.finiteDifferenceJacobian(),
+                                   self.n_vars, self.n_vars)
+
     def set_advance_limit(self, name, limit):
         """
         Limit absolute change of component ``name`` during `ReactorNet.advance`.

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -333,6 +333,10 @@ cdef class Reactor(ReactorBase):
         self.reactor.getState(&y[0])
         return y
 
+    property jacobian:
+        def __get__(self):
+            return get_from_sparse(self.reactor.jacobian(), self.n_vars, self.n_vars)
+
     def set_advance_limit(self, name, limit):
         """
         Limit absolute change of component ``name`` during `ReactorNet.advance`.

--- a/samples/python/reactors/preconditioned_integration.py
+++ b/samples/python/reactors/preconditioned_integration.py
@@ -11,7 +11,7 @@ import numpy as np
 import matplotlib.pyplot as plt
 from timeit import default_timer
 
-def integrate_reactor(n_reactors=15, preconditioner=True):
+def integrate_reactor(n_reactors=1, preconditioner=True):
     """
         Compare the integrations of a preconditioned reactor network and a
         non-preconditioned reactor network. Increase the number of reactors in the

--- a/samples/python/reactors/preconditioned_integration.py
+++ b/samples/python/reactors/preconditioned_integration.py
@@ -49,12 +49,8 @@ def integrate_reactor(n_reactors=15, preconditioner=True):
     else:
         print(f"Non-preconditioned Integration Time: {integ_time:f}")
     # Get and output solver stats
-    lin_stats = sim.linear_solver_stats
-    nonlin_stats = sim.nonlinear_solver_stats
-    for key in lin_stats:
-        print(key, lin_stats[key])
-    for key in nonlin_stats:
-        print(key, nonlin_stats[key])
+    for key, value in sim.solver_stats.items():
+        print(key, value)
     print("\n")
     # return some variables for plotting
     return states.time, states.T, states('CO2').Y, states('C12H26').Y

--- a/src/numerics/AdaptivePreconditioner.cpp
+++ b/src/numerics/AdaptivePreconditioner.cpp
@@ -11,7 +11,7 @@ namespace Cantera
 
 AdaptivePreconditioner::AdaptivePreconditioner()
 {
-    setPreconditionerSide("left");
+    setPreconditionerSide("right");
 }
 
 void AdaptivePreconditioner::setValue(size_t row, size_t col, double value)

--- a/src/numerics/AdaptivePreconditioner.cpp
+++ b/src/numerics/AdaptivePreconditioner.cpp
@@ -9,6 +9,11 @@
 namespace Cantera
 {
 
+AdaptivePreconditioner::AdaptivePreconditioner()
+{
+    setPreconditionerSide("left");
+}
+
 void AdaptivePreconditioner::setValue(size_t row, size_t col, double value)
 {
     m_jac_trips.emplace_back(row, col, value);

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -621,34 +621,15 @@ int CVodesIntegrator::nEvals() const
     return ne;
 }
 
-AnyMap CVodesIntegrator::nonlinearSolverStats() const
-{
-    long int iters = 0, conv_fails = 0;
-    // AnyMap to return stats
-    AnyMap stats;
-    #if CT_SUNDIALS_VERSION >= 40
-        CVodeGetNonlinSolvStats(m_cvode_mem, &iters, &conv_fails);
-    #else
-        warn_user("CVodesIntegrator::nonlinearSolverStats", "Function not"
-                  "supported with sundials versions less than 4.");
-    #endif
-    // Add values to AnyMap
-    stats["nonlinear_iters"] = iters;
-    stats["nonlinear_conv_fails"] = conv_fails;
-    return stats;
-}
-
-AnyMap CVodesIntegrator::linearSolverStats() const
+AnyMap CVodesIntegrator::solverStats() const
 {
     // long int linear solver stats provided by CVodes
     long int jacEvals = 0, linRhsEvals = 0, linIters = 0, linConvFails = 0,
-             precEvals = 0, precSolves = 0, jtSetupEvals = 0, jTimesEvals = 0;
-    // AnyMap to return stats
-    AnyMap stats;
-    #if CT_SUNDIALS_VERSION >= 60
-        CVodeGetLinSolveStats(m_cvode_mem, &jacEvals, &linRhsEvals, &linIters,
-            &linConvFails, &precEvals, &precSolves, &jtSetupEvals, &jTimesEvals);
-    #elif CT_SUNDIALS_VERSION >= 40
+             precEvals = 0, precSolves = 0, jtSetupEvals = 0, jTimesEvals = 0,
+             nonlin_iters = 0, nonlin_conv_fails = 0;
+;
+    #if CT_SUNDIALS_VERSION >= 40
+        CVodeGetNonlinSolvStats(m_cvode_mem, &nonlin_iters, &nonlin_conv_fails);
         CVodeGetNumJacEvals(m_cvode_mem, &jacEvals);
         CVodeGetNumLinRhsEvals(m_cvode_mem, &linRhsEvals);
         CVodeGetNumLinIters(m_cvode_mem, &linIters);
@@ -658,10 +639,12 @@ AnyMap CVodesIntegrator::linearSolverStats() const
         CVodeGetNumJTSetupEvals(m_cvode_mem, &jtSetupEvals);
         CVodeGetNumJtimesEvals(m_cvode_mem, &jTimesEvals);
     #else
-        warn_user("CVodesIntegrator::linearSolverStats", "Function not"
+        warn_user("CVodesIntegrator::solverStats", "Function not"
                   "supported with sundials versions less than 4.");
     #endif
-    // Add data to AnyMap
+
+    // AnyMap to return stats
+    AnyMap stats;
     stats["jac_evals"] = jacEvals;
     stats["lin_rhs_evals"] = linRhsEvals;
     stats["lin_iters"] = linIters;
@@ -670,6 +653,8 @@ AnyMap CVodesIntegrator::linearSolverStats() const
     stats["prec_solves"] = precSolves;
     stats["jt_vec_setup_evals"] = jtSetupEvals;
     stats["jt_vec_prod_evals"] = jTimesEvals;
+    stats["nonlinear_iters"] = nonlin_iters;
+    stats["nonlinear_conv_fails"] = nonlin_conv_fails;
     return stats;
 }
 

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -301,7 +301,7 @@ void CVodesIntegrator::initialize(double t0, FuncEval& func)
     m_func = &func;
     func.clearErrors();
     // Initialize preconditioner if applied
-    if (m_prec_type != PreconditionerType::NO_PRECONDITION) {
+    if (m_prec_side != PreconditionerSide::NO_PRECONDITION) {
         m_preconditioner->initialize(m_neq);
     }
     if (m_y) {
@@ -399,7 +399,7 @@ void CVodesIntegrator::reinitialize(double t0, FuncEval& func)
     m_func = &func;
     func.clearErrors();
     // reinitialize preconditioner if applied
-    if (m_prec_type != PreconditionerType::NO_PRECONDITION) {
+    if (m_prec_side != PreconditionerSide::NO_PRECONDITION) {
         m_preconditioner->initialize(m_neq);
     }
     int result = CVodeReInit(m_cvode_mem, m_t0, m_y);
@@ -455,14 +455,14 @@ void CVodesIntegrator::applyOptions()
         }
 
         // throw preconditioner error for DENSE + NOJAC
-        if (m_prec_type != PreconditionerType::NO_PRECONDITION) {
+        if (m_prec_side != PreconditionerSide::NO_PRECONDITION) {
             throw CanteraError("CVodesIntegrator::applyOptions",
                 "Preconditioning is not available with the specified problem type.");
         }
     } else if (m_type == "DIAG") {
         CVDiag(m_cvode_mem);
         // throw preconditioner error for DIAG
-        if (m_prec_type != PreconditionerType::NO_PRECONDITION) {
+        if (m_prec_side != PreconditionerSide::NO_PRECONDITION) {
             throw CanteraError("CVodesIntegrator::applyOptions",
                 "Preconditioning is not available with the specified problem type.");
         }
@@ -479,16 +479,16 @@ void CVodesIntegrator::applyOptions()
         #endif
         // set preconditioner if used
         #if CT_SUNDIALS_VERSION >= 40
-            if (m_prec_type != PreconditionerType::NO_PRECONDITION) {
+            if (m_prec_side != PreconditionerSide::NO_PRECONDITION) {
                 SUNLinSol_SPGMRSetPrecType((SUNLinearSolver) m_linsol,
-                    static_cast<int>(m_prec_type));
+                    static_cast<int>(m_prec_side));
                 CVodeSetPreconditioner(m_cvode_mem, cvodes_prec_setup,
                     cvodes_prec_solve);
             }
         #else
-            if (m_prec_type != PreconditionerType::NO_PRECONDITION) {
+            if (m_prec_side != PreconditionerSide::NO_PRECONDITION) {
                 SUNSPGMRSetPrecType((SUNLinearSolver) m_linsol,
-                    static_cast<int>(m_prec_type));
+                    static_cast<int>(m_prec_side));
                 CVSpilsSetPreconditioner(m_cvode_mem, cvodes_prec_setup,
                     cvodes_prec_solve);
             }

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -167,7 +167,7 @@ Eigen::SparseMatrix<double> IdealGasConstPressureMoleReactor::jacobian()
     if (m_energy) {
         // getting perturbed state for finite difference
         double deltaTemp = m_thermo->temperature()
-            * std::numeric_limits<double>::epsilon();
+            * std::sqrt(std::numeric_limits<double>::epsilon());
         // finite difference temperature derivatives
         vector_fp ydotNext(m_nv);
         vector_fp yCurrent(m_nv);

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -158,6 +158,10 @@ void IdealGasMoleReactor::eval(double time, double* LHS, double* RHS)
 
 Eigen::SparseMatrix<double> IdealGasMoleReactor::jacobian()
 {
+    if (m_nv == 0) {
+        throw CanteraError("IdealGasMoleReactor::jacobian",
+                           "Reactor must be initialized first.");
+    }
     // clear former jacobian elements
     m_jac_trips.clear();
     // Determine Species Derivatives
@@ -186,10 +190,11 @@ Eigen::SparseMatrix<double> IdealGasMoleReactor::jacobian()
         yNext[0] += deltaTemp;
         // getting perturbed state
         updateState(yNext.data());
-        eval(m_net->time(), yNext.data(), ydotNext.data());
+        double time = (m_net != nullptr) ? m_net->time() : 0.0;
+        eval(time, yNext.data(), ydotNext.data());
         // reset and get original state
         updateState(yCurrent.data());
-        eval(m_net->time(), yCurrent.data(), ydotCurrent.data());
+        eval(time, yCurrent.data(), ydotCurrent.data());
         // d T_dot/dT
         m_jac_trips.emplace_back(0, 0, (ydotNext[0] - ydotCurrent[0]) / deltaTemp);
         // d omega_dot_j/dT

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -181,25 +181,25 @@ Eigen::SparseMatrix<double> IdealGasMoleReactor::jacobian()
         double deltaTemp = m_thermo->temperature()
             * std::sqrt(std::numeric_limits<double>::epsilon());
         // finite difference temperature derivatives
-        vector_fp ydotNext(m_nv);
+        vector_fp lhsPerturbed(m_nv, 1.0), lhsCurrent(m_nv, 1.0);
+        vector_fp rhsPerturbed(m_nv, 0.0), rhsCurrent(m_nv, 0.0);
         vector_fp yCurrent(m_nv);
-        vector_fp ydotCurrent(m_nv);
         getState(yCurrent.data());
-        vector_fp yNext = yCurrent;
+        vector_fp yPerturbed = yCurrent;
         // perturb temperature
-        yNext[0] += deltaTemp;
+        yPerturbed[0] += deltaTemp;
         // getting perturbed state
-        updateState(yNext.data());
+        updateState(yPerturbed.data());
         double time = (m_net != nullptr) ? m_net->time() : 0.0;
-        eval(time, yNext.data(), ydotNext.data());
+        eval(time, lhsPerturbed.data(), rhsPerturbed.data());
         // reset and get original state
         updateState(yCurrent.data());
-        eval(time, yCurrent.data(), ydotCurrent.data());
-        // d T_dot/dT
-        m_jac_trips.emplace_back(0, 0, (ydotNext[0] - ydotCurrent[0]) / deltaTemp);
-        // d omega_dot_j/dT
-        for (size_t j = m_sidx; j < m_nv; j++) {
-            m_jac_trips.emplace_back(j, 0, (ydotNext[j] - ydotCurrent[j]) / deltaTemp);
+        eval(time, lhsCurrent.data(), rhsCurrent.data());
+        // d ydot_j/dT
+        for (size_t j = 0; j < m_nv; j++) {
+            double ydotPerturbed = rhsPerturbed[j] / lhsPerturbed[j];
+            double ydotCurrent = rhsCurrent[j] / lhsCurrent[j];
+            m_jac_trips.emplace_back(j, 0, (ydotPerturbed - ydotCurrent) / deltaTemp);
         }
         // find derivatives d T_dot/dNj
         vector_fp specificHeat(m_nsp);

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -71,6 +71,31 @@ size_t IdealGasMoleReactor::componentIndex(const string& nm) const
     }
 }
 
+std::string IdealGasMoleReactor::componentName(size_t k)
+{
+    if (k == 0) {
+        return "temperature";
+    } else if (k == 1) {
+        return "volume";
+    } else if (k >= m_sidx && k < neq()) {
+        k -= m_sidx;
+        if (k < m_thermo->nSpecies()) {
+            return m_thermo->speciesName(k);
+        } else {
+            k -= m_thermo->nSpecies();
+        }
+        for (auto& S : m_surfaces) {
+            ThermoPhase* th = S->thermo();
+            if (k < th->nSpecies()) {
+                return th->speciesName(k);
+            } else {
+                k -= th->nSpecies();
+            }
+        }
+    }
+    throw IndexError("IdealGasMoleReactor::componentName", "components", k, neq() - 1);
+}
+
 void IdealGasMoleReactor::initialize(double t0)
 {
     MoleReactor::initialize(t0);

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -424,14 +424,9 @@ void ReactorNet::setDerivativeSettings(AnyMap& settings)
     }
 }
 
-AnyMap ReactorNet::nonlinearSolverStats() const
+AnyMap ReactorNet::solverStats() const
 {
-    return m_integ->nonlinearSolverStats();
-}
-
-AnyMap ReactorNet::linearSolverStats() const
-{
-    return m_integ->linearSolverStats();
+    return m_integ->solverStats();
 }
 
 std::string ReactorNet::linearSolverType() const

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -459,7 +459,7 @@ void ReactorNet::preconditionerSetup(double t, double* y, double gamma)
     updateState(yCopy.data());
     // Get jacobians and give elements to preconditioners
     for (size_t i = 0; i < m_reactors.size(); i++) {
-        Eigen::SparseMatrix<double> rJac = m_reactors[i]->jacobian(t, y + m_start[i]);
+        Eigen::SparseMatrix<double> rJac = m_reactors[i]->jacobian();
         for (int k=0; k<rJac.outerSize(); ++k) {
             for (Eigen::SparseMatrix<double>::InnerIterator it(rJac, k); it; ++it) {
                 precon->setValue(it.row() + m_start[i], it.col() + m_start[i],

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -115,7 +115,7 @@ void ReactorNet::initialize()
         writelog("Maximum time step:   {:14.6g}\n", m_maxstep);
     }
     m_integ->initialize(m_time, *this);
-    if (m_integ->preconditionerType() != PreconditionerType::NO_PRECONDITION) {
+    if (m_integ->preconditionerSide() != PreconditionerSide::NO_PRECONDITION) {
         checkPreconditionerSupported();
     }
     m_integrator_init = true;
@@ -127,7 +127,7 @@ void ReactorNet::reinitialize()
     if (m_init) {
         debuglog("Re-initializing reactor network.\n", m_verbose);
         m_integ->reinitialize(m_time, *this);
-        if (m_integ->preconditionerType() != PreconditionerType::NO_PRECONDITION) {
+        if (m_integ->preconditionerSide() != PreconditionerSide::NO_PRECONDITION) {
             checkPreconditionerSupported();
         }
         m_integrator_init = true;

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1042,11 +1042,13 @@ class TestIdealGasConstPressureMoleReactor(TestIdealGasConstPressureReactor):
 
     def create_reactors(self, **kwargs):
         super().create_reactors(**kwargs)
-        self.net2.preconditioner = ct.AdaptivePreconditioner()
+        self.precon = ct.AdaptivePreconditioner()
+        self.net2.preconditioner = self.precon
         self.net2.derivative_settings = {"skip-third-bodies":True, "skip-falloff":True}
 
     def test_get_solver_type(self):
         self.create_reactors()
+        assert self.precon.side == "right"
         self.assertEqual(self.net2.linear_solver_type, "GMRES")
 
     def test_with_surface_reactions(self):

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -150,21 +150,19 @@ TEST(AdaptivePreconditionerTests, test_precon_solver_stats)
     EXPECT_THROW(network.step(), CanteraError);
     // take a step
     network.setLinearSolverType("GMRES");
-    // get linear solver stats
+    // get solver stats
     network.step();
-    AnyMap linearStats = network.linearSolverStats();
-    EXPECT_GE(linearStats["jac_evals"].asInt(), 0);
-    EXPECT_GE(linearStats["lin_rhs_evals"].asInt(), 0);
-    EXPECT_GE(linearStats["lin_iters"].asInt(), 0);
-    EXPECT_GE(linearStats["lin_conv_fails"].asInt(), 0);
-    EXPECT_GE(linearStats["prec_evals"].asInt(), 0);
-    EXPECT_GE(linearStats["prec_solves"].asInt(), 0);
-    EXPECT_GE(linearStats["jt_vec_setup_evals"].asInt(), 0);
-    EXPECT_GE(linearStats["jt_vec_prod_evals"].asInt(), 0);
-    // nonlinear solver stats
-    AnyMap nonlinearStats = network.nonlinearSolverStats();
-    EXPECT_GE(nonlinearStats["nonlinear_iters"].asInt(), 0);
-    EXPECT_GE(nonlinearStats["nonlinear_conv_fails"].asInt(), 0);
+    AnyMap stats = network.solverStats();
+    EXPECT_GE(stats["jac_evals"].asInt(), 0);
+    EXPECT_GE(stats["lin_rhs_evals"].asInt(), 0);
+    EXPECT_GE(stats["lin_iters"].asInt(), 0);
+    EXPECT_GE(stats["lin_conv_fails"].asInt(), 0);
+    EXPECT_GE(stats["prec_evals"].asInt(), 0);
+    EXPECT_GE(stats["prec_solves"].asInt(), 0);
+    EXPECT_GE(stats["jt_vec_setup_evals"].asInt(), 0);
+    EXPECT_GE(stats["jt_vec_prod_evals"].asInt(), 0);
+    EXPECT_GE(stats["nonlinear_iters"].asInt(), 0);
+    EXPECT_GE(stats["nonlinear_conv_fails"].asInt(), 0);
 }
 
 int main(int argc, char** argv)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

Short version: This restores the performance of the preconditioned solver for reactor networks to what it was like before #1010 was rebased to resolve merge conflicts with the updated `Reactor` API from #1003. 

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Expand the set of CVODES solver statistics collected and simplify the interface to a single `solverStats()` function (or `solver_stats` property in Python.
- Enable the selection of which side of the system to applying the preconditioner, and make preconditioning on the right the default -- I find that this often significantly reduces the number of time steps needed.
- Simplify and generalize the conversion of Eigen sparse matrices to Python
- Make the reactor Jacobian available in Python
- Fix some issues with the calculation of calculation of derivatives with respect to temperature (done by finite difference in the Jacobian calculation) -- the wrong arguments were being passed into the `Reactor::eval(double t, double* lhs, double* rhs)` method, treating it like the now-removed `Reactor::evalEqs(double t, double* y, double* ydot)` method. This resulted in wildly wrong values for these derivatives that caused poor performance for the preconditioned integrator.
- Fix missing implementation of `IdealGasMoleReactor::componentName`
- Make a single-reactor finite difference Jacobian available in both C++ and Python, to aid in verification and debugging.
- Add missing terms to the energy equation derivatives related to the off-diagonal derivatives of dX<sub>j</sub>/dn<sub>i</sub>. Add comments to clarify that these terms are deliberately excluded from the species equation to avoid making the Jacobian dense.

**If applicable, provide an example illustrating new features this pull request is introducing**

Results for a sample of ignition delay calculations before this PR:
```
vars =   11, steps =  420, time = 0.003, t_ig = 2.04e-03
vars =   54, steps = 5860, time = 0.331, t_ig = 7.93e-01
vars =  121, failed
vars =  202, steps = 1639, time = 0.310, t_ig = 1.54e-02
vars =  231, failed
vars =  494, steps = 2072, time = 0.965, t_ig = 7.34e-02
vars =  655, failed
vars =  875, failed
vars = 1379, steps = 1504, time = 1.447, t_ig = 3.84e-02
vars = 2116, steps = 1702, time = 2.450, t_ig = 2.22e-02
vars = 2650, steps = 9144, time = 29.482, t_ig = 1.74e-02
vars = 3788, failed
vars = 7172, steps = 1878, time = 20.547, t_ig = 5.40e-02
```

Results for left preconditioning, using this PR:
```
vars =   11, steps =  420, time = 0.002, t_ig = 2.04e-03
vars =   54, steps = 1106, time = 0.043, t_ig = 7.93e-01
vars =  121, steps = 1444, time = 0.152, t_ig = 5.56e-02
vars =  202, steps = 1100, time = 0.182, t_ig = 1.55e-02
vars =  231, steps = 4156, time = 0.927, t_ig = 3.84e-02
vars =  494, steps = 1088, time = 0.412, t_ig = 7.34e-02
vars =  655, steps = 4190, time = 2.065, t_ig = 2.69e-02
vars =  875, steps = 4926, time = 3.398, t_ig = 1.41e-01
vars = 1379, steps = 1207, time = 0.963, t_ig = 3.84e-02
vars = 2116, steps = 1122, time = 1.488, t_ig = 2.22e-02
vars = 2650, steps = 6480, time = 14.042, t_ig = 1.74e-02
vars = 3788, steps = 6097, time = 16.011, t_ig = 1.54e-02
vars = 7172, steps = 1365, time = 9.583, t_ig = 5.40e-02
```

Results for right preconditioning, using this PR:
```
vars =   11, steps =  415, time = 0.002, t_ig = 2.04e-03
vars =   54, steps = 1026, time = 0.044, t_ig = 7.93e-01
vars =  121, steps =  975, time = 0.101, t_ig = 5.56e-02
vars =  202, steps =  918, time = 0.157, t_ig = 1.54e-02
vars =  231, steps = 1150, time = 0.281, t_ig = 3.85e-02
vars =  494, steps =  899, time = 0.380, t_ig = 7.34e-02
vars =  655, steps = 1163, time = 0.635, t_ig = 2.69e-02
vars =  875, steps = 1445, time = 1.055, t_ig = 1.41e-01
vars = 1379, steps =  933, time = 0.808, t_ig = 3.84e-02
vars = 2116, steps =  903, time = 1.212, t_ig = 2.22e-02
vars = 2650, steps = 1296, time = 3.187, t_ig = 1.74e-02
vars = 3788, steps = 1408, time = 4.642, t_ig = 1.54e-02
vars = 7172, steps =  947, time = 7.641, t_ig = 5.40e-02
```

And for reference, results using the standard dense integrator:
```
vars =   11, steps =  561, time = 0.002, t_ig = 2.04e-03
vars =   54, steps = 1398, time = 0.030, t_ig = 7.93e-01
vars =  121, steps = 2457, time = 0.268, t_ig = 5.56e-02
vars =  202, steps = 2233, time = 0.513, t_ig = 1.54e-02
vars =  231, steps = 2124, time = 0.532, t_ig = 3.84e-02
vars =  494, steps = 2239, time = 2.105, t_ig = 7.34e-02
vars =  655, steps = 2015, time = 2.680, t_ig = 2.69e-02
vars =  875, steps = 2874, time = 6.401, t_ig = 1.41e-01
vars = 1379, steps = 2212, time = 13.761, t_ig = 3.84e-02
vars = 2116, steps = 2131, time = 31.797, t_ig = 2.22e-02
vars = 2650, steps = 2862, time = 71.558, t_ig = 1.74e-02
vars = 3788, steps = 2510, time = 128.635, t_ig = 1.54e-02
vars = 7172, steps = 2103, time = 531.998, t_ig = 5.40e-02
```
(and note that this last set is making use of the parallel BLAS/LAPACK implementation available through the macOS Accelerate framework, while the others are all purely single-threaded).

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
