### PR TITLE
[Scons] Remove "install" target from "check_for_pytest"

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1697,17 +1697,17 @@ ruamel_min_version = parse_version('0.15.34')
 # Minimum pytest version assumed based on Ubuntu 20.04
 pytest_min_version = parse_version("4.6.9")
 
+# Pytest is required only to test the Python module
+check_for_pytest = any(
+    target.startswith("test-python") for target in COMMAND_LINE_TARGETS
+)
+
 # Check for the minimum ruamel.yaml version, 0.15.34, at install and test
 # time. The check happens at install and test time because ruamel.yaml is
 # only required to run the Python interface, not to build it.
-check_for_ruamel_yaml = any(
+check_for_ruamel_yaml = check_for_pytest or any(
     target in COMMAND_LINE_TARGETS
-    for target in ["install", "test", "test-python-convert", "test-python"]
-)
-
-# Pytest is required only to test the Python module
-check_for_pytest = check_for_ruamel_yaml or any(
-    target.startswith("test-python") for target in COMMAND_LINE_TARGETS
+    for target in ["install", "test"]
 )
 
 if env['python_package'] == 'y':


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The `check_for_pytest` depends on `check_for_ruamel_yaml` the pytest package is required on `install` phase and it results in the Cantera installation fail if pytest absent even if tests were not required. 

This patch swap `check_for_pytest` and `check_for_ruamel_yaml` dependency order.

The explicit `test-python-convert`, `test-python` targets are dropped from `check_for_ruamel_yaml` because the `check_for_pytest` includes `target.startswith("test-python")`.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

See commit https://github.com/Cantera/cantera/commit/72734b1edd562d4ff4050136821b5003c633f9ab#r97347952 discussion

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
