### PR TITLE
Fix for Sundials 6.6 behavior changes

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -468,6 +468,8 @@ jobs:
           fmt-ver: 9.1
         - sundials-ver: 6.4.1
           fmt-ver: 10
+        - sundials-ver: 6.6
+          fmt-ver: 10
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/SConstruct
+++ b/SConstruct
@@ -1512,7 +1512,7 @@ if env['system_sundials'] == 'y':
     if sundials_ver < parse_version("3.0") or sundials_ver >= parse_version("7.0"):
         logger.error(f"Sundials version {env['sundials_version']!r} is not supported.")
         sys.exit(1)
-    elif sundials_ver > parse_version("6.4.1"):
+    elif sundials_ver > parse_version("6.6.0"):
         logger.warning(f"Sundials version {env['sundials_version']!r} has not been tested.")
 
     logger.info(f"Using system installation of Sundials version {sundials_version!r}.")

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -150,7 +150,7 @@ public:
     // overloaded methods of class FuncEval
 
     //! Return the number of equations
-    virtual size_t neq() {
+    virtual size_t neq() const {
         return m_nv;
     }
 

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -90,6 +90,10 @@ protected:
 private:
     void sensInit(double t0, FuncEval& func);
 
+    //! Check whether a CVODES method indicated an error. If so, throw an exception
+    //! containing the method name and the error code stashed by the cvodes_err() function.
+    void checkError(long flag, const string& ctMethod, const string& cvodesMethod) const;
+
     size_t m_neq = 0;
     void* m_cvode_mem = nullptr;
     SundialsContext m_sundials_ctx; //!< SUNContext object for Sundials>=6.0

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -97,8 +97,16 @@ private:
     void* m_linsol_matrix = nullptr; //!< matrix used by Sundials
     FuncEval* m_func = nullptr;
     double m_t0 = 0.0;
-    double m_time; //!< The current integrator time
+
+    //! The current system time, corresponding to #m_y
+    double m_time;
+
+    //! The latest time reached by the integrator. May be greater than #m_time.
+    double m_tInteg;
+
+    //! The system state at #m_time
     N_Vector m_y = nullptr;
+
     N_Vector m_abstol = nullptr;
     N_Vector m_dky = nullptr;
     string m_type = "DENSE";

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -150,10 +150,10 @@ public:
     }
 
     //! Number of equations.
-    virtual size_t neq()=0;
+    virtual size_t neq() const = 0;
 
     //! Number of sensitivity parameters.
-    virtual size_t nparams() {
+    virtual size_t nparams() const {
         return m_sens_params.size();
     }
 

--- a/include/cantera/numerics/IdasIntegrator.h
+++ b/include/cantera/numerics/IdasIntegrator.h
@@ -107,7 +107,11 @@ private:
     FuncEval* m_func = nullptr;
 
     double m_t0 = 0.0; //!< The start time for the integrator
-    double m_time; //!< The current integrator time
+    double m_time; //!< The current integrator time, corresponding to #m_y
+
+    //! The latest time reached by the integrator. May be greater than #m_time
+    double m_tInteg;
+
     N_Vector m_y = nullptr; //!< The current system state
     N_Vector m_ydot = nullptr; //!< The time derivatives of the system state
     N_Vector m_abstol = nullptr; //!< Absolute tolerances for each state variable

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -157,7 +157,7 @@ public:
 
     //! Number of sensitivity parameters associated with this reactor
     //! (including walls)
-    virtual size_t nSensParams();
+    virtual size_t nSensParams() const;
 
     //! Add a sensitivity parameter associated with the reaction number *rxn*
     //! (in the homogeneous phase).
@@ -183,14 +183,14 @@ public:
 
     //! Check whether Reactor object uses advance limits
     //! @returns           True if at least one limit is set, False otherwise
-    bool hasAdvanceLimits() {
+    bool hasAdvanceLimits() const {
         return !m_advancelimits.empty();
     }
 
     //! Retrieve absolute step size limits during advance
     //! @param[out] limits array of step size limits with length neq
     //! @returns           True if at least one limit is set, False otherwise
-    bool getAdvanceLimits(double* limits);
+    bool getAdvanceLimits(double* limits) const;
 
     //! Set individual step size limit for component name *nm*
     //! @param nm component name

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -60,7 +60,7 @@ public:
     }
 
     //! Get the maximum integrator step.
-    double maxTimeStep() {
+    double maxTimeStep() const {
         return m_maxstep;
     }
 
@@ -205,11 +205,11 @@ public:
                       double* ydot, double* p, Array2D* j);
 
     // overloaded methods of class FuncEval
-    virtual size_t neq() {
+    virtual size_t neq() const {
         return m_nv;
     }
 
-    size_t nReactors() {
+    size_t nReactors() const {
         return m_reactors.size();
     }
 
@@ -227,7 +227,7 @@ public:
 
     virtual void getConstraints(double* constraints);
 
-    virtual size_t nparams() {
+    virtual size_t nparams() const {
         return m_sens_params.size();
     }
 
@@ -254,7 +254,7 @@ public:
                                         double scale);
 
     //! The name of the p-th sensitivity parameter added to this ReactorNet.
-    const std::string& sensitivityParameterName(size_t p) {
+    const string& sensitivityParameterName(size_t p) const {
         return m_paramNames.at(p);
     }
 
@@ -284,10 +284,10 @@ public:
     void setAdvanceLimits(const double* limits);
 
     //! Check whether ReactorNet object uses advance limits
-    bool hasAdvanceLimits();
+    bool hasAdvanceLimits() const;
 
     //! Retrieve absolute step size limits during advance
-    bool getAdvanceLimits(double* limits);
+    bool getAdvanceLimits(double* limits) const;
 
     virtual void preconditionerSetup(double t, double* y, double gamma);
 
@@ -302,7 +302,7 @@ public:
 
 protected:
     //! Check that preconditioning is supported by all reactors in the network
-    virtual void checkPreconditionerSupported();
+    virtual void checkPreconditionerSupported() const;
 
     //! Update the preconditioner based on the already computed jacobian values
     virtual void updatePreconditioner(double gamma);
@@ -315,7 +315,7 @@ protected:
     //! Returns the order used for last solution step of the ODE integrator
     //! The function is intended for internal use by ReactorNet::advance
     //! and deliberately not exposed in external interfaces.
-    virtual int lastOrder();
+    virtual int lastOrder() const;
 
     std::vector<Reactor*> m_reactors;
     std::unique_ptr<Integrator> m_integ;

--- a/samples/cxx/custom/custom.cpp
+++ b/samples/cxx/custom/custom.cpp
@@ -113,7 +113,7 @@ public:
      * Number of equations in the ODE system.
      *   - overridden from FuncEval, called by the integrator during initialization.
      */
-    size_t neq() {
+    size_t neq() const {
         return m_nEqs;
     }
 

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -514,6 +514,11 @@ void CVodesIntegrator::integrate(double tout)
 {
     if (tout == m_time) {
         return;
+    } else if (tout < m_time) {
+        throw CanteraError("CVodesIntegrator::integrate",
+                           "Cannot integrate backwards in time.\n"
+                           "Requested time {} < current time {}",
+                           tout, m_time);
     }
     int nsteps = 0;
     while (m_tInteg < tout) {

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -637,7 +637,7 @@ double CVodesIntegrator::sensitivity(size_t k, size_t p)
         return 0.0;
     }
     if (!m_sens_ok && m_np) {
-        int flag = CVodeGetSens(m_cvode_mem, &m_time, m_yS);
+        int flag = CVodeGetSensDky(m_cvode_mem, m_time, 0, m_yS);
         checkError(flag, "sensitivity", "CVodeGetSens");
         m_sens_ok = true;
     }

--- a/src/numerics/IdasIntegrator.cpp
+++ b/src/numerics/IdasIntegrator.cpp
@@ -453,6 +453,11 @@ void IdasIntegrator::integrate(double tout)
 {
     if (tout == m_time) {
         return;
+    } else if (tout < m_time) {
+        throw CanteraError("IdasIntegrator::integrate",
+                           "Cannot integrate backwards in time.\n"
+                           "Requested time {} < current time {}",
+                           tout, m_time);
     }
     int nsteps = 0;
     while (m_tInteg < tout) {

--- a/src/numerics/IdasIntegrator.cpp
+++ b/src/numerics/IdasIntegrator.cpp
@@ -512,7 +512,7 @@ double IdasIntegrator::sensitivity(size_t k, size_t p)
         return 0.0;
     }
     if (!m_sens_ok && m_np) {
-        int flag = IDAGetSens(m_ida_mem, &m_time, m_yS);
+        int flag = IDAGetSensDky(m_ida_mem, m_time, 0, m_yS);
         checkError(flag, "sensitivity", "IDAGetSens");
         m_sens_ok = true;
     }

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -109,7 +109,7 @@ void Reactor::initialize(double t0)
     m_work.resize(maxnt);
 }
 
-size_t Reactor::nSensParams()
+size_t Reactor::nSensParams() const
 {
     size_t ns = m_sensParams.size();
     for (auto& S : m_surfaces) {
@@ -549,7 +549,7 @@ void Reactor::setAdvanceLimits(const double *limits)
     }
 }
 
-bool Reactor::getAdvanceLimits(double *limits)
+bool Reactor::getAdvanceLimits(double *limits) const
 {
     bool has_limit = hasAdvanceLimits();
     if (has_limit) {

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -272,7 +272,7 @@ void ReactorNet::getEstimate(double time, int k, double* yest)
     }
 }
 
-int ReactorNet::lastOrder()
+int ReactorNet::lastOrder() const
 {
     if (m_integ) {
         return m_integ->lastOrder();
@@ -425,7 +425,7 @@ void ReactorNet::setAdvanceLimits(const double *limits)
     }
 }
 
-bool ReactorNet::hasAdvanceLimits()
+bool ReactorNet::hasAdvanceLimits() const
 {
     bool has_limit = false;
     for (size_t n = 0; n < m_reactors.size(); n++) {
@@ -434,7 +434,7 @@ bool ReactorNet::hasAdvanceLimits()
     return has_limit;
 }
 
-bool ReactorNet::getAdvanceLimits(double *limits)
+bool ReactorNet::getAdvanceLimits(double *limits) const
 {
     bool has_limit = false;
     for (size_t n = 0; n < m_reactors.size(); n++) {
@@ -569,7 +569,7 @@ void ReactorNet::updatePreconditioner(double gamma)
     precon->updatePreconditioner();
 }
 
-void ReactorNet::checkPreconditionerSupported() {
+void ReactorNet::checkPreconditionerSupported() const {
     // check for non-mole-based reactors and throw an error otherwise
     for (auto reactor : m_reactors) {
         if (!reactor->preconditionerSupported()) {

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -221,7 +221,7 @@ class TestReactor(utilities.CanteraTest):
         self.net.max_time_step = max_step_size
         self.net.max_steps = max_steps
         with self.assertRaisesRegex(
-                ct.CanteraError, 'mxstep steps taken before reaching tout'):
+                ct.CanteraError, 'Maximum number of timesteps'):
             self.net.advance(1e-04)
         self.assertLessEqual(self.net.time, max_steps * max_step_size)
         self.assertEqual(self.net.max_steps, max_steps)
@@ -1605,7 +1605,7 @@ class TestFlowReactor2(utilities.CanteraTest):
         sim.max_steps = 13
         assert sim.max_steps == 13
 
-        with pytest.raises(ct.CanteraError, match="mxstep steps taken"):
+        with pytest.raises(ct.CanteraError, match="Maximum number of timesteps"):
             sim.advance(0.1)
 
         assert sim.solver_stats['steps'] == 13
@@ -1624,11 +1624,12 @@ class TestFlowReactor2(utilities.CanteraTest):
         surf.TP = gas.TP
         r, rsurf, sim = self.make_reactors(gas, surf)
 
-        sim.max_time_step = 0.2
+        sim.max_time_step = 0.002
         sim.advance(0.01)
+        sim.step()
         x1 = sim.distance
         x2 = sim.step()
-        dx_limit = 0.05 * (x2-x1)
+        dx_limit = 0.1 * (x2-x1)
 
         sim.max_time_step = dx_limit
         assert sim.max_time_step == dx_limit
@@ -1746,7 +1747,7 @@ class TestFlowReactor2(utilities.CanteraTest):
         # With few steps allowed, won't be able to reach steady-state
         r.inlet_surface_max_error_failures = 10
         r.inlet_surface_max_steps = 200
-        with pytest.raises(ct.CanteraError, match="mxstep steps taken"):
+        with pytest.raises(ct.CanteraError, match="Maximum number of timesteps"):
             sim.initialize()
 
         # Relaxing the tolerances will allow the integrator to reach steady-state

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -348,6 +348,12 @@ class TestReactor(utilities.CanteraTest):
         with pytest.raises(ct.CanteraError, match="No component named 'spam'"):
             self.r1.set_advance_limit("spam", 0.1)
 
+    def test_advance_reverse(self):
+        self.make_reactors(n_reactors=1)
+        self.net.advance(0.1)
+        with pytest.raises(ct.CanteraError, match="backwards in time"):
+            self.net.advance(0.09)
+
     def test_heat_transfer2(self):
         # Result should be the same if (m * cp) / (U * A) is held constant
         self.make_reactors(T1=300, T2=1000)
@@ -1530,6 +1536,15 @@ class TestFlowReactor2(utilities.CanteraTest):
         rsurf = ct.ReactorSurface(surf, r)
         sim = ct.ReactorNet([r])
         return r, rsurf, sim
+
+    def test_advance_reverse(self):
+        surf, gas = self.import_phases()
+        gas.TPX = 1500, 4000, 'NH3:1.0, SiF4:0.4'
+        r, rsurf, sim = self.make_reactors(gas, surf)
+
+        sim.advance(0.1)
+        with pytest.raises(ct.CanteraError, match="backwards in time"):
+            sim.advance(0.09)
 
     def test_no_mass_flow_rate(self):
         surf, gas = self.import_phases()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Avoid using SUNDIALS with the `CV_NORMAL` / `IDA_NORMAL` integration option which has a breaking change in behavior starting with SUNDIALS 6.6. 
- Provide better error messages for some SUNDIALS errors 
- Mark `Reactor` and `ReactorNet` methods as `const` where possible
- Fix getting sensitivities after calling `ReactorNet.advance` to use interpolation correctly

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Resolves #1554 
Resolves #1195

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
