### PR TITLE
Introduce unstrained-flow for BurnerFlame

### DIFF
--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -171,21 +171,31 @@ public:
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
     virtual void fromArray(SolutionArray& arr, double* soln);
 
-    //! Set flow configuration for freely-propagating flames, using an internal
-    //! point with a fixed temperature as the condition to determine the inlet
-    //! mass flux.
+    //! Set flow configuration for freely-propagating flames, using an internal point
+    //! with a fixed temperature as the condition to determine the inlet mass flux.
     void setFreeFlow() {
         m_type = cFreeFlow;
         m_dovisc = false;
         m_isFree = true;
+        m_usesLambda = false;
     }
 
-    //! Set flow configuration for axisymmetric counterflow or burner-stabilized
-    //! flames, using specified inlet mass fluxes.
+    //! Set flow configuration for axisymmetric counterflow flames, using specified
+    //! inlet mass fluxes.
     void setAxisymmetricFlow() {
         m_type = cAxisymmetricStagnationFlow;
         m_dovisc = true;
         m_isFree = false;
+        m_usesLambda = true;
+    }
+
+    //! Set flow configuration for burner-stabilized flames, using specified inlet mass
+    //! fluxes.
+    void setUnstrainedFlow() {
+        m_type = cAxisymmetricStagnationFlow;
+        m_dovisc = false;
+        m_isFree = false;
+        m_usesLambda = false;
     }
 
     //! Return the type of flow domain being represented, either "Free Flame" or
@@ -482,6 +492,7 @@ protected:
 
     bool m_dovisc;
     bool m_isFree;
+    bool m_usesLambda;
 
     //! Update the transport properties at grid points in the range from `j0`
     //! to `j1`, based on solution `x`.

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -733,6 +733,20 @@ cdef class FreeFlow(_FlowBase):
     _domain_type = "free-flow"
 
 
+cdef class UnstrainedFlow(_FlowBase):
+    r"""An unstrained flow domain. The equations solved are standard equations for
+    adiabatic one-dimensional flow. The solution variables are:
+
+    *velocity*
+        axial velocity
+    *T*
+        temperature
+    *Y_k*
+        species mass fractions
+    """
+    _domain_type = "unstrained-flow"
+
+
 cdef class AxisymmetricFlow(_FlowBase):
     r"""
     An axisymmetric flow domain. The equations solved are the similarity equations for
@@ -794,14 +808,15 @@ cdef class IdealGasFlow(_FlowBase):
 
     .. deprecated:: 3.0
 
-        Class to be removed after Cantera 3.0; replaced by `FreeFlow` and
-        s`AxisymmetricFlow`.
+        Class to be removed after Cantera 3.0; replaced by `FreeFlow`,
+        `AxisymmetricFlow` and `UnstrainedFlow`.
     """
     _domain_type = "gas-flow"
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Class to be removed after Cantera 3.0; use 'FreeFlow' "
-                      "or AxisymmetricFlow' instead.", DeprecationWarning)
+        warnings.warn("Class to be removed after Cantera 3.0; use 'FreeFlow', "
+                      "'AxisymmetricFlow' or 'UnstrainedFlow' instead.",
+                      DeprecationWarning)
         super().__init__(*args, **kwargs)
 
 

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -1067,7 +1067,7 @@ class BurnerFlame(FlameBase):
             Defines a grid on the interval [0, width] with internal points
             determined automatically by the solver.
 
-        A domain of class `AxisymmetricFlow` named ``flame`` will be created to
+        A domain of class `UnstrainedFlow` named ``flame`` will be created to
         represent the flame. The three domains comprising the stack are stored as
         ``self.burner``, ``self.flame``, and ``self.outlet``.
         """
@@ -1080,8 +1080,8 @@ class BurnerFlame(FlameBase):
 
         if not hasattr(self, 'flame'):
             # Create flame domain if not already instantiated by a child class
-            #: `AxisymmetricFlow` domain representing the flame
-            self.flame = AxisymmetricFlow(gas, name='flame')
+            #: `UnstrainedFlow` domain representing the flame
+            self.flame = UnstrainedFlow(gas, name='flame')
 
         if width is not None:
             grid = np.array([0.0, 0.1, 0.2, 0.3, 0.5, 0.7, 1.0]) * width

--- a/src/oneD/DomainFactory.cpp
+++ b/src/oneD/DomainFactory.cpp
@@ -53,6 +53,11 @@ DomainFactory::DomainFactory()
         ret->setAxisymmetricFlow();
         return ret;
     });
+    reg("unstrained-flow", [](shared_ptr<Solution> solution, const string& id) {
+        StFlow* ret = new StFlow(solution, id);
+        ret->setUnstrainedFlow();
+        return ret;
+    });
 }
 
 DomainFactory* DomainFactory::factory()

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -132,7 +132,10 @@ string StFlow::type() const {
     if (m_isFree) {
         return "free-flow";
     }
-    return "axisymmetric-flow";
+    if (m_usesLambda) {
+        return "axisymmetric-flow";
+    }
+    return "unstrained-flow";
 }
 
 void StFlow::setThermo(IdealGasPhase& th) {
@@ -730,9 +733,9 @@ bool StFlow::componentActive(size_t n) const
 {
     switch (n) {
     case c_offset_V: // spread_rate
-        return !m_isFree;
+        return m_usesLambda;
     case c_offset_L: // lambda
-        return !m_isFree;
+        return m_usesLambda;
     case c_offset_E: // eField
         return false;
     default:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Prior to this PR, `BurnerFlame` used an `AxisymmetricFlow` domain, despite `spread_rate` and `lambda` not being used.

- Introduce new `unstrained-flow` domain
- `spread_rate` and `lambda` are deactivated in output

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Resolves Cantera/enhancements#171

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
In [2]: %run burner_flame.py
[...]
Solution saved to 'burner_flame.csv'.

In [3]: f.to_array()
Out[3]:
            grid velocity         T          D  ...          HO2         H2O2        AR           N2
0    0.00000e+00  1.10292   373.000  0.0544011  ...  2.00004e-05  2.32431e-06  0.888904  6.64916e-15
1    1.22070e-05  1.10378   373.300  0.0543589  ...  2.04091e-05  2.37217e-06  0.888905 -3.57185e-15
2    2.44141e-05  1.10464   373.600  0.0543165  ...  2.07800e-05  2.42012e-06  0.888906 -2.00555e-15
3    3.66211e-05  1.10550   373.903  0.0542740  ...  2.11161e-05  2.46816e-06  0.888906  2.01846e-15
4    4.88281e-05  1.10637   374.206  0.0542313  ...  2.14203e-05  2.51625e-06  0.888907  8.48023e-15
..           ...      ...       ...        ...  ...          ...          ...       ...          ...
127  3.00000e-01  5.02974  1820.690  0.0119291  ...  4.07495e-07  2.00177e-08  0.888643 -1.31704e-14
128  3.25000e-01  5.05705  1831.589  0.0118646  ...  3.91957e-07  1.87521e-08  0.888642 -1.31743e-14
129  3.50000e-01  5.08146  1841.332  0.0118076  ...  3.78360e-07  1.76830e-08  0.888642 -1.32409e-14
130  4.25000e-01  5.13671  1863.292  0.0116806  ...  3.49561e-07  1.55033e-08  0.888639 -1.32705e-14
131  5.00000e-01  5.13671  1863.292  0.0116806  ...  3.49561e-07  1.55033e-08  0.888639 -1.32705e-14

[132 rows x 14 components; state='TDY']
```

<details>
Before this change, the output was

```
In [1]: %run burner_flame.py
[...]
Solution saved to 'burner_flame.csv'.

In [2]: f.to_array()
Out[2]:
            grid velocity spread_rate lambda         T  ...          HO2         H2O2        AR           N2
0    0.00000e+00  1.10292           0      0   373.000  ...  2.00004e-05  2.32431e-06  0.888904  6.64916e-15
1    1.22070e-05  1.10378           0      0   373.300  ...  2.04091e-05  2.37217e-06  0.888905 -3.57185e-15
2    2.44141e-05  1.10464           0      0   373.600  ...  2.07800e-05  2.42012e-06  0.888906 -2.00555e-15
3    3.66211e-05  1.10550           0      0   373.903  ...  2.11161e-05  2.46816e-06  0.888906  2.01846e-15
4    4.88281e-05  1.10637           0      0   374.206  ...  2.14203e-05  2.51625e-06  0.888907  8.48023e-15
..           ...      ...         ...    ...       ...  ...          ...          ...       ...          ...
127  3.00000e-01  5.02974           0      0  1820.690  ...  4.07495e-07  2.00177e-08  0.888643 -1.31704e-14
128  3.25000e-01  5.05705           0      0  1831.589  ...  3.91957e-07  1.87521e-08  0.888642 -1.31743e-14
129  3.50000e-01  5.08146           0      0  1841.332  ...  3.78360e-07  1.76830e-08  0.888642 -1.32409e-14
130  4.25000e-01  5.13671           0      0  1863.292  ...  3.49561e-07  1.55033e-08  0.888639 -1.32705e-14
131  5.00000e-01  5.13671           0      0  1863.292  ...  3.49561e-07  1.55033e-08  0.888639 -1.32705e-14

[132 rows x 16 components; state='TDY']
```
where `spread_rate` and `lambda` do not add information.
</details>

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
