### PR TITLE
Deprecate some unused classes / methods

### DIFF
--- a/doc/sphinx/yaml/species.rst
+++ b/doc/sphinx/yaml/species.rst
@@ -372,8 +372,10 @@ Ideal gas
 
 A species using the ideal gas equation of state, as
 `described here <https://cantera.org/documentation/dev/doxygen/html/df/d31/classCantera_1_1PDSS__IdealGas.html#details>`__.
-This model is the default if no ``equation-of-state`` section is included.
 
+.. deprecated:: 3.0
+
+    This species thermo model is deprecated and will be removed after Cantera 3.0.
 
 .. _sec-yaml-eos-ions-from-neutral:
 

--- a/include/cantera/numerics/ResidEval.h
+++ b/include/cantera/numerics/ResidEval.h
@@ -11,6 +11,11 @@
 #include "cantera/base/utilities.h"
 #include "cantera/base/global.h"
 
+#ifndef CT_SKIP_DEPRECATION_WARNINGS
+#pragma message("warning: ResidEval.h and class ResidEval are deprecated and will " \
+                "be removed after Cantera 3.0.")
+#endif
+
 namespace Cantera
 {
 
@@ -27,12 +32,15 @@ const int c_LT_ZERO = -2;
  *             \vec{F}(t,\vec{y}, \vec{y^\prime})
  * \f]
  * The DAE solver attempts to find a solution y(t) such that F = 0.
+ * @deprecated Unused. To be removed after Cantera 3.0.
  *  @ingroup DAE_Group
  */
 class ResidEval
 {
 public:
-    ResidEval() {}
+    ResidEval() {
+        warn_deprecated("class ResidEval", "To be removed after Cantera 3.0");
+    }
     virtual ~ResidEval() {}
 
     /**

--- a/include/cantera/numerics/ResidJacEval.h
+++ b/include/cantera/numerics/ResidJacEval.h
@@ -13,6 +13,11 @@
 #include "ResidEval.h"
 #include "DenseMatrix.h"
 
+#ifndef CT_SKIP_DEPRECATION_WARNINGS
+#pragma message("warning: ResidJacEval.h and class ResidJacEval are deprecated and " \
+                "will be removed after Cantera 3.0.")
+#endif
+
 namespace Cantera
 {
 
@@ -51,6 +56,8 @@ enum ResidEval_Type_Enum {
  * A class for full (non-sparse dense matrices with Fortran-compatible data
  * storage. The class adds support for identifying what types of calls are made
  * to the residual evaluator by adding the ResidEval_Type_Enum class.
+ *
+ * @deprecated Unused. To be removed after Cantera 3.0.
  */
 class ResidJacEval : public ResidEval
 {

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -12,7 +12,6 @@
 #define CT_MIXTUREFUGACITYTP_H
 
 #include "ThermoPhase.h"
-#include "cantera/numerics/ResidEval.h"
 
 namespace Cantera
 {

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -67,7 +67,7 @@ namespace Cantera
  *     handle the calculation of the reference state. This object adds the
  *     pressure dependencies to the thermo functions.
  *
- * - PDSS_ConstVol
+ * - PDSS_ConstVol (deprecated in Cantera 3.0)
  *    - standardState model = "ConstVol" or "constant_incompressible"
  *    - This model assumes that the species in the phase obeys the constant
  *      partial molar volume pressure dependence. The manager uses a

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -20,12 +20,13 @@ namespace Cantera
  * This class is for a single Ideal Gas species.
  *
  * @ingroup pdssthermo
+ * @deprecated To be removed after Cantera 3.0.
  */
 class PDSS_IdealGas : public PDSS_Nondimensional
 {
 public:
     //! Default Constructor
-    PDSS_IdealGas() = default;
+    PDSS_IdealGas();
 
     //! @name Molar Thermodynamic Properties of the Species Standard State
     //! @{

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -52,6 +52,8 @@ const int CK_Mode = 10;
  * quantities refers to the reference velocity being referenced to a particular
  * species. Below are the predefined constants for its value.
  *
+ * @deprecated To be removed after Cantera 3.0.
+ *
  * - VB_MASSAVG    Diffusion velocities are based on the mass averaged velocity
  * - VB_MOLEAVG    Diffusion velocities are based on the mole averaged velocities
  * - VB_SPECIES_0  Diffusion velocities are based on the relative motion wrt species 0
@@ -67,16 +69,22 @@ typedef int VelocityBasis;
  */
 //! @{
 //! Diffusion velocities are based on the mass averaged velocity
+//! @deprecated To be removed after Cantera 3.0.
 const VelocityBasis VB_MASSAVG = -1;
 //! Diffusion velocities are based on the mole averaged velocities
+//! @deprecated To be removed after Cantera 3.0.
 const VelocityBasis VB_MOLEAVG = -2;
 //! Diffusion velocities are based on the relative motion wrt species 0
+//! @deprecated To be removed after Cantera 3.0.
 const VelocityBasis VB_SPECIES_0 = 0;
 //! Diffusion velocities are based on the relative motion wrt species 1
+//! @deprecated To be removed after Cantera 3.0.
 const VelocityBasis VB_SPECIES_1 = 1;
 //! Diffusion velocities are based on the relative motion wrt species 2
+//! @deprecated To be removed after Cantera 3.0.
 const VelocityBasis VB_SPECIES_2 = 2;
 //! Diffusion velocities are based on the relative motion wrt species 3
+//! @deprecated To be removed after Cantera 3.0.
 const VelocityBasis VB_SPECIES_3 = 3;
 //! @}
 
@@ -248,6 +256,7 @@ public:
     }
 
     //! The ionic conductivity in 1/ohm/m.
+    //! @deprecated To be removed after Cantera 3.0. Not implemented by any model.
     virtual double ionConductivity() {
         throw NotImplementedError("Transport::ionConductivity",
             "Not implemented for transport model '{}'.", transportModel());
@@ -258,6 +267,8 @@ public:
      *  The units are 1/ohm/m and the length is the number of species
      *
      * @param ionCond   Vector of ionic conductivities
+     *
+     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesIonConductivity(double* const ionCond) {
         throw NotImplementedError("Transport::getSpeciesIonConductivity",
@@ -278,6 +289,8 @@ public:
      *        k = j * nsp + i
      *
      * The size of mobRat must be at least equal to nsp*nsp
+     *
+     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
      */
     virtual void mobilityRatio(double* mobRat) {
         throw NotImplementedError("Transport::mobilityRatio",
@@ -289,6 +302,8 @@ public:
      * The value is dimensionless and the length is the number of species
      *
      * @param mobRat   Vector of mobility ratios
+     *
+     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesMobilityRatio(double** mobRat) {
         throw NotImplementedError("Transport::getSpeciesMobilityRatio",
@@ -349,6 +364,8 @@ public:
      * @param mobil_f  Returns the mobilities of the species in array \c mobil.
      *               The array must be dimensioned at least as large as the
      *               number of species.
+     *
+     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
      */
     virtual void getFluidMobilities(double* const mobil_f) {
         throw NotImplementedError("Transport::getFluidMobilities",
@@ -373,6 +390,8 @@ public:
      * The conductivity is the reciprocal of the resistivity.
      *
      * The units are Siemens m-1, where 1 S = 1 A / volt = 1 s^3 A^2 /kg /m^2
+     *
+     * @deprecated To be removed after Cantera 3.0. Replaced by electricalConductivity()
      */
     virtual double getElectricConduct() {
         throw NotImplementedError("Transport::getElectricConduct",
@@ -391,6 +410,8 @@ public:
      * @param ldf     Leading dimension of the grad_V and current vectors.
      * @param grad_V  The electrostatic potential gradient.
      * @param current The electric current in A/m^2. This is a vector of length ndim
+     *
+     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
      */
     virtual void getElectricCurrent(int ndim,
                                     const double* grad_T,
@@ -446,6 +467,8 @@ public:
      * @param[in] grad_Phi Gradients of the electrostatic potential (length = ndim)
      * @param[out] fluxes  The diffusive mass fluxes. Flat vector with the m_nsp
      *             in the inner loop. length = ldx * ndim.
+     *
+     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesFluxesES(size_t ndim,
                                     const double* grad_T,
@@ -471,6 +494,8 @@ public:
      * @param[out] Vdiff  Diffusive velocities wrt the mass- averaged velocity.
      *               Flat vector with the m_nsp in the inner loop.
      *               length = ldx * ndim. units are m / s.
+     *
+     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesVdiff(size_t ndim,
                                  const double* grad_T,
@@ -499,6 +524,8 @@ public:
      * @param[out] Vdiff  Diffusive velocities wrt the mass-averaged velocity.
      *               Flat vector with the m_nsp in the inner loop. length = ldx
      *               * ndim. units are m / s.
+     *
+     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesVdiffES(size_t ndim,
                                    const double* grad_T,
@@ -695,6 +722,7 @@ public:
      * @param k       Species index to set the parameters on
      * @param p       Vector of parameters. The length of the vector varies with
      *                 the parameterization
+     * @deprecated  To be removed after Cantera 3.0.
      */
     virtual void setParameters(const int type, const int k, const double* const p) {
         throw NotImplementedError("Transport::setParameters",
@@ -714,6 +742,7 @@ public:
      * operators including all of the gas-phase operators.
      *
      * @param ivb   Species the velocity basis
+     * @deprecated  To be removed after Cantera 3.0.
      */
     void setVelocityBasis(VelocityBasis ivb) {
         m_velocityBasis = ivb;
@@ -726,6 +755,7 @@ public:
      * operators including all of the gas-phase operators.
      *
      * @returns the velocity basis
+     * @deprecated  To be removed after Cantera 3.0.
      */
     VelocityBasis getVelocityBasis() const {
         return m_velocityBasis;
@@ -804,6 +834,7 @@ protected:
 
     //! Velocity basis from which diffusion velocities are computed.
     //! Defaults to the mass averaged basis = -2
+    //! @deprecated  To be removed after Cantera 3.0.
     int m_velocityBasis = VB_MASSAVG;
 
     //! reference to Solution

--- a/src/numerics/ResidJacEval.cpp
+++ b/src/numerics/ResidJacEval.cpp
@@ -11,6 +11,7 @@ namespace Cantera
 ResidJacEval::ResidJacEval(doublereal atol) :
     m_atol(atol)
 {
+    warn_deprecated("class ResidJacEval", "To be removed after Cantera 3.0");
 }
 
 int ResidJacEval::nEquations() const

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -10,6 +10,8 @@
 
 #include "cantera/thermo/MixtureFugacityTP.h"
 #include "cantera/base/stringUtils.h"
+#include "cantera/base/utilities.h"
+#include "cantera/base/global.h"
 
 using namespace std;
 

--- a/src/thermo/PDSS_IdealGas.cpp
+++ b/src/thermo/PDSS_IdealGas.cpp
@@ -14,6 +14,11 @@
 namespace Cantera
 {
 
+PDSS_IdealGas::PDSS_IdealGas()
+{
+    warn_deprecated("class PDSS_IdealGas", "To be removed after Cantera 3.0");
+}
+
 void PDSS_IdealGas::initThermo()
 {
     PDSS::initThermo();

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -7,6 +7,7 @@
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/Species.h"
 #include "cantera/base/stringUtils.h"
+#include "cantera/base/utilities.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/math/tools/roots.hpp>

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -7,6 +7,7 @@
 #include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/Species.h"
 #include "cantera/base/stringUtils.h"
+#include "cantera/base/utilities.h"
 
 #include <boost/algorithm/string.hpp>
 #include <boost/math/tools/roots.hpp>

--- a/test/data/thermo-models.yaml
+++ b/test/data/thermo-models.yaml
@@ -544,8 +544,6 @@ gas-species:
       -917.935173, 0.683010238]
     - [3.3372792, -4.94024731e-05, 4.99456778e-07, -1.79566394e-10, 2.00255376e-14,
       -950.158922, -3.20502331]
-  equation-of-state:
-    model: ideal-gas
 - name: H2O
   composition: {H: 2, O: 1}
   thermo:

--- a/test/thermo/RedlichKisterTest.cpp
+++ b/test/thermo/RedlichKisterTest.cpp
@@ -4,7 +4,7 @@
 #include "cantera/thermo/Species.h"
 #include "cantera/thermo/ConstCpPoly.h"
 #include "cantera/base/stringUtils.h"
-#include "cantera/thermo/PDSS_IdealGas.h"
+#include "cantera/thermo/PDSS_ConstVol.h"
 
 namespace Cantera
 {
@@ -112,10 +112,10 @@ TEST_F(RedlichKister_Test, fromScratch)
     rk.addSpecies(sLiC6);
     rk.addSpecies(sVC6);
 
-    auto ssLiC6 = make_unique<PDSS_IdealGas>();
+    auto ssLiC6 = make_unique<PDSS_ConstVol>();
     rk.installPDSS(0, std::move(ssLiC6));
 
-    auto ssVC6 = make_unique<PDSS_IdealGas>();
+    auto ssVC6 = make_unique<PDSS_ConstVol>();
     rk.installPDSS(1, std::move(ssVC6));
 
     double hcoeffs[] = {-3.268E6, 3.955E6, -4.573E6, 6.147E6, -3.339E6, 1.117E7,


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Deprecate the `PDSS_IdealGas` class -- this is never used, and I think the idea of a phase where some species follow the ideal gas laws while others don't is probably not useful
- Deprecate some virtual methods of class `Transport` that are not implemented by any current transport model
- Deprecate the `ResidEval` and `ResidJacEval` classes that ended up not being used with `IdasIntegrator` and `FlowReactor`.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
