### PR TITLE
Remove macOS packaging from workflow

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -71,10 +71,3 @@ jobs:
           -f incoming_ref=${{ env.REF }}
         env:
           GITHUB_TOKEN: ${{ secrets.WINDOWS_MSI_PAT }}
-      - name: Trigger macOS Package Builds
-        run: >
-          gh workflow run -R cantera/cantera-macos-pkg
-          main.yml
-          -f incoming_ref=${{ env.REF }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.MACOS_PKG_PAT }}


### PR DESCRIPTION
After the removal of the legacy Matlab package, there is no longer a need to build the macOS package. When the new Matlab package is ready, the upstream workflow will need to be updated and this code can be restored.

Closes https://github.com/Cantera/cantera-macos-pkg/issues/3