### PR TITLE
Removed redundant error checks to fix issue #1412

### DIFF
--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -100,9 +100,6 @@ extern "C" {
 
     int thermo_setDensity(int n, double rho)
     {
-        if (rho < 0.0) {
-            return -1;
-        }
         try {
             ThermoCabinet::item(n).setDensity(rho);
         } catch (...) {
@@ -122,9 +119,6 @@ extern "C" {
 
     int thermo_setMolarDensity(int n, double ndens)
     {
-        if (ndens < 0.0) {
-            return -1;
-        }
         try {
             ThermoCabinet::item(n).setMolarDensity(ndens);
         } catch (...) {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Removes a redundant error check in `clib/ct.cpp` so external language interfaces can correctly handle errors returned by the method `thermo_setDensity` and `thermo_setMolarDensity`. 

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1412 

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
