### PR TITLE
Adopt PEP-8 for whitespace recommendations

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -128,13 +128,26 @@
 
 ## Python
 
+### Sphinx comments
+
+* Cantera Python documentation is based on the Python documentation generator
+  [Sphinx](https://www.sphinx-doc.org/en/master/index.html)
+* All classes, member variables, and methods should include
+  [Python docstrings](https://peps.python.org/pep-0257/#what-is-a-docstring)
+* Docstrings should use annotations compatible with
+  [automatic documentation generation from code](https://www.sphinx-doc.org/en/master/tutorial/automatic-doc-generation.html).
+  For guidance, refer to existing Cantera documentation or online tutorials (see
+  [example](https://sphinx-rtd-tutorial.readthedocs.io/en/latest/docstrings.html))
+* Indicate the version added for new functions and classes with an annotation like
+  `.. versionadded:: X.Y` where `X.Y` is the next Cantera version. Significant changes
+  in behavior should be indicated with `.. versionchanged:: X.Y`.
+
+### Style Guide
+
 * Style generally follows PEP8 (https://www.python.org/dev/peps/pep-0008/)
 * Code in `.py` and `.pyx` files needs to be written to work with Python 3
 * The minimum Python version that Cantera supports is Python 3.8, so code should only
   use features added in Python 3.8 or earlier
-* Indicate the version added for new functions and classes with an annotation like
-  `.. versionadded:: X.Y` where `X.Y` is the next Cantera version. Significant changes
-  in behavior should be indicated with `.. versionchanged:: X.Y`.
 * Please use double quotes in all new Python code
 
 ## C#

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,10 +55,14 @@
 * Avoid introducing trailing whitespace
 * Limit line lengths to 88 characters when possible
 * Write comments to explain non-obvious operations
-* Use whitespaces to improve code readability (examples: after commas; before and
-  after mathematical operators (`+`/`-`/`*`/`/` except `^`), binary operators
-  (`&&`/`||`/...), and comparisons (`<`/`>`/`==`/...); before and after equality
-  signs `=` unless used for the assignment of a default parameter)
+* Use whitespaces to improve code readability. Examples: after commas; before and
+  after binary operators (`&&`/`||`/...), and comparisons (`<`/`>`/`==`/...); before and
+  after equality signs `=` unless used for the assignment of a default parameter. For
+  mathematical operators (`+`/`-`/`*`/`/` except `^`), whitespace should be added around
+  the operators with the lowest priority (examples: `x + y + z`, `x*2 - 1`, or
+  `(a+b) * (a-b)`). For additional guidance, refer to
+  [Python PEP-8](https://peps.python.org/pep-0008/#whitespace-in-expressions-and-statements),
+  where recommendations can be extrapolated to other programming languages
 * Do not go out of your way to change formatting in otherwise unmodified code
 * Write 'for example', 'such as', or 'that is' instead of using the Latin
   abbreviations 'i.e.' and 'e.g.'.

--- a/SConstruct
+++ b/SConstruct
@@ -907,7 +907,7 @@ for option in opts.keys():
     if isinstance(original, str):
         modified = os.path.expandvars(os.path.expanduser(env[option]))
         if original != modified:
-            logger.info(f"Expanding {original:!r} to {modified:!r}")
+            logger.info(f"Expanding {original!r} to {modified!r}")
             env[option] = modified
 
 if "help" in COMMAND_LINE_TARGETS:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The current style guide for whitespace (per [`CONTRIBUTING.md`](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)) recommends:

> * Use whitespaces to improve code readability (examples: after commas; before and
>  after mathematical operators (`+`/`-`/`*`/`/` except `^`), binary operators
>  (`&&`/`||`/...), and comparisons (`<`/`>`/`==`/...); before and after equality

does not follow [PEP-8 recommendations](https://peps.python.org/pep-0008/#other-recommendations). This PR updates Cantera style guide recommendations to become consistent. 

In addition:
- Update Python documentation instructions
- Fix typo in `SConstruct`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#184

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

Per PEP-8:

```Python
# Correct:
i = i + 1
submitted += 1
x = x*2 - 1
hypot2 = x*x + y*y
c = (a+b) * (a-b)
```

and 

```Python
# Wrong:
i=i+1
submitted +=1
x = x * 2 - 1  # <-- current Cantera style 
hypot2 = x * x + y * y  # <-- current Cantera style 
c = (a + b) * (a - b)  # <-- current Cantera style 
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
