### PR TITLE
[Python] Fix Py_UnbufferedStdioFlag is deprecated

### DIFF
--- a/src/extensions/pythonShim.cpp
+++ b/src/extensions/pythonShim.cpp
@@ -69,10 +69,10 @@ void loadCanteraPython()
     // Prevent output buffering managed by Python.
     // @todo: It may be better to avoid replacing the existing Logger instance
     //     with a PythonLogger in the case of an embedded Python interpreter.
-    Py_UnbufferedStdioFlag = 1;
     const char* venv_path = getenv("VIRTUAL_ENV");
     if (venv_path != nullptr) {
         PyConfig pyconf;
+        pyconf.buffered_stdio = 0;
         PyConfig_InitPythonConfig(&pyconf);
 
         #ifdef _WIN32
@@ -90,7 +90,7 @@ void loadCanteraPython()
     } else {
         #ifdef _WIN32
             setPythonHome();
-      #endif
+        #endif
         Py_Initialize();
     }
     PyObject* pythonExt = PyImport_ImportModule("cantera");


### PR DESCRIPTION
**Changes proposed in this pull request**

- Set up Python config according to https://docs.python.org/3.8/c-api/init_config.html#c.PyConfig.buffered_stdio

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1715 

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
