### PR TITLE
Make SolutionArray formatting consistent for different {fmt} versions

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -45,7 +45,7 @@ jobs:
       run: |
         sudo apt update
         sudo apt install libboost-dev gfortran libopenmpi-dev libpython3-dev \
-        libblas-dev liblapack-dev libhdf5-dev
+        libblas-dev liblapack-dev libhdf5-dev libfmt-dev
         gcc --version
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
@@ -58,7 +58,7 @@ jobs:
     - name: Build Cantera
       run: |
         python3 `which scons` build env_vars=all -j2 debug=n --debug=time \
-        hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
+        system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
         cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Upload shared library
       uses: actions/upload-artifact@v3
@@ -801,7 +801,7 @@ jobs:
       run: brew install --display-times hdf5
       if: matrix.os == 'macos-11'
     - name: Install Apt dependencies (Ubuntu)
-      run: sudo apt install libhdf5-dev
+      run: sudo apt install libhdf5-dev libfmt-dev
       if: matrix.os == 'ubuntu-22.04'
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v2

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -295,7 +295,7 @@ vector<string> integerColumn(string name, const vector<long int>& comp,
                              int rows, int width)
 {
     // extract data for processing
-    vector<double> data;
+    vector<long int> data;
     string notation = fmt::format("{{:{}}}", width);
     size_t maxLen = 2; // minimum column width is 2
     int csize = static_cast<int>(comp.size());

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -273,7 +273,7 @@ vector<string> doubleColumn(string name, const vector<double>& comp,
         notation = fmt::format(" {{:>{}.{}f}}", over + maxLen, tail);
     } else {
         // all entries are integers
-        notation = fmt::format(" {{:>{}}}", over + maxLen);
+        notation = fmt::format(" {{:>{}.0f}}", over + maxLen);
     }
     maxLen = fmt::format(notation, 0.).size();
 

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -303,29 +303,29 @@ vector<string> integerColumn(string name, const vector<long int>& comp,
     if (csize <= rows) {
         for (const auto& val : comp) {
             data.push_back(val);
-            string name = boost::trim_copy(fmt::format(notation, val));
-            if (name[0] == '-') {
-                name = name.substr(1);
+            string formatted = boost::trim_copy(fmt::format(notation, val));
+            if (formatted[0] == '-') {
+                formatted = formatted.substr(1);
             }
-            maxLen = std::max(maxLen, name.size());
+            maxLen = std::max(maxLen, formatted.size());
         }
     } else {
         dots = (rows + 1) / 2;
         for (int row = 0; row < dots; row++) {
             data.push_back(comp[row]);
-            string name = boost::trim_copy(fmt::format(notation, comp[row]));
-            if (name[0] == '-') {
-                name = name.substr(1);
+            string formatted = boost::trim_copy(fmt::format(notation, comp[row]));
+            if (formatted[0] == '-') {
+                formatted = formatted.substr(1);
             }
-            maxLen = std::max(maxLen, name.size());
+            maxLen = std::max(maxLen, formatted.size());
         }
         for (int row = csize - rows / 2; row < csize; row++) {
             data.push_back(comp[row]);
-            string name = boost::trim_copy(fmt::format(notation, comp[row]));
-            if (name[0] == '-') {
-                name = name.substr(1);
+            string formatted = boost::trim_copy(fmt::format(notation, comp[row]));
+            if (formatted[0] == '-') {
+                formatted = formatted.substr(1);
             }
-            maxLen = std::max(maxLen, name.size());
+            maxLen = std::max(maxLen, formatted.size());
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Store pure integer columns as integers
- Be explicit about how to format floating point columns that contain only integers

With {fmt} 6.1.2, this changes the output of:
```python
import cantera as ct
p = ct.Water()
arr = ct.SolutionArray(p, 12)
print(arr)
```
from
```
      T        D
0.0 300.0  996.633
1.0 300.0  996.633
2.0 300.0  996.633
3.0 300.0  996.633
4.0 300.0  996.633
..  ...      ...
7.0 300.0  996.633
8.0 300.0  996.633
9.0 300.0  996.633
10.0 300.0  996.633
11.0 300.0  996.633

[12 rows x 2 components; state='TD']
```
to
```
      T        D
0   300  996.633
1   300  996.633
2   300  996.633
3   300  996.633
4   300  996.633
..  ...      ...
7   300  996.633
8   300  996.633
9   300  996.633
10  300  996.633
11  300  996.633

[12 rows x 2 components; state='TD']
```

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1526

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
