### PR TITLE
Minor updates to oneD StFlow files.

### DIFF
--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -87,6 +87,8 @@ protected:
      * (@f$ \varepsilon_0 @f$).
      * The zero electric field is first evaluated and if the solution state is 2,
      * then the alternative form the electric field equation is evaluated.
+     *
+     * For argument explanation, see evalContinuity() base class.
      */
     void evalElectricField(double* x, double* rsd, int* diag,
                            double rdt, size_t jmin, size_t jmax) override;
@@ -98,6 +100,8 @@ protected:
      * A Neumann boundary for the charged species at the
      * left boundary is added, and the default boundary condition from the overloaded
      * method is left the same for the right boundary.
+     *
+     * For argument explanation, see evalContinuity() base class.
      */
     void evalSpecies(double* x, double* rsd, int* diag,
                      double rdt, size_t jmin, size_t jmax) override;

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -67,15 +67,34 @@ public:
                               vector<double>& mobi_e);
 
 protected:
-    /*!
-     * This function overloads the original electric field function.
-     * The residual function of a non-zero electric field is added.
+
+    /**
+     * @brief Evaluate the electric field equation residual by Gauss's law.
+     *
+     * The function calculates the electric field equation as:
+     * \f[
+     *    \frac{dE}{dz} = \frac{e}{\varepsilon_0} \sum (q_k \cdot n_k)
+     * \f]
+     * and
+     * \f[
+     *    E = -\frac{dV}{dz}
+     * \f]
+     *
+     * @details The electric field equation is a modified form based on Gauss's law,
+     * accounting for charge density and permittivity of free space
+     * (\f$ \varepsilon_0 \f$).
+     * The zero electric field is first evaluated and if the solution state is 2,
+     * then the alternative form the electric field equation is evaluated.
      */
     void evalElectricField(double* x, double* rsd, int* diag,
                            double rdt, size_t jmin, size_t jmax) override;
-    /*!
-     * This function overloads the original species function.
-     * A Neumann boundary for the charged species at the left boundary is added.
+    /**
+     * @brief Evaluate the species equations' residual. This function overloads the
+     * original species function.
+     *
+     * @details A Neumann boundary for the charged species at the
+     * left boundary is added, and the default boundary condition from the overloaded
+     * method is left the same for the right boundary.
      */
     void evalSpecies(double* x, double* rsd, int* diag,
                      double rdt, size_t jmin, size_t jmax) override;

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -68,11 +68,17 @@ public:
 
 protected:
     /*!
-     * This function overloads the original function. The residual function
-     * of electric field is added.
+     * This function overloads the original electric field function.
+     * The residual function of a non-zero electric field is added.
      */
-    void evalResidual(double* x, double* rsd, int* diag,
-                      double rdt, size_t jmin, size_t jmax) override;
+    void evalElectricField(double* x, double* rsd, int* diag,
+                           double rdt, size_t jmin, size_t jmax) override;
+    /*!
+     * This function overloads the original species function.
+     * A Neumann boundary for the charged species at the left boundary is added.
+     */
+    void evalSpecies(double* x, double* rsd, int* diag,
+                     double rdt, size_t jmin, size_t jmax) override;
     void updateTransport(double* x, size_t j0, size_t j1) override;
     void updateDiffFluxes(const double* x, size_t j0, size_t j1) override;
     //! Solving phase one: the fluxes of charged species are turned off

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -80,7 +80,7 @@ protected:
      *
      * @f[
      *    E = -\frac{dV}{dz}
-     * @cite]
+     * @f]
      *
      * The electric field equation is based on Gauss's law,
      * accounting for charge density and permittivity of free space

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -69,30 +69,33 @@ public:
 protected:
 
     /**
-     * @brief Evaluate the electric field equation residual by Gauss's law.
+     * Evaluate the electric field equation residual by Gauss's law.
      *
      * The function calculates the electric field equation as:
-     * \f[
+     * @f[
      *    \frac{dE}{dz} = \frac{e}{\varepsilon_0} \sum (q_k \cdot n_k)
-     * \f]
-     * and
-     * \f[
-     *    E = -\frac{dV}{dz}
-     * \f]
+     * @f]
      *
-     * @details The electric field equation is a modified form based on Gauss's law,
+     * and
+     *
+     * @f[
+     *    E = -\frac{dV}{dz}
+     * @cite]
+     *
+     * The electric field equation is based on Gauss's law,
      * accounting for charge density and permittivity of free space
-     * (\f$ \varepsilon_0 \f$).
+     * (@f$ \varepsilon_0 @f$).
      * The zero electric field is first evaluated and if the solution state is 2,
      * then the alternative form the electric field equation is evaluated.
      */
     void evalElectricField(double* x, double* rsd, int* diag,
                            double rdt, size_t jmin, size_t jmax) override;
+
     /**
-     * @brief Evaluate the species equations' residual. This function overloads the
+     * Evaluate the species equations' residual. This function overloads the
      * original species function.
      *
-     * @details A Neumann boundary for the charged species at the
+     * A Neumann boundary for the charged species at the
      * left boundary is added, and the default boundary condition from the overloaded
      * method is left the same for the right boundary.
      */

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -297,8 +297,7 @@ public:
      *  @param[out] rsdGlobal  Global residual vector
      *  @param[out] diagGlobal  Global boolean mask indicating whether each solution
      *      component has a time derivative (1) or not (0).
-     *  @param[in] rdt Reciprocal of the timestep (`rdt=0` implies steady-
-     *  state.)
+     *  @param[in] rdt Reciprocal of the timestep (`rdt=0` implies steady-state.)
      */
     void eval(size_t jGlobal, double* xGlobal, double* rsdGlobal,
               integer* diagGlobal, double rdt) override;
@@ -353,8 +352,8 @@ protected:
      *
      * Axisymmetric flame:
      *  The continuity equation propagates information from right-to-left.
-     *  The @f$ \rho u @f$ at point 0 is dependent on @f$ \rho u @f$ at point 1 but not
-     *  on @f$ \dot{m} @f$ from the inlet.
+     *  The @f$ \rho u @f$ at point 0 is dependent on @f$ \rho u @f$ at point 1,
+     *  but not on @f$ \dot{m} @f$ from the inlet.
      *
      * Freely-propagating flame:
      *  The continuity equation propagates information away from a fixed temperature
@@ -363,16 +362,18 @@ protected:
      * Unstrained flame:
      *  A specified mass flux; the main example being burner-stabilized flames.
      *
-     * The default boundary condition for the continuity equation is zero velocity
-     * (@f$ u @f$) at the left and right boundary.
+     * The default boundary condition for the continuity equation is
+     * (@f$ u = 0 @f$) at the left and right boundary.
      *
-     * @param [in] x State vector, includes variables like temperature, density, etc.
-     * @param [out] rsd Residual vector that stores the continuity equation residuals.
-     * @param [out] diag Diagonal matrix that controls whether an entry has a
-     *                   time-derivative (used by the solver).
-     * @param [in] rdt Reciprocal of the timestep.
-     * @param [in] jmin The index for the starting point in the grid.
-     * @param [in] jmax The index for the ending point in the grid.
+     * @param[in] x Local domain state vector, includes variables like temperature,
+     *               density, etc.
+     * @param[out] rsd Local domain residual vector that stores the continuity
+     *                  equation residuals.
+     * @param[out] diag Local domain diagonal matrix that controls whether an entry
+     *                   has a time-derivative (used by the solver).
+     * @param[in] rdt Reciprocal of the timestep.
+     * @param[in] jmin The index for the starting point in the local domain grid.
+     * @param[in] jmax The index for the ending point in the local domain grid.
      */
     virtual void evalContinuity(double* x, double* rsd, int* diag,
                                 double rdt, size_t jmin, size_t jmax);
@@ -390,6 +391,8 @@ protected:
      * terms for time and spatial variations of radial velocity (@f$ V @f$). The
      * default boundary condition is zero radial velocity (@f$ V @f$) at the left
      * and right boundary.
+     *
+     * For argument explanation, see evalContinuity().
      */
     virtual void evalMomentum(double* x, double* rsd, int* diag,
                               double rdt, size_t jmin, size_t jmax);
@@ -407,6 +410,8 @@ protected:
      * axisymmetric flows. The lambda equation propagates information from
      * left-to-right. The default boundary condition is @f$ \Lambda = 0 @f$
      * at the left and zero flux at the right boundary.
+     *
+     * For argument explanation, see evalContinuity().
      */
     virtual void evalLambda(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax);
@@ -426,6 +431,8 @@ protected:
      * chemical reactions and diffusion. Default is zero temperature (@f$ T @f$)
      * at the left and right boundaries. These boundary values are updated by the
      * specific boundary object connected to the domain.
+     *
+     * For argument explanation, see evalContinuity().
      */
     virtual void evalEnergy(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax);
@@ -441,6 +448,8 @@ protected:
      * The species equations include terms for temporal and spatial variations
      * of species mass fractions (@f$ Y_k @f$). The default boundary condition is zero
      * flux for species at the left and right boundary.
+     *
+     * For argument explanation, see evalContinuity().
      */
     virtual void evalSpecies(double* x, double* rsd, int* diag,
                              double rdt, size_t jmin, size_t jmax);
@@ -451,6 +460,8 @@ protected:
      * The electric field equation is implemented in the IonFlow class. The default
      * boundary condition is zero electric field (@f$ E @f$) at the boundary,
      * and @f$ E @f$ is zero within the domain.
+     *
+     * For argument explanation, see evalContinuity().
      */
     virtual void evalElectricField(double* x, double* rsd, int* diag,
                                    double rdt, size_t jmin, size_t jmax);

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -343,9 +343,9 @@ protected:
      * @f]
      *
      * The continuity equation propagates information from right-to-left.
-     * The \f$ \rho u \f$ at point 0 is dependent on \f$ \rho u \f$ at point 1 but not
-     * on \f$ \dot{m} \f$ from the inlet. The default value for the continuity equation
-     * is zero velocity (\f$ u \f$) at the left and right boundary.
+     * The @f$ \rho u @f$ at point 0 is dependent on @f$ \rho u @f$ at point 1 but not
+     * on @f$ \dot{m} @f$ from the inlet. The default value for the continuity equation
+     * is zero velocity (@f$ u @f$) at the left and right boundary.
      */
     virtual void evalContinuity(double* x, double* rsd, int* diag,
                                 double rdt, size_t jmin, size_t jmax);
@@ -360,8 +360,8 @@ protected:
      * @f]
      *
      * The radial momentum equation incorporates terms for temporal and spatial
-     * variations of radial velocity (\f$ V \f$). The default boundary condition is zero
-     * radial velocity (\f$ V \f$) at the left and right boundary.
+     * variations of radial velocity (@f$ V @f$). The default boundary condition is zero
+     * radial velocity (@f$ V @f$) at the left and right boundary.
      */
     virtual void evalMomentum(double* x, double* rsd, int* diag,
                               double rdt, size_t jmin, size_t jmax);
@@ -377,7 +377,7 @@ protected:
      * The lambda equation serves as an eigenvalue that allows the momentum
      * equation and continuity equations to be simultaneously satisfied. The lambda
      * equation propgates information from left-to-right. The default
-     * boundary condition is zero (\f$ \lambda \f$) at the left and zero flux at
+     * boundary condition is zero (@f$ \lambda @f$) at the left and zero flux at
      * the right boundary.
      */
     virtual void evalLambda(double* x, double* rsd, int* diag,
@@ -394,8 +394,8 @@ protected:
      * @f]
      *
      * The energy equation includes terms for temporal and spatial
-     * variations of temperature (\f$ T \f$). It includes contributions from
-     * chemical reactions and diffusion. Default is zero temperature (\f$ T \f$)
+     * variations of temperature (@f$ T @f$). It includes contributions from
+     * chemical reactions and diffusion. Default is zero temperature (@f$ T @f$)
      * at the left and right.
      */
     virtual void evalEnergy(double* x, double* rsd, int* diag,
@@ -410,7 +410,7 @@ protected:
      * @f]
      *
      * The species equations include terms for temporal and spatial variations
-     * of species mass fractions (\f$ Y_k \f$). The default boundary condition is zero
+     * of species mass fractions (@f$ Y_k @f$). The default boundary condition is zero
      * flux for species at the left and right boundary.
      */
     virtual void evalSpecies(double* x, double* rsd, int* diag,
@@ -420,8 +420,8 @@ protected:
      * Evaluate the electric field equation residual to be zero everywhere.
      *
      * The electric field equation is implemnted in the IonFlow class. The default
-     * boundary condition is zero electric field (\f$ E \f$) at the boundary,
-     * and \f$ E \f$ is zero within the domain.
+     * boundary condition is zero electric field (@f$ E @f$) at the boundary,
+     * and @f$ E @f$ is zero within the domain.
      */
     virtual void evalElectricField(double* x, double* rsd, int* diag,
                                    double rdt, size_t jmin, size_t jmax);

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -322,12 +322,6 @@ protected:
         return m_wdot(k,j);
     }
 
-    //! Write the net production rates at point `j` into array `m_wdot`
-    void getWdot(double* x, size_t j) {
-        setGas(x,j);
-        m_kin->getNetProductionRates(&m_wdot(0,j));
-    }
-
     //! Update the properties (thermo, transport, and diffusion flux).
     //! This function is called in eval after the points which need
     //! to be updated are defined.

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -367,6 +367,23 @@ protected:
                               double rdt, size_t jmin, size_t jmax);
 
     /**
+     * Evaluate the lambda equation residual.
+     *
+     * The function calculates the lambda equation as
+     * @f[
+     *    \frac{d\lambda}{dz} = 0
+     * @f]
+     *
+     * The lambda equation serves as an eigenvalue that allows the momentum
+     * equation and continuity equations to be simultaneously satisfied. The lambda
+     * equation propgates information from left-to-right. The default
+     * boundary condition is zero (\f$ \lambda \f$) at the left and zero flux at
+     * the right boundary.
+     */
+    virtual void evalLambda(double* x, double* rsd, int* diag,
+                            double rdt, size_t jmin, size_t jmax);
+
+    /**
      * Evaluate the energy equation residual.
      *
      * The function calculates the energy equation:
@@ -398,23 +415,6 @@ protected:
      */
     virtual void evalSpecies(double* x, double* rsd, int* diag,
                              double rdt, size_t jmin, size_t jmax);
-
-    /**
-     * Evaluate the lambda equation residual.
-     *
-     * The function calculates the lambda equation as
-     * @f[
-     *    \frac{d\lambda}{dz} = 0
-     * @f]
-     *
-     * The lambda equation serves as an eigenvalue that allows the momentum
-     * equation and continuity equations to be simultaneously satisfied. The lambda
-     * equation propgates information from left-to-right. The default
-     * boundary condition is zero (\f$ \lambda \f$) at the left and zero flux at
-     * the right boundary.
-     */
-    virtual void evalLambda(double* x, double* rsd, int* diag,
-                            double rdt, size_t jmin, size_t jmax);
 
     /**
      * Evaluate the electric field equation residual to be zero everywhere.

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -366,8 +366,8 @@ protected:
      * The default boundary condition for the continuity equation is zero velocity
      * (@f$ u @f$) at the left and right boundary.
      *
-     * @param [in] x State vector, which includes variables like temperature, density, etc.
-     * @param [out] rsd Residual vector where the continuity equation residuals are stored.
+     * @param [in] x State vector, includes variables like temperature, density, etc.
+     * @param [out] rsd Residual vector that stores the continuity equation residuals.
      * @param [out] diag Diagonal matrix that controls whether an entry has a
      *                   time-derivative (used by the solver).
      * @param [in] rdt Reciprocal of the timestep.

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -206,18 +206,6 @@ public:
     virtual bool doElectricField(size_t j) const;
 
     //! Turn radiation on / off.
-    /*!
-     * The simple radiation model used was established by Liu and Rogg
-     * @cite liu1991. This model considers the radiation of CO2 and H2O.
-     *
-     * This model uses the optically thin limit and the gray-gas approximation to
-     * simply calculate a volume specified heat flux out of the Planck absorption
-     * coefficients, the boundary emissivities and the temperature. Polynomial lines
-     * calculate the species Planck coefficients for H2O and CO2. The data for the
-     * lines are taken from the RADCAL program @cite RADCAL.
-     * The coefficients for the polynomials are taken from
-     * [TNF Workshop](https://tnfworkshop.org/radiation/) material.
-     */
     void enableRadiation(bool doRadiation) {
         m_do_radiation = doRadiation;
     }
@@ -231,10 +219,6 @@ public:
     double radiativeHeatLoss(size_t j) const {
         return m_qdotRadiation[j];
     }
-
-    //! Computes the radiative heat loss vector over points jmin to jmax and stores
-    //! the data in the qdotRadiation variable.
-    void computeRadiation(double* x, size_t jmin, size_t jmax);
 
     //! Set the emissivities for the boundary values
     /*!
@@ -296,11 +280,17 @@ public:
     }
 
     /**
-     *  Evaluate the residual function for axisymmetric stagnation flow. If
-     *  j == npos, the residual function is evaluated at all grid points.
-     *  Otherwise, the residual function is only evaluated at grid points
-     *  j-1, j, and j+1. This option is used to efficiently evaluate the
-     *  Jacobian numerically.
+     * Evaluate the residual functions for axisymmetric stagnation flow. If j == npos,
+     * the residual function is evaluated at all grid points. Otherwise, the residual
+     * function is only evaluated at grid points j-1, j, and j+1. This option is used
+     * to efficiently evaluate the Jacobian numerically.
+     *
+     * These residuals at all the boundary grid points are evaluated using a default
+     * boundary condition that may be modified by a boundary object that is attached
+     * to the domain.The boundary object connected will modify these equations by
+     * subtracting the boundary object's values for V, T, mdot, etc. As a result,
+     * these residual equations will force the solution variables to the values of
+     * the connected boundary object.
      */
     void eval(size_t j, double* x, double* r, integer* mask, double rdt) override;
 
@@ -328,103 +318,111 @@ protected:
     virtual void updateProperties(size_t jg, double* x, size_t jmin, size_t jmax);
 
     /**
-    * @brief Evaluate the continuity equation residual.
-    *
-    * This function calculates the residual of the continuity equation
-    * @f[
-    *     \frac{d(\rho u)}{dz} + 2\rho V = 0
-    * @f]
-    *
-    * @details The continuity equation propagates information from right-to-left.
-    * The \f$ \rho u \f$ at point 0 is dependent on \f$ \rho u \f$ at point 1 but not
-    * on \f$ \dot{m} \f$ from the inlet. The default value for the continuity equation
-    * is zero velocity (\f$ u \f$) at the left and right boundary.
-    */
+     * Computes the radiative heat loss vector over points jmin to jmax and stores
+     * the data in the qdotRadiation variable.
+     *
+     * The simple radiation model used was established by Liu and Rogg
+     * @cite liu1991. This model considers the radiation of CO2 and H2O.
+     *
+     * This model uses the optically thin limit and the gray-gas approximation to
+     * simply calculate a volume specified heat flux out of the Planck absorption
+     * coefficients, the boundary emissivities and the temperature. Polynomial lines
+     * calculate the species Planck coefficients for H2O and CO2. The data for the
+     * lines are taken from the RADCAL program @cite RADCAL.
+     * The coefficients for the polynomials are taken from
+     * [TNF Workshop](https://tnfworkshop.org/radiation/) material.
+     */
+    void computeRadiation(double* x, size_t jmin, size_t jmax);
+
+    /**
+     * Evaluate the continuity equation residual.
+     *
+     * This function calculates the residual of the continuity equation
+     * @f[
+     *     \frac{d(\rho u)}{dz} + 2\rho V = 0
+     * @f]
+     *
+     * The continuity equation propagates information from right-to-left.
+     * The \f$ \rho u \f$ at point 0 is dependent on \f$ \rho u \f$ at point 1 but not
+     * on \f$ \dot{m} \f$ from the inlet. The default value for the continuity equation
+     * is zero velocity (\f$ u \f$) at the left and right boundary.
+     */
     virtual void evalContinuity(double* x, double* rsd, int* diag,
                                 double rdt, size_t jmin, size_t jmax);
 
     /**
-    * @brief Evaluate the momentum equation residual.
-    *
-    * The function calculates the radial momentum equation defined as
-    * \f[
-    *    \rho \frac{dV}{dt} + \rho u \frac{dV}{dz} + \rho V^2 =
-    *    \frac{d(\mu \frac{dV}{dz})}{dz} - \lambda
-    * \f]
-    *
-    * @details The radial momentum equation incorporates terms for temporal and spatial
-    * variations of radial velocity (\f$ V \f$). The default boundary condition is zero
-    * radial velocity (\f$ V \f$) at the left and right boundary.
-    */
+     * Evaluate the momentum equation residual.
+     *
+     * The function calculates the radial momentum equation defined as
+     * @f[
+     *    \rho \frac{dV}{dt} + \rho u \frac{dV}{dz} + \rho V^2 =
+     *    \frac{d(\mu \frac{dV}{dz})}{dz} - \lambda
+     * @f]
+     *
+     * The radial momentum equation incorporates terms for temporal and spatial
+     * variations of radial velocity (\f$ V \f$). The default boundary condition is zero
+     * radial velocity (\f$ V \f$) at the left and right boundary.
+     */
     virtual void evalMomentum(double* x, double* rsd, int* diag,
                               double rdt, size_t jmin, size_t jmax);
 
     /**
-    * @brief Evaluate the energy equation residual.
-    *
-    * The function calculates the energy equation:
-    * \f[
-    *    \rho c_p \frac{dT}{dt} + \rho c_p u \frac{dT}{dz} =
-    *    \frac{d(k \frac{dT}{dz})}{dz} - \sum_k (\omega_k h_{k_{\text{ref}}}) -
-    *    \sum_k \left( \frac{J_k c_{p_k}}{M_k} \frac{dT}{dz} \right)
-    * \f]
-    *
-    * @details The energy equation includes terms for temporal and spatial
-    * variations of temperature (\f$ T \f$). It includes contributions from
-    * chemical reactions and diffusion. Default is zero temperature (\f$ T \f$)
-    * at the left and right.
-    */
+     * Evaluate the energy equation residual.
+     *
+     * The function calculates the energy equation:
+     * @f[
+     *    \rho c_p \frac{dT}{dt} + \rho c_p u \frac{dT}{dz} =
+     *    \frac{d(k \frac{dT}{dz})}{dz} - \sum_k (\omega_k h_{k_{\text{ref}}}) -
+     *    \sum_k \left( \frac{J_k c_{p_k}}{M_k} \frac{dT}{dz} \right)
+     * @f]
+     *
+     * The energy equation includes terms for temporal and spatial
+     * variations of temperature (\f$ T \f$). It includes contributions from
+     * chemical reactions and diffusion. Default is zero temperature (\f$ T \f$)
+     * at the left and right.
+     */
     virtual void evalEnergy(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax);
 
     /**
-    * @brief Evaluate the species equations' residuals.
-    *
-    * The function calculates the species equations as
-    * \f[
-    *    \rho \frac{dY_k}{dt} + \rho u \frac{dY_k}{dz} + \frac{dJ_k}{dz} = M_k\omega_k
-    * \f]
-    *
-    * @details The species equations include terms for temporal and spatial variations
-    * of species mass fractions (\f$ Y_k \f$). The default boundary condition is zero
-    * flux for species at the left and right boundary.
-    */
+     * Evaluate the species equations' residuals.
+     *
+     * The function calculates the species equations as
+     * @f[
+     *    \rho \frac{dY_k}{dt} + \rho u \frac{dY_k}{dz} + \frac{dJ_k}{dz} = M_k\omega_k
+     * @f]
+     *
+     * The species equations include terms for temporal and spatial variations
+     * of species mass fractions (\f$ Y_k \f$). The default boundary condition is zero
+     * flux for species at the left and right boundary.
+     */
     virtual void evalSpecies(double* x, double* rsd, int* diag,
                              double rdt, size_t jmin, size_t jmax);
 
     /**
-    * @brief Evaluate the lambda equation residual.
-    *
-    * The function calculates the lambda equation as
-    * \f[
-    *    \frac{d\lambda}{dz} = 0
-    * \f]
-    *
-    * @details The lambda equation serves as an eigenvalue that allows the momentum
-    * equation and continuity equations to be simultaneously satisfied. The lambda
-    * equation propgates information from left-to-right. The default
-    * boundary condition is zero (\f$ \lambda \f$) at the left and zero flux at
-    * the right boundary.
-    */
+     * Evaluate the lambda equation residual.
+     *
+     * The function calculates the lambda equation as
+     * @f[
+     *    \frac{d\lambda}{dz} = 0
+     * @f]
+     *
+     * The lambda equation serves as an eigenvalue that allows the momentum
+     * equation and continuity equations to be simultaneously satisfied. The lambda
+     * equation propgates information from left-to-right. The default
+     * boundary condition is zero (\f$ \lambda \f$) at the left and zero flux at
+     * the right boundary.
+     */
     virtual void evalLambda(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax);
 
     /**
-    * @brief Evaluate the electric field equation residual using Gauss's law.
-    *
-    * The function calculates the electric field equation as:
-    * \f[
-    *    \frac{dE}{dz} = 0
-    * \f]
-    * and
-    * \f[
-    *    E = -\frac{dV}{dz}
-    * \f]
-    *
-    * @details The electric field equation is based on Gauss's law. The default
-    * boundary condition is zero electric field (\f$ E \f$) at the boundary,
-    * and \f$ E \f$ is zero within the domain.
-    */
+     * Evaluate the electric field equation residual to be zero everywhere.
+     *
+     * The electric field equation is implemnted in the IonFlow class. The default
+     * boundary condition is zero electric field (\f$ E \f$) at the boundary,
+     * and \f$ E \f$ is zero within the domain.
+     */
     virtual void evalElectricField(double* x, double* rsd, int* diag,
                                    double rdt, size_t jmin, size_t jmax);
 

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -287,7 +287,7 @@ public:
      *
      * These residuals at all the boundary grid points are evaluated using a default
      * boundary condition that may be modified by a boundary object that is attached
-     * to the domain.The boundary object connected will modify these equations by
+     * to the domain. The boundary object connected will modify these equations by
      * subtracting the boundary object's values for V, T, mdot, etc. As a result,
      * these residual equations will force the solution variables to the values of
      * the connected boundary object.
@@ -342,10 +342,20 @@ protected:
      *     \frac{d(\rho u)}{dz} + 2\rho V = 0
      * @f]
      *
-     * The continuity equation propagates information from right-to-left.
-     * The @f$ \rho u @f$ at point 0 is dependent on @f$ \rho u @f$ at point 1 but not
-     * on @f$ \dot{m} @f$ from the inlet. The default value for the continuity equation
-     * is zero velocity (@f$ u @f$) at the left and right boundary.
+     * Axisymmetric flame:
+     *  The continuity equation propagates information from right-to-left.
+     *  The @f$ \rho u @f$ at point 0 is dependent on @f$ \rho u @f$ at point 1 but not
+     *  on @f$ \dot{m} @f$ from the inlet.
+     *
+     * Freely-propagating flame:
+     *  The continuity equation propagates information away from a fixed temperature
+     *  point that is set in the domain.
+     *
+     * Unstrained flame: specified mass flux; the main example being
+     *   burner-stabilized flames.
+     *
+     * The default boundary condition for the continuity equation is zero velocity
+     * (@f$ u @f$) at the left and right boundary.
      */
     virtual void evalContinuity(double* x, double* rsd, int* diag,
                                 double rdt, size_t jmin, size_t jmax);
@@ -355,13 +365,14 @@ protected:
      *
      * The function calculates the radial momentum equation defined as
      * @f[
-     *    \rho \frac{dV}{dt} + \rho u \frac{dV}{dz} + \rho V^2 =
-     *    \frac{d(\mu \frac{dV}{dz})}{dz} - \lambda
+     *    \rho u \frac{dV}{dz} + \rho V^2 =
+     *    \frac{d(\mu \frac{dV}{dz})}{dz} - \Lambda
      * @f]
      *
-     * The radial momentum equation incorporates terms for temporal and spatial
-     * variations of radial velocity (@f$ V @f$). The default boundary condition is zero
-     * radial velocity (@f$ V @f$) at the left and right boundary.
+     * The radial momentum equation is used for axisymmetric flows, and incorporates
+     * terms for time and spatial variations of radial velocity (@f$ V @f$). The
+     * default boundary condition is zero radial velocity (@f$ V @f$) at the left
+     * and right boundary.
      */
     virtual void evalMomentum(double* x, double* rsd, int* diag,
                               double rdt, size_t jmin, size_t jmax);
@@ -371,14 +382,14 @@ protected:
      *
      * The function calculates the lambda equation as
      * @f[
-     *    \frac{d\lambda}{dz} = 0
+     *    \frac{d\Lambda}{dz} = 0
      * @f]
      *
      * The lambda equation serves as an eigenvalue that allows the momentum
-     * equation and continuity equations to be simultaneously satisfied. The lambda
-     * equation propgates information from left-to-right. The default
-     * boundary condition is zero (@f$ \lambda @f$) at the left and zero flux at
-     * the right boundary.
+     * equation and continuity equations to be simultaneously satisfied in
+     * axisymmetric flows. The lambda equation propgates information from
+     * left-to-right. The default boundary condition is zero (@f$ \Lambda @f$)
+     * at the left and zero flux at the right boundary.
      */
     virtual void evalLambda(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax);
@@ -388,15 +399,15 @@ protected:
      *
      * The function calculates the energy equation:
      * @f[
-     *    \rho c_p \frac{dT}{dt} + \rho c_p u \frac{dT}{dz} =
+     *    \rho c_p u \frac{dT}{dz} =
      *    \frac{d(k \frac{dT}{dz})}{dz} - \sum_k (\omega_k h_{k_{\text{ref}}}) -
      *    \sum_k \left( \frac{J_k c_{p_k}}{M_k} \frac{dT}{dz} \right)
      * @f]
      *
-     * The energy equation includes terms for temporal and spatial
-     * variations of temperature (@f$ T @f$). It includes contributions from
+     * The energy equation includes contributions from
      * chemical reactions and diffusion. Default is zero temperature (@f$ T @f$)
-     * at the left and right.
+     * at the left and right boundaries. These boundary values are updated by the
+     * specific boundary object connected to the domain.
      */
     virtual void evalEnergy(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax);
@@ -406,7 +417,7 @@ protected:
      *
      * The function calculates the species equations as
      * @f[
-     *    \rho \frac{dY_k}{dt} + \rho u \frac{dY_k}{dz} + \frac{dJ_k}{dz} = M_k\omega_k
+     *    \rho u \frac{dY_k}{dz} + \frac{dJ_k}{dz} = M_k\omega_k
      * @f]
      *
      * The species equations include terms for temporal and spatial variations

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -327,27 +327,104 @@ protected:
     //! to be updated are defined.
     virtual void updateProperties(size_t jg, double* x, size_t jmin, size_t jmax);
 
-    //! Evaluate the residual function for the continuity equation.
+    /**
+    * @brief Evaluate the continuity equation residual.
+    *
+    * This function calculates the residual of the continuity equation
+    * @f[
+    *     \frac{d(\rho u)}{dz} + 2\rho V = 0
+    * @f]
+    *
+    * @details The continuity equation propagates information from right-to-left.
+    * The \f$ \rho u \f$ at point 0 is dependent on \f$ \rho u \f$ at point 1 but not
+    * on \f$ \dot{m} \f$ from the inlet. The default value for the continuity equation
+    * is zero velocity (\f$ u \f$) at the left and right boundary.
+    */
     virtual void evalContinuity(double* x, double* rsd, int* diag,
                                 double rdt, size_t jmin, size_t jmax);
 
-    //! Evaluate the residual function for the momentum equation.
+    /**
+    * @brief Evaluate the momentum equation residual.
+    *
+    * The function calculates the radial momentum equation defined as
+    * \f[
+    *    \rho \frac{dV}{dt} + \rho u \frac{dV}{dz} + \rho V^2 =
+    *    \frac{d(\mu \frac{dV}{dz})}{dz} - \lambda
+    * \f]
+    *
+    * @details The radial momentum equation incorporates terms for temporal and spatial
+    * variations of radial velocity (\f$ V \f$). The default boundary condition is zero
+    * radial velocity (\f$ V \f$) at the left and right boundary.
+    */
     virtual void evalMomentum(double* x, double* rsd, int* diag,
                               double rdt, size_t jmin, size_t jmax);
 
-    //! Evaluate the residual function for the energy equation.
+    /**
+    * @brief Evaluate the energy equation residual.
+    *
+    * The function calculates the energy equation:
+    * \f[
+    *    \rho c_p \frac{dT}{dt} + \rho c_p u \frac{dT}{dz} =
+    *    \frac{d(k \frac{dT}{dz})}{dz} - \sum_k (\omega_k h_{k_{\text{ref}}}) -
+    *    \sum_k \left( \frac{J_k c_{p_k}}{M_k} \frac{dT}{dz} \right)
+    * \f]
+    *
+    * @details The energy equation includes terms for temporal and spatial
+    * variations of temperature (\f$ T \f$). It includes contributions from
+    * chemical reactions and diffusion. Default is zero temperature (\f$ T \f$)
+    * at the left and right.
+    */
     virtual void evalEnergy(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax);
 
-    //! Evaluate the residual function for the species equation.
+    /**
+    * @brief Evaluate the species equations' residuals.
+    *
+    * The function calculates the species equations as
+    * \f[
+    *    \rho \frac{dY_k}{dt} + \rho u \frac{dY_k}{dz} + \frac{dJ_k}{dz} = M_k\omega_k
+    * \f]
+    *
+    * @details The species equations include terms for temporal and spatial variations
+    * of species mass fractions (\f$ Y_k \f$). The default boundary condition is zero
+    * flux for species at the left and right boundary.
+    */
     virtual void evalSpecies(double* x, double* rsd, int* diag,
                              double rdt, size_t jmin, size_t jmax);
 
-    //! Evaluate the residual function for the lambda equation.
+    /**
+    * @brief Evaluate the lambda equation residual.
+    *
+    * The function calculates the lambda equation as
+    * \f[
+    *    \frac{d\lambda}{dz} = 0
+    * \f]
+    *
+    * @details The lambda equation serves as an eigenvalue that allows the momentum
+    * equation and continuity equations to be simultaneously satisfied. The lambda
+    * equation propgates information from left-to-right. The default
+    * boundary condition is zero (\f$ \lambda \f$) at the left and zero flux at
+    * the right boundary.
+    */
     virtual void evalLambda(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax);
 
-    //! Evaluate the residual function for the lambda equation.
+    /**
+    * @brief Evaluate the electric field equation residual using Gauss's law.
+    *
+    * The function calculates the electric field equation as:
+    * \f[
+    *    \frac{dE}{dz} = 0
+    * \f]
+    * and
+    * \f[
+    *    E = -\frac{dV}{dz}
+    * \f]
+    *
+    * @details The electric field equation is based on Gauss's law. The default
+    * boundary condition is zero electric field (\f$ E \f$) at the boundary,
+    * and \f$ E \f$ is zero within the domain.
+    */
     virtual void evalElectricField(double* x, double* rsd, int* diag,
                                    double rdt, size_t jmin, size_t jmax);
 

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -225,9 +225,6 @@ void IonFlow::evalElectricField(double* x, double* rsd, int* diag,
 void IonFlow::evalSpecies(double* x, double* rsd, int* diag,
                           double rdt, size_t jmin, size_t jmax)
 {
-    //-----------------------------------------------
-    //    Species equations
-    //-----------------------------------------------
     StFlow::evalSpecies(x, rsd, diag, rdt, jmin, jmax);
     if (m_stage != 2) {
         return;
@@ -246,7 +243,6 @@ void IonFlow::evalSpecies(double* x, double* rsd, int* diag,
         }
     }
 }
-
 
 void IonFlow::solveElectricField(size_t j)
 {

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -199,16 +199,10 @@ void IonFlow::setSolvingStage(const size_t stage)
     }
 }
 
+//! Evaluate the electric field equation residual
 void IonFlow::evalElectricField(double* x, double* rsd, int* diag,
                                 double rdt, size_t jmin, size_t jmax)
 {
-    //-----------------------------------------------
-    //    Electric field by Gauss's law
-    //
-    //    dE/dz = e/eps_0 * sum(q_k*n_k)
-    //
-    //    E = -dV/dz
-    //-----------------------------------------------
     StFlow::evalElectricField(x, rsd, diag, rdt, jmin, jmax);
     if (m_stage != 2) {
         return;

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -211,14 +211,12 @@ void IonFlow::evalElectricField(double* x, double* rsd, int* diag,
     for (size_t j = jmin; j <= jmax; j++) {
         if (j == 0) {
             rsd[index(c_offset_E, j)] = E(x,0);
-            diag[index(c_offset_E, j)] = 0;
         } else if (j == m_points - 1) {
             rsd[index(c_offset_E, j)] = dEdz(x,j) - rho_e(x,j) / epsilon_0;
-            diag[index(c_offset_E, j)] = 0;
         } else {
             rsd[index(c_offset_E, j)] = dEdz(x,j) - rho_e(x,j) / epsilon_0;
-            diag[index(c_offset_E, j)] = 0;
         }
+        diag[index(c_offset_E, j)] = 0;
     }
 }
 
@@ -238,8 +236,6 @@ void IonFlow::evalSpecies(double* x, double* rsd, int* diag,
             for (size_t k : m_kCharge) {
                 rsd[index(c_offset_Y + k, 0)] = Y(x,k,0) - Y(x,k,1);
             }
-        } else if (j == m_points - 1) { // right boundary
-        } else { // interior points
         }
     }
 }

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -293,30 +293,31 @@ void StFlow::_finalize(const double* x)
     }
 }
 
-void StFlow::eval(size_t j_global, double* x_global, double* rsd_global, integer* diag_global, double rdt)
+void StFlow::eval(size_t jGlobal, double* xGlobal, double* rsdGlobal,
+                  integer* diagGlobal, double rdt)
 {
     // If evaluating a Jacobian, and the global point is outside the domain of
     // influence for this domain, then skip evaluating the residual
-    if (j_global != npos && (j_global + 1 < firstPoint() || j_global > lastPoint() + 1)) {
+    if (jGlobal != npos && (jGlobal + 1 < firstPoint() || jGlobal > lastPoint() + 1)) {
         return;
     }
 
     // start of local part of global arrays
-    double* x = x_global + loc();
-    double* rsd = rsd_global + loc();
-    integer* diag = diag_global + loc();
+    double* x = xGlobal + loc();
+    double* rsd = rsdGlobal + loc();
+    integer* diag = diagGlobal + loc();
 
     size_t jmin, jmax;
-    if (j_global == npos) { // evaluate all points
+    if (jGlobal == npos) { // evaluate all points
         jmin = 0;
         jmax = m_points - 1;
     } else { // evaluate points for Jacobian
-        size_t jpt = (j_global == 0) ? 0 : j_global - firstPoint();
+        size_t jpt = (jGlobal == 0) ? 0 : jGlobal - firstPoint();
         jmin = std::max<size_t>(jpt, 1) - 1;
         jmax = std::min(jpt+1,m_points-1);
     }
 
-    updateProperties(j_global, x, jmin, jmax);
+    updateProperties(jGlobal, x, jmin, jmax);
 
     if (m_do_radiation) { // Calculation of qdotRadiation
         computeRadiation(x, jmin, jmax);

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -431,17 +431,10 @@ void StFlow::updateDiffFluxes(const double* x, size_t j0, size_t j1)
     }
 }
 
+//! Evaluate the continuity equation residual.
 void StFlow::evalContinuity(double* x, double* rsd, int* diag,
-                          double rdt, size_t jmin, size_t jmax)
+                            double rdt, size_t jmin, size_t jmax)
 {
-    //----------------------------------------------
-    //    Continuity equation
-    //
-    //    d(\rho u)/dz + 2\rho V = 0
-    //----------------------------------------------
-    // This propagates information right-to-left, since rho_u at point 0 is dependent
-    // on rho_u at point 1, but not on mdot from the inlet.
-    // The default value for continuity is zero u at the boundary.
     for (size_t j = jmin; j <= jmax; j++) {
         if (j == 0) { // left boundary
             rsd[index(c_offset_U,0)] =
@@ -486,16 +479,11 @@ void StFlow::evalContinuity(double* x, double* rsd, int* diag,
     }
 }
 
+
+//! Evaluate the momentum equation residual.
 void StFlow::evalMomentum(double* x, double* rsd, int* diag,
                           double rdt, size_t jmin, size_t jmax)
 {
-    //------------------------------------------------
-    //    Radial momentum equation
-    //
-    //    \rho dV/dt + \rho u dV/dz + \rho V^2
-    //       = d(\mu dV/dz)/dz - lambda
-    //-------------------------------------------------
-    // The default boundary condition is zero V.
     for (size_t j = jmin; j <= jmax; j++) {
         if (j == 0) { // left boundary
             rsd[index(c_offset_V,0)] = V(x,0);
@@ -517,19 +505,11 @@ void StFlow::evalMomentum(double* x, double* rsd, int* diag,
     }
 }
 
+
+//! Evaluate the energy equation residual.
 void StFlow::evalEnergy(double* x, double* rsd, int* diag,
                         double rdt, size_t jmin, size_t jmax)
 {
-    //-----------------------------------------------
-    //    Energy equation
-    //
-    //    \rho c_p dT/dt + \rho c_p u dT/dz
-    //    = d(k dT/dz)/dz
-    //      - sum_k(\omega_k h_k_ref)
-    //      - sum_k(J_k c_p_k / M_k) dT/dz
-    //-----------------------------------------------
-    // The default boundary condition for energy is a zero T.
-
     // Calculation of qdotRadiation (see docstring of enableRadiation)
     if (m_do_radiation) {
         computeRadiation(x, jmin, jmax);
@@ -567,16 +547,11 @@ void StFlow::evalEnergy(double* x, double* rsd, int* diag,
     }
 }
 
+
+//! Evaluate the species equations' residuals.
 void StFlow::evalSpecies(double* x, double* rsd, int* diag,
                         double rdt, size_t jmin, size_t jmax)
 {
-    //-------------------------------------------------
-    //    Species equations
-    //
-    //   \rho dY_k/dt + \rho u dY_k/dz + dJ_k/dz
-    //   = M_k\omega_k
-    //-------------------------------------------------
-    // The default boundary condition for species is zero flux.
     for (size_t j = jmin; j <= jmax; j++) {
         if (j == 0) { // left boundary
             double sum = 0.0;
@@ -609,12 +584,10 @@ void StFlow::evalSpecies(double* x, double* rsd, int* diag,
     }
 }
 
+//! Evaluate the residual function for the lambda equation.
 void StFlow::evalLambda(double* x, double* rsd, int* diag,
                         double rdt, size_t jmin, size_t jmax)
 {
-    //-------------------------------------------------
-    //    Lambda equation
-    //-------------------------------------------------
     for (size_t j = jmin; j <= jmax; j++) {
         if (j == 0) { // left boundary
             if (m_usesLambda) {
@@ -637,18 +610,10 @@ void StFlow::evalLambda(double* x, double* rsd, int* diag,
     }
 }
 
+//! Evaluate the residual function for the lambda equation.
 void StFlow::evalElectricField(double* x, double* rsd, int* diag,
                                double rdt, size_t jmin, size_t jmax)
 {
-    //-----------------------------------------------
-    //    Electric field (by Gauss's law)
-    //
-    //    dE/dz = 0
-    //
-    //    E = -dV/dz
-    //-----------------------------------------------
-    // The default value for E at the boundary is zero, and E is zero
-    // in the domain as well.
     for (size_t j = jmin; j <= jmax; j++) {
         if (j == 0) { // left boundary
             rsd[index(c_offset_E, 0)] = x[index(c_offset_E, j)];

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -317,7 +317,22 @@ void StFlow::eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt)
     }
 
     updateProperties(jg, x, jmin, jmax);
-    evalResidual(x, rsd, diag, rdt, jmin, jmax);
+
+    //----------------------------------------------------
+    // Evaluate the residual equations at all required
+    // grid points.
+    // These residuals may be modified by a boundary object.
+    // The boundary object connected will modify
+    // these equations by subtracting its values for V, T, mdot, etc.
+    // As a result, these residual equations will force the solution
+    // variables to the values for the boundary object.
+    //----------------------------------------------------
+    evalContinuity(x, rsd, diag, rdt, jmin, jmax);
+    evalMomentum(x, rsd, diag, rdt, jmin, jmax);
+    evalEnergy(x, rsd, diag, rdt, jmin, jmax);
+    evalSpecies(x, rsd, diag, rdt, jmin, jmax);
+    evalLambda(x, rsd, diag, rdt, jmin, jmax);
+    evalElectricField(x, rsd, diag, rdt, jmin, jmax);
 }
 
 void StFlow::updateProperties(size_t jg, double* x, size_t jmin, size_t jmax)
@@ -342,190 +357,6 @@ void StFlow::updateProperties(size_t jg, double* x, size_t jmin, size_t jmax)
     // update the species diffusive mass fluxes whether or not a
     // Jacobian is being evaluated
     updateDiffFluxes(x, j0, j1);
-}
-
-void StFlow::evalResidual(double* x, double* rsd, int* diag,
-                          double rdt, size_t jmin, size_t jmax)
-{
-    //----------------------------------------------------
-    // evaluate the residual equations at all required
-    // grid points
-    //----------------------------------------------------
-
-    // calculation of qdotRadiation (see docstring of enableRadiation)
-    if (m_do_radiation) {
-        // variable definitions for the Planck absorption coefficient and the
-        // radiation calculation:
-        double k_P_ref = 1.0*OneAtm;
-
-        // polynomial coefficients:
-        const double c_H2O[6] = {-0.23093, -1.12390, 9.41530, -2.99880,
-                                     0.51382, -1.86840e-5};
-        const double c_CO2[6] = {18.741, -121.310, 273.500, -194.050,
-                                     56.310, -5.8169};
-
-        // calculation of the two boundary values
-        double boundary_Rad_left = m_epsilon_left * StefanBoltz * pow(T(x, 0), 4);
-        double boundary_Rad_right = m_epsilon_right * StefanBoltz * pow(T(x, m_points - 1), 4);
-
-        // loop over all grid points
-        for (size_t j = jmin; j < jmax; j++) {
-            // helping variable for the calculation
-            double radiative_heat_loss = 0;
-
-            // calculation of the mean Planck absorption coefficient
-            double k_P = 0;
-            // absorption coefficient for H2O
-            if (m_kRadiating[1] != npos) {
-                double k_P_H2O = 0;
-                for (size_t n = 0; n <= 5; n++) {
-                    k_P_H2O += c_H2O[n] * pow(1000 / T(x, j), (double) n);
-                }
-                k_P_H2O /= k_P_ref;
-                k_P += m_press * X(x, m_kRadiating[1], j) * k_P_H2O;
-            }
-            // absorption coefficient for CO2
-            if (m_kRadiating[0] != npos) {
-                double k_P_CO2 = 0;
-                for (size_t n = 0; n <= 5; n++) {
-                    k_P_CO2 += c_CO2[n] * pow(1000 / T(x, j), (double) n);
-                }
-                k_P_CO2 /= k_P_ref;
-                k_P += m_press * X(x, m_kRadiating[0], j) * k_P_CO2;
-            }
-
-            // calculation of the radiative heat loss term
-            radiative_heat_loss = 2 * k_P *(2 * StefanBoltz * pow(T(x, j), 4)
-            - boundary_Rad_left - boundary_Rad_right);
-
-            // set the radiative heat loss vector
-            m_qdotRadiation[j] = radiative_heat_loss;
-        }
-    }
-
-    for (size_t j = jmin; j <= jmax; j++) {
-        //----------------------------------------------
-        //         left boundary
-        //----------------------------------------------
-
-        if (j == 0) {
-            // these may be modified by a boundary object
-
-            // Continuity. This propagates information right-to-left, since
-            // rho_u at point 0 is dependent on rho_u at point 1, but not on
-            // mdot from the inlet.
-            rsd[index(c_offset_U,0)] =
-                -(rho_u(x,1) - rho_u(x,0))/m_dz[0]
-                -(density(1)*V(x,1) + density(0)*V(x,0));
-
-            // the inlet (or other) object connected to this one will modify
-            // these equations by subtracting its values for V, T, and mdot. As
-            // a result, these residual equations will force the solution
-            // variables to the values for the boundary object
-            rsd[index(c_offset_V,0)] = V(x,0);
-            rsd[index(c_offset_T,0)] = T(x,0);
-            if (m_usesLambda) {
-                rsd[index(c_offset_L, 0)] = -rho_u(x, 0);
-            } else {
-                rsd[index(c_offset_L, 0)] = lambda(x, 0);
-                diag[index(c_offset_L, 0)] = 0;
-            }
-
-            // The default boundary condition for species is zero flux. However,
-            // the boundary object may modify this.
-            double sum = 0.0;
-            for (size_t k = 0; k < m_nsp; k++) {
-                sum += Y(x,k,0);
-                rsd[index(c_offset_Y + k, 0)] =
-                    -(m_flux(k,0) + rho_u(x,0)* Y(x,k,0));
-            }
-            rsd[index(c_offset_Y + leftExcessSpecies(), 0)] = 1.0 - sum;
-
-            // set residual of poisson's equ to zero
-            rsd[index(c_offset_E, 0)] = x[index(c_offset_E, j)];
-        } else if (j == m_points - 1) {
-            evalRightBoundary(x, rsd, diag, rdt);
-        } else { // interior points
-            evalContinuity(j, x, rsd, diag, rdt);
-            // set residual of poisson's equ to zero
-            rsd[index(c_offset_E, j)] = x[index(c_offset_E, j)];
-
-            //------------------------------------------------
-            //    Radial momentum equation
-            //
-            //    \rho dV/dt + \rho u dV/dz + \rho V^2
-            //       = d(\mu dV/dz)/dz - lambda
-            //-------------------------------------------------
-            if (m_usesLambda) {
-                rsd[index(c_offset_V,j)] =
-                    (shear(x, j) - lambda(x, j) - rho_u(x, j) * dVdz(x, j)
-                    - m_rho[j] * V(x, j) * V(x, j)) / m_rho[j]
-                    - rdt * (V(x, j) - V_prev(j));
-                diag[index(c_offset_V, j)] = 1;
-            } else {
-                rsd[index(c_offset_V, j)] = V(x, j);
-                diag[index(c_offset_V, j)] = 0;
-            }
-
-            //-------------------------------------------------
-            //    Species equations
-            //
-            //   \rho dY_k/dt + \rho u dY_k/dz + dJ_k/dz
-            //   = M_k\omega_k
-            //-------------------------------------------------
-            getWdot(x,j);
-            for (size_t k = 0; k < m_nsp; k++) {
-                double convec = rho_u(x,j)*dYdz(x,k,j);
-                double diffus = 2.0*(m_flux(k,j) - m_flux(k,j-1))
-                                / (z(j+1) - z(j-1));
-                rsd[index(c_offset_Y + k, j)]
-                = (m_wt[k]*(wdot(k,j))
-                   - convec - diffus)/m_rho[j]
-                  - rdt*(Y(x,k,j) - Y_prev(k,j));
-                diag[index(c_offset_Y + k, j)] = 1;
-            }
-
-            //-----------------------------------------------
-            //    energy equation
-            //
-            //    \rho c_p dT/dt + \rho c_p u dT/dz
-            //    = d(k dT/dz)/dz
-            //      - sum_k(\omega_k h_k_ref)
-            //      - sum_k(J_k c_p_k / M_k) dT/dz
-            //-----------------------------------------------
-            if (m_do_energy[j]) {
-
-                setGas(x,j);
-                double dtdzj = dTdz(x,j);
-                double sum = 0.0;
-
-                grad_hk(x, j);
-                for (size_t k = 0; k < m_nsp; k++) {
-                    double flxk = 0.5*(m_flux(k,j-1) + m_flux(k,j));
-                    sum += wdot(k,j)*m_hk(k,j);
-                    sum += flxk * m_dhk_dz(k,j) / m_wt[k];
-                }
-
-                rsd[index(c_offset_T, j)] = - m_cp[j]*rho_u(x,j)*dtdzj
-                                            - divHeatFlux(x,j) - sum;
-                rsd[index(c_offset_T, j)] /= (m_rho[j]*m_cp[j]);
-                rsd[index(c_offset_T, j)] -= rdt*(T(x,j) - T_prev(j));
-                rsd[index(c_offset_T, j)] -= (m_qdotRadiation[j] / (m_rho[j] * m_cp[j]));
-                diag[index(c_offset_T, j)] = 1;
-            } else {
-                // residual equations if the energy equation is disabled
-                rsd[index(c_offset_T, j)] = T(x,j) - T_fixed(j);
-                diag[index(c_offset_T, j)] = 0;
-            }
-
-            if (m_usesLambda) {
-                rsd[index(c_offset_L, j)] = lambda(x, j) - lambda(x, j - 1);
-            } else {
-                rsd[index(c_offset_L, j)] = lambda(x, j);
-            }
-            diag[index(c_offset_L, j)] = 0;
-        }
-    }
 }
 
 void StFlow::updateTransport(double* x, size_t j0, size_t j1)
@@ -555,23 +386,6 @@ void StFlow::updateTransport(double* x, size_t j0, size_t j1)
             m_trans->getMixDiffCoeffs(&m_diff[j*m_nsp]);
             m_tcon[j] = m_trans->thermalConductivity();
         }
-    }
-}
-
-void StFlow::show(const double* x)
-{
-    writelog("    Pressure:  {:10.4g} Pa\n", m_press);
-
-    Domain1D::show(x);
-
-    if (m_do_radiation) {
-        writeline('-', 79, false, true);
-        writelog("\n          z      radiative heat loss");
-        writeline('-', 79, false, true);
-        for (size_t j = 0; j < m_points; j++) {
-            writelog("\n {:10.4g}        {:10.4g}", m_z[j], m_qdotRadiation[j]);
-        }
-        writelog("\n");
     }
 }
 
@@ -614,6 +428,312 @@ void StFlow::updateDiffFluxes(const double* x, size_t j0, size_t j1)
                 m_flux(k,m) -= m_dthermal(k,m)*gradlogT;
             }
         }
+    }
+}
+
+void StFlow::evalContinuity(double* x, double* rsd, int* diag,
+                          double rdt, size_t jmin, size_t jmax)
+{
+    //----------------------------------------------
+    //    Continuity equation
+    //
+    //    d(\rho u)/dz + 2\rho V = 0
+    //----------------------------------------------
+    // This propagates information right-to-left, since rho_u at point 0 is dependent
+    // on rho_u at point 1, but not on mdot from the inlet.
+    // The default value for continuity is zero u at the boundary.
+    for (size_t j = jmin; j <= jmax; j++) {
+        if (j == 0) { // left boundary
+            rsd[index(c_offset_U,0)] =
+                -(rho_u(x,1) - rho_u(x,0))/m_dz[0]
+                -(density(1)*V(x,1) + density(0)*V(x,0));
+        } else if (j == m_points - 1) { // right boundary
+            if (m_usesLambda) {
+                rsd[index(c_offset_U, j)] = rho_u(x, j);
+            } else {
+                rsd[index(c_offset_U, j)] = rho_u(x, j) - rho_u(x, j-1);
+            }
+        } else { // interior points
+            if (m_usesLambda) {
+                // Note that this propagates the mass flow rate information to the left
+                // (j+1 -> j) from the value specified at the right boundary. The
+                // lambda information propagates in the opposite direction.
+                rsd[index(c_offset_U,j)] =
+                    -(rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
+                    -(density(j+1)*V(x,j+1) + density(j)*V(x,j));
+            } else if (m_isFree) {
+                // terms involving V are zero as V=0 by definition
+                if (grid(j) > m_zfixed) {
+                    rsd[index(c_offset_U,j)] =
+                        - (rho_u(x,j) - rho_u(x,j-1))/m_dz[j-1];
+                } else if (grid(j) == m_zfixed) {
+                    if (m_do_energy[j]) {
+                        rsd[index(c_offset_U,j)] = (T(x,j) - m_tfixed);
+                    } else {
+                        rsd[index(c_offset_U,j)] = (rho_u(x,j)
+                                                    - m_rho[0]*0.3); // why 0.3?
+                    }
+                } else if (grid(j) < m_zfixed) {
+                    rsd[index(c_offset_U,j)] =
+                        - (rho_u(x,j+1) - rho_u(x,j))/m_dz[j];
+                }
+            } else {
+                // unstrained with fixed mass flow rate
+                rsd[index(c_offset_U, j)] = rho_u(x, j) - rho_u(x, j - 1);
+            }
+            diag[index(c_offset_U, j)] = 0; // Algebraic constraint
+        }
+    }
+}
+
+void StFlow::evalMomentum(double* x, double* rsd, int* diag,
+                          double rdt, size_t jmin, size_t jmax)
+{
+    //------------------------------------------------
+    //    Radial momentum equation
+    //
+    //    \rho dV/dt + \rho u dV/dz + \rho V^2
+    //       = d(\mu dV/dz)/dz - lambda
+    //-------------------------------------------------
+    // The default boundary condition is zero V.
+    for (size_t j = jmin; j <= jmax; j++) {
+        if (j == 0) { // left boundary
+            rsd[index(c_offset_V,0)] = V(x,0);
+        } else if (j == m_points - 1) { // right boundary
+            rsd[index(c_offset_V,j)] = V(x,j);
+            diag[index(c_offset_V,j)] = 0;
+        } else { // interior points
+            if (m_usesLambda) {
+                rsd[index(c_offset_V,j)] =
+                    (shear(x, j) - lambda(x, j) - rho_u(x, j) * dVdz(x, j)
+                    - m_rho[j] * V(x, j) * V(x, j)) / m_rho[j]
+                    - rdt * (V(x, j) - V_prev(j));
+                diag[index(c_offset_V, j)] = 1;
+            } else {
+                rsd[index(c_offset_V, j)] = V(x, j);
+                diag[index(c_offset_V, j)] = 0;
+            }
+        }
+    }
+}
+
+void StFlow::evalEnergy(double* x, double* rsd, int* diag,
+                        double rdt, size_t jmin, size_t jmax)
+{
+    //-----------------------------------------------
+    //    Energy equation
+    //
+    //    \rho c_p dT/dt + \rho c_p u dT/dz
+    //    = d(k dT/dz)/dz
+    //      - sum_k(\omega_k h_k_ref)
+    //      - sum_k(J_k c_p_k / M_k) dT/dz
+    //-----------------------------------------------
+    // The default boundary condition for energy is a zero T.
+
+    // Calculation of qdotRadiation (see docstring of enableRadiation)
+    if (m_do_radiation) {
+        computeRadiation(x, jmin, jmax);
+    }
+
+    for (size_t j = jmin; j <= jmax; j++) {
+        if (j == 0) { // left boundary
+            rsd[index(c_offset_T,0)] = T(x,0);
+        } else if (j == m_points - 1) { // right boundary
+            rsd[index(c_offset_T, j)] = T(x, j);
+        } else { // interior points
+            if (m_do_energy[j]) {
+                double dtdzj = dTdz(x,j);
+                double sum = 0.0;
+
+                grad_hk(x, j);
+                for (size_t k = 0; k < m_nsp; k++) {
+                    double flxk = 0.5*(m_flux(k,j-1) + m_flux(k,j));
+                    sum += wdot(k,j)*m_hk(k,j);
+                    sum += flxk * m_dhk_dz(k,j) / m_wt[k];
+                }
+
+                rsd[index(c_offset_T, j)] = - m_cp[j]*rho_u(x,j)*dtdzj
+                                            - divHeatFlux(x,j) - sum;
+                rsd[index(c_offset_T, j)] /= (m_rho[j]*m_cp[j]);
+                rsd[index(c_offset_T, j)] -= rdt*(T(x,j) - T_prev(j));
+                rsd[index(c_offset_T, j)] -= (m_qdotRadiation[j] / (m_rho[j] * m_cp[j]));
+                diag[index(c_offset_T, j)] = 1;
+            } else {
+                // residual equations if the energy equation is disabled
+                rsd[index(c_offset_T, j)] = T(x,j) - T_fixed(j);
+                diag[index(c_offset_T, j)] = 0;
+            }
+        }
+    }
+}
+
+void StFlow::evalSpecies(double* x, double* rsd, int* diag,
+                        double rdt, size_t jmin, size_t jmax)
+{
+    //-------------------------------------------------
+    //    Species equations
+    //
+    //   \rho dY_k/dt + \rho u dY_k/dz + dJ_k/dz
+    //   = M_k\omega_k
+    //-------------------------------------------------
+    // The default boundary condition for species is zero flux.
+    for (size_t j = jmin; j <= jmax; j++) {
+        if (j == 0) { // left boundary
+            double sum = 0.0;
+            for (size_t k = 0; k < m_nsp; k++) {
+                sum += Y(x,k,0);
+                rsd[index(c_offset_Y + k, 0)] =
+                    -(m_flux(k,0) + rho_u(x,0)* Y(x,k,0));
+            }
+            rsd[index(c_offset_Y + leftExcessSpecies(), 0)] = 1.0 - sum;
+        } else if (j == m_points - 1) { // right boundary
+            double sum = 0.0;
+            for (size_t k = 0; k < m_nsp; k++) {
+                sum += Y(x,k,j);
+                rsd[index(k+c_offset_Y,j)] = m_flux(k,j-1) + rho_u(x,j)*Y(x,k,j);
+            }
+            rsd[index(c_offset_Y + rightExcessSpecies(), j)] = 1.0 - sum;
+            diag[index(c_offset_Y + rightExcessSpecies(), j)] = 0;
+        } else { // interior points
+            for (size_t k = 0; k < m_nsp; k++) {
+                double convec = rho_u(x,j)*dYdz(x,k,j);
+                double diffus = 2.0*(m_flux(k,j) - m_flux(k,j-1))
+                                / (z(j+1) - z(j-1));
+                rsd[index(c_offset_Y + k, j)]
+                = (m_wt[k]*(wdot(k,j))
+                   - convec - diffus)/m_rho[j]
+                  - rdt*(Y(x,k,j) - Y_prev(k,j));
+                diag[index(c_offset_Y + k, j)] = 1;
+            }
+        }
+    }
+}
+
+void StFlow::evalLambda(double* x, double* rsd, int* diag,
+                        double rdt, size_t jmin, size_t jmax)
+{
+    //-------------------------------------------------
+    //    Lambda equation
+    //-------------------------------------------------
+    for (size_t j = jmin; j <= jmax; j++) {
+        if (j == 0) { // left boundary
+            if (m_usesLambda) {
+                rsd[index(c_offset_L, 0)] = -rho_u(x, 0);
+            } else {
+                rsd[index(c_offset_L, 0)] = lambda(x, 0);
+                diag[index(c_offset_L, 0)] = 0;
+            }
+        } else if (j == m_points - 1) { // right boundary
+            rsd[index(c_offset_L, j)] = lambda(x, j) - lambda(x, j-1);
+            diag[index(c_offset_L, j)] = 0;
+        } else { // interior points
+            if (m_usesLambda) {
+                rsd[index(c_offset_L, j)] = lambda(x, j) - lambda(x, j - 1);
+            } else {
+                rsd[index(c_offset_L, j)] = lambda(x, j);
+            }
+            diag[index(c_offset_L, j)] = 0;
+        }
+    }
+}
+
+void StFlow::evalElectricField(double* x, double* rsd, int* diag,
+                               double rdt, size_t jmin, size_t jmax)
+{
+    //-----------------------------------------------
+    //    Electric field (by Gauss's law)
+    //
+    //    dE/dz = 0
+    //
+    //    E = -dV/dz
+    //-----------------------------------------------
+    // The default value for E at the boundary is zero, and E is zero
+    // in the domain as well.
+    for (size_t j = jmin; j <= jmax; j++) {
+        if (j == 0) { // left boundary
+            rsd[index(c_offset_E, 0)] = x[index(c_offset_E, j)];
+        } else if (j == m_points - 1) { // right boundary
+            rsd[index(c_offset_E, j)] = x[index(c_offset_E, j)];
+        } else { // interior points
+            rsd[index(c_offset_E, j)] = x[index(c_offset_E, j)];
+        }
+    }
+}
+
+void StFlow::computeRadiation(double* x, size_t jmin, size_t jmax)
+{
+    // Variable definitions for the Planck absorption coefficient and the
+    // radiation calculation:
+    double k_P_ref = 1.0*OneAtm;
+
+    // Polynomial coefficients:
+    const double c_H2O[6] = {-0.23093, -1.12390, 9.41530, -2.99880,
+                                    0.51382, -1.86840e-5};
+    const double c_CO2[6] = {18.741, -121.310, 273.500, -194.050,
+                                    56.310, -5.8169};
+
+    // Calculation of the two boundary values
+    double boundary_Rad_left = m_epsilon_left * StefanBoltz * pow(T(x, 0), 4);
+    double boundary_Rad_right = m_epsilon_right * StefanBoltz * pow(T(x, m_points - 1), 4);
+
+    for (size_t j = jmin; j < jmax; j++) {
+        // calculation of the mean Planck absorption coefficient
+        double k_P = 0;
+        // Absorption coefficient for H2O
+        if (m_kRadiating[1] != npos) {
+            double k_P_H2O = 0;
+            for (size_t n = 0; n <= 5; n++) {
+                k_P_H2O += c_H2O[n] * pow(1000 / T(x, j), (double) n);
+            }
+            k_P_H2O /= k_P_ref;
+            k_P += m_press * X(x, m_kRadiating[1], j) * k_P_H2O;
+        }
+        // Absorption coefficient for CO2
+        if (m_kRadiating[0] != npos) {
+            double k_P_CO2 = 0;
+            for (size_t n = 0; n <= 5; n++) {
+                k_P_CO2 += c_CO2[n] * pow(1000 / T(x, j), (double) n);
+            }
+            k_P_CO2 /= k_P_ref;
+            k_P += m_press * X(x, m_kRadiating[0], j) * k_P_CO2;
+        }
+
+        // Calculation of the radiative heat loss term
+        double radiative_heat_loss = 0;
+        radiative_heat_loss = 2 * k_P *(2 * StefanBoltz * pow(T(x, j), 4)
+                              - boundary_Rad_left - boundary_Rad_right);
+
+        // set the radiative heat loss vector
+        m_qdotRadiation[j] = radiative_heat_loss;
+    }
+}
+
+void StFlow::grad_hk(const double* x, size_t j)
+{
+    for(size_t k = 0; k < m_nsp; k++) {
+        if (u(x, j) > 0.0) {
+            m_dhk_dz(k,j) = (m_hk(k,j) - m_hk(k,j-1)) / m_dz[j - 1];
+        }
+        else {
+            m_dhk_dz(k,j) = (m_hk(k,j+1) - m_hk(k,j)) / m_dz[j];
+        }
+    }
+}
+
+void StFlow::show(const double* x)
+{
+    writelog("    Pressure:  {:10.4g} Pa\n", m_press);
+
+    Domain1D::show(x);
+
+    if (m_do_radiation) {
+        writeline('-', 79, false, true);
+        writelog("\n          z      radiative heat loss");
+        writeline('-', 79, false, true);
+        for (size_t j = 0; j < m_points; j++) {
+            writelog("\n {:10.4g}        {:10.4g}", m_z[j], m_qdotRadiation[j]);
+        }
+        writelog("\n");
     }
 }
 
@@ -934,86 +1054,6 @@ void StFlow::fixTemperature(size_t j)
     m_refiner->setActive(c_offset_T, false);
     if (changed) {
         needJacUpdate();
-    }
-}
-
-void StFlow::evalRightBoundary(double* x, double* rsd, int* diag, double rdt)
-{
-    size_t j = m_points - 1;
-
-    // the boundary object connected to the right of this one may modify or
-    // replace these equations. The default boundary conditions are zero u, V,
-    // and T, and zero diffusive flux for all species.
-
-    rsd[index(c_offset_V,j)] = V(x,j);
-    diag[index(c_offset_V,j)] = 0;
-    double sum = 0.0;
-    // set residual of poisson's equ to zero
-    rsd[index(c_offset_E, j)] = x[index(c_offset_E, j)];
-    for (size_t k = 0; k < m_nsp; k++) {
-        sum += Y(x,k,j);
-        rsd[index(k+c_offset_Y,j)] = m_flux(k,j-1) + rho_u(x,j)*Y(x,k,j);
-    }
-    rsd[index(c_offset_Y + rightExcessSpecies(), j)] = 1.0 - sum;
-    diag[index(c_offset_Y + rightExcessSpecies(), j)] = 0;
-    if (m_usesLambda) {
-        rsd[index(c_offset_U, j)] = rho_u(x, j);
-    } else {
-        rsd[index(c_offset_U, j)] = rho_u(x, j) - rho_u(x, j-1);
-    }
-
-    rsd[index(c_offset_L, j)] = lambda(x, j) - lambda(x, j-1);
-    diag[index(c_offset_L, j)] = 0;
-    rsd[index(c_offset_T, j)] = T(x, j);
-}
-
-void StFlow::evalContinuity(size_t j, double* x, double* rsd, int* diag, double rdt)
-{
-    //algebraic constraint
-    diag[index(c_offset_U, j)] = 0;
-    //----------------------------------------------
-    //    Continuity equation
-    //
-    //    d(\rho u)/dz + 2\rho V = 0
-    //----------------------------------------------
-    if (m_usesLambda) {
-        // Note that this propagates the mass flow rate information to the left
-        // (j+1 -> j) from the value specified at the right boundary. The
-        // lambda information propagates in the opposite direction.
-        rsd[index(c_offset_U,j)] =
-            -(rho_u(x,j+1) - rho_u(x,j))/m_dz[j]
-            -(density(j+1)*V(x,j+1) + density(j)*V(x,j));
-    } else if (m_isFree) {
-        // terms involving V are zero as V=0 by definition
-        if (grid(j) > m_zfixed) {
-            rsd[index(c_offset_U,j)] =
-                - (rho_u(x,j) - rho_u(x,j-1))/m_dz[j-1];
-        } else if (grid(j) == m_zfixed) {
-            if (m_do_energy[j]) {
-                rsd[index(c_offset_U,j)] = (T(x,j) - m_tfixed);
-            } else {
-                rsd[index(c_offset_U,j)] = (rho_u(x,j)
-                                            - m_rho[0]*0.3); // why 0.3?
-            }
-        } else if (grid(j) < m_zfixed) {
-            rsd[index(c_offset_U,j)] =
-                - (rho_u(x,j+1) - rho_u(x,j))/m_dz[j];
-        }
-    } else {
-        // unstrained with fixed mass flow rate
-        rsd[index(c_offset_U, j)] = rho_u(x, j) - rho_u(x, j - 1);
-    }
-}
-
-void StFlow::grad_hk(const double* x, size_t j)
-{
-    for(size_t k = 0; k < m_nsp; k++) {
-        if (u(x, j) > 0.0) {
-            m_dhk_dz(k,j) = (m_hk(k,j) - m_hk(k,j-1)) / m_dz[j - 1];
-        }
-        else {
-            m_dhk_dz(k,j) = (m_hk(k,j+1) - m_hk(k,j)) / m_dz[j];
-        }
     }
 }
 

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -295,7 +295,7 @@ void StFlow::_finalize(const double* x)
 
 void StFlow::eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt)
 {
-    // if evaluating a Jacobian, and the global point is outside the domain of
+    // If evaluating a Jacobian, and the global point is outside the domain of
     // influence for this domain, then skip evaluating the residual
     if (jg != npos && (jg + 1 < firstPoint() || jg > lastPoint() + 1)) {
         return;
@@ -318,15 +318,6 @@ void StFlow::eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt)
 
     updateProperties(jg, x, jmin, jmax);
 
-    //----------------------------------------------------
-    // Evaluate the residual equations at all required
-    // grid points.
-    // These residuals may be modified by a boundary object.
-    // The boundary object connected will modify
-    // these equations by subtracting its values for V, T, mdot, etc.
-    // As a result, these residual equations will force the solution
-    // variables to the values for the boundary object.
-    //----------------------------------------------------
     evalContinuity(x, rsd, diag, rdt, jmin, jmax);
     evalMomentum(x, rsd, diag, rdt, jmin, jmax);
     evalEnergy(x, rsd, diag, rdt, jmin, jmax);
@@ -431,7 +422,6 @@ void StFlow::updateDiffFluxes(const double* x, size_t j0, size_t j1)
     }
 }
 
-//! Evaluate the continuity equation residual.
 void StFlow::evalContinuity(double* x, double* rsd, int* diag,
                             double rdt, size_t jmin, size_t jmax)
 {
@@ -479,8 +469,6 @@ void StFlow::evalContinuity(double* x, double* rsd, int* diag,
     }
 }
 
-
-//! Evaluate the momentum equation residual.
 void StFlow::evalMomentum(double* x, double* rsd, int* diag,
                           double rdt, size_t jmin, size_t jmax)
 {
@@ -505,8 +493,6 @@ void StFlow::evalMomentum(double* x, double* rsd, int* diag,
     }
 }
 
-
-//! Evaluate the energy equation residual.
 void StFlow::evalEnergy(double* x, double* rsd, int* diag,
                         double rdt, size_t jmin, size_t jmax)
 {
@@ -547,10 +533,8 @@ void StFlow::evalEnergy(double* x, double* rsd, int* diag,
     }
 }
 
-
-//! Evaluate the species equations' residuals.
 void StFlow::evalSpecies(double* x, double* rsd, int* diag,
-                        double rdt, size_t jmin, size_t jmax)
+                         double rdt, size_t jmin, size_t jmax)
 {
     for (size_t j = jmin; j <= jmax; j++) {
         if (j == 0) { // left boundary
@@ -584,7 +568,6 @@ void StFlow::evalSpecies(double* x, double* rsd, int* diag,
     }
 }
 
-//! Evaluate the residual function for the lambda equation.
 void StFlow::evalLambda(double* x, double* rsd, int* diag,
                         double rdt, size_t jmin, size_t jmax)
 {
@@ -610,7 +593,6 @@ void StFlow::evalLambda(double* x, double* rsd, int* diag,
     }
 }
 
-//! Evaluate the residual function for the lambda equation.
 void StFlow::evalElectricField(double* x, double* rsd, int* diag,
                                double rdt, size_t jmin, size_t jmax)
 {


### PR DESCRIPTION


<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

Moved methods around to be closer to their contextual counterparts, various comment formatting/cleaning up, pulled radiation computation into a separate method, tried to make residual equation evaluation order consistent across the boundary/interior sections of code that evaluate them.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- A separate function for evaluating the radiative heat term that is outside of the residual method.


**If applicable, fill in the issue number this pull request is fixing**


**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
