### PR TITLE
Speed up Python module import

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -78,7 +78,10 @@ import subprocess
 import re
 import json
 import textwrap
-from pkg_resources import parse_version
+try:
+    from packaging.version import parse as parse_version
+except ImportError:
+    from pkg_resources import parse_version
 import SCons
 
 # ensure that Python and SCons versions are sufficient for the build process

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -6,13 +6,13 @@ import os
 import warnings
 from cpython.ref cimport PyObject
 import numbers
-import pkg_resources
+import importlib.metadata
 import numpy as np
 
 # avoid explicit dependence of cantera on scipy
 try:
-    pkg_resources.get_distribution('scipy')
-except pkg_resources.DistributionNotFound:
+    importlib.metadata.version('scipy')
+except importlib.metadata.PackageNotFoundError:
     _scipy_sparse = ImportError('Method requires a working scipy installation.')
 else:
     from scipy import sparse as _scipy_sparse
@@ -103,8 +103,8 @@ def hdf_support():
     """
     out = []
     try:
-        pkg_resources.get_distribution("h5py")
-    except pkg_resources.DistributionNotFound:
+        importlib.metadata.version("h5py")
+    except importlib.metadata.PackageNotFoundError:
         pass
     else:
         out.append("h5py")

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -6,24 +6,22 @@ from ._cantera import *
 import numpy as np
 from collections import OrderedDict
 import csv as _csv
+import importlib.metadata
 
 def _import_h5py():
     # avoid explicit dependence of cantera on h5py
-    import pkg_resources  # local import to reduce overall import time
     try:
-        pkg_resources.get_distribution('h5py')
-    except pkg_resources.DistributionNotFound:
+        importlib.metadata.version('h5py')
+    except importlib.metadata.PackageNotFoundError:
         raise ImportError('Method requires a working h5py installation.')
     else:
         import h5py
         return h5py
 
 # avoid explicit dependence of cantera on pandas
-import pkg_resources
-
 try:
-    pkg_resources.get_distribution('pandas')
-except pkg_resources.DistributionNotFound:
+    importlib.metadata.version('pandas')
+except importlib.metadata.PackageNotFoundError:
     _pandas = ImportError('Method requires a working pandas installation.')
 else:
     import pandas as _pandas

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -42,6 +42,7 @@ include_package_data = True
 install_requires =
     numpy >= 1.12.0
     ruamel.yaml >= 0.15.34
+    packaging
 python_requires = >=@py_min_ver_str@
 packages =
     cantera

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -42,6 +42,7 @@ include_package_data = True
 install_requires =
     numpy >= 1.12.0
     ruamel.yaml >= 0.15.34
+    packaging
 python_requires = >=@py_min_ver_str@
 packages =
     cantera

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -11,7 +11,10 @@ import time
 import shutil
 import enum
 from pathlib import Path
-from pkg_resources import parse_version
+try:
+    from packaging.version import parse as parse_version
+except ImportError:
+    from pkg_resources import parse_version
 import logging
 from typing import TYPE_CHECKING
 from collections.abc import Mapping as MappingABC
@@ -1352,7 +1355,10 @@ def get_pip_install_location(
     root = quoted(root) if root is not None else None
     install_script = textwrap.dedent(f"""
         from pip import __version__ as pip_version
-        from pkg_resources import parse_version
+        try:
+            from packaging.version import parse as parse_version
+        except ImportError:
+            from pkg_resources import parse_version
         import pip
         import json
         pip_version = parse_version(pip_version)

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -7,12 +7,16 @@ import pickle
 import cantera as ct
 
 try:
-    h5py = ct.composite._import_h5py()
-    have_h5py = True
+    ct.composite._import_pandas()
 except ImportError:
-    have_h5py = False
+    pass
 
-from cantera.composite import _pandas
+try:
+    ct.composite._import_h5py()
+except ImportError:
+    pass
+
+from cantera.composite import _pandas, _h5py
 from . import utilities
 
 
@@ -262,7 +266,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         self.assertEqual(states[0].P, gas.P)
         self.assertArrayNear(states[0].Y, gas.Y)
 
-    @utilities.unittest.skipIf(not have_h5py, "h5py is not installed")
+    @utilities.unittest.skipIf(_h5py is None, "h5py is not installed")
     def test_import_no_norm_data(self):
         outfile = self.test_work_path / "solutionarray.h5"
         # In Python >= 3.8, this can be replaced by the missing_ok argument
@@ -332,7 +336,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         with self.assertRaisesRegex(NotImplementedError, 'not supported'):
             states.write_csv(outfile)
 
-    @utilities.unittest.skipIf(isinstance(_pandas, ImportError), "pandas is not installed")
+    @utilities.unittest.skipIf(_pandas is None, "pandas is not installed")
     def test_to_pandas(self):
         states = ct.SolutionArray(self.gas, 7, extra={"props": range(7)})
         states.TPX = np.linspace(300, 1000, 7), 2e5, 'H2:0.5, O2:0.4'
@@ -343,7 +347,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         with self.assertRaisesRegex(NotImplementedError, 'not supported'):
             states.to_pandas()
 
-    @utilities.unittest.skipIf(not have_h5py, "h5py is not installed")
+    @utilities.unittest.skipIf(_h5py is None, "h5py is not installed")
     def test_write_hdf(self):
         outfile = self.test_work_path / "solutionarray.h5"
         # In Python >= 3.8, this can be replaced by the missing_ok argument
@@ -372,7 +376,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         gas = ct.Solution('gri30.yaml', transport_model=None)
         ct.SolutionArray(gas, 10).write_hdf(outfile)
 
-        with h5py.File(outfile, 'a') as hdf:
+        with _h5py.File(outfile, 'a') as hdf:
             hdf.create_group('spam')
 
         c = ct.SolutionArray(self.gas)
@@ -389,7 +393,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         c.read_hdf(outfile, group='foo/bar/baz')
         self.assertArrayNear(states.T, c.T)
 
-    @utilities.unittest.skipIf(not have_h5py, "h5py is not installed")
+    @utilities.unittest.skipIf(_h5py is None, "h5py is not installed")
     def test_write_hdf_str_column(self):
         outfile = self.test_work_path / "solutionarray.h5"
         # In Python >= 3.8, this can be replaced by the missing_ok argument
@@ -403,7 +407,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         b.read_hdf(outfile)
         self.assertEqual(list(states.spam), list(b.spam))
 
-    @utilities.unittest.skipIf(not have_h5py, "h5py is not installed")
+    @utilities.unittest.skipIf(_h5py is None, "h5py is not installed")
     def test_write_hdf_multidim_column(self):
         outfile = self.test_work_path / "solutionarray.h5"
         # In Python >= 3.8, this can be replaced by the missing_ok argument
@@ -578,7 +582,7 @@ class TestRestorePureFluid(utilities.CanteraTest):
         b.restore_data(data)
         check(a, b)
 
-    @utilities.unittest.skipIf(not have_h5py, "h5py is not installed")
+    @utilities.unittest.skipIf(_h5py is None, "h5py is not installed")
     def test_import_no_norm_water(self):
         outfile = self.test_work_path / "solutionarray.h5"
         # In Python >= 3.8, this can be replaced by the missing_ok argument

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -1,7 +1,7 @@
 import numpy as np
 import re
 import itertools
-import pkg_resources
+import importlib.metadata
 import pytest
 
 import cantera as ct
@@ -10,8 +10,8 @@ from .utilities import allow_deprecated
 
 # avoid explicit dependence of cantera on scipy
 try:
-    pkg_resources.get_distribution('scipy')
-except pkg_resources.DistributionNotFound:
+    importlib.metadata.version('scipy')
+except importlib.metadata.PackageNotFoundError:
     _scipy_sparse = ImportError('Method requires a working scipy installation.')
 else:
     from scipy import sparse as _scipy_sparse


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Replace use of `pkg_resources` with faster alternatives
- Defer loading `pandas` and `scipy` until they are used

**If applicable, provide an example illustrating new features this pull request is introducing**

This reduces the time it takes to import the Cantera Python module by ~70%. This can be examined by running
```
PYTHONPATH=build/python python3 -X importtime -c 'import cantera'
```

On my system (Mac M1 Pro), where the total import time is around 261 ms, the biggest contributors to this are:
- `pandas`: 104 ms
- `cantera._utils`: 80 ms, which encompasses loading `scipy.sparse`
- `pkg_resources`: 55 ms
- `numpy`: 42 ms

With this PR, the total import time is reduced to 80 ms. Of the items mentioned above, `numpy` remains the same, `cantera._utils` decreases to 8 ms, and the others are eliminated.

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
