### PR TITLE
Fix external cantera cimport

### DIFF
--- a/interfaces/cython/cantera/__init__.pxd
+++ b/interfaces/cython/cantera/__init__.pxd
@@ -1,4 +1,22 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-from cantera._cantera cimport *
+# Import content from individual .pxd files
+from cantera._onedim cimport *
+from cantera._utils cimport *
+from cantera.constants cimport *
+from cantera.ctcxx cimport *
+from cantera.delegator cimport *
+from cantera.func1 cimport *
+from cantera.kinetics cimport *
+from cantera.mixture cimport *
+from cantera.preconditioners cimport *
+from cantera.reaction cimport *
+from cantera.reactionpath cimport *
+from cantera.reactor cimport *
+from cantera.solutionbase cimport *
+from cantera.speciesthermo cimport *
+from cantera.thermo cimport *
+from cantera.transport cimport *
+from cantera.units cimport *
+from cantera.yamlwriter cimport *

--- a/interfaces/cython/cantera/constants.pxd
+++ b/interfaces/cython/cantera/constants.pxd
@@ -1,0 +1,19 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+#cython: language_level=3
+#distutils: language = c++
+
+cdef extern from "cantera/base/ct_defs.h" namespace "Cantera":
+    cdef double CxxAvogadro "Cantera::Avogadro"
+    cdef double CxxGasConstant "Cantera::GasConstant"
+    cdef double CxxOneAtm "Cantera::OneAtm"
+    cdef double CxxBoltzmann "Cantera::Boltzmann"
+    cdef double CxxPlanck "Cantera::Planck"
+    cdef double CxxStefanBoltz "Cantera::StefanBoltz"
+    cdef double CxxFaraday "Cantera::Faraday"
+    cdef double CxxElectronCharge "Cantera::ElectronCharge"
+    cdef double CxxElectronMass "Cantera::ElectronMass"
+    cdef double CxxLightSpeed "Cantera::lightSpeed"
+    cdef double CxxPermeability_0 "Cantera::permeability_0"
+    cdef double CxxEpsilon_0 "Cantera::epsilon_0"

--- a/interfaces/cython/cantera/constants.pyx
+++ b/interfaces/cython/cantera/constants.pyx
@@ -4,19 +4,7 @@
 #cython: language_level=3
 #distutils: language=c++
 
-cdef extern from "cantera/base/ct_defs.h" namespace "Cantera":
-    cdef double CxxAvogadro "Cantera::Avogadro"
-    cdef double CxxGasConstant "Cantera::GasConstant"
-    cdef double CxxOneAtm "Cantera::OneAtm"
-    cdef double CxxBoltzmann "Cantera::Boltzmann"
-    cdef double CxxPlanck "Cantera::Planck"
-    cdef double CxxStefanBoltz "Cantera::StefanBoltz"
-    cdef double CxxFaraday "Cantera::Faraday"
-    cdef double CxxElectronCharge "Cantera::ElectronCharge"
-    cdef double CxxElectronMass "Cantera::ElectronMass"
-    cdef double CxxLightSpeed "Cantera::lightSpeed"
-    cdef double CxxPermeability_0 "Cantera::permeability_0"
-    cdef double CxxEpsilon_0 "Cantera::epsilon_0"
+from .constants cimport *
 
 #: Avogadro's Number, /kmol
 avogadro = CxxAvogadro


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

Fix broken `__init__.pxd` file, which is required for the compilation of external Cython code. The file refers to `_cantera.pxd`, which was removed / split into multiple files in #1334. This PR adds all individual `*.pxd` files Cantera provides in its interface.

With this fix, external Cython modules can again access content via
```Cython
cimport cantera as ct
```

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1469

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
