### PR TITLE
Fix segfault in deprecated newPhase factory function

### DIFF
--- a/test/thermo/ThermoPhase_Test.cpp
+++ b/test/thermo/ThermoPhase_Test.cpp
@@ -117,6 +117,17 @@ TEST_F(TestThermoMethods, setConcentrations)
     EXPECT_NEAR(thermo->moleFraction(2), -1e-8 / ctot, 1e-16);
 }
 
+TEST(ThermoConstructors, newPhase)
+{
+    suppress_deprecation_warnings();
+    // Test deprecated newPhase(infile, phasename) factory function
+    unique_ptr<ThermoPhase> gas(newPhase("h2o2.yaml", ""));
+    gas->setState_TPX(400, 2 * OneAtm, "H2:1.0, O2:1.0");
+    EXPECT_NEAR(gas->moleFraction("H2"), 0.5, 1e-8);
+    EXPECT_NEAR(gas->pressure(), 2 * OneAtm, 1e-5);
+    make_deprecation_warnings_fatal();
+}
+
 class EquilRatio_MixFrac_Test : public testing::Test
 {
 public:


### PR DESCRIPTION
The `shared_ptr` goes out of scope at the end of the function, deleting the held `ThermoPhase` right as it's returned.

Erroneous behavior introduced in f3e840dcbe (#1448).

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Replace the `shared_ptr`-based implementation with one that uses a `unique_ptr` (which can be released without destroying the underlying object)
- Add test coverage for this method

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
