### PR TITLE
Fix Matplotlib warnings in examples

### DIFF
--- a/samples/python/kinetics/mechanism_reduction.py
+++ b/samples/python/kinetics/mechanism_reduction.py
@@ -92,6 +92,6 @@ for i, N in enumerate([40, 50, 60, 70, 80]):
     plt.title('Reduced mechanism ignition delay times\n'
               'K: number of species; R: number of reactions')
     plt.xlim(0, 20)
-    plt.tight_layout()
 
+plt.tight_layout()
 plt.show()

--- a/samples/python/reactors/sensitivity1.py
+++ b/samples/python/reactors/sensitivity1.py
@@ -63,9 +63,9 @@ if '--plot' in sys.argv:
     plt.tight_layout()
 
     plt.figure(2)
-    plt.plot(states.t, states.s2, '-', states.t, states.s3, '-g')
-    plt.legend([sim.sensitivity_parameter_name(2), sim.sensitivity_parameter_name(3)],
-               'best')
+    plt.plot(states.t, states.s2, '-', label=sim.sensitivity_parameter_name(2))
+    plt.plot(states.t, states.s3, '-g', label=sim.sensitivity_parameter_name(3))
+    plt.legend(loc='best')
     plt.xlabel('Time (ms)')
     plt.ylabel('OH Sensitivity')
     plt.tight_layout()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Fix a couple of warnings in examples using Matplotlib. The warning in `mechanism_reduction.py` related to `tight_layout` seems to be new in Matplotlib 3.7.2. The warning in `sensitivity1.py` corresponded to an empty legend -- I'm not sure how long this was broken, or for what Matplotlib versions, but I think the new syntax is preferable in any case.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1532

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
