### PR TITLE
Remove vestigial onedim Python functions and methods

### DIFF
--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -148,6 +148,9 @@ public:
     //! Set the state vector for a given location.
     void setState(size_t loc, const vector<double>& state);
 
+    //! Normalize mass/mole fractions
+    void normalize();
+
     /*!
      *  Add auxiliary component to SolutionArray. Initialization requires a subsequent
      *  call of setComponent.

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -160,7 +160,7 @@ public:
     virtual void eval(size_t jg, double* xg, double* rg,
                       integer* diagg, double rdt);
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void restore(SolutionArray& arr, double* soln);
+    virtual void fromArray(SolutionArray& arr, double* soln);
 
 protected:
     int m_ilr;
@@ -199,7 +199,7 @@ public:
                       integer* diagg, double rdt);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void restore(SolutionArray& arr, double* soln) {}
+    virtual void fromArray(SolutionArray& arr, double* soln) {}
 };
 
 /**
@@ -229,7 +229,7 @@ public:
                       integer* diagg, double rdt);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void restore(SolutionArray& arr, double* soln) {}
+    virtual void fromArray(SolutionArray& arr, double* soln) {}
 };
 
 
@@ -259,7 +259,7 @@ public:
                       integer* diagg, double rdt);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void restore(SolutionArray& arr, double* soln) {}
+    virtual void fromArray(SolutionArray& arr, double* soln) {}
 };
 
 
@@ -293,7 +293,7 @@ public:
     virtual void eval(size_t jg, double* xg, double* rg,
                       integer* diagg, double rdt);
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void restore(SolutionArray& arr, double* soln);
+    virtual void fromArray(SolutionArray& arr, double* soln);
 
 protected:
     size_t m_nsp = 0;
@@ -330,7 +330,7 @@ public:
                       integer* diagg, double rdt);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void restore(SolutionArray& arr, double* soln);
+    virtual void fromArray(SolutionArray& arr, double* soln);
 
     virtual void show(std::ostream& s, const double* x);
 
@@ -373,7 +373,7 @@ public:
                       integer* diagg, double rdt);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void restore(SolutionArray& arr, double* soln);
+    virtual void fromArray(SolutionArray& arr, double* soln);
 
     virtual void _getInitialSoln(double* x) {
         m_sphase->getCoverages(x);

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -540,12 +540,19 @@ public:
         m_force_full_update = update;
     }
 
+    //! Set shared data pointer
+    void setData(shared_ptr<vector<double>>& data) {
+        m_data = data;
+    }
+
 protected:
     //! Retrieve meta data
     virtual AnyMap getMeta() const;
 
     //! Retrieve meta data
     virtual void setMeta(const AnyMap& meta);
+
+    shared_ptr<vector<double>> m_data; //!< data pointer shared from OneDim
 
     double m_rdt = 0.0;
     size_t m_nv = 0;

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -562,7 +562,7 @@ public:
 
     //! Set shared data pointer
     void setData(shared_ptr<vector<double>>& data) {
-        m_data = data;
+        m_state = data;
     }
 
 protected:
@@ -572,7 +572,7 @@ protected:
     //! Retrieve meta data
     virtual void setMeta(const AnyMap& meta);
 
-    shared_ptr<vector<double>> m_data; //!< data pointer shared from OneDim
+    shared_ptr<vector<double>> m_state; //!< data pointer shared from OneDim
 
     double m_rdt = 0.0;
     size_t m_nv = 0;

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -344,15 +344,27 @@ public:
      */
     AnyMap serialize(const double* soln) const;
 
-    //! Save the state of this domain as a SolutionArray
+    //! Save the state of this domain as a SolutionArray.
     /*!
      * @param soln local solution vector for this domain
+     * @todo  Despite the method's name, data are copied; the intent is to access data
+     *      directly in future revisions, where a non-const version will be implemented.
      *
      * @since  New in Cantera 3.0.
      */
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const {
         throw NotImplementedError("Domain1D::asArray", "Needs to be overloaded.");
     }
+
+    //! Save the state of this domain to a SolutionArray.
+    /*!
+     * This method serves as an external interface for high-level API's; it does not
+     * provide direct access to memory.
+     * @param normalize If true, normalize concentrations (default=false)
+     *
+     * @since  New in Cantera 3.0.
+     */
+    shared_ptr<SolutionArray> toArray(bool normalize=false) const;
 
     //! Restore the solution for this domain from an AnyMap
     /*!
@@ -372,9 +384,17 @@ public:
      *
      * @since  New in Cantera 3.0.
      */
-    virtual void restore(SolutionArray& arr, double* soln) {
-        throw NotImplementedError("Domain1D::restore", "Needs to be overloaded.");
+    virtual void fromArray(SolutionArray& arr, double* soln) {
+        throw NotImplementedError("Domain1D::fromArray", "Needs to be overloaded.");
     }
+
+    //! Restore the solution for this domain from a SolutionArray.
+    /*!
+     * This method serves as an external interface for high-level API's.
+     * @param  arr SolutionArray defining the state of this domain
+     * @since  New in Cantera 3.0.
+     */
+    void fromArray(const shared_ptr<SolutionArray>& arr);
 
     //! Return thermo/kinetics/transport manager used in the domain
     //! @since  New in Cantera 3.0.

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -340,7 +340,7 @@ protected:
     //! factor time step is multiplied by  if time stepping fails ( < 1 )
     double m_tfactor = 0.5;
 
-    shared_ptr<vector<double>> m_data; //!< Solution vector
+    shared_ptr<vector<double>> m_state; //!< Solution vector
 
     std::unique_ptr<MultiJac> m_jac; //!< Jacobian evaluator
     std::unique_ptr<MultiNewton> m_newt; //!< Newton iterator

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -233,6 +233,7 @@ public:
      */
     void writeStats(int printTime = 1);
 
+    //! @deprecated  To be removed after Cantera 3.0; unused.
     AnyMap serialize(const double* soln) const;
 
     // options

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -339,6 +339,8 @@ protected:
     //! factor time step is multiplied by  if time stepping fails ( < 1 )
     double m_tfactor = 0.5;
 
+    shared_ptr<vector<double>> m_data; //!< Solution vector
+
     std::unique_ptr<MultiJac> m_jac; //!< Jacobian evaluator
     std::unique_ptr<MultiNewton> m_newt; //!< Newton iterator
     double m_rdt = 0.0; //!< reciprocal of time step

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -120,11 +120,13 @@ public:
     /**
      * Output information on current solution for all domains to stream.
      * @param s  Output stream
+     * @since  New in Cantera 3.0.
      */
     void show(std::ostream& s);
 
     /**
      * Show logging information on current solution for all domains.
+     * @since  New in Cantera 3.0.
      */
     void show();
 

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -196,7 +196,7 @@ public:
     const doublereal* solution() {
         warn_deprecated("Sim1D::solution",
             "This method is unused and will be removed after Cantera 3.0.");
-        return m_x.data();
+        return m_data->data();
     }
 
     void setTimeStep(double stepsize, size_t n, const int* tsteps);
@@ -204,12 +204,12 @@ public:
     void solve(int loglevel = 0, bool refine_grid = true);
 
     void eval(doublereal rdt=-1.0, int count = 1) {
-        OneDim::eval(npos, m_x.data(), m_xnew.data(), rdt, count);
+        OneDim::eval(npos, m_data->data(), m_xnew.data(), rdt, count);
     }
 
     // Evaluate the governing equations and return the vector of residuals
     void getResidual(double rdt, double* resid) {
-        OneDim::eval(npos, m_x.data(), resid, rdt, 0);
+        OneDim::eval(npos, m_data->data(), resid, rdt, 0);
     }
 
     //! Refine the grid in all domains.
@@ -278,14 +278,14 @@ public:
     void setSolution(const doublereal* soln) {
         warn_deprecated("Sim1D::setSolution",
             "This method is unused and will be removed after Cantera 3.0.");
-        std::copy(soln, soln + m_x.size(), m_x.data());
+        std::copy(soln, soln + m_data->size(), m_data->data());
     }
 
     // @deprecated  To be removed after Cantera 3.0 (unused)
     const doublereal* solution() const {
         warn_deprecated("Sim1D::solution",
             "This method is unused and will be removed after Cantera 3.0.");
-        return m_x.data();
+        return m_data->data();
     }
 
     doublereal jacobian(int i, int j);
@@ -317,9 +317,6 @@ public:
     }
 
 protected:
-    //! the solution vector
-    vector_fp m_x;
-
     //! the solution vector after the last successful timestepping
     vector_fp m_xlast_ts;
 

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -198,7 +198,7 @@ public:
     const doublereal* solution() {
         warn_deprecated("Sim1D::solution",
             "This method is unused and will be removed after Cantera 3.0.");
-        return m_data->data();
+        return m_state->data();
     }
 
     void setTimeStep(double stepsize, size_t n, const int* tsteps);
@@ -206,12 +206,12 @@ public:
     void solve(int loglevel = 0, bool refine_grid = true);
 
     void eval(doublereal rdt=-1.0, int count = 1) {
-        OneDim::eval(npos, m_data->data(), m_xnew.data(), rdt, count);
+        OneDim::eval(npos, m_state->data(), m_xnew.data(), rdt, count);
     }
 
     // Evaluate the governing equations and return the vector of residuals
     void getResidual(double rdt, double* resid) {
-        OneDim::eval(npos, m_data->data(), resid, rdt, 0);
+        OneDim::eval(npos, m_state->data(), resid, rdt, 0);
     }
 
     //! Refine the grid in all domains.
@@ -280,14 +280,14 @@ public:
     void setSolution(const doublereal* soln) {
         warn_deprecated("Sim1D::setSolution",
             "This method is unused and will be removed after Cantera 3.0.");
-        std::copy(soln, soln + m_data->size(), m_data->data());
+        std::copy(soln, soln + m_state->size(), m_state->data());
     }
 
     // @deprecated  To be removed after Cantera 3.0 (unused)
     const doublereal* solution() const {
         warn_deprecated("Sim1D::solution",
             "This method is unused and will be removed after Cantera 3.0.");
-        return m_data->data();
+        return m_state->data();
     }
 
     doublereal jacobian(int i, int j);

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -169,7 +169,7 @@ public:
     virtual void show(const double* x);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void restore(SolutionArray& arr, double* soln);
+    virtual void fromArray(SolutionArray& arr, double* soln);
 
     //! Set flow configuration for freely-propagating flames, using an internal
     //! point with a fixed temperature as the condition to determine the inlet

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -291,6 +291,11 @@ public:
     //! and restoreState().
     virtual std::map<std::string, size_t> nativeState() const;
 
+    //! Return string acronym representing native state
+    //! @see nativeState
+    //! @since  New in Cantera 3.0
+    string nativeMode() const;
+
     //! Return a vector containing full states defining a phase.
     //! Full states list combinations of properties that allow for the
     //! specification of a thermodynamic state based on user input.

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -291,7 +291,8 @@ public:
     //! and restoreState().
     virtual std::map<std::string, size_t> nativeState() const;
 
-    //! Return string acronym representing native state
+    //! Return string acronym representing the native state of a Phase.
+    //! Examples: "TP", "TDY", "TPY".
     //! @see nativeState
     //! @since  New in Cantera 3.0
     string nativeMode() const;

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -41,6 +41,8 @@ cdef extern from "cantera/oneD/Domain1D.h":
         void setID(string)
         string& id()
         string domainType "type"()
+        shared_ptr[CxxSolutionArray] toArray(cbool) except +translate_exception
+        void fromArray(shared_ptr[CxxSolutionArray]) except +translate_exception
 
 
 cdef extern from "cantera/oneD/Boundary1D.h":

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -10,8 +10,6 @@ from ._utils cimport stringify, pystr, anymap_to_dict
 from ._utils import CanteraError
 from cython.operator import dereference as deref
 
-from .solutionbase import SolutionArrayBase
-
 # Need a pure-python class to store weakrefs to
 class _WeakrefProxy:
     pass

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -9,7 +9,6 @@ from ._utils cimport stringify, pystr, anymap_to_dict
 from ._utils import CanteraError
 from cython.operator import dereference as deref
 
-
 # Need a pure-python class to store weakrefs to
 class _WeakrefProxy:
     pass
@@ -294,8 +293,7 @@ cdef class Domain1D:
 
         .. versionchanged:: 3.0
 
-            The dictionary layout in Cantera 3.0 combines features of HDF and YAML
-            metadata used in Cantera 2.6 to form a uniform interface.
+            Added missing domain-specific simulation settings and updated structure.
         """
         def __get__(self):
             cdef shared_ptr[CxxSolutionArray] arr
@@ -598,7 +596,7 @@ cdef class _FlowBase(Domain1D):
 
             Specialization to be removed after Cantera 3.0, as it is specific to the
             legacy HDF structure for metadata. For new behavior of the getter, use the
-            temporary method 'get_settings3'; the setter will be removed, but is
+            temporary method `get_settings3`; the setter will be removed, but is
             replaceable by setters for individual settings. The global setter is no
             longer needed, as its intended use as a service function for restoring data
             from HDF SolutionArray is replaced by a C++ implementation. As the structure
@@ -1091,26 +1089,6 @@ cdef class Sim1D:
         """
         dom, comp = self._get_indices(domain, component)
         self.sim.setFlatProfile(dom, comp, value)
-
-    def collect_data(self, domain, other):
-        """
-        Return the underlying data specifying a ``domain``. This method is used as
-        a service function for export via `FlameBase.to_solution_array`.
-
-        Derived classes call this function with the flow domain as the ``domain`` and a
-        list of essential non-thermodynamic solution components of the configuration as
-        the ``components``. A different domain (for example, inlet or outlet) can be
-        specified either by name or as the corresponding Domain1D object itself.
-
-        .. deprecated:: 3.0
-
-            Method to be removed after Cantera 3.0. Unused after moving conversion to
-            `SolutionArray` to the C++ core. As `FlameBase.to_solution_array` (which
-            itself is deprecated) bypasses this function, this service function has no
-            use and is now disabled.
-        """
-        raise NotImplementedError(
-            "This method is no longer supported and will be removed after Cantera 3.0.")
 
     def restore_data(self, domain, states, other_cols, meta):
         """

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -9,6 +9,7 @@ from ._utils cimport stringify, pystr, anymap_to_dict
 from ._utils import CanteraError
 from cython.operator import dereference as deref
 
+
 # Need a pure-python class to store weakrefs to
 class _WeakrefProxy:
     pass

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -3,7 +3,6 @@
 
 from .interrupts import no_op
 import warnings
-from collections import OrderedDict
 import numpy as np
 
 from ._utils cimport stringify, pystr, anymap_to_dict

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -319,13 +319,13 @@ cdef CxxAnyValue python_to_anyvalue(item, name=None) except *:
                 v = list_to_anyvalue(item)
         else:
             v = list_to_anyvalue(item)
-    elif isinstance(item, str):
+    elif isinstance(item, (str, np.str_, np.bytes_)):
         v = stringify(item)
     elif isinstance(item, (bool, np.bool_)):
         v = <cbool>(item)
     elif isinstance(item, (int, np.int32, np.int64)):
         v = <long int>(item)
-    elif isinstance(item, float):
+    elif isinstance(item, (float, np.float32, np.float64)):
         v = <double>(item)
     elif item is None:
         pass  # None corresponds to "empty" AnyValue

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -9,6 +9,11 @@ import importlib.metadata
 
 _h5py = None
 def _import_h5py():
+    """
+    .. deprecated:: 3.0
+
+        Function to be removed after Cantera 3.0, as ``h5py`` support will be removed.
+    """
     # defer h5py import
     global _h5py
     if _h5py is not None:
@@ -19,6 +24,8 @@ def _import_h5py():
     except importlib.metadata.PackageNotFoundError:
         raise ImportError('Method requires a working h5py installation.')
     else:
+        warnings.warn(
+            "Support for 'h5py' to be removed after Cantera 3.0.", DeprecationWarning)
         import h5py as _h5py
 
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 from ._cantera import *
 import numpy as np
-from collections import OrderedDict
 import csv as _csv
 import importlib.metadata
 
@@ -860,7 +859,7 @@ class SolutionArray(SolutionArrayBase):
         shape = data[labels[0]].shape
         if not shape:
             # ensure that data with a single entry have appropriate dimensions
-            data = OrderedDict([(k, np.array([v])) for k, v in data.items()])
+            data = {k: np.array([v]) for k, v in data.items()}
         rows = data[labels[0]].shape[0]
 
         for col in data.values():
@@ -1058,8 +1057,8 @@ class SolutionArray(SolutionArrayBase):
 
     def collect_data(self, cols=None, tabular=False, threshold=0, species=None):
         """
-        Returns the data specified by ``cols`` in an ordered dictionary, where
-        keys correspond to `SolutionArray` attributes to be exported.
+        Returns the data specified by ``cols`` in a dictionary, where keys correspond
+        to `SolutionArray` attributes to be exported.
 
         :param cols: A list of any properties of the solution that are scalars
             or which have a value for each species or reaction. If species names
@@ -1148,7 +1147,7 @@ class SolutionArray(SolutionArrayBase):
             else:
                 data += [(c, d)]
 
-        return OrderedDict(data)
+        return dict(data)
 
     def write_csv(self, filename, cols=None, *args, **kwargs):
         """
@@ -1180,7 +1179,7 @@ class SolutionArray(SolutionArrayBase):
             # bytestring needs to be converted for columns containing strings
             data = np.genfromtxt(filename, delimiter=',', deletechars='',
                                  dtype=None, names=True)
-            data_dict = OrderedDict()
+            data_dict = {}
             for label in data.dtype.names:
                 if data[label].dtype.type == np.bytes_:
                     data_dict[label] = data[label].astype('U')
@@ -1190,8 +1189,7 @@ class SolutionArray(SolutionArrayBase):
             # the 'encoding' parameter introduced with NumPy 1.14 simplifies import
             data = np.genfromtxt(filename, delimiter=',', deletechars='',
                                  dtype=None, names=True, encoding=None)
-            data_dict = OrderedDict({label: data[label]
-                                     for label in data.dtype.names})
+            data_dict = {label: data[label] for label in data.dtype.names}
         self.restore_data(data_dict, normalize)
 
     def to_pandas(self, cols=None, *args, **kwargs):
@@ -1225,7 +1223,7 @@ class SolutionArray(SolutionArrayBase):
         data = df.to_numpy(dtype=float)
         labels = list(df.columns)
 
-        data_dict = OrderedDict()
+        data_dict = {}
         for i, label in enumerate(labels):
             data_dict[label] = data[:, i]
         self.restore_data(data_dict, normalize)
@@ -1466,7 +1464,7 @@ class SolutionArray(SolutionArrayBase):
             self.meta = meta
 
             # load data
-            data = OrderedDict()
+            data = {}
             for name, value in dgroup.items():
                 if isinstance(value, _h5py.Group):
                     continue

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -24,8 +24,6 @@ def _import_h5py():
     except importlib.metadata.PackageNotFoundError:
         raise ImportError('Method requires a working h5py installation.')
     else:
-        warnings.warn(
-            "Support for 'h5py' to be removed after Cantera 3.0.", DeprecationWarning)
         import h5py as _h5py
 
 

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -368,7 +368,14 @@ class FlameBase(Sim1D):
         Get the solution at one point or for the full flame domain (if
         ``point=None``) for the specified ``component``. The ``component`` can be
         specified by name or index.
+
+        .. deprecated:: 3.0
+
+            To be removed after Cantera 3.0 to avoid conflation with `Solution`.
+            Replaceable by `profile` or `value`.
         """
+        warnings.warn("Method 'solution' to be removed after Cantera 3.0. "
+            "Replaceable by 'profile' or 'value'.")
         if point is None:
             return self.profile(self.flame, component)
         else:
@@ -381,7 +388,7 @@ class FlameBase(Sim1D):
         ``point``.
         """
         k0 = self.flame.component_index(self.gas.species_name(0))
-        Y = [self.solution(k, point)
+        Y = [self.value(self.flame, k, point)
              for k in range(k0, k0 + self.gas.n_species)]
         self.gas.set_unnormalized_mass_fractions(Y)
         self.gas.TP = self.value(self.flame, 'T', point), self.P
@@ -1492,8 +1499,9 @@ class CounterflowDiffusionFlame(FlameBase):
         >>> f.mixture_fraction('Bilger')
         """
 
-        Yf = [self.solution(k, 0) for k in self.gas.species_names]
-        Yo = [self.solution(k, self.flame.n_points-1) for k in self.gas.species_names]
+        Yf = [self.value(self.flame, k, 0) for k in self.gas.species_names]
+        Yo = [self.value(self.flame, k, self.flame.n_points - 1)
+              for k in self.gas.species_names]
 
         vals = np.empty(self.flame.n_points)
         for i in range(self.flame.n_points):
@@ -1503,8 +1511,9 @@ class CounterflowDiffusionFlame(FlameBase):
 
     @property
     def equivalence_ratio(self):
-        Yf = [self.solution(k, 0) for k in self.gas.species_names]
-        Yo = [self.solution(k, self.flame.n_points-1) for k in self.gas.species_names]
+        Yf = [self.value(self.flame, k, 0) for k in self.gas.species_names]
+        Yo = [self.value(self.flame, k, self.flame.n_points - 1)
+              for k in self.gas.species_names]
 
         vals = np.empty(self.flame.n_points)
         for i in range(self.flame.n_points):

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -656,7 +656,18 @@ class FlameBase(Sim1D):
 
     @property
     def settings(self):
-        """ Return a dictionary listing simulation settings """
+        """
+        Return a dictionary listing simulation settings
+
+        .. deprecated:: 3.0
+
+            To be removed after Cantera 3.0. The getter is replaceable by
+            `Domain1D.settings`; for the setter, use setters for individual settings.
+            Also see deprecation note in `_FlowBase.settings`.
+        """
+        warnings.warn(
+            "Property 'settings' to be removed after Cantera 3.0. Access settings from "
+            "domains instead.", DeprecationWarning)
         out = {'Sim1D_type': type(self).__name__}
         out['transport_model'] = self.transport_model
         out['energy_enabled'] = self.energy_enabled
@@ -671,6 +682,9 @@ class FlameBase(Sim1D):
 
     @settings.setter
     def settings(self, s):
+        warnings.warn(
+            "Property 'settings' to be removed after Cantera 3.0. Use individual "
+            "setters instead.", DeprecationWarning)
         # simple setters
         attr = {'transport_model',
                 'energy_enabled', 'soret_enabled', 'radiation_enabled',

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -14,6 +14,7 @@ from . import __version__, __git_commit__, hdf_support
 class FlameBase(Sim1D):
     """ Base class for flames with a single flow domain """
     __slots__ = ('gas',)
+    #: deprecated and to be removed after Cantera 3.0 here and elsewhere (unused)
     _other = ()
 
     def __init__(self, domains, gas, grid=None):
@@ -47,7 +48,14 @@ class FlameBase(Sim1D):
         :param domain:
             Index of a specific domain within the `Sim1D.domains`
             list. The default is to return other columns of the `Sim1D` object.
+
+        .. deprecated:: 3.0
+
+            Method to be removed after Cantera 3.0. After moving SolutionArray HDF
+            export to the C++ core, this method is unused.
         """
+        warnings.warn("Method to be removed after Cantera 3.0 (unused).",
+                      DeprecationWarning)
         if domain is None:
             return self._other
 
@@ -503,7 +511,7 @@ class FlameBase(Sim1D):
     def from_pandas(self, df, restore_boundaries=True, settings=None):
         """
         Restore the solution vector from a `pandas.DataFrame`; currently disabled
-        (`save`/`restore` or `write_hdf`/`read_hdf` should be used as alternatives).
+        (`save`/`restore` should be used as an alternative).
 
         :param df:
             `pandas.DataFrame` containing data to be restored

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -423,7 +423,6 @@ class FlameBase(Sim1D):
             Domain to be converted; by default, the method retrieves the flow domain
         :param normalize:
             Boolean flag indicating whether mass/mole fractions should be normalized
-            (default=`False`)
 
         .. versionadded:: 3.0
         """
@@ -678,7 +677,6 @@ class FlameBase(Sim1D):
 
             To be removed after Cantera 3.0. The getter is replaceable by
             `Domain1D.settings`; for the setter, use setters for individual settings.
-            Also see deprecation note in `_FlowBase.settings`.
         """
         warnings.warn(
             "Property 'settings' to be removed after Cantera 3.0. Access settings from "

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -60,8 +60,9 @@ cdef class _SolutionBase:
             if name is not '':
                 raise AttributeError('duplicate specification of phase name')
 
-            warnings.warn("Keyword 'name' replaces 'phaseid'",
-                          FutureWarning)
+            warnings.warn(
+                "Support for keyword 'phaseid' to be removed after Cantera 3.0. "
+                "Replaceable by keyword 'name'.", DeprecationWarning)
             name = kwargs['phaseid']
 
         if 'phases' in kwargs:
@@ -69,8 +70,9 @@ cdef class _SolutionBase:
                 raise AttributeError(
                     'duplicate specification of adjacent phases')
 
-            warnings.warn("Keyword 'adjacent' replaces 'phases'",
-                          FutureWarning)
+            warnings.warn(
+                "Support for keyword 'phases' to be removed after Cantera 3.0. "
+                "Replaceable by keyword 'adjacent'.", DeprecationWarning)
             adjacent = kwargs['phases']
 
         # Shallow copy of an existing Solution (for slicing support)

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -46,6 +46,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         cbool hasPhaseTransition()
         cbool isPure()
         cbool isCompressible()
+        string nativeMode()
         stdmap[string, size_t] nativeState() except +translate_exception
         vector[string] fullStates()
         vector[string] partialStates()

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -331,6 +331,11 @@ cdef class ThermoPhase(_SolutionBase):
         def __get__(self):
             return self.thermo.isCompressible()
 
+    @property
+    def _native_mode(self):
+        """  Return string acronym representing native state """
+        return pystr(self.thermo.nativeMode())
+
     property _native_state:
         """
         Default properties defining a state

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -60,7 +60,6 @@ cantera.test = *.txt
 cantera.examples = *.txt
 
 [options.extras_require]
-hdf5 = h5py
 pandas = pandas
 
 [options.entry_points]

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -60,7 +60,6 @@ cantera = *.pxd, test/*.txt, examples/*.txt
 cantera = *.cpp, *.h, *.pyx
 
 [options.extras_require]
-hdf5 = h5py
 pandas = pandas
 
 [options.entry_points]

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -216,8 +216,8 @@ vector<string> SolutionArray::componentNames() const
 
     // state information
     auto phase = m_sol->thermo();
-    const auto& nativeState = phase->nativeState();
-    for (auto& [name, value] : nativeState) {
+    for (auto code : phase->nativeMode()) {
+        string name = string(1, code);
         if (name == "X" || name == "Y") {
             for (auto& spc : phase->speciesNames()) {
                 components.push_back(spc);

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -240,7 +240,7 @@ shared_ptr<SolutionArray> Inlet1D::asArray(const double* soln) const
     return arr;
 }
 
-void Inlet1D::restore(SolutionArray& arr, double* soln)
+void Inlet1D::fromArray(SolutionArray& arr, double* soln)
 {
     Boundary1D::setMeta(arr.meta());
     arr.setLoc(0);
@@ -523,7 +523,7 @@ shared_ptr<SolutionArray> OutletRes1D::asArray(const double* soln) const
     return arr;
 }
 
-void OutletRes1D::restore(SolutionArray& arr, double* soln)
+void OutletRes1D::fromArray(SolutionArray& arr, double* soln)
 {
     Boundary1D::setMeta(arr.meta());
     arr.setLoc(0);
@@ -572,7 +572,7 @@ shared_ptr<SolutionArray> Surf1D::asArray(const double* soln) const
     return SolutionArray::create(m_solution, 0, meta);
 }
 
-void Surf1D::restore(SolutionArray& arr, double* soln)
+void Surf1D::fromArray(SolutionArray& arr, double* soln)
 {
     Boundary1D::setMeta(arr.meta());
     arr.setLoc(0);
@@ -778,13 +778,13 @@ shared_ptr<SolutionArray> ReactingSurf1D::asArray(const double* soln) const
     return arr;
 }
 
-void ReactingSurf1D::restore(SolutionArray& arr, double* soln)
+void ReactingSurf1D::fromArray(SolutionArray& arr, double* soln)
 {
     Boundary1D::setMeta(arr.meta());
     arr.setLoc(0);
     auto surf = std::dynamic_pointer_cast<SurfPhase>(arr.thermo());
     if (!surf) {
-        throw CanteraError("ReactingSurf1D::restore",
+        throw CanteraError("ReactingSurf1D::fromArray",
             "Restoring of coverages requires surface phase");
     }
     m_temp = surf->temperature();

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -145,6 +145,31 @@ AnyMap Domain1D::serialize(const double* soln) const
     return out;
 }
 
+shared_ptr<SolutionArray> Domain1D::toArray(bool normalize) const {
+    if (!m_data) {
+        throw CanteraError("Domain1D::toArray",
+            "Domain needs to be installed in a container before calling asArray.");
+    }
+    if (!normalize) {
+        return asArray(m_data->data() + m_iloc);
+    }
+    auto ret = asArray(m_data->data() + m_iloc);
+    ret->normalize();
+    return ret;
+}
+
+void Domain1D::fromArray(const shared_ptr<SolutionArray>& arr)
+{
+    if (!m_data) {
+        throw CanteraError("Domain1D::fromArray",
+            "Domain needs to be installed in a container before calling fromArray.");
+    }
+    resize(nComponents(), arr->size());
+    m_container->resize();
+    fromArray(*arr, m_data->data() + m_iloc);
+    _finalize(m_data->data() + m_iloc);
+}
+
 void Domain1D::setMeta(const AnyMap& meta)
 {
     auto set_tols = [&](const AnyValue& tols, const string& which, vector_fp& out)
@@ -183,7 +208,7 @@ void Domain1D::restore(const AnyMap& state, double* soln, int loglevel)
         "To be removed after Cantera 3.0; restore from SolutionArray instead.");
     auto arr = SolutionArray::create(solution());
     arr->readEntry(state, "", "");
-    restore(*arr, soln);
+    fromArray(*arr, soln);
 }
 
 void Domain1D::locate()

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -146,28 +146,27 @@ AnyMap Domain1D::serialize(const double* soln) const
 }
 
 shared_ptr<SolutionArray> Domain1D::toArray(bool normalize) const {
-    if (!m_data) {
+    if (!m_state) {
         throw CanteraError("Domain1D::toArray",
             "Domain needs to be installed in a container before calling asArray.");
     }
-    if (!normalize) {
-        return asArray(m_data->data() + m_iloc);
+    auto ret = asArray(m_state->data() + m_iloc);
+    if (normalize) {
+        ret->normalize();
     }
-    auto ret = asArray(m_data->data() + m_iloc);
-    ret->normalize();
     return ret;
 }
 
 void Domain1D::fromArray(const shared_ptr<SolutionArray>& arr)
 {
-    if (!m_data) {
+    if (!m_state) {
         throw CanteraError("Domain1D::fromArray",
             "Domain needs to be installed in a container before calling fromArray.");
     }
     resize(nComponents(), arr->size());
     m_container->resize();
-    fromArray(*arr, m_data->data() + m_iloc);
-    _finalize(m_data->data() + m_iloc);
+    fromArray(*arr, m_state->data() + m_iloc);
+    _finalize(m_state->data() + m_iloc);
 }
 
 void Domain1D::setMeta(const AnyMap& meta)

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -25,6 +25,7 @@ OneDim::OneDim(vector<shared_ptr<Domain1D>>& domains)
 {
     // create a Newton iterator, and add each domain.
     m_newt = make_unique<MultiNewton>(1);
+    m_data = make_shared<vector<double>>();
     for (auto& dom : domains) {
         addDomain(dom);
     }
@@ -40,6 +41,7 @@ OneDim::OneDim(vector<Domain1D*> domains)
 
     // create a Newton iterator, and add each domain.
     m_newt = make_unique<MultiNewton>(1);
+    m_data = make_shared<vector<double>>();
     for (size_t i = 0; i < domains.size(); i++) {
         addDomain(domains[i]);
     }
@@ -96,6 +98,7 @@ void OneDim::addDomain(shared_ptr<Domain1D> d)
     // add it also to the global domain list, and set its container and position
     m_sharedDom.push_back(d);
     m_dom.push_back(d.get());
+    d->setData(m_data);
     d->setContainer(this, m_dom.size()-1);
     resize();
 }
@@ -122,6 +125,7 @@ void OneDim::addDomain(Domain1D* d)
 
     // add it also to the global domain list, and set its container and position
     m_dom.push_back(d);
+    d->setData(m_data);
     d->setContainer(this, m_dom.size()-1);
     resize();
 }
@@ -237,11 +241,7 @@ void OneDim::resize()
         m_size = d->loc() + d->size();
     }
 
-    if (m_data) {
-        m_data->resize(size());
-    } else {
-        m_data = make_shared<vector<double>>(size());
-    }
+    m_data->resize(size());
 
     m_newt->resize(size());
     m_mask.resize(size());
@@ -456,6 +456,8 @@ void OneDim::resetBadValues(double* x)
 
 AnyMap OneDim::serialize(const double* soln) const
 {
+    warn_deprecated("OneDim::serialize",
+        "To be removed after Cantera 3.0; unused.");
     AnyMap state;
     for (size_t i = 0; i < m_dom.size(); i++) {
         state[m_dom[i]->id()] = m_dom[i]->serialize(soln + start(i));

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -25,7 +25,7 @@ OneDim::OneDim(vector<shared_ptr<Domain1D>>& domains)
 {
     // create a Newton iterator, and add each domain.
     m_newt = make_unique<MultiNewton>(1);
-    m_data = make_shared<vector<double>>();
+    m_state = make_shared<vector<double>>();
     for (auto& dom : domains) {
         addDomain(dom);
     }
@@ -41,7 +41,7 @@ OneDim::OneDim(vector<Domain1D*> domains)
 
     // create a Newton iterator, and add each domain.
     m_newt = make_unique<MultiNewton>(1);
-    m_data = make_shared<vector<double>>();
+    m_state = make_shared<vector<double>>();
     for (size_t i = 0; i < domains.size(); i++) {
         addDomain(domains[i]);
     }
@@ -98,7 +98,7 @@ void OneDim::addDomain(shared_ptr<Domain1D> d)
     // add it also to the global domain list, and set its container and position
     m_sharedDom.push_back(d);
     m_dom.push_back(d.get());
-    d->setData(m_data);
+    d->setData(m_state);
     d->setContainer(this, m_dom.size()-1);
     resize();
 }
@@ -125,7 +125,7 @@ void OneDim::addDomain(Domain1D* d)
 
     // add it also to the global domain list, and set its container and position
     m_dom.push_back(d);
-    d->setData(m_data);
+    d->setData(m_state);
     d->setContainer(this, m_dom.size()-1);
     resize();
 }
@@ -241,7 +241,7 @@ void OneDim::resize()
         m_size = d->loc() + d->size();
     }
 
-    m_data->resize(size());
+    m_state->resize(size());
 
     m_newt->resize(size());
     m_mask.resize(size());

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -237,6 +237,12 @@ void OneDim::resize()
         m_size = d->loc() + d->size();
     }
 
+    if (m_data) {
+        m_data->resize(size());
+    } else {
+        m_data = make_shared<vector<double>>(size());
+    }
+
     m_newt->resize(size());
     m_mask.resize(size());
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -303,7 +303,7 @@ AnyMap Sim1D::restore(const std::string& fname, const std::string& id)
         resize();
         m_xlast_ts.clear();
         for (auto dom : m_dom) {
-            dom->restore(*arrs[dom->id()], m_data->data() + dom->loc());
+            dom->fromArray(*arrs[dom->id()], m_data->data() + dom->loc());
         }
         finalize();
     } else if (extension == "yaml" || extension == "yml") {
@@ -320,7 +320,7 @@ AnyMap Sim1D::restore(const std::string& fname, const std::string& id)
         resize();
         m_xlast_ts.clear();
         for (auto dom : m_dom) {
-            dom->restore(*arrs[dom->id()], m_data->data() + dom->loc());
+            dom->fromArray(*arrs[dom->id()], m_data->data() + dom->loc());
         }
         finalize();
     } else {

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -64,10 +64,10 @@ StFlow::StFlow(ThermoPhase* ph, size_t nsp, size_t points) :
     m_qdotRadiation.resize(m_points, 0.0);
 
     //-------------- default solution bounds --------------------
-    setBounds(0, -1e20, 1e20); // no bounds on u
-    setBounds(1, -1e20, 1e20); // V
-    setBounds(2, 200.0, 2*m_thermo->maxTemp()); // temperature bounds
-    setBounds(3, -1e20, 1e20); // lambda should be negative
+    setBounds(c_offset_U, -1e20, 1e20); // no bounds on u
+    setBounds(c_offset_V, -1e20, 1e20); // V
+    setBounds(c_offset_T, 200.0, 2*m_thermo->maxTemp()); // temperature bounds
+    setBounds(c_offset_L, -1e20, 1e20); // lambda should be negative
     setBounds(c_offset_E, -1e20, 1e20); // no bounds for inactive component
 
     // mass fraction bounds

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -684,15 +684,15 @@ void StFlow::updateDiffFluxes(const doublereal* x, size_t j0, size_t j1)
 string StFlow::componentName(size_t n) const
 {
     switch (n) {
-    case 0:
+    case c_offset_U:
         return "velocity";
-    case 1:
+    case c_offset_V:
         return "spread_rate";
-    case 2:
+    case c_offset_T:
         return "T";
-    case 3:
+    case c_offset_L:
         return "lambda";
-    case 4:
+    case c_offset_E:
         return "eField";
     default:
         if (n >= c_offset_Y && n < (c_offset_Y + m_nsp)) {
@@ -706,15 +706,15 @@ string StFlow::componentName(size_t n) const
 size_t StFlow::componentIndex(const std::string& name) const
 {
     if (name=="velocity") {
-        return 0;
+        return c_offset_U;
     } else if (name=="spread_rate") {
-        return 1;
+        return c_offset_V;
     } else if (name=="T") {
-        return 2;
+        return c_offset_T;
     } else if (name=="lambda") {
-        return 3;
+        return c_offset_L;
     } else if (name == "eField") {
-        return 4;
+        return c_offset_E;
     } else {
         for (size_t n=c_offset_Y; n<m_nsp+c_offset_Y; n++) {
             if (componentName(n)==name) {

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -271,6 +271,7 @@ void StFlow::_getInitialSoln(double* x)
     for (size_t j = 0; j < m_points; j++) {
         T(x,j) = m_thermo->temperature();
         m_thermo->getMassFractions(&Y(x, 0, j));
+        m_rho[j] = m_thermo->density();
     }
 }
 
@@ -821,7 +822,7 @@ shared_ptr<SolutionArray> StFlow::asArray(const double* soln) const
     return arr;
 }
 
-void StFlow::restore(SolutionArray& arr, double* soln)
+void StFlow::fromArray(SolutionArray& arr, double* soln)
 {
     Domain1D::setMeta(arr.meta());
     arr.setLoc(0);
@@ -842,7 +843,7 @@ void StFlow::restore(SolutionArray& arr, double* soln)
                 soln[index(i,j)] = data[j];
             }
         } else {
-            warn_user("StFlow::restore", "Saved state does not contain values for "
+            warn_user("StFlow::fromArray", "Saved state does not contain values for "
                 "component '{}' in domain '{}'.", name, id());
         }
     }

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -196,6 +196,19 @@ std::map<std::string, size_t> Phase::nativeState() const
     }
 }
 
+string Phase::nativeMode() const
+{
+    map<size_t, string> states; // reverse lookup
+    for (auto& [name, value] : nativeState()) {
+        states[value] = name;
+    }
+    string out;
+    for (auto& [value, name] : states) {
+        out += name;
+    }
+    return out;
+}
+
 vector<std::string> Phase::fullStates() const
 {
     if (isPure()) {

--- a/test/general/test_composite.cpp
+++ b/test/general/test_composite.cpp
@@ -98,12 +98,13 @@ TEST(SolutionArray, normalize)
     for (size_t loc = 0; loc < arr->size(); loc++) {
         state = arr->getState(loc);
         for (size_t i = 2; i < state.size() - 1; i++) {
+            // test normalized species mass fractions - all are equal except last
             ASSERT_NEAR(state[i], state[2], 1e-12);
             ASSERT_NE(state[i], newState[i]);
             ASSERT_LE(state[i], 1.);
             ASSERT_GE(state[i], 0.);
         }
-        ASSERT_EQ(state.back(), 0.);
+        ASSERT_EQ(state.back(), 0.); // unnormalized negative value is set to zero
     }
 
     newState = {state[0], state[1], 100, 0, 0, 0, 0, 0, 0, 0, 0, -1e12};

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -1,7 +1,6 @@
 import sys
 
 import numpy as np
-from collections import OrderedDict
 import pickle
 
 import pytest
@@ -731,8 +730,7 @@ class TestRestoreIdealGas(utilities.CanteraTest):
         # wrong data shape
         b = ct.SolutionArray(self.gas)
         with self.assertRaises(ValueError):
-            b.restore_data(OrderedDict([(k, v[np.newaxis, :])
-                                        for k, v in data.items()]))
+            b.restore_data({k: v[np.newaxis, :] for k, v in data.items()})
 
         # inconsistent shape of receiving SolutionArray
         b = ct.SolutionArray(self.gas, 9)
@@ -742,15 +740,14 @@ class TestRestoreIdealGas(utilities.CanteraTest):
         # incomplete state
         b = ct.SolutionArray(self.gas)
         with self.assertRaises(ValueError):
-            b.restore_data(OrderedDict([tup for i, tup in enumerate(data.items())
-                                        if i]))
+            b.restore_data(dict([tup for i, tup in enumerate(data.items()) if i]))
 
         # add extra column
         t = np.arange(10, dtype=float)
 
         # auto-detection of extra
         b = ct.SolutionArray(self.gas)
-        data_mod = OrderedDict(data)
+        data_mod = dict(data)  # create a copy
         data_mod['time'] = t
         b.restore_data(data_mod)
         check(a, b)

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1,4 +1,3 @@
-from collections import OrderedDict
 import numpy as np
 import gc
 
@@ -73,6 +72,7 @@ class TestThermoPhase(utilities.CanteraTest):
         self.assertEqual(self.phase._native_state, ('T', 'D', 'Y'))
         self.assertIn('TPY', self.phase._full_states.values())
         self.assertIn('TD', self.phase._partial_states.values())
+        assert self.phase._native_mode == "TDY"
 
     def test_species(self):
         self.assertEqual(self.phase.n_species, 10)
@@ -2011,8 +2011,7 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertArrayNear(row2.T, 900*np.ones(5))
 
     def test_extra_create_by_dict(self):
-        extra = OrderedDict([('grid', np.arange(10)),
-                             ('velocity', np.random.rand(10))])
+        extra = {"grid": np.arange(10), "velocity": np.random.rand(10)}
         states = ct.SolutionArray(self.gas, 10, extra=extra)
         keys = states.extra
         self.assertEqual(keys[0], 'grid')


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

After moving `SolutionArray` support to C++ in #1426 and updating HDF support in #1385, remaining Python versions are replaced, vestigial functions are deprecated, and code is removed where appropriate. Some minor glitches are fixed.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make `Sim1D` data vector accessible to `Domain1D`
- Implement `SolutionArray::normalize` to normalize mass/mole fractions
- Implement `ThermoPhase::nativeMode` to produce acronym describing storage mode
- Fix minor bugs in new C++ `SolutionArray` interface
- Rename some Python / C++ methods for consistency across interfaces
- Use C++ `SolutionArray` methods for the interface between Python `Sim1D` and `SolutionArray`
- Retain ability to restore legacy HDF using `h5py` for Cantera 3.0, but deprecate all associated methods
- Remove `OrderedDict`, which is no longer necessary
- Convert Python `FutureWarning`s to `DeprecationWarning`s
- Replace some hardcoded indices
- _**Deprecate `h5py` support**_

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Resolves Cantera/enhancements#166

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
