### PR TITLE
Link Python module to Cantera shared library

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -133,14 +133,14 @@ jobs:
         python-version: 3.11
       if: matrix.python-version == '3.11'
     - name: Install Brew dependencies
-      run: brew install boost libomp hdf5
+      run: brew install --display-times boost libomp hdf5
     - name: Setup Homebrew Python
       # This path should work for future Python versions as well
       if: matrix.python-version != '3.11'
       run: |
-        brew install python@${{ matrix.python-version }}
+        brew install --display-times python@${{ matrix.python-version }}
         brew link --force --overwrite python@${{ matrix.python-version }}
-        brew install scons
+        brew install --display-times scons
     - name: Upgrade pip
       run: $PYTHON_CMD -m pip install -U pip 'setuptools>=47.0.0,<48' wheel
     - name: Install Python dependencies
@@ -772,7 +772,7 @@ jobs:
       shell: pwsh
       if: matrix.os == 'windows-2022'
     - name: Install Brew dependencies (macOS)
-      run: brew install hdf5
+      run: brew install --display-times hdf5
       if: matrix.os == 'macos-11'
     - name: Install Apt dependencies (Ubuntu)
       run: sudo apt install libhdf5-dev

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -711,6 +711,7 @@ jobs:
       uses: egor-tensin/setup-mingw@v2
       with:
         platform: x64
+        static: false
     - name: Install Boost Headers
       if: steps.cache-boost.outputs.cache-hit != 'true'
       run: |

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -726,6 +726,12 @@ jobs:
         python_package=full env_vars=PYTHONPATH,GITHUB_ACTIONS
         toolchain=mingw f90_interface=n --debug=time
       shell: cmd
+    - name: Upload Wheel
+      uses: actions/upload-artifact@v3
+      with:
+        path: build\python\dist\Cantera*.whl
+        name: Cantera-win_amd64.whl
+        retention-days: 2
     - name: Test Cantera
       run: scons test show_long_tests=yes verbose_tests=yes --debug=time
 

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -384,6 +384,7 @@ jobs:
       - name: Run the examples
         # See https://unix.stackexchange.com/a/392973 for an explanation of the -exec part
         run: |
+          export LD_LIBRARY_PATH=build/lib
           find samples/python -type f -iname "*.py" \
           -exec sh -c 'for n; do echo "$n" | tee -a results.txt && python3 "$n" >> results.txt || exit 1; done' sh {} +
         env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -563,7 +563,7 @@ jobs:
         id: cache-boost
         with:
           path: ${{env.BOOST_ROOT}}
-          key: boost
+          key: boost-178-win
 
       - name: Install Boost Headers
         if: steps.cache-boost.outputs.cache-hit != 'true'
@@ -681,9 +681,9 @@ jobs:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
 
   windows-mingw:
-    name: mingw on Windows, Python 3.8
-    runs-on: windows-2019
-    timeout-minutes: 60
+    name: mingw on Windows, Python 3.10
+    runs-on: windows-2022
+    timeout-minutes: 120 # MinGW is slooooow
     env:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
@@ -695,18 +695,18 @@ jobs:
     - name: Set Up Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.8
+        python-version: "3.10"
         architecture: x64
     - name: Install Python dependencies
       run: |
-        python -m pip install -U pip 'setuptools>=47.0.0,<48' wheel
+        python -m pip install -U pip setuptools wheel
         python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas pytest pytest-github-actions-annotate-failures
     - name: Restore Boost cache
       uses: actions/cache@v3
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
-        key: boost
+        key: boost-178-win
     - name: Set up MinGW
       uses: egor-tensin/setup-mingw@v2
       with:
@@ -724,7 +724,7 @@ jobs:
       shell: bash
     - name: Build Cantera
       run: scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n logging=debug
-        python_package=full env_vars=PYTHONPATH,GITHUB_ACTIONS
+        python_package=full env_vars=USERPROFILE,PYTHONPATH,GITHUB_ACTIONS
         toolchain=mingw f90_interface=n --debug=time
       shell: cmd
     - name: Upload Wheel

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -735,6 +735,15 @@ jobs:
         retention-days: 2
     - name: Test Cantera
       run: scons test show_long_tests=yes verbose_tests=yes --debug=time
+    - name: Upload Test binaries
+      if: always()
+      uses: actions/upload-artifact@v3
+      with:
+        path: |
+          build/test/**/*.exe
+          build/lib/*.dll
+        name: mingw-gtest-binaries
+        retention-days: 2
 
   dotnet:
     name: .NET on ${{ matrix.os }}

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -79,8 +79,8 @@
 * Class names use `InitialCapsNames`
 * Methods use `camelCaseNames`
 * Do not indent the contents of namespaces
-* Code should follow the C++14 standard, with minimum required compiler versions
-  GCC 6.1, Clang 3.4, MSVC 14.1 (2017) and Intel 17.0.
+* Code should follow the C++17 standard, with minimum required compiler versions
+  GCC 7.0, Clang 4.0, MSVC 14.14 (Visual Studio 2017 version 15.7) and Intel 19.0.
 * Avoid manual memory management (that is, `new` and `delete`), preferring to use
   standard library containers, as well as `std::unique_ptr` and
   `std::shared_ptr` when dynamic allocation is required.

--- a/SConstruct
+++ b/SConstruct
@@ -2219,6 +2219,9 @@ else:
 env["external_libs"] = []
 env["external_libs"].extend(env["sundials_libs"])
 
+if env["OS"] == "Linux":
+    env["external_libs"].append("dl")
+
 if env["use_hdf5"]:
     env["external_libs"].append("hdf5")
 

--- a/SConstruct
+++ b/SConstruct
@@ -1900,13 +1900,20 @@ if env["python_package"] == "full" and env["OS"] == "Darwin":
     # the name of the wheel file for the Python module. If this is not specified by the
     # MACOSX_DEPLOYMENT_TARGET environment variable, get the value from the Python
     # installation and use that.
-    if not env["ENV"].get("MACOSX_DEPLOYMENT_TARGET", False):
+    mac_target = env["ENV"].get("MACOSX_DEPLOYMENT_TARGET", None)
+    if not mac_target:
         info = get_command_output(
             env["python_cmd"],
             "-c",
             "import sysconfig; print(sysconfig.get_platform())"
         )
-        env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = info.split("-")[1]
+        mac_target = info.split("-")[1]
+        if parse_version(mac_target) < parse_version('10.15'):
+            # macOS 10.15 is the minimum version with C++17 support
+            mac_target = '10.15'
+
+    env["ENV"]["MACOSX_DEPLOYMENT_TARGET"] = mac_target
+    logger.info(f"MACOSX_DEPLOYMENT_TARGET = {mac_target}")
 
 # Matlab Toolbox settings
 if env["matlab_path"] != "" and env["matlab_toolbox"] == "default":

--- a/SConstruct
+++ b/SConstruct
@@ -1131,9 +1131,6 @@ if env['coverage']:
         logger.error("Coverage testing is only available with GCC.")
         exit(0)
 
-if env['toolchain'] == 'mingw':
-    env.Append(LINKFLAGS=['-static-libgcc', '-static-libstdc++'])
-
 def config_error(message):
     if env["logging"].lower() == "debug":
         logger.error(message)

--- a/SConstruct
+++ b/SConstruct
@@ -219,8 +219,8 @@ config_options = [
            options with spaces, for example, "cxx_flags='-g -Wextra -O3 --std=c++14'"
            """,
         {
-            "cl": "/EHsc",
-            "default": "-std=c++14"
+            "cl": "/EHsc /std:c++17",
+            "default": "-std=c++17"
         }),
     Option(
         "CC",

--- a/SConstruct
+++ b/SConstruct
@@ -2196,7 +2196,15 @@ def install(*args, **kwargs):
 env.SConsignFile()
 
 env.Prepend(CPPPATH=[],
-           LIBPATH=[Dir('build/lib')])
+            LIBPATH=[Dir('build/lib')])
+
+# Add build/lib to library search path in order to find Cantera shared library
+if env['OS'] == 'Windows':
+    env.PrependENVPath('PATH', Dir('#build/lib').abspath)
+elif env['OS'] == 'Darwin':
+    env.PrependENVPath('DYLD_LIBRARY_PATH', Dir('#build/lib').abspath)
+else:
+    env.PrependENVPath('LD_LIBRARY_PATH', Dir('#build/lib').abspath)
 
 for yaml in multi_glob(env, "data", "yaml"):
     dest = Path() / "build" / "data" / yaml.name

--- a/SConstruct
+++ b/SConstruct
@@ -2087,6 +2087,9 @@ else:
     for loc in locations:
         env[f"inst_{loc}"] = env[f"ct_{loc}"].replace(env["ct_installroot"], instRoot)
 
+if env['use_rpath_linkage']:
+    env.Append(RPATH=env['ct_libdir'])
+
 # **************************************
 # *** Set options needed in config.h ***
 # **************************************

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -8,12 +8,6 @@ Import('env', 'build', 'install')
 
 localenv = env.Clone()
 
-# Add build/lib in order to find Cantera shared library
-if env['OS'] == 'Darwin':
-    localenv.PrependENVPath('DYLD_LIBRARY_PATH', Dir('#build/lib').abspath)
-else:
-    localenv.PrependENVPath('LD_LIBRARY_PATH', Dir('#build/lib').abspath)
-
 Page = namedtuple('Page', ['name', 'title', 'objects'])
 
 

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -8,6 +8,12 @@ Import('env', 'build', 'install')
 
 localenv = env.Clone()
 
+# Add build/lib in order to find Cantera shared library
+if env['OS'] == 'Darwin':
+    localenv.PrependENVPath('DYLD_LIBRARY_PATH', Dir('#build/lib').abspath)
+else:
+    localenv.PrependENVPath('LD_LIBRARY_PATH', Dir('#build/lib').abspath)
+
 Page = namedtuple('Page', ['name', 'title', 'objects'])
 
 

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -40,8 +40,7 @@ if not env['system_fmt']:
     license_files["fmtlib"] = File("#ext/fmt/LICENSE.rst")
     localenv = prep_default(env)
     localenv.Prepend(CPPPATH=Dir('#ext/fmt/include'))
-    libraryTargets.extend(
-        localenv.SharedObject(multi_glob(localenv, 'fmt/src', 'cc')))
+    libraryTargets.extend(localenv.SharedObject(['fmt/src/format.cc', 'fmt/src/os.cc']))
     for name in ('format.h', 'ostream.h', 'printf.h', 'core.h', 'format-inl.h'):
         ext_copies.extend(
             copyenv.Command("#include/cantera/ext/fmt/" + name,

--- a/include/cantera/base/ExtensionManager.h
+++ b/include/cantera/base/ExtensionManager.h
@@ -44,6 +44,31 @@ public:
         throw NotImplementedError("ExtensionManager::registerRateBuilders");
     };
 
+    //! Register a user-defined ReactionRate implementation with ReactionRateFactory
+    //! @param extensionName The name of the library/module containing the user-defined
+    //!     rate. For example, the module name for rates implemented in Python.
+    //! @param className The name of the rate in the user's code. For example, the
+    //!     Python class name
+    //! @param rateName The name used to construct a rate of this type using
+    //!     the newReactionRate() function or from a YAML input file
+    virtual void registerRateBuilder(const string& extensionName,
+        const string& className, const string& rateName)
+    {
+        throw NotImplementedError("ExtensionManager::registerRateBuilder");
+    }
+
+    //! Register a user-defined ReactionData implementation
+    //! @param extensionName The name of the library/module containing the user-defined
+    //!     type. For example, the module name for rates implemented in Python.
+    //! @param className The name of the data object in the user's code. For example,
+    //!     the Python class name
+    //! @param rateName The name of the corresponding reaction rate type
+    virtual void registerRateDataBuilder(const string& extensionName,
+        const string& className, const string& rateName)
+    {
+        throw NotImplementedError("ExtensionManager::registerRateDataBuilder");
+    }
+
     //! Create an object in an external language that wraps the specified ReactionData
     //! object
     //!

--- a/include/cantera/base/ExtensionManagerFactory.h
+++ b/include/cantera/base/ExtensionManagerFactory.h
@@ -26,11 +26,11 @@ public:
     //! Delete the static instance of this factory
     virtual void deleteFactory();
 
-private:
     //! Static function that returns the static instance of the factory, creating it
     //! if necessary.
     static ExtensionManagerFactory& factory();
 
+private:
     //! static member of the single factory instance
     static ExtensionManagerFactory* s_factory;
 

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -22,9 +22,11 @@
 #include <cstdlib>
 #include <vector>
 #include <map>
+#include <set>
 #include <string>
 #include <algorithm>
 #include <memory>
+#include <functional>
 
 /**
  * Namespace for the Cantera kernel.
@@ -36,6 +38,12 @@ using std::shared_ptr;
 using std::make_shared;
 using std::unique_ptr;
 using std::isnan; // workaround for bug in libstdc++ 4.8
+using std::string;
+using std::vector;
+using std::map;
+using std::set;
+using std::function;
+using std::pair;
 
 /*!
  * All physical constants are stored here.
@@ -159,20 +167,20 @@ const double Tiny = 1.e-20;
 /*!
  * This is used mostly to assign concentrations and mole fractions to species.
  */
-typedef std::map<std::string, double> compositionMap;
+typedef map<string, double> compositionMap;
 
 //! Map from string names to doubles. Used for defining species mole/mass
 //! fractions, elemental compositions, and reaction stoichiometries.
-typedef std::map<std::string, double> Composition;
+typedef map<string, double> Composition;
 
 //! Turn on the use of stl vectors for the basic array type within cantera
 //! Vector of doubles.
-typedef std::vector<double> vector_fp;
+typedef vector<double> vector_fp;
 //! Vector of ints
-typedef std::vector<int> vector_int;
+typedef vector<int> vector_int;
 
 //! A grouplist is a vector of groups of species
-typedef std::vector<std::vector<size_t> > grouplist_t;
+typedef vector<vector<size_t>> grouplist_t;
 
 //! index returned by functions to indicate "no position"
 const size_t npos = static_cast<size_t>(-1);

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -87,6 +87,11 @@ void loadExtension(const std::string& extType, const std::string& name);
 //! @since New in Cantera 3.0
 void loadExtensions(const AnyMap& node);
 
+//! Returns `true` if Cantera was loaded as a shared library in the current
+//! application. Returns `false` if it was statically linked.
+//! @since New in Cantera 3.0
+bool usingSharedLibrary();
+
 //! Delete and free all memory associated with the application
 /*!
  * Delete all global data.  It should be called at the end of the

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -87,6 +87,9 @@ void loadExtension(const std::string& extType, const std::string& name);
 //! @since New in Cantera 3.0
 void loadExtensions(const AnyMap& node);
 
+//! @copydoc Application::searchPythonVersions
+void searchPythonVersions(const string& versions);
+
 //! Returns `true` if Cantera was loaded as a shared library in the current
 //! application. Returns `false` if it was statically linked.
 //! @since New in Cantera 3.0

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -102,6 +102,11 @@ void appdelete();
 //! @copydoc Application::thread_complete
 void thread_complete();
 
+//! Returns the Cantera version. This function when needing to access the version from a
+//! library, rather than the `CANTERA_VERSION` macro that is available at compile time.
+//! @since New in Cantera 3.0
+string version();
+
 //! Returns the hash of the git commit from which Cantera was compiled, if known
 std::string gitCommit();
 

--- a/include/cantera/clib/clib_defs.h
+++ b/include/cantera/clib/clib_defs.h
@@ -11,21 +11,10 @@
 #include "cantera/base/config.h"
 #include <stdlib.h>
 
-#ifdef _WIN32
-// Windows (MSVC or MinGW)
-# ifdef CANTERA_USE_INTERNAL
-#  define CANTERA_CAPI extern __declspec(dllexport)
-# else
-#  define CANTERA_CAPI extern __declspec(dllimport)
-# endif
-#else
-// Non-Windows platform
-# ifdef CANTERA_USE_INTERNAL
-#  define CANTERA_CAPI extern
-# else
-#  define CANTERA_CAPI
-# endif
-#endif
+// Legacy attribute applied to clib functions. Currently, used only to identify
+// functions that should be considered by the 'sourcegen' parser for inclusion in the
+// C# interface.
+#define CANTERA_CAPI
 
 // Values returned for error conditions
 #ifndef ERR

--- a/include/cantera/cython/funcWrapper.h
+++ b/include/cantera/cython/funcWrapper.h
@@ -7,9 +7,6 @@
 #include "cantera/numerics/Func1.h"
 #include "cantera/base/ctexceptions.h"
 #include <stdexcept>
-
-#define CANTERA_USE_INTERNAL
-#include "cantera/clib/clib_defs.h"
 #include "Python.h"
 
 typedef double(*callback_wrapper)(double, void*, void**);
@@ -166,7 +163,7 @@ private:
 };
 
 extern "C" {
-    CANTERA_CAPI PyObject* pyCanteraError;
+    extern PyObject* pyCanteraError;
 }
 
 

--- a/include/cantera/cython/utils_utils.h
+++ b/include/cantera/cython/utils_utils.h
@@ -25,12 +25,23 @@ static std::map<std::string, PyObject*> mapped_PyWarnings = {
     {"User", PyExc_UserWarning}
 };
 
-// Wrappers for preprocessor defines
-inline std::string get_cantera_version()
+// Cantera version for Python module compilation
+inline std::string get_cantera_version_py()
 {
-    return std::string(CANTERA_VERSION);
+    return CANTERA_VERSION;
 }
 
+// Git commit for Python module compilation
+inline std::string get_cantera_git_commit_py()
+{
+#ifdef GIT_COMMIT
+    return GIT_COMMIT;
+#else
+    return "unknown";
+#endif
+}
+
+// Wrappers for preprocessor defines
 inline int get_sundials_version()
 {
     return CT_SUNDIALS_VERSION;

--- a/include/cantera/extensions/PythonExtensionManager.h
+++ b/include/cantera/extensions/PythonExtensionManager.h
@@ -8,9 +8,6 @@
 
 #include "cantera/base/ExtensionManager.h"
 
-#define BOOST_DLL_USE_STD_FS
-#include <boost/dll/alias.hpp>
-
 namespace Cantera
 {
 
@@ -43,8 +40,6 @@ public:
 private:
     static bool s_imported;
 };
-
-BOOST_DLL_ALIAS(Cantera::PythonExtensionManager::registerSelf, registerPythonExtensionManager);
 
 }
 

--- a/include/cantera/extensions/PythonExtensionManager.h
+++ b/include/cantera/extensions/PythonExtensionManager.h
@@ -8,6 +8,9 @@
 
 #include "cantera/base/ExtensionManager.h"
 
+#define BOOST_DLL_USE_STD_FS
+#include <boost/dll/alias.hpp>
+
 namespace Cantera
 {
 
@@ -29,17 +32,21 @@ public:
     PythonExtensionManager();
     virtual void registerRateBuilders(const std::string& extensionName) override;
 
-    //! Function called from Cython to register an ExtensibleRate implementation
-    static void registerPythonRateBuilder(const std::string& moduleName,
-        const std::string& className, const std::string& rateName);
+    void registerRateBuilder(const string& moduleName,
+        const string& className, const string& rateName) override;
 
-    //! Function called from Cython to register an ExtensibleRateData implementation
-    static void registerPythonRateDataBuilder(const std::string& moduleName,
-        const std::string& className, const std::string& rateName);
+    static ExtensionManager* create() {
+        return new PythonExtensionManager();
+    }
+
+    void registerRateDataBuilder(const string& moduleName,
+        const string& className, const string& rateName) override;
 
 private:
     static bool s_imported;
 };
+
+BOOST_DLL_ALIAS(Cantera::PythonExtensionManager::create, create_manager);
 
 }
 

--- a/include/cantera/extensions/PythonExtensionManager.h
+++ b/include/cantera/extensions/PythonExtensionManager.h
@@ -35,9 +35,7 @@ public:
     void registerRateBuilder(const string& moduleName,
         const string& className, const string& rateName) override;
 
-    static ExtensionManager* create() {
-        return new PythonExtensionManager();
-    }
+    static void registerSelf();
 
     void registerRateDataBuilder(const string& moduleName,
         const string& className, const string& rateName) override;
@@ -46,7 +44,7 @@ private:
     static bool s_imported;
 };
 
-BOOST_DLL_ALIAS(Cantera::PythonExtensionManager::create, create_manager);
+BOOST_DLL_ALIAS(Cantera::PythonExtensionManager::registerSelf, registerPythonExtensionManager);
 
 }
 

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -64,16 +64,10 @@ public:
     ArrheniusBase(double A, double b, double Ea);
 
     //! Constructor based on AnyValue content
-    ArrheniusBase(const AnyValue& rate,
-                  const UnitSystem& units, const UnitStack& rate_units)
-    {
-        setRateParameters(rate, units, rate_units);
-    }
+    ArrheniusBase(const AnyValue& rate, const UnitSystem& units,
+                  const UnitStack& rate_units);
 
-    explicit ArrheniusBase(const AnyMap& node, const UnitStack& rate_units={})
-    {
-        setParameters(node, rate_units);
-    }
+    explicit ArrheniusBase(const AnyMap& node, const UnitStack& rate_units={});
 
     //! Perform object setup based on AnyValue node information
     /*!

--- a/include/cantera/kinetics/BlowersMaselRate.h
+++ b/include/cantera/kinetics/BlowersMaselRate.h
@@ -84,11 +84,8 @@ public:
      */
     BlowersMaselRate(double A, double b, double Ea0, double w);
 
-    explicit BlowersMaselRate(const AnyMap& node, const UnitStack& rate_units={})
-        : BlowersMaselRate()
-    {
-        setParameters(node, rate_units);
-    }
+    explicit BlowersMaselRate(const AnyMap& node,
+                              const UnitStack& rate_units={});
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
         return unique_ptr<MultiRateBase>(new MultiRate<BlowersMaselRate, BlowersMaselData>);

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -105,11 +105,7 @@ public:
     ChebyshevRate(double Tmin, double Tmax, double Pmin, double Pmax,
                   const Array2D& coeffs);
 
-    ChebyshevRate(const AnyMap& node, const UnitStack& rate_units={})
-        : ChebyshevRate()
-    {
-        setParameters(node, rate_units);
-    }
+    ChebyshevRate(const AnyMap& node, const UnitStack& rate_units={});
 
     unique_ptr<MultiRateBase> newMultiRate() const {
         return unique_ptr<MultiRateBase>(

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -37,11 +37,7 @@ class CustomFunc1Rate final : public ReactionRate
 {
 public:
     CustomFunc1Rate();
-    CustomFunc1Rate(const AnyMap& node, const UnitStack& rate_units)
-        : CustomFunc1Rate()
-    {
-        setParameters(node, rate_units);
-    }
+    CustomFunc1Rate(const AnyMap& node, const UnitStack& rate_units);
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
         return unique_ptr<MultiRateBase>(new MultiRate<CustomFunc1Rate, ArrheniusData>);

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -199,7 +199,7 @@ public:
 
     //! Evaluate reaction rate
     //! @param shared_data  data shared by all reactions of a given type
-    virtual double evalFromStruct(const FalloffData& shared_data) {
+    double evalFromStruct(const FalloffData& shared_data) {
         updateTemp(shared_data.temperature, m_work.data());
         m_rc_low = m_lowRate.evalRate(shared_data.logT, shared_data.recipT);
         m_rc_high = m_highRate.evalRate(shared_data.logT, shared_data.recipT);

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -86,11 +86,7 @@ public:
     {
     }
 
-    FalloffRate(const AnyMap& node, const UnitStack& rate_units={})
-        : FalloffRate()
-    {
-        setParameters(node, rate_units);
-    }
+    FalloffRate(const AnyMap& node, const UnitStack& rate_units={});
 
     /**
      * Initialize. Must be called before any other method is invoked.
@@ -286,20 +282,10 @@ class LindemannRate final : public FalloffRate
 public:
     LindemannRate() = default;
 
-    LindemannRate(const AnyMap& node, const UnitStack& rate_units={})
-        : LindemannRate()
-    {
-        setParameters(node, rate_units);
-    }
+    LindemannRate(const AnyMap& node, const UnitStack& rate_units={});
 
-    LindemannRate(
-        const ArrheniusRate& low, const ArrheniusRate& high, const vector_fp& c)
-        : LindemannRate()
-    {
-        m_lowRate = low;
-        m_highRate = high;
-        setFalloffCoeffs(c);
-    }
+    LindemannRate(const ArrheniusRate& low, const ArrheniusRate& high,
+                  const vector_fp& c);
 
     unique_ptr<MultiRateBase> newMultiRate() const override{
         return unique_ptr<MultiRateBase>(
@@ -348,19 +334,9 @@ public:
         m_work.resize(1);
     }
 
-    TroeRate(const AnyMap& node, const UnitStack& rate_units={})
-        : TroeRate()
-    {
-        setParameters(node, rate_units);
-    }
-
-    TroeRate(const ArrheniusRate& low, const ArrheniusRate& high, const vector_fp& c)
-        : TroeRate()
-    {
-        m_lowRate = low;
-        m_highRate = high;
-        setFalloffCoeffs(c);
-    }
+    TroeRate(const AnyMap& node, const UnitStack& rate_units={});
+    TroeRate(const ArrheniusRate& low, const ArrheniusRate& high,
+             const vector_fp& c);
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
         return unique_ptr<MultiRateBase>(new MultiRate<TroeRate, FalloffData>);
@@ -451,11 +427,7 @@ public:
         m_work.resize(2);
     }
 
-    SriRate(const AnyMap& node, const UnitStack& rate_units={})
-        : SriRate()
-    {
-        setParameters(node, rate_units);
-    }
+    SriRate(const AnyMap& node, const UnitStack& rate_units={});
 
     SriRate(const ArrheniusRate& low, const ArrheniusRate& high, const vector_fp& c)
         : SriRate()
@@ -562,11 +534,7 @@ public:
         m_work.resize(1);
     }
 
-    TsangRate(const AnyMap& node, const UnitStack& rate_units={})
-        : TsangRate()
-    {
-        setParameters(node, rate_units);
-    }
+    TsangRate(const AnyMap& node, const UnitStack& rate_units={});
 
     TsangRate(const ArrheniusRate& low, const ArrheniusRate& high, const vector_fp& c)
         : TsangRate()

--- a/include/cantera/kinetics/KineticsFactory.h
+++ b/include/cantera/kinetics/KineticsFactory.h
@@ -21,19 +21,9 @@ namespace Cantera
 class KineticsFactory : public Factory<Kinetics>
 {
 public:
-    static KineticsFactory* factory() {
-        std::unique_lock<std::mutex> lock(kinetics_mutex);
-        if (!s_factory) {
-            s_factory = new KineticsFactory;
-        }
-        return s_factory;
-    }
+    static KineticsFactory* factory();
 
-    virtual void deleteFactory() {
-        std::unique_lock<std::mutex> lock(kinetics_mutex);
-        delete s_factory;
-        s_factory = 0;
-    }
+    virtual void deleteFactory();
 
     /**
      * Return a new, empty kinetics manager.
@@ -49,19 +39,12 @@ private:
 /**
  *  Create a new kinetics manager.
  */
-inline Kinetics* newKineticsMgr(const std::string& model)
-{
-    return KineticsFactory::factory()->newKinetics(model);
-}
+Kinetics* newKineticsMgr(const string& model);
 
 /**
  *  Create a new Kinetics instance.
  */
-inline shared_ptr<Kinetics> newKinetics(const std::string& model)
-{
-    shared_ptr<Kinetics> kin(KineticsFactory::factory()->newKinetics(model));
-    return kin;
-}
+shared_ptr<Kinetics> newKinetics(const string& model);
 
 /*!
  * Create a new kinetics manager, initialize it, and add reactions

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -81,9 +81,7 @@ public:
     //! Constructor from Arrhenius rate expressions at a set of pressures
     explicit PlogRate(const std::multimap<double, ArrheniusRate>& rates);
 
-    PlogRate(const AnyMap& node, const UnitStack& rate_units={}) : PlogRate() {
-        setParameters(node, rate_units);
-    }
+    PlogRate(const AnyMap& node, const UnitStack& rate_units={});
 
     unique_ptr<MultiRateBase> newMultiRate() const {
         return unique_ptr<MultiRateBase>(new MultiRate<PlogRate, PlogData>);

--- a/include/cantera/kinetics/ReactionRateFactory.h
+++ b/include/cantera/kinetics/ReactionRateFactory.h
@@ -38,19 +38,9 @@ public:
      * created. Since there is no need to instantiate more than one factory,
      * on all subsequent calls, a pointer to the existing factory is returned.
      */
-    static ReactionRateFactory* factory() {
-        std::unique_lock<std::mutex> lock(rate_mutex);
-        if (!s_factory) {
-            s_factory = new ReactionRateFactory;
-        }
-        return s_factory;
-    }
+    static ReactionRateFactory* factory();
 
-    virtual void deleteFactory() {
-        std::unique_lock<std::mutex> lock(rate_mutex);
-        delete s_factory;
-        s_factory = 0;
-    }
+    virtual void deleteFactory();
 
 private:
     //! Pointer to the single instance of the factory

--- a/include/cantera/kinetics/TwoTempPlasmaRate.h
+++ b/include/cantera/kinetics/TwoTempPlasmaRate.h
@@ -75,9 +75,7 @@ public:
      */
     TwoTempPlasmaRate(double A, double b, double Ea=0.0, double EE=0.0);
 
-    TwoTempPlasmaRate(const AnyMap& node, const UnitStack& rate_units={}) : TwoTempPlasmaRate() {
-        setParameters(node, rate_units);
-    }
+    TwoTempPlasmaRate(const AnyMap& node, const UnitStack& rate_units={});
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
         return unique_ptr<MultiRateBase>(

--- a/include/cantera/numerics/PreconditionerFactory.h
+++ b/include/cantera/numerics/PreconditionerFactory.h
@@ -17,20 +17,10 @@ class PreconditionerBase;
 class PreconditionerFactory : public Factory<PreconditionerBase>
 {
 public:
-    static PreconditionerFactory* factory() {
-        std::unique_lock<std::mutex> lock(precon_mutex);
-        if (!s_factory) {
-            s_factory = new PreconditionerFactory;
-        }
-        return s_factory;
-    };
+    static PreconditionerFactory* factory();
 
     //! Delete preconditioner factory
-    virtual void deleteFactory() {
-        std::unique_lock<std::mutex> lock(precon_mutex);
-        delete s_factory;
-        s_factory = 0;
-    };
+    virtual void deleteFactory();
 
 private:
     static PreconditionerFactory* s_factory;
@@ -39,10 +29,7 @@ private:
 };
 
 //! Create a Preconditioner object of the specified type
-inline std::shared_ptr<PreconditionerBase> newPreconditioner(const std::string& precon)
-{
-    return std::shared_ptr<PreconditionerBase>(PreconditionerFactory::factory()->create(precon));
-};
+shared_ptr<PreconditionerBase> newPreconditioner(const string& precon);
 
 }
 

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -106,16 +106,10 @@ class Inlet1D : public Boundary1D
 public:
     Inlet1D();
 
-    Inlet1D(shared_ptr<Solution> solution, const std::string& id="") : Inlet1D() {
-        m_solution = solution;
-        m_id = id;
-    }
+    Inlet1D(shared_ptr<Solution> solution, const string& id="");
 
     //! set spreading rate
-    virtual void setSpreadRate(double V0) {
-        m_V0 = V0;
-        needJacUpdate();
-    }
+    virtual void setSpreadRate(double V0);
 
     //! spreading rate
     virtual double spreadRate() {
@@ -237,12 +231,7 @@ class OutletRes1D : public Boundary1D
 public:
     OutletRes1D();
 
-    OutletRes1D(shared_ptr<Solution> solution, const std::string& id="")
-        : OutletRes1D()
-    {
-        m_solution = solution;
-        m_id = id;
-    }
+    OutletRes1D(shared_ptr<Solution> solution, const string& id="");
 
     virtual void showSolution(const double* x) {}
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -183,15 +183,7 @@ public:
     //! Return the type of flow domain being represented, either "Free Flame" or
     //! "Axisymmetric Stagnation".
     //! @see setFreeFlow setAxisymmetricFlow
-    virtual std::string flowType() const {
-        if (m_type == cFreeFlow) {
-            return "Free Flame";
-        } else if (m_type == cAxisymmetricStagnationFlow) {
-            return "Axisymmetric Stagnation";
-        } else {
-            throw CanteraError("StFlow::flowType", "Unknown value for 'm_type'");
-        }
-    }
+    virtual string flowType() const;
 
     void solveEnergyEqn(size_t j=npos);
 
@@ -250,9 +242,8 @@ public:
         return m_rho[j];
     }
 
-    virtual bool fixed_mdot() {
-        return (domainType() != cFreeFlow);
-    }
+    virtual bool fixed_mdot();
+
     void setViscosityFlag(bool dovisc) {
         m_dovisc = dovisc;
     }

--- a/include/cantera/thermo/PDSSFactory.h
+++ b/include/cantera/thermo/PDSSFactory.h
@@ -17,20 +17,10 @@ class PDSSFactory : public Factory<PDSS>
 {
 public:
     //! Static function that creates a static instance of the factory.
-    static PDSSFactory* factory() {
-        std::unique_lock<std::mutex> lock(thermo_mutex);
-        if (!s_factory) {
-            s_factory = new PDSSFactory;
-        }
-        return s_factory;
-    }
+    static PDSSFactory* factory();
 
     //! delete the static instance of this factory
-    virtual void deleteFactory() {
-        std::unique_lock<std::mutex> lock(thermo_mutex);
-        delete s_factory;
-        s_factory = 0;
-    }
+    virtual void deleteFactory();
 
     //! Create a new thermodynamic property manager.
     /*!

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -34,20 +34,10 @@ class ThermoFactory : public Factory<ThermoPhase>
 {
 public:
     //! Static function that creates a static instance of the factory.
-    static ThermoFactory* factory() {
-        std::unique_lock<std::mutex> lock(thermo_mutex);
-        if (!s_factory) {
-            s_factory = new ThermoFactory;
-        }
-        return s_factory;
-    }
+    static ThermoFactory* factory();
 
     //! delete the static instance of this factory
-    virtual void deleteFactory() {
-        std::unique_lock<std::mutex> lock(thermo_mutex);
-        delete s_factory;
-        s_factory = 0;
-    }
+    virtual void deleteFactory();
 
     //! Create a new thermodynamic property manager.
     /*!
@@ -69,21 +59,14 @@ private:
 };
 
 //! @copydoc ThermoFactory::newThermoPhase
-inline ThermoPhase* newThermoPhase(const std::string& model)
-{
-    return ThermoFactory::factory()->create(model);
-}
+ThermoPhase* newThermoPhase(const string& model);
 
 //! Create a new ThermoPhase instance.
 /*!
  * @param model   String to look up the model against
  * @returns a shared pointer to a new ThermoPhase instance matching the model string.
  */
-inline shared_ptr<ThermoPhase> newThermo(const std::string& model)
-{
-    ThermoPhase* tptr = ThermoFactory::factory()->create(model);
-    return shared_ptr<ThermoPhase> (tptr);
-}
+shared_ptr<ThermoPhase> newThermo(const string& model);
 
 //! Create a new ThermoPhase object and initialize it
 /*!

--- a/include/cantera/transport/TransportFactory.h
+++ b/include/cantera/transport/TransportFactory.h
@@ -42,13 +42,7 @@ public:
      * f = TransportFactory::factory();
      * @endcode
      */
-    static TransportFactory* factory() {
-        std::unique_lock<std::mutex> transportLock(transport_mutex);
-        if (!s_factory) {
-            s_factory = new TransportFactory();
-        }
-        return s_factory;
-    }
+    static TransportFactory* factory();
 
     //! Deletes the statically allocated factory instance.
     virtual void deleteFactory();
@@ -104,16 +98,7 @@ Transport* newTransportMgr(const std::string& model="", ThermoPhase* thermo=0,
  *  @returns a Transport object for the phase
  * @ingroup tranprops
  */
-inline shared_ptr<Transport> newTransport(ThermoPhase* thermo,
-                                          const std::string& model = "default") {
-    Transport* tr;
-    if (model == "default") {
-        tr = TransportFactory::factory()->newTransport(thermo, 0);
-    } else {
-        tr = TransportFactory::factory()->newTransport(model, thermo, 0);
-    }
-    return shared_ptr<Transport> (tr);
-}
+shared_ptr<Transport> newTransport(ThermoPhase* thermo, const string& model="default");
 
 //!  Create a new transport manager instance.
 /*!

--- a/include/cantera/zeroD/FlowDeviceFactory.h
+++ b/include/cantera/zeroD/FlowDeviceFactory.h
@@ -24,19 +24,9 @@ namespace Cantera
 class FlowDeviceFactory : public Factory<FlowDevice>
 {
 public:
-    static FlowDeviceFactory* factory() {
-        std::unique_lock<std::mutex> lock(flowDevice_mutex);
-        if (!s_factory) {
-            s_factory = new FlowDeviceFactory;
-        }
-        return s_factory;
-    }
+    static FlowDeviceFactory* factory();
 
-    virtual void deleteFactory() {
-        std::unique_lock<std::mutex> lock(flowDevice_mutex);
-        delete s_factory;
-        s_factory = 0;
-    }
+    virtual void deleteFactory();
 
     //! Create a new flow device by type name.
     /*!
@@ -52,10 +42,7 @@ private:
 
 //! Create a FlowDevice object of the specified type
 //! @ingroup ZeroD
-inline FlowDevice* newFlowDevice(const std::string& model)
-{
-    return FlowDeviceFactory::factory()->newFlowDevice(model);
-}
+FlowDevice* newFlowDevice(const string& model);
 
 }
 

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -24,19 +24,9 @@ namespace Cantera
 class ReactorFactory : public Factory<ReactorBase>
 {
 public:
-    static ReactorFactory* factory() {
-        std::unique_lock<std::mutex> lock(reactor_mutex);
-        if (!s_factory) {
-            s_factory = new ReactorFactory;
-        }
-        return s_factory;
-    }
+    static ReactorFactory* factory();
 
-    virtual void deleteFactory() {
-        std::unique_lock<std::mutex> lock(reactor_mutex);
-        delete s_factory;
-        s_factory = 0;
-    }
+    virtual void deleteFactory();
 
     //! Create a new reactor by type name.
     /*!
@@ -52,10 +42,7 @@ private:
 
 //! Create a Reactor object of the specified type
 //! @ingroup ZeroD
-inline ReactorBase* newReactor(const std::string& model)
-{
-    return ReactorFactory::factory()->newReactor(model);
-}
+ReactorBase* newReactor(const string& model);
 
 }
 

--- a/include/cantera/zeroD/WallFactory.h
+++ b/include/cantera/zeroD/WallFactory.h
@@ -24,19 +24,9 @@ namespace Cantera
 class WallFactory : public Factory<WallBase>
 {
 public:
-    static WallFactory* factory() {
-        std::unique_lock<std::mutex> lock(wall_mutex);
-        if (!s_factory) {
-            s_factory = new WallFactory;
-        }
-        return s_factory;
-    }
+    static WallFactory* factory();
 
-    virtual void deleteFactory() {
-        std::unique_lock<std::mutex> lock(wall_mutex);
-        delete s_factory;
-        s_factory = 0;
-    }
+    virtual void deleteFactory();
 
     //! Create a new wall by type name.
     /*!
@@ -52,10 +42,7 @@ private:
 
 //! Create a WallBase object of the specified type
 //! @ingroup ZeroD
-inline WallBase* newWall(const std::string& model)
-{
-    return WallFactory::factory()->newWall(model);
-}
+WallBase* newWall(const string& model);
 
 }
 

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -43,6 +43,7 @@ for pyxfile in multi_glob(localenv, "cantera", "pyx"):
     obj = localenv.SharedObject(
         f"#build/temp-py/{pyxfile.name.split('.')[0]}", cythonized)
     cython_obj.append(obj)
+cython_obj.extend(env['python_ext_objects'])
 
 module_ext = localenv["py_module_ext"]
 ext = localenv.LoadableModule(f"cantera/_cantera{module_ext}",

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -33,14 +33,21 @@ if env["coverage"]:
 # Build the Python module
 cython_obj = []
 for pyxfile in multi_glob(localenv, "cantera", "pyx"):
-    cythonized = localenv.Command(
+    if pyxfile.name == "_utils.pyx":
+        # Define GIT_COMMIT only in _utils.pyx to avoid unnecessary recompilations
+        cython_env = localenv.Clone()
+        cython_env.Append(CPPDEFINES={'GIT_COMMIT': '\\"{0}\\"'.format(env['git_commit'])})
+    else:
+        cython_env = localenv
+
+    cythonized = cython_env.Command(
          f"cantera/{pyxfile.name.replace('.pyx', '.cpp')}", pyxfile,
          f'''${{python_cmd}} -c "import Cython.Build; Cython.Build.cythonize(r'${{SOURCE}}', compiler_directives={directives!r})"'''
     )
-    for pxd in multi_glob(localenv, "cantera", "pxd"):
-        localenv.Depends(cythonized, pxd)
+    for pxd in multi_glob(cython_env, "cantera", "pxd"):
+        cython_env.Depends(cythonized, pxd)
 
-    obj = localenv.SharedObject(
+    obj = cython_env.SharedObject(
         f"#build/temp-py/{pyxfile.name.split('.')[0]}", cythonized)
     cython_obj.append(obj)
 cython_obj.extend(env['python_ext_objects'])

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -45,11 +45,6 @@ for pyxfile in multi_glob(localenv, "cantera", "pyx"):
     cython_obj.append(obj)
 cython_obj.extend(env['python_ext_objects'])
 
-if not env['system_fmt']:
-    # Workaround until we can figure out why all the necessary symbols aren't
-    # being exported from fmt
-    cython_obj.extend(localenv['fmt_targets'])
-
 module_ext = localenv["py_module_ext"]
 ext = localenv.LoadableModule(f"cantera/_cantera{module_ext}",
                               cython_obj, LIBPREFIX="", SHLIBSUFFIX=module_ext,

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -70,6 +70,19 @@ if env['OS'] == 'Windows':
     dll = [f for f in localenv['cantera_shlib'] if f.name.endswith('.dll')][0]
     copy_dll = localenv.Command(f'cantera/{dll.name}', dll, Copy("$TARGET", "$SOURCE"))
     localenv.Depends(ext, copy_dll)
+
+    # If compiling with MinGW, there are some system libraries that also seem
+    # to need to be installed alongside the Python extension -- elsewhere on the path
+    # does not appear to work.
+    if env['toolchain'] == 'mingw':
+        mingw_dir = Path(which(env.subst('$CXX'))).parent
+        prefixes = ['libgcc', 'libstdc++', 'libwinpthread']
+        for lib in mingw_dir.glob('*.dll'):
+            if any(lib.name.startswith(prefix) for prefix in prefixes):
+                copy_lib = localenv.Command(f'cantera/{lib.name}', str(lib),
+                                            Copy('$TARGET', '$SOURCE'))
+                localenv.Depends(mod, copy_lib)
+
 else:
     localenv.Depends(ext, localenv['cantera_shlib'])
 

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -45,6 +45,11 @@ for pyxfile in multi_glob(localenv, "cantera", "pyx"):
     cython_obj.append(obj)
 cython_obj.extend(env['python_ext_objects'])
 
+if not env['system_fmt']:
+    # Workaround until we can figure out why all the necessary symbols aren't
+    # being exported from fmt
+    cython_obj.extend(localenv['fmt_targets'])
+
 module_ext = localenv["py_module_ext"]
 ext = localenv.LoadableModule(f"cantera/_cantera{module_ext}",
                               cython_obj, LIBPREFIX="", SHLIBSUFFIX=module_ext,
@@ -62,7 +67,16 @@ env['python_extension'] = ext
 localenv.Depends(mod, [ext, dataFiles, setup_cfg, readme, license,
                        "setup.py", "pyproject.toml",
                        "cantera/test/README.txt", "cantera/examples/README.txt"])
-localenv.Depends(ext, localenv['cantera_staticlib'])
+
+if env['OS'] == 'Windows':
+    # On Windows, the cantera library directory is likely not to be on the path.
+    # However, Windows does search the directory containing a library (i.e. the
+    # Python extension module) for DLL dependencies.
+    dll = [f for f in localenv['cantera_shlib'] if f.name.endswith('.dll')][0]
+    copy_dll = localenv.Command(f'cantera/{dll.name}', dll, Copy("$TARGET", "$SOURCE"))
+    localenv.Depends(ext, copy_dll)
+else:
+    localenv.Depends(ext, localenv['cantera_shlib'])
 
 for f in (multi_glob(localenv, 'cantera', 'py') +
           multi_glob(localenv, 'cantera/*', 'py')):

--- a/interfaces/cython/cantera/_cantera.pyx
+++ b/interfaces/cython/cantera/_cantera.pyx
@@ -30,8 +30,8 @@ def bootstrap_cython_submodules():
 bootstrap_cython_submodules()
 
 # Import the contents of the individual .pyx files
-from ._onedim import *
 from ._utils import *
+from ._onedim import *
 from .solutionbase import *
 from .delegator import *
 from .func1 import *

--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -72,12 +72,14 @@ cdef extern from "cantera/base/global.h" namespace "Cantera":
     cdef void Cxx_suppress_thermo_warnings "Cantera::suppress_thermo_warnings" (cbool)
     cdef void Cxx_use_legacy_rate_constants "Cantera::use_legacy_rate_constants" (cbool)
     cdef string CxxGitCommit "Cantera::gitCommit" ()
+    cdef string CxxVersion "Cantera::version" ()
     cdef cbool CxxUsesHDF5 "Cantera::usesHDF5" ()
     cdef cbool CxxDebugModeEnabled "Cantera::debugModeEnabled" ()
 
 
 cdef extern from "cantera/cython/utils_utils.h":
-    cdef string get_cantera_version()
+    cdef string get_cantera_version_py()
+    cdef string get_cantera_git_commit_py()
     cdef int get_sundials_version()
     cdef cppclass CxxPythonLogger "PythonLogger":
         pass

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -49,9 +49,19 @@ def get_data_directories():
 
 __sundials_version__ = '.'.join(str(get_sundials_version()))
 
-__version__ = pystr(get_cantera_version())
+__version__ = pystr(CxxVersion())
+
+if __version__ != pystr(get_cantera_version_py()):
+    raise ImportError("Mismatch betweeen Cantera Python module version "
+        f"({pystr(get_cantera_version_py())}) and Cantera shared library "
+        f"version ({__version__})")
 
 __git_commit__ = pystr(CxxGitCommit())
+
+if __git_commit__ != pystr(get_cantera_git_commit_py()):
+    raise ImportError("Mismatch betweeen Cantera Python module Git commit "
+        f"({pystr(get_cantera_git_commit_py())}) and Cantera shared library "
+        f"git commit ({__git_commit__})")
 
 _USE_SPARSE = False
 

--- a/interfaces/cython/cantera/delegator.pxd
+++ b/interfaces/cython/cantera/delegator.pxd
@@ -62,12 +62,18 @@ cdef extern from "cantera/cython/funcWrapper.h":
     cdef function[int(size_t&, const string&)] pyOverride(
         PyObject*, int(PyFuncInfo&, size_t&, const string&))
 
-cdef extern from "cantera/extensions/PythonExtensionManager.h" namespace "Cantera":
-    cdef cppclass CxxPythonExtensionManager "Cantera::PythonExtensionManager":
+cdef extern from "cantera/base/ExtensionManager.h" namespace "Cantera":
+    cdef cppclass CxxExtensionManager "Cantera::ExtensionManager":
+        void registerRateBuilder(string&, string&, string&) except +translate_exception
+        void registerRateDataBuilder(string&, string&, string&) except +translate_exception
+
+        shared_ptr[CxxExtensionManager] build(string&)
+
+cdef extern from "cantera/base/ExtensionManagerFactory.h" namespace "Cantera":
+    cdef cppclass CxxExtensionManagerFactory "Cantera::ExtensionManagerFactory":
         @staticmethod
-        void registerPythonRateBuilder(string&, string&, string&) except +translate_exception
-        @staticmethod
-        void registerPythonRateDataBuilder(string&, string&, string&) except +translate_exception
+        shared_ptr[CxxExtensionManager] build(string&)
+
 
 ctypedef CxxDelegator* CxxDelegatorPtr
 

--- a/interfaces/cython/cantera/delegator.pxd
+++ b/interfaces/cython/cantera/delegator.pxd
@@ -69,6 +69,12 @@ cdef extern from "cantera/base/ExtensionManager.h" namespace "Cantera":
 
         shared_ptr[CxxExtensionManager] build(string&)
 
+cdef extern from "cantera/extensions/PythonExtensionManager.h" namespace "Cantera":
+    cdef cppclass CxxPythonExtensionManager "Cantera::PythonExtensionManager" (CxxExtensionManager):
+        @staticmethod
+        void registerSelf()
+
+
 cdef extern from "cantera/base/ExtensionManagerFactory.h" namespace "Cantera":
     cdef cppclass CxxExtensionManagerFactory "Cantera::ExtensionManagerFactory":
         @staticmethod

--- a/interfaces/cython/cantera/delegator.pyx
+++ b/interfaces/cython/cantera/delegator.pyx
@@ -345,6 +345,8 @@ cdef int assign_delegates(obj, CxxDelegator* delegator) except -1:
 _rate_delegators = []
 _rate_data_delegators = []
 
+CxxPythonExtensionManager.registerSelf()
+
 def extension(*, name, data=None):
     """
     A decorator for declaring Cantera extensions that should be registered with

--- a/interfaces/cython/cantera/delegator.pyx
+++ b/interfaces/cython/cantera/delegator.pyx
@@ -392,11 +392,14 @@ def extension(*, name, data=None):
     .. versionadded:: 3.0
     """
     def decorator(cls):
+        cdef shared_ptr[CxxExtensionManager] mgr = (
+            CxxExtensionManagerFactory.build(stringify("python")))
+
         if issubclass(cls, ExtensibleRate):
             cls._reaction_rate_type = name
             # Registering immediately supports the case where the main
             # application is Python
-            CxxPythonExtensionManager.registerPythonRateBuilder(
+            mgr.get().registerRateBuilder(
                 stringify(cls.__module__), stringify(cls.__name__), stringify(name))
 
             # Deferred registration supports the case where the main application
@@ -406,7 +409,7 @@ def extension(*, name, data=None):
             # Register the ReactionData delegator
             if not issubclass(data, ExtensibleRateData):
                 raise ValueError("'data' must inherit from 'ExtensibleRateData'")
-            CxxPythonExtensionManager.registerPythonRateDataBuilder(
+            mgr.get().registerRateDataBuilder(
                 stringify(data.__module__), stringify(data.__name__), stringify(name))
             _rate_data_delegators.append((data.__module__, data.__name__, name))
         else:

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -51,7 +51,7 @@ packages =
 # The module extension needs to be here since we don't want setuptools to compile
 # the extension, so there are no ``source`` files in the setup.py ``extension`` and
 # we have to treat the module as package data.
-cantera = *.pxd, *@py_module_ext@, test/*.txt, examples/*.txt, data/*.*
+cantera = *.pxd, *.dll, *@py_module_ext@, test/*.txt, examples/*.txt, data/*.*
 
 [options.extras_require]
 hdf5 = h5py

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -40,7 +40,7 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
         localenv.Append(
             LINKFLAGS=env.subst("${RPATHPREFIX}${ct_libdir}${RPATHSUFFIX}"))
 
-    localenv.Append(LIBS=env['cantera_libs'])
+    localenv.Append(LIBS=env['cantera_shared_libs'])
     localenv.Prepend(CPPPATH=['#include'])
 
     if openmp and not env['HAS_OPENMP']:

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1285,7 +1285,7 @@ def setup_python_env(env):
     plat = info['plat'].replace('-', '_').replace('.', '_')
     numpy_include = info["numpy_include"]
     env.Prepend(CPPPATH=[Dir('#include'), inc, numpy_include])
-    env.Prepend(LIBS=env['cantera_libs'])
+    env.Prepend(LIBS=env['cantera_shared_libs'])
 
     # Fix the module extension for Windows from the sysconfig library.
     # See https://github.com/python/cpython/pull/22088 and

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1139,15 +1139,15 @@ def multi_glob(env: "SCEnvironment", subdir: str, *args: str):
     return matches
 
 
-def which(program: str) -> bool:
+def which(program: str) -> "Optional[str]":
     """Replicates the functionality of the 'which' shell command."""
     for ext in ("", ".exe", ".bat"):
         fpath = Path(program + ext)
         for path in os.environ["PATH"].split(os.pathsep):
             exe_file = Path(path).joinpath(fpath)
             if exe_file.exists() and os.access(exe_file, os.X_OK):
-                return True
-    return False
+                return str(exe_file)
+    return None
 
 
 def listify(value: "Union[str, Iterable]") -> "List[str]":

--- a/src/SConscript
+++ b/src/SConscript
@@ -83,10 +83,9 @@ if env["python_package"] == "full":
          ('''${python_cmd} -c "import Cython.Build; '''
           f'''Cython.Build.cythonize(r'${{SOURCE}}', build_dir='{build_dir}')"''')
     )
-    for pxd in multi_glob(localenv, "#interfaces/cython/cantera", "pxd"):
+    for pxd in multi_glob(pyenv, "#interfaces/cython/cantera", "pxd"):
         localenv.Depends(cythonized, pxd)
 
-    obj = pyenv.SharedObject(cythonized[0])
     if env["OS"] == "Windows":
         escaped_home = '\\"' + pyenv["py_base"].replace("\\", "\\\\") + '\\"'
         pyenv.Append(CPPDEFINES={"CT_PYTHONHOME": escaped_home})
@@ -95,12 +94,23 @@ if env["python_package"] == "full":
 
     env.Command('#src/extensions/pythonExtensions.h', '#build/src/extensions/pythonExtensions.h',
                 Copy('$TARGET', '$SOURCE'))
-    libraryTargets.append(obj)
-    libraryTargets.append(pyenv.SharedObject("extensions/PythonExtensionManager.cpp"))
-    localenv.Append(LIBS=pyenv["py_libs"], LIBPATH=pyenv["py_libpath"])
-    env["cantera_libs"].extend(pyenv["py_libs"])
-    env.Append(LIBPATH=pyenv["py_libpath"])
-    env["extra_lib_dirs"].extend(pyenv["py_libpath"])
+
+    env['python_ext_objects'] = [
+        pyenv.SharedObject(cythonized[0]),
+        pyenv.SharedObject("extensions/PythonExtensionManager.cpp")
+    ]
+    pyenv.Append(LIBS=pyenv["py_libs"], LIBPATH=pyenv["py_libpath"])
+    if pyenv["versioned_shared_library"]:
+        lib = build(pyenv.SharedLibrary("../lib/cantera_python", env['python_ext_objects'],
+                                           SPAWN=get_spawn(pyenv),
+                                           SHLIBVERSION=pyenv["cantera_pure_version"]))
+        install(pyenv.InstallVersionedLib, "$inst_libdir", lib)
+    else:
+        lib = build(pyenv.SharedLibrary("../lib/cantera_python", env['python_ext_objects'],
+                                           SPAWN=get_spawn(pyenv)))
+        install("$inst_libdir", lib)
+
+
 
 # build the Cantera static library
 lib = build(localenv.StaticLibrary('../lib/cantera', libraryTargets,

--- a/src/SConscript
+++ b/src/SConscript
@@ -112,12 +112,46 @@ env['cantera_staticlib'] = lib
 localenv.Append(LIBS=localenv['external_libs'],
                 LIBPATH=localenv['sundials_libdir'] + localenv['blas_lapack_dir'])
 
+def create_def_file(target, source, env):
+    # Adapted from https://stackoverflow.com/a/58958294
+    startPoint = False
+    # Exclude standard API like sprintf to avoid multiple definition link error
+    excluded_functions = {'sprintf', 'snprintf', 'sscanf', 'fprintf'}
+
+    func_count = 0
+    with open(target[0].abspath, 'w') as outfile, open(source[0].abspath, 'r') as infile:
+        outfile.write('EXPORTS\n')
+
+        for l in infile:
+            l_str = l.strip()
+            if startPoint and l_str == 'Summary': # end point
+                break
+            if not startPoint and "public symbols" in l_str:
+                startPoint = True
+                continue
+            if startPoint and l_str:
+                funcName = l_str.split(' ')[-1]
+                if funcName not in excluded_functions:
+                    func_count += 1
+                    outfile.write("    " + funcName + "\n")
+
+    logger.info(f"Exported {func_count} functions in .def file")
+
 # Build the Cantera shared library
 if localenv['layout'] != 'debian':
     if localenv['renamed_shared_libraries']:
         sharedName = '../lib/cantera_shared'
     else:
         sharedName = '../lib/cantera'
+
+    if env['CC'] == 'cl':
+        # For MSVC, use the static library to create a .def file listing all
+        # symbols to export in the shared library.
+        dump = localenv.Command('cantera.dump', lib,
+                                'dumpbin /LINKERMEMBER:1 $SOURCE /OUT:$TARGET')
+        def_file = localenv.Command('cantera_shared.def', dump, create_def_file)
+        localenv.Append(LINKFLAGS=['/DEF:build/src/cantera_shared.def',
+                                   '/IGNORE:4102'])
 
     if localenv['versioned_shared_library']:
         lib = build(localenv.SharedLibrary(sharedName, libraryTargets,
@@ -132,6 +166,8 @@ if localenv['layout'] != 'debian':
     if env["OS"] == "Darwin":
         localenv.AddPostAction(lib,
             Action(f"install_name_tool -id @rpath/{lib[0].name} {lib[0].get_abspath()}"))
+    elif env["CC"] == "cl":
+        env.Depends(lib, def_file)
 
     env['cantera_shlib'] = lib
     localenv.Depends(lib, localenv['config_h_target'])

--- a/src/SConscript
+++ b/src/SConscript
@@ -101,13 +101,14 @@ if env["python_package"] == "full":
         pyenv.SharedObject("extensions/PythonExtensionManager.cpp")
     ]
     pyenv.Append(LIBS=pyenv["py_libs"], LIBPATH=pyenv["py_libpath"])
+    pylibname = f"../lib/cantera_python{pyenv['py_version_short'].replace('.', '_')}"
     if pyenv["versioned_shared_library"]:
-        lib = build(pyenv.SharedLibrary("../lib/cantera_python", env['python_ext_objects'],
+        lib = build(pyenv.SharedLibrary(pylibname, env['python_ext_objects'],
                                            SPAWN=get_spawn(pyenv),
                                            SHLIBVERSION=pyenv["cantera_pure_version"]))
         install(pyenv.InstallVersionedLib, "$inst_libdir", lib)
     else:
-        lib = build(pyenv.SharedLibrary("../lib/cantera_python", env['python_ext_objects'],
+        lib = build(pyenv.SharedLibrary(pylibname, env['python_ext_objects'],
                                            SPAWN=get_spawn(pyenv)))
         install("$inst_libdir", lib)
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -41,6 +41,7 @@ libs = [('base', ['cpp'], baseSetup),
 localenv = env.Clone()
 localenv.Prepend(CPPPATH=[Dir('#include'), Dir('#include/cantera/ext'), Dir('.')])
 localenv.Append(CCFLAGS=env['warning_flags'])
+indicatorEnv = localenv.Clone()  # Get this before any of the PCH complications
 
 if env['CC'] == 'cl' and env['debug']:
     env['use_pch'] = False # PCH doesn't work with per-file PDB
@@ -113,7 +114,8 @@ if env["python_package"] == "full":
 
 
 # build the Cantera static library
-lib = build(localenv.StaticLibrary('../lib/cantera', libraryTargets,
+staticIndicator = indicatorEnv.SharedObject('extensions/canteraStatic.cpp')
+lib = build(localenv.StaticLibrary('../lib/cantera', libraryTargets + staticIndicator,
                                    SPAWN=get_spawn(localenv)))
 localenv.Depends(lib, localenv['config_h_target'])
 install('$inst_libdir', lib)
@@ -154,6 +156,8 @@ if localenv['layout'] != 'debian':
     else:
         sharedName = '../lib/cantera'
 
+    sharedIndicator = indicatorEnv.SharedObject('extensions/canteraShared.cpp')
+
     if env['CC'] == 'cl':
         # For MSVC, use the static library to create a .def file listing all
         # symbols to export in the shared library.
@@ -164,12 +168,12 @@ if localenv['layout'] != 'debian':
                                    '/IGNORE:4102'])
 
     if localenv['versioned_shared_library']:
-        lib = build(localenv.SharedLibrary(sharedName, libraryTargets,
+        lib = build(localenv.SharedLibrary(sharedName, libraryTargets + sharedIndicator,
                                            SPAWN=get_spawn(localenv),
                                            SHLIBVERSION=localenv['cantera_pure_version']))
         install(localenv.InstallVersionedLib, '$inst_libdir', lib)
     else:
-        lib = build(localenv.SharedLibrary(sharedName, libraryTargets,
+        lib = build(localenv.SharedLibrary(sharedName, libraryTargets + sharedIndicator,
                                            SPAWN=get_spawn(localenv)))
         install('$inst_libdir', lib)
 

--- a/src/SConscript
+++ b/src/SConscript
@@ -1,5 +1,6 @@
 from buildutils import *
 from pathlib import Path
+import re
 
 Import('env', 'build', 'install', 'libraryTargets')
 
@@ -128,10 +129,23 @@ localenv.Append(LIBS=localenv['external_libs'],
 def create_def_file(target, source, env):
     # Adapted from https://stackoverflow.com/a/58958294
     startPoint = False
-    # Exclude standard API like sprintf to avoid multiple definition link error
-    excluded_functions = {'sprintf', 'snprintf', 'sscanf', 'fprintf'}
+    # Avoid exporting some unnecessary symbols
+    exclusions = [
+        lambda name: name.startswith(('??_G', '??_E')), # deleting destructors; generate warning LNK4102
+        lambda name: name.startswith(('??_C', '__real@', '__xmm')), # various constants
+        lambda name: name.startswith(('??$forward', '??$addressof', '??$construct', '??$destroy')),
+        lambda name: name.startswith(('SUN', 'N_V', 'CV', 'cv', 'IDA', 'ida')), # Sundials
+        lambda name: '<lambda_' in name, # lambdas
+        lambda name: '@boost@' in name,
+        lambda name: ('@Eigen@' in name or '@YAML@' in name) and 'Cantera' not in name,
+        lambda name: '$vector@' in name and 'Cantera' not in name,
+        lambda name: 'char_traits' in name and 'Cantera' not in name and 'fmt' not in name,
+        lambda name: '_Tree' in name or '$_Hash' in name, # standard library internals
+        lambda name: re.match(r'[\?$]+_[A-Z][a-z_]+@', name), # standard library methods
+    ]
 
     func_count = 0
+    include_count = 0
     with open(target[0].abspath, 'w') as outfile, open(source[0].abspath, 'r') as infile:
         outfile.write('EXPORTS\n')
 
@@ -142,13 +156,14 @@ def create_def_file(target, source, env):
             if not startPoint and "public symbols" in l_str:
                 startPoint = True
                 continue
+            func_count += 1
             if startPoint and l_str:
                 funcName = l_str.split(' ')[-1]
-                if funcName not in excluded_functions:
-                    func_count += 1
+                if not any(test(funcName) for test in exclusions):
+                    include_count += 1
                     outfile.write("    " + funcName + "\n")
 
-    logger.info(f"Exported {func_count} functions in .def file")
+    logger.info(f"Exported {include_count} out of {func_count} functions in .def file")
 
 # Build the Cantera shared library
 if localenv['layout'] != 'debian':
@@ -165,8 +180,7 @@ if localenv['layout'] != 'debian':
         dump = localenv.Command('cantera.dump', lib,
                                 'dumpbin /LINKERMEMBER:1 $SOURCE /OUT:$TARGET')
         def_file = localenv.Command('cantera_shared.def', dump, create_def_file)
-        localenv.Append(LINKFLAGS=['/DEF:build/src/cantera_shared.def',
-                                   '/IGNORE:4102'])
+        localenv.Append(LINKFLAGS=['/DEF:build/src/cantera_shared.def'])
 
     if localenv['versioned_shared_library']:
         lib = build(localenv.SharedLibrary(sharedName, libraryTargets + sharedIndicator,

--- a/src/base/ExtensionManagerFactory.cpp
+++ b/src/base/ExtensionManagerFactory.cpp
@@ -5,10 +5,6 @@
 
 #include "cantera/base/ExtensionManagerFactory.h"
 
-#ifdef CT_HAS_PYTHON
-#include "cantera/extensions/PythonExtensionManager.h"
-#endif
-
 using namespace std;
 
 namespace Cantera
@@ -19,9 +15,6 @@ mutex ExtensionManagerFactory::s_mutex;
 
 ExtensionManagerFactory::ExtensionManagerFactory()
 {
-    #ifdef CT_HAS_PYTHON
-    reg("python", []() { return new PythonExtensionManager(); });
-    #endif
 }
 
 ExtensionManagerFactory& ExtensionManagerFactory::factory()

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -402,6 +402,11 @@ std::string Application::findInputFile(const std::string& name)
 
 void Application::loadExtension(const string& extType, const string& name)
 {
+    if (!usingSharedLibrary()) {
+        throw CanteraError("Application::loadExtension",
+            "Loading extensions requires linking to the Cantera shared library\n"
+            "rather than the static library");
+    }
     if (m_loaded_extensions.count({extType, name})) {
         return;
     }

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -286,12 +286,18 @@ public:
     //! Load an extension implementing user-defined models
     //! @param extType Specifies the interface / language of the extension, for example
     //!     "python"
-    //! @param extName Specifies the name of the extension. The meaning of this
+    //! @param name Specifies the name of the extension. The meaning of this
     //!     parameter depends on the specific extension interface. For example, for
     //!     Python extensions, this is the name of the Python module containing the
     //!     models.
     //! @since New in Cantera 3.0
     void loadExtension(const std::string& extType, const std::string& name);
+
+    //! Set the versions of Python to try when loading user-defined extensions,
+    //! in order of preference. Separate multiple versions with commas, for example
+    //! `"3.11,3.10"`.
+    //! @since New in Cantera 3.0
+    void searchPythonVersions(const string& versions);
 
 #ifdef _WIN32
     long int readStringRegistryKey(const std::string& keyName, const std::string& valueName,
@@ -431,6 +437,9 @@ protected:
 
     //! Current vector of input directories to search for input files
     std::vector<std::string> inputDirs;
+
+    //! Versions of Python to consider when attempting to load user extensions
+    vector<string> m_pythonSearchVersions = {"3.11", "3.10", "3.9", "3.8"};
 
     //! Vector of deprecation warnings that have been emitted (to suppress
     //! duplicates)

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -122,6 +122,11 @@ void thread_complete()
     app()->thread_complete();
 }
 
+string version()
+{
+    return CANTERA_VERSION;
+}
+
 std::string gitCommit()
 {
 #ifdef GIT_COMMIT

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -166,6 +166,10 @@ void loadExtensions(const AnyMap& node)
     }
 }
 
+void searchPythonVersions(const string& versions) {
+    app()->searchPythonVersions(versions);
+}
+
 bool debugModeEnabled()
 {
 #ifdef NDEBUG

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -11,7 +11,6 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#define CANTERA_USE_INTERNAL
 #include "cantera/clib/ct.h"
 
 // Cantera includes

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -5,7 +5,6 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctfunc.h"
 
 #include "cantera/numerics/Func1.h"

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -5,7 +5,6 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctmultiphase.h"
 
 // Cantera includes

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -5,7 +5,6 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctonedim.h"
 
 // Cantera includes

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -6,7 +6,6 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #define CANTERA_USE_INTERNAL
-
 #include "cantera/clib/ctonedim.h"
 
 // Cantera includes

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -5,7 +5,6 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctreactor.h"
 
 // Cantera includes

--- a/src/clib/ctrpath.cpp
+++ b/src/clib/ctrpath.cpp
@@ -5,7 +5,6 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctrpath.h"
 
 // Cantera includes

--- a/src/clib/ctsurf.cpp
+++ b/src/clib/ctsurf.cpp
@@ -6,7 +6,6 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 // clib header information
-#define CANTERA_USE_INTERNAL
 #include "cantera/clib/ctsurf.h"
 
 // Cantera includes

--- a/src/extensions/PythonExtensionManager.cpp
+++ b/src/extensions/PythonExtensionManager.cpp
@@ -20,6 +20,16 @@
 #include <windows.h>
 #endif
 
+#define BOOST_DLL_USE_STD_FS
+#ifdef __MINGW32__
+#define BOOST_DLL_FORCE_ALIAS_INSTANTIATION
+#endif
+#include <boost/dll/alias.hpp>
+
+// This creates and exports the name that is imported from Application::loadExtension
+BOOST_DLL_ALIAS(Cantera::PythonExtensionManager::registerSelf,
+                registerPythonExtensionManager);
+
 namespace ba = boost::algorithm;
 using namespace std;
 

--- a/src/extensions/PythonExtensionManager.cpp
+++ b/src/extensions/PythonExtensionManager.cpp
@@ -5,6 +5,7 @@
 
 #include "cantera/extensions/PythonExtensionManager.h"
 #include "cantera/extensions/PythonHandle.h"
+#include "cantera/base/ExtensionManagerFactory.h"
 
 #include "cantera/kinetics/ReactionRateFactory.h"
 #include "cantera/kinetics/ReactionRateDelegator.h"
@@ -152,6 +153,12 @@ PythonExtensionManager::PythonExtensionManager()
     Py_DECREF(spec);
     Py_DECREF(pyModule);
     s_imported = true;
+}
+
+void PythonExtensionManager::registerSelf()
+{
+    ExtensionManagerFactory::factory().reg("python",
+        []() { return new PythonExtensionManager(); });
 }
 
 void PythonExtensionManager::registerRateBuilders(const string& extensionName)

--- a/src/extensions/PythonExtensionManager.cpp
+++ b/src/extensions/PythonExtensionManager.cpp
@@ -157,7 +157,7 @@ PythonExtensionManager::PythonExtensionManager()
 void PythonExtensionManager::registerRateBuilders(const string& extensionName)
 {
     // Each rate builder class is decorated with @extension, which calls the
-    // registerPythonRateBuilder method to register that class. So all we have
+    // registerRateBuilder method to register that class. So all we have
     // to do here is load the module.
     PyObject* module_name = PyUnicode_FromString(extensionName.c_str());
     PyObject* py_module = PyImport_Import(module_name);
@@ -169,7 +169,7 @@ void PythonExtensionManager::registerRateBuilders(const string& extensionName)
     ct_registerReactionDelegators();
 }
 
-void PythonExtensionManager::registerPythonRateBuilder(
+void PythonExtensionManager::registerRateBuilder(
     const std::string& moduleName, const std::string& className,
     const std::string& rateName)
 {
@@ -198,12 +198,11 @@ void PythonExtensionManager::registerPythonRateBuilder(
     ReactionRateFactory::factory()->reg(rateName, builder);
 }
 
-void PythonExtensionManager::registerPythonRateDataBuilder(
+void PythonExtensionManager::registerRateDataBuilder(
     const string& moduleName, const string& className, const string& rateName)
 {
     // Make sure the helper module has been loaded
     PythonExtensionManager mgr;
-
     // Create a function that links a C++ ReactionDataDelegator
     // object and a Python ExtensibleRateData object of a particular type, and register
     // this function for making that link
@@ -218,7 +217,7 @@ void PythonExtensionManager::registerPythonRateDataBuilder(
         }
         delegator.setWrapper(make_shared<PythonHandle>(extData, false));
     };
-    ExtensionManager::registerReactionDataLinker(rateName, builder);
+    mgr.registerReactionDataLinker(rateName, builder);
 
     // Create a function that will link a Python Solution object to the C++ Solution
     // object that gets passed to the Reaction
@@ -231,7 +230,7 @@ void PythonExtensionManager::registerPythonRateDataBuilder(
         }
         return make_shared<PythonHandle>(pySoln, false);
     };
-    ExtensionManager::registerSolutionLinker("python", solnLinker);
+    mgr.registerSolutionLinker("python", solnLinker);
 }
 
 };

--- a/src/extensions/canteraShared.cpp
+++ b/src/extensions/canteraShared.cpp
@@ -1,0 +1,18 @@
+//! @file canteraShared.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/base/ct_defs.h"
+
+namespace Cantera
+{
+
+bool usingSharedLibrary()
+{
+    // This implementation of usingSharedLibrary is compiled and embedded
+    // only in the Cantera shared library
+    return true;
+}
+
+}

--- a/src/extensions/canteraStatic.cpp
+++ b/src/extensions/canteraStatic.cpp
@@ -1,0 +1,18 @@
+//! @file canteraStatic.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/base/ct_defs.h"
+
+namespace Cantera
+{
+
+bool usingSharedLibrary()
+{
+    // This implementation of usingSharedLibrary is compiled and embedded
+    // only in the Cantera static library
+    return false;
+}
+
+}

--- a/src/kinetics/Arrhenius.cpp
+++ b/src/kinetics/Arrhenius.cpp
@@ -20,6 +20,17 @@ ArrheniusBase::ArrheniusBase(double A, double b, double Ea)
     m_valid = true;
 }
 
+ArrheniusBase::ArrheniusBase(const AnyValue& rate, const UnitSystem& units,
+                             const UnitStack& rate_units)
+{
+    setRateParameters(rate, units, rate_units);
+}
+
+ArrheniusBase::ArrheniusBase(const AnyMap& node, const UnitStack& rate_units)
+{
+    setParameters(node, rate_units);
+}
+
 void ArrheniusBase::setRateParameters(
     const AnyValue& rate, const UnitSystem& units, const UnitStack& rate_units)
 {

--- a/src/kinetics/BlowersMaselRate.cpp
+++ b/src/kinetics/BlowersMaselRate.cpp
@@ -59,6 +59,12 @@ BlowersMaselRate::BlowersMaselRate(double A, double b, double Ea0, double w)
     m_E4_R = w / GasConstant;
 }
 
+BlowersMaselRate::BlowersMaselRate(const AnyMap& node, const UnitStack& rate_units)
+    : BlowersMaselRate()
+{
+    setParameters(node, rate_units);
+}
+
 double BlowersMaselRate::ddTScaledFromStruct(const BlowersMaselData& shared_data) const
 {
     warn_user("BlowersMaselRate::ddTScaledFromStruct",

--- a/src/kinetics/ChebyshevRate.cpp
+++ b/src/kinetics/ChebyshevRate.cpp
@@ -54,6 +54,12 @@ ChebyshevRate::ChebyshevRate(double Tmin, double Tmax, double Pmin, double Pmax,
     setData(coeffs);
 }
 
+ChebyshevRate::ChebyshevRate(const AnyMap& node, const UnitStack& rate_units)
+    : ChebyshevRate()
+{
+    setParameters(node, rate_units);
+}
+
 void ChebyshevRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
 {
     ReactionRate::setParameters(node, rate_units);

--- a/src/kinetics/Custom.cpp
+++ b/src/kinetics/Custom.cpp
@@ -14,6 +14,12 @@ CustomFunc1Rate::CustomFunc1Rate()
 {
 }
 
+CustomFunc1Rate::CustomFunc1Rate(const AnyMap& node, const UnitStack& rate_units)
+    : CustomFunc1Rate()
+{
+    setParameters(node, rate_units);
+}
+
 void CustomFunc1Rate::setRateFunction(shared_ptr<Func1> f)
 {
     m_ratefunc = f;

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -82,6 +82,12 @@ void FalloffData::restore()
     m_perturbed = false;
 }
 
+FalloffRate::FalloffRate(const AnyMap& node, const UnitStack& rate_units)
+    : FalloffRate()
+{
+    setParameters(node, rate_units);
+}
+
 void FalloffRate::init(const vector_fp& c)
 {
     warn_deprecated("FalloffRate::init",
@@ -211,6 +217,36 @@ void FalloffRate::validate(const std::string& equation, const Kinetics& kin)
     }
 }
 
+LindemannRate::LindemannRate(const AnyMap& node, const UnitStack& rate_units)
+    : LindemannRate()
+{
+    setParameters(node, rate_units);
+}
+
+LindemannRate::LindemannRate(const ArrheniusRate& low, const ArrheniusRate& high,
+                             const vector_fp& c)
+    : LindemannRate()
+{
+    m_lowRate = low;
+    m_highRate = high;
+    setFalloffCoeffs(c);
+}
+
+TroeRate::TroeRate(const AnyMap& node, const UnitStack& rate_units)
+    : TroeRate()
+{
+    setParameters(node, rate_units);
+}
+
+TroeRate::TroeRate(const ArrheniusRate& low, const ArrheniusRate& high,
+                   const vector_fp& c)
+    : TroeRate()
+{
+    m_lowRate = low;
+    m_highRate = high;
+    setFalloffCoeffs(c);
+}
+
 void TroeRate::setFalloffCoeffs(const vector_fp& c)
 {
     if (c.size() != 3 && c.size() != 4) {
@@ -337,6 +373,12 @@ void TroeRate::getParameters(AnyMap& node) const
     node["Troe"] = std::move(params);
 }
 
+SriRate::SriRate(const AnyMap& node, const UnitStack& rate_units)
+    : SriRate()
+{
+    setParameters(node, rate_units);
+}
+
 void SriRate::setFalloffCoeffs(const vector_fp& c)
 {
     if (c.size() != 3 && c.size() != 5) {
@@ -459,6 +501,12 @@ void SriRate::getParameters(AnyMap& node) const
     }
     params.setFlowStyle();
     node["SRI"] = std::move(params);
+}
+
+TsangRate::TsangRate(const AnyMap& node, const UnitStack& rate_units)
+    : TsangRate()
+{
+    setParameters(node, rate_units);
 }
 
 void TsangRate::setFalloffCoeffs(const vector_fp& c)

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -35,9 +35,34 @@ KineticsFactory::KineticsFactory() {
     addAlias("edge", "Edge");
 }
 
+KineticsFactory* KineticsFactory::factory() {
+    std::unique_lock<std::mutex> lock(kinetics_mutex);
+    if (!s_factory) {
+        s_factory = new KineticsFactory;
+    }
+    return s_factory;
+}
+
+void KineticsFactory::deleteFactory() {
+    std::unique_lock<std::mutex> lock(kinetics_mutex);
+    delete s_factory;
+    s_factory = 0;
+}
+
 Kinetics* KineticsFactory::newKinetics(const string& model)
 {
     return create(toLowerCopy(model));
+}
+
+Kinetics* newKineticsMgr(const string& model)
+{
+    return KineticsFactory::factory()->newKinetics(model);
+}
+
+shared_ptr<Kinetics> newKinetics(const string& model)
+{
+    shared_ptr<Kinetics> kin(KineticsFactory::factory()->newKinetics(model));
+    return kin;
 }
 
 unique_ptr<Kinetics> newKinetics(const vector<ThermoPhase*>& phases,

--- a/src/kinetics/PlogRate.cpp
+++ b/src/kinetics/PlogRate.cpp
@@ -64,6 +64,12 @@ PlogRate::PlogRate(const std::multimap<double, ArrheniusRate>& rates)
     setRates(rates);
 }
 
+PlogRate::PlogRate(const AnyMap& node, const UnitStack& rate_units)
+    : PlogRate()
+{
+    setParameters(node, rate_units);
+}
+
 void PlogRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
 {
     ReactionRate::setParameters(node, rate_units);

--- a/src/kinetics/ReactionRateFactory.cpp
+++ b/src/kinetics/ReactionRateFactory.cpp
@@ -100,6 +100,20 @@ ReactionRateFactory::ReactionRateFactory()
     });
 }
 
+ReactionRateFactory* ReactionRateFactory::factory() {
+    std::unique_lock<std::mutex> lock(rate_mutex);
+    if (!s_factory) {
+        s_factory = new ReactionRateFactory();
+    }
+    return s_factory;
+}
+
+void ReactionRateFactory::deleteFactory() {
+    std::unique_lock<std::mutex> lock(rate_mutex);
+    delete s_factory;
+    s_factory = 0;
+}
+
 shared_ptr<ReactionRate> newReactionRate(const std::string& type)
 {
     return shared_ptr<ReactionRate> (

--- a/src/kinetics/TwoTempPlasmaRate.cpp
+++ b/src/kinetics/TwoTempPlasmaRate.cpp
@@ -59,6 +59,12 @@ TwoTempPlasmaRate::TwoTempPlasmaRate(double A, double b, double Ea, double EE)
     m_E4_R = EE / GasConstant;
 }
 
+TwoTempPlasmaRate::TwoTempPlasmaRate(const AnyMap& node, const UnitStack& rate_units)
+    : TwoTempPlasmaRate()
+{
+    setParameters(node, rate_units);
+}
+
 double TwoTempPlasmaRate::ddTScaledFromStruct(const TwoTempPlasmaData& shared_data) const
 {
     warn_user("TwoTempPlasmaRate::ddTScaledFromStruct",

--- a/src/numerics/PreconditionerFactory.cpp
+++ b/src/numerics/PreconditionerFactory.cpp
@@ -11,6 +11,21 @@ using namespace std;
 namespace Cantera
 {
 
+PreconditionerFactory* PreconditionerFactory::factory() {
+    std::unique_lock<std::mutex> lock(precon_mutex);
+    if (!s_factory) {
+        s_factory = new PreconditionerFactory;
+    }
+    return s_factory;
+};
+
+//! Delete preconditioner factory
+void PreconditionerFactory::deleteFactory() {
+    std::unique_lock<std::mutex> lock(precon_mutex);
+    delete s_factory;
+    s_factory = 0;
+};
+
 PreconditionerFactory* PreconditionerFactory::s_factory = 0;
 std::mutex PreconditionerFactory::precon_mutex;
 
@@ -18,5 +33,10 @@ PreconditionerFactory::PreconditionerFactory()
 {
     reg("Adaptive", []() { return new AdaptivePreconditioner(); });
 }
+
+shared_ptr<PreconditionerBase> newPreconditioner(const string& precon)
+{
+    return shared_ptr<PreconditionerBase>(PreconditionerFactory::factory()->create(precon));
+};
 
 }

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -96,6 +96,22 @@ Inlet1D::Inlet1D()
     m_xstr = "";
 }
 
+Inlet1D::Inlet1D(shared_ptr<Solution> solution, const string& id)
+    : Inlet1D()
+{
+    m_solution = solution;
+    m_id = id;
+}
+
+
+//! set spreading rate
+void Inlet1D::setSpreadRate(double V0)
+{
+    m_V0 = V0;
+    needJacUpdate();
+}
+
+
 void Inlet1D::showSolution(const double* x)
 {
     writelog("    Mass Flux:   {:10.4g} kg/m^2/s \n", m_mdot);
@@ -334,6 +350,13 @@ OutletRes1D::OutletRes1D()
 {
     m_type = cOutletResType;
     m_xstr = "";
+}
+
+OutletRes1D::OutletRes1D(shared_ptr<Solution> solution, const string& id)
+    : OutletRes1D()
+{
+    m_solution = solution;
+    m_id = id;
 }
 
 void Outlet1D::init()

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -240,6 +240,10 @@ void StFlow::setGasAtMidpoint(const doublereal* x, size_t j)
     m_thermo->setPressure(m_press);
 }
 
+bool StFlow::fixed_mdot() {
+    return (domainType() != cFreeFlow);
+}
+
 void StFlow::_finalize(const doublereal* x)
 {
     if (!m_do_multicomponent && m_do_soret) {
@@ -781,6 +785,16 @@ void StFlow::restore(SolutionArray& arr, double* soln, int loglevel)
 
     updateProperties(npos, soln + loc(), 0, m_points - 1);
     setMeta(arr.meta(), loglevel);
+}
+
+string StFlow::flowType() const {
+    if (m_type == cFreeFlow) {
+        return "Free Flame";
+    } else if (m_type == cAxisymmetricStagnationFlow) {
+        return "Axisymmetric Stagnation";
+    } else {
+        throw CanteraError("StFlow::flowType", "Unknown value for 'm_type'");
+    }
 }
 
 void StFlow::setMeta(const AnyMap& state, int loglevel)

--- a/src/pch/system.h
+++ b/src/pch/system.h
@@ -14,7 +14,5 @@
 #include <memory>
 
 #include <boost/algorithm/string.hpp>
-#include "cantera/base/fmt.h"
-#include "cantera/base/AnyMap.h"
 
 #endif

--- a/src/pch/system.h
+++ b/src/pch/system.h
@@ -9,9 +9,11 @@
 #include <cstdlib>
 #include <vector>
 #include <map>
+#include <set>
 #include <string>
 #include <algorithm>
 #include <memory>
+#include <functional>
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/thermo/PDSSFactory.cpp
+++ b/src/thermo/PDSSFactory.cpp
@@ -37,6 +37,20 @@ PDSSFactory::PDSSFactory()
     reg("HKFT", []() { return new PDSS_HKFT(); });
 }
 
+PDSSFactory* PDSSFactory::factory() {
+    std::unique_lock<std::mutex> lock(thermo_mutex);
+    if (!s_factory) {
+        s_factory = new PDSSFactory;
+    }
+    return s_factory;
+}
+
+void PDSSFactory::deleteFactory() {
+    std::unique_lock<std::mutex> lock(thermo_mutex);
+    delete s_factory;
+    s_factory = 0;
+}
+
 PDSS* PDSSFactory::newPDSS(const std::string& model)
 {
     return create(model);

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -106,6 +106,33 @@ ThermoFactory::ThermoFactory()
     reg("Peng-Robinson", []() { return new PengRobinson(); });
 }
 
+ThermoFactory* ThermoFactory::factory()
+{
+    std::unique_lock<std::mutex> lock(thermo_mutex);
+    if (!s_factory) {
+        s_factory = new ThermoFactory;
+    }
+    return s_factory;
+}
+
+void ThermoFactory::deleteFactory()
+{
+    std::unique_lock<std::mutex> lock(thermo_mutex);
+    delete s_factory;
+    s_factory = 0;
+}
+
+ThermoPhase* newThermoPhase(const string& model)
+{
+    return ThermoFactory::factory()->create(model);
+}
+
+shared_ptr<ThermoPhase> newThermo(const string& model)
+{
+    shared_ptr<ThermoPhase> tptr(ThermoFactory::factory()->create(model));
+    return tptr;
+}
+
 ThermoPhase* ThermoFactory::newThermoPhase(const std::string& model)
 {
     return create(model);

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -52,6 +52,14 @@ TransportFactory::TransportFactory()
     m_CK_mode["CK_Multi"] = m_CK_mode["multicomponent-CK"] = true;
 }
 
+TransportFactory* TransportFactory::factory() {
+    std::unique_lock<std::mutex> transportLock(transport_mutex);
+    if (!s_factory) {
+        s_factory = new TransportFactory();
+    }
+    return s_factory;
+}
+
 void TransportFactory::deleteFactory()
 {
     std::unique_lock<std::mutex> transportLock(transport_mutex);
@@ -104,6 +112,17 @@ Transport* newTransportMgr(const std::string& model, ThermoPhase* thermo, int lo
 {
     TransportFactory* f = TransportFactory::factory();
     return f->newTransport(model, thermo, log_level);
+}
+
+shared_ptr<Transport> newTransport(ThermoPhase* thermo, const string& model)
+{
+    Transport* tr;
+    if (model == "default") {
+        tr = TransportFactory::factory()->newTransport(thermo, 0);
+    } else {
+        tr = TransportFactory::factory()->newTransport(model, thermo, 0);
+    }
+    return shared_ptr<Transport>(tr);
 }
 
 Transport* newDefaultTransportMgr(ThermoPhase* thermo, int loglevel)

--- a/src/zeroD/FlowDeviceFactory.cpp
+++ b/src/zeroD/FlowDeviceFactory.cpp
@@ -20,9 +20,29 @@ FlowDeviceFactory::FlowDeviceFactory()
     reg("Valve", []() { return new Valve(); });
 }
 
+FlowDeviceFactory* FlowDeviceFactory::factory() {
+    std::unique_lock<std::mutex> lock(flowDevice_mutex);
+    if (!s_factory) {
+        s_factory = new FlowDeviceFactory;
+    }
+    return s_factory;
+}
+
+void FlowDeviceFactory::deleteFactory() {
+    std::unique_lock<std::mutex> lock(flowDevice_mutex);
+    delete s_factory;
+    s_factory = 0;
+}
+
+
 FlowDevice* FlowDeviceFactory::newFlowDevice(const std::string& flowDeviceType)
 {
     return create(flowDeviceType);
+}
+
+FlowDevice* newFlowDevice(const string& model)
+{
+    return FlowDeviceFactory::factory()->newFlowDevice(model);
 }
 
 }

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -55,9 +55,28 @@ ReactorFactory::ReactorFactory()
     reg("MoleReactor", []() { return new MoleReactor(); });
 }
 
+ReactorFactory* ReactorFactory::factory() {
+    std::unique_lock<std::mutex> lock(reactor_mutex);
+    if (!s_factory) {
+        s_factory = new ReactorFactory;
+    }
+    return s_factory;
+}
+
+void ReactorFactory::deleteFactory() {
+    std::unique_lock<std::mutex> lock(reactor_mutex);
+    delete s_factory;
+    s_factory = 0;
+}
+
 ReactorBase* ReactorFactory::newReactor(const std::string& reactorType)
 {
     return create(reactorType);
+}
+
+ReactorBase* newReactor(const string& model)
+{
+    return ReactorFactory::factory()->newReactor(model);
 }
 
 }

--- a/src/zeroD/WallFactory.cpp
+++ b/src/zeroD/WallFactory.cpp
@@ -18,9 +18,28 @@ WallFactory::WallFactory()
     reg("Wall", []() { return new Wall(); });
 }
 
+WallFactory* WallFactory::factory() {
+    std::unique_lock<std::mutex> lock(wall_mutex);
+    if (!s_factory) {
+        s_factory = new WallFactory;
+    }
+    return s_factory;
+}
+
+void WallFactory::deleteFactory() {
+    std::unique_lock<std::mutex> lock(wall_mutex);
+    delete s_factory;
+    s_factory = 0;
+}
+
 WallBase* WallFactory::newWall(const std::string& wallType)
 {
     return create(wallType);
+}
+
+WallBase* newWall(const string& model)
+{
+    return WallFactory::factory()->newWall(model);
 }
 
 }

--- a/test/SConscript
+++ b/test/SConscript
@@ -12,7 +12,7 @@ localenv = env.Clone()
 
 # Where possible, link tests against the shared libraries to minimize the sizes
 # of the resulting binaries.
-if localenv['OS'] == 'Linux':
+if localenv['OS'] == 'Linux' or localenv['OS'] == 'Darwin':
     cantera_libs = localenv['cantera_shared_libs']
 else:
     cantera_libs = localenv['cantera_libs']

--- a/test/SConscript
+++ b/test/SConscript
@@ -10,16 +10,9 @@ from buildutils import *
 Import('env','build','install')
 localenv = env.Clone()
 
-# Where possible, link tests against the shared libraries to minimize the sizes
-# of the resulting binaries.
-if localenv['OS'] == 'Linux' or localenv['OS'] == 'Darwin':
-    cantera_libs = localenv['cantera_shared_libs']
-else:
-    cantera_libs = localenv['cantera_libs']
-
 localenv.Prepend(CPPPATH=['#include'],
                  LIBPATH='#build/lib')
-localenv.Append(LIBS=cantera_libs,
+localenv.Append(LIBS=localenv['cantera_shared_libs'],
                 CCFLAGS=env['warning_flags'])
 
 if env['googletest'] == 'submodule':

--- a/test/SConscript
+++ b/test/SConscript
@@ -37,14 +37,6 @@ localenv.PrependENVPath('PYTHONPATH', Dir('#test/python').abspath)
 
 PASSED_FILES = {}
 
-# Add build/lib in order to find Cantera shared library
-if env["OS"] == "Windows":
-    localenv.PrependENVPath('PATH', Dir('#build/lib').abspath)
-elif env['OS'] == 'Darwin':
-    localenv.PrependENVPath('DYLD_LIBRARY_PATH', Dir('#build/lib').abspath)
-else:
-    localenv.PrependENVPath('LD_LIBRARY_PATH', Dir('#build/lib').abspath)
-
 def addTestProgram(subdir, progName, env_vars={}):
     """
     Compile a test program and create a targets for running

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -14,13 +14,6 @@ for optimize_flag in ('-O3', '-O2', '/O2'):
         ccflags.remove(optimize_flag)
 localenv['CCFLAGS'] = ccflags
 
-# Where possible, link tests against the shared libraries to minimize the sizes
-# of the resulting binaries.
-if localenv['OS'] == 'Linux':
-    cantera_libs = localenv['cantera_shared_libs']
-else:
-    cantera_libs = localenv['cantera_libs']
-
 localenv['ENV']['CANTERA_DATA'] = (Dir('#build/data').abspath + os.pathsep +
                                    Dir('#samples/data').abspath + os.pathsep +
                                    Dir('#test/data').abspath)
@@ -70,7 +63,7 @@ class Test(object):
         if source_files:
             self.program = localenv.Program(
                 pjoin(self.subdir, self.programName), source_files,
-                LIBS=self.libs or cantera_libs)
+                LIBS=self.libs or localenv['cantera_shared_libs'])
         else:
             if isinstance(self.programName, str):
                 self.programName += '$PROGSUFFIX'

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -18,15 +18,6 @@ localenv['ENV']['CANTERA_DATA'] = (Dir('#build/data').abspath + os.pathsep +
                                    Dir('#samples/data').abspath + os.pathsep +
                                    Dir('#test/data').abspath)
 
-# Add build/lib in order to find Cantera shared library
-if env["OS"] == "Windows":
-    localenv.PrependENVPath('PATH', Dir('#build/lib').abspath)
-elif env['OS'] == 'Darwin':
-    localenv.PrependENVPath('DYLD_LIBRARY_PATH', Dir('#build/lib').abspath)
-else:
-    localenv.PrependENVPath('LD_LIBRARY_PATH', Dir('#build/lib').abspath)
-
-
 PASSED_FILES = {}
 
 


### PR DESCRIPTION
**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The main purpose of this PR is to modify the implementation of `ExtensibleRate` so that the core Cantera library (`libcantera`) does not need to depend on a specific Python installation at compilation / installation time. Achieving this required some fairly far-reaching changes, though I think they will all have long-term benefits.

- The `PythonExtensionManager` class and associated Cython functions have been moved out of `libcantera` into a separate shim, `libcantera_python` that is loaded on demand. This new library is the one that links to `libpython` and loads the Cantera Python module.
- Because a user C++ program and the Cantera Python module (loaded via `libcantera_python`) both depend on `libcantera`, `libcantera` needs to be loaded as a shared library to avoid having two copies of the library with separate state (which would interfere instantiating user defined types that are only instance with one copy of `ReactionRateFactory`, for example). Multiple versions of Python are supported (not at the same time!) by having multiple versions of `libcantera_python`, e.g. `libcantera_python3_11.so` and `libcantera_python3_10.so`.
- On Windows, linking C++ applications and the Cantera Python module to `libcantera_shared` requires "exporting" the complete C++ interface. Due the the sheer number of methods that need to be exported, rather than the standard approach investigated in #1298, this PR uses the static library to generate a list of symbols to be exported from the DLL.
- The functions to load the `libcantera_python` library on-demand are OS-specific. Rather than use these low-level functions, the Boost.DLL library is used for its higher-level, cross-platform capabilities. While Boost.DLL is header-only, by default it depends on Boost.Filesystem, which has a compiled component. However, since C++17 introduced `std::filesystem` (derived from Boost.Filesystem), Boost.DLL provides an option to use `std::filesystem`. Therefore, in order to avoid introducing a dependence on the compiled components of Boost, **this PR bumps Cantera's compiler requirement to the C++17 standard**.

There are also a few more minor changes that ended up coming along for the ride:
- Add `using` directives within the `Cantera` namespace for some of the most-used standard library types: `string`, `vector`, `map`, `function`, `pair`, `unique_ptr`. I figure `map<string, string>` is more readable than `std::map<std::string, std::string>`.
- Bump vendored versions of `fmt` and `Eigen`.
- Move some function definitions out of the header files, especially in the case of the Factory classes.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Continues the work on https://github.com/Cantera/enhancements/issues/79
- Provides a path to resolving https://github.com/Cantera/conda-recipes/issues/40
- Resolves https://github.com/Cantera/enhancements/issues/140
- The underlying functionality here should enable implementation of https://github.com/Cantera/enhancements/issues/126

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
