### PR TITLE
WIP - Update electrochemical reaction type input for BV and Marcus kinetics

### DIFF
--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -169,17 +169,15 @@ public:
         // activation energy.
         double correction = 1.;
         double beta_tmp = m_beta;
-        if (m_eChemForm == "Marcus") {
-            printf("cantera etaF =%f\n", m_etaF);
-            beta_tmp += (m_etaF / 4. / m_lambdaMarcus); //m_etaF / 4 / m_lambdaMarcus;
-            printf("Marcus correction = %f\n", m_etaF / 4. / m_lambdaMarcus);
-        }
         if (m_deltaPotential_RT != 0.) {
             // Comments preserved from previous implementation:
             // Below we decrease the activation energy below zero.
             // NOTE, there is some discussion about this point. Should we decrease the
             // activation energy below zero? I don't think this has been decided in any
             // definitive way. The treatment below is numerically more stable, however.
+            if (m_eChemForm == "Marcus") {
+                beta_tmp += (m_etaF / 4. / m_lambdaMarcus); //m_etaF / 4 / m_lambdaMarcus;
+            }
             correction = exp(-beta_tmp * m_deltaPotential_RT);
         }
 

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -12,7 +12,6 @@
 #include "cantera/base/global.h"
 #include "cantera/kinetics/BlowersMaselRate.h"
 #include "MultiRate.h"
-#include "InterfaceKinetics.h"
 
 namespace Cantera
 {
@@ -126,6 +125,7 @@ public:
         return m_exchangeCurrentDensityFormulation;
     }
 
+    // String storing the input electrochemical kinetics form used if non-standard
     std::string eChemForm() {
         return m_eChemForm;
     }
@@ -176,6 +176,8 @@ public:
             // activation energy below zero? I don't think this has been decided in any
             // definitive way. The treatment below is numerically more stable, however.
             if (m_eChemForm == "Marcus") {
+                // If Marcus kinetics is being used, adjust beta by the reorganization 
+                // energy m_lambdaMarcus
                 beta_tmp += (m_etaF / 4. / m_lambdaMarcus); //m_etaF / 4 / m_lambdaMarcus;
             }
             correction = exp(-beta_tmp * m_deltaPotential_RT);
@@ -190,6 +192,7 @@ public:
             tmp /= m_prodStandardConcentrations * Faraday;
             correction *= tmp;
         } else if (m_eChemForm == "Marcus") {
+            // If Marcus kinetics is being used, adjust the correction value.
             double tmp = exp(-m_lambda_RT / 4.) * exp(-beta_tmp * m_deltaGibbs_RT);
             tmp /= m_prodStandardConcentrations * Faraday;
             correction *= tmp;
@@ -219,7 +222,7 @@ public:
         return NAN;
     }
 
-    //! Return the charge transfer beta parameter
+    //! Return the Marcus theory reorganization energy parameter
     double lambdaMarcus() const {
         if (m_chargeTransfer) {
             return m_lambdaMarcus;
@@ -227,7 +230,7 @@ public:
         return NAN;
     }
 
-    //! Return the charge transfer beta parameter
+    //! Return the overpotential times Faraday's constant parameter
     double etaF() {
         if (m_chargeTransfer) {
             return m_etaF;
@@ -235,7 +238,8 @@ public:
         return NAN;
     }
 
-    //! Return the charge transfer beta parameter
+    //! Return Marcus theory reorganization energy parameter
+    //! Divided by the Gas Constant and temperature
     double lambda_RT() {
         if (m_chargeTransfer) {
             return m_lambda_RT;
@@ -272,11 +276,11 @@ protected:
     double m_mcov; //!< Coverage term in reaction rate
     bool m_chargeTransfer; //!< Boolean indicating use of electrochemistry
     bool m_exchangeCurrentDensityFormulation; //! Electrochemistry only
-    std::string m_eChemForm;
-    double m_lambdaMarcus; 
-    double m_etaF;
-    double m_lambda_RT;
-    double m_deltaGibbs_RT;
+    std::string m_eChemForm; //! String storing echem kinetics form
+    double m_lambdaMarcus; //! Marcus theory reorganization energy
+    double m_etaF; //! Overpotential times Faraday
+    double m_lambda_RT; //! Marcus theory reorganization energy over RT
+    double m_deltaGibbs_RT; //! Normalized Gibbs free energy change 
     double m_beta; //!< Forward value of apparent electrochemical transfer coefficient
     double m_deltaPotential_RT; //!< Normalized electric potential energy change
     double m_deltaGibbs0_RT; //!< Normalized standard state Gibbs free energy change

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -76,7 +76,6 @@ bool InterfaceData::update(const ThermoPhase& phase, const Kinetics& kin)
             size_t start = kin.kineticsSpeciesIndex(0, n);
             const auto& ph = kin.thermo(n);
             electricPotentials[n] = ph.electricPotential();
-            //chemPotentials[n] = ph.getChemPotentials()
             ph.getPartialMolarEnthalpies(partialMolarEnthalpies.data() + start);
             ph.getStandardChemPotentials(standardChemPotentials.data() + start);
             ph.getChemPotentials(chemPotentials.data() + start);
@@ -305,8 +304,6 @@ void InterfaceRateBase::updateFromStruct(const InterfaceData& shared_data) {
         m_deltaGibbs0_RT /= GasConstant * shared_data.temperature;
         m_deltaGibbs_RT /= GasConstant * shared_data.temperature;
         m_lambda_RT = m_lambdaMarcus / GasConstant / shared_data.temperature;
-        //m_etaF = m_deltaGibbs0_RT + m_deltaPotential_RT;
-        //m_etaF *= GasConstant * shared_data.temperature;
     }
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**

- Change input method from YAML to choose Butler-Volmer kinetics for electrochemical reactions by string instead of bool
- Adds input option for electrochemical reactions to use Marcus theory kinetics

The current WIP updates the input field of the YAML for reactions to choose specific electrochemical kinetics models. This new field is called "echem-kinetics-form" and accepts a string input for either "Butler-Volmer" or "Marcus". If either of these strings is used then the appropriate term to modify the reaction rate evaluation will be added to the correction factor in voltageCorrection of InterfaceRate.h

Related to Cantera/enhancements#38 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
