### PR TITLE
[docs] Differentiate Doxygen from LaTeX commands

### DIFF
--- a/doc/doxygen/thermoprops.dox
+++ b/doc/doxygen/thermoprops.dox
@@ -48,7 +48,7 @@
  *
  *   The first type are those whose underlying species have a reference state associated
  *   with them. The reference state describes the thermodynamic functions for a
- *   species at a single reference pressure, @f$p_0@f$. The thermodynamic functions
+ *   species at a single reference pressure, @f$ p_0 @f$. The thermodynamic functions
  *   are specified via derived objects of the SpeciesThermoInterpType object class, and usually
  *   consist of polynomials in temperature such as the NASA polynomial or the SHOMATE
  *   polynomial.  Calculators for these
@@ -346,14 +346,14 @@
  *  </H3>
  *
  *
- * The activity @f$a_k@f$ and activity coefficient @f$ \gamma_k @f$ of a
+ * The activity @f$ a_k @f$ and activity coefficient @f$ \gamma_k @f$ of a
  * species in solution is related to the chemical potential by
  *
  * @f[
  *    \mu_k = \mu_k^0(T,P) + \hat R T \log a_k.= \mu_k^0(T,P) + \hat R T \log x_k \gamma_k
  * @f]
  *
- * The quantity @f$\mu_k^0(T,P)@f$ is
+ * The quantity @f$ \mu_k^0(T,P) @f$ is
  * the standard chemical potential at unit activity,
  * which depends on the temperature and pressure,
  * but not on the composition. The

--- a/doc/doxygen/thermoprops.dox
+++ b/doc/doxygen/thermoprops.dox
@@ -48,7 +48,7 @@
  *
  *   The first type are those whose underlying species have a reference state associated
  *   with them. The reference state describes the thermodynamic functions for a
- *   species at a single reference pressure, \f$p_0\f$. The thermodynamic functions
+ *   species at a single reference pressure, @f$p_0@f$. The thermodynamic functions
  *   are specified via derived objects of the SpeciesThermoInterpType object class, and usually
  *   consist of polynomials in temperature such as the NASA polynomial or the SHOMATE
  *   polynomial.  Calculators for these
@@ -68,7 +68,7 @@
  *   have any nontrivial examples of these types of phases.
  *   In general, the independent variables that completely describe the state of the
  *   system  for this class are temperature, the
- *   phase density, and \f$ N - 1 \f$ species mole or mass fractions.
+ *   phase density, and @f$ N - 1 @f$ species mole or mass fractions.
  *   Additionally, if the
  *   phase involves charged species, the phase electric potential is an added independent variable.
  *   Examples of the first class of %ThermoPhase functions, which includes the
@@ -291,18 +291,18 @@
  * Treatment of the %Phase Potential and the electrochemical potential of a species
  * </H3>
  *
- *  The electrochemical potential of species k in a phase p, \f$ \zeta_k \f$,
+ *  The electrochemical potential of species k in a phase p, @f$ \zeta_k @f$,
  *  is related to the chemical potential via
  *  the following equation,
  *
- *  \f[
+ *  @f[
  *      \zeta_{k}(T,P) = \mu_{k}(T,P) + z_k \phi_p
- *  \f]
+ *  @f]
  *
- *  where \f$ \nu_k \f$ is the charge of species k, and \f$ \phi_p \f$ is
+ *  where @f$ \nu_k @f$ is the charge of species k, and @f$ \phi_p @f$ is
  *  the electric potential of phase p.
  *
- *  The potential  \f$ \phi_p \f$ is tracked and internally stored within
+ *  The potential  @f$ \phi_p @f$ is tracked and internally stored within
  *  the base %ThermoPhase object. It constitutes a specification of the
  *  internal state of the phase; it's the third state variable, the first
  *  two being temperature and density (or, pressure, for incompressible
@@ -314,9 +314,9 @@
  *  changed by the potential because many phases enforce charge
  *  neutrality:
  *
- *  \f[
+ *  @f[
  *      0 = \sum_k z_k X_k
- *  \f]
+ *  @f]
  *
  *  Whether charge neutrality is necessary for a phase is also specified
  *  within the ThermoPhase object, by the function call
@@ -326,7 +326,7 @@
  *  Cantera::HMWSoln for the proper specification of the chemical potentials.
  *
  *
- *  This equation, when applied to the \f$ \zeta_k \f$ equation described
+ *  This equation, when applied to the @f$ \zeta_k @f$ equation described
  *  above, results in a zero net change in the effective Gibbs free
  *  energy of the phase. However, specific charged species in the phase
  *  may increase or decrease their electrochemical potentials, which will
@@ -346,14 +346,14 @@
  *  </H3>
  *
  *
- * The activity \f$a_k\f$ and activity coefficient \f$ \gamma_k \f$ of a
+ * The activity @f$a_k@f$ and activity coefficient @f$ \gamma_k @f$ of a
  * species in solution is related to the chemical potential by
  *
- * \f[
+ * @f[
  *    \mu_k = \mu_k^0(T,P) + \hat R T \log a_k.= \mu_k^0(T,P) + \hat R T \log x_k \gamma_k
- * \f]
+ * @f]
  *
- * The quantity \f$\mu_k^0(T,P)\f$ is
+ * The quantity @f$\mu_k^0(T,P)@f$ is
  * the standard chemical potential at unit activity,
  * which depends on the temperature and pressure,
  * but not on the composition. The
@@ -361,21 +361,21 @@
  * molality convention, where solute species employ the molality-based
  * activity coefficients:
  *
- * \f[
+ * @f[
  *  \mu_k =  \mu_k^\triangle(T,P) + R T ln(a_k^{\triangle}) =
  *            \mu_k^\triangle(T,P) + R T ln(\gamma_k^{\triangle} \frac{m_k}{m^\triangle})
- * \f]
+ * @f]
  *
  * And, the solvent employs the following convention
- * \f[
+ * @f[
  *    \mu_o = \mu^o_o(T,P) + RT ln(a_o)
- * \f]
+ * @f]
  *
- * where \f$ a_o \f$ is often redefined in terms of the osmotic coefficient \f$ \phi \f$.
+ * where @f$ a_o @f$ is often redefined in terms of the osmotic coefficient @f$ \phi @f$.
  *
- *   \f[
+ *   @f[
  *       \phi = \frac{- ln(a_o)}{\tilde{M}_o \sum_{i \ne o} m_i}
- *   \f]
+ *   @f]
  *
  *  %ThermoPhase classes which employ the molality based convention are all derived
  *  from the MolalityVPSSTP class. See the class description for further information
@@ -418,37 +418,37 @@
  *   however, kinetics is usually expressed in terms of unitless activities,
  *   which most often equate to solid phase mole fractions. In order to
  *   accommodate variability here, %Cantera has come up with the idea
- *   of activity concentrations, \f$ C^a_k \f$. Activity concentrations are the expressions
+ *   of activity concentrations, @f$ C^a_k @f$. Activity concentrations are the expressions
  *   used directly in kinetics expressions.
  *   These activity (or generalized) concentrations are used
  *   by kinetics manager classes to compute the forward and
  *   reverse rates of elementary reactions. Note that they may
  *   or may not have units of concentration --- they might be
  *   partial pressures, mole fractions, or surface coverages,
- *   The activity concentrations for species <I>k</I>, \f$ C^a_k \f$, are
- *   related to the activity for species, k, \f$ a_k \f$,
+ *   The activity concentrations for species <I>k</I>, @f$ C^a_k @f$, are
+ *   related to the activity for species, k, @f$ a_k @f$,
  *   via the following expression:
  *
- *   \f[
+ *   @f[
  *       a_k = C^a_k / C^0_k
- *   \f]
+ *   @f]
  *
- *  \f$ C^0_k \f$ are called standard concentrations. They serve as multiplicative factors
+ *  @f$ C^0_k @f$ are called standard concentrations. They serve as multiplicative factors
  *  between the activities and the generalized concentrations. Standard concentrations
  *  may be different for each species. They may depend on both the temperature
  *  and the pressure. However, they may not depend
  *  on the composition of the phase. For example, for the IdealGasPhase object
  *  the standard concentration is defined as
  *
- *  \f[
+ *  @f[
  *     C^0_k = P/ R T
- *  \f]
+ *  @f]
  *
  *  In many solid phase kinetics problems,
  *
- *   \f[
+ *   @f[
  *     C^0_k = 1.0 ,
- *  \f]
+ *   @f]
  *
  *  is employed making the units for activity concentrations in solids unitless.
  *

--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -77,19 +77,19 @@ const double Sqrt2 = 1.41421356237309504880;
 //! [NIST Reference on Constants, Units, and Uncertainty](https://physics.nist.gov/cuu/Constants/index.html).
 //! @{
 
-//! Avogadro's Number \f$ N_{\mathrm{A}} \f$ [number/kmol]
+//! Avogadro's Number @f$ N_{\mathrm{A}} @f$ [number/kmol]
 const double Avogadro = 6.02214076e26;
 
-//! Boltzmann constant \f$ k \f$ [J/K]
+//! Boltzmann constant @f$ k @f$ [J/K]
 const double Boltzmann = 1.380649e-23;
 
-//! Planck constant \f$ h \f$ [J-s]
+//! Planck constant @f$ h @f$ [J-s]
 const double Planck = 6.62607015e-34;
 
-//! Elementary charge \f$ e \f$ [C]
+//! Elementary charge @f$ e @f$ [C]
 const double ElectronCharge = 1.602176634e-19;
 
-//! Speed of Light in a vacuum \f$ c \f$ [m/s]
+//! Speed of Light in a vacuum @f$ c @f$ [m/s]
 const double lightSpeed = 299792458.0;
 
 //! One atmosphere [Pa]
@@ -104,10 +104,10 @@ const double OneBar = 1.0E5;
 //! These constants are measured and reported by CODATA
 //! @{
 
-//! Fine structure constant \f$ \alpha \f$ []
+//! Fine structure constant @f$ \alpha @f$ []
 const double fineStructureConstant = 7.2973525693e-3;
 
-//! Electron Mass \f$ m_e \f$ [kg]
+//! Electron Mass @f$ m_e @f$ [kg]
 const double ElectronMass = 9.1093837015e-31;
 
 //! @}
@@ -116,7 +116,7 @@ const double ElectronMass = 9.1093837015e-31;
 //! These constants are found from the defined and measured constants
 //! @{
 
-//! Universal Gas Constant \f$ R_u \f$ [J/kmol/K]
+//! Universal Gas Constant @f$ R_u @f$ [J/kmol/K]
 const double GasConstant = Avogadro * Boltzmann;
 
 const double logGasConstant = std::log(GasConstant);
@@ -124,16 +124,16 @@ const double logGasConstant = std::log(GasConstant);
 //! Universal gas constant in cal/mol/K
 const double GasConst_cal_mol_K = GasConstant / 4184.0;
 
-//! Stefan-Boltzmann constant \f$ \sigma \f$ [W/m2/K4]
+//! Stefan-Boltzmann constant @f$ \sigma @f$ [W/m2/K4]
 const double StefanBoltz = 2.0 * std::pow(Pi, 5) * std::pow(Boltzmann, 4) / (15.0 * std::pow(Planck, 3) * lightSpeed * lightSpeed); // 5.670374419e-8
 
-//! Faraday constant \f$ F \f$ [C/kmol]
+//! Faraday constant @f$ F @f$ [C/kmol]
 const double Faraday = ElectronCharge * Avogadro;
 
-//! Permeability of free space \f$ \mu_0 \f$ [N/A2]
+//! Permeability of free space @f$ \mu_0 @f$ [N/A2]
 const double permeability_0 = 2 * fineStructureConstant * Planck / (ElectronCharge * ElectronCharge * lightSpeed);
 
-//! Permittivity of free space \f$ \varepsilon_0 \f$ [F/m]
+//! Permittivity of free space @f$ \varepsilon_0 @f$ [F/m]
 const double epsilon_0 = 1.0 / (lightSpeed * lightSpeed * permeability_0);
 
 //! @}

--- a/include/cantera/equil/ChemEquil.h
+++ b/include/cantera/equil/ChemEquil.h
@@ -152,7 +152,7 @@ protected:
      *
      * @param s mixture to be updated
      * @param x vector of non-dimensional element potentials
-     * \f[ \lambda_m/RT \f].
+     * @f[ \lambda_m/RT @f].
      * @param t temperature in K.
      */
     void setToEquilState(ThermoPhase& s,

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -259,7 +259,7 @@ public:
 
     //! Charge (Coulombs) of phase with index \a p.
     /*!
-     *  The net charge is computed as \f[ Q_p = N_p \sum_k F z_k X_k \f]
+     *  The net charge is computed as @f[ Q_p = N_p \sum_k F z_k X_k @f]
      *  where the sum runs only over species in phase \a p.
      *  @param p index of the phase for which the charge is desired.
      */
@@ -276,9 +276,9 @@ public:
      * Write into array \a mu the chemical potentials of all species
      * [J/kmol]. The chemical potentials are related to the activities by
      *
-     * \f$
+     * @f$
      *          \mu_k = \mu_k^0(T, P) + RT \ln a_k.
-     * \f$.
+     * @f$.
      *
      * @param mu Chemical potential vector. Length = num global species. Units
      *           = J/kmol.
@@ -550,7 +550,7 @@ private:
     //! MultiPhaseEquil solver.
     /*!
      * @param XY   Integer flag specifying properties to hold fixed.
-     * @param err  Error tolerance for \f$\Delta \mu/RT \f$ for all reactions.
+     * @param err  Error tolerance for @f$\Delta \mu/RT @f$ for all reactions.
      *             Also used as the relative error tolerance for the outer loop.
      * @param maxsteps Maximum number of steps to take in solving the fixed TP
      *                 problem.

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -550,7 +550,7 @@ private:
     //! MultiPhaseEquil solver.
     /*!
      * @param XY   Integer flag specifying properties to hold fixed.
-     * @param err  Error tolerance for @f$\Delta \mu/RT @f$ for all reactions.
+     * @param err  Error tolerance for @f$ \Delta \mu/RT @f$ for all reactions.
      *             Also used as the relative error tolerance for the outer loop.
      * @param maxsteps Maximum number of steps to take in solving the fixed TP
      *                 problem.

--- a/include/cantera/equil/MultiPhaseEquil.h
+++ b/include/cantera/equil/MultiPhaseEquil.h
@@ -109,7 +109,7 @@ protected:
     //! Estimate the initial mole numbers. This is done by running each
     //! reaction as far forward or backward as possible, subject to the
     //! constraint that all mole numbers remain non-negative. Reactions for
-    //! which \f$ \Delta \mu^0 \f$ are positive are run in reverse, and ones
+    //! which @f$ \Delta \mu^0 @f$ are positive are run in reverse, and ones
     //! for which it is negative are run in the forward direction. The end
     //! result is equivalent to solving the linear programming problem of
     //! minimizing the linear Gibbs function subject to the element and non-

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -707,7 +707,7 @@ public:
     /*!
      * This is done by running each reaction as far forward or backward as
      * possible, subject to the constraint that all mole numbers remain non-
-     * negative. Reactions for which \f$ \Delta \mu^0 \f$ are positive are run
+     * negative. Reactions for which @f$ \Delta \mu^0 @f$ are positive are run
      * in reverse, and ones for which it is negative are run in the forward
      * direction. The end result is equivalent to solving the linear
      * programming problem of minimizing the linear Gibbs function subject to

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -161,9 +161,9 @@ protected:
 /*!
  * A reaction rate coefficient of the following form.
  *
- *   \f[
+ *   @f[
  *        k_f =  A T^b \exp (-Ea/RT)
- *   \f]
+ *   @f]
  *
  * @ingroup arrheniusGroup
  */

--- a/include/cantera/kinetics/BlowersMaselRate.h
+++ b/include/cantera/kinetics/BlowersMaselRate.h
@@ -50,19 +50,19 @@ protected:
  *               \Delta H)^2}{(V_P^2 - 4w^2 + (\Delta H)^2)}\; \text{Otherwise}
  *   \f}
  * where
- *   \f[
+ *   @f[
  *        V_P = \frac{2w (w + E_0)}{w - E_0},
- *   \f]
- * \f$ w \f$ is the average bond dissociation energy of the bond breaking
+ *   @f]
+ * @f$ w @f$ is the average bond dissociation energy of the bond breaking
  * and that being formed in the reaction. Since the expression is
- * very insensitive to \f$ w \f$ for \f$ w >= 2 E_0 \f$, \f$ w \f$
+ * very insensitive to @f$ w @f$ for @f$ w >= 2 E_0 @f$, @f$ w @f$
  * can be approximated to an arbitrary high value like 1000 kJ/mol.
  *
  * After the activation energy is determined by Blowers-Masel approximation,
  * it can be plugged into Arrhenius function to calculate the rate constant.
- *   \f[
+ *   @f[
  *        k_f =  A T^b \exp (-E_a/RT)
- *   \f]
+ *   @f]
  *
  * @ingroup arrheniusGroup
  */

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -65,7 +65,7 @@ protected:
  *     \log k(T,P) = \sum_{t=1}^{N_T} \sum_{p=1}^{N_P} \alpha_{tp}
  *                       \phi_t(\tilde{T}) \phi_p(\tilde{P})
  * @f]
- * where @f$\alpha_{tp}@f$ are the constants defining the rate, @f$\phi_n(x)@f$
+ * where @f$ \alpha_{tp} @f$ are the constants defining the rate, @f$ \phi_n(x) @f$
  * is the Chebyshev polynomial of the first kind of degree *n* evaluated at
  * *x*, and
  * @f[

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -61,27 +61,27 @@ protected:
 //! as a bivariate Chebyshev polynomial in temperature and pressure.
 /*!
  * The rate constant can be written as:
- * \f[
+ * @f[
  *     \log k(T,P) = \sum_{t=1}^{N_T} \sum_{p=1}^{N_P} \alpha_{tp}
  *                       \phi_t(\tilde{T}) \phi_p(\tilde{P})
- * \f]
- * where \f$\alpha_{tp}\f$ are the constants defining the rate, \f$\phi_n(x)\f$
+ * @f]
+ * where @f$\alpha_{tp}@f$ are the constants defining the rate, @f$\phi_n(x)@f$
  * is the Chebyshev polynomial of the first kind of degree *n* evaluated at
  * *x*, and
- * \f[
+ * @f[
  *  \tilde{T} \equiv \frac{2T^{-1} - T_\mathrm{min}^{-1} - T_\mathrm{max}^{-1}}
  *                        {T_\mathrm{max}^{-1} - T_\mathrm{min}^{-1}}
- * \f]
- * \f[
+ * @f]
+ * @f[
  *  \tilde{P} \equiv \frac{2 \log P - \log P_\mathrm{min} - \log P_\mathrm{max}}
  *                        {\log P_\mathrm{max} - \log P_\mathrm{min}}
- * \f]
+ * @f]
  * are reduced temperature and reduced pressures which map the ranges
- * \f$ (T_\mathrm{min}, T_\mathrm{max}) \f$ and
- * \f$ (P_\mathrm{min}, P_\mathrm{max}) \f$ to (-1, 1).
+ * @f$ (T_\mathrm{min}, T_\mathrm{max}) @f$ and
+ * @f$ (P_\mathrm{min}, P_\mathrm{max}) @f$ to (-1, 1).
  *
  * A ChebyshevRate rate expression is specified in terms of the coefficient matrix
- * \f$ \alpha \f$ and the temperature and pressure ranges. Note that the
+ * @f$ \alpha @f$ and the temperature and pressure ranges. Note that the
  * Chebyshev polynomials are not defined outside the interval (-1,1), and
  * therefore extrapolation of rates outside the range of temperatures and
  * pressures for which they are defined is strongly discouraged.

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -113,19 +113,19 @@ public:
     /**
      * The falloff function. This is defined so that the rate coefficient is
      *
-     * \f[  k = F(Pr)\frac{Pr}{1 + Pr}. \f]
+     * @f[  k = F(Pr)\frac{Pr}{1 + Pr}. @f]
      *
-     * Here \f$ Pr \f$ is the reduced pressure, defined by
+     * Here @f$ Pr @f$ is the reduced pressure, defined by
      *
-     * \f[
+     * @f[
      * Pr = \frac{k_0 [M]}{k_\infty}.
-     * \f]
+     * @f]
      *
      * @param pr reduced pressure (dimensionless).
      * @param work array of size workSize() containing cached
      *             temperature-dependent intermediate results from a prior call
      *             to updateTemp.
-     * @returns the value of the falloff function \f$ F \f$ defined above
+     * @returns the value of the falloff function @f$ F @f$ defined above
      */
     virtual double F(double pr, const double* work) const {
         return 1.0;
@@ -288,29 +288,29 @@ public:
 
 //! The 3- or 4-parameter Troe falloff parameterization.
 /*!
- * The falloff function defines the value of \f$ F \f$ in the following
+ * The falloff function defines the value of @f$ F @f$ in the following
  * rate expression
  *
- *  \f[ k = k_{\infty} \left( \frac{P_r}{1 + P_r} \right) F \f]
+ *  @f[ k = k_{\infty} \left( \frac{P_r}{1 + P_r} \right) F @f]
  *  where
- *  \f[ P_r = \frac{k_0 [M]}{k_{\infty}} \f]
+ *  @f[ P_r = \frac{k_0 [M]}{k_{\infty}} @f]
  *
  * This parameterization is defined by
  *
- * \f[ F = F_{cent}^{1/(1 + f_1^2)} \f]
+ * @f[ F = F_{cent}^{1/(1 + f_1^2)} @f]
  *    where
- * \f[ F_{cent} = (1 - A)\exp(-T/T_3) + A \exp(-T/T_1) + \exp(-T_2/T) \f]
+ * @f[ F_{cent} = (1 - A)\exp(-T/T_3) + A \exp(-T/T_1) + \exp(-T_2/T) @f]
  *
- * \f[ f_1 = (\log_{10} P_r + C) /
- *              \left(N - 0.14 (\log_{10} P_r + C)\right) \f]
+ * @f[ f_1 = (\log_{10} P_r + C) /
+ *              \left(N - 0.14 (\log_{10} P_r + C)\right) @f]
  *
- * \f[ C = -0.4 - 0.67 \log_{10} F_{cent} \f]
+ * @f[ C = -0.4 - 0.67 \log_{10} F_{cent} @f]
  *
- * \f[ N = 0.75 - 1.27 \log_{10} F_{cent} \f]
+ * @f[ N = 0.75 - 1.27 \log_{10} F_{cent} @f]
  *
- *  - If \f$ T_3 \f$ is zero, then the corresponding term is set to zero.
- *  - If \f$ T_1 \f$ is zero, then the corresponding term is set to zero.
- *  - If \f$ T_2 \f$ is zero, then the corresponding term is set to zero.
+ *  - If @f$ T_3 @f$ is zero, then the corresponding term is set to zero.
+ *  - If @f$ T_1 @f$ is zero, then the corresponding term is set to zero.
+ *  - If @f$ T_2 @f$ is zero, then the corresponding term is set to zero.
  *
  * @ingroup falloffGroup
  */
@@ -364,7 +364,7 @@ public:
     virtual void setParameters(
         const AnyMap& node, const UnitStack& rate_units) override;
 
-    //! Sets params to contain, in order, \f[ (A, T_3, T_1, T_2) \f]
+    //! Sets params to contain, in order, @f[ (A, T_3, T_1, T_2) @f]
     /**
      * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
@@ -388,22 +388,22 @@ protected:
 
 //! The SRI falloff function
 /*!
- * The falloff function defines the value of \f$ F \f$ in the following
+ * The falloff function defines the value of @f$ F @f$ in the following
  * rate expression
  *
- *  \f[ k = k_{\infty} \left( \frac{P_r}{1 + P_r} \right) F \f]
+ *  @f[ k = k_{\infty} \left( \frac{P_r}{1 + P_r} \right) F @f]
  *  where
- *  \f[ P_r = \frac{k_0 [M]}{k_{\infty}} \f]
+ *  @f[ P_r = \frac{k_0 [M]}{k_{\infty}} @f]
  *
- *  \f[ F = {\left( a \; exp(\frac{-b}{T}) + exp(\frac{-T}{c})\right)}^n
- *              \;  d \; T^e \f]
+ *  @f[ F = {\left( a \; exp(\frac{-b}{T}) + exp(\frac{-T}{c})\right)}^n
+ *              \;  d \; T^e @f]
  *      where
- *  \f[ n = \frac{1.0}{1.0 + (\log_{10} P_r)^2} \f]
+ *  @f[ n = \frac{1.0}{1.0 + (\log_{10} P_r)^2} @f]
  *
- *  \f$ c \f$ s required to greater than or equal to zero. If it is zero, then
+ *  @f$ c @f$ s required to greater than or equal to zero. If it is zero, then
  *  the corresponding term is set to zero.
  *
- *  \f$ d \f$ is required to be greater than zero.
+ *  @f$ d @f$ is required to be greater than zero.
  *
  * @ingroup falloffGroup
  */
@@ -464,7 +464,7 @@ public:
     virtual void setParameters(
         const AnyMap& node, const UnitStack& rate_units) override;
 
-    //! Sets params to contain, in order, \f[ (a, b, c, d, e) \f]
+    //! Sets params to contain, in order, @f[ (a, b, c, d, e) @f]
     /**
      * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
@@ -492,19 +492,19 @@ protected:
 //! The 1- or 2-parameter Tsang falloff parameterization.
 /*!
  *  The Tsang falloff model is adapted from that of Troe.
- *  It provides a constant or linear in temperature value for \f$ F_{cent} \f$:
- *  \f[ F_{cent} = A + B*T \f]
+ *  It provides a constant or linear in temperature value for @f$ F_{cent} @f$:
+ *  @f[ F_{cent} = A + B*T @f]
  *
- *  The value of \f$ F_{cent} \f$ is then applied to Troe's model for the
- *  determination of the value of \f$ F \f$:
- * \f[ F = F_{cent}^{1/(1 + f_1^2)} \f]
+ *  The value of @f$ F_{cent} @f$ is then applied to Troe's model for the
+ *  determination of the value of @f$ F @f$:
+ * @f[ F = F_{cent}^{1/(1 + f_1^2)} @f]
  *    where
- * \f[ f_1 = (\log_{10} P_r + C) /
- *              \left(N - 0.14 (\log_{10} P_r + C)\right) \f]
+ * @f[ f_1 = (\log_{10} P_r + C) /
+ *              \left(N - 0.14 (\log_{10} P_r + C)\right) @f]
  *
- * \f[ C = -0.4 - 0.67 \log_{10} F_{cent} \f]
+ * @f[ C = -0.4 - 0.67 \log_{10} F_{cent} @f]
  *
- * \f[ N = 0.75 - 1.27 \log_{10} F_{cent} \f]
+ * @f[ N = 0.75 - 1.27 \log_{10} F_{cent} @f]
  *
  *  References:
  *  * Example of reaction database developed by Tsang utilizing this format
@@ -570,7 +570,7 @@ public:
     virtual void setParameters(
         const AnyMap& node, const UnitStack& rate_units) override;
 
-    //! Sets params to contain, in order, \f[ (A, B) \f]
+    //! Sets params to contain, in order, @f[ (A, B) @f]
     /**
      * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -27,31 +27,31 @@ namespace Cantera
  * InterfaceKinetics object, in time. The following equation is used for each
  * surface phase, *i*.
  *
- *   \f[
+ *   @f[
  *        \dot \theta_k = \dot s_k (\sigma_k / s_0)
- *   \f]
+ *   @f]
  *
  * In this equation,
- * - \f$ \theta_k \f$ is the site coverage for the kth species.
- * - \f$ \dot s_k \f$ is the source term for the kth species
- * - \f$ \sigma_k \f$ is the number of surface sites covered by each species k.
- * - \f$ s_0 \f$ is the total site density of the interfacial phase.
+ * - @f$ \theta_k @f$ is the site coverage for the kth species.
+ * - @f$ \dot s_k @f$ is the source term for the kth species
+ * - @f$ \sigma_k @f$ is the number of surface sites covered by each species k.
+ * - @f$ s_0 @f$ is the total site density of the interfacial phase.
  *
  * Additionally, the 0'th equation in the set is discarded. Instead the
  * alternate equation is solved for
  *
- * \f[
+ * @f[
  *     \sum_{k=0}^{N-1}  \dot \theta_k = 0
- * \f]
+ * @f]
  *
- * This last equation serves to ensure that sum of the \f$ \theta_k \f$ values
+ * This last equation serves to ensure that sum of the @f$ \theta_k @f$ values
  * stays constant.
  *
  * The object uses the CVODE software to advance the surface equations.
  *
  * The solution vector used by this object is as follows: For each surface
- * phase with \f$ N_s \f$ surface sites, it consists of the surface coverages
- * \f$ \theta_k \f$ for \f$ k = 0, N_s - 1 \f$
+ * phase with @f$ N_s @f$ surface sites, it consists of the surface coverages
+ * @f$ \theta_k @f$ for @f$ k = 0, N_s - 1 @f$
  *
  * @ingroup surfSolverGroup
  */

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -185,9 +185,9 @@ public:
      * This method carries out a time-accurate advancement of the
      * surface coverages for a specified amount of time.
      *
-     *  \f[
+     *  @f[
      *    \dot {\theta}_k = \dot s_k (\sigma_k / s_0)
-     *  \f]
+     *  @f]
      *
      * @param tstep  Time value to advance the surface coverages
      * @param rtol   The relative tolerance for the integrator
@@ -364,8 +364,8 @@ protected:
 
     //! Array of concentrations for each species in the kinetics mechanism
     /*!
-     * An array of generalized concentrations \f$ C_k \f$ that are defined
-     * such that \f$ a_k = C_k / C^0_k, \f$ where \f$ C^0_k \f$ is a standard
+     * An array of generalized concentrations @f$ C_k @f$ that are defined
+     * such that @f$ a_k = C_k / C^0_k, @f$ where @f$ C^0_k @f$ is a standard
      * concentration/ These generalized concentrations are used by this
      * kinetics manager class to compute the forward and reverse rates of
      * elementary reactions. The "units" for the concentrations of each phase
@@ -378,8 +378,8 @@ protected:
 
     //! Array of activity concentrations for each species in the kinetics object
     /*!
-     * An array of activity concentrations \f$ Ca_k \f$ that are defined
-     * such that \f$ a_k = Ca_k / C^0_k, \f$ where \f$ C^0_k \f$ is a standard
+     * An array of activity concentrations @f$ Ca_k @f$ that are defined
+     * such that @f$ a_k = Ca_k / C^0_k, @f$ where @f$ C^0_k @f$ is a standard
      * concentration. These activity concentrations are used by this
      * kinetics manager class to compute the forward and reverse rates of
      * elementary reactions. The "units" for the concentrations of each phase

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -65,25 +65,25 @@ struct InterfaceData : public BlowersMaselData
  * Rate expressions defined for interfaces may include coverage dependent terms,
  * where an example is given by Kee, et al. @cite kee2003, Eq 11.113.
  * Using %Cantera nomenclature, this expression can be rewritten as
- *  \f[
+ *  @f[
  *      k_f = A T^b \exp \left( - \frac{E_a}{RT} \right)
  *          \prod_k 10^{a_k \theta_k} \theta_k^{m_k}
  *          \exp \left( \frac{- E_k \theta_k}{RT} \right)
- *  \f]
+ *  @f]
  * It is evident that this expression combines a regular modified Arrhenius rate
- * expression \f$ A T^b \exp \left( - \frac{E_a}{RT} \right) \f$ with coverage-related
- * terms, where the parameters \f$ (a_k, E_k, m_k) \f$ describe the dependency on the
- * surface coverage of species \f$ k, \theta_k \f$. In addition to the linear coverage
- * dependence on the activation energy modifier \f$ E_k \f$, polynomial coverage
- * dependence is also available. When the dependence parameter \f$ E_k \f$ is given as
+ * expression @f$ A T^b \exp \left( - \frac{E_a}{RT} \right) @f$ with coverage-related
+ * terms, where the parameters @f$ (a_k, E_k, m_k) @f$ describe the dependency on the
+ * surface coverage of species @f$ k, \theta_k @f$. In addition to the linear coverage
+ * dependence on the activation energy modifier @f$ E_k @f$, polynomial coverage
+ * dependence is also available. When the dependence parameter @f$ E_k @f$ is given as
  * a scalar value, the linear dependency is applied whereas if a list of four values
- * are given as \f$ [E^{(1)}_k, ..., E^{(4)}_k] \f$, a polynomial dependency is applied as
- *  \f[
+ * are given as @f$ [E^{(1)}_k, ..., E^{(4)}_k] @f$, a polynomial dependency is applied as
+ *  @f[
  *      k_f = A T^b \exp \left( - \frac{E_a}{RT} \right)
  *          \prod_k 10^{a_k \theta_k} \theta_k^{m_k}
  *          \exp \left( \frac{- E^{(1)}_k \theta_k - E^{(2)}_k \theta_k^2
  *          - E^{(3)}_k \theta_k^3 - E^{(4)}_k \theta_k^4}{RT} \right)
- *  \f]
+ *  @f]
  * The InterfaceRateBase class implements terms related to coverage only, which allows
  * for combinations with arbitrary rate parameterizations (for example Arrhenius and
  * BlowersMaselRate).
@@ -143,12 +143,12 @@ public:
      *  For reactions that transfer charge across a potential difference, the
      *  activation energies are modified by the potential difference. The correction
      *  factor is based on the net electric potential energy change
-     *  \f[
+     *  @f[
      *   \Delta E_{p,j} = \sum_i E_{p,i} \nu_{i,j}
-     *  \f]
-     *  where potential energies are calculated as \f$ E_{p,i} = F \phi_i z_i \f$.
-     *  Here, \f$ F \f$ is Faraday's constant, \f$ \phi_i \f$ is the electric potential
-     *  of the species phase and \f$ z_i \f$ is the charge of the species.
+     *  @f]
+     *  where potential energies are calculated as @f$ E_{p,i} = F \phi_i z_i @f$.
+     *  Here, @f$ F @f$ is Faraday's constant, @f$ \phi_i @f$ is the electric potential
+     *  of the species phase and @f$ z_i @f$ is the charge of the species.
      *
      *  When an electrode reaction rate is specified in terms of its exchange current
      *  density, the correction factor is adjusted to the standard reaction rate
@@ -186,9 +186,9 @@ public:
     //! Boolean indicating whether rate uses electrochemistry
     /*!
      *  If this is true, the Butler-Volmer correction
-     *  \f[
+     *  @f[
      *    f_{BV} = \exp ( - \beta * Delta E_{p,j} / R T )
-     *  \f]
+     *  @f]
      *  is applied to the forward reaction rate.
      *
      *  @see voltageCorrection().

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -733,8 +733,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
-     * constant, rather than enforcing @f$\sum X_j = 1@f$.
+     * For a derivative with respect to @f$ X_i @f$, all other @f$ X_j @f$ are held
+     * constant, rather than enforcing @f$ \sum X_j = 1 @f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -751,7 +751,7 @@ public:
      * concentrations.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
+     * For a derivative with respect to @f$ c_i @f$, all other @f$ c_j @f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -806,8 +806,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
-     * constant, rather than enforcing @f$\sum X_j = 1@f$.
+     * For a derivative with respect to @f$ X_i @f$, all other @f$ X_j @f$ are held
+     * constant, rather than enforcing @f$ \sum X_j = 1 @f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -824,7 +824,7 @@ public:
      * concentrations.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
+     * For a derivative with respect to @f$ c_i @f$, all other @f$ c_j @f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -879,8 +879,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
-     * constant, rather than enforcing @f$\sum X_j = 1@f$.
+     * For a derivative with respect to @f$ X_i @f$, all other @f$ X_j @f$ are held
+     * constant, rather than enforcing @f$ \sum X_j = 1 @f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -897,7 +897,7 @@ public:
      * concentrations.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
+     * For a derivative with respect to @f$ c_i @f$, all other @f$ c_j @f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -940,8 +940,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
-     * constant, rather than enforcing @f$\sum X_j = 1@f$.
+     * For a derivative with respect to @f$ X_i @f$, all other @f$ X_j @f$ are held
+     * constant, rather than enforcing @f$ \sum X_j = 1 @f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -954,7 +954,7 @@ public:
      * species.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
+     * For a derivative with respect to @f$ c_i @f$, all other @f$ c_j @f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -993,8 +993,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
-     * constant, rather than enforcing @f$\sum X_j = 1@f$.
+     * For a derivative with respect to @f$ X_i @f$, all other @f$ X_j @f$ are held
+     * constant, rather than enforcing @f$ \sum X_j = 1 @f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -1007,7 +1007,7 @@ public:
      * species.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
+     * For a derivative with respect to @f$ c_i @f$, all other @f$ c_j @f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -1046,8 +1046,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held constant,
-     * rather than enforcing @f$\sum X_j = 1@f$.
+     * For a derivative with respect to @f$ X_i @f$, all other @f$ X_j @f$ are held constant,
+     * rather than enforcing @f$ \sum X_j = 1 @f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -1060,7 +1060,7 @@ public:
      * species.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
+     * For a derivative with respect to @f$ c_i @f$, all other @f$ c_j @f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -59,8 +59,8 @@ class AnyMap;
 //! that depend only on temperature, a manager class may choose to store these
 //! quantities internally, and re-evaluate them only when the temperature has
 //! actually changed. Or a manager designed for use with reaction mechanisms
-//! with a few repeated activation energies might precompute the terms \f$
-//! exp(-E/RT) \f$, instead of evaluating the exponential repeatedly for each
+//! with a few repeated activation energies might precompute the terms @f$
+//! exp(-E/RT) @f$, instead of evaluating the exponential repeatedly for each
 //! reaction. There are many other possible 'management styles', each of which
 //! might be better suited to some reaction mechanisms than others.
 //!
@@ -400,9 +400,9 @@ public:
      *  units in array kc, which must be dimensioned at least as large as the
      *  total number of reactions.
      *
-     * \f[
+     * @f[
      *       Kc_i = exp [ \Delta G_{ss,i} ] prod(Cs_k) exp(\sum_k \nu_{k,i} F \phi_n) ]
-     * \f]
+     * @f]
      *
      * @param kc   Output vector containing the equilibrium constants.
      *             Length: nReactions().
@@ -413,10 +413,10 @@ public:
 
     /**
      * Change in species properties. Given an array of molar species property
-     * values \f$ z_k, k = 1, \dots, K \f$, return the array of reaction values
-     * \f[
+     * values @f$ z_k, k = 1, \dots, K @f$, return the array of reaction values
+     * @f[
      *    \Delta Z_i = \sum_k \nu_{k,i} z_k, i = 1, \dots, I.
-     * \f]
+     * @f]
      * For example, if this method is called with the array of standard-state
      * molar Gibbs free energies for the species, then the values returned in
      * array \c deltaProperty would be the standard-state Gibbs free energies of
@@ -733,8 +733,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$X_i\f$, all other \f$X_j\f$ are held
-     * constant, rather than enforcing \f$\sum X_j = 1\f$.
+     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
+     * constant, rather than enforcing @f$\sum X_j = 1@f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -751,7 +751,7 @@ public:
      * concentrations.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$c_i\f$, all other \f$c_j\f$ are held
+     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -806,8 +806,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$X_i\f$, all other \f$X_j\f$ are held
-     * constant, rather than enforcing \f$\sum X_j = 1\f$.
+     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
+     * constant, rather than enforcing @f$\sum X_j = 1@f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -824,7 +824,7 @@ public:
      * concentrations.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$c_i\f$, all other \f$c_j\f$ are held
+     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -879,8 +879,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$X_i\f$, all other \f$X_j\f$ are held
-     * constant, rather than enforcing \f$\sum X_j = 1\f$.
+     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
+     * constant, rather than enforcing @f$\sum X_j = 1@f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -897,7 +897,7 @@ public:
      * concentrations.
      *
      * The method returns a matrix with nReactions rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$c_i\f$, all other \f$c_j\f$ are held
+     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -940,8 +940,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$X_i\f$, all other \f$X_j\f$ are held
-     * constant, rather than enforcing \f$\sum X_j = 1\f$.
+     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
+     * constant, rather than enforcing @f$\sum X_j = 1@f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -954,7 +954,7 @@ public:
      * species.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$c_i\f$, all other \f$c_j\f$ are held
+     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -993,8 +993,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$X_i\f$, all other \f$X_j\f$ are held
-     * constant, rather than enforcing \f$\sum X_j = 1\f$.
+     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held
+     * constant, rather than enforcing @f$\sum X_j = 1@f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -1007,7 +1007,7 @@ public:
      * species.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$c_i\f$, all other \f$c_j\f$ are held
+     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and
@@ -1046,8 +1046,8 @@ public:
      * mole fractions at constant temperature, pressure and molar concentration.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$X_i\f$, all other \f$X_j\f$ are held constant,
-     * rather than enforcing \f$\sum X_j = 1\f$.
+     * For a derivative with respect to @f$X_i@f$, all other @f$X_j@f$ are held constant,
+     * rather than enforcing @f$\sum X_j = 1@f$.
      *
      * @warning  This method is an experimental part of the %Cantera API and
      *      may be changed or removed without notice.
@@ -1060,7 +1060,7 @@ public:
      * species.
      *
      * The method returns a matrix with nTotalSpecies rows and nTotalSpecies columns.
-     * For a derivative with respect to \f$c_i\f$, all other \f$c_j\f$ are held
+     * For a derivative with respect to @f$c_i@f$, all other @f$c_j@f$ are held
      * constant.
      *
      * @warning  This method is an experimental part of the %Cantera API and

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -59,14 +59,14 @@ protected:
 /*!
  * Given two rate expressions at two specific pressures:
  *
- *   * \f$ P_1: k_1(T) = A_1 T^{b_1} e^{-E_1 / RT} \f$
- *   * \f$ P_2: k_2(T) = A_2 T^{b_2} e^{-E_2 / RT} \f$
+ *   * @f$ P_1: k_1(T) = A_1 T^{b_1} e^{-E_1 / RT} @f$
+ *   * @f$ P_2: k_2(T) = A_2 T^{b_2} e^{-E_2 / RT} @f$
  *
- * The rate at an intermediate pressure \f$ P_1 < P < P_2 \f$ is computed as
- * \f[
+ * The rate at an intermediate pressure @f$ P_1 < P < P_2 @f$ is computed as
+ * @f[
  *  \log k(T,P) = \log k_1(T) + \bigl(\log k_2(T) - \log k_1(T)\bigr)
  *      \frac{\log P - \log P_1}{\log P_2 - \log P_1}
- * \f]
+ * @f]
  * Multiple rate expressions may be given at the same pressure, in which case
  * the rate used in the interpolation formula is the sum of all the rates given
  * at that pressure. For pressures outside the given range, the rate expression

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -564,7 +564,7 @@ inline static void _scale(InputIter begin, InputIter end,
  * @f[
  *     r_i = \sum_m^{M_i} s_{k_{m,i}}
  * @f]
- * To understand the operations performed by this class, let @f$ N_{k,i}@f$
+ * To understand the operations performed by this class, let @f$ N_{k,i} @f$
  * denote the stoichiometric coefficient of species k on one side (reactant or
  * product) in reaction i. Then \b N is a sparse K by I matrix of stoichiometric
  * coefficients.
@@ -572,8 +572,8 @@ inline static void _scale(InputIter begin, InputIter end,
  * The following matrix operations may be carried out with a vector S of length
  * K, and a vector R of length I:
  *
- * - @f$ S = S + N R@f$   (incrementSpecies)
- * - @f$ S = S - N R@f$   (decrementSpecies)
+ * - @f$ S = S + N R @f$   (incrementSpecies)
+ * - @f$ S = S - N R @f$   (decrementSpecies)
  * - @f$ R = R + N^T S @f$ (incrementReaction)
  * - @f$ R = R - N^T S @f$ (decrementReaction)
  *

--- a/include/cantera/kinetics/StoichManager.h
+++ b/include/cantera/kinetics/StoichManager.h
@@ -32,14 +32,14 @@ namespace Cantera
  * coefficient matrix and a vector of reaction rates. For example, the species
  * creation rates are given by
  *
- * \f[
+ * @f[
  *  \dot C_k = \sum_k \nu^{(p)}_{k,i} R_i
- * \f]
+ * @f]
  *
- * where \f$ \nu^{(p)_{k,i}} \f$ is the product-side stoichiometric
+ * where @f$ \nu^{(p)_{k,i}} @f$ is the product-side stoichiometric
  * coefficient of species \a k in reaction \a i. This could be done by
  * straightforward matrix multiplication, but would be inefficient, since most
- * of the matrix elements of \f$ \nu^{(p)}_{k,i} \f$ are zero. We could do
+ * of the matrix elements of @f$ \nu^{(p)}_{k,i} @f$ are zero. We could do
  * better by using sparse-matrix algorithms to compute this product.
  *
  * If the reactions are general ones, with non-integral stoichiometric
@@ -559,12 +559,12 @@ inline static void _scale(InputIter begin, InputIter end,
  * products of irreversible reactions).
  *
  * This class is designed for use with elementary reactions, or at least ones
- * with integral stoichiometric coefficients. Let \f$ M(i) \f$ be the number of
+ * with integral stoichiometric coefficients. Let @f$ M(i) @f$ be the number of
  * molecules on the product or reactant side of reaction number i.
- * \f[
+ * @f[
  *     r_i = \sum_m^{M_i} s_{k_{m,i}}
- * \f]
- * To understand the operations performed by this class, let \f$ N_{k,i}\f$
+ * @f]
+ * To understand the operations performed by this class, let @f$ N_{k,i}@f$
  * denote the stoichiometric coefficient of species k on one side (reactant or
  * product) in reaction i. Then \b N is a sparse K by I matrix of stoichiometric
  * coefficients.
@@ -572,19 +572,19 @@ inline static void _scale(InputIter begin, InputIter end,
  * The following matrix operations may be carried out with a vector S of length
  * K, and a vector R of length I:
  *
- * - \f$ S = S + N R\f$   (incrementSpecies)
- * - \f$ S = S - N R\f$   (decrementSpecies)
- * - \f$ R = R + N^T S \f$ (incrementReaction)
- * - \f$ R = R - N^T S \f$ (decrementReaction)
+ * - @f$ S = S + N R@f$   (incrementSpecies)
+ * - @f$ S = S - N R@f$   (decrementSpecies)
+ * - @f$ R = R + N^T S @f$ (incrementReaction)
+ * - @f$ R = R - N^T S @f$ (decrementReaction)
  *
  * The actual implementation, however, does not compute these quantities by
  * matrix multiplication. A faster algorithm is used that makes use of the fact
  * that the \b integer-valued N matrix is very sparse, and the non-zero terms
  * are small positive integers.
- * \f[
+ * @f[
  * S_k = R_{i1} + \dots + R_{iM}
- * \f]
- * where M is the number of molecules, and \f$ i(m) \f$ is the
+ * @f]
+ * where M is the number of molecules, and @f$ i(m) @f$ is the
  * See @ref Stoichiometry
  * @ingroup Stoichiometry
  */

--- a/include/cantera/kinetics/TwoTempPlasmaRate.h
+++ b/include/cantera/kinetics/TwoTempPlasmaRate.h
@@ -47,12 +47,12 @@ struct TwoTempPlasmaData : public ReactionData
  * the electron temperature instead. In addition, the exponential term with
  * activation energy for electron is included.
  *
- *   \f[
+ *   @f[
  *        k_f =  A T_e^b \exp (-E_{a,g}/RT) \exp (E_{a,e} (T_e - T)/(R T T_e))
- *   \f]
+ *   @f]
  *
- * where \f$ T_e \f$ is the electron temperature, \f$ E_{a,g} \f$ is the activation
- * energy for gas, and \f$ E_{a,e} \f$ is the activation energy for electron, see
+ * where @f$ T_e @f$ is the electron temperature, @f$ E_{a,g} @f$ is the activation
+ * energy for gas, and @f$ E_{a,e} @f$ is the activation energy for electron, see
  * Kossyi, et al. @cite kossyi1992.
  *
  * @ingroup arrheniusGroup

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -190,9 +190,9 @@ int solve(DenseMatrix& A, DenseMatrix& b);
 
 //! Multiply \c A*b and return the result in \c prod. Uses BLAS routine DGEMV.
 /*!
- * \f[
+ * @f[
  *     prod_i = sum^N_{j = 1}{A_{ij} b_j}
- * \f]
+ * @f]
  *
  * @param[in]  A     Dense Matrix A with M rows and N columns
  * @param[in]  b     vector b with length N
@@ -202,9 +202,9 @@ void multiply(const DenseMatrix& A, const double* const b, double* const prod);
 
 //! Multiply \c A*b and add it to the result in \c prod. Uses BLAS routine DGEMV.
 /*!
- * \f[
+ * @f[
  *     prod_i += sum^N_{j = 1}{A_{ij} b_j}
- * \f]
+ * @f]
  *
  * @param[in]  A     Dense Matrix A with M rows and N columns
  * @param[in]  b     vector b with length N

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -498,7 +498,7 @@ public:
     Tabulated1(size_t n, const double* tvals, const double* fvals,
                const string& method="linear");
 
-    //! Constructor uses @f$ 2 n@f$ parameters in the following order:
+    //! Constructor uses @f$ 2 n @f$ parameters in the following order:
     //! @f$ [t_0, t_1, \dots, t_{n-1}, f_0, f_1, \dots, f_{n-1}] @f$
     Tabulated1(const vector<double>& params);
 
@@ -1302,7 +1302,7 @@ public:
         }
     }
 
-    //! Constructor uses @f$ 3 n@f$ parameters in the following order:
+    //! Constructor uses @f$ 3 n @f$ parameters in the following order:
     //! @f$ [A_1, b_1, E_1, A_2, b_2, E_2, \dots, A_n, b_n, E_n] @f$
     Arrhenius1(const vector<double>& params);
 

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -40,7 +40,7 @@ const int TabulatedFuncType = 120;
 class TimesConstant1;
 
 //! @defgroup func1 Functor Objects
-//! Functors implement functions of a single variable \f$ f(x) \f$.
+//! Functors implement functions of a single variable @f$ f(x) @f$.
 //! Functor objects can be combined to form compound expressions, which allows for
 //! the implementation of generic mathematical expressions.
 //! @ingroup numerics
@@ -266,9 +266,9 @@ shared_ptr<Func1> newPlusConstFunction(shared_ptr<Func1> f1, double c);
 
 //! Implements the \c sin() function.
 /*!
- * The functor class with type \c "sin" returns \f$ f(x) = \cos(\omega x) \f$,
- * where the argument \f$ x \f$ is in radians.
- * @param omega  Frequency \f$ \omega \f$ (default=1.0)
+ * The functor class with type \c "sin" returns @f$ f(x) = \cos(\omega x) @f$,
+ * where the argument @f$ x @f$ is in radians.
+ * @param omega  Frequency @f$ \omega @f$ (default=1.0)
  * @ingroup func1simple
  */
 class Sin1 : public Func1
@@ -315,9 +315,9 @@ public:
 
 //! Implements the \c cos() function.
 /*!
- * The functor class with type \c "cos" returns \f$ f(x) = \cos(\omega x) \f$,
- * where the argument \f$ x \f$ is in radians.
- * @param omega  Frequency \f$ \omega \f$ (default=1.0)
+ * The functor class with type \c "cos" returns @f$ f(x) = \cos(\omega x) @f$,
+ * where the argument @f$ x @f$ is in radians.
+ * @param omega  Frequency @f$ \omega @f$ (default=1.0)
  * @ingroup func1simple
  */
 class Cos1 : public Func1
@@ -361,7 +361,7 @@ public:
 
 //! Implements the \c exp() (exponential) function.
 /*!
- * The functor class with type \c "exp" returns \f$ f(x) = \exp(a x) \f$.
+ * The functor class with type \c "exp" returns @f$ f(x) = \exp(a x) @f$.
  * @param a  Factor (default=1.0)
  * @ingroup func1simple
  */
@@ -405,7 +405,7 @@ public:
 
 //! Implements the \c log() (natural logarithm) function.
 /*!
- * The functor class with type \c "log" returns \f$ f(x) = \log(a x) \f$.
+ * The functor class with type \c "log" returns @f$ f(x) = \log(a x) @f$.
  * @param a  Factor (default=1.0)
  * @ingroup func1simple
  * @since New in %Cantera 3.0
@@ -435,7 +435,7 @@ public:
 
 //! Implements the \c pow() (power) function.
 /*!
- * The functor class with type \c "pow" returns \f$ f(x) = x^n \f$.
+ * The functor class with type \c "pow" returns @f$ f(x) = x^n @f$.
  * @param n  Exponent
  * @ingroup func1simple
  */
@@ -498,8 +498,8 @@ public:
     Tabulated1(size_t n, const double* tvals, const double* fvals,
                const string& method="linear");
 
-    //! Constructor uses \f$ 2 n\f$ parameters in the following order:
-    //! \f$ [t_0, t_1, \dots, t_{n-1}, f_0, f_1, \dots, f_{n-1}] \f$
+    //! Constructor uses @f$ 2 n@f$ parameters in the following order:
+    //! @f$ [t_0, t_1, \dots, t_{n-1}, f_0, f_1, \dots, f_{n-1}] @f$
     Tabulated1(const vector<double>& params);
 
     //! Set the interpolation method
@@ -533,7 +533,7 @@ private:
 
 //! Implements a constant.
 /*!
- * The functor class with type \c "constant" returns \f$ f(x) = a \f$.
+ * The functor class with type \c "constant" returns @f$ f(x) = a @f$.
  * @param a  Constant
  * @ingroup func1simple
  */
@@ -580,9 +580,9 @@ public:
 
 /**
  * Implements the sum of two functions.
- * The functor class with type \c "sum" returns \f$ f(x) = f_1(x) + f_2(x) \f$.
- * @param f1  Functor \f$ f_1(x) \f$
- * @param f2  Functor \f$ f_2(x) \f$
+ * The functor class with type \c "sum" returns @f$ f(x) = f_1(x) + f_2(x) @f$.
+ * @param f1  Functor @f$ f_1(x) @f$
+ * @param f2  Functor @f$ f_2(x) @f$
  * @ingroup func1compound
  */
 class Sum1 : public Func1
@@ -651,9 +651,9 @@ public:
 
 /**
  * Implements the difference of two functions.
- * The functor class with type \c "diff" returns \f$ f(x) = f_1(x) - f_2(x) \f$.
- * @param f1  Functor \f$ f_1(x) \f$
- * @param f2  Functor \f$ f_2(x) \f$
+ * The functor class with type \c "diff" returns @f$ f(x) = f_1(x) - f_2(x) @f$.
+ * @param f1  Functor @f$ f_1(x) @f$
+ * @param f2  Functor @f$ f_2(x) @f$
  * @ingroup func1compound
  */
 class Diff1 : public Func1
@@ -724,9 +724,9 @@ public:
 
 /**
  * Implements the product of two functions.
- * The functor class with type \c "product" returns \f$ f(x) = f_1(x) f_2(x) \f$.
- * @param f1  Functor \f$ f_1(x) \f$
- * @param f2  Functor \f$ f_2(x) \f$
+ * The functor class with type \c "product" returns @f$ f(x) = f_1(x) f_2(x) @f$.
+ * @param f1  Functor @f$ f_1(x) @f$
+ * @param f2  Functor @f$ f_2(x) @f$
  * @ingroup func1compound
  */
 class Product1 : public Func1
@@ -794,9 +794,9 @@ public:
 
 /**
  * Implements the product of a function and a constant.
- * The functor class with type \c "times-constant" returns \f$ f(x) = a f_1(x) \f$.
- * @param f1  Functor \f$ f_1(x) \f$
- * @param a   Constant \f$ a \f$
+ * The functor class with type \c "times-constant" returns @f$ f(x) = a f_1(x) @f$.
+ * @param f1  Functor @f$ f_1(x) @f$
+ * @param a   Constant @f$ a @f$
  * @ingroup func1modified
  */
 class TimesConstant1 : public Func1
@@ -874,9 +874,9 @@ public:
 
 /**
  * Implements the sum of a function and a constant.
- * The functor class with type \c "plus-constant" returns \f$ f(x) = f_1(x) + a \f$.
- * @param f1  Functor \f$ f_1(x) \f$
- * @param a   Constant \f$ a \f$
+ * The functor class with type \c "plus-constant" returns @f$ f(x) = f_1(x) + a @f$.
+ * @param f1  Functor @f$ f_1(x) @f$
+ * @param a   Constant @f$ a @f$
  * @ingroup func1modified
  */
 class PlusConstant1 : public Func1
@@ -940,9 +940,9 @@ public:
 
 /**
  * Implements the ratio of two functions.
- * The functor class with type \c "ratio" returns \f$ f(x) = f_1(x) / f_2(x) \f$.
- * @param f1  Functor \f$ f_1(x) \f$
- * @param f2  Functor \f$ f_2(x) \f$
+ * The functor class with type \c "ratio" returns @f$ f(x) = f_1(x) / f_2(x) @f$.
+ * @param f1  Functor @f$ f_1(x) @f$
+ * @param f2  Functor @f$ f_2(x) @f$
  * @ingroup func1compound
  */
 class Ratio1 : public Func1
@@ -1009,9 +1009,9 @@ public:
 
 /**
  * Implements a composite function.
- * The functor class with type \c "composite" returns \f$ f(x) = f_1\left(f_2(x)\right) \f$.
- * @param f1  Functor \f$ f_1(x) \f$
- * @param f2  Functor \f$ f_2(x) \f$
+ * The functor class with type \c "composite" returns @f$ f(x) = f_1\left(f_2(x)\right) @f$.
+ * @param f1  Functor @f$ f_1(x) @f$
+ * @param f2  Functor @f$ f_2(x) @f$
  * @ingroup func1compound
  */
 class Composite1 : public Func1
@@ -1082,10 +1082,10 @@ public:
 /**
  * Implements a Gaussian function.
  * The functor class with type \c "Gaussian" returns
- * \f[
+ * @f[
  * f(t) = A e^{-[(t - t_0)/\tau]^2}
- * \f]
- * where \f$ \tau = \mathrm{fwhm} / (2 \sqrt{\ln 2}) \f$.
+ * @f]
+ * where @f$ \tau = \mathrm{fwhm} / (2 \sqrt{\ln 2}) @f$.
  * @param A peak value
  * @param t0 offset
  * @param fwhm full width at half max
@@ -1102,7 +1102,7 @@ public:
     }
 
     //! Constructor uses 3 parameters in the following order:
-    //! \f$ [A, t_0, \mathrm{fwhm}] \f$
+    //! @f$ [A, t_0, \mathrm{fwhm}] @f$
     Gaussian1(const vector<double>& params);
 
     Gaussian1(const Gaussian1& b) :
@@ -1138,10 +1138,10 @@ protected:
 
 /**
  * A Gaussian.
- * \f[
+ * @f[
  * f(t) = A e^{-[(t - t_0)/\tau]^2}
- * \f]
- * where \f[ \tau = \frac{fwhm}{2\sqrt{\ln 2}} \f]
+ * @f]
+ * where @f[ \tau = \frac{fwhm}{2\sqrt{\ln 2}} @f]
  * @param A peak value
  * @param t0 offset
  * @param fwhm full width at half max
@@ -1161,9 +1161,9 @@ class Gaussian : public Gaussian1
 /**
  * Implements a polynomial of degree \e n.
  * The functor class with type \c "polynomial" returns
- * \f[
+ * @f[
  * f(x) = a_n x^n + \dots + a_1 x + a_0
- * \f]
+ * @f]
  * @ingroup func1advanced
  */
 class Poly1 : public Func1
@@ -1174,8 +1174,8 @@ public:
         std::copy(c, c+m_cpoly.size(), m_cpoly.begin());
     }
 
-    //! Constructor uses \f$ n + 1 \f$ parameters in the following order:
-    //! \f$ [a_n, \dots, a_1, a_0] \f$
+    //! Constructor uses @f$ n + 1 @f$ parameters in the following order:
+    //! @f$ [a_n, \dots, a_1, a_0] @f$
     Poly1(const vector<double>& params);
 
     Poly1(const Poly1& b) :
@@ -1216,10 +1216,10 @@ protected:
 /**
  * Implements a Fourier cosine/sine series.
  * The functor class with type \c "Fourier" returns
- * \f[
+ * @f[
  * f(t) = \frac{A_0}{2} +
  * \sum_{n=1}^N A_n \cos (n \omega t) + B_n \sin (n \omega t)
- * \f]
+ * @f]
  * @ingroup func1advanced
  */
 class Fourier1 : public Func1
@@ -1234,8 +1234,8 @@ public:
         std::copy(b, b+n, m_csin.begin());
     }
 
-    //! Constructor uses \f$ 2 n + 2 \f$ parameters in the following order:
-    //! \f$ [a_0, a_1, \dots, a_n, \omega, b_1, \dots, b_n] \f$
+    //! Constructor uses @f$ 2 n + 2 @f$ parameters in the following order:
+    //! @f$ [a_0, a_1, \dots, a_n, \omega, b_1, \dots, b_n] @f$
     Fourier1(const vector<double>& params);
 
     Fourier1(const Fourier1& b) :
@@ -1282,9 +1282,9 @@ protected:
 /**
  * Implements a sum of Arrhenius terms.
  * The functor class with type \c "Arrhenius" returns
- * \f[
+ * @f[
  * f(T) = \sum_{n=1}^N A_n T^b_n \exp(-E_n/T)
- * \f]
+ * @f]
  * @ingroup func1advanced
  */
 class Arrhenius1 : public Func1
@@ -1302,8 +1302,8 @@ public:
         }
     }
 
-    //! Constructor uses \f$ 3 n\f$ parameters in the following order:
-    //! \f$ [A_1, b_1, E_1, A_2, b_2, E_2, \dots, A_n, b_n, E_n] \f$
+    //! Constructor uses @f$ 3 n@f$ parameters in the following order:
+    //! @f$ [A_1, b_1, E_1, A_2, b_2, E_2, \dots, A_n, b_n, E_n] @f$
     Arrhenius1(const vector<double>& params);
 
     Arrhenius1(const Arrhenius1& b) :
@@ -1343,7 +1343,7 @@ protected:
 
 /**
  * Implements a periodic function.
- * Takes any function and makes it periodic with period \f$ T \f$.
+ * Takes any function and makes it periodic with period @f$ T @f$.
  * @param f  Functor to be made periodic
  * @param T  Period
  * @ingroup func1modified

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -22,10 +22,10 @@ namespace Cantera
 /**
  *  Virtual base class for ODE/DAE right-hand-side function evaluators.
  *  Classes derived from FuncEval evaluate the right-hand-side function
- * \f$ \vec{F}(t,\vec{y})\f$ in
- * \f[
+ * @f$ \vec{F}(t,\vec{y})@f$ in
+ * @f[
  *  \dot{\vec{y}} = \vec{F}(t,\vec{y}).
- * \f]
+ * @f]
  *  @ingroup odeGroup
  */
 class FuncEval

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -22,7 +22,7 @@ namespace Cantera
 /**
  *  Virtual base class for ODE/DAE right-hand-side function evaluators.
  *  Classes derived from FuncEval evaluate the right-hand-side function
- * @f$ \vec{F}(t,\vec{y})@f$ in
+ * @f$ \vec{F}(t,\vec{y}) @f$ in
  * @f[
  *  \dot{\vec{y}} = \vec{F}(t,\vec{y}).
  * @f]

--- a/include/cantera/numerics/IdasIntegrator.h
+++ b/include/cantera/numerics/IdasIntegrator.h
@@ -103,7 +103,7 @@ private:
     void* m_linsol_matrix = nullptr; //!< matrix used by Sundials
     SundialsContext m_sundials_ctx; //!< SUNContext object for Sundials>=6.0
 
-    //! Object implementing the DAE residual function \f$ f(t, y, \dot{y}) = 0\f$
+    //! Object implementing the DAE residual function @f$ f(t, y, \dot{y}) = 0@f$
     FuncEval* m_func = nullptr;
 
     double m_t0 = 0.0; //!< The start time for the integrator

--- a/include/cantera/numerics/IdasIntegrator.h
+++ b/include/cantera/numerics/IdasIntegrator.h
@@ -103,7 +103,7 @@ private:
     void* m_linsol_matrix = nullptr; //!< matrix used by Sundials
     SundialsContext m_sundials_ctx; //!< SUNContext object for Sundials>=6.0
 
-    //! Object implementing the DAE residual function @f$ f(t, y, \dot{y}) = 0@f$
+    //! Object implementing the DAE residual function @f$ f(t, y, \dot{y}) = 0 @f$
     FuncEval* m_func = nullptr;
 
     double m_t0 = 0.0; //!< The start time for the integrator

--- a/include/cantera/numerics/ResidEval.h
+++ b/include/cantera/numerics/ResidEval.h
@@ -28,9 +28,9 @@ const int c_LT_ZERO = -2;
 /**
  *  Virtual base class for DAE residual function evaluators.
  *  Classes derived from ResidEval evaluate the residual function
- * \f[
+ * @f[
  *             \vec{F}(t,\vec{y}, \vec{y^\prime})
- * \f]
+ * @f]
  * The DAE solver attempts to find a solution y(t) such that F = 0.
  * @deprecated Unused. To be removed after %Cantera 3.0.
  *  @ingroup DAE_Group

--- a/include/cantera/numerics/polyfit.h
+++ b/include/cantera/numerics/polyfit.h
@@ -17,7 +17,7 @@ namespace Cantera
  * evaluated at those points, this function computes the weighted least-squares
  * polynomial fit of degree *deg*:
  *
- * \f[ f(x) = p[0] + p[1]*x + p[2]*x^2 + \cdots + p[deg]*x^deg \f]
+ * @f[ f(x) = p[0] + p[1]*x + p[2]*x^2 + \cdots + p[deg]*x^deg @f]
  *
  * @param n    The number of points at which the function is evaluated
  * @param deg  The degree of the polynomial fit to be computed. deg <= n - 1.

--- a/include/cantera/numerics/polyfit.h
+++ b/include/cantera/numerics/polyfit.h
@@ -17,7 +17,7 @@ namespace Cantera
  * evaluated at those points, this function computes the weighted least-squares
  * polynomial fit of degree *deg*:
  *
- * @f[ f(x) = p[0] + p[1]*x + p[2]*x^2 + \cdots + p[deg]*x^deg @f]
+ * @f[ f(x) = p[0] + p[1] x + p[2] x^2 + \cdots + p[deg] x^deg @f]
  *
  * @param n    The number of points at which the function is evaluated
  * @param deg  The degree of the polynomial fit to be computed. deg <= n - 1.

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -320,18 +320,18 @@ public:
 
     void evalSSJacobian();
 
-    //! Solve the equation \f$ J^T \lambda = b \f$.
+    //! Solve the equation @f$ J^T \lambda = b @f$.
     /**
-     * Here, \f$ J = \partial f/\partial x \f$ is the Jacobian matrix of the
-     * system of equations \f$ f(x,p)=0 \f$. This can be used to efficiently
-     * solve for the sensitivities of a scalar objective function \f$ g(x,p) \f$
-     * to a vector of parameters \f$ p \f$ by solving:
-     * \f[ J^T \lambda = \left( \frac{\partial g}{\partial x} \right)^T \f]
-     * for \f$ \lambda \f$ and then computing:
-     * \f[
+     * Here, @f$ J = \partial f/\partial x @f$ is the Jacobian matrix of the
+     * system of equations @f$ f(x,p)=0 @f$. This can be used to efficiently
+     * solve for the sensitivities of a scalar objective function @f$ g(x,p) @f$
+     * to a vector of parameters @f$ p @f$ by solving:
+     * @f[ J^T \lambda = \left( \frac{\partial g}{\partial x} \right)^T @f]
+     * for @f$ \lambda @f$ and then computing:
+     * @f[
      *     \left.\frac{dg}{dp}\right|_{f=0} = \frac{\partial g}{\partial p}
      *         - \lambda^T \frac{\partial f}{\partial p}
-     * \f]
+     * @f]
      */
     void solveAdjoint(const double* b, double* lambda);
 

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -31,25 +31,25 @@ namespace Cantera
  *
  *  A good example of this type of phase is intercalation-based lithium storage
  *  materials used for lithium-ion battery electrodes.  Measuring the open
- *  circuit voltage \f$ E_eq \f$, relative to a reference electrode, as a
+ *  circuit voltage @f$ E_eq @f$, relative to a reference electrode, as a
  *  function of lithium mole fraction and as a function of temperature, provides
  *  a means to evaluate the gibbs free energy of reaction:
  *
- *  \f[
+ *  @f[
  *  \Delta g_{\rm rxn} = -\frac{E_eq}{nF}
- *  \f]
+ *  @f]
  *
- *  where \f$ n\f$ is the charge number transferred to the phase, via the
- *  reaction, and \f$ F \f$ is Faraday's constant.  The gibbs energy of
+ *  where @f$ n@f$ is the charge number transferred to the phase, via the
+ *  reaction, and @f$ F @f$ is Faraday's constant.  The gibbs energy of
  *  reaction, in turn, can be separated into enthalpy and entropy of reaction
  *  components:
  *
- *  \f[
+ *  @f[
  *  \Delta g_{\rm rxn} = \Delta h_{\rm rxn} - T\Delta s_{\rm rxn}
- *  \f]
- *  \f[
+ *  @f]
+ *  @f[
  *  \frac{d\Delta g_{\rm rxn}}{dT} =  - \Delta s_{\rm rxn}
- *  \f]
+ *  @f]
  *
  *  For the tabulated binary phase, the user identifies a 'tabulated' species,
  *  while the other is considered the 'reference' species.  The standard state
@@ -57,15 +57,15 @@ namespace Cantera
  *  excess energy contributions, and are calculated according to the reaction
  *  energy terms:
  *
- *  \f[
+ *  @f[
  *  \Delta h_{\rm rxn} = \sum_k \nu_k h^{\rm o}_k
- *  \f]
- *  \f[
+ *  @f]
+ *  @f[
  *  \Delta s_{\rm rxn} = \sum_k \nu_k s^{\rm o}_k + RT\ln\left(\prod_k\left(\frac{c_k}{c^{\rm o}_k} \right)^{\nu_k}\right)
- *  \f]
+ *  @f]
  *
  *  Where the 'reference' species is automatically assigned standard state
- *  thermo variables \f$ h^{\rm o} = 0\f$ and \f$ s^{\rm o} = 0\f$, and standard
+ *  thermo variables @f$ h^{\rm o} = 0@f$ and @f$ s^{\rm o} = 0@f$, and standard
  *  state thermo variables for species in any other phases are calculated
  *  according to the rules specified in that phase definition.
  *
@@ -73,7 +73,7 @@ namespace Cantera
  *  thermodynamics for binary solutions where the tabulated species is
  *  incorporated via an electrochemical reaction, such that the open circuit
  *  voltage can be measured, relative to a counter electrode species with
- *  standard state thermo properties \f$ h^{\rm o} = 0\f$.
+ *  standard state thermo properties @f$ h^{\rm o} = 0@f$.
  *  It is possible that this can be generalized such that this assumption about
  *  the counter-electrode is not required. At present, this is left as future
  *  work.
@@ -81,35 +81,35 @@ namespace Cantera
  *  The user therefore provides a table of three equally-sized vectors of
  *  tabulated data:
  *
- *  - \f$ x_{\rm tab}\f$ = array of mole fractions for the tabulated species
+ *  - @f$ x_{\rm tab}@f$ = array of mole fractions for the tabulated species
  *                         at which measurements were conducted and thermo
  *                         data are provided.
- *  - \f$ h_{\rm tab}\f$ = \f$ F\left(-E_{\rm eq}\left(x,T^{\rm o} \right) + T^{\rm o} \frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT}\right) \f$
- *  - \f$ s_{\rm tab}\f$ = \f$ F \left(\frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT} + s_{\rm counter}^{\rm o} \right) \f$
+ *  - @f$ h_{\rm tab}@f$ = @f$ F\left(-E_{\rm eq}\left(x,T^{\rm o} \right) + T^{\rm o} \frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT}\right) @f$
+ *  - @f$ s_{\rm tab}@f$ = @f$ F \left(\frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT} + s_{\rm counter}^{\rm o} \right) @f$
  *
- *  where \f$ E_{\rm eq}\left(x,T^{\rm o} \right) \f$ and \f$ \frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT} \f$
+ *  where @f$ E_{\rm eq}\left(x,T^{\rm o} \right) @f$ and @f$ \frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT} @f$
  *  are the experimentally-measured open circuit voltage and derivative in
  *  open circuit voltage with respect to temperature, respectively, both
- *  measured as a mole fraction of \f$ x \f$ for the tabulated species and at a
- *  temperature of \f$ T^{\rm o} \f$.  The arrays \f$ h_{\rm tab}\f$ and
- *  \f$ s_{\rm tab}\f$ must be the same length as the \f$ x_{\rm tab}\f$ array.
+ *  measured as a mole fraction of @f$ x @f$ for the tabulated species and at a
+ *  temperature of @f$ T^{\rm o} @f$.  The arrays @f$ h_{\rm tab}@f$ and
+ *  @f$ s_{\rm tab}@f$ must be the same length as the @f$ x_{\rm tab}@f$ array.
  *
  *  From these tabulated inputs, the standard state thermodynamic properties
- *  for the tabulated species (subscript \f$ k\f$, tab) are calculated as:
+ *  for the tabulated species (subscript @f$ k@f$, tab) are calculated as:
  *
- *  \f[
+ *  @f[
  *   h^{\rm o}_{k,\,{\rm tab}} =  h_{\rm tab}
- *  \f]
- *  \f[
+ *  @f]
+ *  @f[
  *   s^{\rm o}_{k,\,{\rm tab}} =  s_{\rm tab} + R\ln\frac{x_{k,\,{\rm tab}}}{1-x_{k,\,{\rm tab}}} + \frac{R}{F} \ln\left(\frac{c^{\rm o}_{k,\,{\rm ref}}}{c^{\rm o}_{k,\,{\rm tab}}}\right)
- *  \f]
+ *  @f]
  *
  *  Now, whenever the composition has changed, the lookup/interpolation of the
  *  tabulated thermo data is performed to update the standard state
  *  thermodynamic data for the tabulated species.
  *
  *  Furthermore, there is an optional feature to include non-ideal effects regarding
- *  partial molar volumes of the species, \f$ \bar V_k\f$. Being derived from
+ *  partial molar volumes of the species, @f$ \bar V_k@f$. Being derived from
  *  IdealSolidSolnPhase, the default assumption in BinarySolutionTabulatedThermo
  *  is that the species comprising the binary solution have constant partial molar
  *  volumes equal to their pure species molar volumes. However, this assumption only
@@ -121,19 +121,19 @@ namespace Cantera
  *  (XRD) measurements of the unit cell volume. Therefore, the user can provide an optional fourth vector of
  *  tabulated molar volume data with the same size as the other tabulated data:
  *
- *  - \f$ V_{\mathrm{m,tab}}\f$ = array of the molar volume of the binary solution phase at
+ *  - @f$ V_{\mathrm{m,tab}}@f$ = array of the molar volume of the binary solution phase at
  *  the tabulated mole fractions.
  *
- *  The partial molar volumes \f$ \bar V_1\f$ of the tabulated species and
- *  \f$ \bar V_2\f$ of the 'reference' species, respectively, can then be derived from
+ *  The partial molar volumes @f$ \bar V_1@f$ of the tabulated species and
+ *  @f$ \bar V_2@f$ of the 'reference' species, respectively, can then be derived from
  *  the provided molar volume:
  *
- *  \f[
+ *  @f[
  *  \bar V_1 = V_{\mathrm{m,tab}} + \left(1-x_{\mathrm {tab}}\right) \cdot
  *  \frac{\mathrm{d}V_{\mathrm{m,tab}}}{\mathrm{d}x_{\mathrm {tab}}} \\
  *  \bar V_2 = V_{\mathrm{m,tab}} - x_{\mathrm {tab}} \cdot
  *  \frac{\mathrm{d}V_{\mathrm{m,tab}}}{\mathrm{d}x_{\mathrm {tab}}}
- *  \f]
+ *  @f]
  *
  *  The derivation is implemented using forward differences at the boundaries of the
  *  input vector and a central differencing scheme at interior points. As the
@@ -144,12 +144,12 @@ namespace Cantera
  *  The calculation of the mass density incorporates the non-ideal behavior by using
  *  the provided molar volume in the equation:
  *
- *  \f[
+ *  @f[
  *  \rho = \frac{\sum_k{x_k W_k}}{V_\mathrm{m}}
- *  \f]
+ *  @f]
  *
- *  where \f$x_k\f$ are the mole fractions, \f$W_k\f$ are the molecular weights, and
- *  \f$V_\mathrm{m}\f$ is the molar volume interpolated from \f$V_{\mathrm{m,tab}}\f$.
+ *  where @f$x_k@f$ are the mole fractions, @f$W_k@f$ are the molecular weights, and
+ *  @f$V_\mathrm{m}@f$ is the molar volume interpolated from @f$V_{\mathrm{m,tab}}@f$.
  *
  *  If the optional fourth input vector is not specified, the molar volume is calculated
  *  by using the pure species molar volumes, as in IdealSolidSolnPhase. Regardless if the
@@ -199,12 +199,12 @@ public:
      *
      * The formula for this is
      *
-     * \f[
+     * @f[
      * \rho = \frac{\sum_k{X_k W_k}}{V_\mathrm{m}}
-     * \f]
+     * @f]
      *
-     * where \f$X_k\f$ are the mole fractions, \f$W_k\f$ are the molecular weights, and
-     * \f$V_\mathrm{m}\f$ is the molar volume interpolated from \f$V_{\mathrm{m,tab}}\f$.
+     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular weights, and
+     * @f$V_\mathrm{m}@f$ is the molar volume interpolated from @f$V_{\mathrm{m,tab}}@f$.
      */
     virtual void calcDensity();
 

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -39,7 +39,7 @@ namespace Cantera
  *  \Delta g_{\rm rxn} = -\frac{E_eq}{nF}
  *  @f]
  *
- *  where @f$ n@f$ is the charge number transferred to the phase, via the
+ *  where @f$ n @f$ is the charge number transferred to the phase, via the
  *  reaction, and @f$ F @f$ is Faraday's constant.  The gibbs energy of
  *  reaction, in turn, can be separated into enthalpy and entropy of reaction
  *  components:
@@ -65,7 +65,7 @@ namespace Cantera
  *  @f]
  *
  *  Where the 'reference' species is automatically assigned standard state
- *  thermo variables @f$ h^{\rm o} = 0@f$ and @f$ s^{\rm o} = 0@f$, and standard
+ *  thermo variables @f$ h^{\rm o} = 0 @f$ and @f$ s^{\rm o} = 0 @f$, and standard
  *  state thermo variables for species in any other phases are calculated
  *  according to the rules specified in that phase definition.
  *
@@ -73,7 +73,7 @@ namespace Cantera
  *  thermodynamics for binary solutions where the tabulated species is
  *  incorporated via an electrochemical reaction, such that the open circuit
  *  voltage can be measured, relative to a counter electrode species with
- *  standard state thermo properties @f$ h^{\rm o} = 0@f$.
+ *  standard state thermo properties @f$ h^{\rm o} = 0 @f$.
  *  It is possible that this can be generalized such that this assumption about
  *  the counter-electrode is not required. At present, this is left as future
  *  work.
@@ -81,21 +81,21 @@ namespace Cantera
  *  The user therefore provides a table of three equally-sized vectors of
  *  tabulated data:
  *
- *  - @f$ x_{\rm tab}@f$ = array of mole fractions for the tabulated species
+ *  - @f$ x_{\rm tab} @f$ = array of mole fractions for the tabulated species
  *                         at which measurements were conducted and thermo
  *                         data are provided.
- *  - @f$ h_{\rm tab}@f$ = @f$ F\left(-E_{\rm eq}\left(x,T^{\rm o} \right) + T^{\rm o} \frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT}\right) @f$
- *  - @f$ s_{\rm tab}@f$ = @f$ F \left(\frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT} + s_{\rm counter}^{\rm o} \right) @f$
+ *  - @f$ h_{\rm tab} @f$ = @f$ F\left(-E_{\rm eq}\left(x,T^{\rm o} \right) + T^{\rm o} \frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT}\right) @f$
+ *  - @f$ s_{\rm tab} @f$ = @f$ F \left(\frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT} + s_{\rm counter}^{\rm o} \right) @f$
  *
  *  where @f$ E_{\rm eq}\left(x,T^{\rm o} \right) @f$ and @f$ \frac{dE_{\rm eq}\left(x,T^{\rm o} \right)}{dT} @f$
  *  are the experimentally-measured open circuit voltage and derivative in
  *  open circuit voltage with respect to temperature, respectively, both
  *  measured as a mole fraction of @f$ x @f$ for the tabulated species and at a
- *  temperature of @f$ T^{\rm o} @f$.  The arrays @f$ h_{\rm tab}@f$ and
- *  @f$ s_{\rm tab}@f$ must be the same length as the @f$ x_{\rm tab}@f$ array.
+ *  temperature of @f$ T^{\rm o} @f$.  The arrays @f$ h_{\rm tab} @f$ and
+ *  @f$ s_{\rm tab} @f$ must be the same length as the @f$ x_{\rm tab} @f$ array.
  *
  *  From these tabulated inputs, the standard state thermodynamic properties
- *  for the tabulated species (subscript @f$ k@f$, tab) are calculated as:
+ *  for the tabulated species (subscript @f$ k @f$, tab) are calculated as:
  *
  *  @f[
  *   h^{\rm o}_{k,\,{\rm tab}} =  h_{\rm tab}
@@ -109,7 +109,7 @@ namespace Cantera
  *  thermodynamic data for the tabulated species.
  *
  *  Furthermore, there is an optional feature to include non-ideal effects regarding
- *  partial molar volumes of the species, @f$ \bar V_k@f$. Being derived from
+ *  partial molar volumes of the species, @f$ \bar V_k @f$. Being derived from
  *  IdealSolidSolnPhase, the default assumption in BinarySolutionTabulatedThermo
  *  is that the species comprising the binary solution have constant partial molar
  *  volumes equal to their pure species molar volumes. However, this assumption only
@@ -121,11 +121,11 @@ namespace Cantera
  *  (XRD) measurements of the unit cell volume. Therefore, the user can provide an optional fourth vector of
  *  tabulated molar volume data with the same size as the other tabulated data:
  *
- *  - @f$ V_{\mathrm{m,tab}}@f$ = array of the molar volume of the binary solution phase at
+ *  - @f$ V_{\mathrm{m,tab}} @f$ = array of the molar volume of the binary solution phase at
  *  the tabulated mole fractions.
  *
- *  The partial molar volumes @f$ \bar V_1@f$ of the tabulated species and
- *  @f$ \bar V_2@f$ of the 'reference' species, respectively, can then be derived from
+ *  The partial molar volumes @f$ \bar V_1 @f$ of the tabulated species and
+ *  @f$ \bar V_2 @f$ of the 'reference' species, respectively, can then be derived from
  *  the provided molar volume:
  *
  *  @f[
@@ -148,8 +148,8 @@ namespace Cantera
  *  \rho = \frac{\sum_k{x_k W_k}}{V_\mathrm{m}}
  *  @f]
  *
- *  where @f$x_k@f$ are the mole fractions, @f$W_k@f$ are the molecular weights, and
- *  @f$V_\mathrm{m}@f$ is the molar volume interpolated from @f$V_{\mathrm{m,tab}}@f$.
+ *  where @f$ x_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular weights, and
+ *  @f$ V_\mathrm{m} @f$ is the molar volume interpolated from @f$ V_{\mathrm{m,tab}} @f$.
  *
  *  If the optional fourth input vector is not specified, the molar volume is calculated
  *  by using the pure species molar volumes, as in IdealSolidSolnPhase. Regardless if the
@@ -203,8 +203,8 @@ public:
      * \rho = \frac{\sum_k{X_k W_k}}{V_\mathrm{m}}
      * @f]
      *
-     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular weights, and
-     * @f$V_\mathrm{m}@f$ is the molar volume interpolated from @f$V_{\mathrm{m,tab}}@f$.
+     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular weights, and
+     * @f$ V_\mathrm{m} @f$ is the molar volume interpolated from @f$ V_{\mathrm{m,tab}} @f$.
      */
     virtual void calcDensity();
 

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -23,21 +23,21 @@ namespace Cantera
  * following relations are used to complete the specification of the
  * thermodynamic functions for the species.
  *
- * \f[
+ * @f[
  * \frac{c_p(T)}{R} = Cp0\_R
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \frac{h^0(T)}{RT} = \frac{1}{T} * (h0\_R + (T - T_0) * Cp0\_R)
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \frac{s^0(T)}{R} =  (s0\_R + (log(T) - log(T_0)) * Cp0\_R)
- * \f]
+ * @f]
  *
  * This parameterization takes 4 input values. These are:
- *       -   c[0] = \f$ T_0 \f$(Kelvin)
- *       -   c[1] = \f$ H_k^o(T_0, p_{ref}) \f$ (J/kmol)
- *       -   c[2] = \f$ S_k^o(T_0, p_{ref}) \f$    (J/kmol K)
- *       -   c[3] = \f$ {Cp}_k^o(T_0, p_{ref}) \f$  (J(kmol K)
+ *       -   c[0] = @f$ T_0 @f$(Kelvin)
+ *       -   c[1] = @f$ H_k^o(T_0, p_{ref}) @f$ (J/kmol)
+ *       -   c[2] = @f$ S_k^o(T_0, p_{ref}) @f$    (J/kmol K)
+ *       -   c[3] = @f$ {Cp}_k^o(T_0, p_{ref}) @f$  (J(kmol K)
  *
  * @ingroup spthermo
  */
@@ -54,18 +54,18 @@ public:
      * @param coeffs       Vector of coefficients used to set the parameters for
      *                     the standard state for species n. There are 4
      *                     coefficients for the ConstCpPoly parameterization.
-     *           -   c[0] = \f$ T_0 \f$(Kelvin)
-     *           -   c[1] = \f$ H_k^o(T_0, p_{ref}) \f$ (J/kmol)
-     *           -   c[2] = \f$ S_k^o(T_0, p_{ref}) \f$    (J/kmol K)
-     *           -   c[3] = \f$ {Cp}_k^o(T_0, p_{ref}) \f$  (J(kmol K)
+     *           -   c[0] = @f$ T_0 @f$(Kelvin)
+     *           -   c[1] = @f$ H_k^o(T_0, p_{ref}) @f$ (J/kmol)
+     *           -   c[2] = @f$ S_k^o(T_0, p_{ref}) @f$    (J/kmol K)
+     *           -   c[3] = @f$ {Cp}_k^o(T_0, p_{ref}) @f$  (J(kmol K)
      */
     ConstCpPoly(double tlow, double thigh, double pref, const double* coeffs);
 
     /*!
-     * @param t0  \f$ T_0 \f$ [K]
-     * @param h0  \f$ h_k^o(T_0, p_{ref}) \f$ [J/kmol]
-     * @param s0  \f$ s_k^o(T_0, p_{ref}) \f$ [J/kmol/K]
-     * @param cp0  \f$ c_{p,k}^o(T_0, p_{ref}) \f$ [J/kmol/K]
+     * @param t0  @f$ T_0 @f$ [K]
+     * @param h0  @f$ h_k^o(T_0, p_{ref}) @f$ [J/kmol]
+     * @param s0  @f$ s_k^o(T_0, p_{ref}) @f$ [J/kmol/K]
+     * @param cp0  @f$ c_{p,k}^o(T_0, p_{ref}) @f$ [J/kmol/K]
      */
     void setParameters(double t0, double h0, double s0, double cp0);
 

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -34,7 +34,7 @@ namespace Cantera
  * @f]
  *
  * This parameterization takes 4 input values. These are:
- *       -   c[0] = @f$ T_0 @f$(Kelvin)
+ *       -   c[0] = @f$ T_0 @f$ (Kelvin)
  *       -   c[1] = @f$ H_k^o(T_0, p_{ref}) @f$ (J/kmol)
  *       -   c[2] = @f$ S_k^o(T_0, p_{ref}) @f$    (J/kmol K)
  *       -   c[3] = @f$ {Cp}_k^o(T_0, p_{ref}) @f$  (J(kmol K)
@@ -54,7 +54,7 @@ public:
      * @param coeffs       Vector of coefficients used to set the parameters for
      *                     the standard state for species n. There are 4
      *                     coefficients for the ConstCpPoly parameterization.
-     *           -   c[0] = @f$ T_0 @f$(Kelvin)
+     *           -   c[0] = @f$ T_0 @f$ (Kelvin)
      *           -   c[1] = @f$ H_k^o(T_0, p_{ref}) @f$ (J/kmol)
      *           -   c[2] = @f$ S_k^o(T_0, p_{ref}) @f$    (J/kmol K)
      *           -   c[3] = @f$ {Cp}_k^o(T_0, p_{ref}) @f$  (J(kmol K)

--- a/include/cantera/thermo/CoverageDependentSurfPhase.h
+++ b/include/cantera/thermo/CoverageDependentSurfPhase.h
@@ -35,32 +35,32 @@ namespace Cantera
  * to cause lateral interaction. Therefore, it is logical to set ideal surface
  * species properties as the low-coverage limit and add lateral interaction terms
  * to them as excess properties. Accordingly, standard state coverage-dependent
- * enthalpy, entropy, and heat capacity of a surface species \f$ k \f$ can be
+ * enthalpy, entropy, and heat capacity of a surface species @f$ k @f$ can be
  * formulated as follows.
  *
- * \f[
+ * @f[
  *  h_k^o(T,\theta)
  *      = \underbrace{h_k^{o,ideal}(T)
  *        + \int_{298}^{T}c_{p,k}^{o,ideal}(T)dT}_{\text{low-coverage limit}}
  *        + \underbrace{h_k^{o,cov}(T,\theta)
  *        + \int_{298}^{T}c_{p,k}^{o,cov}(T,\theta)dT}_{\text{coverage dependence}}
  *
- * \f]
+ * @f]
  *
- * \f[
+ * @f[
  *  s_k^o(T,\theta)
  *     = \underbrace{s_k^{o,ideal}(T)
  *       + \int_{298}^{T}\frac{c_{p,k}^{o,ideal}(T)}{T}dT}_{\text{low-coverage limit}}
  *       + \underbrace{s_k^{o,cov}(T,\theta)
  *       + \int_{298}^{T}\frac{c_{p,k}^{o,cov}(T,\theta)}{T}dT}_{\text{coverage
  *         dependence}}
- * \f]
+ * @f]
  *
- * \f[
+ * @f[
  *  c_{p,k}^o(T,\theta)
  *      = \underbrace{c_{p,k}^{o,ideal}(T)}_{\text{low-coverage limit}}
  *        + \underbrace{c_{p,k}^{o,cov}(T,\theta)}_{\text{coverage dependence}}
- * \f]
+ * @f]
  *
  * ## Mathematical Models for Coverage-dependent Correction Terms
  *
@@ -68,27 +68,27 @@ namespace Cantera
  * with one of the four algebraic models: linear dependecy model, polynomial
  * dependency model, piecewise-linear, and interpolative dependency model.
  * In the dependency model equations, a coverage-dependent correction term is denoted
- * by \f$ f^{cov} \f$ where \f$ f \f$ can be either enthalpy (\f$ h^{cov} \f$) or
- * entropy (\f$ s^{cov} \f$). Because lateral interaction can compose of both
- * self- and cross- interactions, the total correction term of species \f$ k \f$
- * is a sum of all interacting species \f$ j \f$ which can include itself.
- * Coefficients \f$ c^{(1)}_{k,j}-c^{(6)}_{k,j} \f$ are user-provided parameters
+ * by @f$ f^{cov} @f$ where @f$ f @f$ can be either enthalpy (@f$ h^{cov} @f$) or
+ * entropy (@f$ s^{cov} @f$). Because lateral interaction can compose of both
+ * self- and cross- interactions, the total correction term of species @f$ k @f$
+ * is a sum of all interacting species @f$ j @f$ which can include itself.
+ * Coefficients @f$ c^{(1)}_{k,j}-c^{(6)}_{k,j} @f$ are user-provided parameters
  * that can be given in a input yaml.
  *
  * Linear dependency model:
- * \f[
+ * @f[
  *  f^{cov}_k(\theta) = \sum_j c^{(1)}_{k,j} \theta_j
- * \f]
+ * @f]
  *
  * Polynomial dependency model:
- * \f[
+ * @f[
  *  f^{cov}_k(\theta) =
  *   \sum_j \left[c^{(1)}_{k,j}\theta_j + c^{(2)}_{k,j}\theta_j^2
  *           + c^{(3)}_{k,j}\theta_j^3 + c^{(4)}_{k,j}\theta_j^4\right]
- * \f]
+ * @f]
  *
  * Piecewise-linear dependency model:
- * \f[
+ * @f[
  * f^{cov}_k(\theta) = \sum_j \left\{
  *  \begin{array}{ll}
  *  c^{(5)}_{k,j}\theta_j & \text{, } \theta_j \leq \theta^\text{change}_{k,j} \\
@@ -97,31 +97,31 @@ namespace Cantera
  *  & \text{, } \theta_j > \theta^\text{change}_{k,j} \\
  *  \end{array}
  *  \right.
- * \f]
+ * @f]
  *
  * Interpolative dependency model:
- * \f[
+ * @f[
  *  f^{cov}_k(\theta) =
  *   \sum_j \left[\frac{f^{cov}_k(\theta^{higher}_j) - f^{cov}_k(\theta^{lower}_j)}
  *   {\theta^{higher}_j - \theta^{lower}_j}(\theta_j - \theta^{lower}_j)
  *   + f^{cov}_k (\theta^{lower}_j)\right] \\
  *   \text{where } \theta^{lower}_j \leq \theta_j < \theta^{higher}_j
- * \f]
+ * @f]
  *
  * Coverage-dependent heat capacity is calculated using an equation with a
  * quadratic dependence on coverages and a logarithmic dependence on temperature.
  * Temperature is nondimensionalized with a reference temperature of 1 K.
- * The coverage-dependent heat capacity of species \f$ k \f$ is a sum of
- * all quantities dependent on coverage of species \f$ j \f$. Coefficients
- * \f$ c^{(a)}_{k,j} \text{ and } c^{(b)}_{k,j} \f$ are user-provided parameters
+ * The coverage-dependent heat capacity of species @f$ k @f$ is a sum of
+ * all quantities dependent on coverage of species @f$ j @f$. Coefficients
+ * @f$ c^{(a)}_{k,j} \text{ and } c^{(b)}_{k,j} @f$ are user-provided parameters
  * that can be given in an input yaml.
  *
  * Coverage-dependent heat capacity model:
- * \f[
+ * @f[
  *  c^{cov}_{p,k}(\theta) =
  *   \sum_j \left(c^{(a)}_{k,j} \ln\left(\frac{T}{1\text{ K}}\right)
  *   + c^{(b)}_{k,j}\right) \theta_j^2
- * \f]
+ * @f]
  */
 class CoverageDependentSurfPhase : public SurfPhase
 {
@@ -174,12 +174,12 @@ public:
         size_t j;
         //! array of polynomial coefficients describing coverage-dependent enthalpy
         //! [J/kmol] in order of 1st-order, 2nd-order, 3rd-order, and 4th-order
-        //! coefficients (\f$ c^{(1)}, c^{(2)}, c^{(3)}, \text{ and } c^{(4)} \f$
+        //! coefficients (@f$ c^{(1)}, c^{(2)}, c^{(3)}, \text{ and } c^{(4)} @f$
         //! in the linear or the polynomial dependency model)
         vector_fp enthalpy_coeffs;
         //! array of polynomial coefficients describing coverage-dependent entropy
         //! [J/kmol/K] in order of 1st-order, 2nd-order, 3rd-order, and 4th-order
-        //! coefficients (\f$ c^{(1)}, c^{(2)}, c^{(3)}, \text{ and } c^{(4)} \f$
+        //! coefficients (@f$ c^{(1)}, c^{(2)}, c^{(3)}, \text{ and } c^{(4)} @f$
         //! in the linear or the polynomial dependency model)
         vector_fp entropy_coeffs;
         //! boolean indicating whether the dependency is linear
@@ -293,10 +293,10 @@ public:
         //! index of a species whose coverage affects heat capacity of
         //! a target species
         size_t j;
-        //! coefficient \f$ c^{(a)} \f$ [J/kmol/K] in the coverage-dependent
+        //! coefficient @f$ c^{(a)} @f$ [J/kmol/K] in the coverage-dependent
         //! heat capacity model
         double coeff_a;
-        //! coefficient \f$ c^{(b)} \f$ [J/kmol/K] in the coverage-dependent
+        //! coefficient @f$ c^{(b)} @f$ [J/kmol/K] in the coverage-dependent
         //! heat capacity model
         double coeff_b;
     };
@@ -328,8 +328,8 @@ public:
                                       AnyMap& speciesNode) const;
 
     //! @name Methods calculating reference state thermodynamic properties
-    //! Reference state properties are evaluated at \f$ T \text{ and }
-    //! \theta^{ref} \f$. With coverage fixed at a reference value,
+    //! Reference state properties are evaluated at @f$ T \text{ and }
+    //! \theta^{ref} @f$. With coverage fixed at a reference value,
     //! reference state properties are effectively only dependent on temperature.
     //! @{
     virtual void getEnthalpy_RT_ref(double* hrt) const;
@@ -339,131 +339,131 @@ public:
     //! @}
 
     //! @name Methods calculating standard state thermodynamic properties
-    //! Standard state properties are evaluated at \f$ T \text{ and } \theta \f$,
+    //! Standard state properties are evaluated at @f$ T \text{ and } \theta @f$,
     //! and thus are dependent both on temperature and coverage.
     //! @{
 
     //! Get the nondimensionalized standard state enthalpy vector.
     /*!
-     * \f[
+     * @f[
      *      \frac{h^o_k(T,\theta)}{RT}
      *          = \frac{h^{ref}_k(T) + h^{cov}_k(T,\theta)
      *            + \int_{298}^{T} c^{cov}_{p,k}(T,\theta)dT}{RT}
-     * \f]
+     * @f]
      */
     virtual void getEnthalpy_RT(double* hrt) const;
 
     //! Get the nondimensionalized standard state entropy vector.
     /*!
-     * \f[
+     * @f[
      *      \frac{s^o_k(T,\theta)}{R}
      *          = \frac{s^{ref}_k(T) + s^{cov}_k(T,\theta)
      *            + \int_{298}^{T}\frac{c^{cov}_{p,k}(T,\theta)}{T}dT}{R}
      *            - \ln\left(\frac{1}{\theta_{ref}}\right)
-     * \f]
+     * @f]
      */
     virtual void getEntropy_R(double* sr) const;
 
     //! Get the nondimensionalized standard state heat capacity vector.
     /*!
-     * \f[
+     * @f[
      *      \frac{c^o_{p,k}(T,\theta)}{RT}
      *          = \frac{c^{ref}_{p,k}(T) + c^{cov}_{p,k}(T,\theta)}{RT}
-     * \f]
+     * @f]
      */
     virtual void getCp_R(double* cpr) const;
 
     //! Get the nondimensionalized standard state gibbs free energy vector.
     /*!
-     * \f[
+     * @f[
      *      \frac{g^o_k(T,\theta)}{RT}
      *          = \frac{h^o_k(T,\theta)}{RT} + \frac{s^o_k(T,\theta)}{R}
-     * \f]
+     * @f]
      */
     virtual void getGibbs_RT(double* grt) const;
 
     //! Get the standard state gibbs free energy vector. Units: J/kmol.
     /*!
-     * \f[
+     * @f[
      *      g^o_k(T,\theta) = h^o_k(T,\theta) + Ts^o_k(T,\theta)
-     * \f]
+     * @f]
      */
     virtual void getPureGibbs(double* g) const;
 
     //! Get the standard state chemical potential vector. Units: J/kmol.
     /*!
-     * \f[
+     * @f[
      *      \mu^o_k(T,\theta) = h^o_k(T,\theta) + Ts^o_k(T,\theta)
-     * \f]
+     * @f]
      */
     virtual void getStandardChemPotentials(double* mu0) const;
     //! @}
 
     //! @name Methods calculating partial molar thermodynamic properties
-    //! Partial molar properties are evaluated at \f$ T \text{ and } \theta \f$,
+    //! Partial molar properties are evaluated at @f$ T \text{ and } \theta @f$,
     //! and thus are dependent both on temperature and coverage.
     //! @{
 
     //! Get the partial molar enthalpy vector. Units: J/kmol.
     /*!
-     * \f[
+     * @f[
      *      \tilde{h}_k(T,\theta) = h^o_k(T,\theta)
-     * \f]
+     * @f]
      */
     virtual void getPartialMolarEnthalpies(double* hbar) const;
 
     //! Get the partial molar entropy vector. Units: J/kmol/K.
     /*!
-     * \f[
+     * @f[
      *      \tilde{s}_k(T,\theta) = s^o_k(T,\theta) - R\ln(\theta_k)
-     * \f]
+     * @f]
      */
     virtual void getPartialMolarEntropies(double* sbar) const;
 
     //! Get the partial molar heat capacity vector. Units: J/kmol/K.
     /*!
-     * \f[
+     * @f[
      *      \tilde{c}_{p,k}(T,\theta) = c^o_{p,k}(T,\theta)
-     * \f]
+     * @f]
      */
     virtual void getPartialMolarCp(double* cpbar) const;
 
     //! Get the chemical potential vector. Units: J/kmol.
     /*!
-     * \f[
+     * @f[
      *      \mu_k(T,\theta) = \mu^o_k(T,\theta) + RT\ln(\theta_k)
-     * \f]
+     * @f]
      */
     virtual void getChemPotentials(double* mu) const;
     //! @}
 
     //! @name Methods calculating Phase thermodynamic properties
-    //! Phase properties are evaluated at \f$ T \text{ and } \theta \f$,
+    //! Phase properties are evaluated at @f$ T \text{ and } \theta @f$,
     //! and thus are dependent both on temperature and coverage.
 
     //! @{
 
     //! Return the solution's molar enthalpy. Units: J/kmol
     /*!
-     * \f[
+     * @f[
      *      \hat h(T,\theta) = \sum_k \theta_k \tilde{h}_k(T,\theta)
-     * \f]
+     * @f]
      */
     virtual double enthalpy_mole() const;
 
     //! Return the solution's molar entropy. Units: J/kmol/K
     /*!
-     * \f[
+     * @f[
      *      \hat s(T,\theta) = \sum_k \theta_k \tilde{s}_k(T,\theta)
-     * \f]
+     * @f]
      */
     virtual double entropy_mole() const;
 
     //! Return the solution's molar heat capacity. Units: J/kmol/K
     /*!
-     * \f[
+     * @f[
      *      \hat{c_p}(T,\theta) = \sum_k \theta_k \tilde{c_p}_k(T,\theta)
-     * \f]
+     * @f]
      */
     virtual double cp_mole() const;
     //! @}

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -54,9 +54,9 @@ class PDSS_Water;
  * ## Specification of Species Standard State Properties
  *
  * The standard states are on the unit molality basis. Therefore, in the
- * documentation below, the normal \f$ o \f$ superscript is replaced with the
- * \f$ \triangle \f$ symbol. The reference state symbol is now
- *  \f$ \triangle, ref \f$.
+ * documentation below, the normal @f$ o @f$ superscript is replaced with the
+ * @f$ \triangle @f$ symbol. The reference state symbol is now
+ *  @f$ \triangle, ref @f$.
  *
  * It is assumed that the reference state thermodynamics may be obtained by a
  * pointer to a populated species thermodynamic property manager class (see
@@ -65,26 +65,26 @@ class PDSS_Water;
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term \f$ P_0 \hat v\f$ is subtracted
+ * giving the standard-state enthalpy, the term @f$ P_0 \hat v@f$ is subtracted
  * from the specified molar enthalpy to compute the molar internal energy. The
  * entropy is assumed to be independent of the pressure.
  *
  * The enthalpy function is given by the following relation.
  *
- * \f[
+ * @f[
  *      h^\triangle_k(T,P) = h^{\triangle,ref}_k(T)
  *      + \tilde v \left( P - P_{ref} \right)
- * \f]
+ * @f]
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term \f$ P_{ref} \tilde v\f$ is
+ * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v@f$ is
  * subtracted from the specified reference molar enthalpy to compute the molar
  * internal energy.
  *
- * \f[
+ * @f[
  *      u^\triangle_k(T,P) = h^{\triangle,ref}_k(T) - P_{ref} \tilde v
- * \f]
+ * @f]
  *
  * The standard state heat capacity and entropy are independent of pressure. The
  * standard state Gibbs free energy is obtained from the enthalpy and entropy
@@ -99,18 +99,18 @@ class PDSS_Water;
  *
  * ## Specification of Solution Thermodynamic Properties
  *
- * Chemical potentials of the solutes, \f$ \mu_k \f$, and the solvent, \f$ \mu_o
- * \f$, which are based on the molality form, have the following general format:
+ * Chemical potentials of the solutes, @f$ \mu_k @f$, and the solvent, @f$ \mu_o
+ * @f$, which are based on the molality form, have the following general format:
  *
- * \f[
+ * @f[
  *    \mu_k = \mu^{\triangle}_k(T,P) + R T ln(\gamma_k^{\triangle} \frac{m_k}{m^\triangle})
- * \f]
- * \f[
+ * @f]
+ * @f[
  *    \mu_o = \mu^o_o(T,P) + RT ln(a_o)
- * \f]
+ * @f]
  *
- * where \f$ \gamma_k^{\triangle} \f$ is the molality based activity coefficient
- * for species \f$k\f$.
+ * where @f$ \gamma_k^{\triangle} @f$ is the molality based activity coefficient
+ * for species @f$k@f$.
  *
  * Individual activity coefficients of ions can not be independently measured.
  * Instead, only binary pairs forming electroneutral solutions can be measured.
@@ -118,13 +118,13 @@ class PDSS_Water;
  * ### Ionic Strength
  *
  * Most of the parameterizations within the model use the ionic strength as a
- * key variable. The ionic strength, \f$ I\f$ is defined as follows
+ * key variable. The ionic strength, @f$ I@f$ is defined as follows
  *
- *  \f[
+ *  @f[
  *    I = \frac{1}{2} \sum_k{m_k  z_k^2}
- *  \f]
+ *  @f]
  *
- * \f$ m_k \f$ is the molality of the kth species. \f$ z_k \f$ is the charge of
+ * @f$ m_k @f$ is the molality of the kth species. @f$ z_k @f$ is the charge of
  * the kth species. Note, the ionic strength is a defined units quantity. The
  * molality has defined units of gmol kg-1, and therefore the ionic strength has
  * units of sqrt( gmol kg-1).
@@ -139,38 +139,38 @@ class PDSS_Water;
  * the ionic strength, then we will want to consider the associated weak acid as
  * in effect being fully dissociated, when we calculate an effective value for
  * the ionic strength. We will call this calculated value, the stoichiometric
- * ionic strength, \f$ I_s \f$, putting a subscript s to denote it from the more
- * straightforward calculation of \f$ I \f$.
+ * ionic strength, @f$ I_s @f$, putting a subscript s to denote it from the more
+ * straightforward calculation of @f$ I @f$.
  *
- *  \f[
+ *  @f[
  *    I_s = \frac{1}{2} \sum_k{m_k^s  z_k^2}
- *  \f]
+ *  @f]
  *
- * Here, \f$ m_k^s \f$ is the value of the molalities calculated assuming that
+ * Here, @f$ m_k^s @f$ is the value of the molalities calculated assuming that
  * all weak acid-base pairs are in their fully dissociated states. This
  * calculation may be simplified by considering that the weakly associated acid
  * may be made up of two charged species, k1 and k2, each with their own
  * charges, obeying the following relationship:
  *
- *   \f[
+ *   @f[
  *      z_k = z_{k1} +  z_{k2}
- *   \f]
- * Then, we may only need to specify one charge value, say, \f$  z_{k1}\f$, the
+ *   @f]
+ * Then, we may only need to specify one charge value, say, @f$  z_{k1}@f$, the
  * cation charge number, in order to get both numbers, since we have already
- * specified \f$ z_k \f$ in the definition of original species. Then, the
+ * specified @f$ z_k @f$ in the definition of original species. Then, the
  * stoichiometric ionic strength may be calculated via the following formula.
  *
- *  \f[
+ *  @f[
  *    I_s = \frac{1}{2} \left(\sum_{k,ions}{m_k  z_k^2}+
  *               \sum_{k,weak_assoc}(m_k  z_{k1}^2 + m_k  z_{k2}^2) \right)
- *  \f]
+ *  @f]
  *
  * The specification of which species are weakly associated acids is made in YAML
- * input files by specifying the corresponding charge \f$k1\f$ as the `weak-acid-charge`
+ * input files by specifying the corresponding charge @f$k1@f$ as the `weak-acid-charge`
  * parameter of the `Debye-Huckel` block in the corresponding species entry.
  *
  * Because we need the concept of a weakly associated acid in order to calculate
- * \f$ I_s \f$ we need to catalog all species in the phase. This is done using
+ * @f$ I_s @f$ we need to catalog all species in the phase. This is done using
  * the following categories:
  *
  *  -  `cEST_solvent`                Solvent species (neutral)
@@ -208,20 +208,20 @@ class PDSS_Water;
  * DHFORM_DILUTE_LIMIT = 0
  *
  * This form assumes a dilute limit to DH, and is mainly for informational purposes:
- * \f[
+ * @f[
  *     \ln(\gamma_k^\triangle) = - z_k^2 A_{Debye} \sqrt{I}
- * \f]
- * where \f$ I\f$ is the ionic strength
- * \f[
+ * @f]
+ * where @f$ I@f$ is the ionic strength
+ * @f[
  *   I = \frac{1}{2} \sum_k{m_k  z_k^2}
- * \f]
+ * @f]
  *
- * The activity for the solvent water,\f$ a_o \f$, is not independent and must
+ * The activity for the solvent water,@f$ a_o @f$, is not independent and must
  * be determined from the Gibbs-Duhem relation.
  *
- * \f[
+ * @f[
  *      \ln(a_o) = \frac{X_o - 1.0}{X_o} + \frac{ 2 A_{Debye} \tilde{M}_o}{3} (I)^{3/2}
- * \f]
+ * @f]
  *
  * ### Bdot Formulation
  *
@@ -229,28 +229,28 @@ class PDSS_Water;
  *
  * This form assumes Bethke's format for the Debye Huckel activity coefficient:
  *
- * \f[
+ * @f[
  *    \ln(\gamma_k^\triangle) = -z_k^2 \frac{A_{Debye} \sqrt{I}}{ 1 + B_{Debye}  a_k \sqrt{I}}
  *                        + \log(10) B^{dot}_k  I
- * \f]
+ * @f]
  *
- * Note, this particular form where \f$ a_k \f$ can differ in multielectrolyte
+ * Note, this particular form where @f$ a_k @f$ can differ in multielectrolyte
  * solutions has problems with respect to a Gibbs-Duhem analysis. However, we
  * include it here because there is a lot of data fit to it.
  *
- * The activity for the solvent water,\f$ a_o \f$, is not independent and must
+ * The activity for the solvent water,@f$ a_o @f$, is not independent and must
  * be determined from the Gibbs-Duhem relation. Here, we use:
  *
- *  \f[
+ *  @f[
  *       \ln(a_o) = \frac{X_o - 1.0}{X_o}
  *        + \frac{ 2 A_{Debye} \tilde{M}_o}{3} (I)^{1/2}
  *                        \left[ \sum_k{\frac{1}{2} m_k z_k^2 \sigma( B_{Debye} a_k \sqrt{I} ) } \right]
  *                        - \frac{\log(10)}{2} \tilde{M}_o I \sum_k{ B^{dot}_k m_k}
- *  \f]
+ *  @f]
  *    where
- *  \f[
+ *  @f[
  *     \sigma (y) = \frac{3}{y^3} \left[ (1+y) - 2 \ln(1 + y) - \frac{1}{1+y} \right]
- *  \f]
+ *  @f]
  *
  * Additionally, Helgeson's formulation for the water activity is offered as an
  * alternative.
@@ -261,18 +261,18 @@ class PDSS_Water;
  *
  * This form assumes Bethke's format for the Debye-Huckel activity coefficient
  *
- * \f[
+ * @f[
  *    \ln(\gamma_k^\triangle) = -z_k^2 \frac{A_{Debye} \sqrt{I}}{ 1 + B_{Debye}  a \sqrt{I}}
  *                        + \log(10) B^{dot}_k  I
- * \f]
+ * @f]
  *
  * The value of a is determined at the beginning of the calculation, and not changed.
  *
- *  \f[
+ *  @f[
  *       \ln(a_o) = \frac{X_o - 1.0}{X_o}
  *        + \frac{ 2 A_{Debye} \tilde{M}_o}{3} (I)^{3/2} \sigma( B_{Debye} a \sqrt{I} )
  *                        - \frac{\log(10)}{2} \tilde{M}_o I \sum_k{ B^{dot}_k m_k}
- *  \f]
+ *  @f]
  *
  * ### Beta_IJ formulation
  *
@@ -283,26 +283,26 @@ class PDSS_Water;
  * beginning of more complex treatments for stronger electrolytes, fom Pitzer
  * and from Harvey, Moller, and Weire.
  *
- * \f[
+ * @f[
  *    \ln(\gamma_k^\triangle) = -z_k^2 \frac{A_{Debye} \sqrt{I}}{ 1 + B_{Debye}  a \sqrt{I}}
  *                         + 2 \sum_j \beta_{j,k} m_j
- * \f]
+ * @f]
  *
- * In the current treatment the binary interaction coefficients, \f$
- * \beta_{j,k}\f$, are independent of temperature and pressure.
+ * In the current treatment the binary interaction coefficients, @f$
+ * \beta_{j,k}@f$, are independent of temperature and pressure.
  *
- * \f[
+ * @f[
  *    \ln(a_o) = \frac{X_o - 1.0}{X_o}
  *     + \frac{ 2 A_{Debye} \tilde{M}_o}{3} (I)^{3/2} \sigma( B_{Debye} a \sqrt{I} )
  *     -  \tilde{M}_o  \sum_j \sum_k \beta_{j,k} m_j m_k
- * \f]
+ * @f]
  *
- * In this formulation the ionic radius, \f$ a \f$, is a constant, specified as part
+ * In this formulation the ionic radius, @f$ a @f$, is a constant, specified as part
  * of the species definition.
  *
- * The \f$ \beta_{j,k} \f$ parameters are binary interaction parameters. There are in
- * principle \f$ N (N-1) /2 \f$ different, symmetric interaction parameters,
- * where \f$ N \f$ are the number of solute species in the mechanism.
+ * The @f$ \beta_{j,k} @f$ parameters are binary interaction parameters. There are in
+ * principle @f$ N (N-1) /2 @f$ different, symmetric interaction parameters,
+ * where @f$ N @f$ are the number of solute species in the mechanism.
  *
  * ### Pitzer Beta_IJ formulation
  *
@@ -313,54 +313,54 @@ class PDSS_Water;
  * the formulations above in the dilute limit, where rigorous theory may be
  * applied.
  *
- * \f[
+ * @f[
  *    \ln(\gamma_k^\triangle) = -z_k^2 \frac{A_{Debye}}{3} \frac{\sqrt{I}}{ 1 + B_{Debye}  a \sqrt{I}}
  *       -2 z_k^2 \frac{A_{Debye}}{3}  \frac{\ln(1 + B_{Debye}  a  \sqrt{I})}{ B_{Debye}  a}
  *                         + 2 \sum_j \beta_{j,k} m_j
- * \f]
- * \f[
+ * @f]
+ * @f[
  *       \ln(a_o) = \frac{X_o - 1.0}{X_o}
  *        + \frac{ 2 A_{Debye} \tilde{M}_o}{3} \frac{(I)^{3/2} }{1 +  B_{Debye}  a \sqrt{I} }
  *        -  \tilde{M}_o  \sum_j \sum_k \beta_{j,k} m_j m_k
- * \f]
+ * @f]
  *
  * ### Specification of the Debye Huckel Constants
  *
- * In the equations above, the formulas for  \f$  A_{Debye} \f$ and \f$
- * B_{Debye} \f$ are needed. The DebyeHuckel object uses two methods for
- * specifying these quantities. The default method is to assume that \f$
- * A_{Debye} \f$  is a constant, given in the initialization process, and stored
+ * In the equations above, the formulas for  @f$  A_{Debye} @f$ and @f$
+ * B_{Debye} @f$ are needed. The DebyeHuckel object uses two methods for
+ * specifying these quantities. The default method is to assume that @f$
+ * A_{Debye} @f$  is a constant, given in the initialization process, and stored
  * in the member double, m_A_Debye. Optionally, a full water treatment may be
- * employed that makes \f$ A_{Debye} \f$ a full function of *T* and *P*.
+ * employed that makes @f$ A_{Debye} @f$ a full function of *T* and *P*.
  *
- * \f[
+ * @f[
  *      A_{Debye} = \frac{F e B_{Debye}}{8 \pi \epsilon R T} {\left( C_o \tilde{M}_o \right)}^{1/2}
- * \f]
+ * @f]
  * where
- *  \f[
+ *  @f[
  *         B_{Debye} = \frac{F} {{(\frac{\epsilon R T}{2})}^{1/2}}
- *  \f]
+ *  @f]
  * Therefore:
- * \f[
+ * @f[
  *   A_{Debye} = \frac{1}{8 \pi}
  *                 {\left(\frac{2 N_a \rho_o}{1000}\right)}^{1/2}
  *                 {\left(\frac{N_a e^2}{\epsilon R T }\right)}^{3/2}
- * \f]
+ * @f]
  * where
- *   - \f$ N_a \f$ is Avogadro's number
- *   - \f$ \rho_w \f$ is the density of water
- *   - \f$ e \f$ is the electronic charge
- *   - \f$ \epsilon = K \epsilon_o \f$ is the permittivity of water
- *   - \f$ K \f$ is the dielectric constant of water
- *   - \f$ \epsilon_o \f$ is the permittivity of free space
- *   - \f$ \rho_o \f$ is the density of the solvent in its standard state.
+ *   - @f$ N_a @f$ is Avogadro's number
+ *   - @f$ \rho_w @f$ is the density of water
+ *   - @f$ e @f$ is the electronic charge
+ *   - @f$ \epsilon = K \epsilon_o @f$ is the permittivity of water
+ *   - @f$ K @f$ is the dielectric constant of water
+ *   - @f$ \epsilon_o @f$ is the permittivity of free space
+ *   - @f$ \rho_o @f$ is the density of the solvent in its standard state.
  *
  * Nominal value at 298 K and 1 atm = 1.172576 (kg/gmol)^(1/2) based on:
- *   - \f$ \epsilon / \epsilon_0 \f$ = 78.54 (water at 25C)
+ *   - @f$ \epsilon / \epsilon_0 @f$ = 78.54 (water at 25C)
  *   - T = 298.15 K
  *   - B_Debye = 3.28640E9 (kg/gmol)^(1/2) / m
  *
- * Currently, \f$  B_{Debye} \f$ is a constant in the model, specified either by
+ * Currently, @f$  B_{Debye} @f$ is a constant in the model, specified either by
  * a default water value, or through the input file. This may have to be looked
  * at, in the future.
  *
@@ -376,40 +376,40 @@ class PDSS_Water;
  *
  * For example, a bulk-phase binary reaction between liquid species j and k,
  * producing a new liquid species l would have the following equation for its
- * rate of progress variable, \f$ R^1 \f$, which has units of kmol m-3 s-1.
+ * rate of progress variable, @f$ R^1 @f$, which has units of kmol m-3 s-1.
  *
- * \f[
+ * @f[
  *    R^1 = k^1 C_j^a C_k^a =  k^1 (C_o a_j) (C_o a_k)
- * \f]
+ * @f]
  * where
- * \f[
+ * @f[
  *      C_j^a = C_o a_j \quad and \quad C_k^a = C_o a_k
- * \f]
+ * @f]
  *
- * \f$ C_j^a \f$ is the activity concentration of species j, and
- * \f$ C_k^a \f$ is the activity concentration of species k. \f$ C_o \f$
- * is the concentration of water at 298 K and 1 atm. \f$ a_j \f$ is the activity
+ * @f$ C_j^a @f$ is the activity concentration of species j, and
+ * @f$ C_k^a @f$ is the activity concentration of species k. @f$ C_o @f$
+ * is the concentration of water at 298 K and 1 atm. @f$ a_j @f$ is the activity
  * of species j at the current temperature and pressure and concentration of the
- * liquid phase. \f$k^1 \f$ has units of m3 kmol-1 s-1.
+ * liquid phase. @f$k^1 @f$ has units of m3 kmol-1 s-1.
  *
  * The reverse rate constant can then be obtained from the law of microscopic
  * reversibility and the equilibrium expression for the system.
  *
- * \f[
+ * @f[
  *     \frac{a_j a_k}{ a_l} = K^{o,1} = \exp(\frac{\mu^o_l - \mu^o_j - \mu^o_k}{R T} )
- * \f]
+ * @f]
  *
- * \f$  K^{o,1} \f$ is the dimensionless form of the equilibrium constant.
+ * @f$  K^{o,1} @f$ is the dimensionless form of the equilibrium constant.
  *
- * \f[
+ * @f[
  *    R^{-1} = k^{-1} C_l^a =  k^{-1} (C_o a_l)
- * \f]
+ * @f]
  * where
- * \f[
+ * @f[
  *     k^{-1} =  k^1 K^{o,1} C_o
- * \f]
+ * @f]
  *
- * \f$k^{-1} \f$ has units of s-1.
+ * @f$k^{-1} @f$ has units of s-1.
  */
 class DebyeHuckel : public MolalityVPSSTP
 {
@@ -442,12 +442,12 @@ public:
     /**
      * For an ideal, constant partial molar volume solution mixture with
      * pure species phases which exhibit zero volume expansivity:
-     * \f[
+     * @f[
      * \hat s(T, P, X_k) = \sum_k X_k \hat s^0_k(T)
      *      - \hat R  \sum_k X_k log(X_k)
-     * \f]
+     * @f]
      * The reference-state pure-species entropies
-     * \f$ \hat s^0_k(T,p_{ref}) \f$ are computed by the
+     * @f$ \hat s^0_k(T,p_{ref}) @f$ are computed by the
      *  species thermodynamic
      * property manager. The pure species entropies are independent of
      * temperature since the volume expansivities are equal to zero.
@@ -475,9 +475,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
+    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
     //! which depends only on temperature and the pressure. Activity is assumed
     //! to be molality-based here.
     //! @{
@@ -486,7 +486,7 @@ public:
 
     //! Return the standard concentration for the kth species
     /*!
-     * The standard concentration \f$ C^0_k \f$ used to normalize the activity
+     * The standard concentration @f$ C^0_k @f$ used to normalize the activity
      * (that is, generalized) concentration in kinetics calculations.
      *
      * For the time being, we will use the concentration of pure solvent for the
@@ -532,9 +532,9 @@ public:
      * This function returns a vector of chemical potentials of the species in
      * solution.
      *
-     * \f[
+     * @f[
      *    \mu_k = \mu^{\triangle}_k(T,P) + R T ln(\gamma_k^{\triangle} m_k)
-     * \f]
+     * @f]
      *
      * @param mu  Output vector of species chemical
      *            potentials. Length: m_kk. Units: J/kmol
@@ -548,13 +548,13 @@ public:
      * standard state enthalpies modified by the derivative of the
      * molality-based activity coefficient wrt temperature
      *
-     *  \f[
+     *  @f[
      * \bar h_k(T,P) = h^{\triangle}_k(T,P) - R T^2 \frac{d \ln(\gamma_k^\triangle)}{dT}
-     * \f]
+     * @f]
      * The solvent partial molar enthalpy is equal to
-     *  \f[
+     *  @f[
      * \bar h_o(T,P) = h^{o}_o(T,P) - R T^2 \frac{d \ln(a_o}{dT}
-     * \f]
+     * @f]
      *
      * The temperature dependence of the activity coefficients currently
      * only occurs through the temperature dependence of the Debye constant.
@@ -569,22 +569,22 @@ public:
     /**
      * Maxwell's equations provide an insight in how to calculate this
      *   (p.215 Smith and Van Ness)
-     * \f[
+     * @f[
      *    \frac{d\mu_i}{dT} = -\bar{s}_i
-     * \f]
+     * @f]
      *
      * For this phase, the partial molar entropies are equal to the SS species
      * entropies plus the ideal solution contribution:
-     * \f[
+     * @f[
      *     \bar s_k(T,P) =  \hat s^0_k(T) - R log(M0 * molality[k])
-     * \f]
-     * \f[
+     * @f]
+     * @f[
      *     \bar s_{solvent}(T,P) =  \hat s^0_{solvent}(T)
      *                 - R ((xmolSolvent - 1.0) / xmolSolvent)
-     * \f]
+     * @f]
      *
-     * The reference-state pure-species entropies,\f$ \hat s^0_k(T) \f$, at the
-     * reference pressure, \f$ P_{ref} \f$, are computed by the species
+     * The reference-state pure-species entropies,@f$ \hat s^0_k(T) @f$, at the
+     * reference pressure, @f$ P_{ref} @f$, are computed by the species
      * thermodynamic property manager. They are polynomial functions of
      * temperature.
      * @see MultiSpeciesThermo
@@ -632,35 +632,35 @@ public:
      *  The default is to assume that it is constant, given in the
      *  initialization process, and stored in the member double, m_A_Debye.
      *  Optionally, a full water treatment may be employed that makes
-     *  \f$ A_{Debye} \f$ a full function of T and P.
+     *  @f$ A_{Debye} @f$ a full function of T and P.
      *
-     *   \f[
+     *   @f[
      *      A_{Debye} = \frac{F e B_{Debye}}{8 \pi \epsilon R T} {\left( C_o \tilde{M}_o \right)}^{1/2}
-     *   \f]
+     *   @f]
      *  where
-     *  \f[
+     *  @f[
      *         B_{Debye} = \frac{F} {{(\frac{\epsilon R T}{2})}^{1/2}}
-     *  \f]
+     *  @f]
      *  Therefore:
-     *  \f[
+     *  @f[
      *   A_{Debye} = \frac{1}{8 \pi}
      *                 {\left(\frac{2 N_a \rho_o}{1000}\right)}^{1/2}
      *                 {\left(\frac{N_a e^2}{\epsilon R T }\right)}^{3/2}
-     *  \f]
+     *  @f]
      *
      *  where
      *  - Units = sqrt(kg/gmol)
-     *  - \f$ N_a \f$ is Avogadro's number
-     *  - \f$ \rho_w \f$ is the density of water
-     *  - \f$ e \f$ is the electronic charge
-     *  - \f$ \epsilon = K \epsilon_o \f$ is the permittivity of water
-     *  - \f$ K \f$ is the dielectric constant of water,
-     *  - \f$ \epsilon_o \f$ is the permittivity of free space.
-     *  - \f$ \rho_o \f$ is the density of the solvent in its standard state.
+     *  - @f$ N_a @f$ is Avogadro's number
+     *  - @f$ \rho_w @f$ is the density of water
+     *  - @f$ e @f$ is the electronic charge
+     *  - @f$ \epsilon = K \epsilon_o @f$ is the permittivity of water
+     *  - @f$ K @f$ is the dielectric constant of water,
+     *  - @f$ \epsilon_o @f$ is the permittivity of free space.
+     *  - @f$ \rho_o @f$ is the density of the solvent in its standard state.
      *
      *  Nominal value at 298 K and 1 atm = 1.172576 (kg/gmol)^(1/2)
      *  based on:
-     *    - \f$ \epsilon / \epsilon_0 \f$ = 78.54 (water at 25C)
+     *    - @f$ \epsilon / \epsilon_0 @f$ = 78.54 (water at 25C)
      *    - T = 298.15 K
      *    - B_Debye = 3.28640E9 (kg/gmol)^(1/2)/m
      *
@@ -676,7 +676,7 @@ public:
     //! respect to temperature.
     /*!
      * This is a function of temperature and pressure. See A_Debye_TP() for
-     * a definition of \f$ A_{Debye} \f$.
+     * a definition of @f$ A_{Debye} @f$.
      *
      * Units = sqrt(kg/gmol) K-1
      *
@@ -692,7 +692,7 @@ public:
     //! respect to temperature as a function of temperature and pressure.
     /*!
      * This is a function of temperature and pressure. See A_Debye_TP() for
-     * a definition of \f$ A_{Debye} \f$.
+     * a definition of @f$ A_{Debye} @f$.
      *
      * Units = sqrt(kg/gmol) K-2
      *
@@ -708,7 +708,7 @@ public:
     //! respect to pressure, as a function of temperature and pressure.
     /*!
      * This is a function of temperature and pressure. See A_Debye_TP() for
-     * a definition of \f$ A_{Debye} \f$.
+     * a definition of @f$ A_{Debye} @f$.
      *
      * Units = sqrt(kg/gmol) Pa-1
      *

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -65,7 +65,7 @@ class PDSS_Water;
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term @f$ P_0 \hat v@f$ is subtracted
+ * giving the standard-state enthalpy, the term @f$ P_0 \hat v @f$ is subtracted
  * from the specified molar enthalpy to compute the molar internal energy. The
  * entropy is assumed to be independent of the pressure.
  *
@@ -78,7 +78,7 @@ class PDSS_Water;
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v@f$ is
+ * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v @f$ is
  * subtracted from the specified reference molar enthalpy to compute the molar
  * internal energy.
  *
@@ -110,7 +110,7 @@ class PDSS_Water;
  * @f]
  *
  * where @f$ \gamma_k^{\triangle} @f$ is the molality based activity coefficient
- * for species @f$k@f$.
+ * for species @f$ k @f$.
  *
  * Individual activity coefficients of ions can not be independently measured.
  * Instead, only binary pairs forming electroneutral solutions can be measured.
@@ -118,7 +118,7 @@ class PDSS_Water;
  * ### Ionic Strength
  *
  * Most of the parameterizations within the model use the ionic strength as a
- * key variable. The ionic strength, @f$ I@f$ is defined as follows
+ * key variable. The ionic strength, @f$ I @f$ is defined as follows
  *
  *  @f[
  *    I = \frac{1}{2} \sum_k{m_k  z_k^2}
@@ -155,7 +155,7 @@ class PDSS_Water;
  *   @f[
  *      z_k = z_{k1} +  z_{k2}
  *   @f]
- * Then, we may only need to specify one charge value, say, @f$  z_{k1}@f$, the
+ * Then, we may only need to specify one charge value, say, @f$  z_{k1} @f$, the
  * cation charge number, in order to get both numbers, since we have already
  * specified @f$ z_k @f$ in the definition of original species. Then, the
  * stoichiometric ionic strength may be calculated via the following formula.
@@ -166,7 +166,7 @@ class PDSS_Water;
  *  @f]
  *
  * The specification of which species are weakly associated acids is made in YAML
- * input files by specifying the corresponding charge @f$k1@f$ as the `weak-acid-charge`
+ * input files by specifying the corresponding charge @f$ k1 @f$ as the `weak-acid-charge`
  * parameter of the `Debye-Huckel` block in the corresponding species entry.
  *
  * Because we need the concept of a weakly associated acid in order to calculate
@@ -211,7 +211,7 @@ class PDSS_Water;
  * @f[
  *     \ln(\gamma_k^\triangle) = - z_k^2 A_{Debye} \sqrt{I}
  * @f]
- * where @f$ I@f$ is the ionic strength
+ * where @f$ I @f$ is the ionic strength
  * @f[
  *   I = \frac{1}{2} \sum_k{m_k  z_k^2}
  * @f]
@@ -289,7 +289,7 @@ class PDSS_Water;
  * @f]
  *
  * In the current treatment the binary interaction coefficients, @f$
- * \beta_{j,k}@f$, are independent of temperature and pressure.
+ * \beta_{j,k} @f$, are independent of temperature and pressure.
  *
  * @f[
  *    \ln(a_o) = \frac{X_o - 1.0}{X_o}
@@ -390,7 +390,7 @@ class PDSS_Water;
  * @f$ C_k^a @f$ is the activity concentration of species k. @f$ C_o @f$
  * is the concentration of water at 298 K and 1 atm. @f$ a_j @f$ is the activity
  * of species j at the current temperature and pressure and concentration of the
- * liquid phase. @f$k^1 @f$ has units of m3 kmol-1 s-1.
+ * liquid phase. @f$ k^1 @f$ has units of m3 kmol-1 s-1.
  *
  * The reverse rate constant can then be obtained from the law of microscopic
  * reversibility and the equilibrium expression for the system.
@@ -409,7 +409,7 @@ class PDSS_Water;
  *     k^{-1} =  k^1 K^{o,1} C_o
  * @f]
  *
- * @f$k^{-1} @f$ has units of s-1.
+ * @f$ k^{-1} @f$ has units of s-1.
  */
 class DebyeHuckel : public MolalityVPSSTP
 {
@@ -475,9 +475,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
-    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
+    //! quantity @f$ \mu_k^0(T,P) @f$ is the chemical potential at unit activity,
     //! which depends only on temperature and the pressure. Activity is assumed
     //! to be molality-based here.
     //! @{

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -51,7 +51,7 @@ namespace Cantera
  * @f]
  *
  * where @f$ \gamma_k^{\triangle} @f$ is a molar based activity coefficient for
- * species @f$k@f$.
+ * species @f$ k @f$.
  *
  * GibbsExcessVPSSTP contains an internal vector with the current mole fraction
  * vector. That's one of its primary usages. In order to keep the mole fraction
@@ -104,8 +104,8 @@ protected:
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
      * @f]
      *
-     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
-     * weights, and @f$V_k@f$ are the pure species molar volumes.
+     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
+     * weights, and @f$ V_k @f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -121,9 +121,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
-    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
+    //! quantity @f$ \mu_k^0(T,P) @f$ is the chemical potential at unit activity,
     //! which depends only on temperature and pressure.
     //! @{
 

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -43,15 +43,15 @@ namespace Cantera
  * All of the Excess Gibbs free energy formulations in this area employ
  * symmetrical formulations.
  *
- * Chemical potentials of species k, \f$ \mu_o \f$, has the following general
+ * Chemical potentials of species k, @f$ \mu_o @f$, has the following general
  * format:
  *
- * \f[
+ * @f[
  *    \mu_k = \mu^o_k(T,P) + R T ln( \gamma_k X_k )
- * \f]
+ * @f]
  *
- * where \f$ \gamma_k^{\triangle} \f$ is a molar based activity coefficient for
- * species \f$k\f$.
+ * where @f$ \gamma_k^{\triangle} @f$ is a molar based activity coefficient for
+ * species @f$k@f$.
  *
  * GibbsExcessVPSSTP contains an internal vector with the current mole fraction
  * vector. That's one of its primary usages. In order to keep the mole fraction
@@ -100,12 +100,12 @@ protected:
      *
      * The formula for this is
      *
-     * \f[
+     * @f[
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * \f]
+     * @f]
      *
-     * where \f$X_k\f$ are the mole fractions, \f$W_k\f$ are the molecular
-     * weights, and \f$V_k\f$ are the pure species molar volumes.
+     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
+     * weights, and @f$V_k@f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -121,9 +121,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
+    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
     //! which depends only on temperature and pressure.
     //! @{
 
@@ -131,10 +131,10 @@ public:
     virtual void getActivityConcentrations(doublereal* c) const;
 
     /**
-     * The standard concentration \f$ C^0_k \f$ used to normalize the
+     * The standard concentration @f$ C^0_k @f$ used to normalize the
      * generalized concentration. In many cases, this quantity will be the same
      * for all species in a phase - for example, for an ideal gas
-     * \f$ C^0_k = P/\hat R T \f$. For this reason, this method returns a single
+     * @f$ C^0_k = P/\hat R T @f$. For this reason, this method returns a single
      * value, instead of an array.  However, for phases in which the standard
      * concentration is species-specific (for example, surface species of different
      * sizes), this method may be called with an optional parameter indicating
@@ -152,9 +152,9 @@ public:
     //! class and classes that derive from it) at the current solution
     //! temperature, pressure, and solution concentration.
     /*!
-     * \f[
+     * @f[
      *  a_i^\triangle = \gamma_k^{\triangle} \frac{m_k}{m^\triangle}
-     * \f]
+     * @f]
      *
      * This function must be implemented in derived classes.
      *

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -91,7 +91,7 @@ class WaterProps;
  *
  * For these incompressible, standard states, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term @f$ P_0 \hat v@f$ is subtracted
+ * giving the standard-state enthalpy, the term @f$ P_0 \hat v @f$ is subtracted
  * from the specified molar enthalpy to compute the molar internal energy. The
  * entropy is assumed to be independent of the pressure.
  *
@@ -104,7 +104,7 @@ class WaterProps;
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v@f$ is
+ * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v @f$ is
  * subtracted from the specified reference molar enthalpy to compute the molar
  * internal energy.
  *
@@ -136,7 +136,7 @@ class WaterProps;
  * @f]
  *
  * where @f$ \gamma_k^{\triangle} @f$ is the molality based activity coefficient
- * for species @f$k@f$.
+ * for species @f$ k @f$.
  *
  * Individual activity coefficients of ions can not be independently measured.
  * Instead, only binary pairs forming electroneutral solutions can be measured.
@@ -150,7 +150,7 @@ class WaterProps;
  * ### Ionic Strength
  *
  * Most of the parameterizations within the model use the ionic strength as a
- * key variable. The ionic strength, @f$ I@f$ is defined as follows
+ * key variable. The ionic strength, @f$ I @f$ is defined as follows
  *
  * @f[
  *    I = \frac{1}{2} \sum_k{m_k  z_k^2}
@@ -211,7 +211,7 @@ class WaterProps;
  * the theory of unsymmetrical mixing of electrolytes with different charges.
  * This theory depends on the total ionic strength of the solution, and
  * therefore, @f$ \Phi_{c{c'}} @f$ and  @f$ \Phi_{a{a'}} @f$  will depend on
- * *I*, the ionic strength.  @f$ B_{ca}@f$ is a strong function of the
+ * *I*, the ionic strength.  @f$ B_{ca} @f$ is a strong function of the
  * total ionic strength, *I*, of the electrolyte. The rest of the coefficients
  * are assumed to be independent of the molalities or ionic strengths. However,
  * all coefficients are potentially functions of the temperature and pressure
@@ -220,7 +220,7 @@ class WaterProps;
  * *A* is the Debye-Huckel constant. Its specification is described in its
  * own section below.
  *
- * @f$ I@f$ is the ionic strength of the solution, and is given by:
+ * @f$ I @f$ is the ionic strength of the solution, and is given by:
  *
  * @f[
  *     I = \frac{1}{2} \sum_k{m_k  z_k^2}
@@ -238,7 +238,7 @@ class WaterProps;
  *     Z = \sum_i m_i \left| z_i \right|
  * @f]
  *
- * The value of @f$ B_{ca}@f$ is given by the following function
+ * The value of @f$ B_{ca} @f$ is given by the following function
  *
  * @f[
  *     B_{ca} = \beta^{(0)}_{ca} + \beta^{(1)}_{ca} g(\alpha^{(1)}_{ca} \sqrt{I})
@@ -251,7 +251,7 @@ class WaterProps;
  *     g(x) = 2 \frac{(1 - (1 + x)\exp[-x])}{x^2}
  * @f]
  *
- * The formulation for @f$ B_{ca}@f$ combined with the formulation of the Debye-
+ * The formulation for @f$ B_{ca} @f$ combined with the formulation of the Debye-
  * Huckel term in the eqn. for the excess Gibbs free energy stems essentially
  * from an empirical fit to the ionic strength dependent data based over a wide
  * sampling of binary electrolyte systems. @f$ C_{ca} @f$, @f$ \lambda_{nc} @f$,
@@ -263,17 +263,17 @@ class WaterProps;
  * more complicated. @f$ b @f$ is a universal constant defined to be equal to
  * @f$ 1.2\ kg^{1/2}\ gmol^{-1/2} @f$. The exponential coefficient @f$
  * \alpha^{(1)}_{ca} @f$ is usually fixed at @f$ \alpha^{(1)}_{ca} = 2.0\
- * kg^{1/2} gmol^{-1/2}@f$ except for 2-2 electrolytes, while other parameters
+ * kg^{1/2} gmol^{-1/2} @f$ except for 2-2 electrolytes, while other parameters
  * were fit to experimental data. For 2-2 electrolytes, @f$ \alpha^{(1)}_{ca} =
- * 1.4\ kg^{1/2}\ gmol^{-1/2}@f$ is used in combination with either @f$
- * \alpha^{(2)}_{ca} = 12\ kg^{1/2}\ gmol^{-1/2}@f$ or @f$ \alpha^{(2)}_{ca} = k
+ * 1.4\ kg^{1/2}\ gmol^{-1/2} @f$ is used in combination with either @f$
+ * \alpha^{(2)}_{ca} = 12\ kg^{1/2}\ gmol^{-1/2} @f$ or @f$ \alpha^{(2)}_{ca} = k
  * A_\psi @f$, where *k* is a constant. For electrolytes other than 2-2
  * electrolytes the @f$ \beta^{(2)}_{ca} g(\alpha^{(2)}_{ca} \sqrt{I}) @f$  term
  * is not used in the fitting procedure; it is only used for divalent metal
  * solfates and other high-valence electrolytes which exhibit significant
  * association at low ionic strengths.
  *
- * The @f$ \beta^{(0)}_{ca} @f$, @f$ \beta^{(1)}_{ca}@f$, @f$ \beta^{(2)}_{ca}
+ * The @f$ \beta^{(0)}_{ca} @f$, @f$ \beta^{(1)}_{ca} @f$, @f$ \beta^{(2)}_{ca}
  * @f$, and @f$ C_{ca} @f$ binary coefficients are referred to as ion-
  * interaction or Pitzer parameters. These Pitzer parameters may vary with
  * temperature and pressure but they do not depend on the ionic strength. Their
@@ -485,23 +485,23 @@ class WaterProps;
  *        and pressure
  *    - PIZTER_TEMP_COMPLEX1     - string name "COMPLEX" or "COMPLEX1"
  *      - Uses the full temperature dependence for the
- *        @f$\beta^{(0)}_{MX} @f$ (5 coeffs),
- *        the  @f$\beta^{(1)}_{MX} @f$ (3 coeffs),
+ *        @f$ \beta^{(0)}_{MX} @f$ (5 coeffs),
+ *        the  @f$ \beta^{(1)}_{MX} @f$ (3 coeffs),
  *        and @f$ C^{\phi}_{MX} @f$ (5 coeffs) parameters described above.
  *    - PITZER_TEMP_LINEAR        - string name "LINEAR"
  *      - Uses just the temperature dependence for the
- *        @f$\beta^{(0)}_{MX} @f$, the @f$\beta^{(1)}_{MX} @f$,
+ *        @f$ \beta^{(0)}_{MX} @f$, the @f$ \beta^{(1)}_{MX} @f$,
  *        and @f$ C^{\phi}_{MX} @f$ coefficients described above.
  *        There are 2 coefficients for each term.
  *
  * The specification of the binary interaction between a cation and an anion is
- * given by the coefficients, @f$ B_{MX}@f$ and @f$ C_{MX}@f$ The specification
- * of @f$ B_{MX}@f$ is a function of @f$\beta^{(0)}_{MX} @f$,
- * @f$\beta^{(1)}_{MX} @f$, @f$\beta^{(2)}_{MX} @f$, @f$\alpha^{(1)}_{MX} @f$,
- * and @f$\alpha^{(2)}_{MX} @f$. @f$ C_{MX}@f$ is calculated from
- * @f$C^{\phi}_{MX} @f$ from the formula above.
+ * given by the coefficients, @f$ B_{MX} @f$ and @f$ C_{MX} @f$ The specification
+ * of @f$ B_{MX} @f$ is a function of @f$ \beta^{(0)}_{MX} @f$,
+ * @f$ \beta^{(1)}_{MX} @f$, @f$ \beta^{(2)}_{MX} @f$, @f$ \alpha^{(1)}_{MX} @f$,
+ * and @f$ \alpha^{(2)}_{MX} @f$. @f$ C_{MX} @f$ is calculated from
+ * @f$ C^{\phi}_{MX} @f$ from the formula above.
  *
- * The parameters for @f$ \beta^{(0)}@f$ fit the following equation:
+ * The parameters for @f$ \beta^{(0)} @f$ fit the following equation:
  *
  * @f[
  *     \beta^{(0)} = q_0^{{\beta}0} + q_1^{{\beta}0} \left( T - T_r \right)
@@ -513,7 +513,7 @@ class WaterProps;
  * This same `COMPLEX1` temperature dependence given above is used for the
  * following parameters:
  * @f$ \beta^{(0)}_{MX} @f$, @f$ \beta^{(1)}_{MX} @f$,
- * @f$ \beta^{(2)}_{MX} @f$, @f$ \Theta_{cc'} @f$, @f$\Theta_{aa'} @f$,
+ * @f$ \beta^{(2)}_{MX} @f$, @f$ \Theta_{cc'} @f$, @f$ \Theta_{aa'} @f$,
  * @f$ \Psi_{c{c'}a} @f$ and @f$ \Psi_{ca{a'}} @f$.
  *
  * ### Like-Charged Binary Ion Parameters and the Mixing Parameters
@@ -660,7 +660,7 @@ class WaterProps;
  *                    - R T \frac{d \ln(a_o)}{dT}
  * @f]
  *
- * The partial molar heat capacity, @f$ C_{p,k}(T,P)@f$:
+ * The partial molar heat capacity, @f$ C_{p,k}(T,P) @f$:
  *
  * @f[
  *     \bar C_{p,k}(T,P) =  C^{\triangle}_{p,k}(T,P)
@@ -737,7 +737,7 @@ class WaterProps;
  *      a_j  =  \gamma_j^\triangle m_j = \gamma_j^\triangle \frac{n_j}{\tilde{M}_o n_o}
  * @f]
  *
- * @f$k^1 @f$ has units of m^3/kmol/s.
+ * @f$ k^1 @f$ has units of m^3/kmol/s.
  *
  * Therefore the generalized activity concentration of a solute species has the following form
  *
@@ -882,8 +882,8 @@ protected:
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
      * @f]
      *
-     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
-     * weights, and @f$V_k@f$ are the pure species molar volumes.
+     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
+     * weights, and @f$ V_k @f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -899,16 +899,16 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
-    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
+    //! quantity @f$ \mu_k^0(T,P) @f$ is the chemical potential at unit activity,
     //! which depends only on temperature and the pressure. Activity is assumed
     //! to be molality-based here.
     //! @{
 
     //! This method returns an array of generalized activity concentrations
     /*!
-     * The generalized activity concentrations, @f$ C_k^a@f$, are defined such
+     * The generalized activity concentrations, @f$ C_k^a @f$, are defined such
      * that @f$ a_k = C^a_k / C^0_k, @f$ where @f$ C^0_k @f$ is a standard
      * concentration defined below.  These generalized concentrations are used
      * by kinetics manager classes to compute the forward and reverse rates of
@@ -991,7 +991,7 @@ public:
      *      a_j  =  \gamma_j^\triangle m_j = \gamma_j^\triangle \frac{n_j}{\tilde{M}_o n_o}
      * @f]
      *
-     * @f$k^1 @f$ has units of m^3/kmol/s.
+     * @f$ k^1 @f$ has units of m^3/kmol/s.
      *
      * Therefore the generalized activity concentration of a solute species has
      * the following form

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -76,9 +76,9 @@ class WaterProps;
  * #Cantera::WaterPropsIAPWS.
  *
  * The standard states for solutes are on the unit molality basis. Therefore, in
- * the documentation below, the normal \f$ o \f$ superscript is replaced with
- * the \f$ \triangle \f$ symbol. The reference state symbol is now
- * \f$ \triangle, ref \f$.
+ * the documentation below, the normal @f$ o @f$ superscript is replaced with
+ * the @f$ \triangle @f$ symbol. The reference state symbol is now
+ * @f$ \triangle, ref @f$.
  *
  * It is assumed that the reference state thermodynamics may be obtained by a
  * pointer to a populated species thermodynamic property manager class (see
@@ -91,26 +91,26 @@ class WaterProps;
  *
  * For these incompressible, standard states, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term \f$ P_0 \hat v\f$ is subtracted
+ * giving the standard-state enthalpy, the term @f$ P_0 \hat v@f$ is subtracted
  * from the specified molar enthalpy to compute the molar internal energy. The
  * entropy is assumed to be independent of the pressure.
  *
  * The enthalpy function is given by the following relation.
  *
- * \f[
+ * @f[
  *    h^\triangle_k(T,P) = h^{\triangle,ref}_k(T)
  *        + \tilde{v}_k \left( P - P_{ref} \right)
- * \f]
+ * @f]
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term \f$ P_{ref} \tilde v\f$ is
+ * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v@f$ is
  * subtracted from the specified reference molar enthalpy to compute the molar
  * internal energy.
  *
- * \f[
+ * @f[
  *      u^\triangle_k(T,P) = h^{\triangle,ref}_k(T) - P_{ref} \tilde{v}_k
- * \f]
+ * @f]
  *
  * The solute standard state heat capacity and entropy are independent of
  * pressure. The solute standard state Gibbs free energy is obtained from the
@@ -125,18 +125,18 @@ class WaterProps;
  *
  * ## Specification of Solution Thermodynamic Properties
  *
- * Chemical potentials of the solutes, \f$ \mu_k \f$, and the solvent, \f$ \mu_o
- * \f$, which are based on the molality form, have the following general format:
+ * Chemical potentials of the solutes, @f$ \mu_k @f$, and the solvent, @f$ \mu_o
+ * @f$, which are based on the molality form, have the following general format:
  *
- * \f[
+ * @f[
  *    \mu_k = \mu^{\triangle}_k(T,P) + R T ln(\gamma_k^{\triangle} \frac{m_k}{m^\triangle})
- * \f]
- * \f[
+ * @f]
+ * @f[
  *    \mu_o = \mu^o_o(T,P) + RT ln(a_o)
- * \f]
+ * @f]
  *
- * where \f$ \gamma_k^{\triangle} \f$ is the molality based activity coefficient
- * for species \f$k\f$.
+ * where @f$ \gamma_k^{\triangle} @f$ is the molality based activity coefficient
+ * for species @f$k@f$.
  *
  * Individual activity coefficients of ions can not be independently measured.
  * Instead, only binary pairs forming electroneutral solutions can be measured.
@@ -150,13 +150,13 @@ class WaterProps;
  * ### Ionic Strength
  *
  * Most of the parameterizations within the model use the ionic strength as a
- * key variable. The ionic strength, \f$ I\f$ is defined as follows
+ * key variable. The ionic strength, @f$ I@f$ is defined as follows
  *
- * \f[
+ * @f[
  *    I = \frac{1}{2} \sum_k{m_k  z_k^2}
- * \f]
+ * @f]
  *
- * \f$ m_k \f$ is the molality of the kth species. \f$ z_k \f$ is the charge of
+ * @f$ m_k @f$ is the molality of the kth species. @f$ z_k @f$ is the charge of
  * the kth species. Note, the ionic strength is a defined units quantity. The
  * molality has defined units of gmol kg-1, and therefore the ionic strength has
  * units of sqrt(gmol/kg).
@@ -164,19 +164,19 @@ class WaterProps;
  * ### Specification of the Excess Gibbs Free Energy
  *
  * Pitzer's formulation may best be represented as a specification of the excess
- * Gibbs free energy, \f$ G^{ex} \f$, defined as the deviation of the total
+ * Gibbs free energy, @f$ G^{ex} @f$, defined as the deviation of the total
  * Gibbs free energy from that of an ideal molal solution.
- * \f[
+ * @f[
  *     G = G^{id} + G^{ex}
- * \f]
+ * @f]
  *
  * The ideal molal solution contribution, not equal to an ideal solution
  * contribution and in fact containing a singularity at the zero solvent mole
  * fraction limit, is given below.
- * \f[
+ * @f[
  *     G^{id} = n_o \mu^o_o + \sum_{k\ne o} n_k \mu_k^{\triangle}
  *           + \tilde{M}_o n_o ( RT (\sum{m_i(\ln(m_i)-1)}))
- * \f]
+ * @f]
  *
  * From the excess Gibbs free energy formulation, the activity coefficient
  * expression and the osmotic coefficient expression for the solvent may be
@@ -186,7 +186,7 @@ class WaterProps;
  * Pitzer employs the following general expression for the excess Gibbs free
  * energy
  *
- *  \f[
+ *  @f[
  *    \begin{array}{cclc}
  *     \frac{G^{ex}}{\tilde{M}_o  n_o RT} &= &
  *          \left( \frac{4A_{Debye}I}{3b} \right) \ln(1 + b \sqrt{I})
@@ -200,18 +200,18 @@ class WaterProps;
  *        + 2 \sum_{n < n'} \sum m_n m_{n'} \lambda_{n{n'}}
  *        +  \sum_n m^2_n \lambda_{nn}
  *    \end{array}
- *  \f]
+ *  @f]
  *
  * *a* is a subscript over all anions, *c* is a subscript extending over all
  * cations, and  *i* is a subscript that extends over all anions and cations.
  * *n* is a subscript that extends only over neutral solute molecules. The
  * second line contains cross terms where cations affect cations and/or
  * cation/anion pairs, and anions affect anions or cation/anion pairs. Note part
- * of the coefficients, \f$ \Phi_{c{c'}} \f$ and  \f$ \Phi_{a{a'}} \f$ stem from
+ * of the coefficients, @f$ \Phi_{c{c'}} @f$ and  @f$ \Phi_{a{a'}} @f$ stem from
  * the theory of unsymmetrical mixing of electrolytes with different charges.
  * This theory depends on the total ionic strength of the solution, and
- * therefore, \f$ \Phi_{c{c'}} \f$ and  \f$ \Phi_{a{a'}} \f$  will depend on
- * *I*, the ionic strength.  \f$ B_{ca}\f$ is a strong function of the
+ * therefore, @f$ \Phi_{c{c'}} @f$ and  @f$ \Phi_{a{a'}} @f$  will depend on
+ * *I*, the ionic strength.  @f$ B_{ca}@f$ is a strong function of the
  * total ionic strength, *I*, of the electrolyte. The rest of the coefficients
  * are assumed to be independent of the molalities or ionic strengths. However,
  * all coefficients are potentially functions of the temperature and pressure
@@ -220,71 +220,71 @@ class WaterProps;
  * *A* is the Debye-Huckel constant. Its specification is described in its
  * own section below.
  *
- * \f$ I\f$ is the ionic strength of the solution, and is given by:
+ * @f$ I@f$ is the ionic strength of the solution, and is given by:
  *
- * \f[
+ * @f[
  *     I = \frac{1}{2} \sum_k{m_k  z_k^2}
- * \f]
+ * @f]
  *
  * In contrast to several other Debye-Huckel implementations (see @ref
- * DebyeHuckel), the parameter \f$ b\f$ in the above equation is a constant that
+ * DebyeHuckel), the parameter @f$ b @f$ in the above equation is a constant that
  * does not vary with respect to ion identity. This is an important
  * simplification as it avoids troubles with satisfaction of the Gibbs-Duhem
  * analysis.
  *
- * The function \f$ Z \f$ is given by
+ * The function @f$ Z @f$ is given by
  *
- * \f[
+ * @f[
  *     Z = \sum_i m_i \left| z_i \right|
- * \f]
+ * @f]
  *
- * The value of \f$ B_{ca}\f$ is given by the following function
+ * The value of @f$ B_{ca}@f$ is given by the following function
  *
- * \f[
+ * @f[
  *     B_{ca} = \beta^{(0)}_{ca} + \beta^{(1)}_{ca} g(\alpha^{(1)}_{ca} \sqrt{I})
  *            + \beta^{(2)}_{ca} g(\alpha^{(2)}_{ca} \sqrt{I})
- * \f]
+ * @f]
  *
  * where
  *
- * \f[
+ * @f[
  *     g(x) = 2 \frac{(1 - (1 + x)\exp[-x])}{x^2}
- * \f]
+ * @f]
  *
- * The formulation for \f$ B_{ca}\f$ combined with the formulation of the Debye-
+ * The formulation for @f$ B_{ca}@f$ combined with the formulation of the Debye-
  * Huckel term in the eqn. for the excess Gibbs free energy stems essentially
  * from an empirical fit to the ionic strength dependent data based over a wide
- * sampling of binary electrolyte systems. \f$ C_{ca} \f$, \f$ \lambda_{nc} \f$,
- * \f$ \lambda_{na} \f$, \f$ \lambda_{nn} \f$, \f$ \Psi_{c{c'}a} \f$, \f$
- * \Psi_{a{a'}c} \f$ are experimentally derived coefficients that may have
+ * sampling of binary electrolyte systems. @f$ C_{ca} @f$, @f$ \lambda_{nc} @f$,
+ * @f$ \lambda_{na} @f$, @f$ \lambda_{nn} @f$, @f$ \Psi_{c{c'}a} @f$, @f$
+ * \Psi_{a{a'}c} @f$ are experimentally derived coefficients that may have
  * pressure and/or temperature dependencies.
  *
- * The \f$ \Phi_{c{c'}} \f$ and \f$ \Phi_{a{a'}} \f$ formulations are slightly
- * more complicated. \f$ b \f$ is a universal constant defined to be equal to
- * \f$ 1.2\ kg^{1/2}\ gmol^{-1/2} \f$. The exponential coefficient \f$
- * \alpha^{(1)}_{ca} \f$ is usually fixed at \f$ \alpha^{(1)}_{ca} = 2.0\
- * kg^{1/2} gmol^{-1/2}\f$ except for 2-2 electrolytes, while other parameters
- * were fit to experimental data. For 2-2 electrolytes, \f$ \alpha^{(1)}_{ca} =
- * 1.4\ kg^{1/2}\ gmol^{-1/2}\f$ is used in combination with either \f$
- * \alpha^{(2)}_{ca} = 12\ kg^{1/2}\ gmol^{-1/2}\f$ or \f$ \alpha^{(2)}_{ca} = k
- * A_\psi \f$, where *k* is a constant. For electrolytes other than 2-2
- * electrolytes the \f$ \beta^{(2)}_{ca} g(\alpha^{(2)}_{ca} \sqrt{I}) \f$  term
+ * The @f$ \Phi_{c{c'}} @f$ and @f$ \Phi_{a{a'}} @f$ formulations are slightly
+ * more complicated. @f$ b @f$ is a universal constant defined to be equal to
+ * @f$ 1.2\ kg^{1/2}\ gmol^{-1/2} @f$. The exponential coefficient @f$
+ * \alpha^{(1)}_{ca} @f$ is usually fixed at @f$ \alpha^{(1)}_{ca} = 2.0\
+ * kg^{1/2} gmol^{-1/2}@f$ except for 2-2 electrolytes, while other parameters
+ * were fit to experimental data. For 2-2 electrolytes, @f$ \alpha^{(1)}_{ca} =
+ * 1.4\ kg^{1/2}\ gmol^{-1/2}@f$ is used in combination with either @f$
+ * \alpha^{(2)}_{ca} = 12\ kg^{1/2}\ gmol^{-1/2}@f$ or @f$ \alpha^{(2)}_{ca} = k
+ * A_\psi @f$, where *k* is a constant. For electrolytes other than 2-2
+ * electrolytes the @f$ \beta^{(2)}_{ca} g(\alpha^{(2)}_{ca} \sqrt{I}) @f$  term
  * is not used in the fitting procedure; it is only used for divalent metal
  * solfates and other high-valence electrolytes which exhibit significant
  * association at low ionic strengths.
  *
- * The \f$ \beta^{(0)}_{ca} \f$, \f$ \beta^{(1)}_{ca}\f$, \f$ \beta^{(2)}_{ca}
- * \f$, and \f$ C_{ca} \f$ binary coefficients are referred to as ion-
+ * The @f$ \beta^{(0)}_{ca} @f$, @f$ \beta^{(1)}_{ca}@f$, @f$ \beta^{(2)}_{ca}
+ * @f$, and @f$ C_{ca} @f$ binary coefficients are referred to as ion-
  * interaction or Pitzer parameters. These Pitzer parameters may vary with
  * temperature and pressure but they do not depend on the ionic strength. Their
  * values and temperature derivatives of their values have been tabulated for a
  * range of electrolytes
  *
- * The \f$ \Phi_{c{c'}} \f$ and \f$ \Phi_{a{a'}} \f$ contributions, which
+ * The @f$ \Phi_{c{c'}} @f$ and @f$ \Phi_{a{a'}} @f$ contributions, which
  * capture cation-cation and anion-anion interactions, also have an ionic
  * strength dependence.
  *
- * Ternary contributions \f$ \Psi_{c{c'}a} \f$ and \f$ \Psi_{a{a'}c} \f$ have
+ * Ternary contributions @f$ \Psi_{c{c'}a} @f$ and @f$ \Psi_{a{a'}c} @f$ have
  * been measured also for some systems. The success of the Pitzer method lies in
  * its ability to model nonlinear activity coefficients of complex
  * multicomponent systems with just binary and minor ternary contributions,
@@ -296,9 +296,9 @@ class WaterProps;
  * the following derivative of the excess Gibbs Free Energy formulation
  * described above:
  *
- * \f[
+ * @f[
  *    \ln(\gamma_k^\triangle) = \frac{d\left( \frac{G^{ex}}{M_o n_o RT} \right)}{d(m_k)}\Bigg|_{n_i}
- * \f]
+ * @f]
  *
  * In the formulas below the following conventions are used. The subscript *M*
  * refers to a particular cation. The subscript X refers to a particular anion,
@@ -308,88 +308,88 @@ class WaterProps;
  *
  * The activity coefficient for a particular cation *M* is given by
  *
- * \f[
+ * @f[
  *     \ln(\gamma_M^\triangle) = -z_M^2(F) + \sum_a m_a \left( 2 B_{Ma} + Z C_{Ma} \right)
  *     + z_M   \left( \sum_a  \sum_c m_a m_c C_{ca} \right)
  *            + \sum_c m_c \left[ 2 \Phi_{Mc} + \sum_a m_a \Psi_{Mca} \right]
  *            + \sum_{a < a'} \sum m_a m_{a'} \Psi_{Ma{a'}}
  *            +  2 \sum_n m_n \lambda_{nM}
- * \f]
+ * @f]
  *
  * The activity coefficient for a particular anion *X* is given by
  *
- * \f[
+ * @f[
  *     \ln(\gamma_X^\triangle) = -z_X^2(F) + \sum_a m_c \left( 2 B_{cX} + Z C_{cX} \right)
  *     + \left|z_X \right|  \left( \sum_a  \sum_c m_a m_c C_{ca} \right)
  *            + \sum_a m_a \left[ 2 \Phi_{Xa} + \sum_c m_c \Psi_{cXa} \right]
  *            + \sum_{c < c'} \sum m_c m_{c'} \Psi_{c{c'}X}
  *            +  2 \sum_n m_n \lambda_{nM}
- * \f]
- * where the function \f$ F \f$ is given by
+ * @f]
+ * where the function @f$ F @f$ is given by
  *
- * \f[
+ * @f[
  *      F = - A_{\phi} \left[ \frac{\sqrt{I}}{1 + b \sqrt{I}}
  *                + \frac{2}{b} \ln{\left(1 + b\sqrt{I}\right)} \right]
  *                + \sum_a \sum_c m_a m_c B'_{ca}
  *                + \sum_{c < c'} \sum m_c m_{c'} \Phi'_{c{c'}}
  *                + \sum_{a < a'} \sum m_a m_{a'} \Phi'_{a{a'}}
- * \f]
+ * @f]
  *
- * We have employed the definition of \f$ A_{\phi} \f$, also used by Pitzer
+ * We have employed the definition of @f$ A_{\phi} @f$, also used by Pitzer
  * which is equal to
  *
- * \f[
+ * @f[
  *   A_{\phi} = \frac{A_{Debye}}{3}
- * \f]
+ * @f]
  *
- * In the above formulas, \f$ \Phi'_{c{c'}} \f$  and \f$ \Phi'_{a{a'}} \f$ are the
- * ionic strength derivatives of \f$ \Phi_{c{c'}} \f$  and \f$  \Phi_{a{a'}} \f$,
+ * In the above formulas, @f$ \Phi'_{c{c'}} @f$  and @f$ \Phi'_{a{a'}} @f$ are the
+ * ionic strength derivatives of @f$ \Phi_{c{c'}} @f$  and @f$  \Phi_{a{a'}} @f$,
  * respectively.
  *
- * The function \f$ B'_{MX} \f$ is defined as:
+ * The function @f$ B'_{MX} @f$ is defined as:
  *
- * \f[
+ * @f[
  *      B'_{MX} = \left( \frac{\beta^{(1)}_{MX} h(\alpha^{(1)}_{MX} \sqrt{I})}{I}  \right)
  *                \left( \frac{\beta^{(2)}_{MX} h(\alpha^{(2)}_{MX} \sqrt{I})}{I}  \right)
- * \f]
+ * @f]
  *
- * where \f$ h(x) \f$ is defined as
+ * where @f$ h(x) @f$ is defined as
  *
- * \f[
+ * @f[
  *     h(x) = g'(x) \frac{x}{2} =
  *      \frac{2\left(1 - \left(1 + x + \frac{x^2}{2} \right)\exp(-x) \right)}{x^2}
- * \f]
+ * @f]
  *
  * The activity coefficient for neutral species *N* is given by
  *
- * \f[
+ * @f[
  *     \ln(\gamma_N^\triangle) = 2 \left( \sum_i m_i \lambda_{iN}\right)
- * \f]
+ * @f]
  *
  * ### Activity of the Water Solvent
  *
- * The activity for the solvent water,\f$ a_o \f$, is not independent and must
+ * The activity for the solvent water,@f$ a_o @f$, is not independent and must
  * be determined either from the Gibbs-Duhem relation or from taking the
  * appropriate derivative of the same excess Gibbs free energy function as was
  * used to formulate the solvent activity coefficients. Pitzer's description
  * follows the later approach to derive a formula for the osmotic coefficient,
- * \f$ \phi \f$.
+ * @f$ \phi @f$.
  *
- * \f[
+ * @f[
  *      \phi - 1 = - \left( \frac{d\left(\frac{G^{ex}}{RT} \right)}{d(\tilde{M}_o n_o)}  \right)
  *               \frac{1}{\sum_{i \ne 0} m_i}
- * \f]
+ * @f]
  *
  * The osmotic coefficient may be related to the water activity by the following relation:
  *
- * \f[
+ * @f[
  *      \phi = - \frac{1}{\tilde{M}_o \sum_{i \neq o} m_i} \ln(a_o)
  *          = - \frac{n_o}{\sum_{i \neq o}n_i} \ln(a_o)
- * \f]
+ * @f]
  *
  * The result is the following
  *
- * \f[
+ * @f[
  *   \begin{array}{ccclc}
  *     \phi - 1 &= &
  *         \frac{2}{\sum_{i \ne 0} m_i}
@@ -405,28 +405,28 @@ class WaterProps;
  *       + \frac{1}{2} \left( \sum_n m^2_n \lambda_{nn}\right)
  *         \bigg]
  *   \end{array}
- * \f]
+ * @f]
  *
  * It can be shown that the expression
  *
- * \f[
+ * @f[
  *    B^{\phi}_{ca} = \beta^{(0)}_{ca} + \beta^{(1)}_{ca} \exp{(- \alpha^{(1)}_{ca} \sqrt{I})}
  *            + \beta^{(2)}_{ca} \exp{(- \alpha^{(2)}_{ca} \sqrt{I} )}
- * \f]
+ * @f]
  *
- * is consistent with the expression \f$ B_{ca} \f$ in the \f$ G^{ex} \f$
- * expression after carrying out the derivative wrt \f$ m_M \f$.
+ * is consistent with the expression @f$ B_{ca} @f$ in the @f$ G^{ex} @f$
+ * expression after carrying out the derivative wrt @f$ m_M @f$.
  *
- * Also taking into account that  \f$ {\Phi}_{c{c'}} \f$ and
- * \f$ {\Phi}_{a{a'}} \f$ has an ionic strength dependence.
+ * Also taking into account that  @f$ {\Phi}_{c{c'}} @f$ and
+ * @f$ {\Phi}_{a{a'}} @f$ has an ionic strength dependence.
  *
- * \f[
+ * @f[
  *   \Phi^{\phi}_{c{c'}} = {\Phi}_{c{c'}} + I \frac{d{\Phi}_{c{c'}}}{dI}
- * \f]
+ * @f]
  *
- * \f[
+ * @f[
  *   \Phi^{\phi}_{a{a'}} = \Phi_{a{a'}} + I \frac{d\Phi_{a{a'}}}{dI}
- * \f]
+ * @f]
  *
  * ### Temperature and Pressure Dependence of the Pitzer Parameters
  *
@@ -445,30 +445,30 @@ class WaterProps;
  * form was used to fit the temperature dependence of the Pitzer Coefficients
  * for each cation - anion pair, M X.
  *
- * \f[
+ * @f[
  *     \beta^{(0)}_{MX} = q^{b0}_0
  *                      + q^{b0}_1 \left( T - T_r \right)
  *                      + q^{b0}_2 \left( T^2 - T_r^2 \right)
  *                      + q^{b0}_3 \left( \frac{1}{T} - \frac{1}{T_r}\right)
  *                      + q^{b0}_4 \ln \left( \frac{T}{T_r} \right)
- * \f]
- * \f[
+ * @f]
+ * @f[
  *     \beta^{(1)}_{MX} = q^{b1}_0  + q^{b1}_1 \left( T - T_r \right)
  *                      + q^{b1}_{2} \left( T^2 - T_r^2 \right)
- * \f]
- * \f[
+ * @f]
+ * @f[
  *    C^{\phi}_{MX} = q^{Cphi}_0
  *                  + q^{Cphi}_1 \left( T - T_r \right)
  *                  + q^{Cphi}_2 \left( T^2 - T_r^2 \right)
  *                  + q^{Cphi}_3 \left( \frac{1}{T} - \frac{1}{T_r}\right)
  *                  + q^{Cphi}_4 \ln \left( \frac{T}{T_r} \right)
- * \f]
+ * @f]
  *
  * where
  *
- * \f[
+ * @f[
  *     C^{\phi}_{MX} =  2 {\left| z_M z_X \right|}^{1/2} C_{MX}
- * \f]
+ * @f]
  *
  * In later papers, Pitzer has added additional temperature dependencies to all
  * of the other remaining second and third order virial coefficients. Some of
@@ -485,90 +485,90 @@ class WaterProps;
  *        and pressure
  *    - PIZTER_TEMP_COMPLEX1     - string name "COMPLEX" or "COMPLEX1"
  *      - Uses the full temperature dependence for the
- *        \f$\beta^{(0)}_{MX} \f$ (5 coeffs),
- *        the  \f$\beta^{(1)}_{MX} \f$ (3 coeffs),
- *        and \f$ C^{\phi}_{MX} \f$ (5 coeffs) parameters described above.
+ *        @f$\beta^{(0)}_{MX} @f$ (5 coeffs),
+ *        the  @f$\beta^{(1)}_{MX} @f$ (3 coeffs),
+ *        and @f$ C^{\phi}_{MX} @f$ (5 coeffs) parameters described above.
  *    - PITZER_TEMP_LINEAR        - string name "LINEAR"
  *      - Uses just the temperature dependence for the
- *        \f$\beta^{(0)}_{MX} \f$, the \f$\beta^{(1)}_{MX} \f$,
- *        and \f$ C^{\phi}_{MX} \f$ coefficients described above.
+ *        @f$\beta^{(0)}_{MX} @f$, the @f$\beta^{(1)}_{MX} @f$,
+ *        and @f$ C^{\phi}_{MX} @f$ coefficients described above.
  *        There are 2 coefficients for each term.
  *
  * The specification of the binary interaction between a cation and an anion is
- * given by the coefficients, \f$ B_{MX}\f$ and \f$ C_{MX}\f$ The specification
- * of \f$ B_{MX}\f$ is a function of \f$\beta^{(0)}_{MX} \f$,
- * \f$\beta^{(1)}_{MX} \f$, \f$\beta^{(2)}_{MX} \f$, \f$\alpha^{(1)}_{MX} \f$,
- * and \f$\alpha^{(2)}_{MX} \f$. \f$ C_{MX}\f$ is calculated from
- * \f$C^{\phi}_{MX} \f$ from the formula above.
+ * given by the coefficients, @f$ B_{MX}@f$ and @f$ C_{MX}@f$ The specification
+ * of @f$ B_{MX}@f$ is a function of @f$\beta^{(0)}_{MX} @f$,
+ * @f$\beta^{(1)}_{MX} @f$, @f$\beta^{(2)}_{MX} @f$, @f$\alpha^{(1)}_{MX} @f$,
+ * and @f$\alpha^{(2)}_{MX} @f$. @f$ C_{MX}@f$ is calculated from
+ * @f$C^{\phi}_{MX} @f$ from the formula above.
  *
- * The parameters for \f$ \beta^{(0)}\f$ fit the following equation:
+ * The parameters for @f$ \beta^{(0)}@f$ fit the following equation:
  *
- * \f[
+ * @f[
  *     \beta^{(0)} = q_0^{{\beta}0} + q_1^{{\beta}0} \left( T - T_r \right)
  *            + q_2^{{\beta}0} \left( T^2 - T_r^2 \right)
  *            + q_3^{{\beta}0} \left( \frac{1}{T} - \frac{1}{T_r} \right)
  *            + q_4^{{\beta}0} \ln \left( \frac{T}{T_r} \right)
- * \f]
+ * @f]
  *
  * This same `COMPLEX1` temperature dependence given above is used for the
  * following parameters:
- * \f$ \beta^{(0)}_{MX} \f$, \f$ \beta^{(1)}_{MX} \f$,
- * \f$ \beta^{(2)}_{MX} \f$, \f$ \Theta_{cc'} \f$, \f$\Theta_{aa'} \f$,
- * \f$ \Psi_{c{c'}a} \f$ and \f$ \Psi_{ca{a'}} \f$.
+ * @f$ \beta^{(0)}_{MX} @f$, @f$ \beta^{(1)}_{MX} @f$,
+ * @f$ \beta^{(2)}_{MX} @f$, @f$ \Theta_{cc'} @f$, @f$\Theta_{aa'} @f$,
+ * @f$ \Psi_{c{c'}a} @f$ and @f$ \Psi_{ca{a'}} @f$.
  *
  * ### Like-Charged Binary Ion Parameters and the Mixing Parameters
  *
- * The previous section contained the functions, \f$ \Phi_{c{c'}} \f$,
- * \f$ \Phi_{a{a'}} \f$ and their derivatives wrt the ionic strength, \f$
- * \Phi'_{c{c'}} \f$ and \f$ \Phi'_{a{a'}} \f$. Part of these terms come from
+ * The previous section contained the functions, @f$ \Phi_{c{c'}} @f$,
+ * @f$ \Phi_{a{a'}} @f$ and their derivatives wrt the ionic strength, @f$
+ * \Phi'_{c{c'}} @f$ and @f$ \Phi'_{a{a'}} @f$. Part of these terms come from
  * theory.
  *
  * Since like charged ions repel each other and are generally not near each
  * other, the virial coefficients for same-charged ions are small. However,
  * Pitzer doesn't ignore these in his formulation. Relatively larger and longer
  * range terms between like-charged ions exist however, which appear only for
- * unsymmetrical mixing of same-sign charged ions with different charges. \f$
- * \Phi_{ij} \f$, where \f$ ij \f$ is either \f$ a{a'} \f$ or \f$ c{c'} \f$ is
+ * unsymmetrical mixing of same-sign charged ions with different charges. @f$
+ * \Phi_{ij} @f$, where @f$ ij @f$ is either @f$ a{a'} @f$ or @f$ c{c'} @f$ is
  * given by
  *
- * \f[
+ * @f[
  *     {\Phi}_{ij} = \Theta_{ij} + \,^E \Theta_{ij}(I)
- * \f]
+ * @f]
  *
- * \f$ \Theta_{ij} \f$ is the small virial coefficient expansion term. Dependent
+ * @f$ \Theta_{ij} @f$ is the small virial coefficient expansion term. Dependent
  * in general on temperature and pressure, its ionic strength dependence is
- * ignored in Pitzer's approach. \f$ \,^E\Theta_{ij}(I) \f$ accounts for the
+ * ignored in Pitzer's approach. @f$ \,^E\Theta_{ij}(I) @f$ accounts for the
  * electrostatic unsymmetrical mixing effects and is dependent only on the
  * charges of the ions i, j, the total ionic strength and on the dielectric
  * constant and density of the solvent. This seems to be a relatively well-
  * documented part of the theory. They theory below comes from Pitzer summation
  * (Pitzer) in the appendix. It's also mentioned in Bethke's book (Bethke), and
- * the equations are summarized in Harvie & Weare (1980). Within the code, \f$
- * \,^E\Theta_{ij}(I) \f$ is evaluated according to the algorithm described in
+ * the equations are summarized in Harvie & Weare (1980). Within the code, @f$
+ * \,^E\Theta_{ij}(I) @f$ is evaluated according to the algorithm described in
  * Appendix B [Pitzer] as
  *
- * \f[
+ * @f[
  *    \,^E\Theta_{ij}(I) = \left( \frac{z_i z_j}{4I} \right)
  *       \left( J(x_{ij})  - \frac{1}{2} J(x_{ii})
  *                         - \frac{1}{2} J(x_{jj})  \right)
- * \f]
+ * @f]
  *
- * where \f$ x_{ij} = 6 z_i z_j A_{\phi} \sqrt{I} \f$ and
+ * where @f$ x_{ij} = 6 z_i z_j A_{\phi} \sqrt{I} @f$ and
  *
- *  \f[
+ *  @f[
  *     J(x) = \frac{1}{x} \int_0^{\infty}{\left( 1 + q +
  *            \frac{1}{2} q^2 - e^q \right) y^2 dy}
- *  \f]
+ *  @f]
  *
- * and \f$ q = - (\frac{x}{y}) e^{-y} \f$. \f$ J(x) \f$ is evaluated by
+ * and @f$ q = - (\frac{x}{y}) e^{-y} @f$. @f$ J(x) @f$ is evaluated by
  * numerical integration.
  *
- * The \f$  \Theta_{ij} \f$ term is a constant value, specified for pair of cations
+ * The @f$  \Theta_{ij} @f$ term is a constant value, specified for pair of cations
  * or a pair of anions.
  *
  * ### Ternary Pitzer Parameters
  *
- * The \f$  \Psi_{c{c'}a} \f$ and \f$  \Psi_{ca{a'}} \f$ terms represent ternary
+ * The @f$  \Psi_{c{c'}a} @f$ and @f$  \Psi_{ca{a'}} @f$ terms represent ternary
  * interactions between two cations and an anion and two anions and a cation,
  * respectively. In Pitzer's implementation these terms are usually small in
  * absolute size.
@@ -576,7 +576,7 @@ class WaterProps;
  * ### Treatment of Neutral Species
  *
  * Binary virial-coefficient-like interactions between two neutral species may
- * be specified in the \f$ \lambda_{mn} \f$ terms that appear in the formulas
+ * be specified in the @f$ \lambda_{mn} @f$ terms that appear in the formulas
  * above. Currently these interactions are independent of pressure and ionic strength.
  * Also, currently, the neutrality of the species are not checked. Therefore, this
  * interaction may involve charged species in the solution as well.
@@ -587,44 +587,44 @@ class WaterProps;
  *
  * ### Specification of the Debye-Huckel Constant
  *
- * In the equations above, the formula for  \f$  A_{Debye} \f$ is needed. The
+ * In the equations above, the formula for  @f$  A_{Debye} @f$ is needed. The
  * HMWSoln object uses two methods for specifying these quantities. The default
- * method is to assume that \f$  A_{Debye} \f$  is a constant, given in the
+ * method is to assume that @f$  A_{Debye} @f$  is a constant, given in the
  * initialization process, and stored in the member double, m_A_Debye.
  * Optionally, a full water treatment may be employed that makes
- * \f$ A_{Debye} \f$ a full function of *T* and *P* and creates nontrivial
+ * @f$ A_{Debye} @f$ a full function of *T* and *P* and creates nontrivial
  * entries for the excess heat capacity, enthalpy, and excess volumes of
  * solution.
  *
- * \f[
+ * @f[
  *     A_{Debye} = \frac{F e B_{Debye}}{8 \pi \epsilon R T} {\left( C_o \tilde{M}_o \right)}^{1/2}
- * \f]
+ * @f]
  * where
  *
- * \f[
+ * @f[
  *     B_{Debye} = \frac{F} {{(\frac{\epsilon R T}{2})}^{1/2}}
- * \f]
+ * @f]
  * Therefore:
- * \f[
+ * @f[
  *     A_{Debye} = \frac{1}{8 \pi}
  *                 {\left(\frac{2 N_a \rho_o}{1000}\right)}^{1/2}
  *                 {\left(\frac{N_a e^2}{\epsilon R T }\right)}^{3/2}
- * \f]
+ * @f]
  *
  * Units = sqrt(kg/gmol)
  *
  * where
- *  - \f$ N_a \f$ is Avogadro's number
- *  - \f$ \rho_w \f$ is the density of water
- *  - \f$ e \f$ is the electronic charge
- *  - \f$ \epsilon = K \epsilon_o \f$ is the permittivity of water
- *  - \f$ K \f$ is the dielectric constant of water,
- *  - \f$ \epsilon_o \f$ is the permittivity of free space.
- *  - \f$ \rho_o \f$ is the density of the solvent in its standard state.
+ *  - @f$ N_a @f$ is Avogadro's number
+ *  - @f$ \rho_w @f$ is the density of water
+ *  - @f$ e @f$ is the electronic charge
+ *  - @f$ \epsilon = K \epsilon_o @f$ is the permittivity of water
+ *  - @f$ K @f$ is the dielectric constant of water,
+ *  - @f$ \epsilon_o @f$ is the permittivity of free space.
+ *  - @f$ \rho_o @f$ is the density of the solvent in its standard state.
  *
  * Nominal value at 298 K and 1 atm = 1.172576 (kg/gmol)^(1/2)
  * based on:
- *  - \f$ \epsilon / \epsilon_0 \f$ = 78.54 (water at 25C)
+ *  - @f$ \epsilon / \epsilon_0 @f$ = 78.54 (water at 25C)
  *  - T = 298.15 K
  *  - B_Debye = 3.28640E9 (kg/gmol)^(1/2) / m
  *
@@ -635,55 +635,55 @@ class WaterProps;
  * molar enthalpies, entropies, and heat capacities are all non-trivial to
  * compute. The following formulas are used.
  *
- * The partial molar enthalpy, \f$ \bar s_k(T,P) \f$:
+ * The partial molar enthalpy, @f$ \bar s_k(T,P) @f$:
  *
- * \f[
+ * @f[
  * \bar h_k(T,P) = h^{\triangle}_k(T,P)
  *               - R T^2 \frac{d \ln(\gamma_k^\triangle)}{dT}
- * \f]
+ * @f]
  * The solvent partial molar enthalpy is equal to
- * \f[
+ * @f[
  * \bar h_o(T,P) = h^{o}_o(T,P) - R T^2 \frac{d \ln(a_o)}{dT}
  *       = h^{o}_o(T,P)
  *       + R T^2 (\sum_{k \neq o} m_k)  \tilde{M_o} (\frac{d \phi}{dT})
- * \f]
+ * @f]
  *
- * The partial molar entropy, \f$ \bar s_k(T,P) \f$:
+ * The partial molar entropy, @f$ \bar s_k(T,P) @f$:
  *
- * \f[
+ * @f[
  *     \bar s_k(T,P) =  s^{\triangle}_k(T,P)
  *             - R \ln( \gamma^{\triangle}_k \frac{m_k}{m^{\triangle}}))
  *                    - R T \frac{d \ln(\gamma^{\triangle}_k) }{dT}
- * \f]
- * \f[
+ * @f]
+ * @f[
  *      \bar s_o(T,P) = s^o_o(T,P) - R \ln(a_o)
  *                    - R T \frac{d \ln(a_o)}{dT}
- * \f]
+ * @f]
  *
- * The partial molar heat capacity, \f$ C_{p,k}(T,P)\f$:
+ * The partial molar heat capacity, @f$ C_{p,k}(T,P)@f$:
  *
- * \f[
+ * @f[
  *     \bar C_{p,k}(T,P) =  C^{\triangle}_{p,k}(T,P)
  *             - 2 R T \frac{d \ln( \gamma^{\triangle}_k)}{dT}
  *                    - R T^2 \frac{d^2 \ln(\gamma^{\triangle}_k) }{{dT}^2}
- * \f]
- * \f[
+ * @f]
+ * @f[
  *      \bar C_{p,o}(T,P) = C^o_{p,o}(T,P)
  *                   - 2 R T \frac{d \ln(a_o)}{dT}
  *                    - R T^2 \frac{d^2 \ln(a_o)}{{dT}^2}
- * \f]
+ * @f]
  *
  * The pressure dependence of the activity coefficients leads to non-zero terms
  * for the excess Volume of the solution. Therefore, the partial molar volumes
  * are functions of the pressure derivatives of the activity coefficients.
- * \f[
+ * @f[
  *     \bar V_k(T,P) =  V^{\triangle}_k(T,P)
  *                    + R T \frac{d \ln(\gamma^{\triangle}_k) }{dP}
- * \f]
- * \f[
+ * @f]
+ * @f[
  *      \bar V_o(T,P) = V^o_o(T,P)
  *                    + R T \frac{d \ln(a_o)}{dP}
- * \f]
+ * @f]
  *
  * The majority of work for these functions take place in the internal routines
  * that calculate the first and second derivatives of the log of the activity
@@ -707,70 +707,70 @@ class WaterProps;
  *
  * For example, a bulk-phase binary reaction between liquid solute species *j*
  * and *k*, producing a new liquid solute species *l* would have the following
- * equation for its rate of progress variable, \f$ R^1 \f$, which has units of
+ * equation for its rate of progress variable, @f$ R^1 @f$, which has units of
  * kmol m-3 s-1.
  *
- * \f[
+ * @f[
  *    R^1 = k^1 C_j^a C_k^a =  k^1 (C^o_o \tilde{M}_o a_j) (C^o_o \tilde{M}_o a_k)
- * \f]
+ * @f]
  *
  * where
  *
- * \f[
+ * @f[
  *    C_j^a = C^o_o \tilde{M}_o a_j \quad and \quad C_k^a = C^o_o \tilde{M}_o a_k
- * \f]
+ * @f]
  *
- * \f$ C_j^a \f$ is the activity concentration of species *j*, and
- * \f$ C_k^a \f$ is the activity concentration of species *k*. \f$ C^o_o \f$ is
- * the concentration of water at 298 K and 1 atm. \f$ \tilde{M}_o \f$ has units
+ * @f$ C_j^a @f$ is the activity concentration of species *j*, and
+ * @f$ C_k^a @f$ is the activity concentration of species *k*. @f$ C^o_o @f$ is
+ * the concentration of water at 298 K and 1 atm. @f$ \tilde{M}_o @f$ has units
  * of kg solvent per gmol solvent and is equal to
  *
- * \f[
+ * @f[
  *     \tilde{M}_o = \frac{M_o}{1000}
- * \f]
+ * @f]
  *
- * \f$ a_j \f$ is the activity of species *j* at the current temperature and
+ * @f$ a_j @f$ is the activity of species *j* at the current temperature and
  * pressure and concentration of the liquid phase is given by the molality based
  * activity coefficient multiplied by the molality of the jth species.
  *
- * \f[
+ * @f[
  *      a_j  =  \gamma_j^\triangle m_j = \gamma_j^\triangle \frac{n_j}{\tilde{M}_o n_o}
- * \f]
+ * @f]
  *
- * \f$k^1 \f$ has units of m^3/kmol/s.
+ * @f$k^1 @f$ has units of m^3/kmol/s.
  *
  * Therefore the generalized activity concentration of a solute species has the following form
  *
- * \f[
+ * @f[
  *      C_j^a = C^o_o \frac{\gamma_j^\triangle n_j}{n_o}
- * \f]
+ * @f]
  *
  * The generalized activity concentration of the solvent has the same units, but it's a simpler form
  *
- * \f[
+ * @f[
  *      C_o^a = C^o_o a_o
- * \f]
+ * @f]
  *
  * The reverse rate constant can then be obtained from the law of microscopic reversibility
  * and the equilibrium expression for the system.
  *
- * \f[
+ * @f[
  *      \frac{a_j a_k}{ a_l} = K^{o,1} = \exp(\frac{\mu^o_l - \mu^o_j - \mu^o_k}{R T} )
- * \f]
+ * @f]
  *
- * \f$ K^{o,1} \f$ is the dimensionless form of the equilibrium constant.
+ * @f$ K^{o,1} @f$ is the dimensionless form of the equilibrium constant.
  *
- * \f[
+ * @f[
  *       R^{-1} = k^{-1} C_l^a =  k^{-1} (C_o  \tilde{M}_o a_l)
- * \f]
+ * @f]
  *
  * where
  *
- * \f[
+ * @f[
  *       k^{-1} =  k^1 K^{o,1} C_o \tilde{M}_o
- * \f]
+ * @f]
  *
- * \f$ k^{-1} \f$ has units of 1/s.
+ * @f$ k^{-1} @f$ has units of 1/s.
  *
  * @ingroup thermoprops
  */
@@ -833,11 +833,11 @@ public:
      * Molar entropy of the solution. Units: J/kmol/K. For an ideal, constant
      * partial molar volume solution mixture with pure species phases which
      * exhibit zero volume expansivity:
-     * \f[
+     * @f[
      * \hat s(T, P, X_k) = \sum_k X_k \hat s^0_k(T)
      *      - \hat R  \sum_k X_k log(X_k)
-     * \f]
-     * The reference-state pure-species entropies \f$ \hat s^0_k(T,p_{ref}) \f$
+     * @f]
+     * The reference-state pure-species entropies @f$ \hat s^0_k(T,p_{ref}) @f$
      * are computed by the species thermodynamic property manager. The pure
      * species entropies are independent of temperature since the volume
      * expansivities are equal to zero.
@@ -878,12 +878,12 @@ protected:
      *
      * The formula for this is
      *
-     * \f[
+     * @f[
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * \f]
+     * @f]
      *
-     * where \f$X_k\f$ are the mole fractions, \f$W_k\f$ are the molecular
-     * weights, and \f$V_k\f$ are the pure species molar volumes.
+     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
+     * weights, and @f$V_k@f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -899,17 +899,17 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
+    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
     //! which depends only on temperature and the pressure. Activity is assumed
     //! to be molality-based here.
     //! @{
 
     //! This method returns an array of generalized activity concentrations
     /*!
-     * The generalized activity concentrations, \f$ C_k^a\f$, are defined such
-     * that \f$ a_k = C^a_k / C^0_k, \f$ where \f$ C^0_k \f$ is a standard
+     * The generalized activity concentrations, @f$ C_k^a@f$, are defined such
+     * that @f$ a_k = C^a_k / C^0_k, @f$ where @f$ C^0_k @f$ is a standard
      * concentration defined below.  These generalized concentrations are used
      * by kinetics manager classes to compute the forward and reverse rates of
      * elementary reactions.
@@ -917,16 +917,16 @@ public:
      * The generalized activity concentration of a solute species has the
      * following form
      *
-     *  \f[
+     *  @f[
      *      C_j^a = C^o_o \frac{\gamma_j^\triangle n_j}{n_o}
-     *  \f]
+     *  @f]
      *
      * The generalized activity concentration of the solvent has the same units,
      * but it's a simpler form
      *
-     *  \f[
+     *  @f[
      *      C_o^a = C^o_o a_o
-     *  \f]
+     *  @f]
      *
      * @param c Array of generalized concentrations. The
      *          units are kmol m-3 for both the solvent and the solute species
@@ -935,7 +935,7 @@ public:
 
     //! Return the standard concentration for the kth species
     /*!
-     * The standard concentration \f$ C^0_k \f$ used to normalize the activity
+     * The standard concentration @f$ C^0_k @f$ used to normalize the activity
      * (that is, generalized) concentration for use
      *
      * We have set the standard concentration for all solute species in this
@@ -944,9 +944,9 @@ public:
      * solvent). The solvent standard concentration is just equal to its
      * standard state concentration.
      *
-     *   \f[
+     *   @f[
      *      C_j^0 = C^o_o \tilde{M}_o \quad and  C_o^0 = C^o_o
-     *   \f]
+     *   @f]
      *
      * The consequence of this is that the standard concentrations have unequal
      * units between the solvent and the solute. However, both the solvent and
@@ -960,52 +960,52 @@ public:
      *
      * For example, a bulk-phase binary reaction between liquid solute species
      * *j* and *k*, producing a new liquid solute species *l* would have the
-     * following equation for its rate of progress variable, \f$ R^1 \f$, which
+     * following equation for its rate of progress variable, @f$ R^1 @f$, which
      * has units of kmol m-3 s-1.
      *
-     * \f[
+     * @f[
      *    R^1 = k^1 C_j^a C_k^a =  k^1 (C^o_o \tilde{M}_o a_j) (C^o_o \tilde{M}_o a_k)
-     * \f]
+     * @f]
      *
      * where
      *
-     * \f[
+     * @f[
      *      C_j^a = C^o_o \tilde{M}_o a_j \quad and \quad C_k^a = C^o_o \tilde{M}_o a_k
-     * \f]
+     * @f]
      *
-     * \f$ C_j^a \f$ is the activity concentration of species *j*, and
-     * \f$ C_k^a \f$ is the activity concentration of species *k*. \f$ C^o_o \f$
-     * is the concentration of water at 298 K and 1 atm. \f$ \tilde{M}_o \f$ has
+     * @f$ C_j^a @f$ is the activity concentration of species *j*, and
+     * @f$ C_k^a @f$ is the activity concentration of species *k*. @f$ C^o_o @f$
+     * is the concentration of water at 298 K and 1 atm. @f$ \tilde{M}_o @f$ has
      * units of kg solvent per gmol solvent and is equal to
      *
-     * \f[
+     * @f[
      *     \tilde{M}_o = \frac{M_o}{1000}
-     * \f]
+     * @f]
      *
-     * \f$ a_j \f$ is
+     * @f$ a_j @f$ is
      *  the activity of species *j* at the current temperature and pressure
      *  and concentration of the liquid phase is given by the molality based
      *  activity coefficient multiplied by the molality of the jth species.
      *
-     * \f[
+     * @f[
      *      a_j  =  \gamma_j^\triangle m_j = \gamma_j^\triangle \frac{n_j}{\tilde{M}_o n_o}
-     * \f]
+     * @f]
      *
-     * \f$k^1 \f$ has units of m^3/kmol/s.
+     * @f$k^1 @f$ has units of m^3/kmol/s.
      *
      * Therefore the generalized activity concentration of a solute species has
      * the following form
      *
-     * \f[
+     * @f[
      *     C_j^a = C^o_o \frac{\gamma_j^\triangle n_j}{n_o}
-     * \f]
+     * @f]
      *
      * The generalized activity concentration of the solvent has the same units,
      * but it's a simpler form
      *
-     * \f[
+     * @f[
      *     C_o^a = C^o_o a_o
-     * \f]
+     * @f]
      *
      * @param k Optional parameter indicating the species. The default is to
      *         assume this refers to species 0.
@@ -1037,9 +1037,9 @@ public:
      * This function returns a vector of chemical potentials of the
      * species in solution.
      *
-     * \f[
+     * @f[
      *    \mu_k = \mu^{\triangle}_k(T,P) + R T ln(\gamma_k^{\triangle} m_k)
-     * \f]
+     * @f]
      *
      * @param mu  Output vector of species chemical
      *            potentials. Length: m_kk. Units: J/kmol
@@ -1053,16 +1053,16 @@ public:
      * state enthalpies modified by the derivative of the molality-based
      * activity coefficient wrt temperature
      *
-     *  \f[
+     *  @f[
      * \bar h_k(T,P) = h^{\triangle}_k(T,P)
      *               - R T^2 \frac{d \ln(\gamma_k^\triangle)}{dT}
-     * \f]
+     * @f]
      * The solvent partial molar enthalpy is equal to
-     *  \f[
+     *  @f[
      * \bar h_o(T,P) = h^{o}_o(T,P) - R T^2 \frac{d \ln(a_o)}{dT}
      *       = h^{o}_o(T,P)
      *       + R T^2 (\sum_{k \neq o} m_k)  \tilde{M_o} (\frac{d \phi}{dT})
-     * \f]
+     * @f]
      *
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: m_kk. units are J/kmol.
@@ -1081,15 +1081,15 @@ public:
      * entropies plus the ideal solution contribution plus complicated functions
      * of the temperature derivative of the activity coefficients.
      *
-     *  \f[
+     *  @f[
      *     \bar s_k(T,P) =  s^{\triangle}_k(T,P)
      *             - R \ln( \gamma^{\triangle}_k \frac{m_k}{m^{\triangle}}))
      *                    - R T \frac{d \ln(\gamma^{\triangle}_k) }{dT}
-     * \f]
-     * \f[
+     * @f]
+     * @f[
      *      \bar s_o(T,P) = s^o_o(T,P) - R \ln(a_o)
      *                    - R T \frac{d \ln(a_o)}{dT}
-     * \f]
+     * @f]
      *
      *  @param sbar    Output vector of species partial molar entropies.
      *                 Length = m_kk. units are J/kmol/K.
@@ -1102,14 +1102,14 @@ public:
      * For this solution, the partial molar volumes are functions of the
      * pressure derivatives of the activity coefficients.
      *
-     * \f[
+     * @f[
      *     \bar V_k(T,P)  = V^{\triangle}_k(T,P)
      *                    + R T \frac{d \ln(\gamma^{\triangle}_k) }{dP}
-     * \f]
-     * \f[
+     * @f]
+     * @f[
      *      \bar V_o(T,P) = V^o_o(T,P)
      *                    + R T \frac{d \ln(a_o)}{dP}
-     * \f]
+     * @f]
      *
      * @param vbar   Output vector of species partial molar volumes.
      *               Length = m_kk. units are m^3/kmol.
@@ -1121,16 +1121,16 @@ public:
     /*!
      * The following formulas are implemented within the code.
      *
-     * \f[
+     * @f[
      *     \bar C_{p,k}(T,P) =  C^{\triangle}_{p,k}(T,P)
      *             - 2 R T \frac{d \ln( \gamma^{\triangle}_k)}{dT}
      *                    - R T^2 \frac{d^2 \ln(\gamma^{\triangle}_k) }{{dT}^2}
-     * \f]
-     * \f[
+     * @f]
+     * @f[
      *      \bar C_{p,o}(T,P) = C^o_{p,o}(T,P)
      *                   - 2 R T \frac{d \ln(a_o)}{dT}
      *                    - R T^2 \frac{d^2 \ln(a_o)}{{dT}^2}
-     * \f]
+     * @f]
      *
      * @param cpbar   Output vector of species partial molar heat capacities at
      *                constant pressure. Length = m_kk. units are J/kmol/K.

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -53,48 +53,48 @@ namespace Cantera
  *
  * The standard state enthalpy is independent of pressure:
  *
- * \f[
+ * @f[
  *      h^o_k(T,P) = h^{ref}_k(T)
- * \f]
+ * @f]
  *
  * The standard state constant-pressure heat capacity is independent of pressure:
  *
- * \f[
+ * @f[
  *      Cp^o_k(T,P) = Cp^{ref}_k(T)
- * \f]
+ * @f]
  *
  * The standard state entropy depends in the following fashion on pressure:
  *
- * \f[
+ * @f[
  *      S^o_k(T,P) = S^{ref}_k(T) -  R \ln(\frac{P}{P_{ref}})
- * \f]
+ * @f]
  * The standard state Gibbs free energy is obtained from the enthalpy and entropy
  * functions:
  *
- * \f[
+ * @f[
  *      \mu^o_k(T,P) =  h^o_k(T,P) - S^o_k(T,P) T
- * \f]
+ * @f]
  *
- * \f[
+ * @f[
  *      \mu^o_k(T,P) =  \mu^{ref}_k(T) + R T \ln( \frac{P}{P_{ref}})
- * \f]
+ * @f]
  *
  * where
- * \f[
+ * @f[
  *      \mu^{ref}_k(T) =   h^{ref}_k(T)   - T S^{ref}_k(T)
- * \f]
+ * @f]
  *
  * The standard state internal energy is obtained from the enthalpy function also
  *
- * \f[
+ * @f[
  *      u^o_k(T,P) = h^o_k(T) - R T
- * \f]
+ * @f]
  *
  * The molar volume of a species is given by the ideal gas law
  *
- * \f[
+ * @f[
  *      V^o_k(T,P) = \frac{R T}{P}
- * \f]
+ * @f]
  *
  * where R is the molar gas constant. For a complete list of physical constants
  * used within %Cantera, see @ref physConstants .
@@ -102,142 +102,142 @@ namespace Cantera
  * ## Specification of Solution Thermodynamic Properties
  *
  * The activity of a species defined in the phase is given by the ideal gas law:
- * \f[
+ * @f[
  *      a_k = X_k
- * \f]
- * where \f$ X_k \f$ is the mole fraction of species *k*. The chemical potential
+ * @f]
+ * where @f$ X_k @f$ is the mole fraction of species *k*. The chemical potential
  * for species *k* is equal to
  *
- * \f[
+ * @f[
  *      \mu_k(T,P) = \mu^o_k(T, P) + R T \log(X_k)
- * \f]
+ * @f]
  *
  * In terms of the reference state, the above can be rewritten
  *
- * \f[
+ * @f[
  *      \mu_k(T,P) = \mu^{ref}_k(T, P) + R T \log(\frac{P X_k}{P_{ref}})
- * \f]
+ * @f]
  *
  * The partial molar entropy for species *k* is given by the following relation,
  *
- * \f[
+ * @f[
  *      \tilde{s}_k(T,P) = s^o_k(T,P) - R \log(X_k) = s^{ref}_k(T) - R \log(\frac{P X_k}{P_{ref}})
- * \f]
+ * @f]
  *
  * The partial molar enthalpy for species *k* is
  *
- * \f[
+ * @f[
  *      \tilde{h}_k(T,P) = h^o_k(T,P) = h^{ref}_k(T)
- * \f]
+ * @f]
  *
  * The partial molar Internal Energy for species *k* is
  *
- * \f[
+ * @f[
  *      \tilde{u}_k(T,P) = u^o_k(T,P) = u^{ref}_k(T)
- * \f]
+ * @f]
  *
  * The partial molar Heat Capacity for species *k* is
  *
- * \f[
+ * @f[
  *      \tilde{Cp}_k(T,P) = Cp^o_k(T,P) = Cp^{ref}_k(T)
- * \f]
+ * @f]
  *
  * ## Application within Kinetics Managers
  *
- * \f$ C^a_k\f$ are defined such that \f$ a_k = C^a_k / C^s_k, \f$ where \f$
- * C^s_k \f$ is a standard concentration defined below and \f$ a_k \f$ are
+ * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where @f$
+ * C^s_k @f$ is a standard concentration defined below and @f$ a_k @f$ are
  * activities used in the thermodynamic functions.  These activity (or
  * generalized) concentrations are used by kinetics manager classes to compute
  * the forward and reverse rates of elementary reactions. The activity
- * concentration,\f$  C^a_k \f$,is given by the following expression.
+ * concentration,@f$  C^a_k @f$,is given by the following expression.
  *
- * \f[
+ * @f[
  *      C^a_k = C^s_k  X_k  = \frac{P}{R T} X_k
- * \f]
+ * @f]
  *
  * The standard concentration for species *k* is independent of *k* and equal to
  *
- * \f[
+ * @f[
  *     C^s_k =  C^s = \frac{P}{R T}
- * \f]
+ * @f]
  *
  * For example, a bulk-phase binary gas reaction between species j and k,
  * producing a new gas species l would have the following equation for its rate
- * of progress variable, \f$ R^1 \f$, which has units of kmol m-3 s-1.
+ * of progress variable, @f$ R^1 @f$, which has units of kmol m-3 s-1.
  *
- * \f[
+ * @f[
  *    R^1 = k^1 C_j^a C_k^a =  k^1 (C^s a_j) (C^s a_k)
- * \f]
+ * @f]
  * where
- * \f[
+ * @f[
  *    C_j^a = C^s a_j \quad \mbox{and} \quad C_k^a = C^s a_k
- * \f]
+ * @f]
  *
- * \f$ C_j^a \f$ is the activity concentration of species j, and
- * \f$ C_k^a \f$ is the activity concentration of species k. \f$ C^s \f$ is the
- * standard concentration. \f$ a_j \f$ is the activity of species j which is
+ * @f$ C_j^a @f$ is the activity concentration of species j, and
+ * @f$ C_k^a @f$ is the activity concentration of species k. @f$ C^s @f$ is the
+ * standard concentration. @f$ a_j @f$ is the activity of species j which is
  * equal to the mole fraction of j.
  *
  * The reverse rate constant can then be obtained from the law of microscopic
  * reversibility and the equilibrium expression for the system.
  *
- * \f[
+ * @f[
  *     \frac{a_j a_k}{ a_l} = K_a^{o,1} = \exp(\frac{\mu^o_l - \mu^o_j - \mu^o_k}{R T} )
- * \f]
+ * @f]
  *
- * \f$  K_a^{o,1} \f$ is the dimensionless form of the equilibrium constant,
- * associated with the pressure dependent standard states \f$ \mu^o_l(T,P) \f$
- * and their associated activities, \f$ a_l \f$, repeated here:
+ * @f$  K_a^{o,1} @f$ is the dimensionless form of the equilibrium constant,
+ * associated with the pressure dependent standard states @f$ \mu^o_l(T,P) @f$
+ * and their associated activities, @f$ a_l @f$, repeated here:
  *
- * \f[
+ * @f[
  *      \mu_l(T,P) = \mu^o_l(T, P) + R T \log(a_l)
- * \f]
+ * @f]
  *
  * We can switch over to expressing the equilibrium constant in terms of the
  * reference state chemical potentials
  *
- * \f[
+ * @f[
  *     K_a^{o,1} = \exp(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} ) * \frac{P_{ref}}{P}
- * \f]
+ * @f]
  *
- * The concentration equilibrium constant, \f$ K_c \f$, may be obtained by
+ * The concentration equilibrium constant, @f$ K_c @f$, may be obtained by
  * changing over to activity concentrations. When this is done:
  *
- * \f[
+ * @f[
  *       \frac{C^a_j C^a_k}{ C^a_l} = C^o K_a^{o,1} = K_c^1 =
  *           \exp(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} ) * \frac{P_{ref}}{RT}
- * \f]
+ * @f]
  *
  * %Kinetics managers will calculate the concentration equilibrium constant,
- * \f$ K_c \f$, using the second and third part of the above expression as a
+ * @f$ K_c @f$, using the second and third part of the above expression as a
  * definition for the concentration equilibrium constant.
  *
  * For completeness, the pressure equilibrium constant may be obtained as well
  *
- * \f[
+ * @f[
  *       \frac{P_j P_k}{ P_l P_{ref}} = K_p^1 =
  *           \exp\left(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} \right)
- * \f]
+ * @f]
  *
- * \f$ K_p \f$ is the simplest form of the equilibrium constant for ideal gases.
+ * @f$ K_p @f$ is the simplest form of the equilibrium constant for ideal gases.
  * However, it isn't necessarily the simplest form of the equilibrium constant
- * for other types of phases; \f$ K_c \f$ is used instead because it is
+ * for other types of phases; @f$ K_c @f$ is used instead because it is
  * completely general.
  *
  * The reverse rate of progress may be written down as
- * \f[
+ * @f[
  *    R^{-1} = k^{-1} C_l^a =  k^{-1} (C^o a_l)
- * \f]
+ * @f]
  *
  * where we can use the concept of microscopic reversibility to write the
  * reverse rate constant in terms of the forward rate constant and the
- * concentration equilibrium constant, \f$ K_c \f$.
+ * concentration equilibrium constant, @f$ K_c @f$.
  *
- * \f[
+ * @f[
  *    k^{-1} =  k^1 K^1_c
- * \f]
+ * @f]
  *
- * \f$k^{-1} \f$ has units of s-1.
+ * @f$k^{-1} @f$ has units of s-1.
  *
  * ## YAML Example
  *
@@ -283,11 +283,11 @@ public:
     //! Return the Molar enthalpy. Units: J/kmol.
     /*!
      * For an ideal gas mixture,
-     * \f[
+     * @f[
      * \hat h(T) = \sum_k X_k \hat h^0_k(T),
-     * \f]
+     * @f]
      * and is a function only of temperature. The standard-state pure-species
-     * enthalpies \f$ \hat h^0_k(T) \f$ are computed by the species
+     * enthalpies @f$ \hat h^0_k(T) @f$ are computed by the species
      * thermodynamic property manager.
      *
      * \see MultiSpeciesThermo
@@ -299,10 +299,10 @@ public:
     /**
      * Molar entropy. Units: J/kmol/K.
      * For an ideal gas mixture,
-     * \f[
+     * @f[
      * \hat s(T, P) = \sum_k X_k \hat s^0_k(T) - \hat R \log (P/P^0).
-     * \f]
-     * The reference-state pure-species entropies \f$ \hat s^0_k(T) \f$ are
+     * @f]
+     * The reference-state pure-species entropies @f$ \hat s^0_k(T) @f$ are
      * computed by the species thermodynamic property manager.
      * @see MultiSpeciesThermo
      */
@@ -311,10 +311,10 @@ public:
     /**
      * Molar heat capacity at constant pressure. Units: J/kmol/K.
      * For an ideal gas mixture,
-     * \f[
+     * @f[
      * \hat c_p(t) = \sum_k \hat c^0_{p,k}(T).
-     * \f]
-     * The reference-state pure-species heat capacities \f$ \hat c^0_{p,k}(T) \f$
+     * @f]
+     * The reference-state pure-species heat capacities @f$ \hat c^0_{p,k}(T) @f$
      * are computed by the species thermodynamic property manager.
      * @see MultiSpeciesThermo
      */
@@ -323,7 +323,7 @@ public:
     /**
      * Molar heat capacity at constant volume. Units: J/kmol/K.
      * For an ideal gas mixture,
-     * \f[ \hat c_v = \hat c_p - \hat R. \f]
+     * @f[ \hat c_v = \hat c_p - \hat R. @f]
      */
     virtual doublereal cv_mole() const;
 
@@ -334,7 +334,7 @@ public:
     /**
      * Pressure. Units: Pa.
      * For an ideal gas mixture,
-     * \f[ P = n \hat R T. \f]
+     * @f[ P = n \hat R T. @f]
      */
     virtual doublereal pressure() const {
         return GasConstant * molarDensity() * temperature();
@@ -344,9 +344,9 @@ public:
     /*!
      * Units: Pa.
      * This method is implemented by setting the mass density to
-     * \f[
+     * @f[
      * \rho = \frac{P \overline W}{\hat R T }.
-     * \f]
+     * @f]
      *
      * @param p Pressure (Pa)
      */
@@ -359,9 +359,9 @@ public:
      * Units: kg/m^3, Pa.
      * This method is implemented by setting the density to the input value and
      * setting the temperature to
-     * \f[
+     * @f[
      * T = \frac{P \overline W}{\hat R \rho}.
-     * \f]
+     * @f]
      *
      * @param rho Density (kg/m^3)
      * @param p Pressure (Pa)
@@ -380,9 +380,9 @@ public:
     //! Returns the isothermal compressibility. Units: 1/Pa.
     /**
      * The isothermal compressibility is defined as
-     * \f[
+     * @f[
      * \kappa_T = -\frac{1}{v}\left(\frac{\partial v}{\partial P}\right)_T
-     * \f]
+     * @f]
      *  For ideal gases it's equal to the inverse of the pressure
      */
     virtual doublereal isothermalCompressibility() const {
@@ -392,9 +392,9 @@ public:
     //! Return the volumetric thermal expansion coefficient. Units: 1/K.
     /*!
      * The thermal expansion coefficient is defined as
-     * \f[
+     * @f[
      * \beta = \frac{1}{v}\left(\frac{\partial v}{\partial T}\right)_P
-     * \f]
+     * @f]
      * For ideal gases, it's equal to the inverse of the temperature.
      */
     virtual doublereal thermalExpansionCoeff() const {
@@ -406,24 +406,24 @@ public:
     //! @}
     //! @name Chemical Potentials and Activities
     //!
-    //! The activity \f$a_k\f$ of a species in solution is
+    //! The activity @f$a_k@f$ of a species in solution is
     //! related to the chemical potential by
-    //! \f[
+    //! @f[
     //!  \mu_k(T,P,X_k) = \mu_k^0(T,P)
     //! + \hat R T \log a_k.
-    //!  \f]
-    //! The quantity \f$\mu_k^0(T,P)\f$ is the standard state chemical potential
+    //!  @f]
+    //! The quantity @f$\mu_k^0(T,P)@f$ is the standard state chemical potential
     //! at unit activity. It may depend on the pressure and the temperature.
     //! However, it may not depend on the mole fractions of the species in the
     //! solution.
     //!
-    //! The activities are related to the generalized concentrations, \f$\tilde
-    //! C_k\f$, and standard concentrations, \f$C^0_k\f$, by the following
+    //! The activities are related to the generalized concentrations, @f$\tilde
+    //! C_k@f$, and standard concentrations, @f$C^0_k@f$, by the following
     //! formula:
     //!
-    //!  \f[
+    //!  @f[
     //!  a_k = \frac{\tilde C_k}{C^0_k}
-    //!  \f]
+    //!  @f]
     //! The generalized concentrations are used in the kinetics classes to
     //! describe the rates of progress of reactions involving the species. Their
     //! formulation depends upon the specification of the rate constants for
@@ -445,14 +445,14 @@ public:
         getConcentrations(c);
     }
 
-    //! Returns the standard concentration \f$ C^0_k \f$, which is used to
+    //! Returns the standard concentration @f$ C^0_k @f$, which is used to
     //! normalize the generalized concentration.
     /*!
      * This is defined as the concentration by which the generalized
      * concentration is normalized to produce the activity. In many cases, this
      * quantity will be the same for all species in a phase. Since the activity
      * for an ideal gas mixture is simply the mole fraction, for an ideal gas
-     * \f$ C^0_k = P/\hat R T \f$.
+     * @f$ C^0_k = P/\hat R T @f$.
      *
      * @param k Optional parameter indicating the species. The default
      *          is to assume this refers to species 0.

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -144,7 +144,7 @@ namespace Cantera
  *
  * ## Application within Kinetics Managers
  *
- * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where @f$
+ * @f$ C^a_k @f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where @f$
  * C^s_k @f$ is a standard concentration defined below and @f$ a_k @f$ are
  * activities used in the thermodynamic functions.  These activity (or
  * generalized) concentrations are used by kinetics manager classes to compute
@@ -237,7 +237,7 @@ namespace Cantera
  *    k^{-1} =  k^1 K^1_c
  * @f]
  *
- * @f$k^{-1} @f$ has units of s-1.
+ * @f$ k^{-1} @f$ has units of s-1.
  *
  * ## YAML Example
  *
@@ -406,19 +406,19 @@ public:
     //! @}
     //! @name Chemical Potentials and Activities
     //!
-    //! The activity @f$a_k@f$ of a species in solution is
+    //! The activity @f$ a_k @f$ of a species in solution is
     //! related to the chemical potential by
     //! @f[
     //!  \mu_k(T,P,X_k) = \mu_k^0(T,P)
     //! + \hat R T \log a_k.
     //!  @f]
-    //! The quantity @f$\mu_k^0(T,P)@f$ is the standard state chemical potential
+    //! The quantity @f$ \mu_k^0(T,P) @f$ is the standard state chemical potential
     //! at unit activity. It may depend on the pressure and the temperature.
     //! However, it may not depend on the mole fractions of the species in the
     //! solution.
     //!
-    //! The activities are related to the generalized concentrations, @f$\tilde
-    //! C_k@f$, and standard concentrations, @f$C^0_k@f$, by the following
+    //! The activities are related to the generalized concentrations, @f$ \tilde
+    //! C_k @f$, and standard concentrations, @f$ C^0_k @f$, by the following
     //! formula:
     //!
     //!  @f[

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -50,8 +50,8 @@ namespace Cantera
  * The standard concentrations can have three different forms.
  * See setStandardConcentrationModel().
  *
- * \f$ V^0_0 \f$ is the solvent standard molar volume. \f$ m^{\Delta} \f$ is a
- * constant equal to a molality of \f$ 1.0 \quad\mbox{gm kmol}^{-1} \f$.
+ * @f$ V^0_0 @f$ is the solvent standard molar volume. @f$ m^{\Delta} @f$ is a
+ * constant equal to a molality of @f$ 1.0 \quad\mbox{gm kmol}^{-1} @f$.
  *
  * The current default is to have mformGC = 2.
  *
@@ -94,11 +94,11 @@ public:
     /*!
      * Returns the amount of enthalpy per mole of solution. For an ideal molal
      * solution,
-     * \f[
+     * @f[
      * \bar{h}(T, P, X_k) = \sum_k X_k \bar{h}_k(T)
-     * \f]
+     * @f]
      * The formula is written in terms of the partial molar enthalpies.
-     * \f$ \bar{h}_k(T, p, m_k) \f$.
+     * @f$ \bar{h}_k(T, p, m_k) @f$.
      * See the partial molar enthalpy function, getPartialMolarEnthalpies(),
      * for details.
      *
@@ -110,11 +110,11 @@ public:
     /*!
      * Returns the amount of internal energy per mole of solution. For an ideal
      * molal solution,
-     * \f[
+     * @f[
      * \bar{u}(T, P, X_k) = \sum_k X_k \bar{u}_k(T)
-     * \f]
+     * @f]
      * The formula is written in terms of the partial molar internal energy.
-     * \f$ \bar{u}_k(T, p, m_k) \f$.
+     * @f$ \bar{u}_k(T, p, m_k) @f$.
      */
     virtual doublereal intEnergy_mole() const;
 
@@ -122,11 +122,11 @@ public:
     /*!
      * Returns the amount of entropy per mole of solution. For an ideal molal
      * solution,
-     * \f[
+     * @f[
      * \bar{s}(T, P, X_k) = \sum_k X_k \bar{s}_k(T)
-     * \f]
+     * @f]
      * The formula is written in terms of the partial molar entropies.
-     * \f$ \bar{s}_k(T, p, m_k) \f$.
+     * @f$ \bar{s}_k(T, p, m_k) @f$.
      * See the partial molar entropies function, getPartialMolarEntropies(),
      * for details.
      *
@@ -138,9 +138,9 @@ public:
     /*!
      * Returns the Gibbs free energy of the solution per mole of the solution.
      *
-     * \f[
+     * @f[
      * \bar{g}(T, P, X_k) = \sum_k X_k \mu_k(T)
-     * \f]
+     * @f]
      *
      * Units: J/kmol
      */
@@ -148,9 +148,9 @@ public:
 
     //! Molar heat capacity of the solution at constant pressure. Units: J/kmol/K.
     /*!
-     * \f[
+     * @f[
      * \bar{c}_p(T, P, X_k) = \sum_k X_k \bar{c}_{p,k}(T)
-     * \f]
+     * @f]
      *
      * Units: J/kmol/K
      */
@@ -173,12 +173,12 @@ protected:
      *
      * The formula for this is
      *
-     * \f[
+     * @f[
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * \f]
+     * @f]
      *
-     * where \f$X_k\f$ are the mole fractions, \f$W_k\f$ are the molecular
-     * weights, and \f$V_k\f$ are the pure species molar volumes.
+     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
+     * weights, and @f$V_k@f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -191,9 +191,9 @@ public:
     //! The isothermal compressibility. Units: 1/Pa.
     /*!
      * The isothermal compressibility is defined as
-     * \f[
+     * @f[
      * \kappa_T = -\frac{1}{v}\left(\frac{\partial v}{\partial P}\right)_T
-     * \f]
+     * @f]
      *
      * It's equal to zero for this model, since the molar volume doesn't change
      * with pressure or temperature.
@@ -204,9 +204,9 @@ public:
     /*!
      * The thermal expansion coefficient is defined as
      *
-     * \f[
+     * @f[
      * \beta = \frac{1}{v}\left(\frac{\partial v}{\partial T}\right)_P
-     * \f]
+     * @f]
      *
      * It's equal to zero for this model, since the molar volume doesn't change
      * with pressure or temperature.
@@ -216,9 +216,9 @@ public:
     //! @}
     //! @name Activities and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-    //! quantity \f$\mu_k^0(T)\f$ is the chemical potential at unit activity,
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
+    //! quantity @f$\mu_k^0(T)@f$ is the chemical potential at unit activity,
     //! which depends only on temperature and the pressure.
     //! @{
 
@@ -257,18 +257,18 @@ public:
      * This function returns a vector of chemical potentials of the species in
      * solution.
      *
-     * \f[
+     * @f[
      *    \mu_k = \mu^{o}_k(T,P) + R T \ln(\frac{m_k}{m^\Delta})
-     * \f]
-     * \f[
+     * @f]
+     * @f[
      *    \mu_w = \mu^{o}_w(T,P) +
      *            R T ((X_w - 1.0) / X_w)
-     * \f]
+     * @f]
      *
-     * \f$ w \f$ refers to the solvent species.
-     * \f$ X_w \f$ is the mole fraction of the solvent.
-     * \f$ m_k \f$ is the molality of the kth solute.
-     * \f$ m^\Delta \f$ is 1 gmol solute per kg solvent.
+     * @f$ w @f$ refers to the solvent species.
+     * @f$ X_w @f$ is the mole fraction of the solvent.
+     * @f$ m_k @f$ is the molality of the kth solute.
+     * @f$ m^\Delta @f$ is 1 gmol solute per kg solvent.
      *
      * Units: J/kmol.
      *
@@ -281,11 +281,11 @@ public:
     /*!
      * Units (J/kmol). For this phase, the partial molar enthalpies are equal to
      * the species standard state enthalpies.
-     *  \f[
+     *  @f[
      * \bar h_k(T,P) = \hat h^{ref}_k(T) + (P - P_{ref}) \hat V^0_k
-     * \f]
-     * The reference-state pure-species enthalpies, \f$ \hat h^{ref}_k(T) \f$,
-     * at the reference pressure,\f$ P_{ref} \f$, are computed by the species
+     * @f]
+     * The reference-state pure-species enthalpies, @f$ \hat h^{ref}_k(T) @f$,
+     * at the reference pressure,@f$ P_{ref} @f$, are computed by the species
      * thermodynamic property manager. They are polynomial functions of
      * temperature.
      * @see MultiSpeciesThermo
@@ -301,9 +301,9 @@ public:
      * Units (J/kmol). For this phase, the partial molar internal energies are equal to
      * the species standard state internal energies (which are equal to the reference
      * state internal energies)
-     *  \f[
+     *  @f[
      * \bar u_k(T,P) = \hat u^{ref}_k(T)
-     * \f]
+     * @f]
      * @param hbar   Output vector of partial molar internal energies, length #m_kk
      */
     virtual void getPartialMolarIntEnergies(doublereal* hbar) const;
@@ -313,22 +313,22 @@ public:
     /*!
      * Maxwell's equations provide an insight in how to calculate this
      * (p.215 Smith and Van Ness)
-     * \f[
+     * @f[
      *      \frac{d(\mu_k)}{dT} = -\bar{s}_i
-     * \f]
+     * @f]
      * For this phase, the partial molar entropies are equal to the standard
      * state species entropies plus the ideal molal solution contribution.
      *
-     * \f[
+     * @f[
      *   \bar{s}_k(T,P) =  s^0_k(T) - R \ln( \frac{m_k}{m^{\triangle}} )
-     * \f]
-     * \f[
+     * @f]
+     * @f[
      *   \bar{s}_w(T,P) =  s^0_w(T) - R ((X_w - 1.0) / X_w)
-     * \f]
+     * @f]
      *
-     * The subscript, w, refers to the solvent species. \f$ X_w \f$ is the mole
-     * fraction of solvent. The reference-state pure-species entropies,\f$
-     * s^0_k(T) \f$, at the reference pressure, \f$ P_{ref} \f$, are computed by
+     * The subscript, w, refers to the solvent species. @f$ X_w @f$ is the mole
+     * fraction of solvent. The reference-state pure-species entropies,@f$
+     * s^0_k(T) @f$, at the reference pressure, @f$ P_{ref} @f$, are computed by
      * the species thermodynamic property manager. They are polynomial functions
      * of temperature.
      * @see MultiSpeciesThermo
@@ -353,9 +353,9 @@ public:
      * The kth partial molar heat capacity is equal to the temperature
      * derivative of the partial molar enthalpy of the kth species in the
      * solution at constant P and composition (p. 220 Smith and Van Ness).
-     * \f[
+     * @f[
      *    \bar{Cp}_k(T,P) =  {Cp}^0_k(T)
-     * \f]
+     * @f]
      *
      * For this solution, this is equal to the reference state heat capacities.
      *
@@ -383,9 +383,9 @@ public:
      *
      * | model                | ActivityConc                     | StandardConc       |
      * | -------------------- | -------------------------------- | ------------------ |
-     * | unity                | \f$ {m_k}/ { m^{\Delta}}\f$      | \f$ 1.0        \f$ |
-     * | species-molar-volume | \f$  m_k / (m^{\Delta} V_k)\f$   | \f$ 1.0 / V_k  \f$ |
-     * | solvent-molar-volume | \f$  m_k / (m^{\Delta} V^0_0)\f$ | \f$ 1.0 / V^0_0\f$ |
+     * | unity                | @f$ {m_k}/ { m^{\Delta}}@f$      | @f$ 1.0        @f$ |
+     * | species-molar-volume | @f$  m_k / (m^{\Delta} V_k)@f$   | @f$ 1.0 / V_k  @f$ |
+     * | solvent-molar-volume | @f$  m_k / (m^{\Delta} V^0_0)@f$ | @f$ 1.0 / V^0_0@f$ |
      */
     void setStandardConcentrationModel(const std::string& model);
 
@@ -394,7 +394,7 @@ public:
 
     //! Report the molar volume of species k
     /*!
-     * units - \f$ m^3 kmol^{-1} \f$
+     * units - @f$ m^3 kmol^{-1} @f$
      *
      * @param k Species index.
      */
@@ -402,14 +402,14 @@ public:
 
     /*!
      * Fill in a return vector containing the species molar volumes
-     * units - \f$ m^3 kmol^{-1} \f$
+     * units - @f$ m^3 kmol^{-1} @f$
      *
      * @param smv Output vector of species molar volumes.
      */
     void getSpeciesMolarVolumes(double* smv) const;
 
 protected:
-    //! Species molar volume \f$ m^3 kmol^{-1} \f$
+    //! Species molar volume @f$ m^3 kmol^{-1} @f$
     vector_fp m_speciesMolarVolume;
 
     /**

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -177,8 +177,8 @@ protected:
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
      * @f]
      *
-     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
-     * weights, and @f$V_k@f$ are the pure species molar volumes.
+     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
+     * weights, and @f$ V_k @f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -216,9 +216,9 @@ public:
     //! @}
     //! @name Activities and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
-    //! quantity @f$\mu_k^0(T)@f$ is the chemical potential at unit activity,
+    //! quantity @f$ \mu_k^0(T) @f$ is the chemical potential at unit activity,
     //! which depends only on temperature and the pressure.
     //! @{
 
@@ -383,9 +383,9 @@ public:
      *
      * | model                | ActivityConc                     | StandardConc       |
      * | -------------------- | -------------------------------- | ------------------ |
-     * | unity                | @f$ {m_k}/ { m^{\Delta}}@f$      | @f$ 1.0        @f$ |
-     * | species-molar-volume | @f$  m_k / (m^{\Delta} V_k)@f$   | @f$ 1.0 / V_k  @f$ |
-     * | solvent-molar-volume | @f$  m_k / (m^{\Delta} V^0_0)@f$ | @f$ 1.0 / V^0_0@f$ |
+     * | unity                | @f$ {m_k}/ { m^{\Delta}} @f$      | @f$ 1.0        @f$ |
+     * | species-molar-volume | @f$  m_k / (m^{\Delta} V_k) @f$   | @f$ 1.0 / V_k  @f$ |
+     * | solvent-molar-volume | @f$  m_k / (m^{\Delta} V^0_0) @f$ | @f$ 1.0 / V^0_0 @f$ |
      */
     void setStandardConcentrationModel(const std::string& model);
 

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -75,11 +75,11 @@ public:
      * Molar enthalpy of the solution. Units: J/kmol. For an ideal, constant
      * partial molar volume solution mixture with pure species phases which
      * exhibit zero volume expansivity and zero isothermal compressibility:
-     * \f[
+     * @f[
      * \hat h(T,P) = \sum_k X_k \hat h^0_k(T) + (P - P_{ref}) (\sum_k X_k \hat V^0_k)
-     * \f]
+     * @f]
      * The reference-state pure-species enthalpies at the reference pressure Pref
-     * \f$ \hat h^0_k(T) \f$, are computed by the species thermodynamic
+     * @f$ \hat h^0_k(T) @f$, are computed by the species thermodynamic
      * property manager. They are polynomial functions of temperature.
      * @see MultiSpeciesThermo
      */
@@ -89,11 +89,11 @@ public:
      * Molar entropy of the solution. Units: J/kmol/K. For an ideal, constant
      * partial molar volume solution mixture with pure species phases which
      * exhibit zero volume expansivity:
-     * \f[
+     * @f[
      * \hat s(T, P, X_k) = \sum_k X_k \hat s^0_k(T)  - \hat R \sum_k X_k log(X_k)
-     * \f]
+     * @f]
      * The reference-state pure-species entropies
-     * \f$ \hat s^0_k(T,p_{ref}) \f$ are computed by the species thermodynamic
+     * @f$ \hat s^0_k(T,p_{ref}) @f$ are computed by the species thermodynamic
      * property manager. The pure species entropies are independent of
      * pressure since the volume expansivities are equal to zero.
      * @see MultiSpeciesThermo
@@ -104,13 +104,13 @@ public:
      * Molar Gibbs free energy of the solution. Units: J/kmol. For an ideal,
      * constant partial molar volume solution mixture with pure species phases
      * which exhibit zero volume expansivity:
-     * \f[
+     * @f[
      * \hat g(T, P) = \sum_k X_k \hat g^0_k(T,P) + \hat R T \sum_k X_k log(X_k)
-     * \f]
+     * @f]
      * The reference-state pure-species Gibbs free energies
-     * \f$ \hat g^0_k(T) \f$ are computed by the species thermodynamic
+     * @f$ \hat g^0_k(T) @f$ are computed by the species thermodynamic
      * property manager, while the standard state Gibbs free energies
-     * \f$ \hat g^0_k(T,P) \f$ are computed by the member function, gibbs_RT().
+     * @f$ \hat g^0_k(T,P) @f$ are computed by the member function, gibbs_RT().
      * @see MultiSpeciesThermo
      */
     virtual doublereal gibbs_mole() const;
@@ -120,11 +120,11 @@ public:
      * Units: J/kmol/K.
      * For an ideal, constant partial molar volume solution mixture with
      * pure species phases which exhibit zero volume expansivity:
-     * \f[
+     * @f[
      * \hat c_p(T,P) = \sum_k X_k \hat c^0_{p,k}(T) .
-     * \f]
+     * @f]
      * The heat capacity is independent of pressure. The reference-state pure-
-     * species heat capacities \f$ \hat c^0_{p,k}(T) \f$ are computed by the
+     * species heat capacities @f$ \hat c^0_{p,k}(T) @f$ are computed by the
      * species thermodynamic property manager.
      * @see MultiSpeciesThermo
      */
@@ -134,7 +134,7 @@ public:
      * Molar heat capacity at constant volume of the solution. Units: J/kmol/K.
      * For an ideal, constant partial molar volume solution mixture with pure
      * species phases which exhibit zero volume expansivity:
-     * \f[ \hat c_v(T,P) = \hat c_p(T,P) \f]
+     * @f[ \hat c_v(T,P) = \hat c_p(T,P) @f]
      * The two heat capacities are equal.
      */
     virtual doublereal cv_mole() const {
@@ -174,12 +174,12 @@ public:
      *
      * The formula for this is
      *
-     * \f[
+     * @f[
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * \f]
+     * @f]
      *
-     * where \f$X_k\f$ are the mole fractions, \f$W_k\f$ are the molecular
-     * weights, and \f$V_k\f$ are the pure species molar volumes.
+     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
+     * weights, and @f$V_k@f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -191,24 +191,24 @@ public:
     //! @}
     //! @name Chemical Potentials and Activities
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
+    //! The activity @f$a_k@f$ of a species in solution is related to the
     //! chemical potential by
-    //! \f[
+    //! @f[
     //!  \mu_k(T,P,X_k) = \mu_k^0(T,P)
     //! + \hat R T \log a_k.
-    //!  \f]
-    //! The quantity \f$\mu_k^0(T,P)\f$ is the standard state chemical potential
+    //!  @f]
+    //! The quantity @f$\mu_k^0(T,P)@f$ is the standard state chemical potential
     //! at unit activity. It may depend on the pressure and the temperature.
     //! However, it may not depend on the mole fractions of the species in the
     //! solid solution.
     //!
-    //! The activities are related to the generalized concentrations, \f$\tilde
-    //! C_k\f$, and standard concentrations, \f$C^0_k\f$, by the following
+    //! The activities are related to the generalized concentrations, @f$\tilde
+    //! C_k@f$, and standard concentrations, @f$C^0_k@f$, by the following
     //! formula:
     //!
-    //!  \f[
+    //!  @f[
     //!  a_k = \frac{\tilde C_k}{C^0_k}
-    //!  \f]
+    //!  @f]
     //! The generalized concentrations are used in the kinetics classes to
     //! describe the rates of progress of reactions involving the species. Their
     //! formulation depends upon the specification of the rate constants for
@@ -258,7 +258,7 @@ public:
     virtual void getActivityConcentrations(doublereal* c) const;
 
     /**
-     * The standard concentration \f$ C^0_k \f$ used to normalize the
+     * The standard concentration @f$ C^0_k @f$ used to normalize the
      * generalized concentration. In many cases, this quantity will be the
      * same for all species in a phase. However, for this case, we will return
      * a distinct concentration for each species. This is the inverse of the
@@ -280,14 +280,14 @@ public:
      *
      * This function returns a vector of chemical potentials of the
      * species in solution.
-     * \f[
+     * @f[
      *    \mu_k = \mu^{ref}_k(T) + V_k * (p - p_o) + R T ln(X_k)
-     * \f]
+     * @f]
      *  or another way to phrase this is
-     * \f[
+     * @f[
      *    \mu_k = \mu^o_k(T,p) + R T ln(X_k)
-     * \f]
-     *  where \f$ \mu^o_k(T,p) = \mu^{ref}_k(T) + V_k * (p - p_o)\f$
+     * @f]
+     *  where @f$ \mu^o_k(T,p) = \mu^{ref}_k(T) + V_k * (p - p_o)@f$
      *
      * @param mu  Output vector of chemical potentials.
      */
@@ -296,13 +296,13 @@ public:
     /**
      * Get the array of non-dimensional species solution
      * chemical potentials at the current T and P
-     * \f$\mu_k / \hat R T \f$.
-     * \f[
+     * @f$\mu_k / \hat R T @f$.
+     * @f[
      *  \mu^0_k(T,P) = \mu^{ref}_k(T) + (P - P_{ref}) * V_k + RT ln(X_k)
-     * \f]
-     * where \f$V_k\f$ is the molar volume of pure species *k*.
-     * \f$ \mu^{ref}_k(T)\f$ is the chemical potential of pure
-     * species *k* at the reference pressure, \f$P_{ref}\f$.
+     * @f]
+     * where @f$V_k@f$ is the molar volume of pure species *k*.
+     * @f$ \mu^{ref}_k(T)@f$ is the chemical potential of pure
+     * species *k* at the reference pressure, @f$P_{ref}@f$.
      *
      * @param mu   Output vector of dimensionless chemical potentials.
      *             Length = m_kk.
@@ -319,11 +319,11 @@ public:
     /*!
      * Units (J/kmol). For this phase, the partial molar enthalpies are equal to
      * the pure species enthalpies
-     *  \f[
+     *  @f[
      * \bar h_k(T,P) = \hat h^{ref}_k(T) + (P - P_{ref}) \hat V^0_k
-     * \f]
-     * The reference-state pure-species enthalpies, \f$ \hat h^{ref}_k(T) \f$,
-     * at the reference pressure,\f$ P_{ref} \f$, are computed by the species
+     * @f]
+     * The reference-state pure-species enthalpies, @f$ \hat h^{ref}_k(T) @f$,
+     * at the reference pressure,@f$ P_{ref} @f$, are computed by the species
      * thermodynamic property manager. They are polynomial functions of
      * temperature.
      * @see MultiSpeciesThermo
@@ -338,11 +338,11 @@ public:
      * solution. Units: J/kmol/K. For this phase, the partial molar entropies
      * are equal to the pure species entropies plus the ideal solution
      * contribution.
-     *  \f[
+     *  @f[
      * \bar s_k(T,P) =  \hat s^0_k(T) - R log(X_k)
-     * \f]
-     * The reference-state pure-species entropies,\f$ \hat s^{ref}_k(T) \f$, at
-     * the reference pressure, \f$ P_{ref} \f$, are computed by the species
+     * @f]
+     * The reference-state pure-species entropies,@f$ \hat s^{ref}_k(T) @f$, at
+     * the reference pressure, @f$ P_{ref} @f$, are computed by the species
      * thermodynamic property manager. They are polynomial functions of
      * temperature.
      * @see MultiSpeciesThermo
@@ -378,7 +378,7 @@ public:
 
     /**
      * Get the standard state chemical potentials of the species. This is the
-     * array of chemical potentials at unit activity \f$ \mu^0_k(T,P) \f$. We
+     * array of chemical potentials at unit activity @f$ \mu^0_k(T,P) @f$. We
      * define these here as the chemical potentials of the pure species at the
      * temperature and pressure of the solution. This function is used in the
      * evaluation of the equilibrium constant Kc. Therefore, Kc will also depend
@@ -397,12 +397,12 @@ public:
     //! state species at the current *T* and *P* of the solution.
     /*!
      * We assume an incompressible constant partial molar volume here:
-     * \f[
+     * @f[
      *  h^0_k(T,P) = h^{ref}_k(T) + (P - P_{ref}) * V_k
-     * \f]
-     * where \f$V_k\f$ is the molar volume of pure species *k*.
-     * \f$ h^{ref}_k(T)\f$ is the enthalpy of the pure species *k* at the
-     * reference pressure, \f$P_{ref}\f$.
+     * @f]
+     * where @f$V_k@f$ is the molar volume of pure species *k*.
+     * @f$ h^{ref}_k(T)@f$ is the enthalpy of the pure species *k* at the
+     * reference pressure, @f$P_{ref}@f$.
      *
      * @param hrt Vector of length m_kk, which on return hrt[k] will contain the
      *            nondimensional standard state enthalpy of species k.
@@ -424,12 +424,12 @@ public:
      * Get the nondimensional Gibbs function for the species standard states at
      * the current T and P of the solution.
      *
-     * \f[
+     * @f[
      *  \mu^0_k(T,P) = \mu^{ref}_k(T) + (P - P_{ref}) * V_k
-     * \f]
-     * where \f$V_k\f$ is the molar volume of pure species *k*.
-     * \f$ \mu^{ref}_k(T)\f$ is the chemical potential of pure species *k*
-     * at the reference pressure, \f$P_{ref}\f$.
+     * @f]
+     * where @f$V_k@f$ is the molar volume of pure species *k*.
+     * @f$ \mu^{ref}_k(T)@f$ is the chemical potential of pure species *k*
+     * at the reference pressure, @f$P_{ref}@f$.
      *
      * @param grt Vector of length m_kk, which on return sr[k] will contain the
      *           nondimensional standard state Gibbs function for species k.
@@ -440,12 +440,12 @@ public:
      * Get the Gibbs functions for the pure species at the current *T* and *P*
      * of the solution. We assume an incompressible constant partial molar
      * volume here:
-     * \f[
+     * @f[
      *  \mu^0_k(T,P) = \mu^{ref}_k(T) + (P - P_{ref}) * V_k
-     * \f]
-     * where \f$V_k\f$ is the molar volume of pure species *k*.
-     * \f$ \mu^{ref}_k(T)\f$ is the chemical potential of pure species *k* at
-     * the reference pressure, \f$P_{ref}\f$.
+     * @f]
+     * where @f$V_k@f$ is the molar volume of pure species *k*.
+     * @f$ \mu^{ref}_k(T)@f$ is the chemical potential of pure species *k* at
+     * the reference pressure, @f$P_{ref}@f$.
      *
      * @param gpure  Output vector of Gibbs functions for species. Length: m_kk.
      */
@@ -456,12 +456,12 @@ public:
     /**
      * Get the nondimensional heat capacity at constant pressure function for
      * the species standard states at the current T and P of the solution.
-     * \f[
+     * @f[
      *  Cp^0_k(T,P) = Cp^{ref}_k(T)
-     * \f]
-     * where \f$V_k\f$ is the molar volume of pure species *k*.
-     * \f$ Cp^{ref}_k(T)\f$ is the constant pressure heat capacity of species
-     * *k* at the reference pressure, \f$p_{ref}\f$.
+     * @f]
+     * where @f$V_k@f$ is the molar volume of pure species *k*.
+     * @f$ Cp^{ref}_k(T)@f$ is the constant pressure heat capacity of species
+     * *k* at the reference pressure, @f$p_{ref}@f$.
      *
      * @param cpr Vector of length m_kk, which on return cpr[k] will contain the
      *           nondimensional constant pressure heat capacity for species k.
@@ -549,7 +549,7 @@ public:
     /**
      * Report the molar volume of species k
      *
-     * units - \f$ m^3 kmol^-1 \f$
+     * units - @f$ m^3 kmol^-1 @f$
      *
      * @param  k species index
      */
@@ -558,7 +558,7 @@ public:
     /**
      * Fill in a return vector containing the species molar volumes.
      *
-     * units - \f$ m^3 kmol^-1 \f$
+     * units - @f$ m^3 kmol^-1 @f$
      *
      * @param smv  output vector containing species molar volumes.
      *             Length: m_kk.
@@ -596,7 +596,7 @@ protected:
 
     //! Vector of molar volumes for each species in the solution
     /**
-     * Species molar volumes (\f$ m^3 kmol^-1 \f$) at the current mixture state.
+     * Species molar volumes (@f$ m^3 kmol^-1 @f$) at the current mixture state.
      * For the IdealSolidSolnPhase class, these are constant.
      */
     mutable vector_fp m_speciesMolarVolume;

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -178,8 +178,8 @@ public:
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
      * @f]
      *
-     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
-     * weights, and @f$V_k@f$ are the pure species molar volumes.
+     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
+     * weights, and @f$ V_k @f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -191,19 +191,19 @@ public:
     //! @}
     //! @name Chemical Potentials and Activities
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by
     //! @f[
     //!  \mu_k(T,P,X_k) = \mu_k^0(T,P)
     //! + \hat R T \log a_k.
     //!  @f]
-    //! The quantity @f$\mu_k^0(T,P)@f$ is the standard state chemical potential
+    //! The quantity @f$ \mu_k^0(T,P) @f$ is the standard state chemical potential
     //! at unit activity. It may depend on the pressure and the temperature.
     //! However, it may not depend on the mole fractions of the species in the
     //! solid solution.
     //!
-    //! The activities are related to the generalized concentrations, @f$\tilde
-    //! C_k@f$, and standard concentrations, @f$C^0_k@f$, by the following
+    //! The activities are related to the generalized concentrations, @f$ \tilde
+    //! C_k @f$, and standard concentrations, @f$ C^0_k @f$, by the following
     //! formula:
     //!
     //!  @f[
@@ -287,7 +287,7 @@ public:
      * @f[
      *    \mu_k = \mu^o_k(T,p) + R T ln(X_k)
      * @f]
-     *  where @f$ \mu^o_k(T,p) = \mu^{ref}_k(T) + V_k * (p - p_o)@f$
+     *  where @f$ \mu^o_k(T,p) = \mu^{ref}_k(T) + V_k * (p - p_o) @f$
      *
      * @param mu  Output vector of chemical potentials.
      */
@@ -296,13 +296,13 @@ public:
     /**
      * Get the array of non-dimensional species solution
      * chemical potentials at the current T and P
-     * @f$\mu_k / \hat R T @f$.
+     * @f$ \mu_k / \hat R T @f$.
      * @f[
      *  \mu^0_k(T,P) = \mu^{ref}_k(T) + (P - P_{ref}) * V_k + RT ln(X_k)
      * @f]
-     * where @f$V_k@f$ is the molar volume of pure species *k*.
-     * @f$ \mu^{ref}_k(T)@f$ is the chemical potential of pure
-     * species *k* at the reference pressure, @f$P_{ref}@f$.
+     * where @f$ V_k @f$ is the molar volume of pure species *k*.
+     * @f$ \mu^{ref}_k(T) @f$ is the chemical potential of pure
+     * species *k* at the reference pressure, @f$ P_{ref} @f$.
      *
      * @param mu   Output vector of dimensionless chemical potentials.
      *             Length = m_kk.
@@ -400,9 +400,9 @@ public:
      * @f[
      *  h^0_k(T,P) = h^{ref}_k(T) + (P - P_{ref}) * V_k
      * @f]
-     * where @f$V_k@f$ is the molar volume of pure species *k*.
-     * @f$ h^{ref}_k(T)@f$ is the enthalpy of the pure species *k* at the
-     * reference pressure, @f$P_{ref}@f$.
+     * where @f$ V_k @f$ is the molar volume of pure species *k*.
+     * @f$ h^{ref}_k(T) @f$ is the enthalpy of the pure species *k* at the
+     * reference pressure, @f$ P_{ref} @f$.
      *
      * @param hrt Vector of length m_kk, which on return hrt[k] will contain the
      *            nondimensional standard state enthalpy of species k.
@@ -427,9 +427,9 @@ public:
      * @f[
      *  \mu^0_k(T,P) = \mu^{ref}_k(T) + (P - P_{ref}) * V_k
      * @f]
-     * where @f$V_k@f$ is the molar volume of pure species *k*.
-     * @f$ \mu^{ref}_k(T)@f$ is the chemical potential of pure species *k*
-     * at the reference pressure, @f$P_{ref}@f$.
+     * where @f$ V_k @f$ is the molar volume of pure species *k*.
+     * @f$ \mu^{ref}_k(T) @f$ is the chemical potential of pure species *k*
+     * at the reference pressure, @f$ P_{ref} @f$.
      *
      * @param grt Vector of length m_kk, which on return sr[k] will contain the
      *           nondimensional standard state Gibbs function for species k.
@@ -443,9 +443,9 @@ public:
      * @f[
      *  \mu^0_k(T,P) = \mu^{ref}_k(T) + (P - P_{ref}) * V_k
      * @f]
-     * where @f$V_k@f$ is the molar volume of pure species *k*.
-     * @f$ \mu^{ref}_k(T)@f$ is the chemical potential of pure species *k* at
-     * the reference pressure, @f$P_{ref}@f$.
+     * where @f$ V_k @f$ is the molar volume of pure species *k*.
+     * @f$ \mu^{ref}_k(T) @f$ is the chemical potential of pure species *k* at
+     * the reference pressure, @f$ P_{ref} @f$.
      *
      * @param gpure  Output vector of Gibbs functions for species. Length: m_kk.
      */
@@ -459,9 +459,9 @@ public:
      * @f[
      *  Cp^0_k(T,P) = Cp^{ref}_k(T)
      * @f]
-     * where @f$V_k@f$ is the molar volume of pure species *k*.
-     * @f$ Cp^{ref}_k(T)@f$ is the constant pressure heat capacity of species
-     * *k* at the reference pressure, @f$p_{ref}@f$.
+     * where @f$ V_k @f$ is the molar volume of pure species *k*.
+     * @f$ Cp^{ref}_k(T) @f$ is the constant pressure heat capacity of species
+     * *k* at the reference pressure, @f$ p_{ref} @f$.
      *
      * @param cpr Vector of length m_kk, which on return cpr[k] will contain the
      *           nondimensional constant pressure heat capacity for species k.

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -67,12 +67,12 @@ protected:
      * Calculate the density of the mixture using the partial molar volumes and
      * mole fractions as input. The formula for this is
      *
-     * \f[
+     * @f[
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * \f]
+     * @f]
      *
-     * where \f$X_k\f$ are the mole fractions, \f$W_k\f$ are the molecular
-     * weights, and \f$V_k\f$ are the pure species molar volumes.
+     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
+     * weights, and @f$V_k@f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the species standard state molar
@@ -86,7 +86,7 @@ public:
     virtual Units standardConcentrationUnits() const;
     virtual void getActivityConcentrations(doublereal* c) const;
 
-    //! Returns the standard concentration \f$ C^0_k \f$, which is used to
+    //! Returns the standard concentration @f$ C^0_k @f$, which is used to
     //! normalize the generalized concentration.
     /*!
      * This is defined as the concentration by which the generalized

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -71,8 +71,8 @@ protected:
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
      * @f]
      *
-     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
-     * weights, and @f$V_k@f$ are the pure species molar volumes.
+     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
+     * weights, and @f$ V_k @f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the species standard state molar

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -108,9 +108,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is
+    //! The activity @f$ a_k @f$ of a species in solution is
     //! related to the chemical potential by @f[ \mu_k = \mu_k^0(T)
-    //! + \hat R T \log a_k. @f] The quantity @f$\mu_k^0(T,P)@f$ is
+    //! + \hat R T \log a_k. @f] The quantity @f$ \mu_k^0(T,P) @f$ is
     //! the chemical potential at unit activity, which depends only
     //! on temperature and pressure.
     //! @{

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -108,9 +108,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is
-    //! related to the chemical potential by \f[ \mu_k = \mu_k^0(T)
-    //! + \hat R T \log a_k. \f] The quantity \f$\mu_k^0(T,P)\f$ is
+    //! The activity @f$a_k@f$ of a species in solution is
+    //! related to the chemical potential by @f[ \mu_k = \mu_k^0(T)
+    //! + \hat R T \log a_k. @f] The quantity @f$\mu_k^0(T,P)@f$ is
     //! the chemical potential at unit activity, which depends only
     //! on temperature and pressure.
     //! @{
@@ -132,9 +132,9 @@ public:
      * state enthalpies modified by the derivative of the molality-based
      * activity coefficient wrt temperature
      *
-     *  \f[
+     *  @f[
      * \bar h_k(T,P) = h^o_k(T,P) - R T^2 \frac{d \ln(\gamma_k)}{dT}
-     * \f]
+     * @f]
      *
      *  @param hbar  Output vector of species partial molar enthalpies.
      *               Length: m_kk. Units: J/kmol
@@ -150,11 +150,11 @@ public:
      * state enthalpies modified by the derivative of the activity coefficient
      * wrt temperature
      *
-     *  \f[
+     *  @f[
      *   \bar s_k(T,P) = s^o_k(T,P) - R T^2 \frac{d \ln(\gamma_k)}{dT}
      *                              - R \ln( \gamma_k X_k)
      *                              - R T \frac{d \ln(\gamma_k) }{dT}
-     *  \f]
+     *  @f]
      *
      *  @param sbar  Output vector of species partial molar entropies.
      *               Length: m_kk. Units: J/kmol/K

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -39,7 +39,7 @@ namespace Cantera
  * no effect on any quantities, as the molar concentration is a constant.
  *
  * The standard state enthalpy function is given by the following relation,
- * which has a weak dependence on the system pressure, @f$P@f$.
+ * which has a weak dependence on the system pressure, @f$ P @f$.
  *
  * @f[
  *     h^o_k(T,P) =
@@ -125,7 +125,7 @@ namespace Cantera
  *
  * ## Application within Kinetics Managers
  *
- * @f$ C^a_k@f$ are defined such that @f$ C^a_k = a_k = X_k @f$. @f$ C^s_k @f$,
+ * @f$ C^a_k @f$ are defined such that @f$ C^a_k = a_k = X_k @f$. @f$ C^s_k @f$,
  * the standard concentration, is defined to be equal to one. @f$ a_k @f$ are
  * activities used in the thermodynamic functions.  These activity (or
  * generalized) concentrations are used by kinetics manager classes to compute
@@ -308,8 +308,8 @@ public:
      *      \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
      * @f]
      *
-     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
-     * weights, and @f$V_k@f$ are the pure species molar volumes.
+     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
+     * weights, and @f$ V_k @f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -321,9 +321,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
-    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
+    //! quantity @f$ \mu_k^0(T,P) @f$ is the chemical potential at unit activity,
     //! which depends only on temperature and the pressure. Activity is assumed
     //! to be molality-based here.
     //! @{

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -25,7 +25,7 @@ namespace Cantera
  * standard states of the species are assumed to have zero volume expansivity
  * and zero isothermal compressibility.
  *
- * The density of matrix sites is given by the variable \f$ C_o \f$, which has
+ * The density of matrix sites is given by the variable @f$ C_o @f$, which has
  * SI units of kmol m-3.
  *
  * ## Specification of Species Standard State Properties
@@ -39,22 +39,22 @@ namespace Cantera
  * no effect on any quantities, as the molar concentration is a constant.
  *
  * The standard state enthalpy function is given by the following relation,
- * which has a weak dependence on the system pressure, \f$P\f$.
+ * which has a weak dependence on the system pressure, @f$P@f$.
  *
- * \f[
+ * @f[
  *     h^o_k(T,P) =
  *            h^{ref}_k(T) +  \left( \frac{P - P_{ref}}{C_o} \right)
- * \f]
+ * @f]
  *
  * For an incompressible substance, the molar internal energy is independent of
  * pressure. Since the thermodynamic properties are specified by giving the
- * standard-state enthalpy, the term \f$ \frac{P_{ref}}{C_o} \f$ is subtracted
+ * standard-state enthalpy, the term @f$ \frac{P_{ref}}{C_o} @f$ is subtracted
  * from the specified reference molar enthalpy to compute the standard state
  * molar internal energy:
  *
- * \f[
+ * @f[
  *      u^o_k(T,P) = h^{ref}_k(T) - \frac{P_{ref}}{C_o}
- * \f]
+ * @f]
  *
  * The standard state heat capacity, internal energy, and entropy are
  * independent of pressure. The standard state Gibbs free energy is obtained
@@ -63,56 +63,56 @@ namespace Cantera
  * The standard state molar volume is independent of temperature, pressure, and
  * species identity:
  *
- * \f[
+ * @f[
  *      V^o_k(T,P) = \frac{1.0}{C_o}
- * \f]
+ * @f]
  *
  * ## Specification of Solution Thermodynamic Properties
  *
- * The activity of species \f$ k \f$ defined in the phase, \f$ a_k \f$, is given
+ * The activity of species @f$ k @f$ defined in the phase, @f$ a_k @f$, is given
  * by the ideal solution law:
  *
- * \f[
+ * @f[
  *      a_k = X_k ,
- * \f]
+ * @f]
  *
- * where \f$ X_k \f$ is the mole fraction of species *k*. The chemical potential
+ * where @f$ X_k @f$ is the mole fraction of species *k*. The chemical potential
  * for species *k* is equal to
  *
- * \f[
+ * @f[
  *      \mu_k(T,P) = \mu^o_k(T, P) + R T \log(X_k)
- * \f]
+ * @f]
  *
  * The partial molar entropy for species *k* is given by the following relation,
  *
- * \f[
+ * @f[
  *      \tilde{s}_k(T,P) = s^o_k(T,P) - R \log(X_k) = s^{ref}_k(T) - R \log(X_k)
- * \f]
+ * @f]
  *
  * The partial molar enthalpy for species *k* is
  *
- * \f[
+ * @f[
  *      \tilde{h}_k(T,P) = h^o_k(T,P) = h^{ref}_k(T) + \left( \frac{P - P_{ref}}{C_o} \right)
- * \f]
+ * @f]
  *
  * The partial molar Internal Energy for species *k* is
  *
- * \f[
+ * @f[
  *      \tilde{u}_k(T,P) = u^o_k(T,P) = u^{ref}_k(T)
- * \f]
+ * @f]
  *
  * The partial molar Heat Capacity for species *k* is
  *
- * \f[
+ * @f[
  *      \tilde{Cp}_k(T,P) = Cp^o_k(T,P) = Cp^{ref}_k(T)
- * \f]
+ * @f]
  *
  * The partial molar volume is independent of temperature, pressure, and species
  * identity:
  *
- * \f[
+ * @f[
  *      \tilde{V}_k(T,P) =  V^o_k(T,P) = \frac{1.0}{C_o}
- * \f]
+ * @f]
  *
  * It is assumed that the reference state thermodynamics may be obtained by a
  * pointer to a populated species thermodynamic property manager class (see
@@ -125,57 +125,57 @@ namespace Cantera
  *
  * ## Application within Kinetics Managers
  *
- * \f$ C^a_k\f$ are defined such that \f$ C^a_k = a_k = X_k \f$. \f$ C^s_k \f$,
- * the standard concentration, is defined to be equal to one. \f$ a_k \f$ are
+ * @f$ C^a_k@f$ are defined such that @f$ C^a_k = a_k = X_k @f$. @f$ C^s_k @f$,
+ * the standard concentration, is defined to be equal to one. @f$ a_k @f$ are
  * activities used in the thermodynamic functions.  These activity (or
  * generalized) concentrations are used by kinetics manager classes to compute
  * the forward and reverse rates of elementary reactions. The activity
- * concentration,\f$  C^a_k \f$, is given by the following expression.
+ * concentration,@f$  C^a_k @f$, is given by the following expression.
  *
- * \f[
+ * @f[
  *      C^a_k = C^s_k  X_k  =  X_k
- * \f]
+ * @f]
  *
  * The standard concentration for species *k* is identically one
  *
- * \f[
+ * @f[
  *     C^s_k =  C^s = 1.0
- * \f]
+ * @f]
  *
  * For example, a bulk-phase binary gas reaction between species j and k,
  * producing a new species l would have the following equation for its rate of
- * progress variable, \f$ R^1 \f$, which has units of kmol m-3 s-1.
+ * progress variable, @f$ R^1 @f$, which has units of kmol m-3 s-1.
  *
- * \f[
+ * @f[
  *    R^1 = k^1 C_j^a C_k^a =  k^1  X_j X_k
- * \f]
+ * @f]
  *
  * The reverse rate constant can then be obtained from the law of microscopic
  * reversibility and the equilibrium expression for the system.
  *
- * \f[
+ * @f[
  *     \frac{X_j X_k}{ X_l} = K_a^{o,1} = \exp(\frac{\mu^o_l - \mu^o_j - \mu^o_k}{R T} )
- * \f]
+ * @f]
  *
- * \f$  K_a^{o,1} \f$ is the dimensionless form of the equilibrium constant,
- * associated with the pressure dependent standard states \f$ \mu^o_l(T,P) \f$
+ * @f$  K_a^{o,1} @f$ is the dimensionless form of the equilibrium constant,
+ * associated with the pressure dependent standard states @f$ \mu^o_l(T,P) @f$
  * and their associated activities,
- * \f$ a_l \f$, repeated here:
+ * @f$ a_l @f$, repeated here:
  *
- * \f[
+ * @f[
  *      \mu_l(T,P) = \mu^o_l(T, P) + R T \log(a_l)
- * \f]
+ * @f]
  *
- * The concentration equilibrium constant, \f$ K_c \f$, may be obtained by
+ * The concentration equilibrium constant, @f$ K_c @f$, may be obtained by
  * changing over to activity concentrations. When this is done:
  *
- * \f[
+ * @f[
  *     \frac{C^a_j C^a_k}{ C^a_l} = C^o K_a^{o,1} = K_c^1 =
  *         \exp(\frac{\mu^{o}_l - \mu^{o}_j - \mu^{o}_k}{R T} )
- * \f]
+ * @f]
  *
- * %Kinetics managers will calculate the concentration equilibrium constant, \f$
- * K_c \f$, using the second and third part of the above expression as a
+ * %Kinetics managers will calculate the concentration equilibrium constant, @f$
+ * K_c @f$, using the second and third part of the above expression as a
  * definition for the concentration equilibrium constant.
  *
  * @ingroup thermoprops
@@ -211,11 +211,11 @@ public:
     /*!
      * For an ideal solution,
      *
-     *   \f[
+     *   @f[
      *    \hat h(T,P) = \sum_k X_k \hat h^0_k(T,P),
-     *   \f]
+     *   @f]
      *
-     * The standard-state pure-species Enthalpies \f$ \hat h^0_k(T,P) \f$ are
+     * The standard-state pure-species Enthalpies @f$ \hat h^0_k(T,P) @f$ are
      * computed first by the species reference state thermodynamic property
      * manager and then a small pressure dependent term is added in.
      *
@@ -227,10 +227,10 @@ public:
     /*!
      * For an ideal, constant partial molar volume solution mixture with
      * pure species phases which exhibit zero volume expansivity:
-     *   \f[
+     *   @f[
      *       \hat s(T, P, X_k) = \sum_k X_k \hat s^0_k(T)  - \hat R  \sum_k X_k log(X_k)
-     *   \f]
-     * The reference-state pure-species entropies \f$ \hat s^0_k(T,p_{ref}) \f$
+     *   @f]
+     * The reference-state pure-species entropies @f$ \hat s^0_k(T,p_{ref}) @f$
      * are computed by the species thermodynamic property manager. The pure
      * species entropies are independent of pressure since the volume
      * expansivities are equal to zero.
@@ -246,11 +246,11 @@ public:
     /*!
      * For an ideal, constant partial molar volume solution mixture with
      * pure species phases which exhibit zero volume expansivity:
-     *   \f[
+     *   @f[
      *    \hat c_p(T,P) = \sum_k X_k \hat c^0_{p,k}(T) .
-     *   \f]
+     *   @f]
      * The heat capacity is independent of pressure. The reference-state pure-
-     * species heat capacities \f$ \hat c^0_{p,k}(T) \f$ are computed by the
+     * species heat capacities @f$ \hat c^0_{p,k}(T) @f$ are computed by the
      * species thermodynamic property manager.
      *
      * @see MultiSpeciesThermo
@@ -262,9 +262,9 @@ public:
     /*!
      * For an ideal, constant partial molar volume solution mixture with
      * pure species phases which exhibit zero volume expansivity:
-     *  \f[
+     *  @f[
      *     \hat c_v(T,P) = \hat c_p(T,P)
-     *  \f]
+     *  @f]
      *
      * The two heat capacities are equal.
      */
@@ -304,12 +304,12 @@ public:
     /*!
      * The formula for this is
      *
-     * \f[
+     * @f[
      *      \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * \f]
+     * @f]
      *
-     * where \f$X_k\f$ are the mole fractions, \f$W_k\f$ are the molecular
-     * weights, and \f$V_k\f$ are the pure species molar volumes.
+     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
+     * weights, and @f$V_k@f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We
@@ -321,9 +321,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
+    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
     //! which depends only on temperature and the pressure. Activity is assumed
     //! to be molality-based here.
     //! @{
@@ -333,7 +333,7 @@ public:
 
     //! Return the standard concentration for the kth species
     /*!
-     * The standard concentration \f$ C^0_k \f$ used to normalize
+     * The standard concentration @f$ C^0_k @f$ used to normalize
      * the activity (that is, generalized) concentration for use
      *
      * For the time being, we will use the concentration of pure solvent for the
@@ -376,11 +376,11 @@ public:
      * Returns an array of partial molar enthalpies for the species in the
      * mixture. Units (J/kmol). For this phase, the partial molar enthalpies are
      * equal to the pure species enthalpies
-     * \f[
+     * @f[
      * \bar h_k(T,P) = \hat h^{ref}_k(T) + (P - P_{ref}) \hat V^0_k
-     * \f]
-     * The reference-state pure-species enthalpies, \f$ \hat h^{ref}_k(T) \f$,
-     * at the reference pressure,\f$ P_{ref} \f$, are computed by the species
+     * @f]
+     * The reference-state pure-species enthalpies, @f$ \hat h^{ref}_k(T) @f$,
+     * at the reference pressure,@f$ P_{ref} @f$, are computed by the species
      * thermodynamic property manager. They are polynomial functions of
      * temperature.
      * @see MultiSpeciesThermo
@@ -395,11 +395,11 @@ public:
      * solution. Units: J/kmol/K. For this phase, the partial molar entropies
      * are equal to the pure species entropies plus the ideal solution
      * contribution.
-     * \f[
+     * @f[
      * \bar s_k(T,P) =  \hat s^0_k(T) - R log(X_k)
-     * \f]
-     * The reference-state pure-species entropies,\f$ \hat s^{ref}_k(T) \f$, at
-     * the reference pressure, \f$ P_{ref} \f$, are computed by the species
+     * @f]
+     * The reference-state pure-species entropies,@f$ \hat s^{ref}_k(T) @f$, at
+     * the reference pressure, @f$ P_{ref} @f$, are computed by the species
      * thermodynamic property manager. They are polynomial functions of
      * temperature.
      * @see MultiSpeciesThermo
@@ -433,9 +433,9 @@ public:
      * A small pressure dependent term is added onto the reference state enthalpy
      * to get the pressure dependence of this term.
      *
-     * \f[
+     * @f[
      *    h^o_k(T,P) = h^{ref}_k(T) +  \left( \frac{P - P_{ref}}{C_o} \right)
-     * \f]
+     * @f]
      *
      * The reference state thermodynamics is obtained by a pointer to a
      * populated species thermodynamic property manager class (see
@@ -453,9 +453,9 @@ public:
      * The entropy of the standard state is defined as independent of
      * pressure here.
      *
-     * \f[
+     * @f[
      *      s^o_k(T,P) = s^{ref}_k(T)
-     * \f]
+     * @f]
      *
      * The reference state thermodynamics is obtained by a pointer to a
      * populated species thermodynamic property manager class (see
@@ -473,9 +473,9 @@ public:
      * The standard Gibbs free energies are obtained from the enthalpy and
      * entropy formulation.
      *
-     * \f[
+     * @f[
      *      g^o_k(T,P) = h^{o}_k(T,P) - T s^{o}_k(T,P)
-     * \f]
+     * @f]
      *
      * @param grt  Output vector of nondimensional standard state Gibbs free
      *             energies. Length: m_kk.
@@ -487,9 +487,9 @@ public:
     /*!
      * The heat capacity of the standard state is independent of pressure
      *
-     * \f[
+     * @f[
      *      Cp^o_k(T,P) = Cp^{ref}_k(T)
-     * \f]
+     * @f]
      *
      * The reference state thermodynamics is obtained by a pointer to a
      * populated species thermodynamic property manager class (see
@@ -589,7 +589,7 @@ protected:
 
     //! Vector of molar volumes for each species in the solution
     /**
-     * Species molar volumes \f$ m^3 kmol^-1 \f$
+     * Species molar volumes @f$ m^3 kmol^-1 @f$
      */
     vector_fp m_speciesMolarVolume;
 

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -52,14 +52,14 @@ namespace Cantera
  * contains a value for the molar density of the entire mixture. This is the
  * same thing as saying that
  *
- * \f[
+ * @f[
  *     L_i = L^{solid}   \theta_i
- * \f]
+ * @f]
  *
- * \f$ L_i \f$ is the molar volume of the ith lattice. \f$ L^{solid} \f$ is the
- * molar volume of the entire solid. \f$  \theta_i \f$ is a fixed weighting
+ * @f$ L_i @f$ is the molar volume of the ith lattice. @f$ L^{solid} @f$ is the
+ * molar volume of the entire solid. @f$  \theta_i @f$ is a fixed weighting
  * factor for the ith lattice representing the lattice stoichiometric
- * coefficient. For this object the \f$ \theta_i \f$ values are fixed.
+ * coefficient. For this object the @f$ \theta_i @f$ values are fixed.
  *
  * Let's take FeS2 as an example, which may be thought of as a combination of
  * two lattices: Fe and S lattice. The Fe sublattice has a molar density of 1
@@ -81,16 +81,16 @@ namespace Cantera
  * The molar volume of the Lattice solid is calculated from the following
  * formula
  *
- *  \f[
+ *  @f[
  *         V = \sum_i{ \theta_i V_i^{lattice}}
- *  \f]
+ *  @f]
  *
- * where \f$ V_i^{lattice} \f$ is the molar volume of the ith sublattice. This
+ * where @f$ V_i^{lattice} @f$ is the molar volume of the ith sublattice. This
  * is calculated from the following standard formula.
  *
- * \f[
+ * @f[
  *     V_i = \sum_k{ X_k V_k}
- * \f]
+ * @f]
  *
  * where k is a species in the ith sublattice.
  *
@@ -143,14 +143,14 @@ public:
 
     //! Return the Molar Enthalpy. Units: J/kmol.
     /*!
-     * The molar enthalpy is determined by the following formula, where \f$
-     * \theta_n \f$ is the lattice stoichiometric coefficient of the nth lattice
+     * The molar enthalpy is determined by the following formula, where @f$
+     * \theta_n @f$ is the lattice stoichiometric coefficient of the nth lattice
      *
-     * \f[
+     * @f[
      *   \tilde h(T,P) = {\sum_n \theta_n  \tilde h_n(T,P) }
-     * \f]
+     * @f]
      *
-     * \f$ \tilde h_n(T,P) \f$ is the enthalpy of the nth lattice.
+     * @f$ \tilde h_n(T,P) @f$ is the enthalpy of the nth lattice.
      *
      *  units J/kmol
      */
@@ -158,14 +158,14 @@ public:
 
     //! Return the Molar Internal Energy. Units: J/kmol.
     /*!
-     * The molar enthalpy is determined by the following formula, where \f$
-     * \theta_n \f$ is the lattice stoichiometric coefficient of the nth lattice
+     * The molar enthalpy is determined by the following formula, where @f$
+     * \theta_n @f$ is the lattice stoichiometric coefficient of the nth lattice
      *
-     * \f[
+     * @f[
      *   \tilde u(T,P) = {\sum_n \theta_n \tilde u_n(T,P) }
-     * \f]
+     * @f]
      *
-     * \f$ \tilde u_n(T,P) \f$ is the internal energy of the nth lattice.
+     * @f$ \tilde u_n(T,P) @f$ is the internal energy of the nth lattice.
      *
      *  units J/kmol
      */
@@ -173,14 +173,14 @@ public:
 
     //! Return the Molar Entropy. Units: J/kmol/K.
     /*!
-     * The molar enthalpy is determined by the following formula, where \f$
-     * \theta_n \f$ is the lattice stoichiometric coefficient of the nth lattice
+     * The molar enthalpy is determined by the following formula, where @f$
+     * \theta_n @f$ is the lattice stoichiometric coefficient of the nth lattice
      *
-     * \f[
+     * @f[
      *   \tilde s(T,P) = \sum_n \theta_n \tilde s_n(T,P)
-     * \f]
+     * @f]
      *
-     * \f$ \tilde s_n(T,P) \f$ is the molar entropy of the nth lattice.
+     * @f$ \tilde s_n(T,P) @f$ is the molar entropy of the nth lattice.
      *
      *  units J/kmol/K
      */
@@ -189,14 +189,14 @@ public:
     //! Return the Molar Gibbs energy. Units: J/kmol.
     /*!
      * The molar Gibbs free energy is determined by the following formula, where
-     * \f$ \theta_n \f$ is the lattice stoichiometric coefficient of the nth
+     * @f$ \theta_n @f$ is the lattice stoichiometric coefficient of the nth
      * lattice
      *
-     * \f[
+     * @f[
      *   \tilde h(T,P) = {\sum_n \theta_n \tilde h_n(T,P) }
-     * \f]
+     * @f]
      *
-     * \f$ \tilde h_n(T,P) \f$ is the enthalpy of the nth lattice.
+     * @f$ \tilde h_n(T,P) @f$ is the enthalpy of the nth lattice.
      *
      *  units J/kmol
      */
@@ -205,14 +205,14 @@ public:
     //! Return the constant pressure heat capacity. Units: J/kmol/K
     /*!
      * The molar constant pressure heat capacity is determined by the following
-     * formula, where \f$ C_n \f$ is the lattice molar density of the nth
-     * lattice, and \f$ C_T \f$ is the molar density of the solid compound.
+     * formula, where @f$ C_n @f$ is the lattice molar density of the nth
+     * lattice, and @f$ C_T @f$ is the molar density of the solid compound.
      *
-     * \f[
+     * @f[
      *   \tilde c_{p,n}(T,P) = \frac{\sum_n C_n \tilde c_{p,n}(T,P) }{C_T},
-     * \f]
+     * @f]
      *
-     * \f$ \tilde c_{p,n}(T,P) \f$ is the heat capacity of the nth lattice.
+     * @f$ \tilde c_{p,n}(T,P) @f$ is the heat capacity of the nth lattice.
      *
      *  units J/kmol/K
      */
@@ -221,14 +221,14 @@ public:
     //! Return the constant volume heat capacity. Units: J/kmol/K
     /*!
      * The molar constant volume heat capacity is determined by the following
-     * formula, where \f$ C_n \f$ is the lattice molar density of the nth
-     * lattice, and \f$ C_T \f$ is the molar density of the solid compound.
+     * formula, where @f$ C_n @f$ is the lattice molar density of the nth
+     * lattice, and @f$ C_T @f$ is the molar density of the solid compound.
      *
-     * \f[
+     * @f[
      *   \tilde c_{v,n}(T,P) = \frac{\sum_n C_n \tilde c_{v,n}(T,P) }{C_T},
-     * \f]
+     * @f]
      *
-     * \f$ \tilde c_{v,n}(T,P) \f$ is the heat capacity of the nth lattice.
+     * @f$ \tilde c_{v,n}(T,P) @f$ is the heat capacity of the nth lattice.
      *
      *  units J/kmol/K
      */
@@ -254,11 +254,11 @@ public:
     /*!
      * The formula for this is
      *
-     * \f[
+     * @f[
      *      \rho = \sum_n{ \rho_n \theta_n }
-     * \f]
+     * @f]
      *
-     * where \f$ \rho_n \f$  is the density of the nth sublattice
+     * where @f$ \rho_n @f$  is the density of the nth sublattice
      */
     doublereal calcDensity();
 
@@ -344,11 +344,11 @@ public:
     /*!
      * Units (J/kmol). For this phase, the partial molar enthalpies are equal to
      * the pure species enthalpies
-     *  \f[
+     *  @f[
      * \bar h_k(T,P) = \hat h^{ref}_k(T) + (P - P_{ref}) \hat V^0_k
-     * \f]
-     * The reference-state pure-species enthalpies, \f$ \hat h^{ref}_k(T) \f$,
-     * at the reference pressure,\f$ P_{ref} \f$, are computed by the species
+     * @f]
+     * The reference-state pure-species enthalpies, @f$ \hat h^{ref}_k(T) @f$,
+     * at the reference pressure,@f$ P_{ref} @f$, are computed by the species
      * thermodynamic property manager. They are polynomial functions of
      * temperature.
      * @see MultiSpeciesThermo
@@ -363,11 +363,11 @@ public:
      * solution. Units: J/kmol/K. For this phase, the partial molar entropies
      * are equal to the pure species entropies plus the ideal solution
      * contribution.
-     *  \f[
+     *  @f[
      * \bar s_k(T,P) =  \hat s^0_k(T) - R log(X_k)
-     * \f]
-     * The reference-state pure-species entropies,\f$ \hat s^{ref}_k(T) \f$, at
-     * the reference pressure, \f$ P_{ref} \f$, are computed by the species
+     * @f]
+     * The reference-state pure-species entropies,@f$ \hat s^{ref}_k(T) @f$, at
+     * the reference pressure, @f$ P_{ref} @f$, are computed by the species
      * thermodynamic property manager. They are polynomial functions of
      * temperature.
      * @see MultiSpeciesThermo
@@ -401,7 +401,7 @@ public:
     //! the species at their standard states at the current *T* and *P* of the
     //! solution.
     /*!
-     * These are the standard state chemical potentials \f$ \mu^0_k(T,P) \f$.
+     * These are the standard state chemical potentials @f$ \mu^0_k(T,P) @f$.
      * The values are evaluated at the current temperature and pressure of the
      * solution.
      *
@@ -428,7 +428,7 @@ public:
     //! Add a lattice to this phase
     void addLattice(shared_ptr<ThermoPhase> lattice);
 
-    //! Set the lattice stoichiometric coefficients, \f$ \theta_i \f$
+    //! Set the lattice stoichiometric coefficients, @f$ \theta_i @f$
     void setLatticeStoichiometry(const compositionMap& comp);
 
     virtual void setParameters(const AnyMap& phaseNode,

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -115,7 +115,7 @@ namespace Cantera
  *
  * ## Application within Kinetics Managers
  *
- * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where
+ * @f$ C^a_k @f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where
  * @f$ C^s_k @f$ is a standard concentration defined below and @f$ a_k @f$ are
  * activities used in the thermodynamic functions.  These activity (or
  * generalized) concentrations are used by kinetics manager classes to compute
@@ -207,7 +207,7 @@ namespace Cantera
  *    k^{-1} =  k^1 K^1_c
  * @f]
  *
- * @f$k^{-1} @f$ has units of s-1.
+ * @f$ k^{-1} @f$ has units of s-1.
  *
  * @ingroup thermoprops
  */
@@ -239,9 +239,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
-    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
+    //! quantity @f$ \mu_k^0(T,P) @f$ is the chemical potential at unit activity,
     //! which depends only on temperature and pressure.
     //! @{
 

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -41,173 +41,173 @@ namespace Cantera
  * the generalization of the Margules formulation for a phase that has more than
  * 2 species.
  *
- * \f[
+ * @f[
  *     G^E = \sum_i \left(  H_{Ei} - T S_{Ei} \right)
- * \f]
- * \f[
+ * @f]
+ * @f[
  *    H^E_i = n X_{Ai} X_{Bi} \left( h_{o,i} +  h_{1,i} X_{Bi} \right)
- * \f]
- * \f[
+ * @f]
+ * @f[
  *    S^E_i = n X_{Ai} X_{Bi} \left( s_{o,i} +  s_{1,i} X_{Bi} \right)
- * \f]
+ * @f]
  *
  * where n is the total moles in the solution.
  *
  * The activity of a species defined in the phase is given by an excess Gibbs
  * free energy formulation.
  *
- * \f[
+ * @f[
  *      a_k = \gamma_k  X_k
- * \f]
+ * @f]
  *
  * where
  *
- * \f[
+ * @f[
  *      R T \ln( \gamma_k )= \frac{d(n G^E)}{d(n_k)}\Bigg|_{n_i}
- * \f]
+ * @f]
  *
  * Taking the derivatives results in the following expression
  *
- * \f[
+ * @f[
  *      R T \ln( \gamma_k )= \sum_i \left( \left( \delta_{Ai,k} X_{Bi} + \delta_{Bi,k} X_{Ai}  - X_{Ai} X_{Bi} \right)
  *       \left( g^E_{o,i} +  g^E_{1,i} X_{Bi} \right) +
  *       \left( \delta_{Bi,k} - X_{Bi} \right)      X_{Ai} X_{Bi}  g^E_{1,i} \right)
- * \f]
+ * @f]
  * where
- * \f$  g^E_{o,i} =  h_{o,i} - T s_{o,i} \f$ and
- * \f$ g^E_{1,i} =  h_{1,i} - T s_{1,i} \f$ and where
- * \f$ X_k \f$ is the mole fraction of species *k*.
+ * @f$  g^E_{o,i} =  h_{o,i} - T s_{o,i} @f$ and
+ * @f$ g^E_{1,i} =  h_{1,i} - T s_{1,i} @f$ and where
+ * @f$ X_k @f$ is the mole fraction of species *k*.
  *
  * This object inherits from the class VPStandardStateTP. Therefore, the
  * specification and calculation of all standard state and reference state
  * values are handled at that level. Various functional forms for the standard
  * state are permissible. The chemical potential for species *k* is equal to
  *
- * \f[
+ * @f[
  *      \mu_k(T,P) = \mu^o_k(T, P) + R T \ln(\gamma_k X_k)
- * \f]
+ * @f]
  *
  * The partial molar entropy for species *k* is given by
  *
- * \f[
+ * @f[
  *       \tilde{s}_k(T,P) =  s^o_k(T,P)  - R \ln( \gamma_k X_k )
  *              - R T \frac{d \ln(\gamma_k) }{dT}
- * \f]
+ * @f]
  *
  * The partial molar enthalpy for species *k* is given by
  *
- * \f[
+ * @f[
  *      \tilde{h}_k(T,P) = h^o_k(T,P) - R T^2 \frac{d \ln(\gamma_k)}{dT}
- * \f]
+ * @f]
  *
  * The partial molar volume for species *k* is
  *
- * \f[
+ * @f[
  *        \tilde V_k(T,P)  = V^o_k(T,P)  + R T \frac{d \ln(\gamma_k) }{dP}
- * \f]
+ * @f]
  *
  * The partial molar Heat Capacity for species *k* is
  *
- * \f[
+ * @f[
  *      \tilde{C}_{p,k}(T,P) = C^o_{p,k}(T,P)   - 2 R T \frac{d \ln( \gamma_k )}{dT}
  *              - R T^2 \frac{d^2 \ln(\gamma_k) }{{dT}^2}
- * \f]
+ * @f]
  *
  * ## Application within Kinetics Managers
  *
- * \f$ C^a_k\f$ are defined such that \f$ a_k = C^a_k / C^s_k, \f$ where
- * \f$ C^s_k \f$ is a standard concentration defined below and \f$ a_k \f$ are
+ * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where
+ * @f$ C^s_k @f$ is a standard concentration defined below and @f$ a_k @f$ are
  * activities used in the thermodynamic functions.  These activity (or
  * generalized) concentrations are used by kinetics manager classes to compute
  * the forward and reverse rates of elementary reactions. The activity
- * concentration,\f$  C^a_k \f$,is given by the following expression.
+ * concentration,@f$  C^a_k @f$,is given by the following expression.
  *
- * \f[
+ * @f[
  *      C^a_k = C^s_k  X_k  = \frac{P}{R T} X_k
- * \f]
+ * @f]
  *
  * The standard concentration for species *k* is independent of *k* and equal to
  *
- * \f[
+ * @f[
  *     C^s_k =  C^s = \frac{P}{R T}
- * \f]
+ * @f]
  *
  * For example, a bulk-phase binary gas reaction between species j and k,
  * producing a new gas species l would have the following equation for its rate
- * of progress variable, \f$ R^1 \f$, which has units of kmol m-3 s-1.
+ * of progress variable, @f$ R^1 @f$, which has units of kmol m-3 s-1.
  *
- * \f[
+ * @f[
  *    R^1 = k^1 C_j^a C_k^a =  k^1 (C^s a_j) (C^s a_k)
- * \f]
+ * @f]
  * where
- * \f[
+ * @f[
  *    C_j^a = C^s a_j \mbox{\quad and \quad} C_k^a = C^s a_k
- * \f]
+ * @f]
  *
- * \f$ C_j^a \f$ is the activity concentration of species j, and \f$ C_k^a \f$
- * is the activity concentration of species k. \f$ C^s \f$ is the standard
- * concentration. \f$ a_j \f$ is the activity of species j which is equal to the
+ * @f$ C_j^a @f$ is the activity concentration of species j, and @f$ C_k^a @f$
+ * is the activity concentration of species k. @f$ C^s @f$ is the standard
+ * concentration. @f$ a_j @f$ is the activity of species j which is equal to the
  * mole fraction of j.
  *
  * The reverse rate constant can then be obtained from the law of microscopic
  * reversibility and the equilibrium expression for the system.
  *
- * \f[
+ * @f[
  *       \frac{a_j a_k}{ a_l} = K_a^{o,1} = \exp(\frac{\mu^o_l - \mu^o_j - \mu^o_k}{R T} )
- * \f]
+ * @f]
  *
- * \f$  K_a^{o,1} \f$ is the dimensionless form of the equilibrium constant,
- * associated with the pressure dependent standard states \f$ \mu^o_l(T,P) \f$
- * and their associated activities, \f$ a_l \f$, repeated here:
+ * @f$  K_a^{o,1} @f$ is the dimensionless form of the equilibrium constant,
+ * associated with the pressure dependent standard states @f$ \mu^o_l(T,P) @f$
+ * and their associated activities, @f$ a_l @f$, repeated here:
  *
- * \f[
+ * @f[
  *      \mu_l(T,P) = \mu^o_l(T, P) + R T \log(a_l)
- * \f]
+ * @f]
  *
  * We can switch over to expressing the equilibrium constant in terms of the
  * reference state chemical potentials
  *
- * \f[
+ * @f[
  *     K_a^{o,1} = \exp(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} ) * \frac{P_{ref}}{P}
- * \f]
+ * @f]
  *
- * The concentration equilibrium constant, \f$ K_c \f$, may be obtained by
+ * The concentration equilibrium constant, @f$ K_c @f$, may be obtained by
  * changing over to activity concentrations. When this is done:
  *
- * \f[
+ * @f[
  *       \frac{C^a_j C^a_k}{ C^a_l} = C^o K_a^{o,1} = K_c^1 =
  *           \exp(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} ) * \frac{P_{ref}}{RT}
- * \f]
+ * @f]
  *
- * %Kinetics managers will calculate the concentration equilibrium constant, \f$
- * K_c \f$, using the second and third part of the above expression as a
+ * %Kinetics managers will calculate the concentration equilibrium constant, @f$
+ * K_c @f$, using the second and third part of the above expression as a
  * definition for the concentration equilibrium constant.
  *
  * For completeness, the pressure equilibrium constant may be obtained as well
  *
- * \f[
+ * @f[
  *     \frac{P_j P_k}{ P_l P_{ref}} = K_p^1 = \exp(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} )
- * \f]
+ * @f]
  *
- * \f$ K_p \f$ is the simplest form of the equilibrium constant for ideal gases.
+ * @f$ K_p @f$ is the simplest form of the equilibrium constant for ideal gases.
  * However, it isn't necessarily the simplest form of the equilibrium constant
- * for other types of phases; \f$ K_c \f$ is used instead because it is
+ * for other types of phases; @f$ K_c @f$ is used instead because it is
  * completely general.
  *
  * The reverse rate of progress may be written down as
- * \f[
+ * @f[
  *    R^{-1} = k^{-1} C_l^a =  k^{-1} (C^o a_l)
- * \f]
+ * @f]
  *
  * where we can use the concept of microscopic reversibility to write the
  * reverse rate constant in terms of the forward rate constant and the
- * concentration equilibrium constant, \f$ K_c \f$.
+ * concentration equilibrium constant, @f$ K_c @f$.
  *
- * \f[
+ * @f[
  *    k^{-1} =  k^1 K^1_c
- * \f]
+ * @f]
  *
- * \f$k^{-1} \f$ has units of s-1.
+ * @f$k^{-1} @f$ has units of s-1.
  *
  * @ingroup thermoprops
  */
@@ -239,9 +239,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
+    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
     //! which depends only on temperature and pressure.
     //! @{
 
@@ -262,9 +262,9 @@ public:
      * state enthalpies modified by the derivative of the molality-based
      * activity coefficient wrt temperature
      *
-     * \f[
+     * @f[
      *   \bar h_k(T,P) = h^o_k(T,P) - R T^2 \frac{d \ln(\gamma_k)}{dT}
-     * \f]
+     * @f]
      *
      * @param hbar  Vector of returned partial molar enthalpies
      *              (length m_kk, units = J/kmol)
@@ -280,11 +280,11 @@ public:
      * state enthalpies modified by the derivative of the activity coefficient
      * wrt temperature
      *
-     * \f[
+     * @f[
      *   \bar s_k(T,P) = s^o_k(T,P) - R T^2 \frac{d \ln(\gamma_k)}{dT}
      *                              - R \ln( \gamma_k X_k)
      *                              - R T \frac{d \ln(\gamma_k) }{dT}
-     * \f]
+     * @f]
      *
      * @param sbar  Vector of returned partial molar entropies
      *              (length m_kk, units = J/kmol/K)
@@ -300,13 +300,13 @@ public:
      * state enthalpies modified by the derivative of the activity coefficient
      * wrt temperature
      *
-     *  \f[
+     *  @f[
      *   ???????????????
      *   \bar s_k(T,P) = s^o_k(T,P) - R T^2 \frac{d \ln(\gamma_k)}{dT}
      *                              - R \ln( \gamma_k X_k)
      *                              - R T \frac{d \ln(\gamma_k) }{dT}
      *   ???????????????
-     *  \f]
+     *  @f]
      *
      * @param cpbar  Vector of returned partial molar heat capacities
      *              (length m_kk, units = J/kmol/K)

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -128,7 +128,7 @@ public:
     //! Get the array of non-dimensional species chemical potentials
     //! These are partial molar Gibbs free energies.
     /*!
-     * \f$ \mu_k / \hat R T \f$.
+     * @f$ \mu_k / \hat R T @f$.
      * Units: unitless
      *
      * We close the loop on this function, here, calling getChemPotentials() and
@@ -151,8 +151,8 @@ public:
 
     //! Get the array of chemical potentials at unit activity.
     /*!
-     * These are the standard state chemical potentials \f$ \mu^0_k(T,P)
-     * \f$. The values are evaluated at the current temperature and pressure.
+     * These are the standard state chemical potentials @f$ \mu^0_k(T,P)
+     * @f$. The values are evaluated at the current temperature and pressure.
      *
      * For all objects with the Mixture Fugacity approximation, we define the
      * standard state as an ideal gas at the current temperature and pressure
@@ -217,9 +217,9 @@ public:
      * standard state as an ideal gas at the current temperature and pressure
      * of the solution.
      *
-     * \f[
+     * @f[
      *  u^{ss}_k(T,P) = h^{ss}_k(T)  - P * V^{ss}_k
-     * \f]
+     * @f]
      *
      * @param urt    Output vector of nondimensional standard state internal
      *               energies. length = m_kk.
@@ -342,9 +342,9 @@ protected:
 
     //!  Calculate the value of z
     /*!
-     *  \f[
+     *  @f[
      *        z = \frac{P v}{R T}
-     *  \f]
+     *  @f]
      *
      *  returns the value of z
      */

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -130,7 +130,7 @@ const int PHSCALE_NBS = 1;
  * @f]
  *
  * where @f$ \gamma_k^{\triangle} @f$ is the molality based activity coefficient
- * for species @f$k@f$.
+ * for species @f$ k @f$.
  *
  * The chemical potential of the solvent is thus expressed in a different format
  * than the chemical potential of the solutes. Additionally, the activity of the
@@ -329,11 +329,11 @@ public:
      *     m_i = \frac{X_i}{M_o/1000 * X_{o,p}}
      * @f]
      * where
-     *    -  @f$M_o@f$ is the molecular weight of the solvent
-     *    -  @f$X_o@f$ is the mole fraction of the solvent
-     *    -  @f$X_i@f$ is the mole fraction of the solute.
-     *    -  @f$X_{o,p} = \max(X_o^{min}, X_o)@f$
-     *    -  @f$X_o^{min}@f$ = minimum mole fraction of solvent allowed
+     *    -  @f$ M_o @f$ is the molecular weight of the solvent
+     *    -  @f$ X_o @f$ is the mole fraction of the solvent
+     *    -  @f$ X_i @f$ is the mole fraction of the solute.
+     *    -  @f$ X_{o,p} = \max(X_o^{min}, X_o) @f$
+     *    -  @f$ X_o^{min} @f$ = minimum mole fraction of solvent allowed
      *                     in the denominator.
      *
      * The formulas for calculating mole fractions are
@@ -375,9 +375,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
-    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
+    //! quantity @f$ \mu_k^0(T,P) @f$ is the chemical potential at unit activity,
     //! which depends only on temperature and pressure.
     //! @{
 

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -34,10 +34,10 @@ namespace Cantera
  * Activity coefficients for species k may be altered between scales s1 to s2
  * using the following formula
  *
- * \f[
+ * @f[
  *     ln(\gamma_k^{s2}) = ln(\gamma_k^{s1})
  *        + \frac{z_k}{z_j} \left(  ln(\gamma_j^{s2}) - ln(\gamma_j^{s1}) \right)
- * \f]
+ * @f]
  *
  * where j is any one species.
  */
@@ -51,17 +51,17 @@ const int PHSCALE_PITZER = 0;
  * Activity coefficients for species k may be altered between scales s1 to s2
  * using the following formula
  *
- * \f[
+ * @f[
  *     ln(\gamma_k^{s2}) = ln(\gamma_k^{s1})
  *        + \frac{z_k}{z_j} \left(  ln(\gamma_j^{s2}) - ln(\gamma_j^{s1}) \right)
- * \f]
+ * @f]
  *
  * where j is any one species. For the NBS scale, j is equal to the Cl- species
  * and
  *
- * \f[
+ * @f[
  *     ln(\gamma_{Cl-}^{s2}) = \frac{-A_{\phi} \sqrt{I}}{1.0 + 1.5 \sqrt{I}}
- * \f]
+ * @f]
  *
  * This is the NBS pH scale, which is used in all conventional pH measurements.
  * and is based on the Bates-Guggenheim equations.
@@ -83,88 +83,88 @@ const int PHSCALE_NBS = 1;
  * MolalityVPSSTP class return `cAC_CONVENTION_MOLALITY` from this member
  * function.
  *
- * The molality of a solute, \f$ m_i \f$, is defined as
+ * The molality of a solute, @f$ m_i @f$, is defined as
  *
- * \f[
+ * @f[
  *     m_i = \frac{n_i}{\tilde{M}_o n_o}
- * \f]
+ * @f]
  * where
- * \f[
+ * @f[
  *     \tilde{M}_o = \frac{M_o}{1000}
- * \f]
+ * @f]
  *
- * where \f$ M_o \f$ is the molecular weight of the solvent. The molality has
+ * where @f$ M_o @f$ is the molecular weight of the solvent. The molality has
  * units of gmol/kg. For the solute, the molality may be considered
  * as the amount of gmol's of solute per kg of solvent, a natural experimental
  * quantity.
  *
  * The formulas for calculating mole fractions if given the molalities of the
- * solutes is stated below. First calculate \f$ L^{sum} \f$, an intermediate
+ * solutes is stated below. First calculate @f$ L^{sum} @f$, an intermediate
  * quantity.
  *
- * \f[
+ * @f[
  *     L^{sum} = \frac{1}{\tilde{M}_o X_o} = \frac{1}{\tilde{M}_o} + \sum_{i\ne o} m_i
- * \f]
+ * @f]
  * Then,
- * \f[
+ * @f[
  *     X_o =   \frac{1}{\tilde{M}_o L^{sum}}
- * \f]
- * \f[
+ * @f]
+ * @f[
  *     X_i =   \frac{m_i}{L^{sum}}
- * \f]
- * where \f$ X_o \f$ is the mole fraction of solvent, and \f$ X_o \f$ is the
+ * @f]
+ * where @f$ X_o @f$ is the mole fraction of solvent, and @f$ X_o @f$ is the
  * mole fraction of solute *i*. Thus, the molality scale and the mole fraction
  * scale offer a one-to-one mapping between each other, except in the limit of a
  * zero solvent mole fraction.
  *
  * The standard states for thermodynamic objects that derive from MolalityVPSSTP
- * are on the unit molality basis. Chemical potentials of the solutes, \f$ \mu_k
- * \f$, and the solvent, \f$ \mu_o \f$, which are based on the molality form,
+ * are on the unit molality basis. Chemical potentials of the solutes, @f$ \mu_k
+ * @f$, and the solvent, @f$ \mu_o @f$, which are based on the molality form,
  * have the following general format:
  *
- * \f[
+ * @f[
  *    \mu_k = \mu^{\triangle}_k(T,P) + R T ln(\gamma_k^{\triangle} \frac{m_k}{m^\triangle})
- * \f]
- * \f[
+ * @f]
+ * @f[
  *    \mu_o = \mu^o_o(T,P) + RT ln(a_o)
- * \f]
+ * @f]
  *
- * where \f$ \gamma_k^{\triangle} \f$ is the molality based activity coefficient
- * for species \f$k\f$.
+ * where @f$ \gamma_k^{\triangle} @f$ is the molality based activity coefficient
+ * for species @f$k@f$.
  *
  * The chemical potential of the solvent is thus expressed in a different format
  * than the chemical potential of the solutes. Additionally, the activity of the
- * solvent, \f$ a_o \f$, is further reexpressed in terms of an osmotic
- * coefficient, \f$ \phi \f$.
- * \f[
+ * solvent, @f$ a_o @f$, is further reexpressed in terms of an osmotic
+ * coefficient, @f$ \phi @f$.
+ * @f[
  *     \phi = \frac{- ln(a_o)}{\tilde{M}_o \sum_{i \ne o} m_i}
- * \f]
+ * @f]
  *
- * MolalityVPSSTP::osmoticCoefficient() returns the value of \f$ \phi \f$. Note
+ * MolalityVPSSTP::osmoticCoefficient() returns the value of @f$ \phi @f$. Note
  * there are a few of definitions of the osmotic coefficient floating around. We
  * use the one defined in (Activity Coefficients in Electrolyte Solutions, K. S.
  * Pitzer CRC Press, Boca Raton, 1991, p. 85, Eqn. 28). This definition is most
  * clearly related to theoretical calculation.
  *
- * The molar-based activity coefficients \f$ \gamma_k \f$ may be calculated from
- * the molality-based activity coefficients, \f$ \gamma_k^\triangle \f$ by the
+ * The molar-based activity coefficients @f$ \gamma_k @f$ may be calculated from
+ * the molality-based activity coefficients, @f$ \gamma_k^\triangle @f$ by the
  * following formula.
- * \f[
+ * @f[
  *     \gamma_k = \frac{\gamma_k^\triangle}{X_o}
- * \f]
+ * @f]
  * For purposes of establishing a convention, the molar activity coefficient of
  * the solvent is set equal to the molality-based activity coefficient of the
  * solvent:
- * \f[
+ * @f[
  *     \gamma_o = \gamma_o^\triangle
- * \f]
+ * @f]
  *
  * The molality-based and molarity-based standard states may be related to one
  * another by the following formula.
  *
- * \f[
+ * @f[
  *   \mu_k^\triangle(T,P) = \mu_k^o(T,P) + R T \ln(\tilde{M}_o m^\triangle)
- * \f]
+ * @f]
  *
  * An important convention is followed in all routines that derive from
  * MolalityVPSSTP. Standard state thermodynamic functions and reference state
@@ -194,17 +194,17 @@ const int PHSCALE_NBS = 1;
  * Activity coefficients for species k may be altered between scales s1 to s2
  * using the following formula
  *
- * \f[
+ * @f[
  *     ln(\gamma_k^{s2}) = ln(\gamma_k^{s1})
  *        + \frac{z_k}{z_j} \left(  ln(\gamma_j^{s2}) - ln(\gamma_j^{s1}) \right)
- * \f]
+ * @f]
  *
  * where j is any one species. For the NBS scale, j is equal to the Cl- species
  * and
  *
- * \f[
+ * @f[
  *     ln(\gamma_{Cl-}^{s2}) = \frac{-A_{\phi} \sqrt{I}}{1.0 + 1.5 \sqrt{I}}
- * \f]
+ * @f]
  *
  * The Pitzer scale doesn't actually change anything. The pitzer scale is
  * defined as the raw unscaled activity coefficients produced by the underlying
@@ -289,15 +289,15 @@ public:
     /*!
      * We calculate the vector of molalities of the species in the phase and
      * store the result internally:
-     * \f[
+     * @f[
      *     m_i = \frac{X_i}{1000 * M_o * X_{o,p}}
-     * \f]
+     * @f]
      * where
-     *    - \f$ M_o \f$ is the molecular weight of the solvent
-     *    - \f$ X_o \f$ is the mole fraction of the solvent
-     *    - \f$ X_i \f$ is the mole fraction of the solute.
-     *    - \f$ X_{o,p} = \max (X_{o}^{min}, X_o) \f$
-     *    - \f$ X_{o}^{min} \f$ = minimum mole fraction of solvent allowed
+     *    - @f$ M_o @f$ is the molecular weight of the solvent
+     *    - @f$ X_o @f$ is the mole fraction of the solvent
+     *    - @f$ X_i @f$ is the mole fraction of the solute.
+     *    - @f$ X_{o,p} = \max (X_{o}^{min}, X_o) @f$
+     *    - @f$ X_{o}^{min} @f$ = minimum mole fraction of solvent allowed
      *              in the denominator.
      */
     void calcMolalities() const;
@@ -305,15 +305,15 @@ public:
     //! This function will return the molalities of the species.
     /*!
      * We calculate the vector of molalities of the species in the phase
-     * \f[
+     * @f[
      *     m_i = \frac{X_i}{1000 * M_o * X_{o,p}}
-     * \f]
+     * @f]
      * where
-     *    - \f$ M_o \f$ is the molecular weight of the solvent
-     *    - \f$ X_o \f$ is the mole fraction of the solvent
-     *    - \f$ X_i \f$ is the mole fraction of the solute.
-     *    - \f$ X_{o,p} = \max (X_{o}^{min}, X_o) \f$
-     *    - \f$ X_{o}^{min} \f$ = minimum mole fraction of solvent allowed
+     *    - @f$ M_o @f$ is the molecular weight of the solvent
+     *    - @f$ X_o @f$ is the mole fraction of the solvent
+     *    - @f$ X_i @f$ is the mole fraction of the solute.
+     *    - @f$ X_{o,p} = \max (X_{o}^{min}, X_o) @f$
+     *    - @f$ X_{o}^{min} @f$ = minimum mole fraction of solvent allowed
      *              in the denominator.
      *
      * @param molal       Output vector of molalities. Length: m_kk.
@@ -325,30 +325,30 @@ public:
      * Note, the entry for the solvent is not used. We are supplied with the
      * molalities of all of the solute species. We then calculate the mole
      * fractions of all species and update the ThermoPhase object.
-     * \f[
+     * @f[
      *     m_i = \frac{X_i}{M_o/1000 * X_{o,p}}
-     * \f]
+     * @f]
      * where
-     *    -  \f$M_o\f$ is the molecular weight of the solvent
-     *    -  \f$X_o\f$ is the mole fraction of the solvent
-     *    -  \f$X_i\f$ is the mole fraction of the solute.
-     *    -  \f$X_{o,p} = \max(X_o^{min}, X_o)\f$
-     *    -  \f$X_o^{min}\f$ = minimum mole fraction of solvent allowed
+     *    -  @f$M_o@f$ is the molecular weight of the solvent
+     *    -  @f$X_o@f$ is the mole fraction of the solvent
+     *    -  @f$X_i@f$ is the mole fraction of the solute.
+     *    -  @f$X_{o,p} = \max(X_o^{min}, X_o)@f$
+     *    -  @f$X_o^{min}@f$ = minimum mole fraction of solvent allowed
      *                     in the denominator.
      *
      * The formulas for calculating mole fractions are
-     * \f[
+     * @f[
      *     L^{sum} = \frac{1}{\tilde{M}_o X_o} = \frac{1}{\tilde{M}_o} + \sum_{i\ne o} m_i
-     * \f]
+     * @f]
      * Then,
-     * \f[
+     * @f[
      *     X_o =   \frac{1}{\tilde{M}_o L^{sum}}
-     * \f]
-     * \f[
+     * @f]
+     * @f[
      *     X_i =   \frac{m_i}{L^{sum}}
-     * \f]
+     * @f]
      * It is currently an error if the solvent mole fraction is attempted to be
-     * set to a value lower than \f$ X_o^{min} \f$.
+     * set to a value lower than @f$ X_o^{min} @f$.
      *
      * @param molal   Input vector of molalities. Length: m_kk.
      */
@@ -375,9 +375,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f] The
-    //! quantity \f$\mu_k^0(T,P)\f$ is the chemical potential at unit activity,
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f] The
+    //! quantity @f$\mu_k^0(T,P)@f$ is the chemical potential at unit activity,
     //! which depends only on temperature and pressure.
     //! @{
 
@@ -397,9 +397,9 @@ public:
      * consistent with the molality scale. Therefore, this function must return
      * molality-based activities.
      *
-     * \f[
+     * @f[
      *     a_i^\triangle = \gamma_k^{\triangle} \frac{m_k}{m^\triangle}
-     * \f]
+     * @f]
      *
      * This function must be implemented in derived classes.
      *
@@ -415,20 +415,20 @@ public:
      * of the molality-based activity coefficients.
      *  See Denbigh p. 278 for a thorough discussion.
      *
-     * The molar-based activity coefficients \f$ \gamma_k \f$ may be calculated
-     * from the molality-based activity coefficients, \f$ \gamma_k^\triangle \f$
+     * The molar-based activity coefficients @f$ \gamma_k @f$ may be calculated
+     * from the molality-based activity coefficients, @f$ \gamma_k^\triangle @f$
      * by the following formula.
-     * \f[
+     * @f[
      *     \gamma_k = \frac{\gamma_k^\triangle}{X_o}
-     * \f]
+     * @f]
      *
      * For purposes of establishing a convention, the molar activity coefficient of the
      * solvent is set equal to the molality-based activity coefficient of the
      * solvent:
      *
-     * \f[
+     * @f[
      *     \gamma_o = \gamma_o^\triangle
-     * \f]
+     * @f]
      *
      * Derived classes don't need to overload this function. This function is
      * handled at this level.
@@ -452,17 +452,17 @@ public:
      * Activity coefficients for species k may be altered between scales s1 to
      * s2 using the following formula
      *
-     * \f[
+     * @f[
      *     ln(\gamma_k^{s2}) = ln(\gamma_k^{s1})
      *        + \frac{z_k}{z_j} \left(  ln(\gamma_j^{s2}) - ln(\gamma_j^{s1}) \right)
-     * \f]
+     * @f]
      *
      * where j is any one species. For the NBS scale, j is equal to the Cl-
      * species and
      *
-     * \f[
+     * @f[
      *     ln(\gamma_{Cl-}^{s2}) = \frac{-A_{\phi} \sqrt{I}}{1.0 + 1.5 \sqrt{I}}
-     * \f]
+     * @f]
      *
      * @param acMolality Output vector containing the molality based activity
      *                   coefficients. length: m_kk.
@@ -471,9 +471,9 @@ public:
 
     //! Calculate the osmotic coefficient
     /*!
-     * \f[
+     * @f[
      *     \phi = \frac{- ln(a_o)}{\tilde{M}_o \sum_{i \ne o} m_i}
-     * \f]
+     * @f]
      *
      * Note there are a few of definitions of the osmotic coefficient floating
      * around. We use the one defined in (Activity Coefficients in Electrolyte

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -24,7 +24,7 @@ namespace Cantera
  * The Mu0Poly class implements a piecewise constant heat capacity
  * approximation. of the standard state chemical potential of one species at a
  * single reference pressure. The chemical potential is input as a series of
- * (\f$T\f$, \f$ \mu^o(T)\f$) values. The first temperature is assumed to be
+ * (@f$T@f$, @f$ \mu^o(T)@f$) values. The first temperature is assumed to be
  * equal to 298.15 K; however, this may be relaxed in the future. This
  * information, and an assumption of a constant heat capacity within each
  * interval is enough to calculate all thermodynamic functions.
@@ -32,37 +32,37 @@ namespace Cantera
  * The piece-wise constant heat capacity is calculated from the change in the
  * chemical potential over each interval. Once the heat capacity is known, the
  * other thermodynamic functions may be determined. The basic equation for going
- * from temperature point 1 to temperature point 2 are as follows for \f$ T \f$,
- * \f$ T_1 <= T <= T_2 \f$
+ * from temperature point 1 to temperature point 2 are as follows for @f$ T @f$,
+ * @f$ T_1 <= T <= T_2 @f$
  *
- * \f[
+ * @f[
  *      \mu^o(T_1) = h^o(T_1) - T_1 * s^o(T_1)
- * \f]
- * \f[
+ * @f]
+ * @f[
  *      \mu^o(T_2) - \mu^o(T_1) = Cp^o(T_1)(T_2 - T_1) - Cp^o(T_1)(T_2)ln(\frac{T_2}{T_1}) - s^o(T_1)(T_2 - T_1)
- * \f]
- * \f[
+ * @f]
+ * @f[
  *      s^o(T_2) = s^o(T_1) + Cp^o(T_1)ln(\frac{T_2}{T_1})
- * \f]
- * \f[
+ * @f]
+ * @f[
  *      h^o(T_2) = h^o(T_1) + Cp^o(T_1)(T_2 - T_1)
- * \f]
+ * @f]
  *
- *  Within each interval the following relations are used. For \f$ T \f$, \f$
- *  T_1 <= T <= T_2 \f$
+ *  Within each interval the following relations are used. For @f$ T @f$, @f$
+ *  T_1 <= T <= T_2 @f$
  *
- * \f[
+ * @f[
  *      \mu^o(T) = \mu^o(T_1) + Cp^o(T_1)(T - T_1) - Cp^o(T_1)(T_2)ln(\frac{T}{T_1}) - s^o(T_1)(T - T_1)
- * \f]
- * \f[
+ * @f]
+ * @f[
  *      s^o(T) = s^o(T_1) + Cp^o(T_1)ln(\frac{T}{T_1})
- * \f]
- * \f[
+ * @f]
+ * @f[
  *      h^o(T) = h^o(T_1) + Cp^o(T_1)(T - T_1)
- * \f]
+ * @f]
  *
- * Notes about temperature interpolation for \f$ T < T_1 \f$ and \f$ T >
- * T_{npoints} \f$: These are achieved by assuming a constant heat capacity
+ * Notes about temperature interpolation for @f$ T < T_1 @f$ and @f$ T >
+ * T_{npoints} @f$: These are achieved by assuming a constant heat capacity
  * equal to the value in the closest temperature interval. No error is thrown.
  *
  * @note In the future, a better assumption about the heat capacity may be
@@ -81,23 +81,23 @@ public:
      * @param thigh   Maximum temperature
      * @param pref    reference pressure (Pa).
      * @param coeffs  Vector of coefficients used to set the parameters for the
-     *                standard state for species n. There are \f$ 2+npoints*2
-     *                \f$ coefficients, where \f$ npoints \f$ are the number of
+     *                standard state for species n. There are @f$ 2+npoints*2
+     *                @f$ coefficients, where @f$ npoints @f$ are the number of
      *                temperature points. Their identity is further broken down:
      *            - coeffs[0] = number of points (integer)
-     *            - coeffs[1] = \f$ h^o(298.15 K) \f$ (J/kmol)
-     *            - coeffs[2] = \f$ T_1 \f$  (Kelvin)
-     *            - coeffs[3] = \f$ \mu^o(T_1) \f$ (J/kmol)
-     *            - coeffs[4] = \f$ T_2 \f$  (Kelvin)
-     *            - coeffs[5] = \f$ \mu^o(T_2) \f$ (J/kmol)
-     *            - coeffs[6] = \f$ T_3 \f$  (Kelvin)
-     *            - coeffs[7] = \f$ \mu^o(T_3) \f$ (J/kmol)
+     *            - coeffs[1] = @f$ h^o(298.15 K) @f$ (J/kmol)
+     *            - coeffs[2] = @f$ T_1 @f$  (Kelvin)
+     *            - coeffs[3] = @f$ \mu^o(T_1) @f$ (J/kmol)
+     *            - coeffs[4] = @f$ T_2 @f$  (Kelvin)
+     *            - coeffs[5] = @f$ \mu^o(T_2) @f$ (J/kmol)
+     *            - coeffs[6] = @f$ T_3 @f$  (Kelvin)
+     *            - coeffs[7] = @f$ \mu^o(T_3) @f$ (J/kmol)
      *            - ........
      *            .
      */
     Mu0Poly(double tlow, double thigh, double pref, const double* coeffs);
 
-    //! Set parameters for \f$ \mu^o(T) \f$
+    //! Set parameters for @f$ \mu^o(T) @f$
     /*!
      * Calculates and stores the piecewise linear approximation to the
      * thermodynamic functions.

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -24,7 +24,7 @@ namespace Cantera
  * The Mu0Poly class implements a piecewise constant heat capacity
  * approximation. of the standard state chemical potential of one species at a
  * single reference pressure. The chemical potential is input as a series of
- * (@f$T@f$, @f$ \mu^o(T)@f$) values. The first temperature is assumed to be
+ * (@f$ T @f$, @f$ \mu^o(T) @f$) values. The first temperature is assumed to be
  * equal to 298.15 K; however, this may be relaxed in the future. This
  * information, and an assumption of a constant heat capacity within each
  * interval is enough to calculate all thermodynamic functions.

--- a/include/cantera/thermo/Nasa9Poly1.h
+++ b/include/cantera/thermo/Nasa9Poly1.h
@@ -29,8 +29,8 @@ namespace Cantera
  * Individual Species," B. J. McBride, M. J. Zehe, S. Gordon
  * NASA/TP-2002-211556, Sept. 2002
  *
- * Nine coefficients @f$(a_0,\dots,a_8)@f$ are used to represent
- * @f$ C_p^0(T)@f$, @f$ H^0(T)@f$, and @f$ S^0(T) @f$ as
+ * Nine coefficients @f$ (a_0,\dots,a_8) @f$ are used to represent
+ * @f$ C_p^0(T) @f$, @f$ H^0(T) @f$, and @f$ S^0(T) @f$ as
  * polynomials in @f$ T @f$ :
  * @f[
  * \frac{C_p^0(T)}{R} = a_0 T^{-2} + a_1 T^{-1} + a_2 + a_3 T

--- a/include/cantera/thermo/Nasa9Poly1.h
+++ b/include/cantera/thermo/Nasa9Poly1.h
@@ -29,24 +29,24 @@ namespace Cantera
  * Individual Species," B. J. McBride, M. J. Zehe, S. Gordon
  * NASA/TP-2002-211556, Sept. 2002
  *
- * Nine coefficients \f$(a_0,\dots,a_8)\f$ are used to represent
- * \f$ C_p^0(T)\f$, \f$ H^0(T)\f$, and \f$ S^0(T) \f$ as
- * polynomials in \f$ T \f$ :
- * \f[
+ * Nine coefficients @f$(a_0,\dots,a_8)@f$ are used to represent
+ * @f$ C_p^0(T)@f$, @f$ H^0(T)@f$, and @f$ S^0(T) @f$ as
+ * polynomials in @f$ T @f$ :
+ * @f[
  * \frac{C_p^0(T)}{R} = a_0 T^{-2} + a_1 T^{-1} + a_2 + a_3 T
  *                  + a_4 T^2 + a_5 T^3 + a_6 T^4
- * \f]
+ * @f]
  *
- * \f[
+ * @f[
  * \frac{H^0(T)}{RT} = - a_0 T^{-2} + a_1 \frac{\ln T}{T} + a_2
  *     + \frac{a_3}{2} T + \frac{a_4}{3} T^2  + \frac{a_5}{4} T^3 +
  *     \frac{a_6}{5} T^4 + \frac{a_7}{T}
- * \f]
+ * @f]
  *
- * \f[
+ * @f[
  * \frac{s^0(T)}{R} = - \frac{a_0}{2} T^{-2} - a_1 T^{-1} + a_2 \ln T
  *    + a_3 T + \frac{a_4}{2} T^2 + \frac{a_5}{3} T^3  + \frac{a_6}{4} T^4 + a_8
- * \f]
+ * @f]
  *
  * The standard state is assumed to be an ideal gas at the standard pressure of
  * 1 bar, for gases. For condensed species, the standard state is the pure

--- a/include/cantera/thermo/NasaPoly1.h
+++ b/include/cantera/thermo/NasaPoly1.h
@@ -27,20 +27,20 @@ namespace Cantera
  * the Chemkin software package, but differs from the form used in the more
  * recent NASA equilibrium program.
  *
- * Seven coefficients \f$(a_0,\dots,a_6)\f$ are used to represent
- * \f$ c_p^0(T)\f$, \f$ h^0(T)\f$, and \f$ s^0(T) \f$ as
- * polynomials in \f$ T \f$ :
- * \f[
+ * Seven coefficients @f$(a_0,\dots,a_6)@f$ are used to represent
+ * @f$ c_p^0(T)@f$, @f$ h^0(T)@f$, and @f$ s^0(T) @f$ as
+ * polynomials in @f$ T @f$ :
+ * @f[
  * \frac{c_p(T)}{R} = a_0 + a_1 T + a_2 T^2 + a_3 T^3 + a_4 T^4
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \frac{h^0(T)}{RT} = a_0 + \frac{a_1}{2} T + \frac{a_2}{3} T^2
  *                   + \frac{a_3}{4} T^3 + \frac{a_4}{5} T^4  + \frac{a_5}{T}.
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \frac{s^0(T)}{R} = a_0\ln T + a_1 T + \frac{a_2}{2} T^2
  *                  + \frac{a_3}{3} T^3 + \frac{a_4}{4} T^4  + a_6.
- * \f]
+ * @f]
  *
  * @ingroup spthermo
  */

--- a/include/cantera/thermo/NasaPoly1.h
+++ b/include/cantera/thermo/NasaPoly1.h
@@ -27,8 +27,8 @@ namespace Cantera
  * the Chemkin software package, but differs from the form used in the more
  * recent NASA equilibrium program.
  *
- * Seven coefficients @f$(a_0,\dots,a_6)@f$ are used to represent
- * @f$ c_p^0(T)@f$, @f$ h^0(T)@f$, and @f$ s^0(T) @f$ as
+ * Seven coefficients @f$ (a_0,\dots,a_6) @f$ are used to represent
+ * @f$ c_p^0(T) @f$, @f$ h^0(T) @f$, and @f$ s^0(T) @f$ as
  * polynomials in @f$ T @f$ :
  * @f[
  * \frac{c_p(T)}{R} = a_0 + a_1 T + a_2 T^2 + a_3 T^3 + a_4 T^4

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -26,20 +26,20 @@ namespace Cantera
  * the Chemkin software package, but differs from the form used in the more
  * recent NASA equilibrium program.
  *
- * Seven coefficients \f$(a_0,\dots,a_6)\f$ are used to represent
- * \f$ c_p^0(T)\f$, \f$ h^0(T)\f$, and \f$ s^0(T) \f$ as
- * polynomials in \f$ T \f$ :
- * \f[
+ * Seven coefficients @f$(a_0,\dots,a_6)@f$ are used to represent
+ * @f$ c_p^0(T)@f$, @f$ h^0(T)@f$, and @f$ s^0(T) @f$ as
+ * polynomials in @f$ T @f$ :
+ * @f[
  * \frac{c_p(T)}{R} = a_0 + a_1 T + a_2 T^2 + a_3 T^3 + a_4 T^4
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \frac{h^0(T)}{RT} = a_0 + \frac{a_1}{2} T + \frac{a_2}{3} T^2
  *                   + \frac{a_3}{4} T^3 + \frac{a_4}{5} T^4  + \frac{a_5}{T}.
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \frac{s^0(T)}{R} = a_0\ln T + a_1 T + \frac{a_2}{2} T^2
  *                  + \frac{a_3}{3} T^3 + \frac{a_4}{4} T^4  + a_6.
- * \f]
+ * @f]
  *
  * This class is designed specifically for use by the class MultiSpeciesThermo.
  *

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -26,8 +26,8 @@ namespace Cantera
  * the Chemkin software package, but differs from the form used in the more
  * recent NASA equilibrium program.
  *
- * Seven coefficients @f$(a_0,\dots,a_6)@f$ are used to represent
- * @f$ c_p^0(T)@f$, @f$ h^0(T)@f$, and @f$ s^0(T) @f$ as
+ * Seven coefficients @f$ (a_0,\dots,a_6) @f$ are used to represent
+ * @f$ c_p^0(T) @f$, @f$ h^0(T) @f$, and @f$ s^0(T) @f$ as
  * polynomials in @f$ T @f$ :
  * @f[
  * \frac{c_p(T)}{R} = a_0 + a_1 T + a_2 T^2 + a_3 T^3 + a_4 T^4

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -337,9 +337,9 @@ public:
     //! Return the volumetric thermal expansion coefficient. Units: 1/K.
     /*!
      * The thermal expansion coefficient is defined as
-     * \f[
+     * @f[
      *     \beta = \frac{1}{v}\left(\frac{\partial v}{\partial T}\right)_P
-     * \f]
+     * @f]
      */
     virtual doublereal thermalExpansionCoeff() const;
     //! @}

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -52,13 +52,13 @@ public:
     /*!
      * @copydoc PDSS::gibbs_RT()
      *
-     * \f[
+     * @f[
      *   \frac{\mu^o_k}{RT} = \sum_{m}{ \alpha_{m , k} \frac{\mu^o_{m}}{RT}} + ( 1 - \delta_{k,sp}) 2.0 \ln{2.0}
-     * \f]
+     * @f]
      *
-     * *m* is the neutral molecule species index. \f$ \alpha_{m , k} \f$ is the
+     * *m* is the neutral molecule species index. @f$ \alpha_{m , k} @f$ is the
      * stoichiometric coefficient for the neutral molecule, *m*, that creates the
-     * thermodynamics for the ionic species  *k*. A factor  \f$ 2.0 \ln{2.0} \f$
+     * thermodynamics for the ionic species  *k*. A factor  @f$ 2.0 \ln{2.0} @f$
      * is added to all ions except for the species ionic species, which in this
      * case is the single anion species, with species index *sp*.
      */

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -45,61 +45,61 @@ namespace Cantera
  * - Temperature polynomial for the standard state volume
  *   - This standard state model is invoked with the keyword "temperature_polynomial".
  *     The standard state volume is considered a function of temperature only.
- *     \f[
+ *     @f[
  *       V^o_k(T,P) = a_0 + a_1 T + a_2 T^2 + a_3 T^3
- *     \f]
+ *     @f]
  *
  * - Temperature polynomial for the standard state density
  *   - This standard state model is invoked with the keyword "density_temperature_polynomial".
  *     The standard state density, which is the inverse of the volume,
  *     is considered a function of temperature only.
- *     \f[
+ *     @f[
  *       {\rho}^o_k(T,P) = \frac{M_k}{V^o_k(T,P)} = a_0 + a_1 T + a_2 T^2 + a_3 T^3
- *     \f]
+ *     @f]
  *
  * ## Specification of Species Standard State Properties
  *
  * The standard molar Gibbs free energy for species *k* is determined from
  * the enthalpy and entropy expressions
  *
- * \f[
+ * @f[
  *            G^o_k(T,P) = H^o_k(T,P) - S^o_k(T,P)
- * \f]
+ * @f]
  *
  * The enthalpy is calculated mostly from the MultiSpeciesThermo object's enthalpy
  * evaluator. The dependence on pressure originates from the Maxwell relation
  *
- * \f[
+ * @f[
  *            {\left(\frac{dH^o_k}{dP}\right)}_T = T  {\left(\frac{dS^o_k}{dP}\right)}_T + V^o_k
- * \f]
+ * @f]
  * which is equal to
  *
- * \f[
+ * @f[
  *            {\left(\frac{dH^o_k}{dP}\right)}_T =  V^o_k -  T  {\left(\frac{dV^o_k}{dT}\right)}_P
- * \f]
+ * @f]
  *
  * The entropy is calculated mostly from the MultiSpeciesThermo objects entropy
  * evaluator. The dependence on pressure originates from the Maxwell relation:
  *
- * \f[
+ * @f[
  *              {\left(\frac{dS^o_k}{dP}\right)}_T =  - {\left(\frac{dV^o_k}{dT}\right)}_P
- * \f]
+ * @f]
  *
  * The standard state constant-pressure heat capacity expression is obtained
  * from taking the temperature derivative of the Maxwell relation involving the
  * enthalpy given above to yield an expression for the pressure dependence of
  * the heat capacity.
  *
- * \f[
+ * @f[
  *            {\left(\frac{d{C}^o_{p,k}}{dP}\right)}_T =  - T  {\left(\frac{{d}^2{V}^o_k}{{dT}^2}\right)}_T
- * \f]
+ * @f]
  *
  * The standard molar Internal Energy for species *k* is determined from the
  * following relation.
  *
- * \f[
+ * @f[
  *            U^o_k(T,P) = H^o_k(T,P) - p V^o_k
- * \f]
+ * @f]
  *
  * An example of the specification of a standard state using a temperature dependent
  * standard state volume is given in the

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -110,22 +110,22 @@ public:
     //! Units: 1/K2.
     /*!
      * The thermal expansion coefficient is defined as
-     * \f[
+     * @f[
      * \beta = \frac{1}{v}\left(\frac{\partial v}{\partial T}\right)_P
-     * \f]
+     * @f]
      */
     virtual doublereal dthermalExpansionCoeffdT() const;
 
     //! Returns the isothermal compressibility. Units: 1/Pa.
     /*!
      * The isothermal compressibility is defined as
-     * \f[
+     * @f[
      * \kappa_T = -\frac{1}{v}\left(\frac{\partial v}{\partial P}\right)_T
-     * \f]
+     * @f]
      *  or
-     * \f[
+     * @f[
      * \kappa_T = \frac{1}{\rho}\left(\frac{\partial \rho}{\partial P}\right)_T
-     * \f]
+     * @f]
      */
     virtual doublereal isothermalCompressibility() const;
 

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -49,56 +49,56 @@ public:
     /*!
      * Since the mass density, temperature, and mass fractions are stored,
      * this method uses these values to implement the
-     * mechanical equation of state \f$ P(T, \rho, Y_1, \dots, Y_K) \f$.
+     * mechanical equation of state @f$ P(T, \rho, Y_1, \dots, Y_K) @f$.
      *
-     * \f[
+     * @f[
      *    P = \frac{RT}{v-b_{mix}}
      *        - \frac{\left(\alpha a\right)_{mix}}{v^2 + 2b_{mix}v - b_{mix}^2}
-     * \f]
+     * @f]
      *
      * where:
      *
-     * \f[
+     * @f[
      *    \alpha = \left[ 1 + \kappa \left(1-T_r^{0.5}\right)\right]^2
-     * \f]
+     * @f]
      *
      *  and
      *
-     * \f[
+     * @f[
      *    \kappa = \left(0.37464 + 1.54226\omega - 0.26992\omega^2\right),
      *        \qquad \qquad \text{For } \omega <= 0.491 \\
      *
      *    \kappa = \left(0.379642 + 1.487503\omega - 0.164423\omega^2 + 0.016667\omega^3 \right),
      *        \qquad \text{For } \omega > 0.491
-     * \f]
+     * @f]
      *
-     * Coefficients \f$ a_{mix}, b_{mix} \f$ and \f$(a \alpha)_{mix}\f$ are calculated as
+     * Coefficients @f$ a_{mix}, b_{mix} @f$ and @f$(a \alpha)_{mix}@f$ are calculated as
      *
-     * \f[
+     * @f[
      *    a_{mix} = \sum_i \sum_j X_i X_j a_{i, j} = \sum_i \sum_j X_i X_j \sqrt{a_i a_j}
-     * \f]
+     * @f]
      *
-     * \f[
+     * @f[
      *    b_{mix} = \sum_i X_i b_i
-     * \f]
+     * @f]
      *
-     * \f[
+     * @f[
      *   {a \alpha}_{mix} = \sum_i \sum_j X_i X_j {a \alpha}_{i, j}
      *       = \sum_i \sum_j X_i X_j \sqrt{a_i a_j} \sqrt{\alpha_i \alpha_j}
-     * \f]
+     * @f]
      */
     virtual double pressure() const;
 
     //! @}
 
-    //! Returns the standard concentration \f$ C^0_k \f$, which is used to
+    //! Returns the standard concentration @f$ C^0_k @f$, which is used to
     //! normalize the generalized concentration.
     /*!
      * This is defined as the concentration by which the generalized
      * concentration is normalized to produce the activity.
      * The ideal gas mixture is considered as the standard or reference state here.
      * Since the activity for an ideal gas mixture is simply the mole fraction,
-     * for an ideal gas,  \f$ C^0_k = P/\hat R T \f$.
+     * for an ideal gas,  @f$ C^0_k = P/\hat R T @f$.
      *
      * @param k Optional parameter indicating the species. The default is to
      *          assume this refers to species 0.
@@ -136,7 +136,7 @@ public:
     //! Calculate species-specific critical temperature
     /*!
      *  The temperature dependent parameter in P-R EoS is calculated as
-     * \f[ T_{crit} = (0.0778 a)/(0.4572 b R) \f]
+     * @f[ T_{crit} = (0.0778 a)/(0.4572 b R) @f]
      *  Units: Kelvin
      *
      * @param a    species-specific coefficients used in P-R EoS
@@ -160,8 +160,8 @@ public:
     //! Set the pure fluid interaction parameters for a species
     /*!
      *  @param species   Name of the species
-     *  @param a         \f$a\f$ parameter in the Peng-Robinson model [Pa-m^6/kmol^2]
-     *  @param b         \f$a\f$ parameter in the Peng-Robinson model [m^3/kmol]
+     *  @param a         @f$a@f$ parameter in the Peng-Robinson model [Pa-m^6/kmol^2]
+     *  @param b         @f$a@f$ parameter in the Peng-Robinson model [m^3/kmol]
      *  @param w         acentric factor
      */
     void setSpeciesCoeffs(const std::string& species, double a, double b,
@@ -171,7 +171,7 @@ public:
     /*!
      *  @param species_i   Name of one species
      *  @param species_j   Name of the other species
-     *  @param a           \f$a\f$ parameter in the Peng-Robinson model [Pa-m^6/kmol^2]
+     *  @param a           @f$a@f$ parameter in the Peng-Robinson model [Pa-m^6/kmol^2]
      */
     void setBinaryCoeffs(const std::string& species_i,
                          const std::string& species_j, double a);
@@ -191,13 +191,13 @@ protected:
 
     // Special functions not inherited from MixtureFugacityTP
 
-    //! Calculate temperature derivative \f$d(a \alpha)/dT\f$
+    //! Calculate temperature derivative @f$d(a \alpha)/dT@f$
     /*!
      *  These are stored internally.
      */
     double daAlpha_dT() const;
 
-    //! Calculate second derivative \f$d^2(a \alpha)/dT^2\f$
+    //! Calculate second derivative @f$d^2(a \alpha)/dT^2@f$
     /*!
      *  These are stored internally.
      */
@@ -209,21 +209,21 @@ public:
     virtual double thermalExpansionCoeff() const;
     virtual double soundSpeed() const;
 
-    //! Calculate \f$dp/dV\f$ and \f$dp/dT\f$ at the current conditions
+    //! Calculate @f$dp/dV@f$ and @f$dp/dT@f$ at the current conditions
     /*!
      *  These are stored internally.
      */
     void calculatePressureDerivatives() const;
 
-    //! Update the \f$a\f$, \f$b\f$, and \f$\alpha\f$ parameters
+    //! Update the @f$a@f$, @f$b@f$, and @f$\alpha@f$ parameters
     /*!
-     *  The \f$a\f$ and the \f$b\f$ parameters depend on the mole fraction and the
-     *  parameter \f$\alpha\f$ depends on the temperature. This function updates
+     *  The @f$a@f$ and the @f$b@f$ parameters depend on the mole fraction and the
+     *  parameter @f$\alpha@f$ depends on the temperature. This function updates
      *  the internal numbers based on the state of the object.
      */
     virtual void updateMixingExpressions();
 
-    //! Calculate the \f$a\f$, \f$b\f$, and \f$\alpha\f$ parameters given the temperature
+    //! Calculate the @f$a@f$, @f$b@f$, and @f$\alpha@f$ parameters given the temperature
     /*!
      * This function doesn't change the internal state of the object, so it is a
      * const function.  It does use the stored mole fractions in the object.
@@ -240,19 +240,19 @@ public:
     int solveCubic(double T, double pres, double a, double b, double aAlpha,
                    double Vroot[3]) const;
 protected:
-    //! Value of \f$b\f$ in the equation of state
+    //! Value of @f$b@f$ in the equation of state
     /*!
      *  `m_b` is a function of the mole fractions and species-specific b values.
      */
     double m_b = 0.0;
 
-    //! Value of \f$a\f$ in the equation of state
+    //! Value of @f$a@f$ in the equation of state
     /*!
      *  `m_a` depends only on the mole fractions.
      */
     double m_a = 0.0;
 
-    //! Value of \f$a \alpha\f$ in the equation of state
+    //! Value of @f$a \alpha@f$ in the equation of state
     /*!
      *  `m_aAlpha_mix` is a function of the temperature and the mole fractions.
      */

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -72,7 +72,7 @@ public:
      *        \qquad \text{For } \omega > 0.491
      * @f]
      *
-     * Coefficients @f$ a_{mix}, b_{mix} @f$ and @f$(a \alpha)_{mix}@f$ are calculated as
+     * Coefficients @f$ a_{mix}, b_{mix} @f$ and @f$ (a \alpha)_{mix} @f$ are calculated as
      *
      * @f[
      *    a_{mix} = \sum_i \sum_j X_i X_j a_{i, j} = \sum_i \sum_j X_i X_j \sqrt{a_i a_j}
@@ -160,8 +160,8 @@ public:
     //! Set the pure fluid interaction parameters for a species
     /*!
      *  @param species   Name of the species
-     *  @param a         @f$a@f$ parameter in the Peng-Robinson model [Pa-m^6/kmol^2]
-     *  @param b         @f$a@f$ parameter in the Peng-Robinson model [m^3/kmol]
+     *  @param a         @f$ a @f$ parameter in the Peng-Robinson model [Pa-m^6/kmol^2]
+     *  @param b         @f$ a @f$ parameter in the Peng-Robinson model [m^3/kmol]
      *  @param w         acentric factor
      */
     void setSpeciesCoeffs(const std::string& species, double a, double b,
@@ -171,7 +171,7 @@ public:
     /*!
      *  @param species_i   Name of one species
      *  @param species_j   Name of the other species
-     *  @param a           @f$a@f$ parameter in the Peng-Robinson model [Pa-m^6/kmol^2]
+     *  @param a           @f$ a @f$ parameter in the Peng-Robinson model [Pa-m^6/kmol^2]
      */
     void setBinaryCoeffs(const std::string& species_i,
                          const std::string& species_j, double a);
@@ -191,13 +191,13 @@ protected:
 
     // Special functions not inherited from MixtureFugacityTP
 
-    //! Calculate temperature derivative @f$d(a \alpha)/dT@f$
+    //! Calculate temperature derivative @f$ d(a \alpha)/dT @f$
     /*!
      *  These are stored internally.
      */
     double daAlpha_dT() const;
 
-    //! Calculate second derivative @f$d^2(a \alpha)/dT^2@f$
+    //! Calculate second derivative @f$ d^2(a \alpha)/dT^2 @f$
     /*!
      *  These are stored internally.
      */
@@ -209,21 +209,21 @@ public:
     virtual double thermalExpansionCoeff() const;
     virtual double soundSpeed() const;
 
-    //! Calculate @f$dp/dV@f$ and @f$dp/dT@f$ at the current conditions
+    //! Calculate @f$ dp/dV @f$ and @f$ dp/dT @f$ at the current conditions
     /*!
      *  These are stored internally.
      */
     void calculatePressureDerivatives() const;
 
-    //! Update the @f$a@f$, @f$b@f$, and @f$\alpha@f$ parameters
+    //! Update the @f$ a @f$, @f$ b @f$, and @f$ \alpha @f$ parameters
     /*!
-     *  The @f$a@f$ and the @f$b@f$ parameters depend on the mole fraction and the
-     *  parameter @f$\alpha@f$ depends on the temperature. This function updates
+     *  The @f$ a @f$ and the @f$ b @f$ parameters depend on the mole fraction and the
+     *  parameter @f$ \alpha @f$ depends on the temperature. This function updates
      *  the internal numbers based on the state of the object.
      */
     virtual void updateMixingExpressions();
 
-    //! Calculate the @f$a@f$, @f$b@f$, and @f$\alpha@f$ parameters given the temperature
+    //! Calculate the @f$ a @f$, @f$ b @f$, and @f$ \alpha @f$ parameters given the temperature
     /*!
      * This function doesn't change the internal state of the object, so it is a
      * const function.  It does use the stored mole fractions in the object.
@@ -240,19 +240,19 @@ public:
     int solveCubic(double T, double pres, double a, double b, double aAlpha,
                    double Vroot[3]) const;
 protected:
-    //! Value of @f$b@f$ in the equation of state
+    //! Value of @f$ b @f$ in the equation of state
     /*!
      *  `m_b` is a function of the mole fractions and species-specific b values.
      */
     double m_b = 0.0;
 
-    //! Value of @f$a@f$ in the equation of state
+    //! Value of @f$ a @f$ in the equation of state
     /*!
      *  `m_a` depends only on the mole fractions.
      */
     double m_a = 0.0;
 
-    //! Value of @f$a \alpha@f$ in the equation of state
+    //! Value of @f$ a \alpha @f$ in the equation of state
     /*!
      *  `m_aAlpha_mix` is a function of the temperature and the mole fractions.
      */

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -599,15 +599,15 @@ public:
 
     //! Elemental mass fraction of element m
     /*!
-     *  The elemental mass fraction @f$Z_{\mathrm{mass},m}@f$ of element @f$m@f$
+     *  The elemental mass fraction @f$ Z_{\mathrm{mass},m} @f$ of element @f$ m @f$
      *  is defined as
      *  @f[
      *      Z_{\mathrm{mass},m} = \sum_k \frac{a_{m,k} M_m}{M_k} Y_k
      *  @f]
-     *  with @f$a_{m,k}@f$ being the number of atoms of element @f$m@f$ in
-     *  species @f$k@f$, @f$M_m@f$ the atomic weight of element @f$m@f$,
-     *  @f$M_k@f$ the molecular weight of species @f$k@f$, and @f$Y_k@f$
-     *  the mass fraction of species @f$k@f$.
+     *  with @f$ a_{m,k} @f$ being the number of atoms of element @f$ m @f$ in
+     *  species @f$ k @f$, @f$ M_m @f$ the atomic weight of element @f$ m @f$,
+     *  @f$ M_k @f$ the molecular weight of species @f$ k @f$, and @f$ Y_k @f$
+     *  the mass fraction of species @f$ k @f$.
      *
      *  @param[in] m Index of the element within the phase. If m is outside
      *               the valid range, an exception will be thrown.
@@ -618,7 +618,7 @@ public:
 
     //! Elemental mole fraction of element m
     /*!
-     *  The elemental mole fraction @f$Z_{\mathrm{mole},m}@f$ of element @f$m@f$
+     *  The elemental mole fraction @f$ Z_{\mathrm{mole},m} @f$ of element @f$ m @f$
      *  is the number of atoms of element *m* divided by the total number of
      *  atoms. It is defined as:
      *
@@ -626,9 +626,9 @@ public:
      *      Z_{\mathrm{mole},m} = \frac{\sum_k a_{m,k} X_k}
      *                                 {\sum_k \sum_j a_{j,k} X_k}
      *  @f]
-     *  with @f$a_{m,k}@f$ being the number of atoms of element @f$m@f$ in
-     *  species @f$k@f$, @f$\sum_j@f$ being a sum over all elements, and
-     *  @f$X_k@f$ being the mole fraction of species @f$k@f$.
+     *  with @f$ a_{m,k} @f$ being the number of atoms of element @f$ m @f$ in
+     *  species @f$ k @f$, @f$ \sum_j @f$ being a sum over all elements, and
+     *  @f$ X_k @f$ being the mole fraction of species @f$ k @f$.
      *
      *  @param[in] m Index of the element within the phase. If m is outside the
      *               valid range, an exception will be thrown.

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -47,7 +47,7 @@ class Species;
  * It also stores an array of species molecular weights, which are used to
  * convert between mole and mass representations of the composition. For
  * efficiency in mass/mole conversion, the vector of mass fractions divided
- * by molecular weight \f$ Y_k/M_k \f$ is also stored.
+ * by molecular weight @f$ Y_k/M_k @f$ is also stored.
  *
  * Class Phase is not usually used directly. Its primary use is as a base class
  * for class ThermoPhase. It is not generally necessary to overloaded any of
@@ -599,15 +599,15 @@ public:
 
     //! Elemental mass fraction of element m
     /*!
-     *  The elemental mass fraction \f$Z_{\mathrm{mass},m}\f$ of element \f$m\f$
+     *  The elemental mass fraction @f$Z_{\mathrm{mass},m}@f$ of element @f$m@f$
      *  is defined as
-     *  \f[
+     *  @f[
      *      Z_{\mathrm{mass},m} = \sum_k \frac{a_{m,k} M_m}{M_k} Y_k
-     *  \f]
-     *  with \f$a_{m,k}\f$ being the number of atoms of element \f$m\f$ in
-     *  species \f$k\f$, \f$M_m\f$ the atomic weight of element \f$m\f$,
-     *  \f$M_k\f$ the molecular weight of species \f$k\f$, and \f$Y_k\f$
-     *  the mass fraction of species \f$k\f$.
+     *  @f]
+     *  with @f$a_{m,k}@f$ being the number of atoms of element @f$m@f$ in
+     *  species @f$k@f$, @f$M_m@f$ the atomic weight of element @f$m@f$,
+     *  @f$M_k@f$ the molecular weight of species @f$k@f$, and @f$Y_k@f$
+     *  the mass fraction of species @f$k@f$.
      *
      *  @param[in] m Index of the element within the phase. If m is outside
      *               the valid range, an exception will be thrown.
@@ -618,17 +618,17 @@ public:
 
     //! Elemental mole fraction of element m
     /*!
-     *  The elemental mole fraction \f$Z_{\mathrm{mole},m}\f$ of element \f$m\f$
+     *  The elemental mole fraction @f$Z_{\mathrm{mole},m}@f$ of element @f$m@f$
      *  is the number of atoms of element *m* divided by the total number of
      *  atoms. It is defined as:
      *
-     *  \f[
+     *  @f[
      *      Z_{\mathrm{mole},m} = \frac{\sum_k a_{m,k} X_k}
      *                                 {\sum_k \sum_j a_{j,k} X_k}
-     *  \f]
-     *  with \f$a_{m,k}\f$ being the number of atoms of element \f$m\f$ in
-     *  species \f$k\f$, \f$\sum_j\f$ being a sum over all elements, and
-     *  \f$X_k\f$ being the mole fraction of species \f$k\f$.
+     *  @f]
+     *  with @f$a_{m,k}@f$ being the number of atoms of element @f$m@f$ in
+     *  species @f$k@f$, @f$\sum_j@f$ being a sum over all elements, and
+     *  @f$X_k@f$ being the mole fraction of species @f$k@f$.
      *
      *  @param[in] m Index of the element within the phase. If m is outside the
      *               valid range, an exception will be thrown.
@@ -685,8 +685,8 @@ public:
      *  This method must be overloaded in derived classes. Within %Cantera, the
      *  independent variable is either density or pressure. If the state is
      *  defined by temperature, density, and mass fractions, this method should
-     *  use these values to implement the mechanical equation of state \f$ P(T,
-     *  \rho, Y_1, \dots, Y_K) \f$. Alternatively, it returns a stored value.
+     *  use these values to implement the mechanical equation of state @f$ P(T,
+     *  \rho, Y_1, \dots, Y_K) @f$. Alternatively, it returns a stored value.
      */
     virtual double pressure() const {
         throw NotImplementedError("Phase::pressure",
@@ -758,7 +758,7 @@ public:
     //! @{
 
     //! Evaluate the mole-fraction-weighted mean of an array Q.
-    //! \f[ \sum_k X_k Q_k. \f]
+    //! @f[ \sum_k X_k Q_k. @f]
     //! Q should contain pure-species molar property values.
     //!     @param[in] Q Array of length m_kk that is to be averaged.
     //!     @return mole-fraction-weighted mean of Q
@@ -772,7 +772,7 @@ public:
         return m_mmw;
     }
 
-    //! Evaluate \f$ \sum_k X_k \log X_k \f$.
+    //! Evaluate @f$ \sum_k X_k \log X_k @f$.
     //! @return The indicated sum. Dimensionless.
     doublereal sum_xlogx() const;
 

--- a/include/cantera/thermo/PlasmaPhase.h
+++ b/include/cantera/thermo/PlasmaPhase.h
@@ -180,7 +180,7 @@ public:
 
     /**
      * Electron pressure. Units: Pa.
-     * @f[P = n_{k_e} R T_e@f]
+     * @f[P = n_{k_e} R T_e @f]
      */
     virtual double electronPressure() const {
         return GasConstant * concentration(m_electronSpeciesIndex) *

--- a/include/cantera/thermo/PlasmaPhase.h
+++ b/include/cantera/thermo/PlasmaPhase.h
@@ -24,25 +24,25 @@ namespace Cantera
  * distribution with isotropic-velocity model. The generalized electron
  * energy distribution for isotropic-velocity distribution can be
  * expressed as [1,2],
- *   \f[
+ *   @f[
  *          f(\epsilon) = c_1 \frac{\sqrt{\epsilon}}{\epsilon_m^{3/2}}
  *          \exp(-c_2 (\frac{\epsilon}{\epsilon_m})^x),
- *   \f]
- * where \f$ x = 1 \f$ and \f$ x = 2 \f$ correspond to the Maxwellian and
+ *   @f]
+ * where @f$ x = 1 @f$ and @f$ x = 2 @f$ correspond to the Maxwellian and
  * Druyvesteyn (default) electron energy distribution, respectively.
- * \f$ \epsilon_m = 3/2 T_e \f$ [eV] (mean electron energy). The second
+ * @f$ \epsilon_m = 3/2 T_e @f$ [eV] (mean electron energy). The second
  * method uses setDiscretizedElectronEnergyDist() to manually set electron
  * energy distribution and calculate electron temperature from mean electron
  * energy, which is calculated as [3],
- *   \f[
+ *   @f[
  *          \epsilon_m = \int_0^{\infty} \epsilon^{3/2} f(\epsilon) d\epsilon,
- *   \f]
+ *   @f]
  * which can be calculated using trapezoidal rule,
- *   \f[
+ *   @f[
  *          \epsilon_m = \sum_i (\epsilon^{5/2}_{i+1} - \epsilon^{5/2}_i)
  *                       (f(\epsilon_{i+1}) + f(\epsilon_i)) / 2,
- *   \f]
- * where \f$ i \f$ is the index of energy levels.
+ *   @f]
+ * where @f$ i @f$ is the index of energy levels.
  *
  * For references, see Gudmundsson @cite gudmundsson2001; Khalilpour and Foroutan
  * @cite khalilpour2020; Hagelaar and Pitchford @cite hagelaar2005, and BOLOS
@@ -108,7 +108,7 @@ public:
     }
 
     //! Set the shape factor of isotropic electron energy distribution.
-    //! Note that \f$ x = 1 \f$ and \f$ x = 2 \f$ correspond to the
+    //! Note that @f$ x = 1 @f$ and @f$ x = 2 @f$ correspond to the
     //! Maxwellian and Druyvesteyn distribution, respectively.
     //! @param  x The shape factor
     void setIsotropicShapeFactor(double x);
@@ -180,7 +180,7 @@ public:
 
     /**
      * Electron pressure. Units: Pa.
-     * \f[P = n_{k_e} R T_e\f]
+     * @f[P = n_{k_e} R T_e@f]
      */
     virtual double electronPressure() const {
         return GasConstant * concentration(m_electronSpeciesIndex) *
@@ -200,11 +200,11 @@ public:
     //! Return the Molar enthalpy. Units: J/kmol.
     /*!
      * For an ideal gas mixture with additional electron,
-     * \f[
+     * @f[
      * \hat h(T) = \sum_{k \neq k_e} X_k \hat h^0_k(T) + X_{k_e} \hat h^0_{k_e}(T_e),
-     * \f]
+     * @f]
      * and is a function only of temperature. The standard-state pure-species
-     * enthalpies \f$ \hat h^0_k(T) \f$ are computed by the species
+     * enthalpies @f$ \hat h^0_k(T) @f$ are computed by the species
      * thermodynamic property manager.
      *
      * \see MultiSpeciesThermo

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -133,7 +133,7 @@ namespace Cantera
  *
  * ## Application within Kinetics Managers
  *
- * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where
+ * @f$ C^a_k @f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where
  * @f$ C^s_k @f$ is a standard concentration defined below and @f$ a_k @f$ are
  * activities used in the thermodynamic functions.  These activity (or
  * generalized) concentrations are used by kinetics manager classes to compute
@@ -225,7 +225,7 @@ namespace Cantera
  *     k^{-1} =  k^1 K^1_c
  * @f]
  *
- * @f$k^{-1} @f$ has units of s-1.
+ * @f$ k^{-1} @f$ has units of s-1.
  *
  * @ingroup thermoprops
  */
@@ -257,9 +257,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is
+    //! The activity @f$ a_k @f$ of a species in solution is
     //! related to the chemical potential by @f[ \mu_k = \mu_k^0(T)
-    //! + \hat R T \log a_k. @f] The quantity @f$\mu_k^0(T,P)@f$ is
+    //! + \hat R T \log a_k. @f] The quantity @f$ \mu_k^0(T,P) @f$ is
     //! the chemical potential at unit activity, which depends only
     //! on temperature and pressure.
     //! @{

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -41,191 +41,191 @@ namespace Cantera
  * the generalization of the Redlich-Kister formulation for a phase that has
  * more than 2 species.
  *
- * \f[
+ * @f[
  *     G^E = \sum_{i} G^E_{i}
- * \f]
+ * @f]
  *
  * where
  *
- * \f[
+ * @f[
  *    G^E_{i} =   n X_{Ai} X_{Bi} \sum_m \left( A^{i}_m {\left( X_{Ai} -  X_{Bi} \right)}^m \right)
- * \f]
+ * @f]
  *
  * where n is the total moles in the solution and where we can break down the Gibbs free
  * energy contributions into enthalpy and entropy contributions by defining
- * \f$ A^i_m = H^i_m - T S^i_m \f$ :
+ * @f$ A^i_m = H^i_m - T S^i_m @f$ :
  *
- * \f[
+ * @f[
  *    H^E_i = n X_{Ai} X_{Bi} \sum_m \left( H^{i}_m {\left( X_{Ai} -  X_{Bi} \right)}^m \right)
- * \f]
+ * @f]
  *
- * \f[
+ * @f[
  *    S^E_i = n X_{Ai} X_{Bi} \sum_m \left( S^{i}_m {\left( X_{Ai} -  X_{Bi} \right)}^m \right)
- * \f]
+ * @f]
  *
  * The activity of a species defined in the phase is given by an excess Gibbs free
  * energy formulation:
  *
- * \f[
+ * @f[
  *      a_k = \gamma_k  X_k
- * \f]
+ * @f]
  *
  * where
  *
- * \f[
+ * @f[
  *      R T \ln( \gamma_k )= \frac{d(n G^E)}{d(n_k)}\Bigg|_{n_i}
- * \f]
+ * @f]
  *
  * Taking the derivatives results in the following expression
- * \f[
+ * @f[
  *      R T \ln( \gamma_k )=  \sum_i \delta_{Ai,k} (1 - X_{Ai}) X_{Bi} \sum_m \left( A^{i}_m {\left( X_{Ai} -  X_{Bi} \right)}^m \right)
  *                           + \sum_i \delta_{Ai,k} X_{Ai} X_{Bi} \sum_m \left(  A^{i}_0 +  A^{i}_m {\left( X_{Ai} -  X_{Bi} \right)}^{m-1} (1 - X_{Ai} + X_{Bi}) \right)
- * \f]
+ * @f]
  *
  * Evaluating thermodynamic properties requires the following derivatives of
- * \f$ \ln(\gamma_k) \f$:
+ * @f$ \ln(\gamma_k) @f$:
  *
- * \f[
+ * @f[
  *    \frac{d \ln( \gamma_k )}{dT} = - \frac{1}{RT^2} \left( \sum_i \delta_{Ai,k} (1 - X_{Ai}) X_{Bi} \sum_m \left( H^{i}_m {\left( X_{Ai} -  X_{Bi} \right)}^m \right)
  *        + \sum_i \delta_{Ai,k} X_{Ai} X_{Bi} \sum_m \left(  H^{i}_0 +  H^{i}_m {\left( X_{Ai} -  X_{Bi} \right)}^{m-1} (1 - X_{Ai} + X_{Bi}) \right) \right)
- * \f]
+ * @f]
  *
  * and
  *
- * \f[
+ * @f[
  *    \frac{d^2 \ln( \gamma_k )}{dT^2} = -\frac{2}{T} \frac{d \ln( \gamma_k )}{dT}
- * \f]
+ * @f]
  *
  * This object inherits from the class VPStandardStateTP. Therefore, the
  * specification and calculation of all standard state and reference state
  * values are handled at that level. Various functional forms for the standard
  * state are permissible. The chemical potential for species *k* is equal to
  *
- * \f[
+ * @f[
  *      \mu_k(T,P) = \mu^o_k(T, P) + R T \ln(\gamma_k X_k)
- * \f]
+ * @f]
  *
  * The partial molar entropy for species *k* is given by the following relation,
  *
- * \f[
+ * @f[
  *       \tilde{s}_k(T,P) =  s^o_k(T,P)  - R \ln( \gamma_k X_k )
  *              - R T \frac{d \ln(\gamma_k) }{dT}
- * \f]
+ * @f]
  *
  * The partial molar enthalpy for species *k* is given by
  *
- * \f[
+ * @f[
  *      \tilde{h}_k(T,P) = h^o_k(T,P) - R T^2 \frac{d \ln(\gamma_k)}{dT}
- * \f]
+ * @f]
  *
  * The partial molar volume for species *k* is
  *
- * \f[
+ * @f[
  *        \tilde V_k(T,P)  = V^o_k(T,P)  + R T \frac{d \ln(\gamma_k) }{dP}
- * \f]
+ * @f]
  *
  * The partial molar Heat Capacity for species *k* is
  *
- * \f[
+ * @f[
  *      \tilde{C}_{p,k}(T,P) = C^o_{p,k}(T,P)   - 2 R T \frac{d \ln( \gamma_k )}{dT}
  *              - R T^2 \frac{d^2 \ln(\gamma_k) }{{dT}^2} = C^o_{p,k}(T,P)
- * \f]
+ * @f]
  *
  * ## Application within Kinetics Managers
  *
- * \f$ C^a_k\f$ are defined such that \f$ a_k = C^a_k / C^s_k, \f$ where
- * \f$ C^s_k \f$ is a standard concentration defined below and \f$ a_k \f$ are
+ * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^s_k, @f$ where
+ * @f$ C^s_k @f$ is a standard concentration defined below and @f$ a_k @f$ are
  * activities used in the thermodynamic functions.  These activity (or
  * generalized) concentrations are used by kinetics manager classes to compute
  * the forward and reverse rates of elementary reactions. The activity
- * concentration,\f$  C^a_k \f$,is given by the following expression.
+ * concentration,@f$  C^a_k @f$,is given by the following expression.
  *
- * \f[
+ * @f[
  *      C^a_k = C^s_k  X_k  = \frac{P}{R T} X_k
- * \f]
+ * @f]
  *
  * The standard concentration for species *k* is independent of *k* and equal to
  *
- * \f[
+ * @f[
  *     C^s_k =  C^s = \frac{P}{R T}
- * \f]
+ * @f]
  *
  * For example, a bulk-phase binary gas reaction between species j and k,
  * producing a new gas species l would have the following equation for its rate
- * of progress variable, \f$ R^1 \f$, which has units of kmol m-3 s-1.
+ * of progress variable, @f$ R^1 @f$, which has units of kmol m-3 s-1.
  *
- * \f[
+ * @f[
  *    R^1 = k^1 C_j^a C_k^a =  k^1 (C^s a_j) (C^s a_k)
- * \f]
+ * @f]
  * where
- * \f[
+ * @f[
  *    C_j^a = C^s a_j \mbox{\quad and \quad} C_k^a = C^s a_k
- * \f]
+ * @f]
  *
- * \f$ C_j^a \f$ is the activity concentration of species j, and \f$ C_k^a \f$
- * is the activity concentration of species k. \f$ C^s \f$ is the standard
- * concentration. \f$ a_j \f$ is the activity of species j which is equal to the
+ * @f$ C_j^a @f$ is the activity concentration of species j, and @f$ C_k^a @f$
+ * is the activity concentration of species k. @f$ C^s @f$ is the standard
+ * concentration. @f$ a_j @f$ is the activity of species j which is equal to the
  * mole fraction of j.
  *
  * The reverse rate constant can then be obtained from the law of microscopic
  * reversibility and the equilibrium expression for the system.
  *
- * \f[
+ * @f[
  *       \frac{a_j a_k}{ a_l} = K_a^{o,1} = \exp(\frac{\mu^o_l - \mu^o_j - \mu^o_k}{R T} )
- * \f]
+ * @f]
  *
- * \f$ K_a^{o,1} \f$ is the dimensionless form of the equilibrium constant,
- * associated with the pressure dependent standard states \f$ \mu^o_l(T,P) \f$
- * and their associated activities, \f$ a_l \f$, repeated here:
+ * @f$ K_a^{o,1} @f$ is the dimensionless form of the equilibrium constant,
+ * associated with the pressure dependent standard states @f$ \mu^o_l(T,P) @f$
+ * and their associated activities, @f$ a_l @f$, repeated here:
  *
- * \f[
+ * @f[
  *      \mu_l(T,P) = \mu^o_l(T, P) + R T \log(a_l)
- * \f]
+ * @f]
  *
  * We can switch over to expressing the equilibrium constant in terms of the
  * reference state chemical potentials
  *
- * \f[
+ * @f[
  *     K_a^{o,1} = \exp(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} ) * \frac{P_{ref}}{P}
- * \f]
+ * @f]
  *
- * The concentration equilibrium constant, \f$ K_c \f$, may be obtained by
+ * The concentration equilibrium constant, @f$ K_c @f$, may be obtained by
  * changing over to activity concentrations. When this is done:
  *
- * \f[
+ * @f[
  *     \frac{C^a_j C^a_k}{ C^a_l} = C^o K_a^{o,1} = K_c^1 =
  *         \exp(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} ) * \frac{P_{ref}}{RT}
- * \f]
+ * @f]
  *
- * %Kinetics managers will calculate the concentration equilibrium constant, \f$
- * K_c \f$, using the second and third part of the above expression as a
+ * %Kinetics managers will calculate the concentration equilibrium constant, @f$
+ * K_c @f$, using the second and third part of the above expression as a
  * definition for the concentration equilibrium constant.
  *
  * For completeness, the pressure equilibrium constant may be obtained as well
  *
- * \f[
+ * @f[
  *     \frac{P_j P_k}{ P_l P_{ref}} = K_p^1 = \exp(\frac{\mu^{ref}_l - \mu^{ref}_j - \mu^{ref}_k}{R T} )
- * \f]
+ * @f]
  *
- * \f$ K_p \f$ is the simplest form of the equilibrium constant for ideal gases.
+ * @f$ K_p @f$ is the simplest form of the equilibrium constant for ideal gases.
  * However, it isn't necessarily the simplest form of the equilibrium constant
- * for other types of phases; \f$ K_c \f$ is used instead because it is
+ * for other types of phases; @f$ K_c @f$ is used instead because it is
  * completely general.
  *
  * The reverse rate of progress may be written down as
- * \f[
+ * @f[
  *    R^{-1} = k^{-1} C_l^a =  k^{-1} (C^o a_l)
- * \f]
+ * @f]
  *
  * where we can use the concept of microscopic reversibility to write the
  * reverse rate constant in terms of the forward rate constant and the
- * concentration equilibrium constant, \f$ K_c \f$.
+ * concentration equilibrium constant, @f$ K_c @f$.
  *
- * \f[
+ * @f[
  *     k^{-1} =  k^1 K^1_c
- * \f]
+ * @f]
  *
- * \f$k^{-1} \f$ has units of s-1.
+ * @f$k^{-1} @f$ has units of s-1.
  *
  * @ingroup thermoprops
  */
@@ -257,9 +257,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is
-    //! related to the chemical potential by \f[ \mu_k = \mu_k^0(T)
-    //! + \hat R T \log a_k. \f] The quantity \f$\mu_k^0(T,P)\f$ is
+    //! The activity @f$a_k@f$ of a species in solution is
+    //! related to the chemical potential by @f[ \mu_k = \mu_k^0(T)
+    //! + \hat R T \log a_k. @f] The quantity @f$\mu_k^0(T,P)@f$ is
     //! the chemical potential at unit activity, which depends only
     //! on temperature and pressure.
     //! @{
@@ -281,9 +281,9 @@ public:
      * state enthalpies modified by the derivative of the molality-based
      * activity coefficient wrt temperature
      *
-     *  \f[
+     *  @f[
      *   \bar h_k(T,P) = h^o_k(T,P) - R T^2 \frac{d \ln(\gamma_k)}{dT}
-     *  \f]
+     *  @f]
      *
      * @param hbar  Vector of returned partial molar enthalpies
      *              (length m_kk, units = J/kmol)
@@ -297,10 +297,10 @@ public:
      * state entropies modified by the derivative of the activity coefficient
      * with respect to temperature:
      *
-     *  \f[
+     *  @f[
      *   \bar s_k(T,P) = s^o_k(T,P) - R \ln( \gamma_k X_k)
      *                              - R T \frac{d \ln(\gamma_k) }{dT}
-     *  \f]
+     *  @f]
      *
      * @param sbar  Vector of returned partial molar entropies
      *              (length m_kk, units = J/kmol/K)
@@ -315,9 +315,9 @@ public:
      * For this phase, the partial molar heat capacities are equal to the standard
      * state heat capacities:
      *
-     * \f[
+     * @f[
      *      \tilde{C}_{p,k}(T,P) = C^o_{p,k}(T,P)
-     * \f]
+     * @f]
      *
      * @param cpbar  Vector of returned partial molar heat capacities
      *              (length m_kk, units = J/kmol/K)

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -45,11 +45,11 @@ public:
     /*!
      *  Since the mass density, temperature, and mass fractions are stored,
      *  this method uses these values to implement the
-     *  mechanical equation of state \f$ P(T, \rho, Y_1, \dots, Y_K) \f$.
+     *  mechanical equation of state @f$ P(T, \rho, Y_1, \dots, Y_K) @f$.
      *
-     * \f[
+     * @f[
      *    P = \frac{RT}{v-b_{mix}} - \frac{a_{mix}}{T^{0.5} v \left( v + b_{mix} \right) }
-     * \f]
+     * @f]
      */
     virtual doublereal pressure() const;
 
@@ -57,14 +57,14 @@ public:
 
 public:
 
-    //! Returns the standard concentration \f$ C^0_k \f$, which is used to
+    //! Returns the standard concentration @f$ C^0_k @f$, which is used to
     //! normalize the generalized concentration.
     /*!
      * This is defined as the concentration by which the generalized
      * concentration is normalized to produce the activity. In many cases, this
      * quantity will be the same for all species in a phase. Since the activity
      * for an ideal gas mixture is simply the mole fraction, for an ideal gas
-     * \f$ C^0_k = P/\hat R T \f$.
+     * @f$ C^0_k = P/\hat R T @f$.
      *
      * @param k Optional parameter indicating the species. The default is to
      *          assume this refers to species 0.
@@ -90,7 +90,7 @@ public:
     //! Get the array of non-dimensional species chemical potentials.
     //! These are partial molar Gibbs free energies.
     /*!
-     * \f$ \mu_k / \hat R T \f$.
+     * @f$ \mu_k / \hat R T @f$.
      * Units: unitless
      *
      * We close the loop on this function, here, calling getChemPotentials() and
@@ -130,7 +130,7 @@ public:
     /*!
      *  The "a" parameter for species *i* in the Redlich-Kwong model is assumed
      *  to be a linear function of temperature:
-     *  \f[ a = a_0 + a_1 T \f]
+     *  @f[ a = a_0 + a_1 T @f]
      *
      *  @param species   Name of the species
      *  @param a0        constant term in the expression for the "a" parameter
@@ -146,10 +146,10 @@ public:
     /*!
      *  The "a" parameter for interactions between species *i* and *j* is
      *  assumed by default to be computed as:
-     *  \f[ a_{ij} = \sqrt(a_{i,0} a_{j,0}) + \sqrt(a_{i,1} a_{j,1}) T \f]
+     *  @f[ a_{ij} = \sqrt(a_{i,0} a_{j,0}) + \sqrt(a_{i,1} a_{j,1}) T @f]
      *
      *  This function overrides the defaults with the specified parameters:
-     *  \f[ a_{ij} = a_{ij,0} + a_{ij,1} T \f]
+     *  @f[ a_{ij} = a_{ij,0} + a_{ij,1} T @f]
      *
      *  @param species_i   Name of one species
      *  @param species_j   Name of the other species

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -22,30 +22,30 @@ namespace Cantera
 //! The Shomate polynomial parameterization for one temperature range for one
 //! species
 /*!
- * Seven coefficients \f$(A,\dots,G)\f$ are used to represent
- * \f$ c_p^0(T)\f$, \f$ h^0(T)\f$, and \f$ s^0(T) \f$ as
- * polynomials in the temperature, \f$ T \f$ :
+ * Seven coefficients @f$(A,\dots,G)@f$ are used to represent
+ * @f$ c_p^0(T)@f$, @f$ h^0(T)@f$, and @f$ s^0(T) @f$ as
+ * polynomials in the temperature, @f$ T @f$ :
  *
- * \f[
+ * @f[
  * \tilde{c}_p^0(T) = A + B t + C t^2 + D t^3 + \frac{E}{t^2}
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \tilde{h}^0(T) = A t + \frac{B t^2}{2} + \frac{C t^3}{3}
  *                + \frac{D t^4}{4}  - \frac{E}{t} + F.
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \tilde{s}^0(T) = A\ln t + B t + \frac{C t^2}{2}
  *                + \frac{D t^3}{3} - \frac{E}{2t^2} + G.
- * \f]
+ * @f]
  *
  * In the above expressions, the thermodynamic polynomials are expressed in
- * dimensional units, but the temperature,\f$ t \f$, is divided by 1000. The
+ * dimensional units, but the temperature,@f$ t @f$, is divided by 1000. The
  * following dimensions are assumed in the above expressions:
  *
- *    - \f$ \tilde{c}_p^0(T)\f$ = Heat Capacity (J/gmol*K)
- *    - \f$ \tilde{h}^0(T) \f$ = standard Enthalpy (kJ/gmol)
- *    - \f$ \tilde{s}^0(T) \f$= standard Entropy (J/gmol*K)
- *    - \f$ t \f$= temperature (K) / 1000.
+ *    - @f$ \tilde{c}_p^0(T)@f$ = Heat Capacity (J/gmol*K)
+ *    - @f$ \tilde{h}^0(T) @f$ = standard Enthalpy (kJ/gmol)
+ *    - @f$ \tilde{s}^0(T) @f$= standard Entropy (J/gmol*K)
+ *    - @f$ t @f$= temperature (K) / 1000.
  *
  * For more information about Shomate polynomials, see the NIST website,
  * http://webbook.nist.gov/
@@ -69,7 +69,7 @@ public:
      *                     the parameters for the species standard state.
      *
      *  See the class description for the polynomial representation of the
-     *  thermo functions in terms of \f$ A, \dots, G \f$.
+     *  thermo functions in terms of @f$ A, \dots, G @f$.
      */
     ShomatePoly(double tlow, double thigh, double pref, const double* coeffs) :
         SpeciesThermoInterpType(tlow, thigh, pref),
@@ -195,30 +195,30 @@ protected:
 //! The Shomate polynomial parameterization for two temperature ranges for one
 //! species
 /*!
- * Seven coefficients \f$(A,\dots,G)\f$ are used to represent
- * \f$ c_p^0(T)\f$, \f$ h^0(T)\f$, and \f$ s^0(T) \f$ as
- * polynomials in the temperature, \f$ T \f$, in one temperature region:
+ * Seven coefficients @f$(A,\dots,G)@f$ are used to represent
+ * @f$ c_p^0(T)@f$, @f$ h^0(T)@f$, and @f$ s^0(T) @f$ as
+ * polynomials in the temperature, @f$ T @f$, in one temperature region:
  *
- * \f[
+ * @f[
  * \tilde{c}_p^0(T) = A + B t + C t^2 + D t^3 + \frac{E}{t^2}
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \tilde{h}^0(T) = A t + \frac{B t^2}{2} + \frac{C t^3}{3}
  *                + \frac{D t^4}{4}  - \frac{E}{t}  + F.
- * \f]
- * \f[
+ * @f]
+ * @f[
  * \tilde{s}^0(T) = A\ln t + B t + \frac{C t^2}{2}
  *                + \frac{D t^3}{3} - \frac{E}{2t^2}  + G.
- * \f]
+ * @f]
  *
  * In the above expressions, the thermodynamic polynomials are expressed
- * in dimensional units, but the temperature,\f$ t \f$, is divided by 1000. The
+ * in dimensional units, but the temperature,@f$ t @f$, is divided by 1000. The
  * following dimensions are assumed in the above expressions:
  *
- *    - \f$ \tilde{c}_p^0(T)\f$ = Heat Capacity (J/gmol*K)
- *    - \f$ \tilde{h}^0(T) \f$ = standard Enthalpy (kJ/gmol)
- *    - \f$ \tilde{s}^0(T) \f$= standard Entropy (J/gmol*K)
- *    - \f$ t \f$= temperature (K) / 1000.
+ *    - @f$ \tilde{c}_p^0(T)@f$ = Heat Capacity (J/gmol*K)
+ *    - @f$ \tilde{h}^0(T) @f$ = standard Enthalpy (kJ/gmol)
+ *    - @f$ \tilde{s}^0(T) @f$= standard Entropy (J/gmol*K)
+ *    - @f$ t @f$= temperature (K) / 1000.
  *
  * For more information about Shomate polynomials, see the NIST website,
  * http://webbook.nist.gov/

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -22,8 +22,8 @@ namespace Cantera
 //! The Shomate polynomial parameterization for one temperature range for one
 //! species
 /*!
- * Seven coefficients @f$(A,\dots,G)@f$ are used to represent
- * @f$ c_p^0(T)@f$, @f$ h^0(T)@f$, and @f$ s^0(T) @f$ as
+ * Seven coefficients @f$ (A,\dots,G) @f$ are used to represent
+ * @f$ c_p^0(T) @f$, @f$ h^0(T) @f$, and @f$ s^0(T) @f$ as
  * polynomials in the temperature, @f$ T @f$ :
  *
  * @f[
@@ -42,7 +42,7 @@ namespace Cantera
  * dimensional units, but the temperature,@f$ t @f$, is divided by 1000. The
  * following dimensions are assumed in the above expressions:
  *
- *    - @f$ \tilde{c}_p^0(T)@f$ = Heat Capacity (J/gmol*K)
+ *    - @f$ \tilde{c}_p^0(T) @f$ = Heat Capacity (J/gmol*K)
  *    - @f$ \tilde{h}^0(T) @f$ = standard Enthalpy (kJ/gmol)
  *    - @f$ \tilde{s}^0(T) @f$= standard Entropy (J/gmol*K)
  *    - @f$ t @f$= temperature (K) / 1000.
@@ -195,8 +195,8 @@ protected:
 //! The Shomate polynomial parameterization for two temperature ranges for one
 //! species
 /*!
- * Seven coefficients @f$(A,\dots,G)@f$ are used to represent
- * @f$ c_p^0(T)@f$, @f$ h^0(T)@f$, and @f$ s^0(T) @f$ as
+ * Seven coefficients @f$ (A,\dots,G) @f$ are used to represent
+ * @f$ c_p^0(T) @f$, @f$ h^0(T) @f$, and @f$ s^0(T) @f$ as
  * polynomials in the temperature, @f$ T @f$, in one temperature region:
  *
  * @f[
@@ -215,7 +215,7 @@ protected:
  * in dimensional units, but the temperature,@f$ t @f$, is divided by 1000. The
  * following dimensions are assumed in the above expressions:
  *
- *    - @f$ \tilde{c}_p^0(T)@f$ = Heat Capacity (J/gmol*K)
+ *    - @f$ \tilde{c}_p^0(T) @f$ = Heat Capacity (J/gmol*K)
  *    - @f$ \tilde{h}^0(T) @f$ = standard Enthalpy (kJ/gmol)
  *    - @f$ \tilde{s}^0(T) @f$= standard Entropy (J/gmol*K)
  *    - @f$ t @f$= temperature (K) / 1000.

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -84,9 +84,9 @@ public:
     //! @}
     //! @name Activities, Standard State, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. \f]
-    //! The quantity \f$\mu_k^0(T)\f$ is the chemical potential at unit activity,
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f]
+    //! The quantity @f$\mu_k^0(T)@f$ is the chemical potential at unit activity,
     //! which depends only on temperature.
     //! @{
 
@@ -119,7 +119,7 @@ public:
     /*!
      *  These are the phase, partial molar, and the standard state dimensionless
      *  chemical potentials.
-     *  \f$ \mu_k / \hat R T \f$.
+     *  @f$ \mu_k / \hat R T @f$.
      *
      * Units: unitless
      *
@@ -133,7 +133,7 @@ public:
     /*!
      * These are the phase, partial molar, and the standard state chemical
      * potentials.
-     *     \f$ \mu(T,P) = \mu^0_k(T,P) \f$.
+     *     @f$ \mu(T,P) = \mu^0_k(T,P) @f$.
      *
      * @param mu   On return, Contains the chemical potential of the single
      *             species and the phase. Units are J / kmol . Length = 1
@@ -142,7 +142,7 @@ public:
 
     //! Get the species partial molar enthalpies. Units: J/kmol.
     /*!
-     * These are the phase enthalpies.  \f$ h_k \f$.
+     * These are the phase enthalpies.  @f$ h_k @f$.
      *
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: 1. units are J/kmol.
@@ -151,7 +151,7 @@ public:
 
     //! Get the species partial molar internal energies. Units: J/kmol.
     /*!
-     * These are the phase internal energies.  \f$ u_k \f$.
+     * These are the phase internal energies.  @f$ u_k @f$.
      *
      * @param ubar On return, Contains the internal energy of the single species
      *             and the phase. Units are J / kmol . Length = 1
@@ -160,7 +160,7 @@ public:
 
     //! Get the species partial molar entropy. Units: J/kmol K.
     /*!
-     * This is the phase entropy.  \f$ s(T,P) = s_o(T,P) \f$.
+     * This is the phase entropy.  @f$ s(T,P) = s_o(T,P) @f$.
      *
      * @param sbar On return, Contains the entropy of the single species and the
      *             phase. Units are J / kmol / K . Length = 1
@@ -169,7 +169,7 @@ public:
 
     //! Get the species partial molar Heat Capacities. Units: J/ kmol /K.
     /*!
-     * This is the phase heat capacity.  \f$ Cp(T,P) = Cp_o(T,P) \f$.
+     * This is the phase heat capacity.  @f$ Cp(T,P) = Cp_o(T,P) @f$.
      *
      * @param cpbar On return, Contains the heat capacity of the single species
      *              and the phase. Units are J / kmol / K . Length = 1
@@ -178,7 +178,7 @@ public:
 
     //! Get the species partial molar volumes. Units: m^3/kmol.
     /*!
-     * This is the phase molar volume.  \f$ V(T,P) = V_o(T,P) \f$.
+     * This is the phase molar volume.  @f$ V(T,P) = V_o(T,P) @f$.
      *
      * @param vbar On return, Contains the molar volume of the single species
      *             and the phase. Units are m^3 / kmol. Length = 1

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -84,9 +84,9 @@ public:
     //! @}
     //! @name Activities, Standard State, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T) + \hat R T \log a_k. @f]
-    //! The quantity @f$\mu_k^0(T)@f$ is the chemical potential at unit activity,
+    //! The quantity @f$ \mu_k^0(T) @f$ is the chemical potential at unit activity,
     //! which depends only on temperature.
     //! @{
 

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -33,26 +33,26 @@ namespace Cantera
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term \f$ P_0 \hat v\f$ is subtracted
+ * giving the standard-state enthalpy, the term @f$ P_0 \hat v@f$ is subtracted
  * from the specified molar enthalpy to compute the molar internal energy. The
  * entropy is assumed to be independent of the pressure.
  *
  * The enthalpy function is given by the following relation.
  *
- * \f[
+ * @f[
  *              h^o_k(T,P) =
  *                  h^{ref}_k(T) + \tilde v \left( P - P_{ref} \right)
- * \f]
+ * @f]
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term \f$ P_{ref} \tilde v\f$ is
+ * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v@f$ is
  * subtracted from the specified reference molar enthalpy to compute the molar
  * internal energy.
  *
- * \f[
+ * @f[
  *            u^o_k(T,P) = h^{ref}_k(T) - P_{ref} \tilde v
- * \f]
+ * @f]
  *
  * The standard state heat capacity and entropy are independent of pressure. The
  * standard state Gibbs free energy is obtained from the enthalpy and entropy
@@ -73,12 +73,12 @@ namespace Cantera
  * An example of a reaction using this is a sticking coefficient reaction of a
  * substance in an ideal gas phase on a surface with a bulk phase species in
  * this phase. In this case, the rate of progress for this reaction,
- * \f$ R_s \f$, may be expressed via the following equation:
- *   \f[
+ * @f$ R_s @f$, may be expressed via the following equation:
+ *   @f[
  *    R_s = k_s C_{gas}
- *   \f]
- * where the units for \f$ R_s \f$ are kmol m-2 s-1. \f$ C_{gas} \f$ has units
- * of kmol m-3. Therefore, the kinetic rate constant, \f$ k_s \f$, has units of
+ *   @f]
+ * where the units for @f$ R_s @f$ are kmol m-2 s-1. @f$ C_{gas} @f$ has units
+ * of kmol m-3. Therefore, the kinetic rate constant, @f$ k_s @f$, has units of
  * m s-1. Nowhere does the concentration of the bulk phase appear in the rate
  * constant expression, since it's a stoichiometric phase and the activity is
  * always equal to 1.0.
@@ -141,8 +141,8 @@ public:
 
     //! This method returns an array of generalized concentrations
     /*!
-     * \f$ C^a_k\f$ are defined such that \f$ a_k = C^a_k / C^0_k, \f$ where
-     * \f$ C^0_k \f$ is a standard concentration defined below and \f$ a_k \f$
+     * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^0_k, @f$ where
+     * @f$ C^0_k @f$ is a standard concentration defined below and @f$ a_k @f$
      * are activities used in the thermodynamic functions. These activity (or
      * generalized) concentrations are used by kinetics manager classes to
      * compute the forward and reverse rates of elementary reactions.
@@ -158,7 +158,7 @@ public:
 
     //! Return the standard concentration for the kth species
     /*!
-     * The standard concentration \f$ C^0_k \f$ used to normalize the activity
+     * The standard concentration @f$ C^0_k @f$ used to normalize the activity
      * (that is, generalized) concentration. This phase assumes that the kinetics
      * operator works on an dimensionless basis. Thus, the standard
      * concentration is equal to 1.0.
@@ -178,7 +178,7 @@ public:
      * potential expression, and therefore the standard chemical potential and
      * the chemical potential are both equal to the molar Gibbs function.
      *
-     * These are the standard state chemical potentials \f$ \mu^0_k(T,P) \f$.
+     * These are the standard state chemical potentials @f$ \mu^0_k(T,P) @f$.
      * The values are evaluated at the current temperature and pressure of the
      * solution
      *
@@ -202,7 +202,7 @@ public:
      * For an incompressible, stoichiometric substance, the molar internal
      * energy is independent of pressure. Since the thermodynamic properties
      * are specified by giving the standard-state enthalpy, the term
-     * \f$ P_{ref} \hat v\f$ is subtracted from the specified reference molar
+     * @f$ P_{ref} \hat v@f$ is subtracted from the specified reference molar
      * enthalpy to compute the standard state molar internal energy.
      *
      * @param urt  output vector of nondimensional standard state

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -33,7 +33,7 @@ namespace Cantera
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term @f$ P_0 \hat v@f$ is subtracted
+ * giving the standard-state enthalpy, the term @f$ P_0 \hat v @f$ is subtracted
  * from the specified molar enthalpy to compute the molar internal energy. The
  * entropy is assumed to be independent of the pressure.
  *
@@ -46,7 +46,7 @@ namespace Cantera
  *
  * For an incompressible, stoichiometric substance, the molar internal energy is
  * independent of pressure. Since the thermodynamic properties are specified by
- * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v@f$ is
+ * giving the standard-state enthalpy, the term @f$ P_{ref} \tilde v @f$ is
  * subtracted from the specified reference molar enthalpy to compute the molar
  * internal energy.
  *
@@ -141,7 +141,7 @@ public:
 
     //! This method returns an array of generalized concentrations
     /*!
-     * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^0_k, @f$ where
+     * @f$ C^a_k @f$ are defined such that @f$ a_k = C^a_k / C^0_k, @f$ where
      * @f$ C^0_k @f$ is a standard concentration defined below and @f$ a_k @f$
      * are activities used in the thermodynamic functions. These activity (or
      * generalized) concentrations are used by kinetics manager classes to
@@ -202,7 +202,7 @@ public:
      * For an incompressible, stoichiometric substance, the molar internal
      * energy is independent of pressure. Since the thermodynamic properties
      * are specified by giving the standard-state enthalpy, the term
-     * @f$ P_{ref} \hat v@f$ is subtracted from the specified reference molar
+     * @f$ P_{ref} \hat v @f$ is subtracted from the specified reference molar
      * enthalpy to compute the standard state molar internal energy.
      *
      * @param urt  output vector of nondimensional standard state

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -24,7 +24,7 @@ namespace Cantera
  * defined to occupy one or more sites. The surface species are assumed to be
  * independent, and thus the species form an ideal solution.
  *
- * The density of surface sites is given by the variable \f$ n_0 \f$,
+ * The density of surface sites is given by the variable @f$ n_0 @f$,
  * which has SI units of kmol m-2.
  *
  * ## Specification of Species Standard State Properties
@@ -40,9 +40,9 @@ namespace Cantera
  * Therefore, The standard state internal energy for species *k* is equal to the
  * enthalpy for species *k*.
  *
- * \f[
+ * @f[
  *      u^o_k = h^o_k
- * \f]
+ * @f]
  *
  * Also, the standard state chemical potentials, entropy, and heat capacities
  * are independent of pressure. The standard state Gibbs free energy is obtained
@@ -51,43 +51,43 @@ namespace Cantera
  * ## Specification of Solution Thermodynamic Properties
  *
  * The activity of species defined in the phase is given by
- * \f[
+ * @f[
  *      a_k = \theta_k
- * \f]
+ * @f]
  *
  * The chemical potential for species *k* is equal to
- * \f[
+ * @f[
  *      \mu_k(T,P) = \mu^o_k(T) + R T \log(\theta_k)
- * \f]
+ * @f]
  *
  * Pressure is defined as an independent variable in this phase. However, it has
  * no effect on any quantities, as the molar concentration is a constant.
  *
  * The internal energy for species k is equal to the enthalpy for species *k*
- * \f[
+ * @f[
  *      u_k = h_k
- * \f]
+ * @f]
  *
  * The entropy for the phase is given by the following relation, which is
  * independent of the pressure:
  *
- * \f[
+ * @f[
  *      s_k(T,P) = s^o_k(T) - R \log(\theta_k)
- * \f]
+ * @f]
  *
  * ## Application within Kinetics Managers
  *
- * The activity concentration,\f$  C^a_k \f$, used by the kinetics manager, is equal to
- * the actual concentration, \f$ C^s_k \f$, and is given by the following
+ * The activity concentration,@f$  C^a_k @f$, used by the kinetics manager, is equal to
+ * the actual concentration, @f$ C^s_k @f$, and is given by the following
  * expression.
- * \f[
+ * @f[
  *      C^a_k = C^s_k = \frac{\theta_k  n_0}{s_k}
- * \f]
+ * @f]
  *
  * The standard concentration for species *k* is:
- * \f[
+ * @f[
  *      C^0_k = \frac{n_0}{s_k}
- * \f]
+ * @f]
  *
  * An example phase definition is given in the
  * <a href="../../sphinx/html/yaml/phases.html#ideal-surface"> YAML API Reference</a>.
@@ -117,11 +117,11 @@ public:
     //! Return the Molar Enthalpy. Units: J/kmol.
     /*!
      * For an ideal solution,
-     * \f[
+     * @f[
      * \hat h(T,P) = \sum_k X_k \hat h^0_k(T),
-     * \f]
+     * @f]
      * and is a function only of temperature. The standard-state pure-species
-     * Enthalpies \f$ \hat h^0_k(T) \f$ are computed by the species
+     * Enthalpies @f$ \hat h^0_k(T) @f$ are computed by the species
      * thermodynamic property manager.
      *
      * \see MultiSpeciesThermo
@@ -137,9 +137,9 @@ public:
 
     //! Return the Molar Entropy. Units: J/kmol-K
     /**
-     * \f[
+     * @f[
      *  \hat s(T,P) = \sum_k X_k (\hat s^0_k(T) - R \log(\theta_k))
-     * \f]
+     * @f]
      */
     virtual doublereal entropy_mole() const;
 
@@ -155,21 +155,21 @@ public:
 
     //! Return a vector of activity concentrations for each species
     /*!
-     * For this phase the activity concentrations,\f$ C^a_k \f$, are defined to
-     * be equal to the actual concentrations, \f$ C^s_k \f$. Activity
+     * For this phase the activity concentrations,@f$ C^a_k @f$, are defined to
+     * be equal to the actual concentrations, @f$ C^s_k @f$. Activity
      * concentrations are
      *
-     * \f[
+     * @f[
      *            C^a_k = C^s_k = \frac{\theta_k  n_0}{s_k}
-     * \f]
+     * @f]
      *
-     * where \f$ \theta_k \f$ is the surface site fraction for species k,
-     * \f$ n_0 \f$ is the surface site density for the phase, and
-     * \f$ s_k \f$ is the surface size of species k.
+     * where @f$ \theta_k @f$ is the surface site fraction for species k,
+     * @f$ n_0 @f$ is the surface site density for the phase, and
+     * @f$ s_k @f$ is the surface size of species k.
      *
-     * \f$ C^a_k\f$ that are defined such that \f$ a_k = C^a_k / C^0_k, \f$
-     * where \f$ C^0_k \f$ is a standard concentration defined below and \f$ a_k
-     * \f$ are activities used in the thermodynamic functions.  These activity
+     * @f$ C^a_k@f$ that are defined such that @f$ a_k = C^a_k / C^0_k, @f$
+     * where @f$ C^0_k @f$ is a standard concentration defined below and @f$ a_k
+     * @f$ are activities used in the thermodynamic functions.  These activity
      * concentrations are used by kinetics manager classes to compute the
      * forward and reverse rates of elementary reactions. Note that they may or
      * may not have units of concentration --- they might be partial pressures,
@@ -181,15 +181,15 @@ public:
 
     //! Return the standard concentration for the kth species
     /*!
-     * The standard concentration \f$ C^0_k \f$ used to normalize the activity
+     * The standard concentration @f$ C^0_k @f$ used to normalize the activity
      * (that is, generalized) concentration. For this phase, the standard
      * concentration is species- specific
      *
-     * \f[
+     * @f[
      *            C^0_k = \frac{n_0}{s_k}
-     * \f]
+     * @f]
      *
-     * This definition implies that the activity is equal to \f$ \theta_k \f$.
+     * This definition implies that the activity is equal to @f$ \theta_k @f$.
      *
      * @param k Optional parameter indicating the species. The default
      *          is to assume this refers to species 0.

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -167,7 +167,7 @@ public:
      * @f$ n_0 @f$ is the surface site density for the phase, and
      * @f$ s_k @f$ is the surface size of species k.
      *
-     * @f$ C^a_k@f$ that are defined such that @f$ a_k = C^a_k / C^0_k, @f$
+     * @f$ C^a_k @f$ that are defined such that @f$ a_k = C^a_k / C^0_k, @f$
      * where @f$ C^0_k @f$ is a standard concentration defined below and @f$ a_k
      * @f$ are activities used in the thermodynamic functions.  These activity
      * concentrations are used by kinetics manager classes to compute the

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -336,9 +336,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! The activity @f$ a_k @f$ of a species in solution is related to the
     //! chemical potential by @f[ \mu_k = \mu_k^0(T,P) + \hat R T \log a_k. @f]
-    //! The quantity @f$\mu_k^0(T,P)@f$ is the standard chemical potential at
+    //! The quantity @f$ \mu_k^0(T,P) @f$ is the standard chemical potential at
     //! unit activity, which depends on temperature and pressure, but not on
     //! composition. The activity is dimensionless.
     //! @{
@@ -393,7 +393,7 @@ public:
 
     //! This method returns an array of generalized concentrations
     /*!
-     * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^0_k, @f$ where
+     * @f$ C^a_k @f$ are defined such that @f$ a_k = C^a_k / C^0_k, @f$ where
      * @f$ C^0_k @f$ is a standard concentration defined below and @f$ a_k @f$
      * are activities used in the thermodynamic functions. These activity (or
      * generalized) concentrations are used by kinetics manager classes to

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -269,13 +269,13 @@ public:
     //! Returns the isothermal compressibility. Units: 1/Pa.
     /*!
      * The isothermal compressibility is defined as
-     * \f[
+     * @f[
      * \kappa_T = -\frac{1}{v}\left(\frac{\partial v}{\partial P}\right)_T
-     * \f]
+     * @f]
      *  or
-     * \f[
+     * @f[
      * \kappa_T = \frac{1}{\rho}\left(\frac{\partial \rho}{\partial P}\right)_T
-     * \f]
+     * @f]
      */
     virtual doublereal isothermalCompressibility() const {
         throw NotImplementedError("ThermoPhase::isothermalCompressibility");
@@ -284,9 +284,9 @@ public:
     //! Return the volumetric thermal expansion coefficient. Units: 1/K.
     /*!
      * The thermal expansion coefficient is defined as
-     * \f[
+     * @f[
      * \beta = \frac{1}{v}\left(\frac{\partial v}{\partial T}\right)_P
-     * \f]
+     * @f]
      */
     virtual doublereal thermalExpansionCoeff() const {
         throw NotImplementedError("ThermoPhase::thermalExpansionCoeff");
@@ -295,9 +295,9 @@ public:
     //! Return the speed of sound. Units: m/s.
     /*!
      * The speed of sound is defined as
-     * \f[
+     * @f[
      * c = \sqrt{\left(\frac{\partial P}{\partial\rho}\right)_s}
-     * \f]
+     * @f]
      */
     virtual double soundSpeed() const {
         throw NotImplementedError("ThermoPhase::soundSpeed");
@@ -336,9 +336,9 @@ public:
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
     //!
-    //! The activity \f$a_k\f$ of a species in solution is related to the
-    //! chemical potential by \f[ \mu_k = \mu_k^0(T,P) + \hat R T \log a_k. \f]
-    //! The quantity \f$\mu_k^0(T,P)\f$ is the standard chemical potential at
+    //! The activity @f$a_k@f$ of a species in solution is related to the
+    //! chemical potential by @f[ \mu_k = \mu_k^0(T,P) + \hat R T \log a_k. @f]
+    //! The quantity @f$\mu_k^0(T,P)@f$ is the standard chemical potential at
     //! unit activity, which depends on temperature and pressure, but not on
     //! composition. The activity is dimensionless.
     //! @{
@@ -393,8 +393,8 @@ public:
 
     //! This method returns an array of generalized concentrations
     /*!
-     * \f$ C^a_k\f$ are defined such that \f$ a_k = C^a_k / C^0_k, \f$ where
-     * \f$ C^0_k \f$ is a standard concentration defined below and \f$ a_k \f$
+     * @f$ C^a_k@f$ are defined such that @f$ a_k = C^a_k / C^0_k, @f$ where
+     * @f$ C^0_k @f$ is a standard concentration defined below and @f$ a_k @f$
      * are activities used in the thermodynamic functions. These activity (or
      * generalized) concentrations are used by kinetics manager classes to
      * compute the forward and reverse rates of elementary reactions. Note that
@@ -411,10 +411,10 @@ public:
 
     //! Return the standard concentration for the kth species
     /*!
-     * The standard concentration \f$ C^0_k \f$ used to normalize the activity
+     * The standard concentration @f$ C^0_k @f$ used to normalize the activity
      * (that is, generalized) concentration. In many cases, this quantity will be
-     * the same for all species in a phase - for example, for an ideal gas \f$
-     * C^0_k = P/\hat R T \f$. For this reason, this method returns a single
+     * the same for all species in a phase - for example, for an ideal gas @f$
+     * C^0_k = P/\hat R T @f$. For this reason, this method returns a single
      * value, instead of an array.  However, for phases in which the standard
      * concentration is species-specific (such as surface species of different
      * sizes), this method may be called with an optional parameter indicating
@@ -477,7 +477,7 @@ public:
     /**
      * Get the array of non-dimensional species chemical potentials
      * These are partial molar Gibbs free energies.
-     * \f$ \mu_k / \hat R T \f$.
+     * @f$ \mu_k / \hat R T @f$.
      * Units: unitless
      *
      * @param mu  Output vector of dimensionless chemical potentials.
@@ -504,14 +504,14 @@ public:
 
     //!  Get the species electrochemical potentials.
     /*!
-     *  These are partial molar quantities.  This method adds a term \f$ F z_k
-     *  \phi_p \f$ to each chemical potential. The electrochemical potential of
-     *  species k in a phase p, \f$ \zeta_k \f$, is related to the chemical
+     *  These are partial molar quantities.  This method adds a term @f$ F z_k
+     *  \phi_p @f$ to each chemical potential. The electrochemical potential of
+     *  species k in a phase p, @f$ \zeta_k @f$, is related to the chemical
      *  potential via the following equation,
      *
-     *  \f[
+     *  @f[
      *            \zeta_{k}(T,P) = \mu_{k}(T,P) + F z_k \phi_p
-     *  \f]
+     *  @f]
      *
      * @param mu  Output vector of species electrochemical
      *            potentials. Length: m_kk. Units: J/kmol
@@ -576,8 +576,8 @@ public:
     //! Get the array of chemical potentials at unit activity for the species at
     //! their standard states at the current *T* and *P* of the solution.
     /*!
-     * These are the standard state chemical potentials \f$ \mu^0_k(T,P)
-     * \f$. The values are evaluated at the current temperature and pressure of
+     * These are the standard state chemical potentials @f$ \mu^0_k(T,P)
+     * @f$. The values are evaluated at the current temperature and pressure of
      * the solution
      *
      * @param mu      Output vector of chemical potentials.
@@ -1256,20 +1256,20 @@ public:
      * Fuel and oxidizer compositions are given either as
      * mole fractions or mass fractions (specified by `basis`)
      * and do not need to be normalized.
-     * The mixture fraction \f$ Z \f$ can be computed from a single element
-     * \f[ Z_m = \frac{Z_{\mathrm{mass},m}-Z_{\mathrm{mass},m,\mathrm{ox}}}
-     * {Z_{\mathrm{mass},\mathrm{fuel}}-Z_{\mathrm{mass},m,\mathrm{ox}}} \f] where
-     * \f$ Z_{\mathrm{mass},m} \f$ is the elemental mass fraction of element m
-     * in the mixture, and \f$ Z_{\mathrm{mass},m,\mathrm{ox}} \f$ and
-     * \f$ Z_{\mathrm{mass},m,\mathrm{fuel}} \f$ are the elemental mass fractions
+     * The mixture fraction @f$ Z @f$ can be computed from a single element
+     * @f[ Z_m = \frac{Z_{\mathrm{mass},m}-Z_{\mathrm{mass},m,\mathrm{ox}}}
+     * {Z_{\mathrm{mass},\mathrm{fuel}}-Z_{\mathrm{mass},m,\mathrm{ox}}} @f] where
+     * @f$ Z_{\mathrm{mass},m} @f$ is the elemental mass fraction of element m
+     * in the mixture, and @f$ Z_{\mathrm{mass},m,\mathrm{ox}} @f$ and
+     * @f$ Z_{\mathrm{mass},m,\mathrm{fuel}} @f$ are the elemental mass fractions
      * of the oxidizer and fuel, or from the Bilger mixture fraction,
      * which considers the elements C, S, H and O (R. W. Bilger, "Turbulent jet
      * diffusion flames," Prog. Energy Combust. Sci., 109-131 (1979))
-     * \f[ Z_{\mathrm{Bilger}} = \frac{\beta-\beta_{\mathrm{ox}}}
-     * {\beta_{\mathrm{fuel}}-\beta_{\mathrm{ox}}} \f]
-     * with \f$ \beta = 2\frac{Z_C}{M_C}+2\frac{Z_S}{M_S}+\frac{1}{2}\frac{Z_H}{M_H}
-     * -\frac{Z_O}{M_O} \f$
-     * and \f$ M_m \f$ the atomic weight of element \f$ m \f$.
+     * @f[ Z_{\mathrm{Bilger}} = \frac{\beta-\beta_{\mathrm{ox}}}
+     * {\beta_{\mathrm{fuel}}-\beta_{\mathrm{ox}}} @f]
+     * with @f$ \beta = 2\frac{Z_C}{M_C}+2\frac{Z_S}{M_S}+\frac{1}{2}\frac{Z_H}{M_H}
+     * -\frac{Z_O}{M_O} @f$
+     * and @f$ M_m @f$ the atomic weight of element @f$ m @f$.
      *
      * @param fuelComp   composition of the fuel
      * @param oxComp     composition of the oxidizer
@@ -1327,11 +1327,11 @@ public:
     //! Compute the equivalence ratio for the current mixture
     //! given the compositions of fuel and oxidizer
     /*!
-     * The equivalence ratio \f$ \phi \f$ is computed from
-     * \f[ \phi = \frac{Z}{1-Z}\frac{1-Z_{\mathrm{st}}}{Z_{\mathrm{st}}} \f]
-     * where \f$ Z \f$ is the Bilger mixture fraction of the mixture
+     * The equivalence ratio @f$ \phi @f$ is computed from
+     * @f[ \phi = \frac{Z}{1-Z}\frac{1-Z_{\mathrm{st}}}{Z_{\mathrm{st}}} @f]
+     * where @f$ Z @f$ is the Bilger mixture fraction of the mixture
      * given the specified fuel and oxidizer compositions
-     * \f$ Z_{\mathrm{st}} \f$ is the mixture fraction at stoichiometric
+     * @f$ Z_{\mathrm{st}} @f$ is the mixture fraction at stoichiometric
      * conditions. Fuel and oxidizer compositions are given either as
      * mole fractions or mass fractions (specified by `basis`)
      * and do not need to be normalized.
@@ -1346,7 +1346,7 @@ public:
      *                   as mole or mass fractions (default: molar)
      * @returns          equivalence ratio
      * @see mixtureFraction for the definition of the Bilger mixture fraction
-     * @see equivalenceRatio() for the computation of \f$ \phi \f$ without arguments
+     * @see equivalenceRatio() for the computation of @f$ \phi @f$ without arguments
      */
     double equivalenceRatio(const double* fuelComp, const double* oxComp,
                             ThermoBasis basis=ThermoBasis::molar) const;
@@ -1361,12 +1361,12 @@ public:
     //! Compute the equivalence ratio for the current mixture
     //! from available oxygen and required oxygen
     /*!
-     * Computes the equivalence ratio \f$ \phi \f$ from
-     * \f[ \phi =
+     * Computes the equivalence ratio @f$ \phi @f$ from
+     * @f[ \phi =
      * \frac{Z_{\mathrm{mole},C} + Z_{\mathrm{mole},S} + \frac{1}{4}Z_{\mathrm{mole},H}}
-     * {\frac{1}{2}Z_{\mathrm{mole},O}} \f]
-     * where \f$ Z_{\mathrm{mole},m} \f$ is the elemental mole fraction
-     * of element \f$ m \f$. In this special case, the equivalence ratio
+     * {\frac{1}{2}Z_{\mathrm{mole},O}} @f]
+     * where @f$ Z_{\mathrm{mole},m} @f$ is the elemental mole fraction
+     * of element @f$ m @f$. In this special case, the equivalence ratio
      * is independent of a fuel or oxidizer composition because it only
      * considers the locally available oxygen compared to the required oxygen
      * for complete oxidation. It is the same as assuming that the oxidizer
@@ -1391,10 +1391,10 @@ public:
      * mole fractions or mass fractions (specified by `basis`)
      * and do not need to be normalized.
      * Elements C, S, H and O are considered for the oxidation.
-     * Note that the stoichiometric air to fuel ratio \f$ \mathit{AFR}_{\mathrm{st}} \f$
+     * Note that the stoichiometric air to fuel ratio @f$ \mathit{AFR}_{\mathrm{st}} @f$
      * does not depend on the current mixture composition. The current air to fuel ratio
-     * can be computed from \f$ \mathit{AFR} = \mathit{AFR}_{\mathrm{st}}/\phi \f$
-     * where \f$ \phi \f$ is the equivalence ratio of the current mixture
+     * can be computed from @f$ \mathit{AFR} = \mathit{AFR}_{\mathrm{st}}/\phi @f$
+     * where @f$ \phi @f$ is the equivalence ratio of the current mixture
      *
      * @param fuelComp   composition of the fuel
      * @param oxComp     composition of the oxidizer
@@ -1502,9 +1502,9 @@ public:
     //!This method is used by the ChemEquil equilibrium solver.
     /*!
      * It sets the state such that the chemical potentials satisfy
-     * \f[ \frac{\mu_k}{\hat R T} = \sum_m A_{k,m}
-     * \left(\frac{\lambda_m} {\hat R T}\right) \f] where
-     * \f$ \lambda_m \f$ is the element potential of element m. The
+     * @f[ \frac{\mu_k}{\hat R T} = \sum_m A_{k,m}
+     * \left(\frac{\lambda_m} {\hat R T}\right) @f] where
+     * @f$ \lambda_m @f$ is the element potential of element m. The
      * temperature is unchanged.  Any phase (ideal or not) that
      * implements this method can be equilibrated by ChemEquil.
      *
@@ -1777,9 +1777,9 @@ public:
      * act_coeff for the *m*-th species with respect to the number of moles of
      * the *k*-th species.
      *
-     * \f[
+     * @f[
      *     \frac{d \ln(\gamma_m) }{d \ln( n_k ) }\Bigg|_{n_i}
-     * \f]
+     * @f]
      *
      * When implemented, this method is used within the VCS equilibrium solver to
      * calculate the Jacobian elements, which accelerates convergence of the algorithm.

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -172,8 +172,8 @@ protected:
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
      * @f]
      *
-     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
-     * weights, and @f$V_k@f$ are the pure species molar volumes.
+     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
+     * weights, and @f$ V_k @f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -65,7 +65,7 @@ public:
 
     //! Get the array of non-dimensional species chemical potentials.
     /*!
-     * These are partial molar Gibbs free energies, \f$ \mu_k / \hat R T \f$.
+     * These are partial molar Gibbs free energies, @f$ \mu_k / \hat R T @f$.
      *
      * We close the loop on this function, here, calling getChemPotentials() and
      * then dividing by RT. No need for child classes to handle.
@@ -168,12 +168,12 @@ protected:
      *
      * The formula for this is
      *
-     * \f[
+     * @f[
      * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * \f]
+     * @f]
      *
-     * where \f$X_k\f$ are the mole fractions, \f$W_k\f$ are the molecular
-     * weights, and \f$V_k\f$ are the pure species molar volumes.
+     * where @f$X_k@f$ are the mole fractions, @f$W_k@f$ are the molecular
+     * weights, and @f$V_k@f$ are the pure species molar volumes.
      *
      * Note, the basis behind this formula is that in an ideal solution the
      * partial molar volumes are equal to the pure species molar volumes. We

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -26,15 +26,15 @@ class PDSS_Water;
  *
  * ### Treatment of the phase potential and the electrochemical potential of a species
  *
- * The electrochemical potential of species @f$k@f$ in a phase @f$p@f$, @f$ \zeta_k @f$,
+ * The electrochemical potential of species @f$ k @f$ in a phase @f$ p @f$, @f$ \zeta_k @f$,
  * is related to the chemical potential via the following equation,
  *
  * @f[
  *            \zeta_{k}(T,P) = \mu_{k}(T,P) + z_k \phi_p
  * @f]
  *
- * where  @f$ \nu_k @f$ is the charge of species @f$k@f$, and @f$ \phi_p @f$ is
- * the electric potential of phase @f$p@f$.
+ * where  @f$ \nu_k @f$ is the charge of species @f$ k @f$, and @f$ \phi_p @f$ is
+ * the electric potential of phase @f$ p @f$.
  *
  * The potential  @f$ \phi_p @f$ is tracked and internally stored within the
  * base ThermoPhase object. It constitutes a specification of the internal state

--- a/include/cantera/thermo/WaterProps.h
+++ b/include/cantera/thermo/WaterProps.h
@@ -26,17 +26,17 @@ class PDSS_Water;
  *
  * ### Treatment of the phase potential and the electrochemical potential of a species
  *
- * The electrochemical potential of species \f$k\f$ in a phase \f$p\f$, \f$ \zeta_k \f$,
+ * The electrochemical potential of species @f$k@f$ in a phase @f$p@f$, @f$ \zeta_k @f$,
  * is related to the chemical potential via the following equation,
  *
- * \f[
+ * @f[
  *            \zeta_{k}(T,P) = \mu_{k}(T,P) + z_k \phi_p
- * \f]
+ * @f]
  *
- * where  \f$ \nu_k \f$ is the charge of species \f$k\f$, and \f$ \phi_p \f$ is
- * the electric potential of phase \f$p\f$.
+ * where  @f$ \nu_k @f$ is the charge of species @f$k@f$, and @f$ \phi_p @f$ is
+ * the electric potential of phase @f$p@f$.
  *
- * The potential  \f$ \phi_p \f$ is tracked and internally stored within the
+ * The potential  @f$ \phi_p @f$ is tracked and internally stored within the
  * base ThermoPhase object. It constitutes a specification of the internal state
  * of the phase; it's the third state variable, the first two being temperature
  * and density (or, pressure, for incompressible equations of state). It may be
@@ -46,9 +46,9 @@ class PDSS_Water;
  * Note, the overall electrochemical potential of a phase may not be changed
  * by the potential because many phases enforce charge neutrality:
  *
- * \f[
+ * @f[
  *            0 = \sum_k z_k X_k
- * \f]
+ * @f]
  *
  * Whether charge neutrality is necessary for a phase is also specified within
  * the ThermoPhase object, by the function call
@@ -57,7 +57,7 @@ class PDSS_Water;
  * such as DebyeHuckel and HMWSoln for the proper specification of the chemical
  * potentials.
  *
- * This equation, when applied to the \f$ \zeta_k \f$ equation described
+ * This equation, when applied to the @f$ \zeta_k @f$ equation described
  * above, results in a zero net change in the effective Gibbs free energy of
  * the phase. However, specific charged species in the phase may increase or
  * decrease their electrochemical potentials, which will have an effect on
@@ -176,10 +176,10 @@ public:
      * And, therefore, most be recalculated whenever T or P changes. The units
      * returned by this expression are sqrt(kg/gmol).
      *
-     * \f[
+     * @f[
      *   A_{Debye} = \frac{1}{8 \pi} \sqrt{\frac{2 N_{Avog} \rho_w}{1000}}
      *                     {\left(\frac{e^2}{\epsilon k_{boltz} T}\right)}^{\frac{3}{2}}
-     * \f]
+     * @f]
      *
      * Nominal value at 25C and 1atm = 1.172576 sqrt(kg/gmol).
      *

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -110,12 +110,12 @@ namespace Cantera
  *
  * This class is not a ThermoPhase. However, it does maintain an internal
  * state of the object that is dependent on temperature and density. The
- * internal state is characterized by an internally stored @f$ \tau@f$ and a
+ * internal state is characterized by an internally stored @f$ \tau @f$ and a
  * @f$ \delta @f$ value, and an iState value, which indicates whether the
  * point is a liquid, a gas, or a supercritical fluid. Along with that the
- * @f$ \tau@f$ and a @f$ \delta @f$ values are polynomials of @f$ \tau@f$ and
+ * @f$ \tau @f$ and a @f$ \delta @f$ values are polynomials of @f$ \tau @f$ and
  * a @f$ \delta @f$ that are kept by the WaterPropsIAPWSphi class. Therefore,
- * whenever  @f$ \tau@f$ or @f$ \delta @f$ is changed, the function setState()
+ * whenever  @f$ \tau @f$ or @f$ \delta @f$ is changed, the function setState()
  * must be called in order for the internal state to be kept up to date.
  *
  * The class is pretty straightforward. However, one function deserves

--- a/include/cantera/thermo/WaterPropsIAPWS.h
+++ b/include/cantera/thermo/WaterPropsIAPWS.h
@@ -48,28 +48,28 @@ namespace Cantera
  * This class provides a very complicated polynomial for the specific
  * Helmholtz free energy of water, as a function of temperature and density.
  *
- * \f[
+ * @f[
  *     \frac{M\hat{f}(\rho,T)}{R T} = \phi(\delta, \tau) =
  *                     \phi^o(\delta, \tau) +  \phi^r(\delta, \tau)
- * \f]
+ * @f]
  *
  * where
  *
- * \f[
+ * @f[
  *     \delta = \rho / \rho_c \quad \mathrm{and} \quad \tau = T_c / T
- * \f]
+ * @f]
  *
  * The following constants are assumed
  *
- * \f[
+ * @f[
  *     T_c = 647.096\mathrm{\;K}
- * \f]
- * \f[
+ * @f]
+ * @f[
  *     \rho_c = 322 \mathrm{\;kg\,m^{-3}}
- * \f]
- * \f[
+ * @f]
+ * @f[
  *     R/M = 0.46151805 \mathrm{\;kJ\,kg^{-1}\,K^{-1}}
- * \f]
+ * @f]
  *
  * The free energy is a unique single-valued function of the temperature and
  * density over its entire range.
@@ -98,8 +98,8 @@ namespace Cantera
  * then calculating the correction factor.
  *
  * This class provides an interface to the WaterPropsIAPWSphi class, which
- * actually calculates the \f$ \phi^o(\delta, \tau)  \f$ and the
- * \f$ \phi^r(\delta, \tau) \f$ polynomials in dimensionless form.
+ * actually calculates the @f$ \phi^o(\delta, \tau)  @f$ and the
+ * @f$ \phi^r(\delta, \tau) @f$ polynomials in dimensionless form.
  *
  * All thermodynamic results from this class are returned in dimensional form.
  * This is because the gas constant (and molecular weight) used within this
@@ -110,12 +110,12 @@ namespace Cantera
  *
  * This class is not a ThermoPhase. However, it does maintain an internal
  * state of the object that is dependent on temperature and density. The
- * internal state is characterized by an internally stored \f$ \tau\f$ and a
- * \f$ \delta \f$ value, and an iState value, which indicates whether the
+ * internal state is characterized by an internally stored @f$ \tau@f$ and a
+ * @f$ \delta @f$ value, and an iState value, which indicates whether the
  * point is a liquid, a gas, or a supercritical fluid. Along with that the
- * \f$ \tau\f$ and a \f$ \delta \f$ values are polynomials of \f$ \tau\f$ and
- * a \f$ \delta \f$ that are kept by the WaterPropsIAPWSphi class. Therefore,
- * whenever  \f$ \tau\f$ or \f$ \delta \f$ is changed, the function setState()
+ * @f$ \tau@f$ and a @f$ \delta @f$ values are polynomials of @f$ \tau@f$ and
+ * a @f$ \delta @f$ that are kept by the WaterPropsIAPWSphi class. Therefore,
+ * whenever  @f$ \tau@f$ or @f$ \delta @f$ is changed, the function setState()
  * must be called in order for the internal state to be kept up to date.
  *
  * The class is pretty straightforward. However, one function deserves

--- a/include/cantera/transport/DustyGasTransport.h
+++ b/include/cantera/transport/DustyGasTransport.h
@@ -26,20 +26,20 @@ namespace Cantera
  * of species due to a pressure gradient that is part of Darcy's law.
  *
  * The dusty gas model expresses the value of the molar flux of species
- * \f$ k \f$, \f$ J_k \f$ by the following formula.
+ * @f$ k @f$, @f$ J_k @f$ by the following formula.
  *
- * \f[
+ * @f[
  *     \sum_{j \ne k}{\frac{X_j J_k - X_k J_j}{D^e_{kj}}} + \frac{J_k}{\mathcal{D}^{e}_{k,knud}} =
  *             - \nabla C_k  - \frac{C_k}{\mathcal{D}^{e}_{k,knud}} \frac{\kappa}{\mu} \nabla p
- * \f]
+ * @f]
  *
- * \f$ j \f$ is a sum over all species in the gas.
+ * @f$ j @f$ is a sum over all species in the gas.
  *
  * The effective Knudsen diffusion coefficients are given by the following form
  *
- * \f[
+ * @f[
  *    \mathcal{D}^e_{k,knud} =  \frac{2}{3} \frac{r_{pore} \phi}{\tau} \left( \frac{8 R T}{\pi W_k}  \right)^{1/2}
- * \f]
+ * @f]
  *
  * The effective knudsen diffusion coefficients take into account the effects of
  * collisions of gas-phase molecules with the wall.
@@ -71,9 +71,9 @@ public:
 
     //! Get the molar fluxes [kmol/m^2/s], given the thermodynamic state at two nearby points.
     /*!
-     *   \f[
+     *   @f[
      *       J_k = - \sum_{j = 1, N} \left[D^{multi}_{kj}\right]^{-1} \left( \nabla C_j  + \frac{C_j}{\mathcal{D}^{knud}_j} \frac{\kappa}{\mu} \nabla p \right)
-     *   \f]
+     *   @f]
      *
      * @param  state1  Array of temperature, density, and mass fractions for state 1.
      * @param  state2  Array of temperature, density, and mass fractions for state 2.
@@ -120,9 +120,9 @@ public:
      * The value for close-packed spheres is given below, where p is the
      * porosity, t is the tortuosity, and d is the diameter of the sphere
      *
-     * \f[
+     * @f[
      *     \kappa = \frac{p^3 d^2}{72 t (1 - p)^2}
-     * \f]
+     * @f]
      *
      * @param B  set the permeability of the media (units = m^2)
      */
@@ -173,15 +173,15 @@ private:
 
     //! Private routine to update the dusty gas binary diffusion coefficients
     /*!
-     * The dusty gas binary diffusion coefficients \f$  D^{dg}_{i,j} \f$ are
-     * evaluated from the binary gas-phase diffusion coefficients \f$
-     * D^{bin}_{i,j} \f$  using the following formula
+     * The dusty gas binary diffusion coefficients @f$  D^{dg}_{i,j} @f$ are
+     * evaluated from the binary gas-phase diffusion coefficients @f$
+     * D^{bin}_{i,j} @f$  using the following formula
      *
-     * \f[
+     * @f[
      *     D^{dg}_{i,j} =  \frac{\phi}{\tau} D^{bin}_{i,j}
-     * \f]
+     * @f]
      *
-     * where \f$ \phi \f$ is the porosity of the media and \f$ \tau \f$ is the
+     * where @f$ \phi @f$ is the porosity of the media and @f$ \tau @f$ is the
      * tortuosity of the media.
      */
     void updateBinaryDiffCoeffs();
@@ -197,22 +197,22 @@ private:
     /*!
      * The Knudsen diffusion coefficients are given by the following form
      *
-     * \f[
+     * @f[
      *     \mathcal{D}^{knud}_k =  \frac{2}{3} \frac{r_{pore} \phi}{\tau} \left( \frac{8 R T}{\pi W_k}  \right)^{1/2}
-     * \f]
+     * @f]
      */
     void updateKnudsenDiffCoeffs();
 
     //! Calculate the H matrix
     /*!
-     * The multicomponent diffusion H matrix \f$  H_{k,l} \f$ is given by the following form
+     * The multicomponent diffusion H matrix @f$  H_{k,l} @f$ is given by the following form
      *
-     * \f[
+     * @f[
      *    H_{k,l} = - \frac{X_k}{D_{k,l}}
-     * \f]
-     * \f[
+     * @f]
+     * @f[
      *    H_{k,k} = \frac{1}{\mathcal(D)^{knud}_{k}} + \sum_{j \ne k}^N{ \frac{X_j}{D_{k,j}} }
-     * \f]
+     * @f]
      */
     void eval_H_matrix();
 
@@ -273,11 +273,11 @@ private:
      * The permeability is the proportionality constant for Darcy's law which
      * relates discharge rate and viscosity to the applied pressure gradient.
      *
-     * Below is Darcy's law, where \f$ \kappa \f$ is the permeability
+     * Below is Darcy's law, where @f$ \kappa @f$ is the permeability
      *
-     * \f[
+     * @f[
      *     v = \frac{\kappa}{\mu} \frac{\delta P}{\delta x}
-     * \f]
+     * @f]
      *
      * units are m2
      */

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -29,17 +29,17 @@ public:
     /*!
      * The viscosity is computed using the Wilke mixture rule (kg /m /s)
      *
-     * \f[
+     * @f[
      *     \mu = \sum_k \frac{\mu_k X_k}{\sum_j \Phi_{k,j} X_j}.
-     * \f]
+     * @f]
      *
-     * Here \f$ \mu_k \f$ is the viscosity of pure species \e k, and
+     * Here @f$ \mu_k @f$ is the viscosity of pure species \e k, and
      *
-     * \f[
+     * @f[
      *     \Phi_{k,j} = \frac{\left[1
      *                  + \sqrt{\left(\frac{\mu_k}{\mu_j}\sqrt{\frac{M_j}{M_k}}\right)}\right]^2}
      *                  {\sqrt{8}\sqrt{1 + M_k/M_j}}
-     * \f]
+     * @f]
      *
      * @returns the viscosity of the mixture (units =  Pa s = kg /m /s)
      *
@@ -74,11 +74,11 @@ public:
      *
      * This is Eqn. 12.180 from "Chemically Reacting Flow"
      *
-     * \f[
+     * @f[
      *     D_{km}' = \frac{\left( \bar{M} - X_k M_k \right)}{ \bar{\qquad M \qquad } }  {\left( \sum_{j \ne k} \frac{X_j}{D_{kj}} \right) }^{-1}
-     * \f]
+     * @f]
      *
-     * @param[out] d  Vector of mixture diffusion coefficients, \f$ D_{km}' \f$ ,
+     * @param[out] d  Vector of mixture diffusion coefficients, @f$ D_{km}' @f$ ,
      *     for each species (m^2/s). length m_nsp
      */
     virtual void getMixDiffCoeffs(doublereal* const d);
@@ -88,7 +88,7 @@ public:
     //! from the species mole fraction gradients, computed according to
     //! Eq. 12.176 in "Chemically Reacting Flow":
     //!
-    //! \f[  D_{km}^* = \frac{1-X_k}{\sum_{j \ne k}^K X_j/\mathcal{D}_{kj}} \f]
+    //! @f[  D_{km}^* = \frac{1-X_k}{\sum_{j \ne k}^K X_j/\mathcal{D}_{kj}} @f]
     //!
     //! @param[out] d vector of mixture-averaged diffusion coefficients for
     //!     each species, length m_nsp.
@@ -100,10 +100,10 @@ public:
      * from the species mass fraction gradients, computed according to
      * Eq. 12.178 in "Chemically Reacting Flow":
      *
-     * \f[
+     * @f[
      *     \frac{1}{D_{km}} = \sum_{j \ne k}^K \frac{X_j}{\mathcal{D}_{kj}} +
      *     \frac{X_k}{1-Y_k} \sum_{j \ne k}^K \frac{Y_j}{\mathcal{D}_{kj}}
-     * \f]
+     * @f]
      *
      * @param[out] d vector of mixture-averaged diffusion coefficients for
      *     each species, length m_nsp.
@@ -169,10 +169,10 @@ protected:
      *
      * The formula for the weighting function is from Poling and Prausnitz,
      * Eq. (9-5.14):
-     *  \f[
+     *  @f[
      *      \phi_{ij} = \frac{ \left[ 1 + \left( \mu_i / \mu_j \right)^{1/2} \left( M_j / M_i \right)^{1/4} \right]^2 }
      *                    {\left[ 8 \left( 1 + M_i / M_j \right) \right]^{1/2}}
-     *  \f]
+     *  @f]
      */
     virtual void updateViscosity_T();
 
@@ -228,25 +228,25 @@ protected:
      */
     void fitCollisionIntegrals(MMCollisionInt& integrals);
 
-    //! Generate polynomial fits to the viscosity \f$ \eta \f$ and conductivity
-    //! \f$ \lambda \f$.
+    //! Generate polynomial fits to the viscosity @f$ \eta @f$ and conductivity
+    //! @f$ \lambda @f$.
     /*!
      * If CK_mode, then the fits are of the form
-     * \f[
+     * @f[
      *      \log(\eta(i)) = \sum_{n=0}^3 a_n(i) \, (\log T)^n
-     * \f]
+     * @f]
      * and
-     * \f[
+     * @f[
      *      \log(\lambda(i)) = \sum_{n=0}^3 b_n(i) \, (\log T)^n
-     * \f]
+     * @f]
      * Otherwise the fits are of the form
-     * \f[
+     * @f[
      *      \left(\eta(i)\right)^{1/2} = T^{1/4} \sum_{n=0}^4 a_n(i) \, (\log T)^n
-     * \f]
+     * @f]
      * and
-     * \f[
+     * @f[
      *      \lambda(i) = T^{1/2} \sum_{n=0}^4 b_n(i) \, (\log T)^n
-     * \f]
+     * @f]
      *
      * @param integrals interpolator for the collision integrals
      */
@@ -255,13 +255,13 @@ protected:
     //! Generate polynomial fits to the binary diffusion coefficients
     /*!
      * If CK_mode, then the fits are of the form
-     * \f[
+     * @f[
      *      \log(D(i,j)) = \sum_{n=0}^3 c_n(i,j) \, (\log T)^n
-     * \f]
+     * @f]
      * Otherwise the fits are of the form
-     * \f[
+     * @f[
      *      D(i,j) = T^{3/2} \sum_{n=0}^4 c_n(i,j) \, (\log T)^n
-     * \f]
+     * @f]
      *
      * @param integrals interpolator for the collision integrals
      */

--- a/include/cantera/transport/IonGasTransport.h
+++ b/include/cantera/transport/IonGasTransport.h
@@ -59,9 +59,9 @@ public:
     virtual void getMixDiffCoeffs(double* const d);
 
     /*! The electrical conductivity (Siemens/m).
-     * \f[
+     * @f[
      *     \sigma = \sum_k{\left|C_k\right| \mu_k \frac{X_k P}{k_b T}}
-     * \f]
+     * @f]
      */
     virtual double electricalConductivity();
 

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -23,28 +23,28 @@ namespace Cantera
  *
  * The viscosity is computed using the Wilke mixture rule (kg /m /s)
  *
- * \f[
+ * @f[
  *     \mu = \sum_k \frac{\mu_k X_k}{\sum_j \Phi_{k,j} X_j}.
- * \f]
+ * @f]
  *
- * Here \f$ \mu_k \f$ is the viscosity of pure species \e k, and
+ * Here @f$ \mu_k @f$ is the viscosity of pure species \e k, and
  *
- * \f[
+ * @f[
  *     \Phi_{k,j} = \frac{\left[1
  *                  + \sqrt{\left(\frac{\mu_k}{\mu_j}\sqrt{\frac{M_j}{M_k}}\right)}\right]^2}
  *                  {\sqrt{8}\sqrt{1 + M_k/M_j}}
- * \f]
+ * @f]
  *
  * The thermal conductivity is computed from the following mixture rule:
- * \f[
+ * @f[
  *     \lambda = 0.5 \left( \sum_k X_k \lambda_k  + \frac{1}{\sum_k X_k/\lambda_k} \right)
- * \f]
+ * @f]
  *
  * It's used to compute the flux of energy due to a thermal gradient
  *
- * \f[
+ * @f[
  *     j_T =  - \lambda  \nabla T
- * \f]
+ * @f]
  *
  * The flux of energy has units of energy (kg m2 /s2) per second per area.
  *
@@ -72,15 +72,15 @@ public:
     //! Returns the mixture thermal conductivity (W/m /K)
     /*!
      * The thermal conductivity is computed from the following mixture rule:
-     * \f[
+     * @f[
      *     \lambda = 0.5 \left( \sum_k X_k \lambda_k  + \frac{1}{\sum_k X_k/\lambda_k} \right)
-     * \f]
+     * @f]
      *
      * It's used to compute the flux of energy due to a thermal gradient
      *
-     * \f[
+     * @f[
      *     j_T =  - \lambda  \nabla T
-     * \f]
+     * @f]
      *
      * The flux of energy has units of energy (kg m2 /s2) per second per area.
      *
@@ -98,9 +98,9 @@ public:
      * Here, the mobility is calculated from the diffusion coefficient using the
      * Einstein relation
      *
-     * \f[
+     * @f[
      *     \mu^e_k = \frac{F D_k}{R T}
-     * \f]
+     * @f]
      *
      * @param mobil  Returns the mobilities of the species in array \c mobil.
      *               The array must be dimensioned at least as large as the
@@ -128,9 +128,9 @@ public:
      * Units for the returned fluxes are kg m-2 s-1.
      *
      * The diffusive mass flux of species \e k is computed from
-     * \f[
+     * @f[
      *     \vec{j}_k = -n M_k D_k \nabla X_k.
-     * \f]
+     * @f]
      *
      * @param ndim      Number of dimensions in the flux expressions
      * @param grad_T    Gradient of the temperature (length = ndim)

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -335,9 +335,9 @@ public:
      * Frequently, but not always, the mobility is calculated from the diffusion
      * coefficient using the Einstein relation
      *
-     * \f[
+     * @f[
      *      \mu^e_k = \frac{F D_k}{R T}
-     * \f]
+     * @f]
      *
      * @param mobil_e  Returns the mobilities of the species in array \c
      *               mobil_e. The array must be dimensioned at least as large as
@@ -357,9 +357,9 @@ public:
      * Frequently, but not always, the mobility is calculated from the diffusion
      * coefficient using the Einstein relation
      *
-     * \f[
+     * @f[
      *      \mu^f_k = \frac{D_k}{R T}
-     * \f]
+     * @f]
      *
      * @param mobil_f  Returns the mobilities of the species in array \c mobil.
      *               The array must be dimensioned at least as large as the
@@ -377,12 +377,12 @@ public:
     //! Compute the mixture electrical conductivity (S m-1) at the current
     //! conditions of the phase (Siemens m-1)
     /*!
-     * The electrical conductivity, \f$ \sigma \f$, relates the electric current
+     * The electrical conductivity, @f$ \sigma @f$, relates the electric current
      * density, J, to the electric field, E.
      *
-     * \f[
+     * @f[
      *        \vec{J} = \sigma \vec{E}
-     * \f]
+     * @f]
      *
      * We assume here that the mixture electrical conductivity is an isotropic
      * quantity, at this stage. Tensors may be included at a later time.
@@ -579,13 +579,13 @@ public:
 
     //! Return a vector of Thermal diffusion coefficients [kg/m/sec].
     /*!
-     * The thermal diffusion coefficient \f$ D^T_k \f$ is defined so that the
+     * The thermal diffusion coefficient @f$ D^T_k @f$ is defined so that the
      * diffusive mass flux of species *k* induced by the local temperature
      * gradient is given by the following formula:
      *
-     * \f[
+     * @f[
      *     M_k J_k = -D^T_k \nabla \ln T.
-     * \f]
+     * @f]
      *
      * The thermal diffusion coefficient can be either positive or negative.
      *

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -39,16 +39,16 @@ public:
      * with respect to the mass averaged velocity using gradients of the mole
      * fraction.
      *
-     * \f[
+     * @f[
      *     D^\prime_{km} = \frac{\lambda}{\rho c_p}
-     * \f]
+     * @f]
      *
      * In order to obtain the expected behavior from a unity Lewis number model,
      * this formulation requires that the correction velocity be computed as
      *
-     * \f[
+     * @f[
      *     V_c = \sum \frac{W_k}{\overline{W}} D^\prime_{km} \nabla X_k
-     * \f]
+     * @f]
      *
      * @param[out] d  Vector of diffusion coefficients for each species (m^2/s).
      * length m_nsp.
@@ -71,9 +71,9 @@ public:
      * These are the coefficients for calculating the diffusive mass fluxes
      * from the species mass fraction gradients, computed as
      *
-     * \f[
+     * @f[
      *     D_{km} = \frac{\lambda}{\rho c_p}
-     * \f]
+     * @f]
      *
      * @param[out] d  Vector of diffusion coefficients for each species (m^2/s).
      * length m_nsp.

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -168,10 +168,10 @@ public:
     //! Return the sensitivity of the *k*-th solution component with respect to
     //! the *p*-th sensitivity parameter.
     /*!
-     *  The sensitivity coefficient \f$ S_{ki} \f$ of solution variable \f$ y_k
-     *  \f$ with respect to sensitivity parameter \f$ p_i \f$ is defined as:
+     *  The sensitivity coefficient @f$ S_{ki} @f$ of solution variable @f$ y_k
+     *  @f$ with respect to sensitivity parameter @f$ p_i @f$ is defined as:
      *
-     *  \f[ S_{ki} = \frac{1}{y_k} \frac{\partial y_k}{\partial p_i} \f]
+     *  @f[ S_{ki} = \frac{1}{y_k} \frac{\partial y_k}{\partial p_i} @f]
      *
      *  For reaction sensitivities, the parameter is a multiplier on the forward
      *  rate constant (and implicitly on the reverse rate constant for

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -147,11 +147,11 @@ public:
         return "Wall";
     }
 
-    //! Wall velocity \f$ v(t) \f$ at current reactor network time.
+    //! Wall velocity @f$ v(t) @f$ at current reactor network time.
     //! @since New in %Cantera 3.0.
     double velocity() const;
 
-    //! Set the wall velocity to a specified function of time, \f$ v(t) \f$.
+    //! Set the wall velocity to a specified function of time, @f$ v(t) @f$.
     void setVelocity(Func1* f=0) {
         if (f) {
             m_vf = f;
@@ -161,9 +161,9 @@ public:
     //! Rate of volume change (m^3/s) for the adjacent reactors.
     /*!
      * The volume rate of change is given by
-     * \f[
+     * @f[
      *     \dot V = K A (P_{left} - P_{right}) + F(t)
-     * \f]
+     * @f]
      * where *K* is the specified expansion rate coefficient, *A* is the wall
      * area, and *F(t)* is a specified function of time. Positive values for
      * `vdot` correspond to increases in the volume of reactor on left, and
@@ -176,9 +176,9 @@ public:
     //! Rate of volume change (m^3/s) for the adjacent reactors.
     /*!
      * The volume rate of change is given by
-     * \f[
+     * @f[
      *     \dot V = K A (P_{left} - P_{right}) + F(t)
-     * \f]
+     * @f]
      * where *K* is the specified expansion rate coefficient, *A* is the wall area,
      * and and *F(t)* is a specified function evaluated at the current network time.
      * Positive values for `expansionRate` correspond to increases in the volume of
@@ -187,11 +187,11 @@ public:
      */
     virtual double expansionRate();
 
-    //! Heat flux function \f$ q_0(t) \f$ evaluated at current reactor network time.
+    //! Heat flux function @f$ q_0(t) @f$ evaluated at current reactor network time.
     //! @since New in %Cantera 3.0.
     double heatFlux() const;
 
-    //! Specify the heat flux function \f$ q_0(t) \f$.
+    //! Specify the heat flux function @f$ q_0(t) @f$.
     void setHeatFlux(Func1* q) {
         m_qf = q;
     }
@@ -199,9 +199,9 @@ public:
     //! Heat flow rate through the wall (W).
     /*!
      * The heat flux is given by
-     * \f[
+     * @f[
      *     Q = h A (T_{left} - T_{right}) + A G(t)
-     * \f]
+     * @f]
      * where *h* is the heat transfer coefficient, *A* is the wall area, and
      * *G(t)* is a specified function of time. Positive values denote a flux
      * from left to right.
@@ -212,9 +212,9 @@ public:
     //! Heat flow rate through the wall (W).
     /*!
      * The heat flux is given by
-     * \f[
+     * @f[
      *     Q = h A (T_{left} - T_{right}) + A G(t)
-     * \f]
+     * @f]
      * where *h* is the heat transfer coefficient, *A* is the wall area, and
      * *G(t)* is a specified function of time evaluated at the current network
      * time. Positive values denote a flux from left to right.

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -32,10 +32,10 @@ public:
     //! Set the mass flow coefficient.
     /*!
      * *m* has units of kg/s. The mass flow rate is computed as:
-     * \f[\dot{m} = m g(t) \f]
+     * @f[\dot{m} = m g(t) @f]
      * where *g* is a function of time that is set by `setTimeFunction`.
      * If no function is specified, the mass flow rate defaults to:
-     * \f[\dot{m} = m \f]
+     * @f[\dot{m} = m @f]
      */
     void setMassFlowCoeff(double m) {
         m_coeff = m;
@@ -94,11 +94,11 @@ public:
     //! rate
     /*!
      * *c* has units of kg/s/Pa. The mass flow rate is computed as:
-     * \f[\dot{m} = \dot{m}_{primary} + c f(\Delta P) \f]
+     * @f[\dot{m} = \dot{m}_{primary} + c f(\Delta P) @f]
      * where *f* is a functions of pressure drop that is set by
      * `setPressureFunction`. If no functions is specified, the mass flow
      * rate defaults to:
-     * \f[\dot{m} = \dot{m}_{primary} + c \Delta P \f]
+     * @f[\dot{m} = \dot{m}_{primary} + c \Delta P @f]
      */
     void setPressureCoeff(double c) {
         m_coeff = c;
@@ -136,11 +136,11 @@ public:
     //! rate
     /*!
      * *c* has units of kg/s/Pa. The mass flow rate is computed as:
-     * \f[\dot{m} = c g(t) f(\Delta P) \f]
+     * @f[\dot{m} = c g(t) f(\Delta P) @f]
      * where *g* and *f* are functions of time and pressure drop that are set
      * by `setTimeFunction` and `setPressureFunction`, respectively. If no functions are
      * specified, the mass flow rate defaults to:
-     * \f[\dot{m} = c \Delta P \f]
+     * @f[\dot{m} = c \Delta P @f]
      */
     void setValveCoeff(double c) {
         m_coeff = c;

--- a/interfaces/dotnet/Cantera/src/Consts.cs
+++ b/interfaces/dotnet/Cantera/src/Consts.cs
@@ -9,47 +9,47 @@ namespace Cantera;
 public static class Consts
 {
     /// <summary>
-    /// Avogadro's Number \f$ N_{\mathrm{A}} \f$ [number/kmol]
+    /// Avogadro's Number @f$ N_{\mathrm{A}} @f$ [number/kmol]
     /// </summary>
     public const double Avogadro = 6.02214076e26;
 
     /// <summary>
-    /// Boltzmann constant \f$ k \f$ [J/K]
+    /// Boltzmann constant @f$ k @f$ [J/K]
     /// </summary>
     public const double Boltzmann = 1.380649e-23;
 
     /// <summary>
-    /// Planck constant \f$ h \f$ [J-s]
+    /// Planck constant @f$ h @f$ [J-s]
     /// </summary>
     public const double Planck = 6.62607015e-34;
 
     /// <summary>
-    /// Elementary charge \f$ e \f$ [C]
+    /// Elementary charge @f$ e @f$ [C]
     /// </summary>
     public const double ElectronCharge = 1.602176634e-19;
 
     /// <summary>
-    /// Speed of Light in a vacuum \f$ c \f$ [m/s]
+    /// Speed of Light in a vacuum @f$ c @f$ [m/s]
     /// </summary>
     public const double LightSpeed = 299792458.0;
 
     /// <summary>
-    /// Electron Mass \f$ m_e \f$ [kg]
+    /// Electron Mass @f$ m_e @f$ [kg]
     /// </summary>
     public const double ElectronMass = 9.1093837015e-31;
 
     /// <summary>
-    /// Universal Gas Constant \f$ R_u \f$ [J/kmol/K]
+    /// Universal Gas Constant @f$ R_u @f$ [J/kmol/K]
     /// </summary>
     public const double GasConstant = Avogadro * Boltzmann;
 
     /// <summary>
-    /// Faraday constant \f$ F \f$ [C/kmol]
+    /// Faraday constant @f$ F @f$ [C/kmol]
     /// </summary>
     public const double Faraday = ElectronCharge * Avogadro;
 
     /// <summary>
-    /// Stefan-Boltzmann constant \f$ \sigma \f$ [W/m2/K4]
+    /// Stefan-Boltzmann constant @f$ \sigma @f$ [W/m2/K4]
     /// </summary>
     public const double StefanBoltzmann = 5.670374419e-8;
 

--- a/samples/cxx/bvp/blasius.cpp
+++ b/samples/cxx/bvp/blasius.cpp
@@ -20,16 +20,16 @@ using Cantera::npos;
 
 /**
  * This class solves the Blasius boundary value problem on the domain (0,L):
- * \f[
+ * @f[
  *             \frac{d\zeta}{dz} = u.
- * \f]
- * \f[
+ * @f]
+ * @f[
  *             \frac{d^2u}{dz^2} + 0.5\zeta \frac{du}{dz} = 0.
- * \f]
+ * @f]
  * with boundary conditions
- * \f[
+ * @f[
  * \zeta(0) = 0, u(0) = 0, u(L) = 1.
- * \f]
+ * @f]
  * Note that this is formulated as a system of two equations, with maximum
  * order of 2, rather than as a single third-order boundary value problem.
  * For reasons having to do with the band structure of the Jacobian, no

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -87,16 +87,16 @@ doublereal bound_step(const doublereal* x, const doublereal* step,
  *              number of components, and number of points.
  *
  * The return value is
- * \f[
+ * @f[
  *    \sum_{n,j} \left(\frac{s_{n,j}}{w_n}\right)^2
- * \f]
- * where the error weight for solution component \f$n\f$ is given by
- * \f[
+ * @f]
+ * where the error weight for solution component @f$n@f$ is given by
+ * @f[
  *     w_n = \epsilon_{r,n} \frac{\sum_j |x_{n,j}|}{J} + \epsilon_{a,n}.
- * \f]
- * Here \f$\epsilon_{r,n} \f$ is the relative error tolerance for component n,
+ * @f]
+ * Here @f$\epsilon_{r,n} @f$ is the relative error tolerance for component n,
  * and multiplies the average magnitude of solution component n in the domain.
- * The second term, \f$\epsilon_{a,n}\f$, is the absolute error tolerance for
+ * The second term, @f$\epsilon_{a,n}@f$, is the absolute error tolerance for
  * component n.
  */
 doublereal norm_square(const doublereal* x,

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -90,13 +90,13 @@ doublereal bound_step(const doublereal* x, const doublereal* step,
  * @f[
  *    \sum_{n,j} \left(\frac{s_{n,j}}{w_n}\right)^2
  * @f]
- * where the error weight for solution component @f$n@f$ is given by
+ * where the error weight for solution component @f$ n @f$ is given by
  * @f[
  *     w_n = \epsilon_{r,n} \frac{\sum_j |x_{n,j}|}{J} + \epsilon_{a,n}.
  * @f]
- * Here @f$\epsilon_{r,n} @f$ is the relative error tolerance for component n,
+ * Here @f$ \epsilon_{r,n} @f$ is the relative error tolerance for component n,
  * and multiplies the average magnitude of solution component n in the domain.
- * The second term, @f$\epsilon_{a,n}@f$, is the absolute error tolerance for
+ * The second term, @f$ \epsilon_{a,n} @f$, is the absolute error tolerance for
  * component n.
  */
 doublereal norm_square(const doublereal* x,

--- a/src/transport/MultiTransport.cpp
+++ b/src/transport/MultiTransport.cpp
@@ -21,7 +21,7 @@ namespace Cantera
 /**
  * The Parker temperature correction to the rotational collision number.
  *
- * @param tr Reduced temperature \f$ \epsilon/kT \f$
+ * @param tr Reduced temperature @f$ \epsilon/kT @f$
  * @param sqtr square root of tr.
  */
 doublereal Frot(doublereal tr, doublereal sqtr)
@@ -387,7 +387,7 @@ void MultiTransport::getMultiDiffCoeffs(const size_t ld, doublereal* const d)
                           (m_Lmatrix(i,j) - m_Lmatrix(i,i));
         }
     }
-    
+
 }
 
 void MultiTransport::update_T()

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -242,9 +242,9 @@ void MoleReactor::eval(double time, double* LHS, double* RHS)
     }
 
     // Energy equation.
-    // \f[
+    // @f[
     //     \dot U = -P\dot V + A \dot q + \dot m_{in} h_{in} - \dot m_{out} h.
-    // \f]
+    // @f]
     if (m_energy) {
         RHS[0] = - m_thermo->pressure() * m_vdot + m_Qdot;
     } else {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -239,9 +239,9 @@ void Reactor::eval(double time, double* LHS, double* RHS)
     }
 
     // Energy equation.
-    // \f[
+    // @f[
     //     \dot U = -P\dot V + A \dot q + \dot m_{in} h_{in} - \dot m_{out} h.
-    // \f]
+    // @f]
     if (m_energy) {
         RHS[2] = - m_thermo->pressure() * m_vdot + m_Qdot;
     } else {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR complements #1557, and solely replaces `\f[` / `\f]` / `\f$` by  `@f[` / `@f]` / `@f$`. The change clearly differentiates Doxygen commands from $\LaTeX$ commands. In addition, spaces are added to better separate Doxygen from $\LaTeX$ / improve readability.

While the PR creates considerable churn, there will not be a question about what style to follow for Doxygen documentation in the future.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Addresses Cantera/enhancements#179

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
