### PR TITLE
Graphviz tweaks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -39,6 +39,7 @@ environment.y*
 *.msi
 *.mex*
 *.asv
+*.gv*
 .cproject
 .project
 .pydevproject

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -246,8 +246,8 @@ def draw_flow_controllers(flow_controllers, graph=None, graph_attr=None, node_at
             rate *= -1
 
         graph.edge(inflow_name, outflow_name,
-                   **{"label": f"ṁ = {rate:.2g} kg/s", **edge_attr, **fc.edge_attr,
-                      **edge_attr_overwrite})
+                   **{"label": f"{fc.name}\\nṁ = {rate:.2g} kg/s",
+                      **edge_attr, **fc.edge_attr, **edge_attr_overwrite})
 
     return graph
 
@@ -291,18 +291,18 @@ def draw_walls(walls, graph=None, graph_attr=None, node_attr=None, edge_attr=Non
         assert r_in.name != r_out.name, "All reactors must have unique names when drawn."
 
         # display wall velocity as arrow indicating the wall's movement
-        v = w.expansion_rate / w.area
-        if v != 0 and show_wall_velocity:
-            if v > 0:
+        vel = w.expansion_rate / w.area
+        if vel != 0 and show_wall_velocity:
+            if vel > 0:
                 inflow_name, outflow_name = r_in.name, r_out.name
             else:
-                v *= -1
+                vel *= -1
                 inflow_name, outflow_name = r_out.name, r_in.name
 
             graph.edge(inflow_name, outflow_name,
                        **{"arrowtail": "icurveteecurve", "dir": "both",
                           "style": "dotted", "arrowhead": "icurveteecurve",
-                          "label": f"wall vel. = {v:.2g} m/s",
+                          "label": f"{w.name}\\nv = {vel:.2g} m/s",
                           **(moving_wall_edge_attr or {})})
 
         # sum up heat rate/mass flow rate while considering the direction
@@ -310,7 +310,7 @@ def draw_walls(walls, graph=None, graph_attr=None, node_attr=None, edge_attr=Non
                 - sum(idupe.heat_Rate for idupe in inv_duplicates))
 
         # just show wall velocity if there is no heat flow
-        if rate == 0 and v > 0:
+        if rate == 0 and vel > 0:
             return graph
 
         # ensure arrow always indicates a positive flow
@@ -321,7 +321,7 @@ def draw_walls(walls, graph=None, graph_attr=None, node_attr=None, edge_attr=Non
 
         edge_attr = {"color": "red", "style": "dashed", **(edge_attr or {})}
         graph.edge(inflow_name, outflow_name,
-                   **{"label": f"q = {rate:.2g} W", **edge_attr, **w.edge_attr,
-                      **edge_attr_overwrite})
+                   **{"label": f"{w.name}\\nQ̇ = {rate:.2g} W",
+                      **edge_attr, **w.edge_attr, **edge_attr_overwrite})
 
     return graph

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -2083,6 +2083,7 @@ cdef class ReactorNet:
 
         .. versionadded:: 3.1
         """
-        return draw_reactor_net(self, graph_attr, node_attr, edge_attr, heat_flow_attr,
-                 mass_flow_attr, moving_wall_edge_attr, surface_edge_attr,
-                 show_wall_velocity, print_state, species, species_units)
+        return draw_reactor_net(self, graph_attr, node_attr, edge_attr,
+                                heat_flow_attr, mass_flow_attr, moving_wall_edge_attr,
+                                surface_edge_attr, show_wall_velocity, print_state,
+                                species, species_units)

--- a/samples/python/reactors/mix1.py
+++ b/samples/python/reactors/mix1.py
@@ -47,27 +47,27 @@ rho_b = gas_b.density
 # replaced with a reactor with no outlet, if it is desired to integrate the
 # composition leaving the mixer in time, or by an arbitrary network of
 # downstream reactors.
-res_a = ct.Reservoir(gas_a, name='air')
-res_b = ct.Reservoir(gas_b, name='fuel')
-downstream = ct.Reservoir(gas_b, name='outlet')
+res_a = ct.Reservoir(gas_a, name='Air Reservoir')
+res_b = ct.Reservoir(gas_b, name='Fuel Reservoir')
+downstream = ct.Reservoir(gas_a, name='Outlet Reservoir')
 
 # %%
 # Create a reactor for the mixer. A reactor is required instead of a
 # reservoir, since the state will change with time if the inlet mass flow
 # rates change or if there is chemistry occurring.
 gas_b.TPX = 300.0, ct.one_atm, 'O2:0.21, N2:0.78, AR:0.01'
-mixer = ct.IdealGasReactor(gas_b, name='mixer')
+mixer = ct.IdealGasReactor(gas_b, name='Mixer')
 
 # %%
 # Create two mass flow controllers connecting the upstream reservoirs to the
 # mixer, and set their mass flow rates to values corresponding to
 # stoichiometric combustion.
-mfc1 = ct.MassFlowController(res_a, mixer, mdot=rho_a*2.5/0.21)
-mfc2 = ct.MassFlowController(res_b, mixer, mdot=rho_b*1.0)
+mfc1 = ct.MassFlowController(res_a, mixer, mdot=rho_a*2.5/0.21, name="Air Inlet")
+mfc2 = ct.MassFlowController(res_b, mixer, mdot=rho_b*1.0, name="Fuel Inlet")
 
 # %%
 # Connect the mixer to the downstream reservoir with a valve.
-outlet = ct.Valve(mixer, downstream, K=10.0)
+outlet = ct.Valve(mixer, downstream, K=10.0, name="Valve")
 
 sim = ct.ReactorNet([mixer])
 
@@ -84,4 +84,7 @@ print(mixer.thermo.report())
 # %%
 # Show the network structure
 # --------------------------
-diagram = sim.draw(print_state=True, species="X")
+try:
+    diagram = sim.draw(print_state=True, species="X")
+except ImportError as err:
+    print(f"Unable to show network structure:\n{err}")

--- a/samples/python/reactors/reactor2.py
+++ b/samples/python/reactors/reactor2.py
@@ -57,12 +57,12 @@ r2 = ct.IdealGasReactor(gas, name="Reacting partition")
 # conduct heat
 
 # add a flexible wall (a piston) between r2 and r1
-w = ct.Wall(r2, r1, A=1.0, K=0.5e-4, U=100.0)
+w = ct.Wall(r2, r1, A=1.0, K=0.5e-4, U=100.0, name="Piston")
 
 # heat loss to the environment. Heat loss always occur through walls, so we
 # create a wall separating r2 from the environment, give it a non-zero area,
 # and specify the overall heat transfer coefficient through the wall.
-w2 = ct.Wall(r2, env, A=1.0, U=500.0)
+w2 = ct.Wall(r2, env, A=1.0, U=500.0, name="External Wall")
 
 sim = ct.ReactorNet([r1, r2])
 
@@ -118,4 +118,7 @@ _ = ax[2].set(xlabel='Time (s)', ylabel='Volume (m$^3$)')
 # %%
 # Show the final state
 # --------------------
-sim.draw(print_state=True, species="X")
+try:
+    diagram = sim.draw(print_state=True, species="X")
+except ImportError as err:
+    print(f"Unable to show network structure:\n{err}")


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR separates `ReactorNet` visualization tweaks from #1788 to facilitate further reviews.

- Add wall names to ReactorNet graphviz illustrations.
- Partially addresses review comment by removing `diagram.view`

There is a caveat here, - see Cantera/enhancements#212, - as well as per @speth's comment:

> Regarding the extension of the graph idiom, I think there's a simplification that may be worth considering. Instead of seeing just `Reactor` and `ReactorSurface` objects as nodes in the graph, you could also see valves and flow devices as nodes, with the edges of the graph just being the abstract connections among all of the entities that make up the reactor network. This way, there's only the need for one new base class, and no need for anything to sit between a `Reactor` and a `ReactorSurface`. This also gets closer to the original intent of Cantera/enhancements#212, and may work better as the amount of information you might want to display about a connector increases, given some of the limitations of how Graphviz handles (or doesn't) text associated with edges. That said, I do like the `Connector` class as a generalization combining walls and flow devices, and there's probably some further room to adjust this idea.

On the other hand, there is @Naikless's original intent:

> In classical graph terminology, when I introduced the visualization, I envisioned the flow devices and the walls as "edges" that each connect two "nodes" that are reactors or reservoirs. So now they are represented as arrows of different shape and color. This way, the direction of both material and energy flow can be indicated relatively easily. Their main property (the amount of flow) is still displayed.

> Having them represented as nodes could imo quickly lead to very cluttered networks, especially since there are quite a few scenarios conceivable where two reactors have a multitude of connections to one another. But I am happy to hear your arguments on this.

This PR attempts to stick with the original intent.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes https://github.com/Cantera/enhancements/issues/212 (minor aspect of this PR)

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
