### PR TITLE
Fix clash of names with upstream function

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -498,7 +498,7 @@ jobs:
         mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp h5py pandas pytest highfive
       shell: pwsh
     - name: Build Cantera
-      run: scons build system_eigen=y system_yamlcpp=y logging=debug
+      run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
         msvc_toolset_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j2
       shell: pwsh
     - name: Upload shared library

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -56,5 +56,6 @@ typedef int ftnlen;       // Fortran hidden string length type
 // Enable export/import of HDF data via C++ HighFive
 {CT_USE_HDF5!s}
 {CT_USE_SYSTEM_HIGHFIVE!s}
+{CT_USE_HIGHFIVE_BOOLEAN!s}
 
 #endif

--- a/src/base/Storage.cpp
+++ b/src/base/Storage.cpp
@@ -29,6 +29,10 @@
 
 namespace h5 = HighFive;
 
+// Implement read/write support for Booleans
+// Note that HighFive 2.7.0 introduces native boolean support
+// todo: replace below by: typedef h5::details::Boolean H5Boolean;
+
 enum class H5Boolean {
     FALSE = 0,
     TRUE = 1,
@@ -39,7 +43,7 @@ h5::EnumType<H5Boolean> create_enum_boolean() {
             {"TRUE", H5Boolean::TRUE}};
 }
 
-HIGHFIVE_REGISTER_TYPE(H5Boolean, create_enum_boolean)
+HIGHFIVE_REGISTER_TYPE(H5Boolean, ::create_enum_boolean)
 
 #endif
 

--- a/src/base/Storage.cpp
+++ b/src/base/Storage.cpp
@@ -29,21 +29,23 @@
 
 namespace h5 = HighFive;
 
-// Implement read/write support for Booleans
-// Note that HighFive 2.7.0 introduces native boolean support
-// todo: replace below by: typedef h5::details::Boolean H5Boolean;
-
+#ifdef CT_USE_HIGHFIVE_BOOLEAN
+// HighFive 2.7.1 introduces stable native boolean support
+typedef h5::details::Boolean H5Boolean;
+#else
+// Use custom Boolean definition mimicking h5py approach
+// HighFive <=2.6.2 lacks boolean support and HighFive 2.7.0 uses alternate definition
 enum class H5Boolean {
-    FALSE = 0,
-    TRUE = 1,
+    HighFiveFalse = 0,
+    HighFiveTrue = 1,
 };
 
 h5::EnumType<H5Boolean> create_enum_boolean() {
-    return {{"FALSE", H5Boolean::FALSE},
-            {"TRUE", H5Boolean::TRUE}};
+    return {{"FALSE", H5Boolean::HighFiveFalse}, {"TRUE", H5Boolean::HighFiveTrue}};
 }
 
 HIGHFIVE_REGISTER_TYPE(H5Boolean, ::create_enum_boolean)
+#endif
 
 #endif
 
@@ -319,7 +321,8 @@ void writeH5Attributes(h5::Group sub, const AnyMap& meta)
             attr.write(value);
         } else if (item.is<bool>()) {
             bool bValue = item.asBool();
-            H5Boolean value = bValue ? H5Boolean::TRUE : H5Boolean::FALSE;
+            H5Boolean value = bValue ?
+                H5Boolean::HighFiveTrue : H5Boolean::HighFiveFalse;
             h5::Attribute attr = sub.createAttribute<H5Boolean>(
                 name, h5::DataSpace::From(value));
             attr.write(value);
@@ -342,7 +345,8 @@ void writeH5Attributes(h5::Group sub, const AnyMap& meta)
             auto bValue = item.as<vector<bool>>();
             vector<H5Boolean> values;
             for (auto b : bValue) {
-                values.push_back(b ? H5Boolean::TRUE : H5Boolean::FALSE);
+                values.push_back(b ?
+                    H5Boolean::HighFiveTrue : H5Boolean::HighFiveFalse);
             }
             h5::Attribute attr = sub.createAttribute<H5Boolean>(
                 name, h5::DataSpace::From(values));


### PR DESCRIPTION
HighFive 2.7.0 introduces `h5py`-style support for booleans, which is close to identical with what was already implemented in `Storage.cpp`. HighFive uses the exact same name for a new `create_enum_boolean` function, which clashes with an existing local function in `Storage.cpp`, causing CI failures when conda packages `highfive` with versions 2.7.0 and newer are used. 

The resolution is to use the full name for older versions of HighFive (2.7.0 and older), while using HighFive's implementation for boolean support for HighFive 2.7.1 and newer (this avoids a change of their API from 2.7.0 to 2.7.1). For the time being, the git submodule remains on 2.6.2, while conda will grab the newest package available. 

Other updates:
- use system installation of HighFive by default and other SCons logic fixes
- detect and display HighFive version

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

See https://github.com/BlueBrain/HighFive/issues/713 and https://github.com/BlueBrain/HighFive/issues/724

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
