### PR TITLE
Edited docstring for transport_model method for clarity

### DIFF
--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -185,7 +185,7 @@ cdef class Transport(_SolutionBase):
 
     property transport_model:
         """
-        Get/Set the string specifying the transport model, such as `multicomponent`, 
+        Get/Set the string specifying the transport model, such as `multicomponent`,
         `mixture-averaged`, or `unity-Lewis-number`.
 
         Setting a new transport model deletes the underlying C++ Transport

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -185,7 +185,8 @@ cdef class Transport(_SolutionBase):
 
     property transport_model:
         """
-        Get/Set the transport model associated with this transport model.
+        Get/Set the string specifying the transport model, such as `multicomponent`, 
+        `mixture-averaged`, or `unity-Lewis-number`.
 
         Setting a new transport model deletes the underlying C++ Transport
         object and replaces it with a new one implementing the specified model.


### PR DESCRIPTION
The docstring for the python module `transport_model` method in `transport.pyx` has been edited for clarity, adding example strings for the common transport models.

This addresses the suggestion in issue #1658 