### PR TITLE
WIP: 1d point control

### DIFF
--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -253,10 +253,10 @@ public:
     double fixedTemperatureLocation();
 
     //! Set the fuel internal boundary location
-    void setFuelSideBoundary(doublereal tFuel);
-
-    //! Set the oxidizer side internal boundary location
-    void setOxidSideBoundary(doublereal tOxid);
+    void setFuelInternalBoundary(double temperature);
+    
+    //! Set the oxidizer internal boundary location
+    void setOxidizerInternalBoundary(double temperature);
 
     /**
      * Set grid refinement criteria. If dom >= 0, then the settings

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -252,10 +252,12 @@ public:
     //! Return location of the point where temperature is fixed
     double fixedTemperatureLocation();
 
-    //! Set the fuel internal boundary location
+    //! Set the fuel internal boundary location. This is used for one/two-point
+    //! flame control for stagnation flows.
     void setFuelInternalBoundary(double temperature);
     
-    //! Set the oxidizer internal boundary location
+    //! Set the oxidizer internal boundary location. This is used for one/two-point
+    //! flame control for stagnation flows.
     void setOxidizerInternalBoundary(double temperature);
 
     /**

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -252,6 +252,12 @@ public:
     //! Return location of the point where temperature is fixed
     double fixedTemperatureLocation();
 
+    //! Set the fuel internal boundary location and tempereture
+    void setFuelSideTemperature(doublereal tFuel);
+
+    //! Set the oxidizer side internal boundary location and temperature
+    void setOxidSideTemperature(doublereal tOxid);
+
     /**
      * Set grid refinement criteria. If dom >= 0, then the settings
      * apply only to the specified domain.  If dom < 0, the settings

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -252,11 +252,11 @@ public:
     //! Return location of the point where temperature is fixed
     double fixedTemperatureLocation();
 
-    //! Set the fuel internal boundary location and tempereture
-    void setFuelSideTemperature(doublereal tFuel);
+    //! Set the fuel internal boundary location
+    void setFuelSideBoundary(doublereal tFuel);
 
-    //! Set the oxidizer side internal boundary location and temperature
-    void setOxidSideTemperature(doublereal tOxid);
+    //! Set the oxidizer side internal boundary location
+    void setOxidSideBoundary(doublereal tOxid);
 
     /**
      * Set grid refinement criteria. If dom >= 0, then the settings

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -156,6 +156,34 @@ public:
         return m_fixedtemp[j];
     }
 
+    //! The current fuel side internal boundary temperature
+    doublereal fuelSideTemperature() const {
+        if ((m_onePntCtrl || m_twoPntCtrl) && (m_zFuel != Undef)) {
+            return m_tFuel;
+        }
+    }
+
+    //! Set the temperature in the fuel side internal boundary
+    void setFuelSideTemperature(doublereal tFuel) {
+        if ((m_onePntCtrl || m_twoPntCtrl) && (m_zFuel != Undef)) {
+            m_tFuel = tFuel;
+        }
+    }
+
+    //! The current oxidizer side internal boundary temperature
+    doublereal oxidSideTemperature() const {
+        if (m_twoPntCtrl && (m_zOxid != Undef)) {
+            return m_tOxid;
+        }
+    }
+
+    //! Set the temperature in the oxidizer side internal boundary
+    void setOxidSideTemperature(doublereal tOxid) {
+        if (m_twoPntCtrl && (m_zOxid != Undef)) {
+            m_tOxid = tOxid;
+        }
+    }
+
     //! @}
 
     virtual std::string componentName(size_t n) const;

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -28,6 +28,7 @@ enum offset
     , c_offset_L //! (1/r)dP/dr
     , c_offset_E //! electric poisson's equation
     , c_offset_Y //! mass fractions
+    , c_offset_Uo //! oxidizer axial velocity
 };
 
 class Transport;
@@ -315,6 +316,36 @@ public:
         return m_kExcessRight;
     }
 
+    //! Set the status of one point flame control
+    void enableOnePointControl(bool onePntCtrl) {
+        if (m_twoPntCtrl && onePntCtrl) {
+            throw CanteraError("StFlow::enableOnePointControl",
+                               "Two different point control technique couldn't set simutaniously");
+        } else {
+            m_onePntCtrl = onePntCtrl;
+        }
+    }
+
+    //! Set the status of two point flame control
+    void enableTwoPointControl(bool twoPntCtrl) {
+        if (m_onePntCtrl && twoPntCtrl) {
+            throw CanteraError("StFlow::enableTwoPointControl",
+                               "Two different point control technique couldn't set simutaniously");
+        } else {
+            m_twoPntCtrl = twoPntCtrl;
+        }
+    }
+
+    //! Get the status of one point flame control
+    bool onePointControlEnabled() {
+        return m_onePntCtrl;
+    }
+
+    //! Get the status of two point flame control
+    bool twoPointControlEnabled() {
+        return m_twoPntCtrl;
+    }
+
 protected:
     virtual AnyMap getMeta() const;
     virtual void setMeta(const AnyMap& state);
@@ -383,6 +414,10 @@ protected:
 
     doublereal lambda(const doublereal* x, size_t j) const {
         return x[index(c_offset_L, j)];
+    }
+
+    doublereal Uo(const doublereal* x, size_t j) const {
+        return x[index(c_offset_Uo, j)];
     }
 
     doublereal Y(const doublereal* x, size_t k, size_t j) const {
@@ -527,12 +562,30 @@ protected:
     //! to `j1`, based on solution `x`.
     virtual void updateTransport(doublereal* x, size_t j0, size_t j1);
 
+    //! Flag for one point flame control
+    bool m_onePntCtrl;
+
+    //! Flag for two point flame control
+    bool m_twoPntCtrl;
+
 public:
     //! Location of the point where temperature is fixed
     double m_zfixed = Undef;
 
     //! Temperature at the point used to fix the flame location
     double m_tfixed = -1.0;
+
+    //! The location of the internal boundary at fuel side
+    double m_zFuel;
+
+    //! The fixed temperature at the fuel side internal boundary
+    double m_tFuel;
+
+    //! The location of the internal boundary at oxidizer side
+    double m_zOxid;
+
+    //! The fixed temperature at the oxidizer side internal boundary
+    double m_tOxid;
 
 private:
     vector_fp m_ybar;

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -74,6 +74,10 @@ cdef extern from "cantera/oneD/StFlow.h":
         void setPressure(double)
         void enableRadiation(cbool)
         cbool radiationEnabled()
+        void enableOnePointControl(cbool)
+        cbool onePointControlEnabled()
+        void enableTwoPointControl(cbool)
+        cbool twoPointControlEnabled()
         double radiativeHeatLoss(size_t)
         double pressure()
         void setFixedTempProfile(vector[double]&, vector[double]&)
@@ -87,6 +91,10 @@ cdef extern from "cantera/oneD/StFlow.h":
         double rightEmissivity()
         void solveEnergyEqn()
         void fixTemperature()
+        double fuelInternalBoundaryTemperature()
+        double oxidInternalBoundaryTemperature()
+        void setFuelInternalBoundaryTemperature(double)
+        void setOxidInternalBoundaryTemperature(double)
         cbool doEnergy(size_t)
         void enableSoret(cbool) except +translate_exception
         cbool withSoret()
@@ -141,6 +149,8 @@ cdef extern from "cantera/oneD/Sim1D.h":
         void setFixedTemperature(double) except +translate_exception
         double fixedTemperature()
         double fixedTemperatureLocation()
+        void setFuelInternalBoundary(double) except +translate_exception
+        void setOxidizerInternalBoundary(double) except +translate_exception
         void setInterrupt(CxxFunc1*) except +translate_exception
         void setTimeStepCallback(CxxFunc1*)
         void setSteadyCallback(CxxFunc1*)

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -572,6 +572,20 @@ cdef class _FlowBase(Domain1D):
         def __set__(self, enable):
             self.flow.enableSoret(<cbool>enable)
 
+    property onePointControl_enabled:
+        """ Determines whether or not to enable one point flame control"""
+        def __get__(self):
+            return self.flow.onePointControlEnabled()
+        def __set__(self, enable):
+                self.flow.enableOnePointControl(<cbool>enable)
+
+    property twoPointControl_enabled:
+        """ Determines whether or not to enable two point flame control"""
+        def __get__(self):
+            return self.flow.twoPointControlEnabled()
+        def __set__(self, enable):
+                self.flow.enableTwoPointControl(<cbool>enable)
+
     property energy_enabled:
         """ Determines whether or not to solve the energy equation."""
         def __get__(self):
@@ -1580,6 +1594,18 @@ cdef class Sim1D:
             return self.sim.fixedTemperature()
         def __set__(self, T):
             self.sim.setFixedTemperature(T)
+
+    def set_fuel_side_temperature(self, T):
+        """
+        Set the temperature in the fuel side internal boundary.
+        """
+        self.sim.setFuelSideTemperature(T)
+
+    def set_oxid_side_temperature(self, T):
+        """
+        Set the temperature in the xoidizer side internal boundary.
+        """
+        self.sim.setOxidSideTemperature(T)
 
     property fixed_temperature_location:
         """

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -527,6 +527,20 @@ cdef class _FlowBase(Domain1D):
             self.flow.setTransportModel(stringify(model))
             # ensure that transport remains accessible
             self.gas.transport = self.gas.base.transport().get()
+    
+    property tFuel:
+        """ Fuel side internal boundary temperature [K] """
+        def __get__(self):
+            return self.flow.fuelSideTemperature()
+        def __set__(self, T):
+            self.flow.setFuelSideTemperature(T)
+
+    property tOxid:
+        """ Oxidizer side internal boundary temperature [K] """
+        def __get__(self):
+            return self.flow.oxidSideTemperature()
+        def __set__(self, T):
+            self.flow.setOxidSideTemperature(T)
 
     def set_transport(self, _SolutionBase phase):
         """
@@ -1595,17 +1609,17 @@ cdef class Sim1D:
         def __set__(self, T):
             self.sim.setFixedTemperature(T)
 
-    def set_fuel_side_temperature(self, T):
+    def set_fuel_side_boundary(self, T):
         """
-        Set the temperature in the fuel side internal boundary.
+        Set the fuel side internal boundary with approximate temperature.
         """
-        self.sim.setFuelSideTemperature(T)
+        self.sim.setFuelSideBoundary(T)
 
-    def set_oxid_side_temperature(self, T):
+    def set_oxid_side_boundary(self, T):
         """
-        Set the temperature in the xoidizer side internal boundary.
+        Set the xoidizer side internal boundary with approximate temperature.
         """
-        self.sim.setOxidSideTemperature(T)
+        self.sim.setOxidSideBoundary(T)
 
     property fixed_temperature_location:
         """

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -515,6 +515,20 @@ cdef class _FlowBase(Domain1D):
         def __set__(self, P):
             self.flow.setPressure(P)
 
+    property tFuel:
+        """ Fuel side internal boundary temperature [K] """
+        def __get__(self):
+            return self.flow.fuelInternalBoundaryTemperature()
+        def __set__(self, T):
+            self.flow.setFuelInternalBoundaryTemperature(T)
+
+    property tOxid:
+        """ Oxidizer side internal boundary temperature [K] """
+        def __get__(self):
+            return self.flow.oxidInternalBoundaryTemperature()
+        def __set__(self, T):
+            self.flow.setOxidInternalBoundaryTemperature(T)
+
     property transport_model:
         """
         Get/set the transport model used for calculating transport properties.
@@ -527,20 +541,6 @@ cdef class _FlowBase(Domain1D):
             self.flow.setTransportModel(stringify(model))
             # ensure that transport remains accessible
             self.gas.transport = self.gas.base.transport().get()
-    
-    property tFuel:
-        """ Fuel side internal boundary temperature [K] """
-        def __get__(self):
-            return self.flow.fuelSideTemperature()
-        def __set__(self, T):
-            self.flow.setFuelSideTemperature(T)
-
-    property tOxid:
-        """ Oxidizer side internal boundary temperature [K] """
-        def __get__(self):
-            return self.flow.oxidSideTemperature()
-        def __set__(self, T):
-            self.flow.setOxidSideTemperature(T)
 
     def set_transport(self, _SolutionBase phase):
         """
@@ -586,20 +586,6 @@ cdef class _FlowBase(Domain1D):
         def __set__(self, enable):
             self.flow.enableSoret(<cbool>enable)
 
-    property onePointControl_enabled:
-        """ Determines whether or not to enable one point flame control"""
-        def __get__(self):
-            return self.flow.onePointControlEnabled()
-        def __set__(self, enable):
-                self.flow.enableOnePointControl(<cbool>enable)
-
-    property twoPointControl_enabled:
-        """ Determines whether or not to enable two point flame control"""
-        def __get__(self):
-            return self.flow.twoPointControlEnabled()
-        def __set__(self, enable):
-                self.flow.enableTwoPointControl(<cbool>enable)
-
     property energy_enabled:
         """ Determines whether or not to solve the energy equation."""
         def __get__(self):
@@ -609,6 +595,20 @@ cdef class _FlowBase(Domain1D):
                 self.flow.solveEnergyEqn()
             else:
                 self.flow.fixTemperature()
+
+    property onePointControl_enabled:
+        """ Determines whether or not to enable one point flame control"""
+        def __get__(self):
+            return self.flow.onePointControlEnabled()
+        def __set__(self, enable):
+            self.flow.enableOnePointControl(<cbool>enable)
+
+    property twoPointControl_enabled:
+        """ Determines whether or not to enable two point flame control"""
+        def __get__(self):
+            return self.flow.twoPointControlEnabled()
+        def __set__(self, enable):
+            self.flow.enableTwoPointControl(<cbool>enable)
 
     def set_fixed_temp_profile(self, pos, T):
         """Set the fixed temperature profile. This profile is used
@@ -1613,13 +1613,13 @@ cdef class Sim1D:
         """
         Set the fuel side internal boundary with approximate temperature.
         """
-        self.sim.setFuelSideBoundary(T)
+        self.sim.setFuelInternalBoundary(T)
 
     def set_oxid_side_boundary(self, T):
         """
         Set the xoidizer side internal boundary with approximate temperature.
         """
-        self.sim.setOxidSideBoundary(T)
+        self.sim.setOxidizerInternalBoundary(T)
 
     property fixed_temperature_location:
         """

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -240,28 +240,6 @@ class FlameBase(Sim1D):
         self.flame.energy_enabled = enable
 
     @property
-    def onePointControl_enabled(self):
-        """
-        Get/Set whether or not to active one point flame control.
-        """
-        return self.flame.onePointControl_enabled
-
-    @onePointControl_enabled.setter
-    def onePointControl_enabled(self, enable):
-        self.flame.onePointControl_enabled = enable
-
-    @property
-    def twoPointControl_enabled(self):
-        """
-        Get/Set whether or not to active two point flame control.
-        """
-        return self.flame.twoPointControl_enabled
-
-    @twoPointControl_enabled.setter
-    def twoPointControl_enabled(self, enable):
-        self.flame.twoPointControl_enabled = enable
-
-    @property
     def soret_enabled(self):
         """
         Get/Set whether or not to include diffusive mass fluxes due to the
@@ -295,6 +273,28 @@ class FlameBase(Sim1D):
         if len(epsilon) != 2:
             raise ValueError("Boundary emissivities must both be set at the same time.")
         self.flame.boundary_emissivities = epsilon[0], epsilon[1]
+
+    @property
+    def onePointControl_enabled(self):
+        """
+        Get/Set whether or not to active one point flame control.
+        """
+        return self.flame.onePointControl_enabled
+
+    @onePointControl_enabled.setter
+    def onePointControl_enabled(self, enable):
+        self.flame.onePointControl_enabled = enable
+
+    @property
+    def twoPointControl_enabled(self):
+        """
+        Get/Set whether or not to active two point flame control.
+        """
+        return self.flame.twoPointControl_enabled
+
+    @twoPointControl_enabled.setter
+    def twoPointControl_enabled(self, enable):
+        self.flame.twoPointControl_enabled = enable
 
     @property
     def grid(self):

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -311,6 +311,24 @@ class FlameBase(Sim1D):
         self.flame.P = P
 
     @property
+    def tFuel(self):
+        """ Get/Set the fuel side internal boundary temperature [K] """
+        return self.flame.tFuel
+
+    @tFuel.setter
+    def tFuel(self, T):
+        self.flame.tFuel = T
+
+    @property
+    def tOxid(self):
+        """ Get/Set the oxidizer side internal boundary temperature [K] """
+        return self.flame.tOxid
+
+    @tOxid.setter
+    def tOxid(self, T):
+        self.flame.tOxid = T
+
+    @property
     def T(self):
         """ Array containing the temperature [K] at each grid point. """
         return self.profile(self.flame, 'T')

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -240,6 +240,28 @@ class FlameBase(Sim1D):
         self.flame.energy_enabled = enable
 
     @property
+    def onePointControl_enabled(self):
+        """
+        Get/Set whether or not to active one point flame control.
+        """
+        return self.flame.onePointControl_enabled
+
+    @onePointControl_enabled.setter
+    def onePointControl_enabled(self, enable):
+        self.flame.onePointControl_enabled = enable
+
+    @property
+    def twoPointControl_enabled(self):
+        """
+        Get/Set whether or not to active two point flame control.
+        """
+        return self.flame.twoPointControl_enabled
+
+    @twoPointControl_enabled.setter
+    def twoPointControl_enabled(self, enable):
+        self.flame.twoPointControl_enabled = enable
+
+    @property
     def soret_enabled(self):
         """
         Get/Set whether or not to include diffusive mass fluxes due to the
@@ -325,6 +347,12 @@ class FlameBase(Sim1D):
             raise AttributeError(
                 "Electric field is only defined for transport model 'ionized_gas'.")
         return self.profile(self.flame, 'eField')
+    @property
+    def Uo(self):
+        """
+        Array containing the oxidizer velocity [m/s] at each point.
+        """
+        return self.profile(self.flame, 'Uo')
 
     def elemental_mass_fraction(self, m):
         r"""

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -192,7 +192,6 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             // The flow domain sets this to -rho*u. Add mdot to specify the mass
             // flow rate.
             rb[c_offset_L] += m_mdot;
-            rb[c_offset_Uo] = xb[c_offset_Uo];
         } else if (m_flow->onePointControlEnabled()) {
             m_mdot = m_flow->density(0)*xb[c_offset_U];
             rb[c_offset_Uo] += xb[c_offset_U];
@@ -223,12 +222,16 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
         if (m_flow->doEnergy(last_index)) {
             rb[c_offset_T] -= m_temp; // T
         }
+
         if (m_flow->onePointControlEnabled() || m_flow->twoPointControlEnabled()) {
-            m_mdot = -(m_flow->density(last_index)) * xb[c_offset_Uo];
-        } 
-            
-        rb[c_offset_U] += m_mdot; // u      
-        
+            m_mdot = -(m_flow->density(last_index) * xb[c_offset_Uo]);
+            rb[c_offset_U] += m_mdot; // u
+            rb[c_offset_Uo] += 0;
+        } else {
+            rb[c_offset_U] += m_mdot;
+            rb[c_offset_Uo] += m_mdot/m_flow->density(last_index);
+        }
+             
         for (size_t k = 0; k < m_nsp; k++) {
             if (k != m_flow_left->rightExcessSpecies()) {
                 rb[c_offset_Y+k] += m_mdot * m_yin[k];

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -222,7 +222,7 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
         if (m_flow->doEnergy(last_index)) {
             rb[c_offset_T] -= m_temp; // T
         }
-
+        // Point-control
         if (m_flow->onePointControlEnabled() || m_flow->twoPointControlEnabled()) {
             m_mdot = -(m_flow->density(last_index) * xb[c_offset_Uo]);
             rb[c_offset_U] += m_mdot; // u
@@ -231,7 +231,7 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             rb[c_offset_U] += m_mdot;
             rb[c_offset_Uo] += m_mdot/m_flow->density(last_index);
         }
-             
+
         for (size_t k = 0; k < m_nsp; k++) {
             if (k != m_flow_left->rightExcessSpecies()) {
                 rb[c_offset_Y+k] += m_mdot * m_yin[k];

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -192,11 +192,18 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             // The flow domain sets this to -rho*u. Add mdot to specify the mass
             // flow rate.
             rb[c_offset_L] += m_mdot;
+            rb[c_offset_Uo] = xb[c_offset_Uo];
+        } else if (m_flow->onePointControlEnabled()) {
+            m_mdot = m_flow->density(0)*xb[c_offset_U];
+            rb[c_offset_Uo] += xb[c_offset_U];
+        } else if (m_flow->twoPointControlEnabled()) {
+            m_mdot = m_flow->density(0)*xb[c_offset_U];
         } else {
             // if the flow is a freely-propagating flame, mdot is not specified.
             // Set mdot equal to rho*u, and also set lambda to zero.
             m_mdot = m_flow->density(0) * xb[c_offset_U];
             rb[c_offset_L] = xb[c_offset_L];
+            rb[c_offset_Uo] = xb[c_offset_Uo];
         }
 
         // add the convective term to the species residual equations
@@ -210,11 +217,18 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
         // right inlet
         // Array elements corresponding to the last point in the flow domain
         double* rb = rg + loc() - m_flow->nComponents();
+        double* xb = xg + loc() - m_flow->nComponents();
+        size_t last_index = m_flow->nPoints() - 1;
         rb[c_offset_V] -= m_V0;
-        if (m_flow->doEnergy(m_flow->nPoints() - 1)) {
+        if (m_flow->doEnergy(last_index)) {
             rb[c_offset_T] -= m_temp; // T
         }
-        rb[c_offset_U] += m_mdot; // u
+        if (m_flow->onePointControlEnabled() || m_flow->twoPointControlEnabled()) {
+            m_mdot = m_flow->density(last_index) * xb[c_offset_Uo];
+        } 
+            
+        rb[c_offset_U] += m_mdot; // u      
+        
         for (size_t k = 0; k < m_nsp; k++) {
             if (k != m_flow_left->rightExcessSpecies()) {
                 rb[c_offset_Y+k] += m_mdot * m_yin[k];

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -224,7 +224,7 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             rb[c_offset_T] -= m_temp; // T
         }
         if (m_flow->onePointControlEnabled() || m_flow->twoPointControlEnabled()) {
-            m_mdot = m_flow->density(last_index) * xb[c_offset_Uo];
+            m_mdot = -(m_flow->density(last_index)) * xb[c_offset_Uo];
         } 
             
         rb[c_offset_U] += m_mdot; // u      

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -763,6 +763,64 @@ double Sim1D::fixedTemperatureLocation()
     return z_fixed;
 }
 
+void Sim1D::setFuelSideTemperature(doublereal tFuel) 
+{
+    for (size_t n = 0; n < nDomains(); n++) {
+        Domain1D& d = domain(n);
+        if (d.domainType() == cAxisymmetricStagnationFlow) {
+            StFlow* d_axis = dynamic_cast<StFlow*>(&domain(n));
+            size_t np = d_axis->nPoints();
+            if (d_axis->onePointControlEnabled() || d_axis->twoPointControlEnabled()) {
+                if (d_axis->m_zFuel != Undef) {
+                    d_axis->m_tFuel = tFuel;
+                    return;
+                } else {
+                    for (size_t m = 0; m < np-1; m++) {
+                        if (value(n,2,m) == tFuel) {
+                            d_axis->m_zFuel = d_axis->grid(m);
+                            d_axis->m_tFuel = value(n,2,m);
+                            return;
+                        } else if ((value(n,2,m) - tFuel) * (value(n,2,m+1) - tFuel) < 0.0) {
+                            d_axis->m_zFuel = d_axis->grid(m+1);
+                            d_axis->m_tFuel = value(n,2,m+1);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
+void Sim1D::setOxidSideTemperature(doublereal tOxid)
+{
+    for (size_t n = 0; n < nDomains(); n++) {
+        Domain1D& d = domain(n);
+        if (d.domainType() == cAxisymmetricStagnationFlow) {
+            StFlow* d_axis = dynamic_cast<StFlow*>(&domain(n));
+            size_t np = d_axis->nPoints();
+            if (d_axis->twoPointControlEnabled()) {
+                if (d_axis->m_zOxid != Undef) {
+                    d_axis->m_tOxid = tOxid;
+                    return;
+                } else {
+                    for (size_t m = np-1; m > 0; m--) {
+                        if (value(n,2,m) == tOxid) {
+                            d_axis->m_zOxid = d_axis->grid(m);
+                            d_axis->m_tOxid = value(n,2,m);
+                            return;
+                        } else if ((value(n,2,m) - tOxid) * (value(n,2,m-1) - tOxid) < 0.0) {
+                            d_axis->m_zOxid = d_axis->grid(m-1);
+                            d_axis->m_tOxid = value(n,2,m-1);
+                            return;
+                        }
+                    }
+                }
+            }
+        }
+    }
+}
+
 void Sim1D::setRefineCriteria(int dom, double ratio,
                               double slope, double curve, double prune)
 {

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -763,49 +763,76 @@ double Sim1D::fixedTemperatureLocation()
     return z_fixed;
 }
 
-void Sim1D::setFuelSideBoundary(doublereal tFuel) 
+
+void Sim1D::setFuelInternalBoundary(double temperature)
 {
+    double epsilon = 1e-10; // Define your precision threshold here
+
     for (size_t n = 0; n < nDomains(); n++) {
         Domain1D& d = domain(n);
-        if (d.domainType() == cAxisymmetricStagnationFlow) {
-            StFlow* d_axis = dynamic_cast<StFlow*>(&domain(n));
-            size_t np = d_axis->nPoints();
-            if (d_axis->onePointControlEnabled() || d_axis->twoPointControlEnabled()) {
-                for (size_t m = 0; m < np-1; m++) {
-                    if (value(n,2,m) == tFuel) {
-                        d_axis->m_zFuel = d_axis->grid(m);
-                        d_axis->m_tFuel = value(n,2,m);
-                        return;
-                    } else if ((value(n,2,m) - tFuel) * (value(n,2,m+1) - tFuel) < 0.0) {
-                        d_axis->m_zFuel = d_axis->grid(m+1);
-                        d_axis->m_tFuel = value(n,2,m+1);
-                        return;
-                    }
-                }               
+
+        // Skip if the domain type doesn't match
+        if (d.domainType() != cAxisymmetricStagnationFlow) {
+            continue;
+        }
+
+        StFlow* d_axis = dynamic_cast<StFlow*>(&domain(n));
+        size_t np = d_axis->nPoints();
+
+        // Skip if none of the control is enabled
+        if (!d_axis->onePointControlEnabled() && !d_axis->twoPointControlEnabled()) {
+            continue;
+        }
+
+        for (size_t m = 0; m < np-1; m++) {
+            // Check if the absolute difference between the two temperatures is less than epsilon
+            if (std::abs(value(n,2,m) - temperature) < epsilon) {
+                d_axis->m_zFuel = d_axis->grid(m);
+                d_axis->m_tFuel = value(n,2,m);
+                return;
+            }
+
+            if ((value(n,2,m) - temperature) * (value(n,2,m+1) - temperature) < 0.0) {
+                d_axis->m_zFuel = d_axis->grid(m+1);
+                d_axis->m_tFuel = value(n,2,m+1);
+                return;
             }
         }
     }
 }
 
-void Sim1D::setOxidSideBoundary(doublereal tOxid)
+void Sim1D::setOxidizerInternalBoundary(double temperature)
 {
+    double epsilon = 1e-5; // Precision threshold for being 'equal' to a temperature
+
     for (size_t n = 0; n < nDomains(); n++) {
         Domain1D& d = domain(n);
-        if (d.domainType() == cAxisymmetricStagnationFlow) {
-            StFlow* d_axis = dynamic_cast<StFlow*>(&domain(n));
-            size_t np = d_axis->nPoints();
-            if (d_axis->twoPointControlEnabled()) {
-                for (size_t m = np-1; m > 0; m--) {
-                    if (value(n,2,m) == tOxid) {
-                        d_axis->m_zOxid = d_axis->grid(m);
-                        d_axis->m_tOxid = value(n,2,m);
-                        return;
-                    } else if ((value(n,2,m) - tOxid) * (value(n,2,m-1) - tOxid) < 0.0) {
-                        d_axis->m_zOxid = d_axis->grid(m-1);
-                        d_axis->m_tOxid = value(n,2,m-1);
-                        return;
-                    }
-                }
+
+        // Skip if the domain type doesn't match
+        if (d.domainType() != cAxisymmetricStagnationFlow) {
+            continue;
+        }
+
+        StFlow* d_axis = dynamic_cast<StFlow*>(&domain(n));
+        size_t np = d_axis->nPoints();
+
+        // Skip if two-point control is not enabled
+        if (!d_axis->twoPointControlEnabled()) {
+            continue;
+        }
+
+        for (size_t m = np-1; m > 0; m--) {
+            // Check if the absolute difference between the two temperatures is less than epsilon
+            if (std::abs(value(n,2,m) - temperature) < epsilon) {
+                d_axis->m_zOxid = d_axis->grid(m);
+                d_axis->m_tOxid = value(n,2,m);
+                return;
+            } 
+
+            if ((value(n,2,m) - temperature) * (value(n,2,m-1) - temperature) < 0.0) {
+                d_axis->m_zOxid = d_axis->grid(m-1);
+                d_axis->m_tOxid = value(n,2,m-1);
+                return;
             }
         }
     }

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -766,8 +766,7 @@ double Sim1D::fixedTemperatureLocation()
 
 void Sim1D::setFuelInternalBoundary(double temperature)
 {
-    double epsilon = 1e-10; // Define your precision threshold here
-
+    double epsilon = 1e-5; // Precision threshold for being 'equal' to a temperature
     for (size_t n = 0; n < nDomains(); n++) {
         Domain1D& d = domain(n);
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -763,7 +763,7 @@ double Sim1D::fixedTemperatureLocation()
     return z_fixed;
 }
 
-void Sim1D::setFuelSideTemperature(doublereal tFuel) 
+void Sim1D::setFuelSideBoundary(doublereal tFuel) 
 {
     for (size_t n = 0; n < nDomains(); n++) {
         Domain1D& d = domain(n);
@@ -771,28 +771,23 @@ void Sim1D::setFuelSideTemperature(doublereal tFuel)
             StFlow* d_axis = dynamic_cast<StFlow*>(&domain(n));
             size_t np = d_axis->nPoints();
             if (d_axis->onePointControlEnabled() || d_axis->twoPointControlEnabled()) {
-                if (d_axis->m_zFuel != Undef) {
-                    d_axis->m_tFuel = tFuel;
-                    return;
-                } else {
-                    for (size_t m = 0; m < np-1; m++) {
-                        if (value(n,2,m) == tFuel) {
-                            d_axis->m_zFuel = d_axis->grid(m);
-                            d_axis->m_tFuel = value(n,2,m);
-                            return;
-                        } else if ((value(n,2,m) - tFuel) * (value(n,2,m+1) - tFuel) < 0.0) {
-                            d_axis->m_zFuel = d_axis->grid(m+1);
-                            d_axis->m_tFuel = value(n,2,m+1);
-                            return;
-                        }
+                for (size_t m = 0; m < np-1; m++) {
+                    if (value(n,2,m) == tFuel) {
+                        d_axis->m_zFuel = d_axis->grid(m);
+                        d_axis->m_tFuel = value(n,2,m);
+                        return;
+                    } else if ((value(n,2,m) - tFuel) * (value(n,2,m+1) - tFuel) < 0.0) {
+                        d_axis->m_zFuel = d_axis->grid(m+1);
+                        d_axis->m_tFuel = value(n,2,m+1);
+                        return;
                     }
-                }
+                }               
             }
         }
     }
 }
 
-void Sim1D::setOxidSideTemperature(doublereal tOxid)
+void Sim1D::setOxidSideBoundary(doublereal tOxid)
 {
     for (size_t n = 0; n < nDomains(); n++) {
         Domain1D& d = domain(n);
@@ -800,20 +795,15 @@ void Sim1D::setOxidSideTemperature(doublereal tOxid)
             StFlow* d_axis = dynamic_cast<StFlow*>(&domain(n));
             size_t np = d_axis->nPoints();
             if (d_axis->twoPointControlEnabled()) {
-                if (d_axis->m_zOxid != Undef) {
-                    d_axis->m_tOxid = tOxid;
-                    return;
-                } else {
-                    for (size_t m = np-1; m > 0; m--) {
-                        if (value(n,2,m) == tOxid) {
-                            d_axis->m_zOxid = d_axis->grid(m);
-                            d_axis->m_tOxid = value(n,2,m);
-                            return;
-                        } else if ((value(n,2,m) - tOxid) * (value(n,2,m-1) - tOxid) < 0.0) {
-                            d_axis->m_zOxid = d_axis->grid(m-1);
-                            d_axis->m_tOxid = value(n,2,m-1);
-                            return;
-                        }
+                for (size_t m = np-1; m > 0; m--) {
+                    if (value(n,2,m) == tOxid) {
+                        d_axis->m_zOxid = d_axis->grid(m);
+                        d_axis->m_tOxid = value(n,2,m);
+                        return;
+                    } else if ((value(n,2,m) - tOxid) * (value(n,2,m-1) - tOxid) < 0.0) {
+                        d_axis->m_zOxid = d_axis->grid(m-1);
+                        d_axis->m_tOxid = value(n,2,m-1);
+                        return;
                     }
                 }
             }

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -766,7 +766,7 @@ double Sim1D::fixedTemperatureLocation()
 
 void Sim1D::setFuelInternalBoundary(double temperature)
 {
-    double epsilon = 1e-5; // Precision threshold for being 'equal' to a temperature
+    double epsilon = 1e-3; // Precision threshold for being 'equal' to a temperature
     for (size_t n = 0; n < nDomains(); n++) {
         Domain1D& d = domain(n);
 
@@ -802,7 +802,7 @@ void Sim1D::setFuelInternalBoundary(double temperature)
 
 void Sim1D::setOxidizerInternalBoundary(double temperature)
 {
-    double epsilon = 1e-5; // Precision threshold for being 'equal' to a temperature
+    double epsilon = 1e-3; // Precision threshold for being 'equal' to a temperature
 
     for (size_t n = 0; n < nDomains(); n++) {
         Domain1D& d = domain(n);

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -509,7 +509,7 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
             // have different boundary type with different flame control method
             if (!m_onePntCtrl && !m_twoPntCtrl) {
                 rsd[index(c_offset_L,0)] = -rho_u(x,0);
-                rsd[index(c_offset_Uo,0)] = -Uo(x,0);
+                rsd[index(c_offset_Uo,0)] = Uo(x,1) - Uo(x,0);
             } else if (m_onePntCtrl) {
                 rsd[index(c_offset_L,0)] = lambda(x,1) - lambda(x,0);
                 rsd[index(c_offset_Uo,0)] = -Uo(x,0);
@@ -602,7 +602,7 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
 
             if (!m_onePntCtrl && !m_twoPntCtrl) {
                 rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
-                rsd[index(c_offset_Uo, j)] = Uo(x,j) - Uo(x,j-1);
+                rsd[index(c_offset_Uo, j)] = Uo(x,j+1) - Uo(x,j);
             } else if (m_onePntCtrl) {
                 if (grid(j) > m_zFuel) {
                     rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
@@ -1076,7 +1076,11 @@ void StFlow::evalRightBoundary(double* x, double* rsd, int* diag, double rdt)
     diag[index(c_offset_L, j)] = 0;
     // set residual of poisson's equ to zero
     rsd[index(c_offset_E, j)] = x[index(c_offset_E, j)];
-    rsd[index(c_offset_Uo, j)] = Uo(x,j) - Uo(x,j-1);
+    if (!m_onePntCtrl && !m_twoPntCtrl) {
+        rsd[index(c_offset_Uo,j)] = Uo(x,j);
+    } else {
+        rsd[index(c_offset_Uo, j)] = Uo(x,j) - Uo(x,j-1);
+    }
     diag[index(c_offset_Uo, j)] = 0;
     for (size_t k = 0; k < m_nsp; k++) {
         sum += Y(x,k,j);

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -592,17 +592,17 @@ void StFlow::evalContinuityEquation(double* x, double* rsd, int* diag, double rd
             -(rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
             -(density(j+1)*V(x,j+1) + density(j)*V(x,j));
     } else {
-        if (grid(j) > m_zfixed) {
-            rsd[index(c_offset_U,j)] =
-                - (rho_u(x,j) - rho_u(x,j-1))/m_dz[j-1]
-                - (density(j-1)*V(x,j-1) + density(j)*V(x,j));
-        } else if (std::abs(grid(j) - m_zfixed) < epsilon) {
+        if (std::abs(grid(j) - m_zfixed) < epsilon) {
             if (m_do_energy[j]) {
                 rsd[index(c_offset_U,j)] = (T(x,j) - m_tfixed);
             } else {
                 rsd[index(c_offset_U,j)] = (rho_u(x,j)
                                             - m_rho[0]*0.3);
             }
+        } else if (grid(j) > m_zfixed) {
+            rsd[index(c_offset_U,j)] =
+                - (rho_u(x,j) - rho_u(x,j-1))/m_dz[j-1]
+                - (density(j-1)*V(x,j-1) + density(j)*V(x,j));
         } else if (grid(j) < m_zfixed) {
             rsd[index(c_offset_U,j)] =
                 - (rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
@@ -675,18 +675,18 @@ void StFlow::evalLEquation(double* x, double* rsd, int* diag, double rdt, size_t
 {
     double epsilon = 1e-5; // Precision threshold for being 'equal' to a coordinate
     if (m_onePointControl) {
-        if (grid(j) > m_zFuel) {
-            rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
-        } else if (std::abs(grid(j) - m_zFuel) < epsilon ) {
+        if (std::abs(grid(j) - m_zFuel) < epsilon )  {
             rsd[index(c_offset_L, j)] = T(x,j) - m_tFuel;
+        } else if (grid(j) > m_zFuel) {
+            rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
         } else if (grid(j) < m_zFuel) {
             rsd[index(c_offset_L, j)] = lambda(x,j+1) - lambda(x,j);
         }
     } else if (m_twoPointControl) {
-        if (grid(j) > m_zFuel) {
-            rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
-        } else if (std::abs(grid(j) - m_zFuel) < epsilon ) {
+        if (std::abs(grid(j) - m_zFuel) < epsilon ) {
             rsd[index(c_offset_L, j)] = T(x,j) - m_tFuel;
+        } else if (grid(j) > m_zFuel) {
+            rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
         } else if (grid(j) < m_zFuel) {
             rsd[index(c_offset_L, j)] = lambda(x,j+1) - lambda(x,j);
         }
@@ -702,10 +702,10 @@ void StFlow::evalUoEquation(double* x, double* rsd, int* diag, double rdt, size_
     if (m_onePointControl) {
         rsd[index(c_offset_Uo, j)] = Uo(x,j) - Uo(x,j-1);
     } else if (m_twoPointControl) {
-        if (grid(j) > m_zOxid) {
-            rsd[index(c_offset_Uo, j)] = Uo(x,j) - Uo(x,j-1);
-        } else if (std::abs(grid(j) - m_zOxid) < epsilon) {
+        if (std::abs(grid(j) - m_zOxid) < epsilon) {
             rsd[index(c_offset_Uo, j)] = T(x,j) - m_tOxid;
+        } else if (grid(j) > m_zOxid) {
+            rsd[index(c_offset_Uo, j)] = Uo(x,j) - Uo(x,j-1);
         } else if (grid(j) < m_zOxid) {
             rsd[index(c_offset_Uo, j)] = Uo(x,j+1) - Uo(x,j);
         }

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -512,7 +512,7 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
                 rsd[index(c_offset_Uo,0)] = Uo(x,1) - Uo(x,0);
             } else if (m_onePntCtrl) {
                 rsd[index(c_offset_L,0)] = lambda(x,1) - lambda(x,0);
-                rsd[index(c_offset_Uo,0)] = -Uo(x,0);
+                rsd[index(c_offset_Uo,0)] = Uo(x,0);
             } else if (m_twoPntCtrl) {
                 rsd[index(c_offset_L,0)] = lambda(x,1) - lambda(x,0);
                 rsd[index(c_offset_Uo,0)] = Uo(x,1) - Uo(x,0);


### PR DESCRIPTION
This pull request is based on the pull request #766.

**Changes proposed in this pull request**

- The goal is to add a type of continuation method that allows for 1D counter-flow diffusion flame solutions that exist along the unstable burning branch.
- Minor updates to the original pull request
- An attempt to address issues that were brought up in the original pull request

The original work appears to be based on the method described in the following paper:
https://www.yang.gatech.edu/publications/Journal/C&F%20(2014,%20Huo)%20-%20S%20curve.pdf

Reference information: https://www.sciencedirect.com/science/article/abs/pii/S0010218014001825

The original comments by @speth regarding work that needed to be done with this feature center around numerical stability when using the feature.

I would also like to understand the significance of the Strain Equation option that was present in the original work (#541), and why it was not included in this update of #766. To understand if this has anything to do with the stability issues that are being seen when using the feature in its current form.

Another relevant reference that discusses the governing equations used in the previous reference in more detail is: https://www.sciencedirect.com/science/article/abs/pii/S0010218008001569 so that I can compare with what Cantera uses (https://cantera.org/science/flames.html)


