### PR TITLE
C++ code cleanup and modernization

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -97,6 +97,8 @@
 * For any new code, do *not* use the `doublereal` and `integer` typedefs for the
   basic types `double` and `int`, but also do not go out of your way to change
   uses of these in otherwise unmodified code.
+* Initialize member variables with their declarations, when possible, rather than using
+  constructor-based initialization.
 
 ## Python
 

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -34,8 +34,8 @@ namespace Cantera
 //! objects.
 class AnyBase {
 public:
-    AnyBase();
-    virtual ~AnyBase() {};
+    AnyBase() = default;
+    virtual ~AnyBase() = default;
 
     //! For values which are derived from an input file, set the line and column
     //! of this value in that file. Used for providing context for some error
@@ -49,11 +49,11 @@ public:
 protected:
     //! The line where this value occurs in the input file. Set to -1 for values
     //! that weren't created from an input file.
-    int m_line;
+    int m_line = -1;
 
     //! If m_line >= 0, the column where this value occurs in the input file.
     //! If m_line == -1, a value used for determining output ordering
-    int m_column;
+    int m_column = 0;
 
     //! Metadata relevant to an entire AnyMap tree, such as information about
     // the input file used to create it

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -13,6 +13,7 @@
 #include <unordered_map>
 #include <functional>
 #include <set>
+#include <filesystem>
 
 namespace boost
 {
@@ -676,7 +677,8 @@ private:
     //! Cache for previously-parsed input (YAML) files. The key is the full path
     //! to the file, and the second element of the value is the last-modified
     //! time for the file, which is used to enable change detection.
-    static std::unordered_map<std::string, std::pair<AnyMap, int>> s_cache;
+    static std::unordered_map<string,
+                              pair<AnyMap, std::filesystem::file_time_type>> s_cache;
 
     //! Information about fields that should appear first when outputting to
     //! YAML. Keys in this map are matched to `__type__` keys in AnyMap

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -11,8 +11,6 @@
 #include "cantera/base/Units.h"
 
 #include <unordered_map>
-#include <functional>
-#include <set>
 #include <filesystem>
 
 namespace boost

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -12,11 +12,7 @@
 
 #include <unordered_map>
 #include <filesystem>
-
-namespace boost
-{
-class any;
-}
+#include <any>
 
 namespace YAML
 {
@@ -85,10 +81,6 @@ class AnyValue : public AnyBase
 public:
     AnyValue();
     ~AnyValue();
-    AnyValue(AnyValue const& other);
-    AnyValue(AnyValue&& other);
-    AnyValue& operator=(AnyValue const& other);
-    AnyValue& operator=(AnyValue&& other);
 
     bool operator==(const AnyValue& other) const;
     bool operator!=(const AnyValue& other) const;
@@ -275,24 +267,24 @@ private:
     std::string m_key;
 
     //! The held value
-    std::unique_ptr<boost::any> m_value;
+    std::any m_value;
 
-    typedef bool (*Comparer)(const boost::any&, const boost::any&);
+    typedef bool (*Comparer)(const std::any&, const std::any&);
 
     //! Equality comparison function used when *lhs* is of type *T*
     template <typename T>
-    static bool eq_comparer(const boost::any& lhs, const boost::any& rhs);
+    static bool eq_comparer(const std::any& lhs, const std::any& rhs);
 
     //! Helper function for comparing vectors of different (but comparable)
     //! types, for example `vector<double>` and `vector<long int>`
     template<class T, class U>
-    static bool vector_eq(const boost::any& lhs, const boost::any& rhs);
+    static bool vector_eq(const std::any& lhs, const std::any& rhs);
 
     //! Helper function for comparing nested vectors of different (but
     //! comparable) types, for example `vector<vector<double>>` and
     //! `vector<vector<long int>>`
     template<class T, class U>
-    static bool vector2_eq(const boost::any& lhs, const boost::any& rhs);
+    static bool vector2_eq(const std::any& lhs, const std::any& rhs);
 
     mutable Comparer m_equals;
 
@@ -754,8 +746,6 @@ void warn_deprecated(const std::string& source, const AnyBase& node,
 
 }
 
-#ifndef CANTERA_API_NO_BOOST
 #include "cantera/base/AnyMap.inl.h"
-#endif
 
 #endif

--- a/include/cantera/base/AnyMap.inl.h
+++ b/include/cantera/base/AnyMap.inl.h
@@ -87,8 +87,8 @@ AnyValue& AnyValue::operator=(const std::unordered_map<std::string, T> items) {
     *m_value = AnyMap();
     m_equals = eq_comparer<AnyMap>;
     AnyMap& dest = as<AnyMap>();
-    for (const auto& item : items) {
-        dest[item.first] = item.second;
+    for (const auto& [key, value] : items) {
+        dest[key] = value;
     }
     return *this;
 }
@@ -98,8 +98,8 @@ AnyValue& AnyValue::operator=(const std::map<std::string, T> items) {
     *m_value = AnyMap();
     m_equals = eq_comparer<AnyMap>;
     AnyMap& dest = as<AnyMap>();
-    for (const auto& item : items) {
-        dest[item.first] = item.second;
+    for (const auto& [key, value] : items) {
+        dest[key] = value;
     }
     return *this;
 }

--- a/include/cantera/base/AnyMap.inl.h
+++ b/include/cantera/base/AnyMap.inl.h
@@ -179,7 +179,6 @@ template<class T>
 bool AnyValue::eq_comparer(const boost::any& lhs, const boost::any& rhs)
 {
     using boost::any_cast;
-    using std::vector;
     typedef vector<double> vd;
     typedef vector<long int> vi;
     typedef vector<AnyValue> va;

--- a/include/cantera/base/Array.h
+++ b/include/cantera/base/Array.h
@@ -46,7 +46,7 @@ public:
     /**
      * Default constructor. Create an empty array.
      */
-    Array2D();
+    Array2D() = default;
 
     //! Constructor.
     /*!
@@ -72,7 +72,7 @@ public:
 
     Array2D(const Array2D& y);
 
-    virtual ~Array2D() {}
+    virtual ~Array2D() = default;
 
     Array2D& operator=(const Array2D& y);
 
@@ -249,10 +249,10 @@ protected:
     vector_fp m_data;
 
     //! Number of rows
-    size_t m_nrows;
+    size_t m_nrows = 0;
 
     //! Number of columns
-    size_t m_ncols;
+    size_t m_ncols = 0;
 };
 
 //! Output the current contents of the Array2D object

--- a/include/cantera/base/ExtensionManager.h
+++ b/include/cantera/base/ExtensionManager.h
@@ -7,7 +7,6 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/base/ctexceptions.h"
-#include <functional>
 
 namespace Cantera
 {

--- a/include/cantera/base/ExtensionManagerFactory.h
+++ b/include/cantera/base/ExtensionManagerFactory.h
@@ -35,7 +35,7 @@ private:
     static ExtensionManagerFactory* s_factory;
 
     //! Private constructor prevents direct usage
-    ExtensionManagerFactory();
+    ExtensionManagerFactory() = default;
 
     //! Decl for locking mutex for thermo factory singleton
     static std::mutex s_mutex;

--- a/include/cantera/base/FactoryBase.h
+++ b/include/cantera/base/FactoryBase.h
@@ -11,7 +11,6 @@
 
 #include <mutex>
 #include <unordered_map>
-#include <functional>
 #include "cantera/base/ctexceptions.h"
 #include "cantera/base/global.h"
 

--- a/include/cantera/base/Interface.h
+++ b/include/cantera/base/Interface.h
@@ -17,7 +17,7 @@ namespace Cantera
 class Interface : public Solution
 {
 private:
-    Interface();
+    Interface() = default;
 
 public:
     ~Interface() {}

--- a/include/cantera/base/NoExitLogger.h
+++ b/include/cantera/base/NoExitLogger.h
@@ -6,7 +6,6 @@
 #ifndef NOEXITLOGGER_H
 #define NOEXITLOGGER_H
 
-#include <string>
 #include "cantera/base/logger.h"
 
 namespace Cantera {

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -21,10 +21,10 @@ class ExternalHandle;
 class Solution : public std::enable_shared_from_this<Solution>
 {
 protected:
-    Solution();
+    Solution() = default;
 
 public:
-    virtual ~Solution() {}
+    virtual ~Solution() = default;
     Solution(const Solution&) = delete;
     Solution& operator=(const Solution&) = delete;
 

--- a/include/cantera/base/Storage.h
+++ b/include/cantera/base/Storage.h
@@ -8,7 +8,6 @@
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/base/stringUtils.h"
-#include <set>
 
 #if CT_USE_HDF5
 

--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -69,15 +69,15 @@ private:
     //! Scale the unit by the factor `k`
     void scale(double k) { m_factor *= k; }
 
-    double m_factor; //!< conversion factor to Cantera base units
-    double m_mass_dim;
-    double m_length_dim;
-    double m_time_dim;
-    double m_temperature_dim;
-    double m_current_dim;
-    double m_quantity_dim;
-    double m_pressure_dim; //!< pseudo-dimension to track explicit pressure units
-    double m_energy_dim; //!< pseudo-dimension to track explicit energy units
+    double m_factor = 1.0; //!< conversion factor to Cantera base units
+    double m_mass_dim = 0.0;
+    double m_length_dim = 0.0;
+    double m_time_dim = 0.0;
+    double m_temperature_dim = 0.0;
+    double m_current_dim = 0.0;
+    double m_quantity_dim = 0.0;
+    double m_pressure_dim = 0.0; //!< pseudo-dimension to track explicit pressure units
+    double m_energy_dim = 0.0; //!< pseudo-dimension to track explicit energy units
 
     friend class UnitSystem;
 };
@@ -254,29 +254,29 @@ public:
 
 private:
     //! Factor to convert mass from this unit system to kg
-    double m_mass_factor;
+    double m_mass_factor = 1.0;
 
     //! Factor to convert length from this unit system to meters
-    double m_length_factor;
+    double m_length_factor = 1.0;
 
     //! Factor to convert time from this unit system to seconds
-    double m_time_factor;
+    double m_time_factor = 1.0;
 
     //! Factor to convert pressure from this unit system to Pa
-    double m_pressure_factor;
+    double m_pressure_factor = 1.0;
 
     //! Factor to convert energy from this unit system to J
-    double m_energy_factor;
+    double m_energy_factor = 1.0;
 
     //! Factor to convert activation energy from this unit system to J/kmol
-    double m_activation_energy_factor;
+    double m_activation_energy_factor = 1.0;
 
     //! Factor to convert quantity from this unit system to kmol
-    double m_quantity_factor;
+    double m_quantity_factor = 1.0;
 
     //! True if activation energy units are set explicitly, rather than as a
     //! combination of energy and quantity units
-    bool m_explicit_activation_energy;
+    bool m_explicit_activation_energy = false;
 
     //! Map of dimensions (mass, length, etc.) to names of specified default
     //! units

--- a/include/cantera/base/ValueCache.h
+++ b/include/cantera/base/ValueCache.h
@@ -30,13 +30,7 @@ namespace Cantera
  */
 template <class T>
 struct CachedValue {
-    CachedValue() :
-        state1(std::numeric_limits<double>::quiet_NaN()),
-        state2(std::numeric_limits<double>::quiet_NaN()),
-        stateNum(std::numeric_limits<int>::min()),
-        value(T())
-    {
-    }
+    CachedValue() = default;
 
     //! Check whether the currently cached value is valid based on
     //! a single state variable. If it is not valid it updates the stored
@@ -104,18 +98,18 @@ struct CachedValue {
 
     //! Value of the first state variable for the state at which #value was
     //! evaluated, for example temperature.
-    double state1;
+    double state1 = std::numeric_limits<double>::quiet_NaN();
 
     //! Value of the second state variable for the state at which #value was
     //! evaluated, for example density or pressure.
-    double state2;
+    double state2 = std::numeric_limits<double>::quiet_NaN();
 
     //! A surrogate for the composition. For cached properties of Phase,
     //! this should be set to Phase::stateMFNumber()
-    int stateNum;
+    int stateNum = std::numeric_limits<int>::min();
 
     //! The value of the cached property
-    T value;
+    T value = T();
 };
 
 typedef CachedValue<double>& CachedScalar;

--- a/include/cantera/base/YamlWriter.h
+++ b/include/cantera/base/YamlWriter.h
@@ -22,7 +22,7 @@ class Transport;
 class YamlWriter
 {
 public:
-    YamlWriter();
+    YamlWriter() = default;
 
     //! Include top-level information used in YAML header block
     void setHeader(const AnyMap& header);
@@ -76,10 +76,10 @@ protected:
     std::vector<shared_ptr<Solution>> m_phases;
 
     //! See setPrecision()
-    long int m_float_precision;
+    long int m_float_precision = 15;
 
     //! See skipUserDefined()
-    bool m_skip_user_defined;
+    bool m_skip_user_defined = false;
 
     //! Top-level units directive for the output file. Defaults to Cantera's
     //! native SI+kmol system.

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -37,6 +37,7 @@ namespace Cantera
 using std::shared_ptr;
 using std::make_shared;
 using std::unique_ptr;
+using std::make_unique;
 using std::isnan; // workaround for bug in libstdc++ 4.8
 using std::string;
 using std::vector;

--- a/include/cantera/base/utilities.h
+++ b/include/cantera/base/utilities.h
@@ -187,17 +187,13 @@ const U& getValue(const std::map<T, U>& m, const T& key, const U& default_val) {
 }
 
 //! A macro for generating member function detectors, which can then be used in
-//! combination with `std::enable_if` to allow selection of a particular template
-//! specialization based on the presence of that member function. See MultiRate for
-//! examples of use.
-#define CT_DEFINE_HAS_MEMBER(detector_name, func_name)                   \
-    template <typename T>                                                \
-    struct detector_name {                                               \
-        typedef char (& yes)[1], (& no)[2];                              \
-        template <typename C> static yes check(decltype(&C::func_name)); \
-        template <typename> static no check(...);                        \
-        static bool const value = sizeof(check<T>(0)) == sizeof(yes);    \
-    };
+//! combination with `if constexpr` to condition behavior on the availability of that
+//! member function. See MultiRate for examples of use.
+#define CT_DEFINE_HAS_MEMBER(detector_name, func_name) \
+    template<class T, class=void> \
+    struct detector_name : std::false_type {}; \
+    template<class T> \
+    struct detector_name<T, std::void_t<decltype(&T::func_name)>> : std::true_type {};
 
 }
 

--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -25,33 +25,31 @@ int _equilflag(const char* xy);
 class EquilOpt
 {
 public:
-    EquilOpt() : relTolerance(1.e-8), absElemTol(1.0E-70),maxIterations(1000),
-        iterations(0),
-        maxStepSize(10.0), propertyPair(TP), contin(false) {}
+    EquilOpt() = default;
 
-    doublereal relTolerance; //! < Relative tolerance
-    doublereal absElemTol; //! < Abs Tol in element number
-    int maxIterations; //! < Maximum number of iterations
-    int iterations; //! < Iteration counter
+    double relTolerance = 1e-8; //!< Relative tolerance
+    double absElemTol = 1e-70; //!< Abs Tol in element number
+    int maxIterations = 1000; //!< Maximum number of iterations
+    int iterations = 0; //!< Iteration counter
 
     /**
      * Maximum step size. Largest change in any element potential or
-     * in log(T) allowed in one Newton step. Default: 10.0
+     * in log(T) allowed in one Newton step.
      */
-    doublereal maxStepSize;
+    double maxStepSize = 10.0;
 
     /**
      * Property pair flag. Determines which two thermodynamic properties
      * are fixed.
      */
-    int propertyPair;
+    int propertyPair = TP;
 
     /**
      * Continuation flag. Set true if the calculation should be initialized from
      * the last calculation. Otherwise, the calculation will be started from
      * scratch and the initial composition and element potentials estimated.
      */
-    bool contin;
+    bool contin = false;
 };
 
 /**
@@ -80,7 +78,7 @@ public:
 class ChemEquil
 {
 public:
-    ChemEquil();
+    ChemEquil() = default;
 
     //! Constructor combined with the initialization function
     /*!
@@ -91,7 +89,7 @@ public:
      */
     ChemEquil(ThermoPhase& s);
 
-    virtual ~ChemEquil();
+    virtual ~ChemEquil() = default;
 
     /*!
      * Equilibrate a phase, holding the elemental composition fixed at the
@@ -249,7 +247,7 @@ protected:
 
     size_t m_mm; //!< number of elements in the phase
     size_t m_kk; //!< number of species in the phase
-    size_t m_skip;
+    size_t m_skip = npos;
 
     //! This is equal to the rank of the stoichiometric coefficient matrix when
     //! it is computed. It's initialized to #m_mm.
@@ -262,7 +260,7 @@ protected:
 
     //! Current value of the sum of the element abundances given the current
     //! element potentials.
-    doublereal m_elementTotalSum;
+    double m_elementTotalSum = 1.0;
 
     //! Current value of the element mole fractions. Note these aren't the goal
     //! element mole fractions.
@@ -274,11 +272,11 @@ protected:
     //! Storage of the element compositions. natom(k,m) = m_comp[k*m_mm+ m];
     vector_fp m_comp;
     doublereal m_temp, m_dens;
-    doublereal m_p0;
+    double m_p0 = OneAtm;
 
     //! Index of the element id corresponding to the electric charge of each
     //! species. Equal to -1 if there is no such element id.
-    size_t m_eloc;
+    size_t m_eloc = npos;
 
     vector_fp m_startSoln;
 
@@ -292,8 +290,8 @@ protected:
     std::vector<size_t> m_component;
 
     //! element fractional cutoff, below which the element will be zeroed.
-    double m_elemFracCutoff;
-    bool m_doResPerturb;
+    double m_elemFracCutoff = 1e-100;
+    bool m_doResPerturb = false;
 
     std::vector<size_t> m_orderVectorElements;
     std::vector<size_t> m_orderVectorSpecies;

--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -9,7 +9,6 @@
 #define CT_CHEM_EQUIL_H
 
 #include "cantera/base/ct_defs.h"
-#include <functional>
 
 namespace Cantera
 {

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -64,11 +64,11 @@ public:
      *  The constructor takes no arguments, since phases are added using
      *  method addPhase().
      */
-    MultiPhase();
+    MultiPhase() = default;
 
     //! Destructor. Does nothing. Class MultiPhase does not take "ownership"
     //! (that is, responsibility for destroying) the phase objects.
-    virtual ~MultiPhase() {}
+    virtual ~MultiPhase() = default;
 
     //! Add a vector of phases to the mixture
     /*!
@@ -618,23 +618,23 @@ private:
     std::map<std::string, size_t> m_enamemap;
 
     //! Current value of the temperature (kelvin)
-    doublereal m_temp;
+    double m_temp = 298.15;
 
     //! Current value of the pressure (Pa)
-    doublereal m_press;
+    double m_press = OneBar;
 
     //! Number of distinct elements in all of the phases
-    size_t m_nel;
+    size_t m_nel = 0;
 
     //! Number of distinct species in all of the phases
-    size_t m_nsp;
+    size_t m_nsp = 0;
 
     //! True if the init() routine has been called, and the MultiPhase frozen
-    bool m_init;
+    bool m_init = false;
 
     //! Global ID of the element corresponding to the electronic charge. If
     //! there is none, then this is equal to -1
-    size_t m_eloc;
+    size_t m_eloc = npos;
 
     //! Vector of bools indicating whether temperatures are ok for phases.
     /*!
@@ -645,11 +645,11 @@ private:
 
     //! Minimum temperature for which thermo parameterizations are valid.
     //! Stoichiometric phases are ignored in this determination. units Kelvin
-    doublereal m_Tmin;
+    double m_Tmin = 1.0;
 
     //! Minimum temperature for which thermo parameterizations are valid.
     //! Stoichiometric phases are ignored in this determination. units Kelvin
-    doublereal m_Tmax;
+    double m_Tmax = 100000.0;
 
     //! Vector of element abundances
     /*!

--- a/include/cantera/equil/MultiPhaseEquil.h
+++ b/include/cantera/equil/MultiPhaseEquil.h
@@ -165,8 +165,9 @@ protected:
     }
 
     size_t m_nel_mix, m_nsp_mix;
-    size_t m_nel, m_nsp;
-    size_t m_eloc;
+    size_t m_nel = 0;
+    size_t m_nsp = 0;
+    size_t m_eloc = 1000;
     int m_iter;
     MultiPhase* m_mix;
     doublereal m_press, m_temp;
@@ -186,7 +187,7 @@ protected:
     std::vector<size_t> m_species;
     std::vector<size_t> m_element;
     std::vector<bool> m_solnrxn;
-    bool m_force;
+    bool m_force = true;
 };
 
 }

--- a/include/cantera/equil/vcs_SpeciesProperties.h
+++ b/include/cantera/equil/vcs_SpeciesProperties.h
@@ -27,10 +27,10 @@ public:
     std::string SpName;
 
     //! Pointer to the thermo structure for this species
-    VCS_SPECIES_THERMO* SpeciesThermo;
+    VCS_SPECIES_THERMO* SpeciesThermo = nullptr;
 
     //! Molecular Weight of the species (gm/mol)
-    double WtSpecies;
+    double WtSpecies = 0.0;
 
     //! Column of the formula matrix, comprising the
     //! element composition of the species
@@ -38,10 +38,10 @@ public:
 
     //! Charge state of the species -> This may be duplication of what's in the
     //! FormulaMatrixCol entries. However, it's prudent to separate it out.
-    double Charge;
+    double Charge = 0.0;
 
     //! True if this species belongs to a surface phase
-    int SurfaceSpecies;
+    int SurfaceSpecies = 0;
 
     /*
      * Various Calculated Quantities that are appropriate to keep copies of at
@@ -49,28 +49,22 @@ public:
      */
 
     //! Partial molar volume of the species
-    double VolPM;
+    double VolPM = 0.0;
 
     //! Representative value of the mole fraction of this species in a phase.
     //! This value is used for convergence issues and for calculation of
     //! numerical derivatives
-    double ReferenceMoleFraction;
+    double ReferenceMoleFraction = 1e-6;
 
     vcs_SpeciesProperties(size_t indexPhase, size_t indexSpeciesPhase,
                           vcs_VolPhase* owning)
         : IndexPhase(indexPhase)
         , IndexSpeciesPhase(indexSpeciesPhase)
         , OwningPhase(owning)
-        , SpeciesThermo(0)
-        , WtSpecies(0.0)
-        , Charge(0.0)
-        , SurfaceSpecies(0)
-        , VolPM(0.0)
-        , ReferenceMoleFraction(1.0E-6)
     {
     }
 
-    virtual ~vcs_SpeciesProperties() {}
+    virtual ~vcs_SpeciesProperties() = default;
 };
 
 }

--- a/include/cantera/equil/vcs_VolPhase.h
+++ b/include/cantera/equil/vcs_VolPhase.h
@@ -9,7 +9,8 @@
 #ifndef VCS_VOLPHASE_H
 #define VCS_VOLPHASE_H
 
-#include "cantera/equil/vcs_SpeciesProperties.h"
+#include "vcs_SpeciesProperties.h"
+#include "vcs_defs.h"
 #include "cantera/base/Array.h"
 
 namespace Cantera
@@ -527,7 +528,7 @@ private:
 
 private:
     //! Backtrack value of VCS_SOLVE *
-    VCS_SOLVE* m_owningSolverObject;
+    VCS_SOLVE* m_owningSolverObject = nullptr;
 
 public:
     //! Original ID of the phase in the problem.
@@ -535,23 +536,23 @@ public:
      * If a non-ideal phase splits into two due to a miscibility gap, these
      * numbers will stay the same after the split.
      */
-    size_t VP_ID_;
+    size_t VP_ID_ = npos;
 
     //! If true, this phase consists of a single species
-    bool m_singleSpecies;
+    bool m_singleSpecies = true;
 
     //! If true, this phase is a gas-phase like phase
     /*!
      * A RTlog(p/1atm) term is added onto the chemical potential for inert
      * species if this is true.
      */
-    bool m_gasPhase;
+    bool m_gasPhase = false;
 
     //! Type of the equation of state
     /*!
      * The known types are listed at the top of this file.
      */
-    int m_eqnState;
+    int m_eqnState = VCS_EOS_CONSTANT;
 
     //! This is the element number for the charge neutrality condition of the
     //! phase
@@ -559,7 +560,7 @@ public:
      *  If it has one.  If it does not have a charge neutrality
      * constraint, then this value is equal to -1
      */
-    size_t ChargeNeutralityElement;
+    size_t ChargeNeutralityElement = npos;
 
     //! Convention for the activity formulation
     /*!
@@ -567,14 +568,14 @@ public:
      *  * 1 = Molality based activities, mu = mu_0 + ln a_molality. Standard
      *    state is based on unity molality
      */
-    int p_activityConvention;
+    int p_activityConvention = 0;
 
 private:
     //! Number of element constraints within the problem
     /*!
      *  This is usually equal to the number of elements.
      */
-    size_t m_numElemConstraints;
+    size_t m_numElemConstraints = 0;
 
     //! vector of strings containing the element constraint names
     /*!
@@ -620,7 +621,7 @@ private:
     std::vector<size_t> m_elemGlobalIndex;
 
     //! Number of species in the phase
-    size_t m_numSpecies;
+    size_t m_numSpecies = 0;
 
 public:
     //! String name for the phase
@@ -628,12 +629,12 @@ public:
 
 private:
     //!  Total moles of inert in the phase
-    double m_totalMolesInert;
+    double m_totalMolesInert = 0.0;
 
     //! Boolean indicating whether the phase is an ideal solution
     //! and therefore its molar-based activity coefficients are
     //! uniformly equal to one.
-    bool m_isIdealSoln;
+    bool m_isIdealSoln = false;
 
     //! Current state of existence:
     /*!
@@ -649,7 +650,7 @@ private:
      *   because it consists of a single species, which is identified with the
      *   voltage, for example, its an electron metal phase.
      */
-    int m_existence;
+    int m_existence = VCS_PHASE_EXIST_NO;
 
     // Index of the first MF species in the list of unknowns for this phase
     /*!
@@ -659,7 +660,7 @@ private:
      *  to 0 for single species phases, where we set by hand the mole fraction
      *  of species 0 to one.
      */
-    int m_MFStartIndex;
+    int m_MFStartIndex = 0;
 
     //! Index into the species vectors
     /*!
@@ -679,10 +680,10 @@ private:
      *  If we are using Cantera, this is the pointer to the ThermoPhase
      *  object. If not, this is null.
      */
-    ThermoPhase* TP_ptr;
+    ThermoPhase* TP_ptr = nullptr;
 
     //!  Total mols in the phase. units are kmol
-    double v_totalMoles;
+    double v_totalMoles = 0.0;
 
     //! Vector of the current mole fractions for species in the phase
     vector_fp Xmol_;
@@ -712,10 +713,10 @@ private:
 
     //! If the potential is a solution variable in VCS, it acts as a species.
     //! This is the species index in the phase for the potential
-    size_t m_phiVarIndex;
+    size_t m_phiVarIndex = npos;
 
     //! Total Volume of the phase. Units are m**3.
-    mutable double m_totalVol;
+    mutable double m_totalVol = 0.0;
 
     //! Vector of calculated SS0 chemical potentials for the
     //! current Temperature.
@@ -763,14 +764,14 @@ private:
      *  - VCS_STATECALC_NEW
      *  - VCS_STATECALC_TMP
      */
-    int m_vcsStateStatus;
+    int m_vcsStateStatus = VCS_STATECALC_OLD;
 
     //! Value of the potential for the phase (Volts)
-    double m_phi;
+    double m_phi = 0.0;
 
     //! Boolean indicating whether the object has an up-to-date mole number vector
     //! and potential with respect to the current vcs state calc status
-    bool m_UpToDate;
+    bool m_UpToDate = false;
 
     //! Boolean indicating whether activity coefficients are up to date.
     /*!
@@ -778,7 +779,7 @@ private:
      * called when they are needed (and when the state has changed so that they
      * need to be recalculated).
      */
-    mutable bool m_UpToDate_AC;
+    mutable bool m_UpToDate_AC = false;
 
     //! Boolean indicating whether Star volumes are up to date.
     /*!
@@ -787,7 +788,7 @@ private:
      * need to be recalculated). Star volumes are sensitive to temperature and
      * pressure
      */
-    mutable bool m_UpToDate_VolStar;
+    mutable bool m_UpToDate_VolStar = false;
 
     //! Boolean indicating whether partial molar volumes are up to date.
     /*!
@@ -796,25 +797,25 @@ private:
      * need to be recalculated). partial molar volumes are sensitive to
      * everything
      */
-    mutable bool m_UpToDate_VolPM;
+    mutable bool m_UpToDate_VolPM = false;
 
     //! Boolean indicating whether GStar is up to date.
     /*!
      * GStar is sensitive to the temperature and the pressure, only
      */
-    mutable bool m_UpToDate_GStar;
+    mutable bool m_UpToDate_GStar = false;
 
     //! Boolean indicating whether G0 is up to date.
     /*!
      * G0 is sensitive to the temperature and the pressure, only
      */
-    mutable bool m_UpToDate_G0;
+    mutable bool m_UpToDate_G0 = false;
 
     //! Current value of the temperature for this object, and underlying objects
-    double Temp_;
+    double Temp_ = 273.15;
 
     //! Current value of the pressure for this object, and underlying objects
-    double Pres_;
+    double Pres_ = OneAtm;
 };
 
 }

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -1045,13 +1045,13 @@ public:
     size_t m_nsp;
 
     //! Number of element constraints in the problem
-    size_t m_nelem;
+    size_t m_nelem = 0;
 
     //! Number of components calculated for the problem
-    size_t m_numComponents;
+    size_t m_numComponents = 0;
 
     //! Total number of non-component species in the problem
-    size_t m_numRxnTot;
+    size_t m_numRxnTot = 0;
 
     //! Current number of species in the problems. Species can be deleted if
     //! they aren't stable under the current conditions
@@ -1059,11 +1059,11 @@ public:
 
     //! Current number of non-component species in the problem. Species can be
     //! deleted if they aren't stable under the current conditions
-    size_t m_numRxnRdc;
+    size_t m_numRxnRdc = 0;
 
     //! Number of active species which are currently either treated as
     //! minor species
-    size_t m_numRxnMinorZeroed;
+    size_t m_numRxnMinorZeroed = 0;
 
     //! Number of Phases in the problem
     size_t m_numPhases;
@@ -1143,7 +1143,7 @@ public:
      *       1 Only do an estimate if the element abundances aren't satisfied.
      *      -1 Force an estimate of the soln. Throw out the input mole numbers.
      */
-    int m_doEstimateEquil;
+    int m_doEstimateEquil = -1;
 
     //! Total moles of the species
     /*!
@@ -1236,7 +1236,7 @@ public:
      * This number includes the inerts.
      *            -> Don't use this except for scaling purposes
      */
-    double m_totalMolNum;
+    double m_totalMolNum = 0.0;
 
     //! Total kmols of species in each phase
     /*!
@@ -1281,16 +1281,16 @@ public:
     vector_fp TPhInertMoles;
 
     //! Tolerance requirement for major species
-    double m_tolmaj;
+    double m_tolmaj= 1e-8;
 
     //! Tolerance requirements for minor species
-    double m_tolmin;
+    double m_tolmin = 1e-6;
 
     //! Below this, major species aren't refined any more
-    double m_tolmaj2;
+    double m_tolmaj2 = 1e-10;
 
     //! Below this, minor species aren't refined any more
-    double m_tolmin2;
+    double m_tolmin2 = 1e-8;
 
     //! Index vector that keeps track of the species vector rearrangement
     /*!
@@ -1466,7 +1466,7 @@ public:
      * If this is true, then we will use a better approximation to the Hessian
      * based on Jacobian of the ln(ActCoeff) with respect to mole numbers
      */
-    int m_useActCoeffJac;
+    int m_useActCoeffJac = 0;
 
     //! Total volume of all phases. Units are m^3
     double m_totalVol;
@@ -1482,7 +1482,7 @@ public:
     double m_Faraday_dim;
 
     //! Timing and iteration counters for the vcs object
-    VCS_COUNTERS* m_VCount;
+    VCS_COUNTERS* m_VCount = nullptr;
 
     //! Debug printing lvl
     /*!
@@ -1496,14 +1496,14 @@ public:
      *     * 6  Each decision in solve_TP gets a line per species in addition to 4
      *     * 10 Additionally Hessian matrix is printed out
      */
-    int m_debug_print_lvl;
+    int m_debug_print_lvl = 0;
 
     //! printing level of timing information
     /*!
      *  * 1 allowing printing of timing
      *  * 0 do not allow printing of timing -> everything is printed as a NA.
      */
-    int m_timing_print_lvl;
+    int m_timing_print_lvl = 1;
 
     //! Disable printing of timing information. Used to generate consistent
     //! output for tests.

--- a/include/cantera/equil/vcs_species_thermo.h
+++ b/include/cantera/equil/vcs_species_thermo.h
@@ -35,69 +35,52 @@ class VCS_SPECIES_THERMO
      * All objects are public for ease of development
      */
 public:
+    VCS_SPECIES_THERMO() = default;
+
     //! Index of the phase that this species belongs to.
-    size_t IndexPhase;
+    size_t IndexPhase = 0;
 
     //! Index of this species in the current phase.
-    size_t IndexSpeciesPhase;
+    size_t IndexSpeciesPhase = 0;
 
     //! Pointer to the owning phase object.
-    vcs_VolPhase* OwningPhase;
+    vcs_VolPhase* OwningPhase = nullptr;
 
     //! Integer representing the models for the species standard state Naught
     //! temperature dependence. They are listed above and start with VCS_SS0_...
-    int SS0_Model;
+    int SS0_Model = VCS_SS0_CONSTANT;
 
     //! Internal storage of the last calculation of the reference naught Gibbs
     //! free energy at SS0_TSave. (always in units of Kelvin)
-    double SS0_feSave;
+    double SS0_feSave = 0.0;
 
     //! Internal storage of the last temperature used in the calculation of the
     //! reference naught Gibbs free energy. units = kelvin
-    double SS0_TSave;
+    double SS0_TSave = -90.0;
 
     //! Base temperature used in the VCS_SS0_CONSTANT_CP model
-    double SS0_T0;
+    double SS0_T0 = 273.15;
 
     //! Base enthalpy used in the VCS_SS0_CONSTANT_CP model
-    double SS0_H0;
+    double SS0_H0 = 0.0;
 
     //! Base entropy used in the VCS_SS0_CONSTANT_CP model
-    double SS0_S0;
+    double SS0_S0 = 0.0;
 
     //! Base heat capacity used in the VCS_SS0_CONSTANT_CP model
-    double SS0_Cp0;
+    double SS0_Cp0 = 0.0;
 
     //! Value of the pressure for the reference state.
-    //! defaults to 1.01325E5 = 1 atm
-    double SS0_Pref;
+    double SS0_Pref = OneAtm;
 
     //! Integer value representing the star state model.
-    int SSStar_Model;
+    int SSStar_Model = VCS_SSSTAR_CONSTANT;
 
     //! Models for the standard state volume of each species
-    int SSStar_Vol_Model;
+    int SSStar_Vol_Model = VCS_SSVOL_IDEALGAS;
 
     //! parameter that is used in the VCS_SSVOL_CONSTANT model.
-    double SSStar_Vol0;
-
-    VCS_SPECIES_THERMO()
-         : IndexPhase(0)
-         , IndexSpeciesPhase(0)
-         , OwningPhase(0)
-         , SS0_Model(VCS_SS0_CONSTANT)
-         , SS0_feSave(0.0)
-         , SS0_TSave(-90.0)
-         , SS0_T0(273.15)
-         , SS0_H0(0.0)
-         , SS0_S0(0.0)
-         , SS0_Cp0(0.0)
-         , SS0_Pref(1.01325E5)
-         , SSStar_Model(VCS_SSSTAR_CONSTANT)
-         , SSStar_Vol_Model(VCS_SSVOL_IDEALGAS)
-         , SSStar_Vol0(-1.0)
-    {
-    }
+    double SSStar_Vol0 = -1;
 };
 
 }

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -183,7 +183,7 @@ public:
     using ArrheniusBase::ArrheniusBase; // inherit constructors
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiRate<ArrheniusRate, ArrheniusData>);
+        return make_unique<MultiRate<ArrheniusRate, ArrheniusData>>();
     }
 
     virtual const std::string type() const override {

--- a/include/cantera/kinetics/BlowersMaselRate.h
+++ b/include/cantera/kinetics/BlowersMaselRate.h
@@ -107,8 +107,8 @@ public:
     void updateFromStruct(const BlowersMaselData& shared_data) {
         if (shared_data.ready) {
             m_deltaH_R = 0.;
-            for (const auto& item : m_stoich_coeffs) {
-                m_deltaH_R += shared_data.partialMolarEnthalpies[item.first] * item.second;
+            for (const auto& [k, multiplier] : m_stoich_coeffs) {
+                m_deltaH_R += shared_data.partialMolarEnthalpies[k] * multiplier;
             }
             m_deltaH_R /= GasConstant;
         }

--- a/include/cantera/kinetics/BlowersMaselRate.h
+++ b/include/cantera/kinetics/BlowersMaselRate.h
@@ -18,7 +18,7 @@ namespace Cantera
  */
 struct BlowersMaselData : public ReactionData
 {
-    BlowersMaselData();
+    BlowersMaselData() = default;
 
     virtual void update(double T) override;
     virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
@@ -29,12 +29,12 @@ struct BlowersMaselData : public ReactionData
         ready = true;
     }
 
-    bool ready; //!< boolean indicating whether vectors are accessible
-    double density; //!< used to determine if updates are needed
+    bool ready = false; //!< boolean indicating whether vectors are accessible
+    double density = NAN; //!< used to determine if updates are needed
     vector_fp partialMolarEnthalpies; //!< partial molar enthalpies
 
 protected:
-    int m_state_mf_number; //!< integer that is incremented when composition changes
+    int m_state_mf_number = -1; //!< integer that is incremented when composition changes
 };
 
 
@@ -180,7 +180,7 @@ protected:
     //! Pairs of species indices and multipliers to calculate enthalpy change
     std::vector<std::pair<size_t, double>> m_stoich_coeffs;
 
-    double m_deltaH_R; //!< enthalpy change of reaction (in temperature units)
+    double m_deltaH_R = 0.0; //!< enthalpy change of reaction (in temperature units)
 };
 
 }

--- a/include/cantera/kinetics/BlowersMaselRate.h
+++ b/include/cantera/kinetics/BlowersMaselRate.h
@@ -88,7 +88,7 @@ public:
                               const UnitStack& rate_units={});
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiRate<BlowersMaselRate, BlowersMaselData>);
+        return make_unique<MultiRate<BlowersMaselRate, BlowersMaselData>>();
     }
 
     virtual const std::string type() const override {

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -20,7 +20,7 @@ namespace Cantera
 class BulkKinetics : public Kinetics
 {
 public:
-    BulkKinetics();
+    BulkKinetics() = default;
 
     //! @deprecated  To be removed after Cantera 3.0; code base only uses default.
     BulkKinetics(ThermoPhase* thermo);
@@ -76,8 +76,8 @@ protected:
 
     vector_fp m_grt;
 
-    bool m_ROP_ok;
-    doublereal m_temp;
+    bool m_ROP_ok = false;
+    double m_temp = 0.0;
 };
 
 }

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -22,7 +22,7 @@ namespace Cantera
  */
 struct ChebyshevData : public ReactionData
 {
-    ChebyshevData() : pressure(NAN), log10P(0.), m_pressure_buf(-1.) {}
+    ChebyshevData() = default;
 
     virtual void update(double T) override;
 
@@ -50,11 +50,11 @@ struct ChebyshevData : public ReactionData
         pressure = NAN;
     }
 
-    double pressure; //!< pressure
-    double log10P; //!< base 10 logarithm of pressure
+    double pressure = NAN; //!< pressure
+    double log10P = 0.0; //!< base 10 logarithm of pressure
 
 protected:
-    double m_pressure_buf; //!< buffered pressure
+    double m_pressure_buf = -1.0; //!< buffered pressure
 };
 
 //! Pressure-dependent rate expression where the rate coefficient is expressed
@@ -90,7 +90,7 @@ class ChebyshevRate final : public ReactionRate
 {
 public:
     //! Default constructor.
-    ChebyshevRate() : m_log10P(NAN), m_rate_units(Units(0.)) {}
+    ChebyshevRate() = default;
 
     //! Constructor directly from coefficient array
     /*!
@@ -225,7 +225,7 @@ public:
     void setData(const Array2D& coeffs);
 
 protected:
-    double m_log10P; //!< value detecting updates
+    double m_log10P = NAN; //!< value detecting updates
     double Tmin_, Tmax_; //!< valid temperature range
     double Pmin_, Pmax_; //!< valid pressure range
     double TrNum_, TrDen_; //!< terms appearing in the reduced temperature
@@ -234,7 +234,7 @@ protected:
     Array2D m_coeffs; //!<< coefficient array
     vector_fp dotProd_; //!< dot product of coeffs with the reduced pressure polynomial
 
-    Units m_rate_units; //!< Reaction rate units
+    Units m_rate_units = Units(0.); //!< Reaction rate units
 };
 
 }

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -108,8 +108,7 @@ public:
     ChebyshevRate(const AnyMap& node, const UnitStack& rate_units={});
 
     unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(
-            new MultiRate<ChebyshevRate, ChebyshevData>);
+        return make_unique<MultiRate<ChebyshevRate, ChebyshevData>>();
     }
 
     const std::string type() const { return "Chebyshev"; }

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -36,7 +36,7 @@ class Func1;
 class CustomFunc1Rate final : public ReactionRate
 {
 public:
-    CustomFunc1Rate();
+    CustomFunc1Rate() = default;
     CustomFunc1Rate(const AnyMap& node, const UnitStack& rate_units);
 
     unique_ptr<MultiRateBase> newMultiRate() const override {

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -40,7 +40,7 @@ public:
     CustomFunc1Rate(const AnyMap& node, const UnitStack& rate_units);
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiRate<CustomFunc1Rate, ArrheniusData>);
+        return make_unique<MultiRate<CustomFunc1Rate, ArrheniusData>>();
     }
 
     const std::string type() const override { return "custom-rate-function"; }

--- a/include/cantera/kinetics/EdgeKinetics.h
+++ b/include/cantera/kinetics/EdgeKinetics.h
@@ -23,7 +23,7 @@ class EdgeKinetics : public InterfaceKinetics
 {
 public:
     //! Constructor
-    EdgeKinetics() : InterfaceKinetics() {
+    EdgeKinetics() {
         m_nDim = 1;
     }
 

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -286,8 +286,7 @@ public:
                   const vector_fp& c);
 
     unique_ptr<MultiRateBase> newMultiRate() const override{
-        return unique_ptr<MultiRateBase>(
-            new MultiRate<LindemannRate, FalloffData>);
+        return make_unique<MultiRate<LindemannRate, FalloffData>>();
     }
 
     virtual const std::string subType() const override {
@@ -337,7 +336,7 @@ public:
              const vector_fp& c);
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiRate<TroeRate, FalloffData>);
+        return make_unique<MultiRate<TroeRate, FalloffData>>();
     }
 
     //! Set coefficients used by parameterization
@@ -436,7 +435,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiRate<SriRate, FalloffData>);
+        return make_unique<MultiRate<SriRate, FalloffData>>();
     }
 
     //! Set coefficients used by parameterization
@@ -543,7 +542,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(new MultiRate<TsangRate, FalloffData>);
+        return make_unique<MultiRate<TsangRate, FalloffData>>();
     }
 
     //! Set coefficients used by parameterization

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -59,13 +59,15 @@ struct FalloffData : public ReactionData
         molar_density = NAN;
     }
 
-    bool ready; //!< boolean indicating whether vectors are accessible
-    double molar_density; //!< used to determine if updates are needed
+    bool ready = false; //!< boolean indicating whether vectors are accessible
+    double molar_density = NAN; //!< used to determine if updates are needed
     vector_fp conc_3b; //!< vector of effective third-body concentrations
 
 protected:
-    int m_state_mf_number; //!< integer that is incremented when composition changes
-    bool m_perturbed; //!< boolean indicating whether 3-rd body values are perturbed
+    //! integer that is incremented when composition changes
+    int m_state_mf_number = -1;
+    //! boolean indicating whether 3-rd body values are perturbed
+    bool m_perturbed = false;
     vector_fp m_conc_3b_buf; //!< buffered third-body concentrations
 };
 
@@ -78,13 +80,7 @@ protected:
 class FalloffRate : public ReactionRate
 {
 public:
-    FalloffRate()
-        : m_chemicallyActivated(false)
-        , m_negativeA_ok(false)
-        , m_rc_low(NAN)
-        , m_rc_high(NAN)
-    {
-    }
+    FalloffRate() = default;
 
     FalloffRate(const AnyMap& node, const UnitStack& rate_units={});
 
@@ -262,11 +258,13 @@ protected:
     ArrheniusRate m_lowRate; //!< The reaction rate in the low-pressure limit
     ArrheniusRate m_highRate; //!< The reaction rate in the high-pressure limit
 
-    bool m_chemicallyActivated; //!< Flag labeling reaction as chemically activated
-    bool m_negativeA_ok; //!< Flag indicating whether negative A values are permitted
+    //! Flag labeling reaction as chemically activated
+    bool m_chemicallyActivated = false;
+    //! Flag indicating whether negative A values are permitted
+    bool m_negativeA_ok = false;
 
-    double m_rc_low; //!< Evaluated reaction rate in the low-pressure limit
-    double m_rc_high; //!< Evaluated reaction rate in the high-pressure limit
+    double m_rc_low = NAN; //!< Evaluated reaction rate in the low-pressure limit
+    double m_rc_high = NAN; //!< Evaluated reaction rate in the high-pressure limit
     vector_fp m_work; //!< Work vector
 };
 

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -146,9 +146,9 @@ protected:
     //! @name Reaction rate data
     //! @{
 
-    doublereal m_logStandConc;
+    double m_logStandConc = 0.0;
 
-    doublereal m_pres; //!< Last pressure at which rates were evaluated
+    double m_pres = 0.0; //!< Last pressure at which rates were evaluated
 
     //! @}
 

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -75,7 +75,7 @@ public:
                      double maxStepSize=0, size_t maxSteps=20000,
                      size_t maxErrTestFails=7);
 
-    virtual ~ImplicitSurfChem() {};
+    virtual ~ImplicitSurfChem() = default;
 
     /*!
      *  Must be called before calling method 'advance'
@@ -252,10 +252,10 @@ protected:
     /*!
      * This is the total number of unknowns in m_mode 0 problem
      */
-    size_t m_nv;
+    size_t m_nv = 0;
 
-    size_t m_numTotalBulkSpecies;
-    size_t m_numTotalSpecies;
+    size_t m_numTotalBulkSpecies = 0;
+    size_t m_numTotalSpecies = 0;
 
     std::vector<vector_int> pLocVec;
     //! Pointer to the CVODE integrator
@@ -278,17 +278,17 @@ protected:
      * Index into the species vector of the kinetics manager,
      * pointing to the first species from the surrounding medium.
      */
-    int m_mediumSpeciesStart;
+    int m_mediumSpeciesStart = -1;
     /**
      * Index into the species vector of the kinetics manager, pointing to the
      * first species from the condensed phase of the particles.
      */
-    int m_bulkSpeciesStart;
+    int m_bulkSpeciesStart = -1;
     /**
      * Index into the species vector of the kinetics manager, pointing to the
      * first species from the surface of the particles
      */
-    int m_surfSpeciesStart;
+    int m_surfSpeciesStart = -1;
     /**
      * Pointer to the helper method, Placid, which solves the surface problem.
      */
@@ -296,12 +296,12 @@ protected:
 
     //! If true, a common temperature and pressure for all surface and bulk
     //! phases associated with the surface problem is imposed
-    bool m_commonTempPressForPhases;
+    bool m_commonTempPressForPhases = true;
 
 private:
     //! Controls the amount of printing from this routine
     //! and underlying routines.
-    int m_ioFlag;
+    int m_ioFlag = 0;
 };
 }
 

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -57,7 +57,7 @@ class InterfaceKinetics : public Kinetics
 {
 public:
     //! Constructor
-    InterfaceKinetics();
+    InterfaceKinetics() = default;
 
     //! Constructor
     /*!
@@ -316,7 +316,7 @@ protected:
      */
     std::vector<size_t> m_revindex;
 
-    bool m_redo_rates;
+    bool m_redo_rates = false;
 
     //! Vector of rate handlers for interface reactions
     std::vector<unique_ptr<MultiRateBase>> m_interfaceRates;
@@ -396,7 +396,7 @@ protected:
     vector_fp m_phi;
 
     //! Pointer to the single surface phase
-    SurfPhase* m_surf;
+    SurfPhase* m_surf = nullptr;
 
     //! Pointer to the Implicit surface chemistry object
     /*!
@@ -404,12 +404,12 @@ protected:
      * be used to solve this single InterfaceKinetics object's surface problem
      * uncoupled from other surface phases.
      */
-    ImplicitSurfChem* m_integrator;
+    ImplicitSurfChem* m_integrator = nullptr;
 
-    bool m_ROP_ok;
+    bool m_ROP_ok = false;
 
     //! Current temperature of the data
-    doublereal m_temp;
+    double m_temp = 0.0;
 
     //! Int flag to indicate that some phases in the kinetics mechanism are
     //! non-existent.
@@ -418,7 +418,7 @@ protected:
      *  treated correctly in the kinetics operator. The value of this is equal
      *  to the number of phases which don't exist.
      */
-    int m_phaseExistsCheck;
+    int m_phaseExistsCheck = false;
 
     //!  Vector of booleans indicating whether phases exist or not
     /*!
@@ -459,11 +459,11 @@ protected:
      */
     std::vector<std::vector<bool> > m_rxnPhaseIsProduct;
 
-    int m_ioFlag;
+    int m_ioFlag = 0;
 
     //! Number of dimensions of reacting phase (2 for InterfaceKinetics, 1 for
     //! EdgeKinetics)
-    size_t m_nDim;
+    size_t m_nDim = 2;
 };
 
 }

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -237,8 +237,11 @@ protected:
     double m_deltaPotential_RT; //!< Normalized electric potential energy change
     double m_deltaGibbs0_RT; //!< Normalized standard state Gibbs free energy change
     double m_prodStandardConcentrations; //!< Products of standard concentrations
-    std::map<size_t, size_t> m_indices; //!< Map holding indices of coverage species
-    std::vector<std::string> m_cov; //!< Vector holding names of coverage species
+
+    //! Map from coverage dependencies stored in this object to the index of the
+    //! coverage species in the Kinetics object
+    map<size_t, size_t> m_indices;
+    vector<string> m_cov; //!< Vector holding names of coverage species
     vector_fp m_ac; //!< Vector holding coverage-specific exponential dependence
     vector_fp m_ec; //!< Vector holding coverage-specific activation energy dependence
     vector_fp m_mc; //!< Vector holding coverage-specific power-law exponents

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -402,7 +402,9 @@ public:
     //! Update reaction rate parameters
     //! @param shared_data  data shared by all reactions of a given type
     void updateFromStruct(const DataType& shared_data) {
-        _update(shared_data);
+        if constexpr (has_update<RateType>::value) {
+            RateType::updateFromStruct(shared_data);
+        }
         InterfaceRateBase::updateFromStruct(shared_data);
     }
 
@@ -431,22 +433,6 @@ public:
 
     virtual double activationEnergy() const override {
         return RateType::activationEnergy() + m_ecov * GasConstant;
-    }
-
-protected:
-    //! Helper function to process updates for rate types that implement the
-    //! `updateFromStruct` method.
-    template <typename T=RateType,
-        typename std::enable_if<has_update<T>::value, bool>::type = true>
-    void _update(const DataType& shared_data) {
-        T::updateFromStruct(shared_data);
-    }
-
-    //! Helper function for rate types that do not implement `updateFromStruct`.
-    //! Does nothing, but exists to allow generic implementations of update().
-    template <typename T=RateType,
-        typename std::enable_if<!has_update<T>::value, bool>::type = true>
-    void _update(const DataType& shared_data) {
     }
 };
 
@@ -539,7 +525,9 @@ public:
     //! Update reaction rate parameters
     //! @param shared_data  data shared by all reactions of a given type
     void updateFromStruct(const DataType& shared_data) {
-        _update(shared_data);
+        if constexpr (has_update<RateType>::value) {
+            RateType::updateFromStruct(shared_data);
+        }
         InterfaceRateBase::updateFromStruct(shared_data);
         m_factor = pow(m_siteDensity, -m_surfaceOrder);
     }
@@ -574,22 +562,6 @@ public:
 
     virtual double activationEnergy() const override {
         return RateType::activationEnergy() + m_ecov * GasConstant;
-    }
-
-protected:
-    //! Helper function to process updates for rate types that implement the
-    //! `updateFromStruct` method.
-    template <typename T=RateType,
-        typename std::enable_if<has_update<T>::value, bool>::type = true>
-    void _update(const DataType& shared_data) {
-        T::updateFromStruct(shared_data);
-    }
-
-    //! Helper function for rate types that do not implement `updateFromStruct`.
-    //! Does nothing, but exists to allow generic implementations of update().
-    template <typename T=RateType,
-        typename std::enable_if<!has_update<T>::value, bool>::type = true>
-    void _update(const DataType& shared_data) {
     }
 };
 

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -372,8 +372,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(
-            new MultiRate<InterfaceRate<RateType, DataType>, DataType>);
+        return make_unique<MultiRate<InterfaceRate<RateType, DataType>, DataType>>();
     }
 
     //! Identifier of reaction rate type
@@ -461,8 +460,7 @@ public:
     }
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(
-            new MultiRate<StickingRate<RateType, DataType>, DataType>);
+        return make_unique<MultiRate<StickingRate<RateType, DataType>, DataType>>();
     }
 
     //! Identifier of reaction rate type

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -38,7 +38,7 @@ class AnyMap;
  */
 struct InterfaceData : public BlowersMaselData
 {
-    InterfaceData();
+    InterfaceData() = default;
 
     virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
 
@@ -60,7 +60,7 @@ struct InterfaceData : public BlowersMaselData
         ready = true;
     }
 
-    double sqrtT; //!< square root of temperature
+    double sqrtT = NAN; //!< square root of temperature
 
     vector_fp coverages; //!< surface coverages
     vector_fp logCoverages; //!< logarithm of surface coverages

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -117,9 +117,9 @@ public:
     //! @{
 
     //! Default constructor.
-    Kinetics();
+    Kinetics() = default;
 
-    virtual ~Kinetics();
+    virtual ~Kinetics() = default;
 
     //! Kinetics objects are not copyable or assignable
     Kinetics(const Kinetics&) = delete;
@@ -1304,11 +1304,11 @@ protected:
     //! @}
 
     //! Boolean indicating whether Kinetics object is fully configured
-    bool m_ready;
+    bool m_ready = false;
 
     //! The number of species in all of the phases
     //! that participate in this kinetics mechanism.
-    size_t m_kk;
+    size_t m_kk = 0;
 
     //! Vector of perturbation factors for each reaction's rate of
     //! progress vector. It is initialized to one.
@@ -1352,17 +1352,17 @@ protected:
 
     //! Index in the list of phases of the one surface phase.
     //! @deprecated To be removed after Cantera 3.0.
-    size_t m_surfphase;
+    size_t m_surfphase = npos;
 
     //! Phase Index where reactions are assumed to be taking place
     /*!
      * We calculate this by assuming that the phase with the lowest
      * dimensionality is the phase where reactions are taking place.
      */
-    size_t m_rxnphase;
+    size_t m_rxnphase = npos;
 
     //! number of spatial dimensions of lowest-dimensional phase.
-    size_t m_mindim;
+    size_t m_mindim = 4;
 
     //! Forward rate constant for each reaction
     vector_fp m_rfn;
@@ -1389,10 +1389,10 @@ protected:
     vector_fp m_rbuf;
 
     //! See skipUndeclaredSpecies()
-    bool m_skipUndeclaredSpecies;
+    bool m_skipUndeclaredSpecies = false;
 
     //! See skipUndeclaredThirdBodies()
-    bool m_skipUndeclaredThirdBodies;
+    bool m_skipUndeclaredThirdBodies = false;
 
     //! reference to Solution
     std::weak_ptr<Solution> m_root;

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -65,8 +65,8 @@ public:
     }
 
     virtual void getRateConstants(double* kf) override {
-        for (auto& rxn : m_rxn_rates) {
-            kf[rxn.first] = rxn.second.evalFromStruct(m_shared);
+        for (auto& [iRxn, rate] : m_rxn_rates) {
+            kf[iRxn] = rate.evalFromStruct(m_shared);
         }
     }
 
@@ -172,8 +172,8 @@ protected:
     template <typename T=RateType,
         typename std::enable_if<has_ddT<T>::value, bool>::type = true>
     void _process_ddT(double* rop, const double* kf, double deltaT) {
-        for (const auto& rxn : m_rxn_rates) {
-            rop[rxn.first] *= rxn.second.ddTScaledFromStruct(m_shared);
+        for (const auto& [iRxn, rate] : m_rxn_rates) {
+            rop[iRxn] *= rate.ddTScaledFromStruct(m_shared);
         }
     }
 
@@ -188,10 +188,10 @@ protected:
         _update();
 
         // apply numerical derivative
-        for (auto& rxn : m_rxn_rates) {
-            if (kf[rxn.first] != 0.) {
-                double k1 = rxn.second.evalFromStruct(m_shared);
-                rop[rxn.first] *= dTinv * (k1 / kf[rxn.first] - 1.);
+        for (auto& [iRxn, rate] : m_rxn_rates) {
+            if (kf[iRxn] != 0.) {
+                double k1 = rate.evalFromStruct(m_shared);
+                rop[iRxn] *= dTinv * (k1 / kf[iRxn] - 1.);
             } // else not needed: derivative is already zero
         }
 
@@ -209,13 +209,13 @@ protected:
         m_shared.perturbThirdBodies(deltaM);
         _update();
 
-        for (auto& rxn : m_rxn_rates) {
-            if (kf[rxn.first] != 0. && m_shared.conc_3b[rxn.first] > 0.) {
-                double k1 = rxn.second.evalFromStruct(m_shared);
-                rop[rxn.first] *= dMinv * (k1 / kf[rxn.first] - 1.);
-                rop[rxn.first] /= m_shared.conc_3b[rxn.first];
+        for (auto& [iRxn, rate] : m_rxn_rates) {
+            if (kf[iRxn] != 0. && m_shared.conc_3b[iRxn] > 0.) {
+                double k1 = rate.evalFromStruct(m_shared);
+                rop[iRxn] *= dMinv * (k1 / kf[iRxn] - 1.);
+                rop[iRxn] /= m_shared.conc_3b[iRxn];
             } else {
-                rop[rxn.first] = 0.;
+                rop[iRxn] = 0.;
             }
         }
 
@@ -232,8 +232,8 @@ protected:
             // do not overwrite existing entries
             return;
         }
-        for (const auto& rxn : m_rxn_rates) {
-            rop[rxn.first] = 0.;
+        for (const auto& [iRxn, rate] : m_rxn_rates) {
+            rop[iRxn] = 0.;
         }
     }
 
@@ -246,10 +246,10 @@ protected:
         m_shared.perturbPressure(deltaP);
         _update();
 
-        for (auto& rxn : m_rxn_rates) {
-            if (kf[rxn.first] != 0.) {
-                double k1 = rxn.second.evalFromStruct(m_shared);
-                rop[rxn.first] *= dPinv * (k1 / kf[rxn.first] - 1.);
+        for (auto& [iRxn, rate] : m_rxn_rates) {
+            if (kf[iRxn] != 0.) {
+                double k1 = rate.evalFromStruct(m_shared);
+                rop[iRxn] *= dPinv * (k1 / kf[iRxn] - 1.);
             } // else not needed: derivative is already zero
         }
 
@@ -262,8 +262,8 @@ protected:
     template <typename T=RateType, typename D=DataType,
         typename std::enable_if<!has_ddP<D>::value, bool>::type = true>
     void _process_ddP(double* rop, const double* kf, double deltaP) {
-        for (const auto& rxn : m_rxn_rates) {
-            rop[rxn.first] = 0.;
+        for (const auto& [iRxn, rate] : m_rxn_rates) {
+            rop[iRxn] = 0.;
         }
     }
 

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -74,18 +74,54 @@ public:
                                           const double* kf,
                                           double deltaT) override
     {
-        // call helper function: implementation of derivative depends on whether
-        // ReactionRate::ddTFromStruct is defined
-        _process_ddT(rop, kf, deltaT);
+        if constexpr (has_ddT<RateType>::value) {
+            for (const auto& [iRxn, rate] : m_rxn_rates) {
+                rop[iRxn] *= rate.ddTScaledFromStruct(m_shared);
+            }
+        } else {
+            // perturb conditions
+            double dTinv = 1. / (m_shared.temperature * deltaT);
+            m_shared.perturbTemperature(deltaT);
+            _update();
+
+            // apply numerical derivative
+            for (auto& [iRxn, rate] : m_rxn_rates) {
+                if (kf[iRxn] != 0.) {
+                    double k1 = rate.evalFromStruct(m_shared);
+                    rop[iRxn] *= dTinv * (k1 / kf[iRxn] - 1.);
+                } // else not needed: derivative is already zero
+            }
+
+            // revert changes
+            m_shared.restore();
+            _update();
+        }
     }
 
     virtual void processRateConstants_ddP(double* rop,
                                           const double* kf,
                                           double deltaP) override
     {
-        // call helper function: implementation of derivative depends on whether
-        // ReactionData::perturbPressure is defined
-        _process_ddP(rop, kf, deltaP);
+        if constexpr (has_ddP<DataType>::value) {
+            double dPinv = 1. / (m_shared.pressure * deltaP);
+            m_shared.perturbPressure(deltaP);
+            _update();
+
+            for (auto& [iRxn, rate] : m_rxn_rates) {
+                if (kf[iRxn] != 0.) {
+                    double k1 = rate.evalFromStruct(m_shared);
+                    rop[iRxn] *= dPinv * (k1 / kf[iRxn] - 1.);
+                } // else not needed: derivative is already zero
+            }
+
+            // revert changes
+            m_shared.restore();
+            _update();
+        } else {
+            for (const auto& [iRxn, rate] : m_rxn_rates) {
+                rop[iRxn] = 0.;
+            }
+        }
     }
 
     virtual void processRateConstants_ddM(double* rop,
@@ -93,9 +129,33 @@ public:
                                           double deltaM,
                                           bool overwrite=true) override
     {
-        // call helper function: implementation of derivative depends on whether
-        // ReactionRate::thirdBodyConcentration is defined
-        _process_ddM(rop, kf, deltaM, overwrite);
+        if constexpr (has_ddM<DataType>::value) {
+            double dMinv = 1. / deltaM;
+            m_shared.perturbThirdBodies(deltaM);
+            _update();
+
+            for (auto& [iRxn, rate] : m_rxn_rates) {
+                if (kf[iRxn] != 0. && m_shared.conc_3b[iRxn] > 0.) {
+                    double k1 = rate.evalFromStruct(m_shared);
+                    rop[iRxn] *= dMinv * (k1 / kf[iRxn] - 1.);
+                    rop[iRxn] /= m_shared.conc_3b[iRxn];
+                } else {
+                    rop[iRxn] = 0.;
+                }
+            }
+
+            // revert changes
+            m_shared.restore();
+            _update();
+        } else {
+            if (!overwrite) {
+                // do not overwrite existing entries
+                return;
+            }
+            for (const auto& [iRxn, rate] : m_rxn_rates) {
+                rop[iRxn] = 0.;
+            }
+        }
     }
 
     virtual void update(double T) override {
@@ -125,7 +185,9 @@ public:
 
     virtual double evalSingle(ReactionRate& rate) override {
         RateType& R = static_cast<RateType&>(rate);
-        _updateRate(R);
+        if constexpr (has_update<RateType>::value) {
+            R.updateFromStruct(m_shared);
+        }
         return R.evalFromStruct(m_shared);
     }
 
@@ -136,134 +198,12 @@ public:
     }
 
 protected:
-    //! Helper function to process updates for rate types that implement the
-    //! `updateFromStruct` method.
-    template <typename T=RateType,
-        typename std::enable_if<has_update<T>::value, bool>::type = true>
+    //! Helper function to process updates
     void _update() {
-        for (auto& rxn : m_rxn_rates) {
-            rxn.second.updateFromStruct(m_shared);
-        }
-    }
-
-    //! Helper function for rate types that do not implement `updateFromStruct`.
-    //! Does nothing, but exists to allow generic implementations of update().
-    template <typename T=RateType,
-        typename std::enable_if<!has_update<T>::value, bool>::type = true>
-    void _update() {
-    }
-
-    //! Helper function to update a single rate that has an `updateFromStruct` method`.
-    template <typename T=RateType,
-        typename std::enable_if<has_update<T>::value, bool>::type = true>
-    void _updateRate(RateType& rate) {
-        rate.updateFromStruct(m_shared);
-    }
-
-    //! Helper function for single rate that does not implement `updateFromStruct`.
-    //! Exists to allow generic implementations of `evalSingle` and `ddTSingle`.
-    template <typename T=RateType,
-        typename std::enable_if<!has_update<T>::value, bool>::type = true>
-    void _updateRate(RateType& rate) {
-    }
-
-    //! Helper function to process temperature derivatives for rate types that
-    //! implement the `ddTScaledFromStruct` method.
-    template <typename T=RateType,
-        typename std::enable_if<has_ddT<T>::value, bool>::type = true>
-    void _process_ddT(double* rop, const double* kf, double deltaT) {
-        for (const auto& [iRxn, rate] : m_rxn_rates) {
-            rop[iRxn] *= rate.ddTScaledFromStruct(m_shared);
-        }
-    }
-
-    //! Helper function for rate types that do not implement `ddTScaledFromStruct`
-    template <typename T=RateType,
-        typename std::enable_if<!has_ddT<T>::value, bool>::type = true>
-    void _process_ddT(double* rop, const double* kf, double deltaT) {
-
-        // perturb conditions
-        double dTinv = 1. / (m_shared.temperature * deltaT);
-        m_shared.perturbTemperature(deltaT);
-        _update();
-
-        // apply numerical derivative
-        for (auto& [iRxn, rate] : m_rxn_rates) {
-            if (kf[iRxn] != 0.) {
-                double k1 = rate.evalFromStruct(m_shared);
-                rop[iRxn] *= dTinv * (k1 / kf[iRxn] - 1.);
-            } // else not needed: derivative is already zero
-        }
-
-        // revert changes
-        m_shared.restore();
-        _update();
-    }
-
-    //! Helper function to process third-body derivatives for rate data that
-    //! implement the `perturbThirdBodies` method.
-    template <typename T=RateType, typename D=DataType,
-        typename std::enable_if<has_ddM<D>::value, bool>::type = true>
-    void _process_ddM(double* rop, const double* kf, double deltaM, bool overwrite) {
-        double dMinv = 1. / deltaM;
-        m_shared.perturbThirdBodies(deltaM);
-        _update();
-
-        for (auto& [iRxn, rate] : m_rxn_rates) {
-            if (kf[iRxn] != 0. && m_shared.conc_3b[iRxn] > 0.) {
-                double k1 = rate.evalFromStruct(m_shared);
-                rop[iRxn] *= dMinv * (k1 / kf[iRxn] - 1.);
-                rop[iRxn] /= m_shared.conc_3b[iRxn];
-            } else {
-                rop[iRxn] = 0.;
+        if constexpr (has_update<RateType>::value) {
+            for (auto& [i, rxn] : m_rxn_rates) {
+                rxn.updateFromStruct(m_shared);
             }
-        }
-
-        // revert changes
-        m_shared.restore();
-        _update();
-    }
-
-    //! Helper function for rate data that do not implement `perturbThirdBodies`
-    template <typename T=RateType, typename D=DataType,
-        typename std::enable_if<!has_ddM<D>::value, bool>::type = true>
-    void _process_ddM(double* rop, const double* kf, double deltaM, bool overwrite) {
-        if (!overwrite) {
-            // do not overwrite existing entries
-            return;
-        }
-        for (const auto& [iRxn, rate] : m_rxn_rates) {
-            rop[iRxn] = 0.;
-        }
-    }
-
-    //! Helper function to process pressure derivatives for rate data that
-    //! implement the `perturbPressure` method.
-    template <typename T=RateType, typename D=DataType,
-        typename std::enable_if<has_ddP<D>::value, bool>::type = true>
-    void _process_ddP(double* rop, const double* kf, double deltaP) {
-        double dPinv = 1. / (m_shared.pressure * deltaP);
-        m_shared.perturbPressure(deltaP);
-        _update();
-
-        for (auto& [iRxn, rate] : m_rxn_rates) {
-            if (kf[iRxn] != 0.) {
-                double k1 = rate.evalFromStruct(m_shared);
-                rop[iRxn] *= dPinv * (k1 / kf[iRxn] - 1.);
-            } // else not needed: derivative is already zero
-        }
-
-        // revert changes
-        m_shared.restore();
-        _update();
-    }
-
-    //! Helper function for rate data that do not implement `perturbPressure`
-    template <typename T=RateType, typename D=DataType,
-        typename std::enable_if<!has_ddP<D>::value, bool>::type = true>
-    void _process_ddP(double* rop, const double* kf, double deltaP) {
-        for (const auto& [iRxn, rate] : m_rxn_rates) {
-            rop[iRxn] = 0.;
         }
     }
 

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -18,7 +18,7 @@ namespace Cantera
  */
 struct PlogData : public ReactionData
 {
-    PlogData() : pressure(NAN), logP(0.), m_pressure_buf(-1.) {}
+    PlogData() = default;
 
     virtual void update(double T) override;
 
@@ -46,11 +46,11 @@ struct PlogData : public ReactionData
         pressure = NAN;
     }
 
-    double pressure; //!< pressure
-    double logP; //!< logarithm of pressure
+    double pressure = NAN; //!< pressure
+    double logP = 0.0; //!< logarithm of pressure
 
 protected:
-    double m_pressure_buf; //!< buffered pressure
+    double m_pressure_buf = -1.0; //!< buffered pressure
 };
 
 
@@ -76,7 +76,7 @@ class PlogRate final : public ReactionRate
 {
 public:
     //! Default constructor.
-    PlogRate();
+    PlogRate() = default;
 
     //! Constructor from Arrhenius rate expressions at a set of pressures
     explicit PlogRate(const std::multimap<double, ArrheniusRate>& rates);
@@ -186,8 +186,9 @@ protected:
     // Rate expressions which are referenced by the indices stored in pressures_
     std::vector<ArrheniusRate> rates_;
 
-    double logP_; //!< log(p) at the current state
-    double logP1_, logP2_; //!< log(p) at the lower / upper pressure reference
+    double logP_ = -1000; //!< log(p) at the current state
+    double logP1_ = 1000; //!< log(p) at the lower pressure reference
+    double logP2_ = -1000; //!< log(p) at the upper pressure reference
 
     //! Indices to the ranges within rates_ for the lower / upper pressure, such
     //! that rates_[ilow1_] through rates_[ilow2_] (inclusive) are the rates
@@ -195,7 +196,7 @@ protected:
     //! pressure.
     size_t ilow1_, ilow2_, ihigh1_, ihigh2_;
 
-    double rDeltaP_; //!< reciprocal of (logP2 - logP1)
+    double rDeltaP_ = -1.0; //!< reciprocal of (logP2 - logP1)
 };
 
 }

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -84,7 +84,7 @@ public:
     PlogRate(const AnyMap& node, const UnitStack& rate_units={});
 
     unique_ptr<MultiRateBase> newMultiRate() const {
-        return unique_ptr<MultiRateBase>(new MultiRate<PlogRate, PlogData>);
+        return make_unique<MultiRate<PlogRate, PlogData>>();
     }
 
     //! Identifier of reaction rate type

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -24,7 +24,7 @@ class Kinetics;
  */
 struct ReactionData
 {
-    ReactionData() : temperature(1.), logT(0.), recipT(1.), m_temperature_buf(-1.) {}
+    ReactionData() = default;
 
     //! Update data container based on temperature *T*
     /**
@@ -106,12 +106,12 @@ struct ReactionData
         temperature = NAN;
     }
 
-    double temperature; //!< temperature
-    double logT; //!< logarithm of temperature
-    double recipT; //!< inverse of temperature
+    double temperature = 1.0; //!< temperature
+    double logT = 0.0; //!< logarithm of temperature
+    double recipT = 1.0; //!< inverse of temperature
 
 protected:
-    double m_temperature_buf; //!< buffered temperature
+    double m_temperature_buf = -1.0; //!< buffered temperature
 };
 
 }

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -283,7 +283,9 @@ protected:
     std::vector<std::string> m_include;
     std::vector<std::string> m_exclude;
     std::vector<size_t> m_speciesNumber;
-    std::map<size_t, int> m_rxns;
+
+    //! Indices of reactions that are included in the diagram
+    set<size_t> m_rxns;
     size_t m_local;
 };
 

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -278,7 +278,9 @@ public:
 protected:
     doublereal m_flxmax;
     std::map<size_t, std::map<size_t, Path*> > m_paths;
-    std::map<size_t, SpeciesNode*> m_nodes;
+
+    //! map of species index to SpeciesNode
+    map<size_t, SpeciesNode*> m_nodes;
     std::vector<Path*> m_pathlist;
     std::vector<std::string> m_include;
     std::vector<std::string> m_exclude;

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -27,17 +27,16 @@ class SpeciesNode
 {
 public:
     //! Default constructor
-    SpeciesNode() : number(npos), value(0.0),
-        visible(false), m_in(0.0), m_out(0.0) {}
+    SpeciesNode() = default;
 
     //! Destructor
-    virtual ~SpeciesNode() {}
+    virtual ~SpeciesNode() = default;
 
     // public attributes
-    size_t number; //! < Species number
-    std::string name; //! < Label on graph
-    doublereal value; //! < May be used to set node appearance
-    bool visible; //! < Visible on graph;
+    size_t number = npos; //!< Species number
+    string name; //!< Label on graph
+    double value = 0.0; //!< May be used to set node appearance
+    bool visible = false; //!< Visible on graph;
 
     //! @name References
     //!
@@ -73,8 +72,8 @@ public:
     void printPaths();
 
 protected:
-    doublereal m_in;
-    doublereal m_out;
+    double m_in = 0.0;
+    double m_out = 0.0;
     std::vector<Path*> m_paths;
 };
 
@@ -151,7 +150,7 @@ protected:
     std::map<std::string, doublereal> m_label;
     SpeciesNode* m_a, *m_b;
     rxn_path_map m_rxn;
-    doublereal m_total;
+    double m_total = 0.0;
 };
 
 
@@ -161,7 +160,7 @@ protected:
 class ReactionPathDiagram
 {
 public:
-    ReactionPathDiagram();
+    ReactionPathDiagram() = default;
 
     /**
      * Destructor. Deletes all nodes and paths in the diagram.
@@ -260,23 +259,28 @@ public:
     }
     // public attributes
 
-    std::string title;
-    std::string bold_color;
-    std::string normal_color;
-    std::string dashed_color;
-    std::string element;
-    std::string m_font;
-    doublereal threshold, bold_min, dashed_max, label_min;
-    doublereal x_size, y_size;
-    std::string name, dot_options;
-    flow_t flow_type;
-    doublereal scale;
-    doublereal arrow_width;
-    bool show_details;
-    doublereal arrow_hue;
+    string title;
+    string bold_color = "blue";
+    string normal_color = "steelblue";
+    string dashed_color = "gray";
+    string element;
+    string m_font = "Helvetica";
+    double threshold = 0.005;
+    double bold_min = 0.2;
+    double dashed_max = 0.0;
+    double label_min = 0.0;
+    double x_size = -1.0;
+    double y_size = -1.0;
+    string name = "reaction_paths";
+    string dot_options = "center=1;";
+    flow_t flow_type = NetFlow;
+    double scale = -1;
+    double arrow_width = -5.0;
+    bool show_details = false;
+    double arrow_hue = 0.6666;
 
 protected:
-    doublereal m_flxmax;
+    double m_flxmax = 0.0;
     std::map<size_t, std::map<size_t, Path*> > m_paths;
 
     //! map of species index to SpeciesNode
@@ -288,15 +292,15 @@ protected:
 
     //! Indices of reactions that are included in the diagram
     set<size_t> m_rxns;
-    size_t m_local;
+    size_t m_local = npos;
 };
 
 
 class ReactionPathBuilder
 {
 public:
-    ReactionPathBuilder() {}
-    virtual ~ReactionPathBuilder() {}
+    ReactionPathBuilder() = default;
+    virtual ~ReactionPathBuilder() = default;
 
     int init(std::ostream& logfile, Kinetics& s);
 

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -72,7 +72,7 @@ public:
     //!
     //! ```.cpp
     //! unique_ptr<MultiRateBase> newMultiRate() const override {
-    //!     return unique_ptr<MultiRateBase>(new MultiRate<RateType, DataType>);
+    //!     return make_unique<MultiRate<RateType, DataType>>();
     //! ```
     //!
     //! where `RateType` is the derived class name and `DataType` is the corresponding

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -330,15 +330,11 @@ private:
 class C_AnyN
 {
 public:
-    C_AnyN() :
-        m_n(0),
-        m_rxn(npos) {
-    }
+    C_AnyN() = default;
 
     C_AnyN(size_t rxn, const std::vector<size_t>& ic, const vector_fp& order_, const vector_fp& stoich_) :
-        m_n(0),
+        m_n(ic.size()),
         m_rxn(rxn) {
-        m_n = ic.size();
         m_ic.resize(m_n);
         m_jc.resize(m_n, 0);
         m_order.resize(m_n);
@@ -443,7 +439,7 @@ private:
      *  and stoichiometric coefficient vectors for the reactant or product
      *  description of the reaction.
      */
-    size_t m_n;
+    size_t m_n = 0;
 
     //! ID of the reaction corresponding to this stoichiometric manager
     /*!
@@ -451,7 +447,7 @@ private:
      *  and write to Normally this is associated with the reaction number in an
      *  array of quantities indexed by the reaction number, for example, ROP[irxn].
      */
-    size_t m_rxn;
+    size_t m_rxn = npos;
 
     //! Vector of species which are involved with this stoichiometric manager
     //! calculations

--- a/include/cantera/kinetics/ThirdBodyCalc.h
+++ b/include/cantera/kinetics/ThirdBodyCalc.h
@@ -32,13 +32,13 @@ public:
 
         m_species.emplace_back();
         m_eff.emplace_back();
-        for (const auto& eff : efficiencies) {
-            AssertTrace(eff.first != npos);
-            m_species.back().push_back(eff.first);
-            m_eff.back().push_back(eff.second - default_efficiency);
+        for (const auto& [k, efficiency] : efficiencies) {
+            AssertTrace(k != npos);
+            m_species.back().push_back(k);
+            m_eff.back().push_back(efficiency - default_efficiency);
             m_efficiencyList.emplace_back(
                 static_cast<int>(rxnNumber),
-                static_cast<int>(eff.first), eff.second - default_efficiency);
+                static_cast<int>(k), efficiency - default_efficiency);
         }
     }
 

--- a/include/cantera/kinetics/TwoTempPlasmaRate.h
+++ b/include/cantera/kinetics/TwoTempPlasmaRate.h
@@ -78,8 +78,7 @@ public:
     TwoTempPlasmaRate(const AnyMap& node, const UnitStack& rate_units={});
 
     unique_ptr<MultiRateBase> newMultiRate() const override {
-        return unique_ptr<MultiRateBase>(
-            new MultiRate<TwoTempPlasmaRate, TwoTempPlasmaData>);
+        return make_unique<MultiRate<TwoTempPlasmaRate, TwoTempPlasmaData>>();
     }
 
     virtual const std::string type() const override {

--- a/include/cantera/kinetics/TwoTempPlasmaRate.h
+++ b/include/cantera/kinetics/TwoTempPlasmaRate.h
@@ -19,7 +19,7 @@ namespace Cantera
  */
 struct TwoTempPlasmaData : public ReactionData
 {
-    TwoTempPlasmaData() : electronTemp(1.), logTe(0.), recipTe(1.) {}
+    TwoTempPlasmaData() = default;
 
     virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
     virtual void update(double T) override;
@@ -33,9 +33,9 @@ struct TwoTempPlasmaData : public ReactionData
         electronTemp = NAN;
     }
 
-    double electronTemp; //!< electron temperature
-    double logTe; //!< logarithm of electron temperature
-    double recipTe; //!< inverse of electron temperature
+    double electronTemp = 1.0; //!< electron temperature
+    double logTe = 0.0; //!< logarithm of electron temperature
+    double recipTe = 1.0; //!< inverse of electron temperature
 };
 
 

--- a/include/cantera/kinetics/solveSP.h
+++ b/include/cantera/kinetics/solveSP.h
@@ -148,15 +148,11 @@ public:
      */
     solveSP(ImplicitSurfChem* surfChemPtr, int bulkFunc = BULK_ETCH);
 
-    //! Destructor. Deletes the integrator.
-    ~solveSP() {}
+    //! Destructor
+    ~solveSP() = default;
 
-private:
-    //! Unimplemented private copy constructor
-    solveSP(const solveSP& right);
-
-    //! Unimplemented private assignment operator
-    solveSP& operator=(const solveSP& right);
+    solveSP(const solveSP&) = delete;
+    solveSP& operator=(const solveSP&) = delete;
 
 public:
     //! Main routine that actually calculates the pseudo steady state
@@ -303,13 +299,6 @@ private:
                      const doublereal* CSolnSPOld, const bool do_time,
                      const doublereal deltaT);
 
-    //! Pointer to the manager of the implicit surface chemistry problem
-    /*!
-     *  This object actually calls the current object. Thus, we are providing a
-     *  loop-back functionality here.
-     */
-    ImplicitSurfChem* m_SurfChemPtr;
-
     //! Vector of interface kinetics objects
     /*!
      * Each of these is associated with one and only one surface phase.
@@ -320,7 +309,7 @@ private:
     /*!
      * Note, this can be zero, and frequently is
      */
-    size_t m_neq;
+    size_t m_neq = 0;
 
     //! This variable determines how the bulk phases are to be handled
     /*!
@@ -333,7 +322,7 @@ private:
      * This number is equal to the number of InterfaceKinetics objects
      * in the problem. (until further noted)
      */
-    size_t m_numSurfPhases;
+    size_t m_numSurfPhases = 0;
 
     //! Total number of surface species in all surface phases.
     /*!
@@ -341,7 +330,7 @@ private:
      * It's equal to the sum of the number of species in each of the
      * m_numSurfPhases.
      */
-    size_t m_numTotSurfSpecies;
+    size_t m_numTotSurfSpecies = 0;
 
     //! Mapping between the surface phases and the InterfaceKinetics objects
     /*!
@@ -397,7 +386,7 @@ private:
      *
      * This is equal to 0, for the time being
      */
-    size_t m_numBulkPhasesSS;
+    size_t m_numBulkPhasesSS = 0;
 
     //! Vector of number of species in the m_numBulkPhases phases.
     /*!
@@ -410,7 +399,7 @@ private:
      *  This is also the number of bulk equations to solve when bulk equation
      *  solving is turned on.
      */
-    size_t m_numTotBulkSpeciesSS;
+    size_t m_numTotBulkSpeciesSS = 0;
 
     //! Vector of bulk phase pointers, length is equal to m_numBulkPhases.
     std::vector<ThermoPhase*> m_bulkPhasePtrs;
@@ -441,18 +430,9 @@ private:
      */
     std::vector<size_t> m_spSurfLarge;
 
-    //! The absolute tolerance in real units. units are (kmol/m2)
-    doublereal m_atol;
-
-    //! The relative error tolerance.
-    doublereal m_rtol;
-
-    //! maximum value of the time step. units = seconds
-    doublereal m_maxstep;
-
     //! Maximum number of species in any single kinetics operator
     //! -> also maxed wrt the total # of solution species
-    size_t m_maxTotSpecies;
+    size_t m_maxTotSpecies = 0;
 
     //! Temporary vector with length equal to max m_maxTotSpecies
     vector_fp m_netProductionRatesSave;
@@ -504,7 +484,7 @@ private:
     DenseMatrix m_Jac;
 
 public:
-    int m_ioflag;
+    int m_ioflag = 0;
 };
 }
 #endif

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -268,16 +268,16 @@ protected:
     vector_fp ludata;
 
     //! Number of rows and columns of the matrix
-    size_t m_n;
+    size_t m_n = 0;
 
     //! Number of subdiagonals of the matrix
-    size_t m_kl;
+    size_t m_kl = 0;
 
     //! Number of super diagonals of the matrix
-    size_t m_ku;
+    size_t m_ku = 0;
 
     //! value of zero
-    doublereal m_zero;
+    double m_zero = 0;
 
     struct PivData; // pImpl wrapper class
 
@@ -294,7 +294,7 @@ protected:
     //! Extra dp work array needed - size = 3n
     vector_fp work_;
 
-    int m_info;
+    int m_info = 0;
 };
 
 //! Utility routine to print out the matrix

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -90,33 +90,37 @@ protected:
 private:
     void sensInit(double t0, FuncEval& func);
 
-    size_t m_neq;
-    void* m_cvode_mem;
+    size_t m_neq = 0;
+    void* m_cvode_mem = nullptr;
     SundialsContext m_sundials_ctx; //!< SUNContext object for Sundials>=6.0
-    void* m_linsol; //!< Sundials linear solver object
-    void* m_linsol_matrix; //!< matrix used by Sundials
-    FuncEval* m_func;
-    double m_t0;
+    void* m_linsol = nullptr; //!< Sundials linear solver object
+    void* m_linsol_matrix = nullptr; //!< matrix used by Sundials
+    FuncEval* m_func = nullptr;
+    double m_t0 = 0.0;
     double m_time; //!< The current integrator time
-    N_Vector m_y, m_abstol;
-    N_Vector m_dky;
-    std::string m_type;
+    N_Vector m_y = nullptr;
+    N_Vector m_abstol = nullptr;
+    N_Vector m_dky = nullptr;
+    string m_type = "DENSE";
     int m_itol;
     int m_method;
-    int m_maxord;
-    double m_reltol;
-    double m_abstols;
-    double m_reltolsens, m_abstolsens;
-    size_t m_nabs;
-    double m_hmax, m_hmin;
-    int m_maxsteps;
-    int m_maxErrTestFails;
-    N_Vector* m_yS;
-    size_t m_np;
-    int m_mupper, m_mlower;
+    int m_maxord = 0;
+    double m_reltol = 1e-9;
+    double m_abstols = 1e-15;
+    double m_reltolsens = 1e-5;
+    double m_abstolsens = 1e-4;
+    size_t m_nabs = 0;
+    double m_hmax = 0.0;
+    double m_hmin = 0.0;
+    int m_maxsteps = 20000;
+    int m_maxErrTestFails = 0;
+    N_Vector* m_yS = nullptr;
+    size_t m_np = 0;
+    int m_mupper = 0;
+    int m_mlower = 0;
     //! Indicates whether the sensitivities stored in m_yS have been updated
     //! for at the current integrator time.
-    bool m_sens_ok;
+    bool m_sens_ok = false;
 };
 
 } // namespace

--- a/include/cantera/numerics/DAE_Solver.h
+++ b/include/cantera/numerics/DAE_Solver.h
@@ -18,8 +18,8 @@ namespace Cantera
 class Jacobian
 {
 public:
-    Jacobian() {}
-    virtual ~Jacobian() {}
+    Jacobian() = default;
+    virtual ~Jacobian() = default;
     virtual bool supplied() {
         return false;
     }
@@ -77,11 +77,11 @@ class DAE_Solver
 public:
     DAE_Solver(ResidJacEval& f) :
         m_resid(f),
-        m_neq(f.nEquations()),
-        m_time(0.0) {
+        m_neq(f.nEquations())
+    {
     }
 
-    virtual ~DAE_Solver() {}
+    virtual ~DAE_Solver() = default;
 
     /**
      * Set error tolerances. This version specifies a scalar
@@ -247,7 +247,7 @@ protected:
 
     //! Number of total equations in the system
     integer m_neq;
-    doublereal m_time;
+    double m_time = 0.0;
 
 private:
     void warn(const std::string& msg) const {

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -51,7 +51,7 @@ class DenseMatrix : public Array2D
 {
 public:
     //! Default Constructor
-    DenseMatrix();
+    DenseMatrix() = default;
 
     //! Constructor.
     /*!
@@ -137,7 +137,7 @@ public:
      * an error code, that is up to the calling routine to handle correctly.
      * Negative return codes always throw an exception.
      */
-    int m_useReturnErrorCode;
+    int m_useReturnErrorCode = 0;
 
     //! Print Level
     /*!
@@ -146,7 +146,7 @@ public:
      * Level of printing that is carried out. Only error conditions are printed
      * out, if this value is nonzero.
      */
-    int m_printLevel;
+    int m_printLevel = 0;
 
     // Listing of friend functions which are defined below
 

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -43,9 +43,9 @@ class TimesConstant1;
 class Func1
 {
 public:
-    Func1();
+    Func1() = default;
 
-    virtual ~Func1() {}
+    virtual ~Func1() = default;
 
     Func1(const Func1& right);
 
@@ -110,10 +110,10 @@ public:
     void setParent(Func1* p);
 
 protected:
-    doublereal m_c;
-    Func1* m_f1;
-    Func1* m_f2;
-    Func1* m_parent;
+    double m_c = 0.0;
+    Func1* m_f1 = nullptr;
+    Func1* m_f2 = nullptr;
+    Func1* m_parent = nullptr;
 };
 
 
@@ -133,8 +133,7 @@ Func1& newPlusConstFunction(Func1& f1, doublereal c);
 class Sin1 : public Func1
 {
 public:
-    Sin1(doublereal omega = 1.0) :
-        Func1() {
+    Sin1(double omega=1.0) {
         m_c = omega;
     }
 
@@ -176,8 +175,7 @@ public:
 class Cos1 : public Func1
 {
 public:
-    Cos1(doublereal omega = 1.0) :
-        Func1() {
+    Cos1(double omega=1.0) {
         m_c = omega;
     }
 
@@ -212,8 +210,7 @@ public:
 class Exp1 : public Func1
 {
 public:
-    Exp1(doublereal A = 1.0) :
-        Func1() {
+    Exp1(double A=1.0) {
         m_c = A;
     }
 
@@ -246,8 +243,7 @@ public:
 class Pow1 : public Func1
 {
 public:
-    Pow1(doublereal n) :
-        Func1() {
+    Pow1(double n) {
         m_c = n;
     }
 
@@ -287,7 +283,7 @@ public:
      * @param method Interpolation method ('linear' or 'previous')
      */
     Tabulated1(size_t n, const double* tvals, const double* fvals,
-               const std::string& method = "linear");
+               const string& method="linear");
 
     virtual std::string write(const std::string& arg) const;
     virtual int ID() const {
@@ -320,8 +316,7 @@ public:
     /*!
      * @param A   Constant
      */
-    Const1(double A) :
-        Func1() {
+    Const1(double A) {
         m_c = A;
     }
 
@@ -361,8 +356,7 @@ public:
 class Sum1 : public Func1
 {
 public:
-    Sum1(Func1& f1, Func1& f2) :
-        Func1() {
+    Sum1(Func1& f1, Func1& f2) {
         m_f1 = &f1;
         m_f2 = &f2;
         m_f1->setParent(this);
@@ -485,8 +479,7 @@ public:
 class Product1 : public Func1
 {
 public:
-    Product1(Func1& f1, Func1& f2) :
-        Func1() {
+    Product1(Func1& f1, Func1& f2) {
         m_f1 = &f1;
         m_f2 = &f2;
         m_f1->setParent(this);
@@ -548,8 +541,7 @@ public:
 class TimesConstant1 : public Func1
 {
 public:
-    TimesConstant1(Func1& f1, doublereal A) :
-        Func1() {
+    TimesConstant1(Func1& f1, double A) {
         m_f1 = &f1;
         m_c = A;
         m_f1->setParent(this);
@@ -623,8 +615,7 @@ public:
 class PlusConstant1 : public Func1
 {
 public:
-    PlusConstant1(Func1& f1, doublereal A) :
-        Func1() {
+    PlusConstant1(Func1& f1, double A) {
         m_f1 = &f1;
         m_c = A;
         m_f1->setParent(this);
@@ -680,8 +671,7 @@ public:
 class Ratio1 : public Func1
 {
 public:
-    Ratio1(Func1& f1, Func1& f2) :
-        Func1() {
+    Ratio1(Func1& f1, Func1& f2) {
         m_f1 = &f1;
         m_f2 = &f2;
         m_f1->setParent(this);
@@ -746,8 +736,7 @@ public:
 class Composite1 : public Func1
 {
 public:
-    Composite1(Func1& f1, Func1& f2) :
-        Func1() {
+    Composite1(Func1& f1, Func1& f2) {
         m_f1 = &f1;
         m_f2 = &f2;
         m_f1->setParent(this);
@@ -823,8 +812,7 @@ public:
 class Gaussian : public Func1
 {
 public:
-    Gaussian(double A, double t0, double fwhm) :
-        Func1() {
+    Gaussian(double A, double t0, double fwhm) {
         m_A = A;
         m_t0 = t0;
         m_tau = fwhm/(2.0*std::sqrt(std::log(2.0)));
@@ -868,8 +856,7 @@ protected:
 class Poly1 : public Func1
 {
 public:
-    Poly1(size_t n, const double* c) :
-        Func1() {
+    Poly1(size_t n, const double* c) {
         m_cpoly.resize(n+1);
         std::copy(c, c+m_cpoly.size(), m_cpoly.begin());
     }
@@ -919,9 +906,7 @@ protected:
 class Fourier1 : public Func1
 {
 public:
-    Fourier1(size_t n, double omega, double a0,
-             const double* a, const double* b) :
-        Func1() {
+    Fourier1(size_t n, double omega, double a0, const double* a, const double* b) {
         m_omega = omega;
         m_a0_2 = 0.5*a0;
         m_ccos.resize(n);
@@ -979,8 +964,7 @@ protected:
 class Arrhenius1 : public Func1
 {
 public:
-    Arrhenius1(size_t n, const double* c) :
-        Func1() {
+    Arrhenius1(size_t n, const double* c) {
         m_A.resize(n);
         m_b.resize(n);
         m_E.resize(n);
@@ -1032,14 +1016,12 @@ protected:
 class Periodic1 : public Func1
 {
 public:
-    Periodic1(Func1& f, doublereal T) :
-        Func1() {
+    Periodic1(Func1& f, double T) {
         m_func = &f;
         m_c = T;
     }
 
-    Periodic1(const Periodic1& b) :
-        Func1() {
+    Periodic1(const Periodic1& b) {
         *this = Periodic1::operator=(b);
     }
 

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -27,8 +27,8 @@ namespace Cantera
 class FuncEval
 {
 public:
-    FuncEval();
-    virtual ~FuncEval() {}
+    FuncEval() = default;
+    virtual ~FuncEval() = default;
 
     /**
      * Evaluate the right-hand-side function. Called by the integrator.
@@ -138,7 +138,7 @@ public:
 
 protected:
     // If true, errors are accumulated in m_errors. Otherwise, they are printed
-    bool m_suppress_errors;
+    bool m_suppress_errors = false;
 
     //! Errors occurring during function evaluations
     std::vector<std::string> m_errors;

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -22,9 +22,9 @@ class GeneralMatrix
 {
 public:
     //! Base Constructor
-    GeneralMatrix() : m_factored(false) {}
+    GeneralMatrix() = default;
 
-    virtual ~GeneralMatrix() {}
+    virtual ~GeneralMatrix() = default;
 
     //! Zero the matrix elements
     virtual void zero() = 0;
@@ -184,7 +184,7 @@ public:
 protected:
     //! Indicates whether the matrix is factored. 0 for unfactored; Non-zero
     //! values indicate a particular factorization (LU=1, QR=2).
-    int m_factored;
+    int m_factored = false;
 };
 
 }

--- a/include/cantera/numerics/IDA_Solver.h
+++ b/include/cantera/numerics/IDA_Solver.h
@@ -223,44 +223,44 @@ public:
 
 protected:
     //! Pointer to the IDA memory for the problem
-    void* m_ida_mem;
-    void* m_linsol; //!< Sundials linear solver object
-    void* m_linsol_matrix; //!< matrix used by Sundials
+    void* m_ida_mem = nullptr;
+    void* m_linsol = nullptr; //!< Sundials linear solver object
+    void* m_linsol_matrix = nullptr; //!< matrix used by Sundials
     SundialsContext m_sundials_ctx; //!< SUNContext object for Sundials>=6.0
 
     //! Initial value of the time
-    doublereal m_t0;
+    double m_t0 = 0.0;
 
     //! Current value of the solution vector
-    N_Vector m_y;
+    N_Vector m_y = nullptr;
 
     //! Current value of the derivative of the solution vector
-    N_Vector m_ydot;
-    N_Vector m_id;
-    N_Vector m_constraints;
-    N_Vector m_abstol;
-    int m_type;
+    N_Vector m_ydot = nullptr;
+    N_Vector m_id = nullptr;
+    N_Vector m_constraints = nullptr;
+    N_Vector m_abstol = nullptr;
+    int m_type = 0;
 
-    int m_itol;
-    int m_iter;
-    doublereal m_reltol;
-    doublereal m_abstols;
-    int m_nabs;
+    int m_itol = IDA_SS;
+    int m_iter = 0;
+    double m_reltol = 1e-9;
+    double m_abstols = 1e-15;
+    int m_nabs = 0;
 
     //! Maximum value of the timestep allowed
-    doublereal m_hmax;
+    double m_hmax = 0.0;
 
     //! Minimum value of the timestep allowed
-    doublereal m_hmin;
+    double m_hmin = 0.0;
 
     //! Value of the initial time step
-    doublereal m_h0;
+    double m_h0 = 0.0;
 
     //! Maximum number of time steps allowed
-    int m_maxsteps;
+    int m_maxsteps = 20000;
 
     //!  maximum time step order of the method
-    int m_maxord;
+    int m_maxord = 0;
 
     //! Form of the Jacobian
     /*!
@@ -269,41 +269,41 @@ protected:
      *    function in the ResidJacEval class.
      *  2 numerical Jacobian formed by the ResidJacEval class (unimplemented)
      */
-    int m_formJac;
+    int m_formJac = 0;
 
     //! maximum time
-    doublereal m_tstop;
+    double m_tstop = 0.0;
 
     //! Value of the previous, previous time
-    doublereal m_told_old;
+    double m_told_old = 0.0;
 
     //! Value of the previous time
-    doublereal m_told;
+    double m_told = 0;
 
     //! Value of the current time
-    doublereal m_tcurrent;
+    double m_tcurrent = 0;
 
     //! Value of deltaT for the current step
-    doublereal m_deltat;
+    double m_deltat = 0.0;
 
     //! maximum number of error test failures
-    int m_maxErrTestFails;
+    int m_maxErrTestFails = -1;
 
     //! Maximum number of nonlinear solver iterations at one solution
     /*!
      *  If zero, this is the default of 4.
      */
-    int m_maxNonlinIters;
+    int m_maxNonlinIters = 0;
 
     //! Maximum number of nonlinear convergence failures
-    int m_maxNonlinConvFails;
+    int m_maxNonlinConvFails = -1;
 
     //! If true, the algebraic variables don't contribute to error tolerances
-    int m_setSuppressAlg;
+    int m_setSuppressAlg = 0;
 
     std::unique_ptr<ResidData> m_fdata;
-    int m_mupper;
-    int m_mlower;
+    int m_mupper = 0;
+    int m_mlower = 0;
 };
 
 }

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -85,15 +85,24 @@ public:
 protected:
     void _init(size_t n);
 
-    StFlow* m_flow_left, *m_flow_right;
-    size_t m_ilr, m_left_nv, m_right_nv;
-    size_t m_left_loc, m_right_loc;
-    size_t m_left_points;
-    size_t m_left_nsp, m_right_nsp;
-    size_t m_sp_left, m_sp_right;
-    size_t m_start_left, m_start_right;
-    ThermoPhase* m_phase_left, *m_phase_right;
-    double m_temp, m_mdot;
+    StFlow* m_flow_left = nullptr;
+    StFlow* m_flow_right = nullptr;
+    size_t m_ilr = 0;
+    size_t m_left_nv = 0;
+    size_t m_right_nv = 0;
+    size_t m_left_loc = 0;
+    size_t m_right_loc = 0;
+    size_t m_left_points = 0;
+    size_t m_left_nsp = 0;
+    size_t m_right_nsp = 0;
+    size_t m_sp_left = 0;
+    size_t m_sp_right = 0;
+    size_t m_start_left = 0;
+    size_t m_start_right = 0;
+    ThermoPhase* m_phase_left = nullptr;
+    ThermoPhase* m_phase_right = nullptr;
+    double m_temp = 0.0;
+    double m_mdot = 0.0;
 };
 
 
@@ -135,11 +144,11 @@ public:
 
 protected:
     int m_ilr;
-    double m_V0;
-    size_t m_nsp;
+    double m_V0 = 0.0;
+    size_t m_nsp = 0;
     vector_fp m_yin;
     std::string m_xstr;
-    StFlow* m_flow;
+    StFlow* m_flow = nullptr;
 };
 
 /**
@@ -149,7 +158,7 @@ protected:
 class Empty1D : public Boundary1D
 {
 public:
-    Empty1D() : Boundary1D() {
+    Empty1D() {
         m_type = cEmptyType;
     }
 
@@ -177,7 +186,7 @@ public:
 class Symm1D : public Boundary1D
 {
 public:
-    Symm1D() : Boundary1D() {
+    Symm1D() {
         m_type = cSymmType;
     }
 
@@ -203,7 +212,7 @@ public:
 class Outlet1D : public Boundary1D
 {
 public:
-    Outlet1D() : Boundary1D() {
+    Outlet1D() {
         m_type = cOutletType;
     }
 
@@ -251,10 +260,10 @@ public:
     virtual void restore(SolutionArray& arr, double* soln, int loglevel);
 
 protected:
-    size_t m_nsp;
+    size_t m_nsp = 0;
     vector_fp m_yres;
     std::string m_xstr;
-    StFlow* m_flow;
+    StFlow* m_flow = nullptr;
 };
 
 /**
@@ -266,7 +275,7 @@ protected:
 class Surf1D : public Boundary1D
 {
 public:
-    Surf1D() : Boundary1D() {
+    Surf1D() {
         m_type = cSurfType;
     }
 
@@ -333,10 +342,11 @@ public:
     virtual void showSolution(const double* x);
 
 protected:
-    InterfaceKinetics* m_kin;
-    SurfPhase* m_sphase;
-    size_t m_surfindex, m_nsp;
-    bool m_enabled;
+    InterfaceKinetics* m_kin = nullptr;
+    SurfPhase* m_sphase = nullptr;
+    size_t m_surfindex = 0;
+    size_t m_nsp = 0;
+    bool m_enabled = false;
     vector_fp m_work;
     vector_fp m_fixed_cov;
 };

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -535,8 +535,8 @@ protected:
     //! Retrieve meta data
     virtual void setMeta(const AnyMap& meta, int loglevel);
 
-    doublereal m_rdt;
-    size_t m_nv;
+    double m_rdt = 0.0;
+    size_t m_nv = 0;
     size_t m_points;
     vector_fp m_slast;
     vector_fp m_max;
@@ -544,27 +544,28 @@ protected:
     vector_fp m_rtol_ss, m_rtol_ts;
     vector_fp m_atol_ss, m_atol_ts;
     vector_fp m_z;
-    OneDim* m_container;
+    OneDim* m_container = nullptr;
     size_t m_index;
-    int m_type;
+    int m_type = 0;
 
     //! Starting location within the solution vector for unknowns that
     //! correspond to this domain
     /*!
      * Remember there may be multiple domains associated with this problem
      */
-    size_t m_iloc;
+    size_t m_iloc = 0;
 
-    size_t m_jstart;
+    size_t m_jstart = 0;
 
-    Domain1D* m_left, *m_right;
+    Domain1D* m_left = nullptr;
+    Domain1D* m_right = nullptr;
 
     //! Identity tag for the domain
     std::string m_id;
     std::unique_ptr<Refiner> m_refiner;
     std::vector<std::string> m_name;
-    int m_bw;
-    bool m_force_full_update;
+    int m_bw = -1;
+    bool m_force_full_update = false;
 
     //! Composite thermo/kinetics/transport handler
     shared_ptr<Solution> m_solution;

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -88,7 +88,7 @@ protected:
     std::vector<bool> m_do_electric_field;
 
     //! flag for importing transport of electron
-    bool m_import_electron_transport;
+    bool m_import_electron_transport = false;
 
     //! electrical properties
     vector_fp m_speciesCharge;
@@ -107,10 +107,10 @@ protected:
     vector_fp m_mobility;
 
     //! solving stage
-    size_t m_stage;
+    size_t m_stage = 1;
 
     //! index of electron
-    size_t m_kElectron;
+    size_t m_kElectron = npos;
 
     //! electric field
     double E(const double* x, size_t j) const {

--- a/include/cantera/oneD/MultiJac.h
+++ b/include/cantera/oneD/MultiJac.h
@@ -74,12 +74,13 @@ protected:
     OneDim* m_resid;
 
     vector_fp m_r1;
-    doublereal m_rtol, m_atol;
-    doublereal m_elapsed;
+    double m_rtol = 1e-5;
+    double m_atol = sqrt(std::numeric_limits<double>::epsilon());
+    double m_elapsed = 0.0;
     vector_fp m_ssdiag;
     vector_int m_mask;
-    int m_nevals;
-    int m_age;
+    int m_nevals = 0;
+    int m_age = 100000;
     size_t m_size;
     size_t m_points;
 };

--- a/include/cantera/oneD/MultiNewton.h
+++ b/include/cantera/oneD/MultiNewton.h
@@ -76,12 +76,12 @@ protected:
     //! Work arrays of size #m_n used in solve().
     vector_fp m_x, m_stp, m_stp1;
 
-    int m_maxAge;
+    int m_maxAge = 5;
 
     //! number of variables
     size_t m_n;
 
-    doublereal m_elapsed;
+    double m_elapsed = 0.0;
 };
 }
 

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -325,47 +325,48 @@ public:
 protected:
     void evalSSJacobian(doublereal* x, doublereal* xnew);
 
-    doublereal m_tmin; //!< minimum timestep size
-    doublereal m_tmax; //!< maximum timestep size
+    double m_tmin = 1e-16; //!< minimum timestep size
+    double m_tmax = 1e+08; //!< maximum timestep size
 
     //! factor time step is multiplied by  if time stepping fails ( < 1 )
-    doublereal m_tfactor;
+    double m_tfactor = 0.5;
 
     std::unique_ptr<MultiJac> m_jac; //!< Jacobian evaluator
     std::unique_ptr<MultiNewton> m_newt; //!< Newton iterator
-    doublereal m_rdt; //!< reciprocal of time step
-    bool m_jac_ok; //!< if true, Jacobian is current
+    double m_rdt = 0.0; //!< reciprocal of time step
+    bool m_jac_ok = false; //!< if true, Jacobian is current
 
-    size_t m_bw; //!< Jacobian bandwidth
-    size_t m_size; //!< solution vector size
+    size_t m_bw = 0; //!< Jacobian bandwidth
+    size_t m_size = 0; //!< solution vector size
 
     std::vector<Domain1D*> m_dom, m_connect, m_bulk;
 
-    bool m_init;
+    bool m_init = false;
     std::vector<size_t> m_nvars;
     std::vector<size_t> m_loc;
     vector_int m_mask;
-    size_t m_pts;
+    size_t m_pts = 0;
 
     // options
-    int m_ss_jac_age, m_ts_jac_age;
+    int m_ss_jac_age = 20;
+    int m_ts_jac_age = 20;
 
     //! Function called at the start of every call to #eval.
-    Func1* m_interrupt;
+    Func1* m_interrupt = nullptr;
 
     //! User-supplied function called after each successful timestep.
-    Func1* m_time_step_callback;
+    Func1* m_time_step_callback = nullptr;
 
     //! Number of time steps taken in the current call to solve()
-    int m_nsteps;
+    int m_nsteps = 0;
 
     //! Maximum number of timesteps allowed per call to solve()
-    int m_nsteps_max;
+    int m_nsteps_max = 500;
 
 private:
     // statistics
-    int m_nevals;
-    doublereal m_evaltime;
+    int m_nevals = 0;
+    double m_evaltime = 0;
     std::vector<size_t> m_gridpts;
     vector_int m_jacEvals;
     vector_fp m_jacElapsed;

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -414,7 +414,7 @@ protected:
     //             member data
     //---------------------------------------------------------
 
-    doublereal m_press; // pressure
+    double m_press = -1.0; // pressure
 
     // grid parameters
     vector_fp m_dz;
@@ -440,13 +440,13 @@ protected:
 
     size_t m_nsp;
 
-    IdealGasPhase* m_thermo;
-    Kinetics* m_kin;
-    Transport* m_trans;
+    IdealGasPhase* m_thermo = nullptr;
+    Kinetics* m_kin = nullptr;
+    Transport* m_trans = nullptr;
 
     // boundary emissivities for the radiation calculations
-    doublereal m_epsilon_left;
-    doublereal m_epsilon_right;
+    double m_epsilon_left = 0.0;
+    double m_epsilon_right = 0.0;
 
     //! Indices within the ThermoPhase of the radiating species. First index is
     //! for CO2, second is for H2O.
@@ -454,12 +454,12 @@ protected:
 
     // flags
     std::vector<bool> m_do_energy;
-    bool m_do_soret;
+    bool m_do_soret = false;
     std::vector<bool> m_do_species;
-    bool m_do_multicomponent;
+    bool m_do_multicomponent = false;
 
     //! flag for the radiative heat loss
-    bool m_do_radiation;
+    bool m_do_radiation = false;
 
     //! radiative heat loss vector
     vector_fp m_qdotRadiation;
@@ -472,8 +472,8 @@ protected:
     //! Index of species with a large mass fraction at each boundary, for which
     //! the mass fraction may be calculated as 1 minus the sum of the other mass
     //! fractions
-    size_t m_kExcessLeft;
-    size_t m_kExcessRight;
+    size_t m_kExcessLeft = 0;
+    size_t m_kExcessRight = 0;
 
     bool m_dovisc;
 
@@ -483,10 +483,10 @@ protected:
 
 public:
     //! Location of the point where temperature is fixed
-    double m_zfixed;
+    double m_zfixed = Undef;
 
     //! Temperature at the point used to fix the flame location
-    double m_tfixed;
+    double m_tfixed = -1.0;
 
 private:
     vector_fp m_ybar;

--- a/include/cantera/oneD/refine.h
+++ b/include/cantera/oneD/refine.h
@@ -97,9 +97,11 @@ public:
     }
 
 protected:
-    std::map<size_t, int> m_loc;
+    //! Indices of grid points that need new grid points added after them
+    set<size_t> m_loc;
     std::map<size_t, int> m_keep;
-    std::map<std::string, int> m_c;
+    //! Names of components that require the addition of new grid points
+    set<string> m_c;
     std::vector<bool> m_active;
     doublereal m_ratio, m_slope, m_curve, m_prune;
     doublereal m_min_range;

--- a/include/cantera/oneD/refine.h
+++ b/include/cantera/oneD/refine.h
@@ -103,12 +103,16 @@ protected:
     //! Names of components that require the addition of new grid points
     set<string> m_c;
     std::vector<bool> m_active;
-    doublereal m_ratio, m_slope, m_curve, m_prune;
-    doublereal m_min_range;
+    double m_ratio = 10.0;
+    double m_slope = 0.8;
+    double m_curve = 0.8;
+    double m_prune = -0.001;
+    double m_min_range = 0.01;
     Domain1D* m_domain;
-    size_t m_nv, m_npmax;
-    doublereal m_thresh;
-    doublereal m_gridmin; //!< minimum grid spacing [m]
+    size_t m_nv;
+    size_t m_npmax = 1000;
+    double m_thresh = std::sqrt(std::numeric_limits<double>::epsilon());
+    double m_gridmin = 1e-10; //!< minimum grid spacing [m]
 };
 
 }

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -238,7 +238,7 @@ protected:
     void diff(const vector_fp& inputData, vector_fp& derivedData) const;
 
     //! Current tabulated species index
-    size_t m_kk_tab;
+    size_t m_kk_tab = npos;
 
     //! Tabulated contribution to h0[m_kk_tab] at the current composition
     mutable double m_h0_tab;

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -103,17 +103,17 @@ public:
 
 protected:
     //! Base temperature
-    doublereal m_t0;
+    double m_t0 = 0.0;
     //! Dimensionless value of the heat capacity
-    doublereal m_cp0_R;
+    double m_cp0_R = 0.0;
     //! dimensionless value of the enthaply at t0
-    doublereal m_h0_R;
+    double m_h0_R = 0.0;
     //! Dimensionless value of the entropy at t0
-    doublereal m_s0_R;
+    double m_s0_R = 0.0;
     //! log of the t0 value
-    doublereal m_logt0;
+    double m_logt0 = 0.0;
     //! Original value of h0_R, restored by calling resetHf298()
-    double m_h0_R_orig;
+    double m_h0_R_orig = 0.0;
 };
 
 }

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -793,7 +793,7 @@ protected:
      * DHFORM_BETAIJ        = 3
      * DHFORM_PITZER_BETAIJ = 4
      */
-    int m_formDH;
+    int m_formDH = DHFORM_DILUTE_LIMIT;
 
     //! Vector containing the electrolyte species type
     /*!
@@ -812,10 +812,10 @@ protected:
     vector_fp m_Aionic;
 
     //! Default ionic radius for species where it is not specified
-    double m_Aionic_default;
+    double m_Aionic_default = NAN;
 
     //! Current value of the ionic strength on the molality scale
-    mutable double m_IionicMolality;
+    mutable double m_IionicMolality = 0.0;
 
     //! Maximum value of the ionic strength allowed in the calculation of the
     //! activity coefficients.
@@ -826,10 +826,10 @@ public:
     //! instead of the rigorous form obtained from Gibbs-Duhem relation. This
     //! should be used with caution, and is really only included as a validation
     //! exercise.
-    bool m_useHelgesonFixedForm;
+    bool m_useHelgesonFixedForm = false;
 protected:
     //! Stoichiometric ionic strength on the molality scale
-    mutable double m_IionicMolalityStoich;
+    mutable double m_IionicMolalityStoich = 0.0;
 
 public:
     /**
@@ -848,7 +848,7 @@ public:
      * strong function of T, and its variability must be
      * accounted for,
      */
-    int m_form_A_Debye;
+    int m_form_A_Debye = A_DEBYE_CONST;
 
 protected:
     //! Current value of the Debye Constant, A_Debye
@@ -902,13 +902,13 @@ protected:
     /*!
      *  derived from the equation of state for water.
      */
-    PDSS_Water* m_waterSS;
+    PDSS_Water* m_waterSS = nullptr;
 
     //! Storage for the density of water's standard state
     /*!
      * Density depends on temperature and pressure.
      */
-    double m_densWaterSS;
+    double m_densWaterSS = 1000.0;
 
     //! Pointer to the water property calculator
     std::unique_ptr<WaterProps> m_waterProps;

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1387,19 +1387,19 @@ private:
      *       PITZER_TEMP_LINEAR     1
      *       PITZER_TEMP_COMPLEX1   2
      */
-    int m_formPitzerTemp;
+    int m_formPitzerTemp = PITZER_TEMP_CONSTANT;
 
     //! Current value of the ionic strength on the molality scale Associated
     //! Salts, if present in the mechanism, don't contribute to the value of the
     //! ionic strength in this version of the Ionic strength.
-    mutable double m_IionicMolality;
+    mutable double m_IionicMolality = 0.0;
 
     //! Maximum value of the ionic strength allowed in the calculation of the
     //! activity coefficients.
     double m_maxIionicStrength;
 
     //! Reference Temperature for the Pitzer formulations.
-    double m_TempPitzerRef;
+    double m_TempPitzerRef = 298.15;
 
 public:
     /**
@@ -1416,7 +1416,7 @@ public:
      * water is a relatively strong function of T, and its variability must be
      * accounted for,
      */
-    int m_form_A_Debye;
+    int m_form_A_Debye = A_DEBYE_CONST;
 
 private:
     /**
@@ -1454,7 +1454,7 @@ private:
     /*!
      *  derived from the equation of state for water.
      */
-    PDSS* m_waterSS;
+    PDSS* m_waterSS = nullptr;
 
     //! Pointer to the water property calculator
     std::unique_ptr<WaterProps> m_waterProps;
@@ -1772,7 +1772,7 @@ private:
     mutable vector_fp m_molalitiesCropped;
 
     //! Boolean indicating whether the molalities are cropped or are modified
-    mutable bool m_molalitiesAreCropped;
+    mutable bool m_molalitiesAreCropped = false;
 
     //! a counter variable for keeping track of symmetric binary
     //! interactions amongst the solute species.
@@ -1900,41 +1900,41 @@ private:
 
     //! value of the solute mole fraction that centers the cutoff polynomials
     //! for the cutoff =1 process;
-    doublereal IMS_X_o_cutoff_;
+    double IMS_X_o_cutoff_ = 0.2;
 
     //! Parameter in the polyExp cutoff treatment having to do with rate of exp decay
-    doublereal IMS_cCut_;
+    double IMS_cCut_ = 0.05;
 
     //! Parameter in the polyExp cutoff treatment
     /*!
      *  This is the slope of the g function at the zero solvent point
      *  Default value is 0.0
      */
-    doublereal IMS_slopegCut_;
+    double IMS_slopegCut_ = 0.0;
 
     //! @name Parameters in the polyExp cutoff treatment having to do with rate of exp decay
     //! @{
-    doublereal IMS_dfCut_;
-    doublereal IMS_efCut_;
-    doublereal IMS_afCut_;
-    doublereal IMS_bfCut_;
-    doublereal IMS_dgCut_;
-    doublereal IMS_egCut_;
-    doublereal IMS_agCut_;
-    doublereal IMS_bgCut_;
+    double IMS_dfCut_ = 0.0;
+    double IMS_efCut_ = 0.0;
+    double IMS_afCut_ = 0.0;
+    double IMS_bfCut_ = 0.0;
+    double IMS_dgCut_ = 0.0;
+    double IMS_egCut_ = 0.0;
+    double IMS_agCut_ = 0.0;
+    double IMS_bgCut_ = 0.0;
     //! @}
 
     //! value of the solvent mole fraction that centers the cutoff polynomials
     //! for the cutoff =1 process;
-    doublereal MC_X_o_cutoff_;
+    double MC_X_o_cutoff_ = 0.0;
 
     //! @name Parameters in the Molality Exp cutoff treatment
     //! @{
-    doublereal MC_dpCut_;
-    doublereal MC_epCut_;
-    doublereal MC_apCut_;
-    doublereal MC_bpCut_;
-    doublereal MC_cpCut_;
+    double MC_dpCut_ = 0.0;
+    double MC_epCut_ = 0.0;
+    double MC_apCut_ = 0.0;
+    double MC_bpCut_ = 0.0;
+    double MC_cpCut_ = 0.0;
     doublereal CROP_ln_gamma_o_min;
     doublereal CROP_ln_gamma_o_max;
     doublereal CROP_ln_gamma_k_min;
@@ -2060,7 +2060,7 @@ private:
      * @param is Ionic strength
      */
     void calc_lambdas(double is) const;
-    mutable doublereal m_last_is;
+    mutable double m_last_is = -1.0;
 
     /**
      * Calculate etheta and etheta_prime

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -559,7 +559,7 @@ protected:
      *  Value of the reference state pressure in Pascals.
      *  All species must have the same reference state pressure.
      */
-    doublereal m_p0;
+    double m_p0 = -1.0;
 
     //! Temporary storage for dimensionless reference state enthalpies
     mutable vector_fp m_h0_RT;

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -417,10 +417,10 @@ protected:
      * 0 = 'unity', 1 = 'species-molar-volume', 2 = 'solvent-molar-volume'. See
      * setStandardConcentrationModel().
      */
-    int m_formGC;
+    int m_formGC = 2;
 
     //! Cutoff type
-    int IMS_typeCutoff_;
+    int IMS_typeCutoff_ = 0;
 
 private:
     //! vector of size m_kk, used as a temporary holding area.
@@ -452,15 +452,15 @@ public:
 
     //! @name Parameters in the polyExp cutoff having to do with rate of exp decay
     //! @{
-    doublereal IMS_cCut_;
-    doublereal IMS_dfCut_;
-    doublereal IMS_efCut_;
-    doublereal IMS_afCut_;
-    doublereal IMS_bfCut_;
-    doublereal IMS_dgCut_;
-    doublereal IMS_egCut_;
-    doublereal IMS_agCut_;
-    doublereal IMS_bgCut_;
+    double IMS_cCut_;
+    double IMS_dfCut_ = 0.0;
+    double IMS_efCut_ = 0.0;
+    double IMS_afCut_ = 0.0;
+    double IMS_bfCut_ = 0.0;
+    double IMS_dgCut_ = 0.0;
+    double IMS_egCut_ = 0.0;
+    double IMS_agCut_ = 0.0;
+    double IMS_bgCut_ = 0.0;
     //! @}
 
 private:

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -575,7 +575,7 @@ protected:
      * 0 = 'unity', 1 = 'species-molar-volume', 2 = 'solvent-molar-volume'. See
      * setStandardConcentrationModel().
      */
-    int m_formGC;
+    int m_formGC = 0;
 
     /**
      * Value of the reference pressure for all species in this phase. The T
@@ -583,7 +583,7 @@ protected:
      * because this is a single value, all species are required to have the same
      * reference pressure.
      */
-    doublereal m_Pref;
+    double m_Pref = OneAtm;
 
     /**
      * m_Pcurrent = The current pressure
@@ -592,7 +592,7 @@ protected:
      * The density variable which is inherited as part of the State class,
      * m_dens, is always kept current whenever T, P, or X[] change.
      */
-    doublereal m_Pcurrent;
+    double m_Pcurrent = OneAtm;
 
     //! Vector of molar volumes for each species in the solution
     /**

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -144,7 +144,7 @@ protected:
      *    - 1 1/V_k
      *    - 2 1/V_0
      */
-    int m_formGC;
+    int m_formGC = 0;
 
     //! Temporary storage - length = m_kk.
     vector_fp m_pp;

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -319,17 +319,17 @@ protected:
      *
      *  Defaults to cIonSolnType_SINGLEANION, so that LiKCl can be hardwired
      */
-    IonSolnType_enumType ionSolnType_;
+    IonSolnType_enumType ionSolnType_ = cIonSolnType_SINGLEANION;
 
     //! Number of neutral molecule species
     /*!
      * This is equal to the number of species in the neutralMoleculePhase_
      * ThermoPhase.
      */
-    size_t numNeutralMoleculeSpecies_;
+    size_t numNeutralMoleculeSpecies_ = 0;
 
     //! Index of special species
-    size_t indexSpecialSpecies_;
+    size_t indexSpecialSpecies_ = npos;
 
     //! Formula Matrix for composition of neutral molecules
     //! in terms of the molecules in this ThermoPhase

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -563,7 +563,7 @@ protected:
     virtual void compositionChanged();
 
     //! Reference state pressure
-    doublereal m_Pref;
+    double m_Pref = OneAtm;
 
     //! The current pressure
     /*!
@@ -572,7 +572,7 @@ protected:
      * variable which is inherited as part of the State class, m_dens, is always
      * kept current whenever T, P, or X[] change.
      */
-    doublereal m_Pcurrent;
+    double m_Pcurrent = OneAtm;
 
     //! Reference state enthalpies / RT
     mutable vector_fp m_h0_RT;
@@ -599,7 +599,7 @@ protected:
      *
      *  units are kmol m-3
      */
-    doublereal m_site_density;
+    double m_site_density = 0.0;
 
 private:
     //! Update the species reference state thermodynamic functions

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -105,7 +105,7 @@ class LatticeSolidPhase : public ThermoPhase
 {
 public:
     //! Base empty constructor
-    LatticeSolidPhase();
+    LatticeSolidPhase() = default;
 
     virtual std::string type() const {
         return "LatticeSolid";
@@ -451,10 +451,10 @@ public:
 
 protected:
     //! Current value of the pressure
-    doublereal m_press;
+    double m_press = -1.0;
 
     //! Current value of the molar density
-    doublereal m_molar_density;
+    double m_molar_density = 0.0;
 
     //! Vector of sublattic ThermoPhase objects
     std::vector<shared_ptr<ThermoPhase>> m_lattice;

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -415,7 +415,7 @@ private:
 
 protected:
     //! number of binary interaction expressions
-    size_t numBinaryInteractions_;
+    size_t numBinaryInteractions_ = 0;
 
     //! Enthalpy term for the binary mole fraction interaction of the
     //! excess Gibbs free energy expression
@@ -467,13 +467,13 @@ protected:
     /*!
      *  Currently there is only one form.
      */
-    int formMargules_;
+    int formMargules_ = 0;
 
     //! form of the temperature dependence of the Margules interaction expression
     /*!
      *  Currently there is only one form -> constant wrt temperature.
      */
-    int formTempModel_;
+    int formTempModel_ = 0;
 };
 
 }

--- a/include/cantera/thermo/MaskellSolidSolnPhase.h
+++ b/include/cantera/thermo/MaskellSolidSolnPhase.h
@@ -27,7 +27,7 @@ namespace Cantera
 class MaskellSolidSolnPhase : public VPStandardStateTP
 {
 public:
-    MaskellSolidSolnPhase();
+    MaskellSolidSolnPhase() = default;
 
     virtual std::string type() const {
         return "MaskellSolidsoln";
@@ -113,15 +113,15 @@ private:
      * pressure, but only of the mole fractions, we need to independently
      * specify the pressure.
      */
-    doublereal m_Pcurrent;
+    double m_Pcurrent = OneAtm;
 
     //! Value of the enthalpy change on mixing due to protons changing from type
     //! B to type A configurations.
-    doublereal h_mixing;
+    double h_mixing = 0.0;
 
     //! Index of the species whose mole fraction defines the extent of reduction r
-    int product_species_index;
-    int reactant_species_index;
+    int product_species_index = -1;
+    int reactant_species_index = -1;
 
     // Functions to calculate some of the pieces of the mixing terms.
     doublereal s() const;

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -78,7 +78,7 @@ public:
     //! @{
 
     //! Constructor.
-    MixtureFugacityTP();
+    MixtureFugacityTP() = default;
 
     //! @}
     //! @name  Utilities
@@ -557,10 +557,10 @@ protected:
      *  - FLUID_LIQUID
      *  - FLUID_SUPERCRIT
      */
-    int iState_;
+    int iState_ = FLUID_GAS;
 
     //! Force the system to be on a particular side of the spinodal curve
-    int forcedState_;
+    int forcedState_ = FLUID_UNDEFINED;
 
     //! Temporary storage for dimensionless reference state enthalpies
     mutable vector_fp m_h0_RT;

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -23,6 +23,51 @@
 namespace Cantera
 {
 
+//! Scale to be used for the output of single-ion activity coefficients is that
+//! used by Pitzer.
+/*!
+ * This is the internal scale used within the code. One property is that the
+ * activity coefficients for the cation and anion of a single salt will be
+ * equal. This scale is the one presumed by the formulation of the single-ion
+ * activity coefficients described in this report.
+ *
+ * Activity coefficients for species k may be altered between scales s1 to s2
+ * using the following formula
+ *
+ * \f[
+ *     ln(\gamma_k^{s2}) = ln(\gamma_k^{s1})
+ *        + \frac{z_k}{z_j} \left(  ln(\gamma_j^{s2}) - ln(\gamma_j^{s1}) \right)
+ * \f]
+ *
+ * where j is any one species.
+ */
+const int PHSCALE_PITZER = 0;
+
+//! Scale to be used for evaluation of single-ion activity coefficients is that
+//! used by the NBS standard for evaluation of the pH variable.
+/*!
+ * This is not the internal scale used within the code.
+ *
+ * Activity coefficients for species k may be altered between scales s1 to s2
+ * using the following formula
+ *
+ * \f[
+ *     ln(\gamma_k^{s2}) = ln(\gamma_k^{s1})
+ *        + \frac{z_k}{z_j} \left(  ln(\gamma_j^{s2}) - ln(\gamma_j^{s1}) \right)
+ * \f]
+ *
+ * where j is any one species. For the NBS scale, j is equal to the Cl- species
+ * and
+ *
+ * \f[
+ *     ln(\gamma_{Cl-}^{s2}) = \frac{-A_{\phi} \sqrt{I}}{1.0 + 1.5 \sqrt{I}}
+ * \f]
+ *
+ * This is the NBS pH scale, which is used in all conventional pH measurements.
+ * and is based on the Bates-Guggenheim equations.
+ */
+const int PHSCALE_NBS = 1;
+
 /*!
  * MolalityVPSSTP is a derived class of ThermoPhase that handles variable
  * pressure standard state methods for calculating thermodynamic properties that
@@ -545,17 +590,17 @@ protected:
      * the identity of the Cl- species for the PHSCALE_NBS scaling. Either
      * PHSCALE_PITZER or PHSCALE_NBS
      */
-    int m_pHScalingType;
+    int m_pHScalingType = PHSCALE_PITZER;
 
     //! Index of the phScale species
     /*!
      * Index of the species to be used in the single-ion scaling law. This is
      * the identity of the Cl- species for the PHSCALE_NBS scaling
      */
-    size_t m_indexCLM;
+    size_t m_indexCLM = npos;
 
     //! Molecular weight of the Solvent
-    doublereal m_weightSolvent;
+    double m_weightSolvent = 18.01528;
 
     /*!
      * In any molality implementation, it makes sense to have a minimum solvent
@@ -564,63 +609,17 @@ protected:
      * the molality definition to ensure that molal_solvent = 0 when
      * xmol_solvent = 0.
      */
-    doublereal m_xmolSolventMIN;
+    double m_xmolSolventMIN = 0.01;
 
     //! This is the multiplication factor that goes inside log expressions
     //! involving the molalities of species. It's equal to Wt_0 / 1000, where
     //! Wt_0 = weight of solvent (kg/kmol)
-    doublereal m_Mnaught;
+    double m_Mnaught = 18.01528E-3;
 
     //! Current value of the molalities of the species in the phase. Note this
     //! vector is a mutable quantity. units are (kg/kmol)
     mutable vector_fp m_molalities;
 };
-
-
-//! Scale to be used for the output of single-ion activity coefficients is that
-//! used by Pitzer.
-/*!
- * This is the internal scale used within the code. One property is that the
- * activity coefficients for the cation and anion of a single salt will be
- * equal. This scale is the one presumed by the formulation of the single-ion
- * activity coefficients described in this report.
- *
- * Activity coefficients for species k may be altered between scales s1 to s2
- * using the following formula
- *
- * \f[
- *     ln(\gamma_k^{s2}) = ln(\gamma_k^{s1})
- *        + \frac{z_k}{z_j} \left(  ln(\gamma_j^{s2}) - ln(\gamma_j^{s1}) \right)
- * \f]
- *
- * where j is any one species.
- */
-const int PHSCALE_PITZER = 0;
-
-//! Scale to be used for evaluation of single-ion activity coefficients is that
-//! used by the NBS standard for evaluation of the pH variable.
-/*!
- * This is not the internal scale used within the code.
- *
- * Activity coefficients for species k may be altered between scales s1 to s2
- * using the following formula
- *
- * \f[
- *     ln(\gamma_k^{s2}) = ln(\gamma_k^{s1})
- *        + \frac{z_k}{z_j} \left(  ln(\gamma_j^{s2}) - ln(\gamma_j^{s1}) \right)
- * \f]
- *
- * where j is any one species. For the NBS scale, j is equal to the Cl- species
- * and
- *
- * \f[
- *     ln(\gamma_{Cl-}^{s2}) = \frac{-A_{\phi} \sqrt{I}}{1.0 + 1.5 \sqrt{I}}
- * \f]
- *
- * This is the NBS pH scale, which is used in all conventional pH measurements.
- * and is based on the Bates-Guggenheim equations.
- */
-const int PHSCALE_NBS = 1;
 
 }
 

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -140,11 +140,11 @@ public:
 protected:
     //! Number of intervals in the interpolating linear approximation. Number
     //! of points is one more than the number of intervals.
-    size_t m_numIntervals;
+    size_t m_numIntervals = 0;
 
     //! Value of the enthalpy at T = 298.15. This value is tied to the Heat of
     //! formation of the species at 298.15.
-    doublereal m_H298;
+    double m_H298 = 0.0;
 
     //! Points at which the standard state chemical potential are given.
     vector_fp m_t0_int;

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -47,12 +47,12 @@ class MultiSpeciesThermo
 {
 public:
     //! Constructor
-    MultiSpeciesThermo();
+    MultiSpeciesThermo() = default;
 
     // MultiSpeciesThermo objects are not copyable or assignable
     MultiSpeciesThermo(const MultiSpeciesThermo& b) = delete;
     MultiSpeciesThermo& operator=(const MultiSpeciesThermo& b) = delete;
-    virtual ~MultiSpeciesThermo() {}
+    virtual ~MultiSpeciesThermo() = default;
 
     //! Install a new species thermodynamic property parameterization for one
     //! species.
@@ -220,13 +220,13 @@ protected:
     std::map<size_t, std::pair<int, size_t> > m_speciesLoc;
 
     //! Maximum value of the lowest temperature
-    doublereal m_tlow_max;
+    double m_tlow_max = 0.0;
 
     //! Minimum value of the highest temperature
-    doublereal m_thigh_min;
+    double m_thigh_min = 1e+30;
 
     //! reference pressure (Pa)
-    doublereal m_p0;
+    double m_p0 = OneAtm;
 
     //! indicates if data for species has been installed
     std::vector<bool> m_installed;

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -36,7 +36,7 @@ namespace Cantera
 class Nasa9PolyMultiTempRegion : public SpeciesThermoInterpType
 {
 public:
-    Nasa9PolyMultiTempRegion();
+    Nasa9PolyMultiTempRegion() = default;
 
     //! Constructor with all input data
     /*!
@@ -75,8 +75,6 @@ public:
      *                  coefficients for that region.
      */
     void setParameters(const std::map<double, vector_fp>& regions);
-
-    virtual ~Nasa9PolyMultiTempRegion();
 
     virtual int reportType() const;
 
@@ -128,7 +126,7 @@ protected:
     std::vector<std::unique_ptr<Nasa9Poly1>> m_regionPts;
 
     //! current region
-    mutable int m_currRegion;
+    mutable int m_currRegion = 0;
 };
 
 }

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -48,7 +48,7 @@ namespace Cantera
 class NasaPoly2 : public SpeciesThermoInterpType
 {
 public:
-    NasaPoly2();
+    NasaPoly2() = default;
 
     //! Constructor with all input data
     /*!
@@ -169,7 +169,7 @@ public:
 
 protected:
     //! Midrange temperature
-    doublereal m_midT;
+    double m_midT = 0.0;
     //! NasaPoly1 object for the low temperature region.
     NasaPoly1 mnp_low;
     //! NasaPoly1 object for the high temperature region.

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -150,12 +150,12 @@ public:
     //! @{
 
     //! Default Constructor
-    PDSS();
+    PDSS() = default;
 
     // PDSS objects are not copyable or assignable
     PDSS(const PDSS& b) = delete;
     PDSS& operator=(const PDSS& b) = delete;
-    virtual ~PDSS() {}
+    virtual ~PDSS() = default;
 
     //! @}
     //! @name Molar Thermodynamic Properties of the Species Standard State
@@ -449,22 +449,22 @@ public:
 
 protected:
     //! Current temperature used by the PDSS object
-    mutable doublereal m_temp;
+    mutable double m_temp = -1.0;
 
     //! State of the system - pressure
-    mutable doublereal m_pres;
+    mutable double m_pres = -1.0;
 
     //! Reference state pressure of the species.
-    doublereal m_p0;
+    double m_p0 = -1.0;
 
     //! Minimum temperature
-    doublereal m_minTemp;
+    double m_minTemp = -1.0;
 
     //! Maximum temperature
-    doublereal m_maxTemp;
+    double m_maxTemp = 10000.0;
 
     //! Molecular Weight of the species
-    doublereal m_mw;
+    double m_mw = 0.0;
 
     //! Input data supplied via setParameters. This may include parameters for
     //! different phase models, which will be used when initThermo() is called.

--- a/include/cantera/thermo/PDSS_ConstVol.h
+++ b/include/cantera/thermo/PDSS_ConstVol.h
@@ -23,7 +23,7 @@ class PDSS_ConstVol : public PDSS_Nondimensional
 {
 public:
     //! Default Constructor
-    PDSS_ConstVol();
+    PDSS_ConstVol() = default;
 
     //! @name Molar Thermodynamic Properties of the Species Standard State
     //! @{

--- a/include/cantera/thermo/PDSS_HKFT.h
+++ b/include/cantera/thermo/PDSS_HKFT.h
@@ -258,12 +258,12 @@ private:
      *  derived from the equation of state for water.
      *  This object doesn't own the object. Just a shallow pointer.
      */
-    PDSS_Water* m_waterSS;
+    PDSS_Water* m_waterSS = nullptr;
 
     UnitSystem m_units;
 
     //! density of standard-state water. internal temporary variable
-    mutable doublereal m_densWaterSS;
+    mutable double m_densWaterSS = -1.0;
 
     //!  Pointer to the water property calculator
     std::unique_ptr<WaterProps> m_waterProps;
@@ -275,7 +275,7 @@ private:
      *  This is the delta G for the formation reaction of the
      *  ion from elements in their stable state at Tr, Pr.
      */
-    doublereal m_deltaG_formation_tr_pr;
+    double m_deltaG_formation_tr_pr = NAN;
 
     //!  Input value of deltaH of Formation at Tr and Pr    (cal gmol-1)
     /*!
@@ -284,7 +284,7 @@ private:
      *  This is the delta H for the formation reaction of the
      *  ion from elements in their stable state at Tr, Pr.
      */
-    doublereal m_deltaH_formation_tr_pr;
+    double m_deltaH_formation_tr_pr = NAN;
 
     //! Value of the Absolute Gibbs Free Energy NIST scale at T_r and P_r
     /*!
@@ -293,49 +293,49 @@ private:
      *
      *  J kmol-1
      */
-    doublereal m_Mu0_tr_pr;
+    double m_Mu0_tr_pr = 0.0;
 
     //! Input value of S_j at Tr and Pr    (cal gmol-1 K-1)
     /*!
      *  Tr = 298.15   Pr = 1 atm
      */
-    doublereal m_Entrop_tr_pr;
+    double m_Entrop_tr_pr = NAN;
 
     //! Input a1 coefficient (cal gmol-1 bar-1)
-    doublereal m_a1;
+    double m_a1 = 0.0;
 
     //!  Input a2 coefficient (cal gmol-1)
-    doublereal m_a2;
+    double m_a2 = 0.0;
 
     //!  Input a3 coefficient (cal K gmol-1 bar-1)
-    doublereal m_a3;
+    double m_a3 = 0.0;
 
     //!  Input a4 coefficient (cal K gmol-1)
-    doublereal m_a4;
+    double m_a4 = 0.0;
 
     //!  Input c1 coefficient (cal gmol-1 K-1)
-    doublereal m_c1;
+    double m_c1 = 0.0;
 
     //!  Input c2 coefficient (cal K gmol-1)
-    doublereal m_c2;
+    double m_c2 = 0.0;
 
     //! Input  omega_pr_tr coefficient(cal gmol-1)
-    doublereal m_omega_pr_tr;
+    double m_omega_pr_tr = 0.0;
 
     //! y = dZdT = 1/(esp*esp) desp/dT at 298.15 and 1 bar
-    doublereal m_Y_pr_tr;
+    double m_Y_pr_tr = 0.0;
 
     //! Z = -1 / relEpsilon at 298.15 and 1 bar
-    doublereal m_Z_pr_tr;
+    double m_Z_pr_tr = 0.0;
 
     //! Reference pressure is 1 atm in units of bar= 1.0132
-    doublereal m_presR_bar;
+    double m_presR_bar = OneAtm * 1.0E-5;
 
     //! small value that is not quite zero
-    doublereal m_domega_jdT_prtr;
+    double m_domega_jdT_prtr = 0.0;
 
     //! Charge of the ion
-    doublereal m_charge_j;
+    double m_charge_j = 0.0;
 
     //!  Static variable determining error exiting
     /*!

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -25,7 +25,7 @@ class PDSS_IdealGas : public PDSS_Nondimensional
 {
 public:
     //! Default Constructor
-    PDSS_IdealGas();
+    PDSS_IdealGas() = default;
 
     //! @name Molar Thermodynamic Properties of the Species Standard State
     //! @{

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -36,7 +36,7 @@ class PDSS_IonsFromNeutral : public PDSS_Nondimensional
 {
 public:
     //! Default constructor
-    PDSS_IonsFromNeutral();
+    PDSS_IonsFromNeutral() = default;
 
     //! @name  Molar Thermodynamic Properties of the Species Standard State
     //! @{
@@ -101,7 +101,7 @@ protected:
 
     //! Number of neutral molecule species that make up the stoichiometric
     //! vector for this species, in terms of calculating thermodynamic functions
-    size_t numMult_;
+    size_t numMult_ = 0;
 
     //! Vector of species indices in the neutral molecule ThermoPhase
     std::vector<size_t> idNeutralMoleculeVec;
@@ -114,7 +114,7 @@ protected:
     /*!
      *  This is true if this species is not the special species
      */
-    bool add2RTln2_;
+    bool add2RTln2_ = true;
 
     //! Vector of length equal to the number of species in the neutral molecule phase
     mutable vector_fp tmpNM;

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -180,7 +180,7 @@ private:
 
     //! Enumerated data type describing the type of volume model
     //! used to calculate the standard state volume of the species
-    SSVolume_Model volumeModel_;
+    SSVolume_Model volumeModel_ = SSVolume_Model::tpoly;
 
     //! coefficients for the temperature representation
     vector_fp TCoeff_;

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -175,7 +175,7 @@ private:
      * Density is the independent variable here, but it's hidden behind the
      * object's interface.
      */
-    doublereal m_dens;
+    double m_dens;
 
     //! state of the fluid
     /*!
@@ -187,21 +187,21 @@ private:
      *    4  WATER_UNSTABLEGAS
      *  @endcode
      */
-    int m_iState;
+    int m_iState = WATER_LIQUID;
 
     /**
      *  Offset constants used to obtain consistency with the NIST database.
      *  This is added to all internal energy and enthalpy results.
      *  units = J kmol-1.
      */
-    doublereal EW_Offset;
+    double EW_Offset = 0.0;
 
     /**
      *  Offset constant used to obtain consistency with NIST convention.
      *  This is added to all internal entropy results.
      *  units = J kmol-1 K-1.
      */
-    doublereal SW_Offset;
+    double SW_Offset = 0.0;
 
 public:
     /**
@@ -210,7 +210,7 @@ public:
      *  a gas-phase answer is allowed. This is used to check the thermodynamic
      *  consistency with ideal-gas thermo functions for example.
      */
-    bool m_allowGasPhase;
+    bool m_allowGasPhase = false;
 };
 
 }

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -240,19 +240,19 @@ protected:
     /*!
      *  `m_b` is a function of the mole fractions and species-specific b values.
      */
-    double m_b;
+    double m_b = 0.0;
 
     //! Value of \f$a\f$ in the equation of state
     /*!
      *  `m_a` depends only on the mole fractions.
      */
-    double m_a;
+    double m_a = 0.0;
 
     //! Value of \f$\alpha\f$ in the equation of state
     /*!
      *  `m_aAlpha_mix` is a function of the temperature and the mole fractions.
      */
-    double m_aAlpha_mix;
+    double m_aAlpha_mix = 0.0;
 
     // Vectors required to store species-specific a_coeff, b_coeff, alpha, kappa
     // and other derivatives. Length = m_kk.
@@ -271,9 +271,9 @@ protected:
     //! Explicitly-specified binary interaction parameters, to enable serialization
     std::map<std::string, std::map<std::string, double>> m_binaryParameters;
 
-    int m_NSolns;
+    int m_NSolns = 0;
 
-    double m_Vroot[3];
+    double m_Vroot[3] = {0.0, 0.0, 0.0};
 
     //! Temporary storage - length = m_kk.
     mutable vector_fp m_pp;
@@ -286,14 +286,14 @@ protected:
      * Calculated at the current conditions. temperature and mole number kept
      * constant
      */
-    mutable double m_dpdV;
+    mutable double m_dpdV = 0.0;
 
     //! The derivative of the pressure with respect to the temperature
     /*!
      *  Calculated at the current conditions. Total volume and mole number kept
      *  constant
      */
-    mutable double m_dpdT;
+    mutable double m_dpdT = 0.0;
 
     //! Vector of derivatives of pressure with respect to mole number
     /*!

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -106,9 +106,8 @@ class Species;
 class Phase
 {
 public:
-    Phase(); //!< Default constructor.
-
-    virtual ~Phase();
+    Phase() = default; //!< Default constructor.
+    virtual ~Phase() = default;
 
     // Phase objects are not copyable or assignable
     Phase(const Phase&) = delete;
@@ -937,11 +936,11 @@ protected:
     //! should call the parent class method as well.
     virtual void compositionChanged();
 
-    size_t m_kk; //!< Number of species in the phase.
+    size_t m_kk = 0; //!< Number of species in the phase.
 
     //! Dimensionality of the phase. Volumetric phases have dimensionality 3
     //! and surface phases have dimensionality 2.
-    size_t m_ndim;
+    size_t m_ndim = 3;
 
     //! Atomic composition of the species. The number of atoms of element i
     //! in species k is equal to m_speciesComp[k * m_mm + i]
@@ -953,10 +952,10 @@ protected:
     std::map<std::string, shared_ptr<Species> > m_species;
 
     //! Flag determining behavior when adding species with an undefined element
-    UndefElement::behavior m_undefinedElementBehavior;
+    UndefElement::behavior m_undefinedElementBehavior = UndefElement::add;
 
     //! Flag determining whether case sensitive species names are enforced
-    bool m_caseSensitiveSpecies;
+    bool m_caseSensitiveSpecies = false;
 
 private:
     //! Find lowercase species name in m_speciesIndices when case sensitive
@@ -969,15 +968,15 @@ private:
     //! to another value during the course of a calculation.
     std::string m_name;
 
-    doublereal m_temp; //!< Temperature (K). This is an independent variable
+    double m_temp = 0.001; //!< Temperature (K). This is an independent variable
 
     //! Density (kg m-3). This is an independent variable except in the case
     //! of incompressible phases, where it has to be changed using the
     //! assignDensity() method. For compressible substances, the pressure is
     //! determined from this variable rather than other way round.
-    doublereal m_dens;
+    double m_dens = 0.001;
 
-    doublereal m_mmw; //!< mean molecular weight of the mixture (kg kmol-1)
+    double m_mmw = 0.0; //!< mean molecular weight of the mixture (kg kmol-1)
 
     //! m_ym[k] = mole fraction of species k divided by the mean molecular
     //! weight of mixture.
@@ -996,7 +995,7 @@ private:
 
     //! State Change variable. Whenever the mole fraction vector changes,
     //! this int is incremented.
-    int m_stateNum;
+    int m_stateNum = -1;
 
     //! Vector of the species names
     std::vector<std::string> m_speciesNames;
@@ -1007,7 +1006,7 @@ private:
     //! Map of lower-case species names to indices
     std::map<std::string, size_t> m_speciesLower;
 
-    size_t m_mm; //!< Number of elements.
+    size_t m_mm = 0; //!< Number of elements.
     vector_fp m_atomicWeights; //!< element atomic weights (kg kmol-1)
     vector_int m_atomicNumbers; //!< element atomic numbers
     std::vector<std::string> m_elementNames; //!< element names

--- a/include/cantera/thermo/PlasmaPhase.h
+++ b/include/cantera/thermo/PlasmaPhase.h
@@ -304,10 +304,10 @@ protected:
     void normalizeElectronEnergyDistribution();
 
     // Electron energy order in the exponential term
-    double m_isotropicShapeFactor;
+    double m_isotropicShapeFactor = 2.0;
 
     //! Number of points of electron energy levels
-    size_t m_nPoints;
+    size_t m_nPoints = 1001;
 
     //! electron energy levels [ev]. Length: #m_nPoints
     Eigen::ArrayXd m_electronEnergyLevels;
@@ -317,19 +317,19 @@ protected:
     Eigen::ArrayXd m_electronEnergyDist;
 
     //! Index of electron species
-    size_t m_electronSpeciesIndex;
+    size_t m_electronSpeciesIndex = npos;
 
     //! Electron temperature [K]
     double m_electronTemp;
 
     //! Electron energy distribution type
-    std::string m_distributionType;
+    string m_distributionType = "isotropic";
 
     //! Numerical quadrature method for electron energy distribution
-    std::string m_quadratureMethod;
+    string m_quadratureMethod = "simpson";
 
     //! Flag of normalizing electron energy distribution
-    bool m_do_normalizeElectronEnergyDist;
+    bool m_do_normalizeElectronEnergyDist = true;
 };
 
 }

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -31,7 +31,7 @@ class PureFluidPhase : public ThermoPhase
 {
 public:
     //! Empty Base Constructor
-    PureFluidPhase();
+    PureFluidPhase() = default;
 
     virtual std::string type() const {
         return "PureFluid";
@@ -211,17 +211,17 @@ private:
      * The tpx package uses an int to indicate what fluid is being sought. Used
      * only if #m_tpx_name is not set.
      */
-    int m_subflag;
+    int m_subflag = -1;
 
     //! Name for this substance used by the TPX package. If this is not set,
     //! #m_subflag is used instead.
     std::string m_tpx_name;
 
     //! Molecular weight of the substance (kg kmol-1)
-    doublereal m_mw;
+    double m_mw = -1.0;
 
     //! flag to turn on some printing.
-    bool m_verbose;
+    bool m_verbose = false;
 };
 
 }

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -214,19 +214,19 @@ protected:
      *  - 0 = There is no temperature parameterization of a or b
      *  - 1 = The a_ij parameter is a linear function of the temperature
      */
-    int m_formTempParam;
+    int m_formTempParam = 0;
 
     //! Value of b in the equation of state
     /*!
      *  m_b is a function of the temperature and the mole fraction.
      */
-    doublereal m_b_current;
+    double m_b_current = 0.0;
 
     //! Value of a in the equation of state
     /*!
      *  a_b is a function of the temperature and the mole fraction.
      */
-    doublereal m_a_current;
+    double m_a_current = 0.0;
 
     vector_fp a_vec_Curr_;
     vector_fp b_vec_Curr_;
@@ -240,9 +240,9 @@ protected:
     //! For each species, specifies the source of the a and b coefficients
     std::vector<CoeffSource> m_coeffSource;
 
-    int NSolns_;
+    int NSolns_ = 0;
 
-    doublereal Vroot_[3];
+    double Vroot_[3] = {0.0, 0.0, 0.0};
 
     //! Temporary storage - length = m_kk.
     mutable vector_fp m_pp;
@@ -255,14 +255,14 @@ protected:
      * Calculated at the current conditions. temperature and mole number kept
      * constant
      */
-    mutable doublereal dpdV_;
+    mutable double dpdV_ = 0.0;
 
     //! The derivative of the pressure wrt the temperature
     /*!
      *  Calculated at the current conditions. Total volume and mole number kept
      *  constant
      */
-    mutable doublereal dpdT_;
+    mutable double dpdT_ = 0.0;
 
     //! Vector of derivatives of pressure wrt mole number
     /*!

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -57,7 +57,7 @@ class SingleSpeciesTP : public ThermoPhase
 {
 public:
     //! Base empty constructor.
-    SingleSpeciesTP();
+    SingleSpeciesTP() = default;
 
     virtual std::string type() const {
         return "SingleSpecies";
@@ -245,11 +245,11 @@ public:
 
 protected:
     //! The current pressure of the solution (Pa). It gets initialized to 1 atm.
-    doublereal m_press;
+    double m_press = OneAtm;
 
     // Reference pressure (Pa). Must be the same for all species. Defaults to
     // 1 atm.
-    doublereal m_p0;
+    double m_p0 = OneAtm;
 
     //! Dimensionless enthalpy at the (mtlast, m_p0)
     mutable double m_h0_RT;

--- a/include/cantera/thermo/Species.h
+++ b/include/cantera/thermo/Species.h
@@ -24,7 +24,7 @@ class ThermoPhase;
 class Species
 {
 public:
-    Species();
+    Species() = default;
 
     //! Constructor
     Species(const std::string& name, const compositionMap& comp,
@@ -33,7 +33,7 @@ public:
     //! Species objects are not copyable or assignable
     Species(const Species&) = delete;
     Species& operator=(const Species& other) = delete;
-    ~Species();
+    ~Species() = default;
 
     AnyMap parameters(const ThermoPhase* phase=0, bool withInput=true) const;
 
@@ -45,11 +45,11 @@ public:
     compositionMap composition;
 
     //! The electrical charge on the species, in units of the elementary charge.
-    double charge;
+    double charge = 0.0;
 
     //! The effective size of the species. Currently used only for surface
     //! species, where it represents the number of sites occupied.
-    double size;
+    double size = 1.0;
 
     //! The molecular weight [amu] of the species.
     /*!

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -112,7 +112,7 @@ class PDSS;
 class SpeciesThermoInterpType
 {
 public:
-    SpeciesThermoInterpType();
+    SpeciesThermoInterpType() = default;
 
     SpeciesThermoInterpType(double tlow, double thigh, double pref);
 
@@ -120,7 +120,7 @@ public:
     SpeciesThermoInterpType(const SpeciesThermoInterpType& b) = delete;
     SpeciesThermoInterpType& operator=(const SpeciesThermoInterpType& b) = delete;
 
-    virtual ~SpeciesThermoInterpType() {}
+    virtual ~SpeciesThermoInterpType() = default;
 
     //! Returns the minimum temperature that the thermo parameterization is
     //! valid
@@ -283,11 +283,11 @@ protected:
     virtual void getParameters(AnyMap& thermo) const;
 
     //!  lowest valid temperature
-    doublereal m_lowT;
+    double m_lowT = 0.0;
     //! Highest valid temperature
-    doublereal m_highT;
+    double m_highT = 0.0;
     //! Reference state pressure
-    doublereal m_Pref;
+    double m_Pref = 0.0;
 
     AnyMap m_input;
 };

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -317,7 +317,7 @@ protected:
     virtual void compositionChanged();
 
     //! Surface site density (kmol m-2)
-    doublereal m_n0;
+    double m_n0 = 1.0;
 
     //! Vector of species sizes (number of sites occupied). length m_kk.
     vector_fp m_speciesSize;
@@ -326,7 +326,7 @@ protected:
     doublereal m_logn0;
 
     //! Current value of the pressure (Pa)
-    doublereal m_press;
+    double m_press = OneAtm;
 
     //! Temporary storage for the reference state enthalpies
     mutable vector_fp m_h0;

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -102,7 +102,7 @@ class ThermoPhase : public Phase
 public:
     //! Constructor. Note that ThermoPhase is meant to be used as a base class,
     //! so this constructor should not be called explicitly.
-    ThermoPhase();
+    ThermoPhase() = default;
 
     //! @name  Information Methods
     //! @{
@@ -1821,7 +1821,7 @@ protected:
     AnyMap m_input;
 
     //! Stored value of the electric potential for this phase. Units are Volts.
-    doublereal m_phi;
+    double m_phi = 0.0;
 
     //! Boolean indicating whether a charge neutrality condition is a necessity
     /*!
@@ -1831,13 +1831,13 @@ protected:
      * account. However, liquid phases usually require charge neutrality in
      * order for their derived thermodynamics to be valid.
      */
-    bool m_chargeNeutralityNecessary;
+    bool m_chargeNeutralityNecessary = false;
 
     //! Contains the standard state convention
-    int m_ssConvention;
+    int m_ssConvention = cSS_CONVENTION_TEMPERATURE;
 
     //! last value of the temperature processed by reference state
-    mutable doublereal m_tlast;
+    mutable double m_tlast = 0.0;
 };
 
 }

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -265,21 +265,21 @@ protected:
      *
      *  units = Pascals
      */
-    doublereal m_Pcurrent;
+    double m_Pcurrent = OneAtm;
 
     //! The minimum temperature at which data for all species is valid
-    double m_minTemp;
+    double m_minTemp = 0.0;
 
     //! The maximum temperature at which data for all species is valid
-    double m_maxTemp;
+    double m_maxTemp = BigNumber;
 
     //! The last temperature at which the standard state thermodynamic
     //! properties were calculated at.
-    mutable doublereal m_Tlast_ss;
+    mutable double m_Tlast_ss = -1.0;
 
     //! The last pressure at which the Standard State thermodynamic properties
     //! were calculated at.
-    mutable doublereal m_Plast_ss;
+    mutable double m_Plast_ss = -1.0;
 
     //! Storage for the PDSS objects for the species
     /*!

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -243,10 +243,10 @@ public:
 
 protected:
     //! Pointer to the WaterPropsIAPWS object
-    WaterPropsIAPWS* m_waterIAPWS;
+    WaterPropsIAPWS* m_waterIAPWS = nullptr;
 
     //! true if we own the WaterPropsIAPWS object
-    bool m_own_sub;
+    bool m_own_sub = false;
 };
 
 //@}

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -162,7 +162,7 @@ class WaterPropsIAPWS
 {
 public:
     //! Base constructor
-    WaterPropsIAPWS();
+    WaterPropsIAPWS() = default;
 
     WaterPropsIAPWS(const WaterPropsIAPWS& right) = delete;
     WaterPropsIAPWS& operator=(const WaterPropsIAPWS& right) = delete;
@@ -477,13 +477,13 @@ private:
     mutable WaterPropsIAPWSphi m_phi;
 
     //! Dimensionless temperature,  tau = T_C / T
-    doublereal tau;
+    double tau = -1.0;
 
     //! Dimensionless density, delta = rho / rho_c
-    mutable doublereal delta;
+    mutable double delta = -1.0;
 
     //! Current state of the system
-    mutable int iState;
+    mutable int iState = -30000;
 };
 
 }

--- a/include/cantera/thermo/WaterPropsIAPWSphi.h
+++ b/include/cantera/thermo/WaterPropsIAPWSphi.h
@@ -188,13 +188,13 @@ protected:
     doublereal DELTAp[16];
 
     //! Last tau that was used to calculate polynomials
-    doublereal TAUsave;
+    double TAUsave = -1.0;
 
     //! sqrt of TAU
-    doublereal TAUsqrt;
+    double TAUsqrt = -1.0;
 
     //! Last delta that was used to calculate polynomials
-    doublereal DELTAsave;
+    double DELTAsave = -1.0;
 };
 
 } // namespace Cantera

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -201,24 +201,24 @@ private:
     std::unique_ptr<WaterProps> m_waterProps;
 
     //! Molecular weight of Water -> Cantera assumption
-    doublereal m_mw;
+    double m_mw = 0.0;
 
     //! Offset constants used to obtain consistency with the NIST database.
     /*!
      *  This is added to all internal energy and enthalpy results.
      *  units = J kmol-1.
      */
-    doublereal EW_Offset;
+    double EW_Offset = 0.0;
 
     //! Offset constant used to obtain consistency with NIST convention.
     /*!
      *  This is added to all internal entropy results.
      *  units = J kmol-1 K-1.
      */
-    doublereal SW_Offset;
+    double SW_Offset = 0.0;
 
     //! Boolean is true if object has been properly initialized for calculation
-    bool m_ready;
+    bool m_ready = false;
 
     /**
      *  Since this phase represents a liquid (or supercritical) phase, it is an
@@ -226,7 +226,7 @@ private:
      *  a gas-phase answer is allowed. This is used to check the thermodynamic
      *  consistency with ideal-gas thermo functions for example.
      */
-    bool m_allowGasPhase;
+    bool m_allowGasPhase = false;
 };
 
 }

--- a/include/cantera/tpx/Sub.h
+++ b/include/cantera/tpx/Sub.h
@@ -37,9 +37,9 @@ const double Undef = 999.1234;
 class Substance
 {
 public:
-    Substance();
+    Substance() = default;
 
-    virtual ~Substance() {}
+    virtual ~Substance() = default;
 
     void setStdState(double h0 = 0.0, double s0 = 0.0,
                      double t0 = 298.15, double p0 = 1.01325e5);
@@ -175,11 +175,14 @@ public:
     void Set(PropertyPair::type XY, double x0, double y0);
 
 protected:
-    double T, Rho;
-    double Tslast, Rhf, Rhv;
-    double Pst;
-    double m_energy_offset;
-    double m_entropy_offset;
+    double T = Undef;
+    double Rho = Undef;
+    double Tslast = Undef;
+    double Rhf = Undef;
+    double Rhv = Undef;
+    double Pst = Undef;
+    double m_energy_offset = 0.0;
+    double m_entropy_offset = 0.0;
     std::string m_name;
     std::string m_formula;
 
@@ -219,7 +222,7 @@ private:
                 double X, double Y,
                 double atx, double aty, double rtx, double rty);
 
-    int kbr;
+    int kbr = 0;
     double Vmin, Vmax;
     double Pmin, Pmax;
     double dvbf, dv;

--- a/include/cantera/tpx/Sub.h
+++ b/include/cantera/tpx/Sub.h
@@ -7,7 +7,6 @@
 #define TPX_SUB_H
 
 #include "cantera/base/ctexceptions.h"
-#include <algorithm>
 
 namespace tpx
 {

--- a/include/cantera/transport/DustyGasTransport.h
+++ b/include/cantera/transport/DustyGasTransport.h
@@ -243,7 +243,7 @@ private:
     vector_fp m_dk;
 
     //! temperature
-    doublereal m_temp;
+    double m_temp = -1.0;
 
     //! Multicomponent diffusion coefficients. @see eval_H_matrix()
     DenseMatrix m_multidiff;
@@ -255,28 +255,28 @@ private:
     vector_fp m_spwork2;
 
     //! Pressure Gradient
-    doublereal m_gradP;
+    double m_gradP = 0.0;
 
     //! Update-to-date variable for Knudsen diffusion coefficients
-    bool m_knudsen_ok;
+    bool m_knudsen_ok = false;
 
     //! Update-to-date variable for Binary diffusion coefficients
-    bool m_bulk_ok;
+    bool m_bulk_ok = false;
 
     //! Porosity
-    doublereal m_porosity;
+    double m_porosity = 0.0;
 
     //! Tortuosity
-    doublereal m_tortuosity;
+    double m_tortuosity = 1.0;
 
     //! Pore radius (meter)
-    doublereal m_pore_radius;
+    double m_pore_radius = 0.0;
 
     //! Particle diameter
     /*!
      * The medium is assumed to consist of particles of size m_diam. units =  m
      */
-    doublereal m_diam;
+    double m_diam = 0.0;
 
     //! Permeability of the media
     /*!
@@ -291,7 +291,7 @@ private:
      *
      * units are m2
      */
-    doublereal m_perm;
+    double m_perm = -1.0;
 
     //! Pointer to the transport object for the gas phase
     std::unique_ptr<Transport> m_gastran;

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -296,23 +296,23 @@ protected:
     vector_fp m_molefracs;
 
     //! Internal storage for the viscosity of the mixture  (kg /m /s)
-    doublereal m_viscmix;
+    double m_viscmix = 0.0;
 
     //! Update boolean for mixture rule for the mixture viscosity
-    bool m_visc_ok;
+    bool m_visc_ok = false;
 
     //! Update boolean for the weighting factors for the mixture viscosity
-    bool m_viscwt_ok;
+    bool m_viscwt_ok = false;
 
     //! Update boolean for the species viscosities
-    bool m_spvisc_ok;
+    bool m_spvisc_ok = false;
 
     //! Update boolean for the binary diffusivities at unit pressure
-    bool m_bindiff_ok;
+    bool m_bindiff_ok = false;
 
     //! Type of the polynomial fits to temperature. CK_Mode means Chemkin mode.
     //! Currently CA_Mode is used which are different types of fits to temperature.
-    int m_mode;
+    int m_mode = 0;
 
     //! m_phi is a Viscosity Weighting Function. size = m_nsp * n_nsp
     DenseMatrix m_phi;
@@ -357,26 +357,26 @@ protected:
 
     //! Current value of the temperature at which the properties in this object
     //! are calculated (Kelvin).
-    doublereal m_temp;
+    double m_temp = -1.0;
 
     //! Current value of Boltzmann constant times the temperature (Joules)
-    doublereal m_kbt;
+    double m_kbt = 0.0;
 
     //! current value of Boltzmann constant times the temperature.
     //! (Joules) to 1/2 power
-    doublereal m_sqrt_kbt;
+    double m_sqrt_kbt = 0.0;
 
     //! current value of temperature to 1/2 power
-    doublereal m_sqrt_t;
+    double m_sqrt_t = 0.0;
 
     //! Current value of the log of the temperature
-    doublereal m_logt;
+    double m_logt = 0.0;
 
     //! Current value of temperature to 1/4 power
-    doublereal m_t14;
+    double m_t14 = 0.0;
 
     //! Current value of temperature to the 3/2 power
-    doublereal m_t32;
+    double m_t32 = 0.0;
 
     //! Polynomial fits to the binary diffusivity of each species
     /*!
@@ -548,7 +548,7 @@ protected:
     vector_fp m_quad_polar;
 
     //! Level of verbose printing during initialization
-    int m_log_level;
+    int m_log_level = 0;
 };
 
 } // namespace Cantera

--- a/include/cantera/transport/IonGasTransport.h
+++ b/include/cantera/transport/IonGasTransport.h
@@ -49,7 +49,7 @@ namespace Cantera
 class IonGasTransport : public MixTransport
 {
 public:
-    IonGasTransport();
+    IonGasTransport() = default;
 
     virtual std::string transportModel() const {
         return "Ion";
@@ -107,7 +107,7 @@ protected:
     std::vector<size_t> m_kNeutral;
 
     //! index of electron
-    size_t m_kElectron;
+    size_t m_kElectron = npos;
 
     //! parameter of omega11 of n64
     DenseMatrix m_gamma;

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -57,7 +57,7 @@ class MixTransport : public GasTransport
 {
 public:
     //! Default constructor.
-    MixTransport();
+    MixTransport() = default;
 
     virtual std::string transportModel() const {
         return (m_mode == CK_Mode) ? "CK_Mix" : "Mix";
@@ -171,13 +171,13 @@ protected:
     /*!
      *  Units = W /m /K
      */
-    doublereal m_lambda;
+    double m_lambda = 0.0;
 
     //! Update boolean for the species thermal conductivities
-    bool m_spcond_ok;
+    bool m_spcond_ok = false;
 
     //! Update boolean for the mixture rule for the mixture thermal conductivity
-    bool m_condmix_ok;
+    bool m_condmix_ok = false;
 };
 }
 #endif

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -781,17 +781,17 @@ protected:
     ThermoPhase* m_thermo;
 
     //! true if finalize has been called
-    bool m_ready;
+    bool m_ready = false;
 
     //! Number of species
-    size_t m_nsp;
+    size_t m_nsp = 0;
 
     //! Number of dimensions used in flux expressions
     size_t m_nDim;
 
     //! Velocity basis from which diffusion velocities are computed.
     //! Defaults to the mass averaged basis = -2
-    int m_velocityBasis;
+    int m_velocityBasis = VB_MASSAVG;
 
     //! reference to Solution
     std::weak_ptr<Solution> m_root;

--- a/include/cantera/transport/TransportData.h
+++ b/include/cantera/transport/TransportData.h
@@ -18,8 +18,8 @@ class Species;
 class TransportData
 {
 public:
-    TransportData() {}
-    virtual ~TransportData() {}
+    TransportData() = default;
+    virtual ~TransportData() = default;
 
     virtual void validate(const Species& species) {}
 
@@ -45,7 +45,7 @@ protected:
 class GasTransportData : public TransportData
 {
 public:
-    GasTransportData();
+    GasTransportData() = default;
 
     //! Construct a GasTransportData object using MKS units for all parameters.
     GasTransportData(const std::string& geometry, double diameter,
@@ -76,30 +76,30 @@ public:
     std::string geometry;
 
     //! The Lennard-Jones collision diameter [m]
-    double diameter;
+    double diameter = 0.0;
 
     //! The Lennard-Jones well depth [J]
-    double well_depth;
+    double well_depth = 0.0;
 
     //! The permanent dipole moment of the molecule [Coulomb-m]. Default 0.0.
-    double dipole;
+    double dipole = 0.0;
 
     //! The polarizability of the molecule [m^3]. Default 0.0.
-    double polarizability;
+    double polarizability = 0.0;
 
     //! The rotational relaxation number (the number of collisions it takes to
     //! equilibrate the rotational degrees of freedom with the temperature).
     //! Default 0.0.
-    double rotational_relaxation;
+    double rotational_relaxation = 0.0;
 
     //! Pitzer's acentric factor [dimensionless]. Default 0.0.
-    double acentric_factor;
+    double acentric_factor = 0.0;
 
     //! dispersion normalized by e^2. [m^5] Default 0.0.
-    double dispersion_coefficient;
+    double dispersion_coefficient = 0.0;
 
     //! quadrupole. Default 0.0.
-    double quadrupole_polarizability;
+    double quadrupole_polarizability = 0.0;
 };
 
 //! Create a new TransportData object from an AnyMap specification

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -25,7 +25,7 @@ namespace Cantera
 class UnityLewisTransport : public MixTransport
 {
 public:
-//    UnityLewisTransport() {}
+    UnityLewisTransport() = default;
 
     virtual std::string transportModel() const {
         return "UnityLewis";

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -23,9 +23,9 @@ class ReactorBase;
 class FlowDevice
 {
 public:
-    FlowDevice();
+    FlowDevice() = default;
 
-    virtual ~FlowDevice() {}
+    virtual ~FlowDevice() = default;
     FlowDevice(const FlowDevice&) = delete;
     FlowDevice& operator=(const FlowDevice&) = delete;
 
@@ -88,21 +88,22 @@ public:
     virtual void setTimeFunction(Func1* g);
 
 protected:
-    double m_mdot;
+    double m_mdot = Undef;
 
     //! Function set by setPressureFunction; used by updateMassFlowRate
-    Func1* m_pfunc;
+    Func1* m_pfunc = nullptr;
 
     //! Function set by setTimeFunction; used by updateMassFlowRate
-    Func1* m_tfunc;
+    Func1* m_tfunc = nullptr;
 
     //! Coefficient set by derived classes; used by updateMassFlowRate
-    double m_coeff;
+    double m_coeff = 1.0;
 
 private:
-    size_t m_nspin, m_nspout;
-    ReactorBase* m_in;
-    ReactorBase* m_out;
+    size_t m_nspin = 0;
+    size_t m_nspout = 0;
+    ReactorBase* m_in = nullptr;
+    ReactorBase* m_out = nullptr;
     std::vector<size_t> m_in2out, m_out2in;
 };
 

--- a/include/cantera/zeroD/FlowReactor.h
+++ b/include/cantera/zeroD/FlowReactor.h
@@ -15,7 +15,7 @@ namespace Cantera
 class FlowReactor : public Reactor
 {
 public:
-    FlowReactor();
+    FlowReactor() = default;
 
     virtual std::string type() const {
         return "FlowReactor";
@@ -47,9 +47,14 @@ public:
     virtual size_t componentIndex(const std::string& nm) const;
 
 protected:
-    doublereal m_speed, m_dist, m_T;
-    doublereal m_fctr;
-    doublereal m_rho0, m_speed0, m_P0, m_h0;
+    double m_speed = 0.0;
+    double m_dist = 0.0;
+    double m_T = 0.0;
+    double m_fctr = 1.0e10;
+    double m_rho0 = 0.0;
+    double m_speed0 = 0.0;
+    double m_P0 = 0.0;
+    double m_h0 = 0.0;
 };
 }
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -43,7 +43,7 @@ class AnyMap;
 class Reactor : public ReactorBase
 {
 public:
-    Reactor();
+    Reactor() = default;
 
     virtual std::string type() const {
         return "Reactor";
@@ -221,13 +221,13 @@ protected:
     virtual void getSurfaceInitialConditions(double* y);
 
     //! Pointer to the homogeneous Kinetics object that handles the reactions
-    Kinetics* m_kin;
+    Kinetics* m_kin = nullptr;
 
-    doublereal m_vdot; //!< net rate of volume change from moving walls [m^3/s]
+    double m_vdot = 0.0; //!< net rate of volume change from moving walls [m^3/s]
 
-    double m_Qdot; //!< net heat transfer into the reactor, through walls [W]
+    double m_Qdot = 0.0; //!< net heat transfer into the reactor, through walls [W]
 
-    doublereal m_mass; //!< total mass
+    double m_mass = 0.0; //!< total mass
     vector_fp m_work;
 
     //! Production rates of gas phase species on surfaces [kmol/s]
@@ -235,9 +235,9 @@ protected:
 
     vector_fp m_wdot; //!< Species net molar production rates
     vector_fp m_uk; //!< Species molar internal energies
-    bool m_chem;
-    bool m_energy;
-    size_t m_nv;
+    bool m_chem = false;
+    bool m_energy = true;
+    size_t m_nv = 0;
     size_t m_nv_surf; //!!< Number of variables associated with reactor surfaces
 
     vector_fp m_advancelimits; //!< Advance step limit

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -49,7 +49,7 @@ class ReactorBase
 {
 public:
     explicit ReactorBase(const std::string& name = "(none)");
-    virtual ~ReactorBase() {}
+    virtual ~ReactorBase() = default;
     ReactorBase(const ReactorBase&) = delete;
     ReactorBase& operator=(const ReactorBase&) = delete;
 
@@ -249,13 +249,13 @@ public:
 
 protected:
     //! Number of homogeneous species in the mixture
-    size_t m_nsp;
+    size_t m_nsp = 0;
 
-    ThermoPhase* m_thermo;
-    double m_vol; //!< Current volume of the reactor [m^3]
-    double m_enthalpy; //!< Current specific enthalpy of the reactor [J/kg]
-    double m_intEnergy; //!< Current internal energy of the reactor [J/kg]
-    double m_pressure; //!< Current pressure in the reactor [Pa]
+    ThermoPhase* m_thermo = nullptr;
+    double m_vol = 1.0; //!< Current volume of the reactor [m^3]
+    double m_enthalpy = 0.0; //!< Current specific enthalpy of the reactor [J/kg]
+    double m_intEnergy = 0.0; //!< Current internal energy of the reactor [J/kg]
+    double m_pressure = 0.0; //!< Current pressure in the reactor [Pa]
     vector_fp m_state;
     std::vector<FlowDevice*> m_inlet, m_outlet;
 
@@ -268,7 +268,7 @@ protected:
     std::string m_name;
 
     //! The ReactorNet that this reactor is part of
-    ReactorNet* m_net;
+    ReactorNet* m_net = nullptr;
 };
 }
 

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -303,23 +303,25 @@ protected:
 
     std::vector<Reactor*> m_reactors;
     std::unique_ptr<Integrator> m_integ;
-    doublereal m_time;
-    bool m_init;
-    bool m_integrator_init; //!< True if integrator initialization is current
-    size_t m_nv;
+    double m_time = 0.0;
+    bool m_init = false;
+    bool m_integrator_init = false; //!< True if integrator initialization is current
+    size_t m_nv = 0;
 
     //! m_start[n] is the starting point in the state vector for reactor n
     std::vector<size_t> m_start;
 
     vector_fp m_atol;
-    doublereal m_rtol, m_rtolsens;
-    doublereal m_atols, m_atolsens;
+    double m_rtol = 1.0e-9;
+    double m_rtolsens = 1.0e-4;
+    double m_atols = 1.0e-15;
+    double m_atolsens = 1.0e-6;
 
     //! Maximum integrator internal timestep. Default of 0.0 means infinity.
-    doublereal m_maxstep;
+    double m_maxstep = 0.0;
 
-    int m_maxErrTestFails;
-    bool m_verbose;
+    int m_maxErrTestFails = 0;
+    bool m_verbose = false;
 
     //! Names corresponding to each sensitivity parameter
     std::vector<std::string> m_paramNames;

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -20,8 +20,8 @@ class SurfPhase;
 class ReactorSurface
 {
 public:
-    ReactorSurface();
-    virtual ~ReactorSurface() {}
+    ReactorSurface() = default;
+    virtual ~ReactorSurface() = default;
     ReactorSurface(const ReactorSurface&) = delete;
     ReactorSurface& operator=(const ReactorSurface&) = delete;
 
@@ -87,11 +87,11 @@ public:
     void resetSensitivityParameters();
 
 protected:
-    double m_area;
+    double m_area = 1.0;
 
-    SurfPhase* m_thermo;
-    Kinetics* m_kinetics;
-    ReactorBase* m_reactor;
+    SurfPhase* m_thermo = nullptr;
+    Kinetics* m_kinetics = nullptr;
+    ReactorBase* m_reactor = nullptr;
     vector_fp m_cov;
     std::vector<SensitivityParameter> m_params;
 };

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -84,12 +84,12 @@ public:
     }
 
 protected:
-    ReactorBase* m_left;
-    ReactorBase* m_right;
+    ReactorBase* m_left = nullptr;
+    ReactorBase* m_right = nullptr;
 
     std::vector<ReactorSurface> m_surf;
 
-    double m_area;
+    double m_area = 1.0;
 };
 
 //! Represents a wall between between two ReactorBase objects.
@@ -100,7 +100,7 @@ protected:
 class Wall : public WallBase
 {
 public:
-    Wall();
+    Wall() = default;
 
     //! String indicating the wall model implemented. Usually
     //! corresponds to the name of the derived class.
@@ -186,19 +186,19 @@ public:
 protected:
 
     //! expansion rate coefficient
-    double m_k;
+    double m_k = 0.0;
 
     //! heat transfer coefficient
-    double m_rrth;
+    double m_rrth = 0.0;
 
     //! emissivity
-    double m_emiss;
+    double m_emiss = 0.0;
 
     //! Velocity function
-    Func1* m_vf;
+    Func1* m_vf = nullptr;
 
     //! Heat flux function
-    Func1* m_qf;
+    Func1* m_qf = nullptr;
 };
 
 }

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -19,7 +19,7 @@ namespace Cantera
 class MassFlowController : public FlowDevice
 {
 public:
-    MassFlowController();
+    MassFlowController() = default;
 
     virtual std::string type() const {
         return "MassFlowController";
@@ -63,7 +63,7 @@ public:
 class PressureController : public FlowDevice
 {
 public:
-    PressureController();
+    PressureController() = default;
 
     virtual std::string type() const {
         return "PressureController";
@@ -104,7 +104,7 @@ public:
     virtual void updateMassFlowRate(double time);
 
 protected:
-    FlowDevice* m_master;
+    FlowDevice* m_master = nullptr;
 };
 
 //! Supply a mass flow rate that is a function of the pressure drop across the
@@ -117,7 +117,7 @@ protected:
 class Valve : public FlowDevice
 {
 public:
-    Valve();
+    Valve() = default;
 
     virtual std::string type() const {
         return "Valve";

--- a/samples/cxx/CMakeLists.txt.in
+++ b/samples/cxx/CMakeLists.txt.in
@@ -2,7 +2,7 @@ cmake_minimum_required(VERSION 3.1)
 project (@tmpl_progname@)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)
-set(CMAKE_CXX_STANDARD 14)
+set(CMAKE_CXX_STANDARD 17)
 
 find_package(Threads REQUIRED)
 @cmake_extra@

--- a/samples/f77/demo_ftnlib.cpp
+++ b/samples/f77/demo_ftnlib.cpp
@@ -36,7 +36,6 @@
 #include <iostream>
 
 using namespace Cantera;
-using std::string;
 
 // store a pointer to a Solution object
 // provides access to the pointers for functions in other libraries

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -562,11 +562,6 @@ std::unordered_map<std::string, std::vector<std::string>> AnyMap::s_tailFields;
 
 // Methods of class AnyBase
 
-AnyBase::AnyBase()
-    : m_line(-1)
-    , m_column(0)
-{}
-
 void AnyBase::setLoc(int line, int column)
 {
     m_line = line;

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -1343,9 +1343,7 @@ AnyValue& AnyMap::operator[](const std::string& key)
     const auto& iter = m_data.find(key);
     if (iter == m_data.end()) {
         // Create a new key to return
-        // NOTE: 'insert' can be replaced with 'emplace' after support for
-        // G++ 4.7 is dropped.
-        AnyValue& value = m_data.insert({key, AnyValue()}).first->second;
+        AnyValue& value = m_data.emplace(key, AnyValue()).first->second;
         value.setKey(key);
         if (m_metadata) {
             value.propagateMetadata(m_metadata);
@@ -1376,9 +1374,7 @@ const AnyValue& AnyMap::operator[](const std::string& key) const
 
 AnyValue& AnyMap::createForYaml(const std::string& key, int line, int column)
 {
-    // NOTE: 'insert' can be replaced with 'emplace' after support for
-    // G++ 4.7 is dropped.
-    AnyValue& value = m_data.insert({key, AnyValue()}).first->second;
+    AnyValue& value = m_data.emplace(key, AnyValue()).first->second;
     value.setKey(key);
     if (m_metadata) {
         value.propagateMetadata(m_metadata);

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -607,7 +607,7 @@ AnyValue& AnyValue::operator=(AnyValue const& other) {
     }
     AnyBase::operator=(other);
     m_key = other.m_key;
-    m_value.reset(new boost::any{*other.m_value});
+    m_value = make_unique<boost::any>(*other.m_value);
     m_equals = other.m_equals;
     return *this;
 }
@@ -1560,7 +1560,8 @@ AnyMap::OrderedProxy::OrderedProxy(const AnyMap& data)
 {
     // Units always come first
     if (m_data->hasKey("__units__") && m_data->at("__units__").as<AnyMap>().size()) {
-        m_units.reset(new std::pair<const string, AnyValue>{"units", m_data->at("__units__")});
+        m_units = make_unique<pair<const string, AnyValue>>(
+            "units", m_data->at("__units__"));
         m_units->second.setFlowStyle();
         m_ordered.emplace_back(std::pair<int, int>{-2, 0}, m_units.get());
     }
@@ -1672,7 +1673,7 @@ void AnyMap::applyUnits(shared_ptr<UnitSystem>& units) {
         m_data.erase("units");
     }
     if (hasKey("__units__")) {
-        m_units.reset(new UnitSystem(*units));
+        m_units = make_shared<UnitSystem>(*units);
         m_units->setDefaults(m_data["__units__"].asMap<std::string>());
     } else {
         m_units = units;
@@ -1691,7 +1692,7 @@ void AnyMap::setUnits(const UnitSystem& units)
     } else {
         m_data["__units__"] = units.getDelta(*m_units);
     }
-    m_units.reset(new UnitSystem(units));
+    m_units = make_shared<UnitSystem>(units);
 }
 
 void AnyMap::setFlowStyle(bool flow) {

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -554,7 +554,8 @@ struct convert<Cantera::AnyValue> {
 
 namespace Cantera {
 
-std::unordered_map<std::string, std::pair<AnyMap, int>> AnyMap::s_cache;
+std::unordered_map<string,
+                   pair<AnyMap, std::filesystem::file_time_type>> AnyMap::s_cache;
 
 std::unordered_map<std::string, std::vector<std::string>> AnyMap::s_headFields;
 std::unordered_map<std::string, std::vector<std::string>> AnyMap::s_tailFields;
@@ -1764,7 +1765,7 @@ AnyMap AnyMap::fromYamlFile(const std::string& name,
 
     // Check for an already-parsed YAML file with the same last-modified time,
     // and return that if possible
-    int mtime = get_modified_time(fullName);
+    auto mtime = std::filesystem::last_write_time(fullName);
     std::unique_lock<std::mutex> lock(yaml_cache_mutex);
     auto iter = s_cache.find(fullName);
     if (iter != s_cache.end() && iter->second.second == mtime) {

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -15,8 +15,6 @@
 #include <unordered_set>
 
 namespace ba = boost::algorithm;
-using std::vector;
-using std::string;
 
 namespace { // helper functions
 

--- a/src/base/Array.cpp
+++ b/src/base/Array.cpp
@@ -11,12 +11,6 @@
 namespace Cantera
 {
 
-Array2D::Array2D()
-    : m_nrows(0)
-    , m_ncols(0)
-{
-}
-
 Array2D::Array2D(const size_t m, const size_t n, const double v)
     : m_nrows(m)
     , m_ncols(n)

--- a/src/base/ExtensionManager.cpp
+++ b/src/base/ExtensionManager.cpp
@@ -6,8 +6,6 @@
 #include "cantera/base/ExtensionManager.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/base/ExtensionManagerFactory.cpp
+++ b/src/base/ExtensionManagerFactory.cpp
@@ -13,10 +13,6 @@ namespace Cantera
 ExtensionManagerFactory* ExtensionManagerFactory::s_factory = 0;
 mutex ExtensionManagerFactory::s_mutex;
 
-ExtensionManagerFactory::ExtensionManagerFactory()
-{
-}
-
 ExtensionManagerFactory& ExtensionManagerFactory::factory()
 {
     unique_lock<mutex> lock(s_mutex);

--- a/src/base/Interface.cpp
+++ b/src/base/Interface.cpp
@@ -10,9 +10,6 @@
 namespace Cantera
 {
 
-using std::string;
-using std::vector;
-
 void Interface::setThermo(shared_ptr<ThermoPhase> thermo) {
     Solution::setThermo(thermo);
     auto surf = std::dynamic_pointer_cast<SurfPhase>(thermo);

--- a/src/base/Interface.cpp
+++ b/src/base/Interface.cpp
@@ -13,8 +13,6 @@ namespace Cantera
 using std::string;
 using std::vector;
 
-Interface::Interface() {}
-
 void Interface::setThermo(shared_ptr<ThermoPhase> thermo) {
     Solution::setThermo(thermo);
     auto surf = std::dynamic_pointer_cast<SurfPhase>(thermo);

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -318,13 +318,12 @@ shared_ptr<Solution> newSolution(const AnyMap& phaseNode,
 
     // save root-level information (YAML header)
     AnyMap header;
-    for (const auto& item : rootNode.ordered()) {
-        std::string key = item.first;
+    for (const auto& [key, value] : rootNode.ordered()) {
         if (key == "phases") {
             // header ends with "phases" field
             break;
         } else if (key != "units") {
-            header[key] = item.second;
+            header[key] = value;
         }
     }
     sol->header() = header;

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -17,6 +17,8 @@
 #include "cantera/transport/TransportFactory.h"
 #include "cantera/base/stringUtils.h"
 
+#include <boost/algorithm/string.hpp>
+
 namespace Cantera
 {
 

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -20,8 +20,6 @@
 namespace Cantera
 {
 
-Solution::Solution() {}
-
 std::string Solution::name() const {
     if (m_thermo) {
         return m_thermo->name();

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -12,7 +12,7 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/thermo/SurfPhase.h"
-#include <boost/algorithm/string/predicate.hpp>
+#include <boost/algorithm/string.hpp>
 #include <set>
 #include <fstream>
 

--- a/src/base/Storage.cpp
+++ b/src/base/Storage.cpp
@@ -51,9 +51,9 @@ namespace Cantera
 Storage::Storage(std::string fname, bool write) : m_write(write)
 {
     if (m_write) {
-        m_file.reset(new h5::File(fname, h5::File::OpenOrCreate));
+        m_file = make_unique<h5::File>(fname, h5::File::OpenOrCreate);
     } else {
-        m_file.reset(new h5::File(fname, h5::File::ReadOnly));
+        m_file = make_unique<h5::File>(fname, h5::File::ReadOnly);
     }
 }
 

--- a/src/base/Storage.cpp
+++ b/src/base/Storage.cpp
@@ -221,65 +221,65 @@ AnyMap Storage::readAttributes(const std::string& id, bool recursive) const
 
 void writeH5Attributes(h5::Group sub, const AnyMap& meta)
 {
-    for (auto& item : meta) {
-        if (sub.hasAttribute(item.first)) {
+    for (auto& [name, item] : meta) {
+        if (sub.hasAttribute(name)) {
             throw NotImplementedError("writeH5Attributes",
-                "Unable to overwrite existing Attribute '{}'", item.first);
+                "Unable to overwrite existing Attribute '{}'", name);
         }
-        if (item.second.is<double>()) {
-            double value = item.second.asDouble();
+        if (item.is<double>()) {
+            double value = item.asDouble();
             h5::Attribute attr = sub.createAttribute<double>(
-                item.first, h5::DataSpace::From(value));
+                name, h5::DataSpace::From(value));
             attr.write(value);
-        } else if (item.second.is<int>() || item.second.is<long int>()) {
-            int value = item.second.asInt();
+        } else if (item.is<int>() || item.is<long int>()) {
+            int value = item.asInt();
             h5::Attribute attr = sub.createAttribute<int>(
-                item.first, h5::DataSpace::From(value));
+                name, h5::DataSpace::From(value));
             attr.write(value);
-        } else if (item.second.is<std::string>()) {
-            std::string value = item.second.asString();
-            h5::Attribute attr = sub.createAttribute<std::string>(
-                item.first, h5::DataSpace::From(value));
+        } else if (item.is<string>()) {
+            string value = item.asString();
+            h5::Attribute attr = sub.createAttribute<string>(
+                name, h5::DataSpace::From(value));
             attr.write(value);
-        } else if (item.second.is<bool>()) {
-            bool bValue = item.second.asBool();
+        } else if (item.is<bool>()) {
+            bool bValue = item.asBool();
             H5Boolean value = bValue ? H5Boolean::TRUE : H5Boolean::FALSE;
             h5::Attribute attr = sub.createAttribute<H5Boolean>(
-                item.first, h5::DataSpace::From(value));
+                name, h5::DataSpace::From(value));
             attr.write(value);
-        } else if (item.second.is<std::vector<double>>()) {
-            auto values = item.second.as<std::vector<double>>();
+        } else if (item.is<vector<double>>()) {
+            auto values = item.as<vector<double>>();
             h5::Attribute attr = sub.createAttribute<double>(
-                item.first, h5::DataSpace::From(values));
+                name, h5::DataSpace::From(values));
             attr.write(values);
-        } else if (item.second.is<std::vector<int>>()) {
-            auto values = item.second.as<std::vector<int>>();
+        } else if (item.is<vector<int>>()) {
+            auto values = item.as<vector<int>>();
             h5::Attribute attr = sub.createAttribute<int>(
-                item.first, h5::DataSpace::From(values));
+                name, h5::DataSpace::From(values));
             attr.write(values);
-        } else if (item.second.is<std::vector<std::string>>()) {
-            auto values = item.second.as<std::vector<std::string>>();
-            h5::Attribute attr = sub.createAttribute<std::string>(
-                item.first, h5::DataSpace::From(values));
+        } else if (item.is<vector<string>>()) {
+            auto values = item.as<vector<string>>();
+            h5::Attribute attr = sub.createAttribute<string>(
+                name, h5::DataSpace::From(values));
             attr.write(values);
-        } else if (item.second.is<std::vector<bool>>()) {
-            auto bValue = item.second.as<std::vector<bool>>();
-            std::vector<H5Boolean> values;
+        } else if (item.is<vector<bool>>()) {
+            auto bValue = item.as<vector<bool>>();
+            vector<H5Boolean> values;
             for (auto b : bValue) {
                 values.push_back(b ? H5Boolean::TRUE : H5Boolean::FALSE);
             }
             h5::Attribute attr = sub.createAttribute<H5Boolean>(
-                item.first, h5::DataSpace::From(values));
+                name, h5::DataSpace::From(values));
             attr.write(values);
-        } else if (item.second.is<AnyMap>()) {
+        } else if (item.is<AnyMap>()) {
             // step into recursion
-            auto value = item.second.as<AnyMap>();
-            auto grp = sub.createGroup(item.first);
+            auto value = item.as<AnyMap>();
+            auto grp = sub.createGroup(name);
             writeH5Attributes(grp, value);
         } else {
             throw NotImplementedError("writeH5Attributes",
                 "Unable to write attribute '{}' with type '{}'",
-                item.first, item.second.type_str());
+                name, item.type_str());
         }
     }
 }

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -115,8 +115,6 @@ Units::Units(double factor, double mass, double length, double time,
     , m_temperature_dim(temperature)
     , m_current_dim(current)
     , m_quantity_dim(quantity)
-    , m_pressure_dim(0)
-    , m_energy_dim(0)
 {
     if (mass != 0 && length == -mass && time == -2 * mass
         && temperature == 0 && current == 0 && quantity == 0) {
@@ -131,15 +129,6 @@ Units::Units(double factor, double mass, double length, double time,
 }
 
 Units::Units(const std::string& name, bool force_unity)
-    : m_factor(1.0)
-    , m_mass_dim(0)
-    , m_length_dim(0)
-    , m_time_dim(0)
-    , m_temperature_dim(0)
-    , m_current_dim(0)
-    , m_quantity_dim(0)
-    , m_pressure_dim(0)
-    , m_energy_dim(0)
 {
     size_t start = 0;
 
@@ -402,14 +391,6 @@ Units UnitStack::product() const
 }
 
 UnitSystem::UnitSystem(std::initializer_list<std::string> units)
-    : m_mass_factor(1.0)
-    , m_length_factor(1.0)
-    , m_time_factor(1.0)
-    , m_pressure_factor(1.0)
-    , m_energy_factor(1.0)
-    , m_activation_energy_factor(1.0)
-    , m_quantity_factor(1.0)
-    , m_explicit_activation_energy(false)
 {
     setDefaults(units);
 }

--- a/src/base/YamlWriter.cpp
+++ b/src/base/YamlWriter.cpp
@@ -11,7 +11,6 @@
 #include "cantera/kinetics/Reaction.h"
 #include "cantera/transport/Transport.h"
 
-#include <set>
 #include <fstream>
 #include <chrono>
 

--- a/src/base/YamlWriter.cpp
+++ b/src/base/YamlWriter.cpp
@@ -17,12 +17,6 @@
 
 namespace Cantera {
 
-YamlWriter::YamlWriter()
-    : m_float_precision(15)
-    , m_skip_user_defined(false)
-{
-}
-
 void YamlWriter::setHeader(const AnyMap& header) {
     m_header = header;
 }

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -109,13 +109,7 @@ void Application::ThreadMessages::removeThreadMessages()
     }
 }
 
-Application::Application() :
-    m_suppress_deprecation_warnings(false),
-    m_fatal_deprecation_warnings(false),
-    m_suppress_thermo_warnings(false),
-    m_suppress_warnings(false),
-    m_fatal_warnings(false),
-    m_use_legacy_rate_constants(false)
+Application::Application()
 {
     // install a default logwriter that writes to standard
     // output / standard error

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -39,7 +39,7 @@ Application::Messages::Messages()
 {
     // install a default logwriter that writes to standard
     // output / standard error
-    logwriter.reset(new Logger());
+    logwriter = make_unique<Logger>();
 }
 
 void Application::Messages::addError(const std::string& r, const std::string& msg)

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -22,8 +22,6 @@ namespace ba = boost::algorithm;
 
 #ifdef _WIN32
 #include <windows.h>
-#else
-#include <sys/stat.h>
 #endif
 
 #ifdef _MSC_VER
@@ -38,24 +36,6 @@ static std::mutex dir_mutex;
 
 //! Mutex for creating singletons within the application object
 static std::mutex app_mutex;
-
-int get_modified_time(const std::string& path) {
-#ifdef _WIN32
-    HANDLE hFile = CreateFile(path.c_str(), 0, 0,
-                              NULL, OPEN_EXISTING, 0, NULL);
-    if (hFile == INVALID_HANDLE_VALUE) {
-        throw CanteraError("get_modified_time", "Couldn't open file:" + path);
-    }
-    FILETIME modified;
-    GetFileTime(hFile, NULL, NULL, &modified);
-    CloseHandle(hFile);
-    return static_cast<int>(modified.dwLowDateTime);
-#else
-    struct stat attrib;
-    stat(path.c_str(), &attrib);
-    return static_cast<int>(attrib.st_mtime);
-#endif
-}
 
 Application::Messages::Messages()
 {

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -16,8 +16,6 @@
 #include <sstream>
 #include <mutex>
 
-using std::string;
-using std::endl;
 namespace ba = boost::algorithm;
 
 #ifdef _WIN32
@@ -204,7 +202,7 @@ std::string Application::Messages::lastErrorMessage()
 void Application::Messages::getErrors(std::ostream& f)
 {
     for (size_t j = 0; j < errorMessage.size(); j++) {
-        f << errorMessage[j] << endl;
+        f << errorMessage[j] << std::endl;
     }
     errorMessage.clear();
 }

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -11,7 +11,6 @@
 
 #include <boost/algorithm/string/join.hpp>
 
-#include <set>
 #include <thread>
 
 namespace Cantera

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -443,12 +443,12 @@ protected:
     //! duplicates)
     std::set<std::string> warnings;
 
-    bool m_suppress_deprecation_warnings;
-    bool m_fatal_deprecation_warnings;
-    bool m_suppress_thermo_warnings;
-    bool m_suppress_warnings;
-    bool m_fatal_warnings;
-    bool m_use_legacy_rate_constants;
+    bool m_suppress_deprecation_warnings = false;
+    bool m_fatal_deprecation_warnings = false;
+    bool m_suppress_thermo_warnings = false;
+    bool m_suppress_warnings = false;
+    bool m_fatal_warnings = false;
+    bool m_use_legacy_rate_constants = false;
 
     std::set<std::pair<std::string, std::string>> m_loaded_extensions;
 

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -17,8 +17,6 @@
 namespace Cantera
 {
 
-int get_modified_time(const std::string& path);
-
 /*!
  * @defgroup globalData Global Data
  *

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -10,8 +10,6 @@
   #include <boost/core/demangle.hpp>
 #endif
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1657,7 +1657,7 @@ extern "C" {
     {
         static unique_ptr<Logger> logwriter;
         try {
-            logwriter.reset(new ExternalLogger(writer));
+            logwriter = make_unique<ExternalLogger>(writer);
             setLogger(logwriter.get());
             return 0;
         } catch (...) {

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -25,7 +25,6 @@
 #include "cantera/thermo/PureFluidPhase.h"
 #include "cantera/base/ExternalLogger.h"
 
-using namespace std;
 using namespace Cantera;
 
 typedef SharedCabinet<ThermoPhase> ThermoCabinet;

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -14,7 +14,6 @@
 #include "clib_utils.h"
 
 using namespace Cantera;
-using namespace std;
 
 typedef Func1 func_t;
 

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -12,7 +12,6 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "clib_utils.h"
 
-using namespace std;
 using namespace Cantera;
 
 typedef Cabinet<MultiPhase> mixCabinet;

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -15,7 +15,6 @@
 #include "clib_utils.h"
 
 using namespace Cantera;
-using namespace std;
 
 typedef Cabinet<ReactorBase> ReactorCabinet;
 typedef Cabinet<ReactorNet> NetworkCabinet;

--- a/src/clib/ctsurf.cpp
+++ b/src/clib/ctsurf.cpp
@@ -12,7 +12,6 @@
 #include "cantera/thermo/SurfPhase.h"
 #include "clib_utils.h"
 
-using namespace std;
 using namespace Cantera;
 
 typedef SharedCabinet<ThermoPhase> ThermoCabinet;

--- a/src/equil/BasisOptimize.cpp
+++ b/src/equil/BasisOptimize.cpp
@@ -10,8 +10,6 @@
 #include "cantera/base/utilities.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 int BasisOptimize_print_lvl = 0;

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -42,24 +42,9 @@ int _equilflag(const char* xy)
     return -1;
 }
 
-ChemEquil::ChemEquil() : m_skip(npos), m_elementTotalSum(1.0),
-    m_p0(OneAtm), m_eloc(npos),
-    m_elemFracCutoff(1.0E-100),
-    m_doResPerturb(false)
-{}
-
-ChemEquil::ChemEquil(ThermoPhase& s) :
-    m_skip(npos),
-    m_elementTotalSum(1.0),
-    m_p0(OneAtm), m_eloc(npos),
-    m_elemFracCutoff(1.0E-100),
-    m_doResPerturb(false)
+ChemEquil::ChemEquil(ThermoPhase& s)
 {
     initialize(s);
-}
-
-ChemEquil::~ChemEquil()
-{
 }
 
 void ChemEquil::initialize(ThermoPhase& s)

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -14,8 +14,6 @@
 #include "cantera/base/utilities.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -20,18 +20,6 @@ using namespace std;
 namespace Cantera
 {
 
-MultiPhase::MultiPhase() :
-    m_temp(298.15),
-    m_press(OneBar),
-    m_nel(0),
-    m_nsp(0),
-    m_init(false),
-    m_eloc(npos),
-    m_Tmin(1.0),
-    m_Tmax(100000.0)
-{
-}
-
 void MultiPhase::addPhases(MultiPhase& mix)
 {
     for (size_t n = 0; n < mix.nPhases(); n++) {

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -602,8 +602,7 @@ void MultiPhaseEquil::computeN()
     std::vector<std::pair<double, size_t> > moleFractions(m_nsp);
     for (size_t k = 0; k < m_nsp; k++) {
         // use -Xk to generate reversed sort order
-        moleFractions[k].first = - m_mix->speciesMoles(m_species[k]);
-        moleFractions[k].second = k;
+        moleFractions[k] = {-m_mix->speciesMoles(m_species[k]), k};
     }
     std::sort(moleFractions.begin(), moleFractions.end());
     for (size_t k = 0; k < m_nsp; k++) {

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -12,8 +12,6 @@
 #include <cstdio>
 #include <numeric>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -25,10 +25,6 @@ MultiPhaseEquil::MultiPhaseEquil(MultiPhase* mix, bool start, int loglevel) : m_
     m_press = mix->pressure();
     m_temp = mix->temperature();
 
-    m_force = true;
-    m_nel = 0;
-    m_nsp = 0;
-    m_eloc = 1000;
     m_incl_species.resize(m_nsp_mix,1);
     m_incl_element.resize(m_nel_mix,1);
     for (size_t m = 0; m < m_nel_mix; m++) {

--- a/src/equil/vcs_MultiPhaseEquil.cpp
+++ b/src/equil/vcs_MultiPhaseEquil.cpp
@@ -17,8 +17,6 @@
 
 #include <cstdio>
 
-using namespace std;
-
 namespace Cantera
 {
 vcs_MultiPhaseEquil::vcs_MultiPhaseEquil(MultiPhase* mix, int printLvl) :

--- a/src/equil/vcs_VolPhase.cpp
+++ b/src/equil/vcs_VolPhase.cpp
@@ -18,37 +18,8 @@ namespace Cantera
 {
 
 vcs_VolPhase::vcs_VolPhase(VCS_SOLVE* owningSolverObject) :
-    m_owningSolverObject(0),
-    VP_ID_(npos),
-    m_singleSpecies(true),
-    m_gasPhase(false),
-    m_eqnState(VCS_EOS_CONSTANT),
-    ChargeNeutralityElement(npos),
-    p_activityConvention(0),
-    m_numElemConstraints(0),
-    m_elemGlobalIndex(0),
-    m_numSpecies(0),
-    m_totalMolesInert(0.0),
-    m_isIdealSoln(false),
-    m_existence(VCS_PHASE_EXIST_NO),
-    m_MFStartIndex(0),
-    IndSpecies(0),
-    TP_ptr(0),
-    v_totalMoles(0.0),
-    m_phiVarIndex(npos),
-    m_totalVol(0.0),
-    m_vcsStateStatus(VCS_STATECALC_OLD),
-    m_phi(0.0),
-    m_UpToDate(false),
-    m_UpToDate_AC(false),
-    m_UpToDate_VolStar(false),
-    m_UpToDate_VolPM(false),
-    m_UpToDate_GStar(false),
-    m_UpToDate_G0(false),
-    Temp_(273.15),
-    Pres_(1.01325E5)
+    m_owningSolverObject(owningSolverObject)
 {
-    m_owningSolverObject = owningSolverObject;
 }
 
 vcs_VolPhase::~vcs_VolPhase()

--- a/src/equil/vcs_solve.cpp
+++ b/src/equil/vcs_solve.cpp
@@ -44,27 +44,12 @@ VCS_SOLVE::VCS_SOLVE(MultiPhase* mphase, int printLvl) :
     m_printLvl(printLvl),
     m_mix(mphase),
     m_nsp(mphase->nSpecies()),
-    m_nelem(0),
-    m_numComponents(0),
-    m_numRxnTot(0),
     m_numSpeciesRdc(mphase->nSpecies()),
-    m_numRxnRdc(0),
-    m_numRxnMinorZeroed(0),
     m_numPhases(mphase->nPhases()),
-    m_doEstimateEquil(-1),
-    m_totalMolNum(0.0),
     m_temperature(mphase->temperature()),
     m_pressurePA(mphase->pressure()),
-    m_tolmaj(1.0E-8),
-    m_tolmin(1.0E-6),
-    m_tolmaj2(1.0E-10),
-    m_tolmin2(1.0E-8),
-    m_useActCoeffJac(0),
     m_totalVol(mphase->volume()),
-    m_Faraday_dim(Faraday / (m_temperature * GasConstant)),
-    m_VCount(0),
-    m_debug_print_lvl(0),
-    m_timing_print_lvl(1)
+    m_Faraday_dim(Faraday / (m_temperature * GasConstant))
 {
     m_speciesThermoList.resize(m_nsp);
     for (size_t kspec = 0; kspec < m_nsp; kspec++) {

--- a/src/equil/vcs_solve.cpp
+++ b/src/equil/vcs_solve.cpp
@@ -53,7 +53,7 @@ VCS_SOLVE::VCS_SOLVE(MultiPhase* mphase, int printLvl) :
 {
     m_speciesThermoList.resize(m_nsp);
     for (size_t kspec = 0; kspec < m_nsp; kspec++) {
-        m_speciesThermoList[kspec].reset(new VCS_SPECIES_THERMO());
+        m_speciesThermoList[kspec] = make_unique<VCS_SPECIES_THERMO>();
     }
 
     string ser = "VCS_SOLVE: ERROR:\n\t";
@@ -123,7 +123,7 @@ VCS_SOLVE::VCS_SOLVE(MultiPhase* mphase, int printLvl) :
     // Phase Info
     m_VolPhaseList.resize(m_numPhases);
     for (size_t iph = 0; iph < m_numPhases; iph++) {
-        m_VolPhaseList[iph].reset(new vcs_VolPhase(this));
+        m_VolPhaseList[iph] = make_unique<vcs_VolPhase>(this);
     }
 
     // For Future expansion

--- a/src/equil/vcs_util.cpp
+++ b/src/equil/vcs_util.cpp
@@ -13,8 +13,6 @@
 #include <cassert>
 #include <cstring>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/kinetics/BlowersMaselRate.cpp
+++ b/src/kinetics/BlowersMaselRate.cpp
@@ -11,13 +11,6 @@
 namespace Cantera
 {
 
-BlowersMaselData::BlowersMaselData()
-    : ready(false)
-    , density(NAN)
-    , m_state_mf_number(-1)
-{
-}
-
 void BlowersMaselData::update(double T) {
     warn_user("BlowersMaselData::update",
         "This method does not update the change of reaction enthalpy.");
@@ -44,7 +37,6 @@ bool BlowersMaselData::update(const ThermoPhase& phase, const Kinetics& kin)
 }
 
 BlowersMaselRate::BlowersMaselRate()
-    : m_deltaH_R(0.)
 {
     m_Ea_str = "Ea0";
     m_E4_str = "w";
@@ -52,7 +44,6 @@ BlowersMaselRate::BlowersMaselRate()
 
 BlowersMaselRate::BlowersMaselRate(double A, double b, double Ea0, double w)
     : ArrheniusBase(A, b, Ea0)
-    , m_deltaH_R(0.)
 {
     m_Ea_str = "Ea0";
     m_E4_str = "w";

--- a/src/kinetics/BlowersMaselRate.cpp
+++ b/src/kinetics/BlowersMaselRate.cpp
@@ -76,11 +76,11 @@ double BlowersMaselRate::ddTScaledFromStruct(const BlowersMaselData& shared_data
 void BlowersMaselRate::setContext(const Reaction& rxn, const Kinetics& kin)
 {
     m_stoich_coeffs.clear();
-    for (const auto& sp : rxn.reactants) {
-        m_stoich_coeffs.emplace_back(kin.kineticsSpeciesIndex(sp.first), -sp.second);
+    for (const auto& [name, stoich] : rxn.reactants) {
+        m_stoich_coeffs.emplace_back(kin.kineticsSpeciesIndex(name), -stoich);
     }
-    for (const auto& sp : rxn.products) {
-        m_stoich_coeffs.emplace_back(kin.kineticsSpeciesIndex(sp.first), sp.second);
+    for (const auto& [name, stoich] : rxn.products) {
+        m_stoich_coeffs.emplace_back(kin.kineticsSpeciesIndex(name), stoich);
     }
 }
 

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -8,12 +8,6 @@
 namespace Cantera
 {
 
-BulkKinetics::BulkKinetics()
-    : m_ROP_ok(false)
-    , m_temp(0.0)
-{
-}
-
 BulkKinetics::BulkKinetics(ThermoPhase* thermo) : BulkKinetics()
 {
     warn_deprecated("BulkKinetics::BulkKinetics(ThermoPhase*)",

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -124,11 +124,11 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
         return false;
     }
     double dn = 0.0;
-    for (const auto& sp : r->products) {
-        dn += sp.second;
+    for (const auto& [name, stoich] : r->products) {
+        dn += stoich;
     }
-    for (const auto& sp : r->reactants) {
-        dn -= sp.second;
+    for (const auto& [name, stoich] : r->reactants) {
+        dn -= stoich;
     }
 
     m_dn.push_back(dn);
@@ -174,14 +174,14 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
 void BulkKinetics::addThirdBody(shared_ptr<Reaction> r)
 {
     std::map<size_t, double> efficiencies;
-    for (const auto& eff : r->thirdBody()->efficiencies) {
-        size_t k = kineticsSpeciesIndex(eff.first);
+    for (const auto& [name, efficiency] : r->thirdBody()->efficiencies) {
+        size_t k = kineticsSpeciesIndex(name);
         if (k != npos) {
-            efficiencies[k] = eff.second;
+            efficiencies[k] = efficiency;
         } else if (!m_skipUndeclaredThirdBodies) {
-            throw CanteraError("BulkKinetics::addThirdBody", "Found "
-                "third-body efficiency for undefined species '" + eff.first +
-                "' while adding reaction '" + r->equation() + "'");
+            throw CanteraError("BulkKinetics::addThirdBody", "Found third-body"
+                " efficiency for undefined species '{}' while adding reaction '{}'",
+                name, r->equation());
         }
     }
     m_multi_concm.install(nReactions() - 1, efficiencies,

--- a/src/kinetics/Custom.cpp
+++ b/src/kinetics/Custom.cpp
@@ -9,11 +9,6 @@
 namespace Cantera
 {
 
-CustomFunc1Rate::CustomFunc1Rate()
-    : m_ratefunc(0)
-{
-}
-
 CustomFunc1Rate::CustomFunc1Rate(const AnyMap& node, const UnitStack& rate_units)
     : CustomFunc1Rate()
 {

--- a/src/kinetics/Falloff.cpp
+++ b/src/kinetics/Falloff.cpp
@@ -18,10 +18,6 @@ namespace Cantera
 {
 
 FalloffData::FalloffData()
-    : ready(false)
-    , molar_density(NAN)
-    , m_state_mf_number(-1)
-    , m_perturbed(false)
 {
     conc_3b.resize(1, NAN);
     m_conc_3b_buf.resize(1, NAN);

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -14,9 +14,6 @@ namespace Cantera
 {
 
 GasKinetics::GasKinetics()
-    : BulkKinetics()
-    , m_logStandConc(0.0)
-    , m_pres(0.0)
 {
     setDerivativeSettings(AnyMap()); // use default settings
 }

--- a/src/kinetics/GasKinetics.cpp
+++ b/src/kinetics/GasKinetics.cpp
@@ -8,8 +8,6 @@
 #include "cantera/kinetics/GasKinetics.h"
 #include "cantera/thermo/ThermoPhase.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -12,8 +12,6 @@
 #include "cantera/kinetics/solveSP.h"
 #include "cantera/thermo/SurfPhase.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -21,19 +21,11 @@ ImplicitSurfChem::ImplicitSurfChem(
         vector<InterfaceKinetics*> k, double rtol, double atol,
         double maxStepSize, size_t maxSteps,
         size_t maxErrTestFails) :
-    m_nv(0),
-    m_numTotalBulkSpecies(0),
-    m_numTotalSpecies(0),
     m_atol(atol),
     m_rtol(rtol),
     m_maxstep(maxStepSize),
     m_nmax(maxSteps),
-    m_maxErrTestFails(maxErrTestFails),
-    m_mediumSpeciesStart(-1),
-    m_bulkSpeciesStart(-1),
-    m_surfSpeciesStart(-1),
-    m_commonTempPressForPhases(true),
-    m_ioFlag(0)
+    m_maxErrTestFails(maxErrTestFails)
 {
     size_t ntmax = 0;
     size_t kinSpIndex = 0;

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -189,7 +189,7 @@ void ImplicitSurfChem::solvePseudoSteadyStateProblem(int ifuncOverride,
     // time scale - time over which to integrate equations
     doublereal time_scale = timeScaleOverride;
     if (!m_surfSolver) {
-        m_surfSolver.reset(new solveSP(this, bulkFunc));
+        m_surfSolver = make_unique<solveSP>(this, bulkFunc);
         // set ifunc, which sets the algorithm.
         ifunc = SFLUX_INITIALIZE;
     } else {

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -16,18 +16,6 @@ using namespace std;
 namespace Cantera
 {
 
-InterfaceKinetics::InterfaceKinetics()
-    : m_redo_rates(false)
-    , m_surf(0)
-    , m_integrator(0)
-    , m_ROP_ok(false)
-    , m_temp(0.0)
-    , m_phaseExistsCheck(false)
-    , m_ioFlag(0)
-    , m_nDim(2)
-{
-}
-
 InterfaceKinetics::InterfaceKinetics(ThermoPhase* thermo)
     : InterfaceKinetics()
 {

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -11,8 +11,6 @@
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -417,13 +417,13 @@ bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base, bool resize)
     m_rxnPhaseIsReactant.emplace_back(nPhases(), false);
     m_rxnPhaseIsProduct.emplace_back(nPhases(), false);
 
-    for (const auto& sp : r_base->reactants) {
-        size_t k = kineticsSpeciesIndex(sp.first);
+    for (const auto& [name, stoich] : r_base->reactants) {
+        size_t k = kineticsSpeciesIndex(name);
         size_t p = speciesPhaseIndex(k);
         m_rxnPhaseIsReactant[i][p] = true;
     }
-    for (const auto& sp : r_base->products) {
-        size_t k = kineticsSpeciesIndex(sp.first);
+    for (const auto& [name, stoich] : r_base->products) {
+        size_t k = kineticsSpeciesIndex(name);
         size_t p = speciesPhaseIndex(k);
         m_rxnPhaseIsProduct[i][p] = true;
     }

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -145,20 +145,20 @@ void InterfaceRateBase::setCoverageDependencies(const AnyMap& dependencies,
     m_ac.clear();
     m_ec.clear();
     m_mc.clear();
-    for (const auto& item : dependencies) {
+    for (const auto& [species, coeffs] : dependencies) {
         double a, E, m;
-        if (item.second.is<AnyMap>()) {
-            auto& cov_map = item.second.as<AnyMap>();
+        if (coeffs.is<AnyMap>()) {
+            auto& cov_map = coeffs.as<AnyMap>();
             a = cov_map["a"].asDouble();
             m = cov_map["m"].asDouble();
             E = units.convertActivationEnergy(cov_map["E"], "K");
         } else {
-            auto& cov_vec = item.second.asVector<AnyValue>(3);
+            auto& cov_vec = coeffs.asVector<AnyValue>(3);
             a = cov_vec[0].asDouble();
             m = cov_vec[1].asDouble();
             E = units.convertActivationEnergy(cov_vec[2], "K");
         }
-        addCoverageDependence(item.first, a, m, E);
+        addCoverageDependence(species, a, m, E);
     }
 }
 
@@ -229,18 +229,18 @@ void InterfaceRateBase::updateFromStruct(const InterfaceData& shared_data) {
     m_acov = 0.0;
     m_ecov = 0.0;
     m_mcov = 0.0;
-    for (auto& item : m_indices) {
-        m_acov += m_ac[item.first] * shared_data.coverages[item.second];
-        m_ecov += m_ec[item.first] * shared_data.coverages[item.second];
-        m_mcov += m_mc[item.first] * shared_data.logCoverages[item.second];
+    for (auto& [iCov, iKin] : m_indices) {
+        m_acov += m_ac[iCov] * shared_data.coverages[iKin];
+        m_ecov += m_ec[iCov] * shared_data.coverages[iKin];
+        m_mcov += m_mc[iCov] * shared_data.logCoverages[iKin];
     }
 
     // Update change in electrical potential energy
     if (m_chargeTransfer) {
         m_deltaPotential_RT = 0.;
-        for (const auto& ch : m_netCharges) {
+        for (const auto& [iPhase, netCharge] : m_netCharges) {
             m_deltaPotential_RT +=
-                shared_data.electricPotentials[ch.first] * ch.second;
+                shared_data.electricPotentials[iPhase] * netCharge;
         }
         m_deltaPotential_RT /= GasConstant * shared_data.temperature;
     }
@@ -249,12 +249,12 @@ void InterfaceRateBase::updateFromStruct(const InterfaceData& shared_data) {
     if (m_exchangeCurrentDensityFormulation) {
         m_deltaGibbs0_RT = 0.;
         m_prodStandardConcentrations = 1.;
-        for (const auto& item : m_stoichCoeffs) {
+        for (const auto& [k, stoich] : m_stoichCoeffs) {
             m_deltaGibbs0_RT +=
-                shared_data.standardChemPotentials[item.first] * item.second;
-            if (item.second > 0.) {
+                shared_data.standardChemPotentials[k] * stoich;
+            if (stoich > 0.) {
                 m_prodStandardConcentrations *=
-                    shared_data.standardConcentrations[item.first];
+                    shared_data.standardConcentrations[k];
             }
         }
         m_deltaGibbs0_RT /= GasConstant * shared_data.temperature;
@@ -271,19 +271,19 @@ void InterfaceRateBase::setContext(const Reaction& rxn, const Kinetics& kin)
     }
 
     m_stoichCoeffs.clear();
-    for (const auto& sp : rxn.reactants) {
-        m_stoichCoeffs.emplace_back(kin.kineticsSpeciesIndex(sp.first), -sp.second);
+    for (const auto& [name, stoich] : rxn.reactants) {
+        m_stoichCoeffs.emplace_back(kin.kineticsSpeciesIndex(name), -stoich);
     }
-    for (const auto& sp : rxn.products) {
-        m_stoichCoeffs.emplace_back(kin.kineticsSpeciesIndex(sp.first), sp.second);
+    for (const auto& [name, stoich] : rxn.products) {
+        m_stoichCoeffs.emplace_back(kin.kineticsSpeciesIndex(name), stoich);
     }
 
     m_netCharges.clear();
-    for (const auto& sp : m_stoichCoeffs) {
-        size_t n = kin.speciesPhaseIndex(sp.first);
+    for (const auto& [k, stoich] : m_stoichCoeffs) {
+        size_t n = kin.speciesPhaseIndex(k);
         size_t start = kin.kineticsSpeciesIndex(0, n);
-        double charge = kin.thermo(n).charge(sp.first - start);
-        m_netCharges.emplace_back(n, Faraday * charge * sp.second);
+        double charge = kin.thermo(n).charge(k - start);
+        m_netCharges.emplace_back(n, Faraday * charge * stoich);
     }
 }
 
@@ -334,15 +334,15 @@ void StickingCoverage::setContext(const Reaction& rxn, const Kinetics& kin)
         // Identify the sticking species if not explicitly given
         std::vector<std::string> gasSpecies;
         std::vector<std::string> anySpecies;
-        for (const auto& sp : rxn.reactants) {
-            size_t iPhase = kin.speciesPhaseIndex(kin.kineticsSpeciesIndex(sp.first));
+        for (const auto& [name, stoich] : rxn.reactants) {
+            size_t iPhase = kin.speciesPhaseIndex(kin.kineticsSpeciesIndex(name));
             if (iPhase != iInterface) {
                 // Non-interface species. There should be exactly one of these
                 // (either in gas phase or other phase)
                 if (kin.thermo(iPhase).phaseOfMatter() == "gas") {
-                    gasSpecies.push_back(sp.first);
+                    gasSpecies.push_back(name);
                 }
-                anySpecies.push_back(sp.first);
+                anySpecies.push_back(name);
             }
         }
         if (gasSpecies.size() == 1) {
@@ -367,11 +367,11 @@ void StickingCoverage::setContext(const Reaction& rxn, const Kinetics& kin)
     double surface_order = 0.0;
     double multiplier = 1.0;
     // Adjust the A-factor
-    for (const auto& sp : rxn.reactants) {
-        size_t iPhase = kin.speciesPhaseIndex(kin.kineticsSpeciesIndex(sp.first));
+    for (const auto& [name, stoich] : rxn.reactants) {
+        size_t iPhase = kin.speciesPhaseIndex(kin.kineticsSpeciesIndex(name));
         const ThermoPhase& p = kin.thermo(iPhase);
-        size_t k = p.speciesIndex(sp.first);
-        if (sp.first == sticking_species) {
+        size_t k = p.speciesIndex(name);
+        if (name == sticking_species) {
             multiplier *= sqrt(GasConstant / (2 * Pi * p.molecularWeight(k)));
         } else {
             // Non-sticking species. Convert from coverages used in the
@@ -380,7 +380,7 @@ void StickingCoverage::setContext(const Reaction& rxn, const Kinetics& kin)
             // the dependence on the site density is incorporated when the
             // rate constant is evaluated, since we don't assume that the
             // site density is known at this time.
-            double order = getValue(rxn.orders, sp.first, sp.second);
+            double order = getValue(rxn.orders, name, stoich);
             if (&p == &surf) {
                 multiplier *= pow(surf.size(k), order);
                 surface_order += order;

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -13,11 +13,6 @@
 namespace Cantera
 {
 
-InterfaceData::InterfaceData()
-    : sqrtT(NAN)
-{
-}
-
 void InterfaceData::update(double T)
 {
     throw CanteraError("InterfaceData::update",

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -23,19 +23,6 @@ using namespace std;
 
 namespace Cantera
 {
-Kinetics::Kinetics() :
-    m_ready(false),
-    m_kk(0),
-    m_thermo(0),
-    m_surfphase(npos),
-    m_rxnphase(npos),
-    m_mindim(4),
-    m_skipUndeclaredSpecies(false),
-    m_skipUndeclaredThirdBodies(false)
-{
-}
-
-Kinetics::~Kinetics() {}
 
 void Kinetics::checkReactionIndex(size_t i) const
 {

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -12,6 +12,8 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/base/stringUtils.h"
 
+#include <boost/algorithm/string.hpp>
+
 namespace Cantera
 {
 

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -12,8 +12,6 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/base/stringUtils.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/kinetics/PlogRate.cpp
+++ b/src/kinetics/PlogRate.cpp
@@ -92,10 +92,10 @@ void PlogRate::getParameters(AnyMap& rateNode, const Units& rate_units) const
         // object not fully set up
         return;
     }
-    for (const auto& r : getRates()) {
+    for (const auto& [pressure, rate] : getRates()) {
         AnyMap rateNode_;
-        rateNode_["P"].setQuantity(r.first, "Pa");
-        r.second.getRateParameters(rateNode_);
+        rateNode_["P"].setQuantity(pressure, "Pa");
+        rate.getRateParameters(rateNode_);
         rateList.push_back(std::move(rateNode_));
     }
     rateNode["rate-constants"] = std::move(rateList);
@@ -109,8 +109,8 @@ void PlogRate::setRates(const std::multimap<double, ArrheniusRate>& rates)
     m_valid = !rates.empty();
     rates_.reserve(rates.size());
     // Insert intermediate pressures
-    for (const auto& rate : rates) {
-        double logp = std::log(rate.first);
+    for (const auto& [pressure, rate] : rates) {
+        double logp = std::log(pressure);
         if (pressures_.empty() || pressures_.rbegin()->first != logp) {
             // starting a new group
             pressures_[logp] = {j, j+1};
@@ -120,7 +120,7 @@ void PlogRate::setRates(const std::multimap<double, ArrheniusRate>& rates)
         }
 
         j++;
-        rates_.push_back(rate.second);
+        rates_.push_back(rate);
     }
     if (!m_valid) {
         // ensure that reaction rate can be evaluated (but returns NaN)

--- a/src/kinetics/PlogRate.cpp
+++ b/src/kinetics/PlogRate.cpp
@@ -50,22 +50,14 @@ void PlogData::restore()
     m_pressure_buf = -1.;
 }
 
-PlogRate::PlogRate()
-    : logP_(-1000)
-    , logP1_(1000)
-    , logP2_(-1000)
-    , rDeltaP_(-1.0)
-{
-}
+// Methods of class PlogRate
 
 PlogRate::PlogRate(const std::multimap<double, ArrheniusRate>& rates)
-    : PlogRate()
 {
     setRates(rates);
 }
 
 PlogRate::PlogRate(const AnyMap& node, const UnitStack& rate_units)
-    : PlogRate()
 {
     setParameters(node, rate_units);
 }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -18,7 +18,6 @@
 #include "cantera/base/stringUtils.h"
 #include <boost/algorithm/string/predicate.hpp>
 #include <sstream>
-#include <set>
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -282,7 +282,7 @@ void Reaction::setRate(shared_ptr<ReactionRate> rate)
                     "Reaction equation for falloff reaction '{}'\n does not "
                     "contain valid pressure-dependent third body", equation());
             }
-            m_third_body.reset(new ThirdBody("(+M)"));
+            m_third_body = make_shared<ThirdBody>("(+M)");
         }
     }
 }
@@ -404,7 +404,7 @@ void Reaction::setEquation(const std::string& equation, const Kinetics* kin)
                     "Collision efficiencies need to specify single species", equation);
             }
             third_body = effs.begin()->first;
-            m_third_body.reset(new ThirdBody(third_body));
+            m_third_body = make_shared<ThirdBody>(third_body);
             m_third_body->explicit_3rd = true;
         } else if (input.hasKey("default-efficiency")) {
             // insufficient disambiguation of third bodies
@@ -462,7 +462,7 @@ void Reaction::setEquation(const std::string& equation, const Kinetics* kin)
         }
         m_third_body->setName(third_body);
     } else {
-        m_third_body.reset(new ThirdBody(third_body));
+        m_third_body = make_shared<ThirdBody>(third_body);
     }
 
     // adjust reactant coefficients
@@ -825,7 +825,7 @@ ThreeBodyReaction::ThreeBodyReaction()
 {
     warn_deprecated("ThreeBodyReaction",
         "To be removed after Cantera 3.0. Replaceable with Reaction.");
-    m_third_body.reset(new ThirdBody);
+    m_third_body = make_shared<ThirdBody>();
     setRate(newReactionRate(type()));
 }
 
@@ -853,7 +853,7 @@ FalloffReaction::FalloffReaction()
 {
     warn_deprecated("FalloffReaction",
         "To be removed after Cantera 3.0. Replaceable with Reaction.");
-    m_third_body.reset(new ThirdBody);
+    m_third_body = make_shared<ThirdBody>();
     setRate(newReactionRate(type()));
 }
 
@@ -880,19 +880,19 @@ FalloffReaction::FalloffReaction(const AnyMap& node, const Kinetics& kin)
     warn_deprecated("FalloffReaction",
         "To be removed after Cantera 3.0. Replaceable with Reaction.");
     if (node.empty()) {
-        m_third_body.reset(new ThirdBody);
+        m_third_body = make_shared<ThirdBody>();
         setRate(newReactionRate(type()));
     }
 }
 
 unique_ptr<Reaction> newReaction(const std::string& type)
 {
-    return unique_ptr<Reaction>(new Reaction());
+    return make_unique<Reaction>();
 }
 
 unique_ptr<Reaction> newReaction(const AnyMap& rxn_node, const Kinetics& kin)
 {
-    return unique_ptr<Reaction>(new Reaction(rxn_node, kin));
+    return make_unique<Reaction>(rxn_node, kin);
 }
 
 void parseReactionEquation(Reaction& R, const std::string& equation,
@@ -970,7 +970,7 @@ std::vector<shared_ptr<Reaction>> getReactions(const AnyValue& items,
 {
     std::vector<shared_ptr<Reaction>> all_reactions;
     for (const auto& node : items.asVector<AnyMap>()) {
-        shared_ptr<Reaction> R(new Reaction(node, kinetics));
+        auto R = make_shared<Reaction>(node, kinetics);
         R->check();
         R->validate(kinetics);
         if (R->valid() && R->checkSpecies(kinetics)) {

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -128,13 +128,13 @@ vector_int ReactionPathDiagram::reactions()
         for (const auto& rxn : path(i)->reactionMap()) {
             double flxratio = rxn.second/flmax;
             if (flxratio > threshold) {
-                m_rxns[rxn.first] = 1;
+                m_rxns.insert(rxn.first);
             }
         }
     }
     vector_int r;
     for (const auto& rxn : m_rxns) {
-        r.push_back(int(rxn.first));
+        r.push_back(int(rxn));
     }
     return r;
 }
@@ -397,7 +397,7 @@ void ReactionPathDiagram::linkNodes(size_t k1, size_t k2, size_t rxn,
         m_pathlist.push_back(ff);
     }
     ff->addReaction(rxn, value, legend);
-    m_rxns[rxn] = 1;
+    m_rxns.insert(rxn);
     m_flxmax = std::max(ff->flow(), m_flxmax);
 }
 

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -40,7 +40,7 @@ void SpeciesNode::printPaths()
 }
 
 Path::Path(SpeciesNode* begin, SpeciesNode* end)
-    : m_a(begin), m_b(end), m_total(0.0)
+    : m_a(begin), m_b(end)
 {
     begin->addPath(this);
     end->addPath(this);
@@ -76,30 +76,6 @@ void Path::writeLabel(ostream& s, doublereal threshold)
             }
         }
     }
-}
-
-ReactionPathDiagram::ReactionPathDiagram()
-{
-    name = "reaction_paths";
-    m_flxmax = 0.0;
-    bold_color = "blue";
-    normal_color = "steelblue";
-    dashed_color = "gray";
-    dot_options = "center=1;";
-    m_font = "Helvetica";
-    bold_min = 0.2;
-    dashed_max = 0.0;
-    label_min = 0.0;
-    threshold = 0.005;
-    flow_type = NetFlow;
-    scale = -1;
-    x_size = -1.0;
-    y_size = -1.0;
-    arrow_width = -5.0;
-    show_details = false;
-    arrow_hue = 0.6666;
-    title = "";
-    m_local = npos;
 }
 
 ReactionPathDiagram::~ReactionPathDiagram()

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -62,12 +62,12 @@ void Path::writeLabel(ostream& s, doublereal threshold)
         return;
     }
     doublereal v;
-    for (const auto& label : m_label) {
-        v = label.second/m_total;
+    for (const auto& [species, value] : m_label) {
+        v = value / m_total;
         if (m_label.size() == 1) {
-            s << label.first << "\\l";
+            s << species << "\\l";
         } else if (v > threshold) {
-            s << label.first;
+            s << species;
             int percent = int(100*v + 0.5);
             if (percent < 100) {
                 s << " (" << percent << "%)\\l";
@@ -105,8 +105,8 @@ ReactionPathDiagram::ReactionPathDiagram()
 ReactionPathDiagram::~ReactionPathDiagram()
 {
     // delete the nodes
-    for (const auto& node : m_nodes) {
-        delete node.second;
+    for (const auto& [k, node] : m_nodes) {
+        delete node;
     }
 
     // delete the paths
@@ -125,10 +125,10 @@ vector_int ReactionPathDiagram::reactions()
     }
     m_rxns.clear();
     for (size_t i = 0; i < nPaths(); i++) {
-        for (const auto& rxn : path(i)->reactionMap()) {
-            double flxratio = rxn.second/flmax;
+        for (const auto& [iRxn, flux] : path(i)->reactionMap()) {
+            double flxratio = flux / flmax;
             if (flxratio > threshold) {
-                m_rxns.insert(rxn.first);
+                m_rxns.insert(iRxn);
             }
         }
     }
@@ -364,9 +364,9 @@ void ReactionPathDiagram::exportToDot(ostream& s)
         }
     }
     s.precision(2);
-    for (const auto& node : m_nodes) {
-        if (node.second->visible) {
-            s << "s" << node.first << " [ fontname=\""+m_font+"\", label=\"" << node.second->name
+    for (const auto& [kSpecies, node] : m_nodes) {
+        if (node->visible) {
+            s << "s" << kSpecies << " [ fontname=\""+m_font+"\", label=\"" << node->name
               << "\"];" << endl;
         }
     }

--- a/src/kinetics/ReactionRateDelegator.cpp
+++ b/src/kinetics/ReactionRateDelegator.cpp
@@ -7,8 +7,6 @@
 #include "cantera/kinetics/Kinetics.h"
 #include "cantera/base/Solution.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/kinetics/ReactionRateDelegator.cpp
+++ b/src/kinetics/ReactionRateDelegator.cpp
@@ -55,8 +55,8 @@ ReactionRateDelegator::ReactionRateDelegator()
 
 unique_ptr<MultiRateBase> ReactionRateDelegator::newMultiRate() const
 {
-    auto multirate = std::make_unique<MultiRate<ReactionRateDelegator,
-                                                ReactionDataDelegator>>();
+    auto multirate = make_unique<MultiRate<ReactionRateDelegator,
+                                           ReactionDataDelegator>>();
     multirate->sharedData().setType(m_rateType);
     ExtensionManager::wrapReactionData(m_rateType, multirate->sharedData());
     return multirate;

--- a/src/kinetics/solveSP.cpp
+++ b/src/kinetics/solveSP.cpp
@@ -9,7 +9,6 @@
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/kinetics/ImplicitSurfChem.h"
 
-using namespace std;
 namespace Cantera
 {
 

--- a/src/kinetics/solveSP.cpp
+++ b/src/kinetics/solveSP.cpp
@@ -21,21 +21,9 @@ static doublereal calcWeightedNorm(const doublereal [], const doublereal dx[], s
 // solveSP Class Definitions
 
 solveSP::solveSP(ImplicitSurfChem* surfChemPtr, int bulkFunc) :
-    m_SurfChemPtr(surfChemPtr),
     m_objects(surfChemPtr->getObjects()),
-    m_neq(0),
-    m_bulkFunc(bulkFunc),
-    m_numSurfPhases(0),
-    m_numTotSurfSpecies(0),
-    m_numBulkPhasesSS(0),
-    m_numTotBulkSpeciesSS(0),
-    m_atol(1.0E-15),
-    m_rtol(1.0E-4),
-    m_maxstep(1000),
-    m_maxTotSpecies(0),
-    m_ioflag(0)
+    m_bulkFunc(bulkFunc)
 {
-    m_numSurfPhases = 0;
     for (size_t n = 0; n < m_objects.size(); n++) {
         InterfaceKinetics* kin = m_objects[n];
         size_t surfPhaseIndex = kin->reactionPhaseIndex();
@@ -54,8 +42,6 @@ solveSP::solveSP(ImplicitSurfChem* surfChemPtr, int bulkFunc) :
         m_nSpeciesSurfPhase.push_back(nsp);
         m_numTotSurfSpecies += nsp;
     }
-    // We rely on ordering to figure things out
-    m_numBulkPhasesSS = 0;
 
     if (bulkFunc == BULK_DEPOSITION) {
         m_neq = m_numTotSurfSpecies + m_numTotBulkSpeciesSS;
@@ -63,7 +49,6 @@ solveSP::solveSP(ImplicitSurfChem* surfChemPtr, int bulkFunc) :
         m_neq = m_numTotSurfSpecies;
     }
 
-    m_maxTotSpecies = 0;
     for (size_t n = 0; n < m_numSurfPhases; n++) {
         size_t tsp = m_objects[n]->nTotalSpecies();
         m_maxTotSpecies = std::max(m_maxTotSpecies, tsp);

--- a/src/matlab/ctfunctions.cpp
+++ b/src/matlab/ctfunctions.cpp
@@ -16,8 +16,6 @@
 #include "cantera/clib/ctrpath.h"
 #include "ctmatutils.h"
 
-using namespace std;
-
 void reportError()
 {
     int buflen = 0;

--- a/src/matlab/mixturemethods.cpp
+++ b/src/matlab/mixturemethods.cpp
@@ -11,7 +11,6 @@
 #include "cantera/clib/ctmultiphase.h"
 #include "cantera/clib/ct.h"
 #include "ctmatutils.h"
-using namespace std;
 
 void mixturemethods(int nlhs, mxArray* plhs[],
                     int nrhs, const mxArray* prhs[])

--- a/src/matlab/onedimmethods.cpp
+++ b/src/matlab/onedimmethods.cpp
@@ -8,8 +8,6 @@
 #include "ctmatutils.h"
 #include "cantera/clib/ctonedim.h"
 
-using namespace std;
-
 void onedimmethods(int nlhs, mxArray* plhs[],
                    int nrhs, const mxArray* prhs[])
 {

--- a/src/matlab/surfmethods.cpp
+++ b/src/matlab/surfmethods.cpp
@@ -9,8 +9,6 @@
 #include "cantera/clib/ctsurf.h"
 #include "cantera/clib/ct.h"
 
-using namespace std;
-
 void surfmethods(int nlhs, mxArray* plhs[],
                  int nrhs, const mxArray* prhs[])
 {

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -32,12 +32,7 @@ struct BandMatrix::PivData {
 };
 
 BandMatrix::BandMatrix() :
-    m_n(0),
-    m_kl(0),
-    m_ku(0),
-    m_zero(0.0),
-    m_ipiv{new PivData()},
-    m_info(0)
+    m_ipiv{new PivData()}
 {
 }
 
@@ -50,9 +45,7 @@ BandMatrix::BandMatrix(size_t n, size_t kl, size_t ku, doublereal v)   :
     m_n(n),
     m_kl(kl),
     m_ku(ku),
-    m_zero(0.0),
-    m_ipiv{new PivData()},
-    m_info(0)
+    m_ipiv{new PivData()}
 {
     data.resize(n*(2*kl + ku + 1));
     ludata.resize(n*(2*kl + ku + 1));
@@ -70,18 +63,14 @@ BandMatrix::BandMatrix(size_t n, size_t kl, size_t ku, doublereal v)   :
 
 BandMatrix::BandMatrix(const BandMatrix& y) :
     GeneralMatrix(y),
-    m_n(0),
-    m_kl(0),
-    m_ku(0),
-    m_zero(0.0),
+    data(y.data),
+    ludata(y.ludata),
+    m_n(y.m_n),
+    m_kl(y.m_kl),
+    m_ku(y.m_ku),
     m_ipiv{new PivData()},
     m_info(y.m_info)
 {
-    m_n = y.m_n;
-    m_kl = y.m_kl;
-    m_ku = y.m_ku;
-    data = y.data;
-    ludata = y.ludata;
     m_ipiv->data = y.m_ipiv->data;
     m_colPtrs.resize(m_n);
     m_lu_col_ptrs.resize(m_n);

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -101,33 +101,9 @@ extern "C" {
     }
 }
 
-CVodesIntegrator::CVodesIntegrator() :
-    m_neq(0),
-    m_cvode_mem(0),
-    m_linsol(0),
-    m_linsol_matrix(0),
-    m_func(0),
-    m_t0(0.0),
-    m_y(0),
-    m_abstol(0),
-    m_dky(0),
-    m_type("DENSE"),
-    m_itol(CV_SS),
-    m_method(CV_BDF),
-    m_maxord(0),
-    m_reltol(1.e-9),
-    m_abstols(1.e-15),
-    m_reltolsens(1.0e-5),
-    m_abstolsens(1.0e-4),
-    m_nabs(0),
-    m_hmax(0.0),
-    m_hmin(0.0),
-    m_maxsteps(20000),
-    m_maxErrTestFails(0),
-    m_yS(nullptr),
-    m_np(0),
-    m_mupper(0), m_mlower(0),
-    m_sens_ok(false)
+CVodesIntegrator::CVodesIntegrator()
+    : m_itol(CV_SS)
+    , m_method(CV_BDF)
 {
 }
 

--- a/src/numerics/DenseMatrix.cpp
+++ b/src/numerics/DenseMatrix.cpp
@@ -17,16 +17,8 @@
 namespace Cantera
 {
 
-DenseMatrix::DenseMatrix() :
-    m_useReturnErrorCode(0),
-    m_printLevel(0)
-{
-}
-
 DenseMatrix::DenseMatrix(size_t n, size_t m, doublereal v) :
-    Array2D(n, m, v),
-    m_useReturnErrorCode(0),
-    m_printLevel(0)
+    Array2D(n, m, v)
 {
     m_ipiv.resize(std::max(n, m));
     m_colPts.resize(m);
@@ -38,9 +30,7 @@ DenseMatrix::DenseMatrix(size_t n, size_t m, doublereal v) :
 }
 
 DenseMatrix::DenseMatrix(const DenseMatrix& y) :
-    Array2D(y),
-    m_useReturnErrorCode(0),
-    m_printLevel(0)
+    Array2D(y)
 {
     m_ipiv = y.ipiv();
     m_colPts.resize(m_ncols);

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -11,14 +11,6 @@ using namespace std;
 namespace Cantera
 {
 
-Func1::Func1() :
-    m_c(0.0),
-    m_f1(0),
-    m_f2(0),
-    m_parent(0)
-{
-}
-
 Func1::Func1(const Func1& right) :
     m_c(right.m_c),
     m_f1(right.m_f1),
@@ -216,8 +208,8 @@ Func1& Pow1::derivative() const
 /******************************************************************************/
 
 Tabulated1::Tabulated1(size_t n, const double* tvals, const double* fvals,
-                       const std::string& method) :
-    Func1() {
+                       const std::string& method)
+{
     m_tvec.resize(n);
     std::copy(tvals, tvals + n, m_tvec.begin());
     for (auto it = std::begin(m_tvec) + 1; it != std::end(m_tvec); it++) {

--- a/src/numerics/FuncEval.cpp
+++ b/src/numerics/FuncEval.cpp
@@ -4,11 +4,6 @@
 namespace Cantera
 {
 
-FuncEval::FuncEval()
-    : m_suppress_errors(false)
-{
-}
-
 int FuncEval::eval_nothrow(double t, double* y, double* ydot)
 {
     try {

--- a/src/numerics/IDA_Solver.cpp
+++ b/src/numerics/IDA_Solver.cpp
@@ -23,8 +23,6 @@
 #include "ida/ida_spils.h"
 #include "nvector/nvector_serial.h"
 
-using namespace std;
-
 typedef long int sd_size_t;
 
 namespace Cantera

--- a/src/numerics/IDA_Solver.cpp
+++ b/src/numerics/IDA_Solver.cpp
@@ -125,37 +125,7 @@ namespace Cantera
 {
 
 IDA_Solver::IDA_Solver(ResidJacEval& f) :
-    DAE_Solver(f),
-    m_ida_mem(0),
-    m_t0(0.0),
-    m_y(0),
-    m_ydot(0),
-    m_id(0),
-    m_constraints(0),
-    m_abstol(0),
-    m_type(0),
-    m_itol(IDA_SS),
-    m_iter(0),
-    m_reltol(1.e-9),
-    m_abstols(1.e-15),
-    m_nabs(0),
-    m_hmax(0.0),
-    m_hmin(0.0),
-    m_h0(0.0),
-    m_maxsteps(20000),
-    m_maxord(0),
-    m_formJac(0),
-    m_tstop(0.0),
-    m_told_old(0.0),
-    m_told(0.0),
-    m_tcurrent(0.0),
-    m_deltat(0.0),
-    m_maxErrTestFails(-1),
-    m_maxNonlinIters(0),
-    m_maxNonlinConvFails(-1),
-    m_setSuppressAlg(0),
-    m_mupper(0),
-    m_mlower(0)
+    DAE_Solver(f)
 {
 }
 

--- a/src/numerics/IDA_Solver.cpp
+++ b/src/numerics/IDA_Solver.cpp
@@ -466,7 +466,7 @@ void IDA_Solver::init(doublereal t0)
     }
 
     // pass a pointer to func in m_data
-    m_fdata.reset(new ResidData(&m_resid, this, m_resid.nparams()));
+    m_fdata = make_unique<ResidData>(&m_resid, this, m_resid.nparams());
     flag = IDASetUserData(m_ida_mem, m_fdata.get());
     if (flag != IDA_SUCCESS) {
         throw CanteraError("IDA_Solver::init", "IDASetUserData failed.");

--- a/src/numerics/PreconditionerFactory.cpp
+++ b/src/numerics/PreconditionerFactory.cpp
@@ -6,8 +6,6 @@
 #include "cantera/numerics/PreconditionerFactory.h"
 #include "cantera/numerics/AdaptivePreconditioner.h"
 
-
-using namespace std;
 namespace Cantera
 {
 

--- a/src/numerics/ResidJacEval.cpp
+++ b/src/numerics/ResidJacEval.cpp
@@ -6,8 +6,6 @@
 #include "cantera/numerics/ResidJacEval.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 ResidJacEval::ResidJacEval(doublereal atol) :

--- a/src/numerics/funcs.cpp
+++ b/src/numerics/funcs.cpp
@@ -7,8 +7,6 @@
 #include "cantera/numerics/polyfit.h"
 #include "cantera/base/ctexceptions.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -13,15 +13,7 @@ using namespace std;
 namespace Cantera
 {
 
-Boundary1D::Boundary1D() : Domain1D(1, 1, 0.0),
-    m_flow_left(0), m_flow_right(0),
-    m_ilr(0), m_left_nv(0), m_right_nv(0),
-    m_left_loc(0), m_right_loc(0),
-    m_left_points(0),
-    m_left_nsp(0), m_right_nsp(0),
-    m_sp_left(0), m_sp_right(0),
-    m_start_left(0), m_start_right(0),
-    m_phase_left(0), m_phase_right(0), m_temp(0.0), m_mdot(0.0)
+Boundary1D::Boundary1D() : Domain1D(1, 1, 0.0)
 {
     m_type = cConnectorType;
 }
@@ -88,12 +80,8 @@ void Boundary1D::_init(size_t n)
 // ---------------- Inlet1D methods ----------------
 
 Inlet1D::Inlet1D()
-    : m_V0(0.0)
-    , m_nsp(0)
-    , m_flow(0)
 {
     m_type = cInletType;
-    m_xstr = "";
 }
 
 Inlet1D::Inlet1D(shared_ptr<Solution> solution, const string& id)
@@ -345,11 +333,8 @@ shared_ptr<SolutionArray> Symm1D::asArray(const double* soln) const
 // -------- Outlet1D --------
 
 OutletRes1D::OutletRes1D()
-    : m_nsp(0)
-    , m_flow(0)
 {
     m_type = cOutletResType;
-    m_xstr = "";
 }
 
 OutletRes1D::OutletRes1D(shared_ptr<Solution> solution, const string& id)

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -18,18 +18,7 @@ using namespace std;
 namespace Cantera
 {
 
-Domain1D::Domain1D(size_t nv, size_t points, double time) :
-    m_rdt(0.0),
-    m_nv(0),
-    m_container(0),
-    m_index(npos),
-    m_type(0),
-    m_iloc(0),
-    m_jstart(0),
-    m_left(0),
-    m_right(0),
-    m_bw(-1),
-    m_force_full_update(false)
+Domain1D::Domain1D(size_t nv, size_t points, double time)
 {
     resize(nv, points);
 }

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -29,7 +29,7 @@ void Domain1D::resize(size_t nv, size_t np)
     // new grid refiner is required.
     if (nv != m_nv || !m_refiner) {
         m_nv = nv;
-        m_refiner.reset(new Refiner(*this));
+        m_refiner = make_unique<Refiner>(*this);
     }
     m_nv = nv;
     m_name.resize(m_nv,"");

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -11,10 +11,6 @@
 #include "cantera/base/AnyMap.h"
 #include "cantera/base/SolutionArray.h"
 
-#include <set>
-
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -12,8 +12,6 @@
 #include "cantera/base/utilities.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -18,10 +18,7 @@ namespace Cantera
 {
 
 IonFlow::IonFlow(ThermoPhase* ph, size_t nsp, size_t points) :
-    StFlow(ph, nsp, points),
-    m_import_electron_transport(false),
-    m_stage(1),
-    m_kElectron(npos)
+    StFlow(ph, nsp, points)
 {
     // make a local copy of species charge
     for (size_t k = 0; k < m_nsp; k++) {

--- a/src/oneD/MultiJac.cpp
+++ b/src/oneD/MultiJac.cpp
@@ -6,8 +6,6 @@
 #include "cantera/oneD/MultiJac.h"
 #include <ctime>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/oneD/MultiJac.cpp
+++ b/src/oneD/MultiJac.cpp
@@ -20,11 +20,6 @@ MultiJac::MultiJac(OneDim& r)
     m_r1.resize(m_size);
     m_ssdiag.resize(m_size);
     m_mask.resize(m_size);
-    m_elapsed = 0.0;
-    m_nevals = 0;
-    m_age = 100000;
-    m_atol = sqrt(std::numeric_limits<double>::epsilon());
-    m_rtol = 1.0e-5;
 }
 
 void MultiJac::updateTransient(doublereal rdt, integer* mask)

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -132,10 +132,8 @@ const size_t NDAMP = 7;
 // ---------------- MultiNewton methods ----------------
 
 MultiNewton::MultiNewton(int sz)
-    : m_maxAge(5)
+    : m_n(sz)
 {
-    m_n = sz;
-    m_elapsed = 0.0;
 }
 
 void MultiNewton::resize(size_t sz)

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -17,27 +17,11 @@ namespace Cantera
 {
 
 OneDim::OneDim()
-    : m_tmin(1.0e-16), m_tmax(1e8), m_tfactor(0.5),
-      m_rdt(0.0), m_jac_ok(false),
-      m_bw(0), m_size(0),
-      m_init(false), m_pts(0),
-      m_ss_jac_age(20), m_ts_jac_age(20),
-      m_interrupt(0), m_time_step_callback(0),
-      m_nsteps(0), m_nsteps_max(500),
-      m_nevals(0), m_evaltime(0.0)
 {
     m_newt.reset(new MultiNewton(1));
 }
 
-OneDim::OneDim(vector<Domain1D*> domains) :
-    m_tmin(1.0e-16), m_tmax(1e8), m_tfactor(0.5),
-    m_rdt(0.0), m_jac_ok(false),
-    m_bw(0), m_size(0),
-    m_init(false),
-    m_ss_jac_age(20), m_ts_jac_age(20),
-    m_interrupt(0), m_time_step_callback(0),
-    m_nsteps(0), m_nsteps_max(500),
-    m_nevals(0), m_evaltime(0.0)
+OneDim::OneDim(vector<Domain1D*> domains)
 {
     // create a Newton iterator, and add each domain.
     m_newt.reset(new MultiNewton(1));

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -18,13 +18,13 @@ namespace Cantera
 
 OneDim::OneDim()
 {
-    m_newt.reset(new MultiNewton(1));
+    m_newt = make_unique<MultiNewton>(1);
 }
 
 OneDim::OneDim(vector<Domain1D*> domains)
 {
     // create a Newton iterator, and add each domain.
-    m_newt.reset(new MultiNewton(1));
+    m_newt = make_unique<MultiNewton>(1);
     for (size_t i = 0; i < domains.size(); i++) {
         addDomain(domains[i]);
     }
@@ -197,7 +197,7 @@ void OneDim::resize()
     m_mask.resize(size());
 
     // delete the current Jacobian evaluator and create a new one
-    m_jac.reset(new MultiJac(*this));
+    m_jac = make_unique<MultiJac>(*this);
     m_jac_ok = false;
 
     for (size_t i = 0; i < nDomains(); i++) {

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -160,9 +160,9 @@ AnyMap legacyH5(shared_ptr<SolutionArray> arr, const AnyMap& header={})
         {"emissivity-left", "emissivity_left"},
         {"emissivity-right", "emissivity_right"},
     };
-    for (const auto& item : meta_pairs) {
-        if (meta.hasKey(item.second)) {
-            out[item.first] = meta[item.second];
+    for (const auto& [newName, oldName] : meta_pairs) {
+        if (meta.hasKey(oldName)) {
+            out[newName] = meta[oldName];
         }
     }
 
@@ -172,9 +172,9 @@ AnyMap legacyH5(shared_ptr<SolutionArray> arr, const AnyMap& header={})
         {"transient-reltol", "transient_reltol"},
         {"steady-reltol", "steady_reltol"},
     };
-    for (const auto& item : tol_pairs) {
-        if (meta.hasKey(item.second)) {
-            out["tolerances"][item.first] = meta[item.second];
+    for (const auto& [newName, oldName] : tol_pairs) {
+        if (meta.hasKey(oldName)) {
+            out["tolerances"][newName] = meta[oldName];
         }
     }
 
@@ -194,9 +194,9 @@ AnyMap legacyH5(shared_ptr<SolutionArray> arr, const AnyMap& header={})
         {"Soret-enabled", "soret_enabled"},
         {"species-enabled", "species_enabled"},
     };
-    for (const auto& item : header_pairs) {
-        if (header.hasKey(item.second)) {
-            out[item.first] = header[item.second];
+    for (const auto& [newName, oldName] : header_pairs) {
+        if (header.hasKey(oldName)) {
+            out[newName] = header[oldName];
         }
     }
 
@@ -208,9 +208,9 @@ AnyMap legacyH5(shared_ptr<SolutionArray> arr, const AnyMap& header={})
         // {"grid-min", "???"}, // missing
         {"max-points", "max_grid_points"},
     };
-    for (const auto& item : refiner_pairs) {
-        if (header.hasKey(item.second)) {
-            out["refine-criteria"][item.first] = header[item.second];
+    for (const auto& [newName, oldName] : refiner_pairs) {
+        if (header.hasKey(oldName)) {
+            out["refine-criteria"][newName] = header[oldName];
         }
     }
 

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -11,8 +11,6 @@
 #include "cantera/numerics/funcs.h"
 #include "cantera/base/global.h"
 
-#include <set>
-
 using namespace std;
 
 namespace Cantera

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -20,20 +20,7 @@ namespace Cantera
 
 StFlow::StFlow(ThermoPhase* ph, size_t nsp, size_t points) :
     Domain1D(nsp+c_offset_Y, points),
-    m_press(-1.0),
-    m_nsp(nsp),
-    m_thermo(0),
-    m_kin(0),
-    m_trans(0),
-    m_epsilon_left(0.0),
-    m_epsilon_right(0.0),
-    m_do_soret(false),
-    m_do_multicomponent(false),
-    m_do_radiation(false),
-    m_kExcessLeft(0),
-    m_kExcessRight(0),
-    m_zfixed(Undef),
-    m_tfixed(-1.)
+    m_nsp(nsp)
 {
     if (ph->type() == "IdealGas") {
         m_thermo = static_cast<IdealGasPhase*>(ph);

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -12,13 +12,10 @@ using namespace std;
 namespace Cantera
 {
 Refiner::Refiner(Domain1D& domain) :
-    m_ratio(10.0), m_slope(0.8), m_curve(0.8), m_prune(-0.001),
-    m_min_range(0.01), m_domain(&domain), m_npmax(1000),
-    m_gridmin(1e-10)
+    m_domain(&domain)
 {
     m_nv = m_domain->nComponents();
     m_active.resize(m_nv, true);
-    m_thresh = std::sqrt(std::numeric_limits<double>::epsilon());
 }
 
 void Refiner::setCriteria(doublereal ratio, doublereal slope,

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -111,8 +111,8 @@ int Refiner::analyze(size_t n, const doublereal* z,
                 for (size_t j = 0; j < n-1; j++) {
                     doublereal r = fabs(v[j+1] - v[j])/dmax;
                     if (r > 1.0 && dz[j] >= 2 * m_gridmin) {
-                        m_loc[j] = 1;
-                        m_c[name] = 1;
+                        m_loc.insert(j);
+                        m_c.insert(name);
                     }
                     if (r >= m_prune) {
                         m_keep[j] = 1;
@@ -135,9 +135,9 @@ int Refiner::analyze(size_t n, const doublereal* z,
                     doublereal r = fabs(s[j+1] - s[j]) / (dmax + m_thresh/dz[j]);
                     if (r > 1.0 && dz[j] >= 2 * m_gridmin &&
                             dz[j+1] >= 2 * m_gridmin) {
-                        m_c[name] = 1;
-                        m_loc[j] = 1;
-                        m_loc[j+1] = 1;
+                        m_c.insert(name);
+                        m_loc.insert(j);
+                        m_loc.insert(j+1);
                     }
                     if (r >= m_prune) {
                         m_keep[j+1] = 1;
@@ -155,8 +155,8 @@ int Refiner::analyze(size_t n, const doublereal* z,
     for (size_t j = 1; j < n-1; j++) {
         // Add a new point if the ratio with left interval is too large
         if (dz[j] > m_ratio*dz[j-1]) {
-            m_loc[j] = 1;
-            m_c[fmt::format("point {}", j)] = 1;
+            m_loc.insert(j);
+            m_c.insert(fmt::format("point {}", j));
             m_keep[j-1] = 1;
             m_keep[j] = 1;
             m_keep[j+1] = 1;
@@ -165,8 +165,8 @@ int Refiner::analyze(size_t n, const doublereal* z,
 
         // Add a point if the ratio with right interval is too large
         if (dz[j] < dz[j-1]/m_ratio) {
-            m_loc[j-1] = 1;
-            m_c[fmt::format("point {}", j-1)] = 1;
+            m_loc.insert(j-1);
+            m_c.insert(fmt::format("point {}", j-1));
             m_keep[j-2] = 1;
             m_keep[j-1] = 1;
             m_keep[j] = 1;
@@ -215,12 +215,12 @@ void Refiner::show()
                  m_domain->id()+".\n"
                  +"    New points inserted after grid points ");
         for (const auto& loc : m_loc) {
-            writelog("{} ", loc.first);
+            writelog("{} ", loc);
         }
         writelog("\n");
         writelog("    to resolve ");
         for (const auto& c : m_c) {
-            writelog(string(c.first)+" ");
+            writelog(c + " ");
         }
         writelog("\n");
         writeline('#', 78);

--- a/src/pch/system.h
+++ b/src/pch/system.h
@@ -14,6 +14,7 @@
 #include <algorithm>
 #include <memory>
 #include <functional>
+#include <any>
 
 #include <boost/algorithm/string.hpp>
 

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -21,7 +21,6 @@ namespace Cantera
 
 BinarySolutionTabulatedThermo::BinarySolutionTabulatedThermo(const std::string& inputFile,
                                                              const std::string& id_)
-    : m_kk_tab(npos)
 {
     initThermoFile(inputFile, id_);
 }

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -16,12 +16,6 @@ namespace Cantera
 
 ConstCpPoly::ConstCpPoly()
     : SpeciesThermoInterpType(0.0, std::numeric_limits<double>::infinity(), 0.0)
-    , m_t0(0.0)
-    , m_cp0_R(0.0)
-    , m_h0_R(0.0)
-    , m_s0_R(0.0)
-    , m_logt0(0.0)
-    , m_h0_R_orig(0.0)
 {
 }
 

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -396,7 +396,7 @@ void DebyeHuckel::initThermo()
         // Initialize the water property calculator. It will share the internal
         // eos water calculator.
         if (m_form_A_Debye == A_DEBYE_WATER) {
-            m_waterProps.reset(new WaterProps(m_waterSS));
+            m_waterProps = make_unique<WaterProps>(m_waterSS);
         }
     } else if (dynamic_cast<PDSS_ConstVol*>(providePDSS(0)) == 0) {
         throw CanteraError("DebyeHuckel::initThermo", "Solvent standard state"

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -21,8 +21,6 @@
 
 #include <cstdio>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -32,25 +32,17 @@ double B_Debye_default = 3.28640E9; // units = sqrt(kg/gmol) / m
 double maxIionicStrength_default = 30.0;
 }
 
-DebyeHuckel::DebyeHuckel(const std::string& inputFile,
-                         const std::string& id_) :
-    m_formDH(DHFORM_DILUTE_LIMIT),
-    m_Aionic_default(NAN),
-    m_IionicMolality(0.0),
-    m_maxIionicStrength(maxIionicStrength_default),
-    m_useHelgesonFixedForm(false),
-    m_IionicMolalityStoich(0.0),
-    m_form_A_Debye(A_DEBYE_CONST),
-    m_A_Debye(A_Debye_default),
-    m_B_Debye(B_Debye_default),
-    m_waterSS(0),
-    m_densWaterSS(1000.)
+DebyeHuckel::DebyeHuckel(const string& inputFile, const string& id_)
+    : m_maxIionicStrength(maxIionicStrength_default)
+    , m_A_Debye(A_Debye_default)
+    , m_B_Debye(B_Debye_default)
 {
     initThermoFile(inputFile, id_);
 }
 
 DebyeHuckel::~DebyeHuckel()
 {
+    // Defined in .cpp to limit dependence on WaterProps.h
 }
 
 // -------- Molar Thermodynamic Properties of the Solution ---------------

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -10,8 +10,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/ctexceptions.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/GibbsExcessVPSSTP.cpp
+++ b/src/thermo/GibbsExcessVPSSTP.cpp
@@ -18,8 +18,6 @@
 #include "cantera/base/global.h"
 #include <numeric>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -668,7 +668,7 @@ void HMWSoln::initThermo()
 
     // Initialize the water property calculator. It will share the internal eos
     // water calculator.
-    m_waterProps.reset(new WaterProps(dynamic_cast<PDSS_Water*>(m_waterSS)));
+    m_waterProps = make_unique<WaterProps>(dynamic_cast<PDSS_Water*>(m_waterSS));
 
     // Lastly calculate the charge balance and then add stuff until the charges
     // compensate

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -21,8 +21,6 @@
 #include "cantera/thermo/electrolytes.h"
 #include "cantera/base/stringUtils.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -37,34 +37,11 @@ double crop_ln_gamma_k_max_default = 15.0;
 
 HMWSoln::~HMWSoln()
 {
+    // Defined in .cpp to limit dependence on WaterProps.h
 }
 
 HMWSoln::HMWSoln(const std::string& inputFile, const std::string& id_) :
-    m_formPitzerTemp(PITZER_TEMP_CONSTANT),
-    m_IionicMolality(0.0),
     m_maxIionicStrength(maxIionicStrength_default),
-    m_TempPitzerRef(298.15),
-    m_form_A_Debye(A_DEBYE_CONST),
-    m_A_Debye(A_Debye_default),
-    m_waterSS(0),
-    m_molalitiesAreCropped(false),
-    IMS_X_o_cutoff_(0.2),
-    IMS_cCut_(0.05),
-    IMS_slopegCut_(0.0),
-    IMS_dfCut_(0.0),
-    IMS_efCut_(0.0),
-    IMS_afCut_(0.0),
-    IMS_bfCut_(0.0),
-    IMS_dgCut_(0.0),
-    IMS_egCut_(0.0),
-    IMS_agCut_(0.0),
-    IMS_bgCut_(0.0),
-    MC_X_o_cutoff_(0.0),
-    MC_dpCut_(0.0),
-    MC_epCut_(0.0),
-    MC_apCut_(0.0),
-    MC_bpCut_(0.0),
-    MC_cpCut_(0.0),
     CROP_ln_gamma_o_min(crop_ln_gamma_o_min_default),
     CROP_ln_gamma_o_max(crop_ln_gamma_o_max_default),
     CROP_ln_gamma_k_min(crop_ln_gamma_k_min_default),

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -17,8 +17,7 @@ using namespace std;
 namespace Cantera
 {
 
-IdealGasPhase::IdealGasPhase(const std::string& inputFile, const std::string& id_) :
-    m_p0(-1.0)
+IdealGasPhase::IdealGasPhase(const string& inputFile, const string& id_)
 {
     initThermoFile(inputFile, id_);
 }

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -12,8 +12,6 @@
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -36,23 +36,12 @@ namespace Cantera
 
 IdealMolalSoln::IdealMolalSoln(const std::string& inputFile,
                                const std::string& id_) :
-    MolalityVPSSTP(),
-    m_formGC(2),
-    IMS_typeCutoff_(0),
     IMS_X_o_cutoff_(X_o_cutoff_default),
     IMS_gamma_o_min_(gamma_o_min_default),
     IMS_gamma_k_min_(gamma_k_min_default),
     IMS_slopefCut_(slopefCut_default),
     IMS_slopegCut_(slopegCut_default),
-    IMS_cCut_(cCut_default),
-    IMS_dfCut_(0.0),
-    IMS_efCut_(0.0),
-    IMS_afCut_(0.0),
-    IMS_bfCut_(0.0),
-    IMS_dgCut_(0.0),
-    IMS_egCut_(0.0),
-    IMS_agCut_(0.0),
-    IMS_bgCut_(0.0)
+    IMS_cCut_(cCut_default)
 {
     initThermoFile(inputFile, id_);
 }

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -14,8 +14,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -19,11 +19,7 @@ using namespace std;
 namespace Cantera
 {
 
-IdealSolidSolnPhase::IdealSolidSolnPhase(const std::string& inputFile,
-        const std::string& id_) :
-    m_formGC(0),
-    m_Pref(OneAtm),
-    m_Pcurrent(OneAtm)
+IdealSolidSolnPhase::IdealSolidSolnPhase(const string& inputFile, const string& id_)
 {
     initThermoFile(inputFile, id_);
 }

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -20,8 +20,7 @@ using namespace std;
 namespace Cantera
 {
 
-IdealSolnGasVPSS::IdealSolnGasVPSS(const std::string& infile, std::string id_) :
-    m_formGC(0)
+IdealSolnGasVPSS::IdealSolnGasVPSS(const string& infile, string id_)
 {
     initThermoFile(infile, id_);
 }

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -15,8 +15,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -20,6 +20,7 @@
 #include "cantera/thermo/PDSS_IonsFromNeutral.h"
 #include "cantera/base/stringUtils.h"
 
+#include <boost/algorithm/string.hpp>
 #include <fstream>
 
 namespace Cantera

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -27,11 +27,7 @@ using namespace std;
 namespace Cantera
 {
 
-IonsFromNeutralVPSSTP::IonsFromNeutralVPSSTP(const std::string& inputFile,
-        const std::string& id_) :
-    ionSolnType_(cIonSolnType_SINGLEANION),
-    numNeutralMoleculeSpecies_(0),
-    indexSpecialSpecies_(npos)
+IonsFromNeutralVPSSTP::IonsFromNeutralVPSSTP(const string& inputFile, const string& id_)
 {
     initThermoFile(inputFile, id_);
 }

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -22,8 +22,6 @@
 
 #include <fstream>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -19,9 +19,6 @@ namespace Cantera
 {
 
 LatticePhase::LatticePhase(const std::string& inputFile, const std::string& id_)
-    : m_Pref(OneAtm)
-    , m_Pcurrent(OneAtm)
-    , m_site_density(0.0)
 {
     initThermoFile(inputFile, id_);
 }

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -304,8 +304,8 @@ void LatticeSolidPhase::initThermo()
 {
     if (m_input.hasKey("composition")) {
         compositionMap composition = m_input["composition"].asMap<double>();
-        for (auto& item : composition) {
-            AnyMap& node = m_rootNode["phases"].getMapWhere("name", item.first);
+        for (auto& [name, stoich] : composition) {
+            AnyMap& node = m_rootNode["phases"].getMapWhere("name", name);
             addLattice(newThermo(node, m_rootNode));
         }
         setLatticeStoichiometry(composition);

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -18,7 +18,6 @@
 
 #include <boost/algorithm/string.hpp>
 
-using namespace std;
 namespace ba = boost::algorithm;
 
 namespace Cantera

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -23,11 +23,6 @@ namespace ba = boost::algorithm;
 
 namespace Cantera
 {
-LatticeSolidPhase::LatticeSolidPhase() :
-    m_press(-1.0),
-    m_molar_density(0.0)
-{
-}
 
 doublereal LatticeSolidPhase::minTemp(size_t k) const
 {

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -13,8 +13,6 @@
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/stringUtils.h"
 
-using namespace std;
-
 namespace Cantera
 {
 MargulesVPSSTP::MargulesVPSSTP(const string& inputFile, const string& id_)

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -17,10 +17,7 @@ using namespace std;
 
 namespace Cantera
 {
-MargulesVPSSTP::MargulesVPSSTP(const std::string& inputFile, const std::string& id_) :
-    numBinaryInteractions_(0),
-    formMargules_(0),
-    formTempModel_(0)
+MargulesVPSSTP::MargulesVPSSTP(const string& inputFile, const string& id_)
 {
     initThermoFile(inputFile, id_);
 }

--- a/src/thermo/MaskellSolidSolnPhase.cpp
+++ b/src/thermo/MaskellSolidSolnPhase.cpp
@@ -17,14 +17,6 @@
 namespace Cantera
 {
 
-MaskellSolidSolnPhase::MaskellSolidSolnPhase() :
-    m_Pcurrent(OneAtm),
-    h_mixing(0.0),
-    product_species_index(-1),
-    reactant_species_index(-1)
-{
-}
-
 void MaskellSolidSolnPhase::getActivityConcentrations(doublereal* c) const
 {
     getActivityCoefficients(c);

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -16,12 +16,6 @@ using namespace std;
 namespace Cantera
 {
 
-MixtureFugacityTP::MixtureFugacityTP() :
-    iState_(FLUID_GAS),
-    forcedState_(FLUID_UNDEFINED)
-{
-}
-
 int MixtureFugacityTP::standardStateConvention() const
 {
     return cSS_CONVENTION_TEMPERATURE;

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -15,8 +15,6 @@
 
 #include <fstream>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -20,12 +20,7 @@ using namespace std;
 namespace Cantera
 {
 
-MolalityVPSSTP::MolalityVPSSTP() :
-    m_pHScalingType(PHSCALE_PITZER),
-    m_indexCLM(npos),
-    m_weightSolvent(18.01528),
-    m_xmolSolventMIN(0.01),
-    m_Mnaught(18.01528E-3)
+MolalityVPSSTP::MolalityVPSSTP()
 {
     // Change the default to be that charge neutrality in the phase is necessary
     // condition for the proper specification of thermodynamic functions within

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -49,13 +49,12 @@ void Mu0Poly::setParameters(double h0, const std::map<double, double>& T_mu)
     // Distribute the data into the internal arrays, and find the index of the
     // point at 298.15 K.
     size_t iT298 = npos;
-    for (const auto& row : T_mu) {
-        double T1 = row.first;
+    for (const auto& [T1, mu] : T_mu) {
         if (T1 == 298.15) {
             iT298 = m_t0_int.size();
         }
         m_t0_int.push_back(T1);
-        m_mu0_R_int.push_back(row.second / GasConstant);
+        m_mu0_R_int.push_back(mu / GasConstant);
     }
     if (iT298 == npos) {
         throw CanteraError("Mu0Poly::setParameters",

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -13,8 +13,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/AnyMap.h"
 
-using namespace std;
-
 namespace Cantera
 {
 Mu0Poly::Mu0Poly()

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -19,8 +19,6 @@ namespace Cantera
 {
 Mu0Poly::Mu0Poly()
     : SpeciesThermoInterpType(0.0, std::numeric_limits<double>::infinity(), 0.0)
-    , m_numIntervals(0)
-    , m_H298(0.0)
 {
 }
 

--- a/src/thermo/MultiSpeciesThermo.cpp
+++ b/src/thermo/MultiSpeciesThermo.cpp
@@ -96,9 +96,8 @@ void MultiSpeciesThermo::update(doublereal t, doublereal* cp_R,
         const std::vector<index_STIT>& species = iter->second;
         double* tpoly = &jter->second[0];
         species[0].second->updateTemperaturePoly(t, tpoly);
-        for (size_t k = 0; k < species.size(); k++) {
-            size_t i = species[k].first;
-            species[k].second->updateProperties(tpoly, cp_R+i, h_RT+i, s_R+i);
+        for (auto& [i, spthermo] : species) {
+            spthermo->updateProperties(tpoly, cp_R+i, h_RT+i, s_R+i);
         }
     }
 }
@@ -162,8 +161,8 @@ doublereal MultiSpeciesThermo::refPressure(size_t k) const
 SpeciesThermoInterpType* MultiSpeciesThermo::provideSTIT(size_t k)
 {
     try {
-        const std::pair<int, size_t>& loc = m_speciesLoc.at(k);
-        return m_sp.at(loc.first)[loc.second].second.get();
+        auto& [iParam, jSpecies] = m_speciesLoc.at(k);
+        return m_sp.at(iParam)[jSpecies].second.get();
     } catch (std::out_of_range&) {
         return 0;
     }
@@ -172,8 +171,8 @@ SpeciesThermoInterpType* MultiSpeciesThermo::provideSTIT(size_t k)
 const SpeciesThermoInterpType* MultiSpeciesThermo::provideSTIT(size_t k) const
 {
     try {
-        const std::pair<int, size_t>& loc = m_speciesLoc.at(k);
-        return m_sp.at(loc.first)[loc.second].second.get();
+        auto& [iParam, jSpecies] = m_speciesLoc.at(k);
+        return m_sp.at(iParam)[jSpecies].second.get();
     } catch (std::out_of_range&) {
         return 0;
     }

--- a/src/thermo/MultiSpeciesThermo.cpp
+++ b/src/thermo/MultiSpeciesThermo.cpp
@@ -16,12 +16,6 @@
 
 namespace Cantera
 {
-MultiSpeciesThermo::MultiSpeciesThermo() :
-    m_tlow_max(0.0),
-    m_thigh_min(1.0E30),
-    m_p0(OneAtm)
-{
-}
 
 void MultiSpeciesThermo::install_STIT(size_t index,
                                         shared_ptr<SpeciesThermoInterpType> stit_ptr)

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -24,13 +24,7 @@ using namespace std;
 namespace Cantera
 {
 
-Nasa9PolyMultiTempRegion::Nasa9PolyMultiTempRegion()
-    : m_currRegion(0)
-{
-}
-
-Nasa9PolyMultiTempRegion::Nasa9PolyMultiTempRegion(vector<Nasa9Poly1*>& regionPts) :
-    m_currRegion(0)
+Nasa9PolyMultiTempRegion::Nasa9PolyMultiTempRegion(vector<Nasa9Poly1*>& regionPts)
 {
     // From now on, we own these pointers
     for (Nasa9Poly1* region : regionPts) {
@@ -103,10 +97,6 @@ void Nasa9PolyMultiTempRegion::setParameters(const std::map<double, vector_fp>& 
         m_regionPts.emplace_back(poly);
     }
     m_regionPts.back()->setMaxTemp(maxTemp());
-}
-
-Nasa9PolyMultiTempRegion::~Nasa9PolyMultiTempRegion()
-{
 }
 
 int Nasa9PolyMultiTempRegion::reportType() const

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -91,14 +91,14 @@ void Nasa9PolyMultiTempRegion::setParameters(const std::map<double, vector_fp>& 
 {
     m_regionPts.clear();
     m_lowerTempBounds.clear();
-    for (const auto& region : regions) {
-        m_lowerTempBounds.push_back(region.first);
+    for (const auto& [Tmin, coeffs] : regions) {
+        m_lowerTempBounds.push_back(Tmin);
         Nasa9Poly1* poly = new Nasa9Poly1;
         poly->setRefPressure(refPressure());
-        poly->setMinTemp(region.first);
-        poly->setParameters(region.second);
+        poly->setMinTemp(Tmin);
+        poly->setParameters(coeffs);
         if (!m_regionPts.empty()) {
-            m_regionPts.back()->setMaxTemp(region.first);
+            m_regionPts.back()->setMaxTemp(Tmin);
         }
         m_regionPts.emplace_back(poly);
     }

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -19,8 +19,6 @@
 #include "cantera/thermo/speciesThermoTypes.h"
 #include "cantera/base/AnyMap.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/NasaPoly2.cpp
+++ b/src/thermo/NasaPoly2.cpp
@@ -8,11 +8,6 @@
 
 namespace Cantera {
 
-NasaPoly2::NasaPoly2()
-    : m_midT(0)
-{
-}
-
 void NasaPoly2::setParameters(double Tmid, const vector_fp& low,
                               const vector_fp& high) {
     m_midT = Tmid;

--- a/src/thermo/PDSS.cpp
+++ b/src/thermo/PDSS.cpp
@@ -14,15 +14,6 @@
 
 namespace Cantera
 {
-PDSS::PDSS() :
-    m_temp(-1.0),
-    m_pres(-1.0),
-    m_p0(-1.0),
-    m_minTemp(-1.0),
-    m_maxTemp(10000.0),
-    m_mw(0.0)
-{
-}
 
 doublereal PDSS::enthalpy_mole() const
 {

--- a/src/thermo/PDSS_ConstVol.cpp
+++ b/src/thermo/PDSS_ConstVol.cpp
@@ -15,10 +15,6 @@ using namespace std;
 namespace Cantera
 {
 
-PDSS_ConstVol::PDSS_ConstVol()
-{
-}
-
 void PDSS_ConstVol::initThermo()
 {
     PDSS::initThermo();

--- a/src/thermo/PDSS_ConstVol.cpp
+++ b/src/thermo/PDSS_ConstVol.cpp
@@ -10,8 +10,6 @@
 #include "cantera/thermo/PDSS_ConstVol.h"
 #include "cantera/thermo/VPStandardStateTP.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -23,28 +23,8 @@ namespace Cantera
 int PDSS_HKFT::s_InputInconsistencyErrorExit = 1;
 
 PDSS_HKFT::PDSS_HKFT()
-    : m_waterSS(0)
-    , m_densWaterSS(-1.0)
-    , m_deltaG_formation_tr_pr(NAN)
-    , m_deltaH_formation_tr_pr(NAN)
-    , m_Mu0_tr_pr(0.0)
-    , m_Entrop_tr_pr(NAN)
-    , m_a1(0.0)
-    , m_a2(0.0)
-    , m_a3(0.0)
-    , m_a4(0.0)
-    , m_c1(0.0)
-    , m_c2(0.0)
-    , m_omega_pr_tr(0.0)
-    , m_Y_pr_tr(0.0)
-    , m_Z_pr_tr(0.0)
-    , m_presR_bar(0.0)
-    , m_domega_jdT_prtr(0.0)
-    , m_charge_j(0.0)
 {
     m_pres = OneAtm;
-    m_presR_bar = OneAtm * 1.0E-5;
-    m_presR_bar = 1.0;
     m_units.setDefaults({"cm", "gmol", "cal", "bar"});
 }
 

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -15,8 +15,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 // Set the default to error exit if there is an input file inconsistency

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -271,7 +271,7 @@ void PDSS_HKFT::initThermo()
     m_Z_pr_tr = -1.0 / relepsilon;
     doublereal drelepsilondT = m_waterProps->relEpsilon(m_temp, m_pres, 1);
     m_Y_pr_tr = drelepsilondT / (relepsilon * relepsilon);
-    m_waterProps.reset(new WaterProps(m_waterSS));
+    m_waterProps = make_unique<WaterProps>(m_waterSS);
     m_presR_bar = OneAtm / 1.0E5;
     m_presR_bar = 1.0;
     convertDGFormation();

--- a/src/thermo/PDSS_IdealGas.cpp
+++ b/src/thermo/PDSS_IdealGas.cpp
@@ -10,8 +10,6 @@
 #include "cantera/thermo/PDSS_IdealGas.h"
 #include "cantera/thermo/VPStandardStateTP.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/PDSS_IdealGas.cpp
+++ b/src/thermo/PDSS_IdealGas.cpp
@@ -15,10 +15,6 @@ using namespace std;
 namespace Cantera
 {
 
-PDSS_IdealGas::PDSS_IdealGas()
-{
-}
-
 void PDSS_IdealGas::initThermo()
 {
     PDSS::initThermo();

--- a/src/thermo/PDSS_IonsFromNeutral.cpp
+++ b/src/thermo/PDSS_IonsFromNeutral.cpp
@@ -16,13 +16,6 @@ using namespace std;
 namespace Cantera
 {
 
-PDSS_IonsFromNeutral::PDSS_IonsFromNeutral()
-    : neutralMoleculePhase_(0)
-    , numMult_(0)
-    , add2RTln2_(true)
-{
-}
-
 void PDSS_IonsFromNeutral::setParent(VPStandardStateTP* phase, size_t k)
 {
     neutralMoleculePhase_ = dynamic_cast<IonsFromNeutralVPSSTP&>(*phase).getNeutralMoleculePhase();

--- a/src/thermo/PDSS_IonsFromNeutral.cpp
+++ b/src/thermo/PDSS_IonsFromNeutral.cpp
@@ -11,8 +11,6 @@
 #include "cantera/thermo/IonsFromNeutralVPSSTP.h"
 #include "cantera/base/stringUtils.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/PDSS_IonsFromNeutral.cpp
+++ b/src/thermo/PDSS_IonsFromNeutral.cpp
@@ -57,8 +57,8 @@ void PDSS_IonsFromNeutral::initThermo()
         setSpecialSpecies();
     }
     if (m_input.hasKey("multipliers")) {
-        for (const auto& item : m_input["multipliers"].asMap<double>()) {
-            setNeutralSpeciesMultiplier(item.first, item.second);
+        for (const auto& [species, multiplier] : m_input["multipliers"].asMap<double>()) {
+            setNeutralSpeciesMultiplier(species, multiplier);
         }
     }
 
@@ -66,9 +66,9 @@ void PDSS_IonsFromNeutral::initThermo()
     m_minTemp = neutralMoleculePhase_->minTemp();
     m_maxTemp = neutralMoleculePhase_->maxTemp();
     tmpNM.resize(neutralMoleculePhase_->nSpecies());
-    for (auto multiplier : neutralSpeciesMultipliers_) {
-        idNeutralMoleculeVec.push_back( neutralMoleculePhase_->speciesIndex(multiplier.first));
-        factorVec.push_back(multiplier.second);
+    for (auto [species, multiplier] : neutralSpeciesMultipliers_) {
+        idNeutralMoleculeVec.push_back(neutralMoleculePhase_->speciesIndex(species));
+        factorVec.push_back(multiplier);
     }
 }
 

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -16,8 +16,7 @@ namespace Cantera
 {
 
 PDSS_SSVol::PDSS_SSVol()
-    : volumeModel_(SSVolume_Model::tpoly)
-    , TCoeff_(4, 0.0)
+    : TCoeff_(4, 0.0)
 {
 }
 

--- a/src/thermo/PDSS_SSVol.cpp
+++ b/src/thermo/PDSS_SSVol.cpp
@@ -10,8 +10,6 @@
 #include "cantera/thermo/PDSS_SSVol.h"
 #include "cantera/thermo/VPStandardStateTP.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/PDSS_Water.cpp
+++ b/src/thermo/PDSS_Water.cpp
@@ -13,12 +13,7 @@
 namespace Cantera
 {
 PDSS_Water::PDSS_Water() :
-    m_waterProps(&m_sub),
-    m_dens(1000.0),
-    m_iState(WATER_LIQUID),
-    EW_Offset(0.0),
-    SW_Offset(0.0),
-    m_allowGasPhase(false)
+    m_waterProps(&m_sub)
 {
     m_minTemp = 200.;
     m_maxTemp = 10000.;

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -8,6 +8,7 @@
 #include "cantera/thermo/Species.h"
 #include "cantera/base/stringUtils.h"
 
+#include <boost/algorithm/string.hpp>
 #include <boost/math/tools/roots.hpp>
 
 namespace bmt = boost::math::tools;

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -19,15 +19,8 @@ const double PengRobinson::omega_a = 4.5723552892138218E-01;
 const double PengRobinson::omega_b = 7.77960739038885E-02;
 const double PengRobinson::omega_vc = 3.07401308698703833E-01;
 
-PengRobinson::PengRobinson(const std::string& infile, const std::string& id_) :
-    m_b(0.0),
-    m_a(0.0),
-    m_aAlpha_mix(0.0),
-    m_NSolns(0),
-    m_dpdV(0.0),
-    m_dpdT(0.0)
+PengRobinson::PengRobinson(const string& infile, const string& id_)
 {
-    std::fill_n(m_Vroot, 3, 0.0);
     initThermoFile(infile, id_);
 }
 

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -814,27 +814,27 @@ bool Phase::addSpecies(shared_ptr<Species> spec) {
     }
 
     vector_fp comp(nElements());
-    for (const auto& elem : spec->composition) {
-        size_t m = elementIndex(elem.first);
+    for (const auto& [eName, stoich] : spec->composition) {
+        size_t m = elementIndex(eName);
         if (m == npos) { // Element doesn't exist in this phase
             switch (m_undefinedElementBehavior) {
             case UndefElement::ignore:
                 return false;
 
             case UndefElement::add:
-                addElement(elem.first);
+                addElement(eName);
                 comp.resize(nElements());
-                m = elementIndex(elem.first);
+                m = elementIndex(eName);
                 break;
 
             case UndefElement::error:
             default:
                 throw CanteraError("Phase::addSpecies",
                     "Species '{}' contains an undefined element '{}'.",
-                    spec->name, elem.first);
+                    spec->name, eName);
             }
         }
-        comp[m] = elem.second;
+        comp[m] = stoich;
     }
 
     size_t ne = nElements();
@@ -947,9 +947,9 @@ vector<std::string> Phase::findIsomers(const compositionMap& compMap) const
 {
     vector<std::string> isomerNames;
 
-    for (const auto& k : m_species) {
-        if (k.second->composition == compMap) {
-            isomerNames.emplace_back(k.first);
+    for (const auto& [name, species] : m_species) {
+        if (species->composition == compMap) {
+            isomerNames.emplace_back(name);
         }
     }
 
@@ -1017,13 +1017,13 @@ void Phase::compositionChanged() {
 vector_fp Phase::getCompositionFromMap(const compositionMap& comp) const
 {
     vector_fp X(m_kk);
-    for (const auto& sp : comp) {
-        size_t loc = speciesIndex(sp.first);
+    for (const auto& [name, value] : comp) {
+        size_t loc = speciesIndex(name);
         if (loc == npos) {
             throw CanteraError("Phase::getCompositionFromMap",
-                               "Unknown species '{}'", sp.first);
+                               "Unknown species '{}'", name);
         }
-        X[loc] = sp.second;
+        X[loc] = value;
     }
     return X;
 }

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -17,24 +17,6 @@ using namespace std;
 namespace Cantera
 {
 
-Phase::Phase() :
-    m_kk(0),
-    m_ndim(3),
-    m_undefinedElementBehavior(UndefElement::add),
-    m_caseSensitiveSpecies(false),
-    m_temp(0.001),
-    m_dens(0.001),
-    m_mmw(0.0),
-    m_stateNum(-1),
-    m_mm(0),
-    m_elem_type(0)
-{
-}
-
-Phase::~Phase()
-{
-}
-
 std::string Phase::name() const
 {
     return m_name;

--- a/src/thermo/PlasmaPhase.cpp
+++ b/src/thermo/PlasmaPhase.cpp
@@ -12,12 +12,6 @@
 namespace Cantera {
 
 PlasmaPhase::PlasmaPhase(const std::string& inputFile, const std::string& id_)
-    : m_isotropicShapeFactor(2.0)
-    , m_nPoints(1001)
-    , m_electronSpeciesIndex(npos)
-    , m_distributionType("isotropic")
-    , m_quadratureMethod("simpson")
-    , m_do_normalizeElectronEnergyDist(true)
 {
     initThermoFile(inputFile, id_);
 

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -20,13 +20,6 @@ using std::string;
 namespace Cantera
 {
 
-PureFluidPhase::PureFluidPhase() :
-    m_subflag(-1),
-    m_mw(-1.0),
-    m_verbose(false)
-{
-}
-
 void PureFluidPhase::initThermo()
 {
     if (m_input.hasKey("pure-fluid-name")) {

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -15,8 +15,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/global.h"
 
-using std::string;
-
 namespace Cantera
 {
 

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -8,6 +8,7 @@
 #include "cantera/thermo/Species.h"
 #include "cantera/base/stringUtils.h"
 
+#include <boost/algorithm/string.hpp>
 #include <boost/math/tools/roots.hpp>
 
 namespace bmt = boost::math::tools;

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -10,9 +10,6 @@
 
 #include <boost/math/tools/roots.hpp>
 
-#include <algorithm>
-
-using namespace std;
 namespace bmt = boost::math::tools;
 
 namespace Cantera

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -22,15 +22,8 @@ const doublereal RedlichKwongMFTP::omega_a = 4.27480233540E-01;
 const doublereal RedlichKwongMFTP::omega_b = 8.66403499650E-02;
 const doublereal RedlichKwongMFTP::omega_vc = 3.33333333333333E-01;
 
-RedlichKwongMFTP::RedlichKwongMFTP(const std::string& infile, const std::string& id_) :
-    m_formTempParam(0),
-    m_b_current(0.0),
-    m_a_current(0.0),
-    NSolns_(0),
-    dpdV_(0.0),
-    dpdT_(0.0)
+RedlichKwongMFTP::RedlichKwongMFTP(const string& infile, const string& id_)
 {
-    fill_n(Vroot_, 3, 0.0);
     initThermoFile(infile, id_);
 }
 

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -16,11 +16,6 @@ using namespace std;
 
 namespace Cantera
 {
-SingleSpeciesTP::SingleSpeciesTP() :
-    m_press(OneAtm),
-    m_p0(OneAtm)
-{
-}
 
 // ------------ Molar Thermodynamic Properties --------------------
 

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -12,8 +12,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -12,7 +12,6 @@
 #include "cantera/base/global.h"
 #include <iostream>
 #include <limits>
-#include <set>
 
 using namespace std;
 

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -18,22 +18,12 @@ using namespace std;
 
 namespace Cantera {
 
-Species::Species()
-    : charge(0.0)
-    , size(1.0)
-{
-}
-
 Species::Species(const std::string& name_, const compositionMap& comp_,
                  double charge_, double size_)
     : name(name_)
     , composition(comp_)
     , charge(charge_)
     , size(size_)
-{
-}
-
-Species::~Species()
 {
 }
 

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -104,13 +104,13 @@ AnyMap Species::parameters(const ThermoPhase* phase, bool withInput) const
 
 unique_ptr<Species> newSpecies(const AnyMap& node)
 {
-    unique_ptr<Species> s(new Species(node["name"].asString(),
-                                      node["composition"].asMap<double>()));
+    auto s = make_unique<Species>(node["name"].asString(),
+                                  node["composition"].asMap<double>());
 
     if (node.hasKey("thermo")) {
         s->thermo = newSpeciesThermo(node["thermo"].as<AnyMap>());
     } else {
-        s->thermo.reset(new SpeciesThermoInterpType());
+        s->thermo = make_shared<SpeciesThermoInterpType>();
     }
 
     s->size = node.getDouble("sites", 1.0);

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -41,14 +41,14 @@ double Species::molecularWeight() {
     if (m_molecularWeight == Undef) {
         double weight = 0.0;
         const auto& elements = elementWeights();
-        for (const auto& comp : composition) {
-            auto search = elements.find(comp.first);
+        for (const auto& [eName, stoich] : composition) {
+            auto search = elements.find(eName);
             if (search != elements.end()) {
                 if (search->second < 0) {
                     throw CanteraError("setMolecularWeight",
-                        "element '{}' has no stable isotopes", comp.first);
+                        "element '{}' has no stable isotopes", eName);
                 }
-                weight += search->second * comp.second;
+                weight += search->second * stoich;
             }
         }
         setMolecularWeight(weight);
@@ -140,9 +140,9 @@ unique_ptr<Species> newSpecies(const AnyMap& node)
         "thermo", "transport"
     };
     s->input.setUnits(node.units());
-    for (const auto& item : node) {
-        if (known_keys.count(item.first) == 0) {
-            s->input[item.first] = item.second;
+    for (const auto& [key, child] : node) {
+        if (known_keys.count(key) == 0) {
+            s->input[key] = child;
         }
     }
     s->input.applyUnits();

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -187,25 +187,25 @@ unique_ptr<SpeciesThermoInterpType> newSpeciesThermo(const AnyMap& node)
 {
     std::string model = node["model"].asString();
     if (model == "NASA7") {
-        unique_ptr<NasaPoly2> thermo(new NasaPoly2());
+        auto thermo = make_unique<NasaPoly2>();
         setupNasaPoly(*thermo, node);
-        return unique_ptr<SpeciesThermoInterpType>(move(thermo));
+        return thermo;
     } else if (model == "Shomate") {
-        unique_ptr<ShomatePoly2> thermo(new ShomatePoly2());
+        auto thermo = make_unique<ShomatePoly2>();
         setupShomatePoly(*thermo, node);
-        return unique_ptr<SpeciesThermoInterpType>(move(thermo));
+        return thermo;
     } else if (model == "NASA9") {
-        unique_ptr<Nasa9PolyMultiTempRegion> thermo(new Nasa9PolyMultiTempRegion());
+        auto thermo = make_unique<Nasa9PolyMultiTempRegion>();
         setupNasa9Poly(*thermo, node);
-        return unique_ptr<SpeciesThermoInterpType>(move(thermo));
+        return thermo;
     } else if (model == "constant-cp") {
-        unique_ptr<ConstCpPoly> thermo(new ConstCpPoly());
+        auto thermo = make_unique<ConstCpPoly>();
         setupConstCp(*thermo, node);
-        return unique_ptr<SpeciesThermoInterpType>(move(thermo));
+        return thermo;
     } else if (model == "piecewise-Gibbs") {
-        unique_ptr<Mu0Poly> thermo(new Mu0Poly());
+        auto thermo = make_unique<Mu0Poly>();
         setupMu0(*thermo, node);
-        return unique_ptr<SpeciesThermoInterpType>(move(thermo));
+        return thermo;
     } else {
         throw CanteraError("newSpeciesThermo",
             "Unknown thermo model '{}'", model);

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -21,8 +21,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/Units.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -174,12 +174,12 @@ void setupMu0(Mu0Poly& thermo, const AnyMap& node)
     bool dimensionless = node.getBool("dimensionless", false);
     double h0 = node.convert("h0", "J/kmol", 0.0);
     map<double, double> T_mu;
-    for (const auto& item : node["data"]) {
-        double T = node.units().convertTo(fpValueCheck(item.first), "K");
+    for (const auto& [T_str, mu] : node["data"]) {
+        double T = node.units().convertTo(fpValueCheck(T_str), "K");
         if (dimensionless) {
-            T_mu[T] = item.second.asDouble() * GasConstant * T;
+            T_mu[T] = mu.asDouble() * GasConstant * T;
         } else {
-            T_mu[T] = node.units().convert(item.second, "J/kmol");
+            T_mu[T] = node.units().convert(mu, "J/kmol");
         }
     }
     thermo.setParameters(h0, T_mu);

--- a/src/thermo/SpeciesThermoInterpType.cpp
+++ b/src/thermo/SpeciesThermoInterpType.cpp
@@ -11,13 +11,6 @@
 namespace Cantera
 {
 
-SpeciesThermoInterpType::SpeciesThermoInterpType() :
-    m_lowT(0.0),
-    m_highT(0.0),
-    m_Pref(0.0)
-{
-}
-
 SpeciesThermoInterpType::SpeciesThermoInterpType(double tlow,
                                                  double thigh,
                                                  double pref) :

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -21,9 +21,7 @@ using namespace std;
 namespace Cantera
 {
 
-SurfPhase::SurfPhase(const std::string& infile, const std::string& id_) :
-    m_n0(1.0),
-    m_press(OneAtm)
+SurfPhase::SurfPhase(const string& infile, const string& id_)
 {
     setNDim(2);
     initThermoFile(infile, id_);

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -16,8 +16,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -39,6 +39,8 @@
 #include "cantera/thermo/BinarySolutionTabulatedThermo.h"
 #include "cantera/base/stringUtils.h"
 
+#include <boost/algorithm/string.hpp>
+
 namespace Cantera
 {
 

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -39,8 +39,6 @@
 #include "cantera/thermo/BinarySolutionTabulatedThermo.h"
 #include "cantera/base/stringUtils.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -25,14 +25,6 @@ using namespace std;
 namespace Cantera
 {
 
-ThermoPhase::ThermoPhase() :
-    m_phi(0.0),
-    m_chargeNeutralityNecessary(false),
-    m_ssConvention(cSS_CONVENTION_TEMPERATURE),
-    m_tlast(0.0)
-{
-}
-
 void ThermoPhase::resetHf298(size_t k) {
     if (k != npos) {
         m_spthermo.resetHf298(k);

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -20,17 +20,14 @@ using namespace std;
 namespace Cantera
 {
 
-VPStandardStateTP::VPStandardStateTP() :
-    m_Pcurrent(OneAtm),
-    m_minTemp(0.0),
-    m_maxTemp(BigNumber),
-    m_Tlast_ss(-1.0),
-    m_Plast_ss(-1.0)
+VPStandardStateTP::VPStandardStateTP()
 {
+    // Defined in .cpp to limit dependence on PDSS.h via vector<unique_ptr<PDSS>>
 }
 
 VPStandardStateTP::~VPStandardStateTP()
 {
+    // Defined in .cpp to limit dependence on PDSS.h
 }
 
 int VPStandardStateTP::standardStateConvention() const

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -15,8 +15,6 @@
 #include "cantera/base/utilities.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/thermo/WaterProps.cpp
+++ b/src/thermo/WaterProps.cpp
@@ -12,35 +12,26 @@
 namespace Cantera
 {
 WaterProps::WaterProps():
-    m_waterIAPWS(0),
-    m_own_sub(false)
+    m_waterIAPWS(new WaterPropsIAPWS()),
+    m_own_sub(true)
 {
-    // object owns its own water evaluator
-    m_waterIAPWS = new WaterPropsIAPWS();
-    m_own_sub = true;
 }
 
-WaterProps::WaterProps(PDSS_Water* wptr)  :
-    m_waterIAPWS(0),
-    m_own_sub(false)
+WaterProps::WaterProps(PDSS_Water* wptr)
 {
     if (wptr) {
         // object in slave mode; it doesn't own its own water evaluator.
         m_waterIAPWS = wptr->getWater();
-        m_own_sub = false;
     } else {
         m_waterIAPWS = new WaterPropsIAPWS();
         m_own_sub = true;
     }
 }
 
-WaterProps::WaterProps(WaterPropsIAPWS* waterIAPWS)  :
-    m_waterIAPWS(0),
-    m_own_sub(false)
+WaterProps::WaterProps(WaterPropsIAPWS* waterIAPWS)
 {
     if (waterIAPWS) {
         m_waterIAPWS = waterIAPWS;
-        m_own_sub = false;
     } else {
         m_waterIAPWS = new WaterPropsIAPWS();
         m_own_sub = true;

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -37,14 +37,6 @@ static const double R_water = 461.51805; // J/kg/K (Eq. 6.3)
  */
 static const doublereal Rgas = 8.314371E3; // Joules kmol-1 K-1
 
-// Base constructor
-WaterPropsIAPWS::WaterPropsIAPWS() :
-    tau(-1.0),
-    delta(-1.0),
-    iState(-30000)
-{
-}
-
 void WaterPropsIAPWS::calcDim(doublereal temperature, doublereal rho)
 {
     tau = T_c / temperature;

--- a/src/thermo/WaterPropsIAPWSphi.cpp
+++ b/src/thermo/WaterPropsIAPWSphi.cpp
@@ -351,10 +351,7 @@ static const doublereal Bbetai[2] = {
 };
 // \endcond
 
-WaterPropsIAPWSphi::WaterPropsIAPWSphi() :
-    TAUsave(-1.0),
-    TAUsqrt(-1.0),
-    DELTAsave(-1.0)
+WaterPropsIAPWSphi::WaterPropsIAPWSphi()
 {
     for (int i = 0; i < 52; i++) {
         TAUp[i] = 1.0;

--- a/src/thermo/WaterPropsIAPWSphi.cpp
+++ b/src/thermo/WaterPropsIAPWSphi.cpp
@@ -11,9 +11,6 @@
 #include "cantera/thermo/WaterPropsIAPWSphi.h"
 #include "cantera/base/global.h"
 
-#include <cmath>
-#include <algorithm>
-
 namespace Cantera
 {
 

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -15,12 +15,7 @@ using namespace std;
 
 namespace Cantera
 {
-WaterSSTP::WaterSSTP(const std::string& inputFile, const std::string& id) :
-    m_mw(0.0),
-    EW_Offset(0.0),
-    SW_Offset(0.0),
-    m_ready(false),
-    m_allowGasPhase(false)
+WaterSSTP::WaterSSTP(const string& inputFile, const string& id)
 {
     initThermoFile(inputFile, id);
 }

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -11,8 +11,6 @@
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/base/stringUtils.h"
 
-using namespace std;
-
 namespace Cantera
 {
 WaterSSTP::WaterSSTP(const string& inputFile, const string& id)

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -79,7 +79,7 @@ void WaterSSTP::initThermo()
     double rho0 = m_sub.density(298.15, OneAtm, WATER_LIQUID);
     setDensity(rho0);
 
-    m_waterProps.reset(new WaterProps(&m_sub));
+    m_waterProps = make_unique<WaterProps>(&m_sub);
 
     // Set the flag to say we are ready to calculate stuff
     m_ready = true;

--- a/src/tpx/Methane.cpp
+++ b/src/tpx/Methane.cpp
@@ -6,7 +6,6 @@
 #include "Methane.h"
 #include "cantera/base/stringUtils.h"
 
-using namespace std;
 using namespace Cantera;
 
 namespace tpx

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -21,18 +21,6 @@ std::string propertySymbols[] = {"H", "S", "U", "V", "P", "T"};
 
 namespace tpx
 {
-Substance::Substance() :
-    T(Undef),
-    Rho(Undef),
-    Tslast(Undef),
-    Rhf(Undef),
-    Rhv(Undef),
-    Pst(Undef),
-    m_energy_offset(0.0),
-    m_entropy_offset(0.0),
-    kbr(0)
-{
-}
 
 void Substance::setStdState(double h0, double s0, double t0, double p0)
 {

--- a/src/tpx/Sub.cpp
+++ b/src/tpx/Sub.cpp
@@ -11,7 +11,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/global.h"
 
-using std::string;
 using namespace Cantera;
 
 namespace {

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -11,8 +11,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 DustyGasTransport::DustyGasTransport(ThermoPhase* thermo) :

--- a/src/transport/DustyGasTransport.cpp
+++ b/src/transport/DustyGasTransport.cpp
@@ -16,16 +16,7 @@ using namespace std;
 namespace Cantera
 {
 DustyGasTransport::DustyGasTransport(ThermoPhase* thermo) :
-    Transport(thermo),
-    m_temp(-1.0),
-    m_gradP(0.0),
-    m_knudsen_ok(false),
-    m_bulk_ok(false),
-    m_porosity(0.0),
-    m_tortuosity(1.0),
-    m_pore_radius(0.0),
-    m_diam(0.0),
-    m_perm(-1.0)
+    Transport(thermo)
 {
 }
 

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -22,21 +22,7 @@ namespace Cantera
 
 GasTransport::GasTransport(ThermoPhase* thermo) :
     Transport(thermo),
-    m_viscmix(0.0),
-    m_visc_ok(false),
-    m_viscwt_ok(false),
-    m_spvisc_ok(false),
-    m_bindiff_ok(false),
-    m_mode(0),
-    m_polytempvec(5),
-    m_temp(-1.0),
-    m_kbt(0.0),
-    m_sqrt_kbt(0.0),
-    m_sqrt_t(0.0),
-    m_logt(0.0),
-    m_t14(0.0),
-    m_t32(0.0),
-    m_log_level(0)
+    m_polytempvec(5)
 {
 }
 

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -13,10 +13,6 @@
 
 namespace Cantera
 {
-IonGasTransport::IonGasTransport() :
-    m_kElectron(npos)
-{
-}
 
 void IonGasTransport::init(ThermoPhase* thermo, int mode, int log_level)
 {

--- a/src/transport/MMCollisionInt.cpp
+++ b/src/transport/MMCollisionInt.cpp
@@ -11,8 +11,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/global.h"
 
-using namespace std;
-
 namespace Cantera
 {
 const int DeltaDegree = 6;

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -11,8 +11,6 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/transport/MixTransport.cpp
+++ b/src/transport/MixTransport.cpp
@@ -15,12 +15,6 @@ using namespace std;
 
 namespace Cantera
 {
-MixTransport::MixTransport() :
-    m_lambda(0.0),
-    m_spcond_ok(false),
-    m_condmix_ok(false)
-{
-}
 
 void MixTransport::init(ThermoPhase* thermo, int mode, int log_level)
 {

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -10,8 +10,6 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/transport/TransportFactory.h"
 
-using namespace std;
-
 namespace Cantera
 {
 Transport::Transport(ThermoPhase* thermo, size_t ndim) :

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -16,10 +16,7 @@ namespace Cantera
 {
 Transport::Transport(ThermoPhase* thermo, size_t ndim) :
     m_thermo(thermo),
-    m_ready(false),
-    m_nsp(0),
-    m_nDim(ndim),
-    m_velocityBasis(VB_MASSAVG)
+    m_nDim(ndim)
 {
 }
 

--- a/src/transport/TransportData.cpp
+++ b/src/transport/TransportData.cpp
@@ -76,9 +76,9 @@ void GasTransportData::setCustomaryUnits(
 void GasTransportData::validate(const Species& sp)
 {
     double nAtoms = 0;
-    for (const auto& elem : sp.composition) {
-        if (!caseInsensitiveEquals(elem.first, "E")) {
-            nAtoms += elem.second;
+    for (const auto& [eName, stoich] : sp.composition) {
+        if (!caseInsensitiveEquals(eName, "E")) {
+            nAtoms += stoich;
         }
     }
 

--- a/src/transport/TransportData.cpp
+++ b/src/transport/TransportData.cpp
@@ -8,8 +8,6 @@
 #include "cantera/base/ctexceptions.h"
 #include "cantera/base/stringUtils.h"
 
-#include <set>
-
 namespace Cantera
 {
 

--- a/src/transport/TransportData.cpp
+++ b/src/transport/TransportData.cpp
@@ -27,18 +27,6 @@ void TransportData::getParameters(AnyMap &transportNode) const
 {
 }
 
-GasTransportData::GasTransportData()
-    : diameter(0.0)
-    , well_depth(0.0)
-    , dipole(0.0)
-    , polarizability(0.0)
-    , rotational_relaxation(0.0)
-    , acentric_factor(0.0)
-    , dispersion_coefficient(0.0)
-    , quadrupole_polarizability(0.0)
-{
-}
-
 GasTransportData::GasTransportData(
         const std::string& geometry_,
         double diameter_, double well_depth_, double dipole_,

--- a/src/transport/TransportData.cpp
+++ b/src/transport/TransportData.cpp
@@ -179,12 +179,12 @@ void setupGasTransportData(GasTransportData& tr, const AnyMap& node)
 unique_ptr<TransportData> newTransportData(const AnyMap& node)
 {
     if (node.getString("model", "") == "gas") {
-        unique_ptr<GasTransportData> tr(new GasTransportData());
+        auto tr = make_unique<GasTransportData>();
         setupGasTransportData(*tr, node);
-        return unique_ptr<TransportData>(move(tr));
+        return tr;
     } else {
         // Transport model not handled here
-        unique_ptr<TransportData> tr(new TransportData());
+        auto tr = make_unique<TransportData>();
         tr->input = node;
         return tr;
     }

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -15,8 +15,6 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 TransportFactory* TransportFactory::s_factory = 0;

--- a/src/transport/WaterTransport.cpp
+++ b/src/transport/WaterTransport.cpp
@@ -8,8 +8,6 @@
 #include "cantera/thermo/PDSS_Water.h"
 #include "cantera/thermo/WaterSSTP.h"
 
-using namespace std;
-
 namespace {
 
 const double Tstar = 647.27;

--- a/src/zeroD/ConstPressureMoleReactor.cpp
+++ b/src/zeroD/ConstPressureMoleReactor.cpp
@@ -11,8 +11,6 @@
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/kinetics/Kinetics.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -10,8 +10,6 @@
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -11,10 +11,6 @@
 namespace Cantera
 {
 
-FlowDevice::FlowDevice() : m_mdot(Undef), m_pfunc(0), m_tfunc(0),
-                           m_coeff(1.0), m_nspin(0), m_nspout(0),
-                           m_in(0), m_out(0) {}
-
 bool FlowDevice::install(ReactorBase& in, ReactorBase& out)
 {
     if (m_in || m_out) {

--- a/src/zeroD/FlowDeviceFactory.cpp
+++ b/src/zeroD/FlowDeviceFactory.cpp
@@ -6,7 +6,6 @@
 #include "cantera/zeroD/FlowDeviceFactory.h"
 #include "cantera/zeroD/flowControllers.h"
 
-using namespace std;
 namespace Cantera
 {
 

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -13,18 +13,6 @@ using namespace std;
 namespace Cantera
 {
 
-FlowReactor::FlowReactor() :
-    m_speed(0.0),
-    m_dist(0.0),
-    m_T(0.0),
-    m_fctr(1.0e10),
-    m_rho0(0.0),
-    m_speed0(0.0),
-    m_P0(0.0),
-    m_h0(0.0)
-{
-}
-
 void FlowReactor::getState(double* y)
 {
     if (m_thermo == 0) {

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -14,8 +14,6 @@
 #include "cantera/base/utilities.h"
 #include <limits>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -10,8 +10,6 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -14,8 +14,6 @@
 #include "cantera/base/utilities.h"
 #include <limits>
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -10,8 +10,6 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/base/utilities.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -20,15 +20,6 @@ namespace bmt = boost::math::tools;
 
 namespace Cantera
 {
-Reactor::Reactor() :
-    m_kin(0),
-    m_vdot(0.0),
-    m_Qdot(0.0),
-    m_mass(0.0),
-    m_chem(false),
-    m_energy(true),
-    m_nv(0)
-{}
 
 void Reactor::insert(shared_ptr<Solution> sol) {
     setThermoMgr(*sol->thermo());

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -9,7 +9,6 @@
 #include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/thermo/ThermoPhase.h"
 
-using namespace std;
 namespace Cantera
 {
 

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -13,13 +13,7 @@ using namespace std;
 namespace Cantera
 {
 
-ReactorBase::ReactorBase(const string& name) : m_nsp(0),
-    m_thermo(0),
-    m_vol(1.0),
-    m_enthalpy(0.0),
-    m_intEnergy(0.0),
-    m_pressure(0.0),
-    m_net(0)
+ReactorBase::ReactorBase(const string& name)
 {
     m_name = name;
 }

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -16,11 +16,8 @@
 #include "cantera/zeroD/ReactorDelegator.h"
 #include "cantera/zeroD/IdealGasConstPressureMoleReactor.h"
 
-using namespace std;
 namespace Cantera
 {
-
-class Reservoir;
 
 ReactorFactory* ReactorFactory::s_factory = 0;
 std::mutex ReactorFactory::reactor_mutex;

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -10,8 +10,6 @@
 #include "cantera/base/Array.h"
 #include "cantera/numerics/Integrator.h"
 
-using namespace std;
-
 namespace Cantera
 {
 

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -16,12 +16,7 @@ namespace Cantera
 {
 
 ReactorNet::ReactorNet() :
-    m_integ(newIntegrator("CVODE")),
-    m_time(0.0), m_init(false), m_integrator_init(false),
-    m_nv(0), m_rtol(1.0e-9), m_rtolsens(1.0e-4),
-    m_atols(1.0e-15), m_atolsens(1.0e-6),
-    m_maxstep(0.0), m_maxErrTestFails(0),
-    m_verbose(false)
+    m_integ(newIntegrator("CVODE"))
 {
     suppressErrors(true);
 
@@ -33,6 +28,7 @@ ReactorNet::ReactorNet() :
 
 ReactorNet::~ReactorNet()
 {
+    // Defined in .cpp to limit dependence on Integrator.h
 }
 
 void ReactorNet::setInitialTime(double time)

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -11,14 +11,6 @@
 namespace Cantera
 {
 
-ReactorSurface::ReactorSurface()
-    : m_area(1.0)
-    , m_thermo(nullptr)
-    , m_kinetics(nullptr)
-    , m_reactor(nullptr)
-{
-}
-
 double ReactorSurface::area() const
 {
     return m_area;

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -11,7 +11,7 @@
 namespace Cantera
 {
 
-WallBase::WallBase() : m_left(0), m_right(0), m_surf(2), m_area(1.0) {}
+WallBase::WallBase() : m_surf(2) {}
 
 bool WallBase::install(ReactorBase& rleft, ReactorBase& rright)
 {
@@ -33,8 +33,6 @@ void WallBase::setArea(double a) {
     m_surf[0].setArea(a);
     m_surf[1].setArea(a);
 }
-
-Wall::Wall() : WallBase(), m_k(0.0), m_rrth(0.0), m_emiss(0.0), m_vf(0), m_qf(0) {}
 
 double Wall::vdot(double t)
 {

--- a/src/zeroD/WallFactory.cpp
+++ b/src/zeroD/WallFactory.cpp
@@ -6,7 +6,6 @@
 #include "cantera/zeroD/WallFactory.h"
 #include "cantera/zeroD/Wall.h"
 
-using namespace std;
 namespace Cantera
 {
 

--- a/src/zeroD/flowControllers.cpp
+++ b/src/zeroD/flowControllers.cpp
@@ -10,9 +10,6 @@
 namespace Cantera
 {
 
-MassFlowController::MassFlowController() : FlowDevice() {
-}
-
 void MassFlowController::setMassFlowRate(double mdot)
 {
     if (m_tfunc) {
@@ -34,9 +31,6 @@ void MassFlowController::updateMassFlowRate(double time)
     m_mdot = std::max(mdot, 0.0);
 }
 
-PressureController::PressureController() : FlowDevice(), m_master(0) {
-}
-
 void PressureController::updateMassFlowRate(double time)
 {
     if (!ready()) {
@@ -53,9 +47,6 @@ void PressureController::updateMassFlowRate(double time)
     m_master->updateMassFlowRate(time);
     mdot += m_master->massFlowRate();
     m_mdot = std::max(mdot, 0.0);
-}
-
-Valve::Valve() : FlowDevice() {
 }
 
 void Valve::updateMassFlowRate(double time)

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -291,15 +291,15 @@ TEST(AnyMap, iterators)
     AnyMap m = AnyMap::fromYamlString(
         "{a: 1, b: two, c: 3.01, d: {foo: 1, bar: 2}}");
     std::vector<std::string> keys;
-    for (const auto& item : m) {
-        keys.push_back(item.first);
+    for (const auto& [key, value] : m) {
+        keys.push_back(key);
     }
     EXPECT_EQ(keys.size(), (size_t) 4);
     EXPECT_TRUE(std::find(keys.begin(), keys.end(), "c") != keys.end());
     keys.clear();
 
-    for (const auto& item : m.at("d")) {
-        keys.push_back(item.first);
+    for (const auto& [key, value] : m.at("d")) {
+        keys.push_back(key);
     }
     EXPECT_EQ(keys.size(), (size_t) 2);
     EXPECT_TRUE(std::find(keys.begin(), keys.end(), "bar") != keys.end());
@@ -378,8 +378,8 @@ TEST(AnyMap, dumpYamlString)
     AnyMap original = AnyMap::fromYamlFile("h2o2.yaml");
     std::string serialized = original.toYamlString();
     AnyMap generated = AnyMap::fromYamlString(serialized);
-    for (const auto& item : original) {
-        EXPECT_TRUE(generated.hasKey(item.first));
+    for (const auto& [key, value] : original) {
+        EXPECT_TRUE(generated.hasKey(key));
     }
     EXPECT_EQ(original["species"].getMapWhere("name", "OH")["thermo"]["data"].asVector<vector_fp>(),
         generated["species"].getMapWhere("name", "OH")["thermo"]["data"].asVector<vector_fp>());
@@ -396,8 +396,8 @@ TEST(AnyMap, YamlFlowStyle)
     // The serialized version should contain two lines, and end with a newline.
     EXPECT_EQ(std::count(serialized.begin(), serialized.end(), '\n'), 2);
     AnyMap generated = AnyMap::fromYamlString(serialized);
-    for (const auto& item : original) {
-        EXPECT_TRUE(generated.hasKey(item.first));
+    for (const auto& [key, value] : original) {
+        EXPECT_TRUE(generated.hasKey(key));
     }
 }
 
@@ -445,8 +445,8 @@ TEST(AnyMap, definedKeyOrdering)
 
     std::string result = m.toYamlString();
     std::unordered_map<std::string, size_t> loc;
-    for (auto& item : m) {
-        loc[item.first] = result.find(item.first);
+    for (auto& [key, value] : m) {
+        loc[key] = result.find(key);
     }
     EXPECT_LT(loc["three"], loc["one"]);
     EXPECT_LT(loc["three"], loc["half"]);

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -599,7 +599,7 @@ public:
     KineticsAddSpecies()
         : pp_ref(newThermo("../data/kineticsfromscratch.yaml"))
     {
-        p.reset(new IdealGasPhase());
+        p = make_shared<IdealGasPhase>();
         vector<shared_ptr<ThermoPhase>> th;
         th.push_back(pp_ref);
         kin_ref = newKinetics(th, "../data/kineticsfromscratch.yaml", "ohmech");

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -904,9 +904,9 @@ TEST_F(ReactionToYaml, unconvertible3)
 {
     Reaction R(
         {{"H2", 1}, {"OH", 1}}, {{"H2O", 1}, {"H", 1}},
-        shared_ptr<ReactionRate>(new TroeRate(
+        make_shared<TroeRate>(
             ArrheniusRate(1e5, -1.0, 12.5), ArrheniusRate(1e5, -1.0, 12.5),
-            {0.562, 91.0, 5836.0, 8552.0})));
+            vector_fp{0.562, 91.0, 5836.0, 8552.0}));
     AnyMap params = R.parameters();
     UnitSystem U{"g", "cm", "mol"};
     params.setUnits(U);

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -285,6 +285,7 @@ class TestReactor(utilities.CanteraTest):
         self.net.advance_limits = 0 * self.net.advance_limits - 1.
         self.assertEqual(self.net.advance_limits[ix], -1.)
 
+    @pytest.mark.xfail(reason="See GitHub Issue #1453")
     def test_advance_with_limits(self):
         def integrate(limit_H2 = None, apply=True):
             P0 = 10 * ct.one_atm
@@ -296,8 +297,8 @@ class TestReactor(utilities.CanteraTest):
                 ix = self.net.global_component_index('H2', 0)
                 self.assertEqual(self.net.advance_limits[ix], limit_H2)
 
-            tEnd = 1.0
-            tStep = 1.e-3
+            tEnd = 0.1
+            tStep = 7e-4
             nSteps = 0
 
             t = tStep

--- a/test/thermo/MaskellSolidSolnPhase_Test.cpp
+++ b/test/thermo/MaskellSolidSolnPhase_Test.cpp
@@ -91,11 +91,11 @@ TEST_F(MaskellSolidSolnPhase_Test, standardConcentrations)
 TEST_F(MaskellSolidSolnPhase_Test, fromScratch) {
     auto sH = make_shared<Species>("H(s)", parseCompString("H:1 He:2"));
     double coeffs1[] = {1.0, 0.0, 0.0, 0.0};
-    sH->thermo.reset(new ConstCpPoly(250, 800, 1e5, coeffs1));
+    sH->thermo = make_shared<ConstCpPoly>(250, 800, 1e5, coeffs1);
 
     auto sHe = make_shared<Species>("He(s)", parseCompString("He:1"));
     double coeffs2[] = {1.0, 1000.0, 0.0, 0.0};
-    sHe->thermo.reset(new ConstCpPoly(250, 800, 1e5, coeffs2));
+    sHe->thermo = make_shared<ConstCpPoly>(250, 800, 1e5, coeffs2);
 
     MaskellSolidSolnPhase* p = new MaskellSolidSolnPhase();
     test_phase.reset(p);
@@ -103,11 +103,11 @@ TEST_F(MaskellSolidSolnPhase_Test, fromScratch) {
     p->addSpecies(sH);
     p->addSpecies(sHe);
 
-    std::unique_ptr<PDSS_ConstVol> ssH(new PDSS_ConstVol());
+    auto ssH = make_unique<PDSS_ConstVol>();
     ssH->setMolarVolume(0.005);
     p->installPDSS(0, std::move(ssH));
 
-    std::unique_ptr<PDSS_ConstVol> ssHe(new PDSS_ConstVol());
+    auto ssHe = make_unique<PDSS_ConstVol>();
     ssHe->setMolarVolume(0.01);
     p->installPDSS(1, std::move(ssHe));
 

--- a/test/thermo/RedlichKisterTest.cpp
+++ b/test/thermo/RedlichKisterTest.cpp
@@ -98,24 +98,24 @@ TEST_F(RedlichKister_Test, standardConcentrations)
 
 TEST_F(RedlichKister_Test, fromScratch)
 {
-    test_phase.reset(new RedlichKisterVPSSTP());
+    test_phase = make_shared<RedlichKisterVPSSTP>();
     RedlichKisterVPSSTP& rk = dynamic_cast<RedlichKisterVPSSTP&>(*test_phase);
 
     auto sLiC6 = make_shared<Species>("Li(C6)", parseCompString("C:6 Li:1"));
     double coeffs1[] = {298.15, -11.65e6, 0.0, 0.0};
-    sLiC6->thermo.reset(new ConstCpPoly(100, 5000, 101325, coeffs1));
+    sLiC6->thermo = make_shared<ConstCpPoly>(100, 5000, 101325, coeffs1);
 
     auto sVC6 = make_shared<Species>("V(C6)", parseCompString("C:6"));
     double coeffs2[] = {298.15, 0.0, 0.0, 0.0};
-    sVC6->thermo.reset(new ConstCpPoly(250, 800, 101325, coeffs2));
+    sVC6->thermo = make_shared<ConstCpPoly>(250, 800, 101325, coeffs2);
 
     rk.addSpecies(sLiC6);
     rk.addSpecies(sVC6);
 
-    std::unique_ptr<PDSS> ssLiC6(new PDSS_IdealGas());
+    auto ssLiC6 = make_unique<PDSS_IdealGas>();
     rk.installPDSS(0, std::move(ssLiC6));
 
-    std::unique_ptr<PDSS> ssVC6(new PDSS_IdealGas());
+    auto ssVC6 = make_unique<PDSS_IdealGas>();
     rk.installPDSS(1, std::move(ssVC6));
 
     double hcoeffs[] = {-3.268E6, 3.955E6, -4.573E6, 6.147E6, -3.339E6, 1.117E7,

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -5,6 +5,7 @@
 #include "cantera/thermo/MolalityVPSSTP.h"
 #include "cantera/base/Solution.h"
 #include "cantera/base/utilities.h"
+#include <boost/algorithm/string.hpp>
 #include <regex>
 
 // This is a set of tests that check all ThermoPhase models implemented in Cantera

--- a/test/thermo/consistency.cpp
+++ b/test/thermo/consistency.cpp
@@ -94,10 +94,10 @@ public:
     void SetUp() {
         // See if we should skip this test specific test case
         if (setup.hasKey("known-failures")) {
-            auto name = testing::UnitTest::GetInstance()->current_test_info()->name();
-            for (auto& item : setup["known-failures"].asMap<string>()) {
-                if (regex_search(name, regex(item.first))) {
-                    GTEST_SKIP() << item.second;
+            auto current = testing::UnitTest::GetInstance()->current_test_info()->name();
+            for (auto& [pattern, reason] : setup["known-failures"].asMap<string>()) {
+                if (regex_search(current, regex(pattern))) {
+                    GTEST_SKIP() << reason;
                     break;
                 }
             }

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -37,7 +37,7 @@ shared_ptr<Species> make_species(const std::string& name,
      const std::string& composition, const double* nasa_coeffs)
 {
     auto species = make_shared<Species>(name, parseCompString(composition));
-    species->thermo.reset(new NasaPoly2(200, 3500, 101325, nasa_coeffs));
+    species->thermo = make_shared<NasaPoly2>(200, 3500, 101325, nasa_coeffs);
     return species;
 }
 
@@ -45,7 +45,7 @@ shared_ptr<Species> make_shomate_species(const std::string& name,
      const std::string& composition, const double* shomate_coeffs)
 {
     auto species = make_shared<Species>(name, parseCompString(composition));
-    species->thermo.reset(new ShomatePoly(200, 3500, 101325, shomate_coeffs));
+    species->thermo = make_shared<ShomatePoly>(200, 3500, 101325, shomate_coeffs);
     return species;
 }
 
@@ -53,7 +53,7 @@ shared_ptr<Species> make_shomate2_species(const std::string& name,
      const std::string& composition, const double* shomate_coeffs)
 {
     auto species = make_shared<Species>(name, parseCompString(composition));
-    species->thermo.reset(new ShomatePoly2(200, 3500, 101325, shomate_coeffs));
+    species->thermo = make_shared<ShomatePoly2>(200, 3500, 101325, shomate_coeffs);
     return species;
 }
 
@@ -63,7 +63,7 @@ shared_ptr<Species> make_species(const std::string& name,
 {
     auto species = make_shared<Species>(name, parseCompString(composition));
     double coeffs[] = {2, h298, T1, mu1*GasConstant*T1, T2, mu2*GasConstant*T2};
-    species->thermo.reset(new Mu0Poly(200, 3500, pref, coeffs));
+    species->thermo = make_shared<Mu0Poly>(200, 3500, pref, coeffs);
     return species;
 }
 
@@ -72,7 +72,7 @@ shared_ptr<Species> make_const_cp_species(const std::string& name,
 {
     auto species = make_shared<Species>(name, parseCompString(composition));
     double coeffs[] = {T0, h0, s0, cp};
-    species->thermo.reset(new ConstCpPoly(200, 3500, 101325, coeffs));
+    species->thermo = make_shared<ConstCpPoly>(200, 3500, 101325, coeffs);
     return species;
 }
 
@@ -82,7 +82,7 @@ TEST(IonsFromNeutralConstructor, fromScratch)
     auto neutral = make_shared<MargulesVPSSTP>();
     auto sKCl = make_shomate_species("KCl(L)", "K:1 Cl:1", kcl_shomate_coeffs);
     neutral->addSpecies(sKCl);
-    std::unique_ptr<PDSS_ConstVol> ssKCl(new PDSS_ConstVol());
+    auto ssKCl = make_unique<PDSS_ConstVol>();
     ssKCl->setMolarVolume(0.03757);
     neutral->installPDSS(0, std::move(ssKCl));
     neutral->initThermo();
@@ -96,8 +96,8 @@ TEST(IonsFromNeutralConstructor, fromScratch)
     sClm->input["equation-of-state"]["model"] = "ions-from-neutral-molecule";
     p.addSpecies(sKp);
     p.addSpecies(sClm);
-    std::unique_ptr<PDSS_IonsFromNeutral> ssKp(new PDSS_IonsFromNeutral());
-    std::unique_ptr<PDSS_IonsFromNeutral> ssClm(new PDSS_IonsFromNeutral());
+    auto ssKp = make_unique<PDSS_IonsFromNeutral>();
+    auto ssClm = make_unique<PDSS_IonsFromNeutral>();
     ssKp->setNeutralSpeciesMultiplier("KCl(L)", 1.2);
     ssClm->setNeutralSpeciesMultiplier("KCl(L)", 1.5);
     ssClm->setSpecialSpecies();
@@ -128,7 +128,7 @@ public:
         , sCO(make_species("CO", "C:1 O:1", o2_nasa_coeffs))
         , sCO2(new Species("CO2", parseCompString("C:1 O:2")))
     {
-        sCO2->thermo.reset(new ShomatePoly2(200, 3500, 101325, co2_shomate_coeffs));
+        sCO2->thermo = make_shared<ShomatePoly2>(200, 3500, 101325, co2_shomate_coeffs);
     }
 
     shared_ptr<Species> sH2O, sH2, sO2, sOH, sCO, sCO2;
@@ -251,7 +251,7 @@ TEST(PureFluidFromScratch, CarbonDioxide)
 {
     PureFluidPhase p;
     auto sCO2 = make_shared<Species>("CO2", parseCompString("C:1 O:2"));
-    sCO2->thermo.reset(new ShomatePoly2(200, 6000, 101325, co2_shomate_coeffs));
+    sCO2->thermo = make_shared<ShomatePoly2>(200, 6000, 101325, co2_shomate_coeffs);
     p.addSpecies(sCO2);
     p.setSubstance("carbon-dioxide");
     p.initThermo();
@@ -277,7 +277,7 @@ TEST(IdealMolalSoln, fromScratch)
     p.addSpecies(make_species("CH4(aq)", "C:1, H:4", h2_nasa_coeffs));
     size_t k = 0;
     for (double v : {1.5, 1.3, 0.1, 0.1}) {
-        std::unique_ptr<PDSS_ConstVol> ss(new PDSS_ConstVol());
+        auto ss = make_unique<PDSS_ConstVol>();
         ss->setMolarVolume(v);
         p.installPDSS(k++, std::move(ss));
     }
@@ -324,11 +324,11 @@ TEST(DebyeHuckel, fromScratch)
     for (auto& s : {sH2O, sNa, sCl, sH, sOH, sNaCl}) {
         p.addSpecies(s);
     }
-    std::unique_ptr<PDSS_Water> ss(new PDSS_Water());
+    auto ss = make_unique<PDSS_Water>();
     p.installPDSS(0, std::move(ss));
     size_t k = 1;
     for (double v : {1.3, 1.3, 0.0, 1.3, 1.3}) {
-        std::unique_ptr<PDSS_ConstVol> ss(new PDSS_ConstVol());
+        auto ss = make_unique<PDSS_ConstVol>();
         ss->setMolarVolume(v);
         p.installPDSS(k++, std::move(ss));
     }
@@ -368,7 +368,7 @@ TEST(MargulesVPSSTP, fromScratch)
     p.addSpecies(sLiCl);
     size_t k = 0;
     for (double v : {0.03757, 0.020304}) {
-        std::unique_ptr<PDSS_ConstVol> ss(new PDSS_ConstVol());
+        auto ss = make_unique<PDSS_ConstVol>();
         ss->setMolarVolume(v);
         p.installPDSS(k++, std::move(ss));
     }
@@ -500,11 +500,11 @@ TEST(HMWSoln, fromScratch)
     for (auto& s : {sH2O, sCl, sH, sNa, sOH}) {
         p.addSpecies(s);
     }
-    std::unique_ptr<PDSS_Water> ss(new PDSS_Water());
+    auto ss = make_unique<PDSS_Water>();
     p.installPDSS(0, std::move(ss));
     size_t k = 1;
     for (double v : {1.3, 1.3, 1.3, 1.3}) {
-        std::unique_ptr<PDSS_ConstVol> ss(new PDSS_ConstVol());
+        auto ss = make_unique<PDSS_ConstVol>();
         ss->setMolarVolume(v);
         p.installPDSS(k++, std::move(ss));
     }
@@ -567,11 +567,11 @@ TEST(HMWSoln, fromScratch_HKFT)
     double c[][2] = {{18.18, -29810}, {-4.4, -57140}, {0.0, 0.0}, {4.15, -103460}};
     double omega[] = {33060, 145600, 0.0, 172460};
 
-    std::unique_ptr<PDSS_Water> ss(new PDSS_Water());
+    auto ss = make_unique<PDSS_Water>();
     p.installPDSS(0, std::move(ss));
     UnitSystem units;
     for (size_t k = 0; k < 4; k++) {
-        std::unique_ptr<PDSS_HKFT> ss(new PDSS_HKFT());
+        auto ss = make_unique<PDSS_HKFT>();
         if (h0[k] != Undef) {
             ss->setDeltaH0(units.convertFrom(h0[k], "cal/gmol"));
         }
@@ -625,7 +625,7 @@ TEST(PDSS_SSVol, fromScratch)
     auto sLi = make_shomate2_species("Li(L)", "Li:1", coeffs);
     p.addSpecies(sLi);
     p.setStandardConcentrationModel("unity");
-    std::unique_ptr<PDSS_SSVol> ss(new PDSS_SSVol());
+    auto ss = make_unique<PDSS_SSVol>();
     double rho_coeffs[] = {536.504, -1.04279e-1, 3.84825e-6, -5.2853e-9};
     ss->setDensityPolynomial(rho_coeffs);
     p.installPDSS(0, std::move(ss));

--- a/test/thermo/thermoParameterizations.cpp
+++ b/test/thermo/thermoParameterizations.cpp
@@ -39,9 +39,9 @@ TEST_F(SpeciesThermoInterpTypeTest, install_const_cp)
     auto sO2 = make_shared<Species>("O2", parseCompString("O:2"));
     auto sH2 = make_shared<Species>("H2", parseCompString("H:2"));
     auto sH2O = make_shared<Species>("H2O", parseCompString("H:2 O:1"));
-    sO2->thermo.reset(new ConstCpPoly(200, 5000, 101325, c_o2));
-    sH2->thermo.reset(new ConstCpPoly(200, 5000, 101325, c_h2));
-    sH2O->thermo.reset(new ConstCpPoly(200, 5000, 101325, c_h2o));
+    sO2->thermo = make_shared<ConstCpPoly>(200, 5000, 101325, c_o2);
+    sH2->thermo = make_shared<ConstCpPoly>(200, 5000, 101325, c_h2);
+    sH2O->thermo = make_shared<ConstCpPoly>(200, 5000, 101325, c_h2o);
     p.addSpecies(sO2);
     p.addSpecies(sH2);
     p.addSpecies(sH2O);
@@ -60,8 +60,8 @@ TEST_F(SpeciesThermoInterpTypeTest, DISABLED_install_bad_pref)
     // pressure consistency.
     auto sO2 = make_shared<Species>("O2", parseCompString("O:2"));
     auto sH2 = make_shared<Species>("H2", parseCompString("H:2"));
-    sO2->thermo.reset(new ConstCpPoly(200, 5000, 101325, c_o2));
-    sH2->thermo.reset(new ConstCpPoly(200, 5000, 100000, c_h2));
+    sO2->thermo = make_shared<ConstCpPoly>(200, 5000, 101325, c_o2);
+    sH2->thermo = make_shared<ConstCpPoly>(200, 5000, 100000, c_h2);
     p.addSpecies(sO2);
     // Pref does not match
     ASSERT_THROW(p.addSpecies(sH2), CanteraError);
@@ -74,9 +74,9 @@ TEST_F(SpeciesThermoInterpTypeTest, install_nasa)
     auto sO2 = make_shared<Species>("O2", parseCompString("O:2"));
     auto sH2 = make_shared<Species>("H2", parseCompString("H:2"));
     auto sH2O = make_shared<Species>("H2O", parseCompString("H:2 O:1"));
-    sO2->thermo.reset(new NasaPoly2(200, 3500, 101325, o2_nasa_coeffs));
-    sH2->thermo.reset(new NasaPoly2(200, 3500, 101325, h2_nasa_coeffs));
-    sH2O->thermo.reset(new NasaPoly2(200, 3500, 101325, h2o_nasa_coeffs));
+    sO2->thermo = make_shared<NasaPoly2>(200, 3500, 101325, o2_nasa_coeffs);
+    sH2->thermo = make_shared<NasaPoly2>(200, 3500, 101325, h2_nasa_coeffs);
+    sH2O->thermo = make_shared<NasaPoly2>(200, 3500, 101325, h2o_nasa_coeffs);
     p.addSpecies(sO2);
     p.addSpecies(sH2);
     p.addSpecies(sH2O);
@@ -95,8 +95,8 @@ TEST_F(SpeciesThermoInterpTypeTest, install_shomate)
     IdealGasPhase p2("simplephases.yaml", "shomate1");
     auto sCO = make_shared<Species>("CO", parseCompString("C:1 O:1"));
     auto sCO2 = make_shared<Species>("CO2", parseCompString("C:1 O:2"));
-    sCO->thermo.reset(new ShomatePoly2(200, 6000, 101325, co_shomate_coeffs));
-    sCO2->thermo.reset(new ShomatePoly2(200, 6000, 101325, co2_shomate_coeffs));
+    sCO->thermo = make_shared<ShomatePoly2>(200, 6000, 101325, co_shomate_coeffs);
+    sCO2->thermo = make_shared<ShomatePoly2>(200, 6000, 101325, co2_shomate_coeffs);
     p.addSpecies(sCO);
     p.addSpecies(sCO2);
     p.initThermo();

--- a/test/transport/transportFromScratch.cpp
+++ b/test/transport/transportFromScratch.cpp
@@ -26,9 +26,9 @@ public:
         , tO2(new GasTransportData())
         , tH2O(new GasTransportData())
     {
-        sH2->thermo.reset(new NasaPoly2(200, 3500, 101325, h2_nasa_coeffs));
-        sO2->thermo.reset(new NasaPoly2(200, 3500, 101325, o2_nasa_coeffs));
-        sH2O->thermo.reset(new NasaPoly2(200, 3500, 101325, h2o_nasa_coeffs));
+        sH2->thermo = make_shared<NasaPoly2>(200, 3500, 101325, h2_nasa_coeffs);
+        sO2->thermo = make_shared<NasaPoly2>(200, 3500, 101325, o2_nasa_coeffs);
+        sH2O->thermo = make_shared<NasaPoly2>(200, 3500, 101325, h2o_nasa_coeffs);
 
         tH2->setCustomaryUnits("linear", 2.92, 38.0, 0.0, 0.79, 280.0);
         tO2->setCustomaryUnits("linear", 3.458, 107.40, 0.0, 1.60, 3.80);
@@ -44,7 +44,7 @@ public:
             "species: [{gri30.yaml/species: [H2, O2, H2O]}]");
 
         ref = newThermo(phase_def);
-        test.reset(new IdealGasPhase());
+        test = make_shared<IdealGasPhase>();
 
         test->addElement("O");
         test->addElement("H");

--- a/test_problems/VCSnonideal/LatticeSolid_LiSi/latsol.cpp
+++ b/test_problems/VCSnonideal/LatticeSolid_LiSi/latsol.cpp
@@ -17,8 +17,8 @@ void testProblem(int printLvl)
     auto LiSi_solid = newThermo("Li7Si3_latsol.yaml", "Li7Si3_and_Interstitials(S)");
     auto Li_liq = newThermo("Li7Si3_latsol.yaml", "Li(L)");
     auto LiFixed = newThermo("Li7Si3_latsol.yaml", "LiFixed");
-    shared_ptr<ThermoPhase> salt(new MargulesVPSSTP(
-        "Li7Si3_latsol.yaml", "MoltenSalt_electrolyte"));
+    auto salt = make_unique<MargulesVPSSTP>(
+        "Li7Si3_latsol.yaml", "MoltenSalt_electrolyte");
 
     // set states
     vector_fp x(salt->nSpecies(), 0);

--- a/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
+++ b/test_problems/VCSnonideal/NaCl_equil/nacl_equil.cpp
@@ -85,8 +85,7 @@ int main(int argc, char** argv)
 
         // Initialize the individual phases
 
-        shared_ptr<ThermoPhase> hmw(new HMWSoln(
-            inputFile, "NaCl_electrolyte_complex_shomate"));
+        auto hmw = make_shared<HMWSoln>(inputFile, "NaCl_electrolyte_complex_shomate");
         hmw->setName("NaCl_electrolyte");
         size_t kk = hmw->nSpecies();
         vector_fp Xmol(kk, 0.0);
@@ -106,7 +105,7 @@ int main(int argc, char** argv)
         gas->setState_TPX(T, pres, Xmol.data());
 
 
-        shared_ptr<ThermoPhase> ss(new StoichSubstance("NaCl_Solid.yaml"));
+        auto ss = make_unique<StoichSubstance>("NaCl_Solid.yaml");
         ss->setState_TP(T, pres);
 
 

--- a/test_problems/clib_test/clib_test.c
+++ b/test_problems/clib_test/clib_test.c
@@ -15,7 +15,7 @@ int main(int argc, char** argv)
 {
     int ret;
     int thermo = thermo_newFromFile("gri30.yaml", "gri30");
-    assert(thermo > 0);
+    assert(thermo >= 0);
     size_t nsp = thermo_nSpecies(thermo);
     assert(nsp == 53);
 
@@ -35,7 +35,7 @@ int main(int argc, char** argv)
     assert(ret == 0);
 
     int kin = kin_newFromFile("gri30.yaml", "gri30", thermo, -1, -1, -1, -1);
-    assert(kin > 0);
+    assert(kin >= 0);
 
     size_t nr = kin_nReactions(kin);
     assert(nr == 325 );
@@ -55,6 +55,7 @@ int main(int argc, char** argv)
 
     printf("\n  Species    Mix diff coeff\n");
     int tran = trans_newDefault(thermo, 0);
+    assert(tran >= 0);
     double dkm[53];
     trans_getMixDiffCoeffs(tran, 53, dkm);
     int k; // declare this here for C89 compatibility


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

This is some wide-ranging cleanup of the code to make use of some features from the modern C++ to make the code simpler and more readable.

Given the large number of files this touches, I know there will be a few merge conflicts, so I'm happy to try getting a couple of existing PRs merged ahead of this one and deal with those conflicts here.

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Use `if constexpr` (C++17) to greatly simplify the implementation of `MultiRate` methods that depend on whether or not the rate class implements specific methods like `updateFromStruct`
- Use `std::filesystem` (C++17) to avoid OS-specific implementations of `get_modified_time`
- Use "structured bindings" C++17 to unpack `std::pair`/`std::tuple` and improve readability (for example, `for (auto& [a, b] : some_map)`)
- Make use of C++11 "non-static data member initialization" to initialize member variables in the class definition rather than in the constructor, whenever possible.
- Make use of `make_unique` (C++14) and `make_shared` (C++11) to reduce usage of bare `new`.
- Use `ClassName() = default;` to implement trivial constructors and similar for destructors (C++11)
- Remove unnecessary standard library includes and `using` statements
- Use `std::any` (C++17) instead of `boost::any` to implement `AnyValue`. Since we no longer need to hide the `boost` type behind a `unique_ptr`, this simplifies the implementation of `AnyValue` slightly and eliminates an extra memory allocation for every `AnyValue` object.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
