### PR TITLE
Fix version check for system SUNDIALS on Windows / alpha version bump

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -94,7 +94,7 @@ possible.
 Development Site
 ================
 
-The current development version is 3.1.0a2. The current stable version is
+The current development version is 3.1.0a3. The current stable version is
 3.0.0. The `latest Cantera source code <https://github.com/Cantera/cantera>`_,
 the `issue tracker <https://github.com/Cantera/cantera/issues>`_ for bugs and
 enhancement requests, `downloads of Cantera releases and binary installers

--- a/SConstruct
+++ b/SConstruct
@@ -1481,7 +1481,7 @@ if env['system_sundials'] == 'y':
     retcode, sundials_version = conf.TryRun(sundials_version_source, '.cpp')
     if retcode == 0:
         config_error("Failed to determine Sundials version.")
-    env["sundials_version"] = sundials_version.strip(' "\n')
+    env["sundials_version"] = sundials_version.strip(' "\r\n')
 
     sundials_ver = parse_version(env['sundials_version'])
     if sundials_ver < parse_version("3.0") or sundials_ver >= parse_version("8.0"):

--- a/SConstruct
+++ b/SConstruct
@@ -157,7 +157,7 @@ logger.info(
     f"SCons {SCons.__version__} is using the following Python interpreter:\n"
     f"    {sys.executable} (Python {python_version})", print_level=False)
 
-cantera_version = "3.1.0a2"
+cantera_version = "3.1.0a3"
 # For use where pre-release tags are not permitted (MSI, sonames)
 cantera_pure_version = re.match(r'(\d+\.\d+\.\d+)', cantera_version).group(0)
 cantera_short_version = re.match(r'(\d+\.\d+)', cantera_version).group(0)

--- a/doc/doxygen/Doxyfile
+++ b/doc/doxygen/Doxyfile
@@ -48,7 +48,7 @@ PROJECT_NAME           = Cantera
 # could be handy for archiving the generated documentation or if some version
 # control system is used.
 
-PROJECT_NUMBER         = 3.1.0a2
+PROJECT_NUMBER         = 3.1.0a3
 
 # Using the PROJECT_BRIEF tag one can provide an optional one line description
 # for a project that appears at the top of each page and should give viewer a

--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -2055,7 +2055,7 @@ class Parser:
             metadata = BlockMap([
                 ("generator", "ck2yaml"),
                 ("input-files", FlowList(self.files)),
-                ("cantera-version", "3.1.0a2"),
+                ("cantera-version", "3.1.0a3"),
                 ("date", formatdate(localtime=True)),
             ])
             if desc.strip():

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -1661,7 +1661,7 @@ def convert(filename=None, output_name=None, text=None, encoding="latin-1"):
         # information regarding conversion
         metadata = BlockMap([
             ("generator", "cti2yaml"),
-            ("cantera-version", "3.1.0a2"),
+            ("cantera-version", "3.1.0a3"),
             ("date", formatdate(localtime=True)),
         ])
         if filename != "<string>":

--- a/interfaces/cython/cantera/ctml2yaml.py
+++ b/interfaces/cython/cantera/ctml2yaml.py
@@ -2637,7 +2637,7 @@ def convert(
     metadata = BlockMap(
         {
             "generator": "ctml2yaml",
-            "cantera-version": "3.1.0a2",
+            "cantera-version": "3.1.0a3",
             "date": formatdate(localtime=True),
         }
     )

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -751,7 +751,7 @@ void Sim1D::setLeftControlPoint(double temperature)
             if ((current_val - temperature) * (next_val - temperature) < 0.0) {
                 // Pick the coordinate of the point with the temperature closest
                 // to the desired temperature
-                int index = 0;
+                size_t index = 0;
                 if (std::abs(current_val - temperature) <
                     std::abs(next_val - temperature)) {
                     index = m;
@@ -802,7 +802,7 @@ void Sim1D::setRightControlPoint(double temperature)
             if ((current_val - temperature) * (next_val - temperature) < 0.0) {
                 // Pick the coordinate of the point with the temperature closest
                 // to the desired temperature
-                int index = 0;
+                size_t index = 0;
                 if (std::abs(current_val - temperature) <
                     std::abs(next_val - temperature)) {
                     index = m;


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- SCons's, `conf.TryRun` apparently doesn't use Python's universal newlines, so we need to explicitly include `\r` in the set of characters to strip. (Fixes regression introduced in #1746).
- Fix a couple of warnings about `size_t`/`int` conversions
- Bump version to `3.1.0a3`


**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
