### PR TITLE
Prevent segfaults for partial 0-D objects

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -412,7 +412,7 @@ jobs:
         run: python3 -m pip install -U pip setuptools wheel
       - name: Install Python dependencies
         run: |
-            python3 -m pip install numpy ruamel.yaml pandas matplotlib scipy pint graphviz
+            python3 -m pip install numpy ruamel.yaml pandas pyarrow matplotlib scipy pint graphviz
             python3 -m pip install --pre --no-index --find-links dist cantera
       - name: Run the examples
         # See https://unix.stackexchange.com/a/392973 for an explanation of the -exec part

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -202,11 +202,19 @@ public:
 
     //! Returns the current density (kg/m^3) of the reactor's contents.
     double density() const {
+        if (m_state.empty()) {
+            throw CanteraError("ReactorBase::density",
+                               "Reactor state empty and/or contents not defined.");
+        }
         return m_state[1];
     }
 
     //! Returns the current temperature (K) of the reactor's contents.
     double temperature() const {
+        if (m_state.empty()) {
+            throw CanteraError("ReactorBase::temperature",
+                               "Reactor state empty and/or contents not defined.");
+        }
         return m_state[0];
     }
 
@@ -232,11 +240,19 @@ public:
 
     //! Return the vector of species mass fractions.
     const double* massFractions() const {
+        if (m_state.empty()) {
+            throw CanteraError("ReactorBase::massFractions",
+                               "Reactor state empty and/or contents not defined.");
+        }
         return m_state.data() + 2;
     }
 
     //! Return the mass fraction of the *k*-th species.
     double massFraction(size_t k) const {
+        if (m_state.empty()) {
+            throw CanteraError("ReactorBase::massFraction",
+                               "Reactor state empty and/or contents not defined.");
+        }
         return m_state[k+2];
     }
 

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -37,6 +37,10 @@ double Wall::velocity() const {
 double Wall::vdot(double t)
 {
     warn_deprecated("Wall::vdot", "To be removed; replaceable by 'expansionRate'.");
+    if (!ready()) {
+        throw CanteraError("Wall::vdot",
+                           "Wall is not ready; some parameters have not been set.");
+    }
     double rate = m_k * m_area * (m_left->pressure() - m_right->pressure());
 
     if (m_vf) {
@@ -47,6 +51,10 @@ double Wall::vdot(double t)
 
 double Wall::expansionRate()
 {
+    if (!ready()) {
+        throw CanteraError("Wall::expansionRate",
+                           "Wall is not ready; some parameters have not been set.");
+    }
     double rate = m_k * m_area * (m_left->pressure() - m_right->pressure());
 
     if (m_vf) {
@@ -65,6 +73,10 @@ double Wall::heatFlux() const {
 double Wall::Q(double t)
 {
     warn_deprecated("Wall::Q", "To be removed; replaceable by 'heatRate'.");
+    if (!ready()) {
+        throw CanteraError("Wall::Q",
+                           "Wall is not ready; some parameters have not been set.");
+    }
     double q1 = (m_area * m_rrth) *
                 (m_left->temperature() - m_right->temperature());
     if (m_emiss > 0.0) {
@@ -81,6 +93,10 @@ double Wall::Q(double t)
 
 double Wall::heatRate()
 {
+    if (!ready()) {
+        throw CanteraError("Wall::heatRate",
+                           "Wall is not ready; some parameters have not been set.");
+    }
     double q1 = (m_area * m_rrth) *
                 (m_left->temperature() - m_right->temperature());
     if (m_emiss > 0.0) {

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -34,6 +34,32 @@ TEST(zerodim, simple)
     }
 }
 
+// Test guards preventing segfaults for uninitialized zerodim objects
+TEST(zerodim, test_guards)
+{
+    // Reactor with no contents
+    Reactor reactor;
+    EXPECT_THROW(reactor.temperature(), CanteraError);
+    EXPECT_THROW(reactor.density(), CanteraError);
+    EXPECT_THROW(reactor.massFractions(), CanteraError);
+    EXPECT_THROW(reactor.massFraction(0), CanteraError);
+
+    // Wall with no adjacent reactors
+    Wall wall;
+    EXPECT_THROW(wall.heatRate(), CanteraError);
+    EXPECT_THROW(wall.expansionRate(), CanteraError);
+    suppress_deprecation_warnings();
+    EXPECT_THROW(wall.Q(0.), CanteraError);
+    EXPECT_THROW(wall.vdot(0.), CanteraError);
+    make_deprecation_warnings_fatal();
+
+    // FlowDevice with no adjacent reactors
+    EXPECT_THROW(FlowDevice().massFlowRate(), CanteraError);
+    EXPECT_THROW(MassFlowController().updateMassFlowRate(0.), CanteraError);
+    EXPECT_THROW(PressureController().updateMassFlowRate(0.), CanteraError);
+    EXPECT_THROW(Valve().updateMassFlowRate(0.), CanteraError);
+}
+
 // This test ensures that prior reactor initialization of a reactor does
 // not affect later integration within a network. This example was
 // adapted from test_reactor.py::test_equilibrium_HP.


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Prevent segfaults in reactors with no contents
- Prevent segfaults for unconnected walls
- Add google tests

Currently existing guards are largely specific to the implementation of the Python API (example: retrieving temperature for an empty reactor fails when attempting to load the current reactor state into a thermo object). As underlying C++ code is difficult to reach from Python (but may be exposed elsewhere), unit tests are added for C++ directly.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1623

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

Example taken from #1623:
```
In [1]: import cantera as ct
   ...:
   ...: r1 = ct.Reactor()
   ...: r2 = ct.Reactor()
   ...:
   ...: w = ct.Wall(r1,r2)

In [2]: w.heat_rate
---------------------------------------------------------------------------
CanteraError                              Traceback (most recent call last)
Cell In[2], line 1
----> 1 w.heat_rate

File /Volumes/Data/work/GitHub/cantera/build/python/cantera/reactor.pyx:1066, in cantera.reactor.WallBase.heat_rate.__get__()
   1064 .. versionadded:: 3.0
   1065 """
-> 1066 return self.wall.heatRate()
   1067
   1068

CanteraError:
*******************************************************************************
CanteraError thrown by ReactorBase::temperature:
Reactor state empty and/or contents not defined.
*******************************************************************************
```

**Other thoughts**

An alternative to the added guards is to prevent the creation of empty (or unconnected) 0-D objects altogether (which should likely be done when moving from raw pointers to shared pointers for various held objects - `m_thermo`, etc.). As this is more involved and will require a deprecation cycle, the guards proposed in this PR are still appropriate.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
