### PR TITLE
Fix usage of addOrderingRules in SolutionArray

### DIFF
--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -473,6 +473,7 @@ public:
 
     //! Add items from `other` to this AnyMap. If keys in `other` also exist in
     //! this AnyMap, the `keepExisting` option determines which item is used.
+    //! Local units defined in `other` are not retained.
     void update(const AnyMap& other, bool keepExisting=true);
 
     //! Mark `key` as excluded from this map. This prevents `key` from being added
@@ -584,7 +585,7 @@ public:
     class OrderedProxy {
     public:
         OrderedProxy() {}
-        OrderedProxy(const AnyMap& data);
+        OrderedProxy(const AnyMap& data, bool withUnits);
         OrderedIterator begin() const;
         OrderedIterator end() const;
 
@@ -621,10 +622,13 @@ public:
         OrderedProxy::OrderVector::const_iterator m_stop;
     };
 
-    // Return a proxy object that allows iteration in an order determined by the
-    // order of insertion, the location in an input file, and rules specified by
-    // the addOrderingRules() method.
-    OrderedProxy ordered() const { return OrderedProxy(*this); }
+    //! Return a proxy object that allows iteration in an order determined by the order
+    //! of insertion, the location in an input file, and rules specified by the
+    //! addOrderingRules() method. The `withUnits` flag determines whether to include a
+    //! `units` directive, if any local units are defined (for use by the YAML emitter).
+    OrderedProxy ordered(bool withUnits=false) const {
+        return OrderedProxy(*this, withUnits);
+    }
 
     //! Returns the number of elements in this map
     size_t size() const;

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -672,7 +672,8 @@ public:
      * Enables specifying keys that should appear at either the beginning
      * or end of the generated YAML mapping. Only programmatically-added keys
      * are rearranged. Keys which come from YAML input retain their existing
-     * ordering, and are output after programmatically-added keys.
+     * ordering, and are output after programmatically-added keys. Keys are
+     * output in the order provided to this method.
      *
      * This function should be called exactly once for any given spec that
      * is to be added. To facilitate this, the method returns a bool so that

--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -35,6 +35,7 @@ class AnyBase {
 public:
     AnyBase() = default;
     virtual ~AnyBase() = default;
+    AnyBase& operator=(const AnyBase& other);
 
     //! For values which are derived from an input file, set the line and column
     //! of this value in that file. Used for providing context for some error

--- a/samples/python/onedim/diffusion_flame_continuation.py
+++ b/samples/python/onedim/diffusion_flame_continuation.py
@@ -39,7 +39,7 @@ width = 18.e-3  # 18mm wide
 f = ct.CounterflowDiffusionFlame(gas, width=width)
 
 # Define the operating pressure and boundary conditions
-f.P = 1.e5  # 1 bar
+f.P = 1.0e5  # 1 bar
 f.fuel_inlet.mdot = 0.5  # kg/m^2/s
 f.fuel_inlet.X = 'H2:1'
 f.fuel_inlet.T = 300  # K
@@ -87,6 +87,10 @@ error_count = 0
 strain_rate_tol = 0.10
 
 f.two_point_control_enabled = True
+
+# Prevent two point control from finding solutions with negative inlet velocities
+f.flame.set_bounds(spread_rate=(-1e-5, 1e20))
+
 f.max_time_step_count = 100
 T_max = max(f.T)
 a_max = strain_rate = f.strain_rate('max')
@@ -133,7 +137,7 @@ for i in range(n_max):
         logger.debug(err)
         if strain_rate / a_max < strain_rate_tol:
             logger.info('SUCCESS! Traversed unstable branch down to '
-                        f'{100 * strain_rate / a_max:.1f}% of the maximum strain rate.')
+                        f'{100 * strain_rate / a_max:.2f}% of the maximum strain rate.')
             break
 
         # Restore the previous solution and try a smaller temperature increment for the

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -602,6 +602,18 @@ std::unordered_map<string, vector<string>> AnyMap::s_tailFields;
 
 // Methods of class AnyBase
 
+AnyBase& AnyBase::operator=(const AnyBase& other)
+{
+    m_metadata = other.m_metadata;
+    // Copy location information only if it's been set from an input file. Otherwise,
+    // the ordering information at the destination is more important to preserve.
+    if (other.m_line != -1 && other.m_column >= 0) {
+        m_line = other.m_line;
+        m_column = other.m_column;
+    }
+    return *this;
+}
+
 void AnyBase::setLoc(int line, int column)
 {
     m_line = line;

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -296,7 +296,7 @@ YAML::Emitter& operator<<(YAML::Emitter& out, const AnyMap& rhs)
         out << YAML::Flow;
         out << YAML::BeginMap;
         size_t width = 15;
-        for (const auto& [name, value] : rhs.ordered()) {
+        for (const auto& [name, value] : rhs.ordered(true)) {
             string valueStr;
             bool foundType = true;
             bool needsQuotes = false;
@@ -339,7 +339,7 @@ YAML::Emitter& operator<<(YAML::Emitter& out, const AnyMap& rhs)
         }
     } else {
         out << YAML::BeginMap;
-        for (const auto& [key, value] : rhs.ordered()) {
+        for (const auto& [key, value] : rhs.ordered(true)) {
             out << key;
             out << value;
         }
@@ -1492,7 +1492,7 @@ void AnyMap::clear()
 
 void AnyMap::update(const AnyMap& other, bool keepExisting)
 {
-    for (const auto& [key, value] : other) {
+    for (const auto& [key, value] : other.ordered()) {
         if (!keepExisting || m_data.count(key) == 0) {
             (*this)[key] = value;
         }
@@ -1639,11 +1639,13 @@ AnyMap::Iterator& AnyMap::Iterator::operator++()
 }
 
 
-AnyMap::OrderedProxy::OrderedProxy(const AnyMap& data)
+AnyMap::OrderedProxy::OrderedProxy(const AnyMap& data, bool withUnits)
     : m_data(&data)
 {
     // Units always come first
-    if (m_data->hasKey("__units__") && m_data->at("__units__").as<AnyMap>().size()) {
+    if (withUnits && m_data->hasKey("__units__")
+        && m_data->at("__units__").as<AnyMap>().size())
+    {
         m_units = make_unique<pair<const string, AnyValue>>(
             "units", m_data->at("__units__"));
         m_units->second.setFlowStyle();

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -1787,7 +1787,8 @@ bool AnyMap::addOrderingRules(const string& objectType,
     std::unique_lock<std::mutex> lock(yaml_field_order_mutex);
     for (const auto& spec : specs) {
         if (spec.at(0) == "head") {
-            s_headFields[objectType].push_back(spec.at(1));
+            s_headFields[objectType].insert(s_headFields[objectType].begin(),
+                                            spec.at(1));
         } else if (spec.at(0) == "tail") {
             s_tailFields[objectType].push_back(spec.at(1));
         } else {

--- a/src/base/AnyMap.cpp
+++ b/src/base/AnyMap.cpp
@@ -1790,7 +1790,7 @@ void AnyMap::setUnits(const UnitSystem& units)
 }
 
 void AnyMap::setFlowStyle(bool flow) {
-    (*this)["__flow__"] = flow;
+    m_data["__flow__"] = flow;
 }
 
 bool AnyMap::addOrderingRules(const string& objectType,
@@ -1831,6 +1831,7 @@ AnyMap AnyMap::fromYamlString(const string& yaml) {
         throw InputFileError("AnyMap::fromYamlString", fake, err.msg);
     }
     amap.setMetadata("file-contents", AnyValue(yaml));
+    amap.setLoc(0, 0);
     amap.applyUnits();
     return amap;
 }
@@ -1884,6 +1885,7 @@ AnyMap AnyMap::fromYamlFile(const string& name, const string& parent_name)
         throw;
     }
     cache_item["__file__"] = fullName;
+    cache_item.setLoc(0, 0);
 
     if (cache_item.hasKey("deprecated")) {
         warn_deprecated(fullName, cache_item["deprecated"].asString());

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -194,7 +194,7 @@ shared_ptr<Solution> newSolution(const string &infile,
 
     // load YAML file
     auto rootNode = AnyMap::fromYamlFile(infile);
-    AnyMap& phaseNode = rootNode["phases"].getMapWhere("name", name);
+    const AnyMap& phaseNode = rootNode.at("phases").getMapWhere("name", name);
     auto sol = newSolution(phaseNode, rootNode, transport, adjacent);
     sol->setSource(infile);
     return sol;
@@ -204,12 +204,12 @@ shared_ptr<Solution> newSolution(const string& infile, const string& name,
     const string& transport, const vector<string>& adjacent)
 {
     auto rootNode = AnyMap::fromYamlFile(infile);
-    AnyMap& phaseNode = rootNode["phases"].getMapWhere("name", name);
+    const AnyMap& phaseNode = rootNode.at("phases").getMapWhere("name", name);
 
     vector<shared_ptr<Solution>> adjPhases;
     // Create explicitly-specified adjacent bulk phases
     for (auto& name : adjacent) {
-        auto& adjNode = rootNode["phases"].getMapWhere("name", name);
+        const auto& adjNode = rootNode.at("phases").getMapWhere("name", name);
         adjPhases.push_back(newSolution(adjNode, rootNode));
     }
     return newSolution(phaseNode, rootNode, transport, adjPhases);

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -322,9 +322,8 @@ shared_ptr<Solution> newSolution(const AnyMap& phaseNode,
         if (key == "phases") {
             // header ends with "phases" field
             break;
-        } else if (key != "units") {
-            header[key] = value;
         }
+        header[key] = value;
     }
     sol->header() = header;
 

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -924,9 +924,7 @@ AnyMap preamble(const string& desc)
     }
     data["generator"] = "Cantera SolutionArray";
     data["cantera-version"] = CANTERA_VERSION;
-    // escape commit to ensure commits are read correctly from YAML
-    // example: prevent '3491027e7' from being converted to an integer
-    data["git-commit"] = "'" + gitCommit() + "'";
+    data["git-commit"] = gitCommit();
 
     // Add a timestamp indicating the current time
     time_t aclock;

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -1227,8 +1227,8 @@ void SolutionArray::writeEntry(AnyMap& root, const string& name, const string& s
         data["components"] = componentNames();
     }
 
-    for (auto& [key, value] : *m_extra) {
-        data[key] = value;
+    for (auto& [_, key] : *m_order) {
+        data[key] = m_extra->at(key);
     }
 
     auto phase = m_sol->thermo();

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -932,15 +932,6 @@ AnyMap preamble(const string& desc)
     struct tm* newtime = localtime(&aclock); // Convert time to struct tm form
     data["date"] = stripnonprint(asctime(newtime));
 
-    // Force metadata fields to the top of the file
-    if (data.hasKey("description")) {
-        data["description"].setLoc(-6, 0);
-    }
-    data["generator"].setLoc(-5, 0);
-    data["cantera-version"].setLoc(-4, 0);
-    data["git-commit"].setLoc(-3, 0);
-    data["date"].setLoc(-2, 0);
-
     return data;
 }
 

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -202,8 +202,8 @@ AnyMap Reaction::parameters(bool withInput) const
     }
 
     static bool reg = AnyMap::addOrderingRules("Reaction",
-        {{"head", "type"},
-         {"head", "equation"},
+        {{"head", "equation"},
+         {"head", "type"},
          {"tail", "duplicate"},
          {"tail", "orders"},
          {"tail", "negative-orders"},

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -470,10 +470,14 @@ TEST(AnyMap, definedKeyOrdering)
     m["two"] = 2;
     m["three"] = 3;
     m["four"] = 4;
+    m["five"] = 5;
+    m["six"] = 6;
     m["__type__"] = "Test";
 
     AnyMap::addOrderingRules("Test", {
         {"head", "three"},
+        {"head", "five"},
+        {"tail", "six"},
         {"tail", "one"}
     });
 
@@ -487,4 +491,6 @@ TEST(AnyMap, definedKeyOrdering)
     EXPECT_LT(loc["four"], loc["one"]);
     EXPECT_LT(loc["one"], loc["half"]);
     EXPECT_LT(loc["zero"], loc["half"]);
+    EXPECT_LT(loc["three"], loc["five"]);
+    EXPECT_LT(loc["six"], loc["one"]);
 }

--- a/test/general/test_containers.cpp
+++ b/test/general/test_containers.cpp
@@ -356,6 +356,18 @@ TEST(AnyMap, sizes) {
     EXPECT_EQ(m.size(), 0U);
 }
 
+TEST(AnyMap, error_loc) {
+    AnyMap m = AnyMap::fromYamlString("{spam: 4, eggs: 12}");
+    try {
+        m.at("fake");
+        FAIL();
+    } catch (CanteraError& err) {
+        EXPECT_THAT(err.what(), testing::HasSubstr("Error on line 1"));
+        // Column marker lines up with opening brace
+        EXPECT_THAT(err.what(), testing::HasSubstr("\n          ^"));
+    }
+}
+
 TEST(AnyMap, loadYaml)
 {
     AnyMap m = AnyMap::fromYamlString(

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -703,6 +703,10 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         assert list(yml1["arr"]) == list(yml2["arr"])
         assert list(yml1["arr"]["data"]) == list(yml2["arr"]["data"])
 
+        # Header fields come first, and in the desired order
+        assert (list(yml1["arr"])[:4]
+                == ["generator", "cantera-version", "git-commit", "date"])
+
     def run_overwrite(self, mode):
         outfile = self.test_work_path / f"solutionarray_overwrite.{mode}"
         outfile2 = self.test_work_path / f"solutionarray_fresh.{mode}"

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -818,7 +818,7 @@ class TestFreeFlame(utilities.CanteraTest):
         meta = f.restore(filename, "group0")
         assert meta['description'] == desc
         assert meta['cantera-version'] == ct.__version__
-        assert meta['git-commit'] == f"'{ct.__git_commit__}'"
+        assert meta['git-commit'] == ct.__git_commit__
 
         self.check_save_restore(f)
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix order that "head" ordering rules are interpreted, so the first ones given have highest priority
- Fix extra quotes around `git-commit` field
- Avoid setting ordering rules for `SolutionArray` more than once

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1776

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
