### PR TITLE
Minor adjustment to debugging output in Sim1d.cpp for log levels >7

### DIFF
--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -447,7 +447,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                 }
 
                 if (loglevel > 6) {
-                    save("debug_sim1d.yaml", "debug",
+                    save("debug_sim1d.yaml", "solution",
                          "After successful Newton solve", true);
                 }
                 if (loglevel > 7) {
@@ -458,7 +458,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
             } else {
                 debuglog("    failure. \n", loglevel);
                 if (loglevel > 6) {
-                    save("debug_sim1d.yaml", "debug",
+                    save("debug_sim1d.yaml", "solution",
                          "After unsuccessful Newton solve", true);
                 }
                 if (loglevel > 7) {
@@ -471,7 +471,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                 dt = timeStep(nsteps, dt, m_state->data(), m_xnew.data(), loglevel-1);
                 m_xlast_ts = *m_state;
                 if (loglevel > 6) {
-                    save("debug_sim1d.yaml", "debug", "After timestepping", true);
+                    save("debug_sim1d.yaml", "solution", "After timestepping", true);
                 }
                 if (loglevel > 7) {
                     saveResidual("debug_sim1d.yaml", "residual",
@@ -506,7 +506,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                 dt = m_tstep;
             }
             if (new_points && loglevel > 6) {
-                save("debug_sim1d.yaml", "debug", "After regridding", true);
+                save("debug_sim1d.yaml", "solution", "After regridding", true);
             }
             if (new_points && loglevel > 7) {
                 saveResidual("debug_sim1d.yaml", "residual",

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -448,22 +448,22 @@ void Sim1D::solve(int loglevel, bool refine_grid)
 
                 if (loglevel > 6) {
                     save("debug_sim1d.yaml", "debug",
-                         "After successful Newton solve");
+                         "After successful Newton solve", true);
                 }
                 if (loglevel > 7) {
                     saveResidual("debug_sim1d.yaml", "residual",
-                                 "After successful Newton solve");
+                                 "After successful Newton solve", true);
                 }
                 ok = true;
             } else {
                 debuglog("    failure. \n", loglevel);
                 if (loglevel > 6) {
                     save("debug_sim1d.yaml", "debug",
-                         "After unsuccessful Newton solve");
+                         "After unsuccessful Newton solve", true);
                 }
                 if (loglevel > 7) {
                     saveResidual("debug_sim1d.yaml", "residual",
-                                 "After unsuccessful Newton solve");
+                                 "After unsuccessful Newton solve", true);
                 }
                 if (loglevel > 0) {
                     writelog("Take {} timesteps   ", nsteps);
@@ -471,11 +471,11 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                 dt = timeStep(nsteps, dt, m_state->data(), m_xnew.data(), loglevel-1);
                 m_xlast_ts = *m_state;
                 if (loglevel > 6) {
-                    save("debug_sim1d.yaml", "debug", "After timestepping");
+                    save("debug_sim1d.yaml", "debug", "After timestepping", true);
                 }
                 if (loglevel > 7) {
                     saveResidual("debug_sim1d.yaml", "residual",
-                                 "After timestepping");
+                                 "After timestepping", true);
                 }
 
                 if (loglevel == 1) {
@@ -506,11 +506,11 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                 dt = m_tstep;
             }
             if (new_points && loglevel > 6) {
-                save("debug_sim1d.yaml", "debug", "After regridding");
+                save("debug_sim1d.yaml", "debug", "After regridding", true);
             }
             if (new_points && loglevel > 7) {
                 saveResidual("debug_sim1d.yaml", "residual",
-                             "After regridding");
+                             "After regridding", true);
             }
         } else {
             debuglog("grid refinement disabled.\n", loglevel);


### PR DESCRIPTION
**Changes proposed in this pull request**

I added the "true" overwrite flag to the debugging save() and saveResidual() calls in the Sim1d.cpp file to prevent code-stopping errors. I cam across this when trying to debug my work in #1622 . @ischoegl  suggested putting the changes in a separate pull request.


To reproduce the error, run a 1D flow case that experiences failures in the steady newton solve, after taking a few successful newton solves. The error consists of the data group at the highest level already existing in the debug file, causing the code to error out.


**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
