### PR TITLE
Counterflow solution strategy

### DIFF
--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -1336,7 +1336,10 @@ cdef class Sim1D:
             # If initial solve using energy equation fails, fall back on the
             # traditional fixed temperature solve followed by solving the energy
             # equation
-            if not solved:
+            if not solved or self.extinct():
+                if self.extinct():
+                    self.set_initial_guess(*self._initial_guess_args,
+                                           **self._initial_guess_kwargs)
                 log('Initial solve failed; Retrying with energy equation disabled')
                 self.energy_enabled = False
                 try:


### PR DESCRIPTION
Currently, an "extinct flame" solution is treated as successful solution for counterflow flames. Therefore, trying to find a solution by first disabling the energy equation is never tried. However, this can significantly increase the chance of finding the non-extinct solution. This PR modifies the solution strategy for counterflow flames so that after an extinct flame solution is found, the normal workflow of trying another solution with disabled energy equation is applied. Previous discussion can be found in https://github.com/Cantera/enhancements/issues/155.

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
