### PR TITLE
Fix issue #1593 in evaluating of lambda at boundary point.

### DIFF
--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -1027,12 +1027,11 @@ void StFlow::evalRightBoundary(double* x, double* rsd, int* diag, double rdt)
     diag[index(c_offset_Y + rightExcessSpecies(), j)] = 0;
     if (m_usesLambda) {
         rsd[index(c_offset_U, j)] = rho_u(x, j);
-        rsd[index(c_offset_L, j)] = lambda(x, j);
     } else {
         rsd[index(c_offset_U, j)] = rho_u(x, j) - rho_u(x, j-1);
-        rsd[index(c_offset_L, j)] = lambda(x, j) - lambda(x, j-1);
     }
 
+    rsd[index(c_offset_L, j)] = lambda(x, j) - lambda(x, j-1);
     diag[index(c_offset_L, j)] = 0;
     rsd[index(c_offset_T, j)] = T(x, j);
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- right boundary condition for lambda in evalRightBoundary function

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1593

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

Fix the bug of non-uniform lambda for strained flow.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
