### PR TITLE
Implementation of PhotolysisRate 

### DIFF
--- a/data/ozone-photolysis.yaml
+++ b/data/ozone-photolysis.yaml
@@ -1,0 +1,230 @@
+description: |-
+  A simple photolysis mechanism for the breakdown of ozone and formation of NOx. This
+  model was constructed manually from a subset of MCM. Saunders, S. M., Jenkin, M. E.,
+  Derwent, R. G., & Pilling, M. J. (2003). Protocol for the development of the Master
+  Chemical Mechanism, MCM v3 (Part A): tropospheric degradation of non-aromatic
+  volatile organic compounds. Atmospheric Chemistry and Physics, 3(1), 161-180.
+cantera-version: 3.0
+
+units: {length: cm, time: s, quantity: molec}
+
+phases:
+- name: atmos
+  thermo: ideal-gas
+  elements: [O, N, H]
+  species: [O, O2, O1D, O3, NO, NO2, NO3, OH, H2O2, HNO3, HONO]
+  kinetics: gas
+  transport: mixture-averaged
+  state: {T: 300.0, P: 1 atm}
+  zenith_angle: 0.785 # 45 degrees
+
+species:
+- name: O
+  composition: {O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.1682671, -3.27931884e-03, 6.64306396e-06, -6.12806624e-09, 2.11265971e-12,
+      2.91222592e+04, 2.05193346]
+    - [2.56942078, -8.59741137e-05, 4.19484589e-08, -1.00177799e-11, 1.22833691e-15,
+      2.92175791e+04, 4.78433864]
+    note: L1/90
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 80.0
+    diameter: 2.75
+- name: O1D
+  composition: {O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.1682671, -3.27931884e-03, 6.64306396e-06, -6.12806624e-09, 2.11265971e-12,
+      2.91222592e+04, 2.05193346]
+    - [2.56942078, -8.59741137e-05, 4.19484589e-08, -1.00177799e-11, 1.22833691e-15,
+      2.92175791e+04, 4.78433864]
+    note: L1/90
+  transport:
+    model: gas
+    geometry: atom
+    well-depth: 80.0
+    diameter: 2.75
+- name: O2
+  composition: {O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.78245636, -2.99673416e-03, 9.84730201e-06, -9.68129509e-09, 3.24372837e-12,
+      -1063.94356, 3.65767573]
+    - [3.28253784, 1.48308754e-03, -7.57966669e-07, 2.09470555e-10, -2.16717794e-14,
+      -1088.45772, 5.45323129]
+    note: TPIS89
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 107.4
+    diameter: 3.458
+    polarizability: 1.6
+    rotational-relaxation: 3.8
+- name: O3
+  composition: {O: 3}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [3.40738221, 2.05379063e-03, 1.38486052e-05, -2.23311542e-08, 9.76073226e-12,
+      1.58644979e+04, 8.2824758]
+    - [12.3302914, -0.0119324783, 7.98741278e-06, -1.77194552e-09, 1.26075824e-13,
+      1.26755831e+04, -40.8823374]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 4.1
+    well-depth: 180.0
+    rotational-relaxation: 2.0
+- name: NO3
+  composition: {N: 1, O: 3}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [2.1735931, 0.0104902697, 1.1047265e-05, -2.81561854e-08, 1.36583958e-11,
+      7392.19877, 14.6022098]
+    - [7.48347734, 2.57772041e-03, -1.00945831e-06, 1.72314072e-10, -1.07154015e-14,
+      5709.19428, -14.1618155]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 400.0
+    diameter: 4.2
+    dipole: 0.2
+    rotational-relaxation: 1.0
+- name: NO
+  composition: {N: 1, O: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [4.2184763, -4.638976e-03, 1.1041022e-05, -9.3361354e-09, 2.803577e-12,
+      9844.623, 2.2808464]
+    - [3.2606056, 1.1911043e-03, -4.2917048e-07, 6.9457669e-11, -4.0336099e-15,
+      9920.9746, 6.3693027]
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 97.53
+    diameter: 3.621
+    polarizability: 1.76
+    rotational-relaxation: 4.0
+- name: NO2
+  composition: {N: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [3.9440312, -1.585429e-03, 1.6657812e-05, -2.0475426e-08, 7.8350564e-12,
+      2896.6179, 6.3119917]
+    - [4.8847542, 2.1723956e-03, -8.2806906e-07, 1.574751e-10, -1.0510895e-14,
+      2316.4983, -0.11741695]
+  transport:
+    model: gas
+    geometry: nonlinear
+    diameter: 3.5
+    well-depth: 200.0
+    rotational-relaxation: 1.0
+  note: L 7/88
+- name: OH
+  composition: {O: 1, H: 1}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [3.99201543, -2.40131752e-03, 4.61793841e-06, -3.88113333e-09, 1.3641147e-12,
+      3615.08056, -0.103925458]
+    - [3.09288767, 5.48429716e-04, 1.26505228e-07, -8.79461556e-11, 1.17412376e-14,
+      3858.657, 4.4766961]
+    note: RUS78
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 80.0
+    diameter: 2.75
+- name: HNO3
+  composition: {H: 1, N: 1, O: 3}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 6000.0]
+    data:
+    - [1.55975056, 0.0201502169, -1.15217296e-05, -2.3189123e-09, 3.17580552e-12,
+      -1.73955871e+04, 17.7294677]
+    - [8.03061257, 4.46368336e-03, -1.72272779e-06, 2.91611606e-10, -1.80487362e-14,
+      -1.93033764e+04, -16.2543421]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 300.0
+    diameter: 3.5
+    rotational-relaxation: 1.0
+- name: HONO
+  composition: {H: 1, N: 1, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [298.15, 1000.0, 3000.0]
+    data:
+    - [3.49106617, 6.81116875e-03, -1.3094312e-06, -2.34197204e-09, 1.18931535e-12,
+      -1.05722865e+04, 8.99803804]
+    - [4.19966671, 5.94217338e-03, -2.95404834e-06, 7.19846187e-10, -6.74909061e-14,
+      -1.08122769e+04, 5.08809833]
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 350.0
+    diameter: 3.95
+    dipole: 1.639
+    rotational-relaxation: 1.0
+- name: H2O2
+  composition: {H: 2, O: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [4.27611269, -5.42822417e-04, 1.67335701e-05, -2.15770813e-08, 8.62454363e-12,
+      -1.77025821e+04, 3.43505074]
+    - [4.16500285, 4.90831694e-03, -1.90139225e-06, 3.71185986e-10, -2.87908305e-14,
+      -1.78617877e+04, 2.91615662]
+    note: L7/88
+  transport:
+    model: gas
+    geometry: nonlinear
+    well-depth: 107.4
+    diameter: 3.458
+    rotational-relaxation: 3.8
+
+reactions:
+- equation: O3 => O1D + O2 # Reaction 1
+  type: photolysis
+  rate-constant: {l: 6.07e-5, m: 1.743, n: 0.474}
+- equation: O3 => O + O2 # Reaction 2
+  type: photolysis
+  rate-constant: {l: 4.775e-4, m: 0.298, n: 0.080}
+- equation: H2O2 => 2 OH # Reaction 3
+  type: photolysis
+  rate-constant: {l: 1.041e-5, m: 0.723, n: 0.279}
+- equation: NO2 => NO + O # Reaction 4
+  type: photolysis
+  rate-constant: {l: 1.165e-2, m: 0.244, n: 0.267}
+- equation: NO3 => NO + O2 # Reaction 5
+  type: photolysis
+  rate-constant: {l: 2.484e-2, m: 0.168, n: 0.108}
+- equation: NO3 => NO2 + O  # Reaction 6
+  type: photolysis
+  rate-constant: {l: 1.747e-1, m: 0.155, n: 0.125}
+- equation: HONO => NO + OH  # Reaction 7
+  type: photolysis
+  rate-constant: {l: 2.644e-3, m: 0.261, n: 0.288}
+- equation: HNO3 => NO2 + OH  # Reaction 8
+  type: photolysis
+  rate-constant: {l: 9.312e-7, m: 1.230, n: 0.307}

--- a/include/cantera/kinetics/PhotolysisRate.h
+++ b/include/cantera/kinetics/PhotolysisRate.h
@@ -1,0 +1,181 @@
+/**
+ * @file PhotolysisRate.h
+ * This header file includes definitions to implement Photolysis reactions.
+ * The photolysis rate, J, can be parameterized in two ways. A constant J value or
+ * with the equation: \f$ J(x) = l(\cos x)^m e^{-n \sec x } \f$ described by
+ * Saunders et al., 2003. This parameterization is chosen as the
+ * Master Chemical Mechanism (MCM) is one of the most extensive atmospheric models and
+ * uses this parameterization. So it makes model translation into Cantera format
+ * simpler.
+ *
+ *  Saunders, S. M., Jenkin, M. E., Derwent, R. G., & Pilling, M. J. (2003). Protocol
+ * for the development of the Master Chemical Mechanism, MCM v3 (Part A): tropospheric
+ * degradation of non-aromatic volatile organic compounds. Atmospheric Chemistry and
+ * Physics, 3(1), 161-180.
+ *
+ * @since  New in Cantera 3.0.
+ **/
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#ifndef CT_PHOTOLYSISRATE_H
+#define CT_PHOTOLYSISRATE_H
+
+#include "cantera/base/ct_defs.h"
+#include "cantera/base/Units.h"
+#include "cantera/kinetics/ReactionData.h"
+#include "ReactionRate.h"
+#include "MultiRate.h"
+
+namespace Cantera
+{
+
+class AnyValue;
+class AnyMap;
+
+//! Data container holding shared data specific to PhotolysisRate
+/**
+ * The data container `PhotolysisData` holds precalculated data common to
+ * all `PhotolysisRate` objects.
+ */
+struct PhotolysisData : public ReactionData
+{
+    double X = NAN; //!< Zenith angle initially set to NAN
+    virtual bool update(const ThermoPhase& phase, const Kinetics& kin);
+    using ReactionData::update;
+};
+
+//! Base class for Photolysis parameterizations
+/*!
+ * This base class provides a minimally functional interface that allows for parameter
+ * access from derived classes as well as classes that use Photolysis expressions.
+ *
+ */
+class PhotolysisRate : public ReactionRate
+{
+public:
+    //! Default constructor.
+    PhotolysisRate() {}
+
+    //! Constructor with constant parameterization.
+    /*!
+     *  @param J constant photolysis rate to be used
+     */
+    PhotolysisRate(double J);
+
+    //! Constructor with MCM parameterization.
+    /*!
+     *  @param l  First parameter in photolysis parameterization.
+     *  @param m  Second parameter in photolysis parameterization
+     *  @param n  Third parameter in photolysis parameterization
+     */
+    PhotolysisRate(double l, double m, double n);
+
+    //! Constructor based on AnyValue content
+    PhotolysisRate(const AnyValue& rate, const UnitSystem& units,
+                   const UnitStack& rate_units);
+
+    explicit PhotolysisRate(const AnyMap& node, const UnitStack& rate_units={});
+
+    //! Perform object setup based on AnyValue node information
+    /*!
+     *  Used to set parameters from a child of the reaction node, which may have
+     *  different names for different rate parameterizations, such as falloff rates.
+     *
+     *  @param rate  Child of the reaction node containing rate parameters.
+     *      For example, the `rate-coefficient` node for a standard Photolysis reaction.
+     *  @param units  Unit system
+     *  @param rate_units  Unit definitions specific to rate information
+     */
+    void setRateParameters(const AnyValue& rate,
+                           const UnitSystem& units,
+                           const UnitStack& rate_units);
+
+    //! Get parameters used to populate the `rate-coefficient` or
+    //! equivalent field
+    void getRateParameters(AnyMap& node) const;
+
+    virtual void setParameters(
+        const AnyMap& node, const UnitStack& rate_units) override;
+
+    virtual void getParameters(AnyMap& node) const override;
+
+    //! Check rate expression
+    virtual void check(const std::string& equation) override;
+
+    virtual void validate(const std::string& equation, const Kinetics& kin) override;
+
+    //! Return the parameter l in the photolysis parameterization
+    virtual double l_param() const {
+        return m_l;
+    }
+
+    //! Return the parameter m in the photolysis parameterization
+    virtual double m_param() const {
+        return m_m;
+    }
+
+    //! Return the parameter n in the photolysis parameterization
+    virtual double n_param() const {
+        return m_n;
+    }
+
+    unique_ptr<MultiRateBase> newMultiRate() const override {
+        return make_unique<MultiRate<PhotolysisRate, PhotolysisData>>();
+    }
+
+    virtual const std::string type() const override {
+        return "photolysis";
+    }
+
+    //! Evaluate reaction rate
+    double evalRate(double X) const {
+        if (!m_rate_evaluated && !std::isnan(X)) {
+            double J = m_l * std::pow(std::cos(X), m_m);
+            J *= std::exp(-m_n * 1 / std::cos(X));
+            return J;
+        } else {
+            return m_J;
+        }
+    }
+
+    //! Evaluate reaction rate
+    /*!
+     *  @param shared_data  data shared by all reactions of a given type
+     */
+    double evalFromStruct(const PhotolysisData& shared_data) const {
+        double X = shared_data.X;
+        if (!m_rate_evaluated && !std::isnan(X)) {
+            double J = m_l * std::pow(std::cos(X), m_m);
+            J *= std::exp(-m_n * 1 / std::cos(X));
+            return J;
+        } else {
+            return m_J;
+        }
+    }
+
+    //! Evaluate derivative of reaction rate with respect to temperature
+    //! divided by reaction rate
+    /*!
+     *  @param shared_data  data shared by all reactions of a given type
+     */
+    double ddTScaledFromStruct(const PhotolysisData& shared_data) const {
+        return 0;
+    }
+
+protected:
+    double m_rate_evaluated = false; //!< a flag indicating if the rate needs evaluated
+    double m_J = 0; //!< Photolysis rate
+    double m_l = NAN; //!< First parameter in photolysis parameterization
+    double m_m = NAN; //!< Second parameter in photolysis parameterization
+    double m_n = NAN; //!< Third parameter in photolysis parameterization
+    std::string m_J_str = "J"; //!< Parameter string for J
+    std::string m_l_str = "l"; //!< Parameter string for l
+    std::string m_m_str = "m"; //!< Parameter string for m
+    std::string m_n_str = "n"; //!< Parameter string for n
+};
+
+}
+
+#endif

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1808,6 +1808,19 @@ public:
 
     //! @}
 
+    //! Return zenith angle of light exposure, see @file PhotolysisRate.h.
+    //! @since  New in Cantera 3.0.
+    double zenithAngle() const {
+        return m_zenith_angle;
+    }
+
+    //! Set zenith angle of light exposure, see @file PhotolysisRate.h.
+    //! @param X zenith angle in radians
+    //! @since  New in Cantera 3.0.
+    void setZenithAngle(double X) {
+        m_zenith_angle = X;
+    }
+
 protected:
     //! Store the parameters of a ThermoPhase object such that an identical
     //! one could be reconstructed using the newThermo(AnyMap&) function. This
@@ -1850,6 +1863,9 @@ protected:
 
     //! last value of the temperature processed by reference state
     mutable double m_tlast = 0.0;
+
+    //! Zenith angle for light exposure in atmospherics
+    double m_zenith_angle = NAN;
 };
 
 }

--- a/interfaces/cython/cantera/reaction.pxd
+++ b/interfaces/cython/cantera/reaction.pxd
@@ -66,6 +66,15 @@ cdef extern from "cantera/kinetics/Arrhenius.h" namespace "Cantera":
         CxxBlowersMaselRate(CxxAnyMap) except +translate_exception
         CxxBlowersMaselRate(double, double, double, double)
 
+cdef extern from "cantera/kinetics/PhotolysisRate.h" namespace "Cantera":
+    cdef cppclass CxxPhotolysisRate "Cantera::PhotolysisRate" (CxxReactionRate):
+        CxxPhotolysisRate(CxxAnyMap) except +translate_exception
+        CxxPhotolysisRate(double)
+        CxxPhotolysisRate(double, double, double)
+        double evalRate(double)
+        double l_param()
+        double m_param()
+        double n_param()
 
 cdef extern from "cantera/kinetics/TwoTempPlasmaRate.h" namespace "Cantera":
     cdef cppclass CxxTwoTempPlasmaRate "Cantera::TwoTempPlasmaRate" (CxxArrheniusBase):
@@ -246,6 +255,10 @@ cdef class ReactionRate:
     cdef CxxReactionRate* rate
     @staticmethod
     cdef wrap(shared_ptr[CxxReactionRate])
+    cdef set_cxx_object(self)
+
+cdef class PhotolysisRate(ReactionRate):
+    cdef CxxPhotolysisRate* photolysis
     cdef set_cxx_object(self)
 
 cdef class ArrheniusRateBase(ReactionRate):

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -174,6 +174,9 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         double equivalenceRatio() except +translate_exception
         double stoichAirFuelRatio(const double* fuelComp, const double* oxComp, ThermoBasis basis) except +translate_exception
 
+        double zenithAngle()
+        void setZenithAngle(double)
+
 
 cdef extern from "cantera/thermo/SurfPhase.h":
     cdef cppclass CxxSurfPhase "Cantera::SurfPhase":

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -538,6 +538,13 @@ cdef class ThermoPhase(_SolutionBase):
         def __set__(self, val):
             self.thermo.setCaseSensitiveSpecies(bool(val))
 
+    property zenith_angle:
+        """Zenith angle for photolysis reactions"""
+        def __get__(self):
+            return self.thermo.zenithAngle()
+        def __set__(self, value):
+            self.thermo.setZenithAngle(value)
+
     def species(self, k=None):
         """
         Return the `Species` object for species ``k``, where ``k`` is either the

--- a/src/kinetics/PhotolysisRate.cpp
+++ b/src/kinetics/PhotolysisRate.cpp
@@ -1,0 +1,147 @@
+//! @file PhotolysisRate.cpp
+//! @since  New in Cantera 3.0.
+
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "cantera/kinetics/PhotolysisRate.h"
+#include "cantera/thermo/ThermoPhase.h"
+
+namespace Cantera
+{
+
+PhotolysisRate::PhotolysisRate(double J)
+    : m_J(J)
+{
+    m_valid = true;
+    m_rate_evaluated = true;
+}
+
+PhotolysisRate::PhotolysisRate(double l, double m, double n)
+    : m_l(l)
+    , m_m(m)
+    , m_n(n)
+{
+    m_valid = true;
+}
+
+PhotolysisRate::PhotolysisRate(const AnyValue& rate, const UnitSystem& units,
+                             const UnitStack& rate_units)
+{
+    setRateUnits(rate_units);
+    setRateParameters(rate, units, rate_units);
+}
+
+PhotolysisRate::PhotolysisRate(const AnyMap& node, const UnitStack& rate_units)
+{
+    setParameters(node, rate_units);
+}
+
+void PhotolysisRate::setRateParameters(
+    const AnyValue& rate, const UnitSystem& units, const UnitStack& rate_units)
+{
+    if (rate.empty()) {
+        m_l = NAN;
+        m_m = NAN;
+        m_n = NAN;
+        setRateUnits(Units(0.));
+        return;
+    }
+
+    if (rate.is<AnyMap>()) {
+        auto& rate_map = rate.as<AnyMap>();
+        // try to use constant J first then decide to use parameterizations
+        if (rate_map.hasKey(m_J_str)) {
+            m_J = units.convertRateCoeff(rate_map[m_J_str], conversionUnits());
+            m_rate_evaluated = true;
+        } else {
+            // The rate has units which are assigned to l as it is a scalar
+            m_l = units.convertRateCoeff(rate_map[m_l_str], conversionUnits());
+            m_m = rate_map[m_m_str].asDouble();
+            m_n = rate_map[m_n_str].asDouble();
+            m_rate_evaluated = false;
+        }
+    } else {
+        auto& rate_vec = rate.asVector<AnyValue>(1, 3);
+        if (rate_vec.size() < 2) {
+            m_J = units.convertRateCoeff(rate_vec[0], conversionUnits());
+            m_rate_evaluated = true;
+        } else {
+            m_l = units.convertRateCoeff(rate_vec[0], conversionUnits());
+            m_m = rate_vec[1].asDouble();
+            m_n = rate_vec[2].asDouble();
+            m_rate_evaluated = false;
+        }
+    }
+    m_valid = true;
+}
+
+void PhotolysisRate::getRateParameters(AnyMap& node) const
+{
+    if (!valid()) {
+        // Return empty/unmodified AnyMap
+        return;
+    }
+    // Use constant J value if it is not 0 else use parameters
+    if (m_J != 0) {
+        if (conversionUnits().factor() != 0.0) {
+            node[m_J_str].setQuantity(m_J, conversionUnits());
+        } else {
+            node[m_J_str] = m_J;
+            // This can't be converted to a different unit system because the dimensions of
+            // the rate constant were not set. Can occur if the reaction was created outside
+            // the context of a Kinetics object and never added to a Kinetics object.
+            node["__unconvertible__"] = true;
+        }
+    } else {
+        if (conversionUnits().factor() != 0.0) {
+            node[m_l_str].setQuantity(m_l, conversionUnits());
+        } else {
+            node[m_l_str] = m_l;
+        }
+        node[m_m_str] = m_m;
+        node[m_n_str] = m_n;
+    }
+    node.setFlowStyle();
+}
+
+void PhotolysisRate::setParameters(const AnyMap& node, const UnitStack& rate_units)
+{
+    ReactionRate::setParameters(node, rate_units);
+    if (!node.hasKey("rate-constant")) {
+        setRateParameters(AnyValue(), node.units(), rate_units);
+        return;
+    }
+    setRateParameters(node["rate-constant"], node.units(), rate_units);
+}
+
+void PhotolysisRate::getParameters(AnyMap& node) const {
+    AnyMap rateNode;
+    getRateParameters(rateNode);
+    if (!rateNode.empty()) {
+        // RateType object is configured
+        node["rate-constant"] = std::move(rateNode);
+    }
+}
+
+void PhotolysisRate::check(const std::string& equation)
+{
+    //TODO: add check if necessary
+}
+
+void PhotolysisRate::validate(const std::string& equation, const Kinetics& kin)
+{
+    if (!valid()) {
+        throw InputFileError("PhotolysisRate::validate", m_input,
+            "Rate object for reaction '{}' is not configured.", equation);
+    }
+}
+
+bool PhotolysisData::update(const ThermoPhase& phase, const Kinetics& kin)
+{
+    // set a zenith angle if there is one
+    X = phase.zenithAngle();
+    return true;
+}
+
+}

--- a/src/kinetics/ReactionRateFactory.cpp
+++ b/src/kinetics/ReactionRateFactory.cpp
@@ -16,6 +16,7 @@
 #include "cantera/kinetics/InterfaceRate.h"
 #include "cantera/kinetics/PlogRate.h"
 #include "cantera/kinetics/TwoTempPlasmaRate.h"
+#include "cantera/kinetics/PhotolysisRate.h"
 
 namespace Cantera
 {
@@ -32,6 +33,11 @@ ReactionRateFactory::ReactionRateFactory()
     addAlias("Arrhenius", "");
     addAlias("Arrhenius", "elementary");
     addAlias("Arrhenius", "three-body");
+
+    // PhotolysisRate evaluator
+    reg("photolysis", [](const AnyMap& node, const UnitStack& rate_units) {
+        return new PhotolysisRate(node, rate_units);
+    });
 
     // TwoTempPlasmaRate evaluator
     reg("two-temperature-plasma", [](const AnyMap& node, const UnitStack& rate_units) {

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -389,6 +389,11 @@ void setupPhase(ThermoPhase& thermo, const AnyMap& phaseNode, const AnyMap& root
         }
     }
 
+    // set zenith angle if it is provided
+    if (phaseNode.hasKey("zenith_angle")) {
+        thermo.setZenithAngle(phaseNode["zenith_angle"].asDouble());
+    }
+
     thermo.setParameters(phaseNode, rootNode);
     thermo.initThermo();
 

--- a/test/data/kineticsfromscratch.yaml
+++ b/test/data/kineticsfromscratch.yaml
@@ -15,6 +15,7 @@ phases:
   elements: [O, H, Ar]
   species:
   - h2o2.yaml/species: [AR, O, H2, H, OH, O2, H2O, H2O2, HO2]
+  - ozone-photolysis.yaml/species: [O3]
   kinetics: gas
   reactions: [reactions]
   state:
@@ -101,6 +102,14 @@ reactions:
 - equation: O + H2 + M <=> H2O + M  # Reaction 14
   type: Blowers-Masel
   rate-constant: {A: 38700, b: 2.7, Ea0: 2.619184e4, w: 4.184e9}
+- equation: O3 => O + O2 # Reaction 15
+  duplicate: true
+  type: photolysis
+  rate-constant: {l: 4.775e-4, m: 0.298, n: 0.080}
+- equation: O3 => O + O2 # Reaction 16
+  duplicate: true
+  type: photolysis
+  rate-constant: {J: 0.5}
 
 surface:
 - units: {length: cm, quantity: mol, activation-energy: J/mol}

--- a/test/python/test_jacobian.py
+++ b/test/python/test_jacobian.py
@@ -586,8 +586,8 @@ class FromScratchCases(RateExpressionTests):
     @classmethod
     def setUpClass(cls):
         cls.gas = ct.Solution("kineticsfromscratch.yaml", transport_model=None)
-        #   species: [AR, O, H2, H, OH, O2, H2O, H2O2, HO2]
-        cls.gas.X = [0.1, 3e-4, 5e-5, 6e-6, 3e-3, 0.6, 0.25, 1e-6, 2e-5]
+        #   species: [AR, O, H2, H, OH, O2, H2O, H2O2, HO2, O3]
+        cls.gas.X = [0.1, 3e-4, 5e-5, 6e-6, 3e-3, 0.6, 0.25, 1e-6, 2e-5, 1e-4]
         cls.gas.TP = 2000, 5 * ct.one_atm
         super().setUpClass()
 

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -671,7 +671,7 @@ class TestFreeFlame(utilities.CanteraTest):
             "min_temp", "molecular_weights", "product_stoich_coeffs",
             "product_stoich_coeffs3", "product_stoich_coeffs_reversible",
             "reactant_stoich_coeffs", "reactant_stoich_coeffs3", "reference_pressure",
-            "state", "u", "v",
+            "state", "u", "v", "zenith_angle",
             # Skipped because they are 2D (conversion not implemented)
             "binary_diff_coeffs", "creation_rates_ddX", "destruction_rates_ddX",
             "forward_rates_of_progress_ddX", "net_production_rates_ddX",

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -47,6 +47,10 @@ class TestThermoPhase(utilities.CanteraTest):
         with self.assertRaisesRegex(ct.CanteraError, "(?s)phasename.*said so"):
             ct.Solution(yaml=yaml)
 
+    def test_zenith_application(self):
+        gas = ct.Solution("ozone-photolysis.yaml", "atmos")
+        self.assertEqual(gas.zenith_angle, 0.785)
+
     def test_base_attributes(self):
         self.assertIsInstance(self.phase.name, str)
         self.assertIsInstance(self.phase.phase_of_matter, str)
@@ -1945,7 +1949,8 @@ class TestSolutionArray(utilities.CanteraTest):
             # Skipped because they are complicated (conversion not implemented)
             "forward_rates_of_progress_ddX", "net_rates_of_progress_ddX",
             "reverse_rates_of_progress_ddX", "state", "net_rates_of_progress_ddCi",
-            "forward_rates_of_progress_ddCi", "reverse_rates_of_progress_ddCi"
+            "forward_rates_of_progress_ddCi", "reverse_rates_of_progress_ddCi",
+            "zenith_angle"
         }
         skip.update(ct.SolutionArray._passthrough)
 


### PR DESCRIPTION
This commit implements PhotolysisRate which is a type of atmospheric process where light exposure causes the reaction. Other slight changes to files are included such as a zenith angle to the ThermoPhase object which is the angle of light exposure to calculate rates from the applied parameterization. The parameterization implemented is from the Master Chemical Mechanism Protocol.

Saunders, S. M., Jenkin, M. E., Derwent, R. G., & Pilling, M. J. (2003). Protocol for the development of the Master Chemical Mechanism, MCM v3 (Part A): tropospheric degradation of non-aromatic volatile organic compounds. Atmospheric Chemistry and Physics, 3(1), 161-180.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Implementation of PhotolysisRate to model the atmospheric process.
- Implementation of associated tests.
- Python interface for all implementations
- Minor implementations to thermo phase to facilitate Photolysis rate calculation

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

The implementation can be used simply for different photolysis rate calculations or other examples such as modeling photolysis reactions in a gas phase. For example

```
gas = ct.Solution("ozone-photolysis.yaml", "atmos")
gas.zenith_angle = 0.4
print(gas.forward_rate_constants)
```

Presently changing the zenith angle does not force the rates to be updated. I thought perhaps it should but I think the zenith angle should live in the phase as my next step will be implementation of extended phases for heterogeneous chemistry which will require the zenith angle. I am open to suggestions in this regard.

Atmospheric chemistry is an interest in [#47](https://github.com/Cantera/enhancements/issues/47)

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
