### PR TITLE
Remove unused configuration variables

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2120,9 +2120,6 @@ def cdefine(definevar, configvar, comp=True, value=1):
     else:
         configh[definevar] = None
 
-# Need to test all of these to see what platform.system() returns
-configh['DARWIN'] = 1 if env['OS'] == 'Darwin' else None
-
 if env['OS'] == 'Solaris' or env['HAS_CLANG']:
     env["RPATHPREFIX"] = "-Wl,-rpath,"
 

--- a/SConstruct
+++ b/SConstruct
@@ -449,12 +449,6 @@ config_options = [
            needed if the libraries are installed in a standard location, for example,
            '/usr/lib'.""",
         "", PathVariable.PathAccept),
-    EnumOption(
-        "lapack_names",
-        """Set depending on whether the procedure names in the specified
-           libraries are lowercase or uppercase. If you don't know, run 'nm' on
-           the library file (for example, "nm libblas.a").""",
-        "lower", ("lower", "upper")),
     BoolOption(
         "lapack_ftn_trailing_underscore",
         """Controls whether the LAPACK functions have a trailing underscore
@@ -2139,7 +2133,6 @@ else:
 cdefine('LAPACK_FTN_STRING_LEN_AT_END', 'lapack_ftn_string_len_at_end')
 cdefine('LAPACK_FTN_TRAILING_UNDERSCORE', 'lapack_ftn_trailing_underscore')
 cdefine('FTN_TRAILING_UNDERSCORE', 'lapack_ftn_trailing_underscore')
-cdefine('LAPACK_NAMES_LOWERCASE', 'lapack_names', 'lower')
 cdefine('CT_USE_LAPACK', 'use_lapack')
 cdefine("CT_USE_HDF5", "use_hdf5")
 cdefine("CT_USE_SYSTEM_HIGHFIVE", "system_highfive")

--- a/SConstruct
+++ b/SConstruct
@@ -1357,9 +1357,9 @@ if not env['BOOST_LIB_VERSION']:
                  " 'boost_inc_dir' to point to the boost headers.")
 else:
     logger.info(f"Found Boost version {env['BOOST_LIB_VERSION']}")
-# demangle is available in Boost 1.56 or newer
-env['has_demangle'] = conf.CheckDeclaration("boost::core::demangle",
-                                '#include <boost/core/demangle.hpp>', 'C++')
+if parse_version(env['BOOST_LIB_VERSION']) < parse_version("1.61"):
+    # dll support is available in Boost 1.61 or newer
+    config_error("Cantera requires Boost version 1.61 or newer.")
 
 # check BLAS/LAPACK installations
 if env["system_blas_lapack"] == "n":
@@ -2147,7 +2147,6 @@ cdefine("CT_USE_SYSTEM_EIGEN", "system_eigen")
 cdefine("CT_USE_SYSTEM_EIGEN_PREFIXED", "system_eigen_prefixed")
 cdefine('CT_USE_SYSTEM_FMT', 'system_fmt')
 cdefine('CT_USE_SYSTEM_YAMLCPP', 'system_yamlcpp')
-cdefine('CT_USE_DEMANGLE', 'has_demangle')
 cdefine('CT_HAS_PYTHON', 'python_package', 'full')
 
 config_h_build = env.Command('build/src/config.h.build',

--- a/SConstruct
+++ b/SConstruct
@@ -2121,7 +2121,6 @@ def cdefine(definevar, configvar, comp=True, value=1):
         configh[definevar] = None
 
 # Need to test all of these to see what platform.system() returns
-configh['SOLARIS'] = 1 if env['OS'] == 'Solaris' else None
 configh['DARWIN'] = 1 if env['OS'] == 'Darwin' else None
 
 if env['OS'] == 'Solaris' or env['HAS_CLANG']:

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -49,13 +49,6 @@ typedef int ftnlen;       // Fortran hidden string length type
 {CT_USE_DEMANGLE!s}
 {CT_HAS_PYTHON!s}
 
-//--------- operating system --------------------------------------
-
-// The configure script defines this if the operating system is Mac
-// OS X, This used to add some Mac-specific directories to the default
-// data file search path.
-{DARWIN!s}
-
 //-------------- Optional Cantera Capabilities ----------------------
 
 // Enable Sundials to use an external BLAS/LAPACK library if it was

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -46,7 +46,6 @@ typedef int ftnlen;       // Fortran hidden string length type
 {CT_USE_SYSTEM_EIGEN_PREFIXED!s}
 {CT_USE_SYSTEM_FMT!s}
 {CT_USE_SYSTEM_YAMLCPP!s}
-{CT_USE_DEMANGLE!s}
 {CT_HAS_PYTHON!s}
 
 //-------------- Optional Cantera Capabilities ----------------------

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -38,7 +38,6 @@ typedef int ftnlen;       // Fortran hidden string length type
 //-------- LAPACK / BLAS ---------
 
 {LAPACK_FTN_STRING_LEN_AT_END!s}
-{LAPACK_NAMES_LOWERCASE!s}
 {LAPACK_FTN_TRAILING_UNDERSCORE!s}
 {CT_USE_LAPACK!s}
 

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -56,10 +56,6 @@ typedef int ftnlen;       // Fortran hidden string length type
 // data file search path.
 {DARWIN!s}
 
-// Identify whether the operating system is Solaris
-// with a native compiler
-{SOLARIS!s}
-
 //-------------- Optional Cantera Capabilities ----------------------
 
 // Enable Sundials to use an external BLAS/LAPACK library if it was

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -43,9 +43,6 @@ class AnyMap;
  * 'data' subdirectory of the installation directory will be added to the search
  * path.
  *
- * On the Mac, directory '/Applications/Cantera/data' is added to the
- * search path.
- *
  * On any platform, if environment variable CANTERA_DATA is set to a directory
  * name or a list of directory names separated with the OS-dependent path
  * separator (that is, ";" on Windows, ":" elsewhere), then these directories will

--- a/interfaces/python_sdist/SConscript
+++ b/interfaces/python_sdist/SConscript
@@ -125,7 +125,7 @@ configh["CT_USE_LAPACK"] = None
 configh["CT_SUNDIALS_USE_LAPACK"] = None
 
 # These keys are determined by the build machine
-for key in ("SOLARIS", "DARWIN", "CT_USE_DEMANGLE"):
+for key in ("DARWIN", "CT_USE_DEMANGLE"):
     del configh[key]
 
 

--- a/interfaces/python_sdist/SConscript
+++ b/interfaces/python_sdist/SConscript
@@ -125,7 +125,7 @@ configh["CT_USE_LAPACK"] = None
 configh["CT_SUNDIALS_USE_LAPACK"] = None
 
 # These keys are determined by the build machine
-for key in ("DARWIN", "CT_USE_DEMANGLE"):
+for key in ("CT_USE_DEMANGLE"):
     del configh[key]
 
 

--- a/interfaces/python_sdist/SConscript
+++ b/interfaces/python_sdist/SConscript
@@ -124,10 +124,6 @@ ext_target = sdist(localenv.Command("ext", "#ext", copy_ext_src))
 configh["CT_USE_LAPACK"] = None
 configh["CT_SUNDIALS_USE_LAPACK"] = None
 
-# These keys are determined by the build machine
-for key in ("CT_USE_DEMANGLE"):
-    del configh[key]
-
 
 class DefineDict:
     """dict-like class used to fill config.h.in partially.

--- a/interfaces/python_sdist/setup.py
+++ b/interfaces/python_sdist/setup.py
@@ -138,13 +138,6 @@ def configure_build():
     else:
         create_config("DARWIN", 0)
 
-    # I have no idea if this is the value for Solaris, and I don't have a Solaris
-    # machine handy to test. YOLO!
-    if sys.platform.startswith("sunos"):
-        create_config("SOLARIS", 1)
-    else:
-        create_config("SOLARIS", 0)
-
     if sys.platform != "win32":
         extra_compile_flags = ["-std=c++14", "-g0"]
         sundials_configh = {

--- a/interfaces/python_sdist/setup.py
+++ b/interfaces/python_sdist/setup.py
@@ -128,10 +128,10 @@ def configure_build():
         raise ValueError(
             f"Could not convert Boost minor version to integer: '{boost_version}'"
         ) from None
-    if boost_minor_version < 56:
-        create_config("CT_USE_DEMANGLE", 0)
-    else:
-        create_config("CT_USE_DEMANGLE", 1)
+    if boost_minor_version < 61:
+        raise ValueError(
+            "Cantera requires Boost version 1.61 or newer."
+        )
 
     if sys.platform != "win32":
         extra_compile_flags = ["-std=c++14", "-g0"]

--- a/interfaces/python_sdist/setup.py
+++ b/interfaces/python_sdist/setup.py
@@ -133,11 +133,6 @@ def configure_build():
     else:
         create_config("CT_USE_DEMANGLE", 1)
 
-    if sys.platform == "darwin":
-        create_config("DARWIN", 1)
-    else:
-        create_config("DARWIN", 0)
-
     if sys.platform != "win32":
         extra_compile_flags = ["-std=c++14", "-g0"]
         sundials_configh = {

--- a/samples/f77/demo_ftnlib.cpp
+++ b/samples/f77/demo_ftnlib.cpp
@@ -74,12 +74,6 @@ void handleError(CanteraError& err)
 
 extern "C" {
 
-    /// This is the Fortran main program. This works for g77; it may
-    /// need to be modified for other Fortran compilers
-#ifdef NEED_ALT_MAIN
-    extern int MAIN__();
-#endif
-
     /**
      * Read in a reaction mechanism file and create a Solution
      * object. The file may be in Cantera input format or in YAML. (If
@@ -374,27 +368,3 @@ extern "C" {
     }
 
 }
-
-/*
- *  HKM 7/22/09:
- *    I'm skeptical that you need this for any system.
- *    Definitely creates an error (dupl main()) for the solaris
- *    system
- */
-#ifdef NEED_ALT_MAIN
-/**
- * This C++ main program simply calls the Fortran main program.
- */
-int main()
-{
-    try {
-        return MAIN__();
-    } catch (CanteraError& err) {
-        std::cerr << err.what() << std::endl;
-        exit(-1);
-    } catch (...) {
-        cout << "An exception was trapped. Program terminating." << endl;
-        exit(-1);
-    }
-}
-#endif

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -266,11 +266,6 @@ void Application::setDefaultDirectories()
 
 #endif
 
-#ifdef DARWIN
-    // add a default data location for Mac OS X
-    inputDirs.push_back("/Applications/Cantera/data");
-#endif
-
     // CANTERA_DATA is defined in file config.h. This file is written during the
     // build process (unix), and points to the directory specified by the
     // 'prefix' option to 'configure', or else to /usr/local/cantera.

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -412,17 +412,15 @@ protected:
      * path. It is invoked at startup by appinit(), and never should need to
      * be called by user programs.
      *
-     * The current directory (".") is always searched first. Then, on Windows
-     * platforms, if environment variable COMMONPROGRAMFILES is set (which it
-     * should be on Win XP or Win 2000), then directories under this one will
-     * be added to the search path. The %Cantera Windows installer installs
-     * data files to this location.
+     * The current directory (".") is always searched first. Then, on Windows, the
+     * registry is checked to find the Cantera installation directory, and the
+     * 'data' subdirectory of the installation directory will be added to the search
+     * path.
      *
-     * On the Mac, directory '/Applications/Cantera/data' is added to the
-     * search path.
-     *
-     * On any platform, if environment variable CANTERA_DATA is set to a
-     * directory name, then this directory is added to the search path.
+     * On any platform, if environment variable CANTERA_DATA is set to a directory
+     * name or a list of directory names separated with the OS-dependent path
+     * separator (that is, ";" on Windows, ":" elsewhere), then these directories will
+     * be added to the search path.
      *
      * Finally, the location where the data files were installed when
      * %Cantera was built is added to the search path.

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -6,9 +6,7 @@
 #include "cantera/base/FactoryBase.h"
 #include "application.h"
 #include "cantera/base/AnyMap.h"
-#ifdef CT_USE_DEMANGLE
-  #include <boost/core/demangle.hpp>
-#endif
+#include <boost/core/demangle.hpp>
 
 namespace Cantera
 {
@@ -212,11 +210,7 @@ std::string demangle(const std::type_info& type)
     if (typenames.count(type.name())) {
         return typenames[type.name()];
     } else {
-        #ifdef CT_USE_DEMANGLE
-            return boost::core::demangle(type.name());
-        #else
-            return type.name();
-        #endif
+        return boost::core::demangle(type.name());
     }
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Remove (mostly) unused environment variables in `config.h`

- `SOLARIS` is unused
- `NEED_ALT_MAIN` is used by a Fortran example but nowhere defined; there is no evidence of this being used outside of Cantera
- `LAPACK_NAMES_LOWERCASE` has a SCons option, but is nowhere mentioned in C++ or Fortran; there is no evidence of this being used outside of Cantera
- `CT_USE_DEMANGLE` is only required for Boost <1.56. The newly required DLL support was introduced in 1.61
- `DARWIN` is only used to set an obscure data location `/Applications/Cantera/data` - it *may* be used for `cantera-macos-pkg`, but I am not sure how much use the installer sees; its main use appears to be for an installation with Matlab, but I *believe* that the toolbox is broken for M1?

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
