### PR TITLE
Doxygen formatting

### DIFF
--- a/doc/doxygen/thermoprops.dox
+++ b/doc/doxygen/thermoprops.dox
@@ -176,90 +176,90 @@
  *
  *     <TABLE>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_TPX() setState_TPX()\endlink </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_TPX() setState_TPX()@endlink </TD>
  *        <TD>    Sets the temperature, mole fractions and then the pressure
  *                of the phase. </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_TPY() setState_TPY()\endlink    </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_TPY() setState_TPY()@endlink    </TD>
  *        <TD>    Set the temperature, mass fractions and then the pressure
  *                of the phase. </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::MolalityVPSSTP::setState_TPM() setState_TPM()\endlink     </TD>
+ *        <TD> @link Cantera::MolalityVPSSTP::setState_TPM() setState_TPM()@endlink     </TD>
  *        <TD>    Set the temperature, solute molalities, and then the
  *                pressure of the phase. Only from %ThermoPhase objects which
  *                inherit from MolalityVPSSTP
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_TP() setState_TP()\endlink     </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_TP() setState_TP()@endlink     </TD>
  *        <TD>    Set the temperature, and then the pressure
  *                of the phase. The mole fractions are assumed fixed.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_PX() setState_PX()\endlink     </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_PX() setState_PX()@endlink     </TD>
  *        <TD>    Set the mole fractions and then the pressure
  *                         of the phase. The temperature is assumed fixed.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_PY() setState_PY()\endlink     </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_PY() setState_PY()@endlink     </TD>
  *        <TD>  Set the mass fractions and then the pressure
  *                         of the phase. The temperature is assumed fixed.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_HP() setState_HP()\endlink     </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_HP() setState_HP()@endlink     </TD>
  *        <TD> Set the total specific enthalpy and the pressure
  *                         of the phase using an iterative process.
  *                         The mole fractions are assumed fixed
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_UV() setState_UV()\endlink     </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_UV() setState_UV()@endlink     </TD>
  *        <TD>  Set the total specific internal energy and the pressure
  *                         of the phase using an iterative process.
  *                         The mole fractions are assumed fixed.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_SP setState_SP()\endlink     </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_SP setState_SP()@endlink     </TD>
  *        <TD>  Set the total specific internal energy and the pressure
  *                         of the phase using an iterative process.
  *                         The mole fractions are assumed fixed.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setState_SV setState_SV()\endlink     </TD>
+ *        <TD> @link Cantera::ThermoPhase::setState_SV setState_SV()@endlink     </TD>
  *        <TD> Set the total specific entropy and the total specific
  *                         molar volume of the phase using an iterative process.
  *                         The mole fractions are assumed fixed.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::Phase::setConcentrations setConcentrations()\endlink     </TD>
+ *        <TD> @link Cantera::Phase::setConcentrations setConcentrations()@endlink     </TD>
  *        <TD> Set the concentrations of all the species in the
  *                         phase. Note this implicitly specifies the pressure and
  *                         density of the phase. The temperature is assumed fixed.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::Phase::setDensity setDensity()\endlink     </TD>
+ *        <TD> @link Cantera::Phase::setDensity setDensity()@endlink     </TD>
  *        <TD>  Set the total density of the phase. The temperature and
  *                         mole fractions are assumed fixed. Note this implicitly
  *                         sets the pressure of the phase.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::Phase::setTemperature() setTemperature()\endlink     </TD>
+ *        <TD> @link Cantera::Phase::setTemperature() setTemperature()@endlink     </TD>
  *        <TD> Set the temperature of the phase. The density and
  *                         the mole fractions of the phase are fixed.
  *        </TD>
  *      </TR>
  *      <TR>
- *        <TD> \link Cantera::ThermoPhase::setToEquilState() setToEquilState()\endlink     </TD>
+ *        <TD> @link Cantera::ThermoPhase::setToEquilState() setToEquilState()@endlink     </TD>
  *        <TD>  Sets the mole fractions of the phase to their
  *                         equilibrium values assuming fixed temperature and
  *                         total density.

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -128,14 +128,14 @@ public:
 
     //! Returns `true` if the held value is a vector of the specified type, such as
     //! `vector<double>`.
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     template<class T>
     bool isVector() const;
 
     //! Returns `true` if the held value is a matrix of the specified type and a
     //! consistent number of columns, such as `vector<vector<double>>`. If the
     //! number of columns is provided, a match is required.
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     template<class T>
     bool isMatrix(size_t cols=npos) const;
 
@@ -147,7 +147,7 @@ public:
     //! If not a vector or the type is not supported npos is returned.
     //! Types considered include `vector<double>`, `vector<long int>`, `vector<string>`,
     //! and `vector<bool`.
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     size_t vectorSize() const;
 
     //! Returns rows and columns of a matrix.
@@ -155,7 +155,7 @@ public:
     //! npos; if the type is not supported, a npos pair is returned.
     //! Types considered include `vector<vector<double>>`, `vector<vector<long int>>`,
     //! `vector<vector<string>>` and `vector<vector<bool>>`.
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     pair<size_t, size_t> matrixShape() const;
 
     explicit AnyValue(const std::string& value);
@@ -430,7 +430,7 @@ public:
     //! Create an AnyMap from a YAML file.
     /*!
      *  Searches the directory containing the optionally-specified parent file
-     *  first, followed by the current working directory and the Cantera include
+     *  first, followed by the current working directory and the %Cantera include
      *  path.
      */
     static AnyMap fromYamlFile(const std::string& name,
@@ -475,7 +475,7 @@ public:
     std::string keys_str() const;
 
     //! Return an unordered set of keys
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     std::set<std::string> keys() const;
 
     //! Set a metadata value that applies to this AnyMap and its children.

--- a/include/cantera/base/ExtensionManager.h
+++ b/include/cantera/base/ExtensionManager.h
@@ -29,9 +29,9 @@ public:
     }
 };
 
-//! Base class for managing user-defined Cantera extensions written in other languages
+//! Base class for managing user-defined %Cantera extensions written in other languages
 //!
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 class ExtensionManager
 {
 public:

--- a/include/cantera/base/ExtensionManagerFactory.h
+++ b/include/cantera/base/ExtensionManagerFactory.h
@@ -14,7 +14,7 @@ namespace Cantera
 
 //! A factory class for creating ExtensionManager objects
 //!
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 class ExtensionManagerFactory : public Factory<ExtensionManager>
 {
 public:

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -72,7 +72,7 @@ public:
 
     //! Set the Transport object by name
     //! @param model  name of transport model; if omitted, the default model is used
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void setTransportModel(const std::string& model="");
 
     //! Accessor for the ThermoPhase pointer
@@ -139,11 +139,11 @@ public:
     //!   Solution is replaced.
     //! When the callback becomes invalid (for example, the corresponding object is
     //! being deleted, the removeChangedCallback() method must be invoked.
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void registerChangedCallback(void* id, const function<void()>& callback);
 
     //! Remove the callback function associated with the specified object.
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void removeChangedCallback(void* id);
 
 protected:

--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -23,10 +23,10 @@ class ThermoPhase;
  * stored, reshaping operations need to be implemented in high-level API's.
  *
  * The SolutionArray class implements the main interface for saving and restoring of
- * Cantera simulation data. SolutionArray objects can be serialized to and from YAML and
+ * %Cantera simulation data. SolutionArray objects can be serialized to and from YAML and
  * HDF container files using the save() and restore() methods. In addition, there is
  * limited support for CSV files.
- * @since  New in Cantera 3.0.
+ * @since New in %Cantera 3.0.
  * @ingroup solnGroup
  */
 class SolutionArray

--- a/include/cantera/base/Storage.h
+++ b/include/cantera/base/Storage.h
@@ -31,7 +31,7 @@ namespace Cantera
  *  A wrapper class handling storage to HDF; acts as a thin wrapper for HighFive.
  *  The class implements methods that are intended to be called from SolutionArray.
  *
- *  @since  New in Cantera 3.0.
+ *  @since New in %Cantera 3.0.
  *  @warning This class is an experimental part of the %Cantera API and may be
  *      changed or removed without notice.
  */

--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -2,7 +2,7 @@
  * @file Units.h
  * Header for unit conversion utilities, which are used to translate
  * user input from input files (See @ref inputGroup and
- * class \link Cantera::Units Units\endlink).
+ * class @link Cantera::Units Units@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -74,7 +74,7 @@ private:
     //! Scale the unit by the factor `k`
     void scale(double k) { m_factor *= k; }
 
-    double m_factor = 1.0; //!< conversion factor to Cantera base units
+    double m_factor = 1.0; //!< conversion factor to %Cantera base units
     double m_mass_dim = 0.0;
     double m_length_dim = 0.0;
     double m_time_dim = 0.0;
@@ -232,7 +232,7 @@ public:
     //! units specified in `dest`. Works like `convert(AnyValue&, Units&)` but with
     //! special handling for the case where the destination units are undefined.
     //!
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     double convertRateCoeff(const AnyValue& val, const Units& dest) const;
 
     //! Convert an array of AnyValue nodes to the units specified in `dest`. For

--- a/include/cantera/base/Units.h
+++ b/include/cantera/base/Units.h
@@ -1,7 +1,7 @@
 /**
  * @file Units.h
  * Header for unit conversion utilities, which are used to translate
- * user input from input files (See \ref inputGroup and
+ * user input from input files (See @ref inputGroup and
  * class \link Cantera::Units Units\endlink).
  */
 

--- a/include/cantera/base/clockWC.h
+++ b/include/cantera/base/clockWC.h
@@ -1,7 +1,7 @@
 /**
  * @file clockWC.h
  *    Declarations for a simple class that implements an Ansi C wall clock timer
- *   (see \ref Cantera::clockWC).
+ *   (see @ref Cantera::clockWC).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -3,7 +3,7 @@
  * This file contains definitions of constants, types and terms that are used
  * in internal routines and are unlikely to need modifying.
  *
- * All physical constants are stored here (see module \ref physConstants).
+ * All physical constants are stored here (see module @ref physConstants).
  *
  * This file is included in every file within the Cantera namespace.
  */

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -2,7 +2,7 @@
  * @file ctexceptions.h
  *   Definitions for the classes that are
  *   thrown when %Cantera experiences an error condition
- *   (also contains errorhandling module text - see \ref errGroup).
+ *   (also contains errorhandling module text - see @ref errGroup).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -54,7 +54,7 @@ namespace Cantera
  */
 
 
-//! Base class for exceptions thrown by Cantera classes.
+//! Base class for exceptions thrown by %Cantera classes.
 /*!
  * This class is the base class for exceptions thrown by Cantera. It inherits
  * from std::exception so that normal error handling operations from
@@ -127,7 +127,7 @@ private:
 
 //! Array size error.
 /*!
- * This error is thrown if a supplied length to a vector supplied to Cantera is
+ * This error is thrown if a supplied length to a vector supplied to %Cantera is
  * too small.
  *
  * @ingroup errGroup

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -1,12 +1,12 @@
 /**
  * @file global.h
  * This file contains definitions for utility functions and text for modules,
- * inputfiles and logging, (see \ref inputGroup, and \ref logGroup).
+ * inputfiles and logging, (see @ref inputGroup, and @ref logGroup).
  *
  * These functions store some parameters in global storage that are accessible
  * at all times from the calling application. Contains module definitions for
- *     -  inputfiles  (see \ref inputGroup)
- *     -  text logs  (see \ref logGroup)
+ *     -  inputfiles  (see @ref inputGroup)
+ *     -  text logs  (see @ref logGroup)
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -84,7 +84,7 @@ void loadExtension(const std::string& extType, const std::string& name);
 //! Load extensions providing user-defined models from the `extensions` section of the
 //! given node. @see Application::loadExtension
 //!
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 void loadExtensions(const AnyMap& node);
 
 //! @copydoc Application::searchPythonVersions
@@ -100,7 +100,7 @@ void appdelete();
 //! @copydoc Application::thread_complete
 void thread_complete();
 
-//! @defgroup globalSettings  Global Cantera Settings
+//! @defgroup globalSettings  Global %Cantera Settings
 //! @brief Functions for accessing global %Cantera settings.
 //! @ingroup globalData
 
@@ -109,15 +109,15 @@ void thread_complete();
 
 //! Returns `true` if %Cantera was loaded as a shared library in the current
 //! application. Returns `false` if it was statically linked.
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 bool usingSharedLibrary();
 
-//! @name Cantera Version Information
+//! @name %Cantera Version Information
 //! @{
 
 //! Returns the %Cantera version. This function is used to access the version from a
 //! library, rather than the \c CANTERA_VERSION macro that is available at compile time.
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 string version();
 
 //! Returns the hash of the git commit from which %Cantera was compiled, if known
@@ -131,7 +131,7 @@ std::string gitCommit();
 bool debugModeEnabled();
 
 //! Returns true if %Cantera was compiled with C++ \c HDF5 support.
-//! @since  New in Cantera 3.0.
+//! @since New in %Cantera 3.0.
 bool usesHDF5();
 
 //! @}
@@ -142,7 +142,7 @@ bool usesHDF5();
  *
  * Writing diagnostic information to the screen or to a file. It is often
  * useful to be able to write diagnostic messages to the screen or to a file.
- * Cantera defines a set of procedures for this purpose designed to write text messages
+ * %Cantera defines a set of procedures for this purpose designed to write text messages
  * to the screen to document the progress of a complex calculation, such as a
  * flame simulation.
  * @ingroup debugGroup
@@ -166,10 +166,10 @@ inline void debuglog(const std::string& msg, int loglevel)
 //!
 //! This function passes its arguments to the fmt library 'format' function to
 //! generate a formatted string from a Python-style (curly braces) format
-//! string. This method is used throughout Cantera to write log messages. It can
+//! string. This method is used throughout %Cantera to write log messages. It can
 //! also be called by user programs. The advantage of using writelog over
 //! writing directly to the standard output is that messages written with
-//! writelog will display correctly even when Cantera is used from MATLAB or
+//! writelog will display correctly even when %Cantera is used from MATLAB or
 //! other application that do not have a standard output stream.
 template <typename... Args>
 void writelog(const std::string& fmt, const Args&... args) {
@@ -322,7 +322,7 @@ void setLogger(Logger* logwriter);
 //! documentation says doing this from an error handler is not safe on all platforms
 //! and risks deadlocking. However, it can be useful for debugging and is therefore
 //! enabled when running tests.
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 //! @ingroup globalSettings
 void printStackTraceOnSegfault();
 

--- a/include/cantera/base/logger.h
+++ b/include/cantera/base/logger.h
@@ -24,7 +24,7 @@ namespace Cantera
 //! output stream or standard error stream, but classes may be derived from
 //! Logger that implement other output options. This is important when Cantera
 //! is used in applications that do not display the standard output, such as
-//! MATLAB. The Cantera MATLAB interface derives a class from Logger that
+//! MATLAB. The %Cantera MATLAB interface derives a class from Logger that
 //! implements these methods with MATLAB-specific procedures, insuring that the
 //! messages will be passed through to the user. It would also be possible to
 //! derive a class that displayed the messages in a pop-up window, or redirected
@@ -82,7 +82,7 @@ public:
      * The default behavior is to write to the standard error stream, and then
      * call exit(). Note that no end-of-line character is appended to the
      * message, and so if one is desired it must be included in the string. Note
-     * that this default behavior will terminate the application Cantera is
+     * that this default behavior will terminate the application %Cantera is
      * invoked from (MATLAB, Excel, etc.) If this is not desired, then derive a
      * class and reimplement this method.
      *

--- a/include/cantera/base/logger.h
+++ b/include/cantera/base/logger.h
@@ -1,7 +1,7 @@
 /**
  * @file logger.h
  * Header for Base class for 'loggers' that write text messages to log files
- * (see \ref logGroup and class \link Cantera::Logger Logger\endlink).
+ * (see @ref logGroup and class \link Cantera::Logger Logger\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/base/logger.h
+++ b/include/cantera/base/logger.h
@@ -1,7 +1,7 @@
 /**
  * @file logger.h
  * Header for Base class for 'loggers' that write text messages to log files
- * (see @ref logGroup and class \link Cantera::Logger Logger\endlink).
+ * (see @ref logGroup and class @link Cantera::Logger Logger@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/base/stringUtils.h
+++ b/include/cantera/base/stringUtils.h
@@ -115,7 +115,7 @@ void tokenizeString(const std::string& oval,
  * @param oval   String to be broken up
  * @param v     Output vector of tokens.
  *
- * @since  New in Cantera 3.0.
+ * @since New in %Cantera 3.0.
  */
 void tokenizePath(const std::string& oval,
                   std::vector<std::string>& v);

--- a/include/cantera/base/utilities.h
+++ b/include/cantera/base/utilities.h
@@ -1,7 +1,7 @@
 /**
  *  @file utilities.h
  *  Various templated functions that carry out common vector and polynomial operations
- *  (see \ref mathTemplates).
+ *  (see @ref mathTemplates).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
@@ -88,10 +88,10 @@ inline doublereal dot(InputIter x_begin, InputIter x_end,
 
 //! Multiply elements of an array by a scale factor.
 /*!
- * \code
+ * @code
  * vector_fp in(8, 1.0), out(8);
  * scale(in.begin(), in.end(), out.begin(), factor);
- * \endcode
+ * @endcode
  *
  * @param begin  Iterator pointing to the beginning, belonging to the
  *               iterator class InputIter.

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -122,7 +122,7 @@ extern "C" {
     CANTERA_CAPI int thermo_setState_Psat(int n, double p, double x);
     CANTERA_CAPI int thermo_setState_Tsat(int n, double t, double x);
 
-    //! @since Starting in Cantera 3.0, the "phasename" argument should be blank
+    //! @since Starting in %Cantera 3.0, the "phasename" argument should be blank
     CANTERA_CAPI int kin_newFromFile(const char* filename, const char* phasename,
                                      int reactingPhase, int neighbor1, int neighbor2,
                                      int neighbor3, int neighbor4);

--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -51,7 +51,7 @@ extern "C" {
     CANTERA_CAPI int flowdev_new(const char* type);
     CANTERA_CAPI int flowdev_del(int i);
     CANTERA_CAPI int flowdev_install(int i, int n, int m);
-    //! @deprecated To be removed after Cantera 3.0; replaced by flowdev_setPrimary
+    //! @deprecated To be removed after %Cantera 3.0; replaced by flowdev_setPrimary
     CANTERA_CAPI int flowdev_setMaster(int i, int n);
     CANTERA_CAPI int flowdev_setPrimary(int i, int n);
     CANTERA_CAPI double flowdev_massFlowRate(int i);

--- a/include/cantera/core.h
+++ b/include/cantera/core.h
@@ -1,7 +1,7 @@
 /**
  * @file core.h
  *
- * Support for Cantera core calculations from C++ application programs. This
+ * Support for %Cantera core calculations from C++ application programs. This
  * header file includes a minimal set of headers needed to create and use objects
  * that evaluate thermo properties, chemical kinetics and transport properties.
  */

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -1,7 +1,7 @@
 /**
  * @file MultiPhase.h
  * Headers for the \link Cantera::MultiPhase MultiPhase\endlink
- * object that is used to set up multiphase equilibrium problems (see \ref equilGroup).
+ * object that is used to set up multiphase equilibrium problems (see @ref equilGroup).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -20,7 +20,7 @@ class ThermoPhase;
 //! A class for multiphase mixtures. The mixture can contain any
 //! number of phases of any type.
 /*!
- * This object is the basic tool used by Cantera for use in Multiphase
+ * This object is the basic tool used by %Cantera for use in Multiphase
  * equilibrium calculations.
  *
  * It is a container for a set of phases. Each phase has a given number of

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -1,6 +1,6 @@
 /**
  * @file MultiPhase.h
- * Headers for the \link Cantera::MultiPhase MultiPhase\endlink
+ * Headers for the @link Cantera::MultiPhase MultiPhase@endlink
  * object that is used to set up multiphase equilibrium problems (see @ref equilGroup).
  */
 

--- a/include/cantera/equil/vcs_VolPhase.h
+++ b/include/cantera/equil/vcs_VolPhase.h
@@ -51,7 +51,7 @@ class VCS_SOLVE;
  * contains structures that point to the species belonging to this phase in the
  * global vcs species list.
  *
- * This object is considered not to own the underlying Cantera ThermoPhase
+ * This object is considered not to own the underlying %Cantera ThermoPhase
  * object for the phase.
  *
  * This object contains an idea of the temperature and pressure. It checks to

--- a/include/cantera/equil/vcs_internal.h
+++ b/include/cantera/equil/vcs_internal.h
@@ -11,7 +11,7 @@
 #include "cantera/base/global.h"
 namespace Cantera
 {
-//! define this Cantera function to replace printf
+//! define this %Cantera function to replace printf
 /*!
  * We can replace this with printf easily
  */

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -1,7 +1,7 @@
 /**
  * @file vcs_solve.h Header file for the internal object that holds the vcs
  *    equilibrium problem (see Class \link Cantera::VCS_SOLVE
- *    VCS_SOLVE\endlink and \ref equilGroup ).
+ *    VCS_SOLVE\endlink and @ref equilGroup ).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -1,7 +1,7 @@
 /**
  * @file vcs_solve.h Header file for the internal object that holds the vcs
- *    equilibrium problem (see Class \link Cantera::VCS_SOLVE
- *    VCS_SOLVE\endlink and @ref equilGroup ).
+ *    equilibrium problem (see Class @link Cantera::VCS_SOLVE
+ *    VCS_SOLVE@endlink and @ref equilGroup ).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/extensions/PythonExtensionManager.h
+++ b/include/cantera/extensions/PythonExtensionManager.h
@@ -11,7 +11,7 @@
 namespace Cantera
 {
 
-//! Class for managing user-defined Cantera extensions written in Python
+//! Class for managing user-defined %Cantera extensions written in Python
 //!
 //! Handles Python initialization if the main application is not the Python interpreter.
 //!
@@ -21,7 +21,7 @@ namespace Cantera
 //! <a href="../../sphinx/html/cython/utilities.html#cantera.extension">`@extension`</a>
 //! in the Python documentation for more information.
 //!
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 class PythonExtensionManager : public ExtensionManager
 {
 public:

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -24,7 +24,7 @@ public:
     //! @{
     BulkKinetics();
 
-    //! @deprecated  To be removed after Cantera 3.0; code base only uses default.
+    //! @deprecated To be removed after %Cantera 3.0; code base only uses default.
     BulkKinetics(ThermoPhase* thermo);
 
     string kineticsType() const override {

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -124,7 +124,7 @@ public:
 
     void getParameters(AnyMap& rateNode) const;
 
-    //! @deprecated  To be removed after Cantera 3.0.
+    //! @deprecated To be removed after %Cantera 3.0.
     void getParameters(AnyMap& rateNode, const Units& rate_units) const {
         warn_deprecated("ChebyshevRate:getParameters",
             "To be removed after Cantera 3.0. Second argument is no longer needed.");

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -81,7 +81,7 @@ public:
      * @param c Vector of coefficients of the parameterization. The number and
      *     meaning of these coefficients is subclass-dependent.
      *
-     * @deprecated  To be removed after Cantera 3.0; superseded by setFalloffCoeffs()
+     * @deprecated To be removed after %Cantera 3.0; superseded by setFalloffCoeffs()
      */
     void init(const vector_fp& c);
 
@@ -144,7 +144,7 @@ public:
 
     //! The size of the work array required.
     /**
-     * @deprecated  To be removed after Cantera 3.0; unused.
+     * @deprecated To be removed after %Cantera 3.0; unused.
      */
     virtual size_t workSize() const {
         warn_deprecated("FalloffRate::workSize",
@@ -171,7 +171,7 @@ public:
     //! Get the values of the parameters for this object. *params* must be an
     //! array of at least nParameters() elements.
     /**
-     * @deprecated  To be removed after Cantera 3.0; superseded by getFalloffCoeffs()
+     * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
     virtual void getParameters(double* params) const {
         warn_deprecated("FalloffRate::getParameters",
@@ -366,7 +366,7 @@ public:
 
     //! Sets params to contain, in order, \f[ (A, T_3, T_1, T_2) \f]
     /**
-     * @deprecated  To be removed after Cantera 3.0; superseded by getFalloffCoeffs()
+     * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
     virtual void getParameters(double* params) const override;
 
@@ -466,7 +466,7 @@ public:
 
     //! Sets params to contain, in order, \f[ (a, b, c, d, e) \f]
     /**
-     * @deprecated  To be removed after Cantera 3.0; superseded by getFalloffCoeffs()
+     * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
     virtual void getParameters(double* params) const override;
 
@@ -572,7 +572,7 @@ public:
 
     //! Sets params to contain, in order, \f[ (A, B) \f]
     /**
-     * @deprecated  To be removed after Cantera 3.0; superseded by getFalloffCoeffs()
+     * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
     virtual void getParameters(double* params) const override;
 

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -24,7 +24,7 @@ namespace Cantera
  * implements standard mass-action reaction rate expressions for low-density
  * gases.
  * @ingroup kineticsmgr
- * @deprecated Replace with BulkKinetics. To be removed after Cantera 3.0.
+ * @deprecated Replace with BulkKinetics. To be removed after %Cantera 3.0.
  */
 class GasKinetics : public BulkKinetics
 {
@@ -33,7 +33,7 @@ public:
     //! Constructor.
     GasKinetics() {}
 
-    //! @deprecated  To be removed after Cantera 3.0; code base only uses default.
+    //! @deprecated To be removed after %Cantera 3.0; code base only uses default.
     GasKinetics(ThermoPhase* thermo) : GasKinetics() {
         warn_deprecated("GasKinetics::GasKinetics(ThermoPhase*)",
             "To be removed after Cantera 3.0. Use default constructor instead.");

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -1,7 +1,7 @@
 /**
  *  @file ImplicitSurfChem.h
  * Declarations for the implicit integration of surface site density equations
- *  (see \ref  kineticsmgr and class
+ *  (see @ref  kineticsmgr and class
  *  \link Cantera::ImplicitSurfChem ImplicitSurfChem\endlink).
  */
 

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -2,7 +2,7 @@
  *  @file ImplicitSurfChem.h
  * Declarations for the implicit integration of surface site density equations
  *  (see @ref  kineticsmgr and class
- *  \link Cantera::ImplicitSurfChem ImplicitSurfChem\endlink).
+ *  @link Cantera::ImplicitSurfChem ImplicitSurfChem@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -65,7 +65,7 @@ public:
      *               HKM Note -> Since the interface kinetics object will
      *               probably require multiple ThermoPhase objects, this is
      *               probably not a good idea to have this parameter.
-     * @deprecated  To be removed after Cantera 3.0; code base only uses default.
+     * @deprecated To be removed after %Cantera 3.0; code base only uses default.
      */
     InterfaceKinetics(ThermoPhase* thermo);
 

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -111,7 +111,7 @@ public:
     //! Store parameters needed to reconstruct coverage dependencies
     //! @param dependencies  AnyMap receiving coverage information
     //! @param asVector  Optional boolean flag to override map output
-    //! @deprecated  After Cantera 3.0, the optional asVector argument will be removed.
+    //! @deprecated After %Cantera 3.0, the optional asVector argument will be removed.
     void getCoverageDependencies(AnyMap& dependencies, bool asVector=false) const;
 
     //! Add a coverage dependency for species *sp*, with exponential dependence

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -1,7 +1,7 @@
 /**
  * @file Kinetics.h
  *  Base class for kinetics managers and also contains the kineticsmgr
- *  module documentation (see \ref  kineticsmgr and class
+ *  module documentation (see @ref  kineticsmgr and class
  *  \link Cantera::Kinetics Kinetics\endlink).
  */
 

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -140,7 +140,7 @@ public:
     //! Identifies the Kinetics manager type.
     //! Each class derived from Kinetics should override this method to return
     //! a meaningful identifier.
-    //! @since  Starting in Cantera 3.0, the name returned by this method corresponds
+    //! @since Starting in %Cantera 3.0, the name returned by this method corresponds
     //!     to the canonical name used in the YAML input format.
     virtual std::string kineticsType() const {
         return "none";
@@ -217,7 +217,7 @@ public:
      * cSurf. For heterogeneous mechanisms, this identifies the one surface
      * phase. For homogeneous mechanisms, this returns -1.
      *
-     * @deprecated To be removed after Cantera 3.0. Use reactionPhaseIndex instead.
+     * @deprecated To be removed after %Cantera 3.0. Use reactionPhaseIndex instead.
      */
     size_t surfacePhaseIndex() const;
 
@@ -229,8 +229,8 @@ public:
      * of phases. If there is more than one, the index of the first one is
      * returned. For homogeneous mechanisms, the value 0 is returned.
      *
-     * @deprecated Starting in Cantera 3.0, the reacting phase will always be the
-     *     first phase in the InterfaceKinetics object. To be removed after Cantera 3.1.
+     * @deprecated Starting in %Cantera 3.0, the reacting phase will always be the
+     *     first phase in the InterfaceKinetics object. To be removed after %Cantera 3.1.
      */
     size_t reactionPhaseIndex() const {
         return m_rxnphase;
@@ -238,7 +238,7 @@ public:
 
     /**
      * Return pointer to phase where the reactions occur.
-     * @since New in Cantera 3.0
+     * @since New in %Cantera 3.0
      */
     shared_ptr<ThermoPhase> reactionPhase() const;
 
@@ -324,7 +324,7 @@ public:
      *
      * @param nm   Input string name of the species
      * @param ph   Input string name of the phase.
-     * @deprecated To be removed after Cantera 3.0. Species names should be unique
+     * @deprecated To be removed after %Cantera 3.0. Species names should be unique
      *     across all phases.
      */
     size_t kineticsSpeciesIndex(const std::string& nm,
@@ -757,7 +757,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual Eigen::SparseMatrix<double> fwdRatesOfProgress_ddCi()
     {
@@ -830,7 +830,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual Eigen::SparseMatrix<double> revRatesOfProgress_ddCi()
     {
@@ -903,7 +903,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual Eigen::SparseMatrix<double> netRatesOfProgress_ddCi()
     {
@@ -960,7 +960,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     Eigen::SparseMatrix<double> creationRates_ddCi();
 
@@ -1013,7 +1013,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     Eigen::SparseMatrix<double> destructionRates_ddCi();
 
@@ -1066,7 +1066,7 @@ public:
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     Eigen::SparseMatrix<double> netProductionRates_ddCi();
 
@@ -1152,8 +1152,8 @@ public:
      * String specifying the type of reaction.
      *
      * @param i   reaction index
-     * @since  Method returned magic number prior to Cantera 3.0.
-     * @deprecated  To be removed after Cantera 3.0. Replace with
+     * @since Method returned magic number prior to %Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0. Replace with
      *     `kin->reaction(i)->type()`
      */
     virtual std::string reactionType(size_t i) const;
@@ -1162,7 +1162,7 @@ public:
      * String specifying the type of reaction.
      *
      * @param i   reaction index
-     * @deprecated  To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     virtual std::string reactionTypeStr(size_t i) const;
 
@@ -1181,18 +1181,18 @@ public:
      * Return a string representing the reaction.
      *
      * @param i   reaction index
-     * @deprecated To be removed after Cantera 3.0. Replace with
+     * @deprecated To be removed after %Cantera 3.0. Replace with
      *     `kin->reaction(i)->equation()`.
      */
     std::string reactionString(size_t i) const;
 
     //! Returns a string containing the reactants side of the reaction equation.
-    //! @deprecated To be removed after Cantera 3.0. Replace with
+    //! @deprecated To be removed after %Cantera 3.0. Replace with
     //!     `kin->reaction(i)->reactantString()`
     std::string reactantString(size_t i) const;
 
     //! Returns a string containing the products side of the reaction equation.
-    //! @deprecated To be removed after Cantera 3.0. Replace with
+    //! @deprecated To be removed after %Cantera 3.0. Replace with
     //!     `kin->reaction(i)->productString()`
     std::string productString(size_t i) const;
 
@@ -1255,12 +1255,12 @@ public:
      *    kinetics manager object as the value.
      *
      * @param thermo    Reference to the ThermoPhase to be added.
-     * @since New in Cantera 3.0. Replaces addPhase.
+     * @since New in %Cantera 3.0. Replaces addPhase.
      */
     virtual void addThermo(shared_ptr<ThermoPhase> thermo);
 
     //! @see Kinetics::addThermo(shared_ptr<ThermoPhase>)
-    //! @deprecated To be removed after Cantera 3.0. Replaced by addThermo
+    //! @deprecated To be removed after %Cantera 3.0. Replaced by addThermo
     //!     pointer.
     virtual void addPhase(ThermoPhase& thermo);
 
@@ -1391,7 +1391,7 @@ public:
      *     reaction mechanism
      * @param phase_data Output array where the values for the the specified
      *     phase are to be written.
-     * @deprecated Unused. To be removed after Cantera 3.0.
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     void selectPhase(const double* data, const ThermoPhase* phase,
                      double* phase_data);
@@ -1409,7 +1409,7 @@ public:
 
     //! Calculate the reaction enthalpy of a reaction which
     //! has not necessarily been added into the Kinetics object
-    //! @deprecated To be removed after Cantera 3.0
+    //! @deprecated To be removed after %Cantera 3.0
     virtual double reactionEnthalpy(const Composition& reactants,
                                     const Composition& products);
 
@@ -1486,7 +1486,7 @@ protected:
     std::vector<ThermoPhase*> m_thermo;
 
     //! vector of shared pointers, @see m_thermo
-    //! @todo replace m_thermo with shared version after Cantera 3.0
+    //! @todo replace m_thermo with shared version after %Cantera 3.0
     vector<shared_ptr<ThermoPhase>> m_sharedThermo;
 
     /**
@@ -1504,7 +1504,7 @@ protected:
     std::map<std::string, size_t> m_phaseindex;
 
     //! Index in the list of phases of the one surface phase.
-    //! @deprecated To be removed after Cantera 3.0.
+    //! @deprecated To be removed after %Cantera 3.0.
     size_t m_surfphase = npos;
 
     //! Phase Index where reactions are assumed to be taking place

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -2,7 +2,7 @@
  * @file Kinetics.h
  *  Base class for kinetics managers and also contains the kineticsmgr
  *  module documentation (see @ref  kineticsmgr and class
- *  \link Cantera::Kinetics Kinetics\endlink).
+ *  @link Cantera::Kinetics Kinetics@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/kinetics/KineticsFactory.h
+++ b/include/cantera/kinetics/KineticsFactory.h
@@ -69,7 +69,7 @@ shared_ptr<Kinetics> newKinetics(const vector<shared_ptr<ThermoPhase>>& phases,
 
 //! @brief Create a new kinetics manager, initialize it, and add reactions.
 //! @see newKinetics(const vector<shared_ptr<ThermoPhase>>&, const AnyMap&, const AnyMap&, shared_ptr<Solution>)
-//! @deprecated  To be removed after Cantera 3.0;
+//! @deprecated To be removed after %Cantera 3.0;
 //!     superseded by newKinetics() returning shared_ptr
 unique_ptr<Kinetics> newKinetics(const std::vector<ThermoPhase*>& phases,
                                  const AnyMap& phaseNode,
@@ -81,13 +81,13 @@ unique_ptr<Kinetics> newKinetics(const std::vector<ThermoPhase*>& phases,
  *     reactions, with the phase where the reactions occur (lowest-dimensional
  *     phase) listed first.
  * @param filename    File containing the phase definition for the phase where
- *     the reactions occur. Searches the Cantera data for this file.
+ *     the reactions occur. Searches the %Cantera data for this file.
  * @param phase_name  The name of the reacting phase in the input file (that is, the
  *     name of the first phase in the `phases` vector)
  * @deprecated The 'phase_name' argument is deprecated and will be removed after
- *     Cantera 3.0.
- * @since  Starting with Cantera 3.0, if the reacting phase is not the first item in the
- *     `phases` vector, a deprecation warning will be issued. In Cantera 3.1, this
+ *     %Cantera 3.0.
+ * @since Starting with %Cantera 3.0, if the reacting phase is not the first item in
+ *     the `phases` vector, a deprecation warning will be issued. In %Cantera 3.1, this
  *     warning will become an error.
  */
 shared_ptr<Kinetics> newKinetics(const vector<shared_ptr<ThermoPhase>>& phases,
@@ -95,7 +95,7 @@ shared_ptr<Kinetics> newKinetics(const vector<shared_ptr<ThermoPhase>>& phases,
                                  const string& phase_name="");
 
 //! @copydoc newKinetics(const vector<shared_ptr<ThermoPhase>>&, const string&, const string&)
-//! @deprecated  To be removed after Cantera 3.0;
+//! @deprecated To be removed after %Cantera 3.0;
 //!     superseded by newKinetics() returning shared_ptr
 unique_ptr<Kinetics> newKinetics(const std::vector<ThermoPhase*>& phases,
                                  const std::string& filename,

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -172,7 +172,7 @@ public:
     //! has a negative pre-exponential factor.
     void validate(const std::string& equation, const Kinetics& kin);
 
-    //! @deprecated  To be removed after Cantera 3.0;
+    //! @deprecated To be removed after %Cantera 3.0;
     //!              superseded by two-parameter version
     void validate(const std::string& equation);
 

--- a/include/cantera/kinetics/Reaction.h
+++ b/include/cantera/kinetics/Reaction.h
@@ -60,7 +60,7 @@ public:
     UnitStack calculateRateCoeffUnits(const Kinetics& kin);
 
     //! Calculate the units of the rate constant.
-    //! @deprecated  To be removed after Cantera 3.0. Replaceable by
+    //! @deprecated To be removed after %Cantera 3.0. Replaceable by
     //!              calculateRateCoeffUnits.
     UnitStack calculateRateCoeffUnits3(const Kinetics& kin) {
         warn_deprecated("Reaction::calculateRateCoeffUnits3",
@@ -70,11 +70,11 @@ public:
     }
 
     //! Ensure that the rate constant and other parameters for this reaction are valid.
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     void check();
 
     //! Ensure that the rate constant and other parameters for this reaction are valid.
-    //! @deprecated  To be removed after Cantera 3.0. Replaceable by check.
+    //! @deprecated To be removed after %Cantera 3.0. Replaceable by check.
     void validate() {
         warn_deprecated("Reaction::validate",
             "Deprecated in Cantera 3.0 and to be removed thereafter; replaceable "
@@ -178,7 +178,7 @@ public:
     }
 
     //! Check whether reaction involves third body collider
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     bool usesThirdBody() const {
         return bool(m_third_body);
     }
@@ -216,30 +216,30 @@ public:
     ThirdBody(const std::string& third_body);
     ThirdBody(const AnyMap& node);
 
-    //! @deprecated  To be removed after Cantera 3.0; instantiate using string instead
+    //! @deprecated To be removed after %Cantera 3.0; instantiate using string instead
     ThirdBody(double default_efficiency);
 
     //! Name of the third body collider
-    //! @since  New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     std::string name() const {
         return m_name;
     }
 
     //! Set name of the third body collider
-    //! @since  New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void setName(const std::string& third_body);
 
     //! Set third-body efficiencies from AnyMap *node*
-    //! @deprecated  To be removed after Cantera 3.0; renamed to setParameters
+    //! @deprecated To be removed after %Cantera 3.0; renamed to setParameters
     void setEfficiencies(const AnyMap& node);
 
     //! Set third-body efficiencies from AnyMap *node*
-    //! @since  New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void setParameters(const AnyMap& node);
 
     //! Get third-body efficiencies from AnyMap *node*
     //! @param node  AnyMap receiving serialized parameters
-    //! @since  New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void getParameters(AnyMap& node) const;
 
     //! Get the third-body efficiency for species *k*
@@ -247,7 +247,7 @@ public:
 
     //! Suffix representing the third body collider in reaction equation, for example
     //! `+ M` or `(+M)`
-    //! @since  New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     std::string collider() const;
 
     //! Verify that all species involved in collision efficiencies are defined in the
@@ -256,7 +256,7 @@ public:
     //! species, in which case false is returned.
     //! @param rxn  Reaction object
     //! @param kin  Kinetics object
-    //! @since  New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     bool checkSpecies(const Reaction& rxn, const Kinetics& kin) const;
 
     //! Map of species to third body efficiency
@@ -280,7 +280,7 @@ protected:
 
 //! A reaction with a non-reacting third body "M" that acts to add or remove
 //! energy from the reacting species
-//! @deprecated  To be removed after Cantera 3.0. Merged with Reaction
+//! @deprecated To be removed after %Cantera 3.0. Merged with Reaction
 class ThreeBodyReaction : public Reaction
 {
 public:
@@ -298,7 +298,7 @@ public:
 //! decreases as pressure increases due to collisional stabilization of a reaction
 //! intermediate; in this case, the forward rate constant is written as being
 //! proportional to the low-pressure rate constant.
-//! @deprecated  To be removed after Cantera 3.0. Merged with Reaction
+//! @deprecated To be removed after %Cantera 3.0. Merged with Reaction
 class FalloffReaction : public Reaction
 {
 public:

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -196,9 +196,9 @@ public:
      *
      *  To generate a postscript reaction path diagram from the output of this
      *  method saved in file paths.dot, for example, give the command:
-     *  \code
+     *  @code
      *  dot -Tps paths.dot > paths.ps
-     *  \endcode
+     *  @endcode
      *  To generate a GIF image, replace -Tps with -Tgif
      */
     void exportToDot(std::ostream& s);

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -115,7 +115,7 @@ public:
     //!
     //! These units are often the same as the units of the rate expression itself, but
     //! not always; sticking coefficients are a notable exception.
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     const Units& conversionUnits() const {
         return m_conversion_units;
     }
@@ -126,7 +126,7 @@ public:
     //! reaction rate expression, which often have the same units (for example, the
     //! Arrhenius pre-exponential) but may also be different (for example, sticking
     //! coefficients).
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     virtual void setRateUnits(const UnitStack& rate_units) {
         if (rate_units.size() > 1) {
             m_conversion_units = rate_units.product();
@@ -139,7 +139,7 @@ public:
     virtual void check(const std::string& equation) {}
 
     //! Check basic syntax and settings of reaction rate expression
-    //! @deprecated  To be removed after Cantera 3.0.
+    //! @deprecated To be removed after %Cantera 3.0.
     //!              Superseded by single-parameter version
     void check(const std::string& equation, const AnyMap& node) {
         warn_deprecated("ReactionRate::check",
@@ -151,7 +151,7 @@ public:
     virtual void validate(const std::string& equation, const Kinetics& kin) {}
 
     //! Validate the reaction rate expression (legacy call)
-    //! @deprecated  To be removed after Cantera 3.0.
+    //! @deprecated To be removed after %Cantera 3.0.
     //!              Superseded by two-parameter version
     virtual void validate(const std::string& equation) {
         warn_deprecated("ReactionRate::validate",
@@ -220,13 +220,13 @@ public:
     }
 
     //! Boolean indicating whether rate has compositional dependence
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     bool compositionDependent() {
         return m_composition_dependent_rate;
     }
 
     //! Set rate compositional dependence
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void setCompositionDependence(bool comp_dep) {
         m_composition_dependent_rate = comp_dep;
     }

--- a/include/cantera/kinetics/ReactionRateDelegator.h
+++ b/include/cantera/kinetics/ReactionRateDelegator.h
@@ -15,7 +15,7 @@ namespace Cantera
 
 //! Delegate methods of the ReactionData class to external functions
 //!
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 class ReactionDataDelegator : public Delegator, public ReactionData
 {
 public:
@@ -63,7 +63,7 @@ protected:
 
 //! Delegate methods of the ReactionRate class to external functions
 //!
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 //! @ingroup otherRateGroup
 class ReactionRateDelegator : public Delegator, public ReactionRate
 {

--- a/include/cantera/kinetics/ReactionRateFactory.h
+++ b/include/cantera/kinetics/ReactionRateFactory.h
@@ -1,7 +1,7 @@
 /**
  *  @file ReactionRateFactory.h
  *  Factory class for reaction rate objects. Used by classes that implement kinetics
- *  (see @ref reactionGroup and class \link Cantera::ReactionRate ReactionRate\endlink).
+ *  (see @ref reactionGroup and class @link Cantera::ReactionRate ReactionRate@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/kinetics/ReactionRateFactory.h
+++ b/include/cantera/kinetics/ReactionRateFactory.h
@@ -1,7 +1,7 @@
 /**
  *  @file ReactionRateFactory.h
  *  Factory class for reaction rate objects. Used by classes that implement kinetics
- *  (see \ref reactionGroup and class \link Cantera::ReactionRate ReactionRate\endlink).
+ *  (see @ref reactionGroup and class \link Cantera::ReactionRate ReactionRate\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/kinetics/solveSP.h
+++ b/include/cantera/kinetics/solveSP.h
@@ -1,6 +1,6 @@
 /**
  * @file solveSP.h Header file for implicit surface problem solver (see @ref
- *       chemkinetics and class \link Cantera::solveSP solveSP\endlink).
+ *       chemkinetics and class @link Cantera::solveSP solveSP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/kinetics/solveSP.h
+++ b/include/cantera/kinetics/solveSP.h
@@ -1,5 +1,5 @@
 /**
- * @file solveSP.h Header file for implicit surface problem solver (see \ref
+ * @file solveSP.h Header file for implicit surface problem solver (see @ref
  *       chemkinetics and class \link Cantera::solveSP solveSP\endlink).
  */
 

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -2,7 +2,7 @@
  *  @file BandMatrix.h
  *   Declarations for the class BandMatrix
  *   which is a child class of GeneralMatrix for banded matrices handled by solvers
- *    (see class @ref numerics and \link Cantera::BandMatrix BandMatrix\endlink).
+ *    (see class @ref numerics and @link Cantera::BandMatrix BandMatrix@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -2,7 +2,7 @@
  *  @file BandMatrix.h
  *   Declarations for the class BandMatrix
  *   which is a child class of GeneralMatrix for banded matrices handled by solvers
- *    (see class \ref numerics and \link Cantera::BandMatrix BandMatrix\endlink).
+ *    (see class @ref numerics and \link Cantera::BandMatrix BandMatrix\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -20,7 +20,7 @@ namespace Cantera
 /**
  * @defgroup numerics  Numerical Utilities
  *
- * @details Cantera contains some capabilities for solving nonlinear equations and
+ * @details %Cantera contains some capabilities for solving nonlinear equations and
  * integrating both ODE and DAE equation systems in time.
  */
 

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -2,7 +2,7 @@
  *  @file DenseMatrix.h
  *  Headers for the DenseMatrix object, which deals with dense rectangular matrices and
  *  description of the numerics groupings of objects
- *  (see \ref numerics and \link Cantera::DenseMatrix DenseMatrix \endlink) .
+ *  (see @ref numerics and \link Cantera::DenseMatrix DenseMatrix \endlink) .
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -2,7 +2,7 @@
  *  @file DenseMatrix.h
  *  Headers for the DenseMatrix object, which deals with dense rectangular matrices and
  *  description of the numerics groupings of objects
- *  (see @ref numerics and \link Cantera::DenseMatrix DenseMatrix \endlink) .
+ *  (see @ref numerics and @link Cantera::DenseMatrix DenseMatrix @endlink) .
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -110,31 +110,31 @@ public:
 
     virtual ~Func1() = default;
 
-    //! @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+    //! @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
     Func1(const Func1& right);
 
-    //! @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+    //! @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
     Func1& operator=(const Func1& right);
 
     //! Duplicate the current function.
     /*!
      * This duplicates the current function, returning a reference to the newly
      * created function.
-     * @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+     * @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
      */
     virtual Func1& duplicate() const;
 
-    //! @deprecated To be removed after Cantera 3.0. Replaced by type.
+    //! @deprecated To be removed after %Cantera 3.0. Replaced by type.
     virtual int ID() const;
 
     //! Returns a string describing the type of the function
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     virtual string type() const {
         return "functor";
     }
 
     //! Returns a string with the class name of the functor
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     string typeName() const;
 
     //! Calls method eval to evaluate the function
@@ -147,7 +147,7 @@ public:
     /*!
      * This will create a new derivative function and return a reference to the
      * function.
-     * @deprecated To be changed after Cantera 3.0; for new behavior, see derivative3.
+     * @deprecated To be changed after %Cantera 3.0; for new behavior, see derivative3.
      */
     virtual Func1& derivative() const;
 
@@ -155,7 +155,7 @@ public:
     /*!
      * This will create a new derivative function
      * @return  shared pointer to new derivative function.
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual shared_ptr<Func1> derivative3() const;
 
@@ -177,7 +177,7 @@ public:
     doublereal c() const;
 
     //! Function to set the stored constant
-    //! @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+    //! @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
     void setC(doublereal c);
 
     //! accessor function for m_f1
@@ -185,17 +185,17 @@ public:
     Func1& func1() const;
 
     //! Accessor function for m_f1_shared
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     shared_ptr<Func1> func1_shared() const {
         return m_f1_shared;
     }
 
     //! accessor function for m_f2
-    //! @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+    //! @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
     Func1& func2() const;
 
     //! Accessor function for m_f2_shared
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     shared_ptr<Func1> func2_shared() const {
         return m_f2_shared;
     }
@@ -203,16 +203,16 @@ public:
     //! Return the order of the function, if it makes sense
     virtual int order() const;
 
-    //! @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+    //! @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
     Func1& func1_dup() const;
 
-    //! @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+    //! @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
     Func1& func2_dup() const;
 
-    //! @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+    //! @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
     Func1* parent() const;
 
-    //! @deprecated To be removed after Cantera 3.0. Only used by deprecated methods.
+    //! @deprecated To be removed after %Cantera 3.0. Only used by deprecated methods.
     void setParent(Func1* p);
 
 protected:
@@ -408,7 +408,7 @@ public:
  * The functor class with type \c "log" returns \f$ f(x) = \log(a x) \f$.
  * @param a  Factor (default=1.0)
  * @ingroup func1simple
- * @since New in Cantera 3.0
+ * @since New in %Cantera 3.0
  */
 class Log1 : public Func1
 {
@@ -506,7 +506,7 @@ public:
     //! @param method  Evaluation method. If \c "linear" (default), a linear
     //!     interpolation between tabulated values is used; if \c "previous", the
     //!     last tabulated value is held until a new tabulated time value is reached.
-    //! @since  New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void setMethod(const string& method);
 
     virtual std::string write(const std::string& arg) const;
@@ -1090,7 +1090,7 @@ public:
  * @param t0 offset
  * @param fwhm full width at half max
  * @ingroup func1advanced
- * @since  New in Cantera 3.0.
+ * @since New in %Cantera 3.0.
  */
 class Gaussian1 : public Func1
 {
@@ -1146,7 +1146,7 @@ protected:
  * @param t0 offset
  * @param fwhm full width at half max
  * @ingroup func1advanced
- * @deprecated  To be removed after Cantera 3.0; replaced by Gaussian1.
+ * @deprecated To be removed after %Cantera 3.0; replaced by Gaussian1.
  */
 class Gaussian : public Gaussian1
 {

--- a/include/cantera/numerics/Func1Factory.h
+++ b/include/cantera/numerics/Func1Factory.h
@@ -111,21 +111,21 @@ private:
 };
 
 
-//! Create a new simple functor object (see \ref func1simple).
+//! Create a new simple functor object (see @ref func1simple).
 //! @param func1Type  String identifying functor type.
 //! @param coeff  Coefficient; definition depends on functor type.
 //! @ingroup func1simple
 //! @since New in %Cantera 3.0
 shared_ptr<Func1> newFunc1(const string& func1Type, double coeff=1.);
 
-//! Create a new advanced functor object (see \ref func1advanced).
+//! Create a new advanced functor object (see @ref func1advanced).
 //! @param func1Type  String identifying functor type.
 //! @param params  Parameter vector; definition depends on functor type.
 //! @ingroup func1advanced
 //! @since New in %Cantera 3.0
 shared_ptr<Func1> newFunc1(const string& func1Type, const vector<double>& params);
 
-//! Create a new compound functor object (see \ref func1compound).
+//! Create a new compound functor object (see @ref func1compound).
 //! @param func1Type  String identifying functor type.
 //! @param f1  First Func1 object.
 //! @param f2  Second Func1 object.
@@ -134,7 +134,7 @@ shared_ptr<Func1> newFunc1(const string& func1Type, const vector<double>& params
 shared_ptr<Func1> newFunc1(const string& func1Type,
                            const shared_ptr<Func1> f1, const shared_ptr<Func1> f2);
 
-//! Create a new modified functor object (see \ref func1modified).
+//! Create a new modified functor object (see @ref func1modified).
 //! @param func1Type  String identifying functor type.
 //! @param f  Func1 object.
 //! @param coeff  Coefficient; definition depends on functor type.

--- a/include/cantera/numerics/Func1Factory.h
+++ b/include/cantera/numerics/Func1Factory.h
@@ -19,7 +19,7 @@ namespace Cantera
 //! ```cpp
 //!     shared_ptr<Func1> d1 = newFunc1("sin", {1.0});
 //! ```
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 class Func1Factory : public Factory<Func1, const vector<double>&>
 {
 public:
@@ -52,7 +52,7 @@ private:
 //! ```cpp
 //!     shared_ptr<Func1> d1 = newFunc1("sum", f1, f2);
 //! ```
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 class Math1FactoryA
     : public Factory<Func1, const shared_ptr<Func1>, const shared_ptr<Func1>>
 {
@@ -86,7 +86,7 @@ private:
 //! ```cpp
 //!     shared_ptr<Func1> d1 = newFunc1("plus-constant", f, 1.);
 //! ```
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 class Math1FactoryB : public Factory<Func1, const shared_ptr<Func1>, double>
 {
 public:
@@ -115,14 +115,14 @@ private:
 //! @param func1Type  String identifying functor type.
 //! @param coeff  Coefficient; definition depends on functor type.
 //! @ingroup func1simple
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 shared_ptr<Func1> newFunc1(const string& func1Type, double coeff=1.);
 
 //! Create a new advanced functor object (see \ref func1advanced).
 //! @param func1Type  String identifying functor type.
 //! @param params  Parameter vector; definition depends on functor type.
 //! @ingroup func1advanced
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 shared_ptr<Func1> newFunc1(const string& func1Type, const vector<double>& params);
 
 //! Create a new compound functor object (see \ref func1compound).
@@ -130,7 +130,7 @@ shared_ptr<Func1> newFunc1(const string& func1Type, const vector<double>& params
 //! @param f1  First Func1 object.
 //! @param f2  Second Func1 object.
 //! @ingroup func1compound
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 shared_ptr<Func1> newFunc1(const string& func1Type,
                            const shared_ptr<Func1> f1, const shared_ptr<Func1> f2);
 
@@ -139,7 +139,7 @@ shared_ptr<Func1> newFunc1(const string& func1Type,
 //! @param f  Func1 object.
 //! @param coeff  Coefficient; definition depends on functor type.
 //! @ingroup func1modified
-//! @since New in Cantera 3.0
+//! @since New in %Cantera 3.0
 shared_ptr<Func1> newFunc1(const string& func1Type,
                            const shared_ptr<Func1> f, double coeff);
 

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -1,7 +1,7 @@
 /**
  *  @file GeneralMatrix.h
  *   Declarations for the class GeneralMatrix which is a virtual base class for matrices handled by solvers
- *    (see class @ref matrices and \link Cantera::GeneralMatrix GeneralMatrix\endlink).
+ *    (see class @ref matrices and @link Cantera::GeneralMatrix GeneralMatrix@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -1,7 +1,7 @@
 /**
  *  @file GeneralMatrix.h
  *   Declarations for the class GeneralMatrix which is a virtual base class for matrices handled by solvers
- *    (see class \ref matrices and \link Cantera::GeneralMatrix GeneralMatrix\endlink).
+ *    (see class @ref matrices and \link Cantera::GeneralMatrix GeneralMatrix\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/numerics/ResidEval.h
+++ b/include/cantera/numerics/ResidEval.h
@@ -32,7 +32,7 @@ const int c_LT_ZERO = -2;
  *             \vec{F}(t,\vec{y}, \vec{y^\prime})
  * \f]
  * The DAE solver attempts to find a solution y(t) such that F = 0.
- * @deprecated Unused. To be removed after Cantera 3.0.
+ * @deprecated Unused. To be removed after %Cantera 3.0.
  *  @ingroup DAE_Group
  */
 class ResidEval

--- a/include/cantera/numerics/ResidJacEval.h
+++ b/include/cantera/numerics/ResidJacEval.h
@@ -46,18 +46,18 @@ enum ResidEval_Type_Enum {
 //! Wrappers for the function evaluators for Nonlinear solvers and Time steppers
 /*!
  * @attention This class currently does not have any test cases or examples. Its
- *     implementation may be incomplete, and future changes to Cantera may
+ *     implementation may be incomplete, and future changes to %Cantera may
  *     unexpectedly cause this class to stop working. If you use this class,
  *     please consider contributing examples or test cases. In the absence of
  *     new tests or examples, this class may be deprecated and removed in a
- *     future version of Cantera. See
+ *     future version of  %Cantera. See
  *     https://github.com/Cantera/cantera/issues/267 for additional information.
  *
  * A class for full (non-sparse dense matrices with Fortran-compatible data
  * storage. The class adds support for identifying what types of calls are made
  * to the residual evaluator by adding the ResidEval_Type_Enum class.
  *
- * @deprecated Unused. To be removed after Cantera 3.0.
+ * @deprecated Unused. To be removed after %Cantera 3.0.
  */
 class ResidJacEval : public ResidEval
 {

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -53,12 +53,12 @@ public:
     Domain1D& operator=(const Domain1D&) = delete;
 
     //! Domain type flag.
-    //! @deprecated  To be changed after Cantera 3.0; for new behavior, see type.
+    //! @deprecated To be changed after %Cantera 3.0; for new behavior, see type.
     int domainType();
 
     //! String indicating the domain implemented.
-    //! @since New in Cantera 3.0.
-    //! @todo Transition back to domainType after Cantera 3.0
+    //! @since New in %Cantera 3.0.
+    //! @todo Transition back to domainType after %Cantera 3.0
     virtual string type() const {
         return "domain";
     }
@@ -74,19 +74,19 @@ public:
     }
 
     //! Set the solution manager.
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     void setSolution(shared_ptr<Solution> sol) {
         m_solution = sol;
     }
 
     //! Set the kinetics manager.
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     virtual void setKinetics(shared_ptr<Kinetics> kin) {
         throw NotImplementedError("Domain1D::setKinetics");
     }
 
     //! Set transport model to existing instance
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     virtual void setTransport(shared_ptr<Transport> trans) {
         throw NotImplementedError("Domain1D::setTransport");
     }
@@ -350,7 +350,7 @@ public:
      * @todo  Despite the method's name, data are copied; the intent is to access data
      *      directly in future revisions, where a non-const version will be implemented.
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const {
         throw NotImplementedError("Domain1D::asArray", "Needs to be overloaded.");
@@ -362,7 +362,7 @@ public:
      * provide direct access to memory.
      * @param normalize If true, normalize concentrations (default=false)
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     shared_ptr<SolutionArray> toArray(bool normalize=false) const;
 
@@ -373,7 +373,7 @@ public:
      * @param[in]  loglevel 0 to suppress all output; 1 to show warnings; 2 for
      *      verbose output
      *
-     * @deprecated  To be removed after Cantera 3.0; restore from SolutionArray instead.
+     * @deprecated To be removed after %Cantera 3.0; restore from SolutionArray instead.
      */
     void restore(const AnyMap& state, double* soln, int loglevel);
 
@@ -382,7 +382,7 @@ public:
      * @param[in]  arr SolutionArray defining the state of this domain
      * @param[out] soln Value of the solution vector, local to this domain
      *
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual void fromArray(SolutionArray& arr, double* soln) {
         throw NotImplementedError("Domain1D::fromArray", "Needs to be overloaded.");
@@ -392,12 +392,12 @@ public:
     /*!
      * This method serves as an external interface for high-level API's.
      * @param  arr SolutionArray defining the state of this domain
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     void fromArray(const shared_ptr<SolutionArray>& arr);
 
     //! Return thermo/kinetics/transport manager used in the domain
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     shared_ptr<Solution> solution() const {
         return m_solution;
     }
@@ -585,7 +585,7 @@ protected:
     vector_fp m_z;
     OneDim* m_container = nullptr;
     size_t m_index;
-    int m_type = 0; //!< @deprecated To be removed after Cantera 3.0
+    int m_type = 0; //!< @deprecated To be removed after %Cantera 3.0
 
     //! Starting location within the solution vector for unknowns that
     //! correspond to this domain

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -31,7 +31,7 @@ public:
     //! Construct a OneDim container for the domains in the list *domains*.
     OneDim(vector<shared_ptr<Domain1D>>& domains);
 
-    //! @deprecated  To be removed after Cantera 3.0;
+    //! @deprecated To be removed after %Cantera 3.0;
     //!     superseded by OneDim() using vector<shared_ptr<Domain1D>>
     OneDim(std::vector<Domain1D*> domains);
     virtual ~OneDim();
@@ -41,7 +41,7 @@ public:
     //! Add a domain. Domains are added left-to-right.
     void addDomain(shared_ptr<Domain1D> d);
 
-    //! @deprecated  To be removed after Cantera 3.0;
+    //! @deprecated To be removed after %Cantera 3.0;
     //!     superseded by addDomain() using shared_ptr<Domain1D>
     void addDomain(Domain1D* d);
 
@@ -234,7 +234,7 @@ public:
      */
     void writeStats(int printTime = 1);
 
-    //! @deprecated  To be removed after Cantera 3.0; unused.
+    //! @deprecated To be removed after %Cantera 3.0; unused.
     AnyMap serialize(const double* soln) const;
 
     // options
@@ -355,9 +355,9 @@ protected:
     vector<shared_ptr<Domain1D>> m_sharedConnect;
     vector<shared_ptr<Domain1D>> m_sharedBulk;
 
-    vector<Domain1D*> m_dom; //!< @todo remove raw pointers after Cantera 3.0
-    vector<Domain1D*> m_connect; //!< @todo remove raw pointers after Cantera 3.0
-    vector<Domain1D*> m_bulk; //!< @todo remove raw pointers after Cantera 3.0
+    vector<Domain1D*> m_dom; //!< @todo remove raw pointers after %Cantera 3.0
+    vector<Domain1D*> m_connect; //!< @todo remove raw pointers after %Cantera 3.0
+    vector<Domain1D*> m_bulk; //!< @todo remove raw pointers after %Cantera 3.0
 
     bool m_init = false;
     std::vector<size_t> m_nvars;

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -37,7 +37,7 @@ public:
      */
     Sim1D(vector<shared_ptr<Domain1D>>& domains);
 
-    //! @deprecated  To be removed after Cantera 3.0;
+    //! @deprecated To be removed after %Cantera 3.0;
     //!     superseded by Sim1D() using shared_ptr
     Sim1D(std::vector<Domain1D*>& domains);
 
@@ -120,13 +120,13 @@ public:
     /**
      * Output information on current solution for all domains to stream.
      * @param s  Output stream
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     void show(std::ostream& s);
 
     /**
      * Show logging information on current solution for all domains.
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     void show();
 
@@ -136,7 +136,7 @@ public:
      * @param id  Identifier of solution within the container file
      * @param desc  Description of the solution
      * @param loglevel  Level of diagnostic output
-     * @deprecated  To be removed after Cantera 3.0; loglevel is deprecated.
+     * @deprecated To be removed after %Cantera 3.0; loglevel is deprecated.
      */
     void save(const std::string& fname, const std::string& id,
               const std::string& desc, int loglevel);
@@ -155,7 +155,7 @@ public:
      * container files using the restore() method, while individual domains can be
      * loaded using SolutionArray::restore() for further analysis. While CSV do not
      * contain complete information, they can still be used for setting initial states
-     * of individual simulation objects for some Cantera API's.
+     * of individual simulation objects for some %Cantera API's.
      *
      * @param fname  Name of output file (CSV, YAML or HDF)
      * @param name  Identifier of storage location within the container file; this
@@ -178,7 +178,7 @@ public:
      * @param id  Identifier of solution within the container file
      * @param desc  Description of the solution
      * @param loglevel  Level of diagnostic output
-     * @deprecated  To be removed after Cantera 3.0; loglevel is deprecated.
+     * @deprecated To be removed after %Cantera 3.0; loglevel is deprecated.
      */
     void saveResidual(const std::string& fname, const std::string& id,
                       const std::string& desc, int loglevel);
@@ -199,7 +199,7 @@ public:
      * @param fname  Name of container file
      * @param id  Identifier of solution within the container file
      * @param loglevel  Level of diagnostic output
-     * @deprecated  To be removed after Cantera 3.0; loglevel is deprecated.
+     * @deprecated To be removed after %Cantera 3.0; loglevel is deprecated.
      * @return  AnyMap containing header information
      */
     AnyMap restore(const std::string& fname, const std::string& id, int loglevel);
@@ -220,7 +220,7 @@ public:
 
     //! @}
 
-    // @deprecated  To be removed after Cantera 3.0 (unused)
+    //! @deprecated To be removed after %Cantera 3.0 (unused)
     const doublereal* solution() {
         warn_deprecated("Sim1D::solution",
             "This method is unused and will be removed after Cantera 3.0.");
@@ -302,14 +302,14 @@ public:
 
     void getInitialSoln();
 
-    // @deprecated  To be removed after Cantera 3.0 (unused)
+    //! @deprecated To be removed after %Cantera 3.0 (unused)
     void setSolution(const doublereal* soln) {
         warn_deprecated("Sim1D::setSolution",
             "This method is unused and will be removed after Cantera 3.0.");
         std::copy(soln, soln + m_state->size(), m_state->data());
     }
 
-    // @deprecated  To be removed after Cantera 3.0 (unused)
+    //! @deprecated To be removed after %Cantera 3.0 (unused)
     const doublereal* solution() const {
         warn_deprecated("Sim1D::solution",
             "This method is unused and will be removed after Cantera 3.0.");

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -87,7 +87,7 @@ public:
     /**
      * Set the thermo manager.
      *
-     * @deprecated  To be removed after Cantera 3.0 (unused)
+     * @deprecated To be removed after %Cantera 3.0 (unused)
      */
     void setThermo(ThermoPhase& th);
 
@@ -106,11 +106,11 @@ public:
     void setTransport(Transport& trans);
 
     //! Set the transport model
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     void setTransportModel(const std::string& trans);
 
     //! Retrieve transport model
-    //! @since  New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     std::string transportModel() const;
 
     //! Enable thermal diffusion, also known as Soret diffusion.
@@ -212,7 +212,7 @@ public:
     void solveEnergyEqn(size_t j=npos);
 
     //! Get the solving stage (used by IonFlow specialization)
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     virtual size_t getSolvingStage() const;
 
     //! Solving stage mode for handling ionized species (used by IonFlow specialization)

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -2,7 +2,7 @@
  * @file BinarySolutionTabulatedThermo.h
  * Header file for an binary solution model with tabulated standard state
  * thermodynamic data (see @ref thermoprops and class
- * \link Cantera::BinarySolutionTabulatedThermo BinarySolutionTabulatedThermo\endlink).
+ * @link Cantera::BinarySolutionTabulatedThermo BinarySolutionTabulatedThermo@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -1,7 +1,7 @@
 /**
  * @file BinarySolutionTabulatedThermo.h
  * Header file for an binary solution model with tabulated standard state
- * thermodynamic data (see \ref thermoprops and class
+ * thermodynamic data (see @ref thermoprops and class
  * \link Cantera::BinarySolutionTabulatedThermo BinarySolutionTabulatedThermo\endlink).
  */
 

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -1,8 +1,8 @@
 /**
  *  @file ConstCpPoly.h
- * Headers for the \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink
+ * Headers for the @link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType@endlink
  * object that employs a constant heat capacity assumption (see @ref spthermo and
- * \link Cantera::ConstCpPoly ConstCpPoly\endlink).
+ * @link Cantera::ConstCpPoly ConstCpPoly@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -1,7 +1,7 @@
 /**
  *  @file ConstCpPoly.h
  * Headers for the \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink
- * object that employs a constant heat capacity assumption (see \ref spthermo and
+ * object that employs a constant heat capacity assumption (see @ref spthermo and
  * \link Cantera::ConstCpPoly ConstCpPoly\endlink).
  */
 

--- a/include/cantera/thermo/CoverageDependentSurfPhase.h
+++ b/include/cantera/thermo/CoverageDependentSurfPhase.h
@@ -3,7 +3,7 @@
  *  Header for a thermodynamics model of a coverage-dependent surface
  *  phase derived from SurfPhase, applying adsorbate lateral interaction
  *  correction factors to the SurfPhase thermodynamic properties.
- *  (see \ref thermoprops and class
+ *  (see @ref thermoprops and class
  *  \link Cantera::CoverageDependentSurfPhase CoverageDependentSurfPhase\endlink).
  */
 

--- a/include/cantera/thermo/CoverageDependentSurfPhase.h
+++ b/include/cantera/thermo/CoverageDependentSurfPhase.h
@@ -4,7 +4,7 @@
  *  phase derived from SurfPhase, applying adsorbate lateral interaction
  *  correction factors to the SurfPhase thermodynamic properties.
  *  (see @ref thermoprops and class
- *  \link Cantera::CoverageDependentSurfPhase CoverageDependentSurfPhase\endlink).
+ *  @link Cantera::CoverageDependentSurfPhase CoverageDependentSurfPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -2,7 +2,7 @@
  *  @file DebyeHuckel.h
  *    Headers for the DebyeHuckel ThermoPhase object, which models dilute
  *    electrolyte solutions
- *    (see \ref thermoprops and \link Cantera::DebyeHuckel DebyeHuckel \endlink) .
+ *    (see @ref thermoprops and \link Cantera::DebyeHuckel DebyeHuckel \endlink) .
  *
  * Class DebyeHuckel represents a dilute liquid electrolyte phase which
  * obeys the Debye Huckel formulation for nonideality.

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -2,7 +2,7 @@
  *  @file DebyeHuckel.h
  *    Headers for the DebyeHuckel ThermoPhase object, which models dilute
  *    electrolyte solutions
- *    (see @ref thermoprops and \link Cantera::DebyeHuckel DebyeHuckel \endlink) .
+ *    (see @ref thermoprops and @link Cantera::DebyeHuckel DebyeHuckel @endlink) .
  *
  * Class DebyeHuckel represents a dilute liquid electrolyte phase which
  * obeys the Debye Huckel formulation for nonideality.

--- a/include/cantera/thermo/EdgePhase.h
+++ b/include/cantera/thermo/EdgePhase.h
@@ -1,6 +1,6 @@
 /**
  *  @file EdgePhase.h Declarations for the EdgePhase ThermoPhase object, which
- *       models the interface between two surfaces (see \ref thermoprops and
+ *       models the interface between two surfaces (see @ref thermoprops and
  *       \link Cantera::EdgePhase EdgePhase\endlink).
  */
 

--- a/include/cantera/thermo/EdgePhase.h
+++ b/include/cantera/thermo/EdgePhase.h
@@ -1,7 +1,7 @@
 /**
  *  @file EdgePhase.h Declarations for the EdgePhase ThermoPhase object, which
  *       models the interface between two surfaces (see @ref thermoprops and
- *       \link Cantera::EdgePhase EdgePhase\endlink).
+ *       @link Cantera::EdgePhase EdgePhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/Elements.h
+++ b/include/cantera/thermo/Elements.h
@@ -18,7 +18,7 @@ namespace Cantera
 //! @name Types of Element Constraint Equations
 //!
 //! There may be several different types of element constraints handled by the
-//! equilibrium program and by Cantera in other contexts. These defines are used
+//! equilibrium program and by %Cantera in other contexts. These defines are used
 //! to assign each constraint to one category.
 //! @{
 
@@ -104,7 +104,7 @@ const std::map<std::string, double>& elementWeights();
 
 //! Get the atomic weight of an element.
 /*!
- * Get the atomic weight of an element defined in Cantera by its symbol
+ * Get the atomic weight of an element defined in %Cantera by its symbol
  * or by its name. This includes the named isotopes defined in Cantera.
  *
  * @param ename String, name or symbol of the element
@@ -116,7 +116,7 @@ double getElementWeight(const std::string& ename);
 
 //! Get the atomic weight of an element.
 /*!
- * Get the atomic weight of an element defined in Cantera by its atomic
+ * Get the atomic weight of an element defined in %Cantera by its atomic
  * number. The named isotopes cannot be accessed from this function,
  * since the atomic number of the isotopes is the same as the regular
  * element from which they are derived.
@@ -132,7 +132,7 @@ double getElementWeight(int atomicNumber);
 
 //! Get the symbol for an element
 /*!
- * Get the symbol for an element defined in Cantera by its name. This
+ * Get the symbol for an element defined in %Cantera by its name. This
  * includes the named isotopes defined in Cantera.
  *
  * @param ename String, name of the element
@@ -143,7 +143,7 @@ std::string getElementSymbol(const std::string& ename);
 
 //! Get the symbol for an element
 /*!
- * Get the symbol for an element defined in Cantera by its atomic
+ * Get the symbol for an element defined in %Cantera by its atomic
  * number. The named isotopes cannot be accessed from this function,
  * since the atomic number of the isotopes is the same as the regular
  * element from which they are derived.
@@ -157,7 +157,7 @@ std::string getElementSymbol(int atomicNumber);
 
 //! Get the name of an element
 /*!
- * Get the name of an element defined in Cantera by its symbol. This
+ * Get the name of an element defined in %Cantera by its symbol. This
  * includes the named isotopes defined in Cantera.
  *
  * @param ename String, symbol for the element
@@ -168,7 +168,7 @@ std::string getElementName(const std::string& ename);
 
 //! Get the name of an element
 /*!
- * Get the name of an element defined in Cantera by its atomic
+ * Get the name of an element defined in %Cantera by its atomic
  * number. The named isotopes cannot be accessed from this function,
  * since the atomic number of the isotopes is the same as the regular
  * element from which they are derived.
@@ -182,7 +182,7 @@ std::string getElementName(int atomicNumber);
 
 //! Get the atomic number for an element
 /*!
- * Get the atomic number of an element defined in Cantera by its symbol
+ * Get the atomic number of an element defined in %Cantera by its symbol
  * or name. This includes the named isotopes included in Cantera.
  *
  *  @param ename String, name or symbol of the element
@@ -193,12 +193,12 @@ int getAtomicNumber(const std::string& ename);
 
 //! Get the number of named elements defined in Cantera.
 //! This array excludes named isotopes
-//! @since Type is `size_t` in Cantera 3.0
+//! @since Type is `size_t` in %Cantera 3.0
 size_t numElementsDefined();
 
 //! Get the number of named isotopes defined in Cantera.
 //! This array excludes the named elements
-//! @since Type is `size_t` in Cantera 3.0
+//! @since Type is `size_t` in %Cantera 3.0
 size_t numIsotopesDefined();
 
 } // namespace

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -3,7 +3,7 @@
  *   Header for intermediate ThermoPhase object for phases which
  *   employ Gibbs excess free energy based formulations
  *  (see @ref thermoprops
- * and class \link Cantera::GibbsExcessVPSSTP GibbsExcessVPSSTP\endlink).
+ * and class @link Cantera::GibbsExcessVPSSTP GibbsExcessVPSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -2,7 +2,7 @@
  *  @file GibbsExcessVPSSTP.h
  *   Header for intermediate ThermoPhase object for phases which
  *   employ Gibbs excess free energy based formulations
- *  (see \ref thermoprops
+ *  (see @ref thermoprops
  * and class \link Cantera::GibbsExcessVPSSTP GibbsExcessVPSSTP\endlink).
  */
 

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -217,7 +217,7 @@ public:
      *                Length = m_kk. units are m^3/kmol.
      */
     virtual void getPartialMolarVolumes(doublereal* vbar) const;
-    //! @deprecated Unused. To be removed after Cantera 3.0.
+    //! @deprecated Unused. To be removed after %Cantera 3.0.
     virtual const vector_fp& getPartialMolarVolumesVector() const;
     //! @}
 
@@ -229,7 +229,7 @@ protected:
     //! utility routine to check mole fraction sum
     /*!
      * @param x   vector of mole fractions.
-     * @deprecated Unused. To be removed after Cantera 3.0.
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     double checkMFSum(const doublereal* const x) const;
 

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -2,7 +2,7 @@
  *  @file HMWSoln.h
  *    Headers for the HMWSoln ThermoPhase object, which models concentrated
  *    electrolyte solutions
- *    (see \ref thermoprops and \link Cantera::HMWSoln HMWSoln \endlink) .
+ *    (see @ref thermoprops and \link Cantera::HMWSoln HMWSoln \endlink) .
  *
  * Class HMWSoln represents a concentrated liquid electrolyte phase which
  * obeys the Pitzer formulation for nonideality using molality-based
@@ -226,7 +226,7 @@ class WaterProps;
  *     I = \frac{1}{2} \sum_k{m_k  z_k^2}
  * \f]
  *
- * In contrast to several other Debye-Huckel implementations (see \ref
+ * In contrast to several other Debye-Huckel implementations (see @ref
  * DebyeHuckel), the parameter \f$ b\f$ in the above equation is a constant that
  * does not vary with respect to ion identity. This is an important
  * simplification as it avoids troubles with satisfaction of the Gibbs-Duhem

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -2,7 +2,7 @@
  *  @file HMWSoln.h
  *    Headers for the HMWSoln ThermoPhase object, which models concentrated
  *    electrolyte solutions
- *    (see @ref thermoprops and \link Cantera::HMWSoln HMWSoln \endlink) .
+ *    (see @ref thermoprops and @link Cantera::HMWSoln HMWSoln @endlink) .
  *
  * Class HMWSoln represents a concentrated liquid electrolyte phase which
  * obeys the Pitzer formulation for nonideality using molality-based

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -1,7 +1,7 @@
 /**
  *  @file IdealGasPhase.h
  *   ThermoPhase object for the ideal gas equation of
- * state - workhorse for %Cantera (see \ref thermoprops
+ * state - workhorse for %Cantera (see @ref thermoprops
  * and class \link Cantera::IdealGasPhase IdealGasPhase\endlink).
  */
 
@@ -97,7 +97,7 @@ namespace Cantera
  * \f]
  *
  * where R is the molar gas constant. For a complete list of physical constants
- * used within %Cantera, see \ref physConstants .
+ * used within %Cantera, see @ref physConstants .
  *
  * ## Specification of Solution Thermodynamic Properties
  *

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -2,7 +2,7 @@
  *  @file IdealGasPhase.h
  *   ThermoPhase object for the ideal gas equation of
  * state - workhorse for %Cantera (see @ref thermoprops
- * and class \link Cantera::IdealGasPhase IdealGasPhase\endlink).
+ * and class @link Cantera::IdealGasPhase IdealGasPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
@@ -33,8 +33,8 @@ namespace Cantera
  *
  * It is assumed that the reference state thermodynamics may be obtained by a
  * pointer to a populated species thermodynamic property manager class in the
- * base class, ThermoPhase::m_spthermo (see the base class \link
- * Cantera::MultiSpeciesThermo MultiSpeciesThermo \endlink for a description of
+ * base class, ThermoPhase::m_spthermo (see the base class @link
+ * Cantera::MultiSpeciesThermo MultiSpeciesThermo @endlink for a description of
  * the specification of reference state species thermodynamics functions). The
  * reference state, where the pressure is fixed at a single pressure, is a key
  * species property calculation for the Ideal Gas Equation of state.

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -365,7 +365,7 @@ public:
      *
      * @param rho Density (kg/m^3)
      * @param p Pressure (Pa)
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual void setState_DP(doublereal rho, doublereal p)
     {

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -2,7 +2,7 @@
  *  @file IdealMolalSoln.h
  *   ThermoPhase object for the ideal molal equation of
  * state (see @ref thermoprops
- * and class \link Cantera::IdealMolalSoln IdealMolalSoln\endlink).
+ * and class @link Cantera::IdealMolalSoln IdealMolalSoln@endlink).
  *
  * Header file for a derived class of ThermoPhase that handles variable pressure
  * standard state methods for calculating thermodynamic properties that are

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -1,7 +1,7 @@
 /**
  *  @file IdealMolalSoln.h
  *   ThermoPhase object for the ideal molal equation of
- * state (see \ref thermoprops
+ * state (see @ref thermoprops
  * and class \link Cantera::IdealMolalSoln IdealMolalSoln\endlink).
  *
  * Header file for a derived class of ThermoPhase that handles variable pressure

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -1,7 +1,7 @@
 /**
  * @file IdealSolidSolnPhase.h Header file for an ideal solid solution model
  *      with incompressible thermodynamics (see @ref thermoprops and
- *      \link Cantera::IdealSolidSolnPhase IdealSolidSolnPhase\endlink).
+ *      @link Cantera::IdealSolidSolnPhase IdealSolidSolnPhase@endlink).
  *
  * This class inherits from the %Cantera class ThermoPhase and implements an
  * ideal solid solution model with incompressible thermodynamics.

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -1,6 +1,6 @@
 /**
  * @file IdealSolidSolnPhase.h Header file for an ideal solid solution model
- *      with incompressible thermodynamics (see \ref thermoprops and
+ *      with incompressible thermodynamics (see @ref thermoprops and
  *      \link Cantera::IdealSolidSolnPhase IdealSolidSolnPhase\endlink).
  *
  * This class inherits from the %Cantera class ThermoPhase and implements an

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -3,7 +3,7 @@
  *      with incompressible thermodynamics (see \ref thermoprops and
  *      \link Cantera::IdealSolidSolnPhase IdealSolidSolnPhase\endlink).
  *
- * This class inherits from the Cantera class ThermoPhase and implements an
+ * This class inherits from the %Cantera class ThermoPhase and implements an
  * ideal solid solution model with incompressible thermodynamics.
  */
 
@@ -306,7 +306,7 @@ public:
      *
      * @param mu   Output vector of dimensionless chemical potentials.
      *             Length = m_kk.
-     * @deprecated To be removed after Cantera 3.0. Use getChemPotentials() instead.
+     * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
     virtual void getChemPotentials_RT(doublereal* mu) const;
 

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -3,7 +3,7 @@
  * Definition file for a derived class of ThermoPhase that assumes
  * an ideal solution approximation and handles
  * variable pressure standard state methods for calculating
- * thermodynamic properties (see \ref thermoprops and
+ * thermodynamic properties (see @ref thermoprops and
  * class \link Cantera::IdealSolnGasVPSS IdealSolnGasVPSS\endlink).
  */
 

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -4,7 +4,7 @@
  * an ideal solution approximation and handles
  * variable pressure standard state methods for calculating
  * thermodynamic properties (see @ref thermoprops and
- * class \link Cantera::IdealSolnGasVPSS IdealSolnGasVPSS\endlink).
+ * class @link Cantera::IdealSolnGasVPSS IdealSolnGasVPSS@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -1,7 +1,7 @@
 /**
  *  @file IonsFromNeutralVPSSTP.h Header for intermediate ThermoPhase object for
  *   phases which consist of ions whose thermodynamics is calculated from
- *   neutral molecule thermodynamics. (see \ref thermoprops and class \link
+ *   neutral molecule thermodynamics. (see @ref thermoprops and class \link
  *   Cantera::IonsFromNeutralVPSSTP IonsFromNeutralVPSSTP\endlink).
  */
 

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -1,8 +1,8 @@
 /**
  *  @file IonsFromNeutralVPSSTP.h Header for intermediate ThermoPhase object for
  *   phases which consist of ions whose thermodynamics is calculated from
- *   neutral molecule thermodynamics. (see @ref thermoprops and class \link
- *   Cantera::IonsFromNeutralVPSSTP IonsFromNeutralVPSSTP\endlink).
+ *   neutral molecule thermodynamics. (see @ref thermoprops and class @link
+ *   Cantera::IonsFromNeutralVPSSTP IonsFromNeutralVPSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -40,11 +40,11 @@ enum IonSolnType_enumType {
  * this area employ symmetrical formulations.
  *
  * @attention This class currently does not have any test cases or examples. Its
- *     implementation may be incomplete, and future changes to Cantera may
+ *     implementation may be incomplete, and future changes to %Cantera may
  *     unexpectedly cause this class to stop working. If you use this class,
  *     please consider contributing examples or test cases. In the absence of
  *     new tests or examples, this class may be deprecated and removed in a
- *     future version of Cantera. See
+ *     future version of  %Cantera. See
  *     https://github.com/Cantera/cantera/issues/267 for additional information.
  *
  * This class is used for molten salts.
@@ -64,7 +64,7 @@ enum IonSolnType_enumType {
  *  This object can translate between any of the four mole fraction
  *  representations.
  *
- *  @deprecated To be removed after Cantera 3.0.
+ *  @deprecated To be removed after %Cantera 3.0.
  */
 class IonsFromNeutralVPSSTP : public GibbsExcessVPSSTP
 {

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -1,7 +1,7 @@
 /**
  *  @file LatticePhase.h Header for a simple thermodynamics model of a bulk
  *      phase derived from ThermoPhase, assuming a lattice of solid atoms (see
- *      \ref thermoprops and class \link Cantera::LatticePhase
+ *      @ref thermoprops and class \link Cantera::LatticePhase
  *      LatticePhase\endlink).
  */
 

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -1,8 +1,8 @@
 /**
  *  @file LatticePhase.h Header for a simple thermodynamics model of a bulk
  *      phase derived from ThermoPhase, assuming a lattice of solid atoms (see
- *      @ref thermoprops and class \link Cantera::LatticePhase
- *      LatticePhase\endlink).
+ *      @ref thermoprops and class @link Cantera::LatticePhase
+ *      LatticePhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -1,7 +1,7 @@
 /**
  *  @file LatticeSolidPhase.h Header for a simple thermodynamics model of a bulk
  *      solid phase derived from ThermoPhase, assuming an ideal solution model
- *      based on a lattice of solid atoms (see \ref thermoprops and class \link
+ *      based on a lattice of solid atoms (see @ref thermoprops and class \link
  *      Cantera::LatticeSolidPhase LatticeSolidPhase\endlink).
  */
 

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -1,8 +1,8 @@
 /**
  *  @file LatticeSolidPhase.h Header for a simple thermodynamics model of a bulk
  *      solid phase derived from ThermoPhase, assuming an ideal solution model
- *      based on a lattice of solid atoms (see @ref thermoprops and class \link
- *      Cantera::LatticeSolidPhase LatticeSolidPhase\endlink).
+ *      based on a lattice of solid atoms (see @ref thermoprops and class @link
+ *      Cantera::LatticeSolidPhase LatticeSolidPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -1,5 +1,5 @@
 /**
- *  @file  MargulesVPSSTP.h (see \ref thermoprops and class \link
+ *  @file  MargulesVPSSTP.h (see @ref thermoprops and class \link
  *      Cantera::MargulesVPSSTP MargulesVPSSTP\endlink).
  */
 

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -1,6 +1,6 @@
 /**
- *  @file  MargulesVPSSTP.h (see @ref thermoprops and class \link
- *      Cantera::MargulesVPSSTP MargulesVPSSTP\endlink).
+ *  @file  MargulesVPSSTP.h (see @ref thermoprops and class @link
+ *      Cantera::MargulesVPSSTP MargulesVPSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/MaskellSolidSolnPhase.h
+++ b/include/cantera/thermo/MaskellSolidSolnPhase.h
@@ -2,7 +2,7 @@
  * @file MaskellSolidSolnPhase.h Header file for a solid solution model
  * following Maskell, Shaw, and Tye. Electrochimica Acta 1982
  *
- * This class inherits from the Cantera class ThermoPhase and implements a
+ * This class inherits from the %Cantera class ThermoPhase and implements a
  * non-ideal solid solution model with incompressible thermodynamics.
  */
 
@@ -24,7 +24,7 @@ namespace Cantera
  *
  * @ingroup thermoprops
  *
- * @deprecated To be removed after Cantera 3.0. This class has numerous thermodynamic
+ * @deprecated To be removed after %Cantera 3.0. This class has numerous thermodynamic
  *    inconsistencies. See https://github.com/Cantera/cantera/issues/1321.
  */
 class MaskellSolidSolnPhase : public VPStandardStateTP
@@ -83,7 +83,7 @@ public:
 
     virtual void getActivityCoefficients(doublereal* ac) const;
     virtual void getChemPotentials(doublereal* mu) const;
-    //! @deprecated To be removed after Cantera 3.0. Use getChemPotentials() instead.
+    //! @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
     virtual void getChemPotentials_RT(doublereal* mu) const;
 
     //! @}

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -2,7 +2,7 @@
  *  @file MixtureFugacityTP.h
  *    Header file for a derived class of ThermoPhase that handles
  *    non-ideal mixtures based on the fugacity models (see @ref thermoprops and
- *    class \link Cantera::MixtureFugacityTP MixtureFugacityTP\endlink).
+ *    class @link Cantera::MixtureFugacityTP MixtureFugacityTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -1,7 +1,7 @@
 /**
  *  @file MixtureFugacityTP.h
  *    Header file for a derived class of ThermoPhase that handles
- *    non-ideal mixtures based on the fugacity models (see \ref thermoprops and
+ *    non-ideal mixtures based on the fugacity models (see @ref thermoprops and
  *    class \link Cantera::MixtureFugacityTP MixtureFugacityTP\endlink).
  */
 

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -44,11 +44,11 @@ namespace Cantera
  * Kwong class.
  *
  * @attention This class currently does not have any test cases or examples. Its
- *     implementation may be incomplete, and future changes to Cantera may
+ *     implementation may be incomplete, and future changes to %Cantera may
  *     unexpectedly cause this class to stop working. If you use this class,
  *     please consider contributing examples or test cases. In the absence of
  *     new tests or examples, this class may be deprecated and removed in a
- *     future version of Cantera. See
+ *     future version of  %Cantera. See
  *     https://github.com/Cantera/cantera/issues/267 for additional information.
  *
  * Several concepts are introduced. The first concept is there are temporary
@@ -136,7 +136,7 @@ public:
      *
      * @param mu    Output vector of non-dimensional species chemical potentials
      *              Length: m_kk.
-     * @deprecated To be removed after Cantera 3.0. Use getChemPotentials() instead.
+     * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
     virtual void getChemPotentials_RT(doublereal* mu) const;
 

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -3,7 +3,7 @@
  *   Header for intermediate ThermoPhase object for phases which
  *   employ molality based activity coefficient formulations
  *  (see @ref thermoprops
- * and class \link Cantera::MolalityVPSSTP MolalityVPSSTP\endlink).
+ * and class @link Cantera::MolalityVPSSTP MolalityVPSSTP@endlink).
  *
  * Header file for a derived class of ThermoPhase that handles
  * variable pressure standard state methods for calculating

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -2,7 +2,7 @@
  *  @file MolalityVPSSTP.h
  *   Header for intermediate ThermoPhase object for phases which
  *   employ molality based activity coefficient formulations
- *  (see \ref thermoprops
+ *  (see @ref thermoprops
  * and class \link Cantera::MolalityVPSSTP MolalityVPSSTP\endlink).
  *
  * Header file for a derived class of ThermoPhase that handles

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -1,9 +1,9 @@
 /**
  *  @file Mu0Poly.h
  *  Header for a single-species standard state object derived
- *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
+ *  from @link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType@endlink  based
  *  on a piecewise constant mu0 interpolation
- *  (see @ref spthermo and class \link Cantera::Mu0Poly Mu0Poly\endlink).
+ *  (see @ref spthermo and class @link Cantera::Mu0Poly Mu0Poly@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -3,7 +3,7 @@
  *  Header for a single-species standard state object derived
  *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
  *  on a piecewise constant mu0 interpolation
- *  (see \ref spthermo and class \link Cantera::Mu0Poly Mu0Poly\endlink).
+ *  (see @ref spthermo and class \link Cantera::Mu0Poly Mu0Poly\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -1,7 +1,7 @@
 /**
  * @file MultiSpeciesThermo.h
  *  Header for a general species thermodynamic property manager for a phase (see
- * \link Cantera::MultiSpeciesThermo MultiSpeciesThermo\endlink).
+ * @link Cantera::MultiSpeciesThermo MultiSpeciesThermo@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
@@ -38,7 +38,7 @@ namespace Cantera
  * MultiSpeciesThermo object. However, there is no requirement that a
  * MultiSpeciesThermo object handles all of the species in a phase. The member
  * function
- * \link MultiSpeciesThermo::install_STIT() install_STIT()\endlink
+ * @link MultiSpeciesThermo::install_STIT() install_STIT()@endlink
  * is called to install each species into the MultiSpeciesThermo object.
  *
  * @ingroup spthermo

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -127,7 +127,7 @@ public:
      *
      * @param k Species Index
      * @deprecated The species index parameter is deprecated and will be removed after
-     *     Cantera 3.0. All species in a phase must have the same reference pressure.
+     *     %Cantera 3.0. All species in a phase must have the same reference pressure.
      */
     virtual doublereal refPressure(size_t k=npos) const;
 

--- a/include/cantera/thermo/Nasa9Poly1.h
+++ b/include/cantera/thermo/Nasa9Poly1.h
@@ -1,9 +1,9 @@
 /**
  * @file Nasa9Poly1.h Header for a single-species standard state object derived
- *     from \link Cantera::SpeciesThermoInterpType
- *     SpeciesThermoInterpType\endlink based on the NASA 9 coefficient
+ *     from @link Cantera::SpeciesThermoInterpType
+ *     SpeciesThermoInterpType@endlink based on the NASA 9 coefficient
  *     temperature polynomial form applied to one temperature region (see @ref
- *     spthermo and class \link Cantera::Nasa9Poly1 Nasa9Poly1\endlink).
+ *     spthermo and class @link Cantera::Nasa9Poly1 Nasa9Poly1@endlink).
  *
  * This parameterization has one NASA temperature region.
  */

--- a/include/cantera/thermo/Nasa9Poly1.h
+++ b/include/cantera/thermo/Nasa9Poly1.h
@@ -2,7 +2,7 @@
  * @file Nasa9Poly1.h Header for a single-species standard state object derived
  *     from \link Cantera::SpeciesThermoInterpType
  *     SpeciesThermoInterpType\endlink based on the NASA 9 coefficient
- *     temperature polynomial form applied to one temperature region (see \ref
+ *     temperature polynomial form applied to one temperature region (see @ref
  *     spthermo and class \link Cantera::Nasa9Poly1 Nasa9Poly1\endlink).
  *
  * This parameterization has one NASA temperature region.

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -1,11 +1,11 @@
 /**
  *  @file Nasa9PolyMultiTempRegion.h
  *  Header for a single-species standard state object derived
- *  from \link Cantera::SpeciesThermoInterpType
- *  SpeciesThermoInterpType\endlink  based
+ *  from @link Cantera::SpeciesThermoInterpType
+ *  SpeciesThermoInterpType@endlink  based
  *  on the NASA 9 coefficient temperature polynomial form
  *   applied to multiple temperature regions
- *  (see @ref spthermo and class \link Cantera::Nasa9PolyMultiTempRegion Nasa9PolyMultiTempRegion\endlink).
+ *  (see @ref spthermo and class @link Cantera::Nasa9PolyMultiTempRegion Nasa9PolyMultiTempRegion@endlink).
  *
  *  This parameterization has multiple NASA temperature regions.
  */

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -5,7 +5,7 @@
  *  SpeciesThermoInterpType\endlink  based
  *  on the NASA 9 coefficient temperature polynomial form
  *   applied to multiple temperature regions
- *  (see \ref spthermo and class \link Cantera::Nasa9PolyMultiTempRegion Nasa9PolyMultiTempRegion\endlink).
+ *  (see @ref spthermo and class \link Cantera::Nasa9PolyMultiTempRegion Nasa9PolyMultiTempRegion\endlink).
  *
  *  This parameterization has multiple NASA temperature regions.
  */

--- a/include/cantera/thermo/NasaPoly1.h
+++ b/include/cantera/thermo/NasaPoly1.h
@@ -3,7 +3,7 @@
  *  Header for a single-species standard state object derived
  *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
  *  on the NASA temperature polynomial form applied to one temperature region
- *  (see \ref spthermo and class \link Cantera::NasaPoly1 NasaPoly1\endlink).
+ *  (see @ref spthermo and class \link Cantera::NasaPoly1 NasaPoly1\endlink).
  *
  *  This parameterization has one NASA temperature region.
  */

--- a/include/cantera/thermo/NasaPoly1.h
+++ b/include/cantera/thermo/NasaPoly1.h
@@ -1,9 +1,9 @@
 /**
  *  @file NasaPoly1.h
  *  Header for a single-species standard state object derived
- *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
+ *  from @link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType@endlink  based
  *  on the NASA temperature polynomial form applied to one temperature region
- *  (see @ref spthermo and class \link Cantera::NasaPoly1 NasaPoly1\endlink).
+ *  (see @ref spthermo and class @link Cantera::NasaPoly1 NasaPoly1@endlink).
  *
  *  This parameterization has one NASA temperature region.
  */

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -3,7 +3,7 @@
  *  Header for a single-species standard state object derived
  *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
  *  on the NASA temperature polynomial form applied to two temperature regions
- *  (see \ref spthermo and class \link Cantera::NasaPoly2 NasaPoly2\endlink).
+ *  (see @ref spthermo and class \link Cantera::NasaPoly2 NasaPoly2\endlink).
  *
  *  Two zoned NASA polynomial parameterization
  */

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -1,9 +1,9 @@
 /**
  *  @file NasaPoly2.h
  *  Header for a single-species standard state object derived
- *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
+ *  from @link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType@endlink  based
  *  on the NASA temperature polynomial form applied to two temperature regions
- *  (see @ref spthermo and class \link Cantera::NasaPoly2 NasaPoly2\endlink).
+ *  (see @ref spthermo and class @link Cantera::NasaPoly2 NasaPoly2@endlink).
  *
  *  Two zoned NASA polynomial parameterization
  */

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -2,7 +2,7 @@
  *  @file PDSS.h
  *    Declarations for the virtual base class PDSS (pressure dependent standard state)
  *    which handles calculations for a single species in a phase
- *    (see @ref pdssthermo and class \link Cantera::PDSS PDSS\endlink).
+ *    (see @ref pdssthermo and class @link Cantera::PDSS PDSS@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -67,7 +67,7 @@ namespace Cantera
  *     handle the calculation of the reference state. This object adds the
  *     pressure dependencies to the thermo functions.
  *
- * - PDSS_ConstVol (deprecated in Cantera 3.0)
+ * - PDSS_ConstVol (deprecated in %Cantera 3.0)
  *    - standardState model = "ConstVol" or "constant_incompressible"
  *    - This model assumes that the species in the phase obeys the constant
  *      partial molar volume pressure dependence. The manager uses a
@@ -247,22 +247,22 @@ public:
 
     //! Get the difference in the standard state enthalpy
     //! between the current pressure and the reference pressure, p0.
-    //! @deprecated To be removed after Cantera 3.0
+    //! @deprecated To be removed after %Cantera 3.0
     virtual doublereal enthalpyDelp_mole() const;
 
     //! Get the difference in the standard state entropy between
     //! the current pressure and the reference pressure, p0
-    //! @deprecated To be removed after Cantera 3.0
+    //! @deprecated To be removed after %Cantera 3.0
     virtual doublereal entropyDelp_mole() const;
 
     //! Get the difference in the standard state Gibbs free energy
     //! between the current pressure and the reference pressure, p0.
-    //! @deprecated To be removed after Cantera 3.0
+    //! @deprecated To be removed after %Cantera 3.0
     virtual doublereal gibbsDelp_mole() const;
 
     //! Get the difference in standard state heat capacity
     //! between the current pressure and the reference pressure, p0.
-    //! @deprecated To be removed after Cantera 3.0
+    //! @deprecated To be removed after %Cantera 3.0
     virtual doublereal cpDelp_mole() const;
 
     //! @}
@@ -364,7 +364,7 @@ public:
     /*!
      * @param  temp     Temperature (Kelvin)
      * @param  rho      Density (kg m-3)
-     * @deprecated  To be removed after Cantera 3.0
+     * @deprecated To be removed after %Cantera 3.0
      */
     virtual void setState_TR(doublereal temp, doublereal rho);
 
@@ -436,7 +436,7 @@ public:
      * @param minTemp   output - Minimum temperature
      * @param maxTemp   output - Maximum temperature
      * @param refPressure output - reference pressure (Pa).
-     * @deprecated To be removed after Cantera 3.0. Use getParameters() instead.
+     * @deprecated To be removed after %Cantera 3.0. Use getParameters() instead.
      */
     virtual void reportParams(size_t& kindex, int& type, doublereal* const c,
                               doublereal& minTemp, doublereal& maxTemp,

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -2,7 +2,7 @@
  *  @file PDSS.h
  *    Declarations for the virtual base class PDSS (pressure dependent standard state)
  *    which handles calculations for a single species in a phase
- *    (see \ref pdssthermo and class \link Cantera::PDSS PDSS\endlink).
+ *    (see @ref pdssthermo and class \link Cantera::PDSS PDSS\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_ConstVol.h
+++ b/include/cantera/thermo/PDSS_ConstVol.h
@@ -2,7 +2,7 @@
  *  @file PDSS_ConstVol.h
  *    Declarations for the class PDSS_ConstVol (pressure dependent standard state)
  *    which handles calculations for a single species with a constant molar volume in a phase
- *    (see class @ref pdssthermo and \link Cantera::PDSS_ConstVol PDSS_ConstVol\endlink).
+ *    (see class @ref pdssthermo and @link Cantera::PDSS_ConstVol PDSS_ConstVol@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_ConstVol.h
+++ b/include/cantera/thermo/PDSS_ConstVol.h
@@ -2,7 +2,7 @@
  *  @file PDSS_ConstVol.h
  *    Declarations for the class PDSS_ConstVol (pressure dependent standard state)
  *    which handles calculations for a single species with a constant molar volume in a phase
- *    (see class \ref pdssthermo and \link Cantera::PDSS_ConstVol PDSS_ConstVol\endlink).
+ *    (see class @ref pdssthermo and \link Cantera::PDSS_ConstVol PDSS_ConstVol\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_HKFT.h
+++ b/include/cantera/thermo/PDSS_HKFT.h
@@ -3,7 +3,7 @@
  *    Declarations for the class PDSS_HKFT (pressure dependent standard state)
  *    which handles calculations for a single species in a phase using the
  *    HKFT standard state
- *    (see \ref pdssthermo and class \link Cantera::PDSS_HKFT PDSS_HKFT\endlink).
+ *    (see @ref pdssthermo and class \link Cantera::PDSS_HKFT PDSS_HKFT\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_HKFT.h
+++ b/include/cantera/thermo/PDSS_HKFT.h
@@ -3,7 +3,7 @@
  *    Declarations for the class PDSS_HKFT (pressure dependent standard state)
  *    which handles calculations for a single species in a phase using the
  *    HKFT standard state
- *    (see @ref pdssthermo and class \link Cantera::PDSS_HKFT PDSS_HKFT\endlink).
+ *    (see @ref pdssthermo and class @link Cantera::PDSS_HKFT PDSS_HKFT@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_HKFT.h
+++ b/include/cantera/thermo/PDSS_HKFT.h
@@ -45,7 +45,7 @@ public:
      *  Note this is just an extra routine to check the arithmetic
      *
      * @returns the species standard state enthalpy in J kmol-1
-     * @deprecated To be removed after Cantera 3.0
+     * @deprecated To be removed after %Cantera 3.0
      */
     doublereal enthalpy_mole2() const;
 
@@ -161,7 +161,7 @@ private:
     //! between the reference state at Tr, Pr and T,P
     /*!
      *  This is an extra routine that was added to check the arithmetic
-     * @deprecated To be removed after Cantera 3.0
+     * @deprecated To be removed after %Cantera 3.0
      */
     doublereal deltaH() const;
 

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -20,7 +20,7 @@ namespace Cantera
  * This class is for a single Ideal Gas species.
  *
  * @ingroup pdssthermo
- * @deprecated To be removed after Cantera 3.0.
+ * @deprecated To be removed after %Cantera 3.0.
  */
 class PDSS_IdealGas : public PDSS_Nondimensional
 {

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -2,7 +2,7 @@
  *  @file PDSS_IdealGas.h
  *   Declarations for the class PDSS_IdealGas (pressure dependent standard state)
  *    which handles calculations for a single ideal gas species in a phase
- *    (see \ref pdssthermo and class \link Cantera::PDSS_IdealGas PDSS_IdealGas\endlink).
+ *    (see @ref pdssthermo and class \link Cantera::PDSS_IdealGas PDSS_IdealGas\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -2,7 +2,7 @@
  *  @file PDSS_IdealGas.h
  *   Declarations for the class PDSS_IdealGas (pressure dependent standard state)
  *    which handles calculations for a single ideal gas species in a phase
- *    (see @ref pdssthermo and class \link Cantera::PDSS_IdealGas PDSS_IdealGas\endlink).
+ *    (see @ref pdssthermo and class @link Cantera::PDSS_IdealGas PDSS_IdealGas@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -3,7 +3,7 @@
  *   Declarations for the class PDSS_IonsFromNeutral (
  *    which handles calculations for a single ion in a fluid, whose properties
  *    are calculated from another neutral molecule.
- *    (see \ref pdssthermo and class \link Cantera::PDSS_IonsFromNeutral PDSS_IonsFromNeutral\endlink).
+ *    (see @ref pdssthermo and class \link Cantera::PDSS_IonsFromNeutral PDSS_IonsFromNeutral\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -21,16 +21,16 @@ class ThermoPhase;
 //! Derived class for pressure dependent standard states of an ideal gas species
 /*!
  * @attention This class currently does not have any test cases or examples. Its
- *     implementation may be incomplete, and future changes to Cantera may
+ *     implementation may be incomplete, and future changes to %Cantera may
  *     unexpectedly cause this class to stop working. If you use this class,
  *     please consider contributing examples or test cases. In the absence of
  *     new tests or examples, this class may be deprecated and removed in a
- *     future version of Cantera. See
+ *     future version of  %Cantera. See
  *     https://github.com/Cantera/cantera/issues/267 for additional information.
  *
  * This class is for a single Ideal Gas species.
  *
- * @deprecated To be removed after Cantera 3.0
+ * @deprecated To be removed after %Cantera 3.0
  *
  * @ingroup pdssthermo
  */

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -3,7 +3,7 @@
  *   Declarations for the class PDSS_IonsFromNeutral (
  *    which handles calculations for a single ion in a fluid, whose properties
  *    are calculated from another neutral molecule.
- *    (see @ref pdssthermo and class \link Cantera::PDSS_IonsFromNeutral PDSS_IonsFromNeutral\endlink).
+ *    (see @ref pdssthermo and class @link Cantera::PDSS_IonsFromNeutral PDSS_IonsFromNeutral@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -20,11 +20,11 @@ namespace Cantera
 //! volume model of some sort.
 /*!
  * @attention This class currently does not have any test cases or examples. Its
- *     implementation may be incomplete, and future changes to Cantera may
+ *     implementation may be incomplete, and future changes to %Cantera may
  *     unexpectedly cause this class to stop working. If you use this class,
  *     please consider contributing examples or test cases. In the absence of
  *     new tests or examples, this class may be deprecated and removed in a
- *     future version of Cantera. See
+ *     future version of  %Cantera. See
  *     https://github.com/Cantera/cantera/issues/267 for additional information.
  *
  * Class PDSS_SSVol is an implementation class that compute the properties of a

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -3,7 +3,7 @@
  *    Declarations for the class PDSS_SSVol (pressure dependent standard state)
  *    which handles calculations for a single species with an expression for the standard state molar volume in a phase
  *    given by an enumerated data type
- *    (see class @ref pdssthermo and \link Cantera::PDSS_SSVol PDSS_SSVol\endlink).
+ *    (see class @ref pdssthermo and @link Cantera::PDSS_SSVol PDSS_SSVol@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -3,7 +3,7 @@
  *    Declarations for the class PDSS_SSVol (pressure dependent standard state)
  *    which handles calculations for a single species with an expression for the standard state molar volume in a phase
  *    given by an enumerated data type
- *    (see class \ref pdssthermo and \link Cantera::PDSS_SSVol PDSS_SSVol\endlink).
+ *    (see class @ref pdssthermo and \link Cantera::PDSS_SSVol PDSS_SSVol\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -2,7 +2,7 @@
  *  @file PDSS_Water.h
  * Implementation of a pressure dependent standard state
  * virtual function for a Pure Water Phase
- * (see \ref pdssthermo and class \link Cantera::PDSS_Water PDSS_Water\endlink).
+ * (see @ref pdssthermo and class \link Cantera::PDSS_Water PDSS_Water\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -2,7 +2,7 @@
  *  @file PDSS_Water.h
  * Implementation of a pressure dependent standard state
  * virtual function for a Pure Water Phase
- * (see @ref pdssthermo and class \link Cantera::PDSS_Water PDSS_Water\endlink).
+ * (see @ref pdssthermo and class @link Cantera::PDSS_Water PDSS_Water@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -28,7 +28,7 @@ class Species;
  * of each species, and for describing the current state of the phase. They do
  * not in themselves contain Thermodynamic equation of state information.
  * However, they do comprise all of the necessary background functionality to
- * support thermodynamic calculations (see \ref thermoprops).
+ * support thermodynamic calculations (see @ref thermoprops).
  */
 
 //! Class Phase is the base class for phases of matter, managing the species and
@@ -156,7 +156,7 @@ public:
     std::string elementName(size_t m) const;
 
     //! Return the index of element named 'name'. The index is an integer
-    //! assigned to each element in the order it was added. Returns \ref npos
+    //! assigned to each element in the order it was added. Returns @ref npos
     //! if the specified element is not found.
     //!     @param name Name of the element
     size_t elementIndex(const std::string& name) const;
@@ -235,7 +235,7 @@ public:
     //!     @param name String name of the species. It may also be in the form
     //!            phaseName:speciesName
     //!     @return The index of the species. If the name is not found,
-    //!             the value \ref npos is returned.
+    //!             the value @ref npos is returned.
     size_t speciesIndex(const std::string& name) const;
 
     //! Name of the species with index k

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -122,14 +122,14 @@ public:
      * course of a calculation. For example, if duplicates of a phase object
      * are instantiated and used in multiple places (such as a ReactorNet), they
      * will have the same constitutive input, that is, the names of the phases will
-     * be the same. Note that this is not a problem for Cantera internally;
+     * be the same. Note that this is not a problem for %Cantera internally;
      * however, a user may want to rename phase objects in order to clarify.
      */
     //!@{
 
     //! Return the name of the phase.
     /*!
-     *   Names are unique within a Cantera problem.
+     *   Names are unique within a %Cantera problem.
      */
     std::string name() const;
 
@@ -140,7 +140,7 @@ public:
     //! String indicating the thermodynamic model implemented. Usually
     //! corresponds to the name of the derived class, less any suffixes such as
     //! "Phase", TP", "VPSS", etc.
-    //! @since  Starting in Cantera 3.0, the name returned by this method corresponds
+    //! @since Starting in %Cantera 3.0, the name returned by this method corresponds
     //!     to the canonical name used in the YAML input format.
     virtual std::string type() const {
         return "Phase";
@@ -226,7 +226,7 @@ public:
     //!     @param  k         species index
     //!     @param atomArray  vector containing the atomic number in the species.
     //!                       Length: m_mm
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     void getAtoms(size_t k, double* atomArray) const;
 
     //! Returns the index of a species named 'name' within the Phase object.
@@ -243,10 +243,10 @@ public:
     std::string speciesName(size_t k) const;
 
     //! Returns the expanded species name of a species, including the phase name
-    //! This is guaranteed to be unique within a Cantera problem.
+    //! This is guaranteed to be unique within a %Cantera problem.
     //!     @param k  Species index within the phase
     //!     @return   The "phaseName:speciesName" string
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     std::string speciesSPName(int k) const;
 
     //! Return a const reference to the vector of species names
@@ -294,7 +294,7 @@ public:
     //! Return string acronym representing the native state of a Phase.
     //! Examples: "TP", "TDY", "TPY".
     //! @see nativeState
-    //! @since  New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     string nativeMode() const;
 
     //! Return a vector containing full states defining a phase.
@@ -379,7 +379,7 @@ public:
     //!     @param t     Temperature in kelvin
     //!     @param dens  Density (kg/m^3)
     //!     @param x     vector of species mole fractions, length m_kk
-    //!     @deprecated To be removed after Cantera 3.0; replaceable by calls to
+    //!     @deprecated To be removed after %Cantera 3.0; replaceable by calls to
     //!                 setMoleFractions() and setState_TD().
     void setState_TRX(doublereal t, doublereal dens, const doublereal* x);
 
@@ -389,7 +389,7 @@ public:
     //!     @param x     Composition Map containing the mole fractions.
     //!                  Species not included in the map are assumed to have
     //!                  a zero mole fraction.
-    //!     @deprecated To be removed after Cantera 3.0; replaceable by calls to
+    //!     @deprecated To be removed after %Cantera 3.0; replaceable by calls to
     //!                 setMoleFractionsByName() and setState_TD().
     void setState_TRX(doublereal t, doublereal dens, const compositionMap& x);
 
@@ -397,7 +397,7 @@ public:
     //!     @param t     Temperature in kelvin
     //!     @param dens  Density (kg/m^3)
     //!     @param y     vector of species mass fractions, length m_kk
-    //!     @deprecated To be removed after Cantera 3.0; replaceable by calls to
+    //!     @deprecated To be removed after %Cantera 3.0; replaceable by calls to
     //!                 setMassFractions() and setState_TD().
     void setState_TRY(doublereal t, doublereal dens, const doublereal* y);
 
@@ -407,7 +407,7 @@ public:
     //!     @param y     Composition Map containing the mass fractions.
     //!                  Species not included in the map are assumed to have
     //!                  a zero mass fraction.
-    //!     @deprecated To be removed after Cantera 3.0; replaceable by calls to
+    //!     @deprecated To be removed after %Cantera 3.0; replaceable by calls to
     //!                 setMassFractionsByName() and setState_TD().
     void setState_TRY(doublereal t, doublereal dens, const compositionMap& y);
 
@@ -416,43 +416,43 @@ public:
     //!     @param t     Temperature in kelvin
     //!     @param n     molar density (kmol/m^3)
     //!     @param x     vector of species mole fractions, length m_kk
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     void setState_TNX(doublereal t, doublereal n, const doublereal* x);
 
     //! Set the internally stored temperature (K) and density (kg/m^3)
     //!     @param t     Temperature in kelvin
     //!     @param rho   Density (kg/m^3)
-    //!     @deprecated  To be removed after Cantera 3.0; renamed to setState_TD()
+    //!     @deprecated To be removed after %Cantera 3.0; renamed to setState_TD()
     void setState_TR(doublereal t, doublereal rho);
 
     //! Set the internally stored temperature (K) and density (kg/m^3)
     //!     @param t     Temperature in kelvin
     //!     @param rho   Density (kg/m^3)
-    //!     @since  New in Cantera 3.0.
+    //!     @since New in %Cantera 3.0.
     void setState_TD(double t, double rho);
 
     //! Set the internally stored temperature (K) and mole fractions.
     //!     @param t   Temperature in kelvin
     //!     @param x   vector of species mole fractions, length m_kk
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     void setState_TX(doublereal t, doublereal* x);
 
     //! Set the internally stored temperature (K) and mass fractions.
     //!     @param t   Temperature in kelvin
     //!     @param y   vector of species mass fractions, length m_kk
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     void setState_TY(doublereal t, doublereal* y);
 
     //! Set the density (kg/m^3) and mole fractions.
     //!     @param rho  Density (kg/m^3)
     //!     @param x    vector of species mole fractions, length m_kk
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     void setState_RX(doublereal rho, doublereal* x);
 
     //! Set the density (kg/m^3) and mass fractions.
     //!     @param rho  Density (kg/m^3)
     //!     @param y    vector of species mass fractions, length m_kk
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     void setState_RY(doublereal rho, doublereal* y);
 
     //! @} end group set thermo state
@@ -464,7 +464,7 @@ public:
 
     //! Copy the vector of molecular weights into vector weights.
     //!     @param weights Output vector of molecular weights (kg/kmol)
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     void getMolecularWeights(vector_fp& weights) const;
 
     //! Copy the vector of molecular weights into array weights.
@@ -639,7 +639,7 @@ public:
     //! Returns a const pointer to the start of the moleFraction/MW array.
     //! This array is the array of mole fractions, each divided by the mean
     //! molecular weight.
-    //! @deprecated To be removed after Cantera 3.0. Generally replaceable by using
+    //! @deprecated To be removed after %Cantera 3.0. Generally replaceable by using
     //!     getMoleFractions() and meanMolecularWeight().
     const double* moleFractdivMMW() const;
 
@@ -714,7 +714,7 @@ public:
 
     //! Set the internally stored molar density (kmol/m^3) of the phase.
     //!     @param[in] molarDensity Input molar density (kmol/m^3).
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     virtual void setMolarDensity(const double molarDensity);
 
     //! Set the internally stored pressure (Pa) at constant temperature and

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -2,7 +2,7 @@
  *  @file PureFluidPhase.h
  *
  *   Header for a ThermoPhase class for a pure fluid phase consisting of
- *   gas, liquid, mixed-gas-liquid and supercritical fluid (see \ref thermoprops
+ *   gas, liquid, mixed-gas-liquid and supercritical fluid (see @ref thermoprops
  *   and class \link Cantera::PureFluidPhase PureFluidPhase\endlink).
  *
  * It inherits from ThermoPhase, but is built on top of the tpx package.

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -3,7 +3,7 @@
  *
  *   Header for a ThermoPhase class for a pure fluid phase consisting of
  *   gas, liquid, mixed-gas-liquid and supercritical fluid (see @ref thermoprops
- *   and class \link Cantera::PureFluidPhase PureFluidPhase\endlink).
+ *   and class @link Cantera::PureFluidPhase PureFluidPhase@endlink).
  *
  * It inherits from ThermoPhase, but is built on top of the tpx package.
  */

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -1,5 +1,5 @@
 /**
- *  @file  RedlichKisterVPSSTP.h (see \ref thermoprops and class \link
+ *  @file  RedlichKisterVPSSTP.h (see @ref thermoprops and class \link
  *      Cantera::RedlichKisterVPSSTP RedlichKisterVPSSTP\endlink).
  */
 

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -1,6 +1,6 @@
 /**
- *  @file  RedlichKisterVPSSTP.h (see @ref thermoprops and class \link
- *      Cantera::RedlichKisterVPSSTP RedlichKisterVPSSTP\endlink).
+ *  @file  RedlichKisterVPSSTP.h (see @ref thermoprops and class @link
+ *      Cantera::RedlichKisterVPSSTP RedlichKisterVPSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -98,7 +98,7 @@ public:
      *
      * @param mu    Output vector of non-dimensional species chemical potentials
      *              Length: m_kk.
-     * @deprecated To be removed after Cantera 3.0. Use getChemPotentials() instead.
+     * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
     virtual void getChemPotentials_RT(doublereal* mu) const;
 

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -1,10 +1,10 @@
 /**
  *  @file ShomatePoly.h
  *  Header for a single-species standard state object derived
- *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
+ *  from @link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType@endlink  based
  *  on the Shomate temperature polynomial form applied to one temperature region
- *  (see @ref spthermo and class \link Cantera::ShomatePoly ShomatePoly\endlink and
- *   \link Cantera::ShomatePoly2 ShomatePoly2\endlink).
+ *  (see @ref spthermo and class @link Cantera::ShomatePoly ShomatePoly@endlink and
+ *   @link Cantera::ShomatePoly2 ShomatePoly2@endlink).
  *    Shomate polynomial expressions.
  */
 

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -51,7 +51,7 @@ namespace Cantera
  * http://webbook.nist.gov/
  *
  * Before being used within Cantera, the dimensions must be adjusted to those
- * used by Cantera (for example, Joules and kmol).
+ * used by %Cantera (for example, Joules and kmol).
  *
  * @ingroup spthermo
  */
@@ -224,7 +224,7 @@ protected:
  * http://webbook.nist.gov/
  *
  * Before being used within Cantera, the dimensions must be adjusted to those
- * used by Cantera (for example, Joules and kmol).
+ * used by %Cantera (for example, Joules and kmol).
  *
  * This function uses two temperature regions, each with a Shomate polynomial
  * representation to represent the thermo functions. There are 15 coefficients,

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -3,7 +3,7 @@
  *  Header for a single-species standard state object derived
  *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
  *  on the Shomate temperature polynomial form applied to one temperature region
- *  (see \ref spthermo and class \link Cantera::ShomatePoly ShomatePoly\endlink and
+ *  (see @ref spthermo and class \link Cantera::ShomatePoly ShomatePoly\endlink and
  *   \link Cantera::ShomatePoly2 ShomatePoly2\endlink).
  *    Shomate polynomial expressions.
  */

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -125,7 +125,7 @@ public:
      *
      * @param murt  On return, Contains the chemical potential / RT of the
      *              single species and the phase. Units are unitless. Length = 1
-     * @deprecated To be removed after Cantera 3.0. Use getChemPotentials() instead.
+     * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
     virtual void getChemPotentials_RT(doublereal* murt) const;
 

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -2,7 +2,7 @@
  *  @file SingleSpeciesTP.h
  *  Header for the SingleSpeciesTP class, which is a filter class for ThermoPhase,
  *  that eases the construction of single species phases
- *  ( see @ref thermoprops and class \link Cantera::SingleSpeciesTP SingleSpeciesTP\endlink).
+ *  ( see @ref thermoprops and class @link Cantera::SingleSpeciesTP SingleSpeciesTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -2,7 +2,7 @@
  *  @file SingleSpeciesTP.h
  *  Header for the SingleSpeciesTP class, which is a filter class for ThermoPhase,
  *  that eases the construction of single species phases
- *  ( see \ref thermoprops and class \link Cantera::SingleSpeciesTP SingleSpeciesTP\endlink).
+ *  ( see @ref thermoprops and class \link Cantera::SingleSpeciesTP SingleSpeciesTP\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/SpeciesThermoFactory.h
+++ b/include/cantera/thermo/SpeciesThermoFactory.h
@@ -2,7 +2,7 @@
  *  @file SpeciesThermoFactory.h
  *    Header for factory functions to build instances of classes that manage the
  *    standard-state thermodynamic properties of a set of species
- *    (see \ref spthermo);
+ *    (see @ref spthermo);
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -2,8 +2,8 @@
  *  @file SpeciesThermoInterpType.h
  *
  * Pure Virtual Base class for individual species reference state thermodynamic
- * managers and text for the spthermo module (see @ref spthermo and class \link
- * Cantera::SpeciesThermoInterpType SpeciesThermoInterpType \endlink).
+ * managers and text for the spthermo module (see @ref spthermo and class @link
+ * Cantera::SpeciesThermoInterpType SpeciesThermoInterpType @endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/SpeciesThermoInterpType.h
+++ b/include/cantera/thermo/SpeciesThermoInterpType.h
@@ -2,7 +2,7 @@
  *  @file SpeciesThermoInterpType.h
  *
  * Pure Virtual Base class for individual species reference state thermodynamic
- * managers and text for the spthermo module (see \ref spthermo and class \link
+ * managers and text for the spthermo module (see @ref spthermo and class \link
  * Cantera::SpeciesThermoInterpType SpeciesThermoInterpType \endlink).
  */
 

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -2,7 +2,7 @@
  * @file StoichSubstance.h
  * Header file for the StoichSubstance class, which represents a fixed-composition
  * incompressible substance (see @ref thermoprops and
- * class \link Cantera::StoichSubstance StoichSubstance\endlink)
+ * class @link Cantera::StoichSubstance StoichSubstance@endlink)
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -1,7 +1,7 @@
 /**
  * @file StoichSubstance.h
  * Header file for the StoichSubstance class, which represents a fixed-composition
- * incompressible substance (see \ref thermoprops and
+ * incompressible substance (see @ref thermoprops and
  * class \link Cantera::StoichSubstance StoichSubstance\endlink)
  */
 

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -3,7 +3,7 @@
  *  Header for a simple thermodynamics model of a surface phase
  *  derived from ThermoPhase,
  *  assuming an ideal solution model
- *  (see \ref thermoprops and class \link Cantera::SurfPhase SurfPhase\endlink).
+ *  (see @ref thermoprops and class \link Cantera::SurfPhase SurfPhase\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -211,7 +211,7 @@ public:
 
     //! Since interface phases have no volume, setting this to a value other than 0.0
     //! raises an exception.
-    //! @deprecated Unused. To be removed after Cantera 3.0
+    //! @deprecated Unused. To be removed after %Cantera 3.0
     virtual void setMolarDensity(const double vm);
 
     //! Returns the site density

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -3,7 +3,7 @@
  *  Header for a simple thermodynamics model of a surface phase
  *  derived from ThermoPhase,
  *  assuming an ideal solution model
- *  (see @ref thermoprops and class \link Cantera::SurfPhase SurfPhase\endlink).
+ *  (see @ref thermoprops and class @link Cantera::SurfPhase SurfPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -1,7 +1,7 @@
 /**
  *  @file ThermoFactory.h
  *     Headers for the factory class that can create known ThermoPhase objects
- *     (see \ref thermoprops and class \link Cantera::ThermoFactory ThermoFactory\endlink).
+ *     (see @ref thermoprops and class \link Cantera::ThermoFactory ThermoFactory\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -1,7 +1,7 @@
 /**
  *  @file ThermoFactory.h
  *     Headers for the factory class that can create known ThermoPhase objects
- *     (see @ref thermoprops and class \link Cantera::ThermoFactory ThermoFactory\endlink).
+ *     (see @ref thermoprops and class @link Cantera::ThermoFactory ThermoFactory@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -44,7 +44,7 @@ public:
      * @param model  The name of the thermo model
      * @returns a pointer to a new ThermoPhase object of the type specified. Throws a
      *     CanteraError if the named model isn't registered with ThermoFactory.
-     * @deprecated  To be removed after Cantera 3.0; superseded by newThermo()
+     * @deprecated To be removed after %Cantera 3.0; superseded by newThermo()
      */
     virtual ThermoPhase* newThermoPhase(const std::string& model);
 
@@ -60,7 +60,7 @@ private:
 };
 
 //! @copydoc newThermoModel(const string&)
-//! @deprecated  To be removed after Cantera 3.0; superseded by newThermoModel()
+//! @deprecated To be removed after %Cantera 3.0; superseded by newThermoModel()
 ThermoPhase* newThermoPhase(const string& model);
 
 //! Create a new ThermoPhase instance.
@@ -68,7 +68,7 @@ ThermoPhase* newThermoPhase(const string& model);
   * @param model   String to look up the model against
   * @returns a shared pointer to a new ThermoPhase object of the type specified. Throws a
   *     CanteraError if the named model is not registered with ThermoFactory.
-  * @since New in Cantera 3.0. Replaces newThermo
+  * @since New in %Cantera 3.0. Replaces newThermo
   */
  shared_ptr<ThermoPhase> newThermoModel(const string& model);
 
@@ -79,7 +79,7 @@ ThermoPhase* newThermoPhase(const string& model);
  * @param rootNode   The root node of the tree containing the phase definition,
  *     which will be used as the default location from which to read species
  *     definitions.
- * @since New in Cantera 3.0.
+ * @since New in %Cantera 3.0.
  */
 shared_ptr<ThermoPhase> newThermo(const AnyMap& phaseNode,
                                   const AnyMap& rootNode=AnyMap());
@@ -94,18 +94,18 @@ shared_ptr<ThermoPhase> newThermo(const AnyMap& phaseNode,
  * @param id     name (id) of the phase in the file.
  *               If this is blank, the first phase in the file is used.
  * @returns an initialized ThermoPhase object.
- * @since Changed in Cantera 3.0. Prior to Cantera 3.0, the function used a single
+ * @since Changed in %Cantera 3.0. Prior to %Cantera 3.0, the function used a single
  *      argument specifying the thermo model, which is now deprecated.
  */
 shared_ptr<ThermoPhase> newThermo(const string& infile, const string& id="");
 
 //! @copydoc newThermo(const AnyMap&, const AnyMap&)
-//! @deprecated  To be removed after Cantera 3.0; superseded by newThermo()
+//! @deprecated To be removed after %Cantera 3.0; superseded by newThermo()
 unique_ptr<ThermoPhase> newPhase(const AnyMap& phaseNode,
                                  const AnyMap& rootNode=AnyMap());
 
 //! @copydoc newThermo(const string&, const string&)
-//! @deprecated  To be removed after Cantera 3.0; superseded by newThermo()
+//! @deprecated To be removed after %Cantera 3.0; superseded by newThermo()
 ThermoPhase* newPhase(const std::string& infile, std::string id="");
 
 //! Initialize a ThermoPhase object

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -2,7 +2,7 @@
  *  @file ThermoPhase.h
  * Header file for class ThermoPhase, the base class for phases with
  * thermodynamic properties, and the text for the Module thermoprops
- * (see \ref thermoprops and class \link Cantera::ThermoPhase ThermoPhase\endlink).
+ * (see @ref thermoprops and class \link Cantera::ThermoPhase ThermoPhase\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -2,7 +2,7 @@
  *  @file ThermoPhase.h
  * Header file for class ThermoPhase, the base class for phases with
  * thermodynamic properties, and the text for the Module thermoprops
- * (see @ref thermoprops and class \link Cantera::ThermoPhase ThermoPhase\endlink).
+ * (see @ref thermoprops and class @link Cantera::ThermoPhase ThermoPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -53,7 +53,7 @@ enum class ThermoBasis
  * phases of matter of any type. It defines a common public interface, and
  * implements a few methods. Most of the methods, however, are declared virtual
  * and are meant to be overloaded in derived classes.  The standard way used
- * throughout Cantera to compute properties of phases of matter is through
+ * throughout %Cantera to compute properties of phases of matter is through
  * pointers of type ThermoPhase* that point to objects of subclasses of
  * ThermoPhase.
  *
@@ -66,7 +66,7 @@ enum class ThermoBasis
  *
  * Instances of subclasses of ThermoPhase should be created using the factory
  * class ThermoFactory, not by calling the constructor directly. This allows new
- * classes to be used with the various Cantera language interfaces.
+ * classes to be used with the various %Cantera language interfaces.
  *
  * To implement a new equation of state, derive a class from ThermoPhase and
  * overload the virtual methods in ThermoPhase. Methods that are not needed can
@@ -483,7 +483,7 @@ public:
      * @param mu  Output vector of dimensionless chemical potentials.
      *            Length: m_kk.
      *
-     * @deprecated To be removed after Cantera 3.0. Use getChemPotentials() instead.
+     * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
     virtual void getChemPotentials_RT(doublereal* mu) const {
         throw NotImplementedError("ThermoPhase::getChemPotentials_RT");
@@ -888,7 +888,7 @@ public:
      * @param p    Pressure (Pa)
      * @param x    Vector of mole fractions.
      *             Length is equal to m_kk.
-     * @deprecated To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     virtual void setState_PX(doublereal p, doublereal* x);
 
@@ -901,7 +901,7 @@ public:
      * @param p    Pressure (Pa)
      * @param y    Vector of mass fractions.
      *             Length is equal to m_kk.
-     * @deprecated To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     virtual void setState_PY(doublereal p, doublereal* y);
 
@@ -1080,7 +1080,7 @@ public:
      *
      * @param rho Density (kg/m^3)
      * @param p   Pressure (Pa)
-     * @deprecated  To be removed after Cantera 3.0; renamed to setState_DP()
+     * @deprecated To be removed after %Cantera 3.0; renamed to setState_DP()
      */
     void setState_RP(doublereal rho, doublereal p);
 
@@ -1096,7 +1096,7 @@ public:
      *
      * @param rho Density (kg/m^3)
      * @param p   Pressure (Pa)
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual void setState_DP(double rho, double p) {
         throw NotImplementedError("ThermoPhase::setState_DP");
@@ -1112,7 +1112,7 @@ public:
      * @param p    Pressure (Pa)
      * @param x    Vector of mole fractions.
      *             Length is equal to m_kk.
-     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     * @deprecated To be removed after %Cantera 3.0; replaceable by calls to
      *              setMoleFractions() and setState_DP().
      */
     virtual void setState_RPX(doublereal rho, doublereal p, const doublereal* x);
@@ -1127,7 +1127,7 @@ public:
      * @param p    Pressure (Pa)
      * @param x    Composition map of mole fractions. Species not in
      *              the composition map are assumed to have zero mole fraction
-     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     * @deprecated To be removed after %Cantera 3.0; replaceable by calls to
      *              setMoleFractionsByName() and setState_DP().
      */
     virtual void setState_RPX(doublereal rho, doublereal p, const compositionMap& x);
@@ -1143,7 +1143,7 @@ public:
      * @param x    String containing a composition map of the mole fractions.
      *              Species not in the composition map are assumed to have zero
      *              mole fraction
-     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     * @deprecated To be removed after %Cantera 3.0; replaceable by calls to
      *              setMoleFractionsByName() and setState_DP().
      */
     virtual void setState_RPX(doublereal rho, doublereal p, const std::string& x);
@@ -1158,7 +1158,7 @@ public:
      * @param p    Pressure (Pa)
      * @param y    Vector of mole fractions.
      *              Length is equal to m_kk.
-     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     * @deprecated To be removed after %Cantera 3.0; replaceable by calls to
      *              setMassFractions() and setState_DP().
      */
     virtual void setState_RPY(doublereal rho, doublereal p, const doublereal* y);
@@ -1173,7 +1173,7 @@ public:
      * @param p   Pressure (Pa)
      * @param y   Composition map of mole fractions. Species not in
      *             the composition map are assumed to have zero mole fraction
-     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     * @deprecated To be removed after %Cantera 3.0; replaceable by calls to
      *              setMassFractionsByName() and setState_DP().
      */
     virtual void setState_RPY(doublereal rho, doublereal p, const compositionMap& y);
@@ -1189,7 +1189,7 @@ public:
      * @param y    String containing a composition map of the mole fractions.
      *              Species not in the composition map are assumed to have zero
      *              mole fraction
-     * @deprecated  To be removed after Cantera 3.0; replaceable by calls to
+     * @deprecated To be removed after %Cantera 3.0; replaceable by calls to
      *              setMassFractionsByName() and setState_DP().
      */
     virtual void setState_RPY(doublereal rho, doublereal p, const std::string& y);
@@ -1813,7 +1813,7 @@ public:
      * override the getCsvReportData method.
      *
      * @param csvFile  ofstream file to print comma separated data for the phase
-     * @deprecated To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     virtual void reportCSV(std::ofstream& csvFile) const;
 
@@ -1827,7 +1827,7 @@ protected:
 
     //! Fills `names` and `data` with the column names and species thermo
     //! properties to be included in the output of the reportCSV method.
-    //! @deprecated To be removed after Cantera 3.0.
+    //! @deprecated To be removed after %Cantera 3.0.
     virtual void getCsvReportData(std::vector<std::string>& names,
                                   std::vector<vector_fp>& data) const;
 

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -3,7 +3,7 @@
  *    Header file for a derived class of ThermoPhase that handles
  *    variable pressure standard state methods for calculating
  *    thermodynamic properties (see @ref thermoprops and
- *    class \link Cantera::VPStandardStateTP VPStandardStateTP\endlink).
+ *    class @link Cantera::VPStandardStateTP VPStandardStateTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -72,7 +72,7 @@ public:
      *
      * @param mu    Output vector of non-dimensional species chemical potentials
      *              Length: m_kk.
-     * @deprecated To be removed after Cantera 3.0. Use getChemPotentials() instead.
+     * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
     virtual void getChemPotentials_RT(doublereal* mu) const;
 

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -2,7 +2,7 @@
  *  @file VPStandardStateTP.h
  *    Header file for a derived class of ThermoPhase that handles
  *    variable pressure standard state methods for calculating
- *    thermodynamic properties (see \ref thermoprops and
+ *    thermodynamic properties (see @ref thermoprops and
  *    class \link Cantera::VPStandardStateTP VPStandardStateTP\endlink).
  */
 

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -3,7 +3,7 @@
  *   Header for a class used to house several approximation
  *   routines for properties of water.
  *  (see @ref thermoprops
- *   and class \link Cantera::WaterProps WaterProps\endlink).
+ *   and class @link Cantera::WaterProps WaterProps@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
@@ -85,8 +85,8 @@ class PDSS_Water;
 /*!
  * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
  * a complete implementation of a thermo phase by itself (see @ref thermoprops
- * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
- * \link Cantera::PDSS_Water PDSS_Water\endlink).
+ * and classes @link Cantera::WaterSSTP WaterSSTP@endlink and
+ * @link Cantera::PDSS_Water PDSS_Water@endlink).
  *
  * The class is also a wrapper around the WaterPropsIAPWS class which provides
  * the calculations for the equation of state properties for water.

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -2,7 +2,7 @@
  *  @file WaterProps.h
  *   Header for a class used to house several approximation
  *   routines for properties of water.
- *  (see \ref thermoprops
+ *  (see @ref thermoprops
  *   and class \link Cantera::WaterProps WaterProps\endlink).
  */
 
@@ -84,7 +84,7 @@ class PDSS_Water;
 //! properties of water.
 /*!
  * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
- * a complete implementation of a thermo phase by itself (see \ref thermoprops
+ * a complete implementation of a thermo phase by itself (see @ref thermoprops
  * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
  * \link Cantera::PDSS_Water PDSS_Water\endlink).
  *

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -2,7 +2,7 @@
  * @file WaterPropsIAPWS.h
  * Headers for a class for calculating the equation of state of water
  * from the IAPWS 1995 Formulation based on the steam tables thermodynamic
- * basis (See class \link Cantera::WaterPropsIAPWS WaterPropsIAPWS\endlink).
+ * basis (See class @link Cantera::WaterPropsIAPWS WaterPropsIAPWS@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or
@@ -38,8 +38,8 @@ namespace Cantera
 /*!
  * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
  * a complete implementation of a thermo phase by itself (see @ref thermoprops
- * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
- * \link Cantera::PDSS_Water PDSS_Water\endlink).
+ * and classes @link Cantera::WaterSSTP WaterSSTP@endlink and
+ * @link Cantera::PDSS_Water PDSS_Water@endlink).
  *
  * The reference is W. Wagner, A. Pruss, "The IAPWS Formulation 1995 for the
  * Thermodynamic Properties of Ordinary Water Substance for General and

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -37,7 +37,7 @@ namespace Cantera
 //! Class for calculating the equation of state of water.
 /*!
  * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
- * a complete implementation of a thermo phase by itself (see \ref thermoprops
+ * a complete implementation of a thermo phase by itself (see @ref thermoprops
  * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
  * \link Cantera::PDSS_Water PDSS_Water\endlink).
  *

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -171,7 +171,7 @@ public:
     /*!
      * @param temperature   temperature (kelvin)
      * @param rho           density  (kg m-3)
-     * @deprecated  To be removed after Cantera 3.0; renamed to setState_TD()
+     * @deprecated To be removed after %Cantera 3.0; renamed to setState_TD()
      */
     void setState_TR(doublereal temperature, doublereal rho);
 
@@ -179,7 +179,7 @@ public:
     /*!
      * @param temperature   temperature (kelvin)
      * @param rho           density  (kg m-3)
-     * @since  New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     void setState_TD(double temperature, double rho);
 
@@ -205,47 +205,47 @@ public:
 
     //! Calculate the Helmholtz free energy in mks units of J kmol-1 K-1,
     //! using the last temperature and density
-    //! @deprecated To be removed after Cantera 3.0. This class provides mass-based
+    //! @deprecated To be removed after %Cantera 3.0. This class provides mass-based
     //!     values only.
     doublereal helmholtzFE() const;
 
     //! Calculate the Gibbs free energy in mks units of J kmol-1 K-1.
     //! using the last temperature and density
-    //! @deprecated To be removed after Cantera 3.0. This class provides mass-based
+    //! @deprecated To be removed after %Cantera 3.0. This class provides mass-based
     //!     values only.
     doublereal Gibbs() const;
 
     //! Calculate the enthalpy in mks units of J kmol-1
     //! using the last temperature and density
-    //! @deprecated To be removed after Cantera 3.0. This class provides mass-based
+    //! @deprecated To be removed after %Cantera 3.0. This class provides mass-based
     //!     values only.
     doublereal enthalpy() const;
 
     //! Calculate the internal energy in mks units of J kmol-1
-    //! @deprecated To be removed after Cantera 3.0. This class provides mass-based
+    //! @deprecated To be removed after %Cantera 3.0. This class provides mass-based
     //!     values only.
     doublereal intEnergy() const;
 
     //! Calculate the entropy in mks units of J kmol-1 K-1
-    //! @deprecated To be removed after Cantera 3.0. This class provides mass-based
+    //! @deprecated To be removed after %Cantera 3.0. This class provides mass-based
     //!     values only.
     doublereal entropy() const;
 
     //! Calculate the constant volume heat capacity in mks units of J kmol-1 K-1
     //! at the last temperature and density
-    //! @deprecated To be removed after Cantera 3.0. This class provides mass-based
+    //! @deprecated To be removed after %Cantera 3.0. This class provides mass-based
     //!     values only.
     doublereal cv() const;
 
     //! Calculate the constant pressure heat capacity in mks units of J kmol-1 K-1
     //! at the last temperature and density
-    //! @deprecated To be removed after Cantera 3.0. This class provides mass-based
+    //! @deprecated To be removed after %Cantera 3.0. This class provides mass-based
     //!     values only.
     doublereal cp() const;
 
     //! Calculate the molar volume (kmol m-3) at the last temperature and
     //! density
-    //! @deprecated To be removed after Cantera 3.0. This class provides mass-based
+    //! @deprecated To be removed after %Cantera 3.0. This class provides mass-based
     //!     values only.
     doublereal molarVolume() const;
 

--- a/include/cantera/thermo/WaterPropsIAPWSphi.h
+++ b/include/cantera/thermo/WaterPropsIAPWSphi.h
@@ -21,7 +21,7 @@ namespace Cantera
 //! Low level class for the real description of water.
 /*!
  * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
- * a complete implementation of a thermo phase by itself (see \ref thermoprops
+ * a complete implementation of a thermo phase by itself (see @ref thermoprops
  * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
  * \link Cantera::PDSS_Water PDSS_Water\endlink).
  *

--- a/include/cantera/thermo/WaterPropsIAPWSphi.h
+++ b/include/cantera/thermo/WaterPropsIAPWSphi.h
@@ -1,8 +1,8 @@
 /**
  * @file WaterPropsIAPWSphi.h
  * Header for Lowest level of the classes which support a real water model
- * (see class \link Cantera::WaterPropsIAPWS WaterPropsIAPWS\endlink and class
- * \link Cantera::WaterPropsIAPWSphi WaterPropsIAPWSphi\endlink).
+ * (see class @link Cantera::WaterPropsIAPWS WaterPropsIAPWS@endlink and class
+ * @link Cantera::WaterPropsIAPWSphi WaterPropsIAPWSphi@endlink).
  *
  * This class calculates dimensionless quantities.
  */
@@ -22,8 +22,8 @@ namespace Cantera
 /*!
  * This is a helper class for WaterSSTP and PDSS_Water and does not constitute
  * a complete implementation of a thermo phase by itself (see @ref thermoprops
- * and classes \link Cantera::WaterSSTP WaterSSTP\endlink and
- * \link Cantera::PDSS_Water PDSS_Water\endlink).
+ * and classes @link Cantera::WaterSSTP WaterSSTP@endlink and
+ * @link Cantera::PDSS_Water PDSS_Water@endlink).
  *
  * The reference is Wagner and Pruss @cite wagner2002.
  *

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -200,7 +200,7 @@ private:
      */
     std::unique_ptr<WaterProps> m_waterProps;
 
-    //! Molecular weight of Water -> Cantera assumption
+    //! Molecular weight of Water -> %Cantera assumption
     double m_mw = 0.0;
 
     //! Offset constants used to obtain consistency with the NIST database.

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -1,7 +1,7 @@
 /**
  *  @file WaterSSTP.h
  * Declares a ThermoPhase class consisting of pure water (see @ref thermoprops
- * and class \link Cantera::WaterSSTP WaterSSTP\endlink).
+ * and class @link Cantera::WaterSSTP WaterSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -1,6 +1,6 @@
 /**
  *  @file WaterSSTP.h
- * Declares a ThermoPhase class consisting of pure water (see \ref thermoprops
+ * Declares a ThermoPhase class consisting of pure water (see @ref thermoprops
  * and class \link Cantera::WaterSSTP WaterSSTP\endlink).
  */
 

--- a/include/cantera/thermo/speciesThermoTypes.h
+++ b/include/cantera/thermo/speciesThermoTypes.h
@@ -1,6 +1,6 @@
 /**
  *  @file speciesThermoTypes.h Contains const definitions for types of species
- *       reference-state thermodynamics managers (see \ref spthermo)
+ *       reference-state thermodynamics managers (see @ref spthermo)
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/transport/DustyGasTransport.h
+++ b/include/cantera/transport/DustyGasTransport.h
@@ -1,8 +1,8 @@
 /**
  * @file DustyGasTransport.h Headers for the DustyGasTransport object, which
  *   models transport properties in porous media using the dusty gas
- *   approximation (see @ref tranprops and \link Cantera::DustyGasTransport
- *   DustyGasTransport \endlink) .
+ *   approximation (see @ref tranprops and @link Cantera::DustyGasTransport
+ *   DustyGasTransport @endlink) .
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/transport/DustyGasTransport.h
+++ b/include/cantera/transport/DustyGasTransport.h
@@ -1,7 +1,7 @@
 /**
  * @file DustyGasTransport.h Headers for the DustyGasTransport object, which
  *   models transport properties in porous media using the dusty gas
- *   approximation (see \ref tranprops and \link Cantera::DustyGasTransport
+ *   approximation (see @ref tranprops and \link Cantera::DustyGasTransport
  *   DustyGasTransport \endlink) .
  */
 

--- a/include/cantera/transport/HighPressureGasTransport.h
+++ b/include/cantera/transport/HighPressureGasTransport.h
@@ -21,11 +21,11 @@ namespace Cantera
 //! high pressure gas mixtures.
 /*!
  * @attention This class currently does not have any test cases or examples. Its
- *     implementation may be incomplete, and future changes to Cantera may
+ *     implementation may be incomplete, and future changes to %Cantera may
  *     unexpectedly cause this class to stop working. If you use this class,
  *     please consider contributing examples or test cases. In the absence of
  *     new tests or examples, this class may be deprecated and removed in a
- *     future version of Cantera. See
+ *     future version of  %Cantera. See
  *     https://github.com/Cantera/cantera/issues/267 for additional information.
  *
  * The implementation employs a method of corresponding states, using the

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -2,7 +2,7 @@
  *  @file MixTransport.h
  *    Headers for the MixTransport object, which models transport properties
  *    in ideal gas solutions using a mixture averaged approximation
- *    (see @ref tranprops and \link Cantera::MixTransport MixTransport \endlink) .
+ *    (see @ref tranprops and @link Cantera::MixTransport MixTransport @endlink) .
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -2,7 +2,7 @@
  *  @file MixTransport.h
  *    Headers for the MixTransport object, which models transport properties
  *    in ideal gas solutions using a mixture averaged approximation
- *    (see \ref tranprops and \link Cantera::MixTransport MixTransport \endlink) .
+ *    (see @ref tranprops and \link Cantera::MixTransport MixTransport \endlink) .
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -1,8 +1,8 @@
 /**
  * @file Transport.h Headers for the Transport object, which is the virtual
  *     base class for all transport property evaluators and also includes the
- *     tranprops group definition (see @ref tranprops and \link
- *     Cantera::Transport Transport \endlink) .
+ *     tranprops group definition (see @ref tranprops and @link
+ *     Cantera::Transport Transport @endlink) .
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -1,7 +1,7 @@
 /**
  * @file Transport.h Headers for the Transport object, which is the virtual
  *     base class for all transport property evaluators and also includes the
- *     tranprops group definition (see \ref tranprops and \link
+ *     tranprops group definition (see @ref tranprops and \link
  *     Cantera::Transport Transport \endlink) .
  */
 
@@ -31,13 +31,13 @@ class Solution;
 class AnyMap;
 
 /*!
- * \addtogroup tranprops
+ * @addtogroup tranprops
  */
-//!  \cond
+//!  @cond
 
 const int CK_Mode = 10;
 
-//!   \endcond
+//!   @endcond
 
 //! The diffusion fluxes must be referenced to a particular reference
 //! fluid velocity.
@@ -65,7 +65,7 @@ const int CK_Mode = 10;
 typedef int VelocityBasis;
 
 /*!
- * \addtogroup tranprops
+ * @addtogroup tranprops
  */
 //! @{
 //! Diffusion velocities are based on the mass averaged velocity

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -52,7 +52,7 @@ const int CK_Mode = 10;
  * quantities refers to the reference velocity being referenced to a particular
  * species. Below are the predefined constants for its value.
  *
- * @deprecated To be removed after Cantera 3.0.
+ * @deprecated To be removed after %Cantera 3.0.
  *
  * - VB_MASSAVG    Diffusion velocities are based on the mass averaged velocity
  * - VB_MOLEAVG    Diffusion velocities are based on the mole averaged velocities
@@ -69,22 +69,22 @@ typedef int VelocityBasis;
  */
 //! @{
 //! Diffusion velocities are based on the mass averaged velocity
-//! @deprecated To be removed after Cantera 3.0.
+//! @deprecated To be removed after %Cantera 3.0.
 const VelocityBasis VB_MASSAVG = -1;
 //! Diffusion velocities are based on the mole averaged velocities
-//! @deprecated To be removed after Cantera 3.0.
+//! @deprecated To be removed after %Cantera 3.0.
 const VelocityBasis VB_MOLEAVG = -2;
 //! Diffusion velocities are based on the relative motion wrt species 0
-//! @deprecated To be removed after Cantera 3.0.
+//! @deprecated To be removed after %Cantera 3.0.
 const VelocityBasis VB_SPECIES_0 = 0;
 //! Diffusion velocities are based on the relative motion wrt species 1
-//! @deprecated To be removed after Cantera 3.0.
+//! @deprecated To be removed after %Cantera 3.0.
 const VelocityBasis VB_SPECIES_1 = 1;
 //! Diffusion velocities are based on the relative motion wrt species 2
-//! @deprecated To be removed after Cantera 3.0.
+//! @deprecated To be removed after %Cantera 3.0.
 const VelocityBasis VB_SPECIES_2 = 2;
 //! Diffusion velocities are based on the relative motion wrt species 3
-//! @deprecated To be removed after Cantera 3.0.
+//! @deprecated To be removed after %Cantera 3.0.
 const VelocityBasis VB_SPECIES_3 = 3;
 //! @}
 
@@ -154,7 +154,7 @@ public:
      * @param thermo   Pointer to the ThermoPhase class representing this phase.
      * @param ndim     Dimension of the flux vector used in the calculation.
      *
-     * @deprecated The `thermo` and `ndim` parameters will be removed after Cantera 3.0.
+     * @deprecated The `thermo` and `ndim` parameters will be removed after %Cantera 3.0.
      *     The ThermoPhase object should be specifed when calling the `init` method.
      *
      * @see TransportFactory
@@ -169,7 +169,7 @@ public:
 
     //! Identifies the model represented by this Transport object. Each derived class
     //! should override this method to return a meaningful identifier.
-    //! @since  New in Cantera 3.0. The name returned by this method corresponds
+    //! @since New in %Cantera 3.0. The name returned by this method corresponds
     //!     to the canonical name used in the YAML input format.
     virtual std::string transportModel() const {
         return "none";
@@ -177,7 +177,7 @@ public:
 
     //! Identifies the Transport object type. Each derived class should override
     //! this method to return a meaningful identifier.
-    //! @deprecated  To be removed after Cantera 3.0. Replaced by transportModel
+    //! @deprecated To be removed after %Cantera 3.0. Replaced by transportModel
     std::string transportType() const {
         warn_deprecated("Transport::transportType",
             "To be removed after Cantera 3.0. Replaced by transportModel().");
@@ -196,19 +196,19 @@ public:
 
     /*!
      * Returns true if the transport manager is ready for use.
-     * @deprecated To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     bool ready();
 
     //! Set the number of dimensions to be expected in flux expressions
     /*!
      *  @param ndim  Number of dimensions in flux expressions
-     *  @deprecated Unused. To be removed after Cantera 3.0.
+     *  @deprecated Unused. To be removed after %Cantera 3.0.
      */
     void setNDim(const int ndim);
 
     //! Return the number of dimensions in flux expressions
-    //! @deprecated Unused. To be removed after Cantera 3.0.
+    //! @deprecated Unused. To be removed after %Cantera 3.0.
     size_t nDim() const {
         return m_nDim;
     }
@@ -256,7 +256,7 @@ public:
     }
 
     //! The ionic conductivity in 1/ohm/m.
-    //! @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+    //! @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
     virtual double ionConductivity() {
         throw NotImplementedError("Transport::ionConductivity",
             "Not implemented for transport model '{}'.", transportModel());
@@ -268,7 +268,7 @@ public:
      *
      * @param ionCond   Vector of ionic conductivities
      *
-     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+     * @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesIonConductivity(double* const ionCond) {
         throw NotImplementedError("Transport::getSpeciesIonConductivity",
@@ -290,7 +290,7 @@ public:
      *
      * The size of mobRat must be at least equal to nsp*nsp
      *
-     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+     * @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
      */
     virtual void mobilityRatio(double* mobRat) {
         throw NotImplementedError("Transport::mobilityRatio",
@@ -303,7 +303,7 @@ public:
      *
      * @param mobRat   Vector of mobility ratios
      *
-     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+     * @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesMobilityRatio(double** mobRat) {
         throw NotImplementedError("Transport::getSpeciesMobilityRatio",
@@ -365,7 +365,7 @@ public:
      *               The array must be dimensioned at least as large as the
      *               number of species.
      *
-     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+     * @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
      */
     virtual void getFluidMobilities(double* const mobil_f) {
         throw NotImplementedError("Transport::getFluidMobilities",
@@ -391,7 +391,7 @@ public:
      *
      * The units are Siemens m-1, where 1 S = 1 A / volt = 1 s^3 A^2 /kg /m^2
      *
-     * @deprecated To be removed after Cantera 3.0. Replaced by electricalConductivity()
+     * @deprecated To be removed after %Cantera 3.0. Replaced by electricalConductivity()
      */
     virtual double getElectricConduct() {
         throw NotImplementedError("Transport::getElectricConduct",
@@ -411,7 +411,7 @@ public:
      * @param grad_V  The electrostatic potential gradient.
      * @param current The electric current in A/m^2. This is a vector of length ndim
      *
-     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+     * @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
      */
     virtual void getElectricCurrent(int ndim,
                                     const double* grad_T,
@@ -468,7 +468,7 @@ public:
      * @param[out] fluxes  The diffusive mass fluxes. Flat vector with the m_nsp
      *             in the inner loop. length = ldx * ndim.
      *
-     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+     * @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesFluxesES(size_t ndim,
                                     const double* grad_T,
@@ -495,7 +495,7 @@ public:
      *               Flat vector with the m_nsp in the inner loop.
      *               length = ldx * ndim. units are m / s.
      *
-     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+     * @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesVdiff(size_t ndim,
                                  const double* grad_T,
@@ -525,7 +525,7 @@ public:
      *               Flat vector with the m_nsp in the inner loop. length = ldx
      *               * ndim. units are m / s.
      *
-     * @deprecated To be removed after Cantera 3.0. Not implemented by any model.
+     * @deprecated To be removed after %Cantera 3.0. Not implemented by any model.
      */
     virtual void getSpeciesVdiffES(size_t ndim,
                                    const double* grad_T,
@@ -722,7 +722,7 @@ public:
      * @param k       Species index to set the parameters on
      * @param p       Vector of parameters. The length of the vector varies with
      *                 the parameterization
-     * @deprecated  To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     virtual void setParameters(const int type, const int k, const double* const p) {
         throw NotImplementedError("Transport::setParameters",
@@ -742,7 +742,7 @@ public:
      * operators including all of the gas-phase operators.
      *
      * @param ivb   Species the velocity basis
-     * @deprecated  To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     void setVelocityBasis(VelocityBasis ivb) {
         m_velocityBasis = ivb;
@@ -755,7 +755,7 @@ public:
      * operators including all of the gas-phase operators.
      *
      * @returns the velocity basis
-     * @deprecated  To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     VelocityBasis getVelocityBasis() const {
         return m_velocityBasis;
@@ -790,13 +790,13 @@ public:
      *
      * @param   thermo  Reference to the ThermoPhase object that the transport
      *                  object will use
-     * @deprecated To be removed after Cantera 3.0. The ThermoPhase object should be
+     * @deprecated To be removed after %Cantera 3.0. The ThermoPhase object should be
      *     set as part of the call to `init`.
      */
     virtual void setThermo(ThermoPhase& thermo);
 
     //! Set root Solution holding all phase information
-    //! @deprecated Unused. To be removed after Cantera 3.0.
+    //! @deprecated Unused. To be removed after %Cantera 3.0.
     virtual void setRoot(std::shared_ptr<Solution> root);
 
     //! Boolean indicating the form of the transport properties polynomial fits.
@@ -812,7 +812,7 @@ protected:
      * Once finalize() has been called, the transport manager should be ready to
      * compute any supported transport property, and no further modifications to
      * the model parameters should be made.
-     * @deprecated To be removed after Cantera 3.0.
+     * @deprecated To be removed after %Cantera 3.0.
      */
     void finalize();
 
@@ -822,23 +822,23 @@ protected:
     ThermoPhase* m_thermo;
 
     //! true if finalize has been called
-    //! @deprecated To be removed after Cantera 3.0
+    //! @deprecated To be removed after %Cantera 3.0
     bool m_ready = false;
 
     //! Number of species
     size_t m_nsp = 0;
 
     //! Number of dimensions used in flux expressions
-    //! @deprecated To be removed after Cantera 3.0
+    //! @deprecated To be removed after %Cantera 3.0
     size_t m_nDim;
 
     //! Velocity basis from which diffusion velocities are computed.
     //! Defaults to the mass averaged basis = -2
-    //! @deprecated  To be removed after Cantera 3.0.
+    //! @deprecated To be removed after %Cantera 3.0.
     int m_velocityBasis = VB_MASSAVG;
 
     //! reference to Solution
-    //! @deprecated To be removed after Cantera 3.0
+    //! @deprecated To be removed after %Cantera 3.0
     std::weak_ptr<Solution> m_root;
 };
 

--- a/include/cantera/transport/TransportFactory.h
+++ b/include/cantera/transport/TransportFactory.h
@@ -1,7 +1,7 @@
 /**
  *  @file TransportFactory.h
  *  Header file defining class TransportFactory
- *     (see \link Cantera::TransportFactory TransportFactory\endlink)
+ *     (see @link Cantera::TransportFactory TransportFactory@endlink)
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/transport/TransportFactory.h
+++ b/include/cantera/transport/TransportFactory.h
@@ -87,7 +87,7 @@ private:
 };
 
 //! @copydoc TransportFactory::newTransport(const std::string&, ThermoPhase*, int)
-//! @deprecated  To be removed after Cantera 3.0; superseded by newTransport()
+//! @deprecated To be removed after %Cantera 3.0; superseded by newTransport()
 Transport* newTransportMgr(const std::string& model="", ThermoPhase* thermo=0,
                            int log_level=0);
 
@@ -103,7 +103,7 @@ shared_ptr<Transport> newTransport(shared_ptr<ThermoPhase> thermo,
                                    const string& model="default");
 
 //! @copydoc newTransport(shared_ptr<ThermoPhase>, const string&)
-//! @deprecated  To be removed after Cantera 3.0; superseded by newTransport()
+//! @deprecated To be removed after %Cantera 3.0; superseded by newTransport()
 shared_ptr<Transport> newTransport(ThermoPhase* thermo, const string& model="default");
 
 //!  Create a new transport manager instance.
@@ -111,7 +111,7 @@ shared_ptr<Transport> newTransport(ThermoPhase* thermo, const string& model="def
  *  @param thermo     ThermoPhase object associated with the phase
  *  @param loglevel   int containing the Loglevel, defaults to zero
  *  @returns a transport manager for the phase
- * @deprecated  To be removed after Cantera 3.0; superseded by newTransport()
+ * @deprecated To be removed after %Cantera 3.0; superseded by newTransport()
  * @ingroup tranprops
  */
 Transport* newDefaultTransportMgr(ThermoPhase* thermo, int loglevel = 0);

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -3,7 +3,7 @@
  *    Headers for the UnityLewisTransport object, which models transport
  *    properties in ideal gas solutions using the unity Lewis number
  *    approximation
- *    (see @ref tranprops and \link Cantera::UnityLewisTransport UnityLewisTransport \endlink) .
+ *    (see @ref tranprops and @link Cantera::UnityLewisTransport UnityLewisTransport @endlink) .
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -3,7 +3,7 @@
  *    Headers for the UnityLewisTransport object, which models transport
  *    properties in ideal gas solutions using the unity Lewis number
  *    approximation
- *    (see \ref tranprops and \link Cantera::UnityLewisTransport UnityLewisTransport \endlink) .
+ *    (see @ref tranprops and \link Cantera::UnityLewisTransport UnityLewisTransport \endlink) .
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/include/cantera/transport/WaterTransport.h
+++ b/include/cantera/transport/WaterTransport.h
@@ -26,7 +26,7 @@ public:
      *  @param ndim     Number of dimensions of the flux expressions.
      *                  Defaults to a value of one.
      *
-     * @deprecated The `thermo` and `ndim` parameters will be removed after Cantera 3.0.
+     * @deprecated The `thermo` and `ndim` parameters will be removed after %Cantera 3.0.
      *     The ThermoPhase object should be specifed when calling the `init` method.
      */
     WaterTransport(ThermoPhase* thermo = 0, int ndim = -1);

--- a/include/cantera/zeroD/ConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/ConstPressureMoleReactor.h
@@ -14,7 +14,7 @@ namespace Cantera
 /*!
  * ConstPressureMoleReactor is a class for constant-pressure reactors
  * which use a state of moles.
- * @since New in Cantera 3.0
+ * @since New in %Cantera 3.0
  * @ingroup reactorGroup
  */
 class ConstPressureMoleReactor : public MoleReactor

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -83,7 +83,7 @@ public:
      * coefficient set by a flow device specific function; unless a user-defined
      * pressure function is set, this is the pressure difference across the device.
      * The calculation of mass flow rate depends to the flow device.
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     double evalPressureFunction();
 
@@ -97,7 +97,7 @@ public:
      * The mass flow rate [kg/s] is calculated for a Flow device, and multiplied by a
      * function of time, which returns 1.0 unless a user-defined function is provided.
      * The calculation of mass flow rate depends on the flow device.
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     double evalTimeFunction();
 
@@ -108,7 +108,7 @@ public:
 
     //! Set current reactor network time
     /*!
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     void setSimTime(double time) {
         m_time = time;

--- a/include/cantera/zeroD/FlowDeviceFactory.h
+++ b/include/cantera/zeroD/FlowDeviceFactory.h
@@ -29,7 +29,7 @@ public:
     //! Create a new flow device by type name.
     /*!
      * @param flowDeviceType the type to be created.
-     * @deprecated  To be removed after Cantera 3.0; replaceable by newFlowDevice3.
+     * @deprecated To be removed after %Cantera 3.0; replaceable by newFlowDevice3.
      */
     virtual FlowDevice* newFlowDevice(const std::string& flowDeviceType);
 

--- a/include/cantera/zeroD/FlowReactor.h
+++ b/include/cantera/zeroD/FlowReactor.h
@@ -62,7 +62,7 @@ public:
         return m_area;
     }
 
-    //! @deprecated To be removed after Cantera 3.0. Access distance through the
+    //! @deprecated To be removed after %Cantera 3.0. Access distance through the
     //!     ReactorNet object
     double distance() const;
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -233,7 +233,7 @@ public:
     //! @warning  This method is an experimental part of the %Cantera
     //! API and may be changed or removed without notice.
     //!
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     //!
     virtual bool preconditionerSupported() const {return false;};
 

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -29,7 +29,7 @@ public:
     //! Create a new reactor by type name.
     /*!
      * @param reactorType the type to be created.
-     * @deprecated  To be removed after Cantera 3.0; replaceable by newReactor3.
+     * @deprecated To be removed after %Cantera 3.0; replaceable by newReactor3.
      */
     virtual ReactorBase* newReactor(const std::string& reactorType);
 
@@ -51,7 +51,7 @@ private:
 //! @{
 
 //! Create a Reactor object of the specified type
-//! @deprecated  To be changed after %Cantera 3.0; for new behavior, see newReactor3().
+//! @deprecated To be changed after %Cantera 3.0; for new behavior, see newReactor3().
 ReactorBase* newReactor(const string& model);
 
 //! Create a Reactor object of the specified type

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -53,7 +53,7 @@ public:
 
     //! Get the initial value of the independent variable (typically time).
     /*!
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     double getInitialTime() const {
         return m_initial_time;

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -40,7 +40,7 @@ public:
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
      * does nothing (that is, constant volume), but may be overloaded.
-     * @deprecated To be removed after Cantera 3.0; replaceable by expansionRate.
+     * @deprecated To be removed after %Cantera 3.0; replaceable by expansionRate.
      */
     virtual double vdot(double t) {
         warn_deprecated("WallBase::vdot",
@@ -53,7 +53,7 @@ public:
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
      * does nothing (that is, constant volume), but may be overloaded.
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual double expansionRate() {
         return 0.0;
@@ -63,7 +63,7 @@ public:
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
      * does nothing (that is, an adiabatic wall), but may be overloaded.
-     * @deprecated To be removed after Cantera 3.0; replaceable by heatRate.
+     * @deprecated To be removed after %Cantera 3.0; replaceable by heatRate.
      */
     virtual double Q(double t) {
         warn_deprecated("WallBase::Q",
@@ -75,7 +75,7 @@ public:
     /*!
      * This method is called by Reactor::evalWalls(). Base class method
      * does nothing (that is, an adiabatic wall), but may be overloaded.
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual double heatRate() {
         return 0.0;
@@ -112,7 +112,7 @@ public:
 
     //! Set current reactor network time
     /*!
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     void setSimTime(double time) {
         m_time = time;
@@ -148,7 +148,7 @@ public:
     }
 
     //! Wall velocity \f$ v(t) \f$ at current reactor network time.
-    //! @since New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     double velocity() const;
 
     //! Set the wall velocity to a specified function of time, \f$ v(t) \f$.
@@ -183,12 +183,12 @@ public:
      * and and *F(t)* is a specified function evaluated at the current network time.
      * Positive values for `expansionRate` correspond to increases in the volume of
      * reactor on left, and decreases in the volume of the reactor on the right.
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual double expansionRate();
 
     //! Heat flux function \f$ q_0(t) \f$ evaluated at current reactor network time.
-    //! @since New in Cantera 3.0.
+    //! @since New in %Cantera 3.0.
     double heatFlux() const;
 
     //! Specify the heat flux function \f$ q_0(t) \f$.
@@ -218,7 +218,7 @@ public:
      * where *h* is the heat transfer coefficient, *A* is the wall area, and
      * *G(t)* is a specified function of time evaluated at the current network
      * time. Positive values denote a flux from left to right.
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     virtual double heatRate();
 

--- a/include/cantera/zeroD/WallFactory.h
+++ b/include/cantera/zeroD/WallFactory.h
@@ -29,7 +29,7 @@ public:
     //! Create a new wall by type name.
     /*!
      * @param wallType the type to be created.
-     * @deprecated  To be removed after Cantera 3.0; replaceable by newWall3.
+     * @deprecated To be removed after %Cantera 3.0; replaceable by newWall3.
      */
     virtual WallBase* newWall(const std::string& wallType);
 
@@ -51,7 +51,7 @@ private:
 //! @{
 
 //! Create a WallBase object of the specified type
-//! @deprecated  To be changed after %Cantera 3.0; for new behavior, see newWall3().
+//! @deprecated To be changed after %Cantera 3.0; for new behavior, see newWall3().
 WallBase* newWall(const string& model);
 
 //! Create a WallBase object of the specified type

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -77,7 +77,7 @@ public:
 
     //! Set the primary mass flow controller.
     /*!
-     * @since New in Cantera 3.0.
+     * @since New in %Cantera 3.0.
      */
     void setPrimary(FlowDevice* primary) {
         m_primary = primary;

--- a/samples/cxx/bvp/BoundaryValueProblem.h
+++ b/samples/cxx/bvp/BoundaryValueProblem.h
@@ -1,6 +1,6 @@
 /**
  *  @file BoundaryValueProblem.h
- *  Simplified interface to the capabilities provided by Cantera to
+ *  Simplified interface to the capabilities provided by %Cantera to
  *  solve boundary value problems.
  */
 

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -19,10 +19,10 @@ namespace Cantera
 /*!
  * @defgroup globalData Global Data
  *
- * Global data are available anywhere. There are two kinds. Cantera has an
+ * Global data are available anywhere. There are two kinds. %Cantera has an
  * assortment of constant values for physical parameters. Also, Cantera
  * maintains a collection of global data which is specific to each process that
- * invokes Cantera functions. This process-specific data is stored in the class
+ * invokes %Cantera functions. This process-specific data is stored in the class
  * Application.
  */
 
@@ -54,7 +54,7 @@ protected:
         //! throwing an exception.
         /*!
          * This routine adds an error message to the end of the stack of errors
-         * that Cantera accumulates in the Application class.
+         * that %Cantera accumulates in the Application class.
          * @param r    Procedure name which is generating the error condition
          * @param msg  Descriptive message of the error condition.
          *
@@ -92,7 +92,7 @@ protected:
         //!  Prints all of the error messages to an ostream
         /*!
          * Write out all of the saved error messages to the ostream f using
-         * the function Logger::writelog. Cantera saves a stack of exceptions
+         * the function Logger::writelog. %Cantera saves a stack of exceptions
          * that it has caught in the Application class. This routine writes
          * out all of the error messages to the ostream and then clears them
          * from internal storage.
@@ -117,11 +117,11 @@ protected:
         //!  Write a message to the screen.
         /*!
          * The string may be of any length, and may contain end-of-line
-         * characters. This method is used throughout Cantera to write log
+         * characters. This method is used throughout %Cantera to write log
          * messages. It can also be called by user programs.  The advantage of
          * using writelog over writing directly to the standard output is that
          * messages written with writelog will display correctly even when
-         * Cantera is used from MATLAB or other application that do not have a
+         * %Cantera is used from MATLAB or other application that do not have a
          * standard output stream.
          *
          * @param msg  c++ string to be written to the screen
@@ -266,10 +266,10 @@ public:
      */
     std::string findInputFile(const std::string& name);
 
-    //! Get the Cantera data directories
+    //! Get the %Cantera data directories
     /*!
      * This routine returns a string including the names of all the
-     * directories searched by Cantera for data files.
+     * directories searched by %Cantera for data files.
      *
      * @param sep Separator to use between directories in the string
      * @return A string of directories separated by the input sep
@@ -287,13 +287,13 @@ public:
     //!     parameter depends on the specific extension interface. For example, for
     //!     Python extensions, this is the name of the Python module containing the
     //!     models.
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void loadExtension(const std::string& extType, const std::string& name);
 
     //! Set the versions of Python to try when loading user-defined extensions,
     //! in order of preference. Separate multiple versions with commas, for example
     //! `"3.11,3.10"`.
-    //! @since New in Cantera 3.0
+    //! @since New in %Cantera 3.0
     void searchPythonVersions(const string& versions);
 
 #ifdef _WIN32
@@ -354,7 +354,7 @@ public:
         return m_suppress_warnings;
     }
 
-    //! Turns Cantera warnings into exceptions. Activated within the test
+    //! Turns %Cantera warnings into exceptions. Activated within the test
     //! suite to make sure that your warning message are being raised.
     void make_warnings_fatal() {
         m_fatal_warnings = true;
@@ -399,7 +399,7 @@ public:
     /*!
      * Delete the memory allocated per thread by Cantera.  It should be called
      * from within the thread just before the thread terminates.  If your
-     * version of Cantera has not been specifically compiled for thread safety
+     * version of %Cantera has not been specifically compiled for thread safety
      * this function does nothing.
      */
     void thread_complete();
@@ -414,7 +414,7 @@ protected:
      * be called by user programs.
      *
      * The current directory (".") is always searched first. Then, on Windows, the
-     * registry is checked to find the Cantera installation directory, and the
+     * registry is checked to find the %Cantera installation directory, and the
      * 'data' subdirectory of the installation directory will be added to the search
      * path.
      *

--- a/src/base/clockWC.cpp
+++ b/src/base/clockWC.cpp
@@ -1,7 +1,7 @@
 /**
  * @file clockWC.cpp
  *    Definitions for a simple class that implements an Ansi C wall clock timer
- *     (see \ref Cantera::clockWC).
+ *     (see @ref Cantera::clockWC).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -18,7 +18,7 @@ namespace Cantera {
  * Template for classes to hold pointers to objects. The SharedCabinet<M> class
  * maintains a list of pointers to objects of class M (or of subclasses of M). These
  * classes are used by the 'clib' interface library functions that provide access to
- * Cantera C++ objects from outside C++. To refer to an existing object, the library
+ * %Cantera C++ objects from outside C++. To refer to an existing object, the library
  * functions take an integer argument that specifies the location in the pointer list
  * maintained by the appropriate SharedCabinet<M> instance. The pointer is retrieved
  * from the list by the interface function, the desired method is invoked, and the

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -1,6 +1,6 @@
 /**
  * @file MultiPhase.cpp
- * Definitions for the \link Cantera::MultiPhase MultiPhase\endlink
+ * Definitions for the @link Cantera::MultiPhase MultiPhase@endlink
  * object that is used to set up multiphase equilibrium problems (see @ref equilGroup).
  */
 

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -1,7 +1,7 @@
 /**
  * @file MultiPhase.cpp
  * Definitions for the \link Cantera::MultiPhase MultiPhase\endlink
- * object that is used to set up multiphase equilibrium problems (see \ref equilGroup).
+ * object that is used to set up multiphase equilibrium problems (see @ref equilGroup).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file ImplicitSurfChem.cpp
  * Definitions for the implicit integration of surface site density equations
- *  (see \ref  kineticsmgr and class
+ *  (see @ref  kineticsmgr and class
  *  \link Cantera::ImplicitSurfChem ImplicitSurfChem\endlink).
  */
 

--- a/src/kinetics/ImplicitSurfChem.cpp
+++ b/src/kinetics/ImplicitSurfChem.cpp
@@ -2,7 +2,7 @@
  *  @file ImplicitSurfChem.cpp
  * Definitions for the implicit integration of surface site density equations
  *  (see @ref  kineticsmgr and class
- *  \link Cantera::ImplicitSurfChem ImplicitSurfChem\endlink).
+ *  @link Cantera::ImplicitSurfChem ImplicitSurfChem@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -1,6 +1,6 @@
 /**
  *  @file Kinetics.cpp Declarations for the base class for kinetics managers
- *      (see \ref  kineticsmgr and class \link Cantera::Kinetics  Kinetics \endlink).
+ *      (see @ref  kineticsmgr and class \link Cantera::Kinetics  Kinetics \endlink).
  *
  *  Kinetics managers calculate rates of progress of species due to
  *  homogeneous or heterogeneous kinetics.

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -1,6 +1,6 @@
 /**
  *  @file Kinetics.cpp Declarations for the base class for kinetics managers
- *      (see @ref  kineticsmgr and class \link Cantera::Kinetics  Kinetics \endlink).
+ *      (see @ref  kineticsmgr and class @link Cantera::Kinetics  Kinetics @endlink).
  *
  *  Kinetics managers calculate rates of progress of species due to
  *  homogeneous or heterogeneous kinetics.

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -2,7 +2,7 @@
  *  @file BinarySolutionTabulatedThermo.cpp Implementation file for an binary
  *      solution model with tabulated standard state thermodynamic data (see
  *       @ref thermoprops and class
- *       \link Cantera::BinarySolutionTabulatedThermo BinarySolutionTabulatedThermo\endlink).
+ *       @link Cantera::BinarySolutionTabulatedThermo BinarySolutionTabulatedThermo@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/BinarySolutionTabulatedThermo.cpp
+++ b/src/thermo/BinarySolutionTabulatedThermo.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file BinarySolutionTabulatedThermo.cpp Implementation file for an binary
  *      solution model with tabulated standard state thermodynamic data (see
- *       \ref thermoprops and class
+ *       @ref thermoprops and class
  *       \link Cantera::BinarySolutionTabulatedThermo BinarySolutionTabulatedThermo\endlink).
  */
 

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file ConstCpPoly.cpp
  * Declarations for the \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType \endlink object that
- * employs a constant heat capacity assumption (see \ref spthermo and
+ * employs a constant heat capacity assumption (see @ref spthermo and
  * \link Cantera::ConstCpPoly ConstCpPoly \endlink).
  */
 

--- a/src/thermo/ConstCpPoly.cpp
+++ b/src/thermo/ConstCpPoly.cpp
@@ -1,8 +1,8 @@
 /**
  *  @file ConstCpPoly.cpp
- * Declarations for the \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType \endlink object that
+ * Declarations for the @link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType @endlink object that
  * employs a constant heat capacity assumption (see @ref spthermo and
- * \link Cantera::ConstCpPoly ConstCpPoly \endlink).
+ * @link Cantera::ConstCpPoly ConstCpPoly @endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -3,7 +3,7 @@
  *  Definitions for a thermodynamics model of a coverage-dependent surface
  *  phase derived from SurfPhase, applying adsorbate lateral interaction
  *  correction factors to the SurfPhase thermodynamic properties.
- *  (see \ref thermoprops and class
+ *  (see @ref thermoprops and class
  *  \link Cantera::CoverageDependentSurfPhase CoverageDependentSurfPhase\endlink).
  */
 

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -4,7 +4,7 @@
  *  phase derived from SurfPhase, applying adsorbate lateral interaction
  *  correction factors to the SurfPhase thermodynamic properties.
  *  (see @ref thermoprops and class
- *  \link Cantera::CoverageDependentSurfPhase CoverageDependentSurfPhase\endlink).
+ *  @link Cantera::CoverageDependentSurfPhase CoverageDependentSurfPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -2,7 +2,7 @@
  *  @file DebyeHuckel.cpp
  *    Declarations for the DebyeHuckel ThermoPhase object, which models dilute
  *    electrolyte solutions
- *    (see \ref thermoprops and \link Cantera::DebyeHuckel DebyeHuckel \endlink).
+ *    (see @ref thermoprops and \link Cantera::DebyeHuckel DebyeHuckel \endlink).
  *
  * Class DebyeHuckel represents a dilute liquid electrolyte phase which
  * obeys the Debye Huckel formulation for nonideality.

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -2,7 +2,7 @@
  *  @file DebyeHuckel.cpp
  *    Declarations for the DebyeHuckel ThermoPhase object, which models dilute
  *    electrolyte solutions
- *    (see @ref thermoprops and \link Cantera::DebyeHuckel DebyeHuckel \endlink).
+ *    (see @ref thermoprops and @link Cantera::DebyeHuckel DebyeHuckel @endlink).
  *
  * Class DebyeHuckel represents a dilute liquid electrolyte phase which
  * obeys the Debye Huckel formulation for nonideality.

--- a/src/thermo/Elements.cpp
+++ b/src/thermo/Elements.cpp
@@ -57,7 +57,7 @@ struct isotopeWeightData {
 
 /*!
  * @var static vector<atomicWeightData> atomicWeightTable
- * \brief atomicWeightTable is a vector containing the atomic weights database.
+ * @brief atomicWeightTable is a vector containing the atomic weights database.
  *
  * atomicWeightTable is a static variable with scope limited to this file.
  * It can only be referenced via the functions in this file.
@@ -187,7 +187,7 @@ static vector<atomicWeightData> atomicWeightTable {
 
 /*!
  * @var static vector<isotopeWeightData> isotopeWeightTable
- * \brief isotopeWeightTable is a vector containing the atomic weights database.
+ * @brief isotopeWeightTable is a vector containing the atomic weights database.
  *
  * isotopeWeightTable is a static variable with scope limited to this file.
  * It can only be referenced via the functions in this file.

--- a/src/thermo/GibbsExcessVPSSTP.cpp
+++ b/src/thermo/GibbsExcessVPSSTP.cpp
@@ -2,7 +2,7 @@
  *  @file GibbsExcessVPSSTP.cpp
  *   Definitions for intermediate ThermoPhase object for phases which
  *   employ excess Gibbs free energy formulations
- *  (see @ref thermoprops and class \link Cantera::GibbsExcessVPSSTP GibbsExcessVPSSTP\endlink).
+ *  (see @ref thermoprops and class @link Cantera::GibbsExcessVPSSTP GibbsExcessVPSSTP@endlink).
  *
  * Header file for a derived class of ThermoPhase that handles variable pressure
  * standard state methods for calculating thermodynamic properties that are

--- a/src/thermo/GibbsExcessVPSSTP.cpp
+++ b/src/thermo/GibbsExcessVPSSTP.cpp
@@ -2,7 +2,7 @@
  *  @file GibbsExcessVPSSTP.cpp
  *   Definitions for intermediate ThermoPhase object for phases which
  *   employ excess Gibbs free energy formulations
- *  (see \ref thermoprops and class \link Cantera::GibbsExcessVPSSTP GibbsExcessVPSSTP\endlink).
+ *  (see @ref thermoprops and class \link Cantera::GibbsExcessVPSSTP GibbsExcessVPSSTP\endlink).
  *
  * Header file for a derived class of ThermoPhase that handles variable pressure
  * standard state methods for calculating thermodynamic properties that are

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -2,7 +2,7 @@
  *  @file HMWSoln.cpp
  *    Definitions for the HMWSoln ThermoPhase object, which
  *    models concentrated electrolyte solutions
- *    (see @ref thermoprops and \link Cantera::HMWSoln HMWSoln \endlink) .
+ *    (see @ref thermoprops and @link Cantera::HMWSoln HMWSoln @endlink) .
  *
  * Class HMWSoln represents a concentrated liquid electrolyte phase which obeys
  * the Pitzer formulation for nonideality using molality-based standard states.

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -2,7 +2,7 @@
  *  @file HMWSoln.cpp
  *    Definitions for the HMWSoln ThermoPhase object, which
  *    models concentrated electrolyte solutions
- *    (see \ref thermoprops and \link Cantera::HMWSoln HMWSoln \endlink) .
+ *    (see @ref thermoprops and \link Cantera::HMWSoln HMWSoln \endlink) .
  *
  * Class HMWSoln represents a concentrated liquid electrolyte phase which obeys
  * the Pitzer formulation for nonideality using molality-based standard states.

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -2,7 +2,7 @@
  *  @file IdealGasPhase.cpp
  *   ThermoPhase object for the ideal gas equation of
  * state - workhorse for %Cantera (see @ref thermoprops
- * and class \link Cantera::IdealGasPhase IdealGasPhase\endlink).
+ * and class @link Cantera::IdealGasPhase IdealGasPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/IdealGasPhase.cpp
+++ b/src/thermo/IdealGasPhase.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file IdealGasPhase.cpp
  *   ThermoPhase object for the ideal gas equation of
- * state - workhorse for %Cantera (see \ref thermoprops
+ * state - workhorse for %Cantera (see @ref thermoprops
  * and class \link Cantera::IdealGasPhase IdealGasPhase\endlink).
  */
 

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file IdealMolalSoln.cpp
  *   ThermoPhase object for the ideal molal equation of
- * state (see \ref thermoprops
+ * state (see @ref thermoprops
  * and class \link Cantera::IdealMolalSoln IdealMolalSoln\endlink).
  *
  * Definition file for a derived class of ThermoPhase that handles variable

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -2,7 +2,7 @@
  *  @file IdealMolalSoln.cpp
  *   ThermoPhase object for the ideal molal equation of
  * state (see @ref thermoprops
- * and class \link Cantera::IdealMolalSoln IdealMolalSoln\endlink).
+ * and class @link Cantera::IdealMolalSoln IdealMolalSoln@endlink).
  *
  * Definition file for a derived class of ThermoPhase that handles variable
  * pressure standard state methods for calculating thermodynamic properties that

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -1,6 +1,6 @@
 /**
  *  @file IdealSolidSolnPhase.cpp Implementation file for an ideal solid
- *      solution model with incompressible thermodynamics (see \ref
+ *      solution model with incompressible thermodynamics (see @ref
  *      thermoprops and \link Cantera::IdealSolidSolnPhase
  *      IdealSolidSolnPhase\endlink).
  */
@@ -392,7 +392,7 @@ void IdealSolidSolnPhase::getSpeciesParameters(const std::string &name,
 void IdealSolidSolnPhase::setToEquilState(const doublereal* mu_RT)
 {
     const vector_fp& grt = gibbs_RT_ref();
-    
+
     // Within the method, we protect against inf results if the exponent is too
     // high.
     //

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -1,8 +1,8 @@
 /**
  *  @file IdealSolidSolnPhase.cpp Implementation file for an ideal solid
  *      solution model with incompressible thermodynamics (see @ref
- *      thermoprops and \link Cantera::IdealSolidSolnPhase
- *      IdealSolidSolnPhase\endlink).
+ *      thermoprops and @link Cantera::IdealSolidSolnPhase
+ *      IdealSolidSolnPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -3,7 +3,7 @@
  * Definition file for a derived class of ThermoPhase that assumes
  * an ideal solution approximation and handles
  * variable pressure standard state methods for calculating
- * thermodynamic properties (see \ref thermoprops and
+ * thermodynamic properties (see @ref thermoprops and
  * class \link Cantera::IdealSolnGasVPSS IdealSolnGasVPSS\endlink).
  */
 

--- a/src/thermo/IdealSolnGasVPSS.cpp
+++ b/src/thermo/IdealSolnGasVPSS.cpp
@@ -4,7 +4,7 @@
  * an ideal solution approximation and handles
  * variable pressure standard state methods for calculating
  * thermodynamic properties (see @ref thermoprops and
- * class \link Cantera::IdealSolnGasVPSS IdealSolnGasVPSS\endlink).
+ * class @link Cantera::IdealSolnGasVPSS IdealSolnGasVPSS@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -2,7 +2,7 @@
  *  @file IonsFromNeutralVPSSTP.cpp
  *   Definitions for the object which treats ionic liquids as made of ions as species
  *   even though the thermodynamics is obtained from the neutral molecule representation.
- *  (see \ref thermoprops
+ *  (see @ref thermoprops
  *   and class \link Cantera::IonsFromNeutralVPSSTP IonsFromNeutralVPSSTP\endlink).
  *
  * Header file for a derived class of ThermoPhase that handles variable pressure

--- a/src/thermo/IonsFromNeutralVPSSTP.cpp
+++ b/src/thermo/IonsFromNeutralVPSSTP.cpp
@@ -3,7 +3,7 @@
  *   Definitions for the object which treats ionic liquids as made of ions as species
  *   even though the thermodynamics is obtained from the neutral molecule representation.
  *  (see @ref thermoprops
- *   and class \link Cantera::IonsFromNeutralVPSSTP IonsFromNeutralVPSSTP\endlink).
+ *   and class @link Cantera::IonsFromNeutralVPSSTP IonsFromNeutralVPSSTP@endlink).
  *
  * Header file for a derived class of ThermoPhase that handles variable pressure
  * standard state methods for calculating thermodynamic properties that are

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -3,7 +3,7 @@
  *  Definitions for a simple thermodynamics model of a bulk phase
  *  derived from ThermoPhase,
  *  assuming a lattice of solid atoms
- *  (see @ref thermoprops and class \link Cantera::LatticePhase LatticePhase\endlink).
+ *  (see @ref thermoprops and class @link Cantera::LatticePhase LatticePhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -3,7 +3,7 @@
  *  Definitions for a simple thermodynamics model of a bulk phase
  *  derived from ThermoPhase,
  *  assuming a lattice of solid atoms
- *  (see \ref thermoprops and class \link Cantera::LatticePhase LatticePhase\endlink).
+ *  (see @ref thermoprops and class \link Cantera::LatticePhase LatticePhase\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -3,7 +3,7 @@
  *  Definitions for a simple thermodynamics model of a bulk solid phase
  *  derived from ThermoPhase,
  *  assuming an ideal solution model based on a lattice of solid atoms
- *  (see @ref thermoprops and class \link Cantera::LatticeSolidPhase LatticeSolidPhase\endlink).
+ *  (see @ref thermoprops and class @link Cantera::LatticeSolidPhase LatticeSolidPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -3,7 +3,7 @@
  *  Definitions for a simple thermodynamics model of a bulk solid phase
  *  derived from ThermoPhase,
  *  assuming an ideal solution model based on a lattice of solid atoms
- *  (see \ref thermoprops and class \link Cantera::LatticeSolidPhase LatticeSolidPhase\endlink).
+ *  (see @ref thermoprops and class \link Cantera::LatticeSolidPhase LatticeSolidPhase\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -3,7 +3,7 @@
  *   Definitions for ThermoPhase object for phases which
  *   employ excess Gibbs free energy formulations related to Margules
  *   expansions (see @ref thermoprops
- *    and class \link Cantera::MargulesVPSSTP MargulesVPSSTP\endlink).
+ *    and class @link Cantera::MargulesVPSSTP MargulesVPSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -2,7 +2,7 @@
  *  @file MargulesVPSSTP.cpp
  *   Definitions for ThermoPhase object for phases which
  *   employ excess Gibbs free energy formulations related to Margules
- *   expansions (see \ref thermoprops
+ *   expansions (see @ref thermoprops
  *    and class \link Cantera::MargulesVPSSTP MargulesVPSSTP\endlink).
  */
 

--- a/src/thermo/MaskellSolidSolnPhase.cpp
+++ b/src/thermo/MaskellSolidSolnPhase.cpp
@@ -1,6 +1,6 @@
 /**
  *  @file MaskellSolidSolnPhase.cpp Implementation file for an ideal solid
- *      solution model with incompressible thermodynamics (see \ref
+ *      solution model with incompressible thermodynamics (see @ref
  *      thermoprops and \link Cantera::MaskellSolidSolnPhase
  *      MaskellSolidSolnPhase\endlink).
  */

--- a/src/thermo/MaskellSolidSolnPhase.cpp
+++ b/src/thermo/MaskellSolidSolnPhase.cpp
@@ -1,8 +1,8 @@
 /**
  *  @file MaskellSolidSolnPhase.cpp Implementation file for an ideal solid
  *      solution model with incompressible thermodynamics (see @ref
- *      thermoprops and \link Cantera::MaskellSolidSolnPhase
- *      MaskellSolidSolnPhase\endlink).
+ *      thermoprops and @link Cantera::MaskellSolidSolnPhase
+ *      MaskellSolidSolnPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file MixtureFugacityTP.cpp
  *    Methods file for a derived class of ThermoPhase that handles
- *    non-ideal mixtures based on the fugacity models (see \ref thermoprops and
+ *    non-ideal mixtures based on the fugacity models (see @ref thermoprops and
  *    class \link Cantera::MixtureFugacityTP MixtureFugacityTP\endlink).
  */
 

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -2,7 +2,7 @@
  *  @file MixtureFugacityTP.cpp
  *    Methods file for a derived class of ThermoPhase that handles
  *    non-ideal mixtures based on the fugacity models (see @ref thermoprops and
- *    class \link Cantera::MixtureFugacityTP MixtureFugacityTP\endlink).
+ *    class @link Cantera::MixtureFugacityTP MixtureFugacityTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -3,7 +3,7 @@
  *   Definitions for intermediate ThermoPhase object for phases which
  *   employ molality based activity coefficient formulations
  *  (see @ref thermoprops
- * and class \link Cantera::MolalityVPSSTP MolalityVPSSTP\endlink).
+ * and class @link Cantera::MolalityVPSSTP MolalityVPSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/MolalityVPSSTP.cpp
+++ b/src/thermo/MolalityVPSSTP.cpp
@@ -2,7 +2,7 @@
  *  @file MolalityVPSSTP.cpp
  *   Definitions for intermediate ThermoPhase object for phases which
  *   employ molality based activity coefficient formulations
- *  (see \ref thermoprops
+ *  (see @ref thermoprops
  * and class \link Cantera::MolalityVPSSTP MolalityVPSSTP\endlink).
  */
 

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -1,9 +1,9 @@
 /**
  *  @file Mu0Poly.cpp
  *  Definitions for a single-species standard state object derived
- *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
+ *  from @link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType@endlink  based
  *  on a piecewise constant mu0 interpolation
- *  (see @ref spthermo and class \link Cantera::Mu0Poly Mu0Poly\endlink).
+ *  (see @ref spthermo and class @link Cantera::Mu0Poly Mu0Poly@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/Mu0Poly.cpp
+++ b/src/thermo/Mu0Poly.cpp
@@ -3,7 +3,7 @@
  *  Definitions for a single-species standard state object derived
  *  from \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink  based
  *  on a piecewise constant mu0 interpolation
- *  (see \ref spthermo and class \link Cantera::Mu0Poly Mu0Poly\endlink).
+ *  (see @ref spthermo and class \link Cantera::Mu0Poly Mu0Poly\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/MultiSpeciesThermo.cpp
+++ b/src/thermo/MultiSpeciesThermo.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file MultiSpeciesThermo.cpp
  *  Declarations for a thermodynamic property manager for multiple species
- *  in a phase (see \ref spthermo and
+ *  in a phase (see @ref spthermo and
  * \link Cantera::MultiSpeciesThermo MultiSpeciesThermo\endlink).
  */
 

--- a/src/thermo/MultiSpeciesThermo.cpp
+++ b/src/thermo/MultiSpeciesThermo.cpp
@@ -2,7 +2,7 @@
  *  @file MultiSpeciesThermo.cpp
  *  Declarations for a thermodynamic property manager for multiple species
  *  in a phase (see @ref spthermo and
- * \link Cantera::MultiSpeciesThermo MultiSpeciesThermo\endlink).
+ * @link Cantera::MultiSpeciesThermo MultiSpeciesThermo@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/Nasa9Poly1.cpp
+++ b/src/thermo/Nasa9Poly1.cpp
@@ -1,10 +1,10 @@
 /**
  * @file Nasa9Poly1.cpp Definitions for a single-species standard state object
  *     derived from
- * \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink based
+ * @link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType@endlink based
  * on the NASA 9 coefficient temperature polynomial form applied to one
- * temperature region (see @ref spthermo and class \link Cantera::Nasa9Poly1
- * Nasa9Poly1\endlink).
+ * temperature region (see @ref spthermo and class @link Cantera::Nasa9Poly1
+ * Nasa9Poly1@endlink).
  *
  * This parameterization has one NASA temperature region.
  */

--- a/src/thermo/Nasa9Poly1.cpp
+++ b/src/thermo/Nasa9Poly1.cpp
@@ -3,7 +3,7 @@
  *     derived from
  * \link Cantera::SpeciesThermoInterpType SpeciesThermoInterpType\endlink based
  * on the NASA 9 coefficient temperature polynomial form applied to one
- * temperature region (see \ref spthermo and class \link Cantera::Nasa9Poly1
+ * temperature region (see @ref spthermo and class \link Cantera::Nasa9Poly1
  * Nasa9Poly1\endlink).
  *
  * This parameterization has one NASA temperature region.

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -5,7 +5,7 @@
  *    SpeciesThermoInterpType\endlink  based
  *  on the NASA 9 coefficient temperature polynomial form
  *  applied to one temperature region
- *  (see \ref spthermo and class
+ *  (see @ref spthermo and class
  *   \link Cantera::Nasa9Poly1 Nasa9Poly1\endlink).
  *
  *  This parameterization has one NASA temperature region.

--- a/src/thermo/Nasa9PolyMultiTempRegion.cpp
+++ b/src/thermo/Nasa9PolyMultiTempRegion.cpp
@@ -1,12 +1,12 @@
 /**
  *  @file Nasa9PolyMultiTempRegion.cpp
  *  Definitions for a single-species standard state object derived
- *  from \link Cantera::SpeciesThermoInterpType
- *    SpeciesThermoInterpType\endlink  based
+ *  from @link Cantera::SpeciesThermoInterpType
+ *    SpeciesThermoInterpType@endlink  based
  *  on the NASA 9 coefficient temperature polynomial form
  *  applied to one temperature region
  *  (see @ref spthermo and class
- *   \link Cantera::Nasa9Poly1 Nasa9Poly1\endlink).
+ *   @link Cantera::Nasa9Poly1 Nasa9Poly1@endlink).
  *
  *  This parameterization has one NASA temperature region.
  */

--- a/src/thermo/PDSS.cpp
+++ b/src/thermo/PDSS.cpp
@@ -2,7 +2,7 @@
  * @file PDSS.cpp
  * Implementation of a pressure dependent standard state
  * virtual function
- * (see class \link Cantera::PDSS PDSS\endlink).
+ * (see class @link Cantera::PDSS PDSS@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -3,7 +3,7 @@
  *    Definitions for the class PDSS_HKFT (pressure dependent standard state)
  *    which handles calculations for a single species in a phase using the
  *    HKFT standard state
- *    (see @ref pdssthermo and class \link Cantera::PDSS_HKFT PDSS_HKFT\endlink).
+ *    (see @ref pdssthermo and class @link Cantera::PDSS_HKFT PDSS_HKFT@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/PDSS_HKFT.cpp
+++ b/src/thermo/PDSS_HKFT.cpp
@@ -3,7 +3,7 @@
  *    Definitions for the class PDSS_HKFT (pressure dependent standard state)
  *    which handles calculations for a single species in a phase using the
  *    HKFT standard state
- *    (see \ref pdssthermo and class \link Cantera::PDSS_HKFT PDSS_HKFT\endlink).
+ *    (see @ref pdssthermo and class \link Cantera::PDSS_HKFT PDSS_HKFT\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -1,7 +1,7 @@
 /**
  * @file PureFluidPhase.cpp Definitions for a ThermoPhase object for a pure
  *     fluid phase consisting of gas, liquid, mixed-gas-liquid and supercritical
- *     fluid (see \ref thermoprops and class \link Cantera::PureFluidPhase
+ *     fluid (see @ref thermoprops and class \link Cantera::PureFluidPhase
  *     PureFluidPhase\endlink).
  */
 

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -1,8 +1,8 @@
 /**
  * @file PureFluidPhase.cpp Definitions for a ThermoPhase object for a pure
  *     fluid phase consisting of gas, liquid, mixed-gas-liquid and supercritical
- *     fluid (see @ref thermoprops and class \link Cantera::PureFluidPhase
- *     PureFluidPhase\endlink).
+ *     fluid (see @ref thermoprops and class @link Cantera::PureFluidPhase
+ *     PureFluidPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -3,7 +3,7 @@
  *   Definitions for ThermoPhase object for phases which
  *   employ excess Gibbs free energy formulations related to RedlichKister
  *   expansions (see @ref thermoprops
- *    and class \link Cantera::RedlichKisterVPSSTP RedlichKisterVPSSTP\endlink).
+ *    and class @link Cantera::RedlichKisterVPSSTP RedlichKisterVPSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -2,7 +2,7 @@
  *  @file RedlichKisterVPSSTP.cpp
  *   Definitions for ThermoPhase object for phases which
  *   employ excess Gibbs free energy formulations related to RedlichKister
- *   expansions (see \ref thermoprops
+ *   expansions (see @ref thermoprops
  *    and class \link Cantera::RedlichKisterVPSSTP RedlichKisterVPSSTP\endlink).
  */
 

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -2,7 +2,7 @@
  *  @file SingleSpeciesTP.cpp
  *  Definitions for the SingleSpeciesTP class, which is a filter class for ThermoPhase,
  *  that eases the construction of single species phases
- *  ( see \ref thermoprops and class \link Cantera::SingleSpeciesTP SingleSpeciesTP\endlink).
+ *  ( see @ref thermoprops and class \link Cantera::SingleSpeciesTP SingleSpeciesTP\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/SingleSpeciesTP.cpp
+++ b/src/thermo/SingleSpeciesTP.cpp
@@ -2,7 +2,7 @@
  *  @file SingleSpeciesTP.cpp
  *  Definitions for the SingleSpeciesTP class, which is a filter class for ThermoPhase,
  *  that eases the construction of single species phases
- *  ( see @ref thermoprops and class \link Cantera::SingleSpeciesTP SingleSpeciesTP\endlink).
+ *  ( see @ref thermoprops and class @link Cantera::SingleSpeciesTP SingleSpeciesTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/SpeciesThermoFactory.cpp
+++ b/src/thermo/SpeciesThermoFactory.cpp
@@ -2,7 +2,7 @@
  *  @file SpeciesThermoFactory.cpp
  *    Definitions for factory functions to build instances of classes that
  *    manage the standard-state thermodynamic properties of a set of species
- *    (see \ref spthermo);
+ *    (see @ref spthermo);
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/StoichSubstance.cpp
+++ b/src/thermo/StoichSubstance.cpp
@@ -2,7 +2,7 @@
  *  @file StoichSubstance.cpp
  * Definition file for the StoichSubstance class, which represents a fixed-composition
  * incompressible substance (see @ref thermoprops and
- * class \link Cantera::StoichSubstance StoichSubstance\endlink)
+ * class @link Cantera::StoichSubstance StoichSubstance@endlink)
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/StoichSubstance.cpp
+++ b/src/thermo/StoichSubstance.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file StoichSubstance.cpp
  * Definition file for the StoichSubstance class, which represents a fixed-composition
- * incompressible substance (see \ref thermoprops and
+ * incompressible substance (see @ref thermoprops and
  * class \link Cantera::StoichSubstance StoichSubstance\endlink)
  */
 

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -3,7 +3,7 @@
  *  Definitions for a simple thermodynamic model of a surface phase
  *  derived from ThermoPhase, assuming an ideal solution model
  *  (see @ref thermoprops and class
- *  \link Cantera::SurfPhase SurfPhase\endlink).
+ *  @link Cantera::SurfPhase SurfPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/SurfPhase.cpp
+++ b/src/thermo/SurfPhase.cpp
@@ -2,7 +2,7 @@
  *  @file SurfPhase.cpp
  *  Definitions for a simple thermodynamic model of a surface phase
  *  derived from ThermoPhase, assuming an ideal solution model
- *  (see \ref thermoprops and class
+ *  (see @ref thermoprops and class
  *  \link Cantera::SurfPhase SurfPhase\endlink).
  */
 

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file ThermoFactory.cpp
  *     Definitions for the factory class that can create known ThermoPhase objects
- *     (see \ref thermoprops and class \link Cantera::ThermoFactory ThermoFactory\endlink).
+ *     (see @ref thermoprops and class \link Cantera::ThermoFactory ThermoFactory\endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/ThermoFactory.cpp
+++ b/src/thermo/ThermoFactory.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file ThermoFactory.cpp
  *     Definitions for the factory class that can create known ThermoPhase objects
- *     (see @ref thermoprops and class \link Cantera::ThermoFactory ThermoFactory\endlink).
+ *     (see @ref thermoprops and class @link Cantera::ThermoFactory ThermoFactory@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -2,7 +2,7 @@
  *  @file ThermoPhase.cpp
  * Definition file for class ThermoPhase, the base class for phases with
  * thermodynamic properties
- * (see class \link Cantera::ThermoPhase ThermoPhase\endlink).
+ * (see class @link Cantera::ThermoPhase ThermoPhase@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -3,7 +3,7 @@
  * Definition file for a derived class of ThermoPhase that handles
  * variable pressure standard state methods for calculating
  * thermodynamic properties (see @ref thermoprops and
- * class \link Cantera::VPStandardStateTP VPStandardStateTP\endlink).
+ * class @link Cantera::VPStandardStateTP VPStandardStateTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -2,7 +2,7 @@
  *  @file VPStandardStateTP.cpp
  * Definition file for a derived class of ThermoPhase that handles
  * variable pressure standard state methods for calculating
- * thermodynamic properties (see \ref thermoprops and
+ * thermodynamic properties (see @ref thermoprops and
  * class \link Cantera::VPStandardStateTP VPStandardStateTP\endlink).
  */
 

--- a/src/thermo/WaterPropsIAPWS.cpp
+++ b/src/thermo/WaterPropsIAPWS.cpp
@@ -2,7 +2,7 @@
  * @file WaterPropsIAPWS.cpp
  * Definitions for a class for calculating the equation of state of water
  * from the IAPWS 1995 Formulation based on the steam tables thermodynamic
- * basis (See class \link Cantera::WaterPropsIAPWS WaterPropsIAPWS\endlink).
+ * basis (See class @link Cantera::WaterPropsIAPWS WaterPropsIAPWS@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/WaterPropsIAPWSphi.cpp
+++ b/src/thermo/WaterPropsIAPWSphi.cpp
@@ -1,8 +1,8 @@
 /**
  * @file WaterPropsIAPWSphi.cpp
  * Definitions for Lowest level of the classes which support a real water
- * model (see class \link Cantera::WaterPropsIAPWS WaterPropsIAPWS\endlink and
- * class \link Cantera::WaterPropsIAPWSphi WaterPropsIAPWSphi \endlink).
+ * model (see class @link Cantera::WaterPropsIAPWS WaterPropsIAPWS@endlink and
+ * class @link Cantera::WaterPropsIAPWSphi WaterPropsIAPWSphi @endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or

--- a/src/thermo/WaterPropsIAPWSphi.cpp
+++ b/src/thermo/WaterPropsIAPWSphi.cpp
@@ -28,7 +28,7 @@ using std::fabs;
  * H didn't turn out to be .611872 J/kg, but .611782 J/kg.
  * There may be a slight error here somehow.
  */
-//  \cond
+//  @cond
 static const doublereal ni0[9] = {
     0.0,
     -8.32044648201 - 0.000000001739715,
@@ -346,7 +346,7 @@ static const doublereal Bbetai[2] = {
     +0.3,
     +0.3
 };
-// \endcond
+// @endcond
 
 WaterPropsIAPWSphi::WaterPropsIAPWSphi()
 {

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -1,6 +1,6 @@
 /**
  *  @file WaterSSTP.cpp
- * Definitions for a ThermoPhase class consisting of pure water (see \ref thermoprops
+ * Definitions for a ThermoPhase class consisting of pure water (see @ref thermoprops
  * and class \link Cantera::WaterSSTP WaterSSTP\endlink).
  */
 

--- a/src/thermo/WaterSSTP.cpp
+++ b/src/thermo/WaterSSTP.cpp
@@ -1,7 +1,7 @@
 /**
  *  @file WaterSSTP.cpp
  * Definitions for a ThermoPhase class consisting of pure water (see @ref thermoprops
- * and class \link Cantera::WaterSSTP WaterSSTP\endlink).
+ * and class @link Cantera::WaterSSTP WaterSSTP@endlink).
  */
 
 // This file is part of Cantera. See License.txt in the top-level directory or


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add some Doxygen recommendations to `CONTRIBUTING.md`
- Avoid creating unnecessary links to Cantera namespace
- Use consistent Doxygen `@ref` command (about half of instances used `\ref`)
- Switch from `\` to `@` for less commonly used Doxygen commands

Doxygen supports commands that either start with `\` or `@`. As the former is also used for LaTeX, using the latter will better differentiate syntax. It is noted that this PR does not replace instances of `\f[`/`\f]` and `\f$`, as this would create significantly more churn (see #1558).

As an aside, there is a good "perfectionist" Doxygen style guide [here](http://micro-os-plus.github.io/develop/doxygen-style-guide/). Note that I don't think it makes sense to be this rigid, but it was interesting enough to post a link here.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Partially Cantera/enhancements#179

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
