### PR TITLE
Fix issues with 1D flame solver

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -336,7 +336,7 @@ jobs:
             libblas-dev liblapack-dev libhdf5-dev libfmt-dev libsundials-dev
       - name: Install conda dependencies
         run: |
-          mamba install -q doxygen=1.9.7 scons pip scikits.odes
+          mamba install doxygen=1.9.7 scons pip scikits.odes
       - name: Upgrade pip
         run: pip install -U pip setuptools wheel
       - name: Install Python dependencies
@@ -579,7 +579,7 @@ jobs:
       # use boost-cpp rather than boost from conda-forge
       # Install SCons >=4.4.0 to make sure that MSVC_TOOLSET_VERSION variable is present
       run: |
-        mamba install -q '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp pandas pytest pytest-xdist highfive pint python-graphviz fmt=${{ matrix.fmt-ver }}
+        mamba install '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp pandas pytest pytest-xdist highfive pint python-graphviz fmt=${{ matrix.fmt-ver }}
       shell: pwsh
     - name: Build Cantera
       run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
@@ -830,7 +830,7 @@ jobs:
     - name: Install library dependencies with Conda (Windows)
       # fmt needs to match the version of the windows-2022 runner selected to upload
       # the cantera_shared.dll artifact
-      run: mamba install -q yaml-cpp mkl highfive fmt=8.1
+      run: mamba install yaml-cpp mkl highfive fmt=8.1
       shell: pwsh
       if: matrix.os == 'windows-2022'
     - name: Install Brew dependencies (macOS)

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -541,24 +541,23 @@ jobs:
           test -f h2o2-test.ck
 
   windows-2022:
-    name: ${{ matrix.os }}, MSVC ${{ matrix.vs-toolset }}, Python ${{ matrix.python-version }}, fmt ${{ matrix.fmt-ver }}
-    runs-on: ${{ matrix.os }}
+    name: Windows 2022, Python ${{ matrix.python-version }}, fmt ${{ matrix.fmt-ver }}
+    runs-on: windows-2022
     timeout-minutes: 60
     defaults:
       run:
         shell: bash -l {0}
     strategy:
       matrix:
-        os: ["windows-2022"]
-        vs-toolset: ["14.3"]
-        python-version: ["3.8", "3.10", "3.11", "3.12"]
         include:
-        - python-version: 3.8
-          fmt-ver: 10
-        - python-version: 3.10
-          fmt-ver: 8.1
-        - python-version: 3.11
-          fmt-ver: 7.1
+        - python-version: '3.8'
+          fmt-ver: '10'
+        - python-version: '3.10'
+          fmt-ver: '8.1'
+        - python-version: '3.11'
+          fmt-ver: '9.1'
+        - python-version: '3.12'
+          fmt-ver: '7.1'
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -579,15 +578,15 @@ jobs:
       # use boost-cpp rather than boost from conda-forge
       # Install SCons >=4.4.0 to make sure that MSVC_TOOLSET_VERSION variable is present
       run: |
-        mamba install '"scons>=4.4.0"' numpy cython ruamel.yaml boost-cpp eigen yaml-cpp pandas pytest pytest-xdist highfive pint python-graphviz fmt=${{ matrix.fmt-ver }}
+        mamba install scons numpy cython ruamel.yaml boost-cpp eigen yaml-cpp pandas pytest pytest-xdist highfive pint python-graphviz fmt=${{ matrix.fmt-ver }}
       shell: pwsh
     - name: Build Cantera
       run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
-        msvc_toolset_version=${{ matrix.vs-toolset }} f90_interface=n debug=n --debug=time -j4
+        toolchain=msvc f90_interface=n debug=n --debug=time -j4
       shell: pwsh
     - name: Upload shared library
       uses: actions/upload-artifact@v4
-      if: matrix.python-version == '3.11' && matrix.vs-toolset == '14.3'
+      if: matrix.python-version == '3.11'
       with:
         path: build/lib/cantera_shared.dll
         name: cantera_shared.dll
@@ -830,7 +829,7 @@ jobs:
     - name: Install library dependencies with Conda (Windows)
       # fmt needs to match the version of the windows-2022 runner selected to upload
       # the cantera_shared.dll artifact
-      run: mamba install yaml-cpp mkl highfive fmt=8.1
+      run: mamba install yaml-cpp mkl highfive fmt=9.1
       shell: pwsh
       if: matrix.os == 'windows-2022'
     - name: Install Brew dependencies (macOS)

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -104,9 +104,9 @@ jobs:
     - name: Run compiled tests
       run: scons test-gtest test-legacy --debug=time
     - name: Run Python tests
-      run: |
-        LD_LIBRARY_PATH=build/lib
-        python3 -m pytest -raP -v -n auto --durations=50 test/python
+      run: python3 -m pytest -raP -v -n auto --durations=50 test/python
+      env:
+        LD_LIBRARY_PATH: build/lib
 
   fedora-docker:
     name: Docker 'fedora:${{ matrix.image }}' image
@@ -148,9 +148,9 @@ jobs:
     - name: Run compiled tests
       run: scons test-gtest test-legacy --debug=time
     - name: Run Python tests
-      run: |
-        LD_LIBRARY_PATH=build/lib
-        python3 -m pytest -raP -v -n auto --durations=50 test/python
+      run: python3 -m pytest -raP -v -n auto --durations=50 test/python
+      env:
+        LD_LIBRARY_PATH: build/lib
 
   ubuntu-python-prerelease:
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }}

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -73,7 +73,7 @@ public:
     //! Set the Transport object by name
     //! @param model  name of transport model; if omitted, the default model is used
     //! @since New in %Cantera 3.0
-    void setTransportModel(const string& model="");
+    void setTransportModel(const string& model="default");
 
     //! Accessor for the ThermoPhase pointer
     shared_ptr<ThermoPhase> thermo() {
@@ -203,7 +203,7 @@ shared_ptr<Solution> newSolution(const string& infile, const string& name,
  */
 shared_ptr<Solution> newSolution(const string& infile,
                                  const string& name="",
-                                 const string& transport="",
+                                 const string& transport="default",
                                  const vector<shared_ptr<Solution>>& adjacent={});
 
 //! Create and initialize a new Solution manager from AnyMap objects
@@ -227,7 +227,7 @@ shared_ptr<Solution> newSolution(const string& infile,
  */
 shared_ptr<Solution> newSolution(
     const AnyMap& phaseNode, const AnyMap& rootNode=AnyMap(),
-    const string& transport="",
+    const string& transport="default",
     const vector<shared_ptr<Solution>>& adjacent={},
     const map<string, shared_ptr<Solution>>& related={});
 

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -152,6 +152,8 @@ public:
         return m_V0;
     }
 
+    void setTemperature(double T) override;
+
     void show(const double* x) override;
 
     size_t nSpecies() override {

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -929,6 +929,10 @@ class CounterflowDiffusionFlame(FlameBase):
         u0o = mdoto / rho0o
         T0o = self.oxidizer_inlet.T
 
+        if mdoto == mdotf == 0.0:
+            raise CanteraError("Mass flow for fuel and/or oxidizer "
+                               "must be positive")
+
         zst = 1 / (1 + self.gas.stoich_air_fuel_ratio(Yin_f, Yin_o, 'mass'))
         Yst = zst * Yin_f + (1.0 - zst) * Yin_o
 
@@ -1348,6 +1352,10 @@ class CounterflowPremixedFlame(FlameBase):
         rhob = self.gas.density
         ub = self.products.mdot / rhob
 
+        if uu == ub == 0.0:
+            raise CanteraError("Mass flow for reactants and/or products "
+                               "must be positive")
+
         locs = np.array([0.0, 0.4, 0.6, 1.0])
         self.set_profile('T', locs, [Tu, Tu, Teq, Tb])
         for k in range(self.gas.n_species):
@@ -1421,6 +1429,9 @@ class CounterflowTwinPremixedFlame(FlameBase):
         super().set_initial_guess(data=data, group=group)
         if data:
             return
+
+        if self.reactants.mdot == 0:
+            raise CanteraError("Reactants velocity must be positive")
 
         Yu = self.reactants.Y
         Tu = self.reactants.T

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -123,7 +123,7 @@ class FlameBase(Sim1D):
 
         if isinstance(left, Inlet1D) and isinstance(right, Inlet1D):
             # find stagnation plane
-            i = np.flatnonzero(self.velocity > 0)[-1]
+            i = np.flatnonzero(arr.velocity > 0)[-1]
 
             # adjust temperatures
             grid = arr.grid

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -561,6 +561,8 @@ class FreeFlame(FlameBase):
             self.flame = FreeFlow(gas, name='flame')
 
         if width is not None:
+            if grid is not None:
+                raise ValueError("'grid' and 'width' arguments are mutually exclusive")
             grid = np.array([0.0, 0.2, 0.3, 0.4, 0.5, 0.6, 0.8, 1.0]) * width
 
         super().__init__((self.inlet, self.flame, self.outlet), gas, grid)
@@ -757,6 +759,8 @@ class BurnerFlame(FlameBase):
             self.flame = UnstrainedFlow(gas, name='flame')
 
         if width is not None:
+            if grid is not None:
+                raise ValueError("'grid' and 'width' arguments are mutually exclusive")
             grid = np.array([0.0, 0.1, 0.2, 0.3, 0.5, 0.7, 1.0]) * width
 
         super().__init__((self.burner, self.flame, self.outlet), gas, grid)
@@ -893,6 +897,8 @@ class CounterflowDiffusionFlame(FlameBase):
         self.flame = AxisymmetricFlow(gas, name='flame')
 
         if width is not None:
+            if grid is not None:
+                raise ValueError("'grid' and 'width' arguments are mutually exclusive")
             grid = np.array([0.0, 0.2, 0.4, 0.6, 0.8, 1.0]) * width
 
         super().__init__((self.fuel_inlet, self.flame, self.oxidizer_inlet), gas, grid)
@@ -1219,6 +1225,8 @@ class ImpingingJet(FlameBase):
         self.flame.set_axisymmetric_flow()
 
         if width is not None:
+            if grid is not None:
+                raise ValueError("'grid' and 'width' arguments are mutually exclusive")
             grid = np.array([0.0, 0.2, 0.4, 0.6, 0.8, 1.0]) * width
 
         if surface is None:
@@ -1308,6 +1316,8 @@ class CounterflowPremixedFlame(FlameBase):
         self.flame = AxisymmetricFlow(gas, name='flame')
 
         if width is not None:
+            if grid is not None:
+                raise ValueError("'grid' and 'width' arguments are mutually exclusive")
             # Create grid points aligned with initial guess profile
             grid = np.array([0.0, 0.3, 0.5, 0.7, 1.0]) * width
 
@@ -1406,6 +1416,8 @@ class CounterflowTwinPremixedFlame(FlameBase):
         self.products = SymmetryPlane1D(name='products', phase=gas)
 
         if width is not None:
+            if grid is not None:
+                raise ValueError("'grid' and 'width' arguments are mutually exclusive")
             # Create grid points aligned with initial guess profile
             grid = np.array([0.0, 0.2, 0.4, 0.5, 0.6, 0.8, 1.0]) * width
 

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -914,9 +914,6 @@ class CounterflowDiffusionFlame(FlameBase):
         if data:
             return
 
-        moles = lambda el: (self.gas.elemental_mass_fraction(el) /
-                            self.gas.atomic_weight(el))
-
         # Compute stoichiometric mixture composition
         Yin_f = self.fuel_inlet.Y
         self.gas.TPY = self.fuel_inlet.T, self.P, Yin_f
@@ -925,12 +922,6 @@ class CounterflowDiffusionFlame(FlameBase):
         u0f = mdotf / rho0f
         T0f = self.fuel_inlet.T
 
-        sFuel = moles('O')
-        if 'C' in self.gas.element_names:
-            sFuel -= 2 * moles('C')
-        if 'H' in self.gas.element_names:
-            sFuel -= 0.5 * moles('H')
-
         Yin_o = self.oxidizer_inlet.Y
         self.gas.TPY = self.oxidizer_inlet.T, self.P, Yin_o
         mdoto = self.oxidizer_inlet.mdot
@@ -938,13 +929,7 @@ class CounterflowDiffusionFlame(FlameBase):
         u0o = mdoto / rho0o
         T0o = self.oxidizer_inlet.T
 
-        sOx = moles('O')
-        if 'C' in self.gas.element_names:
-            sOx -= 2 * moles('C')
-        if 'H' in self.gas.element_names:
-            sOx -= 0.5 * moles('H')
-
-        zst = 1.0 / (1 - sFuel / sOx)
+        zst = 1 / (1 + self.gas.stoich_air_fuel_ratio(Yin_f, Yin_o, 'mass'))
         Yst = zst * Yin_f + (1.0 - zst) * Yin_o
 
         # get adiabatic flame temperature and composition

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -43,11 +43,11 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         void setSource(string)
         CxxAnyMap& header() except +translate_exception
         shared_ptr[CxxThermoPhase] thermo()
-        void setThermo(shared_ptr[CxxThermoPhase])
+        void setThermo(shared_ptr[CxxThermoPhase]) except +translate_exception
         shared_ptr[CxxKinetics] kinetics()
-        void setKinetics(shared_ptr[CxxKinetics])
+        void setKinetics(shared_ptr[CxxKinetics]) except +translate_exception
         shared_ptr[CxxTransport] transport()
-        void setTransport(shared_ptr[CxxTransport])
+        void setTransport(shared_ptr[CxxTransport]) except +translate_exception
         void setTransportModel(const string&) except +translate_exception
         CxxAnyMap parameters(cbool) except +translate_exception
         size_t nAdjacent()

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -68,7 +68,7 @@ cdef class _SolutionBase:
             infile = str(infile)
 
         # Transport model: "" is a sentinel value to use the default model
-        transport = kwargs.get("transport_model", "")
+        transport = kwargs.get("transport_model", "default")
 
         if infile or yaml:
             # Parse YAML input

--- a/samples/clib/demo.c
+++ b/samples/clib/demo.c
@@ -42,7 +42,7 @@ void exit_with_error()
 
 int main(int argc, char** argv)
 {
-    int soln = soln_newSolution("gri30.yaml", "gri30", "");
+    int soln = soln_newSolution("gri30.yaml", "gri30", "default");
     // In principle, one ought to check for errors after every Cantera call. But this
     // is the only one likely to occur in part of this example, due to the input file
     // not being found.

--- a/samples/python/thermo/isentropic_units.py
+++ b/samples/python/thermo/isentropic_units.py
@@ -16,7 +16,11 @@ import numpy as np
 # This sets the default output format of the units to have 2 significant digits
 # and the units are printed with a Unicode font. See:
 # https://pint.readthedocs.io/en/stable/user/formatting.html
-ctu.units.default_format = ".2F~P"
+if hasattr(ctu.cantera_units_registry, "formatter"):  # pint >= 0.24
+    ctu.cantera_units_registry.formatter.default_format = ".2F~P"
+else:
+    ctu.units.default_format = ".2F~P"
+
 
 
 def soundspeed(gas):

--- a/samples/python/thermo/sound_speed_units.py
+++ b/samples/python/thermo/sound_speed_units.py
@@ -16,7 +16,10 @@ import numpy as np
 # This sets the default output format of the units to have 2 significant digits
 # and the units are printed with a Unicode font. See:
 # https://pint.readthedocs.io/en/stable/user/formatting.html#unit-format-types
-ctu.units.default_format = ".2F~P"
+if hasattr(ctu.cantera_units_registry, "formatter"):  # pint >= 0.24
+    ctu.cantera_units_registry.formatter.default_format = ".2F~P"
+else:
+    ctu.units.default_format = ".2F~P"
 
 def equilibrium_sound_speeds(gas, rtol=1.0e-6, max_iter=5000):
     """

--- a/src/base/Interface.cpp
+++ b/src/base/Interface.cpp
@@ -35,7 +35,7 @@ void Interface::setKinetics(shared_ptr<Kinetics> kinetics) {
 shared_ptr<Interface> newInterface(const string& infile,
     const string& name, const vector<string>& adjacent)
 {
-    auto sol = newSolution(infile, name, "", adjacent);
+    auto sol = newSolution(infile, name, "default", adjacent);
     auto iface = std::dynamic_pointer_cast<Interface>(sol);
     if (!iface) {
         auto rootNode = AnyMap::fromYamlFile(infile);
@@ -57,7 +57,7 @@ shared_ptr<Interface> newInterface(const string& infile,
 shared_ptr<Interface> newInterface(AnyMap& phaseNode, const AnyMap& rootNode,
     const vector<shared_ptr<Solution>>& adjacent)
 {
-    auto sol = newSolution(phaseNode, rootNode, "", adjacent);
+    auto sol = newSolution(phaseNode, rootNode, "default", adjacent);
     auto iface = std::dynamic_pointer_cast<Interface>(sol);
     if (!iface) {
         throw InputFileError("newInterface", phaseNode,

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -75,11 +75,7 @@ void Solution::setTransportModel(const string& model) {
         throw CanteraError("Solution::setTransportModel",
             "Unable to set Transport model without valid ThermoPhase object.");
     }
-    if (model == "") {
-        setTransport(newTransport(m_thermo, "default"));
-    } else {
-        setTransport(newTransport(m_thermo, model));
-    }
+    setTransport(newTransport(m_thermo, model));
 }
 
 void Solution::addAdjacent(shared_ptr<Solution> adjacent) {
@@ -260,7 +256,7 @@ shared_ptr<Solution> newSolution(const AnyMap& phaseNode,
             if (!all_related.count(name)) {
                 // Create a new phase only if there isn't already one with the same name
                 auto adj = newSolution(phases.getMapWhere("name", name), root,
-                                    "", {}, all_related);
+                                       "default", {}, all_related);
                 all_related[name] = adj;
                 for (size_t i = 0; i < adj->nAdjacent(); i++) {
                     all_related[adj->adjacent(i)->name()] = adj->adjacent(i);

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -102,6 +102,14 @@ void Inlet1D::setSpreadRate(double V0)
     needJacUpdate();
 }
 
+void Inlet1D::setTemperature(double T)
+{
+    Boundary1D::setTemperature(T);
+    // Adjust flow domain temperature bounds based on inlet temperature
+    if (m_flow != nullptr && m_flow->lowerBound(c_offset_T) >= m_temp) {
+        m_flow->setBounds(c_offset_T, m_temp - 5.0, m_flow->upperBound(c_offset_T));
+    }
+}
 
 void Inlet1D::show(const double* x)
 {
@@ -168,6 +176,7 @@ void Inlet1D::init()
     } else {
         m_yin[0] = 1.0;
     }
+
 }
 
 void Inlet1D::eval(size_t jg, double* xg, double* rg,

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -22,7 +22,7 @@ string reportError()
 
 TEST(ct, cabinet_exceptions)
 {
-    soln_newSolution("h2o2.yaml", "ohmech", "");
+    soln_newSolution("h2o2.yaml", "ohmech", "default");
     soln_name(999, 0, 0);
 
     string err = reportError();
@@ -43,7 +43,7 @@ TEST(ct, cabinet_exceptions)
 TEST(ct, new_solution)
 {
     string name = "ohmech";
-    int ref = soln_newSolution("h2o2.yaml", name.c_str(), "");
+    int ref = soln_newSolution("h2o2.yaml", name.c_str(), "default");
 
     int buflen = soln_name(ref, 0, 0) + 1; // include \0
     ASSERT_EQ(buflen, int(name.size() + 1));
@@ -63,7 +63,7 @@ TEST(ct, soln_objects)
 
     int ref = soln_newSolution("gri30.yaml", "gri30", "none");
     ASSERT_EQ(ref, 0);
-    int ref2 = soln_newSolution("h2o2.yaml", "ohmech", "");
+    int ref2 = soln_newSolution("h2o2.yaml", "ohmech", "default");
     ASSERT_EQ(ref2, 1);
 
     int thermo = soln_thermo(ref2);
@@ -106,7 +106,7 @@ TEST(ct, new_interface)
 {
     ct_resetStorage();
 
-    int sol = soln_newSolution("ptcombust.yaml", "gas", "");
+    int sol = soln_newSolution("ptcombust.yaml", "gas", "none");
     ASSERT_EQ(sol, 0);
 
     vector<int> adj{sol};

--- a/test/clib/test_ctonedim.cpp
+++ b/test/clib/test_ctonedim.cpp
@@ -12,7 +12,7 @@ TEST(ctonedim, freeflow)
 {
     ct_resetStorage();
 
-    int sol = soln_newSolution("h2o2.yaml", "ohmech", "");
+    int sol = soln_newSolution("h2o2.yaml", "ohmech", "default");
     int ph = soln_thermo(sol);
     ASSERT_GE(ph, 0);
 
@@ -40,7 +40,7 @@ TEST(ctonedim, freeflow_from_parts)
 {
     ct_resetStorage();
 
-    int sol = soln_newSolution("h2o2.yaml", "ohmech", "");
+    int sol = soln_newSolution("h2o2.yaml", "ohmech", "default");
     int ph = soln_thermo(sol);
     ASSERT_GE(ph, 0);
     int kin = soln_kinetics(sol);
@@ -111,7 +111,7 @@ TEST(ctonedim, reacting_surface_from_parts)
 
 TEST(ctonedim, catcomb_stack)
 {
-    int sol = soln_newSolution("ptcombust.yaml", "gas", "");
+    int sol = soln_newSolution("ptcombust.yaml", "gas", "default");
     int gas = soln_thermo(sol);
     int gas_kin = soln_kinetics(sol);
     int trans = soln_transport(sol);
@@ -145,7 +145,7 @@ TEST(ctonedim, freeflame_from_parts)
     ct_resetStorage();
     auto gas = newThermo("h2o2.yaml", "ohmech");
 
-    int sol = soln_newSolution("h2o2.yaml", "ohmech", "");
+    int sol = soln_newSolution("h2o2.yaml", "ohmech", "default");
     int ph = soln_thermo(sol);
     int kin = soln_kinetics(sol);
     int tr = soln_transport(sol);

--- a/test/oneD/test_oneD.cpp
+++ b/test/oneD/test_oneD.cpp
@@ -116,7 +116,7 @@ TEST(onedim, flame_types)
 
 TEST(onedim, ion_flame_types)
 {
-    auto sol = newSolution("ch4_ion.yaml", "", "");
+    auto sol = newSolution("ch4_ion.yaml");
     ASSERT_EQ(sol->transport()->transportModel(), "ionized-gas");
 
     auto free = newDomain<IonFlow>("free-flow", sol, "flow");

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -413,6 +413,10 @@ class TestFreeFlame(utilities.CanteraTest):
     def test_mixture_averaged_case8(self):
         self.run_mix(phi=2.0, T=400, width=2.0, p=5.0, refine=False)
 
+    def test_mixture_averaged_case9(self):
+        self.run_mix(phi=0.8, T=180, width=0.05, p=1.0, refine=False)
+        assert self.sim.flame.bounds('T')[0] < 190
+
     def test_adjoint_sensitivities(self):
         self.run_mix(phi=0.5, T=300, width=0.1, p=1.0, refine=True)
         self.sim.flame.set_steady_tolerances(default=(1e-10, 1e-15))

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -149,6 +149,12 @@ class TestOnedim(utilities.CanteraTest):
         with pytest.raises(ct.CanteraError, match="Invalid Transport model"):
             gas.transport_model = 'none'
 
+    def test_width_grid(self):
+        gas = ct.Solution('h2o2.yaml')
+        for cls in ct.FlameBase.__subclasses__():
+            with pytest.raises(ValueError, match="mutually exclusive"):
+                sim = cls(gas, grid=[0, 0.1, 0.2], width=0.4)
+
 
 class TestFreeFlame(utilities.CanteraTest):
     tol_ss = [1.0e-5, 1.0e-14]  # [rtol atol] for steady-state problem

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -922,8 +922,6 @@ class TestDiffusionFlame(utilities.CanteraTest):
         self.sim.oxidizer_inlet.X = oxidizer
         self.sim.oxidizer_inlet.T = T_ox
 
-        self.sim.set_initial_guess()
-
     def solve_fixed_T(self):
         # Solve with the energy equation disabled
         self.sim.energy_enabled = False
@@ -945,6 +943,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
     def test_mixture_averaged(self, saveReference=False):
         referenceFile = "DiffusionFlameTest-h2-mix.csv"
         self.create_sim(p=ct.one_atm)
+        self.sim.set_initial_guess()
 
         nPoints = len(self.sim.grid)
         Tfixed = self.sim.T
@@ -1059,6 +1058,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
     def test_mixture_averaged_rad(self, saveReference=False):
         referenceFile = "DiffusionFlameTest-h2-mix-rad.csv"
         self.create_sim(p=ct.one_atm)
+        self.sim.set_initial_guess()
 
         nPoints = len(self.sim.grid)
         Tfixed = self.sim.T
@@ -1127,6 +1127,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
 
     def test_mixture_fraction(self):
         self.create_sim(p=ct.one_atm)
+        self.sim.set_initial_guess()
         Z = self.sim.mixture_fraction('H')
         self.assertNear(Z[0], 1.0)
         self.assertNear(Z[-1], 0.0)
@@ -1140,6 +1141,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
 
     def test_equivalence_ratio(self):
         self.create_sim(p=ct.one_atm)
+        self.sim.set_initial_guess()
         phi = self.sim.equivalence_ratio
         assert phi[0] == np.inf
         assert np.isclose(phi[-1], 0.0)

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -1241,7 +1241,7 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
         sim = ct.CounterflowPremixedFlame(gas=gas, width=width)
         sim.reactants.mdot = 10 * gas.density
         sim.products.mdot = 5 * gas.density
-        sim.set_refine_criteria(ratio=6, slope=0.7, curve=0.8, prune=0.4)
+        sim.set_refine_criteria(ratio=6, slope=0.7, curve=0.8, prune=0.1)
         sim.solve(loglevel=0, auto=True)
         self.assertTrue(all(sim.T >= T - 1e-3))
         self.assertTrue(all(sim.spread_rate >= -1e-9))
@@ -1355,11 +1355,11 @@ class TestCounterflowPremixedFlameNonIdeal(utilities.CanteraTest):
 
     def run_case(self, phi, T, width, P):
         gas = ct.Solution("h2o2.yaml", "ohmech-RK")
-        gas.TPX = T, P * ct.one_atm, {'H2':phi, 'O2':0.5, 'AR':2}
+        gas.TPX = T, P * ct.one_atm, {'H2':phi, 'O2':0.5, 'AR':3}
         sim = ct.CounterflowPremixedFlame(gas=gas, width=width)
         sim.reactants.mdot = 10 * gas.density
         sim.products.mdot = 5 * gas.density
-        sim.set_refine_criteria(ratio=6, slope=0.7, curve=0.8, prune=0.4)
+        sim.set_refine_criteria(ratio=6, slope=0.7, curve=0.8, prune=0.1)
         sim.solve(loglevel=0, auto=True)
         self.assertTrue(all(sim.T >= T - 1e-3))
         self.assertTrue(all(sim.spread_rate >= -1e-9))
@@ -1680,7 +1680,7 @@ class TestTwinFlame(utilities.CanteraTest):
         gas.TP = T, ct.one_atm
         gas.set_equivalence_ratio(phi, 'H2', 'O2:1.0, AR:4.0')
         sim = ct.CounterflowTwinPremixedFlame(gas=gas, width=width)
-        sim.set_refine_criteria(ratio=5, slope=0.8, curve=1.0, prune=0.4)
+        sim.set_refine_criteria(ratio=5, slope=0.8, curve=1.0, prune=0.1)
         axial_velocity = 2.0
         sim.reactants.mdot = gas.density * axial_velocity
         sim.solve(loglevel=0, auto=True)

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -142,6 +142,13 @@ class TestOnedim(utilities.CanteraTest):
         gas.transport_model = 'multicomponent'
         assert flame.transport_model == 'multicomponent'
 
+        with pytest.raises(ct.CanteraError, match="Invalid Transport model"):
+            flame.transport_model = 'none'
+
+        gas.transport_model = 'unity-Lewis-number'
+        with pytest.raises(ct.CanteraError, match="Invalid Transport model"):
+            gas.transport_model = 'none'
+
 
 class TestFreeFlame(utilities.CanteraTest):
     tol_ss = [1.0e-5, 1.0e-14]  # [rtol atol] for steady-state problem

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -1978,9 +1978,16 @@ class StickReactionTests(InterfaceReactionTests):
     _sticking_species = None
     _sticking_order = None
 
+    def setUp(self):
+        weight = self.gas[self._sticking_species].molecular_weights[0]
+        self._rate_obj.sticking_species = self._sticking_species
+        self._rate_obj.sticking_order = self._sticking_order
+        self._rate_obj.sticking_weight = weight
+        self._rate_obj.motz_wise_correction = "Motz-Wise" in self._yaml
+
     def finalize(self, rxn):
         rxn = super().finalize(rxn)
-        weight = self.gas.molecular_weights[self.gas.species_index(self._sticking_species)]
+        weight = self.gas[self._sticking_species].molecular_weights[0]
         rxn.rate.sticking_species = self._sticking_species
         rxn.rate.sticking_order = self._sticking_order
         rxn.rate.sticking_weight = weight

--- a/test_problems/.gitignore
+++ b/test_problems/.gitignore
@@ -27,6 +27,7 @@ cathermo/testWaterTP/WaterSSTP
 cathermo/VPissp/ISSPTester2
 clib_test/clib_test
 cxx_samples/flamespeed.h5
+cxx_samples/flamespeed.yaml
 diamondSurf/diamondSurf
 diamondSurf/runDiamond_output.out
 dustyGasTransport/dustyGasTransport


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This PR fixes a number of issues with the 1D flame solver.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Handle empty string as transport model more consistently. This now always means the `none` transport model. The string `default` needs to be specified to activate the YAML-specified transport model. Resolves #1680
- Detect invalid boundary conditions for flame configurations. Fixes #1694
- Eliminate redundant calculation of stoichiometric mixture fraction in diffusion flame initial guess
- Disallow redundant flame grid specification. Fixes #1693
- Fix setting diffusion flame initial guess from known data. Fixes #1674
- Handle potential exceptions propagating from callbacks when switching thermo/kinetics/transport objects attached to a Solution
- Automatically adjust temperature bounds for low-temperature flames. Fixes #1684
- Tweak flame tests to run faster. Previously, the single test `TestCounterflowPremixedFlameNonIdeal::test_solve_case1` was previously taking upwards of 30 seconds to run on GitHub Actions.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
