### PR TITLE
Make use of 'override' specifier

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -148,6 +148,7 @@ jobs:
       run: python3 `which scons` build env_vars=all
         CXX=clang++-12 CC=clang-12 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
         -j2 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
+        warning_flags='-Wall -Werror -Wsuggest-override'
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -767,7 +767,7 @@ public:
         {
         }
 
-    virtual string getClass() const {
+    string getClass() const override {
         return "InputFileError";
     }
 protected:

--- a/include/cantera/base/Array.h
+++ b/include/cantera/base/Array.h
@@ -86,7 +86,7 @@ public:
      * @param m  This is the number of columns in the new matrix
      * @param v  Default fill value -> defaults to zero.
      */
-    void resize(size_t n, size_t m, double v=0.0);
+    virtual void resize(size_t n, size_t m, double v=0.0);
 
     //! Append a column to the existing matrix using a std vector
     /*!

--- a/include/cantera/base/ExtensionManagerFactory.h
+++ b/include/cantera/base/ExtensionManagerFactory.h
@@ -24,7 +24,7 @@ public:
     }
 
     //! Delete the static instance of this factory
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
     //! Static function that returns the static instance of the factory, creating it
     //! if necessary.

--- a/include/cantera/base/NoExitLogger.h
+++ b/include/cantera/base/NoExitLogger.h
@@ -14,10 +14,8 @@ namespace Cantera {
 class NoExitLogger : public Logger {
 public:
     NoExitLogger() {}
-    virtual ~NoExitLogger() {}
 
-    virtual void error(const string& msg)
-    {
+    void error(const string& msg) override {
        std::cerr << msg << std::endl;
     }
 };

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -94,7 +94,7 @@ public:
     virtual ~CanteraError() throw() {};
 
     //! Get a description of the error
-    const char* what() const throw();
+    const char* what() const throw() override;
 
     //! Method overridden by derived classes to format the error message
     virtual string getMessage() const;
@@ -147,8 +147,8 @@ public:
     ArraySizeError(const string& procedure, size_t sz, size_t reqd) :
         CanteraError(procedure), sz_(sz), reqd_(reqd) {}
 
-    virtual string getMessage() const;
-    virtual string getClass() const {
+    string getMessage() const override;
+    string getClass() const override {
         return "ArraySizeError";
     }
 
@@ -178,9 +178,9 @@ public:
     IndexError(const string& func, const string& arrayName, size_t m, size_t mmax) :
         CanteraError(func), arrayName_(arrayName), m_(m), mmax_(mmax) {}
 
-    virtual ~IndexError() throw() {};
-    virtual string getMessage() const;
-    virtual string getClass() const {
+    ~IndexError() throw() override {};
+    string getMessage() const override;
+    string getClass() const override {
         return "IndexError";
     }
 
@@ -204,7 +204,7 @@ public:
     NotImplementedError(const string& func, const string& msg, const Args&... args) :
         CanteraError(func, msg, args...) {}
 
-    virtual string getClass() const {
+    string getClass() const override {
         return "NotImplementedError";
     }
 };

--- a/include/cantera/cython/funcWrapper.h
+++ b/include/cantera/cython/funcWrapper.h
@@ -100,7 +100,7 @@ public:
         Py_XDECREF(m_value);
     }
 
-    std::string getMessage() const {
+    std::string getMessage() const override {
         std::string msg;
 
         PyObject* name = PyObject_GetAttrString(m_type, "__name__");
@@ -130,7 +130,7 @@ public:
         return msg;
     }
 
-    virtual std::string getClass() const {
+    std::string getClass() const override {
         return "Exception";
     }
 
@@ -148,7 +148,7 @@ public:
         m_pyobj(pyobj) {
     }
 
-    double eval(double t) const {
+    double eval(double t) const override {
         void* err[2] = {0, 0};
         double y = m_callback(t, m_pyobj, err);
         if (err[0]) {

--- a/include/cantera/cython/utils_utils.h
+++ b/include/cantera/cython/utils_utils.h
@@ -50,7 +50,7 @@ inline int get_sundials_version()
 class PythonLogger : public Cantera::Logger
 {
 public:
-    virtual void write(const std::string& s) {
+    void write(const std::string& s) override {
         // 1000 bytes is the maximum size permitted by PySys_WriteStdout
         static const size_t N = 999;
         for (size_t i = 0; i < s.size(); i+=N) {
@@ -59,12 +59,12 @@ public:
         std::cout.flush();
     }
 
-    virtual void writeendl() {
+    void writeendl() override {
         PySys_WriteStdout("%s", "\n");
         std::cout.flush();
     }
 
-    virtual void warn(const std::string& warning, const std::string& msg) {
+    void warn(const std::string& warning, const std::string& msg) override {
         if (mapped_PyWarnings.find(warning) != mapped_PyWarnings.end()) {
             PyErr_WarnEx(mapped_PyWarnings[warning], msg.c_str(), 1);
         } else {
@@ -73,7 +73,7 @@ public:
         }
     }
 
-    virtual void error(const std::string& msg) {
+    void error(const std::string& msg) override {
         PyErr_SetString(PyExc_RuntimeError, msg.c_str());
     }
 };

--- a/include/cantera/extensions/PythonExtensionManager.h
+++ b/include/cantera/extensions/PythonExtensionManager.h
@@ -25,7 +25,7 @@ namespace Cantera
 class PythonExtensionManager : public ExtensionManager
 {
 public:
-    virtual void registerRateBuilders(const string& extensionName) override;
+    void registerRateBuilders(const string& extensionName) override;
 
     void registerRateBuilder(const string& moduleName,
         const string& className, const string& rateName) override;

--- a/include/cantera/kinetics/Arrhenius.h
+++ b/include/cantera/kinetics/Arrhenius.h
@@ -28,7 +28,7 @@ class AnyMap;
  */
 struct ArrheniusData : public ReactionData
 {
-    virtual bool update(const ThermoPhase& phase, const Kinetics& kin);
+    bool update(const ThermoPhase& phase, const Kinetics& kin) override;
     using ReactionData::update;
 };
 
@@ -79,15 +79,14 @@ public:
     //! equivalent field
     void getRateParameters(AnyMap& node) const;
 
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override;
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
-    virtual void getParameters(AnyMap& node) const override;
+    void getParameters(AnyMap& node) const override;
 
     //! Check rate expression
-    virtual void check(const string& equation) override;
+    void check(const string& equation) override;
 
-    virtual void validate(const string& equation, const Kinetics& kin) override;
+    void validate(const string& equation, const Kinetics& kin) override;
 
     //! Return the pre-exponential factor *A* (in m, kmol, s to powers depending
     //! on the reaction order)
@@ -176,7 +175,7 @@ public:
         return make_unique<MultiRate<ArrheniusRate, ArrheniusData>>();
     }
 
-    virtual const string type() const override {
+    const string type() const override {
         return "Arrhenius";
     }
 

--- a/include/cantera/kinetics/BlowersMaselRate.h
+++ b/include/cantera/kinetics/BlowersMaselRate.h
@@ -20,11 +20,11 @@ struct BlowersMaselData : public ReactionData
 {
     BlowersMaselData() = default;
 
-    virtual void update(double T) override;
-    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
+    void update(double T) override;
+    bool update(const ThermoPhase& phase, const Kinetics& kin) override;
     using ReactionData::update;
 
-    virtual void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
+    void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
         partialMolarEnthalpies.resize(nSpecies, 0.);
         ready = true;
     }
@@ -90,11 +90,11 @@ public:
         return make_unique<MultiRate<BlowersMaselRate, BlowersMaselData>>();
     }
 
-    virtual const string type() const override {
+    const string type() const override {
         return "Blowers-Masel";
     }
 
-    virtual void setContext(const Reaction& rxn, const Kinetics& kin) override;
+    void setContext(const Reaction& rxn, const Kinetics& kin) override;
 
     //! Evaluate reaction rate
     double evalRate(double logT, double recipT) const {
@@ -149,7 +149,7 @@ protected:
     }
 
 public:
-    virtual double activationEnergy() const override {
+    double activationEnergy() const override {
         return effectiveActivationEnergy_R(m_deltaH_R) * GasConstant;
     }
 

--- a/include/cantera/kinetics/ChebyshevRate.h
+++ b/include/cantera/kinetics/ChebyshevRate.h
@@ -24,15 +24,15 @@ struct ChebyshevData : public ReactionData
 {
     ChebyshevData() = default;
 
-    virtual void update(double T) override;
+    void update(double T) override;
 
-    virtual void update(double T, double P) override {
+    void update(double T, double P) override {
         ReactionData::update(T);
         pressure = P;
         log10P = std::log10(P);
     }
 
-    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
+    bool update(const ThermoPhase& phase, const Kinetics& kin) override;
 
     using ReactionData::update;
 
@@ -43,9 +43,9 @@ struct ChebyshevData : public ReactionData
      */
     void perturbPressure(double deltaP);
 
-    virtual void restore() override;
+    void restore() override;
 
-    virtual void invalidateCache() override {
+    void invalidateCache() override {
         ReactionData::invalidateCache();
         pressure = NAN;
     }
@@ -109,20 +109,20 @@ public:
 
     ChebyshevRate(const AnyMap& node, const UnitStack& rate_units={});
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
+    unique_ptr<MultiRateBase> newMultiRate() const override {
         return make_unique<MultiRate<ChebyshevRate, ChebyshevData>>();
     }
 
-    const string type() const { return "Chebyshev"; }
+    const string type() const override { return "Chebyshev"; }
 
     //! Perform object setup based on AnyMap node information
     /*!
      *  @param node  AnyMap containing rate information
      *  @param rate_units  Unit definitions specific to rate information
      */
-    void setParameters(const AnyMap& node, const UnitStack& rate_units);
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
-    void getParameters(AnyMap& rateNode) const;
+    void getParameters(AnyMap& rateNode) const override;
 
     //! @deprecated To be removed after %Cantera 3.0.
     void getParameters(AnyMap& rateNode, const Units& rate_units) const {
@@ -131,7 +131,7 @@ public:
         return getParameters(rateNode);
     }
 
-    virtual void validate(const string& equation, const Kinetics& kin);
+    void validate(const string& equation, const Kinetics& kin) override;
 
     //! Update information specific to reaction
     /*!

--- a/include/cantera/kinetics/Custom.h
+++ b/include/cantera/kinetics/Custom.h
@@ -49,7 +49,7 @@ public:
     void getParameters(AnyMap& rateNode, const Units& rate_units=Units(0.)) const;
     using ReactionRate::getParameters;
 
-    virtual void validate(const string& equation, const Kinetics& kin) override;
+    void validate(const string& equation, const Kinetics& kin) override;
 
     //! Update information specific to reaction
     /*!

--- a/include/cantera/kinetics/EdgeKinetics.h
+++ b/include/cantera/kinetics/EdgeKinetics.h
@@ -25,7 +25,7 @@ public:
         m_nDim = 1;
     }
 
-    virtual string kineticsType() const {
+    string kineticsType() const override {
         return "edge";
     }
 };

--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -21,11 +21,11 @@ struct FalloffData : public ReactionData
 {
     FalloffData();
 
-    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
+    bool update(const ThermoPhase& phase, const Kinetics& kin) override;
 
-    virtual void update(double T) override;
+    void update(double T) override;
 
-    virtual void update(double T, double M) override;
+    void update(double T, double M) override;
 
     using ReactionData::update;
 
@@ -36,15 +36,15 @@ struct FalloffData : public ReactionData
      */
     void perturbThirdBodies(double deltaM);
 
-    virtual void restore() override;
+    void restore() override;
 
-    virtual void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
+    void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
         conc_3b.resize(nReactions, NAN);
         m_conc_3b_buf.resize(nReactions, NAN);
         ready = true;
     }
 
-    virtual void invalidateCache() override {
+    void invalidateCache() override {
         ReactionData::invalidateCache();
         molar_density = NAN;
     }
@@ -155,7 +155,7 @@ public:
         return 0;
     }
 
-    virtual const string type() const override {
+    const string type() const override {
         if (m_chemicallyActivated) {
             return "chemically-activated";
         }
@@ -168,8 +168,7 @@ public:
         return 0;
     }
 
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override;
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
     //! Get the values of the parameters for this object. *params* must be an
     //! array of at least nParameters() elements.
@@ -181,7 +180,7 @@ public:
             "To be removed after Cantera 3.0; superseded by getFalloffCoeffs.");
     }
 
-    virtual void getParameters(AnyMap& node) const override;
+    void getParameters(AnyMap& node) const override;
 
     //! Evaluate reaction rate
     //! @param shared_data  data shared by all reactions of a given type
@@ -209,8 +208,8 @@ public:
         return pr * m_rc_high;
     }
 
-    virtual void check(const string& equation) override;
-    virtual void validate(const string& equation, const Kinetics& kin) override;
+    void check(const string& equation) override;
+    void validate(const string& equation, const Kinetics& kin) override;
 
     //! Get flag indicating whether negative A values are permitted
     bool allowNegativePreExponentialFactor() const {
@@ -283,7 +282,7 @@ public:
         return make_unique<MultiRate<LindemannRate, FalloffData>>();
     }
 
-    virtual const string subType() const override {
+    const string subType() const override {
         return "Lindemann";
     }
 };
@@ -352,9 +351,9 @@ public:
      * @param c Vector of three or four doubles: The doubles are the parameters,
      *          a, T_3, T_1, and (optionally) T_2 of the Troe parameterization
      */
-    virtual void setFalloffCoeffs(const vector<double>& c) override;
+    void setFalloffCoeffs(const vector<double>& c) override;
 
-    virtual void getFalloffCoeffs(vector<double>& c) const override;
+    void getFalloffCoeffs(vector<double>& c) const override;
 
     //! Update the temperature parameters in the representation
     /*!
@@ -362,32 +361,31 @@ public:
      *   @param work      Vector of working space, length 1, representing the
      *                    temperature-dependent part of the parameterization.
      */
-    virtual void updateTemp(double T, double* work) const override;
+    void updateTemp(double T, double* work) const override;
 
-    virtual double F(double pr, const double* work) const override;
+    double F(double pr, const double* work) const override;
 
-    virtual size_t workSize() const override {
+    size_t workSize() const override {
         return 1;
     }
 
-    virtual const string subType() const override {
+    const string subType() const override {
         return "Troe";
     }
 
-    virtual size_t nParameters() const override {
+    size_t nParameters() const override {
         return 4;
     }
 
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override;
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
     //! Sets params to contain, in order, @f[ (A, T_3, T_1, T_2) @f]
     /**
      * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
-    virtual void getParameters(double* params) const override;
+    void getParameters(double* params) const override;
 
-    virtual void getParameters(AnyMap& node) const override;
+    void getParameters(AnyMap& node) const override;
 
 protected:
     //! parameter a in the 4-parameter Troe falloff function. Dimensionless
@@ -464,9 +462,9 @@ public:
      *          a, b, c, d (optional; default 1.0), and e (optional; default
      *          0.0) of the SRI parameterization
      */
-    virtual void setFalloffCoeffs(const vector<double>& c) override;
+    void setFalloffCoeffs(const vector<double>& c) override;
 
-    virtual void getFalloffCoeffs(vector<double>& c) const override;
+    void getFalloffCoeffs(vector<double>& c) const override;
 
     //! Update the temperature parameters in the representation
     /*!
@@ -474,32 +472,31 @@ public:
      *   @param work      Vector of working space, length 2, representing the
      *                    temperature-dependent part of the parameterization.
      */
-    virtual void updateTemp(double T, double* work) const override;
+    void updateTemp(double T, double* work) const override;
 
-    virtual double F(double pr, const double* work) const override;
+    double F(double pr, const double* work) const override;
 
-    virtual size_t workSize() const override {
+    size_t workSize() const override {
         return 2;
     }
 
-    virtual const string subType() const override {
+    const string subType() const override {
         return "SRI";
     }
 
-    virtual size_t nParameters() const override {
+    size_t nParameters() const override {
         return 5;
     }
 
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override;
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
     //! Sets params to contain, in order, @f[ (a, b, c, d, e) @f]
     /**
      * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
-    virtual void getParameters(double* params) const override;
+    void getParameters(double* params) const override;
 
-    virtual void getParameters(AnyMap& node) const override;
+    void getParameters(AnyMap& node) const override;
 
 protected:
     //! parameter a in the 5-parameter SRI falloff function. Dimensionless.
@@ -569,9 +566,9 @@ public:
      * @param c Vector of one or two doubles: The doubles are the parameters,
      *          a and (optionally) b of the Tsang F_cent parameterization
      */
-    virtual void setFalloffCoeffs(const vector<double>& c) override;
+    void setFalloffCoeffs(const vector<double>& c) override;
 
-    virtual void getFalloffCoeffs(vector<double>& c) const override;
+    void getFalloffCoeffs(vector<double>& c) const override;
 
     //! Update the temperature parameters in the representation
     /*!
@@ -579,32 +576,31 @@ public:
      *   @param work      Vector of working space, length 1, representing the
      *                    temperature-dependent part of the parameterization.
      */
-    virtual void updateTemp(double T, double* work) const override;
+    void updateTemp(double T, double* work) const override;
 
-    virtual double F(double pr, const double* work) const override;
+    double F(double pr, const double* work) const override;
 
-    virtual size_t workSize() const override {
+    size_t workSize() const override {
         return 1;
     }
 
-    virtual const string subType() const override {
+    const string subType() const override {
         return "Tsang";
     }
 
-    virtual size_t nParameters() const override {
+    size_t nParameters() const override {
         return 2;
     }
 
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override;
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
     //! Sets params to contain, in order, @f[ (A, B) @f]
     /**
      * @deprecated To be removed after %Cantera 3.0; superseded by getFalloffCoeffs()
      */
-    virtual void getParameters(double* params) const override;
+    void getParameters(double* params) const override;
 
-    virtual void getParameters(AnyMap& node) const override;
+    void getParameters(AnyMap& node) const override;
 
 protected:
     //! parameter a in the Tsang F_cent formulation. Dimensionless

--- a/include/cantera/kinetics/GasKinetics.h
+++ b/include/cantera/kinetics/GasKinetics.h
@@ -40,7 +40,7 @@ public:
         addPhase(*thermo);
     }
 
-    virtual string kineticsType() const {
+    string kineticsType() const override {
         return "gas";
     }
 

--- a/include/cantera/kinetics/ImplicitSurfChem.h
+++ b/include/cantera/kinetics/ImplicitSurfChem.h
@@ -77,33 +77,31 @@ public:
                      double maxStepSize=0, size_t maxSteps=20000,
                      size_t maxErrTestFails=7);
 
-    virtual ~ImplicitSurfChem() = default;
-
     /**
      *  Must be called before calling method 'advance'
      */
-    virtual void initialize(double t0 = 0.0);
+    void initialize(double t0=0.0);
 
     /**
      *  Set the maximum integration step-size.  Note, setting this value to zero
      *  disables this option
      */
-    virtual void setMaxStepSize(double maxstep = 0.0);
+    void setMaxStepSize(double maxstep=0.0);
 
     /**
      *  Set the relative and absolute integration tolerances.
      */
-    virtual void setTolerances(double rtol=1.e-7, double atol=1.e-14);
+    void setTolerances(double rtol=1.e-7, double atol=1.e-14);
 
     /**
      *  Set the maximum number of CVODES integration steps.
      */
-    virtual void setMaxSteps(size_t maxsteps = 20000);
+    void setMaxSteps(size_t maxsteps=20000);
 
     /**
      *  Set the maximum number of CVODES error test failures
      */
-    virtual void setMaxErrTestFails(size_t maxErrTestFails = 7);
+    void setMaxErrTestFails(size_t maxErrTestFails=7);
 
     //! Integrate from t0 to t1. The integrator is reinitialized first.
     /*!
@@ -150,7 +148,7 @@ public:
     // overloaded methods of class FuncEval
 
     //! Return the number of equations
-    virtual size_t neq() const {
+    size_t neq() const override {
         return m_nv;
     }
 
@@ -162,7 +160,7 @@ public:
      *                derivative of the surface coverages.
      *  @param p   Unused parameter pass-through parameter vector
      */
-    virtual void eval(double t, double* y, double* ydot, double* p);
+    void eval(double t, double* y, double* ydot, double* p) override;
 
     //! Get the current state of the solution vector
     /*!
@@ -170,7 +168,7 @@ public:
      *            On output, this contains the initial value
      *           of the solution.
      */
-    virtual void getState(double* y);
+    void getState(double* y) override;
 
     /**
      * Get the specifications for the problem from the values

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -69,11 +69,11 @@ public:
      */
     InterfaceKinetics(ThermoPhase* thermo);
 
-    virtual ~InterfaceKinetics();
+    ~InterfaceKinetics() override;
 
-    virtual void resizeReactions();
+    void resizeReactions() override;
 
-    virtual string kineticsType() const {
+    string kineticsType() const override {
         return "surface";
     }
 
@@ -94,25 +94,25 @@ public:
      *   where deltaG is the electrochemical potential difference between
      *   products minus reactants.
      */
-    virtual void getEquilibriumConstants(double* kc);
+    void getEquilibriumConstants(double* kc) override;
 
-    virtual void getDeltaGibbs(double* deltaG);
+    void getDeltaGibbs(double* deltaG) override;
 
-    virtual void getDeltaElectrochemPotentials(double* deltaM);
-    virtual void getDeltaEnthalpy(double* deltaH);
-    virtual void getDeltaEntropy(double* deltaS);
+    void getDeltaElectrochemPotentials(double* deltaM) override;
+    void getDeltaEnthalpy(double* deltaH) override;
+    void getDeltaEntropy(double* deltaS) override;
 
-    virtual void getDeltaSSGibbs(double* deltaG);
-    virtual void getDeltaSSEnthalpy(double* deltaH);
-    virtual void getDeltaSSEntropy(double* deltaS);
+    void getDeltaSSGibbs(double* deltaG) override;
+    void getDeltaSSEnthalpy(double* deltaH) override;
+    void getDeltaSSEntropy(double* deltaS) override;
 
     //! @}
     //! @name Reaction Mechanism Informational Query Routines
     //! @{
 
-    virtual void getActivityConcentrations(double* const conc);
+    void getActivityConcentrations(double* const conc) override;
 
-    virtual bool isReversible(size_t i) {
+    bool isReversible(size_t i) override {
         if (std::find(m_revindex.begin(), m_revindex.end(), i)
                 < m_revindex.end()) {
             return true;
@@ -121,9 +121,8 @@ public:
         }
     }
 
-    virtual void getFwdRateConstants(double* kfwd);
-    virtual void getRevRateConstants(double* krev,
-                                     bool doIrreversible = false);
+    void getFwdRateConstants(double* kfwd) override;
+    void getRevRateConstants(double* krev, bool doIrreversible=false) override;
 
     //! @}
     //! @name Reaction Mechanism Construction
@@ -142,23 +141,23 @@ public:
      *
      * @param thermo    Reference to the ThermoPhase to be added.
      */
-    virtual void addThermo(shared_ptr<ThermoPhase> thermo);
+    void addThermo(shared_ptr<ThermoPhase> thermo) override;
 
     //! @see InterfaceKinetics::addThermo(shared_ptr<ThermoPhase>)
-    virtual void addPhase(ThermoPhase& thermo);
+    void addPhase(ThermoPhase& thermo) override;
 
-    virtual void init();
-    virtual void resizeSpecies();
-    virtual bool addReaction(shared_ptr<Reaction> r, bool resize=true);
-    virtual void modifyReaction(size_t i, shared_ptr<Reaction> rNew);
-    virtual void setMultiplier(size_t i, double f);
+    void init() override;
+    void resizeSpecies() override;
+    bool addReaction(shared_ptr<Reaction> r, bool resize=true) override;
+    void modifyReaction(size_t i, shared_ptr<Reaction> rNew) override;
+    void setMultiplier(size_t i, double f) override;
     //! @}
 
     //! Internal routine that updates the Rates of Progress of the reactions
     /*!
      *  This is actually the guts of the functionality of the object
      */
-    virtual void updateROP();
+    void updateROP() override;
 
     //! Update properties that depend on temperature
     /*!
@@ -306,11 +305,11 @@ public:
     */
     double interfaceCurrent(const size_t iphase);
 
-    virtual void setDerivativeSettings(const AnyMap& settings);
-    virtual void getDerivativeSettings(AnyMap& settings) const;
-    virtual Eigen::SparseMatrix<double> fwdRatesOfProgress_ddCi();
-    virtual Eigen::SparseMatrix<double> revRatesOfProgress_ddCi();
-    virtual Eigen::SparseMatrix<double> netRatesOfProgress_ddCi();
+    void setDerivativeSettings(const AnyMap& settings) override;
+    void getDerivativeSettings(AnyMap& settings) const override;
+    Eigen::SparseMatrix<double> fwdRatesOfProgress_ddCi() override;
+    Eigen::SparseMatrix<double> revRatesOfProgress_ddCi() override;
+    Eigen::SparseMatrix<double> netRatesOfProgress_ddCi() override;
 
 protected:
     //! @name Internal service methods

--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -30,17 +30,17 @@ struct InterfaceData : public BlowersMaselData
 {
     InterfaceData() = default;
 
-    virtual bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
+    bool update(const ThermoPhase& bulk, const Kinetics& kin) override;
 
-    virtual void update(double T) override;
+    void update(double T) override;
 
-    virtual void update(double T, const vector<double>& values) override;
+    void update(double T, const vector<double>& values) override;
 
     using BlowersMaselData::update;
 
     virtual void perturbTemperature(double deltaT);
 
-    virtual void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
+    void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
         coverages.resize(nSpecies, 0.);
         logCoverages.resize(nSpecies, 0.);
         partialMolarEnthalpies.resize(nSpecies, 0.);
@@ -384,24 +384,22 @@ public:
     }
 
     //! Identifier of reaction rate type
-    virtual const string type() const override {
+    const string type() const override {
         return "interface-" + RateType::type();
     }
 
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override
-    {
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override {
         InterfaceRateBase::setParameters(node);
         RateType::setParameters(node, rate_units);
     }
 
-    virtual void getParameters(AnyMap& node) const override {
+    void getParameters(AnyMap& node) const override {
         RateType::getParameters(node);
         node["type"] = type();
         InterfaceRateBase::getParameters(node);
     }
 
-    virtual void setContext(const Reaction& rxn, const Kinetics& kin) override {
+    void setContext(const Reaction& rxn, const Kinetics& kin) override {
         RateType::setContext(rxn, kin);
         InterfaceRateBase::setContext(rxn, kin);
     }
@@ -433,12 +431,12 @@ public:
         throw NotImplementedError("InterfaceRate<>::ddTScaledFromStruct");
     }
 
-    virtual double preExponentialFactor() const override {
+    double preExponentialFactor() const override {
         return RateType::preExponentialFactor() *
             std::exp(std::log(10.0) * m_acov + m_mcov);
     }
 
-    virtual double activationEnergy() const override {
+    double activationEnergy() const override {
         return RateType::activationEnergy() + m_ecov * GasConstant;
     }
 
@@ -483,7 +481,7 @@ public:
     }
 
     //! Identifier of reaction rate type
-    virtual const string type() const override {
+    const string type() const override {
         return "sticking-" + RateType::type();
     }
 
@@ -492,9 +490,7 @@ public:
         RateType::m_conversion_units = Units(1.0);
     }
 
-    virtual void setParameters(
-        const AnyMap& node, const UnitStack& rate_units) override
-    {
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override {
         InterfaceRateBase::setParameters(node);
         setRateUnits(rate_units);
         RateType::m_negativeA_ok = node.getBool("negative-A", false);
@@ -507,7 +503,7 @@ public:
             node["sticking-coefficient"], node.units(), rate_units);
     }
 
-    virtual void getParameters(AnyMap& node) const override {
+    void getParameters(AnyMap& node) const override {
         node["type"] = type();
         if (RateType::m_negativeA_ok) {
             node["negative-A"] = true;
@@ -522,13 +518,13 @@ public:
         InterfaceRateBase::getParameters(node);
     }
 
-    virtual void setContext(const Reaction& rxn, const Kinetics& kin) override {
+    void setContext(const Reaction& rxn, const Kinetics& kin) override {
         RateType::setContext(rxn, kin);
         InterfaceRateBase::setContext(rxn, kin);
         StickingCoverage::setContext(rxn, kin);
     }
 
-    virtual void validate(const string &equation, const Kinetics& kin) override {
+    void validate(const string &equation, const Kinetics& kin) override {
         RateType::validate(equation, kin);
         fmt::memory_buffer err_reactions;
         double T[] = {200.0, 500.0, 1000.0, 2000.0, 5000.0, 10000.0};
@@ -578,12 +574,12 @@ public:
         throw NotImplementedError("StickingRate<>::ddTScaledFromStruct");
     }
 
-    virtual double preExponentialFactor() const override {
+    double preExponentialFactor() const override {
         return RateType::preExponentialFactor() *
             std::exp(std::log(10.0) * m_acov + m_mcov);
     }
 
-    virtual double activationEnergy() const override {
+    double activationEnergy() const override {
         return RateType::activationEnergy() + m_ecov * GasConstant;
     }
 };

--- a/include/cantera/kinetics/KineticsFactory.h
+++ b/include/cantera/kinetics/KineticsFactory.h
@@ -23,12 +23,12 @@ class KineticsFactory : public Factory<Kinetics>
 public:
     static KineticsFactory* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
     /**
      * Return a new, empty kinetics manager.
      */
-    virtual Kinetics* newKinetics(const string& model);
+    Kinetics* newKinetics(const string& model);
 
 private:
     static KineticsFactory* s_factory;

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -26,7 +26,7 @@ class MultiRate final : public MultiRateBase
     CT_DEFINE_HAS_MEMBER(has_ddM, perturbThirdBodies)
 
 public:
-    virtual string type() override {
+    string type() override {
         if (!m_rxn_rates.size()) {
             throw CanteraError("MultiRate::type",
                  "Cannot determine type of empty rate handler.");
@@ -34,13 +34,13 @@ public:
         return m_rxn_rates.at(0).second.type();
     }
 
-    virtual void add(size_t rxn_index, ReactionRate& rate) override {
+    void add(size_t rxn_index, ReactionRate& rate) override {
         m_indices[rxn_index] = m_rxn_rates.size();
         m_rxn_rates.emplace_back(rxn_index, dynamic_cast<RateType&>(rate));
         m_shared.invalidateCache();
     }
 
-    virtual bool replace(size_t rxn_index, ReactionRate& rate) override {
+    bool replace(size_t rxn_index, ReactionRate& rate) override {
         if (!m_rxn_rates.size()) {
             throw CanteraError("MultiRate::replace",
                  "Invalid operation: cannot replace rate object "
@@ -60,20 +60,18 @@ public:
         return false;
     }
 
-    virtual void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
+    void resize(size_t nSpecies, size_t nReactions, size_t nPhases) override {
         m_shared.resize(nSpecies, nReactions, nPhases);
         m_shared.invalidateCache();
     }
 
-    virtual void getRateConstants(double* kf) override {
+    void getRateConstants(double* kf) override {
         for (auto& [iRxn, rate] : m_rxn_rates) {
             kf[iRxn] = rate.evalFromStruct(m_shared);
         }
     }
 
-    virtual void processRateConstants_ddT(double* rop,
-                                          const double* kf,
-                                          double deltaT) override
+    void processRateConstants_ddT(double* rop, const double* kf, double deltaT) override
     {
         if constexpr (has_ddT<RateType>::value) {
             for (const auto& [iRxn, rate] : m_rxn_rates) {
@@ -99,9 +97,7 @@ public:
         }
     }
 
-    virtual void processRateConstants_ddP(double* rop,
-                                          const double* kf,
-                                          double deltaP) override
+    void processRateConstants_ddP(double* rop, const double* kf, double deltaP) override
     {
         if constexpr (has_ddP<DataType>::value) {
             double dPinv = 1. / (m_shared.pressure * deltaP);
@@ -125,10 +121,8 @@ public:
         }
     }
 
-    virtual void processRateConstants_ddM(double* rop,
-                                          const double* kf,
-                                          double deltaM,
-                                          bool overwrite=true) override
+    void processRateConstants_ddM(double* rop, const double* kf, double deltaM,
+                                  bool overwrite=true) override
     {
         if constexpr (has_ddM<DataType>::value) {
             double dMinv = 1. / deltaM;
@@ -159,22 +153,22 @@ public:
         }
     }
 
-    virtual void update(double T) override {
+    void update(double T) override {
         m_shared.update(T);
         _update();
     }
 
-    virtual void update(double T, double extra) override {
+    void update(double T, double extra) override {
         m_shared.update(T, extra);
         _update();
     }
 
-    virtual void update(double T, const vector<double>& extra) override {
+    void update(double T, const vector<double>& extra) override {
         m_shared.update(T, extra);
         _update();
     }
 
-    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override {
+    bool update(const ThermoPhase& phase, const Kinetics& kin) override {
         bool changed = m_shared.update(phase, kin);
         if (changed) {
             // call helper function only if needed: implementation depends on whether
@@ -184,7 +178,7 @@ public:
         return changed;
     }
 
-    virtual double evalSingle(ReactionRate& rate) override {
+    double evalSingle(ReactionRate& rate) override {
         RateType& R = static_cast<RateType&>(rate);
         if constexpr (has_update<RateType>::value) {
             R.updateFromStruct(m_shared);

--- a/include/cantera/kinetics/PlogRate.h
+++ b/include/cantera/kinetics/PlogRate.h
@@ -20,15 +20,15 @@ struct PlogData : public ReactionData
 {
     PlogData() = default;
 
-    virtual void update(double T) override;
+    void update(double T) override;
 
-    virtual void update(double T, double P) override {
+    void update(double T, double P) override {
         ReactionData::update(T);
         pressure = P;
         logP = std::log(P);
     }
 
-    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
+    bool update(const ThermoPhase& phase, const Kinetics& kin) override;
 
     using ReactionData::update;
 
@@ -39,9 +39,9 @@ struct PlogData : public ReactionData
      */
     void perturbPressure(double deltaP);
 
-    virtual void restore() override;
+    void restore() override;
 
-    virtual void invalidateCache() override {
+    void invalidateCache() override {
         ReactionData::invalidateCache();
         pressure = NAN;
     }
@@ -84,22 +84,22 @@ public:
 
     PlogRate(const AnyMap& node, const UnitStack& rate_units={});
 
-    unique_ptr<MultiRateBase> newMultiRate() const {
+    unique_ptr<MultiRateBase> newMultiRate() const override {
         return make_unique<MultiRate<PlogRate, PlogData>>();
     }
 
     //! Identifier of reaction rate type
-    const string type() const { return "pressure-dependent-Arrhenius"; }
+    const string type() const override { return "pressure-dependent-Arrhenius"; }
 
     //! Perform object setup based on AnyMap node information
     /*!
      *  @param node  AnyMap containing rate information
      *  @param rate_units  Unit definitions specific to rate information
      */
-    void setParameters(const AnyMap& node, const UnitStack& rate_units);
+    void setParameters(const AnyMap& node, const UnitStack& rate_units) override;
 
     void getParameters(AnyMap& rateNode, const Units& rate_units) const;
-    void getParameters(AnyMap& rateNode) const {
+    void getParameters(AnyMap& rateNode) const override {
         return getParameters(rateNode, Units(0));
     }
 
@@ -170,11 +170,11 @@ public:
     //! temperatures at each interpolation pressure. This is potentially an
     //! issue when one of the Arrhenius expressions at a particular pressure
     //! has a negative pre-exponential factor.
-    void validate(const string& equation, const Kinetics& kin);
+    void validate(const string& equation, const Kinetics& kin) override;
 
     //! @deprecated To be removed after %Cantera 3.0;
     //!              superseded by two-parameter version
-    void validate(const string& equation);
+    void validate(const string& equation) override;
 
     //! Return the pressures and Arrhenius expressions which comprise this
     //! reaction.

--- a/include/cantera/kinetics/ReactionRateDelegator.h
+++ b/include/cantera/kinetics/ReactionRateDelegator.h
@@ -70,14 +70,14 @@ class ReactionRateDelegator : public Delegator, public ReactionRate
 public:
     ReactionRateDelegator();
 
-    virtual unique_ptr<MultiRateBase> newMultiRate() const override;
+    unique_ptr<MultiRateBase> newMultiRate() const override;
 
     //! Set the reaction type based on the user-provided reaction rate parameterization
     void setType(const string& type) {
         m_rateType = type;
     }
 
-    virtual const string type() const override {
+    const string type() const override {
         return m_rateType;
     }
 

--- a/include/cantera/kinetics/ReactionRateFactory.h
+++ b/include/cantera/kinetics/ReactionRateFactory.h
@@ -64,7 +64,7 @@ public:
      */
     static ReactionRateFactory* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
 private:
     //! Pointer to the single instance of the factory

--- a/include/cantera/kinetics/TwoTempPlasmaRate.h
+++ b/include/cantera/kinetics/TwoTempPlasmaRate.h
@@ -21,14 +21,14 @@ struct TwoTempPlasmaData : public ReactionData
 {
     TwoTempPlasmaData() = default;
 
-    virtual bool update(const ThermoPhase& phase, const Kinetics& kin) override;
-    virtual void update(double T) override;
-    virtual void update(double T, double Te) override;
+    bool update(const ThermoPhase& phase, const Kinetics& kin) override;
+    void update(double T) override;
+    void update(double T, double Te) override;
     using ReactionData::update;
 
     virtual void updateTe(double Te);
 
-    virtual void invalidateCache() override {
+    void invalidateCache() override {
         ReactionData::invalidateCache();
         electronTemp = NAN;
     }
@@ -78,11 +78,11 @@ public:
         return make_unique<MultiRate<TwoTempPlasmaRate, TwoTempPlasmaData>>();
     }
 
-    virtual const string type() const override {
+    const string type() const override {
         return "two-temperature-plasma";
     }
 
-    virtual void setContext(const Reaction& rxn, const Kinetics& kin) override;
+    void setContext(const Reaction& rxn, const Kinetics& kin) override;
 
     //! Evaluate reaction rate
     /*!

--- a/include/cantera/numerics/AdaptivePreconditioner.h
+++ b/include/cantera/numerics/AdaptivePreconditioner.h
@@ -41,9 +41,9 @@ public:
 
     void setValue(size_t row, size_t col, double value) override;
 
-    virtual void stateAdjustment(vector<double>& state) override;
+    void stateAdjustment(vector<double>& state) override;
 
-    virtual void updatePreconditioner() override;
+    void updatePreconditioner() override;
 
     //! Prune preconditioner elements
     void prunePreconditioner();

--- a/include/cantera/numerics/BandMatrix.h
+++ b/include/cantera/numerics/BandMatrix.h
@@ -74,8 +74,8 @@ public:
      */
     void bfill(double v = 0.0);
 
-    double& operator()(size_t i, size_t j);
-    double operator()(size_t i, size_t j) const;
+    double& operator()(size_t i, size_t j) override;
+    double operator()(size_t i, size_t j) const override;
 
     //! Return a changeable reference to element (i,j).
     /*!
@@ -117,7 +117,7 @@ public:
      */
     double _value(size_t i, size_t j) const;
 
-    virtual size_t nRows() const;
+    size_t nRows() const override;
 
     //! Number of columns
     size_t nColumns() const;
@@ -132,8 +132,8 @@ public:
     size_t ldim() const;
 
     //! Multiply A*b and write result to @c prod.
-    virtual void mult(const double* b, double* prod) const;
-    virtual void leftMult(const double* const b, double* const prod) const;
+    void mult(const double* b, double* prod) const override;
+    void leftMult(const double* const b, double* const prod) const override;
 
     //! Perform an LU decomposition, the LAPACK routine DGBTRF is used.
     /*!
@@ -142,7 +142,7 @@ public:
      * @returns a success flag. 0 indicates a success; ~0 indicates some
      *         error occurred, see the LAPACK documentation
      */
-    int factor();
+    int factor() override;
 
     //! Solve the matrix problem Ax = b
     /*!
@@ -162,14 +162,14 @@ public:
      * @returns a success flag. 0 indicates a success; ~0 indicates some error
      *     occurred, see the LAPACK documentation
      */
-    int solve(double* b, size_t nrhs=1, size_t ldb=0);
+    int solve(double* b, size_t nrhs=1, size_t ldb=0) override;
 
     //! Returns an iterator for the start of the band storage data
     /*!
      * Iterator points to the beginning of the data, and it is changeable.
      * @deprecated Unused. To be removed after %Cantera 3.0.
      */
-    virtual vector<double>::iterator begin();
+    vector<double>::iterator begin() override;
 
     //! Returns an iterator for the end of the band storage data
     /*!
@@ -183,7 +183,7 @@ public:
      * Iterator points to the beginning of the data, and it is not changeable.
      * @deprecated Unused. To be removed after %Cantera 3.0.
      */
-    vector<double>::const_iterator begin() const;
+    vector<double>::const_iterator begin() const override;
 
     //! Returns a const iterator for the end of the band storage data
     /*!
@@ -192,7 +192,7 @@ public:
      */
     vector<double>::const_iterator end() const;
 
-    virtual void zero();
+    void zero() override;
 
     //! Returns an estimate of the inverse of the condition number for the matrix
     /*!
@@ -201,14 +201,14 @@ public:
      * @param a1norm Norm of the matrix
      * @returns the inverse of the condition number
      */
-    virtual double rcond(double a1norm);
+    double rcond(double a1norm) override;
 
     //! Returns the factor algorithm used.  This method will always return 0
     //! (LU) for band matrices.
-    virtual int factorAlgorithm() const;
+    int factorAlgorithm() const override;
 
     //! Returns the one norm of the matrix
-    virtual double oneNorm() const;
+    double oneNorm() const override;
 
     //! Return a pointer to the top of column j
     /*!
@@ -232,7 +232,7 @@ public:
      *  @param j   Value of the column
      *  @returns a pointer to the top of the column
      */
-    virtual double* ptrColumn(size_t j);
+    double* ptrColumn(size_t j) override;
 
     //! Return a vector of const pointers to the columns
     /*!
@@ -241,7 +241,7 @@ public:
      *
      * @returns a vector of pointers to the top of the columns of the matrices.
      */
-    virtual double* const* colPts();
+    double* const* colPts() override;
 
     //! Check to see if we have any zero rows in the Jacobian
     /*!
@@ -251,7 +251,7 @@ public:
      * @param valueSmall  OUTPUT value of the largest coefficient in the smallest row
      * @return index of the row that is most nearly zero
      */
-    virtual size_t checkRows(double& valueSmall) const;
+    size_t checkRows(double& valueSmall) const override;
 
     //! Check to see if we have any zero columns in the Jacobian
     /*!
@@ -261,7 +261,7 @@ public:
      * @param valueSmall  OUTPUT value of the largest coefficient in the smallest column
      * @return index of the column that is most nearly zero
      */
-    virtual size_t checkColumns(double& valueSmall) const;
+    size_t checkColumns(double& valueSmall) const override;
 
     //! LAPACK "info" flag after last factor/solve operation
     int info() const { return m_info; };

--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -31,53 +31,53 @@ public:
      *  Jacobian function, Newton iteration.
      */
     CVodesIntegrator();
-    virtual ~CVodesIntegrator();
-    virtual void setTolerances(double reltol, size_t n, double* abstol);
-    virtual void setTolerances(double reltol, double abstol);
-    virtual void setSensitivityTolerances(double reltol, double abstol);
-    virtual void initialize(double t0, FuncEval& func);
-    virtual void reinitialize(double t0, FuncEval& func);
-    virtual void integrate(double tout);
-    virtual double step(double tout);
-    virtual double& solution(size_t k);
-    virtual double* solution();
-    virtual double* derivative(double tout, int n);
-    virtual int lastOrder() const;
-    virtual int nEquations() const {
+    ~CVodesIntegrator() override;
+    void setTolerances(double reltol, size_t n, double* abstol) override;
+    void setTolerances(double reltol, double abstol) override;
+    void setSensitivityTolerances(double reltol, double abstol) override;
+    void initialize(double t0, FuncEval& func) override;
+    void reinitialize(double t0, FuncEval& func) override;
+    void integrate(double tout) override;
+    double step(double tout) override;
+    double& solution(size_t k) override;
+    double* solution() override;
+    double* derivative(double tout, int n) override;
+    int lastOrder() const override;
+    int nEquations() const  override{
         return static_cast<int>(m_neq);
     }
-    virtual int nEvals() const;
-    virtual void setMaxOrder(int n) {
+    int nEvals() const override;
+    void setMaxOrder(int n) override {
         m_maxord = n;
     }
-    virtual void setMethod(MethodType t);
-    virtual void setMaxStepSize(double hmax);
-    virtual void setMinStepSize(double hmin);
-    virtual void setMaxSteps(int nmax);
-    virtual int maxSteps();
-    virtual void setMaxErrTestFails(int n);
-    virtual AnyMap solverStats() const;
-    void setLinearSolverType(const string& linSolverType) {
+    void setMethod(MethodType t) override;
+    void setMaxStepSize(double hmax) override;
+    void setMinStepSize(double hmin) override;
+    void setMaxSteps(int nmax) override;
+    int maxSteps() override;
+    void setMaxErrTestFails(int n) override;
+    AnyMap solverStats() const override;
+    void setLinearSolverType(const string& linSolverType) override {
         m_type = linSolverType;
     }
-    virtual string linearSolverType() const {
+    string linearSolverType() const override {
         return m_type;
     }
-    virtual void setBandwidth(int N_Upper, int N_Lower) {
+    void setBandwidth(int N_Upper, int N_Lower) override {
         m_mupper = N_Upper;
         m_mlower = N_Lower;
     }
-    virtual int nSensParams() {
+    int nSensParams() override {
         return static_cast<int>(m_np);
     }
-    virtual double sensitivity(size_t k, size_t p);
-    virtual void setProblemType(int probtype);
+    double sensitivity(size_t k, size_t p) override;
+    void setProblemType(int probtype) override;
 
     //! Returns a string listing the weighted error estimates associated
     //! with each solution component.
     //! This information can be used to identify which variables are
     //! responsible for integrator failures or unexpected small timesteps.
-    virtual string getErrorInfo(int N);
+    string getErrorInfo(int N);
 
     //! Error message information provide by CVodes
     string m_error_message;

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -78,7 +78,7 @@ public:
      * @param m  New number of columns
      * @param v  Default fill value. defaults to zero.
      */
-    void resize(size_t n, size_t m, double v = 0.0);
+    void resize(size_t n, size_t m, double v=0.0) override;
 
     virtual double* const* colPts();
 

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -293,23 +293,23 @@ public:
         return *this;
     }
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 
-    virtual int ID() const {
+    int ID() const override {
         return SinFuncType;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "sin";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override{
         return sin(m_c*t);
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
-    virtual shared_ptr<Func1> derivative3() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
+    shared_ptr<Func1> derivative3() const override;
 };
 
 
@@ -342,20 +342,20 @@ public:
         return *this;
     }
 
-    virtual Func1& duplicate() const;
-    virtual string write(const string& arg) const;
-    virtual int ID() const {
+    Func1& duplicate() const override;
+    string write(const string& arg) const override;
+    int ID() const override {
         return CosFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "cos";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return cos(m_c * t);
     }
-    virtual Func1& derivative() const;
-    virtual shared_ptr<Func1> derivative3() const;
+    Func1& derivative() const override;
+    shared_ptr<Func1> derivative3() const override;
 };
 
 
@@ -385,21 +385,21 @@ public:
         Func1::operator=(right);
         return *this;
     }
-    virtual string write(const string& arg) const;
-    virtual int ID() const {
+    string write(const string& arg) const override;
+    int ID() const override {
         return ExpFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "exp";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return exp(m_c*t);
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
-    virtual shared_ptr<Func1> derivative3() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
+    shared_ptr<Func1> derivative3() const override;
 };
 
 
@@ -420,17 +420,17 @@ public:
     //! Constructor uses single parameter (factor)
     Log1(const vector<double>& params);
 
-    virtual string type() const {
+    string type() const override {
         return "log";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return log(m_c * t);
     }
 
-    virtual shared_ptr<Func1> derivative3() const;
+    shared_ptr<Func1> derivative3() const override;
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 };
 
 //! Implements the @c pow() (power) function.
@@ -459,20 +459,20 @@ public:
         Func1::operator=(right);
         return *this;
     }
-    virtual string write(const string& arg) const;
-    virtual int ID() const {
+    string write(const string& arg) const override;
+    int ID() const override {
         return PowFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "pow";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return pow(t, m_c);
     }
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
-    virtual shared_ptr<Func1> derivative3() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
+    shared_ptr<Func1> derivative3() const override;
 };
 
 //! Implements a tabulated function.
@@ -509,21 +509,21 @@ public:
     //! @since New in %Cantera 3.0
     void setMethod(const string& method);
 
-    virtual string write(const string& arg) const;
-    virtual int ID() const {
+    string write(const string& arg) const override;
+    int ID() const override {
         return TabulatedFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         if (m_isLinear) {
             return "tabulated-linear";
         }
         return "tabulated-previous";
     }
 
-    virtual double eval(double t) const;
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
-    virtual shared_ptr<Func1> derivative3() const;
+    double eval(double t) const override;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
+    shared_ptr<Func1> derivative3() const override;
 private:
     vector<double> m_tvec; //!< Vector of time values
     vector<double> m_fvec; //!< Vector of function values
@@ -559,20 +559,20 @@ public:
         return *this;
     }
 
-    virtual string write(const string& arg) const;
-    virtual int ID() const {
+    string write(const string& arg) const override;
+    int ID() const override {
         return ConstFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "constant";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return m_c;
     }
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
-    virtual shared_ptr<Func1> derivative3() const {
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
+    shared_ptr<Func1> derivative3() const override {
         return make_shared<Const1>(0.0);
     }
 };
@@ -597,7 +597,7 @@ public:
 
     Sum1(shared_ptr<Func1> f1, shared_ptr<Func1> f2) : Func1(f1, f2) {}
 
-    virtual ~Sum1() {
+    ~Sum1() override {
         if (!m_f1_shared) {
             delete m_f1;
         }
@@ -624,29 +624,29 @@ public:
         return *this;
     }
 
-    virtual int ID() const {
+    int ID() const override {
         return SumFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "sum";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return m_f1->eval(t) + m_f2->eval(t);
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
 
-    virtual shared_ptr<Func1> derivative3() const {
+    shared_ptr<Func1> derivative3() const override {
         return newSumFunction(m_f1_shared->derivative3(), m_f2_shared->derivative3());
     }
 
-    virtual int order() const {
+    int order() const override {
         return 0;
     }
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 };
 
 /**
@@ -668,7 +668,7 @@ public:
 
     Diff1(shared_ptr<Func1> f1, shared_ptr<Func1> f2) : Func1(f1, f2) {}
 
-    virtual ~Diff1() {
+    ~Diff1() override {
         if (!m_f1_shared) {
             delete m_f1;
         }
@@ -695,30 +695,30 @@ public:
         return *this;
     }
 
-    virtual int ID() const {
+    int ID() const override {
         return DiffFuncType;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "diff";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return m_f1->eval(t) - m_f2->eval(t);
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
 
-    virtual shared_ptr<Func1> derivative3() const {
+    shared_ptr<Func1> derivative3() const override {
         return newDiffFunction(m_f1_shared->derivative3(), m_f2_shared->derivative3());
     }
 
-    virtual int order() const {
+    int order() const override {
         return 0;
     }
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 };
 
 
@@ -741,7 +741,7 @@ public:
 
     Product1(shared_ptr<Func1> f1, shared_ptr<Func1> f2) : Func1(f1, f2) {}
 
-    virtual ~Product1() {
+    ~Product1() override {
         if (!m_f1_shared) {
             delete m_f1;
         }
@@ -768,26 +768,26 @@ public:
         return *this;
     }
 
-    virtual int ID() const {
+    int ID() const override {
         return ProdFuncType;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "product";
     }
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return m_f1->eval(t) * m_f2->eval(t);
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
 
-    virtual shared_ptr<Func1> derivative3() const;
+    shared_ptr<Func1> derivative3() const override;
 
-    virtual int order() const {
+    int order() const override {
         return 1;
     }
 };
@@ -810,7 +810,7 @@ public:
 
     TimesConstant1(shared_ptr<Func1> f1, double a) : Func1(f1, a) {}
 
-    virtual ~TimesConstant1() {
+    ~TimesConstant1() override {
         if (!m_f1_shared) {
             delete m_f1;
         }
@@ -831,14 +831,14 @@ public:
         m_parent = 0;
         return *this;
     }
-    virtual int ID() const {
+    int ID() const override {
         return TimesConstantFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "times-constant";
     }
 
-    virtual double isProportional(TimesConstant1& other) {
+    double isProportional(TimesConstant1& other) override {
         if (func1().isIdentical(other.func1())) {
             return (other.c()/c());
         } else {
@@ -846,7 +846,7 @@ public:
         }
     }
 
-    virtual double isProportional(Func1& other) {
+    double isProportional(Func1& other) override {
         if (func1().isIdentical(other)) {
             return 1.0/c();
         } else {
@@ -854,20 +854,20 @@ public:
         }
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return m_f1->eval(t) * m_c;
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
 
-    virtual shared_ptr<Func1> derivative3() const {
+    shared_ptr<Func1> derivative3() const override {
         return newTimesConstFunction(m_f1_shared->derivative3(), m_c);
     }
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 
-    virtual int order() const {
+    int order() const override {
         return 0;
     }
 };
@@ -890,7 +890,7 @@ public:
 
     PlusConstant1(shared_ptr<Func1> f1, double a) : Func1(f1, a) {}
 
-    virtual ~PlusConstant1() {
+    ~PlusConstant1() override {
         if (!m_f1_shared) {
             delete m_f1;
         }
@@ -912,27 +912,27 @@ public:
         return *this;
     }
 
-    virtual int ID() const {
+    int ID() const override {
         return PlusConstantFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "plus-constant";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return m_f1->eval(t) + m_c;
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
 
-    virtual shared_ptr<Func1> derivative3() const {
+    shared_ptr<Func1> derivative3() const override {
         return m_f1_shared->derivative3();
     }
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 
-    virtual int order() const {
+    int order() const override {
         return 0;
     }
 };
@@ -957,7 +957,7 @@ public:
 
     Ratio1(shared_ptr<Func1> f1, shared_ptr<Func1> f2) : Func1(f1, f2) {}
 
-    virtual ~Ratio1() {
+    ~Ratio1() override {
         if (!m_f1_shared) {
             delete m_f1;
         }
@@ -984,25 +984,25 @@ public:
         return *this;
     }
 
-    virtual int ID() const {
+    int ID() const override {
         return RatioFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "ratio";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return m_f1->eval(t) / m_f2->eval(t);
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
 
-    virtual shared_ptr<Func1> derivative3() const;
+    shared_ptr<Func1> derivative3() const override;
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 
-    virtual int order() const {
+    int order() const override {
         return 1;
     }
 };
@@ -1026,7 +1026,7 @@ public:
 
     Composite1(shared_ptr<Func1> f1, shared_ptr<Func1> f2) : Func1(f1, f2) {}
 
-    virtual ~Composite1() {
+    ~Composite1() override {
         if (!m_f1_shared) {
             delete m_f1;
         }
@@ -1053,25 +1053,25 @@ public:
         return *this;
     }
 
-    virtual int ID() const {
+    int ID() const override {
         return CompositeFuncType;
     }
-    virtual string type() const {
+    string type() const override {
         return "composite";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         return m_f1->eval(m_f2->eval(t));
     }
 
-    virtual Func1& duplicate() const;
-    virtual Func1& derivative() const;
+    Func1& duplicate() const override;
+    Func1& derivative() const override;
 
-    virtual shared_ptr<Func1> derivative3() const;
+    shared_ptr<Func1> derivative3() const override;
 
-    virtual string write(const string& arg) const;
+    string write(const string& arg) const override;
 
-    virtual int order() const {
+    int order() const override {
         return 2;
     }
 };
@@ -1122,11 +1122,11 @@ public:
         return *this;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "Gaussian";
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         double x = (t - m_t0)/m_tau;
         return m_A * std::exp(-x*x);
     }
@@ -1154,7 +1154,7 @@ class Gaussian : public Gaussian1
 
     Gaussian(const Gaussian& b);
 
-    virtual Func1& duplicate() const;
+    Func1& duplicate() const override;
 };
 
 
@@ -1193,13 +1193,13 @@ public:
         return *this;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "polynomial";
     }
 
-    virtual Func1& duplicate() const;
+    Func1& duplicate() const override;
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         double r = m_cpoly[m_cpoly.size()-1];
         for (size_t n = 1; n < m_cpoly.size(); n++) {
             r *= t;
@@ -1256,13 +1256,13 @@ public:
         return *this;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "Fourier";
     }
 
-    virtual Func1& duplicate() const;
+    Func1& duplicate() const override;
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         size_t n, nn;
         double sum = m_a0_2;
         for (n = 0; n < m_ccos.size(); n++) {
@@ -1323,13 +1323,13 @@ public:
         return *this;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "Arrhenius";
     }
 
-    virtual Func1& duplicate() const;
+    Func1& duplicate() const override;
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         double sum = 0.0;
         for (size_t n = 0; n < m_A.size(); n++) {
             sum += m_A[n]*std::pow(t,m_b[n])*std::exp(-m_E[n]/t);
@@ -1371,19 +1371,19 @@ public:
         return *this;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "periodic";
     }
 
-    virtual Func1& duplicate() const;
+    Func1& duplicate() const override;
 
-    virtual ~Periodic1() {
+    ~Periodic1() override {
         if (!m_f1_shared) {
             delete m_f1;
         }
     }
 
-    virtual double eval(double t) const {
+    double eval(double t) const override {
         int np = int(t/m_c);
         double time = t - np*m_c;
         return m_f1->eval(time);

--- a/include/cantera/numerics/Func1Factory.h
+++ b/include/cantera/numerics/Func1Factory.h
@@ -30,7 +30,7 @@ public:
      */
     static Func1Factory* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
 private:
     //! Pointer to the single instance of the factory
@@ -64,7 +64,7 @@ public:
      */
     static Math1FactoryA* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
 private:
     //! Pointer to the single instance of the factory
@@ -97,7 +97,7 @@ public:
      */
     static Math1FactoryB* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
 private:
     //! Pointer to the single instance of the factory

--- a/include/cantera/numerics/PreconditionerFactory.h
+++ b/include/cantera/numerics/PreconditionerFactory.h
@@ -20,7 +20,7 @@ public:
     static PreconditionerFactory* factory();
 
     //! Delete preconditioner factory
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
 private:
     static PreconditionerFactory* s_factory;

--- a/include/cantera/numerics/ResidJacEval.h
+++ b/include/cantera/numerics/ResidJacEval.h
@@ -69,7 +69,7 @@ public:
     ResidJacEval(double atol = 1.0e-13);
 
     //! Return the number of equations in the equation system
-    virtual int nEquations() const;
+    int nEquations() const override;
 
     //! Evaluate the residual function
     /*!
@@ -96,11 +96,10 @@ public:
                             const int id_x = -1,
                             const double delta_x = 0.0);
 
-    virtual int eval(const double t, const double* const y,
-                     const double* const ydot,
-                     double* const r);
+    int eval(const double t, const double* const y, const double* const ydot,
+             double* const r) override;
 
-    virtual int getInitialConditions(const double t0, double* const y, double* const ydot);
+    int getInitialConditions(const double t0, double* const y, double* const ydot) override;
 
     //! Filter the solution predictions
     /*!

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -41,15 +41,15 @@ class Boundary1D : public Domain1D
 public:
     Boundary1D();
 
-    virtual void init() {
+    void init() override {
         _init(1);
     }
 
-    virtual string type() const {
+    string type() const override {
         return "boundary";
     }
 
-    virtual bool isConnector() {
+    bool isConnector() override {
         return true;
     }
 
@@ -102,9 +102,9 @@ public:
         return m_mdot;
     }
 
-    virtual void setupGrid(size_t n, const double* z) {}
+    void setupGrid(size_t n, const double* z) override {}
 
-    virtual void fromArray(SolutionArray& arr, double* soln);
+    void fromArray(SolutionArray& arr, double* soln) override;
 
 protected:
     void _init(size_t n);
@@ -142,33 +142,31 @@ public:
 
     Inlet1D(shared_ptr<Solution> solution, const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "inlet";
     }
 
-    virtual void setSpreadRate(double V0);
+    void setSpreadRate(double V0) override;
 
-    virtual double spreadRate() {
+    double spreadRate() override {
         return m_V0;
     }
 
-    virtual void show(const double* x);
+    void show(const double* x) override;
 
-    virtual size_t nSpecies() {
+    size_t nSpecies() override {
         return m_nsp;
     }
 
-    virtual void setMoleFractions(const string& xin);
-    virtual void setMoleFractions(const double* xin);
-    virtual double massFraction(size_t k) {
+    void setMoleFractions(const string& xin) override;
+    void setMoleFractions(const double* xin) override;
+    double massFraction(size_t k) override {
         return m_yin[k];
     }
-
-    virtual void init();
-    virtual void eval(size_t jg, double* xg, double* rg,
-                      integer* diagg, double rdt);
-    virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void fromArray(SolutionArray& arr, double* soln);
+    void init() override;
+    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    shared_ptr<SolutionArray> asArray(const double* soln) const override;
+    void fromArray(SolutionArray& arr, double* soln) override;
 
 protected:
     int m_ilr;
@@ -194,18 +192,17 @@ public:
         m_id = id;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "empty";
     }
 
-    virtual void show(const double* x) {}
+    void show(const double* x) override {}
 
-    virtual void init();
+    void init() override;
 
-    virtual void eval(size_t jg, double* xg, double* rg,
-                      integer* diagg, double rdt);
+    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
-    virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
+    shared_ptr<SolutionArray> asArray(const double* soln) const override;
 };
 
 /**
@@ -224,16 +221,15 @@ public:
         m_id = id;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "symmetry-plane";
     }
 
-    virtual void init();
+    void init() override;
 
-    virtual void eval(size_t jg, double* xg, double* rg,
-                      integer* diagg, double rdt);
+    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
-    virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
+    shared_ptr<SolutionArray> asArray(const double* soln) const override;
 };
 
 
@@ -253,16 +249,15 @@ public:
         m_id = id;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "outlet";
     }
 
-    virtual void init();
+    void init() override;
 
-    virtual void eval(size_t jg, double* xg, double* rg,
-                      integer* diagg, double rdt);
+    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
-    virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
+    shared_ptr<SolutionArray> asArray(const double* soln) const override;
 };
 
 
@@ -277,27 +272,26 @@ public:
 
     OutletRes1D(shared_ptr<Solution> solution, const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "outlet-reservoir";
     }
 
-    virtual void show(const double* x) {}
+    void show(const double* x) override {}
 
-    virtual size_t nSpecies() {
+    size_t nSpecies() override {
         return m_nsp;
     }
 
-    virtual void setMoleFractions(const string& xin);
-    virtual void setMoleFractions(const double* xin);
-    virtual double massFraction(size_t k) {
+    void setMoleFractions(const string& xin) override;
+    void setMoleFractions(const double* xin) override;
+    double massFraction(size_t k) override {
         return m_yres[k];
     }
 
-    virtual void init();
-    virtual void eval(size_t jg, double* xg, double* rg,
-                      integer* diagg, double rdt);
-    virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void fromArray(SolutionArray& arr, double* soln);
+    void init() override;
+    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
+    shared_ptr<SolutionArray> asArray(const double* soln) const override;
+    void fromArray(SolutionArray& arr, double* soln) override;
 
 protected:
     size_t m_nsp = 0;
@@ -323,21 +317,20 @@ public:
         m_id = id;
     }
 
-    virtual string type() const {
+    string type() const override {
         return "surface";
     }
 
-    virtual void init();
+    void init() override;
 
-    virtual void eval(size_t jg, double* xg, double* rg,
-                      integer* diagg, double rdt);
+    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
-    virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void fromArray(SolutionArray& arr, double* soln);
+    shared_ptr<SolutionArray> asArray(const double* soln) const override;
+    void fromArray(SolutionArray& arr, double* soln) override;
 
-    virtual void show(std::ostream& s, const double* x);
+    void show(std::ostream& s, const double* x) override;
 
-    virtual void show(const double* x);
+    void show(const double* x) override;
 };
 
 /**
@@ -349,11 +342,11 @@ public:
     ReactingSurf1D();
     ReactingSurf1D(shared_ptr<Solution> solution, const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "reacting-surface";
     }
 
-    virtual void setKinetics(shared_ptr<Kinetics> kin);
+    void setKinetics(shared_ptr<Kinetics> kin) override;
 
     //! @deprecated To be removed after %Cantera 3.0; replaced by setKinetics()
     void setKineticsMgr(InterfaceKinetics* kin);
@@ -366,26 +359,25 @@ public:
         return m_enabled;
     }
 
-    virtual string componentName(size_t n) const;
+    string componentName(size_t n) const override;
 
-    virtual void init();
-    virtual void resetBadValues(double* xg);
+    void init() override;
+    void resetBadValues(double* xg) override;
 
-    virtual void eval(size_t jg, double* xg, double* rg,
-                      integer* diagg, double rdt);
+    void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
-    virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void fromArray(SolutionArray& arr, double* soln);
+    shared_ptr<SolutionArray> asArray(const double* soln) const override;
+    void fromArray(SolutionArray& arr, double* soln) override;
 
-    virtual void _getInitialSoln(double* x) {
+    void _getInitialSoln(double* x) override {
         m_sphase->getCoverages(x);
     }
 
-    virtual void _finalize(const double* x) {
+    void _finalize(const double* x) override {
         std::copy(x, x+m_nsp, m_fixed_cov.begin());
     }
 
-    virtual void show(const double* x);
+    void show(const double* x) override;
 
 protected:
     InterfaceKinetics* m_kin = nullptr;

--- a/include/cantera/oneD/DomainFactory.h
+++ b/include/cantera/oneD/DomainFactory.h
@@ -29,7 +29,7 @@ public:
      */
     static DomainFactory* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
 private:
     //! Pointer to the single instance of the factory

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -40,21 +40,21 @@ public:
     //! @param points  initial number of grid points
     IonFlow(shared_ptr<Solution> sol, const string& id="", size_t points = 1);
 
-    virtual string type() const;
+    string type() const override;
 
-    virtual size_t getSolvingStage() const {
+    size_t getSolvingStage() const override {
         return m_stage;
     }
-    virtual void setSolvingStage(const size_t stage);
+    void setSolvingStage(const size_t stage) override;
 
-    virtual void resize(size_t components, size_t points);
-    virtual bool componentActive(size_t n) const;
+    void resize(size_t components, size_t points) override;
+    bool componentActive(size_t n) const override;
 
-    virtual void _finalize(const double* x);
+    void _finalize(const double* x) override;
 
-    virtual void solveElectricField(size_t j=npos);
-    virtual void fixElectricField(size_t j=npos);
-    virtual bool doElectricField(size_t j) const {
+    void solveElectricField(size_t j=npos) override;
+    void fixElectricField(size_t j=npos) override;
+    bool doElectricField(size_t j) const override {
         return m_do_electric_field[j];
     }
 
@@ -78,15 +78,15 @@ protected:
      * This function overloads the original function. The residual function
      * of electric field is added.
      */
-    virtual void evalResidual(double* x, double* rsd, int* diag,
-                              double rdt, size_t jmin, size_t jmax);
-    virtual void updateTransport(double* x, size_t j0, size_t j1);
-    virtual void updateDiffFluxes(const double* x, size_t j0, size_t j1);
+    void evalResidual(double* x, double* rsd, int* diag,
+                      double rdt, size_t jmin, size_t jmax) override;
+    void updateTransport(double* x, size_t j0, size_t j1) override;
+    void updateDiffFluxes(const double* x, size_t j0, size_t j1) override;
     //! Solving phase one: the fluxes of charged species are turned off
-    virtual void frozenIonMethod(const double* x, size_t j0, size_t j1);
+    void frozenIonMethod(const double* x, size_t j0, size_t j1);
     //! Solving phase two: the electric field equation is added coupled
     //! by the electrical drift
-    virtual void electricFieldMethod(const double* x, size_t j0, size_t j1);
+    void electricFieldMethod(const double* x, size_t j0, size_t j1);
     //! flag for solving electric field or not
     vector<bool> m_do_electric_field;
 

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -333,7 +333,7 @@ public:
      */
     void solveAdjoint(const double* b, double* lambda);
 
-    virtual void resize();
+    void resize() override;
 
     //! Set a function that will be called after each successful steady-state
     //! solve, before regridding. Intended to be used for observing solver

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -67,14 +67,14 @@ public:
 
     ~StFlow();
 
-    virtual string type() const;
+    string type() const override;
 
     //! @name Problem Specification
     //! @{
 
-    virtual void setupGrid(size_t n, const double* z);
+    void setupGrid(size_t n, const double* z) override;
 
-    virtual void resetBadValues(double* xg);
+    void resetBadValues(double* xg) override;
 
     ThermoPhase& phase() {
         return *m_thermo;
@@ -91,14 +91,14 @@ public:
      */
     void setThermo(ThermoPhase& th);
 
-    virtual void setKinetics(shared_ptr<Kinetics> kin);
+    void setKinetics(shared_ptr<Kinetics> kin) override;
 
     //! Set the kinetics manager.
     //! @deprecated To be removed after %Cantera 3.0;
     //!     replaced by Domain1D::setKinetics()
     void setKinetics(Kinetics& kin);
 
-    virtual void setTransport(shared_ptr<Transport> trans);
+    void setTransport(shared_ptr<Transport> trans) override;
 
     //! Set transport model to existing instance
     //! @deprecated To be removed after %Cantera 3.0;
@@ -135,9 +135,9 @@ public:
     }
 
     //! Write the initial solution estimate into array x.
-    virtual void _getInitialSoln(double* x);
+    void _getInitialSoln(double* x) override;
 
-    virtual void _finalize(const double* x);
+    void _finalize(const double* x) override;
 
     //! Sometimes it is desired to carry out the simulation using a specified
     //! temperature profile, rather than computing it by solving the energy
@@ -163,18 +163,18 @@ public:
 
     //! @}
 
-    virtual string componentName(size_t n) const;
+    string componentName(size_t n) const override;
 
-    virtual size_t componentIndex(const string& name) const;
+    size_t componentIndex(const string& name) const override;
 
     //! Returns true if the specified component is an active part of the solver state
     virtual bool componentActive(size_t n) const;
 
     //! Print the solution.
-    virtual void show(const double* x);
+    void show(const double* x) override;
 
-    virtual shared_ptr<SolutionArray> asArray(const double* soln) const;
-    virtual void fromArray(SolutionArray& arr, double* soln);
+    shared_ptr<SolutionArray> asArray(const double* soln) const override;
+    void fromArray(SolutionArray& arr, double* soln) override;
 
     //! Set flow configuration for freely-propagating flames, using an internal point
     //! with a fixed temperature as the condition to determine the inlet mass flux.
@@ -279,7 +279,7 @@ public:
     }
 
     //! Change the grid size. Called after grid refinement.
-    virtual void resize(size_t components, size_t points);
+    void resize(size_t components, size_t points) override;
 
     //! Set the gas object state to be consistent with the solution at point j.
     void setGas(const double* x, size_t j);
@@ -327,16 +327,14 @@ public:
      *  j-1, j, and j+1. This option is used to efficiently evaluate the
      *  Jacobian numerically.
      */
-    virtual void eval(size_t j, double* x, double* r, integer* mask, double rdt);
+    void eval(size_t j, double* x, double* r, integer* mask, double rdt) override;
 
     //! Evaluate all residual components at the right boundary.
-    virtual void evalRightBoundary(double* x, double* res, int* diag,
-                                   double rdt);
+    virtual void evalRightBoundary(double* x, double* res, int* diag, double rdt);
 
     //! Evaluate the residual corresponding to the continuity equation at all
     //! interior grid points.
-    virtual void evalContinuity(size_t j, double* x, double* r,
-                                int* diag, double rdt);
+    virtual void evalContinuity(size_t j, double* x, double* r, int* diag, double rdt);
 
     //! Index of the species on the left boundary with the largest mass fraction
     size_t leftExcessSpecies() const {
@@ -349,8 +347,8 @@ public:
     }
 
 protected:
-    virtual AnyMap getMeta() const;
-    virtual void setMeta(const AnyMap& state);
+    AnyMap getMeta() const override;
+    void setMeta(const AnyMap& state) override;
 
     double wdot(size_t k, size_t j) const {
         return m_wdot(k,j);

--- a/include/cantera/thermo/BinarySolutionTabulatedThermo.h
+++ b/include/cantera/thermo/BinarySolutionTabulatedThermo.h
@@ -173,14 +173,14 @@ public:
      */
     explicit BinarySolutionTabulatedThermo(const string& infile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "binary-solution-tabulated";
     }
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void initThermo();
-    virtual bool ready() const;
-    virtual void getParameters(AnyMap& phaseNode) const;
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void initThermo() override;
+    bool ready() const override;
+    void getParameters(AnyMap& phaseNode) const override;
 
     /**
      * returns an array of partial molar volumes of the species
@@ -191,7 +191,7 @@ public:
      *
      * @param vbar  Output vector of partial molar volumes. Length: m_kk.
      */
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     /**
      * Overloads the calcDensity() method of IdealSolidSoln to also consider non-ideal
@@ -206,11 +206,11 @@ public:
      * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular weights, and
      * @f$ V_\mathrm{m} @f$ is the molar volume interpolated from @f$ V_{\mathrm{m,tab}} @f$.
      */
-    virtual void calcDensity();
+    void calcDensity() override;
 
 protected:
     //! If the compositions have changed, update the tabulated thermo lookup
-    virtual void compositionChanged();
+    void compositionChanged() override;
 
     //! Species thermodynamics linear interpolation function
     /*!
@@ -254,7 +254,7 @@ protected:
     vector<double> m_derived_molar_volume_tab;
 
 private:
-    virtual void _updateThermo() const;
+    void _updateThermo() const override;
 };
 }
 

--- a/include/cantera/thermo/ConstCpPoly.h
+++ b/include/cantera/thermo/ConstCpPoly.h
@@ -66,7 +66,7 @@ public:
      */
     void setParameters(double t0, double h0, double s0, double cp0);
 
-    virtual int reportType() const {
+    int reportType() const override {
         return CONSTANT_CP;
     }
 
@@ -78,21 +78,21 @@ public:
      *
      */
     void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                          double* s_R) const;
+                          double* s_R) const override;
 
     void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                              double* s_R) const;
+                              double* s_R) const override;
 
-    size_t nCoeffs() const { return 4; }
+    size_t nCoeffs() const override { return 4; }
 
     void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                          double& pref, double* const coeffs) const;
+                          double& pref, double* const coeffs) const override;
 
-    virtual void getParameters(AnyMap& thermo) const;
+    void getParameters(AnyMap& thermo) const override;
 
-    virtual double reportHf298(double* const h298 = 0) const;
-    virtual void modifyOneHf298(const size_t k, const double Hf298New);
-    virtual void resetHf298();
+    double reportHf298(double* const h298=nullptr) const override;
+    void modifyOneHf298(const size_t k, const double Hf298New) override;
+    void resetHf298() override;
 
 protected:
     //! Base temperature

--- a/include/cantera/thermo/CoverageDependentSurfPhase.h
+++ b/include/cantera/thermo/CoverageDependentSurfPhase.h
@@ -220,7 +220,7 @@ public:
     explicit CoverageDependentSurfPhase(const string& infile="",
                                         const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "coverage-dependent-surface";
     }
 
@@ -230,21 +230,20 @@ public:
      */
     void addInterpolativeDependency(const InterpolativeDependency& int_deps);
 
-    virtual void initThermo();
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void getParameters(AnyMap& phaseNode) const;
-    virtual void getSpeciesParameters(const string& name,
-                                      AnyMap& speciesNode) const;
+    void initThermo() override;
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void getParameters(AnyMap& phaseNode) const override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
 
     //! @name Methods calculating reference state thermodynamic properties
     //! Reference state properties are evaluated at @f$ T \text{ and }
     //! \theta^{ref} @f$. With coverage fixed at a reference value,
     //! reference state properties are effectively only dependent on temperature.
     //! @{
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getEntropy_R_ref(double* sr) const;
-    virtual void getCp_R_ref(double* cpr) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getEntropy_R_ref(double* sr) const override;
+    void getCp_R_ref(double* cpr) const override;
+    void getGibbs_RT_ref(double* grt) const override;
     //! @}
 
     //! @name Methods calculating standard state thermodynamic properties
@@ -260,7 +259,7 @@ public:
      *            + \int_{298}^{T} c^{cov}_{p,k}(T,\theta)dT}{RT}
      * @f]
      */
-    virtual void getEnthalpy_RT(double* hrt) const;
+    void getEnthalpy_RT(double* hrt) const override;
 
     //! Get the nondimensionalized standard state entropy vector.
     /*!
@@ -271,7 +270,7 @@ public:
      *            - \ln\left(\frac{1}{\theta_{ref}}\right)
      * @f]
      */
-    virtual void getEntropy_R(double* sr) const;
+    void getEntropy_R(double* sr) const override;
 
     //! Get the nondimensionalized standard state heat capacity vector.
     /*!
@@ -280,7 +279,7 @@ public:
      *          = \frac{c^{ref}_{p,k}(T) + c^{cov}_{p,k}(T,\theta)}{RT}
      * @f]
      */
-    virtual void getCp_R(double* cpr) const;
+    void getCp_R(double* cpr) const override;
 
     //! Get the nondimensionalized standard state gibbs free energy vector.
     /*!
@@ -289,7 +288,7 @@ public:
      *          = \frac{h^o_k(T,\theta)}{RT} + \frac{s^o_k(T,\theta)}{R}
      * @f]
      */
-    virtual void getGibbs_RT(double* grt) const;
+    void getGibbs_RT(double* grt) const override;
 
     //! Get the standard state gibbs free energy vector. Units: J/kmol.
     /*!
@@ -297,7 +296,7 @@ public:
      *      g^o_k(T,\theta) = h^o_k(T,\theta) + Ts^o_k(T,\theta)
      * @f]
      */
-    virtual void getPureGibbs(double* g) const;
+    void getPureGibbs(double* g) const override;
 
     //! Get the standard state chemical potential vector. Units: J/kmol.
     /*!
@@ -305,7 +304,7 @@ public:
      *      \mu^o_k(T,\theta) = h^o_k(T,\theta) + Ts^o_k(T,\theta)
      * @f]
      */
-    virtual void getStandardChemPotentials(double* mu0) const;
+    void getStandardChemPotentials(double* mu0) const override;
     //! @}
 
     //! @name Methods calculating partial molar thermodynamic properties
@@ -319,7 +318,7 @@ public:
      *      \tilde{h}_k(T,\theta) = h^o_k(T,\theta)
      * @f]
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     //! Get the partial molar entropy vector. Units: J/kmol/K.
     /*!
@@ -327,7 +326,7 @@ public:
      *      \tilde{s}_k(T,\theta) = s^o_k(T,\theta) - R\ln(\theta_k)
      * @f]
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     //! Get the partial molar heat capacity vector. Units: J/kmol/K.
     /*!
@@ -335,7 +334,7 @@ public:
      *      \tilde{c}_{p,k}(T,\theta) = c^o_{p,k}(T,\theta)
      * @f]
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
     //! Get the chemical potential vector. Units: J/kmol.
     /*!
@@ -343,7 +342,7 @@ public:
      *      \mu_k(T,\theta) = \mu^o_k(T,\theta) + RT\ln(\theta_k)
      * @f]
      */
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
     //! @}
 
     //! @name Methods calculating Phase thermodynamic properties
@@ -358,7 +357,7 @@ public:
      *      \hat h(T,\theta) = \sum_k \theta_k \tilde{h}_k(T,\theta)
      * @f]
      */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     //! Return the solution's molar entropy. Units: J/kmol/K
     /*!
@@ -366,7 +365,7 @@ public:
      *      \hat s(T,\theta) = \sum_k \theta_k \tilde{s}_k(T,\theta)
      * @f]
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
     //! Return the solution's molar heat capacity. Units: J/kmol/K
     /*!
@@ -374,7 +373,7 @@ public:
      *      \hat{c_p}(T,\theta) = \sum_k \theta_k \tilde{c_p}_k(T,\theta)
      * @f]
      */
-    virtual double cp_mole() const;
+    double cp_mole() const override;
     //! @}
 
 protected:

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -414,7 +414,7 @@ class PDSS_Water;
 class DebyeHuckel : public MolalityVPSSTP
 {
 public:
-    virtual ~DebyeHuckel();
+    ~DebyeHuckel() override;
 
     //! Full constructor for creating the phase.
     /*!
@@ -427,7 +427,7 @@ public:
     //! @name  Utilities
     //! @{
 
-    virtual string type() const {
+    string type() const override {
         return "Debye-Huckel";
     }
 
@@ -435,7 +435,7 @@ public:
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     //! Molar entropy. Units: J/kmol/K.
     /**
@@ -452,10 +452,10 @@ public:
      * temperature since the volume expansivities are equal to zero.
      * @see MultiSpeciesThermo
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
-    virtual double gibbs_mole() const;
-    virtual double cp_mole() const;
+    double gibbs_mole() const override;
+    double cp_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
@@ -468,7 +468,7 @@ public:
     //! @{
 
 protected:
-    virtual void calcDensity();
+    void calcDensity() override;
 
 public:
     //! @}
@@ -481,7 +481,7 @@ public:
     //! to be molality-based here.
     //! @{
 
-    virtual void getActivityConcentrations(double* c) const;
+    void getActivityConcentrations(double* c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -497,7 +497,7 @@ public:
      *         assume this refers to species 0.
      * @return the standard Concentration in units of m^3/kmol
      */
-    virtual double standardConcentration(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
 
     //! Get the array of non-dimensional activities at the current solution
     //! temperature, pressure, and solution concentration.
@@ -506,7 +506,7 @@ public:
      *
      * @param ac  Output vector of activities. Length: m_kk.
      */
-    virtual void getActivities(double* ac) const;
+    void getActivities(double* ac) const override;
 
     //! Get the array of non-dimensional molality-based activity coefficients at
     //! the current solution temperature, pressure, and solution concentration.
@@ -519,7 +519,7 @@ public:
      * @param acMolality Vector of Molality-based activity coefficients
      *                   Length: m_kk
      */
-    virtual void getMolalityActivityCoefficients(double* acMolality) const;
+    void getMolalityActivityCoefficients(double* acMolality) const override;
 
     //! @}
     //! @name Partial Molar Properties of the Solution
@@ -538,7 +538,7 @@ public:
      * @param mu  Output vector of species chemical
      *            potentials. Length: m_kk. Units: J/kmol
      */
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species
     //! in the mixture. Units (J/kmol)
@@ -561,7 +561,7 @@ public:
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: m_kk. units are J/kmol.
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     //! Returns an array of partial molar entropies of the species in the
     //! solution. Units: J/kmol/K.
@@ -591,9 +591,9 @@ public:
      *  @param sbar    Output vector of species partial molar entropies.
      *                 Length = m_kk. units are J/kmol/K.
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
     //! Return an array of partial molar volumes for the species in the mixture.
     //! Units: m^3/kmol.
@@ -611,7 +611,7 @@ public:
      *  @param vbar   Output vector of species partial molar volumes.
      *                Length = m_kk. units are m^3/kmol.
      */
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     //! @}
 
@@ -619,10 +619,10 @@ public:
      *  -------------- Utilities -------------------------------
      */
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
-    virtual void getSpeciesParameters(const string& name, AnyMap& speciesNode) const;
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
 
     //! Return the Debye Huckel constant as a function of temperature
     //! and pressure (Units = sqrt(kg/gmol))

--- a/include/cantera/thermo/EdgePhase.h
+++ b/include/cantera/thermo/EdgePhase.h
@@ -38,7 +38,7 @@ public:
      */
     explicit EdgePhase(const string& infile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "edge";
     }
 };

--- a/include/cantera/thermo/GibbsExcessVPSSTP.h
+++ b/include/cantera/thermo/GibbsExcessVPSSTP.h
@@ -94,28 +94,7 @@ public:
     //! @{
 
 protected:
-    /**
-     * Calculate the density of the mixture using the partial molar volumes and
-     * mole fractions as input
-     *
-     * The formula for this is
-     *
-     * @f[
-     * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * @f]
-     *
-     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
-     * weights, and @f$ V_k @f$ are the pure species molar volumes.
-     *
-     * Note, the basis behind this formula is that in an ideal solution the
-     * partial molar volumes are equal to the pure species molar volumes. We
-     * have additionally specified in this class that the pure species molar
-     * volumes are independent of temperature and pressure.
-     *
-     * NOTE: This is a non-virtual function, which is not a member of the
-     *       ThermoPhase base class.
-     */
-    void calcDensity();
+    void calcDensity() override;
 
 public:
     //! @}
@@ -127,8 +106,8 @@ public:
     //! which depends only on temperature and pressure.
     //! @{
 
-    virtual Units standardConcentrationUnits() const;
-    virtual void getActivityConcentrations(double* c) const;
+    Units standardConcentrationUnits() const override;
+    void getActivityConcentrations(double* c) const override;
 
     /**
      * The standard concentration @f$ C^0_k @f$ used to normalize the
@@ -145,8 +124,8 @@ public:
      *
      * @param k species index. Defaults to zero.
      */
-    virtual double standardConcentration(size_t k=0) const;
-    virtual double logStandardConc(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
+    double logStandardConc(size_t k=0) const override;
 
     //! Get the array of non-dimensional activities (molality based for this
     //! class and classes that derive from it) at the current solution
@@ -160,13 +139,12 @@ public:
      *
      * @param ac     Output vector of molality-based activities. Length: m_kk.
      */
-    virtual void getActivities(double* ac) const;
+    void getActivities(double* ac) const override;
 
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     //! Get the array of temperature derivatives of the log activity coefficients
     /*!
-     * This function is virtual, and first appears in GibbsExcessVPSSTP.
      *
      * units = 1/Kelvin
      *
@@ -177,7 +155,7 @@ public:
         throw NotImplementedError("GibbsExcessVPSSTP::getdlnActCoeffdT");
     }
 
-    virtual void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) {
+    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override {
         throw NotImplementedError("GibbsExcessVPSSTP::getdlnActCoeffdlnN: "
                                   "nonzero and nonimplemented");
     }
@@ -216,15 +194,15 @@ public:
      *  @param vbar   Output vector of species partial molar volumes.
      *                Length = m_kk. units are m^3/kmol.
      */
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
     //! @deprecated Unused. To be removed after %Cantera 3.0.
     virtual const vector<double>& getPartialMolarVolumesVector() const;
     //! @}
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
 protected:
-    virtual void compositionChanged();
+    void compositionChanged() override;
 
     //! utility routine to check mole fraction sum
     /*!

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -796,7 +796,7 @@ public:
     //! @name  Utilities
     //! @{
 
-    virtual string type() const {
+    string type() const override {
         return "HMW-electrolyte";
     }
 
@@ -804,12 +804,7 @@ public:
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    //! Molar enthalpy. Units: J/kmol.
-    /**
-     * Molar enthalpy of the solution. Units: J/kmol.
-     *      (HKM -> Bump up to Parent object)
-     */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     /**
      * Excess molar enthalpy of the solution from
@@ -845,21 +840,13 @@ public:
      *
      *      (HKM -> Bump up to Parent object)
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
-    //! Molar Gibbs function. Units: J/kmol.
-    /*!
-     *      (HKM -> Bump up to Parent object)
-     */
-    virtual double gibbs_mole() const;
+    double gibbs_mole() const override;
 
-    virtual double cp_mole() const;
+    double cp_mole() const override;
 
-    //! Molar heat capacity at constant volume. Units: J/kmol/K.
-    /*!
-     *      (HKM -> Bump up to Parent object)
-     */
-    virtual double cv_mole() const;
+    double cv_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
@@ -872,28 +859,7 @@ public:
     //! @{
 
 protected:
-    /**
-     * Calculate the density of the mixture using the partial
-     * molar volumes and mole fractions as input
-     *
-     * The formula for this is
-     *
-     * @f[
-     * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * @f]
-     *
-     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
-     * weights, and @f$ V_k @f$ are the pure species molar volumes.
-     *
-     * Note, the basis behind this formula is that in an ideal solution the
-     * partial molar volumes are equal to the pure species molar volumes. We
-     * have additionally specified in this class that the pure species molar
-     * volumes are independent of temperature and pressure.
-     *
-     * NOTE: This is a non-virtual function, which is not a member of the
-     *       ThermoPhase base class.
-     */
-    void calcDensity();
+    void calcDensity() override;
 
 public:
     //! @}
@@ -931,7 +897,7 @@ public:
      * @param c Array of generalized concentrations. The
      *          units are kmol m-3 for both the solvent and the solute species
      */
-    virtual void getActivityConcentrations(double* c) const;
+    void getActivityConcentrations(double* c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -1011,7 +977,7 @@ public:
      *         assume this refers to species 0.
      * @returns the standard Concentration in units of m^3/kmol.
      */
-    virtual double standardConcentration(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
 
     //! Get the array of non-dimensional activities at the current solution
     //! temperature, pressure, and solution concentration.
@@ -1025,7 +991,7 @@ public:
      *
      * @param ac  Output vector of activities. Length: m_kk.
      */
-    virtual void getActivities(double* ac) const;
+    void getActivities(double* ac) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -1044,7 +1010,7 @@ public:
      * @param mu  Output vector of species chemical
      *            potentials. Length: m_kk. Units: J/kmol
      */
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species
     //! in the mixture. Units (J/kmol)
@@ -1067,7 +1033,7 @@ public:
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: m_kk. units are J/kmol.
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     //! Returns an array of partial molar entropies of the species in the
     //! solution. Units: J/kmol/K.
@@ -1094,7 +1060,7 @@ public:
      *  @param sbar    Output vector of species partial molar entropies.
      *                 Length = m_kk. units are J/kmol/K.
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     //! Return an array of partial molar volumes for the species in the mixture.
     //! Units: m^3/kmol.
@@ -1114,7 +1080,7 @@ public:
      * @param vbar   Output vector of species partial molar volumes.
      *               Length = m_kk. units are m^3/kmol.
      */
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     //! Return an array of partial molar heat capacities for the species in the
     //! mixture.  Units: J/kmol/K
@@ -1135,7 +1101,7 @@ public:
      * @param cpbar   Output vector of species partial molar heat capacities at
      *                constant pressure. Length = m_kk. units are J/kmol/K.
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
 public:
     //! @}
@@ -1154,7 +1120,7 @@ public:
      *
      * @param T  Temperature (kelvin)
      */
-    virtual double satPressure(double T);
+    double satPressure(double T) override;
 
     /*
      *  -------------- Utilities -------------------------------
@@ -1189,8 +1155,8 @@ public:
     void setCroppingCoefficients(double ln_gamma_k_min, double ln_gamma_k_max,
                                  double ln_gamma_o_min, double ln_gamma_o_max);
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
 
     //! Value of the Debye Huckel constant as a function of temperature
     //! and pressure.
@@ -1319,7 +1285,7 @@ public:
      * @param acMolality Output vector containing the molality based activity coefficients.
      *                   length: m_kk.
      */
-    void getUnscaledMolalityActivityCoefficients(double* acMolality) const;
+    void getUnscaledMolalityActivityCoefficients(double* acMolality) const override;
 
 private:
     //! Apply the current phScale to a set of activity Coefficients
@@ -1960,7 +1926,7 @@ private:
      * @param acMolality input/Output vector containing the molality based
      *                   activity coefficients. length: m_kk.
      */
-    virtual void applyphScale(double* acMolality) const;
+    void applyphScale(double* acMolality) const override;
 
 private:
     /**

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -260,11 +260,11 @@ public:
      */
     explicit IdealGasPhase(const string& inputFile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "ideal-gas";
     }
 
-    virtual bool isIdeal() const {
+    bool isIdeal() const override {
         return true;
     }
 
@@ -272,7 +272,7 @@ public:
     /*!
      * For the `IdealGasPhase`, this string is always `gas`.
      */
-    virtual string phaseOfMatter() const {
+    string phaseOfMatter() const override {
         return "gas";
     }
 
@@ -291,7 +291,7 @@ public:
      *
      * \see MultiSpeciesThermo
      */
-    virtual double enthalpy_mole() const {
+    double enthalpy_mole() const override {
         return RT() * mean_X(enthalpy_RT_ref());
     }
 
@@ -305,7 +305,7 @@ public:
      * computed by the species thermodynamic property manager.
      * @see MultiSpeciesThermo
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
     /**
      * Molar heat capacity at constant pressure. Units: J/kmol/K.
@@ -317,14 +317,14 @@ public:
      * are computed by the species thermodynamic property manager.
      * @see MultiSpeciesThermo
      */
-    virtual double cp_mole() const;
+    double cp_mole() const override;
 
     /**
      * Molar heat capacity at constant volume. Units: J/kmol/K.
      * For an ideal gas mixture,
      * @f[ \hat c_v = \hat c_p - \hat R. @f]
      */
-    virtual double cv_mole() const;
+    double cv_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State
@@ -335,7 +335,7 @@ public:
      * For an ideal gas mixture,
      * @f[ P = n \hat R T. @f]
      */
-    virtual double pressure() const {
+    double pressure() const override {
         return GasConstant * molarDensity() * temperature();
     }
 
@@ -349,7 +349,7 @@ public:
      *
      * @param p Pressure (Pa)
      */
-    virtual void setPressure(double p) {
+    void setPressure(double p) override {
         setDensity(p * meanMolecularWeight() / RT());
     }
 
@@ -366,8 +366,7 @@ public:
      * @param p Pressure (Pa)
      * @since New in %Cantera 3.0.
      */
-    virtual void setState_DP(double rho, double p)
-    {
+    void setState_DP(double rho, double p) override {
         if (p <= 0) {
             throw CanteraError("IdealGasPhase::setState_DP",
                                "pressure must be positive");
@@ -384,7 +383,7 @@ public:
      * @f]
      *  For ideal gases it's equal to the inverse of the pressure
      */
-    virtual double isothermalCompressibility() const {
+    double isothermalCompressibility() const override {
         return 1.0 / pressure();
     }
 
@@ -396,11 +395,11 @@ public:
      * @f]
      * For ideal gases, it's equal to the inverse of the temperature.
      */
-    virtual double thermalExpansionCoeff() const {
+    double thermalExpansionCoeff() const override {
         return 1.0 / temperature();
     }
 
-    virtual double soundSpeed() const;
+    double soundSpeed() const override;
 
     //! @}
     //! @name Chemical Potentials and Activities
@@ -439,7 +438,7 @@ public:
      *           upon the implementation of the reaction rate expressions within
      *           the phase.
      */
-    virtual void getActivityConcentrations(double* c) const {
+    void getActivityConcentrations(double* c) const override {
         getConcentrations(c);
     }
 
@@ -457,7 +456,7 @@ public:
      * @return
      *   Returns the standard Concentration in units of m3 kmol-1.
      */
-    virtual double standardConcentration(size_t k = 0) const;
+    double standardConcentration(size_t k=0) const override;
 
     //! Get the array of non-dimensional activity coefficients at the current
     //! solution temperature, pressure, and solution concentration.
@@ -466,43 +465,43 @@ public:
      *
      * @param ac Output vector of activity coefficients. Length: m_kk.
      */
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     //! @}
     //! @name Partial Molar Properties of the Solution
     //! @{
 
-    virtual void getChemPotentials(double* mu) const;
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
-    virtual void getPartialMolarEntropies(double* sbar) const;
-    virtual void getPartialMolarIntEnergies(double* ubar) const;
-    virtual void getPartialMolarCp(double* cpbar) const;
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getChemPotentials(double* mu) const override;
+    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarIntEnergies(double* ubar) const override;
+    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
     //! @{
 
-    virtual void getStandardChemPotentials(double* mu) const;
-    virtual void getEnthalpy_RT(double* hrt) const;
-    virtual void getEntropy_R(double* sr) const;
-    virtual void getGibbs_RT(double* grt) const;
-    virtual void getPureGibbs(double* gpure) const;
-    virtual void getIntEnergy_RT(double* urt) const;
-    virtual void getCp_R(double* cpr) const;
-    virtual void getStandardVolumes(double* vol) const;
+    void getStandardChemPotentials(double* mu) const override;
+    void getEnthalpy_RT(double* hrt) const override;
+    void getEntropy_R(double* sr) const override;
+    void getGibbs_RT(double* grt) const override;
+    void getPureGibbs(double* gpure) const override;
+    void getIntEnergy_RT(double* urt) const override;
+    void getCp_R(double* cpr) const override;
+    void getStandardVolumes(double* vol) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
-    virtual void getGibbs_ref(double* g) const;
-    virtual void getEntropy_R_ref(double* er) const;
-    virtual void getIntEnergy_RT_ref(double* urt) const;
-    virtual void getCp_R_ref(double* cprt) const;
-    virtual void getStandardVolumes_ref(double* vol) const;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getGibbs_RT_ref(double* grt) const override;
+    void getGibbs_ref(double* g) const override;
+    void getEntropy_R_ref(double* er) const override;
+    void getIntEnergy_RT_ref(double* urt) const override;
+    void getCp_R_ref(double* cprt) const override;
+    void getStandardVolumes_ref(double* vol) const override;
 
     //! @}
     //! @name NonVirtual Internal methods to Return References to Reference State Thermo
@@ -550,8 +549,8 @@ public:
 
     //! @}
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void setToEquilState(const double* mu_RT);
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void setToEquilState(const double* mu_RT) override;
 
 protected:
     //! Reference state pressure

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -78,11 +78,11 @@ public:
      */
     explicit IdealMolalSoln(const string& inputFile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "ideal-molal-solution";
     }
 
-    virtual bool isIdeal() const {
+    bool isIdeal() const override {
         return true;
     }
 
@@ -103,7 +103,7 @@ public:
      *
      * Units: J/kmol
      */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     //! Molar internal energy of the solution: Units: J/kmol.
     /*!
@@ -115,7 +115,7 @@ public:
      * The formula is written in terms of the partial molar internal energy.
      * @f$ \bar{u}_k(T, p, m_k) @f$.
      */
-    virtual double intEnergy_mole() const;
+    double intEnergy_mole() const override;
 
     //! Molar entropy of the solution. Units: J/kmol/K.
     /*!
@@ -131,7 +131,7 @@ public:
      *
      * Units: J/kmol/K.
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
     //! Molar Gibbs function for the solution: Units J/kmol.
     /*!
@@ -143,7 +143,7 @@ public:
      *
      * Units: J/kmol
      */
-    virtual double gibbs_mole() const;
+    double gibbs_mole() const override;
 
     //! Molar heat capacity of the solution at constant pressure. Units: J/kmol/K.
     /*!
@@ -153,7 +153,7 @@ public:
      *
      * Units: J/kmol/K
      */
-    virtual double cp_mole() const;
+    double cp_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
@@ -166,25 +166,7 @@ public:
     //! @{
 
 protected:
-    /**
-     * Calculate the density of the mixture using the partial molar volumes and
-     * mole fractions as input
-     *
-     * The formula for this is
-     *
-     * @f[
-     * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * @f]
-     *
-     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
-     * weights, and @f$ V_k @f$ are the pure species molar volumes.
-     *
-     * Note, the basis behind this formula is that in an ideal solution the
-     * partial molar volumes are equal to the pure species molar volumes. We
-     * have additionally specified in this class that the pure species molar
-     * volumes are independent of temperature and pressure.
-     */
-    void calcDensity();
+    void calcDensity() override;
 
 public:
     //! The isothermal compressibility. Units: 1/Pa.
@@ -197,7 +179,7 @@ public:
      * It's equal to zero for this model, since the molar volume doesn't change
      * with pressure or temperature.
      */
-    virtual double isothermalCompressibility() const;
+    double isothermalCompressibility() const override;
 
     //! The thermal expansion coefficient. Units: 1/K.
     /*!
@@ -210,7 +192,7 @@ public:
      * It's equal to zero for this model, since the molar volume doesn't change
      * with pressure or temperature.
      */
-    virtual double thermalExpansionCoeff() const;
+    double thermalExpansionCoeff() const override;
 
     //! @}
     //! @name Activities and Activity Concentrations
@@ -221,9 +203,9 @@ public:
     //! which depends only on temperature and the pressure.
     //! @{
 
-    virtual Units standardConcentrationUnits() const;
-    virtual void getActivityConcentrations(double* c) const;
-    virtual double standardConcentration(size_t k=0) const;
+    Units standardConcentrationUnits() const override;
+    void getActivityConcentrations(double* c) const override;
+    double standardConcentration(size_t k=0) const override;
 
     /**
      * Get the array of non-dimensional activities at the current solution
@@ -233,7 +215,7 @@ public:
      *
      * @param ac      Output activity coefficients. Length: m_kk.
      */
-    virtual void getActivities(double* ac) const;
+    void getActivities(double* ac) const override;
 
     /**
      * Get the array of non-dimensional molality-based activity coefficients at
@@ -245,7 +227,7 @@ public:
      * @param acMolality      Output Molality-based activity coefficients.
      *                        Length: m_kk.
      */
-    virtual void getMolalityActivityCoefficients(double* acMolality) const;
+    void getMolalityActivityCoefficients(double* acMolality) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -273,7 +255,7 @@ public:
      *
      * @param mu     Output vector of species chemical potentials. Length: m_kk.
      */
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species in the
     //! mixture.
@@ -292,7 +274,7 @@ public:
      * @param hbar   Output vector of partial molar enthalpies.
      *               Length: m_kk.
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     //! Returns an array of partial molar internal energies for the species in the
     //! mixture.
@@ -305,7 +287,7 @@ public:
      * @f]
      * @param hbar   Output vector of partial molar internal energies, length #m_kk
      */
-    virtual void getPartialMolarIntEnergies(double* hbar) const;
+    void getPartialMolarIntEnergies(double* hbar) const override;
 
     //! Returns an array of partial molar entropies of the species in the
     //! solution. Units: J/kmol.
@@ -335,7 +317,7 @@ public:
      * @param sbar Output vector of partial molar entropies.
      *             Length: m_kk.
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     // partial molar volumes of the species Units: m^3 kmol-1.
     /*!
@@ -345,7 +327,7 @@ public:
      * Units: m^3 kmol-1.
      *  @param vbar Output vector of partial molar volumes.
      */
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     //! Partial molar heat capacity of the solution:. UnitsL J/kmol/K
     /*!
@@ -363,17 +345,17 @@ public:
      * @param cpbar  Output vector of partial molar heat capacities.
      *               Length: m_kk.
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
     //! @}
 
     // -------------- Utilities -------------------------------
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
-    virtual void initThermo();
+    void initThermo() override;
 
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void getParameters(AnyMap& phaseNode) const override;
 
     //! Set the standard concentration model.
     /*!

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -55,15 +55,15 @@ public:
      */
     explicit IdealSolidSolnPhase(const string& infile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "ideal-condensed";
     }
 
-    virtual bool isIdeal() const {
+    bool isIdeal() const override {
         return true;
     }
 
-    virtual bool isCompressible() const {
+    bool isCompressible() const override {
         return false;
     }
 
@@ -82,7 +82,7 @@ public:
      * property manager. They are polynomial functions of temperature.
      * @see MultiSpeciesThermo
      */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     /**
      * Molar entropy of the solution. Units: J/kmol/K. For an ideal, constant
@@ -97,7 +97,7 @@ public:
      * pressure since the volume expansivities are equal to zero.
      * @see MultiSpeciesThermo
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
     /**
      * Molar Gibbs free energy of the solution. Units: J/kmol. For an ideal,
@@ -112,7 +112,7 @@ public:
      * @f$ \hat g^0_k(T,P) @f$ are computed by the member function, gibbs_RT().
      * @see MultiSpeciesThermo
      */
-    virtual double gibbs_mole() const;
+    double gibbs_mole() const override;
 
     /**
      * Molar heat capacity at constant pressure of the solution.
@@ -127,7 +127,7 @@ public:
      * species thermodynamic property manager.
      * @see MultiSpeciesThermo
      */
-    virtual double cp_mole() const;
+    double cp_mole() const override;
 
     /**
      * Molar heat capacity at constant volume of the solution. Units: J/kmol/K.
@@ -136,7 +136,7 @@ public:
      * @f[ \hat c_v(T,P) = \hat c_p(T,P) @f]
      * The two heat capacities are equal.
      */
-    virtual double cv_mole() const {
+    double cv_mole() const override {
         return cp_mole();
     }
 
@@ -154,7 +154,7 @@ public:
      * Pressure. Units: Pa. For this incompressible system, we return the
      * internally stored independent value of the pressure.
      */
-    virtual double pressure() const {
+    double pressure() const override {
         return m_Pcurrent;
     }
 
@@ -165,7 +165,7 @@ public:
      *
      * @param p   Input Pressure (Pa)
      */
-    virtual void setPressure(double p);
+    void setPressure(double p) override;
 
     /**
      * Calculate the density of the mixture using the partial molar volumes and
@@ -216,7 +216,7 @@ public:
     //! provided by the multiplicative factor of the standard concentrations.
     //! @{
 
-    virtual Units standardConcentrationUnits() const;
+    Units standardConcentrationUnits() const override;
 
     /**
      * This method returns the array of generalized concentrations. The
@@ -253,7 +253,7 @@ public:
      * @param c  Pointer to array of doubles of length m_kk, which on exit
      *           will contain the generalized concentrations.
      */
-    virtual void getActivityConcentrations(double* c) const;
+    void getActivityConcentrations(double* c) const override;
 
     /**
      * The standard concentration @f$ C^0_k @f$ used to normalize the
@@ -265,13 +265,13 @@ public:
      * @param k Species number: this is a require parameter, a change from the
      *     ThermoPhase base class, where it was an optional parameter.
      */
-    virtual double standardConcentration(size_t k) const;
+    double standardConcentration(size_t k) const override;
 
     //! Get the array of species activity coefficients
     /*!
      * @param ac output vector of activity coefficients. Length: m_kk
      */
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     /**
      * Get the species chemical potentials. Units: J/kmol.
@@ -289,7 +289,7 @@ public:
      *
      * @param mu  Output vector of chemical potentials.
      */
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     /**
      * Get the array of non-dimensional species solution
@@ -306,7 +306,7 @@ public:
      *             Length = m_kk.
      * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
-    virtual void getChemPotentials_RT(double* mu) const;
+    void getChemPotentials_RT(double* mu) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -329,7 +329,7 @@ public:
      * @param hbar Output vector containing partial molar enthalpies.
      *             Length: m_kk.
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     /**
      * Returns an array of partial molar entropies of the species in the
@@ -348,7 +348,7 @@ public:
      * @param sbar Output vector containing partial molar entropies.
      *             Length: m_kk.
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     /**
      * Returns an array of partial molar Heat Capacities at constant pressure of
@@ -357,7 +357,7 @@ public:
      *
      * @param cpbar  Output vector of partial heat capacities. Length: m_kk.
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
     /**
      * returns an array of partial molar volumes of the species
@@ -368,7 +368,7 @@ public:
      *
      * @param vbar  Output vector of partial molar volumes. Length: m_kk.
      */
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
@@ -387,7 +387,7 @@ public:
      * @param mu0   Output vector of standard state chemical potentials.
      *              Length: m_kk.
      */
-    virtual void getStandardChemPotentials(double* mu0) const {
+    void getStandardChemPotentials(double* mu0) const override {
         getPureGibbs(mu0);
     }
 
@@ -405,7 +405,7 @@ public:
      * @param hrt Vector of length m_kk, which on return hrt[k] will contain the
      *            nondimensional standard state enthalpy of species k.
      */
-    virtual void getEnthalpy_RT(double* hrt) const;
+    void getEnthalpy_RT(double* hrt) const override;
 
     //! Get the nondimensional Entropies for the species standard states at the
     //! current T and P of the solution.
@@ -416,7 +416,7 @@ public:
      * @param sr Vector of length m_kk, which on return sr[k] will contain the
      *           nondimensional standard state entropy for species k.
      */
-    virtual void getEntropy_R(double* sr) const;
+    void getEntropy_R(double* sr) const override;
 
     /**
      * Get the nondimensional Gibbs function for the species standard states at
@@ -432,7 +432,7 @@ public:
      * @param grt Vector of length m_kk, which on return sr[k] will contain the
      *           nondimensional standard state Gibbs function for species k.
      */
-    virtual void getGibbs_RT(double* grt) const;
+    void getGibbs_RT(double* grt) const override;
 
     /**
      * Get the Gibbs functions for the pure species at the current *T* and *P*
@@ -447,9 +447,9 @@ public:
      *
      * @param gpure  Output vector of Gibbs functions for species. Length: m_kk.
      */
-    virtual void getPureGibbs(double* gpure) const;
+    void getPureGibbs(double* gpure) const override;
 
-    virtual void getIntEnergy_RT(double* urt) const;
+    void getIntEnergy_RT(double* urt) const override;
 
     /**
      * Get the nondimensional heat capacity at constant pressure function for
@@ -464,20 +464,20 @@ public:
      * @param cpr Vector of length m_kk, which on return cpr[k] will contain the
      *           nondimensional constant pressure heat capacity for species k.
      */
-    virtual void getCp_R(double* cpr) const;
+    void getCp_R(double* cpr) const override;
 
-    virtual void getStandardVolumes(double* vol) const;
+    void getStandardVolumes(double* vol) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
-    virtual void getGibbs_ref(double* g) const;
-    virtual void getEntropy_R_ref(double* er) const;
-    virtual void getIntEnergy_RT_ref(double* urt) const;
-    virtual void getCp_R_ref(double* cprt) const;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getGibbs_RT_ref(double* grt) const override;
+    void getGibbs_ref(double* g) const override;
+    void getEntropy_R_ref(double* er) const override;
+    void getIntEnergy_RT_ref(double* urt) const override;
+    void getCp_R_ref(double* cprt) const override;
 
     /**
      * Returns a reference to the vector of nondimensional enthalpies of the
@@ -521,11 +521,11 @@ public:
     //! @name Utility Functions
     //! @{
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
-    virtual void getSpeciesParameters(const string& name, AnyMap& speciesNode) const;
-    virtual void setToEquilState(const double* mu_RT);
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
+    void setToEquilState(const double* mu_RT) override;
 
     //! Set the form for the standard and generalized concentrations
     /*!
@@ -565,7 +565,7 @@ public:
     //! @}
 
 protected:
-    virtual void compositionChanged();
+    void compositionChanged() override;
 
     /**
      * The standard concentrations can have one of three different forms:

--- a/include/cantera/thermo/IdealSolnGasVPSS.h
+++ b/include/cantera/thermo/IdealSolnGasVPSS.h
@@ -33,11 +33,11 @@ public:
     //! @name  Utilities (IdealSolnGasVPSS)
     //! @{
 
-    virtual string type() const {
+    string type() const override {
         return "ideal-solution-VPSS";
     }
 
-    virtual bool isIdeal() const {
+    bool isIdeal() const override {
         return true;
     }
 
@@ -51,40 +51,24 @@ public:
     //! @name Molar Thermodynamic Properties
     //! @{
 
-    virtual double enthalpy_mole() const;
-    virtual double entropy_mole() const;
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double enthalpy_mole() const override;
+    double entropy_mole() const override;
+    double cp_mole() const override;
+    double cv_mole() const override;
 
     //! @}
     //! @name Mechanical Properties
     //! @{
 
-    void setPressure(double p);
+    void setPressure(double p) override;
 
 protected:
-    /**
-     * Calculate the density of the mixture using the partial molar volumes and
-     * mole fractions as input. The formula for this is
-     *
-     * @f[
-     * \rho = \frac{\sum_k{X_k W_k}}{\sum_k{X_k V_k}}
-     * @f]
-     *
-     * where @f$ X_k @f$ are the mole fractions, @f$ W_k @f$ are the molecular
-     * weights, and @f$ V_k @f$ are the pure species molar volumes.
-     *
-     * Note, the basis behind this formula is that in an ideal solution the
-     * partial molar volumes are equal to the species standard state molar
-     * volumes. The species molar volumes may be functions of temperature and
-     * pressure.
-     */
-    virtual void calcDensity();
+    void calcDensity() override;
     //! @}
 
 public:
-    virtual Units standardConcentrationUnits() const;
-    virtual void getActivityConcentrations(double* c) const;
+    Units standardConcentrationUnits() const override;
+    void getActivityConcentrations(double* c) const override;
 
     //! Returns the standard concentration @f$ C^0_k @f$, which is used to
     //! normalize the generalized concentration.
@@ -98,27 +82,20 @@ public:
      * @return
      *   Returns the standard Concentration in units of m3 kmol-1.
      */
-    virtual double standardConcentration(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
 
-    //! Get the array of non-dimensional activity coefficients at the current
-    //! solution temperature, pressure, and solution concentration.
-    /*!
-     *  For ideal gases, the activity coefficients are all equal to one.
-     *
-     * @param ac Output vector of activity coefficients. Length: m_kk.
-     */
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
 
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    virtual void getChemPotentials(double* mu) const;
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
-    virtual void getPartialMolarEntropies(double* sbar) const;
-    virtual void getPartialMolarIntEnergies(double* ubar) const;
-    virtual void getPartialMolarCp(double* cpbar) const;
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getChemPotentials(double* mu) const override;
+    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarIntEnergies(double* ubar) const override;
+    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarVolumes(double* vbar) const override;
     //! @}
 
 public:
@@ -130,10 +107,10 @@ public:
     //! see importPhase().
     //! @{
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
-    virtual void setToEquilState(const double* lambda_RT);
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
+    void setToEquilState(const double* lambda_RT) override;
 
     //! @}
 

--- a/include/cantera/thermo/IonsFromNeutralVPSSTP.h
+++ b/include/cantera/thermo/IonsFromNeutralVPSSTP.h
@@ -85,7 +85,7 @@ public:
     //! @name  Utilities
     //! @{
 
-    virtual string type() const {
+    string type() const override {
         return "IonsFromNeutral";
     }
 
@@ -97,12 +97,12 @@ public:
     /*!
      * This is calculated from the partial molar enthalpies of the species.
      */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
-    virtual double entropy_mole() const;
-    virtual double gibbs_mole() const;
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double entropy_mole() const override;
+    double gibbs_mole() const override;
+    double cp_mole() const override;
+    double cv_mole() const override;
 
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
@@ -114,13 +114,13 @@ public:
     //! on temperature and pressure.
     //! @{
 
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species in the
     //! mixture.
@@ -138,7 +138,7 @@ public:
      *  @param hbar  Output vector of species partial molar enthalpies.
      *               Length: m_kk. Units: J/kmol
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     //! Returns an array of partial molar entropies for the species in the
     //! mixture.
@@ -158,13 +158,13 @@ public:
      *  @param sbar  Output vector of species partial molar entropies.
      *               Length: m_kk. Units: J/kmol/K
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
-    virtual void getdlnActCoeffds(const double dTds, const double* const dXds,
-                                  double* dlnActCoeffds) const;
-    virtual void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const;
-    virtual void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const;
-    virtual void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN);
+    void getdlnActCoeffds(const double dTds, const double* const dXds,
+                          double* dlnActCoeffds) const override;
+    void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const override;
+    void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const override;
+    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override;
     //! @}
 
     //! Get the Salt Dissociation Coefficients.
@@ -228,7 +228,7 @@ public:
     //! These methods set all or part of the thermodynamic state.
     //! @{
 
-    virtual void calcDensity();
+    void calcDensity() override;
 
     //! Calculate ion mole fractions from neutral molecule mole fractions.
     /*!
@@ -252,14 +252,14 @@ public:
 
     //! @}
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
     void setNeutralMoleculePhase(shared_ptr<ThermoPhase> neutral);
     shared_ptr<ThermoPhase> getNeutralMoleculePhase();
 
-    virtual void setParameters(const AnyMap& phaseNode,
-                               const AnyMap& rootNode=AnyMap());
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void setParameters(const AnyMap& phaseNode,
+                       const AnyMap& rootNode=AnyMap()) override;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
 
 private:
     //! Update the activity coefficients
@@ -312,7 +312,7 @@ private:
     void s_update_dlnActCoeff_dlnN() const;
 
 protected:
-    virtual void compositionChanged();
+    void compositionChanged() override;
 
     //! Ion solution type
     /*!

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -191,15 +191,15 @@ public:
      */
     explicit LatticePhase(const string& inputFile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "lattice";
     }
 
-    virtual bool isCompressible() const {
+    bool isCompressible() const override {
         return false;
     }
 
-    map<string, size_t> nativeState() const {
+    map<string, size_t> nativeState() const override {
         return { {"T", 0}, {"P", 1}, {"X", 2} };
     }
 
@@ -220,7 +220,7 @@ public:
      *
      * \see MultiSpeciesThermo
      */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     //! Molar entropy of the solution. Units: J/kmol/K
     /*!
@@ -238,7 +238,7 @@ public:
      *
      * @see MultiSpeciesThermo
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
     //! Molar heat capacity at constant pressure of the solution.
     //! Units: J/kmol/K.
@@ -254,7 +254,7 @@ public:
      *
      * @see MultiSpeciesThermo
      */
-    virtual double cp_mole() const;
+    double cp_mole() const override;
 
     //! Molar heat capacity at constant volume of the solution.
     //! Units: J/kmol/K.
@@ -267,7 +267,7 @@ public:
      *
      * The two heat capacities are equal.
      */
-    virtual double cv_mole() const;
+    double cv_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
@@ -284,7 +284,7 @@ public:
      * For this incompressible system, we return the internally stored
      * independent value of the pressure.
      */
-    virtual double pressure() const {
+    double pressure() const override {
         return m_Pcurrent;
     }
 
@@ -296,7 +296,7 @@ public:
      *
      * @param p   Input Pressure (Pa)
      */
-    virtual void setPressure(double p);
+    void setPressure(double p) override;
 
     //! Calculate the density of the mixture using the partial molar volumes and
     //! mole fractions as input
@@ -327,8 +327,8 @@ public:
     //! to be molality-based here.
     //! @{
 
-    virtual Units standardConcentrationUnits() const;
-    virtual void getActivityConcentrations(double* c) const;
+    Units standardConcentrationUnits() const override;
+    void getActivityConcentrations(double* c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -344,8 +344,8 @@ public:
      *         assume this refers to species 0.
      * @returns the standard Concentration in units of m^3/kmol.
      */
-    virtual double standardConcentration(size_t k=0) const;
-    virtual double logStandardConc(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
+    double logStandardConc(size_t k=0) const override;
 
     //! Get the array of non-dimensional activity coefficients at
     //! the current solution temperature, pressure, and solution concentration.
@@ -354,7 +354,7 @@ public:
      *
      * @param ac Output vector of activity coefficients. Length: m_kk.
      */
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -369,7 +369,7 @@ public:
      * @param mu  Output vector of species chemical
      *            potentials. Length: m_kk. Units: J/kmol
      */
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     /**
      * Returns an array of partial molar enthalpies for the species in the
@@ -387,7 +387,7 @@ public:
      * @param hbar Output vector containing partial molar enthalpies.
      *             Length: m_kk.
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     /**
      * Returns an array of partial molar entropies of the species in the
@@ -406,7 +406,7 @@ public:
      * @param sbar Output vector containing partial molar entropies.
      *             Length: m_kk.
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     /**
      * Returns an array of partial molar Heat Capacities at constant pressure of
@@ -415,11 +415,11 @@ public:
      *
      * @param cpbar  Output vector of partial heat capacities. Length: m_kk.
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
-    virtual void getPartialMolarVolumes(double* vbar) const;
-    virtual void getStandardChemPotentials(double* mu) const;
-    virtual void getPureGibbs(double* gpure) const;
+    void getPartialMolarVolumes(double* vbar) const override;
+    void getStandardChemPotentials(double* mu) const override;
+    void getPureGibbs(double* gpure) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
@@ -444,7 +444,7 @@ public:
      * @param hrt      Output vector of nondimensional standard state enthalpies.
      *                 Length: m_kk.
      */
-    virtual void getEnthalpy_RT(double* hrt) const;
+    void getEnthalpy_RT(double* hrt) const override;
 
     //! Get the array of nondimensional Entropy functions for the species
     //! standard states at the current *T* and *P* of the solution.
@@ -464,7 +464,7 @@ public:
      * @param sr   Output vector of nondimensional standard state entropies.
      *             Length: m_kk.
      */
-    virtual void getEntropy_R(double* sr) const;
+    void getEntropy_R(double* sr) const override;
 
     //! Get the nondimensional Gibbs functions for the species standard states
     //! at the current *T* and *P* of the solution.
@@ -479,7 +479,7 @@ public:
      * @param grt  Output vector of nondimensional standard state Gibbs free
      *             energies. Length: m_kk.
      */
-    virtual void getGibbs_RT(double* grt) const;
+    void getGibbs_RT(double* grt) const override;
 
     //! Get the nondimensional Heat Capacities at constant pressure for the
     //! species standard states at the current *T* and *P* of the solution
@@ -498,17 +498,9 @@ public:
      * @param cpr   Output vector of nondimensional standard state heat
      *              capacities. Length: m_kk.
      */
-    virtual void getCp_R(double* cpr) const;
+    void getCp_R(double* cpr) const override;
 
-    //! Get the molar volumes of the species standard states at the current
-    //! *T* and *P* of the solution.
-    /*!
-     * units = m^3 / kmol
-     *
-     * @param vol     Output vector containing the standard state volumes.
-     *                Length: m_kk.
-     */
-    virtual void getStandardVolumes(double* vol) const;
+    void getStandardVolumes(double* vol) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
@@ -524,8 +516,8 @@ public:
      */
     const vector<double>& gibbs_RT_ref() const;
 
-    virtual void getGibbs_RT_ref(double* grt) const;
-    virtual void getGibbs_ref(double* g) const;
+    void getGibbs_RT_ref(double* grt) const override;
+    void getGibbs_ref(double* g) const override;
 
     //! Returns a reference to the dimensionless reference state Entropy vector.
     /*!
@@ -546,19 +538,19 @@ public:
     //! @name  Utilities for Initialization of the Object
     //! @{
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
     //! Set the density of lattice sites [kmol/m^3]
     void setSiteDensity(double sitedens);
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
-    virtual void getSpeciesParameters(const string& name, AnyMap& speciesNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
 
     //! @}
 
 protected:
-    virtual void compositionChanged();
+    void compositionChanged() override;
 
     //! Reference state pressure
     double m_Pref = OneAtm;

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -284,20 +284,13 @@ public:
      *
      * @param x On return, x contains the mole fractions. Must have a length
      *          greater than or equal to the number of species.
+     *
+     * @todo This method shadows but does not override Phase::getMoleFractions(). The
+     *       LatticeSolidPhase class should be revised to avoid needing to override the
+     *       methods for getting composition. See
+     *       https://github.com/Cantera/cantera/issues/1310 for additional information.
      */
-    virtual void getMoleFractions(double* const x) const;
-
-    virtual double moleFraction(const int k) const {
-        throw NotImplementedError("LatticeSolidPhase::moleFraction");
-    }
-
-    virtual void getMassFractions(double* const y) const {
-        throw NotImplementedError("LatticeSolidPhase::getMassFractions");
-    }
-
-    virtual double massFraction(const int k) const {
-        throw NotImplementedError("LatticeSolidPhase::massFraction");
-    }
+    void getMoleFractions(double* const x) const;
 
     virtual void setMassFractions(const double* const y) {
         throw NotImplementedError("LatticeSolidPhase::setMassFractions");

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -107,7 +107,7 @@ public:
     //! Base empty constructor
     LatticeSolidPhase() = default;
 
-    virtual string type() const {
+    string type() const override {
         return "compound-lattice";
     }
 
@@ -115,21 +115,21 @@ public:
     /*!
      * `LatticeSolid` phases only represent solids.
      */
-    virtual string phaseOfMatter() const {
+    string phaseOfMatter() const override {
         return "solid";
     }
 
-    virtual bool isCompressible() const {
+    bool isCompressible() const override {
         return false;
     }
 
-    map<string, size_t> nativeState() const {
+    map<string, size_t> nativeState() const override {
         return { {"T", 0}, {"P", 1}, {"X", 2} };
     }
 
-    virtual double minTemp(size_t k = npos) const;
-    virtual double maxTemp(size_t k = npos) const;
-    virtual double refPressure() const;
+    double minTemp(size_t k=npos) const override;
+    double maxTemp(size_t k=npos) const override;
+    double refPressure() const override;
 
     //! This method returns the convention used in specification of the standard
     //! state, of which there are currently two, temperature based, and variable
@@ -137,7 +137,7 @@ public:
     /*!
      *  All of the thermo is determined by slave ThermoPhase routines.
      */
-    virtual int standardStateConvention() const {
+    int standardStateConvention() const override {
         return cSS_CONVENTION_SLAVE;
     }
 
@@ -154,7 +154,7 @@ public:
      *
      *  units J/kmol
      */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     //! Return the Molar Internal Energy. Units: J/kmol.
     /*!
@@ -169,7 +169,7 @@ public:
      *
      *  units J/kmol
      */
-    virtual double intEnergy_mole() const;
+    double intEnergy_mole() const override;
 
     //! Return the Molar Entropy. Units: J/kmol/K.
     /*!
@@ -184,7 +184,7 @@ public:
      *
      *  units J/kmol/K
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
     //! Return the Molar Gibbs energy. Units: J/kmol.
     /*!
@@ -200,7 +200,7 @@ public:
      *
      *  units J/kmol
      */
-    virtual double gibbs_mole() const;
+    double gibbs_mole() const override;
 
     //! Return the constant pressure heat capacity. Units: J/kmol/K
     /*!
@@ -216,7 +216,7 @@ public:
      *
      *  units J/kmol/K
      */
-    virtual double cp_mole() const;
+    double cp_mole() const override;
 
     //! Return the constant volume heat capacity. Units: J/kmol/K
     /*!
@@ -232,7 +232,7 @@ public:
      *
      *  units J/kmol/K
      */
-    virtual double cv_mole() const {
+    double cv_mole() const override {
         return cp_mole();
     }
 
@@ -240,7 +240,7 @@ public:
     /*!
      *  This method simply returns the stored pressure value.
      */
-    virtual double pressure() const {
+    double pressure() const override {
         return m_press;
     }
 
@@ -248,7 +248,7 @@ public:
     /*!
      * @param p Pressure (units - Pa)
      */
-    virtual void setPressure(double p);
+    void setPressure(double p) override;
 
     //! Calculate the density of the solid mixture
     /*!
@@ -275,7 +275,7 @@ public:
      *           pass portions of this vector to the sublattices which assume
      *           that the portions individually sum to one. Length is m_kk.
      */
-    virtual void setMoleFractions(const double* const x);
+    void setMoleFractions(const double* const x) override;
 
     //! Get the species mole fraction vector.
     /*!
@@ -292,31 +292,31 @@ public:
      */
     void getMoleFractions(double* const x) const;
 
-    virtual void setMassFractions(const double* const y) {
+    void setMassFractions(const double* const y) override {
         throw NotImplementedError("LatticeSolidPhase::setMassFractions");
     }
 
-    virtual void setMassFractions_NoNorm(const double* const y) {
+    void setMassFractions_NoNorm(const double* const y) override {
         throw NotImplementedError("LatticeSolidPhase::setMassFractions_NoNorm");
     }
 
-    virtual void getConcentrations(double* const c) const {
+    void getConcentrations(double* const c) const override {
         throw NotImplementedError("LatticeSolidPhase::getConcentrations");
     }
 
-    virtual double concentration(size_t k) const {
+    double concentration(size_t k) const override {
         throw NotImplementedError("LatticeSolidPhase::concentration");
     }
 
-    virtual void setConcentrations(const double* const conc) {
+    void setConcentrations(const double* const conc) override {
         throw NotImplementedError("LatticeSolidPhase::setConcentrations");
     }
 
-    virtual Units standardConcentrationUnits() const;
+    Units standardConcentrationUnits() const override;
 
-    virtual void getActivityConcentrations(double* c) const;
+    void getActivityConcentrations(double* c) const override;
 
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     //! Get the species chemical potentials. Units: J/kmol.
     /*!
@@ -330,7 +330,7 @@ public:
      * @param mu  Output vector of species chemical potentials. Length: m_kk.
      *            Units: J/kmol
      */
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species in the
     //! mixture.
@@ -349,7 +349,7 @@ public:
      * @param hbar Output vector containing partial molar enthalpies.
      *             Length: m_kk.
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     /**
      * Returns an array of partial molar entropies of the species in the
@@ -368,7 +368,7 @@ public:
      * @param sbar Output vector containing partial molar entropies.
      *             Length: m_kk.
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     /**
      * Returns an array of partial molar Heat Capacities at constant pressure of
@@ -377,7 +377,7 @@ public:
      *
      * @param cpbar  Output vector of partial heat capacities. Length: m_kk.
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
     /**
      * returns an array of partial molar volumes of the species in the solution.
@@ -388,7 +388,7 @@ public:
      *
      * @param vbar  Output vector of partial molar volumes. Length: m_kk.
      */
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     //! Get the array of standard state chemical potentials at unit activity for
     //! the species at their standard states at the current *T* and *P* of the
@@ -404,19 +404,19 @@ public:
      * @param mu0    Output vector of chemical potentials.
      *               Length: m_kk. Units: J/kmol
      */
-    virtual void getStandardChemPotentials(double* mu0) const;
+    void getStandardChemPotentials(double* mu0) const override;
 
-    virtual double standardConcentration(size_t k=0) const;
-    virtual double logStandardConc(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
+    double logStandardConc(size_t k=0) const override;
 
     //! @name Thermodynamic Values for the Species Reference States
     //! @{
 
-    virtual void getGibbs_RT_ref(double* grt) const;
-    virtual void getGibbs_ref(double* g) const;
+    void getGibbs_RT_ref(double* grt) const override;
+    void getGibbs_ref(double* g) const override;
     //! @}
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
     //! Add a lattice to this phase
     void addLattice(shared_ptr<ThermoPhase> lattice);
@@ -424,11 +424,11 @@ public:
     //! Set the lattice stoichiometric coefficients, @f$ \theta_i @f$
     void setLatticeStoichiometry(const Composition& comp);
 
-    virtual void setParameters(const AnyMap& phaseNode,
-                               const AnyMap& rootNode=AnyMap());
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
-    virtual void getSpeciesParameters(const string& name, AnyMap& speciesNode) const;
+    void setParameters(const AnyMap& phaseNode,
+                       const AnyMap& rootNode=AnyMap()) override;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
 
     //! Set the Lattice mole fractions using a string
     /*!
@@ -438,8 +438,8 @@ public:
      */
     void setLatticeMoleFractionsByName(int n, const string& x);
 
-    virtual void modifyOneHf298SS(const size_t k, const double Hf298New);
-    virtual void resetHf298(const size_t k=npos);
+    void modifyOneHf298SS(const size_t k, const double Hf298New) override;
+    void resetHf298(const size_t k=npos) override;
 
 protected:
     //! Current value of the pressure

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -223,17 +223,17 @@ public:
      */
     explicit MargulesVPSSTP(const string& inputFile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "Margules";
     }
 
     //! @name  Molar Thermodynamic Properties
     //! @{
 
-    virtual double enthalpy_mole() const;
-    virtual double entropy_mole() const;
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double enthalpy_mole() const override;
+    double entropy_mole() const override;
+    double cp_mole() const override;
+    double cv_mole() const override;
 
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
@@ -244,13 +244,13 @@ public:
     //! which depends only on temperature and pressure.
     //! @{
 
-    virtual void getLnActivityCoefficients(double* lnac) const;
+    void getLnActivityCoefficients(double* lnac) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species in the
     //! mixture.
@@ -268,7 +268,7 @@ public:
      * @param hbar  Vector of returned partial molar enthalpies
      *              (length m_kk, units = J/kmol)
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     //! Returns an array of partial molar entropies for the species in the
     //! mixture.
@@ -288,7 +288,7 @@ public:
      * @param sbar  Vector of returned partial molar entropies
      *              (length m_kk, units = J/kmol/K)
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     //! Returns an array of partial molar entropies for the species in the
     //! mixture.
@@ -310,9 +310,9 @@ public:
      * @param cpbar  Vector of returned partial molar heat capacities
      *              (length m_kk, units = J/kmol/K)
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     //! Get the array of temperature second derivatives of the log activity
     //! coefficients
@@ -322,9 +322,9 @@ public:
      * @param d2lnActCoeffdT2  Output vector of temperature 2nd derivatives of
      *                         the log Activity Coefficients. length = m_kk
      */
-    virtual void getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const;
+    void getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const;
 
-    virtual void getdlnActCoeffdT(double* dlnActCoeffdT) const;
+    void getdlnActCoeffdT(double* dlnActCoeffdT) const override;
 
     //! @}
     //! @name Initialization
@@ -335,8 +335,8 @@ public:
     //! see importPhase()
     //! @{
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
 
     //! Add a binary species interaction with the specified parameters
     /*!
@@ -359,11 +359,11 @@ public:
     //! @name  Derivatives of Thermodynamic Variables needed for Applications
     //! @{
 
-    virtual void getdlnActCoeffds(const double dTds, const double* const dXds,
-                                  double* dlnActCoeffds) const;
-    virtual void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const;
-    virtual void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const;
-    virtual void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN);
+    void getdlnActCoeffds(const double dTds, const double* const dXds,
+                          double* dlnActCoeffds) const override;
+    void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const override;
+    void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const override;
+    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override;
 
     //! @}
 

--- a/include/cantera/thermo/MaskellSolidSolnPhase.h
+++ b/include/cantera/thermo/MaskellSolidSolnPhase.h
@@ -32,20 +32,20 @@ class MaskellSolidSolnPhase : public VPStandardStateTP
 public:
     MaskellSolidSolnPhase();
 
-    virtual string type() const {
+    string type() const override {
         return "MaskellSolidsoln";
     }
 
-    virtual Units standardConcentrationUnits() const { return Units(1.0); }
-    virtual void getActivityConcentrations(double* c) const;
-    virtual double standardConcentration(size_t k=0) const { return 1.0; }
-    virtual double logStandardConc(size_t k=0) const { return 0.0; }
+    Units standardConcentrationUnits() const override { return Units(1.0); }
+    void getActivityConcentrations(double* c) const override;
+    double standardConcentration(size_t k=0) const override { return 1.0; }
+    double logStandardConc(size_t k=0) const override { return 0.0; }
 
     //! @name Molar Thermodynamic Properties of the Solution
     //! @{
 
-    virtual double enthalpy_mole() const;
-    virtual double entropy_mole() const;
+    double enthalpy_mole() const override;
+    double entropy_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
@@ -62,7 +62,7 @@ public:
      * For this incompressible system, we return the internally stored
      * independent value of the pressure.
      */
-    virtual double pressure() const {
+    double pressure() const override {
         return m_Pcurrent;
     }
 
@@ -73,36 +73,36 @@ public:
      *
      * @param p   Input Pressure (Pa)
      */
-    virtual void setPressure(double p);
+    void setPressure(double p) override;
 
-    virtual void calcDensity();
+    void calcDensity() override;
 
     //! @}
     //! @name Chemical Potentials and Activities
     //! @{
 
-    virtual void getActivityCoefficients(double* ac) const;
-    virtual void getChemPotentials(double* mu) const;
+    void getActivityCoefficients(double* ac) const override;
+    void getChemPotentials(double* mu) const override;
     //! @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
-    virtual void getChemPotentials_RT(double* mu) const;
+    void getChemPotentials_RT(double* mu) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
-    virtual void getPartialMolarEntropies(double* sbar) const;
-    virtual void getPartialMolarCp(double* cpbar) const;
-    virtual void getPartialMolarVolumes(double* vbar) const;
-    virtual void getPureGibbs(double* gpure) const;
-    virtual void getStandardChemPotentials(double* mu) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarVolumes(double* vbar) const override;
+    void getPureGibbs(double* gpure) const override;
+    void getStandardChemPotentials(double* mu) const override;
 
     //! @}
     //! @name Utility Functions
     //! @{
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
 
     void set_h_mix(const double hmix) { h_mixing = hmix; }
 

--- a/include/cantera/thermo/MetalPhase.h
+++ b/include/cantera/thermo/MetalPhase.h
@@ -25,94 +25,94 @@ public:
 
     // Overloaded methods of class ThermoPhase
 
-    virtual string type() const {
+    string type() const override {
         return "electron-cloud";
     }
 
-    virtual bool isCompressible() const {
+    bool isCompressible() const override {
         return false;
     }
 
-    virtual double enthalpy_mole() const {
+    double enthalpy_mole() const override {
         return 0.0;
     }
-    virtual double intEnergy_mole() const {
+    double intEnergy_mole() const override {
         return - pressure() * molarVolume();
     }
-    virtual double entropy_mole() const {
+    double entropy_mole() const override {
         return 0.0;
     }
-    virtual double gibbs_mole() const {
+    double gibbs_mole() const override {
         return 0.0;
     }
-    virtual double cp_mole() const {
+    double cp_mole() const override {
         return 0.0;
     }
-    virtual double cv_mole() const {
+    double cv_mole() const override {
         return 0.0;
     }
 
-    virtual void setPressure(double pres) {
+    void setPressure(double pres) override {
         m_press = pres;
     }
-    virtual double pressure() const {
+    double pressure() const override {
         return m_press;
     }
 
-    virtual void getChemPotentials(double* mu) const {
+    void getChemPotentials(double* mu) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             mu[n] = 0.0;
         }
     }
 
-    virtual void getEnthalpy_RT(double* hrt) const {
+    void getEnthalpy_RT(double* hrt) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             hrt[n] = 0.0;
         }
     }
 
-    virtual void getEntropy_R(double* sr) const {
+    void getEntropy_R(double* sr) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             sr[n] = 0.0;
         }
     }
 
-    virtual void getStandardChemPotentials(double* mu0) const {
+    void getStandardChemPotentials(double* mu0) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             mu0[n] = 0.0;
         }
     }
 
-    virtual void getActivityConcentrations(double* c) const {
+    void getActivityConcentrations(double* c) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             c[n] = 1.0;
         }
     }
-    virtual void getPartialMolarEnthalpies(double *h) const {
+    void getPartialMolarEnthalpies(double *h) const override {
         for (size_t n = 0; n < nSpecies(); n++) {
             h[n] = 0.0;
         }
     }
 
-    virtual Units standardConcentrationUnits() const {
+    Units standardConcentrationUnits() const override {
         return Units(1.0);
     }
 
-    virtual double standardConcentration(size_t k=0) const {
+    double standardConcentration(size_t k=0) const override {
         return 1.0;
     }
 
-    virtual double logStandardConc(size_t k=0) const {
+    double logStandardConc(size_t k=0) const override {
         return 0.0;
     }
 
-    virtual void initThermo() {
+    void initThermo() override {
         if (m_input.hasKey("density")) {
             assignDensity(m_input.convert("density", "kg/m^3"));
         }
     }
 
-    virtual void getParameters(AnyMap& phaseNode) const {
+    void getParameters(AnyMap& phaseNode) const override {
         ThermoPhase::getParameters(phaseNode);
         phaseNode["density"].setQuantity(density(), "kg/m^3");
     }

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -75,11 +75,11 @@ public:
     //! @name  Utilities
     //! @{
 
-    virtual string type() const {
+    string type() const override {
         return "MixtureFugacity";
     }
 
-    virtual int standardStateConvention() const;
+    int standardStateConvention() const override;
 
     //! Set the solution branch to force the ThermoPhase to exist on one branch
     //! or another
@@ -88,7 +88,7 @@ public:
      *       -1 means gas. The value -2 means unrestricted. Values of zero or
      *       greater refer to species dominated condensed phases.
      */
-    virtual void setForcedSolutionBranch(int solnBranch);
+    void setForcedSolutionBranch(int solnBranch);
 
     //! Report the solution branch which the solution is restricted to
     /*!
@@ -96,7 +96,7 @@ public:
      *      gas. The value -2 means unrestricted. Values of zero or greater
      *      refer to species dominated condensed phases.
      */
-    virtual int forcedSolutionBranch() const;
+    int forcedSolutionBranch() const;
 
     //! Report the solution branch which the solution is actually on
     /*!
@@ -104,14 +104,14 @@ public:
      *      gas. The value -2 means superfluid.. Values of zero or greater refer
      *      to species dominated condensed phases.
      */
-    virtual int reportSolnBranchActual() const;
+    int reportSolnBranchActual() const;
 
     //! @}
     //! @name Molar Thermodynamic properties
     //! @{
 
-    virtual double enthalpy_mole() const;
-    virtual double entropy_mole() const;
+    double enthalpy_mole() const override;
+    double entropy_mole() const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
@@ -130,7 +130,7 @@ public:
      *              Length: m_kk.
      * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
-    virtual void getChemPotentials_RT(double* mu) const;
+    void getChemPotentials_RT(double* mu) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
@@ -153,7 +153,7 @@ public:
      * @param mu   Output vector of standard state chemical potentials.
      *             length = m_kk. units are J / kmol.
      */
-    virtual void getStandardChemPotentials(double* mu) const;
+    void getStandardChemPotentials(double* mu) const override;
 
     //! Get the nondimensional Enthalpy functions for the species at their
     //! standard states at the current *T* and *P* of the solution.
@@ -165,7 +165,7 @@ public:
     * @param hrt     Output vector of standard state enthalpies.
     *                length = m_kk. units are unitless.
     */
-    virtual void getEnthalpy_RT(double* hrt) const;
+    void getEnthalpy_RT(double* hrt) const override;
 
     //! Get the array of nondimensional Enthalpy functions for the standard
     //! state species at the current *T* and *P* of the solution.
@@ -177,7 +177,7 @@ public:
      * @param sr     Output vector of nondimensional standard state entropies.
      *               length = m_kk.
      */
-    virtual void getEntropy_R(double* sr) const;
+    void getEntropy_R(double* sr) const override;
 
     //! Get the nondimensional Gibbs functions for the species at their standard
     //! states of solution at the current T and P of the solution.
@@ -189,7 +189,7 @@ public:
      * @param grt    Output vector of nondimensional standard state Gibbs free
      *               energies. length = m_kk.
      */
-    virtual void getGibbs_RT(double* grt) const;
+    void getGibbs_RT(double* grt) const override;
 
     //! Get the pure Gibbs free energies of each species. Species are assumed to
     //! be in their standard states.
@@ -199,7 +199,7 @@ public:
      * @param[out] gpure   Array of standard state Gibbs free energies. length =
      *     m_kk. units are J/kmol.
      */
-    virtual void getPureGibbs(double* gpure) const;
+    void getPureGibbs(double* gpure) const override;
 
     //! Returns the vector of nondimensional internal Energies of the standard
     //! state at the current temperature and pressure of the solution for each
@@ -216,7 +216,7 @@ public:
      * @param urt    Output vector of nondimensional standard state internal
      *               energies. length = m_kk.
      */
-    virtual void getIntEnergy_RT(double* urt) const;
+    void getIntEnergy_RT(double* urt) const override;
 
     //! Get the nondimensional Heat Capacities at constant pressure for the
     //! standard state of the species at the current T and P.
@@ -229,7 +229,7 @@ public:
      *               Capacities at constant pressure for the standard state of
      *               the species. Length: m_kk.
      */
-    virtual void getCp_R(double* cpr) const;
+    void getCp_R(double* cpr) const override;
 
     //! Get the molar volumes of each species in their standard states at the
     //! current *T* and *P* of the solution.
@@ -243,7 +243,7 @@ public:
      * @param vol Output vector of species volumes. length = m_kk.
      *            units =  m^3 / kmol
      */
-    virtual void getStandardVolumes(double* vol) const;
+    void getStandardVolumes(double* vol) const override;
     //! @}
 
     //! Set the temperature of the phase
@@ -253,7 +253,7 @@ public:
      *
      * @param temp  Temperature (kelvin)
      */
-    virtual void setTemperature(const double temp);
+    void setTemperature(const double temp) override;
 
     //! Set the internally stored pressure (Pa) at constant temperature and
     //! composition
@@ -263,10 +263,10 @@ public:
      *
      *  @param p input Pressure (Pa)
      */
-    virtual void setPressure(double p);
+    void setPressure(double p) override;
 
 protected:
-    virtual void compositionChanged();
+    void compositionChanged() override;
 
     //! Updates the reference state thermodynamic functions at the current T of
     //! the solution.
@@ -297,8 +297,8 @@ public:
     //! routine _updateRefStateThermo().
     //! @{
 
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getGibbs_RT_ref(double* grt) const override;
 
 protected:
     //! Returns the vector of nondimensional Gibbs free energies of the
@@ -312,10 +312,10 @@ protected:
     const vector<double>& gibbs_RT_ref() const;
 
 public:
-    virtual void getGibbs_ref(double* g) const;
-    virtual void getEntropy_R_ref(double* er) const;
-    virtual void getCp_R_ref(double* cprt) const;
-    virtual void getStandardVolumes_ref(double* vol) const;
+    void getGibbs_ref(double* g) const override;
+    void getEntropy_R_ref(double* er) const override;
+    void getCp_R_ref(double* cprt) const override;
+    void getStandardVolumes_ref(double* vol) const override;
 
     //! @}
     //! @name Initialization Methods - For Internal use
@@ -325,7 +325,7 @@ public:
     //! input file. They are not normally used in application programs.
     //! To see how they are used, see importPhase().
     //! @{
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
     //! @}
 
 protected:
@@ -470,8 +470,8 @@ public:
      * @param TKelvin   Temperature (Kelvin)
      * @return          The saturation pressure at the given temperature
      */
-    virtual double satPressure(double TKelvin);
-    virtual void getActivityConcentrations(double* c) const;
+    double satPressure(double TKelvin) override;
+    void getActivityConcentrations(double* c) const override;
 
 protected:
     //! Calculate the pressure and the pressure derivative given the temperature
@@ -492,11 +492,11 @@ protected:
     //! @name Critical State Properties.
     //! @{
 
-    virtual double critTemperature() const;
-    virtual double critPressure() const;
-    virtual double critVolume() const;
-    virtual double critCompressibility() const;
-    virtual double critDensity() const;
+    double critTemperature() const override;
+    double critPressure() const override;
+    double critVolume() const override;
+    double critCompressibility() const override;
+    double critDensity() const override;
     virtual void calcCriticalConditions(double& pc, double& tc, double& vc) const;
 
     //! Solve the cubic equation of state

--- a/include/cantera/thermo/MolalityVPSSTP.h
+++ b/include/cantera/thermo/MolalityVPSSTP.h
@@ -243,7 +243,7 @@ public:
     /*!
      * All derived phases from `MolalityVPSSTP` always represent liquids.
      */
-    virtual string phaseOfMatter() const {
+    string phaseOfMatter() const override {
         return "liquid";
     }
 
@@ -384,10 +384,10 @@ public:
     /**
      *  We set the convention to molality here.
      */
-    int activityConvention() const;
+    int activityConvention() const override;
 
-    virtual void getActivityConcentrations(double* c) const;
-    virtual double standardConcentration(size_t k=0) const;
+    void getActivityConcentrations(double* c) const override;
+    double standardConcentration(size_t k=0) const override;
 
     //! Get the array of non-dimensional activities (molality based for this
     //! class and classes that derive from it) at the current solution
@@ -405,7 +405,7 @@ public:
      *
      * @param ac     Output vector of molality-based activities. Length: m_kk.
      */
-    virtual void getActivities(double* ac) const;
+    void getActivities(double* ac) const override;
 
     //! Get the array of non-dimensional activity coefficients at
     //! the current solution temperature, pressure, and solution concentration.
@@ -436,7 +436,7 @@ public:
      * @param ac  Output vector containing the mole-fraction based activity
      *            coefficients. length: m_kk.
      */
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     //! Get the array of non-dimensional molality based activity coefficients at
     //! the current solution temperature, pressure, and solution concentration.
@@ -494,8 +494,8 @@ public:
     //! see importPhase().
     //! @{
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void initThermo();
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void initThermo() override;
 
     //! @}
 
@@ -530,17 +530,17 @@ public:
     /*!
      * Additionally uses the keys `molalities` or `M` to set the molalities.
      */
-    virtual void setState(const AnyMap& state);
+    void setState(const AnyMap& state) override;
 
-    virtual void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) {
+    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override {
         getdlnActCoeffdlnN_numderiv(ld, dlnActCoeffdlnN);
     }
 
-    virtual string report(bool show_thermo=true, double threshold=1e-14) const;
+    string report(bool show_thermo=true, double threshold=1e-14) const override;
 
 protected:
-    virtual void getCsvReportData(vector<string>& names,
-                                  vector<vector<double>>& data) const;
+    void getCsvReportData(vector<string>& names,
+                          vector<vector<double>>& data) const override;
 
     //! Get the array of unscaled non-dimensional molality based activity
     //! coefficients at the current solution temperature, pressure, and solution
@@ -578,7 +578,7 @@ private:
      * Right now we use a restrictive interpretation. The species must be named
      * "Cl-". It must consist of exactly one Cl and one E atom.
      */
-    virtual size_t findCLMIndex() const;
+    size_t findCLMIndex() const;
 
 protected:
     //! Scaling to be used for output of single-ion species activity

--- a/include/cantera/thermo/Mu0Poly.h
+++ b/include/cantera/thermo/Mu0Poly.h
@@ -108,7 +108,7 @@ public:
      */
     void setParameters(double h0, const map<double, double>& T_mu);
 
-    virtual int reportType() const {
+    int reportType() const override {
         return MU0_INTERP;
     }
 
@@ -118,20 +118,18 @@ public:
      * Temperature Polynomial:
      *     tt[0] = temp (Kelvin)
      */
-    virtual void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                                  double* s_R) const;
+    void updateProperties(const double* tt, double* cp_R, double* h_RT,
+                          double* s_R) const override;
 
-    virtual void updatePropertiesTemp(const double temp,
-                                      double* cp_R,
-                                      double* h_RT,
-                                      double* s_R) const;
+    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
+                              double* s_R) const override;
 
-    virtual size_t nCoeffs() const;
+    size_t nCoeffs() const override;
 
-    virtual void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                                  double& pref, double* const coeffs) const;
+    void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
+                          double& pref, double* const coeffs) const override;
 
-    virtual void getParameters(AnyMap& thermo) const;
+    void getParameters(AnyMap& thermo) const override;
 
 protected:
     //! Number of intervals in the interpolating linear approximation. Number

--- a/include/cantera/thermo/Nasa9Poly1.h
+++ b/include/cantera/thermo/Nasa9Poly1.h
@@ -74,10 +74,10 @@ public:
     //! Set the array of 9 polynomial coefficients
     void setParameters(const vector<double>& coeffs);
 
-    virtual int reportType() const;
+    int reportType() const override;
 
-    virtual size_t temperaturePolySize() const { return 7; }
-    virtual void updateTemperaturePoly(double T, double* T_poly) const;
+    size_t temperaturePolySize() const override { return 7; }
+    void updateTemperaturePoly(double T, double* T_poly) const override;
 
     /**
      * @copydoc SpeciesThermoInterpType::updateProperties
@@ -91,11 +91,11 @@ public:
      *   - tt[5] = 1.0/(t*t);
      *   - tt[6] = std::log(t);
      */
-    virtual void updateProperties(const double* tt,
-                                  double* cp_R, double* h_RT, double* s_R) const;
+    void updateProperties(const double* tt, double* cp_R, double* h_RT,
+                          double* s_R) const override;
 
-    virtual void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                                      double* s_R) const;
+    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
+                              double* s_R) const override;
 
     //! This utility function reports back the type of parameterization and all
     //! of the parameters for the species
@@ -115,10 +115,10 @@ public:
      *       - coeffs[2] is max temperature
      *       - coeffs[3+i] from i =0,9 are the coefficients themselves
      */
-    virtual void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                                  double& pref, double* const coeffs) const;
+    void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
+                          double& pref, double* const coeffs) const override;
 
-    virtual void getParameters(AnyMap& thermo) const;
+    void getParameters(AnyMap& thermo) const override;
 
 protected:
     //! array of polynomial coefficients

--- a/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
+++ b/include/cantera/thermo/Nasa9PolyMultiTempRegion.h
@@ -76,19 +76,19 @@ public:
      */
     void setParameters(const map<double, vector<double>>& regions);
 
-    virtual int reportType() const;
+    int reportType() const override;
 
-    virtual size_t temperaturePolySize() const { return 7; }
-    virtual void updateTemperaturePoly(double T, double* T_poly) const;
+    size_t temperaturePolySize() const override { return 7; }
+    void updateTemperaturePoly(double T, double* T_poly) const override;
 
     //! @copydoc Nasa9Poly1::updateProperties
-    virtual void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                                  double* s_R) const;
+    void updateProperties(const double* tt, double* cp_R, double* h_RT,
+                          double* s_R) const override;
 
-    virtual void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                                      double* s_R) const;
+    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
+                              double* s_R) const override;
 
-    virtual size_t nCoeffs() const;
+    size_t nCoeffs() const override;
 
     //! This utility function reports back the type of parameterization and all
     //! of the parameters for the species, index.
@@ -109,10 +109,10 @@ public:
      *        coeffs[index+1] = maxTempZone
      *        coeffs[index+2+i] from i =0,9 are the coefficients themselves
      */
-    virtual void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                                  double& pref, double* const coeffs) const;
+    void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
+                          double& pref, double* const coeffs) const override;
 
-    virtual void getParameters(AnyMap& thermo) const;
+    void getParameters(AnyMap& thermo) const override;
 
 protected:
     //! Lower boundaries of each temperature regions

--- a/include/cantera/thermo/NasaPoly1.h
+++ b/include/cantera/thermo/NasaPoly1.h
@@ -74,13 +74,13 @@ public:
         m_coeff5_orig = m_coeff[5];
     }
 
-    virtual int reportType() const {
+    int reportType() const override {
         return NASA1;
     }
 
-    virtual size_t temperaturePolySize() const { return 6; }
+    size_t temperaturePolySize() const override { return 6; }
 
-    virtual void updateTemperaturePoly(double T, double* T_poly) const {
+    void updateTemperaturePoly(double T, double* T_poly) const override {
         T_poly[0] = T;
         T_poly[1] = T * T;
         T_poly[2] = T_poly[1] * T;
@@ -100,8 +100,8 @@ public:
      *  tt[4] = 1.0/t;
      *  tt[5] = std::log(t);
      */
-    virtual void updateProperties(const double* tt,
-                                  double* cp_R, double* h_RT, double* s_R) const {
+    void updateProperties(const double* tt, double* cp_R, double* h_RT,
+                          double* s_R) const override {
         double ct0 = m_coeff[0]; // a0
         double ct1 = m_coeff[1]*tt[0]; // a1 * T
         double ct2 = m_coeff[2]*tt[1]; // a2 * T^2
@@ -121,15 +121,15 @@ public:
         *s_R = s;
     }
 
-    virtual void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                                      double* s_R) const {
+    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
+                              double* s_R) const override {
         double tPoly[6];
         updateTemperaturePoly(temp, tPoly);
         updateProperties(tPoly, cp_R, h_RT, s_R);
     }
 
-    virtual void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                                  double& pref, double* const coeffs) const {
+    void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
+                          double& pref, double* const coeffs) const override {
         n = 0;
         type = NASA1;
         tlow = m_lowT;
@@ -138,13 +138,13 @@ public:
         std::copy(m_coeff.begin(), m_coeff.end(), coeffs);
     }
 
-    virtual void getParameters(AnyMap& thermo) const {
+    void getParameters(AnyMap& thermo) const override {
         // NasaPoly1 is only used as an embedded model within NasaPoly2, so all
         // that needs to be added here are the polynomial coefficients
         thermo["data"].asVector<vector<double>>().push_back(m_coeff);
     }
 
-    virtual double reportHf298(double* const h298 = 0) const {
+    double reportHf298(double* const h298=nullptr) const override {
         double tt[6];
         double temp = 298.15;
         updateTemperaturePoly(temp, tt);
@@ -164,13 +164,13 @@ public:
         return h;
     }
 
-    virtual void modifyOneHf298(const size_t k, const double Hf298New) {
+    void modifyOneHf298(const size_t k, const double Hf298New) override {
         double hcurr = reportHf298(0);
         double delH = Hf298New - hcurr;
         m_coeff[5] += (delH) / GasConstant;
     }
 
-    virtual void resetHf298() {
+    void resetHf298() override {
         m_coeff[5] = m_coeff5_orig;
     }
 

--- a/include/cantera/thermo/NasaPoly2.h
+++ b/include/cantera/thermo/NasaPoly2.h
@@ -67,17 +67,17 @@ public:
         mnp_high(coeffs[0], thigh, pref, coeffs + 1) {
     }
 
-    virtual void setMinTemp(double Tmin) {
+    void setMinTemp(double Tmin) override {
         SpeciesThermoInterpType::setMinTemp(Tmin);
         mnp_low.setMinTemp(Tmin);
     }
 
-    virtual void setMaxTemp(double Tmax) {
+    void setMaxTemp(double Tmax) override {
         SpeciesThermoInterpType::setMaxTemp(Tmax);
         mnp_high.setMaxTemp(Tmax);
     }
 
-    virtual void setRefPressure(double Pref) {
+    void setRefPressure(double Pref) override {
         SpeciesThermoInterpType::setRefPressure(Pref);
         mnp_low.setRefPressure(Pref);
         mnp_high.setRefPressure(Pref);
@@ -91,19 +91,19 @@ public:
      */
     void setParameters(double Tmid, const vector<double>& low, const vector<double>& high);
 
-    virtual int reportType() const {
+    int reportType() const override {
         return NASA2;
     }
 
-    virtual size_t temperaturePolySize() const { return 6; }
+    size_t temperaturePolySize() const override { return 6; }
 
-    virtual void updateTemperaturePoly(double T, double* T_poly) const {
+    void updateTemperaturePoly(double T, double* T_poly) const override {
         mnp_low.updateTemperaturePoly(T, T_poly);
     }
 
     //! @copydoc NasaPoly1::updateProperties
     void updateProperties(const double* tt,
-                          double* cp_R, double* h_RT, double* s_R) const {
+                          double* cp_R, double* h_RT, double* s_R) const override {
         if (tt[0] <= m_midT) {
             mnp_low.updateProperties(tt, cp_R, h_RT, s_R);
         } else {
@@ -112,9 +112,7 @@ public:
     }
 
     void updatePropertiesTemp(const double temp,
-                              double* cp_R,
-                              double* h_RT,
-                              double* s_R) const {
+                              double* cp_R, double* h_RT, double* s_R) const override {
         if (temp <= m_midT) {
             mnp_low.updatePropertiesTemp(temp, cp_R, h_RT, s_R);
         } else {
@@ -122,18 +120,18 @@ public:
         }
     }
 
-    size_t nCoeffs() const { return 15; }
+    size_t nCoeffs() const override { return 15; }
 
     void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                          double& pref, double* const coeffs) const {
+                          double& pref, double* const coeffs) const override {
         mnp_high.reportParameters(n, type, coeffs[0], thigh, pref, coeffs + 1);
         mnp_low.reportParameters(n, type, tlow, coeffs[0], pref, coeffs + 8);
         type = NASA2;
     }
 
-    virtual void getParameters(AnyMap& thermo) const;
+    void getParameters(AnyMap& thermo) const override;
 
-    double reportHf298(double* const h298 = 0) const {
+    double reportHf298(double* const h298=nullptr) const override {
         double h;
         if (298.15 <= m_midT) {
             h = mnp_low.reportHf298(0);
@@ -146,12 +144,12 @@ public:
         return h;
     }
 
-    void resetHf298() {
+    void resetHf298() override {
         mnp_low.resetHf298();
         mnp_high.resetHf298();
     }
 
-    void modifyOneHf298(const size_t k, const double Hf298New) {
+    void modifyOneHf298(const size_t k, const double Hf298New) override {
         double h298now = reportHf298(0);
         double delH = Hf298New - h298now;
         double h = mnp_low.reportHf298(0);
@@ -162,7 +160,7 @@ public:
         mnp_high.modifyOneHf298(k, hnew);
     }
 
-    void validate(const string& name);
+    void validate(const string& name) override;
 
 protected:
     //! Midrange temperature

--- a/include/cantera/thermo/PDSS.h
+++ b/include/cantera/thermo/PDSS.h
@@ -476,10 +476,10 @@ protected:
 class PDSS_Molar : public virtual PDSS
 {
 public:
-    virtual double enthalpy_RT() const;
-    virtual double entropy_R() const;
-    virtual double gibbs_RT() const;
-    virtual double cp_R() const;
+    double enthalpy_RT() const override;
+    double entropy_R() const override;
+    double gibbs_RT() const override;
+    double cp_R() const override;
 };
 
 //! Base class for PDSS classes which compute nondimensional properties directly
@@ -488,22 +488,22 @@ class PDSS_Nondimensional : public virtual PDSS
 public:
     PDSS_Nondimensional();
 
-    virtual double enthalpy_mole() const;
-    virtual double entropy_mole() const;
-    virtual double gibbs_mole() const;
-    virtual double cp_mole() const;
+    double enthalpy_mole() const override;
+    double entropy_mole() const override;
+    double gibbs_mole() const override;
+    double cp_mole() const override;
 
-    virtual double enthalpy_RT_ref() const;
-    virtual double entropy_R_ref() const;
-    virtual double gibbs_RT_ref() const;
-    virtual double cp_R_ref() const;
-    virtual double molarVolume_ref() const;
-    virtual double enthalpy_RT() const;
-    virtual double entropy_R() const;
-    virtual double gibbs_RT() const;
-    virtual double cp_R() const;
-    virtual double molarVolume() const;
-    virtual double density() const;
+    double enthalpy_RT_ref() const override;
+    double entropy_R_ref() const override;
+    double gibbs_RT_ref() const override;
+    double cp_R_ref() const override;
+    double molarVolume_ref() const override;
+    double enthalpy_RT() const override;
+    double entropy_R() const override;
+    double gibbs_RT() const override;
+    double cp_R() const override;
+    double molarVolume() const override;
+    double density() const override;
 
 protected:
     double m_h0_RT; //!< Reference state enthalpy divided by RT

--- a/include/cantera/thermo/PDSSFactory.h
+++ b/include/cantera/thermo/PDSSFactory.h
@@ -20,7 +20,7 @@ public:
     static PDSSFactory* factory();
 
     //! delete the static instance of this factory
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
     //! Create a new thermodynamic property manager.
     /*!
@@ -29,7 +29,7 @@ public:
      *   Returns NULL if something went wrong. Throws an exception if the string
      *   wasn't matched.
      */
-    virtual PDSS* newPDSS(const string& model);
+    PDSS* newPDSS(const string& model);
 
 private:
     //! static member of a single instance

--- a/include/cantera/thermo/PDSS_ConstVol.h
+++ b/include/cantera/thermo/PDSS_ConstVol.h
@@ -29,25 +29,25 @@ public:
     //! @{
 
     // See PDSS.h for documentation of functions overridden from Class PDSS
-    virtual double intEnergy_mole() const;
-    virtual double cv_mole() const;
+    double intEnergy_mole() const override;
+    double cv_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
     //! @{
 
-    virtual void setPressure(double pres);
-    virtual void setTemperature(double temp);
-    virtual void setState_TP(double temp, double pres);
-    virtual void setState_TR(double temp, double rho);
-    virtual double satPressure(double t);
+    void setPressure(double pres) override;
+    void setTemperature(double temp) override;
+    void setState_TP(double temp, double pres) override;
+    void setState_TR(double temp, double rho) override;
+    double satPressure(double t) override;
 
     //! @}
     //! @name Initialization of the Object
     //! @{
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& eosNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& eosNode) const override;
 
     //! Set the (constant) molar volume [m3/kmol] of the species. Must be called before
     //! initThermo().

--- a/include/cantera/thermo/PDSS_HKFT.h
+++ b/include/cantera/thermo/PDSS_HKFT.h
@@ -35,7 +35,7 @@ public:
 
     // See PDSS.h for documentation of functions overridden from Class PDSS
 
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     //! Return the molar enthalpy in units of J kmol-1
     /*!
@@ -49,12 +49,12 @@ public:
      */
     double enthalpy_mole2() const;
 
-    virtual double intEnergy_mole() const;
-    virtual double entropy_mole() const;
-    virtual double gibbs_mole() const;
-    virtual double cp_mole() const;
-    virtual double molarVolume() const;
-    virtual double density() const;
+    double intEnergy_mole() const override;
+    double entropy_mole() const override;
+    double gibbs_mole() const override;
+    double cp_mole() const override;
+    double molarVolume() const override;
+    double density() const override;
 
     //! @}
     //! @name Properties of the Reference State of the Species in the Solution
@@ -64,28 +64,28 @@ public:
         return m_p0;
     }
 
-    virtual double gibbs_RT_ref() const;
-    virtual double enthalpy_RT_ref() const;
-    virtual double entropy_R_ref() const;
-    virtual double cp_R_ref() const;
-    virtual double molarVolume_ref() const;
+    double gibbs_RT_ref() const override;
+    double enthalpy_RT_ref() const override;
+    double entropy_R_ref() const override;
+    double cp_R_ref() const override;
+    double molarVolume_ref() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
     //! @{
 
-    virtual void setState_TP(double temp, double pres);
+    void setState_TP(double temp, double pres) override;
 
     //! @}
     //! @name Initialization of the Object
     //! @{
 
-    void setParent(VPStandardStateTP* phase, size_t k) {
+    void setParent(VPStandardStateTP* phase, size_t k) override {
         m_tp = phase;
         m_spindex = k;
     }
 
-    virtual void initThermo();
+    void initThermo() override;
 
      //! Set enthalpy of formation at Pr, Tr [J/kmol]
     void setDeltaH0(double dh0);
@@ -105,7 +105,7 @@ public:
     void set_c(double* c);
     void setOmega(double omega); //!< Set omega [J/kmol]
 
-    virtual void getParameters(AnyMap& eosNode) const;
+    void getParameters(AnyMap& eosNode) const override;
 
     //! This utility function reports back the type of parameterization and
     //! all of the parameters for the species, index.
@@ -133,9 +133,8 @@ public:
      * @param maxTemp   output - Maximum temperature
      * @param refPressure output - reference pressure (Pa).
      */
-    virtual void reportParams(size_t& kindex, int& type, double* const c,
-                              double& minTemp, double& maxTemp,
-                              double& refPressure) const;
+    void reportParams(size_t& kindex, int& type, double* const c, double& minTemp,
+                      double& maxTemp, double& refPressure) const override;
     //! @}
 
 private:

--- a/include/cantera/thermo/PDSS_IdealGas.h
+++ b/include/cantera/thermo/PDSS_IdealGas.h
@@ -33,25 +33,25 @@ public:
 
     // See PDSS.h for documentation of functions overridden from Class PDSS
 
-    virtual double intEnergy_mole() const;
-    virtual double cv_mole() const;
+    double intEnergy_mole() const override;
+    double cv_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
     //! @{
 
-    virtual double pressure() const;
-    virtual void setPressure(double pres);
-    virtual void setTemperature(double temp);
-    virtual void setState_TP(double temp, double pres);
-    virtual void setState_TR(double temp, double rho);
+    double pressure() const override;
+    void setPressure(double pres) override;
+    void setTemperature(double temp) override;
+    void setState_TP(double temp, double pres) override;
+    void setState_TR(double temp, double rho) override;
 
     //! @}
     //! @name Initialization of the Object
     //! @{
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& eosNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& eosNode) const override;
     //! @}
 };
 }

--- a/include/cantera/thermo/PDSS_IonsFromNeutral.h
+++ b/include/cantera/thermo/PDSS_IonsFromNeutral.h
@@ -45,9 +45,9 @@ public:
 
     // See PDSS.h for documentation of functions overridden from Class PDSS
 
-    virtual double enthalpy_RT() const;
-    virtual double intEnergy_mole() const;
-    virtual double entropy_R() const;
+    double enthalpy_RT() const override;
+    double intEnergy_mole() const override;
+    double entropy_R() const override;
 
     /**
      * @copydoc PDSS::gibbs_RT()
@@ -62,37 +62,37 @@ public:
      * is added to all ions except for the species ionic species, which in this
      * case is the single anion species, with species index *sp*.
      */
-    virtual double gibbs_RT() const;
-    virtual double cp_R() const;
-    virtual double molarVolume() const;
-    virtual double density() const;
+    double gibbs_RT() const override;
+    double cp_R() const override;
+    double molarVolume() const override;
+    double density() const override;
 
     //! @}
     //! @name Properties of the Reference State of the Species in the Solution
     //! @{
 
-    virtual double gibbs_RT_ref() const;
-    virtual double enthalpy_RT_ref() const;
-    virtual double entropy_R_ref() const;
-    virtual double cp_R_ref() const;
-    virtual double molarVolume_ref() const;
+    double gibbs_RT_ref() const override;
+    double enthalpy_RT_ref() const override;
+    double entropy_R_ref() const override;
+    double cp_R_ref() const override;
+    double molarVolume_ref() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
     //! @{
 
-    virtual void setState_TP(double temp, double pres);
+    void setState_TP(double temp, double pres) override;
 
     //! @}
     //! @name Initialization of the Object
     //! @{
 
-    void setParent(VPStandardStateTP* phase, size_t k);
+    void setParent(VPStandardStateTP* phase, size_t k) override;
 
     void setNeutralSpeciesMultiplier(const string& species, double mult);
     void setSpecialSpecies(bool special=true);
-    virtual void getParameters(AnyMap& eosNode) const;
-    virtual void initThermo();
+    void getParameters(AnyMap& eosNode) const override;
+    void initThermo() override;
     //! @}
 
 protected:

--- a/include/cantera/thermo/PDSS_SSVol.h
+++ b/include/cantera/thermo/PDSS_SSVol.h
@@ -119,29 +119,29 @@ public:
 
     // See PDSS.h for documentation of functions overridden from Class PDSS
 
-    virtual double intEnergy_mole() const;
-    virtual double cv_mole() const;
+    double intEnergy_mole() const override;
+    double cv_mole() const override;
 
     //! @}
 
     //! @name Mechanical Equation of State Properties
     //! @{
 
-    virtual void setPressure(double pres);
-    virtual void setTemperature(double temp);
-    virtual void setState_TP(double temp, double pres);
+    void setPressure(double pres) override;
+    void setTemperature(double temp) override;
+    void setState_TP(double temp, double pres) override;
 
     //! @}
     //! @name Miscellaneous properties of the standard state
     //! @{
 
-    virtual double satPressure(double t);
+    double satPressure(double t) override;
 
     //! @}
     //! @name Initialization of the Object
     //! @{
 
-    virtual void initThermo();
+    void initThermo() override;
 
     //! Set polynomial coefficients for the standard state molar volume as a
     //! function of temperature. Cubic polynomial (4 coefficients). Leading
@@ -153,7 +153,7 @@ public:
     //! is the constant (temperature-independent) term [kg/m^3].
     void setDensityPolynomial(double* coeffs);
 
-    virtual void getParameters(AnyMap& eosNode) const;
+    void getParameters(AnyMap& eosNode) const override;
 
     //! @}
 

--- a/include/cantera/thermo/PDSS_Water.h
+++ b/include/cantera/thermo/PDSS_Water.h
@@ -57,14 +57,14 @@ public:
 
     // See PDSS.h for documentation of functions overridden from Class PDSS
 
-    virtual double enthalpy_mole() const;
-    virtual double intEnergy_mole() const;
-    virtual double entropy_mole() const;
-    virtual double gibbs_mole() const;
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
-    virtual double molarVolume() const;
-    virtual double density() const;
+    double enthalpy_mole() const override;
+    double intEnergy_mole() const override;
+    double entropy_mole() const override;
+    double gibbs_mole() const override;
+    double cp_mole() const override;
+    double cv_mole() const override;
+    double molarVolume() const override;
+    double density() const override;
 
     //! @}
     //! @name Properties of the Reference State of the Species in the Solution
@@ -80,21 +80,21 @@ public:
      */
     double pref_safe(double temp) const;
 
-    virtual double gibbs_RT_ref() const;
-    virtual double enthalpy_RT_ref() const;
-    virtual double entropy_R_ref() const;
-    virtual double cp_R_ref() const;
-    virtual double molarVolume_ref() const;
+    double gibbs_RT_ref() const override;
+    double enthalpy_RT_ref() const override;
+    double entropy_R_ref() const override;
+    double cp_R_ref() const override;
+    double molarVolume_ref() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
     //! @{
 
-    virtual double pressure() const;
-    virtual void setPressure(double pres);
-    virtual void setTemperature(double temp);
-    virtual void setState_TP(double temp, double pres);
-    virtual void setState_TR(double temp, double rho);
+    double pressure() const override;
+    void setPressure(double pres) override;
+    void setTemperature(double temp) override;
+    void setState_TP(double temp, double pres) override;
+    void setState_TR(double temp, double rho) override;
 
     //! Set the density of the water phase
     /*!
@@ -104,7 +104,7 @@ public:
      */
     void setDensity(double dens);
 
-    virtual double thermalExpansionCoeff() const;
+    double thermalExpansionCoeff() const override;
 
     //! Return the derivative of the volumetric thermal expansion coefficient.
     //! Units: 1/K2.
@@ -114,7 +114,7 @@ public:
      * \beta = \frac{1}{v}\left(\frac{\partial v}{\partial T}\right)_P
      * @f]
      */
-    virtual double dthermalExpansionCoeffdT() const;
+    double dthermalExpansionCoeffdT() const;
 
     //! Returns the isothermal compressibility. Units: 1/Pa.
     /*!
@@ -127,16 +127,16 @@ public:
      * \kappa_T = \frac{1}{\rho}\left(\frac{\partial \rho}{\partial P}\right)_T
      * @f]
      */
-    virtual double isothermalCompressibility() const;
+    double isothermalCompressibility() const;
 
     //! @}
     //! @name Miscellaneous properties of the standard state
     //! @{
 
-    virtual double critTemperature() const;
-    virtual double critPressure() const;
-    virtual double critDensity() const;
-    virtual double satPressure(double t);
+    double critTemperature() const override;
+    double critPressure() const override;
+    double critDensity() const override;
+    double satPressure(double t) override;
 
     //! Get a pointer to a changeable WaterPropsIAPWS object
     WaterPropsIAPWS* getWater() {
@@ -148,7 +148,7 @@ public:
         return &m_waterProps;
     }
 
-    virtual void getParameters(AnyMap& eosNode) const;
+    void getParameters(AnyMap& eosNode) const override;
 
     //! @}
 

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -30,15 +30,15 @@ public:
      */
     explicit PengRobinson(const string& infile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "Peng-Robinson";
     }
 
     //! @name Molar Thermodynamic properties
     //! @{
 
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double cp_mole() const override;
+    double cv_mole() const override;
 
     //! @}
     //! @name Mechanical Properties
@@ -86,7 +86,7 @@ public:
      *       = \sum_i \sum_j X_i X_j \sqrt{a_i a_j} \sqrt{\alpha_i \alpha_j}
      * @f]
      */
-    virtual double pressure() const;
+    double pressure() const override;
 
     //! @}
 
@@ -104,7 +104,7 @@ public:
      * @return
      *   Returns the standard Concentration in units of m^3 / kmol.
      */
-    virtual double standardConcentration(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
 
     //! Get the array of non-dimensional activity coefficients at the current
     //! solution temperature, pressure, and solution concentration.
@@ -115,21 +115,21 @@ public:
      *
      * @param ac Output vector of activity coefficients. Length: m_kk.
      */
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    virtual void getChemPotentials(double* mu) const;
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
-    virtual void getPartialMolarEntropies(double* sbar) const;
-    virtual void getPartialMolarIntEnergies(double* ubar) const;
+    void getChemPotentials(double* mu) const override;
+    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarIntEnergies(double* ubar) const override;
     //! Calculate species-specific molar specific heats
     /*!
      *  This function is currently not implemented for Peng-Robinson phase.
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarVolumes(double* vbar) const override;
     //! @}
 
     //! Calculate species-specific critical temperature
@@ -141,7 +141,7 @@ public:
      * @param a    species-specific coefficients used in P-R EoS
      * @param b    species-specific coefficients used in P-R EoS
      */
-    virtual double speciesCritTemperature(double a, double b) const;
+    double speciesCritTemperature(double a, double b) const;
 
     //! @name Initialization Methods - For Internal use
     //!
@@ -151,9 +151,9 @@ public:
     //! To see how they are used, see importPhase().
     //! @{
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void initThermo();
-    virtual void getSpeciesParameters(const string& name, AnyMap& speciesNode) const;
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void initThermo() override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
 
     //! Set the pure fluid interaction parameters for a species
     /*!
@@ -175,15 +175,15 @@ public:
 
 protected:
     // Special functions inherited from MixtureFugacityTP
-    virtual double sresid() const;
-    virtual double hresid() const;
+    double sresid() const override;
+    double hresid() const override;
 
-    virtual double liquidVolEst(double T, double& pres) const;
-    virtual double densityCalc(double T, double pressure, int phase, double rhoguess);
+    double liquidVolEst(double T, double& pres) const override;
+    double densityCalc(double T, double pressure, int phase, double rhoguess) override;
 
-    virtual double densSpinodalLiquid() const;
-    virtual double densSpinodalGas() const;
-    virtual double dpdVCalc(double T, double molarVol, double& presCalc) const;
+    double densSpinodalLiquid() const override;
+    double densSpinodalGas() const override;
+    double dpdVCalc(double T, double molarVol, double& presCalc) const override;
 
     // Special functions not inherited from MixtureFugacityTP
 
@@ -201,9 +201,9 @@ protected:
 
 public:
 
-    virtual double isothermalCompressibility() const;
-    virtual double thermalExpansionCoeff() const;
-    virtual double soundSpeed() const;
+    double isothermalCompressibility() const override;
+    double thermalExpansionCoeff() const override;
+    double soundSpeed() const override;
 
     //! Calculate @f$ dp/dV @f$ and @f$ dp/dT @f$ at the current conditions
     /*!
@@ -217,7 +217,7 @@ public:
      *  parameter @f$ \alpha @f$ depends on the temperature. This function updates
      *  the internal numbers based on the state of the object.
      */
-    virtual void updateMixingExpressions();
+    void updateMixingExpressions() override;
 
     //! Calculate the @f$ a @f$, @f$ b @f$, and @f$ \alpha @f$ parameters given the temperature
     /*!
@@ -230,7 +230,7 @@ public:
      */
     void calculateAB(double& aCalc, double& bCalc, double& aAlpha) const;
 
-    void calcCriticalConditions(double& pc, double& tc, double& vc) const;
+    void calcCriticalConditions(double& pc, double& tc, double& vc) const override;
 
     //! Prepare variables and call the function to solve the cubic equation of state
     int solveCubic(double T, double pres, double a, double b, double aAlpha,

--- a/include/cantera/thermo/PlasmaPhase.h
+++ b/include/cantera/thermo/PlasmaPhase.h
@@ -71,11 +71,11 @@ public:
      */
     explicit PlasmaPhase(const string& inputFile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "plasma";
     }
 
-    virtual void initThermo();
+    void initThermo() override;
 
     //! Set electron energy levels.
     //! @param  levels The vector of electron energy levels (eV).
@@ -119,7 +119,7 @@ public:
 
     //! Set the internally stored electron temperature of the phase (K).
     //! @param  Te Electron temperature in Kelvin
-    virtual void setElectronTemperature(double Te);
+    void setElectronTemperature(double Te) override;
 
     //! Set mean electron energy [eV]. This method also sets electron temperature
     //! accordingly.
@@ -161,11 +161,11 @@ public:
         return m_do_normalizeElectronEnergyDist;
     }
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
     //! Electron Temperature (K)
     //!     @return The electron temperature of the phase
-    virtual double electronTemperature() const {
+    double electronTemperature() const override {
         return m_electronTemp;
     }
 
@@ -208,49 +208,49 @@ public:
      *
      * \see MultiSpeciesThermo
      */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
-    virtual double cp_mole() const {
+    double cp_mole() const override {
         throw NotImplementedError("PlasmaPhase::cp_mole");
     }
 
-    virtual double entropy_mole() const {
+    double entropy_mole() const override {
         throw NotImplementedError("PlasmaPhase::entropy_mole");
     }
 
-    virtual double gibbs_mole() const {
+    double gibbs_mole() const override {
         throw NotImplementedError("PlasmaPhase::gibbs_mole");
     }
 
-    virtual double intEnergy_mole() const {
+    double intEnergy_mole() const override {
         throw NotImplementedError("PlasmaPhase::intEnergy_mole");
     }
 
-    virtual void getEntropy_R(double* sr) const;
+    void getEntropy_R(double* sr) const override;
 
-    virtual void getGibbs_RT(double* grt) const;
+    void getGibbs_RT(double* grt) const override;
 
-    virtual void getGibbs_ref(double* g) const;
+    void getGibbs_ref(double* g) const override;
 
-    virtual void getStandardVolumes_ref(double* vol) const;
+    void getStandardVolumes_ref(double* vol) const override;
 
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
-    virtual void getStandardChemPotentials(double* muStar) const;
+    void getStandardChemPotentials(double* muStar) const override;
 
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
-    virtual void getPartialMolarIntEnergies(double* ubar) const;
+    void getPartialMolarIntEnergies(double* ubar) const override;
 
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void getParameters(AnyMap& phaseNode) const override;
 
-    virtual void setParameters(const AnyMap& phaseNode,
-                               const AnyMap& rootNode=AnyMap());
+    void setParameters(const AnyMap& phaseNode,
+                       const AnyMap& rootNode=AnyMap()) override;
 
 protected:
-    virtual void updateThermo() const;
+    void updateThermo() const override;
 
     //! Check the electron energy levels
     /*!

--- a/include/cantera/thermo/PureFluidPhase.h
+++ b/include/cantera/thermo/PureFluidPhase.h
@@ -33,7 +33,7 @@ public:
     //! Empty Base Constructor
     PureFluidPhase() = default;
 
-    virtual string type() const {
+    string type() const override {
         return "pure-fluid";
     }
 
@@ -52,7 +52,7 @@ public:
      * at the current pressure, the mechanical phase is `gas`. Otherwise, the mechanical
      * phase is `liquid`.
      */
-    virtual string phaseOfMatter() const;
+    string phaseOfMatter() const override;
 
     //! Set the name of the TPX substance to use for the equation of state. This
     //! function should be called before initThermo().
@@ -60,33 +60,33 @@ public:
         m_tpx_name = name;
     }
 
-    virtual bool isPure() const {
+    bool isPure() const override {
         return true;
     }
 
-    virtual bool hasPhaseTransition() const {
+    bool hasPhaseTransition() const override {
         return true;
     }
 
-    virtual vector<string> fullStates() const;
-    virtual vector<string> partialStates() const;
+    vector<string> fullStates() const override;
+    vector<string> partialStates() const override;
 
-    virtual double minTemp(size_t k=npos) const;
-    virtual double maxTemp(size_t k=npos) const;
+    double minTemp(size_t k=npos) const override;
+    double maxTemp(size_t k=npos) const override;
 
-    virtual double enthalpy_mole() const;
-    virtual double intEnergy_mole() const;
-    virtual double entropy_mole() const;
-    virtual double gibbs_mole() const;
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double enthalpy_mole() const override;
+    double intEnergy_mole() const override;
+    double entropy_mole() const override;
+    double gibbs_mole() const override;
+    double cp_mole() const override;
+    double cv_mole() const override;
 
     //! Return the thermodynamic pressure (Pa).
     /*!
      * This method calculates the current pressure consistent with the
      * independent variables, T, rho.
      */
-    virtual double pressure() const;
+    double pressure() const override;
 
     //! sets the thermodynamic pressure (Pa).
     /*!
@@ -95,28 +95,28 @@ public:
      *
      * @param p  Pressure (Pa)
      */
-    virtual void setPressure(double p);
-    virtual void setTemperature(const double T);
-    virtual void setDensity(const double rho);
+    void setPressure(double p) override;
+    void setTemperature(const double T) override;
+    void setDensity(const double rho) override;
 
-    virtual void getChemPotentials(double* mu) const {
+    void getChemPotentials(double* mu) const override{
         mu[0] = gibbs_mole();
     }
 
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
-    virtual void getPartialMolarEntropies(double* sbar) const;
-    virtual void getPartialMolarIntEnergies(double* ubar) const;
-    virtual void getPartialMolarCp(double* cpbar) const;
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarIntEnergies(double* ubar) const override;
+    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarVolumes(double* vbar) const override;
 
-    virtual Units standardConcentrationUnits() const;
-    virtual void getActivityConcentrations(double* c) const;
-    virtual double standardConcentration(size_t k=0) const;
+    Units standardConcentrationUnits() const override;
+    void getActivityConcentrations(double* c) const override;
+    double standardConcentration(size_t k=0) const override;
 
-    virtual void getActivities(double* a) const;
+    void getActivities(double* a) const override;
 
-    virtual double isothermalCompressibility() const;
-    virtual double thermalExpansionCoeff() const;
+    double isothermalCompressibility() const override;
+    double thermalExpansionCoeff() const override;
 
     //! Returns a reference to the substance object
     tpx::Substance& TPX_Substance();
@@ -129,10 +129,10 @@ public:
     //! activity of the fluid is always then defined to be equal to one.
     //! @{
 
-    virtual void getStandardChemPotentials(double* mu) const;
-    virtual void getEnthalpy_RT(double* hrt) const;
-    virtual void getEntropy_R(double* sr) const;
-    virtual void getGibbs_RT(double* grt) const;
+    void getStandardChemPotentials(double* mu) const override;
+    void getEnthalpy_RT(double* hrt) const override;
+    void getEntropy_R(double* sr) const override;
+    void getGibbs_RT(double* grt) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
@@ -141,10 +141,10 @@ public:
     //! the reference pressure and current temperature of the fluid.
     //! @{
 
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
-    virtual void getGibbs_ref(double* g) const;
-    virtual void getEntropy_R_ref(double* er) const;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getGibbs_RT_ref(double* grt) const override;
+    void getGibbs_ref(double* g) const override;
+    void getEntropy_R_ref(double* er) const override;
 
     //! @}
     //! @name Setting the State
@@ -152,43 +152,43 @@ public:
     //! These methods set all or part of the thermodynamic state.
     //! @{
 
-    virtual void setState_HP(double h, double p, double tol=1e-9);
-    virtual void setState_UV(double u, double v, double tol=1e-9);
-    virtual void setState_SV(double s, double v, double tol=1e-9);
-    virtual void setState_SP(double s, double p, double tol=1e-9);
-    virtual void setState_ST(double s, double t, double tol=1e-9);
-    virtual void setState_TV(double t, double v, double tol=1e-9);
-    virtual void setState_PV(double p, double v, double tol=1e-9);
-    virtual void setState_UP(double u, double p, double tol=1e-9);
-    virtual void setState_VH(double v, double h, double tol=1e-9);
-    virtual void setState_TH(double t, double h, double tol=1e-9);
-    virtual void setState_SH(double s, double h, double tol=1e-9);
+    void setState_HP(double h, double p, double tol=1e-9) override;
+    void setState_UV(double u, double v, double tol=1e-9) override;
+    void setState_SV(double s, double v, double tol=1e-9) override;
+    void setState_SP(double s, double p, double tol=1e-9) override;
+    void setState_ST(double s, double t, double tol=1e-9) override;
+    void setState_TV(double t, double v, double tol=1e-9) override;
+    void setState_PV(double p, double v, double tol=1e-9) override;
+    void setState_UP(double u, double p, double tol=1e-9) override;
+    void setState_VH(double v, double h, double tol=1e-9) override;
+    void setState_TH(double t, double h, double tol=1e-9) override;
+    void setState_SH(double s, double h, double tol=1e-9) override;
     //! @}
     //! @name Critical State Properties
     //! @{
 
-    virtual double critTemperature() const;
-    virtual double critPressure() const;
-    virtual double critDensity() const;
+    double critTemperature() const override;
+    double critPressure() const override;
+    double critDensity() const override;
 
     //! @}
     //! @name Saturation properties.
     //! @{
 
-    virtual double satTemperature(double p) const;
-    virtual double satPressure(double t);
-    virtual double vaporFraction() const;
+    double satTemperature(double p) const override;
+    double satPressure(double t) override;
+    double vaporFraction() const override;
 
-    virtual void setState_Tsat(double t, double x);
-    virtual void setState_Psat(double p, double x);
+    void setState_Tsat(double t, double x) override;
+    void setState_Psat(double p, double x) override;
     //! @}
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
 
-    virtual string report(bool show_thermo=true, double threshold=1e-14) const;
+    string report(bool show_thermo=true, double threshold=1e-14) const override;
 
-    virtual bool compatibleWithMultiPhase() const {
+    bool compatibleWithMultiPhase() const override {
         return false;
     }
 

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -241,17 +241,17 @@ public:
      */
     explicit RedlichKisterVPSSTP(const string& inputFile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "Redlich-Kister";
     }
 
     //! @name  Molar Thermodynamic Properties
     //! @{
 
-    virtual double enthalpy_mole() const;
-    virtual double entropy_mole() const;
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double enthalpy_mole() const override;
+    double entropy_mole() const override;
+    double cp_mole() const override;
+    double cv_mole() const override;
 
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
@@ -263,13 +263,13 @@ public:
     //! on temperature and pressure.
     //! @{
 
-    virtual void getLnActivityCoefficients(double* lnac) const;
+    void getLnActivityCoefficients(double* lnac) const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution
     //! @{
 
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     //! Returns an array of partial molar enthalpies for the species in the
     //! mixture.
@@ -287,7 +287,7 @@ public:
      * @param hbar  Vector of returned partial molar enthalpies
      *              (length m_kk, units = J/kmol)
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     //! Returns an array of partial molar entropies for the species in the
     //! mixture.
@@ -304,7 +304,7 @@ public:
      * @param sbar  Vector of returned partial molar entropies
      *              (length m_kk, units = J/kmol/K)
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     //! Returns an array of partial molar heat capacities for the species in the
     //! mixture.
@@ -321,9 +321,9 @@ public:
      * @param cpbar  Vector of returned partial molar heat capacities
      *              (length m_kk, units = J/kmol/K)
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
     //! @}
 
     //! Get the array of temperature second derivatives of the log activity
@@ -334,9 +334,9 @@ public:
      * @param d2lnActCoeffdT2  Output vector of temperature 2nd derivatives of
      *                         the log Activity Coefficients. length = m_kk
      */
-    virtual void getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const;
+    void getd2lnActCoeffdT2(double* d2lnActCoeffdT2) const;
 
-    virtual void getdlnActCoeffdT(double* dlnActCoeffdT) const;
+    void getdlnActCoeffdT(double* dlnActCoeffdT) const override;
 
     //! @name Initialization
     //!
@@ -345,8 +345,8 @@ public:
     //! input file. They are not normally used in application programs.
     //! To see how they are used, see importPhase().
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
 
     //! Add a binary species interaction with the specified parameters
     /*!
@@ -364,11 +364,11 @@ public:
     //! @name  Derivatives of Thermodynamic Variables needed for Applications
     //! @{
 
-    virtual void getdlnActCoeffds(const double dTds, const double* const dXds,
-                                  double* dlnActCoeffds) const;
-    virtual void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const;
-    virtual void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const;
-    virtual void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN);
+    void getdlnActCoeffds(const double dTds, const double* const dXds,
+                          double* dlnActCoeffds) const override;
+    void getdlnActCoeffdlnX_diag(double* dlnActCoeffdlnX_diag) const override;
+    void getdlnActCoeffdlnN_diag(double* dlnActCoeffdlnN_diag) const override;
+    void getdlnActCoeffdlnN(const size_t ld, double* const dlnActCoeffdlnN) override;
     //! @}
 
 private:

--- a/include/cantera/thermo/RedlichKwongMFTP.h
+++ b/include/cantera/thermo/RedlichKwongMFTP.h
@@ -28,14 +28,14 @@ public:
      */
     explicit RedlichKwongMFTP(const string& infile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "Redlich-Kwong";
     }
 
     //! @name Molar Thermodynamic properties
     //! @{
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double cp_mole() const override;
+    double cv_mole() const override;
     //! @}
     //! @name Mechanical Properties
     //! @{
@@ -50,7 +50,7 @@ public:
      *    P = \frac{RT}{v-b_{mix}} - \frac{a_{mix}}{T^{0.5} v \left( v + b_{mix} \right) }
      * @f]
      */
-    virtual double pressure() const;
+    double pressure() const override;
 
     //! @}
 
@@ -70,7 +70,7 @@ public:
      * @return
      *   Returns the standard Concentration in units of m3 kmol-1.
      */
-    virtual double standardConcentration(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
 
     //! Get the array of non-dimensional activity coefficients at the current
     //! solution temperature, pressure, and solution concentration.
@@ -81,7 +81,7 @@ public:
      *
      * @param ac Output vector of activity coefficients. Length: m_kk.
      */
-    virtual void getActivityCoefficients(double* ac) const;
+    void getActivityCoefficients(double* ac) const override;
 
     //! @name  Partial Molar Properties of the Solution
     //! @{
@@ -99,16 +99,16 @@ public:
      *              Length: m_kk.
      * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
-    virtual void getChemPotentials_RT(double* mu) const;
+    void getChemPotentials_RT(double* mu) const override;
 
-    virtual void getChemPotentials(double* mu) const;
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
-    virtual void getPartialMolarEntropies(double* sbar) const;
-    virtual void getPartialMolarIntEnergies(double* ubar) const;
-    virtual void getPartialMolarCp(double* cpbar) const {
+    void getChemPotentials(double* mu) const override;
+    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarIntEnergies(double* ubar) const override;
+    void getPartialMolarCp(double* cpbar) const override {
         throw NotImplementedError("RedlichKwongMFTP::getPartialMolarCp");
     }
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
     //! @}
 
 public:
@@ -120,9 +120,9 @@ public:
     //! To see how they are used, see importPhase().
     //! @{
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
-    virtual void initThermo();
-    virtual void getSpeciesParameters(const string& name, AnyMap& speciesNode) const;
+    bool addSpecies(shared_ptr<Species> spec) override;
+    void initThermo() override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
 
     //! Set the pure fluid interaction parameters for a species
     /*!
@@ -160,20 +160,20 @@ public:
 
 protected:
     // Special functions inherited from MixtureFugacityTP
-    virtual double sresid() const;
-    virtual double hresid() const;
+    double sresid() const override;
+    double hresid() const override;
 
 public:
-    virtual double liquidVolEst(double TKelvin, double& pres) const;
-    virtual double densityCalc(double T, double pressure, int phase, double rhoguess);
+    double liquidVolEst(double TKelvin, double& pres) const override;
+    double densityCalc(double T, double pressure, int phase, double rhoguess) override;
 
-    virtual double densSpinodalLiquid() const;
-    virtual double densSpinodalGas() const;
-    virtual double dpdVCalc(double TKelvin, double molarVol, double& presCalc) const;
+    double densSpinodalLiquid() const override;
+    double densSpinodalGas() const override;
+    double dpdVCalc(double TKelvin, double molarVol, double& presCalc) const override;
 
-    virtual double isothermalCompressibility() const;
-    virtual double thermalExpansionCoeff() const;
-    virtual double soundSpeed() const;
+    double isothermalCompressibility() const override;
+    double thermalExpansionCoeff() const override;
+    double soundSpeed() const override;
 
     //! Calculate dpdV and dpdT at the current conditions
     /*!
@@ -187,7 +187,7 @@ public:
      *  temperature. This function updates the internal numbers based on the
      *  state of the object.
      */
-    virtual void updateMixingExpressions();
+    void updateMixingExpressions() override;
 
     //! Calculate the a and the b parameters given the temperature
     /*!
@@ -204,7 +204,7 @@ public:
 
     double da_dt() const;
 
-    void calcCriticalConditions(double& pc, double& tc, double& vc) const;
+    void calcCriticalConditions(double& pc, double& tc, double& vc) const override;
 
     //! Prepare variables and call the function to solve the cubic equation of state
     int solveCubic(double T, double pres, double a, double b, double Vroot[3]) const;

--- a/include/cantera/thermo/ShomatePoly.h
+++ b/include/cantera/thermo/ShomatePoly.h
@@ -94,13 +94,13 @@ public:
         m_coeff5_orig = m_coeff[5];
     }
 
-    virtual int reportType() const {
+    int reportType() const override {
         return SHOMATE;
     }
 
-    virtual size_t temperaturePolySize() const { return 6; }
+    size_t temperaturePolySize() const override { return 6; }
 
-    virtual void updateTemperaturePoly(double T, double* T_poly) const {
+    void updateTemperaturePoly(double T, double* T_poly) const override {
         double tt = 1.e-3*T;
         T_poly[0] = tt;
         T_poly[1] = tt * tt;
@@ -122,8 +122,8 @@ public:
      *   - `t[4] = log(t)`
      *   - `t[5] = 1.0/t;
      */
-    virtual void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                                  double* s_R) const {
+    void updateProperties(const double* tt, double* cp_R, double* h_RT,
+                          double* s_R) const override {
         double A = m_coeff[0];
         double Bt = m_coeff[1]*tt[0];
         double Ct2 = m_coeff[2]*tt[1];
@@ -137,15 +137,15 @@ public:
         *s_R = A*tt[4] + Bt + 0.5*Ct2 + 1.0/3.0*Dt3 - 0.5*Etm2 + G;
     }
 
-    virtual void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
-                                      double* s_R) const {
+    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
+                              double* s_R) const override {
         double tPoly[6];
         updateTemperaturePoly(temp, tPoly);
         updateProperties(tPoly, cp_R, h_RT, s_R);
     }
 
-    virtual void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                                  double& pref, double* const coeffs) const {
+    void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
+                          double& pref, double* const coeffs) const override {
         n = 0;
         type = SHOMATE;
         tlow = m_lowT;
@@ -156,7 +156,7 @@ public:
         }
     }
 
-    virtual void getParameters(AnyMap& thermo) const {
+    void getParameters(AnyMap& thermo) const override {
         // ShomatePoly is only used as an embedded model within ShomatePoly2, so
         // all that needs to be added here are the polynomial coefficients
         vector<double> dimensioned_coeffs(m_coeff.size());
@@ -166,19 +166,19 @@ public:
         thermo["data"].asVector<vector<double>>().push_back(dimensioned_coeffs);
     }
 
-    virtual double reportHf298(double* const h298 = 0) const {
+    double reportHf298(double* const h298=nullptr) const override {
         double cp_R, h_RT, s_R;
         updatePropertiesTemp(298.15, &cp_R, &h_RT, &s_R);
         return h_RT * GasConstant * 298.15;
     }
 
-    virtual void modifyOneHf298(const size_t k, const double Hf298New) {
+    void modifyOneHf298(const size_t k, const double Hf298New) override {
         double hnow = reportHf298();
         double delH = Hf298New - hnow;
         m_coeff[5] += delH / (1e3 * GasConstant);
     }
 
-    virtual void resetHf298() {
+    void resetHf298() override {
         m_coeff[5] = m_coeff5_orig;
     }
 
@@ -250,17 +250,17 @@ public:
     {
     }
 
-    virtual void setMinTemp(double Tmin) {
+    void setMinTemp(double Tmin) override {
         SpeciesThermoInterpType::setMinTemp(Tmin);
         msp_low.setMinTemp(Tmin);
     }
 
-    virtual void setMaxTemp(double Tmax) {
+    void setMaxTemp(double Tmax) override {
         SpeciesThermoInterpType::setMaxTemp(Tmax);
         msp_high.setMaxTemp(Tmax);
     }
 
-    virtual void setRefPressure(double Pref) {
+    void setRefPressure(double Pref) override {
         SpeciesThermoInterpType::setRefPressure(Pref);
         msp_low.setRefPressure(Pref);
         msp_high.setRefPressure(Pref);
@@ -280,19 +280,19 @@ public:
         msp_high.setParameters(high);
     }
 
-    virtual int reportType() const {
+    int reportType() const override {
         return SHOMATE2;
     }
 
-    virtual size_t temperaturePolySize() const { return 7; }
+    size_t temperaturePolySize() const override{ return 7; }
 
-    virtual void updateTemperaturePoly(double T, double* T_poly) const {
+    void updateTemperaturePoly(double T, double* T_poly) const override {
         msp_low.updateTemperaturePoly(T, T_poly);
     }
 
     //! @copydoc ShomatePoly::updateProperties
-    virtual void updateProperties(const double* tt, double* cp_R, double* h_RT,
-                                  double* s_R) const {
+    void updateProperties(const double* tt, double* cp_R, double* h_RT,
+                          double* s_R) const override {
         double T = 1000 * tt[0];
         if (T <= m_midT) {
             msp_low.updateProperties(tt, cp_R, h_RT, s_R);
@@ -301,10 +301,8 @@ public:
         }
     }
 
-    virtual void updatePropertiesTemp(const double temp,
-                                      double* cp_R,
-                                      double* h_RT,
-                                      double* s_R) const {
+    void updatePropertiesTemp(const double temp, double* cp_R, double* h_RT,
+                              double* s_R) const override {
         if (temp <= m_midT) {
             msp_low.updatePropertiesTemp(temp, cp_R, h_RT, s_R);
         } else {
@@ -312,16 +310,16 @@ public:
         }
     }
 
-    virtual size_t nCoeffs() const { return 15; }
+    size_t nCoeffs() const override { return 15; }
 
-    virtual void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
-                                  double& pref, double* const coeffs) const {
+    void reportParameters(size_t& n, int& type, double& tlow, double& thigh,
+                          double& pref, double* const coeffs) const override {
         msp_low.reportParameters(n, type, tlow, coeffs[0], pref, coeffs + 1);
         msp_high.reportParameters(n, type, coeffs[0], thigh, pref, coeffs + 8);
         type = SHOMATE2;
     }
 
-    virtual void getParameters(AnyMap& thermo) const {
+    void getParameters(AnyMap& thermo) const override {
         SpeciesThermoInterpType::getParameters(thermo);
         thermo["model"] = "Shomate";
         vector<double> Tranges {m_lowT, m_midT, m_highT};
@@ -331,7 +329,7 @@ public:
         msp_high.getParameters(thermo);
     }
 
-    virtual double reportHf298(double* const h298 = 0) const {
+    double reportHf298(double* const h298=nullptr) const override {
         double h;
         if (298.15 <= m_midT) {
             h = msp_low.reportHf298(h298);
@@ -344,7 +342,7 @@ public:
         return h;
     }
 
-    virtual void modifyOneHf298(const size_t k, const double Hf298New) {
+    void modifyOneHf298(const size_t k, const double Hf298New) override {
         double h298now = reportHf298(0);
         double delH = Hf298New - h298now;
         double h = msp_low.reportHf298(0);
@@ -355,7 +353,7 @@ public:
         msp_high.modifyOneHf298(k, hnew);
     }
 
-    virtual void resetHf298() {
+    void resetHf298() override {
         msp_low.resetHf298();
         msp_high.resetHf298();
     }

--- a/include/cantera/thermo/SingleSpeciesTP.h
+++ b/include/cantera/thermo/SingleSpeciesTP.h
@@ -59,11 +59,11 @@ public:
     //! Base empty constructor.
     SingleSpeciesTP() = default;
 
-    virtual string type() const {
+    string type() const override {
         return "SingleSpecies";
     }
 
-    virtual bool isPure() const {
+    bool isPure() const override {
         return true;
     }
 
@@ -74,12 +74,12 @@ public:
     //! classes don't need to supply entries for these functions.
     //! @{
 
-    virtual double enthalpy_mole() const;
-    virtual double intEnergy_mole() const;
-    virtual double entropy_mole() const;
-    virtual double gibbs_mole() const;
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double enthalpy_mole() const override;
+    double intEnergy_mole() const override;
+    double entropy_mole() const override;
+    double gibbs_mole() const override;
+    double cp_mole() const override;
+    double cv_mole() const override;
 
     //! @}
     //! @name Activities, Standard State, and Activity Concentrations
@@ -98,11 +98,11 @@ public:
      *
      * @param a   Output vector of activities. Length: 1.
      */
-    virtual void getActivities(double* a) const {
+    void getActivities(double* a) const override {
         a[0] = 1.0;
     }
 
-    virtual void getActivityCoefficients(double* ac) const {
+    void getActivityCoefficients(double* ac) const override {
         ac[0] = 1.0;
     }
 
@@ -127,7 +127,7 @@ public:
      *              single species and the phase. Units are unitless. Length = 1
      * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
-    virtual void getChemPotentials_RT(double* murt) const;
+    void getChemPotentials_RT(double* murt) const override;
 
     //! Get the array of chemical potentials
     /*!
@@ -138,7 +138,7 @@ public:
      * @param mu   On return, Contains the chemical potential of the single
      *             species and the phase. Units are J / kmol . Length = 1
      */
-    virtual void getChemPotentials(double* mu) const;
+    void getChemPotentials(double* mu) const override;
 
     //! Get the species partial molar enthalpies. Units: J/kmol.
     /*!
@@ -147,7 +147,7 @@ public:
      * @param hbar    Output vector of species partial molar enthalpies.
      *                Length: 1. units are J/kmol.
      */
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
+    void getPartialMolarEnthalpies(double* hbar) const override;
 
     //! Get the species partial molar internal energies. Units: J/kmol.
     /*!
@@ -156,7 +156,7 @@ public:
      * @param ubar On return, Contains the internal energy of the single species
      *             and the phase. Units are J / kmol . Length = 1
      */
-    virtual void getPartialMolarIntEnergies(double* ubar) const;
+    void getPartialMolarIntEnergies(double* ubar) const override;
 
     //! Get the species partial molar entropy. Units: J/kmol K.
     /*!
@@ -165,7 +165,7 @@ public:
      * @param sbar On return, Contains the entropy of the single species and the
      *             phase. Units are J / kmol / K . Length = 1
      */
-    virtual void getPartialMolarEntropies(double* sbar) const;
+    void getPartialMolarEntropies(double* sbar) const override;
 
     //! Get the species partial molar Heat Capacities. Units: J/ kmol /K.
     /*!
@@ -174,7 +174,7 @@ public:
      * @param cpbar On return, Contains the heat capacity of the single species
      *              and the phase. Units are J / kmol / K . Length = 1
      */
-    virtual void getPartialMolarCp(double* cpbar) const;
+    void getPartialMolarCp(double* cpbar) const override;
 
     //! Get the species partial molar volumes. Units: m^3/kmol.
     /*!
@@ -183,7 +183,7 @@ public:
      * @param vbar On return, Contains the molar volume of the single species
      *             and the phase. Units are m^3 / kmol. Length = 1
      */
-    virtual void getPartialMolarVolumes(double* vbar) const;
+    void getPartialMolarVolumes(double* vbar) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
@@ -194,7 +194,7 @@ public:
     //! are not resolved at the SingleSpeciesTP level.
     //! @{
 
-    virtual void getPureGibbs(double* gpure) const;
+    void getPureGibbs(double* gpure) const override;
 
     //! Get the molar volumes of each species in their standard states at the
     //! current *T* and *P* of the solution.
@@ -207,7 +207,7 @@ public:
      * @param vbar On output this contains the standard volume of the species
      *             and phase (m^3/kmol). Vector of length 1
      */
-    virtual void getStandardVolumes(double* vbar) const;
+    void getStandardVolumes(double* vbar) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference State
@@ -217,11 +217,11 @@ public:
     //! involve a specification of the equation of state.
     //! @{
 
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
-    virtual void getGibbs_ref(double* g) const;
-    virtual void getEntropy_R_ref(double* er) const;
-    virtual void getCp_R_ref(double* cprt) const;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getGibbs_RT_ref(double* grt) const override;
+    void getGibbs_ref(double* g) const override;
+    void getEntropy_R_ref(double* er) const override;
+    void getCp_R_ref(double* cprt) const override;
 
     //! @}
     //! @name Setting the State
@@ -230,18 +230,18 @@ public:
     //! @{
 
     //! Mass fractions are fixed, with Y[0] = 1.0.
-    virtual void setMassFractions(const double* const y) {};
+    void setMassFractions(const double* const y) override {};
 
     //! Mole fractions are fixed, with x[0] = 1.0.
-    virtual void setMoleFractions(const double* const x) {};
+    void setMoleFractions(const double* const x) override {};
 
-    virtual void setState_HP(double h, double p, double tol=1e-9);
-    virtual void setState_UV(double u, double v, double tol=1e-9);
-    virtual void setState_SP(double s, double p, double tol=1e-9);
-    virtual void setState_SV(double s, double v, double tol=1e-9);
+    void setState_HP(double h, double p, double tol=1e-9) override;
+    void setState_UV(double u, double v, double tol=1e-9) override;
+    void setState_SP(double s, double p, double tol=1e-9) override;
+    void setState_SV(double s, double v, double tol=1e-9) override;
     //! @}
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
 protected:
     //! The current pressure of the solution (Pa). It gets initialized to 1 atm.

--- a/include/cantera/thermo/StoichSubstance.h
+++ b/include/cantera/thermo/StoichSubstance.h
@@ -98,11 +98,11 @@ public:
      */
     explicit StoichSubstance(const string& infile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "fixed-stoichiometry";
     }
 
-    virtual bool isCompressible() const {
+    bool isCompressible() const override {
         return false;
     }
 
@@ -114,7 +114,7 @@ public:
      * For an incompressible substance, the density is independent of pressure.
      * This method simply returns the stored pressure value.
      */
-    virtual double pressure() const;
+    double pressure() const override;
 
     //! Set the pressure at constant temperature. Units: Pa.
     /*!
@@ -124,10 +124,10 @@ public:
      *
      * @param p Pressure (units - Pa)
      */
-    virtual void setPressure(double p);
+    void setPressure(double p) override;
 
-    virtual double isothermalCompressibility() const;
-    virtual double thermalExpansionCoeff() const;
+    double isothermalCompressibility() const override;
+    double thermalExpansionCoeff() const override;
 
     //! @}
     //! @name Activities, Standard States, and Activity Concentrations
@@ -136,7 +136,7 @@ public:
     //! is only one species. Therefore, the activity is equal to one.
     //! @{
 
-    virtual Units standardConcentrationUnits() const;
+    Units standardConcentrationUnits() const override;
 
     //! This method returns an array of generalized concentrations
     /*!
@@ -153,7 +153,7 @@ public:
      *           units depend upon the implementation of the
      *           reaction rate expressions within the phase.
      */
-    virtual void getActivityConcentrations(double* c) const;
+    void getActivityConcentrations(double* c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -167,8 +167,8 @@ public:
      * @return
      *   Returns The standard Concentration as 1.0
      */
-    virtual double standardConcentration(size_t k=0) const;
-    virtual double logStandardConc(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
+    double logStandardConc(size_t k=0) const override;
 
     //! Get the array of chemical potentials at unit activity for the species at
     //! their standard states at the current *T* and *P* of the solution.
@@ -184,16 +184,16 @@ public:
      * @param mu0     Output vector of chemical potentials.
      *                Length: m_kk.
      */
-    virtual void getStandardChemPotentials(double* mu0) const;
+    void getStandardChemPotentials(double* mu0) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
     //! @{
 
-    virtual void getEnthalpy_RT(double* hrt) const;
-    virtual void getEntropy_R(double* sr) const;
-    virtual void getGibbs_RT(double* grt) const;
-    virtual void getCp_R(double* cpr) const;
+    void getEnthalpy_RT(double* hrt) const override;
+    void getEntropy_R(double* sr) const override;
+    void getGibbs_RT(double* grt) const override;
+    void getCp_R(double* cpr) const override;
 
     //! Returns the vector of nondimensional Internal Energies of the standard
     //! state species at the current *T* and *P* of the solution
@@ -207,7 +207,7 @@ public:
      * @param urt  output vector of nondimensional standard state
      *             internal energies of the species. Length: m_kk.
      */
-    virtual void getIntEnergy_RT(double* urt) const;
+    void getIntEnergy_RT(double* urt) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference States
@@ -220,11 +220,11 @@ public:
      * @param urt    Output vector of nondimensional reference state internal
      *               energies of the species. Length: m_kk
      */
-    virtual void getIntEnergy_RT_ref(double* urt) const;
+    void getIntEnergy_RT_ref(double* urt) const override;
     //! @}
 
-    virtual void initThermo();
-    virtual void getSpeciesParameters(const string& name, AnyMap& speciesNode) const;
+    void initThermo() override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
 };
 
 }

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -106,11 +106,11 @@ public:
      */
     explicit SurfPhase(const string& infile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "ideal-surface";
     }
 
-    virtual bool isCompressible() const {
+    bool isCompressible() const override {
         return false;
     }
 
@@ -126,14 +126,14 @@ public:
      *
      * \see MultiSpeciesThermo
      */
-    virtual double enthalpy_mole() const;
+    double enthalpy_mole() const override;
 
     //! Return the Molar Internal Energy. Units: J/kmol
     /**
      * For a surface phase, the pressure is not a relevant thermodynamic
      * variable, and so the Enthalpy is equal to the Internal Energy.
      */
-    virtual double intEnergy_mole() const;
+    double intEnergy_mole() const override;
 
     //! Return the Molar Entropy. Units: J/kmol-K
     /**
@@ -141,17 +141,17 @@ public:
      *  \hat s(T,P) = \sum_k X_k (\hat s^0_k(T) - R \ln \theta_k)
      * @f]
      */
-    virtual double entropy_mole() const;
+    double entropy_mole() const override;
 
-    virtual double cp_mole() const;
-    virtual double cv_mole() const;
+    double cp_mole() const override;
+    double cv_mole() const override;
 
-    virtual void getChemPotentials(double* mu) const;
-    virtual void getPartialMolarEnthalpies(double* hbar) const;
-    virtual void getPartialMolarEntropies(double* sbar) const;
-    virtual void getPartialMolarCp(double* cpbar) const;
-    virtual void getPartialMolarVolumes(double* vbar) const;
-    virtual void getStandardChemPotentials(double* mu0) const;
+    void getChemPotentials(double* mu) const override;
+    void getPartialMolarEnthalpies(double* hbar) const override;
+    void getPartialMolarEntropies(double* sbar) const override;
+    void getPartialMolarCp(double* cpbar) const override;
+    void getPartialMolarVolumes(double* vbar) const override;
+    void getStandardChemPotentials(double* mu0) const override;
 
     //! Return a vector of activity concentrations for each species
     /*!
@@ -177,7 +177,7 @@ public:
      *
      * @param c vector of activity concentration (kmol m-2).
      */
-    virtual void getActivityConcentrations(double* c) const;
+    void getActivityConcentrations(double* c) const override;
 
     //! Return the standard concentration for the kth species
     /*!
@@ -196,23 +196,23 @@ public:
      * @return the standard concentration in units of kmol/m^2 for surface phases or
      *     kmol/m for edge phases.
      */
-    virtual double standardConcentration(size_t k = 0) const;
-    virtual double logStandardConc(size_t k=0) const;
+    double standardConcentration(size_t k=0) const override;
+    double logStandardConc(size_t k=0) const override;
 
-    virtual void initThermo();
-    virtual void getParameters(AnyMap& phaseNode) const;
+    void initThermo() override;
+    void getParameters(AnyMap& phaseNode) const override;
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
     //! Since interface phases have no volume, this returns 0.0.
-    virtual double molarVolume() const {
+    virtual double molarVolume() const override {
         return 0.0;
     }
 
     //! Since interface phases have no volume, setting this to a value other than 0.0
     //! raises an exception.
     //! @deprecated Unused. To be removed after %Cantera 3.0
-    virtual void setMolarDensity(const double vm);
+    void setMolarDensity(const double vm) override;
 
     //! Returns the site density
     /*!
@@ -223,7 +223,7 @@ public:
     }
 
     //! Returns the number of sites occupied by one molecule of species *k*.
-    virtual double size(size_t k) const {
+    double size(size_t k) const {
         return m_speciesSize[k];
     }
 
@@ -233,14 +233,14 @@ public:
      */
     void setSiteDensity(double n0);
 
-    virtual void getGibbs_RT(double* grt) const;
-    virtual void getEnthalpy_RT(double* hrt) const;
-    virtual void getEntropy_R(double* sr) const;
-    virtual void getCp_R(double* cpr) const;
-    virtual void getStandardVolumes(double* vol) const;
+    void getGibbs_RT(double* grt) const override;
+    void getEnthalpy_RT(double* hrt) const override;
+    void getEntropy_R(double* sr) const override;
+    void getCp_R(double* cpr) const override;
+    void getStandardVolumes(double* vol) const override;
 
     //! Return the thermodynamic pressure (Pa).
-    virtual double pressure() const {
+    double pressure() const override {
         return m_press;
     }
 
@@ -249,15 +249,15 @@ public:
     /*!
      *  @param p input Pressure (Pa)
      */
-    virtual void setPressure(double p) {
+    void setPressure(double p) override {
         m_press = p;
     }
 
-    virtual void getPureGibbs(double* g) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getEntropy_R_ref(double* er) const;
-    virtual void getCp_R_ref(double* cprt) const;
+    void getPureGibbs(double* g) const override;
+    void getGibbs_RT_ref(double* grt) const override;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getEntropy_R_ref(double* er) const override;
+    void getCp_R_ref(double* cprt) const override;
 
     //! Set the surface site fractions to a specified state.
     /*!
@@ -307,10 +307,10 @@ public:
     /*!
      * Additionally uses the key `coverages` to set the fractional coverages.
      */
-    virtual void setState(const AnyMap& state);
+    void setState(const AnyMap& state) override;
 
 protected:
-    virtual void compositionChanged();
+    void compositionChanged() override;
 
     //! Surface site density (kmol m-2)
     double m_n0 = 1.0;

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -205,7 +205,7 @@ public:
     bool addSpecies(shared_ptr<Species> spec) override;
 
     //! Since interface phases have no volume, this returns 0.0.
-    virtual double molarVolume() const override {
+    double molarVolume() const override {
         return 0.0;
     }
 

--- a/include/cantera/thermo/ThermoFactory.h
+++ b/include/cantera/thermo/ThermoFactory.h
@@ -34,7 +34,7 @@ public:
     static ThermoFactory* factory();
 
     //! delete the static instance of this factory
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
     //! Create a new thermodynamic property manager.
     /*!
@@ -43,7 +43,7 @@ public:
      *     CanteraError if the named model isn't registered with ThermoFactory.
      * @deprecated To be removed after %Cantera 3.0; superseded by newThermo()
      */
-    virtual ThermoPhase* newThermoPhase(const string& model);
+    ThermoPhase* newThermoPhase(const string& model);
 
 private:
     //! static member of a single instance

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -397,7 +397,7 @@ public:
     //! @name  Information Methods
     //! @{
 
-    virtual string type() const {
+    string type() const override {
         return "none";
     }
 
@@ -1917,9 +1917,9 @@ public:
     //! To see how they are used, see importPhase().
     //! @{
 
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
-    virtual void modifySpecies(size_t k, shared_ptr<Species> spec);
+    void modifySpecies(size_t k, shared_ptr<Species> spec) override;
 
     //! Return a changeable reference to the calculation manager for species
     //! reference-state thermodynamic properties
@@ -1984,7 +1984,7 @@ public:
     const AnyMap& input() const;
     AnyMap& input();
 
-    virtual void invalidateCache();
+    void invalidateCache() override;
 
     //! @}
     //! @name  Derivatives of Thermodynamic Variables needed for Applications

--- a/include/cantera/thermo/VPStandardStateTP.h
+++ b/include/cantera/thermo/VPStandardStateTP.h
@@ -48,16 +48,16 @@ public:
     //! Constructor.
     VPStandardStateTP();
 
-    virtual ~VPStandardStateTP();
+    ~VPStandardStateTP() override;
 
-    virtual bool isCompressible() const {
+    bool isCompressible() const override {
         return false;
     }
 
     //! @name  Utilities (VPStandardStateTP)
     //! @{
 
-    virtual int standardStateConvention() const;
+    int standardStateConvention() const override;
 
     //! @}
     //! @name  Partial Molar Properties of the Solution (VPStandardStateTP)
@@ -74,7 +74,7 @@ public:
      *              Length: m_kk.
      * @deprecated To be removed after %Cantera 3.0. Use getChemPotentials() instead.
      */
-    virtual void getChemPotentials_RT(double* mu) const;
+    void getChemPotentials_RT(double* mu) const override;
 
     //! @}
     //! @name  Properties of the Standard State of the Species in the Solution
@@ -85,14 +85,14 @@ public:
     //! recalculated unless the temperature or pressure changes.
     //! @{
 
-    virtual void getStandardChemPotentials(double* mu) const;
-    virtual void getEnthalpy_RT(double* hrt) const;
-    virtual void getEntropy_R(double* sr) const;
-    virtual void getGibbs_RT(double* grt) const;
-    virtual void getPureGibbs(double* gpure) const;
-    virtual void getIntEnergy_RT(double* urt) const;
-    virtual void getCp_R(double* cpr) const;
-    virtual void getStandardVolumes(double* vol) const;
+    void getStandardChemPotentials(double* mu) const override;
+    void getEnthalpy_RT(double* hrt) const override;
+    void getEntropy_R(double* sr) const override;
+    void getGibbs_RT(double* grt) const override;
+    void getPureGibbs(double* gpure) const override;
+    void getIntEnergy_RT(double* urt) const override;
+    void getCp_R(double* cpr) const override;
+    void getStandardVolumes(double* vol) const override;
     virtual const vector<double>& getStandardVolumes() const;
     //! @}
 
@@ -103,7 +103,7 @@ public:
      *
      * @param temp  Temperature (kelvin)
      */
-    virtual void setTemperature(const double temp);
+    void setTemperature(const double temp) override;
 
     //! Set the internally stored pressure (Pa) at constant temperature and
     //! composition
@@ -113,7 +113,7 @@ public:
      *
      *  @param p input Pressure (Pa)
      */
-    virtual void setPressure(double p);
+    void setPressure(double p) override;
 
     //! Set the temperature and pressure at the same time
     /*!
@@ -123,7 +123,7 @@ public:
      *  @param T  temperature (kelvin)
      *  @param pres pressure (pascal)
      */
-    virtual void setState_TP(double T, double pres);
+    void setState_TP(double T, double pres) override;
 
     //! Returns the current pressure of the phase
     /*!
@@ -132,7 +132,7 @@ public:
      *
      * @returns the pressure in pascals.
      */
-    virtual double pressure() const {
+    double pressure() const override {
         return m_Pcurrent;
     }
 
@@ -157,8 +157,8 @@ public:
      */
     virtual void updateStandardStateThermo() const;
 
-    virtual double minTemp(size_t k=npos) const;
-    virtual double maxTemp(size_t k=npos) const;
+    double minTemp(size_t k=npos) const override;
+    double maxTemp(size_t k=npos) const override;
 
 
 protected:
@@ -216,17 +216,17 @@ public:
     //! routine _updateRefStateThermo().
     //! @{
 
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getGibbs_RT_ref(double* grt) const override;
 
 protected:
     const vector<double>& Gibbs_RT_ref() const;
 
 public:
-    virtual void getGibbs_ref(double* g) const;
-    virtual void getEntropy_R_ref(double* er) const;
-    virtual void getCp_R_ref(double* cprt) const;
-    virtual void getStandardVolumes_ref(double* vol) const;
+    void getGibbs_ref(double* g) const override;
+    void getEntropy_R_ref(double* er) const override;
+    void getCp_R_ref(double* cprt) const override;
+    void getStandardVolumes_ref(double* vol) const override;
 
     //! @}
     //! @name Initialization Methods - For Internal use
@@ -237,12 +237,11 @@ public:
     //! To see how they are used, see importPhase().
     //! @{
 
-    virtual void initThermo();
-    virtual void getSpeciesParameters(const string& name,
-                                      AnyMap& speciesNode) const;
+    void initThermo() override;
+    void getSpeciesParameters(const string& name, AnyMap& speciesNode) const override;
 
     using Phase::addSpecies;
-    virtual bool addSpecies(shared_ptr<Species> spec);
+    bool addSpecies(shared_ptr<Species> spec) override;
 
     //! Install a PDSS object for species *k*
     void installPDSS(size_t k, unique_ptr<PDSS>&& pdss);
@@ -252,7 +251,7 @@ public:
     const PDSS* providePDSS(size_t k) const;
 
 protected:
-    virtual void invalidateCache();
+    void invalidateCache() override;
 
     //! Current value of the pressure - state variable
     /*!

--- a/include/cantera/thermo/WaterSSTP.h
+++ b/include/cantera/thermo/WaterSSTP.h
@@ -75,40 +75,40 @@ public:
      */
     explicit WaterSSTP(const string& inputFile="", const string& id="");
 
-    virtual string type() const {
+    string type() const override {
         return "liquid-water-IAPWS95";
     }
 
-    virtual string phaseOfMatter() const;
+    string phaseOfMatter() const override;
 
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    virtual double cv_mole() const;
+    double cv_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties
     //! @{
 
-    virtual double pressure() const;
-    virtual void setPressure(double p);
-    virtual double isothermalCompressibility() const;
-    virtual double thermalExpansionCoeff() const;
+    double pressure() const override;
+    void setPressure(double p) override;
+    double isothermalCompressibility() const override;
+    double thermalExpansionCoeff() const override;
 
     //! Return the derivative of the volumetric thermal expansion coefficient.
     //! Units: 1/K2.
-    virtual double dthermalExpansionCoeffdT() const;
+    double dthermalExpansionCoeffdT() const;
 
     //! @}
     //! @name Properties of the Standard State of the Species in the Solution
     //! @{
 
-    virtual void getStandardChemPotentials(double* gss) const;
-    virtual void getGibbs_RT(double* grt) const;
-    virtual void getEnthalpy_RT(double* hrt) const;
-    virtual void getEntropy_R(double* sr) const;
-    virtual void getCp_R(double* cpr) const;
-    virtual void getIntEnergy_RT(double* urt) const;
+    void getStandardChemPotentials(double* gss) const override;
+    void getGibbs_RT(double* grt) const override;
+    void getEnthalpy_RT(double* hrt) const override;
+    void getEntropy_R(double* sr) const override;
+    void getCp_R(double* cpr) const override;
+    void getIntEnergy_RT(double* urt) const override;
 
     //! @}
     //! @name Thermodynamic Values for the Species Reference State
@@ -118,21 +118,21 @@ public:
     //! equation of state.
     //! @{
 
-    virtual void getEnthalpy_RT_ref(double* hrt) const;
-    virtual void getGibbs_RT_ref(double* grt) const;
-    virtual void getGibbs_ref(double* g) const;
-    virtual void getEntropy_R_ref(double* er) const;
-    virtual void getCp_R_ref(double* cprt) const;
-    virtual void getStandardVolumes_ref(double* vol) const;
+    void getEnthalpy_RT_ref(double* hrt) const override;
+    void getGibbs_RT_ref(double* grt) const override;
+    void getGibbs_ref(double* g) const override;
+    void getEntropy_R_ref(double* er) const override;
+    void getCp_R_ref(double* cprt) const override;
+    void getStandardVolumes_ref(double* vol) const override;
     //! @}
 
-    virtual double critTemperature() const;
-    virtual double critPressure() const;
-    virtual double critDensity() const;
+    double critTemperature() const override;
+    double critPressure() const override;
+    double critDensity() const override;
 
-    virtual double satPressure(double t);
+    double satPressure(double t) override;
 
-    virtual bool compatibleWithMultiPhase() const {
+    bool compatibleWithMultiPhase() const override{
         return false;
     }
 
@@ -142,7 +142,7 @@ public:
      * functionality of the routine. Above Tcrit, we query the density to toggle
      * between 0 and 1.
      */
-    virtual double vaporFraction() const;
+    double vaporFraction() const override;
 
     //! Set the temperature of the phase
     /*!
@@ -151,7 +151,7 @@ public:
      *
      * @param temp Temperature (Kelvin)
      */
-    virtual void setTemperature(const double temp);
+    void setTemperature(const double temp) override;
 
     //! Set the density of the phase
     /*!
@@ -160,9 +160,9 @@ public:
      *
      * @param dens value of the density in kg m-3
      */
-    virtual void setDensity(const double dens);
+    void setDensity(const double dens) override;
 
-    virtual void initThermo();
+    void initThermo() override;
 
     //! Get a pointer to a changeable WaterPropsIAPWS object
     WaterPropsIAPWS* getWater() {

--- a/include/cantera/transport/DustyGasTransport.h
+++ b/include/cantera/transport/DustyGasTransport.h
@@ -61,13 +61,13 @@ public:
 
     //  overloaded base class methods
 
-    virtual void setThermo(ThermoPhase& thermo);
+    void setThermo(ThermoPhase& thermo) override;
 
-    virtual string transportModel() const {
+    string transportModel() const override {
         return "DustyGas";
     }
 
-    virtual void getMultiDiffCoeffs(const size_t ld, double* const d);
+    void getMultiDiffCoeffs(const size_t ld, double* const d) override;
 
     //! Get the molar fluxes [kmol/m^2/s], given the thermodynamic state at two nearby points.
     /*!
@@ -81,8 +81,8 @@ public:
      *
      * @param fluxes   Vector of species molar fluxes due to diffusional driving force
      */
-    virtual void getMolarFluxes(const double* const state1, const double* const state2,
-                                const double delta, double* const fluxes);
+    void getMolarFluxes(const double* const state1, const double* const state2,
+                        const double delta, double* const fluxes) override;
 
     // new methods added in this class
 

--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -45,10 +45,10 @@ public:
      *
      * @see updateViscosity_T()
      */
-    virtual double viscosity();
+    double viscosity() override;
 
     //! Get the pure-species viscosities
-    virtual void getSpeciesViscosities(double* const visc) {
+    void getSpeciesViscosities(double* const visc) override {
         update_T();
         updateViscosity_T();
         std::copy(m_visc.begin(), m_visc.end(), visc);
@@ -61,7 +61,7 @@ public:
      * @param ld   offset of rows in the storage
      * @param d    output vector of diffusion coefficients. Units of m**2 / s
      */
-    virtual void getBinaryDiffCoeffs(const size_t ld, double* const d);
+    void getBinaryDiffCoeffs(const size_t ld, double* const d) override;
 
     //! Returns the Mixture-averaged diffusion coefficients [m^2/s].
     /*!
@@ -81,7 +81,7 @@ public:
      * @param[out] d  Vector of mixture diffusion coefficients, @f$ D_{km}' @f$ ,
      *     for each species (m^2/s). length m_nsp
      */
-    virtual void getMixDiffCoeffs(double* const d);
+    void getMixDiffCoeffs(double* const d) override;
 
     //! Returns the mixture-averaged diffusion coefficients [m^2/s].
     //! These are the coefficients for calculating the molar diffusive fluxes
@@ -92,7 +92,7 @@ public:
     //!
     //! @param[out] d vector of mixture-averaged diffusion coefficients for
     //!     each species, length m_nsp.
-    virtual void getMixDiffCoeffsMole(double* const d);
+    void getMixDiffCoeffsMole(double* const d) override;
 
     //! Returns the mixture-averaged diffusion coefficients [m^2/s].
     /*!
@@ -108,51 +108,49 @@ public:
      * @param[out] d vector of mixture-averaged diffusion coefficients for
      *     each species, length m_nsp.
      */
-    virtual void getMixDiffCoeffsMass(double* const d);
+    void getMixDiffCoeffsMass(double* const d) override;
 
     //! Return the polynomial fits to the viscosity of species i
     //! @see fitProperties()
-    virtual void getViscosityPolynomial(size_t i, double* coeffs) const;
+    void getViscosityPolynomial(size_t i, double* coeffs) const override;
 
     //! Return the temperature fits of the heat conductivity of species i
     //! @see fitProperties()
-    virtual void getConductivityPolynomial(size_t i, double* coeffs) const;
+    void getConductivityPolynomial(size_t i, double* coeffs) const override;
 
     //! Return the polynomial fits to the binary diffusivity of species pair (i, j)
     //! @see fitDiffCoeffs()
-    virtual void getBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) const;
+    void getBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) const override;
 
     //! Return the polynomial fits to the collision integral of species pair (i, j)
     //! @see fitCollisionIntegrals()
-    virtual void getCollisionIntegralPolynomial(size_t i, size_t j,
-                                                double* astar_coeffs,
-                                                double* bstar_coeffs,
-                                                double* cstar_coeffs) const;
+    void getCollisionIntegralPolynomial(size_t i, size_t j,
+                                        double* astar_coeffs,
+                                        double* bstar_coeffs,
+                                        double* cstar_coeffs) const override;
 
     //! Modify the polynomial fits to the viscosity of species i
     //! @see fitProperties()
-    virtual void setViscosityPolynomial(size_t i, double* coeffs);
+    void setViscosityPolynomial(size_t i, double* coeffs) override;
 
     //! Modify the temperature fits of the heat conductivity of species i
     //! @see fitProperties()
-    virtual void setConductivityPolynomial(size_t i, double* coeffs);
+    void setConductivityPolynomial(size_t i, double* coeffs) override;
 
     //! Modify the polynomial fits to the binary diffusivity of species pair (i, j)
     //! @see fitDiffCoeffs()
-    virtual void setBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs);
+    void setBinDiffusivityPolynomial(size_t i, size_t j, double* coeffs) override;
 
     //! Modify the polynomial fits to the collision integral of species pair (i, j)
     //! @see fitCollisionIntegrals()
-    virtual void setCollisionIntegralPolynomial(size_t i, size_t j,
-                                                double* astar_coeffs,
-                                                double* bstar_coeffs,
-                                                double* cstar_coeffs, bool actualT);
+    void setCollisionIntegralPolynomial(size_t i, size_t j,
+                                        double* astar_coeffs,
+                                        double* bstar_coeffs,
+                                        double* cstar_coeffs, bool actualT) override;
 
-    virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
+    void init(ThermoPhase* thermo, int mode=0, int log_level=0) override;
 
-    //! Boolean indicating the form of the transport properties polynomial fits.
-    //! Returns true if the Chemkin form is used.
-    bool CKMode() const {
+    bool CKMode() const override {
         return m_mode == CK_Mode;
     }
 

--- a/include/cantera/transport/HighPressureGasTransport.h
+++ b/include/cantera/transport/HighPressureGasTransport.h
@@ -47,7 +47,7 @@ protected:
     HighPressureGasTransport(ThermoPhase* thermo=0);
 
 public:
-    virtual string transportModel() const {
+    string transportModel() const override {
         return "HighPressureGas";
     }
 
@@ -55,9 +55,9 @@ public:
     /*!
      *  Currently not implemented for this model
      */
-    virtual void getThermalDiffCoeffs(double* const dt);
+    void getThermalDiffCoeffs(double* const dt) override;
 
-    virtual double thermalConductivity();
+    double thermalConductivity() override;
 
     /**
      * Returns the matrix of binary diffusion coefficients
@@ -67,28 +67,28 @@ public:
      * @param ld    offset of rows in the storage
      * @param d     output vector of diffusion coefficients.  Units of m**2 / s
      */
-    virtual void getBinaryDiffCoeffs(const size_t ld, double* const d);
+    void getBinaryDiffCoeffs(const size_t ld, double* const d) override;
 
-    virtual void getMultiDiffCoeffs(const size_t ld, double* const d);
+    void getMultiDiffCoeffs(const size_t ld, double* const d) override;
 
-    virtual double viscosity();
+    double viscosity() override;
 
     friend class TransportFactory;
 
 protected:
-    virtual double Tcrit_i(size_t i);
+    double Tcrit_i(size_t i);
 
-    virtual double Pcrit_i(size_t i);
+    double Pcrit_i(size_t i);
 
-    virtual double Vcrit_i(size_t i);
+    double Vcrit_i(size_t i);
 
-    virtual double Zcrit_i(size_t i);
+    double Zcrit_i(size_t i);
 
     vector<double> store(size_t i, size_t nsp);
 
-    virtual double FQ_i(double Q, double Tr, double MW);
+    double FQ_i(double Q, double Tr, double MW);
 
-    virtual double setPcorr(double Pr, double Tr);
+    double setPcorr(double Pr, double Tr);
 };
 }
 #endif

--- a/include/cantera/transport/IonGasTransport.h
+++ b/include/cantera/transport/IonGasTransport.h
@@ -36,27 +36,27 @@ class IonGasTransport : public MixTransport
 public:
     IonGasTransport() = default;
 
-    virtual string transportModel() const {
+    string transportModel() const override {
         return "ionized-gas";
     }
 
-    virtual void init(ThermoPhase* thermo, int mode, int log_level);
+    void init(ThermoPhase* thermo, int mode, int log_level) override;
 
     //! Viscosity of the mixture  (kg/m/s).
     //! Only Neutral species contribute to Viscosity.
-    virtual double viscosity();
+    double viscosity() override;
 
     //! Returns the mixture thermal conductivity (W/m/K).
     //! Only Neutral species contribute to thermal conductivity.
-    virtual double thermalConductivity();
+    double thermalConductivity() override;
 
     //! The mobilities for ions in gas.
     //! The ion mobilities are calculated by Blanc's law.
-    virtual void getMobilities(double* const mobi);
+    void getMobilities(double* const mobi) override;
 
     //! The mixture transport for ionized gas.
     //! The binary transport between two charged species is neglected.
-    virtual void getMixDiffCoeffs(double* const d);
+    void getMixDiffCoeffs(double* const d) override;
 
     /**
      * The electrical conductivity (Siemens/m).
@@ -64,7 +64,7 @@ public:
      *     \sigma = \sum_k{\left|C_k\right| \mu_k \frac{X_k P}{k_b T}}
      * @f]
      */
-    virtual double electricalConductivity();
+    double electricalConductivity() override;
 
 protected:
     //! setup parameters for n64 model
@@ -72,7 +72,7 @@ protected:
 
     //! Generate polynomial fits to the binary diffusion coefficients.
     //! Use Stockmayer-(n,6,4) model for collision between charged and neutral species.
-    virtual void fitDiffCoeffs(MMCollisionInt& integrals);
+    void fitDiffCoeffs(MMCollisionInt& integrals) override;
 
     /**
      * Collision integral of omega11 of n64 collision model.

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -57,7 +57,7 @@ public:
     //! Default constructor.
     MixTransport() = default;
 
-    virtual string transportModel() const {
+    string transportModel() const override {
         return (m_mode == CK_Mode) ? "mixture-averaged-CK" : "mixture-averaged";
     }
 
@@ -67,7 +67,7 @@ public:
      *
      * @param dt  Vector of thermal diffusion coefficients. Units = kg/m/s
      */
-    virtual void getThermalDiffCoeffs(double* const dt);
+    void getThermalDiffCoeffs(double* const dt) override;
 
     //! Returns the mixture thermal conductivity (W/m /K)
     /*!
@@ -88,7 +88,7 @@ public:
      *
      * @returns the mixture thermal conductivity, with units of W/m/K
      */
-    virtual double thermalConductivity();
+    double thermalConductivity() override;
 
     //! Get the Electrical mobilities (m^2/V/s).
     /*!
@@ -106,21 +106,21 @@ public:
      *               The array must be dimensioned at least as large as the
      *               number of species.
      */
-    virtual void getMobilities(double* const mobil);
+    void getMobilities(double* const mobil) override;
 
     //! Update the internal parameters whenever the temperature has changed
     /*!
      * This is called whenever a transport property is requested if the
      * temperature has changed since the last call to update_T().
      */
-    virtual void update_T();
+    void update_T() override;
 
     //! Update the internal parameters whenever the concentrations have changed
     /*!
      * This is called whenever a transport property is requested if the
      * concentrations have changed since the last call to update_C().
      */
-    virtual void update_C();
+    void update_C() override;
 
     //! Get the species diffusive mass fluxes wrt to the mass averaged velocity,
     //! given the gradients in mole fraction and temperature
@@ -143,11 +143,11 @@ public:
      * @param fluxes    Output of the diffusive mass fluxes. Flat vector with
      *                  the m_nsp in the inner loop. length = ldx * ndim
      */
-    virtual void getSpeciesFluxes(size_t ndim, const double* const grad_T,
-                                  size_t ldx, const double* const grad_X,
-                                  size_t ldf, double* const fluxes);
+    void getSpeciesFluxes(size_t ndim, const double* const grad_T,
+                          size_t ldx, const double* const grad_X,
+                          size_t ldf, double* const fluxes) override;
 
-    virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
+    void init(ThermoPhase* thermo, int mode=0, int log_level=0) override;
 
 protected:
     //! Update the temperature dependent parts of the species thermal

--- a/include/cantera/transport/MultiTransport.h
+++ b/include/cantera/transport/MultiTransport.h
@@ -31,7 +31,7 @@ public:
      */
     MultiTransport(ThermoPhase* thermo=0);
 
-    virtual string transportModel() const {
+    string transportModel() const override {
         return (m_mode == CK_Mode) ? "multicomponent-CK" : "multicomponent";
     }
 
@@ -45,11 +45,11 @@ public:
      *
      * @param dt  Vector of thermal diffusion coefficients. Units = kg/m/s
      */
-    virtual void getThermalDiffCoeffs(double* const dt);
+    void getThermalDiffCoeffs(double* const dt) override;
 
-    virtual double thermalConductivity();
+    double thermalConductivity() override;
 
-    virtual void getMultiDiffCoeffs(const size_t ld, double* const d);
+    void getMultiDiffCoeffs(const size_t ld, double* const d) override;
 
     //! Get the species diffusive mass fluxes wrt to the mass averaged velocity,
     //! given the gradients in mole fraction and temperature
@@ -67,9 +67,9 @@ public:
      * @param fluxes   Output of the diffusive mass fluxes. Flat vector with the
      *                 m_nsp in the inner loop. length = ldx * ndim
      */
-    virtual void getSpeciesFluxes(size_t ndim, const double* const grad_T,
-                                  size_t ldx, const double* const grad_X,
-                                  size_t ldf, double* const fluxes);
+    void getSpeciesFluxes(size_t ndim, const double* const grad_T,
+                          size_t ldx, const double* const grad_X,
+                          size_t ldf, double* const fluxes) override;
 
     //! Get the molar diffusional fluxes [kmol/m^2/s] of the species, given the
     //! thermodynamic state at two nearby points.
@@ -84,10 +84,8 @@ public:
      * @param delta  Distance from state 1 to state 2 (m).
      * @param fluxes Output molar fluxes of the species. (length = m_nsp)
      */
-    virtual void getMolarFluxes(const double* const state1,
-                                const double* const state2,
-                                const double delta,
-                                double* const fluxes);
+    void getMolarFluxes(const double* const state1, const double* const state2,
+                        const double delta, double* const fluxes) override;
 
     //! Get the mass diffusional fluxes [kg/m^2/s] of the species, given the
     //! thermodynamic state at two nearby points.
@@ -102,19 +100,19 @@ public:
      * @param delta  Distance from state 1 to state 2 (m).
      * @param fluxes Output mass fluxes of the species. (length = m_nsp)
      */
-    virtual void getMassFluxes(const double* state1, const double* state2, double delta,
-                               double* fluxes);
+    void getMassFluxes(const double* state1, const double* state2, double delta,
+                       double* fluxes) override;
 
-    virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
+    void init(ThermoPhase* thermo, int mode=0, int log_level=0) override;
 
 protected:
     //! Update basic temperature-dependent quantities if the temperature has
     //! changed.
-    void update_T();
+    void update_T() override;
 
     //! Update basic concentration-dependent quantities if the concentrations
     //! have changed.
-    void update_C();
+    void update_C() override;
 
     //! Update the temperature-dependent terms needed to compute the thermal
     //! conductivity and thermal diffusion coefficients.

--- a/include/cantera/transport/TransportData.h
+++ b/include/cantera/transport/TransportData.h
@@ -67,9 +67,9 @@ public:
     //! inconsistent with the atomic composition, non-positive diameter, or
     //! negative values for well depth, dipole, polarizability, or
     //! rotational relaxation number.
-    virtual void validate(const Species& species);
+    void validate(const Species& species) override;
 
-    virtual void getParameters(AnyMap& transportNode) const;
+    void getParameters(AnyMap& transportNode) const override;
 
     //! A string specifying the molecular geometry. One of `atom`, `linear`, or
     //! `nonlinear`.

--- a/include/cantera/transport/TransportFactory.h
+++ b/include/cantera/transport/TransportFactory.h
@@ -45,7 +45,7 @@ public:
     static TransportFactory* factory();
 
     //! Deletes the statically allocated factory instance.
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
     //! Build a new transport manager using a transport manager
     //! that may not be the same as in the phase description
@@ -55,8 +55,7 @@ public:
      *  @param thermo    ThermoPhase object
      *  @param log_level log level
      */
-    virtual Transport* newTransport(const string& model, ThermoPhase* thermo,
-                                    int log_level=0);
+    Transport* newTransport(const string& model, ThermoPhase* thermo, int log_level=0);
 
     //! Build a new transport manager using the default transport manager
     //! in the phase description and return a base class pointer to it
@@ -64,7 +63,7 @@ public:
      * @param thermo    ThermoPhase object
      * @param log_level log level
      */
-    virtual Transport* newTransport(ThermoPhase* thermo, int log_level=0);
+    Transport* newTransport(ThermoPhase* thermo, int log_level=0);
 
 private:
     //! Static instance of the factor -> This is the only instance of this

--- a/include/cantera/transport/UnityLewisTransport.h
+++ b/include/cantera/transport/UnityLewisTransport.h
@@ -27,7 +27,7 @@ class UnityLewisTransport : public MixTransport
 public:
     UnityLewisTransport() = default;
 
-    virtual string transportModel() const {
+    string transportModel() const override {
         return "unity-Lewis-number";
     }
 
@@ -53,7 +53,7 @@ public:
      * @param[out] d  Vector of diffusion coefficients for each species (m^2/s).
      * length m_nsp.
      */
-    virtual void getMixDiffCoeffs(double* const d) {
+    void getMixDiffCoeffs(double* const d) override {
         double Dm = thermalConductivity() / (m_thermo->density() * m_thermo->cp_mass());
         for (size_t k = 0; k < m_nsp; k++) {
             d[k] = Dm;
@@ -61,7 +61,7 @@ public:
     }
 
     //! Not implemented for unity Lewis number approximation
-    virtual void getMixDiffCoeffsMole(double* const d){
+    void getMixDiffCoeffsMole(double* const d) override {
         throw NotImplementedError("UnityLewisTransport::getMixDiffCoeffsMole");
     }
 
@@ -78,7 +78,7 @@ public:
      * @param[out] d  Vector of diffusion coefficients for each species (m^2/s).
      * length m_nsp.
      */
-    virtual void getMixDiffCoeffsMass(double* const d){
+    void getMixDiffCoeffsMass(double* const d) override {
         double Dm = thermalConductivity() / (m_thermo->density() * m_thermo->cp_mass());
         for (size_t k = 0; k < m_nsp; k++) {
             d[k] = Dm;

--- a/include/cantera/transport/WaterTransport.h
+++ b/include/cantera/transport/WaterTransport.h
@@ -31,7 +31,7 @@ public:
      */
     WaterTransport(ThermoPhase* thermo = 0, int ndim = -1);
 
-    virtual string transportModel() const {
+    string transportModel() const override {
         return "Water";
     }
 
@@ -46,9 +46,9 @@ public:
      * and for water, even near the critical point. Pressures above 500 MPa and
      * temperature above 900 C are suspect.
      */
-    virtual double viscosity();
+    double viscosity() override;
 
-    virtual double bulkViscosity() {
+    double bulkViscosity() override {
         return 0.0;
     }
 
@@ -64,9 +64,9 @@ public:
      * and for water, even near the critical point. Pressures above 500 MPa and
      * temperature above 900 C are suspect.
      */
-    virtual double thermalConductivity();
+    double thermalConductivity() override;
 
-    virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0);
+    void init(ThermoPhase* thermo, int mode=0, int log_level=0) override;
 };
 }
 #endif

--- a/include/cantera/zeroD/ConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/ConstPressureMoleReactor.h
@@ -22,21 +22,21 @@ class ConstPressureMoleReactor : public MoleReactor
 public:
     ConstPressureMoleReactor() {}
 
-    virtual string type() const {
+    string type() const override {
         return "ConstPressureMoleReactor";
     };
 
-    virtual size_t componentIndex(const string& nm) const;
+    size_t componentIndex(const string& nm) const override;
 
-    virtual string componentName(size_t k);
+    string componentName(size_t k) override;
 
-    virtual void getState(double* y);
+    void getState(double* y) override;
 
-    virtual void initialize(double t0 = 0.0);
+    void initialize(double t0=0.0) override;
 
-    virtual void eval(double t, double* LHS, double* RHS);
+    void eval(double t, double* LHS, double* RHS) override;
 
-    virtual void updateState(double* y);
+    void updateState(double* y) override;
 
 protected:
     const size_t m_sidx = 1;

--- a/include/cantera/zeroD/ConstPressureReactor.h
+++ b/include/cantera/zeroD/ConstPressureReactor.h
@@ -25,23 +25,23 @@ class ConstPressureReactor : public Reactor
 public:
     ConstPressureReactor() {}
 
-    virtual string type() const {
+    string type() const override {
         return "ConstPressureReactor";
     }
 
-    virtual void getState(double* y);
+    void getState(double* y) override;
 
-    virtual void initialize(double t0 = 0.0);
-    virtual void eval(double t, double* LHS, double* RHS);
+    void initialize(double t0=0.0) override;
+    void eval(double t, double* LHS, double* RHS) override;
 
-    virtual void updateState(double* y);
+    void updateState(double* y) override;
 
     //! Return the index in the solution vector for this reactor of the
     //! component named *nm*. Possible values for *nm* are "mass", "enthalpy",
     //! the name of a homogeneous phase species, or the name of a surface
     //! species.
-    virtual size_t componentIndex(const string& nm) const;
-    string componentName(size_t k);
+    size_t componentIndex(const string& nm) const override;
+    string componentName(size_t k) override;
 };
 
 }

--- a/include/cantera/zeroD/FlowDeviceFactory.h
+++ b/include/cantera/zeroD/FlowDeviceFactory.h
@@ -24,14 +24,14 @@ class FlowDeviceFactory : public Factory<FlowDevice>
 public:
     static FlowDeviceFactory* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
     //! Create a new flow device by type name.
     /*!
      * @param flowDeviceType the type to be created.
      * @deprecated To be removed after %Cantera 3.0; replaceable by newFlowDevice3.
      */
-    virtual FlowDevice* newFlowDevice(const string& flowDeviceType);
+    FlowDevice* newFlowDevice(const string& flowDeviceType);
 
 private:
     static FlowDeviceFactory* s_factory;

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -22,32 +22,32 @@ class IdealGasConstPressureMoleReactor : public ConstPressureMoleReactor
 public:
     IdealGasConstPressureMoleReactor() {}
 
-    virtual string type() const {
+    string type() const override {
         return "IdealGasConstPressureMoleReactor";
     };
 
-    virtual size_t componentIndex(const string& nm) const;
+    size_t componentIndex(const string& nm) const override;
 
-    virtual string componentName(size_t k);
+    string componentName(size_t k) override;
 
-    virtual void setThermoMgr(ThermoPhase& thermo);
+    void setThermoMgr(ThermoPhase& thermo) override;
 
-    virtual void getState(double* y);
+    void getState(double* y) override;
 
-    virtual void initialize(double t0 = 0.0);
+    void initialize(double t0=0.0) override;
 
-    virtual void eval(double t, double* LHS, double* RHS);
+    void eval(double t, double* LHS, double* RHS) override;
 
-    virtual void updateState(double* y);
+    void updateState(double* y) override;
 
     //! Calculate an approximate Jacobian to accelerate preconditioned solvers
 
     //! Neglects derivatives with respect to mole fractions that would generate a
     //! fully-dense Jacobian. Currently also neglects terms related to interactions
     //! between reactors, for example via inlets and outlets.
-    virtual Eigen::SparseMatrix<double> jacobian();
+    Eigen::SparseMatrix<double> jacobian() override;
 
-    virtual bool preconditionerSupported() const {return true;};
+    bool preconditionerSupported() const override { return true; };
 
 protected:
     vector<double> m_hk; //!< Species molar enthalpies

--- a/include/cantera/zeroD/IdealGasConstPressureReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureReactor.h
@@ -24,25 +24,25 @@ class IdealGasConstPressureReactor : public ConstPressureReactor
 public:
     IdealGasConstPressureReactor() {}
 
-    virtual string type() const {
+    string type() const override {
         return "IdealGasConstPressureReactor";
     }
 
-    virtual void setThermoMgr(ThermoPhase& thermo);
+    void setThermoMgr(ThermoPhase& thermo) override;
 
-    virtual void getState(double* y);
+    void getState(double* y) override;
 
-    virtual void initialize(double t0 = 0.0);
-    virtual void eval(double t, double* LHS, double* RHS);
+    void initialize(double t0=0.0) override;
+    void eval(double t, double* LHS, double* RHS) override;
 
-    virtual void updateState(double* y);
+    void updateState(double* y) override;
 
     //! Return the index in the solution vector for this reactor of the
     //! component named *nm*. Possible values for *nm* are "mass",
     //! "temperature", the name of a homogeneous phase species, or the name of a
     //! surface species.
-    virtual size_t componentIndex(const string& nm) const;
-    string componentName(size_t k);
+    size_t componentIndex(const string& nm) const override;
+    string componentName(size_t k) override;
 
 protected:
     vector<double> m_hk; //!< Species molar enthalpies

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -22,32 +22,32 @@ class IdealGasMoleReactor : public MoleReactor
 public:
     IdealGasMoleReactor() {}
 
-    virtual string type() const {
+    string type() const override {
         return "IdealGasMoleReactor";
     }
 
-    virtual size_t componentIndex(const string& nm) const;
+    size_t componentIndex(const string& nm) const override;
 
-    virtual string componentName(size_t k);
+    string componentName(size_t k) override;
 
-    virtual void setThermoMgr(ThermoPhase& thermo);
+    void setThermoMgr(ThermoPhase& thermo) override;
 
-    virtual void getState(double* y);
+    void getState(double* y) override;
 
-    virtual void initialize(double t0 = 0.0);
+    void initialize(double t0=0.0) override;
 
-    virtual void eval(double t, double* LHS, double* RHS);
+    void eval(double t, double* LHS, double* RHS) override;
 
-    virtual void updateState(double* y);
+    void updateState(double* y) override;
 
     //! Calculate an approximate Jacobian to accelerate preconditioned solvers
 
     //! Neglects derivatives with respect to mole fractions that would generate a
     //! fully-dense Jacobian. Currently, also neglects terms related to interactions
     //! between reactors, for example via inlets and outlets.
-    virtual Eigen::SparseMatrix<double> jacobian();
+    Eigen::SparseMatrix<double> jacobian() override;
 
-    virtual bool preconditionerSupported() const {return true;};
+    bool preconditionerSupported() const override {return true;};
 
 protected:
     vector<double> m_uk; //!< Species molar internal energies

--- a/include/cantera/zeroD/IdealGasReactor.h
+++ b/include/cantera/zeroD/IdealGasReactor.h
@@ -22,26 +22,26 @@ class IdealGasReactor : public Reactor
 public:
     IdealGasReactor() {}
 
-    virtual string type() const {
+    string type() const override {
         return "IdealGasReactor";
     }
 
-    virtual void setThermoMgr(ThermoPhase& thermo);
+    void setThermoMgr(ThermoPhase& thermo) override;
 
-    virtual void getState(double* y);
+    void getState(double* y) override;
 
-    virtual void initialize(double t0 = 0.0);
+    void initialize(double t0=0.0) override;
 
-    virtual void eval(double t, double* LHS, double* RHS);
+    void eval(double t, double* LHS, double* RHS) override;
 
-    virtual void updateState(double* y);
+    void updateState(double* y) override;
 
     //! Return the index in the solution vector for this reactor of the
     //! component named *nm*. Possible values for *nm* are "mass",
     //! "volume", "temperature", the name of a homogeneous phase species, or the
     //! name of a surface species.
-    virtual size_t componentIndex(const string& nm) const;
-    string componentName(size_t k);
+    size_t componentIndex(const string& nm) const override;
+    string componentName(size_t k) override;
 
 protected:
     vector<double> m_uk; //!< Species molar internal energies

--- a/include/cantera/zeroD/MoleReactor.h
+++ b/include/cantera/zeroD/MoleReactor.h
@@ -22,21 +22,21 @@ class MoleReactor : public Reactor
 public:
     MoleReactor() {}
 
-    virtual string type() const {
+    string type() const override {
         return "MoleReactor";
     }
 
-    virtual void initialize(double t0 = 0.0);
+    void initialize(double t0=0.0) override;
 
-    virtual void getState(double* y);
+    void getState(double* y) override;
 
-    virtual void updateState(double* y);
+    void updateState(double* y) override;
 
-    virtual void eval(double t, double* LHS, double* RHS);
+    void eval(double t, double* LHS, double* RHS) override;
 
-    size_t componentIndex(const string& nm) const;
+    size_t componentIndex(const string& nm) const override;
 
-    string componentName(size_t k);
+    string componentName(size_t k) override;
 
 protected:
     //! For each surface in the reactor, update vector of triplets with all relevant
@@ -46,17 +46,17 @@ protected:
 
     //! Get moles of the system from mass fractions stored by thermo object
     //! @param y vector for moles to be put into
-    virtual void getMoles(double* y);
+    void getMoles(double* y);
 
     //! Set internal mass variable based on moles given
     //! @param y vector of moles of the system
-    virtual void setMassFromMoles(double* y);
+    void setMassFromMoles(double* y);
 
-    virtual void evalSurfaces(double* LHS, double* RHS, double* sdot);
+    void evalSurfaces(double* LHS, double* RHS, double* sdot) override;
 
-    virtual void updateSurfaceState(double* y);
+    void updateSurfaceState(double* y) override;
 
-    virtual void getSurfaceInitialConditions(double* y);
+    void getSurfaceInitialConditions(double* y) override;
 
     //! const value for the species start index
     const size_t m_sidx = 2;

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -45,7 +45,7 @@ class Reactor : public ReactorBase
 public:
     Reactor() = default;
 
-    virtual string type() const {
+    string type() const override {
         return "Reactor";
     }
 
@@ -74,9 +74,9 @@ public:
 
     void insert(shared_ptr<Solution> sol);
 
-    virtual void setKineticsMgr(Kinetics& kin);
+    void setKineticsMgr(Kinetics& kin) override;
 
-    void setChemistry(bool cflag=true) {
+    void setChemistry(bool cflag=true) override {
         m_chem = cflag;
     }
 
@@ -86,7 +86,7 @@ public:
         return m_chem;
     }
 
-    void setEnergy(int eflag=1) {
+    void setEnergy(int eflag=1) override {
         if (eflag > 0) {
             m_energy = true;
         } else {
@@ -123,7 +123,7 @@ public:
         throw NotImplementedError("Reactor::getStateDae(y, ydot)");
     }
 
-    virtual void initialize(double t0 = 0.0);
+    void initialize(double t0=0.0) override;
 
     //! Evaluate the reactor governing equations. Called by ReactorNet::eval.
     //! @param[in] t time.
@@ -150,8 +150,7 @@ public:
         throw NotImplementedError("Reactor::getConstraints");
     }
 
-
-    virtual void syncState();
+    void syncState() override;
 
     //! Set the state of the reactor to correspond to the state vector *y*.
     virtual void updateState(double* y);

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -96,92 +96,91 @@ public:
 
     // Overrides of Reactor methods
 
-    virtual void initialize(double t0) override {
+    void initialize(double t0) override {
         m_initialize(t0);
     }
 
-    virtual void syncState() override {
+    void syncState() override {
         m_syncState();
     }
 
-    virtual void getState(double* y) override {
+    void getState(double* y) override {
         std::array<size_t, 1> sizes{R::neq()};
         m_getState(sizes, y);
     }
 
-    virtual void updateState(double* y) override {
+    void updateState(double* y) override {
         std::array<size_t, 1> sizes{R::neq()};
         m_updateState(sizes, y);
     }
 
-    virtual void updateSurfaceState(double* y) override {
+    void updateSurfaceState(double* y) override {
         std::array<size_t, 1> sizes{R::m_nv_surf};
         m_updateSurfaceState(sizes, y);
     }
 
-    virtual void getSurfaceInitialConditions(double* y) override {
+    void getSurfaceInitialConditions(double* y) override {
         std::array<size_t, 1> sizes{R::m_nv_surf};
         m_getSurfaceInitialConditions(sizes, y);
     }
 
-    virtual void updateConnected(bool updatePressure) override {
+    void updateConnected(bool updatePressure) override {
         m_updateConnected(updatePressure);
     }
 
-    virtual void eval(double t, double* LHS, double* RHS) override {
+    void eval(double t, double* LHS, double* RHS) override {
         std::array<size_t, 2> sizes{R::neq(), R::neq()};
         m_eval(sizes, t, LHS, RHS);
     }
 
-    virtual void evalWalls(double t) override {
+    void evalWalls(double t) override {
         m_evalWalls(t);
     }
 
-    virtual void evalSurfaces(double* LHS, double* RHS, double* sdot) override
-    {
+    void evalSurfaces(double* LHS, double* RHS, double* sdot) override {
         std::array<size_t, 3> sizes{R::m_nv_surf, R::m_nv_surf, R::m_nsp};
         m_evalSurfaces(sizes, LHS, RHS, sdot);
     }
 
-    virtual string componentName(size_t k) override {
+    string componentName(size_t k) override {
         return m_componentName(k);
     }
 
-    virtual size_t componentIndex(const string& nm) const override {
+    size_t componentIndex(const string& nm) const override {
         return m_componentIndex(nm);
     }
 
-    virtual size_t speciesIndex(const string& nm) const override {
+    size_t speciesIndex(const string& nm) const override {
         return m_speciesIndex(nm);
     }
 
     // Public access to protected Reactor variables needed by derived classes
 
-    virtual void setNEq(size_t n) override {
+    void setNEq(size_t n) override {
         R::m_nv = n;
     }
 
-    virtual double expansionRate() const override {
+    double expansionRate() const override {
         return R::m_vdot;
     }
 
-    virtual void setExpansionRate(double v) override {
+    void setExpansionRate(double v) override {
         R::m_vdot = v;
     }
 
-    virtual double heatRate() const override {
+    double heatRate() const override {
         return R::m_Qdot;
     }
 
-    virtual void setHeatRate(double q) override {
+    void setHeatRate(double q) override {
         R::m_Qdot = q;
     }
 
-    virtual void restoreThermoState() override {
+    void restoreThermoState() override {
         R::m_thermo->restoreState(R::m_state);
     }
 
-    virtual void restoreSurfaceState(size_t n) override {
+    void restoreSurfaceState(size_t n) override {
         R::m_surfaces.at(n)->syncState();
     }
 

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -24,14 +24,14 @@ class ReactorFactory : public Factory<ReactorBase>
 public:
     static ReactorFactory* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
     //! Create a new reactor by type name.
     /*!
      * @param reactorType the type to be created.
      * @deprecated To be removed after %Cantera 3.0; replaceable by newReactor3.
      */
-    virtual ReactorBase* newReactor(const string& reactorType);
+    ReactorBase* newReactor(const string& reactorType);
 
 private:
     static ReactorFactory* s_factory;

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -30,7 +30,7 @@ class ReactorNet : public FuncEval
 {
 public:
     ReactorNet();
-    virtual ~ReactorNet();
+    ~ReactorNet() override;
     ReactorNet(const ReactorNet&) = delete;
     ReactorNet& operator=(const ReactorNet&) = delete;
 
@@ -205,7 +205,7 @@ public:
                       double* ydot, double* p, Array2D* j);
 
     // overloaded methods of class FuncEval
-    virtual size_t neq() const {
+    size_t neq() const override {
         return m_nv;
     }
 
@@ -213,21 +213,21 @@ public:
         return m_reactors.size();
     }
 
-    virtual void eval(double t, double* y, double* ydot, double* p);
+    void eval(double t, double* y, double* ydot, double* p) override;
 
     //! eval coupling for IDA / DAEs
-    virtual void evalDae(double t, double* y, double* ydot, double* p,
-                         double* residual);
+    void evalDae(double t, double* y, double* ydot, double* p,
+                 double* residual) override;
 
-    virtual void getState(double* y);
-    virtual void getStateDae(double* y, double* ydot);
+    void getState(double* y) override;
+    void getStateDae(double* y, double* ydot) override;
 
     //! Return k-th derivative at the current state of the system
     virtual void getDerivative(int k, double* dky);
 
-    virtual void getConstraints(double* constraints);
+    void getConstraints(double* constraints) override;
 
-    virtual size_t nparams() const {
+    size_t nparams() const override {
         return m_sens_params.size();
     }
 
@@ -288,9 +288,9 @@ public:
     //! Retrieve absolute step size limits during advance
     bool getAdvanceLimits(double* limits) const;
 
-    virtual void preconditionerSetup(double t, double* y, double gamma);
+    void preconditionerSetup(double t, double* y, double gamma) override;
 
-    virtual void preconditionerSolve(double* rhs, double* output);
+    void preconditionerSolve(double* rhs, double* output) override;
 
     //! Get solver stats from integrator
     AnyMap solverStats() const;
@@ -303,8 +303,7 @@ protected:
     //! Check that preconditioning is supported by all reactors in the network
     virtual void checkPreconditionerSupported() const;
 
-    //! Update the preconditioner based on the already computed jacobian values
-    virtual void updatePreconditioner(double gamma);
+    void updatePreconditioner(double gamma) override;
 
     //! Estimate a future state based on current derivatives.
     //! The function is intended for internal use by ReactorNet::advance

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -20,11 +20,11 @@ class Reservoir : public ReactorBase
 public:
     Reservoir() {}
 
-    virtual string type() const {
+    string type() const override {
         return "Reservoir";
     }
 
-    virtual void initialize(double t0 = 0.0) {}
+    void initialize(double t0=0.0) override {}
 
     void insert(ThermoPhase& contents) {
         setThermoMgr(contents);

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -138,7 +138,7 @@ public:
 
     //! String indicating the wall model implemented. Usually
     //! corresponds to the name of the derived class.
-    virtual string type() const {
+    string type() const override {
         return "Wall";
     }
 
@@ -166,7 +166,7 @@ public:
      * @deprecated Still used by traditional MATLAB toolbox; replaceable by
      *      expansionRate.
      */
-    virtual double vdot(double t);
+    double vdot(double t) override;
 
     //! Rate of volume change (m^3/s) for the adjacent reactors.
     /*!
@@ -180,7 +180,7 @@ public:
      * reactor on left, and decreases in the volume of the reactor on the right.
      * @since New in %Cantera 3.0.
      */
-    virtual double expansionRate();
+    double expansionRate() override;
 
     //! Heat flux function @f$ q_0(t) @f$ evaluated at current reactor network time.
     //! @since New in %Cantera 3.0.
@@ -202,7 +202,7 @@ public:
      * from left to right.
      * @deprecated Still used by traditional MATLAB toolbox; replaceable by heatRate.
      */
-    virtual double Q(double t);
+    double Q(double t) override;
 
     //! Heat flow rate through the wall (W).
     /*!
@@ -215,7 +215,7 @@ public:
      * time. Positive values denote a flux from left to right.
      * @since New in %Cantera 3.0.
      */
-    virtual double heatRate();
+    double heatRate() override;
 
     void setThermalResistance(double Rth) {
         m_rrth = 1.0/Rth;

--- a/include/cantera/zeroD/WallFactory.h
+++ b/include/cantera/zeroD/WallFactory.h
@@ -24,14 +24,14 @@ class WallFactory : public Factory<WallBase>
 public:
     static WallFactory* factory();
 
-    virtual void deleteFactory();
+    void deleteFactory() override;
 
     //! Create a new wall by type name.
     /*!
      * @param wallType the type to be created.
      * @deprecated To be removed after %Cantera 3.0; replaceable by newWall3.
      */
-    virtual WallBase* newWall(const string& wallType);
+    WallBase* newWall(const string& wallType);
 
 private:
     static WallFactory* s_factory;

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -22,7 +22,7 @@ class MassFlowController : public FlowDevice
 public:
     MassFlowController() = default;
 
-    virtual string type() const {
+    string type() const override {
         return "MassFlowController";
     }
 
@@ -46,14 +46,14 @@ public:
         return m_coeff;
     }
 
-    virtual void setPressureFunction(Func1* f) {
+    void setPressureFunction(Func1* f) override {
         throw NotImplementedError("MassFlowController::setPressureFunction");
     }
 
     //! If a function of time has been specified for mdot, then update the
     //! stored mass flow rate. Otherwise, mdot is a constant, and does not
     //! need updating.
-    virtual void updateMassFlowRate(double time);
+    void updateMassFlowRate(double time) override;
 };
 
 /**
@@ -67,11 +67,11 @@ class PressureController : public FlowDevice
 public:
     PressureController() = default;
 
-    virtual string type() const {
+    string type() const override {
         return "PressureController";
     }
 
-    virtual bool ready() {
+    bool ready() override {
         return FlowDevice::ready() && m_primary != 0;
     }
 
@@ -86,7 +86,7 @@ public:
     //! @deprecated To be removed after %Cantera 3.0; replaced by setPrimary().
     void setMaster(FlowDevice* master);
 
-    virtual void setTimeFunction(Func1* g) {
+    void setTimeFunction(Func1* g) override {
         throw NotImplementedError("PressureController::setTimeFunction");
     }
 
@@ -109,7 +109,7 @@ public:
         return m_coeff;
     }
 
-    virtual void updateMassFlowRate(double time);
+    void updateMassFlowRate(double time) override;
 
 protected:
     FlowDevice* m_primary = nullptr;
@@ -128,7 +128,7 @@ class Valve : public FlowDevice
 public:
     Valve() = default;
 
-    virtual string type() const {
+    string type() const override {
         return "Valve";
     }
 
@@ -152,7 +152,7 @@ public:
     }
 
     //! Compute the current mass flow rate, based on the pressure difference.
-    virtual void updateMassFlowRate(double time);
+    void updateMassFlowRate(double time) override;
 };
 
 }

--- a/samples/cxx/bvp/BoundaryValueProblem.h
+++ b/samples/cxx/bvp/BoundaryValueProblem.h
@@ -190,7 +190,7 @@ public:
      * grid points. Overload in derived classes to specify other
      * choices for initial values.
      */
-    virtual double initialValue(size_t n, size_t j) {
+    double initialValue(size_t n, size_t j) override {
         return 0.0;
     }
 

--- a/samples/cxx/bvp/blasius.cpp
+++ b/samples/cxx/bvp/blasius.cpp
@@ -58,12 +58,9 @@ public:
         setComponent(1, B); // u will be component 1
     }
 
-    // destructor
-    virtual ~Blasius() {}
-
     // specify guesses for the initial values. These can be anything
     // that leads to a converged solution.
-    virtual double initialValue(size_t n, size_t j) {
+    double initialValue(size_t n, size_t j) override {
         switch (n) {
         case 0:
             return 0.1*z(j);
@@ -77,7 +74,7 @@ public:
     // Specify the residual function. This is where the ODE system and boundary
     // conditions are specified. The solver will attempt to find a solution
     // x so that rsd is zero.
-    void eval(size_t jg, double* x, double* rsd, int* diag, double rdt) {
+    void eval(size_t jg, double* x, double* rsd, int* diag, double rdt) override {
         size_t jpt = jg - firstPoint();
         size_t jmin, jmax;
         if (jg == npos) {  // evaluate all points

--- a/samples/cxx/custom/custom.cpp
+++ b/samples/cxx/custom/custom.cpp
@@ -62,7 +62,7 @@ public:
      * @param[in] p sensitivity parameter vector, length nparams()
      *   - note: sensitivity analysis isn't implemented in this example
      */
-    void eval(double t, double* y, double* ydot, double* p) {
+    void eval(double t, double* y, double* ydot, double* p) override {
         // the solution vector *y* is [T, Y_1, Y_2, ... Y_K], where T is the
         // system temperature, and Y_k is the mass fraction of species k.
         // similarly, the time derivative of the solution vector, *ydot*, is
@@ -113,7 +113,7 @@ public:
      * Number of equations in the ODE system.
      *   - overridden from FuncEval, called by the integrator during initialization.
      */
-    size_t neq() const {
+    size_t neq() const override {
         return m_nEqs;
     }
 
@@ -122,7 +122,7 @@ public:
      *   - overridden from FuncEval, called by the integrator during initialization.
      * @param[out] y solution vector, length neq()
      */
-    void getState(double* y) {
+    void getState(double* y) override {
         // the solution vector *y* is [T, Y_1, Y_2, ... Y_K], where T is the
         // system temperature, and Y_k is the mass fraction of species k.
         y[0] = m_gas->temperature();

--- a/src/matlab/mllogger.h
+++ b/src/matlab/mllogger.h
@@ -18,17 +18,17 @@ class ML_Logger : public Logger
 {
 public:
     ML_Logger() {}
-    virtual ~ML_Logger() {}
+    ~ML_Logger() override {}
 
-    virtual void write(const string& s) {
+    void write(const string& s) override {
         mexPrintf("%s", s.c_str());
     }
 
-    virtual void writeendl() {
+    void writeendl() override {
         mexPrintf("\n");
     }
 
-    virtual void error(const string& msg) {
+    void error(const string& msg) override {
         mexErrMsgTxt(msg.c_str());
     }
 };

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -32,10 +32,9 @@ double LatticeSolidPhase::minTemp(size_t k) const
             }
         }
     }
-    double mm = 1.0E300;
-    for (size_t n = 0; n < m_lattice.size(); n++) {
-        double ml = m_lattice[n]->minTemp();
-        mm = std::min(mm, ml);
+    double mm = 0;
+    for (auto& lattice : m_lattice) {
+        mm = std::max(mm, lattice->minTemp());
     }
     return mm;
 }
@@ -49,10 +48,9 @@ double LatticeSolidPhase::maxTemp(size_t k) const
             }
         }
     }
-    double mm = -1.0E300;
-    for (size_t n = 0; n < m_lattice.size(); n++) {
-        double ml = m_lattice[n]->maxTemp();
-        mm = std::max(mm, ml);
+    double mm = BigNumber;
+    for (auto& lattice : m_lattice) {
+        mm = std::min(mm, lattice->maxTemp());
     }
     return mm;
 }

--- a/src/tpx/CarbonDioxide.h
+++ b/src/tpx/CarbonDioxide.h
@@ -21,15 +21,15 @@ public:
         m_formula="CO2";
     }
 
-    double MolWt();
-    double Tcrit();
-    double Pcrit();
-    double Vcrit();
-    double Tmin();
-    double Tmax();
+    double MolWt() override;
+    double Tcrit() override;
+    double Pcrit() override;
+    double Vcrit() override;
+    double Tmin() override;
+    double Tmax() override;
 
     //! Pressure. Equation P-3 in Reynolds. P(rho, T).
-    double Pp();
+    double Pp() override;
 
     /**
      * internal energy. See Reynolds eqn (15) section 2
@@ -37,17 +37,17 @@ public:
      *  u = (the integral from T to To of co(T)dT) +
      *         sum from i to N ([C(i) - T*Cprime(i)] + uo
      */
-    double up();
+    double up() override;
 
     //! entropy. See Reynolds eqn (16) section 2
-    double sp();
+    double sp() override;
 
     //! Pressure at Saturation. Equation S-2 in Reynolds.
-    double Psat();
+    double Psat() override;
 
 private:
     //! Liquid density. Equation D2 in Reynolds.
-    double ldens();
+    double ldens() override;
 
     /**
      * C returns a multiplier in each term of the sum in P-3, used in

--- a/src/tpx/HFC134a.h
+++ b/src/tpx/HFC134a.h
@@ -22,22 +22,23 @@ public:
         m_formula = "C2F4H2";
     }
 
-    double MolWt();
-    double Tcrit();
-    double Pcrit();
-    double Vcrit();
-    double Tmin();
-    double Tmax();
+    double MolWt() override;
+    double Tcrit() override;
+    double Pcrit() override;
+    double Vcrit() override;
+    double Tmin() override;
+    double Tmax() override;
 
-    double Pp();
+    double Pp() override;
     double fp();
-    double up();
-    double sp() {
+    double up() override;
+    double sp() override {
         return ((up() - m_energy_offset) - fp())/T + m_entropy_offset;
     }
-    double Psat();
-private:
-    double ldens();
+    double Psat() override;
+
+protected:
+    double ldens() override;
 };
 }
 #endif // ! HFC134_H

--- a/src/tpx/Heptane.h
+++ b/src/tpx/Heptane.h
@@ -20,15 +20,15 @@ public:
         m_formula = "C7H16";
     }
 
-    double MolWt();
-    double Tcrit();
-    double Pcrit();
-    double Vcrit();
-    double Tmin();
-    double Tmax();
+    double MolWt() override;
+    double Tcrit() override;
+    double Pcrit() override;
+    double Vcrit() override;
+    double Tmin() override;
+    double Tmax() override;
 
     //! Pressure. Equation P-2 in Reynolds.
-    double Pp();
+    double Pp() override;
 
     /**
      * Internal energy.
@@ -36,17 +36,17 @@ public:
      *  u = (the integral from T to To of co(T)dT) +
      *         sum from i to N ([C(i) - T*Cprime(i)] + uo
      */
-    double up();
+    double up() override;
 
     //! Entropy. See Reynolds eqn (16) section 2
-    double sp();
+    double sp() override;
 
     //! Pressure at Saturation. Equation S-2 in Reynolds.
-    double Psat();
+    double Psat() override;
 
 private:
     //! liquid density. Equation D2 in Reynolds.
-    double ldens();
+    double ldens() override;
 
     /**
      * C returns a multiplier in each term of the sum

--- a/src/tpx/Hydrogen.h
+++ b/src/tpx/Hydrogen.h
@@ -21,23 +21,25 @@ public:
         m_formula = "H2";
     }
 
-    double MolWt();
-    double Tcrit();
-    double Pcrit();
-    double Vcrit();
-    double Tmin();
-    double Tmax();
+    double MolWt() override;
+    double Tcrit() override;
+    double Pcrit() override;
+    double Vcrit() override;
+    double Tmin() override;
+    double Tmax() override;
 
-    double Pp();
-    double up();
-    double sp();
+    double Pp() override;
+    double up() override;
+    double sp() override;
 
     //! Saturation pressure. Equation s3 in Reynolds TPSI.
-    double Psat();
+    double Psat() override;
+
+protected:
+    //! Liquid density. Equation D4 in Reynolds TPSI.
+    double ldens() override;
 
 private:
-    //! Liquid density. Equation D4 in Reynolds TPSI.
-    double ldens();
     double C(int i, double rt, double rt2);
     double Cprime(int i, double rt, double rt2, double rt3);
     double I(int i, double egrho);

--- a/src/tpx/Methane.h
+++ b/src/tpx/Methane.h
@@ -21,24 +21,25 @@ public:
         m_formula = "CH4";
     }
 
-    double MolWt();
-    double Tcrit();
-    double Pcrit();
-    double Vcrit();
-    double Tmin();
-    double Tmax();
+    double MolWt() override;
+    double Tcrit() override;
+    double Pcrit() override;
+    double Vcrit() override;
+    double Tmin() override;
+    double Tmax() override;
 
-    double Pp();
-    double up();
-    double sp();
+    double Pp() override;
+    double up() override;
+    double sp() override;
 
     //! Saturation pressure. Equation S3 from Reynolds TPSI.
-    double Psat();
+    double Psat() override;
+
+protected:
+    //! Liquid density. Equation D3 from Reynolds TPSI.
+    double ldens() override;
 
 private:
-    //! Liquid density. Equation D3 from Reynolds TPSI.
-    double ldens();
-
     double C(int i, double rt, double rt2);
     double Cprime(int i, double rt, double rt2, double rt3);
     double I(int i, double egrho);

--- a/src/tpx/Nitrogen.h
+++ b/src/tpx/Nitrogen.h
@@ -21,24 +21,25 @@ public:
         m_formula = "N2";
     }
 
-    double MolWt();
-    double Tcrit();
-    double Pcrit();
-    double Vcrit();
-    double Tmin();
-    double Tmax();
+    double MolWt() override;
+    double Tcrit() override;
+    double Pcrit() override;
+    double Vcrit() override;
+    double Tmin() override;
+    double Tmax() override;
 
-    double Pp();
-    double up();
-    double sp();
+    double Pp() override;
+    double up() override;
+    double sp() override;
 
     //! Saturation pressure. Equation S4 from Reynolds TPSI.
-    double Psat();
+    double Psat() override;
+
+protected:
+    //! Liquid density. Equation D2 from Reynolds TPSI.
+    double ldens() override;
 
 private:
-    //! Liquid density. Equation D2 from Reynolds TPSI.
-    double ldens();
-
     //! Equation P4 from Reynolds TPSI.
     double C(int i, double rt, double rt2);
     double Cprime(int i, double rt, double rt2, double rt3);

--- a/src/tpx/Oxygen.h
+++ b/src/tpx/Oxygen.h
@@ -20,24 +20,25 @@ public:
         m_formula="O2";
     }
 
-    double MolWt();
-    double Tcrit();
-    double Pcrit();
-    double Vcrit();
-    double Tmin();
-    double Tmax();
+    double MolWt() override;
+    double Tcrit() override;
+    double Pcrit() override;
+    double Vcrit() override;
+    double Tmin() override;
+    double Tmax() override;
 
-    double Pp();
-    double up();
-    double sp();
+    double Pp() override;
+    double up() override;
+    double sp() override;
 
     //! Saturation pressure. Equation S4 from Reynolds TPSI.
-    double Psat();
+    double Psat() override;
+
+protected:
+    //! Liquid density. Equation D2 from Reynolds TPSI.
+    double ldens() override;
 
 private:
-    //! Liquid density. Equation D2 from Reynolds TPSI.
-    double ldens();
-
     //! Equation P4 from Reynolds TPSI.
     double C(int i, double rt, double rt2);
     double Cprime(int i, double rt, double rt2, double rt3);

--- a/src/tpx/Water.h
+++ b/src/tpx/Water.h
@@ -20,21 +20,23 @@ public:
         m_formula = "H2O";
     }
 
-    double MolWt();
-    double Tcrit();
-    double Pcrit();
-    double Vcrit();
-    double Tmin();
-    double Tmax();
+    double MolWt() override;
+    double Tcrit() override;
+    double Pcrit() override;
+    double Vcrit() override;
+    double Tmin() override;
+    double Tmax() override;
 
-    double Pp();
-    double up();
-    double sp();
-    double Psat();
+    double Pp() override;
+    double up() override;
+    double sp() override;
+    double Psat() override;
     double dPsatdT();
 
+protected:
+    double ldens() override;
+
 private:
-    double ldens();
     double C(int i);
     double Cprime(int i);
     double I(int i);

--- a/test/kinetics/pdep.cpp
+++ b/test/kinetics/pdep.cpp
@@ -20,7 +20,7 @@ public:
         soln_.reset();
     }
 
-    void SetUp() {
+    void SetUp() override {
         string Xref = "H:1.0, R1A:1.0, R1B:1.0, R2:1.0, R3:1.0, R4:1.0, R5:1.0, R6:1.0";
 
         soln_->thermo()->setState_TPX(900.0, 101325 * 8.0, Xref);

--- a/test/thermo_consistency/consistency.cpp
+++ b/test/thermo_consistency/consistency.cpp
@@ -107,7 +107,7 @@ public:
         make_deprecation_warnings_fatal();
     }
 
-    void SetUp() {
+    void SetUp() override {
         // See if we should skip this test specific test case
         if (setup.hasKey("known-failures")) {
             auto current = testing::UnitTest::GetInstance()->current_test_info()->name();

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -27,12 +27,10 @@ TEST(zerodim, simple)
     network.initialize();
 
     double t = 0.0;
-    int count = 0;
     while (t < 0.1) {
         ASSERT_GE(cppReactor.temperature(), T);
         t = network.time() + 5e-3;
         network.advance(t);
-        count++;
     }
 }
 

--- a/test_problems/shared/fileLog.h
+++ b/test_problems/shared/fileLog.h
@@ -10,11 +10,11 @@ public:
         m_fs.open(fName, std::ios::out);
     }
 
-    virtual void write(const std::string& msg) {
+    void write(const std::string& msg) override {
         m_fs << msg;
     }
 
-    virtual void writeendl() {
+    void writeendl() override {
         m_fs << std::endl;
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Make use of the [override specifier](https://en.cppreference.com/w/cpp/language/override) for overrides of virtual functions. That is, in derived classes, write
```c++
int foo(double bar) override;
```
instead of
```c++
virtual foo(double bar);
```
where the `virtual` keyword in the derived class actually has no effect. This helps distinguish between virtual functions introduced in a class and overrides of base class methods. More importantly, it helps detect some subtle errors, where an override is desired but does not actually correspond to the base class method, for example by having a different argument type or a difference in `const`ness, where having the `override` specifier will generate an error.

Since the default C++11 behavior is that the `override` specifier is not _required_ (for backwards compatibility), this PR also updates the Clang CI runner to issue a warning in cases where it _could_ be used, and is further configured with `-Werror` to treat such warnings as errors.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
