### PR TITLE
Add stack trace option to CanteraError

### DIFF
--- a/doc/sphinx/develop/running-tests.md
+++ b/doc/sphinx/develop/running-tests.md
@@ -1,3 +1,6 @@
+```{py:currentmodule} cantera
+```
+
 # Running Tests and Debugging
 
 ## Using Cantera from the Build Directory
@@ -384,3 +387,15 @@ Then at the `(gdb)` prompt, type `run` and press Enter.
 After the debugger reaches the error, the most useful command is the `where` command,
 which will print a stack trace. The `up` command will move up the stack each time it is
 called and print the corresponding line of the source code.
+
+## Accessing Stack Traces
+
+Before resorting to running in the debugger, it can sometimes be helpful to get the
+stack trace associated with an error from within a normal workflow. To enable printing
+a stacktrace after an unhandled exception or segmentation fault, you can call the C++
+function {ct}`printStackTraceOnSegfault` or the Python function
+{py:func}`print_stack_trace_on_segfault`. To add stack trace information to the error
+message printed by any `CanteraError` exceptions, you can call the C++ method
+{ct}`CanteraError::setStackTraceDepth` with a depth of 20 to print the top 20 frames of
+the call stack, or similarly the Python method
+{py:meth}`CanteraError.set_stack_trace_depth`.

--- a/doc/sphinx/python/utilities.rst
+++ b/doc/sphinx/python/utilities.rst
@@ -47,6 +47,7 @@ Global Functions
 .. autofunction:: suppress_thermo_warnings
 .. autofunction:: use_legacy_rate_constants
 .. autofunction:: debug_mode_enabled
+.. autofunction:: print_stack_trace_on_segfault
 .. autofunction:: add_module_directory
 
 .. autofunction:: extension(name: str)

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -81,7 +81,7 @@ public:
      */
     template <typename... Args>
     CanteraError(const string& procedure, const string& msg, const Args&... args)
-        : procedure_(procedure)
+        : CanteraError(procedure)
     {
         if (sizeof...(args) == 0) {
             msg_ = msg;
@@ -107,6 +107,10 @@ public:
         return "CanteraError";
     }
 
+    //! Set the number of stack frames to include when a CanteraError is displayed. By
+    //! default, or if the depth is set to 0, no stack information will be shown.
+    static void setStackTraceDepth(int depth);
+
 protected:
     //! Protected default constructor discourages throwing errors containing no
     //! information.
@@ -121,6 +125,9 @@ protected:
 
 private:
     string msg_; //!< Message associated with the exception
+
+    string traceback_; //!< Stack trace to location where exception was thrown
+    static int traceDepth_; //!< Number of stack frames to show. 0 to disable.
 };
 
 

--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -84,6 +84,13 @@ cdef extern from "cantera/base/global.h" namespace "Cantera":
     cdef void CxxPrintStackTraceOnSegfault "Cantera::printStackTraceOnSegfault" ()
 
 
+cdef extern from "cantera/base/ctexceptions.h" namespace "Cantera":
+    cdef cppclass CxxCanteraError "Cantera::CanteraError":
+        CxxCanteraError()
+        @staticmethod
+        void setStackTraceDepth(int)
+
+
 cdef extern from "cantera/cython/utils_utils.h":
     cdef string get_cantera_version_py()
     cdef string get_cantera_git_commit_py()

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -153,7 +153,13 @@ cdef comp_map_to_dict(Composition m):
     return {pystr(species):value for species,value in (<object>m).items()}
 
 class CanteraError(RuntimeError):
-    pass
+    @staticmethod
+    def set_stack_trace_depth(depth):
+        """
+        Set the number of stack frames to include when a `CanteraError` is displayed. By
+        default, or if the depth is set to 0, no stack information will be shown.
+        """
+        CxxCanteraError.setStackTraceDepth(depth)
 
 _DimensionalValue = namedtuple('_DimensionalValue',
                               ('value', 'units', 'activation_energy'),

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -507,10 +507,14 @@ void CVodesIntegrator::integrate(double tout)
     int nsteps = 0;
     while (m_tInteg < tout) {
         if (nsteps >= m_maxsteps) {
+            string f_errs = m_func->getErrors();
+            if (!f_errs.empty()) {
+                f_errs = "\nExceptions caught during RHS evaluation:\n" + f_errs;
+            }
             throw CanteraError("CVodesIntegrator::integrate",
                 "Maximum number of timesteps ({}) taken without reaching output "
-                "time ({}).\nCurrent integrator time: {}",
-                nsteps, tout, m_tInteg);
+                "time ({}).\nCurrent integrator time: {}{}",
+                nsteps, tout, m_tInteg, f_errs);
         }
         int flag = CVode(m_cvode_mem, tout, m_y, &m_tInteg, CV_ONE_STEP);
         if (flag != CV_SUCCESS) {

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -231,6 +231,7 @@ int main(int argc, char** argv)
     testing::InitGoogleTest(&argc, argv);
     make_deprecation_warnings_fatal();
     printStackTraceOnSegfault();
+    Cantera::CanteraError::setStackTraceDepth(20);
     vector<string> fileNames = {"gtest-freeflame.yaml", "gtest-freeflame.h5"};
     for (const auto& fileName : fileNames) {
         if (std::ifstream(fileName).good()) {

--- a/test/equil/equil_gas.cpp
+++ b/test/equil/equil_gas.cpp
@@ -316,6 +316,7 @@ int main(int argc, char** argv)
     testing::InitGoogleTest(&argc, argv);
     make_deprecation_warnings_fatal();
     printStackTraceOnSegfault();
+    Cantera::CanteraError::setStackTraceDepth(20);
     int result = RUN_ALL_TESTS();
     appdelete();
     return result;

--- a/test/general/string_processing.cpp
+++ b/test/general/string_processing.cpp
@@ -119,6 +119,7 @@ int main(int argc, char** argv)
     testing::InitGoogleTest(&argc, argv);
     Cantera::make_deprecation_warnings_fatal();
     Cantera::printStackTraceOnSegfault();
+    Cantera::CanteraError::setStackTraceDepth(20);
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();
     return result;

--- a/test/general/test_misc.cpp
+++ b/test/general/test_misc.cpp
@@ -2,10 +2,25 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "gtest/gtest.h"
+#include "gmock/gmock.h"
 #include "cantera/base/global.h"
+#include "cantera/base/Solution.h"
 
 using namespace Cantera;
+using ::testing::HasSubstr;
 
 TEST(FatalError, stacktrace) {
     EXPECT_DEATH(std::abort(), "Stack trace");
+}
+
+TEST(CanteraError, stacktrace) {
+    bool raised = false;
+    try {
+        newSolution("xyz567.yaml");
+    } catch (CanteraError& err) {
+        raised = true;
+        // Check for information about an intermediate function call
+        EXPECT_THAT(err.what(), testing::HasSubstr("AnyMap::fromYamlFile"));
+    }
+    EXPECT_TRUE(raised);
 }

--- a/test/kinetics/pdep.cpp
+++ b/test/kinetics/pdep.cpp
@@ -226,6 +226,7 @@ int main(int argc, char** argv)
     printf("Running main() from pdep.cpp\n");
     Cantera::make_deprecation_warnings_fatal();
     Cantera::printStackTraceOnSegfault();
+    Cantera::CanteraError::setStackTraceDepth(20);
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();

--- a/test/oneD/test_oneD.cpp
+++ b/test/oneD/test_oneD.cpp
@@ -226,6 +226,7 @@ int main(int argc, char** argv)
     testing::InitGoogleTest(&argc, argv);
     make_deprecation_warnings_fatal();
     printStackTraceOnSegfault();
+    CanteraError::setStackTraceDepth(20);
     int result = RUN_ALL_TESTS();
     appdelete();
     return result;

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -2810,6 +2810,7 @@ class ExtensibleReactorTest(utilities.CanteraTest):
 
         r = DummyReactor(self.gas)
         net = ct.ReactorNet([r])
+        net.max_steps = 10
 
         # Because the TestException is raised inside code called by CVODES, the actual
         # error raised will be a CanteraError

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -2802,7 +2802,7 @@ class ExtensibleReactorTest(utilities.CanteraTest):
         class DummyReactor(ct.ExtensibleConstPressureReactor):
             def before_eval(self, t, LHS, RHS):
                 if t > 0.1:
-                    raise TestException()
+                    raise TestException("spam")
 
             def before_component_index(self, name):
                 if name == "fail":
@@ -2814,11 +2814,11 @@ class ExtensibleReactorTest(utilities.CanteraTest):
 
         # Because the TestException is raised inside code called by CVODES, the actual
         # error raised will be a CanteraError
-        with self.assertRaises(ct.CanteraError):
+        with pytest.raises(ct.CanteraError, match="TestException: spam"):
             net.advance(0.2)
 
-        self.assertEqual(r.component_index("enthalpy"), 1)
-        with self.assertRaises(TestException):
+        assert r.component_index("enthalpy") == 1
+        with pytest.raises(TestException):
             r.component_index("fail")
 
     def test_misc(self):

--- a/test/python/utilities.py
+++ b/test/python/utilities.py
@@ -21,6 +21,7 @@ CANTERA_DATA_PATH = Path(cantera.__file__).parent / "data"
 cantera.add_directory(TEST_DATA_PATH)
 cantera.add_directory(CANTERA_DATA_PATH)
 cantera.print_stack_trace_on_segfault()
+cantera.CanteraError.set_stack_trace_depth(20)
 
 @pytest.fixture
 def allow_deprecated():

--- a/test/thermo/nasapoly.cpp
+++ b/test/thermo/nasapoly.cpp
@@ -133,6 +133,7 @@ int main(int argc, char** argv)
     printf("Running main() from nasapoly.cpp\n");
     Cantera::make_deprecation_warnings_fatal();
     Cantera::printStackTraceOnSegfault();
+    Cantera::CanteraError::setStackTraceDepth(20);
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();

--- a/test/thermo_consistency/consistency.cpp
+++ b/test/thermo_consistency/consistency.cpp
@@ -897,6 +897,7 @@ int main(int argc, char** argv)
     printf("Running main() from consistency.cpp\n");
     testing::InitGoogleTest(&argc, argv);
     Cantera::make_deprecation_warnings_fatal();
+    Cantera::CanteraError::setStackTraceDepth(20);
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();
     return result;

--- a/test/transport/transportFromScratch.cpp
+++ b/test/transport/transportFromScratch.cpp
@@ -173,6 +173,7 @@ int main(int argc, char** argv)
     printf("Running main() from transportFromScratch.cpp\n");
     make_deprecation_warnings_fatal();
     printStackTraceOnSegfault();
+    CanteraError::setStackTraceDepth(20);
     testing::InitGoogleTest(&argc, argv);
     int result = RUN_ALL_TESTS();
     appdelete();

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -213,6 +213,7 @@ int main(int argc, char** argv)
     printf("Running main() from test_zeroD.cpp\n");
     testing::InitGoogleTest(&argc, argv);
     Cantera::make_deprecation_warnings_fatal();
+    Cantera::CanteraError::setStackTraceDepth(20);
     printStackTraceOnSegfault();
     int result = RUN_ALL_TESTS();
     Cantera::appdelete();


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Add a static method `CanteraError::setStackTraceDepth` that can be used to add the top *N* C++ stack frames to the message of a `CanteraError`. This can provide additional context on where certain errors are being thrown from.

**If applicable, provide an example illustrating new features this pull request is introducing**

From Python, instantiate a `Solution` object where the YAML file specifies a negative temperature for the initial state:
```py
import cantera as ct
ct.CanteraError.set_stack_trace_depth(10)
ct.Solution('broken.yaml')
```
Now, the Python traceback is followed by the `CanteraError` message and the top of the C++ stack:
```
Traceback (most recent call last):
  File "<stdin>", line 1, in <module>
  File "build/python/cantera/solutionbase.pyx", line 37, in cantera.solutionbase._SolutionBase.__cinit__
    self._cinit(infile=infile, name=name, adjacent=adjacent, origin=origin,
  File "build/python/cantera/solutionbase.pyx", line 75, in cantera.solutionbase._SolutionBase._cinit
    self._init_yaml(infile, name, adjacent, yaml, transport)
  File "build/python/cantera/solutionbase.pyx", line 160, in cantera.solutionbase._SolutionBase._init_yaml
    soln = newSolution(
cantera._utils.CanteraError: 
*******************************************************************************
CanteraError thrown by Phase::setTemperature:
temperature must be positive. T = -300
-------------------------------------------------------------------------------
 0# Cantera::CanteraError::CanteraError(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 1# Cantera::CanteraError::CanteraError<double>(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, double const&) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 2# Cantera::Phase::setTemperature(double) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 3# Cantera::ThermoPhase::setState_TP(double, double) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 4# Cantera::ThermoPhase::setState(Cantera::AnyMap const&) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 5# Cantera::setupPhase(Cantera::ThermoPhase&, Cantera::AnyMap const&, Cantera::AnyMap const&) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 6# Cantera::newThermo(Cantera::AnyMap const&, Cantera::AnyMap const&) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 7# Cantera::newSolution(Cantera::AnyMap const&, Cantera::AnyMap const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::vector<std::__1::shared_ptr<Cantera::Solution>, std::__1::allocator<std::__1::shared_ptr<Cantera::Solution>>> const&, std::__1::map<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>, std::__1::shared_ptr<Cantera::Solution>, std::__1::less<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>>>, std::__1::allocator<std::__1::pair<std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const, std::__1::shared_ptr<Cantera::Solution>>>> const&) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 8# Cantera::newSolution(std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::basic_string<char, std::__1::char_traits<char>, std::__1::allocator<char>> const&, std::__1::vector<std::__1::shared_ptr<Cantera::Solution>, std::__1::allocator<std::__1::shared_ptr<Cantera::Solution>>> const&) in /Users/speth/src/cantera/build/lib/libcantera_shared.3.1.0.dylib
 9# __pyx_pw_7cantera_12solutionbase_13_SolutionBase_9_init_yaml(_object*, _object* const*, long, _object*) in /Users/speth/src/cantera/build/python/cantera/_cantera.cpython-311-darwin.so
*******************************************************************************
```

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
