### PR TITLE
[1D] Bugfix : Segfault if no transport specified in the YAML file

### DIFF
--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -104,6 +104,12 @@ StFlow::StFlow(shared_ptr<Solution> sol, const string& id, size_t points)
     m_id = id;
     m_kin = m_solution->kinetics().get();
     m_trans = m_solution->transport().get();
+    
+    m_solution->registerChangedCallback(this, [this]() {
+        setKinetics(m_solution->kinetics());
+        setTransport(m_solution->transport());
+    });
+    
     if (m_trans->transportModel() == "none") {
         // @deprecated
         warn_deprecated("StFlow",
@@ -112,10 +118,7 @@ StFlow::StFlow(shared_ptr<Solution> sol, const string& id, size_t points)
             "is deprecated and\nwill be removed after Cantera 3.0.");
         setTransportModel("mixture-averaged");
     }
-    m_solution->registerChangedCallback(this, [this]() {
-        setKinetics(m_solution->kinetics());
-        setTransport(m_solution->transport());
-    });
+
 }
 
 StFlow::~StFlow()


### PR DESCRIPTION
call "registerChangedCallback" before transport setting if transportModel() is "none"

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Segfault encountered if no "transport:" field specified in the YAML file
- Calling registerChangedCallback **before** defining "mixture-averaged" as default transport model in StFlow constructor solves the problem

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
