### PR TITLE
OneD domain factories and cleanup

### DIFF
--- a/doc/sphinx/cython/onedim.rst
+++ b/doc/sphinx/cython/onedim.rst
@@ -59,17 +59,17 @@ IdealGasFlow
 .. autoclass:: IdealGasFlow(thermo)
     :inherited-members:
 
-IonFlow
-^^^^^^^
-.. autoclass:: IonFlow(thermo)
-
 FreeFlow
 ^^^^^^^^
 .. autoclass:: FreeFlow(thermo)
 
-AxisymmetricStagnationFlow
-^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: AxisymmetricStagnationFlow(thermo)
+AxisymmetricFlow
+^^^^^^^^^^^^^^^^
+.. autoclass:: AxisymmetricFlow(thermo)
+
+IonFlow
+^^^^^^^
+.. autoclass:: IonFlow(thermo)
 
 Boundaries
 ----------

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -28,6 +28,7 @@ extern "C" {
     CANTERA_CAPI int soln_thermo(int n);
     CANTERA_CAPI int soln_kinetics(int n);
     CANTERA_CAPI int soln_transport(int n);
+    //! note that soln_setTransportModel deletes the previous transport model
     CANTERA_CAPI int soln_setTransportModel(int n, const char* model);
     CANTERA_CAPI size_t soln_nAdjacent(int n);
     CANTERA_CAPI int soln_adjacent(int n, int a);

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -28,6 +28,7 @@ extern "C" {
     CANTERA_CAPI int soln_thermo(int n);
     CANTERA_CAPI int soln_kinetics(int n);
     CANTERA_CAPI int soln_transport(int n);
+    CANTERA_CAPI int soln_setTransportModel(int n, const char* model);
     CANTERA_CAPI size_t soln_nAdjacent(int n);
     CANTERA_CAPI int soln_adjacent(int n, int a);
 
@@ -158,6 +159,7 @@ extern "C" {
     CANTERA_CAPI int trans_newDefault(int th, int loglevel);
     CANTERA_CAPI int trans_new(const char* model, int th, int loglevel);
     CANTERA_CAPI int trans_del(int n);
+    CANTERA_CAPI int trans_transportModel(int n, int lennm, char* nm);
     CANTERA_CAPI double trans_viscosity(int n);
     CANTERA_CAPI double trans_electricalConductivity(int n);
     CANTERA_CAPI double trans_thermalConductivity(int n);

--- a/include/cantera/clib/ctonedim.h
+++ b/include/cantera/clib/ctonedim.h
@@ -15,6 +15,7 @@ extern "C" {
 #endif
 
     CANTERA_CAPI int ct_clearOneDim();
+    CANTERA_CAPI int domain_new(const char* type, int i, const char* id);
     CANTERA_CAPI int domain_del(int i);
     CANTERA_CAPI int domain_type(int i);
     CANTERA_CAPI int domain_type3(int i, size_t lennm, char* nm);

--- a/include/cantera/clib/ctonedim.h
+++ b/include/cantera/clib/ctonedim.h
@@ -17,6 +17,7 @@ extern "C" {
     CANTERA_CAPI int ct_clearOneDim();
     CANTERA_CAPI int domain_del(int i);
     CANTERA_CAPI int domain_type(int i);
+    CANTERA_CAPI int domain_type3(int i, size_t lennm, char* nm);
     CANTERA_CAPI size_t domain_index(int i);
     CANTERA_CAPI size_t domain_nComponents(int i);
     CANTERA_CAPI size_t domain_nPoints(int i);
@@ -70,6 +71,7 @@ extern "C" {
     CANTERA_CAPI int sim1D_setProfile(int i, int dom, int comp,
                                       size_t np, const double* pos, size_t nv, const double* v);
     CANTERA_CAPI int sim1D_setFlatProfile(int i, int dom, int comp, double v);
+    CANTERA_CAPI int sim1D_show(int i, const char* fname);
     CANTERA_CAPI int sim1D_showSolution(int i, const char* fname);
     CANTERA_CAPI int sim1D_setTimeStep(int i, double stepsize, size_t ns, const int* nsteps);
     CANTERA_CAPI int sim1D_getInitialSoln(int i);

--- a/include/cantera/clib/ctonedim.h
+++ b/include/cantera/clib/ctonedim.h
@@ -40,8 +40,10 @@ extern "C" {
 
     CANTERA_CAPI int bdry_setMdot(int i, double mdot);
     CANTERA_CAPI int bdry_setTemperature(int i, double t);
+    CANTERA_CAPI int bdry_setSpreadRate(int i, double v);
     CANTERA_CAPI int bdry_setMoleFractions(int i, const char* x);
     CANTERA_CAPI double bdry_temperature(int i);
+    CANTERA_CAPI double bdry_spreadRate(int i);
     CANTERA_CAPI double bdry_massFraction(int i, int k);
     CANTERA_CAPI double bdry_mdot(int i);
 

--- a/include/cantera/core.h
+++ b/include/cantera/core.h
@@ -10,6 +10,7 @@
 #define CT_INCL_CORE_H
 
 #include "cantera/base/Solution.h"
+#include "cantera/base/Interface.h"
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/kinetics/Kinetics.h"
 #include "cantera/transport/Transport.h"

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -83,6 +83,16 @@ public:
         m_mdot = mdot;
     }
 
+    //! Set tangential velocity gradient [1/s] at this boundary.
+    virtual void setSpreadRate(double V0) {
+        throw NotImplementedError("Boundary1D::setSpreadRate");
+    }
+
+    //! Tangential velocity gradient [1/s] at this boundary.
+    virtual double spreadRate() {
+        throw NotImplementedError("Boundary1D::spreadRate");
+    }
+
     //! The total mass flow rate [kg/m2/s].
     virtual double mdot() {
         return m_mdot;
@@ -129,10 +139,8 @@ public:
         return "inlet";
     }
 
-    //! set spreading rate
     virtual void setSpreadRate(double V0);
 
-    //! spreading rate
     virtual double spreadRate() {
         return m_V0;
     }

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -145,7 +145,7 @@ public:
         return m_V0;
     }
 
-    virtual void showSolution(const double* x);
+    virtual void show(const double* x);
 
     virtual size_t nSpecies() {
         return m_nsp;
@@ -191,7 +191,7 @@ public:
         return "empty";
     }
 
-    virtual void showSolution(const double* x) {}
+    virtual void show(const double* x) {}
 
     virtual void init();
 
@@ -278,7 +278,7 @@ public:
         return "outlet-reservoir";
     }
 
-    virtual void showSolution(const double* x) {}
+    virtual void show(const double* x) {}
 
     virtual size_t nSpecies() {
         return m_nsp;
@@ -332,9 +332,9 @@ public:
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
     virtual void restore(SolutionArray& arr, double* soln, int loglevel);
 
-    virtual void showSolution_s(std::ostream& s, const double* x);
+    virtual void show(std::ostream& s, const double* x);
 
-    virtual void showSolution(const double* x);
+    virtual void show(const double* x);
 };
 
 /**
@@ -383,7 +383,7 @@ public:
         std::copy(x, x+m_nsp, m_fixed_cov.begin());
     }
 
-    virtual void showSolution(const double* x);
+    virtual void show(const double* x);
 
 protected:
     InterfaceKinetics* m_kin = nullptr;

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -41,6 +41,14 @@ public:
         _init(1);
     }
 
+    virtual string type() const {
+        return "boundary";
+    }
+
+    virtual bool isConnector() {
+        return true;
+    }
+
     //! Set the temperature.
     virtual void setTemperature(double t) {
         m_temp = t;
@@ -117,6 +125,10 @@ public:
 
     Inlet1D(shared_ptr<Solution> solution, const string& id="");
 
+    virtual string type() const {
+        return "inlet";
+    }
+
     //! set spreading rate
     virtual void setSpreadRate(double V0);
 
@@ -167,6 +179,10 @@ public:
         m_id = id;
     }
 
+    virtual string type() const {
+        return "empty";
+    }
+
     virtual void showSolution(const double* x) {}
 
     virtual void init();
@@ -195,6 +211,10 @@ public:
         m_id = id;
     }
 
+    virtual string type() const {
+        return "symmetry-plane";
+    }
+
     virtual void init();
 
     virtual void eval(size_t jg, double* xg, double* rg,
@@ -221,6 +241,10 @@ public:
         m_id = id;
     }
 
+    virtual string type() const {
+        return "outlet";
+    }
+
     virtual void init();
 
     virtual void eval(size_t jg, double* xg, double* rg,
@@ -241,6 +265,10 @@ public:
     OutletRes1D();
 
     OutletRes1D(shared_ptr<Solution> solution, const string& id="");
+
+    virtual string type() const {
+        return "outlet-reservoir";
+    }
 
     virtual void showSolution(const double* x) {}
 
@@ -284,6 +312,10 @@ public:
         m_id = id;
     }
 
+    virtual string type() const {
+        return "surface";
+    }
+
     virtual void init();
 
     virtual void eval(size_t jg, double* xg, double* rg,
@@ -306,6 +338,10 @@ class ReactingSurf1D : public Boundary1D
 public:
     ReactingSurf1D();
     ReactingSurf1D(shared_ptr<Solution> solution, const std::string& id="");
+
+    virtual string type() const {
+        return "reacting-surface";
+    }
 
     virtual void setKinetics(shared_ptr<Kinetics> kin);
 

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -11,7 +11,7 @@
 namespace Cantera
 {
 
-// domain types
+// domain types (deprecated); to be removed after Cantera 3.0
 const int cFlowType = 50;
 const int cFreeFlow = 51;
 const int cAxisymmetricStagnationFlow = 52;
@@ -552,7 +552,7 @@ protected:
     vector_fp m_z;
     OneDim* m_container = nullptr;
     size_t m_index;
-    int m_type = 0;
+    int m_type = 0; //!< @deprecated To be removed after Cantera 3.0
 
     //! Starting location within the solution vector for unknowns that
     //! correspond to this domain

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -57,14 +57,20 @@ public:
         return m_type;
     }
 
+    //! String indicating the domain implemented.
+    //! @since New in Cantera 3.0.
+    virtual string type() const {
+        return "domain";
+    }
+
     //! The left-to-right location of this domain.
     size_t domainIndex() {
         return m_index;
     }
 
     //! True if the domain is a connector domain.
-    bool isConnector() {
-        return (m_type >= cConnectorType);
+    virtual bool isConnector() {
+        return false;
     }
 
     //! Set the solution manager.

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -472,10 +472,18 @@ public:
         }
     }
 
-    virtual void showSolution_s(std::ostream& s, const doublereal* x) {}
+    //! @deprecated To be removed after Cantera 3.0; replaced by show
+    virtual void showSolution_s(std::ostream& s, const double* x);
 
     //! Print the solution.
-    virtual void showSolution(const doublereal* x);
+    //! @deprecated To be removed after Cantera 3.0; replaced by show
+    virtual void showSolution(const double* x);
+
+    //! Print the solution.
+    virtual void show(std::ostream& s, const double* x) {}
+
+    //! Print the solution.
+    virtual void show(const double* x);
 
     doublereal z(size_t jlocal) const {
         return m_z[jlocal];

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -53,12 +53,12 @@ public:
     Domain1D& operator=(const Domain1D&) = delete;
 
     //! Domain type flag.
-    int domainType() {
-        return m_type;
-    }
+    //! @deprecated  To be changed after Cantera 3.0; for new behavior, see type.
+    int domainType();
 
     //! String indicating the domain implemented.
     //! @since New in Cantera 3.0.
+    //! @todo Transition back to domainType after Cantera 3.0
     virtual string type() const {
         return "domain";
     }

--- a/include/cantera/oneD/DomainFactory.h
+++ b/include/cantera/oneD/DomainFactory.h
@@ -1,0 +1,74 @@
+//! @file DomainFactory.h
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef DOMAIN_FACTORY_H
+#define DOMAIN_FACTORY_H
+
+#include "cantera/oneD/Domain1D.h"
+#include "cantera/base/FactoryBase.h"
+
+namespace Cantera
+{
+
+//! Factory class to create domain objects
+//!
+//! This class is mainly used via the newDomain() function, for example:
+//!
+//! ```cpp
+//!     shared_ptr<Domain1D> d1 = newDomain("Inlet", sol, "reactants");
+//! ```
+//!
+//! @ingroup onedim
+class DomainFactory : public Factory<Domain1D, shared_ptr<Solution>, const string&>
+{
+public:
+    /**
+     * Return a pointer to the factory. On the first call, a new instance is
+     * created. Since there is no need to instantiate more than one factory,
+     * on all subsequent calls, a pointer to the existing factory is returned.
+     */
+    static DomainFactory* factory();
+
+    virtual void deleteFactory();
+
+private:
+    //! Pointer to the single instance of the factory
+    static DomainFactory* s_factory;
+
+    //! default constructor, which is defined as private
+    DomainFactory();
+
+    //! Mutex for use when calling the factory
+    static std::mutex domain_mutex;
+};
+
+//! Create a Domain object of the specified type. An optional template argument will
+//! dynamically cast Domain1D to the desired specialization.
+//! @param domainType  string identifying domain type.
+//! @param solution  Solution holding ThermoPhase, Kinetics and Transport objects.
+//! @param id  string identifier describing domain. If omitted, id defaults to the
+//!     domain type identifier.
+//! @ingroup onedim
+template <class T=Domain1D>
+shared_ptr<T> newDomain(
+    const string& domainType, shared_ptr<Solution> solution, const string& id="")
+{
+    string id_ = id;
+    if (id_ == "") {
+        id_ = domainType;
+    }
+    auto ret = std::dynamic_pointer_cast<T>(
+        shared_ptr<Domain1D>(
+            DomainFactory::factory()->create(domainType, solution, id_)));
+    if (!ret) {
+        throw CanteraError("newDomain",
+            "Invalid cast: unable to access 'Domain1D' as '{}'.", demangle(typeid(T)));
+    }
+    return ret;
+}
+
+}
+
+#endif

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -40,6 +40,10 @@ public:
     //! @param points  initial number of grid points
     IonFlow(shared_ptr<Solution> sol, const std::string& id="", size_t points = 1);
 
+    virtual string type() const {
+        return "ion-flow";
+    }
+
     //! set the solving stage
     virtual void setSolvingStage(const size_t phase);
 

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -40,9 +40,7 @@ public:
     //! @param points  initial number of grid points
     IonFlow(shared_ptr<Solution> sol, const std::string& id="", size_t points = 1);
 
-    virtual string type() const {
-        return "ion-flow";
-    }
+    virtual string type() const;
 
     //! set the solving stage
     virtual void setSolvingStage(const size_t phase);

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -29,12 +29,20 @@ public:
     OneDim();
 
     //! Construct a OneDim container for the domains in the list *domains*.
+    OneDim(vector<shared_ptr<Domain1D>>& domains);
+
+    //! @deprecated  To be removed after Cantera 3.0;
+    //!     superseded by OneDim() using vector<shared_ptr<Domain1D>>
     OneDim(std::vector<Domain1D*> domains);
     virtual ~OneDim();
     OneDim(const OneDim&) = delete;
     OneDim& operator=(const OneDim&) = delete;
 
     //! Add a domain. Domains are added left-to-right.
+    void addDomain(shared_ptr<Domain1D> d);
+
+    //! @deprecated  To be removed after Cantera 3.0;
+    //!     superseded by addDomain() using shared_ptr<Domain1D>
     void addDomain(Domain1D* d);
 
     //! Return a reference to the Jacobian evaluator.
@@ -339,7 +347,13 @@ protected:
     size_t m_bw = 0; //!< Jacobian bandwidth
     size_t m_size = 0; //!< solution vector size
 
-    std::vector<Domain1D*> m_dom, m_connect, m_bulk;
+    vector<shared_ptr<Domain1D>> m_sharedDom;
+    vector<shared_ptr<Domain1D>> m_sharedConnect;
+    vector<shared_ptr<Domain1D>> m_sharedBulk;
+
+    vector<Domain1D*> m_dom; //!< @todo remove raw pointers after Cantera 3.0
+    vector<Domain1D*> m_connect; //!< @todo remove raw pointers after Cantera 3.0
+    vector<Domain1D*> m_bulk; //!< @todo remove raw pointers after Cantera 3.0
 
     bool m_init = false;
     std::vector<size_t> m_nvars;

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -103,13 +103,26 @@ public:
     /**
      * Output information on current solution for all domains to stream.
      * @param s  Output stream
+     * @deprecated To be removed after Cantera 3.0; replaced by show
      */
     void showSolution(std::ostream& s);
 
     /**
      * Show logging information on current solution for all domains.
+     * @deprecated To be removed after Cantera 3.0; replaced by show
      */
     void showSolution();
+
+    /**
+     * Output information on current solution for all domains to stream.
+     * @param s  Output stream
+     */
+    void show(std::ostream& s);
+
+    /**
+     * Show logging information on current solution for all domains.
+     */
+    void show();
 
     /**
      * Save the current solution to a container file.

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -30,11 +30,15 @@ public:
 
     /**
      * Standard constructor.
-     * @param domains A vector of pointers to the domains to be linked together.
+     * @param domains A vector of shared pointers to the domains to be linked together.
      *     The domain pointers must be entered in left-to-right order --- that is,
      *     the pointer to the leftmost domain is domain[0], the pointer to the
      *     domain to its right is domain[1], etc.
      */
+    Sim1D(vector<shared_ptr<Domain1D>>& domains);
+
+    //! @deprecated  To be removed after Cantera 3.0;
+    //!     superseded by Sim1D() using shared_ptr
     Sim1D(std::vector<Domain1D*>& domains);
 
     //! @name Setting initial values

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -63,6 +63,10 @@ public:
 
     ~StFlow();
 
+    virtual string type() const {
+        return "gas-flow";
+    }
+
     //! @name Problem Specification
     //! @{
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -188,6 +188,12 @@ public:
         m_isFree = false;
     }
 
+    //! Return flag indicating whether flow is free
+    //! @see setFreeFlow setAxisymmetricFlow
+    bool isFree() {
+        return m_isFree;
+    }
+
     //! Return the type of flow domain being represented, either "Free Flame" or
     //! "Axisymmetric Stagnation".
     //! @see setFreeFlow setAxisymmetricFlow

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -166,7 +166,7 @@ public:
     virtual bool componentActive(size_t n) const;
 
     //! Print the solution.
-    virtual void showSolution(const doublereal* x);
+    virtual void show(const double* x);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
     virtual void restore(SolutionArray& arr, double* soln, int loglevel);

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -188,12 +188,6 @@ public:
         m_isFree = false;
     }
 
-    //! Return flag indicating whether flow is free
-    //! @see setFreeFlow setAxisymmetricFlow
-    bool isFree() {
-        return m_isFree;
-    }
-
     //! Return the type of flow domain being represented, either "Free Flame" or
     //! "Axisymmetric Stagnation".
     //! @see setFreeFlow setAxisymmetricFlow

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -63,9 +63,7 @@ public:
 
     ~StFlow();
 
-    virtual string type() const {
-        return "gas-flow";
-    }
+    virtual string type() const;
 
     //! @name Problem Specification
     //! @{
@@ -179,6 +177,7 @@ public:
     void setFreeFlow() {
         m_type = cFreeFlow;
         m_dovisc = false;
+        m_isFree = true;
     }
 
     //! Set flow configuration for axisymmetric counterflow or burner-stabilized
@@ -186,11 +185,13 @@ public:
     void setAxisymmetricFlow() {
         m_type = cAxisymmetricStagnationFlow;
         m_dovisc = true;
+        m_isFree = false;
     }
 
     //! Return the type of flow domain being represented, either "Free Flame" or
     //! "Axisymmetric Stagnation".
     //! @see setFreeFlow setAxisymmetricFlow
+    //! @deprecated  To be removed after Cantera 3.0; replaced by type.
     virtual string flowType() const;
 
     void solveEnergyEqn(size_t j=npos);
@@ -480,6 +481,7 @@ protected:
     size_t m_kExcessRight = 0;
 
     bool m_dovisc;
+    bool m_isFree;
 
     //! Update the transport properties at grid points in the range from `j0`
     //! to `j1`, based on solution `x`.

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -97,7 +97,7 @@ cdef extern from "cantera/oneD/IonFlow.h":
 
 cdef extern from "cantera/oneD/Sim1D.h":
     cdef cppclass CxxSim1D "Cantera::Sim1D":
-        CxxSim1D(vector[CxxDomain1D*]&) except +translate_exception
+        CxxSim1D(vector[shared_ptr[CxxDomain1D]]&) except +translate_exception
         void setValue(size_t, size_t, size_t, double) except +translate_exception
         void setProfile(size_t, size_t, vector[double]&, vector[double]&) except +translate_exception
         void setFlatProfile(size_t, size_t, double) except +translate_exception

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -16,7 +16,7 @@ class _WeakrefProxy:
     pass
 
 cdef class Domain1D:
-    _domain_type = "None"
+    _domain_type = "none"
     def __cinit__(self, _SolutionBase phase not None, *args, **kwargs):
         self.domain = NULL
 
@@ -673,6 +673,49 @@ cdef class _FlowBase(Domain1D):
             return pystr(self.flow.flowType())
 
 
+cdef class FreeFlow(_FlowBase):
+    r"""A free flow domain. The equations solved are standard equations for adiabatic
+    one-dimensional flow. The solution variables are:
+
+    *velocity*
+        axial velocity
+    *T*
+        temperature
+    *Y_k*
+        species mass fractions
+    """
+    _domain_type = "free-flow"
+
+
+cdef class AxisymmetricFlow(_FlowBase):
+    r"""
+    An axisymmetric flow domain. The equations solved are the similarity equations for
+    the flow in a finite-height gap of infinite radial extent. The solution variables
+    are:
+
+    *velocity*
+        axial velocity
+    *spread_rate*
+        radial velocity divided by radius
+    *T*
+        temperature
+    *lambda*
+        :math:`(1/r)(dP/dr)`
+    *Y_k*
+        species mass fractions
+
+    It may be shown that if the boundary conditions on these variables are independent
+    of radius, then a similarity solution to the exact governing equations exists in
+    which these variables are all independent of radius. This solution holds only in
+    the low-Mach-number limit, in which case :math:`(dP/dz) = 0`, and :math:`lambda` is
+    a constant. (Lambda is treated as a spatially-varying solution variable for
+    numerical reasons, but in the final solution it is always independent of :math:`z`.)
+    As implemented here, the governing equations assume an ideal gas mixture. Arbitrary
+    chemistry is allowed, as well as arbitrary variation of the transport properties.
+    """
+    _domain_type = "axisymmetric-flow"
+
+
 cdef class IdealGasFlow(_FlowBase):
     """
     An ideal gas flow domain. Functions `set_free_flow` and
@@ -702,8 +745,18 @@ cdef class IdealGasFlow(_FlowBase):
     it is always independent of z.) As implemented here, the governing
     equations assume an ideal gas mixture.  Arbitrary chemistry is allowed, as
     well as arbitrary variation of the transport properties.
+
+    .. deprecated:: 3.0
+
+        Class to be removed after Cantera 3.0; replaced by `FreeFlow` and
+        s`AxisymmetricFlow`.
     """
     _domain_type = "gas-flow"
+
+    def __init__(self, *args, **kwargs):
+        warnings.warn("Class to be removed after Cantera 3.0; use 'FreeFlow' "
+                      "or AxisymmetricFlow' instead.", DeprecationWarning)
+        super().__init__(*args, **kwargs)
 
 
 cdef class IonFlow(_FlowBase):

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -761,12 +761,12 @@ cdef class Sim1D:
         self.sim = NULL
 
     def __init__(self, domains, *args, **kwargs):
-        cdef vector[CxxDomain1D*] D
+        cdef vector[shared_ptr[CxxDomain1D]] cxx_domains
         cdef Domain1D d
         for d in domains:
-            D.push_back(d.domain)
+            cxx_domains.push_back(d._domain)
 
-        self.sim = new CxxSim1D(D)
+        self.sim = new CxxSim1D(cxx_domains)
         self.domains = tuple(domains)
         self.set_interrupt(no_op)
         self._initialized = False

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -56,7 +56,7 @@ class FlameBase(Sim1D):
         if isinstance(dom, Inlet1D):
             return tuple([e for e in self._other
                           if e not in {'grid', 'lambda', 'eField'}])
-        elif isinstance(dom, (IdealGasFlow, IonFlow)):
+        elif isinstance(dom, (FreeFlow, AxisymmetricFlow, IdealGasFlow, IonFlow)):
             return self._other
         else:
             return ()
@@ -764,9 +764,9 @@ class FreeFlame(FlameBase):
 
     def __init__(self, gas, grid=None, width=None):
         """
-        A domain of type IdealGasFlow named 'flame' will be created to represent
-        the flame and set to free flow. The three domains comprising the stack
-        are stored as ``self.inlet``, ``self.flame``, and ``self.outlet``.
+        A domain of type `FreeFlow` named 'flame' will be created to represent
+        the flame. The three domains comprising the stack are stored as ``self.inlet``,
+        ``self.flame``, and ``self.outlet``.
 
         :param grid:
             A list of points to be used as the initial grid. Not recommended
@@ -785,9 +785,8 @@ class FreeFlame(FlameBase):
 
         if not hasattr(self, 'flame'):
             # Create flame domain if not already instantiated by a child class
-            #: `IdealGasFlow` domain representing the flame
-            self.flame = IdealGasFlow(gas, name='flame')
-            self.flame.set_free_flow()
+            #: `FreeFlow` domain representing the flame
+            self.flame = FreeFlow(gas, name='flame')
 
         if width is not None:
             grid = np.array([0.0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.8, 1.0]) * width
@@ -1008,10 +1007,9 @@ class BurnerFlame(FlameBase):
             Defines a grid on the interval [0, width] with internal points
             determined automatically by the solver.
 
-        A domain of class `IdealGasFlow` named ``flame`` will be created to
-        represent the flame and set to axisymmetric stagnation flow. The three
-        domains comprising the stack are stored as ``self.burner``,
-        ``self.flame``, and ``self.outlet``.
+        A domain of class `AxisymmetricFlow` named ``flame`` will be created to
+        represent the flame. The three domains comprising the stack are stored as
+        ``self.burner``, ``self.flame``, and ``self.outlet``.
         """
         #: `Inlet1D` at the left of the domain representing the burner surface through
         #: which reactants flow
@@ -1022,9 +1020,8 @@ class BurnerFlame(FlameBase):
 
         if not hasattr(self, 'flame'):
             # Create flame domain if not already instantiated by a child class
-            #: `IdealGasFlow` domain representing the flame
-            self.flame = IdealGasFlow(gas, name='flame')
-            self.flame.set_axisymmetric_flow()
+            #: `AxisymmetricFlow` domain representing the flame
+            self.flame = AxisymmetricFlow(gas, name='flame')
 
         if width is not None:
             grid = np.array([0.0, 0.1, 0.2, 0.3, 0.5, 0.7, 1.0]) * width
@@ -1159,10 +1156,9 @@ class CounterflowDiffusionFlame(FlameBase):
             Defines a grid on the interval [0, width] with internal points
             determined automatically by the solver.
 
-        A domain of class `IdealGasFlow` named ``flame`` will be created to
-        represent the flame and set to axisymmetric stagnation flow. The three
-        domains comprising the stack are stored as ``self.fuel_inlet``,
-        ``self.flame``, and ``self.oxidizer_inlet``.
+        A domain of class `AxisymmetricFlow` named ``flame`` will be created to
+        represent the flame. The three domains comprising the stack are stored as
+        ``self.fuel_inlet``, ``self.flame``, and ``self.oxidizer_inlet``.
         """
 
         #: `Inlet1D` at the left of the domain representing the fuel mixture
@@ -1173,9 +1169,8 @@ class CounterflowDiffusionFlame(FlameBase):
         self.oxidizer_inlet = Inlet1D(name='oxidizer_inlet', phase=gas)
         self.oxidizer_inlet.T = gas.T
 
-        #: `IdealGasFlow` domain representing the flame
-        self.flame = IdealGasFlow(gas, name='flame')
-        self.flame.set_axisymmetric_flow()
+        #: `AxisymmetricFlow` domain representing the flame
+        self.flame = AxisymmetricFlow(gas, name='flame')
 
         if width is not None:
             grid = np.array([0.0, 0.2, 0.4, 0.6, 0.8, 1.0]) * width
@@ -1483,17 +1478,16 @@ class ImpingingJet(FlameBase):
         :param surface:
             A Kinetics object used to compute any surface reactions.
 
-        A domain of class `IdealGasFlow` named ``flame`` will be created to
-        represent the flame and set to axisymmetric stagnation flow. The three
-        domains comprising the stack are stored as ``self.inlet``,
-        ``self.flame``, and ``self.surface``.
+        A domain of class `AxisymmetricFlow` named ``flame`` will be created to
+        represent the flame. The three domains comprising the stack are stored as
+        ``self.inlet``, ``self.flame``, and ``self.surface``.
         """
 
         #: `Inlet1D` at the left of the domain representing the incoming reactants
         self.inlet = Inlet1D(name='inlet', phase=gas)
 
-        #: `IdealGasFlow` domain representing the flame
-        self.flame = IdealGasFlow(gas, name='flame')
+        #: `AxisymmetricFlow` domain representing the flame
+        self.flame = AxisymmetricFlow(gas, name='flame')
         self.flame.set_axisymmetric_flow()
 
         if width is not None:
@@ -1570,10 +1564,9 @@ class CounterflowPremixedFlame(FlameBase):
             Defines a grid on the interval [0, width] with internal points
             determined automatically by the solver.
 
-        A domain of class `IdealGasFlow` named ``flame`` will be created to
-        represent the flame and set to axisymmetric stagnation flow. The three
-        domains comprising the stack are stored as ``self.reactants``,
-        ``self.flame``, and ``self.products``.
+        A domain of class `AxisymmetricFlow` named ``flame`` will be created to
+        represent the flame. The three domains comprising the stack are stored as
+        ``self.reactants``, ``self.flame``, and ``self.products``.
         """
 
         #: `Inlet1D` at the left of the domain representing premixed reactants
@@ -1584,9 +1577,8 @@ class CounterflowPremixedFlame(FlameBase):
         self.products = Inlet1D(name='products', phase=gas)
         self.products.T = gas.T
 
-        #: `IdealGasFlow` domain representing the flame
-        self.flame = IdealGasFlow(gas, name='flame')
-        self.flame.set_axisymmetric_flow()
+        #: `AxisymmetricFlow` domain representing the flame
+        self.flame = AxisymmetricFlow(gas, name='flame')
 
         if width is not None:
             # Create grid points aligned with initial guess profile
@@ -1674,16 +1666,15 @@ class CounterflowTwinPremixedFlame(FlameBase):
             Defines a grid on the interval [0, width] with internal points
             determined automatically by the solver.
 
-        A domain of class `IdealGasFlow` named ``flame`` will be created to
-        represent the flame and set to axisymmetric stagnation flow. The three
-        domains comprising the stack are stored as ``self.reactants``,
-        ``self.flame``, and ``self.products``.
+        A domain of class `AxisymmetricFlow` named ``flame`` will be created to
+        represent the flame. The three domains comprising the stack are stored as
+        ``self.reactants``, ``self.flame``, and ``self.products``.
         """
         self.reactants = Inlet1D(name='reactants', phase=gas)
         self.reactants.T = gas.T
 
-        self.flame = IdealGasFlow(gas, name='flame')
-        self.flame.set_axisymmetric_flow()
+        #: `AxisymmetricFlow` domain representing the flame
+        self.flame = AxisymmetricFlow(gas, name='flame')
 
         #The right boundary is a symmetry plane
         self.products = SymmetryPlane1D(name='products', phase=gas)

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -177,7 +177,7 @@ class FlameBase(Sim1D):
             arr.TP = T + left.T - T[0], self.P
 
             # adjust velocities
-            if self.flame.flow_type != "Free Flame":
+            if self.flame.domain_type.startswith("axisymmetric"):
                 self.gas.TPY = left.T, self.P, left.Y
                 u0 = left.mdot / self.gas.density
                 arr.velocity = u0 * arr.velocity / arr.velocity[0]

--- a/interfaces/matlab/toolbox/1D/@Domain1D/domainType.m
+++ b/interfaces/matlab/toolbox/1D/@Domain1D/domainType.m
@@ -1,12 +1,10 @@
-function i = domainType(d)
+function v = domainType(d)
 % DOMAINTYPE  Get the type of domain.
-% i = domainType(d)
+% v = domainType(d)
 % :param d:
 %     Instance of class :mat:func:`Domain1D`
 % :return:
-%     This function returns an integer flag denoting the domain
-%     type.
+%     This function returns a string describing the domain type.
 %
 
-i = domain_methods(d.dom_id, 12);
-
+v = domain_methods(d.dom_id, 12);

--- a/interfaces/matlab/toolbox/1D/@Domain1D/isFlow.m
+++ b/interfaces/matlab/toolbox/1D/@Domain1D/isFlow.m
@@ -7,11 +7,6 @@ function a = isFlow(d)
 %     1 if the domain is a flow domain, and 0 otherwise.
 %
 
-t = domainType(d);
-
-% See Domain1D.h for definitions of constants
-if t < 100
-    a = 1;
-else
-    a = 0;
+v = domainType(d);
+a = int8(strcmp(v, 'free-flow') || strcmp(v, 'axisymmetric-flow'));
 end

--- a/interfaces/matlab/toolbox/1D/@Domain1D/isInlet.m
+++ b/interfaces/matlab/toolbox/1D/@Domain1D/isInlet.m
@@ -7,9 +7,5 @@ function a = isInlet(d)
 %     1 if the domain is an inlet, and 0 otherwise.
 %
 
-t = domainType(d);
-if t == 104
-  a = 1;
-else
-  a = 0;
+a = int8(strcmp(domainType(d), 'inlet'));
 end

--- a/interfaces/matlab/toolbox/1D/@Domain1D/isSurface.m
+++ b/interfaces/matlab/toolbox/1D/@Domain1D/isSurface.m
@@ -7,9 +7,5 @@ function a = isSurface(d)
 %     1 if the domain is a surface, and 0 otherwise.
 %
 
-t = domainType(d);
-if t == 102
-    a = 1;
-else
-    a = 0;
+a = int8(strcmp(domainType(d), 'surface'));
 end

--- a/samples/cxx/flamespeed/flamespeed.cpp
+++ b/samples/cxx/flamespeed/flamespeed.cpp
@@ -15,6 +15,7 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/onedim.h"
+#include "cantera/oneD/DomainFactory.h"
 #include "cantera/base/stringUtils.h"
 #include <fstream>
 
@@ -53,8 +54,8 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
 
         //-------- step 1: create the flow -------------
 
-        StFlow flow(sol, "flow");
-        flow.setFreeFlow();
+        auto flow = newDomain<StFlow>("gas-flow", sol, "flow");
+        flow->setFreeFlow();
 
         // create an initial grid
         int nz = 6;
@@ -65,24 +66,24 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
             z[iz] = ((double)iz)*dz;
         }
 
-        flow.setupGrid(nz, &z[0]);
+        flow->setupGrid(nz, &z[0]);
 
         //------- step 2: create the inlet  -----------------------
 
-        Inlet1D inlet(sol, "inlet");
+        auto inlet = newDomain<Inlet1D>("inlet", sol);
 
-        inlet.setMoleFractions(x.data());
-        double mdot=uin*rho_in;
-        inlet.setMdot(mdot);
-        inlet.setTemperature(temp);
+        inlet->setMoleFractions(x.data());
+        double mdot = uin * rho_in;
+        inlet->setMdot(mdot);
+        inlet->setTemperature(temp);
 
         //------- step 3: create the outlet  ---------------------
 
-        Outlet1D outlet(sol, "outlet");
+        auto outlet = newDomain<Outlet1D>("outlet", sol);
 
         //=================== create the container and insert the domains =====
 
-        std::vector<Domain1D*> domains { &inlet, &flow, &outlet };
+        vector<shared_ptr<Domain1D>> domains { inlet, flow, outlet };
         Sim1D flame(domains);
 
         //----------- Supply initial guess----------------------
@@ -90,7 +91,7 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
         vector_fp locs{0.0, 0.3, 0.7, 1.0};
         vector_fp value;
 
-        double uout = inlet.mdot()/rho_out;
+        double uout = inlet->mdot()/rho_out;
         value = {uin, uin, uout, uout};
         flame.setInitialGuess("velocity",locs,value);
         value = {temp, temp, Tad, Tad};
@@ -101,9 +102,9 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
             flame.setInitialGuess(gas->speciesName(i),locs,value);
         }
 
-        inlet.setMoleFractions(x.data());
-        inlet.setMdot(mdot);
-        inlet.setTemperature(temp);
+        inlet->setMoleFractions(x.data());
+        inlet->setMdot(mdot);
+        inlet->setTemperature(temp);
 
         flame.show();
 
@@ -135,29 +136,29 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
         // exist. The temperature at this location will then be fixed for
         // remainder of calculation.
         flame.setFixedTemperature(0.5 * (temp + Tad));
-        flow.solveEnergyEqn();
+        flow->solveEnergyEqn();
 
         flame.solve(loglevel,refine_grid);
         double flameSpeed_mix = flame.value(flowdomain,
-                                            flow.componentIndex("velocity"),0);
+                                            flow->componentIndex("velocity"),0);
         print("Flame speed with mixture-averaged transport: {} m/s\n",
               flameSpeed_mix);
         flame.save(fileName, "mix", "Solution with mixture-averaged transport", 0);
 
         // now switch to multicomponent transport
-        flow.setTransportModel("multicomponent");
+        flow->setTransportModel("multicomponent");
         flame.solve(loglevel, refine_grid);
         double flameSpeed_multi = flame.value(flowdomain,
-                                              flow.componentIndex("velocity"),0);
+                                              flow->componentIndex("velocity"),0);
         print("Flame speed with multicomponent transport: {} m/s\n",
               flameSpeed_multi);
         flame.save(fileName, "multi", "Solution with multicomponent transport", 0);
 
         // now enable Soret diffusion
-        flow.enableSoret(true);
+        flow->enableSoret(true);
         flame.solve(loglevel, refine_grid);
         double flameSpeed_full = flame.value(flowdomain,
-                                             flow.componentIndex("velocity"),0);
+                                             flow->componentIndex("velocity"),0);
         print("Flame speed with multicomponent transport + Soret: {} m/s\n",
               flameSpeed_full);
         flame.save(fileName, "soret",
@@ -167,17 +168,17 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
 
         print("\n{:9s}\t{:8s}\t{:5s}\t{:7s}\n",
               "z (m)", "T (K)", "U (m/s)", "Y(CO)");
-        for (size_t n = 0; n < flow.nPoints(); n++) {
-            Tvec.push_back(flame.value(flowdomain,flow.componentIndex("T"),n));
+        for (size_t n = 0; n < flow->nPoints(); n++) {
+            Tvec.push_back(flame.value(flowdomain,flow->componentIndex("T"),n));
             COvec.push_back(flame.value(flowdomain,
-                                        flow.componentIndex("CO"),n));
+                                        flow->componentIndex("CO"),n));
             CO2vec.push_back(flame.value(flowdomain,
-                                         flow.componentIndex("CO2"),n));
+                                         flow->componentIndex("CO2"),n));
             Uvec.push_back(flame.value(flowdomain,
-                                       flow.componentIndex("velocity"),n));
-            zvec.push_back(flow.grid(n));
+                                       flow->componentIndex("velocity"),n));
+            zvec.push_back(flow->grid(n));
             print("{:9.6f}\t{:8.3f}\t{:5.3f}\t{:7.5f}\n",
-                  flow.grid(n), Tvec[n], Uvec[n], COvec[n]);
+                  flow->grid(n), Tvec[n], Uvec[n], COvec[n]);
         }
 
         print("\nAdiabatic flame temperature from equilibrium is: {}\n", Tad);
@@ -185,9 +186,9 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
 
         std::ofstream outfile("flamespeed.csv", std::ios::trunc);
         outfile << "  Grid,   Temperature,   Uvec,   CO,    CO2\n";
-        for (size_t n = 0; n < flow.nPoints(); n++) {
+        for (size_t n = 0; n < flow->nPoints(); n++) {
             print(outfile, " {:11.3e}, {:11.3e}, {:11.3e}, {:11.3e}, {:11.3e}\n",
-                  flow.grid(n), Tvec[n], Uvec[n], COvec[n], CO2vec[n]);
+                  flow->grid(n), Tvec[n], Uvec[n], COvec[n], CO2vec[n]);
         }
     } catch (CanteraError& err) {
         std::cerr << err.what() << std::endl;

--- a/samples/cxx/flamespeed/flamespeed.cpp
+++ b/samples/cxx/flamespeed/flamespeed.cpp
@@ -105,7 +105,7 @@ int flamespeed(double phi, bool refine_grid, int loglevel)
         inlet.setMdot(mdot);
         inlet.setTemperature(temp);
 
-        flame.showSolution();
+        flame.show();
 
         int flowdomain = 1;
         double ratio = 10.0;

--- a/samples/python/onedim/adiabatic_flame.py
+++ b/samples/python/onedim/adiabatic_flame.py
@@ -26,7 +26,7 @@ gas.TPX = Tin, p, reactants
 # Set up flame object
 f = ct.FreeFlame(gas, width=width)
 f.set_refine_criteria(ratio=3, slope=0.06, curve=0.12)
-f.show_solution()
+f.show()
 
 # Solve with mixture-averaged transport model
 f.transport_model = 'mixture-averaged'
@@ -41,13 +41,13 @@ output.unlink(missing_ok=True)
 # Solve with the energy equation enabled
 f.save(output, name="mix", description="solution with mixture-averaged transport")
 
-f.show_solution()
+f.show()
 print(f"mixture-averaged flamespeed = {f.velocity[0]:7f} m/s")
 
 # Solve with multi-component transport properties
 f.transport_model = 'multicomponent'
 f.solve(loglevel)  # don't use 'auto' on subsequent solves
-f.show_solution()
+f.show()
 print(f"multicomponent flamespeed = {f.velocity[0]:7f} m/s")
 f.save(output, name="multi", description="solution with multicomponent transport")
 

--- a/samples/python/onedim/burner_flame.py
+++ b/samples/python/onedim/burner_flame.py
@@ -22,7 +22,7 @@ gas.TPX = tburner, p, reactants
 f = ct.BurnerFlame(gas, width=width)
 f.burner.mdot = mdot
 f.set_refine_criteria(ratio=3.0, slope=0.05, curve=0.1)
-f.show_solution()
+f.show()
 
 f.transport_model = 'mixture-averaged'
 f.solve(loglevel, auto=True)
@@ -37,7 +37,7 @@ f.save(output, name="mix", description="solution with mixture-averaged transport
 
 f.transport_model = 'multicomponent'
 f.solve(loglevel)  # don't use 'auto' on subsequent solves
-f.show_solution()
+f.show()
 f.save(output, name="multi", description="solution with multicomponent transport")
 
 f.write_csv('burner_flame.csv', quiet=False)

--- a/samples/python/onedim/diffusion_flame.py
+++ b/samples/python/onedim/diffusion_flame.py
@@ -53,7 +53,7 @@ f.set_refine_criteria(ratio=4, slope=0.2, curve=0.3, prune=0.04)
 
 # Solve the problem
 f.solve(loglevel, auto=True)
-f.show_solution()
+f.show()
 
 if "native" in ct.hdf_support():
     output = Path() / "diffusion_flame.h5"
@@ -78,7 +78,7 @@ plt.xlim(0.000, 0.020)
 # Turn on radiation and solve again
 f.radiation_enabled = True
 f.solve(loglevel=1, refine_grid=False)
-f.show_solution()
+f.show()
 
 # Plot Temperature with radiation
 plt.plot(f.flame.grid, f.T, label='Temperature with radiation')

--- a/samples/python/onedim/flame_fixed_T.py
+++ b/samples/python/onedim/flame_fixed_T.py
@@ -51,7 +51,7 @@ zloc /= max(zloc)
 f.flame.set_fixed_temp_profile(zloc, tvalues)
 
 # show the initial estimate for the solution
-f.show_solution()
+f.show()
 
 # don't solve the energy equation
 f.energy_enabled = False

--- a/samples/python/onedim/ion_burner_flame.py
+++ b/samples/python/onedim/ion_burner_flame.py
@@ -22,7 +22,7 @@ mdot = 0.15 * gas.density
 f = ct.IonBurnerFlame(gas, width=width)
 f.burner.mdot = mdot
 f.set_refine_criteria(ratio=3.0, slope=0.05, curve=0.1)
-f.show_solution()
+f.show()
 
 f.transport_model = 'ionized-gas'
 f.solve(loglevel, auto=True)

--- a/samples/python/onedim/ion_free_flame.py
+++ b/samples/python/onedim/ion_free_flame.py
@@ -24,7 +24,7 @@ gas.TPX = Tin, p, reactants
 # Set up flame object
 f = ct.IonFreeFlame(gas, width=width)
 f.set_refine_criteria(ratio=3, slope=0.05, curve=0.1)
-f.show_solution()
+f.show()
 
 # stage one
 f.solve(loglevel=loglevel, auto=True)
@@ -40,7 +40,7 @@ output.unlink(missing_ok=True)
 
 f.save(output, name="ion", description="solution with ionized gas transport")
 
-f.show_solution()
+f.show()
 print(f"mixture-averaged flamespeed = {f.velocity[0]:7f} m/s")
 
 # write the velocity, temperature, density, and mole fractions to a CSV file

--- a/samples/python/onedim/premixed_counterflow_flame.py
+++ b/samples/python/onedim/premixed_counterflow_flame.py
@@ -40,7 +40,7 @@ sim.reactants.mdot = mdot_reactants
 sim.products.mdot = mdot_products
 
 sim.set_initial_guess()  # assume adiabatic equilibrium products
-sim.show_solution()
+sim.show()
 
 sim.solve(loglevel, auto=True)
 
@@ -55,4 +55,4 @@ sim.save(output, name="mix", description="solution with mixture-averaged transpo
 # write the velocity, temperature, and mole fractions to a CSV file
 sim.write_csv("premixed_counterflow_flame.csv", quiet=False)
 sim.show_stats()
-sim.show_solution()
+sim.show()

--- a/samples/python/onedim/premixed_counterflow_twin_flame.py
+++ b/samples/python/onedim/premixed_counterflow_twin_flame.py
@@ -68,7 +68,7 @@ def solveOpposedFlame(oppFlame, massFlux=0.12, loglevel=1,
     oppFlame.reactants.mdot = massFlux
     oppFlame.set_refine_criteria(ratio=ratio, slope=slope, curve=curve, prune=prune)
 
-    oppFlame.show_solution()
+    oppFlame.show()
     oppFlame.solve(loglevel, auto=True)
 
     # Compute the strain rate, just before the flame. This is not necessarily

--- a/samples/python/onedim/stagnation_flame.py
+++ b/samples/python/onedim/stagnation_flame.py
@@ -66,7 +66,7 @@ sim.set_grid_min(1e-4)
 sim.set_refine_criteria(ratio=ratio, slope=slope, curve=curve, prune=prune)
 
 sim.set_initial_guess(products='equil')  # assume adiabatic equilibrium products
-sim.show_solution()
+sim.show()
 
 sim.solve(loglevel, auto=True)
 

--- a/samples/python/surface_chemistry/catalytic_combustion.py
+++ b/samples/python/surface_chemistry/catalytic_combustion.py
@@ -69,7 +69,7 @@ sim.inlet.X = comp1
 sim.surface.T = tsurf
 
 # Show the initial solution estimate
-sim.show_solution()
+sim.show()
 
 # Solving problems with stiff chemistry coupled to flow can require a
 # sequential approach where solutions are first obtained for simpler problems
@@ -94,7 +94,7 @@ for mult in np.logspace(-5, 0, 6):
     sim.solve(loglevel)
 
 # At this point, we should have the solution for the hydrogen/air problem.
-sim.show_solution()
+sim.show()
 
 # Now switch the inlet to the methane/air composition.
 sim.inlet.X = comp2
@@ -106,7 +106,7 @@ sim.set_refine_criteria(100.0, 0.15, 0.2, 0.0)
 sim.solve(loglevel)
 
 # show the solution
-sim.show_solution()
+sim.show()
 
 # save the full solution to HDF or YAML container files. The 'restore' method can be
 # used to restore or restart a simulation from a solution stored in this form.

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -345,6 +345,18 @@ public:
     }
 
     /**
+     * Return object n, cast to the specified type.
+     */
+    template <class T>
+    static shared_ptr<T> as(size_t n) {
+        auto obj = std::dynamic_pointer_cast<T>(at(n));
+        if (obj) {
+            return obj;
+        }
+        throw CanteraError("SharedCabinet::as", "Item is not of the correct type.");
+    }
+
+    /**
      * Return a reference to object n.
      */
     static M& item(size_t n) {

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -244,7 +244,7 @@ extern "C" {
         }
     }
 
-    doublereal thermo_temperature(int n)
+    double thermo_temperature(int n)
     {
         try {
             return ThermoCabinet::item(n).temperature();
@@ -263,7 +263,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal thermo_density(int n)
+    double thermo_density(int n)
     {
         try {
             return ThermoCabinet::item(n).density();
@@ -282,7 +282,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal thermo_molarDensity(int n)
+    double thermo_molarDensity(int n)
     {
         try {
             return ThermoCabinet::item(n).molarDensity();
@@ -301,7 +301,7 @@ extern "C" {
         return 0;
     }
 
-    doublereal thermo_meanMolecularWeight(int n)
+    double thermo_meanMolecularWeight(int n)
     {
         try {
             return ThermoCabinet::item(n).meanMolecularWeight();
@@ -340,7 +340,7 @@ extern "C" {
         }
     }
 
-    doublereal thermo_moleFraction(int n, size_t k)
+    double thermo_moleFraction(int n, size_t k)
     {
         try {
             return ThermoCabinet::item(n).moleFraction(k);
@@ -361,7 +361,7 @@ extern "C" {
         }
     }
 
-    doublereal thermo_massFraction(int n, size_t k)
+    double thermo_massFraction(int n, size_t k)
     {
         try {
             return ThermoCabinet::item(n).massFraction(k);
@@ -501,7 +501,7 @@ extern "C" {
     }
 
 
-    doublereal thermo_nAtoms(int n, size_t k, size_t m)
+    double thermo_nAtoms(int n, size_t k, size_t m)
     {
         try {
             return ThermoCabinet::item(n).nAtoms(k,m);
@@ -510,7 +510,7 @@ extern "C" {
         }
     }
 
-    int thermo_addElement(int n, const char* name, doublereal weight)
+    int thermo_addElement(int n, const char* name, double weight)
     {
         try {
             ThermoCabinet::item(n).addElement(name, weight);
@@ -880,7 +880,7 @@ extern "C" {
         }
     }
 
-    doublereal thermo_refPressure(int n)
+    double thermo_refPressure(int n)
     {
         try {
             return ThermoCabinet::item(n).refPressure();
@@ -889,7 +889,7 @@ extern "C" {
         }
     }
 
-    doublereal thermo_minTemp(int n, int k)
+    double thermo_minTemp(int n, int k)
     {
         try {
             ThermoPhase& ph = ThermoCabinet::item(n);
@@ -904,7 +904,7 @@ extern "C" {
         }
     }
 
-    doublereal thermo_maxTemp(int n, int k)
+    double thermo_maxTemp(int n, int k)
     {
         try {
             ThermoPhase& ph = ThermoCabinet::item(n);
@@ -966,7 +966,7 @@ extern "C" {
         }
     }
 
-    doublereal thermo_thermalExpansionCoeff(int n)
+    double thermo_thermalExpansionCoeff(int n)
     {
         try {
             return ThermoCabinet::item(n).thermalExpansionCoeff();
@@ -975,7 +975,7 @@ extern "C" {
         }
     }
 
-    doublereal thermo_isothermalCompressibility(int n)
+    double thermo_isothermalCompressibility(int n)
     {
         try {
             return ThermoCabinet::item(n).isothermalCompressibility();

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -189,6 +189,19 @@ extern "C" {
         }
     }
 
+    int soln_setTransportModel(int n, const char* model)
+    {
+        try {
+            auto soln = SolutionCabinet::at(n);
+            TransportCabinet::del(
+                TransportCabinet::index(*(soln->transport())));
+            soln->setTransportModel(model);
+            return TransportCabinet::add(soln->transport());
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     size_t soln_nAdjacent(int n)
     {
         try {
@@ -1433,6 +1446,16 @@ extern "C" {
         try {
             auto tr = newTransport(ThermoCabinet::at(ith), model);
             return TransportCabinet::add(tr);
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int trans_transportModel(int i, int lennm, char* nm)
+    {
+        try {
+            return static_cast<int>(
+                copyString(TransportCabinet::item(i).transportModel(), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -121,7 +121,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_nAtoms(int i, int k, int m)
+    double mix_nAtoms(int i, int k, int m)
     {
         try {
             MultiPhase& mix = mixCabinet::item(i);
@@ -142,7 +142,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_phaseMoles(int i, int n)
+    double mix_phaseMoles(int i, int n)
     {
         try {
             MultiPhase& mix = mixCabinet::item(i);
@@ -206,7 +206,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_temperature(int i)
+    double mix_temperature(int i)
     {
         try {
             return mixCabinet::item(i).temperature();
@@ -215,7 +215,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_minTemp(int i)
+    double mix_minTemp(int i)
     {
         try {
             return mixCabinet::item(i).minTemp();
@@ -224,7 +224,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_maxTemp(int i)
+    double mix_maxTemp(int i)
     {
         try {
             return mixCabinet::item(i).maxTemp();
@@ -233,7 +233,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_charge(int i)
+    double mix_charge(int i)
     {
         try {
             return mixCabinet::item(i).charge();
@@ -242,7 +242,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_phaseCharge(int i, int p)
+    double mix_phaseCharge(int i, int p)
     {
         try {
             MultiPhase& mix = mixCabinet::item(i);
@@ -267,7 +267,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_pressure(int i)
+    double mix_pressure(int i)
     {
         try {
             return mixCabinet::item(i).pressure();
@@ -276,7 +276,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_speciesMoles(int i, int k)
+    double mix_speciesMoles(int i, int k)
     {
         try {
             MultiPhase& mix = mixCabinet::item(i);
@@ -287,7 +287,7 @@ extern "C" {
         }
     }
 
-    doublereal mix_elementMoles(int i, int m)
+    double mix_elementMoles(int i, int m)
     {
         try {
             MultiPhase& mix = mixCabinet::item(i);
@@ -298,8 +298,8 @@ extern "C" {
         }
     }
 
-    doublereal mix_equilibrate(int i, const char* XY, doublereal rtol,
-                               int maxsteps, int maxiter, int loglevel)
+    double mix_equilibrate(int i, const char* XY, double rtol,
+                           int maxsteps, int maxiter, int loglevel)
     {
         try {
             mixCabinet::item(i).equilibrate(XY, "auto", rtol, maxsteps, maxiter,

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -63,6 +63,15 @@ extern "C" {
         }
     }
 
+    int domain_type3(int i, size_t lennm, char* nm)
+    {
+        try {
+            return static_cast<int>(copyString(DomainCabinet::item(i).type(), nm, lennm));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     size_t domain_index(int i)
     {
         try {
@@ -519,6 +528,22 @@ extern "C" {
             sim.checkDomainIndex(dom);
             sim.domain(dom).checkComponentIndex(comp);
             sim.setFlatProfile(dom, comp, v);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int sim1D_show(int i, const char* fname)
+    {
+        try {
+            string fn = string(fname);
+            if (fn == "-") {
+                SimCabinet::item(i).show();
+            } else {
+                ofstream fout(fname);
+                SimCabinet::item(i).show(fout);
+            }
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -320,6 +320,16 @@ extern "C" {
         }
     }
 
+    int bdry_setSpreadRate(int i, double v)
+    {
+        try {
+            DomainCabinet::as<Boundary1D>(i)->setSpreadRate(v);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int bdry_setMoleFractions(int i, const char* x)
     {
         try {
@@ -334,6 +344,15 @@ extern "C" {
     {
         try {
             return DomainCabinet::as<Boundary1D>(i)->temperature();
+        } catch (...) {
+            return handleAllExceptions(DERR, DERR);
+        }
+    }
+
+    double bdry_spreadRate(int i)
+    {
+        try {
+            return DomainCabinet::as<Boundary1D>(i)->spreadRate();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }

--- a/src/matlab/onedimmethods.cpp
+++ b/src/matlab/onedimmethods.cpp
@@ -97,6 +97,16 @@ void onedimmethods(int nlhs, mxArray* plhs[],
             reportError();
         }
         return;
+    } else if (job == 12) {
+        checkNArgs(3, nrhs);
+        int buflen = domain_type3(dom, 0, 0);
+        char* output_buf = (char*)mxCalloc(buflen, sizeof(char));
+        int iok = domain_type3(dom, buflen, output_buf);
+        if (iok < 0) {
+            reportError();
+        }
+        plhs[0] = mxCreateString(output_buf);
+        return;
     } else if (job < 40) {
         // methods
         int k;
@@ -109,10 +119,6 @@ void onedimmethods(int nlhs, mxArray* plhs[],
         case 11:
             checkNArgs(3, nrhs);
             vv = (double) domain_nComponents(dom);
-            break;
-        case 12:
-            checkNArgs(3, nrhs);
-            vv = domain_type(dom);
             break;
         case 13:
             checkNArgs(3, nrhs);
@@ -300,7 +306,7 @@ void onedimmethods(int nlhs, mxArray* plhs[],
         case 103:
             checkNArgs(4, nrhs);
             fname = getString(prhs[3]);
-            iok = sim1D_showSolution(dom, fname);
+            iok = sim1D_show(dom, fname);
             break;
         case 104:
             checkNArgs(5, nrhs);

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -100,7 +100,7 @@ void Inlet1D::setSpreadRate(double V0)
 }
 
 
-void Inlet1D::showSolution(const double* x)
+void Inlet1D::show(const double* x)
 {
     writelog("    Mass Flux:   {:10.4g} kg/m^2/s \n", m_mdot);
     writelog("    Temperature: {:10.4g} K \n", m_temp);
@@ -579,13 +579,13 @@ void Surf1D::restore(SolutionArray& arr, double* soln, int loglevel)
     m_temp = arr.thermo()->temperature();
 }
 
-void Surf1D::showSolution_s(std::ostream& s, const double* x)
+void Surf1D::show(std::ostream& s, const double* x)
 {
     s << "-------------------  Surface " << domainIndex() << " ------------------- " << std::endl;
     s << "  temperature: " << m_temp << " K" << std::endl;
 }
 
-void Surf1D::showSolution(const double* x)
+void Surf1D::show(const double* x)
 {
     writelog("    Temperature: {:10.4g} K \n\n", m_temp);
 }
@@ -791,7 +791,7 @@ void ReactingSurf1D::restore(SolutionArray& arr, double* soln, int loglevel)
     surf->getCoverages(soln);
 }
 
-void ReactingSurf1D::showSolution(const double* x)
+void ReactingSurf1D::show(const double* x)
 {
     writelog("    Temperature: {:10.4g} K \n", m_temp);
     writelog("    Coverages: \n");

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -50,7 +50,7 @@ void Boundary1D::_init(size_t n)
         } else {
             throw CanteraError("Boundary1D::_init",
                 "Boundary domains can only be connected on the left to flow "
-                "domains, not type {} domains.", r.domainType());
+                "domains, not '{}' domains.", r.type());
         }
     }
 
@@ -72,7 +72,7 @@ void Boundary1D::_init(size_t n)
         } else {
             throw CanteraError("Boundary1D::_init",
                 "Boundary domains can only be connected on the right to flow "
-                "domains, not type {} domains.", r.domainType());
+                "domains, not '{}' domains.", r.type());
         }
     }
 }
@@ -226,7 +226,6 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
 shared_ptr<SolutionArray> Inlet1D::asArray(const double* soln) const
 {
     AnyMap meta = Boundary1D::getMeta();
-    meta["type"] = "inlet";
     meta["mass-flux"] = m_mdot;
     auto arr = SolutionArray::create(m_solution, 1, meta);
 
@@ -273,7 +272,6 @@ void Empty1D::eval(size_t jg, double* xg, double* rg,
 shared_ptr<SolutionArray> Empty1D::asArray(const double* soln) const
 {
     AnyMap meta = Boundary1D::getMeta();
-    meta["type"] = "empty";
     return SolutionArray::create(m_solution, 0, meta);
 }
 
@@ -326,7 +324,6 @@ void Symm1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
 shared_ptr<SolutionArray> Symm1D::asArray(const double* soln) const
 {
     AnyMap meta = Boundary1D::getMeta();
-    meta["type"] = "symmetry";
     return SolutionArray::create(m_solution, 0, meta);
 }
 
@@ -408,7 +405,6 @@ void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
 shared_ptr<SolutionArray> Outlet1D::asArray(const double* soln) const
 {
     AnyMap meta = Boundary1D::getMeta();
-    meta["type"] = "outlet";
     return SolutionArray::create(m_solution, 0, meta);
 }
 
@@ -513,7 +509,6 @@ void OutletRes1D::eval(size_t jg, double* xg, double* rg,
 shared_ptr<SolutionArray> OutletRes1D::asArray(const double* soln) const
 {
     AnyMap meta = Boundary1D::getMeta();
-    meta["type"] = "outlet-reservoir";
     meta["temperature"] = m_temp;
     auto arr = SolutionArray::create(m_solution, 1, meta);
 
@@ -573,7 +568,6 @@ void Surf1D::eval(size_t jg, double* xg, double* rg,
 shared_ptr<SolutionArray> Surf1D::asArray(const double* soln) const
 {
     AnyMap meta = Boundary1D::getMeta();
-    meta["type"] = "surface";
     meta["temperature"] = m_temp;
     return SolutionArray::create(m_solution, 0, meta);
 }
@@ -768,7 +762,6 @@ void ReactingSurf1D::eval(size_t jg, double* xg, double* rg,
 shared_ptr<SolutionArray> ReactingSurf1D::asArray(const double* soln) const
 {
     AnyMap meta = Boundary1D::getMeta();
-    meta["type"] = "reacting-surface";
     meta["temperature"] = m_temp;
     meta["phase"]["name"] = m_sphase->name();
     AnyValue source = m_sphase->input().getMetadata("filename");

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -209,7 +209,21 @@ void Domain1D::setupGrid(size_t n, const doublereal* z)
     }
 }
 
-void Domain1D::showSolution(const doublereal* x)
+void Domain1D::showSolution_s(std::ostream& s, const double* x)
+{
+    warn_deprecated("Domain1D::showSolution_s",
+        "To be removed after Cantera 3.0; replaced by 'show'.");
+    show(s, x);
+}
+
+void Domain1D::showSolution(const double* x)
+{
+    warn_deprecated("Domain1D::showSolution",
+        "To be removed after Cantera 3.0; replaced by 'show'.");
+    show(x);
+}
+
+void Domain1D::show(const double* x)
 {
     size_t nn = m_nv/5;
     for (size_t i = 0; i < nn; i++) {

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -117,6 +117,7 @@ AnyMap Domain1D::getMeta() const
         }
     };
     AnyMap state;
+    state["type"] = type();
     state["points"] = static_cast<long int>(nPoints());
     if (nComponents() && nPoints()) {
         state["tolerances"]["transient-abstol"] = wrap_tols(m_atol_ts);

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -23,6 +23,13 @@ Domain1D::~Domain1D()
 {
 }
 
+int Domain1D::domainType()
+{
+    warn_deprecated("Domain1D::domainType",
+        "To be changed after Cantera 3.0; for new behavior, see 'type'.");
+    return m_type;
+}
+
 void Domain1D::resize(size_t nv, size_t np)
 {
     // if the number of components is being changed, then a

--- a/src/oneD/DomainFactory.cpp
+++ b/src/oneD/DomainFactory.cpp
@@ -1,0 +1,74 @@
+//! @file DomainFactory.cpp
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/oneD/DomainFactory.h"
+#include "cantera/oneD/Boundary1D.h"
+#include "cantera/oneD/StFlow.h"
+#include "cantera/oneD/IonFlow.h"
+
+namespace Cantera
+{
+
+DomainFactory* DomainFactory::s_factory = 0;
+std::mutex DomainFactory::domain_mutex;
+
+DomainFactory::DomainFactory()
+{
+    reg("inlet", [](shared_ptr<Solution> solution, const string& id) {
+        return new Inlet1D(solution, id);
+    });
+    reg("empty", [](shared_ptr<Solution> solution, const string& id) {
+        return new Empty1D(solution, id);
+    });
+    reg("symmetry-plane", [](shared_ptr<Solution> solution, const string& id) {
+        return new Symm1D(solution, id);
+    });
+    reg("outlet", [](shared_ptr<Solution> solution, const string& id) {
+        return new Outlet1D(solution, id);
+    });
+    reg("outlet-reservoir", [](shared_ptr<Solution> solution, const string& id) {
+        return new OutletRes1D(solution, id);
+    });
+    reg("surface", [](shared_ptr<Solution> solution, const string& id) {
+        return new Surf1D(solution, id);
+    });
+    reg("reacting-surface", [](shared_ptr<Solution> solution, const string& id) {
+        return new ReactingSurf1D(solution, id);
+    });
+    reg("gas-flow", [](shared_ptr<Solution> solution, const string& id) {
+        return new StFlow(solution, id);
+    });
+    reg("ion-flow", [](shared_ptr<Solution> solution, const string& id) {
+        return new IonFlow(solution, id);
+    });
+    reg("free-flow", [](shared_ptr<Solution> solution, const string& id) {
+        StFlow* ret = new StFlow(solution, id);
+        ret->setFreeFlow();
+        return ret;
+    });
+    reg("axisymmetric-flow", [](shared_ptr<Solution> solution, const string& id) {
+        StFlow* ret = new StFlow(solution, id);
+        ret->setAxisymmetricFlow();
+        return ret;
+    });
+}
+
+DomainFactory* DomainFactory::factory()
+{
+    std::unique_lock<std::mutex> lock(domain_mutex);
+    if (!s_factory) {
+        s_factory = new DomainFactory;
+    }
+    return s_factory;
+}
+
+void DomainFactory::deleteFactory()
+{
+    std::unique_lock<std::mutex> lock(domain_mutex);
+    delete s_factory;
+    s_factory = 0;
+}
+
+}

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -74,6 +74,13 @@ IonFlow::IonFlow(shared_ptr<Solution> sol, const std::string& id, size_t points)
     });
 }
 
+string IonFlow::type() const {
+    if (m_isFree) {
+        return "free-ion-flow";
+    }
+    return "stagnation-ion-flow";
+}
+
 void IonFlow::resize(size_t components, size_t points){
     StFlow::resize(components, points);
     m_mobility.resize(m_nsp*m_points);

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -625,7 +625,7 @@ int Sim1D::setFixedTemperature(double t)
         StFlow* d_free = dynamic_cast<StFlow*>(&domain(n));
         size_t npnow = d.nPoints();
         size_t nstart = znew.size();
-        if (d_free && d_free->isFree()) {
+        if (d_free && !d_free->fixed_mdot()) {
             for (size_t m = 0; m < npnow - 1; m++) {
                 bool fixedpt = false;
                 double t1 = value(n, 2, m);
@@ -703,7 +703,7 @@ double Sim1D::fixedTemperature()
     double t_fixed = std::numeric_limits<double>::quiet_NaN();
     for (size_t n = 0; n < nDomains(); n++) {
         StFlow* d = dynamic_cast<StFlow*>(&domain(n));
-        if (d && d->isFree() && d->m_tfixed > 0) {
+        if (d && !d->fixed_mdot() && d->m_tfixed > 0) {
             t_fixed = d->m_tfixed;
             break;
         }
@@ -716,7 +716,7 @@ double Sim1D::fixedTemperatureLocation()
     double z_fixed = std::numeric_limits<double>::quiet_NaN();
     for (size_t n = 0; n < nDomains(); n++) {
         StFlow* d = dynamic_cast<StFlow*>(&domain(n));
-        if (d && d->isFree() && d->m_tfixed > 0) {
+        if (d && !d->fixed_mdot() && d->m_tfixed > 0) {
             z_fixed = d->m_zfixed;
             break;
         }

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -296,7 +296,7 @@ void Sim1D::setFlatProfile(size_t dom, size_t comp, doublereal v)
 void Sim1D::showSolution(ostream& s)
 {
     for (size_t n = 0; n < nDomains(); n++) {
-        if (domain(n).domainType() != cEmptyType) {
+        if (domain(n).type() != "empty") {
             domain(n).showSolution_s(s, &m_x[start(n)]);
         }
     }
@@ -305,7 +305,7 @@ void Sim1D::showSolution(ostream& s)
 void Sim1D::showSolution()
 {
     for (size_t n = 0; n < nDomains(); n++) {
-        if (domain(n).domainType() != cEmptyType) {
+        if (domain(n).type() != "empty") {
             writelog("\n\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> "+domain(n).id()
                      +" <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n\n");
             domain(n).showSolution(&m_x[start(n)]);
@@ -591,7 +591,7 @@ int Sim1D::setFixedTemperature(double t)
         StFlow* d_free = dynamic_cast<StFlow*>(&domain(n));
         size_t npnow = d.nPoints();
         size_t nstart = znew.size();
-        if (d_free && d_free->domainType() == cFreeFlow) {
+        if (d_free && d_free->isFree()) {
             for (size_t m = 0; m < npnow - 1; m++) {
                 bool fixedpt = false;
                 double t1 = value(n, 2, m);
@@ -669,7 +669,7 @@ double Sim1D::fixedTemperature()
     double t_fixed = std::numeric_limits<double>::quiet_NaN();
     for (size_t n = 0; n < nDomains(); n++) {
         StFlow* d = dynamic_cast<StFlow*>(&domain(n));
-        if (d && d->domainType() == cFreeFlow && d->m_tfixed > 0) {
+        if (d && d->isFree() && d->m_tfixed > 0) {
             t_fixed = d->m_tfixed;
             break;
         }
@@ -682,7 +682,7 @@ double Sim1D::fixedTemperatureLocation()
     double z_fixed = std::numeric_limits<double>::quiet_NaN();
     for (size_t n = 0; n < nDomains(); n++) {
         StFlow* d = dynamic_cast<StFlow*>(&domain(n));
-        if (d && d->domainType() == cFreeFlow && d->m_tfixed > 0) {
+        if (d && d->isFree() && d->m_tfixed > 0) {
             z_fixed = d->m_zfixed;
             break;
         }

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -22,10 +22,30 @@ using namespace std;
 namespace Cantera
 {
 
+Sim1D::Sim1D(vector<shared_ptr<Domain1D>>& domains) :
+    OneDim(domains),
+    m_steady_callback(0)
+{
+    // resize the internal solution vector and the work array, and perform
+    // domain-specific initialization of the solution vector.
+    resize();
+    for (size_t n = 0; n < nDomains(); n++) {
+        domain(n)._getInitialSoln(&m_x[start(n)]);
+    }
+
+    // set some defaults
+    m_tstep = 1.0e-5;
+    m_steps = { 10 };
+}
+
 Sim1D::Sim1D(vector<Domain1D*>& domains) :
     OneDim(domains),
     m_steady_callback(0)
 {
+    warn_deprecated("Sim1D::Sim1D(vector<Domain1D*>&)",
+        "To be removed after Cantera 3.0; superseded by "
+        "Sim1D::Sim1D(vector<shared_ptr<Domain1D>>&).");
+
     // resize the internal solution vector and the work array, and perform
     // domain-specific initialization of the solution vector.
     resize();

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -295,20 +295,34 @@ void Sim1D::setFlatProfile(size_t dom, size_t comp, doublereal v)
 
 void Sim1D::showSolution(ostream& s)
 {
+    warn_deprecated("Sim1D::showSolution",
+        "To be removed after Cantera 3.0; replaced by 'show'.");
+    show(s);
+}
+
+void Sim1D::showSolution()
+{
+    warn_deprecated("Sim1D::showSolution",
+        "To be removed after Cantera 3.0; replaced by 'show'.");
+    show();
+}
+
+void Sim1D::show(ostream& s)
+{
     for (size_t n = 0; n < nDomains(); n++) {
         if (domain(n).type() != "empty") {
-            domain(n).showSolution_s(s, &m_x[start(n)]);
+            domain(n).show(s, &m_x[start(n)]);
         }
     }
 }
 
-void Sim1D::showSolution()
+void Sim1D::show()
 {
     for (size_t n = 0; n < nDomains(); n++) {
         if (domain(n).type() != "empty") {
             writelog("\n\n>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>>> "+domain(n).id()
                      +" <<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<<\n\n");
-            domain(n).showSolution(&m_x[start(n)]);
+            domain(n).show(&m_x[start(n)]);
         }
     }
 }
@@ -462,7 +476,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
             writeline('.', 78, true, true);
         }
         if (loglevel > 2) {
-            showSolution();
+            show();
         }
 
         if (refine_grid) {

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -621,11 +621,11 @@ void StFlow::updateTransport(doublereal* x, size_t j0, size_t j1)
     }
 }
 
-void StFlow::showSolution(const doublereal* x)
+void StFlow::show(const doublereal* x)
 {
     writelog("    Pressure:  {:10.4g} Pa\n", m_press);
 
-    Domain1D::showSolution(x);
+    Domain1D::show(x);
 
     if (m_do_radiation) {
         writeline('-', 79, false, true);

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -128,6 +128,13 @@ StFlow::~StFlow()
     }
 }
 
+string StFlow::type() const {
+    if (m_isFree) {
+        return "free-flow";
+    }
+    return "axisymmetric-flow";
+}
+
 void StFlow::setThermo(IdealGasPhase& th) {
     warn_deprecated("StFlow::setThermo", "To be removed after Cantera 3.0.");
     m_thermo = &th;
@@ -735,7 +742,6 @@ bool StFlow::componentActive(size_t n) const
 AnyMap StFlow::getMeta() const
 {
     AnyMap state = Domain1D::getMeta();
-    state["type"] = flowType();
     state["transport-model"] = m_trans->transportModel();
 
     state["phase"]["name"] = m_thermo->name();
@@ -846,6 +852,8 @@ void StFlow::restore(SolutionArray& arr, double* soln, int loglevel)
 }
 
 string StFlow::flowType() const {
+    warn_deprecated("StFlow::flowType",
+        "To be removed after Cantera 3.0; superseded by 'type'.");
     if (m_type == cFreeFlow) {
         return "Free Flame";
     } else if (m_type == cAxisymmetricStagnationFlow) {

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -183,7 +183,7 @@ int Refiner::analyze(size_t n, const doublereal* z,
         }
 
         // Keep the point where the temperature is fixed
-        if (fflame && fflame->domainType() == cFreeFlow && z[j] == fflame->m_zfixed) {
+        if (fflame && fflame->isFree() && z[j] == fflame->m_zfixed) {
             m_keep[j] = 1;
         }
     }

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -183,7 +183,7 @@ int Refiner::analyze(size_t n, const doublereal* z,
         }
 
         // Keep the point where the temperature is fixed
-        if (fflame && fflame->isFree() && z[j] == fflame->m_zfixed) {
+        if (fflame && !fflame->fixed_mdot() && z[j] == fflame->m_zfixed) {
             m_keep[j] = 1;
         }
     }

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -63,7 +63,7 @@ TEST(ct, soln_objects)
 
     int ref = soln_newSolution("gri30.yaml", "gri30", "none");
     ASSERT_EQ(ref, 0);
-    int ref2 = soln_newSolution("h2o2.yaml", "ohmech", "mixture-averaged");
+    int ref2 = soln_newSolution("h2o2.yaml", "ohmech", "");
     ASSERT_EQ(ref2, 1);
 
     int thermo = soln_thermo(ref2);
@@ -76,6 +76,11 @@ TEST(ct, soln_objects)
 
     int trans = soln_kinetics(ref2);
     ASSERT_EQ(trans, 1);
+    int buflen = trans_transportModel(trans, 0, 0);
+    vector<char> buf(buflen);
+    trans_transportModel(trans, buflen, buf.data());
+    string trName(buf.data());
+    ASSERT_EQ(trName, "mixture-averaged");
 
     soln_del(ref2);
     size_t nsp = thermo_nSpecies(thermo);
@@ -88,14 +93,13 @@ TEST(ct, soln_objects)
     err = reportError();
     EXPECT_THAT(err, HasSubstr("has been deleted."));
 
-    trans = soln_setTransportModel(ref, "Mix");
+    trans = soln_setTransportModel(ref, "mixture-averaged");
     ASSERT_EQ(trans, 2);
-    int buflen = trans_transportModel(trans, 0, 0);
-    char* buf = new char[buflen];
-    trans_transportModel(trans, buflen, buf);
-    string trName = buf;
-    ASSERT_EQ(trName, "Mix");
-    delete[] buf;
+    buflen = trans_transportModel(trans, 0, 0);
+    buf.resize(buflen);
+    trans_transportModel(trans, buflen, buf.data());
+    trName = buf.data();
+    ASSERT_EQ(trName, "mixture-averaged");
 }
 
 TEST(ct, new_interface)

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -87,6 +87,15 @@ TEST(ct, soln_objects)
     ASSERT_EQ(nr, npos);
     err = reportError();
     EXPECT_THAT(err, HasSubstr("has been deleted."));
+
+    trans = soln_setTransportModel(ref, "Mix");
+    ASSERT_EQ(trans, 2);
+    int buflen = trans_transportModel(trans, 0, 0);
+    char* buf = new char[buflen];
+    trans_transportModel(trans, buflen, buf);
+    string trName = buf;
+    ASSERT_EQ(trName, "Mix");
+    delete[] buf;
 }
 
 TEST(ct, new_interface)

--- a/test/clib/test_ctonedim.cpp
+++ b/test/clib/test_ctonedim.cpp
@@ -36,8 +36,15 @@ TEST(ctonedim, freeflow)
 
 TEST(ctonedim, inlet)
 {
-    int index = inlet_new();
-    ASSERT_GE(index, 0);
+    int inlet = inlet_new();
+    ASSERT_GE(inlet, 0);
+
+    int buflen = domain_type3(inlet, 0, 0);
+    char* buf = new char[buflen];
+    domain_type3(inlet, buflen, buf);
+    string domName = buf;
+    ASSERT_EQ(domName, "inlet");
+    delete[] buf;
 }
 
 TEST(ctonedim, outlet)

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -190,7 +190,7 @@ class TestFreeFlame(utilities.CanteraTest):
         p = ct.one_atm
         reactants = 'H2:0.65, O2:0.5, AR:2'
         self.create_sim(p, Tin, reactants, width=0.0001)
-        self.assertEqual(self.sim.flame.flow_type, 'Free Flame')
+        assert self.sim.flame.domain_type == "free-flow"
 
     def test_fixed_temperature(self):
         # test setting of fixed temperature

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -8,13 +8,13 @@ import pytest
 class TestOnedim(utilities.CanteraTest):
     def test_instantiate(self):
         gas = ct.Solution("h2o2.yaml")
-
-        flame = ct.IdealGasFlow(gas)
+        free = ct.FreeFlow(gas)
+        axi = ct.AxisymmetricFlow(gas)
 
     def test_badInstantiate(self):
         solid = ct.Solution("diamond.yaml", "diamond")
         with pytest.raises(ct.CanteraError, match="Unsupported phase type"):
-            ct.IdealGasFlow(solid)
+            ct.FreeFlow(solid)
 
     def test_instantiateSurface(self):
         gas = ct.Solution("diamond.yaml", "gas")
@@ -27,7 +27,7 @@ class TestOnedim(utilities.CanteraTest):
         gas1 = ct.Solution("h2o2.yaml")
         gas2 = ct.Solution("h2o2.yaml")
         inlet = ct.Inlet1D(name='something', phase=gas1)
-        flame = ct.IdealGasFlow(gas1)
+        flame = ct.FreeFlow(gas1)
         sim = ct.Sim1D((inlet, flame))
 
         self.assertEqual(inlet.name, 'something')
@@ -52,7 +52,7 @@ class TestOnedim(utilities.CanteraTest):
 
     def test_grid_check(self):
         gas = ct.Solution("h2o2.yaml")
-        flame = ct.IdealGasFlow(gas)
+        flame = ct.FreeFlow(gas)
 
         with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
             flame.grid = [0, 0.1, 0.1, 0.2]
@@ -63,14 +63,14 @@ class TestOnedim(utilities.CanteraTest):
     def test_unpicklable(self):
         import pickle
         gas = ct.Solution("h2o2.yaml")
-        flame = ct.IdealGasFlow(gas)
+        flame = ct.FreeFlow(gas)
         with self.assertRaises(NotImplementedError):
             pickle.dumps(flame)
 
     def test_uncopyable(self):
         import copy
         gas = ct.Solution("h2o2.yaml")
-        flame = ct.IdealGasFlow(gas)
+        flame = ct.FreeFlow(gas)
         with self.assertRaises(NotImplementedError):
             copy.copy(flame)
 
@@ -90,7 +90,7 @@ class TestOnedim(utilities.CanteraTest):
     def test_invalid_property(self):
         gas1 = ct.Solution("h2o2.yaml")
         inlet = ct.Inlet1D(name='something', phase=gas1)
-        flame = ct.IdealGasFlow(gas1)
+        flame = ct.FreeFlow(gas1)
         sim = ct.Sim1D((inlet, flame))
 
         for x in (inlet, flame, sim):
@@ -102,7 +102,7 @@ class TestOnedim(utilities.CanteraTest):
     def test_tolerances(self):
         gas = ct.Solution("h2o2.yaml")
         left = ct.Inlet1D(gas)
-        flame = ct.IdealGasFlow(gas)
+        flame = ct.FreeFlow(gas)
         right = ct.Inlet1D(gas)
         # Some things don't work until the domains have been added to a Sim1D
         sim = ct.Sim1D((left, flame, right))


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Implement `DomainFactory` (see https://github.com/Cantera/cantera/projects/2)
- Initial simplifications in Python API
- Deprecate magic numbers in `Domain1D::domainType`
- Replace raw pointers by shared pointers in assembly of `Sim1D`.
- Remove `solution` from `Domain1D::show` and `Sim1D::show` to avoid erroneous conflation with `Solution` objects
- Introduce `clib` function returning domain type as well as `new_domain` factory loader (to facilitate #1182)

While other tweaks are possible, they will create merge conflicts with #1079

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Implements one 'idea' in https://github.com/Cantera/cantera/projects/2

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```c++
shared_ptr<Domain1D> inlet = newDomain("inlet", sol, "reactants");
shared_ptr<Domain1D> flow = newDomain("gas-flow", sol, "flow");
```

for `clib`, the following items are added:
```c
int domain_type3(int i, size_t lennm, char* nm); /* returns char* instead of magic number */
int sim1D_show(int i, const char* fname); /* replaces sim1D_showSolution */
int bdry_setSpreadRate(int i, double v); /* replaces inlet_setSpreadRate */
double bdry_spreadRate(int i); /* add missing getter */

int soln_setTransportModel(int n, const char* model); /* addendum to #1448 */
int trans_transportModel(int n, int lennm, char* nm); /* returns char* specifying transport type */

int domain_new(const char* type, int i, const char* id); /* factory constructor */
```

For the Python API, the following items are (re-)introduced:
```Python
flow = ct.FreeFlow(gas)
flow = ct.AxisymmetricFlow(gas)
```

with `IdealGasFlow` being deprecated.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
