### PR TITLE
Bump version to 3.0.0a3

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ possible.
 Development Site
 ================
 
-The current development version is 3.0.0a2. The current stable version is
+The current development version is 3.0.0a3. The current stable version is
 2.6.0. The `latest Cantera source code <https://github.com/Cantera/cantera>`_,
 the `issue tracker <https://github.com/Cantera/cantera/issues>`_ for bugs and
 enhancement requests, `downloads of Cantera releases and binary installers

--- a/SConstruct
+++ b/SConstruct
@@ -883,7 +883,7 @@ for arg in ARGUMENTS:
         logger.error(f"Encountered unexpected command line option: {arg!r}")
         sys.exit(1)
 
-env["cantera_version"] = "3.0.0a2"
+env["cantera_version"] = "3.0.0a3"
 # For use where pre-release tags are not permitted (MSI, sonames)
 env['cantera_pure_version'] = re.match(r'(\d+\.\d+\.\d+)', env['cantera_version']).group(0)
 env['cantera_short_version'] = re.match(r'(\d+\.\d+)', env['cantera_version']).group(0)

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = Cantera
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.0a2
+PROJECT_NUMBER         = 3.0.0a3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1934,7 +1934,7 @@ class Parser:
             metadata = BlockMap([
                 ("generator", "ck2yaml"),
                 ("input-files", FlowList(files)),
-                ("cantera-version", "3.0.0a2"),
+                ("cantera-version", "3.0.0a3"),
                 ("date", formatdate(localtime=True)),
             ])
             if desc.strip():

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1661,7 +1661,7 @@ def convert(filename=None, output_name=None, text=None, encoding="latin-1"):
         # information regarding conversion
         metadata = BlockMap([
             ("generator", "cti2yaml"),
-            ("cantera-version", "3.0.0a2"),
+            ("cantera-version", "3.0.0a3"),
             ("date", formatdate(localtime=True)),
         ])
         if filename != "<string>":

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -2641,7 +2641,7 @@ def convert(
     metadata = BlockMap(
         {
             "generator": "ctml2yaml",
-            "cantera-version": "3.0.0a2",
+            "cantera-version": "3.0.0a3",
             "date": formatdate(localtime=True),
         }
     )


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Bump development version to `3.0.0a3` in order to ensure that `conda` packages on `cantera/label/dev` are up to date. While force-uploading to replace package files on `anaconda.org` works for `mamba`, it does not appear to be properly resolved by `conda`.

Recent work on `libcantera-devel` now produces samples for `cxx`, `f90` and `f77` that can be compiled locally using `make`, `scons` and `cmake` on Linux without having to tweak configuration files (see updated instruction proposed in Cantera/cantera-website#225). Some work remains for Intel macOS and Windows.