### PR TITLE
Improve output of regression test runner

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -108,16 +108,12 @@ valid_commands = ("build", "clean", "install", "uninstall",
 if GetOption("silent"):
     logger.logger.setLevel("ERROR")
 else:
-    logger.logger.setLevel("WARNING")
+    logger.logger.setLevel("INFO")
 
 for command in COMMAND_LINE_TARGETS:
     if command not in valid_commands and not command.startswith('test'):
         logger.error(f"Unrecognized command line target: {command!r}")
         sys.exit(1)
-
-    # update default logging level
-    if command in ["build", "dump"] and not GetOption("silent"):
-        logger.logger.setLevel("INFO")
 
 if "clean" in COMMAND_LINE_TARGETS:
     remove_directory("build")

--- a/samples/cxx/LiC6_electrode/LiC6_electrode.cpp
+++ b/samples/cxx/LiC6_electrode/LiC6_electrode.cpp
@@ -83,6 +83,6 @@ int main(int argc, char** argv)
         return 0;
     } catch (CanteraError& err) {
         std::cout << err.what() << std::endl;
-        return 0;
+        return -1;
     }
 }

--- a/samples/cxx/demo/demo.cpp
+++ b/samples/cxx/demo/demo.cpp
@@ -122,7 +122,9 @@ int main()
 {
     try {
         demoprog();
+        return 0;
     } catch (CanteraError& err) {
         std::cout << err.what() << std::endl;
+        return -1;
     }
 }

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -743,7 +743,7 @@ def regression_test(target: "LFSNode", source: "LFSNode", env: "SCEnvironment"):
 
     for blessed, output in comparisons:
         if not dir.joinpath(output).is_file():
-            logger.info(f"Output file '{output}' not found", print_level=False)
+            logger.error(f"Output file '{output}' not found", print_level=False)
             logger.error("FAILED", print_level=False)
             diff |= TestResult.FAIL
             continue
@@ -755,7 +755,7 @@ def regression_test(target: "LFSNode", source: "LFSNode", env: "SCEnvironment"):
 
     for blessed, output in env["test_profiles"]:
         if not dir.joinpath(output).is_file():
-            logger.info(f"Output file '{output}' not found", print_level=False)
+            logger.error(f"Output file '{output}' not found", print_level=False)
             logger.error("FAILED", print_level=False)
             diff |= TestResult.FAIL
             continue


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Restore log information printed during successful and unsuccessful runs of the regression test (`test_problems`) runner
- Prevent these tests from incorrectly succeeding based on reading output files from previous runs
- Return non-zero status after error from all C++ examples

**If applicable, provide an example illustrating new features this pull request is introducing**

Results of running `scons test-cxx-LiC6-electrode`:

Old per-test output (successful test):
```
...
clang++ -o build/samples/cxx/LiC6_electrode/LiC6_electrode.o blah blah blah
clang++ -o build/samples/cxx/LiC6_electrode/LiC6_electrode blah blah blah
* Running test 'cxx-LiC6-electrode'...
```

Old per-test output (missing output file):
```
clang++ -o build/samples/cxx/LiC6_electrode/LiC6_electrode.o blah blah blah
clang++ -o build/samples/cxx/LiC6_electrode/LiC6_electrode blah blah blah
* Running test 'cxx-LiC6-electrode'...
FAILED
```

New output (successful test):
```
clang++ -o build/samples/cxx/LiC6_electrode/LiC6_electrode.o blah blah blah
clang++ -o build/samples/cxx/LiC6_electrode/LiC6_electrode blah blah blah
* Running test 'cxx-LiC6-electrode'...
Comparing 'LiC6_electrode_blessed.csv' with 'LiC6_electrode_output.csv'
PASSED
```

New output (missing output file):
```
clang++ -o build/samples/cxx/LiC6_electrode/LiC6_electrode.o blah blah blah
clang++ -o build/samples/cxx/LiC6_electrode/LiC6_electrode blah blah blah
* Running test 'cxx-LiC6-electrode'...
Output file 'LiC6_electrode_output.csv' not found
FAILED
```


<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
