### PR TITLE
Make CI builds faster

### DIFF
--- a/.github/workflows/linters.yml
+++ b/.github/workflows/linters.yml
@@ -12,12 +12,12 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 10
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout the repository
         with:
           fetch-depth: 100
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
       - name: Check example keywords

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -91,7 +91,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons==3.1.2 numpy cython pandas pytest \
-        pytest-github-actions-annotate-failures pint graphviz
+        pytest-github-actions-annotate-failures pytest-xdist pint graphviz
     - name: Build Cantera
       run: |
         python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
@@ -106,10 +106,13 @@ jobs:
         retention-days: 2
     - name: Build Tests
       run:
-        python3 `which scons` -j4 build-tests
-    - name: Test Cantera
-      run:
-        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
+        python3 `which scons` -j4 build-tests --debug=time
+    - name: Run compiled tests
+      run: python3 `which scons` test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        LD_LIBRARY_PATH=build/lib
+        python3 -m pytest -raP -v -n auto --durations=50 test/python
     - name: Save the wheel file to install Cantera
       uses: actions/upload-artifact@v3
       with:
@@ -142,8 +145,8 @@ jobs:
     - name: Upgrade pip
       run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
-      run: |
-        python3 -m pip install ruamel.yaml scons numpy cython pandas pytest pytest-github-actions-annotate-failures pint graphviz
+      run: python3 -m pip install ruamel.yaml scons numpy cython pandas pytest
+        pytest-xdist pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
@@ -151,10 +154,13 @@ jobs:
         logging=debug warning_flags='-Wall -Werror -Wsuggest-override'
     - name: Build Tests
       run:
-        python3 `which scons` -j4 build-tests
-    - name: Test Cantera
-      run:
-        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
+        python3 `which scons` -j4 build-tests --debug=time
+    - name: Run compiled tests
+      run: python3 `which scons` test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        LD_LIBRARY_PATH=build/lib
+        python3 -m pytest -raP -v -n auto --durations=50 test/python
 
   macos-multiple-pythons:
     name: ${{ matrix.macos-version }} with Python ${{ matrix.python-version }}
@@ -175,7 +181,7 @@ jobs:
         submodules: recursive
     - name: Write dependencies to a file for caching
       run: |
-        echo "scons ruamel.yaml numpy cython pandas pytest pytest-github-actions-annotate-failures pint graphviz" | tr " " "\n" > requirements.txt
+        echo "scons ruamel.yaml numpy cython pandas pytest pytest-xdist pytest-github-actions-annotate-failures pint graphviz" | tr " " "\n" > requirements.txt
     - name: Set up Python
       uses: actions/setup-python@v5
       with:
@@ -201,11 +207,13 @@ jobs:
         name: libcantera_shared.dylib
         retention-days: 2
     - name: Build Tests
-      run:
-        scons -j3 build-tests
-    - name: Test Cantera
-      run:
-        scons test show_long_tests=yes verbose_tests=yes --debug=time
+      run: scons -j3 build-tests --debug=time
+    - name: Run compiled tests
+      run: scons test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        export DYLD_LIBRARY_PATH=build/lib
+        python3 -m pytest -raP -v -n auto --durations=50 test/python
 
   # Coverage is its own job because macOS builds of the samples
   # use Homebrew gfortran which is not compatible for coverage
@@ -250,11 +258,11 @@ jobs:
         FORTRANFLAGS='-O0' env_vars=all -j4 --debug=time \
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
     - name: Build Tests
-      run:
-        python3 `which scons` -j4 build-tests
-    - name: Test Cantera
-      run:
-        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
+      run: python3 `which scons` -j4 build-tests --debug=time
+    - name: Run compiled tests
+      run: python3 `which scons` test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: python3 `which scons` test-python show_long_tests=yes verbose_tests=yes
     - name: Build the .NET interface
       run: dotnet build
       working-directory: interfaces/dotnet
@@ -502,7 +510,7 @@ jobs:
         run: |
           conda install -q sundials=${{ matrix.sundials-ver }} scons numpy ruamel.yaml \
           cython boost-cpp fmt=${{ matrix.fmt-ver }} eigen yaml-cpp pandas \
-          libgomp openblas pytest highfive python-graphviz
+          libgomp openblas pytest pytest-xdist highfive python-graphviz
       - name: Build Cantera
         run: |
           scons build system_fmt=y system_eigen=y system_yamlcpp=y system_sundials=y \
@@ -571,7 +579,7 @@ jobs:
       # use boost-cpp rather than boost from conda-forge
       # Install SCons >=4.4.0 to make sure that MSVC_TOOLSET_VERSION variable is present
       run: |
-        mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp pandas pytest highfive pint python-graphviz fmt=${{ matrix.fmt-ver }}
+        mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp pandas pytest pytest-xdist highfive pint python-graphviz fmt=${{ matrix.fmt-ver }}
       shell: pwsh
     - name: Build Cantera
       run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
@@ -585,9 +593,12 @@ jobs:
         name: cantera_shared.dll
         retention-days: 2
     - name: Build Tests
-      run: scons -j4 build-tests
-    - name: Test Cantera
-      run: scons test show_long_tests=yes verbose_tests=yes --debug=time
+      run: scons -j4 build-tests --debug=time
+    - name: Run compiled tests
+      run: scons test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        pytest -raP -v -n auto --durations=50 test/python
       shell: pwsh
     - name: Test Install
       # spot-check installation locations
@@ -638,7 +649,7 @@ jobs:
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip setuptools wheel
-          python -m pip install 'scons<4.4.0' pypiwin32 numpy ruamel.yaml cython pandas graphviz pytest pytest-github-actions-annotate-failures
+          python -m pip install 'scons<4.4.0' pypiwin32 numpy ruamel.yaml cython pandas graphviz pytest pytest-xdist pytest-github-actions-annotate-failures
       - name: Restore Boost cache
         uses: actions/cache@v3
         id: cache-boost
@@ -662,9 +673,11 @@ jobs:
           msvc_version=${{ matrix.vs-toolset }} f90_interface=n --debug=time
         shell: cmd
       - name: Build Tests
-        run: scons -j4 build-tests
-      - name: Test Cantera
-        run: scons test show_long_tests=yes verbose_tests=yes --debug=time
+        run: scons -j4 build-tests --debug=time
+      - name: Run compiled tests
+        run: scons test-gtest test-legacy --debug=time
+      - name: Run Python tests
+        run: python -m pytest -raP -v -n auto --durations=50 test/python
 
   # Adapted from https://www.scivision.dev/intel-oneapi-github-actions/
   linux-intel-oneapi:
@@ -704,7 +717,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons numpy cython pandas pytest \
-        pytest-github-actions-annotate-failures pint graphviz
+        pytest-xdist pytest-github-actions-annotate-failures pint graphviz
     - name: Setup Intel oneAPI environment
       run: |
         source /opt/intel/oneapi/setvars.sh
@@ -714,11 +727,13 @@ jobs:
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
         --debug=time f90_interface=n # FORTRAN=ifx
     - name: Build Tests
-      run:
-        python3 `which scons` -j4 build-tests
-    - name: Test Cantera
+      run: python3 `which scons` -j4 build-tests --debug=time
+    - name: Run compiled tests
+      run: python3 `which scons` test-gtest test-legacy --debug=time
+    - name: Run Python tests
       run: |
-        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
+        LD_LIBRARY_PATH=$LD_LIBRARY_PATH:build/lib
+        python3 -m pytest -raP -v -n auto --durations=50 test/python
 
   windows-mingw:
     name: mingw on Windows, Python 3.10
@@ -740,7 +755,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python -m pip install -U pip setuptools wheel
-        python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas pytest pytest-github-actions-annotate-failures pint graphviz
+        python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas pytest pytest-xdist pytest-github-actions-annotate-failures pint graphviz
     - name: Restore Boost cache
       uses: actions/cache@v3
       id: cache-boost
@@ -775,9 +790,11 @@ jobs:
         name: Cantera-win_amd64.whl
         retention-days: 2
     - name: Build Tests
-      run: scons -j4 build-tests
-    - name: Test Cantera
-      run: scons test show_long_tests=yes verbose_tests=yes --debug=time
+      run: scons -j4 build-tests --debug=time
+    - name: Run compiled tests
+      run: scons test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: python -m pytest -raP -v -n auto --durations=50 test/python
     - name: Upload Test binaries
       if: always()
       uses: actions/upload-artifact@v3

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -104,6 +104,9 @@ jobs:
         path: build/lib/libcantera_shared.so
         name: libcantera_shared-${{ matrix.os }}.so
         retention-days: 2
+    - name: Build Tests
+      run:
+        python3 `which scons` -j4 build-tests
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
@@ -146,6 +149,9 @@ jobs:
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
         -j4 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
         logging=debug warning_flags='-Wall -Werror -Wsuggest-override'
+    - name: Build Tests
+      run:
+        python3 `which scons` -j4 build-tests
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
@@ -194,6 +200,9 @@ jobs:
         path: build/lib/libcantera_shared.dylib
         name: libcantera_shared.dylib
         retention-days: 2
+    - name: Build Tests
+      run:
+        scons -j3 build-tests
     - name: Test Cantera
       run:
         scons test show_long_tests=yes verbose_tests=yes --debug=time
@@ -240,6 +249,9 @@ jobs:
         optimize=n skip_slow_tests=y no_optimize_flags='-DNDEBUG -O0' \
         FORTRANFLAGS='-O0' env_vars=all -j4 --debug=time \
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
+    - name: Build Tests
+      run:
+        python3 `which scons` -j4 build-tests
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
@@ -572,6 +584,8 @@ jobs:
         path: build/lib/cantera_shared.dll
         name: cantera_shared.dll
         retention-days: 2
+    - name: Build Tests
+      run: scons -j4 build-tests
     - name: Test Cantera
       run: scons test show_long_tests=yes verbose_tests=yes --debug=time
       shell: pwsh
@@ -647,6 +661,8 @@ jobs:
           python_package=full env_vars=USERPROFILE,GITHUB_ACTIONS
           msvc_version=${{ matrix.vs-toolset }} f90_interface=n --debug=time
         shell: cmd
+      - name: Build Tests
+        run: scons -j4 build-tests
       - name: Test Cantera
         run: scons test show_long_tests=yes verbose_tests=yes --debug=time
 
@@ -697,6 +713,9 @@ jobs:
       run: python3 `which scons` build env_vars=all CC=icx CXX=icpx -j4 debug=n
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
         --debug=time f90_interface=n # FORTRAN=ifx
+    - name: Build Tests
+      run:
+        python3 `which scons` -j4 build-tests
     - name: Test Cantera
       run: |
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
@@ -755,6 +774,8 @@ jobs:
         path: build\python\dist\Cantera*.whl
         name: Cantera-win_amd64.whl
         retention-days: 2
+    - name: Build Tests
+      run: scons -j4 build-tests
     - name: Test Cantera
       run: scons test show_long_tests=yes verbose_tests=yes --debug=time
     - name: Upload Test binaries

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -809,7 +809,7 @@ jobs:
     name: .NET on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-11]
+        os: [ubuntu-22.04, windows-2022, macos-13]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     needs: [ubuntu-multiple-pythons, macos-multiple-pythons, windows-2022]
@@ -835,7 +835,7 @@ jobs:
       if: matrix.os == 'windows-2022'
     - name: Install Brew dependencies (macOS)
       run: brew install --display-times hdf5
-      if: matrix.os == 'macos-11'
+      if: matrix.os == 'macos-13'
     - name: Install Apt dependencies (Ubuntu)
       run: |
         sudo apt update

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -49,7 +49,7 @@ jobs:
           python3 -m pip install ruamel.yaml scons==3.1.2
       - name: Build Cantera
         run: |
-          python3 `which scons` build env_vars=all -j2 debug=n --debug=time \
+          python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
           cc_flags=-D_GLIBCXX_ASSERTIONS
       - name: Set up MATLAB
         uses: matlab-actions/setup-matlab@v1
@@ -94,7 +94,7 @@ jobs:
         pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: |
-        python3 `which scons` build env_vars=all -j2 debug=n --debug=time \
+        python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
         system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
         cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Upload shared library
@@ -144,7 +144,7 @@ jobs:
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
-        -j2 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
+        -j4 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
         logging=debug warning_flags='-Wall -Werror -Wsuggest-override'
     - name: Test Cantera
       run:
@@ -238,7 +238,7 @@ jobs:
       run: |
         python3 `which scons` build blas_lapack_libs=lapack,blas coverage=y \
         optimize=n skip_slow_tests=y no_optimize_flags='-DNDEBUG -O0' \
-        FORTRANFLAGS='-O0' env_vars=all -j2 --debug=time \
+        FORTRANFLAGS='-O0' env_vars=all -j4 --debug=time \
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
     - name: Test Cantera
       run:
@@ -329,7 +329,7 @@ jobs:
             sphinx-copybutton matplotlib pandas scipy pint coolprop graphviz
           pip install "git+https://github.com/Cantera/sphinx-tags.git@main"
       - name: Build Cantera
-        run: scons build -j2 debug=n optimize=y use_pch=n
+        run: scons build -j4 debug=n optimize=y use_pch=n
       - name: Build documentation
         run: |
           scons sphinx doxygen logging=debug \
@@ -494,7 +494,7 @@ jobs:
       - name: Build Cantera
         run: |
           scons build system_fmt=y system_eigen=y system_yamlcpp=y system_sundials=y \
-          system_highfive=y blas_lapack_libs='lapack,blas' -j2 logging=debug debug=n \
+          system_highfive=y blas_lapack_libs='lapack,blas' -j4 logging=debug debug=n \
           optimize_flags='-O3 -ffast-math -fno-finite-math-only'
       - name: Test Cantera
         run: scons test-zeroD test-python-reactor show_long_tests=yes verbose_tests=yes
@@ -563,7 +563,7 @@ jobs:
       shell: pwsh
     - name: Build Cantera
       run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
-        msvc_toolset_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j2
+        msvc_toolset_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j4
       shell: pwsh
     - name: Upload shared library
       uses: actions/upload-artifact@v3
@@ -643,7 +643,7 @@ jobs:
           rm $BOOST_ROOT/download.7z
         shell: bash
       - name: Build Cantera
-        run: scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n logging=debug
+        run: scons build -j4 boost_inc_dir=%BOOST_ROOT% debug=n logging=debug
           python_package=full env_vars=USERPROFILE,GITHUB_ACTIONS
           msvc_version=${{ matrix.vs-toolset }} f90_interface=n --debug=time
         shell: cmd
@@ -694,7 +694,7 @@ jobs:
         source /opt/intel/oneapi/setvars.sh
         printenv >> $GITHUB_ENV
     - name: Build Cantera
-      run: python3 `which scons` build env_vars=all CC=icx CXX=icpx -j2 debug=n
+      run: python3 `which scons` build env_vars=all CC=icx CXX=icpx -j4 debug=n
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
         --debug=time f90_interface=n # FORTRAN=ifx
     - name: Test Cantera
@@ -745,7 +745,7 @@ jobs:
         rm $BOOST_ROOT/download.7z
       shell: bash
     - name: Build Cantera
-      run: scons build -j2 boost_inc_dir=%BOOST_ROOT% debug=n logging=debug
+      run: scons build -j4 boost_inc_dir=%BOOST_ROOT% debug=n logging=debug
         python_package=full env_vars=USERPROFILE,PYTHONPATH,GITHUB_ACTIONS
         toolchain=mingw f90_interface=n --debug=time
       shell: cmd

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -27,12 +27,12 @@ jobs:
       CANTERA_ROOT: /home/runner/work/cantera/cantera
       CANTERA_DATA: /home/runner/work/cantera/cantera/data
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout the repository
         with:
           submodules: recursive
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: '3.10'
           architecture: x64
@@ -52,9 +52,9 @@ jobs:
           python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
           cc_flags=-D_GLIBCXX_ASSERTIONS
       - name: Set up MATLAB
-        uses: matlab-actions/setup-matlab@v1
+        uses: matlab-actions/setup-matlab@v2
       - name: Run tests
-        uses: matlab-actions/run-tests@v1
+        uses: matlab-actions/run-tests@v2
         with:
           select-by-folder: /home/runner/work/cantera/cantera/test/matlab_experimental
 
@@ -71,12 +71,12 @@ jobs:
       HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
       HDF5_INCLUDEDIR: /usr/include/hdf5/serial
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64
@@ -98,7 +98,7 @@ jobs:
         system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
         cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Upload shared library
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: matrix.python-version == '3.11'
       with:
         path: build/lib/libcantera_shared.so
@@ -114,7 +114,7 @@ jobs:
         LD_LIBRARY_PATH=build/lib
         python3 -m pytest -raP -v -n auto --durations=50 test/python
     - name: Save the wheel file to install Cantera
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: build/python/dist/Cantera*.whl
         retention-days: 2
@@ -129,12 +129,12 @@ jobs:
       HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
       HDF5_INCLUDEDIR: /usr/include/hdf5/serial
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
         architecture: x64
@@ -200,8 +200,8 @@ jobs:
     - name: Build Cantera
       run: scons build env_vars=all -j3 debug=n --debug=time boost_inc_dir=${BOOST_INC_DIR}
     - name: Upload shared library
-      uses: actions/upload-artifact@v3
-      if: matrix.python-version == '3.11'
+      uses: actions/upload-artifact@v4
+      if: matrix.python-version == '3.11' && matrix.macos-version == 'macos-12'
       with:
         path: build/lib/libcantera_shared.dylib
         name: libcantera_shared.dylib
@@ -227,12 +227,12 @@ jobs:
       HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
       HDF5_INCLUDEDIR: /usr/include/hdf5/serial
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
     - name: Setup python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: '3.11'
         architecture: x64
@@ -248,7 +248,7 @@ jobs:
         python3 -m pip install ruamel.yaml scons numpy cython pandas scipy pytest \
         pytest-github-actions-annotate-failures pytest-cov gcovr!=7.0.0 pint graphviz
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.x'
     - name: Build Cantera
@@ -282,19 +282,19 @@ jobs:
         --exclude '.*ext.*' --exclude '(.+/)?_cantera\.cpp$' --exclude '^test.*' \
         --xml coverage.xml --html-details htmlcoverage.html --txt
     - name: Archive C++ coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: cxx-coverage-report
         path: htmlcoverage*
         retention-days: 5
     - name: Archive Python coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: python-coverage-report
         path: build/python-coverage*
         retention-days: 5
     - name: Archive .NET coverage results
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         name: dotnet-coverage-report
         path: interfaces/dotnet/coveragereport*
@@ -317,7 +317,7 @@ jobs:
     env:
       DEPLOY: ${{ github.event_name == 'push' && github.repository_owner == 'Cantera' && endsWith(github.ref, 'main') }}
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout the repository
         with:
           submodules: recursive
@@ -369,7 +369,7 @@ jobs:
           tar --exclude="*.map" --exclude="*.md5" -czf docs.tar.gz html
         if: failure() || success()
       - name: Store archive of docs output
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: build/doc/docs.tar.gz
           name: docs
@@ -412,10 +412,10 @@ jobs:
     steps:
       # We're not building Cantera here, we only need the checkout for the samples
       # folder, so no need to do a recursive checkout
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout the repository
       - name: Setup Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -424,12 +424,12 @@ jobs:
           sudo apt update
           sudo apt install graphviz libhdf5-103 libfmt-dev
       - name: Download the wheel artifact
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: cantera-wheel-${{ matrix.python-version }}-${{ matrix.os }}
           path: dist
       - name: Download the Cantera shared library (.so)
-        uses: actions/download-artifact@v3
+        uses: actions/download-artifact@v4
         with:
           name: libcantera_shared-${{ matrix.os }}.so
           path: build/lib
@@ -458,11 +458,11 @@ jobs:
           PYTHONWARNINGS: "error,ignore:warn_name_set_on_empty_Forward::pyparsing,ignore:datetime.datetime.utcfromtimestamp:DeprecationWarning:"
           MPLBACKEND: Agg
       - name: Save the results file for inspection
-        uses: actions/upload-artifact@v3
+        uses: actions/upload-artifact@v4
         with:
           path: results.txt
           retention-days: 2
-          name: example-results
+          name: example-results-${{ matrix.python-version }}-${{ matrix.os }}
         # Run this step if the job was successful or failed, but not if it was cancelled
         # Using always() would run this step if the job was cancelled as well.
         if: failure() || success()
@@ -493,11 +493,11 @@ jobs:
           fmt-ver: 10
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout the repository
         with:
           submodules: recursive
-      - uses: conda-incubator/setup-miniconda@v2
+      - uses: conda-incubator/setup-miniconda@v3
         with:
           auto-update-conda: true
           python-version: ${{ env.PYTHON_VERSION }}
@@ -561,12 +561,12 @@ jobs:
           fmt-ver: 7.1
       fail-fast: false
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
     - name: Set up conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: ${{ matrix.python-version }}
@@ -586,7 +586,7 @@ jobs:
         msvc_toolset_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j4
       shell: pwsh
     - name: Upload shared library
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       if: matrix.python-version == '3.11' && matrix.vs-toolset == '14.3'
       with:
         path: build/lib/cantera_shared.dll
@@ -637,12 +637,12 @@ jobs:
         python-version: ["3.8", "3.10", "3.11", "3.12"]
       fail-fast: false
     steps:
-      - uses: actions/checkout@v3
+      - uses: actions/checkout@v4
         name: Checkout the repository
         with:
           submodules: recursive
       - name: Set Up Python
-        uses: actions/setup-python@v4
+        uses: actions/setup-python@v5
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
@@ -651,7 +651,7 @@ jobs:
           python -m pip install -U pip setuptools wheel
           python -m pip install 'scons<4.4.0' pypiwin32 numpy ruamel.yaml cython pandas graphviz pytest pytest-xdist pytest-github-actions-annotate-failures
       - name: Restore Boost cache
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         id: cache-boost
         with:
           path: ${{env.BOOST_ROOT}}
@@ -703,12 +703,12 @@ jobs:
       run: |
         sudo apt-get install intel-oneapi-compiler-fortran intel-oneapi-compiler-dpcpp-cpp-and-cpp-classic \
         intel-oneapi-mpi intel-oneapi-mpi-devel intel-oneapi-mkl ninja-build libboost-dev libhdf5-dev
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.8
         architecture: x64
@@ -743,12 +743,12 @@ jobs:
       BOOST_ROOT: ${{github.workspace}}/3rdparty/boost
       BOOST_URL: https://boostorg.jfrog.io/artifactory/main/release/1.78.0/source/boost_1_78_0.7z
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
     - name: Set Up Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: "3.10"
         architecture: x64
@@ -757,7 +757,7 @@ jobs:
         python -m pip install -U pip setuptools wheel
         python -m pip install scons pypiwin32 numpy ruamel.yaml cython h5py pandas pytest pytest-xdist pytest-github-actions-annotate-failures pint graphviz
     - name: Restore Boost cache
-      uses: actions/cache@v3
+      uses: actions/cache@v4
       id: cache-boost
       with:
         path: ${{env.BOOST_ROOT}}
@@ -784,7 +784,7 @@ jobs:
         toolchain=mingw f90_interface=n --debug=time
       shell: cmd
     - name: Upload Wheel
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: build\python\dist\Cantera*.whl
         name: Cantera-win_amd64.whl
@@ -797,7 +797,7 @@ jobs:
       run: python -m pytest -raP -v -n auto --durations=50 test/python
     - name: Upload Test binaries
       if: always()
-      uses: actions/upload-artifact@v3
+      uses: actions/upload-artifact@v4
       with:
         path: |
           build/test/**/*.exe
@@ -815,10 +815,10 @@ jobs:
     needs: [ubuntu-multiple-pythons, macos-multiple-pythons, windows-2022]
     timeout-minutes: 60
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
     - name: Set up conda
-      uses: conda-incubator/setup-miniconda@v2
+      uses: conda-incubator/setup-miniconda@v3
       with:
         auto-update-conda: true
         python-version: "3.11"
@@ -842,21 +842,21 @@ jobs:
         sudo apt install libhdf5-dev libfmt-dev
       if: matrix.os == 'ubuntu-22.04'
     - name: Setup .NET Core SDK
-      uses: actions/setup-dotnet@v2
+      uses: actions/setup-dotnet@v4
       with:
         dotnet-version: '6.x'
     - name: Download the Cantera shared library (.so)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: libcantera_shared-ubuntu-22.04.so
         path: build/lib
     - name: Download the Cantera shared library (.dylib)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: libcantera_shared.dylib
         path: build/lib
     - name: Download the Cantera shared library (.dll)
-      uses: actions/download-artifact@v3
+      uses: actions/download-artifact@v4
       with:
         name: cantera_shared.dll
         path: build/lib

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -20,12 +20,12 @@ jobs:
       HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
       HDF5_INCLUDEDIR: /usr/include/hdf5/serial
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: 3.11
         architecture: x64
@@ -74,7 +74,7 @@ jobs:
         apt install -y git
         git config --global init.defaultBranch main
         git config --global --add safe.directory /__w/cantera/cantera
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
@@ -124,7 +124,7 @@ jobs:
         dnf install -y git
         git config --global init.defaultBranch main
         git config --global --add safe.directory /__w/cantera/cantera
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
     - name: Install dependencies
       # Use packages from Fedora
@@ -165,12 +165,12 @@ jobs:
       HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
       HDF5_INCLUDEDIR: /usr/include/hdf5/serial
     steps:
-    - uses: actions/checkout@v3
+    - uses: actions/checkout@v4
       name: Checkout the repository
       with:
         submodules: recursive
     - name: Setup Python
-      uses: actions/setup-python@v4
+      uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
         architecture: x64

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -45,6 +45,8 @@ jobs:
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
         -j4 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
         logging=debug
+    - name: Build Tests
+      run: python3 `which scons` -j4 build-tests
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
@@ -93,6 +95,8 @@ jobs:
         system_eigen=y system_fmt=y system_sundials=y system_yamlcpp=y \
         system_blas_lapack=y hdf_support=y f90_interface=y \
         cc_flags=-D_GLIBCXX_ASSERTIONS
+    - name: Build Tests
+      run: scons -j4 build-tests
     - name: Test Cantera
       run:
         scons test verbose_tests=yes --debug=time
@@ -132,6 +136,8 @@ jobs:
         system_yamlcpp=y system_blas_lapack=y hdf_support=y
       # note: 'system_highfive=y' is omitted as the current packaged version is too old;
       # once newer version is available in 'latest', this should be tested as well
+    - name: Build Tests
+      run: scons -j4 build-tests
     - name: Test Cantera
       run:
         scons test verbose_tests=yes --debug=time
@@ -176,6 +182,8 @@ jobs:
         python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
         system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
         system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS
+    - name: Build Tests
+      run: python3 `which scons` -j4 build-tests
     - name: Test Cantera
       run:
         python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
@@ -206,5 +214,7 @@ jobs:
         ./.venv/bin/python -m pip install ruamel.yaml numpy cython pandas pytest pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: $(brew --prefix)/bin/scons build env_vars=all python_cmd="$(pwd)/.venv/bin/python" -j3 debug=n --debug=time boost_inc_dir=${BOOST_INC_DIR}
+    - name: Build Tests
+      run: $(brew --prefix)/bin/scons -j3 build-tests
     - name: Test Cantera
       run: $(brew --prefix)/bin/scons test show_long_tests=yes verbose_tests=yes --debug=time

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -38,7 +38,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons numpy pandas pytest pint \
-          pytest-github-actions-annotate-failures graphviz
+          pytest-xdist pytest-github-actions-annotate-failures graphviz
         python3 -m pip install --pre cython
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all
@@ -47,9 +47,12 @@ jobs:
         logging=debug
     - name: Build Tests
       run: python3 `which scons` -j4 build-tests
-    - name: Test Cantera
-      run:
-        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
+    - name: Run compiled tests
+      run: python3 `which scons` test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        LD_LIBRARY_PATH=build/lib
+        python3 -m pytest -raP -v -n auto --durations=50 test/python
 
   ubuntu-docker:
     name: Docker 'ubuntu:${{ matrix.image }}' image
@@ -83,7 +86,8 @@ jobs:
         libblas-dev liblapack-dev libhdf5-dev libfmt-dev libyaml-cpp-dev \
         libgtest-dev libgmock-dev libeigen3-dev libsundials-dev \
         cython3 python3-numpy python3-pandas python3-pint python3-graphviz \
-        python3-ruamel.yaml python3-setuptools python3-wheel python3-pytest
+        python3-ruamel.yaml python3-setuptools python3-wheel python3-pytest \
+        python3-pytest-xdist
         gcc --version
     - name: Install Python dependencies
       run: |
@@ -97,9 +101,12 @@ jobs:
         cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Build Tests
       run: scons -j4 build-tests
-    - name: Test Cantera
-      run:
-        scons test verbose_tests=yes --debug=time
+    - name: Run compiled tests
+      run: scons test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        LD_LIBRARY_PATH=build/lib
+        python3 -m pytest -raP -v -n auto --durations=50 test/python
 
   fedora-docker:
     name: Docker 'fedora:${{ matrix.image }}' image
@@ -125,9 +132,9 @@ jobs:
         dnf install -y boost-devel eigen3-devel fmt-devel gcc gcc-c++ \
         gcc-fortran gmock-devel gtest-devel python3 python3-cython \
         python3-devel python3-numpy python3-pandas python3-pint python3-pip \
-        python3-pytest python3-ruamel-yaml python3-scipy python3-scons \
-        python3-wheel sundials-devel yaml-cpp-devel hdf5-devel highfive-devel \
-        python3-graphviz
+        python3-pytest python3-pytest-xdist python3-ruamel-yaml python3-scipy \
+        python3-scons python3-wheel sundials-devel yaml-cpp-devel hdf5-devel \
+        highfive-devel python3-graphviz
     - name: Build Cantera
       run: |
         scons build -j4 debug=n --debug=time python_package=full f90_interface=y \
@@ -138,9 +145,12 @@ jobs:
       # once newer version is available in 'latest', this should be tested as well
     - name: Build Tests
       run: scons -j4 build-tests
-    - name: Test Cantera
-      run:
-        scons test verbose_tests=yes --debug=time
+    - name: Run compiled tests
+      run: scons test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        LD_LIBRARY_PATH=build/lib
+        python3 -m pytest -raP -v -n auto --durations=50 test/python
 
   ubuntu-python-prerelease:
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
@@ -176,7 +186,7 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons numpy cython pandas pytest \
-        pytest-github-actions-annotate-failures pint graphviz
+        pytest-xdist pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: |
         python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
@@ -184,9 +194,12 @@ jobs:
         system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Build Tests
       run: python3 `which scons` -j4 build-tests
-    - name: Test Cantera
-      run:
-        python3 `which scons` test show_long_tests=yes verbose_tests=yes --debug=time
+    - name: Run compiled tests
+      run: python3 `which scons` test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        LD_LIBRARY_PATH=build/lib
+        python3 -m pytest -raP -v -n auto --durations=50 test/python
 
   macos-homebrew:
     runs-on: macos-14
@@ -211,10 +224,15 @@ jobs:
     - name: Install Python dependencies
       run: |
         ./.venv/bin/python -m pip install -U pip setuptools wheel build
-        ./.venv/bin/python -m pip install ruamel.yaml numpy cython pandas pytest pytest-github-actions-annotate-failures pint graphviz
+        ./.venv/bin/python -m pip install ruamel.yaml numpy cython pandas pytest \
+          pytest-xdist pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: $(brew --prefix)/bin/scons build env_vars=all python_cmd="$(pwd)/.venv/bin/python" -j3 debug=n --debug=time boost_inc_dir=${BOOST_INC_DIR}
     - name: Build Tests
       run: $(brew --prefix)/bin/scons -j3 build-tests
-    - name: Test Cantera
-      run: $(brew --prefix)/bin/scons test show_long_tests=yes verbose_tests=yes --debug=time
+    - name: Run compiled tests
+      run: $(brew --prefix)/bin/scons test-gtest test-legacy --debug=time
+    - name: Run Python tests
+      run: |
+        export DYLD_LIBRARY_PATH=build/lib
+        ./.venv/bin/python -m pytest -raP -v -n auto --durations=50 test/python

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -43,7 +43,7 @@ jobs:
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
-        -j2 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
+        -j4 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
         logging=debug
     - name: Test Cantera
       run:
@@ -88,7 +88,7 @@ jobs:
         pipenv install pytest-github-actions-annotate-failures
     - name: Build Cantera
       run: |
-        scons build env_vars=all -j2 debug=n --debug=time \
+        scons build env_vars=all -j4 debug=n --debug=time \
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
         system_eigen=y system_fmt=y system_sundials=y system_yamlcpp=y \
         system_blas_lapack=y hdf_support=y f90_interface=y \
@@ -126,7 +126,7 @@ jobs:
         python3-graphviz
     - name: Build Cantera
       run: |
-        scons build -j2 debug=n --debug=time python_package=full f90_interface=y \
+        scons build -j4 debug=n --debug=time python_package=full f90_interface=y \
         extra_inc_dirs=/usr/include/eigen3 libdirname=/usr/lib64 \
         system_eigen=y system_fmt=y system_blas_lapack=y system_sundials=y \
         system_yamlcpp=y system_blas_lapack=y hdf_support=y
@@ -173,7 +173,7 @@ jobs:
         pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
       run: |
-        python3 `which scons` build env_vars=all -j2 debug=n --debug=time \
+        python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
         system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
         system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Test Cantera

--- a/SConstruct
+++ b/SConstruct
@@ -25,6 +25,10 @@ Basic usage:
 
     'scons test-NAME' - Run the test named "NAME".
 
+    'scons build-NAME' - Build the program for the test named "NAME".
+
+    'scons build-tests' - Build the programs for all tests.
+
     'scons samples' - Compile the C++ and Fortran samples.
 
     'scons msi' - Build a Windows installer (.msi) for Cantera.
@@ -111,7 +115,7 @@ else:
     logger.logger.setLevel("INFO")
 
 for command in COMMAND_LINE_TARGETS:
-    if command not in valid_commands and not command.startswith('test'):
+    if command not in valid_commands and not command.startswith(('test', 'build-')):
         logger.error(f"Unrecognized command line target: {command!r}")
         sys.exit(1)
 
@@ -2351,7 +2355,7 @@ if 'msi' in COMMAND_LINE_TARGETS:
     build_msi = Alias('msi', msi_target)
 
 ### Tests ###
-if any(target.startswith('test') for target in COMMAND_LINE_TARGETS):
+if any(target.startswith(('test', 'build-')) for target in COMMAND_LINE_TARGETS):
     env['testNames'] = []
     env['test_results'] = env.Command('test_results', [], test_results.print_report)
 

--- a/SConstruct
+++ b/SConstruct
@@ -23,6 +23,9 @@ Basic usage:
 
     'scons test-help' - List available tests.
 
+    'scons test-{python,gtest,legacy}' - Run all Python, GTest, or legacy
+                                         (test_problems) test cases, respectively.
+
     'scons test-NAME' - Run the test named "NAME".
 
     'scons build-NAME' - Build the program for the test named "NAME".

--- a/doc/sphinx/develop/running-tests.md
+++ b/doc/sphinx/develop/running-tests.md
@@ -339,7 +339,7 @@ of the GTest test suite by changing the `program` name above.
 Before running any of the GTest programs through VS Code, you will first need to
 use SCons to compile the corresponding test program, for example by running
 ```sh
-scons test-thermo
+scons build-thermo
 ```
 
 If you make any changes to the test program or the Cantera library code, re-run this
@@ -360,11 +360,11 @@ help with running either the C++ or Python tests through GDB on Linux.
 
 ### Running C++ (GoogleTest) Tests
 
-First, run the target test through SCons to make sure the Cantera library and the test
+First, build the target test through SCons to make sure the Cantera library and the test
 executable are up to date. We'll use the `kinetics` test subset as an example, with the
 goal of debugging the `PlogLowPressure` test.
 ```sh
-scons test-kinetics
+scons build-kinetics
 ```
 
 Next, you need to set some environment variables that specify where the test program can

--- a/interfaces/matlab_experimental/Base/Kinetics.m
+++ b/interfaces/matlab_experimental/Base/Kinetics.m
@@ -429,7 +429,7 @@ classdef Kinetics < handle
             % :return:
             %    True if reaction number i is reversible. false if irreversible.
 
-            n = boolean(ctFunc('kin_isReversible', kin.kinID, i - 1));
+            n = ctFunc('kin_isReversible', kin.kinID, i - 1) == 1;
         end
 
         function wdot = get.netProdRates(kin)

--- a/test/SConscript
+++ b/test/SConscript
@@ -104,7 +104,9 @@ def addTestProgram(subdir, progName, env_vars={}):
         run_program = testenv.Command(passedFile, program, gtestRunner)
         env.Depends(run_program, env['build_targets'])
         env.Depends(env['test_results'], run_program)
-        Alias('test-%s' % progName, run_program)
+        Alias(f'test-{progName}', run_program)
+        Alias(f'build-{progName}', program)
+        Alias('build-tests', program)
         env['testNames'].append(progName)
     else:
         test_results.failed['test-%s (googletest disabled)' % progName] = 1

--- a/test/SConscript
+++ b/test/SConscript
@@ -105,6 +105,7 @@ def addTestProgram(subdir, progName, env_vars={}):
         env.Depends(run_program, env['build_targets'])
         env.Depends(env['test_results'], run_program)
         Alias(f'test-{progName}', run_program)
+        Alias('test-gtest', run_program)
         Alias(f'build-{progName}', program)
         Alias('build-tests', program)
         env['testNames'].append(progName)

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -71,6 +71,7 @@ class Test(object):
         localenv.Depends(env['test_results'], run)
         localenv.Depends(run, env['build_targets'])
         localenv.Alias('test-clean', self.clean(localenv))
+        localenv.Alias('test-legacy', run)
         localenv.Alias(f'test-{self.testName}', run)
         localenv.Alias(f'build-{self.testName}', self.program)
         localenv.Alias('build-tests', self.program)

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -71,7 +71,9 @@ class Test(object):
         localenv.Depends(env['test_results'], run)
         localenv.Depends(run, env['build_targets'])
         localenv.Alias('test-clean', self.clean(localenv))
-        localenv.Alias('test-%s' % self.testName, run)
+        localenv.Alias(f'test-{self.testName}', run)
+        localenv.Alias(f'build-{self.testName}', self.program)
+        localenv.Alias('build-tests', self.program)
         env['testNames'].append(self.testName)
 
         # reset: just delete the ".passed" file so that this test will be re-run


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Adjust number of processors used to reflect changes in specs of GitHub-provided runners
- Build test binaries in parallel
- Run Python test suite in parallel

This reduces the total runner time used by the CI jobs by ~15%, and the runtime of the slowest CI job (MinGW) by ~30%.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
