### PR TITLE
Fix post-merge tests

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -102,7 +102,9 @@ jobs:
         python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
         system_fmt=y cc_flags=-D_GLIBCXX_ASSERTIONS
     - name: Upload shared library
-      uses: actions/upload-artifact@v4
+      # Pin to 4.3.4 to resolve errors around only uploading symlinks.
+      # See https://github.com/actions/upload-artifact/issues/589
+      uses: actions/upload-artifact@v4.3.4
       if: matrix.python-version == '3.11'
       with:
         path: build/lib/libcantera_shared.so
@@ -205,7 +207,9 @@ jobs:
       run: scons build env_vars=all -j3 debug=n --debug=time
         boost_inc_dir=${BOOST_INC_DIR} ${{ matrix.extra-build-args }}
     - name: Upload shared library
-      uses: actions/upload-artifact@v4
+      # Pin to 4.3.4 to resolve errors around only uploading symlinks.
+      # See https://github.com/actions/upload-artifact/issues/589
+      uses: actions/upload-artifact@v4.3.4
       if: matrix.python-version == '3.11' && matrix.macos-version == 'macos-12'
       with:
         path: build/lib/libcantera_shared.dylib
@@ -606,7 +610,9 @@ jobs:
         --debug=time -j4
       shell: pwsh
     - name: Upload shared library
-      uses: actions/upload-artifact@v4
+      # Pin to 4.3.4 to resolve errors around only uploading symlinks.
+      # See https://github.com/actions/upload-artifact/issues/589
+      uses: actions/upload-artifact@v4.3.4
       if: matrix.python-version == '3.11'
       with:
         path: build/lib/cantera_shared.dll

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -10,15 +10,22 @@ on:
     # Run when the main branch is pushed to
     branches:
       - main
+  # Run on pull requests when this file is modified
+  pull_request:
+    branches:
+      - main
+    paths:
+      - .github/workflows/post-merge-tests.yml
+
+env:
+  PIP_EXTRA_INDEX_URL: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+  PIP_ONLY_BINARY: ":all:"
 
 jobs:
   prerelease-cython:
     name: Pre-release Cython
     runs-on: ubuntu-22.04
     timeout-minutes: 60
-    env:
-      HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
-      HDF5_INCLUDEDIR: /usr/include/hdf5/serial
     steps:
     - uses: actions/checkout@v4
       name: Checkout the repository
@@ -43,16 +50,16 @@ jobs:
     - name: Build Cantera
       run: python3 `which scons` build env_vars=all
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
-        -j4 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
-        logging=debug python_package=y
+        -j4 debug=n --debug=time logging=debug python_package=y
     - name: Build Tests
       run: python3 `which scons` -j4 build-tests
     - name: Run compiled tests
       run: python3 `which scons` test-gtest test-legacy --debug=time
     - name: Run Python tests
-      run: |
-        LD_LIBRARY_PATH=build/lib
-        python3 -m pytest -raP -v -n auto --durations=50 test/python
+      run: python3 -m pytest -raP -v -n auto --durations=50 test/python
+      env:
+        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:build/lib"
+        PYTHONPATH: build/python
 
   ubuntu-docker:
     name: Docker 'ubuntu:${{ matrix.image }}' image
@@ -64,9 +71,6 @@ jobs:
     timeout-minutes: 60
     container:
       image: ubuntu:${{ matrix.image }}
-    env:
-      HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
-      HDF5_INCLUDEDIR: /usr/include/hdf5/serial
     steps:
     - name: Install git on ubuntu:${{ matrix.image }}
       run: |
@@ -95,7 +99,6 @@ jobs:
     - name: Build Cantera
       run: |
         scons build env_vars=all -j4 debug=n --debug=time \
-        hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
         system_eigen=y system_fmt=y system_sundials=y system_yamlcpp=y \
         system_blas_lapack=y hdf_support=y f90_interface=y \
         cc_flags=-D_GLIBCXX_ASSERTIONS python_package=y
@@ -106,7 +109,8 @@ jobs:
     - name: Run Python tests
       run: python3 -m pytest -raP -v -n auto --durations=50 test/python
       env:
-        LD_LIBRARY_PATH: build/lib
+        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:build/lib"
+        PYTHONPATH: build/python
 
   fedora-docker:
     name: Docker 'fedora:${{ matrix.image }}' image
@@ -134,7 +138,7 @@ jobs:
         python3-devel python3-numpy python3-pandas python3-pint python3-pip \
         python3-pytest python3-pytest-xdist python3-ruamel-yaml python3-scipy \
         python3-scons python3-wheel sundials-devel yaml-cpp-devel hdf5-devel \
-        highfive-devel python3-graphviz
+        highfive-devel python3-graphviz python3-packaging
     - name: Build Cantera
       run: |
         scons build -j4 debug=n --debug=time python_package=y f90_interface=y \
@@ -151,6 +155,7 @@ jobs:
       run: python3 -m pytest -raP -v -n auto --durations=50 test/python
       env:
         LD_LIBRARY_PATH: build/lib
+        PYTHONPATH: build/python
 
   ubuntu-python-prerelease:
     name: ${{ matrix.os }} with Python ${{ matrix.python-version }}
@@ -161,9 +166,6 @@ jobs:
         python-version: ['3.13']
         os: ['ubuntu-22.04', 'ubuntu-24.04']
       fail-fast: false
-    env:
-      HDF5_LIBDIR: /usr/lib/x86_64-linux-gnu/hdf5/serial
-      HDF5_INCLUDEDIR: /usr/include/hdf5/serial
     steps:
     - uses: actions/checkout@v4
       name: Checkout the repository
@@ -182,25 +184,26 @@ jobs:
         libblas-dev liblapack-dev libhdf5-dev libfmt-dev
         gcc --version
     - name: Upgrade pip
-      run: python3 -m pip install -U pip setuptools wheel
+      run: python3 -m pip install -U pip setuptools wheel packaging
     - name: Install Python dependencies
       run: |
-        python3 -m pip install ruamel.yaml scons numpy cython pandas pytest \
+        python3 -m pip install ruamel.yaml scons pytest \
         pytest-xdist pytest-github-actions-annotate-failures pint graphviz
+        python3 -m pip install --pre numpy cython pandas scipy
     - name: Build Cantera
       run: |
         python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
-        system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
-        system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS \
+        system_fmt=y system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS \
         python_package=y
     - name: Build Tests
       run: python3 `which scons` -j4 build-tests
     - name: Run compiled tests
       run: python3 `which scons` test-gtest test-legacy --debug=time
     - name: Run Python tests
-      run: |
-        LD_LIBRARY_PATH=build/lib
-        python3 -m pytest -raP -v -n auto --durations=50 test/python
+      run: python3 -m pytest -raP -v -n auto --durations=50 test/python
+      env:
+        LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:build/lib"
+        PYTHONPATH: build/python
 
   macos-homebrew:
     runs-on: macos-14
@@ -213,27 +216,30 @@ jobs:
         submodules: recursive
     # NumPy is installed here for the Python custom rate tests
     - name: Install Brew dependencies
-      run: brew install --display-times boost libomp hdf5 python python-setuptools scons numpy
+      run: brew install --display-times boost libomp hdf5 python numpy
     - name: Set Include folder
-      run: |
-        echo "BOOST_INC_DIR=$(brew --prefix)/include" >> $GITHUB_ENV
+      run: echo "BOOST_INC_DIR=$(brew --prefix)/include" >> $GITHUB_ENV
     # This is necessary because of PEP 668 https://peps.python.org/pep-0668/
     # PEP 668 prohibits installation to system Python packages via pip
     - name: Create a virtualenv for dependencies
       run: |
         $(brew --prefix)/bin/python3.12 -m venv .venv
     - name: Install Python dependencies
+      # SCons must be installed into the virtualenv because packaging is a dependency
+      # and we can't install packaging for the homebrew Python
       run: |
         ./.venv/bin/python -m pip install -U pip setuptools wheel build
         ./.venv/bin/python -m pip install ruamel.yaml numpy cython pandas pytest \
-          pytest-xdist pytest-github-actions-annotate-failures pint graphviz
+          pytest-xdist pytest-github-actions-annotate-failures pint graphviz \
+          scons packaging
     - name: Build Cantera
-      run: $(brew --prefix)/bin/scons build env_vars=all python_cmd="$(pwd)/.venv/bin/python" -j3 debug=n --debug=time boost_inc_dir=${BOOST_INC_DIR} python_package=y
+      run: ./.venv/bin/scons build env_vars=all -j3 debug=n --debug=time boost_inc_dir=${BOOST_INC_DIR} python_package=y
     - name: Build Tests
-      run: $(brew --prefix)/bin/scons -j3 build-tests
+      run: ./.venv/bin/scons -j3 build-tests
     - name: Run compiled tests
-      run: $(brew --prefix)/bin/scons test-gtest test-legacy --debug=time
+      run: ./.venv/bin/scons test-gtest test-legacy --debug=time
     - name: Run Python tests
-      run: |
-        export DYLD_LIBRARY_PATH=build/lib
-        ./.venv/bin/python -m pytest -raP -v -n auto --durations=50 test/python
+      run: ./.venv/bin/python -m pytest -raP -v -n auto --durations=50 test/python
+      env:
+        DYLD_LIBRARY_PATH: "${DYLD_LIBRARY_PATH}:build/lib"
+        PYTHONPATH: build/python

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -44,7 +44,7 @@ jobs:
       run: python3 `which scons` build env_vars=all
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
         -j4 debug=n --debug=time hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR
-        logging=debug
+        logging=debug python_package=y
     - name: Build Tests
       run: python3 `which scons` -j4 build-tests
     - name: Run compiled tests
@@ -98,7 +98,7 @@ jobs:
         hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
         system_eigen=y system_fmt=y system_sundials=y system_yamlcpp=y \
         system_blas_lapack=y hdf_support=y f90_interface=y \
-        cc_flags=-D_GLIBCXX_ASSERTIONS
+        cc_flags=-D_GLIBCXX_ASSERTIONS python_package=y
     - name: Build Tests
       run: scons -j4 build-tests
     - name: Run compiled tests
@@ -191,7 +191,8 @@ jobs:
       run: |
         python3 `which scons` build env_vars=all -j4 debug=n --debug=time \
         system_fmt=y hdf_libdir=$HDF5_LIBDIR hdf_include=$HDF5_INCLUDEDIR \
-        system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS
+        system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS \
+        python_package=y
     - name: Build Tests
       run: python3 `which scons` -j4 build-tests
     - name: Run compiled tests
@@ -227,7 +228,7 @@ jobs:
         ./.venv/bin/python -m pip install ruamel.yaml numpy cython pandas pytest \
           pytest-xdist pytest-github-actions-annotate-failures pint graphviz
     - name: Build Cantera
-      run: $(brew --prefix)/bin/scons build env_vars=all python_cmd="$(pwd)/.venv/bin/python" -j3 debug=n --debug=time boost_inc_dir=${BOOST_INC_DIR}
+      run: $(brew --prefix)/bin/scons build env_vars=all python_cmd="$(pwd)/.venv/bin/python" -j3 debug=n --debug=time boost_inc_dir=${BOOST_INC_DIR} python_package=y
     - name: Build Tests
       run: $(brew --prefix)/bin/scons -j3 build-tests
     - name: Run compiled tests

--- a/SConstruct
+++ b/SConstruct
@@ -1728,8 +1728,8 @@ elif env['python_package'] == 'none':
 env["python_min_version"] = python_min_version
 env["python_max_version"] = python_max_version
 env["py_requires_ver_str"] = py_requires_ver_str
-env["cython_version_spec"] = SpecifierSet(">=0.29.31")
-env["numpy_version_spec"] = SpecifierSet(">=1.12.0,<3")
+env["cython_version_spec"] = SpecifierSet(">=0.29.31", prereleases=True)
+env["numpy_version_spec"] = SpecifierSet(">=1.12.0,<3", prereleases=True)
 env["cython_version_spec_str"] = str(env["cython_version_spec"])
 env["numpy_version_spec_str"] = str(env["numpy_version_spec"])
 
@@ -1738,11 +1738,11 @@ env["numpy_version_spec_str"] = str(env["numpy_version_spec"])
 # 18.04 repositories and seems to work. Older versions such as
 # 0.13.14 on CentOS7 and 0.10.23 on Ubuntu 16.04 raise an exception
 # that they are missing the RoundTripRepresenter
-env["ruamel_version_spec"] = SpecifierSet(">=0.15.34")
+env["ruamel_version_spec"] = SpecifierSet(">=0.15.34", prereleases=True)
 env["ruamel_version_spec_str"] = str(env["ruamel_version_spec"])
 
 # Minimum pytest version assumed based on Ubuntu 20.04
-env["pytest_version_spec"] = SpecifierSet(">=4.6.9")
+env["pytest_version_spec"] = SpecifierSet(">=4.6.9", prereleases=True)
 
 env['install_python_action'] = ''
 env['python_module_loc'] = ''

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -1,6 +1,7 @@
 """Cython-based Python Module"""
 import re
 from pathlib import Path
+from packaging.version import parse as parse_version
 from buildutils import *
 
 Import('env', 'build', 'install')
@@ -79,6 +80,10 @@ ext = localenv.LoadableModule(f"cantera/_cantera{module_ext}",
 
 build_cmd = ("$python_cmd_esc -m pip wheel -v --no-build-isolation --no-deps "
              "--wheel-dir=build/python/dist build/python")
+# We've already warned that this Python version might be unsupported, so disable
+# pip's check for a correct version of Python.
+if parse_version(localenv["py_version_short"]) >= env["python_max_version"]:
+    build_cmd += " --ignore-requires-python"
 wheel_name = ("Cantera-${cantera_version}-cp${py_version_nodot}"
               "-cp${py_version_nodot}-${py_plat}.whl")
 mod = build(localenv.Command(f"#build/python/dist/{wheel_name}", "setup.cfg",

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -434,7 +434,7 @@ protected:
     vector<string> inputDirs;
 
     //! Versions of Python to consider when attempting to load user extensions
-    vector<string> m_pythonSearchVersions = {"3.12", "3.11", "3.10", "3.9", "3.8"};
+    vector<string> m_pythonSearchVersions = {"3.13", "3.12", "3.11", "3.10", "3.9", "3.8"};
 
     //! Set of deprecation warnings that have been emitted (to suppress duplicates)
     set<string> warnings;

--- a/test/python/test_units.py
+++ b/test/python/test_units.py
@@ -1,10 +1,14 @@
-from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Optional, Tuple, Dict
-import sys
 
 import pytest
-pytest.importorskip("pint", "0.17.0")
+try:
+    pint = pytest.importorskip("pint", "0.17.0")
+except TypeError as e:
+    # The extra exception handling is here because pint is incompatible with
+    # Python 3.13. Once https://github.com/hgrecco/pint/issues/1969 is resolved the
+    # try/except here can be restored to just the importorskip.
+    pytest.skip(f"pint import failed due to {e}", allow_module_level=True)
 import cantera.with_units as ctu
 import cantera as ct
 try:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Set up the `SpecifierSet`s for version comparisons to allow pre-release versions of packages. This shouldn't change any behavior for stable versions.
- `hdf` variables no longer need to be specified to SCons CLI, they're handled by SConstruct since #1723
- Install pre-release wheels from the anaconda index for NumPy, SciPy, Pandas, and Cython. This means we don't have to build them ourselves :tada: 
- If the Python package is built for a newer version of Python than we support, ignore pip's error about unsupported Python because the user is warned by SCons anyways
- Add support for Python 3.13 to the extensions

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1751 

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
