### PR TITLE
Resolve compilation issues with C++20 mode and fmt 11.0

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -174,6 +174,9 @@ jobs:
         include:
           - macos-version: 'macos-12'
             python-version: '3.8'
+          - macos-version: 'macos-14'
+            python-version: '3.10'
+            extra-build-args: cxx_flags='-std=c++20'
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -199,7 +202,8 @@ jobs:
     - name: Install Python dependencies
       run: python -m pip install -r requirements.txt
     - name: Build Cantera
-      run: scons build env_vars=all -j3 debug=n --debug=time boost_inc_dir=${BOOST_INC_DIR}
+      run: scons build env_vars=all -j3 debug=n --debug=time
+        boost_inc_dir=${BOOST_INC_DIR} ${{ matrix.extra-build-args }}
     - name: Upload shared library
       uses: actions/upload-artifact@v4
       if: matrix.python-version == '3.11' && matrix.macos-version == 'macos-12'
@@ -496,7 +500,7 @@ jobs:
       matrix:
         include:
         - sundials-ver: 3
-          fmt-ver: 7.1
+          fmt-ver: 6.1.2
         - sundials-ver: 4
           fmt-ver: 8.1
         - sundials-ver: 5.8
@@ -506,7 +510,8 @@ jobs:
         - sundials-ver: 6.6
           fmt-ver: 10
         - sundials-ver: 7.0
-          fmt-ver: 10
+          fmt-ver: 11
+          extra-build-args: cxx_flags='-std=c++20'
       fail-fast: false
     steps:
       - uses: actions/checkout@v4
@@ -528,7 +533,8 @@ jobs:
         run: |
           scons build system_fmt=y system_eigen=y system_yamlcpp=y system_sundials=y \
           system_highfive=y blas_lapack_libs='lapack,blas' -j4 logging=debug debug=n \
-          optimize_flags='-O3 -ffast-math -fno-finite-math-only'
+          optimize_flags='-O3 -ffast-math -fno-finite-math-only' \
+          ${{ matrix.extra-build-args}}
       - name: Test Cantera
         run: scons test-zeroD test-python-reactor show_long_tests=yes verbose_tests=yes
       - name: Test Install
@@ -571,6 +577,9 @@ jobs:
           fmt-ver: '9.1'
         - python-version: '3.12'
           fmt-ver: '7.1'
+        - python-version: '3.12'
+          fmt-ver: '11.0'
+          extra-build-args: cxx_flags='/EHsc /std:c++20'
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -592,7 +601,8 @@ jobs:
         post-cleanup: none
     - name: Build Cantera
       run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
-        toolchain=msvc f90_interface=n debug=n --debug=time -j4
+        toolchain=msvc f90_interface=n debug=n ${{ matrix.extra-build-args }}
+        --debug=time -j4
       shell: pwsh
     - name: Upload shared library
       uses: actions/upload-artifact@v4

--- a/SConstruct
+++ b/SConstruct
@@ -216,7 +216,7 @@ config_options = [
            options with spaces, for example, "cxx_flags='-g -Wextra -O3 --std=c++14'"
            """,
         {
-            "cl": "/EHsc /std:c++17",
+            "cl": "/EHsc /std:c++17 /utf-8",
             "default": "-std=c++17"
         }),
     Option(

--- a/doc/sphinx/develop/compiling/dependencies.md
+++ b/doc/sphinx/develop/compiling/dependencies.md
@@ -81,7 +81,7 @@ compiler is required only if you plan to build the Fortran module.
     Cantera source code using Git, fmt will be automatically downloaded and the
     necessary portions will be compiled and installed with Cantera.
   - <https://fmt.dev/latest/index.html>
-  - Known to work with version 9.1.0.
+  - Known to work with versions 6.1.2 through 11.0.
 
 - yaml-cpp
 

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -746,7 +746,8 @@ public:
         : CanteraError(
             procedure,
             formatError(
-                (sizeof...(args) == 0) ? message : fmt::format(message, args...),
+                (sizeof...(args) == 0) ? message
+                                       : fmt::format(fmt::runtime(message), args...),
                 node.m_line, node.m_column, node.m_metadata))
         {
         }
@@ -761,7 +762,8 @@ public:
         : CanteraError(
             procedure,
             formatError2(
-                (sizeof...(args) == 0) ? message : fmt::format(message, args...),
+                (sizeof...(args) == 0) ? message
+                                       : fmt::format(fmt::runtime(message), args...),
                 node1.m_line, node1.m_column, node1.m_metadata,
                 node2.m_line, node2.m_column, node2.m_metadata))
         {

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -86,7 +86,7 @@ public:
         if (sizeof...(args) == 0) {
             msg_ = msg;
         } else {
-            msg_ = fmt::format(msg, args...);
+            msg_ = fmt::format(fmt::runtime(msg), args...);
         }
     }
 

--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -42,4 +42,12 @@ void fmt_append(fmt::memory_buffer& b, const std::string& tmpl, Args... args) {
 }
 #endif
 
+#if FMT_VERSION > 100000
+  #if CT_USE_SYSTEM_FMT
+    #include <fmt/ranges.h>
+  #else
+    #include <fmt/join.h>
+  #endif
+#endif
+
 #endif

--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -26,13 +26,13 @@
 
 #if FMT_VERSION < 80000
 template <typename... Args>
-void fmt_append(fmt::memory_buffer& b, Args... args) {
-    format_to(b, args...);
+void fmt_append(fmt::memory_buffer& b, const std::string& tmpl, Args... args) {
+    format_to(b, tmpl, args...);
 }
 #else
 template <typename... Args>
-void fmt_append(fmt::memory_buffer& b, Args... args) {
-    format_to(fmt::appender(b), args...);
+void fmt_append(fmt::memory_buffer& b, const std::string& tmpl, Args... args) {
+    format_to(fmt::appender(b), fmt::runtime(tmpl), args...);
 }
 #endif
 

--- a/include/cantera/base/fmt.h
+++ b/include/cantera/base/fmt.h
@@ -29,6 +29,12 @@ template <typename... Args>
 void fmt_append(fmt::memory_buffer& b, const std::string& tmpl, Args... args) {
     format_to(b, tmpl, args...);
 }
+namespace fmt {
+template <typename T>
+T runtime(T arg) {
+    return arg;
+}
+}
 #else
 template <typename... Args>
 void fmt_append(fmt::memory_buffer& b, const std::string& tmpl, Args... args) {

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -176,7 +176,7 @@ void writelog(const string& fmt, const Args&... args) {
     if (sizeof...(args) == 0) {
         writelog_direct(fmt);
     } else {
-        writelog_direct(fmt::format(fmt, args...));
+        writelog_direct(fmt::format(fmt::runtime(fmt), args...));
     }
 }
 
@@ -228,7 +228,7 @@ void warn_deprecated(const string& method, const string& msg, const Args&... arg
     if (sizeof...(args) == 0) {
         _warn_deprecated(method, msg);
     } else {
-        _warn_deprecated(method, fmt::format(msg, args...));
+        _warn_deprecated(method, fmt::format(fmt::runtime(msg), args...));
     }
 }
 
@@ -253,7 +253,7 @@ void warn(const string& warning, const string& method,
     if (sizeof...(args) == 0) {
         _warn(warning, method, msg);
     } else {
-        _warn(warning, method, fmt::format(msg, args...));
+        _warn(warning, method, fmt::format(fmt::runtime(msg), args...));
     }
 }
 
@@ -268,7 +268,7 @@ void warn_user(const string& method, const string& msg, const Args&... args) {
     if (sizeof...(args) == 0) {
         _warn("Cantera", method, msg);
     } else {
-        _warn("Cantera", method, fmt::format(msg, args...));
+        _warn("Cantera", method, fmt::format(fmt::runtime(msg), args...));
     }
 }
 

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -164,7 +164,7 @@ string formatDouble(double x, long int precision)
     size_t last;
     string s0;
     if (useExp) {
-        s0 = fmt::format(fmt::format("{:.{}e}", x, precision));
+        s0 = fmt::format(fmt::runtime(fmt::format("{:.{}e}", x, precision)));
         // last digit of significand
         last = s0.size() - 5;
         if (s0[last + 1] == 'e') {
@@ -195,7 +195,7 @@ string formatDouble(double x, long int precision)
     if (s0[last - 1] == '0') {
         s1 = s0; // Recycle original string
     } else if (useExp) {
-        s1 = fmt::format(fmt::format("{:.{}e}", x, precision - 2));
+        s1 = fmt::format(fmt::runtime(fmt::format("{:.{}e}", x, precision - 2)));
     } else {
         s1 = fmt::format("{:.{}f}", x, precision - log10x - 2);
     }

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -232,17 +232,19 @@ vector<string> doubleColumn(string name, const vector<double>& comp,
     if (csize <= rows) {
         for (const auto& val : comp) {
             data.push_back(val);
-            raw.push_back(boost::trim_copy(fmt::format(notation, val)));
+            raw.push_back(boost::trim_copy(fmt::format(fmt::runtime(notation), val)));
         }
     } else {
         dots = (rows + 1) / 2;
         for (int row = 0; row < dots; row++) {
             data.push_back(comp[row]);
-            raw.push_back(boost::trim_copy(fmt::format(notation, comp[row])));
+            raw.push_back(boost::trim_copy(
+                fmt::format(fmt::runtime(notation), comp[row])));
         }
         for (int row = csize - rows / 2; row < csize; row++) {
             data.push_back(comp[row]);
-            raw.push_back(boost::trim_copy(fmt::format(notation, comp[row])));
+            raw.push_back(boost::trim_copy(
+                fmt::format(fmt::runtime(notation), comp[row])));
         }
     }
 
@@ -292,17 +294,17 @@ vector<string> doubleColumn(string name, const vector<double>& comp,
         // all entries are integers
         notation = fmt::format(" {{:>{}.0f}}", over + maxLen);
     }
-    maxLen = fmt::format(notation, 0.).size();
+    maxLen = fmt::format(fmt::runtime(notation), 0.).size();
 
     // assemble output
     string section = fmt::format("{{:>{}}}", maxLen);
-    vector<string> col = {fmt::format(section, name)};
+    vector<string> col = {fmt::format(fmt::runtime(section), name)};
     int count = 0;
     for (const auto& val : data) {
-        col.push_back(fmt::format(notation, val));
+        col.push_back(fmt::format(fmt::runtime(notation), val));
         count++;
         if (count == dots) {
-            col.push_back(fmt::format(section, "..."));
+            col.push_back(fmt::format(fmt::runtime(section), "..."));
         }
     }
     return col;
@@ -320,7 +322,8 @@ vector<string> integerColumn(string name, const vector<long int>& comp,
     if (csize <= rows) {
         for (const auto& val : comp) {
             data.push_back(val);
-            string formatted = boost::trim_copy(fmt::format(notation, val));
+            string formatted = boost::trim_copy(
+                fmt::format(fmt::runtime(notation), val));
             if (formatted[0] == '-') {
                 formatted = formatted.substr(1);
             }
@@ -330,7 +333,8 @@ vector<string> integerColumn(string name, const vector<long int>& comp,
         dots = (rows + 1) / 2;
         for (int row = 0; row < dots; row++) {
             data.push_back(comp[row]);
-            string formatted = boost::trim_copy(fmt::format(notation, comp[row]));
+            string formatted = boost::trim_copy(
+                fmt::format(fmt::runtime(notation), comp[row]));
             if (formatted[0] == '-') {
                 formatted = formatted.substr(1);
             }
@@ -338,7 +342,8 @@ vector<string> integerColumn(string name, const vector<long int>& comp,
         }
         for (int row = csize - rows / 2; row < csize; row++) {
             data.push_back(comp[row]);
-            string formatted = boost::trim_copy(fmt::format(notation, comp[row]));
+            string formatted = boost::trim_copy(
+                fmt::format(fmt::runtime(notation), comp[row]));
             if (formatted[0] == '-') {
                 formatted = formatted.substr(1);
             }
@@ -356,13 +361,13 @@ vector<string> integerColumn(string name, const vector<long int>& comp,
     }
 
     // assemble output
-    vector<string> col = {fmt::format(notation, name)};
+    vector<string> col = {fmt::format(fmt::runtime(notation), name)};
     int count = 0;
     for (const auto& val : data) {
-        col.push_back(fmt::format(notation, val));
+        col.push_back(fmt::format(fmt::runtime(notation), val));
         count++;
         if (count == dots) {
-            col.push_back(fmt::format(notation, ".."));
+            col.push_back(fmt::format(fmt::runtime(notation), ".."));
         }
     }
     return col;
@@ -381,31 +386,33 @@ vector<string> stringColumn(string name, const vector<string>& comp,
         for (const auto& val : comp) {
             data.push_back(val);
             maxLen = std::max(maxLen,
-                boost::trim_copy(fmt::format(notation, val)).size());
+                boost::trim_copy(fmt::format(fmt::runtime(notation), val)).size());
         }
     } else {
         dots = (rows + 1) / 2;
         for (int row = 0; row < dots; row++) {
             data.push_back(comp[row]);
             maxLen = std::max(maxLen,
-                boost::trim_copy(fmt::format(notation, comp[row])).size());
+                boost::trim_copy(
+                    fmt::format(fmt::runtime(notation), comp[row])).size());
         }
         for (int row = csize - rows / 2; row < csize; row++) {
             data.push_back(comp[row]);
             maxLen = std::max(maxLen,
-                boost::trim_copy(fmt::format(notation, comp[row])).size());
+                boost::trim_copy(
+                    fmt::format(fmt::runtime(notation), comp[row])).size());
         }
     }
 
     // assemble output
     notation = fmt::format("  {{:>{}}}", maxLen);
-    vector<string> col = {fmt::format(notation, name)};
+    vector<string> col = {fmt::format(fmt::runtime(notation), name)};
     int count = 0;
     for (const auto& val : data) {
-        col.push_back(fmt::format(notation, val));
+        col.push_back(fmt::format(fmt::runtime(notation), val));
         count++;
         if (count == dots) {
-            col.push_back(fmt::format(notation, "..."));
+            col.push_back(fmt::format(fmt::runtime(notation), "..."));
         }
     }
     return col;
@@ -443,8 +450,8 @@ vector<string> formatColumn(string name, const AnyValue& comp, int rows, int wid
 
     // assemble output
     string notation = fmt::format("  {{:>{}}}", maxLen);
-    repr = fmt::format(notation, repr);
-    vector<string> col = {fmt::format(notation, name)};
+    repr = fmt::format(fmt::runtime(notation), repr);
+    vector<string> col = {fmt::format(fmt::runtime(notation), name)};
     if (size <= rows) {
         for (int row = 0; row < size; row++) {
             col.push_back(repr);
@@ -454,7 +461,7 @@ vector<string> formatColumn(string name, const AnyValue& comp, int rows, int wid
         for (int row = 0; row < dots; row++) {
             col.push_back(repr);
         }
-        col.push_back(fmt::format(notation, "..."));
+        col.push_back(fmt::format(fmt::runtime(notation), "..."));
         for (int row = size - rows / 2; row < size; row++) {
             col.push_back(repr);
         }

--- a/src/thermo/PureFluidPhase.cpp
+++ b/src/thermo/PureFluidPhase.cpp
@@ -393,7 +393,7 @@ string PureFluidPhase::report(bool show_thermo, double threshold) const
 
     string one_property = fmt::format("{{:>{}}}   {{:<.5g}} {{}}\n", name_width);
 
-    string two_prop_header = "{}   {:^15}   {:^15}\n";
+    constexpr auto two_prop_header = "{}   {:^15}   {:^15}\n";
     string kg_kmol_header = fmt::format(
         two_prop_header, blank_leader, "1 kg", "1 kmol"
     );

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -1291,7 +1291,7 @@ string ThermoPhase::report(bool show_thermo, double threshold) const
 
     string one_property = fmt::format("{{:>{}}}   {{:<.5g}} {{}}\n", name_width);
 
-    string two_prop_header = "{}   {:^15}   {:^15}\n";
+    constexpr auto two_prop_header = "{}   {:^15}   {:^15}\n";
     string kg_kmol_header = fmt::format(
         two_prop_header, blank_leader, "1 kg", "1 kmol"
     );


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix usage of `fmt` when compiling in C++20 mode
- Add support for the recently-released `fmt` 11.0
- Add CI tests specifying use of C++20 mode and using `fmt` 11.0

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Closes #1711
- Closes #1735

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
