### PR TITLE
Fix SolutionArray YAML overwrite / order components

### DIFF
--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -989,9 +989,12 @@ void SolutionArray::writeHeader(AnyMap& root, const string& name,
                                 const string& desc, bool overwrite)
 {
     AnyMap& data = openField(root, name);
-    if (!data.empty() && !overwrite) {
-        throw CanteraError("SolutionArray::writeHeader",
-            "Field name '{}' exists; use 'overwrite' argument to overwrite.", name);
+    if (!data.empty()) {
+        if (!overwrite) {
+            throw CanteraError("SolutionArray::writeHeader",
+                "Field name '{}' exists; use 'overwrite' argument to overwrite.", name);
+        }
+        data.clear();
     }
     data.update(preamble(desc));
 }

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -14,6 +14,7 @@
 #include "cantera/thermo/SurfPhase.h"
 #include "cantera/base/utilities.h"
 #include <boost/algorithm/string.hpp>
+#include <boost/range/adaptor/reversed.hpp>
 #include <fstream>
 #include <sstream>
 
@@ -1275,6 +1276,23 @@ void SolutionArray::writeEntry(AnyMap& root, const string& name, const string& s
         }
         data["components"] = componentNames();
     }
+
+    // add ordering rules
+    vector<vector<string>> ordering = {};
+    if (data.hasKey("components")) {
+        auto components = data["components"].as<vector<string>>();
+        for (auto component : boost::adaptors::reverse(components)) {
+            ordering.push_back({"head", component});
+        }
+    }
+
+    const vector<string> header = { "type", "size", "basis", "components" };
+    for (auto entry : boost::adaptors::reverse(header)) {
+        ordering.push_back({"head", entry});
+    }
+
+    data["__type__"] = "SolutionArray";
+    AnyMap::addOrderingRules("SolutionArray", ordering);
 
     // If this is not replacing an existing solution, put it at the end
     if (!preexisting) {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix issue where YAML `SolutionArray` output entries were not correctly overwritten 
- Order YAML output based on components

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1772

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

`SolutionArray` output respects `component` order (previously the order could be scrambled, especially when overwriting):
```YAML
arr:
  generator: Cantera SolutionArray
  cantera-version: 3.1.0a3
  git-commit: "'9a730d862'"
  date: Wed Aug 14 20:13:21 2024
  data:
    size: 3
    basis: mass
    components: [T, D, H2, H, O, O2, OH, H2O, HO2, H2O2, AR, N2, spam]
    T: [3185.196897445414, 3185.196897445414, 3185.196897445414]
    D: [0.1383648238149952, 0.1383648238149952, 0.1383648238149952]
    H2: [7.461973701196079e-03, 7.461973701196079e-03, 7.461973701196079e-03]
    H: [2.754568580688943e-03, 2.754568580688943e-03, 2.754568580688943e-03]
    O: [0.05418042113328690, 0.05418042113328690, 0.05418042113328690]
    O2: [0.3131633165600913, 0.3131633165600913, 0.3131633165600913]
    OH: [0.1300522902586164, 0.1300522902586164, 0.1300522902586164]
    H2O: [0.4921274938532937, 0.4921274938532937, 0.4921274938532937]
    HO2: [2.473953814465240e-04, 2.473953814465240e-04, 2.473953814465240e-04]
    H2O2: [1.254053138021190e-05, 1.254053138021190e-05, 1.254053138021190e-05]
    AR: [0.0, 0.0, 0.0]
    N2: [0.0, 0.0, 0.0]
    spam: [eggs, eggs, eggs]
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
