### PR TITLE
Add Python 3.12 post-merge-test

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -124,10 +124,12 @@ jobs:
         python3-wheel sundials-devel yaml-cpp-devel hdf5-devel highfive-devel
     - name: Build Cantera
       run: |
-        scons build -j2 debug=n --debug=time \
-        extra_inc_dirs=/usr/include/eigen3 f90_interface=y \
-        libdirname=/usr/lib64 python_package=full system_eigen=y system_fmt=y \
-        system_sundials=y system_yamlcpp=y system_blas_lapack=y hdf_support=y
+        scons build -j2 debug=n --debug=time python_package=full f90_interface=y \
+        extra_inc_dirs=/usr/include/eigen3 libdirname=/usr/lib64 \
+        system_eigen=y system_fmt=y system_blas_lapack=y system_sundials=y \
+        system_yamlcpp=y system_blas_lapack=y hdf_support=y
+      # note: 'system_highfive=y' is omitted as the current packaged version is too old;
+      # once newer version is available in 'latest', this should be tested as well
     - name: Test Cantera
       run:
         scons test verbose_tests=yes --debug=time
@@ -158,20 +160,20 @@ jobs:
     - name: Install Apt dependencies
       run: |
         sudo apt update
-        sudo apt install libboost-dev gfortran libopenmpi-dev libpython3-dev \
+        sudo apt install libboost-dev gfortran libopenmpi-dev \
         libblas-dev liblapack-dev libhdf5-dev libfmt-dev
         gcc --version
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
       run: |
-        python3 -m pip install ruamel.yaml scons==3.1.2 numpy cython pandas pytest \
+        python3 -m pip install ruamel.yaml scons numpy cython pandas pytest \
         pytest-github-actions-annotate-failures pint
     - name: Build Cantera
       run: |
         python3 `which scons` build env_vars=all -j2 debug=n --debug=time \
         system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
-        cc_flags=-D_GLIBCXX_ASSERTIONS
+        system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -89,7 +89,9 @@ jobs:
       run: |
         scons build env_vars=all -j2 debug=n --debug=time \
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
-        cc_flags=-D_GLIBCXX_ASSERTIONS f90_interface=y
+        system_eigen=y system_fmt=y system_sundials=y system_yamlcpp=y \
+        system_blas_lapack=y hdf_support=y f90_interface=y \
+        cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Test Cantera
       run:
         scons test verbose_tests=yes --debug=time
@@ -119,13 +121,57 @@ jobs:
         gcc-fortran gmock-devel gtest-devel python3 python3-cython \
         python3-devel python3-numpy python3-pandas python3-pint python3-pip \
         python3-pytest python3-ruamel-yaml python3-scipy python3-scons \
-        python3-wheel sundials-devel yaml-cpp-devel
+        python3-wheel sundials-devel yaml-cpp-devel hdf5-devel highfive-devel
     - name: Build Cantera
       run: |
         scons build -j2 debug=n --debug=time \
         extra_inc_dirs=/usr/include/eigen3 f90_interface=y \
         libdirname=/usr/lib64 python_package=full system_eigen=y system_fmt=y \
-        system_sundials=y system_yamlcpp=y system_blas_lapack=y
+        system_sundials=y system_yamlcpp=y system_blas_lapack=y hdf_support=y
     - name: Test Cantera
       run:
         scons test verbose_tests=yes --debug=time
+
+  ubuntu-python-prerelease:
+    name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
+    runs-on: ${{ matrix.os }}
+    timeout-minutes: 60
+    strategy:
+      matrix:
+        python-version: ['3.12']
+        os: ['ubuntu-20.04', 'ubuntu-22.04']
+      fail-fast: false
+    env:
+      HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
+      HDF5_INCLUDEDIR: /usr/include/hdf5/serial
+    steps:
+    - uses: actions/checkout@v3
+      name: Checkout the repository
+      with:
+        submodules: recursive
+    - name: Setup Python
+      uses: actions/setup-python@v4
+      with:
+        python-version: ${{ matrix.python-version }}
+        architecture: x64
+        allow-prereleases: true
+    - name: Install Apt dependencies
+      run: |
+        sudo apt update
+        sudo apt install libboost-dev gfortran libopenmpi-dev libpython3-dev \
+        libblas-dev liblapack-dev libhdf5-dev libfmt-dev
+        gcc --version
+    - name: Upgrade pip
+      run: python3 -m pip install -U pip setuptools wheel
+    - name: Install Python dependencies
+      run: |
+        python3 -m pip install ruamel.yaml scons==3.1.2 numpy cython pandas pytest \
+        pytest-github-actions-annotate-failures pint
+    - name: Build Cantera
+      run: |
+        python3 `which scons` build env_vars=all -j2 debug=n --debug=time \
+        system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
+        cc_flags=-D_GLIBCXX_ASSERTIONS
+    - name: Test Cantera
+      run:
+        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time

--- a/SConstruct
+++ b/SConstruct
@@ -1601,7 +1601,7 @@ if env["use_hdf5"] and env["system_highfive"] in ("n", "default"):
         h5_version = Path(cmake_lists).read_text()
         h5_version = [line for line in h5_version.split("\n")
                       if line.startswith("project(HighFive")]
-        return re.search('[0-9]+\.[0-9]+\.[0-9]+', h5_version[0]).group(0)
+        return re.search(r'[0-9]+\.[0-9]+\.[0-9]+', h5_version[0]).group(0)
 
     env["HIGHFIVE_VERSION"] = highfive_version("ext/HighFive/CMakeLists.txt")
     highfive_include = '"../ext/HighFive/include/highfive/H5DataType.hpp"'

--- a/SConstruct
+++ b/SConstruct
@@ -1565,15 +1565,16 @@ if env["use_hdf5"] and env["system_highfive"] in ("y", "default"):
                         f"System HighFive version {h5_lib_version} is not "
                         "supported; version 2.5 or higher is required.")
                 logger.info(
-                    f"System HighFive version {h5_lib_version} is not supported.")
+                    f"System HighFive version {h5_lib_version} is not supported. "
+                    "Using private installation instead.")
             else:
                 env["system_highfive"] = True
+                logger.info("Using system installation of HighFive library.")
             env["HIGHFIVE_VERSION"] = h5_lib_version.strip()
         else:
             config_error("Detected invalid HighFive configuration.")
 
         highfive_include = "<highfive/H5DataType.hpp>"
-        logger.info("Using system installation of HighFive library.")
 
     elif env["system_highfive"] == "y":
         config_error(

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -179,7 +179,7 @@ class Option:
         if len(asterisks) == 1:
             # catch unbalanced '*', for example in '*nix'
             found = f"*{asterisks[0]}"
-            replacement = f"\{found}"
+            replacement = fr"\{found}"
             description = description.replace(found, replacement)
 
         return f"{'':<{indent}}{description}\n"

--- a/site_scons/site_tools/subst.py
+++ b/site_scons/site_tools/subst.py
@@ -126,7 +126,7 @@ def _subst_emitter(target, source, env):
 # Replace @key@ with the value of that key, and @@ with a single @
 ##############################################################################
 
-_SubstFile_pattern = "@(?P<key>\w*?)@"
+_SubstFile_pattern = r"@(?P<key>\w*?)@"
 
 
 def _SubstFile_replace(env, mo):
@@ -169,7 +169,7 @@ def SubstFile(env, target, source):
 ##############################################################################
 
 _SubstHeader_pattern = (
-    "(?m)^(?P<space>\\s*?)(?P<type>#define|#undef)\\s+?@(?P<key>\w+?)@(?P<ending>.*?)$"
+    r"(?m)^(?P<space>\\s*?)(?P<type>#define|#undef)\\s+?@(?P<key>\w+?)@(?P<ending>.*?)$"
 )
 
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This is a minor update to #1604.

- fix several raw strings that lead to syntax warnings in Python 3.12 
- add Python 3.12 post-merge test as recommended by @bryanwweber (note that the runner is currently still failing due to upstream limitations, see https://github.com/Cantera/cantera/actions/runs/6061035003/job/16445794850)
- force system libraries in ubuntu docker post-merge-test
- add hdf5 to fedora docker post-merge-test

At this point, fedora `rawhide` is still the only runner that uses Python 3.12 successfully.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
