### PR TITLE
ck2yaml argparse / yaml2k fixes

### DIFF
--- a/doc/sphinx/yaml/ck2yaml.rst
+++ b/doc/sphinx/yaml/ck2yaml.rst
@@ -3,5 +3,10 @@ Chemkin to YAML conversion
 **************************
 
 .. note::
-    For documentation and tutorial, refer to the `Converting Chemkin-format files
+    For a tutorial, refer to the `Converting Chemkin-format files
     <https://cantera.org/tutorials/ck2yaml-tutorial.html>`_ pages.
+
+.. argparse::
+   :module: cantera.ck2yaml
+   :func: create_argparser
+   :prog: ck2yaml

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -6,7 +6,7 @@
 
 """Convert Chemkin-format mechanism files to YAML.
 
-There are two main entry points to this script, `main` and `convert`. The former is
+There are two main entry points to this script, ``main`` and ``convert``. The former is
 used from the command line interface and parses the arguments passed. The latter uses
 arguments that correspond to options of the command line interface.
 """
@@ -2228,75 +2228,78 @@ def create_argparser():
             "Convert Chemkin-format mechanisms to Cantera YAML input files"),
         epilog=textwrap.dedent(
             """
-            example:
+            Example::
+
                 ck2yaml --input=chem.inp --thermo=therm.dat --transport=tran.dat
 
-            The equal sign in the options above is optional.
+            If the **ck2yaml** script is not on your path but the Cantera Python module is,
+            **ck2yaml** can also be invoked by running::
+
+                python -m cantera.ck2yaml --input=chem.inp --thermo=therm.dat --transport=tran.dat
+
+            In both cases, the equal signs in the options are optional.
             """),
         formatter_class=argparse.RawDescriptionHelpFormatter
     )
     parser.add_argument(
         "-p", "--permissive", action="store_true", default=False,
-        help=("ignore recoverable parsing errors, such as duplicate thermo or "
-              "transport data"))
-        # The '--permissive' option allows certain recoverable parsing errors (such as
-        # duplicate transport data) to be ignored.
+        help=("This option allows certain recoverable parsing errors (for example, "
+              "duplicate thermo or transport data) to be ignored."))
     parser.add_argument(
         "-q", "--quiet", action="store_true", default=False,
-        help="do not produce logging output")
+        help="Suppresses warning messages, such as those about duplicate thermo data.")
     parser.add_argument(
         "-d", "--debug", action="store_true", default=False,
-        help="use debugging mode")
+        help=("Enables additional debugging output that may be helpful in identifying "
+              "problems in the input files or **ck2yaml** itself."))
     parser.add_argument(
         "--input", default="",
-        help=("Chemkin-format mechanism file; if omitted, THERMO data are "
-              "converted to a YAML file containing only species definitions"))
-        # An input file containing only species definitions (which can be referenced
-        # from phase definitions in other input files) can be created by specifying
-        # only a thermo file.
+        help=("Chemkin-format chemistry input file, containing a list of all the "
+              "element names that are used, a list of all the species names, and a "
+              "list of all the reactions to be considered between the species. This "
+              "file can also optionally contain species THERMO and TRANSPORT data."))
     parser.add_argument(
         "--thermo", default="",
-        help=("Chemkin-format thermo data file; if omitted, thermo data must be "
-              "included in INPUT file"))
+        help=("If the INPUT file does not contain THERMO data, a separate file "
+              "containing thermodynamic information must be specified. If no INPUT "
+              "file is provided, THERMO data are converted to a YAML file containing "
+              "only species definitions (which can be referenced from phase "
+              "definitions in other input files)."))
     parser.add_argument(
         "--transport", default="",
-        help=("Chemkin-format transport data file; if omitted and transport data are "
-              "not included in INPUT file, transport models will not be supported"))
+        help=("If the INPUT file does not contain TRANSPORT data, a separate file "
+              "containing transport information may be specified. Transport data are "
+              "required for Cantera capabilities that use transport properties such "
+              "as one-dimensional flame calculations; they are usually not required "
+              "for zero-dimensional reactor simulations."))
     parser.add_argument(
         "--surface", default="",
-        help=("Chemkin-format surface mechanism file; if provided, a corresponding "
-              "gas phase mechanism should be specified as INPUT"))
-        # For the case of a surface mechanism, the gas phase input file should be
-        # specified as 'input' and the surface phase input file should be specified as
-        # 'surface'.
+        help=("For surface mechanisms, the SURFACE file defines surface species "
+              "and reactions occurring on the surface. Gas phase species and reactions "
+              "should be defined in the INPUT file."))
     parser.add_argument(
         "--extra", default="",
-        help=("YAML file with auxiliary data to be included in output, such as "
-              "file description or custom fields"))
-        # The '--extra=<filename>' option takes a YAML file as input. This option can
-        # be used to add to the file description, or to define custom fields that are
-        # included in the YAML output.
+        help=("This option specifies a YAML file which can be used to add to the "
+              "**description** field or to define custom fields that are included in "
+              "the YAML output."))
     parser.add_argument(
         "--name", default="gas",
-        help=("name of phase used for YAML output; default is 'gas'"))
-        # The '--name=<name>' option is used
-        # to override default phase names (that is, 'gas').
+        help=("This specifies the name of the phase in the resulting YAML file. The "
+              "default is **gas**."))
     parser.add_argument(
         "--single-intermediate-temperature", action="store_true", default=False,
-        help=("thermo data with single break temperature; last value in first line "
-              "of each species thermo entry is the molecular weight"))
-        # The '--single-intermediate-temperature' option should be used with thermo
-        # data where only a single break temperature is used and the last value in the
-        # first line of each species thermo entry is the molecular weight instead.
+        help=("This option should be used with thermo data where only a single break "
+              "temperature is used and the last value in the first line of each "
+              "species thermo entry is the molecular weight instead."))
     parser.add_argument(
         "--no-validate", action="store_true", default=False,
-        help="skip validation step")
+        help=("Disables the validation step, where the YAML mechanism is imported in "
+              "Cantera to check for errors such as unlabeled duplicate reactions and "
+              "discontinuous thermodynamic data."))
     parser.add_argument(
         "--output", default="",
-        help=("YAML output file name; if not specified, the output file name is based "
-              "on the input file, with the extension changed to '.yaml'"))
-        # If the output file name is not given, an output file with the same name as
-        # the input file, with the extension changed to '.yaml'.
+        help=("Specifies the OUTPUT file name. By default, the output file name is the "
+              "input file name with the extension changed to **.yaml**."))
 
     return parser
 

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -6,7 +6,7 @@
 
 """Convert Chemkin-format mechanism files to YAML.
 
-There are two main entry points to this script, `main` and `Parser.convert_mech`. The former is
+There are two main entry points to this script, `main` and `convert`. The former is
 used from the command line interface and parses the arguments passed. The latter uses
 arguments that correspond to options of the command line interface.
 """
@@ -16,6 +16,7 @@ import os.path
 import sys
 import numpy as np
 import re
+import warnings
 import argparse
 import textwrap
 from email.utils import formatdate
@@ -2133,10 +2134,27 @@ class Parser:
               'the kinetics input file.'.format(equation, lines[0], lines[1]))
 
 
+def convert(input_file, thermo_file=None, transport_file=None,
+            surface_file=None, phase_name='gas', extra_file=None,
+            out_name=None, single_intermediate_temperature=False, quiet=False,
+            permissive=None):
+    _, surface_names = Parser.convert_mech(
+        input_file, thermo_file, transport_file, surface_file, phase_name,
+        extra_file, out_name, single_intermediate_temperature, quiet, permissive)
+    return surface_names
+
+
 def convert_mech(input_file, thermo_file=None, transport_file=None,
                  surface_file=None, phase_name='gas', extra_file=None,
                  out_name=None, single_intermediate_temperature=False, quiet=False,
                  permissive=None):
+    """
+    .. deprecated:: 3.0
+
+        To be removed after Cantera 3.1; renamed to :func:`convert`.
+    """
+    warnings.warn(
+        "To be removed after Cantera 3.1; renamed to 'convert'")
     _, surface_names = Parser.convert_mech(
         input_file, thermo_file, transport_file, surface_file, phase_name,
         extra_file, out_name, single_intermediate_temperature, quiet, permissive)

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -2180,7 +2180,9 @@ def convert_mech(input_file, thermo_file=None, transport_file=None,
     return surface_names
 
 
-def main(argv):
+def main(argv=None):
+    if argv is None:
+        argv = sys.argv[1:]
 
     longOptions = ['input=', 'thermo=', 'transport=', 'surface=', 'name=',
                    'extra=', 'output=', 'permissive', 'help', 'debug',
@@ -2266,8 +2268,5 @@ def main(argv):
         sys.exit(1)
 
 
-def script_entry_point():
-    main(sys.argv[1:])
-
 if __name__ == '__main__':
-    main(sys.argv[1:])
+    main()

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -5,7 +5,7 @@
 
 """Convert legacy CTI input files to YAML.
 
-There are two main entry points to this script, `main` and `convert`. The former is
+There are two main entry points to this script, ``main`` and ``convert``. The former is
 used from the command line interface and parses the arguments passed. The latter
 accepts either the name of the CTI input file or a string containing the CTI
 content.

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -5,7 +5,7 @@
 
 """Convert legacy CTML input to YAML format.
 
-There are two main entry points to this script, `main` and `convert`. The former is
+There are two main entry points to this script, ``main`` and ``convert``. The former is
 used from the command line interface and parses the arguments passed. The latter
 accepts either the name of the CTML input file or a string containing the CTML
 content.

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -334,7 +334,8 @@ cdef class _SolutionBase:
         Y.to_file(str(filename))
 
     def write_chemkin(self, mechanism_path=None, thermo_path=None, transport_path=None,
-                      sort_species=False, sort_elements=False, overwrite=False):
+                      sort_species=None, sort_elements=None, overwrite=False,
+                      quiet=False):
         """
         Write this `~cantera.Solution` instance to one or more Chemkin-format files.
         See the documentation for `cantera.yaml2ck.convert` for information about the
@@ -351,7 +352,8 @@ cdef class _SolutionBase:
             sort_elements=sort_elements,
             overwrite=overwrite,
         )
-        print(f"Wrote: {output_paths}")
+        if not quiet:
+            print(f"Wrote: {output_paths}")
 
     def __getitem__(self, selection):
         copy = self.__class__(origin=self)

--- a/interfaces/cython/cantera/yaml2ck.py
+++ b/interfaces/cython/cantera/yaml2ck.py
@@ -826,7 +826,7 @@ def main():
             print("Validating mechanism...", end="")
             with tempfile.TemporaryDirectory() as td:
                 out_name = Path(td) / "test_mech.yaml"
-                ck2yaml.convert_mech(
+                ck2yaml.convert(
                     *ck_paths,
                     phase_name="gas",
                     out_name=out_name,

--- a/interfaces/cython/cantera/yaml2ck.py
+++ b/interfaces/cython/cantera/yaml2ck.py
@@ -170,7 +170,7 @@ def build_species_text(species: Iterable[ct.Species], max_width=80) -> str:
 
     .. versionadded:: 3.0
     """
-    species_names = {s.name: s.input_data.get("note", "") for s in species}
+    species_names = {s.name: str(s.input_data.get('note', '')) for s in species}
 
     # Notes shorter than 7 characters are probably related to thermo entries
     # and will be included with the thermo entry.
@@ -287,7 +287,7 @@ def build_thermodynamics_text(
         if spec.thermo.max_temp > max_temp:
             max_temp = spec.thermo.max_temp
 
-        note = input_data["thermo"].get("note", "")
+        note = str(input_data['thermo'].get('note', ''))
         if len(note) <= 6:
             comment = ""
             fmt_data["note"] = note

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -66,7 +66,7 @@ units = pint
 
 [options.entry_points]
 console_scripts =
-    ck2yaml = cantera.ck2yaml:script_entry_point
+    ck2yaml = cantera.ck2yaml:main
     cti2yaml = cantera.cti2yaml:main
     ctml2yaml = cantera.ctml2yaml:main
     yaml2ck = cantera.yaml2ck:main

--- a/interfaces/python_minimal/setup.cfg.in
+++ b/interfaces/python_minimal/setup.cfg.in
@@ -43,7 +43,7 @@ packages =
 
 [options.entry_points]
 console_scripts =
-    ck2yaml = cantera.ck2yaml:script_entry_point
+    ck2yaml = cantera.ck2yaml:main
     cti2yaml = cantera.cti2yaml:main
     ctml2yaml = cantera.ctml2yaml:main
     yaml2ck = cantera.yaml2ck:main

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -71,7 +71,7 @@ units = pint
 
 [options.entry_points]
 console_scripts =
-    ck2yaml = cantera.ck2yaml:script_entry_point
+    ck2yaml = cantera.ck2yaml:main
     cti2yaml = cantera.cti2yaml:main
     ctml2yaml = cantera.ctml2yaml:main
     yaml2ck = cantera.yaml2ck:main

--- a/test/data/species-names.yaml
+++ b/test/data/species-names.yaml
@@ -76,6 +76,7 @@ species:
       -1.02466476e+04, -4.64130376]
     - [0.074851495, 0.0133909467, -5.73285809e-06, 1.22292535e-09, -1.0181523e-13,
       -9468.34459, 18.437318]
+    note: 120521 # string incidentally serialized as integer
 - name: plus
   composition: {C: 1, H: 4}
   thermo:
@@ -86,6 +87,7 @@ species:
       -1.02466476e+04, -4.64130376]
     - [0.074851495, 0.0133909467, -5.73285809e-06, 1.22292535e-09, -1.0181523e-13,
       -9468.34459, 18.437318]
+    note: 12.05 # string incidentally serialized as float
 - name: trans_butene
   composition: {C: 1, H: 4}
   thermo:

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -31,7 +31,7 @@ class ck2yamlTest(utilities.CanteraTest):
         # In Python >= 3.8, this can be replaced by the missing_ok argument
         if output.is_file():
             output.unlink()
-        ck2yaml.convert_mech(inputFile, thermo_file=thermo,
+        ck2yaml.convert(inputFile, thermo_file=thermo,
             transport_file=transport, surface_file=surface, out_name=output,
             extra_file=extra, quiet=True, **kwargs)
         return output
@@ -591,7 +591,7 @@ class yaml2ckTest(utilities.CanteraTest):
             mech, thermo, transport = self._convert_to_ck(input_file, phase_name)
 
         output = self.test_work_path / (Path(input_file).stem + self.ext)
-        ck2yaml.convert_mech(
+        ck2yaml.convert(
             mech,
             thermo_file=thermo,
             transport_file=transport,

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -780,6 +780,25 @@ class yaml2ckTest(utilities.CanteraTest):
         self.check_kinetics(ck_phase, yaml_phase, [900, 1800], [2e5, 20e5], tol=2e-7)
         self.check_transport(ck_phase, yaml_phase, [298, 1001, 2400])
 
+    def test_write_notes(self):
+        input_file = self.test_data_path / 'species-names.yaml'
+        yaml_phase = ct.Solution(input_file)
+        assert yaml_phase.species("eq=uals").input_data["thermo"]["note"] == 120521
+        assert yaml_phase.species("plus").input_data["thermo"]["note"] == 12.05
+
+        ck_file = self.test_work_path / 'species-names.ck'
+        ck_file.unlink(missing_ok=True)
+        yaml_phase.write_chemkin(ck_file, quiet=True)
+
+        yaml_file = self.test_work_path / 'species-names.yaml'
+        yaml_file.unlink(missing_ok=True)
+        ck2yaml.convert(ck_file, out_name=yaml_file, quiet=True)
+        assert yaml_file.exists()
+
+        ck_phase = ct.Solution(yaml_file)
+        assert ck_phase.species("eq=uals").input_data["thermo"]["note"] == "120521"
+        assert ck_phase.species("plus").input_data["thermo"]["note"] == "12.05"
+
 
 class cti2yamlTest(utilities.CanteraTest):
     def convert(self, basename, src_dir=None, encoding=None):

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -757,6 +757,29 @@ class yaml2ckTest(utilities.CanteraTest):
         self.check_kinetics(ck_phase, yaml_phase, [900, 1800], [2e5, 20e5], tol=2e-7)
         self.check_transport(ck_phase, yaml_phase, [298, 1001, 2400])
 
+    def test_write_chemkin(self):
+        # test alternative converter
+        yaml_phase = ct.Solution('h2o2.yaml')
+        ck_file = self.test_work_path / 'test.ck'
+        ck_file.unlink(missing_ok=True)
+        yaml_phase.write_chemkin(ck_file, quiet=True)
+        yaml_phase.write_chemkin(
+            ck_file, sort_species='alphabetical', overwrite=True, quiet=True)
+        assert ck_file.exists()
+
+        yaml_file = self.test_work_path / 'test.yaml'
+        yaml_file.unlink(missing_ok=True)
+        ck2yaml.convert(ck_file, out_name=yaml_file, quiet=True)
+        assert yaml_file.exists()
+        ck_phase = ct.Solution(yaml_file)
+
+        X = {'O2': 0.3, 'H': 0.1, 'H2': 0.2, 'AR': 0.4}
+        ck_phase.X = X
+        yaml_phase.X = X
+        self.check_thermo(ck_phase, yaml_phase, [300, 500, 1300, 2000])
+        self.check_kinetics(ck_phase, yaml_phase, [900, 1800], [2e5, 20e5], tol=2e-7)
+        self.check_transport(ck_phase, yaml_phase, [298, 1001, 2400])
+
 
 class cti2yamlTest(utilities.CanteraTest):
     def convert(self, basename, src_dir=None, encoding=None):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Switch `ck2yaml` to `argparse` in order to be consistent with other converter scripts
- Update documentation; taking advantage of `sphinx-argparse` 
- Address `Solution.write_chemkin` bugs

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1611, partially addresses #1610

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

`ck2yaml` now has the following help text (generated by `argparse`)
```
% ck2yaml --help
usage: ck2yaml [-h] [-p] [-q] [-d] [--input INPUT] [--thermo THERMO] [--transport TRANSPORT]
               [--surface SURFACE] [--extra EXTRA] [--name NAME] [--single-intermediate-temperature]
               [--no-validate] [--output OUTPUT]

Convert Chemkin-format mechanisms to Cantera YAML input files

options:
  -h, --help            show this help message and exit
  -p, --permissive      This option allows certain recoverable parsing errors (for example, duplicate
                        thermo or transport data) to be ignored.
  -q, --quiet           Suppresses warning messages, such as those about duplicate thermo data.
  -d, --debug           Enables additional debugging output that may be helpful in identifying problems
                        in the input files or **ck2yaml** itself.
  --input INPUT         Chemkin-format chemistry input file, containing a list of all the element names
                        that are used, a list of all the species names, and a list of all the reactions
                        to be considered between the species. This file can also optionally contain
                        species THERMO and TRANSPORT data.
  --thermo THERMO       If the INPUT file does not contain THERMO data, a separate file containing
                        thermodynamic information must be specified. If no INPUT file is provided,
                        THERMO data are converted to a YAML file containing only species definitions
                        (which can be referenced from phase definitions in other input files).
  --transport TRANSPORT
                        If the INPUT file does not contain TRANSPORT data, a separate file containing
                        transport information may be specified. Transport data are required for Cantera
                        calculations that use transport properties such as one-dimensional flame
                        calculations; they are usually not required for zero-dimensional reactor
                        simulations.
  --surface SURFACE     For surface mechanisms, the SURFACE file defines surface species and reactions
                        occurring on the surface. Gas phase species and reactions should be defined in
                        the INPUT file.
  --extra EXTRA         This option specifies a YAML file which can be used to add to the
                        **description** field or to define custom fields that are included in the YAML
                        output.
  --name NAME           This specifies the name of the phase in the resulting YAML file. The default is
                        **gas**.
  --single-intermediate-temperature
                        This option should be used with thermo data where only a single break
                        temperature is used and the last value in the first line of each species thermo
                        entry is the molecular weight instead.
  --no-validate         Disables the validation step, where the YAML mechanism is imported in Cantera
                        to check for errors such as unlabeled duplicate reactions and discontinuous
                        thermodynamic data.
  --output OUTPUT       Specifies the OUTPUT file name. By default, the output file name is the input
                        file name with the extension changed to **.yaml**.

Example::

    ck2yaml --input=chem.inp --thermo=therm.dat --transport=tran.dat

If the **ck2yaml** script is not on your path but the Cantera Python module is,
**ck2yaml** can also be invoked by running::

    python -m cantera.ck2yaml --input=chem.inp --thermo=therm.dat --transport=tran.dat

In both cases, the equal sign in the options is optional.
```

While not the main issue, this now works:
```Python
import cantera as ct
gas = ct.Solution('h2o2.yaml')
gas.write_chemkin('test.ck')
gas.write_chemkin('test.ck', sort_species='alphabetical', overwrite=True)
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
