### PR TITLE
Simplify CLib's (Shared)Cabinet

### DIFF
--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -181,13 +181,6 @@ public:
     }
 
     /**
-     * Return a reference to object n.
-     */
-    static M& item(int n) {
-        return *at(n);
-    }
-
-    /**
      * Return a reference to object n, cast to a reference of the specified type.
      */
     template <class T>

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -16,39 +16,39 @@
 namespace Cantera {
 
 /**
- * Template for classes to hold pointers to objects. The SharedCabinet<M> class
+ * Template for classes to hold pointers to objects. The Cabinet<M> class
  * maintains a list of pointers to objects of class M (or of subclasses of M). These
  * classes are used by the 'clib' interface library functions that provide access to
  * %Cantera C++ objects from outside C++. To refer to an existing object, the library
  * functions take an integer argument that specifies the location in the pointer list
- * maintained by the appropriate SharedCabinet<M> instance. The pointer is retrieved
+ * maintained by the appropriate Cabinet<M> instance. The pointer is retrieved
  * from the list by the interface function, the desired method is invoked, and the
  * result returned to the non-C++ calling procedure. By storing the pointers in a
- * SharedCabinet, there is no need to encode them in a string or integer and pass
+ * Cabinet, there is no need to encode them in a string or integer and pass
  * them out to the non-C++ calling routine, as some other interfacing schemes do.
  *
- * The SharedCabinet<M> class can be used to store pointers to arbitrary objects. In
+ * The Cabinet<M> class can be used to store pointers to arbitrary objects. In
  * most cases, class M is a base class with virtual methods, and the base class versions
  * of the methods throw CanteraError exceptions. The subclasses overload these methods
- * to implement the desired functionality. Class SharedCabinet<M> stores only the
+ * to implement the desired functionality. Class Cabinet<M> stores only the
  * base-class pointers, but since the methods are virtual, the method of the appropriate
  * subclass will be invoked.
  *
- * As the SharedCabinet<M> class uses smart pointers, it is set up to allow deleting
+ * As the Cabinet<M> class uses smart pointers, it is set up to allow deleting
  * objects in an inherently safe manner. Method 'del' does the following. If called
  * with n >= 0, it dereferences the object. The original object is only destroyed if the
  * reference is not shared by other objects. In this way, if it is deleted again
  * inadvertently nothing happens, and if an attempt is made to reference the object by
  * its index number, a standard exception is thrown.
  *
- * The SharedCabinet<M> class is implemented as a singleton. The constructor is never
- * explicitly called; instead, static function SharedCabinet<M>::SharedCabinet() is
+ * The Cabinet<M> class is implemented as a singleton. The constructor is never
+ * explicitly called; instead, static function Cabinet<M>::Cabinet() is
  * called to obtain a pointer to the instance. This function calls the constructor on
  * the first call and stores the pointer to this instance. Subsequent calls simply
  * return the already-created pointer.
  */
 template<class M>
-class SharedCabinet
+class Cabinet
 {
 public:
     typedef vector<shared_ptr<M>>& dataRef;
@@ -57,7 +57,7 @@ public:
     /**
      * Constructor.
      */
-    SharedCabinet() {}
+    Cabinet() {}
 
     /**
      * Add a new object. The index of the object is returned.
@@ -113,7 +113,7 @@ public:
         try {
             return add(*data[n]);  // do not copy parent to avoid ambiguous data
         } catch (std::exception& err) {
-            throw CanteraError("SharedCabinet::newCopy", err.what());
+            throw CanteraError("Cabinet::newCopy", err.what());
         }
     }
 
@@ -125,7 +125,7 @@ public:
         if (n >= 0 && n < len(data)) {
             lookupRef lookup = getLookup();
             if (!lookup.count(data[n].get())) {
-                throw CanteraError("SharedCabinet::del",
+                throw CanteraError("Cabinet::del",
                     "Lookup table does not contain reference to object.");
             }
             if (lookup[data[n].get()].size() == 1) {
@@ -137,7 +137,7 @@ public:
             }
             data[n].reset();
         } else {
-            throw CanteraError("SharedCabinet::del",
+            throw CanteraError("Cabinet::del",
                 "Attempt made to delete a non-existing object.");
         }
     }
@@ -148,7 +148,7 @@ public:
     static int parent(int n) {
         auto& parents = getParents();
         if (n < 0 || n >= len(parents)) {
-            throw CanteraError("SharedCabinet::parent", "Index {} out of range.", n);
+            throw CanteraError("Cabinet::parent", "Index {} out of range.", n);
         }
         return parents[n];
     }
@@ -159,10 +159,10 @@ public:
     static shared_ptr<M>& at(int n) {
         dataRef data = getData();
         if (n < 0 || n >= len(data)) {
-            throw CanteraError("SharedCabinet::at", "Index {} out of range.", n);
+            throw CanteraError("Cabinet::at", "Index {} out of range.", n);
         }
         if (!data[n]) {
-            throw CanteraError("SharedCabinet::at",
+            throw CanteraError("Cabinet::at",
                 "Object with index {} has been deleted.", n);
         }
         return data[n];
@@ -177,12 +177,12 @@ public:
         if (obj) {
             return obj;
         }
-        throw CanteraError("SharedCabinet::as", "Item is not of the correct type.");
+        throw CanteraError("Cabinet::as", "Item is not of the correct type.");
     }
 
     /**
-     * Return the index in the SharedCabinet to the specified object, or -1 if the
-     * object is not in the SharedCabinet. If multiple indices reference the same
+     * Return the index in the Cabinet to the specified object, or -1 if the
+     * object is not in the Cabinet. If multiple indices reference the same
      * object, the index of the last one added is returned.
      */
     static int index(const M& obj, int parent=-1) {
@@ -203,36 +203,36 @@ public:
 private:
     /**
      * Static function that returns a pointer to the data member of
-     * the singleton SharedCabinet<M> instance. All member functions should
+     * the singleton Cabinet<M> instance. All member functions should
      * access the data through this function.
      */
     static dataRef getData() {
         if (s_storage == nullptr) {
-            s_storage = new SharedCabinet<M>();
+            s_storage = new Cabinet<M>();
         }
         return s_storage->m_table;
     }
 
     /**
      * Static function that returns a pointer to the list of parent object handles of
-     * the singleton SharedCabinet<M> instance. All member functions should
+     * the singleton Cabinet<M> instance. All member functions should
      * access the data through this function.
      */
     static vector<int>& getParents() {
         if (s_storage == nullptr) {
-            s_storage = new SharedCabinet<M>();
+            s_storage = new Cabinet<M>();
         }
         return s_storage->m_parents;
     }
 
     /**
      * Static function that returns a pointer to the reverse lookup table of
-     * the singleton SharedCabinet<M> instance. All member functions should
+     * the singleton Cabinet<M> instance. All member functions should
      * access the lookup table through this function.
      */
     static lookupRef getLookup() {
         if (s_storage == nullptr) {
-            s_storage = new SharedCabinet<M>();
+            s_storage = new Cabinet<M>();
         }
         return s_storage->m_lookup;
     }
@@ -240,7 +240,7 @@ private:
     /**
      * Pointer to the single instance of this class.
      */
-    static SharedCabinet<M>* s_storage;
+    static Cabinet<M>* s_storage;
 
     /**
      * Reverse lookup table for the single instance of this class.

--- a/src/clib/Cabinet.h
+++ b/src/clib/Cabinet.h
@@ -181,18 +181,6 @@ public:
     }
 
     /**
-     * Return a reference to object n, cast to a reference of the specified type.
-     */
-    template <class T>
-    static T& get(int n) {
-        auto obj = std::dynamic_pointer_cast<T>(at(n));
-        if (obj) {
-            return *obj;
-        }
-        throw CanteraError("SharedCabinet::get", "Item is not of the correct type.");
-    }
-
-    /**
      * Return the index in the SharedCabinet to the specified object, or -1 if the
      * object is not in the SharedCabinet. If multiple indices reference the same
      * object, the index of the last one added is returned.

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1075,7 +1075,7 @@ extern "C" {
     double thermo_vaporFraction(int n)
     {
         try {
-            return ThermoCabinet::get<PureFluidPhase>(n).vaporFraction();
+            return ThermoCabinet::as<PureFluidPhase>(n)->vaporFraction();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1102,7 +1102,7 @@ extern "C" {
     int thermo_setState_Psat(int n, double p, double x)
     {
         try {
-            ThermoCabinet::get<PureFluidPhase>(n).setState_Psat(p, x);
+            ThermoCabinet::as<PureFluidPhase>(n)->setState_Psat(p, x);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1112,7 +1112,7 @@ extern "C" {
     int thermo_setState_Tsat(int n, double t, double x)
     {
         try {
-            ThermoCabinet::get<PureFluidPhase>(n).setState_Tsat(t, x);
+            ThermoCabinet::as<PureFluidPhase>(n)->setState_Tsat(t, x);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1459,7 +1459,7 @@ extern "C" {
     int kin_advanceCoverages(int n, double tstep)
     {
         try {
-            KineticsCabinet::get<InterfaceKinetics>(n).advanceCoverages(tstep);
+            KineticsCabinet::as<InterfaceKinetics>(n)->advanceCoverages(tstep);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -28,10 +28,10 @@
 
 using namespace Cantera;
 
-typedef SharedCabinet<ThermoPhase> ThermoCabinet;
-typedef SharedCabinet<Kinetics> KineticsCabinet;
-typedef SharedCabinet<Transport> TransportCabinet;
-typedef SharedCabinet<Solution> SolutionCabinet;
+typedef Cabinet<ThermoPhase> ThermoCabinet;
+typedef Cabinet<Kinetics> KineticsCabinet;
+typedef Cabinet<Transport> TransportCabinet;
+typedef Cabinet<Solution> SolutionCabinet;
 
 template<> ThermoCabinet* ThermoCabinet::s_storage = 0;
 template<> KineticsCabinet* KineticsCabinet::s_storage = 0;

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -141,7 +141,7 @@ extern "C" {
     int soln_name(int n, int buflen, char* buf)
     {
         try {
-            string name = SolutionCabinet::item(n).name();
+            string name = SolutionCabinet::at(n)->name();
             copyString(name, buf, buflen);
             return int(name.size());
         } catch (...) {
@@ -248,7 +248,7 @@ extern "C" {
     size_t thermo_nElements(int n)
     {
         try {
-            return ThermoCabinet::item(n).nElements();
+            return ThermoCabinet::at(n)->nElements();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -257,7 +257,7 @@ extern "C" {
     size_t thermo_nSpecies(int n)
     {
         try {
-            return ThermoCabinet::item(n).nSpecies();
+            return ThermoCabinet::at(n)->nSpecies();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -266,7 +266,7 @@ extern "C" {
     double thermo_temperature(int n)
     {
         try {
-            return ThermoCabinet::item(n).temperature();
+            return ThermoCabinet::at(n)->temperature();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -275,7 +275,7 @@ extern "C" {
     int thermo_setTemperature(int n, double t)
     {
         try {
-            ThermoCabinet::item(n).setTemperature(t);
+            ThermoCabinet::at(n)->setTemperature(t);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -285,7 +285,7 @@ extern "C" {
     double thermo_density(int n)
     {
         try {
-            return ThermoCabinet::item(n).density();
+            return ThermoCabinet::at(n)->density();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -294,7 +294,7 @@ extern "C" {
     int thermo_setDensity(int n, double rho)
     {
         try {
-            ThermoCabinet::item(n).setDensity(rho);
+            ThermoCabinet::at(n)->setDensity(rho);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -304,7 +304,7 @@ extern "C" {
     double thermo_molarDensity(int n)
     {
         try {
-            return ThermoCabinet::item(n).molarDensity();
+            return ThermoCabinet::at(n)->molarDensity();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -313,7 +313,7 @@ extern "C" {
     double thermo_meanMolecularWeight(int n)
     {
         try {
-            return ThermoCabinet::item(n).meanMolecularWeight();
+            return ThermoCabinet::at(n)->meanMolecularWeight();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -322,7 +322,7 @@ extern "C" {
     size_t thermo_elementIndex(int n, const char* nm)
     {
         try {
-             size_t k = ThermoCabinet::item(n).elementIndex(nm);
+             size_t k = ThermoCabinet::at(n)->elementIndex(nm);
              if (k == npos) {
                 throw CanteraError("thermo_elementIndex",
                                    "No such element {}.", nm);
@@ -336,7 +336,7 @@ extern "C" {
     size_t thermo_speciesIndex(int n, const char* nm)
     {
         try {
-             size_t k = ThermoCabinet::item(n).speciesIndex(nm);
+             size_t k = ThermoCabinet::at(n)->speciesIndex(nm);
              if (k == npos) {
                 throw CanteraError("thermo_speciesIndex",
                                    "No such species {}.", nm);
@@ -350,9 +350,9 @@ extern "C" {
     int thermo_getMoleFractions(int n, size_t lenx, double* x)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.checkSpeciesArraySize(lenx);
-            p.getMoleFractions(x);
+            auto& p = ThermoCabinet::at(n);
+            p->checkSpeciesArraySize(lenx);
+            p->getMoleFractions(x);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -362,7 +362,7 @@ extern "C" {
     double thermo_moleFraction(int n, size_t k)
     {
         try {
-            return ThermoCabinet::item(n).moleFraction(k);
+            return ThermoCabinet::at(n)->moleFraction(k);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -371,9 +371,9 @@ extern "C" {
     int thermo_getMassFractions(int n, size_t leny, double* y)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.checkSpeciesArraySize(leny);
-            p.getMassFractions(y);
+            auto& p = ThermoCabinet::at(n);
+            p->checkSpeciesArraySize(leny);
+            p->getMassFractions(y);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -383,7 +383,7 @@ extern "C" {
     double thermo_massFraction(int n, size_t k)
     {
         try {
-            return ThermoCabinet::item(n).massFraction(k);
+            return ThermoCabinet::at(n)->massFraction(k);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -392,12 +392,12 @@ extern "C" {
     int thermo_setMoleFractions(int n, size_t lenx, double* x, int norm)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.checkSpeciesArraySize(lenx);
+            auto& p = ThermoCabinet::at(n);
+            p->checkSpeciesArraySize(lenx);
             if (norm) {
-                p.setMoleFractions(x);
+                p->setMoleFractions(x);
             } else {
-                p.setMoleFractions_NoNorm(x);
+                p->setMoleFractions_NoNorm(x);
             }
             return 0;
         } catch (...) {
@@ -408,8 +408,8 @@ extern "C" {
     int thermo_setMoleFractionsByName(int n, const char* x)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.setMoleFractionsByName(x);
+            auto& p = ThermoCabinet::at(n);
+            p->setMoleFractionsByName(x);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -420,12 +420,12 @@ extern "C" {
                                double* y, int norm)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.checkSpeciesArraySize(leny);
+            auto& p = ThermoCabinet::at(n);
+            p->checkSpeciesArraySize(leny);
             if (norm) {
-                p.setMassFractions(y);
+                p->setMassFractions(y);
             } else {
-                p.setMassFractions_NoNorm(y);
+                p->setMassFractions_NoNorm(y);
             }
             return 0;
         } catch (...) {
@@ -436,8 +436,8 @@ extern "C" {
     int thermo_setMassFractionsByName(int n, const char* y)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.setMassFractionsByName(y);
+            auto& p = ThermoCabinet::at(n);
+            p->setMassFractionsByName(y);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -447,9 +447,9 @@ extern "C" {
     int thermo_getAtomicWeights(int n, size_t lenm, double* atw)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.checkElementArraySize(lenm);
-            const vector<double>& wt = p.atomicWeights();
+            auto& p = ThermoCabinet::at(n);
+            p->checkElementArraySize(lenm);
+            const vector<double>& wt = p->atomicWeights();
             copy(wt.begin(), wt.end(), atw);
             return 0;
         } catch (...) {
@@ -460,9 +460,9 @@ extern "C" {
     int thermo_getMolecularWeights(int n, size_t lenm, double* mw)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.checkSpeciesArraySize(lenm);
-            const vector<double>& wt = p.molecularWeights();
+            auto& p = ThermoCabinet::at(n);
+            p->checkSpeciesArraySize(lenm);
+            const vector<double>& wt = p->molecularWeights();
             copy(wt.begin(), wt.end(), mw);
             return 0;
         } catch (...) {
@@ -473,9 +473,9 @@ extern "C" {
     int thermo_getCharges(int n, size_t lenm, double* sc)
     {
         try {
-            ThermoPhase& p = ThermoCabinet::item(n);
-            p.checkSpeciesArraySize(lenm);
-            p.getCharges(sc);
+            auto& p = ThermoCabinet::at(n);
+            p->checkSpeciesArraySize(lenm);
+            p->getCharges(sc);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -485,7 +485,7 @@ extern "C" {
     int thermo_getName(int n, size_t lennm, char* nm)
     {
         try {
-            return static_cast<int>(copyString(ThermoCabinet::item(n).name(), nm, lennm));
+            return static_cast<int>(copyString(ThermoCabinet::at(n)->name(), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -494,7 +494,7 @@ extern "C" {
     int thermo_setName(int n, const char* nm)
     {
         try {
-            ThermoCabinet::item(n).setName(nm);
+            ThermoCabinet::at(n)->setName(nm);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -504,7 +504,7 @@ extern "C" {
     int thermo_getSpeciesName(int n, size_t k, size_t lennm, char* nm)
     {
         try {
-            return static_cast<int>(copyString(ThermoCabinet::item(n).speciesName(k), nm, lennm));
+            return static_cast<int>(copyString(ThermoCabinet::at(n)->speciesName(k), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -513,7 +513,7 @@ extern "C" {
     int thermo_getElementName(int n, size_t m, size_t lennm, char* nm)
     {
         try {
-            return static_cast<int>(copyString(ThermoCabinet::item(n).elementName(m), nm, lennm));
+            return static_cast<int>(copyString(ThermoCabinet::at(n)->elementName(m), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -522,7 +522,7 @@ extern "C" {
     double thermo_nAtoms(int n, size_t k, size_t m)
     {
         try {
-            return ThermoCabinet::item(n).nAtoms(k,m);
+            return ThermoCabinet::at(n)->nAtoms(k,m);
         } catch (...) {
             return handleAllExceptions(ERR, ERR);
         }
@@ -531,7 +531,7 @@ extern "C" {
     int thermo_addElement(int n, const char* name, double weight)
     {
         try {
-            ThermoCabinet::item(n).addElement(name, weight);
+            ThermoCabinet::at(n)->addElement(name, weight);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -543,7 +543,7 @@ extern "C" {
     int thermo_getEosType(int n, size_t leneos, char* eos)
     {
         try {
-            return static_cast<int>(copyString(ThermoCabinet::item(n).type(), eos, leneos));
+            return static_cast<int>(copyString(ThermoCabinet::at(n)->type(), eos, leneos));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -552,7 +552,7 @@ extern "C" {
     double thermo_enthalpy_mole(int n)
     {
         try {
-            return ThermoCabinet::item(n).enthalpy_mole();
+            return ThermoCabinet::at(n)->enthalpy_mole();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -561,7 +561,7 @@ extern "C" {
     double thermo_intEnergy_mole(int n)
     {
         try {
-            return ThermoCabinet::item(n).intEnergy_mole();
+            return ThermoCabinet::at(n)->intEnergy_mole();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -570,7 +570,7 @@ extern "C" {
     double thermo_entropy_mole(int n)
     {
         try {
-            return ThermoCabinet::item(n).entropy_mole();
+            return ThermoCabinet::at(n)->entropy_mole();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -579,7 +579,7 @@ extern "C" {
     double thermo_gibbs_mole(int n)
     {
         try {
-            return ThermoCabinet::item(n).gibbs_mole();
+            return ThermoCabinet::at(n)->gibbs_mole();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -588,7 +588,7 @@ extern "C" {
     double thermo_cp_mole(int n)
     {
         try {
-            return ThermoCabinet::item(n).cp_mole();
+            return ThermoCabinet::at(n)->cp_mole();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -597,7 +597,7 @@ extern "C" {
     double thermo_cv_mole(int n)
     {
         try {
-            return ThermoCabinet::item(n).cv_mole();
+            return ThermoCabinet::at(n)->cv_mole();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -606,7 +606,7 @@ extern "C" {
     double thermo_pressure(int n)
     {
         try {
-            return ThermoCabinet::item(n).pressure();
+            return ThermoCabinet::at(n)->pressure();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -615,7 +615,7 @@ extern "C" {
     double thermo_enthalpy_mass(int n)
     {
         try {
-            return ThermoCabinet::item(n).enthalpy_mass();
+            return ThermoCabinet::at(n)->enthalpy_mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -624,7 +624,7 @@ extern "C" {
     double thermo_intEnergy_mass(int n)
     {
         try {
-            return ThermoCabinet::item(n).intEnergy_mass();
+            return ThermoCabinet::at(n)->intEnergy_mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -633,7 +633,7 @@ extern "C" {
     double thermo_entropy_mass(int n)
     {
         try {
-            return ThermoCabinet::item(n).entropy_mass();
+            return ThermoCabinet::at(n)->entropy_mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -642,7 +642,7 @@ extern "C" {
     double thermo_gibbs_mass(int n)
     {
         try {
-            return ThermoCabinet::item(n).gibbs_mass();
+            return ThermoCabinet::at(n)->gibbs_mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -651,7 +651,7 @@ extern "C" {
     double thermo_cp_mass(int n)
     {
         try {
-            return ThermoCabinet::item(n).cp_mass();
+            return ThermoCabinet::at(n)->cp_mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -660,7 +660,7 @@ extern "C" {
     double thermo_cv_mass(int n)
     {
         try {
-            return ThermoCabinet::item(n).cv_mass();
+            return ThermoCabinet::at(n)->cv_mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -669,7 +669,7 @@ extern "C" {
     double thermo_electricPotential(int n)
     {
         try {
-            return ThermoCabinet::item(n).electricPotential();
+            return ThermoCabinet::at(n)->electricPotential();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -678,9 +678,9 @@ extern "C" {
     int thermo_chemPotentials(int n, size_t lenm, double* murt)
     {
         try {
-            ThermoPhase& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getChemPotentials(murt);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getChemPotentials(murt);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -690,9 +690,9 @@ extern "C" {
     int thermo_electrochemPotentials(int n, size_t lenm, double* emu)
     {
         try {
-            ThermoPhase& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getElectrochemPotentials(emu);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getElectrochemPotentials(emu);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -704,7 +704,7 @@ extern "C" {
         try {
             if (p < 0.0) throw CanteraError("thermo_setPressure",
                                                 "pressure cannot be negative");
-            ThermoCabinet::item(n).setPressure(p);
+            ThermoCabinet::at(n)->setPressure(p);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -714,7 +714,7 @@ extern "C" {
     int thermo_set_TP(int n, double* vals)
     {
         try{
-            ThermoCabinet::item(n).setState_TP(vals[0], vals[1]);
+            ThermoCabinet::at(n)->setState_TP(vals[0], vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -724,7 +724,7 @@ extern "C" {
     int thermo_set_TD(int n, double* vals)
     {
         try{
-            ThermoCabinet::item(n).setState_TD(vals[0], vals[1]);
+            ThermoCabinet::at(n)->setState_TD(vals[0], vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -734,7 +734,7 @@ extern "C" {
     int thermo_set_DP(int n, double* vals)
     {
         try{
-            ThermoCabinet::item(n).setState_DP(vals[0], vals[1]);
+            ThermoCabinet::at(n)->setState_DP(vals[0], vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -748,8 +748,8 @@ extern "C" {
                 throw CanteraError("thermo_set_HP",
                                    "pressure cannot be negative");
             }
-            ThermoCabinet::item(n).setState_HP(vals[0],vals[1]);
-            if (ThermoCabinet::item(n).temperature() < 0.0) {
+            ThermoCabinet::at(n)->setState_HP(vals[0],vals[1]);
+            if (ThermoCabinet::at(n)->temperature() < 0.0) {
                 throw CanteraError("thermo_set_HP",
                                    "temperature cannot be negative");
             }
@@ -766,8 +766,8 @@ extern "C" {
                 throw CanteraError("thermo_set_UV",
                                    "specific volume cannot be negative");
             }
-            ThermoCabinet::item(n).setState_UV(vals[0],vals[1]);
-            if (ThermoCabinet::item(n).temperature() < 0.0) {
+            ThermoCabinet::at(n)->setState_UV(vals[0],vals[1]);
+            if (ThermoCabinet::at(n)->temperature() < 0.0) {
                 throw CanteraError("thermo_set_UV",
                                    "temperature cannot be negative");
             }
@@ -780,7 +780,7 @@ extern "C" {
     int thermo_set_SV(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_SV(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_SV(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -790,7 +790,7 @@ extern "C" {
     int thermo_set_SP(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_SP(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_SP(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -800,7 +800,7 @@ extern "C" {
     int thermo_set_ST(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_ST(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_ST(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -810,7 +810,7 @@ extern "C" {
     int thermo_set_TV(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_TV(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_TV(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -820,7 +820,7 @@ extern "C" {
     int thermo_set_PV(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_PV(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_PV(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -830,7 +830,7 @@ extern "C" {
     int thermo_set_UP(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_UP(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_UP(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -840,7 +840,7 @@ extern "C" {
     int thermo_set_VH(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_VH(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_VH(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -850,7 +850,7 @@ extern "C" {
     int thermo_set_TH(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_TH(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_TH(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -860,7 +860,7 @@ extern "C" {
     int thermo_set_SH(int n, double* vals)
     {
         try {
-            ThermoCabinet::item(n).setState_SH(vals[0],vals[1]);
+            ThermoCabinet::at(n)->setState_SH(vals[0],vals[1]);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -871,8 +871,8 @@ extern "C" {
                            double rtol, int maxsteps, int maxiter, int loglevel)
     {
         try {
-            ThermoCabinet::item(n).equilibrate(XY, solver, rtol, maxsteps,
-                                               maxiter, 0, loglevel);
+            ThermoCabinet::at(n)->equilibrate(XY, solver, rtol, maxsteps,
+                                              maxiter, 0, loglevel);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -882,7 +882,7 @@ extern "C" {
     double thermo_refPressure(int n)
     {
         try {
-            return ThermoCabinet::item(n).refPressure();
+            return ThermoCabinet::at(n)->refPressure();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -891,12 +891,12 @@ extern "C" {
     double thermo_minTemp(int n, int k)
     {
         try {
-            ThermoPhase& ph = ThermoCabinet::item(n);
+            auto& ph = ThermoCabinet::at(n);
             if (k != -1) {
-                ph.checkSpeciesIndex(k);
-                return ph.minTemp(k);
+                ph->checkSpeciesIndex(k);
+                return ph->minTemp(k);
             } else {
-                return ph.minTemp();
+                return ph->minTemp();
             }
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
@@ -906,12 +906,12 @@ extern "C" {
     double thermo_maxTemp(int n, int k)
     {
         try {
-            ThermoPhase& ph = ThermoCabinet::item(n);
+            auto& ph = ThermoCabinet::at(n);
             if (k != -1) {
-                ph.checkSpeciesIndex(k);
-                return ph.maxTemp(k);
+                ph->checkSpeciesIndex(k);
+                return ph->maxTemp(k);
             } else {
-                return ph.maxTemp();
+                return ph->maxTemp();
             }
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
@@ -922,9 +922,9 @@ extern "C" {
     int thermo_getEnthalpies_RT(int n, size_t lenm, double* h_rt)
     {
         try {
-            ThermoPhase& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getEnthalpy_RT_ref(h_rt);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getEnthalpy_RT_ref(h_rt);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -934,9 +934,9 @@ extern "C" {
     int thermo_getEntropies_R(int n, size_t lenm, double* s_r)
     {
         try {
-            ThermoPhase& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getEntropy_R_ref(s_r);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getEntropy_R_ref(s_r);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -946,9 +946,9 @@ extern "C" {
     int thermo_getCp_R(int n, size_t lenm, double* cp_r)
     {
         try {
-            ThermoPhase& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getCp_R_ref(cp_r);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getCp_R_ref(cp_r);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -958,7 +958,7 @@ extern "C" {
     int thermo_setElectricPotential(int n, double v)
     {
         try {
-            ThermoCabinet::item(n).setElectricPotential(v);
+            ThermoCabinet::at(n)->setElectricPotential(v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -968,9 +968,9 @@ extern "C" {
     int thermo_getPartialMolarEnthalpies(int n, size_t lenm, double* pmh)
     {
         try {
-            auto& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getPartialMolarEnthalpies(pmh);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getPartialMolarEnthalpies(pmh);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -980,9 +980,9 @@ extern "C" {
     int thermo_getPartialMolarEntropies(int n, size_t lenm, double* pms)
     {
         try {
-            auto& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getPartialMolarEntropies(pms);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getPartialMolarEntropies(pms);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -992,9 +992,9 @@ extern "C" {
     int thermo_getPartialMolarIntEnergies(int n, size_t lenm, double* pmu)
     {
         try {
-            auto& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getPartialMolarIntEnergies(pmu);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getPartialMolarIntEnergies(pmu);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1004,9 +1004,9 @@ extern "C" {
     int thermo_getPartialMolarCp(int n, size_t lenm, double* pmcp)
     {
         try {
-            auto& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getPartialMolarCp(pmcp);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getPartialMolarCp(pmcp);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1016,9 +1016,9 @@ extern "C" {
     int thermo_getPartialMolarVolumes(int n, size_t lenm, double* pmv)
     {
         try {
-            auto& thrm = ThermoCabinet::item(n);
-            thrm.checkSpeciesArraySize(lenm);
-            thrm.getPartialMolarVolumes(pmv);
+            auto& thrm = ThermoCabinet::at(n);
+            thrm->checkSpeciesArraySize(lenm);
+            thrm->getPartialMolarVolumes(pmv);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1028,7 +1028,7 @@ extern "C" {
     double thermo_thermalExpansionCoeff(int n)
     {
         try {
-            return ThermoCabinet::item(n).thermalExpansionCoeff();
+            return ThermoCabinet::at(n)->thermalExpansionCoeff();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1037,7 +1037,7 @@ extern "C" {
     double thermo_isothermalCompressibility(int n)
     {
         try {
-            return ThermoCabinet::item(n).isothermalCompressibility();
+            return ThermoCabinet::at(n)->isothermalCompressibility();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1048,7 +1048,7 @@ extern "C" {
     double thermo_critTemperature(int n)
     {
         try {
-            return ThermoCabinet::item(n).critTemperature();
+            return ThermoCabinet::at(n)->critTemperature();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1057,7 +1057,7 @@ extern "C" {
     double thermo_critPressure(int n)
     {
         try {
-            return ThermoCabinet::item(n).critPressure();
+            return ThermoCabinet::at(n)->critPressure();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1066,7 +1066,7 @@ extern "C" {
     double thermo_critDensity(int n)
     {
         try {
-            return ThermoCabinet::item(n).critDensity();
+            return ThermoCabinet::at(n)->critDensity();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1084,7 +1084,7 @@ extern "C" {
     double thermo_satTemperature(int n, double p)
     {
         try {
-            return ThermoCabinet::item(n).satTemperature(p);
+            return ThermoCabinet::at(n)->satTemperature(p);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1093,7 +1093,7 @@ extern "C" {
     double thermo_satPressure(int n, double t)
     {
         try {
-            return ThermoCabinet::item(n).satPressure(t);
+            return ThermoCabinet::at(n)->satPressure(t);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1124,7 +1124,7 @@ extern "C" {
     int kin_getType(int n, size_t lennm, char* nm)
     {
         try {
-            return static_cast<int>(copyString(KineticsCabinet::item(n).kineticsType(), nm, lennm));
+            return static_cast<int>(copyString(KineticsCabinet::at(n)->kineticsType(), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1133,7 +1133,7 @@ extern "C" {
     size_t kin_start(int n, int p)
     {
         try {
-            return KineticsCabinet::item(n).kineticsSpeciesIndex(0,p);
+            return KineticsCabinet::at(n)->kineticsSpeciesIndex(0,p);
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -1142,7 +1142,7 @@ extern "C" {
     size_t kin_speciesIndex(int n, const char* nm)
     {
         try {
-            return KineticsCabinet::item(n).kineticsSpeciesIndex(nm);
+            return KineticsCabinet::at(n)->kineticsSpeciesIndex(nm);
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -1153,7 +1153,7 @@ extern "C" {
     size_t kin_nSpecies(int n)
     {
         try {
-            return KineticsCabinet::item(n).nTotalSpecies();
+            return KineticsCabinet::at(n)->nTotalSpecies();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -1162,7 +1162,7 @@ extern "C" {
     size_t kin_nReactions(int n)
     {
         try {
-            return KineticsCabinet::item(n).nReactions();
+            return KineticsCabinet::at(n)->nReactions();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -1171,7 +1171,7 @@ extern "C" {
     size_t kin_nPhases(int n)
     {
         try {
-            return KineticsCabinet::item(n).nPhases();
+            return KineticsCabinet::at(n)->nPhases();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -1180,7 +1180,7 @@ extern "C" {
     size_t kin_phaseIndex(int n, const char* ph)
     {
         try {
-            size_t k = KineticsCabinet::item(n).phaseIndex(ph);
+            size_t k = KineticsCabinet::at(n)->phaseIndex(ph);
             if (k == npos) {
                 throw CanteraError("kin_phaseIndex",
                                    "No such phase {}.", ph);
@@ -1194,7 +1194,7 @@ extern "C" {
     size_t kin_reactionPhaseIndex(int n)
     {
         try {
-            return KineticsCabinet::item(n).reactionPhaseIndex();
+            return KineticsCabinet::at(n)->reactionPhaseIndex();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -1203,10 +1203,10 @@ extern "C" {
     double kin_reactantStoichCoeff(int n, int k, int i)
     {
         try {
-            Kinetics& kin = KineticsCabinet::item(n);
-            kin.checkSpeciesIndex(k);
-            kin.checkReactionIndex(i);
-            return kin.reactantStoichCoeff(k,i);
+            auto& kin = KineticsCabinet::at(n);
+            kin->checkSpeciesIndex(k);
+            kin->checkReactionIndex(i);
+            return kin->reactantStoichCoeff(k,i);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1215,10 +1215,10 @@ extern "C" {
     double kin_productStoichCoeff(int n, int k, int i)
     {
         try {
-            Kinetics& kin = KineticsCabinet::item(n);
-            kin.checkSpeciesIndex(k);
-            kin.checkReactionIndex(i);
-            return kin.productStoichCoeff(k,i);
+            auto& kin = KineticsCabinet::at(n);
+            kin->checkSpeciesIndex(k);
+            kin->checkReactionIndex(i);
+            return kin->productStoichCoeff(k,i);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1227,9 +1227,9 @@ extern "C" {
     int kin_getReactionType(int n, int i, size_t len, char* buf)
     {
         try {
-            Kinetics& kin = KineticsCabinet::item(n);
-            kin.checkReactionIndex(i);
-            return static_cast<int>(copyString(kin.reaction(i)->type(), buf, len));
+            auto& kin = KineticsCabinet::at(n);
+            kin->checkReactionIndex(i);
+            return static_cast<int>(copyString(kin->reaction(i)->type(), buf, len));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1238,9 +1238,9 @@ extern "C" {
     int kin_getFwdRatesOfProgress(int n, size_t len, double* fwdROP)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkReactionArraySize(len);
-            k.getFwdRatesOfProgress(fwdROP);
+            auto& k = KineticsCabinet::at(n);
+            k->checkReactionArraySize(len);
+            k->getFwdRatesOfProgress(fwdROP);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1250,9 +1250,9 @@ extern "C" {
     int kin_getRevRatesOfProgress(int n, size_t len, double* revROP)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkReactionArraySize(len);
-            k.getRevRatesOfProgress(revROP);
+            auto& k = KineticsCabinet::at(n);
+            k->checkReactionArraySize(len);
+            k->getRevRatesOfProgress(revROP);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1262,9 +1262,9 @@ extern "C" {
     int kin_isReversible(int n, int i)
     {
         try {
-            Kinetics& kin = KineticsCabinet::item(n);
-            kin.checkReactionIndex(i);
-            return (int) kin.isReversible(i);
+            auto& kin = KineticsCabinet::at(n);
+            kin->checkReactionIndex(i);
+            return (int) kin->isReversible(i);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1273,9 +1273,9 @@ extern "C" {
     int kin_getNetRatesOfProgress(int n, size_t len, double* netROP)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkReactionArraySize(len);
-            k.getNetRatesOfProgress(netROP);
+            auto& k = KineticsCabinet::at(n);
+            k->checkReactionArraySize(len);
+            k->getNetRatesOfProgress(netROP);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1285,9 +1285,9 @@ extern "C" {
     int kin_getFwdRateConstants(int n, size_t len, double* kfwd)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkReactionArraySize(len);
-            k.getFwdRateConstants(kfwd);
+            auto& k = KineticsCabinet::at(n);
+            k->checkReactionArraySize(len);
+            k->getFwdRateConstants(kfwd);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1297,9 +1297,9 @@ extern "C" {
     int kin_getRevRateConstants(int n, int doIrreversible, size_t len, double* krev)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkReactionArraySize(len);
-            k.getRevRateConstants(krev, doIrreversible != 0);
+            auto& k = KineticsCabinet::at(n);
+            k->checkReactionArraySize(len);
+            k->getRevRateConstants(krev, doIrreversible != 0);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1309,26 +1309,26 @@ extern "C" {
     int kin_getDelta(int n, int job, size_t len, double* delta)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkReactionArraySize(len);
+            auto& k = KineticsCabinet::at(n);
+            k->checkReactionArraySize(len);
             switch (job) {
             case 0:
-                k.getDeltaEnthalpy(delta);
+                k->getDeltaEnthalpy(delta);
                 break;
             case 1:
-                k.getDeltaGibbs(delta);
+                k->getDeltaGibbs(delta);
                 break;
             case 2:
-                k.getDeltaEntropy(delta);
+                k->getDeltaEntropy(delta);
                 break;
             case 3:
-                k.getDeltaSSEnthalpy(delta);
+                k->getDeltaSSEnthalpy(delta);
                 break;
             case 4:
-                k.getDeltaSSGibbs(delta);
+                k->getDeltaSSGibbs(delta);
                 break;
             case 5:
-                k.getDeltaSSEntropy(delta);
+                k->getDeltaSSEntropy(delta);
                 break;
             default:
                 return ERR;
@@ -1342,9 +1342,9 @@ extern "C" {
     int kin_getCreationRates(int n, size_t len, double* cdot)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkSpeciesArraySize(len);
-            k.getCreationRates(cdot);
+            auto& k = KineticsCabinet::at(n);
+            k->checkSpeciesArraySize(len);
+            k->getCreationRates(cdot);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1354,9 +1354,9 @@ extern "C" {
     int kin_getDestructionRates(int n, size_t len, double* ddot)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkSpeciesArraySize(len);
-            k.getDestructionRates(ddot);
+            auto& k = KineticsCabinet::at(n);
+            k->checkSpeciesArraySize(len);
+            k->getDestructionRates(ddot);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1366,9 +1366,9 @@ extern "C" {
     int kin_getNetProductionRates(int n, size_t len, double* wdot)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkSpeciesArraySize(len);
-            k.getNetProductionRates(wdot);
+            auto& k = KineticsCabinet::at(n);
+            k->checkSpeciesArraySize(len);
+            k->getNetProductionRates(wdot);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1379,12 +1379,12 @@ extern "C" {
     {
         try {
             // @todo This function only works for single phase kinetics
-            Kinetics& k = KineticsCabinet::item(n);
-            ThermoPhase& p = k.thermo();
+            auto& k = KineticsCabinet::at(n);
+            ThermoPhase& p = k->thermo();
             size_t nsp = p.nSpecies();
-            k.checkSpeciesArraySize(len);
-            k.checkSpeciesArraySize(nsp);
-            k.getNetProductionRates(ydot);
+            k->checkSpeciesArraySize(len);
+            k->checkSpeciesArraySize(nsp);
+            k->getNetProductionRates(ydot);
             double rho_inv = 1.0 / p.density();
             for (size_t k = 0; k < nsp; k++) {
                 ydot[k] *= p.molecularWeight(k) * rho_inv;
@@ -1398,9 +1398,9 @@ extern "C" {
     double kin_multiplier(int n, int i)
     {
         try {
-            Kinetics& kin = KineticsCabinet::item(n);
-            kin.checkReactionIndex(i);
-            return kin.multiplier(i);
+            auto& kin = KineticsCabinet::at(n);
+            kin->checkReactionIndex(i);
+            return kin->multiplier(i);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -1409,9 +1409,9 @@ extern "C" {
     size_t kin_phase(int n, size_t i)
     {
         try {
-            Kinetics& kin = KineticsCabinet::item(n);
-            kin.checkPhaseIndex(i);
-            return ThermoCabinet::index(kin.thermo(i));
+            auto& kin = KineticsCabinet::at(n);
+            kin->checkPhaseIndex(i);
+            return ThermoCabinet::index(kin->thermo(i));
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -1420,9 +1420,9 @@ extern "C" {
     int kin_getEquilibriumConstants(int n, size_t len, double* kc)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkReactionArraySize(len);
-            k.getEquilibriumConstants(kc);
+            auto& k = KineticsCabinet::at(n);
+            k->checkReactionArraySize(len);
+            k->getEquilibriumConstants(kc);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1432,9 +1432,9 @@ extern "C" {
     int kin_getReactionString(int n, int i, int len, char* buf)
     {
         try {
-            Kinetics& k = KineticsCabinet::item(n);
-            k.checkReactionIndex(i);
-            return static_cast<int>(copyString(k.reaction(i)->equation(), buf, len));
+            auto& k = KineticsCabinet::at(n);
+            k->checkReactionIndex(i);
+            return static_cast<int>(copyString(k->reaction(i)->equation(), buf, len));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1444,9 +1444,9 @@ extern "C" {
     {
         try {
             if (v >= 0.0) {
-                Kinetics& kin = KineticsCabinet::item(n);
-                kin.checkReactionIndex(i);
-                kin.setMultiplier(i,v);
+                auto& kin = KineticsCabinet::at(n);
+                kin->checkReactionIndex(i);
+                kin->setMultiplier(i,v);
                 return 0;
             } else {
                 return ERR;
@@ -1472,7 +1472,7 @@ extern "C" {
     {
         try {
             return static_cast<int>(
-                copyString(TransportCabinet::item(i).transportModel(), nm, lennm));
+                copyString(TransportCabinet::at(i)->transportModel(), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1481,7 +1481,7 @@ extern "C" {
     double trans_viscosity(int n)
     {
         try {
-            return TransportCabinet::item(n).viscosity();
+            return TransportCabinet::at(n)->viscosity();
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1490,7 +1490,7 @@ extern "C" {
     double trans_electricalConductivity(int n)
     {
         try {
-            return TransportCabinet::item(n).electricalConductivity();
+            return TransportCabinet::at(n)->electricalConductivity();
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1499,7 +1499,7 @@ extern "C" {
     double trans_thermalConductivity(int n)
     {
         try {
-            return TransportCabinet::item(n).thermalConductivity();
+            return TransportCabinet::at(n)->thermalConductivity();
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -1508,9 +1508,9 @@ extern "C" {
     int trans_getThermalDiffCoeffs(int n, int ldt, double* dt)
     {
         try {
-            Transport& tr = TransportCabinet::item(n);
-            tr.checkSpeciesArraySize(ldt);
-            tr.getThermalDiffCoeffs(dt);
+            auto& tr = TransportCabinet::at(n);
+            tr->checkSpeciesArraySize(ldt);
+            tr->getThermalDiffCoeffs(dt);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1520,9 +1520,9 @@ extern "C" {
     int trans_getMixDiffCoeffs(int n, int ld, double* d)
     {
         try {
-            Transport& tr = TransportCabinet::item(n);
-            tr.checkSpeciesArraySize(ld);
-            tr.getMixDiffCoeffs(d);
+            auto& tr = TransportCabinet::at(n);
+            tr->checkSpeciesArraySize(ld);
+            tr->getMixDiffCoeffs(d);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1533,9 +1533,9 @@ extern "C" {
     {
         try {
             // @todo length of d should be passed for bounds checking
-            Transport& tr = TransportCabinet::item(n);
-            tr.checkSpeciesArraySize(ld);
-            tr.getBinaryDiffCoeffs(ld,d);
+            auto& tr = TransportCabinet::at(n);
+            tr->checkSpeciesArraySize(ld);
+            tr->getBinaryDiffCoeffs(ld,d);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1546,9 +1546,9 @@ extern "C" {
     {
         try {
             // @todo length of d should be passed for bounds checking
-            Transport& tr = TransportCabinet::item(n);
-            tr.checkSpeciesArraySize(ld);
-            tr.getMultiDiffCoeffs(ld,d);
+            auto& tr = TransportCabinet::at(n);
+            tr->checkSpeciesArraySize(ld);
+            tr->getMultiDiffCoeffs(ld,d);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1559,7 +1559,7 @@ extern "C" {
                              const double* state2, double delta, double* fluxes)
     {
         try {
-            TransportCabinet::item(n).getMolarFluxes(state1, state2, delta, fluxes);
+            TransportCabinet::at(n)->getMolarFluxes(state1, state2, delta, fluxes);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1570,7 +1570,7 @@ extern "C" {
                             const double* state2, double delta, double* fluxes)
     {
         try {
-            TransportCabinet::item(n).getMassFluxes(state1, state2, delta, fluxes);
+            TransportCabinet::at(n)->getMassFluxes(state1, state2, delta, fluxes);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1584,7 +1584,7 @@ extern "C" {
         try {
             bool stherm = (show_thermo != 0);
             return static_cast<int>(
-                copyString(ThermoCabinet::item(nth).report(stherm, threshold),
+                copyString(ThermoCabinet::at(nth)->report(stherm, threshold),
                 buf, ibuf));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -1595,7 +1595,7 @@ extern "C" {
     {
         try {
             bool stherm = (show_thermo != 0);
-            writelog(ThermoCabinet::item(nth).report(stherm, threshold));
+            writelog(ThermoCabinet::at(nth)->report(stherm, threshold));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -15,8 +15,8 @@
 
 using namespace Cantera;
 
-typedef SharedCabinet<Func1> FuncCabinet;
-// Assign storage to the SharedCabinet<Func1> static member
+typedef Cabinet<Func1> FuncCabinet;
+// Assign storage to the Cabinet<Func1> static member
 template<> FuncCabinet* FuncCabinet::s_storage = 0;
 
 extern "C" {

--- a/src/clib/ctfunc.cpp
+++ b/src/clib/ctfunc.cpp
@@ -133,7 +133,7 @@ extern "C" {
     int func_type(int i, size_t lennm, char* nm)
     {
         try {
-            return static_cast<int>(copyString(FuncCabinet::item(i).type(), nm, lennm));
+            return static_cast<int>(copyString(FuncCabinet::at(i)->type(), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -142,7 +142,7 @@ extern "C" {
     double func_value(int i, double t)
     {
         try {
-            return FuncCabinet::item(i).eval(t);
+            return FuncCabinet::at(i)->eval(t);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -169,7 +169,7 @@ extern "C" {
     int func_write(int i, const char* arg, size_t len, char* buf)
     {
         try {
-            return static_cast<int>(copyString(FuncCabinet::item(i).write(arg), buf, len));
+            return static_cast<int>(copyString(FuncCabinet::at(i)->write(arg), buf, len));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -14,8 +14,8 @@
 
 using namespace Cantera;
 
-typedef SharedCabinet<MultiPhase> mixCabinet;
-typedef SharedCabinet<ThermoPhase> ThermoCabinet;
+typedef Cabinet<MultiPhase> mixCabinet;
+typedef Cabinet<ThermoPhase> ThermoCabinet;
 
 template<> mixCabinet* mixCabinet::s_storage = 0;
 template<> ThermoCabinet* ThermoCabinet::s_storage; // defined in ct.cpp

--- a/src/clib/ctmultiphase.cpp
+++ b/src/clib/ctmultiphase.cpp
@@ -54,7 +54,7 @@ extern "C" {
     int mix_addPhase(int i, int j, double moles)
     {
         try {
-            mixCabinet::item(i).addPhase(&ThermoCabinet::item(j), moles);
+            mixCabinet::at(i)->addPhase(ThermoCabinet::at(j).get(), moles);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -64,7 +64,7 @@ extern "C" {
     int mix_init(int i)
     {
         try {
-            mixCabinet::item(i).init();
+            mixCabinet::at(i)->init();
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -74,7 +74,7 @@ extern "C" {
     int mix_updatePhases(int i)
     {
         try {
-            mixCabinet::item(i).updatePhases();
+            mixCabinet::at(i)->updatePhases();
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -84,7 +84,7 @@ extern "C" {
     size_t mix_nElements(int i)
     {
         try {
-            return mixCabinet::item(i).nElements();
+            return mixCabinet::at(i)->nElements();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -93,7 +93,7 @@ extern "C" {
     size_t mix_elementIndex(int i, const char* name)
     {
         try {
-            return mixCabinet::item(i).elementIndex(name);
+            return mixCabinet::at(i)->elementIndex(name);
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -102,7 +102,7 @@ extern "C" {
     size_t mix_nSpecies(int i)
     {
         try {
-            return mixCabinet::item(i).nSpecies();
+            return mixCabinet::at(i)->nSpecies();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -111,10 +111,10 @@ extern "C" {
     size_t mix_speciesIndex(int i, int k, int p)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkPhaseIndex(p);
-            mix.checkSpeciesIndex(k);
-            return mix.speciesIndex(k, p);
+            auto& mix = mixCabinet::at(i);
+            mix->checkPhaseIndex(p);
+            mix->checkSpeciesIndex(k);
+            return mix->speciesIndex(k, p);
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -123,10 +123,10 @@ extern "C" {
     double mix_nAtoms(int i, int k, int m)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkSpeciesIndex(k);
-            mix.checkElementIndex(m);
-            return mixCabinet::item(i).nAtoms(k,m);
+            auto& mix = mixCabinet::at(i);
+            mix->checkSpeciesIndex(k);
+            mix->checkElementIndex(m);
+            return mixCabinet::at(i)->nAtoms(k,m);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -135,7 +135,7 @@ extern "C" {
     size_t mix_nPhases(int i)
     {
         try {
-            return mixCabinet::item(i).nPhases();
+            return mixCabinet::at(i)->nPhases();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -144,9 +144,9 @@ extern "C" {
     double mix_phaseMoles(int i, int n)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkPhaseIndex(n);
-            return mix.phaseMoles(n);
+            auto& mix = mixCabinet::at(i);
+            mix->checkPhaseIndex(n);
+            return mix->phaseMoles(n);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -155,13 +155,13 @@ extern "C" {
     int mix_setPhaseMoles(int i, int n, double v)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkPhaseIndex(n);
+            auto& mix = mixCabinet::at(i);
+            mix->checkPhaseIndex(n);
             if (v < 0.0) {
                 throw CanteraError("mix_setPhaseMoles",
                                    "Mole number must be non-negative.");
             }
-            mix.setPhaseMoles(n, v);
+            mix->setPhaseMoles(n, v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -171,9 +171,9 @@ extern "C" {
     int mix_setMoles(int i, size_t nlen, const double* n)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkSpeciesArraySize(nlen);
-            mix.setMoles(n);
+            auto& mix = mixCabinet::at(i);
+            mix->checkSpeciesArraySize(nlen);
+            mix->setMoles(n);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -184,7 +184,7 @@ extern "C" {
     int mix_setMolesByName(int i, const char* n)
     {
         try {
-            mixCabinet::item(i).setMolesByName(n);
+            mixCabinet::at(i)->setMolesByName(n);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -198,7 +198,7 @@ extern "C" {
                 throw CanteraError("mix_setTemperature",
                                    "Temperature must be positive.");
             }
-            mixCabinet::item(i).setTemperature(t);
+            mixCabinet::at(i)->setTemperature(t);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -208,7 +208,7 @@ extern "C" {
     double mix_temperature(int i)
     {
         try {
-            return mixCabinet::item(i).temperature();
+            return mixCabinet::at(i)->temperature();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -217,7 +217,7 @@ extern "C" {
     double mix_minTemp(int i)
     {
         try {
-            return mixCabinet::item(i).minTemp();
+            return mixCabinet::at(i)->minTemp();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -226,7 +226,7 @@ extern "C" {
     double mix_maxTemp(int i)
     {
         try {
-            return mixCabinet::item(i).maxTemp();
+            return mixCabinet::at(i)->maxTemp();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -235,7 +235,7 @@ extern "C" {
     double mix_charge(int i)
     {
         try {
-            return mixCabinet::item(i).charge();
+            return mixCabinet::at(i)->charge();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -244,9 +244,9 @@ extern "C" {
     double mix_phaseCharge(int i, int p)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkPhaseIndex(p);
-            return mix.phaseCharge(p);
+            auto& mix = mixCabinet::at(i);
+            mix->checkPhaseIndex(p);
+            return mix->phaseCharge(p);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -259,7 +259,7 @@ extern "C" {
                 throw CanteraError("mix_setPressure",
                                    "Pressure must be positive.");
             }
-            mixCabinet::item(i).setPressure(p);
+            mixCabinet::at(i)->setPressure(p);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -269,7 +269,7 @@ extern "C" {
     double mix_pressure(int i)
     {
         try {
-            return mixCabinet::item(i).pressure();
+            return mixCabinet::at(i)->pressure();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -278,9 +278,9 @@ extern "C" {
     double mix_speciesMoles(int i, int k)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkSpeciesIndex(k);
-            return mix.speciesMoles(k);
+            auto& mix = mixCabinet::at(i);
+            mix->checkSpeciesIndex(k);
+            return mix->speciesMoles(k);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -289,9 +289,9 @@ extern "C" {
     double mix_elementMoles(int i, int m)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkElementIndex(m);
-            return mix.elementMoles(m);
+            auto& mix = mixCabinet::at(i);
+            mix->checkElementIndex(m);
+            return mix->elementMoles(m);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -301,7 +301,7 @@ extern "C" {
                            int maxsteps, int maxiter, int loglevel)
     {
         try {
-            mixCabinet::item(i).equilibrate(XY, "auto", rtol, maxsteps, maxiter,
+            mixCabinet::at(i)->equilibrate(XY, "auto", rtol, maxsteps, maxiter,
                                             0, loglevel);
             return 0;
         } catch (...) {
@@ -312,9 +312,9 @@ extern "C" {
     int mix_getChemPotentials(int i, size_t lenmu, double* mu)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkSpeciesArraySize(lenmu);
-            mix.getChemPotentials(mu);
+            auto& mix = mixCabinet::at(i);
+            mix->checkSpeciesArraySize(lenmu);
+            mix->getChemPotentials(mu);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -324,7 +324,7 @@ extern "C" {
     double mix_enthalpy(int i)
     {
         try {
-            return mixCabinet::item(i).enthalpy();
+            return mixCabinet::at(i)->enthalpy();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -333,7 +333,7 @@ extern "C" {
     double mix_entropy(int i)
     {
         try {
-            return mixCabinet::item(i).entropy();
+            return mixCabinet::at(i)->entropy();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -342,7 +342,7 @@ extern "C" {
     double mix_gibbs(int i)
     {
         try {
-            return mixCabinet::item(i).gibbs();
+            return mixCabinet::at(i)->gibbs();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -351,7 +351,7 @@ extern "C" {
     double mix_cp(int i)
     {
         try {
-            return mixCabinet::item(i).cp();
+            return mixCabinet::at(i)->cp();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -360,7 +360,7 @@ extern "C" {
     double mix_volume(int i)
     {
         try {
-            return mixCabinet::item(i).volume();
+            return mixCabinet::at(i)->volume();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -369,9 +369,9 @@ extern "C" {
     size_t mix_speciesPhaseIndex(int i, int k)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkSpeciesIndex(k);
-            return mix.speciesPhaseIndex(k);
+            auto& mix = mixCabinet::at(i);
+            mix->checkSpeciesIndex(k);
+            return mix->speciesPhaseIndex(k);
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -380,9 +380,9 @@ extern "C" {
     double mix_moleFraction(int i, int k)
     {
         try {
-            MultiPhase& mix = mixCabinet::item(i);
-            mix.checkSpeciesIndex(k);
-            return mix.moleFraction(k);
+            auto& mix = mixCabinet::at(i);
+            mix->checkSpeciesIndex(k);
+            return mix->moleFraction(k);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -20,15 +20,15 @@
 using namespace std;
 using namespace Cantera;
 
-typedef SharedCabinet<Sim1D> SimCabinet;
-typedef SharedCabinet<Domain1D> DomainCabinet;
+typedef Cabinet<Sim1D> SimCabinet;
+typedef Cabinet<Domain1D> DomainCabinet;
 template<> SimCabinet* SimCabinet::s_storage = 0;
 template<> DomainCabinet* DomainCabinet::s_storage = 0;
 
-typedef SharedCabinet<ThermoPhase> ThermoCabinet;
-typedef SharedCabinet<Kinetics> KineticsCabinet;
-typedef SharedCabinet<Transport> TransportCabinet;
-typedef SharedCabinet<Solution> SolutionCabinet;
+typedef Cabinet<ThermoPhase> ThermoCabinet;
+typedef Cabinet<Kinetics> KineticsCabinet;
+typedef Cabinet<Transport> TransportCabinet;
+typedef Cabinet<Solution> SolutionCabinet;
 template<> ThermoCabinet* ThermoCabinet::s_storage; // defined in ct.cpp
 template<> KineticsCabinet* KineticsCabinet::s_storage; // defined in ct.cpp
 template<> TransportCabinet* TransportCabinet::s_storage; // defined in ct.cpp

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -50,7 +50,7 @@ extern "C" {
     int domain_new(const char* type, int i, const char* id)
     {
         try {
-            auto soln = SolutionCabinet::at(i);
+            auto& soln = SolutionCabinet::at(i);
             auto d = newDomain(type, soln, id);
             return DomainCabinet::add(d);
         } catch (...) {
@@ -71,7 +71,7 @@ extern "C" {
     int domain_type(int i, size_t lennm, char* nm)
     {
         try {
-            return static_cast<int>(copyString(DomainCabinet::item(i).type(), nm, lennm));
+            return static_cast<int>(copyString(DomainCabinet::at(i)->type(), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -80,7 +80,7 @@ extern "C" {
     size_t domain_index(int i)
     {
         try {
-            return DomainCabinet::item(i).domainIndex();
+            return DomainCabinet::at(i)->domainIndex();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -89,7 +89,7 @@ extern "C" {
     size_t domain_nComponents(int i)
     {
         try {
-            return DomainCabinet::item(i).nComponents();
+            return DomainCabinet::at(i)->nComponents();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -98,7 +98,7 @@ extern "C" {
     size_t domain_nPoints(int i)
     {
         try {
-            return DomainCabinet::item(i).nPoints();
+            return DomainCabinet::at(i)->nPoints();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -107,9 +107,9 @@ extern "C" {
     int domain_componentName(int i, int n, int sz, char* buf)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkComponentIndex(n);
-            return static_cast<int>(copyString(dom.componentName(n), buf, sz));
+            auto& dom = DomainCabinet::at(i);
+            dom->checkComponentIndex(n);
+            return static_cast<int>(copyString(dom->componentName(n), buf, sz));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -118,7 +118,7 @@ extern "C" {
     size_t domain_componentIndex(int i, const char* name)
     {
         try {
-            return DomainCabinet::item(i).componentIndex(name);
+            return DomainCabinet::at(i)->componentIndex(name);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -127,9 +127,9 @@ extern "C" {
     double domain_grid(int i, int n)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkPointIndex(n);
-            return dom.grid(n);
+            auto& dom = DomainCabinet::at(i);
+            dom->checkPointIndex(n);
+            return dom->grid(n);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -138,9 +138,9 @@ extern "C" {
     int domain_setBounds(int i, int n, double lower, double upper)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkComponentIndex(n);
-            dom.setBounds(n, lower, upper);
+            auto& dom = DomainCabinet::at(i);
+            dom->checkComponentIndex(n);
+            dom->setBounds(n, lower, upper);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -150,9 +150,9 @@ extern "C" {
     double domain_upperBound(int i, int n)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkComponentIndex(n);
-            return dom.upperBound(n);
+            auto& dom = DomainCabinet::at(i);
+            dom->checkComponentIndex(n);
+            return dom->upperBound(n);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -161,9 +161,9 @@ extern "C" {
     double domain_lowerBound(int i, int n)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkComponentIndex(n);
-            return dom.lowerBound(n);
+            auto& dom = DomainCabinet::at(i);
+            dom->checkComponentIndex(n);
+            return dom->lowerBound(n);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -173,9 +173,9 @@ extern "C" {
                                    double atol)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkComponentIndex(n);
-            dom.setSteadyTolerances(rtol, atol, n);
+            auto& dom = DomainCabinet::at(i);
+            dom->checkComponentIndex(n);
+            dom->setSteadyTolerances(rtol, atol, n);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -186,9 +186,9 @@ extern "C" {
                                       double atol)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkComponentIndex(n);
-            dom.setTransientTolerances(rtol, atol, n);
+            auto& dom = DomainCabinet::at(i);
+            dom->checkComponentIndex(n);
+            dom->setTransientTolerances(rtol, atol, n);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -198,9 +198,9 @@ extern "C" {
     double domain_rtol(int i, int n)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkComponentIndex(n);
-            return dom.rtol(n);
+            auto& dom = DomainCabinet::at(i);
+            dom->checkComponentIndex(n);
+            return dom->rtol(n);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -209,9 +209,9 @@ extern "C" {
     double domain_atol(int i, int n)
     {
         try {
-            Domain1D& dom = DomainCabinet::item(i);
-            dom.checkComponentIndex(n);
-            return dom.atol(n);
+            auto& dom = DomainCabinet::at(i);
+            dom->checkComponentIndex(n);
+            return dom->atol(n);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -220,7 +220,7 @@ extern "C" {
     int domain_setupGrid(int i, size_t npts, const double* grid)
     {
         try {
-            DomainCabinet::item(i).setupGrid(npts, grid);
+            DomainCabinet::at(i)->setupGrid(npts, grid);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -230,7 +230,7 @@ extern "C" {
     int domain_setID(int i, const char* id)
     {
         try {
-            DomainCabinet::item(i).setID(id);
+            DomainCabinet::at(i)->setID(id);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -328,7 +328,7 @@ extern "C" {
     int flow1D_new(int iph, int ikin, int itr, int itype)
     {
         try {
-            auto ph = ThermoCabinet::at(iph);
+            auto& ph = ThermoCabinet::at(iph);
             auto x = make_shared<Flow1D>(ph, ph->nSpecies(), 2);
             if (itype == 1) {
                 x->setAxisymmetricFlow();
@@ -443,7 +443,7 @@ extern "C" {
     int sim1D_setValue(int i, int dom, int comp, int localPoint, double value)
     {
         try {
-            SimCabinet::item(i).setValue(dom, comp, localPoint, value);
+            SimCabinet::at(i)->setValue(dom, comp, localPoint, value);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -454,15 +454,15 @@ extern "C" {
                          size_t nv, const double* v)
     {
         try {
-            Sim1D& sim = SimCabinet::item(i);
-            sim.checkDomainIndex(dom);
-            sim.domain(dom).checkComponentIndex(comp);
+            auto& sim = SimCabinet::at(i);
+            sim->checkDomainIndex(dom);
+            sim->domain(dom).checkComponentIndex(comp);
             vector<double> vv, pv;
             for (size_t n = 0; n < np; n++) {
                 vv.push_back(v[n]);
                 pv.push_back(pos[n]);
             }
-            sim.setProfile(dom, comp, pv, vv);
+            sim->setProfile(dom, comp, pv, vv);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -472,10 +472,10 @@ extern "C" {
     int sim1D_setFlatProfile(int i, int dom, int comp, double v)
     {
         try {
-            Sim1D& sim = SimCabinet::item(i);
-            sim.checkDomainIndex(dom);
-            sim.domain(dom).checkComponentIndex(comp);
-            sim.setFlatProfile(dom, comp, v);
+            auto& sim = SimCabinet::at(i);
+            sim->checkDomainIndex(dom);
+            sim->domain(dom).checkComponentIndex(comp);
+            sim->setFlatProfile(dom, comp, v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -487,10 +487,10 @@ extern "C" {
         try {
             string fn = string(fname);
             if (fn == "-") {
-                SimCabinet::item(i).show();
+                SimCabinet::at(i)->show();
             } else {
                 ofstream fout(fname);
-                SimCabinet::item(i).show(fout);
+                SimCabinet::at(i)->show(fout);
             }
             return 0;
         } catch (...) {
@@ -501,7 +501,7 @@ extern "C" {
     int sim1D_setTimeStep(int i, double stepsize, size_t ns, const int* nsteps)
     {
         try {
-            SimCabinet::item(i).setTimeStep(stepsize, ns, nsteps);
+            SimCabinet::at(i)->setTimeStep(stepsize, ns, nsteps);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -511,7 +511,7 @@ extern "C" {
     int sim1D_getInitialSoln(int i)
     {
         try {
-            SimCabinet::item(i).getInitialSoln();
+            SimCabinet::at(i)->getInitialSoln();
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -522,7 +522,7 @@ extern "C" {
     {
         try {
             bool r = (refine_grid == 0 ? false : true);
-            SimCabinet::item(i).solve(loglevel, r);
+            SimCabinet::at(i)->solve(loglevel, r);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -532,7 +532,7 @@ extern "C" {
     int sim1D_refine(int i, int loglevel)
     {
         try {
-            SimCabinet::item(i).refine(loglevel);
+            SimCabinet::at(i)->refine(loglevel);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -543,7 +543,7 @@ extern "C" {
                                 double slope, double curve, double prune)
     {
         try {
-            SimCabinet::item(i).setRefineCriteria(dom, ratio, slope, curve, prune);
+            SimCabinet::at(i)->setRefineCriteria(dom, ratio, slope, curve, prune);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -553,7 +553,7 @@ extern "C" {
     int sim1D_setGridMin(int i, int dom, double gridmin)
     {
         try {
-            SimCabinet::item(i).setGridMin(dom, gridmin);
+            SimCabinet::at(i)->setGridMin(dom, gridmin);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -563,7 +563,7 @@ extern "C" {
     int sim1D_save(int i, const char* fname, const char* id, const char* desc)
     {
         try {
-            SimCabinet::item(i).save(fname, id, desc);
+            SimCabinet::at(i)->save(fname, id, desc);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -573,7 +573,7 @@ extern "C" {
     int sim1D_restore(int i, const char* fname, const char* id)
     {
         try {
-            SimCabinet::item(i).restore(fname, id);
+            SimCabinet::at(i)->restore(fname, id);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -583,7 +583,7 @@ extern "C" {
     int sim1D_writeStats(int i, int printTime)
     {
         try {
-            SimCabinet::item(i).writeStats(printTime);
+            SimCabinet::at(i)->writeStats(printTime);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -593,7 +593,7 @@ extern "C" {
     int sim1D_domainIndex(int i, const char* name)
     {
         try {
-            return (int) SimCabinet::item(i).domainIndex(name);
+            return (int) SimCabinet::at(i)->domainIndex(name);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -602,10 +602,10 @@ extern "C" {
     double sim1D_value(int i, int idom, int icomp, int localPoint)
     {
         try {
-            Sim1D& sim = SimCabinet::item(i);
-            sim.checkDomainIndex(idom);
-            sim.domain(idom).checkComponentIndex(icomp);
-            return sim.value(idom, icomp, localPoint);
+            auto& sim = SimCabinet::at(i);
+            sim->checkDomainIndex(idom);
+            sim->domain(idom).checkComponentIndex(icomp);
+            return sim->value(idom, icomp, localPoint);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -614,10 +614,10 @@ extern "C" {
     double sim1D_workValue(int i, int idom, int icomp, int localPoint)
     {
         try {
-            Sim1D& sim = SimCabinet::item(i);
-            sim.checkDomainIndex(idom);
-            sim.domain(idom).checkComponentIndex(icomp);
-            return sim.workValue(idom, icomp, localPoint);
+            auto& sim = SimCabinet::at(i);
+            sim->checkDomainIndex(idom);
+            sim->domain(idom).checkComponentIndex(icomp);
+            return sim->workValue(idom, icomp, localPoint);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -626,7 +626,7 @@ extern "C" {
     int sim1D_eval(int i, double rdt, int count)
     {
         try {
-            SimCabinet::item(i).eval(rdt, count);
+            SimCabinet::at(i)->eval(rdt, count);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -636,7 +636,7 @@ extern "C" {
     int sim1D_setMaxJacAge(int i, int ss_age, int ts_age)
     {
         try {
-            SimCabinet::item(i).setJacAge(ss_age, ts_age);
+            SimCabinet::at(i)->setJacAge(ss_age, ts_age);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -646,7 +646,7 @@ extern "C" {
     int sim1D_setFixedTemperature(int i, double temp)
     {
         try {
-            SimCabinet::item(i).setFixedTemperature(temp);
+            SimCabinet::at(i)->setFixedTemperature(temp);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/clib/ctonedim.cpp
+++ b/src/clib/ctonedim.cpp
@@ -298,7 +298,7 @@ extern "C" {
     double bdry_massFraction(int i, int k)
     {
         try {
-            return DomainCabinet::get<Boundary1D>(i).massFraction(k);
+            return DomainCabinet::as<Boundary1D>(i)->massFraction(k);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -307,7 +307,7 @@ extern "C" {
     double bdry_mdot(int i)
     {
         try {
-            return DomainCabinet::get<Boundary1D>(i).mdot();
+            return DomainCabinet::as<Boundary1D>(i)->mdot();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -316,7 +316,7 @@ extern "C" {
     int reactingsurf_enableCoverageEqs(int i, int onoff)
     {
         try {
-            DomainCabinet::get<ReactingSurf1D>(i).enableCoverageEquations(onoff != 0);
+            DomainCabinet::as<ReactingSurf1D>(i)->enableCoverageEquations(onoff != 0);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -348,7 +348,7 @@ extern "C" {
     int flow1D_setTransport(int i, int itr)
     {
         try {
-            DomainCabinet::get<Flow1D>(i).setTransport(TransportCabinet::at(itr));
+            DomainCabinet::as<Flow1D>(i)->setTransport(TransportCabinet::at(itr));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -359,7 +359,7 @@ extern "C" {
     {
         try {
             bool withSoret = (iSoret > 0);
-            DomainCabinet::get<Flow1D>(i).enableSoret(withSoret);
+            DomainCabinet::as<Flow1D>(i)->enableSoret(withSoret);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -369,7 +369,7 @@ extern "C" {
     int flow1D_setPressure(int i, double p)
     {
         try {
-            DomainCabinet::get<Flow1D>(i).setPressure(p);
+            DomainCabinet::as<Flow1D>(i)->setPressure(p);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -379,7 +379,7 @@ extern "C" {
     double flow1D_pressure(int i)
     {
         try {
-            return DomainCabinet::get<Flow1D>(i).pressure();
+            return DomainCabinet::as<Flow1D>(i)->pressure();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -394,7 +394,7 @@ extern "C" {
                 vpos[j] = pos[j];
                 vtemp[j] = temp[j];
             }
-            DomainCabinet::get<Flow1D>(i).setFixedTempProfile(vpos, vtemp);
+            DomainCabinet::as<Flow1D>(i)->setFixedTempProfile(vpos, vtemp);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -405,9 +405,9 @@ extern "C" {
     {
         try {
             if (flag > 0) {
-                DomainCabinet::get<Flow1D>(i).solveEnergyEqn(npos);
+                DomainCabinet::as<Flow1D>(i)->solveEnergyEqn(npos);
             } else {
-                DomainCabinet::get<Flow1D>(i).fixTemperature(npos);
+                DomainCabinet::as<Flow1D>(i)->fixTemperature(npos);
             }
             return 0;
         } catch (...) {

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -92,7 +92,7 @@ extern "C" {
     int reactor_insert(int i, int n)
     {
         try {
-            ReactorCabinet::get<Reactor>(i).insert(SolutionCabinet::at(n));
+            ReactorCabinet::as<Reactor>(i)->insert(SolutionCabinet::at(n));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -174,7 +174,7 @@ extern "C" {
     int reactor_setChemistry(int i, int cflag)
     {
         try {
-            ReactorCabinet::get<Reactor>(i).setChemistry(cflag != 0);
+            ReactorCabinet::as<Reactor>(i)->setChemistry(cflag != 0);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -184,7 +184,7 @@ extern "C" {
     int reactor_setEnergy(int i, int eflag)
     {
         try {
-            ReactorCabinet::get<Reactor>(i).setEnergy(eflag);
+            ReactorCabinet::as<Reactor>(i)->setEnergy(eflag);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -194,7 +194,7 @@ extern "C" {
     int reactor_setMassFlowRate(int i, double mdot)
     {
         try {
-            ReactorCabinet::get<FlowReactor>(i).setMassFlowRate(mdot);
+            ReactorCabinet::as<FlowReactor>(i)->setMassFlowRate(mdot);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -204,7 +204,7 @@ extern "C" {
     size_t reactor_nSensParams(int i)
     {
         try {
-            return ReactorCabinet::get<Reactor>(i).nSensParams();
+            return ReactorCabinet::as<Reactor>(i)->nSensParams();
         } catch (...) {
             return handleAllExceptions(npos, npos);
         }
@@ -213,7 +213,7 @@ extern "C" {
     int reactor_addSensitivityReaction(int i, int rxn)
     {
         try {
-            ReactorCabinet::get<Reactor>(i).addSensitivityReaction(rxn);
+            ReactorCabinet::as<Reactor>(i)->addSensitivityReaction(rxn);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -386,7 +386,7 @@ extern "C" {
     int flowdev_setPrimary(int i, int n)
     {
         try {
-            FlowDeviceCabinet::get<PressureController>(i).setPrimary(
+            FlowDeviceCabinet::as<PressureController>(i)->setPrimary(
                 FlowDeviceCabinet::at(n).get());
             return 0;
         } catch (...) {
@@ -406,7 +406,7 @@ extern "C" {
     int flowdev_setMassFlowCoeff(int i, double v)
     {
         try {
-            FlowDeviceCabinet::get<MassFlowController>(i).setMassFlowCoeff(v);
+            FlowDeviceCabinet::as<MassFlowController>(i)->setMassFlowCoeff(v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -416,7 +416,7 @@ extern "C" {
     int flowdev_setValveCoeff(int i, double v)
     {
         try {
-            FlowDeviceCabinet::get<Valve>(i).setValveCoeff(v);
+            FlowDeviceCabinet::as<Valve>(i)->setValveCoeff(v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -426,7 +426,7 @@ extern "C" {
     int flowdev_setPressureCoeff(int i, double v)
     {
         try {
-            FlowDeviceCabinet::get<PressureController>(i).setPressureCoeff(v);
+            FlowDeviceCabinet::as<PressureController>(i)->setPressureCoeff(v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -525,7 +525,7 @@ extern "C" {
     int wall_setThermalResistance(int i, double rth)
     {
         try {
-            WallCabinet::get<Wall>(i).setThermalResistance(rth);
+            WallCabinet::as<Wall>(i)->setThermalResistance(rth);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -535,7 +535,7 @@ extern "C" {
     int wall_setHeatTransferCoeff(int i, double u)
     {
         try {
-            WallCabinet::get<Wall>(i).setHeatTransferCoeff(u);
+            WallCabinet::as<Wall>(i)->setHeatTransferCoeff(u);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -545,7 +545,7 @@ extern "C" {
     int wall_setHeatFlux(int i, int n)
     {
         try {
-            WallCabinet::get<Wall>(i).setHeatFlux(FuncCabinet::at(n).get());
+            WallCabinet::as<Wall>(i)->setHeatFlux(FuncCabinet::at(n).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -555,7 +555,7 @@ extern "C" {
     int wall_setExpansionRateCoeff(int i, double k)
     {
         try {
-            WallCabinet::get<Wall>(i).setExpansionRateCoeff(k);
+            WallCabinet::as<Wall>(i)->setExpansionRateCoeff(k);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -565,7 +565,7 @@ extern "C" {
     int wall_setVelocity(int i, int n)
     {
         try {
-            WallCabinet::get<Wall>(i).setVelocity(FuncCabinet::at(n).get());
+            WallCabinet::as<Wall>(i)->setVelocity(FuncCabinet::at(n).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -575,7 +575,7 @@ extern "C" {
     int wall_setEmissivity(int i, double epsilon)
     {
         try {
-            WallCabinet::get<Wall>(i).setEmissivity(epsilon);
+            WallCabinet::as<Wall>(i)->setEmissivity(epsilon);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -62,7 +62,7 @@ extern "C" {
     int reactor_setInitialVolume(int i, double v)
     {
         try {
-            ReactorCabinet::item(i).setInitialVolume(v);
+            ReactorCabinet::at(i)->setInitialVolume(v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -72,7 +72,7 @@ extern "C" {
     int reactor_setThermoMgr(int i, int n)
     {
         try {
-            ReactorCabinet::item(i).setThermoMgr(ThermoCabinet::item(n));
+            ReactorCabinet::at(i)->setThermoMgr(*ThermoCabinet::at(n));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -82,7 +82,7 @@ extern "C" {
     int reactor_setKineticsMgr(int i, int n)
     {
         try {
-            ReactorCabinet::item(i).setKineticsMgr(KineticsCabinet::item(n));
+            ReactorCabinet::at(i)->setKineticsMgr(*KineticsCabinet::at(n));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -102,7 +102,7 @@ extern "C" {
     double reactor_mass(int i)
     {
         try {
-            return ReactorCabinet::item(i).mass();
+            return ReactorCabinet::at(i)->mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -111,7 +111,7 @@ extern "C" {
     double reactor_volume(int i)
     {
         try {
-            return ReactorCabinet::item(i).volume();
+            return ReactorCabinet::at(i)->volume();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -120,7 +120,7 @@ extern "C" {
     double reactor_density(int i)
     {
         try {
-            return ReactorCabinet::item(i).density();
+            return ReactorCabinet::at(i)->density();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -129,7 +129,7 @@ extern "C" {
     double reactor_temperature(int i)
     {
         try {
-            return ReactorCabinet::item(i).temperature();
+            return ReactorCabinet::at(i)->temperature();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -138,7 +138,7 @@ extern "C" {
     double reactor_enthalpy_mass(int i)
     {
         try {
-            return ReactorCabinet::item(i).enthalpy_mass();
+            return ReactorCabinet::at(i)->enthalpy_mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -147,7 +147,7 @@ extern "C" {
     double reactor_intEnergy_mass(int i)
     {
         try {
-            return ReactorCabinet::item(i).intEnergy_mass();
+            return ReactorCabinet::at(i)->intEnergy_mass();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -156,7 +156,7 @@ extern "C" {
     double reactor_pressure(int i)
     {
         try {
-            return ReactorCabinet::item(i).pressure();
+            return ReactorCabinet::at(i)->pressure();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -165,7 +165,7 @@ extern "C" {
     double reactor_massFraction(int i, int k)
     {
         try {
-            return ReactorCabinet::item(i).massFraction(k);
+            return ReactorCabinet::at(i)->massFraction(k);
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -244,7 +244,7 @@ extern "C" {
     int reactornet_setInitialTime(int i, double t)
     {
         try {
-            NetworkCabinet::item(i).setInitialTime(t);
+            NetworkCabinet::at(i)->setInitialTime(t);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -254,7 +254,7 @@ extern "C" {
     int reactornet_setMaxTimeStep(int i, double maxstep)
     {
         try {
-            NetworkCabinet::item(i).setMaxTimeStep(maxstep);
+            NetworkCabinet::at(i)->setMaxTimeStep(maxstep);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -264,7 +264,7 @@ extern "C" {
     int reactornet_setTolerances(int i, double rtol, double atol)
     {
         try {
-            NetworkCabinet::item(i).setTolerances(rtol, atol);
+            NetworkCabinet::at(i)->setTolerances(rtol, atol);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -274,7 +274,7 @@ extern "C" {
     int reactornet_setSensitivityTolerances(int i, double rtol, double atol)
     {
         try {
-            NetworkCabinet::item(i).setSensitivityTolerances(rtol, atol);
+            NetworkCabinet::at(i)->setSensitivityTolerances(rtol, atol);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -284,8 +284,8 @@ extern "C" {
     int reactornet_addreactor(int i, int n)
     {
         try {
-            NetworkCabinet::item(i).addReactor(
-                dynamic_cast<Reactor&>(ReactorCabinet::item(n)));
+            NetworkCabinet::at(i)->addReactor(
+                dynamic_cast<Reactor&>(*ReactorCabinet::at(n)));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -295,7 +295,7 @@ extern "C" {
     int reactornet_advance(int i, double t)
     {
         try {
-            NetworkCabinet::item(i).advance(t);
+            NetworkCabinet::at(i)->advance(t);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -305,7 +305,7 @@ extern "C" {
     double reactornet_step(int i)
     {
         try {
-            return NetworkCabinet::item(i).step();
+            return NetworkCabinet::at(i)->step();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -314,7 +314,7 @@ extern "C" {
     double reactornet_time(int i)
     {
         try {
-            return NetworkCabinet::item(i).time();
+            return NetworkCabinet::at(i)->time();
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -323,7 +323,7 @@ extern "C" {
     double reactornet_rtol(int i)
     {
         try {
-            return NetworkCabinet::item(i).rtol();
+            return NetworkCabinet::at(i)->rtol();
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -332,7 +332,7 @@ extern "C" {
     double reactornet_atol(int i)
     {
         try {
-            return NetworkCabinet::item(i).atol();
+            return NetworkCabinet::at(i)->atol();
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -341,7 +341,7 @@ extern "C" {
     double reactornet_sensitivity(int i, const char* v, int p, int r)
     {
         try {
-            return NetworkCabinet::item(i).sensitivity(v, p, r);
+            return NetworkCabinet::at(i)->sensitivity(v, p, r);
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -371,8 +371,8 @@ extern "C" {
     int flowdev_install(int i, int n, int m)
     {
         try {
-            bool ok = FlowDeviceCabinet::item(i).install(ReactorCabinet::item(n),
-                      ReactorCabinet::item(m));
+            bool ok = FlowDeviceCabinet::at(i)->install(*ReactorCabinet::at(n),
+                                                        *ReactorCabinet::at(m));
             if (!ok) {
                 throw CanteraError("flowdev_install",
                                    "Could not install flow device.");
@@ -387,7 +387,7 @@ extern "C" {
     {
         try {
             FlowDeviceCabinet::get<PressureController>(i).setPrimary(
-                &FlowDeviceCabinet::item(n));
+                FlowDeviceCabinet::at(n).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -397,7 +397,7 @@ extern "C" {
     double flowdev_massFlowRate(int i)
     {
         try {
-            return FlowDeviceCabinet::item(i).massFlowRate();
+            return FlowDeviceCabinet::at(i)->massFlowRate();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -436,7 +436,7 @@ extern "C" {
     int flowdev_setPressureFunction(int i, int n)
     {
         try {
-            FlowDeviceCabinet::item(i).setPressureFunction(&FuncCabinet::item(n));
+            FlowDeviceCabinet::at(i)->setPressureFunction(FuncCabinet::at(n).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -446,7 +446,7 @@ extern "C" {
     int flowdev_setTimeFunction(int i, int n)
     {
         try {
-            FlowDeviceCabinet::item(i).setTimeFunction(&FuncCabinet::item(n));
+            FlowDeviceCabinet::at(i)->setTimeFunction(FuncCabinet::at(n).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -477,8 +477,8 @@ extern "C" {
     int wall_install(int i, int n, int m)
     {
         try {
-            WallCabinet::item(i).install(ReactorCabinet::item(n),
-                                         ReactorCabinet::item(m));
+            WallCabinet::at(i)->install(*ReactorCabinet::at(n),
+                                        *ReactorCabinet::at(m));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -488,7 +488,7 @@ extern "C" {
     double wall_expansionRate(int i)
     {
         try {
-            return WallCabinet::item(i).expansionRate();
+            return WallCabinet::at(i)->expansionRate();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -497,7 +497,7 @@ extern "C" {
     double wall_heatRate(int i)
     {
         try {
-            return WallCabinet::item(i).heatRate();
+            return WallCabinet::at(i)->heatRate();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -506,7 +506,7 @@ extern "C" {
     double wall_area(int i)
     {
         try {
-            return WallCabinet::item(i).area();
+            return WallCabinet::at(i)->area();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -515,7 +515,7 @@ extern "C" {
     int wall_setArea(int i, double v)
     {
         try {
-            WallCabinet::item(i).setArea(v);
+            WallCabinet::at(i)->setArea(v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -545,7 +545,7 @@ extern "C" {
     int wall_setHeatFlux(int i, int n)
     {
         try {
-            WallCabinet::get<Wall>(i).setHeatFlux(&FuncCabinet::item(n));
+            WallCabinet::get<Wall>(i).setHeatFlux(FuncCabinet::at(n).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -565,7 +565,7 @@ extern "C" {
     int wall_setVelocity(int i, int n)
     {
         try {
-            WallCabinet::get<Wall>(i).setVelocity(&FuncCabinet::item(n));
+            WallCabinet::get<Wall>(i).setVelocity(FuncCabinet::at(n).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -585,7 +585,7 @@ extern "C" {
     int wall_ready(int i)
     {
         try {
-            return int(WallCabinet::item(i).ready());
+            return int(WallCabinet::at(i)->ready());
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }
@@ -615,7 +615,7 @@ extern "C" {
     int reactorsurface_install(int i, int n)
     {
         try {
-            ReactorCabinet::item(n).addSurface(&ReactorSurfaceCabinet::item(i));
+            ReactorCabinet::at(n)->addSurface(ReactorSurfaceCabinet::at(i).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -625,7 +625,7 @@ extern "C" {
     int reactorsurface_setkinetics(int i, int n)
     {
         try {
-            ReactorSurfaceCabinet::item(i).setKinetics(&KineticsCabinet::item(n));
+            ReactorSurfaceCabinet::at(i)->setKinetics(KineticsCabinet::at(n).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -635,7 +635,7 @@ extern "C" {
     double reactorsurface_area(int i)
     {
         try {
-            return ReactorSurfaceCabinet::item(i).area();
+            return ReactorSurfaceCabinet::at(i)->area();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -644,7 +644,7 @@ extern "C" {
     int reactorsurface_setArea(int i, double v)
     {
         try {
-            ReactorSurfaceCabinet::item(i).setArea(v);
+            ReactorSurfaceCabinet::at(i)->setArea(v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -654,7 +654,7 @@ extern "C" {
     int reactorsurface_addSensitivityReaction(int i, int rxn)
     {
         try {
-            ReactorSurfaceCabinet::item(i).addSensitivityReaction(rxn);
+            ReactorSurfaceCabinet::at(i)->addSensitivityReaction(rxn);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -16,15 +16,15 @@
 
 using namespace Cantera;
 
-typedef SharedCabinet<ReactorBase> ReactorCabinet;
-typedef SharedCabinet<ReactorNet> NetworkCabinet;
-typedef SharedCabinet<FlowDevice> FlowDeviceCabinet;
-typedef SharedCabinet<WallBase> WallCabinet;
-typedef SharedCabinet<Func1> FuncCabinet;
-typedef SharedCabinet<ThermoPhase> ThermoCabinet;
-typedef SharedCabinet<Kinetics> KineticsCabinet;
-typedef SharedCabinet<Solution> SolutionCabinet;
-typedef SharedCabinet<ReactorSurface> ReactorSurfaceCabinet;
+typedef Cabinet<ReactorBase> ReactorCabinet;
+typedef Cabinet<ReactorNet> NetworkCabinet;
+typedef Cabinet<FlowDevice> FlowDeviceCabinet;
+typedef Cabinet<WallBase> WallCabinet;
+typedef Cabinet<Func1> FuncCabinet;
+typedef Cabinet<ThermoPhase> ThermoCabinet;
+typedef Cabinet<Kinetics> KineticsCabinet;
+typedef Cabinet<Solution> SolutionCabinet;
+typedef Cabinet<ReactorSurface> ReactorSurfaceCabinet;
 
 template<> ReactorCabinet* ReactorCabinet::s_storage = 0;
 template<> NetworkCabinet* NetworkCabinet::s_storage = 0;

--- a/src/clib/ctrpath.cpp
+++ b/src/clib/ctrpath.cpp
@@ -48,7 +48,7 @@ extern "C" {
     int rdiag_detailed(int i)
     {
         try {
-            DiagramCabinet::item(i).show_details = true;
+            DiagramCabinet::at(i)->show_details = true;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -58,7 +58,7 @@ extern "C" {
     int rdiag_brief(int i)
     {
         try {
-            DiagramCabinet::item(i).show_details = false;
+            DiagramCabinet::at(i)->show_details = false;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -68,7 +68,7 @@ extern "C" {
     int rdiag_setThreshold(int i, double v)
     {
         try {
-            DiagramCabinet::item(i).threshold = v;
+            DiagramCabinet::at(i)->threshold = v;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -78,7 +78,7 @@ extern "C" {
     int rdiag_setBoldColor(int i, const char* color)
     {
         try {
-            DiagramCabinet::item(i).bold_color = color;
+            DiagramCabinet::at(i)->bold_color = color;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -88,7 +88,7 @@ extern "C" {
     int rdiag_setNormalColor(int i, const char* color)
     {
         try {
-            DiagramCabinet::item(i).normal_color = color;
+            DiagramCabinet::at(i)->normal_color = color;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -98,7 +98,7 @@ extern "C" {
     int rdiag_setDashedColor(int i, const char* color)
     {
         try {
-            DiagramCabinet::item(i).dashed_color = color;
+            DiagramCabinet::at(i)->dashed_color = color;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -108,7 +108,7 @@ extern "C" {
     int rdiag_setDotOptions(int i, const char* opt)
     {
         try {
-            DiagramCabinet::item(i).dot_options = opt;
+            DiagramCabinet::at(i)->dot_options = opt;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -118,7 +118,7 @@ extern "C" {
     int rdiag_setFont(int i, const char* font)
     {
         try {
-            DiagramCabinet::item(i).setFont(font);
+            DiagramCabinet::at(i)->setFont(font);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -128,7 +128,7 @@ extern "C" {
     int rdiag_setBoldThreshold(int i, double v)
     {
         try {
-            DiagramCabinet::item(i).bold_min = v;
+            DiagramCabinet::at(i)->bold_min = v;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -138,7 +138,7 @@ extern "C" {
     int rdiag_setNormalThreshold(int i, double v)
     {
         try {
-            DiagramCabinet::item(i).dashed_max = v;
+            DiagramCabinet::at(i)->dashed_max = v;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -148,7 +148,7 @@ extern "C" {
     int rdiag_setLabelThreshold(int i, double v)
     {
         try {
-            DiagramCabinet::item(i).label_min = v;
+            DiagramCabinet::at(i)->label_min = v;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -158,7 +158,7 @@ extern "C" {
     int rdiag_setScale(int i, double v)
     {
         try {
-            DiagramCabinet::item(i).scale = v;
+            DiagramCabinet::at(i)->scale = v;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -169,9 +169,9 @@ extern "C" {
     {
         try {
             if (iflow == 0) {
-                DiagramCabinet::item(i).flow_type = OneWayFlow;
+                DiagramCabinet::at(i)->flow_type = OneWayFlow;
             } else {
-                DiagramCabinet::item(i).flow_type = NetFlow;
+                DiagramCabinet::at(i)->flow_type = NetFlow;
             }
             return 0;
         } catch (...) {
@@ -182,7 +182,7 @@ extern "C" {
     int rdiag_setArrowWidth(int i, double v)
     {
         try {
-            DiagramCabinet::item(i).arrow_width = v;
+            DiagramCabinet::at(i)->arrow_width = v;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -192,7 +192,7 @@ extern "C" {
     int rdiag_setTitle(int i, const char* title)
     {
         try {
-            DiagramCabinet::item(i).title = title;
+            DiagramCabinet::at(i)->title = title;
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -202,7 +202,7 @@ extern "C" {
     int rdiag_add(int i, int n)
     {
         try {
-            DiagramCabinet::item(i).add(DiagramCabinet::item(n));
+            DiagramCabinet::at(i)->add(*DiagramCabinet::at(n));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -213,7 +213,7 @@ extern "C" {
                         size_t lda, double* a)
     {
         try {
-            DiagramCabinet::item(i).findMajorPaths(threshold, lda, a);
+            DiagramCabinet::at(i)->findMajorPaths(threshold, lda, a);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -225,9 +225,9 @@ extern "C" {
         try {
             ofstream f(fname);
             if (fmt == 0) {
-                DiagramCabinet::item(i).exportToDot(f);
+                DiagramCabinet::at(i)->exportToDot(f);
             } else {
-                DiagramCabinet::item(i).writeData(f);
+                DiagramCabinet::at(i)->writeData(f);
             }
             return 0;
         } catch (...) {
@@ -238,7 +238,7 @@ extern "C" {
     int rdiag_displayOnly(int i, int k)
     {
         try {
-            DiagramCabinet::item(i).displayOnly(k);
+            DiagramCabinet::at(i)->displayOnly(k);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -268,7 +268,7 @@ extern "C" {
     {
         try {
             ofstream flog(logfile);
-            BuilderCabinet::item(i).init(flog, KineticsCabinet::item(k));
+            BuilderCabinet::at(i)->init(flog, *KineticsCabinet::at(k));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -284,8 +284,8 @@ extern "C" {
             if (iquiet > 0) {
                 quiet = true;
             }
-            BuilderCabinet::item(i).build(KineticsCabinet::item(k), el, fdot,
-                                          DiagramCabinet::item(idiag), quiet);
+            BuilderCabinet::at(i)->build(*KineticsCabinet::at(k), el, fdot,
+                                         *DiagramCabinet::at(idiag), quiet);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/clib/ctrpath.cpp
+++ b/src/clib/ctrpath.cpp
@@ -16,12 +16,12 @@
 using namespace Cantera;
 using namespace std;
 
-typedef SharedCabinet<ReactionPathBuilder> BuilderCabinet;
-typedef SharedCabinet<ReactionPathDiagram> DiagramCabinet;
+typedef Cabinet<ReactionPathBuilder> BuilderCabinet;
+typedef Cabinet<ReactionPathDiagram> DiagramCabinet;
 template<> DiagramCabinet* DiagramCabinet::s_storage = 0;
 template<> BuilderCabinet* BuilderCabinet::s_storage = 0;
 
-typedef SharedCabinet<Kinetics> KineticsCabinet;
+typedef Cabinet<Kinetics> KineticsCabinet;
 template<> KineticsCabinet* KineticsCabinet::s_storage; // defined in ct.cpp
 
 extern "C" {

--- a/src/clib/ctsurf.cpp
+++ b/src/clib/ctsurf.cpp
@@ -23,7 +23,7 @@ extern "C" {
     int surf_setSiteDensity(int i, double s0)
     {
         try {
-            ThermoCabinet::get<SurfPhase>(i).setSiteDensity(s0);
+            ThermoCabinet::as<SurfPhase>(i)->setSiteDensity(s0);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -33,7 +33,7 @@ extern "C" {
     double surf_siteDensity(int i)
     {
         try {
-            return ThermoCabinet::get<SurfPhase>(i).siteDensity();
+            return ThermoCabinet::as<SurfPhase>(i)->siteDensity();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -43,9 +43,9 @@ extern "C" {
     {
         try {
             if(norm){
-                ThermoCabinet::get<SurfPhase>(i).setCoverages(c);
+                ThermoCabinet::as<SurfPhase>(i)->setCoverages(c);
             } else {
-                ThermoCabinet::get<SurfPhase>(i).setCoveragesNoNorm(c);
+                ThermoCabinet::as<SurfPhase>(i)->setCoveragesNoNorm(c);
             }
             return 0;
         } catch (...) {
@@ -56,7 +56,7 @@ extern "C" {
     int surf_setCoveragesByName(int i, const char* c)
     {
         try {
-            ThermoCabinet::get<SurfPhase>(i).setCoveragesByName(c);
+            ThermoCabinet::as<SurfPhase>(i)->setCoveragesByName(c);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -66,7 +66,7 @@ extern "C" {
     int surf_getCoverages(int i, double* c)
     {
         try {
-            ThermoCabinet::get<SurfPhase>(i).getCoverages(c);
+            ThermoCabinet::as<SurfPhase>(i)->getCoverages(c);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -76,7 +76,7 @@ extern "C" {
     int surf_setConcentrations(int i, const double* c)
     {
         try {
-            ThermoCabinet::get<SurfPhase>(i).setConcentrations(c);
+            ThermoCabinet::as<SurfPhase>(i)->setConcentrations(c);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -86,7 +86,7 @@ extern "C" {
     int surf_getConcentrations(int i, double* c)
     {
         try {
-            ThermoCabinet::get<SurfPhase>(i).getConcentrations(c);
+            ThermoCabinet::as<SurfPhase>(i)->getConcentrations(c);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/clib/ctsurf.cpp
+++ b/src/clib/ctsurf.cpp
@@ -14,7 +14,7 @@
 
 using namespace Cantera;
 
-typedef SharedCabinet<ThermoPhase> ThermoCabinet;
+typedef Cabinet<ThermoPhase> ThermoCabinet;
 template<> ThermoCabinet* ThermoCabinet::s_storage; // defined in ct.cpp
 
 

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -39,17 +39,17 @@ namespace {
 
 ThermoPhase* _fph(const integer* n)
 {
-    return &ThermoCabinet::item(*n);
+    return ThermoCabinet::at(*n).get();
 }
 
 static Kinetics* _fkin(const integer* n)
 {
-    return &KineticsCabinet::item(*n);
+    return KineticsCabinet::at(*n).get();
 }
 
 ThermoPhase* _fth(const integer* n)
 {
-    return &ThermoCabinet::item(*n);
+    return ThermoCabinet::at(*n).get();
 }
 
 shared_ptr<ThermoPhase> _fthermo(const integer* n)
@@ -59,7 +59,7 @@ shared_ptr<ThermoPhase> _fthermo(const integer* n)
 
 Transport* _ftrans(const integer* n)
 {
-    return &TransportCabinet::item(*n);
+    return TransportCabinet::at(*n).get();
 }
 
 } // unnamed namespace

--- a/src/fortran/fct.cpp
+++ b/src/fortran/fct.cpp
@@ -25,9 +25,9 @@
 
 using namespace Cantera;
 
-typedef SharedCabinet<ThermoPhase> ThermoCabinet;
-typedef SharedCabinet<Kinetics> KineticsCabinet;
-typedef SharedCabinet<Transport> TransportCabinet;
+typedef Cabinet<ThermoPhase> ThermoCabinet;
+typedef Cabinet<Kinetics> KineticsCabinet;
+typedef Cabinet<Transport> TransportCabinet;
 
 typedef integer status_t;
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR is mostly house-keeping for a simple bulk-replacement to streamline CLib's storage class (a left-over item from #1770 which I decided to break down into more manageable chunks)

- Replace all occurrences of `SharedCabinet::item` by `SharedCabinet::at`
- Replace all occurrences of `SharedCabinet::get` by SharedCabinet::as`
- Eliminate `SharedCabinet::item` and `SharedCabinet::get`
- Rename `SharedCabinet` back to `Cabinet` (original name of before shared pointers were introduced in #1448)

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
