### PR TITLE
Python 3.11 support

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -25,7 +25,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: [ '3.7', '3.9', '3.10' ]
+        python-version: ['3.8', '3.10', '3.11']
         os: ['ubuntu-20.04', 'ubuntu-22.04']
       fail-fast: false
     steps:
@@ -48,9 +48,6 @@ jobs:
     - name: Install Python dependencies
       run: python3 -m pip install ruamel.yaml scons==3.1.2 numpy cython h5py pandas
         pytest pytest-github-actions-annotate-failures
-    - name: Install typing_extensions for Python 3.7
-      if: matrix.python-version == '3.7'
-      run: python3 -m pip install typing_extensions
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all -j2 debug=n --debug=time
     - name: Upload shared library
@@ -101,7 +98,7 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        python-version: [ '3.7', '3.9', '3.10' ]
+        python-version: ['3.8', '3.10', '3.11']
       fail-fast: false
     steps:
     # Attempt to fix intermittent cloning errors. The error message says something like
@@ -124,9 +121,6 @@ jobs:
     - name: Install Python dependencies
       run: python3 -m pip install ruamel.yaml numpy cython h5py pandas pytest
         pytest-github-actions-annotate-failures
-    - name: Install typing_extensions for Python 3.7
-      if: matrix.python-version == '3.7'
-      run: python3 -m pip install typing_extensions
     - name: Build Cantera
       run: scons build env_vars=all -j3 debug=n --debug=time
     - name: Upload shared library
@@ -311,7 +305,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.7', '3.9', '3.10']
+        python-version: ['3.8', '3.10', '3.11']
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -331,9 +325,6 @@ jobs:
         run: python3 -m pip install -U pip setuptools wheel
       - name: Install Python dependencies
         run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas matplotlib scipy
-      - name: Install typing_extensions for Python 3.7
-        if: matrix.python-version == '3.7'
-        run: python3 -m pip install typing_extensions
       - name: Build Cantera
         # compile with GCC 9.4.0 on ubuntu-20.04 as an alternative to the default
         # (GCC 7.5.0 is both default and oldest supported version)
@@ -429,7 +420,7 @@ jobs:
       matrix:
         os: ["windows-2022"]
         vs-toolset: ["14.1", "14.3"]
-        python-version: [ "3.7", "3.9", "3.10" ]
+        python-version: ["3.8", "3.10", "3.11"]
       fail-fast: false
     steps:
     - uses: actions/checkout@v2
@@ -452,9 +443,6 @@ jobs:
       run: |
         mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp h5py pandas pytest
       shell: pwsh
-    - name: Install typing_extensions for Python 3.7
-      if: matrix.python-version == '3.7'
-      run: mamba install -q typing_extensions
     - name: Build Cantera
       run: scons build system_eigen=y system_yamlcpp=y logging=debug
         msvc_toolset_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j2
@@ -501,7 +489,7 @@ jobs:
     strategy:
       matrix:
         vs-toolset: ['14.2']
-        python-version: [ "3.7", "3.9", "3.10" ]
+        python-version: ["3.8", "3.10", "3.11"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2
@@ -516,10 +504,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip setuptools wheel
-          python -m pip install '"scons<4.4.0"' pypiwin32 numpy ruamel.yaml cython h5py pandas pytest pytest-github-actions-annotate-failures
-      - name: Install typing_extensions for Python 3.7
-        if: matrix.python-version == '3.7'
-        run: python -m pip install typing_extensions
+          python -m pip install '"scons<4.4.0"' pypiwin32 numpy ruamel.yaml cython pandas pytest pytest-github-actions-annotate-failures
       - name: Restore Boost cache
         uses: actions/cache@v2
         id: cache-boost

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -360,7 +360,7 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        sundials-ver: [ 3, 4, 5.8, 6.2 ]
+        sundials-ver: [ 3, 4, 5.8, 6.4.1 ]
       fail-fast: false
     steps:
       - uses: actions/checkout@v2

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -46,8 +46,9 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml scons==3.1.2 numpy cython h5py pandas
-        pytest pytest-github-actions-annotate-failures
+      run: |
+        python3 -m pip install ruamel.yaml scons==3.1.2 numpy cython pandas pytest pytest-github-actions-annotate-failures
+        python3 -m pip install h5py || true
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all -j2 debug=n --debug=time
     - name: Upload shared library
@@ -132,7 +133,10 @@ jobs:
     - name: Upgrade pip
       run: $PYTHON_CMD -m pip install -U pip 'setuptools>=47.0.0,<48' wheel
     - name: Install Python dependencies
-      run: $PYTHON_CMD -m pip install ruamel.yaml numpy cython h5py pandas pytest pytest-github-actions-annotate-failures
+      # h5py is optional; may fail if no wheel is present for a given OS/Python version
+      run: |
+        $PYTHON_CMD -m pip install ruamel.yaml numpy cython pandas pytest pytest-github-actions-annotate-failures
+        $PYTHON_CMD -m pip install h5py || true
     - name: Install Python dependencies for GH Python
       if: matrix.python-version == '3.11'
       run:
@@ -340,7 +344,9 @@ jobs:
       - name: Upgrade pip
         run: python3 -m pip install -U pip setuptools wheel
       - name: Install Python dependencies
-        run: python3 -m pip install ruamel.yaml scons numpy cython h5py pandas matplotlib scipy
+        run: |
+          python3 -m pip install ruamel.yaml scons numpy cython pandas matplotlib scipy
+          python3 -m pip install h5py || true
       - name: Build Cantera
         # compile with GCC 9.4.0 on ubuntu-20.04 as an alternative to the default
         # (GCC 7.5.0 is both default and oldest supported version)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -100,6 +100,8 @@ jobs:
       matrix:
         python-version: ['3.8', '3.10', '3.11']
       fail-fast: false
+    env:
+      PYTHON_CMD: "python${{ matrix.python-version }}"
     steps:
     # Attempt to fix intermittent cloning errors. The error message says something like
     # error: RPC failed; curl 18 transfer closed with outstanding read data remaining
@@ -113,16 +115,30 @@ jobs:
       name: Checkout the repository
       with:
         submodules: recursive
+    - name: Setup GH Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: 3.11
+      if: matrix.python-version == '3.11'
     - name: Install Brew dependencies
+      run: brew install boost libomp
+    - name: Setup Homebrew Python
+      # This path should work for future Python versions as well
+      if: matrix.python-version != '3.11'
       run: |
-        brew install boost libomp scons python@${{ matrix.python-version }}
+        brew install python@${{ matrix.python-version }}
+        brew link --force --overwrite python@${{ matrix.python-version }}
+        brew install scons
     - name: Upgrade pip
-      run: python3 -m pip install -U pip 'setuptools>=47.0.0,<48' wheel
+      run: $PYTHON_CMD -m pip install -U pip 'setuptools>=47.0.0,<48' wheel
     - name: Install Python dependencies
-      run: python3 -m pip install ruamel.yaml numpy cython h5py pandas pytest
-        pytest-github-actions-annotate-failures
+      run: $PYTHON_CMD -m pip install ruamel.yaml numpy cython h5py pandas pytest pytest-github-actions-annotate-failures
+    - name: Install Python dependencies for GH Python
+      if: matrix.python-version == '3.11'
+      run:
+        $PYTHON_CMD -m pip install scons
     - name: Build Cantera
-      run: scons build env_vars=all -j3 debug=n --debug=time
+      run: scons build env_vars=all -j3 python_cmd=$PYTHON_CMD debug=n --debug=time
     - name: Upload shared library
       uses: actions/upload-artifact@v3
       if: matrix.python-version == '3.10'

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -102,8 +102,8 @@
 
 * Style generally follows PEP8 (https://www.python.org/dev/peps/pep-0008/)
 * Code in `.py` and `.pyx` files needs to be written to work with Python 3
-* The minimum Python version that Cantera supports is Python 3.7, so code should only
-  use features added in Python 3.7 or earlier
+* The minimum Python version that Cantera supports is Python 3.8, so code should only
+  use features added in Python 3.8 or earlier
 * Indicate the version added for new functions and classes with an annotation like
   `.. versionadded:: X.Y` where `X.Y` is the next Cantera version. Significant changes
   in behavior should be indicated with `.. versionchanged:: X.Y`.

--- a/SConstruct
+++ b/SConstruct
@@ -65,7 +65,7 @@ Additional command options:
 # and simplest option that will reliably trigger an error in Python 2
 # and provide actionable feedback for users.
 f"""
-Cantera must be built using Python 3.7 or higher. You can invoke SCons by executing
+Cantera must be built using Python 3.8 or higher. You can invoke SCons by executing
     python3 `which scons`
 followed by any desired options.
 """
@@ -1578,7 +1578,7 @@ logger.debug("\n".join(debug_message), print_level=False)
 env['python_cmd_esc'] = quoted(env['python_cmd'])
 
 # Python Package Settings
-python_min_version = parse_version("3.7")
+python_min_version = parse_version("3.8")
 # The string is used to set python_requires in setup.cfg.in
 env['py_min_ver_str'] = str(python_min_version)
 # Note: cython_min_version is redefined below if the Python version is 3.8 or higher

--- a/SConstruct
+++ b/SConstruct
@@ -1462,7 +1462,7 @@ if env['system_sundials'] == 'y':
     if sundials_ver < parse_version("3.0") or sundials_ver >= parse_version("7.0"):
         logger.error(f"Sundials version {env['sundials_version']!r} is not supported.")
         sys.exit(1)
-    elif sundials_ver > parse_version("6.2"):
+    elif sundials_ver > parse_version("6.4.1"):
         logger.warning(f"Sundials version {env['sundials_version']!r} has not been tested.")
 
     logger.info(f"Using system installation of Sundials version {sundials_version!r}.")

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -21,7 +21,7 @@ from email.utils import formatdate
 import warnings
 import copy
 
-from typing import Any, Dict, Union, Iterable, Optional, List, Tuple
+from typing import Any, Dict, Union, Iterable, Optional, List, Tuple, TypedDict
 from typing import TYPE_CHECKING
 
 import numpy as np
@@ -47,9 +47,6 @@ if yaml_version < yaml_min_version:
     )
 
 if TYPE_CHECKING:
-    # This is available in the built-in typing module in Python 3.8
-    from typing_extensions import TypedDict
-
     QUANTITY = Union[float, str]
 
     RK_EOS_DICT = TypedDict(

--- a/interfaces/cython/cantera/yaml2ck.py
+++ b/interfaces/cython/cantera/yaml2ck.py
@@ -61,13 +61,7 @@ from pathlib import Path
 from textwrap import fill, dedent, TextWrapper
 import cantera as ct
 from email.utils import formatdate
-from typing import Optional, Iterable
-
-try:
-    from typing import Literal
-except ImportError:
-    # Needed for Python 3.7 support
-    from typing_extensions import Literal
+from typing import Optional, Iterable, Literal
 
 if sys.version_info < (3, 9):
     class BooleanOptionalAction(argparse.Action):

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -23,10 +23,10 @@ classifiers =
     Programming Language :: Cython
     Programming Language :: Fortran
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
@@ -42,7 +42,6 @@ include_package_data = True
 install_requires =
     numpy >= 1.12.0
     ruamel.yaml >= 0.15.34
-    typing_extensions >=4.2.0,<4.3.0;python_version<'3.8'
 python_requires = >=@py_min_ver_str@
 packages =
     cantera

--- a/interfaces/python_minimal/setup.cfg.in
+++ b/interfaces/python_minimal/setup.cfg.in
@@ -19,10 +19,10 @@ classifiers =
     Operating System :: Microsoft :: Windows
     Operating System :: POSIX :: Linux
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
 project_urls =
@@ -36,7 +36,6 @@ zip_safe = True
 install_requires =
     numpy >= 1.12.0
     ruamel.yaml >= 0.15.34
-    typing_extensions >=4.2.0,<4.3.0;python_version<'3.8'
 python_requires = >=@py_min_ver_str@
 packages =
     cantera

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -23,10 +23,10 @@ classifiers =
     Programming Language :: Cython
     Programming Language :: Fortran
     Programming Language :: Python :: 3 :: Only
-    Programming Language :: Python :: 3.6
-    Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
+    Programming Language :: Python :: 3.11
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
@@ -42,7 +42,6 @@ include_package_data = True
 install_requires =
     numpy >= 1.12.0
     ruamel.yaml >= 0.15.34
-    typing_extensions >=4.2.0,<4.3.0;python_version<'3.8'
 python_requires = >=@py_min_ver_str@
 packages =
     cantera

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1327,10 +1327,6 @@ def setup_python_env(env):
             env.Append(LIBS=f"python{py_version_nodot}")
             if env['OS_BITS'] == 64:
                 env.Append(CPPDEFINES='MS_WIN64')
-            # Fix for https://bugs.python.org/issue11566. Fixed in 3.7.3 and higher.
-            # See https://github.com/python/cpython/pull/11283
-            if py_version_full < parse_version("3.7.3"):
-                env.Append(CPPDEFINES={"_hypot": "hypot"})
 
     if "numpy_1_7_API" in env:
         env.Append(CPPDEFINES="NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -244,8 +244,14 @@ int BandMatrix::factor()
     long int nu = static_cast<long int>(nSuperDiagonals());
     long int nl = static_cast<long int>(nSubDiagonals());
     long int smu = nu + nl;
-    m_info = bandGBTRF(m_lu_col_ptrs.data(), static_cast<long int>(nColumns()),
-                       nu, nl, smu, m_ipiv->data.data());
+    #if CT_SUNDIALS_VERSION >= 60
+        m_info = SUNDlsMat_bandGBTRF(m_lu_col_ptrs.data(),
+                                     static_cast<long int>(nColumns()),
+                                     nu, nl, smu, m_ipiv->data.data());
+    #else
+        m_info = bandGBTRF(m_lu_col_ptrs.data(), static_cast<long int>(nColumns()),
+                        nu, nl, smu, m_ipiv->data.data());
+    #endif
 #endif
     if (m_info != 0) {
         throw Cantera::CanteraError("BandMatrix::factor",
@@ -278,7 +284,13 @@ int BandMatrix::solve(doublereal* b, size_t nrhs, size_t ldb)
     long int nl = static_cast<long int>(nSubDiagonals());
     long int smu = nu + nl;
     double** a = m_lu_col_ptrs.data();
-    bandGBTRS(a, static_cast<long int>(nColumns()), smu, nl, m_ipiv->data.data(), b);
+    #if CT_SUNDIALS_VERSION >= 60
+        SUNDlsMat_bandGBTRS(a, static_cast<long int>(nColumns()), smu, nl,
+                            m_ipiv->data.data(), b);
+    #else
+        bandGBTRS(a, static_cast<long int>(nColumns()), smu, nl,
+                  m_ipiv->data.data(), b);
+    #endif
     m_info = 0;
 #endif
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix use of code that was deprecated or made internal in Python 3.11, in the implementation of extensible reaction rates
- Drop support for Python 3.7
- Change CI tests from Python 3.7, 3.9, and 3.10 to 3.8, 3.10, and 3.11
- Fix deprecation warnings from Sundials 6.0 and newer
- Fix CI so it uses the correct Python versions on macOS -- previously, all builds/tests were using the latest Homebrew Python (3.10) that is installed as `python3`, instead of the other specific Python versions which are only installed as `python3.9` etc.
- For Python 3.11 on macOS, use the Python provided by GitHub, since it's not available yet via Homebrew. We can't use this for older Pythons due to a missing library dependency (`libintl`) for linking to `libpython3.x`.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1349

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
