### PR TITLE
Fix restoring ImpingingJet from HDF5

### DIFF
--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -104,6 +104,8 @@ public:
 
     virtual void setupGrid(size_t n, const double* z) {}
 
+    virtual void fromArray(SolutionArray& arr, double* soln);
+
 protected:
     void _init(size_t n);
 
@@ -201,7 +203,6 @@ public:
                       integer* diagg, double rdt);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void fromArray(SolutionArray& arr, double* soln) {}
 };
 
 /**
@@ -230,7 +231,6 @@ public:
                       integer* diagg, double rdt);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void fromArray(SolutionArray& arr, double* soln) {}
 };
 
 
@@ -259,7 +259,6 @@ public:
                       integer* diagg, double rdt);
 
     virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void fromArray(SolutionArray& arr, double* soln) {}
 };
 
 

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -77,6 +77,11 @@ void Boundary1D::_init(size_t n)
     }
 }
 
+void Boundary1D::fromArray(SolutionArray& arr, double* soln)
+{
+    setMeta(arr.meta());
+}
+
 // ---------------- Inlet1D methods ----------------
 
 Inlet1D::Inlet1D()
@@ -574,9 +579,10 @@ shared_ptr<SolutionArray> Surf1D::asArray(const double* soln) const
 
 void Surf1D::fromArray(SolutionArray& arr, double* soln)
 {
-    Boundary1D::setMeta(arr.meta());
-    arr.setLoc(0);
-    m_temp = arr.thermo()->temperature();
+    auto meta = arr.meta();
+    m_temp = meta["temperature"].asDouble();
+    meta.erase("temperature");
+    Boundary1D::setMeta(meta);
 }
 
 void Surf1D::show(std::ostream& s, const double* x)

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -308,7 +308,13 @@ AnyMap Sim1D::restore(const string& fname, const string& name)
 
         for (auto dom : m_dom) {
             auto arr = SolutionArray::create(dom->solution());
-            arr->readEntry(fname, name, dom->id());
+            try {
+                arr->readEntry(fname, name, dom->id());
+            } catch (CanteraError& err) {
+                throw CanteraError("Sim1D::restore",
+                    "Encountered exception when reading entry '{}' from '{}':\n{}",
+                    name, fname, err.getMessage());
+            }
             dom->resize(dom->nComponents(), arr->size());
             if (!header.hasKey("generator")) {
                 arr->meta() = legacyH5(arr, header);
@@ -318,7 +324,13 @@ AnyMap Sim1D::restore(const string& fname, const string& name)
         resize();
         m_xlast_ts.clear();
         for (auto dom : m_dom) {
-            dom->fromArray(*arrs[dom->id()], m_state->data() + dom->loc());
+            try {
+                dom->fromArray(*arrs[dom->id()], m_state->data() + dom->loc());
+            } catch (CanteraError& err) {
+                throw CanteraError("Sim1D::restore",
+                    "Encountered exception when restoring domain '{}' from HDF:\n{}",
+                    dom->id(), err.getMessage());
+            }
         }
         finalize();
     } else if (extension == "yaml" || extension == "yml") {
@@ -328,14 +340,26 @@ AnyMap Sim1D::restore(const string& fname, const string& name)
 
         for (auto dom : m_dom) {
             auto arr = SolutionArray::create(dom->solution());
-            arr->readEntry(root, name, dom->id());
+            try {
+                arr->readEntry(root, name, dom->id());
+            } catch (CanteraError& err) {
+                throw CanteraError("Sim1D::restore",
+                    "Encountered exception when reading entry '{}' from '{}':\n{}",
+                    name, fname, err.getMessage());
+            }
             dom->resize(dom->nComponents(), arr->size());
             arrs[dom->id()] = arr;
         }
         resize();
         m_xlast_ts.clear();
         for (auto dom : m_dom) {
-            dom->fromArray(*arrs[dom->id()], m_state->data() + dom->loc());
+            try {
+                dom->fromArray(*arrs[dom->id()], m_state->data() + dom->loc());
+            } catch (CanteraError& err) {
+                throw CanteraError("Sim1D::restore",
+                    "Encountered exception when restoring domain '{}' from YAML:\n{}",
+                    dom->id(), err.getMessage());
+            }
         }
         finalize();
     } else {

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -1502,6 +1502,87 @@ class TestBurnerFlame(utilities.CanteraTest):
         for rhou_j in sim.density * sim.velocity:
             self.assertNear(rhou_j, rhou, 1e-4)
 
+
+class TestStagnationFlame(utilities.CanteraTest):
+    def setUp(self):
+        self.gas = ct.Solution("h2o2.yaml")
+
+    def create_stagnation(self, comp, tsurf, tinlet, mdot, width):
+        p = 0.05 * ct.one_atm  # pressure
+        self.gas.TPX = tinlet, p, comp
+
+        sim = ct.ImpingingJet(gas=self.gas, width=width)
+        sim.inlet.mdot = mdot
+        sim.surface.T = tsurf
+        return sim
+
+    def run_stagnation(self, xh2, mdot, width):
+        # Simplified version of the example 'stagnation_flame.py'
+        tburner = 373.0  # burner temperature
+        tsurf = 500.0
+        comp = {'H2': xh2, 'O2': 1, 'AR': 7}
+        sim = self.create_stagnation(comp, tsurf, tburner, mdot, width)
+
+        sim.set_grid_min(1e-4)
+        sim.set_refine_criteria(3., 0.1, 0.2, 0.06)
+        sim.set_initial_guess(products='equil')  # assume adiabatic equilibrium products
+
+        sim.solve(loglevel=0, auto=True)
+
+        assert sim.T.max() > tburner + tsurf
+        self.sim = sim
+
+    def test_stagnation_case1(self):
+        self.run_stagnation(xh2=1.8, mdot=0.06, width=0.2)
+
+    @pytest.mark.skipif("native" not in ct.hdf_support(),
+                        reason="Cantera compiled without HDF support")
+    def test_restore_hdf(self):
+        self.run_save_restore("h5")
+
+    def test_restore_yaml(self):
+        self.run_save_restore("yaml")
+
+    def run_save_restore(self, mode):
+        filename = self.test_work_path / f"stagnation.{mode}"
+        filename.unlink(missing_ok=True)
+
+        self.run_stagnation(xh2=1.8, mdot=0.06, width=0.1)
+        self.sim.save(filename, "test")
+
+        jet = ct.ImpingingJet(gas=self.gas)
+        jet.restore(filename, "test")
+
+        self.check_save_restore(jet)
+
+    def check_save_restore(self, jet):
+        # pytest.approx is used as equality for floats cannot be guaranteed for loaded
+        # HDF5 files if they were created on a different OS and/or architecture
+        assert list(jet.grid) == pytest.approx(list(self.sim.grid))
+        assert list(jet.T) == pytest.approx(list(self.sim.T), 1e-3)
+        k = self.sim.gas.species_index('H2')
+        assert list(jet.X[k, :]) == pytest.approx(list(self.sim.X[k, :]), 1e-4)
+
+        settings = self.sim.flame.get_settings3()
+        for k, v in jet.flame.get_settings3().items():
+            assert k in settings
+            if k == "fixed_temperature":
+                # fixed temperature is NaN
+                continue
+            if isinstance(v, dict):
+                for kk, vv in v.items():
+                    if isinstance(vv, float):
+                        assert settings[k][kk] == pytest.approx(vv)
+                    else:
+                        assert settings[k][kk] == vv
+            if isinstance(k, float):
+                assert settings[k] == pytest.approx(v)
+            else:
+                assert settings[k] == v
+
+        jet.solve(loglevel=0)
+
+
 class TestImpingingJet(utilities.CanteraTest):
     def setUp(self):
         self.gas = ct.Solution("ptcombust-simple.yaml", "gas")


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix #1580
- Add unit test for `StagnationFlame`
- Improve error messages

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1580

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

Run `samples/python/onedim/stagnation_flame.py` example, then

```
In [1]: import cantera as ct
   ...: gas = ct.Solution('h2o2.yaml')
   ...: flame = ct.ImpingingJet(gas)
   ...: flame.restore('stagnation_flame_data/stagnation_flame.h5', 'mdot-0')
Out[1]:
{'cantera-version': '3.0.0b1',
 'date': 'Fri Aug 11 10:54:37 2023',
 'description': 'mdot = 0.06 kg/m2/s',
 'generator': 'Cantera SolutionArray',
 'git-commit': "'c92138c12'"}
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
