### PR TITLE
Simplify input for extensible interface reactions

### DIFF
--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -113,7 +113,7 @@ Reaction::Reaction(const AnyMap& node, const Kinetics& kin)
             if (!ba::starts_with(rate_type, "sticking-")) {
                 rateNode["type"] = "sticking-" + rate_type;
             }
-        } else {
+        } else if (rate_type == "Arrhenius") { // no explicitly-specified type
             throw InputFileError("Reaction::Reaction", input,
                 "Unable to infer interface reaction type.");
         }

--- a/test/data/extensible-reactions.yaml
+++ b/test/data/extensible-reactions.yaml
@@ -23,6 +23,5 @@ reactions:
 surface-reactions:
 - equation: H(S) + OH(S) <=> H2O(S) + PT(S)
   type: foo-rate
-  rate-constant: {}
   A: 1.3e+14
   E: 71.3

--- a/test/data/extensible-reactions.yaml
+++ b/test/data/extensible-reactions.yaml
@@ -8,8 +8,21 @@ phases:
   species: [{h2o2.yaml/species: all}]
   kinetics: gas
   state: {T: 300.0, P: 1 atm}
+- name: surface
+  thermo: ideal-surface
+  adjacent-phases: [gas]
+  species: [{ptcombust.yaml/species: all}]
+  kinetics: surface
+  reactions: [surface-reactions]
 
 reactions:
 - equation: H + O2 = HO2
   type: square-rate
   A: 3.14
+
+surface-reactions:
+- equation: H(S) + OH(S) <=> H2O(S) + PT(S)
+  type: foo-rate
+  rate-constant: {}
+  A: 1.3e+14
+  E: 71.3

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -1716,6 +1716,13 @@ class TestExtensible2(utilities.CanteraTest):
         assert user_ext.SquareRate.use_count[0] == initialRate
         assert user_ext.SquareRateData.use_count[0] == initialData
 
+    def test_interface_rate(self):
+        surf = ct.Interface("extensible-reactions.yaml", "surface")
+        assert surf.n_reactions == 1
+        T = 432.0
+        surf.adjacent["gas"].TP = T, ct.one_atm
+        assert surf.forward_rate_constants[0] == approx(1.3e14 * np.exp(-71.3 / T))
+
 
 @ct.extension(name="user-rate-2", data=UserRate1Data)
 class UserRate2(ct.ExtensibleRate):

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -1722,6 +1722,9 @@ class TestExtensible2(utilities.CanteraTest):
         T = 432.0
         surf.adjacent["gas"].TP = T, ct.one_atm
         assert surf.forward_rate_constants[0] == approx(1.3e14 * np.exp(-71.3 / T))
+        input_data = surf.reaction(0).input_data
+        assert input_data["type"] == "foo-rate"
+        assert "rate-constant" not in input_data
 
 
 @ct.extension(name="user-rate-2", data=UserRate1Data)

--- a/test/python/user_ext.py
+++ b/test/python/user_ext.py
@@ -47,7 +47,7 @@ class FooRateData(ct.ExtensibleRateData):
         return True
 
 
-@ct.extension(name="interface-foo-rate", data=FooRateData)
+@ct.extension(name="foo-rate", data=FooRateData)
 class FooRate(ct.ExtensibleRate):
     __slots__ = ("A", "E")
 

--- a/test/python/user_ext.py
+++ b/test/python/user_ext.py
@@ -1,4 +1,5 @@
 import cantera as ct
+import numpy as np
 
 class SquareRateData(ct.ExtensibleRateData):
     __slots__ = ("Tsquared",)
@@ -34,3 +35,29 @@ class SquareRate(ct.ExtensibleRate):
 
     def __del__(self):
         self.use_count[0] -= 1
+
+# A custom interface rate & rate data type
+
+class FooRateData(ct.ExtensibleRateData):
+    __slots__ = ("T",)
+
+    def update(self, interface):
+        gas = interface.adjacent['gas'] # assume gas phase is adjacent to us
+        self.T = gas.T
+        return True
+
+
+@ct.extension(name="interface-foo-rate", data=FooRateData)
+class FooRate(ct.ExtensibleRate):
+    __slots__ = ("A", "E")
+
+    def set_parameters(self, node, units):
+        self.A = node["A"]
+        self.E = node["E"]
+
+    def get_parameters(self, node):
+        node["A"] = self.A
+        node["E"] = self.E
+
+    def eval(self, data):
+        return self.A * np.exp(-self.E / data.T)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add a test case for an extensible interface reaction
- Fix the requirement of using an empty `rate-constant` field and needing the `interface-` prefix on the implementation of the rate parameterization for extensible reactions on interfaces.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1620

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
