### PR TITLE
Migrate YAML docs

### DIFF
--- a/doc/doxygen/cantera.bib
+++ b/doc/doxygen/cantera.bib
@@ -137,6 +137,14 @@
     url = {https://doi.org/10.1016/0098-3004(92)90029-Q},
     doi = {10.1016/0098-3004(92)90029-Q},
     year = {1992}}
+@techreport{kee1986,
+    author = {R.~J.~Kee and G.~Dixon-Lewis and J.~Warnatz and M.~E.~Coltrin and
+        J.~A.~Miller},
+    institution = {Sandia National Laboratories},
+    number = {SAND86-8246},
+    title = {A {Fortran} computer code package for the evaluation of gas-phase
+        multicomponent transport properties},
+    year = {1986}}
 @techreport{kee1989,
     author = {R.~J.~Kee and F.~M.~Rupley and J.~A.~Miller},
     institution = {Sandia National Laboratories},

--- a/doc/doxygen/cantera.bib
+++ b/doc/doxygen/cantera.bib
@@ -475,6 +475,17 @@
     url = {https://dx.doi.org/10.1063/1.1461829},
     volume = {31},
     year = {2002}}
+@article{westbrook1981,
+    author = {C.~K.~Westbrook and F.~L.~Dryer},
+    journal = {Combustion Science and Technology},
+    volume = {27},
+    number = {1-2},
+    pages = {31-43},
+    title = {Simplified Reaction Mechanisms for the Oxidation of Hydrocarbon Fuels in
+        Flames},
+    doi = {10.1080/00102208108946970},
+    URL = {https://doi.org/10.1080/00102208108946970},
+    year = {1981}}
 @article{zhu2006,
     author = {H.~Zhu and R.~J.~Kee},
     journal = {Journal of The Electrochemical Society},

--- a/doc/sphinx/userguide/ck2yaml-tutorial.md
+++ b/doc/sphinx/userguide/ck2yaml-tutorial.md
@@ -1,0 +1,289 @@
+# Converting Chemkin Format Files
+
+Many existing reaction mechanism files are in **CK format**, by which we mean the input
+file format developed for use with the Chemkin-II software package (and subsequent
+releases) as specified in the report describing the Chemkin software
+{cite:p}`kee1989`. Cantera comes with a converter utility program `ck2yaml` (or
+`ck2yaml.py`) that converts CK format into Cantera's YAML format. If you want to convert
+a Chemkin-format file to YAML format, or you're having errors when you try to do so,
+this section will help.
+
+## Converting gas-phase mechanisms
+
+:::{seealso}
+For documentation of all the command line options that can be used with `ck2yaml`, see
+its [documentation in the reference section](sec-ck2yaml).
+:::
+
+To convert a gas phase mechanism where the thermodynamic and transport data are provided
+as separate files, run the following command from a terminal (command prompt):
+
+```bash
+ck2yaml --input=chem.inp --thermo=therm.dat --transport=tran.dat
+```
+
+If the `ck2yaml` script is not on your path but the Cantera Python module is,
+`ck2yaml` can also be used by running:
+
+```bash
+python -m cantera.ck2yaml --input=chem.inp --thermo=therm.dat --transport=tran.dat
+```
+
+:::{tip}
+If you're using Cantera from IPython or a Jupyter Notebook, you can run the above shell
+command from Python by prefixing it with an exclamation point. For example:
+
+```ipython
+!python -m cantera.ck2yaml --input=chem.inp --thermo=therm.dat --transport=tran.dat
+```
+:::
+
+## Converting surface mechanism files
+
+For mechanisms involving both surface and gas phase species, an additional input file
+is needed to define the surface species and reactions occurring on the surface. This
+file is specified with the `--surface` option:
+
+```bash
+python -m cantera.ck2yaml --input=gas.inp --thermo=therm.dat --surface=surf.inp
+```
+
+## Converting standalone thermo data
+
+An input file containing only species definitions (which can be referenced from
+phase definitions in other input files) can be created by specifying only a
+thermo file. For example:
+
+```bash
+ck2yaml --thermo=therm.dat
+```
+
+## Debugging common errors in CK files
+
+When `ck2yaml` encounters an error, it attempts to print the surrounding information to
+help you to locate the error. Many of the most common errors are due to an inconsistency
+of the input files from their standard, as defined in the report for Chemkin referenced
+above. Here, we describe some requirements of the CK format that are common sources of
+errors.
+
+:::{tip}
+Many existing CK format files cause errors in `ck2yaml` when they are processed. Some of
+these errors may be avoided by specifying the `--permissive` option. This option allows
+certain recoverable parsing errors (for example, duplicate transport or thermodynamic
+data) to be ignored.
+:::
+
+### Input file sections
+
+Each section of a CK input file must start with a keyword representing that section and
+end with the keyword `END`. Keywords that may begin a section include:
+
+  - `ELEMENTS` or `ELEM`
+  - `SPECIES` or `SPEC`
+  - `THERMO` or `THERMO ALL`
+  - `REACTIONS` or `REAC`
+  - `TRANSPORT`
+
+### Thermo data
+
+The thermodynamic data is read in a fixed format. This means that each column of the
+input has a particular meaning. The format for each thermodynamic entry should be as
+follows:
+
+```
+CH3OH             L 8/88C   1H   4O   1     G   200.000  3500.000  1000.000    1
+ 1.78970791E+00 1.40938292E-02-6.36500835E-06 1.38171085E-09-1.17060220E-13    2
+-2.53748747E+04 1.45023623E+01 5.71539582E+00-1.52309129E-02 6.52441155E-05    3
+-7.10806889E-08 2.61352698E-11-2.56427656E+04-1.50409823E+00                   4
+```
+
+:::{caution}
+Many common errors are generated because information is missing or in the wrong column.
+Check thoroughly for extraneous or missing spaces. Also make sure that the input file
+does not contain tab characters.
+:::
+
+The following table is adapted from the Chemkin manual {cite:p}`kee1989` to describe
+the column positioning of each required part of the entry. Empty columns should be
+filled with spaces.
+
+:::{list-table}
+:header-rows: 1
+
+* - Line No.
+  - Columns
+  - Contents
+* - 1
+  - 1--18
+  - Species Name
+* - 1
+  - 19--24
+  - Date (Optional)
+* - 1
+  - 25--44
+  - Atomic Symbols and formula
+* - 1
+  - 45
+  - Phase of species (`S`, `L`, or `G`)
+* - 1
+  - 46--55
+  - Low temperature
+* - 1
+  - 56--65
+  - High temperature
+* - 1
+  - 66--73
+  - Common temperature
+* - 1
+  - 74--78
+  - Additional Atomic Symbols
+* - 1
+  - 80
+  - The integer `1`
+* - 2
+  - 1--75
+  - Coefficients $a_1$ to $a_5$ for the upper temperature interval
+* - 2
+  - 80
+  - The integer `2`
+* - 3
+  - 1--75
+  - Coefficients $a_6,\ a_7$ for the upper temperature interval, and $a_1,\ a_2,\ a_3$
+    for the lower temperature interval
+* - 3
+  - 80
+  - The integer `3`
+* - 4
+  - 1--60
+  - Coefficients $a_4$ through $a_7$ for the lower temperature interval
+* - 4
+  - 80
+  - The integer `4`
+:::
+
+#### Line 1
+
+The first 18 columns are reserved for the species name. The name assigned to the
+species in the thermodynamic data must be the same as the species name defined in the
+`SPECIES` section. If the species name is shorter than 18 characters, the rest of the
+characters should be filled by spaces.
+
+The next six columns (columns 19--24) are typically used to write a date; they are not
+used further.
+
+The next 20 columns (25--44) are used to specify the elemental composition of the
+species. Five characters are used for each element: the first two specify the element
+symbol, while the remaining three specify the number of atoms of that element in the
+species. Up to four elements may be specified this way. For species with more than four
+elements, the [extended composition format](sec-ck-extended-composition) described below
+may be used.
+
+In column 45, the phase of the species (`S`, `L`, or `G` for solid, liquid, or gas
+respectively) should be specified.
+
+The next 28 columns are reserved for the temperatures that delimit the ranges of the
+polynomials specified on the next several lines. The first two temperatures have a width
+of 10 columns each (46--55 and 56--65), and represent the lowest temperature and highest
+temperature for which the polynomials are valid. The last temperature has a width of 8
+columns (66--73) and is the **common** temperature, where the switch from low to high
+occurs.
+
+The next 5 columns (74--78) are reserved for atomic symbols and are usually left blank
+for the default behavior.
+
+Column 79 is blank; and finally, the row is ended in column 80 with the integer `1`.
+
+#### Lines 2--4
+
+% TODO: Link to NASA polynomials section in Science docs
+
+The next three lines of the thermodynamic entry have a similar format. They contain the
+coefficients of the 7-coefficient polynomial formulation in two temperature regions.
+
+The second row of the thermo entry (the first after the information row) contains the
+first five coefficients that apply to the temperature range between the midpoint and the
+upper limit. 15 columns are alloted for each coefficient (for a total of 75 columns),
+with no spaces between them. Although the entry above shows spaces between positive
+coefficients, it is to be noted that this is done only for formatting consistency with
+other lines that contain negative numbers. After the coefficients, four spaces in
+columns 76--79 are followed by the integer `2` in column 80.
+
+On the next line, the last two coefficients for the upper temperature range and the
+first three coefficients for the lower temperature range are specified. Once again, this
+takes up the first 75 columns, columns 76--79 are blank, and the integer `3` is in
+column 80.
+
+Finally, on the last line of a particular entry, the last four coefficients of the lower
+temperature range are specified in columns 1--60, 19 blank spaces are present, and the
+integer `4` is in column 80.
+
+(sec-ck-extended-composition)=
+#### Extended composition format
+
+If the number of atoms of an element in a thermodynamic entry has more than 3 digits,
+the standard format for the composition cannot be used. To allow for such species, the
+following extended format is allowed. The element symbol should have a `0` in the first
+line of the entry. An ampersand (`&`) is added after the index of the first line, and
+the element symbols and their amounts should be written on the next line as follows:
+
+```
+BIN6J      PYRENEJ1     C   0H   0    0    0G   300.000  5000.000 1401.000     1&
+C 778    H 263
+ 3.63345177E+01 3.13968020E-02-1.09044660E-05 1.71125597E-09-1.00056355E-13    2
+ 4.05143093E+04-1.77494305E+02-1.20603441E+01 1.59247554E-01-1.41562602E-04    3
+ 6.26071650E-08-1.09305161E-11 5.56473533E+04 7.68451211E+01                   4
+```
+
+or on separate lines with ampersand (`&`) as the last character on the line:
+
+```
+BIN6       PYRENE       C   0H   0    0    0G   300.000  5000.000 1401.000     1&
+C      778&
+H      264
+ 3.65839677E+01 3.36764102E-02-1.16783938E-05 1.83077466E-09-1.06963777E-13    2
+ 9.29809483E+03-1.81272070E+02-1.29758980E+01 1.63790064E-01-1.43851166E-04    3
+ 6.31057915E-08-1.09568047E-11 2.48866399E+04 7.94950474E+01                   4
+```
+
+### Transport parameters
+
+The transport data file also has a specified format, as described in {cite:p}`kee1986`,
+although the format is not as strict as for the thermodynamic entries. In particular,
+the first 15 columns of a line are reserved for the species name. *One common source of
+errors is a species that is present in the transport data file, but not in the
+thermodynamic data or in the species list; or a species that is present in the species
+list but not the transport data file.* The rest of the columns on a given line have no
+particular format, but must be present in the following order:
+
+:::{list-table}
+:header-rows: 1
+
+* - Parameter Number
+  - Parameter Name
+* - 1
+  - An integer with value 0, 1, or 2 indicating monatomic, linear, or non-linear
+    molecular geometry.
+* - 2
+  - The Lennard-Jones potential well depth $\varepsilon/k_B$ in Kelvin
+* - 3
+  - The Lennard-Jones collision diameter $\sigma$ in Angstrom
+* - 4
+  - The dipole moment $\mu$ in Debye
+* - 5
+  - The polarizability $\alpha$ in Angstroms cubed
+* - 6
+  - The rotational relaxation collision number $Z_{rot}$ at 298 K
+:::
+
+Another common error is if all six of these numbers are not present for every species.
+
+### Other formatting issues
+
+It may be the case that scientific formatted numbers are missing the `E`. In this case,
+numbers often show up as `1.1+01`, when they should be `1.1E+01`. You can fix this with
+a Regular Expression "find and replace":
+
+```
+Find: (\d+\.\d+)([+-]\d+)
+Replace: $1E$2
+```

--- a/doc/sphinx/userguide/creating-mechanisms.md
+++ b/doc/sphinx/userguide/creating-mechanisms.md
@@ -13,7 +13,7 @@ re-used for other simulations. This guide describes how to write such files to d
 phases and interfaces for use in Cantera simulations.
 
 ```{seealso}
-See the [](yaml-tutorial) for an introduction to the YAML syntax used by Cantera and
+See the [](input-tutorial) for an introduction to the YAML syntax used by Cantera and
 a description of how dimensional values are handled.
 ```
 

--- a/doc/sphinx/userguide/creating-mechanisms.md
+++ b/doc/sphinx/userguide/creating-mechanisms.md
@@ -1,0 +1,691 @@
+# Creating YAML Mechanism Files from Scratch
+
+Virtually every Cantera simulation involves one or more phases of matter. Depending on
+the calculation being performed, it may be necessary to evaluate thermodynamic
+properties, transport properties, and/or reaction rates for the phase(s) present. Before
+the properties can be evaluated, each phase must be defined, meaning that the models to
+use to compute its properties and reaction rates must be specified, along with any
+parameters the models require.
+
+Because the amount of data required can be quite large, this data is imported from a
+YAML file that can be read by the application, so that a given phase model can be
+re-used for other simulations. This guide describes how to write such files to define
+phases and interfaces for use in Cantera simulations.
+
+```{seealso}
+See the [](yaml-tutorial) for an introduction to the YAML syntax used by Cantera and
+a description of how dimensional values are handled.
+```
+
+## Phases
+
+For each phase that appears in a problem, a corresponding entry should be present in the
+`phases` section of the input file. The phase entry specifies the elements and species
+present in that phase, and the models to be used for computing thermodynamic, kinetic,
+and transport properties.
+
+### Naming the Phase
+
+The `name` entry is a string that identifies the phase. It must be unique within the
+file among all phase definitions of any type. Phases are referenced by name when
+importing them. The `name` is also used to identify the phase within multiphase mixtures
+or at phase boundaries.
+
+### Setting the Thermodynamic Model
+
+The thermodynamic model used to represent a phase is specified in the `thermo` field. A
+[complete list of supported models](sec-yaml-phase-thermo-models) can be found in the
+YAML Input File Reference. Some thermodynamic models use additional fields in the phase
+entry, which are described in the linked documentation.
+
+### Declaring the Elements
+
+In most cases, it is not necessary to specify the elements present in a phase. If no
+`elements` field is present, elements will be added automatically using the definitions
+of the standard chemical elements based on the composition of the species present in the
+phase.
+
+If non-standard elements such as isotopes need to be represented, or the ordering of
+elements within the phase is important, the elements in the phase may be declared in the
+optional `elements` entry.
+
+If all of the elements to be added are either standard chemical elements or defined in
+the [`elements`](sec-yaml-guide-elements) section of the current input file, the
+elements can be specified as a list of element symbols. For example:
+
+``` yaml
+phases:
+- name: my-mechanism
+  elements: [H, C, O, Ar]
+  ...
+```
+
+To add elements from other top-level sections, from a different file, or from multiple
+such sources, a list of single-key mappings can be used where the key of each mapping
+specifies the source and the value is a list of element names. The keys can be:
+
+- The name of a section within the current file.
+- The name of an input file and a section in that file, separated by a slash, for
+  example `myfile.yaml/my_elements`. If a relative path is specified, the directory
+  containing the current file is searched first, followed by the Cantera data path.
+- The name `default` to reference the standard chemical elements.
+
+Example:
+
+```yaml
+
+my-isotopes:
+- name: O18
+  atomic-weight: 17.9991603
+phases:
+- name: my-phase
+  elements:
+  - default: [C, H, Ar]
+  - my-isotopes: [O18]
+  - myelements.yaml/uranium: [U235, U238]
+  species: ...
+  ...
+```
+
+The order of the elements specified in the input file determines the order of the
+elements in the phase when it is imported by Cantera.
+
+### Declaring the Species
+
+If the species present in the phase corresponds to those species defined in the
+[`species`](sec-yaml-guide-species) section of the input file, the `species` field may
+be omitted, and those species will be added to the phase automatically. As a more
+explicit alternative, the `species` field may be set to the string `all`.
+
+To include specific species from the `species` section of the input file, the `species`
+entry can be a list of species names from that section. For example:
+
+```yaml
+phases:
+- name: my-phase
+  species: [H2, O2, H2O]
+  ...
+```
+
+If species are defined in multiple input file sections, the `species` entry can be a
+list of single-key mappings, where the key of each mapping specifies the source and the
+value is either the string `all` or a list of species names. Each key can be either the
+name of a section within the current input file or the name of a different file and a
+section in that file, separated by a slash. If a relative path is specified, the
+directory containing the current file is searched first, followed by the Cantera data
+path. Example:
+
+```yaml
+phases:
+- name: my-phase
+  species:
+  - species: [O2, N2]
+  - more_species: all
+  - subdir/myfile.yaml/species: [NO2, N2O]
+  ...
+```
+
+The order of species specified in the input file determines the order of the species in
+the phase when it is imported by Cantera.
+
+Species containing elements that are not declared within the phase may be skipped by
+setting the `skip-undeclared-elements` field to `true`. For example, to add all species
+from the `species` section that contain only hydrogen or oxygen, the phase definition
+could contain:
+
+```yaml
+phases:
+- name: hydrogen-and-oxygen
+  elements: [H, O]
+  species: all
+  skip-undeclared-elements: true
+  ...
+```
+
+### Setting the Kinetics Model
+
+The kinetics model to be used, if any, is specified in the `kinetics` field. Supported
+kinetics models are `bulk`, `surface`, and `edge`, depending on the dimensionality of
+the phase. If omitted, no kinetics model will be used. For additional details, see the
+[list of supported models](sec-yaml-phase-kinetics) in the YAML Input File Reference.
+
+### Declaring the Reactions
+
+If a kinetics model has been specified, reactions may be added to the phase. By default,
+all reactions from the `reactions` section of the input file will be added.
+Equivalently, the `reactions` entry may be specified as the string `all`.
+
+To disable automatic addition of reactions from the `reactions` section, the `reactions`
+entry may be set to `none`. This may be useful if reactions will be added
+programmatically after the phase is constructed. The `reactions` field must be set to
+`none` if a kinetics model has been specified but there is no `reactions` section in the
+input file.
+
+To include only those reactions from the `reactions` section where all of the species
+involved are declared as being in the phase, the `reactions` entry can be set to the
+string `declared-species`.
+
+To include reactions from multiple sections or other files, the `reactions` entry can be
+given as a list of section names, for example:
+
+```yaml
+phases:
+- name: my-phase
+  ...
+  reactions:
+  - OH_submechanism
+  - otherfile.yaml/C1-reactions
+  - otherfile.yaml/C2-reactions
+  ...
+```
+
+To include reactions from multiple sections or other files while only including
+reactions involving declared species, a list of single-key mappings can be used, where
+the key is the section name (or file and section name) and the value is either the
+string `all` or the string `declared-species`. For example:
+
+```yaml
+phases:
+- name: my-phase
+  ...
+  reactions:
+  - OH_submechanism: all
+  - otherfile.yaml/C1-reactions: all
+  - otherfile.yaml/C2-reactions: declared-species
+  ...
+```
+
+To permit reactions containing third-body efficiencies for species not present in the
+phase, the additional field `skip-undeclared-third-bodies` may be added to the phase
+entry with the value `true`.
+
+### Setting the Transport Model
+
+To enable transport property calculation, the transport model to be used can be
+specified in the `transport` field. A [complete list of supported models](sec-yaml-phase-transport)
+can be found in the YAML Input File Reference. For most transport models, additional
+parameters need to be specified within each species definition.
+
+### Declaring Adjacent Phases
+
+For interface phases (surfaces and edges), the names of phases adjacent to the interface
+can be specified, in which case these additional phases can be automatically constructed
+when creating the interface phase. This behavior is useful when the interface has
+reactions that include species from one of these adjacent phases, since those phases
+must be known when adding such reactions to the interface.
+
+If the definitions of the adjacent phases are contained in the `phases` section of the
+same input file as the interface, they can be specified as a list of names:
+
+```yaml
+phases:
+- name: my-surface-phase
+  ...
+  adjacent: [gas, bulk]
+  ...
+- name: gas
+  ...
+- name: bulk
+  ...
+```
+
+Alternatively, if the adjacent phase definitions are in other sections or other input
+files, they can be specified as a list of single-key mappings where the key is the
+section name (or file and section name) and the value is the phase name:
+
+```yaml
+phases:
+- name: my-surface-phase
+  ...
+  adjacent:
+  - {my-other-phases: gas}
+  # a phase defined in the 'phases' section of a different YAML file
+  - {path/to/other-file.yaml/phases: bulk}
+  ...
+my-other-phases:
+- name: gas
+  ...
+```
+
+Since an interface kinetics mechanism is defined for the lowest-dimensional phase
+involved in the mechanism, only higher-dimensional adjacent phases should be specified.
+For example, when defining a surface, adjacent bulk phases may be specified, but
+adjacent edges must not.
+
+### Setting the Initial State
+
+The initial state of a phase can be set using two properties to set the thermodynamic
+state, plus the composition. This state is specified as a mapping in the `state` field
+of `phase` entry.
+
+The thermodynamic state can be set by specifying two properties, such as temperature
+(`T`) and pressure (`P`) or internal energy (`U`) and density (`D`). The full list of
+[property names and valid combinations](sec-yaml-setting-state) can be found in the YAML
+Input File Reference. In addition the composition can be set by providing a mapping that
+gives the mass fractions (`X`), mole fractions (`Y`), `coverages` (for surface phases),
+or molalities (`M`, for certain solution models). Where necessary, the values will be
+automatically normalized.
+
+Some examples of setting the state:
+
+```yaml
+phases:
+- name: my-phase
+  ...
+  state:
+    T: 300 K
+    P: 101325 Pa
+    X: {O2: 1.0, N2: 3.76}
+- name: my-other-phase
+  ...
+  state:
+    density: 100 kg/m^3
+    T: 298
+    Y:
+      CH4: 0.2
+      C3H8: 0.1
+      CO2: 0.7
+```
+
+For pure fluid phases, the temperature, pressure, and vapor fraction may all be
+specified if and only if they define a consistent state.
+
+### Examples
+
+The following input file defines two equivalent gas phases including all reactions and
+species defined in the input file. The species and reaction data is not shown for
+clarity. In the second case, the phase definition is simplified by having the elements
+added based on the species definitions, taking the species definitions from the default
+`species` section, and reactions from the default `reactions` section.
+
+```yaml
+phases:
+- name: gas1
+  thermo: ideal-gas
+  elements: [O, H, N, Ar]
+  species: [H2, H, O, O2, OH, H2O, HO2, H2O2, N2, AR]
+  kinetics: gas
+  reactions: all
+  transport: mixture-averaged
+  state:
+    T: 300.0
+    P: 1.01325e+05
+- name: gas2
+  thermo: ideal-gas
+  kinetics: gas
+  transport: mixture-averaged
+  state: {T: 300.0, 1 atm}
+
+species:
+- H2: ...
+- H: ...
+...
+- AR: ...
+
+reactions:
+...
+```
+
+An input file defining an interface and its adjacent bulk phases, with full species data
+not shown for clarity:
+
+```yaml
+phases:
+- name: graphite
+  thermo: lattice
+  species:
+  - graphite-species: all
+  state: {T: 300, P: 101325, X: {C6: 1.0, LiC6: 1e-5}}
+  density: 2.26 g/cm^3
+
+- name: electrolyte
+  thermo: lattice
+  species: [{electrolyte-species: all}]
+  density: 1208.2 kg/m^3
+  state:
+    T: 300
+    P: 101325
+    X: {Li+(e): 0.08, PF6-(e): 0.08, EC(e): 0.28, EMC(e): 0.56}
+
+- name: anode-surface
+  thermo: ideal-surface
+  adjacent: [graphite, electrolyte]
+  kinetics: surface
+  reactions: [graphite-anode-reactions]
+  species: [{anode-species: all}]
+  site-density: 1.0 mol/cm^2
+  state: {T: 300, P: 101325}
+
+graphite-species:
+- name: C6
+  ...
+- name: LiC6
+  ...
+
+electrolyte-species:
+- name: Li+(e)
+  ...
+- name: PF6-(e)
+  ...
+- name: EC(e)
+  ...
+- name: EMC(e)
+  ...
+
+anode-species:
+- name: (int)
+  ...
+
+graphite-anode-reactions:
+- equation: LiC6 <=> Li+(e) + C6
+  rate-constant: [5.74, 0.0, 0.0]
+  beta: 0.4
+```
+
+(sec-yaml-guide-species)=
+## Species
+
+For each species declared as part of a phase description, a species definition is
+required to describe the composition, thermodynamic, and transport parameters of that
+species.
+
+The default location for species entries is in the `species` section of the input file.
+Species defined in this section will automatically be considered for addition to phases
+defined in the same file. Species can be defined in other sections of the input file or
+in other input files, and these species definitions can be used in phase definitions by
+explicitly referencing the section name.
+
+### Species Name
+
+The name of a species is given in the `name` field of a `species` entry. Names may
+include almost all printable characters, with the exception of spaces. The use of some
+characters such as `[`, `]`, and `,` may require that species names be enclosed in
+quotes when written in YAML. Some valid species names given in a YAML list include:
+
+```yaml
+[CH4, methane, argon_2+, "C[CH2]", CH2(singlet), "H2O,l"]
+```
+
+### Elemental Composition
+
+The elemental composition of a species is specified as a mapping in the `composition`
+entry.
+
+For gaseous species, the elemental composition is well-defined, since the species
+represent distinct molecules. For species in solid or liquid solutions, or on surfaces,
+there may be several possible ways of defining the species. For example, an aqueous
+species might be defined with or without including the water molecules in the solvation
+cage surrounding it.
+
+For surface species, it is possible for the `composition` mapping to be empty, in which
+case the species is composed of nothing, and represents an empty surface site. This can
+also be done to represent vacancies in solids. A charged vacancy can be defined to be
+composed solely of electrons.
+
+The number of atoms of an element must be non-negative, except for the special "element"
+`E` that represents an electron.
+
+Examples:
+
+```yaml
+composition: {C: 1, O: 2}  # carbon dioxide
+composition: {Ar: 1, E: -2}  # Ar++
+composition: {Y: 1, Ba: 2, Cu: 3, O: 6.5}  # stoichiometric YBCO
+composition: {}  # A surface species representing an empty site
+```
+
+### Thermodynamic Properties
+
+In addition to the thermodynamic model used at the phase level for computing properties,
+parameterizations are usually required for the enthalpy, entropy, and specific heat
+capacities of individual species under standard conditions. These parameterizations are
+provided in the `thermo` field of each `species` entry, with the type of
+parameterization specified by the `model` field. A
+[complete list of parameterizations](sec-yaml-species-thermo) and their model-specific
+fields can be found in the YAML Input File Reference.
+
+An example `thermo` field using the 7-coefficient NASA polynomials in two temperature
+regions:
+
+```yaml
+thermo:
+  model: NASA7
+  temperature-ranges: [200.0, 1000.0, 3500.0]
+  data:
+  - [5.14987613, -0.0136709788, 4.91800599e-05, -4.84743026e-08, 1.66693956e-11,
+    -1.02466476e+04, -4.64130376]
+  - [0.074851495, 0.0133909467, -5.73285809e-06, 1.22292535e-09, -1.0181523e-13,
+    -9468.34459, 18.437318]
+```
+
+### Species Equation of State
+
+For some phase thermodynamic models, additional equation of state parameterizations are
+needed for each species. This information is provided in the `equation-of-state` field
+of each `species` entry, with the type of parameterization used specified by the `model`
+field of the `equation-of-state` field. A
+[complete list of equation of state parameterizations](sec-yaml-species-eos) and their
+model-specific fields can be found in the YAML Input File Reference.
+
+(sec-yaml-guide-species-transport)=
+### Species Transport Coefficients
+
+Transport-related parameters for each species are needed in order to calculate transport
+properties of a phase. These parameters are provided in the `transport` field of each
+`species` entry, with the type of the parameterization used specified by the `model`
+field of the `transport` field. The only model type specifically handled is `gas`. The
+parameters used depend on the transport model specified at the phase level. The full set
+of possible parameters is described in the {ref}`API documentation
+<sec-yaml-species-transport>`.
+
+An example of a `transport` entry for a gas-phase species:
+
+```yaml
+transport:
+  model: gas
+  geometry: linear
+  well-depth: 107.4
+  diameter: 3.458
+  polarizability: 1.6
+  rotational-relaxation: 3.8
+```
+
+(sec-yaml-guide-reactions)=
+## Reactions
+
+Cantera supports a number of different types of reactions, including several types of
+homogeneous reactions, surface reactions, and electrochemical reactions. The reaction
+entries for all reaction types some common features. These general fields of a reaction
+entry are described first, followed by fields used for specific reaction types.
+
+
+### The Reaction Equation
+
+The reaction equation, specified in the `equation` field of the reaction entry,
+determines the reactant and product stoichiometry. All tokens (species names,
+stoichiometric coefficients, `+`, and `<=>`) in the reaction equation must be separated
+with spaces. Some examples of correctly and incorrectly formatted reaction equations are
+shown below:
+
+```yaml
+- equation: 2 CH2 <=> CH + CH3  # OK
+- equation: 2 CH2<=>CH + CH3  # error - spaces required around '<=>''
+- equation: 2CH2 <=> CH + CH3  # error - space required between '2' and 'CH2'
+- equation: CH2 + CH2 <=> CH + CH3  # OK
+- equation: 2 CH2 <=> CH+CH3  # error - spaces required around '+'
+```
+
+Whether the reaction is reversible or not is determined by the form of the equality sign
+in the reaction equation. If either `<=>` or `=` is found, then the reaction is regarded
+as reversible, and the reverse rate will be computed based on the equilibrium constant.
+If, on the other hand, `=>` is found, the reaction will be treated as irreversible.
+
+### Reaction type
+
+The type of the rate coefficient parameterization may be specified in the `type` field
+of the `reaction` entry. The [fields for specific reaction types](sec-yaml-reactions)
+and additional parameters defining the rate constant for each of these reaction types
+are described in the YAML Input File Reference.
+
+The default parameterization is `elementary`. Reactions involving surface species are
+automatically identified as [`interface`](sec-yaml-interface-Arrhenius) reactions,
+reactions involving surface species with the `type` specified as `Blowers-Masel` are
+treated as [`interface-Blowers-Masel`](sec-yaml-interface-Blowers-Masel), and reactions
+involving charge transfer are automatically identified as
+[`electrochemical`](sec-yaml-electrochemical-reaction) reactions.
+
+### Arrhenius Expressions
+
+Most reaction types in Cantera are parameterized by one or more modified Arrhenius
+expressions, such as
+
+$$  A T^b e^{-E_a / RT}  $$
+
+where $A$ is the pre-exponential factor, $T$ is the temperature, $b$ is the temperature
+exponent, $E_a$ is the activation energy, and $R$ is the gas constant. Rates in this
+form can be written as YAML mappings. For example:
+
+```yaml
+{A: 1.0e13, b: 0, E: 7.3 kcal/mol}
+```
+
+The units of $A$ can be specified explicitly if desired. If not specified, they will be
+determined based on the `quantity`, `length`, and `time` units specified in the
+governing `units` fields. Since the units of $A$ depend on the reaction order, the units
+of each reactant concentration (dependent on phase type and dimensionality), and the
+units of the rate of progress (different for homogeneous and heterogeneous reactions),
+it is usually best not to specify units for $A$, in which case they will be computed
+taking all of these factors into account.
+
+```{note}
+If $b \ne 0$, then the term $T^b$ should have units of $\mathrm{K}^b$, which would
+change the units of $A$. This is not done, however, so the units associated with $A$
+are really the units for $k_f$. One way to formally express this is to replace $T^b$
+by the non-dimensional quantity $[T/(1\;\mathrm{K})]^b$.
+```
+
+The key `E` is used to specify $E_a$.
+
+(sec-yaml-reaction-options)=
+### Duplicate Reactions
+
+When a reaction is imported into a phase, it is checked to see that it is not a
+duplicate of another reaction already present in the phase, and normally an error
+results if a duplicate is found. But in some cases, it may be appropriate to include
+duplicate reactions, for example if a reaction can proceed through two distinctly
+different pathways, each with its own rate expression. Another case where duplicate
+reactions can be used is if it is desired to implement a reaction rate coefficient of
+the form:
+
+$$  k_f(T) = \sum_{n=1}^{N} A_n T^{b_n} \exp(-E_n/RT)  $$
+
+While Cantera does not provide such a form for reaction rates, it can be implemented by
+defining $N$ duplicate reactions, and assigning one rate coefficient in the sum to each
+reaction. By adding the field:
+
+```yaml
+duplicate: true
+```
+
+to a reaction entry, then the reaction not only *may* have a duplicate, it *must*. Any
+reaction that specifies that it is a duplicate, but cannot be paired with another
+reaction in the phase that qualifies as its duplicate generates an error.
+
+### Negative Pre-exponential Factors
+
+If some of the terms in the above sum have negative $A_n$, this scheme fails, since
+Cantera normally does not allow negative pre-exponential factors. But if there are
+duplicate reactions such that the total rate is positive, then the fact that negative
+$A$ parameters are acceptable can be indicated by adding the field:
+
+```yaml
+negative-A: true
+```
+
+### Reaction Orders
+
+Explicit reaction orders different from the stoichiometric coefficients are sometimes
+used for non-elementary reactions. For example, consider the global reaction:
+
+$$  \mathrm{C_8H_{18} + 12.5 O_2 \rightarrow 8 CO_2 + 9 H_2O}  $$
+
+the forward rate constant might be given as {cite:p}`westbrook1981`:
+
+$$
+k_f = 4.6 \times 10^{11} [\mathrm{C_8H_{18}}]^{0.25} [\mathrm{O_2}]^{1.5}
+      \exp\left(\frac{30.0\,\mathrm{kcal/mol}}{RT}\right)
+$$
+
+This reaction could be defined as:
+
+```yaml
+- equation: C8H18 + 12.5 O2 => 8 CO2 + 9 H2O
+  rate-constant: {A: 4.6e11, b: 0.0, Ea: 30.0 kcal/mol}
+  orders: {C8H18: 0.25, O2: 1.5}
+```
+
+Special care is required in this case since the units of the pre-exponential factor
+depend on the sum of the reaction orders, which may not be an integer.
+
+Note that you can change reaction orders only for irreversible reactions.
+
+#### Negative Reaction Orders
+
+Normally, reaction orders are required to be positive. However, in some cases negative
+reaction orders provide better fits for experimental data. In these cases, the default
+behavior may be overridden by adding the `negative-orders` field to the reaction entry.
+For example:
+
+```yaml
+- equation: C8H18 + 12.5 O2 => 8 CO2 + 9 H2O
+  rate-constant: {A: 4.6e11, b: 0.0, Ea: 30.0 kcal/mol}
+  orders: {C8H18: -0.25, O2: 1.75}
+  negative-orders: true
+```
+
+#### Non-reactant Orders
+
+Some global reactions could have reactions orders for non-reactant species. In this
+case, the `nonreactant-orders` field must be added to the reaction entry:
+
+```yaml
+- equation: C8H18 + 12.5 O2 => 8 CO2 + 9 H2O
+  rate-constant: {A: 4.6e11, b: 0.0, Ea: 30.0 kcal/mol}
+  orders: {C8H18: -0.25, CO: 0.15}
+  negative-orders: true
+  nonreactant-orders: true
+```
+
+(sec-yaml-guide-elements)=
+## Elements
+
+Cantera provides built-in definitions for the chemical elements, including values for
+their atomic weights taken from IUPAC / CIAAW. These elements can be used by specifying
+the corresponding atomic symbols when specifying the composition of species.
+
+In order to give a name to a particular isotope or a virtual element representing a
+surface site, a custom `element` entry can be used. The default location for `element`
+entries is the `elements` section of the input file. Elements defined in this section
+will automatically be considered for addition to phases defined in the same file.
+Elements can be defined in other sections of the input file if those sections are named
+explicitly in the `elements` field of the phase definition.
+
+An element entry has the following fields:
+
+- `symbol`: The symbol to be used for the element, for example when specifying the
+  composition of a species.
+- `atomic-weight`: The atomic weight of the element, in unified atomic mass units
+  (dalton)
+- `atomic-number`: The atomic number of the element. Optional.
+- `entropy298`: The standard molar entropy of the element at 298.15 K. Optional.
+
+An example `elements` section:
+
+```yaml
+elements:
+- symbol: C13
+  atomic-weight: 13.003354826
+  atomic-number: 6
+- symbol: O-18
+  atomic-weight: 17.9991603
+```

--- a/doc/sphinx/userguide/index.md
+++ b/doc/sphinx/userguide/index.md
@@ -27,6 +27,7 @@ using Cantera, such as evaluating the ignition delay time for a fuel under diffe
 conditions, or calculating the voltage of a Lithium-ion battery as it is discharged.
 
 - [](ck2yaml-tutorial)
+- [](creating-mechanisms)
 - [](thermobuild)
 
 ```{toctree}
@@ -35,5 +36,6 @@ conditions, or calculating the voltage of a Lithium-ion battery as it is dischar
 python-tutorial
 faq
 ck2yaml-tutorial
+creating-mechanisms
 thermobuild
 ```

--- a/doc/sphinx/userguide/index.md
+++ b/doc/sphinx/userguide/index.md
@@ -31,6 +31,7 @@ conditions, or calculating the voltage of a Lithium-ion battery as it is dischar
 - [](creating-mechanisms)
 - [](thermobuild)
 - [](input-errors)
+- [](legacy2yaml-tutorial)
 
 ```{toctree}
 :hidden:
@@ -42,4 +43,5 @@ ck2yaml-tutorial
 creating-mechanisms
 thermobuild
 input-errors
+legacy2yaml-tutorial
 ```

--- a/doc/sphinx/userguide/index.md
+++ b/doc/sphinx/userguide/index.md
@@ -13,6 +13,7 @@ Cantera within your preferred interface language, and demonstrate some basic
 troubleshooting.
 
 - [Getting Started with Python](python-tutorial)
+- [](input-tutorial)
 
 ## Frequently asked questions
 
@@ -34,6 +35,7 @@ conditions, or calculating the voltage of a Lithium-ion battery as it is dischar
 :hidden:
 
 python-tutorial
+input-tutorial
 faq
 ck2yaml-tutorial
 creating-mechanisms

--- a/doc/sphinx/userguide/index.md
+++ b/doc/sphinx/userguide/index.md
@@ -30,6 +30,7 @@ conditions, or calculating the voltage of a Lithium-ion battery as it is dischar
 - [](ck2yaml-tutorial)
 - [](creating-mechanisms)
 - [](thermobuild)
+- [](input-errors)
 
 ```{toctree}
 :hidden:
@@ -40,4 +41,5 @@ faq
 ck2yaml-tutorial
 creating-mechanisms
 thermobuild
+input-errors
 ```

--- a/doc/sphinx/userguide/index.md
+++ b/doc/sphinx/userguide/index.md
@@ -26,10 +26,12 @@ The tutorials in this section are designed to help you accomplish a specific tas
 using Cantera, such as evaluating the ignition delay time for a fuel under different
 conditions, or calculating the voltage of a Lithium-ion battery as it is discharged.
 
+{doc}`ck2yaml-tutorial`
 
 ```{toctree}
 :hidden:
 
 python-tutorial
 faq
+ck2yaml-tutorial
 ```

--- a/doc/sphinx/userguide/index.md
+++ b/doc/sphinx/userguide/index.md
@@ -12,11 +12,11 @@ with Cantera's basic functionality and capabilities, give some examples of how t
 Cantera within your preferred interface language, and demonstrate some basic
 troubleshooting.
 
-{doc}`Getting Started with Python <python-tutorial>`
+- [Getting Started with Python](python-tutorial)
 
 ## Frequently asked questions
 
-See the {doc}`FAQ <faq>` for answers to some common issues that arise when using
+See the [FAQ](faq) for answers to some common issues that arise when using
 Cantera. If your question isn't answered here, consider asking us on the
 <a href="https://cantera.org/community.html#the-cantera-users-group">Cantera Users' Group</a>.
 
@@ -26,7 +26,8 @@ The tutorials in this section are designed to help you accomplish a specific tas
 using Cantera, such as evaluating the ignition delay time for a fuel under different
 conditions, or calculating the voltage of a Lithium-ion battery as it is discharged.
 
-{doc}`ck2yaml-tutorial`
+- [](ck2yaml-tutorial)
+- [](thermobuild)
 
 ```{toctree}
 :hidden:
@@ -34,4 +35,5 @@ conditions, or calculating the voltage of a Lithium-ion battery as it is dischar
 python-tutorial
 faq
 ck2yaml-tutorial
+thermobuild
 ```

--- a/doc/sphinx/userguide/input-errors.md
+++ b/doc/sphinx/userguide/input-errors.md
@@ -1,0 +1,108 @@
+# Handling Errors in Input Files
+
+During processing of an input file, errors may be encountered. These could be syntax
+errors, or could be ones that are flagged as errors by Cantera due to some apparent
+inconsistency in the data---an unphysical value, a species that contains an undeclared
+element, a reaction that contains an undeclared species, missing species or element
+definitions, multiple definitions of elements, species, or reactions, and so on. This
+section is intended to help you understand some causes for these errors and their
+solutions.
+
+## Syntax Errors
+
+Syntax errors are caught by the YAML parser, and must be corrected before proceeding
+further. If a syntax error is encountered, Cantera will raise an exception which
+includes the location of the error. Additional information such as a traceback showing
+where in the code the input file was being read may be printed as well.
+
+For example, consider the following input file, which is intended to create a gas with
+the species and reactions of GRI-Mech 3.0, but is missing the colon which is needed
+after the `thermo` key:
+
+```yaml
+phases:
+- name: gas
+  thermo ideal-gas
+  kinetics: gas
+  elements: [H, O]
+  species: [{gri30.yaml/species: all}]
+  reactions: [gri30.yaml/reactions]
+```
+
+When this definition is imported into an application, an error message like the
+following would be printed to the screen, and execution of the program or script would
+terminate:
+
+```pytb
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/some/path/cantera/base.pyx", line 25, in cantera._cantera._SolutionBase.__cinit__
+    self._init_yaml(infile, phaseid, phases, yaml)
+  File "/some/path/cantera/base.pyx", line 49, in cantera._cantera._SolutionBase._init_yaml
+    root = AnyMapFromYamlFile(stringify(infile))
+cantera._cantera.CanteraError:
+***********************************************************************
+InputFileError thrown by AnyMap::fromYamlFile:
+Error on line 4 of ./gas.yaml:
+illegal map value
+|  Line |
+|     1 | phases:
+|     2 | - name: gas
+|     3 |   thermo ideal-gas
+>     4 >   kinetics: gas
+                    ^
+|     5 |   elements: [H, O]
+|     6 |   species: [{gri30.yaml/species: all}]
+|     7 |   reactions: [gri30.yaml/reactions]
+***********************************************************************
+```
+
+The top part of the error message shows the chain of functions that were called before
+the error was encountered. For the most part, these are internal Cantera functions not
+of direct concern here. The relevant part of this error message is the part between the
+lines of asterisks. This message says that the YAML parser ran into a problem on line 4
+of `gas.yaml`. In many cases, including this one, the parser will fail somewhere *after*
+the actual problem with the input file, since it must continue parsing until it finds
+something that cannot possibly be valid YAML syntax. In this case, the problem from the
+parser's perspective is that the key which started on line 3 continues across a new line
+before it finds a colon that can be considered as the separator. Since a key can't be
+broken across lines like this, the parser indicates the error at the point where it
+found the colon. By looking back from the indicated point of the error, we can see that
+the problem is the missing colon in the previous line.
+
+## Cantera Errors
+
+Now let's consider the other class of errors, ones that Cantera itself detects.
+Continuing the example above, suppose that the missing colon is corrected, and the input
+file processed again. Again an error message results, but this time it is from Cantera:
+
+```pytb
+Traceback (most recent call last):
+  File "<stdin>", line 1, in <module>
+  File "/some/path/cantera/base.pyx", line 25, in cantera._cantera._SolutionBase.__cinit__
+    self._init_yaml(infile, phaseid, phases, yaml)
+  File "/some/path/cantera/base.pyx", line 49, in cantera._cantera._SolutionBase._init_yaml
+    root = AnyMapFromYamlFile(stringify(infile))
+cantera._cantera.CanteraError:
+***********************************************************************
+CanteraError thrown by Phase::addSpecies:
+Species 'C' contains an undefined element 'C'.
+***********************************************************************
+```
+
+The problem is that the phase definition specifies that all species are to be imported
+from the `gri30` mechanism, but only the elements H and O are declared. The `gri30`
+mechanism contains species composed of the elements H, O, C, N, and Ar. If the
+definition is modified to declare these additional elements:
+
+```yaml
+phases:
+- name: gas
+  thermo: ideal-gas
+  kinetics: gas
+  elements: [H, O, C, N, Ar]
+  species: [{gri30.yaml/species: all}]
+  reactions: [gri30.yaml/reactions]
+```
+
+it may be imported successfully.

--- a/doc/sphinx/userguide/input-tutorial.md
+++ b/doc/sphinx/userguide/input-tutorial.md
@@ -1,0 +1,250 @@
+# Introduction to YAML Input Files
+
+All calculations in Cantera require an input file to describe the properties of the
+relevant phase(s) of matter. These input files can be provided via one of several
+methods:
+
+- *Use an existing input file*. The input files included with Cantera should suffice for
+  tutorials and introductory work with thermodynamic phases and reaction kinetics. A
+  number of additional input files are available from various sources on the web.
+
+- *Convert a mechanism from Chemkin (CK) format to YAML format*. Many reaction
+  mechanisms are published in Chemkin (CK) format, and can be converted to Cantera's
+  YAML format using the `ck2yaml` conversion tool. see [](ck2yaml-tutorial) for more
+  information.
+
+- *Create your own YAML file from scratch or by editing an existing file*. Advanced
+  users may need to edit an existing input file in order to define additional species,
+  reactions, or entirely new phases. See [](creating-mechanisms) for more information.
+
+```{tip}
+Whenever you edit a Cantera input file, it is *highly advised* that you begin by copying
+the existing file and saving it under a new name, before editing the new file. Editing a
+file under its original name can easily lead to errors, if one forgets that this file
+does not represent the original mechanism.
+```
+
+## Understanding Cantera's Input File Syntax
+
+With any input file, it can be helpful to understand the syntax requirements. Clearly,
+anyone writing directly in the YAML formats must conform to these standards. However,
+even when importing an externally-provided file or converting from CK format,
+understanding the input file syntax can help diagnose and correct any errors (although
+many/most of the CK conversion errors will be related to errors in the CK syntax
+formatting).
+
+Cantera YAML files use a subset of the [YAML 1.2](https://yaml.org/spec/1.2/spec.html)
+specification. Cantera YAML files consist of individual values, which may be strings,
+numbers or booleans, that are then composed as elements of nested mappings and
+sequences.
+
+### Strings
+
+Strings may be generally written without quotes, but may be enclosed in single
+quotes or double quotes if needed in order to avoid certain parsing ambiguities.
+
+```yaml
+A string
+Another 'string'
+"A string: that requires quotes"
+```
+
+### Numbers
+
+Numbers can be written as integers, decimal values, or using E-notation
+
+```yaml
+3
+3.14
+6.022e23
+```
+
+### Booleans
+
+Boolean values in YAML are written as the words `true` or `false`.
+
+### Sequences
+
+A sequence of multiple items is specified by separating the items by commas and
+enclosing them in square brackets. The individual items can have any type -- strings,
+integers, floating-point numbers, mappings, or sequences.
+
+```yaml
+elements: [O, H, C, N, Ar]
+temperature-ranges: [200.0, 1000.0, 3500.0]
+```
+
+The syntax above, using square brackets to define a list, is called **flow style** in
+YAML. Sequences can also be written in **block style**, using one line for each item in
+the sequence, with each line starting with a dash:
+
+```yaml
+elements:
+- O
+- H
+- C
+- N
+- Ar
+```
+
+Sequences can also be nested. The following examples are all equivalent:
+
+```yaml
+data: [[1, 2], [3, 4]]
+
+data:
+-
+  - 1
+  - 2
+-
+  - 3
+  - 4
+
+data:
+- - 1
+  - 2
+- - 3
+  - 4
+```
+
+### Mappings
+
+A mapping is a container consisting of key--value pairs. The keys in a mapping must be
+unique. Like sequences, there are two ways to write a mapping. In the **flow style**,
+the mapping is enclosed in curly brackets, colons (followed by spaces) are used to
+separate keys and values, and key--value pairs are separated by commas:
+
+```yaml
+composition: {H: 2, C: 1, O: 1}
+```
+
+In the **block style**, each key is written on a new line, followed by a colon. The
+value can be placed either on the same line, or on the following line, indented one
+level:
+
+```yaml
+composition:
+  H: 2
+  C:
+    1
+  O: 1
+```
+
+All keys in Cantera YAML files are treated as strings. A Cantera YAML file is itself a
+mapping, usually in the **block style**. We refer to the keys in this top-level mapping
+as the **sections** of the input file.
+
+### Sequences of Mappings
+
+A common structure in Cantera input files is a nested sequence of mappings. This can be
+written in the **block style** as:
+
+```yaml
+- equation: O2 + CO <=> O + CO2
+  rate-constant: {A: 2.5e+12, b: 0, Ea: 47800}
+- equation: O2 + CH2O <=> HO2 + HCO
+  rate-constant: {A: 1.0e+14, b: 0, Ea: 40000}
+- equation: H + O2 + M <=> HO2 + M
+  type: three-body
+  rate-constant: {A: 2.8e+18, b: -0.86, Ea: 0}
+  efficiencies: {AR: 0, C2H6: 1.5, CO: 0.75, CO2: 1.5, H2O: 0, N2: 0, O2: 0}
+```
+
+The keys in each mapping need not be the same. In this example, each of the three
+mappings in the sequence has `equation` and `rate-constant` keys, while only the third
+entry has `type` and `efficiencies` keys.
+
+### Comments
+
+The character `#` is the comment character. Everything to the right of this character on
+a line is ignored:
+
+```yaml
+# set the default units
+units:
+  length: cm  # use centimeters for length
+  quantity: mol  # use moles for quantity
+```
+
+### Dimensional Values
+
+Many fields have numerical values that represent dimensional quantities---a pressure, or
+a density, for example. If these are entered without specifying the units, the default
+units (set by the `units` directive) will be used. However, it is also possible to
+specify the units for each individual dimensional quantity, unless stated otherwise. All
+that is required is to write the units after the value, separated by a space:
+
+```yaml
+pressure: 1.0e5  # default is Pascals
+pressure: 1.0 bar  # this is equivalent
+density: 4.0 g/cm^3
+density: 4000.0  # kg/m^3
+```
+
+Compound unit strings may be used, as long as a few rules are followed:
+
+1. Units in the denominator follow `/`.
+2. Units in the numerator follow `*`, except for the first one.
+3. Numerical exponents follow the unit string with a `^` character.
+
+Examples of compound units:
+
+```yaml
+A: 1.0e20 cm^6/mol^2/s  # OK
+h: 6.626e-34 J*s  # OK
+density: 3.0 g*cm^-3  # OK
+A: 1.0e20 cm6/mol/s  # error (missing '^')
+A: 1.0e20 cm^6/mol^2-s  # error ('s' should be in denominator)
+density: 3.0g/cm^3  # error (missing space between value and units)
+```
+
+See the [Units API](sec-yaml-units) documentation for additional details, including the
+full set of supported units.
+
+### Default units
+
+Default units that apply to a whole input file or some portion thereof can be set using
+`units` mapping. A `units` mapping placed at the top level of an input file applies to
+the entire file. A `units` mapping placed as a member of another mapping applies to that
+mapping and any nested mappings or sequences, and overrides higher-level `units`
+mappings:
+
+```yaml
+units: {length: cm, mass: kg}
+section1:
+  units: {length: m}
+  density: 4000  # interpreted as 4000 kg/m^3
+section2:
+  density: 0.1  # interpreted as 0.1 kg/cm^3
+section3:
+- units: {mass: mg}  # must be the first item in the list
+- name: species1
+  density: 5e4  # interpreted as 5e4 mg/cm^3
+```
+
+Default units may be set for `mass`, `length`, `time`, `quantity`, `pressure`, `energy`,
+and `activation-energy`.
+
+## Input Files Distributed with Cantera
+
+Several reaction mechanism files are included in the Cantera distribution, including
+ones that model natural gas combustion (`gri30.yaml`), high-temperature air
+(`air.yaml`), a hydrogen/oxygen reaction mechanism (`h2o2.yaml`), some pure fluids in
+the liquid-vapor region (`liquidvapor.yaml`), and a few surface reaction mechanisms
+(such as `ptcombust.yaml`, `diamond.yaml`, etc.), among others.
+
+```{caution}
+The input files included with Cantera are provided for convenience, and may not be
+suited for research purposes.
+```
+
+Under Windows, these files may be located in `C:\Program Files\Cantera\data` depending
+on how you installed Cantera and the options you specified. On a Unix/Linux/macOS
+machine, they are usually kept in the `data` subdirectory within the Cantera
+installation directory. You can also browse the [list of data
+files](https://github.com/Cantera/cantera/tree/main/data) in the Cantera source
+repository.
+
+% TODO: add link to the Matlab tutorial
+Please see the tutorials for [Python](python-tutorial) and Matlab for
+instructions on how to import from these pre-existing files.

--- a/doc/sphinx/userguide/legacy2yaml-tutorial.md
+++ b/doc/sphinx/userguide/legacy2yaml-tutorial.md
@@ -1,0 +1,82 @@
+# Converting Legacy CTI and XML Input Files to YAML
+
+If you want to convert an existing, legacy CTI or XML input file to the YAML format,
+this section will help.
+
+## cti2yaml
+
+Cantera comes with a converter utility `cti2yaml` (or `cti2yaml.py`) that converts
+legacy CTI format mechanisms into the new YAML format introduced in Cantera 2.5. This
+program can be run from the command line to convert files to the YAML format.
+
+**Usage:**
+
+```bash
+cti2yaml [-h] input [output]
+```
+
+The `input` argument is required, and specifies the name of the input file to be
+converted. The optional `output` argument specifies the name of the new output file. If
+`output` is not specified, then the output file will have the same name as the input
+file, with the extension replaced with `.yaml`. The full command line interface for
+`cti2yaml` is documented [here](/yaml/cti2yaml).
+
+**Example:**
+
+```bash
+cti2yaml mymech.cti
+```
+
+will generate the output file `mymech.yaml`.
+
+If the `cti2yaml` script is not on your path, but the Cantera Python module is,
+`cti2yaml` can be used by running:
+
+```bash
+python -m cantera.cti2yaml mymech.cti
+```
+
+It is not necessary to use `cti2yaml` to convert any of the CTI input files previously
+included with Cantera. YAML versions of these files are already included with Cantera.
+
+```{tip}
+For input files where you have both the CTI and XML versions, `cti2yaml` is recommended
+over `ctml2yaml`. In cases where the mechanism was originally converted from a CK-format
+mechanism, it is recommended to use `ck2yaml` if the original input files are available.
+```
+
+## ctml2yaml
+
+Cantera comes with a converter utility `ctml2yaml` (or `ctml2yaml.py`) that converts
+legacy XML (CTML) format mechanisms into the new YAML format introduced in Cantera 2.5.
+This program can be run from the command line to convert files to the YAML format.
+
+**Usage:**
+
+```bash
+ctml2yaml [-h] input [output]
+```
+
+The `input` argument is required, and specifies the name of the input file to be
+converted. The optional `output` argument specifies the name of the new output file. If
+`output` is not specified, then the output file will have the same name as the input
+file, with the extension replaced with `.yaml`. The full command line interface for
+`ctml2yaml` is documented [here](/yaml/ctml2yaml).
+
+**Example:**
+
+```bash
+ctml2yaml mymech.xml
+```
+
+will generate the output file `mymech.yaml`.
+
+If the `ctml2yaml` script is not on your path, but the Cantera Python module is,
+`ctml2yaml` can be used by running:
+
+```bash
+python -m cantera.cti2yaml mymech.xml
+```
+
+It is not necessary to use `ctml2yaml` to convert any of the XML input files included
+with Cantera. YAML versions of these files are already included with Cantera.

--- a/doc/sphinx/userguide/thermobuild.md
+++ b/doc/sphinx/userguide/thermobuild.md
@@ -1,0 +1,114 @@
+(sec-thermobuild)=
+# Converting Data from NASA ThermoBuild
+
+% TODO: Link to NASA9 Science docs
+
+Thermodynamic data for a range of species can be obtained from the
+[NASA ThermoBuild](https://cearun.grc.nasa.gov/ThermoBuild/index_ds.html) tool.
+This thermodynamic data is described using the 9-coefficient NASA polynomial parameterization, which is implemented by Cantera.
+
+To generate an input file containing thermodynamic data, use the ThermoBuild web
+interface to select the elements you want to include, and click *process*. Then, select
+the species you want to include in your mechanism and click *continue*. Select the
+content on the resulting page starting with the line that says `thermo`, and ending with
+the line that says `END REACTANTS` and save it to a file.
+
+Next, we need to make a few modifications to this file so it contains all of the
+information needed to be processed by Cantera's CK file parser. For this example, let's
+suppose you have selected just the species `CO` and `CO2` from ThermoBuild.
+
+- Modify the first line of the file so that it reads `thermo nasa9`. This is done to
+  distinguish this input format from the one used for the 7-coefficient NASA
+  polynomials.
+- Replace the last two lines (`END PRODUCTS` and `END REACTANTS`) with a single line
+  that reads `END`.
+
+## Creating species definitions only
+
+If you only want to generate a species database that can be referenced from other
+Cantera input files, the above modifications are sufficient. The last step is simply to
+convert the input file to the Cantera YAML format using `ck2yaml`. If you named the file
+`mythermo.txt`, then the command to convert it would be:
+
+```bash
+ck2yaml --thermo=mythermo.txt
+```
+
+This will generate the file `mythermo.yaml`. You can then reference the species
+definitions from this file in phase definitions in other Cantera input files, for
+example:
+
+```yaml
+phases:
+- name: gas
+  thermo: ideal-gas
+  species:
+  - {mythermo.yaml/species: all}
+```
+
+## Creating a complete phase definition
+
+To create a complete phase definition, you also need to add two sections to the top of
+the ThermoBuild input file. First, a section declaring all of the elements:
+
+```
+elements
+C O
+end
+```
+
+And second, a section declaring all of the species:
+
+```
+species
+CO CO2
+end
+```
+
+The resulting input file should look like the following:
+
+```
+elements
+C O
+end
+
+species
+CO CO2
+end
+
+thermo nasa9
+   200.000  1000.000  6000.000 20000.000   9/09/04
+CO                Gurvich,1979 pt1 p25 pt2 p29.
+ 3 tpis79 C   1.00O   1.00    0.00    0.00    0.00 0   28.0101000    -110535.196
+    200.000   1000.0007 -2.0 -1.0  0.0  1.0  2.0  3.0  4.0  0.0         8671.104
+ 1.489045326D+04-2.922285939D+02 5.724527170D+00-8.176235030D-03 1.456903469D-05
+-1.087746302D-08 3.027941827D-12                -1.303131878D+04-7.859241350D+00
+   1000.000   6000.0007 -2.0 -1.0  0.0  1.0  2.0  3.0  4.0  0.0         8671.104
+ 4.619197250D+05-1.944704863D+03 5.916714180D+00-5.664282830D-04 1.398814540D-07
+-1.787680361D-11 9.620935570D-16                -2.466261084D+03-1.387413108D+01
+   6000.000  20000.0007 -2.0 -1.0  0.0  1.0  2.0  3.0  4.0  0.0         8671.104
+ 8.868662960D+08-7.500377840D+05 2.495474979D+02-3.956351100D-02 3.297772080D-06
+-1.318409933D-10 1.998937948D-15                 5.701421130D+06-2.060704786D+03
+CO2               Gurvich,1991 pt1 p27 pt2 p24.
+ 3 g 9/99 C   1.00O   2.00    0.00    0.00    0.00 0   44.0095000    -393510.000
+    200.000   1000.0007 -2.0 -1.0  0.0  1.0  2.0  3.0  4.0  0.0         9365.469
+ 4.943650540D+04-6.264116010D+02 5.301725240D+00 2.503813816D-03-2.127308728D-07
+-7.689988780D-10 2.849677801D-13                -4.528198460D+04-7.048279440D+00
+   1000.000   6000.0007 -2.0 -1.0  0.0  1.0  2.0  3.0  4.0  0.0         9365.469
+ 1.176962419D+05-1.788791477D+03 8.291523190D+00-9.223156780D-05 4.863676880D-09
+-1.891053312D-12 6.330036590D-16                -3.908350590D+04-2.652669281D+01
+   6000.000  20000.0007 -2.0 -1.0  0.0  1.0  2.0  3.0  4.0  0.0         9365.469
+-1.544423287D+09 1.016847056D+06-2.561405230D+02 3.369401080D-02-2.181184337D-06
+ 6.991420840D-11-8.842351500D-16                -8.043214510D+06 2.254177493D+03
+END
+```
+
+This file (saved for example as `myphase.txt`) can then be converted to the Cantera YAML
+format using the [`ck2yaml`](/yaml/ck2yaml) utility from a shell:
+
+```bash
+ck2yaml --input=myphase.txt
+```
+
+This will generate a an input file named `myphase.yaml` with a phase named `gas` that
+can be directly imported in Cantera.

--- a/doc/sphinx/yaml/cti2yaml.rst
+++ b/doc/sphinx/yaml/cti2yaml.rst
@@ -5,8 +5,7 @@ CTI to YAML conversion
 ***********************
 
 .. seealso::
-    For a tutorial, refer to the `Converting CTI and XML input files to YAML
-    <https://cantera.org/tutorials/legacy2yaml.html>`_ pages.
+    For a tutorial, refer to the page :doc:`/userguide/legacy2yaml-tutorial`.
 
 .. argparse::
    :module: cantera.cti2yaml

--- a/doc/sphinx/yaml/ctml2yaml.rst
+++ b/doc/sphinx/yaml/ctml2yaml.rst
@@ -5,8 +5,7 @@ CTML to YAML conversion
 ***********************
 
 .. seealso::
-    For a tutorial, refer to the `Converting CTI and XML input files to YAML
-    <https://cantera.org/tutorials/legacy2yaml.html>`_ pages.
+    For a tutorial, refer to the page :doc:`/userguide/legacy2yaml-tutorial`.
 
 .. argparse::
    :module: cantera.ctml2yaml

--- a/doc/sphinx/yaml/phases.rst
+++ b/doc/sphinx/yaml/phases.rst
@@ -95,6 +95,8 @@ and optionally reactions that can take place in that phase. The fields of a
     - ``Redlich-Kister`` (:ref:`details <sec-yaml-Redlich-Kister>`)
     - ``Redlich-Kwong`` (:ref:`details <sec-yaml-Redlich-Kwong>`)
 
+.. _sec-yaml-phase-kinetics:
+
 ``kinetics``
     String specifying the kinetics model to be used. Supported model strings
     are:
@@ -133,20 +135,30 @@ and optionally reactions that can take place in that phase. The fields of a
     ``false``. The value set at the phase level may be overridden on individual
     reactions.
 
+.. _sec-yaml-phase-transport:
+
 ``transport``
     String specifying the transport model to be used. Supported model strings
     are:
 
     - ``none``
-    - ``high-pressure`` (:ct:`details <HighPressureGasTransport>`)
-    - ``ionized-gas`` (:ct:`details <IonGasTransport>`)
-    - ``mixture-averaged`` (:ct:`details <MixTransport>`)
-    - ``mixture-averaged-CK`` (:ct:`details <MixTransport>`)
-    - ``multicomponent`` (:ct:`details <MultiTransport>`)
-    - ``multicomponent-CK`` (:ct:`details <MultiTransport>`)
-    - ``unity-Lewis-number`` (:ct:`details <UnityLewisTransport>`)
-    - ``water`` (:ct:`details <WaterTransport>`)
-
+    - ``high-pressure``: A model for high-pressure gas transport properties based on a
+      method of corresponding states (:ct:`details <HighPressureGasTransport>`)
+    - ``ionized-gas``: A model implementing the Stockmayer-(n,6,4) model for transport
+      of ions in a gas (:ct:`details <IonGasTransport>`)
+    - ``mixture-averaged``: The mixture-averaged transport model for ideal gases
+      (:ct:`details <MixTransport>`)
+    - ``mixture-averaged-CK``: The mixture-averaged transport model for ideal gases,
+      using polynomial fits corresponding to Chemkin-II (:ct:`details <MixTransport>`)
+    - ``multicomponent``: The multicomponent transport model for ideal gases
+      (:ct:`details <MultiTransport>`)
+    - ``multicomponent-CK``: The multicomponent transport model for ideal gases, using
+      polynomial fits corresponding to Chemkin-II (:ct:`details <MultiTransport>`)
+    - ``unity-Lewis-number``: A transport model for ideal gases, where diffusion
+      coefficients for all species are set so that the Lewis number is 1
+      (:ct:`details <UnityLewisTransport>`)
+    - ``water``: A transport model for pure water applicable in both liquid and vapor
+      phases (:ct:`details <WaterTransport>`)
 
 .. _sec-yaml-setting-state:
 
@@ -205,8 +217,9 @@ Phase thermodynamic models
 ``binary-solution-tabulated``
 -----------------------------
 
-A phase implementing tabulated standard state thermodynamics for one species in
-a binary solution, as :ct:`described here <BinarySolutionTabulatedThermo>`.
+A phase representing a binary solution where the excess enthalpy and entropy are
+interpolated between tabulated values as a function of mole fraction, as
+:ct:`described here <BinarySolutionTabulatedThermo>`.
 
 Includes the fields of :ref:`sec-yaml-ideal-condensed`, plus:
 
@@ -295,10 +308,9 @@ Example::
 ``Debye-Huckel``
 ----------------
 
-The Debye-Hückel model as :ct:`described here <DebyeHuckel>`.
-
-Additional parameters for this model are contained in the ``activity-data``
-field:
+A dilute liquid electrolyte which obeys the Debye-Hückel formulation for nonideality as
+:ct:`described here <DebyeHuckel>`. Additional parameters for this model are contained
+in the ``activity-data`` field:
 
 ``activity-data``
     The activity data field contains the following fields:
@@ -423,7 +435,7 @@ Additional fields:
 ``fixed-stoichiometry``
 -----------------------
 
-A phase with fixed composition, as :ct:`described here <StoichSubstance>`.
+An incompressible phase with fixed composition, as :ct:`described here <StoichSubstance>`.
 
 
 .. _sec-yaml-HMW-electrolyte:
@@ -555,7 +567,7 @@ Example::
 ``ideal-gas``
 -------------
 
-The ideal gas model as :ct:`described here <IdealGasPhase>`.
+A mixture which obeys the ideal gas law, as :ct:`described here <IdealGasPhase>`.
 
 Example::
 
@@ -573,7 +585,7 @@ Example::
 ``ideal-molal-solution``
 ------------------------
 
-A phase based on the mixing-rule assumption that all molality-based activity
+An ideal solution based on the mixing-rule assumption that all molality-based activity
 coefficients are equal to one, as :ct:`described here <IdealMolalSoln>`.
 
 Additional fields:
@@ -627,7 +639,7 @@ Example::
 ``ideal-condensed``
 -------------------
 
-A condensed phase ideal solution as :ct:`described here <IdealSolidSolnPhase>`.
+An ideal liquid or solid solution as :ct:`described here <IdealSolidSolnPhase>`.
 
 Additional fields:
 
@@ -656,7 +668,7 @@ Additional fields:
 ``ideal-surface``
 -----------------
 
-An ideal surface phase, as :ct:`described here <SurfPhase>`.
+An ideal surface between two bulk phases, as :ct:`described here <SurfPhase>`.
 
 Additional fields:
 
@@ -684,8 +696,8 @@ Example::
 ``lattice``
 -----------
 
-A simple thermodynamic model for a bulk phase, assuming a lattice of solid
-atoms, as :ct:`described here <LatticePhase>`.
+A simple thermodynamic model for a bulk phase, assuming an incompressible lattice of
+solid atoms, as :ct:`described here <LatticePhase>`.
 
 Additional fields:
 
@@ -698,7 +710,8 @@ Additional fields:
 ``liquid-water-IAPWS95``
 ------------------------
 
-An equation of state for liquid water, as :ct:`described here <WaterSSTP>`.
+An implementation of the IAPWS95 equation of state for water :cite:p:`wagner2002`, for
+the liquid region only as :ct:`described here <WaterSSTP>`.
 
 
 .. _sec-yaml-Margules:
@@ -751,7 +764,8 @@ Example::
 ``Peng-Robinson``
 -----------------
 
-A multi-species Peng-Robinson phase as :ct:`described here <PengRobinson>`.
+A multi-species real gas following the Peng-Robinson equation of state, as
+:ct:`described here <PengRobinson>`.
 
 The parameters for each species are contained in the corresponding species
 entries. See :ref:`Peng-Robinson species equation of state <sec-yaml-eos-peng-robinson>`.
@@ -834,8 +848,9 @@ Example::
 ``pure-fluid``
 --------------
 
-A phase representing a pure fluid equation of state for one of several species,
-as :ct:`described here <PureFluidPhase>`.
+A phase representing a pure fluid equation of state for one of several pure substances
+including liquid, vapor, two-phase, and supercritical regions, as
+:ct:`described here <PureFluidPhase>`.
 
 Additional fields:
 

--- a/doc/sphinx/yaml/species.rst
+++ b/doc/sphinx/yaml/species.rst
@@ -336,7 +336,8 @@ Example::
 HKFT
 ----
 
-The Helgeson-Kirkham-Flowers-Tanger model as :ct:`described here <PDSS_HKFT>`.
+The Helgeson-Kirkham-Flowers-Tanger model for aqueous species as
+:ct:`described here <PDSS_HKFT>`.
 
 Additional fields:
 
@@ -394,7 +395,7 @@ Additional fields:
 Peng-Robinson
 -------------
 
-A model where species follow the Peng-Robinson equation of state as
+A model where species follow the Peng-Robinson real gas equation of state as
 :ct:`described here <PengRobinson>`.
 
 Additional fields:
@@ -430,7 +431,7 @@ Example::
 Redlich-Kwong
 -------------
 
-A model where species follow the Redlich-Kwong equation of state as
+A model where species follow the Redlich-Kwong real gas equation of state as
 :ct:`described here <RedlichKwongMFTP>`.
 
 Additional fields:

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -132,7 +132,7 @@ class InputError(Exception):
     the exceptional behavior.
     """
     def __init__(self, message, *args, **kwargs):
-        message += ("\nPlease check https://cantera.org/tutorials/"
+        message += ("\nPlease check https://cantera.org/stable/userguide/"
                    "ck2yaml-tutorial.html#debugging-common-errors-in-ck-files"
                    "\nfor the correct Chemkin syntax.")
         if args or kwargs:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Migrate YAML-related documentation into the versioned Sphinx documentation
- Re-organize this content a bit, within the "User Guide" section of the website
  - A short introduction, syntax overview, and discussion of included input files is given in the "Introduction to YAML Input Files"
  - Under the "task guides", we have:
    - "Converting Chemkin Format Files"
    - "Creating YAML Mechanism Files from Scratch" (which has been condensed to a single page),
    - "Converting Data from NASA ThermoBuild"
    - "Handling Errors in Input Files"
    - "Converting Legacy CTI and XML Input Files to YAML"

**If applicable, fill in the issue number this pull request is fixing**

Continues work on Cantera/enhancements#178.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
