### PR TITLE
[SCons] Get git commit from environment variable

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -162,11 +162,16 @@ cantera_version = "3.1.0a4"
 cantera_pure_version = re.match(r'(\d+\.\d+\.\d+)', cantera_version).group(0)
 cantera_short_version = re.match(r'(\d+\.\d+)', cantera_version).group(0)
 
-try:
-    cantera_git_commit = get_command_output("git", "rev-parse", "--short", "HEAD")
+cantera_git_commit = os.environ.get("CT_GIT_COMMIT")
+if not cantera_git_commit:
+    try:
+        cantera_git_commit = get_command_output("git", "rev-parse", "--short", "HEAD")
+        logger.info(f"Building Cantera from git commit {cantera_git_commit!r}")
+    except (subprocess.CalledProcessError, FileNotFoundError):
+        cantera_git_commit = "unknown"
+else:
     logger.info(f"Building Cantera from git commit {cantera_git_commit!r}")
-except (subprocess.CalledProcessError, FileNotFoundError):
-    cantera_git_commit = "unknown"
+
 
 # Python Package Settings
 python_min_version = parse_version("3.8")


### PR DESCRIPTION
In some build environments, particularly conda forge, we use archives of the Cantera source code downloaded from GitHub. These archives do not include the .git folder, so we cannot use the git CLI to retrieve the commit information. This change reads the commit hash from the CT_GIT_COMMIT environment variable if its set. This will allow us to bring the output from all our packages closer together.

Also, at least for Linux, the conda-forge packages are currently including the commit hash of the `cantera-feedstock` repository, presumably due to how it's checked out in the builder. So that would be extra double confusing :confounded: 

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
