### PR TITLE
Add support for building MATLAB toolbox on Apple Silicon

### DIFF
--- a/src/matlab/SConscript
+++ b/src/matlab/SConscript
@@ -1,6 +1,8 @@
 import os
+import sys
 from os.path import join as pjoin
 from buildutils import *
+from pathlib import Path
 
 Import('env', 'build', 'install')
 
@@ -33,12 +35,16 @@ elif localenv['OS'] == 'Darwin':
     linklibs += ['mx', 'mex', 'mat'] + env['LIBM']
     linkflags.extend(['-Wl,-exported_symbol,_mexFunction'])
 
-    if localenv['OS_BITS'] == 64:
-        matlab_libs = pjoin(localenv['matlab_path'], 'bin', 'maci64')
-        mexSuffix = '.mexmaci64'
+    matlab_path = Path(localenv["matlab_path"])
+    if (matlab_path / "bin" / "maca64").is_dir():
+        matlab_libs = (matlab_path / "bin" / "maca64").as_posix()
+        mexSuffix = ".mexmaca64"
+    elif (matlab_path / "bin" / "maci64").is_dir():
+        matlab_libs = (matlab_path / "bin" / "maci64").as_posix()
+        mexSuffix = ".mexmaci64"
     else:
-        matlab_libs = pjoin(localenv['matlab_path'], 'bin', 'macx86')
-        mexSuffix = '.mexmaci'
+        logger.error("Couldn't determine target architecture for Matlab toolbox")
+        sys.exit(1)
 
 elif os.name == 'posix':
     linklibs = list(env['cantera_libs'])


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add support for building MATLAB toolbox on Apple Silicon

The native builds of MATLAB for Apple Silicon require the "preview" release of MATLAB 2023b.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
