### PR TITLE
Polynomial Ea coverage dependency

### DIFF
--- a/doc/sphinx/yaml/reactions.rst
+++ b/doc/sphinx/yaml/reactions.rst
@@ -388,7 +388,9 @@ Includes the fields of an :ref:`sec-yaml-elementary` reaction plus:
 
     ``E``
         Activation energy dependence on coverage, which uses the same sign convention
-        as the leading-order activation energy term
+        as the leading-order activation energy term. This can be a scalar value for
+        the linear dependency or a list of four values for the polynomial dependency
+        given in the order of 1st, 2nd, 3rd, and 4th-order coefficients
 
     or a list containing the three elements above, in the given order.
 
@@ -403,12 +405,21 @@ Examples::
       rate-constant: {A: 3.7e21 cm^2/mol/s, b: 0, Ea: 67400 J/mol}
       coverage-dependencies: {H(s): {a: 0, m: 0, E: -6000 J/mol}}
 
+    - equation: 2 O(S) => O2 + 2 Pt(S)
+      rate-constant: {A: 3.7e+21, b: 0, Ea: 213200 J/mol}
+      coverage-dependencies: {O(S): {a: 0.0, m: 0.0,
+        E: [1.0e3 J/mol, 3.0e3 J/mol , -7.0e4 J/mol , 5.0e3 J/mol]}
+
     - equation: CH4 + PT(S) + O(S) => CH3(S) + OH(S)
       rate-constant: {A: 5.0e+18, b: 0.7, Ea: 4.2e+04}
       coverage-dependencies:
         O(S): [0, 0, 8000]
         PT(S): [0, -1.0, 0]
 
+    - equation: 2 O(S) => O2 + 2 Pt(S)
+      rate-constant: {A: 3.7e+21, b: 0, Ea: 213200 J/mol}
+      coverage-dependencies:
+        O(S): [0, 0, [1.0e6, 3.0e6, -7.0e7, 5.0e6]]
 
 .. _sec-yaml-interface-Blowers-Masel:
 

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -141,7 +141,7 @@ public:
 
     //! Set association with an ordered list of all species associated with a given
     //! `Kinetics` object.
-    void setSpecies(const std::vector<std::string>& species);
+    void setSpecies(const vector<string>& species);
 
     //! Update reaction rate parameters
     //! @param shared_data  data shared by all reactions of a given type
@@ -257,16 +257,16 @@ protected:
     //! Vector holding coverage-specific activation energy dependence as a
     //! 5-membered array of polynomial coeffcients starting from 0th-order to
     //! 4th-order coefficients
-    std::vector<vector_fp> m_ec;
-    std::vector<bool> m_lindep; //!< Vector holding boolean for linear dependence
+    vector<vector_fp> m_ec;
+    vector<bool> m_lindep; //!< Vector holding boolean for linear dependence
     vector_fp m_mc; //!< Vector holding coverage-specific power-law exponents
 
 private:
     //! Pairs of species index and multipliers to calculate enthalpy change
-    std::vector<std::pair<size_t, double>> m_stoichCoeffs;
+    vector<pair<size_t, double>> m_stoichCoeffs;
 
     //! Pairs of phase index and net electric charges (same order as m_stoichCoeffs)
-    std::vector<std::pair<size_t, double>> m_netCharges;
+    vector<pair<size_t, double>> m_netCharges;
 };
 
 
@@ -301,7 +301,7 @@ public:
     }
 
     //! Get sticking species.
-    std::string stickingSpecies() const {
+    string stickingSpecies() const {
         return m_stickingSpecies;
     }
 
@@ -311,7 +311,7 @@ public:
      *  to be explicitly identified. Note that species have to be specified prior
      *  to adding a reaction to a Kinetics object.
      */
-    void setStickingSpecies(const std::string& stickingSpecies) {
+    void setStickingSpecies(const string& stickingSpecies) {
         m_stickingSpecies = stickingSpecies;
         m_explicitSpecies = true;
     }
@@ -360,7 +360,7 @@ public:
 protected:
     bool m_motzWise; //!< boolean indicating whether Motz & Wise correction is used
     bool m_explicitMotzWise; //!< Correction cannot be overriden by default
-    std::string m_stickingSpecies; //!< string identifying sticking species
+    string m_stickingSpecies; //!< string identifying sticking species
     bool m_explicitSpecies; //!< Boolean flag
     double m_surfaceOrder; //!< exponent applied to site density term
     double m_multiplier; //!< multiplicative factor in rate expression
@@ -391,7 +391,7 @@ public:
     }
 
     //! Identifier of reaction rate type
-    virtual const std::string type() const override {
+    virtual const string type() const override {
         return "interface-" + RateType::type();
     }
 
@@ -482,7 +482,7 @@ public:
     }
 
     //! Identifier of reaction rate type
-    virtual const std::string type() const override {
+    virtual const string type() const override {
         return "sticking-" + RateType::type();
     }
 
@@ -527,7 +527,7 @@ public:
         StickingCoverage::setContext(rxn, kin);
     }
 
-    virtual void validate(const std::string &equation, const Kinetics& kin) override {
+    virtual void validate(const string &equation, const Kinetics& kin) override {
         RateType::validate(equation, kin);
         fmt::memory_buffer err_reactions;
         double T[] = {200.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0};

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -88,7 +88,7 @@ struct InterfaceData : public BlowersMaselData
  * dependence on the activation energy modifier \f$ E_k \f$, polynomial coverage
  * dependence is also available. When the dependence parameter \f$ E_k \f$ is given as
  * a scalar value, the linear dependency is applied whereas if a list of four values
- * are given as \f$ [E^{(1)}_k-E^{(4)}_k] \f$, a polynomial dependency is applied as
+ * are given as \f$ [E^{(1)}_k, ..., E^{(4)}_k] \f$, a polynomial dependency is applied as
  *  \f[
  *      k_f = A T^b \exp \left( - \frac{E_a}{RT} \right)
  *          \prod_k 10^{a_k \theta_k} \theta_k^{m_k}
@@ -127,7 +127,7 @@ public:
     //! Add a coverage dependency for species *sp*, with exponential dependence
     //! *a*, power-law exponent *m*, and activation energy dependence *e*,
     //! where *e* is in Kelvin, that is, energy divided by the molar gas constant.
-    virtual void addCoverageDependence(const string& sp, double a, double m, vector_fp e);
+    virtual void addCoverageDependence(const string& sp, double a, double m, const vector_fp& e);
 
     //! Boolean indicating whether rate uses exchange current density formulation
     bool exchangeCurrentDensityFormulation() {
@@ -449,7 +449,7 @@ public:
         return RateType::activationEnergy() + m_ecov * GasConstant;
     }
 
-    void addCoverageDependence(const string& sp, double a, double m, vector_fp e) override {
+    void addCoverageDependence(const string& sp, double a, double m, const vector_fp& e) override {
         InterfaceRateBase::addCoverageDependence(sp, a, m, e);
         RateType::setCompositionDependence(true);
     }

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -190,12 +190,8 @@ void InterfaceRateBase::getCoverageDependencies(AnyMap& dependencies,
             if (m_lindep[k]) {
                 dep[2] = m_ec[k][1];
             } else {
-                vector<AnyValue> dep(3);
-                vector_fp E_temp(4);
-                for (size_t i = 0; i < m_ec[k].size() - 1; i++) {
-                    E_temp[i] = m_ec[k][i+1];
-                }
-                dep[2] = E_temp;
+                throw NotImplementedError("InterfaceRateBase::getCoverageDependencies",
+                    "Polynomial dependency not implemented for asVector.");
             }
             dep[0] = m_ac[k];
             dep[1] = m_mc[k];

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -190,7 +190,7 @@ void InterfaceRateBase::getCoverageDependencies(AnyMap& dependencies,
             if (m_lindep[k]) {
                 dep[2] = m_ec[k][1];
             } else {
-                std::vector<AnyValue> dep(3);
+                vector<AnyValue> dep(3);
                 vector_fp E_temp(4);
                 for (size_t i = 0; i < m_ec[k].size() - 1; i++) {
                     E_temp[i] = m_ec[k][i+1];
@@ -207,7 +207,7 @@ void InterfaceRateBase::getCoverageDependencies(AnyMap& dependencies,
             if (m_lindep[k]) {
                 dep["E"].setQuantity(m_ec[k][1], "K", true);
             } else {
-                std::vector<AnyValue> E_temp(4);
+                vector<AnyValue> E_temp(4);
                 for (size_t i = 0; i < m_ec[k].size() - 1; i++) {
                     E_temp[i].setQuantity(m_ec[k][i+1], "K", true);
                 }
@@ -218,7 +218,7 @@ void InterfaceRateBase::getCoverageDependencies(AnyMap& dependencies,
     }
 }
 
-void InterfaceRateBase::addCoverageDependence(const std::string& sp,
+void InterfaceRateBase::addCoverageDependence(const string& sp,
                                               double a, double m,
                                               const vector_fp& e)
 {
@@ -234,7 +234,7 @@ void InterfaceRateBase::addCoverageDependence(const std::string& sp,
     }
 }
 
-void InterfaceRateBase::setSpecies(const std::vector<std::string>& species)
+void InterfaceRateBase::setSpecies(const vector<string>& species)
 {
     m_indices.clear();
     for (size_t k = 0; k < m_cov.size(); k++) {
@@ -367,11 +367,11 @@ void StickingCoverage::setContext(const Reaction& rxn, const Kinetics& kin)
     // Identify the interface phase
     size_t iInterface = kin.reactionPhaseIndex();
 
-    std::string sticking_species = m_stickingSpecies;
+    string sticking_species = m_stickingSpecies;
     if (sticking_species == "") {
         // Identify the sticking species if not explicitly given
-        std::vector<std::string> gasSpecies;
-        std::vector<std::string> anySpecies;
+        vector<string> gasSpecies;
+        vector<string> anySpecies;
         for (const auto& [name, stoich] : rxn.reactants) {
             size_t iPhase = kin.speciesPhaseIndex(kin.kineticsSpeciesIndex(name));
             if (iPhase != iInterface) {

--- a/src/kinetics/InterfaceRate.cpp
+++ b/src/kinetics/InterfaceRate.cpp
@@ -154,7 +154,7 @@ void InterfaceRateBase::setCoverageDependencies(const AnyMap& dependencies,
                 E[1] = units.convertActivationEnergy(cov_map["E"], "K");
             } else {
                 m_lindep.push_back(false);
-                auto& E_temp = cov_map["E"].asVector<AnyValue>(4);
+                auto& E_temp = cov_map["E"].asVector<AnyValue>(1, 4);
                 for (size_t i = 0; i < E_temp.size(); i++) {
                     E[i+1] = units.convertActivationEnergy(E_temp[i], "K");
                 }
@@ -168,7 +168,7 @@ void InterfaceRateBase::setCoverageDependencies(const AnyMap& dependencies,
                 E[1] = units.convertActivationEnergy(cov_vec[2], "K");
             } else {
                 m_lindep.push_back(false);
-                auto& E_temp = cov_vec[2].asVector<AnyValue>(4);
+                auto& E_temp = cov_vec[2].asVector<AnyValue>(1, 4);
                 for (size_t i = 0; i < E_temp.size(); i++) {
                     E[i+1] = units.convertActivationEnergy(E_temp[i], "K");
                 }
@@ -219,7 +219,8 @@ void InterfaceRateBase::getCoverageDependencies(AnyMap& dependencies,
 }
 
 void InterfaceRateBase::addCoverageDependence(const std::string& sp,
-                                              double a, double m, vector_fp e)
+                                              double a, double m,
+                                              const vector_fp& e)
 {
     if (std::find(m_cov.begin(), m_cov.end(), sp) == m_cov.end()) {
         m_cov.push_back(sp);
@@ -264,7 +265,11 @@ void InterfaceRateBase::updateFromStruct(const InterfaceData& shared_data) {
     m_mcov = 0.0;
     for (auto& [iCov, iKin] : m_indices) {
         m_acov += m_ac[iCov] * shared_data.coverages[iKin];
-        m_ecov += poly4(shared_data.coverages[iKin], m_ec[iCov].data());
+        if (m_lindep[iCov]) {
+            m_ecov += m_ec[iCov][1] * shared_data.coverages[iKin];
+        } else {
+            m_ecov += poly4(shared_data.coverages[iKin], m_ec[iCov].data());
+        }
         m_mcov += m_mc[iCov] * shared_data.logCoverages[iKin];
     }
 

--- a/test/data/surface-phases.yaml
+++ b/test/data/surface-phases.yaml
@@ -148,6 +148,10 @@ Pt-reactions:
 Pt-multisite-reactions:
 - equation: 2 O(s) <=> O2(s)
   rate-constant: {A: 3.1e9 cm^2/mol/s, b: 0.0, Ea: 0.0}
+  # dummy reaction for polynomial Ea coverage dependence
+  coverage-dependencies:
+    {O(s): {a: 0, m: 0, E: [1.0e3 J/mol, 3.0e3 J/mol,
+                            -7.0e4 J/mol, 5.0e3 J/mol]}}
 
 graphite-anode-species:
 - name: EC(e)

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -605,8 +605,23 @@ TEST(Kinetics, InterfaceKineticsFromYaml)
     auto& cov_map = coverage_deps["H(s)"].as<Cantera::AnyMap>();
     EXPECT_DOUBLE_EQ(cov_map["E"].asDouble(), -6e6);
 
+
     auto R3 = kin->reaction(2);
     EXPECT_TRUE(std::dynamic_pointer_cast<StickingArrheniusRate>(R3->rate()));
+
+    auto soln2 = newInterface("surface-phases.yaml", "Pt-multi-sites");
+    auto kin2 = soln2->kinetics();
+    auto R4 = kin2->reaction(3);
+    vector_fp coeffs{1.0e6, 3.0e6, -7.0e7, 5.0e6};
+    const auto rate4 = std::dynamic_pointer_cast<InterfaceArrheniusRate>(R4->rate());
+    Cantera::AnyMap coverage_deps2;
+    rate4->getCoverageDependencies(coverage_deps2);
+    coverage_deps2.applyUnits();
+    auto& cov_map2 = coverage_deps2["O(s)"].as<Cantera::AnyMap>();
+    auto& poly_dep = cov_map2["E"].asVector<AnyValue>();
+    for (size_t i = 0; i < poly_dep.size(); i++) {
+        EXPECT_DOUBLE_EQ(poly_dep[i].asDouble(), coeffs[i]);
+    }
 }
 
 TEST(Kinetics, BMInterfaceKineticsFromYaml)

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -599,10 +599,10 @@ TEST(Kinetics, InterfaceKineticsFromYaml)
     auto R2 = kin->reaction(1);
     const auto rate2 = std::dynamic_pointer_cast<InterfaceArrheniusRate>(R2->rate());
     EXPECT_DOUBLE_EQ(rate2->preExponentialFactor(), 3.7e20);
-    Cantera::AnyMap coverage_deps;
+    AnyMap coverage_deps;
     rate2->getCoverageDependencies(coverage_deps);
     coverage_deps.applyUnits();
-    auto& cov_map = coverage_deps["H(s)"].as<Cantera::AnyMap>();
+    auto& cov_map = coverage_deps["H(s)"].as<AnyMap>();
     EXPECT_DOUBLE_EQ(cov_map["E"].asDouble(), -6e6);
 
 
@@ -614,10 +614,10 @@ TEST(Kinetics, InterfaceKineticsFromYaml)
     auto R4 = kin2->reaction(3);
     vector_fp coeffs{1.0e6, 3.0e6, -7.0e7, 5.0e6};
     const auto rate4 = std::dynamic_pointer_cast<InterfaceArrheniusRate>(R4->rate());
-    Cantera::AnyMap coverage_deps2;
+    AnyMap coverage_deps2;
     rate4->getCoverageDependencies(coverage_deps2);
     coverage_deps2.applyUnits();
-    auto& cov_map2 = coverage_deps2["O(s)"].as<Cantera::AnyMap>();
+    auto& cov_map2 = coverage_deps2["O(s)"].as<AnyMap>();
     auto& poly_dep = cov_map2["E"].asVector<AnyValue>();
     for (size_t i = 0; i < poly_dep.size(); i++) {
         EXPECT_DOUBLE_EQ(poly_dep[i].asDouble(), coeffs[i]);
@@ -639,10 +639,10 @@ TEST(Kinetics, BMInterfaceKineticsFromYaml)
     auto R2 = kin->reaction(0);
     const auto rate2 = std::dynamic_pointer_cast<InterfaceBlowersMaselRate>(R2->rate());
     EXPECT_DOUBLE_EQ(rate2->preExponentialFactor(), 3.7e20);
-    Cantera::AnyMap coverage_deps;
+    AnyMap coverage_deps;
     rate2->getCoverageDependencies(coverage_deps);
     coverage_deps.applyUnits();
-    auto& cov_map = coverage_deps["H(S)"].as<Cantera::AnyMap>();
+    auto& cov_map = coverage_deps["H(S)"].as<AnyMap>();
     EXPECT_DOUBLE_EQ(cov_map["E"].asDouble(), -6e6);
 
     auto R3 = kin->reaction(1);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- This PR will enable polynomial coverage dependency on activation energy for `InterfaceRate` on top of the current linear coverage dependency.
- The current methods for linear coverage dependency remain unchanged when a surface reaction's `E` in `coverage-dependencies` is given as a scalar value.
- When `E` is given as a list of four values, the 4th-order polynomial dependency is applied.
- Accordingly, source code changes are made in `InterfaceRate.cpp` and `InterfaceRate.h` as well as additional documentations in `InterfaceRate.h` and `reactions.rst` are appended.
- Lastly, an additional test routine is added to `kineticsFromYaml.cpp` with additional dummy coverage dependency parameters in `surface-phases.yaml`.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
