### PR TITLE
Make 1D flow domains agnostic of transport model

### DIFF
--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -42,18 +42,19 @@ public:
 
     virtual string type() const;
 
-    //! set the solving stage
-    virtual void setSolvingStage(const size_t phase);
+    virtual size_t getSolvingStage() const {
+        return m_stage;
+    }
+    virtual void setSolvingStage(const size_t stage);
 
     virtual void resize(size_t components, size_t points);
     virtual bool componentActive(size_t n) const;
 
     virtual void _finalize(const double* x);
-    //! set to solve electric field on a point
-    void solveElectricField(size_t j=npos);
-    //! set to fix voltage on a point
-    void fixElectricField(size_t j=npos);
-    bool doElectricField(size_t j) {
+
+    virtual void solveElectricField(size_t j=npos);
+    virtual void fixElectricField(size_t j=npos);
+    virtual bool doElectricField(size_t j) const {
         return m_do_electric_field[j];
     }
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -205,6 +205,26 @@ public:
 
     void solveEnergyEqn(size_t j=npos);
 
+    //! Get the solving stage (used by IonFlow specialization)
+    //! @since New in Cantera 3.0
+    virtual size_t getSolvingStage() const;
+
+    //! Solving stage mode for handling ionized species (used by IonFlow specialization)
+    //! - \c stage=1: the fluxes of charged species are set to zero
+    //! - \c stage=2: the electric field equation is solved, and the drift flux for
+    //!     ionized species is evaluated
+    virtual void setSolvingStage(const size_t stage);
+
+    //! Set to solve electric field in a point (used by IonFlow specialization)
+    virtual void solveElectricField(size_t j=npos);
+
+    //! Set to fix voltage in a point (used by IonFlow specialization)
+    virtual void fixElectricField(size_t j=npos);
+
+    //! Retrieve flag indicating whether electric field is solved or not (used by
+    //! IonFlow specialization)
+    virtual bool doElectricField(size_t j) const;
+
     //! Turn radiation on / off.
     /*!
      *  The simple radiation model used was established by Y. Liu and B. Rogg
@@ -425,9 +445,9 @@ protected:
     //! Update the diffusive mass fluxes.
     virtual void updateDiffFluxes(const doublereal* x, size_t j0, size_t j1);
 
-    //! Get the gradient of species specific molar enthalpies 
+    //! Get the gradient of species specific molar enthalpies
     virtual void grad_hk(const double* x, size_t j);
-    
+
     //---------------------------------------------------------
     //             member data
     //---------------------------------------------------------

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -77,11 +77,11 @@ cdef extern from "cantera/oneD/StFlow.h":
         double radiativeHeatLoss(size_t)
         double pressure()
         void setFixedTempProfile(vector[double]&, vector[double]&)
-        size_t getSolvingStage()
-        void setSolvingStage(size_t)
-        void solveElectricField()
-        void fixElectricField()
-        cbool doElectricField(size_t)
+        size_t getSolvingStage() except +translate_exception
+        void setSolvingStage(size_t) except +translate_exception
+        void solveElectricField() except +translate_exception
+        void fixElectricField() except +translate_exception
+        cbool doElectricField(size_t) except +translate_exception
         void setBoundaryEmissivities(double, double)
         double leftEmissivity()
         double rightEmissivity()

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -76,6 +76,11 @@ cdef extern from "cantera/oneD/StFlow.h":
         double radiativeHeatLoss(size_t)
         double pressure()
         void setFixedTempProfile(vector[double]&, vector[double]&)
+        size_t getSolvingStage()
+        void setSolvingStage(size_t)
+        void solveElectricField()
+        void fixElectricField()
+        cbool doElectricField(size_t)
         void setBoundaryEmissivities(double, double)
         double leftEmissivity()
         double rightEmissivity()
@@ -87,14 +92,6 @@ cdef extern from "cantera/oneD/StFlow.h":
         void setFreeFlow()
         void setAxisymmetricFlow()
         string flowType()
-
-
-cdef extern from "cantera/oneD/IonFlow.h":
-    cdef cppclass CxxIonFlow "Cantera::IonFlow" (CxxStFlow):
-        void setSolvingStage(int)
-        void solveElectricField()
-        void fixElectricField()
-        cbool doElectricField(size_t)
 
 
 cdef extern from "cantera/oneD/Sim1D.h":

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -69,6 +69,7 @@ cdef extern from "cantera/oneD/StFlow.h":
     cdef cppclass CxxStFlow "Cantera::StFlow" (CxxDomain1D):
         void setTransportModel(const string&) except +translate_exception
         void setTransport(CxxTransport&) except +translate_exception
+        string type()
         string transportModel()
         void setPressure(double)
         void enableRadiation(cbool)

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -737,6 +737,18 @@ cdef class _FlowBase(Domain1D):
             return pystr(self.flow.flowType())
 
     @property
+    def type(self):
+        """
+        Return the type of flow domain being represented.
+
+        Examples:
+        - ``free-flow``/``free-ion-flow``,
+        - ``axisymmetric-flow``/``axisymmetric-ion-flow``,
+        - ``unstrained-flow``/``unstrained-ion-flow``
+        """
+        return pystr(self.flow.type())
+
+    @property
     def solving_stage(self):
         """
         Solving stage mode for handling ionized species (only relevant if transport

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -63,7 +63,7 @@ class FlameBase(Sim1D):
         if isinstance(dom, Inlet1D):
             return tuple([e for e in self._other
                           if e not in {'grid', 'lambda', 'eField'}])
-        elif isinstance(dom, (FreeFlow, AxisymmetricFlow, IdealGasFlow, IonFlow)):
+        elif isinstance(dom, (FreeFlow, AxisymmetricFlow, IdealGasFlow)):
             return self._other
         else:
             return ()
@@ -1032,7 +1032,7 @@ class IonFlameBase(FlameBase):
         return self.profile(self.flame, 'eField')
 
     def solve(self, loglevel=1, refine_grid=True, auto=False, stage=1, enable_energy=True):
-        self.flame.set_solving_stage(stage)
+        self.flame.solving_stage = stage
         if stage == 1:
             super().solve(loglevel, refine_grid, auto)
         if stage == 2:
@@ -1048,8 +1048,8 @@ class IonFreeFlame(IonFlameBase, FreeFlame):
     def __init__(self, gas, grid=None, width=None):
         if not hasattr(self, 'flame'):
             # Create flame domain if not already instantiated by a child class
-            #: `IonFlow` domain representing the flame
-            self.flame = IonFlow(gas, name='flame')
+            #: `FreeFlow` domain representing the flame
+            self.flame = FreeFlow(gas, name='flame')
             self.flame.set_free_flow()
 
         super().__init__(gas, grid, width)
@@ -1197,8 +1197,8 @@ class IonBurnerFlame(IonFlameBase, BurnerFlame):
     def __init__(self, gas, grid=None, width=None):
         if not hasattr(self, 'flame'):
             # Create flame domain if not already instantiated by a child class
-            #: `IonFlow` domain representing the flame
-            self.flame = IonFlow(gas, name='flame')
+            #: `UnstrainedFlow` domain representing the flame
+            self.flame = UnstrainedFlow(gas, name='flame')
             self.flame.set_axisymmetric_flow()
 
         super().__init__(gas, grid, width)

--- a/samples/python/onedim/ion_burner_flame.py
+++ b/samples/python/onedim/ion_burner_flame.py
@@ -19,14 +19,13 @@ gas = ct.Solution('gri30_ion.yaml')
 gas.TPX = tburner, p, reactants
 mdot = 0.15 * gas.density
 
-f = ct.IonBurnerFlame(gas, width=width)
+f = ct.BurnerFlame(gas, width=width)
 f.burner.mdot = mdot
 f.set_refine_criteria(ratio=3.0, slope=0.05, curve=0.1)
 f.show()
 
-f.transport_model = 'ionized-gas'
 f.solve(loglevel, auto=True)
-f.solve(loglevel=loglevel, stage=2, enable_energy=True)
+f.solve(loglevel=loglevel, stage=2)
 
 if "native" in ct.hdf_support():
     output = Path() / "ion_burner_flame.h5"
@@ -36,4 +35,4 @@ output.unlink(missing_ok=True)
 
 f.save(output, name="mix", description="solution with mixture-averaged transport")
 
-f.save('ion_burner_flame.csv', basis="mole")
+f.save('ion_burner_flame.csv', basis="mole", overwrite=True)

--- a/samples/python/onedim/ion_free_flame.py
+++ b/samples/python/onedim/ion_free_flame.py
@@ -22,7 +22,7 @@ gas = ct.Solution('gri30_ion.yaml')
 gas.TPX = Tin, p, reactants
 
 # Set up flame object
-f = ct.IonFreeFlame(gas, width=width)
+f = ct.FreeFlame(gas, width=width)
 f.set_refine_criteria(ratio=3, slope=0.05, curve=0.1)
 f.show()
 
@@ -30,7 +30,7 @@ f.show()
 f.solve(loglevel=loglevel, auto=True)
 
 # stage two
-f.solve(loglevel=loglevel, stage=2, enable_energy=True)
+f.solve(loglevel=loglevel, stage=2)
 
 if "native" in ct.hdf_support():
     output = Path() / "ion_free_flame.h5"
@@ -44,4 +44,4 @@ f.show()
 print(f"mixture-averaged flamespeed = {f.velocity[0]:7f} m/s")
 
 # write the velocity, temperature, density, and mole fractions to a CSV file
-f.save('ion_free_flame.csv', basis="mole")
+f.save('ion_free_flame.csv', basis="mole", overwrite=True)

--- a/src/oneD/DomainFactory.cpp
+++ b/src/oneD/DomainFactory.cpp
@@ -7,6 +7,7 @@
 #include "cantera/oneD/Boundary1D.h"
 #include "cantera/oneD/StFlow.h"
 #include "cantera/oneD/IonFlow.h"
+#include "cantera/transport/Transport.h"
 
 namespace Cantera
 {
@@ -44,17 +45,32 @@ DomainFactory::DomainFactory()
         return new IonFlow(solution, id);
     });
     reg("free-flow", [](shared_ptr<Solution> solution, const string& id) {
-        StFlow* ret = new StFlow(solution, id);
+        StFlow* ret;
+        if (solution->transport()->transportModel() == "ionized-gas") {
+            ret = new IonFlow(solution, id);
+        } else {
+            ret = new StFlow(solution, id);
+        }
         ret->setFreeFlow();
         return ret;
     });
     reg("axisymmetric-flow", [](shared_ptr<Solution> solution, const string& id) {
-        StFlow* ret = new StFlow(solution, id);
+        StFlow* ret;
+        if (solution->transport()->transportModel() == "ionized-gas") {
+            ret = new IonFlow(solution, id);
+        } else {
+            ret = new StFlow(solution, id);
+        }
         ret->setAxisymmetricFlow();
         return ret;
     });
     reg("unstrained-flow", [](shared_ptr<Solution> solution, const string& id) {
-        StFlow* ret = new StFlow(solution, id);
+        StFlow* ret;
+        if (solution->transport()->transportModel() == "ionized-gas") {
+            ret = new IonFlow(solution, id);
+        } else {
+            ret = new StFlow(solution, id);
+        }
         ret->setUnstrainedFlow();
         return ret;
     });

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -78,7 +78,10 @@ string IonFlow::type() const {
     if (m_isFree) {
         return "free-ion-flow";
     }
-    return "stagnation-ion-flow";
+    if (m_usesLambda) {
+        return "axisymmetric-ion-flow";
+    }
+    return "unstrained-ion-flow";
 }
 
 void IonFlow::resize(size_t components, size_t points){

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -564,14 +564,14 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
                 setGas(x,j);
                 double dtdzj = dTdz(x,j);
                 double sum = 0.0;
-                
+
                 grad_hk(x, j);
                 for (size_t k = 0; k < m_nsp; k++) {
                     double flxk = 0.5*(m_flux(k,j-1) + m_flux(k,j));
                     sum += wdot(k,j)*m_hk(k,j);
                     sum += flxk * m_dhk_dz(k,j) / m_wt[k];
                 }
-                
+
                 rsd[index(c_offset_T, j)] = - m_cp[j]*rho_u(x,j)*dtdzj
                                             - divHeatFlux(x,j) - sum;
                 rsd[index(c_offset_T, j)] /= (m_rho[j]*m_cp[j]);
@@ -942,6 +942,36 @@ void StFlow::solveEnergyEqn(size_t j)
     }
 }
 
+size_t StFlow::getSolvingStage() const
+{
+    throw NotImplementedError("StFlow::getSolvingStage",
+        "Not used by '{}' objects.", type());
+}
+
+void StFlow::setSolvingStage(const size_t stage)
+{
+    throw NotImplementedError("StFlow::setSolvingStage",
+        "Not used by '{}' objects.", type());
+}
+
+void StFlow::solveElectricField(size_t j)
+{
+    throw NotImplementedError("StFlow::solveElectricField",
+        "Not used by '{}' objects.", type());
+}
+
+void StFlow::fixElectricField(size_t j)
+{
+    throw NotImplementedError("StFlow::fixElectricField",
+        "Not used by '{}' objects.", type());
+}
+
+bool StFlow::doElectricField(size_t j) const
+{
+    throw NotImplementedError("StFlow::doElectricField",
+        "Not used by '{}' objects.", type());
+}
+
 void StFlow::setBoundaryEmissivities(doublereal e_left, doublereal e_right)
 {
     if (e_left < 0 || e_left > 1) {
@@ -1047,7 +1077,7 @@ void StFlow::evalContinuity(size_t j, double* x, double* rsd, int* diag, double 
     }
 }
 
-void StFlow::grad_hk(const double* x, size_t j) 
+void StFlow::grad_hk(const double* x, size_t j)
 {
     for(size_t k = 0; k < m_nsp; k++) {
         if (u(x, j) > 0.0) {

--- a/test/oneD/test_oneD.cpp
+++ b/test/oneD/test_oneD.cpp
@@ -5,6 +5,7 @@
 #include "cantera/core.h"
 #include "cantera/onedim.h"
 #include "cantera/oneD/DomainFactory.h"
+#include "cantera/oneD/IonFlow.h"
 
 using namespace Cantera;
 
@@ -34,8 +35,7 @@ TEST(onedim, freeflame)
     double Tad = gas->temperature();
 
     // flow
-    auto flow = newDomain<StFlow>("gas-flow", sol, "flow");
-    flow->setFreeFlow();
+    auto flow = newDomain<StFlow>("free-flow", sol, "flow");
 
     // grid
     int nz = 21;
@@ -102,6 +102,30 @@ TEST(onedim, freeflame)
     }
 }
 
+TEST(onedim, flame_types)
+{
+    auto sol = newSolution("h2o2.yaml", "ohmech", "mixture-averaged");
+
+    auto free = newDomain<StFlow>("free-flow", sol, "flow");
+    ASSERT_EQ(free->type(), "free-flow");
+    auto symm = newDomain<StFlow>("axisymmetric-flow", sol, "flow");
+    ASSERT_EQ(symm->type(), "axisymmetric-flow");
+    auto burner = newDomain<StFlow>("unstrained-flow", sol, "flow");
+    ASSERT_EQ(burner->type(), "unstrained-flow");
+}
+
+TEST(onedim, ion_flame_types)
+{
+    auto sol = newSolution("ch4_ion.yaml", "", "");
+    ASSERT_EQ(sol->transport()->transportModel(), "ionized-gas");
+
+    auto free = newDomain<IonFlow>("free-flow", sol, "flow");
+    ASSERT_EQ(free->type(), "free-ion-flow");
+    auto symm = newDomain<IonFlow>("axisymmetric-flow", sol, "flow");
+    ASSERT_EQ(symm->type(), "axisymmetric-ion-flow");
+    auto burner = newDomain<IonFlow>("unstrained-flow", sol, "flow");
+    ASSERT_EQ(burner->type(), "unstrained-ion-flow");
+}
 
 int main(int argc, char** argv)
 {

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -1684,17 +1684,17 @@ class TestIonFreeFlame(utilities.CanteraTest):
         # Solution object used to compute mixture properties
         self.gas = ct.Solution('ch4_ion.yaml')
         self.gas.TPX = Tin, p, reactants
-        self.sim = ct.IonFreeFlame(self.gas, width=width)
+        self.sim = ct.FreeFlame(self.gas, width=width)
+        assert self.sim.transport_model == 'ionized-gas'
         self.sim.set_refine_criteria(ratio=4, slope=0.8, curve=1.0)
         # Ionized species may require tighter absolute tolerances
         self.sim.flame.set_steady_tolerances(Y=(1e-4, 1e-12))
-        self.sim.transport_model = 'ionized-gas'
 
         # stage one
         self.sim.solve(loglevel=0, auto=True)
 
         #stage two
-        self.sim.solve(loglevel=0, stage=2, enable_energy=True)
+        self.sim.solve(loglevel=0, stage=2)
 
         # Regression test
         self.assertNear(max(self.sim.E), 142.666221, 1e-3)
@@ -1710,10 +1710,10 @@ class TestIonBurnerFlame(utilities.CanteraTest):
         # Solution object used to compute mixture properties
         self.gas = ct.Solution('ch4_ion.yaml')
         self.gas.TPX = Tburner, p, reactants
-        self.sim = ct.IonBurnerFlame(self.gas, width=width)
+        self.sim = ct.BurnerFlame(self.gas, width=width)
+        assert self.sim.transport_model == 'ionized-gas'
         self.sim.set_refine_criteria(ratio=4, slope=0.1, curve=0.1)
         self.sim.burner.mdot = self.gas.density * 0.15
-        self.sim.transport_model = 'ionized-gas'
 
         self.sim.solve(loglevel=0, stage=2, auto=True)
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Switch between `StFlow` and `IonFlow` in C++ factory constructors. This allows for the following:

- Absorb `IonFlow` behavior in conventional `FreeFlow`/`UnstrainedFlow`/`AxisymmetricFlow`
- Absorb `IonFreeFlame` in `FreeFlame`
- Absorb `IonBurnerFlame` in `BurnerFlame`
- Deprecate all "ion" specializations in the user-facing API

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#165

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```Python
# Instantiate Solution with 'ionized-gas' transport model
gas = ct.Solution('gri30_ion.yaml')
gas.TPX = Tin, p, reactants

# Set up flame object - automatically sets up correct flow domain model
f = ct.FreeFlame(gas, width=width)
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
