### PR TITLE
Prevent garbage collection / segfaults with CustomRate

### DIFF
--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -227,6 +227,9 @@ cdef class _SolutionBase:
             self.kinetics.skipUndeclaredThirdBodies(True)
             for reaction in reactions:
                 self.kinetics.addReaction(reaction._reaction, False)
+                if isinstance(reaction.rate, (CustomRate, ExtensibleRate)):
+                    # prevent premature garbage collection
+                    self._custom_rates.append(reaction.rate)
             self.kinetics.resizeReactions()
 
         if isinstance(self, Transport):

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -660,7 +660,9 @@ class TestFreeFlame(utilities.CanteraTest):
 
         self.sim.solve(loglevel=0)
 
-    @pytest.mark.filterwarnings("ignore:.*reaction_phase_index.*:DeprecationWarning")
+    # @pytest.mark.filterwarnings("ignore:.*reaction_phase_index.*:DeprecationWarning")
+    # TODO: remove fixture after Cantera 3.1; @pytest.mark.filterwarnings does not work
+    @pytest.mark.usefixtures("allow_deprecated")  # to ignore reaction_phase_index
     def test_array_properties(self):
         self.create_sim(ct.one_atm, 300, 'H2:1.1, O2:1, AR:5')
         grid_shape = self.sim.grid.shape


### PR DESCRIPTION
CustomRate/ExtensibleRate need to be held by Python objects regardless of instantiation pathway.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Prevent garbage collection of `CustomRate` objects when creating `Solution` objects from list of species and reactions.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1762

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
