### PR TITLE
Migrate to build 1.0 for sdist

### DIFF
--- a/interfaces/python_sdist/SConscript
+++ b/interfaces/python_sdist/SConscript
@@ -5,7 +5,7 @@ import shutil
 from textwrap import dedent
 
 from build import ProjectBuilder
-from build.env import IsolatedEnvBuilder
+from build.env import DefaultIsolatedEnv
 
 from buildutils import logger
 
@@ -151,10 +151,10 @@ sdist(localenv.Command("README.rst", "#README.rst", Copy("$TARGET", "$SOURCE")))
 
 def build_sdist(target, source, env):
     build_dir = Path(source[0].abspath).parent
-    builder = ProjectBuilder(str(build_dir))
-    with IsolatedEnvBuilder() as build_env:
-        builder.python_executable = build_env.executable
-        builder.scripts_dir = build_env.scripts_dir
+    with DefaultIsolatedEnv() as build_env:
+        builder = ProjectBuilder(str(build_dir),
+                                 python_executable=build_env.python_executable)
+
         # first install the build dependencies
         build_env.install(builder.build_system_requires)
         # then get the extra required dependencies from the backend

--- a/samples/python/thermo/sound_speed_units.py
+++ b/samples/python/thermo/sound_speed_units.py
@@ -11,7 +11,7 @@ import numpy as np
 
 # This sets the default output format of the units to have 2 significant digits
 # and the units are printed with a Unicode font. See:
-# https://pint.readthedocs.io/en/stable/formatting.html#unit-format-types
+# https://pint.readthedocs.io/en/stable/user/formatting.html#unit-format-types
 ctu.units.default_format = ".2F~P"
 
 def equilibrium_sound_speeds(gas, rtol=1.0e-6, max_iter=5000):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Use updated `build` API (https://pypa-build.readthedocs.io/en/latest/changelog.html); the old `IsolatedEnvBuilder` was removed with the 1.0 release.
- Fix a broken link into the `pint` docs.

**If applicable, fill in the issue number this pull request is fixing**

This should fix the current error that's breaking the PyPI package builds.

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
