### PR TITLE
Patch Segfault Error for Experimental Matlab Toolbox

### DIFF
--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -1302,8 +1302,16 @@ classdef ThermoPhase < handle
         function set.X(tp, xx)
             tol = 1e-9;
 
+            if isempty(xx)
+                error('Array cannot be empty');
+            end
+
             if isa(xx, 'double')
                 nsp = tp.nSpecies;
+
+                if length(xx) ~= nsp
+                    error('Length of array must be equal to number of species.')
+                end
 
                 if abs(sum(xx) - 1) <= tol
                     norm = 0;
@@ -1323,8 +1331,16 @@ classdef ThermoPhase < handle
         function set.Y(tp, yy)
             tol = 1e-9;
 
+            if isempty(yy)
+                error('Array cannot be empty');
+            end
+
             if isa(yy, 'double')
                 nsp = tp.nSpecies;
+
+                if length(yy) ~= nsp
+                    error('Length of array must be equal to number of species.')
+                end
 
                 if abs(sum(yy) -1) <= tol
                     norm = 0;


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Added extra error handling for mole fraction and mass fraction setters in the new matlab toolbox.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Setting X and Y with an empty array/string OR arrays of incorrect length (not matching the number of species) will cause a segfault error and instantly crashes Matlab. 
- This patch is necessary for the Matlab test suite (#1496)  to run without crashing. 

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
