### PR TITLE
Implement local AnyMap ordering rules

### DIFF
--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -698,8 +698,24 @@ public:
     static bool addOrderingRules(const string& objectType,
                                  const vector<vector<string>>& specs);
 
+    //! Set local rules for element order when outputting AnyMap objects to YAML.
+    //! Rules follow the same logic as those implemented by addOrderingRules(), and
+    //! override those global rules.
+    void setOrderingRules(const vector<vector<string>>& specs);
+
     //! Remove the specified file from the input cache if it is present
     static void clearCachedFile(const string& filename);
+
+protected:
+    //! Fields that should appear first in YAML output when overriding global rules.
+    const vector<string>& headFields() const {
+        return m_headFields;
+    }
+
+    //! Fields that should appear last in YAML output when overriding global rules.
+    const vector<string>& tailFields() const {
+        return m_tailFields;
+    }
 
 private:
     //! The stored data
@@ -723,6 +739,12 @@ private:
     //! YAML. Keys in this map are matched to `__type__` keys in AnyMap
     //! objects, and values are a list of field names.
     static std::unordered_map<string, vector<string>> s_tailFields;
+
+    //! Fields that should appear first in YAML output when overriding global rules.
+    vector<string> m_headFields = {};
+
+    //! Fields that should appear last in YAML output when overriding global rules.
+    vector<string> m_tailFields = {};
 
     friend class AnyValue;
     friend YAML::Emitter& YAML::operator<<(YAML::Emitter& out, const AnyMap& rhs);

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -1285,14 +1285,11 @@ void SolutionArray::writeEntry(AnyMap& root, const string& name, const string& s
             ordering.push_back({"head", component});
         }
     }
-
-    const vector<string> header = { "type", "size", "basis", "components" };
+    const vector<string> header = {"type", "size", "api-shape", "basis", "components"};
     for (auto entry : boost::adaptors::reverse(header)) {
         ordering.push_back({"head", entry});
     }
-
-    data["__type__"] = "SolutionArray";
-    AnyMap::addOrderingRules("SolutionArray", ordering);
+    data.setOrderingRules(ordering);
 
     // If this is not replacing an existing solution, put it at the end
     if (!preexisting) {

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -488,3 +488,29 @@ TEST(AnyMap, definedKeyOrdering)
     EXPECT_LT(loc["one"], loc["half"]);
     EXPECT_LT(loc["zero"], loc["half"]);
 }
+
+TEST(AnyMap, localKeyOrdering)
+{
+    AnyMap m = AnyMap::fromYamlString("{zero: 1, half: 2}");
+    m["one"] = 1;
+    m["two"] = 2;
+    m["three"] = 3;
+    m["four"] = 4;
+    m["__type__"] = "Test";
+
+    m.setOrderingRules({
+        {"head", "three"},
+        {"tail", "one"}
+    });
+
+    string result = m.toYamlString();
+    std::unordered_map<string, size_t> loc;
+    for (auto& [key, value] : m) {
+        loc[key] = result.find(key);
+    }
+    EXPECT_LT(loc["three"], loc["one"]);
+    EXPECT_LT(loc["three"], loc["half"]);
+    EXPECT_LT(loc["four"], loc["one"]);
+    EXPECT_LT(loc["one"], loc["half"]);
+    EXPECT_LT(loc["zero"], loc["half"]);
+}


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Allow ordering rules defined for individual `AnyMap` instances. 
- 'Local' rules override global rules.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1776

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
