### PR TITLE
Cleaning up the redundant line inside the for loop in evalSurfaces()

### DIFF
--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -299,7 +299,6 @@ void Reactor::evalSurfaces(double* LHS, double* RHS, double* sdot)
             RHS[loc + k] = m_work[surfloc + k] * rs0 * surf->size(k);
             sum -= RHS[loc + k];
         }
-        LHS[loc] = 1.0;
         RHS[loc] = sum;
         loc += nk;
 

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -296,7 +296,6 @@ void Reactor::evalSurfaces(double* LHS, double* RHS, double* sdot)
         size_t ns = kin->reactionPhaseIndex();
         size_t surfloc = kin->kineticsSpeciesIndex(0,ns);
         for (size_t k = 1; k < nk; k++) {
-            LHS[loc] = 1.0;
             RHS[loc + k] = m_work[surfloc + k] * rs0 * surf->size(k);
             sum -= RHS[loc + k];
         }


### PR DESCRIPTION
**Changes proposed in this pull request**
The LHS array in `evalSurfaces()` is set to 1 by default. The line `LHS[loc] = 1` inside the for loop is removed, as it is redundant and confusing. 