### PR TITLE
Small fixes in oneD

### DIFF
--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -184,7 +184,7 @@ class FlameBase(Sim1D):
             arr.TP = T + left.T - T[0], self.P
 
             # adjust velocities
-            if self.flame.domain_type.startswith("axisymmetric"):
+            if not self.flame.domain_type.startswith("free"):
                 self.gas.TPY = left.T, self.P, left.Y
                 u0 = left.mdot / self.gas.density
                 arr.velocity = u0 * arr.velocity / arr.velocity[0]

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -195,7 +195,7 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
         } else {
             // if the flow is a freely-propagating flame, mdot is not specified.
             // Set mdot equal to rho*u, and also set lambda to zero.
-            m_mdot = m_flow->density(0)*xb[0];
+            m_mdot = m_flow->density(0) * xb[c_offset_U];
             rb[c_offset_L] = xb[c_offset_L];
         }
 

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -514,8 +514,6 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
             rsd[index(c_offset_E, 0)] = x[index(c_offset_E, j)];
         } else if (j == m_points - 1) {
             evalRightBoundary(x, rsd, diag, rdt);
-            // set residual of poisson's equ to zero
-            rsd[index(c_offset_E, j)] = x[index(c_offset_E, j)];
         } else { // interior points
             evalContinuity(j, x, rsd, diag, rdt);
             // set residual of poisson's equ to zero
@@ -1023,6 +1021,8 @@ void StFlow::evalRightBoundary(double* x, double* rsd, int* diag, double rdt)
     doublereal sum = 0.0;
     rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
     diag[index(c_offset_L, j)] = 0;
+    // set residual of poisson's equ to zero
+    rsd[index(c_offset_E, j)] = x[index(c_offset_E, j)];
     for (size_t k = 0; k < m_nsp; k++) {
         sum += Y(x,k,j);
         rsd[index(k+c_offset_Y,j)] = m_flux(k,j-1) + rho_u(x,j)*Y(x,k,j);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix bug in `FlameBase.set_initial_guess`
- Replace remaining hardcoded `c_offset_U` reference in `Inlet1D::eval`
- Consolidate code in `StFlow::evalRightBoundary`

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
