### PR TITLE
Use C++17 attribute for deprecated types

### DIFF
--- a/include/cantera/base/ct_defs.h
+++ b/include/cantera/base/ct_defs.h
@@ -177,7 +177,7 @@ const double Tiny = 1.e-20;
  * This is used mostly to assign concentrations and mole fractions to species.
  * @deprecated To be removed after %Cantera 3.0
  */
-typedef map<string, double> compositionMap;
+typedef map<string, double> compositionMap [[deprecated("replaceable by Composition")]];
 
 //! Map from string names to doubles. Used for defining species mole/mass
 //! fractions, elemental compositions, and reaction stoichiometries.
@@ -186,10 +186,10 @@ typedef map<string, double> Composition;
 //! Turn on the use of stl vectors for the basic array type within cantera
 //! Vector of doubles.
 //! @deprecated To be removed after %Cantera 3.0
-typedef vector<double> vector_fp;
+typedef vector<double> vector_fp [[deprecated("replaceable by vector<double>")]];
 //! Vector of ints
 //! @deprecated To be removed after %Cantera 3.0
-typedef vector<int> vector_int;
+typedef vector<int> vector_int [[deprecated("replaceable by vector<int>")]];
 
 //! index returned by functions to indicate "no position"
 const size_t npos = static_cast<size_t>(-1);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Use [C++17 attributes](https://en.cppreference.com/w/cpp/language/attributes) to generate deprecation warnings.

In #1565/#1568, the custom types `compositionMap`, `vector_fp`, and `vector_int` were deprecated. The C++17 attribute `[[deprecated("reason")]]` provides for a way to generate compile-time deprecation warnings. (The usual deprecation process with `Cantera::warn_deprecated` does not work for these instances.)

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

As an example, using `vector_fp` triggers the following warning on Apple clang:

```
warning: 'vector_fp' is deprecated: replaceable by vector<double> [-Wdeprecated-declarations]
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
