### PR TITLE
Fix Conda packaging issues

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -520,8 +520,9 @@ jobs:
     - name: Test Install
       # spot-check installation locations
       run: |
+        set -x
         scons install
-        test -f ${CONDA_PREFIX}/Library/lib/cantera_shared.dll
+        test -f ${CONDA_PREFIX}/Library/bin/cantera_shared.dll
         test -f ${CONDA_PREFIX}/Library/include/cantera/base/Solution.h
         test -f ${CONDA_PREFIX}/Scripts/ck2yaml
         test -f ${CONDA_PREFIX}/share/cantera/data/gri30.yaml
@@ -531,6 +532,7 @@ jobs:
     - name: Test Essentials
       # ensure that Python package loads and converter scripts work
       run: |
+        set -x
         python -c 'import cantera as ct; import sys; sys.exit(0) if ct.__version__.startswith("3.0.0") else sys.exit(1)'
         ck2yaml --input=test/data/h2o2.inp --output=h2o2-test.yaml
         test -f h2o2-test.yaml

--- a/SConstruct
+++ b/SConstruct
@@ -2135,7 +2135,6 @@ cdefine("CT_USE_SYSTEM_EIGEN", "system_eigen")
 cdefine("CT_USE_SYSTEM_EIGEN_PREFIXED", "system_eigen_prefixed")
 cdefine('CT_USE_SYSTEM_FMT', 'system_fmt')
 cdefine('CT_USE_SYSTEM_YAMLCPP', 'system_yamlcpp')
-cdefine('CT_HAS_PYTHON', 'python_package', 'full')
 
 config_h_build = env.Command('build/src/config.h.build',
                              'include/cantera/base/config.h.in',

--- a/SConstruct
+++ b/SConstruct
@@ -2024,7 +2024,8 @@ elif env["layout"] == "conda":
 prefix = Path(env["prefix"])
 
 if env["layout"] == "conda" and os.name == "nt":
-    env["ct_libdir"] = (prefix / "Library" / env["libdirname"]).as_posix()
+    env["ct_libdir"] = (prefix / "Library" / "lib").as_posix()
+    env["ct_shlibdir"] = (prefix / "Library" / "bin").as_posix()
     env["ct_bindir"] = (prefix / "Scripts").as_posix()
     env["ct_python_bindir"] = (prefix / "Scripts").as_posix()
     env["ct_incdir"] = (prefix / "Library" / "include" / "cantera").as_posix()
@@ -2035,6 +2036,14 @@ else:
         env["prefix"] = prefix.as_posix()
     env["ct_libdir"] = (prefix / env["libdirname"]).as_posix()
     env["ct_bindir"] = (prefix / "bin").as_posix()
+
+    # On Windows, the search path for DLLs is the "bin" dir. "lib" dirs are used only for
+    # static and "import" libraries
+    if env["OS"] == "Windows":
+        env["ct_shlibdir"] = env["ct_bindir"]
+    else:
+        env["ct_shlibdir"] = env["ct_libdir"]
+
     env["ct_python_bindir"] = (prefix / "bin").as_posix()
     env["ct_incdir"] = (prefix / "include" / "cantera").as_posix()
     env["ct_incroot"] = (prefix / "include").as_posix()
@@ -2081,7 +2090,7 @@ if os.path.abspath(instRoot) == Dir('.').abspath:
     sys.exit(1)
 
 env["inst_root"] = instRoot
-locations = ["libdir", "bindir", "python_bindir", "incdir", "incroot",
+locations = ["libdir", "shlibdir", "bindir", "python_bindir", "incdir", "incroot",
     "matlab_dir", "datadir", "sampledir", "docdir", "mandir"]
 for loc in locations:
     if env["prefix"] == ".":

--- a/SConstruct
+++ b/SConstruct
@@ -603,7 +603,7 @@ config_options = [
            more generic library name, for example, 'libcantera_shared.so.2.5.0' as the
            actual library and 'libcantera_shared.so' and 'libcantera_shared.so.2'
            as symlinks.""",
-        {"mingw": False, "default": True}),
+        {"mingw": False, "cl": False, "default": True}),
     BoolOption(
         "use_rpath_linkage",
         """If enabled, link to all shared libraries using 'rpath', that is, a fixed

--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -66,7 +66,7 @@ public:
 
     //! Size of SolutionArray (number of entries)
     int size() const {
-        return m_size;
+        return static_cast<int>(m_size);
     }
 
     //! Resize SolutionArray objects with a single dimension (default).

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -45,7 +45,6 @@ typedef int ftnlen;       // Fortran hidden string length type
 {CT_USE_SYSTEM_EIGEN_PREFIXED!s}
 {CT_USE_SYSTEM_FMT!s}
 {CT_USE_SYSTEM_YAMLCPP!s}
-{CT_HAS_PYTHON!s}
 
 //-------------- Optional Cantera Capabilities ----------------------
 

--- a/samples/clib/SConscript
+++ b/samples/clib/SConscript
@@ -16,7 +16,7 @@ for programName, sources in samples:
     # Generate SConstruct files to be installed
     linkflags = ["-g", localenv["thread_flags"]]
     if not localenv["package_build"]:
-        linkflags.append(f"-Wl,-rpath,{localenv['ct_libdir']}")
+        linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
         incdirs = [localenv["ct_incroot"]]
         libdirs = [localenv["ct_libdir"]] + localenv["extra_lib_dirs"]
     else:

--- a/samples/clib/SConscript
+++ b/samples/clib/SConscript
@@ -15,13 +15,11 @@ for programName, sources in samples:
 
     # Generate SConstruct files to be installed
     linkflags = ["-g", localenv["thread_flags"]]
+    incdirs = [localenv["ct_incroot"]]
+    libdirs = [localenv["ct_libdir"]] + localenv["extra_lib_dirs"]
     if not localenv["package_build"]:
         linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
-        incdirs = [localenv["ct_incroot"]]
-        libdirs = [localenv["ct_libdir"]] + localenv["extra_lib_dirs"]
-    else:
-        incdirs = []
-        libdirs = []
+        libdirs.extend(localenv["extra_lib_dirs"])
 
     localenv["tmpl_compiler_flags"] = repr(localenv["CCFLAGS"])
     localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -53,6 +53,8 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     # by the "RecursiveInstall" that grabs everything in the cxx directory.
 
     flag_excludes = ["$(", "/TP", "$)", "/nologo"]
+    incdirs = [localenv["ct_incroot"]]
+    libdirs = [localenv["ct_libdir"]]
     if localenv["package_build"]:
         # Remove sysroot flags in templated output files. This only applies to the
         # conda package for now.
@@ -60,16 +62,12 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
         # compatible with the SDK used for building.
         flag_excludes.extend(["-isysroot", "-mmacosx", "-march", "-mtune"
                               "-fdebug-prefix-map"])
-        incdirs = []
-        libdirs = []
     else:
-        incdirs = [localenv["ct_incroot"]]
         incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
         incdirs.append(localenv["hdf_include"])
         incdirs.extend(localenv["extra_inc_dirs"])
         incdirs = list(set(incdirs))
 
-        libdirs = [localenv["ct_libdir"]]
         libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
         libdirs.append(localenv["hdf_libdir"])
         libdirs.extend(localenv["extra_lib_dirs"])

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -68,8 +68,6 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
         incdirs.extend(localenv["extra_inc_dirs"])
         incdirs = list(set(incdirs))
 
-        libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
-        libdirs.append(localenv["hdf_libdir"])
         libdirs.extend(localenv["extra_lib_dirs"])
         libdirs = list(set(libdirs))
 
@@ -79,8 +77,8 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     localenv['tmpl_cantera_frameworks'] = repr(localenv['FRAMEWORKS'])
     localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])
     localenv['cmake_cantera_incdirs'] = ' '.join(quoted(x) for x in incdirs if x)
-    localenv['tmpl_cantera_libs'] = repr(localenv['cantera_libs'])
-    localenv['cmake_cantera_libs'] = ' '.join(localenv['cantera_libs'])
+    localenv['tmpl_cantera_libs'] = repr(localenv['cantera_shared_libs'])
+    localenv['cmake_cantera_libs'] = ' '.join(localenv['cantera_shared_libs'])
     if env['OS'] == 'Darwin':
         localenv['cmake_cantera_libs'] += ' ${ACCELERATE_FRAMEWORK}'
         localenv['cmake_cantera_incdirs'] += ' "/usr/local/include"'

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -52,20 +52,17 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
     # Note: These CMakeLists.txt and SConstruct files are automatically installed
     # by the "RecursiveInstall" that grabs everything in the cxx directory.
 
-
+    flag_excludes = ["$(", "/TP", "$)", "/nologo"]
     if localenv["package_build"]:
         # Remove sysroot flags in templated output files. This only applies to the
         # conda package for now.
         # Users should compile against their local SDKs, which should be backwards
         # compatible with the SDK used for building.
-        excludes = (
-            "-isysroot", "-mmacosx", "-march", "-mtune", "-fdebug-prefix-map")
-        cc_flags = compiler_flag_list(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
-            excludes)
+        flag_excludes.extend(["-isysroot", "-mmacosx", "-march", "-mtune"
+                              "-fdebug-prefix-map"])
         incdirs = []
         libdirs = []
     else:
-        cc_flags = localenv["CCFLAGS"] + localenv["CXXFLAGS"]
         incdirs = [localenv["ct_incroot"]]
         incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
         incdirs.append(localenv["hdf_include"])
@@ -78,6 +75,8 @@ set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
         libdirs.extend(localenv["extra_lib_dirs"])
         libdirs = list(set(libdirs))
 
+    cc_flags = compiler_flag_list(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
+                                  flag_excludes)
     localenv["tmpl_compiler_flags"] = repr(cc_flags)
     localenv['tmpl_cantera_frameworks'] = repr(localenv['FRAMEWORKS'])
     localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -37,7 +37,7 @@ if localenv["package_build"]:
     libdirs = []
 else:
     cc_flags = localenv["CCFLAGS"] + localenv["CXXFLAGS"]
-    linkflags.append(f"-Wl,-rpath,{localenv['ct_libdir']}")
+    linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
 
     incdirs = [localenv["ct_incroot"]]
     incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -24,19 +24,17 @@ for program_name, fortran_sources in samples:
 # Generate SConstruct file to be installed
 linkflags = ["-g", localenv["thread_flags"]]
 
+flag_excludes = ["$(", "/TP", "$)", "/nologo"]
 if localenv["package_build"]:
     # Remove sysroot flags in templated output files. This only applies to the
     # conda package for now.
     # Users should compile against their local SDKs, which should be backwards
     # compatible with the SDK used for building.
-    excludes = (
-        "-isysroot", "-mmacosx", "-march", "-mtune", "-fdebug-prefix-map")
-    cc_flags = compiler_flag_list(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
-        excludes)
+    flag_excludes.extend(["-isysroot", "-mmacosx", "-march", "-mtune",
+                          "-fdebug-prefix-map"])
     incdirs = []
     libdirs = []
 else:
-    cc_flags = localenv["CCFLAGS"] + localenv["CXXFLAGS"]
     linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
 
     incdirs = [localenv["ct_incroot"]]
@@ -53,6 +51,8 @@ else:
 
 libs = ["cantera_fortran"] + localenv["cantera_libs"] + localenv["cxx_stdlib"]
 
+cc_flags = compiler_flag_list(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
+                              flag_excludes)
 localenv["tmpl_compiler_flags"] = repr(cc_flags)
 localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])
 localenv['tmpl_cantera_libs'] = repr(libs)

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -25,6 +25,8 @@ for program_name, fortran_sources in samples:
 linkflags = ["-g", localenv["thread_flags"]]
 
 flag_excludes = ["$(", "/TP", "$)", "/nologo"]
+incdirs = [localenv["ct_incroot"]]
+libdirs = [localenv["ct_libdir"]]
 if localenv["package_build"]:
     # Remove sysroot flags in templated output files. This only applies to the
     # conda package for now.
@@ -32,18 +34,14 @@ if localenv["package_build"]:
     # compatible with the SDK used for building.
     flag_excludes.extend(["-isysroot", "-mmacosx", "-march", "-mtune",
                           "-fdebug-prefix-map"])
-    incdirs = []
-    libdirs = []
 else:
     linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
 
-    incdirs = [localenv["ct_incroot"]]
     incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
     incdirs.append(localenv["hdf_include"])
     incdirs.extend(localenv["extra_inc_dirs"])
     incdirs = list(set(incdirs))
 
-    libdirs = [localenv["ct_libdir"]]
     libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
     libdirs.append(localenv["hdf_libdir"])
     libdirs.extend(localenv["extra_lib_dirs"])

--- a/samples/f90/SConscript
+++ b/samples/f90/SConscript
@@ -20,7 +20,7 @@ for programName, sources in samples:
     incdirs = [pjoin(localenv["ct_incroot"], "cantera")] # path to fortran .mod
     libdirs = []
     if not localenv["package_build"]:
-        linkflags.append(f"-Wl,-rpath,{localenv['ct_libdir']}")
+        linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
         libdirs = [localenv["ct_libdir"]]
         libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
         libdirs.append(localenv["hdf_libdir"])

--- a/samples/f90/SConscript
+++ b/samples/f90/SConscript
@@ -18,16 +18,13 @@ for programName, sources in samples:
     # Generate SConstruct files to be installed
     linkflags = ["-g", localenv["thread_flags"]]
     incdirs = [pjoin(localenv["ct_incroot"], "cantera")] # path to fortran .mod
-    libdirs = []
+    libdirs = [localenv["ct_libdir"]]
     if not localenv["package_build"]:
         linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
-        libdirs = [localenv["ct_libdir"]]
         libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
         libdirs.append(localenv["hdf_libdir"])
         libdirs.extend(localenv["extra_lib_dirs"])
         libdirs = list(set(libdirs))
-    else:
-        libdirs = []
 
     libs = ['cantera_fortran'] + localenv['cantera_libs'] + env['cxx_stdlib']
 

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1106,9 +1106,11 @@ def compiler_flag_list(
     """
     if not isinstance(flags, str):
         flags = " ".join(flags)
-    # split concatenated entries
-    flags = f" {flags}".split(" -")[1:]
-    flags = [f"-{flag}" for flag in flags]
+    # split concatenated entries. Options can start with "-", "/", or "$"
+    flags = re.findall(r"""(?:^|\ +)        # start of string or leading whitespace
+                       ([-/\$].+?)          # capture start of option
+                       (?=\ +[-/\$]|\ *$)   # start of next option or end of string
+                       """, flags, re.VERBOSE)
     cc_flags = []
     excludes = tuple(excludes)
     for flag in flags:

--- a/src/SConscript
+++ b/src/SConscript
@@ -88,13 +88,8 @@ if env["python_package"] == "full":
     pyenv.Append(LIBS=pyenv["py_libs"], LIBPATH=pyenv["py_libpath"])
     shim = pyenv.SharedObject("extensions/pythonShim.cpp")
     pylibname = f"../lib/cantera_python{pyenv['py_version_short'].replace('.', '_')}"
-    if pyenv["versioned_shared_library"]:
-        lib = build(pyenv.SharedLibrary(pylibname, shim, SPAWN=get_spawn(pyenv),
-                                        SHLIBVERSION=pyenv["cantera_pure_version"]))
-        install(pyenv.InstallVersionedLib, "$inst_libdir", lib)
-    else:
-        lib = build(pyenv.SharedLibrary(pylibname, shim, SPAWN=get_spawn(pyenv)))
-        install("$inst_libdir", lib)
+    lib = build(pyenv.SharedLibrary(pylibname, shim, SPAWN=get_spawn(pyenv)))
+    install("$inst_libdir", lib)
 
 
 # build the Cantera static library

--- a/src/SConscript
+++ b/src/SConscript
@@ -89,7 +89,7 @@ if env["python_package"] == "full":
     shim = pyenv.SharedObject("extensions/pythonShim.cpp")
     pylibname = f"../lib/cantera_python{pyenv['py_version_short'].replace('.', '_')}"
     lib = build(pyenv.SharedLibrary(pylibname, shim, SPAWN=get_spawn(pyenv)))
-    install("$inst_libdir", lib)
+    install("$inst_shlibdir", lib)
 
 
 # build the Cantera static library
@@ -162,11 +162,17 @@ if localenv['versioned_shared_library']:
     lib = build(localenv.SharedLibrary(sharedName, libraryTargets + sharedIndicator,
                                         SPAWN=get_spawn(localenv),
                                         SHLIBVERSION=localenv['cantera_pure_version']))
-    install(localenv.InstallVersionedLib, '$inst_libdir', lib)
+    install(localenv.InstallVersionedLib, '$inst_shlibdir', lib)
 else:
     lib = build(localenv.SharedLibrary(sharedName, libraryTargets + sharedIndicator,
-                                        SPAWN=get_spawn(localenv)))
-    install('$inst_libdir', lib)
+                                       SPAWN=get_spawn(localenv)))
+    for libfile in lib:
+        if libfile.name.endswith(('.exp', '.lib')):
+            # On Windows, these are the export/import libraries used when linking, which
+            # should be installed in the same location as static libraries
+            install('$inst_libdir', libfile)
+        else:
+            install('$inst_shlibdir', libfile)
 
 if env["OS"] == "Darwin":
     localenv.AddPostAction(lib,

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -14,6 +14,7 @@
 #include "cantera/thermo/SurfPhase.h"
 #include <boost/algorithm/string.hpp>
 #include <fstream>
+#include <sstream>
 
 
 namespace ba = boost::algorithm;

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -299,7 +299,7 @@ public:
     /**
      * Add a copy of the nth object to storage. The index of the new entry is returned.
      */
-    static int copy(size_t n) {
+    static int copy(int n) {
         dataRef data = getData();
         try {
             return add(*data[n]);
@@ -311,7 +311,7 @@ public:
     /**
      * Delete the nth object.
      */
-    static void del(size_t n) {
+    static void del(int n) {
         dataRef data = getData();
         if (n >= 0 && n < data.size()) {
             lookupRef lookup = getLookup();
@@ -336,7 +336,7 @@ public:
     /**
      * Return a shared pointer to object n.
      */
-    static shared_ptr<M>& at(size_t n) {
+    static shared_ptr<M>& at(int n) {
         dataRef data = getData();
         if (n < 0 || n >= data.size()) {
             throw CanteraError("SharedCabinet::at", "Index {} out of range.", n);
@@ -348,7 +348,7 @@ public:
      * Return object n, cast to the specified type.
      */
     template <class T>
-    static shared_ptr<T> as(size_t n) {
+    static shared_ptr<T> as(int n) {
         auto obj = std::dynamic_pointer_cast<T>(at(n));
         if (obj) {
             return obj;
@@ -359,7 +359,7 @@ public:
     /**
      * Return a reference to object n.
      */
-    static M& item(size_t n) {
+    static M& item(int n) {
         auto ptr = at(n);
         if (!ptr) {
             throw CanteraError("SharedCabinet::item",
@@ -372,7 +372,7 @@ public:
      * Return a reference to object n, cast to a reference of the specified type.
      */
     template <class T>
-    static T& get(size_t n) {
+    static T& get(int n) {
         auto obj = std::dynamic_pointer_cast<T>(at(n));
         if (obj) {
             return *obj;

--- a/src/fortran/SConscript
+++ b/src/fortran/SConscript
@@ -32,11 +32,18 @@ if localenv['layout'] != 'debian':
                                              SHLIBVERSION=localenv['cantera_pure_version'],
                                              LIBS=list(env['cantera_shared_libs'] + env['cxx_stdlib']),
                                              LINK='$FORTRAN_LINK'))
-        install(localenv.InstallVersionedLib, '$inst_libdir', shlib)
+        install(localenv.InstallVersionedLib, '$inst_shlibdir', shlib)
     else:
         shlib = build(localenv.SharedLibrary(target=sharedName, source=objects,
                                              SPAWN=get_spawn(localenv),
                                              LIBS=list(env['cantera_shared_libs'] + env['cxx_stdlib']),
                                              LINK='$FORTRAN_LINK'))
-        install('$inst_libdir', shlib)
+        for libfile in shlib:
+            if libfile.name.endswith(('.exp', '.lib')):
+                # On Windows, these are the export/import libraries used when linking, which
+                # should be installed in the same location as static libraries
+                install('$inst_libdir', libfile)
+            else:
+                install('$inst_shlibdir', libfile)
+
     localenv.Depends(shlib, localenv['config_h_target'])

--- a/src/fortran/SConscript
+++ b/src/fortran/SConscript
@@ -20,30 +20,29 @@ install('$inst_libdir', lib)
 install('$inst_incdir', mods)
 
 # Build the Cantera Fortran interface shared library
-if localenv['layout'] != 'debian':
-    if localenv['renamed_shared_libraries']:
-        sharedName = '../../lib/cantera_fortran_shared'
-    else:
-        sharedName = '../../lib/cantera_fortran'
+if localenv['renamed_shared_libraries']:
+    sharedName = '../../lib/cantera_fortran_shared'
+else:
+    sharedName = '../../lib/cantera_fortran'
 
-    if localenv['versioned_shared_library']:
-        shlib = build(localenv.SharedLibrary(target=sharedName, source=objects,
-                                             SPAWN=get_spawn(localenv),
-                                             SHLIBVERSION=localenv['cantera_pure_version'],
-                                             LIBS=list(env['cantera_shared_libs'] + env['cxx_stdlib']),
-                                             LINK='$FORTRAN_LINK'))
-        install(localenv.InstallVersionedLib, '$inst_shlibdir', shlib)
-    else:
-        shlib = build(localenv.SharedLibrary(target=sharedName, source=objects,
-                                             SPAWN=get_spawn(localenv),
-                                             LIBS=list(env['cantera_shared_libs'] + env['cxx_stdlib']),
-                                             LINK='$FORTRAN_LINK'))
-        for libfile in shlib:
-            if libfile.name.endswith(('.exp', '.lib')):
-                # On Windows, these are the export/import libraries used when linking, which
-                # should be installed in the same location as static libraries
-                install('$inst_libdir', libfile)
-            else:
-                install('$inst_shlibdir', libfile)
+if localenv['versioned_shared_library']:
+    shlib = build(localenv.SharedLibrary(target=sharedName, source=objects,
+                                         SPAWN=get_spawn(localenv),
+                                         SHLIBVERSION=localenv['cantera_pure_version'],
+                                         LIBS=list(env['cantera_shared_libs'] + env['cxx_stdlib']),
+                                         LINK='$FORTRAN_LINK'))
+    install(localenv.InstallVersionedLib, '$inst_shlibdir', shlib)
+else:
+    shlib = build(localenv.SharedLibrary(target=sharedName, source=objects,
+                                         SPAWN=get_spawn(localenv),
+                                         LIBS=list(env['cantera_shared_libs'] + env['cxx_stdlib']),
+                                         LINK='$FORTRAN_LINK'))
+    for libfile in shlib:
+        if libfile.name.endswith(('.exp', '.lib')):
+            # On Windows, these are the export/import libraries used when linking, which
+            # should be installed in the same location as static libraries
+            install('$inst_libdir', libfile)
+        else:
+            install('$inst_shlibdir', libfile)
 
-    localenv.Depends(shlib, localenv['config_h_target'])
+localenv.Depends(shlib, localenv['config_h_target'])

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -138,7 +138,8 @@ Eigen::SparseMatrix<double> IdealGasConstPressureMoleReactor::jacobian()
         std::vector<Eigen::Triplet<double>> species_trips(dnk_dnj.nonZeros());
         for (int k = 0; k < dnk_dnj.outerSize(); k++) {
             for (Eigen::SparseMatrix<double>::InnerIterator it(dnk_dnj, k); it; ++it) {
-                species_trips.emplace_back(it.row(), it.col(), it.value());
+                species_trips.emplace_back(static_cast<int>(it.row()),
+                                           static_cast<int>(it.col()), it.value());
             }
         }
         addSurfaceJacobian(species_trips);
@@ -168,7 +169,7 @@ Eigen::SparseMatrix<double> IdealGasConstPressureMoleReactor::jacobian()
     for (int k = 0; k < dnk_dnj.outerSize(); k++) {
         for (Eigen::SparseMatrix<double>::InnerIterator it(dnk_dnj, k); it; ++it) {
             // gas phase species need the addition of  V / N * omega_dot
-            if (it.row() < m_nsp) {
+            if (static_cast<size_t>(it.row()) < m_nsp) {
                 it.valueRef() = it.value() + netProductionRates[it.row()] * molarVol;
             }
             m_jac_trips.emplace_back(static_cast<int>(it.row() + m_sidx),

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -172,7 +172,8 @@ Eigen::SparseMatrix<double> IdealGasMoleReactor::jacobian()
         std::vector<Eigen::Triplet<double>> species_trips;
         for (int k = 0; k < dnk_dnj.outerSize(); k++) {
             for (Eigen::SparseMatrix<double>::InnerIterator it(dnk_dnj, k); it; ++it) {
-                species_trips.emplace_back(it.row(), it.col(), it.value());
+                species_trips.emplace_back(static_cast<int>(it.row()),
+                                           static_cast<int>(it.col()), it.value());
             }
         }
         addSurfaceJacobian(species_trips);

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -130,7 +130,8 @@ void MoleReactor::addSurfaceJacobian(vector<Eigen::Triplet<double>> &triplets)
                         scalar /= m_vol;
                     }
                     // push back scaled value triplet
-                    triplets.emplace_back(row, col, scalar * it.value());
+                    triplets.emplace_back(static_cast<int>(row), static_cast<int>(col),
+                                          scalar * it.value());
                 }
             }
         }

--- a/test/SConscript
+++ b/test/SConscript
@@ -15,6 +15,9 @@ localenv.Prepend(CPPPATH=['#include'],
 localenv.Append(LIBS=localenv['cantera_shared_libs'],
                 CCFLAGS=env['warning_flags'])
 
+if env['python_package'] != 'full':
+    localenv.Append(CPPDEFINES={'CT_SKIP_PYTHON': '1'})
+
 if env['googletest'] == 'submodule':
     localenv.Prepend(CPPPATH=['#ext/googletest/googletest/include',
                               '#ext/googletest/googlemock/include'])

--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -533,7 +533,7 @@ TEST(Reaction, TwoTempPlasmaFromYaml)
 
 TEST(Reaction, PythonExtensibleRate)
 {
-    #ifndef CT_HAS_PYTHON
+    #ifdef CT_SKIP_PYTHON // Possibly set via test/SConscript
     GTEST_SKIP();
     #endif
     auto sol = newSolution("extensible-reactions.yaml");


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This is a companion to Cantera/conda-recipes#44 for updates that need to be made in the main Cantera repository.

*Note*: I've also pushed this branch to the `Cantera/cantera` repository to allow me to run the Conda packaging CI against this branch. This will be deleted later.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Eliminate `CT_HAS_PYTHON` preprocessor variable to enable more efficient incremental builds
- Install `cantera_shared.dll` to the `Library\bin` directory, where all the other conda package DLLs go
- Fix propagation of compiler flags for MSVC in generated `SConstruct` / `CMakeLists.txt` files
- Fix include/lib dirs in the generated build scripts (updates from #1509 were a bit too aggressive in trimming these)
- Don't use SO-versioning for the shim library used to load the Python module from C++
- Fix some compiler warnings on Windows related to integer sizes
- Fix loading the Python "shim" library when installed as a Conda package

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
