### PR TITLE
Fix handling of reference pressure in MultiSpeciesThermo

### DIFF
--- a/doc/sphinx/yaml/species.rst
+++ b/doc/sphinx/yaml/species.rst
@@ -160,6 +160,7 @@ Example::
     thermo:
       model: Shomate
       temperature-ranges: [298, 1300, 6000]
+      reference-pressure: 1 bar
       data:
       - [25.56759, 6.096130, 4.054656, -2.671301, 0.131021,
         -118.0089, 227.3665]

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -126,6 +126,8 @@ public:
      * for the first species.
      *
      * @param k Species Index
+     * @deprecated The species index parameter is deprecated and will be removed after
+     *     Cantera 3.0. All species in a phase must have the same reference pressure.
      */
     virtual doublereal refPressure(size_t k=npos) const;
 
@@ -226,7 +228,7 @@ protected:
     double m_thigh_min = 1e+30;
 
     //! reference pressure (Pa)
-    double m_p0 = OneAtm;
+    double m_p0 = 0.0;
 
     //! indicates if data for species has been installed
     std::vector<bool> m_installed;

--- a/test/thermo/thermoParameterizations.cpp
+++ b/test/thermo/thermoParameterizations.cpp
@@ -54,10 +54,19 @@ TEST_F(SpeciesThermoInterpTypeTest, install_const_cp)
     EXPECT_DOUBLE_EQ(p2.cp_mass(), p.cp_mass());
 }
 
-TEST_F(SpeciesThermoInterpTypeTest, DISABLED_install_bad_pref)
+TEST_F(SpeciesThermoInterpTypeTest, install_specified_pref)
 {
-    // Currently broken because MultiSpeciesThermo does not enforce reference
-    // pressure consistency.
+    auto sO2 = make_shared<Species>("O2", parseCompString("O:2"));
+    auto sH2 = make_shared<Species>("H2", parseCompString("H:2"));
+    sO2->thermo = make_shared<ConstCpPoly>(200, 5000, 100000, c_o2);
+    sH2->thermo = make_shared<ConstCpPoly>(200, 5000, 100000, c_h2);
+    p.addSpecies(sO2);
+    // Pref does not match
+    EXPECT_DOUBLE_EQ(p.refPressure(), 1e5);
+}
+
+TEST_F(SpeciesThermoInterpTypeTest, install_bad_pref)
+{
     auto sO2 = make_shared<Species>("O2", parseCompString("O:2"));
     auto sH2 = make_shared<Species>("H2", parseCompString("H:2"));
     sO2->thermo = make_shared<ConstCpPoly>(200, 5000, 101325, c_o2);


### PR DESCRIPTION
**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Require all species in a phase to have the same reference pressure.
- Set the reference pressure for the phase based on the first species added (instead of ignoring the value specified by the species)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1435

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
