### PR TITLE
Fix memory management errors in ExtensibleRate

### DIFF
--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -275,6 +275,13 @@ bool legacy_rate_constants_used();
 //! @copydoc Application::Messages::setLogger
 void setLogger(Logger* logwriter);
 
+//! Enables printing a stacktrace to `std::err` if a segfault occurs. The Boost
+//! documentation says doing this from an error handler is not safe on all platforms
+//! and risks deadlocking. However, it can be useful for debugging and is therefore
+//! enabled when running tests.
+//! @since New in Cantera 3.0
+void printStackTraceOnSegfault();
+
 //! Clip *value* such that lower <= value <= upper
 template <class T>
 inline T clip(const T& value, const T& lower, const T& upper)

--- a/include/cantera/extensions/PythonHandle.h
+++ b/include/cantera/extensions/PythonHandle.h
@@ -20,8 +20,14 @@ public:
     //! @param obj  The Python object to be held
     //! @param weak  `true` if this is a weak reference to the Python object and this
     //!    handle is not responsible for deleting the Python object, or `false` if this
-    //!    handle "owns" the Python object
-    PythonHandle(PyObject* obj, bool weak) : m_obj(obj), m_weak(weak) {}
+    //!    handle should own a reference to the Python object
+    PythonHandle(PyObject* obj, bool weak) : m_obj(obj), m_weak(weak) {
+        if (!weak) {
+            Py_XINCREF(obj);
+        }
+    }
+    PythonHandle(const PythonHandle&) = delete;
+    PythonHandle& operator=(const PythonHandle&) = delete;
 
     ~PythonHandle() {
         if (!m_weak) {

--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -81,6 +81,7 @@ cdef extern from "cantera/base/global.h" namespace "Cantera":
     cdef string CxxVersion "Cantera::version" ()
     cdef cbool CxxUsesHDF5 "Cantera::usesHDF5" ()
     cdef cbool CxxDebugModeEnabled "Cantera::debugModeEnabled" ()
+    cdef void CxxPrintStackTraceOnSegfault "Cantera::printStackTraceOnSegfault" ()
 
 
 cdef extern from "cantera/cython/utils_utils.h":

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -72,6 +72,15 @@ _USE_SPARSE = False
 def debug_mode_enabled():
     return CxxDebugModeEnabled()
 
+def print_stack_trace_on_segfault():
+    """
+    Enable printing a stack trace if a segfault occurs. Not recommended for general
+    use as it is possible for this to deadlock.
+
+    .. versionadded:: 3.0
+    """
+    CxxPrintStackTraceOnSegfault()
+
 def appdelete():
     """ Delete all global Cantera C++ objects """
     CxxAppdelete()

--- a/interfaces/cython/cantera/ctcxx.pxd
+++ b/interfaces/cython/cantera/ctcxx.pxd
@@ -11,7 +11,7 @@ from libcpp.cast cimport dynamic_cast
 from libcpp.pair cimport pair
 from libcpp cimport bool as cbool
 from libcpp.functional cimport function
-from libcpp.memory cimport shared_ptr, dynamic_pointer_cast
+from libcpp.memory cimport shared_ptr, weak_ptr, dynamic_pointer_cast
 from cpython cimport bool as pybool
 from cpython.ref cimport PyObject
 from cython.operator cimport dereference as deref, preincrement as inc

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -107,6 +107,7 @@ cdef object _wrap_Solution(shared_ptr[CxxSolution] cxx_soln)
 
 cdef class _SolutionBase:
     cdef shared_ptr[CxxSolution] _base
+    cdef weak_ptr[CxxSolution] weak_base
     cdef CxxSolution* base
     cdef CxxThermoPhase* thermo
     cdef CxxKinetics* kinetics

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -463,7 +463,7 @@ cdef _assign_Solution(_SolutionBase soln, shared_ptr[CxxSolution] cxx_soln,
             soln._adjacent[name] = _wrap_Solution(adj_soln)
 
     cdef shared_ptr[CxxExternalHandle] handle
-    handle.reset(new CxxPythonHandle(<PyObject*>soln, True))
+    handle.reset(new CxxPythonHandle(<PyObject*>soln, not weak))
     soln.base.holdExternalHandle(stringify("python"), handle)
 
 

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -100,10 +100,6 @@ cdef class _SolutionBase:
 
         self._selected_species = np.ndarray(0, dtype=np.uint64)
 
-        cdef shared_ptr[CxxExternalHandle] handle
-        handle.reset(new CxxPythonHandle(<PyObject*>self, True))
-        self.base.holdExternalHandle(stringify("python"), handle)
-
     def __init__(self, *args, **kwargs):
         if isinstance(self, Transport) and kwargs.get("init", True):
             assert self.transport is not NULL
@@ -465,6 +461,10 @@ cdef _assign_Solution(_SolutionBase soln, shared_ptr[CxxSolution] cxx_soln,
             adj_soln = soln.base.adjacent(i)
             name = pystr(adj_soln.get().name())
             soln._adjacent[name] = _wrap_Solution(adj_soln)
+
+    cdef shared_ptr[CxxExternalHandle] handle
+    handle.reset(new CxxPythonHandle(<PyObject*>soln, True))
+    soln.base.holdExternalHandle(stringify("python"), handle)
 
 
 cdef object _wrap_Solution(shared_ptr[CxxSolution] cxx_soln):

--- a/src/extensions/PythonExtensionManager.cpp
+++ b/src/extensions/PythonExtensionManager.cpp
@@ -103,6 +103,7 @@ void PythonExtensionManager::registerRateBuilder(
         // reference cycle is handled on the Python side.
         delegator->holdExternalHandle("python",
                                       make_shared<PythonHandle>(extRate, false));
+        Py_XDECREF(extRate);
         return delegator.release();
     };
     ReactionRateFactory::factory()->reg(rateName, builder);
@@ -124,7 +125,9 @@ void PythonExtensionManager::registerRateDataBuilder(
                                "Problem in ct_newPythonExtensibleRateData:\n{}",
                                getPythonExceptionInfo());
         }
-        delegator.setWrapper(make_shared<PythonHandle>(extData, false));
+        auto handle = make_shared<PythonHandle>(extData, false);
+        Py_XDECREF(extData);
+        delegator.setWrapper(handle);
     };
     mgr.registerReactionDataLinker(rateName, "python", builder);
 
@@ -137,7 +140,9 @@ void PythonExtensionManager::registerRateDataBuilder(
                                "Problem in ct_wrapSolution:\n{}",
                                getPythonExceptionInfo());
         }
-        return make_shared<PythonHandle>(pySoln, false);
+        auto handle = make_shared<PythonHandle>(pySoln, false);
+        Py_XDECREF(pySoln);
+        return handle;
     };
     mgr.registerSolutionLinker("python", solnLinker);
 }

--- a/src/extensions/pythonShim.cpp
+++ b/src/extensions/pythonShim.cpp
@@ -38,6 +38,10 @@ void checkPythonError(bool condition, const string& message) {
 
 void loadCanteraPython()
 {
+    // Prevent output buffering managed by Python.
+    // @todo: It may be better to avoid replacing the existing Logger instance
+    //     with a PythonLogger in the case of an embedded Python interpreter.
+    Py_UnbufferedStdioFlag = 1;
     const char* venv_path = getenv("VIRTUAL_ENV");
     if (venv_path != nullptr) {
         PyConfig pyconf;

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -230,6 +230,7 @@ int main(int argc, char** argv)
     printf("Running main() from test_clib.cpp\n");
     testing::InitGoogleTest(&argc, argv);
     make_deprecation_warnings_fatal();
+    printStackTraceOnSegfault();
     vector<string> fileNames = {"gtest-freeflame.yaml", "gtest-freeflame.h5"};
     for (const auto& fileName : fileNames) {
         if (std::ifstream(fileName).good()) {

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -315,6 +315,7 @@ int main(int argc, char** argv)
     printf("Running main() from equil_gas.cpp\n");
     testing::InitGoogleTest(&argc, argv);
     make_deprecation_warnings_fatal();
+    printStackTraceOnSegfault();
     int result = RUN_ALL_TESTS();
     appdelete();
     return result;

--- a/test/general/string_processing.cpp
+++ b/test/general/string_processing.cpp
@@ -118,6 +118,7 @@ int main(int argc, char** argv)
     printf("Running main() from string_processing.cpp\n");
     testing::InitGoogleTest(&argc, argv);
     Cantera::make_deprecation_warnings_fatal();
+    Cantera::printStackTraceOnSegfault();
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();
     return result;

--- a/test/general/test_misc.cpp
+++ b/test/general/test_misc.cpp
@@ -1,0 +1,11 @@
+// This file is part of Cantera. See License.txt in the top-level directory or
+// at https://cantera.org/license.txt for license and copyright information.
+
+#include "gtest/gtest.h"
+#include "cantera/base/global.h"
+
+using namespace Cantera;
+
+TEST(FatalError, stacktrace) {
+    EXPECT_DEATH(std::abort(), "Stack trace");
+}

--- a/test/kinetics/pdep.cpp
+++ b/test/kinetics/pdep.cpp
@@ -226,6 +226,7 @@ int main(int argc, char** argv)
 {
     printf("Running main() from pdep.cpp\n");
     Cantera::make_deprecation_warnings_fatal();
+    Cantera::printStackTraceOnSegfault();
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();

--- a/test/oneD/test_oneD.cpp
+++ b/test/oneD/test_oneD.cpp
@@ -108,6 +108,7 @@ int main(int argc, char** argv)
     printf("Running main() from test_oneD.cpp\n");
     testing::InitGoogleTest(&argc, argv);
     make_deprecation_warnings_fatal();
+    printStackTraceOnSegfault();
     int result = RUN_ALL_TESTS();
     appdelete();
     return result;

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -1801,6 +1801,24 @@ class TestExtensible3(utilities.CanteraTest):
         rxn2 = self.gas.reaction(self.gas.n_reactions - 1)
         assert id(rate) == id(rxn.rate) == id(rxn2.rate)
 
+    def test_interface_adjacent(self):
+        # Phases adjacent to an interface automatically are initialized slightly
+        # differently, warranting a separate test to make sure the Solution wrapper
+        # is created correctly
+        surf = ct.Interface('kineticsfromscratch.yaml', 'Pt_surf', transport_model=None)
+        gas = surf.adjacent['ohmech']
+        rxn = """
+        equation: H2 + OH = H2O + H
+        type: user-rate-2
+        A: 1000
+        L: 200
+        Ea: 1000 K
+        """
+        rxn = ct.Reaction.from_yaml(rxn, kinetics=gas)
+        gas.add_reaction(rxn)
+        kf = 1000 * (200 / 2.0)**2 * exp(-1000/gas.T)
+        assert gas.forward_rate_constants[-1] == approx(kf)
+
 
 class InterfaceReactionTests(ReactionTests):
     # test suite for surface reaction expressions

--- a/test/python/utilities.py
+++ b/test/python/utilities.py
@@ -20,6 +20,7 @@ CANTERA_DATA_PATH = Path(cantera.__file__).parent / "data"
 
 cantera.add_directory(TEST_DATA_PATH)
 cantera.add_directory(CANTERA_DATA_PATH)
+cantera.print_stack_trace_on_segfault()
 
 @pytest.fixture
 def allow_deprecated():

--- a/test/thermo/nasapoly.cpp
+++ b/test/thermo/nasapoly.cpp
@@ -132,6 +132,7 @@ int main(int argc, char** argv)
 {
     printf("Running main() from nasapoly.cpp\n");
     Cantera::make_deprecation_warnings_fatal();
+    Cantera::printStackTraceOnSegfault();
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();

--- a/test/transport/transportFromScratch.cpp
+++ b/test/transport/transportFromScratch.cpp
@@ -171,6 +171,8 @@ TEST_F(TransportFromScratch, thermalConductivityMulti)
 int main(int argc, char** argv)
 {
     printf("Running main() from transportFromScratch.cpp\n");
+    make_deprecation_warnings_fatal();
+    printStackTraceOnSegfault();
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
     appdelete();

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -197,6 +197,7 @@ int main(int argc, char** argv)
     printf("Running main() from test_zeroD.cpp\n");
     testing::InitGoogleTest(&argc, argv);
     Cantera::make_deprecation_warnings_fatal();
+    printStackTraceOnSegfault();
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();
     return result;


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Don't buffer output from Python when embedding, to avoid confusing ordering of debug log messages
- Print stack traces after tests that segfault as a debugging aid
- Update to the attempted fix for #1489 in 2158ff983: we need to use a `weak_ptr` to know whether the C++ `Solution` object still exists before calling `removeChangedCallback`.
- Fix a reference counting error when creating a `PythonHandle` from Python

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
