### PR TITLE
Enhance Python Func1 Interface

### DIFF
--- a/doc/sphinx/cython/zerodim.rst
+++ b/doc/sphinx/cython/zerodim.rst
@@ -13,7 +13,7 @@ Defining Functions
 
 .. autoclass:: Func1
 
-.. autoclass:: TabulatedFunction
+.. autoclass:: Tabulated1
 
 Base Classes
 ------------

--- a/include/cantera/clib/ctfunc.h
+++ b/include/cantera/clib/ctfunc.h
@@ -16,8 +16,7 @@ extern "C" {
 
     CANTERA_CAPI int func_new(int type, size_t n, size_t lenp, const double* p);
     CANTERA_CAPI int func_new_basic(const char* type, double c);
-    CANTERA_CAPI int func_new_advanced(
-        const char* type, size_t lenp, const double* p, size_t n);
+    CANTERA_CAPI int func_new_advanced(const char* type, size_t lenp, const double* p);
     CANTERA_CAPI int func_new_compound(const char* type, int a, int b);
     CANTERA_CAPI int func_new_modified(const char* type, int a, double c);
     CANTERA_CAPI int func_del(int i);

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -134,7 +134,7 @@ public:
 
     //! Returns a string describing the type of the function
     //! @since  New in Cantera 3.0.
-    string type_name() const;
+    string typeName() const;
 
     //! Calls method eval to evaluate the function
     doublereal operator()(doublereal t) const;

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -132,6 +132,10 @@ public:
         return "functor";
     }
 
+    //! Returns a string describing the type of the function
+    //! @since  New in Cantera 3.0.
+    string type_name() const;
+
     //! Calls method eval to evaluate the function
     doublereal operator()(doublereal t) const;
 

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -274,7 +274,7 @@ public:
     }
 
     //! Constructor uses single parameter (frequency)
-    Sin1(const vector<double>& params, size_t n=npos);
+    Sin1(const vector<double>& params);
 
     Sin1(const Sin1& b) :
         Func1(b) {
@@ -323,7 +323,7 @@ public:
     }
 
     //! Constructor uses single parameter (frequency)
-    Cos1(const vector<double>& params, size_t n=npos);
+    Cos1(const vector<double>& params);
 
     Cos1(const Cos1& b) :
         Func1(b) {
@@ -368,7 +368,7 @@ public:
     }
 
     //! Constructor uses single parameter (exponent factor)
-    Exp1(const vector<double>& params, size_t n=npos);
+    Exp1(const vector<double>& params);
 
     Exp1(const Exp1& b) :
         Func1(b) {
@@ -413,7 +413,7 @@ public:
     }
 
     //! Constructor uses single parameter (factor)
-    Log1(const vector<double>& params, size_t n=npos);
+    Log1(const vector<double>& params);
 
     virtual string type() const {
         return "log";
@@ -442,7 +442,7 @@ public:
     }
 
     //! Constructor uses single parameter (exponent)
-    Pow1(const vector<double>& params, size_t n=npos);
+    Pow1(const vector<double>& params);
 
     Pow1(const Pow1& b) :
         Func1(b) {
@@ -495,7 +495,7 @@ public:
 
     //! Constructor uses \f$ 2 n\f$ parameters in the following order:
     //! \f$ [t_0, t_1, \dots, t_{n-1}, f_0, f_1, \dots, f_{n-1}] \f$
-    Tabulated1(const vector<double>& params, size_t n);
+    Tabulated1(const vector<double>& params);
 
     //! Set the interpolation method
     //! @param method  Evaluation method. If \c "linear" (default), a linear
@@ -540,7 +540,7 @@ public:
     }
 
     //! Constructor uses single parameter (constant)
-    Const1(const vector<double>& params, size_t n=npos);
+    Const1(const vector<double>& params);
 
     Const1(const Const1& b) :
         Func1(b) {
@@ -1098,7 +1098,7 @@ public:
 
     //! Constructor uses 3 parameters in the following order:
     //! \f$ [A, t_0, \mathrm{fwhm}] \f$
-    Gaussian1(const vector<double>& params, size_t n=npos);
+    Gaussian1(const vector<double>& params);
 
     Gaussian1(const Gaussian1& b) :
         Func1(b) {
@@ -1171,7 +1171,7 @@ public:
 
     //! Constructor uses \f$ n + 1 \f$ parameters in the following order:
     //! \f$ [a_n, \dots, a_1, a_0] \f$
-    Poly1(const vector<double>& params, size_t n);
+    Poly1(const vector<double>& params);
 
     Poly1(const Poly1& b) :
         Func1(b) {
@@ -1231,7 +1231,7 @@ public:
 
     //! Constructor uses \f$ 2 n + 2 \f$ parameters in the following order:
     //! \f$ [a_0, a_1, \dots, a_n, \omega, b_1, \dots, b_n] \f$
-    Fourier1(const vector<double>& params, size_t n);
+    Fourier1(const vector<double>& params);
 
     Fourier1(const Fourier1& b) :
         Func1(b) {
@@ -1299,7 +1299,7 @@ public:
 
     //! Constructor uses \f$ 3 n\f$ parameters in the following order:
     //! \f$ [A_1, b_1, E_1, A_2, b_2, E_2, \dots, A_n, b_n, E_n] \f$
-    Arrhenius1(const vector<double>& params, size_t n=1);
+    Arrhenius1(const vector<double>& params);
 
     Arrhenius1(const Arrhenius1& b) :
         Func1() {

--- a/include/cantera/numerics/Func1Factory.h
+++ b/include/cantera/numerics/Func1Factory.h
@@ -20,7 +20,7 @@ namespace Cantera
 //!     shared_ptr<Func1> d1 = newFunc1("sin", {1.0});
 //! ```
 //! @since New in Cantera 3.0
-class Func1Factory : public Factory<Func1, const vector<double>&, size_t>
+class Func1Factory : public Factory<Func1, const vector<double>&>
 {
 public:
     /**
@@ -121,11 +121,9 @@ shared_ptr<Func1> newFunc1(const string& func1Type, double coeff=1.);
 //! Create a new advanced functor object (see \ref func1advanced).
 //! @param func1Type  String identifying functor type.
 //! @param params  Parameter vector; definition depends on functor type.
-//! @param n  Integer; definition depends on function type and may or may not be used.
 //! @ingroup func1advanced
 //! @since New in Cantera 3.0
-shared_ptr<Func1> newFunc1(const string& func1Type,
-                           const vector<double>& params, size_t n=1);
+shared_ptr<Func1> newFunc1(const string& func1Type, const vector<double>& params);
 
 //! Create a new compound functor object (see \ref func1compound).
 //! @param func1Type  String identifying functor type.

--- a/interfaces/cython/cantera/func1.pxd
+++ b/interfaces/cython/cantera/func1.pxd
@@ -6,13 +6,14 @@
 
 from .ctcxx cimport *
 
+
 cdef extern from "cantera/numerics/Func1.h":
     cdef cppclass CxxFunc1 "Cantera::Func1":
         double eval(double) except +translate_exception
+        string type()
+        string type_name()
+        string write(string)
 
-    cdef cppclass CxxTabulated1 "Cantera::Tabulated1" (CxxFunc1):
-        CxxTabulated1(int, double*, double*, string) except +translate_exception
-        double eval(double) except +translate_exception
 
 cdef extern from "cantera/cython/funcWrapper.h":
     ctypedef double (*callback_wrapper)(double, void*, void**) except? 0.0
@@ -31,12 +32,20 @@ cdef extern from "cantera/cython/funcWrapper.h":
         void setExceptionValue(PyObject*)
 
 
+cdef extern from "cantera/numerics/Func1Factory.h":
+    cdef shared_ptr[CxxFunc1] CxxNewFunc1 "Cantera::newFunc1" (
+        string, double) except +translate_exception
+    cdef shared_ptr[CxxFunc1] CxxNewFunc1 "Cantera::newFunc1" (
+        string, vector[double]&) except +translate_exception
+    cdef shared_ptr[CxxFunc1] CxxNewFunc1 "Cantera::newFunc1" (
+        string, shared_ptr[CxxFunc1], shared_ptr[CxxFunc1]) except +translate_exception
+    cdef shared_ptr[CxxFunc1] CxxNewFunc1 "Cantera::newFunc1" (
+        string, shared_ptr[CxxFunc1], double) except +translate_exception
+
+
 cdef class Func1:
     cdef shared_ptr[CxxFunc1] _func
     cdef CxxFunc1* func
     cdef object callable
     cdef object exception
     cpdef void _set_callback(self, object) except *
-
-cdef class TabulatedFunction(Func1):
-    cpdef void _set_tables(self, object, object, string) except *

--- a/interfaces/cython/cantera/func1.pxd
+++ b/interfaces/cython/cantera/func1.pxd
@@ -6,13 +6,20 @@
 
 from .ctcxx cimport *
 
+cdef extern from "cantera/numerics/Func1.h":
+    cdef cppclass CxxFunc1 "Cantera::Func1":
+        double eval(double) except +translate_exception
+
+    cdef cppclass CxxTabulated1 "Cantera::Tabulated1" (CxxFunc1):
+        CxxTabulated1(int, double*, double*, string) except +translate_exception
+        double eval(double) except +translate_exception
+
 cdef extern from "cantera/cython/funcWrapper.h":
     ctypedef double (*callback_wrapper)(double, void*, void**) except? 0.0
     cdef int translate_exception()
 
-    cdef cppclass CxxFunc1 "Func1Py":
-        CxxFunc1(callback_wrapper, void*)
-        double eval(double) except +translate_exception
+    cdef cppclass CxxFunc1Py "Func1Py" (CxxFunc1):
+        CxxFunc1Py(callback_wrapper, void*)
 
     cdef cppclass PyFuncInfo:
         PyFuncInfo()
@@ -22,12 +29,6 @@ cdef extern from "cantera/cython/funcWrapper.h":
         void setExceptionType(PyObject*)
         PyObject* exceptionValue()
         void setExceptionValue(PyObject*)
-
-
-cdef extern from "cantera/numerics/Func1.h":
-    cdef cppclass CxxTabulated1 "Cantera::Tabulated1":
-        CxxTabulated1(int, double*, double*, string) except +translate_exception
-        double eval(double) except +translate_exception
 
 
 cdef class Func1:

--- a/interfaces/cython/cantera/func1.pxd
+++ b/interfaces/cython/cantera/func1.pxd
@@ -11,7 +11,7 @@ cdef extern from "cantera/numerics/Func1.h":
     cdef cppclass CxxFunc1 "Cantera::Func1":
         double eval(double) except +translate_exception
         string type()
-        string type_name()
+        string typeName()
         string write(string)
 
 

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -90,7 +90,7 @@ cdef class Func1:
 
     cpdef void _set_callback(self, c) except *:
         self.callable = c
-        self._func.reset(new CxxFunc1(func_callback, <void*>self))
+        self._func.reset(new CxxFunc1Py(func_callback, <void*>self))
         self.func = self._func.get()
 
     def __call__(self, t):

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -151,7 +151,7 @@ cdef class Func1:
         else:
             raise ValueError("Invalid arguments")
 
-        cls_name = pystr(func.get().type_name()).split("::")[-1]
+        cls_name = pystr(func.get().typeName()).split("::")[-1]
         cdef Func1 out = type(
             cls_name, (cls, ), {"__module__": cls.__module__})(None, init=False)
         out._func = func

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -7,6 +7,7 @@ import numpy as np
 
 from ._utils cimport *
 
+
 cdef double func_callback(double t, void* obj, void** err) except? 0.0:
     """
     This function is called from C/C++ to evaluate a `Func1` object ``obj``,
@@ -65,33 +66,107 @@ cdef class Func1:
         self.exception = None
         self.callable = None
 
-    def __init__(self, c):
+    def __init__(self, c, *, init=True):
+        if init is False:
+            # used by 'create' classmethod
+            return
         if hasattr(c, '__call__'):
             # callback function
             self._set_callback(c)
-        else:
-            arr = np.array(c)
-            try:
-                if arr.ndim == 0:
-                    # handle constants or unsized numpy arrays
-                    k = float(c)
-                    self._set_callback(lambda t: k)
-                elif arr.size == 1:
-                    # handle lists, tuples or numpy arrays with a single element
-                    k = float(c[0])
-                    self._set_callback(lambda t: k)
-                else:
-                    raise TypeError
+            return
 
-            except TypeError:
-                raise TypeError(
-                    "'Func1' objects must be constructed from a number or "
-                    "a callable object") from None
+        cdef Func1 func
+        try:
+            arr = np.array(c)
+            if arr.ndim == 0:
+                # handle constants or unsized numpy arrays
+                k = float(c)
+            elif arr.size == 1:
+                # handle lists, tuples or numpy arrays with a single element
+                k = float(c[0])
+            else:
+                raise TypeError
+            func = Func1.cxx_functor("constant", k)
+            self._func = func._func
+            self.func = self._func.get()
+
+        except TypeError:
+            raise TypeError(
+                "'Func1' objects must be constructed from a number or "
+                "a callable object") from None
 
     cpdef void _set_callback(self, c) except *:
         self.callable = c
         self._func.reset(new CxxFunc1Py(func_callback, <void*>self))
         self.func = self._func.get()
+
+    @property
+    def type(self):
+        """
+        Return the type of the underlying C++ functor object.
+
+        .. versionadded:: 3.0
+        """
+        return pystr(self.func.type())
+
+    @classmethod
+    def cxx_functor(cls, functor_type, *args):
+        """
+        Retrieve a C++ `Func1` functor (advanced feature).
+
+        For implemented functor types, see the Cantera C++ ``Func1`` documentation.
+
+        .. versionadded:: 3.0
+        """
+        cdef shared_ptr[CxxFunc1] func
+        cdef Func1 f0
+        cdef Func1 f1
+        cdef string cxx_string = stringify(functor_type)
+        cdef vector[double] arr
+        if len(args) == 0:
+            # simple functor with no parameter
+            func = CxxNewFunc1(cxx_string, 1.)
+        elif len(args) == 1:
+            if hasattr(args[0], "__len__"):
+                # advanced functor with array and no parameter
+                for v in args[0]:
+                    arr.push_back(v)
+                func = CxxNewFunc1(cxx_string, arr)
+            else:
+                # simple functor with scalar parameter
+                func = CxxNewFunc1(cxx_string, float(args[0]))
+        elif len(args) == 2:
+            if isinstance(args[0], Func1) and isinstance(args[1], Func1):
+                # compound functor
+                f0 = args[0]
+                f1 = args[1]
+                func = CxxNewFunc1(cxx_string, f0._func, f1._func)
+            elif isinstance(args[0], Func1):
+                # modified functor
+                f0 = args[0]
+                func = CxxNewFunc1(cxx_string, f0._func, float(args[1]))
+            else:
+                raise ValueError("Invalid arguments")
+        else:
+            raise ValueError("Invalid arguments")
+
+        cls_name = pystr(func.get().type_name()).split("::")[-1]
+        cdef Func1 out = type(
+            cls_name, (cls, ), {"__module__": cls.__module__})(None, init=False)
+        out._func = func
+        out.func = out._func.get()
+        return out
+
+    def write(self, name="t"):
+        """
+        Write a :math:`LaTeX` expression representing a functor.
+
+        :param name:
+            Name of the variable to be used.
+
+        .. versionadded:: 3.0
+        """
+        return pystr(self.func.write(stringify(name)))
 
     def __call__(self, t):
         return self.func.eval(t)
@@ -134,17 +209,7 @@ cdef class TabulatedFunction(Func1):
     """
 
     def __init__(self, time, fval, method='linear'):
-        self._set_tables(time, fval, stringify(method))
-
-    cpdef void _set_tables(self, time, fval, string method) except *:
-        tt = np.asarray(time, dtype=np.double)
-        ff = np.asarray(fval, dtype=np.double)
-        if tt.size != ff.size:
-            raise ValueError("Sizes of arrays do not match "
-                             "({} vs {})".format(tt.size, ff.size))
-        elif tt.size == 0:
-            raise ValueError("Arrays must not be empty.")
-        cdef np.ndarray[np.double_t, ndim=1] tvec = tt
-        cdef np.ndarray[np.double_t, ndim=1] fvec = ff
-        self.func = <CxxFunc1*>(new CxxTabulated1(tt.size, &tvec[0], &fvec[0],
-                                                  method))
+        arr = np.hstack([np.array(time), np.array(fval)])
+        cdef Func1 func = Func1.cxx_functor(f"tabulated-{method}", arr)
+        self._func = func._func
+        self.func = self._func.get()

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -41,16 +41,16 @@ extern "C" {
                 r = newFunc1("constant", params[0]);
             } else if (type == FourierFuncType) {
                 vector<double> par(params, params + lenp);
-                r = newFunc1("Fourier", par, n);
+                r = newFunc1("Fourier", par);
             } else if (type == GaussianFuncType) {
                 vector<double> par(params, params + lenp);
-                r = newFunc1("Gaussian", par, n);
+                r = newFunc1("Gaussian", par);
             } else if (type == PolyFuncType) {
                 vector<double> par(params, params + lenp);
-                r = newFunc1("polynomial", par, n);
+                r = newFunc1("polynomial", par);
             } else if (type == ArrheniusFuncType) {
                 vector<double> par(params, params + lenp);
-                r = newFunc1("Arrhenius", par, n);
+                r = newFunc1("Arrhenius", par);
             } else if (type == PeriodicFuncType) {
                 r = newFunc1("periodic", FuncCabinet::at(nn), params[0]);
             } else if (type == SumFuncType) {
@@ -85,11 +85,11 @@ extern "C" {
         }
     }
 
-    int func_new_advanced(const char* type, size_t lenp, const double* params, size_t n)
+    int func_new_advanced(const char* type, size_t lenp, const double* params)
     {
         try {
             vector<double> par(params, params + lenp);
-            return FuncCabinet::add(newFunc1(type, par, n));
+            return FuncCabinet::add(newFunc1(type, par));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -46,7 +46,7 @@ int Func1::ID() const
     return 0;
 }
 
-string Func1::type_name() const
+string Func1::typeName() const
 {
     return demangle(typeid(*this));
 }

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -612,7 +612,7 @@ Func1& Periodic1::duplicate() const {
 
 string Func1::write(const std::string& arg) const
 {
-    return fmt::format("<unknown {}>({})", ID(), arg);
+    return fmt::format("\\mathrm{{{}}}({})", type(), arg);
 }
 
 string Pow1::write(const std::string& arg) const

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -147,7 +147,7 @@ void Func1::setParent(Func1* p)
 
 /*****************************************************************************/
 
-Sin1::Sin1(const vector<double>& params, size_t n)
+Sin1::Sin1(const vector<double>& params)
 {
     if (params.size() != 1) {
         throw CanteraError("Sin1::Sin1",
@@ -189,7 +189,7 @@ shared_ptr<Func1> Sin1::derivative3() const
 
 /*****************************************************************************/
 
-Cos1::Cos1(const vector<double>& params, size_t n)
+Cos1::Cos1(const vector<double>& params)
 {
     if (params.size() != 1) {
         throw CanteraError("Cos1::Cos1",
@@ -231,7 +231,7 @@ std::string Cos1::write(const std::string& arg) const
 
 /**************************************************************************/
 
-Exp1::Exp1(const vector<double>& params, size_t n)
+Exp1::Exp1(const vector<double>& params)
 {
     if (params.size() != 1) {
         throw CanteraError("Exp1::Exp1",
@@ -276,7 +276,7 @@ std::string Exp1::write(const std::string& arg) const
     }
 }
 
-Log1::Log1(const vector<double>& params, size_t n)
+Log1::Log1(const vector<double>& params)
 {
     if (params.size() != 1) {
         throw CanteraError("Log1::Log1",
@@ -304,7 +304,7 @@ std::string Log1::write(const std::string& arg) const
 
 /******************************************************************************/
 
-Pow1::Pow1(const vector<double>& params, size_t n)
+Pow1::Pow1(const vector<double>& params)
 {
     if (params.size() != 1) {
         throw CanteraError("Pow1::Pow1",
@@ -349,7 +349,7 @@ shared_ptr<Func1> Pow1::derivative3() const
 
 /******************************************************************************/
 
-Const1::Const1(const vector<double>& params, size_t n)
+Const1::Const1(const vector<double>& params)
 {
     if (params.size() != 1) {
         throw CanteraError("Const1::Const1",
@@ -358,31 +358,28 @@ Const1::Const1(const vector<double>& params, size_t n)
     m_c = params[0];
 }
 
-Poly1::Poly1(const vector<double>& params, size_t n)
+Poly1::Poly1(const vector<double>& params)
 {
-    if (n < 0) {
+    if (params.size() == 0) {
         throw CanteraError("Poly1::Poly1",
-            "Parameter n must be at least 0.");
+            "Constructor needs an array that is not empty.");
     }
-    if (params.size() != n + 1) {
-        throw CanteraError("Poly1::Poly1",
-            "Constructor needs exactly n + 1 = {} parameters (with n={}).", n + 1, n);
-    }
+    size_t n = params.size() - 1;
     m_cpoly.resize(n + 1);
     copy(params.data(), params.data() + m_cpoly.size(), m_cpoly.begin());
 }
 
-Fourier1::Fourier1(const vector<double>& params, size_t n)
+Fourier1::Fourier1(const vector<double>& params)
 {
-    if (n < 1) {
+    if (params.size() < 4) {
         throw CanteraError("Fourier1::Fourier1",
-            "Parameter n must be at least 1.");
+            "Constructor needs an array with at least 4 entries.");
     }
-    if (params.size() != 2 * n + 2) {
+    if (params.size() % 2 != 0) {
         throw CanteraError("Fourier1::Fourier1",
-            "Constructor needs exactly 2 * n + 2 = {} parameters (with n={}).",
-            2 * n + 2, n);
+            "Constructor needs an array with an even number of entries.");
     }
+    size_t n = params.size() / 2 - 1;
     m_omega = params[n + 1];
     m_a0_2 = 0.5 * params[0];
     m_ccos.resize(n);
@@ -391,7 +388,7 @@ Fourier1::Fourier1(const vector<double>& params, size_t n)
     copy(params.data() + n + 2, params.data() + 2 * n + 2, m_csin.begin());
 }
 
-Gaussian1::Gaussian1(const vector<double>& params, size_t n)
+Gaussian1::Gaussian1(const vector<double>& params)
 {
     if (params.size() != 3) {
         throw CanteraError("Gaussian1::Gaussian1",
@@ -402,17 +399,17 @@ Gaussian1::Gaussian1(const vector<double>& params, size_t n)
     m_tau = params[2] / (2. * sqrt(log(2.)));
 }
 
-Arrhenius1::Arrhenius1(const vector<double>& params, size_t n)
+Arrhenius1::Arrhenius1(const vector<double>& params)
 {
-    if (n < 1) {
+    if (params.size() < 3) {
         throw CanteraError("Arrhenius1::Arrhenius1",
-            "Parameter n must be at least 1.");
+            "Constructor needs an array with at least 3 entries.");
     }
-    if (params.size() != 3 * n) {
+    if (params.size() % 3 != 0) {
         throw CanteraError("Arrhenius1::Arrhenius1",
-            "Constructor needs exactly 3 * n parameters grouped as (Ai, bi, Ei) for "
-            "i=0..n-1.");
+            "Constructor needs an array with multiples of 3 entries.");
     }
+    size_t n = params.size() / 3;
     m_A.resize(n);
     m_b.resize(n);
     m_E.resize(n);
@@ -440,16 +437,17 @@ Tabulated1::Tabulated1(size_t n, const double* tvals, const double* fvals,
     setMethod(method);
 }
 
-Tabulated1::Tabulated1(const vector<double>& params, size_t n) : m_isLinear(true)
+Tabulated1::Tabulated1(const vector<double>& params) : m_isLinear(true)
 {
-    if (n < 1) {
+    if (params.size() < 4) {
         throw CanteraError("Tabulated1::Tabulated1",
-            "Parameter n must be at least 1.");
+            "Constructor needs an array with at least 4 entries.");
     }
-    if (params.size() != 2 * n) {
+    if (params.size() % 2 != 0) {
         throw CanteraError("Tabulated1::Tabulated1",
-            "Constructor needs exactly 2 * n = {} parameters (with n={}).", 2 * n, n);
+            "Constructor needs an array with an even number of entries.");
     }
+    size_t n = params.size() / 2;
     m_tvec.resize(n);
     copy(params.data(), params.data() + n, m_tvec.begin());
     for (auto it = std::begin(m_tvec) + 1; it != std::end(m_tvec); it++) {

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -46,6 +46,11 @@ int Func1::ID() const
     return 0;
 }
 
+string Func1::type_name() const
+{
+    return demangle(typeid(*this));
+}
+
 // Calls method eval to evaluate the function
 doublereal Func1::operator()(doublereal t) const
 {

--- a/src/numerics/Func1Factory.cpp
+++ b/src/numerics/Func1Factory.cpp
@@ -13,44 +13,44 @@ std::mutex Func1Factory::s_mutex;
 
 Func1Factory::Func1Factory()
 {
-    reg("functor", [](const vector<double>& params, size_t n) {
+    reg("functor", [](const vector<double>& params) {
         return new Func1();
     });
-    reg("sin", [](const vector<double>& params, size_t n) {
+    reg("sin", [](const vector<double>& params) {
         return new Sin1(params);
     });
-    reg("cos", [](const vector<double>& params, size_t n) {
+    reg("cos", [](const vector<double>& params) {
         return new Cos1(params);
     });
-    reg("exp", [](const vector<double>& params, size_t n) {
+    reg("exp", [](const vector<double>& params) {
         return new Exp1(params);
     });
-    reg("log", [](const vector<double>& params, size_t n) {
+    reg("log", [](const vector<double>& params) {
         return new Log1(params);
     });
-    reg("pow", [](const vector<double>& params, size_t n) {
+    reg("pow", [](const vector<double>& params) {
         return new Pow1(params);
     });
-    reg("constant", [](const vector<double>& params, size_t n) {
+    reg("constant", [](const vector<double>& params) {
         return new Const1(params);
     });
-    reg("polynomial", [](const vector<double>& params, size_t n) {
-        return new Poly1(params, n);
+    reg("polynomial", [](const vector<double>& params) {
+        return new Poly1(params);
     });
-    reg("Fourier", [](const vector<double>& params, size_t n) {
-        return new Fourier1(params, n);
+    reg("Fourier", [](const vector<double>& params) {
+        return new Fourier1(params);
     });
-    reg("Gaussian", [](const vector<double>& params, size_t n) {
-        return new Gaussian1(params, n);
+    reg("Gaussian", [](const vector<double>& params) {
+        return new Gaussian1(params);
     });
-    reg("Arrhenius", [](const vector<double>& params, size_t n) {
-        return new Arrhenius1(params, n);
+    reg("Arrhenius", [](const vector<double>& params) {
+        return new Arrhenius1(params);
     });
-    reg("tabulated-linear", [](const vector<double>& params, size_t n) {
-        return new Tabulated1(params, n);
+    reg("tabulated-linear", [](const vector<double>& params) {
+        return new Tabulated1(params);
     });
-    reg("tabulated-previous", [](const vector<double>& params, size_t n) {
-        auto fcn = new Tabulated1(params, n);
+    reg("tabulated-previous", [](const vector<double>& params) {
+        auto fcn = new Tabulated1(params);
         fcn->setMethod("previous");
         return fcn;
     });
@@ -145,14 +145,13 @@ void Math1FactoryB::deleteFactory()
 shared_ptr<Func1> newFunc1(const string& func1Type, double coeff)
 {
     return shared_ptr<Func1>(
-        Func1Factory::factory()->create(func1Type, {coeff}, npos));
+        Func1Factory::factory()->create(func1Type, {coeff}));
 }
 
-shared_ptr<Func1> newFunc1(const string& func1Type,
-                           const vector<double>& params, size_t n)
+shared_ptr<Func1> newFunc1(const string& func1Type, const vector<double>& params)
 {
     return shared_ptr<Func1>(
-        Func1Factory::factory()->create(func1Type, params, n));
+        Func1Factory::factory()->create(func1Type, params));
 }
 
 shared_ptr<Func1> newFunc1(const string& func1Type, const shared_ptr<Func1> f1,

--- a/test/clib/test_ctfunc.cpp
+++ b/test/clib/test_ctfunc.cpp
@@ -13,7 +13,7 @@ TEST(ctfunc, invalid)
 {
     // exceptions return -1
     ASSERT_EQ(func_new_basic("spam", 0.), -1);
-    ASSERT_EQ(func_new_advanced("eggs", 0, NULL, 1), -1);
+    ASSERT_EQ(func_new_advanced("eggs", 0, NULL), -1);
 }
 
 TEST(ctfunc, sin)
@@ -86,55 +86,45 @@ TEST(ctfunc, tabulated_linear)
 {
     vector<double> params = {0., 1., 2., 1., 0., 1.};
 
-    int fcn = func_new_advanced("tabulated-linear", params.size(), params.data(), 3);
+    int fcn = func_new_advanced("tabulated-linear", params.size(), params.data());
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), 0.5);
 
     // exceptions return -1
-    EXPECT_EQ(
-        func_new_advanced("tabulated-linear", params.size(), params.data(), 2), -1);
-    EXPECT_EQ(func_new_advanced("tabulated-linear", 5, params.data(), 3), -1);
+    EXPECT_EQ(func_new_advanced("tabulated-linear", 5, params.data()), -1);
 }
 
 TEST(ctfunc, tabulated_previous)
 {
     vector<double> params = {0., 1., 2., 1., 0., 1.};
 
-    int fcn = func_new_advanced("tabulated-previous", params.size(), params.data(), 3);
+    int fcn = func_new_advanced("tabulated-previous", params.size(), params.data());
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), 1.);
 }
 
 TEST(ctfunc, poly)
 {
-    int n = 2;
     double a0 = .5;
     double a1 = .25;
     double a2 = .125;
     vector<double> params = {a0, a1, a2};
-    int fcn = func_new_advanced("polynomial", params.size(), params.data(), n);
+    int fcn = func_new_advanced("polynomial", params.size(), params.data());
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func_value(fcn, .5), (a2 * .5 + a1) * .5 + a0);
-
-    // exceptions return -1
-    EXPECT_EQ(func_new_advanced("polynomial", n, params.data(), n), -1);
 }
 
 TEST(ctfunc, Fourier)
 {
-    int n = 1;
     double a0 = .5;
     double a1 = .25;
     double b1 = .125;
     double omega = 2.;
     vector<double> params = {a0, a1, omega, b1};
-    int fcn = func_new_advanced("Fourier", params.size(), params.data(), n);
+    int fcn = func_new_advanced("Fourier", params.size(), params.data());
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(
         func_value(fcn, .5), .5 * a0 + a1 * cos(omega * .5) + b1 * sin(omega * .5));
-
-    // exceptions return -1
-    EXPECT_EQ(func_new_advanced("Fourier", 2 * n, params.data(), n), -1);
 }
 
 TEST(ctfunc, Gaussian)
@@ -143,14 +133,14 @@ TEST(ctfunc, Gaussian)
     double t0 = .6;
     double fwhm = .25;
     vector<double> params = {A, t0, fwhm};
-    int fcn = func_new_advanced("Gaussian", params.size(), params.data(), npos);
+    int fcn = func_new_advanced("Gaussian", params.size(), params.data());
     ASSERT_GE(fcn, 0);
     double tau = fwhm / (2. * sqrt(log(2.)));
     double x = - t0 / tau;
     EXPECT_DOUBLE_EQ(func_value(fcn, 0.), A * exp(-x * x));
 
     // exceptions return -1
-    EXPECT_EQ(func_new_advanced("Gaussian", 2, params.data(), 0), -1);
+    EXPECT_EQ(func_new_advanced("Gaussian", 2, params.data()), -1);
 }
 
 TEST(ctfunc, Arrhenius)
@@ -159,7 +149,7 @@ TEST(ctfunc, Arrhenius)
     double b = 2.7;
     double E = 2.619184e+07 / GasConstant;
     vector<double> params = {A, b, E};
-    int fcn = func_new_advanced("Arrhenius", params.size(), params.data(), 1);
+    int fcn = func_new_advanced("Arrhenius", params.size(), params.data());
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func_value(fcn, 1000.), A * pow(1000., b) * exp(-E/1000.));
 }
@@ -258,7 +248,7 @@ TEST(ctmath, generic)
     // Composite function reported in issue #752
 
     vector<double> params = {0., 0., 1., 1.};
-    int fs = func_new_advanced("Fourier", params.size(), params.data(), 1); // sin(x)
+    int fs = func_new_advanced("Fourier", params.size(), params.data()); // sin(x)
     auto func_s = newFunc1("sin", 1.);
     EXPECT_DOUBLE_EQ(func_value(fs, 0.5), func_s->eval(0.5));
 
@@ -267,7 +257,7 @@ TEST(ctmath, generic)
     EXPECT_DOUBLE_EQ(func_value(fs2, 0.5), func_s2->eval(0.5));
 
     double one = 1.;
-    int fs1 = func_new_advanced("polynomial", 1, &one, 0); // 1.
+    int fs1 = func_new_advanced("polynomial", 1, &one); // 1.
     auto func_s1 = newFunc1("constant", 1.);
     EXPECT_DOUBLE_EQ(func_value(fs1, 0.5), func_s1->eval(0.5));
     EXPECT_DOUBLE_EQ(func_value(fs1, 0.5), 1.);
@@ -277,7 +267,7 @@ TEST(ctmath, generic)
     EXPECT_DOUBLE_EQ(func_value(fs2_1, 0.5), func_s2_1->eval(0.5));
 
     vector<double> p_arr = {1., .5, 0.};
-    int fs3 = func_new_advanced("Arrhenius", 3, p_arr.data(), 1);  // sqrt function
+    int fs3 = func_new_advanced("Arrhenius", 3, p_arr.data());  // sqrt function
     auto func_s3 = newFunc1("Arrhenius", p_arr);
     EXPECT_DOUBLE_EQ(func_value(fs3, 0.5), func_s3->eval(0.5));
 

--- a/test/python/test_func1.py
+++ b/test/python/test_func1.py
@@ -127,7 +127,7 @@ class TestFunc1(utilities.CanteraTest):
         arr = np.array([[0, 2], [1, 1], [2, 0]])
         time = arr[:, 0]
         fval = arr[:, 1]
-        fcn = ct.TabulatedFunction(time, fval)
+        fcn = ct.Tabulated1(time, fval)
         assert fcn.type == "tabulated-linear"
         for t, f in zip(time, fval):
             self.assertNear(f, fcn(t))
@@ -135,7 +135,7 @@ class TestFunc1(utilities.CanteraTest):
     def test_tabulated2(self):
         time = [0, 1, 2]
         fval = [2, 1, 0]
-        fcn = ct.TabulatedFunction(time, fval)
+        fcn = ct.Tabulated1(time, fval)
         assert fcn.type == "tabulated-linear"
         for t, f in zip(time, fval):
             self.assertNear(f, fcn(t))
@@ -143,14 +143,14 @@ class TestFunc1(utilities.CanteraTest):
     def test_tabulated3(self):
         time = 0, 1, 2,
         fval = 2, 1, 0,
-        fcn = ct.TabulatedFunction(time, fval)
+        fcn = ct.Tabulated1(time, fval)
         self.assertNear(fcn(-1), fval[0])
         self.assertNear(fcn(3), fval[-1])
 
     def test_tabulated4(self):
         time = np.array([0, 1, 2])
         fval = np.array([2, 1, 0])
-        fcn = ct.TabulatedFunction(time, fval)
+        fcn = ct.Tabulated1(time, fval)
         tt = .5*(time[1:] + time[:-1])
         ff = .5*(fval[1:] + fval[:-1])
         for t, f in zip(tt, ff):
@@ -159,17 +159,17 @@ class TestFunc1(utilities.CanteraTest):
     def test_tabulated5(self):
         time = [0, 1, 2]
         fval = [2, 1, 0]
-        fcn = ct.TabulatedFunction(time, fval, method='previous')
+        fcn = ct.Tabulated1(time, fval, method='previous')
         assert fcn.type == "tabulated-previous"
         val = np.array([fcn(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]])
         self.assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
 
     def test_tabulated_failures(self):
         with pytest.raises(ct.CanteraError, match="even number of entries"):
-            ct.TabulatedFunction(range(2), range(3))
+            ct.Tabulated1(range(2), range(3))
         with pytest.raises(ct.CanteraError, match="at least 4 entries"):
-            ct.TabulatedFunction([], [])
+            ct.Tabulated1([], [])
         with pytest.raises(ct.CanteraError, match="monotonically"):
-            ct.TabulatedFunction((0, 1, 0.5, 2), (2, 1, 1, 0))
+            ct.Tabulated1((0, 1, 0.5, 2), (2, 1, 1, 0))
         with pytest.raises(ct.CanteraError, match="No such type"):
-            ct.TabulatedFunction((0, 1, 1, 2), (2, 1, 1, 0), method='spam')
+            ct.Tabulated1((0, 1, 1, 2), (2, 1, 1, 0), method='spam')

--- a/test/python/test_func1.py
+++ b/test/python/test_func1.py
@@ -2,6 +2,8 @@ import numpy as np
 
 import cantera as ct
 from . import utilities
+import math
+import pytest
 
 class TestFunc1(utilities.CanteraTest):
     def test_function(self):
@@ -12,6 +14,7 @@ class TestFunc1(utilities.CanteraTest):
 
     def test_lambda(self):
         f = ct.Func1(lambda t: np.sin(t)*np.sqrt(t))
+        assert f.type == "functor"
         for t in [0.1, 0.7, 4.5]:
             self.assertNear(f(t), np.sin(t)*np.sqrt(t))
 
@@ -24,6 +27,7 @@ class TestFunc1(utilities.CanteraTest):
 
         m = Multiplier(8.1)
         f = ct.Func1(m)
+        assert f.type == "functor"
         for t in [0.1, 0.7, 4.5]:
             self.assertNear(f(t), 8.1*t)
 
@@ -31,6 +35,7 @@ class TestFunc1(utilities.CanteraTest):
         f = ct.Func1(5)
         for t in [0.1, 0.7, 4.5]:
             self.assertNear(f(t), 5)
+        assert f.type == "constant"
 
     def test_sequence(self):
         f = ct.Func1([5])
@@ -42,7 +47,9 @@ class TestFunc1(utilities.CanteraTest):
 
     def test_numpy(self):
         f = ct.Func1(np.array(5))
+        assert f.type == "constant"
         g = ct.Func1(np.array([[5]]))
+        assert g.type == "constant"
         for t in [0.1, 0.7, 4.5]:
             self.assertNear(f(t), 5)
             self.assertNear(g(t), 5)
@@ -70,11 +77,58 @@ class TestFunc1(utilities.CanteraTest):
         with self.assertRaises(NotImplementedError):
             copy.copy(f)
 
+    def test_simple(self):
+        functors = {
+            'sin': math.sin,
+            'cos': math.cos,
+            'exp': math.exp,
+            'log': math.log,
+        }
+        for name, fcn in functors.items():
+            coeff = 2.34
+            func = ct.Func1.cxx_functor(name, coeff)
+            assert func.type == name
+            for val in [.1, 1., 10.]:
+                assert name in func.write()
+                assert func(val) == pytest.approx(fcn(coeff * val))
+
+    def test_compound(self):
+        functors = {
+            'sum': lambda x, y: x + y,
+            'diff': lambda x, y: x - y,
+            'product': lambda x, y: x * y,
+            'ratio': lambda x, y: x / y,
+        }
+        f1 = ct.Func1.cxx_functor('pow', 2)
+        f2 = ct.Func1.cxx_functor('sin')
+        for name, fcn in functors.items():
+            func = ct.Func1.cxx_functor(name, f1, f2)
+            assert func.type == name
+            for val in [.1, 1., 10.]:
+                assert name not in func.write()
+                assert func(val) == pytest.approx(fcn(f1(val), f2(val)))
+
+    def test_modified(self):
+        functors = {
+            'plus-constant': lambda x, y: x + y,
+            'times-constant': lambda x, y: x * y,
+        }
+        f1 = ct.Func1.cxx_functor('sin')
+        constant = 2.34
+        for name, fcn in functors.items():
+            func = ct.Func1.cxx_functor(name, f1, constant)
+            assert func.type == name
+            for val in [.1, 1., 10.]:
+                assert name not in func.write()
+                assert func(val) == pytest.approx(fcn(f1(val), constant))
+
     def test_tabulated1(self):
+        # this implicitly probes advanced functors
         arr = np.array([[0, 2], [1, 1], [2, 0]])
         time = arr[:, 0]
         fval = arr[:, 1]
         fcn = ct.TabulatedFunction(time, fval)
+        assert fcn.type == "tabulated-linear"
         for t, f in zip(time, fval):
             self.assertNear(f, fcn(t))
 
@@ -82,6 +136,7 @@ class TestFunc1(utilities.CanteraTest):
         time = [0, 1, 2]
         fval = [2, 1, 0]
         fcn = ct.TabulatedFunction(time, fval)
+        assert fcn.type == "tabulated-linear"
         for t, f in zip(time, fval):
             self.assertNear(f, fcn(t))
 
@@ -105,15 +160,16 @@ class TestFunc1(utilities.CanteraTest):
         time = [0, 1, 2]
         fval = [2, 1, 0]
         fcn = ct.TabulatedFunction(time, fval, method='previous')
+        assert fcn.type == "tabulated-previous"
         val = np.array([fcn(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]])
         self.assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
 
     def test_tabulated_failures(self):
-        with self.assertRaisesRegex(ValueError, 'do not match'):
+        with pytest.raises(ct.CanteraError, match="even number of entries"):
             ct.TabulatedFunction(range(2), range(3))
-        with self.assertRaisesRegex(ValueError, 'must not be empty'):
+        with pytest.raises(ct.CanteraError, match="at least 4 entries"):
             ct.TabulatedFunction([], [])
-        with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
+        with pytest.raises(ct.CanteraError, match="monotonically"):
             ct.TabulatedFunction((0, 1, 0.5, 2), (2, 1, 1, 0))
-        with self.assertRaisesRegex(NotImplementedError, 'not implemented'):
-            ct.TabulatedFunction((0, 1, 1, 2), (2, 1, 1, 0), method='not implemented')
+        with pytest.raises(ct.CanteraError, match="No such type"):
+            ct.TabulatedFunction((0, 1, 1, 2), (2, 1, 1, 0), method='spam')


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Provide access to all C++ `Func1` objects from Python with dynamically created classes.
- Remove unnecessary argument from advanced functor constructors (oversight in #1513)
- Replace Python callbacks returning constants with C++ functors
- Rename `TabulatedFunction` to `Tabulated1` to ensure names are consistent

While the `Func1` API in Python should mainly serve as an 'advanced feature', it can serve as a template for other API's (example: new MATLAB interface Cantera/enhancements#177).

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
In [1]: import cantera as ct

In [2]: f1 = ct.Func1.cxx_functor("sin")
   ...: f2 = ct.Func1.cxx_functor("Gaussian", [0, 1, 2])
   ...: func = ct.Func1.cxx_functor("sum", f1, f2)

In [3]: func
Out[3]: <cantera.func1.Sum1 at 0x10457cd00>

In [4]: print(func.write())
\sin(t) + \mathrm{Gaussian}(t)
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
