### PR TITLE
Make Func1 API's more consistent

### DIFF
--- a/include/cantera/clib/ctfunc.h
+++ b/include/cantera/clib/ctfunc.h
@@ -19,6 +19,10 @@ extern "C" {
     CANTERA_CAPI int func_new_advanced(const char* type, size_t lenp, const double* p);
     CANTERA_CAPI int func_new_compound(const char* type, int a, int b);
     CANTERA_CAPI int func_new_modified(const char* type, int a, double c);
+    CANTERA_CAPI int func_new_sum(int a, int b);
+    CANTERA_CAPI int func_new_diff(int a, int b);
+    CANTERA_CAPI int func_new_prod(int a, int b);
+    CANTERA_CAPI int func_new_ratio(int a, int b);
     CANTERA_CAPI int func_del(int i);
     CANTERA_CAPI int func_type(int i, size_t lennm, char* nm);
     CANTERA_CAPI double func_value(int i, double t);

--- a/include/cantera/clib/ctonedim.h
+++ b/include/cantera/clib/ctonedim.h
@@ -67,7 +67,7 @@ extern "C" {
             size_t m, const double* temp);
     CANTERA_CAPI int flow1D_solveEnergyEqn(int i, int flag);
 
-    //! @todo: Remove all functions with `stflow` prefix after Cantera 3.1
+    //! @todo: Remove all functions with `stflow` prefix after %Cantera 3.1
     CANTERA_CAPI int stflow_new(int iph, int ikin, int itr, int itype);
     CANTERA_CAPI int stflow_setTransport(int i, int itr);
     CANTERA_CAPI int stflow_enableSoret(int i, int iSoret);

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -104,7 +104,7 @@ public:
     //! Creates a derivative to the current function
     /*!
      * @return  shared pointer to new derivative function.
-     * @since Starting in Cantera 3.1, the return type is a `shared_ptr`.
+     * @since Starting in %Cantera 3.1, the return type is a `shared_ptr`.
      */
     virtual shared_ptr<Func1> derivative() const;
 

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -82,7 +82,7 @@ public:
 
     virtual ~Func1() = default;
 
-    Func1(const Func1& right) = delete;
+    // Func1(const Func1& right) = delete;  //! @todo Uncomment after %Cantera 3.1
     Func1& operator=(const Func1& right) = delete;
 
     //! Returns a string describing the type of the function
@@ -110,11 +110,20 @@ public:
 
     //! Routine to determine if two functions are the same.
     /*!
-     * Two functions are the same if they are the same function. This means
-     * that the ID and stored constant is the same. This means that the #m_f1
-     * and #m_f2 are identical if they are non-null. Functors of the base class
-     * Func1 are by default not identical, as they are used by callback functions
-     * that cannot be differentiated.
+     * Two functions are the same if they are the same function. For example, either
+     * ID and stored constant are the same, or the #m_f1 and #m_f2 are identical if they
+     * are non-null. Functors of the base class Func1 are by default not identical, as
+     * they are used by callback functions that cannot be differentiated. In instances
+     * where exact comparisons are not implemented, `false` is returned to prevent false
+     * positives that could lead to incorrect simplifications of compound functors.
+     */
+    virtual bool isIdentical(shared_ptr<Func1> other) const;
+
+    //! Routine to determine if two functions are the same.
+    /*!
+     * @deprecated Deprecated in %Cantera 3.1 and removed thereafter; replaced by
+     *      isIdentical(shared_ptr<Func1>&).
+     * @todo Restore deleted copy constructor after removal.
      */
     virtual bool isIdentical(Func1& other) const;
 
@@ -367,7 +376,7 @@ public:
     //! @since New in %Cantera 3.0
     void setMethod(const string& method);
 
-    bool isIdentical(Func1& other) const override {
+    bool isIdentical(shared_ptr<Func1> other) const override {
         return false;  // base class check is insufficient
     }
 
@@ -682,7 +691,7 @@ public:
         return "Gaussian";
     }
 
-    bool isIdentical(Func1& other) const override {
+    bool isIdentical(shared_ptr<Func1> other) const override {
         return false;  // base class check is insufficient
     }
 
@@ -728,7 +737,7 @@ public:
         return "polynomial3";
     }
 
-    bool isIdentical(Func1& other) const override {
+    bool isIdentical(shared_ptr<Func1> other) const override {
         return false;  // base class check is insufficient
     }
 
@@ -776,7 +785,7 @@ public:
         return "Fourier";
     }
 
-    bool isIdentical(Func1& other) const override {
+    bool isIdentical(shared_ptr<Func1> other) const override {
         return false;  // base class check is insufficient
     }
 
@@ -828,7 +837,7 @@ public:
         return "Arrhenius";
     }
 
-    bool isIdentical(Func1& other) const override {
+    bool isIdentical(shared_ptr<Func1> other) const override {
         return false;  // base class check is insufficient
     }
 

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -116,7 +116,15 @@ public:
      */
     bool isIdentical(Func1& other) const;
 
+    /**
+     * @deprecated Deprecated in %Cantera 3.1 and removed thereafter; replaced by
+     *      internal function.
+     */
     virtual double isProportional(TimesConstant1& other);
+    /**
+     * @deprecated Deprecated in %Cantera 3.1 and removed thereafter; replaced by
+     *      internal function.
+     */
     virtual double isProportional(Func1& other);
 
     //! Write LaTeX string describing function.

--- a/include/cantera/numerics/Func1.h
+++ b/include/cantera/numerics/Func1.h
@@ -111,10 +111,12 @@ public:
     //! Routine to determine if two functions are the same.
     /*!
      * Two functions are the same if they are the same function. This means
-     * that the ID and stored constant is the same. This means that the m_f1
-     * and m_f2 are identical if they are non-null.
+     * that the ID and stored constant is the same. This means that the #m_f1
+     * and #m_f2 are identical if they are non-null. Functors of the base class
+     * Func1 are by default not identical, as they are used by callback functions
+     * that cannot be differentiated.
      */
-    bool isIdentical(Func1& other) const;
+    virtual bool isIdentical(Func1& other) const;
 
     /**
      * @deprecated Deprecated in %Cantera 3.1 and removed thereafter; replaced by
@@ -130,16 +132,16 @@ public:
     //! Write LaTeX string describing function.
     virtual string write(const string& arg) const;
 
-    //! Accessor function for the stored constant
+    //! Accessor function for the stored constant #m_c.
     double c() const;
 
-    //! Accessor function for m_f1
+    //! Accessor function for #m_f1.
     //! @since New in %Cantera 3.0.
     shared_ptr<Func1> func1_shared() const {
         return m_f1;
     }
 
-    //! Accessor function for m_f2
+    //! Accessor function for #m_f2.
     //! @since New in %Cantera 3.0.
     shared_ptr<Func1> func2_shared() const {
         return m_f2;
@@ -364,6 +366,10 @@ public:
     //!     last tabulated value is held until a new tabulated time value is reached.
     //! @since New in %Cantera 3.0
     void setMethod(const string& method);
+
+    bool isIdentical(Func1& other) const override {
+        return false;  // base class check is insufficient
+    }
 
     string write(const string& arg) const override;
 
@@ -676,6 +682,10 @@ public:
         return "Gaussian";
     }
 
+    bool isIdentical(Func1& other) const override {
+        return false;  // base class check is insufficient
+    }
+
     double eval(double t) const override {
         double x = (t - m_t0)/m_tau;
         return m_A * std::exp(-x*x);
@@ -716,6 +726,10 @@ public:
 
     string type() const override {
         return "polynomial3";
+    }
+
+    bool isIdentical(Func1& other) const override {
+        return false;  // base class check is insufficient
     }
 
     double eval(double t) const override {
@@ -760,6 +774,10 @@ public:
 
     string type() const override {
         return "Fourier";
+    }
+
+    bool isIdentical(Func1& other) const override {
+        return false;  // base class check is insufficient
     }
 
     double eval(double t) const override {
@@ -808,6 +826,10 @@ public:
 
     string type() const override {
         return "Arrhenius";
+    }
+
+    bool isIdentical(Func1& other) const override {
+        return false;  // base class check is insufficient
     }
 
     double eval(double t) const override {

--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -589,7 +589,7 @@ protected:
     //! Alternate version of evalContinuity with legacy signature.
     //! Implemented by StFlow; included here to prevent compiler warnings about shadowed
     //! virtual functions.
-    //! @deprecated To be removed after Cantera 3.1.
+    //! @deprecated To be removed after %Cantera 3.1.
     virtual void evalContinuity(size_t j, double* x, double* r, int* diag, double rdt);
 
     /**

--- a/include/cantera/oneD/StFlow.h
+++ b/include/cantera/oneD/StFlow.h
@@ -15,7 +15,7 @@ namespace Cantera
  *  This class represents 1D flow domains that satisfy the one-dimensional
  *  similarity solution for chemically-reacting, axisymmetric flows.
  *
- *  @deprecated To be removed after Cantera 3.1; replaced by Flow1D.
+ *  @deprecated To be removed after %Cantera 3.1; replaced by Flow1D.
  *  @ingroup flowGroup
  */
 class StFlow : public Flow1D

--- a/include/cantera/zeroD/FlowDeviceFactory.h
+++ b/include/cantera/zeroD/FlowDeviceFactory.h
@@ -44,7 +44,7 @@ private:
 //! @{
 
 //! Create a FlowDevice object of the specified type
-//! @since Starting in Cantera 3.1, this method returns a `shared_ptr<FlowDevice>`
+//! @since Starting in %Cantera 3.1, this method returns a `shared_ptr<FlowDevice>`
 shared_ptr<FlowDevice> newFlowDevice(const string& model);
 
 //! Create a FlowDevice object of the specified type

--- a/include/cantera/zeroD/WallFactory.h
+++ b/include/cantera/zeroD/WallFactory.h
@@ -44,7 +44,7 @@ private:
 //! @{
 
 //! Create a WallBase object of the specified type
-//! @since Starting in Cantera 3.1, this method returns a `shared_ptr<WallBase>`
+//! @since Starting in %Cantera 3.1, this method returns a `shared_ptr<WallBase>`
 shared_ptr<WallBase> newWall(const string& model);
 
 //! Create a WallBase object of the specified type

--- a/interfaces/cython/cantera/func1.pxd
+++ b/interfaces/cython/cantera/func1.pxd
@@ -42,6 +42,14 @@ cdef extern from "cantera/numerics/Func1Factory.h":
     cdef shared_ptr[CxxFunc1] CxxNewFunc1 "Cantera::newFunc1" (
         string, shared_ptr[CxxFunc1], double) except +translate_exception
     cdef string CxxCheckFunc1 "Cantera::checkFunc1" (string) except +translate_exception
+    cdef shared_ptr[CxxFunc1] CxxNewSumFunction "Cantera::newSumFunction" (
+        shared_ptr[CxxFunc1], shared_ptr[CxxFunc1]) except +translate_exception
+    cdef shared_ptr[CxxFunc1] CxxNewDiffFunction "Cantera::newDiffFunction" (
+        shared_ptr[CxxFunc1], shared_ptr[CxxFunc1]) except +translate_exception
+    cdef shared_ptr[CxxFunc1] CxxNewProdFunction "Cantera::newProdFunction" (
+        shared_ptr[CxxFunc1], shared_ptr[CxxFunc1]) except +translate_exception
+    cdef shared_ptr[CxxFunc1] CxxNewRatioFunction "Cantera::newRatioFunction" (
+        shared_ptr[CxxFunc1], shared_ptr[CxxFunc1]) except +translate_exception
 
 
 cdef class Func1:
@@ -50,3 +58,7 @@ cdef class Func1:
     cdef object callable
     cdef object exception
     cpdef void _set_callback(self, object) except *
+    @staticmethod
+    cdef shared_ptr[CxxFunc1] _make_cxx_func1(string, tuple)
+    @staticmethod
+    cdef Func1 _make_func1(shared_ptr[CxxFunc1])

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -295,7 +295,9 @@ cdef class Func1:
 
         .. versionadded:: 3.1
         """
-        return pystr(self.func.typeName())
+        # ensure that Windows and macOS/Linux return same string
+        # (names demangled on some Windows systems start with 'class ')
+        return pystr(self.func.typeName()).split()[-1]
 
     def write(self, name="x"):
         """

--- a/interfaces/matlab_experimental/Func/Func1.m
+++ b/interfaces/matlab_experimental/Func/Func1.m
@@ -67,6 +67,12 @@ classdef Func1 < handle
 
             ctIsLoaded;
 
+            if isnumeric(typ)
+                % instantiate from handle
+                x.id = typ;
+                return
+            end
+
             if ~isa(typ, 'char')
                 error('Function type must be a string');
             end
@@ -134,19 +140,43 @@ classdef Func1 < handle
         %% Func1 Class Utility Methods
 
         function r = plus(f1,f2)
-            r = Func1('sum', f1, f2);
+            if isa(f1, 'double') && length(f1) == 1
+                f1 = Func1('constant', f1);
+            elseif isa(f2, 'double') && length(f2) == 1
+                f2 = Func1('constant', f2);
+            end
+            id = ctFunc('func_new_sum', f1.id, f2.id);
+            r = Func1(id);
         end
 
         function r = minus(f1,f2)
-            r = Func1('diff', f1, f2);
+            if isa(f1, 'double') && length(f1) == 1
+                f1 = Func1('constant', f1);
+            elseif isa(f2, 'double') && length(f2) == 1
+                f2 = Func1('constant', f2);
+            end
+            id = ctFunc('func_new_diff', f1.id, f2.id);
+            r = Func1(id);
         end
 
         function r = mtimes(f1,f2)
-            r = Func1('product', f1, f2);
+            if isa(f1, 'double') && length(f1) == 1
+                f1 = Func1('constant', f1);
+            elseif isa(f2, 'double') && length(f2) == 1
+                f2 = Func1('constant', f2);
+            end
+            id = ctFunc('func_new_prod', f1.id, f2.id);
+            r = Func1(id);
         end
 
         function r = mrdivide(f1,f2)
-            r = Func1('ratio', f1, f2);
+            if isa(f1, 'double') && length(f1) == 1
+                f1 = Func1('constant', f1);
+            elseif isa(f2, 'double') && length(f2) == 1
+                f2 = Func1('constant', f2);
+            end
+            id = ctFunc('func_new_ratio', f1.id, f2.id);
+            r = Func1(id);
         end
 
         function s = type(f)

--- a/samples/python/reactors/reactor2.py
+++ b/samples/python/reactors/reactor2.py
@@ -96,7 +96,7 @@ df = pd.DataFrame.from_dict({
     'P2 (bar)': states2.P / 1e5,
     'V2 (m3)': states2.V,
 })
-df.to_csv("pistion.csv")
+df.to_csv("piston.csv")
 df
 
 # %%

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -70,6 +70,46 @@ extern "C" {
         }
     }
 
+    int func_new_sum(int a, int b)
+    {
+        try {
+            return FuncCabinet::add(
+                newSumFunction(FuncCabinet::at(a), FuncCabinet::at(b)));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int func_new_diff(int a, int b)
+    {
+        try {
+            return FuncCabinet::add(
+                newDiffFunction(FuncCabinet::at(a), FuncCabinet::at(b)));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int func_new_prod(int a, int b)
+    {
+        try {
+            return FuncCabinet::add(
+                newProdFunction(FuncCabinet::at(a), FuncCabinet::at(b)));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int func_new_ratio(int a, int b)
+    {
+        try {
+            return FuncCabinet::add(
+                newRatioFunction(FuncCabinet::at(a), FuncCabinet::at(b)));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int func_del(int i)
     {
         try {

--- a/src/numerics/Func1.cpp
+++ b/src/numerics/Func1.cpp
@@ -38,7 +38,7 @@ shared_ptr<Func1> Func1::derivative() const
 
 bool Func1::isIdentical(Func1& other) const
 {
-    if (type() != other.type() || m_c != other.m_c) {
+    if (type() == "functor" || type() != other.type() || m_c != other.m_c) {
         return false;
     }
     if (m_f1) {

--- a/test/clib/test_ctfunc.cpp
+++ b/test/clib/test_ctfunc.cpp
@@ -187,6 +187,8 @@ TEST(ctmath, sum)
     int fcn = func_new_compound("sum", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) + cos(omega * 0.5));
+    int fcn2 = func_new_sum(fcn0, fcn1);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), func_value(fcn2, 0.5));
 }
 
 TEST(ctmath, diff)
@@ -197,6 +199,8 @@ TEST(ctmath, diff)
     int fcn = func_new_compound("diff", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) - cos(omega * 0.5));
+    int fcn2 = func_new_diff(fcn0, fcn1);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), func_value(fcn2, 0.5));
 }
 
 TEST(ctmath, prod)
@@ -207,6 +211,8 @@ TEST(ctmath, prod)
     int fcn = func_new_compound("product", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) * cos(omega * 0.5));
+    int fcn2 = func_new_prod(fcn0, fcn1);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), func_value(fcn2, 0.5));
 }
 
 TEST(ctmath, ratio)
@@ -217,6 +223,8 @@ TEST(ctmath, ratio)
     int fcn = func_new_compound("ratio", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), sin(omega * 0.5) / cos(omega * 0.5));
+    int fcn2 = func_new_ratio(fcn0, fcn1);
+    EXPECT_DOUBLE_EQ(func_value(fcn, 0.5), func_value(fcn2, 0.5));
 }
 
 TEST(ctmath, composite)

--- a/test/general/test_numerics.cpp
+++ b/test/general/test_numerics.cpp
@@ -133,7 +133,7 @@ TEST(ctfunc, functor)
     auto functor = newFunc1("functor");
     ASSERT_EQ(functor->type(), "functor");
     ASSERT_THROW(functor->derivative(), CanteraError);
-    ASSERT_FALSE(functor->isIdentical(*functor));  // comparison is disabled
+    ASSERT_FALSE(functor->isIdentical(functor));  // comparison is disabled
 }
 
 TEST(ctfunc, invalid)
@@ -159,7 +159,7 @@ TEST(ctfunc, sin)
     EXPECT_DOUBLE_EQ(dfunctor->eval(.5), omega * cos(omega * .5));
 
     ASSERT_THROW(newFunc1("sin", vector<double>()), CanteraError);
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 }
 
 TEST(ctfunc, cos)
@@ -175,7 +175,7 @@ TEST(ctfunc, cos)
     EXPECT_DOUBLE_EQ(dfunctor->eval(.5), -omega * sin(omega * .5));
 
     ASSERT_THROW(newFunc1("cos", {1., 2.}), CanteraError);
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 }
 
 TEST(ctfunc, exp)
@@ -191,7 +191,7 @@ TEST(ctfunc, exp)
     EXPECT_DOUBLE_EQ(dfunctor->eval(.5), omega * exp(omega * .5));
 
     ASSERT_THROW(newFunc1("exp", {1., 2.}), CanteraError);
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 }
 
 TEST(ctfunc, log)
@@ -208,7 +208,7 @@ TEST(ctfunc, log)
     EXPECT_DOUBLE_EQ(dfunctor->eval(.5), omega / .5);
 
     ASSERT_THROW(newFunc1("log", vector<double>()), CanteraError);
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 }
 
 TEST(ctfunc, pow)
@@ -222,7 +222,7 @@ TEST(ctfunc, pow)
     EXPECT_DOUBLE_EQ(dfunctor->eval(.5), exp * pow(.5, exp - 1));
 
     ASSERT_THROW(newFunc1("pow", vector<double>()), CanteraError);
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 }
 
 TEST(ctfunc, constant)
@@ -238,7 +238,7 @@ TEST(ctfunc, constant)
     EXPECT_DOUBLE_EQ(dfunctor->eval(.5), 0.);
 
     ASSERT_THROW(newFunc1("constant", {1., 2., 3.}), CanteraError);
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 }
 
 TEST(ctfunc, tabulated_linear)
@@ -259,7 +259,7 @@ TEST(ctfunc, tabulated_linear)
 
     params.push_back(1.);
     ASSERT_THROW(newFunc1("tabulated-linear", params), CanteraError);
-    ASSERT_FALSE(functor->isIdentical(*functor));  // comparison is disabled
+    ASSERT_FALSE(functor->isIdentical(functor));  // comparison is disabled
 }
 
 TEST(ctfunc, tabulated_previous)
@@ -279,7 +279,7 @@ TEST(ctfunc, tabulated_previous)
     auto dfunctor = functor->derivative();
     EXPECT_DOUBLE_EQ(dfunctor->eval(.5), 0.);
     EXPECT_DOUBLE_EQ(dfunctor->eval(1.5), 0.);
-    ASSERT_FALSE(functor->isIdentical(*functor));  // comparison is disabled
+    ASSERT_FALSE(functor->isIdentical(functor));  // comparison is disabled
 }
 
 TEST(ctfunc, poly)
@@ -298,7 +298,7 @@ TEST(ctfunc, poly)
     params = {1, 0, -1, 0, 0, 0, 0, 0, 0, 0, 0};
     auto functor1 = newFunc1("polynomial3", params);
     EXPECT_EQ(functor1->write("x"), "x^{10} - x^8");
-    ASSERT_FALSE(functor0->isIdentical(*functor0));  // comparison is disabled
+    ASSERT_FALSE(functor0->isIdentical(functor0));  // comparison is disabled
 }
 
 TEST(ctfunc, Fourier)
@@ -319,7 +319,7 @@ TEST(ctfunc, Fourier)
     params.push_back(1.);
     ASSERT_THROW(newFunc1("Fourier", params), CanteraError);
     ASSERT_THROW(newFunc1("Fourier", vector<double>({1., 2.})), CanteraError);
-    ASSERT_FALSE(functor->isIdentical(*functor));  // comparison is disabled
+    ASSERT_FALSE(functor->isIdentical(functor));  // comparison is disabled
 }
 
 TEST(ctfunc, Gaussian)
@@ -339,7 +339,7 @@ TEST(ctfunc, Gaussian)
     ASSERT_THROW(functor->derivative(), CanteraError);
 
     ASSERT_THROW(newFunc1("Gaussian", vector<double>({1., 2.})), CanteraError);
-    ASSERT_FALSE(functor->isIdentical(*functor));  // comparison is disabled
+    ASSERT_FALSE(functor->isIdentical(functor));  // comparison is disabled
 }
 
 TEST(ctfunc, Arrhenius)
@@ -355,7 +355,7 @@ TEST(ctfunc, Arrhenius)
     ASSERT_THROW(functor->derivative(), CanteraError);
 
     ASSERT_THROW(newFunc1("Arrhenius", vector<double>({1., 2.})), CanteraError);
-    ASSERT_FALSE(functor->isIdentical(*functor));  // comparison is disabled
+    ASSERT_FALSE(functor->isIdentical(functor));  // comparison is disabled
 }
 
 TEST(ctmath, invalid)
@@ -377,7 +377,7 @@ TEST(ctmath, sum)
     EXPECT_EQ(functor->type(), "sum");
     EXPECT_DOUBLE_EQ(functor->eval(0.), 1.);
     EXPECT_DOUBLE_EQ(functor->eval(x), sin(omega * x) + cos(omega * x));
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 
     auto dfunctor = functor->derivative();
     EXPECT_DOUBLE_EQ(dfunctor->eval(x), omega * (cos(omega * x) - sin(omega * x)));
@@ -430,7 +430,7 @@ TEST(ctmath, diff)
     EXPECT_EQ(functor->type(), "diff");
     EXPECT_DOUBLE_EQ(functor->eval(0.), -1.);
     EXPECT_DOUBLE_EQ(functor->eval(x), sin(omega * x) - cos(omega * x));
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 
     auto dfunctor = functor->derivative();
     EXPECT_DOUBLE_EQ(dfunctor->eval(.5), omega * (cos(omega * .5) + sin(omega * .5)));
@@ -480,7 +480,7 @@ TEST(ctmath, prod)
     EXPECT_EQ(functor->type(), "product");
     EXPECT_DOUBLE_EQ(functor->eval(0.), 0);
     EXPECT_DOUBLE_EQ(functor->eval(x), sin(omega * x) * cos(omega * x));
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 
     auto dfunctor = functor->derivative();
     EXPECT_DOUBLE_EQ(dfunctor->eval(x),
@@ -534,7 +534,7 @@ TEST(ctmath, ratio)
     EXPECT_EQ(functor->type(), "ratio");
     EXPECT_DOUBLE_EQ(functor->eval(0.), 0.);
     EXPECT_DOUBLE_EQ(functor->eval(x), sin(omega * x) / cos(omega * x));
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 
     auto dfunctor = functor->derivative();
     EXPECT_DOUBLE_EQ(dfunctor->eval(x), omega / pow(cos(omega * x), 2));
@@ -575,7 +575,7 @@ TEST(ctmath, composite)
     EXPECT_EQ(functor->type(), "composite");
     EXPECT_DOUBLE_EQ(functor->eval(0.), sin(omega));
     EXPECT_DOUBLE_EQ(functor->eval(x), sin(omega * cos(omega * x)));
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 
     auto dfunctor = functor->derivative();
     EXPECT_DOUBLE_EQ(dfunctor->eval(x),
@@ -593,7 +593,7 @@ TEST(ctmath, times_constant)
     EXPECT_EQ(functor->type(), "times-constant");
     EXPECT_DOUBLE_EQ(functor->eval(0.), 0.);
     EXPECT_DOUBLE_EQ(functor->eval(x), sin(omega * x) * A);
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 
     auto dfunctor = functor->derivative();
     EXPECT_DOUBLE_EQ(dfunctor->eval(x), A * omega * cos(omega * x));
@@ -609,7 +609,7 @@ TEST(ctmath, plus_constant)
     EXPECT_EQ(functor->type(), "plus-constant");
     EXPECT_DOUBLE_EQ(functor->eval(0.), A);
     EXPECT_DOUBLE_EQ(functor->eval(x), sin(omega * x) + A);
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 
     auto dfunctor = functor->derivative();
     EXPECT_DOUBLE_EQ(dfunctor->eval(x), omega * cos(omega * x));
@@ -625,7 +625,7 @@ TEST(ctmath, periodic)
     EXPECT_EQ(functor->type(), "periodic");
     EXPECT_DOUBLE_EQ(functor->eval(0.), functor->eval(A));
     EXPECT_DOUBLE_EQ(functor->eval(x), functor->eval(x + A));
-    ASSERT_TRUE(functor->isIdentical(*functor));
+    ASSERT_TRUE(functor->isIdentical(functor));
 
     ASSERT_THROW(functor->derivative(), CanteraError);
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR ensures that Python and MATLAB API's are consistent as far as possible (follow-up to #1741).

- Implement alternative Python constructor that corresponds to MATLAB API
- Deprecate `Func1.cxx_functor` in Python
- Use specialized functions for `Func1` operators that implement rules for simplifications (rules had already been part of the code base, but were not used as of Cantera 3.0)
- Update operators in MATLAB
- Implement operators in Python
- Fix some typos and exceptions for `Func1::isIdentical`
- Add google tests for operator functions to improve coverage of previously untested code.

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

In MATLAB:
```MATLAB
>> out = Func1('sin') / 2  % Func1 operators work as of PR 1741
 
out = 
 
   0.5\sin(x)
 
>> out.type()  % simplification introduced in this PR (used to be 'ratio')

ans =

    'times-constant'
```

In Python:
```Python
In [1]: import cantera as ct

In [2]: a = ct.Func1(lambda x: x**2)

In [3]: b = a * 0  # Func1 operator introduced in this PR

In [4]: b.type
Out[4]: 'constant'

In [5]: b(1.5)
Out[5]: 0.0

In [6]: c = 2 * a

In [7]: c.type
Out[7]: 'times-constant'

In [8]: c(1.5), 2 * 1.5**2
Out[8]: (4.5, 4.5)

In [9]: f5 = ct.Func1("pow", 3.)  # MATLAB-like constructor (used to be 'ct.Func1.cxx_functor')
   ...: f5.type
Out[9]: 'pow'

In [10]: f5(2.0)
Out[10]: 8.0
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
