### PR TITLE
Fixes to help with conda-forge builds

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -2050,7 +2050,7 @@ if conda_prefix is not None and sys.executable.startswith(str(conda_prefix)):
             env["prefix"] = conda_prefix.resolve().as_posix()
         logger.info(
             f"Using conda environment as default 'prefix': {env['prefix']}")
-elif env["layout"] == "conda":
+elif env["layout"] == "conda" and not env["package_build"]:
     logger.error("Layout option 'conda' requires a conda environment.")
     sys.exit(1)
 

--- a/include/cantera/numerics/DenseMatrix.h
+++ b/include/cantera/numerics/DenseMatrix.h
@@ -151,12 +151,6 @@ public:
      * out, if this value is nonzero.
      */
     int m_printLevel = 0;
-
-    // Listing of friend functions which are defined below
-
-    friend int solve(DenseMatrix& A, double* b, size_t nrhs, size_t ldb);
-    friend int solve(DenseMatrix& A, DenseMatrix& b);
-    friend int invert(DenseMatrix& A, int nn);
 };
 
 

--- a/include/cantera/transport/MultiTransport.h
+++ b/include/cantera/transport/MultiTransport.h
@@ -150,8 +150,6 @@ protected:
     //! Mole fraction vector from last L-matrix evaluation
     vector<double> m_molefracs_last;
 
-    void correctBinDiffCoeffs();
-
     //! Boolean indicating viscosity is up to date
     bool m_l0000_ok;
     bool m_lmatrix_soln_ok;

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -51,8 +51,8 @@ if localenv["package_build"]:
     # compatible with the SDK used for building.
     excludes = (
         "-isysroot", "-mmacosx", "-march", "-mtune", "-fdebug-prefix-map")
-    localenv["CCFLAGS"] = compiler_flag_list(localenv["CCFLAGS"], excludes)
-    localenv["CXXFLAGS"] = compiler_flag_list(localenv["CXXFLAGS"], excludes)
+    localenv["CCFLAGS"] = compiler_flag_list(localenv["CCFLAGS"], env["CC"], excludes)
+    localenv["CXXFLAGS"] = compiler_flag_list(localenv["CXXFLAGS"], env["CC"], excludes)
 
 # Generate cantera.pc for use with pkg-config
 localenv["pc_prefix"] = localenv["prefix"]

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -18,12 +18,17 @@ pc_libdirs = []
 pc_incdirs = []
 pc_cflags = list(localenv['CXXFLAGS'])
 
+if 'Accelerate' in localenv['FRAMEWORKS']:
+    pc_cflags.append('-framework Accelerate')
+
+if '-pthread' in localenv['thread_flags']:
+    pc_cflags.append('-pthread')
+    pc_libs.append('pthread')
+
+flag_excludes = []
 if localenv["package_build"]:
-    # Remove local conda build environment from the installed include list
-    for i in range(len(pc_cflags) - 1):
-        if pc_cflags[i] == '-isystem' and '/_build_env/' in pc_cflags[i+1]:
-            del pc_cflags[i:i+2]
-            break
+    flag_excludes.extend(("-isysroot", "-mmacosx", "-march", "-mtune",
+                          "-fdebug-prefix-map", ".*/_build_env/"))
 else:
     pc_incdirs.extend(localenv["extra_inc_dirs"])
     pc_libdirs.extend(localenv["extra_lib_dirs"])
@@ -37,29 +42,13 @@ else:
     if localenv["use_hdf5"]:
         pc_incdirs.append(localenv["hdf_include"])
 
-if 'Accelerate' in localenv['FRAMEWORKS']:
-    pc_cflags.append('-framework Accelerate')
-
-if '-pthread' in localenv['thread_flags']:
-    pc_cflags.append('-pthread')
-    pc_libs.append('pthread')
-
-if localenv["package_build"]:
-    # Remove sysroot flags in templated output files. This only applies to the
-    # conda package for now.
-    # Users should compile against their local SDKs, which should be backwards
-    # compatible with the SDK used for building.
-    excludes = (
-        "-isysroot", "-mmacosx", "-march", "-mtune", "-fdebug-prefix-map")
-    localenv["CCFLAGS"] = compiler_flag_list(localenv["CCFLAGS"], env["CC"], excludes)
-    localenv["CXXFLAGS"] = compiler_flag_list(localenv["CXXFLAGS"], env["CC"], excludes)
+pc_cflags.extend(f"-isystem {dir}" for dir in pc_incdirs if dir)
 
 # Generate cantera.pc for use with pkg-config
 localenv["pc_prefix"] = localenv["prefix"]
-localenv["pc_libdirs"] = " ".join(f"-L{dir}" for dir in pc_libdirs)
+localenv["pc_libdirs"] = " ".join(f"-L{dir}" for dir in pc_libdirs if dir)
 localenv["pc_libs"] = " ".join(f"-l{lib}" for lib in pc_libs)
-localenv["pc_incdirs"] = " ".join(f"-I{dir}" for dir in pc_incdirs)
-localenv["pc_cflags"] = " ".join(pc_cflags)
+localenv["pc_cflags"] = " ".join(compiler_flag_list(pc_cflags, env["CC"], flag_excludes))
 
 pc = build(localenv.SubstFile("cantera.pc", "cantera.pc.in"))
 install("$inst_libdir/pkgconfig", pc)

--- a/platform/posix/cantera.pc.in
+++ b/platform/posix/cantera.pc.in
@@ -9,4 +9,4 @@ URL: https://cantera.org
 Version: @cantera_version@
 
 Libs: -L${libdir} -Wl,-rpath,${libdir} @pc_libdirs@ @pc_libs@
-Cflags: @pc_cflags@ -I${includedir} @pc_incdirs@
+Cflags: @pc_cflags@ -isystem ${includedir}

--- a/samples/clib/SConscript
+++ b/samples/clib/SConscript
@@ -21,6 +21,11 @@ for programName, sources in samples:
         linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
         libdirs.extend(localenv["extra_lib_dirs"])
 
+    if env["OS"] == "Darwin" and env["use_rpath_linkage"] and not env.subst("$__RPATH"):
+        # SCons fails to specify RPATH on macOS, so circumvent that behavior by
+        # specifying this directly as part of LINKFLAGS
+        linkflags.extend(env.subst(f'$RPATHPREFIX{d}$RPATHSUFFIX') for d in libdirs)
+
     localenv["tmpl_compiler_flags"] = repr(localenv["CCFLAGS"])
     localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])
     localenv['tmpl_cantera_libs'] = repr(localenv['cantera_shared_libs'])

--- a/samples/clib/SConscript
+++ b/samples/clib/SConscript
@@ -14,19 +14,36 @@ for programName, sources in samples:
                 LIBPATH=env['extra_lib_dirs'] + ['#build/lib'])
 
     # Generate SConstruct files to be installed
-    linkflags = ["-g", localenv["thread_flags"]]
+    linkflags = [localenv["thread_flags"]]
+    flag_excludes = [r"\$\(", "/TP", r"\$\)", "/nologo"]
     incdirs = [localenv["ct_incroot"]]
-    libdirs = [localenv["ct_libdir"]] + localenv["extra_lib_dirs"]
-    if not localenv["package_build"]:
-        linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
-        libdirs.extend(localenv["extra_lib_dirs"])
+    libdirs = [localenv["ct_libdir"]]
 
     if env["OS"] == "Darwin" and env["use_rpath_linkage"] and not env.subst("$__RPATH"):
         # SCons fails to specify RPATH on macOS, so circumvent that behavior by
         # specifying this directly as part of LINKFLAGS
         linkflags.extend(env.subst(f'$RPATHPREFIX{d}$RPATHSUFFIX') for d in libdirs)
 
-    localenv["tmpl_compiler_flags"] = repr(localenv["CCFLAGS"])
+    if localenv['package_build']:
+        # For package builds, use environment variables or rely on SCons to find the
+        # default compiler
+        localenv['tmpl_cc'] = "env['CC'] = os.environ.get('CC', env['CC'])"
+
+        # Remove flags that are specific to the build host. Users should compile against
+        # their local SDKs, which should be backwards compatible with the SDK used for
+        # building.
+        flag_excludes.extend(["-isysroot", "-mmacosx", "-march", "-mtune",
+                              "-fdebug-prefix-map", ".*/_build_env/"])
+    else:
+        linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
+        libdirs.extend(localenv["extra_lib_dirs"])
+        # Otherwise, use the same compiler that was used to build Cantera, with the
+        # environment variables optionally overriding
+        localenv['tmpl_cc'] = env.subst("env['CC'] = os.environ.get('CC', '$CC')")
+
+    linkflags = compiler_flag_list(linkflags, env["CC"], flag_excludes)
+    localenv["tmpl_compiler_flags"] = repr(
+        compiler_flag_list(localenv["CCFLAGS"], env["CC"], flag_excludes))
     localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])
     localenv['tmpl_cantera_libs'] = repr(localenv['cantera_shared_libs'])
     localenv['tmpl_cantera_libdirs'] = repr([x for x in libdirs if x])
@@ -35,15 +52,6 @@ for programName, sources in samples:
 
     localenv['tmpl_progname'] = programName
     localenv['tmpl_sourcename'] = programName + '.c'
-
-    if localenv['package_build']:
-        # For package builds, use environment variables or rely on SCons to find the
-        # default compiler
-        localenv['tmpl_cc'] = "env['CC'] = os.environ.get('CC', env['CC'])"
-    else:
-        # Otherwise, use the same compiler that was used to build Cantera, with the
-        # environment variables optionally overriding
-        localenv['tmpl_cc'] = env.subst("env['CC'] = os.environ.get('CC', '$CC')")
 
     sconstruct = localenv.SubstFile('SConstruct', 'SConstruct.in')
     install("$inst_sampledir/clib", sconstruct)

--- a/samples/clib/SConscript
+++ b/samples/clib/SConscript
@@ -36,6 +36,15 @@ for programName, sources in samples:
     localenv['tmpl_progname'] = programName
     localenv['tmpl_sourcename'] = programName + '.c'
 
+    if localenv['package_build']:
+        # For package builds, use environment variables or rely on SCons to find the
+        # default compiler
+        localenv['tmpl_cc'] = "env['CC'] = os.environ.get('CC', env['CC'])"
+    else:
+        # Otherwise, use the same compiler that was used to build Cantera, with the
+        # environment variables optionally overriding
+        localenv['tmpl_cc'] = env.subst("env['CC'] = os.environ.get('CC', '$CC')")
+
     sconstruct = localenv.SubstFile('SConstruct', 'SConstruct.in')
     install("$inst_sampledir/clib", sconstruct)
 

--- a/samples/clib/SConstruct.in
+++ b/samples/clib/SConstruct.in
@@ -1,7 +1,7 @@
 import os
 env = Environment(ENV = os.environ)
 
-env['CC'] = '@CC@'
+@tmpl_cc@
 env.Append(CCFLAGS=@tmpl_compiler_flags@,
            CPPPATH=@tmpl_cantera_incdirs@,
            LIBS=@tmpl_cantera_libs@,

--- a/samples/clib/demo.c
+++ b/samples/clib/demo.c
@@ -24,9 +24,27 @@
 #include "cantera/clib/ctrpath.h"
 #include "cantera/clib/ctsurf.h"
 
+void exit_with_error()
+{
+    int buflen = 0;
+    char* output_buf = 0;
+    buflen = ct_getCanteraError(buflen, output_buf) + 1;
+    output_buf = malloc(sizeof(char) * buflen);
+    ct_getCanteraError(buflen, output_buf);
+    printf("%s", output_buf);
+    free(output_buf);
+    exit(1);
+}
+
 int main(int argc, char** argv)
 {
     int soln = soln_newSolution("gri30.yaml", "gri30", "");
+    // In principle, one ought to check for errors after every Cantera call. But this
+    // is the only one likely to occur in part of this example, due to the input file
+    // not being found.
+    if (soln < 0) {
+        exit_with_error();
+    }
     int thermo = soln_thermo(soln);
 
     thermo_setTemperature(thermo, 500);

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -102,19 +102,14 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}
         env_args.append('MSVC_VERSION={0!r}'.format(localenv['MSVC_VERSION']))
     localenv['tmpl_env_args'] = ', '.join(env_args)
 
-    if localenv["package_build"]:
-        # We do not want to specify the conda compilers from the build environment,
-        # because those won't be installed on the user's system.
-        if localenv["OS"] == "Darwin":
-            localenv["CXX"] = "clang++"
-            localenv["CC"] = "clang"
-        elif localenv["OS"] == "Windows":
-            # compilation needs the Visual Studio Command Prompt
-            localenv["CXX"] = "cl"
-            localenv["CC"] = "cl"
-        else:
-            localenv["CXX"] = "g++"
-            localenv["CC"] = "gcc"
+    if localenv['package_build']:
+        # For package builds, use environment variables or rely on SCons to find the
+        # default compiler
+        localenv['tmpl_cxx'] = "env['CXX'] = os.environ.get('CXX', env['CXX'])"
+    else:
+        # Otherwise, use the same compiler that was used to build Cantera, with the
+        # environment variables optionally overriding
+        localenv['tmpl_cxx'] = env.subst("env['CXX'] = os.environ.get('CXX', '$CXX')")
 
     sconstruct = localenv.SubstFile(pjoin(subdir, 'SConstruct'), 'SConstruct.in')
     install(pjoin('$inst_sampledir', 'cxx', subdir), sconstruct)

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -52,7 +52,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}
     # Note: These CMakeLists.txt and SConstruct files are automatically installed
     # by the "RecursiveInstall" that grabs everything in the cxx directory.
 
-    flag_excludes = ["$(", "/TP", "$)", "/nologo"]
+    flag_excludes = [r"\$\(", "/TP", r"\$\)", "/nologo"]
     incdirs = [localenv["ct_incroot"]]
     libdirs = [localenv["ct_libdir"]]
     if localenv["package_build"]:
@@ -60,8 +60,8 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}
         # conda package for now.
         # Users should compile against their local SDKs, which should be backwards
         # compatible with the SDK used for building.
-        flag_excludes.extend(["-isysroot", "-mmacosx", "-march", "-mtune"
-                              "-fdebug-prefix-map"])
+        flag_excludes.extend(["-isysroot", "-mmacosx", "-march", "-mtune",
+                              "-fdebug-prefix-map", ".*/_build_env/"])
     else:
         incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
         incdirs.append(localenv["hdf_include"])
@@ -78,7 +78,8 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}
                                    for d in libdirs])
 
     cc_flags = compiler_flag_list(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
-                                  flag_excludes)
+                                  env["CC"], flag_excludes)
+    link_flags = compiler_flag_list(localenv["LINKFLAGS"], env["CC"], flag_excludes)
     localenv["tmpl_compiler_flags"] = repr(cc_flags)
     localenv['tmpl_cantera_frameworks'] = repr(localenv['FRAMEWORKS'])
     localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])
@@ -90,7 +91,7 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}
         localenv['cmake_cantera_incdirs'] += ' "/usr/local/include"'
     localenv['tmpl_cantera_libdirs'] = repr([x for x in libdirs if x])
     localenv['cmake_cantera_libdirs'] = ' '.join(quoted(x) for x in libdirs if x)
-    localenv['tmpl_cantera_linkflags'] = repr(localenv['LINKFLAGS'])
+    localenv['tmpl_cantera_linkflags'] = repr(link_flags)
     localenv['tmpl_progname'] = name
     localenv['tmpl_sourcename'] = name + '.cpp'
     env_args = []

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -71,6 +71,12 @@ set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}
         libdirs.extend(localenv["extra_lib_dirs"])
         libdirs = list(set(libdirs))
 
+    if env["OS"] == "Darwin" and env["use_rpath_linkage"] and not env.subst("$__RPATH"):
+        # SCons fails to specify RPATH on macOS, so circumvent that behavior by
+        # specifying this directly as part of LINKFLAGS
+        localenv.Append(LINKFLAGS=[env.subst(f'$RPATHPREFIX{d}$RPATHSUFFIX')
+                                   for d in libdirs])
+
     cc_flags = compiler_flag_list(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
                                   flag_excludes)
     localenv["tmpl_compiler_flags"] = repr(cc_flags)

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -28,8 +28,8 @@ for subdir, name, extensions, openmp in samples:
 
         localenv['cmake_extra'] = """
 find_package(OpenMP REQUIRED)
-set(CMAKE_CXX_FLAGS ${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS})
-set(CMAKE_EXE_LINKER_FLAGS ${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS})
+set(CMAKE_CXX_FLAGS "${CMAKE_CXX_FLAGS} ${OpenMP_CXX_FLAGS}")
+set(CMAKE_EXE_LINKER_FLAGS "${CMAKE_EXE_LINKER_FLAGS} ${OpenMP_EXE_LINKER_FLAGS}")
 """
     else:
         localenv['cmake_extra'] = ''

--- a/samples/cxx/SConstruct.in
+++ b/samples/cxx/SConstruct.in
@@ -1,6 +1,7 @@
-env = Environment(@tmpl_env_args@)
+import os
+env = Environment(ENV=os.environ, @tmpl_env_args@)
 
-env['CXX'] = '@CXX@'
+@tmpl_cxx@
 env.Append(CCFLAGS=@tmpl_compiler_flags@,
            CPPPATH=@tmpl_cantera_incdirs@,
            LIBS=@tmpl_cantera_libs@,

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -24,7 +24,7 @@ for program_name, fortran_sources in samples:
 # Generate SConstruct file to be installed
 linkflags = ["-g", localenv["thread_flags"]]
 
-flag_excludes = ["$(", "/TP", "$)", "/nologo"]
+flag_excludes = [r"\$\(", "/TP", r"\$\)", "/nologo"]
 incdirs = [localenv["ct_incroot"]]
 libdirs = [localenv["ct_libdir"]]
 if localenv["package_build"]:
@@ -32,8 +32,8 @@ if localenv["package_build"]:
     # conda package for now.
     # Users should compile against their local SDKs, which should be backwards
     # compatible with the SDK used for building.
-    flag_excludes.extend(["-isysroot", "-mmacosx", "-march", "-mtune",
-                          "-fdebug-prefix-map"])
+    flag_excludes.extend(["-mmacosx", "-march", "-mtune", "-fdebug-prefix-map",
+                          "-isysroot", ".*/_build_env/"])
 else:
     linkflags.append(f"-Wl,-rpath,{localenv['ct_shlibdir']}")
 
@@ -50,7 +50,7 @@ else:
 libs = ["cantera_fortran"] + localenv["cantera_libs"] + localenv["cxx_stdlib"]
 
 cc_flags = compiler_flag_list(localenv["CCFLAGS"] + localenv["CXXFLAGS"],
-                              flag_excludes)
+                              env["CC"], flag_excludes)
 localenv["tmpl_compiler_flags"] = repr(cc_flags)
 localenv['tmpl_cantera_incdirs'] = repr([x for x in incdirs if x])
 localenv['tmpl_cantera_libs'] = repr(libs)

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -58,19 +58,16 @@ localenv['tmpl_cantera_libdirs'] = repr([x for x in libdirs if x])
 localenv['tmpl_cantera_linkflags'] = repr([x for x in linkflags if x])
 localenv['tmpl_cantera_frameworks'] = repr(localenv['FRAMEWORKS'])
 
-if localenv["package_build"]:
-    # We do not want to specify the conda compilers from the build environment,
-    # because those won't be installed on the user's system.
-    if localenv["OS"] == "Darwin":
-        localenv["F77"] = "gfortran"
-        localenv["CC"] = "clang"
-    elif env["OS"] == "Windows":
-        # compilation needs the Visual Studio Command Prompt
-        localenv["F77"] = "ifx"
-        localenv["CC"] = "cl"
-    else:
-        localenv["F77"] = "gfortran"
-        localenv["CC"] = "gcc"
+if localenv['package_build']:
+    # For package builds, use environment variables or rely on SCons to find the
+    # default compilers
+    localenv['tmpl_cc'] = "env['CC'] = os.environ.get('CC', env['CC'])"
+    localenv['tmpl_f77'] = "env['F77'] = os.environ.get('F77', env['F77'])"
+else:
+    # Otherwise, use the same compilers that were used to build Cantera, with the
+    # environment variables optionally overriding
+    localenv['tmpl_cc'] = env.subst("env['cc'] = os.environ.get('cc', '$cc')")
+    localenv['tmpl_f77'] = env.subst("env['F77'] = os.environ.get('F77', '$F77')")
 
 sconstruct = localenv.SubstFile('SConstruct', 'SConstruct.in')
 install("$inst_sampledir/f77", sconstruct)

--- a/samples/f77/SConstruct.in
+++ b/samples/f77/SConstruct.in
@@ -1,8 +1,8 @@
 import os
 env = Environment(ENV = os.environ)
 
-env['F77'] = '@F77@'
-env['CC'] = '@CC@'
+@tmpl_cc@
+@tmpl_f77@
 env.Append(FFLAGS='-g',
            CCFLAGS=@tmpl_compiler_flags@,
            CPPPATH=@tmpl_cantera_incdirs@,

--- a/samples/f90/SConscript
+++ b/samples/f90/SConscript
@@ -37,6 +37,15 @@ for programName, sources in samples:
     localenv['tmpl_progname'] = programName
     localenv['tmpl_sourcename'] = programName + '.f90'
 
+    if localenv['package_build']:
+        # For package builds, use environment variables or rely on SCons to find the
+        # default compiler
+        localenv['tmpl_f90'] = "env['F90'] = os.environ.get('F90', env['F90'])"
+    else:
+        # Otherwise, use the same compiler that was used to build Cantera, with the
+        # environment variables optionally overriding
+        localenv['tmpl_f90'] = env.subst("env['F90'] = os.environ.get('F90', '$F90')")
+
     sconstruct = localenv.SubstFile('SConstruct', 'SConstruct.in')
     install("$inst_sampledir/f90", sconstruct)
 

--- a/samples/f90/SConstruct.in
+++ b/samples/f90/SConstruct.in
@@ -1,7 +1,7 @@
 import os
 env = Environment(ENV = os.environ)
 
-env['F90'] = '@F90@'
+@tmpl_f90@
 env.Append(FFLAGS='-g',
            F90PATH=@tmpl_cantera_incdirs@,
            LIBS=@tmpl_cantera_libs@,

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -224,12 +224,14 @@ void Application::setDefaultDirectories()
     // environment variable).
 #ifdef _WIN32
     string pathsep = ";";
+    string dirsep = "\\";
 #else
     string pathsep = ":";
+    string dirsep = "/";
 #endif
 
-    if (getenv("CANTERA_DATA") != 0) {
-        string s = string(getenv("CANTERA_DATA"));
+    if (getenv("CANTERA_DATA") != nullptr) {
+        string s(getenv("CANTERA_DATA"));
         size_t start = 0;
         size_t end = s.find(pathsep);
         while (end != npos) {
@@ -238,6 +240,13 @@ void Application::setDefaultDirectories()
             end = s.find(pathsep, start);
         }
         inputDirs.push_back(s.substr(start,end));
+    }
+
+    // If a conda environment is active, add the location of the Cantera data directory
+    // that may exist in that environment.
+    if (getenv("CONDA_PREFIX") != nullptr) {
+        string s(getenv("CONDA_PREFIX"));
+        inputDirs.push_back(s + dirsep + "share" + dirsep + "cantera" + dirsep + "data");
     }
 
 #ifdef _WIN32

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1376,7 +1376,7 @@ class TestReactorJacobians(utilities.CanteraTest):
         net.derivative_settings = {"skip-coverage-dependence":True}
         net.initialize()
         # check that they two arrays are the same
-        self.assertArrayNear(r1.jacobian, r2.jacobian, 1e-6, 1e-8)
+        self.assertArrayNear(r1.jacobian, r2.jacobian, 2e-6, 1e-8)
 
 # A rate type used for testing integrator error handling
 class FailRateData(ct.ExtensibleRateData):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Fixes to resolve issues encountered while trying to update the conda-forge recipe (see conda-forge/cantera-feedstock#27), plus (unrelated) removal of a few unnecessary declarations.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Relax tolerance on `test_phase_order_surf_jacobian`, which was failing by a slim margin on ppc64le Linux builds
- Fix OpenMP flags in generated `CMakeLists.txt` files -- see https://gitlab.kitware.com/cmake/community/-/wikis/doc/cmake/VariablesListsStrings for some help understanding the rather non-intuitive CMake syntax.
- Implement workaround in sample SConstruct files for SCons ignoring `RPATH` on macOS
- Improve setting compiler in sample SConstruct files: do not set a default compiler for "package" builds, and allow the user to override using standard environment variables such as `CXX`
- Always allow the `conda` layout when using `package_build`
- Check return value of `soln_newSolution` in clib demo to avoid undefined behavior if the input file is not found
- Search the active conda environment for YAML files
- Fix cleanup of `-isysroot` flags in package builds
- Remove declaration for the method `MultiTransport::correctBinDiffCoeffs` which had no corresponding implementation
- Remove `friend` declarations from `DenseMatrix` -- these methods either don't exist with the specified signature (`invert`) or only access public members of the `DenseMatrix` class (`solve`) and don't need to be friends.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
