### PR TITLE
[base] Fix repeated slicing of SolutionArray

### DIFF
--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -71,9 +71,19 @@ SolutionArray::SolutionArray(const SolutionArray& other,
     , m_extra(other.m_extra)
     , m_order(other.m_order)
     , m_shared(true)
-    , m_active(selected)
 {
     m_sol->thermo()->addSpeciesLock();
+    if (!other.m_shared) {
+        // direct slicing is possible
+        m_active = selected;
+    } else {
+        // slicing a previously sliced SolutionArray
+        m_active.clear();
+        m_active.reserve(selected.size());
+        for (auto loc : selected) {
+            m_active.push_back(other.m_active.at(loc));
+        }
+    }
     for (auto loc : m_active) {
         if (loc < 0 || loc >= (int)m_dataSize) {
             IndexError("SolutionArray::SolutionArray", "indices", loc, m_dataSize);

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -233,6 +233,24 @@ class TestSolutionArray(utilities.CanteraTest):
         arr = ct.SolutionArray(self.gas, states=states)
         assert arr.shape == (3, 5) # shape is based on numpy conversion
 
+    def test_slice_twice(self):
+        T_list = np.linspace(300, 1000, 8)
+        self.gas.TPX = T_list[0], ct.one_atm, {"H2": 1.}
+        arr = ct.SolutionArray(self.gas)
+        for T in T_list[1:]:
+            self.gas.TPX = T, ct.one_atm, {"H2": 1.}
+            arr.append(self.gas.state)
+        ix = 4
+        arr_trunc = arr[ix:]
+        assert arr_trunc.T[0] == arr.T[ix]
+        assert arr_trunc[0].T == arr.T[ix]
+        assert arr_trunc.T[-1] == arr.T[-1]
+        assert arr_trunc[-1].T == arr.T[-1]
+        assert (arr_trunc.T[:2] == arr.T[ix:ix+2]).all()
+        assert (arr_trunc[:2].T == arr.T[ix:ix+2]).all()
+        with self.assertRaises(IndexError):
+            arr_trunc[10]
+
     def test_from_state_numpy(self):
         states = np.array([[list(self.gas.state)] * 5] * 3)
         arr = ct.SolutionArray(self.gas, states=states)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Fix `SolutionArray` slices that are sliced again

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1690

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

See example provided in #1690
```
In [1]: import cantera as ct
   ...: gas = ct.Solution('gri30.yaml')
   ...: gas.TP = 650, 10 * ct.one_atm
   ...: gas.set_equivalence_ratio(.5, "CH4", "N2:0.79,O2:0.21")
   ...:
   ...: r = ct.IdealGasConstPressureReactor(gas)
   ...: sim = ct.ReactorNet([r])
   ...: solnArr = ct.SolutionArray(gas)
   ...: for i in range(1000):
   ...:     sim.step()
   ...:     solnArr.append(r.thermo.state)
   ...:
   ...: print("Original Soln Arr From Reactor Network")
   ...: print(solnArr[0].T)
   ...: print(solnArr.T[0])
   ...:
   ...: print("Truncated Soln Arr From Reactor Network")
   ...: solnArr_trunc = solnArr[800:]
   ...: print(solnArr_trunc[0].T)
   ...: print(solnArr_trunc.T[0])
Original Soln Arr From Reactor Network
650.0
650.0
Truncated Soln Arr From Reactor Network
653.1879043727091
653.1879043727091

In [2]: solnArr[800]
Out[2]:
           T        D           H2            H  ...         C3H7         C3H8      CH2CHO       CH3CHO
800  653.188  5.26327  1.03361e-09  1.58059e-17  ...  1.58630e-13  1.93274e-09  5.1190e-18  2.39309e-18

[1 rows x 55 components; state='TDY']

In [3]: solnArr_trunc[0]
Out[3]:
           T        D           H2            H  ...         C3H7         C3H8      CH2CHO       CH3CHO
800  653.188  5.26327  1.03361e-09  1.58059e-17  ...  1.58630e-13  1.93274e-09  5.1190e-18  2.39309e-18

[1 rows x 55 components; state='TDY']

```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
