### PR TITLE
Fix serialization of phases with reactions from multiple YAML sections

### DIFF
--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -118,6 +118,10 @@ AnyMap Solution::parameters(bool withInput) const
     if (withInput) {
         auto transport = out["transport"];
         AnyMap input = m_thermo->input();
+        if (input.hasKey("reactions")) {
+            // all reactions are listed in the standard 'reactions' section
+            input.erase("reactions");
+        }
         out.update(input);
         if (input.hasKey("transport")) {
             // revert changes / ensure that correct model is referenced


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Information on reactions in the phase input section is kept in user data, but cannot be used for the serialization, as there is no bookkeeping of where reactions originated. As it is not essential to retain this information, the user input is deleted.


**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1522

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

See example provided in #1522.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
