### PR TITLE
Remove CT_SUNDIALS_VERSION constant in favor of SUNDIALS-defined constants

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -528,6 +528,7 @@ jobs:
             python=${{ env.PYTHON_VERSION }} sundials=${{ matrix.sundials-ver }} scons
             numpy ruamel.yaml cython boost-cpp fmt=${{ matrix.fmt-ver }} eigen yaml-cpp
             pandas libgomp openblas pytest pytest-xdist highfive python-graphviz
+            setuptools
           post-cleanup: none
       - name: Build Cantera
         run: |
@@ -596,7 +597,7 @@ jobs:
         create-args: >-
           python=${{ matrix.python-version }} scons numpy cython ruamel.yaml boost-cpp
           eigen yaml-cpp pandas pytest pytest-xdist highfive pint python-graphviz
-          fmt=${{ matrix.fmt-ver }}
+          fmt=${{ matrix.fmt-ver }} setuptools
         init-shell: powershell bash
         post-cleanup: none
     - name: Build Cantera

--- a/SConstruct
+++ b/SConstruct
@@ -1475,7 +1475,7 @@ if env['system_sundials'] == 'y':
     elif sundials_ver > parse_version("7.0.0"):
         logger.warning(f"Sundials version {env['sundials_version']!r} has not been tested.")
 
-    logger.info(f"Using system installation of Sundials version {sundials_version!r}.")
+    logger.info(f"Using system installation of Sundials version {env['sundials_version']!r}.")
 
     # Determine whether or not Sundials was built with BLAS/LAPACK
     if sundials_ver <= parse_version("5.4"):

--- a/SConstruct
+++ b/SConstruct
@@ -476,7 +476,7 @@ config_options = [
            preferred option depends on the CPU manufacturer. In general, OpenBLAS
            ('openblas') is prioritized over standard libraries ('lapack,blas'), with
            Eigen being used if no suitable BLAS/LAPACK libraries are detected. On Intel
-           CPU's, MKL (Windows: 'mkl_rt' / Linux: 'mkl_rt,dl') has the highest priority,
+           CPUs, MKL (Windows: 'mkl_rt' / Linux: 'mkl_rt,dl') has the highest priority,
            followed by the other options. Note that Eigen is required whether or not
            BLAS/LAPACK libraries are used.""",
         "default", ("default", "y", "n")),
@@ -1199,7 +1199,7 @@ if nan_works.strip() != "1":
     config_error(
         "Cantera requires a working implementation of 'std::isnan'.\n"
         "If you have specified '-ffast-math' or equivalent as an optimization option,\n"
-        "either remove this option or add the '-fno-finite-math-only option'."
+        "either remove this option or add the '-fno-finite-math-only' option."
     )
 
 def split_version(version):

--- a/SConstruct
+++ b/SConstruct
@@ -1887,7 +1887,6 @@ if env["OS"] == "Darwin" and env["use_rpath_linkage"] and not env.subst("$__RPAT
     env.Append(LINKFLAGS=[env.subst(f'$RPATHPREFIX{x}$RPATHSUFFIX')
                           for x in env['RPATH']])
 
-configh['CT_SUNDIALS_VERSION'] = env['sundials_version'].replace('.','')
 
 if env.get('has_sundials_lapack') and env['use_lapack']:
     configh['CT_SUNDIALS_USE_LAPACK'] = 1

--- a/SConstruct
+++ b/SConstruct
@@ -1511,6 +1511,20 @@ else: # env['system_sundials'] == 'n'
     env['sundials_version'] = '5.3'
     env['has_sundials_lapack'] = int(env['use_lapack'])
 
+if env['system_sundials'] == 'y':
+    env['sundials_libs'] = ['sundials_cvodes', 'sundials_idas', 'sundials_nvecserial']
+    if sundials_ver >= parse_version("7.0.0"):
+        env['sundials_libs'].append('sundials_core')
+    if env['use_lapack']:
+        if env.get('has_sundials_lapack'):
+            env['sundials_libs'].extend(('sundials_sunlinsollapackdense',
+                                         'sundials_sunlinsollapackband'))
+        else:
+            env['sundials_libs'].extend(('sundials_sunlinsoldense',
+                                         'sundials_sunlinsolband'))
+else:
+    env['sundials_libs'] = []
+
 if env["hdf_include"] and env["hdf_support"] in ("y", "default"):
     env["hdf_include"] = Path(env["hdf_include"]).as_posix()
     add_system_include(env, env["hdf_include"])
@@ -1987,21 +2001,6 @@ if addInstallActions:
     if env["example_data"]:
         for yaml in multi_glob(env, "data/example_data", "yaml"):
             install("$inst_datadir/example_data", yaml)
-
-
-if env['system_sundials'] == 'y':
-    env['sundials_libs'] = ['sundials_cvodes', 'sundials_idas', 'sundials_nvecserial']
-    if sundials_ver >= parse_version("7.0.0"):
-        env['sundials_libs'].append('sundials_core')
-    if env['use_lapack']:
-        if env.get('has_sundials_lapack'):
-            env['sundials_libs'].extend(('sundials_sunlinsollapackdense',
-                                         'sundials_sunlinsollapackband'))
-        else:
-            env['sundials_libs'].extend(('sundials_sunlinsoldense',
-                                         'sundials_sunlinsolband'))
-else:
-    env['sundials_libs'] = []
 
 # List of shared libraries needed to link to Cantera
 if env["renamed_shared_libraries"]:

--- a/include/cantera/base/config.h.in
+++ b/include/cantera/base/config.h.in
@@ -32,9 +32,6 @@ typedef int ftnlen;       // Fortran hidden string length type
 // For linux and most unix systems, this is the case.
 {FTN_TRAILING_UNDERSCORE!s}
 
-
-{CT_SUNDIALS_VERSION!s}
-
 //-------- LAPACK / BLAS ---------
 
 {LAPACK_FTN_STRING_LEN_AT_END!s}

--- a/include/cantera/cython/utils_utils.h
+++ b/include/cantera/cython/utils_utils.h
@@ -5,6 +5,7 @@
 #define CT_PY_UTILS_UTILS_H
 
 #include "cantera/base/logger.h"
+#include "sundials/sundials_config.h"
 
 #include "Python.h"
 
@@ -42,9 +43,9 @@ inline std::string get_cantera_git_commit_py()
 }
 
 // Wrappers for preprocessor defines
-inline int get_sundials_version()
+inline std::string get_sundials_version()
 {
-    return CT_SUNDIALS_VERSION;
+    return SUNDIALS_VERSION;
 }
 
 class PythonLogger : public Cantera::Logger

--- a/include/cantera/numerics/SundialsContext.h
+++ b/include/cantera/numerics/SundialsContext.h
@@ -7,8 +7,9 @@
 #define CT_SUNDIALSCONTEXT_H
 
 #include "cantera/base/ct_defs.h"
+#include "sundials/sundials_config.h"
 
-#if CT_SUNDIALS_VERSION >= 60
+#if SUNDIALS_VERSION_MAJOR >= 6
     #include "sundials/sundials_context.h"
 #endif
 
@@ -18,10 +19,10 @@ namespace Cantera
 //! A wrapper for managing a SUNContext object, need for Sundials >= 6.0
 class SundialsContext
 {
-#if CT_SUNDIALS_VERSION >= 60
+#if SUNDIALS_VERSION_MAJOR >= 6
 public:
     SundialsContext() {
-        #if CT_SUNDIALS_VERSION >= 70
+        #if SUNDIALS_VERSION_MAJOR >= 7
             SUNContext_Create(SUN_COMM_NULL, &m_context);
 
         #else

--- a/include/cantera/numerics/sundials_headers.h
+++ b/include/cantera/numerics/sundials_headers.h
@@ -1,7 +1,6 @@
 #ifndef CT_SUNDIALS_HEADERS
 #define CT_SUNDIALS_HEADERS
 
-#include "sundials/sundials_config.h"
 #include "sundials/sundials_types.h"
 #include "sundials/sundials_math.h"
 #include "sundials/sundials_nvector.h"

--- a/include/cantera/numerics/sundials_headers.h
+++ b/include/cantera/numerics/sundials_headers.h
@@ -1,6 +1,7 @@
 #ifndef CT_SUNDIALS_HEADERS
 #define CT_SUNDIALS_HEADERS
 
+#include "sundials/sundials_config.h"
 #include "sundials/sundials_types.h"
 #include "sundials/sundials_math.h"
 #include "sundials/sundials_nvector.h"
@@ -18,14 +19,14 @@
 #include "sunlinsol/sunlinsol_spgmr.h"
 #include "cvodes/cvodes_diag.h"
 
-#if CT_SUNDIALS_VERSION < 70
+#if SUNDIALS_VERSION_MAJOR < 7
     #include "cvodes/cvodes_direct.h"
     #include "idas/idas_direct.h"
     #include "idas/idas_spils.h"
     #include "cvodes/cvodes_spils.h"
 #endif
 
-#if CT_SUNDIALS_VERSION < 60
+#if SUNDIALS_VERSION_MAJOR < 6
     typedef realtype sunrealtype;
     typedef booleantype sunbooleantype;
 #endif

--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -94,7 +94,7 @@ cdef extern from "cantera/base/ctexceptions.h" namespace "Cantera":
 cdef extern from "cantera/cython/utils_utils.h":
     cdef string get_cantera_version_py()
     cdef string get_cantera_git_commit_py()
-    cdef int get_sundials_version()
+    cdef string get_sundials_version()
     cdef cppclass CxxPythonLogger "PythonLogger":
         pass
 

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -51,7 +51,7 @@ def get_data_directories():
     """ Get a list of the directories Cantera searches for data files. """
     return pystr(CxxGetDataDirectories(stringify(os.pathsep))).split(os.pathsep)
 
-__sundials_version__ = '.'.join(str(get_sundials_version()))
+__sundials_version__ = pystr(get_sundials_version())
 
 __version__ = pystr(CxxVersion())
 

--- a/interfaces/python_sdist/build_sdist.py
+++ b/interfaces/python_sdist/build_sdist.py
@@ -43,7 +43,6 @@ def do_configure_substitution(
     configure_subst = {
         "CANTERA_VERSION": f'#define CANTERA_VERSION "{cantera_version}"',
         "CANTERA_SHORT_VERSION": f'#define CANTERA_SHORT_VERSION "{cantera_short_version}"',
-        "CT_SUNDIALS_VERSION": "#define CT_SUNDIALS_VERSION 70",
         "FTN_TRAILING_UNDERSCORE": "#define FTN_TRAILING_UNDERSCORE 1",
         "LAPACK_FTN_STRING_LEN_AT_END": "#define LAPACK_FTN_STRING_LEN_AT_END 1",
         "LAPACK_FTN_TRAILING_UNDERSCORE": "#define LAPACK_FTN_TRAILING_UNDERSCORE 1",

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1335,6 +1335,9 @@ def setup_python_env(env):
     plat = info['plat'].replace('-', '_').replace('.', '_')
     numpy_include = info["numpy_include"]
     env.Prepend(CPPPATH=Dir('#include'))
+    if env["system_sundials"] == "n":
+        env.Prepend(CPPPATH=Dir('#include/cantera/ext'))
+
     add_system_include(env, (inc, numpy_include), 'prepend')
     env.Prepend(LIBS=env['cantera_shared_libs'])
 

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -6,7 +6,6 @@
 #include "cantera/numerics/BandMatrix.h"
 #include "cantera/base/utilities.h"
 #include "cantera/base/stringUtils.h"
-#include "sundials/sundials_config.h"
 
 #if CT_USE_LAPACK
     #include "cantera/numerics/ctlapack.h"

--- a/src/numerics/BandMatrix.cpp
+++ b/src/numerics/BandMatrix.cpp
@@ -6,6 +6,7 @@
 #include "cantera/numerics/BandMatrix.h"
 #include "cantera/base/utilities.h"
 #include "cantera/base/stringUtils.h"
+#include "sundials/sundials_config.h"
 
 #if CT_USE_LAPACK
     #include "cantera/numerics/ctlapack.h"
@@ -233,7 +234,7 @@ int BandMatrix::factor()
     long int nu = static_cast<long int>(nSuperDiagonals());
     long int nl = static_cast<long int>(nSubDiagonals());
     long int smu = nu + nl;
-    #if CT_SUNDIALS_VERSION >= 60
+    #if SUNDIALS_VERSION_MAJOR >= 6
         m_info = SUNDlsMat_bandGBTRF(m_lu_col_ptrs.data(),
                                      static_cast<long int>(nColumns()),
                                      nu, nl, smu, m_ipiv->data.data());
@@ -273,7 +274,7 @@ int BandMatrix::solve(double* b, size_t nrhs, size_t ldb)
     long int nl = static_cast<long int>(nSubDiagonals());
     long int smu = nu + nl;
     double** a = m_lu_col_ptrs.data();
-    #if CT_SUNDIALS_VERSION >= 60
+    #if SUNDIALS_VERSION_MAJOR >= 6
         SUNDlsMat_bandGBTRS(a, static_cast<long int>(nColumns()), smu, nl,
                             m_ipiv->data.data(), b);
     #else

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -5,7 +5,6 @@
 
 #include "cantera/numerics/CVodesIntegrator.h"
 #include "cantera/base/stringUtils.h"
-#include "sundials/sundials_config.h"
 
 #include <iostream>
 using namespace std;

--- a/src/numerics/IdasIntegrator.cpp
+++ b/src/numerics/IdasIntegrator.cpp
@@ -7,7 +7,6 @@
 #include "cantera/base/stringUtils.h"
 
 #include "cantera/numerics/sundials_headers.h"
-#include "sundials/sundials_config.h"
 
 using namespace std;
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Replace `CT_SUNDIALS_VERSION` with `SUNDIALS_VERSION_MAJOR`. In all the existing cases, the comparison was to `x0` (where `x` was one of 4, 6, or 7) indicating only the major version was being considered.
- Ensured that the version checks for SUNDIALS in SConstruct are still relevant

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes https://github.com/Cantera/enhancements/issues/209

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
