### PR TITLE
Update C++ SolutionArray interface to use 'int'

### DIFF
--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -27,7 +27,7 @@ class SolutionArray
 {
 private:
     SolutionArray(const shared_ptr<Solution>& sol,
-                  size_t size,
+                  int size,
                   const AnyMap& meta);
 
     SolutionArray(const SolutionArray& arr, const vector<int>& indices);
@@ -43,7 +43,7 @@ public:
      *  @param meta  AnyMap holding SolutionArray meta data
      */
     static shared_ptr<SolutionArray> create(const shared_ptr<Solution>& sol,
-                                            size_t size=0,
+                                            int size=0,
                                             const AnyMap& meta={})
     {
         return shared_ptr<SolutionArray>(new SolutionArray(sol, size, meta));
@@ -70,7 +70,7 @@ public:
     }
 
     //! Resize SolutionArray objects with a single dimension (default).
-    void resize(size_t size);
+    void resize(int size);
 
     //! SolutionArray shape information used by high-level API's.
     vector<long int> apiShape() const {
@@ -82,8 +82,8 @@ public:
     void setApiShape(const vector<long int>& shape);
 
     //! Number of SolutionArray dimensions used by high-level API's.
-    size_t apiNdim() const {
-        return m_apiShape.size();
+    int apiNdim() const {
+        return static_cast<int>(m_apiShape.size());
     }
 
     /*!
@@ -142,18 +142,18 @@ public:
     /*!
      *  Update the buffered location used to access SolutionArray entries.
      */
-    void setLoc(size_t loc, bool restore=true);
+    void setLoc(int loc, bool restore=true);
 
     /*!
      *  Update state at given location to state of associated Solution object.
      */
-    void updateState(size_t loc);
+    void updateState(int loc);
 
     //! Retrieve the state vector for a given location.
-    vector<double> getState(size_t loc);
+    vector<double> getState(int loc);
 
     //! Set the state vector for a given location.
-    void setState(size_t loc, const vector<double>& state);
+    void setState(int loc, const vector<double>& state);
 
     //! Normalize mass/mole fractions
     void normalize();
@@ -178,10 +178,10 @@ public:
     vector<string> listExtra(bool all=true) const;
 
     //! Retrieve auxiliary data for a given location.
-    AnyMap getAuxiliary(size_t loc);
+    AnyMap getAuxiliary(int loc);
 
     //! Set auxiliary data for a given location.
-    void setAuxiliary(size_t loc, const AnyMap& data);
+    void setAuxiliary(int loc, const AnyMap& data);
 
     //! Append location entry at end of SolutionArray.
     void append(const vector<double>& state, const AnyMap& extra);

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -67,11 +67,11 @@ cdef extern from "cantera/base/SolutionArray.h" namespace "Cantera":
     cdef cppclass CxxSolutionArray "Cantera::SolutionArray":
         shared_ptr[CxxSolutionArray] share(vector[int]&) except +translate_exception
         void reset() except +translate_exception
-        size_t size()
-        void resize(size_t) except +translate_exception
+        int size()
+        void resize(int) except +translate_exception
         vector[long int] apiShape() except +translate_exception
         void setApiShape(vector[long int]&) except +translate_exception
-        size_t apiNdim()
+        int apiNdim()
         string info(vector[string]&, int, int) except +translate_exception
         CxxAnyMap meta()
         void setMeta(CxxAnyMap&)
@@ -79,21 +79,21 @@ cdef extern from "cantera/base/SolutionArray.h" namespace "Cantera":
         cbool hasComponent(string&)
         CxxAnyValue getComponent(string&) except +translate_exception
         void setComponent(string&, CxxAnyValue&) except +translate_exception
-        void setLoc(size_t) except +translate_exception
-        void updateState(size_t) except +translate_exception
-        vector[double] getState(size_t) except +translate_exception
-        void setState(size_t, vector[double]&) except +translate_exception
+        void setLoc(int) except +translate_exception
+        void updateState(int) except +translate_exception
+        vector[double] getState(int) except +translate_exception
+        void setState(int, vector[double]&) except +translate_exception
         vector[string] listExtra()
         cbool hasExtra(string&)
         void addExtra(string&, cbool) except +translate_exception
-        CxxAnyMap getAuxiliary(size_t) except +translate_exception
-        void setAuxiliary(size_t, CxxAnyMap&) except +translate_exception
+        CxxAnyMap getAuxiliary(int) except +translate_exception
+        void setAuxiliary(int, CxxAnyMap&) except +translate_exception
         void append(vector[double]&, CxxAnyMap&) except +translate_exception
         void save(string&, string&, string&, string&, cbool, int, string&) except +translate_exception
         CxxAnyMap restore(string&, string&, string&) except +translate_exception
 
     cdef shared_ptr[CxxSolutionArray] CxxNewSolutionArray "Cantera::SolutionArray::create" (
-        shared_ptr[CxxSolution], size_t, CxxAnyMap&) except +translate_exception
+        shared_ptr[CxxSolution], int, CxxAnyMap&) except +translate_exception
 
 
 ctypedef void (*transportMethod1d)(CxxTransport*, double*) except +translate_exception

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -63,7 +63,7 @@ public:
     static int add(shared_ptr<M> obj) {
         dataRef data = getData();
         data.push_back(obj);
-        int idx = data.size() - 1;
+        int idx = static_cast<int>(data.size()) - 1;
         lookupRef lookup = getLookup();
         if (index(*obj) >= 0) {
             lookup[obj.get()].insert(idx);
@@ -77,8 +77,7 @@ public:
      * Return cabinet size.
      */
     static int size() {
-        int size = getData().size();
-        return size;
+        return static_cast<int>(getData().size());
     }
 
     /**
@@ -87,7 +86,7 @@ public:
     static int clear() {
         dataRef data = getData();
         for (size_t i = 0; i < data.size(); i++) {
-            del(i);
+            del(static_cast<int>(i));
         }
         return 0;
     }

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -27,7 +27,8 @@ extern "C" {
     {
         try {
             shared_ptr<Func1> r;
-            size_t m = lenp;
+            int m = static_cast<int>(lenp);
+            int nn = static_cast<int>(n);
             if (type == SinFuncType) {
                 r = newFunc1("sin", params[0]);
             } else if (type == CosFuncType) {
@@ -51,21 +52,21 @@ extern "C" {
                 vector<double> par(params, params + lenp);
                 r = newFunc1("Arrhenius", par, n);
             } else if (type == PeriodicFuncType) {
-                r = newFunc1("periodic", FuncCabinet::at(n), params[0]);
+                r = newFunc1("periodic", FuncCabinet::at(nn), params[0]);
             } else if (type == SumFuncType) {
-                r = newFunc1("sum", FuncCabinet::at(n), FuncCabinet::at(m));
+                r = newFunc1("sum", FuncCabinet::at(nn), FuncCabinet::at(m));
             } else if (type == DiffFuncType) {
-                r = newFunc1("diff", FuncCabinet::at(n), FuncCabinet::at(m));
+                r = newFunc1("diff", FuncCabinet::at(nn), FuncCabinet::at(m));
             } else if (type == ProdFuncType) {
-                r = newFunc1("product", FuncCabinet::at(n), FuncCabinet::at(m));
+                r = newFunc1("product", FuncCabinet::at(nn), FuncCabinet::at(m));
             } else if (type == RatioFuncType) {
-                r = newFunc1("ratio", FuncCabinet::at(n), FuncCabinet::at(m));
+                r = newFunc1("ratio", FuncCabinet::at(nn), FuncCabinet::at(m));
             } else if (type == CompositeFuncType) {
-                r = newFunc1("composite", FuncCabinet::at(n), FuncCabinet::at(m));
+                r = newFunc1("composite", FuncCabinet::at(nn), FuncCabinet::at(m));
             } else if (type == TimesConstantFuncType) {
-                r = newFunc1("times-constant", FuncCabinet::at(n), params[0]);
+                r = newFunc1("times-constant", FuncCabinet::at(nn), params[0]);
             } else if (type == PlusConstantFuncType) {
-                r = newFunc1("plus-constant", FuncCabinet::at(n), params[0]);
+                r = newFunc1("plus-constant", FuncCabinet::at(nn), params[0]);
             } else {
                 throw CanteraError("func_new", "unknown function type");
             }

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -789,7 +789,8 @@ AnyMap StFlow::getMeta() const
 
 shared_ptr<SolutionArray> StFlow::asArray(const double* soln) const
 {
-    auto arr = SolutionArray::create(m_solution, nPoints(), getMeta());
+    auto arr = SolutionArray::create(
+        m_solution, static_cast<int>(nPoints()), getMeta());
     arr->addExtra("grid", false); // leading entry
     AnyValue value;
     value = m_z;

--- a/test/clib/test_ctonedim.cpp
+++ b/test/clib/test_ctonedim.cpp
@@ -208,10 +208,10 @@ TEST(ctonedim, freeflame_from_parts)
     // set up initial guess
     vector<double> locs{0.0, 0.3, 0.7, 1.0};
     vector<double> value{uin, uin, uout, uout};
-    int comp = domain_componentIndex(flow, "velocity");
+    int comp = static_cast<int>(domain_componentIndex(flow, "velocity"));
     sim1D_setProfile(flame, dom, comp, 4, locs.data(), 4, value.data());
     value = {T, T, Tad, Tad};
-    comp = domain_componentIndex(flow, "T");
+    comp = static_cast<int>(domain_componentIndex(flow, "T"));
     sim1D_setProfile(flame, dom, comp, 4, locs.data(), 4, value.data());
     for (size_t i = 0; i < nsp; i++) {
         value = {yin[i], yin[i], yout[i], yout[i]};
@@ -220,7 +220,7 @@ TEST(ctonedim, freeflame_from_parts)
         thermo_getSpeciesName(ph, i, buflen, buf);
         string name = buf;
         ASSERT_EQ(name, gas->speciesName(i));
-        comp = domain_componentIndex(flow, buf);
+        comp = static_cast<int>(domain_componentIndex(flow, buf));
         sim1D_setProfile(flame, dom, comp, 4, locs.data(), 4, value.data());
     }
 
@@ -246,10 +246,10 @@ TEST(ctonedim, freeflame_from_parts)
     }
 
     ASSERT_EQ(domain_nPoints(flow), nz + 1);
-    comp = domain_componentIndex(dom, "T");
+    comp = static_cast<int>(domain_componentIndex(dom, "T"));
     double Tprev = sim1D_value(flame, dom, comp, 0);
     for (size_t n = 0; n < domain_nPoints(flow); n++) {
-        T = sim1D_value(flame, dom, comp, n);
+        T = sim1D_value(flame, dom, comp, static_cast<int>(n));
         ASSERT_GE(T, Tprev);
         Tprev = T;
     }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Use `int` for all C++ `SolutionArray` interface methods
- Fixes MSVC warnings
- Avoids potential warnings from `clib`

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
