### PR TITLE
Reactor net visualization

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -92,7 +92,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons==3.1.2 numpy cython pandas pytest \
-        pytest-github-actions-annotate-failures pint
+        pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: |
         python3 `which scons` build env_vars=all -j2 debug=n --debug=time \
@@ -141,7 +141,7 @@ jobs:
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
       run: |
-        python3 -m pip install ruamel.yaml scons numpy cython pandas pytest pytest-github-actions-annotate-failures pint
+        python3 -m pip install ruamel.yaml scons numpy cython pandas pytest pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
@@ -192,7 +192,7 @@ jobs:
       run: $PYTHON_CMD -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
       run: |
-        $PYTHON_CMD -m pip install ruamel.yaml numpy cython pandas pytest pytest-github-actions-annotate-failures pint
+        $PYTHON_CMD -m pip install ruamel.yaml numpy cython pandas pytest pytest-github-actions-annotate-failures pint graphviz
     - name: Install Python dependencies for GH Python
       if: matrix.python-version == '3.11'
       run:
@@ -241,7 +241,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons numpy cython pandas scipy pytest \
-        pytest-github-actions-annotate-failures pytest-cov gcovr pint
+        pytest-github-actions-annotate-failures pytest-cov gcovr pint graphviz
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v2
       with:
@@ -412,7 +412,7 @@ jobs:
         run: python3 -m pip install -U pip setuptools wheel
       - name: Install Python dependencies
         run: |
-            python3 -m pip install numpy ruamel.yaml pandas matplotlib scipy pint
+            python3 -m pip install numpy ruamel.yaml pandas matplotlib scipy pint graphviz
             python3 -m pip install --pre --no-index --find-links dist cantera
       - name: Run the examples
         # See https://unix.stackexchange.com/a/392973 for an explanation of the -exec part
@@ -476,7 +476,7 @@ jobs:
         run: |
           conda install -q sundials=${{ matrix.sundials-ver }} scons numpy ruamel.yaml \
           cython boost-cpp fmt=${{ matrix.fmt-ver }} eigen yaml-cpp pandas \
-          libgomp openblas pytest highfive
+          libgomp openblas pytest highfive python-graphviz
       - name: Build Cantera
         run: |
           scons build system_fmt=y system_eigen=y system_yamlcpp=y system_sundials=y \
@@ -545,7 +545,7 @@ jobs:
       # use boost-cpp rather than boost from conda-forge
       # Install SCons >=4.4.0 to make sure that MSVC_TOOLSET_VERSION variable is present
       run: |
-        mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp pandas pytest highfive pint fmt=${{ matrix.fmt-ver }}
+        mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp pandas pytest highfive pint python-graphviz fmt=${{ matrix.fmt-ver }}
       shell: pwsh
     - name: Build Cantera
       run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
@@ -610,7 +610,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip setuptools wheel
-          python -m pip install '"scons<4.4.0"' pypiwin32 numpy ruamel.yaml cython pandas pytest pytest-github-actions-annotate-failures
+          python -m pip install '"scons<4.4.0"' pypiwin32 numpy ruamel.yaml cython pandas graphviz pytest pytest-github-actions-annotate-failures
       - name: Restore Boost cache
         uses: actions/cache@v3
         id: cache-boost
@@ -674,7 +674,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons numpy cython pandas pytest \
-        pytest-github-actions-annotate-failures pint
+        pytest-github-actions-annotate-failures pint graphviz
     - name: Setup Intel oneAPI environment
       run: |
         source /opt/intel/oneapi/setvars.sh
@@ -707,7 +707,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install -U pip setuptools wheel
-        python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas pytest pytest-github-actions-annotate-failures pint
+        python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas pytest pytest-github-actions-annotate-failures pint graphviz
     - name: Restore Boost cache
       uses: actions/cache@v3
       id: cache-boost

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons numpy pandas pytest pint \
-          pytest-github-actions-annotate-failures
+          pytest-github-actions-annotate-failures graphviz
         python3 -m pip install --pre cython
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all
@@ -80,7 +80,7 @@ jobs:
         libboost-dev gfortran libopenmpi-dev libpython3-dev \
         libblas-dev liblapack-dev libhdf5-dev libfmt-dev libyaml-cpp-dev \
         libgtest-dev libgmock-dev libeigen3-dev libsundials-dev \
-        cython3 python3-numpy python3-pandas python3-pint \
+        cython3 python3-numpy python3-pandas python3-pint python3-graphviz \
         python3-ruamel.yaml python3-setuptools python3-wheel python3-pytest
         gcc --version
     - name: Install Python dependencies
@@ -122,7 +122,8 @@ jobs:
         gcc-fortran gmock-devel gtest-devel python3 python3-cython \
         python3-devel python3-numpy python3-pandas python3-pint python3-pip \
         python3-pytest python3-ruamel-yaml python3-scipy python3-scons \
-        python3-wheel sundials-devel yaml-cpp-devel hdf5-devel highfive-devel
+        python3-wheel sundials-devel yaml-cpp-devel hdf5-devel highfive-devel \
+        python3-graphviz
     - name: Build Cantera
       run: |
         scons build -j2 debug=n --debug=time python_package=full f90_interface=y \
@@ -169,7 +170,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons numpy cython pandas pytest \
-        pytest-github-actions-annotate-failures pint
+        pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: |
         python3 `which scons` build env_vars=all -j2 debug=n --debug=time \

--- a/AUTHORS
+++ b/AUTHORS
@@ -24,6 +24,7 @@ Thomas Fiala (@thomasfiala), Technische Universität München
 David Fronczek
 Mark E. Fuller (@mefuller), Technion
 Sammo Gabay (@Burkenyo)
+Niclas Garan (@Naikless), Technische Universität Berlin
 Matteo Giani (@MarcDuQuesne)
 Dave Goodwin, California Institute of Technology
 China Hagström (@chinahg), Massachusetts Institute of Technology

--- a/doc/sphinx/python/zerodim.rst
+++ b/doc/sphinx/python/zerodim.rst
@@ -40,78 +40,78 @@ Reservoir
 
 Reactor
 ^^^^^^^
-.. autoclass:: Reactor
+.. autoclass:: Reactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 MoleReactor
 ^^^^^^^^^^^
-.. autoclass:: MoleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: MoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasReactor
 ^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: IdealGasReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasMoleReactor
 ^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasMoleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: IdealGasMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ConstPressureReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ConstPressureReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ConstPressureMoleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ConstPressureMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasConstPressureReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: IdealGasConstPressureReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasConstPressureMoleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: IdealGasConstPressureMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 FlowReactor
 ^^^^^^^^^^^
-.. autoclass:: FlowReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: FlowReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleReactor
 ^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ExtensibleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ExtensibleIdealGasReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleConstPressureReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ExtensibleConstPressureReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasConstPressureReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ExtensibleIdealGasConstPressureReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleMoleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ExtensibleMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasMoleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ExtensibleIdealGasMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleConstPressureMoleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ExtensibleConstPressureMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasConstPressureMoleReactor(contents=None, *, name=None, energy='on')
+.. autoclass:: ExtensibleIdealGasConstPressureMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
 
 Walls
 -----
 
 Wall
 ^^^^
-.. autoclass:: Wall(left, right, *, name=None, A=None, K=None, U=None, Q=None, velocity=None)
+.. autoclass:: Wall(left, right, *, name=None, A=None, K=None, U=None, Q=None, velocity=None, edge_attr=None)
    :inherited-members:
 
 Surfaces
@@ -145,3 +145,18 @@ Preconditioners
 AdaptivePreconditioner
 ^^^^^^^^^^^^^^^^^^^^^^
 .. autoclass:: AdaptivePreconditioner
+
+Drawing Reactor Networks
+------------------------
+These functions provide the implementation behind the ``draw`` methods of the
+corresponding classes.
+
+.. autofunction:: cantera.drawnetwork.draw_reactor
+
+.. autofunction:: cantera.drawnetwork.draw_reactor_net
+
+.. autofunction:: cantera.drawnetwork.draw_surface
+
+.. autofunction:: cantera.drawnetwork.draw_flow_controllers
+
+.. autofunction:: cantera.drawnetwork.draw_walls

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -31,16 +31,16 @@ def _needs_graphviz(func):
 
 
 @_needs_graphviz
-def draw_reactor(r, dot=None, graph_attr=None, node_attr=None, print_state=False, species=None,
-                 species_units="percent", **kwargs):
+def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=False,
+                 species=None, species_units="percent"):
     """
     Draw `ReactorBase` object as ``graphviz`` ``dot`` node.
-    The node is added to an existing ``dot`` graph if provided.
+    The node is added to an existing ``graph`` if provided.
     Optionally include current reactor state in the node.
 
     :param r:
         `ReactorBase` object or subclass.
-    :param dot:
+    :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param print_state:
@@ -71,8 +71,8 @@ def draw_reactor(r, dot=None, graph_attr=None, node_attr=None, print_state=False
     .. versionadded:: 3.1
     """
 
-    if not dot:
-        dot = _graphviz.Digraph(name=r.name, graph_attr=graph_attr)
+    if not graph:
+        graph = _graphviz.Digraph(name=r.name, graph_attr=graph_attr)
 
     # attributes defined in Reactor.node_attr overwrite default attributes
     node_attr = dict(node_attr or {}, **r.node_attr)
@@ -110,20 +110,21 @@ def draw_reactor(r, dot=None, graph_attr=None, node_attr=None, print_state=False
 
         # For full state output, shape must be 'Mrecord'
         node_attr.pop("shape", None)
-        dot.node(r.name, shape="Mrecord",
-                 label=f"{{{T_label}|{P_label}}}|{s_label}",
-                 xlabel=r.name,
-                 **node_attr)
+        graph.node(r.name, shape="Mrecord",
+                   label=f"{{{T_label}|{P_label}}}|{s_label}",
+                   xlabel=r.name,
+                   **node_attr)
 
     else:
-        dot.node(r.name, **node_attr)
+        graph.node(r.name, **node_attr)
 
-    return dot
+    return graph
 
 
 @_needs_graphviz
-def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None, heat_flow_attr=None,
-                     mass_flow_attr=None, print_state=False, **kwargs):
+def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
+                     heat_flow_attr=None, mass_flow_attr=None, print_state=False,
+                     **kwargs):
     """
     Draw `ReactorNet` object as ``graphviz.graphs.DiGraph``. Connecting flow
     controllers and walls are depicted as arrows.
@@ -165,7 +166,7 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None, heat_fl
     .. versionadded:: 3.1
     """
 
-    dot = _graphviz.Digraph(graph_attr=graph_attr)
+    graph = _graphviz.Digraph(graph_attr=graph_attr)
 
     # collect elements as set to avoid duplicates
     reactors = set(n.reactors)
@@ -174,9 +175,9 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None, heat_fl
 
     reactor_groups = {}
     for r in reactors:
-        if r.groupname not in reactor_groups:
-            reactor_groups[r.groupname] = set()
-        reactor_groups[r.groupname].add(r)
+        if r.group_name not in reactor_groups:
+            reactor_groups[r.group_name] = set()
+        reactor_groups[r.group_name].add(r)
 
     reactor_groups.pop("", None)
     if reactor_groups:
@@ -188,16 +189,17 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None, heat_fl
                 drawn_reactors.add(r)
                 connections.update(r.walls + r.inlets + r.outlets)
                 for surface in r.surfaces:
-                    draw_surface(surface, sub, graph_attr, node_attr, print_state, **kwargs)
+                    draw_surface(surface, sub, graph_attr, node_attr, print_state,
+                                 **kwargs)
             sub.attr(label=name)
-            dot.subgraph(sub)
-    reactors.difference_update(drawn_reactors)
+            graph.subgraph(sub)
+    reactors -= drawn_reactors
 
     for r in reactors:
-        draw_reactor(r, dot, graph_attr, node_attr, print_state, **kwargs)
+        draw_reactor(r, graph, graph_attr, node_attr, print_state, **kwargs)
         connections.update(r.walls + r.inlets + r.outlets)
         for surface in r.surfaces:
-            draw_surface(surface, dot, graph_attr, node_attr, print_state, **kwargs)
+            draw_surface(surface, graph, graph_attr, node_attr, print_state, **kwargs)
 
     # some Reactors or Reservoirs only exist as connecting nodes
     connected_reactors = _get_connected_reactors(connections)
@@ -210,12 +212,12 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None, heat_fl
     # remove already drawn reactors and draw new reactors
     connected_reactors.difference_update(drawn_reactors)
     for r in connected_reactors:
-        draw_reactor(r, dot, graph_attr, node_attr, print_state, **kwargs)
+        draw_reactor(r, graph, graph_attr, node_attr, print_state, **kwargs)
 
-    draw_connections(connections, dot, graph_attr, node_attr, edge_attr, heat_flow_attr,
-                     mass_flow_attr, **kwargs)
+    draw_connections(connections, graph, graph_attr, node_attr, edge_attr,
+                     heat_flow_attr, mass_flow_attr, **kwargs)
 
-    return dot
+    return graph
 
 
 def _get_connected_reactors(connections):
@@ -243,14 +245,14 @@ def _get_connected_reactors(connections):
     return connected_reactors
 
 
-def draw_surface(surface, dot=None, graph_attr=None, node_attr=None, surface_edge_attr=None,
-                 print_state=False, **kwargs):
+def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
+                 surface_edge_attr=None, print_state=False, **kwargs):
     """
     Draw `ReactorSurface` object with its connected reactor.
 
     :param surface:
         `ReactorSurface` object.
-    :param dot:
+    :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the connection is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param graph_attr:
@@ -284,21 +286,21 @@ def draw_surface(surface, dot=None, graph_attr=None, node_attr=None, surface_edg
     """
 
     r = surface.reactor
-    dot = draw_reactor(r, dot, graph_attr, node_attr, print_state, **kwargs)
+    graph = draw_reactor(r, graph, graph_attr, node_attr, print_state, **kwargs)
     name = f"{r.name} surface"
     edge_attr = {"style": "dotted", "arrowhead": "none",
                  **(surface_edge_attr or {})}
 
-    dot.node(name, **dict(node_attr or {}, **surface.node_attr))
-    dot.edge(r.name, name, **edge_attr)
+    graph.node(name, **dict(node_attr or {}, **surface.node_attr))
+    graph.edge(r.name, name, **edge_attr)
 
-    return dot
+    return graph
 
 
 @_needs_graphviz
-def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edge_attr=None,
-                     heat_flow_attr=None, mass_flow_attr=None, wall_edge_attr=None,
-                     show_wall_velocity=True, **kwargs):
+def draw_connections(connections, graph=None, graph_attr=None, node_attr=None,
+                     edge_attr=None, heat_flow_attr=None, mass_flow_attr=None,
+                     wall_edge_attr=None, show_wall_velocity=True, **kwargs):
     """
     Draw connections between reactors and reservoirs. This includes flow
     controllers and walls.
@@ -306,7 +308,7 @@ def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edg
     :param connections:
         Iterable containing connections that are either subtypes of
         `FlowDevice` or `WallBase`.
-    :param dot:
+    :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the connection is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param graph_attr:
@@ -343,16 +345,16 @@ def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edg
     .. versionadded:: 3.1
     """
 
-    if not dot:
-        dot = _graphviz.Digraph(graph_attr=graph_attr)
+    if not graph:
+        graph = _graphviz.Digraph(graph_attr=graph_attr)
     if len(connections) > 1:
         # set default style for all connections and nodes if provided
-        dot.edge_attr.update(edge_attr or {})
+        graph.edge_attr.update(edge_attr or {})
         edge_attr_overwrite = {}
     else:
         # assume overwrite if single connection is drawn
         edge_attr_overwrite = edge_attr or {}
-    dot.node_attr.update(node_attr or {})
+    graph.node_attr.update(node_attr or {})
 
     # retrieve default attributes for all mass flow and heat connections
     mass_flow_attr = mass_flow_attr or {}
@@ -411,10 +413,11 @@ def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edg
                     v = -c.velocity
                     inflow_name, outflow_name = r_out_name, r_in_name
 
-                dot.edge(inflow_name, outflow_name,
-                         **{"arrowtail": "icurveteecurve", "dir": "both", "style": "dotted",
-                            "arrowhead": "icurveteecurve", "label": f"wall vel. = {v:.2g} m/s",
-                            **(wall_edge_attr or {})})
+                graph.edge(inflow_name, outflow_name,
+                           **{"arrowtail": "icurveteecurve", "dir": "both",
+                              "style": "dotted", "arrowhead": "icurveteecurve",
+                              "label": f"wall vel. = {v:.2g} m/s",
+                              **(wall_edge_attr or {})})
         except AttributeError:
             pass
 
@@ -430,15 +433,15 @@ def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edg
             inflow_name, outflow_name = r_out_name, r_in_name
             rate *= -1
         elif v > 0:
-            return dot
+            return graph
 
         if rate_attr == "mass_flow_rate":
             label = f"m = {rate:.2g} kg/s"
         elif rate_attr == "heat_rate":
             label = f"q = {rate:.2g} W"
 
-        dot.edge(inflow_name, outflow_name,
-                 **{"label": label, "samehead": samehead, "sametail": sametail,
-                    **edge_attr})
+        graph.edge(inflow_name, outflow_name,
+                   **{"label": label, "samehead": samehead, "sametail": sametail,
+                      **edge_attr})
 
-    return dot
+    return graph

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -397,6 +397,7 @@ def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edg
         # id to ensure that wall velocity and heat flow arrows align
         samehead = sametail = r_in_name + "-" + r_out_name
         # display wall velocity as arrow indicating the wall's movement
+        v = 0
         try:
             if c.velocity != 0 and show_wall_velocity:
                 if c.velocity > 0:
@@ -407,10 +408,8 @@ def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edg
                     inflow_name, outflow_name = r_out_name, r_in_name
 
                 dot.edge(inflow_name, outflow_name,
-                         **{"arrowtail": "teecrow", "dir": "back",
-                            "arrowsize": "1.5", "penwidth": "0", "weight": "2",
-                            "samehead": samehead, "sametail": sametail,
-                            "taillabel": f"wall velocity = {v:.2g} m/s",
+                         **{"arrowtail": "icurveteecurve", "dir": "both", "style": "dotted",
+                            "arrowhead": "icurveteecurve", "label": f"wall vel. = {v:.2g} m/s",
                             **(wall_edge_attr or {})})
         except AttributeError:
             pass
@@ -421,11 +420,13 @@ def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edg
                 - sum(getattr(c, rate_attr) for c in inv_duplicates))
 
         # ensure arrow always indicates a positive flow
-        if rate >= 0:
+        if rate > 0:
             inflow_name, outflow_name = r_in_name, r_out_name
-        else:
+        elif rate < 0:
             inflow_name, outflow_name = r_out_name, r_in_name
             rate *= -1
+        elif v > 0:
+            return dot
 
         if rate_attr == "mass_flow_rate":
             label = f"m = {rate:.2g} kg/s"

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -43,28 +43,25 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
     :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
+    :param graph_attr:
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        general appearance of the drawn network.
+        Has no effect if existing `graph` is provided.
+        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
+    :param node_attr:
+        Attributes to be passed to the ``node`` method invoked to draw the reactor.
+        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
     :param print_state:
         Whether state information of the reactor is printed into the node.
         Defaults to ``False``.
     :param species:
         If ``print_state`` is ``True``, define how species are to be printed.
-        Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all
-        species, respectively, or an iterable that contains the desired species
-        names as strings. Defaults to ``None``.
+        Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all species,
+        respectively, or an iterable that contains the desired species names as strings.
+        Defaults to ``None``.
     :param species_units:
-        Defines the units the species are displayed in as either `"percent"` or
-        `"ppm"`. Defaults to `"percent"`.
-    :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that
-        control the general appearance of the drawn network.
-        See https://graphviz.org/docs/graph/ for a list of all usable
-        attributes.
-    :param node_attr:
-        Attributes to be passed to the ``node`` method invoked to draw the
-        reactor. ``node_attr`` defined in the reactor object itself have
-        priority.
-        See https://graphviz.org/docs/nodes/ for a list of all usable
-        attributes.
+        Defines the units the species are displayed in as either `"percent"` or `"ppm"`.
+        Defaults to `"percent"`.
     :return:
         ``graphviz.graphs.BaseGraph`` object with reactor
 
@@ -74,8 +71,8 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
     if not graph:
         graph = _graphviz.Digraph(name=r.name, graph_attr=graph_attr)
 
-    # attributes defined in Reactor.node_attr overwrite default attributes
-    node_attr = dict(node_attr or {}, **r.node_attr)
+    # Priorities set directly in call overwrite object attributes
+    node_attr = {**r.node_attr, **(node_attr or {})}
 
     # include full reactor state in representation if desired
     if print_state:
@@ -112,8 +109,7 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
         node_attr.pop("shape", None)
         graph.node(r.name, shape="Mrecord",
                    label=f"{{{T_label}|{P_label}}}|{s_label}",
-                   xlabel=r.name,
-                   **node_attr)
+                   xlabel=r.name, **node_attr)
 
     else:
         graph.node(r.name, **node_attr)
@@ -123,8 +119,9 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
 
 @_needs_graphviz
 def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
-                     heat_flow_attr=None, mass_flow_attr=None, print_state=False,
-                     **kwargs):
+                     heat_flow_attr=None, mass_flow_attr=None,
+                     moving_wall_edge_attr=None, surface_edge_attr=None,
+                     print_state=False, show_wall_velocity=True, **kwargs):
     """
     Draw `ReactorNet` object as ``graphviz.graphs.DiGraph``. Connecting flow
     controllers and walls are depicted as arrows.
@@ -132,45 +129,54 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
     :param n:
         `ReactorNet` object
     :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that
-        control the general appearance of the drawn network.
-        See https://graphviz.org/docs/graph/ for a list of all usable
-        attributes.
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        general appearance of the drawn network.
+        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
     :param node_attr:
-        Attributes to be passed to the ``node`` method invoked to draw the
-        reactor. ``node_attr`` defined in the reactor object itself have
-        priority.
-        See https://graphviz.org/docs/nodes/ for a list of all usable
-        attributes.
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        default appearance of any ``node`` (reactors, reservoirs).
+        ``node_attr`` defined in the reactor object itself have priority.
+        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
     :param edge_attr:
-        Attributes to be passed to the ``edge`` method invoked to draw
-        reactor connections. ``edge_attr`` defined in the connection objects
-        (subclasses of `FlowDevice` or walls) themselve have priority.
-        See https://graphviz.org/docs/edges/ for a list of all usable
-        attributes.
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        default appearance of any ``edge`` (flow controllers, walls).
+        ``edge_attr`` defined in the connection objects (subclasses of `FlowDevice` or
+        walls) themselves have priority.
+        See https://graphviz.org/docs/edges/ for a list of all usable attributes.
     :param heat_flow_attr:
         Same as `edge_attr` but only applied to edges representing walls.
+        Default is {"color": "red", "style": "dashed"}.
     :param mass_flow_attr:
-        Same as `edge_attr` but only applied to edges representing
-        `FlowDevice` objects.
+        Same as `edge_attr` but only applied to edges representing `FlowDevice` objects.
+    :param moving_wall_edge_attr:
+        Same as `edge_attr` but only applied to edges representing wall movement.
+    :param surface_edge_attr:
+        Same as `edge_attr` but only applied to edges representing connections between a
+        surface and its reactor.
+        Default is `{"style": "dotted", "arrowhead": "none"}`.
     :param print_state:
-        Whether state information of each reactor is printed into the
-        respective node. See `draw_reactor` for additional keywords to
-        control this output. Defaults to ``False``.
+        Whether state information of each reactor is printed into the respective node.
+        See `draw_reactor` for additional keywords to control this output.
+        Defaults to ``False``.
+    :param show_wall_velocity:
+        If ``True``, wall movement will be indicated by additional arrows with the
+        corresponding wall velocity as a label.
     :param kwargs:
         Additional keywords are passed on to each call of `draw_reactor`,
-        `draw_surface` and `draw_connections`.
+        `draw_surface`, `draw_flow_controllers`, and `draw_walls`.
     :return:
         ``graphviz.graphs.BaseGraph`` object with reactor net.
 
     .. versionadded:: 3.1
     """
 
-    graph = _graphviz.Digraph(graph_attr=graph_attr)
+    graph = _graphviz.Digraph(graph_attr=graph_attr, node_attr=node_attr,
+                              edge_attr=edge_attr)
 
     # collect elements as set to avoid duplicates
     reactors = set(n.reactors)
-    connections = set()
+    flow_controllers = set()
+    walls = set()
     drawn_reactors = set()
 
     reactor_groups = {}
@@ -182,27 +188,31 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
     reactor_groups.pop("", None)
     if reactor_groups:
         for name, group in reactor_groups.items():
-            sub = _graphviz.Digraph(name=f"cluster_{name}",
-                                    graph_attr=graph_attr)
+            sub = _graphviz.Digraph(name=f"cluster_{name}", graph_attr=graph_attr)
             for r in group:
-                draw_reactor(r, sub, graph_attr, node_attr, print_state, **kwargs)
+                draw_reactor(r, sub, print_state=print_state, **kwargs)
                 drawn_reactors.add(r)
-                connections.update(r.walls + r.inlets + r.outlets)
+                flow_controllers.update(r.inlets + r.outlets)
+                walls.update(r.walls)
                 for surface in r.surfaces:
-                    draw_surface(surface, sub, graph_attr, node_attr, print_state,
-                                 **kwargs)
+                    draw_surface(surface, sub, print_state=print_state, **kwargs)
             sub.attr(label=name)
             graph.subgraph(sub)
     reactors -= drawn_reactors
 
     for r in reactors:
-        draw_reactor(r, graph, graph_attr, node_attr, print_state, **kwargs)
-        connections.update(r.walls + r.inlets + r.outlets)
+        draw_reactor(r, graph, print_state=print_state, **kwargs)
+        flow_controllers.update(r.inlets + r.outlets)
+        walls.update(r.walls)
         for surface in r.surfaces:
-            draw_surface(surface, graph, graph_attr, node_attr, print_state, **kwargs)
+            draw_surface(surface, graph, print_state=print_state, **kwargs)
 
     # some Reactors or Reservoirs only exist as connecting nodes
-    connected_reactors = _get_connected_reactors(connections)
+    connected_reactors = set()
+    for fc in flow_controllers:
+        connected_reactors.update((fc.upstream, fc.downstream))
+    for w in walls:
+        connected_reactors.update((w.left_reactor, w.right_reactor))
 
     # ensure that all names are unique
     all_reactors = reactors | connected_reactors
@@ -210,39 +220,19 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
     assert len(names) == len(all_reactors), "All reactors must have unique names when drawn."
 
     # remove already drawn reactors and draw new reactors
-    connected_reactors.difference_update(drawn_reactors)
+    connected_reactors -= drawn_reactors
     for r in connected_reactors:
-        draw_reactor(r, graph, graph_attr, node_attr, print_state, **kwargs)
+        draw_reactor(r, graph, print_state=print_state, **kwargs)
 
-    draw_connections(connections, graph, graph_attr, node_attr, edge_attr,
-                     heat_flow_attr, mass_flow_attr, **kwargs)
+    fc_edge_attr = {**(edge_attr or {}), **(mass_flow_attr or {})}
+    draw_flow_controllers(flow_controllers, graph, edge_attr=fc_edge_attr, **kwargs)
+    w_edge_attr = {**(edge_attr or {}), "color": "red", "style": "dashed",
+                   **(heat_flow_attr or {})}
+    draw_walls(walls, graph, edge_attr=w_edge_attr,
+               moving_wall_edge_attr=moving_wall_edge_attr,
+               show_wall_velocity=show_wall_velocity, **kwargs)
 
     return graph
-
-
-def _get_connected_reactors(connections):
-    """
-    Collect and return all connected reactors.
-
-    :param connections:
-        Iterable containing connections that are either subtypes of
-        `FlowDevice` or `WallBase`.
-    :return:
-        A ``set`` containing the connected reactors and reservoir
-
-    """
-
-    connected_reactors = set()
-
-    for c in connections:
-        # this block detects whether c is a Wall or a FlowController
-        try:
-            r_in, r_out = c.upstream, c.downstream
-        except AttributeError:
-            r_in, r_out = c.left_reactor, c.right_reactor
-        connected_reactors.update((r_in, r_out))
-
-    return connected_reactors
 
 
 def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
@@ -256,21 +246,17 @@ def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
         ``graphviz.graphs.BaseGraph`` object to which the connection is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that
-        control the general appearance of the drawn network.
-        See https://graphviz.org/docs/graph/ for a list of all usable
-        attributes.
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        general appearance of the drawn network.
+        Has no effect if existing `graph` is provided.
+        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
     :param node_attr:
-        Attributes to be passed to the ``node`` method invoked to draw the
-        reactor. ``node_attr`` defined in the `ReactorSurface` object itself
-        have priority.
-        See https://graphviz.org/docs/nodes/ for a list of all usable
-        attributes.
+        Attributes to be passed to the ``node`` method invoked to draw the reactor.
+        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
     :param surface_edge_attr:
-        Attributes to be passed to the ``edge`` method invoked to draw
-        the connection between the surface and its reactor.
-        See https://graphviz.org/docs/edges/ for a list of all usable
-        attributes.
+        Attributes to be passed to the ``edge`` method invoked to draw the connection
+        between the surface and its reactor.
+        See https://graphviz.org/docs/edges/ for a list of all usable attributes.
         Default is `{"style": "dotted", "arrowhead": "none"}`.
     :param print_state:
         Whether state information of the reactor is printed into the node.
@@ -298,47 +284,30 @@ def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
 
 
 @_needs_graphviz
-def draw_connections(connections, graph=None, graph_attr=None, node_attr=None,
-                     edge_attr=None, heat_flow_attr=None, mass_flow_attr=None,
-                     wall_edge_attr=None, show_wall_velocity=True, **kwargs):
+def draw_flow_controllers(flow_controllers, graph=None, graph_attr=None, node_attr=None,
+                          edge_attr=None):
     """
-    Draw connections between reactors and reservoirs. This includes flow
-    controllers and walls.
+    Draw flow controller connections between reactors and reservoirs.
 
-    :param connections:
-        Iterable containing connections that are either subtypes of
-        `FlowDevice` or `WallBase`.
+    :param flow_controllers:
+        Iterable of subtypes of `FlowDevice`.
     :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the connection is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that
-        control the general appearance of the drawn network.
-        See https://graphviz.org/docs/graph/ for a list of all usable
-        attributes.
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        general appearance of the drawn network.
+        Has no effect if existing `graph` is provided.
+        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
     :param node_attr:
-        Attributes to be passed to the ``node`` method invoked to draw the
-        reactor. ``node_attr`` defined in the reactor object itself have
-        priority.
-        See https://graphviz.org/docs/nodes/ for a list of all usable
-        attributes.
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        default appearance of any ``node`` (reactors, reservoirs).
+        Has no effect if existing `graph` is provided.
+        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
     :param edge_attr:
-        Attributes to be passed to the ``edge`` method invoked to draw
-        reactor connections. ``edge_attr`` defined in the connection objects
-        (subclasses of `FlowDevice` or walls) themselve have priority.
-        See https://graphviz.org/docs/edges/ for a list of all usable
-        attributes.
-    :param heat_flow_attr:
-        Same as `edge_attr` but only applied to edges representing heat flow.
-    :param mass_flow_attr:
-        Same as `edge_attr` but only applied to edges representing
-        `FlowDevice` objects.
-    :param wall_edge_attr:
-        Same as `edge_attr` but only applied to edges representing wall
-        movement.
-    :param show_wall_velocity:
-        If ``True``, wall movement will be indicated by additional arrows with
-        the corresponding wall velocity as a label.
+        Attributes to be passed to the ``edge`` method invoked to draw reactor
+        connections.
+        See https://graphviz.org/docs/edges/ for a list of all usable attributes.
     :return:
         A ``graphviz.graphs.BaseGraph`` object depicting the connections.
 
@@ -346,102 +315,145 @@ def draw_connections(connections, graph=None, graph_attr=None, node_attr=None,
     """
 
     if not graph:
-        graph = _graphviz.Digraph(graph_attr=graph_attr)
-    if len(connections) > 1:
-        # set default style for all connections and nodes if provided
-        graph.edge_attr.update(edge_attr or {})
-        edge_attr_overwrite = {}
-    else:
-        # assume overwrite if single connection is drawn
-        edge_attr_overwrite = edge_attr or {}
-    graph.node_attr.update(node_attr or {})
+        graph = _graphviz.Digraph(graph_attr=graph_attr, node_attr=node_attr)
+    # assume overwrite if single connection is drawn
+    edge_attr_overwrite = (edge_attr or {}) if len(flow_controllers) == 1 else {}
 
-    # retrieve default attributes for all mass flow and heat connections
-    mass_flow_attr = mass_flow_attr or {}
-    heat_flow_attr = heat_flow_attr or {}
+    # using a while loop instead of iterating over all connections allows to remove
+    # duplicate connections once they have been detected.
+    flow_controllers = set(flow_controllers)
+    while flow_controllers:
+        fc = flow_controllers.pop()
 
-    # using a while loop instead of iterating over all connections allows to
-    # remove duplicate connections once they have been detected.
-    connections = set(connections)
-    while True:
-        try:
-            c = connections.pop()
-        except KeyError:
-            break
+        r_in, r_out = fc.upstream, fc.downstream
 
-        # this block detects whether c is a Wall or a FlowController
-        try:
-            inflow, outflow = "upstream", "downstream"
-            r_in, r_out = getattr(c, inflow), getattr(c, outflow)
-            rate_attr = "mass_flow_rate"
-            edge_attr = dict(mass_flow_attr, **c.edge_attr, **edge_attr_overwrite)
-        except AttributeError:
-            inflow, outflow = "left_reactor", "right_reactor"
-            r_in, r_out = getattr(c, inflow), getattr(c, outflow)
-            rate_attr = "heat_rate"
-            edge_attr = {"color": "red", "style": "dashed",
-                         **heat_flow_attr, **c.edge_attr, **edge_attr_overwrite}
+        # find "duplicate" flow controllers that connect the same two objects to
+        # eventually draw them as a single connection
+        duplicates, inv_duplicates = set(), set()
+        for fc_ in flow_controllers:
+            if fc_.upstream is r_in and fc_.downstream is r_out:
+                duplicates.add(fc_)
+            elif fc_.downstream is r_in and fc_.upstream is r_out:
+                inv_duplicates.add(fc_)
 
-        # find "duplicate" connections of the same kind that connect the same
-        # two objects to eventually draw them as a single connection
-        duplicates = set()
-        inv_duplicates = set()
-        for c_ in connections:
-            try:
-                if getattr(c_, inflow) is r_in and getattr(c_, outflow) is r_out:
-                    duplicates.add(c_)
-                elif getattr(c_, outflow) is r_in and getattr(c_, inflow) is r_out:
-                    inv_duplicates.add(c_)
-            except AttributeError:
-                continue
-
-        # remove duplicates from the set of the connections still to be drawn
-        connections.difference_update(duplicates | inv_duplicates)
+        # remove duplicates from the set of the flow elements still to be drawn
+        flow_controllers -= duplicates | inv_duplicates
 
         assert r_in.name != r_out.name, "All reactors must have unique names when drawn."
-        r_in_name, r_out_name = r_in.name, r_out.name
-        # id to ensure that wall velocity and heat flow arrows align
-        samehead = sametail = r_in_name + "-" + r_out_name
-        # display wall velocity as arrow indicating the wall's movement
-        v = 0
-        try:
-            if c.velocity != 0 and show_wall_velocity:
-                if c.velocity > 0:
-                    v = c.velocity
-                    inflow_name, outflow_name = r_in_name, r_out_name
-                else:
-                    v = -c.velocity
-                    inflow_name, outflow_name = r_out_name, r_in_name
 
-                graph.edge(inflow_name, outflow_name,
-                           **{"arrowtail": "icurveteecurve", "dir": "both",
-                              "style": "dotted", "arrowhead": "icurveteecurve",
-                              "label": f"wall vel. = {v:.2g} m/s",
-                              **(wall_edge_attr or {})})
-        except AttributeError:
-            pass
+        # sum up mass flow rate while considering the direction
+        rate = (fc.mass_flow_rate + sum(dupe.mass_flow_rate for dupe in duplicates)
+                - sum(idupe.mass_flow_rate for idupe in inv_duplicates))
 
-        # sum up heat rate/mass flow rate while considering the direction
-        rate = (getattr(c, rate_attr)
-                + sum(getattr(c, rate_attr) for c in duplicates)
-                - sum(getattr(c, rate_attr) for c in inv_duplicates))
-
-        # ensure arrow always indicates a positive flow
-        if rate > 0:
-            inflow_name, outflow_name = r_in_name, r_out_name
-        elif rate < 0:
-            inflow_name, outflow_name = r_out_name, r_in_name
+        inflow_name, outflow_name = r_in.name, r_out.name
+        if rate < 0:
+            inflow_name, outflow_name = r_out.name, r_in.name
             rate *= -1
-        elif v > 0:
-            return graph
-
-        if rate_attr == "mass_flow_rate":
-            label = f"m = {rate:.2g} kg/s"
-        elif rate_attr == "heat_rate":
-            label = f"q = {rate:.2g} W"
 
         graph.edge(inflow_name, outflow_name,
-                   **{"label": label, "samehead": samehead, "sametail": sametail,
-                      **edge_attr})
+                   **{"label": f"m = {rate:.2g} kg/s", **edge_attr, **fc.edge_attr,
+                      **edge_attr_overwrite})
+
+    return graph
+
+
+@_needs_graphviz
+def draw_walls(walls, graph=None, graph_attr=None, node_attr=None, edge_attr=None,
+               moving_wall_edge_attr=None, show_wall_velocity=True):
+    """
+    Draw wall connections between reactors and reservoirs.
+
+    :param walls:
+        Iterable of subtypes of `WallBase` that connect reactors and reservoirs.
+    :param graph:
+        ``graphviz.graphs.BaseGraph`` object to which the connection is added.
+        If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
+    :param graph_attr:
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        general appearance of the drawn network.
+        Has no effect if existing `graph` is provided.
+        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
+    :param node_attr:
+        Attributes to be passed to the ``graphviz.Digraph`` function that control the
+        default appearance of any ``node`` (reactors, reservoirs).
+        Has no effect if existing `graph` is provided.
+        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
+    :param edge_attr:
+        Attributes to be passed to the ``edge`` method invoked to draw reactor
+        connections.
+        Default is {"color": "red", "style": "dashed"}.
+        See https://graphviz.org/docs/edges/ for a list of all usable attributes.
+    :param moving_wall_edge_attr:
+        Same as `edge_attr` but only applied to edges representing wall movement.
+        Default is {"arrowtail": "icurveteecurve", "dir": "both", "style": "dotted",
+        "arrowhead": "icurveteecurve"}.
+    :param show_wall_velocity:
+        If ``True``, wall movement will be indicated by additional arrows with the
+        corresponding wall velocity as a label.
+    :return:
+        A ``graphviz.graphs.BaseGraph`` object depicting the connections.
+
+    .. versionadded:: 3.1
+    """
+    if not graph:
+        graph = _graphviz.Digraph(graph_attr=graph_attr, node_attr=node_attr)
+    # assume overwrite if single connection is drawn
+    edge_attr_overwrite = (edge_attr or {}) if len(walls) == 1 else {}
+
+    # using a while loop instead of iterating over all connections allows to remove
+    # duplicate connections once they have been detected.
+    walls = set(walls)
+    while walls:
+        w = walls.pop()
+
+        r_in, r_out = w.left_reactor, w.right_reactor
+
+        # find "duplicate"walls that connect the same two objects to eventually draw
+        # them as a single connection
+        duplicates, inv_duplicates = set(), set()
+        for w_ in walls:
+            if w_.left_reactor is r_in and w_.right_reactor is r_out:
+                duplicates.add(w_)
+            elif w_.right_reactor is r_in and w_.left_reactor is r_out:
+                inv_duplicates.add(w_)
+
+        # remove duplicates from the set of the walls still to be drawn
+        walls -= duplicates | inv_duplicates
+
+        assert r_in.name != r_out.name, "All reactors must have unique names when drawn."
+
+        # display wall velocity as arrow indicating the wall's movement
+        v = w.velocity
+        if v != 0 and show_wall_velocity:
+            if v > 0:
+                inflow_name, outflow_name = r_in.name, r_out.name
+            else:
+                v *= -1
+                inflow_name, outflow_name = r_out.name, r_in.name
+
+            graph.edge(inflow_name, outflow_name,
+                       **{"arrowtail": "icurveteecurve", "dir": "both",
+                          "style": "dotted", "arrowhead": "icurveteecurve",
+                          "label": f"wall vel. = {v:.2g} m/s",
+                          **(moving_wall_edge_attr or {})})
+
+        # sum up heat rate/mass flow rate while considering the direction
+        rate = (w.heat_rate + sum(dupe.heat_rate for dupe in duplicates)
+                - sum(idupe.heat_Rate for idupe in inv_duplicates))
+
+        # just show wall velocity if there is no heat flow
+        if rate == 0 and v > 0:
+            return graph
+
+        # ensure arrow always indicates a positive flow
+        inflow_name, outflow_name = r_in.name, r_out.name
+        if rate < 0:
+            inflow_name, outflow_name = r_out.name, r_in.name
+            rate *= -1
+
+        edge_attr = {"color": "red", "style": "dashed", **(edge_attr or {})}
+        graph.edge(inflow_name, outflow_name,
+                   **{"label": f"q = {rate:.2g} W", **edge_attr, **w.edge_attr,
+                      **edge_attr_overwrite})
 
     return graph

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -126,6 +126,8 @@ def draw_reactor_net(n, **kwargs):
     for r in reactors:
         draw_reactor(r, dot, **kwargs)
         connections.update(r.walls + r.inlets + r.outlets)
+        for surface in r.surfaces:
+            draw_surface(surface, dot, **kwargs)
 
     # some Reactors or Reservoirs only exist as connecting nodes
     connected_reactors = get_connected_reactors(connections)
@@ -165,7 +167,37 @@ def get_connected_reactors(connections):
     return connected_reactors
 
 
-@needs_graphviz
+def draw_surface(surface, dot=None, **kwargs):
+    """
+    Draw `ReactorSurface` object with its connected reactor.
+
+    :param surface:
+        `ReactorSurface` object.
+    :param dot:
+        ``graphviz.graphs.BaseGraph`` object to which the connection is added.
+        If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
+    :param **kwargs:
+        Keyword options can contain ``graph_attr`` and general ``node_attr``
+        and ``edge_attr`` to be passed on to the ``graphviz`` functions to
+        control the appearance of the graph, reactor nodes, and connection
+        edges. ``node_attr`` and ``edge_attr`` defined in the objects
+        themselves have priority.
+    :return:
+        A ``graphviz.graphs.BaseGraph`` object depicting the surface and its
+        reactor.
+
+    """
+    r = surface.reactor
+    dot = draw_reactor(r, dot, **kwargs)
+    name = f"{r.name} surface"
+    edge_attr = {"style": "dotted", "arrowhead": "none",
+                 **kwargs.get("edge_attr", {})}
+
+    node_attr = dict(kwargs.get("node_attr", {}), **surface.node_attr)
+    dot.node(name, **node_attr)
+    dot.edge(r.name, name, **edge_attr)
+
+    return dot
 def draw_connections(connections, dot=None, **kwargs):
     """
     Draw connections between reactors and reservoirs. This includes flow

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -68,6 +68,7 @@ def draw_reactor(r, dot=None, graph_attr=None, node_attr=None, print_state=False
     :return:
         ``graphviz.graphs.BaseGraph`` object with reactor
 
+    .. versionadded:: 3.1
     """
 
     if not dot:
@@ -161,6 +162,7 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None, heat_fl
     :return:
         ``graphviz.graphs.BaseGraph`` object with reactor net.
 
+    .. versionadded:: 3.1
     """
 
     dot = _graphviz.Digraph(graph_attr=graph_attr)
@@ -278,6 +280,7 @@ def draw_surface(surface, dot=None, graph_attr=None, node_attr=None, surface_edg
         A ``graphviz.graphs.BaseGraph`` object depicting the surface and its
         reactor.
 
+    .. versionadded:: 3.1
     """
 
     r = surface.reactor
@@ -337,6 +340,7 @@ def draw_connections(connections, dot=None, graph_attr=None, node_attr=None, edg
     :return:
         A ``graphviz.graphs.BaseGraph`` object depicting the connections.
 
+    .. versionadded:: 3.1
     """
 
     if not dot:

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -34,19 +34,19 @@ def _needs_graphviz(func):
 def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=False,
                  species=None, species_units="percent"):
     """
-    Draw `ReactorBase` object as ``graphviz`` ``dot`` node.
+    Draw `~cantera.ReactorBase` object as ``graphviz`` ``dot`` node.
     The node is added to an existing ``graph`` if provided.
     Optionally include current reactor state in the node.
 
     :param r:
-        `ReactorBase` object or subclass.
+        `~cantera.ReactorBase` object or subclass.
     :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param graph_attr:
         Attributes to be passed to the ``graphviz.Digraph`` function that control the
         general appearance of the drawn network.
-        Has no effect if existing `graph` is provided.
+        Has no effect if existing ``graph`` is provided.
         See https://graphviz.org/docs/graph/ for a list of all usable attributes.
     :param node_attr:
         Attributes to be passed to the ``node`` method invoked to draw the reactor.
@@ -60,8 +60,8 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
         respectively, or an iterable that contains the desired species names as strings.
         Defaults to ``None``.
     :param species_units:
-        Defines the units the species are displayed in as either `"percent"` or `"ppm"`.
-        Defaults to `"percent"`.
+        Defines the units the species are displayed in as either ``"percent"`` or
+        ``"ppm"``. Defaults to ``"percent"``.
     :return:
         ``graphviz.graphs.BaseGraph`` object with reactor
 
@@ -123,11 +123,11 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
                      moving_wall_edge_attr=None, surface_edge_attr=None,
                      print_state=False, show_wall_velocity=True, **kwargs):
     """
-    Draw `ReactorNet` object as ``graphviz.graphs.DiGraph``. Connecting flow
+    Draw `~cantera.ReactorNet` object as ``graphviz.graphs.DiGraph``. Connecting flow
     controllers and walls are depicted as arrows.
 
     :param n:
-        `ReactorNet` object
+        `~cantera.ReactorNet` object
     :param graph_attr:
         Attributes to be passed to the ``graphviz.Digraph`` function that control the
         general appearance of the drawn network.
@@ -140,20 +140,21 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
     :param edge_attr:
         Attributes to be passed to the ``graphviz.Digraph`` function that control the
         default appearance of any ``edge`` (flow controllers, walls).
-        ``edge_attr`` defined in the connection objects (subclasses of `FlowDevice` or
-        walls) themselves have priority.
+        ``edge_attr`` defined in the connection objects (subclasses of
+        `~cantera.FlowDevice` or walls) themselves have priority.
         See https://graphviz.org/docs/edges/ for a list of all usable attributes.
     :param heat_flow_attr:
-        Same as `edge_attr` but only applied to edges representing walls.
-        Default is {"color": "red", "style": "dashed"}.
+        Same as ``edge_attr`` but only applied to edges representing walls.
+        Default is ``{"color": "red", "style": "dashed"}``.
     :param mass_flow_attr:
-        Same as `edge_attr` but only applied to edges representing `FlowDevice` objects.
+        Same as ``edge_attr`` but only applied to edges representing
+        `~cantera.FlowDevice` objects.
     :param moving_wall_edge_attr:
-        Same as `edge_attr` but only applied to edges representing wall movement.
+        Same as ``edge_attr`` but only applied to edges representing wall movement.
     :param surface_edge_attr:
-        Same as `edge_attr` but only applied to edges representing connections between a
-        surface and its reactor.
-        Default is `{"style": "dotted", "arrowhead": "none"}`.
+        Same as ``edge_attr`` but only applied to edges representing connections between
+        a surface and its reactor.
+        Default is ``{"style": "dotted", "arrowhead": "none"}``.
     :param print_state:
         Whether state information of each reactor is printed into the respective node.
         See `draw_reactor` for additional keywords to control this output.
@@ -238,17 +239,17 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
 def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
                  surface_edge_attr=None, print_state=False, **kwargs):
     """
-    Draw `ReactorSurface` object with its connected reactor.
+    Draw `~cantera.ReactorSurface` object with its connected reactor.
 
     :param surface:
-        `ReactorSurface` object.
+        `~cantera.ReactorSurface` object.
     :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the connection is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param graph_attr:
         Attributes to be passed to the ``graphviz.Digraph`` function that control the
         general appearance of the drawn network.
-        Has no effect if existing `graph` is provided.
+        Has no effect if existing ``graph`` is provided.
         See https://graphviz.org/docs/graph/ for a list of all usable attributes.
     :param node_attr:
         Attributes to be passed to the ``node`` method invoked to draw the reactor.
@@ -257,16 +258,15 @@ def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
         Attributes to be passed to the ``edge`` method invoked to draw the connection
         between the surface and its reactor.
         See https://graphviz.org/docs/edges/ for a list of all usable attributes.
-        Default is `{"style": "dotted", "arrowhead": "none"}`.
+        Default is ``{"style": "dotted", "arrowhead": "none"}``.
     :param print_state:
         Whether state information of the reactor is printed into the node.
-        See `draw_reactor` for additional keywords to control this output.
+        See ``draw_reactor`` for additional keywords to control this output.
         Defaults to ``False``.
     :param kwargs:
         Additional keywords are passed on to `draw_reactor`.
     :return:
-        A ``graphviz.graphs.BaseGraph`` object depicting the surface and its
-        reactor.
+        A ``graphviz.graphs.BaseGraph`` object depicting the surface and its reactor.
 
     .. versionadded:: 3.1
     """
@@ -290,19 +290,19 @@ def draw_flow_controllers(flow_controllers, graph=None, graph_attr=None, node_at
     Draw flow controller connections between reactors and reservoirs.
 
     :param flow_controllers:
-        Iterable of subtypes of `FlowDevice`.
+        Iterable of subtypes of `~cantera.FlowDevice`.
     :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the connection is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param graph_attr:
         Attributes to be passed to the ``graphviz.Digraph`` function that control the
         general appearance of the drawn network.
-        Has no effect if existing `graph` is provided.
+        Has no effect if existing ``graph`` is provided.
         See https://graphviz.org/docs/graph/ for a list of all usable attributes.
     :param node_attr:
         Attributes to be passed to the ``graphviz.Digraph`` function that control the
         default appearance of any ``node`` (reactors, reservoirs).
-        Has no effect if existing `graph` is provided.
+        Has no effect if existing ``graph`` is provided.
         See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
     :param edge_attr:
         Attributes to be passed to the ``edge`` method invoked to draw reactor
@@ -364,29 +364,30 @@ def draw_walls(walls, graph=None, graph_attr=None, node_attr=None, edge_attr=Non
     Draw wall connections between reactors and reservoirs.
 
     :param walls:
-        Iterable of subtypes of `WallBase` that connect reactors and reservoirs.
+        Iterable of subtypes of `~cantera.WallBase` that connect reactors and
+        reservoirs.
     :param graph:
         ``graphviz.graphs.BaseGraph`` object to which the connection is added.
         If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
     :param graph_attr:
         Attributes to be passed to the ``graphviz.Digraph`` function that control the
         general appearance of the drawn network.
-        Has no effect if existing `graph` is provided.
+        Has no effect if existing ``graph`` is provided.
         See https://graphviz.org/docs/graph/ for a list of all usable attributes.
     :param node_attr:
         Attributes to be passed to the ``graphviz.Digraph`` function that control the
         default appearance of any ``node`` (reactors, reservoirs).
-        Has no effect if existing `graph` is provided.
+        Has no effect if existing ``graph`` is provided.
         See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
     :param edge_attr:
         Attributes to be passed to the ``edge`` method invoked to draw reactor
         connections.
-        Default is {"color": "red", "style": "dashed"}.
+        Default is ``{"color": "red", "style": "dashed"}``.
         See https://graphviz.org/docs/edges/ for a list of all usable attributes.
     :param moving_wall_edge_attr:
-        Same as `edge_attr` but only applied to edges representing wall movement.
-        Default is {"arrowtail": "icurveteecurve", "dir": "both", "style": "dotted",
-        "arrowhead": "icurveteecurve"}.
+        Same as ``edge_attr`` but only applied to edges representing wall movement.
+        Default is ``{"arrowtail": "icurveteecurve", "dir": "both", "style": "dotted",
+        "arrowhead": "icurveteecurve"}``.
     :param show_wall_velocity:
         If ``True``, wall movement will be indicated by additional arrows with the
         corresponding wall velocity as a label.

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -1,0 +1,257 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+import importlib.metadata
+from functools import wraps
+
+_graphviz = None
+def _import_graphviz():
+    # defer import of graphviz
+    global _graphviz
+    if _graphviz is not None:
+        return
+    try:
+        importlib.metadata.version("graphviz")
+    except importlib.metadata.PackageNotFoundError:
+        raise ImportError("This requires the graphviz package.")
+    else:
+        import graphviz as _graphviz
+
+
+def needs_graphviz(func):
+    # decorator function to load graphviz when needed
+    @wraps(func)
+    def inner(*args, **kwargs):
+        if not _graphviz:
+            _import_graphviz()
+        return func(*args, **kwargs)
+
+    return inner
+
+
+@needs_graphviz
+def draw_reactor(r, dot=None, print_state=False, species=None, **kwargs):
+    """
+    Draw `ReactorBase` object as ``graphviz`` ``dot`` node.
+    The node is added to an existing ``dot`` graph if provided.
+    Optionally include current reactor state in the node.
+
+    :param r:
+        `ReactorBase` object or subclass.
+    :param dot:
+        ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
+        If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
+    :param print_state:
+        Whether state information of the reactor is printed into the node.
+        Defaults to ``False``.
+    :param species:
+        If ``print_state`` is ``True``, define how species are to be printed.
+        Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all
+        species, respectively, or an iterable that contains the desired species
+        names as strings. Defaults to ``None``.
+    :param **kwargs:
+        Keyword options can contain ``graph_attr`` and general ``node_attr`` to
+        be passed on to the ``graphviz`` functions to control the appearance of
+        the graph and reactor node. ``node_attr`` defined in the reactor object
+        itself have priority.
+    :return:
+        ``graphviz.graphs.BaseGraph`` object with reactor
+
+    """
+    if not dot:
+        dot = _graphviz.Digraph(name=r.name,
+                                graph_attr=kwargs.get("graph_attr"))
+
+    # attributes defined in Reactor.node_attr overwrite default attributes
+    node_attr = dict(kwargs.get("node_attr", {}), **r.node_attr)
+
+    # include full reactor state in representation if desired
+    if print_state:
+        T_label = f"T (K)\\n{r.T:.2f}"
+        P_label = f"P (bar)\\n{r.thermo.P*1e-5:.3f}"
+        s_label = ""
+
+        if species == "X":
+            X = r.thermo.mole_fraction_dict()
+            s_percents = "\\n".join([f"{s}: {v*100:.2f}" for s, v in X.items()])
+            s_label += "X (%)\\n" + s_percents
+        elif species == "Y":
+            Y = r.thermo.mass_fraction_dict()
+            s_percents = "\\n".join([f"{s}: {v*100:.2f}" for s, v in Y.items()])
+            s_label += "Y (%)\\n" + s_percents
+        else:
+            # If individual species are provided as iterable of strings
+            if species:
+                X = r.thermo.mole_fraction_dict(threshold=-1)
+                s_percents = "\\n".join([f"{s}: {X[s]*100:.2f}" for s in species])
+                s_label += "X (%)\\n" + s_percents
+
+        # For full state output, shape must be 'Mrecord'
+        node_attr = {k:v for k,v in node_attr.items() if k != "shape"}
+        dot.node(r.name, shape="Mrecord",
+                         label="{"+ T_label +"|"+ P_label +"}"+"|"+ s_label,
+                         xlabel=r.name,
+                         **node_attr)
+
+    else:
+        dot.node(r.name, **node_attr)
+
+    return dot
+
+
+@needs_graphviz
+def draw_reactor_net(n, **kwargs):
+    """
+    Draw `ReactorNet` object as ``graphviz.graphs.DiGraph``. Connecting flow
+    controllers and walls are depicted as arrows.
+
+    :param n:
+        `ReactorNet` object
+    :param **kwargs:
+        Keyword options can contain ``graph_attr`` and general ``node_attr``,
+        ``edge_attr``, ``heat_flow_attr``, and ``mass_flow_attr`` to be passed
+        on to the ``graphviz`` functions to control the appearance of the
+        graph, reactor nodes, and connection edges. ``node_attr`` and
+        ``edge_attr`` defined in the objects themselves have priority.
+    :return:
+        ``graphviz.graphs.BaseGraph`` object with reactor net.
+
+    """
+    dot = _graphviz.Digraph(graph_attr=kwargs.get("graph_attr"))
+
+    # collect elements as set to avoid duplicates
+    reactors = set(n.reactors)
+    connections = set()
+
+    for r in reactors:
+        draw_reactor(r, dot, **kwargs)
+        connections.update(r.walls + r.inlets + r.outlets)
+
+    # some Reactors or Reservoirs only exist as connecting nodes
+    connected_reactors = get_connected_reactors(connections)
+
+    # remove already drawn reactors and draw new reactors
+    connected_reactors.difference_update(reactors)
+    for r in connected_reactors:
+        draw_reactor(r, dot, **kwargs)
+
+    draw_connections(connections, dot, **kwargs)
+
+    return dot
+
+
+def get_connected_reactors(connections):
+    """
+    Collect and returned all connected reactors.
+
+    :param connections:
+        Iterable containing connections that are either subtypes of
+        `FlowDevice` or `WallBase`.
+    :return:
+        A ``set`` containing the connected reactors and reservoir
+
+    """
+
+    connected_reactors = set()
+
+    for c in connections:
+        # this block detects whether c is a Wall or a FlowController
+        try:
+            r_in, r_out = c.upstream, c.downstream
+        except AttributeError:
+            r_in, r_out = c.left_reactor, c.right_reactor
+        connected_reactors.update((r_in, r_out))
+
+    return connected_reactors
+
+
+@needs_graphviz
+def draw_connections(connections, dot=None, **kwargs):
+    """
+    Draw connections between reactors and reservoirs. This includes flow
+    controllers and walls.
+
+    :param connections:
+        Iterable containing connections that are either subtypes of
+        `FlowDevice` or `WallBase`.
+    :param dot:
+        ``graphviz.graphs.BaseGraph`` object to which the connection is added.
+        If not provided, a new ``DiGraph`` is created. Defaults to ``None``
+    :param **kwargs:
+        Keyword options can contain ``graph_attr`` and general ``node_attr``,
+        ``edge_attr``, ``heat_flow_attr``, and ``mass_flow_attr`` to be passed
+        on to the ``graphviz`` functions to control the appearance of the
+        graph, reactor nodes, and connection edges. ``node_attr`` and
+        ``edge_attr`` defined in the objects themselves have priority
+    :return:
+        A ``graphviz.graphs.BaseGraph`` object depicting the connections.
+
+    """
+    if not dot:
+        dot = _graphviz.Digraph(graph_attr=kwargs.get("graph_attr"))
+    # set default style for all connections and nodes if provided
+    dot.edge_attr.update(kwargs.get("edge_attr", {}))
+    dot.node_attr.update(kwargs.get("node_attr", {}))
+
+    # retrieve default attributes for all mass flow and heat connections
+    mass_flow_attr = kwargs.get("mass_flow_attr", {})
+    heat_flow_attr = kwargs.get("heat_flow_attr", {})
+
+    # using a while loop instead of iterating over all connections allows to
+    # remove duplicate connections once they have been detected.
+    connections = set(connections)
+    while True:
+        try:
+            c = connections.pop()
+        except KeyError:
+            break
+
+        # this block detects whether c is a Wall or a FlowController
+        try:
+            inflow, outflow = "upstream", "downstream"
+            r_in, r_out = getattr(c, inflow), getattr(c, outflow)
+            rate_attr = "mass_flow_rate"
+            edge_attr = dict(mass_flow_attr, **c.edge_attr)
+        except AttributeError:
+            inflow, outflow = "left_reactor", "right_reactor"
+            r_in, r_out = getattr(c, inflow), getattr(c, outflow)
+            rate_attr = "heat_rate"
+            edge_attr = {"color": "red", "style": "dashed",
+                         **heat_flow_attr, **c.edge_attr}
+
+        # find "duplicate" connections of the same kind that connect the same
+        # two objects to eventually draw them as a single connection
+        duplicates = set()
+        inv_duplicates = set()
+        for c_ in connections:
+            try:
+                if getattr(c_, inflow) is r_in and getattr(c_, outflow) is r_out:
+                    duplicates.add(c_)
+                elif getattr(c_, outflow) is r_in and getattr(c_, inflow) is r_out:
+                    inv_duplicates.add(c_)
+            except AttributeError:
+                continue
+
+        # remove duplicates from the set of the connections still to be drawn
+        connections.difference_update(duplicates | inv_duplicates)
+
+        # sum up heat rate/mass flow rate while considering the direction
+        rate = (getattr(c, rate_attr)
+                + sum(getattr(c, rate_attr) for c in duplicates)
+                - sum(getattr(c, rate_attr) for c in inv_duplicates))
+
+        # ensure arrow always indicates a positive flow
+        if rate >= 0:
+            inflow_name, outflow_name = r_in.name, r_out.name
+        else:
+            inflow_name, outflow_name = r_out.name, r_in.name
+            rate *= -1
+
+        if rate_attr == "mass_flow_rate":
+            label = f"m = {rate:.2g} kg/s"
+        elif rate_attr == "heat_rate":
+            label = f"q = {rate:.2g} W"
+
+        dot.edge(inflow_name, outflow_name, **{"label": label, **edge_attr})
+
+    return dot

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -189,8 +189,13 @@ def draw_connections(connections, dot=None, **kwargs):
     """
     if not dot:
         dot = _graphviz.Digraph(graph_attr=kwargs.get("graph_attr"))
-    # set default style for all connections and nodes if provided
-    dot.edge_attr.update(kwargs.get("edge_attr", {}))
+    if len(connections) > 1:
+        # set default style for all connections and nodes if provided
+        dot.edge_attr.update(kwargs.get("edge_attr", {}))
+        edge_attr_overwrite = {}
+    else:
+        # assume overwrite if single connection is drawn
+        edge_attr_overwrite = kwargs.get("edge_attr", {})
     dot.node_attr.update(kwargs.get("node_attr", {}))
 
     # retrieve default attributes for all mass flow and heat connections
@@ -211,13 +216,13 @@ def draw_connections(connections, dot=None, **kwargs):
             inflow, outflow = "upstream", "downstream"
             r_in, r_out = getattr(c, inflow), getattr(c, outflow)
             rate_attr = "mass_flow_rate"
-            edge_attr = dict(mass_flow_attr, **c.edge_attr)
+            edge_attr = dict(mass_flow_attr, **c.edge_attr, **edge_attr_overwrite)
         except AttributeError:
             inflow, outflow = "left_reactor", "right_reactor"
             r_in, r_out = getattr(c, inflow), getattr(c, outflow)
             rate_attr = "heat_rate"
             edge_attr = {"color": "red", "style": "dashed",
-                         **heat_flow_attr, **c.edge_attr}
+                         **heat_flow_attr, **c.edge_attr, **edge_attr_overwrite}
 
         # find "duplicate" connections of the same kind that connect the same
         # two objects to eventually draw them as a single connection

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -226,8 +226,11 @@ cdef class ReactorBase:
     cdef object _weakref_proxy
     cdef public dict node_attr
     """
-    A dictionary containing draw attributes for the representation of the reactor as a graphviz
-    node. See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
+    A dictionary containing draw attributes for the representation of the reactor as a
+    graphviz node. See https://graphviz.org/docs/nodes/ for a list of all usable
+    attributes.
+
+    .. versionadded:: 3.1
     """
 
 cdef class Reactor(ReactorBase):
@@ -235,8 +238,11 @@ cdef class Reactor(ReactorBase):
     cdef object _kinetics
     cdef public str group_name
     """
-    Optional name of a grouping of reactors that will be drawn as a cluster in the graphical
-    representation using graphviz. See https://graphviz.org/Gallery/directed/cluster.html.
+    Optional name of a grouping of reactors that will be drawn as a cluster in the
+    graphical representation using graphviz. See
+    https://graphviz.org/Gallery/directed/cluster.html.
+
+    .. versionadded:: 3.1
     """
 
 cdef class MoleReactor(Reactor):
@@ -270,8 +276,11 @@ cdef class ReactorSurface:
     cdef ReactorBase _reactor
     cdef public dict node_attr
     """
-    A dictionary containing draw attributes for the representation of the reactor surface as a
-    graphviz node. See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
+    A dictionary containing draw attributes for the representation of the reactor
+    surface as a graphviz node. See https://graphviz.org/docs/nodes/ for a list of all
+    usable attributes.
+
+    .. versionadded:: 3.1
     """
 
 cdef class WallBase:
@@ -284,8 +293,11 @@ cdef class WallBase:
     cdef str name
     cdef public dict edge_attr
     """
-    A dictionary containing draw attributes for the representation of the `WallBase` as a
-    graphviz edge.See https://graphviz.org/docs/edges/ for a list of all usable attributes.
+    A dictionary containing draw attributes for the representation of the `WallBase` as
+    a graphviz edge.See https://graphviz.org/docs/edges/ for a list of all usable
+    attributes.
+
+    .. versionadded:: 3.1
     """
 
 cdef class Wall(WallBase):
@@ -301,8 +313,11 @@ cdef class FlowDevice:
     cdef ReactorBase _downstream
     cdef public dict edge_attr
     """
-    A dictionary containing draw attributes for the representation of the `FlowDevice` as a
-    graphviz edge.See https://graphviz.org/docs/edges/ for a list of all usable attributes.
+    A dictionary containing draw attributes for the representation of the `FlowDevice`
+    as a graphviz edge.See https://graphviz.org/docs/edges/ for a list of all usable
+    attributes.
+
+    .. versionadded:: 3.1
     """
 
 cdef class MassFlowController(FlowDevice):

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -233,7 +233,7 @@ cdef class ReactorBase:
 cdef class Reactor(ReactorBase):
     cdef CxxReactor* reactor
     cdef object _kinetics
-    cdef public str groupname
+    cdef public str group_name
     """
     Optional name of a grouping of reactors that will be drawn as a cluster in the graphical
     representation using graphviz. See https://graphviz.org/Gallery/directed/cluster.html.

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -258,6 +258,7 @@ cdef class ExtensibleReactor(Reactor):
 cdef class ReactorSurface:
     cdef CxxReactorSurface* surface
     cdef Kinetics _kinetics
+    cdef ReactorBase _reactor
 
 cdef class WallBase:
     cdef shared_ptr[CxxWallBase] _wall

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -229,6 +229,7 @@ cdef class ReactorBase:
 cdef class Reactor(ReactorBase):
     cdef CxxReactor* reactor
     cdef object _kinetics
+    cdef public str groupname
 
 cdef class MoleReactor(Reactor):
     pass

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -224,7 +224,7 @@ cdef class ReactorBase:
     cdef list _walls
     cdef list _surfaces
     cdef object _weakref_proxy
-    cdef dict _node_attr
+    cdef public dict node_attr
 
 cdef class Reactor(ReactorBase):
     cdef CxxReactor* reactor
@@ -259,6 +259,7 @@ cdef class ReactorSurface:
     cdef CxxReactorSurface* surface
     cdef Kinetics _kinetics
     cdef ReactorBase _reactor
+    cdef public dict node_attr
 
 cdef class WallBase:
     cdef shared_ptr[CxxWallBase] _wall
@@ -268,7 +269,7 @@ cdef class WallBase:
     cdef ReactorBase _left_reactor
     cdef ReactorBase _right_reactor
     cdef str name
-    cdef dict _edge_attr
+    cdef public dict edge_attr
 
 cdef class Wall(WallBase):
     pass
@@ -281,7 +282,7 @@ cdef class FlowDevice:
     cdef str name
     cdef ReactorBase _upstream
     cdef ReactorBase _downstream
-    cdef dict _edge_attr
+    cdef public dict edge_attr
 
 cdef class MassFlowController(FlowDevice):
     pass

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -225,11 +225,19 @@ cdef class ReactorBase:
     cdef list _surfaces
     cdef object _weakref_proxy
     cdef public dict node_attr
+    """
+    A dictionary containing draw attributes for the representation of the reactor as a graphviz
+    node. See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
+    """
 
 cdef class Reactor(ReactorBase):
     cdef CxxReactor* reactor
     cdef object _kinetics
     cdef public str groupname
+    """
+    Optional name of a grouping of reactors that will be drawn as a cluster in the graphical
+    representation using graphviz. See https://graphviz.org/Gallery/directed/cluster.html.
+    """
 
 cdef class MoleReactor(Reactor):
     pass
@@ -261,6 +269,10 @@ cdef class ReactorSurface:
     cdef Kinetics _kinetics
     cdef ReactorBase _reactor
     cdef public dict node_attr
+    """
+    A dictionary containing draw attributes for the representation of the reactor surface as a
+    graphviz node. See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
+    """
 
 cdef class WallBase:
     cdef shared_ptr[CxxWallBase] _wall
@@ -271,6 +283,10 @@ cdef class WallBase:
     cdef ReactorBase _right_reactor
     cdef str name
     cdef public dict edge_attr
+    """
+    A dictionary containing draw attributes for the representation of the `WallBase` as a
+    graphviz edge.See https://graphviz.org/docs/edges/ for a list of all usable attributes.
+    """
 
 cdef class Wall(WallBase):
     pass
@@ -284,6 +300,10 @@ cdef class FlowDevice:
     cdef ReactorBase _upstream
     cdef ReactorBase _downstream
     cdef public dict edge_attr
+    """
+    A dictionary containing draw attributes for the representation of the `FlowDevice` as a
+    graphviz edge.See https://graphviz.org/docs/edges/ for a list of all usable attributes.
+    """
 
 cdef class MassFlowController(FlowDevice):
     pass

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -224,6 +224,7 @@ cdef class ReactorBase:
     cdef list _walls
     cdef list _surfaces
     cdef object _weakref_proxy
+    cdef dict _node_attr
 
 cdef class Reactor(ReactorBase):
     cdef CxxReactor* reactor
@@ -266,6 +267,7 @@ cdef class WallBase:
     cdef ReactorBase _left_reactor
     cdef ReactorBase _right_reactor
     cdef str name
+    cdef dict _edge_attr
 
 cdef class Wall(WallBase):
     pass
@@ -278,6 +280,7 @@ cdef class FlowDevice:
     cdef str name
     cdef ReactorBase _upstream
     cdef ReactorBase _downstream
+    cdef dict _edge_attr
 
 cdef class MassFlowController(FlowDevice):
     pass

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -195,6 +195,7 @@ cdef class ReactorBase:
          :return:
              ``graphviz.graphs.BaseGraph`` object with reactor
 
+        .. versionadded:: 3.1
         """
         return draw_reactor(self, dot, graph_attr, node_attr, print_state, species,
                             species_units)
@@ -888,7 +889,10 @@ cdef class ReactorSurface:
 
     @property
     def reactor(self):
-        """Return the `Reactor` object the surface is connected to."""
+        """
+        Return the `Reactor` object the surface is connected to.
+        .. versionadded:: 3.1
+        """
         return self._reactor
 
     def draw(self, dot=None, *, graph_attr=None, node_attr=None, surface_edge_attr=None,
@@ -927,6 +931,7 @@ cdef class ReactorSurface:
             ``graphviz.graphs.BaseGraph`` object with surface and connected
             reactor.
 
+        .. versionadded:: 3.1
         """
         return draw_surface(self, dot, graph_attr, node_attr, surface_edge_attr, print_state,
                             **kwargs)
@@ -1028,12 +1033,18 @@ cdef class WallBase:
 
     @property
     def left_reactor(self):
-        """Return the `Reactor` or `Reservoir` object left of the wall."""
+        """
+        Return the `Reactor` or `Reservoir` object left of the wall.
+        .. versionadded:: 3.1
+        """
         return self._left_reactor
 
     @property
     def right_reactor(self):
-        """Return the `Reactor` or `Reservoir` object right of the wall."""
+        """
+        Return the `Reactor` or `Reservoir` object right of the wall.
+        .. versionadded:: 3.1
+        """
         return self._right_reactor
 
     @property
@@ -1094,6 +1105,7 @@ cdef class WallBase:
         :return:
             A ``graphviz.graphs.BaseGraph`` object depicting the connection.
 
+        .. versionadded:: 3.1
         """
         return draw_connections([self], dot, graph_attr, node_attr, edge_attr, wall_edge_attr,
                                 show_wall_velocity)
@@ -1250,6 +1262,7 @@ cdef class FlowDevice:
     def upstream(self):
         """
         Return the `Reactor` or `Reservoir` object upstream of the flow device.
+        .. versionadded:: 3.1
         """
         return self._upstream
 
@@ -1257,6 +1270,7 @@ cdef class FlowDevice:
     def downstream(self):
         """
         Return the `Reactor` or `Reservoir` object downstream of the flow device.
+        .. versionadded:: 3.1
         """
         return self._downstream
 
@@ -1352,6 +1366,7 @@ cdef class FlowDevice:
         :return:
             A ``graphviz.graphs.BaseGraph`` object depicting the connection.
 
+        .. versionadded:: 3.1
         """
         return draw_connections([self], dot, graph_attr, node_attr, edge_attr)
 
@@ -1601,6 +1616,7 @@ cdef class ReactorNet:
     def reactors(self):
         """
         List of all reactors that are part of the reactor network.
+        .. versionadded:: 3.1
         """
         return self._reactors
 
@@ -2057,6 +2073,7 @@ cdef class ReactorNet:
         :return:
             ``graphviz.graphs.BaseGraph`` object with reactor net.
 
+        .. versionadded:: 3.1
         """
         return draw_reactor_net(self, graph_attr, node_attr, edge_attr, heat_flow_attr,
                  mass_flow_attr, print_state, **kwargs)

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -49,9 +49,9 @@ cdef class ReactorBase:
             self.volume = volume
 
         if node_attr is not None:
-            self._node_attr = node_attr
+            self.node_attr = node_attr
         else:
-            self._node_attr = {}
+            self.node_attr = {}
 
     def insert(self, _SolutionBase solution):
         """
@@ -75,15 +75,6 @@ cdef class ReactorBase:
 
         def __set__(self, name):
             self.rbase.setName(stringify(name))
-
-    @property
-    def node_attr(self):
-        """Atrributes like ``style`` when drawn as node by graphviz dot."""
-        return self._node_attr
-
-    @node_attr.setter
-    def node_attr(self, attr):
-        self._node_attr = attr
 
     def syncState(self):
         """
@@ -981,9 +972,9 @@ cdef class WallBase:
         if velocity is not None:
             self.velocity = velocity
         if edge_attr is not None:
-            self._edge_attr = edge_attr
+            self.edge_attr = edge_attr
         else:
-            self._edge_attr = {}
+            self.edge_attr = {}
 
     def _install(self, ReactorBase left, ReactorBase right):
         """
@@ -1008,15 +999,6 @@ cdef class WallBase:
             return self.wall.area()
         def __set__(self, double value):
             self.wall.setArea(value)
-
-    @property
-    def edge_attr(self):
-        """Style options when drawn as an edge by graphviz dot."""
-        return self._edge_attr
-
-    @edge_attr.setter
-    def edge_attr(self, attr):
-        self._edge_attr = attr
 
     @property
     def left_reactor(self):
@@ -1196,9 +1178,9 @@ cdef class FlowDevice:
             self.name = '{0}_{1}'.format(self.__class__.__name__, n)
 
         if edge_attr is not None:
-            self._edge_attr = edge_attr
+            self.edge_attr = edge_attr
         else:
-            self._edge_attr = {}
+            self.edge_attr = {}
 
         self._install(upstream, downstream)
 
@@ -1240,15 +1222,6 @@ cdef class FlowDevice:
         """
         def __get__(self):
             return self.dev.massFlowRate()
-
-    @property
-    def edge_attr(self):
-        """Style options when drawn as an edge by graphviz dot."""
-        return self._edge_attr
-
-    @edge_attr.setter
-    def edge_attr(self, attr):
-        self._edge_attr = attr
 
     @property
     def pressure_function(self):

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -208,7 +208,8 @@ cdef class Reactor(ReactorBase):
     def __cinit__(self, *args, **kwargs):
         self.reactor = <CxxReactor*>(self.rbase)
 
-    def __init__(self, contents=None, *, name=None, energy='on', **kwargs):
+    def __init__(self, contents=None, *, name=None, energy='on',
+                 groupname=None, **kwargs):
         """
         :param contents:
             Reactor contents. If not specified, the reactor is initially empty.
@@ -220,7 +221,9 @@ cdef class Reactor(ReactorBase):
         :param energy:
             Set to ``'on'`` or ``'off'``. If set to ``'off'``, the energy
             equation is not solved, and the temperature is held at its
-            initial value..
+            initial value.
+        :param groupname:
+            Group reactors of the same ``groupname`` when drawn using graphviz.
 
         Some examples showing how to create :class:`Reactor` objects are
         shown below.
@@ -246,6 +249,11 @@ cdef class Reactor(ReactorBase):
             self.energy_enabled = False
         elif energy != 'on':
             raise ValueError("'energy' must be either 'on' or 'off'")
+
+        if groupname is not None:
+            self.groupname = groupname
+        else:
+            self.groupname = ""
 
     def insert(self, _SolutionBase solution):
         """

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -160,8 +160,8 @@ cdef class ReactorBase:
         """
         self._walls.append(wall)
 
-    def draw(self, dot=None, *, print_state=False, species=None, graph_attr=None,
-             node_attr=None):
+    def draw(self, dot=None, *, print_state=False, species=None,
+             species_units="percent", graph_attr=None, node_attr=None):
         """
         Draw as ``graphviz`` ``dot`` node.
         The node is added to an existing ``dot`` graph if provided.
@@ -178,6 +178,9 @@ cdef class ReactorBase:
            Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all
            species, respectively, or an iterable that contains the desired species
            names as strings. Defaults to ``None``.
+       :param species_units:
+           Defines the units the species are displayed in as either `"percent"` or
+           `"ppm"`. Defaults to `"percent"`.
        :param graph_attr:
            Attributes to be passed to the ``graphviz.Digraph`` function that
            control the general appearance of the drawn network.
@@ -890,7 +893,7 @@ cdef class ReactorSurface:
         return self._reactor
 
     def draw(self, dot=None, *, print_state=False, species=None,
-             graph_attr=None, node_attr=None, edge_attr=None):
+             graph_attr=None, node_attr=None, edge_attr=None, **kwargs):
         """
         Draw the surface as a ``graphviz`` ``dot`` node connected to its
         reactor.
@@ -903,11 +906,6 @@ cdef class ReactorSurface:
         :param print_state:
             Whether state information of the reactor is printed into its node.
             Defaults to ``False``
-        :param species:
-            If ``print_state`` is ``True``, define how species are to be printed.
-            Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all
-            species, respectively, or an iterable that contains the desired species
-            names as strings. Defaults to ``None``
         :param graph_attr:
             Attributes to be passed to the ``graphviz.Digraph`` function that
             control the general appearance of the drawn network.
@@ -925,6 +923,9 @@ cdef class ReactorSurface:
             (subclasses of `FlowDevice` or walls) themselve have priority.
             See https://graphviz.org/docs/edges/ for a list of all usable
             attributes.
+        :param kwargs:
+            Additional keywords are passed on to each call of `draw_reactor`,
+            `draw_surface` and `draw_connections`.
         :return:
             ``graphviz.graphs.BaseGraph`` object with surface and connected
             reactor.
@@ -2025,7 +2026,7 @@ cdef class ReactorNet:
 
     def draw(self, *, print_state=False, species=None, graph_attr=None,
              node_attr=None, edge_attr=None, heat_flow_attr=None,
-             mass_flow_attr=None):
+             mass_flow_attr=None, **kwargs):
         """
         Draw as ``graphviz.graphs.DiGraph``. Connecting flow controllers and
         walls are depicted as arrows.
@@ -2033,11 +2034,6 @@ cdef class ReactorNet:
         :param print_state:
             Whether state information of the reactors is printed into each node.
             Defaults to ``False``.
-        :param species:
-            If ``print_state`` is ``True``, define how species are to be printed.
-            Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all
-            species, respectively, or an iterable that contains the desired species
-            names as strings. Defaults to ``None``.
         :param graph_attr:
             Attributes to be passed to the ``graphviz.Digraph`` function that
             control the general appearance of the drawn network.
@@ -2060,6 +2056,9 @@ cdef class ReactorNet:
         :param mass_flow_attr:
             Same as `edge_attr` but only applied to edges representing
             `FlowDevice` objects.
+        :param kwargs:
+            Additional keywords are passed on to each call of `draw_reactor`,
+            `draw_surface` and `draw_connections`.
         :return:
             ``graphviz.graphs.BaseGraph`` object with reactor net.
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -183,8 +183,8 @@ cdef class ReactorBase:
             respectively, or an iterable that contains the desired species names as
             strings. Defaults to ``None``.
         :param species_units:
-            Defines the units the species are displayed in as either `"percent"` or
-            `"ppm"`. Defaults to `"percent"`.
+            Defines the units the species are displayed in as either ``"percent"`` or
+            ``"ppm"``. Defaults to ``"percent"``.
         :return:
             ``graphviz.graphs.BaseGraph`` object with reactor
 
@@ -225,8 +225,14 @@ cdef class Reactor(ReactorBase):
             Set to ``'on'`` or ``'off'``. If set to ``'off'``, the energy
             equation is not solved, and the temperature is held at its
             initial value.
+        :param node_attr:
+            Attributes to be passed to the ``node`` method invoked to draw this reactor.
+            See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
         :param group_name:
             Group reactors of the same ``group_name`` when drawn using graphviz.
+
+        .. versionadded:: 3.1
+           Added the ``node_attr`` and ``group_name`` parameters.
 
         Some examples showing how to create :class:`Reactor` objects are
         shown below.
@@ -807,6 +813,12 @@ cdef class ReactorSurface:
         The `Reactor` into which this surface should be installed.
     :param A:
         The area of the reacting surface [m^2]
+    :param node_attr:
+        Attributes to be passed to the ``node`` method invoked to draw this surface.
+        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
+
+    .. versionadded:: 3.1
+       Added the ``node_attr`` parameter.
     """
     def __cinit__(self):
         self.surface = new CxxReactorSurface()
@@ -877,6 +889,7 @@ cdef class ReactorSurface:
     def reactor(self):
         """
         Return the `Reactor` object the surface is connected to.
+
         .. versionadded:: 3.1
         """
         return self._reactor
@@ -906,7 +919,7 @@ cdef class ReactorSurface:
             Whether state information of the reactor is printed into its node.
             Defaults to ``False``
         :param kwargs:
-            Additional keywords are passed on to `draw_reactor`.
+            Additional keywords are passed on to ``~.drawnetwork.draw_reactor``.
         :return:
             ``graphviz.graphs.BaseGraph`` object with surface and connected
             reactor.
@@ -960,6 +973,10 @@ cdef class WallBase:
         :param edge_attr:
             Attributes like ``style`` when drawn as a connecting edge using
             graphviz's dot language. Default is ``{}``.
+
+        .. versionadded:: 3.1
+           Added the ``edge_attr`` parameter.
+
         """
         self._velocity_func = None
         self._heat_flux_func = None
@@ -1012,6 +1029,7 @@ cdef class WallBase:
     def left_reactor(self):
         """
         Return the `Reactor` or `Reservoir` object left of the wall.
+
         .. versionadded:: 3.1
         """
         return self._left_reactor
@@ -1020,6 +1038,7 @@ cdef class WallBase:
     def right_reactor(self):
         """
         Return the `Reactor` or `Reservoir` object right of the wall.
+
         .. versionadded:: 3.1
         """
         return self._right_reactor
@@ -1059,22 +1078,22 @@ cdef class WallBase:
         :param graph_attr:
             Attributes to be passed to the ``graphviz.Digraph`` function that control
             the general appearance of the drawn network.
-            Has no effect if existing `graph` is provided.
+            Has no effect if existing ``graph`` is provided.
             See https://graphviz.org/docs/graph/ for a list of all usable attributes.
         :param node_attr:
             Attributes to be passed to the ``graphviz.Digraph`` function that control
             the default appearance of any ``node`` (reactors, reservoirs).
-            Has no effect if existing `graph` is provided.
+            Has no effect if existing ``graph`` is provided.
             See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
         :param edge_attr:
             Attributes to be passed to the ``edge`` method invoked to draw this wall
             connection.
-            Default is {"color": "red", "style": "dashed"}.
+            Default is ``{"color": "red", "style": "dashed"}``.
             See https://graphviz.org/docs/edges/ for a list of all usable attributes.
         :param moving_wall_edge_attr:
-            Same as `edge_attr` but only applied to edges representing wall movement.
-            Default is {"arrowtail": "icurveteecurve", "dir": "both", "style": "dotted",
-            "arrowhead": "icurveteecurve"}.
+            Same as ``edge_attr`` but only applied to edges representing wall movement.
+            Default is ``{"arrowtail": "icurveteecurve", "dir": "both",
+            "style": "dotted", "arrowhead": "icurveteecurve"}``.
         :param show_wall_velocity:
             If ``True``, wall movement will be indicated by additional arrows with the
             corresponding wall velocity as a label.
@@ -1235,6 +1254,7 @@ cdef class FlowDevice:
     def upstream(self):
         """
         Return the `Reactor` or `Reservoir` object upstream of the flow device.
+
         .. versionadded:: 3.1
         """
         return self._upstream
@@ -1243,6 +1263,7 @@ cdef class FlowDevice:
     def downstream(self):
         """
         Return the `Reactor` or `Reservoir` object downstream of the flow device.
+
         .. versionadded:: 3.1
         """
         return self._downstream
@@ -1322,12 +1343,12 @@ cdef class FlowDevice:
         :param graph_attr:
             Attributes to be passed to the ``graphviz.Digraph`` function that control
             the general appearance of the drawn network.
-            Has no effect if existing `graph` is provided.
+            Has no effect if existing ``graph`` is provided.
             See https://graphviz.org/docs/graph/ for a list of all usable attributes.
         :param node_attr:
             Attributes to be passed to the ``graphviz.Digraph`` function that control
             the default appearance of any ``node`` (reactors, reservoirs).
-            Has no effect if existing `graph` is provided.
+            Has no effect if existing ``graph`` is provided.
             See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
         :param edge_attr:
             Attributes to be passed to the ``edge`` method invoked to draw this flow
@@ -1586,6 +1607,7 @@ cdef class ReactorNet:
     def reactors(self):
         """
         List of all reactors that are part of the reactor network.
+
         .. versionadded:: 3.1
         """
         return self._reactors
@@ -2027,23 +2049,24 @@ cdef class ReactorNet:
             or walls) themselves have priority.
             See https://graphviz.org/docs/edges/ for a list of all usable attributes.
         :param heat_flow_attr:
-            Same as `edge_attr` but only applied to edges representing walls.
-            Default is {"color": "red", "style": "dashed"}.
+            Same as ``edge_attr`` but only applied to edges representing walls.
+            Default is ``{"color": "red", "style": "dashed"}``.
         :param mass_flow_attr:
-            Same as `edge_attr` but only applied to edges representing `FlowDevice`
+            Same as ``edge_attr`` but only applied to edges representing `FlowDevice`
             objects.
         :param moving_wall_edge_attr:
-            Same as `edge_attr` but only applied to edges representing wall movement.
+            Same as ``edge_attr`` but only applied to edges representing wall movement.
         :param surface_edge_attr:
-            Same as `edge_attr` but only applied to edges representing connections
+            Same as ``edge_attr`` but only applied to edges representing connections
             between `ReactorSurface` objects and reactors.
-            Default is `{"style": "dotted", "arrowhead": "none"}`.
+            Default is ``{"style": "dotted", "arrowhead": "none"}``.
         :param print_state:
             Whether state information of the reactors is printed into each node.
             Defaults to ``False``.
         :param kwargs:
-            Additional keywords are passed on to each call of `draw_reactor`,
-            `draw_surface`, `draw_flow_controllers`, and `draw_walls`.
+            Additional keywords are passed on to each call of
+            `~.drawnetwork.draw_reactor`, `~.drawnetwork.draw_surface`,
+            `~.drawnetwork.draw_flow_controllers`, and `~.drawnetwork.draw_walls`.
         :return:
             ``graphviz.graphs.BaseGraph`` object with reactor net.
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -10,7 +10,7 @@ from .thermo cimport *
 from ._utils cimport pystr, stringify, comp_map, py_to_anymap, anymap_to_py
 from ._utils import *
 from .delegator cimport *
-from .drawnetwork import draw_reactor, draw_reactor_net, draw_connections
+from .drawnetwork import *
 
 _reactor_counts = _defaultdict(int)
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -48,10 +48,7 @@ cdef class ReactorBase:
         if volume is not None:
             self.volume = volume
 
-        if node_attr is not None:
-            self.node_attr = node_attr
-        else:
-            self.node_attr = {}
+        self.node_attr = node_attr or {}
 
     def insert(self, _SolutionBase solution):
         """
@@ -985,10 +982,7 @@ cdef class WallBase:
             self.heat_flux = Q
         if velocity is not None:
             self.velocity = velocity
-        if edge_attr is not None:
-            self.edge_attr = edge_attr
-        else:
-            self.edge_attr = {}
+        self.edge_attr = edge_attr or {}
 
     def _install(self, ReactorBase left, ReactorBase right):
         """
@@ -1216,10 +1210,7 @@ cdef class FlowDevice:
             n = _reactor_counts[self.__class__.__name__]
             self.name = '{0}_{1}'.format(self.__class__.__name__, n)
 
-        if edge_attr is not None:
-            self.edge_attr = edge_attr
-        else:
-            self.edge_attr = {}
+        self.edge_attr = edge_attr or {}
 
         self._install(upstream, downstream)
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -168,32 +168,28 @@ cdef class ReactorBase:
         Optionally include current reactor state in the node.
 
         :param graph:
-           ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
-           If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
-       :param graph_attr:
-           Attributes to be passed to the ``graphviz.Digraph`` function that
-           control the general appearance of the drawn network.
-           See https://graphviz.org/docs/graph/ for a list of all usable
-           attributes.
-       :param node_attr:
-           Attributes to be passed to the ``node`` method invoked to draw the
-           reactor. ``node_attr`` defined in the reactor object itself have
-           priority.
-           See https://graphviz.org/docs/nodes/ for a list of all usable
-           attributes.
-       :param print_state:
-           Whether state information of the reactor is printed into the node.
-           Defaults to ``False``.
-       :param species:
-           If ``print_state`` is ``True``, define how species are to be printed.
-           Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all
-           species, respectively, or an iterable that contains the desired species
-           names as strings. Defaults to ``None``.
-       :param species_units:
-           Defines the units the species are displayed in as either `"percent"` or
-           `"ppm"`. Defaults to `"percent"`.
-         :return:
-             ``graphviz.graphs.BaseGraph`` object with reactor
+            ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
+            If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
+        :param graph_attr:
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the general appearance of the drawn network.
+            See https://graphviz.org/docs/graph/ for a list of all usable attributes.
+        :param node_attr:
+            Attributes to be passed to the ``node`` method invoked to draw the reactor.
+            See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
+        :param print_state:
+            Whether state information of the reactor is printed into the node.
+            Defaults to ``False``.
+        :param species:
+            If ``print_state`` is ``True``, define how species are to be printed.
+            Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all species,
+            respectively, or an iterable that contains the desired species names as
+            strings. Defaults to ``None``.
+        :param species_units:
+            Defines the units the species are displayed in as either `"percent"` or
+            `"ppm"`. Defaults to `"percent"`.
+        :return:
+            ``graphviz.graphs.BaseGraph`` object with reactor
 
         .. versionadded:: 3.1
         """
@@ -828,10 +824,7 @@ cdef class ReactorSurface:
             self.install(r)
         if A is not None:
             self.area = A
-        if node_attr is not None:
-            self.node_attr = node_attr
-        else:
-            self.node_attr = {'shape': 'underline'}
+        self.node_attr = node_attr or {'shape': 'underline'}
 
     def install(self, Reactor r):
         """
@@ -896,28 +889,22 @@ cdef class ReactorSurface:
         """
         Draw the surface as a ``graphviz`` ``dot`` node connected to its reactor.
         The node is added to an existing ``graph`` if provided.
-        The node is added to an existing ``dot`` graph if provided.
         Optionally include current reactor state in the reactor node.
 
         :param graph:
             ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
             If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
         :param graph_attr:
-            Attributes to be passed to the ``graphviz.Digraph`` function that
-            control the general appearance of the drawn network.
-            See https://graphviz.org/docs/graph/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the general appearance of the drawn network.
+            See https://graphviz.org/docs/graph/ for a list of all usable attributes.
         :param node_attr:
-            Attributes to be passed to the ``node`` method invoked to draw the
-            reactor. ``node_attr`` defined in the reactor object itself have
-            priority.
-            See https://graphviz.org/docs/nodes/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``node`` method invoked to draw the reactor.
+            See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
         :param surface_edge_attr:
-            Attributes to be passed to the ``edge`` method invoked to draw
-            the connection between the surface and its reactor.
-            See https://graphviz.org/docs/edges/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``edge`` method invoked to draw the
+            connection between the surface and its reactor.
+            See https://graphviz.org/docs/edges/ for a list of all usable attributes.
         :param print_state:
             Whether state information of the reactor is printed into its node.
             Defaults to ``False``
@@ -1076,28 +1063,27 @@ cdef class WallBase:
             ``graphviz.graphs.BaseGraph`` object to which the connection is added.
             If not provided, a new ``DiGraph`` is created. Defaults to ``None``
         :param graph_attr:
-            Attributes to be passed to the ``graphviz.Digraph`` function that
-            control the general appearance of the drawn network.
-            See https://graphviz.org/docs/graph/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the general appearance of the drawn network.
+            Has no effect if existing `graph` is provided.
+            See https://graphviz.org/docs/graph/ for a list of all usable attributes.
         :param node_attr:
-            Attributes to be passed to the ``node`` method invoked to draw the
-            connected reactors. ``node_attr`` defined in the reactor objects
-            itself have priority.
-            See https://graphviz.org/docs/nodes/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the default appearance of any ``node`` (reactors, reservoirs).
+            Has no effect if existing `graph` is provided.
+            See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
         :param edge_attr:
-            Attributes to be passed to the ``edge`` method invoked to draw
-            reactor connections. ``edge_attr`` defined in the connection objects
-            (subclasses of `FlowDevice` or walls) themselve have priority.
-            See https://graphviz.org/docs/edges/ for a list of all usable
-            attributes.
-        :param wall_edge_attr:
-            Same as `edge_attr` but only applied to edges representing wall
-            movement.
+            Attributes to be passed to the ``edge`` method invoked to draw this wall
+            connection.
+            Default is {"color": "red", "style": "dashed"}.
+            See https://graphviz.org/docs/edges/ for a list of all usable attributes.
+        :param moving_wall_edge_attr:
+            Same as `edge_attr` but only applied to edges representing wall movement.
+            Default is {"arrowtail": "icurveteecurve", "dir": "both", "style": "dotted",
+            "arrowhead": "icurveteecurve"}.
         :param show_wall_velocity:
-            If ``True``, wall movement will be indicated by additional arrows with
-            the corresponding wall velocity as a label.
+            If ``True``, wall movement will be indicated by additional arrows with the
+            corresponding wall velocity as a label.
         :return:
             A ``graphviz.graphs.BaseGraph`` object depicting the connection.
 
@@ -1336,29 +1322,26 @@ cdef class FlowDevice:
 
     def draw(self, graph=None, *, graph_attr=None, node_attr=None, edge_attr=None):
         """
-        Draw as connection between upstream and downstream reactor or reservoir
-        using ``graphviz``.
+        Draw as connection between upstream and downstream reactor or reservoir using
+        ``graphviz``.
 
         :param graph:
             ``graphviz.graphs.BaseGraph`` object to which the connection is added.
             If not provided, a new ``DiGraph`` is created. Defaults to ``None``
         :param graph_attr:
-            Attributes to be passed to the ``graphviz.Digraph`` function that
-            control the general appearance of the drawn network.
-            See https://graphviz.org/docs/graph/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the general appearance of the drawn network.
+            Has no effect if existing `graph` is provided.
+            See https://graphviz.org/docs/graph/ for a list of all usable attributes.
         :param node_attr:
-            Attributes to be passed to the ``node`` method invoked to draw the
-            reactor. ``node_attr`` defined in the reactor object itself have
-            priority.
-            See https://graphviz.org/docs/nodes/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the default appearance of any ``node`` (reactors, reservoirs).
+            Has no effect if existing `graph` is provided.
+            See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
         :param edge_attr:
-            Attributes to be passed to the ``edge`` method invoked to draw
-            reactor connections. ``edge_attr`` defined in the connection objects
-            (subclasses of `FlowDevice` or walls) themselve have priority.
-            See https://graphviz.org/docs/edges/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``edge`` method invoked to draw this flow
+            controller connection.
+            See https://graphviz.org/docs/edges/ for a list of all usable attributes.
         :return:
             A ``graphviz.graphs.BaseGraph`` object depicting the connection.
 
@@ -2029,47 +2012,52 @@ cdef class ReactorNet:
         def __set__(self, settings):
             self.net.setDerivativeSettings(py_to_anymap(settings))
 
-    def draw(self, *, graph_attr=None, node_attr=None, edge_attr=None, heat_flow_attr=None,
-             mass_flow_attr=None, surface_edge_attr=None, print_state=False, **kwargs):
+    def draw(self, *, graph_attr=None, node_attr=None, edge_attr=None,
+             heat_flow_attr=None, mass_flow_attr=None, moving_wall_edge_attr=None,
+             surface_edge_attr=None, print_state=False, show_wall_velocity=True,
+             **kwargs):
         """
         Draw as ``graphviz.graphs.DiGraph``. Connecting flow controllers and
         walls are depicted as arrows.
 
         :param graph_attr:
-            Attributes to be passed to the ``graphviz.Digraph`` function that
-            control the general appearance of the drawn network.
-            See https://graphviz.org/docs/graph/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the general appearance of the drawn network.
+            See https://graphviz.org/docs/graph/ for a list of all usable attributes.
         :param node_attr:
-            Attributes to be passed to the ``node`` method invoked to draw the
-            reactor. ``node_attr`` defined in the reactor object itself have
-            priority.
-            See https://graphviz.org/docs/nodes/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the default appearance of any ``node`` (reactors, reservoirs).
+            ``node_attr`` defined in the reactor object itself have priority.
+            See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
         :param edge_attr:
-            Attributes to be passed to the ``edge`` method invoked to draw
-            reactor connections. ``edge_attr`` defined in the connection objects
-            (subclasses of `FlowDevice` or walls) themselve have priority.
-            See https://graphviz.org/docs/edges/ for a list of all usable
-            attributes.
+            Attributes to be passed to the ``graphviz.Digraph`` function that control
+            the default appearance of any ``edge`` (flow controllers, walls).
+            ``edge_attr`` defined in the connection objects (subclasses of `FlowDevice`
+            or walls) themselves have priority.
+            See https://graphviz.org/docs/edges/ for a list of all usable attributes.
         :param heat_flow_attr:
             Same as `edge_attr` but only applied to edges representing walls.
+            Default is {"color": "red", "style": "dashed"}.
         :param mass_flow_attr:
-            Same as `edge_attr` but only applied to edges representing
-            `FlowDevice` objects.
+            Same as `edge_attr` but only applied to edges representing `FlowDevice`
+            objects.
+        :param moving_wall_edge_attr:
+            Same as `edge_attr` but only applied to edges representing wall movement.
         :param surface_edge_attr:
-            Same as `edge_attr` but only applied to edges representing
-            connections between `ReactorSurface` objects and reactors.
+            Same as `edge_attr` but only applied to edges representing connections
+            between `ReactorSurface` objects and reactors.
+            Default is `{"style": "dotted", "arrowhead": "none"}`.
         :param print_state:
             Whether state information of the reactors is printed into each node.
             Defaults to ``False``.
         :param kwargs:
             Additional keywords are passed on to each call of `draw_reactor`,
-            `draw_surface` and `draw_connections`.
+            `draw_surface`, `draw_flow_controllers`, and `draw_walls`.
         :return:
             ``graphviz.graphs.BaseGraph`` object with reactor net.
 
         .. versionadded:: 3.1
         """
         return draw_reactor_net(self, graph_attr, node_attr, edge_attr, heat_flow_attr,
-                 mass_flow_attr, print_state, **kwargs)
+                 mass_flow_attr, moving_wall_edge_attr, surface_edge_attr, print_state,
+                 **kwargs)

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -160,14 +160,14 @@ cdef class ReactorBase:
         """
         self._walls.append(wall)
 
-    def draw(self, dot=None, *, graph_attr=None, node_attr=None, print_state=False,
+    def draw(self, graph=None, *, graph_attr=None, node_attr=None, print_state=False,
              species=None, species_units="percent"):
         """
         Draw as ``graphviz`` ``dot`` node.
-        The node is added to an existing ``dot`` graph if provided.
+        The node is added to an existing ``graph`` if provided.
         Optionally include current reactor state in the node.
 
-       :param dot:
+        :param graph:
            ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
            If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
        :param graph_attr:
@@ -197,7 +197,7 @@ cdef class ReactorBase:
 
         .. versionadded:: 3.1
         """
-        return draw_reactor(self, dot, graph_attr, node_attr, print_state, species,
+        return draw_reactor(self, graph, graph_attr, node_attr, print_state, species,
                             species_units)
 
     def __reduce__(self):
@@ -219,8 +219,7 @@ cdef class Reactor(ReactorBase):
     def __cinit__(self, *args, **kwargs):
         self.reactor = <CxxReactor*>(self.rbase)
 
-    def __init__(self, contents=None, *, name=None, energy='on',
-                 groupname=None, **kwargs):
+    def __init__(self, contents=None, *, name=None, energy='on', group_name="", **kwargs):
         """
         :param contents:
             Reactor contents. If not specified, the reactor is initially empty.
@@ -233,8 +232,8 @@ cdef class Reactor(ReactorBase):
             Set to ``'on'`` or ``'off'``. If set to ``'off'``, the energy
             equation is not solved, and the temperature is held at its
             initial value.
-        :param groupname:
-            Group reactors of the same ``groupname`` when drawn using graphviz.
+        :param group_name:
+            Group reactors of the same ``group_name`` when drawn using graphviz.
 
         Some examples showing how to create :class:`Reactor` objects are
         shown below.
@@ -261,10 +260,7 @@ cdef class Reactor(ReactorBase):
         elif energy != 'on':
             raise ValueError("'energy' must be either 'on' or 'off'")
 
-        if groupname is not None:
-            self.groupname = groupname
-        else:
-            self.groupname = ""
+        self.group_name = group_name
 
     def insert(self, _SolutionBase solution):
         """
@@ -895,15 +891,15 @@ cdef class ReactorSurface:
         """
         return self._reactor
 
-    def draw(self, dot=None, *, graph_attr=None, node_attr=None, surface_edge_attr=None,
+    def draw(self, graph=None, *, graph_attr=None, node_attr=None, surface_edge_attr=None,
              print_state=False, **kwargs):
         """
-        Draw the surface as a ``graphviz`` ``dot`` node connected to its
-        reactor.
+        Draw the surface as a ``graphviz`` ``dot`` node connected to its reactor.
+        The node is added to an existing ``graph`` if provided.
         The node is added to an existing ``dot`` graph if provided.
         Optionally include current reactor state in the reactor node.
 
-        :param dot:
+        :param graph:
             ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
             If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
         :param graph_attr:
@@ -933,8 +929,8 @@ cdef class ReactorSurface:
 
         .. versionadded:: 3.1
         """
-        return draw_surface(self, dot, graph_attr, node_attr, surface_edge_attr, print_state,
-                            **kwargs)
+        return draw_surface(self, graph, graph_attr, node_attr, surface_edge_attr,
+                            print_state, **kwargs)
 
     def add_sensitivity_reaction(self, int m):
         """
@@ -1070,13 +1066,13 @@ cdef class WallBase:
         return self.wall.heatRate()
 
 
-    def draw(self, dot=None, *, graph_attr=None, node_attr=None, edge_attr=None,
-             wall_edge_attr=None, show_wall_velocity=True):
+    def draw(self, graph=None, *, graph_attr=None, node_attr=None, edge_attr=None,
+             moving_wall_edge_attr=None, show_wall_velocity=True):
         """
         Draw as connection between left and right reactor or reservoir using
         ``graphviz``.
 
-        :param dot:
+        :param graph:
             ``graphviz.graphs.BaseGraph`` object to which the connection is added.
             If not provided, a new ``DiGraph`` is created. Defaults to ``None``
         :param graph_attr:
@@ -1107,8 +1103,8 @@ cdef class WallBase:
 
         .. versionadded:: 3.1
         """
-        return draw_connections([self], dot, graph_attr, node_attr, edge_attr, wall_edge_attr,
-                                show_wall_velocity)
+        return draw_walls([self], graph, graph_attr, node_attr, edge_attr,
+                                moving_wall_edge_attr, show_wall_velocity)
 
 
 cdef class Wall(WallBase):
@@ -1338,12 +1334,12 @@ cdef class FlowDevice:
         self.dev.setTimeFunction(g.func)
 
 
-    def draw(self, dot=None, *, graph_attr=None, node_attr=None, edge_attr=None):
+    def draw(self, graph=None, *, graph_attr=None, node_attr=None, edge_attr=None):
         """
         Draw as connection between upstream and downstream reactor or reservoir
         using ``graphviz``.
 
-        :param dot:
+        :param graph:
             ``graphviz.graphs.BaseGraph`` object to which the connection is added.
             If not provided, a new ``DiGraph`` is created. Defaults to ``None``
         :param graph_attr:
@@ -1368,7 +1364,7 @@ cdef class FlowDevice:
 
         .. versionadded:: 3.1
         """
-        return draw_connections([self], dot, graph_attr, node_attr, edge_attr)
+        return draw_flow_controllers([self], graph, graph_attr, node_attr, edge_attr)
 
 
 cdef class MassFlowController(FlowDevice):

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -915,6 +915,16 @@ cdef class WallBase:
             self.wall.setArea(value)
 
     @property
+    def left_reactor(self):
+        """Return the `Reactor` or `Reservoir` object left of the wall."""
+        return self._left_reactor
+
+    @property
+    def right_reactor(self):
+        """Return the `Reactor` or `Reservoir` object right of the wall."""
+        return self._right_reactor
+
+    @property
     def expansion_rate(self):
         """
         Get the rate of volumetric change [m^3/s] associated with the wall at the
@@ -1078,6 +1088,20 @@ cdef class FlowDevice:
         # Keep references to prevent premature garbage collection
         self._upstream = upstream
         self._downstream = downstream
+
+    @property
+    def upstream(self):
+        """
+        Return the `Reactor` or `Reservoir` object upstream of the flow device.
+        """
+        return self._upstream
+
+    @property
+    def downstream(self):
+        """
+        Return the `Reactor` or `Reservoir` object downstream of the flow device.
+        """
+        return self._downstream
 
     property mass_flow_rate:
         """
@@ -1383,6 +1407,13 @@ cdef class ReactorNet:
         reinitialization.
         """
         self.net.reinitialize()
+
+    @property
+    def reactors(self):
+        """
+        List of all reactors that are part of the reactor network.
+        """
+        return self._reactors
 
     @property
     def time(self):

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -63,6 +63,7 @@ cantera.examples = *.txt
 [options.extras_require]
 pandas = pandas
 units = pint
+graphviz = python-graphviz
 
 [options.entry_points]
 console_scripts =

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -63,7 +63,7 @@ cantera.examples = *.txt
 [options.extras_require]
 pandas = pandas
 units = pint
-graphviz = python-graphviz
+graphviz = graphviz
 
 [options.entry_points]
 console_scripts =

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -68,6 +68,7 @@ cantera = *.cpp, *.h, *.pyx
 [options.extras_require]
 pandas = pandas
 units = pint
+graphviz = python-graphviz
 
 [options.entry_points]
 console_scripts =

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -68,7 +68,7 @@ cantera = *.cpp, *.h, *.pyx
 [options.extras_require]
 pandas = pandas
 units = pint
-graphviz = python-graphviz
+graphviz = graphviz
 
 [options.entry_points]
 console_scripts =

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -906,6 +906,18 @@ class TestReactor(utilities.CanteraTest):
         self.assertEqual(dot.body, expected)
 
     @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    def test_draw_reactors_same_name(self):
+        self.make_reactors()
+        self.r1.name = 'Reactor'
+        self.r2.name = 'Reactor'
+        dot = self.net.draw()
+        expected = ['\tReactor\n', '\tReactor_1\n']
+        self.assertEqual(dot.body, expected)
+        # ensure reactor_names dict has been cleared
+        dot = self.net.draw()
+        self.assertEqual(dot.body, expected)
+
+    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
     def test_draw_wall(self):
         T1, P1, X1 = 300, 101325, 'O2:1.0'
         T2, P2, X2 = 600, 101325, 'O2:1.0'

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -960,10 +960,9 @@ class TestReactor(utilities.CanteraTest):
         self.r2.name = "Name 2"
         w = ct.Wall(self.r1, self.r2, U=0.1, velocity=1)
         dot = w.draw()
-        expected = [('\t"Name 1" -> "Name 2" [arrowsize=1.5 arrowtail=teecrow '
-                     'dir=back penwidth=0 samehead="Name 1-Name 2" '
-                     'sametail="Name 1-Name 2" '
-                     'taillabel="wall velocity = 1 m/s" weight=2]\n'),
+        expected = [('\t"Name 1" -> "Name 2" [label="wall vel. = 1 m/s" '
+                     'arrowhead=icurveteecurve arrowtail=icurveteecurve '
+                     'dir=both style=dotted]\n'),
                     ('\t"Name 2" -> "Name 1" [label="q = 30 W" '
                      'color=red samehead="Name 1-Name 2" '
                      'sametail="Name 1-Name 2" style=dashed]\n')]

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -865,7 +865,7 @@ class TestReactor(utilities.CanteraTest):
         with self.assertRaises(ct.CanteraError):
             self.net.initialize()
 
-    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_reactor(self):
         self.make_reactors()
         T1, P1, X1 = 300, 101325, 'O2:1.0'
@@ -877,53 +877,54 @@ class TestReactor(utilities.CanteraTest):
         r1.node_attr = {'style': 'filled', 'fillcolor': 'green'}
         graph = r1.draw()
         expected = ['\tName [fillcolor=green style=filled]\n']
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
         # overwrite style during call to draw
         expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|" color=blue '
                      'fillcolor=green shape=Mrecord style="" xlabel=Name]\n')]
         graph = r1.draw(print_state=True, node_attr={"style": "", "color": "blue"})
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
         # print state with mole fractions
         r1.node_attr = {}
         expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|X (%)'
                      '\\nO2: 100.00" shape=Mrecord xlabel=Name]\n')]
         graph = r1.draw(print_state=True, species="X")
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
         # print state with mass fractions
         expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|Y (%)'
                      '\\nO2: 100.00" shape=Mrecord xlabel=Name]\n')]
         graph = r1.draw(print_state=True, species="Y")
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
         # print state with specified species
         expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|X (%)'
                      '\\nH2: 0.00" shape=Mrecord xlabel=Name]\n')]
         graph = r1.draw(print_state=True, species=["H2"])
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
         # print state with specified species and specified unit
         expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|X (ppm)'
                      '\\nO2: 1000000.0" shape=Mrecord xlabel=Name]\n')]
         graph = r1.draw(print_state=True, species=["O2"], species_units="ppm")
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
         # add reactor to existiing graph
         graph = _graphviz.Digraph()
         r1.draw(graph)
         expected = ['\tName\n']
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
-    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_reactors_same_name(self):
         self.make_reactors()
         self.r1.name = 'Reactor'
         self.r2.name = 'Reactor'
-        self.assertRaises(AssertionError, self.net.draw)
+        with pytest.raises(AssertionError, match="unique names"):
+            self.net.draw()
 
-    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_grouped_reactors(self):
         self.make_reactors()
         self.r1.name = "Reactor 1"
@@ -939,9 +940,9 @@ class TestReactor(utilities.CanteraTest):
                     '\t\t"Reactor 2"\n',
                     '\t\tlabel="Group 2"\n',
                     '\t}\n']
-        self.assertSetEqual(set(graph.body), set(expected))
+        assert set(graph.body) == set(expected)
 
-    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_wall(self):
         T1, P1, X1 = 300, 101325, 'O2:1.0'
         T2, P2, X2 = 600, 101325, 'O2:1.0'
@@ -954,9 +955,9 @@ class TestReactor(utilities.CanteraTest):
                        edge_attr={'style': 'dashed', 'color': 'blue'})
         expected = [('\t"Name 2" -> "Name 1" [label="q = 30 W" '
                      'color=blue style=dashed]\n')]
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
-    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_moving_wall(self):
         T1, P1, X1 = 300, 101325, 'O2:1.0'
         T2, P2, X2 = 600, 101325, 'O2:1.0'
@@ -970,7 +971,7 @@ class TestReactor(utilities.CanteraTest):
                      'dir=both style=dotted]\n'),
                     ('\t"Name 2" -> "Name 1" [label="q = 30 W" '
                      'color=red style=dashed]\n')]
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
         # omit heat flow if zero
         w.heat_transfer_coeff = 0
@@ -978,10 +979,9 @@ class TestReactor(utilities.CanteraTest):
         expected = [('\t"Name 1" -> "Name 2" [label="wall vel. = 1 m/s" '
                      'arrowhead=icurveteecurve arrowtail=icurveteecurve '
                      'dir=both style=dotted]\n')]
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
-
-    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_flow_controller(self):
         self.make_reactors(n_reactors=1)
         self.r1.name = "Reactor"
@@ -999,9 +999,9 @@ class TestReactor(utilities.CanteraTest):
                          edge_attr={'style': 'dotted', 'color': 'blue'})
         expected = [('\tInlet -> Reactor [label="m = 2 kg/s" color=blue '
                      'style=dotted xlabel=MFC]\n')]
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
-    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_network(self):
         self.make_reactors()
         self.r1.name = "Hot reactor"
@@ -1042,7 +1042,7 @@ class TestReactor(utilities.CanteraTest):
                     ('\t"Hot inlet" -> "Hot reactor" [label="m = 3 kg/s" '
                      'color=green]\n')]
         # use sets because order can be random
-        self.assertSetEqual(set(graph.body), set(expected))
+        assert set(graph.body) == set(expected)
 
 
 class TestMoleReactor(TestReactor):

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -917,7 +917,26 @@ class TestReactor(utilities.CanteraTest):
         dot = w.draw(node_attr={'style': 'filled'},
                      edge_attr={'style': 'dashed'})
         expected = [('\t"Name 2" -> "Name 1" [label="q = 30 W" '
-                     'color=blue style=dashed]\n')]
+                     'color=blue samehead="Name 1-Name 2" '
+                     'sametail="Name 1-Name 2" style=dashed]\n')]
+        self.assertEqual(dot.body, expected)
+
+    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    def test_draw_moving_wall(self):
+        T1, P1, X1 = 300, 101325, 'O2:1.0'
+        T2, P2, X2 = 600, 101325, 'O2:1.0'
+        self.make_reactors(T1=T1, P1=P1, X1=X1, T2=T2, P2=P2, X2=X2)
+        self.r1.name = "Name 1"
+        self.r2.name = "Name 2"
+        w = ct.Wall(self.r1, self.r2, U=0.1, velocity=1)
+        dot = w.draw()
+        expected = [('\t"Name 1" -> "Name 2" [arrowsize=1.5 arrowtail=teecrow '
+                     'dir=back penwidth=0 samehead="Name 1-Name 2" '
+                     'sametail="Name 1-Name 2" '
+                     'taillabel="wall velocity = 1 m/s" weight=2]\n'),
+                    ('\t"Name 2" -> "Name 1" [label="q = 30 W" '
+                     'color=red samehead="Name 1-Name 2" '
+                     'sametail="Name 1-Name 2" style=dashed]\n')]
         self.assertEqual(dot.body, expected)
 
     @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
@@ -937,6 +956,7 @@ class TestReactor(utilities.CanteraTest):
         dot = mfc.draw(node_attr={'style': 'filled'},
                        edge_attr={'style': 'dotted'})
         expected = [('\tInlet -> Reactor [label="m = 2 kg/s" '
+                     'samehead="Inlet-Reactor" sametail="Inlet-Reactor" '
                      'style=dotted xlabel=MFC]\n')]
         self.assertEqual(dot.body, expected)
 
@@ -973,15 +993,20 @@ class TestReactor(utilities.CanteraTest):
                     ('\tOutlet [label="{T (K)\\n200.00|P (bar)'
                      '\\n1.013}|" shape=Mrecord xlabel=Outlet]\n'),
                     ('\t"Cold inlet" -> "Cold reactor" [label="m = 2 kg/s" '
-                     'color=green]\n'),
+                     'color=green samehead="Cold inlet-Cold reactor" '
+                     'sametail="Cold inlet-Cold reactor"]\n'),
                     ('\t"Hot reactor" -> Outlet [label="m = 3 kg/s" '
-                     'color=green]\n'),
+                     'color=green samehead="Hot reactor-Outlet" '
+                     'sametail="Hot reactor-Outlet"]\n'),
                     ('\t"Cold reactor" -> Outlet [label="m = 2 kg/s" '
-                     'color=green]\n'),
+                     'color=green samehead="Cold reactor-Outlet" '
+                     'sametail="Cold reactor-Outlet"]\n'),
                     ('\t"Hot reactor" -> "Cold reactor" [label="q = 4e+03 W" '
-                     'color=orange style=dashed]\n'),
+                     'color=orange samehead="Hot reactor-Cold reactor" '
+                     'sametail="Hot reactor-Cold reactor" style=dashed]\n'),
                     ('\t"Hot inlet" -> "Hot reactor" [label="m = 3 kg/s" '
-                     'color=green]\n')]
+                     'color=green samehead="Hot inlet-Hot reactor" '
+                     'sametail="Hot inlet-Hot reactor"]\n')]
         # use sets because order can be random
         self.assertSetEqual(set(dot.body), set(expected))
 

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -900,6 +900,11 @@ class TestReactor(utilities.CanteraTest):
         dot = r1.draw(print_state=True, species=["H2"])
         self.assertEqual(dot.body, expected)
 
+        expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|X (ppm)'
+                     '\\nO2: 1000000.0" shape=Mrecord xlabel=Name]\n')]
+        dot = r1.draw(print_state=True, species=["O2"], species_units="ppm")
+        self.assertEqual(dot.body, expected)
+
         dot = _graphviz.Digraph()
         r1.draw(dot)
         expected = ['\tName\n']

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1996,6 +1996,20 @@ class TestSurfaceKinetics(utilities.CanteraTest):
                                         rtol=1e-5, atol=1e-9, xtol=1e-12)
         self.assertFalse(bool(bad), bad)
 
+    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    def test_draw_ReactorSurface(self):
+        self.make_reactors()
+        surf = ct.ReactorSurface(self.interface, self.r1)
+        self.r1.name = "Reactor"
+
+        dot = surf.draw(node_attr={'style': 'filled'},
+                        edge_attr={'color': 'red'})
+        expected = ['\tReactor [style=filled]\n',
+                    '\t"Reactor surface" [shape=underline style=filled]\n',
+                    ('\tReactor -> "Reactor surface" '
+                     '[arrowhead=none color=red style=dotted]\n')]
+        self.assertEqual(dot.body, expected)
+
 
 class TestReactorSensitivities(utilities.CanteraTest):
     def test_sensitivities1(self):

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -915,12 +915,7 @@ class TestReactor(utilities.CanteraTest):
         self.make_reactors()
         self.r1.name = 'Reactor'
         self.r2.name = 'Reactor'
-        dot = self.net.draw()
-        expected = ['\tReactor\n', '\tReactor_1\n']
-        self.assertEqual(dot.body, expected)
-        # ensure reactor_names dict has been cleared
-        dot = self.net.draw()
-        self.assertEqual(dot.body, expected)
+        self.assertRaises(AssertionError, self.net.draw)
 
     @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
     def test_draw_grouped_reactors(self):
@@ -2063,8 +2058,9 @@ class TestSurfaceKinetics(utilities.CanteraTest):
         self.r1.name = "Reactor"
 
         dot = surf.draw(node_attr={'style': 'filled'},
-                        edge_attr={'color': 'red'})
-        expected = ['\tReactor [style=filled]\n',
+                        surface_edge_attr={'color': 'red'}, print_state=True)
+        expected = [('\tReactor [label="{T (K)\\n1200.00|P (bar)\\n0.010}|" shape=Mrecord '
+                     'style=filled xlabel=Reactor]\n'),
                     '\t"Reactor surface" [shape=underline style=filled]\n',
                     ('\tReactor -> "Reactor surface" '
                      '[arrowhead=none color=red style=dotted]\n')]

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -922,8 +922,8 @@ class TestReactor(utilities.CanteraTest):
         self.make_reactors()
         self.r1.name = "Reactor 1"
         self.r2.name = "Reactor 2"
-        self.r1.groupname = "Group 1"
-        self.r2.groupname = "Group 2"
+        self.r1.group_name = "Group 1"
+        self.r2.group_name = "Group 2"
         dot = self.net.draw()
         expected = ['\tsubgraph "cluster_Group 1" {\n',
                     '\t\t"Reactor 1"\n',

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -918,6 +918,24 @@ class TestReactor(utilities.CanteraTest):
         self.assertEqual(dot.body, expected)
 
     @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    def test_draw_grouped_reactors(self):
+        self.make_reactors()
+        self.r1.name = "Reactor 1"
+        self.r2.name = "Reactor 2"
+        self.r1.groupname = "Group 1"
+        self.r2.groupname = "Group 2"
+        dot = self.net.draw()
+        expected = ['\tsubgraph "cluster_Group 1" {\n',
+                    '\t\t"Reactor 1"\n',
+                    '\t\tlabel="Group 1"\n',
+                    '\t}\n',
+                    '\tsubgraph "cluster_Group 2" {\n',
+                    '\t\t"Reactor 2"\n',
+                    '\t\tlabel="Group 2"\n',
+                    '\t}\n']
+        self.assertSetEqual(set(dot.body), set(expected))
+
+    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
     def test_draw_wall(self):
         T1, P1, X1 = 300, 101325, 'O2:1.0'
         T2, P2, X2 = 600, 101325, 'O2:1.0'

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -7,6 +7,14 @@ from pytest import approx
 from .utilities import unittest
 
 import cantera as ct
+
+try:
+    ct.drawnetwork._import_graphviz()
+except ImportError:
+    pass
+
+from cantera.drawnetwork import _graphviz
+
 from . import utilities
 
 class TestReactor(utilities.CanteraTest):
@@ -856,6 +864,127 @@ class TestReactor(utilities.CanteraTest):
         # reactors do not support preconditioning
         with self.assertRaises(ct.CanteraError):
             self.net.initialize()
+
+    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    def test_draw_reactor(self):
+        self.make_reactors()
+        T1, P1, X1 = 300, 101325, 'O2:1.0'
+        self.gas1.TPX = T1, P1, X1
+        r1 = self.reactorClass(self.gas1, node_attr={'fillcolor': 'red'})
+        r1.name = "Name"
+        r1.node_attr = {'style': 'filled', 'fillcolor': 'green'}
+        dot = r1.draw()
+        expected = ['\tName [fillcolor=green style=filled]\n']
+        self.assertEqual(dot.body, expected)
+
+        r1.node_attr = {"style": "filled"}
+        expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|" '
+                     'color=blue shape=Mrecord style=filled xlabel=Name]\n')]
+        dot = r1.draw(print_state=True, node_attr={"style": "",
+                                                   "color": "blue"})
+        self.assertEqual(dot.body, expected)
+
+        r1.node_attr = {}
+        expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|X (%)'
+                     '\\nO2: 100.00" shape=Mrecord xlabel=Name]\n')]
+        dot = r1.draw(print_state=True, species="X")
+        self.assertEqual(dot.body, expected)
+
+        expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|Y (%)'
+                     '\\nO2: 100.00" shape=Mrecord xlabel=Name]\n')]
+        dot = r1.draw(print_state=True, species="Y")
+        self.assertEqual(dot.body, expected)
+
+        expected = [('\tName [label="{T (K)\\n300.00|P (bar)\\n1.013}|X (%)'
+                     '\\nH2: 0.00" shape=Mrecord xlabel=Name]\n')]
+        dot = r1.draw(print_state=True, species=["H2"])
+        self.assertEqual(dot.body, expected)
+
+        dot = _graphviz.Digraph()
+        r1.draw(dot)
+        expected = ['\tName\n']
+        self.assertEqual(dot.body, expected)
+
+    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    def test_draw_wall(self):
+        T1, P1, X1 = 300, 101325, 'O2:1.0'
+        T2, P2, X2 = 600, 101325, 'O2:1.0'
+        self.make_reactors(T1=T1, P1=P1, X1=X1, T2=T2, P2=P2, X2=X2)
+        self.r1.name = "Name 1"
+        self.r2.name = "Name 2"
+        w = ct.Wall(self.r1, self.r2, U=0.1, edge_attr={'style': 'dotted'})
+        w.edge_attr = {'color': 'blue'}
+        dot = w.draw(node_attr={'style': 'filled'},
+                     edge_attr={'style': 'dashed'})
+        expected = [('\t"Name 2" -> "Name 1" [label="q = 30 W" '
+                     'color=blue style=dashed]\n')]
+        self.assertEqual(dot.body, expected)
+
+    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    def test_draw_flow_controller(self):
+        self.make_reactors(n_reactors=1)
+        self.r1.name = "Reactor"
+        gas2 = ct.Solution('h2o2.yaml', transport_model=None)
+        gas2.TPX = 300, 10*101325, 'H2:1.0'
+        inlet_reservoir = ct.Reservoir(gas2, name='Inlet')
+        gas2.TPX = 300, 101325, 'H2:1.0'
+        outlet_reservoir = ct.Reservoir(gas2, name='Outlet')
+        mfc = ct.MassFlowController(inlet_reservoir, self.r1, mdot=2,
+                                    edge_attr={'xlabel': 'MFC'})
+        pfc = ct.PressureController(self.r1, outlet_reservoir, primary=mfc)
+        pfc.edge_attr = {'color': 'purple'}
+        self.net.advance_to_steady_state()
+        dot = mfc.draw(node_attr={'style': 'filled'},
+                       edge_attr={'style': 'dotted'})
+        expected = [('\tInlet -> Reactor [label="m = 2 kg/s" '
+                     'style=dotted xlabel=MFC]\n')]
+        self.assertEqual(dot.body, expected)
+
+    @utilities.unittest.skipIf(_graphviz is None, "graphviz is not installed")
+    def test_draw_network(self):
+        self.make_reactors()
+        self.r1.name = "Hot reactor"
+        self.r2.name = "Cold reactor"
+        self.add_wall(U=10)
+        gas2 = ct.Solution('h2o2.yaml', transport_model=None)
+        gas2.TPX = 600, 101325, 'O2:1.0'
+        hot_inlet = ct.Reservoir(gas2, name='Hot inlet')
+        gas2.TPX = 200, 101325, 'O2:1.0'
+        cold_inlet = ct.Reservoir(gas2, name='Cold inlet')
+        outlet = ct.Reservoir(gas2, name='Outlet')
+        mfc_hot1 = ct.MassFlowController(hot_inlet, self.r1, mdot=2)
+        mfc_hot2 = ct.MassFlowController(hot_inlet, self.r1, mdot=1)
+        mfc_cold = ct.MassFlowController(cold_inlet, self.r2, mdot=2)
+        pfc_hot1 = ct.PressureController(self.r1, outlet, primary=mfc_hot1)
+        pfc_hot2 = ct.PressureController(self.r1, outlet, primary=mfc_hot2)
+        pfc_cold = ct.PressureController(self.r2, outlet, primary=mfc_cold)
+        self.net.advance_to_steady_state()
+        dot = self.net.draw(mass_flow_attr={'color': 'green'},
+                            heat_flow_attr={'color': 'orange'},
+                            print_state=True)
+        expected = [('\t"Cold reactor" [label="{T (K)\\n202.18|P (bar)'
+                     '\\n1.013}|" shape=Mrecord xlabel="Cold reactor"]\n'),
+                    ('\t"Hot reactor" [label="{T (K)\\n598.68|P (bar)'
+                     '\\n1.013}|" shape=Mrecord xlabel="Hot reactor"]\n'),
+                    ('\t"Hot inlet" [label="{T (K)\\n600.00|P (bar)'
+                     '\\n1.013}|" shape=Mrecord xlabel="Hot inlet"]\n'),
+                    ('\t"Cold inlet" [label="{T (K)\\n200.00|P (bar)'
+                     '\\n1.013}|" shape=Mrecord xlabel="Cold inlet"]\n'),
+                    ('\tOutlet [label="{T (K)\\n200.00|P (bar)'
+                     '\\n1.013}|" shape=Mrecord xlabel=Outlet]\n'),
+                    ('\t"Cold inlet" -> "Cold reactor" [label="m = 2 kg/s" '
+                     'color=green]\n'),
+                    ('\t"Hot reactor" -> Outlet [label="m = 3 kg/s" '
+                     'color=green]\n'),
+                    ('\t"Cold reactor" -> Outlet [label="m = 2 kg/s" '
+                     'color=green]\n'),
+                    ('\t"Hot reactor" -> "Cold reactor" [label="q = 4e+03 W" '
+                     'color=orange style=dashed]\n'),
+                    ('\t"Hot inlet" -> "Hot reactor" [label="m = 3 kg/s" '
+                     'color=green]\n')]
+        # use sets because order can be random
+        self.assertSetEqual(set(dot.body), set(expected))
+
 
 class TestMoleReactor(TestReactor):
     reactorClass = ct.MoleReactor


### PR DESCRIPTION
**Changes proposed in this pull request**

This PR is based on the enhancement I suggested [here](https://github.com/Cantera/enhancements/issues/180). It includes functions and methods to directly visualize components and their connections in a `ReactorNet` or on their own using the `grahpviz` package. 

I wrote the functionality as a standalone module and included the functions as methods in the corresponding objects. If this is considered too intrusive, skipping https://github.com/Cantera/cantera/commit/2ad20c41228c0c531f16a67fc28ec1a87c5de8ae leaves them separated.

Other things I would be happy to receive feedback about:
- For the sake of simplicity, the new cython extension class attributes for the draw options are currently implemented as Python dicts. If this is a performance issue at some point, they could probably also be something more low-level like strings.
- For the "lazy"/optional import of `graphviz` I have copied the behavior found for the `Solution` methods that require `pandas`. I don't know if this is still best practice.
- I don't know if I have sufficiently adhered to the preferred import pattern in `__init__.py`.
- unit tests are missing yet. Should they just be part of the `TestReactor` class?

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes https://github.com/Cantera/enhancements/issues/180

**If applicable, provide an example illustrating new features this pull request is introducing**

- Adds functions and methods based on them that can draw `ReactorBase`, `WallBase` and `FlowDevice` objects
  ```python
  gas = ct.Solution('h2o2.yaml')
  r = ct.Reactor(gas)
  r.draw()
  ```
  ![image](https://github.com/Cantera/cantera/assets/44439108/43758699-710b-4244-b81c-89340c6a4c34)
  ```python
  r2 = ct.Reactor(gas)
  w = ct.Wall(r,r2,U=0.1)
  w.draw()
  ```
  ![image](https://github.com/Cantera/cantera/assets/44439108/ed297aa3-bac8-42bd-a132-2e6051f935e5)
 (not defining a phase for the reactors causes `Wall` to throw an Access Violation, as reported [here](https://github.com/Cantera/cantera/issues/1623))

- Reactors can be drawn plain or with their current state (T, P, composition) displayed 
   ```python
  r.draw()
  ```
  ![image](https://github.com/Cantera/cantera/assets/44439108/f411913e-8079-4927-9043-584ead3bbdf3)
   ```python
  r.draw(print_state=True, species='X')
  ```
  ![image](https://github.com/Cantera/cantera/assets/44439108/4f17dd1c-ee44-4abe-9c10-124e7293e544)
- Detects all connections between these objects and draws them as arrows. Corresponding mass and heat flows are added as labels. Connections between identical objects are summed up. Here is the visualization of the `ic_engine.py` sample:
   ```python
  sim.draw()
  ```
  ![image](https://github.com/Cantera/cantera/assets/44439108/39cf5c73-e64e-42c5-9f7b-6a42a77a644d)
- The style of these elements can be fully customized using `graphviz` regular `node_attr` and `edge_attr` keywords. This can be done either generally when calling the `draw` function or individually for each object by setting corresponding attributes, in which case the latter takes precedence:
  ```python
  r.node_attr={"color":"red"}
  r.draw(node_attr={"color":"green", "shape":"square"})
  ```  
  ![image](https://github.com/Cantera/cantera/assets/44439108/a3ce02ab-199d-4ecc-a9d2-b75fcbb9844b)

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) 
- [x] unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
