### PR TITLE
Fix reversible reaction behavior in Matlab interface

### DIFF
--- a/interfaces/matlab_experimental/Base/Kinetics.m
+++ b/interfaces/matlab_experimental/Base/Kinetics.m
@@ -542,7 +542,7 @@ classdef Kinetics < handle
             nr = kin.nReactions;
             xx = zeros(1, nr);
             pt = libpointer('doublePtr', xx);
-            ctFunc('kin_getRevRateConstants', kin.kinID, 1, nr, pt);
+            ctFunc('kin_getRevRateConstants', kin.kinID, 0, nr, pt);
             k = pt.Value;
         end
 

--- a/interfaces/matlab_experimental/Base/Kinetics.m
+++ b/interfaces/matlab_experimental/Base/Kinetics.m
@@ -72,10 +72,8 @@ classdef Kinetics < handle
         %     >> k = kin.equilibriumConstants
         %
         % :return:
-        %    A column vector of the equilibrium constants for all
-        %    reactions. The vector has an entry for every reaction,
-        %    whether reversible or not, but non-zero values occur only
-        %    for the reversible reactions.
+        %    A column vector of the equilibrium constants in concentration units for all
+        %    reactions, calculated from the standard Gibbs free energy of reaction.
         equilibriumConstants
 
         forwardRateConstants % Forward reaction rate constants for all reactions.


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Matlab: Return 0 as reverse rate constant for irreversible reactions. This behavior is consistent with Python and the default behavior in C++
- Matlab: Fix docstring for Kinetics.equilibriumConstants. The equilibrium constant is calculated regardless of whether the     reaction is marked as reversible. This is consistent with the behavior of the Python and C++ interfaces.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #1691 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) ~~and unit tests address code coverage~~ *fixing the Matlab toolbox's tests is out of scope for this PR*
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
