### PR TITLE
[SCons] Disable F90 interface default on Apple clang

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1411,6 +1411,9 @@ end program main
 
 set_fortran("{}FLAGS", env["FORTRANFLAGS"])
 
+if env["using_apple_clang"] and env["f90_interface"] == "default":
+    env["f90_interface"] = "n"
+
 if env['f90_interface'] in ('y','default'):
     foundF90 = False
     if env['FORTRAN']:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Disable `f90_interface` by default if Apple clang is detected (i.e. only applies if `f90_interface=default`)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Bypasses #1379 and #1387

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
