### PR TITLE
Add callbacks for synchronizing with C++ Solution members

### DIFF
--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -108,6 +108,22 @@ public:
     //! Returns a null pointer if the requested handle does not exist.
     shared_ptr<ExternalHandle> getExternalHandle(const std::string& name) const;
 
+    //! Register a function to be called if any of the Solution's thermo, kinetics,
+    //! or transport objects is replaced.
+    //! @param id  A unique ID corresponding to the object affected by the callback.
+    //!   Typically, this is a pointer to an object that also holds a reference to the
+    //!   Solution object.
+    //! @param callback  The callback function to be called after any component of the
+    //!   Solution is replaced.
+    //! When the callback becomes invalid (for example, the corresponding object is
+    //! being deleted, the removeChangedCallback() method must be invoked.
+    //! @since New in Cantera 3.0
+    void registerChangedCallback(void* id, const function<void()>& callback);
+
+    //! Remove the callback function associated with the specified object.
+    //! @since New in Cantera 3.0
+    void removeChangedCallback(void* id);
+
 protected:
     shared_ptr<ThermoPhase> m_thermo;  //!< ThermoPhase manager
     shared_ptr<Kinetics> m_kinetics;  //!< Kinetics manager
@@ -124,6 +140,10 @@ protected:
     //! Wrappers for this Kinetics object in extension languages, for evaluation
     //! of user-defined reaction rates
     std::map<std::string, shared_ptr<ExternalHandle>> m_externalHandles;
+
+    //! Callback functions that are invoked when the therm, kinetics, or transport
+    //! members of the Solution are replaced.
+    map<void*, function<void()>> m_changeCallbacks;
 };
 
 //! Create and initialize a new Solution from an input file

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -63,6 +63,8 @@ public:
     //! @param points  initial number of grid points
     StFlow(shared_ptr<Solution> sol, const std::string& id="", size_t points=1);
 
+    ~StFlow();
+
     //! @name Problem Specification
     //! @{
 
@@ -439,11 +441,6 @@ protected:
     IdealGasPhase* m_thermo;
     Kinetics* m_kin;
     Transport* m_trans;
-
-    // Smart pointer preventing garbage collection when the transport model of an
-    // associated Solution object changes: the transport model of the StFlow object
-    // will remain unaffected by an external change.
-    shared_ptr<Transport> m_trans_shared;
 
     // boundary emissivities for the radiation calculations
     doublereal m_epsilon_left;

--- a/interfaces/cython/cantera/delegator.pxd
+++ b/interfaces/cython/cantera/delegator.pxd
@@ -84,3 +84,4 @@ cdef extern from "cantera/base/ExtensionManagerFactory.h" namespace "Cantera":
 ctypedef CxxDelegator* CxxDelegatorPtr
 
 cdef int assign_delegates(object, CxxDelegator*) except -1
+cdef void callback_v(PyFuncInfo& funcInfo)

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -59,6 +59,8 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         size_t nAdjacent()
         shared_ptr[CxxSolution] adjacent(size_t)
         void holdExternalHandle(string&, shared_ptr[CxxExternalHandle])
+        void registerChangedCallback(void*, function[void()])
+        void removeChangedCallback(void*)
 
     cdef shared_ptr[CxxSolution] CxxNewSolution "Cantera::Solution::create" ()
     cdef shared_ptr[CxxSolution] newSolution (
@@ -86,4 +88,5 @@ cdef class _SolutionBase:
     cdef np.ndarray _selected_species
     cdef object parent
     cdef object _adjacent
+    cdef object _soln_changed_callback
     cdef public object _references

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -195,7 +195,6 @@ cdef class Transport(_SolutionBase):
 
         def __set__(self, model):
             self.base.setTransport(newTransport(self.thermo, stringify(model)))
-            self.transport = self.base.transport().get()
 
     property CK_mode:
         """Boolean to indicate if the chemkin interpretation is used."""

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -42,6 +42,9 @@ void Solution::setName(const std::string& name) {
 
 void Solution::setThermo(shared_ptr<ThermoPhase> thermo) {
     m_thermo = thermo;
+    for (const auto& [id, callback] : m_changeCallbacks) {
+        callback();
+    }
 }
 
 void Solution::setKinetics(shared_ptr<Kinetics> kinetics) {
@@ -49,10 +52,16 @@ void Solution::setKinetics(shared_ptr<Kinetics> kinetics) {
     if (m_kinetics) {
         m_kinetics->setRoot(shared_from_this());
     }
+    for (const auto& [id, callback] : m_changeCallbacks) {
+        callback();
+    }
 }
 
 void Solution::setTransport(shared_ptr<Transport> transport) {
     m_transport = transport;
+    for (const auto& [id, callback] : m_changeCallbacks) {
+        callback();
+    }
 }
 
 void Solution::setTransportModel(const std::string& model) {
@@ -152,10 +161,20 @@ shared_ptr<ExternalHandle> Solution::getExternalHandle(const std::string& name) 
     }
 }
 
-shared_ptr<Solution> newSolution(const std::string& infile,
-                                 const std::string& name,
-                                 const std::string& transport,
-                                 const std::vector<shared_ptr<Solution>>& adjacent)
+void Solution::registerChangedCallback(void *id, const function<void()>& callback)
+{
+    m_changeCallbacks[id] = callback;
+}
+
+void Solution::removeChangedCallback(void* id)
+{
+    m_changeCallbacks.erase(id);
+}
+
+shared_ptr<Solution> newSolution(const std::string &infile,
+                                 const std::string &name,
+                                 const std::string &transport,
+                                 const std::vector<shared_ptr<Solution>> &adjacent)
 {
     // get file extension
     size_t dot = infile.find_last_of(".");

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -64,8 +64,7 @@ IonFlow::IonFlow(shared_ptr<Solution> sol, const std::string& id, size_t points)
     m_solution = sol;
     m_id = id;
     m_kin = m_solution->kinetics().get();
-    m_trans_shared = m_solution->transport();
-    m_trans = m_trans_shared.get();
+    m_trans = m_solution->transport().get();
     if (m_trans->transportModel() == "None") {
         // @deprecated
         warn_deprecated("IonFlow",
@@ -74,6 +73,10 @@ IonFlow::IonFlow(shared_ptr<Solution> sol, const std::string& id, size_t points)
             "is deprecated and\nwill be removed after Cantera 3.0.");
         setTransportModel("Ion");
     }
+    m_solution->registerChangedCallback(this, [this]() {
+        setKinetics(*m_solution->kinetics());
+        setTransport(*m_solution->transport());
+    });
 }
 
 void IonFlow::resize(size_t components, size_t points){

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -128,6 +128,22 @@ class TestOnedim(utilities.CanteraTest):
         self.assertEqual(rtol_ss, set((5e-3, 3e-4, 7e-7)))
         self.assertEqual(rtol_ts, set((6e-3, 4e-4, 2e-7)))
 
+    def test_switch_transport(self):
+        gas = ct.Solution('h2o2.yaml')
+        gas.set_equivalence_ratio(0.9, 'H2', 'O2:0.21, N2:0.79')
+        flame = ct.FreeFlame(gas, width=0.1)
+        flame.set_initial_guess()
+
+        assert gas.transport_model == flame.transport_model == 'Mix'
+
+        flame.transport_model = 'UnityLewis'
+        assert gas.transport_model == flame.transport_model == 'UnityLewis'
+        Dkm_flame = flame.mix_diff_coeffs
+        assert all(Dkm_flame[1,:] == Dkm_flame[2,:])
+
+        gas.transport_model = 'Multi'
+        assert flame.transport_model == 'Multi'
+
 
 class TestFreeFlame(utilities.CanteraTest):
     tol_ss = [1.0e-5, 1.0e-14]  # [rtol atol] for steady-state problem


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add a system for registering callback functions with the C++ `Solution` class that are invoked whenever one of the members of the `Solution` is replaced, e.g. by calling `setTransportModel`.
- Register callbacks from `StFlow` and `IonFlow`
- Register a callback from the Python `Solution` class

**If applicable, fill in the issue number this pull request is fixing**

Fixes #1409

**If applicable, provide an example illustrating new features this pull request is introducing**

```py
>>> import cantera as ct
>>> gas = ct.Solution('h2o2.yaml')
>>> flame = ct.FreeFlame(gas, width=0.1)
>>> gas.transport_model = 'UnityLewis'
>>> print(gas.transport_model, flame.transport_model)
UnityLewis UnityLewis
>>> flame.transport_model = 'Multi'
>>> print(gas.transport_model, flame.transport_model)
Multi Multi
```
<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
