### PR TITLE
Add option for mass gradient-based fluxes

### DIFF
--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -106,6 +106,24 @@ public:
         return m_do_soret;
     }
 
+    //! Compute species diffusive fluxes with respect to
+    //! their mass fraction gradients (fluxGradientBasis = ThermoBasis::mass)
+    //! or mole fraction gradients (fluxGradientBasis = ThermoBasis::molar, default)
+    //! when using the mixture-averaged transport model.
+    //! @param fluxGradientBasis set flux computation to mass or mole basis
+    //! @since New in %Cantera 3.1.
+    void setFluxGradientBasis(ThermoBasis fluxGradientBasis);
+
+    //! Compute species diffusive fluxes with respect to
+    //! their mass fraction gradients (fluxGradientBasis = ThermoBasis::mass)
+    //! or mole fraction gradients (fluxGradientBasis = ThermoBasis::molar, default)
+    //! when using the mixture-averaged transport model.
+    //! @return the basis used for flux computation (mass or mole fraction gradients)
+    //! @since New in %Cantera 3.1.
+    ThermoBasis fluxGradientBasis() const {
+        return m_fluxGradientBasis;
+    }
+
     //! Set the pressure. Since the flow equations are for the limit of small
     //! Mach number, the pressure is very nearly constant throughout the flow.
     void setPressure(double p) {
@@ -639,6 +657,7 @@ protected:
     // flags
     vector<bool> m_do_energy;
     bool m_do_soret = false;
+    ThermoBasis m_fluxGradientBasis = ThermoBasis::molar;
     vector<bool> m_do_species;
     bool m_do_multicomponent = false;
 

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -88,6 +88,8 @@ cdef extern from "cantera/oneD/StFlow.h":
         cbool doEnergy(size_t)
         void enableSoret(cbool) except +translate_exception
         cbool withSoret()
+        void setFluxGradientBasis(ThermoBasis) except +translate_exception
+        ThermoBasis fluxGradientBasis()
         void setFreeFlow()
         void setAxisymmetricFlow()
 

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -515,6 +515,27 @@ cdef class _FlowBase(Domain1D):
         def __set__(self, enable):
             self.flow.enableSoret(<cbool>enable)
 
+    property flux_gradient_basis:
+        """
+        Get/Set whether or not species diffusive fluxes are computed with
+        respect to their mass fraction gradients ('mass')
+        or mole fraction gradients ('molar', default) when
+        using the mixture-averaged transport model.
+        """
+        def __get__(self):
+            if self.flow.fluxGradientBasis() == ThermoBasis.molar:
+                return 'molar'
+            else:
+                return 'mass'
+        def __set__(self, basis):
+            if basis == 'molar':
+                self.flow.setFluxGradientBasis(ThermoBasis.molar)
+            elif basis == 'mass':
+                self.flow.setFluxGradientBasis(ThermoBasis.mass)
+            else:
+                raise ValueError("Valid choices are 'mass' or 'molar'."
+                                 " Got {!r}.".format(basis))
+
     property energy_enabled:
         """ Determines whether or not to solve the energy equation."""
         def __get__(self):

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -216,6 +216,20 @@ class FlameBase(Sim1D):
         self.flame.soret_enabled = enable
 
     @property
+    def flux_gradient_basis(self):
+        """
+        Get/Set whether or not species diffusive fluxes are computed with
+        respect to their mass fraction gradients ('mass')
+        or mole fraction gradients ('molar', default) when
+        using the mixture-averaged transport model.
+        """
+        return self.flame.flux_gradient_basis
+
+    @flux_gradient_basis.setter
+    def flux_gradient_basis(self, basis):
+        self.flame.flux_gradient_basis = basis
+
+    @property
     def radiation_enabled(self):
         """
         Get/Set whether or not to include radiative heat transfer

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -480,6 +480,22 @@ class TestFreeFlame(utilities.CanteraTest):
         # towards zero as grid is refined)
         self.assertLess(dh_unity_lewis, 0.1 * dh_mix)
 
+    def test_flux_gradient_mass(self):
+        self.create_sim(ct.one_atm, 300, 'H2:1.1, O2:1, AR:5.3')
+        self.sim.transport_model = 'mixture-averaged'
+        self.sim.set_refine_criteria(ratio=3.0, slope=0.08, curve=0.12)
+        assert self.sim.flux_gradient_basis == 'molar'
+        self.sim.solve(loglevel=0, auto=True)
+        sl_mole = self.sim.velocity[0]
+        self.sim.flux_gradient_basis = 'mass'
+        assert self.sim.flux_gradient_basis == 'mass'
+        self.sim.solve(loglevel=0)
+        sl_mass = self.sim.velocity[0]
+        # flame speeds should not be exactly equal
+        assert sl_mole != sl_mass
+        # but they should be close
+        assert sl_mole == approx(sl_mass, rel=0.1)
+
     def test_soret_with_mix(self):
         # Test that enabling Soret diffusion without
         # multicomponent transport results in an error


### PR DESCRIPTION
**Changes proposed in this pull request**

Add a new option to compute species diffusive fluxes with respect to their mass fraction gradients for 1D flames. See https://github.com/Cantera/enhancements/issues/195 for extended discussion. All changes are fully backward compatible.

After some brainstoming, I settled on `flux_gradient_basis` as the new property's name, i.e. using mole or mass fraction gradients for computing species fluxes. If you have a better idea, feel free to let me know.
I also changed the API to use the established basis enum. Performance-wise, this should not have an impact, since the comparison `m_fluxGradientBasis == ThermoBasis::molar` is a simple hard-coded comparison against zero.

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
