### PR TITLE
[Python] Updates for NumPy 2.0 support in the sdist builder

### DIFF
--- a/.github/workflows/packaging.yml
+++ b/.github/workflows/packaging.yml
@@ -10,10 +10,6 @@ on:
         description: "Try to upload wheels and sdist to PyPI after building"
         required: false
         default: "false"
-      upload_to_anaconda:
-        description: "Try to upload package to Anaconda after building"
-        required: false
-        default: "false"
   push:
     # Run on tags that look like releases
     tags:
@@ -25,7 +21,7 @@ on:
 jobs:
   build-packages:
     name: Trigger building packages from external repos
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-22.04
     steps:
       - name: Set up the job
         run: |
@@ -41,13 +37,6 @@ jobs:
           else
             echo "UPLOAD_TO_PYPI=false" >> $GITHUB_ENV
           fi
-          if [ -n "${{ github.event.inputs.upload_to_anaconda }}" ]; then
-            echo "UPLOAD_TO_ANACONDA=${{ github.event.inputs.upload_to_anaconda }}" >> $GITHUB_ENV
-          elif [[ "${{ github.ref }}" == refs/tags* ]]; then
-            echo "UPLOAD_TO_ANACONDA=true" >> $GITHUB_ENV
-          else
-            echo "UPLOAD_TO_ANACONDA=false" >> $GITHUB_ENV
-          fi
       - name: Trigger PyPI/Wheel builds
         run: >
           gh workflow run -R cantera/pypi-packages
@@ -56,18 +45,3 @@ jobs:
           -f upload=${{ env.UPLOAD_TO_PYPI }}
         env:
           GITHUB_TOKEN: ${{ secrets.PYPI_PACKAGE_PAT }}
-      - name: Trigger Conda builds
-        run: >
-          gh workflow run -R cantera/conda-recipes
-          main.yml
-          -f incoming_ref=${{ env.REF }}
-          -f upload=${{ env.UPLOAD_TO_ANACONDA }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.CONDA_PACKAGE_PAT }}
-      - name: Trigger Windows MSI Builds
-        run: >
-          gh workflow run -R cantera/cantera-windows-binaries
-          main.yaml
-          -f incoming_ref=${{ env.REF }}
-        env:
-          GITHUB_TOKEN: ${{ secrets.WINDOWS_MSI_PAT }}

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -158,8 +158,8 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.12']
-        os: ['ubuntu-20.04', 'ubuntu-22.04']
+        python-version: ['3.13']
+        os: ['ubuntu-22.04', 'ubuntu-24.04']
       fail-fast: false
     env:
       HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial

--- a/SConstruct
+++ b/SConstruct
@@ -1828,10 +1828,12 @@ if env['python_package'] != 'none':
             warn_no_full_package = True
         elif cython_version < parse_version("3.0.0"):
             logger.info(
-                f"Using Cython version {cython_version} (uses legacy NumPy API)")
-            env["numpy_1_7_API"] = True
+                f"Using Cython version {cython_version} (uses legacy NumPy API)"
+            )
+            env["require_numpy_1_7_API"] = True
         else:
             logger.info(f"Using Cython version {cython_version}")
+            env["require_numpy_1_7_API"] = False
 
         pytest_version = versions.get("pytest")
         if not check_for_pytest:

--- a/doc/sphinx/install/conda.md
+++ b/doc/sphinx/install/conda.md
@@ -239,5 +239,5 @@ running the commands:
 
 ```shell
 conda activate ct-dev
-conda update --conda-forge libcantera-devel
+conda update --channel conda-forge libcantera-devel
 ```

--- a/doc/sphinx/install/conda.md
+++ b/doc/sphinx/install/conda.md
@@ -33,6 +33,7 @@ solver. To configure the `libmamba` solver, you can run:
 ```shell
 conda config --set solver libmamba
 ```
+
 :::
 
 (sec-conda-python-interface)=
@@ -53,7 +54,7 @@ from Python. For this example, the environment is named `ct-env`. From the comma
 line (or the Anaconda Prompt on Windows), run:
 
 ```shell
-conda create --name ct-env cantera ipython matplotlib jupyter
+conda create --name ct-env --channel conda-forge cantera ipython matplotlib jupyter
 ```
 
 This will create an environment named `ct-env` with Cantera, IPython, Matplotlib, and
@@ -110,8 +111,8 @@ conda activate ct-env
 ### Option 3: Install the development version of Cantera
 
 To install a recent development snapshot (that is, an alpha or beta version) of Cantera,
-use the `conda-forge/label/cantera_dev` channel. Assuming you have an environment named `ct-dev`,
-you can type:
+use the `conda-forge/label/cantera_dev` channel. Assuming you have an environment named
+`ct-dev`, you can type:
 
 ```shell
 conda activate ct-dev
@@ -124,7 +125,7 @@ and then reinstall Cantera:
 ```shell
 conda activate ct-dev
 conda remove cantera
-conda install cantera
+conda install --channel conda-forge cantera
 ```
 
 Alternatively, you can remove the `ct-dev` environment and follow Options 1 or 2 above
@@ -139,7 +140,7 @@ If you already have Cantera installed in a conda environment (named, for example
 
 ```shell
 conda activate ct-dev
-conda update cantera
+conda update --channel conda-forge cantera
 ```
 
 (sec-conda-development-interface)=
@@ -154,7 +155,7 @@ From the command line (or the Anaconda Prompt on Windows), create a new conda
 environment named `ct-dev` using:
 
 ```shell
-conda create --name ct-dev libcantera-devel
+conda create --name ct-dev --channel conda-forge libcantera-devel
 ```
 
 C++ header and libraries are installed within the `ct-dev` environment folder, which
@@ -178,8 +179,8 @@ data files            path/to/conda/envs/ct-dev/share/cantera/data
 In addition to `libcantera-devel`, installation of additional packages is recommended:
 
 ```shell
-$ conda activate ct-dev
-$ conda install cmake scons pkg-config
+conda activate ct-dev
+conda install --channel conda-forge cmake scons pkg-config
 ```
 
 C++ programs can be compiled according to instructions outlined in the [C++
@@ -188,22 +189,22 @@ pre-configured instruction files to facilitate compilation using the build tools
 and `CMake`, for example:
 
 ```shell
-$ cd /path/to/conda/envs/ct-dev/share/cantera/samples/cxx/demo
-$ scons  # uses SConstruct; or
-$ cmake . && cmake --build .  # uses CMakeLists.txt
+cd /path/to/conda/envs/ct-dev/share/cantera/samples/cxx/demo
+scons  # uses SConstruct; or
+cmake . && cmake --build .  # uses CMakeLists.txt
 ```
 
 In addition, individual C++ Cantera sample programs can also be compiled using the
 `pkg-config` build system:
 
 ```shell
-$ g++ demo.cpp -o demo $(pkg-config --cflags --libs cantera)
+g++ demo.cpp -o demo $(pkg-config --cflags --libs cantera)
 ```
 
 In all cases, the build process yields the executable `demo`, which is run as:
 
 ```shell
-$ ./demo
+./demo
 ```
 
 ### Windows Systems
@@ -222,10 +223,10 @@ C++ programs can be compiled according to instructions outlined in the
 preconfigured instruction files to facilitate compilation using the build tools `SCons`
 and `CMake`, for example:
 
-```shell
-$ cd path\to\conda\envs\ct-dev\share\cantera\samples\cxx\demo
-$ scons  # uses SConstruct; or
-$ cmake . && cmake --build . --config Release  # uses CMakeLists.txt
+```pwsh
+cd path\to\conda\envs\ct-dev\share\cantera\samples\cxx\demo
+scons  # uses SConstruct; or
+cmake . && cmake --build . --config Release  # uses CMakeLists.txt
 ```
 
 Fortran 90 support is not provided for Windows.
@@ -238,5 +239,5 @@ running the commands:
 
 ```shell
 conda activate ct-dev
-conda update libcantera-devel
+conda update --conda-forge libcantera-devel
 ```

--- a/doc/sphinx/install/conda.md
+++ b/doc/sphinx/install/conda.md
@@ -2,15 +2,13 @@
 
 (sec-install-conda)=
 
-[Anaconda](https://www.anaconda.com/download#Downloads) and
-[Miniconda](https://docs.conda.io/projects/miniconda/en/latest/) are Python
-distributions that include the ``conda`` package manager, which can be used to install
-Cantera.
+Conda is a package manager built by the Anaconda company. There are several
+distributions of Python that include `conda`, including [Anaconda][anaconda] and
+[miniforge][miniforge]. If you do not have conda installed, we highly recommend using
+[miniforge][miniforge].
 
-Installing Cantera using Conda can provide the Cantera
-[Python module](sec-conda-python-interface) as well as libraries for linking to
-applications written in C++, C, or Fortran 90. There are some exceptions to the
-availability of each interface depending on the operating system and Conda channel used.
+[anaconda]: https://www.anaconda.com/download#Downloads
+[miniforge]: https://github.com/conda-forge/miniforge?tab=readme-ov-file#install
 
 :::{attention}
 The *legacy* Matlab Cantera interface is discontinued and removed in Cantera 3.1. Users
@@ -19,48 +17,34 @@ packages, or migrate their code base to the experimental Matlab toolbox that is
 currently under development.
 :::
 
-Both the Anaconda and Miniconda distributions are available for Linux, macOS (Intel and
-ARM/Apple Silicon), and Windows. On Windows, users should install a 64-bit version of
-Anaconda or Miniconda, since the Cantera Conda packages are only available for 64-bit
-installations.
-
-Both Anaconda and Miniconda include the `conda` package manager; the difference is that
-Anaconda includes a large number of Python packages that are widely used in scientific
-applications, while Miniconda is a minimal distribution that only includes Python and
-Conda, although all of the packages available in Anaconda can be installed in Miniconda.
+Both Anaconda and miniforge include the `conda` package manager. The main difference is
+that miniforge configures `conda-forge` as the default channel. The `conda-forge`
+channel includes many more, up-to-date, packages than the default channel in Anaconda.
 For more details on how to use conda, see the
 [conda documentation](https://docs.conda.io/projects/conda/en/latest/user-guide/index.html).
 
-Conda can install a large set of packages by default and it is possible to install
-packages such as Cantera that are maintained independently. These additional channels
-from which packages may be obtained are specified by adding the `--channel` option in
-the `install` or `create` commands.
-
 For instructions on upgrading an existing conda-based installation of Cantera, see
 [Upgrading from an earlier Cantera version](sec-conda-python-upgrade).
+
+:::{tip}
+To dramatically improve install speed, we recommend using the `libmamba` dependency
+solver. To configure the `libmamba` solver, you can run:
+
+```shell
+conda config --set solver libmamba
+```
+:::
 
 (sec-conda-python-interface)=
 
 ## Python interface
 
-Cantera's Python interface is available from two channels:
+Cantera's Python interface can be installed from the popular `conda-forge` channel.
+Packages are available for the following platforms:
 
-1. The `cantera` channel. This channel should be used if you installed Python from the
-   default channel in conda. This channel also has pre-release versions of Cantera for
-   testing. Cantera packages are available in this channel for the following platforms:
-
-   - Windows (64-bit Intel)
-   - Linux (64-bit Intel)
-   - macOS (64-bit Intel and 64-bit ARM (Apple Silicon))
-
-2. The `conda-forge` channel. This channel should be used if you installed Python from
-   the `conda-forge` channel or if your OS/processor combination is not supported by the
-   `cantera` channel. Cantera packages are available in this channel for the following
-   platforms:
-
-   - Windows (64-bit Intel)
-   - Linux (64-bit Intel, 64-bit ARM, and 64-bit PPCLE)
-   - macOS (64-bit Intel and 64-bit ARM (Apple Silicon))
+- Windows (64-bit Intel)
+- Linux (64-bit Intel, 64-bit ARM, and 64-bit PPCLE)
+- macOS (64-bit Intel and 64-bit ARM (Apple Silicon))
 
 ### Option 1: Create a new environment for Cantera
 
@@ -69,16 +53,11 @@ from Python. For this example, the environment is named `ct-env`. From the comma
 line (or the Anaconda Prompt on Windows), run:
 
 ```shell
-conda create --name ct-env --channel cantera cantera ipython matplotlib jupyter
+conda create --name ct-env cantera ipython matplotlib jupyter
 ```
 
 This will create an environment named `ct-env` with Cantera, IPython, Matplotlib, and
-all their dependencies installed. In this case, we want to install Cantera from the
-`cantera` channel, so we add `--channel cantera` and to tell Conda to look at the
-`cantera` channel in addition to the default channels.
-
-If you want to use the `conda-forge` channel, replace `--channel cantera` with
-`--channel conda-forge`.
+all their dependencies installed.
 
 To use the scripts and modules installed in the `ct-env` environment, including Jupyter,
 you must activate it it by running:
@@ -97,8 +76,7 @@ remember that location.
 ```yaml
 name: ct-env
 channels:
-- cantera  # or use cantera/label/dev for alpha/beta packages
-- defaults
+- conda-forge
 dependencies:
 - python  # Cantera supports Python 3.8 and up
 - cantera
@@ -132,12 +110,12 @@ conda activate ct-env
 ### Option 3: Install the development version of Cantera
 
 To install a recent development snapshot (that is, an alpha or beta version) of Cantera,
-use the `cantera/label/dev` channel. Assuming you have an environment named `ct-dev`,
+use the `conda-forge/label/cantera_dev` channel. Assuming you have an environment named `ct-dev`,
 you can type:
 
 ```shell
 conda activate ct-dev
-conda install --channel cantera/label/dev cantera
+conda install --channel conda-forge/label/cantera_dev cantera
 ```
 
 If you later want to revert back to the stable version in that environment, first remove
@@ -146,7 +124,7 @@ and then reinstall Cantera:
 ```shell
 conda activate ct-dev
 conda remove cantera
-conda install --channel cantera cantera
+conda install cantera
 ```
 
 Alternatively, you can remove the `ct-dev` environment and follow Options 1 or 2 above
@@ -161,12 +139,8 @@ If you already have Cantera installed in a conda environment (named, for example
 
 ```shell
 conda activate ct-dev
-conda update --channel cantera cantera
+conda update cantera
 ```
-
-This assumes you are using Python from the default conda channel. If you installed
-Python and Cantera from the `conda-forge` channel, you should specify the option
-`--channel conda-forge`.
 
 (sec-conda-development-interface)=
 
@@ -176,18 +150,12 @@ The Cantera development interface provides header files and libraries needed to 
 your own C++, C, or Fortran applications that link to Cantera. It also provides several
 sample programs and build scripts that you can adapt for your own applications.
 
-In the following example, Cantera's development interface is installed from the
-`cantera/label/dev` channel. From the command line (or the Anaconda Prompt on Windows),
-create a new conda environment named `ct-dev` using:
+From the command line (or the Anaconda Prompt on Windows), create a new conda
+environment named `ct-dev` using:
 
 ```shell
-conda create --name ct-dev --channel cantera/label/dev libcantera-devel
+conda create --name ct-dev libcantera-devel
 ```
-
-This will create an environment named `ct-dev` with Cantera's development interface. In
-this case, the addition of `--channel cantera/label/dev` ensures that the package is
-pulled from the most recent available Cantera version. Note that `label/dev` refers to
-the experimental development *channel* of Cantera, and not the development *interface*.
 
 C++ header and libraries are installed within the `ct-dev` environment folder, which
 itself depends on the type of `conda` installation, and is abbreviated as
@@ -199,12 +167,12 @@ recommendations for a given operating system.
 Installation folders are:
 
 ```shell
-library files               path/to/conda/envs/ct-dev/lib
-pkg-config                  path/to/conda/envs/ct-dev/lib/pkgconfig
-C++ headers                 path/to/conda/envs/ct-dev/include
-Fortran module files        path/to/conda/envs/ct-dev/include/cantera
-samples                     path/to/conda/envs/ct-dev/share/cantera/samples
-data files                  path/to/conda/envs/ct-dev/share/cantera/data
+library files         path/to/conda/envs/ct-dev/lib
+pkg-config            path/to/conda/envs/ct-dev/lib/pkgconfig
+C++ headers           path/to/conda/envs/ct-dev/include
+Fortran module files  path/to/conda/envs/ct-dev/include/cantera
+samples               path/to/conda/envs/ct-dev/share/cantera/samples
+data files            path/to/conda/envs/ct-dev/share/cantera/data
 ```
 
 In addition to `libcantera-devel`, installation of additional packages is recommended:
@@ -214,10 +182,10 @@ $ conda activate ct-dev
 $ conda install cmake scons pkg-config
 ```
 
-C++ programs can be compiled according to instructions outlined in the
-[C++ Guide](/userguide/compiling-cxx). Sample folders for C, C++ and Fortran include
-preconfigured instruction files to facilitate compilation using the build tools
-`SCons` and `CMake`, for example:
+C++ programs can be compiled according to instructions outlined in the [C++
+Guide](/userguide/compiling-cxx). Sample folders for C, C++ and Fortran include
+pre-configured instruction files to facilitate compilation using the build tools `SCons`
+and `CMake`, for example:
 
 ```shell
 $ cd /path/to/conda/envs/ct-dev/share/cantera/samples/cxx/demo
@@ -270,5 +238,5 @@ running the commands:
 
 ```shell
 conda activate ct-dev
-conda update --channel cantera/label/dev libcantera-devel
+conda update libcantera-devel
 ```

--- a/include/cantera/cython/kinetics_utils.h
+++ b/include/cantera/cython/kinetics_utils.h
@@ -42,13 +42,13 @@ inline void sparseCscData(const Eigen::SparseMatrix<double>& mat,
 
     const double* valuePtr = mat.valuePtr();
     const int* innerPtr = mat.innerIndexPtr();
-    for (size_t i = 0; i < mat.nonZeros(); ++i) {
+    for (int i = 0; i < mat.nonZeros(); ++i) {
         value[i] = valuePtr[i];
         inner[i] = innerPtr[i];
     }
 
     const int* outerPtr = mat.outerIndexPtr();
-    for (size_t i = 0; i < mat.outerSize() + 1; ++i) {
+    for (int i = 0; i < mat.outerSize() + 1; ++i) {
         outer[i] = outerPtr[i];
     }
 }

--- a/interfaces/cython/setup.cfg.in
+++ b/interfaces/cython/setup.cfg.in
@@ -40,9 +40,8 @@ project_urls =
 [options]
 zip_safe = False
 install_requires =
-    numpy >= 1.12.0
+    numpy >= 1.12.0,<3
     ruamel.yaml >= 0.15.34
-    packaging
 python_requires @py_requires_ver_str@
 packages =
     cantera
@@ -64,7 +63,9 @@ cantera.examples = *.txt
 
 [options.extras_require]
 pandas = pandas
-units = pint
+units =
+    pint
+    numpy<2.0; python_version <= '3.9'
 graphviz = graphviz
 
 [options.entry_points]

--- a/interfaces/python_sdist/SConscript
+++ b/interfaces/python_sdist/SConscript
@@ -158,8 +158,8 @@ sdist(localenv.Command("README.rst", "#README.rst", Copy("$TARGET", "$SOURCE")))
 def build_sdist(target, source, env):
     build_dir = Path(source[0].abspath).parent
     with DefaultIsolatedEnv() as build_env:
-        builder = ProjectBuilder(str(build_dir),
-                                 python_executable=build_env.python_executable)
+        builder = ProjectBuilder.from_isolated_env(env=build_env,
+                                                   source_dir=str(build_dir))
 
         # first install the build dependencies
         build_env.install(builder.build_system_requires)

--- a/interfaces/python_sdist/SConscript
+++ b/interfaces/python_sdist/SConscript
@@ -7,7 +7,7 @@ from textwrap import dedent
 from build import ProjectBuilder
 from build.env import DefaultIsolatedEnv
 
-from buildutils import logger
+from buildutils import logger, multi_glob
 
 Import("env")
 
@@ -137,10 +137,15 @@ sdist(localenv.RecursiveInstall("cantera/data",
                                 "#data"))
 
 if localenv["example_data"]:
+    for yaml in multi_glob(localenv, "#data/example_data", "yaml"):
+        sdist(localenv.Command(f"cantera/data/example_data/{yaml.name}", yaml.abspath,
+                               Copy("$TARGET", "$SOURCE")))
     # Add example_data directory to setup.cfg
     localenv["cfg_example_data"] = "cantera.data.example_data"
+    localenv["cfg_example_data_options"] = "cantera.data.example_data = *.*"
 else:
     localenv["cfg_example_data"] = ""
+    localenv["cfg_example_data_options"] = ""
 
 # Copy the minimal Sundials configuration template into the sdist so that
 # it can be filled in at compile time on the user's machine
@@ -164,7 +169,7 @@ def build_sdist(target, source, env):
         # first install the build dependencies
         build_env.install(builder.build_system_requires)
         # then get the extra required dependencies from the backend
-        build_env.install(builder.get_requires_for_build("sdist"))
+        build_env.install(builder.get_requires_for_build("sdist", {}))
         builder.build("sdist", str(build_dir / "dist"), {})
 
 
@@ -182,7 +187,7 @@ def finish_sdist_message(target, source, env):
 
 sdist_target = f"dist/Cantera-{env['cantera_version']}.tar.gz"
 sdist_sources = ("setup.py", "pyproject.toml", "MANIFEST.in")
-built_sdist = localenv.Command(sdist_target, sdist_sources, build_sdist)
+built_sdist_target = localenv.Command(sdist_target, sdist_sources, build_sdist)
 finish_sdist = localenv.Command("finish_sdist", sdist_target, finish_sdist_message)
-localenv.Depends(built_sdist, sdist_targets)
+localenv.Depends(built_sdist_target, sdist_targets)
 env.Alias("sdist", finish_sdist)

--- a/interfaces/python_sdist/pyproject.toml
+++ b/interfaces/python_sdist/pyproject.toml
@@ -4,7 +4,8 @@
 requires = [
   "setuptools>=67.6.1",
   "wheel",
-  "oldest-supported-numpy",
-  "Cython>=0.29.34",
+  "numpy>=2.0; python_version > '3.8'",
+  "oldest_supported_numpy; python_version == '3.8'",
+  "Cython>=3.0.10",
 ]
 build-backend = "setuptools.build_meta"

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -61,6 +61,7 @@ cantera = *.pxd
 cantera.data = *.*
 cantera.examples = *.txt
 cantera.test = *.txt
+@cfg_example_data_options@
 
 # These options exclude data from the wheel file but not from the sdist
 [options.exclude_package_data]

--- a/interfaces/python_sdist/setup.cfg.in
+++ b/interfaces/python_sdist/setup.cfg.in
@@ -41,9 +41,8 @@ project_urls =
 zip_safe = False
 include_package_data = True
 install_requires =
-    numpy >= 1.12.0
+    numpy >= 1.12.0,<3
     ruamel.yaml >= 0.15.34
-    packaging
 python_requires @py_requires_ver_str@
 packages =
     cantera
@@ -69,7 +68,10 @@ cantera = *.cpp, *.h, *.pyx
 
 [options.extras_require]
 pandas = pandas
-units = pint
+units =
+    pint
+    numpy<2.0; python_version <= '3.9'
+
 graphviz = graphviz
 
 [options.entry_points]

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1382,7 +1382,7 @@ def setup_python_env(env):
             if env['OS_BITS'] == 64:
                 env.Append(CPPDEFINES='MS_WIN64')
 
-    if "numpy_1_7_API" in env:
+    if not env.get("require_numpy_1_7_API", True):
         env.Append(CPPDEFINES="NPY_NO_DEPRECATED_API=NPY_1_7_API_VERSION")
 
 


### PR DESCRIPTION
- **Fix a few compiler warnings from Eigen in the Cython interface**
- **Change how the sdist build environment is created**
- **Install example data in the sdist**
  This can be configured by the top-level example_data option
- **Simplify extension setup to resolve duplicate cythonizing**
  When building the sdist via scons, the cython step was running twice because of the conditional. In addition, we were getting a warning about building the extension from multiple source files. These changes resolve both problems by cythonizing once if the files aren't present and only including the C++ sources in the extension.
- **Fix build-system dependencies for NumPy 2.0 support**
  NumPy 2.0 does not support Python 3.8, so we need to special case that version. Also special case for Pint, which doesn't support NumPy 2.0 on Python 3.9.