### PR TITLE
Fix minor issues in ck2yaml and test suite

### DIFF
--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -2045,6 +2045,10 @@ class Parser:
             phase_name = None
 
         if surface_file:
+            if phase_name is None:
+                msg = "Cannot specify a surface mechanism without a gas phase"
+                logger.warning(f"\nERROR: {msg}\n")
+                raise InputError(msg)
             parser.files.append(surface_file)
             surface_file = os.path.expanduser(surface_file)
             if not os.path.exists(surface_file):

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -346,8 +346,9 @@ class KineticsFromReactions(utilities.CanteraTest):
         assert gas.n_reactions == len(reactions)
         assert gas.n_species == len(h2o2.species_names)
 
-        gas.write_yaml("reduced.yaml")
-        restored = ct.Solution("reduced.yaml")
+        yaml_file = self.test_work_path / "reduced.yaml"
+        gas.write_yaml(yaml_file)
+        restored = ct.Solution(yaml_file)
         assert gas.species_names == restored.species_names
         assert gas.reaction_equations() == restored.reaction_equations()
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

Fix glitch in test suite / improve exception handling

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1666, closes #1656

**Illustration**

Using the minimal example from #1656 (issue reporting unhelpful exception handling), the output is now

```
% python -m cantera.ck2yaml --thermo=test/data/surface2-thermo.dat --surface=test/data/surface2.inp

ERROR: Cannot specify a surface mechanism without a gas phase

Traceback (most recent call last):
  File "<frozen runpy>", line 198, in _run_module_as_main
  File "<frozen runpy>", line 88, in _run_code
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cantera-dev/lib/python3.11/site-packages/cantera/ck2yaml.py", line 2316, in <module>
    main()
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cantera-dev/lib/python3.11/site-packages/cantera/ck2yaml.py", line 2199, in main
    parser, surfaces = Parser.convert_mech(input_file, thermo_file,
                       ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
  File "/opt/homebrew/Caskroom/miniforge/base/envs/cantera-dev/lib/python3.11/site-packages/cantera/ck2yaml.py", line 2051, in convert_mech
    raise InputError(msg)
InputError: Cannot specify a surface mechanism without a gas phase
Please check https://cantera.org/stable/userguide/ck2yaml-tutorial.html#debugging-common-errors-in-ck-files
for the correct Chemkin syntax.
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
