### PR TITLE
Simplify BurnerFlame simulations

### DIFF
--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -130,6 +130,8 @@ protected:
 
 /**
  * An inlet.
+ * Unstrained flows use an inlet to the left of the flow domain (left-to-right flow).
+ * Strained flow configurations may have inlets on the either side of the flow domain.
  */
 class Inlet1D : public Boundary1D
 {
@@ -160,8 +162,6 @@ public:
         return m_yin[k];
     }
 
-    //! @deprecated To be changed after %Cantera 3.0. Right-to-left flow
-    //!     will only be supported for counter-flow configurations.
     virtual void init();
     virtual void eval(size_t jg, double* xg, double* rg,
                       integer* diagg, double rdt);

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -159,6 +159,9 @@ public:
     virtual double massFraction(size_t k) {
         return m_yin[k];
     }
+
+    //! @deprecated To be changed after %Cantera 3.0. Right-to-left flow
+    //!     will only be supported for counter-flow configurations.
     virtual void init();
     virtual void eval(size_t jg, double* xg, double* rg,
                       integer* diagg, double rdt);
@@ -236,6 +239,7 @@ public:
 
 /**
  * An outlet.
+ * Flow is assumed to be from left to right.
  */
 class Outlet1D : public Boundary1D
 {
@@ -265,6 +269,7 @@ public:
 
 /**
  * An outlet with specified composition.
+ * Flow is assumed to be from left to right.
  */
 class OutletRes1D : public Boundary1D
 {
@@ -288,6 +293,7 @@ public:
     virtual double massFraction(size_t k) {
         return m_yres[k];
     }
+
     virtual void init();
     virtual void eval(size_t jg, double* xg, double* rg,
                       integer* diagg, double rdt);

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -292,7 +292,18 @@ public:
         return m_rho[j];
     }
 
+    //! @deprecated To be removed after %Cantera 3.0. Superseded by isFree()
     virtual bool fixed_mdot();
+
+    /**
+     * Retrieve flag indicating whether flow is freely propagating.
+     * The flow is unstrained and the axial mass flow rate is not specified.
+     * For free flame propagation, the axial velocity is determined by the solver.
+     * @since New in %Cantera 3.0
+     */
+    bool isFree() const {
+        return m_isFree;
+    }
 
     void setViscosityFlag(bool dovisc) {
         m_dovisc = dovisc;

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -305,6 +305,17 @@ public:
         return m_isFree;
     }
 
+    /**
+     * Retrieve flag indicating whether flow uses radial momentum.
+     * If `true`, radial momentum equation for @f$ V @f$ as well as
+     * @f$ d\Lambda/dz = 0 @f$ are solved; if `false`, @f$ \Lambda(z) = 0 @f$ and
+     * @f$ V(z) = 0 @f$ by definition.
+     * @since New in %Cantera 3.0
+     */
+    bool usesLambda() const {
+        return m_usesLambda;
+    }
+
     void setViscosityFlag(bool dovisc) {
         m_dovisc = dovisc;
     }

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -312,7 +312,7 @@ public:
      * @f$ V(z) = 0 @f$ by definition.
      * @since New in %Cantera 3.0
      */
-    bool usesLambda() const {
+    bool isStrained() const {
         return m_usesLambda;
     }
 

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -142,14 +142,19 @@ void Inlet1D::init()
     // if a flow domain is present on the left, then this must be a right inlet.
     // Note that an inlet object can only be a terminal object - it cannot have
     // flows on both the left and right
-    if (m_flow_left) {
+    if (m_flow_left && !m_flow_right) {
+        if (!m_flow_left->usesLambda()) {
+            throw CanteraError("Inlet1D::init",
+                "Right inlets with right-to-left flow are only supported for "
+                "strained flow configurations.");
+        }
         m_ilr = RightInlet;
         m_flow = m_flow_left;
     } else if (m_flow_right) {
         m_ilr = LeftInlet;
         m_flow = m_flow_right;
     } else {
-        throw CanteraError("Inlet1D::init","no flow!");
+        throw CanteraError("Inlet1D::init", "Inlet1D is not properly connected.");
     }
 
     // components = u, V, T, lambda, + mass fractions
@@ -353,10 +358,13 @@ void Outlet1D::init()
     _init(0);
 
     if (m_flow_right) {
-        m_flow_right->setViscosityFlag(false);
+        throw CanteraError("Outlet1D::init",
+            "Left outlets with right-to-left flow are not supported.");
     }
     if (m_flow_left) {
         m_flow_left->setViscosityFlag(false);
+    } else {
+        throw CanteraError("Outlet1D::init", "Outlet1D is not connected.");
     }
 }
 
@@ -372,39 +380,23 @@ void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
     double* r = rg + loc();
     integer* diag = diagg + loc();
 
-    if (m_flow_right) {
-        size_t nc = m_flow_right->nComponents();
-        double* xb = x;
-        double* rb = r;
-        for (size_t k = c_offset_Y; k < nc; k++) {
-            rb[k] = xb[k] - xb[k + nc];
-        }
-        if (m_flow_left->doEnergy(0)) {
-            rb[c_offset_T] = xb[c_offset_T + nc] - xb[c_offset_T]; // zero T gradient
-        } else {
-            rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(0);
-        }
+    // flow is left-to-right
+    size_t nc = m_flow_left->nComponents();
+    double* xb = x - nc;
+    double* rb = r - nc;
+    int* db = diag - nc;
+
+    size_t last = m_flow_left->nPoints() - 1;
+    if (m_flow_left->doEnergy(last)) {
+        rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T - nc]; // zero T gradient
+    } else {
+        rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(last);
     }
-
-    if (m_flow_left) {
-        // flow is left-to-right
-        size_t nc = m_flow_left->nComponents();
-        double* xb = x - nc;
-        double* rb = r - nc;
-        int* db = diag - nc;
-
-        size_t last = m_flow_left->nPoints() - 1;
-        if (m_flow_left->doEnergy(last)) {
-            rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T - nc]; // zero T gradient
-        } else {
-            rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(last);
-        }
-        size_t kSkip = c_offset_Y + m_flow_left->rightExcessSpecies();
-        for (size_t k = c_offset_Y; k < nc; k++) {
-            if (k != kSkip) {
-                rb[k] = xb[k] - xb[k - nc]; // zero mass fraction gradient
-                db[k] = 0;
-            }
+    size_t kSkip = c_offset_Y + m_flow_left->rightExcessSpecies();
+    for (size_t k = c_offset_Y; k < nc; k++) {
+        if (k != kSkip) {
+            rb[k] = xb[k] - xb[k - nc]; // zero mass fraction gradient
+            db[k] = 0;
         }
     }
 }
@@ -440,12 +432,14 @@ void OutletRes1D::init()
 {
     _init(0);
 
+    if (m_flow_right) {
+        throw CanteraError("OutletRes1D::init",
+            "Left outlets with right-to-left flow are not supported.");
+    }
     if (m_flow_left) {
         m_flow = m_flow_left;
-    } else if (m_flow_right) {
-        m_flow = m_flow_right;
     } else {
-        throw CanteraError("OutletRes1D::init","no flow!");
+        throw CanteraError("OutletRes1D::init", "no flow!");
     }
 
     m_nsp = m_flow->phase().nSpecies();
@@ -469,42 +463,22 @@ void OutletRes1D::eval(size_t jg, double* xg, double* rg,
     double* r = rg + loc();
     integer* diag = diagg + loc();
 
-    if (m_flow_right) {
-        size_t nc = m_flow_right->nComponents();
-        double* xb = x;
-        double* rb = r;
+    size_t nc = m_flow_left->nComponents();
+    double* xb = x - nc;
+    double* rb = r - nc;
+    int* db = diag - nc;
 
-        if (m_flow_right->doEnergy(0)) {
-            // zero gradient for T
-            rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T + nc];
-        } else {
-            rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(0);
-        }
-
-        // specified mass fractions
-        for (size_t k = c_offset_Y; k < nc; k++) {
-            rb[k] = xb[k] - m_yres[k-c_offset_Y];
-        }
+    size_t last = m_flow_left->nPoints() - 1;
+    if (m_flow_left->doEnergy(last)) {
+        rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T - nc]; // zero T gradient
+    } else {
+        rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(last);
     }
-
-    if (m_flow_left) {
-        size_t nc = m_flow_left->nComponents();
-        double* xb = x - nc;
-        double* rb = r - nc;
-        int* db = diag - nc;
-
-        size_t last = m_flow_left->nPoints() - 1;
-        if (m_flow_left->doEnergy(last)) {
-            rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T - nc]; // zero T gradient
-        } else {
-            rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(last);
-        }
-        size_t kSkip = m_flow_left->rightExcessSpecies();
-        for (size_t k = c_offset_Y; k < nc; k++) {
-            if (k != kSkip) {
-                rb[k] = xb[k] - m_yres[k-c_offset_Y]; // fixed Y
-                db[k] = 0;
-            }
+    size_t kSkip = m_flow_left->rightExcessSpecies();
+    for (size_t k = c_offset_Y; k < nc; k++) {
+        if (k != kSkip) {
+            rb[k] = xb[k] - m_yres[k-c_offset_Y]; // fixed Y
+            db[k] = 0;
         }
     }
 }
@@ -663,6 +637,7 @@ void ReactingSurf1D::init()
 {
     m_nv = m_nsp;
     _init(m_nsp);
+
     m_fixed_cov.resize(m_nsp, 0.0);
     m_fixed_cov[0] = 1.0;
     m_work.resize(m_kin->nTotalSpecies(), 0.0);

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -178,10 +178,6 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
         // the inlet, since this is set within the flow domain from the
         // continuity equation.
 
-        // spreading rate. The flow domain sets this to V(0),
-        // so for finite spreading rate subtract m_V0.
-        rb[c_offset_V] -= m_V0;
-
         if (m_flow->doEnergy(0)) {
             // The third flow residual is for T, where it is set to T(0).  Subtract
             // the local temperature to hold the flow T to the inlet T.
@@ -199,6 +195,10 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             // The flow domain sets this to -rho*u. Add mdot to specify the mass
             // flow rate
             rb[c_offset_L] += m_mdot;
+
+            // spreading rate. The flow domain sets this to V(0),
+            // so for finite spreading rate subtract m_V0.
+            rb[c_offset_V] -= m_V0;
         } else {
             rb[c_offset_U] = m_flow->density(0) * xb[c_offset_U] - m_mdot;
             rb[c_offset_L] = xb[c_offset_L];
@@ -212,7 +212,7 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
         }
 
     } else {
-        // right inlet
+        // right inlet (should only be used for counter-flow flames)
         // Array elements corresponding to the last point in the flow domain
         double* rb = rg + loc() - m_flow->nComponents();
         rb[c_offset_V] -= m_V0;

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -188,15 +188,15 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             rb[c_offset_T] -= m_temp;
         }
 
-        if (m_flow->fixed_mdot()) {
-            // The flow domain sets this to -rho*u. Add mdot to specify the mass
-            // flow rate.
-            rb[c_offset_L] += m_mdot;
-        } else {
+        if (m_flow->isFree()) {
             // if the flow is a freely-propagating flame, mdot is not specified.
             // Set mdot equal to rho*u, and also set lambda to zero.
             m_mdot = m_flow->density(0) * xb[c_offset_U];
             rb[c_offset_L] = xb[c_offset_L];
+        } else {
+            // The flow domain sets this to -rho*u. Add mdot to specify the mass
+            // flow rate.
+            rb[c_offset_L] += m_mdot;
         }
 
         // add the convective term to the species residual equations
@@ -385,7 +385,7 @@ void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
         int* db = diag - nc;
 
         // zero Lambda
-        if (m_flow_left->fixed_mdot()) {
+        if (!m_flow_left->isFree()) {
             rb[c_offset_U] = xb[c_offset_L];
         }
 
@@ -488,9 +488,7 @@ void OutletRes1D::eval(size_t jg, double* xg, double* rg,
         double* rb = r - nc;
         int* db = diag - nc;
 
-        if (!m_flow_left->fixed_mdot()) {
-            ;
-        } else {
+        if (m_flow_left->isFree()) {
             rb[c_offset_U] = xb[c_offset_L]; // zero Lambda
         }
         if (m_flow_left->doEnergy(m_flow_left->nPoints()-1)) {

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -193,10 +193,13 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             // Set mdot equal to rho*u, and also set lambda to zero.
             m_mdot = m_flow->density(0) * xb[c_offset_U];
             rb[c_offset_L] = xb[c_offset_L];
-        } else {
+        } else if (m_flow->usesLambda()) {
             // The flow domain sets this to -rho*u. Add mdot to specify the mass
-            // flow rate (both axisymmetric and unstrained).
+            // flow rate
             rb[c_offset_L] += m_mdot;
+        } else {
+            rb[c_offset_U] = m_flow->density(0) * xb[c_offset_U] - m_mdot;
+            rb[c_offset_L] = xb[c_offset_L];
         }
 
         // add the convective term to the species residual equations
@@ -369,27 +372,17 @@ void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
         size_t nc = m_flow_right->nComponents();
         double* xb = x;
         double* rb = r;
-        if (!m_flow_right->usesLambda()) {
-            rb[c_offset_L] = xb[c_offset_L];
-        }
-        if (m_flow_right->doEnergy(0)) {
-            rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T + nc];
-        }
         for (size_t k = c_offset_Y; k < nc; k++) {
             rb[k] = xb[k] - xb[k + nc];
         }
     }
 
     if (m_flow_left) {
+        // flow is left-to-right
         size_t nc = m_flow_left->nComponents();
         double* xb = x - nc;
         double* rb = r - nc;
         int* db = diag - nc;
-
-        // zero Lambda
-        if (!m_flow_left->isFree()) {
-            rb[c_offset_U] = xb[c_offset_L];
-        }
 
         if (m_flow_left->doEnergy(m_flow_left->nPoints()-1)) {
             rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T - nc]; // zero T gradient

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -143,7 +143,7 @@ void Inlet1D::init()
     // Note that an inlet object can only be a terminal object - it cannot have
     // flows on both the left and right
     if (m_flow_left && !m_flow_right) {
-        if (!m_flow_left->usesLambda()) {
+        if (!m_flow_left->isStrained()) {
             throw CanteraError("Inlet1D::init",
                 "Right inlets with right-to-left flow are only supported for "
                 "strained flow configurations.");
@@ -196,7 +196,7 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             // Set mdot equal to rho*u, and also set lambda to zero.
             m_mdot = m_flow->density(0) * xb[c_offset_U];
             rb[c_offset_L] = xb[c_offset_L];
-        } else if (m_flow->usesLambda()) {
+        } else if (m_flow->isStrained()) {
             // The flow domain sets this to -rho*u. Add mdot to specify the mass
             // flow rate
             rb[c_offset_L] += m_mdot;

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -186,6 +186,8 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             // The third flow residual is for T, where it is set to T(0).  Subtract
             // the local temperature to hold the flow T to the inlet T.
             rb[c_offset_T] -= m_temp;
+        } else {
+            rb[c_offset_T] -= m_flow->T_fixed(0);
         }
 
         if (m_flow->isFree()) {
@@ -216,6 +218,8 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
         rb[c_offset_V] -= m_V0;
         if (m_flow->doEnergy(m_flow->nPoints() - 1)) {
             rb[c_offset_T] -= m_temp; // T
+        } else {
+            rb[c_offset_T] -= m_flow->T_fixed(m_flow->nPoints() - 1);
         }
         rb[c_offset_U] += m_mdot; // u
         for (size_t k = 0; k < m_nsp; k++) {
@@ -375,6 +379,11 @@ void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
         for (size_t k = c_offset_Y; k < nc; k++) {
             rb[k] = xb[k] - xb[k + nc];
         }
+        if (m_flow_left->doEnergy(0)) {
+            rb[c_offset_T] = xb[c_offset_T + nc] - xb[c_offset_T]; // zero T gradient
+        } else {
+            rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(0);
+        }
     }
 
     if (m_flow_left) {
@@ -384,8 +393,11 @@ void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
         double* rb = r - nc;
         int* db = diag - nc;
 
-        if (m_flow_left->doEnergy(m_flow_left->nPoints()-1)) {
+        size_t last = m_flow_left->nPoints() - 1;
+        if (m_flow_left->doEnergy(last)) {
             rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T - nc]; // zero T gradient
+        } else {
+            rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(last);
         }
         size_t kSkip = c_offset_Y + m_flow_left->rightExcessSpecies();
         for (size_t k = c_offset_Y; k < nc; k++) {
@@ -462,13 +474,11 @@ void OutletRes1D::eval(size_t jg, double* xg, double* rg,
         double* xb = x;
         double* rb = r;
 
-        // this seems wrong...
-        // zero Lambda
-        rb[c_offset_U] = xb[c_offset_L];
-
         if (m_flow_right->doEnergy(0)) {
             // zero gradient for T
             rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T + nc];
+        } else {
+            rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(0);
         }
 
         // specified mass fractions
@@ -483,11 +493,11 @@ void OutletRes1D::eval(size_t jg, double* xg, double* rg,
         double* rb = r - nc;
         int* db = diag - nc;
 
-        if (!m_flow_left->usesLambda()) {
-            rb[c_offset_L] = xb[c_offset_L]; // zero Lambda
-        }
-        if (m_flow_left->doEnergy(m_flow_left->nPoints()-1)) {
-            rb[c_offset_T] = xb[c_offset_T] - m_temp; // zero dT/dz
+        size_t last = m_flow_left->nPoints() - 1;
+        if (m_flow_left->doEnergy(last)) {
+            rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T - nc]; // zero T gradient
+        } else {
+            rb[c_offset_T] = xb[c_offset_T] - m_flow_left->T_fixed(last);
         }
         size_t kSkip = m_flow_left->rightExcessSpecies();
         for (size_t k = c_offset_Y; k < nc; k++) {

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -195,7 +195,7 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
             rb[c_offset_L] = xb[c_offset_L];
         } else {
             // The flow domain sets this to -rho*u. Add mdot to specify the mass
-            // flow rate.
+            // flow rate (both axisymmetric and unstrained).
             rb[c_offset_L] += m_mdot;
         }
 
@@ -369,7 +369,9 @@ void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
         size_t nc = m_flow_right->nComponents();
         double* xb = x;
         double* rb = r;
-        rb[c_offset_U] = xb[c_offset_L];
+        if (!m_flow_right->usesLambda()) {
+            rb[c_offset_L] = xb[c_offset_L];
+        }
         if (m_flow_right->doEnergy(0)) {
             rb[c_offset_T] = xb[c_offset_T] - xb[c_offset_T + nc];
         }
@@ -488,8 +490,8 @@ void OutletRes1D::eval(size_t jg, double* xg, double* rg,
         double* rb = r - nc;
         int* db = diag - nc;
 
-        if (m_flow_left->isFree()) {
-            rb[c_offset_U] = xb[c_offset_L]; // zero Lambda
+        if (!m_flow_left->usesLambda()) {
+            rb[c_offset_L] = xb[c_offset_L]; // zero Lambda
         }
         if (m_flow_left->doEnergy(m_flow_left->nPoints()-1)) {
             rb[c_offset_T] = xb[c_offset_T] - m_temp; // zero dT/dz

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -664,7 +664,7 @@ int Sim1D::setFixedTemperature(double t)
         StFlow* d_free = dynamic_cast<StFlow*>(&domain(n));
         size_t npnow = d.nPoints();
         size_t nstart = znew.size();
-        if (d_free && !d_free->fixed_mdot()) {
+        if (d_free && d_free->isFree()) {
             for (size_t m = 0; m < npnow - 1; m++) {
                 bool fixedpt = false;
                 double t1 = value(n, c_offset_T, m);
@@ -742,7 +742,7 @@ double Sim1D::fixedTemperature()
     double t_fixed = std::numeric_limits<double>::quiet_NaN();
     for (size_t n = 0; n < nDomains(); n++) {
         StFlow* d = dynamic_cast<StFlow*>(&domain(n));
-        if (d && !d->fixed_mdot() && d->m_tfixed > 0) {
+        if (d && d->isFree() && d->m_tfixed > 0) {
             t_fixed = d->m_tfixed;
             break;
         }
@@ -755,7 +755,7 @@ double Sim1D::fixedTemperatureLocation()
     double z_fixed = std::numeric_limits<double>::quiet_NaN();
     for (size_t n = 0; n < nDomains(); n++) {
         StFlow* d = dynamic_cast<StFlow*>(&domain(n));
-        if (d && !d->fixed_mdot() && d->m_tfixed > 0) {
+        if (d && d->isFree() && d->m_tfixed > 0) {
             z_fixed = d->m_zfixed;
             break;
         }

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -1054,24 +1054,23 @@ void StFlow::evalContinuity(size_t j, double* x, double* rsd, int* diag, double 
             -(rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
             -(density(j+1)*V(x,j+1) + density(j)*V(x,j));
     } else if (m_isFree) {
+        // terms involving V are zero as V=0 by definition
         if (grid(j) > m_zfixed) {
             rsd[index(c_offset_U,j)] =
-                - (rho_u(x,j) - rho_u(x,j-1))/m_dz[j-1]
-                - (density(j-1)*V(x,j-1) + density(j)*V(x,j));
+                - (rho_u(x,j) - rho_u(x,j-1))/m_dz[j-1];
         } else if (grid(j) == m_zfixed) {
             if (m_do_energy[j]) {
                 rsd[index(c_offset_U,j)] = (T(x,j) - m_tfixed);
             } else {
                 rsd[index(c_offset_U,j)] = (rho_u(x,j)
-                                            - m_rho[0]*0.3);
+                                            - m_rho[0]*0.3); // why 0.3?
             }
         } else if (grid(j) < m_zfixed) {
             rsd[index(c_offset_U,j)] =
-                - (rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
-                - (density(j+1)*V(x,j+1) + density(j)*V(x,j));
+                - (rho_u(x,j+1) - rho_u(x,j))/m_dz[j];
         }
     } else {
-        // unstrained
+        // unstrained with fixed mass flow rate
         rsd[index(c_offset_U, j)] = rho_u(x, j) - rho_u(x, j - 1);
     }
 }

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -485,7 +485,12 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
             } else {
                 rsd[index(c_offset_T,0)] = T(x,0) - T_fixed(0);
             }
-            rsd[index(c_offset_L,0)] = -rho_u(x,0);
+            if (m_isFree) {
+                rsd[index(c_offset_L, 0)] = lambda(x, 0);
+            } else {
+                // used to set mass flow rate
+                rsd[index(c_offset_L, 0)] = -rho_u(x, 0);
+            }
 
             // The default boundary condition for species is zero flux. However,
             // the boundary object may modify this.
@@ -569,7 +574,11 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
                 diag[index(c_offset_T, j)] = 0;
             }
 
-            rsd[index(c_offset_L, j)] = lambda(x,j) - lambda(x,j-1);
+            if (m_isFree) {
+                rsd[index(c_offset_L, j)] = lambda(x, j);
+            } else {
+                rsd[index(c_offset_L, j)] = lambda(x, j) - lambda(x, j - 1);
+            }
             diag[index(c_offset_L, j)] = 0;
         }
     }

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -513,11 +513,16 @@ void StFlow::evalResidual(double* x, double* rsd, int* diag,
             //    \rho dV/dt + \rho u dV/dz + \rho V^2
             //       = d(\mu dV/dz)/dz - lambda
             //-------------------------------------------------
-            rsd[index(c_offset_V,j)]
-            = (shear(x,j) - lambda(x,j) - rho_u(x,j)*dVdz(x,j)
-               - m_rho[j]*V(x,j)*V(x,j))/m_rho[j]
-              - rdt*(V(x,j) - V_prev(j));
-            diag[index(c_offset_V, j)] = 1;
+            if (m_usesLambda) {
+                rsd[index(c_offset_V,j)] =
+                    (shear(x, j) - lambda(x, j) - rho_u(x, j) * dVdz(x, j)
+                    - m_rho[j] * V(x, j) * V(x, j)) / m_rho[j]
+                    - rdt * (V(x, j) - V_prev(j));
+                diag[index(c_offset_V, j)] = 1;
+            } else {
+                rsd[index(c_offset_V, j)] = V(x, j);
+                diag[index(c_offset_V, j)] = 0;
+            }
 
             //-------------------------------------------------
             //    Species equations
@@ -1010,6 +1015,7 @@ void StFlow::evalRightBoundary(double* x, double* rsd, int* diag, double rdt)
     // and T, and zero diffusive flux for all species.
 
     rsd[index(c_offset_V,j)] = V(x,j);
+    diag[index(c_offset_V,j)] = 0;
     double sum = 0.0;
     // set residual of poisson's equ to zero
     rsd[index(c_offset_E, j)] = x[index(c_offset_E, j)];

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -298,6 +298,8 @@ void StFlow::setGasAtMidpoint(const double* x, size_t j)
 }
 
 bool StFlow::fixed_mdot() {
+    warn_deprecated("StFlow::fixed_mdot", "To be removed after"
+        " Cantera 3.0. Replaced by isFree().");
     return !m_isFree;
 }
 

--- a/src/oneD/refine.cpp
+++ b/src/oneD/refine.cpp
@@ -181,7 +181,7 @@ int Refiner::analyze(size_t n, const double* z, const double* x)
         }
 
         // Keep the point where the temperature is fixed
-        if (fflame && !fflame->fixed_mdot() && z[j] == fflame->m_zfixed) {
+        if (fflame && fflame->isFree() && z[j] == fflame->m_zfixed) {
             m_keep[j] = 1;
         }
     }

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -103,7 +103,7 @@ class TestOnedim(utilities.CanteraTest):
         gas = ct.Solution("h2o2.yaml")
         left = ct.Inlet1D(gas)
         flame = ct.FreeFlow(gas)
-        right = ct.Inlet1D(gas)
+        right = ct.Outlet1D(gas)
         # Some things don't work until the domains have been added to a Sim1D
         sim = ct.Sim1D((left, flame, right))
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Unstrained flames have historically been implemented as axisymmetric flames where 'lambda' was used to specify the mass flow rate implicitly (lambda was propagated left-to-right and velocity propagated right-to-left), which leads to confusing boundary conditions (see #1533). The calculation also involves 'V' (which is zero) for the calculation of continuity, which is certainly not intuitive. Beyond, 'V' was also integrated for free flames, although it is by definition zero.

This PR removes the dependency on 'lambda' and 'V', and instead propagates information on mass flow rate left-to-right directly for the 'U' solution component, meaning that 'lambda'/'V' entries are no longer used for unconstrained flames (i.e. `BurnerFlame` and `FreeFlame` variants).

In addition: 
* simplify logic used for the evaluation of boundary conditions
* only evaluate 'V' for strained flames
* deprecate 'left' outlets, as they are untested and unlikely to work, i.e. only support 'right-to-left' flow for strained flames

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1533

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
