### PR TITLE
Expose Peng-Robinson EoS parameters to Python interface

### DIFF
--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -177,10 +177,10 @@ public:
     /*!
      * @return
      *   Returns an AnyMap containing the following key names and values:
-     *   - "aAlpha_mix": The value of m_aAlpha_mix
-     *   - "b_mix": The value of the m_b
-     *   - "daAlpha_dT": The value returned by the daAlpha_dT() method
-     *   - "d2aAlpha_dT2": The value returned by the d2aAlpha_dT2() method
+     *   - `aAlpha_mix`: The value of #m_aAlpha_mix
+     *   - `b_mix`: The value of the #m_b
+     *   - `daAlpha_dT`: The value returned by the daAlpha_dT() method
+     *   - `d2aAlpha_dT2`: The value returned by the d2aAlpha_dT2() method
      */
     AnyMap getAuxiliaryData() override;
 

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -173,6 +173,14 @@ public:
     void setBinaryCoeffs(const string& species_i, const string& species_j, double a);
     //! @}
 
+    //! Compute additional method based on name
+    /*!
+     * @param name The name of the quantity to compute
+     * @return Computed value wrapped in AnyValue type for Peng-Robinson phase
+     *         quantities
+     */
+    AnyValue compute_extra_method(const std::string& name) override;
+
 protected:
     // Special functions inherited from MixtureFugacityTP
     double sresid() const override;

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -173,13 +173,8 @@ public:
     void setBinaryCoeffs(const string& species_i, const string& species_j, double a);
     //! @}
 
-    //! Compute additional method based on name
-    /*!
-     * @param name The name of the quantity to compute
-     * @return Computed value wrapped in AnyValue type for Peng-Robinson phase
-     *         quantities
-     */
-    AnyValue compute_extra_method(const std::string& name) override;
+    //! Return common parameters used by the Peng-Robinson equation of state
+    AnyMap getEosParameters() override;
 
 protected:
     // Special functions inherited from MixtureFugacityTP

--- a/include/cantera/thermo/PengRobinson.h
+++ b/include/cantera/thermo/PengRobinson.h
@@ -173,8 +173,16 @@ public:
     void setBinaryCoeffs(const string& species_i, const string& species_j, double a);
     //! @}
 
-    //! Return common parameters used by the Peng-Robinson equation of state
-    AnyMap getEosParameters() override;
+    //! Return parameters used by the Peng-Robinson equation of state.
+    /*!
+     * @return
+     *   Returns an AnyMap containing the following key names and values:
+     *   - "aAlpha_mix": The value of m_aAlpha_mix
+     *   - "b_mix": The value of the m_b
+     *   - "daAlpha_dT": The value returned by the daAlpha_dT() method
+     *   - "d2aAlpha_dT2": The value returned by the d2aAlpha_dT2() method
+     */
+    AnyMap getAuxiliaryData() override;
 
 protected:
     // Special functions inherited from MixtureFugacityTP

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1556,6 +1556,16 @@ public:
             const Composition& oxComp, ThermoBasis basis=ThermoBasis::molar) const;
     //! @}
 
+    //! Compute additional method based on name
+    /*!
+     * @param name The name of the quantity to compute
+     * @return Computed value wrapped in AnyValue type
+     */
+    virtual AnyValue compute_extra_method(const std::string& name)
+    {
+        throw NotImplementedError("ThermoPhase::compute_extra_method");
+    }
+
 private:
 
     //! Carry out work in HP and UV calculations.

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1556,14 +1556,11 @@ public:
             const Composition& oxComp, ThermoBasis basis=ThermoBasis::molar) const;
     //! @}
 
-    //! Compute additional method based on name
-    /*!
-     * @param name The name of the quantity to compute
-     * @return Computed value wrapped in AnyValue type
-     */
-    virtual AnyValue compute_extra_method(const std::string& name)
+    //! Return common parameters used by an equation of state that a user may
+    //! want to access.
+    virtual AnyMap getEosParameters()
     {
-        throw NotImplementedError("ThermoPhase::compute_extra_method");
+        throw NotImplementedError("ThermoPhase::getEosParameters");
     }
 
 private:

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -1556,11 +1556,12 @@ public:
             const Composition& oxComp, ThermoBasis basis=ThermoBasis::molar) const;
     //! @}
 
-    //! Return common parameters used by an equation of state that a user may
-    //! want to access.
-    virtual AnyMap getEosParameters()
+    //! Return intermediate or model-specific parameters used by particular
+    //! derived classes. Specific parameters are described in overidden
+    //! methods of classes that derive from the base class.
+    virtual AnyMap getAuxiliaryData()
     {
-        throw NotImplementedError("ThermoPhase::getEosParameters");
+        return AnyMap();
     }
 
 private:

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -175,7 +175,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         double equivalenceRatio() except +translate_exception
         double stoichAirFuelRatio(const double* fuelComp, const double* oxComp, ThermoBasis basis) except +translate_exception
 
-        CxxAnyValue compute_extra_method(string) except +translate_exception
+        CxxAnyMap getEosParameters() except +translate_exception
 
 
 cdef extern from "cantera/thermo/SurfPhase.h":

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -175,7 +175,7 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         double equivalenceRatio() except +translate_exception
         double stoichAirFuelRatio(const double* fuelComp, const double* oxComp, ThermoBasis basis) except +translate_exception
 
-        CxxAnyMap getEosParameters() except +translate_exception
+        CxxAnyMap getAuxiliaryData() except +translate_exception
 
 
 cdef extern from "cantera/thermo/SurfPhase.h":

--- a/interfaces/cython/cantera/thermo.pxd
+++ b/interfaces/cython/cantera/thermo.pxd
@@ -175,6 +175,8 @@ cdef extern from "cantera/thermo/ThermoPhase.h" namespace "Cantera":
         double equivalenceRatio() except +translate_exception
         double stoichAirFuelRatio(const double* fuelComp, const double* oxComp, ThermoBasis basis) except +translate_exception
 
+        CxxAnyValue compute_extra_method(string) except +translate_exception
+
 
 cdef extern from "cantera/thermo/SurfPhase.h":
     cdef cppclass CxxSurfPhase "Cantera::SurfPhase":

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1172,9 +1172,12 @@ cdef class ThermoPhase(_SolutionBase):
         X = self.thermo.getMoleFractionsByName(threshold)
         return {pystr(item.first):item.second for item in X}
 
-    def compute_extra_method(self, name):
-        cdef CxxAnyValue value = self.thermo.compute_extra_method(stringify(name))
-        return anyvalue_to_python(name, value)
+    def get_eos_parameters(self):
+        """
+        Return a dictionary giving common eos parameters.
+        """
+        cdef CxxAnyMap values = self.thermo.getEosParameters()
+        return anymap_to_py(values)
 
     ######## Read-only thermodynamic properties ########
 

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1172,6 +1172,10 @@ cdef class ThermoPhase(_SolutionBase):
         X = self.thermo.getMoleFractionsByName(threshold)
         return {pystr(item.first):item.second for item in X}
 
+    def compute_extra_method(self, name):
+        cdef CxxAnyValue value = self.thermo.compute_extra_method(stringify(name))
+        return anyvalue_to_python(name, value)
+
     ######## Read-only thermodynamic properties ########
 
     property P:

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -1172,12 +1172,6 @@ cdef class ThermoPhase(_SolutionBase):
         X = self.thermo.getMoleFractionsByName(threshold)
         return {pystr(item.first):item.second for item in X}
 
-    def get_eos_parameters(self):
-        """
-        Return a dictionary giving common eos parameters.
-        """
-        cdef CxxAnyMap values = self.thermo.getEosParameters()
-        return anymap_to_py(values)
 
     ######## Read-only thermodynamic properties ########
 
@@ -1341,6 +1335,15 @@ cdef class ThermoPhase(_SolutionBase):
         """Saturation temperature [K] at the current pressure."""
         def __get__(self):
             return self.thermo.satTemperature(self.P)
+
+    property auxiliary_data:
+        """
+        Intermediate or model-specific parameters used by particular
+        derived classes.
+        """
+        def __get__(self):
+            cdef CxxAnyMap values = self.thermo.getAuxiliaryData()
+            return anymap_to_py(values)
 
     ######## Methods to get/set the complete thermodynamic state ########
 

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -780,4 +780,18 @@ int PengRobinson::solveCubic(double T, double pres, double a, double b, double a
                                          an, bn, cn, dn, tc, vc);
 }
 
+AnyValue PengRobinson::compute_extra_method(const std::string& name)
+{
+    if(name == "aAlpha_mix") {
+        return AnyValue(m_aAlpha_mix);
+    } else if(name == "b_mix") {
+        return AnyValue(m_b);
+    } else if(name == "daAlpha_dT") {
+        return AnyValue(daAlpha_dT());
+    } else if(name == "d2aAlpha_dT2") {
+        return AnyValue(d2aAlpha_dT2());
+    }
+    throw CanteraError("PengRobinson::compute_extra_method", "Unknown method: {}", name);
+}
+
 }

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -780,18 +780,17 @@ int PengRobinson::solveCubic(double T, double pres, double a, double b, double a
                                          an, bn, cn, dn, tc, vc);
 }
 
-AnyValue PengRobinson::compute_extra_method(const std::string& name)
+AnyMap PengRobinson::getEosParameters()
 {
-    if(name == "aAlpha_mix") {
-        return AnyValue(m_aAlpha_mix);
-    } else if(name == "b_mix") {
-        return AnyValue(m_b);
-    } else if(name == "daAlpha_dT") {
-        return AnyValue(daAlpha_dT());
-    } else if(name == "d2aAlpha_dT2") {
-        return AnyValue(d2aAlpha_dT2());
-    }
-    throw CanteraError("PengRobinson::compute_extra_method", "Unknown method: {}", name);
+    AnyMap parameters;
+
+    // Add each parameter to the map.
+    parameters["aAlpha_mix"] = AnyValue(m_aAlpha_mix);
+    parameters["b_mix"] = AnyValue(m_b);
+    parameters["daAlpha_dT"] = AnyValue(daAlpha_dT());
+    parameters["d2aAlpha_dT2"] = AnyValue(d2aAlpha_dT2());
+
+    return parameters;
 }
 
 }

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -780,15 +780,14 @@ int PengRobinson::solveCubic(double T, double pres, double a, double b, double a
                                          an, bn, cn, dn, tc, vc);
 }
 
-AnyMap PengRobinson::getEosParameters()
+AnyMap PengRobinson::getAuxiliaryData()
 {
-    AnyMap parameters;
+    AnyMap parameters = ThermoPhase::getAuxiliaryData();
 
-    // Add each parameter to the map.
-    parameters["aAlpha_mix"] = AnyValue(m_aAlpha_mix);
-    parameters["b_mix"] = AnyValue(m_b);
-    parameters["daAlpha_dT"] = AnyValue(daAlpha_dT());
-    parameters["d2aAlpha_dT2"] = AnyValue(d2aAlpha_dT2());
+    parameters["aAlpha_mix"] = m_aAlpha_mix;
+    parameters["b_mix"] = m_b;
+    parameters["daAlpha_dT"] = daAlpha_dT();
+    parameters["d2aAlpha_dT2"] = d2aAlpha_dT2();
 
     return parameters;
 }

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -970,6 +970,16 @@ class TestThermoPhase(utilities.CanteraTest):
             self.phase.add_species(species)
 
 
+    def test_auxiliary_data(self):
+        """
+        Should get back a dictionary with 4 keys present when calling the auxiliary_data
+        property for the Peng-Robinson thermo phase.
+        """
+        gas = ct.Solution('co2_PR_example.yaml', 'CO2-PR')
+        gas.TPX = 300, 101325, 'H2:1.0'
+        params = gas.auxiliary_data
+        self.assertEqual(len(params), 4)
+
 class TestThermo(utilities.CanteraTest):
     def setUp(self):
         self.gas = ct.ThermoPhase("h2o2.yaml")


### PR DESCRIPTION
This pull request seeks to expose the Peng-Robinson equation of state parameters, such as aAlpha, b, and the first and second derivatives of aAlpha with respect to temperature so that these values are available through the Python interface of the ThermoPhase object. These parameters are often used in the context of compressible flamelet table tabulations.

See: https://arxiv.org/abs/1704.02639


I'm attempting to use the AnyValue object for the return type to generalize a bit. The overall idea I had was to have a catch-all function that can dispatch to method that return values from the eos objects.


```
def add_additional_data(flame, gas):
    for i in range(flame.flame.n_points):
        # Set the state of the gas to match the local state
        T = flame.T[i]
        P = flame.P
        X = flame.X[:,i]
        gas.TPX = T, P, X

        # Compute additional data
        aAlpha_mix = gas.compute_extra_method('aAlpha_mix')
        b_mix = gas.compute_extra_method('b_mix')
        daAlpha_dT = gas.compute_extra_method('daAlpha_dT')
        d2aAlpha_dT2 = gas.compute_extra_method('d2aAlpha_dT2')
        print(f'aAlpha_mix: {aAlpha_mix}, b_mix: {b_mix}, daAlpha_dT: {daAlpha_dT}, d2aAlpha_dT2: {d2aAlpha_dT2}')

```

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
