### PR TITLE
[python] Fix dimension of sliced SolutionArray methods

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1417,11 +1417,13 @@ def _make_functions():
         return np.empty(self.shape + (self._phase.n_selected_species,))
 
     def empty_total_species(self):
-        return np.empty(self.shape + (self._phase.n_total_species,))
+        n_tot = self._phase.n_total_species
+        # account for deselected species
+        n_tot -= self._phase.n_species - self._phase.n_selected_species
+        return np.empty(self.shape + (n_tot,))
 
     def empty_species2(self):
-        return np.empty(self.shape + (self._phase.n_species,
-                                       self._phase.n_species))
+        return np.empty(self.shape + (self._phase.n_species, self._phase.n_species))
 
     def empty_reactions(self):
         return np.empty(self.shape + (self._phase.n_reactions,))

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1429,8 +1429,13 @@ def _make_functions():
         return np.empty(self.shape + (self._phase.n_reactions,))
 
     # Factory for creating read-only properties
-    def make_prop(name, get_container, doc_source):
+    def make_prop(name, get_container, doc_source, block_interface=False):
         def getter(self):
+            if block_interface and isinstance(self._phase, Interface):
+                # used to block Interface methods that require synchronized updates of
+                # linked phases
+                raise NotImplementedError(
+                    "Method not implemented for SolutionArray containing Interface.")
             v = get_container(self)
             for loc, index in enumerate(self._indices):
                 self._set_loc(loc)
@@ -1455,13 +1460,13 @@ def _make_functions():
 
     for name in SolutionArray._n_total_species:
         setattr(SolutionArray, name,
-                make_prop(name, empty_total_species, Solution))
+                make_prop(name, empty_total_species, Solution, True))
 
     for name in SolutionArray._n_species2:
-        setattr(SolutionArray, name, make_prop(name, empty_species2, Solution))
+        setattr(SolutionArray, name, make_prop(name, empty_species2, Solution, True))
 
     for name in SolutionArray._n_reactions:
-        setattr(SolutionArray, name, make_prop(name, empty_reactions, Solution))
+        setattr(SolutionArray, name, make_prop(name, empty_reactions, Solution, True))
 
     # Factory for creating wrappers for functions which return a value
     def caller(name, get_container):

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -270,6 +270,23 @@ class TestSolutionArray(utilities.CanteraTest):
         gas.add_species(species_x)
         assert gas.n_species == N + 1
 
+    def test_selected_species(self):
+        gas = ct.Solution("h2o2.yaml", transport_model=None)
+        gas.TPX = 300, ct.one_atm, {"H2": .5, "O2": .5}
+        gas.equilibrate("HP")
+        gas.TP = 1500, ct.one_atm
+        siz = 10
+        arr = ct.SolutionArray(gas, shape=siz)
+        for spc in gas.species_names:
+            assert arr(spc).Y.shape == (siz, 1)
+            assert arr(spc).Y[0] == gas[spc].Y[0]
+            wi_dot = arr(spc).net_production_rates
+            assert wi_dot.shape == (siz, 1)
+            assert wi_dot[0] == gas[spc].net_production_rates[0]
+        spc = ["H2", "O2"]
+        assert arr(*spc).Y.shape == (siz, 2)
+        assert arr(*spc).net_production_rates.shape == (siz, 2)
+
 
 class TestSolutionArrayInfo(utilities.CanteraTest):
     """ Test SolutionArray summary output """

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -287,6 +287,15 @@ class TestSolutionArray(utilities.CanteraTest):
         assert arr(*spc).Y.shape == (siz, 2)
         assert arr(*spc).net_production_rates.shape == (siz, 2)
 
+    def test_interface_wdot(self):
+        gas = ct.Solution("ptcombust.yaml", "gas", transport_model=None)
+        surf = ct.Interface("ptcombust.yaml", "Pt_surf", [gas])
+        arr = ct.SolutionArray(surf, shape=1)
+        with self.assertRaisesRegex(NotImplementedError, "containing Interface"):
+            arr.net_production_rates
+        arr = ct.SolutionArray(gas, shape=1)
+        assert arr.net_production_rates.size == gas.n_species
+
 
 class TestSolutionArrayInfo(utilities.CanteraTest):
     """ Test SolutionArray summary output """


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

* Fix dimension of 'inherited' `Solution` methods
* Disable some problematic `SolutionArray` methods when phase is an `Interface`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1717

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->


```
In [1]: import cantera as ct
   ...: gas = ct.Solution("h2o2.yaml")
   ...: gas.TPY = 900, 1.e05, {"H2": 1.0, "O2": 1.0}

In [2]: arr = ct.SolutionArray(gas, states=[list(gas.state)] * 10)

In [3]: arr("H2").Y.shape
Out[3]: (10, 1)

In [4]: arr("H2").net_production_rates.shape
Out[4]: (10, 1)
```

**Comments**

This is to make the interface _somewhat_ consistent with `Solution`; there are some differences, e.g. round vs square brackets, or passing of lists vs argument lists, where fixes go beyond the scope of this PR. Also, `Solution` currently does not slice `gas["O2"].binary_diff_coeffs` correctly, so this PR merely ensures that implementations are mostly consistent.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
