### PR TITLE
Fix various YAML serialization issues

### DIFF
--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -250,6 +250,9 @@ public:
     template<class T>
     AnyValue& operator=(const map<string, T> items);
 
+    //! @see AnyMap::exclude()
+    static AnyValue exclude();
+
     //! Return the held `AnyMap` as a `map` where all of the values have
     //! the specified type.
     template<class T>
@@ -470,6 +473,10 @@ public:
     //! Add items from `other` to this AnyMap. If keys in `other` also exist in
     //! this AnyMap, the `keepExisting` option determines which item is used.
     void update(const AnyMap& other, bool keepExisting=true);
+
+    //! Mark `key` as excluded from this map. This prevents `key` from being added
+    //! by update(). Explicitly setting a value for `key` overrides this exclusion.
+    void exclude(const string& key);
 
     //! Return a string listing the keys in this AnyMap, for use in error
     //! messages, for example

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -626,9 +626,7 @@ public:
     OrderedProxy ordered() const { return OrderedProxy(*this); }
 
     //! Returns the number of elements in this map
-    size_t size() const {
-        return m_data.size();
-    };
+    size_t size() const;
 
     bool operator==(const AnyMap& other) const;
     bool operator!=(const AnyMap& other) const;

--- a/include/cantera/base/AnyMap.inl.h
+++ b/include/cantera/base/AnyMap.inl.h
@@ -224,7 +224,8 @@ bool AnyValue::eq_comparer(const std::any& lhs, const std::any& rhs)
     auto& ltype = lhs.type();
     auto& rtype = rhs.type();
     AssertThrowMsg(ltype == typeid(T),
-        "AnyValue::eq_comparer", "Compare function does not match held type");
+        "AnyValue::eq_comparer", "Compare function ({}) does not match held type ({})",
+        demangle(ltype), demangle(typeid(T)));
 
     if (ltype == rtype) {
         return any_cast<T>(lhs) == any_cast<T>(rhs);

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -326,35 +326,15 @@ YAML::Emitter& operator<<(YAML::Emitter& out, const AnyMap& rhs)
 
 //! Write YAML strings spanning multiple lines if input includes endline '\n'
 void emitString(YAML::Emitter& out, const string& str0) {
-    size_t endline = str0.rfind('\n');
-    if (endline == string::npos) {
+    if (str0.rfind('\n') == string::npos) {
         out << str0;
         return;
     }
 
-    // Remove trailing line break
-    string str1 = str0;
-    if (endline == str1.size() - 1) {
-        str1.erase(endline, 1);
-        endline = str1.rfind('\n');
-    }
-
-    // Deblank lines (remove whitespace surrounding line breaks)
-    while (endline != string::npos) {
-        size_t len = 1;
-        while (str1[endline + len] == ' ') {
-            len++; // account for whitespace after line break
-        }
-        while (str1[endline - 1] == ' ') {
-            len++; // account for whitespace before line break
-            endline--;
-        }
-        if (len > 1) {
-            // remove surrounding whitespace
-            str1.replace(endline, len, "\n");
-        }
-        endline = str1.rfind('\n', endline - 1);
-    }
+    // Remove leading and trailing whitespace
+    size_t left = str0.find_first_not_of("\n\t ");
+    size_t right = str0.find_last_not_of("\n\t ");
+    string str1 = str0.substr(left, right - left + 1);
     out << YAML::Literal << str1;
 }
 

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -1449,7 +1449,11 @@ const AnyValue& AnyMap::at(const string& key) const
 
 bool AnyMap::empty() const
 {
-    return m_data.size() == 0;
+    // Iterate to check for non-hidden, non-excluded elements
+    for ([[maybe_unused]] const auto& item : *this) {
+        return false;
+    }
+    return true;
 }
 
 bool AnyMap::hasKey(const string& key) const
@@ -1699,6 +1703,16 @@ AnyMap::OrderedIterator::OrderedIterator(
 {
     m_iter = start;
     m_stop = stop;
+}
+
+size_t AnyMap::size() const
+{
+    size_t n = 0;
+    // Iterate to count only non-hidden, non-excluded elements
+    for ([[maybe_unused]] const auto& item : *this) {
+        n++;
+    }
+    return n;
 }
 
 bool AnyMap::operator==(const AnyMap& other) const

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -135,7 +135,10 @@ Type elementTypes(const YAML::Node& node)
             types = types | Type::Sequence;
         } else if (el.IsScalar()) {
             string nodestr = el.as<string>();
-            if (isInt(nodestr)) {
+            if (el.Tag() == "!") {
+                // Prevent implicit conversion of quoted strings to numeric types
+                types = types | Type::String;
+            } else if (isInt(nodestr)) {
                 types = types | Type::Integer;
             } else if (isFloat(nodestr)) {
                 types = types | Type::Double;

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -259,6 +259,9 @@ struct convert<Cantera::AnyMap> {
 
     static bool decode(const Node& node, Cantera::AnyMap& target) {
         target.setLoc(node.Mark().line, node.Mark().column);
+        if (node.Style() == YAML::EmitterStyle::Flow) {
+            target.setFlowStyle();
+        }
         if (node.IsSequence()) {
             // Convert a top-level list to a map with the key "items"
             target["items"] = node.as<AnyValue>();

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -226,15 +226,23 @@ void Reaction::getParameters(AnyMap& reactionNode) const
 
     if (duplicate) {
         reactionNode["duplicate"] = true;
+    } else {
+        reactionNode.exclude("duplicate");
     }
     if (orders.size()) {
         reactionNode["orders"] = orders;
+    } else {
+        reactionNode.exclude("orders");
     }
     if (allow_negative_orders) {
         reactionNode["negative-orders"] = true;
+    } else {
+        reactionNode.exclude("negative-orders");
     }
     if (allow_nonreactant_orders) {
         reactionNode["nonreactant-orders"] = true;
+    } else {
+        reactionNode.exclude("nonreactant-orders");
     }
 
     reactionNode.update(m_rate->parameters());
@@ -251,7 +259,7 @@ void Reaction::getParameters(AnyMap& reactionNode) const
             reactionNode["type"] = "elementary";
         }
     } else if (ba::ends_with(rtype, "Arrhenius")) {
-        reactionNode.erase("type");
+        reactionNode.exclude("type");
     } else if (m_explicit_type) {
         reactionNode["type"] = type();
     } else if (ba::ends_with(rtype, "Blowers-Masel")) {

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -72,10 +72,16 @@ AnyMap Species::parameters(const ThermoPhase* phase, bool withInput) const
 
     if (charge != 0) {
         speciesNode["charge"] = charge;
+    } else {
+        speciesNode.exclude("charge");
     }
+
     if (size != 1) {
         speciesNode["size"] = size;
+    } else {
+        speciesNode.exclude("size");
     }
+
     if (thermo) {
         AnyMap thermoNode = thermo->parameters(withInput);
         if (thermoNode.size()) {

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -304,6 +304,7 @@ TEST(AnyMap, iterators)
 {
     AnyMap m = AnyMap::fromYamlString(
         "{a: 1, b: two, c: 3.01, d: {foo: 1, bar: 2}}");
+
     vector<string> keys;
     for (const auto& [key, value] : m) {
         keys.push_back(key);
@@ -334,6 +335,14 @@ TEST(AnyMap, null_values)
         EXPECT_THAT(err.what(),
                     testing::HasSubstr("Key 'b' not found or contains no value"));
     }
+}
+
+TEST(AnyMap, sizes) {
+    AnyMap m = AnyMap::fromYamlString("{__hidden__: 3}");
+    m.exclude("baz");
+    m.setFlowStyle();
+    EXPECT_TRUE(m.empty());
+    EXPECT_EQ(m.size(), 0U);
 }
 
 TEST(AnyMap, loadYaml)

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -286,6 +286,17 @@ TEST(AnyMap, conversion_to_anyvalue)
     EXPECT_EQ(n.at("strings").asVector<AnyValue>()[0].asString(), "foo");
 }
 
+TEST(AnyMap, conversion_from_quoted)
+{
+    AnyMap m = AnyMap::fromYamlString(
+        "{top: '99', mixed: [5.1, '122599', '3.140'], uniform: ['99', 100.1']}");
+    EXPECT_TRUE(m["top"].is<string>());
+    EXPECT_FALSE(m["top"].is<int>());
+    EXPECT_THROW(m["mixed"].asVector<double>(), InputFileError);
+    EXPECT_DOUBLE_EQ(m["mixed"].asVector<AnyValue>()[0].asDouble(), 5.1);
+    EXPECT_THROW(m["uniform"].asVector<double>(), InputFileError);
+}
+
 TEST(AnyMap, read_subnormal)
 {
     AnyMap m = AnyMap::fromYamlString(

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -1218,6 +1218,22 @@ class TestSolutionSerialization(utilities.CanteraTest):
         self.assertEqual(data2["thermo"]["something"], [False, True])
         self.assertTrue(gas2.reaction(5).input_data["baked-beans"])
 
+    def test_yaml_strings(self):
+        gas = ct.Solution('h2o2.yaml', transport_model=None)
+        desc = "   Line 1\n    Line 2\n  Line 3"
+        note = "First\n\nSecond\n  Third"
+        gas.update_user_header({"description": desc})
+        gas.species(2).update_user_data({"note": note})
+
+        gas.write_yaml(self.test_work_path / "h2o2-generated-user-header.yaml")
+        gas2 = ct.Solution(self.test_work_path / "h2o2-generated-user-header.yaml")
+
+        # Ideally, multi-line YAML emitter would indicate stripping of the final newline
+        # (element annotated with '|-' instead of just '|') but this doesn't seem to be
+        # possible as of yaml-cpp 0.8.0.
+        assert gas2.input_header["description"].strip() == desc.strip()
+        assert gas2.species(2).input_data["note"].strip() == note.strip()
+
 
 class TestSpeciesSerialization(utilities.CanteraTest):
     def test_species_simple(self):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix serialization of changes to reaction/species flags with default values that are normally omitted, such as `duplicate: true`
- Add quotes when outputting strings that look like numbers, such as `123185` so they will be read in as strings rather than being implicitly converted to integers
- Remove initial indentation from multiline strings when serializing, to work around `yaml-cpp`'s limited support of multiline strings.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Closes #1629
- Closes #1610
- Closes #1695

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
