### PR TITLE
Use Solution for zeroD objects

### DIFF
--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -14,12 +14,12 @@
 extern "C" {
 #endif
 
-    CANTERA_CAPI int reactor_new(const char* type);
+    CANTERA_CAPI int reactor_new(const char* type);  //! @deprecated: remove after 3.1
+    CANTERA_CAPI int reactor_new3(const char* type, int n, const char* name);
     CANTERA_CAPI int reactor_del(int i);
     CANTERA_CAPI int reactor_setInitialVolume(int i, double v);
     CANTERA_CAPI int reactor_setChemistry(int i, int cflag);
     CANTERA_CAPI int reactor_setEnergy(int i, int eflag);
-    CANTERA_CAPI int reactor_setSolution(int i, int n);
     CANTERA_CAPI int reactor_setThermoMgr(int i, int n);
     CANTERA_CAPI int reactor_setKineticsMgr(int i, int n);
     CANTERA_CAPI int reactor_insert(int i, int n);

--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -19,6 +19,7 @@ extern "C" {
     CANTERA_CAPI int reactor_setInitialVolume(int i, double v);
     CANTERA_CAPI int reactor_setChemistry(int i, int cflag);
     CANTERA_CAPI int reactor_setEnergy(int i, int eflag);
+    CANTERA_CAPI int reactor_setSolution(int i, int n);
     CANTERA_CAPI int reactor_setThermoMgr(int i, int n);
     CANTERA_CAPI int reactor_setKineticsMgr(int i, int n);
     CANTERA_CAPI int reactor_insert(int i, int n);

--- a/include/cantera/zeroD/ConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/ConstPressureMoleReactor.h
@@ -20,7 +20,7 @@ namespace Cantera
 class ConstPressureMoleReactor : public MoleReactor
 {
 public:
-    ConstPressureMoleReactor() {}
+    using MoleReactor::MoleReactor; // inherit constructors
 
     string type() const override {
         return "ConstPressureMoleReactor";

--- a/include/cantera/zeroD/ConstPressureReactor.h
+++ b/include/cantera/zeroD/ConstPressureReactor.h
@@ -23,7 +23,7 @@ namespace Cantera
 class ConstPressureReactor : public Reactor
 {
 public:
-    ConstPressureReactor() {}
+    using Reactor::Reactor; // inherit constructors
 
     string type() const override {
         return "ConstPressureReactor";

--- a/include/cantera/zeroD/FlowReactor.h
+++ b/include/cantera/zeroD/FlowReactor.h
@@ -16,7 +16,7 @@ namespace Cantera
 class FlowReactor : public IdealGasReactor
 {
 public:
-    FlowReactor() = default;
+    using IdealGasReactor::IdealGasReactor; // inherit constructors
 
     string type() const override {
         return "FlowReactor";

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -20,7 +20,7 @@ namespace Cantera
 class IdealGasConstPressureMoleReactor : public ConstPressureMoleReactor
 {
 public:
-    IdealGasConstPressureMoleReactor() {}
+    using ConstPressureMoleReactor::ConstPressureMoleReactor; // inherit constructors
 
     string type() const override {
         return "IdealGasConstPressureMoleReactor";

--- a/include/cantera/zeroD/IdealGasConstPressureReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureReactor.h
@@ -22,7 +22,7 @@ namespace Cantera
 class IdealGasConstPressureReactor : public ConstPressureReactor
 {
 public:
-    IdealGasConstPressureReactor() {}
+    using ConstPressureReactor::ConstPressureReactor; // inherit constructors
 
     string type() const override {
         return "IdealGasConstPressureReactor";

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -20,7 +20,7 @@ namespace Cantera
 class IdealGasMoleReactor : public MoleReactor
 {
 public:
-    IdealGasMoleReactor() {}
+    using MoleReactor::MoleReactor; // inherit constructors
 
     string type() const override {
         return "IdealGasMoleReactor";

--- a/include/cantera/zeroD/IdealGasReactor.h
+++ b/include/cantera/zeroD/IdealGasReactor.h
@@ -20,7 +20,7 @@ namespace Cantera
 class IdealGasReactor : public Reactor
 {
 public:
-    IdealGasReactor() {}
+    using Reactor::Reactor; // inherit constructors
 
     string type() const override {
         return "IdealGasReactor";

--- a/include/cantera/zeroD/MoleReactor.h
+++ b/include/cantera/zeroD/MoleReactor.h
@@ -20,7 +20,7 @@ namespace Cantera
 class MoleReactor : public Reactor
 {
 public:
-    MoleReactor() {}
+    using Reactor::Reactor; // inherit constructors
 
     string type() const override {
         return "MoleReactor";

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -46,6 +46,7 @@ class AnyMap;
 class Reactor : public ReactorBase
 {
 public:
+    Reactor(shared_ptr<Solution> sol, const string& name = "(none)");
     using ReactorBase::ReactorBase; // inherit constructors
 
     string type() const override {

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -46,7 +46,7 @@ class AnyMap;
 class Reactor : public ReactorBase
 {
 public:
-    Reactor() = default;
+    using ReactorBase::ReactorBase; // inherit constructors
 
     string type() const override {
         return "Reactor";

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -68,14 +68,16 @@ public:
     /**
      * Insert something into the reactor. The 'something' must belong to a class
      * that is a subclass of both ThermoPhase and Kinetics.
+     * @deprecated Unused; to be removed after %Cantera 3.1.
      */
     template<class G>
     void insert(G& contents) {
+        warn_deprecated("Reactor::insert", "Unused; to be removed after Cantera 3.1.");
         setThermoMgr(contents);
         setKineticsMgr(contents);
     }
 
-    void insert(shared_ptr<Solution> sol);
+    using ReactorBase::insert;
 
     void setKineticsMgr(Kinetics& kin) override;
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -26,6 +26,7 @@ class ReactorNet;
 class ReactorSurface;
 class Kinetics;
 class ThermoPhase;
+class Solution;
 
 enum class SensParameterType {
     reaction,
@@ -50,6 +51,11 @@ class ReactorBase
 {
 public:
     explicit ReactorBase(const string& name = "(none)");
+    //! Instantiate a ReactorBase object with Solution contents.
+    //! @param sol  Solution object to be set.
+    //! @param name  Name of the reactor.
+    //! @since New in %Cantera 3.1.
+    ReactorBase(shared_ptr<Solution> sol, const string& name = "(none)");
     virtual ~ReactorBase() = default;
     ReactorBase(const ReactorBase&) = delete;
     ReactorBase& operator=(const ReactorBase&) = delete;
@@ -70,6 +76,11 @@ public:
         m_name = name;
     }
 
+    //! Set the Solution specifying the ReactorBase content.
+    //! @param sol  Solution object to be set.
+    //! @since New in %Cantera 3.1.
+    void setSolution(shared_ptr<Solution> sol);
+
     //! @name Methods to set up a simulation
     //! @{
 
@@ -81,9 +92,11 @@ public:
     //! Specify the mixture contained in the reactor. Note that a pointer to
     //! this substance is stored, and as the integration proceeds, the state of
     //! the substance is modified.
+    //! @todo: make protected (should only be used internally)
     virtual void setThermoMgr(ThermoPhase& thermo);
 
     //! Specify chemical kinetics governing the reactor.
+    //! @todo: make protected (should only be used internally)
     virtual void setKineticsMgr(Kinetics& kin) {
         throw NotImplementedError("ReactorBase::setKineticsMgr");
     }
@@ -286,6 +299,9 @@ protected:
 
     //! The ReactorNet that this reactor is part of
     ReactorNet* m_net = nullptr;
+
+    //! Composite thermo/kinetics/transport handler
+    shared_ptr<Solution> m_solution;
 };
 }
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -89,6 +89,9 @@ public:
         m_vol = vol;
     }
 
+    //! @deprecated To be removed after %Cantera 3.1. Superseded by setSolution.
+    void insert(shared_ptr<Solution> sol);
+
     //! Specify the mixture contained in the reactor. Note that a pointer to
     //! this substance is stored, and as the integration proceeds, the state of
     //! the substance is modified.

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -95,11 +95,14 @@ public:
     //! Specify the mixture contained in the reactor. Note that a pointer to
     //! this substance is stored, and as the integration proceeds, the state of
     //! the substance is modified.
-    //! @todo: make protected (should only be used internally)
+    //! @since After %Cantera 3.1, this method will be become a 'protected' method for
+    //! internal use only.
+    //! @todo make protected
     virtual void setThermoMgr(ThermoPhase& thermo);
 
-    //! Specify chemical kinetics governing the reactor.
-    //! @todo: make protected (should only be used internally)
+    //! @since After %Cantera 3.1, this method will be become a 'protected' method for
+    //! internal use only.
+    //! @todo make protected
     virtual void setKineticsMgr(Kinetics& kin) {
         throw NotImplementedError("ReactorBase::setKineticsMgr");
     }

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -44,8 +44,14 @@ private:
 //! @{
 
 //! Create a Reactor object of the specified type
-//! @since Starting in Cantera 3.1, this method returns a `shared_ptr<ReactorBase>`
+//! @since Starting in %Cantera 3.1, this method returns a `shared_ptr<ReactorBase>`
+//! @deprecated Transitional method. Use newReactor() with contents instead.
 shared_ptr<ReactorBase> newReactor(const string& model);
+
+//! Create a Reactor object of the specified type and contents
+//! @since New in %Cantera 3.1.
+shared_ptr<ReactorBase> newReactor(
+    const string& model, shared_ptr<Solution> contents, const string& name="(none)");
 
 //! Create a Reactor object of the specified type
 //! @since New in %Cantera 3.0.

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -18,11 +18,6 @@ namespace Cantera
 class Reservoir : public ReactorBase
 {
 public:
-    Reservoir(shared_ptr<Solution> sol, const string& name = "(none)") {
-        m_solution = sol;
-        m_name = name;
-        setThermoMgr(*sol->thermo());
-    }
     using ReactorBase::ReactorBase; // inherit constructors
 
     string type() const override {

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -18,7 +18,7 @@ namespace Cantera
 class Reservoir : public ReactorBase
 {
 public:
-    Reservoir() {}
+    using ReactorBase::ReactorBase; // inherit constructors
 
     string type() const override {
         return "Reservoir";

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -18,6 +18,11 @@ namespace Cantera
 class Reservoir : public ReactorBase
 {
 public:
+    Reservoir(shared_ptr<Solution> sol, const string& name = "(none)") {
+        m_solution = sol;
+        m_name = name;
+        setThermoMgr(*sol->thermo());
+    }
     using ReactorBase::ReactorBase; // inherit constructors
 
     string type() const override {

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -26,13 +26,14 @@ public:
 
     void initialize(double t0=0.0) override {}
 
+    //! @deprecated Unused; to be removed after %Cantera 3.1.
     void insert(ThermoPhase& contents) {
+        warn_deprecated("Reservoir::insert",
+            "Unused; to be removed after Cantera 3.1.");
         setThermoMgr(contents);
     }
 
-    void insert(shared_ptr<Solution> sol) {
-        setThermoMgr(*sol->thermo());
-    }
+    using ReactorBase::insert;
 };
 
 }

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -38,7 +38,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxReactorBase "Cantera::ReactorBase":
         CxxReactorBase()
         string type()
-        void setThermoMgr(CxxThermoPhase&) except +translate_exception
+        void setSolution(shared_ptr[CxxSolution]) except +translate_exception
         void restoreState() except +translate_exception
         void syncState() except +translate_exception
         double volume()
@@ -48,7 +48,6 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
 
     cdef cppclass CxxReactor "Cantera::Reactor" (CxxReactorBase):
         CxxReactor()
-        void setKineticsMgr(CxxKinetics&)
         void setChemistry(cbool)
         cbool chemistryEnabled()
         void setEnergy(int)

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -58,7 +58,7 @@ cdef class ReactorBase:
         self._thermo = solution
         # Block species from being added to the phase as long as this object exists
         self._thermo._references[self._weakref_proxy] = True
-        self.rbase.setThermoMgr(deref(solution.thermo))
+        self.rbase.setSolution(solution._base)
 
     property type:
         """The type of the reactor."""
@@ -268,8 +268,6 @@ cdef class Reactor(ReactorBase):
         """
         ReactorBase.insert(self, solution)
         self._kinetics = solution
-        if solution.kinetics != NULL:
-            self.reactor.setKineticsMgr(deref(solution.kinetics))
 
     property kinetics:
         """

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -220,7 +220,8 @@ cdef class Reactor(ReactorBase):
         """
         :param contents:
             Reactor contents. If not specified, the reactor is initially empty.
-            In this case, call `insert` to specify the contents.
+            In this case, call `insert` to specify the contents. Providing valid
+            contents will become mandatory after Cantera 3.1.
         :param name:
             Used only to identify this reactor in output. If not specified,
             defaults to ``'Reactor_n'``, where *n* is an integer assigned in

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -27,7 +27,7 @@ cdef class ReactorBase:
         self._reactor = newReactor(stringify(self.reactor_type))
         self.rbase = self._reactor.get()
 
-    def __init__(self, ThermoPhase contents=None, name=None, *, volume=None,
+    def __init__(self, _SolutionBase contents=None, name=None, *, volume=None,
                  node_attr=None):
 
         self._weakref_proxy = _WeakrefProxy()
@@ -35,8 +35,12 @@ cdef class ReactorBase:
         self._outlets = []
         self._walls = []
         self._surfaces = []
-        if isinstance(contents, ThermoPhase):
+        if isinstance(contents, _SolutionBase):
             self.insert(contents)
+        else:
+            warnings.warn(
+                "Starting in Cantera 3.1, the reactor contents must not be empty.",
+                DeprecationWarning)
 
         if name is not None:
             self.name = name
@@ -239,11 +243,6 @@ cdef class Reactor(ReactorBase):
 
         >>> gas = Solution('gri30.yaml')
         >>> r1 = Reactor(gas)
-
-        This is equivalent to:
-
-        >>> r1 = Reactor()
-        >>> r1.insert(gas)
 
         Arguments may be specified using keywords in any order:
 

--- a/interfaces/matlab_experimental/Reactor/Reactor.m
+++ b/interfaces/matlab_experimental/Reactor/Reactor.m
@@ -130,11 +130,7 @@ classdef Reactor < handle
                     error('Wrong object type');
                 end
 
-                ctFunc('reactor_setThermoMgr', r.id, content.tpID);
-
-                if ~strcmp(r.type, 'Reservoir')
-                    ctFunc('reactor_setKineticsMgr', r.id, content.kinID);
-                end
+                ctFunc('reactor_setSolution', r.id, content.phaseID);
 
             elseif ~(isa(content, 'double') && content == 0)
                 error('Reactor contents must be an object of type "Solution"');

--- a/interfaces/matlab_experimental/Reactor/Reactor.m
+++ b/interfaces/matlab_experimental/Reactor/Reactor.m
@@ -86,17 +86,17 @@ classdef Reactor < handle
     methods
         %% Reactor Class Constructor
 
-        function r = Reactor(content, typ)
+        function r = Reactor(content, typ, name)
             % Reactor Class ::
             %
-            %     >> r = Reactor(content, typ)
+            %     >> r = Reactor(content, typ, name)
             %
             % A :mat:class:`Reactor` object simulates a perfectly-stirred reactor.
             % It has a time-dependent state, and may be coupled to other
             % reactors through flow lines or through walls that may expand
             % or contract and/or conduct heat.
             %
-            % :param contents:
+            % :param content:
             %    Instance of :mat:class:`Solution` representing the contents of
             %    the reactor.
             % :param typ:
@@ -107,34 +107,31 @@ classdef Reactor < handle
             %      - `ConstPressureReactor`
             %      - `IdealGasReactor`
             %      - `IdealGasConstPressureReactor`
+            % :param name:
+            %    Reactor name (optional; default is ``(none)``).
             % :return:
             %    Instance of :mat:class:`Reactor`.
 
             ctIsLoaded;
 
             if nargin == 0
-                content = 0;
-                typ = 'Reactor';
+                error('Reactor contents must be specified')
             elseif nargin == 1
                 typ = 'Reactor'
-            elseif nargin > 2
+                name = '(none)'
+            elseif nargin == 2
+                name = '(none)'
+            elseif nargin > 3
                 error('too many arguments');
             end
 
-            r.type = char(typ);
-            r.id = ctFunc('reactor_new', typ);
-
-            if isa(content, 'Solution')
-                r.contents = content;
-                if ~isa(content, 'ThermoPhase')
-                    error('Wrong object type');
-                end
-
-                ctFunc('reactor_setSolution', r.id, content.phaseID);
-
-            elseif ~(isa(content, 'double') && content == 0)
+            if ~isa(content, 'Solution')
                 error('Reactor contents must be an object of type "Solution"');
             end
+
+            r.type = char(typ);
+            r.id = ctFunc('reactor_new3', typ, content.phaseID, name);
+
 
         end
 

--- a/interfaces/matlab_experimental/readme.md
+++ b/interfaces/matlab_experimental/readme.md
@@ -23,7 +23,7 @@ function calling from Cantera Clib.
 5. In the Matlab command window, run
    `cd([pwd, '/interfaces/matlab_experimental/Utility'])` to navigate to the Utility
    folder.
-6. Open the file named 'cantera_root.m', in the second line, edit `output=` to
+6. Open the file named 'ctRoot.m', in the second line, edit `output=` to
    `output='/path/to/conda/environment'`, then save the file. This sets the search path
    for the `ctLoad` command to find the shared library file for Cantera.
 7. Make sure the current (old) Matlab Toolbox for

--- a/samples/cxx/combustor/combustor.cpp
+++ b/samples/cxx/combustor/combustor.cpp
@@ -27,37 +27,32 @@ void runexample()
     auto gas = sol->thermo();
 
     // create a reservoir for the fuel inlet, and set to pure methane.
-    Reservoir fuel_in;
     gas->setState_TPX(300.0, OneAtm, "CH4:1.0");
-    fuel_in.insert(sol);
+    Reservoir fuel_in(sol);
     double fuel_mw = gas->meanMolecularWeight();
 
     auto air = newSolution("air.yaml", "air", "none");
     double air_mw = air->thermo()->meanMolecularWeight();
 
     // create a reservoir for the air inlet
-    Reservoir air_in;
-    air_in.insert(air);
+    Reservoir air_in(air);
 
     // to ignite the fuel/air mixture, we'll introduce a pulse of radicals.
     // The steady-state behavior is independent of how we do this, so we'll
     // just use a stream of pure atomic hydrogen.
     gas->setState_TPX(300.0, OneAtm, "H:1.0");
-    Reservoir igniter;
-    igniter.insert(sol);
+    Reservoir igniter(sol);
 
 
     // create the combustor, and fill it in initially with N2
     gas->setState_TPX(300.0, OneAtm, "N2:1.0");
-    Reactor combustor;
-    combustor.insert(sol);
+    Reactor combustor(sol);
     combustor.setInitialVolume(1.0);
 
 
     // create a reservoir for the exhaust. The initial composition
     // doesn't matter.
-    Reservoir exhaust;
-    exhaust.insert(sol);
+    Reservoir exhaust(sol);
 
 
     // lean combustion, phi = 0.5

--- a/samples/cxx/kinetics1/kinetics1.cpp
+++ b/samples/cxx/kinetics1/kinetics1.cpp
@@ -33,15 +33,11 @@ int kinetics1(int np, void* p)
     gas->setState_TPX(1001.0, OneAtm, "H2:2.0, O2:1.0, N2:4.0");
     int nsp = gas->nSpecies();
 
-    // create a reactor
-    IdealGasConstPressureReactor r;
-
-    // 'insert' the gas into the reactor and environment.  Note
-    // that it is ok to insert the same gas object into multiple
-    // reactors or reservoirs. All this means is that this object
-    // will be used to evaluate thermodynamic or kinetic
-    // quantities needed.
-    r.insert(sol);
+    // create a reactor and 'insert' the gas into the reactor and environment.
+    // Note that it is ok to insert the same gas object into multiple reactors
+    // or reservoirs. All this means is that this object will be used to evaluate
+    // thermodynamic or kinetic quantities needed.
+    IdealGasConstPressureReactor r(sol);
 
     double dt = 1.e-5; // interval at which output is written
     int nsteps = 100; // number of intervals

--- a/samples/cxx/openmp_ignition/openmp_ignition.cpp
+++ b/samples/cxx/openmp_ignition/openmp_ignition.cpp
@@ -36,9 +36,8 @@ void run()
     for (int i = 0; i < nThreads; i++) {
         auto sol = newSolution("gri30.yaml", "gri30", "none");
         sols.emplace_back(sol);
-        reactors.emplace_back(new IdealGasConstPressureReactor());
+        reactors.emplace_back(new IdealGasConstPressureReactor(sol));
         nets.emplace_back(new ReactorNet());
-        reactors.back()->insert(sol);
         nets.back()->addReactor(*reactors.back());
     }
 

--- a/samples/python/reactors/ic_engine.py
+++ b/samples/python/reactors/ic_engine.py
@@ -15,7 +15,6 @@ Requires: cantera >= 3.0, scipy >= 0.19, matplotlib >= 2.0
 import cantera as ct
 import numpy as np
 
-from scipy.integrate import trapz
 import matplotlib.pyplot as plt
 
 #########################################################################
@@ -253,13 +252,13 @@ plt.show()
 ######################################################################
 
 # heat release
-Q = trapz(states.heat_release_rate * states.V, t)
+Q = np.trapz(states.heat_release_rate * states.V, t)
 output_str = '{:45s}{:>4.1f} {}'
 print(output_str.format('Heat release rate per cylinder (estimate):',
                         Q / t[-1] / 1000., 'kW'))
 
 # expansion power
-W = trapz(states.dWv_dt, t)
+W = np.trapz(states.dWv_dt, t)
 print(output_str.format('Expansion power per cylinder (estimate):',
                         W / t[-1] / 1000., 'kW'))
 
@@ -269,6 +268,6 @@ print(output_str.format('Efficiency (estimate):', eta * 100., '%'))
 
 # CO emissions
 MW = states.mean_molecular_weight
-CO_emission = trapz(MW * states.mdot_out * states('CO').X[:, 0], t)
-CO_emission /= trapz(MW * states.mdot_out, t)
+CO_emission = np.trapz(MW * states.mdot_out * states('CO').X[:, 0], t)
+CO_emission /= np.trapz(MW * states.mdot_out, t)
 print(output_str.format('CO emission (estimate):', CO_emission * 1.e6, 'ppm'))

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -89,6 +89,16 @@ extern "C" {
         }
     }
 
+    int reactor_setSolution(int i, int n)
+    {
+        try {
+            ReactorCabinet::get<Reactor>(i).setSolution(SolutionCabinet::at(n));
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int reactor_insert(int i, int n)
     {
         try {

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -49,6 +49,15 @@ extern "C" {
         }
     }
 
+    int reactor_new3(const char* type, int n, const char* name)
+    {
+        try {
+            return ReactorCabinet::add(newReactor(type, SolutionCabinet::at(n)));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int reactor_del(int i)
     {
         try {
@@ -83,16 +92,6 @@ extern "C" {
     {
         try {
             ReactorCabinet::item(i).setKineticsMgr(KineticsCabinet::item(n));
-            return 0;
-        } catch (...) {
-            return handleAllExceptions(-1, ERR);
-        }
-    }
-
-    int reactor_setSolution(int i, int n)
-    {
-        try {
-            ReactorCabinet::get<Reactor>(i).setSolution(SolutionCabinet::at(n));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -22,11 +22,6 @@ namespace bmt = boost::math::tools;
 namespace Cantera
 {
 
-void Reactor::insert(shared_ptr<Solution> sol) {
-    setThermoMgr(*sol->thermo());
-    setKineticsMgr(*sol->kinetics());
-}
-
 void Reactor::setDerivativeSettings(AnyMap& settings)
 {
     m_kin->setDerivativeSettings(settings);

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -22,6 +22,14 @@ namespace bmt = boost::math::tools;
 namespace Cantera
 {
 
+Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
+{
+    m_solution = sol;
+    m_name = name;
+    setThermoMgr(*sol->thermo());
+    setKineticsMgr(*sol->kinetics());
+}
+
 void Reactor::setDerivativeSettings(AnyMap& settings)
 {
     m_kin->setDerivativeSettings(settings);

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -36,8 +36,8 @@ void ReactorBase::setSolution(shared_ptr<Solution> sol) {
 
 void ReactorBase::insert(shared_ptr<Solution> sol)
 {
-    // warn_deprecated("ReactorBase::insert",
-    //     "To be removed after Cantera 3.1. Superseded by 'setSolution'.");
+    warn_deprecated("ReactorBase::insert",
+        "To be removed after Cantera 3.1. Superseded by 'setSolution'.");
     setSolution(sol);
 }
 

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -34,6 +34,13 @@ void ReactorBase::setSolution(shared_ptr<Solution> sol) {
     }
 }
 
+void ReactorBase::insert(shared_ptr<Solution> sol)
+{
+    // warn_deprecated("ReactorBase::insert",
+    //     "To be removed after Cantera 3.1. Superseded by 'setSolution'.");
+    setSolution(sol);
+}
+
 void ReactorBase::setThermoMgr(ThermoPhase& thermo)
 {
     m_thermo = &thermo;

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -7,6 +7,7 @@
 #include "cantera/zeroD/FlowDevice.h"
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/zeroD/ReactorSurface.h"
+#include "cantera/base/Solution.h"
 #include "cantera/thermo/ThermoPhase.h"
 
 namespace Cantera
@@ -15,6 +16,22 @@ namespace Cantera
 ReactorBase::ReactorBase(const string& name)
 {
     m_name = name;
+}
+
+ReactorBase::ReactorBase(shared_ptr<Solution> sol, const string& name)
+{
+    m_name = name;
+    setSolution(sol);
+}
+
+void ReactorBase::setSolution(shared_ptr<Solution> sol) {
+    m_solution = sol;
+    setThermoMgr(*sol->thermo());
+    try {
+        setKineticsMgr(*sol->kinetics());
+    } catch (NotImplementedError&) {
+        // kinetics not used (example: Reservoir)
+    }
 }
 
 void ReactorBase::setThermoMgr(ThermoPhase& thermo)

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -68,11 +68,24 @@ void ReactorFactory::deleteFactory() {
 
 shared_ptr<ReactorBase> newReactor(const string& model)
 {
+    // deprecation warning is handled in Python API
     return shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model));
+}
+
+shared_ptr<ReactorBase> newReactor(
+    const string& model, shared_ptr<Solution> contents, const string& name)
+{
+    // once empty reactors are no longer supported, the create factory method should
+    // support passing a Solution object and a name
+    auto ret = shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model));
+    ret->setSolution(contents);
+    ret->setName(name);
+    return ret;
 }
 
 shared_ptr<ReactorBase> newReactor3(const string& model)
 {
+    warn_deprecated("newReactor3", "To be removed after Cantera 3.1.");
     return newReactor(model);
 }
 

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -38,11 +38,9 @@ TEST(ctreactor, reactor_simple)
     thermo_setTemperature(thermo, T);
     thermo_setPressure(thermo, P);
 
-    int reactor = reactor_new("IdealGasReactor");
-    int ret = reactor_setSolution(reactor, sol);
-    ASSERT_EQ(ret, 0);
+    int reactor = reactor_new3("IdealGasReactor", sol, "test");
     int net = reactornet_new();
-    ret = reactornet_addreactor(net, reactor);
+    int ret = reactornet_addreactor(net, reactor);
     ASSERT_EQ(ret, 0);
 
     double t = 0.0;

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -68,8 +68,8 @@ class TestReactor(utilities.CanteraTest):
         self.assertEqual(len(R.kinetics.net_production_rates), g.n_species)
 
     def test_volume(self):
-        with pytest.warns(DeprecationWarning, match="must not be empty"):
-            R = self.reactorClass(volume=11)
+        g = ct.Solution('h2o2.yaml', transport_model=None)
+        R = self.reactorClass(g, volume=11)
         self.assertEqual(R.volume, 11)
 
         R.volume = 9
@@ -855,8 +855,8 @@ class TestReactor(utilities.CanteraTest):
                 x.foobar
 
     def test_bad_kwarg(self):
-        with pytest.warns(DeprecationWarning, match="must not be empty"):
-            self.reactorClass(name='ok')
+        g = ct.Solution('h2o2.yaml', transport_model=None)
+        self.reactorClass(g, name='ok')
         with self.assertRaises(TypeError):
             r1 = self.reactorClass(foobar=3.14)
 

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -53,7 +53,8 @@ class TestReactor(utilities.CanteraTest):
         self.assertTrue(self.net.verbose)
 
     def test_insert(self):
-        R = self.reactorClass()
+        with pytest.warns(DeprecationWarning, match="must not be empty"):
+            R = self.reactorClass()
         with self.assertRaisesRegex(ct.CanteraError, 'No phase'):
             R.T
         with self.assertRaisesRegex(ct.CanteraError, 'No phase'):
@@ -67,7 +68,8 @@ class TestReactor(utilities.CanteraTest):
         self.assertEqual(len(R.kinetics.net_production_rates), g.n_species)
 
     def test_volume(self):
-        R = self.reactorClass(volume=11)
+        with pytest.warns(DeprecationWarning, match="must not be empty"):
+            R = self.reactorClass(volume=11)
         self.assertEqual(R.volume, 11)
 
         R.volume = 9
@@ -853,7 +855,8 @@ class TestReactor(utilities.CanteraTest):
                 x.foobar
 
     def test_bad_kwarg(self):
-        self.reactorClass(name='ok')
+        with pytest.warns(DeprecationWarning, match="must not be empty"):
+            self.reactorClass(name='ok')
         with self.assertRaises(TypeError):
             r1 = self.reactorClass(foobar=3.14)
 

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -20,7 +20,6 @@ TEST(zerodim, simple)
     auto sol = newSolution("gri30.yaml", "gri30", "none");
     sol->thermo()->setState_TPX(T, P, X);
     auto cppReactor = newReactor("IdealGasReactor", sol, "simple");
-    // IdealGasReactor cppReactor(sol, "simple");
     ASSERT_EQ(cppReactor->name(), "simple");
     cppReactor->initialize();
     ReactorNet network;

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -19,8 +19,8 @@ TEST(zerodim, simple)
 
     auto sol = newSolution("gri30.yaml", "gri30", "none");
     sol->thermo()->setState_TPX(T, P, X);
-    IdealGasReactor cppReactor;
-    cppReactor.insert(sol);
+    IdealGasReactor cppReactor(sol, "simple");
+    ASSERT_EQ(cppReactor.name(), "simple");
     cppReactor.initialize();
     ReactorNet network;
     network.addReactor(cppReactor);
@@ -74,8 +74,7 @@ TEST(zerodim, test_individual_reactor_initialization)
     shared_ptr<Solution> sol1 = newSolution("h2o2.yaml");
     sol1->thermo()->setState_TPX(T0, P0, X0);
     // set up reactor object
-    Reactor reactor1;
-    reactor1.insert(sol1);
+    Reactor reactor1(sol1);
     // initialize reactor prior to integration to ensure no impact
     reactor1.initialize();
     // setup reactor network and integrate
@@ -88,8 +87,7 @@ TEST(zerodim, test_individual_reactor_initialization)
     sol2->thermo()->setState_TPX(T0, P0, X0);
     sol2->thermo()->equilibrate("UV");
     // secondary reactor for comparison
-    Reactor reactor2;
-    reactor2.insert(sol2);
+    Reactor reactor2(sol2);
     reactor2.initialize(0.0);
     // get state of reactors
     vector<double> state1(reactor1.neq());
@@ -109,8 +107,7 @@ TEST(MoleReactorTestSet, test_mole_reactor_get_state)
     double tol = 1e-8;
     auto sol = newSolution("h2o2.yaml");
     sol->thermo()->setState_TPY(1000.0, OneAtm, "H2:0.5, O2:0.5");
-    IdealGasConstPressureMoleReactor reactor;
-    reactor.insert(sol);
+    IdealGasConstPressureMoleReactor reactor(sol);
     reactor.setInitialVolume(0.5);
     reactor.setEnergy(false);
     reactor.initialize();
@@ -189,8 +186,7 @@ TEST(AdaptivePreconditionerTests, test_precon_solver_stats)
     // setting up solution object and thermo/kinetics pointers
     auto sol = newSolution("h2o2.yaml");
     sol->thermo()->setState_TPY(1000.0, OneAtm, "H2:0.5, O2:0.5");
-    IdealGasMoleReactor reactor;
-    reactor.insert(sol);
+    IdealGasMoleReactor reactor(sol);
     reactor.setInitialVolume(0.5);
     // setup reactor network and integrate
     ReactorNet network;

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -9,8 +9,8 @@
 
 using namespace Cantera;
 
-// This test is an exact equivalent of a clib test
-// (clib::test_ctreactor.cpp::ctreactor::reactor_insert)
+// This test is an (almost) exact equivalent of a clib test
+// (clib::test_ctreactor.cpp::ctreactor::reactor_simple)
 TEST(zerodim, simple)
 {
     double T = 1050;

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -19,16 +19,17 @@ TEST(zerodim, simple)
 
     auto sol = newSolution("gri30.yaml", "gri30", "none");
     sol->thermo()->setState_TPX(T, P, X);
-    IdealGasReactor cppReactor(sol, "simple");
-    ASSERT_EQ(cppReactor.name(), "simple");
-    cppReactor.initialize();
+    auto cppReactor = newReactor("IdealGasReactor", sol, "simple");
+    // IdealGasReactor cppReactor(sol, "simple");
+    ASSERT_EQ(cppReactor->name(), "simple");
+    cppReactor->initialize();
     ReactorNet network;
-    network.addReactor(cppReactor);
+    network.addReactor(dynamic_cast<IdealGasReactor&>(*cppReactor));
     network.initialize();
 
     double t = 0.0;
     while (t < 0.1) {
-        ASSERT_GE(cppReactor.temperature(), T);
+        ASSERT_GE(cppReactor->temperature(), T);
         t = network.time() + 5e-3;
         network.advance(t);
     }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Assign `Solution` to zeroD objects where possible
- Implement instantiation of non-empty `Reactor` objects, and trigger deprecation warnings when attempting to create reactors without content whenever feasible
- Some legacy routes for empty `Reactor` objects remain (example: legacy MATLAB toolbox)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Prepares a future solution for #1457

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
