### PR TITLE
Expose partial molar thermo properties to MATLAB

### DIFF
--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -92,10 +92,16 @@ extern "C" {
     CANTERA_CAPI double thermo_thermalExpansionCoeff(int n);
     CANTERA_CAPI double thermo_isothermalCompressibility(int n);
     CANTERA_CAPI int thermo_chemPotentials(int n, size_t lenm, double* murt);
+    CANTERA_CAPI int thermo_electrochemPotentials(int n, size_t lenm, double* emu);
     CANTERA_CAPI int thermo_getEnthalpies_RT(int n, size_t lenm, double* h_rt);
     CANTERA_CAPI int thermo_getEntropies_R(int n, size_t lenm, double* s_r);
     CANTERA_CAPI int thermo_getCp_R(int n, size_t lenm, double* cp_r);
     CANTERA_CAPI int thermo_setElectricPotential(int n, double v);
+    CANTERA_CAPI int thermo_getPartialMolarEnthalpies(int n, size_t lenm, double* pmh);
+    CANTERA_CAPI int thermo_getPartialMolarEntropies(int n, size_t lenm, double* pms);
+    CANTERA_CAPI int thermo_getPartialMolarIntEnergies(int n, size_t lenm, double* pmu);
+    CANTERA_CAPI int thermo_getPartialMolarCp(int n, size_t lenm, double* pmcp);
+    CANTERA_CAPI int thermo_getPartialMolarVolumes(int n, size_t lenm, double* pmv);
     CANTERA_CAPI int thermo_set_TP(int n, double* vals);
     CANTERA_CAPI int thermo_set_TD(int n, double* vals);
     CANTERA_CAPI int thermo_set_DP(int n, double* vals);

--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -119,19 +119,6 @@ classdef ThermoPhase < handle
         % Partial molar volumes for the species in the mixture. Units: m^3/kmol.
         partialMolarVolumes
 
-        % Non-dimensional enthalpies ::
-        %
-        %     >> v = tp.enthalpies_RT
-        %
-        % :param tp:
-        %     Instance of class :mat:class:`ThermoPhase` (or another
-        %     object that derives from ThermoPhase).
-        % :return:
-        %     Vector of standard-state species enthalpies constant
-        %     and T is the temperature. For gaseous species, these
-        %     values are ideal gas enthalpies.
-        enthalpies_RT
-
         critDensity % Critical density. Units: kg/m^3.
 
         critPressure % Critical pressure. Units: Pa.
@@ -1097,14 +1084,6 @@ classdef ThermoPhase < handle
             pt = libpointer('doublePtr', xx);
             ctFunc('thermo_getPartialMolarVolumes', tp.tpID, nsp, pt);
             volumes = pt.Value;
-        end
-
-        function enthalpy = get.enthalpies_RT(tp)
-            nsp = tp.nSpecies;
-            xx = zeros(1, nsp);
-            pt = libpointer('doublePtr', xx);
-            ctFunc('thermo_getEnthalpies_RT', tp.tpID, nsp, pt);
-            enthalpy = pt.Value;
         end
 
         function entropy = get.S(tp)

--- a/interfaces/matlab_experimental/Base/ThermoPhase.m
+++ b/interfaces/matlab_experimental/Base/ThermoPhase.m
@@ -90,21 +90,6 @@ classdef ThermoPhase < handle
 
         Q % Vapor fraction of the phase.
 
-        % Chemical potentials of the species ::
-        %
-        %     >> mu = tp.chemPotentials
-        %
-        % The expressions used to compute the chemical potential
-        % depend on the model implemented by the underlying kernel
-        % thermo manager.
-        %
-        % :param tp:
-        %     Instance of class :mat:class:`ThermoPhase` (or another
-        %     object that derives from ThermoPhase).
-        % :return:
-        %     Vector of species chemical potentials. Units: J/kmol.
-        chemicalPotentials
-
         % Basis-dependent specific heat at constant volume.
         % Units: J/kg-K (mass basis) or J/kmol-K (molar basis).
         cv
@@ -113,11 +98,26 @@ classdef ThermoPhase < handle
         % Units: J/kg-K (mass basis) or J/kmol-K (molar basis).
         cp
 
-        critDensity % Critical density. Units: kg/m^3.
+        % Chemical potentials of the species. Units: J/kmol.
+        chemicalPotentials
 
-        critPressure % Critical pressure. Units: Pa.
+        % Electrochemical potentials of the species. Units: J/kmol.
+        electrochemicalPotentials
 
-        critTemperature % Critical temperature. Units: K.
+        % Partial molar enthalpies for the species in the mixture. Units: J/kmol.
+        partialMolarEnthalpies
+
+        % Partial molar entropies for the species in the mixture. Units: J/kmol/K.
+        partialMolarEntropies
+
+        % Partial molar internal energies for the species in the mixture. Units: J/kmol.
+        partialMolarIntEnergies
+
+        % Partial molar heat capacities for the species in the mixture. Units: J/kmol/K.
+        partialMolarCp
+
+        % Partial molar volumes for the species in the mixture. Units: m^3/kmol.
+        partialMolarVolumes
 
         % Non-dimensional enthalpies ::
         %
@@ -131,6 +131,12 @@ classdef ThermoPhase < handle
         %     and T is the temperature. For gaseous species, these
         %     values are ideal gas enthalpies.
         enthalpies_RT
+
+        critDensity % Critical density. Units: kg/m^3.
+
+        critPressure % Critical pressure. Units: Pa.
+
+        critTemperature % Critical temperature. Units: K.
 
         eosType % Type of equation of state.
 
@@ -855,14 +861,6 @@ classdef ThermoPhase < handle
             e = pt.Value;
         end
 
-        function mu = get.chemicalPotentials(tp)
-            nsp = tp.nSpecies;
-            xx = zeros(1, nsp);
-            pt = libpointer('doublePtr', xx);
-            ctFunc('thermo_chemPotentials', tp.tpID, nsp, pt);
-            mu = pt.Value;
-        end
-
         function c = get.cv(tp)
             if strcmp(tp.basis, 'molar')
                 c = ctFunc('thermo_cv_mole', tp.tpID);
@@ -1043,6 +1041,62 @@ classdef ThermoPhase < handle
             else
                 enthalpy = ctFunc('thermo_enthalpy_mass', tp.tpID);
             end
+        end
+
+        function mu = get.chemicalPotentials(tp)
+            nsp = tp.nSpecies;
+            xx = zeros(1, nsp);
+            pt = libpointer('doublePtr', xx);
+            ctFunc('thermo_chemPotentials', tp.tpID, nsp, pt);
+            mu = pt.Value;
+        end
+
+        function emu = get.electrochemicalPotentials(tp)
+            nsp = tp.nSpecies;
+            xx = zeros(1, nsp);
+            pt = libpointer('doublePtr', xx);
+            ctFunc('thermo_electrochemPotentials', tp.tpID, nsp, pt);
+            emu = pt.Value;
+        end
+
+        function enthalpies = get.partialMolarEnthalpies(tp)
+            nsp = tp.nSpecies;
+            xx = zeros(1, nsp);
+            pt = libpointer('doublePtr', xx);
+            ctFunc('thermo_getPartialMolarEnthalpies', tp.tpID, nsp, pt);
+            enthalpies = pt.Value;
+        end
+
+        function entropies = get.partialMolarEntropies(tp)
+            nsp = tp.nSpecies;
+            xx = zeros(1, nsp);
+            pt = libpointer('doublePtr', xx);
+            ctFunc('thermo_getPartialMolarEntropies', tp.tpID, nsp, pt);
+            entropies = pt.Value;
+        end
+
+        function intEnergies = get.partialMolarIntEnergies(tp)
+            nsp = tp.nSpecies;
+            xx = zeros(1, nsp);
+            pt = libpointer('doublePtr', xx);
+            ctFunc('thermo_getPartialMolarIntEnergies', tp.tpID, nsp, pt);
+            intEnergies = pt.Value;
+        end
+
+        function cps = get.partialMolarCp(tp)
+            nsp = tp.nSpecies;
+            xx = zeros(1, nsp);
+            pt = libpointer('doublePtr', xx);
+            ctFunc('thermo_getPartialMolarCp', tp.tpID, nsp, pt);
+            cps = pt.Value;
+        end
+
+        function volumes = get.partialMolarVolumes(tp)
+            nsp = tp.nSpecies;
+            xx = zeros(1, nsp);
+            pt = libpointer('doublePtr', xx);
+            ctFunc('thermo_getPartialMolarVolumes', tp.tpID, nsp, pt);
+            volumes = pt.Value;
         end
 
         function enthalpy = get.enthalpies_RT(tp)

--- a/samples/matlab_experimental/PFR_solver.m
+++ b/samples/matlab_experimental/PFR_solver.m
@@ -35,7 +35,7 @@ function F = PFR_Solver(x, soln_vector, gas, mdot, A_in, dAdx, k)
 
     gas.basis = 'mass';
     MW = gas.molecularWeights;
-    h = gas.enthalpies_RT .* R .* T;
+    h = gas.partialMolarEnthalpies;
     w = gas.netProdRates;
     Cp = gas.cp;
     %--------------------------------------------------------------------------

--- a/samples/matlab_experimental/conhp.m
+++ b/samples/matlab_experimental/conhp.m
@@ -12,9 +12,9 @@ function dydt = conhp(t, y, gas, mw)
 
     % energy equation
     wdot = gas.netProdRates;
-    H = gas.enthalpies_RT';
+    H = gas.partialMolarEnthalpies';
     gas.basis = 'mass';
-    tdot =- gas.T * GasConstant / (gas.D * gas.cp) .* wdot * H;
+    tdot =- 1 / (gas.D * gas.cp) .* wdot * H;
 
     % set up column vector for dydt
     dydt = [tdot

--- a/samples/matlab_experimental/conuv.m
+++ b/samples/matlab_experimental/conuv.m
@@ -12,9 +12,9 @@ function dydt = conuv(t, y, gas, mw)
 
     % energy equation
     wdot = gas.netProdRates;
-    H = (gas.enthalpies_RT - ones(1, nsp))';
+    U = gas.partialMolarIntEnergies';
     gas.basis = 'mass';
-    tdot =- gas.T * GasConstant / (gas.D * gas.cv) .* wdot * H;
+    tdot =- 1 / (gas.D * gas.cv) .* wdot * U;
 
     % set up column vector for dydt
     dydt = [tdot

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -696,6 +696,18 @@ extern "C" {
         }
     }
 
+    int thermo_electrochemPotentials(int n, size_t lenm, double* emu)
+    {
+        try {
+            ThermoPhase& thrm = ThermoCabinet::item(n);
+            thrm.checkSpeciesArraySize(lenm);
+            thrm.getElectrochemPotentials(emu);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int thermo_setPressure(int n, double p)
     {
         try {
@@ -969,6 +981,66 @@ extern "C" {
     {
         try {
             ThermoCabinet::item(n).setElectricPotential(v);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int thermo_getPartialMolarEnthalpies(int n, size_t lenm, double* pmh)
+    {
+        try {
+            auto& thrm = ThermoCabinet::item(n);
+            thrm.checkSpeciesArraySize(lenm);
+            thrm.getPartialMolarEnthalpies(pmh);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int thermo_getPartialMolarEntropies(int n, size_t lenm, double* pms)
+    {
+        try {
+            auto& thrm = ThermoCabinet::item(n);
+            thrm.checkSpeciesArraySize(lenm);
+            thrm.getPartialMolarEntropies(pms);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int thermo_getPartialMolarIntEnergies(int n, size_t lenm, double* pmu)
+    {
+        try {
+            auto& thrm = ThermoCabinet::item(n);
+            thrm.checkSpeciesArraySize(lenm);
+            thrm.getPartialMolarIntEnergies(pmu);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int thermo_getPartialMolarCp(int n, size_t lenm, double* pmcp)
+    {
+        try {
+            auto& thrm = ThermoCabinet::item(n);
+            thrm.checkSpeciesArraySize(lenm);
+            thrm.getPartialMolarCp(pmcp);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int thermo_getPartialMolarVolumes(int n, size_t lenm, double* pmv)
+    {
+        try {
+            auto& thrm = ThermoCabinet::item(n);
+            thrm.checkSpeciesArraySize(lenm);
+            thrm.getPartialMolarVolumes(pmv);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -208,6 +208,32 @@ TEST(ct, thermo)
     double T = thermo_temperature(thermo);
     ASSERT_GT(T, 2200);
     ASSERT_LT(T, 2300);
+
+    size_t ns = thermo_nSpecies(thermo);
+    vector<double> work(ns);
+    vector<double> X(ns);
+    thermo_getMoleFractions(thermo, ns, X.data());
+    double prod;
+
+    thermo_getPartialMolarEnthalpies(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, thermo_enthalpy_mole(thermo), 1e-6);
+
+    thermo_getPartialMolarEntropies(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, thermo_entropy_mole(thermo), 1e-6);
+
+    thermo_getPartialMolarIntEnergies(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, thermo_intEnergy_mole(thermo), 1e-6);
+
+    thermo_getPartialMolarCp(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, thermo_cp_mole(thermo), 1e-6);
+
+    thermo_getPartialMolarVolumes(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, 1./thermo_molarDensity(thermo), 1e-6);
 }
 
 TEST(ct, kinetics)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Expose partial molar thermo properties to MATLAB, and remove mislabeled reference state `enthalpies_RT`. The fix sidesteps the discussion of "standard state" vs "reference state" nomenclature of #522, and instead focuses on quantities that are relevant to the actual state. Added properties are:

- `ThermoPhase.partialMolarEnthalpies`
- `ThermoPhase.partialMolarEntropies`
- `ThermoPhase.partialMolarIntEnergies`
- `ThermoPhase.partialMolarCp`
- `ThermoPhase.partialMolarVolumes`
- `ThermoPhase.electrochemicalPotentials`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #522

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
>> gas = Solution('h2o2.yaml');
>> gas.TPX = {300, OneAtm, 'H2:1,O2:1'};
>> gas.equilibrate('HP');
>> gas.partialMolarEnthalpies

ans =

   1.0e+08 *

    0.8545    2.7231    3.0389    0.9457    1.2587   -1.1919    1.4706    0.4063    0.5432    0.8945

>> gas.partialMolarEnthalpies * gas.X'

ans =

   6.6029e+04

>> gas.H

ans =

   6.6029e+04
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
