### PR TITLE
Add electrochemical reactions to Science section

### DIFF
--- a/doc/sphinx/reference/kinetics/reaction-rates.md
+++ b/doc/sphinx/reference/kinetics/reaction-rates.md
@@ -106,6 +106,72 @@ reactions:
 - [](sec-plog-rate)
 - [](sec-chebyshev-rate)
 
+
+(sec-electrochemical-reactions)=
+## Electrochemical Reactions
+
+In an electrochemical reaction (one that moves electrical charge from one phase of matter to another), the electric potential difference $\Delta\phi$ at the phase boundary exerts an additional "force" on the reaction that must be accounted for in the rate expression.  
+
+The free energy of the reaction equals the electrochemical potential change, $\Delta\tilde{\mu}_{\rm rxn}$:
+
+$$\Delta\tilde{\mu}_{\rm rxn} = \Delta\mu_{\rm rxn} + n_{\rm elec}F\Delta\phi$$
+
+where $\mu_{\rm rxn}$ is the chemical potential, $n_{\rm elec}$ is the total electrical charge moved across the phase boundary (e.g. from "phase 1" to "phase 2", where $\Delta\phi = \phi_2 - \phi_1$), and $F$ is Faraday's constant (96,485 Coulombs per mole of charge).
+
+Cantera's charge transfer treatment assumes a reversible reaction with a linear energy profile in the region of the transition state.  From above, for any $\Delta\phi$ the free energy of the reaction changes by $n_{\rm elec}F\Delta\phi$.  The transition state energy, meanwhile, changes by a fraction of this, $\beta n_{\rm elec}F\Delta\phi$, where the "symmetry parameter" $\beta$ is a number between 0 and 1.  
+
+This means that the activation energy for the reaction changes:
+- The barrier height for the forward reaction increases by $\beta n_{\rm elec}F\Delta\phi$.
+- The reverse reaction barrier height decreases by $\left(1-\beta\right) n_{\rm elec}F\Delta\phi$.  
+
+Note that $n_{\rm elec}$ and $\Delta \phi$ both have a sign, so the terms "increase" and "decrease" are relative; the forward barrier height might increase by a negative amount (i.e. decrease), for instance.
+
+From transition state theory, the forward and reverse reaction rates are therefore calculated as:
+
+$$ R_f = k_f\exp\left(-\frac{\beta n_{\rm elec}F\Delta\phi}{RT} \right)\Pi_k C_{{\rm ac},\,k}^{\nu_k^\prime}\$$
+
+and
+
+$$ R_r = k_r\exp\left(\frac{\left(1-\beta\right)n_{\rm elec}F\Delta\phi}{RT} \right)\Pi_k C_{{\rm ac},\,k}^{\nu_k^{\prime\prime}},$$
+
+respectively, where $k_f$ and $k_r$ are the normal chemical rate coefficients in the absence of any electric potential difference (e.g., calculated using Arrhenius coefficients), $C_{{\rm ac},\,k}$ is the activity concentration of species $k$, $\nu_k^\prime$ and $\nu_k^{\prime\prime}$ are the forward and reverse stoichiometric coefficients, respectively, for species $k$ for this reaction, and $R$ and $T$ are the universal gas constant and temperature, respectively.
+
+Note that Cantera's actual software implementation looks quite different from the description above, which is meant solely to give a clearer understanding of the science behind Cantera's calculations.
+```{admonition} YAML Usage
+:class: tip
+- Electrochemical reactions only occur at phase boundaries and therefore use the standard [``interface``](sec-yaml-interface-Arrhenius) reaction rate implementation. 
+- Charge transfer is automatically detected, and $n_{\rm elec}$ automatically calculated.  If no value for `beta` is provided, an [``electrochemical``](sec-yaml-electrochemical-reaction) reaction assumes a default of ``beta = 0.5``.
+``` 
+ 
+ (sec-butler-volmer)=
+### The Butler-Volmer Form
+ 
+Cantera's electrochemical reaction rate calculation is equivalent to the commonly-used Butler-Volmer rate form. In Butler-Volmer, the net rate of progress, $R_{\rm net} = R_f - R_r$, can be written as:
+
+$$ R_{\rm net} = \frac{i_\circ}{n_{\rm elec}F}\left[\exp\left(-\frac{\beta n_{\rm elec}F\eta}{RT} \right) - \exp\left( \frac{\left(1-\beta\right)n_{\rm elec}F\eta}{RT}\right) \right]$$
+
+where the kinetic rate constant $i_\circ$ is known as the "exchange current density" and $\eta$ the "overpotential" -- the difference between the actual electric potential difference and that which would set the reaction to equilibrium:
+
+$$ \eta = \Delta\phi - \Delta\phi_{\rm equil}$$
+
+To convert between the two forms, the exchange current density varies with the chemical state and can be calculated as:
+
+$$i_\circ = n_{\rm elec}Fk_f^{\left(1-\beta\right)}k_r^\beta\Pi_k C_{{\rm ac},\,k}^{\left(1-\beta\right)\nu_k^\prime}\Pi_k C_{{\rm ac},\,k}^{\beta\nu_k^{\prime\prime}}.$$
+
+
+````{admonition} YAML Usage
+:class: tip
+- One can explicitly provide an exchange current density, rather than the $k_f$ value, by setting the optional ``exchange-current-density-formulation`` field to ``true``.
+
+```yaml
+- equation: LiC6 <=> Li+(e) + C6
+  rate-constant: [5.74, 0.0, 0.0]
+  beta: 0.4
+  exchange-current-density-formulation: true
+```
+Here, the rate constant Arrhenius parameters will be used to calculate the exchange current density.
+````
+
 (sec-reaction-orders)=
 ## Reaction Orders
 

--- a/doc/sphinx/reference/kinetics/reaction-rates.md
+++ b/doc/sphinx/reference/kinetics/reaction-rates.md
@@ -110,7 +110,7 @@ reactions:
 (sec-electrochemical-reactions)=
 ## Electrochemical Reactions
 
-In an electrochemical reaction (one that moves electrical charge from one phase of matter to another), the electric potential difference $\Delta\phi$ at the phase boundary exerts an additional "force" on the reaction that must be accounted for in the rate expression.  
+In an electrochemical reaction (one that moves electrical charge from one phase of matter to another), the electric potential difference $\Delta\phi$ at the phase boundary exerts an additional "force" on the reaction that must be accounted for in the rate expression.
 
 The free energy of the reaction equals the electrochemical potential change, $\Delta\tilde{\mu}_{\rm rxn}$:
 
@@ -118,11 +118,11 @@ $$\Delta\tilde{\mu}_{\rm rxn} = \Delta\mu_{\rm rxn} + n_{\rm elec}F\Delta\phi$$
 
 where $\mu_{\rm rxn}$ is the chemical potential, $n_{\rm elec}$ is the total electrical charge moved across the phase boundary (e.g. from "phase 1" to "phase 2", where $\Delta\phi = \phi_2 - \phi_1$), and $F$ is Faraday's constant (96,485 Coulombs per mole of charge).
 
-Cantera's charge transfer treatment assumes a reversible reaction with a linear energy profile in the region of the transition state.  From above, for any $\Delta\phi$ the free energy of the reaction changes by $n_{\rm elec}F\Delta\phi$.  The transition state energy, meanwhile, changes by a fraction of this, $\beta n_{\rm elec}F\Delta\phi$, where the "symmetry parameter" $\beta$ is a number between 0 and 1.  
+Cantera's charge transfer treatment assumes a reversible reaction with a linear energy profile in the region of the transition state.  From above, for any $\Delta\phi$ the free energy of the reaction changes by $n_{\rm elec}F\Delta\phi$.  The transition state energy, meanwhile, changes by a fraction of this, $\beta n_{\rm elec}F\Delta\phi$, where the "symmetry parameter" $\beta$ is a number between 0 and 1.
 
 This means that the activation energy for the reaction changes:
 - The barrier height for the forward reaction increases by $\beta n_{\rm elec}F\Delta\phi$.
-- The reverse reaction barrier height decreases by $\left(1-\beta\right) n_{\rm elec}F\Delta\phi$.  
+- The reverse reaction barrier height decreases by $\left(1-\beta\right) n_{\rm elec}F\Delta\phi$.
 
 Note that $n_{\rm elec}$ and $\Delta \phi$ both have a sign, so the terms "increase" and "decrease" are relative; the forward barrier height might increase by a negative amount (i.e. decrease), for instance.
 
@@ -139,13 +139,13 @@ respectively, where $k_f$ and $k_r$ are the normal chemical rate coefficients in
 Note that Cantera's actual software implementation looks quite different from the description above, which is meant solely to give a clearer understanding of the science behind Cantera's calculations.
 ```{admonition} YAML Usage
 :class: tip
-- Electrochemical reactions only occur at phase boundaries and therefore use the standard [``interface``](sec-yaml-interface-Arrhenius) reaction rate implementation. 
+- Electrochemical reactions only occur at phase boundaries and therefore use the standard [``interface``](sec-yaml-interface-Arrhenius) reaction rate implementation.
 - Charge transfer is automatically detected, and $n_{\rm elec}$ automatically calculated.  If no value for `beta` is provided, an [``electrochemical``](sec-yaml-electrochemical-reaction) reaction assumes a default of ``beta = 0.5``.
-``` 
- 
- (sec-butler-volmer)=
+```
+
+(sec-butler-volmer)=
 ### The Butler-Volmer Form
- 
+
 Cantera's electrochemical reaction rate calculation is equivalent to the commonly-used Butler-Volmer rate form. In Butler-Volmer, the net rate of progress, $R_{\rm net} = R_f - R_r$, can be written as:
 
 $$ R_{\rm net} = \frac{i_\circ}{n_{\rm elec}F}\left[\exp\left(-\frac{\beta n_{\rm elec}F\eta}{RT} \right) - \exp\left( \frac{\left(1-\beta\right)n_{\rm elec}F\eta}{RT}\right) \right]$$

--- a/doc/sphinx/reference/kinetics/reaction-rates.md
+++ b/doc/sphinx/reference/kinetics/reaction-rates.md
@@ -117,10 +117,10 @@ expression.
 
 The free energy of the reaction equals the electrochemical potential change:
 
-$$\Delta\tilde{\mu}_{\rm rxn} = \Delta\mu_{\rm rxn} + n_{\rm elec}F\Delta\phi$$
+$$  \Delta\tilde{\mu}_{\rm rxn} = \Delta\mu_{\rm rxn} + n_{\rm elec}F\Delta\phi  $$
 
 where $\mu_{\rm rxn}$ is the chemical potential, $n_{\rm elec}$ is the total electrical
-charge moved across the phase boundary (in other words, the chanrge moved from "phase 1"
+charge moved across the phase boundary (in other words, the charge moved from "phase 1"
 to "phase 2", where $\Delta\phi = \phi_2 - \phi_1$), and $F$ is Faraday's constant
 (96,485 Coulombs per mole of charge).
 
@@ -131,10 +131,10 @@ energy, meanwhile, changes by a fraction of this, $\beta n_{\rm elec}F\Delta\phi
 the "symmetry parameter" $\beta$ is a number between 0 and 1.
 
 This means that the activation energy for the reaction changes:
-- The barrier height for the forward reaction increases by 
-$\beta n_{\rm elec}F\Delta\phi$.
+- The barrier height for the forward reaction increases by
+  $\beta n_{\rm elec}F\Delta\phi$.
 - The reverse reaction barrier height decreases by
-$\left(1-\beta\right) n_{\rm elec}F\Delta\phi$.
+  $\left(1-\beta\right) n_{\rm elec}F\Delta\phi$.
 
 Note that $n_{\rm elec}$ and $\Delta \phi$ both have a sign, so the terms "increase" and
 "decrease" are relative; the forward barrier height might increase by a negative amount
@@ -143,17 +143,17 @@ Note that $n_{\rm elec}$ and $\Delta \phi$ both have a sign, so the terms "incre
 From transition state theory, the forward and reverse reaction rates are therefore
 calculated as:
 
-$$ R_f = k_f\exp\left(-\frac{\beta n_{\rm elec}F\Delta\phi}{RT} \right)\prod_k
-C_{{\rm ac},\,k}^{\nu_k^\prime}$$
+$$  R_f = k_f\exp\left(-\frac{\beta n_{\rm elec}F\Delta\phi}{RT} \right)\prod_k
+C_{{\rm ac},\,k}^{\nu_k^\prime}  $$
 
 and
 
-$$ R_r = k_r\exp\left(\frac{\left(1-\beta\right)n_{\rm elec}F\Delta\phi}{RT} \right)
-\prod_k C_{{\rm ac},\,k}^{\nu_k^{\prime\prime}},$$
+$$  R_r = k_r\exp\left(\frac{\left(1-\beta\right)n_{\rm elec}F\Delta\phi}{RT} \right)
+\prod_k C_{{\rm ac},\,k}^{\nu_k^{\prime\prime}},  $$
 
 respectively, where $k_f$ and $k_r$ are the normal chemical rate coefficients in the
 absence of any electric potential difference (such as those calculated using Arrhenius
-coefficients), $C_{{\rm ac},\,k}$ is the 
+coefficients), $C_{{\rm ac},\,k}$ is the
 {ct}`activity concentration <ThermoPhase::getActivityConcentrations>` of species $k$,
 $\nu_k^\prime$ and $\nu_k^{\prime\prime}$ are the reactant and product stoichiometric
 coefficients, respectively, for species $k$ for this reaction, and $R$ and $T$ are the
@@ -162,14 +162,15 @@ universal gas constant and temperature, respectively.
 Note that Cantera's actual software implementation looks quite different from the
 description above, which is meant solely to give a clearer understanding of the science
 behind Cantera's calculations.
+
 ```{admonition} YAML Usage
 :class: tip
 - Electrochemical reactions only occur at phase boundaries and therefore use the
-standard [``interface``](sec-yaml-interface-Arrhenius) reaction rate implementation.
+  standard [``interface``](sec-yaml-interface-Arrhenius) reaction rate implementation.
 - Charge transfer is automatically detected, and $n_{\rm elec}$ automatically
-calculated.  If no value for `beta` is provided, an
-[``electrochemical``](sec-yaml-electrochemical-reaction) reaction assumes a default of
-``beta = 0.5``.
+  calculated.  If no value for `beta` is provided, an
+  [``electrochemical``](sec-yaml-electrochemical-reaction) reaction assumes a default of
+  ``beta = 0.5``.
 ```
 
 (sec-butler-volmer)=
@@ -180,21 +181,21 @@ Butler-Volmer rate form. In Butler-Volmer, the net rate of progress,
 $R_{\rm net} = R_f - R_r$, can be written as:
 
 $$ R_{\rm net} = \frac{i_\circ}{n_{\rm elec}F}\left[\exp\left(-\frac{\beta
-n_{\rm elec}F\eta}{RT} \right) - \exp\left( 
+n_{\rm elec}F\eta}{RT} \right) - \exp\left(
 \frac{\left(1-\beta\right)n_{\rm elec}F\eta}{RT}\right) \right]$$
 
 where the kinetic rate constant $i_\circ$ is known as the "exchange current density" and
 $\eta$ the "overpotential" -- the difference between the actual electric potential
 difference and that which would set the reaction to equilibrium:
 
-$$ \eta = \Delta\phi - \Delta\phi_{\rm equil}$$
+$$  \eta = \Delta\phi - \Delta\phi_{\rm equil}  $$
 
 To convert between the two forms, the exchange current density varies with the chemical
 state and can be calculated as:
 
-$$i_\circ = n_{\rm elec}Fk_f^{\left(1-\beta\right)}k_r^\beta\prod_k
+$$  i_\circ = n_{\rm elec}Fk_f^{\left(1-\beta\right)}k_r^\beta\prod_k
 C_{{\rm ac},\,k}^{\left(1-\beta\right)\nu_k^\prime}
-\prod_k C_{{\rm ac},\,k}^{\beta\nu_k^{\prime\prime}}.$$
+\prod_k C_{{\rm ac},\,k}^{\beta\nu_k^{\prime\prime}}.  $$
 
 
 ````{admonition} YAML Usage

--- a/doc/sphinx/reference/kinetics/reaction-rates.md
+++ b/doc/sphinx/reference/kinetics/reaction-rates.md
@@ -110,58 +110,97 @@ reactions:
 (sec-electrochemical-reactions)=
 ## Electrochemical Reactions
 
-In an electrochemical reaction (one that moves electrical charge from one phase of matter to another), the electric potential difference $\Delta\phi$ at the phase boundary exerts an additional "force" on the reaction that must be accounted for in the rate expression.
+In an electrochemical reaction (one that moves electrical charge from one phase of
+matter to another), the electric potential difference $\Delta\phi$ at the phase boundary
+exerts an additional "force" on the reaction that must be accounted for in the rate
+expression.
 
-The free energy of the reaction equals the electrochemical potential change, $\Delta\tilde{\mu}_{\rm rxn}$:
+The free energy of the reaction equals the electrochemical potential change:
 
 $$\Delta\tilde{\mu}_{\rm rxn} = \Delta\mu_{\rm rxn} + n_{\rm elec}F\Delta\phi$$
 
-where $\mu_{\rm rxn}$ is the chemical potential, $n_{\rm elec}$ is the total electrical charge moved across the phase boundary (e.g. from "phase 1" to "phase 2", where $\Delta\phi = \phi_2 - \phi_1$), and $F$ is Faraday's constant (96,485 Coulombs per mole of charge).
+where $\mu_{\rm rxn}$ is the chemical potential, $n_{\rm elec}$ is the total electrical
+charge moved across the phase boundary (in other words, the chanrge moved from "phase 1"
+to "phase 2", where $\Delta\phi = \phi_2 - \phi_1$), and $F$ is Faraday's constant
+(96,485 Coulombs per mole of charge).
 
-Cantera's charge transfer treatment assumes a reversible reaction with a linear energy profile in the region of the transition state.  From above, for any $\Delta\phi$ the free energy of the reaction changes by $n_{\rm elec}F\Delta\phi$.  The transition state energy, meanwhile, changes by a fraction of this, $\beta n_{\rm elec}F\Delta\phi$, where the "symmetry parameter" $\beta$ is a number between 0 and 1.
+Cantera's charge transfer treatment assumes a reversible reaction with a linear energy
+profile in the region of the transition state.  From above, for any $\Delta\phi$ the
+free energy of the reaction changes by $n_{\rm elec}F\Delta\phi$.  The transition state
+energy, meanwhile, changes by a fraction of this, $\beta n_{\rm elec}F\Delta\phi$, where
+the "symmetry parameter" $\beta$ is a number between 0 and 1.
 
 This means that the activation energy for the reaction changes:
-- The barrier height for the forward reaction increases by $\beta n_{\rm elec}F\Delta\phi$.
-- The reverse reaction barrier height decreases by $\left(1-\beta\right) n_{\rm elec}F\Delta\phi$.
+- The barrier height for the forward reaction increases by 
+$\beta n_{\rm elec}F\Delta\phi$.
+- The reverse reaction barrier height decreases by
+$\left(1-\beta\right) n_{\rm elec}F\Delta\phi$.
 
-Note that $n_{\rm elec}$ and $\Delta \phi$ both have a sign, so the terms "increase" and "decrease" are relative; the forward barrier height might increase by a negative amount (i.e. decrease), for instance.
+Note that $n_{\rm elec}$ and $\Delta \phi$ both have a sign, so the terms "increase" and
+"decrease" are relative; the forward barrier height might increase by a negative amount
+(that is, decrease), for instance.
 
-From transition state theory, the forward and reverse reaction rates are therefore calculated as:
+From transition state theory, the forward and reverse reaction rates are therefore
+calculated as:
 
-$$ R_f = k_f\exp\left(-\frac{\beta n_{\rm elec}F\Delta\phi}{RT} \right)\Pi_k C_{{\rm ac},\,k}^{\nu_k^\prime}\$$
+$$ R_f = k_f\exp\left(-\frac{\beta n_{\rm elec}F\Delta\phi}{RT} \right)\prod_k
+C_{{\rm ac},\,k}^{\nu_k^\prime}$$
 
 and
 
-$$ R_r = k_r\exp\left(\frac{\left(1-\beta\right)n_{\rm elec}F\Delta\phi}{RT} \right)\Pi_k C_{{\rm ac},\,k}^{\nu_k^{\prime\prime}},$$
+$$ R_r = k_r\exp\left(\frac{\left(1-\beta\right)n_{\rm elec}F\Delta\phi}{RT} \right)
+\prod_k C_{{\rm ac},\,k}^{\nu_k^{\prime\prime}},$$
 
-respectively, where $k_f$ and $k_r$ are the normal chemical rate coefficients in the absence of any electric potential difference (e.g., calculated using Arrhenius coefficients), $C_{{\rm ac},\,k}$ is the activity concentration of species $k$, $\nu_k^\prime$ and $\nu_k^{\prime\prime}$ are the forward and reverse stoichiometric coefficients, respectively, for species $k$ for this reaction, and $R$ and $T$ are the universal gas constant and temperature, respectively.
+respectively, where $k_f$ and $k_r$ are the normal chemical rate coefficients in the
+absence of any electric potential difference (such as those calculated using Arrhenius
+coefficients), $C_{{\rm ac},\,k}$ is the 
+{ct}`activity concentration <ThermoPhase::getActivityConcentrations>` of species $k$,
+$\nu_k^\prime$ and $\nu_k^{\prime\prime}$ are the reactant and product stoichiometric
+coefficients, respectively, for species $k$ for this reaction, and $R$ and $T$ are the
+universal gas constant and temperature, respectively.
 
-Note that Cantera's actual software implementation looks quite different from the description above, which is meant solely to give a clearer understanding of the science behind Cantera's calculations.
+Note that Cantera's actual software implementation looks quite different from the
+description above, which is meant solely to give a clearer understanding of the science
+behind Cantera's calculations.
 ```{admonition} YAML Usage
 :class: tip
-- Electrochemical reactions only occur at phase boundaries and therefore use the standard [``interface``](sec-yaml-interface-Arrhenius) reaction rate implementation.
-- Charge transfer is automatically detected, and $n_{\rm elec}$ automatically calculated.  If no value for `beta` is provided, an [``electrochemical``](sec-yaml-electrochemical-reaction) reaction assumes a default of ``beta = 0.5``.
+- Electrochemical reactions only occur at phase boundaries and therefore use the
+standard [``interface``](sec-yaml-interface-Arrhenius) reaction rate implementation.
+- Charge transfer is automatically detected, and $n_{\rm elec}$ automatically
+calculated.  If no value for `beta` is provided, an
+[``electrochemical``](sec-yaml-electrochemical-reaction) reaction assumes a default of
+``beta = 0.5``.
 ```
 
 (sec-butler-volmer)=
 ### The Butler-Volmer Form
 
-Cantera's electrochemical reaction rate calculation is equivalent to the commonly-used Butler-Volmer rate form. In Butler-Volmer, the net rate of progress, $R_{\rm net} = R_f - R_r$, can be written as:
+Cantera's electrochemical reaction rate calculation is equivalent to the commonly-used
+Butler-Volmer rate form. In Butler-Volmer, the net rate of progress,
+$R_{\rm net} = R_f - R_r$, can be written as:
 
-$$ R_{\rm net} = \frac{i_\circ}{n_{\rm elec}F}\left[\exp\left(-\frac{\beta n_{\rm elec}F\eta}{RT} \right) - \exp\left( \frac{\left(1-\beta\right)n_{\rm elec}F\eta}{RT}\right) \right]$$
+$$ R_{\rm net} = \frac{i_\circ}{n_{\rm elec}F}\left[\exp\left(-\frac{\beta
+n_{\rm elec}F\eta}{RT} \right) - \exp\left( 
+\frac{\left(1-\beta\right)n_{\rm elec}F\eta}{RT}\right) \right]$$
 
-where the kinetic rate constant $i_\circ$ is known as the "exchange current density" and $\eta$ the "overpotential" -- the difference between the actual electric potential difference and that which would set the reaction to equilibrium:
+where the kinetic rate constant $i_\circ$ is known as the "exchange current density" and
+$\eta$ the "overpotential" -- the difference between the actual electric potential
+difference and that which would set the reaction to equilibrium:
 
 $$ \eta = \Delta\phi - \Delta\phi_{\rm equil}$$
 
-To convert between the two forms, the exchange current density varies with the chemical state and can be calculated as:
+To convert between the two forms, the exchange current density varies with the chemical
+state and can be calculated as:
 
-$$i_\circ = n_{\rm elec}Fk_f^{\left(1-\beta\right)}k_r^\beta\Pi_k C_{{\rm ac},\,k}^{\left(1-\beta\right)\nu_k^\prime}\Pi_k C_{{\rm ac},\,k}^{\beta\nu_k^{\prime\prime}}.$$
+$$i_\circ = n_{\rm elec}Fk_f^{\left(1-\beta\right)}k_r^\beta\prod_k
+C_{{\rm ac},\,k}^{\left(1-\beta\right)\nu_k^\prime}
+\prod_k C_{{\rm ac},\,k}^{\beta\nu_k^{\prime\prime}}.$$
 
 
 ````{admonition} YAML Usage
 :class: tip
-- One can explicitly provide an exchange current density, rather than the $k_f$ value, by setting the optional ``exchange-current-density-formulation`` field to ``true``.
+One can explicitly provide an exchange current density, rather than the $k_f$ value,
+by setting the optional ``exchange-current-density-formulation`` field to ``true``.
 
 ```yaml
 - equation: LiC6 <=> Li+(e) + C6
@@ -169,7 +208,8 @@ $$i_\circ = n_{\rm elec}Fk_f^{\left(1-\beta\right)}k_r^\beta\Pi_k C_{{\rm ac},\,
   beta: 0.4
   exchange-current-density-formulation: true
 ```
-Here, the rate constant Arrhenius parameters will be used to calculate the exchange current density.
+Here, the rate constant Arrhenius parameters will be used to calculate the exchange
+current density.
 ````
 
 (sec-reaction-orders)=

--- a/doc/sphinx/yaml/reactions.rst
+++ b/doc/sphinx/yaml/reactions.rst
@@ -518,7 +518,8 @@ Example::
 ``electrochemical``
 -------------------
 
-Interface reactions involving charge transfer between phases.
+Interface reactions involving :ref:`charge transfer <sec-electrochemical-reactions>`
+between phases.
 
 Includes the fields of an :ref:`sec-yaml-interface-Arrhenius` reaction, plus:
 


### PR DESCRIPTION
**Changes proposed in this pull request**

Adds description of Cantera's implementation of electrochemical rate theory to the `Reference` section of the website.

Added to `doc/sphinx/reference/kinetics/reaction-rates.md`.

Closes https://github.com/Cantera/cantera-website/issues/172

Gives a basic overview of how electrochemical reactions are handled in Cantera, including the concepts of:

1. Electrochemical potential of the reaction
2. How changes in potential change the electrochemical potential of the overall reaction and of the transition state
3. How this, plus the symmetry parameter, lead to an evaluation of the electrochemical reaction rate.

Documentation also includes description of specifying the rate parameter as an "exchange current density."

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
