### PR TITLE
Add compatibility with Sundials 7.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -454,6 +454,8 @@ jobs:
           fmt-ver: 10
         - sundials-ver: 6.6
           fmt-ver: 10
+        - sundials-ver: 7.0
+          fmt-ver: 10
       fail-fast: false
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -784,7 +784,9 @@ jobs:
       run: brew install --display-times hdf5
       if: matrix.os == 'macos-11'
     - name: Install Apt dependencies (Ubuntu)
-      run: sudo apt install libhdf5-dev libfmt-dev
+      run: |
+        sudo apt update
+        sudo apt install libhdf5-dev libfmt-dev
       if: matrix.os == 'ubuntu-22.04'
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v2

--- a/doc/sphinx/develop/compiling/dependencies.md
+++ b/doc/sphinx/develop/compiling/dependencies.md
@@ -63,7 +63,7 @@ compiler is required only if you plan to build the Fortran module.
     Git, SUNDIALS will be automatically downloaded and the necessary portions will be
     compiled and installed with Cantera.
   - <https://computing.llnl.gov/projects/sundials>
-  - Known to work with versions >= 3.0. Expected to work with versions \<= 7.0.
+  - Known to work with versions >= 3.0 and \<= 7.0.
   - To use SUNDIALS with Cantera on a Linux/Unix system, it must be compiled
     with the `-fPIC` flag. You can specify this flag when configuring SUNDIALS as
     `cmake -DCMAKE_C_FLAGS=-fPIC <other command-line options>`

--- a/include/cantera/numerics/SundialsContext.h
+++ b/include/cantera/numerics/SundialsContext.h
@@ -21,7 +21,12 @@ class SundialsContext
 #if CT_SUNDIALS_VERSION >= 60
 public:
     SundialsContext() {
-        SUNContext_Create(nullptr, &m_context);
+        #if CT_SUNDIALS_VERSION >= 70
+            SUNContext_Create(SUN_COMM_NULL, &m_context);
+
+        #else
+            SUNContext_Create(nullptr, &m_context);
+        #endif
     }
     ~SundialsContext() {
         SUNContext_Free(&m_context);

--- a/include/cantera/numerics/sundials_headers.h
+++ b/include/cantera/numerics/sundials_headers.h
@@ -16,11 +16,19 @@
     #include "sunlinsol/sunlinsol_band.h"
 #endif
 #include "sunlinsol/sunlinsol_spgmr.h"
-#include "cvodes/cvodes_direct.h"
 #include "cvodes/cvodes_diag.h"
-#include "cvodes/cvodes_spils.h"
-#include "idas/idas_direct.h"
-#include "idas/idas_spils.h"
+
+#if CT_SUNDIALS_VERSION < 70
+    #include "cvodes/cvodes_direct.h"
+    #include "idas/idas_direct.h"
+    #include "idas/idas_spils.h"
+    #include "cvodes/cvodes_spils.h"
+#endif
+
+#if CT_SUNDIALS_VERSION < 60
+    typedef realtype sunrealtype;
+    typedef booleantype sunbooleantype;
+#endif
 
 #define CV_SS 1
 #define IDA_SS 1

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -36,7 +36,7 @@ extern "C" {
      * evaluates the desired equations.
      * @ingroup odeGroup
      */
-    static int cvodes_rhs(realtype t, N_Vector y, N_Vector ydot, void* f_data)
+    static int cvodes_rhs(sunrealtype t, N_Vector y, N_Vector ydot, void* f_data)
     {
         FuncEval* f = (FuncEval*) f_data;
         return f->evalNoThrow(t, NV_DATA_S(y), NV_DATA_S(ydot));
@@ -44,7 +44,8 @@ extern "C" {
 
     //! Function called by CVodes when an error is encountered instead of
     //! writing to stdout. Here, save the error message provided by CVodes so
-    //! that it can be included in the subsequently raised CanteraError.
+    //! that it can be included in the subsequently raised CanteraError. Used by
+    //! SUNDIALS 6.x and older.
     static void cvodes_err(int error_code, const char* module,
                            const char* function, char* msg, void* eh_data)
     {
@@ -53,8 +54,23 @@ extern "C" {
         integrator->m_error_message += "\n";
     }
 
-    static int cvodes_prec_setup(realtype t, N_Vector y, N_Vector ydot, booleantype jok,
-                                 booleantype *jcurPtr, realtype gamma, void *f_data)
+    //! Function called by CVodes when an error is encountered instead of
+    //! writing to stdout. Here, save the error message provided by CVodes so
+    //! that it can be included in the subsequently raised CanteraError. Used by
+    //! SUNDIALS 7.0 and newer.
+    #if CT_SUNDIALS_VERSION >= 70
+        static void sundials_err(int line, const char *func, const char *file,
+                                const char *msg, SUNErrCode err_code,
+                                void *err_user_data, SUNContext sunctx)
+        {
+            CVodesIntegrator* integrator = (CVodesIntegrator*) err_user_data;
+            integrator->m_error_message = fmt::format("{}: {}\n", func, msg);
+        }
+    #endif
+
+    static int cvodes_prec_setup(sunrealtype t, N_Vector y, N_Vector ydot,
+                                 sunbooleantype jok, sunbooleantype *jcurPtr,
+                                 sunrealtype gamma, void *f_data)
     {
         FuncEval* f = (FuncEval*) f_data;
         if (!jok) {
@@ -67,9 +83,9 @@ extern "C" {
         }
     }
 
-    static int cvodes_prec_solve(realtype t, N_Vector y, N_Vector ydot, N_Vector r,
-                                 N_Vector z, realtype gamma, realtype delta, int lr,
-                                 void* f_data)
+    static int cvodes_prec_solve(sunrealtype t, N_Vector y, N_Vector ydot, N_Vector r,
+                                 N_Vector z, sunrealtype gamma, sunrealtype delta,
+                                 int lr, void* f_data)
     {
         FuncEval* f = (FuncEval*) f_data;
         return f->preconditioner_solve_nothrow(NV_DATA_S(r),NV_DATA_S(z));
@@ -292,7 +308,11 @@ void CVodesIntegrator::initialize(double t0, FuncEval& func)
                                "CVodeInit failed.");
         }
     }
-    flag = CVodeSetErrHandlerFn(m_cvode_mem, &cvodes_err, this);
+    #if CT_SUNDIALS_VERSION >= 70
+        flag = SUNContext_PushErrHandler(m_sundials_ctx.get(), &sundials_err, this);
+    #else
+        flag = CVodeSetErrHandlerFn(m_cvode_mem, &cvodes_err, this);
+    #endif
 
     if (m_itol == CV_SV) {
         flag = CVodeSVtolerances(m_cvode_mem, m_reltol, m_abstol);
@@ -389,7 +409,7 @@ void CVodesIntegrator::applyOptions()
         }
     } else if (m_type == "GMRES") {
         #if CT_SUNDIALS_VERSION >= 60
-            m_linsol = SUNLinSol_SPGMR(m_y, PREC_NONE, 0, m_sundials_ctx.get());
+            m_linsol = SUNLinSol_SPGMR(m_y, SUN_PREC_NONE, 0, m_sundials_ctx.get());
             CVodeSetLinearSolver(m_cvode_mem, (SUNLinearSolver) m_linsol, nullptr);
         #elif CT_SUNDIALS_VERSION >= 40
             m_linsol = SUNLinSol_SPGMR(m_y, PREC_NONE, 0);

--- a/src/numerics/IdasIntegrator.cpp
+++ b/src/numerics/IdasIntegrator.cpp
@@ -37,7 +37,7 @@ extern "C" {
 * FuncEval::evalDae() method of an instance of a subclass of FuncEval that is passed
 * into this function as the `f_data` parameter.
 */
-static int ida_rhs(realtype t, N_Vector y, N_Vector ydot, N_Vector r, void* f_data)
+static int ida_rhs(sunrealtype t, N_Vector y, N_Vector ydot, N_Vector r, void* f_data)
 {
     FuncEval* f = (FuncEval*) f_data;
     return f->evalDaeNoThrow(t, NV_DATA_S(y), NV_DATA_S(ydot), NV_DATA_S(r));
@@ -53,6 +53,20 @@ static void ida_err(int error_code, const char* module,
     integrator->m_error_message = msg;
     integrator->m_error_message += "\n";
 }
+
+//! Function called by CVodes when an error is encountered instead of
+//! writing to stdout. Here, save the error message provided by CVodes so
+//! that it can be included in the subsequently raised CanteraError. Used by
+//! SUNDIALS 7.0 and newer.
+#if CT_SUNDIALS_VERSION >= 70
+    static void sundials_err(int line, const char *func, const char *file,
+                            const char *msg, SUNErrCode err_code,
+                            void *err_user_data, SUNContext sunctx)
+    {
+        IdasIntegrator* integrator = (IdasIntegrator*) err_user_data;
+        integrator->m_error_message = fmt::format("{}: {}\n", func, msg);
+    }
+#endif
 
 }
 
@@ -279,7 +293,11 @@ void IdasIntegrator::initialize(double t0, FuncEval& func)
         }
     }
 
-    flag = IDASetErrHandlerFn(m_ida_mem, &ida_err, this);
+    #if CT_SUNDIALS_VERSION >= 70
+        flag = SUNContext_PushErrHandler(m_sundials_ctx.get(), &sundials_err, this);
+    #else
+        flag = IDASetErrHandlerFn(m_ida_mem, &ida_err, this);
+    #endif
 
     // set constraints
     flag = IDASetId(m_ida_mem, m_constraints);
@@ -361,7 +379,7 @@ void IdasIntegrator::applyOptions()
         #endif
     } else if (m_type == "GMRES") {
         #if CT_SUNDIALS_VERSION >= 60
-            m_linsol = SUNLinSol_SPGMR(m_y, PREC_NONE, 0, m_sundials_ctx.get());
+            m_linsol = SUNLinSol_SPGMR(m_y, SUN_PREC_NONE, 0, m_sundials_ctx.get());
             IDASetLinearSolver(m_ida_mem, (SUNLinearSolver) m_linsol, nullptr);
         #elif CT_SUNDIALS_VERSION >= 40
             m_linsol = SUNLinSol_SPGMR(m_y, PREC_NONE, 0);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This PR adds compatibility with Sundials 7.0 which introduces a couple of breaking changes. Specifically:

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Changes to the signature of `SUNContext_Create`
- Changes to the signature of error handling callback functions
- The addition of the `sundials_core` library that needs to be linked for any Sundials usage
- Removal of some previously-deprecated typedefs (such as `realtype`) and headers (such as `cvodes_direct.h`)

~~Currently, this is not tested as part of CI since there are no conda-forge packages for the release candidate. I figure we can wait and merge this after the full release when those packages are available.~~

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
