### PR TITLE
Remove/deprecate legacy Solution handling

### DIFF
--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -63,11 +63,7 @@ extern "C" {
     CANTERA_CAPI int wall_new(const char* type);
     CANTERA_CAPI int wall_del(int i);
     CANTERA_CAPI int wall_install(int i, int n, int m);
-    //! @deprecated Only used by traditional MATLAB toolbox
-    CANTERA_CAPI double wall_vdot(int i, double t);
     CANTERA_CAPI double wall_expansionRate(int i);
-    //! @deprecated Only used by traditional MATLAB toolbox
-    CANTERA_CAPI double wall_Q(int i, double t);
     CANTERA_CAPI double wall_heatRate(int i);
     CANTERA_CAPI double wall_area(int i);
     CANTERA_CAPI int wall_setArea(int i, double v);

--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -14,14 +14,14 @@
 extern "C" {
 #endif
 
-    CANTERA_CAPI int reactor_new(const char* type);  //! @deprecated: remove after 3.1
+    CANTERA_CAPI int reactor_new(const char* type);  //!< @deprecated: remove after 3.1
     CANTERA_CAPI int reactor_new3(const char* type, int n, const char* name);
     CANTERA_CAPI int reactor_del(int i);
     CANTERA_CAPI int reactor_setInitialVolume(int i, double v);
     CANTERA_CAPI int reactor_setChemistry(int i, int cflag);
     CANTERA_CAPI int reactor_setEnergy(int i, int eflag);
-    CANTERA_CAPI int reactor_setThermoMgr(int i, int n);
-    CANTERA_CAPI int reactor_setKineticsMgr(int i, int n);
+    CANTERA_CAPI int reactor_setThermoMgr(int i, int n);  //!< @deprecated: remove after 3.1
+    CANTERA_CAPI int reactor_setKineticsMgr(int i, int n);  //!< @deprecated: remove after 3.1
     CANTERA_CAPI int reactor_insert(int i, int n);
     CANTERA_CAPI double reactor_mass(int i);
     CANTERA_CAPI double reactor_volume(int i);

--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -30,8 +30,6 @@ public:
 
     string componentName(size_t k) override;
 
-    void setThermoMgr(ThermoPhase& thermo) override;
-
     void getState(double* y) override;
 
     void initialize(double t0=0.0) override;
@@ -50,6 +48,8 @@ public:
     bool preconditionerSupported() const override { return true; };
 
 protected:
+    void setThermo(ThermoPhase& thermo) override;
+
     vector<double> m_hk; //!< Species molar enthalpies
 };
 

--- a/include/cantera/zeroD/IdealGasConstPressureReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureReactor.h
@@ -28,8 +28,6 @@ public:
         return "IdealGasConstPressureReactor";
     }
 
-    void setThermoMgr(ThermoPhase& thermo) override;
-
     void getState(double* y) override;
 
     void initialize(double t0=0.0) override;
@@ -45,6 +43,8 @@ public:
     string componentName(size_t k) override;
 
 protected:
+    void setThermo(ThermoPhase& thermo) override;
+
     vector<double> m_hk; //!< Species molar enthalpies
 };
 }

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -30,8 +30,6 @@ public:
 
     string componentName(size_t k) override;
 
-    void setThermoMgr(ThermoPhase& thermo) override;
-
     void getState(double* y) override;
 
     void initialize(double t0=0.0) override;
@@ -50,6 +48,8 @@ public:
     bool preconditionerSupported() const override {return true;};
 
 protected:
+    void setThermo(ThermoPhase& thermo) override;
+
     vector<double> m_uk; //!< Species molar internal energies
 };
 

--- a/include/cantera/zeroD/IdealGasReactor.h
+++ b/include/cantera/zeroD/IdealGasReactor.h
@@ -26,8 +26,6 @@ public:
         return "IdealGasReactor";
     }
 
-    void setThermoMgr(ThermoPhase& thermo) override;
-
     void getState(double* y) override;
 
     void initialize(double t0=0.0) override;
@@ -44,6 +42,8 @@ public:
     string componentName(size_t k) override;
 
 protected:
+    void setThermo(ThermoPhase& thermo) override;
+
     vector<double> m_uk; //!< Species molar internal energies
 };
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -74,13 +74,11 @@ public:
     template<class G>
     void insert(G& contents) {
         warn_deprecated("Reactor::insert", "Unused; to be removed after Cantera 3.1.");
-        setThermoMgr(contents);
-        setKineticsMgr(contents);
+        setThermo(contents);
+        setKinetics(contents);
     }
 
     using ReactorBase::insert;
-
-    void setKineticsMgr(Kinetics& kin) override;
 
     void setChemistry(bool cflag=true) override {
         m_chem = cflag;
@@ -244,6 +242,8 @@ public:
     virtual bool preconditionerSupported() const {return false;};
 
 protected:
+    void setKinetics(Kinetics& kin) override;
+
     //! Return the index in the solution vector for this reactor of the species
     //! named *nm*, in either the homogeneous phase or a surface phase, relative
     //! to the start of the species terms. Used to implement componentIndex for

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -95,17 +95,11 @@ public:
     //! Specify the mixture contained in the reactor. Note that a pointer to
     //! this substance is stored, and as the integration proceeds, the state of
     //! the substance is modified.
-    //! @since After %Cantera 3.1, this method will be become a 'protected' method for
-    //! internal use only.
-    //! @todo make protected
-    virtual void setThermoMgr(ThermoPhase& thermo);
+    //! @deprecated To be removed after %Cantera 3.1. Superseded by setSolution.
+    void setThermoMgr(ThermoPhase& thermo);
 
-    //! @since After %Cantera 3.1, this method will be become a 'protected' method for
-    //! internal use only.
-    //! @todo make protected
-    virtual void setKineticsMgr(Kinetics& kin) {
-        throw NotImplementedError("ReactorBase::setKineticsMgr");
-    }
+    //! @deprecated To be removed after %Cantera 3.1. Superseded by setSolution.
+    void setKineticsMgr(Kinetics& kin);
 
     //! Enable or disable changes in reactor composition due to chemical reactions.
     virtual void setChemistry(bool cflag = true) {
@@ -284,6 +278,18 @@ public:
     void setNetwork(ReactorNet* net);
 
 protected:
+    //! Specify the mixture contained in the reactor. Note that a pointer to
+    //! this substance is stored, and as the integration proceeds, the state of
+    //! the substance is modified.
+    //! @since New in %Cantera 3.1.
+    virtual void setThermo(ThermoPhase& thermo);
+
+    //! Specify the kinetics manager for the reactor. Called by setSolution().
+    //! @since New in %Cantera 3.1.
+    virtual void setKinetics(Kinetics& kin) {
+        throw NotImplementedError("ReactorBase::setKinetics");
+    }
+
     //! Number of homogeneous species in the mixture
     size_t m_nsp = 0;
 

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -30,7 +30,7 @@ public:
     void insert(ThermoPhase& contents) {
         warn_deprecated("Reservoir::insert",
             "Unused; to be removed after Cantera 3.1.");
-        setThermoMgr(contents);
+        setThermo(contents);
     }
 
     using ReactorBase::insert;

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -33,18 +33,6 @@ public:
         return "WallBase";
     }
 
-    //! Rate of volume change (m^3/s) for the adjacent reactors.
-    /*!
-     * This method is called by Reactor::evalWalls(). Base class method
-     * does nothing (that is, constant volume), but may be overloaded.
-     * @deprecated Still used by traditional MATLAB toolbox; replaceable by expansionRate.
-     */
-    virtual double vdot(double t) {
-        warn_deprecated("WallBase::vdot",
-            "To be removed; replaceable by 'expansionRate'.");
-        return 0.0;
-    }
-
     //! Rate of volume change (m^3/s) for the adjacent reactors at current reactor
     //! network time.
     /*!
@@ -53,18 +41,6 @@ public:
      * @since New in %Cantera 3.0.
      */
     virtual double expansionRate() {
-        return 0.0;
-    }
-
-    //! Heat flow rate through the wall (W).
-    /*!
-     * This method is called by Reactor::evalWalls(). Base class method
-     * does nothing (that is, an adiabatic wall), but may be overloaded.
-     * @deprecated Still used by traditional MATLAB toolbox; replaceable by heatRate.
-     */
-    virtual double Q(double t) {
-        warn_deprecated("WallBase::Q",
-            "To be removed; replaceable by 'heatRate'.");
         return 0.0;
     }
 
@@ -159,21 +135,6 @@ public:
      * @f[
      *     \dot V = K A (P_{left} - P_{right}) + F(t)
      * @f]
-     * where *K* is the specified expansion rate coefficient, *A* is the wall
-     * area, and *F(t)* is a specified function of time. Positive values for
-     * `vdot` correspond to increases in the volume of reactor on left, and
-     * decreases in the volume of the reactor on the right.
-     * @deprecated Still used by traditional MATLAB toolbox; replaceable by
-     *      expansionRate.
-     */
-    double vdot(double t) override;
-
-    //! Rate of volume change (m^3/s) for the adjacent reactors.
-    /*!
-     * The volume rate of change is given by
-     * @f[
-     *     \dot V = K A (P_{left} - P_{right}) + F(t)
-     * @f]
      * where *K* is the specified expansion rate coefficient, *A* is the wall area,
      * and and *F(t)* is a specified function evaluated at the current network time.
      * Positive values for `expansionRate` correspond to increases in the volume of
@@ -190,19 +151,6 @@ public:
     void setHeatFlux(Func1* q) {
         m_qf = q;
     }
-
-    //! Heat flow rate through the wall (W).
-    /*!
-     * The heat flux is given by
-     * @f[
-     *     Q = h A (T_{left} - T_{right}) + A G(t)
-     * @f]
-     * where *h* is the heat transfer coefficient, *A* is the wall area, and
-     * *G(t)* is a specified function of time. Positive values denote a flux
-     * from left to right.
-     * @deprecated Still used by traditional MATLAB toolbox; replaceable by heatRate.
-     */
-    double Q(double t) override;
 
     //! Heat flow rate through the wall (W).
     /*!

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -31,6 +31,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
 
     # factories
     cdef shared_ptr[CxxReactorBase] newReactor(string) except +translate_exception
+    cdef shared_ptr[CxxReactorBase] newReactor(string, shared_ptr[CxxSolution], string) except +translate_exception
     cdef shared_ptr[CxxFlowDevice] newFlowDevice(string) except +translate_exception
     cdef shared_ptr[CxxWallBase] newWall(string) except +translate_exception
 

--- a/samples/clib/demo.c
+++ b/samples/clib/demo.c
@@ -87,10 +87,8 @@ int main(int argc, char** argv)
     thermo_print(thermo, 1, 1e-6);
 
     printf("\ntime       Temperature\n");
-    int reactor = reactor_new("IdealGasReactor");
+    int reactor = reactor_new3("IdealGasReactor", soln, "test");
     int net = reactornet_new();
-    reactor_setThermoMgr(reactor, thermo);
-    reactor_setKineticsMgr(reactor, kin);
     reactornet_addreactor(net, reactor);
 
     double t = 0.0;

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -494,28 +494,10 @@ extern "C" {
         }
     }
 
-    double wall_vdot(int i, double t)
-    {
-        try {
-            return WallCabinet::item(i).vdot(t);
-        } catch (...) {
-            return handleAllExceptions(DERR, DERR);
-        }
-    }
-
     double wall_expansionRate(int i)
     {
         try {
             return WallCabinet::item(i).expansionRate();
-        } catch (...) {
-            return handleAllExceptions(DERR, DERR);
-        }
-    }
-
-    double wall_Q(int i, double t)
-    {
-        try {
-            return WallCabinet::item(i).Q(t);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -52,7 +52,7 @@ extern "C" {
     int reactor_new3(const char* type, int n, const char* name)
     {
         try {
-            return ReactorCabinet::add(newReactor(type, SolutionCabinet::at(n)));
+            return ReactorCabinet::add(newReactor(type, SolutionCabinet::at(n), name));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -17,13 +17,13 @@
 namespace Cantera
 {
 
-void IdealGasConstPressureMoleReactor::setThermoMgr(ThermoPhase& thermo)
+void IdealGasConstPressureMoleReactor::setThermo(ThermoPhase& thermo)
 {
     if (thermo.type() != "ideal-gas") {
-        throw CanteraError("IdealGasConstPressureMoleReactor::setThermoMgr",
+        throw CanteraError("IdealGasConstPressureMoleReactor::setThermo",
                            "Incompatible phase type provided");
     }
-    ConstPressureMoleReactor::setThermoMgr(thermo);
+    ConstPressureMoleReactor::setThermo(thermo);
 }
 
 void IdealGasConstPressureMoleReactor::getState(double* y)

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -13,15 +13,15 @@
 namespace Cantera
 {
 
-void IdealGasConstPressureReactor::setThermoMgr(ThermoPhase& thermo)
+void IdealGasConstPressureReactor::setThermo(ThermoPhase& thermo)
 {
     //! @todo: Add a method to ThermoPhase that indicates whether a given
     //! subclass is compatible with this reactor model
     if (thermo.type() != "ideal-gas") {
-        throw CanteraError("IdealGasConstPressureReactor::setThermoMgr",
+        throw CanteraError("IdealGasConstPressureReactor::setThermo",
                            "Incompatible phase type provided");
     }
-    Reactor::setThermoMgr(thermo);
+    Reactor::setThermo(thermo);
 }
 
 void IdealGasConstPressureReactor::getState(double* y)

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -17,13 +17,13 @@
 namespace Cantera
 {
 
-void IdealGasMoleReactor::setThermoMgr(ThermoPhase& thermo)
+void IdealGasMoleReactor::setThermo(ThermoPhase& thermo)
 {
     if (thermo.type() != "ideal-gas") {
-        throw CanteraError("IdealGasMoleReactor::setThermoMgr",
+        throw CanteraError("IdealGasMoleReactor::setThermo",
                            "Incompatible phase type provided");
     }
-    MoleReactor::setThermoMgr(thermo);
+    MoleReactor::setThermo(thermo);
 }
 
 void IdealGasMoleReactor::getState(double* y)

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -13,15 +13,15 @@
 namespace Cantera
 {
 
-void IdealGasReactor::setThermoMgr(ThermoPhase& thermo)
+void IdealGasReactor::setThermo(ThermoPhase& thermo)
 {
     //! @todo: Add a method to ThermoPhase that indicates whether a given
     //! subclass is compatible with this reactor model
     if (thermo.type() != "ideal-gas") {
-        throw CanteraError("IdealGasReactor::setThermoMgr",
+        throw CanteraError("IdealGasReactor::setThermo",
                            "Incompatible phase type provided");
     }
-    Reactor::setThermoMgr(thermo);
+    Reactor::setThermo(thermo);
 }
 
 void IdealGasReactor::getState(double* y)

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -26,8 +26,8 @@ Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
 {
     m_solution = sol;
     m_name = name;
-    setThermoMgr(*sol->thermo());
-    setKineticsMgr(*sol->kinetics());
+    setThermo(*sol->thermo());
+    setKinetics(*sol->kinetics());
 }
 
 void Reactor::setDerivativeSettings(AnyMap& settings)
@@ -39,7 +39,7 @@ void Reactor::setDerivativeSettings(AnyMap& settings)
     }
 }
 
-void Reactor::setKineticsMgr(Kinetics& kin)
+void Reactor::setKinetics(Kinetics& kin)
 {
     m_kin = &kin;
     if (m_kin->nReactions() == 0) {

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -26,9 +26,9 @@ ReactorBase::ReactorBase(shared_ptr<Solution> sol, const string& name)
 
 void ReactorBase::setSolution(shared_ptr<Solution> sol) {
     m_solution = sol;
-    setThermoMgr(*sol->thermo());
+    setThermo(*sol->thermo());
     try {
-        setKineticsMgr(*sol->kinetics());
+        setKinetics(*sol->kinetics());
     } catch (NotImplementedError&) {
         // kinetics not used (example: Reservoir)
     }
@@ -41,7 +41,7 @@ void ReactorBase::insert(shared_ptr<Solution> sol)
     setSolution(sol);
 }
 
-void ReactorBase::setThermoMgr(ThermoPhase& thermo)
+void ReactorBase::setThermo(ThermoPhase& thermo)
 {
     m_thermo = &thermo;
     m_nsp = m_thermo->nSpecies();
@@ -49,6 +49,20 @@ void ReactorBase::setThermoMgr(ThermoPhase& thermo)
     m_enthalpy = m_thermo->enthalpy_mass();
     m_intEnergy = m_thermo->intEnergy_mass();
     m_pressure = m_thermo->pressure();
+}
+
+void ReactorBase::setThermoMgr(ThermoPhase& thermo)
+{
+    warn_deprecated("ReactorBase::setThermoMgr",
+        "To be removed after Cantera 3.1. Superseded by 'setSolution'.");
+    setThermo(thermo);
+}
+
+void ReactorBase::setKineticsMgr(Kinetics& kin)
+{
+    warn_deprecated("ReactorBase::setKineticsMgr",
+        "To be removed after Cantera 3.1. Superseded by 'setSolution'.");
+    setKinetics(kin);
 }
 
 void ReactorBase::syncState()

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -68,7 +68,9 @@ void ReactorFactory::deleteFactory() {
 
 shared_ptr<ReactorBase> newReactor(const string& model)
 {
-    // deprecation warning is handled in Python API
+    warn_deprecated("newReactor",
+        "Creation of empty reactor objects is deprecated in Cantera 3.1 and will be \n"
+        "removed thereafter; reactor contents should be provided in the constructor.");
     return shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model));
 }
 

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -34,21 +34,6 @@ double Wall::velocity() const {
     return 0.;
 }
 
-double Wall::vdot(double t)
-{
-    warn_deprecated("Wall::vdot", "To be removed; replaceable by 'expansionRate'.");
-    if (!ready()) {
-        throw CanteraError("Wall::vdot",
-                           "Wall is not ready; some parameters have not been set.");
-    }
-    double rate = m_k * m_area * (m_left->pressure() - m_right->pressure());
-
-    if (m_vf) {
-        rate += m_area * m_vf->eval(t);
-    }
-    return rate;
-}
-
 double Wall::expansionRate()
 {
     if (!ready()) {
@@ -68,27 +53,6 @@ double Wall::heatFlux() const {
         return m_qf->eval(m_time);
     }
     return 0.;
-}
-
-double Wall::Q(double t)
-{
-    warn_deprecated("Wall::Q", "To be removed; replaceable by 'heatRate'.");
-    if (!ready()) {
-        throw CanteraError("Wall::Q",
-                           "Wall is not ready; some parameters have not been set.");
-    }
-    double q1 = (m_area * m_rrth) *
-                (m_left->temperature() - m_right->temperature());
-    if (m_emiss > 0.0) {
-        double tl = m_left->temperature();
-        double tr = m_right->temperature();
-        q1 += m_emiss * m_area * StefanBoltz * (tl*tl*tl*tl - tr*tr*tr*tr);
-    }
-
-    if (m_qf) {
-        q1 += m_area * m_qf->eval(t);
-    }
-    return q1;
 }
 
 double Wall::heatRate()

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -20,9 +20,9 @@ TEST(ctreactor, reactor_objects)
     int thermo = thermo_newFromFile("gri30.yaml", "gri30");
     int kin = kin_newFromFile("gri30.yaml", "", thermo, -1, -1, -1, -1);
 
+    suppress_deprecation_warnings();
     int reactor = reactor_new("IdealGasReactor");
     ASSERT_GE(reactor, 0);
-    suppress_deprecation_warnings();
     int ret = reactor_setThermoMgr(reactor, thermo);
     ASSERT_EQ(ret, 0);
     ret = reactor_setKineticsMgr(reactor, kin);
@@ -76,8 +76,8 @@ TEST(ctreactor, reactor_insert)
     thermo_setTemperature(thermo, T);
     thermo_setPressure(thermo, P);
 
-    int reactor = reactor_new("IdealGasReactor");
     suppress_deprecation_warnings();
+    int reactor = reactor_new("IdealGasReactor");
     int ret = reactor_insert(reactor, sol);
     make_deprecation_warnings_fatal();
     ASSERT_EQ(ret, 0);
@@ -109,8 +109,8 @@ TEST(ctreactor, reactor_from_parts)
     thermo_setTemperature(thermo, T);
     thermo_setPressure(thermo, P);
 
-    int reactor = reactor_new("IdealGasReactor");
     suppress_deprecation_warnings();
+    int reactor = reactor_new("IdealGasReactor");
     reactor_setThermoMgr(reactor, thermo);
     reactor_setKineticsMgr(reactor, kin);
     make_deprecation_warnings_fatal();

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -8,6 +8,13 @@
 
 using namespace Cantera;
 
+TEST(ctreactor, reactor_soln)
+{
+    int sol = soln_newSolution("gri30.yaml", "gri30", "none");
+    int reactor = reactor_new3("IdealGasReactor", sol, "test");
+    ASSERT_EQ(reactor, 0);
+}
+
 TEST(ctreactor, reactor_objects)
 {
     int thermo = thermo_newFromFile("gri30.yaml", "gri30");
@@ -15,10 +22,12 @@ TEST(ctreactor, reactor_objects)
 
     int reactor = reactor_new("IdealGasReactor");
     ASSERT_GE(reactor, 0);
+    suppress_deprecation_warnings();
     int ret = reactor_setThermoMgr(reactor, thermo);
     ASSERT_EQ(ret, 0);
     ret = reactor_setKineticsMgr(reactor, kin);
     ASSERT_EQ(ret, 0);
+    make_deprecation_warnings_fatal();
 }
 
 vector<double> T_ctreactor = {
@@ -101,8 +110,10 @@ TEST(ctreactor, reactor_from_parts)
     thermo_setPressure(thermo, P);
 
     int reactor = reactor_new("IdealGasReactor");
+    suppress_deprecation_warnings();
     reactor_setThermoMgr(reactor, thermo);
     reactor_setKineticsMgr(reactor, kin);
+    make_deprecation_warnings_fatal();
     int net = reactornet_new();
     int ret = reactornet_addreactor(net, reactor);
     ASSERT_EQ(ret, 0);

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -4,7 +4,7 @@ import re
 import numpy as np
 import pytest
 from pytest import approx
-from .utilities import unittest
+from .utilities import unittest, allow_deprecated
 
 import cantera as ct
 
@@ -52,9 +52,9 @@ class TestReactor(utilities.CanteraTest):
         self.net.verbose = True
         self.assertTrue(self.net.verbose)
 
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_insert(self):
-        with pytest.warns(DeprecationWarning, match="must not be empty"):
-            R = self.reactorClass()
+        R = self.reactorClass()  # warning raised from C++ code
         with self.assertRaisesRegex(ct.CanteraError, 'No phase'):
             R.T
         with self.assertRaisesRegex(ct.CanteraError, 'No phase'):
@@ -692,9 +692,10 @@ class TestReactor(utilities.CanteraTest):
         assert valve.pressure_function == approx(delta_p())
         assert valve.mass_flow_rate == approx(mdot())
 
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_valve_errors(self):
         self.make_reactors()
-        res = ct.Reservoir()
+        res = ct.Reservoir()  # warning raised from C++ code
 
         with self.assertRaisesRegex(ct.CanteraError, 'contents not defined'):
             # Must assign contents of both reactors before creating Valve
@@ -857,8 +858,8 @@ class TestReactor(utilities.CanteraTest):
     def test_bad_kwarg(self):
         g = ct.Solution('h2o2.yaml', transport_model=None)
         self.reactorClass(g, name='ok')
-        with self.assertRaises(TypeError):
-            r1 = self.reactorClass(foobar=3.14)
+        with self.assertRaises(ct.CanteraError):
+            self.reactorClass(foobar=3.14)
 
     def test_preconditioner_unsupported(self):
         self.make_reactors()

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -48,10 +48,6 @@ TEST(zerodim, test_guards)
     Wall wall;
     EXPECT_THROW(wall.heatRate(), CanteraError);
     EXPECT_THROW(wall.expansionRate(), CanteraError);
-    suppress_deprecation_warnings();
-    EXPECT_THROW(wall.Q(0.), CanteraError);
-    EXPECT_THROW(wall.vdot(0.), CanteraError);
-    make_deprecation_warnings_fatal();
 
     // FlowDevice with no adjacent reactors
     EXPECT_THROW(FlowDevice().massFlowRate(), CanteraError);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Removal of legacy MATLAB toolbox #1670 allows for some simplifications / deprecations:

- Remove remaining legacy wall methods from CAPI and C++
- Deprecate `setThermoMgr`/`setKineticsMgr` for 0D
- Move deprecation warning for empty reactor objects from Python to C++

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Partially addresses #1457

_A clean resolution of #1457 will require pushing the Python `_WeakrefProxy` approach to the C++ layer?_

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
