### PR TITLE
Reproducible names for zeroD objects

### DIFF
--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -19,6 +19,8 @@ extern "C" {
 
     CANTERA_CAPI int reactor_new(const char* type, int n, const char* name);
     CANTERA_CAPI int reactor_del(int i);
+    CANTERA_CAPI int reactor_name(int i, int len, char* nbuf);
+    CANTERA_CAPI int reactor_setName(int i, const char* name);
     CANTERA_CAPI int reactor_setInitialVolume(int i, double v);
     CANTERA_CAPI int reactor_setChemistry(int i, int cflag);
     CANTERA_CAPI int reactor_setEnergy(int i, int eflag);
@@ -49,8 +51,10 @@ extern "C" {
     CANTERA_CAPI double reactornet_atol(int i);
     CANTERA_CAPI double reactornet_sensitivity(int i, const char* v, int p, int r);
 
-    CANTERA_CAPI int flowdev_new(const char* type);
+    CANTERA_CAPI int flowdev_new(const char* type, const char* name);
     CANTERA_CAPI int flowdev_del(int i);
+    CANTERA_CAPI int flowdev_name(int i, int len, char* nbuf);
+    CANTERA_CAPI int flowdev_setName(int i, const char* name);
     CANTERA_CAPI int flowdev_install(int i, int n, int m);
     CANTERA_CAPI int flowdev_setPrimary(int i, int n);
     CANTERA_CAPI double flowdev_massFlowRate(int i);
@@ -60,8 +64,10 @@ extern "C" {
     CANTERA_CAPI int flowdev_setPressureFunction(int i, int n);
     CANTERA_CAPI int flowdev_setTimeFunction(int i, int n);
 
-    CANTERA_CAPI int wall_new(const char* type);
+    CANTERA_CAPI int wall_new(const char* type, const char* name);
     CANTERA_CAPI int wall_del(int i);
+    CANTERA_CAPI int wall_name(int i, int len, char* nbuf);
+    CANTERA_CAPI int wall_setName(int i, const char* name);
     CANTERA_CAPI int wall_install(int i, int n, int m);
     CANTERA_CAPI double wall_expansionRate(int i);
     CANTERA_CAPI double wall_heatRate(int i);
@@ -75,8 +81,10 @@ extern "C" {
     CANTERA_CAPI int wall_setEmissivity(int i, double epsilon);
     CANTERA_CAPI int wall_ready(int i);
 
-    CANTERA_CAPI int reactorsurface_new(int type);
+    CANTERA_CAPI int reactorsurface_new(const char* name);
     CANTERA_CAPI int reactorsurface_del(int i);
+    CANTERA_CAPI int reactorsurface_name(int i, int len, char* nbuf);
+    CANTERA_CAPI int reactorsurface_setName(int i, const char* name);
     CANTERA_CAPI int reactorsurface_install(int i, int n);
     CANTERA_CAPI int reactorsurface_setkinetics(int i, int n);
     CANTERA_CAPI double reactorsurface_area(int i);

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -45,6 +45,9 @@ public:
         m_name = name;
     }
 
+    //! Set the default name of a flow device. Returns `false` if it was previously set.
+    bool setDefaultName(map<string, int>& counts);
+
     //! Mass flow rate (kg/s).
     double massFlowRate() {
         if (m_mdot == Undef) {
@@ -131,6 +134,7 @@ public:
 
 protected:
     string m_name;  //!< Flow device name.
+    bool m_defaultNameSet = false;  //!< `true` if default name has been previously set.
 
     double m_mdot = Undef;
 

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -23,7 +23,7 @@ class ReactorBase;
 class FlowDevice
 {
 public:
-    FlowDevice() = default;
+    FlowDevice(const string& name="(none)") : m_name(name) {}
 
     virtual ~FlowDevice() = default;
     FlowDevice(const FlowDevice&) = delete;
@@ -33,6 +33,16 @@ public:
     //! corresponds to the name of the derived class.
     virtual string type() const {
         return "FlowDevice";
+    }
+
+    //! Retrieve flow device name.
+    string name() const {
+        return m_name;
+    }
+
+    //! Set flow device name.
+    void setName(const string& name) {
+        m_name = name;
     }
 
     //! Mass flow rate (kg/s).
@@ -77,6 +87,11 @@ public:
         return *m_out;
     }
 
+    //! Return a mutable reference to the downstream reactor.
+    ReactorBase& out() {
+        return *m_out;
+    }
+
     //! Return current value of the pressure function.
     /*!
      * The mass flow rate [kg/s] is calculated given the pressure drop [Pa] and a
@@ -115,6 +130,8 @@ public:
     }
 
 protected:
+    string m_name;  //!< Flow device name.
+
     double m_mdot = Undef;
 
     //! Function set by setPressureFunction; used by updateMassFlowRate

--- a/include/cantera/zeroD/FlowDeviceFactory.h
+++ b/include/cantera/zeroD/FlowDeviceFactory.h
@@ -19,7 +19,7 @@ namespace Cantera
 //! ```cpp
 //!     shared_ptr<FlowDevice> mfc = newFlowDevice("MassFlowController");
 //! ```
-class FlowDeviceFactory : public Factory<FlowDevice>
+class FlowDeviceFactory : public Factory<FlowDevice, const string&>
 {
 public:
     static FlowDeviceFactory* factory();
@@ -34,22 +34,22 @@ private:
 
 //! @defgroup flowDeviceGroup Flow Devices
 //! Flow device objects connect zero-dimensional reactors.
-//! FlowDevice objects should be instantiated via the newFlowDevice() function, for
+//! FlowDevice objects should be instantiated via the newFlowDevice function, for
 //! example:
 //!
 //! ```cpp
-//!     shared_ptr<FlowDevice> mfc = newFlowDevice("MassFlowController");
+//!     shared_ptr<FlowDevice> mfc = newFlowDevice("MassFlowController", "my_mfc");
 //! ```
 //! @ingroup zerodGroup
 //! @{
 
 //! Create a FlowDevice object of the specified type
 //! @since Starting in %Cantera 3.1, this method returns a `shared_ptr<FlowDevice>`
-shared_ptr<FlowDevice> newFlowDevice(const string& model);
+shared_ptr<FlowDevice> newFlowDevice(const string& model, const string& name="(none)");
 
 //! Create a FlowDevice object of the specified type
 //! @since New in %Cantera 3.0.
-//! @deprecated Transitional method. Use newFlowDevice() instead.
+//! @deprecated Replaced by newFlowDevice. To be removed after %Cantera 3.1.
 shared_ptr<FlowDevice> newFlowDevice3(const string& model);
 
 //! @}

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -46,7 +46,7 @@ class AnyMap;
 class Reactor : public ReactorBase
 {
 public:
-    Reactor(shared_ptr<Solution> sol, const string& name = "(none)");
+    Reactor(shared_ptr<Solution> sol, const string& name="(none)");
     using ReactorBase::ReactorBase; // inherit constructors
 
     string type() const override {

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -50,12 +50,12 @@ struct SensitivityParameter
 class ReactorBase
 {
 public:
-    explicit ReactorBase(const string& name = "(none)");
+    explicit ReactorBase(const string& name="(none)");
     //! Instantiate a ReactorBase object with Solution contents.
     //! @param sol  Solution object to be set.
     //! @param name  Name of the reactor.
     //! @since New in %Cantera 3.1.
-    ReactorBase(shared_ptr<Solution> sol, const string& name = "(none)");
+    ReactorBase(shared_ptr<Solution> sol, const string& name="(none)");
     virtual ~ReactorBase();
     ReactorBase(const ReactorBase&) = delete;
     ReactorBase& operator=(const ReactorBase&) = delete;

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -76,6 +76,9 @@ public:
         m_name = name;
     }
 
+    //! Set the default name of a reactor. Returns `false` if it was previously set.
+    bool setDefaultName(map<string, int>& counts);
+
     //! Set the Solution specifying the ReactorBase content.
     //! @param sol  Solution object to be set.
     //! @since New in %Cantera 3.1.
@@ -307,7 +310,8 @@ protected:
     //! Vector of length nWalls(), indicating whether this reactor is on the left (0)
     //! or right (1) of each wall.
     vector<int> m_lr;
-    string m_name;
+    string m_name;  //!< Reactor name.
+    bool m_defaultNameSet = false;  //!< `true` if default name has been previously set.
 
     //! The ReactorNet that this reactor is part of
     ReactorNet* m_net = nullptr;

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -59,7 +59,7 @@ template <class R>
 class ReactorDelegator : public Delegator, public R, public ReactorAccessor
 {
 public:
-    ReactorDelegator() {
+    ReactorDelegator(const string& name="") : m_name(name) {
         install("initialize", m_initialize, [this](double t0) { R::initialize(t0); });
         install("syncState", m_syncState, [this]() { R::syncState(); });
         install("getState", m_getState,
@@ -185,6 +185,7 @@ public:
     }
 
 private:
+    string m_name;
     function<void(double)> m_initialize;
     function<void()> m_syncState;
     function<void(std::array<size_t, 1>, double*)> m_getState;

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -59,7 +59,9 @@ template <class R>
 class ReactorDelegator : public Delegator, public R, public ReactorAccessor
 {
 public:
-    ReactorDelegator(const string& name="") : m_name(name) {
+    ReactorDelegator(shared_ptr<Solution> contents, const string& name="(none)")
+        : R(contents, name)
+    {
         install("initialize", m_initialize, [this](double t0) { R::initialize(t0); });
         install("syncState", m_syncState, [this]() { R::syncState(); });
         install("getState", m_getState,
@@ -95,6 +97,10 @@ public:
     }
 
     // Overrides of Reactor methods
+
+    string type() const override {
+        return fmt::format("Extensible{}", R::type());
+    }
 
     void initialize(double t0) override {
         m_initialize(t0);
@@ -185,7 +191,6 @@ public:
     }
 
 private:
-    string m_name;
     function<void(double)> m_initialize;
     function<void()> m_syncState;
     function<void(std::array<size_t, 1>, double*)> m_getState;

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -19,7 +19,7 @@ namespace Cantera
 //! ```cpp
 //!     shared_ptr<ReactorBase> r1 = newReactor("IdealGasReactor");
 //! ```
-class ReactorFactory : public Factory<ReactorBase>
+class ReactorFactory : public Factory<ReactorBase, const string&>
 {
 public:
     static ReactorFactory* factory();

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -19,7 +19,7 @@ namespace Cantera
 //! ```cpp
 //!     shared_ptr<ReactorBase> r1 = newReactor("IdealGasReactor");
 //! ```
-class ReactorFactory : public Factory<ReactorBase, const string&>
+class ReactorFactory : public Factory<ReactorBase, shared_ptr<Solution>, const string&>
 {
 public:
     static ReactorFactory* factory();

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -305,6 +305,9 @@ protected:
 
     void updatePreconditioner(double gamma) override;
 
+    //! Create reproducible names for reactors and walls/connectors.
+    void updateNames(Reactor& r);
+
     //! Estimate a future state based on current derivatives.
     //! The function is intended for internal use by ReactorNet::advance
     //! and deliberately not exposed in external interfaces.
@@ -316,6 +319,7 @@ protected:
     virtual int lastOrder() const;
 
     vector<Reactor*> m_reactors;
+    map<string, int> m_counts;  //!< Map used for default name generation
     unique_ptr<Integrator> m_integ;
 
     //! The independent variable in the system. May be either time or space depending

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -20,10 +20,25 @@ class SurfPhase;
 class ReactorSurface
 {
 public:
-    ReactorSurface() = default;
+    ReactorSurface(const string& name="(none)") : m_name(name) {}
     virtual ~ReactorSurface() = default;
     ReactorSurface(const ReactorSurface&) = delete;
     ReactorSurface& operator=(const ReactorSurface&) = delete;
+
+    //! String indicating the wall model implemented.
+    virtual string type() const {
+        return "ReactorSurface";
+    }
+
+    //! Retrieve reactor surface name.
+    string name() const {
+        return m_name;
+    }
+
+    //! Set reactor surface name.
+    void setName(const string& name) {
+        m_name = name;
+    }
 
     //! Returns the surface area [m^2]
     double area() const;
@@ -87,6 +102,8 @@ public:
     void resetSensitivityParameters();
 
 protected:
+    string m_name;  //!< Reactor surface name.
+
     double m_area = 1.0;
 
     SurfPhase* m_thermo = nullptr;

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -40,6 +40,9 @@ public:
         m_name = name;
     }
 
+    //! Set the default name of a wall. Returns `false` if it was previously set.
+    bool setDefaultName(map<string, int>& counts);
+
     //! Returns the surface area [m^2]
     double area() const;
 
@@ -103,6 +106,7 @@ public:
 
 protected:
     string m_name;  //!< Reactor surface name.
+    bool m_defaultNameSet = false;  //!< `true` if default name has been previously set.
 
     double m_area = 1.0;
 

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -21,7 +21,7 @@ class Func1;
 class WallBase
 {
 public:
-    WallBase() = default;
+    WallBase(const string& name="(none)") : m_name(name) {}
 
     virtual ~WallBase() {}
     WallBase(const WallBase&) = delete;
@@ -31,6 +31,16 @@ public:
     //! corresponds to the name of the derived class.
     virtual string type() const {
         return "WallBase";
+    }
+
+    //! Retrieve wall name.
+    string name() const {
+        return m_name;
+    }
+
+    //! Set wall name.
+    void setName(const string& name) {
+        m_name = name;
     }
 
     //! Rate of volume change (m^3/s) for the adjacent reactors at current reactor
@@ -92,6 +102,8 @@ public:
     }
 
 protected:
+    string m_name;  //!< Wall name.
+
     ReactorBase* m_left = nullptr;
     ReactorBase* m_right = nullptr;
 
@@ -110,7 +122,7 @@ protected:
 class Wall : public WallBase
 {
 public:
-    Wall() = default;
+    using WallBase::WallBase;  // inherit constructors
 
     //! String indicating the wall model implemented. Usually
     //! corresponds to the name of the derived class.

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -43,6 +43,9 @@ public:
         m_name = name;
     }
 
+    //! Set the default name of a wall. Returns `false` if it was previously set.
+    bool setDefaultName(map<string, int>& counts);
+
     //! Rate of volume change (m^3/s) for the adjacent reactors at current reactor
     //! network time.
     /*!
@@ -89,7 +92,7 @@ public:
     }
 
     //! Return a reference to the Reactor or Reservoir to the right of the wall.
-    const ReactorBase& right() {
+    ReactorBase& right() {
         return *m_right;
     }
 
@@ -103,6 +106,7 @@ public:
 
 protected:
     string m_name;  //!< Wall name.
+    bool m_defaultNameSet = false;  //!< `true` if default name has been previously set.
 
     ReactorBase* m_left = nullptr;
     ReactorBase* m_right = nullptr;

--- a/include/cantera/zeroD/WallFactory.h
+++ b/include/cantera/zeroD/WallFactory.h
@@ -19,7 +19,7 @@ namespace Cantera
 //! ```cpp
 //!     shared_ptr<WallBase> piston = newWall("Wall");
 //! ```
-class WallFactory : public Factory<WallBase>
+class WallFactory : public Factory<WallBase, const string&>
 {
 public:
     static WallFactory* factory();
@@ -34,22 +34,22 @@ private:
 
 //! @defgroup wallGroup Walls
 //! Zero-dimensional objects adjacent to reactors.
-//! Wall objects should be instantiated via the newWall() function, for
+//! Wall objects should be instantiated via the newWall function, for
 //! example:
 //!
 //! ```cpp
-//!     shared_ptr<WallBase> piston = newWall("Wall");
+//!     shared_ptr<WallBase> piston = newWall("Wall", "my_piston");
 //! ```
 //! @ingroup zerodGroup
 //! @{
 
 //! Create a WallBase object of the specified type
 //! @since Starting in %Cantera 3.1, this method returns a `shared_ptr<WallBase>`
-shared_ptr<WallBase> newWall(const string& model);
+shared_ptr<WallBase> newWall(const string& model, const string& name="(none)");
 
 //! Create a WallBase object of the specified type
 //! @since New in %Cantera 3.0.
-//! @deprecated Transitional method. Use newWall() instead.
+//! @deprecated Replaced by newWall. To be removed after %Cantera 3.1.
 shared_ptr<WallBase> newWall3(const string& model);
 
 //! @}

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -20,7 +20,7 @@ namespace Cantera
 class MassFlowController : public FlowDevice
 {
 public:
-    MassFlowController() = default;
+    using FlowDevice::FlowDevice;  // inherit constructors
 
     string type() const override {
         return "MassFlowController";
@@ -65,7 +65,7 @@ public:
 class PressureController : public FlowDevice
 {
 public:
-    PressureController() = default;
+    using FlowDevice::FlowDevice;  // inherit constructors
 
     string type() const override {
         return "PressureController";
@@ -123,7 +123,7 @@ protected:
 class Valve : public FlowDevice
 {
 public:
-    Valve() = default;
+    using FlowDevice::FlowDevice;  // inherit constructors
 
     string type() const override {
         return "Valve";

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -32,8 +32,8 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     # factories
     cdef shared_ptr[CxxReactorBase] newReactor(string) except +translate_exception
     cdef shared_ptr[CxxReactorBase] newReactor(string, shared_ptr[CxxSolution], string) except +translate_exception
-    cdef shared_ptr[CxxFlowDevice] newFlowDevice(string) except +translate_exception
-    cdef shared_ptr[CxxWallBase] newWall(string) except +translate_exception
+    cdef shared_ptr[CxxFlowDevice] newFlowDevice(string, string) except +translate_exception
+    cdef shared_ptr[CxxWallBase] newWall(string, string) except +translate_exception
 
     # reactors
     cdef cppclass CxxReactorBase "Cantera::ReactorBase":
@@ -86,6 +86,8 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxWallBase "Cantera::WallBase":
         CxxWallBase()
         string type()
+        string name()
+        void setName(string) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&)
         double area()
         void setArea(double)
@@ -117,7 +119,10 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     # reactor surface
 
     cdef cppclass CxxReactorSurface "Cantera::ReactorSurface":
-        CxxReactorSurface()
+        CxxReactorSurface(string) except +translate_exception
+        string type()
+        string name()
+        void setName(string) except +translate_exception
         double area()
         void setArea(double)
         void setKinetics(CxxKinetics*)
@@ -132,6 +137,8 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxFlowDevice "Cantera::FlowDevice":
         CxxFlowDevice()
         string type()
+        string name()
+        void setName(string) except +translate_exception
         double massFlowRate() except +translate_exception
         double massFlowRate(double) except +translate_exception
         cbool install(CxxReactorBase&, CxxReactorBase&) except +translate_exception

--- a/interfaces/matlab_experimental/Reactor/ConstPressureReactor.m
+++ b/interfaces/matlab_experimental/Reactor/ConstPressureReactor.m
@@ -1,7 +1,7 @@
 classdef ConstPressureReactor < Reactor
     % Create a constant pressure reactor object. ::
     %
-    %     >> r = ConstPressureReactor(contents)
+    %     >> r = ConstPressureReactor(contents, name)
     %
     % A :mat:class:`ConstPressureReactor` is an instance of class
     % :mat:class:`Reactor` where the pressure is held constant. The volume
@@ -10,26 +10,27 @@ classdef ConstPressureReactor < Reactor
     %
     % .. code-block:: matlab
     %
-    %     r1 = ConstPressureReactor         % an empty reactor
     %     r2 = ConstPressureReactor(contents)    % a reactor containing contents
     %
     % See also: :mat:class:`Reactor`
     %
     % :param contents:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
+    % :param name:
+    %     Reactor name (optional; default is ``(none)``).
     % :return:
     %     Instance of class :mat:class:`ConstPressureReactor`.
 
     methods
 
-        function r = ConstPressureReactor(contents)
+        function r = ConstPressureReactor(contents, name)
             % Constructor
 
-            if nargin == 0
-                contents = 0;
+            if nargin < 2
+                name = '(none)'
             end
 
-            r@Reactor(contents, 'ConstPressureReactor');
+            r@Reactor(contents, 'ConstPressureReactor', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/FlowDevice.m
+++ b/interfaces/matlab_experimental/Reactor/FlowDevice.m
@@ -1,7 +1,7 @@
 classdef FlowDevice < handle
     % FlowDevice Class ::
     %
-    %     >> x = FlowDevice(typ)
+    %     >> x = FlowDevice(typ, name)
     %
     % Base class for devices that allow flow between reactors.
     % :mat:class:`FlowDevice` objects are assumed to be adiabatic,
@@ -18,6 +18,8 @@ classdef FlowDevice < handle
     %     Type of :mat:class:`FlowDevice` to be created. ``typ='MassFlowController'``
     %     for :mat:class:`MassFlowController`,  ``typ='PressureController'`` for
     %     :mat:class:`PressureController`, and ``typ='Valve'`` for :mat:class:`Valve`.
+    % :param name:
+    %     Reactor name (optional; default is ``(none)``).
     % :return:
     %     Instance of class :mat:class:`FlowDevice`.
 
@@ -30,7 +32,7 @@ classdef FlowDevice < handle
 
     properties (SetAccess = public)
 
-        name  % name of flow device.
+        name  % Name of flow device.
 
         % Upstream object of type :mat:class:`Reactor` or :mat:class:`Reservoir`.
         upstream

--- a/interfaces/matlab_experimental/Reactor/FlowDevice.m
+++ b/interfaces/matlab_experimental/Reactor/FlowDevice.m
@@ -30,6 +30,8 @@ classdef FlowDevice < handle
 
     properties (SetAccess = public)
 
+        name  % name of flow device.
+
         % Upstream object of type :mat:class:`Reactor` or :mat:class:`Reservoir`.
         upstream
 
@@ -56,7 +58,7 @@ classdef FlowDevice < handle
     methods
         %% FlowDevice Class Constructor
 
-        function x = FlowDevice(typ)
+        function x = FlowDevice(typ, name)
             % Create a :mat:class:`FlowDevice` object.
 
             ctIsLoaded;
@@ -64,9 +66,12 @@ classdef FlowDevice < handle
             if nargin == 0
                 error('please specify the type of flow device to be created');
             end
+            if nargin < 2
+                name = '(none)';
+            end
 
             x.type = typ;
-            x.id = ctFunc('flowdev_new', typ);
+            x.id = ctFunc('flowdev_new', typ, name);
             x.upstream = -1;
             x.downstream = -1;
         end
@@ -112,11 +117,19 @@ classdef FlowDevice < handle
 
         %% FlowDevice Get Methods
 
+        function name = get.name(f)
+            name = ctString('flowdev_name', f.id);
+        end
+
         function mdot = get.massFlowRate(f)
             mdot = ctFunc('flowdev_massFlowRate2', f.id);
         end
 
         %% FlowDevice Set Methods
+
+        function set.name(f, name)
+            ctFunc('flowdev_setName', f.id, name);
+        end
 
         function set.massFlowRate(f, mdot)
 

--- a/interfaces/matlab_experimental/Reactor/FlowReactor.m
+++ b/interfaces/matlab_experimental/Reactor/FlowReactor.m
@@ -1,33 +1,34 @@
 classdef FlowReactor < Reactor
     % Create a flow reactor object. ::
     %
-    %     >> r = FlowReactor(contents)
+    %     >> r = FlowReactor(contents, name)
     %
     % A reactor representing adiabatic plug flow in a constant-area
     % duct. Examples:
     %
     % .. code-block:: matlab
     %
-    %     r1 = FlowReactor         % an empty reactor
     %     r2 = FlowReactor(gas)    % a reactor containing a gas
     %
     % See also: :mat:class:`Reactor`
     %
     % :param contents:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
+    % :param name:
+    %     Reactor name (optional; default is ``(none)``).
     % :return:
     %     Instance of class :mat:class:`FlowReactor`.
 
     methods
 
-        function r = FlowReactor(contents)
+        function r = FlowReactor(contents, name)
             % Constructor
 
-            if nargin == 0
-                contents = 0;
+            if nargin < 2
+                name = '(none)'
             end
 
-            r@Reactor(contents, 'FlowReactor');
+            r@Reactor(contents, 'FlowReactor', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/IdealGasConstPressureReactor.m
+++ b/interfaces/matlab_experimental/Reactor/IdealGasConstPressureReactor.m
@@ -1,7 +1,7 @@
 classdef IdealGasConstPressureReactor < Reactor
     % Create a constant pressure reactor with an ideal gas. ::
     %
-    %     >> r = IdealGasConstPressureReactor(contents)
+    %     >> r = IdealGasConstPressureReactor(contents, name)
     %
     % An :mat:class:`IdealGasConstPressureReactor` is an instance of
     % :mat:class:`Reactor` where the pressure is held constant.
@@ -13,26 +13,27 @@ classdef IdealGasConstPressureReactor < Reactor
     %
     % .. code-block:: matlab
     %
-    %     r1 = IdealGasConstPressureReactor      % an empty reactor
     %     r2 = IdealGasConstPressureReactor(gas) % a reactor containing a gas
     %
     % See also: :mat:class:`Reactor`
     %
     % :param contents:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
+    % :param name:
+    %     Reactor name (optional; default is ``(none)``).
     % :return:
     %     Instance of class :mat:class:`IdealGasConstPressureReactor`.
 
     methods
 
-        function r = IdealGasConstPressureReactor(contents)
+        function r = IdealGasConstPressureReactor(contents, name)
             % Constructor
 
-            if nargin == 0
-                contents = 0;
+            if nargin < 2
+                name = '(none)';
             end
 
-            r@Reactor(contents, 'IdealGasConstPressureReactor');
+            r@Reactor(contents, 'IdealGasConstPressureReactor', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/IdealGasReactor.m
+++ b/interfaces/matlab_experimental/Reactor/IdealGasReactor.m
@@ -1,7 +1,7 @@
 classdef IdealGasReactor < Reactor
     % Create a reactor with an ideal gas. ::
     %
-    %     >> r = IdealGasReactor(contents)
+    %     >> r = IdealGasReactor(contents, name)
     %
     % An :mat:class:`IdealGasReactor` is an instance of :mat:class:`Reactor` where
     % the governing equations are specialized for the ideal gas equation of state
@@ -9,26 +9,27 @@ classdef IdealGasReactor < Reactor
     %
     % .. code-block:: matlab
     %
-    %     r1 = IdealGasReactor         % an empty reactor
     %     r2 = IdealGasReactor(gas)    % a reactor containing a gas
     %
     % See also: :mat:class:`Reactor`
     %
     % :param contents:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
+    % :param name:
+    %     Reactor name (optional; default is ``(none)``).
     % :return:
     %     Instance of class :mat:class:`IdealGasReactor`.
 
     methods
 
-        function r = IdealGasReactor(contents)
+        function r = IdealGasReactor(contents, name)
             % Constructor
 
-            if nargin == 0
-                contents = 0;
+            if nargin < 2
+                name = '(none)';
             end
 
-            r@Reactor(contents, 'IdealGasReactor');
+            r@Reactor(contents, 'IdealGasReactor', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/MassFlowController.m
+++ b/interfaces/matlab_experimental/Reactor/MassFlowController.m
@@ -1,7 +1,7 @@
 classdef MassFlowController < FlowDevice
     % Create a mass flow controller. ::
     %
-    %     >> m = MassFlowController(upstream, downstream)
+    %     >> m = MassFlowController(upstream, downstream, name)
     %
     % Creates an instance of class :mat:class:`FlowDevice` configured to
     % simulate a mass flow controller that maintains a constant mass flow
@@ -17,20 +17,22 @@ classdef MassFlowController < FlowDevice
     %     Upstream :mat:class:`Reactor` or :mat:class:`Reservoir`.
     % :param downstream:
     %     Downstream :mat:class:`Reactor` or :mat:class:`Reservoir`.
+    % :param name:
+    %     Flow device name (optional; default is ``(none)``).
     % :return:
     %     Instance of class :mat:class:`FlowDevice`.
 
     methods
 
-        function m = MassFlowController(upstream, downstream)
+        function m = MassFlowController(upstream, downstream, name)
             % Constructor
 
-            m@FlowDevice('MassFlowController');
-
-            if nargin == 2
-                m.install(upstream, downstream)
+            if nargin < 3
+                name = '(none)';
             end
 
+            m@FlowDevice('MassFlowController', name);
+            m.install(upstream, downstream)
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/Reactor.m
+++ b/interfaces/matlab_experimental/Reactor/Reactor.m
@@ -9,6 +9,8 @@ classdef Reactor < handle
 
     properties (SetAccess = public)
 
+        name  % Name of reactor.
+
         contents
 
         % Density of the reactor contents at the end of the last call to
@@ -158,6 +160,10 @@ classdef Reactor < handle
 
         %% Reactor Get Methods
 
+        function name = get.name(r)
+            name = ctString('reactor_name', r.id);
+        end
+
         function temperature = get.T(r)
             temperature = ctFunc('reactor_temperature', r.id);
         end
@@ -212,6 +218,10 @@ classdef Reactor < handle
         end
 
         %% Reactor set methods
+
+        function set.name(r, name)
+            ctFunc('reactor_setName', r.id, name);
+        end
 
         function set.V(r, v0)
 

--- a/interfaces/matlab_experimental/Reactor/ReactorSurface.m
+++ b/interfaces/matlab_experimental/Reactor/ReactorSurface.m
@@ -1,7 +1,7 @@
 classdef ReactorSurface < handle
     % ReactorSurface Class ::
     %
-    %     >> s = ReactorSurface(surf, reactor, area)
+    %     >> s = ReactorSurface(surf, reactor, name)
     %
     % A surface on which heterogeneous reactions take place. The
     % mechanism object (typically an instance of :mat:class:`Interface`)
@@ -10,18 +10,14 @@ classdef ReactorSurface < handle
     % temperature on each side is taken to be equal to the
     % temperature of the reactor.
     %
-    % Note: all of the arguments are optional and can be activated
-    % after initial construction by using the various methods of
-    % the :mat:class:`ReactorSurface` class.
-    %
     % :param surf:
     %    Surface reaction mechanisms for the left-facing surface.
     %    This must bean instance of class :mat:class:`Kinetics`, or of a class
     %    derived from Kinetics, such as :mat:class:`Interface`.
     % :param reactor:
     %    Instance of class 'Reactor' to be used as the adjacent bulk phase.
-    % :param area:
-    %    The area of the surface in m^2. Defaults to 1.0 m^2 if not specified.
+    % :param name:
+    %    Reactor surface name (optional; default is ``(none)``).
     % :return:
     %    Instance of class :mat:class:`ReactorSurface`.
 
@@ -29,56 +25,30 @@ classdef ReactorSurface < handle
         surfID
     end
 
-    properties (SetAccess = protected)
-        reactor
-    end
-
     properties (SetAccess = public)
+        name  % Name of reactor surface.
+
         area % Area of the reactor surface in m^2.
     end
 
     methods
         %% ReactorSurface Class Constructor
 
-        function s = ReactorSurface(surf, reactor, area)
+        function s = ReactorSurface(surf, reactor, name)
             % Create a :mat:class:`ReactorSurface` object.
 
             ctIsLoaded;
 
-            s.surfID = ctFunc('reactorsurface_new', 0);
-            s.reactor = -1;
-
-            if nargin >= 1
-                ikin = 0;
-
-                if isa(surf, 'Kinetics')
-                    ikin = surf.kinID;
-                end
-
-                ctFunc('reactorsurface_setkinetics', s.surfID, ikin);
+            if ~isa(surf, 'Kinetics') || ~isa(reactor, 'Reactor')
+                error('Invalid parameters.')
+            end
+            if nargin < 3
+                name = '(none)';
             end
 
-            if nargin >= 2
-
-                if isa(reactor, 'Reactor')
-                    s.reactor = reactor;
-                    ctFunc('reactorsurface_install', s.surfID, reactor.id);
-                else
-                    warning('Reactor was not installed due to incorrect type');
-                end
-
-            end
-
-            if nargin >= 3
-
-                if isnumeric(area)
-                    s.area = area;
-                else
-                    warning('Area was not a number and was not set');
-                end
-
-            end
-
+            s.surfID = ctFunc('reactorsurface_new', name);
+            ctFunc('reactorsurface_setkinetics', s.surfID, surf.kinID);
+            ctFunc('reactorsurface_install', s.surfID, reactor.id);
         end
 
         %% ReactorSurface Class Destructor
@@ -106,11 +76,19 @@ classdef ReactorSurface < handle
 
         %% ReactorSurface Get Methods
 
+        function name = get.name(s)
+            name = ctString('reactorsurface_name', s.surfID);
+        end
+
         function a = get.area(s)
             a = ctFunc('reactorsurface_area', s.surfID);
         end
 
         %% ReactorSurface Set Methods
+
+        function set.name(s, name)
+            ctFunc('reactorsurface_setName', s.surfID, name);
+        end
 
         function set.area(s, a)
             ctFunc('reactorsurface_setArea', s.surfID, a);

--- a/interfaces/matlab_experimental/Reactor/Reservoir.m
+++ b/interfaces/matlab_experimental/Reactor/Reservoir.m
@@ -1,7 +1,7 @@
 classdef Reservoir < Reactor
     % Create a :mat:class:`Reservoir` object. ::
     %
-    %     >> r = Reservoir(contents)
+    %     >> r = Reservoir(contents, name)
     %
     % A :mat:class:`Reservoir` is an instance of class :mat:class:`Reactor`
     % configured so that its intensive state is constant in time. A reservoir
@@ -14,26 +14,27 @@ classdef Reservoir < Reactor
     %
     % .. code-block:: matlab
     %
-    %     r1 = Reservoir         % an empty reservoir
     %     r2 = Reservoir(gas)    % a reservoir containing a gas
     %
     % See also: :mat:class:`Reactor`
     %
     % :param contents:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
+    % :param name:
+    %     Reservoir name (optional; default is ``(none)``).
     % :return:
     %     Instance of class :mat:class:`Reactor`.
 
     methods
 
-        function r = Reservoir(contents)
+        function r = Reservoir(contents, name)
             % Constructor
 
-            if nargin == 0
-                contents = 0;
+            if nargin < 2
+                name = '(none)';
             end
 
-            r@Reactor(contents, 'Reservoir');
+            r@Reactor(contents, 'Reservoir', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/Valve.m
+++ b/interfaces/matlab_experimental/Reactor/Valve.m
@@ -1,7 +1,7 @@
 classdef Valve < FlowDevice
     % Create a valve. ::
     %
-    %     >> v = Valve(upstream, downstream)
+    %     >> v = Valve(upstream, downstream, name)
     %
     % Create an instance of class :mat:class:`FlowDevice` configured to
     % simulate a valve that produces a flow rate proportional to the
@@ -26,20 +26,22 @@ classdef Valve < FlowDevice
     %     Upstream reactor or reservoir.
     % :param downstream:
     %     Downstream Reactor or reservoir.
+    % :param name:
+    %     Valve name (optional; default is ``(none)``).
     % :return:
     %     Instance of class :mat:class:`FlowDevice`.
 
     methods
 
-        function v = Valve(upstream, downstream)
+        function v = Valve(upstream, downstream, name)
             % Constructor
 
-            v@FlowDevice('Valve');
-
-            if nargin == 2
-                v.install(upstream, downstream)
+            if nargin < 3
+                name = '(none)';
             end
 
+            v@FlowDevice('Valve', name);
+            v.install(upstream, downstream)
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/Wall.m
+++ b/interfaces/matlab_experimental/Reactor/Wall.m
@@ -1,7 +1,7 @@
 classdef Wall < handle
     % Wall Class ::
     %
-    %     >> x = Wall(l, r)
+    %     >> x = Wall(l, r, name)
     %
     % A Wall separates two reactors, or a reactor and a reservoir.
     % A Wall has a finite area, may conduct heat between the two
@@ -40,6 +40,8 @@ classdef Wall < handle
     % :param r:
     %    Instance of class :mat:class:`Reactor` to be used as the bulk phase
     %    on the right side of the wall.
+    % :param name:
+    %     Wall name (optional; default is ``(none)``).
     % :return:
     %    Instance of class :mat:class:`Wall`.
 
@@ -114,9 +116,7 @@ classdef Wall < handle
 
             % Check whether the wall is ready.
             ok = ctFunc('wall_ready', w.id);
-            if ok
-                disp('The wall object is ready.');
-            else
+            if ~ok
                 error('The wall object is not ready.');
             end
 

--- a/interfaces/matlab_experimental/Reactor/Wall.m
+++ b/interfaces/matlab_experimental/Reactor/Wall.m
@@ -52,6 +52,8 @@ classdef Wall < handle
 
     properties (SetAccess = protected)
 
+        name  % Name of wall.
+
         left % Reactor on the left.
         right % Reactor on the right.
 
@@ -87,15 +89,18 @@ classdef Wall < handle
     methods
         %% Wall Class Constructor
 
-        function w = Wall(l, r)
+        function w = Wall(l, r, name)
             % Create a :mat:class:`Wall` object.
             ctIsLoaded;
 
             % At the moment, only one wall type is implemented
             typ = 'Wall';
+            if nargin < 3
+                name = '(none)';
+            end
 
             w.type = char(typ);
-            w.id = ctFunc('wall_new', w.type);
+            w.id = ctFunc('wall_new', w.type, name);
 
             % Install the wall between left and right reactors
             w.left = l;
@@ -127,6 +132,10 @@ classdef Wall < handle
 
         %% ReactorNet get methods
 
+        function name = get.name(w)
+            name = ctString('wall_name', w.id);
+        end
+
         function a = get.area(w)
             a = ctFunc('wall_area', w.id);
         end
@@ -140,6 +149,10 @@ classdef Wall < handle
         end
 
         %% ReactorNet set methods
+
+        function set.name(w, name)
+            ctFunc('wall_setName', w.id, name);
+        end
 
         function set.area(w, a)
             ctFunc('wall_setArea', w.id, a);

--- a/samples/matlab_experimental/surf_reactor.m
+++ b/samples/matlab_experimental/surf_reactor.m
@@ -46,7 +46,8 @@ w = Wall(r, env);
 A = 1e-4; % Wall area
 
 % Add a reacting surface, with an area matching that of the wall
-rsurf = ReactorSurface(surf, r, A);
+rsurf = ReactorSurface(surf, r);
+rsurf.area = A;
 
 % set the wall area and heat transfer coefficient.
 w.area = A;

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -12,6 +12,7 @@
 #include "cantera/thermo/ThermoPhase.h"
 #include "cantera/kinetics/Kinetics.h"
 #include "cantera/zerodim.h"
+#include "cantera/base/stringUtils.h"
 #include "clib_utils.h"
 
 using namespace Cantera;
@@ -53,6 +54,26 @@ extern "C" {
     {
         try {
             ReactorCabinet::del(i);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int reactor_name(int i, int len, char* nbuf)
+    {
+        try {
+            return static_cast<int>(
+                copyString(ReactorCabinet::at(i)->name(), nbuf, len));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int reactor_setName(int i, const char* name)
+    {
+        try {
+            ReactorCabinet::at(i)->setName(name);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -349,10 +370,10 @@ extern "C" {
 
     // flow devices
 
-    int flowdev_new(const char* type)
+    int flowdev_new(const char* type, const char* name)
     {
         try {
-            return FlowDeviceCabinet::add(newFlowDevice(type));
+            return FlowDeviceCabinet::add(newFlowDevice(type, name));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -362,6 +383,26 @@ extern "C" {
     {
         try {
             FlowDeviceCabinet::del(i);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int flowdev_name(int i, int len, char* nbuf)
+    {
+        try {
+            return static_cast<int>(
+                copyString(FlowDeviceCabinet::at(i)->name(), nbuf, len));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int flowdev_setName(int i, const char* name)
+    {
+        try {
+            FlowDeviceCabinet::at(i)->setName(name);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -455,10 +496,10 @@ extern "C" {
 
     /////////////    Walls   ///////////////////////
 
-    int wall_new(const char* type)
+    int wall_new(const char* type, const char* name)
     {
         try {
-            return WallCabinet::add(newWall(type));
+            return WallCabinet::add(newWall(type, name));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -468,6 +509,26 @@ extern "C" {
     {
         try {
             WallCabinet::del(i);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int wall_name(int i, int len, char* nbuf)
+    {
+        try {
+            return static_cast<int>(
+                copyString(WallCabinet::at(i)->name(), nbuf, len));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int wall_setName(int i, const char* name)
+    {
+        try {
+            WallCabinet::at(i)->setName(name);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -593,10 +654,10 @@ extern "C" {
 
     // ReactorSurface
 
-    int reactorsurface_new(int type)
+    int reactorsurface_new(const char* name)
     {
         try {
-            return ReactorSurfaceCabinet::add(make_shared<ReactorSurface>());
+            return ReactorSurfaceCabinet::add(make_shared<ReactorSurface>(name));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -606,6 +667,26 @@ extern "C" {
     {
         try {
             ReactorSurfaceCabinet::del(i);
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int reactorsurface_name(int i, int len, char* nbuf)
+    {
+        try {
+            return static_cast<int>(
+                copyString(ReactorSurfaceCabinet::at(i)->name(), nbuf, len));
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
+    int reactorsurface_setName(int i, const char* name)
+    {
+        try {
+            ReactorSurfaceCabinet::at(i)->setName(name);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -11,6 +11,20 @@
 namespace Cantera
 {
 
+bool FlowDevice::setDefaultName(map<string, int>& counts)
+{
+    if (m_defaultNameSet) {
+        return false;
+    }
+    m_defaultNameSet = true;
+    string typ(type());
+    if (m_name == "(none)" || m_name == "") {
+        m_name = fmt::format("{}_{}", type(), counts[type()]);
+    }
+    counts[type()]++;
+    return true;
+}
+
 bool FlowDevice::install(ReactorBase& in, ReactorBase& out)
 {
     if (m_in || m_out) {

--- a/src/zeroD/FlowDeviceFactory.cpp
+++ b/src/zeroD/FlowDeviceFactory.cpp
@@ -14,9 +14,15 @@ std::mutex FlowDeviceFactory::flowDevice_mutex;
 
 FlowDeviceFactory::FlowDeviceFactory()
 {
-    reg("MassFlowController", []() { return new MassFlowController(); });
-    reg("PressureController", []() { return new PressureController(); });
-    reg("Valve", []() { return new Valve(); });
+    reg("MassFlowController", [](const string& name) {
+        return new MassFlowController(name);
+    });
+    reg("PressureController", [](const string& name) {
+        return new PressureController(name);
+    });
+    reg("Valve", [](const string& name) {
+        return new Valve(name);
+    });
 }
 
 FlowDeviceFactory* FlowDeviceFactory::factory() {
@@ -33,13 +39,15 @@ void FlowDeviceFactory::deleteFactory() {
     s_factory = 0;
 }
 
-shared_ptr<FlowDevice> newFlowDevice(const string& model)
+shared_ptr<FlowDevice> newFlowDevice(const string& model, const string& name)
 {
-    return shared_ptr<FlowDevice>(FlowDeviceFactory::factory()->create(model));
+    return shared_ptr<FlowDevice>(FlowDeviceFactory::factory()->create(model, name));
 }
 
 shared_ptr<FlowDevice> newFlowDevice3(const string& model)
 {
+    warn_deprecated("newFlowDevice3",
+        "Use newFlowDevice instead; to be removed after Cantera 3.1.");
     return newFlowDevice(model);
 }
 

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -23,9 +23,16 @@ namespace Cantera
 {
 
 Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
+    : ReactorBase(name)
 {
+    if (!sol || !(sol->thermo())) {
+        warn_deprecated("Reactor::Reactor",
+            "Creation of empty reactor objects is deprecated in Cantera 3.1 and will "
+            "raise\nexceptions thereafter; reactor contents should be provided in the "
+            "constructor.");
+        return;
+    }
     setSolution(sol);
-    m_name = name;
     setThermo(*sol->thermo());
     setKinetics(*sol->kinetics());
 }

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -37,6 +37,19 @@ ReactorBase::~ReactorBase()
     }
 }
 
+bool ReactorBase::setDefaultName(map<string, int>& counts)
+{
+    if (m_defaultNameSet) {
+        return false;
+    }
+    m_defaultNameSet = true;
+    if (m_name == "(none)" || m_name == "") {
+        m_name = fmt::format("{}_{}", type(), counts[type()]);
+    }
+    counts[type()]++;
+    return true;
+}
+
 void ReactorBase::setSolution(shared_ptr<Solution> sol) {
     if (!sol || !(sol->thermo())) {
         throw CanteraError("ReactorBase::setSolution",

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -18,8 +18,15 @@ ReactorBase::ReactorBase(const string& name) : m_name(name)
 }
 
 ReactorBase::ReactorBase(shared_ptr<Solution> sol, const string& name)
+    : ReactorBase(name)
 {
-    m_name = name;
+    if (!sol || !(sol->thermo())) {
+        warn_deprecated("ReactorBase::ReactorBase",
+            "Creation of empty reactor objects is deprecated in Cantera 3.1 and will "
+            "raise\nexceptions thereafter; reactor contents should be provided in the "
+            "constructor.");
+        return;
+    }
     setSolution(sol);
 }
 

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -13,9 +13,8 @@
 namespace Cantera
 {
 
-ReactorBase::ReactorBase(const string& name)
+ReactorBase::ReactorBase(const string& name) : m_name(name)
 {
-    m_name = name;
 }
 
 ReactorBase::ReactorBase(shared_ptr<Solution> sol, const string& name)

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -24,32 +24,60 @@ std::mutex ReactorFactory::reactor_mutex;
 
 ReactorFactory::ReactorFactory()
 {
-    reg("Reservoir", [](const string& name) { return new Reservoir(name); });
-    reg("Reactor", [](const string& name) { return new Reactor(name); });
-    reg("ConstPressureReactor", [](const string& name) { return new ConstPressureReactor(name); });
-    reg("FlowReactor", [](const string& name) { return new FlowReactor(name); });
-    reg("IdealGasReactor", [](const string& name) { return new IdealGasReactor(name); });
-    reg("IdealGasConstPressureReactor", [](const string& name) { return new IdealGasConstPressureReactor(name); });
-    reg("ExtensibleReactor", [](const string& name) { return new ReactorDelegator<Reactor>(name); });
+    reg("Reservoir",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new Reservoir(sol, name); });
+    reg("Reactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new Reactor(sol, name); });
+    reg("ConstPressureReactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ConstPressureReactor(sol, name); });
+    reg("FlowReactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new FlowReactor(sol, name); });
+    reg("IdealGasReactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new IdealGasReactor(sol, name); });
+    reg("IdealGasConstPressureReactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new IdealGasConstPressureReactor(sol, name); });
+    reg("ExtensibleReactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorDelegator<Reactor>(sol, name); });
     reg("ExtensibleIdealGasReactor",
-        [](const string& name) { return new ReactorDelegator<IdealGasReactor>(name); });
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorDelegator<IdealGasReactor>(sol, name); });
     reg("ExtensibleConstPressureReactor",
-        [](const string& name) { return new ReactorDelegator<ConstPressureReactor>(name); });
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorDelegator<ConstPressureReactor>(sol, name); });
     reg("ExtensibleIdealGasConstPressureReactor",
-        [](const string& name) { return new ReactorDelegator<IdealGasConstPressureReactor>(name); });
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorDelegator<IdealGasConstPressureReactor>(sol, name); });
     reg("ExtensibleMoleReactor",
-        [](const string& name) { return new ReactorDelegator<MoleReactor>(name); });
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorDelegator<MoleReactor>(sol, name); });
     reg("ExtensibleConstPressureMoleReactor",
-        [](const string& name) { return new ReactorDelegator<ConstPressureMoleReactor>(name); });
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorDelegator<ConstPressureMoleReactor>(sol, name); });
     reg("ExtensibleIdealGasMoleReactor",
-        [](const string& name) { return new ReactorDelegator<IdealGasMoleReactor>(name); });
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorDelegator<IdealGasMoleReactor>(sol, name); });
     reg("ExtensibleIdealGasConstPressureMoleReactor",
-        [](const string& name) { return new ReactorDelegator<IdealGasConstPressureMoleReactor>(name); });
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorDelegator<IdealGasConstPressureMoleReactor>(sol, name); });
     reg("IdealGasConstPressureMoleReactor",
-        [](const string& name) { return new IdealGasConstPressureMoleReactor(name); });
-    reg("IdealGasMoleReactor", [](const string& name) { return new IdealGasMoleReactor(name); });
-    reg("ConstPressureMoleReactor", [](const string& name) { return new ConstPressureMoleReactor(name); });
-    reg("MoleReactor", [](const string& name) { return new MoleReactor(name); });
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new IdealGasConstPressureMoleReactor(sol, name); });
+    reg("IdealGasMoleReactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new IdealGasMoleReactor(sol, name); });
+    reg("ConstPressureMoleReactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ConstPressureMoleReactor(sol, name); });
+    reg("MoleReactor",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new MoleReactor(sol, name); });
 }
 
 ReactorFactory* ReactorFactory::factory() {
@@ -68,20 +96,15 @@ void ReactorFactory::deleteFactory() {
 
 shared_ptr<ReactorBase> newReactor(const string& model)
 {
-    warn_deprecated("newReactor",
-        "Creation of empty reactor objects is deprecated in Cantera 3.1 and will be \n"
-        "removed thereafter; reactor contents should be provided in the constructor.");
-    return shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model, ""));
+    return shared_ptr<ReactorBase>(
+        ReactorFactory::factory()->create(model, nullptr, ""));
 }
 
 shared_ptr<ReactorBase> newReactor(
     const string& model, shared_ptr<Solution> contents, const string& name)
 {
-    // once empty reactors are no longer supported, the create factory method should
-    // support passing a Solution object
-    auto ret = shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model, name));
-    ret->setSolution(contents);
-    return ret;
+    return shared_ptr<ReactorBase>(
+        ReactorFactory::factory()->create(model, contents, name));
 }
 
 shared_ptr<ReactorBase> newReactor3(const string& model)

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -24,32 +24,32 @@ std::mutex ReactorFactory::reactor_mutex;
 
 ReactorFactory::ReactorFactory()
 {
-    reg("Reservoir", []() { return new Reservoir(); });
-    reg("Reactor", []() { return new Reactor(); });
-    reg("ConstPressureReactor", []() { return new ConstPressureReactor(); });
-    reg("FlowReactor", []() { return new FlowReactor(); });
-    reg("IdealGasReactor", []() { return new IdealGasReactor(); });
-    reg("IdealGasConstPressureReactor", []() { return new IdealGasConstPressureReactor(); });
-    reg("ExtensibleReactor", []() { return new ReactorDelegator<Reactor>(); });
+    reg("Reservoir", [](const string& name) { return new Reservoir(name); });
+    reg("Reactor", [](const string& name) { return new Reactor(name); });
+    reg("ConstPressureReactor", [](const string& name) { return new ConstPressureReactor(name); });
+    reg("FlowReactor", [](const string& name) { return new FlowReactor(name); });
+    reg("IdealGasReactor", [](const string& name) { return new IdealGasReactor(name); });
+    reg("IdealGasConstPressureReactor", [](const string& name) { return new IdealGasConstPressureReactor(name); });
+    reg("ExtensibleReactor", [](const string& name) { return new ReactorDelegator<Reactor>(name); });
     reg("ExtensibleIdealGasReactor",
-        []() { return new ReactorDelegator<IdealGasReactor>(); });
+        [](const string& name) { return new ReactorDelegator<IdealGasReactor>(name); });
     reg("ExtensibleConstPressureReactor",
-        []() { return new ReactorDelegator<ConstPressureReactor>(); });
+        [](const string& name) { return new ReactorDelegator<ConstPressureReactor>(name); });
     reg("ExtensibleIdealGasConstPressureReactor",
-        []() { return new ReactorDelegator<IdealGasConstPressureReactor>(); });
+        [](const string& name) { return new ReactorDelegator<IdealGasConstPressureReactor>(name); });
     reg("ExtensibleMoleReactor",
-        []() { return new ReactorDelegator<MoleReactor>(); });
+        [](const string& name) { return new ReactorDelegator<MoleReactor>(name); });
     reg("ExtensibleConstPressureMoleReactor",
-        []() { return new ReactorDelegator<ConstPressureMoleReactor>(); });
+        [](const string& name) { return new ReactorDelegator<ConstPressureMoleReactor>(name); });
     reg("ExtensibleIdealGasMoleReactor",
-        []() { return new ReactorDelegator<IdealGasMoleReactor>(); });
+        [](const string& name) { return new ReactorDelegator<IdealGasMoleReactor>(name); });
     reg("ExtensibleIdealGasConstPressureMoleReactor",
-        []() { return new ReactorDelegator<IdealGasConstPressureMoleReactor>(); });
-    reg("IdealGasConstPressureMoleReactor", []() { return new
-        IdealGasConstPressureMoleReactor(); });
-    reg("IdealGasMoleReactor", []() { return new IdealGasMoleReactor(); });
-    reg("ConstPressureMoleReactor", []() { return new ConstPressureMoleReactor(); });
-    reg("MoleReactor", []() { return new MoleReactor(); });
+        [](const string& name) { return new ReactorDelegator<IdealGasConstPressureMoleReactor>(name); });
+    reg("IdealGasConstPressureMoleReactor",
+        [](const string& name) { return new IdealGasConstPressureMoleReactor(name); });
+    reg("IdealGasMoleReactor", [](const string& name) { return new IdealGasMoleReactor(name); });
+    reg("ConstPressureMoleReactor", [](const string& name) { return new ConstPressureMoleReactor(name); });
+    reg("MoleReactor", [](const string& name) { return new MoleReactor(name); });
 }
 
 ReactorFactory* ReactorFactory::factory() {
@@ -71,17 +71,16 @@ shared_ptr<ReactorBase> newReactor(const string& model)
     warn_deprecated("newReactor",
         "Creation of empty reactor objects is deprecated in Cantera 3.1 and will be \n"
         "removed thereafter; reactor contents should be provided in the constructor.");
-    return shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model));
+    return shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model, ""));
 }
 
 shared_ptr<ReactorBase> newReactor(
     const string& model, shared_ptr<Solution> contents, const string& name)
 {
     // once empty reactors are no longer supported, the create factory method should
-    // support passing a Solution object and a name
-    auto ret = shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model));
+    // support passing a Solution object
+    auto ret = shared_ptr<ReactorBase>(ReactorFactory::factory()->create(model, name));
     ret->setSolution(contents);
-    ret->setName(name);
     return ret;
 }
 

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -5,6 +5,7 @@
 
 #include "cantera/zeroD/ReactorNet.h"
 #include "cantera/zeroD/FlowDevice.h"
+#include "cantera/zeroD/ReactorSurface.h"
 #include "cantera/zeroD/Wall.h"
 #include "cantera/base/utilities.h"
 #include "cantera/base/Array.h"
@@ -304,6 +305,44 @@ void ReactorNet::addReactor(Reactor& r)
         // numerically, and use a Newton linear iterator
         m_integ->setMethod(BDF_Method);
         m_integ->setLinearSolverType("DENSE");
+    }
+    updateNames(r);
+}
+
+void ReactorNet::updateNames(Reactor& r)
+{
+    // ensure that reactors and components have reproducible names
+    r.setDefaultName(m_counts);
+
+    for (size_t i=0; i<r.nWalls(); i++) {
+        auto& w = r.wall(i);
+        w.setDefaultName(m_counts);
+        if (w.left().type() == "Reservoir") {
+            w.left().setDefaultName(m_counts);
+        }
+        if (w.right().type() == "Reservoir") {
+            w.right().setDefaultName(m_counts);
+        }
+    }
+
+    for (size_t i=0; i<r.nInlets(); i++) {
+        auto& in = r.inlet(i);
+        in.setDefaultName(m_counts);
+        if (in.in().type() == "Reservoir") {
+            in.in().setDefaultName(m_counts);
+        }
+    }
+
+    for (size_t i=0; i<r.nOutlets(); i++) {
+        auto& out = r.outlet(i);
+        out.setDefaultName(m_counts);
+        if (out.out().type() == "Reservoir") {
+            out.out().setDefaultName(m_counts);
+        }
+    }
+
+    for (size_t i=0; i<r.nSurfs(); i++) {
+        r.surface(i)->setDefaultName(m_counts);
     }
 }
 

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -12,6 +12,19 @@
 namespace Cantera
 {
 
+bool ReactorSurface::setDefaultName(map<string, int>& counts)
+{
+    if (m_defaultNameSet) {
+        return false;
+    }
+    m_defaultNameSet = true;
+    if (m_name == "(none)" || m_name == "") {
+        m_name = fmt::format("{}_{}", type(), counts[type()]);
+    }
+    counts[type()]++;
+    return true;
+}
+
 double ReactorSurface::area() const
 {
     return m_area;

--- a/src/zeroD/Wall.cpp
+++ b/src/zeroD/Wall.cpp
@@ -10,6 +10,19 @@
 namespace Cantera
 {
 
+bool WallBase::setDefaultName(map<string, int>& counts)
+{
+    if (m_defaultNameSet) {
+        return false;
+    }
+    m_defaultNameSet = true;
+    if (m_name == "(none)" || m_name == "") {
+        m_name = fmt::format("{}_{}", type(), counts[type()]);
+    }
+    counts[type()]++;
+    return true;
+}
+
 bool WallBase::install(ReactorBase& rleft, ReactorBase& rright)
 {
     // check if wall is already installed

--- a/src/zeroD/WallFactory.cpp
+++ b/src/zeroD/WallFactory.cpp
@@ -14,7 +14,7 @@ std::mutex WallFactory::wall_mutex;
 
 WallFactory::WallFactory()
 {
-    reg("Wall", []() { return new Wall(); });
+    reg("Wall", [](const string& name) { return new Wall(name); });
 }
 
 WallFactory* WallFactory::factory() {
@@ -31,13 +31,15 @@ void WallFactory::deleteFactory() {
     s_factory = 0;
 }
 
-shared_ptr<WallBase> newWall(const string& model)
+shared_ptr<WallBase> newWall(const string& model, const string& name)
 {
-    return shared_ptr<WallBase>(WallFactory::factory()->create(model));
+    return shared_ptr<WallBase>(WallFactory::factory()->create(model, name));
 }
 
 shared_ptr<WallBase> newWall3(const string& model)
 {
+    warn_deprecated("newWall3",
+        "Use newWall instead; to be removed after Cantera 3.1.");
     return newWall(model);
 }
 

--- a/test/clib/test_clib.cpp
+++ b/test/clib/test_clib.cpp
@@ -10,14 +10,11 @@ using ::testing::HasSubstr;
 
 string reportError()
 {
-    int buflen = 0;
-    char* output_buf = 0;
-    buflen = ct_getCanteraError(buflen, output_buf) + 1;
-    output_buf = new char[buflen];
-    ct_getCanteraError(buflen, output_buf);
-    string err = output_buf;
-    delete[] output_buf;
-    return err;
+    vector<char> output_buf;
+    int buflen = ct_getCanteraError(0, output_buf.data()) + 1;
+    output_buf.resize(buflen);
+    ct_getCanteraError(buflen, output_buf.data());
+    return string(output_buf.data());
 }
 
 TEST(ct, cabinet_exceptions)
@@ -62,11 +59,10 @@ TEST(ct, new_solution)
     int thermo = soln_thermo(ref);
     ASSERT_EQ(thermo_parent(thermo), ref);
 
-    char* buf = new char[buflen];
-    soln_name(ref, buflen, buf);
-    string solName = buf;
+    vector<char> buf(buflen);
+    soln_name(ref, buflen, buf.data());
+    string solName(buf.data());
     ASSERT_EQ(solName, name);
-    delete[] buf;
 }
 
 TEST(ct, soln_objects)
@@ -142,19 +138,17 @@ TEST(ct, new_interface)
 
     int ph_surf = soln_thermo(surf);
     int buflen = soln_name(ph_surf, 0, 0) + 1; // include \0
-    char* buf = new char[buflen];
-    soln_name(ph_surf, buflen, buf);
-    string solName = buf;
+    vector<char> buf(buflen);
+    soln_name(ph_surf, buflen, buf.data());
+    string solName(buf.data());
     ASSERT_EQ(solName, "Pt_surf");
-    delete[] buf;
 
     int kin_surf = soln_kinetics(surf);
     buflen = kin_getType(kin_surf, 0, 0) + 1; // include \0
-    buf = new char[buflen];
-    kin_getType(ph_surf, buflen, buf);
-    string kinType = buf;
+    buf.resize(buflen);
+    kin_getType(ph_surf, buflen, buf.data());
+    string kinType(buf.data());
     ASSERT_EQ(kinType, "surface");
-    delete[] buf;
 }
 
 TEST(ct, new_interface_auto)
@@ -170,18 +164,16 @@ TEST(ct, new_interface_auto)
     ASSERT_EQ(gas, 1);
 
     int buflen = soln_name(gas, 0, 0) + 1; // include \0
-    char* buf = new char[buflen];
-    soln_name(gas, buflen, buf);
-    string solName = buf;
+    vector<char> buf(buflen);
+    soln_name(gas, buflen, buf.data());
+    string solName(buf.data());
     ASSERT_EQ(solName, "gas");
-    delete[] buf;
 
     buflen = soln_adjacentName(surf, 0, 0, 0) + 1;
-    char* buf2 = new char[buflen];
-    soln_adjacentName(surf, 0, buflen, buf2);
-    solName = buf2;
+    buf.resize(buflen);
+    soln_adjacentName(surf, 0, buflen, buf.data());
+    solName = buf.data();
     ASSERT_EQ(solName, "gas");
-    delete[] buf2;
 }
 
 TEST(ct, thermo)

--- a/test/clib/test_ctfunc.cpp
+++ b/test/clib/test_ctfunc.cpp
@@ -27,11 +27,10 @@ TEST(ctfunc, sin)
     EXPECT_DOUBLE_EQ(func_value(dfcn, 0.5), omega * cos(omega * 0.5));
 
     int buflen = func_write(fcn, "x", 0, 0);
-    char* buf = new char[buflen];
-    func_write(fcn, "x", buflen, buf);
-    string rep = buf;
+    vector<char> buf(buflen);
+    func_write(fcn, "x", buflen, buf.data());
+    string rep(buf.data());
     ASSERT_EQ(rep, "\\sin(2.1x)");
-    delete[] buf;
 }
 
 TEST(ctfunc, cos)
@@ -123,11 +122,10 @@ TEST(ctfunc, poly)
     params = {1, 0, -2.2, 3.1};
     fcn = func_new_advanced("polynomial3", params.size(), params.data());
     int buflen = func_write(fcn, "x", 0, 0);
-    char* buf = new char[buflen];
-    func_write(fcn, "x", buflen, buf);
-    string rep = buf;
+    vector<char> buf(buflen);
+    func_write(fcn, "x", buflen, buf.data());
+    string rep(buf.data());
     ASSERT_EQ(rep, "x^3 - 2.2x + 3.1");
-    delete[] buf;
 }
 
 TEST(ctfunc, Fourier)

--- a/test/clib/test_ctonedim.cpp
+++ b/test/clib/test_ctonedim.cpp
@@ -29,11 +29,10 @@ TEST(ctonedim, freeflow)
     ASSERT_NEAR(flow1D_pressure(flow), P, 1e-5);
 
     int buflen = domain_type(flow, 0, 0);
-    char* buf = new char[buflen];
-    domain_type(flow, buflen, buf);
-    string domType = buf;
+    vector<char> buf(buflen);
+    domain_type(flow, buflen, buf.data());
+    string domType(buf.data());
     ASSERT_EQ(domType, "free-flow");
-    delete[] buf;
 }
 
 TEST(ctonedim, inlet)
@@ -43,11 +42,10 @@ TEST(ctonedim, inlet)
     ASSERT_GE(inlet, 0);
 
     int buflen = domain_type(inlet, 0, 0);
-    char* buf = new char[buflen];
-    domain_type(inlet, buflen, buf);
-    string domType = buf;
+    vector<char> buf(buflen);
+    domain_type(inlet, buflen, buf.data());
+    string domType(buf.data());
     ASSERT_EQ(domType, "inlet");
-    delete[] buf;
 }
 
 TEST(ctonedim, outlet)
@@ -57,11 +55,10 @@ TEST(ctonedim, outlet)
     ASSERT_GE(outlet, 0);
 
     int buflen = domain_type(outlet, 0, 0);
-    char* buf = new char[buflen];
-    domain_type(outlet, buflen, buf);
-    string domType = buf;
+    vector<char> buf(buflen);
+    domain_type(outlet, buflen, buf.data());
+    string domType(buf.data());
     ASSERT_EQ(domType, "outlet");
-    delete[] buf;
 }
 
 TEST(ctonedim, reacting_surface)
@@ -71,11 +68,10 @@ TEST(ctonedim, reacting_surface)
     ASSERT_GE(surf, 0);
 
     int buflen = domain_type(surf, 0, 0);
-    char* buf = new char[buflen];
-    domain_type(surf, buflen, buf);
-    string domType = buf;
+    vector<char> buf(buflen);
+    domain_type(surf, buflen, buf.data());
+    string domType(buf.data());
     ASSERT_EQ(domType, "reacting-surface");
-    delete[] buf;
 }
 
 TEST(ctonedim, catcomb)
@@ -170,11 +166,11 @@ TEST(ctonedim, freeflame)
     for (size_t i = 0; i < nsp; i++) {
         value = {yin[i], yin[i], yout[i], yout[i]};
         int buflen = thermo_getSpeciesName(ph, i, 0, 0) + 1; // include \0
-        char* buf = new char[buflen];
-        thermo_getSpeciesName(ph, i, buflen, buf);
-        string name = buf;
+        vector<char> buf(buflen);
+        thermo_getSpeciesName(ph, i, buflen, buf.data());
+        string name(buf.data());
         ASSERT_EQ(name, gas->speciesName(i));
-        comp = static_cast<int>(domain_componentIndex(flow, buf));
+        comp = static_cast<int>(domain_componentIndex(flow, buf.data()));
         sim1D_setProfile(flame, dom, comp, 4, locs.data(), 4, value.data());
     }
 

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -13,6 +13,15 @@ TEST(ctreactor, reactor_soln)
     int sol = soln_newSolution("gri30.yaml", "gri30", "none");
     int reactor = reactor_new("IdealGasReactor", sol, "test");
     ASSERT_EQ(reactor, 0);
+
+    int ret = reactor_setName(reactor, "spam");
+    ASSERT_EQ(ret, 0);
+    int buflen = reactor_name(reactor, 0, 0);
+    char* buf = new char[buflen];
+    reactor_name(reactor, buflen, buf);
+    string rName = buf;
+    ASSERT_EQ(rName, "spam");
+    delete[] buf;
 }
 
 vector<double> T_ctreactor = {

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -17,11 +17,10 @@ TEST(ctreactor, reactor_soln)
     int ret = reactor_setName(reactor, "spam");
     ASSERT_EQ(ret, 0);
     int buflen = reactor_name(reactor, 0, 0);
-    char* buf = new char[buflen];
-    reactor_name(reactor, buflen, buf);
-    string rName = buf;
+    vector<char> buf(buflen);
+    reactor_name(reactor, buflen, buf.data());
+    string rName(buf.data());
     ASSERT_EQ(rName, "spam");
-    delete[] buf;
 }
 
 vector<double> T_ctreactor = {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR seeks to implement reproducible (and unique) reactor, flow device and wall names in the C++ layer, which was previously only handled by the Python API. Rather than auto-creating unique names based on the number of certain object types created within a Cantera session, this PR switches to an approach that creates names dependent on `ReactorNet` objects, which guarantees that reproducible auto-generated names are attached to various `zeroD` objects.

- Ensure that reactors, walls and connectors have names that are stored in C++ layer
- Names are generated automatically if none are provided
- Names should be reproducible for a given `ReactorNet`, which is important for serialization (e.g. Cantera/enhancements#206)
- Update API's for Python and MATLAB
- ~Remove deprecated functions from `clib` (in anticipation of Cantera/enhancements#211)~

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1764

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
