### PR TITLE
mods to enable python3.12

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.11']
+        python-version: ['3.8', '3.10', '3.11', '3.12']
         os: ['ubuntu-20.04', 'ubuntu-22.04']
       fail-fast: false
     env:

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -65,7 +65,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.10', '3.11']
         os: ['ubuntu-20.04', 'ubuntu-22.04']
       fail-fast: false
     env:

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -93,3 +93,39 @@ jobs:
     - name: Test Cantera
       run:
         scons test verbose_tests=yes --debug=time
+
+  fedora-docker:
+    name: Docker 'fedora:${{ matrix.image }}' image
+    strategy:
+      matrix:
+        image: [rawhide, latest]
+      fail-fast: false
+    runs-on: ubuntu-latest
+    timeout-minutes: 60
+    container:
+      image: fedora:${{ matrix.image }}
+    steps:
+    - name: Install git on fedora:${{ matrix.image }}
+      run: |
+        dnf install -y git
+        git config --global init.defaultBranch main
+        git config --global --add safe.directory /__w/cantera/cantera
+    - uses: actions/checkout@v3
+      name: Checkout the repository
+    - name: Install dependencies
+      # Use packages from Fedora
+      run: |
+        dnf install -y boost-devel eigen3-devel fmt-devel gcc gcc-c++ \
+        gcc-fortran gmock-devel gtest-devel python3 python3-cython \
+        python3-devel python3-numpy python3-pandas python3-pint python3-pip \
+        python3-pytest python3-ruamel-yaml python3-scipy python3-scons \
+        python3-wheel sundials-devel yaml-cpp-devel
+    - name: Build Cantera
+      run: |
+        scons build -j2 debug=n --debug=time \
+        extra_inc_dirs=/usr/include/eigen3 f90_interface=y \
+        libdirname=/usr/lib64 python_package=full system_eigen=y system_fmt=y \
+        system_sundials=y system_yamlcpp=y system_blas_lapack=y
+    - name: Test Cantera
+      run:
+        scons test verbose_tests=yes --debug=time

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics

--- a/interfaces/python_minimal/setup.cfg.in
+++ b/interfaces/python_minimal/setup.cfg.in
@@ -23,6 +23,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics
 project_urls =

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -27,6 +27,7 @@ classifiers =
     Programming Language :: Python :: 3.9
     Programming Language :: Python :: 3.10
     Programming Language :: Python :: 3.11
+    Programming Language :: Python :: 3.12
     Programming Language :: Python :: Implementation :: CPython
     Topic :: Scientific/Engineering :: Chemistry
     Topic :: Scientific/Engineering :: Physics

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -434,7 +434,7 @@ protected:
     vector<string> inputDirs;
 
     //! Versions of Python to consider when attempting to load user extensions
-    vector<string> m_pythonSearchVersions = {"3.11", "3.10", "3.9", "3.8"};
+    vector<string> m_pythonSearchVersions = {"3.12", "3.11", "3.10", "3.9", "3.8"};
 
     //! Set of deprecation warnings that have been emitted (to suppress duplicates)
     set<string> warnings;


### PR DESCRIPTION
**Changes proposed in this pull request**

- enable building Cantera with Python 3.12 (thanks for the pointer @speth)
- update docs in source to include Python 3.12
- verified in Fedora 39, Rawhide builds (e.g. https://koji.fedoraproject.org/koji/buildinfo?buildID=2279235)

Closes #1602 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
