### PR TITLE
Support Sundials 6.0 and 6.1

### DIFF
--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -611,7 +611,7 @@ AnyMap CVodesIntegrator::solverStats() const
                   "supported with sundials versions less than 4.");
     #endif
 
-    #if SUNDIALS_VERSION_MAJOR >= 6
+    #if SUNDIALS_VERSION_MAJOR >= 7 || (SUNDIALS_VERSION_MAJOR == 6 && SUNDIALS_VERSION_MINOR >= 2)
         long int stepSolveFails = 0;
         CVodeGetNumStepSolveFails(m_cvode_mem, &stepSolveFails);
         stats["step_solve_fails"] = stepSolveFails;


### PR DESCRIPTION
CVodeGetNumStepSolveFails is only defined in SUNDIALS 6.2 and up. Since the previous version check had a typo, this code was never included.

Closes #1771

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
