### PR TITLE
more detailed debugging outputs, solver documentation, and high loglevel print improvements

### DIFF
--- a/include/cantera/oneD/MultiNewton.h
+++ b/include/cantera/oneD/MultiNewton.h
@@ -111,6 +111,15 @@ public:
      * Find the solution to F(X) = 0 by damped Newton iteration. On entry, x0
      * contains an initial estimate of the solution. On successful return, x1
      * contains the converged solution.
+     *
+     * The convergence criteria is when the 2-norm of the Newton step is less than one.
+     *
+     * Returns:
+     * - int : Status code
+     *   - `1`  a converged step was able to be taken.
+     *   - `-2` no suitable damping coefficient was found within the maximum iterations.
+     *   - `-3` the current solution `x0` was too close to the boundary and the step
+     *          points out of the allowed domain.
      */
     int solve(double* x0, double* x1, OneDim& r, MultiJac& jac, int loglevel);
 
@@ -124,7 +133,7 @@ public:
 
 protected:
     //! Work arrays of size #m_n used in solve().
-    vector<double> m_x, m_stp, m_stp1, temp_x0, temp_stp0;
+    vector<double> m_x, m_stp, m_stp1;
 
     int m_maxAge = 5;
 

--- a/include/cantera/oneD/MultiNewton.h
+++ b/include/cantera/oneD/MultiNewton.h
@@ -60,18 +60,19 @@ public:
      *   F(x) = 0
      * @f]
      *
-     * Where `F` is the system of nonlinear equations, `x` is the solution vector.
+     * Where @f$ F @f$ is the system of nonlinear equations and @f$ x @f$ is the
+     * solution vector.
      *
      * For the damped Newton method we are solving:
      *
      * @f[
-     *   x_{k+1} - x_k = \Delta x_k = -\alpha_k J^(-1)(x_k) F(x_k)
+     *   x_{k+1} - x_k = \Delta x_k = -\alpha_k J^{-1}(x_k) F(x_k)
      * @f]
      *
-     * Where @f$ J @f$ is the Jacobian matrix of @f$ F @f$ with respect to @f$ x @f$, and @f$ \alpha_k @f$ is
-     * the damping factor, and @f$ \Delta x_k @f$ is the Newton step at @fx_k @f, sometimes
-     * called the correction vector. In the equations here, k is just an iteration
-     * variable.
+     * Where @f$ J @f$ is the Jacobian matrix of @f$ F @f$ with respect to @f$ x @f$,
+     * and @f$ \alpha_k @f$ is the damping factor, and @f$ \Delta x_k @f$ is the Newton
+     * step at @f$ x_k @f$, sometimes called the correction vector. In the equations
+     * here, @f$ k @f$ is just an iteration variable.
      *
      * In this method, the Jacobian does not update, even when the solution vector is
      * evaluated at different points.
@@ -83,8 +84,9 @@ public:
      *   x_{k+1} = x_k + \alpha_k \Delta x_k
      * @f]
      *
-     * Pick @f$ \alpha_k @f$ such that @f$ \norm{\Delta x_{k+1}} < \norm{\Delta x_k} @f$.
-     * Where @f$ \Delta x_k = J^{-1}(x_k) F(x_k) @f$, and
+     * Pick @f$ \alpha_k @f$ such that
+     * @f$ \Vert \Delta x_{k+1} \Vert < \Vert \Delta x_k \Vert @f$
+     * where @f$ \Delta x_k = J^{-1}(x_k) F(x_k) @f$, and
      * @f$ \Delta x_{k+1} = J^{-1}(x_{k}) F(x_{k+1}) @f$.
      *
      * @param[in] x0 initial solution about which a Newton step will be taken

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -46,14 +46,16 @@ public:
     MultiNewton& newton();
 
     /**
-     * Solve F(x) = 0, where F(x) is the multi-domain residual function. Returns
-     * a 1 on success, and either a -2 or -3 on failure depending on whether the
-     * maximum number of damping steps was reached(-2) or if the solution was up
-     * against the bounds(-3).
+     * Solve F(x) = 0, where F(x) is the multi-domain residual function.
      *
      * @param x0         Starting estimate of solution.
      * @param x1         Final solution satisfying F(x1) = 0.
      * @param loglevel   Controls amount of diagnostic output.
+     *
+     * @returns
+     * - 1 for success
+     * - -2 failure (maximum number of damping steps was reached)
+     * - -3 failure (solution was up against the bounds
      */
     int solve(double* x0, double* x1, int loglevel);
 

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -46,7 +46,11 @@ public:
     MultiNewton& newton();
 
     /**
-     * Solve F(x) = 0, where F(x) is the multi-domain residual function.
+     * Solve F(x) = 0, where F(x) is the multi-domain residual function. Returns
+     * a 1 on success, and either a -2 or -3 on failure depending on whether the
+     * maximum number of damping steps was reached(-2) or if the solution was up
+     * against the bounds(-3).
+     *
      * @param x0         Starting estimate of solution.
      * @param x1         Final solution satisfying F(x1) = 0.
      * @param loglevel   Controls amount of diagnostic output.
@@ -232,6 +236,13 @@ public:
     void setMaxTimeStep(double tmax) {
         m_tmax = tmax;
     }
+
+    /**
+     * Sets a factor by which the time step is reduced if the time stepping
+     * fails. The default value is 0.5.
+     *
+     * @param tfactor factor time step is multiplied by if time stepping fails
+     */
     void setTimeStepFactor(double tfactor) {
         m_tfactor = tfactor;
     }

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -168,10 +168,35 @@ public:
      */
     AnyMap restore(const string& fname, const string& name);
 
+    /**
+     * Deletes a `debug_sim1d.yaml` file if it exists. Used to clear the file for
+     * successive calls to the solve() method.
+     */
     void clearDebugFile();
 
-    void writeDebugInfo(const string& header, const string& message, int loglevel,
-                        int attempt_counter);
+    /**
+     * Write solver debugging information to a YAML file based on the specified log
+     * level.
+     *
+     * This method writes solver debug information to a specified YAML file
+     * (`debug_sim1d.yaml`). The section headers are formatted according to the provided
+     * `header_suffix` and `attempt_counter` arguments. Depending on the log level, the
+     * method will save either the solution information or the residual information
+     * for each attempted solution.
+     *
+     * @param header_suffix  Header used to construct a unique section in the YAML file
+     *                       where the information will be written to.
+     * @param message  A string that is written to the `description` tag in the YAML
+     *                 file.
+     * @param loglevel  Controls the type of output that will be written. A `loglevel`
+     *                  greater than 6 saves the solution, and a `loglevel` greater
+     *                  than 7 saves the residual additionally.
+     * @param attempt_counter  An integer counter used to uniquely identify the attempt
+     *                         which is included in the file header to differentiate
+     *                         between multiple solution attempts.
+     */
+     void writeDebugInfo(const string& header_suffix, const string& message, int loglevel,
+                         int attempt_counter);
 
 
     //! @}

--- a/include/cantera/oneD/Sim1D.h
+++ b/include/cantera/oneD/Sim1D.h
@@ -168,6 +168,12 @@ public:
      */
     AnyMap restore(const string& fname, const string& name);
 
+    void clearDebugFile();
+
+    void writeDebugInfo(const string& header, const string& message, int loglevel,
+                        int attempt_counter);
+
+
     //! @}
 
     void setTimeStep(double stepsize, size_t n, const int* tsteps);

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -323,7 +323,7 @@ int MultiNewton::solve(double* x0, double* x1, OneDim& r, MultiJac& jac, int log
     while (true) {
         // Check whether the Jacobian should be re-evaluated.
         if (jac.age() > m_maxAge) {
-            if (loglevel > 0) {
+            if (loglevel > 1) {
                 writelog("\n  Maximum Jacobian age reached ({}), updating it.", m_maxAge);
             }
             forceNewJac = true;
@@ -365,7 +365,7 @@ int MultiNewton::solve(double* x0, double* x1, OneDim& r, MultiJac& jac, int log
                     break;
                 }
                 nJacReeval++;
-                if (loglevel > 0) {
+                if (loglevel > 1) {
                     writelog("\n  Re-evaluating Jacobian (damping coefficient not found"
                             " with this Jacobian)");
                 }

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -232,14 +232,11 @@ int MultiNewton::dampStep(const double* x0, const double* step0,
 {
     // write header
     if (loglevel > 0 && writetitle) {
-        string header = fmt::format("  {:->23}Damped Newton iteration{:->24}", "", "");
-        string separator = fmt::format("  {:->70}", "");
-        writelog("\n\n{}", header);
-
+        writelog("\n\n  {:-^70}", " Damped Newton iteration ");
         writelog("\n  {:<4s}  {:<10s}   {:<10s}  {:<7s}  {:<7s}  {:<7s}  {:<5s}  {:<3s}\n",
                  "Iter", "F_damp", "F_bound", "log(ss)",
-                "log(s0)", "log(s1)", "N_jac", "Age");
-        writelog(separator);
+                 "log(s0)", "log(s1)", "N_jac", "Age");
+        writelog("  {:->70}", "");
     }
 
     // compute the weighted norm of the undamped step size step0
@@ -379,8 +376,7 @@ int MultiNewton::solve(double* x0, double* x1, OneDim& r, MultiJac& jac, int log
     }
     // Close off the damped iteration table that is written by the dampedStep() method
     if (loglevel > 1) {
-        string separator = fmt::format("\n  {:->70}", "");
-        writelog(separator);
+        writelog("\n  {:->70}", "");
     }
 
     if (status < 0) { // Reset x1 to x0 if the solution failed

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -341,10 +341,10 @@ double OneDim::timeStep(int nsteps, double dt, double* x, double* r, int logleve
     int successiveFailures = 0;
 
     // Only output this if nothing else under this function call will be output
-    if (loglevel == 1){
-        debuglog("\n============================", loglevel);
-        debuglog(fmt::format("\n{:<5s}  {:<11s}   {:<7s}\n", "step", "dt (s)", "log(ss)"), loglevel);
-        debuglog("============================", loglevel);
+    if (loglevel == 1) {
+        writelog("\n============================");
+        writelog("\n{:<5s}  {:<11s}   {:<7s}\n", "step", "dt (s)", "log(ss)");
+        writelog("============================");
     }
     while (n < nsteps) {
         if (loglevel == 1) { // At level 1, output concise information
@@ -392,7 +392,7 @@ double OneDim::timeStep(int nsteps, double dt, double* x, double* r, int logleve
             successiveFailures++;
             if (loglevel == 1) {
                 writelog("\nTimestep failed");
-            }else if (loglevel > 1) {
+            } else if (loglevel > 1) {
                 writelog("\nTimestep ({}) failed", n);
             }
             if (successiveFailures > 2) {
@@ -415,7 +415,7 @@ double OneDim::timeStep(int nsteps, double dt, double* x, double* r, int logleve
     if (loglevel == 1) {
         double ss = ssnorm(x, r);
         writelog("\n{:<5d}  {:<6.4e}   {:>7.4f}", n, dt, log10(ss));
-        debuglog("\n============================", loglevel);
+        writelog("\n============================");
     } else if (loglevel > 1) {
         double ss = ssnorm(x, r);
         writelog("\nTimestep({}) dt= {:<11.4e} log10(ss)= {:<7.4f}\n", n, dt, log10(ss));

--- a/src/oneD/OneDim.cpp
+++ b/src/oneD/OneDim.cpp
@@ -217,7 +217,7 @@ int OneDim::solve(double* x, double* xnew, int loglevel)
         m_jac->updateTransient(m_rdt, m_mask.data());
         m_jac_ok = true;
     }
-    return m_newt->solve(x, xnew, *this, *m_jac, loglevel-1);
+    return m_newt->solve(x, xnew, *this, *m_jac, loglevel);
 }
 
 void OneDim::evalSSJacobian(double* x, double* xnew)
@@ -361,7 +361,7 @@ double OneDim::timeStep(int nsteps, double dt, double* x, double* r, int logleve
         int j0 = m_jac->nEvals(); // Store the current number of Jacobian evaluations
 
         // solve the transient problem
-        int status = solve(x, r, loglevel-1);
+        int status = solve(x, r, loglevel);
 
         // successful time step. Copy the new solution in r to
         // the current solution in x.
@@ -418,7 +418,7 @@ double OneDim::timeStep(int nsteps, double dt, double* x, double* r, int logleve
         writelog("\n============================");
     } else if (loglevel > 1) {
         double ss = ssnorm(x, r);
-        writelog("\nTimestep({}) dt= {:<11.4e} log10(ss)= {:<7.4f}\n", n, dt, log10(ss));
+        writelog("\nTimestep ({}) dt= {:<11.4e} log10(ss)= {:<7.4f}\n", n, dt, log10(ss));
     }
 
     // return the value of the last stepsize, which may be smaller

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -600,8 +600,12 @@ int Sim1D::refine(int loglevel)
 }
 
 void Sim1D::clearDebugFile() {
-    if (std::remove("debug_sim1d.yaml") != 0) {
-        writelog("Warning: Unable to delete previous debug file 'debug_sim1d.yaml'\n");
+    // Use std::filesystem::remove to attempt deletion without throwing exceptions
+    if (!std::filesystem::remove("debug_sim1d.yaml")) {
+        // Only log a warning if the file existed and couldn't be deleted for some other reason
+        if (std::filesystem::exists("debug_sim1d.yaml")) {
+            writelog("Warning: Unable to delete previous debug file 'debug_sim1d.yaml'\n");
+        }
     }
 }
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -438,7 +438,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
             setSteadyMode();
             newton().setOptions(m_ss_jac_age);
             debuglog("\nAttempt Newton solution of steady-state problem.", loglevel);
-            int status = newtonSolve(loglevel-1);
+            int status = newtonSolve(loglevel);
 
             if (status == 0) {
                 if (loglevel > 0) {
@@ -490,7 +490,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
         if (loglevel > 0) {
             writeline('.', 78, true, true);
         }
-        if (loglevel > 2) {
+        if (loglevel > 3) {
             show();
         }
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -418,7 +418,6 @@ void Sim1D::solve(int loglevel, bool refine_grid)
     // For debugging outputs
     int attempt_counter = 0;
     const int max_history = 10; // Store up to 10 previous solutions
-    std::string header;
     if (loglevel > 6) {
         clearDebugFile();
     }
@@ -466,7 +465,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
                                loglevel, attempt_counter);
 
                 if (loglevel > 0) {
-                    writelog("\nTake {} timesteps:", nsteps);
+                    writelog("\nAttempt {} timesteps.", nsteps);
                 }
 
                 dt = timeStep(nsteps, dt, m_state->data(), m_xnew.data(), loglevel-1);
@@ -599,25 +598,22 @@ int Sim1D::refine(int loglevel)
     return np;
 }
 
-void Sim1D::clearDebugFile() {
-    // Use std::filesystem::remove to attempt deletion without throwing exceptions
-    if (!std::filesystem::remove("debug_sim1d.yaml")) {
-        // Only log a warning if the file existed and couldn't be deleted for some other reason
-        if (std::filesystem::exists("debug_sim1d.yaml")) {
-            writelog("Warning: Unable to delete previous debug file 'debug_sim1d.yaml'\n");
-        }
-    }
+void Sim1D::clearDebugFile()
+{
+    std::filesystem::remove("debug_sim1d.yaml");
 }
 
-void Sim1D::writeDebugInfo(const std::string& header, const std::string& message,
-                         int loglevel, int attempt_counter) {
+void Sim1D::writeDebugInfo(const string& header_suffix, const string& message,
+                           int loglevel, int attempt_counter)
+{
+    string file_header;
     if (loglevel > 6) {
-        std::string fileHeader = fmt::format("solution_{}_{}", attempt_counter, header);
-        save("debug_sim1d.yaml", fileHeader, message, true);
+        file_header = fmt::format("solution_{}_{}", attempt_counter, header_suffix);
+        save("debug_sim1d.yaml", file_header, message, true);
     }
     if (loglevel > 7) {
-        std::string fileHeader = fmt::format("residual_{}_{}", attempt_counter, header);
-        saveResidual("debug_sim1d.yaml", fileHeader, message, true);
+        file_header = fmt::format("residual_{}_{}", attempt_counter, header_suffix);
+        saveResidual("debug_sim1d.yaml", file_header, message, true);
     }
 }
 

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -475,7 +475,7 @@ void Sim1D::solve(int loglevel, bool refine_grid)
 
                 // Repeat the last timestep's data for logging purposes
                 if (loglevel == 1) {
-                    writelog("\nFinal timestep info: dt= {:<10.4g} log10(ss)= {:<10.4g}\n", dt,
+                    writelog("\nFinal timestep info: dt= {:<10.4g} log(ss)= {:<10.4g}\n", dt,
                              log10(ssnorm(m_state->data(), m_xnew.data())));
                 }
                 istep++;


### PR DESCRIPTION
Current work for a potential improvement for the damped newton step function as well as an improvement in the debugging output that the 1D solver generates when loglevel is set to 8. For the debugging outputs, a more comprehensive history of the solution steps that result in a failure is kept in the debugging file, which can then be examined to find where a solution started to diverge

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
