### PR TITLE
Add CI linting for some code style issues

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -14,6 +14,8 @@ jobs:
     steps:
       - uses: actions/checkout@v3
         name: Checkout the repository
+        with:
+          fetch-depth: 100
       - name: Setup Python
         uses: actions/setup-python@v4
         with:
@@ -42,3 +44,10 @@ jobs:
             fi
           done
           exit $RETCODE
+      - name: Whitespace errors
+        if: success() || failure()
+        run: |
+          git config --global core.autocrlf false
+          git config --global core.whitespace \
+            -cr-at-eol,tab-in-indent,blank-at-eol,blank-at-eof
+          git diff --check ${{ github.event.pull_request.base.sha }}

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -1,0 +1,43 @@
+name: Linters
+
+on:
+  pull_request:
+  # Build when a pull request targets main
+    branches:
+      - main
+
+jobs:
+  linter:
+    name: Lint checks
+    runs-on: ubuntu-latest
+    timeout-minutes: 10
+    steps:
+      - uses: actions/checkout@v3
+        name: Checkout the repository
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.10'
+      - name: Check example keywords
+        run: python3 doc/example-keywords.py compare
+      - name: Get changed C++ files
+        id: changed-cxx-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files: |
+            **.h
+            **.cpp
+      # Comment blocks starting with "/*!" do not support autobrief
+      - name: Check for problematic Doxygen comment blocks
+        if: steps.changed-cxx-files.outputs.any_changed == 'true'
+        run: |
+          RETCODE=0
+          for file in ${{ steps.changed-cxx-files.outputs.all_changed_files }}; do
+            RESULT=`perl -0777 -ne 'while(m/\n\n *\/\*!.*?\*\//gs){print "$&\n";}' $file`
+            if [ "$RESULT" ]; then
+              echo ------ ${file} ------
+              echo "$RESULT"
+              RETCODE=1
+            fi
+          done
+          exit $RETCODE

--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -21,6 +21,7 @@ jobs:
       - name: Check example keywords
         run: python3 doc/example-keywords.py compare
       - name: Get changed C++ files
+        if: success() || failure()
         id: changed-cxx-files
         uses: tj-actions/changed-files@v37
         with:
@@ -29,7 +30,7 @@ jobs:
             **.cpp
       # Comment blocks starting with "/*!" do not support autobrief
       - name: Check for problematic Doxygen comment blocks
-        if: steps.changed-cxx-files.outputs.any_changed == 'true'
+        if: (success() || failure()) && steps.changed-cxx-files.outputs.any_changed == 'true'
         run: |
           RETCODE=0
           for file in ${{ steps.changed-cxx-files.outputs.all_changed_files }}; do

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,41 +301,6 @@ jobs:
         files: ./coverage.xml,./build/pycov.xml,./interfaces/dotnet/coverage.cobertura.xml
         fail_ci_if_error: true
 
-  linter:
-    name: Lint checks
-    runs-on: ubuntu-latest
-    timeout-minutes: 10
-    steps:
-      - uses: actions/checkout@v3
-        name: Checkout the repository
-      - name: Setup Python
-        uses: actions/setup-python@v4
-        with:
-          python-version: '3.10'
-      - name: Check example keywords
-        run: python3 doc/example-keywords.py compare
-      - name: Get changed C++ files
-        id: changed-cxx-files
-        uses: tj-actions/changed-files@v37
-        with:
-          files: |
-            **.h
-            **.cpp
-      # Comment blocks starting with "/*!" do not support autobrief
-      - name: Check for problematic Doxygen comment blocks
-        if: steps.changed-cxx-files.outputs.any_changed == 'true'
-        run: |
-          RETCODE=0
-          for file in ${{ steps.changed-cxx-files.outputs.all_changed_files }}; do
-            RESULT=`perl -0777 -ne 'while(m/\n\n *\/\*!.*?\*\//gs){print "$&\n";}' $file`
-            if [ "$RESULT" ]; then
-              echo ------ ${file} ------
-              echo "$RESULT"
-              RETCODE=1
-            fi
-          done
-          exit $RETCODE
-
   docs:
     name: Build docs
     runs-on: ubuntu-latest

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -301,8 +301,8 @@ jobs:
         files: ./coverage.xml,./build/pycov.xml,./interfaces/dotnet/coverage.cobertura.xml
         fail_ci_if_error: true
 
-  example-keywords:
-    name: Check example keywords
+  linter:
+    name: Lint checks
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
@@ -312,8 +312,29 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.10'
-      - name: Check keywords
+      - name: Check example keywords
         run: python3 doc/example-keywords.py compare
+      - name: Get changed C++ files
+        id: changed-cxx-files
+        uses: tj-actions/changed-files@v37
+        with:
+          files: |
+            **.h
+            **.cpp
+      # Comment blocks starting with "/*!" do not support autobrief
+      - name: Check for problematic Doxygen comment blocks
+        if: steps.changed-cxx-files.outputs.any_changed == 'true'
+        run: |
+          RETCODE=0
+          for file in ${{ steps.changed-cxx-files.outputs.all_changed_files }}; do
+            RESULT=`perl -0777 -ne 'while(m/\n\n *\/\*!.*?\*\//gs){print "$&\n";}' $file`
+            if [ "$RESULT" ]; then
+              echo ------ ${file} ------
+              echo "$RESULT"
+              RETCODE=1
+            fi
+          done
+          exit $RETCODE
 
   docs:
     name: Build docs


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

Automate checks for some formatting issues that are easy to miss during pull request reviews.

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Check modified files for misleading Doxygen comment blocks that do not support "autobrief"
- Check for whitespace issues using `git diff --check`: trailing whitespace, tabs in indentation, and CRLF line endings.

**If applicable, provide an example illustrating new features this pull request is introducing**

CI will indicate failure and logs will include messages like the following for whitespace issues:
```
include/cantera/kinetics/Kinetics.h:48: trailing whitespace.
+//! reversible with a reverse rate satisfying detailed balance, include  
include/cantera/kinetics/Kinetics.h:55: trailing whitespace.
+//! A kinetics manager implements a kinetics model. Since the model equations  
include/cantera/kinetics/Kinetics.h:56: trailing whitespace.
+//! may be complex and expensive to evaluate, a kinetics manager may adopt 
```

And like this for bare `/*!` comment blocks (without a preceding `//!` block to provide the "brief" description):
```
------ include/cantera/kinetics/Kinetics.h ------


    /*!
     * Takes as input an array of properties for all species in the mechanism
     * and copies those values belonging to a particular phase to the output
     * array.
     * @param data Input data array.
     * @param phase Pointer to one of the phase objects participating in this
     *     reaction mechanism
     * @param phase_data Output array where the values for the the specified
     *     phase are to be written.
     * @deprecated Unused. To be removed after %Cantera 3.0.
     */
```

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
