### PR TITLE
Soave-Redlich-Kwong EOS

### DIFF
--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -150,6 +150,9 @@ public:
      * @param aAlpha (output) Returns the (a*alpha) value.
      */
     void calculateAB(double& aCalc, double& bCalc, double& aAlphaCalc) const
+
+    void calcCriticalConditions(double& pc, double& tc, double& vc) const;
+
     //! Prepare variables and call the function to solve the cubic equation of state
     int solveCubic(double T, double pres, double a, double b, double aAlpha,
                    double Vroot[3]) const;

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -26,9 +26,67 @@ public:
         return "Soave-Redlich-Kwong";
     }
 
+protected:
+
+    virtual double dpdVCalc(double T, double molarVol, double& presCalc) const;
+
+    // Special functions not inherited from MixtureFugacityTP
+
+    //! Calculate temperature derivative \f$d(a \alpha)/dT\f$
+    /*!
+     *  These are stored internally.
+     */
+    double daAlpha_dT() const;
+
+    //! Calculate second derivative \f$d^2(a \alpha)/dT^2\f$
+    /*!
+     *  These are stored internally.
+     */
+    double d2aAlpha_dT2() const;
+
 public:
-    int SoaveRedlichKwong::solveCubic(double T, double pres, double a, double b, double aAlpha,
-                                  double Vroot[3]) const;
+    //! Calculate \f$dp/dV\f$ and \f$dp/dT\f$ at the current conditions
+    /*!
+     *  These are stored internally.
+     */
+    void calculatePressureDerivatives() const;
+
+    //! Prepare variables and call the function to solve the cubic equation of state
+    int solveCubic(double T, double pres, double a, double b, double aAlpha,
+                   double Vroot[3]) const;
+
+protected:
+    //! Value of \f$b\f$ in the equation of state
+    /*!
+     *  `m_b` is a function of the mole fractions and species-specific b values.
+     */
+    double m_b;
+
+    //! Value of \f$a\f$ in the equation of state
+    /*!
+     *  `m_a` depends only on the mole fractions.
+     */
+    double m_a;
+
+    //! Value of \f$\alpha\f$ in the equation of state
+    /*!
+     *  `m_aAlpha_mix` is a function of the temperature and the mole fractions.
+     */
+    double m_aAlpha_mix;
+
+    //! The derivative of the pressure with respect to the volume
+    /*!
+     * Calculated at the current conditions. temperature and mole number kept
+     * constant
+     */
+    mutable double m_dpdV;
+
+    //! The derivative of the pressure with respect to the temperature
+    /*!
+     *  Calculated at the current conditions. Total volume and mole number kept
+     *  constant
+     */
+    mutable double m_dpdT;
 
 private:
     static const double omega_a;

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -19,6 +19,15 @@ namespace Cantera
 class SoaveRedlichKwong : public MixtureFugacityTP
 {
 public:
+
+    //! Construct and initialize a SoaveRedlichKwong object directly from an
+    //! input file
+    /*!
+     * @param infile    Name of the input file containing the phase YAML data.
+     *                  If blank, an empty phase will be created.
+     * @param id        ID of the phase in the input file. If empty, the
+     *                  first phase definition in the input file will be used.
+     */
     explicit SoaveRedlichKwong(const std::string& infile="",
                                const std::string& id="");
 
@@ -77,8 +86,8 @@ public:
      *       \f[ T_{crit} = (0.0778 a)/(0.4572 b R) \f] TODO
      *  Units: Kelvin
      *
-     * @param a    species-specific coefficients used in P-R EoS
-     * @param b    species-specific coefficients used in P-R EoS
+     * @param a    species-specific coefficients used in SRK EoS
+     * @param b    species-specific coefficients used in SRK EoS
      */
     double speciesCritTemperature(double a, double b) const;
 
@@ -94,6 +103,26 @@ public:
     virtual void initThermo();
     virtual void getSpeciesParameters(const std::string& name,
                                       AnyMap& speciesNode) const;
+
+    //! Set the pure fluid interaction parameters for a species
+    /*!
+     *  @param species   Name of the species
+     *  @param a         \f$a\f$ parameter in the Soave-Redlich-Kwong model [Pa-m^6/kmol^2]
+     *  @param b         \f$a\f$ parameter in the Soave-Redlich-Kwong model [m^3/kmol]
+     *  @param w         acentric factor
+     */
+    void setSpeciesCoeffs(const std::string& species, double a, double b,
+                          double w);
+
+    //! Set values for the interaction parameter between two species
+    /*!
+     *  @param species_i   Name of one species
+     *  @param species_j   Name of the other species
+     *  @param a           \f$a\f$ parameter in the Soave-Redlich-Kwong model [Pa-m^6/kmol^2]
+     */
+    void setBinaryCoeffs(const std::string& species_i,
+                         const std::string& species_j, double a);
+    //! @}
 
 protected:
     // Special functions inherited from MixtureFugacityTP

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -35,6 +35,12 @@ public:
         return "Soave-Redlich-Kwong";
     }
 
+    //! @name Molar Thermodynamic properties
+    //! @{
+
+    virtual double cp_mole() const;
+    virtual double cv_mole() const;
+
     //! @}
     //! @name Mechanical Properties
     //! @{
@@ -79,6 +85,49 @@ public:
      */
     virtual double pressure() const;
 
+    //! @}
+
+    //! Returns the standard concentration \f$ C^0_k \f$, which is used to
+    //! normalize the generalized concentration.
+    /*!
+     * This is defined as the concentration by which the generalized
+     * concentration is normalized to produce the activity.
+     * The ideal gas mixture is considered as the standard or reference state here.
+     * Since the activity for an ideal gas mixture is simply the mole fraction,
+     * for an ideal gas,  \f$ C^0_k = P/\hat R T \f$.
+     *
+     * @param k Optional parameter indicating the species. The default is to
+     *          assume this refers to species 0.
+     * @return
+     *   Returns the standard Concentration in units of m^3 / kmol.
+     */
+    virtual double standardConcentration(size_t k=0) const;
+
+    //! Get the array of non-dimensional activity coefficients at the current
+    //! solution temperature, pressure, and solution concentration.
+    /*!
+     * For all objects with the Mixture Fugacity approximation, we define the
+     * standard state as an ideal gas at the current temperature and pressure of
+     * the solution. The activities are based on this standard state.
+     *
+     * @param ac Output vector of activity coefficients. Length: m_kk.
+     */
+    virtual void getActivityCoefficients(double* ac) const;
+
+    //! @name  Partial Molar Properties of the Solution
+    //! @{
+
+    virtual void getChemPotentials(double* mu) const;
+    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    virtual void getPartialMolarEntropies(double* sbar) const;
+    virtual void getPartialMolarIntEnergies(double* ubar) const;
+    //! Calculate species-specific molar specific heats
+    /*!
+     *  This function is currently not implemented for Soave-Redlich-Kwong phase.
+     */
+    virtual void getPartialMolarCp(double* cpbar) const;
+    virtual void getPartialMolarVolumes(double* vbar) const;
+    //! @}
 
     //! Calculate species-specific critical temperature
     /*!
@@ -89,7 +138,7 @@ public:
      * @param a    species-specific coefficients used in SRK EoS
      * @param b    species-specific coefficients used in SRK EoS
      */
-    double speciesCritTemperature(double a, double b) const;
+    virtual double speciesCritTemperature(double a, double b) const;
 
     //! @name Initialization Methods - For Internal use
     //!
@@ -126,6 +175,8 @@ public:
 
 protected:
     // Special functions inherited from MixtureFugacityTP
+    virtual double sresid() const;
+    virtual double hresid() const;
 
     virtual double liquidVolEst(double T, double& pres) const;
     virtual double densityCalc(double T, double pressure, int phase, double rhoguess);
@@ -169,7 +220,7 @@ public:
      */
     virtual void updateMixingExpressions();
 
-    //! Calculate the \f$a\f$, \f$b\f$, and \f$\a alpha\f$ parameters given the temperature
+    //! Calculate the \f$a\f$, \f$b\f$, and \f$a \alpha\f$ parameters given the temperature
     /*!
      * This function doesn't change the internal state of the object, so it is a
      * const function.  It does use the stored mole fractions in the object.
@@ -178,7 +229,7 @@ public:
      * @param bCalc (output)  Returns the b value.
      * @param aAlpha (output) Returns the (a*alpha) value.
      */
-    void calculateAB(double& aCalc, double& bCalc, double& aAlphaCalc) const
+    void calculateAB(double& aCalc, double& bCalc, double& aAlphaCalc) const;
 
     void calcCriticalConditions(double& pc, double& tc, double& vc) const;
 

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -26,6 +26,50 @@ public:
         return "Soave-Redlich-Kwong";
     }
 
+    //! @}
+    //! @name Mechanical Properties
+    //! @{
+
+    //! Return the thermodynamic pressure (Pa).
+    /*!
+     * Since the mass density, temperature, and mass fractions are stored,
+     * this method uses these values to implement the
+     * mechanical equation of state \f$ P(T, \rho, Y_1, \dots, Y_K) \f$.
+     *
+     * \f[
+     *    P = \frac{RT}{v-b_{mix}}
+     *        - \frac{\left(a\alpha\right)_{mix}}{v\left(v + b_{mix}\right)}
+     * \f]
+     *
+     * where:
+     *
+     * \f[
+     *    \alpha = \left[ 1 + \kappa \left(1-T_r^{0.5}\right)\right]^2
+     * \f]
+     *
+     *  and
+     *
+     * \f[
+     *    \kappa = \left(0.48508 + 1.55171\omega - 0.15613\omega^2\right)
+     * \f]
+     *
+     * Coefficients \f$ a_{mix}, b_{mix} \f$ and \f$(a \alpha)_{mix}\f$ are calculated as
+     *
+     * \f[
+     *    a_{mix} = \sum_i \sum_j X_i X_j a_{i, j} = \sum_i \sum_j X_i X_j \sqrt{a_i a_j}
+     * \f]
+     *
+     * \f[
+     *    b_{mix} = \sum_i X_i b_i
+     * \f]
+     *
+     * \f[
+     *   {a \alpha}_{mix} = \sum_i \sum_j X_i X_j {a \alpha}_{i, j}
+     *       = \sum_i \sum_j X_i X_j \sqrt{a_i a_j} \sqrt{\alpha_i \alpha_j}
+     * \f]
+     */
+    virtual double pressure() const;
+
 
     //! Calculate species-specific critical temperature
     /*!

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -25,11 +25,17 @@ public:
     virtual std::string type() const {
         return "Soave-Redlich-Kwong";
     }
+
+public:
+    int SoaveRedlichKwong::solveCubic(double T, double pres, double a, double b, double aAlpha,
+                                  double Vroot[3]) const;
+
 private:
     static const double omega_a;
     static const double omega_b;
     static const double omega_vc;
-}
+
+};
 }
 
 #endif

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -76,6 +76,12 @@ protected:
     double d2aAlpha_dT2() const;
 
 public:
+    //! Returns the isothermal compressibility. Units: 1/Pa.
+    double isothermalCompressibility() const;
+
+    //! Return the volumetric thermal expansion coefficient. Units: 1/K.
+    double thermalExpansionCoeff() const;
+
     //! Calculate \f$dp/dV\f$ and \f$dp/dT\f$ at the current conditions
     /*!
      *  These are stored internally.

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -76,6 +76,24 @@ public:
      */
     void calculatePressureDerivatives() const;
 
+    //! Update the \f$a\f$, \f$b\f$, and \f$\alpha\f$ parameters
+    /*!
+     *  The \f$a\f$ and the \f$b\f$ parameters depend on the mole fraction and the
+     *  parameter \f$\alpha\f$ depends on the temperature. This function updates
+     *  the internal numbers based on the state of the object.
+     */
+    virtual void updateMixingExpressions();
+
+    //! Calculate the \f$a\f$, \f$b\f$, and \f$\a alpha\f$ parameters given the temperature
+    /*!
+     * This function doesn't change the internal state of the object, so it is a
+     * const function.  It does use the stored mole fractions in the object.
+     *
+     * @param aCalc (output)  Returns the a value
+     * @param bCalc (output)  Returns the b value.
+     * @param aAlpha (output) Returns the (a*alpha) value.
+     */
+    void calculateAB(double& aCalc, double& bCalc, double& aAlphaCalc) const
     //! Prepare variables and call the function to solve the cubic equation of state
     int solveCubic(double T, double pres, double a, double b, double aAlpha,
                    double Vroot[3]) const;

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -1,0 +1,35 @@
+//! @file SoaveRedlichKwong.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_SOAVEREDLICHKWONG_H
+#define CT_SOAVEREDLICHKWONG_H
+
+#include "MixtureFugacityTP.h"
+#include "cantera/base/Array.h"
+
+namespace Cantera
+{
+/**
+ * Implementation of a multi-species Soave-Redlich-Kwong equation of state
+ *
+ * @ingroup thermoprops
+ */
+class SoaveRedlichKwong : public MixtureFugacityTP
+{
+public:
+    explicit SoaveRedlichKwong(const std::string& infile="",
+                               const std::string& id="");
+
+    virtual std::string type() const {
+        return "Soave-Redlich-Kwong";
+    }
+private:
+    static const double omega_a;
+    static const double omega_b;
+    static const double omega_vc;
+}
+}
+
+#endif

--- a/include/cantera/thermo/SoaveRedlichKwong.h
+++ b/include/cantera/thermo/SoaveRedlichKwong.h
@@ -26,6 +26,31 @@ public:
         return "Soave-Redlich-Kwong";
     }
 
+
+    //! Calculate species-specific critical temperature
+    /*!
+     *  The temperature dependent parameter in SRK EoS is calculated as
+     *       \f[ T_{crit} = (0.0778 a)/(0.4572 b R) \f] TODO
+     *  Units: Kelvin
+     *
+     * @param a    species-specific coefficients used in P-R EoS
+     * @param b    species-specific coefficients used in P-R EoS
+     */
+    double speciesCritTemperature(double a, double b) const;
+
+    //! @name Initialization Methods - For Internal use
+    //!
+    //! The following methods are used in the process of constructing
+    //! the phase and setting its parameters from a specification in an
+    //! input file. They are not normally used in application programs.
+    //! To see how they are used, see importPhase().
+    //! @{
+
+    virtual bool addSpecies(shared_ptr<Species> spec);
+    virtual void initThermo();
+    virtual void getSpeciesParameters(const std::string& name,
+                                      AnyMap& speciesNode) const;
+
 protected:
 
     virtual double dpdVCalc(double T, double molarVol, double& presCalc) const;
@@ -87,6 +112,11 @@ protected:
      *  constant
      */
     mutable double m_dpdT;
+
+
+    enum class CoeffSource { EoS, CritProps, Database };
+    //! For each species, specifies the source of the a, b, and omega coefficients
+    std::vector<CoeffSource> m_coeffSource;
 
 private:
     static const double omega_a;

--- a/src/thermo/SoaveRedlichKwong.cpp
+++ b/src/thermo/SoaveRedlichKwong.cpp
@@ -312,6 +312,42 @@ double SoaveRedlichKwong::dpdVCalc(double T, double molarVol, double& presCalc) 
     return -GasConstant * T / (vmb * vmb) + m_aAlpha_mix * (2 * molarVol + m_b) / (denom * denom);
 }
 
+double SoaveRedlichKwong::isothermalCompressibility() const 
+{
+    double P = pressure();
+    double mv = molarVolume();
+    double T = temperature();
+    double RT_ = RT();
+    double Z = P * mv / RT_;
+
+    double A = m_aAlpha_mix * P / (RT_ * RT_);
+    double B = m_b * P / RT_;
+
+    double dAdP = A / P;
+    double dBdP = B / P;
+    double dZdP = ((B - Z) * dAdP + (A + B + 2 * B * Z) * dBdP) / (3 * Z * Z - 2 * Z + A - B - B * B);
+
+    return 1 / P - dZdP / Z;
+}
+
+double SoaveRedlichKwong::thermalExpansionCoeff() const 
+{
+    double P = pressure();
+    double mv = molarVolume();
+    double T = temperature();
+    double RT_ = RT();
+    double Z = P * mv / RT_;
+
+    double A = m_aAlpha_mix * P / (RT_ * RT_);
+    double B = m_b * P / RT_;
+
+    double dAdT = P / (RT_ * RT_) * (daAlpha_dT() - 2 * m_aAlpha_mix / T);
+    double dBdT = -B / T;
+    double dZdP = ((B - Z) * dAdT + (A + B + 2 * B * Z) * dBdT) / (3 * Z * Z - 2 * Z + A - B - B * B);
+
+    return 1 / T + dZdT / Z;
+}
+
 void SoaveRedlichKwong::calculatePressureDerivatives() const
 {
     double T = temperature();

--- a/src/thermo/SoaveRedlichKwong.cpp
+++ b/src/thermo/SoaveRedlichKwong.cpp
@@ -481,37 +481,16 @@ double SoaveRedlichKwong::dpdVCalc(double T, double molarVol, double& presCalc) 
     return -GasConstant * T / (vmb * vmb) + m_aAlpha_mix * (2 * molarVol + m_b) / (denom * denom);
 }
 
-double SoaveRedlichKwong::isothermalCompressibility() const 
+double SoaveRedlichKwong::isothermalCompressibility() const
 {
-    double P = pressure();
-    double RT_ = RT();
-    double Z = z();
-
-    double A = m_aAlpha_mix * P / (RT_ * RT_);
-    double B = m_b * P / RT_;
-
-    double dAdP = A / P;
-    double dBdP = B / P;
-    double dZdP = ((B - Z) * dAdP + (A + Z + 2 * B * Z) * dBdP) / (3 * Z * Z - 2 * Z + A - B - B * B);
-
-    return 1 / P - dZdP / Z;
+    calculatePressureDerivatives();
+    return -1 / (molarVolume() * m_dpdV);
 }
 
-double SoaveRedlichKwong::thermalExpansionCoeff() const 
+double SoaveRedlichKwong::thermalExpansionCoeff() const
 {
-    double P = pressure();
-    double T = temperature();
-    double RT_ = RT();
-    double Z = z();
-
-    double A = m_aAlpha_mix * P / (RT_ * RT_);
-    double B = m_b * P / RT_;
-
-    double dAdT = P / (RT_ * RT_) * (daAlpha_dT() - 2 * m_aAlpha_mix / T);
-    double dBdT = -B / T;
-    double dZdT = ((B - Z) * dAdT + (A + Z + 2 * B * Z) * dBdT) / (3 * Z * Z - 2 * Z + A - B - B * B);
-
-    return 1 / T + dZdT / Z;
+    calculatePressureDerivatives();
+    return -m_dpdT / (molarVolume() * m_dpdV);
 }
 
 void SoaveRedlichKwong::calculatePressureDerivatives() const

--- a/src/thermo/SoaveRedlichKwong.cpp
+++ b/src/thermo/SoaveRedlichKwong.cpp
@@ -20,6 +20,80 @@ const double SoaveRedlichKwong::omega_vc = 3.33333333333333E-01;
 
 
 
+double SoaveRedlichKwong::dpdVCalc(double T, double molarVol, double& presCalc) const
+{
+    double denom = molarVol * (molarVol + m_b);
+    double vmb = molarVol - m_b;
+    return -GasConstant * T / (vmb * vmb) + m_aAlpha_mix * (2 * molarVol + m_b) / (denom * denom);
+}
+
+void SoaveRedlichKwong::calculatePressureDerivatives() const
+{
+    double T = temperature();
+    double mv = molarVolume();
+    double pres;
+
+    m_dpdV = dpdVCalc(T, mv, pres);
+    m_dpdT = GasConstant / (mv - m_b) - daAlpha_dT() / (mv * (mv + m_b));
+}
+
+double SoaveRedlichKwong::daAlpha_dT() const
+{
+    // Same as PengRobinson::daAlpha_dT()
+    double daAlphadT = 0.0, k, Tc, sqtTr, coeff1, coeff2;
+    for (size_t i = 0; i < m_kk; i++) {
+        // Calculate first derivative of alpha for individual species
+        Tc = speciesCritTemperature(m_a_coeffs(i,i), m_b_coeffs[i]);
+        sqtTr = sqrt(temperature() / Tc);
+        coeff1 = 1 / (Tc*sqtTr);
+        coeff2 = sqtTr - 1;
+        k = m_kappa[i];
+        m_dalphadT[i] = coeff1 * (k*k*coeff2 - k);
+    }
+    // Calculate mixture derivative
+    for (size_t i = 0; i < m_kk; i++) {
+        for (size_t j = 0; j < m_kk; j++) {
+            daAlphadT += moleFractions_[i] * moleFractions_[j] * 0.5
+                         * m_aAlpha_binary(i, j)
+                         * (m_dalphadT[i] / m_alpha[i] + m_dalphadT[j] / m_alpha[j]);
+        }
+    }
+    return daAlphadT;
+}
+
+double SoaveRedlichKwong::d2aAlpha_dT2() const
+{
+    // Same as PengRobinson::d2aAlpha_dT2()
+    for (size_t i = 0; i < m_kk; i++) {
+        double Tcrit_i = speciesCritTemperature(m_a_coeffs(i, i), m_b_coeffs[i]);
+        double sqt_Tr = sqrt(temperature() / Tcrit_i);
+        double coeff1 = 1 / (Tcrit_i*sqt_Tr);
+        double coeff2 = sqt_Tr - 1;
+        // Calculate first and second derivatives of alpha for individual species
+        double k = m_kappa[i];
+        m_dalphadT[i] = coeff1 * (k*k*coeff2 - k);
+        m_d2alphadT2[i] = (k*k + k) * coeff1 / (2*sqt_Tr*sqt_Tr*Tcrit_i);
+    }
+
+    // Calculate mixture derivative
+    double d2aAlphadT2 = 0.0;
+    for (size_t i = 0; i < m_kk; i++) {
+        double alphai = m_alpha[i];
+        for (size_t j = 0; j < m_kk; j++) {
+            double alphaj = m_alpha[j];
+            double alphaij = alphai * alphaj;
+            double term1 = m_d2alphadT2[i] / alphai + m_d2alphadT2[j] / alphaj;
+            double term2 = 2 * m_dalphadT[i] * m_dalphadT[j] / alphaij;
+            double term3 = m_dalphadT[i] / alphai + m_dalphadT[j] / alphaj;
+            d2aAlphadT2 += 0.5 * moleFractions_[i] * moleFractions_[j]
+                           * m_aAlpha_binary(i, j)
+                           * (term1 + term2 - 0.5 * term3 * term3);
+        }
+    }
+    return d2aAlphadT2;
+}
+
+
 int SoaveRedlichKwong::solveCubic(double T, double pres, double a, double b, double aAlpha,
                                   double Vroot[3]) const
 {
@@ -30,7 +104,7 @@ int SoaveRedlichKwong::solveCubic(double T, double pres, double a, double b, dou
 
     double tc = a * omega_b / (b * omega_a * GasConstant);
     double pc = omega_b * R * tc / b;
-    double vc = omega_vc * GasConstant * tc / pc
+    double vc = omega_vc * GasConstant * tc / pc;
 
     return MixtureFugacityTP::solveCubic(T, pres, a, b, aAlpha, Vroot,
                                          an, bn, cn, dn, tc, vc);

--- a/src/thermo/SoaveRedlichKwong.cpp
+++ b/src/thermo/SoaveRedlichKwong.cpp
@@ -103,6 +103,7 @@ double SoaveRedlichKwong::pressure() const
     double mv = molarVolume();
     return GasConstant * T / (mv - m_b) - m_aAlpha_mix / (mv * (mv - m_b))
 }
+
 double SoaveRedlichKwong::speciesCritTemperature(double a, double b) const
 {
     if (b <= 0.0) {
@@ -534,6 +535,24 @@ double SoaveRedlichKwong::d2aAlpha_dT2() const
     return d2aAlphadT2;
 }
 
+void SoaveRedlichKwong::calcCriticalConditions(double& pc, double& tc, double& vc) const
+{
+    if (m_b <= 0.0) {
+        tc = 1000000.;
+        pc = 1.0E13;
+        vc = omega_vc * GasConstant * tc / pc;
+        return;
+    }
+    if (m_a <= 0.0) {
+        tc = 0.0;
+        pc = 0.0;
+        vc = 2.0 * m_b;
+        return;
+    }
+    tc = m_a * omega_b / (m_b * omega_a * GasConstant);
+    pc = omega_b * GasConstant * tc / m_b;
+    vc = omega_vc * GasConstant * tc / pc;
+}
 
 int SoaveRedlichKwong::solveCubic(double T, double pres, double a, double b, double aAlpha,
                                   double Vroot[3]) const

--- a/src/thermo/SoaveRedlichKwong.cpp
+++ b/src/thermo/SoaveRedlichKwong.cpp
@@ -101,7 +101,7 @@ double SoaveRedlichKwong::pressure() const
     // Get a copy of the private variables stored in the State object
     double T = temperature();
     double mv = molarVolume();
-    return GasConstant * T / (mv - m_b) - m_aAlpha_mix / (mv * (mv - m_b))
+    return GasConstant * T / (mv - m_b) - m_aAlpha_mix / (mv * (mv + m_b))
 }
 
 double SoaveRedlichKwong::speciesCritTemperature(double a, double b) const

--- a/src/thermo/SoaveRedlichKwong.cpp
+++ b/src/thermo/SoaveRedlichKwong.cpp
@@ -1,0 +1,20 @@
+//! @file SoaveRedlichKwong.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/thermo/SoaveRedlichKwong.h"
+#include "cantera/thermo/ThermoFactory.h"
+#include "cantera/thermo/Species.h"
+#include "cantera/base/stringUtils.h"
+
+#include <boost/math/tools/roots.hpp>
+
+namespace bmt = boost::math::tools;
+
+namespace Cantera
+{
+const double SoaveRedlichKwong::omega_a = 4.27480233540E-01;
+const double SoaveRedlichKwong::omega_b = 8.66403499650E-02;
+const double SoaveRedlichKwong::omega_vc = 3.33333333333333E-01;
+}

--- a/src/thermo/SoaveRedlichKwong.cpp
+++ b/src/thermo/SoaveRedlichKwong.cpp
@@ -17,4 +17,23 @@ namespace Cantera
 const double SoaveRedlichKwong::omega_a = 4.27480233540E-01;
 const double SoaveRedlichKwong::omega_b = 8.66403499650E-02;
 const double SoaveRedlichKwong::omega_vc = 3.33333333333333E-01;
+
+
+
+int SoaveRedlichKwong::solveCubic(double T, double pres, double a, double b, double aAlpha,
+                                  double Vroot[3]) const
+{
+    double an = 1.0;
+    double bn = - GasConstant * T / pres;
+    double cn = (aAlpha - b * GasConstant * T) / pres - b * b;
+    double dn = aAlpha * b / pres;
+
+    double tc = a * omega_b / (b * omega_a * GasConstant);
+    double pc = omega_b * R * tc / b;
+    double vc = omega_vc * GasConstant * tc / pc
+
+    return MixtureFugacityTP::solveCubic(T, pres, a, b, aAlpha, Vroot,
+                                         an, bn, cn, dn, tc, vc);
+}
+
 }

--- a/src/thermo/SoaveRedlichKwong.cpp
+++ b/src/thermo/SoaveRedlichKwong.cpp
@@ -19,6 +19,15 @@ const double SoaveRedlichKwong::omega_b = 8.66403499650E-02;
 const double SoaveRedlichKwong::omega_vc = 3.33333333333333E-01;
 
 
+
+double SoaveRedlichKwong::pressure() const
+{
+    _updateReferenceStateThermo();
+    // Get a copy of the private variables stored in the State object
+    double T = temperature();
+    double mv = molarVolume();
+    return GasConstant * T / (mv - m_b) - m_aAlpha_mix / (mv * (mv - m_b))
+}
 double SoaveRedlichKwong::speciesCritTemperature(double a, double b) const
 {
     if (b <= 0.0) {

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -25,6 +25,7 @@
 #include "cantera/thermo/PureFluidPhase.h"
 #include "cantera/thermo/RedlichKwongMFTP.h"
 #include "cantera/thermo/PengRobinson.h"
+#include "cantera/thermo/SoaveRedlichKwong.h"
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/thermo/EdgePhase.h"
 #include "cantera/thermo/MetalPhase.h"
@@ -104,6 +105,7 @@ ThermoFactory::ThermoFactory()
     reg("binary-solution-tabulated", []() { return new BinarySolutionTabulatedThermo(); });
     addAlias("binary-solution-tabulated", "BinarySolutionTabulatedThermo");
     reg("Peng-Robinson", []() { return new PengRobinson(); });
+    reg("Soave-Redlich-Kwong", []() { return new SoaveRedlichKwong(); });
 }
 
 ThermoPhase* ThermoFactory::newThermoPhase(const std::string& model)

--- a/test/data/co2_SRK_example.yaml
+++ b/test/data/co2_SRK_example.yaml
@@ -1,0 +1,129 @@
+units: {length: cm, quantity: mol, activation-energy: cal/mol}
+
+phases:
+- name: CO2-PR
+  species: [CO2, H2O, H2, CO, CH4, O2, N2]
+  thermo: Soave-Redlich-Kwong
+  kinetics: gas
+  reactions: all
+  state: {T: 300, P: 1 atm, mole-fractions: {CO2: 0.99, H2: 0.01}}
+
+
+species:
+- name: CO2
+  composition: {C: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.35677352, 8.98459677e-03, -7.12356269e-06, 2.45919022e-09, -1.43699548e-13,
+      -4.83719697e+04, 9.90105222]
+    - [3.85746029, 4.41437026e-03, -2.21481404e-06, 5.23490188e-10, -4.72084164e-14,
+      -4.8759166e+04, 2.27163806]
+    note: L7/88
+  equation-of-state:
+    model: Soave-Redlich-Kwong
+    a: 3.700552E+11
+    b: 29.6547
+    acentric-factor: 0.228
+- name: H2O
+  composition: {H: 2, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.19864056, -2.0364341e-03, 6.52040211e-06, -5.48797062e-09, 1.77197817e-12,
+      -3.02937267e+04, -0.849032208]
+    - [3.03399249, 2.17691804e-03, -1.64072518e-07, -9.7041987e-11, 1.68200992e-14,
+      -3.00042971e+04, 4.9667701]
+    note: L8/89
+  equation-of-state:
+    model: Soave-Redlich-Kwong
+    a: 5.608487E+11
+    b: 21.1282
+    acentric-factor: 0.344
+- name: H2
+  composition: {H: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.34433112, 7.98052075e-03, -1.9478151e-05, 2.01572094e-08, -7.37611761e-12,
+      -917.935173, 0.683010238]
+    - [3.3372792, -4.94024731e-05, 4.99456778e-07, -1.79566394e-10, 2.00255376e-14,
+      -950.158922, -3.20502331]
+    note: TPIS78
+  equation-of-state:
+    model: Soave-Redlich-Kwong
+    a: 2.494771E+10
+    b: 18.4290
+    acentric-factor: -0.22
+- name: CO
+  composition: {C: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.57953347, -6.1035368e-04, 1.01681433e-06, 9.07005884e-10, -9.04424499e-13,
+      -1.4344086e+04, 3.50840928]
+    - [2.71518561, 2.06252743e-03, -9.98825771e-07, 2.30053008e-10, -2.03647716e-14,
+      -1.41518724e+04, 7.81868772]
+    note: TPIS79
+  equation-of-state:
+    model: Soave-Redlich-Kwong
+    a: 1.502575E+11
+    b: 27.4578
+    acentric-factor: 0.049
+- name: CH4
+  composition: {C: 1, H: 4}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [5.14987613, -0.0136709788, 4.91800599e-05, -4.84743026e-08, 1.66693956e-11,
+      -1.02466476e+04, -4.64130376]
+    - [0.074851495, 0.0133909467, -5.73285809e-06, 1.22292535e-09, -1.0181523e-13,
+      -9468.34459, 18.437318]
+    note: L8/88
+  equation-of-state:
+    model: Soave-Redlich-Kwong
+    a: 2.333891E+11
+    b: 29.8499
+    acentric-factor: 0.01
+- name: O2
+  composition: {O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.78245636, -2.99673416e-03, 9.84730201e-06, -9.68129509e-09, 3.24372837e-12,
+      -1063.94356, 3.65767573]
+    - [3.28253784, 1.48308754e-03, -7.57966669e-07, 2.09470555e-10, -2.16717794e-14,
+      -1088.45772, 5.45323129]
+    note: TPIS89
+  equation-of-state:
+    model: Soave-Redlich-Kwong
+    a: 1.400265E+11
+    b: 22.0823
+    acentric-factor: 0.022
+- name: N2
+  composition: {N: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [300.0, 1000.0, 5000.0]
+    data:
+    - [3.298677, 1.4082404e-03, -3.963222e-06, 5.641515e-09, -2.444854e-12,
+      -1020.8999, 3.950372]
+    - [2.92664, 1.4879768e-03, -5.68476e-07, 1.0097038e-10, -6.753351e-15,
+      -922.7977, 5.980528]
+    note: '121286'
+  equation-of-state:
+    model: Soave-Redlich-Kwong
+    a: 1.388390E+11
+    b: 31.2734
+    acentric-factor: 0.04
+
+
+reactions:
+- equation: CO2 + H2 <=> CO + H2O  # Reaction 1
+  rate-constant: {A: 1.2E+3, b: 0, Ea: 0}

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -55,6 +55,15 @@ peng-robinson:
   - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
   - {T: 600, P: 200 bar, X: {CO2: 0.4, CH4: 0.2, H2O: 0.4}}
 
+soave-redlich-kwong:
+  setup:
+    file: co2_SRK_example.yaml
+    rtol_fd: 1e-5
+  states:
+  - {T: 300, P: 101325, X: {CO2: 0.7, CH4: 0.2, H2O: 0.1}}
+  - {T: 320, P: 200 bar, X: {CO2: 0.3, CH4: 0.5, H2O: 0.2}}
+  - {T: 600, P: 200 bar, X: {CO2: 0.4, CH4: 0.2, H2O: 0.4}}
+
 ideal-molal-solution:
   setup:
     file: thermo-models.yaml

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -345,6 +345,56 @@ TEST_P(TestConsistency, dSdv_const_T_eq_dPdT_const_V) {
     }
 }
 
+TEST_P(TestConsistency, betaT_eq_minus_dmv_dP_const_T_div_mv)
+{
+    double betaT1;
+    try {
+        betaT1 = phase->isothermalCompressibility();
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
+
+    double T = phase->temperature();
+    double P1 = phase->pressure();
+    double mv1 = phase->molarVolume();
+    
+    double P2 = P1 * (1 + 1e-7);
+    phase->setState_TP(T, P2);
+    double betaT2 = phase->isothermalCompressibility();
+    double mv2 = phase->molarVolume();
+
+    double betaT_mid = 0.5 * (betaT1 + betaT2);
+    double mv_mid = 0.5 * (mv1 + mv2);
+    double betaT_fd = -1 / mv_mid * (mv2 - mv1) / (P2 - P1);
+
+    EXPECT_NEAR(betaT_fd, betaT_mid, max({rtol_fd * betaT_mid, rtol_fd * betaT_fd, atol}));
+}
+
+TEST_P(TestConsistency, alphaV_eq_dmv_dT_const_P_div_mv)
+{
+    double alphaV1;
+    try {
+        alphaV1 = phase->thermalExpansionCoeff();
+    } catch (NotImplementedError& err) {
+        GTEST_SKIP() << err.getMethod() << " threw NotImplementedError";
+    }
+
+    double P = phase->pressure();
+    double T1 = phase->temperature();
+    double mv1 = phase->molarVolume();
+
+    double T2 = T1 * (1 + 1e-7);
+    phase->setState_TP(T2, P);
+    double alphaV2 = phase->thermalExpansionCoeff();
+    double mv2 = phase->molarVolume();
+
+    double alphaV_mid = 0.5 * (alphaV1 + alphaV2);
+    double mv_mid = 0.5 * (mv1 + mv2);
+    double alphaV_fd = 1 / mv_mid * (mv2 - mv1) / (T2 - T1);
+
+    EXPECT_NEAR(alphaV_fd, alphaV_mid, max({rtol_fd * alphaV_mid, rtol_fd * alphaV_fd, atol}));
+}
+
 // ---------- Tests for consistency of standard state properties ---------------
 
 TEST_P(TestConsistency, hk0_eq_uk0_plus_p_vk0)

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -606,6 +606,12 @@ INSTANTIATE_TEST_SUITE_P(PengRobinson, TestConsistency,
         testing::ValuesIn(getStates("peng-robinson")))
 );
 
+INSTANTIATE_TEST_SUITE_P(SoaveRedlichKwong, TestConsistency,
+    testing::Combine(
+        testing::Values(getSetup("soave-redlich-kwong")),
+        testing::ValuesIn(getStates("soave-redlich-kwong")))
+);
+
 INSTANTIATE_TEST_SUITE_P(IdealMolalSolution, TestConsistency,
     testing::Combine(
         testing::Values(getSetup("ideal-molal-solution")),


### PR DESCRIPTION
Closes https://github.com/Cantera/enhancements/issues/159

Proposed changes:
- Add `SoaveRedlichKwong` class 
- Moved shared cubic EoS functionality to `MixtureFugacityTP`

Derivations at https://github.com/corykinney/Soave-Redlich-Kwong.

To do:
- [ ] Finish derivations and implementations for thermodynamic properties
- [ ] Implement tests similar to `RedlichKwongMFTP`/`PengRobinson`
- [ ] Consolidate shared functionality of all three in `MixtureFugacityTP`
- [ ] Clean up commit history

**Checklist**

- [x] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
