### PR TITLE
[SCons] Ensure paths use posix-style separators

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -78,7 +78,6 @@ import subprocess
 import re
 import json
 import textwrap
-from os.path import join as pjoin
 from pkg_resources import parse_version
 import SCons
 
@@ -1967,20 +1966,11 @@ env.Prepend(CPPPATH=[],
            LIBPATH=[Dir('build/lib')])
 
 for yaml in multi_glob(env, "data", "yaml"):
-    dest = pjoin("build", "data", yaml.name)
-    build(env.Command(dest, yaml.path, Copy("$TARGET", "$SOURCE")))
-for subdir in os.listdir('data'):
-    if os.path.isdir(pjoin('data', subdir)):
-        for yaml in multi_glob(env, pjoin("data", subdir), "yaml"):
-            dest = pjoin("build", "data", subdir, yaml.name)
-            if not os.path.exists(pjoin("build", "data", subdir)):
-                os.makedirs(pjoin("build", "data", subdir))
-            build(env.Command(dest, yaml.path, Copy("$TARGET", "$SOURCE")))
-
+    dest = Path() / "build" / "data" / yaml.name
+    build(env.Command(str(dest), yaml.path, Copy("$TARGET", "$SOURCE")))
 
 if addInstallActions:
     # Put headers in place
-    headerBase = 'include/cantera'
     install(env.RecursiveInstall, '$inst_incdir', 'include/cantera')
 
     # Data files

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -176,13 +176,12 @@ if env["stage_dir"]:
 install_cmd.extend(("--no-build-isolation", "--no-deps", "-v", "--force-reinstall",
                     "build/python"))
 if localenv['PYTHON_INSTALLER'] == 'direct':
-    mod_inst = install(localenv.Command, 'dummy', mod,
-                       " ".join(install_cmd))
+    mod_inst = install(localenv.Command, "dummy", mod, " ".join(install_cmd))
     env["install_python_action"] = mod_inst
     install_locs = get_pip_install_location(localenv["python_cmd"], user_install,
                                             python_prefix)
-    env["python_module_loc"] = install_locs["platlib"]
-    env["ct_pyscriptdir"] = install_locs["scripts"]
+    env["python_module_loc"] = Path(install_locs["platlib"]).as_posix()
+    env["ct_pyscriptdir"] = Path(install_locs["scripts"]).as_posix()
 elif localenv['PYTHON_INSTALLER'] == 'debian':
     install(localenv.Command, 'dummy', mod,
             'cd build/python && '

--- a/samples/cxx/CMakeLists.txt.in
+++ b/samples/cxx/CMakeLists.txt.in
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project (@tmpl_progname@)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_STANDARD 11)
+set(CMAKE_CXX_STANDARD 14)
 
 find_package(Threads REQUIRED)
 @cmake_extra@


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Ensure that paths use posix-style separators on all platforms. The post-install message becomes

```
*************** Cantera 3.0.0a2 has been successfully installed ****************

File locations:

  library files               C:/Users/ischo/miniconda3/envs/cantera-dev/Library/lib
  C++ headers                 C:/Users/ischo/miniconda3/envs/cantera-dev/Library/include
  samples                     C:/Users/ischo/miniconda3/envs/cantera-dev/share/cantera/samples
  data files                  C:/Users/ischo/miniconda3/envs/cantera-dev/share/cantera/data
  input file converters       C:/Users/ischo/miniconda3/envs/cantera-dev/Scripts
  Python package              C:/Users/ischo/miniconda3/envs/cantera-dev/Lib/site-packages
  Python examples             C:/Users/ischo/miniconda3/envs/cantera-dev/share/cantera/samples/python
  Matlab toolbox              C:/Users/ischo/miniconda3/envs/cantera-dev/share/cantera/matlab/toolbox
  Matlab samples              C:/Users/ischo/miniconda3/envs/cantera-dev/share/cantera/samples/matlab

An m-file to set the correct matlab path for Cantera is at:

  C:/Users/ischo/miniconda3/envs/cantera-dev/share/cantera/matlab/toolbox/ctpath.m

********************************************************************************
```

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1374

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
