### PR TITLE
Replace Cabinet in clib / update zeroD factory constructors

### DIFF
--- a/include/cantera/zeroD/FlowDeviceFactory.h
+++ b/include/cantera/zeroD/FlowDeviceFactory.h
@@ -14,10 +14,10 @@ namespace Cantera
 
 //! Factory class to create FlowDevice objects.
 //!
-//! This class is mainly used via the newFlowDevice() function, for example:
+//! This class is mainly used via the newFlowDevice3() function, for example:
 //!
 //! ```cpp
-//!     unique_ptr<FlowDevice> mfc(newFlowDevice("MassFlowController"));
+//!     shared_ptr<FlowDevice> mfc = newFlowDevice3("MassFlowController");
 //! ```
 //!
 //! @ingroup ZeroD
@@ -31,6 +31,7 @@ public:
     //! Create a new flow device by type name.
     /*!
      * @param flowDeviceType the type to be created.
+     * @deprecated  To be removed after Cantera 3.0; replaceable by newFlowDevice3.
      */
     virtual FlowDevice* newFlowDevice(const std::string& flowDeviceType);
 
@@ -41,8 +42,15 @@ private:
 };
 
 //! Create a FlowDevice object of the specified type
+//! @deprecated  To be changed after Cantera 3.0; for new behavior, see newFlowDevice3.
 //! @ingroup ZeroD
 FlowDevice* newFlowDevice(const string& model);
+
+//! Create a FlowDevice object of the specified type
+//! @ingroup ZeroD
+//! @since New in Cantera 3.0.
+//! @todo Transition back to newFlowDevice after Cantera 3.0
+shared_ptr<FlowDevice> newFlowDevice3(const string& model);
 
 }
 

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -14,10 +14,10 @@ namespace Cantera
 
 //! Factory class to create reactor objects
 //!
-//! This class is mainly used via the newReactor() function, for example:
+//! This class is mainly used via the newReactor3() function, for example:
 //!
 //! ```cpp
-//!     unique_ptr<ReactorBase> r1(newReactor("IdealGasReactor"));
+//!     shared_ptr<ReactorBase> r1 = newReactor3("IdealGasReactor");
 //! ```
 //!
 //! @ingroup ZeroD
@@ -31,6 +31,7 @@ public:
     //! Create a new reactor by type name.
     /*!
      * @param reactorType the type to be created.
+     * @deprecated  To be removed after Cantera 3.0; replaceable by newReactor3.
      */
     virtual ReactorBase* newReactor(const std::string& reactorType);
 
@@ -41,8 +42,15 @@ private:
 };
 
 //! Create a Reactor object of the specified type
+//! @deprecated  To be changed after Cantera 3.0; for new behavior, see newReactor3.
 //! @ingroup ZeroD
 ReactorBase* newReactor(const string& model);
+
+//! Create a Reactor object of the specified type
+//! @ingroup ZeroD
+//! @since New in Cantera 3.0.
+//! @todo Transition back to newReactor after Cantera 3.0
+shared_ptr<ReactorBase> newReactor3(const string& model);
 
 }
 

--- a/include/cantera/zeroD/WallFactory.h
+++ b/include/cantera/zeroD/WallFactory.h
@@ -14,10 +14,10 @@ namespace Cantera
 
 //! Factory class to create WallBase objects
 //!
-//! This class is mainly used via the newWall() function, for example:
+//! This class is mainly used via the newWall3() function, for example:
 //!
 //! ```cpp
-//!     unique_ptr<WallBase> piston(newWall("Wall"));
+//!     shared_ptr<WallBase> piston = newWall3("Wall");
 //! ```
 //!
 //! @ingroup ZeroD
@@ -31,6 +31,7 @@ public:
     //! Create a new wall by type name.
     /*!
      * @param wallType the type to be created.
+     * @deprecated  To be removed after Cantera 3.0; replaceable by newWall3.
      */
     virtual WallBase* newWall(const std::string& wallType);
 
@@ -41,8 +42,15 @@ private:
 };
 
 //! Create a WallBase object of the specified type
+//! @deprecated  To be changed after Cantera 3.0; for new behavior, see newWall3.
 //! @ingroup ZeroD
 WallBase* newWall(const string& model);
+
+//! Create a WallBase object of the specified type
+//! @ingroup ZeroD
+//! @since New in Cantera 3.0.
+//! @todo Transition back to newWall after Cantera 3.0
+shared_ptr<WallBase> newWall3(const string& model);
 
 }
 

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -32,7 +32,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     # factories
     cdef shared_ptr[CxxReactorBase] newReactor3(string) except +translate_exception
     cdef CxxFlowDevice* newFlowDevice(string) except +translate_exception
-    cdef CxxWallBase* newWall(string) except +translate_exception
+    cdef shared_ptr[CxxWallBase] newWall3(string) except +translate_exception
 
     # reactors
     cdef cppclass CxxReactorBase "Cantera::ReactorBase":
@@ -253,6 +253,7 @@ cdef class ReactorSurface:
     cdef Kinetics _kinetics
 
 cdef class WallBase:
+    cdef shared_ptr[CxxWallBase] _wall
     cdef CxxWallBase* wall
     cdef object _velocity_func
     cdef object _heat_flux_func

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -30,7 +30,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxFlowDevice "Cantera::FlowDevice"
 
     # factories
-    cdef CxxReactorBase* newReactor(string) except +translate_exception
+    cdef shared_ptr[CxxReactorBase] newReactor3(string) except +translate_exception
     cdef CxxFlowDevice* newFlowDevice(string) except +translate_exception
     cdef CxxWallBase* newWall(string) except +translate_exception
 
@@ -210,6 +210,7 @@ cdef extern from "cantera/zeroD/ReactorDelegator.h" namespace "Cantera":
 ctypedef CxxReactorAccessor* CxxReactorAccessorPtr
 
 cdef class ReactorBase:
+    cdef shared_ptr[CxxReactorBase] _reactor
     cdef CxxReactorBase* rbase
     cdef object _thermo
     cdef list _inlets

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -31,7 +31,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
 
     # factories
     cdef shared_ptr[CxxReactorBase] newReactor3(string) except +translate_exception
-    cdef CxxFlowDevice* newFlowDevice(string) except +translate_exception
+    cdef shared_ptr[CxxFlowDevice] newFlowDevice3(string) except +translate_exception
     cdef shared_ptr[CxxWallBase] newWall3(string) except +translate_exception
 
     # reactors
@@ -265,6 +265,7 @@ cdef class Wall(WallBase):
     pass
 
 cdef class FlowDevice:
+    cdef shared_ptr[CxxFlowDevice] _dev
     cdef CxxFlowDevice* dev
     cdef Func1 _rate_func
     cdef Func1 _time_func

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -23,7 +23,8 @@ cdef class ReactorBase:
     """
     reactor_type = "none"
     def __cinit__(self, *args, **kwargs):
-        self.rbase = newReactor(stringify(self.reactor_type))
+        self._reactor = newReactor3(stringify(self.reactor_type))
+        self.rbase = self._reactor.get()
 
     def __init__(self, ThermoPhase contents=None, name=None, *, volume=None):
         self._weakref_proxy = _WeakrefProxy()
@@ -43,9 +44,6 @@ cdef class ReactorBase:
 
         if volume is not None:
             self.volume = volume
-
-    def __dealloc__(self):
-        del self.rbase
 
     def insert(self, _SolutionBase solution):
         """

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -838,7 +838,8 @@ cdef class WallBase:
     """
     wall_type = "none"
     def __cinit__(self, *args, **kwargs):
-        self.wall = newWall(stringify(self.wall_type))
+        self._wall = newWall3(stringify(self.wall_type))
+        self.wall = self._wall.get()
 
     def __init__(self, left, right, *, name=None, A=None, K=None, U=None,
                  Q=None, velocity=None):

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -1023,7 +1023,8 @@ cdef class FlowDevice:
     """
     flowdevice_type = "none"
     def __cinit__(self, *args, **kwargs):
-        self.dev = newFlowDevice(stringify(self.flowdevice_type))
+        self._dev = newFlowDevice3(stringify(self.flowdevice_type))
+        self.dev = self._dev.get()
 
     def __init__(self, upstream, downstream, *, name=None):
         assert self.dev != NULL
@@ -1037,9 +1038,6 @@ cdef class FlowDevice:
             self.name = '{0}_{1}'.format(self.__class__.__name__, n)
 
         self._install(upstream, downstream)
-
-    def __dealloc__(self):
-        del self.dev
 
     property type:
         """The type of the flow device."""

--- a/samples/python/surface_chemistry/lithium_ion_battery.py
+++ b/samples/python/surface_chemistry/lithium_ion_battery.py
@@ -108,7 +108,7 @@ def anode_current(phi_s, phi_l, X_Li_anode):
     # Get the net reaction rate at the anode-side interface
     # Reaction according to input file:
     # Li+[electrolyte] + V[anode] + electron <=> Li[anode]
-    r = anode_int.net_rates_of_progress  # [kmol/m2/s]
+    r = anode_int.net_rates_of_progress[0]  # [kmol/m2/s]
 
     # Calculate the current. Should be negative for cell discharge.
     return r * ct.faraday * area_anode
@@ -129,7 +129,7 @@ def cathode_current(phi_s, phi_l, X_Li_cathode):
     # Get the net reaction rate at the cathode-side interface
     # Reaction according to input file:
     # Li+[electrolyte] + V[cathode] + electron <=> Li[cathode]
-    r = cathode_int.net_rates_of_progress  # [kmol/m2/s]
+    r = cathode_int.net_rates_of_progress[0]  # [kmol/m2/s]
 
     # Calculate the current. Should be negative for cell discharge.
     return - r * ct.faraday * area_cathode

--- a/samples/python/surface_chemistry/sofc.py
+++ b/samples/python/surface_chemistry/sofc.py
@@ -55,7 +55,7 @@ def show_coverages(s):
 
 def equil_OCV(gas1, gas2):
     return (-ct.gas_constant * gas1.T *
-            math.log(gas1['O2'].X / gas2['O2'].X) / (4.0*ct.faraday))
+            math.log(gas1['O2'].X[0] / gas2['O2'].X[0]) / (4.0 * ct.faraday))
 
 
 def NewtonSolver(f, xstart, C=0.0):

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -72,24 +72,24 @@ extern "C" {
             } else if (type == PeriodicFuncType) {
                 r = new Periodic1(FuncCabinet::item(n), params[0]);
             } else if (type == SumFuncType) {
-                r = &newSumFunction(FuncCabinet::item(n).duplicate(),
-                                    FuncCabinet::item(m).duplicate());
+                r = new Sum1(FuncCabinet::item(n).duplicate(),
+                             FuncCabinet::item(m).duplicate());
             } else if (type == DiffFuncType) {
-                r = &newDiffFunction(FuncCabinet::item(n).duplicate(),
-                                     FuncCabinet::item(m).duplicate());
+                r = new Diff1(FuncCabinet::item(n).duplicate(),
+                              FuncCabinet::item(m).duplicate());
             } else if (type == ProdFuncType) {
-                r = &newProdFunction(FuncCabinet::item(n).duplicate(),
-                                     FuncCabinet::item(m).duplicate());
+                r = new Product1(FuncCabinet::item(n).duplicate(),
+                                 FuncCabinet::item(m).duplicate());
             } else if (type == RatioFuncType) {
-                r = &newRatioFunction(FuncCabinet::item(n).duplicate(),
-                                      FuncCabinet::item(m).duplicate());
+                r = new Ratio1(FuncCabinet::item(n).duplicate(),
+                               FuncCabinet::item(m).duplicate());
             } else if (type == CompositeFuncType) {
-                r = &newCompositeFunction(FuncCabinet::item(n).duplicate(),
-                                          FuncCabinet::item(m).duplicate());
+                r = new Composite1(FuncCabinet::item(n).duplicate(),
+                                   FuncCabinet::item(m).duplicate());
             } else if (type == TimesConstantFuncType) {
-                r = &newTimesConstFunction(FuncCabinet::item(n).duplicate(), params[0]);
+                r = new TimesConstant1(FuncCabinet::item(n).duplicate(), params[0]);
             } else if (type == PlusConstantFuncType) {
-                r = &newPlusConstFunction(FuncCabinet::item(n).duplicate(), params[0]);
+                r = new PlusConstant1(FuncCabinet::item(n).duplicate(), params[0]);
             } else {
                 throw CanteraError("func_new","unknown function type");
                 r = new Func1();

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -14,7 +14,7 @@
 
 using namespace Cantera;
 
-typedef Cabinet<MultiPhase> mixCabinet;
+typedef SharedCabinet<MultiPhase> mixCabinet;
 typedef SharedCabinet<ThermoPhase> ThermoCabinet;
 
 template<> mixCabinet* mixCabinet::s_storage = 0;
@@ -25,8 +25,7 @@ extern "C" {
     int mix_new()
     {
         try {
-            MultiPhase* m = new MultiPhase;
-            return mixCabinet::add(m);
+            return mixCabinet::add(make_shared<MultiPhase>());
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -16,7 +16,7 @@
 
 using namespace Cantera;
 
-typedef Cabinet<ReactorBase> ReactorCabinet;
+typedef SharedCabinet<ReactorBase> ReactorCabinet;
 typedef SharedCabinet<ReactorNet> NetworkCabinet;
 typedef Cabinet<FlowDevice> FlowDeviceCabinet;
 typedef Cabinet<WallBase> WallCabinet;
@@ -43,8 +43,7 @@ extern "C" {
     int reactor_new(const char* type)
     {
         try {
-            ReactorBase* r = ReactorFactory::factory()->newReactor(type);
-            return ReactorCabinet::add(r);
+            return ReactorCabinet::add(newReactor3(type));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -18,7 +18,7 @@ using namespace Cantera;
 
 typedef SharedCabinet<ReactorBase> ReactorCabinet;
 typedef SharedCabinet<ReactorNet> NetworkCabinet;
-typedef Cabinet<FlowDevice> FlowDeviceCabinet;
+typedef SharedCabinet<FlowDevice> FlowDeviceCabinet;
 typedef SharedCabinet<WallBase> WallCabinet;
 typedef Cabinet<Func1> FuncCabinet;
 typedef SharedCabinet<ThermoPhase> ThermoCabinet;
@@ -352,8 +352,7 @@ extern "C" {
     int flowdev_new(const char* type)
     {
         try {
-            FlowDevice* f = FlowDeviceFactory::factory()->newFlowDevice(type);
-            return FlowDeviceCabinet::add(f);
+            return FlowDeviceCabinet::add(newFlowDevice3(type));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -19,7 +19,7 @@ using namespace Cantera;
 typedef SharedCabinet<ReactorBase> ReactorCabinet;
 typedef SharedCabinet<ReactorNet> NetworkCabinet;
 typedef Cabinet<FlowDevice> FlowDeviceCabinet;
-typedef Cabinet<WallBase> WallCabinet;
+typedef SharedCabinet<WallBase> WallCabinet;
 typedef Cabinet<Func1> FuncCabinet;
 typedef SharedCabinet<ThermoPhase> ThermoCabinet;
 typedef SharedCabinet<Kinetics> KineticsCabinet;
@@ -459,8 +459,7 @@ extern "C" {
     int wall_new(const char* type)
     {
         try {
-            WallBase* w = WallFactory::factory()->newWall(type);
-            return WallCabinet::add(w);
+            return WallCabinet::add(newWall3(type));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -24,7 +24,7 @@ typedef Cabinet<Func1> FuncCabinet;
 typedef SharedCabinet<ThermoPhase> ThermoCabinet;
 typedef SharedCabinet<Kinetics> KineticsCabinet;
 typedef SharedCabinet<Solution> SolutionCabinet;
-typedef Cabinet<ReactorSurface> ReactorSurfaceCabinet;
+typedef SharedCabinet<ReactorSurface> ReactorSurfaceCabinet;
 
 template<> ReactorCabinet* ReactorCabinet::s_storage = 0;
 template<> NetworkCabinet* NetworkCabinet::s_storage = 0;
@@ -599,7 +599,7 @@ extern "C" {
     int reactorsurface_new(int type)
     {
         try {
-            return ReactorSurfaceCabinet::add(new ReactorSurface());
+            return ReactorSurfaceCabinet::add(make_shared<ReactorSurface>());
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -17,7 +17,7 @@
 using namespace Cantera;
 
 typedef Cabinet<ReactorBase> ReactorCabinet;
-typedef Cabinet<ReactorNet> NetworkCabinet;
+typedef SharedCabinet<ReactorNet> NetworkCabinet;
 typedef Cabinet<FlowDevice> FlowDeviceCabinet;
 typedef Cabinet<WallBase> WallCabinet;
 typedef Cabinet<Func1> FuncCabinet;
@@ -226,7 +226,7 @@ extern "C" {
     int reactornet_new()
     {
         try {
-            return NetworkCabinet::add(new ReactorNet());
+            return NetworkCabinet::add(make_shared<ReactorNet>());
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/clib/ctrpath.cpp
+++ b/src/clib/ctrpath.cpp
@@ -46,15 +46,6 @@ extern "C" {
         }
     }
 
-    int rdiag_copy(int i)
-    {
-        try {
-            return DiagramCabinet::newCopy(i);
-        } catch (...) {
-            return handleAllExceptions(-1, ERR);
-        }
-    }
-
     int rdiag_detailed(int i)
     {
         try {

--- a/src/clib/ctrpath.cpp
+++ b/src/clib/ctrpath.cpp
@@ -16,8 +16,8 @@
 using namespace Cantera;
 using namespace std;
 
-typedef Cabinet<ReactionPathBuilder> BuilderCabinet;
-typedef Cabinet<ReactionPathDiagram> DiagramCabinet;
+typedef SharedCabinet<ReactionPathBuilder> BuilderCabinet;
+typedef SharedCabinet<ReactionPathDiagram> DiagramCabinet;
 template<> DiagramCabinet* DiagramCabinet::s_storage = 0;
 template<> BuilderCabinet* BuilderCabinet::s_storage = 0;
 
@@ -29,8 +29,7 @@ extern "C" {
     int rdiag_new()
     {
         try {
-            ReactionPathDiagram* d = new ReactionPathDiagram();
-            return DiagramCabinet::add(d);
+            return DiagramCabinet::add(make_shared<ReactionPathDiagram>());
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -249,8 +248,7 @@ extern "C" {
     int rbuild_new()
     {
         try {
-            ReactionPathBuilder* d = new ReactionPathBuilder();
-            return BuilderCabinet::add(d);
+            return BuilderCabinet::add(make_shared<ReactionPathBuilder>());
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/zeroD/FlowDeviceFactory.cpp
+++ b/src/zeroD/FlowDeviceFactory.cpp
@@ -36,12 +36,22 @@ void FlowDeviceFactory::deleteFactory() {
 
 FlowDevice* FlowDeviceFactory::newFlowDevice(const std::string& flowDeviceType)
 {
+    warn_deprecated("FlowDeviceFactory::newFlowDevice",
+        "To be removed after Cantera 3.0; for new behavior, see 'newFlowDevice3'.");
     return create(flowDeviceType);
 }
 
 FlowDevice* newFlowDevice(const string& model)
 {
+    warn_deprecated("newFlowDevice",
+        "To be changed after Cantera 3.0; for new behavior, see 'newFlowDevice3'.");
     return FlowDeviceFactory::factory()->newFlowDevice(model);
+}
+
+shared_ptr<FlowDevice> newFlowDevice3(const string& model)
+{
+    shared_ptr<FlowDevice> fdptr(FlowDeviceFactory::factory()->create(model));
+    return fdptr;
 }
 
 }

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -68,12 +68,22 @@ void ReactorFactory::deleteFactory() {
 
 ReactorBase* ReactorFactory::newReactor(const std::string& reactorType)
 {
+    warn_deprecated("ReactorFactory::newReactor",
+        "To be removed after Cantera 3.0; for new behavior, see 'newReactor3'.");
     return create(reactorType);
 }
 
 ReactorBase* newReactor(const string& model)
 {
+    warn_deprecated("newReactor",
+        "To be changed after Cantera 3.0; for new behavior, see 'newReactor3'.");
     return ReactorFactory::factory()->newReactor(model);
+}
+
+shared_ptr<ReactorBase> newReactor3(const string& model)
+{
+    shared_ptr<ReactorBase> rptr(ReactorFactory::factory()->create(model));
+    return rptr;
 }
 
 }

--- a/src/zeroD/WallFactory.cpp
+++ b/src/zeroD/WallFactory.cpp
@@ -33,12 +33,22 @@ void WallFactory::deleteFactory() {
 
 WallBase* WallFactory::newWall(const std::string& wallType)
 {
+    warn_deprecated("WallFactory::newWall",
+        "To be removed after Cantera 3.0; for new behavior, see 'newWall3'.");
     return create(wallType);
 }
 
 WallBase* newWall(const string& model)
 {
+    warn_deprecated("newWall",
+        "To be changed after Cantera 3.0; for new behavior, see 'newWall3'.");
     return WallFactory::factory()->newWall(model);
+}
+
+shared_ptr<WallBase> newWall3(const string& model)
+{
+    shared_ptr<WallBase> wptr(WallFactory::factory()->create(model));
+    return wptr;
 }
 
 }

--- a/test/clib/test_ctfunc.cpp
+++ b/test/clib/test_ctfunc.cpp
@@ -1,0 +1,104 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <fstream>
+
+#include "cantera/core.h"
+#include "cantera/clib/ctfunc.h"
+#include "cantera/numerics/Func1.h"
+
+using namespace Cantera;
+
+TEST(ctfunc, sin)
+{
+    double omega = 2.;
+    int fcn = func_new(SinFuncType, 0, 1, &omega);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), 0.);
+    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5));
+}
+
+TEST(ctfunc, cos)
+{
+    double omega = 2.;
+    int fcn = func_new(CosFuncType, 0, 1, &omega);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), 1.);
+    ASSERT_EQ(func_value(fcn, 0.5), cos(omega * 0.5));
+}
+
+TEST(ctfunc, sum)
+{
+    double omega = 2.;
+    int fcn0 = func_new(SinFuncType, 0, 1, &omega);
+    int fcn1 = func_new(CosFuncType, 0, 1, &omega);
+    int fcn = func_new(SumFuncType, fcn0, fcn1, NULL);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), 1.);
+    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) + cos(omega * 0.5));
+}
+
+TEST(ctfunc, diff)
+{
+    double omega = 2.;
+    int fcn0 = func_new(SinFuncType, 0, 1, &omega);
+    int fcn1 = func_new(CosFuncType, 0, 1, &omega);
+    int fcn = func_new(DiffFuncType, fcn0, fcn1, NULL);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), -1.);
+    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) - cos(omega * 0.5));
+}
+
+TEST(ctfunc, prod)
+{
+    double omega = 2.;
+    int fcn0 = func_new(SinFuncType, 0, 1, &omega);
+    int fcn1 = func_new(CosFuncType, 0, 1, &omega);
+    int fcn = func_new(ProdFuncType, fcn0, fcn1, NULL);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), 0);
+    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) * cos(omega * 0.5));
+}
+
+TEST(ctfunc, ratio)
+{
+    double omega = 2.;
+    int fcn0 = func_new(SinFuncType, 0, 1, &omega);
+    int fcn1 = func_new(CosFuncType, 0, 1, &omega);
+    int fcn = func_new(RatioFuncType, fcn0, fcn1, NULL);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), 0.);
+    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) / cos(omega * 0.5));
+}
+
+TEST(ctfunc, composite)
+{
+    double omega = 2.;
+    int fcn0 = func_new(SinFuncType, 0, 1, &omega);
+    int fcn1 = func_new(CosFuncType, 0, 1, &omega);
+    int fcn = func_new(CompositeFuncType, fcn0, fcn1, NULL);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), sin(omega));
+    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * cos(omega * 0.5)));
+}
+
+TEST(ctfunc, times_constant)
+{
+    double omega = 2.;
+    int fcn0 = func_new(SinFuncType, 0, 1, &omega);
+    double A = 1.234;
+    int fcn = func_new(TimesConstantFuncType, fcn0, 1, &A);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), 0.);
+    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) * A);
+}
+
+TEST(ctfunc, plus_constant)
+{
+    double omega = 2.;
+    int fcn0 = func_new(SinFuncType, 0, 1, &omega);
+    double A = 1.234;
+    int fcn = func_new(PlusConstantFuncType, fcn0, 1, &A);
+    ASSERT_GE(fcn, 0);
+    ASSERT_EQ(func_value(fcn, 0.), A);
+    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) + A);
+}

--- a/test/clib/test_ctfunc.cpp
+++ b/test/clib/test_ctfunc.cpp
@@ -13,8 +13,8 @@ TEST(ctfunc, sin)
     double omega = 2.;
     int fcn = func_new(SinFuncType, 0, 1, &omega);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), 0.);
-    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), 0.);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5));
 }
 
 TEST(ctfunc, cos)
@@ -22,8 +22,8 @@ TEST(ctfunc, cos)
     double omega = 2.;
     int fcn = func_new(CosFuncType, 0, 1, &omega);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), 1.);
-    ASSERT_EQ(func_value(fcn, 0.5), cos(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), 1.);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), cos(omega * 0.5));
 }
 
 TEST(ctfunc, sum)
@@ -33,8 +33,8 @@ TEST(ctfunc, sum)
     int fcn1 = func_new(CosFuncType, 0, 1, &omega);
     int fcn = func_new(SumFuncType, fcn0, fcn1, NULL);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), 1.);
-    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) + cos(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), 1.);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) + cos(omega * 0.5));
 }
 
 TEST(ctfunc, diff)
@@ -44,8 +44,8 @@ TEST(ctfunc, diff)
     int fcn1 = func_new(CosFuncType, 0, 1, &omega);
     int fcn = func_new(DiffFuncType, fcn0, fcn1, NULL);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), -1.);
-    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) - cos(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), -1.);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) - cos(omega * 0.5));
 }
 
 TEST(ctfunc, prod)
@@ -55,8 +55,8 @@ TEST(ctfunc, prod)
     int fcn1 = func_new(CosFuncType, 0, 1, &omega);
     int fcn = func_new(ProdFuncType, fcn0, fcn1, NULL);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), 0);
-    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) * cos(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), 0);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) * cos(omega * 0.5));
 }
 
 TEST(ctfunc, ratio)
@@ -66,8 +66,8 @@ TEST(ctfunc, ratio)
     int fcn1 = func_new(CosFuncType, 0, 1, &omega);
     int fcn = func_new(RatioFuncType, fcn0, fcn1, NULL);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), 0.);
-    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) / cos(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), 0.);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) / cos(omega * 0.5));
 }
 
 TEST(ctfunc, composite)
@@ -77,8 +77,8 @@ TEST(ctfunc, composite)
     int fcn1 = func_new(CosFuncType, 0, 1, &omega);
     int fcn = func_new(CompositeFuncType, fcn0, fcn1, NULL);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), sin(omega));
-    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * cos(omega * 0.5)));
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), sin(omega));
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * cos(omega * 0.5)));
 }
 
 TEST(ctfunc, times_constant)
@@ -88,8 +88,8 @@ TEST(ctfunc, times_constant)
     double A = 1.234;
     int fcn = func_new(TimesConstantFuncType, fcn0, 1, &A);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), 0.);
-    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) * A);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), 0.);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) * A);
 }
 
 TEST(ctfunc, plus_constant)
@@ -99,6 +99,6 @@ TEST(ctfunc, plus_constant)
     double A = 1.234;
     int fcn = func_new(PlusConstantFuncType, fcn0, 1, &A);
     ASSERT_GE(fcn, 0);
-    ASSERT_EQ(func_value(fcn, 0.), A);
-    ASSERT_EQ(func_value(fcn, 0.5), sin(omega * 0.5) + A);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.), A);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) + A);
 }

--- a/test/clib/test_ctmultiphase.cpp
+++ b/test/clib/test_ctmultiphase.cpp
@@ -1,0 +1,18 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <fstream>
+
+#include "cantera/core.h"
+#include "cantera/clib/ct.h"
+#include "cantera/clib/ctmultiphase.h"
+
+using namespace Cantera;
+
+TEST(ctmix, new)
+{
+    int thermo = thermo_newFromFile("gri30.yaml", "gri30");
+    int mix = mix_new();
+    ASSERT_GE(mix, 0);
+    int ret = mix_addPhase(mix, thermo, 1.);
+    ASSERT_EQ(ret, 0);
+}

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -14,7 +14,7 @@ TEST(ctreactor, reactor_objects)
     int kin = kin_newFromFile("gri30.yaml", "", thermo, -1, -1, -1, -1);
 
     int reactor = reactor_new("IdealGasReactor");
-    ASSERT_GT(reactor, 0);
+    ASSERT_GE(reactor, 0);
     int ret = reactor_setThermoMgr(reactor, thermo);
     ASSERT_EQ(ret, 0);
     ret = reactor_setKineticsMgr(reactor, kin);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make `zeroD` factory constructors return `shared_ptr<ReactorBase>`, etc.
- Replace `Cabinet` by `SharedCabinet` in `clib` interface
- Add some unit tests for `ctfunc`
- Fix deprecation warnings in `sofc.py` and `lithium_ion_battery.py` samples

*Caveat:* `Cabinet<Func1>` remains as required updates go beyond the scope of this PR. While some functions can be replaced by classes, internal class methods `Func1::derivative` etc. would need extensive refactoring.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Addresses Cantera/enhancements#164

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
