### PR TITLE
Fix issues for undeclared third-bodies and implicit third-body reactions

### DIFF
--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -1625,6 +1625,9 @@ protected:
     //! See skipUndeclaredThirdBodies()
     bool m_skipUndeclaredThirdBodies = false;
 
+    //! Flag indicating whether reactions include undeclared third bodies
+    bool m_hasUndeclaredThirdBodies = false;
+
     //! reference to Solution
     std::weak_ptr<Solution> m_root;
 };

--- a/interfaces/cython/cantera/kinetics.pxd
+++ b/interfaces/cython/cantera/kinetics.pxd
@@ -35,8 +35,8 @@ cdef extern from "cantera/kinetics/Kinetics.h" namespace "Cantera":
         void addThermo(shared_ptr[CxxThermoPhase]) except +translate_exception
         void init() except +translate_exception
         void skipUndeclaredThirdBodies(cbool)
-        void addReaction(shared_ptr[CxxReaction]) except +translate_exception
-        void addReaction(shared_ptr[CxxReaction], cbool) except +translate_exception
+        cbool addReaction(shared_ptr[CxxReaction]) except +translate_exception
+        cbool addReaction(shared_ptr[CxxReaction], cbool) except +translate_exception
         void modifyReaction(int, shared_ptr[CxxReaction]) except +translate_exception
         void invalidateCache() except +translate_exception
         void resizeReactions()

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1502,10 +1502,19 @@ cdef class Reaction:
         species names and the values, are the stoichiometric coefficients, for example
         ``{'CH4':1, 'OH':1}``, or as a composition string, for example
         ``'CH4:1, OH:1'``.
+
+        .. deprecated:: 3.0
+
+            Setter for reactants is deprecated and will be removed after Cantera 3.0.
+            Use constructor instead.
         """
         def __get__(self):
             return comp_map_to_dict(self.reaction.reactants)
         def __set__(self, reactants):
+            warnings.warn(
+                "'Reaction.reactants' setter is deprecated and will be removed after "
+                "Cantera 3.0.\nInstantiate using constructor instead.",
+                DeprecationWarning)
             self.reaction.reactants = comp_map(reactants)
 
     property products:
@@ -1514,10 +1523,19 @@ cdef class Reaction:
         species names and the values, are the stoichiometric coefficients, for example
         ``{'CH3':1, 'H2O':1}``, or as a composition string, for example
         ``'CH3:1, H2O:1'``.
+
+        .. deprecated:: 3.0
+
+            Setter for products is deprecated and will be removed after Cantera 3.0.
+            Use constructor instead.
         """
         def __get__(self):
             return comp_map_to_dict(self.reaction.products)
         def __set__(self, products):
+            warnings.warn(
+                "'Reaction.products' setter is deprecated and will be removed after "
+                "Cantera 3.0.\nInstantiate using constructor instead.",
+                DeprecationWarning)
             self.reaction.products = comp_map(products)
 
     def __contains__(self, species):

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1673,6 +1673,18 @@ cdef class Reaction:
             if self.reaction.usesThirdBody():
                 return ThirdBody.wrap(self.reaction.thirdBody())
 
+    @property
+    def third_body_name(self):
+        """
+        Returns name of `ThirdBody` collider if `Reaction` uses a third body collider,
+        and ``None`` otherwise.
+
+        .. versionadded:: 3.0
+        """
+        if self.reaction.usesThirdBody():
+            return ThirdBody.wrap(self.reaction.thirdBody()).name
+        return None
+
     property efficiencies:
         """
         Get/Set a `dict` defining non-default third-body efficiencies for this reaction,

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -88,6 +88,8 @@ void BulkKinetics::addThirdBody(shared_ptr<Reaction> r)
             throw CanteraError("BulkKinetics::addThirdBody", "Found third-body"
                 " efficiency for undefined species '{}' while adding reaction '{}'",
                 name, r->equation());
+        } else {
+            m_hasUndeclaredThirdBodies = true;
         }
     }
     m_multi_concm.install(nReactions() - 1, efficiencies,

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -643,6 +643,9 @@ AnyMap Kinetics::parameters()
         if (nReactions() == 0) {
             out["reactions"] = "none";
         }
+        if (m_hasUndeclaredThirdBodies) {
+            out["skip-undeclared-third-bodies"] = true;
+        }
     }
     return out;
 }

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -822,7 +822,9 @@ bool ThirdBody::checkSpecies(const Reaction& rxn, const Kinetics& kin) const
             throw InputFileError("ThirdBody::checkSpecies", rxn.input, "Reaction '{}'\n"
                 "is a three-body reaction with undeclared species: '{}'",
                 rxn.equation(), ba::join(undeclared, "', '"));
-        } else if (kin.skipUndeclaredSpecies() && m_name != "M") {
+        } else if (kin.skipUndeclaredThirdBodies() && m_name != "M") {
+            // Prevent addition of reaction silently as "skip-undeclared-third-bodies"
+            // is set to true
             return false;
         }
     }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Fix a series of bugs and edge cases that involve undeclared third-body colliders and/or implicitly defined third-body reactions.

- Add `skip-undeclared-third-bodies` to serialization (see #1403)
- Prevent segfault if an implicitly defined third-body reaction contains an invalid collider (see #1587)
- Prevent silent skipping of invalid reactions in Python API for creation of `Solution` from scratch
- Fix `samples/python/kinetics/extract_submechanism.py` sample, where reaction list included invalid reactions
- Address several edge cases where `Reaction` objects are created from reactant/product `Composition`, where several invalid combinations were not caught (also, implicit third-bodies were not implemented correctly).
- Deprecate `Reaction.reactants/products` setter in Python, as they allow for undefined behavior

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1403 
Closes #1587

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
