### PR TITLE
Yaml2ck fixes

### DIFF
--- a/interfaces/cython/cantera/yaml2ck.py
+++ b/interfaces/cython/cantera/yaml2ck.py
@@ -318,6 +318,7 @@ def build_thermodynamics_text(
         fmt_data["coeff_11_14"] = four_coeff_line.format(*low_coeffs[3:])
         text = fmt.format(**fmt_data)
         if comment:
+            comment = comment.replace("\n", "\n!")
             text = f"!{comment}\n" + text
         thermo_data[spec.name] = text
 

--- a/interfaces/cython/cantera/yaml2ck.py
+++ b/interfaces/cython/cantera/yaml2ck.py
@@ -704,9 +704,9 @@ def convert(
         ]
         thermo_path.write_text("\n".join(thermo_text))
 
-    # TODO: Handle phases without reactions
     all_reactions = solution.reactions()
-    mechanism_text.append(build_reactions_text(all_reactions, all_species))
+    if all_reactions:
+        mechanism_text.append(build_reactions_text(all_reactions, all_species))
 
     if transport_path is None and transport_exists:
         mechanism_text.append(build_transport_text(all_species, separate_file=False))

--- a/test/data/multi-line-notes.yaml
+++ b/test/data/multi-line-notes.yaml
@@ -1,0 +1,34 @@
+description: |-
+  GRI-Mech Version 3.0 with only H2 and a multi-line note substituted
+
+units: {length: cm, time: s, quantity: mol, activation-energy: cal/mol}
+
+phases:
+- name: gri30
+  thermo: ideal-gas
+  elements: [H]
+  species: [H2]
+  transport: mixture-averaged
+  state: {T: 300.0, P: 1 atm}
+
+species:
+- name: H2
+  composition: {H: 2}
+  thermo:
+    model: NASA7
+    temperature-ranges: [200.0, 1000.0, 3500.0]
+    data:
+    - [2.34433112, 7.98052075e-03, -1.9478151e-05, 2.01572094e-08, -7.37611761e-12,
+      -917.935173, 0.683010238]
+    - [3.3372792, -4.94024731e-05, 4.99456778e-07, -1.79566394e-10, 2.00255376e-14,
+      -950.158922, -3.20502331]
+    note: |-
+      Line 1
+      Line 2
+  transport:
+    model: gas
+    geometry: linear
+    well-depth: 38.0
+    diameter: 2.92
+    polarizability: 0.79
+    rotational-relaxation: 280.0

--- a/test/data/yaml-ck-reactions.yaml
+++ b/test/data/yaml-ck-reactions.yaml
@@ -16,6 +16,15 @@ phases:
   state:
     T: 300.0
     P: 1.01325e+05
+- name: no-reactions
+  thermo: ideal-gas
+  elements: [O, H, Ar]
+  kinetics: gas
+  transport: mixture-averaged
+  reactions: none
+  state:
+    T: 300.0
+    P: 1.01325e+05
     
 species:
 - name: AR

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -825,6 +825,23 @@ class yaml2ckTest(utilities.CanteraTest):
         assert ck_phase.species("eq=uals").input_data["thermo"]["note"] == "120521"
         assert ck_phase.species("plus").input_data["thermo"]["note"] == "12.05"
 
+    def test_multi_line_notes(self):
+        input_file = self.test_data_path / 'multi-line-notes.yaml'
+        yaml_phase = ct.Solution(input_file)
+        assert yaml_phase.species("H2").input_data["thermo"]["note"] == "Line 1\nLine 2"
+
+        ck_file = self.test_work_path / 'multi-line-notes.ck'
+        ck_file.unlink(missing_ok=True)
+        yaml_phase.write_chemkin(ck_file, quiet=True)
+
+        yaml_file = self.test_work_path / 'multi-line-notes.yaml'
+        yaml_file.unlink(missing_ok=True)
+        ck2yaml.convert(ck_file, out_name=yaml_file, quiet=True)
+        assert yaml_file.exists()
+
+        ck_phase = ct.Solution(yaml_file)
+        assert ck_phase.species("H2").input_data["thermo"]["note"] == "Line 1\nLine 2"
+
 
 class cti2yamlTest(utilities.CanteraTest):
     def convert(self, basename, src_dir=None, encoding=None):

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -783,6 +783,16 @@ class yaml2ckTest(utilities.CanteraTest):
         self.check_kinetics(ck_phase, yaml_phase, [900, 1800], [2e5, 20e5], tol=2e-7)
         self.check_transport(ck_phase, yaml_phase, [298, 1001, 2400])
 
+    def test_phase_no_reactions(self):
+        input_file = self.test_data_path / "yaml-ck-reactions.yaml"
+        yaml_phase = ct.Solution(input_file, name="no-reactions")
+        assert yaml_phase.n_reactions == 0
+
+        ck_file = self.test_work_path / 'no-reactions.ck'
+        ck_file.unlink(missing_ok=True)
+        yaml_phase.write_chemkin(ck_file, quiet=True)
+        assert ck_file.exists()
+
     def test_write_chemkin(self):
         # test alternative converter
         yaml_phase = ct.Solution('h2o2.yaml')


### PR DESCRIPTION
**Changes proposed in this pull request**

This pull request would fix a couple of issues with `yaml2ck`:

- Multi-line species thermo notes now have the comment marker `!` at the beginning of each line
- Writing a phase with no reactions will no longer crash, as the `REACTIONS` section is omitted

**If applicable, fill in the issue number this pull request is fixing**

Closes #1633 and closes #1679

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
