### PR TITLE
[SCons] add AR config option (e.g. to set llvm-ar instead of ar)

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -203,6 +203,10 @@ windows_options = [
 
 config_options = [
     Option(
+        "AR",
+        "The archiver to use.",
+        "${AR}"),
+    Option(
         "CXX",
         "The C++ compiler to use.",
         "${CXX}"),
@@ -848,7 +852,7 @@ else:
 
 add_RegressionTest(env)
 
-opts.AddVariables(*config.to_scons(["CC", "CXX"], env=env))
+opts.AddVariables(*config.to_scons(["AR", "CC", "CXX"], env=env))
 opts.Update(env)
 
 # Check if this is actually Apple's clang on macOS


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Some systems that are based on Clang/LLVM configurations could rely on `llvm-ar` archiver instead of `ar` to package static libraries. The proposed tiny patch offers additional config option (like `CC`, `CXX`) to allow user to set appropeate prefered AR variable.

Please refer Gentoo Linux issue: https://bugs.gentoo.org/773541

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes # None

**If applicable, provide an example illustrating new features this pull request is introducing**

For build and tests of proposed feature the following common SCons configuration was used:
```
debug="no" 
f90_interface=y 
python_package=full 
python_cmd=python3.10 
optimize_flags="-Wno-inline" 
renamed_shared_libraries="no" 
use_pch="no" 
system_fmt="y" 
system_eigen="y" 
system_yamlcpp="y" 
env_vars="all" 
extra_inc_dirs="/usr/include/eigen3" 
prefix="/usr
```
The additional alternate options will be mentioned in appropreate cases.
The system `Sundials 6.5.0` was used until test with sundials from Cantera submodule (`Sundials 5.3.0`)
The `gfortran` always is used to build `f90_interface`
*The `cantera.conf` was removed before each build run!*

Please notice the example of archiver call (`ar` or `llvm-ar`):

1. Case: `system_sundials="y" system_blas_lapack=n` (lapack support is disabled)
```
ar rc build/lib/libcantera.a build/src/base/AnyMap.os ...

scons -j4 test
...
Tests passed: 4830
Up-to-date tests skipped: 0
Tests failed: 0
```

2. Case: `system_sundials="y" system_blas_lapack=y blas_lapack_libs="blas,lapack"`
```
ar rc build/lib/libcantera.a build/src/base/AnyMap.os ...

scons -j4 test
...
Tests passed: 4830
Up-to-date tests skipped: 0
Tests failed: 0
```

3. Case: `AR=llvm-ar CC=clang CXX=clang++ system_sundials="y" system_blas_lapack=n`  (lapack support is disabled)

```
    ...
    AR = 'llvm-ar'
    CC = 'clang'
    CXX = 'clang++'
    ...

llvm-ar rc build/lib/libcantera.a build/src/base/AnyMap.os ...

scons -j4 test
...
Tests passed: 4830
Up-to-date tests skipped: 0
Tests failed: 0
```

4. Case: `AR=llvm-ar CC=clang CXX=clang++ system_sundials="y" system_blas_lapack=y blas_lapack_libs="blas,lapack"`
```
    ...
    AR = 'llvm-ar'
    CC = 'clang'
    CXX = 'clang++'
    ...

llvm-ar rc build/lib/libcantera.a build/src/base/AnyMap.os ...

scons -j4 test
...
Tests passed: 4830
Up-to-date tests skipped: 0
Tests failed: 0
```

5. Case: `AR=llvm-ar CC=clang CXX=clang++ system_sundials="n" system_blas_lapack=y blas_lapack_libs="blas,lapack"`
```
    ...
    AR = 'llvm-ar'
    CC = 'clang'
    CXX = 'clang++'
    ...
    system_sundials = 'n'
...
    CT_SUNDIALS_VERSION                 53
...

llvm-ar rc build/lib/libcantera.a build/ext/sundials/src/sundials/sundials_band.os ...

scons -j4 test
...
Tests passed: 4830
Up-to-date tests skipped: 0
Tests failed: 0
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
