### PR TITLE
Assorted C++ / SCons cleanup

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -397,7 +397,7 @@ jobs:
       - name: Install Apt dependencies
         run: |
           sudo apt update
-          sudo apt install graphviz libhdf5-103
+          sudo apt install graphviz libhdf5-103 libfmt-dev
       - name: Download the wheel artifact
         uses: actions/download-artifact@v3
         with:

--- a/SConstruct
+++ b/SConstruct
@@ -1338,7 +1338,7 @@ if env["system_eigen"] in ("n", "default"):
             config_error("Eigen not found and submodule checkout failed.\n"
                          "Try manually checking out the submodule with:\n\n"
                          "    git submodule update --init --recursive ext/eigen\n")
-    eigen_include = "'../ext/eigen/Eigen/Core'"
+    eigen_include = '"../ext/eigen/Eigen/Core"'
 
 eigen_versions = 'QUOTE(EIGEN_WORLD_VERSION) "." QUOTE(EIGEN_MAJOR_VERSION) "." QUOTE(EIGEN_MINOR_VERSION)'
 eigen_version_source = get_expression_value([eigen_include], eigen_versions)

--- a/SConstruct
+++ b/SConstruct
@@ -1373,9 +1373,10 @@ if not env['BOOST_LIB_VERSION']:
                  " 'boost_inc_dir' to point to the boost headers.")
 else:
     logger.info(f"Found Boost version {env['BOOST_LIB_VERSION']}")
-if parse_version(env['BOOST_LIB_VERSION']) < parse_version("1.61"):
-    # dll support is available in Boost 1.61 or newer
-    config_error("Cantera requires Boost version 1.61 or newer.")
+if parse_version(env['BOOST_LIB_VERSION']) < parse_version("1.70"):
+    # Boost.DLL with std::filesystem (making it header-only) is available in Boost 1.70
+    # or newer
+    config_error("Cantera requires Boost version 1.70 or newer.")
 
 # check BLAS/LAPACK installations
 if env["system_blas_lapack"] == "n":

--- a/SConstruct
+++ b/SConstruct
@@ -1239,7 +1239,10 @@ if env['system_fmt'] in ('n', 'default'):
     env['system_fmt'] = False
     logger.info(f"Using private installation of fmt library.")
 
-env.Append(CPPDEFINES={"FMT_HEADER_ONLY": 1})
+if env["OS"] == "Windows" and parse_version(fmt_lib_version) < parse_version("8.0.0"):
+    # Workaround for symbols not exported on Windows in older fmt versions
+    env.Append(CPPDEFINES={"FMT_HEADER_ONLY": 1})
+
 logger.info(f"Using fmt version {fmt_lib_version}")
 
 # Check for yaml-cpp library and checkout submodule if needed

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -285,7 +285,7 @@ public:
     bool hasMapWhere(const string& key, const string& value) const;
 
     //! Return values used to determine the sort order when outputting to YAML
-    pair <int, int> order() const;
+    pair<int, int> order() const;
 
     //! See AnyMap::applyUnits()
     void applyUnits(shared_ptr<UnitSystem>& units);

--- a/include/cantera/base/Array.h
+++ b/include/cantera/base/Array.h
@@ -35,6 +35,7 @@ public:
     //! types.
     /*!
      * This is just equal to vector<double>::iterator.
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     typedef vector<double>::iterator iterator;
 
@@ -42,6 +43,7 @@ public:
     //! Array2D types.
     /*!
      * This is just equal to vector<double>::const_iterator.
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     typedef vector<double>::const_iterator const_iterator;
 
@@ -197,24 +199,20 @@ public:
     }
 
     //! Return an iterator pointing to the first element
-    iterator begin() {
-        return m_data.begin();
-    }
+    //! @deprecated Unused. To be removed after %Cantera 3.0.
+    iterator begin();
 
     //! Return an iterator pointing past the last element
-    iterator end() {
-        return m_data.end();
-    }
+    //! @deprecated Unused. To be removed after %Cantera 3.0.
+    iterator end();
 
     //! Return a const iterator pointing to the first element
-    const_iterator begin() const {
-        return m_data.begin();
-    }
+    //! @deprecated Unused. To be removed after %Cantera 3.0.
+    const_iterator begin() const;
 
     //! Return a const iterator pointing to past the last element
-    const_iterator end() const {
-        return m_data.end();
-    }
+    //! @deprecated Unused. To be removed after %Cantera 3.0.
+    const_iterator end() const;
 
     //! Return a reference to the data vector
     vector<double>& data() {
@@ -225,6 +223,8 @@ public:
     const vector<double>& data() const {
         return m_data;
     }
+
+    void operator*=(double a);
 
     //! Return a pointer to the top of column j, columns are contiguous
     //! in memory

--- a/include/cantera/base/ValueCache.h
+++ b/include/cantera/base/ValueCache.h
@@ -176,10 +176,10 @@ public:
 
 protected:
     //! Cached scalar values
-    map<int, CachedValue<double> > m_scalarCache;
+    map<int, CachedValue<double>> m_scalarCache;
 
     //! Cached array values
-    map<int, CachedValue<vector<double>> > m_arrayCache;
+    map<int, CachedValue<vector<double>>> m_arrayCache;
 
     //! The last assigned id. Automatically incremented by the getId() method.
     static int m_last_id;

--- a/include/cantera/equil/vcs_solve.h
+++ b/include/cantera/equil/vcs_solve.h
@@ -1451,7 +1451,7 @@ public:
     //! Charge of each species. Length = number of species.
     vector<double> m_chargeSpecies;
 
-    vector<vector<size_t> > phasePopProblemLists_;
+    vector<vector<size_t>> phasePopProblemLists_;
 
     //! Vector of pointers to thermo structures which identify the model
     //! and parameters for evaluating the thermodynamic functions for that

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -483,7 +483,7 @@ protected:
      *  m_rxnPhaseIsReactant[j][p] indicates whether a species in phase p
      *  participates in reaction j as a reactant.
      */
-    vector<vector<bool> > m_rxnPhaseIsReactant;
+    vector<vector<bool>> m_rxnPhaseIsReactant;
 
     //! Vector of vector of booleans indicating whether a phase participates in a
     //! reaction as a product
@@ -491,7 +491,7 @@ protected:
      *  m_rxnPhaseIsReactant[j][p] indicates whether a species in phase p
      *  participates in reaction j as a product.
      */
-    vector<vector<bool> > m_rxnPhaseIsProduct;
+    vector<vector<bool>> m_rxnPhaseIsProduct;
 
     int m_ioFlag = 0;
 

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -1546,7 +1546,7 @@ protected:
     vector<double> m_perturb;
 
     //! Vector of Reaction objects represented by this Kinetics manager
-    vector<shared_ptr<Reaction> > m_reactions;
+    vector<shared_ptr<Reaction>> m_reactions;
 
     //! m_thermo is a vector of pointers to ThermoPhase objects that are
     //! involved with this kinetics operator

--- a/include/cantera/kinetics/ReactionPath.h
+++ b/include/cantera/kinetics/ReactionPath.h
@@ -279,7 +279,7 @@ public:
 
 protected:
     double m_flxmax = 0.0;
-    map<size_t, map<size_t, Path*> > m_paths;
+    map<size_t, map<size_t, Path*>> m_paths;
 
     //! map of species index to SpeciesNode
     map<size_t, SpeciesNode*> m_nodes;
@@ -317,8 +317,8 @@ protected:
     vector<double> m_ropf;
     vector<double> m_ropr;
     vector<double> m_x;
-    vector<vector<size_t> > m_reac;
-    vector<vector<size_t> > m_prod;
+    vector<vector<size_t>> m_reac;
+    vector<vector<size_t>> m_prod;
     DenseMatrix m_elatoms;
     vector<vector<int>> m_groups;
     vector<Group> m_sgroup;
@@ -327,7 +327,7 @@ protected:
     //! m_transfer[reaction][reactant number][product number] where "reactant
     //! number" means the number of the reactant in the reaction equation. For example,
     //! for "A+B -> C+D", "B" is reactant number 1 and "C" is product number 0.
-    map<size_t, map<size_t, map<size_t, Group> > > m_transfer;
+    map<size_t, map<size_t, map<size_t, Group>>> m_transfer;
 
     vector<bool> m_determinate;
     Array2D m_atoms;

--- a/include/cantera/kinetics/ThirdBodyCalc.h
+++ b/include/cantera/kinetics/ThirdBodyCalc.h
@@ -136,7 +136,7 @@ protected:
     vector<size_t> m_no_mass_action_index;
 
     //! m_species[i][j] is the index of the j-th species in reaction i.
-    vector<vector<size_t> > m_species;
+    vector<vector<size_t>> m_species;
 
     //! m_eff[i][j] is the efficiency of the j-th species in reaction i.
     vector<vector<double>> m_eff;

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -167,24 +167,28 @@ public:
     //! Returns an iterator for the start of the band storage data
     /*!
      * Iterator points to the beginning of the data, and it is changeable.
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     virtual vector<double>::iterator begin();
 
     //! Returns an iterator for the end of the band storage data
     /*!
      * Iterator points to the end of the data, and it is changeable.
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     vector<double>::iterator end();
 
     //! Returns a const iterator for the start of the band storage data
     /*!
      * Iterator points to the beginning of the data, and it is not changeable.
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     vector<double>::const_iterator begin() const;
 
     //! Returns a const iterator for the end of the band storage data
     /*!
      * Iterator points to the end of the data, and it is not changeable.
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     vector<double>::const_iterator end() const;
 

--- a/include/cantera/numerics/GeneralMatrix.h
+++ b/include/cantera/numerics/GeneralMatrix.h
@@ -143,13 +143,13 @@ public:
 
     //! Return an iterator pointing to the first element
     /*!
-     * We might drop this later
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     virtual vector<double>::iterator begin() = 0;
 
     //! Return a const iterator pointing to the first element
     /*!
-     * We might drop this later
+     * @deprecated Unused. To be removed after %Cantera 3.0.
      */
     virtual vector<double>::const_iterator begin() const = 0;
 

--- a/include/cantera/thermo/CoverageDependentSurfPhase.h
+++ b/include/cantera/thermo/CoverageDependentSurfPhase.h
@@ -137,36 +137,8 @@ public:
          *          a target species
          * @param dep_map map of coverage-dependency parameters
          */
-        PolynomialDependency(size_t k, size_t j, const AnyMap& dep_map):
-            k(k),
-            j(j),
-            enthalpy_coeffs({0.0, 0.0, 0.0, 0.0, 0.0}),
-            entropy_coeffs({0.0, 0.0, 0.0, 0.0, 0.0}),
-            isLinear(false)
-        {
-            // For linear model
-            if (dep_map["model"] == "linear") {
-                if (dep_map.hasKey("enthalpy")) {
-                    enthalpy_coeffs[1] = dep_map.convert("enthalpy", "J/kmol");
-                }
-                if (dep_map.hasKey("entropy")) {
-                    entropy_coeffs[1] = dep_map.convert("entropy", "J/kmol/K");
-                }
-                isLinear = true;
-            // For polynomial(4th) model
-            } else if (dep_map["model"] == "polynomial") {
-                if (dep_map.hasKey("enthalpy-coefficients")) {
-                    enthalpy_coeffs = dep_map.convertVector(
-                        "enthalpy-coefficients", "J/kmol");
-                    enthalpy_coeffs.insert(enthalpy_coeffs.begin(), 0.0);
-                }
-                if (dep_map.hasKey("entropy-coefficients")) {
-                    entropy_coeffs = dep_map.convertVector(
-                        "entropy-coefficients", "J/kmol/K");
-                    entropy_coeffs.insert(entropy_coeffs.begin(), 0.0);
-                }
-            }
-        }
+        PolynomialDependency(size_t k, size_t j, const AnyMap& dep_map);
+
         //! index of a target species whose enthalpy and entropy is calculated
         size_t k;
         //! index of a species whose coverage affects enthalpy and entropy of
@@ -199,71 +171,8 @@ public:
          * @param node species node of a target species
          */
         InterpolativeDependency(size_t k, size_t j,
-                                const AnyMap& dep_map, const AnyBase& node):
-            k(k),
-            j(j),
-            enthalpy_map({{0.0, 0.0}, {1.0, 0.0}}),
-            entropy_map({{0.0, 0.0}, {1.0, 0.0}}),
-            isPiecewise(false)
-        {
-            // For piecewise-linear model
-            // Piecewise-linear model coefficients are converted into
-            // a map <coverages: values>
-            if (dep_map["model"] == "piecewise-linear") {
-                if (dep_map.hasKey("enthalpy-low") ||
-                    dep_map.hasKey("enthalpy-change") ||
-                    dep_map.hasKey("enthalpy-high")) {
-                    auto cov_change = dep_map["enthalpy-change"].as<double>();
-                    enthalpy_map[cov_change] =
-                        dep_map.convert("enthalpy-low", "J/kmol") * cov_change;
-                    enthalpy_map[1.0] = (1.0 - cov_change)
-                        * dep_map.convert("enthalpy-high", "J/kmol")
-                        + enthalpy_map[cov_change];
-                }
-                if (dep_map.hasKey("entropy-low") ||
-                    dep_map.hasKey("entropy-change") ||
-                    dep_map.hasKey("entropy-high")) {
-                    auto cov_change = dep_map["entropy-change"].as<double>();
-                    entropy_map[cov_change] =
-                        dep_map.convert("entropy-low", "J/kmol/K") * cov_change;
-                    entropy_map[1.0] = (1.0 - cov_change)
-                        * dep_map.convert("entropy-high", "J/kmol/K")
-                        + entropy_map[cov_change];
-                }
-                isPiecewise = true;
-            // For interpolative model
-            } else if (dep_map["model"] == "interpolative") {
-                if (dep_map.hasKey("enthalpy-coverages") ||
-                    dep_map.hasKey("enthalpies")) {
-                    auto hcovs = dep_map["enthalpy-coverages"].as<vector<double>>();
-                    vector<double> enthalpies = dep_map.convertVector("enthalpies", "J/kmol");
-                    if (hcovs.size() != enthalpies.size()) {
-                        throw InputFileError("CoverageDependentSurfPhase::\
-                        addInterpolativeDependency", node,
-                        "Sizes of coverages array and enthalpies array are \
-                        not equal.");
-                    }
-                    for (size_t i = 0; i < hcovs.size(); i++) {
-                        enthalpy_map[hcovs[i]] = enthalpies[i];
-                    }
-                }
-                if (dep_map.hasKey("entropy-coverages") ||
-                    dep_map.hasKey("entropies")) {
-                    auto scovs = dep_map["entropy-coverages"].as<vector<double>>();
-                    vector<double> entropies = dep_map.convertVector("entropies",
-                                                                "J/kmol/K");
-                    if (scovs.size() != entropies.size()) {
-                        throw InputFileError("CoverageDependentSurfPhase::\
-                        addInterpolativeDependency", node,
-                        "Sizes of coverages array and entropies array are \
-                        not equal.");
-                    }
-                    for (size_t i = 0; i < scovs.size(); i++) {
-                        entropy_map[scovs[i]] = entropies[i];
-                    }
-                }
-            }
-        }
+                                const AnyMap& dep_map, const AnyBase& node);
+
         //! index of a target species whose enthalpy and entropy are calculated
         size_t k;
         //! index of a species whose coverage affects enthalpy and entropy of

--- a/include/cantera/thermo/MultiSpeciesThermo.h
+++ b/include/cantera/thermo/MultiSpeciesThermo.h
@@ -199,8 +199,8 @@ protected:
     //! Mark species *k* as having its thermodynamic data installed
     void markInstalled(size_t k);
 
-    typedef pair<size_t, shared_ptr<SpeciesThermoInterpType> > index_STIT;
-    typedef map<int, vector<index_STIT> > STIT_map;
+    typedef pair<size_t, shared_ptr<SpeciesThermoInterpType>> index_STIT;
+    typedef map<int, vector<index_STIT>> STIT_map;
     typedef map<int, vector<double>> tpoly_map;
 
     //! This is the main data structure, which contains the
@@ -215,7 +215,7 @@ protected:
     //! Map from species index to location within #m_sp, such that
     //! `m_sp[m_speciesLoc[k].first][m_speciesLoc[k].second]` is the
     //! SpeciesThermoInterpType object for species `k`.
-    map<size_t, pair<int, size_t> > m_speciesLoc;
+    map<size_t, pair<int, size_t>> m_speciesLoc;
 
     //! Maximum value of the lowest temperature
     double m_tlow_max = 0.0;

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -969,7 +969,7 @@ protected:
 
     vector<double> m_speciesCharge; //!< Vector of species charges. length m_kk.
 
-    map<string, shared_ptr<Species> > m_species;
+    map<string, shared_ptr<Species>> m_species;
 
     //! Flag determining behavior when adding species with an undefined element
     UndefElement::behavior m_undefinedElementBehavior = UndefElement::add;

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -7,14 +7,11 @@
 #define CT_WALL_H
 
 #include "cantera/base/ctexceptions.h"
-#include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/zeroD/ReactorBase.h"
 
 namespace Cantera
 {
 
-class Kinetics;
-class SurfPhase;
 class Func1;
 
 /**
@@ -24,7 +21,7 @@ class Func1;
 class WallBase
 {
 public:
-    WallBase();
+    WallBase() = default;
 
     virtual ~WallBase() {}
     WallBase(const WallBase&) = delete;
@@ -121,8 +118,6 @@ public:
 protected:
     ReactorBase* m_left = nullptr;
     ReactorBase* m_right = nullptr;
-
-    vector<ReactorSurface> m_surf;
 
     //! current reactor network time
     double m_time = 0.0;

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -18,7 +18,13 @@ pc_libdirs = []
 pc_incdirs = []
 pc_cflags = list(localenv['CXXFLAGS'])
 
-if not localenv["package_build"]:
+if localenv["package_build"]:
+    # Remove local conda build environment from the installed include list
+    for i in range(len(pc_cflags) - 1):
+        if pc_cflags[i] == '-isystem' and '/_build_env/' in pc_cflags[i+1]:
+            del pc_cflags[i:i+2]
+            break
+else:
     pc_incdirs.extend(localenv["extra_inc_dirs"])
     pc_libdirs.extend(localenv["extra_lib_dirs"])
 

--- a/src/base/Array.cpp
+++ b/src/base/Array.cpp
@@ -7,6 +7,7 @@
 
 #include "cantera/base/Array.h"
 #include "cantera/base/utilities.h"
+#include "cantera/base/global.h"
 
 namespace Cantera
 {
@@ -96,6 +97,25 @@ void Array2D::getColumn(size_t m, double* const col)
     }
 }
 
+Array2D::iterator Array2D::begin() {
+    warn_deprecated("Array2D::begin", "To be removed after Cantera 3.0.");
+    return m_data.begin();
+}
+
+Array2D::iterator Array2D::end() {
+    warn_deprecated("Array2D::end", "To be removed after Cantera 3.0.");
+    return m_data.end();
+}
+
+Array2D::const_iterator Array2D::begin() const {
+    warn_deprecated("Array2D::begin", "To be removed after Cantera 3.0.");
+    return m_data.begin();
+}
+
+Array2D::const_iterator Array2D::end() const {
+    warn_deprecated("Array2D::end", "To be removed after Cantera 3.0.");
+    return m_data.end();
+}
 
 std::ostream& operator<<(std::ostream& s, const Array2D& m)
 {

--- a/src/equil/MultiPhaseEquil.cpp
+++ b/src/equil/MultiPhaseEquil.cpp
@@ -591,7 +591,7 @@ double MultiPhaseEquil::computeReactionSteps(vector<double>& dxi)
 void MultiPhaseEquil::computeN()
 {
     // Sort the list of species by mole fraction (decreasing order)
-    vector<pair<double, size_t> > moleFractions(m_nsp);
+    vector<pair<double, size_t>> moleFractions(m_nsp);
     for (size_t k = 0; k < m_nsp; k++) {
         // use -Xk to generate reversed sort order
         moleFractions[k] = {-m_mix->speciesMoles(m_species[k]), k};

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -107,8 +107,8 @@ void Kinetics::checkSpeciesArraySize(size_t kk) const
 pair<size_t, size_t> Kinetics::checkDuplicates(bool throw_err) const
 {
     //! Map of (key indicating participating species) to reaction numbers
-    map<size_t, vector<size_t> > participants;
-    vector<map<int, double> > net_stoich;
+    map<size_t, vector<size_t>> participants;
+    vector<map<int, double>> net_stoich;
     std::unordered_set<size_t> unmatched_duplicates;
     for (size_t i = 0; i < m_reactions.size(); i++) {
         if (m_reactions[i]->duplicate) {

--- a/src/kinetics/ReactionPath.cpp
+++ b/src/kinetics/ReactionPath.cpp
@@ -540,8 +540,8 @@ int ReactionPathBuilder::init(ostream& logfile, Kinetics& kin)
 
     // all reactants / products, even ones appearing on both sides of the
     // reaction
-    vector<vector<size_t> > allProducts(m_nr);
-    vector<vector<size_t> > allReactants(m_nr);
+    vector<vector<size_t>> allProducts(m_nr);
+    vector<vector<size_t>> allReactants(m_nr);
     for (size_t i = 0; i < m_nr; i++) {
         for (size_t k = 0; k < m_ns; k++) {
             for (int n = 0; n < kin.reactantStoichCoeff(k, i); n++) {
@@ -733,7 +733,7 @@ int ReactionPathBuilder::build(Kinetics& s, const string& element,
                         double f;
                         if ((m_atoms(kkp,m) < m_elatoms(m, i)) &&
                                 (m_atoms(kkr,m) < m_elatoms(m, i))) {
-                            map<size_t, map<size_t, Group> >& g = m_transfer[i];
+                            map<size_t, map<size_t, Group>>& g = m_transfer[i];
                             if (g.empty()) {
                                 if (!warn[i] && !quiet) {
                                     output << endl;

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -292,23 +292,27 @@ int BandMatrix::solve(double* b, size_t nrhs, size_t ldb)
 
 vector<double>::iterator BandMatrix::begin()
 {
+    warn_deprecated("BandMatrix::begin", "To be removed after Cantera 3.0.");
     m_factored = false;
     return data.begin();
 }
 
 vector<double>::iterator BandMatrix::end()
 {
+    warn_deprecated("BandMatrix::end", "To be removed after Cantera 3.0.");
     m_factored = false;
     return data.end();
 }
 
 vector<double>::const_iterator BandMatrix::begin() const
 {
+    warn_deprecated("BandMatrix::begin", "To be removed after Cantera 3.0.");
     return data.begin();
 }
 
 vector<double>::const_iterator BandMatrix::end() const
 {
+    warn_deprecated("BandMatrix::end", "To be removed after Cantera 3.0.");
     return data.end();
 }
 

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -660,7 +660,7 @@ string CVodesIntegrator::getErrorInfo(int N)
     CVodeGetErrWeights(m_cvode_mem, errw);
     CVodeGetEstLocalErrors(m_cvode_mem, errs);
 
-    vector<tuple<double, double, size_t> > weightedErrors;
+    vector<tuple<double, double, size_t>> weightedErrors;
     for (size_t i=0; i<m_neq; i++) {
         double err = NV_Ith_S(errs, i) * NV_Ith_S(errw, i);
         weightedErrors.emplace_back(-abs(err), err, i);

--- a/src/thermo/CoverageDependentSurfPhase.cpp
+++ b/src/thermo/CoverageDependentSurfPhase.cpp
@@ -22,6 +22,105 @@ using namespace std;
 namespace Cantera
 {
 
+CoverageDependentSurfPhase::PolynomialDependency::PolynomialDependency(
+    size_t k, size_t j, const AnyMap& dep_map
+) :
+    k(k),
+    j(j),
+    enthalpy_coeffs({0.0, 0.0, 0.0, 0.0, 0.0}),
+    entropy_coeffs({0.0, 0.0, 0.0, 0.0, 0.0}),
+    isLinear(false)
+{
+    // For linear model
+    if (dep_map["model"] == "linear") {
+        if (dep_map.hasKey("enthalpy")) {
+            enthalpy_coeffs[1] = dep_map.convert("enthalpy", "J/kmol");
+        }
+        if (dep_map.hasKey("entropy")) {
+            entropy_coeffs[1] = dep_map.convert("entropy", "J/kmol/K");
+        }
+        isLinear = true;
+    // For polynomial(4th) model
+    } else if (dep_map["model"] == "polynomial") {
+        if (dep_map.hasKey("enthalpy-coefficients")) {
+            enthalpy_coeffs = dep_map.convertVector(
+                "enthalpy-coefficients", "J/kmol");
+            enthalpy_coeffs.insert(enthalpy_coeffs.begin(), 0.0);
+        }
+        if (dep_map.hasKey("entropy-coefficients")) {
+            entropy_coeffs = dep_map.convertVector(
+                "entropy-coefficients", "J/kmol/K");
+            entropy_coeffs.insert(entropy_coeffs.begin(), 0.0);
+        }
+    }
+}
+
+CoverageDependentSurfPhase::InterpolativeDependency::InterpolativeDependency(
+    size_t k, size_t j, const AnyMap& dep_map, const AnyBase& node
+) :
+    k(k),
+    j(j),
+    enthalpy_map({{0.0, 0.0}, {1.0, 0.0}}),
+    entropy_map({{0.0, 0.0}, {1.0, 0.0}}),
+    isPiecewise(false)
+{
+    // For piecewise-linear model
+    // Piecewise-linear model coefficients are converted into
+    // a map <coverages: values>
+    if (dep_map["model"] == "piecewise-linear") {
+        if (dep_map.hasKey("enthalpy-low") ||
+            dep_map.hasKey("enthalpy-change") ||
+            dep_map.hasKey("enthalpy-high"))
+        {
+            auto cov_change = dep_map["enthalpy-change"].as<double>();
+            enthalpy_map[cov_change] =
+                dep_map.convert("enthalpy-low", "J/kmol") * cov_change;
+            enthalpy_map[1.0] = (1.0 - cov_change)
+                * dep_map.convert("enthalpy-high", "J/kmol")
+                + enthalpy_map[cov_change];
+        }
+        if (dep_map.hasKey("entropy-low") ||
+            dep_map.hasKey("entropy-change") ||
+            dep_map.hasKey("entropy-high"))
+        {
+            auto cov_change = dep_map["entropy-change"].as<double>();
+            entropy_map[cov_change] =
+                dep_map.convert("entropy-low", "J/kmol/K") * cov_change;
+            entropy_map[1.0] = (1.0 - cov_change)
+                * dep_map.convert("entropy-high", "J/kmol/K")
+                + entropy_map[cov_change];
+        }
+        isPiecewise = true;
+    // For interpolative model
+    } else if (dep_map["model"] == "interpolative") {
+        if (dep_map.hasKey("enthalpy-coverages") || dep_map.hasKey("enthalpies")) {
+            auto hcovs = dep_map["enthalpy-coverages"].as<vector<double>>();
+            vector<double> enthalpies = dep_map.convertVector("enthalpies", "J/kmol");
+            if (hcovs.size() != enthalpies.size()) {
+                throw InputFileError("CoverageDependentSurfPhase::"
+                    "addInterpolativeDependency", node,
+                    "Sizes of coverages array and enthalpies array are not equal.");
+            }
+            for (size_t i = 0; i < hcovs.size(); i++) {
+                enthalpy_map[hcovs[i]] = enthalpies[i];
+            }
+        }
+        if (dep_map.hasKey("entropy-coverages") || dep_map.hasKey("entropies")) {
+            auto scovs = dep_map["entropy-coverages"].as<vector<double>>();
+            vector<double> entropies = dep_map.convertVector("entropies",
+                                                        "J/kmol/K");
+            if (scovs.size() != entropies.size()) {
+                throw InputFileError("CoverageDependentSurfPhase::"
+                    "addInterpolativeDependency", node,
+                    "Sizes of coverages array and entropies array are not equal.");
+            }
+            for (size_t i = 0; i < scovs.size(); i++) {
+                entropy_map[scovs[i]] = entropies[i];
+            }
+        }
+    }
+}
+
 CoverageDependentSurfPhase::CoverageDependentSurfPhase(const string& infile,
                                                        const string& id_):
     m_theta_ref(1.0),

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -142,7 +142,7 @@ unique_ptr<Species> newSpecies(const AnyMap& node)
 
 vector<shared_ptr<Species>> getSpecies(const AnyValue& items)
 {
-    vector<shared_ptr<Species> > all_species;
+    vector<shared_ptr<Species>> all_species;
     for (const auto& node : items.asVector<AnyMap>()) {
         all_species.emplace_back(newSpecies(node));
     }

--- a/src/zeroD/ConstPressureMoleReactor.cpp
+++ b/src/zeroD/ConstPressureMoleReactor.cpp
@@ -5,6 +5,7 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "cantera/zeroD/Wall.h"
+#include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/ConstPressureMoleReactor.h"
 #include "cantera/base/utilities.h"

--- a/src/zeroD/ConstPressureReactor.cpp
+++ b/src/zeroD/ConstPressureReactor.cpp
@@ -6,6 +6,7 @@
 #include "cantera/zeroD/ConstPressureReactor.h"
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/Wall.h"
+#include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/kinetics/Kinetics.h"
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/base/utilities.h"

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -6,12 +6,9 @@
 #include "cantera/base/stringUtils.h"
 #include "cantera/numerics/Func1.h"
 #include "cantera/zeroD/Wall.h"
-#include "cantera/thermo/SurfPhase.h"
 
 namespace Cantera
 {
-
-WallBase::WallBase() : m_surf(2) {}
 
 bool WallBase::install(ReactorBase& rleft, ReactorBase& rright)
 {
@@ -23,15 +20,11 @@ bool WallBase::install(ReactorBase& rleft, ReactorBase& rright)
     m_right = &rright;
     m_left->addWall(*this, 0);
     m_right->addWall(*this, 1);
-    m_surf[0].setReactor(&rleft);
-    m_surf[1].setReactor(&rright);
     return true;
 }
 
 void WallBase::setArea(double a) {
     m_area = a;
-    m_surf[0].setArea(a);
-    m_surf[1].setArea(a);
 }
 
 double Wall::velocity() const {

--- a/test/python/test_units.py
+++ b/test/python/test_units.py
@@ -4,12 +4,14 @@ from typing import Optional, Tuple, Dict
 import sys
 
 import pytest
-ctu = pytest.importorskip("cantera.with_units")
+pytest.importorskip("pint", "0.17.0")
+import cantera.with_units as ctu
 import cantera as ct
 try:
     from pint.testing import assert_allclose
 except ModuleNotFoundError:
     # pint.testing was introduced in pint 0.20
+    # assert_quantity_almost_equal was introduced in pint 0.17.
     from pint.testsuite.helpers import assert_quantity_almost_equal as assert_allclose
 
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Update check for Boost to specify 1.70 as minimum version
- Use `FMT_HEADER_ONLY` only for platforms and fmt versions where necessary (revises fix for #1540)
- Fix reporting Eigen version during build process
- Clean up spacing around angle brackets in templates, e.g. change `vector<vector<double> >` to `vector<vector<double>>`
- Deprecate unused `begin()` / `end()` methods of matrix classes
- Remove vestigial `ReactorSurface` data from `WallBase`
- Keep conda build environment path out of generated `cantera.pc`
- Skip pint-based tests for pint<0.17.0, where the test helpers aren't available

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
