### PR TITLE
Implement ThermoPhase species locks in C++

### DIFF
--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -39,7 +39,7 @@ private:
     SolutionArray(const SolutionArray& arr, const vector<int>& indices);
 
 public:
-    virtual ~SolutionArray() {}
+    virtual ~SolutionArray();
 
     /**
      *  Instantiate a new SolutionArray reference.

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -65,7 +65,7 @@ public:
 
     //! Destructor. Does nothing. Class MultiPhase does not take "ownership"
     //! (that is, responsibility for destroying) the phase objects.
-    virtual ~MultiPhase() = default;
+    virtual ~MultiPhase();
 
     //! Add a vector of phases to the mixture
     /*!

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -186,7 +186,7 @@ public:
     Empty1D() = default;
 
     Empty1D(shared_ptr<Solution> solution, const string& id="") : Empty1D() {
-        m_solution = solution;
+        setSolution(solution);
         m_id = id;
     }
 
@@ -213,7 +213,7 @@ public:
     Symm1D() = default;
 
     Symm1D(shared_ptr<Solution> solution, const string& id="") : Symm1D() {
-        m_solution = solution;
+        setSolution(solution);
         m_id = id;
     }
 
@@ -239,7 +239,7 @@ public:
     Outlet1D() = default;
 
     Outlet1D(shared_ptr<Solution> solution, const string& id="") : Outlet1D() {
-        m_solution = solution;
+        setSolution(solution);
         m_id = id;
     }
 
@@ -305,7 +305,7 @@ public:
     Surf1D() = default;
 
     Surf1D(shared_ptr<Solution> solution, const string& id="") : Surf1D() {
-        m_solution = solution;
+        setSolution(solution);
         m_id = id;
     }
 

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -60,9 +60,7 @@ public:
 
     //! Set the solution manager.
     //! @since New in %Cantera 3.0.
-    void setSolution(shared_ptr<Solution> sol) {
-        m_solution = sol;
-    }
+    void setSolution(shared_ptr<Solution> sol);
 
     //! Set the kinetics manager.
     //! @since New in %Cantera 3.0.
@@ -408,7 +406,7 @@ public:
     void linkLeft(Domain1D* left) {
         m_left = left;
         if (!m_solution && left && left->solution()) {
-            m_solution = left->solution();
+            setSolution(left->solution());
         }
         locate();
     }
@@ -417,7 +415,7 @@ public:
     void linkRight(Domain1D* right) {
         m_right = right;
         if (!m_solution && right && right->solution()) {
-            m_solution = right->solution();
+            setSolution(right->solution());
         }
     }
 

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -713,6 +713,18 @@ public:
     //!     @param alias alternate name
     void addSpeciesAlias(const string& name, const string& alias);
 
+    //! Lock species list to prevent addition of new species.
+    //! Increments a reference counter used to track whether the Phase is being used by
+    //! a Reactor, Domain1D, or MultiPhase object, which require the number of species
+    //! to remain constant. Should be called in C++ by the object owning the reference.
+    void addSpeciesLock() {
+        m_nSpeciesLocks++;
+    }
+
+    //! Decrement species lock counter.
+    //! Should only be called in C++ by the object owning the reference.
+    void removeSpeciesLock();
+
     //! Return a vector with isomers names matching a given composition map
     //!     @param compMap Composition of the species.
     //!     @return A vector of species names for matching species.
@@ -852,7 +864,9 @@ protected:
 
     vector<double> m_speciesCharge; //!< Vector of species charges. length m_kk.
 
-    map<string, shared_ptr<Species>> m_species;
+    map<string, shared_ptr<Species>> m_species; //!< Map of Species objects
+
+    size_t m_nSpeciesLocks = 0; //!< Reference counter preventing species addition
 
     //! Flag determining behavior when adding species with an undefined element
     UndefElement::behavior m_undefinedElementBehavior = UndefElement::add;

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -56,7 +56,7 @@ public:
     //! @param name  Name of the reactor.
     //! @since New in %Cantera 3.1.
     ReactorBase(shared_ptr<Solution> sol, const string& name = "(none)");
-    virtual ~ReactorBase() = default;
+    virtual ~ReactorBase();
     ReactorBase(const ReactorBase&) = delete;
     ReactorBase& operator=(const ReactorBase&) = delete;
 

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -153,7 +153,6 @@ cdef class Domain1D:
     cdef shared_ptr[CxxDomain1D] _domain
     cdef CxxDomain1D* domain
     cdef _SolutionBase gas
-    cdef object _weakref_proxy
     cdef public pybool have_user_tolerances
 
 cdef class Boundary1D(Domain1D):

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -9,23 +9,16 @@ from ._utils cimport stringify, pystr, anymap_to_py
 from ._utils import CanteraError
 from cython.operator import dereference as deref
 
-# Need a pure-python class to store weakrefs to
-class _WeakrefProxy:
-    pass
-
 cdef class Domain1D:
     _domain_type = "none"
     def __cinit__(self, _SolutionBase phase not None, *args, **kwargs):
         self.domain = NULL
 
     def __init__(self, phase, *args, **kwargs):
-        self._weakref_proxy = _WeakrefProxy()
         if self.domain is NULL:
             raise TypeError("Can't instantiate abstract class Domain1D.")
 
         self.gas = phase
-        # Block species from being added to the phase as long as this object exists
-        self.gas._references[self._weakref_proxy] = True
         self.set_default_tolerances()
 
     property phase:
@@ -424,7 +417,6 @@ cdef class ReactingSurface1D(Boundary1D):
     _domain_type = "reacting-surface"
 
     def __init__(self, _SolutionBase phase, name=None):
-        self._weakref_proxy = _WeakrefProxy()
         gas = None
         for val in phase._adjacent.values():
             if val.phase_of_matter == "gas":
@@ -435,8 +427,6 @@ cdef class ReactingSurface1D(Boundary1D):
         super().__init__(gas, name=name)
 
         self.surface = phase
-        # Block species from being added to the phase as long as this object exists
-        self.surface._references[self._weakref_proxy] = True
 
     property phase:
         """

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -142,6 +142,11 @@ class DustyGas(DustyGasTransport, Kinetics, ThermoPhase):
     __slots__ = ()
 
 
+# A pure-Python class to store weakrefs to
+class _WeakrefProxy:
+    pass
+
+
 class Quantity:
     """
     A class representing a specific quantity of a `Solution`. In addition to the
@@ -382,11 +387,6 @@ for _attr in dir(Solution):
             setattr(Quantity, _attr, _prop(_attr))
 
 
-# A pure-Python class to store weakrefs to
-class _WeakrefProxy:
-    pass
-
-
 class SolutionArray(SolutionArrayBase):
     """
     A class providing a convenient interface for representing many thermodynamic
@@ -583,8 +583,6 @@ class SolutionArray(SolutionArrayBase):
 
     def __init__(self, phase, shape=(0,), states=None, extra=None, meta={}, init=True):
         self._phase = phase
-        self._weakref_proxy = _WeakrefProxy()
-        phase._references[self._weakref_proxy] = True
         if not init:
             return
 

--- a/interfaces/cython/cantera/mixture.pxd
+++ b/interfaces/cython/cantera/mixture.pxd
@@ -52,5 +52,4 @@ cdef extern from "cantera/equil/MultiPhase.h" namespace "Cantera":
 cdef class Mixture:
     cdef CxxMultiPhase* mix
     cdef list _phases
-    cdef object _weakref_proxy
     cpdef int element_index(self, element) except *

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -8,10 +8,6 @@ from .solutionbase cimport *
 from .thermo cimport *
 from ._utils cimport *
 
-# Need a pure-python class to store weakrefs to
-class _WeakrefProxy:
-    pass
-
 cdef class Mixture:
     """
 
@@ -44,7 +40,6 @@ cdef class Mixture:
     def __cinit__(self, phases):
         self.mix = new CxxMultiPhase()
         self._phases = []
-        self._weakref_proxy = _WeakrefProxy()
 
         cdef _SolutionBase phase
         if isinstance(phases[0], _SolutionBase):
@@ -53,7 +48,6 @@ cdef class Mixture:
 
         for phase,moles in phases:
             # Block species from being added to the phase as long as this object exists
-            phase._references[self._weakref_proxy] = True
             self.mix.addPhase(phase.thermo, moles)
             self._phases.append(phase)
 

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -222,7 +222,6 @@ cdef class ReactorBase:
     cdef list _outlets
     cdef list _walls
     cdef list _surfaces
-    cdef object _weakref_proxy
     cdef public dict node_attr
     """
     A dictionary containing draw attributes for the representation of the reactor as a

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -14,10 +14,6 @@ from .drawnetwork import *
 
 _reactor_counts = _defaultdict(int)
 
-# Need a pure-python class to store weakrefs to
-class _WeakrefProxy:
-    pass
-
 cdef class ReactorBase:
     """
     Common base class for reactors and reservoirs.
@@ -29,8 +25,6 @@ cdef class ReactorBase:
 
     def __init__(self, _SolutionBase contents=None, name=None, *, volume=None,
                  node_attr=None):
-
-        self._weakref_proxy = _WeakrefProxy()
         self._inlets = []
         self._outlets = []
         self._walls = []
@@ -60,8 +54,6 @@ cdef class ReactorBase:
         properties and kinetic rates for this reactor.
         """
         self._thermo = solution
-        # Block species from being added to the phase as long as this object exists
-        self._thermo._references[self._weakref_proxy] = True
         self.rbase.setSolution(solution._base)
 
     property type:

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -122,4 +122,3 @@ cdef class _SolutionBase:
 cdef class SolutionArrayBase:
     cdef shared_ptr[CxxSolutionArray] _base
     cdef CxxSolutionArray* base
-    cdef public object _weakref_proxy

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -270,10 +270,9 @@ cdef class ThermoPhase(_SolutionBase):
         # In composite objects, the ThermoPhase constructor needs to be called first
         # to prevent instantiation of stand-alone 'Kinetics' or 'Transport' objects.
         # The following is used as a sentinel. After initialization, the _references
-        # object is used to track whether the ThermoPhase is being used by a `Reactor`,
-        # `Domain1D`, or `Mixture` object and to prevent species from being added to the
-        # ThermoPhase if so, since these objects require the number of species to remain
-        # constant.
+        # object is used to track whether the ThermoPhase is being used by other
+        # objects that require the number of species to remain constant and do not
+        # have C++ implementations (e.g. Quantity objects).
         self._references = weakref.WeakKeyDictionary()
         # validate plasma phase
         self._enable_plasma = False
@@ -583,8 +582,7 @@ cdef class ThermoPhase(_SolutionBase):
         """
         if self._references:
             raise CanteraError('Cannot add species to ThermoPhase object because it'
-                ' is being used by another object,\nsuch as a Reactor, Domain1D (flame),'
-                ' SolutionArray, Quantity, or Mixture object.')
+                ' is being used by a Quantity object.')
         self.thermo.addUndefinedElements()
         self.thermo.addSpecies(species._species)
         species._phase = self

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -20,6 +20,13 @@ using namespace std;
 namespace Cantera
 {
 
+MultiPhase::~MultiPhase()
+{
+    for (size_t i = 0; i < m_phase.size(); i++) {
+        m_phase[i]->removeSpeciesLock();
+    }
+}
+
 void MultiPhase::addPhases(MultiPhase& mix)
 {
     for (size_t n = 0; n < mix.nPhases(); n++) {
@@ -101,6 +108,9 @@ void MultiPhase::addPhase(ThermoPhase* p, double moles)
         m_Tmin = std::max(p->minTemp(), m_Tmin);
         m_Tmax = std::min(p->maxTemp(), m_Tmax);
     }
+
+    // lock species list
+    p->addSpeciesLock();
 }
 
 void MultiPhase::init()

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -90,7 +90,7 @@ Inlet1D::Inlet1D()
 Inlet1D::Inlet1D(shared_ptr<Solution> solution, const string& id)
     : Inlet1D()
 {
-    m_solution = solution;
+    setSolution(solution);
     m_id = id;
 }
 
@@ -351,7 +351,7 @@ OutletRes1D::OutletRes1D()
 OutletRes1D::OutletRes1D(shared_ptr<Solution> solution, const string& id)
     : OutletRes1D()
 {
-    m_solution = solution;
+    setSolution(solution);
     m_id = id;
 }
 
@@ -591,7 +591,7 @@ ReactingSurf1D::ReactingSurf1D(shared_ptr<Solution> solution, const string& id)
             "Detected incompatible kinetics type '{}'",
             solution->kinetics()->kineticsType());
     }
-    m_solution = solution;
+    setSolution(solution);
     m_id = id;
     m_kin = kin.get();
     m_sphase = phase.get();
@@ -601,10 +601,11 @@ ReactingSurf1D::ReactingSurf1D(shared_ptr<Solution> solution, const string& id)
 
 void ReactingSurf1D::setKinetics(shared_ptr<Kinetics> kin)
 {
-    m_solution = Solution::create();
-    m_solution->setThermo(kin->reactionPhase());
-    m_solution->setKinetics(kin);
-    m_solution->setTransportModel("none");
+    auto sol = Solution::create();
+    sol->setThermo(kin->reactionPhase());
+    sol->setKinetics(kin);
+    sol->setTransportModel("none");
+    setSolution(sol);
     m_kin = dynamic_pointer_cast<InterfaceKinetics>(kin).get();
     m_sphase = dynamic_pointer_cast<SurfPhase>(kin->reactionPhase()).get();
     m_nsp = m_sphase->nSpecies();

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -9,7 +9,9 @@
 #include "cantera/oneD/MultiJac.h"
 #include "cantera/oneD/refine.h"
 #include "cantera/base/AnyMap.h"
+#include "cantera/base/Solution.h"
 #include "cantera/base/SolutionArray.h"
+#include "cantera/thermo/ThermoPhase.h"
 
 namespace Cantera
 {
@@ -21,6 +23,22 @@ Domain1D::Domain1D(size_t nv, size_t points, double time)
 
 Domain1D::~Domain1D()
 {
+    if (m_solution) {
+        m_solution->thermo()->removeSpeciesLock();
+    }
+}
+
+void Domain1D::setSolution(shared_ptr<Solution> sol)
+{
+    if (!sol || !(sol->thermo())) {
+        throw CanteraError("Domain1D::setSolution",
+            "Missing or incomplete Solution object.");
+    }
+    if (m_solution) {
+        m_solution->thermo()->removeSpeciesLock();
+    }
+    m_solution = sol;
+    m_solution->thermo()->addSpeciesLock();
 }
 
 void Domain1D::resize(size_t nv, size_t np)

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -56,7 +56,7 @@ IonFlow::IonFlow(ThermoPhase* ph, size_t nsp, size_t points) :
 IonFlow::IonFlow(shared_ptr<Solution> sol, const string& id, size_t points)
     : IonFlow(sol->thermo().get(), sol->thermo()->nSpecies(), points)
 {
-    m_solution = sol;
+    setSolution(sol);
     m_id = id;
     m_kin = m_solution->kinetics().get();
     m_trans = m_solution->transport().get();

--- a/src/oneD/StFlow.cpp
+++ b/src/oneD/StFlow.cpp
@@ -92,14 +92,15 @@ StFlow::StFlow(ThermoPhase* ph, size_t nsp, size_t points) :
 StFlow::StFlow(shared_ptr<ThermoPhase> th, size_t nsp, size_t points)
     : StFlow(th.get(), nsp, points)
 {
-    m_solution = Solution::create();
-    m_solution->setThermo(th);
+    auto sol = Solution::create();
+    sol->setThermo(th);
+    setSolution(sol);
 }
 
 StFlow::StFlow(shared_ptr<Solution> sol, const string& id, size_t points)
     : StFlow(sol->thermo().get(), sol->thermo()->nSpecies(), points)
 {
-    m_solution = sol;
+    setSolution(sol);
     m_id = id;
     m_kin = m_solution->kinetics().get();
     m_trans = m_solution->transport().get();

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -698,7 +698,15 @@ size_t Phase::addElement(const string& symbol, double weight, int atomic_number,
     return m_mm-1;
 }
 
-bool Phase::addSpecies(shared_ptr<Species> spec) {
+bool Phase::addSpecies(shared_ptr<Species> spec)
+{
+    if (m_nSpeciesLocks) {
+        throw CanteraError("Phase::addSpecies",
+                "Cannot add species to ThermoPhase '{}' because it is being "
+                "used by another object,\nsuch as a Reactor, Domain1D (flame), "
+                "SolutionArray, or MultiPhase (Mixture) object.", m_name);
+    }
+
     if (m_species.find(spec->name) != m_species.end()) {
         throw CanteraError("Phase::addSpecies",
             "Phase '{}' already contains a species named '{}'.",
@@ -833,6 +841,15 @@ void Phase::addSpeciesAlias(const string& name, const string& alias)
             "Unable to add alias '{}' "
             "(original species '{}' not found).", alias, name);
     }
+}
+
+void Phase::removeSpeciesLock()
+{
+    if (!m_nSpeciesLocks) {
+        throw CanteraError("Phase::removeSpeciesLock",
+                "ThermoPhase '{}' has no current species locks.", m_name);
+    }
+    m_nSpeciesLocks--;
 }
 
 vector<string> Phase::findIsomers(const Composition& compMap) const

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -24,7 +24,7 @@ namespace Cantera
 
 Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
 {
-    m_solution = sol;
+    setSolution(sol);
     m_name = name;
     setThermoMgr(*sol->thermo());
     setKineticsMgr(*sol->kinetics());

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -24,7 +24,21 @@ ReactorBase::ReactorBase(shared_ptr<Solution> sol, const string& name)
     setSolution(sol);
 }
 
+ReactorBase::~ReactorBase()
+{
+    if (m_solution) {
+        m_solution->thermo()->removeSpeciesLock();
+    }
+}
+
 void ReactorBase::setSolution(shared_ptr<Solution> sol) {
+    if (!sol || !(sol->thermo())) {
+        throw CanteraError("ReactorBase::setSolution",
+            "Missing or incomplete Solution object.");
+    }
+    if (m_solution) {
+        m_solution->thermo()->removeSpeciesLock();
+    }
     m_solution = sol;
     setThermoMgr(*sol->thermo());
     try {
@@ -32,6 +46,7 @@ void ReactorBase::setSolution(shared_ptr<Solution> sol) {
     } catch (NotImplementedError&) {
         // kinetics not used (example: Reservoir)
     }
+    m_solution->thermo()->addSpeciesLock();
 }
 
 void ReactorBase::insert(shared_ptr<Solution> sol)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Move sentinels preventing species addition for `ThermoPhase` objects used by `ReactorBase`, `Domain1D`, `SolutionArray` and `MultiPhase` instances from Python API to C++.

The implementation uses reference counters that should only be used within C++ (and not exposed at interfaces). This allows for most `_WeakrefProxy` sentinels to be be removed in Python. One exception is `Quantity`, which does not have a C++ equivalent.

The approach is relatively simple, and turns out to be independent of migrating various C++ classes to use `Solution`.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1457

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review