### PR TITLE
Fix inconsistent string handling in `clib`

### DIFF
--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -66,7 +66,7 @@ extern "C" {
     CANTERA_CAPI size_t thermo_elementIndex(int n, const char* nm);
     CANTERA_CAPI size_t thermo_speciesIndex(int n, const char* nm);
     //! @since Changed signature in %Cantera 3.1
-    CANTERA_CAPI int thermo_report3(int nth, int show_thermo, double threshold, int ibuf, char* buf);
+    CANTERA_CAPI int thermo_report(int nth, int show_thermo, double threshold, int ibuf, char* buf);
     CANTERA_CAPI int thermo_print(int nth, int show_thermo, double threshold);
     CANTERA_CAPI double thermo_nAtoms(int n, size_t k, size_t m);
     CANTERA_CAPI int thermo_addElement(int n, const char* name, double weight);
@@ -182,7 +182,7 @@ extern "C" {
     CANTERA_CAPI int ct_setLogCallback(LogCallback writer);
     CANTERA_CAPI int ct_addCanteraDirectory(size_t buflen, const char* buf);
     //! @since Changed signature in %Cantera 3.1
-    CANTERA_CAPI int ct_getDataDirectories3(const char* sep, int buflen, char* buf);
+    CANTERA_CAPI int ct_getDataDirectories(const char* sep, int buflen, char* buf);
     CANTERA_CAPI int ct_getCanteraVersion(int buflen, char* buf);
     CANTERA_CAPI int ct_getGitCommit(int buflen, char* buf);
     CANTERA_CAPI int ct_suppress_thermo_warnings(int suppress);

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -65,8 +65,8 @@ extern "C" {
     CANTERA_CAPI int thermo_setName(int n, const char* nm);
     CANTERA_CAPI size_t thermo_elementIndex(int n, const char* nm);
     CANTERA_CAPI size_t thermo_speciesIndex(int n, const char* nm);
-    CANTERA_CAPI int thermo_report(int nth,
-                                  int ibuf, char* buf, int show_thermo);
+    //! @since Changed signature in %Cantera 3.1
+    CANTERA_CAPI int thermo_report3(int nth, int show_thermo, int ibuf, char* buf);
     CANTERA_CAPI int thermo_print(int nth, int show_thermo, double threshold);
     CANTERA_CAPI double thermo_nAtoms(int n, size_t k, size_t m);
     CANTERA_CAPI int thermo_addElement(int n, const char* name, double weight);
@@ -181,7 +181,8 @@ extern "C" {
     CANTERA_CAPI int ct_setLogWriter(void* logger);
     CANTERA_CAPI int ct_setLogCallback(LogCallback writer);
     CANTERA_CAPI int ct_addCanteraDirectory(size_t buflen, const char* buf);
-    CANTERA_CAPI int ct_getDataDirectories(int buflen, char* buf, const char* sep);
+    //! @since Changed signature in %Cantera 3.1
+    CANTERA_CAPI int ct_getDataDirectories3(const char* sep, int buflen, char* buf);
     CANTERA_CAPI int ct_getCanteraVersion(int buflen, char* buf);
     CANTERA_CAPI int ct_getGitCommit(int buflen, char* buf);
     CANTERA_CAPI int ct_suppress_thermo_warnings(int suppress);

--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -66,7 +66,7 @@ extern "C" {
     CANTERA_CAPI size_t thermo_elementIndex(int n, const char* nm);
     CANTERA_CAPI size_t thermo_speciesIndex(int n, const char* nm);
     //! @since Changed signature in %Cantera 3.1
-    CANTERA_CAPI int thermo_report3(int nth, int show_thermo, int ibuf, char* buf);
+    CANTERA_CAPI int thermo_report3(int nth, int show_thermo, double threshold, int ibuf, char* buf);
     CANTERA_CAPI int thermo_print(int nth, int show_thermo, double threshold);
     CANTERA_CAPI double thermo_nAtoms(int n, size_t k, size_t m);
     CANTERA_CAPI int thermo_addElement(int n, const char* name, double weight);

--- a/include/cantera/clib/ctfunc.h
+++ b/include/cantera/clib/ctfunc.h
@@ -24,7 +24,8 @@ extern "C" {
     CANTERA_CAPI double func_value(int i, double t);
     CANTERA_CAPI int func_derivative(int i);
     CANTERA_CAPI int func_duplicate(int i);
-    CANTERA_CAPI int func_write(int i, const char* arg, size_t lennm, char* nm); //!< @since Changed signature in %Cantera 3.1
+    //! @since Changed signature in %Cantera 3.1
+    CANTERA_CAPI int func_write(int i, const char* arg, size_t lennm, char* nm);
     CANTERA_CAPI int ct_clearFunc();
 
 #ifdef __cplusplus

--- a/interfaces/dotnet/Cantera/src/DataDirectoryCollection.cs
+++ b/interfaces/dotnet/Cantera/src/DataDirectoryCollection.cs
@@ -17,7 +17,7 @@ public class DataDirectoryCollection : IReadOnlyList<DirectoryInfo>
 
         return InteropUtil
             .GetString(500, (size, buffer) =>
-                LibCantera.ct_getDataDirectories3(sep.ToString(), size, buffer))
+                LibCantera.ct_getDataDirectories(sep.ToString(), size, buffer))
             .Split(sep)
             .Select(d => new DirectoryInfo(d));
     }

--- a/interfaces/dotnet/Cantera/src/DataDirectoryCollection.cs
+++ b/interfaces/dotnet/Cantera/src/DataDirectoryCollection.cs
@@ -17,7 +17,7 @@ public class DataDirectoryCollection : IReadOnlyList<DirectoryInfo>
 
         return InteropUtil
             .GetString(500, (size, buffer) =>
-                LibCantera.ct_getDataDirectories(size, buffer, sep.ToString()))
+                LibCantera.ct_getDataDirectories3(sep.ToString(), size, buffer))
             .Split(sep)
             .Select(d => new DirectoryInfo(d));
     }

--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -976,8 +976,11 @@ classdef ThermoPhase < handle
             s = ctString('thermo_getName', tp.tpID);
         end
 
-        function str = get.report(tp)
-            str = ctString('thermo_report3', tp.tpID, 1);
+        function str = get.report(tp, threshold)
+            if nargin < 2
+                threshold = 1e-14;
+            end
+            str = ctString('thermo_report3', tp.tpID, 1, threshold);
         end
 
         function n = get.speciesNames(tp)

--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -977,16 +977,7 @@ classdef ThermoPhase < handle
         end
 
         function str = get.report(tp)
-            buflen = 0 - calllib(ctLib, 'thermo_report', tp.tpID, 0, '', 1);
-            aa = char(ones(1, buflen));
-            ptr = libpointer('cstring', aa);
-            [iok, bb] = calllib(ctLib, 'thermo_report', tp.tpID, buflen, ptr, 1);
-
-            if iok < 0
-                error(ctGetErr);
-            end
-
-            str = bb;
+            str = ctString('thermo_report3', tp.tpID, 1);
         end
 
         function n = get.speciesNames(tp)

--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -980,7 +980,7 @@ classdef ThermoPhase < handle
             if nargin < 2
                 threshold = 1e-14;
             end
-            str = ctString('thermo_report3', tp.tpID, 1, threshold);
+            str = ctString('thermo_report', tp.tpID, 1, threshold);
         end
 
         function n = get.speciesNames(tp)

--- a/interfaces/matlab_experimental/Utility/ctDataDirectories.m
+++ b/interfaces/matlab_experimental/Utility/ctDataDirectories.m
@@ -9,5 +9,5 @@ function d = ctDataDirectories()
     %     Cell array with strings representing the data file search directories
 
     ctIsLoaded;
-    d = ctString('ct_getDataDirectories3', ';');
+    d = ctString('ct_getDataDirectories', ';');
 end

--- a/interfaces/matlab_experimental/Utility/ctDataDirectories.m
+++ b/interfaces/matlab_experimental/Utility/ctDataDirectories.m
@@ -9,10 +9,5 @@ function d = ctDataDirectories()
     %     Cell array with strings representing the data file search directories
 
     ctIsLoaded;
-    buflen = calllib(ct, 'ct_getDataDirectories', 0, '', ';');
-    aa = char(ones(1, buflen));
-    ptr = libpointer('cstring', aa);
-    [~, bb, ~] = calllib(ct, 'ct_getDataDirectories', buflen, ptr, ';');
-    d = bb;
-    clear aa, bb, ptr
+    d = ctString('ct_getDataDirectories3', ';');
 end

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1586,7 +1586,7 @@ extern "C" {
 
     //-------------------- Functions ---------------------------
 
-    int thermo_report3(int nth, int show_thermo, double threshold, int ibuf, char* buf)
+    int thermo_report(int nth, int show_thermo, double threshold, int ibuf, char* buf)
     {
         try {
             bool stherm = (show_thermo != 0);
@@ -1630,7 +1630,7 @@ extern "C" {
         }
     }
 
-    int ct_getDataDirectories3(const char* sep, int buflen, char* buf)
+    int ct_getDataDirectories(const char* sep, int buflen, char* buf)
     {
         try {
             return static_cast<int>(copyString(getDataDirectories(sep), buf, buflen));

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1586,16 +1586,12 @@ extern "C" {
 
     //-------------------- Functions ---------------------------
 
-    int thermo_report(int nth, int ibuf, char* buf, int show_thermo)
+    int thermo_report3(int nth, int show_thermo, int ibuf, char* buf)
     {
         try {
             bool stherm = (show_thermo != 0);
-            string s = ThermoCabinet::item(nth).report(stherm);
-            if (int(s.size()) > ibuf - 1) {
-                return -(static_cast<int>(s.size()) + 1);
-            }
-            copyString(s, buf, ibuf);
-            return 0;
+            return static_cast<int>(
+                copyString(ThermoCabinet::item(nth).report(stherm), buf, ibuf));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1633,7 +1629,7 @@ extern "C" {
         }
     }
 
-    int ct_getDataDirectories(int buflen, char* buf, const char* sep)
+    int ct_getDataDirectories3(const char* sep, int buflen, char* buf)
     {
         try {
             return static_cast<int>(copyString(getDataDirectories(sep), buf, buflen));

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1586,12 +1586,13 @@ extern "C" {
 
     //-------------------- Functions ---------------------------
 
-    int thermo_report3(int nth, int show_thermo, int ibuf, char* buf)
+    int thermo_report3(int nth, int show_thermo, double threshold, int ibuf, char* buf)
     {
         try {
             bool stherm = (show_thermo != 0);
             return static_cast<int>(
-                copyString(ThermoCabinet::item(nth).report(stherm), buf, ibuf));
+                copyString(ThermoCabinet::item(nth).report(stherm, threshold),
+                buf, ibuf));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/test/matlab_experimental/ctTestThermo.m
+++ b/test/matlab_experimental/ctTestThermo.m
@@ -295,11 +295,8 @@ classdef ctTestThermo < matlab.unittest.TestCase
 
             self.verifySubstring(str, self.phase.name);
             self.verifySubstring(str, 'temperature');
-
-            for i = 1:self.phase.nSpecies
-                name = self.phase.speciesName(i);
-                self.verifySubstring(str, name{:});
-            end
+            self.verifySubstring(str, 'H2');
+            self.verifySubstring(str, 'minor');
         end
 
         function testRefInfo(self)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix instances where `clib` functions use inconsistent string handling, i.e. `ct_getDataDirectories` and `thermo_report`
- Replace by `ct_getDataDirectories3` and `thermo_report3` that have buffer length and char buffer in last two positions.
- Add threshold to MATLAB thermo report for more compact output (consistent with Python)

The change ensures that a single helper function `ctString.m` can be used as the interface to pass strings from C++ to MATLAB.

**If applicable, provide an example illustrating new features this pull request is introducing**

*Experimental* MATLAB now shows compact report (suppressing minor species):
```
>> gas = Solution('gri30.yaml')

  gri30:

       temperature   300 K
          pressure   1.0133e+05 Pa
           density   0.081894 kg/m^3
  mean mol. weight   2.016 kg/kmol
   phase of matter   gas

                          1 kg             1 kmol     
                     ---------------   ---------------
          enthalpy             26469             53361  J
   internal energy       -1.2108e+06        -2.441e+06  J
           entropy             64910        1.3086e+05  J/K
    Gibbs function       -1.9447e+07       -3.9204e+07  J
 heat capacity c_p             14311             28851  J/K
 heat capacity c_v             10187             20536  J/K

                      mass frac. Y      mole frac. X     chem. pot. / RT
                     ---------------   ---------------   ---------------
                H2                 1                 1           -15.717
     [  +52 minor]                 0                 0  
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
