### PR TITLE
Avoid star import from buildutils

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -90,11 +90,16 @@ from packaging.specifiers import SpecifierSet
 from packaging.version import parse as parse_version
 import SCons
 
+from buildutils import (Option, PathOption, BoolOption, EnumOption, Configuration,
+                        logger, remove_directory, remove_file, test_results,
+                        add_RegressionTest, get_command_output, listify, which,
+                        ConfigBuilder, multi_glob, quoted, add_system_include,
+                        checkout_submodule, check_for_python, check_sundials,
+                        config_error, run_preprocessor, make_relative_path_absolute)
+
 # ensure that Python and SCons versions are sufficient for the build process
 EnsurePythonVersion(3, 7)
 EnsureSConsVersion(3, 0, 0)
-
-from buildutils import *
 
 if not COMMAND_LINE_TARGETS:
     # Print usage help
@@ -1853,7 +1858,7 @@ cdefine('CT_USE_SYSTEM_YAMLCPP', 'system_yamlcpp')
 
 config_h_build = env.Command('build/src/config.h.build',
                              'include/cantera/base/config.h.in',
-                       ConfigBuilder(configh))
+                             ConfigBuilder(configh))
 # This separate copy operation, which SCons will skip if config.h.build is
 # unmodified, prevents unnecessary rebuilds of the precompiled header
 config_h = env.Command('include/cantera/base/config.h',

--- a/doc/SConscript
+++ b/doc/SConscript
@@ -1,11 +1,9 @@
-
 from collections import namedtuple
-from os.path import join as pjoin
 from pathlib import Path
-import os
 import subprocess
-from buildutils import *
 from SCons import Errors
+
+from buildutils import multi_glob
 
 Import('env', 'build', 'install')
 

--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -2,7 +2,9 @@
 import re
 from pathlib import Path
 from packaging.version import parse as parse_version
-from buildutils import *
+
+from buildutils import (get_command_output, which, multi_glob,
+                        get_pip_install_location, setup_python_env)
 
 Import('env', 'build', 'install')
 

--- a/platform/posix/SConscript
+++ b/platform/posix/SConscript
@@ -1,6 +1,4 @@
-import os
-
-from buildutils import *
+from buildutils import multi_glob, compiler_flag_list
 
 Import('env', 'build', 'install')
 localenv = env.Clone()

--- a/samples/clib/SConscript
+++ b/samples/clib/SConscript
@@ -1,5 +1,4 @@
-from os.path import join as pjoin, relpath
-from buildutils import *
+from buildutils import quoted, compiler_flag_list
 
 Import('env', 'install', 'buildSample')
 localenv = env.Clone()

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -1,7 +1,7 @@
 from os.path import join as pjoin
-import os
-from buildutils import *
 from collections import namedtuple
+
+from buildutils import logger, multi_glob, quoted, compiler_flag_list
 
 Import('env', 'build', 'install', 'buildSample')
 

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -1,5 +1,4 @@
-from os.path import join as pjoin, relpath
-from buildutils import *
+from buildutils import compiler_flag_list
 
 Import('env', 'install', 'buildSample')
 localenv = env.Clone()

--- a/samples/f90/SConscript
+++ b/samples/f90/SConscript
@@ -1,5 +1,6 @@
-from os.path import join as pjoin, relpath
-from buildutils import *
+from os.path import join as pjoin
+
+from buildutils import quoted
 
 Import('env', 'install', 'buildSample')
 localenv = env.Clone()

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -23,14 +23,6 @@ try:
 except ImportError:
     np = None
 
-__all__ = ("Option", "PathOption", "BoolOption", "EnumOption", "Configuration",
-           "logger", "remove_directory", "remove_file", "test_results",
-           "add_RegressionTest", "get_command_output", "listify", "which",
-           "ConfigBuilder", "multi_glob", "get_spawn", "quoted", "add_system_include",
-           "get_pip_install_location", "compiler_flag_list", "setup_python_env",
-           "checkout_submodule", "check_for_python", "make_relative_path_absolute",
-           "check_sundials", "config_error", "run_preprocessor")
-
 if TYPE_CHECKING:
     from typing import Iterable, TypeVar, Union, List, Dict, Tuple, Optional, \
         Iterator, Sequence

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1145,7 +1145,7 @@ def compiler_flag_list(
     cc_flags = []
     for flag in flags:
         if flag in cc_flags:
-                continue
+            continue
         if not any(re.match(exclude, flag) for exclude in excludes):
             cc_flags.append(flag)
 
@@ -1212,9 +1212,8 @@ def listify(value: "Union[str, Iterable]") -> "List[str]":
     """
     if isinstance(value, str):
         return value.split()
-    else:
-        # Already a sequence. Return as a list
-        return list(value)
+    # Already a sequence. Return as a list
+    return list(value)
 
 
 def remove_file(name: "TPathLike") -> None:
@@ -1231,19 +1230,6 @@ def remove_directory(name: "TPathLike") -> None:
     if path_name.exists() and path_name.is_dir():
         logger.info(f"Removing directory '{name!s}'")
         shutil.rmtree(path_name)
-
-
-def ipdb():
-    """
-    Break execution and drop into an IPython debug shell at the point
-    where this function is called.
-    """
-    from IPython.core.debugger import Pdb
-    from IPython.core import getipython
-
-    ip = getipython.get_ipython()
-    def_colors = ip.colors
-    Pdb(def_colors).set_trace(sys._getframe().f_back)
 
 
 def get_spawn(env: "SCEnvironment"):
@@ -1305,6 +1291,7 @@ def get_command_output(cmd: str, *args: str, ignore_errors=False):
         **kwargs,
     )
     return data.stdout.strip()
+
 
 _python_info = None
 def setup_python_env(env):
@@ -1392,6 +1379,7 @@ def setup_python_env(env):
 
 
     return env
+
 
 def get_pip_install_location(
     python_cmd: str,

--- a/src/SConscript
+++ b/src/SConscript
@@ -1,6 +1,7 @@
-from buildutils import *
-from pathlib import Path
 import re
+
+from buildutils import (logger, remove_file, multi_glob, get_spawn,
+                        add_system_include, setup_python_env)
 
 Import('env', 'build', 'install', 'libraryTargets')
 

--- a/src/fortran/SConscript
+++ b/src/fortran/SConscript
@@ -1,4 +1,4 @@
-from buildutils import *
+from buildutils import multi_glob, get_spawn
 
 Import('env', 'build', 'install')
 

--- a/test/SConscript
+++ b/test/SConscript
@@ -5,7 +5,7 @@ from os.path import join as pjoin
 import time
 import sys
 
-from buildutils import *
+from buildutils import logger, test_results, multi_glob
 
 Import('env','build','install')
 localenv = env.Clone()

--- a/test_problems/SConscript
+++ b/test_problems/SConscript
@@ -1,6 +1,7 @@
 import os
 from os.path import join as pjoin
-from buildutils import *
+
+from buildutils import test_results, multi_glob
 
 Import('env','build','install')
 localenv = env.Clone()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Replace 
```Python
from buildutils import *
```

with imports of specific methods and classes. The change improves readability and avoids unnecessary clutter in various namespaces.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
