### PR TITLE
Fix some problems with ExtensibleRate

### DIFF
--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -112,9 +112,9 @@ cdef class _SolutionBase:
         if name is not None:
             self.name = name
 
-    def __dealloc__(self):
-        if self._base:
-            self._base.get().removeChangedCallback(<PyObject*>self)
+    def __del__(self):
+        if self.base:
+            self.base.removeChangedCallback(<PyObject*>self)
 
     property name:
         """


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix de-registration of "change callbacks" from Python. I'm pretty sure this is the bug causing the failures noted in #1489.
- Fix working with locally-instantiated `ExtensibleRate` objects so they can also be retrieved from the `Solution` object

**If applicable, fill in the issue number this pull request is fixing**

Closes #1489

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
