### PR TITLE
Fix compiler warnings

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ possible.
 Development Site
 ================
 
-The current development version is 3.0.0a5. The current stable version is
+The current development version is 3.0.0b1. The current stable version is
 2.6.0. The `latest Cantera source code <https://github.com/Cantera/cantera>`_,
 the `issue tracker <https://github.com/Cantera/cantera/issues>`_ for bugs and
 enhancement requests, `downloads of Cantera releases and binary installers

--- a/SConstruct
+++ b/SConstruct
@@ -947,7 +947,7 @@ for arg in ARGUMENTS:
         logger.error(f"Encountered unexpected command line option: {arg!r}")
         sys.exit(1)
 
-env["cantera_version"] = "3.0.0a5"
+env["cantera_version"] = "3.0.0b1"
 # For use where pre-release tags are not permitted (MSI, sonames)
 env['cantera_pure_version'] = re.match(r'(\d+\.\d+\.\d+)', env['cantera_version']).group(0)
 env['cantera_short_version'] = re.match(r'(\d+\.\d+)', env['cantera_version']).group(0)

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -38,7 +38,7 @@ PROJECT_NAME           = Cantera
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.0.0a5
+PROJECT_NUMBER         = 3.0.0b1
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -34,6 +34,13 @@ def prep_gmock(env):
     return localenv
 
 
+def prep_yamlcpp(env):
+    localenv = prep_default(env)
+    if env['CC'] == 'cl':
+        # "class ... needs to have dll-interface to be used by clients of class ..."
+        localenv.Append(CCFLAGS='/wd4251')
+    return localenv
+
 ext_copies = []
 
 if not env['system_fmt']:

--- a/include/cantera/base/clockWC.h
+++ b/include/cantera/base/clockWC.h
@@ -60,7 +60,7 @@ public:
      * machines clock() returns type unsigned long (HP) and on others (SUN)
      * it returns type long. An attempt to recover the actual time for clocks
      * which have rolled over is made also. However, it only works if this
-     * function is called fairly regularily during the solution procedure.
+     * function is called fairly regularly during the solution procedure.
      */
     double secondsWC();
 

--- a/include/cantera/base/utilities.h
+++ b/include/cantera/base/utilities.h
@@ -186,6 +186,12 @@ const U& getValue(const std::map<T, U>& m, const T& key, const U& default_val) {
     return (iter == m.end()) ? default_val : iter->second;
 }
 
+//! Get the size of a container, cast to a signed integer type
+template <class T, class U=int>
+U len(const T& container) {
+    return static_cast<U>(container.size());
+}
+
 //! A macro for generating member function detectors, which can then be used in
 //! combination with `if constexpr` to condition behavior on the availability of that
 //! member function. See MultiRate for examples of use.

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -299,7 +299,7 @@ public:
     //! Gets the interface current for the ith phase
     /*!
     * @param iphase Phase Id
-    * @return The double specifying the interface current. The interface Current
+    * @return The double specifying the interface current. The interface current
     *         is useful when charge transfer reactions occur at an interface. It
     *         is defined here as the net positive charge entering the phase
     *         specified by the Phase Id. (Units: A/m^2 for a surface reaction,

--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -21,7 +21,7 @@ namespace Cantera
 //! AdaptivePreconditioner a preconditioner designed for use with large
 //! mechanisms that leverages sparse solvers. It does this by pruning
 //! the preconditioner by a threshold value. It also neglects pressure
-//! dependence and thirdbody contributions in its formation and has a
+//! dependence and third body contributions in its formation and has a
 //! finite difference approximation for temperature.
 class AdaptivePreconditioner : public PreconditionerBase
 {
@@ -64,10 +64,10 @@ public:
     //! Get the threshold value for setting elements
     double threshold() { return m_threshold; }
 
-    //! Get ilut fill factor
+    //! Get ILUT fill factor
     double ilutFillFactor() { return m_fill_factor; }
 
-    //! Get ilut drop tolerance
+    //! Get ILUT drop tolerance
     double ilutDropTol() { return m_drop_tol; }
 
     //! Set the threshold value to compare elements against
@@ -98,10 +98,10 @@ public:
     void printJacobian();
 
 protected:
-    //! ilut fill factor
+    //! ILUT fill factor
     double m_fill_factor = 0;
 
-    //! ilut drop tolerance
+    //! ILUT drop tolerance
     double m_drop_tol = 0;
 
     //! Vector of triples representing the jacobian used in preconditioning

--- a/include/cantera/numerics/funcs.h
+++ b/include/cantera/numerics/funcs.h
@@ -32,7 +32,7 @@ doublereal linearInterp(doublereal x, const vector_fp& xpts,
 
 //! Numerical integration of a function using the trapezoidal rule.
 /*!
- * Vector x contanins a monotonic sequence of grid points, and
+ * Vector x contains a monotonic sequence of grid points, and
  * Vector f contains function values defined at these points.
  * The size of x and f must be the same.
  *
@@ -46,7 +46,7 @@ double trapezoidal(const Eigen::ArrayXd& f, const Eigen::ArrayXd& x);
 //! For even number, Simpson's rule is used for the first
 //! N-2 intervals with a trapezoidal rule on the last interval.
 /*!
- * Vector x contanins a monotonic sequence of grid points, and
+ * Vector x contains a monotonic sequence of grid points, and
  * Vector f contains function values defined at these points.
  * The size of x and f must be the same.
  *
@@ -57,7 +57,7 @@ double simpson(const Eigen::ArrayXd& f, const Eigen::ArrayXd& x);
 
 //! Numerical integration of a function.
 /*!
- * Vector x contanins a monotonic sequence of grid points, and
+ * Vector x contains a monotonic sequence of grid points, and
  * Vector f contains function values defined at these points.
  * The size of x and f must be the same.
  *

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -66,8 +66,8 @@ public:
      * "Calculation and analysis of the mobility and diffusion coefficient
      * of thermal electrons in methane/air premixed flames."
      * Combustion and flame 159.12 (2012): 3518-3521.
-     * If in the future the class GasTranport is improved, this method may
-     * be discard. This method specifies this profile.
+     * If in the future the class GasTransport is improved, this method may
+     * be discarded. This method specifies this profile.
     */
     void setElectronTransport(vector_fp& tfix,
                               vector_fp& diff_e,

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -106,7 +106,7 @@ protected:
     double m_t0 = 0.0;
     //! Dimensionless value of the heat capacity
     double m_cp0_R = 0.0;
-    //! dimensionless value of the enthaply at t0
+    //! dimensionless value of the enthalpy at t0
     double m_h0_R = 0.0;
     //! Dimensionless value of the entropy at t0
     double m_s0_R = 0.0;

--- a/include/cantera/thermo/CoverageDependentSurfPhase.h
+++ b/include/cantera/thermo/CoverageDependentSurfPhase.h
@@ -172,12 +172,12 @@ public:
         //! index of a species whose coverage affects enthalpy and entropy of
         //! a target species
         size_t j;
-        //! array of polynomial coefficients describing coverage-depdendent enthalpy
+        //! array of polynomial coefficients describing coverage-dependent enthalpy
         //! [J/kmol] in order of 1st-order, 2nd-order, 3rd-order, and 4th-order
         //! coefficients (\f$ c^{(1)}, c^{(2)}, c^{(3)}, \text{ and } c^{(4)} \f$
         //! in the linear or the polynomial dependency model)
         vector_fp enthalpy_coeffs;
-        //! array of polynomial coefficients describing coverage-depdendent entropy
+        //! array of polynomial coefficients describing coverage-dependent entropy
         //! [J/kmol/K] in order of 1st-order, 2nd-order, 3rd-order, and 4th-order
         //! coefficients (\f$ c^{(1)}, c^{(2)}, c^{(3)}, \text{ and } c^{(4)} \f$
         //! in the linear or the polynomial dependency model)

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -57,7 +57,7 @@ namespace Cantera
  * vector. That's one of its primary usages. In order to keep the mole fraction
  * vector constant, all of the setState functions are redesigned at this layer.
  *
- * ### Activity Concentrations: Relationship of ThermoPhase to %Kinetics Expressions
+ * ### Activity Concentrations: Relationship of ThermoPhase to Kinetics Expressions
  *
  * As explained in a similar discussion in the ThermoPhase class, the actual
  * units used in kinetics expressions must be specified in the ThermoPhase class

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -142,7 +142,7 @@ namespace Cantera
  *      \tilde{Cp}_k(T,P) = Cp^o_k(T,P) = Cp^{ref}_k(T)
  * \f]
  *
- * ## %Application within Kinetics Managers
+ * ## Application within Kinetics Managers
  *
  * \f$ C^a_k\f$ are defined such that \f$ a_k = C^a_k / C^s_k, \f$ where \f$
  * C^s_k \f$ is a standard concentration defined below and \f$ a_k \f$ are

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -123,7 +123,7 @@ namespace Cantera
  * only has a weak dependence on the enthalpy, and doesn't effect the molar
  * concentration.
  *
- * ## %Application within Kinetics Managers
+ * ## Application within Kinetics Managers
  *
  * \f$ C^a_k\f$ are defined such that \f$ C^a_k = a_k = X_k \f$. \f$ C^s_k \f$,
  * the standard concentration, is defined to be equal to one. \f$ a_k \f$ are

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -94,7 +94,7 @@ namespace Cantera
  *
  * where k is a species in the ith sublattice.
  *
- * The mole fraction vector is redefined witin the the LatticeSolidPhase object.
+ * The mole fraction vector is redefined within the the LatticeSolidPhase object.
  * Each of the mole fractions sum to one on each of the sublattices.  The
  * routine getMoleFraction() and setMoleFraction() have been redefined to use
  * this convention.
@@ -456,7 +456,7 @@ protected:
     //! Current value of the molar density
     double m_molar_density = 0.0;
 
-    //! Vector of sublattic ThermoPhase objects
+    //! Vector of sublattice ThermoPhase objects
     std::vector<shared_ptr<ThermoPhase>> m_lattice;
 
     //! Vector of mole fractions

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -113,7 +113,7 @@ namespace Cantera
  *              - R T^2 \frac{d^2 \ln(\gamma_k) }{{dT}^2}
  * \f]
  *
- * ## %Application within Kinetics Managers
+ * ## Application within Kinetics Managers
  *
  * \f$ C^a_k\f$ are defined such that \f$ a_k = C^a_k / C^s_k, \f$ where
  * \f$ C^s_k \f$ is a standard concentration defined below and \f$ a_k \f$ are

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -104,7 +104,7 @@ namespace Cantera
  * The PDSS objects may or may not utilize a SpeciesThermoInterpType reference
  * state manager class to calculate the reference state thermodynamics functions
  * in their own calculation. There are some classes, such as PDSS_IdealGas and
- * PDSS+_ConstVol, which utilize the SpeciesThermoInterpType object because the
+ * PDSS_ConstVol, which utilize the SpeciesThermoInterpType object because the
  * calculation is very similar to the reference state calculation, while there
  * are other classes, PDSS_Water and PDSS_HKFT, which don't utilize the
  * reference state calculation at all, because it wouldn't make sense to. For

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -57,7 +57,7 @@ public:
      * \f]
      *
      * *m* is the neutral molecule species index. \f$ \alpha_{m , k} \f$ is the
-     * stoiciometric coefficient for the neutral molecule, *m*, that creates the
+     * stoichiometric coefficient for the neutral molecule, *m*, that creates the
      * thermodynamics for the ionic species  *k*. A factor  \f$ 2.0 \ln{2.0} \f$
      * is added to all ions except for the species ionic species, which in this
      * case is the single anion species, with species index *sp*.

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -2,7 +2,7 @@
  *  @file PureFluidPhase.h
  *
  *   Header for a ThermoPhase class for a pure fluid phase consisting of
- *   gas, liquid, mixed-gas-liquid and supercrit fluid (see \ref thermoprops
+ *   gas, liquid, mixed-gas-liquid and supercritical fluid (see \ref thermoprops
  *   and class \link Cantera::PureFluidPhase PureFluidPhase\endlink).
  *
  * It inherits from ThermoPhase, but is built on top of the tpx package.

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -131,7 +131,7 @@ namespace Cantera
  *              - R T^2 \frac{d^2 \ln(\gamma_k) }{{dT}^2} = C^o_{p,k}(T,P)
  * \f]
  *
- * ## %Application within Kinetics Managers
+ * ## Application within Kinetics Managers
  *
  * \f$ C^a_k\f$ are defined such that \f$ a_k = C^a_k / C^s_k, \f$ where
  * \f$ C^s_k \f$ is a standard concentration defined below and \f$ a_k \f$ are

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -75,7 +75,7 @@ namespace Cantera
  *            s_k(T,P) = s^o_k(T) - R \log(\theta_k)
  *       \f]
  *
- * ## %Application within Kinetics Managers
+ * ## Application within Kinetics Managers
  *
  * The activity concentration,\f$  C^a_k \f$, used by the kinetics manager, is equal to
  * the actual concentration, \f$ C^s_k \f$, and is given by the following

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -59,7 +59,7 @@ class WaterProps;
  *
  * So(1bar) = S(P0) + RT ln(1bar/P0)
  *
- * ## %Application within Kinetics Managers
+ * ## Application within Kinetics Managers
  *
  * This is unimplemented.
  *

--- a/include/cantera/tpx/Sub.h
+++ b/include/cantera/tpx/Sub.h
@@ -153,7 +153,7 @@ public:
 
     virtual double Pp()=0;
 
-    //! Enthaply of a single-phase state
+    //! Enthalpy of a single-phase state
     double hp() {
         return up() + Pp()/Rho;
     }

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -46,7 +46,7 @@ public:
     }
 
     //! Update the mass flow rate at time 'time'. This must be overloaded in
-    //! subclassess to update m_mdot.
+    //! subclasses to update m_mdot.
     virtual void updateMassFlowRate(double time) {}
 
     //! Mass flow rate (kg/s) of outlet species k. Returns zero if this species

--- a/include/cantera/zeroD/FlowReactor.h
+++ b/include/cantera/zeroD/FlowReactor.h
@@ -140,7 +140,7 @@ protected:
     //! Density [kg/m^3]. First component of the state vector.
     double m_rho = NAN;
     //! Axial velocity [m/s]. Second component of the state vector.
-    double m_u = NAN;
+    double m_u = -1.0;
     //! Pressure [Pa]. Third component of the state vector.
     double m_P = NAN;
     //! Temperature [K]. Fourth component of the state vector.

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -438,8 +438,8 @@ cdef class ReactingSurface1D(Boundary1D):
     def __init__(self, _SolutionBase phase, name=None):
         self._weakref_proxy = _WeakrefProxy()
         if phase.phase_of_matter == "gas":
-            warnings.warn("Starting in Cantera 3.0, parameter 'phase' should "
-                "reference surface instead of gas phase.", DeprecationWarning)
+            warnings.warn("ReactingSurface1D: Starting in Cantera 3.0, parameter 'phase'"
+                " should reference surface instead of gas phase.", DeprecationWarning)
             super().__init__(phase)
             if name is not None:
                 self.name = name
@@ -477,8 +477,9 @@ cdef class ReactingSurface1D(Boundary1D):
             Method to be removed after Cantera 3.0; set `Kinetics` when instantiating
             `ReactingSurface1D` instead.
         """
-        warnings.warn("Method to be removed after Cantera 3.0; set 'Kinetics' when "
-            "instantiating 'ReactingSurface1D' instead.", DeprecationWarning)
+        warnings.warn("ReactingSurface1D.set_kinetics: Method to be removed after "
+            "Cantera 3.0; set 'Kinetics' when instantiating 'ReactingSurface1D' "
+            "instead.", DeprecationWarning)
         if pystr(kin.kinetics.kineticsType()) not in ("surface", "edge"):
             raise TypeError('Kinetics object must be derived from '
                             'InterfaceKinetics.')
@@ -535,8 +536,8 @@ cdef class _FlowBase(Domain1D):
 
             Method to be removed after Cantera 3.0. Replaceable by `transport_model`
         """
-        warnings.warn("Method to be removed after Cantera 3.0; use property "
-                      "'transport_model' instead.", DeprecationWarning)
+        warnings.warn("_FlowBase.set_transport: Method to be removed after Cantera 3.0;"
+                      " use property 'transport_model' instead.", DeprecationWarning)
         self._weakref_proxy = _WeakrefProxy()
         self.gas._references[self._weakref_proxy] = True
         self.gas = phase
@@ -623,8 +624,8 @@ cdef class _FlowBase(Domain1D):
         """
         def __get__(self):
             warnings.warn(
-                "Property getter to change after Cantera 3.0.\nFor new behavior, use "
-                "'get_settings3'.", DeprecationWarning)
+                "_FlowBase.settings: Property getter to change after Cantera 3.0.\n"
+                "For new behavior, use 'get_settings3'.", DeprecationWarning)
 
             out = {
                 'Domain1D_type': type(self).__name__,
@@ -653,8 +654,8 @@ cdef class _FlowBase(Domain1D):
 
             return out
         def __set__(self, meta):
-            warnings.warn("Property setter to be removed after Cantera 3.0. "
-                "Replaceable by individual setters.", DeprecationWarning)
+            warnings.warn("_FlowBase.settings: Property setter to be removed after "
+            "Cantera 3.0. Replaceable by individual setters.", DeprecationWarning)
 
             # boundary emissivities
             if 'emissivity_left' in meta or 'emissivity_right' in meta:
@@ -875,8 +876,8 @@ cdef class IdealGasFlow(_FlowBase):
     _domain_type = "gas-flow"
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Class to be removed after Cantera 3.0; use 'FreeFlow', "
-                      "'AxisymmetricFlow' or 'UnstrainedFlow' instead.",
+        warnings.warn("Class 'IdealGasFlow' to be removed after Cantera 3.0; use "
+                      "'FreeFlow', 'AxisymmetricFlow' or 'UnstrainedFlow' instead.",
                       DeprecationWarning)
         super().__init__(*args, **kwargs)
 
@@ -895,8 +896,8 @@ cdef class IonFlow(_FlowBase):
     _domain_type = "ion-flow"
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Class to be removed after Cantera 3.0; use 'FreeFlow', "
-                      "'AxisymmetricFlow' or 'UnstrainedFlow' instead.",
+        warnings.warn("Class 'IonFlow' to be removed after Cantera 3.0; use 'FreeFlow',"
+                      " 'AxisymmetricFlow' or 'UnstrainedFlow' instead.",
                       DeprecationWarning)
         super().__init__(*args, **kwargs)
 
@@ -908,8 +909,8 @@ cdef class IonFlow(_FlowBase):
         - ``stage == 2``: the electric field equation is solved, and the drift flux for
           ionized species is evaluated
         """
-        warnings.warn("Method to be removed after Cantera 3.0; use "
-                      "'solving_stage' property instead.", DeprecationWarning)
+        warnings.warn("IonFlow.set_solving_stage: Method to be removed after Cantera "
+                      "3.0; use 'solving_stage' property instead.", DeprecationWarning)
         self.solving_stage = stage
 
 
@@ -1173,7 +1174,8 @@ cdef class Sim1D:
             interface to the C++ core, except for `FlameBase.from_solution_array`,
             which itself is deprecated due to a pending removal of ``h5py`` support.
         """
-        warnings.warn("Method to be removed after Cantera 3.0.", DeprecationWarning)
+        warnings.warn("Sim1D.restore_data: Method to be removed after Cantera 3.0.",
+                      DeprecationWarning)
         idom = self.domain_index(domain)
         dom = self.domains[idom]
         T, P, Y = states
@@ -1629,8 +1631,8 @@ cdef class Sim1D:
             Argument loglevel is no longer supported
         """
         if loglevel is not None:
-            warnings.warn("Argument 'loglevel' is deprecated and will be ignored.",
-                DeprecationWarning)
+            warnings.warn("Sim1D.save: Argument 'loglevel' is deprecated and will be "
+                "ignored.", DeprecationWarning)
         self.sim.save(stringify(str(filename)), stringify(name),
                       stringify(description), overwrite, compression, stringify(basis))
 
@@ -1657,8 +1659,8 @@ cdef class Sim1D:
             Implemented return value for meta data; loglevel is no longer supported
         """
         if loglevel is not None:
-            warnings.warn("Argument 'loglevel' is deprecated and will be ignored.",
-                DeprecationWarning)
+            warnings.warn("Sim1D.restore: Argument 'loglevel' is deprecated and will be"
+                 " ignored.", DeprecationWarning)
         cdef CxxAnyMap header
         header = self.sim.restore(stringify(str(filename)), stringify(name))
         self._initialized = True

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -56,14 +56,14 @@ __sundials_version__ = '.'.join(str(get_sundials_version()))
 __version__ = pystr(CxxVersion())
 
 if __version__ != pystr(get_cantera_version_py()):
-    raise ImportError("Mismatch betweeen Cantera Python module version "
+    raise ImportError("Mismatch between Cantera Python module version "
         f"({pystr(get_cantera_version_py())}) and Cantera shared library "
         f"version ({__version__})")
 
 __git_commit__ = pystr(CxxGitCommit())
 
 if __git_commit__ != pystr(get_cantera_git_commit_py()):
-    raise ImportError("Mismatch betweeen Cantera Python module Git commit "
+    raise ImportError("Mismatch between Cantera Python module Git commit "
         f"({pystr(get_cantera_git_commit_py())}) and Cantera shared library "
         f"git commit ({__git_commit__})")
 

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1947,7 +1947,7 @@ class Parser:
             metadata = BlockMap([
                 ("generator", "ck2yaml"),
                 ("input-files", FlowList(files)),
-                ("cantera-version", "3.0.0a5"),
+                ("cantera-version", "3.0.0b1"),
                 ("date", formatdate(localtime=True)),
             ])
             if desc.strip():

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1202,7 +1202,7 @@ class SolutionArray(SolutionArrayBase):
             Method to be removed after Cantera 3.0; superseded by `save`. Note that
             `write_csv` does not support escaping of commas within string entries.
         """
-        warnings.warn("'write_csv' is superseded by 'save' and will be removed "
+        warnings.warn("SolutionArray.write_csv: Superseded by 'save' and will be removed "
                       "after Cantera 3.0.", DeprecationWarning)
         data_dict = self.collect_data(*args, cols=cols, tabular=True, **kwargs)
         data = np.hstack([d[:, np.newaxis] for d in data_dict.values()])
@@ -1430,9 +1430,9 @@ class SolutionArray(SolutionArrayBase):
             the call is redirected to `save` in order to prevent the creation of a file
             with legacy HDF format.
         """
-        warnings.warn("Method to be removed after Cantera 3.0; use 'save' instead.\n"
-            "Note that the call is redirected to 'save' in order to prevent the "
-            "creation of a file with legacy HDF format;\nas a consequence, "
+        warnings.warn("SolutionArray.write_hdf: To be removed after Cantera 3.0; use "
+            "'save' instead.\n Note that the call is redirected to 'save' in order to "
+            "prevent the creation of a file with legacy HDF format;\nas a consequence, "
             "some options are no longer supported.", DeprecationWarning)
 
         if group is None:
@@ -1476,8 +1476,8 @@ class SolutionArray(SolutionArrayBase):
         if _h5py is None:
             _import_h5py()
 
-        warnings.warn("Method to be removed after Cantera 3.0; use 'restore' instead.",
-            DeprecationWarning)
+        warnings.warn("SolutionArray.read_hdf: Method to be removed after Cantera 3.0; "
+                      "use 'restore' instead.", DeprecationWarning)
 
         with _h5py.File(filename, 'r') as hdf:
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1203,7 +1203,7 @@ class SolutionArray(SolutionArrayBase):
             `write_csv` does not support escaping of commas within string entries.
         """
         warnings.warn("SolutionArray.write_csv: Superseded by 'save' and will be removed "
-                      "after Cantera 3.0.", DeprecationWarning)
+                      "after Cantera 3.0.", DeprecationWarning, stacklevel=2)
         data_dict = self.collect_data(*args, cols=cols, tabular=True, **kwargs)
         data = np.hstack([d[:, np.newaxis] for d in data_dict.values()])
         labels = list(data_dict.keys())
@@ -1433,7 +1433,7 @@ class SolutionArray(SolutionArrayBase):
         warnings.warn("SolutionArray.write_hdf: To be removed after Cantera 3.0; use "
             "'save' instead.\n Note that the call is redirected to 'save' in order to "
             "prevent the creation of a file with legacy HDF format;\nas a consequence, "
-            "some options are no longer supported.", DeprecationWarning)
+            "some options are no longer supported.", DeprecationWarning, stacklevel=2)
 
         if group is None:
             raise KeyError("Missing required parameter 'group'.")
@@ -1477,7 +1477,7 @@ class SolutionArray(SolutionArrayBase):
             _import_h5py()
 
         warnings.warn("SolutionArray.read_hdf: Method to be removed after Cantera 3.0; "
-                      "use 'restore' instead.", DeprecationWarning)
+                      "use 'restore' instead.", DeprecationWarning, stacklevel=2)
 
         with _h5py.File(filename, 'r') as hdf:
 

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1661,7 +1661,7 @@ def convert(filename=None, output_name=None, text=None, encoding="latin-1"):
         # information regarding conversion
         metadata = BlockMap([
             ("generator", "cti2yaml"),
-            ("cantera-version", "3.0.0a5"),
+            ("cantera-version", "3.0.0b1"),
             ("date", formatdate(localtime=True)),
         ])
         if filename != "<string>":

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -2638,7 +2638,7 @@ def convert(
     metadata = BlockMap(
         {
             "generator": "ctml2yaml",
-            "cantera-version": "3.0.0a5",
+            "cantera-version": "b1",
             "date": formatdate(localtime=True),
         }
     )

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -84,7 +84,7 @@ cdef class Func1:
                 k = float(c)
             elif arr.size == 1:
                 # handle lists, tuples or numpy arrays with a single element
-                k = float(c[0])
+                k = float(arr.flat[0])
             else:
                 raise TypeError
             func = Func1.cxx_functor("constant", k)

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -299,8 +299,9 @@ cdef class Kinetics(_SolutionBase):
             `Kinetics.reactant_stoich_coeffs`
         """
         def __get__(self):
-            warnings.warn("Method to be removed after Cantera 3.0; use property "
-                        "'reactant_stoich_coeffs' instead.", DeprecationWarning)
+            warnings.warn("Kinetics.reactant_stoich_coeffs3: To be removed after "
+                          "Cantera 3.0; use property 'reactant_stoich_coeffs' instead.",
+                          DeprecationWarning)
             return self.reactant_stoich_coeffs
 
     property product_stoich_coeffs:
@@ -333,8 +334,9 @@ cdef class Kinetics(_SolutionBase):
             `Kinetics.product_stoich_coeffs`
         """
         def __get__(self):
-            warnings.warn("Method to be removed after Cantera 3.0; use property "
-                        "'product_stoich_coeffs' instead.", DeprecationWarning)
+            warnings.warn("Kinetics.product_stoich_coeffs3: Method to be removed after "
+                          "Cantera 3.0; use property 'product_stoich_coeffs' instead.",
+                          DeprecationWarning)
             return self.product_stoich_coeffs
 
     property product_stoich_coeffs_reversible:

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -55,7 +55,7 @@ class FlameBase(Sim1D):
             export to the C++ core, this method is unused.
         """
         warnings.warn("FlameBase.other_components: Method to be removed after "
-                      "Cantera 3.0 (unused).", DeprecationWarning)
+                      "Cantera 3.0 (unused).", DeprecationWarning, stacklevel=2)
         if domain is None:
             return self._other
 
@@ -385,7 +385,8 @@ class FlameBase(Sim1D):
             Replaceable by `profile` or `value`.
         """
         warnings.warn("FlameBase.solution: To be removed after Cantera 3.0. "
-                      "Replaceable by 'profile' or 'value'.", DeprecationWarning)
+                      "Replaceable by 'profile' or 'value'.", DeprecationWarning,
+                      stacklevel=2)
         if point is None:
             return self.profile(self.flame, component)
         else:
@@ -422,7 +423,7 @@ class FlameBase(Sim1D):
             Method to be removed after Cantera 3.0; superseded by `save`.
         """
         warnings.warn("FlameBase.write_csv: Superseded by 'save'. To be removed "
-                      "after Cantera 3.0.", DeprecationWarning)
+                      "after Cantera 3.0.", DeprecationWarning, stacklevel=2)
 
         # save data
         cols = ('extra', 'T', 'D', species)
@@ -466,7 +467,7 @@ class FlameBase(Sim1D):
             Method to be removed after Cantera 3.0; superseded by `to_array`.
         """
         warnings.warn("FlameBase.to_solution_array: To be removed after Cantera 3.0. "
-                      "Replaceable by 'to_array'.", DeprecationWarning)
+                      "Replaceable by 'to_array'.", DeprecationWarning, stacklevel=2)
         return self.to_array(domain, normalize)
 
     def from_array(self, arr, domain=None):
@@ -497,7 +498,7 @@ class FlameBase(Sim1D):
             Method to be removed after Cantera 3.0; replaced by `from_array`.
         """
         warnings.warn("FlameBase.from_solution_array: To be removed after Cantera 3.0. "
-                      "Replaced by 'from_array'.", DeprecationWarning)
+                      "Replaced by 'from_array'.", DeprecationWarning, stacklevel=2)
         if domain is None:
             domain = self.flame
         else:
@@ -636,7 +637,7 @@ class FlameBase(Sim1D):
         warnings.warn("FlameBase.write_hdf: To be removed after Cantera 3.0; use "
             "'save' instead.\nNote that the call is redirected to 'save' in order to "
             "prevent the creation of a file with deprecated HDF format.",
-            DeprecationWarning)
+            DeprecationWarning, stacklevel=2)
 
         self.save(filename, name=group, description=description,
                   compression=compression_opts)
@@ -665,7 +666,7 @@ class FlameBase(Sim1D):
             Method to be removed after Cantera 3.0; superseded by `restore`.
         """
         warnings.warn("FlameBase.read_hdf: To be removed after Cantera 3.0; use "
-                      "'restore' instead.", DeprecationWarning)
+                      "'restore' instead.", DeprecationWarning, stacklevel=2)
 
         if restore_boundaries:
             domains = range(3)
@@ -693,7 +694,7 @@ class FlameBase(Sim1D):
             `Domain1D.settings`; for the setter, use setters for individual settings.
         """
         warnings.warn("FlameBase.settings: to be removed after Cantera 3.0. Access "
-            "settings from domains instead.", DeprecationWarning)
+            "settings from domains instead.", DeprecationWarning, stacklevel=2)
         out = {'Sim1D_type': type(self).__name__}
         out['transport_model'] = self.transport_model
         out['energy_enabled'] = self.energy_enabled
@@ -709,7 +710,7 @@ class FlameBase(Sim1D):
     @settings.setter
     def settings(self, s):
         warnings.warn("FlameBase.settings: To be removed after Cantera 3.0. Use "
-            "individual setters instead.", DeprecationWarning)
+            "individual setters instead.", DeprecationWarning, stacklevel=2)
         # simple setters
         attr = {'transport_model',
                 'energy_enabled', 'soret_enabled', 'radiation_enabled',
@@ -1045,7 +1046,7 @@ class IonFreeFlame(FreeFlame):
     def __init__(self, gas, grid=None, width=None):
         warnings.warn(
             "'IonFreeFlame' is deprecated and will be removed after Cantera 3.0;",
-            "replaceable by 'FreeFlame'.", DeprecationWarning)
+            "replaceable by 'FreeFlame'.", DeprecationWarning, stacklevel=2)
         super().__init__(gas, grid, width)
 
 
@@ -1199,7 +1200,7 @@ class IonBurnerFlame(BurnerFlame):
     def __init__(self, gas, grid=None, width=None):
         warnings.warn(
             "'IonBurnerFlame' is deprecated and will be removed after Cantera 3.0; ",
-            "replaceable by 'BurnerFlame'.", DeprecationWarning)
+            "replaceable by 'BurnerFlame'.", DeprecationWarning, stacklevel=2)
         super().__init__(gas, grid, width)
 
 

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -134,7 +134,7 @@ class FlameBase(Sim1D):
 
         elif isinstance(data, (str, Path)):
             data = str(data)
-            arr = SolutionArray(self.gas, extra=self.other_components())
+            arr = SolutionArray(self.gas)
             if any(data.endswith(suffix) for suffix in [".hdf5", ".h5", ".hdf"]):
                 # data source identifies a HDF file
                 if "native" in hdf_support():
@@ -151,7 +151,7 @@ class FlameBase(Sim1D):
                 raise ValueError(f"'{data}' does not identify CSV, YAML or HDF file.")
         else:
             # data source is presumably a pandas DataFrame
-            arr = SolutionArray(self.gas, extra=self.other_components())
+            arr = SolutionArray(self.gas)
             arr.from_pandas(data)
 
         # get left and right boundaries

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -54,8 +54,8 @@ class FlameBase(Sim1D):
             Method to be removed after Cantera 3.0. After moving SolutionArray HDF
             export to the C++ core, this method is unused.
         """
-        warnings.warn("Method to be removed after Cantera 3.0 (unused).",
-                      DeprecationWarning)
+        warnings.warn("FlameBase.other_components: Method to be removed after "
+                      "Cantera 3.0 (unused).", DeprecationWarning)
         if domain is None:
             return self._other
 
@@ -384,8 +384,8 @@ class FlameBase(Sim1D):
             To be removed after Cantera 3.0 to avoid conflation with `Solution`.
             Replaceable by `profile` or `value`.
         """
-        warnings.warn("Method 'solution' to be removed after Cantera 3.0. "
-            "Replaceable by 'profile' or 'value'.")
+        warnings.warn("FlameBase.solution: To be removed after Cantera 3.0. "
+                      "Replaceable by 'profile' or 'value'.", DeprecationWarning)
         if point is None:
             return self.profile(self.flame, component)
         else:
@@ -421,7 +421,7 @@ class FlameBase(Sim1D):
 
             Method to be removed after Cantera 3.0; superseded by `save`.
         """
-        warnings.warn("'write_csv' is superseded by 'save' and will be removed "
+        warnings.warn("FlameBase.write_csv: Superseded by 'save'. To be removed "
                       "after Cantera 3.0.", DeprecationWarning)
 
         # save data
@@ -465,9 +465,8 @@ class FlameBase(Sim1D):
 
             Method to be removed after Cantera 3.0; superseded by `to_array`.
         """
-        warnings.warn(
-            "Method to be removed after Cantera 3.0. Replaceable by 'to_array'.",
-            DeprecationWarning)
+        warnings.warn("FlameBase.to_solution_array: To be removed after Cantera 3.0. "
+                      "Replaceable by 'to_array'.", DeprecationWarning)
         return self.to_array(domain, normalize)
 
     def from_array(self, arr, domain=None):
@@ -497,9 +496,8 @@ class FlameBase(Sim1D):
 
             Method to be removed after Cantera 3.0; replaced by `from_array`.
         """
-        warnings.warn(
-            "Method to be removed after Cantera 3.0. Replaced by 'from_array'.",
-            DeprecationWarning)
+        warnings.warn("FlameBase.from_solution_array: To be removed after Cantera 3.0. "
+                      "Replaced by 'from_array'.", DeprecationWarning)
         if domain is None:
             domain = self.flame
         else:
@@ -635,9 +633,10 @@ class FlameBase(Sim1D):
             the call is redirected to `save` in order to prevent the creation of a file
             with deprecated HDF format.
         """
-        warnings.warn("Method to be removed after Cantera 3.0; use 'save' instead.\n"
-            "Note that the call is redirected to 'save' in order to prevent the "
-            "creation of a file with deprecated HDF format.", DeprecationWarning)
+        warnings.warn("FlameBase.write_hdf: To be removed after Cantera 3.0; use "
+            "'save' instead.\nNote that the call is redirected to 'save' in order to "
+            "prevent the creation of a file with deprecated HDF format.",
+            DeprecationWarning)
 
         self.save(filename, name=group, description=description,
                   compression=compression_opts)
@@ -665,9 +664,8 @@ class FlameBase(Sim1D):
 
             Method to be removed after Cantera 3.0; superseded by `restore`.
         """
-        warnings.warn(
-            "Method to be removed after Cantera 3.0; use 'restore' instead.",
-            DeprecationWarning)
+        warnings.warn("FlameBase.read_hdf: To be removed after Cantera 3.0; use "
+                      "'restore' instead.", DeprecationWarning)
 
         if restore_boundaries:
             domains = range(3)
@@ -694,9 +692,8 @@ class FlameBase(Sim1D):
             To be removed after Cantera 3.0. The getter is replaceable by
             `Domain1D.settings`; for the setter, use setters for individual settings.
         """
-        warnings.warn(
-            "Property 'settings' to be removed after Cantera 3.0. Access settings from "
-            "domains instead.", DeprecationWarning)
+        warnings.warn("FlameBase.settings: to be removed after Cantera 3.0. Access "
+            "settings from domains instead.", DeprecationWarning)
         out = {'Sim1D_type': type(self).__name__}
         out['transport_model'] = self.transport_model
         out['energy_enabled'] = self.energy_enabled
@@ -711,9 +708,8 @@ class FlameBase(Sim1D):
 
     @settings.setter
     def settings(self, s):
-        warnings.warn(
-            "Property 'settings' to be removed after Cantera 3.0. Use individual "
-            "setters instead.", DeprecationWarning)
+        warnings.warn("FlameBase.settings: To be removed after Cantera 3.0. Use "
+            "individual setters instead.", DeprecationWarning)
         # simple setters
         attr = {'transport_model',
                 'energy_enabled', 'soret_enabled', 'radiation_enabled',

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1307,9 +1307,8 @@ cdef class Reaction:
                   equation=None, init=True, efficiencies=None,
                   Kinetics kinetics=None, third_body=None):
         if kinetics:
-            warnings.warn(
-                "Parameter 'kinetics' is no longer used and will be removed after "
-                "Cantera 3.0.", DeprecationWarning)
+            warnings.warn("Reaction: Parameter 'kinetics' is no longer used and will "
+                          "be removed after Cantera 3.0.", DeprecationWarning)
 
         if not init:
             return
@@ -1349,8 +1348,8 @@ cdef class Reaction:
             _third_body = ThirdBody(third_body)
         elif efficiencies:
             warnings.warn(
-                "Argument 'efficiencies' is deprecated and will be removed after "
-                "Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
+                "Reaction: Argument 'efficiencies' is deprecated and will be removed "
+                "after Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
             third_body = "M"
             _third_body = ThirdBody(third_body)
             _third_body.efficiencies = efficiencies
@@ -1668,15 +1667,15 @@ cdef class Reaction:
         """
         def __get__(self):
             warnings.warn(
-                "Property 'efficiencies' is deprecated and will be removed after "
-                "Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
+                "Reaction.efficiencies: Property is deprecated and will be removed "
+                "after Cantera 3.0. Access via ThirdBody instead.", DeprecationWarning)
             if self.third_body is None:
                 raise ValueError("Reaction does not involve third body collider")
             return self.third_body.efficiencies
         def __set__(self, eff):
             warnings.warn(
-                "Property 'efficiencies' is deprecated and will be removed after "
-                "Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
+                "Reaction.efficiencies: Property is deprecated and will be removed "
+                "after Cantera 3.0. Access via ThirdBody instead.", DeprecationWarning)
             if self.third_body is None:
                 raise ValueError("Reaction does not involve third body collider")
             self.third_body.efficiencies = comp_map(eff)
@@ -1693,15 +1692,15 @@ cdef class Reaction:
         """
         def __get__(self):
             warnings.warn(
-                "Property 'default_efficiency' is deprecated and will be removed after "
-                "Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
+                "Reaction.default_efficiency: Property is deprecated and will be "
+                "removed after Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
             if self.third_body is None:
                 raise ValueError("Reaction does not involve third body collider")
             return self.third_body.default_efficiency
         def __set__(self, default_eff):
             warnings.warn(
-                "Property 'default_efficiency' is deprecated and will be removed after "
-                "Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
+                "Reaction.default_efficiency: Property is deprecated and will be "
+                "removed after Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
             if self.third_body is None:
                 raise ValueError("Reaction does not involve third body collider")
             self.third_body.default_efficiency = default_eff
@@ -1717,7 +1716,7 @@ cdef class Reaction:
             `ThirdBody` object instead.
         """
         warnings.warn(
-            "Method 'efficiency' is deprecated and will be removed after "
+            "Reaction.efficiency: Method is deprecated and will be removed after "
             "Cantera 3.0. Use ThirdBody instead.", DeprecationWarning)
         if self.third_body is None:
             raise ValueError("Reaction does not involve third body collider")
@@ -1818,8 +1817,8 @@ cdef class ThreeBodyReaction(Reaction):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Class to be removed after Cantera 3.0; no specialization "
-                      "necessary.", DeprecationWarning)
+        warnings.warn("ThreeBodyReaction: Class to be removed after Cantera 3.0; "
+                      "no specialization necessary.", DeprecationWarning)
 
 
 cdef class FalloffReaction(Reaction):
@@ -1852,8 +1851,8 @@ cdef class FalloffReaction(Reaction):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Class to be removed after Cantera 3.0; no specialization "
-                      "necessary.", DeprecationWarning)
+        warnings.warn("FalloffReaction: Class to be removed after Cantera 3.0; "
+                      "no specialization necessary.", DeprecationWarning)
 
 cdef class ChemicallyActivatedReaction(FalloffReaction):
     """
@@ -1864,8 +1863,8 @@ cdef class ChemicallyActivatedReaction(FalloffReaction):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Class to be removed after Cantera 3.0; no specialization "
-                      "necessary.", DeprecationWarning)
+        warnings.warn("ChemicallyActivatedReaction: Class to be removed after Cantera "
+                      "3.0; no specialization necessary.", DeprecationWarning)
 
 cdef class CustomReaction(Reaction):
     """
@@ -1884,5 +1883,5 @@ cdef class CustomReaction(Reaction):
     """
 
     def __init__(self, *args, **kwargs):
-        warnings.warn("Class to be removed after Cantera 3.0; no specialization "
-                      "necessary.", DeprecationWarning)
+        warnings.warn("CustomReaction: Class to be removed after Cantera 3.0; no "
+                      "specialization necessary.", DeprecationWarning)

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -60,8 +60,8 @@ cdef class _SolutionBase:
                 raise AttributeError('duplicate specification of phase name')
 
             warnings.warn(
-                "Support for keyword 'phaseid' to be removed after Cantera 3.0. "
-                "Replaceable by keyword 'name'.", DeprecationWarning)
+                "_SolutionBase: Support for keyword 'phaseid' to be removed after "
+                "Cantera 3.0. Replaceable by keyword 'name'.", DeprecationWarning)
             name = kwargs['phaseid']
 
         if 'phases' in kwargs:
@@ -70,8 +70,8 @@ cdef class _SolutionBase:
                     'duplicate specification of adjacent phases')
 
             warnings.warn(
-                "Support for keyword 'phases' to be removed after Cantera 3.0. "
-                "Replaceable by keyword 'adjacent'.", DeprecationWarning)
+                "_SolutionBase: Support for keyword 'phases' to be removed after "
+                "Cantera 3.0. Replaceable by keyword 'adjacent'.", DeprecationWarning)
             adjacent = kwargs['phases']
 
         # Shallow copy of an existing Solution (for slicing support)

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1874,7 +1874,7 @@ cdef class ThermoPhase(_SolutionBase):
             self.plasma.setQuadratureMethod(stringify(method))
 
     property normalize_electron_energy_distribution_enabled:
-        """ Automatically normalize electron energy distribuion """
+        """ Automatically normalize electron energy distribution """
         def __get__(self):
             if not self._enable_plasma:
                 raise ThermoModelMethodError(self.thermo_model)

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -13,7 +13,7 @@ if env['INSTALL_MANPAGES']:
 
 # cantera.pc for use with pkg-config
 
-pc_libs = list(localenv['cantera_libs'])
+pc_libs = list(localenv['cantera_shared_libs'])
 pc_libdirs = []
 pc_incdirs = []
 pc_cflags = list(localenv['CXXFLAGS'])
@@ -22,19 +22,14 @@ if not localenv["package_build"]:
     pc_incdirs.extend(localenv["extra_inc_dirs"])
     pc_libdirs.extend(localenv["extra_lib_dirs"])
 
-if localenv['system_sundials']:
-    # Add links to the sundials environment
-    if localenv["sundials_libdir"] and not localenv["package_build"]:
-        pc_libdirs.append(localenv['sundials_libdir'])
-
-    if localenv["sundials_include"] and not localenv["package_build"]:
+    if localenv['system_sundials'] and localenv["sundials_include"]:
         pc_incdirs.append(localenv['sundials_include'])
 
-if localenv["boost_inc_dir"] and not localenv["package_build"]:
-    pc_incdirs.append(localenv['boost_inc_dir'])
+    if localenv["boost_inc_dir"]:
+        pc_incdirs.append(localenv['boost_inc_dir'])
 
-if localenv["use_hdf5"] and not localenv["package_build"]:
-    pc_incdirs.append(localenv["hdf_include"])
+    if localenv["use_hdf5"]:
+        pc_incdirs.append(localenv["hdf_include"])
 
 if 'Accelerate' in localenv['FRAMEWORKS']:
     pc_cflags.append('-framework Accelerate')

--- a/platform/posix/cantera.pc.in
+++ b/platform/posix/cantera.pc.in
@@ -8,5 +8,5 @@ Description: Cantera library
 URL: https://cantera.org
 Version: @cantera_version@
 
-Libs: -L${libdir} @pc_libdirs@ @pc_libs@
+Libs: -L${libdir} -Wl,-rpath,${libdir} @pc_libdirs@ @pc_libs@
 Cflags: @pc_cflags@ -I${includedir} @pc_incdirs@

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -160,7 +160,7 @@ string formatDouble(double x, long int precision)
 
     // Build string with full precision
     bool useExp = std::abs(x) < 1e-2 || std::abs(x) >= 1e4;
-    int log10x;
+    int log10x = 0;
     size_t last;
     string s0;
     if (useExp) {

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -9,6 +9,7 @@
 #define CT_CABINET_H
 
 #include "cantera/base/ctexceptions.h"
+#include "cantera/base/utilities.h"
 #include <unordered_map>
 
 namespace Cantera {
@@ -117,7 +118,7 @@ public:
      */
     static void del(int n) {
         dataRef data = getData();
-        if (n >= 0 && n < data.size()) {
+        if (n >= 0 && n < len(data)) {
             lookupRef lookup = getLookup();
             if (!lookup.count(data[n].get())) {
                 throw CanteraError("SharedCabinet::del",
@@ -142,7 +143,7 @@ public:
      */
     static shared_ptr<M>& at(int n) {
         dataRef data = getData();
-        if (n < 0 || n >= data.size()) {
+        if (n < 0 || n >= len(data)) {
             throw CanteraError("SharedCabinet::at", "Index {} out of range.", n);
         }
         if (!data[n]) {

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -40,7 +40,7 @@ namespace Cantera {
  * inadvertently nothing happens, and if an attempt is made to reference the object by
  * its index number, a standard exception is thrown.
  *
- * The SharedCabinet<M> class is implemented as a singlet. The constructor is never
+ * The SharedCabinet<M> class is implemented as a singleton. The constructor is never
  * explicitly called; instead, static function SharedCabinet<M>::SharedCabinet() is
  * called to obtain a pointer to the instance. This function calls the constructor on
  * the first call and stores the pointer to this instance. Subsequent calls simply

--- a/src/equil/ChemEquil.cpp
+++ b/src/equil/ChemEquil.cpp
@@ -1027,10 +1027,8 @@ int ChemEquil::estimateEP_Brinkley(ThermoPhase& s, vector_fp& x,
             for (size_t m = 0; m < m_mm; m++) {
                 size_t kMSp = npos;
                 size_t kMSp2 = npos;
-                int nSpeciesWithElem = 0;
                 for (size_t k = 0; k < m_kk; k++) {
                     if (n_i_calc[k] > nCutoff && fabs(nAtoms(k,m)) > 0.001) {
-                        nSpeciesWithElem++;
                         if (kMSp != npos) {
                             kMSp2 = k;
                             double factor = fabs(nAtoms(kMSp,m) / nAtoms(kMSp2,m));

--- a/src/equil/vcs_solve_TP.cpp
+++ b/src/equil/vcs_solve_TP.cpp
@@ -816,7 +816,7 @@ void VCS_SOLVE::solve_tp_inner(size_t& iti, size_t& it1,
         // We have a tentative m_deltaMolNumSpecies[]. Now apply other criteria
         // to limit its magnitude.
         double par = 0.5;
-        size_t ll;
+        size_t ll = 0;
         for (size_t k = 0; k < m_numComponents; ++k) {
             if (m_molNumSpecies_old[k] > 0.0) {
                 double xx = -m_deltaMolNumSpecies[k] / m_molNumSpecies_old[k];

--- a/src/extensions/pythonShim.cpp
+++ b/src/extensions/pythonShim.cpp
@@ -13,7 +13,6 @@
 #include <boost/dll/alias.hpp>
 
 #include "Python.h"
-#include <codecvt>
 #include <filesystem>
 
 #ifdef _WIN32
@@ -83,7 +82,7 @@ void loadCanteraPython()
         #endif
         string path(venv_path);
         path += suffix;
-        wstring wpath = wstring_convert<codecvt_utf8<wchar_t>>().from_bytes(path);
+        wstring wpath = std::filesystem::path(path).wstring();
         PyStatus status = PyConfig_SetString(&pyconf, &pyconf.program_name,
                                                 wpath.c_str());
         checkPythonError(PyStatus_Exception(status), "PyConfig_SetString failed");

--- a/src/numerics/ResidJacEval.cpp
+++ b/src/numerics/ResidJacEval.cpp
@@ -3,6 +3,7 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
+#define CT_SKIP_DEPRECATION_WARNINGS
 #include "cantera/numerics/ResidJacEval.h"
 #include "cantera/base/global.h"
 

--- a/src/numerics/funcs.cpp
+++ b/src/numerics/funcs.cpp
@@ -50,7 +50,7 @@ double trapezoidal(const Eigen::ArrayXd& f, const Eigen::ArrayXd& x)
 //! Only for odd number of points. This function is used only
 //! by calling simpson.
 /*!
- * Vector x contanins a monotonic sequence of grid points, and
+ * Vector x contains a monotonic sequence of grid points, and
  * Vector f contains function values defined at these points.
  * The size of x and f must be the same.
  *

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -452,7 +452,6 @@ void Sim1D::solve(int loglevel, bool refine_grid)
     int new_points = 1;
     doublereal dt = m_tstep;
     m_nsteps = 0;
-    int soln_number = -1;
     finalize();
 
     while (new_points > 0) {
@@ -495,7 +494,6 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                                  "After successful Newton solve");
                 }
                 ok = true;
-                soln_number++;
             } else {
                 debuglog("    failure. \n", loglevel);
                 if (loglevel > 6) {

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -29,6 +29,11 @@ void FlowReactor::getStateDae(double* y, double* ydot)
     // set the first component to the initial density
     y[0] = m_rho;
 
+    if (m_u < 0) {
+        throw CanteraError("FlowReactor::getStateDae",
+            "Set mass flow rate before initializing reactor");
+    }
+
     // set the second component to the initial speed
     y[1] = m_u;
 

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -68,11 +68,11 @@ TEST(ct, soln_objects)
 
     int thermo = soln_thermo(ref2);
     ASSERT_EQ(thermo, 2);
-    ASSERT_EQ(thermo_nSpecies(thermo), 10);
+    ASSERT_EQ(thermo_nSpecies(thermo), 10u);
 
     int kin = soln_kinetics(ref2);
     ASSERT_EQ(kin, 1);
-    ASSERT_EQ(kin_nReactions(kin), 29);
+    ASSERT_EQ(kin_nReactions(kin), 29u);
 
     int trans = soln_kinetics(ref2);
     ASSERT_EQ(trans, 1);
@@ -138,7 +138,7 @@ TEST(ct, new_interface_auto)
     int surf = soln_newInterface("ptcombust.yaml", "Pt_surf", 0, adj.data());
     ASSERT_EQ(surf, 1);
 
-    ASSERT_EQ(soln_nAdjacent(surf), 1);
+    ASSERT_EQ(soln_nAdjacent(surf), 1u);
     int gas = soln_adjacent(surf, 0);
     ASSERT_EQ(gas, 0);
 
@@ -156,7 +156,7 @@ TEST(ct, thermo)
     int thermo = thermo_newFromFile("gri30.yaml", "gri30");
     ASSERT_GE(thermo, 0);
     size_t nsp = thermo_nSpecies(thermo);
-    ASSERT_EQ(nsp, 53);
+    ASSERT_EQ(nsp, 53u);
 
     ret = thermo_setTemperature(thermo, 500);
     ASSERT_EQ(ret, 0);
@@ -179,7 +179,7 @@ TEST(ct, kinetics)
     ASSERT_GE(kin, 0);
 
     size_t nr = kin_nReactions(kin);
-    ASSERT_EQ(nr, 325);
+    ASSERT_EQ(nr, 325u);
 
     thermo_equilibrate(thermo, "HP", 0, 1e-9, 50000, 1000, 0);
     double T = thermo_temperature(thermo);

--- a/test/clib/test_ctonedim.cpp
+++ b/test/clib/test_ctonedim.cpp
@@ -245,7 +245,7 @@ TEST(ctonedim, freeflame_from_parts)
         ASSERT_GE(ret, 0);
     }
 
-    ASSERT_EQ(domain_nPoints(flow), nz + 1);
+    ASSERT_EQ(domain_nPoints(flow), static_cast<size_t>(nz + 1));
     comp = static_cast<int>(domain_componentIndex(dom, "T"));
     double Tprev = sim1D_value(flame, dom, comp, 0);
     for (size_t n = 0; n < domain_nPoints(flow); n++) {

--- a/test/general/test_composite.cpp
+++ b/test/general/test_composite.cpp
@@ -87,7 +87,7 @@ TEST(SolutionArray, normalize)
     vector<double> state = arr->getState(0); // size is 12
     vector<double> newState = {state[0], state[1], 1, 1, 1, 1, 1, 1, 1, 1, 1, -1e12};
     ASSERT_EQ(newState.size(), state.size());
-    for (size_t loc = 0; loc < arr->size(); loc++) {
+    for (int loc = 0; loc < arr->size(); loc++) {
         arr->setState(loc, newState);
         state = arr->getState(loc);
         for (size_t i = 0; i < state.size(); i++) {
@@ -95,7 +95,7 @@ TEST(SolutionArray, normalize)
         }
     }
     arr->normalize();
-    for (size_t loc = 0; loc < arr->size(); loc++) {
+    for (int loc = 0; loc < arr->size(); loc++) {
         state = arr->getState(loc);
         for (size_t i = 2; i < state.size() - 1; i++) {
             // test normalized species mass fractions - all are equal except last
@@ -109,7 +109,7 @@ TEST(SolutionArray, normalize)
 
     newState = {state[0], state[1], 100, 0, 0, 0, 0, 0, 0, 0, 0, -1e12};
     ASSERT_EQ(newState.size(), state.size());
-    for (size_t loc = 0; loc < arr->size(); loc++) {
+    for (int loc = 0; loc < arr->size(); loc++) {
         arr->setState(loc, newState);
         state = arr->getState(loc);
         for (size_t i = 0; i < state.size(); i++) {
@@ -117,7 +117,7 @@ TEST(SolutionArray, normalize)
         }
     }
     arr->normalize();
-    for (size_t loc = 0; loc < arr->size(); loc++) {
+    for (int loc = 0; loc < arr->size(); loc++) {
         state = arr->getState(loc);
         ASSERT_EQ(state[2], 1.);
         for (size_t i = 3; i < state.size(); i++) {
@@ -222,7 +222,7 @@ TEST(SolutionArray, extraSingle) {
 template<class T>
 void testSingleCol(SolutionArray& arr, const T& value, bool sliced=false)
 {
-    size_t size = arr.size();
+    int size = arr.size();
     T defaultValue = vector<T>(1)[0];
 
     AnyValue any;
@@ -240,8 +240,8 @@ void testSingleCol(SolutionArray& arr, const T& value, bool sliced=false)
     AnyValue extra;
     extra = arr.getComponent("spam");
     ASSERT_TRUE(extra.isVector<T>());
-    ASSERT_EQ(extra.asVector<T>().size(), arr.size());
-    for (size_t i = 0; i < size; ++i) {
+    ASSERT_EQ(len(extra.asVector<T>()), arr.size());
+    for (int i = 0; i < size; ++i) {
         ASSERT_EQ(extra.asVector<T>()[i], value);
     }
 
@@ -259,7 +259,7 @@ void testSingleCol(SolutionArray& arr, const T& value, bool sliced=false)
         extra = arr.getComponent("spam");
         ASSERT_TRUE(extra.isVector<T>());
         ASSERT_EQ(arr.size(), 2 * size);
-        for (size_t i = 0; i < size; ++i) {
+        for (int i = 0; i < size; ++i) {
             ASSERT_EQ(extra.asVector<T>()[i], value);
             ASSERT_EQ(extra.asVector<T>()[i + size], defaultValue);
         }
@@ -269,7 +269,7 @@ void testSingleCol(SolutionArray& arr, const T& value, bool sliced=false)
     extra = arr.getComponent("spam");
     AnyMap m;
     m["spam"] = value;
-    for (size_t i = 0; i < arr.size(); ++i) {
+    for (int i = 0; i < arr.size(); ++i) {
         ASSERT_EQ(extra.asVector<T>()[i], defaultValue);
         arr.setAuxiliary(i, m);
         ASSERT_EQ(arr.getAuxiliary(i)["spam"].as<T>(), value);
@@ -279,7 +279,7 @@ void testSingleCol(SolutionArray& arr, const T& value, bool sliced=false)
     any = value;
     arr.setComponent("spam", any);
     extra = arr.getComponent("spam");
-    for (size_t i = 0; i < arr.size(); ++i) {
+    for (int i = 0; i < arr.size(); ++i) {
         ASSERT_EQ(extra.asVector<T>()[i], value);
     }
 }
@@ -361,7 +361,7 @@ TEST(SolutionArray, extraSlicedStrings) {
 template<class T>
 void testMultiCol(SolutionArray& arr, const vector<T>& value, bool sliced=false)
 {
-    size_t size = arr.size();
+    int size = arr.size();
     T defaultValue = vector<T>(1)[0];
 
     AnyValue any;
@@ -382,8 +382,8 @@ void testMultiCol(SolutionArray& arr, const vector<T>& value, bool sliced=false)
     ASSERT_TRUE(extra.isMatrix<T>());
     ASSERT_EQ(extra.matrixShape().first, arr.size());
     ASSERT_EQ(extra.matrixShape().second, any.vectorSize());
-    for (size_t i = 0; i < size; ++i) {
-        for (size_t j = 0; j < value.size(); ++j) {
+    for (int i = 0; i < size; ++i) {
+        for (int j = 0; j < value.size(); ++j) {
             ASSERT_EQ(extra.asVector<vector<T>>()[i][j], value[j]);
         }
     }
@@ -406,9 +406,9 @@ void testMultiCol(SolutionArray& arr, const vector<T>& value, bool sliced=false)
         arr.resize(2 * size);
         extra = arr.getComponent("spam");
         ASSERT_EQ(arr.size(), 2 * size);
-        ASSERT_EQ(extra.asVector<vector<T>>().size(), 2 * size);
-        for (size_t i = 0; i < size; ++i) {
-            for (size_t j = 0; j < value.size(); ++j) {
+        ASSERT_EQ(len(extra.asVector<vector<T>>()), 2 * size);
+        for (int i = 0; i < size; ++i) {
+            for (int j = 0; j < value.size(); ++j) {
                 ASSERT_EQ(extra.asVector<vector<T>>()[i][j], value[j]);
                 ASSERT_EQ(extra.asVector<vector<T>>()[i + size][j], defaultValue);
             }
@@ -421,7 +421,7 @@ void testMultiCol(SolutionArray& arr, const vector<T>& value, bool sliced=false)
     extra = arr.getComponent("spam");
     ASSERT_TRUE(extra.isMatrix<T>());
     ASSERT_EQ(extra.matrixShape().second, value.size());
-    for (size_t i = 0; i < arr.size(); ++i) {
+    for (int i = 0; i < arr.size(); ++i) {
         for (size_t j = 0; j < value.size(); ++j) {
             ASSERT_EQ(extra.asVector<vector<T>>()[i][j], defaultValue);
         }

--- a/test/general/test_composite.cpp
+++ b/test/general/test_composite.cpp
@@ -44,11 +44,11 @@ TEST(SolutionArray, empty)
     AnyValue vec;
     vec = arr->getComponent("T");
     ASSERT_TRUE(vec.isVector<double>());
-    ASSERT_EQ(vec.vectorSize(), 0);
+    ASSERT_EQ(vec.vectorSize(), 0u);
 
     vec = arr->getComponent("H2");
     ASSERT_TRUE(vec.isVector<double>());
-    ASSERT_EQ(vec.vectorSize(), 0);
+    ASSERT_EQ(vec.vectorSize(), 0u);
 
     ASSERT_THROW(arr->getAuxiliary(0), CanteraError);
     ASSERT_THROW(arr->getComponent("foo"), CanteraError);
@@ -65,11 +65,11 @@ TEST(SolutionArray, simple)
     AnyValue vec;
     vec = arr->getComponent("T");
     ASSERT_TRUE(vec.isVector<double>());
-    ASSERT_EQ(vec.vectorSize(), 5);
+    ASSERT_EQ(vec.vectorSize(), 5u);
 
     vec = arr->getComponent("H2");
     ASSERT_TRUE(vec.isVector<double>());
-    ASSERT_EQ(vec.vectorSize(), 5);
+    ASSERT_EQ(vec.vectorSize(), 5u);
 
     ASSERT_THROW(arr->getComponent("foo"), CanteraError);
 
@@ -157,7 +157,7 @@ TEST(SolutionArray, extraEmpty) {
     arr->setComponent("spam", any);
     any = arr->getComponent("spam");
     ASSERT_TRUE(any.isVector<double>());
-    ASSERT_EQ(any.asVector<double>().size(), 0);
+    ASSERT_EQ(any.asVector<double>().size(), 0u);
     arr->setComponent("spam", AnyValue());
     any = arr->getComponent("spam");
     ASSERT_TRUE(any.is<void>());
@@ -177,7 +177,7 @@ TEST(SolutionArray, extraSingle) {
     // set entire component
     any = vector<double>({3.1415});
     ASSERT_TRUE(any.isVector<double>());
-    ASSERT_EQ(any.asVector<double>().size(), 1);
+    ASSERT_EQ(any.asVector<double>().size(), 1u);
 
     // reset
     arr->setComponent("spam", AnyValue());
@@ -189,7 +189,7 @@ TEST(SolutionArray, extraSingle) {
     arr->setComponent("spam", any);
     any = arr->getComponent("spam");
     ASSERT_TRUE(any.isVector<long int>());
-    ASSERT_EQ(any.asVector<long int>().size(), 1);
+    ASSERT_EQ(any.asVector<long int>().size(), 1u);
     any = 2;
     arr->setComponent("spam", any);
     any = vector<double>({2.});
@@ -201,7 +201,7 @@ TEST(SolutionArray, extraSingle) {
     arr->setComponent("spam", any);
     any = arr->getComponent("spam");
     ASSERT_TRUE(any.isVector<string>());
-    ASSERT_EQ(any.asVector<string>().size(), 1);
+    ASSERT_EQ(any.asVector<string>().size(), 1u);
 
     // replace/initialize using default values: vectors
     any = vector<long int>({3, 4, 5});
@@ -210,8 +210,8 @@ TEST(SolutionArray, extraSingle) {
     arr->setComponent("spam", any);
     any = arr->getComponent("spam");
     ASSERT_TRUE(any.isMatrix<long int>());
-    ASSERT_EQ(any.matrixShape().first, 1);
-    ASSERT_EQ(any.matrixShape().second, 3);
+    ASSERT_EQ(any.matrixShape().first, 1u);
+    ASSERT_EQ(any.matrixShape().second, 3u);
 
     // attempt to reset with empty vector
     arr->setComponent("spam", AnyValue());
@@ -380,10 +380,10 @@ void testMultiCol(SolutionArray& arr, const vector<T>& value, bool sliced=false)
     AnyValue extra;
     extra = arr.getComponent("spam");
     ASSERT_TRUE(extra.isMatrix<T>());
-    ASSERT_EQ(extra.matrixShape().first, arr.size());
+    ASSERT_EQ(extra.matrixShape().first, static_cast<size_t>(arr.size()));
     ASSERT_EQ(extra.matrixShape().second, any.vectorSize());
     for (int i = 0; i < size; ++i) {
-        for (int j = 0; j < value.size(); ++j) {
+        for (size_t j = 0; j < value.size(); ++j) {
             ASSERT_EQ(extra.asVector<vector<T>>()[i][j], value[j]);
         }
     }
@@ -408,7 +408,7 @@ void testMultiCol(SolutionArray& arr, const vector<T>& value, bool sliced=false)
         ASSERT_EQ(arr.size(), 2 * size);
         ASSERT_EQ(len(extra.asVector<vector<T>>()), 2 * size);
         for (int i = 0; i < size; ++i) {
-            for (int j = 0; j < value.size(); ++j) {
+            for (size_t j = 0; j < value.size(); ++j) {
                 ASSERT_EQ(extra.asVector<vector<T>>()[i][j], value[j]);
                 ASSERT_EQ(extra.asVector<vector<T>>()[i + size][j], defaultValue);
             }

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -414,7 +414,7 @@ TEST(AnyMap, nestedVectorsToYaml)
         for (size_t j = 0; j < 4; j++) {
             strings.back().push_back(words[(i + 3 * j) % words.size()]);
             booleans.back().push_back(i == j);
-            integers.back().push_back(6*i + j);
+            integers.back().push_back(static_cast<int>(6*i + j));
         }
     }
     AnyMap original;

--- a/test/general/test_serialization.cpp
+++ b/test/general/test_serialization.cpp
@@ -18,7 +18,7 @@ TEST(YamlWriter, formatDouble)
 {
     AnyMap m;
     int count;
-    float delta;
+    double delta;
 
     // check least significant digit
     // default precision is 15 (see AnyMap.cpp::getPrecision)
@@ -49,7 +49,7 @@ TEST(YamlWriter, formatDoubleExp)
 {
     AnyMap m;
     int count;
-    float delta;
+    double delta;
 
     // check least significant digit
     // default precision is 15 (see AnyMap.cpp::getPrecision)
@@ -572,8 +572,8 @@ TEST(Storage, writeData)
 
     // matrices
     any = vector<vector<double>>({{1.1, 2.2, 3.3}, {4.4, 5.5, 6.6}});
-    EXPECT_EQ(any.matrixShape().first, 2);
-    EXPECT_EQ(any.matrixShape().second, 3);
+    EXPECT_EQ(any.matrixShape().first, 2u);
+    EXPECT_EQ(any.matrixShape().second, 3u);
     file->writeData("test", "double-matrix", any);
     any = vector<vector<long int>>({{1, 2}, {3, 4}, {5, 6}});
     file->writeData("test", "integer-matrix", any);
@@ -586,7 +586,7 @@ TEST(Storage, writeData)
 
     // invalid vectors of vectors (irregular shape)
     any = vector<vector<double>>({{1.1, 2.2}, {3.3}});
-    EXPECT_EQ(any.matrixShape().first, 2);
+    EXPECT_EQ(any.matrixShape().first, 2u);
     EXPECT_EQ(any.matrixShape().second, npos);
     EXPECT_THROW(file->writeData("test", "invalid3", any), CanteraError);
     any = vector<vector<long int>>({{1, 2}, {3, 4, 5}, {6}});
@@ -657,19 +657,19 @@ TEST(Storage, readData)
 
     auto data = file->readData("test", "double-vector", 3);
     ASSERT_TRUE(data.isVector<double>());
-    ASSERT_EQ(data.asVector<double>().size(), 3);
+    ASSERT_EQ(data.asVector<double>().size(), 3u);
     // need to know length
     EXPECT_THROW(file->readData("test", "double-vector", 4), CanteraError);
 
     data = file->readData("test", "integer-vector", 4, 0);
     ASSERT_TRUE(data.isVector<long int>());
-    ASSERT_EQ(data.asVector<long int>().size(), 4);
+    ASSERT_EQ(data.asVector<long int>().size(), 4u);
     // invalid number of columns
     EXPECT_THROW(file->readData("test", "integer-vector", 4, 2), CanteraError);
 
     data = file->readData("test", "string-vector", 2);
     ASSERT_TRUE(data.isVector<string>());
-    ASSERT_EQ(data.asVector<string>().size(), 2);
+    ASSERT_EQ(data.asVector<string>().size(), 2u);
 
     data = file->readData("test", "double-matrix", 2);
     ASSERT_TRUE(data.isMatrix<double>());

--- a/test/oneD/test_oneD.cpp
+++ b/test/oneD/test_oneD.cpp
@@ -61,7 +61,7 @@ TEST(onedim, freeflame)
     // set up simulation
     vector<shared_ptr<Domain1D>> domains { inlet, flow, outlet };
     Sim1D flame(domains);
-    int dom = flame.domainIndex("flow");
+    int dom = static_cast<int>(flame.domainIndex("flow"));
     ASSERT_EQ(dom, 1);
 
     // set up initial guess
@@ -92,7 +92,7 @@ TEST(onedim, freeflame)
         flame.save("gtest-freeflame.h5", "cpp", "Solution from C++ interface", true);
     }
 
-    ASSERT_EQ(flow->nPoints(), nz + 1);
+    ASSERT_EQ(flow->nPoints(), static_cast<size_t>(nz + 1));
     size_t comp = flow->componentIndex("T");
     double Tprev = flame.value(dom, comp, 0);
     for (size_t n = 0; n < flow->nPoints(); n++) {

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -723,9 +723,11 @@ class TestLegacyHDF(utilities.CanteraTest):
     def test_legacy_hdf_str_column_h5py(self):
         self.run_read_legacy_hdf_str_column(legacy=True)
 
+
     @pytest.mark.xfail(reason="Unable to read fixed length strings from HDF")
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
+    @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
     def test_legacy_hdf_str_column(self):
         # h5py writes strings with fixed length, which require a priori knowledge of
         # length in order to be read with HighFive (which currently only supports
@@ -752,6 +754,7 @@ class TestLegacyHDF(utilities.CanteraTest):
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
+    @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
     def test_legacy_hdf_multidim(self):
         self.run_read_legacy_hdf_multidim()
 
@@ -801,6 +804,7 @@ class TestLegacyHDF(utilities.CanteraTest):
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
+    @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
     def test_legacy_hdf(self):
         self.run_legacy_hdf()
 
@@ -834,6 +838,7 @@ class TestLegacyHDF(utilities.CanteraTest):
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
+    @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
     def test_read_legacy_hdf_no_norm(self):
         self.run_read_legacy_hdf_no_norm()
 
@@ -860,6 +865,7 @@ class TestLegacyHDF(utilities.CanteraTest):
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
+    @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
     def test_import_no_norm_water(self):
         self.run_import_no_norm_water()
 

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -104,7 +104,7 @@ class TestModels(utilities.CanteraTest):
                 else:
                     X = a.X
                     xmin = np.min(X[X>0])
-                    ix = np.where(xmin)
+                    ix = np.where(X == xmin)
                     X[ix] = .5 * X[ix]
                     X = np.diag(X.sum(axis=1)).dot(X)
                     self.assertFalse(sol.is_pure)

--- a/test/python/test_jacobian.py
+++ b/test/python/test_jacobian.py
@@ -625,14 +625,17 @@ class TestBlowersMasel(FromScratchCases, utilities.CanteraTest):
     rate_type = "Blowers-Masel"
 
     @pytest.mark.xfail(reason="Change of reaction enthalpy is not considered")
+    @pytest.mark.filterwarnings("ignore:.*does not consider.*(electron|enthalpy).*:UserWarning")
     def test_forward_rop_ddT(self):
         super().test_forward_rop_ddT()
 
     @pytest.mark.xfail(reason="Change of reaction enthalpy is not considered")
+    @pytest.mark.filterwarnings("ignore:.*does not consider.*(electron|enthalpy).*:UserWarning")
     def test_reverse_rop_ddT(self):
         super().test_reverse_rop_ddT()
 
     @pytest.mark.xfail(reason="Change of reaction enthalpy is not considered")
+    @pytest.mark.filterwarnings("ignore:.*does not consider.*(electron|enthalpy).*:UserWarning")
     def test_net_rop_ddT(self):
         super().test_net_rop_ddT()
 

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -1052,7 +1052,7 @@ class TestLithiumIonBatteryKinetics(utilities.CanteraTest):
             electrolyte.electric_potential = phi_l
 
             # Calculate the current.
-            return ct.faraday * anode_int.net_rates_of_progress * area_anode
+            return ct.faraday * anode_int.net_rates_of_progress[0] * area_anode
 
         # This function returns the Cantera calculated cathode current
         def cathode_current(phi_s, phi_l, X_Li_cathode):
@@ -1062,7 +1062,7 @@ class TestLithiumIonBatteryKinetics(utilities.CanteraTest):
             electrolyte.electric_potential = phi_l
 
             # Calculate the current. Should be negative for cell discharge.
-            return - ct.faraday * cathode_int.net_rates_of_progress * area_cathode
+            return - ct.faraday * cathode_int.net_rates_of_progress[0] * area_cathode
 
         # Calculate cell voltage, separately for each entry of the input vectors
         data = []

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -349,6 +349,8 @@ class TestFreeFlame(utilities.CanteraTest):
         for rhou_j in self.sim.density * self.sim.velocity:
             self.assertNear(rhou_j, rhou, 1e-4)
 
+    @pytest.mark.filterwarnings("ignore:.*_FlowBase.settings.*Cantera 3.0.*:DeprecationWarning")
+    @pytest.mark.filterwarnings("ignore:.*FlameBase.settings.*Cantera 3.0.*:DeprecationWarning")
     def test_settings(self):
         self.create_sim(p=ct.one_atm, Tin=400, reactants='H2:0.8, O2:0.5', width=0.1)
         self.sim.set_initial_guess()
@@ -567,6 +569,7 @@ class TestFreeFlame(utilities.CanteraTest):
         # TODO: check that the solution is actually correct (that is, that the
         # residual satisfies the error tolerances) on the new grid.
 
+    @pytest.mark.filterwarnings("ignore:.*legacy YAML format.*:UserWarning")
     def test_restore_legacy_yaml(self):
         reactants = 'H2:1.1, O2:1, AR:5'
         p = 5 * ct.one_atm
@@ -796,6 +799,7 @@ class TestFreeFlame(utilities.CanteraTest):
         self.run_restore_legacy_hdf(True)
 
     @pytest.mark.usefixtures("allow_deprecated")
+    @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
     def test_restore_legacy_hdf(self):
@@ -823,10 +827,12 @@ class TestFreeFlame(utilities.CanteraTest):
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
+    @pytest.mark.filterwarnings("ignore:.*_FlowBase.settings.*Cantera 3.0.*:DeprecationWarning")
     def test_save_restore_hdf(self):
         # save and restore with native format (HighFive only)
         self.run_save_restore("h5")
 
+    @pytest.mark.filterwarnings("ignore:.*_FlowBase.settings.*Cantera 3.0.*:DeprecationWarning")
     def test_save_restore_yaml(self):
         self.run_save_restore("yaml")
 
@@ -1554,9 +1560,10 @@ class TestImpingingJet(utilities.CanteraTest):
     @pytest.mark.usefixtures("allow_deprecated")
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
+    @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
     def test_restore_legacy_hdf(self):
         # Legacy input file was created using the Cantera 2.6 Python test suite:
-        # - restore_legacy.h5 -> test_onedim.py::TestImpinginJet::test_write_hdf
+        # - restore_legacy.h5 -> test_onedim.py::TestImpingingJet::test_write_hdf
         filename = self.test_data_path / f"impingingjet_legacy.h5"
 
         self.run_reacting_surface(xch4=0.095, tsurf=900.0, mdot=0.06, width=0.1)
@@ -1593,8 +1600,8 @@ class TestImpingingJet(utilities.CanteraTest):
         k = self.sim.gas.species_index('H2')
         assert list(jet.X[k, :]) == pytest.approx(list(self.sim.X[k, :]), 1e-4)
 
-        settings = self.sim.settings
-        for k, v in jet.settings.items():
+        settings = self.sim.flame.get_settings3()
+        for k, v in jet.flame.get_settings3().items():
             assert k in settings
             if k == "fixed_temperature":
                 # fixed temperature is NaN

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -339,6 +339,7 @@ class TestBlowersMaselRate(ReactionRateTests, utilities.CanteraTest):
         self.assertTrue(rate.allow_negative_pre_exponential_factor)
 
     @pytest.mark.xfail(reason="Change of reaction enthalpy is not considered")
+    @pytest.mark.filterwarnings("ignore:.*does not consider.*(enthalpy|electron).*:UserWarning")
     def test_derivative_ddT(self):
         super().test_derivative_ddT()
 
@@ -375,6 +376,7 @@ class TestTwoTempPlasmaRate(ReactionRateTests, utilities.CanteraTest):
         rate.allow_negative_pre_exponential_factor = True
         self.assertTrue(rate.allow_negative_pre_exponential_factor)
 
+    @pytest.mark.filterwarnings("ignore:.*does not consider.*(enthalpy|electron).*:UserWarning")
     def test_derivative_ddT(self):
         # check temperature derivative against numerical derivative
         deltaT = self.soln.derivative_settings["rtol-delta"]

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1499,6 +1499,7 @@ class TestFlowReactor(utilities.CanteraTest):
         surf = ct.Interface('methane_pox_on_pt.yaml', 'Pt_surf')
         gas = surf.adjacent['gas']
         r = ct.FlowReactor(gas)
+        r.mass_flow_rate = 0.1
         rsurf = ct.ReactorSurface(surf, r)
         sim = ct.ReactorNet([r])
         sim.initialize()
@@ -1529,6 +1530,14 @@ class TestFlowReactor2(utilities.CanteraTest):
         rsurf = ct.ReactorSurface(surf, r)
         sim = ct.ReactorNet([r])
         return r, rsurf, sim
+
+    def test_no_mass_flow_rate(self):
+        surf, gas = self.import_phases()
+        r = ct.FlowReactor(gas)
+        rsurf = ct.ReactorSurface(surf, r)
+        sim = ct.ReactorNet([r])
+        with pytest.raises(ct.CanteraError, match="mass flow rate"):
+            sim.initialize()
 
     def test_mixed_reactor_types(self):
         surf, gas = self.import_phases()

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1998,7 +1998,7 @@ class TestSolutionArray(utilities.CanteraTest):
         self.assertEqual(Dkm.shape, (2,3,5,self.gas.n_species))
 
         for i,j,k in np.ndindex(TT.shape):
-            self.gas.TPX = T[k], P[i], X[j]
+            self.gas.TPX = T[k], P[i][0][0], X[j]
             self.assertNear(self.gas.enthalpy_mass, h[i,j,k])
             self.assertArrayNear(self.gas.reverse_rates_of_progress, ropr[i,j,k])
             self.assertArrayNear(self.gas.mix_diff_coeffs, Dkm[i,j,k])

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -120,7 +120,7 @@ TEST(AdaptivePreconditionerTests, test_adaptive_precon_utils)
     precon.setIlutDropTol(droptol);
     EXPECT_NEAR(precon.ilutDropTol(), droptol, tol);
 
-    double fillfactor = testSize/2;
+    int fillfactor = static_cast<int>(testSize) / 2;
     precon.setIlutFillFactor(fillfactor);
     EXPECT_NEAR(precon.ilutFillFactor(), fillfactor, tol);
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix various compiler warnings. Almost all CI configurations are currently free of warnings for compiling both the main library as well as the test suite, with a couple of exceptions
  - The Intel compiler generates some warnings from within Eigen, and seems to be ignoring the compiler flags that are intended to ignore warnings from external/system libraries.
  - MSVC issues some warnings about symbols from `yaml-cpp` being marked as DLL export that MSVC thinks maybe shouldn't be.
- Fix deprecation warnings from Numpy about treating non-zero-D arrays a scalars
- Check that mass flow rate is set for `FlowReactor`. On macOS using `openblas`, not doing this before calling `initialize` would lead to a confusing LAPACK error.
- Update `yaml-cpp` submodule (to fix warnings related to C++17)
- Improve deprecation warnings issued from Python to include the name of the deprecated method, and to show the line where that function is called from (rather than the line with the call to `warnings.warn`
- Hide "expected" warnings in the `pytest` test suite
- Fix documentation typos and some Doxygen formatting issues
- Bump version to 3.0.0b1 (the corresponding commit will be tagged after this is merged). I'll hold off on merging this until after a couple of other currently-open PRs are merged.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
