### PR TITLE
Limit {fmt} versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -409,7 +409,7 @@ jobs:
         if: failure() || success()
 
   multiple-sundials:
-    name: Sundials ${{ matrix.sundials-ver }}
+    name: Sundials ${{ matrix.sundials-ver }} / fmt ${{ matrix.fmt-ver }}
     runs-on: ubuntu-latest
     timeout-minutes: 60
     env:
@@ -419,7 +419,15 @@ jobs:
         shell: bash -l {0}
     strategy:
       matrix:
-        sundials-ver: [ 3, 4, 5.8, 6.4.1 ]
+        include:
+        - sundials-ver: 3
+          fmt-ver: 7.1
+        - sundials-ver: 4
+          fmt-ver: 8.1
+        - sundials-ver: 5.8
+          fmt-ver: 9.1
+        - sundials-ver: 6.4.1
+          fmt-ver: 10
       fail-fast: false
     steps:
       - uses: actions/checkout@v3
@@ -438,8 +446,8 @@ jobs:
         # use boost-cpp rather than boost from conda-forge
         run: |
           conda install -q sundials=${{ matrix.sundials-ver }} scons numpy ruamel.yaml \
-          cython boost-cpp fmt eigen yaml-cpp h5py pandas libgomp openblas pytest \
-          highfive pint
+          cython boost-cpp fmt=${{ matrix.fmt-ver }} eigen yaml-cpp h5py pandas \
+          libgomp openblas pytest highfive pint
       - name: Build Cantera
         run: |
           scons build system_fmt=y system_eigen=y system_yamlcpp=y system_sundials=y \
@@ -470,7 +478,7 @@ jobs:
           test -f h2o2-test.ck
 
   windows-2022:
-    name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}
+    name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}, fmt ${{ matrix.fmt-ver }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     defaults:
@@ -481,6 +489,13 @@ jobs:
         os: ["windows-2022"]
         vs-toolset: ["14.1", "14.3"]
         python-version: ["3.8", "3.10", "3.11"]
+        include:
+        - python-version: 3.8
+          fmt-ver: 10
+        - python-version: 3.10
+          fmt-ver: 8.1
+        - python-version: 3.11
+          fmt-ver: 7.1
       fail-fast: false
     steps:
     - uses: actions/checkout@v3
@@ -501,7 +516,7 @@ jobs:
       # use boost-cpp rather than boost from conda-forge
       # Install SCons >=4.4.0 to make sure that MSVC_TOOLSET_VERSION variable is present
       run: |
-        mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp h5py pandas pytest highfive pint
+        mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp h5py pandas pytest highfive pint fmt=${{ matrix.fmt-ver }}
       shell: pwsh
     - name: Build Cantera
       run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
@@ -509,7 +524,7 @@ jobs:
       shell: pwsh
     - name: Upload shared library
       uses: actions/upload-artifact@v3
-      if: matrix.python-version == '3.10'
+      if: matrix.python-version == '3.10' && matrix.vs-toolset == '14.3'
       with:
         path: build/lib/cantera_shared.dll
         name: cantera_shared.dll
@@ -777,7 +792,9 @@ jobs:
     - name: Install Python dependencies
       run: python3 -m pip install ruamel.yaml
     - name: Install library dependencies with Conda (Windows)
-      run: mamba install -q yaml-cpp mkl highfive
+      # fmt needs to match the version of the windows-2022 runner selected to upload
+      # the cantera_shared.dll artifact
+      run: mamba install -q yaml-cpp mkl highfive fmt=8.1
       shell: pwsh
       if: matrix.os == 'windows-2022'
     - name: Install Brew dependencies (macOS)

--- a/SConstruct
+++ b/SConstruct
@@ -1206,7 +1206,6 @@ if env['system_fmt'] in ('y', 'default'):
         else:
             env['system_fmt'] = True
             logger.info(f"Using system installation of fmt library.")
-            logger.info(f"Using fmt version {fmt_lib_version}")
     elif env['system_fmt'] == 'y':
         config_error('Expected system installation of fmt library, but it '
             'could not be found.')
@@ -1236,7 +1235,9 @@ if env['system_fmt'] in ('n', 'default'):
     fmt_lib_version = split_version(fmt_lib_version)
     env['system_fmt'] = False
     logger.info(f"Using private installation of fmt library.")
-    logger.info(f"Using fmt version {fmt_lib_version}")
+
+env.Append(CPPDEFINES={"FMT_HEADER_ONLY": 1})
+logger.info(f"Using fmt version {fmt_lib_version}")
 
 # Check for yaml-cpp library and checkout submodule if needed
 if env['system_yamlcpp'] in ('y', 'default'):

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -48,10 +48,7 @@ if not env['system_fmt']:
     localenv = prep_default(env)
     localenv.Prepend(CPPPATH=Dir('#ext/fmt/include'))
     libraryTargets.extend(localenv.SharedObject(['fmt/src/format.cc', 'fmt/src/os.cc']))
-    fmt_includes = [
-        'format.h', 'ostream.h', 'printf.h', 'core.h', 'compile.h', 'format-inl.h'
-    ]
-    for name in fmt_includes:
+    for name in ('format.h', 'ostream.h', 'printf.h', 'core.h', 'format-inl.h'):
         ext_copies.extend(
             copyenv.Command("#include/cantera/ext/fmt/" + name,
                             "#ext/fmt/include/fmt/" + name,

--- a/ext/SConscript
+++ b/ext/SConscript
@@ -48,7 +48,10 @@ if not env['system_fmt']:
     localenv = prep_default(env)
     localenv.Prepend(CPPPATH=Dir('#ext/fmt/include'))
     libraryTargets.extend(localenv.SharedObject(['fmt/src/format.cc', 'fmt/src/os.cc']))
-    for name in ('format.h', 'ostream.h', 'printf.h', 'core.h', 'format-inl.h'):
+    fmt_includes = [
+        'format.h', 'ostream.h', 'printf.h', 'core.h', 'compile.h', 'format-inl.h'
+    ]
+    for name in fmt_includes:
         ext_copies.extend(
             copyenv.Command("#include/cantera/ext/fmt/" + name,
                             "#ext/fmt/include/fmt/" + name,

--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -13,34 +13,18 @@
 #if defined(_WIN32) && !defined(NOMINMAX)
 #define NOMINMAX
 #endif
+
 #if CT_USE_SYSTEM_FMT
-  #include "fmt/format.h"
-  #if defined(FMT_VERSION) && FMT_VERSION >= 40000
-    #include "fmt/printf.h"
-  #endif
-  #include "fmt/ostream.h"
+  #include <fmt/format.h>
+  #include <fmt/printf.h>
+  #include <fmt/ostream.h>
 #else
   #include "cantera/ext/fmt/format.h"
-  #if defined(FMT_VERSION) && FMT_VERSION >= 40000
-    #include "cantera/ext/fmt/printf.h"
-  #endif
+  #include "cantera/ext/fmt/printf.h"
   #include "cantera/ext/fmt/ostream.h"
 #endif
 
-#if !defined(FMT_VERSION) || FMT_VERSION < 50000
-namespace fmt {
-using memory_buffer = MemoryWriter;
-}
-template <typename... Args>
-void format_to(fmt::memory_buffer& b, Args... args) {
-    b.write(args...);
-}
-inline std::string to_string(fmt::memory_buffer& b) {
-    return b.str();
-}
-#endif
-
-#if !defined(FMT_VERSION) ||  FMT_VERSION < 80000
+#if FMT_VERSION < 80000
 template <typename... Args>
 void fmt_append(fmt::memory_buffer& b, Args... args) {
     format_to(b, args...);

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -388,7 +388,7 @@ void emitFlowVector(YAML::Emitter& out, const vector<T>& v)
     out << YAML::Flow;
     out << YAML::BeginSeq;
     size_t width = 15; // wild guess, but no better value is available
-    for (const auto& x : v) {
+    for (const T& x : v) {
         string xstr = fmt::format("{}", x);
         // Wrap to the next line if this item would exceed the target line length
         if (width + xstr.size() > max_line_length) {

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -999,7 +999,7 @@ void SolutionArray::writeEntry(const string& fname, bool overwrite, const string
     size_t last = names.size() - 1;
     vector<AnyValue> components;
     vector<bool> isSpecies;
-    std::stringstream header;
+    fmt::memory_buffer header;
     for (const auto& key : names) {
         string label = key;
         size_t col;
@@ -1032,13 +1032,11 @@ void SolutionArray::writeEntry(const string& fname, bool overwrite, const string
                 "Detected column name containing double quotes or line feeds: '{}'.",
                 label);
         }
+        string sep = (col == last) ? "" : ",";
         if (label.find(",") != string::npos) {
-            header << "\"" << label << "\"";
+            fmt_append(header, "\"{}\"{}", label, sep);
         } else {
-            header << label;
-        }
-        if (col != last) {
-            header << ",";
+            fmt_append(header, "{}{}", label, sep);
         }
     }
 
@@ -1052,11 +1050,15 @@ void SolutionArray::writeEntry(const string& fname, bool overwrite, const string
         std::remove(fname.c_str());
     }
     std::ofstream output(fname);
-    const auto default_precision = output.precision();
-    output << header.str() << std::endl << std::setprecision(9);
+    output << to_string(header) << std::endl;
 
+    size_t maxLen = npos;
     vector<double> buf(speciesNames.size(), 0.);
     for (int row = 0; row < static_cast<int>(m_size); row++) {
+        fmt::memory_buffer line;
+        if (maxLen != npos) {
+            line.reserve(maxLen);
+        }
         setLoc(row);
         if (mole) {
             m_sol->thermo()->getMoleFractions(buf.data());
@@ -1066,14 +1068,18 @@ void SolutionArray::writeEntry(const string& fname, bool overwrite, const string
 
         size_t idx = 0;
         for (size_t col = 0; col < components.size(); col++) {
+            string sep = (col == last) ? "" : ",";
             if (isSpecies[col]) {
-                output << buf[idx++];
+                fmt_append(line, "{:.9g}{}", buf[idx++], sep);
             } else {
                 auto& data = components[col];
                 if (data.isVector<double>()) {
-                    output << data.asVector<double>()[row];
+                    fmt_append(line, "{:.9g}{}", data.asVector<double>()[row], sep);
                 } else if (data.isVector<long int>()) {
-                    output << data.asVector<long int>()[row];
+                    fmt_append(line, "{}{}", data.asVector<long int>()[row], sep);
+                } else if (data.isVector<bool>()) {
+                    fmt_append(line, "{}{}",
+                               static_cast<bool>(data.asVector<bool>()[row]), sep);
                 } else {
                     auto value = data.asVector<string>()[row];
                     if (value.find("\"") != string::npos ||
@@ -1084,19 +1090,16 @@ void SolutionArray::writeEntry(const string& fname, bool overwrite, const string
                             "'{}'", value);
                     }
                     if (value.find(",") != string::npos) {
-                        output << "\"" << value << "\"";
+                        fmt_append(line, "\"{}\"{}", value, sep);
                     } else {
-                        output << value;
+                        fmt_append(line, "{}{}", value, sep);
                     }
                 }
             }
-            if (col != last) {
-                output << ",";
-            }
         }
-        output << std::endl;
+        output << to_string(line) << std::endl;
+        maxLen = std::max(maxLen, line.size());
     }
-    output << std::endl << std::setprecision(default_precision);
 }
 
 void SolutionArray::writeEntry(const string& fname, const string& name,


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Frequent API changes in the {fmt} library have led to numerous workarounds in `fmt.h`. At the same time, the library is small (especially after [version 7.0](https://github.com/fmtlib/fmt/releases/tag/7.0.0)) and can be easily included from a git submodule. Note that the latest released {fmt} version is 10.0.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Limit support to {fmt} [version 6.1.2](https://github.com/fmtlib/fmt/releases/tag/6.1.2) and newer (version packaged with Ubuntu 12.04 LTS), where SCons logic ignores older system libraries under the `default` setting.
- Remove *most* workarounds in `fmt.h`
- Test multiple {fmt} version in GH actions
- Switch `SolutionArray::save` CSV writing to {fmt}

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1537, closes #1540

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

While this is was not an objective of the PR, the `SolutionArray` CSV writer speed was improved significantly. For `main`, the benchmark is:

```
In [1]: cd samples/python/onedim/
/Volumes/Data/work/GitHub/cantera/samples/python/onedim

In [2]: %run ion_free_flame.py
[...]

In [3]: %timeit f.save("test.csv", overwrite=True)
3.49 ms ± 116 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)
```

Using the proposed PR (switch to {fmt}), this reduces to

```
In [3]: %timeit f.save("test.csv", overwrite=True)
1.95 ms ± 16 µs per loop (mean ± std. dev. of 7 runs, 1,000 loops each)
```

This could potentially be further improved by using [version 7.1](https://github.com/fmtlib/fmt/releases/tag/7.1.0) `fmt/os.h` file output  (1.52 ms) and/or the compile-time format string compilation `FMT_COMPILE`, but a major caveat is that the latter is not compatible with `icc` (beyond only being available after 7.0). Note that YAML output is significantly slower (bottlenecks are elsewhere), so the possible optimization is not worthwhile: 

```
In [4]: %timeit f.save("test.h5", "test", overwrite=True)
6.81 ms ± 15.8 µs per loop (mean ± std. dev. of 7 runs, 100 loops each)

In [5]: %timeit f.save("test.yaml", "test", overwrite=True)
87.3 ms ± 122 µs per loop (mean ± std. dev. of 7 runs, 10 loops each)
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
