### PR TITLE
Fix reading arrays containing subnormal floating point values

### DIFF
--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -508,7 +508,11 @@ struct convert<Cantera::AnyValue> {
             if (types == Type::Integer) {
                 target = node.as<std::vector<long int>>();
             } else if (types == (Type::Integer | Type::Double) || types == Type::Double) {
-                target = node.as<vector_fp>();
+                vector_fp values;
+                for (const auto& elem : node) {
+                    values.push_back(fpValue(elem.as<string>()));
+                }
+                target = std::move(values);
             } else if (types == Type::String) {
                 target = node.as<std::vector<std::string>>();
             } else if (types == Type::Bool) {
@@ -524,7 +528,14 @@ struct convert<Cantera::AnyValue> {
                 if (subtypes == Type::Integer) {
                     target = node.as<std::vector<std::vector<long int>>>();
                 } else if (subtypes == (Type::Integer | Type::Double) || subtypes == Type::Double) {
-                    target = node.as<std::vector<std::vector<double>>>();
+                    vector<vector<double>> values;
+                    for (const auto& row : node) {
+                        values.emplace_back();
+                        for (const auto& value : row) {
+                            values.back().push_back(fpValue(value.as<string>()));
+                        }
+                    }
+                    target = std::move(values);
                 } else if (subtypes == Type::String) {
                     target = node.as<std::vector<std::vector<std::string>>>();
                 } else if (subtypes == Type::Bool) {

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -286,6 +286,20 @@ TEST(AnyMap, conversion_to_anyvalue)
     EXPECT_EQ(n.at("strings").asVector<AnyValue>()[0].asString(), "foo");
 }
 
+TEST(AnyMap, read_subnormal)
+{
+    AnyMap m = AnyMap::fromYamlString(
+        "scalar: 4.940656458412465e-324\n"
+        "vector: [1.999999997714111, 1.482285197259138, 1.151630981915516,\n"
+        "2.957408463878464, 2.035192404627, -4.940656458412465e-324]\n"
+        "matrix: [[1.999999997714111, -4.940656458412465e-324, 1.151630981915516],\n"
+        "[2.957408463878464, 2.035192404627, 1.482285197259138]]");
+
+    EXPECT_DOUBLE_EQ(m["scalar"].asDouble(), 0.0);
+    EXPECT_DOUBLE_EQ(m["vector"].asVector<double>()[5], 0.0);
+    EXPECT_DOUBLE_EQ(m["matrix"].asVector<vector<double>>()[0][1], 0.0);
+}
+
 TEST(AnyMap, iterators)
 {
     AnyMap m = AnyMap::fromYamlString(


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Use our `fpValue` function for converting strings to `double` for array inputs (of any dimensionality). We were already using this function for single floating point values, mainly because it provides better error messages for badly-formatted values. It turns out that it is also more robust for handling [subnormal](https://en.wikipedia.org/wiki/Subnormal_number) floating point values than whatever `yaml-cpp` does.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1530

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
