### PR TITLE
Update ReactorNet drawing functions

### DIFF
--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -92,7 +92,8 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
 def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
                      heat_flow_attr=None, mass_flow_attr=None,
                      moving_wall_edge_attr=None, surface_edge_attr=None,
-                     print_state=False, show_wall_velocity=True, **kwargs):
+                     show_wall_velocity=True, print_state=False, species=None,
+                     species_units="percent"):
     """
     See `.ReactorNet.draw`.
 
@@ -119,22 +120,26 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
         for name, group in reactor_groups.items():
             sub = _graphviz.Digraph(name=f"cluster_{name}", graph_attr=graph_attr)
             for r in group:
-                draw_reactor(r, sub, print_state=print_state, **kwargs)
+                draw_reactor(r, sub, print_state=print_state, species=species,
+                             species_units=species_units)
                 drawn_reactors.add(r)
                 flow_controllers.update(r.inlets + r.outlets)
                 walls.update(r.walls)
                 for surface in r.surfaces:
-                    draw_surface(surface, sub, print_state=print_state, **kwargs)
+                    draw_surface(surface, sub, print_state=print_state, species=species,
+                                 species_units=species_units)
             sub.attr(label=name)
             graph.subgraph(sub)
     reactors -= drawn_reactors
 
     for r in reactors:
-        draw_reactor(r, graph, print_state=print_state, **kwargs)
+        draw_reactor(r, graph, print_state=print_state, species=species,
+                     species_units=species_units)
         flow_controllers.update(r.inlets + r.outlets)
         walls.update(r.walls)
         for surface in r.surfaces:
-            draw_surface(surface, graph, print_state=print_state, **kwargs)
+            draw_surface(surface, graph, print_state=print_state, species=species,
+                         species_units=species_units)
 
     # some Reactors or Reservoirs only exist as connecting nodes
     connected_reactors = set()
@@ -151,21 +156,23 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
     # remove already drawn reactors and draw new reactors
     connected_reactors -= drawn_reactors
     for r in connected_reactors:
-        draw_reactor(r, graph, print_state=print_state, **kwargs)
+        draw_reactor(r, graph, print_state=print_state, species=species,
+                     species_units=species_units)
 
     fc_edge_attr = {**(edge_attr or {}), **(mass_flow_attr or {})}
-    draw_flow_controllers(flow_controllers, graph, edge_attr=fc_edge_attr, **kwargs)
+    draw_flow_controllers(flow_controllers, graph, edge_attr=fc_edge_attr)
     w_edge_attr = {**(edge_attr or {}), "color": "red", "style": "dashed",
                    **(heat_flow_attr or {})}
     draw_walls(walls, graph, edge_attr=w_edge_attr,
                moving_wall_edge_attr=moving_wall_edge_attr,
-               show_wall_velocity=show_wall_velocity, **kwargs)
+               show_wall_velocity=show_wall_velocity)
 
     return graph
 
 
 def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
-                 surface_edge_attr=None, print_state=False, **kwargs):
+                 surface_edge_attr=None, print_state=False, species=None,
+                 species_units="percent"):
     """
     See `.ReactorSurface.draw`.
 
@@ -173,7 +180,8 @@ def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
     """
 
     r = surface.reactor
-    graph = draw_reactor(r, graph, graph_attr, node_attr, print_state, **kwargs)
+    graph = draw_reactor(r, graph, graph_attr, node_attr, print_state, species=species,
+                         species_units=species_units)
     name = f"{r.name} surface"
     edge_attr = {"style": "dotted", "arrowhead": "none",
                  **(surface_edge_attr or {})}

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -78,9 +78,14 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
 
         # For full state output, shape must be 'Mrecord'
         node_attr.pop("shape", None)
-        graph.node(r.name, shape="Mrecord",
-                   label=f"{{{T_label}|{P_label}}}|{s_label}",
-                   xlabel=r.name, **node_attr)
+        if s_label:
+            graph.node(r.name, shape="Mrecord",
+                    label=f"{{{r.name}|{{{{{T_label}|{P_label}}}|{s_label}}}}}",
+                    **node_attr)
+        else:
+            graph.node(r.name, shape="Mrecord",
+                    label=f"{{{r.name}|{{{T_label}|{P_label}}}}}",
+                    **node_attr)
 
     else:
         graph.node(r.name, **node_attr)
@@ -241,7 +246,7 @@ def draw_flow_controllers(flow_controllers, graph=None, graph_attr=None, node_at
             rate *= -1
 
         graph.edge(inflow_name, outflow_name,
-                   **{"label": f"m = {rate:.2g} kg/s", **edge_attr, **fc.edge_attr,
+                   **{"label": f"ṁ = {rate:.2g} kg/s", **edge_attr, **fc.edge_attr,
                       **edge_attr_overwrite})
 
     return graph

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -34,36 +34,7 @@ def _needs_graphviz(func):
 def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=False,
                  species=None, species_units="percent"):
     """
-    Draw `~cantera.ReactorBase` object as ``graphviz`` ``dot`` node.
-    The node is added to an existing ``graph`` if provided.
-    Optionally include current reactor state in the node.
-
-    :param r:
-        `~cantera.ReactorBase` object or subclass.
-    :param graph:
-        ``graphviz.graphs.BaseGraph`` object to which the reactor is added.
-        If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
-    :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        general appearance of the drawn network.
-        Has no effect if existing ``graph`` is provided.
-        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
-    :param node_attr:
-        Attributes to be passed to the ``node`` method invoked to draw the reactor.
-        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
-    :param print_state:
-        Whether state information of the reactor is printed into the node.
-        Defaults to ``False``.
-    :param species:
-        If ``print_state`` is ``True``, define how species are to be printed.
-        Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all species,
-        respectively, or an iterable that contains the desired species names as strings.
-        Defaults to ``None``.
-    :param species_units:
-        Defines the units the species are displayed in as either ``"percent"`` or
-        ``"ppm"``. Defaults to ``"percent"``.
-    :return:
-        ``graphviz.graphs.BaseGraph`` object with reactor
+    See `.ReactorBase.draw`.
 
     .. versionadded:: 3.1
     """
@@ -123,50 +94,7 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
                      moving_wall_edge_attr=None, surface_edge_attr=None,
                      print_state=False, show_wall_velocity=True, **kwargs):
     """
-    Draw `~cantera.ReactorNet` object as ``graphviz.graphs.DiGraph``. Connecting flow
-    controllers and walls are depicted as arrows.
-
-    :param n:
-        `~cantera.ReactorNet` object
-    :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        general appearance of the drawn network.
-        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
-    :param node_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        default appearance of any ``node`` (reactors, reservoirs).
-        ``node_attr`` defined in the reactor object itself have priority.
-        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
-    :param edge_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        default appearance of any ``edge`` (flow controllers, walls).
-        ``edge_attr`` defined in the connection objects (subclasses of
-        `~cantera.FlowDevice` or walls) themselves have priority.
-        See https://graphviz.org/docs/edges/ for a list of all usable attributes.
-    :param heat_flow_attr:
-        Same as ``edge_attr`` but only applied to edges representing walls.
-        Default is ``{"color": "red", "style": "dashed"}``.
-    :param mass_flow_attr:
-        Same as ``edge_attr`` but only applied to edges representing
-        `~cantera.FlowDevice` objects.
-    :param moving_wall_edge_attr:
-        Same as ``edge_attr`` but only applied to edges representing wall movement.
-    :param surface_edge_attr:
-        Same as ``edge_attr`` but only applied to edges representing connections between
-        a surface and its reactor.
-        Default is ``{"style": "dotted", "arrowhead": "none"}``.
-    :param print_state:
-        Whether state information of each reactor is printed into the respective node.
-        See `draw_reactor` for additional keywords to control this output.
-        Defaults to ``False``.
-    :param show_wall_velocity:
-        If ``True``, wall movement will be indicated by additional arrows with the
-        corresponding wall velocity as a label.
-    :param kwargs:
-        Additional keywords are passed on to each call of `draw_reactor`,
-        `draw_surface`, `draw_flow_controllers`, and `draw_walls`.
-    :return:
-        ``graphviz.graphs.BaseGraph`` object with reactor net.
+    See `.ReactorNet.draw`.
 
     .. versionadded:: 3.1
     """
@@ -239,34 +167,7 @@ def draw_reactor_net(n, graph_attr=None, node_attr=None, edge_attr=None,
 def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
                  surface_edge_attr=None, print_state=False, **kwargs):
     """
-    Draw `~cantera.ReactorSurface` object with its connected reactor.
-
-    :param surface:
-        `~cantera.ReactorSurface` object.
-    :param graph:
-        ``graphviz.graphs.BaseGraph`` object to which the connection is added.
-        If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
-    :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        general appearance of the drawn network.
-        Has no effect if existing ``graph`` is provided.
-        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
-    :param node_attr:
-        Attributes to be passed to the ``node`` method invoked to draw the reactor.
-        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
-    :param surface_edge_attr:
-        Attributes to be passed to the ``edge`` method invoked to draw the connection
-        between the surface and its reactor.
-        See https://graphviz.org/docs/edges/ for a list of all usable attributes.
-        Default is ``{"style": "dotted", "arrowhead": "none"}``.
-    :param print_state:
-        Whether state information of the reactor is printed into the node.
-        See ``draw_reactor`` for additional keywords to control this output.
-        Defaults to ``False``.
-    :param kwargs:
-        Additional keywords are passed on to `draw_reactor`.
-    :return:
-        A ``graphviz.graphs.BaseGraph`` object depicting the surface and its reactor.
+    See `.ReactorSurface.draw`.
 
     .. versionadded:: 3.1
     """
@@ -287,29 +188,10 @@ def draw_surface(surface, graph=None, graph_attr=None, node_attr=None,
 def draw_flow_controllers(flow_controllers, graph=None, graph_attr=None, node_attr=None,
                           edge_attr=None):
     """
-    Draw flow controller connections between reactors and reservoirs.
+    See `.FlowDevice.draw`.
 
     :param flow_controllers:
         Iterable of subtypes of `~cantera.FlowDevice`.
-    :param graph:
-        ``graphviz.graphs.BaseGraph`` object to which the connection is added.
-        If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
-    :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        general appearance of the drawn network.
-        Has no effect if existing ``graph`` is provided.
-        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
-    :param node_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        default appearance of any ``node`` (reactors, reservoirs).
-        Has no effect if existing ``graph`` is provided.
-        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
-    :param edge_attr:
-        Attributes to be passed to the ``edge`` method invoked to draw reactor
-        connections.
-        See https://graphviz.org/docs/edges/ for a list of all usable attributes.
-    :return:
-        A ``graphviz.graphs.BaseGraph`` object depicting the connections.
 
     .. versionadded:: 3.1
     """
@@ -361,38 +243,10 @@ def draw_flow_controllers(flow_controllers, graph=None, graph_attr=None, node_at
 def draw_walls(walls, graph=None, graph_attr=None, node_attr=None, edge_attr=None,
                moving_wall_edge_attr=None, show_wall_velocity=True):
     """
-    Draw wall connections between reactors and reservoirs.
+    See `.Wall.draw`.
 
     :param walls:
-        Iterable of subtypes of `~cantera.WallBase` that connect reactors and
-        reservoirs.
-    :param graph:
-        ``graphviz.graphs.BaseGraph`` object to which the connection is added.
-        If not provided, a new ``DiGraph`` is created. Defaults to ``None``.
-    :param graph_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        general appearance of the drawn network.
-        Has no effect if existing ``graph`` is provided.
-        See https://graphviz.org/docs/graph/ for a list of all usable attributes.
-    :param node_attr:
-        Attributes to be passed to the ``graphviz.Digraph`` function that control the
-        default appearance of any ``node`` (reactors, reservoirs).
-        Has no effect if existing ``graph`` is provided.
-        See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
-    :param edge_attr:
-        Attributes to be passed to the ``edge`` method invoked to draw reactor
-        connections.
-        Default is ``{"color": "red", "style": "dashed"}``.
-        See https://graphviz.org/docs/edges/ for a list of all usable attributes.
-    :param moving_wall_edge_attr:
-        Same as ``edge_attr`` but only applied to edges representing wall movement.
-        Default is ``{"arrowtail": "icurveteecurve", "dir": "both", "style": "dotted",
-        "arrowhead": "icurveteecurve"}``.
-    :param show_wall_velocity:
-        If ``True``, wall movement will be indicated by additional arrows with the
-        corresponding wall velocity as a label.
-    :return:
-        A ``graphviz.graphs.BaseGraph`` object depicting the connections.
+        Iterable of subtypes of `~cantera.Wall` that connect reactors and reservoirs.
 
     .. versionadded:: 3.1
     """

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -884,8 +884,9 @@ cdef class ReactorSurface:
         """
         return self._reactor
 
-    def draw(self, graph=None, *, graph_attr=None, node_attr=None, surface_edge_attr=None,
-             print_state=False, **kwargs):
+    def draw(self, graph=None, *, graph_attr=None, node_attr=None,
+             surface_edge_attr=None,  print_state=False, species=None,
+             species_units="percent"):
         """
         Draw the surface as a ``graphviz`` ``dot`` node connected to its reactor.
         The node is added to an existing ``graph`` if provided.
@@ -908,8 +909,14 @@ cdef class ReactorSurface:
         :param print_state:
             Whether state information of the reactor is printed into its node.
             Defaults to ``False``
-        :param kwargs:
-            Additional keywords are passed on to ``~.drawnetwork.draw_reactor``.
+        :param species:
+            If ``print_state`` is ``True``, define how species are to be printed.
+            Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all species,
+            respectively, or an iterable that contains the desired species names as
+            strings. Defaults to ``None``.
+        :param species_units:
+            Defines the units the species are displayed in as either ``"percent"`` or
+            ``"ppm"``. Defaults to ``"percent"``.
         :return:
             ``graphviz.graphs.BaseGraph`` object with surface and connected
             reactor.
@@ -917,7 +924,7 @@ cdef class ReactorSurface:
         .. versionadded:: 3.1
         """
         return draw_surface(self, graph, graph_attr, node_attr, surface_edge_attr,
-                            print_state, **kwargs)
+                            print_state, species, species_units)
 
     def add_sensitivity_reaction(self, int m):
         """
@@ -2017,8 +2024,8 @@ cdef class ReactorNet:
 
     def draw(self, *, graph_attr=None, node_attr=None, edge_attr=None,
              heat_flow_attr=None, mass_flow_attr=None, moving_wall_edge_attr=None,
-             surface_edge_attr=None, print_state=False, show_wall_velocity=True,
-             **kwargs):
+             surface_edge_attr=None, show_wall_velocity=True, print_state=False,
+             species=None, species_units="percent"):
         """
         Draw as ``graphviz.graphs.DiGraph``. Connecting flow controllers and
         walls are depicted as arrows.
@@ -2050,18 +2057,25 @@ cdef class ReactorNet:
             Same as ``edge_attr`` but only applied to edges representing connections
             between `ReactorSurface` objects and reactors.
             Default is ``{"style": "dotted", "arrowhead": "none"}``.
+        :param show_wall_velocity:
+            If ``True``, wall movement will be indicated by additional arrows with the
+            corresponding wall velocity as a label.
         :param print_state:
             Whether state information of the reactors is printed into each node.
             Defaults to ``False``.
-        :param kwargs:
-            Additional keywords are passed on to each call of
-            `~.drawnetwork.draw_reactor`, `~.drawnetwork.draw_surface`,
-            `~.drawnetwork.draw_flow_controllers`, and `~.drawnetwork.draw_walls`.
+        :param species:
+            If ``print_state`` is ``True``, define how species are to be printed.
+            Options are ``'X'`` and ``'Y'`` for mole and mass fractions of all species,
+            respectively, or an iterable that contains the desired species names as
+            strings. Defaults to ``None``.
+        :param species_units:
+            Defines the units the species are displayed in as either ``"percent"`` or
+            ``"ppm"``. Defaults to ``"percent"``.
         :return:
             ``graphviz.graphs.BaseGraph`` object with reactor net.
 
         .. versionadded:: 3.1
         """
         return draw_reactor_net(self, graph_attr, node_attr, edge_attr, heat_flow_attr,
-                 mass_flow_attr, moving_wall_edge_attr, surface_edge_attr, print_state,
-                 **kwargs)
+                 mass_flow_attr, moving_wall_edge_attr, surface_edge_attr,
+                 show_wall_velocity, print_state, species, species_units)

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -157,9 +157,8 @@ cdef class ReactorBase:
     def draw(self, graph=None, *, graph_attr=None, node_attr=None, print_state=False,
              species=None, species_units="percent"):
         """
-        Draw as ``graphviz`` ``dot`` node.
-        The node is added to an existing ``graph`` if provided.
-        Optionally include current reactor state in the node.
+        Draw as ``graphviz`` ``dot`` node. The node is added to an existing ``graph`` if
+        provided. Optionally include current reactor state in the node.
 
         :param graph:
             ``graphviz.graphs.BaseGraph`` object to which the reactor is added.


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Avoid maintaining redundant docstrings in `drawnetwork.py` -- just reference the docs for the member function versions
- Fix ability to pass arguments to `ReactorNet.draw` to show composition for all reactors in the network
- When drawing the state, put the reactor label inside the reactor boundary to avoid ugly overlaps

**If applicable, provide an example illustrating new features this pull request is introducing**
Graph generated by adding
```python
mixer.draw(print_state=True, species="X")
```
to `mix1.py`:

![rnet](https://github.com/Cantera/cantera/assets/644977/827a699f-0877-44d1-9c0e-5ba169738e4e)


<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
