### PR TITLE
Rebuild for post1

### DIFF
--- a/interfaces/cython/pyproject.toml
+++ b/interfaces/cython/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel", "Cython>=0.29.12"]
+requires = ["setuptools>=43.0.0,<61", "wheel", "Cython>=0.29.12"]
 build-backend = "setuptools.build_meta"

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -42,7 +42,7 @@ include_package_data = True
 install_requires =
     numpy >= 1.12.0
     ruamel.yaml >= 0.15.34
-python_requires = >=@py_min_ver_str@
+python_requires = >=@py_min_ver_str@,<3.11
 packages =
     cantera
     cantera.data

--- a/interfaces/python_minimal/pyproject.toml
+++ b/interfaces/python_minimal/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel"]
+requires = ["setuptools>=43.0.0,<61", "wheel"]
 build-backend = "setuptools.build_meta"

--- a/interfaces/python_minimal/setup.cfg.in
+++ b/interfaces/python_minimal/setup.cfg.in
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
 project_urls =
@@ -36,7 +37,7 @@ zip_safe = True
 install_requires =
     numpy >= 1.12.0
     ruamel.yaml >= 0.15.34
-python_requires = >=@py_min_ver_str@
+python_requires = >=@py_min_ver_str@,<3.11
 packages =
     cantera
 

--- a/interfaces/python_sdist/pyproject.toml
+++ b/interfaces/python_sdist/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel", "oldest-supported-numpy", "Cython>=0.29.12"]
+requires = ["setuptools>=43.0.0,<61", "wheel", "oldest-supported-numpy", "Cython>=0.29.12"]
 build-backend = "setuptools.build_meta"

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.7
     Programming Language :: Python :: 3.8
     Programming Language :: Python :: 3.9
+    Programming Language :: Python :: 3.10
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
@@ -42,7 +43,7 @@ include_package_data = True
 install_requires =
     numpy >= 1.12.0
     ruamel.yaml >= 0.15.34
-python_requires = >=@py_min_ver_str@
+python_requires = >=@py_min_ver_str@,<3.11
 packages =
     cantera
     cantera.data

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -65,7 +65,6 @@ cantera = *.pxd
 cantera = *.cpp, *.h, *.pyx
 
 [options.extras_require]
-hdf5 = h5py
 pandas = pandas
 
 [options.entry_points]


### PR DESCRIPTION
Updates to the build configuration for the 2.6 branch to explicitly indicate that Python 3.11 is not supported. Once this is merged, I will kick off a manual build in the pypi-packages repo, also on the 2.6 branch, since that's working now: https://github.com/Cantera/pypi-packages/actions/runs/4516536636