### PR TITLE
Provide links to previous Doxygen documentation

### DIFF
--- a/doc/doxygen/versions.md
+++ b/doc/doxygen/versions.md
@@ -4,8 +4,9 @@
 > interface documentation, refer to
 > [cantera.org](https://cantera.org/documentation/index.html#need-something-else).
 
-Previous versions of the **%Cantera Developer API**:
+**%Cantera Developer API** versions:
 
+* [dev/latest](https://cantera.org/documentation/dev/doxygen/html/index.html) (unstable)
 * [v2.6.0](https://cantera.org/documentation/docs-2.6/doxygen/html/modules.html)
 * [v2.5.1](https://cantera.org/documentation/docs-2.5/doxygen/html/modules.html)
 * [v2.4.0](https://cantera.org/documentation/docs-2.4/doxygen/html/modules.html)

--- a/doc/doxygen/versions.md
+++ b/doc/doxygen/versions.md
@@ -1,0 +1,15 @@
+@page previous-versions Previous Versions
+
+> **Note:** For release notes and previous versions of the Python/MATLAB
+> interface documentation, refer to
+> [cantera.org](https://cantera.org/documentation/index.html#need-something-else).
+
+Previous versions of the **%Cantera Developer API**:
+
+* [v2.6.0](https://cantera.org/documentation/docs-2.6/doxygen/html/modules.html)
+* [v2.5.1](https://cantera.org/documentation/docs-2.5/doxygen/html/modules.html)
+* [v2.4.0](https://cantera.org/documentation/docs-2.4/doxygen/html/modules.html)
+* [v2.3.0](https://cantera.org/documentation/docs-2.3/doxygen/html/modules.html)
+* [v2.2.1](https://cantera.org/documentation/docs-2.2/doxygen/html/modules.html)
+* [v2.1.2](https://cantera.org/documentation/docs-2.1/doxygen/html/modules.html)
+* [v2.0.2](https://cantera.org/documentation/docs-2.0/doxygen/html/modules.html)

--- a/include/cantera/kinetics/KineticsFactory.h
+++ b/include/cantera/kinetics/KineticsFactory.h
@@ -41,7 +41,7 @@ private:
 
 /**
  *  Create a new kinetics manager.
- *  @deprecated  To be removed after Cantera 3.0; superseded by newKinetics.
+ *  @deprecated To be removed after %Cantera 3.0; superseded by newKinetics().
  */
 Kinetics* newKineticsMgr(const string& model);
 

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -181,7 +181,7 @@ public:
     void setC(doublereal c);
 
     //! accessor function for m_f1
-    //! @deprecated To be removed after Cantera 3.0; replaced by func1_shared.
+    //! @deprecated To be removed after %Cantera 3.0; replaced by func1_shared().
     Func1& func1() const;
 
     //! Accessor function for m_f1_shared

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -350,7 +350,7 @@ public:
 
     virtual void setKinetics(shared_ptr<Kinetics> kin);
 
-    //! @deprecated  To be removed after Cantera 3.0; replaced by setKinetics
+    //! @deprecated To be removed after %Cantera 3.0; replaced by setKinetics()
     void setKineticsMgr(InterfaceKinetics* kin);
 
     void enableCoverageEquations(bool docov) {

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -340,7 +340,7 @@ public:
     /*!
      * @param soln local solution vector for this domain
      *
-     * @deprecated  To be removed after Cantera 3.0; superseded by asArray.
+     * @deprecated To be removed after %Cantera 3.0; superseded by asArray().
      */
     AnyMap serialize(const double* soln) const;
 
@@ -490,11 +490,11 @@ public:
         }
     }
 
-    //! @deprecated To be removed after Cantera 3.0; replaced by show
+    //! @deprecated To be removed after %Cantera 3.0; replaced by show()
     virtual void showSolution_s(std::ostream& s, const double* x);
 
     //! Print the solution.
-    //! @deprecated To be removed after Cantera 3.0; replaced by show
+    //! @deprecated To be removed after %Cantera 3.0; replaced by show()
     virtual void showSolution(const double* x);
 
     //! Print the solution.

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -107,13 +107,13 @@ public:
     /**
      * Output information on current solution for all domains to stream.
      * @param s  Output stream
-     * @deprecated To be removed after Cantera 3.0; replaced by show
+     * @deprecated To be removed after %Cantera 3.0; replaced by show()
      */
     void showSolution(std::ostream& s);
 
     /**
      * Show logging information on current solution for all domains.
-     * @deprecated To be removed after Cantera 3.0; replaced by show
+     * @deprecated To be removed after %Cantera 3.0; replaced by show()
      */
     void showSolution();
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -94,13 +94,15 @@ public:
     virtual void setKinetics(shared_ptr<Kinetics> kin);
 
     //! Set the kinetics manager.
-    //! @deprecated  To be removed after Cantera 3.0; replaced by Domain1D::setKinetics
+    //! @deprecated To be removed after %Cantera 3.0;
+    //!     replaced by Domain1D::setKinetics()
     void setKinetics(Kinetics& kin);
 
     virtual void setTransport(shared_ptr<Transport> trans);
 
     //! Set transport model to existing instance
-    //! @deprecated  To be removed after Cantera 3.0; replaced by Domain1D::setKinetics
+    //! @deprecated To be removed after %Cantera 3.0;
+    //!     replaced by Domain1D::setKinetics()
     void setTransport(Transport& trans);
 
     //! Set the transport model
@@ -204,7 +206,7 @@ public:
     //! Return the type of flow domain being represented, either "Free Flame" or
     //! "Axisymmetric Stagnation".
     //! @see setFreeFlow setAxisymmetricFlow
-    //! @deprecated  To be removed after Cantera 3.0; replaced by type.
+    //! @deprecated To be removed after %Cantera 3.0; replaced by type().
     virtual string flowType() const;
 
     void solveEnergyEqn(size_t j=npos);

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -53,53 +53,53 @@ namespace Cantera
  *   - This standard state model is invoked with the keyword "density_temperature_polynomial".
  *     The standard state density, which is the inverse of the volume,
  *     is considered a function of temperature only.
- *    \f[
+ *     \f[
  *       {\rho}^o_k(T,P) = \frac{M_k}{V^o_k(T,P)} = a_0 + a_1 T + a_2 T^2 + a_3 T^3
- *    \f]
+ *     \f]
  *
  * ## Specification of Species Standard State Properties
  *
  * The standard molar Gibbs free energy for species *k* is determined from
  * the enthalpy and entropy expressions
  *
- *       \f[
+ * \f[
  *            G^o_k(T,P) = H^o_k(T,P) - S^o_k(T,P)
- *       \f]
+ * \f]
  *
  * The enthalpy is calculated mostly from the MultiSpeciesThermo object's enthalpy
  * evaluator. The dependence on pressure originates from the Maxwell relation
  *
- *       \f[
+ * \f[
  *            {\left(\frac{dH^o_k}{dP}\right)}_T = T  {\left(\frac{dS^o_k}{dP}\right)}_T + V^o_k
- *       \f]
+ * \f]
  * which is equal to
  *
- *       \f[
+ * \f[
  *            {\left(\frac{dH^o_k}{dP}\right)}_T =  V^o_k -  T  {\left(\frac{dV^o_k}{dT}\right)}_P
- *       \f]
+ * \f]
  *
  * The entropy is calculated mostly from the MultiSpeciesThermo objects entropy
  * evaluator. The dependence on pressure originates from the Maxwell relation:
  *
- *       \f[
+ * \f[
  *              {\left(\frac{dS^o_k}{dP}\right)}_T =  - {\left(\frac{dV^o_k}{dT}\right)}_P
- *       \f]
+ * \f]
  *
  * The standard state constant-pressure heat capacity expression is obtained
  * from taking the temperature derivative of the Maxwell relation involving the
  * enthalpy given above to yield an expression for the pressure dependence of
  * the heat capacity.
  *
- *       \f[
+ * \f[
  *            {\left(\frac{d{C}^o_{p,k}}{dP}\right)}_T =  - T  {\left(\frac{{d}^2{V}^o_k}{{dT}^2}\right)}_T
- *       \f]
+ * \f]
  *
  * The standard molar Internal Energy for species *k* is determined from the
  * following relation.
  *
- *       \f[
+ * \f[
  *            U^o_k(T,P) = H^o_k(T,P) - p V^o_k
- *       \f]
+ * \f]
  *
  * An example of the specification of a standard state using a temperature dependent
  * standard state volume is given in the

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -136,7 +136,7 @@ public:
     //! Calculate species-specific critical temperature
     /*!
      *  The temperature dependent parameter in P-R EoS is calculated as
-     *       \f[ T_{crit} = (0.0778 a)/(0.4572 b R) \f]
+     * \f[ T_{crit} = (0.0778 a)/(0.4572 b R) \f]
      *  Units: Kelvin
      *
      * @param a    species-specific coefficients used in P-R EoS

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -39,10 +39,10 @@ namespace Cantera
  *
  * The enthalpy function is given by the following relation.
  *
- *       \f[
+ * \f[
  *              h^o_k(T,P) =
  *                  h^{ref}_k(T) + \tilde v \left( P - P_{ref} \right)
- *       \f]
+ * \f]
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
@@ -50,9 +50,9 @@ namespace Cantera
  * subtracted from the specified reference molar enthalpy to compute the molar
  * internal energy.
  *
- *       \f[
+ * \f[
  *            u^o_k(T,P) = h^{ref}_k(T) - P_{ref} \tilde v
- *       \f]
+ * \f]
  *
  * The standard state heat capacity and entropy are independent of pressure. The
  * standard state Gibbs free energy is obtained from the enthalpy and entropy

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -159,9 +159,9 @@ public:
      * be equal to the actual concentrations, \f$ C^s_k \f$. Activity
      * concentrations are
      *
-     *      \f[
+     * \f[
      *            C^a_k = C^s_k = \frac{\theta_k  n_0}{s_k}
-     *      \f]
+     * \f]
      *
      * where \f$ \theta_k \f$ is the surface site fraction for species k,
      * \f$ n_0 \f$ is the surface site density for the phase, and
@@ -185,9 +185,9 @@ public:
      * (that is, generalized) concentration. For this phase, the standard
      * concentration is species- specific
      *
-     *        \f[
+     * \f[
      *            C^0_k = \frac{n_0}{s_k}
-     *        \f]
+     * \f]
      *
      * This definition implies that the activity is equal to \f$ \theta_k \f$.
      *

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -509,9 +509,9 @@ public:
      *  species k in a phase p, \f$ \zeta_k \f$, is related to the chemical
      *  potential via the following equation,
      *
-     *       \f[
+     *  \f[
      *            \zeta_{k}(T,P) = \mu_{k}(T,P) + F z_k \phi_p
-     *       \f]
+     *  \f]
      *
      * @param mu  Output vector of species electrochemical
      *            potentials. Length: m_kk. Units: J/kmol

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -29,9 +29,9 @@ class PDSS_Water;
  * The electrochemical potential of species \f$k\f$ in a phase \f$p\f$, \f$ \zeta_k \f$,
  * is related to the chemical potential via the following equation,
  *
- *       \f[
+ * \f[
  *            \zeta_{k}(T,P) = \mu_{k}(T,P) + z_k \phi_p
- *       \f]
+ * \f]
  *
  * where  \f$ \nu_k \f$ is the charge of species \f$k\f$, and \f$ \phi_p \f$ is
  * the electric potential of phase \f$p\f$.
@@ -46,9 +46,9 @@ class PDSS_Water;
  * Note, the overall electrochemical potential of a phase may not be changed
  * by the potential because many phases enforce charge neutrality:
  *
- *       \f[
+ * \f[
  *            0 = \sum_k z_k X_k
- *       \f]
+ * \f]
  *
  * Whether charge neutrality is necessary for a phase is also specified within
  * the ThermoPhase object, by the function call

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -83,7 +83,7 @@ public:
         m_primary = primary;
     }
 
-    //! @deprecated To be removed after Cantera 3.0; replaced by setPrimary.
+    //! @deprecated To be removed after %Cantera 3.0; replaced by setPrimary().
     void setMaster(FlowDevice* master);
 
     virtual void setTimeFunction(Func1* g) {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Make previous versions of Doxygen documentation easier to find (from current Doxygen page).

Also, fix a couple of Doxygen issues that prevent proper rendering of math equations or cross-references.

While there are - at least some - other projects that have implemented a version switcher for Doxygen documentation (example: [OpenCV](https://docs.opencv.org/5.x/)), this would presumably require regeneration of old documentation. Creating a page with links is a much simpler solution.

Addresses Cantera/enhancements#179

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

<img width="1304" alt="image" src="https://github.com/Cantera/cantera/assets/12603999/9a7f5e99-aa55-4552-b82a-69b3d47be795">

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
