### PR TITLE
[SCons] SONAME 'libcantera_python' if 'versioned_shared_library'

### DIFF
--- a/src/SConscript
+++ b/src/SConscript
@@ -88,8 +88,13 @@ if env["python_package"] == "full":
     pyenv.Append(LIBS=pyenv["py_libs"], LIBPATH=pyenv["py_libpath"])
     shim = pyenv.SharedObject("extensions/pythonShim.cpp")
     pylibname = f"../lib/cantera_python{pyenv['py_version_short'].replace('.', '_')}"
-    lib = build(pyenv.SharedLibrary(pylibname, shim, SPAWN=get_spawn(pyenv)))
-    install("$inst_shlibdir", lib)
+    if localenv['versioned_shared_library']:
+        lib = build(pyenv.SharedLibrary(pylibname, shim, SPAWN=get_spawn(pyenv),
+                                        SHLIBVERSION=pyenv['cantera_pure_version']))
+        install(pyenv.InstallVersionedLib, "$inst_shlibdir", lib)
+    else:
+        lib = build(pyenv.SharedLibrary(pylibname, shim, SPAWN=get_spawn(pyenv)))
+        install("$inst_shlibdir", lib)
 
 
 # build the Cantera static library


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Currently the Cantera 3.0.0 release build and install the `libcantera_python3_1.so` library (e.g. for python 3.11) without soname/library version and without versioned symlinks to that library if `versioned_shared_library` is set `True`.
- Proposed changes conditionally makes `libcantera_python` to be versioned if env `versioned_shared_library` is used and installs appropriate symlinks. Thus instead of `libcantera_python3_11.so` the `@libcantera_python3_11.so`, `@libcantera_python3_11.so.3`, `libcantera_python3_11.so.3.0.0` are installed (where name started with `@` is mark for symlink).
- 
**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes # none

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
