### PR TITLE
Update reactor API

### DIFF
--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -51,7 +51,9 @@ extern "C" {
     CANTERA_CAPI int flowdev_new(const char* type);
     CANTERA_CAPI int flowdev_del(int i);
     CANTERA_CAPI int flowdev_install(int i, int n, int m);
+    //! @deprecated To be removed after Cantera 3.0; replaced by flowdev_setPrimary
     CANTERA_CAPI int flowdev_setMaster(int i, int n);
+    CANTERA_CAPI int flowdev_setPrimary(int i, int n);
     CANTERA_CAPI double flowdev_massFlowRate(int i);
     CANTERA_CAPI int flowdev_setMassFlowCoeff(int i, double v);
     CANTERA_CAPI int flowdev_setValveCoeff(int i, double v);
@@ -62,8 +64,16 @@ extern "C" {
     CANTERA_CAPI int wall_new(const char* type);
     CANTERA_CAPI int wall_del(int i);
     CANTERA_CAPI int wall_install(int i, int n, int m);
+    //! @deprecated To be changed after Cantera 3.0; for new behavior, see wall_vdot3,
+    //!     to continue old behavior, use wall_vdot2.
     CANTERA_CAPI double wall_vdot(int i, double t);
+    CANTERA_CAPI double wall_vdot3(int i);
+    CANTERA_CAPI double wall_vdot2(int i, double t);
+    //! @deprecated To be removed after Cantera 3.0; for new behavior, see wall_qdot,
+    //!     to continue old behavior, use wall_qdot2.
     CANTERA_CAPI double wall_Q(int i, double t);
+    CANTERA_CAPI double wall_qdot(int i);
+    CANTERA_CAPI double wall_qdot2(int i, double t);
     CANTERA_CAPI double wall_area(int i);
     CANTERA_CAPI int wall_setArea(int i, double v);
     CANTERA_CAPI int wall_setThermalResistance(int i, double rth);

--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -64,16 +64,12 @@ extern "C" {
     CANTERA_CAPI int wall_new(const char* type);
     CANTERA_CAPI int wall_del(int i);
     CANTERA_CAPI int wall_install(int i, int n, int m);
-    //! @deprecated To be changed after Cantera 3.0; for new behavior, see wall_vdot3,
-    //!     to continue old behavior, use wall_vdot2.
+    //! @deprecated Only used by traditional MATLAB toolbox
     CANTERA_CAPI double wall_vdot(int i, double t);
-    CANTERA_CAPI double wall_vdot3(int i);
-    CANTERA_CAPI double wall_vdot2(int i, double t);
-    //! @deprecated To be removed after Cantera 3.0; for new behavior, see wall_qdot,
-    //!     to continue old behavior, use wall_qdot2.
+    CANTERA_CAPI double wall_expansionRate(int i);
+    //! @deprecated Only used by traditional MATLAB toolbox
     CANTERA_CAPI double wall_Q(int i, double t);
-    CANTERA_CAPI double wall_qdot(int i);
-    CANTERA_CAPI double wall_qdot2(int i, double t);
+    CANTERA_CAPI double wall_heatRate(int i);
     CANTERA_CAPI double wall_area(int i);
     CANTERA_CAPI int wall_setArea(int i, double v);
     CANTERA_CAPI int wall_setThermalResistance(int i, double rth);

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -132,7 +132,7 @@ public:
         return "functor";
     }
 
-    //! Returns a string describing the type of the function
+    //! Returns a string with the class name of the functor
     //! @since  New in Cantera 3.0.
     string typeName() const;
 

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -85,7 +85,7 @@ public:
      * The calculation of mass flow rate depends to the flow device.
      * @since New in Cantera 3.0.
      */
-    double getPressureFunction();
+    double evalPressureFunction();
 
     //! Set a function of pressure that is used in determining the
     //! mass flow rate through the device. The evaluation of mass flow
@@ -99,7 +99,7 @@ public:
      * The calculation of mass flow rate depends on the flow device.
      * @since New in Cantera 3.0.
      */
-    double getTimeFunction();
+    double evalTimeFunction();
 
     //! Set a function of time that is used in determining
     //! the mass flow rate through the device. The evaluation of mass flow

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -77,15 +77,42 @@ public:
         return *m_out;
     }
 
+    //! Return current value of the pressure function.
+    /*!
+     * The mass flow rate [kg/s] is calculated given the pressure drop [Pa] and a
+     * coefficient set by a flow device specific function; unless a user-defined
+     * pressure function is set, this is the pressure difference across the device.
+     * The calculation of mass flow rate depends to the flow device.
+     * @since New in Cantera 3.0.
+     */
+    double getPressureFunction();
+
     //! Set a function of pressure that is used in determining the
     //! mass flow rate through the device. The evaluation of mass flow
     //! depends on the derived flow device class.
     virtual void setPressureFunction(Func1* f);
 
+    //! Return current value of the time function.
+    /*!
+     * The mass flow rate [kg/s] is calculated for a Flow device, and multiplied by a
+     * function of time, which returns 1.0 unless a user-defined function is provided.
+     * The calculation of mass flow rate depends on the flow device.
+     * @since New in Cantera 3.0.
+     */
+    double getTimeFunction();
+
     //! Set a function of time that is used in determining
     //! the mass flow rate through the device. The evaluation of mass flow
     //! depends on the derived flow device class.
     virtual void setTimeFunction(Func1* g);
+
+    //! Set current reactor network time
+    /*!
+     * @since New in Cantera 3.0.
+     */
+    void setSimTime(double time) {
+        m_time = time;
+    }
 
 protected:
     double m_mdot = Undef;
@@ -98,6 +125,9 @@ protected:
 
     //! Coefficient set by derived classes; used by updateMassFlowRate
     double m_coeff = 1.0;
+
+    //! Current reactor network time
+    double m_time = 0.;
 
 private:
     size_t m_nspin = 0;

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -261,8 +261,8 @@ protected:
     //! Update the state of SurfPhase objects attached to this reactor
     virtual void updateSurfaceState(double* y);
 
-    //! Update the state information needed by connected reactors and flow
-    //! devices. Called from updateState().
+    //! Update the state information needed by connected reactors, flow devices,
+    //! and reactor walls. Called from updateState().
     //! @param updatePressure  Indicates whether to update #m_pressure. Should
     //!     `true` for reactors where the pressure is a dependent property,
     //!     calculated from the state, and `false` when the pressure is constant

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -29,21 +29,21 @@ public:
     virtual void setNEq(size_t n) = 0;
 
     //! Get the net rate of volume change (for example, from moving walls) [m^3/s]
-    virtual double vdot() const = 0;
+    virtual double expansionRate() const = 0;
 
     //! Set the net rate of volume change (for example, from moving walls) [m^3/s]
-    virtual void setVdot(double v) = 0;
+    virtual void setExpansionRate(double v) = 0;
 
     //! Get the net heat transfer rate (for example, through walls) into the
     //! reactor [W]. This value is initialized and calculated as part of
     //! Reactor::evalWalls().
-    virtual double qdot() const = 0;
+    virtual double heatRate() const = 0;
 
     //! Set the net heat transfer rate (for example, through walls) into the
     //! reactor [W]. For a value set using this method to affect the calculations done
     //! by Reactor::eval, this method should be called in either a "replace" or "after"
     //! delegate for Reactor::evalWalls().
-    virtual void setQdot(double q) = 0;
+    virtual void setHeatRate(double q) = 0;
 
     //! Set the state of the thermo object to correspond to the state of the reactor
     virtual void restoreThermoState() = 0;
@@ -160,19 +160,19 @@ public:
         R::m_nv = n;
     }
 
-    virtual double vdot() const override {
+    virtual double expansionRate() const override {
         return R::m_vdot;
     }
 
-    virtual void setVdot(double v) override {
+    virtual void setExpansionRate(double v) override {
         R::m_vdot = v;
     }
 
-    virtual double qdot() const override {
+    virtual double heatRate() const override {
         return R::m_Qdot;
     }
 
-    virtual void setQdot(double q) override {
+    virtual void setHeatRate(double q) override {
         R::m_Qdot = q;
     }
 

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -51,6 +51,14 @@ public:
     //! state as the initial condition.
     void setInitialTime(double time);
 
+    //! Get the initial value of the independent variable (typically time).
+    /*!
+     * @since New in Cantera 3.0.
+     */
+    double getInitialTime() const {
+        return m_initial_time;
+    }
+
     //! Get the maximum integrator step.
     double maxTimeStep() {
         return m_maxstep;
@@ -315,6 +323,9 @@ protected:
     //! The independent variable in the system. May be either time or space depending
     //! on the type of reactors in the network.
     double m_time = 0.0;
+
+    //! The initial value of the independent variable in the system.
+    double m_initial_time = 0.0;
 
     bool m_init = false;
     bool m_integrator_init = false; //!< True if integrator initialization is current

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -45,6 +45,12 @@ public:
         return 0.0;
     }
 
+    //! Rate of volume change (m^3/s) for the adjacent reactors at current reactor
+    //! network time.
+    double vdot() {
+        return vdot(m_time);
+    }
+
     //! Heat flow rate through the wall (W).
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
@@ -52,6 +58,11 @@ public:
      */
     virtual double Q(double t) {
         return 0.0;
+    }
+
+    //! Heat flow rate through the wall (W) at current reactor network time.
+    double qdot() {
+        return Q(m_time);
     }
 
     //! Area in (m^2).
@@ -83,11 +94,19 @@ public:
         return *m_right;
     }
 
+    //! Set current reactor network time
+    void setSimTime(double time) {
+        m_time = time;
+    }
+
 protected:
     ReactorBase* m_left = nullptr;
     ReactorBase* m_right = nullptr;
 
     std::vector<ReactorSurface> m_surf;
+
+    //! current reactor network time
+    double m_time = 0.0;
 
     double m_area = 1.0;
 };
@@ -108,6 +127,9 @@ public:
         return "Wall";
     }
 
+    //! Wall velocity \f$ v(t) \f$ at current reactor network time.
+    double velocity() const;
+
     //! Set the wall velocity to a specified function of time, \f$ v(t) \f$.
     void setVelocity(Func1* f=0) {
         if (f) {
@@ -127,6 +149,9 @@ public:
      * decreases in the volume of the reactor on the right.
      */
     virtual double vdot(double t);
+
+    //! Heat flux function \f$ q_0(t) \f$ evaluated at current reactor network time.
+    double heatFlux() const;
 
     //! Specify the heat flux function \f$ q_0(t) \f$.
     void setHeatFlux(Func1* q) {

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -47,6 +47,9 @@ public:
 
     //! Rate of volume change (m^3/s) for the adjacent reactors at current reactor
     //! network time.
+    /*!
+     * @since New in Cantera 3.0.
+     */
     double vdot() {
         return vdot(m_time);
     }
@@ -67,13 +70,16 @@ public:
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
      * does nothing (that is, an adiabatic wall), but may be overloaded.
-     * @since Cantera 3.0
+     * @since New in Cantera 3.0
      */
     virtual double qdot(double t) {
         return 0.0;
     }
 
     //! Heat flow rate through the wall (W) at current reactor network time.
+    /*!
+     * @since New in Cantera 3.0.
+     */
     double qdot() {
         return qdot(m_time);
     }
@@ -108,6 +114,9 @@ public:
     }
 
     //! Set current reactor network time
+    /*!
+     * @since New in Cantera 3.0.
+     */
     void setSimTime(double time) {
         m_time = time;
     }

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -55,14 +55,27 @@ public:
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
      * does nothing (that is, an adiabatic wall), but may be overloaded.
+     * @deprecated To be removed after Cantera 2.6; replaced by qdot(double).
      */
-    virtual double Q(double t) {
+    double Q(double t) {
+        warn_deprecated("WallBase::Q",
+            "To be removed after Cantera 3.0; replaced by qdot(double).");
+        return qdot(t);
+    }
+
+    //! Heat flow rate through the wall (W).
+    /*!
+     * This method is called by Reactor::evalWalls(). Base class method
+     * does nothing (that is, an adiabatic wall), but may be overloaded.
+     * @since Cantera 3.0
+     */
+    virtual double qdot(double t) {
         return 0.0;
     }
 
     //! Heat flow rate through the wall (W) at current reactor network time.
     double qdot() {
-        return Q(m_time);
+        return qdot(m_time);
     }
 
     //! Area in (m^2).
@@ -168,7 +181,7 @@ public:
      * *G(t)* is a specified function of time. Positive values denote a flux
      * from left to right.
      */
-    virtual double Q(double t);
+    virtual double qdot(double t);
 
     void setThermalResistance(double Rth) {
         m_rrth = 1.0/Rth;

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -40,48 +40,45 @@ public:
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
      * does nothing (that is, constant volume), but may be overloaded.
+     * @deprecated To be removed after Cantera 3.0; replaceable by expansionRate.
      */
     virtual double vdot(double t) {
+        warn_deprecated("WallBase::vdot",
+            "To be removed after Cantera 3.0; replaceable by 'expansionRate'.");
         return 0.0;
     }
 
     //! Rate of volume change (m^3/s) for the adjacent reactors at current reactor
     //! network time.
     /*!
+     * This method is called by Reactor::evalWalls(). Base class method
+     * does nothing (that is, constant volume), but may be overloaded.
      * @since New in Cantera 3.0.
      */
-    double vdot() {
-        return vdot(m_time);
+    virtual double expansionRate() {
+        return 0.0;
     }
 
     //! Heat flow rate through the wall (W).
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
      * does nothing (that is, an adiabatic wall), but may be overloaded.
-     * @deprecated To be removed after Cantera 2.6; replaced by qdot(double).
+     * @deprecated To be removed after Cantera 3.0; replaceable by heatRate.
      */
-    double Q(double t) {
+    virtual double Q(double t) {
         warn_deprecated("WallBase::Q",
-            "To be removed after Cantera 3.0; replaced by qdot(double).");
-        return qdot(t);
-    }
-
-    //! Heat flow rate through the wall (W).
-    /*!
-     * This method is called by Reactor::evalWalls(). Base class method
-     * does nothing (that is, an adiabatic wall), but may be overloaded.
-     * @since New in Cantera 3.0
-     */
-    virtual double qdot(double t) {
+            "To be removed after Cantera 3.0; replaceable by 'heatRate'.");
         return 0.0;
     }
 
     //! Heat flow rate through the wall (W) at current reactor network time.
     /*!
+     * This method is called by Reactor::evalWalls(). Base class method
+     * does nothing (that is, an adiabatic wall), but may be overloaded.
      * @since New in Cantera 3.0.
      */
-    double qdot() {
-        return qdot(m_time);
+    virtual double heatRate() {
+        return 0.0;
     }
 
     //! Area in (m^2).
@@ -150,6 +147,7 @@ public:
     }
 
     //! Wall velocity \f$ v(t) \f$ at current reactor network time.
+    //! @since New in Cantera 3.0.
     double velocity() const;
 
     //! Set the wall velocity to a specified function of time, \f$ v(t) \f$.
@@ -169,10 +167,27 @@ public:
      * area, and *F(t)* is a specified function of time. Positive values for
      * `vdot` correspond to increases in the volume of reactor on left, and
      * decreases in the volume of the reactor on the right.
+     * @deprecated Still used by traditional MATLAB toolbox; replaceable by
+     *      expansionRate.
      */
     virtual double vdot(double t);
 
+    //! Rate of volume change (m^3/s) for the adjacent reactors.
+    /*!
+     * The volume rate of change is given by
+     * \f[
+     *     \dot V = K A (P_{left} - P_{right}) + F(t)
+     * \f]
+     * where *K* is the specified expansion rate coefficient, *A* is the wall area,
+     * and and *F(t)* is a specified function evaluated at the current network time.
+     * Positive values for `expansionRate` correspond to increases in the volume of
+     * reactor on left, and decreases in the volume of the reactor on the right.
+     * @since New in Cantera 3.0.
+     */
+    virtual double expansionRate();
+
     //! Heat flux function \f$ q_0(t) \f$ evaluated at current reactor network time.
+    //! @since New in Cantera 3.0.
     double heatFlux() const;
 
     //! Specify the heat flux function \f$ q_0(t) \f$.
@@ -189,8 +204,22 @@ public:
      * where *h* is the heat transfer coefficient, *A* is the wall area, and
      * *G(t)* is a specified function of time. Positive values denote a flux
      * from left to right.
+     * @deprecated Still used by traditional MATLAB toolbox; replaceable by heatRate.
      */
-    virtual double qdot(double t);
+    virtual double Q(double t);
+
+    //! Heat flow rate through the wall (W).
+    /*!
+     * The heat flux is given by
+     * \f[
+     *     Q = h A (T_{left} - T_{right}) + A G(t)
+     * \f]
+     * where *h* is the heat transfer coefficient, *A* is the wall area, and
+     * *G(t)* is a specified function of time evaluated at the current network
+     * time. Positive values denote a flux from left to right.
+     * @since New in Cantera 3.0.
+     */
+    virtual double heatRate();
 
     void setThermalResistance(double Rth) {
         m_rrth = 1.0/Rth;

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -57,7 +57,7 @@ public:
 
 /**
  * A class for flow controllers where the flow rate is equal to the flow rate
- * of a "master" mass flow controller plus a correction proportional to the
+ * of a primary mass flow controller plus a correction proportional to the
  * pressure difference between the inlet and outlet.
  */
 class PressureController : public FlowDevice
@@ -69,14 +69,16 @@ public:
         return "PressureController";
     }
 
-
     virtual bool ready() {
-        return FlowDevice::ready() && m_master != 0;
+        return FlowDevice::ready() && m_primary != 0;
     }
 
-    void setMaster(FlowDevice* master) {
-        m_master = master;
+    void setPrimary(FlowDevice* primary) {
+        m_primary = primary;
     }
+
+    //! @deprecated To be removed after Cantera 3.0; replaced by setPrimary.
+    void setMaster(FlowDevice* master);
 
     virtual void setTimeFunction(Func1* g) {
         throw NotImplementedError("PressureController::setTimeFunction");
@@ -86,11 +88,11 @@ public:
     //! rate
     /*!
      * *c* has units of kg/s/Pa. The mass flow rate is computed as:
-     * \f[\dot{m} = \dot{m}_{master} + c f(\Delta P) \f]
+     * \f[\dot{m} = \dot{m}_{primary} + c f(\Delta P) \f]
      * where *f* is a functions of pressure drop that is set by
      * `setPressureFunction`. If no functions is specified, the mass flow
      * rate defaults to:
-     * \f[\dot{m} = \dot{m}_{master} + c \Delta P \f]
+     * \f[\dot{m} = \dot{m}_{primary} + c \Delta P \f]
      */
     void setPressureCoeff(double c) {
         m_coeff = c;
@@ -104,7 +106,7 @@ public:
     virtual void updateMassFlowRate(double time);
 
 protected:
-    FlowDevice* m_master = nullptr;
+    FlowDevice* m_primary = nullptr;
 };
 
 //! Supply a mass flow rate that is a function of the pressure drop across the

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -73,6 +73,10 @@ public:
         return FlowDevice::ready() && m_primary != 0;
     }
 
+    //! Set the primary mass flow controller.
+    /*!
+     * @since New in Cantera 3.0.
+     */
     void setPrimary(FlowDevice* primary) {
         m_primary = primary;
     }

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -94,8 +94,10 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void setCoverages(int, double*)
         void setCoverages(int, Composition&) except +translate_exception
         void syncCoverages(int)
+        double vdot()
         double vdot(double)
-        double Q(double)
+        double qdot()
+        double qdot(double)
 
         void addSensitivityReaction(int, size_t) except +translate_exception
         size_t nSensParams(int)
@@ -108,7 +110,9 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         double getHeatTransferCoeff()
         void setEmissivity(double) except +translate_exception
         double getEmissivity()
+        double velocity()
         void setVelocity(CxxFunc1*)
+        double heatFlux()
         void setHeatFlux(CxxFunc1*)
 
     # reactor surface
@@ -132,7 +136,9 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         double massFlowRate() except +translate_exception
         double massFlowRate(double) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&) except +translate_exception
+        double getPressureFunction()
         void setPressureFunction(CxxFunc1*) except +translate_exception
+        double getTimeFunction()
         void setTimeFunction(CxxFunc1*) except +translate_exception
 
     cdef cppclass CxxMassFlowController "Cantera::MassFlowController" (CxxFlowDevice):
@@ -150,7 +156,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         CxxPressureController()
         double getPressureCoeff()
         void setPressureCoeff(double)
-        void setMaster(CxxFlowDevice*)
+        void setPrimary(CxxFlowDevice*)
 
     # reactor net
 
@@ -164,6 +170,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         double time() except +translate_exception
         double distance() except +translate_exception
         void setInitialTime(double)
+        double getInitialTime()
         void setTolerances(double, double)
         double rtol()
         double atol()

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -94,10 +94,10 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void setCoverages(int, double*)
         void setCoverages(int, Composition&) except +translate_exception
         void syncCoverages(int)
-        double vdot()
-        double vdot(double)
-        double qdot()
-        double qdot(double)
+        double expansionRate() except +translate_exception
+        double vdot(double) except +translate_exception
+        double heatRate() except +translate_exception
+        double Q(double) except +translate_exception
 
         void addSensitivityReaction(int, size_t) except +translate_exception
         size_t nSensParams(int)
@@ -136,9 +136,9 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         double massFlowRate() except +translate_exception
         double massFlowRate(double) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&) except +translate_exception
-        double getPressureFunction()
+        double evalPressureFunction() except +translate_exception
         void setPressureFunction(CxxFunc1*) except +translate_exception
-        double getTimeFunction()
+        double evalTimeFunction() except +translate_exception
         void setTimeFunction(CxxFunc1*) except +translate_exception
 
     cdef cppclass CxxMassFlowController "Cantera::MassFlowController" (CxxFlowDevice):

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -206,10 +206,10 @@ cdef extern from "cantera/zeroD/ReactorDelegator.h" namespace "Cantera":
     cdef cppclass CxxReactorAccessor "Cantera::ReactorAccessor":
         CxxReactorAccessor()
         void setNEq(size_t)
-        double vdot()
-        void setVdot(double)
-        double qdot()
-        void setQdot(double)
+        double expansionRate()
+        void setExpansionRate(double)
+        double heatRate()
+        void setHeatRate(double)
         void restoreThermoState() except +translate_exception
         void restoreSurfaceState(size_t) except +translate_exception
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -912,7 +912,7 @@ cdef class WallBase:
             self.wall.setArea(value)
 
     @property
-    def vdot3(self):
+    def expansion_rate(self):
         """
         Get the rate of volumetric change [m^3/s] associated with the wall at the
         current reactor network time. A positive value corresponds to the left-hand
@@ -920,7 +920,7 @@ cdef class WallBase:
 
         .. versionadded:: 3.0
         """
-        return self.wall.vdot()
+        return self.wall.expansionRate()
 
     def vdot(self, double t):
         """
@@ -930,23 +930,20 @@ cdef class WallBase:
 
         .. deprecated:: 3.0
 
-            To be changed after Cantera 3.0; for new behavior, see property ``vdot3``.
+            To be removed after Cantera 3.0; replaceable by ``expansion_rate``.
         """
-        warnings.warn(
-            "To be changed after Cantera 3.0; for new behavior, see property 'vdot3'.",
-            DeprecationWarning)
         return self.wall.vdot(t)
 
     @property
-    def qdot3(self):
+    def heat_rate(self):
         """
         Get the total heat flux [W] through the wall  at the current reactor network
-        time. A positive value corresponds to the left-hand reactor volume increasing,
-        and the right-hand reactor volume decreasing.
+        time. A positive value corresponds to heat flowing from the left-hand reactor
+        to the right-hand one.
 
         .. versionadded:: 3.0
         """
-        return self.wall.qdot()
+        return self.wall.heatRate()
 
     def qdot(self, double t):
         """
@@ -956,12 +953,9 @@ cdef class WallBase:
 
         .. deprecated:: 3.0
 
-            To be changed after Cantera 3.0; for new behavior, see property ``qdot3``.
+            To be removed after Cantera 3.0; replaceable by ``heat_rate``.
         """
-        warnings.warn(
-            "To be changed after Cantera 3.0; for new behavior, see property 'qdot3'.",
-            DeprecationWarning)
-        return self.wall.qdot(t)
+        return self.wall.Q(t)
 
 
 cdef class Wall(WallBase):
@@ -1158,7 +1152,7 @@ cdef class FlowDevice:
 
         .. versionadded:: 3.0
         """
-        return self.dev.getPressureFunction()
+        return self.dev.evalPressureFunction()
 
     @pressure_function.setter
     def pressure_function(self, k):
@@ -1205,7 +1199,7 @@ cdef class FlowDevice:
 
         .. versionadded:: 3.0
         """
-        return self.dev.getTimeFunction()
+        return self.dev.evalTimeFunction()
 
     @time_function.setter
     def time_function(self, k):

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -595,8 +595,8 @@ cdef class ExtensibleReactor(Reactor):
         `n_vars`.
 
     ``eval_walls(self, t : double) -> None``
-        Responsible for calculating the net rate of volume change `vdot`
-        and the net rate of heat transfer `qdot` caused by walls connected
+        Responsible for calculating the net rate of volume change `expansion_rate`
+        and the net rate of heat transfer `heat_rate` caused by walls connected
         to this reactor.
 
     ``eval_surfaces(LHS : double[:], RHS : double[:], sdot : double[:]) -> None``
@@ -654,20 +654,66 @@ cdef class ExtensibleReactor(Reactor):
     property vdot:
         """
         Get/Set the net rate of volume change (for example, from moving walls) [m^3/s]
+
+        .. deprecated:: 3.0
+
+            To be removed in Cantera 3.0; renamed to `expansion_rate`.
         """
         def __get__(self):
-            return self.accessor.vdot()
+            warnings.warn(
+                "ExtensibleReactor.vdot: To be removed in Cantera 3.0; "
+                "renamed to 'expansion_rate'.", DeprecationWarning)
+            return self.accessor.expansionRate()
         def __set__(self, vdot):
-            self.accessor.setVdot(vdot)
+            warnings.warn(
+                "ExtensibleReactor.vdot: To be removed in Cantera 3.0; "
+                "renamed to 'expansion_rate'.", DeprecationWarning)
+            self.accessor.setExpansionRate(vdot)
+
+    @property
+    def expansion_rate(self):
+        """
+        Get/Set the net rate of volume change (for example, from moving walls) [m^3/s]
+
+        .. versionadded:: 3.0
+        """
+        return self.accessor.expansionRate()
+
+    @expansion_rate.setter
+    def expansion_rate(self, vdot):
+        self.accessor.setExpansionRate(vdot)
 
     property qdot:
         """
         Get/Set the net heat transfer rate (for example, through walls) [W]
+
+        .. deprecated:: 3.0
+
+            To be removed in Cantera 3.0; renamed to `heat_rate`.
         """
         def __get__(self):
-            return self.accessor.qdot()
+            warnings.warn(
+                "ExtensibleReactor.qdot: To be removed in Cantera 3.0; "
+                "renamed to 'heat_rate'.", DeprecationWarning)
+            return self.accessor.heatRate()
         def __set__(self, qdot):
-            self.accessor.setQdot(qdot)
+            warnings.warn(
+                "ExtensibleReactor.qdot: To be removed in Cantera 3.0; "
+                "renamed to 'heat_rate'.", DeprecationWarning)
+            self.accessor.setHeatRate(qdot)
+
+    @property
+    def heat_rate(self):
+        """
+        Get/Set the net heat transfer rate (for example, through walls) [W]
+
+        .. versionadded:: 3.0
+        """
+        return self.accessor.heatRate()
+
+    @heat_rate.setter
+    def heat_rate(self, qdot):
+        self.accessor.setHeatRate(qdot)
 
     def restore_thermo_state(self):
         """

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -1088,8 +1088,8 @@ cdef class Wall(WallBase):
             Replaced by the ``velocity`` property.
         """
         warnings.warn(
-            "To be removed after Cantera 3.0; replaced by property 'velocity'.",
-            DeprecationWarning)
+            "Wall.set_velocity: To be removed after Cantera 3.0; replaced by property "
+            "'velocity'.", DeprecationWarning)
         self.velocity = v
 
     @property
@@ -1123,8 +1123,8 @@ cdef class Wall(WallBase):
             Replaced by the ``heat_flux`` property.
         """
         warnings.warn(
-            "To be removed after Cantera 3.0; replaced by property 'heat_flux'.",
-            DeprecationWarning)
+            "Wall.set_heat_flux: To be removed after Cantera 3.0; replaced by property "
+            "'heat_flux'.", DeprecationWarning)
         self.heat_flux = q
 
 
@@ -1226,8 +1226,8 @@ cdef class FlowDevice:
             To be removed after Cantera 3.0. Use property ``pressure_function`` instead.
         """
         warnings.warn(
-            "To be removed after Cantera 3.0; replaced by 'pressure_function'.",
-            DeprecationWarning)
+            "FlowDevice.set_pressure_function: To be removed after Cantera 3.0; "
+            "replaced by 'pressure_function'.", DeprecationWarning)
         self.pressure_function = k
 
     @property
@@ -1272,8 +1272,8 @@ cdef class FlowDevice:
             To be removed after Cantera 3.0. Use property ``time_function`` instead.
         """
         warnings.warn(
-            "To be removed after Cantera 3.0; replaced by 'time_function'.",
-            DeprecationWarning)
+            "FlowDevice.set_time_function: To be removed after Cantera 3.0; "
+            "replaced by 'time_function'.", DeprecationWarning)
         self.time_function = k
 
 
@@ -1421,8 +1421,9 @@ cdef class PressureController(FlowDevice):
     def __init__(self, upstream, downstream, *,
             name=None, primary=None, K=1., **kwargs):
         if "master" in kwargs:
-            warnings.warn("The 'master' keyword argument is deprecated; "
-                          "use 'primary' instead.", DeprecationWarning)
+            warnings.warn(
+                "PressureController: The 'master' keyword argument is deprecated; "
+                "use 'primary' instead.", DeprecationWarning)
             primary = kwargs["master"]
         super().__init__(upstream, downstream, name=name)
         if primary is not None:
@@ -1465,8 +1466,9 @@ cdef class PressureController(FlowDevice):
 
             To be removed after Cantera 3.0; replaced by property ``primary``.
         """
-        warnings.warn("To be removed after Cantera 3.0; replaced by 'primary'.",
-                      DeprecationWarning)
+        warnings.warn(
+            "PressureController.set_master: To be removed after Cantera 3.0; "
+            "replaced by 'primary'.", DeprecationWarning)
         self.primary = d
 
 
@@ -1568,8 +1570,8 @@ cdef class ReactorNet:
             To be removed after Cantera 3.0. Use property ``initial_time`` instead.
         """
         warnings.warn(
-            "To be removed after Cantera 3.0. Use property 'initial_time' instead.",
-            DeprecationWarning)
+            "ReactorNet.set_initial_time: To be removed after Cantera 3.0. "
+            "Use property 'initial_time' instead.", DeprecationWarning)
         self.initial_time = t
 
     property max_time_step:

--- a/interfaces/matlab_experimental/Reactor/FlowDevice.m
+++ b/interfaces/matlab_experimental/Reactor/FlowDevice.m
@@ -134,11 +134,11 @@ classdef FlowDevice < handle
 
         end
 
-        function setMaster(f, d)
-            % Set the Master flow device used to compute this device's
+        function setPrimary(f, d)
+            % Set the primary flow device used to compute this device's
             % mass flow rate. ::
             %
-            %     >> f.setMaster(d)
+            %     >> f.setPrimary(d)
             %
             % :param f:
             %     Instance of class :mat:class:`MassFlowController`.
@@ -146,9 +146,9 @@ classdef FlowDevice < handle
             %     Instance of class :mat:class:`Func`.
 
             if strcmp(f.type, 'PressureController')
-                k = ctFunc('flowdev_setMaster', f.id, d);
+                k = ctFunc('flowdev_setPrimary', f.id, d);
             else
-                error('Master flow device can only be set for pressure controllers.');
+                error('Primary flow device can only be set for pressure controllers.');
             end
 
         end

--- a/interfaces/matlab_experimental/Reactor/Wall.m
+++ b/interfaces/matlab_experimental/Reactor/Wall.m
@@ -60,6 +60,8 @@ classdef Wall < handle
     properties (SetAccess = public)
 
         area % Area of the wall in m^2.
+        heatRate % Total heat transfer rate through the wall at current time step in W.
+        expansionRate % Rate of volumetric change at current time step in m^3/s.
         thermalResistance % Thermal resistance in K*m^2/W.
         heatTransferCoeff % Heat transfer coefficient in W/(m^2-K).
         emissivity % Non-dimensional emissivity.
@@ -129,15 +131,12 @@ classdef Wall < handle
             a = ctFunc('wall_area', w.id);
         end
 
-        function q = qdot(w, t)
-            % Total heat transfer rate through a wall at a given time t.
-
-            q = ctFunc('wall_Q', w.id, t);
+        function q = get.heatRate(w)
+            q = ctFunc('wall_heatRate', w.id);
         end
 
-        function v = vdot(w, t)
-            % Rate of volumetric change at a given time t.
-            v = ctFunc('wall_vdot', w.id, t);
+        function v = get.expansionRate(w)
+            v = ctFunc('wall_expansionRate', w.id);
         end
 
         %% ReactorNet set methods

--- a/samples/python/reactors/combustor.py
+++ b/samples/python/reactors/combustor.py
@@ -11,7 +11,7 @@ depends on variables other than time by capturing these variables from the
 enclosing scope. Also shows the use of a PressureController to create a constant
 pressure reactor with a fixed volume.
 
-Requires: cantera >= 2.5.0, matplotlib >= 2.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 Keywords: combustion, reactor network, well-stirred reactor, plotting
 """
 
@@ -54,11 +54,11 @@ def mdot(t):
 
 inlet_mfc = ct.MassFlowController(inlet, combustor, mdot=mdot)
 
-# A PressureController has a baseline mass flow rate matching the 'master'
+# A PressureController has a baseline mass flow rate matching the 'primary'
 # MassFlowController, with an additional pressure-dependent term. By explicitly
 # including the upstream mass flow rate, the pressure is kept constant without
 # needing to use a large value for 'K', which can introduce undesired stiffness.
-outlet_mfc = ct.PressureController(combustor, exhaust, master=inlet_mfc, K=0.01)
+outlet_mfc = ct.PressureController(combustor, exhaust, primary=inlet_mfc, K=0.01)
 
 # the simulation only contains one reactor
 sim = ct.ReactorNet([combustor])
@@ -69,7 +69,7 @@ states = ct.SolutionArray(gas, extra=['tres'])
 
 residence_time = 0.1  # starting residence time
 while combustor.T > 500:
-    sim.set_initial_time(0.0)  # reset the integrator
+    sim.initial_time = 0.0  # reset the integrator
     sim.advance_to_steady_state()
     print('tres = {:.2e}; T = {:.1f}'.format(residence_time, combustor.T))
     states.append(combustor.thermo.state, tres=residence_time)

--- a/samples/python/reactors/custom2.py
+++ b/samples/python/reactors/custom2.py
@@ -14,7 +14,7 @@ acceleration is proportional to the pressure difference, and the velocity is
 determined by integrating the equation of motion. This requires adding a new
 variable to the reactor's state vector which represents the wall velocity.
 
-Requires: cantera >= 2.6.0, matplotlib >= 2.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 Keywords: combustion, reactor network, user-defined model, plotting
 """
 
@@ -47,7 +47,7 @@ class InertialWallReactor(ct.ExtensibleIdealGasReactor):
         # This method is used to set the state of the Reactor and Wall objects
         # based on the new values for the state vector provided by the ODE solver
         self.v_wall = y[self.i_wall]
-        self.walls[0].set_velocity(self.v_wall)
+        self.walls[0].velocity = self.v_wall
 
     def after_eval(self, t, LHS, RHS):
         # Calculate the time derivative for the additional equation

--- a/samples/python/reactors/ic_engine.py
+++ b/samples/python/reactors/ic_engine.py
@@ -103,6 +103,8 @@ cyl.volume = V_oT
 
 # define inlet state
 gas.TPX = T_inlet, p_inlet, comp_inlet
+# Note: The previous line is technically not needed as the state of the gas object is
+# already set correctly; change if inlet state is different from the reactor state.
 inlet = ct.Reservoir(gas)
 
 # inlet valve

--- a/samples/python/reactors/ic_engine.py
+++ b/samples/python/reactors/ic_engine.py
@@ -1,4 +1,3 @@
-# -*- coding: utf-8 -*-
 """
 Simulation of a (gaseous) Diesel-type internal combustion engine.
 
@@ -6,7 +5,7 @@ The simulation uses n-Dodecane as fuel, which is injected close to top dead
 center. Note that this example uses numerous simplifying assumptions and
 thus serves for illustration purposes only.
 
-Requires: cantera >= 2.5.0, scipy >= 0.19, matplotlib >= 2.0
+Requires: cantera >= 3.0, scipy >= 0.19, matplotlib >= 2.0
 Keywords: combustion, thermodynamics, internal combustion engine,
           thermodynamic cycle, reactor network, plotting, pollutant formation
 """
@@ -110,7 +109,7 @@ inlet = ct.Reservoir(gas)
 inlet_valve = ct.Valve(inlet, cyl)
 inlet_delta = np.mod(inlet_close - inlet_open, 4 * np.pi)
 inlet_valve.valve_coeff = inlet_valve_coeff
-inlet_valve.set_time_function(
+inlet_valve.time_function = (
     lambda t: np.mod(crank_angle(t) - inlet_open, 4 * np.pi) < inlet_delta)
 
 # define injector state (gaseous!)
@@ -122,7 +121,7 @@ injector_mfc = ct.MassFlowController(injector, cyl)
 injector_delta = np.mod(injector_close - injector_open, 4 * np.pi)
 injector_t_open = (injector_close - injector_open) / 2. / np.pi / f
 injector_mfc.mass_flow_coeff = injector_mass / injector_t_open
-injector_mfc.set_time_function(
+injector_mfc.time_function = (
     lambda t: np.mod(crank_angle(t) - injector_open, 4 * np.pi) < injector_delta)
 
 # define outlet pressure (temperature and composition don't matter)
@@ -133,7 +132,7 @@ outlet = ct.Reservoir(gas)
 outlet_valve = ct.Valve(cyl, outlet)
 outlet_delta = np.mod(outlet_close - outlet_open, 4 * np.pi)
 outlet_valve.valve_coeff = outlet_valve_coeff
-outlet_valve.set_time_function(
+outlet_valve.time_function = (
     lambda t: np.mod(crank_angle(t) - outlet_open, 4 * np.pi) < outlet_delta)
 
 # define ambient pressure (temperature and composition don't matter)
@@ -143,7 +142,7 @@ ambient_air = ct.Reservoir(gas)
 # piston is modeled as a moving wall
 piston = ct.Wall(ambient_air, cyl)
 piston.area = A_piston
-piston.set_velocity(piston_speed)
+piston.velocity = piston_speed
 
 # create a reactor network containing the cylinder and limit advance step
 sim = ct.ReactorNet([cyl])

--- a/samples/python/reactors/pfr.py
+++ b/samples/python/reactors/pfr.py
@@ -1,10 +1,9 @@
-# -*- coding: utf-8 -*-
 """
 This example solves a plug-flow reactor problem of hydrogen-oxygen combustion.
 The PFR is computed by two approaches: The simulation of a Lagrangian fluid
 particle, and the simulation of a chain of reactors.
 
-Requires: cantera >= 2.5.0, matplotlib >= 2.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 Keywords: combustion, reactor network, plug flow reactor
 """
 
@@ -109,7 +108,7 @@ m = ct.MassFlowController(upstream, r2, mdot=mass_flow_rate2)
 # We need an outlet to the downstream reservoir. This will determine the
 # pressure in the reactor. The value of K will only affect the transient
 # pressure difference.
-v = ct.PressureController(r2, downstream, master=m, K=1e-5)
+v = ct.PressureController(r2, downstream, primary=m, K=1e-5)
 
 sim2 = ct.ReactorNet([r2])
 

--- a/samples/python/reactors/surf_pfr_chain.py
+++ b/samples/python/reactors/surf_pfr_chain.py
@@ -5,7 +5,7 @@ methane over a platinum catalyst in a packed bed reactor. To avoid needing to so
 DAE system, the PFR is approximated as a chain of successive WSRs. See surf_pfr.py
 for a more advanced implementation that solves the DAE system directly.
 
-Requires: cantera >= 2.5.0
+Requires: cantera >= 3.0
 Keywords: catalysis, reactor network, surface chemistry, plug flow reactor,
           packed bed reactor
 """
@@ -95,7 +95,7 @@ m = ct.MassFlowController(upstream, r, mdot=mass_flow_rate)
 # We need an outlet to the downstream reservoir. This will determine the
 # pressure in the reactor. The value of K will only affect the transient
 # pressure difference.
-v = ct.PressureController(r, downstream, master=m, K=1e-5)
+v = ct.PressureController(r, downstream, primary=m, K=1e-5)
 
 sim = ct.ReactorNet([r])
 

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -394,6 +394,17 @@ extern "C" {
         }
     }
 
+    int flowdev_setPrimary(int i, int n)
+    {
+        try {
+            FlowDeviceCabinet::get<PressureController>(i).setPrimary(
+                &FlowDeviceCabinet::item(n));
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     double flowdev_massFlowRate(int i)
     {
         try {
@@ -494,10 +505,46 @@ extern "C" {
         }
     }
 
+    double wall_vdot2(int i, double t)
+    {
+        try {
+            return WallCabinet::item(i).vdot(t);
+        } catch (...) {
+            return handleAllExceptions(DERR, DERR);
+        }
+    }
+
+    double wall_vdot3(int i)
+    {
+        try {
+            return WallCabinet::item(i).vdot();
+        } catch (...) {
+            return handleAllExceptions(DERR, DERR);
+        }
+    }
+
     double wall_Q(int i, double t)
     {
         try {
             return WallCabinet::item(i).Q(t);
+        } catch (...) {
+            return handleAllExceptions(DERR, DERR);
+        }
+    }
+
+    double wall_qdot2(int i, double t)
+    {
+        try {
+            return WallCabinet::item(i).qdot(t);
+        } catch (...) {
+            return handleAllExceptions(DERR, DERR);
+        }
+    }
+
+    double wall_qdot(int i)
+    {
+        try {
+            return WallCabinet::item(i).qdot();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -505,19 +505,10 @@ extern "C" {
         }
     }
 
-    double wall_vdot2(int i, double t)
+    double wall_expansionRate(int i)
     {
         try {
-            return WallCabinet::item(i).vdot(t);
-        } catch (...) {
-            return handleAllExceptions(DERR, DERR);
-        }
-    }
-
-    double wall_vdot3(int i)
-    {
-        try {
-            return WallCabinet::item(i).vdot();
+            return WallCabinet::item(i).expansionRate();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -532,19 +523,10 @@ extern "C" {
         }
     }
 
-    double wall_qdot2(int i, double t)
+    double wall_heatRate(int i)
     {
         try {
-            return WallCabinet::item(i).qdot(t);
-        } catch (...) {
-            return handleAllExceptions(DERR, DERR);
-        }
-    }
-
-    double wall_qdot(int i)
-    {
-        try {
-            return WallCabinet::item(i).qdot();
+            return WallCabinet::item(i).heatRate();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -47,7 +47,7 @@ void FlowDevice::setPressureFunction(Func1* f)
     m_pfunc = f;
 }
 
-double FlowDevice::getPressureFunction()
+double FlowDevice::evalPressureFunction()
 {
     double delta_P = in().pressure() - out().pressure();
     if (m_pfunc) {
@@ -61,7 +61,7 @@ void FlowDevice::setTimeFunction(Func1* g)
     m_tfunc = g;
 }
 
-double FlowDevice::getTimeFunction()
+double FlowDevice::evalTimeFunction()
 {
     if (m_tfunc) {
         return m_tfunc->eval(m_time);

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -47,9 +47,26 @@ void FlowDevice::setPressureFunction(Func1* f)
     m_pfunc = f;
 }
 
+double FlowDevice::getPressureFunction()
+{
+    double delta_P = in().pressure() - out().pressure();
+    if (m_pfunc) {
+        return m_pfunc->eval(delta_P);
+    }
+    return delta_P;
+}
+
 void FlowDevice::setTimeFunction(Func1* g)
 {
     m_tfunc = g;
+}
+
+double FlowDevice::getTimeFunction()
+{
+    if (m_tfunc) {
+        return m_tfunc->eval(m_time);
+    }
+    return 1.;
 }
 
 double FlowDevice::outletSpeciesMassFlowRate(size_t k)

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -277,7 +277,7 @@ void Reactor::evalWalls(double t)
     for (size_t i = 0; i < m_wall.size(); i++) {
         int f = 2 * m_lr[i] - 1;
         m_vdot -= f * m_wall[i]->vdot(t);
-        m_Qdot += f * m_wall[i]->Q(t);
+        m_Qdot += f * m_wall[i]->qdot(t);
     }
 }
 

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -196,9 +196,11 @@ void Reactor::updateConnected(bool updatePressure) {
         time = (timeIsIndependent()) ? m_net->time() : m_net->distance();
     }
     for (size_t i = 0; i < m_outlet.size(); i++) {
+        m_outlet[i]->setSimTime(time);
         m_outlet[i]->updateMassFlowRate(time);
     }
     for (size_t i = 0; i < m_inlet.size(); i++) {
+        m_inlet[i]->setSimTime(time);
         m_inlet[i]->updateMassFlowRate(time);
     }
     for (size_t i = 0; i < m_wall.size(); i++) {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -274,12 +274,13 @@ void Reactor::eval(double time, double* LHS, double* RHS)
 
 void Reactor::evalWalls(double t)
 {
+    // time is currently unused
     m_vdot = 0.0;
     m_Qdot = 0.0;
     for (size_t i = 0; i < m_wall.size(); i++) {
         int f = 2 * m_lr[i] - 1;
-        m_vdot -= f * m_wall[i]->vdot(t);
-        m_Qdot += f * m_wall[i]->qdot(t);
+        m_vdot -= f * m_wall[i]->expansionRate();
+        m_Qdot += f * m_wall[i]->heatRate();
     }
 }
 

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -201,6 +201,9 @@ void Reactor::updateConnected(bool updatePressure) {
     for (size_t i = 0; i < m_inlet.size(); i++) {
         m_inlet[i]->updateMassFlowRate(time);
     }
+    for (size_t i = 0; i < m_wall.size(); i++) {
+        m_wall[i]->setSimTime(time);
+    }
 }
 
 void Reactor::eval(double time, double* LHS, double* RHS)

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -28,6 +28,7 @@ ReactorNet::~ReactorNet()
 void ReactorNet::setInitialTime(double time)
 {
     m_time = time;
+    m_initial_time = time;
     m_integrator_init = false;
 }
 

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -58,7 +58,7 @@ double Wall::heatFlux() const {
     return 0.;
 }
 
-double Wall::Q(double t)
+double Wall::qdot(double t)
 {
     double q1 = (m_area * m_rrth) *
                 (m_left->temperature() - m_right->temperature());

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -43,10 +43,22 @@ double Wall::velocity() const {
 
 double Wall::vdot(double t)
 {
+    warn_deprecated("Wall::vdot",
+        "To be removed after Cantera 3.0; replaceable by 'expansionRate'.");
     double rate = m_k * m_area * (m_left->pressure() - m_right->pressure());
 
     if (m_vf) {
         rate += m_area * m_vf->eval(t);
+    }
+    return rate;
+}
+
+double Wall::expansionRate()
+{
+    double rate = m_k * m_area * (m_left->pressure() - m_right->pressure());
+
+    if (m_vf) {
+        rate += m_area * m_vf->eval(m_time);
     }
     return rate;
 }
@@ -58,8 +70,10 @@ double Wall::heatFlux() const {
     return 0.;
 }
 
-double Wall::qdot(double t)
+double Wall::Q(double t)
 {
+    warn_deprecated("Wall::Q",
+        "To be removed after Cantera 3.0; replaceable by 'heatRate'.");
     double q1 = (m_area * m_rrth) *
                 (m_left->temperature() - m_right->temperature());
     if (m_emiss > 0.0) {
@@ -70,6 +84,22 @@ double Wall::qdot(double t)
 
     if (m_qf) {
         q1 += m_area * m_qf->eval(t);
+    }
+    return q1;
+}
+
+double Wall::heatRate()
+{
+    double q1 = (m_area * m_rrth) *
+                (m_left->temperature() - m_right->temperature());
+    if (m_emiss > 0.0) {
+        double tl = m_left->temperature();
+        double tr = m_right->temperature();
+        q1 += m_emiss * m_area * StefanBoltz * (tl*tl*tl*tl - tr*tr*tr*tr);
+    }
+
+    if (m_qf) {
+        q1 += m_area * m_qf->eval(m_time);
     }
     return q1;
 }

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -34,6 +34,13 @@ void WallBase::setArea(double a) {
     m_surf[1].setArea(a);
 }
 
+double Wall::velocity() const {
+    if (m_vf) {
+        return m_vf->eval(m_time);
+    }
+    return 0.;
+}
+
 double Wall::vdot(double t)
 {
     double rate = m_k * m_area * (m_left->pressure() - m_right->pressure());
@@ -42,6 +49,13 @@ double Wall::vdot(double t)
         rate += m_area * m_vf->eval(t);
     }
     return rate;
+}
+
+double Wall::heatFlux() const {
+    if (m_qf) {
+        return m_qf->eval(m_time);
+    }
+    return 0.;
 }
 
 double Wall::Q(double t)

--- a/src/zeroD/flowControllers.cpp
+++ b/src/zeroD/flowControllers.cpp
@@ -31,6 +31,13 @@ void MassFlowController::updateMassFlowRate(double time)
     m_mdot = std::max(mdot, 0.0);
 }
 
+void PressureController::setMaster(FlowDevice* master)
+{
+    warn_deprecated("PressureController::setMaster",
+        "To be removed after Cantera 3.0; replaced by setPrimary.");
+    m_primary = master;
+}
+
 void PressureController::updateMassFlowRate(double time)
 {
     if (!ready()) {
@@ -44,8 +51,8 @@ void PressureController::updateMassFlowRate(double time)
     } else {
         mdot *= delta_P;
     }
-    m_master->updateMassFlowRate(time);
-    mdot += m_master->massFlowRate();
+    m_primary->updateMassFlowRate(time);
+    mdot += m_primary->massFlowRate();
     m_mdot = std::max(mdot, 0.0);
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Make Python API more pythonic

- use properties instead of of `set_XYZ` methods in Python
- evaluate functors at reactor network time
- replace `set_master` by `primary` property

API becomes consistent with existing `mfc` behavior
```
>>> mfc.mass_flow_rate = 0.3
>>> mfc.mass_flow_rate = lambda t: 2.5 * exp(-10 * (t - 0.5)**2)
```

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#160
Closes #1460

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```Python
net.initial_time = 0.                   # instead of net.set_initial_time(0.)
wall.velocity = lambda t: sin(t)        # instead of wall.set_velocity(lambda t: sin(t))
wall.heat_flux = lambda t: cos(t)       # instead of wall.set_heat_flux(lambda t: cos(t))
vdot = wall.expansion_rate              # instead of wall.vdot(net.time)
qdot = wall.heat_rate                   # instead of wall.qdot(net.time)
valve.time_function = lambda t: sin(t)  # instead of valve.set_time_function(lambda t: sin(t))
mfc.pressure_function = lambda p: p**2  # instead of mfc.set_pressure_function(lambda p: p**2)
pc.primary = mfc                        # instead of pc.set_master(mfc)
```

~In `clib`, the new functions `wall_vdot2` and `wall_qdot2` are introduced to preserve current behavior for the old MATLAB toolbox (i.e. no backport) while freeing up `wall_vdot` and `wall_qdot` for all revised interfaces (i.e. reactor network time is automatically used).~ *Edit: no change for traditional MATLAB, new functions `wall_expansionRate` and `wall_heatRate` for revised interfaces.*

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
