### PR TITLE
Address minor gcc warnings

### DIFF
--- a/include/cantera/kinetics/InterfaceRate.h
+++ b/include/cantera/kinetics/InterfaceRate.h
@@ -94,6 +94,8 @@ class InterfaceRateBase
 public:
     InterfaceRateBase();
 
+    virtual ~InterfaceRateBase() = default;
+
     //! Perform object setup based on AnyMap node information
     //! @param node  AnyMap object containing reaction rate specification
     void setParameters(const AnyMap& node);

--- a/include/cantera/kinetics/ReactionData.h
+++ b/include/cantera/kinetics/ReactionData.h
@@ -27,6 +27,8 @@ struct ReactionData
 {
     ReactionData() = default;
 
+    virtual ~ReactionData() = default;
+
     //! Update data container based on temperature *T*
     /**
      * Only used in conjunction with MultiRateBase::evalSingle / ReactionRate::eval.

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -767,19 +767,19 @@ bool operator!=(const string& lhs, const AnyValue& rhs)
 // Specialization for "Quantity"
 
 void AnyValue::setQuantity(double value, const string& units, bool is_act_energy) {
-    m_value = Quantity{AnyValue(value), Units(units), is_act_energy};
+    m_value = Quantity{AnyValue(value), Units(units), is_act_energy, {}};
     m_equals = eq_comparer<Quantity>;
 }
 
 void AnyValue::setQuantity(double value, const Units& units) {
-    m_value = Quantity{AnyValue(value), units, false};
+    m_value = Quantity{AnyValue(value), units, false, {}};
     m_equals = eq_comparer<Quantity>;
 }
 
 void AnyValue::setQuantity(const vector<double>& values, const string& units) {
     AnyValue v;
     v = values;
-    m_value = Quantity{v, Units(units), false};
+    m_value = Quantity{v, Units(units), false, {}};
     m_equals = eq_comparer<Quantity>;
 }
 


### PR DESCRIPTION
**Changes proposed in this pull request**

Two minor fixes to address warnings issued by gcc (tested with 14.1):

- Add virtual destructors to two base classes (I don't see a reason for these to not have virtual destructors)
- Explicitly include the `unitConverter` struct of `Quantity` in brace initializers

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
