### PR TITLE
Remove clib *newFromFile from MATLAB / fix memory leaks

### DIFF
--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -33,7 +33,7 @@ extern "C" {
     CANTERA_CAPI size_t soln_nAdjacent(int n);
     CANTERA_CAPI int soln_adjacent(int n, int a);
 
-    CANTERA_CAPI int thermo_newFromFile(const char* filename, const char* phasename);
+    CANTERA_CAPI int thermo_newFromFile(const char* filename, const char* phasename); //!< @todo remove from .NET and Fortran interfaces
     CANTERA_CAPI int thermo_del(int n);
     CANTERA_CAPI size_t thermo_nElements(int n);
     CANTERA_CAPI size_t thermo_nSpecies(int n);
@@ -123,7 +123,7 @@ extern "C" {
     //! @since Starting in %Cantera 3.0, the "phasename" argument should be blank
     CANTERA_CAPI int kin_newFromFile(const char* filename, const char* phasename,
                                      int reactingPhase, int neighbor1, int neighbor2,
-                                     int neighbor3, int neighbor4);
+                                     int neighbor3, int neighbor4); //!< @todo remove from .NET and Fortran interfaces
     CANTERA_CAPI int kin_del(int n);
     CANTERA_CAPI size_t kin_nSpecies(int n);
     CANTERA_CAPI size_t kin_nReactions(int n);
@@ -156,8 +156,8 @@ extern "C" {
     CANTERA_CAPI int kin_advanceCoverages(int n, double tstep);
     CANTERA_CAPI size_t kin_phase(int n, size_t i);
 
-    CANTERA_CAPI int trans_newDefault(int th, int loglevel);
-    CANTERA_CAPI int trans_new(const char* model, int th, int loglevel);
+    CANTERA_CAPI int trans_newDefault(int th, int loglevel); //!< @todo remove from .NET and Fortran interfaces
+    CANTERA_CAPI int trans_new(const char* model, int th, int loglevel); //!< @todo remove from .NET and Fortran interfaces
     CANTERA_CAPI int trans_del(int n);
     CANTERA_CAPI int trans_transportModel(int n, int lennm, char* nm);
     CANTERA_CAPI double trans_viscosity(int n);

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -35,6 +35,8 @@ extern "C" {
     CANTERA_CAPI int soln_adjacentName(int n, int a, int lennm, char* nm);
 
     CANTERA_CAPI int thermo_newFromFile(const char* filename, const char* phasename); //!< @todo remove from .NET and Fortran interfaces
+    CANTERA_CAPI int thermo_parent(int n);
+    CANTERA_CAPI int thermo_size();
     CANTERA_CAPI int thermo_del(int n);
     CANTERA_CAPI size_t thermo_nElements(int n);
     CANTERA_CAPI size_t thermo_nSpecies(int n);
@@ -125,6 +127,7 @@ extern "C" {
     CANTERA_CAPI int kin_newFromFile(const char* filename, const char* phasename,
                                      int reactingPhase, int neighbor1, int neighbor2,
                                      int neighbor3, int neighbor4); //!< @todo remove from .NET and Fortran interfaces
+    CANTERA_CAPI int kin_parent(int n);
     CANTERA_CAPI int kin_del(int n);
     CANTERA_CAPI size_t kin_nSpecies(int n);
     CANTERA_CAPI size_t kin_nReactions(int n);
@@ -159,6 +162,7 @@ extern "C" {
 
     CANTERA_CAPI int trans_newDefault(int th, int loglevel); //!< @todo remove from .NET and Fortran interfaces
     CANTERA_CAPI int trans_new(const char* model, int th, int loglevel); //!< @todo remove from .NET and Fortran interfaces
+    CANTERA_CAPI int trans_parent(int n);
     CANTERA_CAPI int trans_del(int n);
     CANTERA_CAPI int trans_transportModel(int n, int lennm, char* nm);
     CANTERA_CAPI double trans_viscosity(int n);

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -32,6 +32,7 @@ extern "C" {
     CANTERA_CAPI int soln_setTransportModel(int n, const char* model);
     CANTERA_CAPI size_t soln_nAdjacent(int n);
     CANTERA_CAPI int soln_adjacent(int n, int a);
+    CANTERA_CAPI int soln_adjacentName(int n, int a, int lennm, char* nm);
 
     CANTERA_CAPI int thermo_newFromFile(const char* filename, const char* phasename); //!< @todo remove from .NET and Fortran interfaces
     CANTERA_CAPI int thermo_del(int n);

--- a/interfaces/matlab_experimental/Base/Interface.m
+++ b/interfaces/matlab_experimental/Base/Interface.m
@@ -58,7 +58,7 @@ classdef Interface < handle & ThermoPhase & Kinetics
 
             % Inherit methods and properties from ThermoPhase and Kinetics
             s@ThermoPhase(ID);
-            s@Kinetics('clib', ID);
+            s@Kinetics(ID);
             s.phaseID = ID;
             s.interfaceName = name;
             s.nAdjacent = ctFunc('soln_nAdjacent', ID);

--- a/interfaces/matlab_experimental/Base/Interface.m
+++ b/interfaces/matlab_experimental/Base/Interface.m
@@ -57,7 +57,7 @@ classdef Interface < handle & ThermoPhase & Kinetics
             ID = ctFunc('soln_newInterface', src, name, na, adj);
 
             % Inherit methods and properties from ThermoPhase and Kinetics
-            s@ThermoPhase('clib', ID);
+            s@ThermoPhase(ID);
             s@Kinetics('clib', ID);
             s.phaseID = ID;
             s.interfaceName = name;

--- a/interfaces/matlab_experimental/Base/Interface.m
+++ b/interfaces/matlab_experimental/Base/Interface.m
@@ -19,7 +19,7 @@ classdef Interface < handle & ThermoPhase & Kinetics
     %     Instance of class :mat:class:`Interface`.
 
     properties (SetAccess = immutable)
-        phaseID % ID of the interface.
+        solnID % ID of the interface.
         interfaceName % Name of the interface.
     end
 
@@ -51,7 +51,7 @@ classdef Interface < handle & ThermoPhase & Kinetics
             % Get ID of adjacent phases
             adj = [];
             for i = 3:nargin
-                adj(i-2) = varargin{i}.phaseID;
+                adj(i-2) = varargin{i}.solnID;
             end
 
             ID = ctFunc('soln_newInterface', src, name, na, adj);
@@ -59,7 +59,7 @@ classdef Interface < handle & ThermoPhase & Kinetics
             % Inherit methods and properties from ThermoPhase and Kinetics
             s@ThermoPhase(ID);
             s@Kinetics(ID);
-            s.phaseID = ID;
+            s.solnID = ID;
             s.interfaceName = name;
             s.nAdjacent = ctFunc('soln_nAdjacent', ID);
         end
@@ -68,7 +68,7 @@ classdef Interface < handle & ThermoPhase & Kinetics
 
         function delete(s)
             % Delete :mat:class:`Interface` object.
-            disp('Interface class object has been deleted');
+            ctFunc('soln_del', s.solnID);
         end
 
         %% Interface Get Methods

--- a/interfaces/matlab_experimental/Base/Kinetics.m
+++ b/interfaces/matlab_experimental/Base/Kinetics.m
@@ -1,7 +1,11 @@
 classdef Kinetics < handle
     % Kinetics Class ::
     %
-    %     >> k = Kinetics(varargin)
+    %     >> k = Kinetics(id)
+    %
+    % Retrieve instance of class :mat:class:`Kinetics` associated with a
+    % :mat:class:`Solution` object. The constructor is called whenever a new
+    % :mat:class:`Solution` is instantiated and should not be used directly.
     %
     % Class :mat:class:`Kinetics` represents kinetics managers, which manage
     % reaction mechanisms. The reaction mechanism attributes are specified in a

--- a/interfaces/matlab_experimental/Base/Kinetics.m
+++ b/interfaces/matlab_experimental/Base/Kinetics.m
@@ -11,32 +11,10 @@ classdef Kinetics < handle
     % reaction rates of progress, species production rates, and other
     % quantities pertaining to a reaction mechanism.
     %
-    % :param varargin:
-    %     Variable number of inputs consisting of the following:
-    %       - ph:
-    %           An instance of class :mat:class:`ThermoPhase` representing the
-    %           phase in which reactions occur.
-    %       - src:
-    %           Input string of YAML file name when creating from file OR
-    %           "clib" when called by the class constructors of :mat:class:`Solution`
-    %           or :mat:class:`Interface`.
-    %     Optional:
-    %       - id:
-    %           ID of the phase to import as specified in the input file.
-    %       - neighbor1:
-    %           Instance of class :mat:class:`ThermoPhase` or
-    %           :mat:class:`Solution` representing the 1st neighboring phase.
-    %       - neighbor2:
-    %           Instance of class :mat:class:`ThermoPhase` or
-    %           :mat:class:`Solution` representing the 2nd neighboring phase.
-    %       - neighbor3:
-    %           Instance of class :mat:class:`ThermoPhase` or
-    %           :mat:class:`Solution` representing the 3rd neighboring phase.
-    %       - neighbor4:
-    %           Instance of class :mat:class:`ThermoPhase` or
-    %           :mat:class:`Solution` representing the 4th neighboring phase.
+    % :param id:
+    %     Integer ID of the solution holding the :mat:class:`Kinetics` object.
     % :return:
-    %      Instance of class :mat:class:`Kinetics`.
+    %     Instance of class :mat:class:`Kinetics`.
 
     properties (SetAccess = immutable)
         kinID % ID of the Kinetics object.
@@ -112,41 +90,21 @@ classdef Kinetics < handle
     methods
         %% Kinetics Class Constructor
 
-        function kin = Kinetics(varargin)
+        function kin = Kinetics(id)
 
             ctIsLoaded;
 
-            tmp = varargin{1};
-            src = varargin{2};
-
-            if ischar(tmp) & isnumeric(src)
-                if strcmp(tmp, 'clib')
-                    kin.kinID = ctFunc('soln_kinetics', src);
-                    return
-                end
+            if ~isnumeric(id)
+                error('Invalid argument: constructor requires integer solution ID.')
             end
 
-            ph = tmp.tpID;
-
-            if nargin == 2
-                id = '-';
-            elseif nargin > 2
-                id = varargin{3};
-            end
-
-            neighbours = {-1, -1, -1, -1};
-
-            for i = 4:length(varargin)
-                neighbours{i-3} = varargin{i}.tpID;
-            end
-
-            kin.kinID = ctFunc('kin_newFromFile', src, id, ph, neighbours{:});
+            kin.kinID = ctFunc('soln_kinetics', id);
         end
 
         %% Kinetics Class Destructor
 
         function delete(kin)
-            % Delete the :mat:class:`Sim1D` object.
+            % Delete the :mat:class:`Kinetics` object.
 
             if ~isa(kin, 'Solution') && ~isa(kin, 'Interface')
                 ctFunc('kin_del', kin.kinID);

--- a/interfaces/matlab_experimental/Base/Kinetics.m
+++ b/interfaces/matlab_experimental/Base/Kinetics.m
@@ -101,16 +101,6 @@ classdef Kinetics < handle
             kin.kinID = ctFunc('soln_kinetics', id);
         end
 
-        %% Kinetics Class Destructor
-
-        function delete(kin)
-            % Delete the :mat:class:`Kinetics` object.
-
-            if ~isa(kin, 'Solution') && ~isa(kin, 'Interface')
-                ctFunc('kin_del', kin.kinID);
-            end
-        end
-
         %% Get scalar attributes
 
         function n = kineticsSpeciesIndex(kin, name, phase)

--- a/interfaces/matlab_experimental/Base/Solution.m
+++ b/interfaces/matlab_experimental/Base/Solution.m
@@ -77,7 +77,7 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
             ID = ctFunc('soln_newSolution', src, name, transport_model);
             % Inherit methods and properties from ThermoPhase, Kinetics, and Transport
             s@ThermoPhase(ID);
-            s@Kinetics('clib', ID);
+            s@Kinetics(ID);
             s@Transport('clib', ID);
             s.phaseID = ID;
             s.solnName = ctString('soln_name', s.phaseID);

--- a/interfaces/matlab_experimental/Base/Solution.m
+++ b/interfaces/matlab_experimental/Base/Solution.m
@@ -1,7 +1,7 @@
 classdef Solution < handle & ThermoPhase & Kinetics & Transport
     % Solution Class ::
     %
-    %     >> s = Solution(src, name, trans)
+    %     >> s = Solution(src, name, transport_model)
     %
     % Class :mat:class:`Solution` represents solutions of multiple species. A
     % solution is defined as a mixture of two or more constituents
@@ -12,20 +12,12 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
     % of each species, which may be given as mole fractions or mass
     % fractions. ::
     %
-    %     >> s = Solution('input.yaml', phase_name, transport_model)
+    %     >> s = Solution('input.yaml')
     %
-    % constructs a :mat:class:`Solution` object from a specification contained in
-    % file ``input.yaml`` with the name of the phase to be imported specified with
-    % ``phase_name``. If a :mat:class:`Transport` model is included in ``input.yaml``,
-    % it will be included in the :mat:class:`Solution` instance with the default
-    % transport modeling as set in the input file. To specify the transport modeling,
-    % set the input argument ``trans`` to one of ``'default'``, ``'none'``,
-    % ``'mixture-averaged'``, or ``'multicomponent'``.
-    %
-    % In this case, the phase name must be specified as well. Alternatively,
-    % change the ``transport`` node in the YAML file, or ``transport``
-    % property in the CTI file before loading the phase. The transport
-    % modeling cannot be changed once the phase is loaded.
+    % constructs a :mat:class:`Solution` object from specifications contained in
+    % file ``input.yaml``. The phase defaults to the first phase listed in the
+    % YAML input file and no :mat:class:`Transport` model is included unless
+    % explicitly specified.
     %
     % Class :mat:class:`Solution` derives from three more basic classes, and most of
     % its methods are inherited from these classes. These are:
@@ -42,14 +34,14 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
     % :param name:
     %     name of the phase to import as specified in the YAML file.
     % :param transport_model:
-    %     String specigying transport model. Possible values are ``'default'``,
+    %     String specifying transport model. Possible values are ``'default'``,
     %     ``'none'``, ``'mixture-averaged'``, or ``'multicomponent'``. If not specified,
     %     ``'none'`` is used.
     % :return:
     %     Instance of class :mat:class:`Solution`.
 
     properties (SetAccess = immutable)
-        phaseID % ID of the solution.
+        solnID % ID of the solution.
         solnName % Name of the solution.
     end
 
@@ -79,8 +71,8 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
             s@ThermoPhase(ID);
             s@Kinetics(ID);
             s@Transport(ID);
-            s.phaseID = ID;
-            s.solnName = ctString('soln_name', s.phaseID);
+            s.solnID = ID;
+            s.solnName = ctString('soln_name', s.solnID);
             s.th = s.tpID;
         end
 
@@ -88,7 +80,7 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
 
         function delete(s)
             % Delete :mat:class:`Solution` object.
-            ctFunc('soln_del', s.phaseID);
+            ctFunc('soln_del', s.solnID);
         end
 
     end

--- a/interfaces/matlab_experimental/Base/Solution.m
+++ b/interfaces/matlab_experimental/Base/Solution.m
@@ -78,7 +78,7 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
             % Inherit methods and properties from ThermoPhase, Kinetics, and Transport
             s@ThermoPhase(ID);
             s@Kinetics(ID);
-            s@Transport('clib', ID);
+            s@Transport(ID);
             s.phaseID = ID;
             s.solnName = ctString('soln_name', s.phaseID);
             s.th = s.tpID;

--- a/interfaces/matlab_experimental/Base/Solution.m
+++ b/interfaces/matlab_experimental/Base/Solution.m
@@ -36,7 +36,7 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
     % :param transport_model:
     %     String specifying transport model. Possible values are ``'default'``,
     %     ``'none'``, ``'mixture-averaged'``, or ``'multicomponent'``. If not specified,
-    %     ``'none'`` is used.
+    %     ``'default'`` is used.
     % :return:
     %     Instance of class :mat:class:`Solution`.
 
@@ -54,19 +54,25 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
 
             ctIsLoaded;
 
-            if nargin == 0 || ~ischar(src)
-                error("Invalid argument: Solution requires name of input file.")
+            if isnumeric(src)
+                % New MATLAB object from existing C++ Solution
+                ID = src;
+            else
+                % New C++/MATLAB object from YAML source
+                if ~ischar(src)
+                    error("Invalid argument: Solution requires name of input file.")
+                end
+                if nargin < 2
+                    name = '';
+                end
+
+                if nargin < 3
+                    transport_model = 'default';
+                end
+
+                ID = ctFunc('soln_newSolution', src, name, transport_model);
             end
 
-            if nargin < 2
-                name = '';
-            end
-
-            if nargin < 3
-                transport_model = 'none';
-            end
-
-            ID = ctFunc('soln_newSolution', src, name, transport_model);
             % Inherit methods and properties from ThermoPhase, Kinetics, and Transport
             s@ThermoPhase(ID);
             s@Kinetics(ID);

--- a/interfaces/matlab_experimental/Base/Solution.m
+++ b/interfaces/matlab_experimental/Base/Solution.m
@@ -1,7 +1,7 @@
 classdef Solution < handle & ThermoPhase & Kinetics & Transport
     % Solution Class ::
     %
-    %     >> s = Solution(src, id, trans)
+    %     >> s = Solution(src, name, trans)
     %
     % Class :mat:class:`Solution` represents solutions of multiple species. A
     % solution is defined as a mixture of two or more constituents
@@ -39,12 +39,12 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
     %
     % :param src:
     %     Input string of YAML file name.
-    % :param id:
-    %     ID of the phase to import as specified in the YAML file.
-    % :param trans:
-    %     String, transport modeling. Possible values are ``'default'``, ``'none'``,
-    %     ``'mixture-averaged'``, or ``'multicomponent'``. If not specified,
-    %     ``'default'`` is used.
+    % :param name:
+    %     name of the phase to import as specified in the YAML file.
+    % :param transport_model:
+    %     String specigying transport model. Possible values are ``'default'``,
+    %     ``'none'``, ``'mixture-averaged'``, or ``'multicomponent'``. If not specified,
+    %     ``'none'`` is used.
     % :return:
     %     Instance of class :mat:class:`Solution`.
 
@@ -57,25 +57,24 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
 
         %% Solution Class Constructor
 
-        function s = Solution(src, id, trans)
+        function s = Solution(src, name, transport_model)
             % Create a :mat:class:`Solution` object.
 
             ctIsLoaded;
 
-            if nargin < 2 || nargin > 3
-                error('Solution class constructor expects 2 or 3 input arguments.');
+            if nargin == 0 || ~ischar(src)
+                error("Invalid argument: Solution requires name of input file.")
             end
 
-            if nargin == 3
-                if ~(strcmp(trans, 'default') || strcmp(trans, 'none')...
-                     || strcmp(trans, 'mixture-averaged') || strcmp(trans, 'multicomponent'))
-                    error('Unknown transport modelling specified.');
-                end
-            else
-                trans = 'default';
+            if nargin < 2
+                name = '';
             end
 
-            ID = ctFunc('soln_newSolution', src, id, trans);
+            if nargin < 3
+                transport_model = 'none';
+            end
+
+            ID = ctFunc('soln_newSolution', src, name, transport_model);
             % Inherit methods and properties from ThermoPhase, Kinetics, and Transport
             s@ThermoPhase('clib', ID);
             s@Kinetics('clib', ID);

--- a/interfaces/matlab_experimental/Base/Solution.m
+++ b/interfaces/matlab_experimental/Base/Solution.m
@@ -76,7 +76,7 @@ classdef Solution < handle & ThermoPhase & Kinetics & Transport
 
             ID = ctFunc('soln_newSolution', src, name, transport_model);
             % Inherit methods and properties from ThermoPhase, Kinetics, and Transport
-            s@ThermoPhase('clib', ID);
+            s@ThermoPhase(ID);
             s@Kinetics('clib', ID);
             s@Transport('clib', ID);
             s.phaseID = ID;

--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -436,16 +436,6 @@ classdef ThermoPhase < handle
             tp.basis = 'molar';
         end
 
-        %% ThermoPhase class Destructor
-
-        function delete(tp)
-            % Delete the :mat:class:`ThermoPhase` object.
-
-            if ~isa(tp, 'Solution') && ~isa(tp, 'Interface')
-                ctFunc('thermo_del', tp.tpID);
-            end
-        end
-
         %% ThermoPhase Utility Methods
 
         function display(tp)

--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -1,14 +1,10 @@
 classdef ThermoPhase < handle
     % ThermoPhase Class ::
     %
-    %     >> t = ThermoPhase(src, id)
+    %     >> t = ThermoPhase(id)
     %
-    % :param src:
-    %     Input string of YAML file name when creating from file OR
-    %     "clib" when called by the class constructors of :mat:class:`Solution`
-    %     or :mat:class:`Interface`.
     % :param id:
-    %     ID of the phase to import as specified in the input file.
+    %     Integer ID of the solution holding the :mat:class:`ThermoPhase` object.
     % :return:
     %     Instance of class :mat:class:`ThermoPhase`.
 
@@ -428,21 +424,15 @@ classdef ThermoPhase < handle
     methods
         %% ThermoPhase Class Constructor
 
-        function tp = ThermoPhase(src, id)
+        function tp = ThermoPhase(id)
             % Create a :mat:class:`ThermoPhase` object.
             ctIsLoaded;
 
-            if strcmp(src, 'clib') & isnumeric(id)
-                tp.tpID = ctFunc('soln_thermo', id);
-                tp.basis = 'molar';
-                return
+            if ~isnumeric(id)
+                error('Invalid argument: constructor requires integer solution ID.')
             end
 
-            if nargin < 2
-                id = '';
-            end
-
-            tp.tpID = ctFunc('thermo_newFromFile', src, id);
+            tp.tpID = ctFunc('soln_thermo', id);
             tp.basis = 'molar';
         end
 

--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -3,6 +3,10 @@ classdef ThermoPhase < handle
     %
     %     >> t = ThermoPhase(id)
     %
+    % Retrieve instance of class :mat:class:`ThermoPhase` associated with a
+    % :mat:class:`Solution` object. The constructor is called whenever a new
+    % :mat:class:`Solution` is instantiated and should not be used directly.
+    %
     % :param id:
     %     Integer ID of the solution holding the :mat:class:`ThermoPhase` object.
     % :return:

--- a/interfaces/matlab_experimental/Base/Transport.m
+++ b/interfaces/matlab_experimental/Base/Transport.m
@@ -1,26 +1,13 @@
 classdef Transport < handle
     % Transport Class ::
     %
-    %     >> tr = Transport(th, model, loglevel)
+    %     >> tr = Transport(id)
     %
-    % Create a new instance of class :mat:class:`Transport`. One to three
-    % arguments may be supplied. The first must be an instance of class
-    % :mat:class:`ThermoPhase`. The second (optional) argument is the type of
-    % model desired, specified by the string ``'default'``,
-    % ``'mixture-averaged'`` or ``'multicomponent'``. ``'default'``
-    % uses the default transport specified in the phase definition.
-    % The third argument is the logging level desired.
+    % Retrieve instance of class :mat:class:`Transport` associated with a
+    % :mat:class:`Solution` object.
     %
-    % :param tp:
-    %     Instance of class :mat:class:`ThermoPhase` OR string "clib"
-    %     when called by the class constructors of :mat:class:`Solution` or
-    %     :mat:class:`Interface`.
-    % :param model:
-    %     String indicating the transport model to use. Possible values
-    %     are ``'default'``, ``'none'``, ``'mixture-averaged'``,
-    %     and ``'multicomponent'``. Optional.
-    % :param loglevel:
-    %     Level of diagnostic logging. Default if not specified is 4. Optional.
+    % :param id:
+    %     Integer ID of the solution holding the :mat:class:`Transport` object.
     % :return:
     %     Instance of class :mat:class:`Transport`.
 
@@ -53,43 +40,16 @@ classdef Transport < handle
     methods
         %% Transport Class Constructor
 
-        function tr = Transport(varargin)
-
+        function tr = Transport(id)
+            % Create a :mat:class:`Transport` object.
             ctIsLoaded;
-            tr.trID = 0;
 
-            tp = varargin{1};
-
-            if ischar(tp) & isnumeric(varargin{2})
-                if strcmp(tp, 'clib')
-                    tr.trID = ctFunc('soln_transport', varargin{2});
-                    return
-                end
+            if ~isnumeric(id)
+                error('Invalid argument: constructor requires integer solution ID.')
             end
 
-            if nargin < 2
-                model = 'default'
-            else
-                model = varargin{2};
-            end
-
-            if nargin < 3
-                loglevel = 4;
-            end
-
-            if ~isa(tp, 'ThermoPhase')
-                error(['The first argument must be an ', ...
-                       'instance of class ThermoPhase']);
-            end
-
-            tr.th = tp.tpID;
-
-            if strcmp(model, 'default')
-                tr.trID = ctFunc('trans_newDefault', tp.tpID, loglevel);
-            else
-                tr.trID = ctFunc('trans_new', model, tp.tpID, loglevel);
-            end
-
+            tr.trID = ctFunc('soln_transport', id);
+            tr.th = ctFunc('soln_thermo', id);
         end
 
         %% Transport Destructor Methods

--- a/interfaces/matlab_experimental/Base/Transport.m
+++ b/interfaces/matlab_experimental/Base/Transport.m
@@ -52,16 +52,6 @@ classdef Transport < handle
             tr.th = ctFunc('soln_thermo', id);
         end
 
-        %% Transport Destructor Methods
-
-        function delete(tr)
-            % Delete the :mat:class:`Transport` object.
-
-            if ~isa(tr, 'Solution')
-                ctFunc('trans_del', tr.trID);
-            end
-        end
-
         %% Transport Get Methods
 
         function v = get.viscosity(tr)

--- a/interfaces/matlab_experimental/Base/Transport.m
+++ b/interfaces/matlab_experimental/Base/Transport.m
@@ -4,7 +4,8 @@ classdef Transport < handle
     %     >> tr = Transport(id)
     %
     % Retrieve instance of class :mat:class:`Transport` associated with a
-    % :mat:class:`Solution` object.
+    % :mat:class:`Solution` object. The constructor is called whenever a new
+    % :mat:class:`Solution` is instantiated and should not be used directly.
     %
     % :param id:
     %     Integer ID of the solution holding the :mat:class:`Transport` object.

--- a/interfaces/matlab_experimental/OneDim/Domain1D.m
+++ b/interfaces/matlab_experimental/OneDim/Domain1D.m
@@ -92,7 +92,7 @@ classdef Domain1D < handle
 
             ctIsLoaded;
 
-            d.domainID = ctFunc('domain_new', type, phase.phaseID, id);
+            d.domainID = ctFunc('domain_new', type, phase.solnID, id);
 
         end
 

--- a/interfaces/matlab_experimental/Reactor/Reactor.m
+++ b/interfaces/matlab_experimental/Reactor/Reactor.m
@@ -117,10 +117,10 @@ classdef Reactor < handle
             if nargin == 0
                 error('Reactor contents must be specified')
             elseif nargin == 1
-                typ = 'Reactor'
-                name = '(none)'
+                typ = 'Reactor';
+                name = '(none)';
             elseif nargin == 2
-                name = '(none)'
+                name = '(none)';
             elseif nargin > 3
                 error('too many arguments');
             end
@@ -130,7 +130,7 @@ classdef Reactor < handle
             end
 
             r.type = char(typ);
-            r.id = ctFunc('reactor_new3', typ, content.phaseID, name);
+            r.id = ctFunc('reactor_new3', typ, content.solnID, name);
 
 
         end

--- a/interfaces/sourcegen/sourcegen/csharp/config.yaml
+++ b/interfaces/sourcegen/sourcegen/csharp/config.yaml
@@ -10,6 +10,7 @@ ignore_funcs:
   ct.h:
     - ct_setLogWriter
     - soln_newInterface # signature causes syntax error in sourcegen
+    - thermo_size
   ctreactor.h:
     - flowReactor_setMassFlowRate
 

--- a/samples/matlab_experimental/surf_reactor.m
+++ b/samples/matlab_experimental/surf_reactor.m
@@ -13,17 +13,17 @@ close all
 tic
 help surf_reactor
 
-%% Set the initial conditions
-
-t = 870.0;
-gas = Solution('ptcombust.yaml', 'gas');
-
-gas.TPX = {t, OneAtm, 'CH4:0.01, O2:0.21, N2:0.78'};
-
 % The surface reaction mechanism describes catalytic combustion of
 % methane on platinum, and is from Deutschmann et al., 26th
 % Symp. (Intl.) on Combustion,1996, pp. 1747-1754
-surf = Interface('ptcombust.yaml', 'Pt_surf', gas);
+surf = Interface('ptcombust.yaml', 'Pt_surf');
+gas = surf.adjacent('gas');
+
+%% Set the initial conditions
+
+t = 870.0;
+gas.TPX = {t, OneAtm, 'CH4:0.01, O2:0.21, N2:0.78'};
+
 surf.TP = {t, surf.P};
 
 nsp = gas.nSpecies;

--- a/samples/matlab_experimental/surf_reactor.m
+++ b/samples/matlab_experimental/surf_reactor.m
@@ -11,7 +11,7 @@ clear all
 close all
 
 tic
-help surfreactor
+help surf_reactor
 
 %% Set the initial conditions
 

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -227,6 +227,19 @@ extern "C" {
         }
     }
 
+    int soln_adjacentName(int n, int a, int lennm, char* nm)
+    {
+        try {
+            auto soln = SolutionCabinet::at(n);
+            if (a < 0 || a >= (int)soln->nAdjacent()) {
+                throw CanteraError("soln_adjacentName", "Invalid index {}.", a);
+            }
+            return static_cast<int>(copyString(soln->adjacent(a)->name(), nm, lennm));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     //--------------- Phase ---------------------//
 
     size_t thermo_nElements(int n)

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -90,13 +90,7 @@ extern "C" {
                 soln = newInterface(infile, name, adj);
             } else {
                 soln = newInterface(infile, name);
-                for (size_t i = 0; i < soln->nAdjacent(); i++) {
-                    // add automatically loaded adjacent solutions
-                    auto adj = soln->adjacent(i);
-                    if (SolutionCabinet::index(*adj) < 0) {
-                        SolutionCabinet::add(adj);
-                    }
-                }
+                // adjacent phases can be retrieved via soln_adjacent
             }
             // add associated objects
             ThermoCabinet::add(soln->thermo());
@@ -218,7 +212,16 @@ extern "C" {
             if (a < 0 || a >= (int)soln->nAdjacent()) {
                 return -1;
             }
-            return SolutionCabinet::index(*(soln->adjacent(a)));
+            auto adj = soln->adjacent(a);
+            // add associated objects
+            ThermoCabinet::add(adj->thermo());
+            if (adj->kinetics()) {
+                KineticsCabinet::add(adj->kinetics());
+            }
+            if (adj->transport()) {
+                TransportCabinet::add(adj->transport());
+            }
+            return SolutionCabinet::add(adj);
         } catch (...) {
             return handleAllExceptions(-2, ERR);
         }

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -61,15 +61,16 @@ extern "C" {
     {
         try {
             auto soln = newSolution(infile, name, transport);
+            int id = SolutionCabinet::add(soln);
             // add associated objects
-            ThermoCabinet::add(soln->thermo());
+            ThermoCabinet::add(soln->thermo(), id);
             if (soln->kinetics()) {
-                KineticsCabinet::add(soln->kinetics());
+                KineticsCabinet::add(soln->kinetics(), id);
             }
             if (soln->transport()) {
-                TransportCabinet::add(soln->transport());
+                TransportCabinet::add(soln->transport(), id);
             }
-            return SolutionCabinet::add(soln);
+            return id;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -93,14 +94,15 @@ extern "C" {
                 // adjacent phases can be retrieved via soln_adjacent
             }
             // add associated objects
-            ThermoCabinet::add(soln->thermo());
+            int id = SolutionCabinet::add(soln);
+            ThermoCabinet::add(soln->thermo(), id);
             if (soln->kinetics()) {
-                KineticsCabinet::add(soln->kinetics());
+                KineticsCabinet::add(soln->kinetics(), id);
             }
             if (soln->transport()) {
-                TransportCabinet::add(soln->transport());
+                TransportCabinet::add(soln->transport(), id);
             }
-            return SolutionCabinet::add(soln);
+            return id;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -112,18 +114,18 @@ extern "C" {
             if (n >= 0 && n < SolutionCabinet::size()) {
                 // remove all associated objects
                 auto soln = SolutionCabinet::at(n);
-                int index = ThermoCabinet::index(*(soln->thermo()));
+                int index = ThermoCabinet::index(*(soln->thermo()), n);
                 if (index >= 0) {
                     ThermoCabinet::del(index);
                 }
                 if (soln->kinetics()) {
-                    index = KineticsCabinet::index(*(soln->kinetics()));
+                    index = KineticsCabinet::index(*(soln->kinetics()), n);
                     if (index >= 0) {
                         KineticsCabinet::del(index);
                     }
                 }
                 if (soln->transport()) {
-                    index = TransportCabinet::index(*(soln->transport()));
+                    index = TransportCabinet::index(*(soln->transport()), n);
                     if (index >= 0) {
                         TransportCabinet::del(index);
                     }
@@ -151,7 +153,7 @@ extern "C" {
     {
         try {
             auto soln = SolutionCabinet::at(n);
-            return ThermoCabinet::index(*soln->thermo());
+            return ThermoCabinet::index(*soln->thermo(), n);
         } catch (...) {
             return handleAllExceptions(-2, ERR);
         }
@@ -164,7 +166,7 @@ extern "C" {
             if (!soln->kinetics()) {
                 return -1;
             }
-            return KineticsCabinet::index(*(soln->kinetics()));
+            return KineticsCabinet::index(*(soln->kinetics()), n);
         } catch (...) {
             return handleAllExceptions(-2, ERR);
         }
@@ -177,7 +179,7 @@ extern "C" {
             if (!soln->transport()) {
                 return -1;
             }
-            return TransportCabinet::index(*(soln->transport()));
+            return TransportCabinet::index(*(soln->transport()), n);
         } catch (...) {
             return handleAllExceptions(-2, ERR);
         }
@@ -188,9 +190,9 @@ extern "C" {
         try {
             auto soln = SolutionCabinet::at(n);
             TransportCabinet::del(
-                TransportCabinet::index(*(soln->transport())));
+                TransportCabinet::index(*(soln->transport()), n));
             soln->setTransportModel(model);
-            return TransportCabinet::add(soln->transport());
+            return TransportCabinet::add(soln->transport(), n);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -209,19 +211,20 @@ extern "C" {
     {
         try {
             auto soln = SolutionCabinet::at(n);
-            if (a < 0 || a >= (int)soln->nAdjacent()) {
+            if (a < 0 || a >= static_cast<int>(soln->nAdjacent())) {
                 return -1;
             }
             auto adj = soln->adjacent(a);
             // add associated objects
-            ThermoCabinet::add(adj->thermo());
+            int id = SolutionCabinet::add(adj);
+            ThermoCabinet::add(adj->thermo(), id);
             if (adj->kinetics()) {
-                KineticsCabinet::add(adj->kinetics());
+                KineticsCabinet::add(adj->kinetics(), id);
             }
             if (adj->transport()) {
-                TransportCabinet::add(adj->transport());
+                TransportCabinet::add(adj->transport(), id);
             }
-            return SolutionCabinet::add(adj);
+            return id;
         } catch (...) {
             return handleAllExceptions(-2, ERR);
         }
@@ -231,7 +234,7 @@ extern "C" {
     {
         try {
             auto soln = SolutionCabinet::at(n);
-            if (a < 0 || a >= (int)soln->nAdjacent()) {
+            if (a < 0 || a >= static_cast<int>(soln->nAdjacent())) {
                 throw CanteraError("soln_adjacentName", "Invalid index {}.", a);
             }
             return static_cast<int>(copyString(soln->adjacent(a)->name(), nm, lennm));
@@ -1723,6 +1726,42 @@ extern "C" {
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int thermo_parent(int n)
+    {
+        try {
+            return ThermoCabinet::parent(n);
+        } catch (...) {
+            return handleAllExceptions(-2, ERR);
+        }
+    }
+
+    int thermo_size()
+    {
+        try {
+            return ThermoCabinet::size();
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int kin_parent(int n)
+    {
+        try {
+            return KineticsCabinet::parent(n);
+        } catch (...) {
+            return handleAllExceptions(-2, ERR);
+        }
+    }
+
+    int trans_parent(int n)
+    {
+        try {
+            return TransportCabinet::parent(n);
+        } catch (...) {
+            return handleAllExceptions(-2, ERR);
         }
     }
 

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -136,11 +136,11 @@ TEST(ct, new_interface_auto)
 
     vector<int> adj;
     int surf = soln_newInterface("ptcombust.yaml", "Pt_surf", 0, adj.data());
-    ASSERT_EQ(surf, 1);
+    ASSERT_EQ(surf, 0);
 
     ASSERT_EQ(soln_nAdjacent(surf), 1u);
     int gas = soln_adjacent(surf, 0);
-    ASSERT_EQ(gas, 0);
+    ASSERT_EQ(gas, 1);
 
     int buflen = soln_name(gas, 0, 0) + 1; // include \0
     char* buf = new char[buflen];
@@ -148,6 +148,13 @@ TEST(ct, new_interface_auto)
     string solName = buf;
     ASSERT_EQ(solName, "gas");
     delete[] buf;
+
+    buflen = soln_adjacentName(surf, 0, 0, 0) + 1;
+    char* buf2 = new char[buflen];
+    soln_adjacentName(surf, 0, buflen, buf2);
+    solName = buf2;
+    ASSERT_EQ(solName, "gas");
+    delete[] buf2;
 }
 
 TEST(ct, thermo)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Remove `clib`'s `*_newFromFile` constructors from MATLAB; use pathways using `Solution` exclusively instead
- Fix memory leak in `clib` where automatically added *adjacent* phases could not be removed
- Make MATLAB `Interface.adjacent` consistent with Python version (select phase by name rather than index)
- Fix ambiguous references that will lead to memory leaks (going back to #1448)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Resolves #1756
Partially addresses Cantera/enhancements#199

**Example**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

New in *experimental* MATLAB:
```
surf = Interface('ptcombust.yaml', 'Pt_surf');
gas = surf.adjacent('gas');
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
