### PR TITLE
Fix duplicate target error when building MSI

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2117,7 +2117,10 @@ else:
     locations = ["libdir", "bindir", "python_bindir", "incdir", "incroot",
         "matlab_dir", "datadir", "sampledir", "docdir", "mandir"]
     for loc in locations:
-        env[f"inst_{loc}"] = env[f"ct_{loc}"].replace(env["ct_installroot"], instRoot)
+        if env["prefix"] == ".":
+            env[f"inst_{loc}"] = (Path(instRoot) / env[f"ct_{loc}"]).as_posix()
+        else:
+            env[f"inst_{loc}"] = env[f"ct_{loc}"].replace(env["ct_installroot"], instRoot)
 
 if env['use_rpath_linkage']:
     env.Append(RPATH=env['ct_libdir'])


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

MSI builds (see [here](https://github.com/Cantera/cantera-windows-binaries/actions/runs/5271431913/jobs/9532295584)) are currently failing with the error:
```
scons: *** Two different builders (<class 'SCons.Builder.BuilderBase'> and InstallBuilder) were specified for the same target: include\cantera\base\config.h
File "D:\a\cantera-windows-binaries\cantera-windows-binaries\cantera\site_scons\site_tools\recursiveInstall.py", line 52, in RecursiveInstall
```

This PR fixes this error.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
