### PR TITLE
Deprecate 'R' in C++ setter nomenclature in favor of 'D'

### DIFF
--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -78,7 +78,9 @@ extern "C" {
     CANTERA_CAPI int thermo_getCp_R(int n, size_t lenm, double* cp_r);
     CANTERA_CAPI int thermo_setElectricPotential(int n, double v);
     CANTERA_CAPI int thermo_set_TP(int n, double* vals);
+    CANTERA_CAPI int thermo_set_TD(int n, double* vals);
     CANTERA_CAPI int thermo_set_RP(int n, double* vals);
+    CANTERA_CAPI int thermo_set_DP(int n, double* vals);
     CANTERA_CAPI int thermo_set_HP(int n, double* vals);
     CANTERA_CAPI int thermo_set_UV(int n, double* vals);
     CANTERA_CAPI int thermo_set_SV(int n, double* vals);

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -365,11 +365,12 @@ public:
      *
      * @param rho Density (kg/m^3)
      * @param p Pressure (Pa)
+     * @since  New in Cantera 3.0.
      */
-    virtual void setState_RP(doublereal rho, doublereal p)
+    virtual void setState_DP(doublereal rho, doublereal p)
     {
         if (p <= 0) {
-            throw CanteraError("IdealGasPhase::setState_RP",
+            throw CanteraError("IdealGasPhase::setState_DP",
                                "pressure must be positive");
         }
         setDensity(rho);

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -360,8 +360,17 @@ public:
     /*!
      * @param  temp     Temperature (Kelvin)
      * @param  rho      Density (kg m-3)
+     * @deprecated  To be removed after Cantera 3.0; renamed to setState_TD()
      */
     virtual void setState_TR(doublereal temp, doublereal rho);
+
+    //! Set the internal temperature and density
+    /*!
+     * @param  temp     Temperature (Kelvin)
+     * @param  rho      Density (kg m-3)
+     * @since  New in Cantera 3.0.
+     */
+    virtual void setState_TD(double temp, double rho);
 
     //! critical temperature
     virtual doublereal critTemperature() const;

--- a/include/cantera/thermo/PDSS_ConstVol.h
+++ b/include/cantera/thermo/PDSS_ConstVol.h
@@ -39,7 +39,7 @@ public:
     virtual void setPressure(doublereal pres);
     virtual void setTemperature(doublereal temp);
     virtual void setState_TP(doublereal temp, doublereal pres);
-    virtual void setState_TR(doublereal temp, doublereal rho);
+    virtual void setState_TD(double temp, double rho);
     virtual doublereal satPressure(doublereal t);
 
     //! @}

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -43,7 +43,7 @@ public:
     virtual void setPressure(doublereal pres);
     virtual void setTemperature(doublereal temp);
     virtual void setState_TP(doublereal temp, doublereal pres);
-    virtual void setState_TR(doublereal temp, doublereal rho);
+    virtual void setState_TD(double temp, double rho);
 
     //! @}
     //! @name Initialization of the Object

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -94,7 +94,7 @@ public:
     virtual void setPressure(doublereal pres);
     virtual void setTemperature(doublereal temp);
     virtual void setState_TP(doublereal temp, doublereal pres);
-    virtual void setState_TR(doublereal temp, doublereal rho);
+    virtual void setState_TD(double temp, double rho);
 
     //! Set the density of the water phase
     /*!

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -60,10 +60,9 @@ class Species;
  * based on a T and P, in which case they need to overload these functions too.
  *
  * Class Phase contains a number of utility functions that will set the state
- * of the phase in its entirety, by first setting the composition, then the
- * temperature and then density (or pressure for incompressible substances)
- * An example of this is the function
- * Phase::setState_TRY(double t, double dens, const double* y).
+ * of the phase in its entirety, by first setting the composition, and then
+ * temperature and pressure. An example of this is the function
+ * Phase::setState_TPY(double t, double p, const double* y).
  *
  * For bulk (3-dimensional) phases, the mass density has units of kg/m^3, and the molar
  * density and concentrations have units of kmol/m^3, and the units listed in the
@@ -371,6 +370,8 @@ public:
     //!     @param t     Temperature in kelvin
     //!     @param dens  Density (kg/m^3)
     //!     @param x     vector of species mole fractions, length m_kk
+    //!     @deprecated To be removed after Cantera 3.0; replaceable by calls to
+    //!                 setMoleFractions() and setState_TD().
     void setState_TRX(doublereal t, doublereal dens, const doublereal* x);
 
     //! Set the internally stored temperature (K), density, and mole fractions.
@@ -379,12 +380,16 @@ public:
     //!     @param x     Composition Map containing the mole fractions.
     //!                  Species not included in the map are assumed to have
     //!                  a zero mole fraction.
+    //!     @deprecated To be removed after Cantera 3.0; replaceable by calls to
+    //!                 setMoleFractionsByName() and setState_TD().
     void setState_TRX(doublereal t, doublereal dens, const compositionMap& x);
 
     //! Set the internally stored temperature (K), density, and mass fractions.
     //!     @param t     Temperature in kelvin
     //!     @param dens  Density (kg/m^3)
     //!     @param y     vector of species mass fractions, length m_kk
+    //!     @deprecated To be removed after Cantera 3.0; replaceable by calls to
+    //!                 setMassFractions() and setState_TD().
     void setState_TRY(doublereal t, doublereal dens, const doublereal* y);
 
     //! Set the internally stored temperature (K), density, and mass fractions.
@@ -393,6 +398,8 @@ public:
     //!     @param y     Composition Map containing the mass fractions.
     //!                  Species not included in the map are assumed to have
     //!                  a zero mass fraction.
+    //!     @deprecated To be removed after Cantera 3.0; replaceable by calls to
+    //!                 setMassFractionsByName() and setState_TD().
     void setState_TRY(doublereal t, doublereal dens, const compositionMap& y);
 
     //! Set the internally stored temperature (K), molar density (kmol/m^3), and

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -405,7 +405,14 @@ public:
     //! Set the internally stored temperature (K) and density (kg/m^3)
     //!     @param t     Temperature in kelvin
     //!     @param rho   Density (kg/m^3)
+    //!     @deprecated  To be removed after Cantera 3.0; renamed to setState_TD()
     void setState_TR(doublereal t, doublereal rho);
+
+    //! Set the internally stored temperature (K) and density (kg/m^3)
+    //!     @param t     Temperature in kelvin
+    //!     @param rho   Density (kg/m^3)
+    //!     @since  New in Cantera 3.0.
+    void setState_TD(double t, double rho);
 
     //! Set the internally stored temperature (K) and mole fractions.
     //!     @param t   Temperature in kelvin

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1067,9 +1067,26 @@ public:
      *
      * @param rho Density (kg/m^3)
      * @param p   Pressure (Pa)
+     * @deprecated  To be removed after Cantera 3.0; renamed to setState_DP()
      */
-    virtual void setState_RP(doublereal rho, doublereal p) {
-        throw NotImplementedError("ThermoPhase::setState_RP");
+    void setState_RP(doublereal rho, doublereal p);
+
+    //! Set the density (kg/m**3) and pressure (Pa) at constant composition
+    /*!
+     * This method must be reimplemented in derived classes, where it may
+     * involve the solution of a nonlinear equation. Within %Cantera, the
+     * independent variable is the density. Therefore, this function solves for
+     * the temperature that will yield the desired input pressure and density.
+     * The composition is held constant during this process.
+     *
+     * This base class function will print an error, if not overridden.
+     *
+     * @param rho Density (kg/m^3)
+     * @param p   Pressure (Pa)
+     * @since  New in Cantera 3.0.
+     */
+    virtual void setState_DP(double rho, double p) {
+        throw NotImplementedError("ThermoPhase::setState_DP");
     }
 
     //! Set the density (kg/m**3), pressure (Pa) and mole fractions
@@ -1082,6 +1099,8 @@ public:
      * @param p    Pressure (Pa)
      * @param x    Vector of mole fractions.
      *             Length is equal to m_kk.
+     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     *              setMoleFractions() and setState_DP().
      */
     virtual void setState_RPX(doublereal rho, doublereal p, const doublereal* x);
 
@@ -1095,6 +1114,8 @@ public:
      * @param p    Pressure (Pa)
      * @param x    Composition map of mole fractions. Species not in
      *              the composition map are assumed to have zero mole fraction
+     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     *              setMoleFractionsByName() and setState_DP().
      */
     virtual void setState_RPX(doublereal rho, doublereal p, const compositionMap& x);
 
@@ -1109,6 +1130,8 @@ public:
      * @param x    String containing a composition map of the mole fractions.
      *              Species not in the composition map are assumed to have zero
      *              mole fraction
+     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     *              setMoleFractionsByName() and setState_DP().
      */
     virtual void setState_RPX(doublereal rho, doublereal p, const std::string& x);
 
@@ -1122,6 +1145,8 @@ public:
      * @param p    Pressure (Pa)
      * @param y    Vector of mole fractions.
      *              Length is equal to m_kk.
+     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     *              setMassFractions() and setState_DP().
      */
     virtual void setState_RPY(doublereal rho, doublereal p, const doublereal* y);
 
@@ -1135,6 +1160,8 @@ public:
      * @param p   Pressure (Pa)
      * @param y   Composition map of mole fractions. Species not in
      *             the composition map are assumed to have zero mole fraction
+     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     *              setMassFractionsByName() and setState_DP().
      */
     virtual void setState_RPY(doublereal rho, doublereal p, const compositionMap& y);
 
@@ -1149,6 +1176,8 @@ public:
      * @param y    String containing a composition map of the mole fractions.
      *              Species not in the composition map are assumed to have zero
      *              mole fraction
+     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     *              setMassFractionsByName() and setState_DP().
      */
     virtual void setState_RPY(doublereal rho, doublereal p, const std::string& y);
 

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -140,11 +140,11 @@ namespace Cantera
  * There are only three functions which actually change the value of the
  * internal state of this object after it's been instantiated
  *
- *   - setState_TR(temperature, rho)
+ *   - setState_TD(temperature, rho)
  *   - density(temperature, pressure, phase, rhoguess)
  *   - psat(temperature, waterState);
  *
- * The setState_TR() is the main function that sets the temperature and rho
+ * The setState_TD() is the main function that sets the temperature and rho
  * value. The density() function serves as a setState_TP() function, in that
  * it sets internal state to a temperature and pressure. However, note that
  * this is potentially multivalued. Therefore, we need to supply in addition a
@@ -171,8 +171,17 @@ public:
     /*!
      * @param temperature   temperature (kelvin)
      * @param rho           density  (kg m-3)
+     * @deprecated  To be removed after Cantera 3.0; renamed to setState_TD()
      */
     void setState_TR(doublereal temperature, doublereal rho);
+
+    //! Set the internal state of the object wrt temperature and density
+    /*!
+     * @param temperature   temperature (kelvin)
+     * @param rho           density  (kg m-3)
+     * @since  New in Cantera 3.0.
+     */
+    void setState_TD(double temperature, double rho);
 
     //! Get the Gibbs free energy (J/kg) at the current temperature and density
     double gibbs_mass() const;

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -128,7 +128,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         void setState_UV(double, double) except +translate_exception
         void setState_SP(double, double) except +translate_exception
         void setState_SV(double, double) except +translate_exception
-        void setState_RP(double, double) except +translate_exception
+        void setState_DP(double, double) except +translate_exception
         void setState_ST(double, double) except +translate_exception
         void setState_TV(double, double) except +translate_exception
         void setState_PV(double, double) except +translate_exception

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -122,7 +122,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         double elementalMoleFraction(size_t) except +translate_exception
 
         # state setters
-        void setState_TR(double, double) except +translate_exception
+        void setState_TD(double, double) except +translate_exception
         void setState_TP(double, double) except +translate_exception
         void setState_HP(double, double) except +translate_exception
         void setState_UV(double, double) except +translate_exception

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1465,7 +1465,7 @@ cdef class ThermoPhase(_SolutionBase):
             assert len(values) == 2, 'incorrect number of values'
             D = values[0] if values[0] is not None else self.density
             P = values[1] if values[1] is not None else self.P
-            self.thermo.setState_RP(D*self._mass_factor(), P)
+            self.thermo.setState_DP(D*self._mass_factor(), P)
 
     property DPX:
         """Get/Set density [kg/m^3], pressure [Pa], and mole fractions."""
@@ -1476,7 +1476,7 @@ cdef class ThermoPhase(_SolutionBase):
             D = values[0] if values[0] is not None else self.density
             P = values[1] if values[1] is not None else self.P
             self.X = values[2]
-            self.thermo.setState_RP(D*self._mass_factor(), P)
+            self.thermo.setState_DP(D*self._mass_factor(), P)
 
     property DPY:
         """Get/Set density [kg/m^3], pressure [Pa], and mass fractions."""
@@ -1487,7 +1487,7 @@ cdef class ThermoPhase(_SolutionBase):
             D = values[0] if values[0] is not None else self.density
             P = values[1] if values[1] is not None else self.P
             self.Y = values[2]
-            self.thermo.setState_RP(D*self._mass_factor(), P)
+            self.thermo.setState_DP(D*self._mass_factor(), P)
 
     property HP:
         """Get/Set enthalpy [J/kg or J/kmol] and pressure [Pa]."""

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1351,7 +1351,7 @@ cdef class ThermoPhase(_SolutionBase):
             assert len(values) == 2, 'incorrect number of values'
             T = values[0] if values[0] is not None else self.T
             D = values[1] if values[1] is not None else self.density
-            self.thermo.setState_TR(T, D * self._mass_factor())
+            self.thermo.setState_TD(T, D * self._mass_factor())
 
     property TDX:
         """
@@ -1365,7 +1365,7 @@ cdef class ThermoPhase(_SolutionBase):
             T = values[0] if values[0] is not None else self.T
             D = values[1] if values[1] is not None else self.density
             self.X = values[2]
-            self.thermo.setState_TR(T, D * self._mass_factor())
+            self.thermo.setState_TD(T, D * self._mass_factor())
 
     property TDY:
         """
@@ -1379,7 +1379,7 @@ cdef class ThermoPhase(_SolutionBase):
             T = values[0] if values[0] is not None else self.T
             D = values[1] if values[1] is not None else self.density
             self.Y = values[2]
-            self.thermo.setState_TR(T, D * self._mass_factor())
+            self.thermo.setState_TD(T, D * self._mass_factor())
 
     property TP:
         """Get/Set temperature [K] and pressure [Pa]."""

--- a/interfaces/dotnet/Cantera/src/Enums.cs
+++ b/interfaces/dotnet/Cantera/src/Enums.cs
@@ -15,7 +15,7 @@ public enum ThermoPair
     /// <summary>
     /// Density and Pressure
     /// </summary>
-    RP, DensityPressure = RP,
+    DP, DensityPressure = DP,
 
     /// <summary>
     /// Temperature and Volume

--- a/interfaces/matlab/toolbox/@ThermoPhase/set.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/set.m
@@ -171,7 +171,7 @@ elseif ntot == 2
         setTemperature(tp, tval);
         setPressure(tp, pval);
     elseif np == 1 && nv == 1
-        setState_RP(tp, [1.0/vval, pval])
+        setState_DP(tp, [1.0/vval, pval])
     elseif nt == 1 && nq == 1
         setState_Tsat(tp, [tval,qval]);
     elseif np == 1 && nq == 1

--- a/interfaces/matlab/toolbox/@ThermoPhase/setState_DP.m
+++ b/interfaces/matlab/toolbox/@ThermoPhase/setState_DP.m
@@ -1,6 +1,6 @@
-function setState_RP(tp, rp)
-% SETSTATE_RP  Set the density and pressure.
-% setState_RP(tp, [density,p])
+function setState_DP(tp, dp)
+% SETSTATE_DP  Set the density and pressure.
+% setState_DP(tp, [density,p])
 % The density is set first, then the pressure is set by
 % changing the temperature holding the density and
 % chemical composition fixed.
@@ -8,9 +8,9 @@ function setState_RP(tp, rp)
 % :param tp:
 %     Instance of class :mat:func:`ThermoPhase` (or another
 %     class derived from ThermoPhase)
-% :param rp:
+% :param dp:
 %     Vector of length 2 containing the desired values for the density (kg/m^3)
 %     and pressure (Pa)
 %
-warning('To be removed after Cantera 3.0. Renamed to setState_DP.')
-thermo_set(tp.tp_id, 26, rp);
+
+thermo_set(tp.tp_id, 26, dp);

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -524,10 +524,30 @@ extern "C" {
         }
     }
 
+    int thermo_set_TD(int n, double* vals)
+    {
+        try{
+            ThermoCabinet::item(n).setState_TD(vals[0], vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int thermo_set_RP(int n, double* vals)
     {
         try{
             ThermoCabinet::item(n).setState_RP(vals[0], vals[1]);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int thermo_set_DP(int n, double* vals)
+    {
+        try{
+            ThermoCabinet::item(n).setState_DP(vals[0], vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/matlab/thermomethods.cpp
+++ b/src/matlab/thermomethods.cpp
@@ -63,7 +63,7 @@ static void thermoset(int nlhs, mxArray* plhs[],
                 ierr = thermo_setState_Tsat(th,ptr[0],ptr[1]);
                 break;
             case 26:
-                ierr = thermo_set_RP(th,ptr);
+                ierr = thermo_set_DP(th,ptr);
                 break;
             case 27:
                 ierr = thermo_set_ST(th,ptr);

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -462,7 +462,7 @@ int MixtureFugacityTP::corr0(doublereal TKelvin, doublereal pres, doublereal& de
         retn = -1;
     } else {
         densLiqGuess = densLiq;
-        setState_TR(TKelvin, densLiq);
+        setState_TD(TKelvin, densLiq);
         liqGRT = gibbs_mole() / RT();
     }
 
@@ -476,7 +476,7 @@ int MixtureFugacityTP::corr0(doublereal TKelvin, doublereal pres, doublereal& de
         retn = -2;
     } else {
         densGasGuess = densGas;
-        setState_TR(TKelvin, densGas);
+        setState_TD(TKelvin, densGas);
         gasGRT = gibbs_mole() / RT();
     }
     return retn;
@@ -718,14 +718,14 @@ doublereal MixtureFugacityTP::calculatePsat(doublereal TKelvin, doublereal& mola
         molarVolGas = mw / RhoGas;
         molarVolLiquid = mw / RhoLiquid;
         // Put the fluid in the desired end condition
-        setState_TR(tempSave, densSave);
+        setState_TD(tempSave, densSave);
         return pres;
     } else {
         pres = critPressure();
         setState_TP(TKelvin, pres);
         molarVolGas = mw / density();
         molarVolLiquid = molarVolGas;
-        setState_TR(tempSave, densSave);
+        setState_TD(tempSave, densSave);
     }
     return pres;
 }

--- a/src/thermo/PDSS.cpp
+++ b/src/thermo/PDSS.cpp
@@ -8,6 +8,7 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
+#include "cantera/base/global.h"
 #include "cantera/thermo/PDSS.h"
 #include "cantera/thermo/VPStandardStateTP.h"
 
@@ -184,7 +185,14 @@ void PDSS::setState_TP(doublereal temp, doublereal pres)
 
 void PDSS::setState_TR(doublereal temp, doublereal rho)
 {
-    throw NotImplementedError("PDSS::setState_TR");
+    warn_deprecated("PDSS::setState_TR",
+        "To be removed after Cantera 3.0. Renamed to setState_TD.");
+    setState_TD(temp, rho);
+}
+
+void PDSS::setState_TD(double temp, double rho)
+{
+    throw NotImplementedError("PDSS::setState_TD");
 }
 
 doublereal PDSS::satPressure(doublereal t)

--- a/src/thermo/PDSS_ConstVol.cpp
+++ b/src/thermo/PDSS_ConstVol.cpp
@@ -78,12 +78,12 @@ void PDSS_ConstVol::setState_TP(doublereal temp, doublereal pres)
     setPressure(pres);
 }
 
-void PDSS_ConstVol::setState_TR(doublereal temp, doublereal rho)
+void PDSS_ConstVol::setState_TD(double temp, double rho)
 {
-    doublereal rhoStored = m_mw / m_constMolarVolume;
+    double rhoStored = m_mw / m_constMolarVolume;
     if (fabs(rhoStored - rho) / (rhoStored + rho) > 1.0E-4) {
-        throw CanteraError("PDSS_ConstVol::setState_TR",
-                           "Inconsistent supplied rho");
+        throw CanteraError("PDSS_ConstVol::setState_TD",
+                           "Inconsistent supplied density.");
     }
     setTemperature(temp);
 }

--- a/src/thermo/PDSS_IdealGas.cpp
+++ b/src/thermo/PDSS_IdealGas.cpp
@@ -74,7 +74,7 @@ void PDSS_IdealGas::setState_TP(doublereal temp, doublereal pres)
     setTemperature(temp);
 }
 
-void PDSS_IdealGas::setState_TR(doublereal temp, doublereal rho)
+void PDSS_IdealGas::setState_TD(double temp, double rho)
 {
     m_pres = GasConstant * temp * rho / m_mw;
     setTemperature(temp);

--- a/src/thermo/PDSS_Water.cpp
+++ b/src/thermo/PDSS_Water.cpp
@@ -92,7 +92,7 @@ doublereal PDSS_Water::gibbs_RT_ref() const
 {
     m_sub.density(m_temp, m_p0, m_iState);
     double h = m_sub.enthalpy_mass() * m_mw;
-    m_sub.setState_TR(m_temp, m_dens);
+    m_sub.setState_TD(m_temp, m_dens);
     return (h + EW_Offset - SW_Offset * m_temp) / (m_temp * GasConstant);
 }
 
@@ -100,7 +100,7 @@ doublereal PDSS_Water::enthalpy_RT_ref() const
 {
     m_sub.density(m_temp, m_p0, m_iState);
     double h = m_sub.enthalpy_mass() * m_mw;
-    m_sub.setState_TR(m_temp, m_dens);
+    m_sub.setState_TD(m_temp, m_dens);
     return (h + EW_Offset) / (m_temp * GasConstant);
 }
 
@@ -108,7 +108,7 @@ doublereal PDSS_Water::entropy_R_ref() const
 {
     m_sub.density(m_temp, m_p0, m_iState);
     double s = m_sub.entropy_mass() * m_mw;
-    m_sub.setState_TR(m_temp, m_dens);
+    m_sub.setState_TD(m_temp, m_dens);
     return (s + SW_Offset) / GasConstant;
 }
 
@@ -116,7 +116,7 @@ doublereal PDSS_Water::cp_R_ref() const
 {
     m_sub.density(m_temp, m_p0, m_iState);
     double cp = m_sub.cp_mass() * m_mw;
-    m_sub.setState_TR(m_temp, m_dens);
+    m_sub.setState_TD(m_temp, m_dens);
     return cp / GasConstant;
 }
 
@@ -124,7 +124,7 @@ doublereal PDSS_Water::molarVolume_ref() const
 {
     m_sub.density(m_temp, m_p0, m_iState);
     double mv = m_mw / m_sub.density();
-    m_sub.setState_TR(m_temp, m_dens);
+    m_sub.setState_TD(m_temp, m_dens);
     return mv;
 }
 
@@ -177,7 +177,7 @@ doublereal PDSS_Water::dthermalExpansionCoeffdT() const
             "unable to solve for the density at T = {}, P = {}", tt, pres);
     }
     doublereal vald = m_sub.coeffThermExp();
-    m_sub.setState_TR(m_temp, dens_save);
+    m_sub.setState_TD(m_temp, dens_save);
     doublereal val2 = m_sub.coeffThermExp();
     return (val2 - vald) / 0.04;
 }
@@ -205,7 +205,7 @@ doublereal PDSS_Water::critDensity() const
 void PDSS_Water::setDensity(doublereal dens)
 {
     m_dens = dens;
-    m_sub.setState_TR(m_temp, m_dens);
+    m_sub.setState_TD(m_temp, m_dens);
 }
 
 doublereal PDSS_Water::density() const
@@ -216,7 +216,7 @@ doublereal PDSS_Water::density() const
 void PDSS_Water::setTemperature(doublereal temp)
 {
     m_temp = temp;
-    m_sub.setState_TR(temp, m_dens);
+    m_sub.setState_TD(temp, m_dens);
 }
 
 void PDSS_Water::setState_TP(doublereal temp, doublereal pres)
@@ -225,11 +225,11 @@ void PDSS_Water::setState_TP(doublereal temp, doublereal pres)
     setPressure(pres);
 }
 
-void PDSS_Water::setState_TR(doublereal temp, doublereal dens)
+void PDSS_Water::setState_TD(double temp, double dens)
 {
     m_temp = temp;
     m_dens = dens;
-    m_sub.setState_TR(m_temp, m_dens);
+    m_sub.setState_TD(m_temp, m_dens);
 }
 
 doublereal PDSS_Water::pref_safe(doublereal temp) const

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -393,9 +393,11 @@ void Phase::setMassFractionsByName(const std::string& y)
 
 void Phase::setState_TRX(doublereal t, doublereal dens, const doublereal* x)
 {
+    warn_deprecated("Phase::setState_TRX",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMoleFractions and setState_TD.");
     setMoleFractions(x);
-    setTemperature(t);
-    setDensity(dens);
+    setState_TD(t, dens);
 }
 
 void Phase::setState_TNX(doublereal t, doublereal n, const doublereal* x)
@@ -407,23 +409,29 @@ void Phase::setState_TNX(doublereal t, doublereal n, const doublereal* x)
 
 void Phase::setState_TRX(doublereal t, doublereal dens, const compositionMap& x)
 {
+    warn_deprecated("Phase::setState_TRX",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMoleFractionsByName and setState_TD.");
     setMoleFractionsByName(x);
-    setTemperature(t);
-    setDensity(dens);
+    setState_TD(t, dens);
 }
 
 void Phase::setState_TRY(doublereal t, doublereal dens, const doublereal* y)
 {
+    warn_deprecated("Phase::setState_TRY",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMassFractions and setState_TD.");
     setMassFractions(y);
-    setTemperature(t);
-    setDensity(dens);
+    setState_TD(t, dens);
 }
 
 void Phase::setState_TRY(doublereal t, doublereal dens, const compositionMap& y)
 {
+    warn_deprecated("Phase::setState_TRY",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMassFractionsByName and setState_TD.");
     setMassFractionsByName(y);
-    setTemperature(t);
-    setDensity(dens);
+    setState_TD(t, dens);
 }
 
 void Phase::setState_TR(doublereal t, doublereal rho)

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -428,6 +428,13 @@ void Phase::setState_TRY(doublereal t, doublereal dens, const compositionMap& y)
 
 void Phase::setState_TR(doublereal t, doublereal rho)
 {
+    warn_deprecated("Phase::setState_TR",
+        "To be removed after Cantera 3.0. Renamed to setState_TD.");
+    setState_TD(t, rho);
+}
+
+void Phase::setState_TD(double t, double rho)
+{
     setTemperature(t);
     setDensity(rho);
 }

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -308,67 +308,67 @@ doublereal PureFluidPhase::satTemperature(doublereal p) const
 void PureFluidPhase::setState_HP(double h, double p, double tol)
 {
     Set(tpx::PropertyPair::HP, h, p);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_UV(double u, double v, double tol)
 {
     Set(tpx::PropertyPair::UV, u, v);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_SV(double s, double v, double tol)
 {
     Set(tpx::PropertyPair::SV, s, v);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_SP(double s, double p, double tol)
 {
     Set(tpx::PropertyPair::SP, s, p);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_ST(double s, double t, double tol)
 {
     Set(tpx::PropertyPair::ST, s, t);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_TV(double t, double v, double tol)
 {
     Set(tpx::PropertyPair::TV, t, v);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_PV(double p, double v, double tol)
 {
     Set(tpx::PropertyPair::PV, p, v);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_UP(double u, double p, double tol)
 {
     Set(tpx::PropertyPair::UP, u, p);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_VH(double v, double h, double tol)
 {
     Set(tpx::PropertyPair::VH, v, h);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_TH(double t, double h, double tol)
 {
     Set(tpx::PropertyPair::TH, t, h);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 void PureFluidPhase::setState_SH(double s, double h, double tol)
 {
     Set(tpx::PropertyPair::SH, s, h);
-    setState_TR(m_sub->Temp(), 1.0/m_sub->v());
+    setState_TD(m_sub->Temp(), 1.0/m_sub->v());
 }
 
 doublereal PureFluidPhase::satPressure(doublereal t)

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -134,7 +134,7 @@ void ThermoPhase::setState_TP(doublereal t, doublereal p)
         setTemperature(t);
         setPressure(p);
     } catch (CanteraError&) {
-        setState_TR(tsave, dsave);
+        setState_TD(tsave, dsave);
         throw;
     }
 }
@@ -267,7 +267,7 @@ void ThermoPhase::setState(const AnyMap& input_state)
             setState_TP(T, P);
         }
     } else if (state.hasKey("T") && state.hasKey("D")) {
-        setState_TR(state.convert("T", "K"), state.convert("D", "kg/m^3"));
+        setState_TD(state.convert("T", "K"), state.convert("D", "kg/m^3"));
     } else if (state.hasKey("T") && state.hasKey("V")) {
         setState_TV(state.convert("T", "K"), state.convert("V", "m^3/kg"));
     } else if (state.hasKey("H") && state.hasKey("P")) {

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -141,38 +141,63 @@ void ThermoPhase::setState_TP(doublereal t, doublereal p)
 
 void ThermoPhase::setState_RPX(doublereal rho, doublereal p, const doublereal* x)
 {
+    warn_deprecated("ThermoPhase::setState_RPX",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMoleFractions and setState_DP.");
     setMoleFractions(x);
-    setState_RP(rho, p);
+    setState_DP(rho, p);
 }
 
 void ThermoPhase::setState_RPX(doublereal rho, doublereal p, const compositionMap& x)
 {
+    warn_deprecated("ThermoPhase::setState_RPX",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMoleFractionsByName and setState_DP.");
     setMoleFractionsByName(x);
-    setState_RP(rho,p);
+    setState_DP(rho, p);
 }
 
 void ThermoPhase::setState_RPX(doublereal rho, doublereal p, const std::string& x)
 {
+    warn_deprecated("ThermoPhase::setState_RPX",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMoleFractionsByName and setState_DP.");
     setMoleFractionsByName(x);
-    setState_RP(rho,p);
+    setState_DP(rho, p);
 }
 
 void ThermoPhase::setState_RPY(doublereal rho, doublereal p, const doublereal* y)
 {
+    warn_deprecated("ThermoPhase::setState_RPY",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMassFractions and setState_DP.");
     setMassFractions(y);
-    setState_RP(rho,p);
+    setState_DP(rho, p);
 }
 
 void ThermoPhase::setState_RPY(doublereal rho, doublereal p, const compositionMap& y)
 {
+    warn_deprecated("ThermoPhase::setState_RPY",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMassFractionsByName and setState_DP.");
     setMassFractionsByName(y);
-    setState_RP(rho,p);
+    setState_DP(rho, p);
 }
 
 void ThermoPhase::setState_RPY(doublereal rho, doublereal p, const std::string& y)
 {
+    warn_deprecated("ThermoPhase::setState_RPY",
+        "To be removed after Cantera 3.0. Replaceable by calls to "
+        "setMassFractionsByName and setState_DP.");
     setMassFractionsByName(y);
-    setState_RP(rho,p);
+    setState_DP(rho, p);
+}
+
+void ThermoPhase::setState_RP(doublereal rho, doublereal p)
+{
+    warn_deprecated("ThermoPhase::setState_RP",
+        "To be removed after Cantera 3.0. Renamed to setState_DP.");
+    setState_DP(rho, p);
 }
 
 void ThermoPhase::setState_PX(doublereal p, doublereal* x)
@@ -291,7 +316,7 @@ void ThermoPhase::setState(const AnyMap& input_state)
     } else if (state.hasKey("S") && state.hasKey("H")) {
         setState_SH(state.convert("S", "J/kg/K"), state.convert("H", "J/kg"));
     } else if (state.hasKey("D") && state.hasKey("P")) {
-        setState_RP(state.convert("D", "kg/m^3"), state.convert("P", "Pa"));
+        setState_DP(state.convert("D", "kg/m^3"), state.convert("P", "Pa"));
     } else if (state.hasKey("P") && state.hasKey("Q")) {
         setState_Psat(state.convert("P", "Pa"), state["Q"].asDouble());
     } else if (state.hasKey("T") && state.hasKey("Q")) {

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -86,7 +86,7 @@ doublereal WaterPropsIAPWS::density(doublereal temperature, doublereal pressure,
     if (fabs(pressure - P_c) / P_c < 1.e-8 &&
         fabs(temperature - T_c) / T_c < 1.e-8) {
         // Catch critical point, as no solution is found otherwise
-        setState_TR(temperature, Rho_c);
+        setState_TD(temperature, Rho_c);
         return Rho_c;
     }
     doublereal deltaGuess = 0.0;
@@ -117,7 +117,7 @@ doublereal WaterPropsIAPWS::density(doublereal temperature, doublereal pressure,
     }
     double p_red = pressure / (R_water * temperature * Rho_c);
     deltaGuess = rhoguess / Rho_c;
-    setState_TR(temperature, rhoguess);
+    setState_TD(temperature, rhoguess);
     doublereal delta_retn = m_phi.dfind(p_red, tau, deltaGuess);
     if (delta_retn <= 0) {
         // No solution found for first initial guess; perturb initial guess once
@@ -133,7 +133,7 @@ doublereal WaterPropsIAPWS::density(doublereal temperature, doublereal pressure,
 
         // Set the internal state -> this may be a duplication. However, let's
         // just be sure.
-        setState_TR(temperature, density_retn);
+        setState_TD(temperature, density_retn);
     } else {
         density_retn = -1.0;
     }
@@ -287,7 +287,7 @@ void WaterPropsIAPWS::corr(doublereal temperature, doublereal pressure,
             "Error occurred trying to find liquid density at (T,P) = {}  {}",
             temperature, pressure);
     }
-    setState_TR(temperature, densLiq);
+    setState_TD(temperature, densLiq);
     doublereal gibbsLiqRT = m_phi.gibbs_RT();
 
     densGas = density(temperature, pressure, WATER_GAS, densGas);
@@ -296,7 +296,7 @@ void WaterPropsIAPWS::corr(doublereal temperature, doublereal pressure,
             "Error occurred trying to find gas density at (T,P) = {}  {}",
             temperature, pressure);
     }
-    setState_TR(temperature, densGas);
+    setState_TD(temperature, densGas);
     doublereal gibbsGasRT = m_phi.gibbs_RT();
 
     delGRT = gibbsLiqRT - gibbsGasRT;
@@ -311,7 +311,7 @@ void WaterPropsIAPWS::corr1(doublereal temperature, doublereal pressure,
             "Error occurred trying to find liquid density at (T,P) = {}  {}",
             temperature, pressure);
     }
-    setState_TR(temperature, densLiq);
+    setState_TD(temperature, densLiq);
     doublereal prL = m_phi.phiR();
 
     densGas = density(temperature, pressure, WATER_GAS, densGas);
@@ -320,7 +320,7 @@ void WaterPropsIAPWS::corr1(doublereal temperature, doublereal pressure,
             "Error occurred trying to find gas density at (T,P) = {}  {}",
             temperature, pressure);
     }
-    setState_TR(temperature, densGas);
+    setState_TD(temperature, densGas);
     doublereal prG = m_phi.phiR();
     doublereal rhs = (prL - prG) + log(densLiq/densGas);
     rhs /= (1.0/densGas - 1.0/densLiq);
@@ -334,7 +334,7 @@ doublereal WaterPropsIAPWS::psat(doublereal temperature, int waterState)
     double dp, pcorr;
     if (temperature >= T_c) {
         densGas = density(temperature, P_c, WATER_SUPERCRIT);
-        setState_TR(temperature, densGas);
+        setState_TD(temperature, densGas);
         return P_c;
     }
     double p = psat_est(temperature);
@@ -359,9 +359,9 @@ doublereal WaterPropsIAPWS::psat(doublereal temperature, int waterState)
     }
     // Put the fluid in the desired end condition
     if (waterState == WATER_LIQUID) {
-        setState_TR(temperature, densLiq);
+        setState_TD(temperature, densLiq);
     } else if (waterState == WATER_GAS) {
-        setState_TR(temperature, densGas);
+        setState_TD(temperature, densGas);
     } else {
         throw CanteraError("WaterPropsIAPWS::psat",
                            "unknown water state input: {}", waterState);
@@ -585,6 +585,13 @@ doublereal WaterPropsIAPWS::densSpinodalSteam() const
 }
 
 void WaterPropsIAPWS::setState_TR(doublereal temperature, doublereal rho)
+{
+    warn_deprecated("WaterPropsIAPWS::setState_TR",
+        "To be removed after Cantera 3.0. Renamed to setState_TD.");
+    setState_TD(temperature, rho);
+}
+
+void WaterPropsIAPWS::setState_TD(double temperature, double rho)
 {
     calcDim(temperature, rho);
     m_phi.tdpolycalc(tau, delta);

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -168,7 +168,7 @@ void WaterSSTP::getGibbs_RT_ref(doublereal* grt) const
     if (dd <= 0.0) {
         throw CanteraError("WaterSSTP::getGibbs_RT_ref", "error");
     }
-    m_sub.setState_TR(T, dd);
+    m_sub.setState_TD(T, dd);
     double g = m_sub.gibbs_mass() * m_mw;
     *grt = (g + EW_Offset - SW_Offset*T)/ RT();
     dd = m_sub.density(T, p, waterState, dens);
@@ -197,7 +197,7 @@ void WaterSSTP::getEntropy_R_ref(doublereal* sr) const
     if (dd <= 0.0) {
         throw CanteraError("WaterSSTP::getEntropy_R_ref", "error");
     }
-    m_sub.setState_TR(T, dd);
+    m_sub.setState_TD(T, dd);
 
     double s = m_sub.entropy_mass() * m_mw;
     *sr = (s + SW_Offset)/ GasConstant;
@@ -215,7 +215,7 @@ void WaterSSTP::getCp_R_ref(doublereal* cpr) const
         waterState = WATER_LIQUID;
     }
     doublereal dd = m_sub.density(T, OneAtm, waterState, dens);
-    m_sub.setState_TR(T, dd);
+    m_sub.setState_TD(T, dd);
     if (dd <= 0.0) {
         throw CanteraError("WaterSSTP::getCp_R_ref", "error");
     }
@@ -293,7 +293,7 @@ doublereal WaterSSTP::dthermalExpansionCoeffdT() const
             "Unable to solve for the density at T = {}, P = {}", tt, pres);
     }
     doublereal vald = m_sub.coeffThermExp();
-    m_sub.setState_TR(T, dens_save);
+    m_sub.setState_TD(T, dens_save);
     doublereal val2 = m_sub.coeffThermExp();
     return (val2 - vald) / 0.04;
 }
@@ -321,20 +321,20 @@ void WaterSSTP::setTemperature(const doublereal temp)
             "the triple point temperature (T_triple = 273.16).", temp);
     }
     Phase::setTemperature(temp);
-    m_sub.setState_TR(temp, density());
+    m_sub.setState_TD(temp, density());
 }
 
 void WaterSSTP::setDensity(const doublereal dens)
 {
     Phase::setDensity(dens);
-    m_sub.setState_TR(temperature(), dens);
+    m_sub.setState_TD(temperature(), dens);
 }
 
 doublereal WaterSSTP::satPressure(doublereal t) {
     doublereal tsave = temperature();
     doublereal dsave = density();
     doublereal pp = m_sub.psat(t);
-    m_sub.setState_TR(tsave, dsave);
+    m_sub.setState_TD(tsave, dsave);
     return pp;
 }
 

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -90,7 +90,7 @@ void IdealGasMoleReactor::updateState(double* y)
     m_vol = y[1];
     // set state
     m_thermo->setMolesNoTruncate(y + m_sidx);
-    m_thermo->setState_TR(y[0], m_mass / m_vol);
+    m_thermo->setState_TD(y[0], m_mass / m_vol);
     updateConnected(true);
     updateSurfaceState(y + m_nsp + m_sidx);
 }

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -66,7 +66,7 @@ void IdealGasReactor::updateState(doublereal* y)
     m_mass = y[0];
     m_vol = y[1];
     m_thermo->setMassFractions_NoNorm(y+3);
-    m_thermo->setState_TR(y[2], m_mass / m_vol);
+    m_thermo->setState_TD(y[2], m_mass / m_vol);
     updateConnected(true);
     updateSurfaceState(y + m_nsp + 3);
 }

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -136,7 +136,7 @@ void MoleReactor::updateState(double* y)
         double U = y[0];
         // Residual function: error in internal energy as a function of T
         auto u_err = [this, U](double T) {
-            m_thermo->setState_TR(T, m_mass / m_vol);
+            m_thermo->setState_TD(T, m_mass / m_vol);
             return m_thermo->intEnergy_mass() * m_mass - U;
         };
         double T = m_thermo->temperature();
@@ -153,7 +153,7 @@ void MoleReactor::updateState(double* y)
                     bmt::eps_tolerance<double>(48), maxiter);
             } catch (std::exception& err2) {
                 // Set m_thermo back to a reasonable state if root finding fails
-                m_thermo->setState_TR(T, m_mass / m_vol);
+                m_thermo->setState_TD(T, m_mass / m_vol);
                 throw CanteraError("MoleReactor::updateState",
                     "{}\nat U = {}, rho = {}", err2.what(), U, m_mass / m_vol);
             }
@@ -161,7 +161,7 @@ void MoleReactor::updateState(double* y)
         if (fabs(TT.first - TT.second) > 1e-7*TT.first) {
             throw CanteraError("MoleReactor::updateState", "root finding failed");
         }
-        m_thermo->setState_TR(TT.second, m_mass / m_vol);
+        m_thermo->setState_TD(TT.second, m_mass / m_vol);
     } else {
         m_thermo->setDensity(m_mass / m_vol);
     }

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -141,7 +141,7 @@ void Reactor::updateState(doublereal* y)
         double U = y[2];
         // Residual function: error in internal energy as a function of T
         auto u_err = [this, U](double T) {
-            m_thermo->setState_TR(T, m_mass / m_vol);
+            m_thermo->setState_TD(T, m_mass / m_vol);
             return m_thermo->intEnergy_mass() * m_mass - U;
         };
 
@@ -159,7 +159,7 @@ void Reactor::updateState(doublereal* y)
                     bmt::eps_tolerance<double>(48), maxiter);
             } catch (std::exception& err2) {
                 // Set m_thermo back to a reasonable state if root finding fails
-                m_thermo->setState_TR(T, m_mass / m_vol);
+                m_thermo->setState_TD(T, m_mass / m_vol);
                 throw CanteraError("Reactor::updateState",
                     "{}\nat U = {}, rho = {}", err2.what(), U, m_mass / m_vol);
             }
@@ -167,7 +167,7 @@ void Reactor::updateState(doublereal* y)
         if (fabs(TT.first - TT.second) > 1e-7*TT.first) {
             throw CanteraError("Reactor::updateState", "root finding failed");
         }
-        m_thermo->setState_TR(TT.second, m_mass / m_vol);
+        m_thermo->setState_TD(TT.second, m_mass / m_vol);
     } else {
         m_thermo->setDensity(m_mass/m_vol);
     }

--- a/test/thermo/PengRobinson_Test.cpp
+++ b/test/thermo/PengRobinson_Test.cpp
@@ -139,7 +139,7 @@ TEST_F(PengRobinson_Test, getPressure)
     {
         const double temp = 296 + i * 50;
         set_r(1.0);
-        test_phase->setState_TR(temp, rho);
+        test_phase->setState_TD(temp, rho);
         const double Tcrit = test_phase->critTemperature();
         mv = 1 / rho * test_phase->meanMolecularWeight();
         //Calculate pressure using Peng-Robinson EoS

--- a/test/thermo/ThermoPhase_Test.cpp
+++ b/test/thermo/ThermoPhase_Test.cpp
@@ -55,7 +55,7 @@ TEST_F(TestThermoMethods, setState_nan)
     EXPECT_THROW(thermo->setState_TP(555, nan), CanteraError);
     EXPECT_THROW(thermo->setState_HP(nan, 55555), CanteraError);
     EXPECT_THROW(thermo->setState_SV(1234, nan), CanteraError);
-    EXPECT_THROW(thermo->setState_TR(555, nan), CanteraError);
+    EXPECT_THROW(thermo->setState_TD(555, nan), CanteraError);
 }
 
 TEST_F(TestThermoMethods, setState_AnyMap)

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -283,7 +283,7 @@ TEST_P(TestConsistency, cv_eq_dudT)
     double T1 = phase->temperature();
     double dT = 1e-5 * phase->temperature();
     if (phase->isCompressible()) {
-        phase->setState_TR(T1 + dT, phase->density());
+        phase->setState_TD(T1 + dT, phase->density());
     } else {
         phase->setTemperature(T1 + dT);
     }
@@ -325,7 +325,7 @@ TEST_P(TestConsistency, cv_eq_dsdT_const_v_times_T)
     double T1 = phase->temperature();
     double dT = 1e-4 * phase->temperature();
     if (phase->isCompressible()) {
-        phase->setState_TR(T1 + dT, phase->density());
+        phase->setState_TD(T1 + dT, phase->density());
     } else {
         phase->setTemperature(T1 + dT);
     }
@@ -371,12 +371,12 @@ TEST_P(TestConsistency, dSdv_const_T_eq_dPdT_const_V) {
         double v1 = 1 / phase->density();
         double P1 = phase->pressure();
         double v2 = v1 * (1 + 1e-7);
-        phase->setState_TR(T, 1 / v2);
+        phase->setState_TD(T, 1 / v2);
         double s2 = phase->entropy_mass();
         double dsdv = (s2 - s1) / (v2 - v1);
 
         double T2 = T * (1 + 1e-7);
-        phase->setState_TR(T2, 1 / v1);
+        phase->setState_TD(T2, 1 / v1);
         double P2 = phase->pressure();
         double dPdT = (P2 - P1) / (T2 - T);
         double tol = rtol_fd * std::max(std::abs(dPdT), std::abs(dsdv));

--- a/test/thermo/cubicSolver_Test.cpp
+++ b/test/thermo/cubicSolver_Test.cpp
@@ -78,7 +78,7 @@ TEST_F(cubicSolver_Test, solve_cubic)
     // Obtain pressure using EoS and compare against the given pressure value
     set_r(1.0);
     rho = test_phase->meanMolecularWeight()/Vroot[0];
-    peng_robinson_phase->setState_TR(temp, rho);
+    peng_robinson_phase->setState_TD(temp, rho);
     p = peng_robinson_phase->pressure();
     EXPECT_NEAR(p, pres, 1);
 
@@ -95,7 +95,7 @@ TEST_F(cubicSolver_Test, solve_cubic)
     // Obtain pressure using EoS and compare against the given pressure value
     set_r(1.0);
     rho = test_phase->meanMolecularWeight()/Vroot[0];
-    peng_robinson_phase->setState_TR(temp, rho);
+    peng_robinson_phase->setState_TD(temp, rho);
     p = peng_robinson_phase->pressure();
     EXPECT_NEAR(p, pres, 1);
 
@@ -111,7 +111,7 @@ TEST_F(cubicSolver_Test, solve_cubic)
     // Obtain pressure using EoS and compare against the given pressure value
     set_r(1.0);
     rho = test_phase->meanMolecularWeight()/Vroot[0];
-    peng_robinson_phase->setState_TR(Tcrit, rho);
+    peng_robinson_phase->setState_TD(Tcrit, rho);
     p = peng_robinson_phase->pressure();
     EXPECT_NEAR(p, pCrit, 1);
 }

--- a/test/thermo/water_iapws.cpp
+++ b/test/thermo/water_iapws.cpp
@@ -54,10 +54,10 @@ class WaterPropsIAPWS_Test : public testing::Test
 public:
     double dPdT(double T, double P) {
         double rho = water.density(T, P);
-        water.setState_TR(T, rho);
+        water.setState_TD(T, rho);
         double P1 = water.pressure();
         double T2 = T + 0.001;
-        water.setState_TR(T2, rho);
+        water.setState_TD(T2, rho);
         double P2 = water.pressure();
         return (P2 - P1) / 0.001;
     }
@@ -131,7 +131,7 @@ TEST_F(WaterPropsIAPWS_Test, expansion_coeffs)
     vector_fp beta_num{1.0000203087, 1265.46651311, 1.2405192825};
     for (size_t i = 0; i < TT.size(); i++) {
         double rho = water.density(TT[i], PP[i], WATER_GAS);
-        water.setState_TR(TT[i], rho);
+        water.setState_TD(TT[i], rho);
         EXPECT_NEAR(water.coeffThermExp(), alpha[i], 2e-14);
         EXPECT_NEAR(water.coeffPresExp(), beta[i], beta[i] * 2e-12);
         EXPECT_NEAR(dPdT(TT[i], PP[i]) / (461.51805 * rho),


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

While Cantera's Python nomenclature uses `TD`/`TDX`/`TDY` and `DP`/`DPX`/`DPY`, other API's use the older (?) nomenclature `TR`/`TRX`/`TRY` and `RP`/`RPX`/`RPY`. This PR seeks to implement a uniform nomenclature.

In addition, a new 
```C++
    CANTERA_CAPI int thermo_set_TD(int n, double* vals);
```
is added to `ct.h`, which is needed for work in #1182.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
