### PR TITLE
yaml2ck: Check if third body is in species list

### DIFF
--- a/interfaces/cython/cantera/yaml2ck.py
+++ b/interfaces/cython/cantera/yaml2ck.py
@@ -336,7 +336,7 @@ def build_thermodynamics_text(
     )
 
 
-def build_reactions_text(reactions: Iterable[ct.Reaction]):
+def build_reactions_text(reactions: Iterable[ct.Reaction], species: Iterable[ct.Species]):
     """
     Create the reaction definition section of this file.
 
@@ -345,6 +345,8 @@ def build_reactions_text(reactions: Iterable[ct.Reaction]):
 
     .. versionadded:: 3.0
     """
+
+    species_names = [spec.name for spec in species]
 
     # Note: Cantera converts explicit reverse rate coefficients given by the ``REV``
     # keyword into two independent irreversible reactions. Therefore, there's no need to
@@ -478,6 +480,7 @@ def build_reactions_text(reactions: Iterable[ct.Reaction]):
                 " ".join(
                     f"{spec}/{value:.3E}/"
                     for spec, value in reac.third_body.efficiencies.items()
+                    if spec in species_names
                 )
             )
 
@@ -701,7 +704,7 @@ def convert(
 
     # TODO: Handle phases without reactions
     all_reactions = solution.reactions()
-    mechanism_text.append(build_reactions_text(all_reactions))
+    mechanism_text.append(build_reactions_text(all_reactions, all_species))
 
     if transport_path is None and transport_exists:
         mechanism_text.append(build_transport_text(all_species, separate_file=False))

--- a/interfaces/cython/cantera/yaml2ck.py
+++ b/interfaces/cython/cantera/yaml2ck.py
@@ -342,11 +342,13 @@ def build_reactions_text(reactions: Iterable[ct.Reaction], species: Iterable[ct.
 
     :param reactions:
         An iterable of `cantera.Reaction` instances to be included.
+    :param species:
+        An iterable of `cantera.Species` definitions for this file.
 
     .. versionadded:: 3.0
     """
 
-    species_names = [spec.name for spec in species]
+    species_names = {spec.name for spec in species}
 
     # Note: Cantera converts explicit reverse rate coefficients given by the ``REV``
     # keyword into two independent irreversible reactions. Therefore, there's no need to

--- a/test/data/undeclared-third-body.yaml
+++ b/test/data/undeclared-third-body.yaml
@@ -1,0 +1,13 @@
+phases:
+- name: test
+  thermo: ideal-gas
+  elements: [O, H, C, Ar]
+  species:
+  - gri30.yaml/species: all
+  kinetics: gas
+  skip-undeclared-elements: true
+  skip-undeclared-third-bodies: true
+  reactions:
+  - gri30.yaml/reactions: declared-species
+  transport: mixture-averaged
+  state: {T: 300.0, P: 1 atm}

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -736,6 +736,19 @@ class yaml2ckTest(utilities.CanteraTest):
             ck_phase, yaml_phase, [300, 800, 1450, 2800], [5e3, 1e5, 2e6]
         )
 
+    def test_undeclared_third_body(self):
+        input_file = self.test_data_path / "undeclared-third-body.yaml"
+        mech = self.convert(input_file)
+        with open(mech) as fid:
+            lines = fid.readlines()
+        for i, line in enumerate(lines):
+            if line.startswith("H + O2 + M <=> HO2 + M"):
+                next = lines[i + 1]
+                assert "N2" not in next
+                assert all(sp in next for sp in ["AR", "C2H6", "CO", "CO2", "H2O", "O2"])
+        ck_phase, yaml_phase = self.check_conversion(input_file)
+        self.check_kinetics(ck_phase, yaml_phase, [900, 1800], [2e5, 20e5])
+
     def test_pdep(self):
         input_file = self.test_data_path / "pdep-test.yaml"
         self.convert(input_file)


### PR DESCRIPTION
**Changes proposed in this pull request**

This pull request adds a check in `yaml2ck` for third body efficiencies for species that might not be present in the `ct.Solution` object due to the `skip-undeclared-third-bodies: true` flag.

Closes #1683 

Using the provided example from the issue referenced:

```yaml
phases:
- name: test
  thermo: ideal-gas
  elements: [O, H, C, Ar]
  species:
  - gri30.yaml/species: all
  kinetics: gas
  skip-undeclared-elements: true
  skip-undeclared-third-bodies: true
  reactions:
  - gri30.yaml/reactions: declared-species
  transport: mixture-averaged
  state: {T: 300.0, P: 1 atm}
```

The outputted Chemkin file from `python -m cantera.yaml2ck test.yaml --overwrite` before the change:

```
H + O2 + M <=> HO2 + M           2.8000000000000005e+18 -0.86 0.0
AR/0.000E+00/ C2H6/1.500E+00/ CO/7.500E-01/ CO2/1.500E+00/ H2O/0.000E+00/ N2/0.000E+00/ O2/0.000E+00/
```

versus after the change:

```
H + O2 + M <=> HO2 + M           2.8000000000000005e+18 -0.86 0.0
AR/0.000E+00/ C2H6/1.500E+00/ CO/7.500E-01/ CO2/1.500E+00/ H2O/0.000E+00/ O2/0.000E+00/
```

The `N2` efficiency is omitted from the list as desired. 

**Feedback**

An example file still needs to be added with a corresponding test case, but before doing so, I wanted to solicit feedback on potential edge cases. What behavior would be expected if no explicit third body species are present in the mechanism? Are there any other possible cases that need to be accounted for proactively? 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
