### PR TITLE
Solutionarray summary

### DIFF
--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -90,10 +90,12 @@ public:
 
     /*!
      *  Print a concise summary of a SolutionArray.
+     *  @param keys  List of components to be displayed; if empty, all components are
+     *      considered.
      *  @param rows  Maximum number of rendered rows.
      *  @param width  Maximum width of rendered output.
      */
-    string info(int rows=10, int width=80);
+    string info(const vector<string>& keys, int rows=10, int width=80);
 
     //! SolutionArray meta data.
     AnyMap& meta() {

--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -88,6 +88,13 @@ public:
         return m_apiShape.size();
     }
 
+    /*!
+     *  Print a concise summary of a SolutionArray.
+     *  @param rows  Maximum number of rendered rows.
+     *  @param width  Maximum width of rendered output.
+     */
+    string info(int rows=10, int width=80);
+
     //! SolutionArray meta data.
     AnyMap& meta() {
         return m_meta;

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -78,7 +78,7 @@ cdef extern from "cantera/base/SolutionArray.h" namespace "Cantera":
         vector[long int] apiShape() except +translate_exception
         void setApiShape(vector[long int]&) except +translate_exception
         size_t apiNdim()
-        string info(int, int) except +translate_exception
+        string info(vector[string]&, int, int) except +translate_exception
         CxxAnyMap meta()
         void setMeta(CxxAnyMap&)
         vector[string] componentNames() except +translate_exception

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -78,6 +78,7 @@ cdef extern from "cantera/base/SolutionArray.h" namespace "Cantera":
         vector[long int] apiShape() except +translate_exception
         void setApiShape(vector[long int]&) except +translate_exception
         size_t apiNdim()
+        string info(int, int) except +translate_exception
         CxxAnyMap meta()
         void setMeta(CxxAnyMap&)
         vector[string] componentNames() except +translate_exception

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -520,6 +520,9 @@ cdef class SolutionArrayBase:
         dest.base = dest._base.get()
         return dest
 
+    def __repr__(self):
+        return self.info()
+
     @property
     def size(self):
         """ The number of elements in the `SolutionArrayBase`. """

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -4,6 +4,7 @@
 cimport numpy as np
 import numpy as np
 from pathlib import PurePath
+from os import get_terminal_size
 import warnings
 
 from .thermo cimport *
@@ -538,7 +539,7 @@ cdef class SolutionArrayBase:
             cxx_shape.push_back(dim)
         self.base.setApiShape(cxx_shape)
 
-    def info(self, keys=None, rows=10, width=80):
+    def info(self, keys=None, rows=10, width=None):
         """
         Print a concise summary of a `SolutionArray`.
 
@@ -560,6 +561,12 @@ cdef class SolutionArrayBase:
             for key in self.component_names:
                 if key not in names or key in keep:
                     cxx_keys.push_back(stringify(key))
+        if width is None:
+            try:
+                width = get_terminal_size().columns
+            except:
+                width = 100
+
         return pystr(self.base.info(cxx_keys, rows, width))
 
     @property

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -537,6 +537,15 @@ cdef class SolutionArrayBase:
             cxx_shape.push_back(dim)
         self.base.setApiShape(cxx_shape)
 
+    def info(self, rows=10, width=80):
+        """
+        Print a concise summary of a `SolutionArray`.
+
+        :param rows: Maximum number of rendered rows.
+        :param width: Maximum width of rendered output.
+        """
+        return pystr(self.base.info(rows, width))
+
     @property
     def meta(self):
         """

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -505,11 +505,8 @@ string SolutionArray::info(const vector<string>& keys, int rows, int width)
             // add separator
             cols.push_back(vector<string>(size + 1, "  ..."));
         }
-        while (tail.size()) {
-            // copy trailing columns
-            cols.push_back(tail.back());
-            tail.pop_back();
-        }
+        // copy trailing columns
+        cols.insert(cols.end(), tail.rbegin(), tail.rend());
 
         // assemble formatted output
         for (size_t row = 0; row < size; row++) {

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -278,6 +278,121 @@ class TestSolutionArray(utilities.CanteraTest):
         assert gas.n_species == N + 1
 
 
+class TestSolutionArrayInfo(utilities.CanteraTest):
+    """ Test SolutionArray summary output """
+    width = 80
+
+    @classmethod
+    def setUpClass(cls):
+        utilities.CanteraTest.setUpClass()
+        cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
+
+    def setUp(self):
+        self.gas.TPY = 300, ct.one_atm, "H2: 1"
+
+    def check(self, arr, repr, rows):
+        count = 0
+        width = None
+        header = None
+        for line in repr.split("\n"):
+            if not len(line):
+                break
+            if width is None:
+                width = len(line)
+                assert width <= self.width
+                header = line.split()
+            else:
+                assert width == len(line)
+            count += 1
+
+        if rows is not None:
+            assert count == rows + 1 # account for header
+
+        names = arr.component_names
+        if "..." not in header:
+            assert len(header) == len(names)
+        else:
+            assert len(header) > 1
+            header = {key for key in header if key != "..."}
+            assert not header.difference(names)
+
+    def test_short(self):
+        arr = ct.SolutionArray(self.gas, 5)
+        self.check(arr, arr.info(rows=10, width=self.width), 5)
+
+    def test_long(self):
+        arr = ct.SolutionArray(self.gas, 20, extra={"spam": "eggs"})
+        self.check(arr, arr.info(rows=10, width=self.width), 11)
+
+    def test_scientific(self):
+        arr = ct.SolutionArray(self.gas, 20)
+        arr.set_equivalence_ratio(np.linspace(.5, 1.5, 20), "H2", "O2:1,N2:10")
+        arr.equilibrate("HP")
+        self.check(arr, arr.info(rows=7, width=self.width), 8)
+
+    def test_plus_minus_i(self):
+        arr = ct.SolutionArray(self.gas, 20,
+                               extra={"foo": 10 * np.arange(-10, 10, dtype=int)})
+        self.check(arr, arr.info(rows=12, width=self.width), 13)
+
+    def test_plus_minus_f(self):
+        arr = ct.SolutionArray(self.gas, 20, extra={"foo": "bar", "spam": "eggs"})
+        self.check(arr, arr.info(rows=9), 10)
+        arr.foo = np.linspace(-1, 1.5, 20)
+        self.check(arr, arr.info(rows=12, width=self.width), 13)
+
+    def test_plus_minus_e(self):
+        arr = ct.SolutionArray(self.gas, 20, extra={"foo": "bar", "spam": "eggs"})
+        self.check(arr, arr.info(rows=9, width=100), 10)
+        arr.foo = np.linspace(-1e6, 1.5e6, 20)
+        self.check(arr, arr.info(rows=12, width=self.width), 13)
+
+    def test_strings(self):
+        arr = ct.SolutionArray(self.gas, 26, extra={"foo": "bar", "spam": "eggs"})
+        arr.spam = ["abcdefghijklmnopqrstuvwxyz"[:ix+1] for ix in range(26)]
+        self.check(arr, arr.info(rows=12, width=self.width), 13)
+
+    def test_double_vector(self):
+        arr = ct.SolutionArray(self.gas, 15, extra={"spam": "eggs"})
+        arr.spam = [[1.1, 2.2, 3.3] for _ in range(15)]
+        self.check(arr, arr.info(rows=12, width=self.width), 13)
+
+    def test_integer_vector(self):
+        arr = ct.SolutionArray(self.gas, 15, extra={"spam": "eggs"})
+        arr.spam = [np.array([1, 2, 3], dtype=int) for _ in range(15)]
+        self.check(arr, arr.info(rows=12, width=self.width), 13)
+
+    def test_string_vector(self):
+        arr = ct.SolutionArray(self.gas, 15, extra={"spam": "eggs"})
+        arr.spam = [["foo", "bar"] for _ in range(15)]
+        self.check(arr, arr.info(rows=12, width=self.width), 13)
+
+    def test_select_species(self):
+        arr = ct.SolutionArray(self.gas, 5)
+        arr2 = arr("H2")
+        lines = arr2.info(width=self.width).split("\n")
+        assert lines[0].split() == ["T", "D", "H2"]
+
+    def test_select_rows(self):
+        arr = ct.SolutionArray(self.gas, 25)
+        ix = [2, 5, 6, 9, 15, 3]
+        arr2 = arr[ix]
+        self.check(arr2, arr2.info(width=self.width), 6)
+        lines = arr2.info(width=self.width).split("\n")[1:-2]
+        loc = [int(line.split()[0]) for line in lines]
+        assert loc == ix
+
+    def test_water_simple(self):
+        w = ct.Water()
+        arr = ct.SolutionArray(w, 10)
+        self.check(arr, arr.info(rows=12, width=self.width), 10)
+
+    def test_water_extra(self):
+        w = ct.Water()
+        arr = ct.SolutionArray(w, 15, extra={"spam": np.arange(15, dtype=int)})
+        self.check(arr, arr.info(rows=7, width=self.width), 8)
+
+
 class TestSolutionArrayIO(utilities.CanteraTest):
     """ Test SolutionArray file IO """
     @classmethod


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR adds a utility function `SolutionArray::info`, which provides a concise summary of the content. The styling is inspired by *pandas*' `DataFrame.info`, although it is implemented in C++ and thus available for all API's. Under the hood, the C++ library `fmt` is used to format content.

~In addition, this PR fixes a glitch in the order of `SolutionArray::componentNames`, where the native storage mode `TDY` was alphabetically sorted as `DTY` (same fix is also added in #1464).~

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
In [1]: import cantera as ct
   ...: gas = ct.Solution("h2o2.yaml")
   ...: arr = ct.SolutionArray(gas, 20, extra={"spam": "eggs"})

In [2]: arr
Out[2]:
      T          D   H2    H    O   O2   OH  H2O  HO2  H2O2   AR   N2  spam
0   300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
1   300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
2   300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
3   300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
4   300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
..  ...        ...  ...  ...  ...  ...  ...  ...  ...   ...  ...  ...   ...
15  300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
16  300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
17  300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
18  300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs
19  300  0.0818939    1    0    0    0    0    0    0     0    0    0  eggs

[20 rows x 13 components; state='TDY']
```

and
```
In [3]: import numpy as np
   ...: arr.set_equivalence_ratio(np.linspace(.5, 1.5, 20), "H2", "O2:1,N2:10")
   ...: arr.equilibrate("HP")
   ...: arr.spam = np.linspace(-1e-6, 1e-6, 20)

In [4]: print(arr.info(rows=7, width=100))
           T         D           H2            H  ...         H2O2   AR        N2         spam
0    975.173  0.341386  1.25945e-12  1.75212e-16  ...  4.62014e-11    0  0.891728 -1.00000e-06
1   1036.780  0.319853  9.06756e-12  2.40164e-15  ...  1.05086e-10    0  0.891126 -8.94737e-07
2   1096.955  0.301139  5.14047e-11  2.36240e-14  ...  2.12557e-10    0  0.890525 -7.89474e-07
3   1155.770  0.284717  2.40637e-10  1.77659e-13  ...  3.89439e-10    0  0.889925 -6.84211e-07
..       ...       ...          ...          ...  ...          ...  ...       ...          ...
17  1446.986  0.209250  5.00863e-03  9.17217e-08  ...  7.48958e-14    0  0.881604  7.89474e-07
18  1439.223  0.208801  5.67268e-03  8.85969e-08  ...  5.62427e-14    0  0.881016  8.94737e-07
19  1431.564  0.208357  6.33584e-03  8.50061e-08  ...  4.28479e-14    0  0.880428  1.00000e-06

[20 rows x 13 components; state='TDY']
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
