### PR TITLE
[Kinetics] Implement band aid for plog validations

### DIFF
--- a/src/kinetics/PlogRate.cpp
+++ b/src/kinetics/PlogRate.cpp
@@ -133,7 +133,7 @@ void PlogRate::validate(const std::string& equation, const Kinetics& kin)
     }
 
     fmt::memory_buffer err_reactions;
-    double T[] = {200.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0};
+    double T[] = {300.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0};
     PlogData data;
 
     for (auto iter = ++pressures_.begin(); iter->first < 1000; iter++) {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Per discussion in #1405, the previous set of temperatures used for validation of P-log rates is a somewhat arbitrary set. Some mechanisms fail for 200 K but work fine for 300 K and up. This work-around was discussed as a band-aid to make 
some relevant mechanisms work (AramcoMech 3.0 / NUIGMech 1.1), although a more long-term solution should be found.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Partially addresses #1405

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
