### PR TITLE
Extensible jacobian and network jacobian interfaces

### DIFF
--- a/doc/sphinx/develop/index.md
+++ b/doc/sphinx/develop/index.md
@@ -1,6 +1,7 @@
 # Develop
 
 (sec-compiling)=
+
 ## Compiling Cantera from Source
 
 If you're interested in contributing new features to Cantera, or you want to try the
@@ -12,9 +13,9 @@ Cantera](compiling/configure-build) on your computer.
 
 The following additional references may also be useful:
 
-- [](compiling/dependencies.md)
-- [](compiling/config-options)
-- [](compiling/special-cases)
+-   [](compiling/dependencies.md)
+-   [](compiling/config-options)
+-   [](compiling/special-cases)
 
 ```{toctree}
 :caption: Compiling Cantera from Source
@@ -35,7 +36,7 @@ compiling/special-cases
 This section is a work in progress.
 ```
 
-- [](reactor-integration)
+-   [](reactor-integration)
 
 ```{toctree}
 :caption: How Cantera Works

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -141,40 +141,47 @@ public:
         m_time = time;
     }
 
-    /*! Build the Jacobian terms specific to the flow device for the given connected reactor.
-     * @param r a pointer to the calling reactor
-     * @param jacVector a vector of triplets to be added to the jacobian for the reactor
-     * @warning This function is an experimental part of the %Cantera API and may be changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Build the Jacobian terms specific to the flow device for the given connected
+    //! reactor.
+    //! @param r a pointer to the calling reactor
+    //! @param jacVector a vector of triplets to be added to the jacobian for the
+    //! reactor
+    //! @warning This function is an experimental part of the %Cantera API and may be
+    //! changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     virtual void buildReactorJacobian(ReactorBase* r, vector<Eigen::Triplet<double>>& jacVector) {
         throw NotImplementedError(type() + "::buildReactorJacobian");
     }
 
-    /*! Build the Jacobian terms specific to the flow device for the network. These terms
-     * will be adjusted to the networks indexing system outside of the reactor.
-     * @param jacVector a vector of triplets to be added to the jacobian for the reactor
-     * @warning This function is an experimental part of the %Cantera API and may be changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Build the Jacobian terms specific to the flow device for the network. These
+    //! terms
+    //! will be adjusted to the networks indexing system outside of the reactor.
+    //! @param jacVector a vector of triplets to be added to the jacobian for the
+    //! reactor
+    //! @warning This function is an experimental part of the %Cantera API and may be
+    //! changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) {
         throw NotImplementedError(type() + "::buildNetworkJacobian");
     }
 
-    /*! Specify the jacobian terms have been calculated and should not be recalculated.
-     * @warning This function is an experimental part of the %Cantera API and may be changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Specify the jacobian terms have been calculated and should not be recalculated.
+    //! @warning This function is an experimental part of the %Cantera API and may be
+    //! changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     void jacobianCalculated() { m_jac_calculated = true; };
 
-    /*! Specify that jacobian terms have not been calculated and should be recalculated.
-     * @warning This function is an experimental part of the %Cantera API and may be changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Specify that jacobian terms have not been calculated and should be recalculated.
+    //! @warning This function is an experimental part of the %Cantera API and may be changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     void jacobianNotCalculated() { m_jac_calculated = false; };
 
 protected:

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -149,9 +149,10 @@ public:
     //! @warning This function is an experimental part of the %Cantera API and may be
     //! changed
     //! or removed without notice.
-    //! @since New in %Cantera 3.0.
+    //! @since New in %Cantera 3.1.
     //!
-    virtual void buildReactorJacobian(ReactorBase* r, vector<Eigen::Triplet<double>>& jacVector) {
+    virtual void buildReactorJacobian(ReactorBase* r,
+        vector<Eigen::Triplet<double>>& jacVector) {
         throw NotImplementedError(type() + "::buildReactorJacobian");
     }
 
@@ -163,28 +164,11 @@ public:
     //! @warning This function is an experimental part of the %Cantera API and may be
     //! changed
     //! or removed without notice.
-    //! @since New in %Cantera 3.0.
+    //! @since New in %Cantera 3.1.
     //!
     virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) {
-        if (!m_jac_calculated) {
-            throw NotImplementedError(type() + "::buildNetworkJacobian");
-        }
+        throw NotImplementedError(type() + "::buildNetworkJacobian");
     }
-
-    //! Specify the jacobian terms have been calculated and should not be recalculated.
-    //! @warning This function is an experimental part of the %Cantera API and may be
-    //! changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
-    //!
-    void jacobianCalculated() { m_jac_calculated = true; };
-
-    //! Specify that jacobian terms have not been calculated and should be recalculated.
-    //! @warning This function is an experimental part of the %Cantera API and may be changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
-    //!
-    void jacobianNotCalculated() { m_jac_calculated = false; };
 
 protected:
     string m_name;  //!< Flow device name.

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -10,6 +10,7 @@
 #include "cantera/base/global.h"
 #include "cantera/base/ctexceptions.h"
 #include "ConnectorNode.h"
+#include "cantera/numerics/eigen_sparse.h"
 
 namespace Cantera
 {
@@ -140,7 +141,49 @@ public:
         m_time = time;
     }
 
+    /*! Build the Jacobian terms specific to the flow device for the given connected reactor.
+     * @param r a pointer to the calling reactor
+     * @param jacVector a vector of triplets to be added to the jacobian for the reactor
+     * @warning This function is an experimental part of the %Cantera API and may be changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    virtual void buildReactorJacobian(ReactorBase* r, vector<Eigen::Triplet<double>>& jacVector) {
+        throw NotImplementedError(type() + "::buildReactorJacobian");
+    }
+
+    /*! Build the Jacobian terms specific to the flow device for the network. These terms
+     * will be adjusted to the networks indexing system outside of the reactor.
+     * @param jacVector a vector of triplets to be added to the jacobian for the reactor
+     * @warning This function is an experimental part of the %Cantera API and may be changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) {
+        throw NotImplementedError(type() + "::buildNetworkJacobian");
+    }
+
+    /*! Specify the jacobian terms have been calculated and should not be recalculated.
+     * @warning This function is an experimental part of the %Cantera API and may be changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    void jacobianCalculated() { m_jac_calculated = true; };
+
+    /*! Specify that jacobian terms have not been calculated and should be recalculated.
+     * @warning This function is an experimental part of the %Cantera API and may be changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    void jacobianNotCalculated() { m_jac_calculated = false; };
+
 protected:
+    string m_name;  //!< Flow device name.
+    bool m_defaultNameSet = false;  //!< `true` if default name has been previously set.
+    //! a variable to switch on and off so calculations are not doubled by the calling
+    //! reactor or network
+    bool m_jac_calculated = false;
+
     double m_mdot = Undef;
 
     //! Function set by setPressureFunction; used by updateMassFlowRate

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -166,7 +166,9 @@ public:
     //! @since New in %Cantera 3.0.
     //!
     virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) {
-        throw NotImplementedError(type() + "::buildNetworkJacobian");
+        if (!m_jac_calculated) {
+            throw NotImplementedError(type() + "::buildNetworkJacobian");
+        }
     }
 
     //! Specify the jacobian terms have been calculated and should not be recalculated.

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -39,7 +39,7 @@ public:
     //! Neglects derivatives with respect to mole fractions that would generate a
     //! fully-dense Jacobian. Currently also neglects terms related to interactions
     //! between reactors, for example via inlets and outlets.
-    Eigen::SparseMatrix<double> jacobian() override;
+    void buildJacobian(vector<Eigen::Triplet<double>>& jacVector) override;
 
     bool preconditionerSupported() const override { return true; };
 

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -43,12 +43,6 @@ public:
 
     bool preconditionerSupported() const override { return true; };
 
-    double temperatureDerivative() override { return 1; };
-
-    double temperatureRadiationDerivative() override {
-        return 4 * std::pow(temperature(), 3);
-    }
-
     double moleDerivative(size_t index) override;
 
     double moleRadiationDerivative(size_t index) override;

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -43,6 +43,18 @@ public:
 
     bool preconditionerSupported() const override { return true; };
 
+    double temperatureDerivative() override { return 1; };
+
+    double temperatureRadiationDerivative() override {
+        return 4 * std::pow(temperature(), 3);
+    }
+
+    double moleDerivative(size_t index) override;
+
+    double moleRadiationDerivative(size_t index) override;
+
+    size_t speciesOffset() const override { return m_sidx; };
+
     size_t componentIndex(const string& nm) const override;
     string componentName(size_t k) override;
     double upperBound(size_t k) const override;

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -43,9 +43,7 @@ public:
 
     bool preconditionerSupported() const override { return true; };
 
-    double moleDerivative(size_t index) override;
-
-    double moleRadiationDerivative(size_t index) override;
+    double temperature_ddni(size_t index) override;
 
     size_t speciesOffset() const override { return m_sidx; };
 

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -45,9 +45,7 @@ public:
 
     bool preconditionerSupported() const override {return true;};
 
-    double moleDerivative(size_t index) override;
-
-    double moleRadiationDerivative(size_t index) override;
+    double temperature_ddni(size_t index) override;
 
     size_t speciesOffset() const override { return m_sidx; };
 

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -45,6 +45,18 @@ public:
 
     bool preconditionerSupported() const override {return true;};
 
+    double temperatureDerivative() override { return 1; };
+
+    double temperatureRadiationDerivative() override {
+        return 4 * std::pow(temperature(), 3);
+    }
+
+    double moleDerivative(size_t index) override;
+
+    double moleRadiationDerivative(size_t index) override;
+
+    size_t speciesOffset() const override { return m_sidx; };
+
 protected:
     vector<double> m_uk; //!< Species molar internal energies
 };

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -40,12 +40,8 @@ public:
 
     void updateState(double* y) override;
 
-    //! Calculate an approximate Jacobian to accelerate preconditioned solvers
-
-    //! Neglects derivatives with respect to mole fractions that would generate a
-    //! fully-dense Jacobian. Currently, also neglects terms related to interactions
-    //! between reactors, for example via inlets and outlets.
-    Eigen::SparseMatrix<double> jacobian() override;
+    //! Calculate the Jacobian to accelerate preconditioned solvers
+    void buildJacobian(vector<Eigen::Triplet<double>>& jacVector) override;
 
     bool preconditionerSupported() const override {return true;};
 

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -45,12 +45,6 @@ public:
 
     bool preconditionerSupported() const override {return true;};
 
-    double temperatureDerivative() override { return 1; };
-
-    double temperatureRadiationDerivative() override {
-        return 4 * std::pow(temperature(), 3);
-    }
-
     double moleDerivative(size_t index) override;
 
     double moleRadiationDerivative(size_t index) override;

--- a/include/cantera/zeroD/MoleReactor.h
+++ b/include/cantera/zeroD/MoleReactor.h
@@ -7,6 +7,7 @@
 #define CT_MOLEREACTOR_H
 
 #include "Reactor.h"
+#include "cantera/zeroD/Wall.h"
 
 namespace Cantera
 {
@@ -40,6 +41,8 @@ public:
     double lowerBound(size_t k) const override;
     void resetBadValues(double* y) override;
 
+    size_t energyIndex() const override { return m_eidx; };
+
 protected:
     //! For each surface in the reactor, update vector of triplets with all relevant
     //! surface jacobian derivatives of species with respect to species
@@ -62,6 +65,9 @@ protected:
 
     //! const value for the species start index
     const size_t m_sidx = 2;
+
+    //! index of state variable associated with energy
+    const size_t m_eidx = 0;
 };
 
 }

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -231,7 +231,27 @@ public:
         throw NotImplementedError(type() + "::buildJacobian");
     }
 
-    // virtual void jacobian()
+    //! Calculate the Jacobian of a Reactor specialization for wall contributions.
+    //! @param jacVector vector where jacobian triplets are added
+    //! @warning Depending on the particular implementation, this may return an
+    //! approximate Jacobian intended only for use in forming a preconditioner for
+    //! iterative solvers.
+    //! @ingroup derivGroup
+    //!
+    //! @warning  This method is an experimental part of the %Cantera
+    //! API and may be changed or removed without notice.
+    virtual void buildWallJacobian(vector<Eigen::Triplet<double>>& jacVector);
+
+    //! Calculate flow contributions to the Jacobian of a Reactor specialization.
+    //! @param jac_vector vector where jacobian triplets are added
+    //! @warning Depending on the particular implementation, this may return an
+    //! approximate Jacobian intended only for use in forming a preconditioner for
+    //! iterative solvers.
+    //! @ingroup derivGroup
+    //!
+    //! @warning  This method is an experimental part of the %Cantera
+    //! API and may be changed or removed without notice.
+    virtual void buildFlowJacobian(vector<Eigen::Triplet<double>>& jacVector);
 
     //! Calculate the reactor-specific Jacobian using a finite difference method.
     //!
@@ -320,6 +340,10 @@ protected:
 
     //! Vector of triplets representing the jacobian
     vector<Eigen::Triplet<double>> m_jac_trips;
+    //! Boolean to skip walls in jacobian
+    bool m_jac_skip_walls = false;
+    //! Boolean to skip flow devices in jacobian
+    bool m_jac_skip_flow_devices = false;
 };
 }
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -218,8 +218,7 @@ public:
     }
 
     //! Calculate the Jacobian of a specific Reactor specialization.
-    //! @param jac_vector vector where jacobian triplets are added
-    //! @param offset offset added to the row and col indices of the elements
+    //! @param jacVector vector where jacobian triplets are added
     //! @warning Depending on the particular implementation, this may return an
     //! approximate Jacobian intended only for use in forming a preconditioner for
     //! iterative solvers.
@@ -243,7 +242,7 @@ public:
     virtual void buildWallJacobian(vector<Eigen::Triplet<double>>& jacVector);
 
     //! Calculate flow contributions to the Jacobian of a Reactor specialization.
-    //! @param jac_vector vector where jacobian triplets are added
+    //! @param jacVector vector where jacobian triplets are added
     //! @warning Depending on the particular implementation, this may return an
     //! approximate Jacobian intended only for use in forming a preconditioner for
     //! iterative solvers.

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -199,7 +199,7 @@ public:
     //! @param limit value for step size limit
     void setAdvanceLimit(const string& nm, const double limit);
 
-    //! Calculate the Jacobian of a specific Reactor specialization.
+    //! A wrapper for the Jacobian function to return the Eigen::SparseMatrix<double>
     //! @warning Depending on the particular implementation, this may return an
     //! approximate Jacobian intended only for use in forming a preconditioner for
     //! iterative solvers.
@@ -208,8 +208,30 @@ public:
     //! @warning  This method is an experimental part of the %Cantera
     //! API and may be changed or removed without notice.
     virtual Eigen::SparseMatrix<double> jacobian() {
-        throw NotImplementedError("Reactor::jacobian");
+        m_jac_trips.clear();
+        // Add before, during, after evals
+        buildJacobian(m_jac_trips);
+        // construct jacobian from vector
+        Eigen::SparseMatrix<double> jac(m_nv, m_nv);
+        jac.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
+        return jac;
     }
+
+    //! Calculate the Jacobian of a specific Reactor specialization.
+    //! @param jac_vector vector where jacobian triplets are added
+    //! @param offset offset added to the row and col indices of the elements
+    //! @warning Depending on the particular implementation, this may return an
+    //! approximate Jacobian intended only for use in forming a preconditioner for
+    //! iterative solvers.
+    //! @ingroup derivGroup
+    //!
+    //! @warning  This method is an experimental part of the %Cantera
+    //! API and may be changed or removed without notice.
+    virtual void buildJacobian(vector<Eigen::Triplet<double>>& jacVector) {
+        throw NotImplementedError(type() + "::buildJacobian");
+    }
+
+    // virtual void jacobian()
 
     //! Calculate the reactor-specific Jacobian using a finite difference method.
     //!

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -207,15 +207,7 @@ public:
     //!
     //! @warning  This method is an experimental part of the %Cantera
     //! API and may be changed or removed without notice.
-    virtual Eigen::SparseMatrix<double> jacobian() {
-        m_jac_trips.clear();
-        // Add before, during, after evals
-        buildJacobian(m_jac_trips);
-        // construct jacobian from vector
-        Eigen::SparseMatrix<double> jac(m_nv, m_nv);
-        jac.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
-        return jac;
-    }
+    virtual Eigen::SparseMatrix<double> jacobian();
 
     //! Calculate the Jacobian of a specific Reactor specialization.
     //! @param jacVector vector where jacobian triplets are added

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -302,11 +302,69 @@ public:
         return m_sensParams.size();
     }
 
+    /*! Calculate the derivative of temperature with respect to the temperature in the
+     * heat transfer equation based on the reactor specific equation of state.
+     * This function should also transform the state of the derivative to that
+     * appropriate for the jacobian's state/
+     * @warning This function is an experimental part of the %Cantera API and may be changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    virtual double temperatureDerivative() {
+        throw NotImplementedError("Reactor::temperatureDerivative");
+    }
+
+    /*! Calculate the derivative of temperature with respect to the temperature in the
+     * heat transfer radiation equation based on the reactor specific equation of state.
+     * This function should also transform the state of the derivative to that
+     * appropriate for the jacobian's state/
+     * @warning This function is an experimental part of the %Cantera API and may be changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    virtual double temperatureRadiationDerivative() {
+        throw NotImplementedError("Reactor::temperatureRadiationDerivative");
+    }
+
+    /*! Calculate the derivative of T with respect to the ith species in the heat
+     * transfer equation based on the reactor specific equation of state.
+     * @param index index of the species the derivative is with respect too
+     * @warning This function is an experimental part of the %Cantera API and may be changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    virtual double moleDerivative(size_t index) {
+        throw NotImplementedError("Reactor::moleDerivative");
+    }
+
+    /*! Calculate the derivative of T with respect to the ith species in the heat
+     * transfer radiation equation based on the reactor specific equation of state.
+     * @param index index of the species the derivative is with respect too
+     * @warning This function is an experimental part of the %Cantera API and may be changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    virtual double moleRadiationDerivative(size_t index) {
+        throw NotImplementedError("Reactor::moleRadiationDerivative");
+    }
+
+    //! Return the index associated with energy of the system
+    virtual size_t energyIndex() const { return m_eidx; };
+
+    //! Return the offset between species and state variables
+    virtual size_t speciesOffset() const { return m_sidx; };
+
 protected:
     explicit ReactorBase(const string& name="(none)");
 
     //! Number of homogeneous species in the mixture
     size_t m_nsp = 0;
+
+    //! species offset in the state vector
+    const size_t m_sidx = 3;
+
+    //! index of state variable associated with energy
+    const size_t m_eidx = 1;
 
     ThermoPhase* m_thermo = nullptr;
     double m_vol = 0.0; //!< Current volume of the reactor [m^3]

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -302,48 +302,50 @@ public:
         return m_sensParams.size();
     }
 
-    /*! Calculate the derivative of temperature with respect to the temperature in the
-     * heat transfer equation based on the reactor specific equation of state.
-     * This function should also transform the state of the derivative to that
-     * appropriate for the jacobian's state/
-     * @warning This function is an experimental part of the %Cantera API and may be changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Calculate the derivative of temperature with respect to the temperature in the
+    //! heat transfer equation based on the reactor specific equation of state.
+    //! This function should also transform the state of the derivative to that
+    //! appropriate for the jacobian's state/
+    //! @warning This function is an experimental part of the %Cantera API and may be changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     virtual double temperatureDerivative() {
         throw NotImplementedError("Reactor::temperatureDerivative");
     }
 
-    /*! Calculate the derivative of temperature with respect to the temperature in the
-     * heat transfer radiation equation based on the reactor specific equation of state.
-     * This function should also transform the state of the derivative to that
-     * appropriate for the jacobian's state/
-     * @warning This function is an experimental part of the %Cantera API and may be changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Calculate the derivative of temperature with respect to the temperature in the
+    //! heat transfer radiation equation based on the reactor specific equation of
+    //! state.
+    //! This function should also transform the state of the derivative to that
+    //! appropriate for the jacobian's state/
+    //! @warning This function is an experimental part of the %Cantera API and may be
+    //! changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     virtual double temperatureRadiationDerivative() {
         throw NotImplementedError("Reactor::temperatureRadiationDerivative");
     }
 
-    /*! Calculate the derivative of T with respect to the ith species in the heat
-     * transfer equation based on the reactor specific equation of state.
-     * @param index index of the species the derivative is with respect too
-     * @warning This function is an experimental part of the %Cantera API and may be changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Calculate the derivative of T with respect to the ith species in the heat
+    //! transfer equation based on the reactor specific equation of state.
+    //! @param index index of the species the derivative is with respect too
+    //! @warning This function is an experimental part of the %Cantera API and may be changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     virtual double moleDerivative(size_t index) {
         throw NotImplementedError("Reactor::moleDerivative");
     }
 
-    /*! Calculate the derivative of T with respect to the ith species in the heat
-     * transfer radiation equation based on the reactor specific equation of state.
-     * @param index index of the species the derivative is with respect too
-     * @warning This function is an experimental part of the %Cantera API and may be changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Calculate the derivative of T with respect to the ith species in the heat
+    //! transfer radiation equation based on the reactor specific equation of state.
+    //! @param index index of the species the derivative is with respect too
+    //! @warning This function is an experimental part of the %Cantera API and may be changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     virtual double moleRadiationDerivative(size_t index) {
         throw NotImplementedError("Reactor::moleRadiationDerivative");
     }

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -302,52 +302,15 @@ public:
         return m_sensParams.size();
     }
 
-    //! Calculate the derivative of temperature with respect to the temperature in the
-    //! heat transfer equation based on the reactor specific equation of state.
-    //! This function should also transform the state of the derivative to that
-    //! appropriate for the jacobian's state/
-    //! @warning This function is an experimental part of the %Cantera API and may be changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
-    //!
-    virtual double temperatureDerivative() {
-        throw NotImplementedError("Reactor::temperatureDerivative");
-    }
-
-    //! Calculate the derivative of temperature with respect to the temperature in the
-    //! heat transfer radiation equation based on the reactor specific equation of
-    //! state.
-    //! This function should also transform the state of the derivative to that
-    //! appropriate for the jacobian's state/
-    //! @warning This function is an experimental part of the %Cantera API and may be
-    //! changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
-    //!
-    virtual double temperatureRadiationDerivative() {
-        throw NotImplementedError("Reactor::temperatureRadiationDerivative");
-    }
-
-    //! Calculate the derivative of T with respect to the ith species in the heat
-    //! transfer equation based on the reactor specific equation of state.
+    //! Calculate the derivative of T with respect to the ith species in the energy
+    //! conservation equation based on the reactor specific equation of state.
     //! @param index index of the species the derivative is with respect too
-    //! @warning This function is an experimental part of the %Cantera API and may be changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
+    //! @warning This function is an experimental part of the %Cantera API and may
+    //! be changed or removed without notice.
+    //! @since New in %Cantera 3.1.
     //!
-    virtual double moleDerivative(size_t index) {
-        throw NotImplementedError("Reactor::moleDerivative");
-    }
-
-    //! Calculate the derivative of T with respect to the ith species in the heat
-    //! transfer radiation equation based on the reactor specific equation of state.
-    //! @param index index of the species the derivative is with respect too
-    //! @warning This function is an experimental part of the %Cantera API and may be changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
-    //!
-    virtual double moleRadiationDerivative(size_t index) {
-        throw NotImplementedError("Reactor::moleRadiationDerivative");
+    virtual double temperature_ddni(size_t index) {
+        throw NotImplementedError("Reactor::temperature_ddni");
     }
 
     //! Return the index associated with energy of the system

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -10,6 +10,7 @@
 #include "cantera/base/Delegator.h"
 #include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/thermo/SurfPhase.h"
+#include "cantera/numerics/eigen_sparse.h"
 
 namespace Cantera
 {
@@ -94,6 +95,8 @@ public:
             [this](const string& nm) { return R::componentIndex(nm); });
         install("speciesIndex", m_speciesIndex,
             [this](const string& nm) { return R::speciesIndex(nm); });
+        install("buildJacobian", m_build_jacobian,
+            [this](vector<Eigen::Triplet<double>>& jv) { R::buildJacobian(jv); });
     }
 
     // Overrides of Reactor methods
@@ -160,6 +163,10 @@ public:
         return m_speciesIndex(nm);
     }
 
+    void buildJacobian(vector<Eigen::Triplet<double>>& jacVector) override {
+        m_build_jacobian(jacVector);
+    }
+
     // Public access to protected Reactor variables needed by derived classes
 
     void setNEq(size_t n) override {
@@ -204,6 +211,7 @@ private:
     function<string(size_t)> m_componentName;
     function<size_t(const string&)> m_componentIndex;
     function<size_t(const string&)> m_speciesIndex;
+    function<void(vector<Eigen::Triplet<double>>&)> m_build_jacobian;
 };
 
 }

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -52,6 +52,10 @@ public:
     //! Set the state of the thermo object for surface *n* to correspond to the
     //! state of that surface
     virtual void restoreSurfaceState(size_t n) = 0;
+
+    //! Public access to the default evaluation function so it can be used in
+    //! replace functions
+    virtual void defaultEval(double t, double* LHS, double* RHS) = 0;
 };
 
 //! Delegate methods of the Reactor class to external functions
@@ -165,6 +169,10 @@ public:
 
     void buildJacobian(vector<Eigen::Triplet<double>>& jacVector) override {
         m_build_jacobian(jacVector);
+    }
+
+    void defaultEval(double t, double* LHS, double* RHS) override {
+        R::eval(t, LHS, RHS);
     }
 
     // Public access to protected Reactor variables needed by derived classes

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -74,7 +74,8 @@ public:
         install("updateState", m_updateState,
             [this](std::array<size_t, 1> sizes, double* y) { R::updateState(y); });
         install("updateSurfaceState", m_updateSurfaceState,
-            [this](std::array<size_t, 1> sizes, double* y) { R::updateSurfaceState(y); });
+            [this](std::array<size_t, 1> sizes, double* y)
+            { R::updateSurfaceState(y); });
         install("getSurfaceInitialConditions", m_getSurfaceInitialConditions,
             [this](std::array<size_t, 1> sizes, double* y) {
                 R::getSurfaceInitialConditions(y);
@@ -89,8 +90,8 @@ public:
         );
         install("evalWalls", m_evalWalls, [this](double t) { R::evalWalls(t); });
         install("evalSurfaces", m_evalSurfaces,
-            [this](std::array<size_t, 3> sizes, double* LHS, double* RHS, double* sdot) {
-                R::evalSurfaces(LHS, RHS, sdot);
+            [this](std::array<size_t, 3> sizes, double* LHS, double* RHS, double* sd) {
+                R::evalSurfaces(LHS, RHS, sd);
             }
         );
         install("componentName", m_componentName,

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -414,8 +414,7 @@ protected:
     void addReactor(shared_ptr<ReactorBase> reactor);
 
     //! Calculate the Jacobian of the entire reactor network.
-    //! @param jac_vector vector where jacobian triplets are added
-    //! @param offset offset added to the row and col indices of the elements
+    //! @param jacVector vector where jacobian triplets are added
     //! @warning Depending on the particular implementation, this may return an
     //! approximate Jacobian intended only for use in forming a preconditioner for
     //! iterative solvers.

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -7,6 +7,8 @@
 #define CT_REACTORNET_H
 
 #include "Reactor.h"
+#include "Wall.h"
+#include "FlowDevice.h"
 #include "cantera/numerics/FuncEval.h"
 #include "cantera/numerics/SteadyStateSystem.h"
 
@@ -284,16 +286,7 @@ public:
     //! Return the index corresponding to the start of the reactor specific state
     //! vector in the reactor with index *reactor* in the global state vector for the
     //! reactor network.
-    size_t globalStartIndex(Reactor* curr_reactor) {
-        for (size_t i = 0; i < m_reactors.size(); i++) {
-            if (curr_reactor == m_reactors[i]) {
-                return m_start[i];
-            }
-        }
-        throw CanteraError("ReactorNet::globalStartIndex: ",
-                curr_reactor->name(), " not found in network.");
-        return npos;
-    }
+    size_t globalStartIndex(ReactorBase* curr_reactor);
 
     //! Return the name of the i-th component of the global state vector. The
     //! name returned includes both the name of the reactor and the specific
@@ -498,6 +491,10 @@ protected:
     //! derivative settings
     bool m_jac_skip_walls = false;
     bool m_jac_skip_flow_devices = false;
+    //! set to store walls for Jacobian calculation
+    set<WallBase*> m_walls;
+    //! set to store flow devices for Jacobian calculation
+    set<FlowDevice*> m_flow_devices;
 };
 
 

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -281,6 +281,20 @@ public:
     //! reactor network.
     size_t globalComponentIndex(const string& component, size_t reactor=0);
 
+    //! Return the index corresponding to the start of the reactor specific state
+    //! vector in the reactor with index *reactor* in the global state vector for the
+    //! reactor network.
+    size_t globalStartIndex(Reactor* curr_reactor) {
+        for (size_t i = 0; i < m_reactors.size(); i++) {
+            if (curr_reactor == m_reactors[i]) {
+                return m_start[i];
+            }
+        }
+        throw CanteraError("ReactorNet::globalStartIndex: ",
+                curr_reactor->name(), " not found in network.");
+        return npos;
+    }
+
     //! Return the name of the i-th component of the global state vector. The
     //! name returned includes both the name of the reactor and the specific
     //! component, for example `'reactor1: CH4'`.
@@ -481,6 +495,10 @@ protected:
     //! "left hand side" of each governing equation
     vector<double> m_LHS;
     vector<double> m_RHS;
+
+    //! derivative settings
+    bool m_jac_skip_walls = false;
+    bool m_jac_skip_flow_devices = false;
 };
 
 

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -89,46 +89,26 @@ public:
     //! Build the Jacobian terms specific to the flow device for the given connected
     //! reactor.
     //! @param r a pointer to the calling reactor
-    //! @param jacVector a vector of triplets to be added to the jacobian for the
-    //! reactor
+    //! @param jacVector a vector of triplets to be added to the reactor Jacobian
     //! @warning This function is an experimental part of the %Cantera API and may be
-    //! changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
+    //! changed or removed without notice.
+    //! @since New in %Cantera 3.1.
     //!
-    virtual void buildReactorJacobian(ReactorBase* r, vector<Eigen::Triplet<double>>& jacVector) {
+    virtual void buildReactorJacobian(ReactorBase* r,
+        vector<Eigen::Triplet<double>>& jacVector) {
         throw NotImplementedError("WallBase::buildReactorJacobian");
     }
 
-    //! Build the Jacobian terms specific to the flow device for the network. These
-    //! terms
-    //! will be adjusted to the networks indexing system outside of the reactor.
-    //! @param jacVector a vector of triplets to be added to the jacobian for the
-    //! reactor
+    //! Build the Jacobian cross-reactor terms specific to the flow device for the
+    //! network.
+    //! @param jacVector a vector of triplets to be added to the network Jacobian
     //! @warning This function is an experimental part of the %Cantera API and may be
-    //! changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
+    //! changed or removed without notice.
+    //! @since New in %Cantera 3.1.
     //!
     virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) {
         throw NotImplementedError("WallBase::buildNetworkJacobian");
     }
-
-    //! Specify the jacobian terms have been calculated and should not be recalculated.
-    //! @warning This function is an experimental part of the %Cantera API and may be
-    //! changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
-    //!
-    void jacobianCalculated() { m_jac_calculated = true; };
-
-    //! Specify that jacobian terms have not been calculated and should be recalculated.
-    //! @warning This function is an experimental part of the %Cantera API and may be
-    //! changed
-    //! or removed without notice.
-    //! @since New in %Cantera 3.0.
-    //!
-    void jacobianNotCalculated() { m_jac_calculated = false; };
 
 protected:
     ReactorBase* m_left = nullptr;
@@ -138,10 +118,6 @@ protected:
     double m_time = 0.0;
 
     double m_area = 1.0;
-
-    //! a variable to switch on and off so calculations are not doubled by the calling
-    //! reactor or network
-    bool m_jac_calculated = false;
 };
 
 //! Represents a wall between between two ReactorBase objects.
@@ -249,9 +225,11 @@ public:
         return m_k;
     }
 
-    virtual void buildReactorJacobian(ReactorBase* r, vector<Eigen::Triplet<double>>& jacVector) override;
+    void buildReactorJacobian(ReactorBase* r,
+        vector<Eigen::Triplet<double>>& jacVector) override;
 
-    virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) override;
+    void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector)
+        override;
 
 protected:
 

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -9,6 +9,7 @@
 #include "cantera/base/ctexceptions.h"
 #include "cantera/zeroD/ReactorBase.h"
 #include "ConnectorNode.h"
+#include "cantera/numerics/eigen_sparse.h"
 
 namespace Cantera
 {
@@ -85,6 +86,46 @@ public:
         m_time = time;
     }
 
+    /*! Build the Jacobian terms specific to the flow device for the given connected reactor.
+     * @param r a pointer to the calling reactor
+     * @param jacVector a vector of triplets to be added to the jacobian for the reactor
+     * @warning This function is an experimental part of the %Cantera API and may be
+     * changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    virtual void buildReactorJacobian(ReactorBase* r, vector<Eigen::Triplet<double>>& jacVector) {
+        throw NotImplementedError("WallBase::buildReactorJacobian");
+    }
+
+    /*! Build the Jacobian terms specific to the flow device for the network. These terms
+     * will be adjusted to the networks indexing system outside of the reactor.
+     * @param jacVector a vector of triplets to be added to the jacobian for the reactor
+     * @warning This function is an experimental part of the %Cantera API and may be
+     * changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) {
+        throw NotImplementedError("WallBase::buildNetworkJacobian");
+    }
+
+    /*! Specify the jacobian terms have been calculated and should not be recalculated.
+     * @warning This function is an experimental part of the %Cantera API and may be
+     * changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    void jacobianCalculated() { m_jac_calculated = true; };
+
+    /*! Specify that jacobian terms have not been calculated and should be recalculated.
+     * @warning This function is an experimental part of the %Cantera API and may be
+     * changed
+     * or removed without notice.
+     * @since New in %Cantera 3.0.
+     */
+    void jacobianNotCalculated() { m_jac_calculated = false; };
+
 protected:
     ReactorBase* m_left = nullptr;
     ReactorBase* m_right = nullptr;
@@ -93,6 +134,10 @@ protected:
     double m_time = 0.0;
 
     double m_area = 1.0;
+
+    //! a variable to switch on and off so calculations are not doubled by the calling
+    //! reactor or network
+    bool m_jac_calculated = false;
 };
 
 //! Represents a wall between between two ReactorBase objects.
@@ -199,6 +244,10 @@ public:
     double getExpansionRateCoeff() const {
         return m_k;
     }
+
+    virtual void buildReactorJacobian(ReactorBase* r, vector<Eigen::Triplet<double>>& jacVector) override;
+
+    virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) override;
 
 protected:
 

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -86,44 +86,48 @@ public:
         m_time = time;
     }
 
-    /*! Build the Jacobian terms specific to the flow device for the given connected reactor.
-     * @param r a pointer to the calling reactor
-     * @param jacVector a vector of triplets to be added to the jacobian for the reactor
-     * @warning This function is an experimental part of the %Cantera API and may be
-     * changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Build the Jacobian terms specific to the flow device for the given connected
+    //! reactor.
+    //! @param r a pointer to the calling reactor
+    //! @param jacVector a vector of triplets to be added to the jacobian for the
+    //! reactor
+    //! @warning This function is an experimental part of the %Cantera API and may be
+    //! changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     virtual void buildReactorJacobian(ReactorBase* r, vector<Eigen::Triplet<double>>& jacVector) {
         throw NotImplementedError("WallBase::buildReactorJacobian");
     }
 
-    /*! Build the Jacobian terms specific to the flow device for the network. These terms
-     * will be adjusted to the networks indexing system outside of the reactor.
-     * @param jacVector a vector of triplets to be added to the jacobian for the reactor
-     * @warning This function is an experimental part of the %Cantera API and may be
-     * changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Build the Jacobian terms specific to the flow device for the network. These
+    //! terms
+    //! will be adjusted to the networks indexing system outside of the reactor.
+    //! @param jacVector a vector of triplets to be added to the jacobian for the
+    //! reactor
+    //! @warning This function is an experimental part of the %Cantera API and may be
+    //! changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     virtual void buildNetworkJacobian(vector<Eigen::Triplet<double>>& jacVector) {
         throw NotImplementedError("WallBase::buildNetworkJacobian");
     }
 
-    /*! Specify the jacobian terms have been calculated and should not be recalculated.
-     * @warning This function is an experimental part of the %Cantera API and may be
-     * changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Specify the jacobian terms have been calculated and should not be recalculated.
+    //! @warning This function is an experimental part of the %Cantera API and may be
+    //! changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     void jacobianCalculated() { m_jac_calculated = true; };
 
-    /*! Specify that jacobian terms have not been calculated and should be recalculated.
-     * @warning This function is an experimental part of the %Cantera API and may be
-     * changed
-     * or removed without notice.
-     * @since New in %Cantera 3.0.
-     */
+    //! Specify that jacobian terms have not been calculated and should be recalculated.
+    //! @warning This function is an experimental part of the %Cantera API and may be
+    //! changed
+    //! or removed without notice.
+    //! @since New in %Cantera 3.0.
+    //!
     void jacobianNotCalculated() { m_jac_calculated = false; };
 
 protected:

--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -122,3 +122,5 @@ cdef anyvalue_to_python(string name, CxxAnyValue& v)
 
 cdef vector[CxxEigenTriplet] python_to_triplets(triplets) except *
 cdef triplets_to_python(vector[CxxEigenTriplet]& triplets)
+
+cdef CxxEigenTriplet get_triplet(row, col, val) except *

--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -9,6 +9,7 @@ from libcpp.memory cimport unique_ptr, make_unique
 
 from .ctcxx cimport *
 from .units cimport UnitSystem, CxxUnits
+from .delegator cimport CxxEigenTriplet
 
 cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
     cdef cppclass CxxAnyValue "Cantera::AnyValue"
@@ -118,3 +119,6 @@ cdef anymap_to_py(CxxAnyMap& m)
 
 cdef CxxAnyValue python_to_anyvalue(item, name=*) except *
 cdef anyvalue_to_python(string name, CxxAnyValue& v)
+
+cdef vector[CxxEigenTriplet] python_to_triplets(triplets) except *
+cdef triplets_to_python(vector[CxxEigenTriplet]& triplets)

--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -120,7 +120,4 @@ cdef anymap_to_py(CxxAnyMap& m)
 cdef CxxAnyValue python_to_anyvalue(item, name=*) except *
 cdef anyvalue_to_python(string name, CxxAnyValue& v)
 
-cdef vector[CxxEigenTriplet] python_to_triplets(triplets) except *
-cdef triplets_to_python(vector[CxxEigenTriplet]& triplets)
-
 cdef CxxEigenTriplet get_triplet(row, col, val) except *

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -528,40 +528,9 @@ cdef vector[vector[string]] list2_string_to_anyvalue(data):
             v[i][j] = stringify(jtem)
     return v
 
-cdef vector[CxxEigenTriplet] python_to_triplets(triplets):
-    # check that triplet dimensions are met
-    trip_shape = np.shape(triplets)
-    assert len(trip_shape) == 2
-    assert trip_shape[1] == 3
-    cdef vector[CxxEigenTriplet] trips
-    # c++ variables
-    cdef size_t row
-    cdef size_t col
-    cdef double val
-    cdef CxxEigenTriplet* trip_ptr
-    for r, c, v in triplets:
-        row = r
-        col = c
-        val = v
-        trip_ptr = new CxxEigenTriplet(row, col, val)
-        trips.push_back(dereference(trip_ptr))
-    return trips
-
 cdef CxxEigenTriplet get_triplet(row, col, val):
     cdef CxxEigenTriplet* trip_ptr = new CxxEigenTriplet(row, col, val)
     return dereference(trip_ptr)
-
-cdef triplets_to_python(vector[CxxEigenTriplet]& triplets):
-    values = []
-    cdef size_t row
-    cdef size_t col
-    cdef double val
-    for t in triplets:
-        row = t.row()
-        col = t.col()
-        val = t.value()
-        values.append((row, col, val))
-    return values
 
 def _py_to_any_to_py(dd):
     # used for internal testing purposes only

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -5,6 +5,7 @@ import os
 import warnings
 from cpython.ref cimport PyObject
 from libcpp.utility cimport move
+from cython.operator cimport dereference
 import numbers as _numbers
 import importlib as _importlib
 from collections import namedtuple as _namedtuple
@@ -526,6 +527,37 @@ cdef vector[vector[string]] list2_string_to_anyvalue(data):
         for j, jtem in enumerate(item):
             v[i][j] = stringify(jtem)
     return v
+
+cdef vector[CxxEigenTriplet] python_to_triplets(triplets):
+    # check that triplet dimensions are met
+    trip_shape = np.shape(triplets)
+    assert len(trip_shape) == 2
+    assert trip_shape[1] == 3
+    cdef vector[CxxEigenTriplet] trips
+    # c++ variables
+    cdef size_t row
+    cdef size_t col
+    cdef double val
+    cdef CxxEigenTriplet* trip_ptr
+    for r, c, v in triplets:
+        row = r
+        col = c
+        val = v
+        trip_ptr = new CxxEigenTriplet(row, col, val)
+        trips.push_back(dereference(trip_ptr))
+    return trips
+
+cdef triplets_to_python(vector[CxxEigenTriplet]& triplets):
+    values = []
+    cdef size_t row
+    cdef size_t col
+    cdef double val
+    for t in triplets:
+        row = t.row()
+        col = t.col()
+        val = t.value()
+        values.append((row, col, val))
+    return values
 
 def _py_to_any_to_py(dd):
     # used for internal testing purposes only

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -547,6 +547,10 @@ cdef vector[CxxEigenTriplet] python_to_triplets(triplets):
         trips.push_back(dereference(trip_ptr))
     return trips
 
+cdef CxxEigenTriplet get_triplet(row, col, val):
+    cdef CxxEigenTriplet* trip_ptr = new CxxEigenTriplet(row, col, val)
+    return dereference(trip_ptr)
+
 cdef triplets_to_python(vector[CxxEigenTriplet]& triplets):
     values = []
     cdef size_t row

--- a/interfaces/cython/cantera/delegator.pxd
+++ b/interfaces/cython/cantera/delegator.pxd
@@ -7,6 +7,15 @@
 from .ctcxx cimport *
 from .func1 cimport *
 from .units cimport CxxUnitStack
+# from .kinetics cimport *
+
+cdef extern from "cantera/numerics/eigen_sparse.h" namespace "Eigen":
+    cdef cppclass CxxEigenTriplet "Eigen::Triplet<double>":
+        CxxEigenTriplet()
+        CxxEigenTriplet(size_t, size_t, double)
+        size_t row()
+        size_t col()
+        size_t value()
 
 cdef extern from "<array>" namespace "std" nogil:
     cdef cppclass size_array1 "std::array<size_t, 1>":
@@ -52,7 +61,7 @@ cdef extern from "cantera/base/Delegator.h" namespace "Cantera":
         void setDelegate(string&, function[int(double&, void*)], string&) except +translate_exception
         void setDelegate(string&, function[int(string&, size_t)], string&) except +translate_exception
         void setDelegate(string&, function[int(size_t&, string&)], string&) except +translate_exception
-
+        void setDelegate(string&, function[void(vector[CxxEigenTriplet]&)], string&) except +translate_exception
 
 cdef extern from "cantera/cython/funcWrapper.h":
     # pyOverride is actually a templated function, but we have to specify the individual
@@ -77,6 +86,9 @@ cdef extern from "cantera/cython/funcWrapper.h":
     cdef function[int(string&, size_t)] pyOverride(PyObject*, int(PyFuncInfo&, string&, size_t))
     cdef function[int(size_t&, const string&)] pyOverride(
         PyObject*, int(PyFuncInfo&, size_t&, const string&))
+    cdef function[void(vector[CxxEigenTriplet]&)] pyOverride(
+        PyObject*, void(PyFuncInfo&, vector[CxxEigenTriplet]&))
+
 
 cdef extern from "cantera/base/ExtensionManager.h" namespace "Cantera":
     cdef cppclass CxxExtensionManager "Cantera::ExtensionManager":

--- a/interfaces/cython/cantera/delegator.pyx
+++ b/interfaces/cython/cantera/delegator.pyx
@@ -9,7 +9,7 @@ from libc.stdlib cimport malloc
 from libc.string cimport strcpy
 
 from ._utils import CanteraError
-from ._utils cimport stringify, pystr, anymap_to_py, py_to_anymap, triplets_to_python, python_to_triplets, get_triplet
+from ._utils cimport stringify, pystr, anymap_to_py, py_to_anymap, get_triplet
 from .units cimport Units, UnitStack
 # from .reaction import ExtensibleRate, ExtensibleRateData
 from .reaction cimport (ExtensibleRate, ExtensibleRateData, CxxReaction,

--- a/interfaces/cython/cantera/delegator.pyx
+++ b/interfaces/cython/cantera/delegator.pyx
@@ -319,6 +319,7 @@ cdef int assign_delegates(obj, CxxDelegator* delegator) except -1:
 
         if when is None:
             continue
+
         cxx_name = stringify(options[0])
         callback = options[1].replace(' ', '')
 

--- a/interfaces/cython/cantera/jacobians.pxd
+++ b/interfaces/cython/cantera/jacobians.pxd
@@ -46,20 +46,16 @@ cdef extern from "cantera/numerics/SystemJacobianFactory.h" namespace "Cantera":
 cdef class SystemJacobian:
     @staticmethod
     cdef wrap(shared_ptr[CxxSystemJacobian])
-    cdef set_cxx_object(self)
     cdef shared_ptr[CxxSystemJacobian] _base
 
 cdef class EigenSparseJacobian(SystemJacobian):
-    cdef set_cxx_object(self)
     cdef CxxEigenSparseJacobian* sparse_jac
 
 cdef class EigenSparseDirectJacobian(EigenSparseJacobian):
     pass
 
 cdef class AdaptivePreconditioner(EigenSparseJacobian):
-    cdef set_cxx_object(self)
     cdef CxxAdaptivePreconditioner* adaptive
 
 cdef class BandedJacobian(SystemJacobian):
-    cdef set_cxx_object(self)
     cdef CxxMultiJac* band_jac

--- a/interfaces/cython/cantera/jacobians.pxd
+++ b/interfaces/cython/cantera/jacobians.pxd
@@ -12,6 +12,8 @@ cdef extern from "cantera/numerics/SystemJacobian.h" namespace "Cantera":
         CxxSystemJacobian()
         string preconditionerSide()
         string type()
+        double gamma()
+        void setGamma(double) except +translate_exception
         void setPreconditionerSide(string) except +translate_exception
 
 cdef extern from "cantera/numerics/EigenSparseJacobian.h" namespace "Cantera":

--- a/interfaces/cython/cantera/jacobians.pyx
+++ b/interfaces/cython/cantera/jacobians.pyx
@@ -48,7 +48,7 @@ cdef class SystemJacobian:
         jac.set_cxx_object()
         return jac
 
-    cdef set_cxx_object(self):
+    def set_cxx_object(self):
         pass
 
     property side:
@@ -67,10 +67,10 @@ cdef class SystemJacobian:
         """ Get/Set the value of gamma used in the expression P = (I - gamma * J).
         """
         def __get__(self):
-            return self.pbase.get().gamma()
+            return self._base.get().gamma()
 
         def __set__(self, value):
-            self.pbase.get().setGamma(value)
+            self._base.get().setGamma(value)
 
 
 cdef class EigenSparseJacobian(SystemJacobian):
@@ -81,7 +81,8 @@ cdef class EigenSparseJacobian(SystemJacobian):
 
     _type = "eigen-sparse"
 
-    cdef set_cxx_object(self):
+    def set_cxx_object(self):
+        super().set_cxx_object()
         self.sparse_jac = <CxxEigenSparseJacobian*>self._base.get()
 
     def print_contents(self):
@@ -117,7 +118,8 @@ cdef class AdaptivePreconditioner(EigenSparseJacobian):
     _type = "Adaptive"
     linear_solver_type = "GMRES"
 
-    cdef set_cxx_object(self):
+    def set_cxx_object(self):
+        super().set_cxx_object()
         self.adaptive = <CxxAdaptivePreconditioner*>self._base.get()
 
     property threshold:
@@ -188,5 +190,6 @@ cdef class BandedJacobian(SystemJacobian):
     _type = "banded-direct"
     linear_solver_type = "direct"
 
-    cdef set_cxx_object(self):
+    def set_cxx_object(self):
+        super().set_cxx_object()
         self.band_jac = <CxxMultiJac*>self._base.get()

--- a/interfaces/cython/cantera/jacobians.pyx
+++ b/interfaces/cython/cantera/jacobians.pyx
@@ -63,6 +63,15 @@ cdef class SystemJacobian:
         def __set__(self, side):
             self._base.get().setPreconditionerSide(stringify(side))
 
+    property gamma:
+        """ Get/Set the value of gamma used in the expression P = (I - gamma * J).
+        """
+        def __get__(self):
+            return self.pbase.get().gamma()
+
+        def __set__(self, value):
+            self.pbase.get().setGamma(value)
+
 
 cdef class EigenSparseJacobian(SystemJacobian):
     """

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -5,6 +5,7 @@
 #distutils: language = c++
 
 from .ctcxx cimport *
+from .delegator cimport CxxEigenTriplet
 from .kinetics cimport *
 from .func1 cimport *
 from .jacobians cimport *
@@ -58,6 +59,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void getState(double*) except +translate_exception
         CxxSparseMatrix jacobian() except +translate_exception
         CxxSparseMatrix finiteDifferenceJacobian() except +translate_exception
+        void buildJacobian(vector[CxxEigenTriplet]&) except +translate_exception
         void setAdvanceLimit(string&, double) except +translate_exception
         void addSensitivitySpeciesEnthalpy(size_t) except +translate_exception
 

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -220,6 +220,7 @@ cdef extern from "cantera/zeroD/ReactorDelegator.h" namespace "Cantera":
         void setHeatRate(double)
         void restoreThermoState() except +translate_exception
         void restoreSurfaceState(size_t) except +translate_exception
+        void defaultEval(double time, double* LHS, double* RHS)
 
 
 ctypedef CxxReactorAccessor* CxxReactorAccessorPtr

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -207,6 +207,8 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void setPreconditioner(shared_ptr[CxxSystemJacobian] preconditioner)
         void setDerivativeSettings(CxxAnyMap&)
         CxxAnyMap solverStats() except +translate_exception
+        CxxSparseMatrix jacobian() except +translate_exception
+        CxxSparseMatrix finiteDifferenceJacobian() except +translate_exception
 
 cdef extern from "cantera/zeroD/ReactorDelegator.h" namespace "Cantera":
     cdef cppclass CxxReactorAccessor "Cantera::ReactorAccessor":

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -645,7 +645,8 @@ cdef class ExtensibleReactor(Reactor):
         'eval_surfaces': ('evalSurfaces', 'void(double*,double*,double*)'),
         'component_name': ('componentName', 'string(size_t)'),
         'component_index': ('componentIndex', 'size_t(string)'),
-        'species_index': ('speciesIndex', 'size_t(string)')
+        'species_index': ('speciesIndex', 'size_t(string)'),
+        'build_jacobian': ('buildJacobian', 'void(vector[CxxEigenTriplet]&)')
     }
 
     def __cinit__(self, *args, **kwargs):

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -2082,6 +2082,31 @@ cdef class ReactorNet:
         def __set__(self, settings):
             self.net.setDerivativeSettings(py_to_anymap(settings))
 
+    property jacobian:
+        """
+        Get the system Jacobian or an approximation thereof.
+
+        **Warning**: Depending on the particular implementation, this may return an
+        approximate Jacobian intended only for use in forming a preconditioner for
+        iterative solvers, excluding terms that would generate a fully-dense Jacobian.
+
+        **Warning**: This method is an experimental part of the Cantera API and may be
+        changed or removed without notice.
+        """
+        def __get__(self):
+            return get_from_sparse(self.net.jacobian(), self.n_vars, self.n_vars)
+
+    property finite_difference_jacobian:
+        """
+        Get the system Jacobian, calculated using a finite difference method.
+
+        **Warning:** this property is an experimental part of the Cantera API and
+        may be changed or removed without notice.
+        """
+        def __get__(self):
+            return get_from_sparse(self.net.finiteDifferenceJacobian(),
+                                   self.n_vars, self.n_vars)
+
     def draw(self, *, graph_attr=None, node_attr=None, edge_attr=None,
              heat_flow_attr=None, mass_flow_attr=None, moving_wall_edge_attr=None,
              surface_edge_attr=None, show_wall_velocity=True, print_state=False,

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -2,6 +2,8 @@
 # at https://cantera.org/license.txt for license and copyright information.
 
 import warnings
+import numpy as np
+from collections import defaultdict as _defaultdict
 import numbers as _numbers
 from cython.operator cimport dereference as deref
 import numpy as np
@@ -704,6 +706,16 @@ cdef class ExtensibleReactor(Reactor):
         state of that surface
         """
         self.accessor.restoreSurfaceState(n)
+
+    def default_eval(self, time, LHS, RHS):
+        """
+        Evaluation of the base reactors `eval` function to be used in `replace`
+        functions and maintain original functionality.
+        """
+        assert len(LHS) == self.n_vars and len(RHS) == self.n_vars
+        cdef np.ndarray[np.double_t, ndim=1, mode="c"] rhs = np.frombuffer(RHS)
+        cdef np.ndarray[np.double_t, ndim=1, mode="c"] lhs = np.frombuffer(LHS)
+        self.accessor.defaultEval(time, &lhs[0], &rhs[0])
 
 
 cdef class ExtensibleIdealGasReactor(ExtensibleReactor):

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -289,23 +289,11 @@ double IdealGasConstPressureMoleReactor::lowerBound(size_t k) const {
     }
 }
 
-double IdealGasConstPressureMoleReactor::moleDerivative(size_t index)
+double IdealGasConstPressureMoleReactor::temperature_ddni(size_t index)
 {
     // derivative of temperature transformed by ideal gas law
-    vector<double> moles(m_nsp);
-    getMoles(moles.data());
-    double dTdni = pressure() * m_vol / GasConstant / std::accumulate(moles.begin(), moles.end(), 0.0);
-    return dTdni;
-}
-
-double IdealGasConstPressureMoleReactor::moleRadiationDerivative(size_t index)
-{
-    // derivative of temperature transformed by ideal gas law
-    vector<double> moles(m_nsp);
-    getMoles(moles.data());
-    double dT4dni = std::pow(pressure() * m_vol / GasConstant, 4);
-    dT4dni *= std::pow(1 / std::accumulate(moles.begin(), moles.end(), 0.0), 5);
-    return dT4dni;
+    double n_total = m_mass / m_thermo->meanMolecularWeight();
+    return pressure() * m_vol / GasConstant / n_total;
 }
 
 }

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -125,7 +125,10 @@ void IdealGasConstPressureMoleReactor::buildJacobian(
     // d (dot(omega)) / d c_j, it is later transformed appropriately.
     Eigen::SparseMatrix<double> dnk_dnj = m_kin->netProductionRates_ddCi();
     // species size that accounts for surface species
-    size_t ssize = m_nv - m_sidx;
+    size_t ssize = m_nsp;
+    for (auto surf : m_surfaces) {
+        ssize += surf->thermo()->nSpecies();
+    }
     // map derivatives from the surface chemistry jacobian
     // to the reactor jacobian
     if (!m_surfaces.empty()) {

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -274,32 +274,16 @@ void IdealGasMoleReactor::buildJacobian(vector<Eigen::Triplet<double>>& jacVecto
             jacVector.emplace_back(0, static_cast<int>(j + m_sidx),
                 (specificHeat[j] * qdot - NCv * uk_dnkdnj_sums[j]) * denom);
         }
-
-        // build wall jacobian
         buildWallJacobian(jacVector);
     }
-
-    // build flow jacobian
     buildFlowJacobian(jacVector);
 }
 
-double IdealGasMoleReactor::moleDerivative(size_t index)
+double IdealGasMoleReactor::temperature_ddni(size_t index)
 {
     // derivative of temperature transformed by ideal gas law
-    vector<double> moles(m_nsp);
-    getMoles(moles.data());
-    double dTdni = pressure() * m_vol / GasConstant / std::accumulate(moles.begin(), moles.end(), 0.0);
-    return dTdni;
-}
-
-double IdealGasMoleReactor::moleRadiationDerivative(size_t index)
-{
-    // derivative of temperature transformed by ideal gas law
-    vector<double> moles(m_nsp);
-    getMoles(moles.data());
-    double dT4dni = std::pow(pressure() * m_vol / GasConstant, 4);
-    dT4dni *= std::pow(1 / std::accumulate(moles.begin(), moles.end(), 0.0), 5);
-    return dT4dni;
+    double n_total = m_mass / m_thermo->meanMolecularWeight();
+    return pressure() * m_vol / GasConstant / n_total;
 }
 
 }

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -193,7 +193,10 @@ void IdealGasMoleReactor::buildJacobian(vector<Eigen::Triplet<double>>& jacVecto
     // d (dot(omega)) / d c_j, it is later transformed appropriately.
     Eigen::SparseMatrix<double> dnk_dnj = m_kin->netProductionRates_ddCi();
     // species size that accounts for surface species
-    size_t ssize = m_nv - m_sidx;
+    size_t ssize = m_nsp;
+    for (auto surf : m_surfaces) {
+        ssize += surf->thermo()->nSpecies();
+    }
     // map derivatives from the surface chemistry jacobian
     // to the reactor jacobian
     if (!m_surfaces.empty()) {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -658,7 +658,7 @@ void Reactor::buildFlowJacobian(vector<Eigen::Triplet<double>>& jacVector)
             m_outlet[i]->buildReactorJacobian(this, jacVector);
         }
 
-        for (size_t i = 0; i <m_outlet.size(); i++) {
+        for (size_t i = 0; i <m_inlet.size(); i++) {
             m_inlet[i]->buildReactorJacobian(this, jacVector);
         }
     }

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -642,7 +642,7 @@ void Reactor::setAdvanceLimit(const string& nm, const double limit)
     }
 }
 
-void Reactor:: buildWallJacobian(vector<Eigen::Triplet<double>>& jacVector)
+void Reactor::buildWallJacobian(vector<Eigen::Triplet<double>>& jacVector)
 {
     if (!m_jac_skip_walls) {
         for (size_t i = 0; i < m_wall.size(); i++) {
@@ -664,4 +664,13 @@ void Reactor::buildFlowJacobian(vector<Eigen::Triplet<double>>& jacVector)
     }
 }
 
+Eigen::SparseMatrix<double> Reactor::jacobian() {
+        m_jac_trips.clear();
+        // Add before, during, after evals
+        buildJacobian(m_jac_trips);
+        // construct jacobian from vector
+        Eigen::SparseMatrix<double> jac(m_nv, m_nv);
+        jac.setFromTriplets(m_jac_trips.begin(), m_jac_trips.end());
+        return jac;
+    }
 }

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -872,15 +872,11 @@ void ReactorNet::buildJacobian(vector<Eigen::Triplet<double>>& jacVector)
 
     // loop through all connections and then set them found so calculations are not
     // repeated
-    for (auto r : m_reactors) {
-        // walls
-        for (const auto& wall : m_walls) {
-            wall->buildNetworkJacobian(jacVector);
-        }
-        // flow devices
-        for (const auto& flow_device : m_flow_devices) {
-            flow_device->buildNetworkJacobian(jacVector);
-        }
+    for (const auto& wall : m_walls) {
+        wall->buildNetworkJacobian(jacVector);
+    }
+    for (const auto& flow_device : m_flow_devices) {
+        flow_device->buildNetworkJacobian(jacVector);
     }
 }
 

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -872,7 +872,7 @@ void ReactorNet::buildJacobian(vector<Eigen::Triplet<double>>& jacVector)
             }
         }
         // flow devices
-        if (m_jac_skip_flow_devices) {
+        if (!m_jac_skip_flow_devices) {
             // outlets
             for (size_t i = 0; i < r->nOutlets(); i++) {
                 r->outlet(i).buildNetworkJacobian(jacVector);

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -784,10 +784,10 @@ void ReactorNet::preconditionerSetup(double t, double* y, double gamma)
     // Update network with adjusted state
     updateState(yCopy.data());
     // Create jacobian triplet vector
-    vector<Eigen::Triplet<double>> jac_vector;
-    buildJacobian(jac_vector);
+    vector<Eigen::Triplet<double>> jacVector;
+    buildJacobian(jacVector);
     // Add to preconditioner with offset
-    for (auto it : jac_vector) {
+    for (auto it : jacVector) {
         precon->setValue(it.row(), it.col(), it.value());
     }
     // post reactor setup operations

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1543,6 +1543,17 @@ class TestIdealGasMoleReactor(TestMoleReactor):
     reactorClass = ct.IdealGasMoleReactor
     test_preconditioner_unsupported = None
 
+    @pytest.mark.diagnose
+    def test_heat_transfer_network(self):
+        # Result should be the same if (m * cp) / (U * A) is held constant
+        self.make_reactors(T1=300, T2=1000)
+        self.add_wall(U=200, A=1.0)
+        self.net.preconditioner = ct.AdaptivePreconditioner()
+        print(self.net.finite_difference_jacobian)
+        # self.net.advance(1.0)
+        # T1a = self.r1.T
+        # T2a = self.r2.T
+
     def test_adaptive_precon_integration(self):
         # Network one with non-mole reactor
         T0 = 900

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -3572,7 +3572,7 @@ class TestExtensibleReactor:
         net.preconditioner = ct.AdaptivePreconditioner()
         net.advance_to_steady_state()
         # reactors should have the same solution because the default is used
-        self.assertArrayNear(r.get_state(), rstd.get_state())
+        assert r.get_state() == approx(rstd.get_state())
 
 
 class TestSteadySolver:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

In this pull request I have setup basic structure for adding contributions to the jacobian from flow devices and walls.
I have also added an extensible jacobian interface to the `ExtensibleReactor` system and modified the existing jacobian system to pass a vector of triplets as is needed in lieu of creating a large number of separate sparse matrices. 

@speth @ischoegl some additional tests are needed for the wall and flow contributions but I wanted to get the content officially into a PR.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Jacobian contributions from walls and flow devices
- Extensible jacobian interface
- Enhancements to existing jacobian backend

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
