### PR TITLE
Pytest transition

### DIFF
--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -56,6 +56,13 @@ def load_yaml():
                 return yaml.safe_load(stream)
     return _load
 
+@pytest.fixture(scope="session")
+def test_data_path():
+    return TEST_DATA_PATH
+
+@pytest.fixture(scope="session")
+def cantera_data_path():
+    return CANTERA_DATA_PATH
 
 @pytest.fixture(scope="session", autouse=True)
 def cantera_setup():
@@ -67,6 +74,7 @@ def cantera_setup():
     cantera.add_directory(CANTERA_DATA_PATH)
     cantera.print_stack_trace_on_segfault()
     cantera.CanteraError.set_stack_trace_depth(20)
+    cantera.make_deprecation_warnings_fatal()
 
     # Yield control to tests
     yield
@@ -102,7 +110,6 @@ def test_work_path(request, cantera_setup):
         work_path = Path(tempfile.mkdtemp())
         using_tempfile = True
 
-    cantera.make_deprecation_warnings_fatal()
     cantera.add_directory(work_path)
 
     # Assign to the test class

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,6 +1,123 @@
+import cantera
+from os import environ
+from pathlib import Path
 import pytest
+import tempfile
 
-# Loads fixtures defined in utilities.py for use in tests
-pytest_plugins = ["utilities"]
+try:
+    from ruamel import yaml
+except ImportError:
+    import ruamel_yaml as yaml
 
 pytest.register_assert_rewrite("pint.testing")
+
+TEST_DATA_PATH = Path(__file__).parents[1] / "data"
+CANTERA_DATA_PATH = Path(cantera.__file__).parent / "data"
+
+
+def pytest_configure(config):
+    config.addinivalue_line("markers", "slow_test: mark test as slow")
+
+def pytest_collection_modifyitems(config, items):
+    if environ.get("CT_SKIP_SLOW", "0") == "1":
+        skip_slow = pytest.mark.skip(reason="slow test")
+        for item in items:
+            if "slow_test" in item.keywords:
+                item.add_marker(skip_slow)
+
+@pytest.fixture
+def allow_deprecated():
+    cantera.suppress_deprecation_warnings()
+    yield
+    cantera.make_deprecation_warnings_fatal()
+
+
+@pytest.fixture
+def has_temperature_derivative_warnings():
+    with pytest.warns(UserWarning, match="ddTScaledFromStruct"):
+        # test warning raised for BlowersMasel and TwoTempPlasma derivatives
+        yield
+
+
+@pytest.fixture(scope="session")
+def load_yaml():
+    """
+    Fixture to load YAML files safely.
+    """
+    def _load(yml_file):
+        try:
+            yaml_parser = yaml.YAML(typ="safe")
+            with open(yml_file, "rt", encoding="utf-8") as stream:
+                return yaml_parser.load(stream)
+        except yaml.constructor.ConstructorError:
+            # Ensure that the loader remains backward-compatible with legacy
+            # ruamel.yaml versions (prior to 0.17.0).
+            with open(yml_file, "rt", encoding="utf-8") as stream:
+                return yaml.safe_load(stream)
+    return _load
+
+
+@pytest.fixture(scope="session", autouse=True)
+def cantera_setup():
+    """
+    Fixture to set up Cantera environment for the entire test session.
+    """
+    # Add data directories
+    cantera.add_directory(TEST_DATA_PATH)
+    cantera.add_directory(CANTERA_DATA_PATH)
+    cantera.print_stack_trace_on_segfault()
+    cantera.CanteraError.set_stack_trace_depth(20)
+
+    # Yield control to tests
+    yield
+
+
+@pytest.fixture(scope="class", autouse=True)
+def test_work_path(request, cantera_setup):
+    """
+    Fixture to create a working directory for a test class.
+    This will only run for class-based tests.
+
+    The check on the request.cls attribute is to ensure that this fixture
+    does not run for function-based tests. There is likely a better way to
+    do this, perhaps by disabling autouse and using the fixture explicitly
+    in the test classes that need it.
+    """
+
+    if request.cls is None:
+        # If this is not a class-based test, do nothing.
+        yield
+        return
+
+    root_dir = Path(__file__).parents[2].resolve()
+    if (root_dir / "SConstruct").is_file():
+        work_path = root_dir / "test" / "work" / "python"
+        using_tempfile = False
+        try:
+            work_path.mkdir(exist_ok=True)
+        except FileNotFoundError:
+            work_path = Path(tempfile.mkdtemp())
+            using_tempfile = True
+    else:
+        work_path = Path(tempfile.mkdtemp())
+        using_tempfile = True
+
+    cantera.make_deprecation_warnings_fatal()
+    cantera.add_directory(work_path)
+
+    # Assign to the test class
+    request.cls.test_work_path = work_path
+    request.cls.using_tempfile = using_tempfile
+    request.cls.test_data_path = TEST_DATA_PATH
+    request.cls.cantera_data_path = CANTERA_DATA_PATH
+
+    yield
+
+    # Teardown: Remove the working directory if it was a temporary one
+    if using_tempfile:
+        try:
+            for f in work_path.glob("*.*"):
+                f.unlink()
+            work_path.rmdir()
+        except FileNotFoundError:
+            pass

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -16,6 +16,14 @@ TEST_DATA_PATH = Path(__file__).parents[1] / "data"
 CANTERA_DATA_PATH = Path(cantera.__file__).parent / "data"
 
 
+def pytest_addoption(parser):
+    parser.addoption(
+        "--save-reference", action="store", default=None,
+        help="Save the reference output files for specific tests. "
+             "Options: diffusion, counterflow_premixed, counterflow_premixed_nonideal, "
+             "combustor, wall"
+    )
+
 def pytest_configure(config):
     config.addinivalue_line("markers", "slow_test: mark test as slow")
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -97,8 +97,6 @@ def test_work_path(request, cantera_setup):
     # Assign to the test class
     request.cls.test_work_path = work_path
     request.cls.using_tempfile = using_tempfile
-    request.cls.test_data_path = TEST_DATA_PATH
-    request.cls.cantera_data_path = CANTERA_DATA_PATH
 
     yield
 

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,3 +1,6 @@
 import pytest
 
+# Loads fixtures defined in utilities.py for use in tests
+pytest_plugins = ["utilities"]
+
 pytest.register_assert_rewrite("pint.testing")

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -1,5 +1,6 @@
 import cantera
-from os import environ
+import os
+import sys
 from pathlib import Path
 import pytest
 import tempfile
@@ -19,7 +20,7 @@ def pytest_configure(config):
     config.addinivalue_line("markers", "slow_test: mark test as slow")
 
 def pytest_collection_modifyitems(config, items):
-    if environ.get("CT_SKIP_SLOW", "0") == "1":
+    if os.environ.get("CT_SKIP_SLOW", "0") == "1":
         skip_slow = pytest.mark.skip(reason="slow test")
         for item in items:
             if "slow_test" in item.keywords:
@@ -46,7 +47,7 @@ def test_data_path():
 def cantera_data_path():
     return CANTERA_DATA_PATH
 
-@pytest.fixture(scope="session", autouse=True)
+@pytest.fixture(scope="module", autouse=True)
 def cantera_setup():
     """
     Fixture to set up Cantera environment for the entire test session.

--- a/test/python/conftest.py
+++ b/test/python/conftest.py
@@ -38,24 +38,6 @@ def has_temperature_derivative_warnings():
         # test warning raised for BlowersMasel and TwoTempPlasma derivatives
         yield
 
-
-@pytest.fixture(scope="session")
-def load_yaml():
-    """
-    Fixture to load YAML files safely.
-    """
-    def _load(yml_file):
-        try:
-            yaml_parser = yaml.YAML(typ="safe")
-            with open(yml_file, "rt", encoding="utf-8") as stream:
-                return yaml_parser.load(stream)
-        except yaml.constructor.ConstructorError:
-            # Ensure that the loader remains backward-compatible with legacy
-            # ruamel.yaml versions (prior to 0.17.0).
-            with open(yml_file, "rt", encoding="utf-8") as stream:
-                return yaml.safe_load(stream)
-    return _load
-
 @pytest.fixture(scope="session")
 def test_data_path():
     return TEST_DATA_PATH

--- a/test/python/pytest.ini
+++ b/test/python/pytest.ini
@@ -1,2 +1,5 @@
 [pytest]
+markers =
+    slow_test: mark test as slow
+
 pythonpath = ../../build/python

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -791,7 +791,7 @@ class TestLegacyHDF:
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
     @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
-    def test_legacy_hdf(self, test_data_path, legacy=False):
+    def test_legacy_hdf(self, test_data_path):
         # recreate states used to create legacy HDF file (valid portion)
         extra = {'foo': range(7), 'bar': range(7)}
         meta = {'spam': 'eggs', 'hello': 'world'}
@@ -814,7 +814,7 @@ class TestLegacyHDF:
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
     @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
-    def test_read_legacy_hdf_no_norm(self, test_data_path, legacy=False):
+    def test_read_legacy_hdf_no_norm(self, test_data_path):
         # recreate states used to create legacy HDF file
         self.gas.set_unnormalized_mole_fractions(np.full(self.gas.n_species, 0.3))
         states = ct.SolutionArray(self.gas, 5)
@@ -822,10 +822,7 @@ class TestLegacyHDF:
         infile = test_data_path / "solutionarray_no_norm_legacy.h5"
 
         b = ct.SolutionArray(self.gas)
-        if legacy:
-            b.read_hdf(infile, normalize=False)
-        else:
-            b.restore(infile, "group0")
+        b.restore(infile, "group0")
         assert states.T == approx(b.T, rel=1e-7)
         assert states.P == approx(b.P, rel=1e-7)
         assert states.X == approx(b.X, rel=1e-7)

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -14,8 +14,6 @@ except ImportError:
 
 from cantera.composite import _pandas
 
-from . import utilities
-from .utilities import allow_deprecated
 from .utilities import (
     assertNear,
     assertArrayNear

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -3,7 +3,6 @@ import pickle
 import pytest
 import re
 from ruamel import yaml
-import sys
 
 import cantera as ct
 
@@ -17,7 +16,6 @@ from cantera.composite import _pandas
 from .utilities import (
     assertNear,
     assertArrayNear
-
 )
 
 @pytest.fixture(scope='class')
@@ -1113,12 +1111,11 @@ class TestSolutionSerialization:
         assert data['custom-field']['first'] == True
         assert data['custom-field']['last'] == [100, 200, 300]
 
-        if sys.version_info >= (3,7):
-            # Check that items are ordered as expected
-            assert list(data) == ["name", "thermo", "elements", "species", "state",
-                                  "custom-field", "literal-string"]
-            assert list(data["custom-field"]) == ["first", "second", "last"]
-            assert data["literal-string"] == "spam\nand\neggs\n"
+        # Check that items are ordered as expected
+        assert list(data) == ["name", "thermo", "elements", "species", "state",
+                                "custom-field", "literal-string"]
+        assert list(data["custom-field"]) == ["first", "second", "last"]
+        assert data["literal-string"] == "spam\nand\neggs\n"
 
     def test_input_data_debye_huckel(self):
         soln = ct.Solution('thermo-models.yaml', 'debye-huckel-B-dot-ak')

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -22,8 +22,8 @@ from . import utilities
 class TestModels(utilities.CanteraTest):
 
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.yml_file = cls.test_data_path / "thermo-models.yaml"
         cls.yml = utilities.load_yaml(cls.yml_file)
 
@@ -169,8 +169,8 @@ class TestPickle(utilities.CanteraTest):
 class TestEmptyThermoPhase(utilities.CanteraTest):
     """ Test empty Solution object """
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.ThermoPhase()
 
     def test_empty_report(self):
@@ -189,8 +189,8 @@ class TestEmptyThermoPhase(utilities.CanteraTest):
 class TestEmptySolution(TestEmptyThermoPhase):
     """ Test empty Solution object """
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution()
 
     def test_empty_composite(self):
@@ -216,8 +216,8 @@ class TestEmptyEdgeCases(utilities.CanteraTest):
 class TestSolutionArray(utilities.CanteraTest):
     """ Test SolutionArray basics """
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
     def test_from_state_scalar(self):
@@ -322,8 +322,8 @@ class TestSolutionArrayInfo(utilities.CanteraTest):
     width = 80
 
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
     def setUp(self):
@@ -435,8 +435,8 @@ class TestSolutionArrayInfo(utilities.CanteraTest):
 class TestSolutionArrayIO(utilities.CanteraTest):
     """ Test SolutionArray file IO """
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
     def test_collect_data(self):
@@ -601,7 +601,7 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         with pytest.raises(ct.CanteraError, match="Invalid species basis"):
             arr.save(outfile, basis="foo")
 
-    @utilities.unittest.skipIf(_pandas is None, "pandas is not installed")
+    @pytest.mark.skipif(_pandas is None, reason="pandas is not installed")
     def test_to_pandas(self):
         states = ct.SolutionArray(self.gas, 7, extra={"props": range(7)})
         states.TPX = np.linspace(300, 1000, 7), 2e5, 'H2:0.5, O2:0.4'
@@ -860,8 +860,8 @@ class TestLegacyHDF(utilities.CanteraTest):
 class TestRestoreIdealGas(utilities.CanteraTest):
     """ Test restoring of the IdealGas class """
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
     def test_restore_gas(self):
@@ -970,8 +970,8 @@ class TestRestoreIdealGas(utilities.CanteraTest):
 class TestRestorePureFluid(utilities.CanteraTest):
     """ Test restoring of the PureFluid class """
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.water = ct.Water()
 
     def test_restore_water(self):

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -1,12 +1,9 @@
-import sys
-
 import numpy as np
 import pickle
-import re
-
 import pytest
+import re
 from ruamel import yaml
-from .utilities import allow_deprecated
+import sys
 
 import cantera as ct
 
@@ -16,16 +13,22 @@ except ImportError:
     pass
 
 from cantera.composite import _pandas
+
 from . import utilities
+from .utilities import allow_deprecated
+from .utilities import (
+    assertNear,
+    assertArrayNear
 
+)
 
-class TestModels(utilities.CanteraTest):
+@pytest.fixture(scope='class')
+def setup_models_tests(request, load_yaml):
+    request.cls.yml_file = request.cls.test_data_path / "thermo-models.yaml"
+    request.cls.yml = load_yaml(request.cls.yml_file)
 
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.yml_file = cls.test_data_path / "thermo-models.yaml"
-        cls.yml = utilities.load_yaml(cls.yml_file)
+@pytest.mark.usefixtures('setup_models_tests')
+class TestModels:
 
     def test_load_thermo_models(self):
         for ph in self.yml['phases']:
@@ -38,26 +41,26 @@ class TestModels(utilities.CanteraTest):
                 z = sol.state # calls Phase::saveState
                 sol.TP = 300, 2*ct.one_atm
                 sol.state = z # calls Phase::restoreState
-                self.assertEqual(sol.T, T0)
-                self.assertEqual(sol.P, p0)
+                assert sol.T == T0
+                assert sol.P == p0
 
                 if sol.thermo_model in ('pure-fluid',):
-                    self.assertTrue(sol.has_phase_transition)
+                    assert sol.has_phase_transition
                 else:
-                    self.assertFalse(sol.has_phase_transition)
+                    assert not sol.has_phase_transition
 
                 if not sol.is_compressible:
-                    with self.assertRaisesRegex(ct.CanteraError,
-                                                'Density is not an independent'):
+                    with pytest.raises(ct.CanteraError,
+                                       match='Density is not an independent'):
                         sol.TD = TD
 
-                self.assertEqual(len(z), sol.state_size)
+                assert len(z) == sol.state_size
                 if sol.is_pure:
                     # stoich phase (fixed composition)
-                    self.assertEqual(sol.n_species, 1)
-                    self.assertEqual(len(z), 2)
+                    assert sol.n_species == 1
+                    assert len(z) == 2
                 else:
-                    self.assertEqual(len(z), 2 + sol.n_species)
+                    assert len(z) == 2 + sol.n_species
 
             except Exception as inst:
 
@@ -74,9 +77,9 @@ class TestModels(utilities.CanteraTest):
     def test_restore_thermo_models(self):
 
         def check(a, b):
-            self.assertArrayNear(a.T, b.T)
-            self.assertArrayNear(a.P, b.P)
-            self.assertArrayNear(a.X, b.X)
+            assertArrayNear(a.T, b.T)
+            assertArrayNear(a.P, b.P)
+            assertArrayNear(a.X, b.X)
 
         for ph in self.yml['phases']:
 
@@ -104,8 +107,8 @@ class TestModels(utilities.CanteraTest):
                     ix = np.where(X == xmin)
                     X[ix] = .5 * X[ix]
                     X = np.diag(X.sum(axis=1)).dot(X)
-                    self.assertFalse(sol.is_pure)
-                    self.assertIn('TPX', sol._full_states.values())
+                    assert not sol.is_pure
+                    assert 'TPX' in sol._full_states.values()
                     a.TPX = T, P, X
 
                 # default columns
@@ -127,7 +130,7 @@ class TestModels(utilities.CanteraTest):
                     raise TypeError(msg) from inst
 
 
-class TestPickle(utilities.CanteraTest):
+class TestPickle:
 
     def test_pickle_gas(self):
         gas = ct.Solution("h2o2.yaml", transport_model=None)
@@ -137,11 +140,11 @@ class TestPickle(utilities.CanteraTest):
 
         with open(self.test_work_path / "gas.pkl", "rb") as pkl:
             gas2 = pickle.load(pkl)
-        self.assertNear(gas.T, gas2.T)
-        self.assertNear(gas.P, gas2.P)
-        self.assertArrayNear(gas.X, gas2.X)
+        assertNear(gas.T, gas2.T)
+        assertNear(gas.P, gas2.P)
+        assertArrayNear(gas.X, gas2.X)
 
-        self.assertEqual(gas2.transport_model, "none")
+        assert  gas2.transport_model == "none"
 
     def test_pickle_gas_with_transport(self):
         gas = ct.Solution("h2o2.yaml")
@@ -152,26 +155,25 @@ class TestPickle(utilities.CanteraTest):
 
         with open(self.test_work_path / "gas.pkl", "rb") as pkl:
             gas2 = pickle.load(pkl)
-        self.assertNear(gas.T, gas2.T)
-        self.assertNear(gas.P, gas2.P)
-        self.assertArrayNear(gas.X, gas2.X)
+        assertNear(gas.T, gas2.T)
+        assertNear(gas.P, gas2.P)
+        assertArrayNear(gas.X, gas2.X)
 
-        self.assertEqual(gas2.transport_model, "multicomponent")
+        assert gas2.transport_model == "multicomponent"
 
     def test_pickle_interface(self):
         interface = ct.Interface("diamond.yaml", "diamond_100")
 
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             with open(self.test_work_path / "interface.pkl", "wb") as pkl:
                 pickle.dump(interface, pkl)
 
-
-class TestEmptyThermoPhase(utilities.CanteraTest):
+@pytest.fixture(scope='class')
+def setup_empty_thermo_phase_tests(request):
+    request.cls.gas = ct.ThermoPhase()
+@pytest.mark.usefixtures('setup_empty_thermo_phase_tests')
+class TestEmptyThermoPhase:
     """ Test empty Solution object """
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.ThermoPhase()
 
     def test_empty_report(self):
         with pytest.raises(NotImplementedError):
@@ -186,62 +188,63 @@ class TestEmptyThermoPhase(utilities.CanteraTest):
             self.gas.equilibrate("TP")
 
 
-class TestEmptySolution(TestEmptyThermoPhase):
+class TestEmptySolution:
     """ Test empty Solution object """
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.Solution()
 
-    def test_empty_composite(self):
-        self.assertEqual(self.gas.thermo_model, "none")
-        self.assertEqual(self.gas.composite, ("none", "none", "none"))
+    @pytest.fixture(scope='function')
+    def gas(self):
+        return ct.Solution()
+
+    def test_empty_composite(self, gas):
+        assert gas.thermo_model == "none"
+        assert gas.composite ==  ("none", "none", "none")
 
 
-class TestEmptyEdgeCases(utilities.CanteraTest):
+class TestEmptyEdgeCases:
     """ Test for edge cases where constructors are not allowed """
     def test_empty_phase(self):
-        with self.assertRaisesRegex(ValueError, "Arguments are insufficient to define a phase"):
+        with pytest.raises(ValueError,
+                           match="Arguments are insufficient to define a phase"):
             ct.ThermoPhase(thermo="ideal-gas")
 
     def test_empty_kinetics(self):
-        with self.assertRaisesRegex(ValueError, "Cannot instantiate"):
+        with pytest.raises(ValueError, match="Cannot instantiate"):
             ct.Kinetics()
 
     def test_empty_transport(self):
-        with self.assertRaisesRegex(ValueError, "Cannot instantiate"):
+        with pytest.raises(ValueError, match="Cannot instantiate"):
             ct.Transport()
 
 
-class TestSolutionArray(utilities.CanteraTest):
+class TestSolutionArray:
     """ Test SolutionArray basics """
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
-    def test_from_state_scalar(self):
-        state = list(self.gas.state)
-        arr = ct.SolutionArray(self.gas, states=[state])
+    @pytest.fixture(scope='function')
+    def gas(self):
+        return ct.Solution('h2o2.yaml', transport_model=None)
+
+    def test_from_state_scalar(self, gas):
+        state = list(gas.state)
+        arr = ct.SolutionArray(gas, states=[state])
         assert arr.shape == (1,)
 
-    def test_from_state_list(self):
-        states = [list(self.gas.state)] * 5
-        arr = ct.SolutionArray(self.gas, states=states)
+    def test_from_state_list(self, gas):
+        states = [list(gas.state)] * 5
+        arr = ct.SolutionArray(gas, states=states)
         assert arr.shape == (5,)
 
-    def test_from_state_array(self):
-        states = [[list(self.gas.state)] * 5] * 3
-        arr = ct.SolutionArray(self.gas, states=states)
+    def test_from_state_array(self, gas):
+        states = [[list(gas.state)] * 5] * 3
+        arr = ct.SolutionArray(gas, states=states)
         assert arr.shape == (3, 5) # shape is based on numpy conversion
 
-    def test_slice_twice(self):
+    def test_slice_twice(self, gas):
         T_list = np.linspace(300, 1000, 8)
-        self.gas.TPX = T_list[0], ct.one_atm, {"H2": 1.}
-        arr = ct.SolutionArray(self.gas)
+        gas.TPX = T_list[0], ct.one_atm, {"H2": 1.}
+        arr = ct.SolutionArray(gas)
         for T in T_list[1:]:
-            self.gas.TPX = T, ct.one_atm, {"H2": 1.}
-            arr.append(self.gas.state)
+            gas.TPX = T, ct.one_atm, {"H2": 1.}
+            arr.append(gas.state)
         ix = 4
         arr_trunc = arr[ix:]
         assert arr_trunc.T[0] == arr.T[ix]
@@ -250,22 +253,22 @@ class TestSolutionArray(utilities.CanteraTest):
         assert arr_trunc[-1].T == arr.T[-1]
         assert (arr_trunc.T[:2] == arr.T[ix:ix+2]).all()
         assert (arr_trunc[:2].T == arr.T[ix:ix+2]).all()
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             arr_trunc[10]
 
-    def test_from_state_numpy(self):
-        states = np.array([[list(self.gas.state)] * 5] * 3)
-        arr = ct.SolutionArray(self.gas, states=states)
+    def test_from_state_numpy(self, gas):
+        states = np.array([[list(gas.state)] * 5] * 3)
+        arr = ct.SolutionArray(gas, states=states)
         assert arr.shape == (3, 5)
 
-    def test_missing_attribute(self):
-        arr = ct.SolutionArray(self.gas, 5, extra={"spam": 0})
+    def test_missing_attribute(self, gas):
+        arr = ct.SolutionArray(gas, 5, extra={"spam": 0})
         assert len(arr.spam) == 5
         with pytest.raises(AttributeError, match="no attribute"):
             arr.eggs
 
-    def test_auxiliary(self):
-        arr = ct.SolutionArray(self.gas, 5, extra={"spam": 0})
+    def test_auxiliary(self, gas):
+        arr = ct.SolutionArray(gas, 5, extra={"spam": 0})
         arr.spam = np.arange(5)
         assert len(arr.spam) == 5
         assert arr.get_auxiliary(4) == {"spam": 4}
@@ -311,22 +314,22 @@ class TestSolutionArray(utilities.CanteraTest):
         gas = ct.Solution("ptcombust.yaml", "gas", transport_model=None)
         surf = ct.Interface("ptcombust.yaml", "Pt_surf", [gas])
         arr = ct.SolutionArray(surf, shape=1)
-        with self.assertRaisesRegex(NotImplementedError, "containing Interface"):
+        with pytest.raises(NotImplementedError, match="containing Interface"):
             arr.net_production_rates
         arr = ct.SolutionArray(gas, shape=1)
         assert arr.net_production_rates.size == gas.n_species
 
 
-class TestSolutionArrayInfo(utilities.CanteraTest):
+@pytest.fixture(scope='class')
+def setup_solution_array_info_tests(request):
+    request.cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
+@pytest.mark.usefixtures('setup_solution_array_info_tests')
+class TestSolutionArrayInfo:
     """ Test SolutionArray summary output """
     width = 80
 
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
-
-    def setUp(self):
+    def setup_method(self):
+        """ Runs before each test """
         self.gas.TPY = 300, ct.one_atm, "H2: 1"
 
     def check(self, arr, repr, rows):
@@ -431,25 +434,25 @@ class TestSolutionArrayInfo(utilities.CanteraTest):
         arr = ct.SolutionArray(w, 15, extra={"spam": np.arange(15, dtype=int)})
         self.check(arr, arr.info(rows=7, width=self.width), 8)
 
+@pytest.fixture(scope='class')
+def setup_solution_array_io_tests(request):
+    request.cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
-class TestSolutionArrayIO(utilities.CanteraTest):
+@pytest.mark.usefixtures('setup_solution_array_io_tests')
+class TestSolutionArrayIO:
     """ Test SolutionArray file IO """
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
     def test_collect_data(self):
         states = ct.SolutionArray(self.gas)
         collected = states.collect_data(tabular=True)
-        self.assertIsInstance(collected, dict)
-        self.assertIn('Y_H2', collected)
-        self.assertEqual(len(collected['Y_H2']), 0)
+        assert isinstance(collected, dict)
+        assert 'Y_H2' in collected
+        assert len(collected['Y_H2']) == 0
 
         states = ct.SolutionArray(self.gas)
         collected = states.collect_data(tabular=False, species='X')
-        self.assertIn('X', collected)
-        self.assertEqual(collected['X'].shape, (0, self.gas.n_species))
+        assert 'X' in collected
+        assert collected['X'].shape == (0, self.gas.n_species)
 
     def test_getitem(self):
         states = ct.SolutionArray(self.gas, 10, extra={"index": range(10)})
@@ -464,13 +467,13 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         gas.TPX = 300, ct.one_atm, 'H2:0.5, O2:0.4'
         states = ct.SolutionArray(gas)
         states.append(gas.state)
-        self.assertEqual(states[0].T, gas.T)
-        self.assertEqual(states[0].P, gas.P)
-        self.assertArrayNear(states[0].X, gas.X)
-        self.assertEqual(len(states), 1)
-        self.assertEqual(states.shape, (1,))
-        self.assertEqual(states.ndim, 1)
-        self.assertEqual(states.size, 1)
+        assert states[0].T == gas.T
+        assert states[0].P == gas.P
+        assertArrayNear(states[0].X, gas.X)
+        assert len(states) == 1
+        assert states.shape == (1,)
+        assert states.ndim == 1
+        assert states.size == 1
 
     def test_append_no_norm_data(self):
         gas = ct.Solution("h2o2.yaml")
@@ -478,9 +481,9 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         gas.set_unnormalized_mass_fractions(np.full(gas.n_species, 0.3))
         states = ct.SolutionArray(gas)
         states.append(T=gas.T, P=gas.P, Y=gas.Y, normalize=False)
-        self.assertEqual(states[0].T, gas.T)
-        self.assertEqual(states[0].P, gas.P)
-        self.assertArrayNear(states[0].Y, gas.Y)
+        assert states[0].T == gas.T
+        assert states[0].P == gas.P
+        assertArrayNear(states[0].Y, gas.Y)
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
@@ -496,20 +499,20 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         gas_new = ct.Solution("h2o2.yaml")
         b = ct.SolutionArray(gas_new)
         b.restore(outfile, "group0") #, normalize=False)
-        self.assertArrayNear(states.T, b.T)
-        self.assertArrayNear(states.P, b.P)
-        self.assertArrayNear(states.X, b.X)
+        assertArrayNear(states.T, b.T)
+        assertArrayNear(states.P, b.P)
+        assertArrayNear(states.X, b.X)
 
     def check_arrays(self, a, b, rtol=1e-8):
-        self.assertArrayNear(a.T, b.T, rtol=rtol)
-        self.assertArrayNear(a.P, b.P, rtol=rtol)
-        self.assertArrayNear(a.X, b.X, rtol=rtol)
+        assertArrayNear(a.T, b.T, rtol=rtol)
+        assertArrayNear(a.P, b.P, rtol=rtol)
+        assertArrayNear(a.X, b.X, rtol=rtol)
         for key in a.extra:
             value = getattr(a, key)
             if isinstance(value[0], str):
                 assert (getattr(b, key) == value).all()
             else:
-                self.assertArrayNear(getattr(b, key), value, rtol=rtol)
+                assertArrayNear(getattr(b, key), value, rtol=rtol)
         if b.meta:
             # not all output formats preserve metadata
             for key, value in a.meta.items():
@@ -606,9 +609,9 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         states = ct.SolutionArray(self.gas, 7, extra={"props": range(7)})
         states.TPX = np.linspace(300, 1000, 7), 2e5, 'H2:0.5, O2:0.4'
         df = states.to_pandas()
-        self.assertEqual(df.shape[0], 7)
+        assert df.shape[0] == 7
         states.props = np.zeros((7,2,))
-        with self.assertRaisesRegex(NotImplementedError, 'not supported'):
+        with pytest.raises(NotImplementedError, match='not supported'):
             states.to_pandas()
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
@@ -738,23 +741,27 @@ class TestSolutionArrayIO(utilities.CanteraTest):
         return outfile, outfile2
 
 
-class TestLegacyHDF(utilities.CanteraTest):
-    # Test SolutionArray legacy HDF file input
-    #
-    # All input files were created using the Cantera 2.6 Python test suite:
-    # - solutionarray_fancy_legacy.h5
-    #   -> test_composite.py::TestSolutionArrayIO::test_write_hdf
-    # - solutionarray_str_legacy.h5
-    #   -> test_composite.py::TestSolutionArrayIO::test_write_hdf_str_column
-    # - solutionarray_multi_legacy.h5
-    #   -> test_composite.py::TestSolutionArrayIO::test_write_hdf_multi_column
-    # - solutionarray_no_norm_legacy.h5
-    #   -> test_composite.py::TestSolutionArrayIO::test_import_no_norm_data
-    # - solutionarray_water_legacy.h5
-    #   -> test_composite.py::TestRestorePureFluid::test_import_no_norm_water
+@pytest.fixture(scope='function')
+def setup_legacy_hdf_tests(request):
+    request.cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
-    def setUp(self):
-        self.gas = ct.Solution('h2o2.yaml', transport_model=None)
+@pytest.mark.usefixtures('setup_legacy_hdf_tests')
+class TestLegacyHDF:
+    """
+    Test SolutionArray legacy HDF file input
+
+    All input files were created using the Cantera 2.6 Python test suite:
+    - solutionarray_fancy_legacy.h5
+      -> test_composite.py::TestSolutionArrayIO::test_write_hdf
+    - solutionarray_str_legacy.h5
+      -> test_composite.py::TestSolutionArrayIO::test_write_hdf_str_column
+    - solutionarray_multi_legacy.h5
+      -> test_composite.py::TestSolutionArrayIO::test_write_hdf_multi_column
+    - solutionarray_no_norm_legacy.h5
+      -> test_composite.py::TestSolutionArrayIO::test_import_no_norm_data
+     - solutionarray_water_legacy.h5
+      -> test_composite.py::TestRestorePureFluid::test_import_no_norm_water
+    """
 
     @pytest.mark.xfail(reason="Unable to read fixed length strings from HDF")
     @pytest.mark.skipif("native" not in ct.hdf_support(),
@@ -789,7 +796,7 @@ class TestLegacyHDF(utilities.CanteraTest):
         infile = self.test_data_path / f"solutionarray_multi_legacy.h5"
 
         b.restore(infile, "group0")
-        self.assertArrayNear(arr.spam, b.spam)
+        assertArrayNear(arr.spam, b.spam)
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
@@ -808,14 +815,14 @@ class TestLegacyHDF(utilities.CanteraTest):
         infile = self.test_data_path / f"solutionarray_fancy_legacy.h5"
         b = ct.SolutionArray(self.gas)
         attr = b.restore(infile, "group0")
-        self.assertArrayNear(states.T, b.T)
-        self.assertArrayNear(states.P, b.P)
-        self.assertArrayNear(states.X, b.X)
-        self.assertArrayNear(states.foo, b.foo)
-        self.assertArrayNear(states.bar, b.bar)
-        self.assertEqual(b.meta['spam'], 'eggs')
-        self.assertEqual(b.meta['hello'], 'world')
-        self.assertEqual(attr['foobar'], 'spam and eggs')
+        assertArrayNear(states.T, b.T)
+        assertArrayNear(states.P, b.P)
+        assertArrayNear(states.X, b.X)
+        assertArrayNear(states.foo, b.foo)
+        assertArrayNear(states.bar, b.bar)
+        assert b.meta['spam'] == 'eggs'
+        assert b.meta['hello'] == 'world'
+        assert attr['foobar'] == 'spam and eggs'
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
@@ -835,9 +842,9 @@ class TestLegacyHDF(utilities.CanteraTest):
             b.read_hdf(infile, normalize=False)
         else:
             b.restore(infile, "group0")
-        self.assertArrayNear(states.T, b.T, rtol=1e-7)
-        self.assertArrayNear(states.P, b.P, rtol=1e-7)
-        self.assertArrayNear(states.X, b.X, rtol=1e-7)
+        assertArrayNear(states.T, b.T, rtol=1e-7)
+        assertArrayNear(states.P, b.P, rtol=1e-7)
+        assertArrayNear(states.X, b.X, rtol=1e-7)
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
@@ -852,29 +859,30 @@ class TestLegacyHDF(utilities.CanteraTest):
         infile = self.test_data_path / "solutionarray_water_legacy.h5"
         c = ct.SolutionArray(w_new)
         c.restore(infile, "group0")
-        self.assertArrayNear(states.T, c.T, rtol=1e-7)
-        self.assertArrayNear(states.P, c.P, rtol=1e-7)
-        self.assertArrayNear(states.Q, c.Q, rtol=1e-7)
+        assertArrayNear(states.T, c.T, rtol=1e-7)
+        assertArrayNear(states.P, c.P, rtol=1e-7)
+        assertArrayNear(states.Q, c.Q, rtol=1e-7)
 
 
-class TestRestoreIdealGas(utilities.CanteraTest):
+@pytest.fixture(scope='class')
+def setup_restore_ideal_gas_tests(request):
+    request.cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
+
+@pytest.mark.usefixtures('setup_restore_ideal_gas_tests')
+class TestRestoreIdealGas:
     """ Test restoring of the IdealGas class """
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
     def test_restore_gas(self):
 
         def check(a, b, atol=None):
             if atol is None:
-                self.assertArrayNear(a.T, b.T)
-                self.assertArrayNear(a.P, b.P)
-                self.assertArrayNear(a.X, b.X)
+                assertArrayNear(a.T, b.T)
+                assertArrayNear(a.P, b.P)
+                assertArrayNear(a.X, b.X)
             else:
-                self.assertArrayNear(a.T, b.T, atol=atol)
-                self.assertArrayNear(a.P, b.P, atol=atol)
-                self.assertArrayNear(a.X, b.X, atol=atol)
+                assertArrayNear(a.T, b.T, atol=atol)
+                assertArrayNear(a.P, b.P, atol=atol)
+                assertArrayNear(a.X, b.X, atol=atol)
 
         # test ThermoPhase
         a = ct.SolutionArray(self.gas)
@@ -896,23 +904,23 @@ class TestRestoreIdealGas(utilities.CanteraTest):
         # skip concentrations
         b = ct.SolutionArray(self.gas)
         b.restore_data({'T': data['T'], 'density': data['density']})
-        self.assertArrayNear(a.T, b.T)
-        self.assertArrayNear(a.density, b.density)
-        self.assertFalse(np.allclose(a.X, b.X))
+        assertArrayNear(a.T, b.T)
+        assertArrayNear(a.density, b.density)
+        assert not np.allclose(a.X, b.X)
 
         # wrong data shape
         b = ct.SolutionArray(self.gas)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             b.restore_data({k: v[np.newaxis, :] for k, v in data.items()})
 
         # inconsistent shape of receiving SolutionArray
         b = ct.SolutionArray(self.gas, 9)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             b.restore_data(data)
 
         # incomplete state
         b = ct.SolutionArray(self.gas)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             b.restore_data(dict([tup for i, tup in enumerate(data.items()) if i]))
 
         # add extra column
@@ -929,16 +937,16 @@ class TestRestoreIdealGas(utilities.CanteraTest):
         b = ct.SolutionArray(self.gas, extra=('time',))
         b.restore_data(data_mod)
         check(a, b)
-        self.assertArrayNear(b.time, t)
+        assertArrayNear(b.time, t)
 
         # wrong extra
         b = ct.SolutionArray(self.gas, extra=('xyz',))
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             b.restore_data(data_mod)
 
         # missing extra
         b = ct.SolutionArray(self.gas, extra=('time'))
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             b.restore_data(data)
 
         # inconsistent species
@@ -946,7 +954,7 @@ class TestRestoreIdealGas(utilities.CanteraTest):
         val = data_mod.pop('Y_AR')
         data_mod['Y_invalid'] = val
         b = ct.SolutionArray(self.gas)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             b.restore_data(data_mod)
 
         # incomplete species info (using threshold)
@@ -964,24 +972,24 @@ class TestRestoreIdealGas(utilities.CanteraTest):
         b = ct.SolutionArray(self.gas)
         b.restore_data(data)
         check(a, b)
-        self.assertEqual(len(b.extra), 0)
+        assert len(b.extra) == 0
 
+@pytest.fixture(scope='class')
+def setup_restore_pure_fluid_tests(request):
+    request.cls.water = ct.Water()
 
-class TestRestorePureFluid(utilities.CanteraTest):
+@pytest.mark.usefixtures('setup_restore_pure_fluid_tests')
+class TestRestorePureFluid:
     """ Test restoring of the PureFluid class """
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.water = ct.Water()
 
     def test_restore_water(self):
 
         def check(a, b):
-            self.assertArrayNear(a.T, b.T)
-            self.assertArrayNear(a.P, b.P)
-            self.assertArrayNear(a.Q, b.Q)
+            assertArrayNear(a.T, b.T)
+            assertArrayNear(a.P, b.P)
+            assertArrayNear(a.Q, b.Q)
 
-        self.assertTrue(self.water.has_phase_transition)
+        assert self.water.has_phase_transition
 
         # benchmark
         a = ct.SolutionArray(self.water, 10)
@@ -1003,7 +1011,7 @@ class TestRestorePureFluid(utilities.CanteraTest):
 
         # default columns
         data = a.collect_data()
-        self.assertEqual(list(data.keys()), ['T', 'density'])
+        assert list(data.keys()) == ['T', 'density']
         b = ct.SolutionArray(self.water)
         b.restore_data(data)
         check(a, b)
@@ -1029,18 +1037,18 @@ class TestRestorePureFluid(utilities.CanteraTest):
         w_new = ct.Water()
         c = ct.SolutionArray(w_new)
         c.restore(outfile, "group0") # normalize=False)
-        self.assertArrayNear(states.T, c.T)
-        self.assertArrayNear(states.P, c.P)
-        self.assertArrayNear(states.Q, c.Q)
+        assertArrayNear(states.T, c.T)
+        assertArrayNear(states.P, c.P)
+        assertArrayNear(states.Q, c.Q)
 
     def test_append_no_norm_water(self):
         w = ct.Water()
         states = ct.SolutionArray(w)
         w.TQ = 300, 0.5
         states.append(w.state)
-        self.assertEqual(states[0].T, w.T)
-        self.assertEqual(states[0].P, w.P)
-        self.assertEqual(states[0].Q, w.Q)
+        assert states[0].T == w.T
+        assert states[0].P == w.P
+        assert states[0].Q == w.Q
 
     def test_phase_of_matter(self):
         # based on test_thermo.py::TestSolutionArray::test_phase_of_matter
@@ -1054,25 +1062,27 @@ class TestRestorePureFluid(utilities.CanteraTest):
         states[:4].TP = T, P
         states[4].TQ = 300, .4
         pom = ['liquid', 'gas', 'supercritical', 'supercritical', 'liquid-gas-mix']
-        self.assertEqual(list(states.phase_of_matter), pom)
+        assert list(states.phase_of_matter) == pom
         states.save(outfile, "group0")
 
         saved = ct.SolutionArray(water)
         saved.restore(outfile, "group0") # normalize=False)
-        self.assertArrayNear(states.T, saved.T)
-        self.assertArrayNear(states.P, saved.P)
-        self.assertArrayNear(states.Q, saved.Q)
-        self.assertEqual(list(saved.phase_of_matter), pom)
+        assertArrayNear(states.T, saved.T)
+        assertArrayNear(states.P, saved.P)
+        assertArrayNear(states.Q, saved.Q)
+        assert list(saved.phase_of_matter) == pom
 
 
-class TestSolutionSerialization(utilities.CanteraTest):
+class TestSolutionSerialization:
+    """ Test Solution serialization """
+
     def test_input_data_simple(self):
         gas = ct.Solution('h2o2.yaml')
         data = gas.input_data
-        self.assertEqual(data['name'], 'ohmech')
-        self.assertEqual(data['thermo'], 'ideal-gas')
-        self.assertEqual(data['kinetics'], 'bulk')
-        self.assertEqual(data['transport'], 'mixture-averaged')
+        assert data['name'] == 'ohmech'
+        assert data['thermo'] == 'ideal-gas'
+        assert data['kinetics'] == 'bulk'
+        assert data['transport'] == 'mixture-averaged'
 
     def test_input_data_user_modifications(self):
         gas = ct.Solution("h2o2.yaml")
@@ -1081,97 +1091,94 @@ class TestSolutionSerialization(utilities.CanteraTest):
         extra = {"foo": [1.2, 3.4], "bar": [[1, 2], [3, 4]]}
         gas.update_user_data(extra)
         data2 = gas.input_data
-        self.assertEqual(extra["foo"], data2["foo"])
-        self.assertEqual(extra["bar"], data2["bar"])
+        assert extra["foo"] == data2["foo"]
+        assert extra["bar"] == data2["bar"]
         gas.clear_user_data()
         data3 = gas.input_data
-        self.assertEqual(data1, data3)
+        assert data1 == data3
 
     def test_input_data_state(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
         data = gas.input_data
-        self.assertEqual(gas.T, data['state']['T'])
-        self.assertEqual(gas.density, data['state']['density'])
+        assert gas.T == data['state']['T']
+        assert gas.density == data['state']['density']
 
         gas.TP = 500, 3.14e5
         data = gas.input_data
-        self.assertEqual(gas.T, data['state']['T'])
-        self.assertEqual(gas.density, data['state']['density'])
+        assert gas.T == data['state']['T']
+        assert gas.density == data['state']['density']
 
     def test_input_data_custom(self):
         gas = ct.Solution('ideal-gas.yaml')
         data = gas.input_data
-        self.assertEqual(data['custom-field']['first'], True)
-        self.assertEqual(data['custom-field']['last'], [100, 200, 300])
+        assert data['custom-field']['first'] == True
+        assert data['custom-field']['last'] == [100, 200, 300]
 
         if sys.version_info >= (3,7):
             # Check that items are ordered as expected
-            self.assertEqual(
-                list(data),
-                ["name", "thermo", "elements", "species", "state",
-                 "custom-field", "literal-string"]
-            )
-            self.assertEqual(list(data["custom-field"]), ["first", "second", "last"])
-            self.assertEqual(data["literal-string"], "spam\nand\neggs\n")
+            assert list(data) == ["name", "thermo", "elements", "species", "state",
+                                  "custom-field", "literal-string"]
+            assert list(data["custom-field"]) == ["first", "second", "last"]
+            assert data["literal-string"] == "spam\nand\neggs\n"
 
     def test_input_data_debye_huckel(self):
         soln = ct.Solution('thermo-models.yaml', 'debye-huckel-B-dot-ak')
         data = soln.input_data
-        self.assertEqual(data['thermo'], 'Debye-Huckel')
+        assert data['thermo'] == 'Debye-Huckel'
         act_data = data['activity-data']
-        self.assertEqual(act_data['model'], 'B-dot-with-variable-a')
-        self.assertEqual(act_data['default-ionic-radius'], 4e-10)
-        self.assertNotIn('kinetics', data)
-        self.assertNotIn('transport', data)
+        assert act_data['model'] == 'B-dot-with-variable-a'
+        assert act_data['default-ionic-radius'] == 4e-10
+        assert 'kinetics' not in data
+        assert 'transport' not in data
 
-    def test_yaml_simple(self):
+    def test_yaml_simple(self, load_yaml):
         gas = ct.Solution('h2o2.yaml')
         gas.TPX = 500, ct.one_atm, 'H2: 1.0, O2: 1.0'
         gas.equilibrate('HP')
         gas.TP = 1500, ct.one_atm
         gas.write_yaml(self.test_work_path / "h2o2-generated.yaml")
-        generated = utilities.load_yaml(self.test_work_path / "h2o2-generated.yaml")
+        generated = load_yaml(self.test_work_path / "h2o2-generated.yaml")
         for key in ('generator', 'date', 'phases', 'species', 'reactions'):
-            self.assertIn(key, generated)
-        self.assertEqual(generated['phases'][0]['transport'], 'mixture-averaged')
+            assert key in generated
+        assert generated['phases'][0]['transport'] == 'mixture-averaged'
         for i, species in enumerate(generated['species']):
-            self.assertEqual(species['composition'], gas.species(i).composition)
+            assert species['composition'] == gas.species(i).composition
         for blessed, generated in zip(gas.reactions(), generated["reactions"]):
             assert blessed.equation == generated["equation"]
 
         gas2 = ct.Solution(self.test_work_path / "h2o2-generated.yaml")
-        self.assertArrayNear(gas.concentrations, gas2.concentrations)
-        self.assertArrayNear(gas.partial_molar_enthalpies,
-                             gas2.partial_molar_enthalpies)
-        self.assertArrayNear(gas.forward_rate_constants,
-                             gas2.forward_rate_constants)
-        self.assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
+        assertArrayNear(gas.concentrations, gas2.concentrations)
+        assertArrayNear(gas.partial_molar_enthalpies,
+                        gas2.partial_molar_enthalpies)
+        assertArrayNear(gas.forward_rate_constants,
+                        gas2.forward_rate_constants)
+        assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
 
-    def test_yaml_outunits1(self):
+    def test_yaml_outunits1(self, load_yaml):
         gas = ct.Solution('h2o2.yaml')
         gas.TPX = 500, ct.one_atm, 'H2: 1.0, O2: 1.0'
         gas.equilibrate('HP')
         gas.TP = 1500, ct.one_atm
         units = {'length': 'cm', 'quantity': 'mol', 'energy': 'cal'}
         gas.write_yaml(self.test_work_path / "h2o2-generated.yaml", units=units)
-        generated = utilities.load_yaml(self.test_work_path / "h2o2-generated.yaml")
-        original = utilities.load_yaml(self.cantera_data_path / "h2o2.yaml")
-        self.assertEqual(generated['units'], units)
+        generated = load_yaml(self.test_work_path / "h2o2-generated.yaml")
+        original = load_yaml(self.cantera_data_path / "h2o2.yaml")
+        assert generated['units'] == units
 
         for r1, r2 in zip(original['reactions'], generated['reactions']):
             if 'rate-constant' in r1:
-                self.assertNear(r1['rate-constant']['A'], r2['rate-constant']['A'])
-                self.assertNear(r1['rate-constant']['Ea'], r2['rate-constant']['Ea'])
+                assertNear(r1['rate-constant']['A'], r2['rate-constant']['A'])
+                assertNear(r1['rate-constant']['Ea'], r2['rate-constant']['Ea'])
 
         gas2 = ct.Solution(self.test_work_path / "h2o2-generated.yaml")
-        self.assertArrayNear(gas.concentrations, gas2.concentrations)
-        self.assertArrayNear(gas.partial_molar_enthalpies,
-                             gas2.partial_molar_enthalpies)
-        self.assertArrayNear(gas.forward_rate_constants,
-                             gas2.forward_rate_constants)
-        self.assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
+        assertArrayNear(gas.concentrations, gas2.concentrations)
+        assertArrayNear(gas.partial_molar_enthalpies,
+                        gas2.partial_molar_enthalpies)
+        assertArrayNear(gas.forward_rate_constants,
+                        gas2.forward_rate_constants)
+        assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
 
-    def test_yaml_outunits2(self):
+    def test_yaml_outunits2(self, load_yaml):
         gas = ct.Solution('h2o2.yaml')
         gas.TPX = 500, ct.one_atm, 'H2: 1.0, O2: 1.0'
         gas.equilibrate('HP')
@@ -1179,52 +1186,53 @@ class TestSolutionSerialization(utilities.CanteraTest):
         units = {'length': 'cm', 'quantity': 'mol', 'energy': 'cal'}
         system = ct.UnitSystem(units)
         gas.write_yaml(self.test_work_path / "h2o2-generated.yaml", units=system)
-        generated = utilities.load_yaml(self.test_work_path / "h2o2-generated.yaml")
-        original = utilities.load_yaml(self.cantera_data_path / "h2o2.yaml")
+        generated = load_yaml(self.test_work_path / "h2o2-generated.yaml")
+        original = load_yaml(self.cantera_data_path / "h2o2.yaml")
 
         for r1, r2 in zip(original['reactions'], generated['reactions']):
             if 'rate-constant' in r1:
-                self.assertNear(r1['rate-constant']['A'], r2['rate-constant']['A'])
-                self.assertNear(r1['rate-constant']['Ea'], r2['rate-constant']['Ea'])
+                assertNear(r1['rate-constant']['A'], r2['rate-constant']['A'])
+                assertNear(r1['rate-constant']['Ea'], r2['rate-constant']['Ea'])
 
         gas2 = ct.Solution(self.test_work_path / "h2o2-generated.yaml")
-        self.assertArrayNear(gas.concentrations, gas2.concentrations)
-        self.assertArrayNear(gas.partial_molar_enthalpies,
-                             gas2.partial_molar_enthalpies)
-        self.assertArrayNear(gas.forward_rate_constants,
-                             gas2.forward_rate_constants)
-        self.assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
+        assertArrayNear(gas.concentrations, gas2.concentrations)
+        assertArrayNear(gas.partial_molar_enthalpies,
+                        gas2.partial_molar_enthalpies)
+        assertArrayNear(gas.forward_rate_constants,
+                        gas2.forward_rate_constants)
+        assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
 
-    def check_ptcombust(self, gas, surf):
-        generated = utilities.load_yaml(self.test_work_path / "ptcombust-generated.yaml")
+    @pytest.mark.usefixtures('load_yaml')
+    def check_ptcombust(self, gas, surf, load_yaml):
+        generated = load_yaml(self.test_work_path / "ptcombust-generated.yaml")
         for key in ("phases", "species", "gas-reactions", "Pt_surf-reactions"):
-            self.assertIn(key, generated)
-        self.assertEqual(len(generated["gas-reactions"]), gas.n_reactions)
-        self.assertEqual(len(generated["Pt_surf-reactions"]), surf.n_reactions)
-        self.assertEqual(len(generated["species"]), surf.n_total_species)
+            assert key in generated
+        assert len(generated["gas-reactions"]) == gas.n_reactions
+        assert len(generated["Pt_surf-reactions"]) == surf.n_reactions
+        assert len(generated["species"]) == surf.n_total_species
 
         surf2 = ct.Solution(self.test_work_path / "ptcombust-generated.yaml", "Pt_surf")
-        self.assertArrayNear(surf.concentrations, surf2.concentrations)
-        self.assertArrayNear(surf.partial_molar_enthalpies,
-                             surf2.partial_molar_enthalpies)
-        self.assertArrayNear(surf.forward_rate_constants,
-                             surf2.forward_rate_constants)
+        assertArrayNear(surf.concentrations, surf2.concentrations)
+        assertArrayNear(surf.partial_molar_enthalpies,
+                        surf2.partial_molar_enthalpies)
+        assertArrayNear(surf.forward_rate_constants,
+                        surf2.forward_rate_constants)
 
-    def test_yaml_surface_explicit(self):
+    def test_yaml_surface_explicit(self, load_yaml):
         gas = ct.Solution("ptcombust.yaml", "gas")
         surf = ct.Interface("ptcombust.yaml", "Pt_surf", [gas])
         gas.TPY = 900, ct.one_atm, np.ones(gas.n_species)
         surf.coverages = np.ones(surf.n_species)
         surf.write_yaml(self.test_work_path / "ptcombust-generated.yaml")
-        self.check_ptcombust(gas, surf)
+        self.check_ptcombust(gas, surf, load_yaml)
 
-    def test_yaml_surface_adjacent(self):
+    def test_yaml_surface_adjacent(self, load_yaml):
         surf = ct.Interface("ptcombust.yaml", "Pt_surf")
         gas = surf.adjacent["gas"]
         gas.TPY = 900, ct.one_atm, np.ones(gas.n_species)
         surf.coverages = np.ones(surf.n_species)
         surf.write_yaml(self.test_work_path / "ptcombust-generated.yaml")
-        self.check_ptcombust(gas, surf)
+        self.check_ptcombust(gas, surf, load_yaml)
 
     def test_yaml_eos(self):
         ice = ct.Solution('water.yaml', 'ice')
@@ -1232,8 +1240,8 @@ class TestSolutionSerialization(utilities.CanteraTest):
         ice.write_yaml(self.test_work_path / "ice-generated.yaml", units={'length': 'mm', 'mass': 'g'})
 
         ice2 = ct.Solution(self.test_work_path / "ice-generated.yaml")
-        self.assertNear(ice.density, ice2.density)
-        self.assertNear(ice.entropy_mole, ice2.entropy_mole)
+        assertNear(ice.density, ice2.density)
+        assertNear(ice.entropy_mole, ice2.entropy_mole)
 
     def test_yaml_inconsistent_species(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
@@ -1247,7 +1255,7 @@ class TestSolutionSerialization(utilities.CanteraTest):
         h2.thermo = ct.NasaPoly2(h2.thermo.min_temp, h2.thermo.max_temp,
                                  h2.thermo.reference_pressure, nasa_coeffs)
         gas2.modify_species(gas2.species_index('H2'), h2)
-        with self.assertRaisesRegex(ct.CanteraError, "different definitions"):
+        with pytest.raises(ct.CanteraError, match="different definitions"):
             gas.write_yaml(self.test_work_path / "h2o2-error.yaml", phases=gas2)
 
     def test_yaml_user_data(self):
@@ -1264,12 +1272,12 @@ class TestSolutionSerialization(utilities.CanteraTest):
         gas2 = ct.Solution(self.test_work_path / "h2o2-generated-user-data.yaml")
         data2 = gas2.species(2).input_data
 
-        self.assertEqual(gas2.input_data["spam"], extra["spam"])
-        self.assertEqual(gas2.input_data["eggs"], extra["eggs"])
-        self.assertEqual(data2["foo"], "bar")
-        self.assertEqual(data2["transport"]["baz"], 1234.5)
-        self.assertEqual(data2["thermo"]["something"], [False, True])
-        self.assertTrue(gas2.reaction(5).input_data["baked-beans"])
+        assert gas2.input_data["spam"] == extra["spam"]
+        assert gas2.input_data["eggs"] == extra["eggs"]
+        assert data2["foo"] == "bar"
+        assert data2["transport"]["baz"] == 1234.5
+        assert data2["thermo"]["something"] == [False, True]
+        assert gas2.reaction(5).input_data["baked-beans"]
 
     def test_yaml_strings(self):
         yaml = """
@@ -1333,57 +1341,58 @@ class TestSolutionSerialization(utilities.CanteraTest):
         assert not gas_reduced.reaction(24).duplicate
 
 
-class TestSpeciesSerialization(utilities.CanteraTest):
+class TestSpeciesSerialization:
+
     def test_species_simple(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
         data = gas.species('H2O').input_data
-        self.assertEqual(data['name'], 'H2O')
-        self.assertEqual(data['composition'], {'H': 2, 'O': 1})
+        assert data['name'] == 'H2O'
+        assert data['composition'] == {'H': 2, 'O': 1}
 
     def test_species_thermo(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
         data = gas.species('H2O').input_data['thermo']
-        self.assertEqual(data['model'], 'NASA7')
-        self.assertEqual(data['temperature-ranges'], [200, 1000, 3500])
-        self.assertEqual(data['note'], 'L8/89')
+        assert data['model'] == 'NASA7'
+        assert data['temperature-ranges'] == [200, 1000, 3500]
+        assert data['note'] == 'L8/89'
 
     def test_species_transport(self):
         gas = ct.Solution('h2o2.yaml')
         data = gas.species('H2O').input_data['transport']
-        self.assertEqual(data['model'], 'gas')
-        self.assertEqual(data['geometry'], 'nonlinear')
-        self.assertNear(data['dipole'], 1.844)
+        assert data['model'] == 'gas'
+        assert data['geometry'] == 'nonlinear'
+        assertNear(data['dipole'], 1.844)
 
 
-class TestInterfaceAdjacent(utilities.CanteraTest):
+class TestInterfaceAdjacent:
     def test_surface(self):
         surf = ct.Interface("ptcombust.yaml", "Pt_surf")
-        self.assertEqual(list(surf.adjacent), ["gas"])
-        self.assertEqual(surf.phase_index(surf), 0)
-        self.assertEqual(surf.phase_index("gas"), 1)
-        self.assertEqual(surf.phase_index(surf.adjacent["gas"]), 1)
+        assert list(surf.adjacent) == ["gas"]
+        assert surf.phase_index(surf) == 0
+        assert surf.phase_index("gas") == 1
+        assert surf.phase_index(surf.adjacent["gas"]) == 1
 
     def test_named_adjacent(self):
         # override the adjacent-phases to change the order
         surf = ct.Interface("surface-phases.yaml", "anode-surface",
                             adjacent=["electrolyte", "graphite"])
-        self.assertEqual(list(surf.adjacent), ["electrolyte", "graphite"])
+        assert list(surf.adjacent), ["electrolyte", "graphite"]
 
     def test_edge(self):
         tpb = ct.Interface("sofc.yaml", "tpb")
-        self.assertEqual(set(tpb.adjacent), {"metal_surface", "oxide_surface", "metal"})
-        self.assertIsInstance(tpb.adjacent["metal_surface"], ct.Interface)
-        self.assertNotIsInstance(tpb.adjacent["metal"], ct.Interface)
+        assert set(tpb.adjacent) == {"metal_surface", "oxide_surface", "metal"}
+        assert isinstance(tpb.adjacent["metal_surface"], ct.Interface)
+        assert not isinstance(tpb.adjacent["metal"], ct.Interface)
         gas1 = tpb.adjacent["metal_surface"].adjacent["gas"]
         gas2 = tpb.adjacent["oxide_surface"].adjacent["gas"]
         gas1.X = [0.1, 0.4, 0.3, 0.2]
-        self.assertArrayNear(gas1.X, gas2.X)
+        assertArrayNear(gas1.X, gas2.X)
 
     def test_invalid(self):
-        with self.assertRaisesRegex(ct.CanteraError, "does not contain"):
+        with pytest.raises(ct.CanteraError, match="does not contain"):
             surf = ct.Interface("ptcombust.yaml", "Pt_surf", ["foo"])
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             surf = ct.Interface("ptcombust.yaml", "Pt_surf", [2])
 
     def test_remote_file(self):
@@ -1399,5 +1408,5 @@ class TestInterfaceAdjacent(utilities.CanteraTest):
         """
 
         surf = ct.Interface(yaml=yaml)
-        self.assertEqual(surf.adjacent["gas"].n_species, 32)
-        self.assertEqual(surf.n_reactions, 24)
+        assert surf.adjacent["gas"].n_species == 32
+        assert surf.n_reactions == 24

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -321,14 +321,15 @@ class TestSolutionArray:
 @pytest.fixture(scope='class')
 def setup_solution_array_info_tests(request):
     request.cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
-@pytest.mark.usefixtures('setup_solution_array_info_tests')
+
+@pytest.fixture(scope='function')
+def setup_solution_array_info_data(request, setup_solution_array_info_tests):
+    request.cls.gas.TPY = 300, ct.one_atm, "H2: 1"
+
+@pytest.mark.usefixtures('setup_solution_array_info_data')
 class TestSolutionArrayInfo:
     """ Test SolutionArray summary output """
     width = 80
-
-    def setup_method(self):
-        """ Runs before each test """
-        self.gas.TPY = 300, ct.one_atm, "H2: 1"
 
     def check(self, arr, repr, rows):
         count = 0
@@ -1200,7 +1201,6 @@ class TestSolutionSerialization:
                         gas2.forward_rate_constants)
         assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
 
-    @pytest.mark.usefixtures('load_yaml')
     def check_ptcombust(self, gas, surf, load_yaml):
         generated = load_yaml(self.test_work_path / "ptcombust-generated.yaml")
         for key in ("phases", "species", "gas-reactions", "Pt_surf-reactions"):

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -14,9 +14,6 @@ except ImportError:
 
 from cantera.composite import _pandas
 
-from .utilities import (
-    assertArrayNear
-)
 
 @pytest.fixture(scope='class')
 def setup_models_tests(request, load_yaml):
@@ -73,9 +70,9 @@ class TestModels:
     def test_restore_thermo_models(self):
 
         def check(a, b):
-            assertArrayNear(a.T, b.T)
-            assertArrayNear(a.P, b.P)
-            assertArrayNear(a.X, b.X)
+            assert a.T == approx(b.T)
+            assert a.P == approx(b.P)
+            assert a.X == approx(b.X)
 
         for ph in self.yml['phases']:
 
@@ -138,7 +135,7 @@ class TestPickle:
             gas2 = pickle.load(pkl)
         assert gas.T == approx(gas2.T)
         assert gas.P == approx(gas2.P)
-        assertArrayNear(gas.X, gas2.X)
+        assert gas.X == approx(gas2.X)
 
         assert  gas2.transport_model == "none"
 
@@ -153,7 +150,7 @@ class TestPickle:
             gas2 = pickle.load(pkl)
         assert gas.T == approx(gas2.T)
         assert gas.P == approx(gas2.P)
-        assertArrayNear(gas.X, gas2.X)
+        assert gas.X == approx(gas2.X)
 
         assert gas2.transport_model == "multicomponent"
 
@@ -463,7 +460,7 @@ class TestSolutionArrayIO:
         states.append(gas.state)
         assert states[0].T == gas.T
         assert states[0].P == gas.P
-        assertArrayNear(states[0].X, gas.X)
+        assert states[0].X == approx(gas.X)
         assert len(states) == 1
         assert states.shape == (1,)
         assert states.ndim == 1
@@ -477,7 +474,7 @@ class TestSolutionArrayIO:
         states.append(T=gas.T, P=gas.P, Y=gas.Y, normalize=False)
         assert states[0].T == gas.T
         assert states[0].P == gas.P
-        assertArrayNear(states[0].Y, gas.Y)
+        assert states[0].Y == approx(gas.Y)
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
@@ -493,20 +490,20 @@ class TestSolutionArrayIO:
         gas_new = ct.Solution("h2o2.yaml")
         b = ct.SolutionArray(gas_new)
         b.restore(outfile, "group0") #, normalize=False)
-        assertArrayNear(states.T, b.T)
-        assertArrayNear(states.P, b.P)
-        assertArrayNear(states.X, b.X)
+        assert states.T == approx(b.T)
+        assert states.P == approx(b.P)
+        assert states.X == approx(b.X)
 
     def check_arrays(self, a, b, rtol=1e-8):
-        assertArrayNear(a.T, b.T, rtol=rtol)
-        assertArrayNear(a.P, b.P, rtol=rtol)
-        assertArrayNear(a.X, b.X, rtol=rtol)
+        assert a.T == approx(b.T, rel=rtol)
+        assert a.P == approx(b.P, rel=rtol)
+        assert a.X == approx(b.X, rel=rtol)
         for key in a.extra:
             value = getattr(a, key)
             if isinstance(value[0], str):
                 assert (getattr(b, key) == value).all()
             else:
-                assertArrayNear(getattr(b, key), value, rtol=rtol)
+                assert getattr(b, key) == approx(value, rel=rtol)
         if b.meta:
             # not all output formats preserve metadata
             for key, value in a.meta.items():
@@ -790,7 +787,7 @@ class TestLegacyHDF:
         infile = self.test_data_path / f"solutionarray_multi_legacy.h5"
 
         b.restore(infile, "group0")
-        assertArrayNear(arr.spam, b.spam)
+        assert arr.spam == approx(b.spam)
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
@@ -809,11 +806,11 @@ class TestLegacyHDF:
         infile = self.test_data_path / f"solutionarray_fancy_legacy.h5"
         b = ct.SolutionArray(self.gas)
         attr = b.restore(infile, "group0")
-        assertArrayNear(states.T, b.T)
-        assertArrayNear(states.P, b.P)
-        assertArrayNear(states.X, b.X)
-        assertArrayNear(states.foo, b.foo)
-        assertArrayNear(states.bar, b.bar)
+        assert states.T == approx(b.T)
+        assert states.P == approx(b.P)
+        assert states.X == approx(b.X)
+        assert states.foo == approx(b.foo)
+        assert states.bar == approx(b.bar)
         assert b.meta['spam'] == 'eggs'
         assert b.meta['hello'] == 'world'
         assert attr['foobar'] == 'spam and eggs'
@@ -836,9 +833,9 @@ class TestLegacyHDF:
             b.read_hdf(infile, normalize=False)
         else:
             b.restore(infile, "group0")
-        assertArrayNear(states.T, b.T, rtol=1e-7)
-        assertArrayNear(states.P, b.P, rtol=1e-7)
-        assertArrayNear(states.X, b.X, rtol=1e-7)
+        assert states.T == approx(b.T, rel=1e-7)
+        assert states.P == approx(b.P, rel=1e-7)
+        assert states.X == approx(b.X, rel=1e-7)
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
@@ -853,9 +850,9 @@ class TestLegacyHDF:
         infile = self.test_data_path / "solutionarray_water_legacy.h5"
         c = ct.SolutionArray(w_new)
         c.restore(infile, "group0")
-        assertArrayNear(states.T, c.T, rtol=1e-7)
-        assertArrayNear(states.P, c.P, rtol=1e-7)
-        assertArrayNear(states.Q, c.Q, rtol=1e-7)
+        assert states.T == approx(c.T, rel=1e-7)
+        assert states.P == approx(c.P, rel=1e-7)
+        assert states.Q == approx(c.Q, rel=1e-7)
 
 
 @pytest.fixture(scope='class')
@@ -870,13 +867,13 @@ class TestRestoreIdealGas:
 
         def check(a, b, atol=None):
             if atol is None:
-                assertArrayNear(a.T, b.T)
-                assertArrayNear(a.P, b.P)
-                assertArrayNear(a.X, b.X)
+                assert a.T == approx(b.T)
+                assert a.P == approx(b.P)
+                assert a.X == approx(b.X)
             else:
-                assertArrayNear(a.T, b.T, atol=atol)
-                assertArrayNear(a.P, b.P, atol=atol)
-                assertArrayNear(a.X, b.X, atol=atol)
+                assert a.T == approx(b.T, abs=atol)
+                assert a.P == approx(b.P, abs=atol)
+                assert a.X == approx(b.X, abs=atol)
 
         # test ThermoPhase
         a = ct.SolutionArray(self.gas)
@@ -898,9 +895,9 @@ class TestRestoreIdealGas:
         # skip concentrations
         b = ct.SolutionArray(self.gas)
         b.restore_data({'T': data['T'], 'density': data['density']})
-        assertArrayNear(a.T, b.T)
-        assertArrayNear(a.density, b.density)
-        assert not np.allclose(a.X, b.X)
+        assert a.T == approx(b.T)
+        assert a.density == approx(b.density)
+        assert not a.X == approx(b.X)
 
         # wrong data shape
         b = ct.SolutionArray(self.gas)
@@ -931,7 +928,7 @@ class TestRestoreIdealGas:
         b = ct.SolutionArray(self.gas, extra=('time',))
         b.restore_data(data_mod)
         check(a, b)
-        assertArrayNear(b.time, t)
+        assert b.time == approx(t)
 
         # wrong extra
         b = ct.SolutionArray(self.gas, extra=('xyz',))
@@ -979,9 +976,9 @@ class TestRestorePureFluid:
     def test_restore_water(self):
 
         def check(a, b):
-            assertArrayNear(a.T, b.T)
-            assertArrayNear(a.P, b.P)
-            assertArrayNear(a.Q, b.Q)
+            assert a.T == approx(b.T)
+            assert a.P == approx(b.P)
+            assert a.Q == approx(b.Q)
 
         assert self.water.has_phase_transition
 
@@ -1031,9 +1028,9 @@ class TestRestorePureFluid:
         w_new = ct.Water()
         c = ct.SolutionArray(w_new)
         c.restore(outfile, "group0") # normalize=False)
-        assertArrayNear(states.T, c.T)
-        assertArrayNear(states.P, c.P)
-        assertArrayNear(states.Q, c.Q)
+        assert states.T == approx(c.T)
+        assert states.P == approx(c.P)
+        assert states.Q == approx(c.Q)
 
     def test_append_no_norm_water(self):
         w = ct.Water()
@@ -1061,9 +1058,9 @@ class TestRestorePureFluid:
 
         saved = ct.SolutionArray(water)
         saved.restore(outfile, "group0") # normalize=False)
-        assertArrayNear(states.T, saved.T)
-        assertArrayNear(states.P, saved.P)
-        assertArrayNear(states.Q, saved.Q)
+        assert states.T == approx(saved.T)
+        assert states.P == approx(saved.P)
+        assert states.Q == approx(saved.Q)
         assert list(saved.phase_of_matter) == pom
 
 
@@ -1140,12 +1137,10 @@ class TestSolutionSerialization:
             assert blessed.equation == generated["equation"]
 
         gas2 = ct.Solution(self.test_work_path / "h2o2-generated.yaml")
-        assertArrayNear(gas.concentrations, gas2.concentrations)
-        assertArrayNear(gas.partial_molar_enthalpies,
-                        gas2.partial_molar_enthalpies)
-        assertArrayNear(gas.forward_rate_constants,
-                        gas2.forward_rate_constants)
-        assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
+        assert gas.concentrations == approx(gas2.concentrations)
+        assert gas.partial_molar_enthalpies == approx(gas2.partial_molar_enthalpies)
+        assert gas.forward_rate_constants == approx(gas2.forward_rate_constants)
+        assert gas.mix_diff_coeffs == approx(gas2.mix_diff_coeffs)
 
     def test_yaml_outunits1(self, load_yaml):
         gas = ct.Solution('h2o2.yaml')
@@ -1164,12 +1159,10 @@ class TestSolutionSerialization:
                 assert r1['rate-constant']['Ea'] == approx(r2['rate-constant']['Ea'])
 
         gas2 = ct.Solution(self.test_work_path / "h2o2-generated.yaml")
-        assertArrayNear(gas.concentrations, gas2.concentrations)
-        assertArrayNear(gas.partial_molar_enthalpies,
-                        gas2.partial_molar_enthalpies)
-        assertArrayNear(gas.forward_rate_constants,
-                        gas2.forward_rate_constants)
-        assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
+        assert gas.concentrations == approx(gas2.concentrations)
+        assert gas.partial_molar_enthalpies == approx(gas2.partial_molar_enthalpies)
+        assert gas.forward_rate_constants == approx(gas2.forward_rate_constants)
+        assert gas.mix_diff_coeffs == approx(gas2.mix_diff_coeffs)
 
     def test_yaml_outunits2(self, load_yaml):
         gas = ct.Solution('h2o2.yaml')
@@ -1188,12 +1181,10 @@ class TestSolutionSerialization:
                 assert r1['rate-constant']['Ea'] == approx(r2['rate-constant']['Ea'])
 
         gas2 = ct.Solution(self.test_work_path / "h2o2-generated.yaml")
-        assertArrayNear(gas.concentrations, gas2.concentrations)
-        assertArrayNear(gas.partial_molar_enthalpies,
-                        gas2.partial_molar_enthalpies)
-        assertArrayNear(gas.forward_rate_constants,
-                        gas2.forward_rate_constants)
-        assertArrayNear(gas.mix_diff_coeffs, gas2.mix_diff_coeffs)
+        assert gas.concentrations == approx(gas2.concentrations)
+        assert gas.partial_molar_enthalpies == approx(gas2.partial_molar_enthalpies)
+        assert gas.forward_rate_constants == approx(gas2.forward_rate_constants)
+        assert gas.mix_diff_coeffs == approx(gas2.mix_diff_coeffs)
 
     def check_ptcombust(self, gas, surf, load_yaml):
         generated = load_yaml(self.test_work_path / "ptcombust-generated.yaml")
@@ -1204,11 +1195,9 @@ class TestSolutionSerialization:
         assert len(generated["species"]) == surf.n_total_species
 
         surf2 = ct.Solution(self.test_work_path / "ptcombust-generated.yaml", "Pt_surf")
-        assertArrayNear(surf.concentrations, surf2.concentrations)
-        assertArrayNear(surf.partial_molar_enthalpies,
-                        surf2.partial_molar_enthalpies)
-        assertArrayNear(surf.forward_rate_constants,
-                        surf2.forward_rate_constants)
+        assert surf.concentrations == approx(surf2.concentrations)
+        assert surf.partial_molar_enthalpies == approx(surf2.partial_molar_enthalpies)
+        assert surf.forward_rate_constants == approx(surf2.forward_rate_constants)
 
     def test_yaml_surface_explicit(self, load_yaml):
         gas = ct.Solution("ptcombust.yaml", "gas")
@@ -1378,7 +1367,7 @@ class TestInterfaceAdjacent:
         gas1 = tpb.adjacent["metal_surface"].adjacent["gas"]
         gas2 = tpb.adjacent["oxide_surface"].adjacent["gas"]
         gas1.X = [0.1, 0.4, 0.3, 0.2]
-        assertArrayNear(gas1.X, gas2.X)
+        assert gas1.X == approx(gas2.X)
 
     def test_invalid(self):
         with pytest.raises(ct.CanteraError, match="does not contain"):

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -5,15 +5,16 @@ from pathlib import Path
 import pytest
 from pytest import approx
 
-
 import cantera as ct
 from cantera import ck2yaml, cti2yaml, ctml2yaml, yaml2ck, lxcat2yaml
 from .utilities import load_yaml
 
+
 class Testck2yaml:
     @pytest.fixture(autouse=True)
-    def inject_fixtures(self, capsys):
+    def inject_fixtures(self, capsys, test_data_path):
         self._capsys = capsys
+        self.test_data_path = test_data_path
 
     def convert(self, inputFile, thermo=None, transport=None,
                 surface=None, output=None, quiet=True, extra=None, **kwargs):
@@ -780,6 +781,10 @@ class Testyaml2ck:
     """Test yaml2ck by converting to CK then back to YAML to read with Cantera."""
     ext: str = "-from-yaml2ck.yaml"
 
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, test_data_path):
+        self.test_data_path = test_data_path
+
     def _convert_to_ck(
         self,
         input_file: Path,
@@ -1079,6 +1084,11 @@ class Testyaml2ck:
 
 
 class Testcti2yaml:
+
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, test_data_path):
+        self.test_data_path = test_data_path
+
     def convert(self, basename, src_dir=None, encoding=None):
         if src_dir is None:
             src_dir = self.test_data_path
@@ -1301,6 +1311,11 @@ class Testcti2yaml:
 
 
 class Testctml2yaml:
+
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, test_data_path):
+        self.test_data_path = test_data_path
+
     def convert(self, basename, src_dir=None):
         if src_dir is None:
             src_dir = self.test_data_path
@@ -1658,6 +1673,11 @@ class Testctml2yaml:
             self.convert("duplicate-reactionData-ids")
 
 class Testlxcat2yaml:
+
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, test_data_path):
+        self.test_data_path = test_data_path
+
     def convert(self, inputFile=None, database=None, mechFile=None, phase=None,
                 insert=True, output=None):
         if inputFile is not None:

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -5,9 +5,6 @@ from pathlib import Path
 import pytest
 from pytest import approx
 
-from .utilities import (
-    assertArrayNear
-)
 
 import cantera as ct
 from cantera import ck2yaml, cti2yaml, ctml2yaml, yaml2ck, lxcat2yaml
@@ -399,10 +396,10 @@ class Testck2yaml:
 
         R = gas.reactant_stoich_coeffs
         P = gas.product_stoich_coeffs
-        assertArrayNear(R[:,0], [0, 1.5, 0.5, 0])
-        assertArrayNear(P[:,0], [1, 0, 0, 1])
-        assertArrayNear(R[:,1], [1, 0, 0, 1])
-        assertArrayNear(P[:,1], [0, 0.33, 1.67, 0])
+        assert R[:,0] == approx([0, 1.5, 0.5, 0])
+        assert P[:,0] == approx([1, 0, 0, 1])
+        assert R[:,1] == approx([1, 0, 0, 1])
+        assert P[:,1] == approx([0, 0.33, 1.67, 0])
 
     def test_unparsable_reaction(self):
         with pytest.raises(ck2yaml.InputError, match="Unparsable line"):

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -8,6 +8,7 @@ from pytest import approx
 
 import cantera as ct
 from cantera import ck2yaml, cti2yaml, ctml2yaml, yaml2ck, lxcat2yaml
+from .utilities import load_yaml
 
 class Testck2yaml:
     @pytest.fixture(autouse=True)
@@ -678,7 +679,7 @@ class Testck2yaml:
         captured = self._capsys.readouterr()
         assert "Missing input file: 'nonexistent-file-813.inp'" in captured.out
 
-    def test_extra(self, load_yaml):
+    def test_extra(self):
         output = self.convert("h2o2.inp", output="h2o2_extra", extra="extra.yaml")
         yml = load_yaml(output)
 
@@ -701,7 +702,7 @@ class Testck2yaml:
         assert "alternate description" in captured.out
         assert "needs to be a string" in captured.out
 
-    def test_sri_zero(self, load_yaml):
+    def test_sri_zero(self):
         # This test tests it can convert the SRI parameters when D or E equal to 0
         output = self.convert('sri_convert_test.txt')
         mech = load_yaml(output)
@@ -737,7 +738,7 @@ class Testck2yaml:
                     'R1A + R1B', 'R3 + H'):
             assert token in captured.out
 
-    def test_single_Tint(self, load_yaml):
+    def test_single_Tint(self):
         output = self.convert(None, thermo="thermo_single_Tint.dat",
                               output="thermo_single_Tint",
                               single_intermediate_temperature=True)
@@ -918,8 +919,8 @@ class Testyaml2ck:
                 assert Dkm_ck[i] == approx(Dkm_yaml[yaml_idx[i]])
 
     @pytest.mark.slow_test
-    def test_gri30(self):
-        input_file = self.cantera_data_path / "gri30.yaml"
+    def test_gri30(self, cantera_data_path):
+        input_file = cantera_data_path / "gri30.yaml"
         self.convert(input_file)
         X = {'O2': 0.3, 'H2': 0.1, 'CH4': 0.2, 'CO2': 0.4}
         ck_phase, yaml_phase = self.check_conversion(input_file)
@@ -936,8 +937,8 @@ class Testyaml2ck:
         self.check_thermo(ck_phase, yaml_phase, [300, 500])
         self.check_kinetics(ck_phase, yaml_phase, [300, 1001, 2500], [1e5, 10e5])
 
-    def test_phase_id(self):
-        input_file = self.cantera_data_path / "nDodecane_Reitz.yaml"
+    def test_phase_id(self, cantera_data_path):
+        input_file = cantera_data_path / "nDodecane_Reitz.yaml"
         self.convert(input_file, "nDodecane_IG")
         ck_phase, yaml_phase = self.check_conversion(input_file, name="nDodecane_IG")
         ck_phase.X = "h2:1"

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -7,11 +7,18 @@ from pytest import approx
 
 from . import utilities
 from .utilities import allow_deprecated
+from .utilities import (
+    assertNear,
+    assertArrayNear,
+    assertIsFinite,
+    assertIsNaN,
+    compare
+)
 
 import cantera as ct
 from cantera import ck2yaml, cti2yaml, ctml2yaml, yaml2ck, lxcat2yaml
 
-class ck2yamlTest(utilities.CanteraTest):
+class Testck2yaml:
     @pytest.fixture(autouse=True)
     def inject_fixtures(self, capsys):
         self._capsys = capsys
@@ -43,18 +50,18 @@ class ck2yamlTest(utilities.CanteraTest):
         ref = ct.Solution(refFile)
         gas = ct.Solution(testFile)
 
-        self.assertEqual(ref.element_names, gas.element_names)
-        self.assertEqual(ref.species_names, gas.species_names)
+        assert ref.element_names == gas.element_names
+        assert ref.species_names == gas.species_names
         coeffs_ref = ref.reactant_stoich_coeffs
         coeffs_gas = gas.reactant_stoich_coeffs
-        self.assertEqual(coeffs_gas.shape, coeffs_ref.shape)
-        self.assertTrue((coeffs_gas == coeffs_ref).all())
+        assert coeffs_gas.shape == coeffs_ref.shape
+        assert (coeffs_gas == coeffs_ref).all()
 
         compositionA = [[ref.n_atoms(i,j) for j in range(ref.n_elements)]
                         for i in range(ref.n_species)]
         compositionB = [[gas.n_atoms(i,j) for j in range(gas.n_elements)]
                         for i in range(gas.n_species)]
-        self.assertEqual(compositionA, compositionB)
+        assert compositionA, compositionB
 
         return ref, gas
 
@@ -70,9 +77,9 @@ class ck2yamlTest(utilities.CanteraTest):
             gas_s = gas.standard_entropies_R
             for i in range(gas.n_species):
                 message = ' for species {0} at T = {1}'.format(i, T)
-                self.assertNear(ref_cp[i], gas_cp[i], 1e-7, msg='cp'+message)
-                self.assertNear(ref_h[i], gas_h[i], 1e-7, msg='h'+message)
-                self.assertNear(ref_s[i], gas_s[i], 1e-7, msg='s'+message)
+                assertNear(ref_cp[i], gas_cp[i], 1e-7, msg='cp'+message)
+                assertNear(ref_h[i], gas_h[i], 1e-7, msg='h'+message)
+                assertNear(ref_s[i], gas_s[i], 1e-7, msg='s'+message)
 
     def checkKinetics(self, ref, gas, temperatures, pressures, tol=1e-8):
         for T,P in itertools.product(temperatures, pressures):
@@ -84,8 +91,8 @@ class ck2yamlTest(utilities.CanteraTest):
             gas_kr = gas.reverse_rate_constants
             for i in range(gas.n_reactions):
                 message = ' for reaction {0} at T = {1}, P = {2}'.format(i, T, P)
-                self.assertNear(ref_kf[i], gas_kf[i], rtol=tol, msg='kf' + message)
-                self.assertNear(ref_kr[i], gas_kr[i], rtol=tol, msg='kr' + message)
+                assertNear(ref_kf[i], gas_kf[i], rtol=tol, msg='kf' + message)
+                assertNear(ref_kr[i], gas_kr[i], rtol=tol, msg='kr' + message)
 
     @utilities.slow_test
     def test_gri30(self):
@@ -112,8 +119,8 @@ class ck2yamlTest(utilities.CanteraTest):
                 "[{dummy-thermo-from-ck.yaml/species: [R1A, R1B, P1]}], "
                 "thermo: ideal-gas}]}")
         gas = ct.Solution(yaml=yaml)
-        self.assertEqual(gas.n_species, 3)
-        self.assertEqual(gas.n_reactions, 0)
+        assert gas.n_species == 3
+        assert gas.n_reactions == 0
 
     def test_missing_thermo(self):
         with pytest.raises(ck2yaml.InputError):
@@ -210,33 +217,33 @@ class ck2yamlTest(utilities.CanteraTest):
         output = self.convert('species-names.inp')
         gas = ct.Solution(output)
 
-        self.assertEqual(gas.n_species, 10)
-        self.assertEqual(gas.species_name(0), '(Parens)')
-        self.assertEqual(gas.species_name(1), '@#$%^-2')
-        self.assertEqual(gas.species_index('co:lons:'), 2)
-        self.assertEqual(gas.species_name(3), '[xy2]*{.}')
-        self.assertEqual(gas.species_name(4), 'plus+')
-        self.assertEqual(gas.species_name(5), 'eq=uals')
-        self.assertEqual(gas.species_name(6), 'plus')
-        self.assertEqual(gas.species_name(7), 'trans_butene')
-        self.assertEqual(gas.species_name(8), 'co')
-        self.assertEqual(gas.species_name(9), "amp&ersand")
+        assert gas.n_species == 10
+        assert gas.species_name(0) == '(Parens)'
+        assert gas.species_name(1) == '@#$%^-2'
+        assert gas.species_index('co:lons:') == 2
+        assert gas.species_name(3) == '[xy2]*{.}'
+        assert gas.species_name(4) == 'plus+'
+        assert gas.species_name(5) == 'eq=uals'
+        assert gas.species_name(6) == 'plus'
+        assert gas.species_name(7) == 'trans_butene'
+        assert gas.species_name(8) == 'co'
+        assert gas.species_name(9) == "amp&ersand"
 
-        self.assertEqual(gas.n_reactions, 13)
+        assert gas.n_reactions == 13
         nu = gas.product_stoich_coeffs - gas.reactant_stoich_coeffs
-        self.assertEqual(list(nu[:,0]), [-1, -1, 0, 2, 0, 0, 0, 0, 0, 0])
-        self.assertEqual(list(nu[:,1]), [-2, 3, 0, -1, 0, 0, 0, 0, 0, 0])
-        self.assertEqual(list(nu[:,2]), [-1, 0, 0, 0, 1, 0, 0, 0, 0, 0])
-        self.assertEqual(list(nu[:,3]), [3, 0, 0, 0, -2, -1, 0, 0, 0, 0])
-        self.assertEqual(list(nu[:,4]), [2, 0, 0, 0, -1, 0, -1, 0, 0, 0])
-        self.assertEqual(list(nu[:,5]), [1, 0, 0, 0, 1, -1, -1, 0, 0, 0])
-        self.assertEqual(list(nu[:,6]), [2, 0, -1, 0, 0, -1, 0, 0, 0, 0])
-        self.assertEqual(list(nu[:,7]), [0, 0, 0, 0, -1, 1, 0, 0, 0, 0])
-        self.assertEqual(list(nu[:,8]), [0, 0, 0, 0, -1, 1, 0, 0, 0, 0])
-        self.assertEqual(list(nu[:,9]), [0, 0, 0, 0, -1, 1, 0, 0, 0, 0])
-        self.assertEqual(list(nu[:,10]), [0, 0, -1, 0, 2, 0, 0, -1, 0, 0])
-        self.assertEqual(list(nu[:,11]), [0, 0, -1, 0, 2, 0, 0, 0, -1, 0])
-        self.assertEqual(list(nu[:,12]), [0, 0, 0, 0, 1, 0, 0, 0, 0, -1])
+        assert list(nu[:,0]) == [-1, -1, 0, 2, 0, 0, 0, 0, 0, 0]
+        assert list(nu[:,1]) == [-2, 3, 0, -1, 0, 0, 0, 0, 0, 0]
+        assert list(nu[:,2]) == [-1, 0, 0, 0, 1, 0, 0, 0, 0, 0]
+        assert list(nu[:,3]) == [3, 0, 0, 0, -2, -1, 0, 0, 0, 0]
+        assert list(nu[:,4])== [2, 0, 0, 0, -1, 0, -1, 0, 0, 0]
+        assert list(nu[:,5])== [1, 0, 0, 0, 1, -1, -1, 0, 0, 0]
+        assert list(nu[:,6])== [2, 0, -1, 0, 0, -1, 0, 0, 0, 0]
+        assert list(nu[:,7])== [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
+        assert list(nu[:,8])== [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
+        assert list(nu[:,9])== [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
+        assert list(nu[:,10])== [0, 0, -1, 0, 2, 0, 0, -1, 0, 0]
+        assert list(nu[:,11])== [0, 0, -1, 0, 2, 0, 0, 0, -1, 0]
+        assert list(nu[:,12])== [0, 0, 0, 0, 1, 0, 0, 0, 0, -1]
 
     def test_unterminatedSections(self):
         output = self.convert('unterminated-sections.inp', quiet=False)
@@ -244,8 +251,8 @@ class ck2yamlTest(utilities.CanteraTest):
         for section in ["ELEMENTS", "SPECIES", "THERMO", "REACTIONS"]:
             assert f"{section} section implicitly ended" in captured.out
         gas = ct.Solution(output)
-        self.assertEqual(gas.n_species, 3)
-        self.assertEqual(gas.n_reactions, 2)
+        assert gas.n_species == 3
+        assert gas.n_reactions == 2
 
     def test_unterminatedSections2(self):
         output = self.convert('unterminated-sections2.inp', quiet=False)
@@ -254,8 +261,8 @@ class ck2yamlTest(utilities.CanteraTest):
             assert f"{section} section implicitly ended" in captured.out
 
         gas = ct.Solution(output)
-        self.assertEqual(gas.n_species, 3)
-        self.assertEqual(gas.n_reactions, 2)
+        assert gas.n_species == 3
+        assert gas.n_reactions == 2
 
     def test_unrecognized_section(self):
         with pytest.raises(ck2yaml.InputError):
@@ -320,19 +327,19 @@ class ck2yamlTest(utilities.CanteraTest):
         # two irreversible reactions with reactants and products swapped, unless
         # the explicit reverse rate is zero so only the forward reaction is used.
         Rr = gas.reverse_rate_constants
-        self.assertEqual(Rr[0], 0.0)
-        self.assertEqual(Rr[1], 0.0)
-        self.assertEqual(Rr[2], 0.0)
-        self.assertEqual(Rr[3], 0.0)
-        self.assertEqual(Rr[4], 0.0)
+        assert  Rr[0] == 0.0
+        assert Rr[1] == 0.0
+        assert Rr[2] == 0.0
+        assert Rr[3] == 0.0
+        assert Rr[4] == 0.0
         Rstoich = gas.reactant_stoich_coeffs
         Pstoich = gas.product_stoich_coeffs
-        self.assertEqual(list(Rstoich[:, 0]), list(Pstoich[:, 1]))
-        self.assertEqual(list(Rstoich[:, 1]), list(Pstoich[:, 0]))
-        self.assertEqual(list(Rstoich[:, 2]), list(Pstoich[:, 3]))
-        self.assertEqual(list(Rstoich[:, 3]), list(Pstoich[:, 2]))
+        assert list(Rstoich[:, 0]) == list(Pstoich[:, 1])
+        assert list(Rstoich[:, 1]) == list(Pstoich[:, 0])
+        assert list(Rstoich[:, 2]) == list(Pstoich[:, 3])
+        assert list(Rstoich[:, 3]) == list(Pstoich[:, 2])
 
-        self.assertEqual(gas.n_reactions, 5)
+        assert gas.n_reactions == 5
 
     def test_explicit_forward_order(self):
         output = self.convert("explicit-forward-order.inp", thermo="dummy-thermo.dat")
@@ -358,10 +365,10 @@ class ck2yamlTest(utilities.CanteraTest):
     def test_negative_A_factor(self):
         output = self.convert('negative-rate.inp', thermo='dummy-thermo.dat')
         gas = ct.Solution(output)  # Validate the mechanism
-        self.assertLess(gas.reaction(4).rate.pre_exponential_factor, 0)
-        self.assertLess(gas.reaction(1).rate.pre_exponential_factor, 0)
-        self.assertLess(gas.reaction(2).rate.pre_exponential_factor, 0)
-        self.assertLess(gas.forward_rate_constants[5], 0)
+        assert gas.reaction(4).rate.pre_exponential_factor < 0
+        assert gas.reaction(1).rate.pre_exponential_factor < 0
+        assert gas.reaction(2).rate.pre_exponential_factor < 0
+        assert gas.forward_rate_constants[5] < 0
 
     def test_bad_troe_value(self):
         with pytest.raises(ck2yaml.InputError):
@@ -398,10 +405,10 @@ class ck2yamlTest(utilities.CanteraTest):
 
         R = gas.reactant_stoich_coeffs
         P = gas.product_stoich_coeffs
-        self.assertArrayNear(R[:,0], [0, 1.5, 0.5, 0])
-        self.assertArrayNear(P[:,0], [1, 0, 0, 1])
-        self.assertArrayNear(R[:,1], [1, 0, 0, 1])
-        self.assertArrayNear(P[:,1], [0, 0.33, 1.67, 0])
+        assertArrayNear(R[:,0], [0, 1.5, 0.5, 0])
+        assertArrayNear(P[:,0], [1, 0, 0, 1])
+        assertArrayNear(R[:,1], [1, 0, 0, 1])
+        assertArrayNear(P[:,1], [0, 0.33, 1.67, 0])
 
     def test_unparsable_reaction(self):
         with pytest.raises(ck2yaml.InputError, match="Unparsable line"):
@@ -458,7 +465,7 @@ class ck2yamlTest(utilities.CanteraTest):
 
         gas = ct.Solution(output)
         gas.TPX = 300, 101325, 'H2:1.0, O2:1.0'
-        self.assertAlmostEqual(gas.thermal_conductivity, 0.07663, 4)
+        assert gas.thermal_conductivity == approx(0.07663, rel=1e-4)
 
     def test_transport_embedded(self):
         output = self.convert('with-transport.inp')
@@ -466,7 +473,7 @@ class ck2yamlTest(utilities.CanteraTest):
         gas.X = [0.2, 0.3, 0.5]
         D = gas.mix_diff_coeffs
         for d in D:
-            self.assertTrue(d > 0.0)
+            assert d > 0.0
 
     def test_transport_missing_species(self):
         with pytest.raises(ck2yaml.InputError):
@@ -548,30 +555,30 @@ class ck2yamlTest(utilities.CanteraTest):
     def test_empty_reaction_section(self):
         output = self.convert('h2o2_emptyReactions.inp')
         gas = ct.Solution(output)
-        self.assertEqual(gas.n_species, 9)
-        self.assertEqual(gas.n_reactions, 0)
+        assert gas.n_species == 9
+        assert gas.n_reactions == 0
 
     def test_reaction_comments1(self):
         output = self.convert('pdep-test.inp')
         text = output.read_text()
-        self.assertIn('Generic mechanism header', text)
-        self.assertIn('Single PLOG reaction', text)
-        self.assertIn('Multiple PLOG expressions at the same pressure', text)
+        assert 'Generic mechanism header' in text
+        assert 'Single PLOG reaction' in text
+        assert 'Multiple PLOG expressions at the same pressure' in text
 
     def test_reaction_comments2(self):
         output = self.convert('explicit-third-bodies.inp', thermo='dummy-thermo.dat')
         text = output.read_text()
-        self.assertIn('An end of line comment', text)
-        self.assertIn('A comment after the last reaction', text)
+        assert 'An end of line comment' in text
+        assert 'A comment after the last reaction' in text
 
     def test_custom_element(self):
         output = self.convert('custom-elements.inp')
         gas = ct.Solution(output)
-        self.assertEqual(gas.n_elements, 4)
-        self.assertNear(gas.atomic_weight(2), 13.003)
-        self.assertEqual(gas.n_atoms('ethane', 'C'), 2)
-        self.assertEqual(gas.n_atoms('CC', 'C'), 1)
-        self.assertEqual(gas.n_atoms('CC', 'Ci'), 1)
+        assert gas.n_elements == 4
+        assertNear(gas.atomic_weight(2), 13.003)
+        assert gas.n_atoms('ethane', 'C') == 2
+        assert gas.n_atoms('CC', 'C') == 1
+        assert gas.n_atoms('CC', 'Ci') == 1
 
     def test_surface_mech(self):
         output = self.convert('surface1-gas.inp', surface='surface1.inp',
@@ -580,31 +587,31 @@ class ck2yamlTest(utilities.CanteraTest):
         surf = ct.Interface(output, 'PT_SURFACE')
         gas = surf.adjacent["gas"]
 
-        self.assertEqual(gas.n_reactions, 11)
-        self.assertEqual(surf.n_reactions, 15)
-        self.assertEqual(surf.species('O2_Pt').size, 3)
+        assert gas.n_reactions == 11
+        assert surf.n_reactions == 15
+        assert surf.species('O2_Pt').size == 3
 
         # Different units for rate constants in each input file
         # 62.1 kJ/gmol = 6.21e7 J/kmol
-        self.assertNear(gas.reaction(0).rate.activation_energy, 6.21e7)
+        assertNear(gas.reaction(0).rate.activation_energy, 6.21e7)
         # 67400 J/mol = 6.74e7 J/kmol
-        self.assertNear(surf.reaction(1).rate.activation_energy, 6.74e7)
+        assertNear(surf.reaction(1).rate.activation_energy, 6.74e7)
 
         # Sticking coefficients
-        self.assertTrue(surf.reaction(4).duplicate)
-        self.assertNotIsInstance(surf.reaction(1).rate, ct.StickingArrheniusRate)
-        self.assertIsInstance(surf.reaction(2).rate, ct.StickingArrheniusRate)
-        self.assertTrue(surf.reaction(2).rate.motz_wise_correction)
-        self.assertIsInstance(surf.reaction(4).rate, ct.StickingArrheniusRate)
-        self.assertFalse(surf.reaction(4).rate.motz_wise_correction)
-        self.assertTrue(surf.reaction(6).rate.motz_wise_correction)
+        assert surf.reaction(4).duplicate
+        assert not isinstance(surf.reaction(1).rate, ct.StickingArrheniusRate)
+        assert isinstance(surf.reaction(2).rate, ct.StickingArrheniusRate)
+        assert surf.reaction(2).rate.motz_wise_correction
+        assert isinstance(surf.reaction(4).rate, ct.StickingArrheniusRate)
+        assert not surf.reaction(4).rate.motz_wise_correction
+        assert surf.reaction(6).rate.motz_wise_correction
 
         # Coverage dependencies
         covdeps = surf.reaction(1).rate.coverage_dependencies
-        self.assertEqual(len(covdeps), 2)
-        self.assertIn("H_Pt", covdeps)
-        self.assertEqual(covdeps["OH_Pt"]["m"], 1.0)
-        self.assertNear(covdeps["H_Pt"]["E"], -6e6) # 6000 J/gmol = 6e6 J/kmol
+        assert len(covdeps) == 2
+        assert "H_Pt" in covdeps
+        assert covdeps["OH_Pt"]["m"] == 1.0
+        assertNear(covdeps["H_Pt"]["E"], -6e6) # 6000 J/gmol = 6e6 J/kmol
 
     def test_surface_mech2(self):
         output = self.convert('surface1-gas-noreac.inp', surface='surface1.inp',
@@ -613,13 +620,13 @@ class ck2yamlTest(utilities.CanteraTest):
         gas = ct.Solution(output, 'gas')
         surf = ct.Interface(output, 'PT_SURFACE', [gas])
 
-        self.assertEqual(gas.n_reactions, 0)
-        self.assertEqual(surf.n_reactions, 15)
+        assert gas.n_reactions == 0
+        assert surf.n_reactions == 15
 
         covdeps = surf.reaction(1).rate.coverage_dependencies
-        self.assertIn("H_Pt", covdeps)
-        self.assertEqual(covdeps["OH_Pt"]["m"], 1.0)
-        self.assertNear(covdeps["H_Pt"]["E"], -6e6)
+        assert "H_Pt" in covdeps
+        assert covdeps["OH_Pt"]["m"] == 1.0
+        assertNear(covdeps["H_Pt"]["E"], -6e6)
 
     def test_surf_bad_files(self):
         with pytest.raises(ck2yaml.InputError):
@@ -663,12 +670,12 @@ class ck2yamlTest(utilities.CanteraTest):
     def test_third_body_plus_falloff_reactions(self):
         output = self.convert("third_body_plus_falloff_reaction.inp")
         gas = ct.Solution(output)
-        self.assertEqual(gas.n_reactions, 2)
+        assert gas.n_reactions == 2
 
     def test_blank_line_in_header(self):
         output = self.convert("blank_line_in_header.inp")
         gas = ct.Solution(output)
-        self.assertEqual(gas.n_reactions, 1)
+        assert gas.n_reactions == 1
 
     def test_missing_input_files(self):
         with pytest.raises(IOError, match="Missing input file"):
@@ -680,14 +687,14 @@ class ck2yamlTest(utilities.CanteraTest):
         captured = self._capsys.readouterr()
         assert "Missing input file: 'nonexistent-file-813.inp'" in captured.out
 
-    def test_extra(self):
+    def test_extra(self, load_yaml):
         output = self.convert("h2o2.inp", output="h2o2_extra", extra="extra.yaml")
-        yml = utilities.load_yaml(output)
+        yml = load_yaml(output)
 
         desc = yml['description'].split('\n')[-1]
-        self.assertEqual(desc, 'This is an alternative description.')
+        assert desc == 'This is an alternative description.'
         for key in ['foo', 'bar']:
-            self.assertIn(key, yml.keys())
+            assert key in yml.keys()
 
     def test_extra_reserved(self):
         with pytest.raises(ck2yaml.InputError,
@@ -703,14 +710,14 @@ class ck2yamlTest(utilities.CanteraTest):
         assert "alternate description" in captured.out
         assert "needs to be a string" in captured.out
 
-    def test_sri_zero(self):
+    def test_sri_zero(self, load_yaml):
         # This test tests it can convert the SRI parameters when D or E equal to 0
         output = self.convert('sri_convert_test.txt')
-        mech = utilities.load_yaml(output)
+        mech = load_yaml(output)
         D = mech['reactions'][0]['SRI']['D']
         E = mech['reactions'][0]['SRI']['E']
-        self.assertEqual(D, 0)
-        self.assertEqual(E, 0)
+        assert D == 0
+        assert E == 0
 
     def test_duplicate_reactions(self):
         # Running a test this way instead of using the convertMech function
@@ -739,11 +746,11 @@ class ck2yamlTest(utilities.CanteraTest):
                     'R1A + R1B', 'R3 + H'):
             assert token in captured.out
 
-    def test_single_Tint(self):
+    def test_single_Tint(self, load_yaml):
         output = self.convert(None, thermo="thermo_single_Tint.dat",
                               output="thermo_single_Tint",
                               single_intermediate_temperature=True)
-        mech = utilities.load_yaml(output)
+        mech = load_yaml(output)
 
         # Al(cr)
         thermo = mech["species"][0]["thermo"]
@@ -777,7 +784,7 @@ class ck2yamlTest(utilities.CanteraTest):
         assert "no more than 3 digits." in captured.out
 
 
-class yaml2ckTest(utilities.CanteraTest):
+class Testyaml2ck:
     """Test yaml2ck by converting to CK then back to YAML to read with Cantera."""
     ext: str = "-from-yaml2ck.yaml"
 
@@ -853,23 +860,22 @@ class yaml2ckTest(utilities.CanteraTest):
         ck_phase = cls(ckname, **kwargs)
         yaml_phase = cls(basename, phase_name, **kwargs)
 
-        self.assertEqual(set(ck_phase.element_names), set(yaml_phase.element_names))
-        self.assertEqual(set(ck_phase.species_names), set(yaml_phase.species_names))
+        assert set(ck_phase.element_names) == set(yaml_phase.element_names)
+        assert set(ck_phase.species_names) == set(yaml_phase.species_names)
 
         yamlSpecies = [yaml_phase.species(s) for s in ck_phase.species_names]
         for C, Y in zip(ck_phase.species(), yamlSpecies):
-            self.assertEqual(C.composition, Y.composition)
+            assert C.composition == Y.composition
 
-        self.assertEqual(ck_phase.n_reactions, yaml_phase.n_reactions)
+        assert ck_phase.n_reactions == yaml_phase.n_reactions
         for C, Y in zip(ck_phase.reactions(), yaml_phase.reactions()):
-            self.assertEqual(C.__class__, Y.__class__)
-            self.assertEqual(C.reactants, Y.reactants)
-            self.assertEqual(C.products, Y.products)
-            self.assertEqual(C.duplicate, Y.duplicate)
+            assert C.__class__ == Y.__class__
+            assert C.reactants == Y.reactants
+            assert C.products == Y.products
+            assert C.duplicate == Y.duplicate
 
         for i, sp in zip(range(ck_phase.n_reactions), ck_phase.kinetics_species_names):
-            self.assertEqual(ck_phase.reactant_stoich_coeff(sp, i),
-                             yaml_phase.reactant_stoich_coeff(sp, i))
+            assert ck_phase.reactant_stoich_coeff(sp, i) == yaml_phase.reactant_stoich_coeff(sp, i)
 
         return ck_phase, yaml_phase
 
@@ -885,12 +891,12 @@ class yaml2ckTest(utilities.CanteraTest):
             h_yaml = yaml_phase.partial_molar_enthalpies
             s_ck = ck_phase.partial_molar_entropies
             s_yaml = yaml_phase.partial_molar_entropies
-            self.assertNear(ck_phase.density, yaml_phase.density)
+            assertNear(ck_phase.density, yaml_phase.density)
             for i in range(ck_phase.n_species):
                 message = ' for species {0} at T = {1}'.format(i, T)
-                self.assertNear(cp_ck[i], cp_yaml[yaml_idx[i]], tol, msg='cp'+message)
-                self.assertNear(h_ck[i], h_yaml[yaml_idx[i]], tol, msg='h'+message)
-                self.assertNear(s_ck[i], s_yaml[yaml_idx[i]], tol, msg='s'+message)
+                assertNear(cp_ck[i], cp_yaml[yaml_idx[i]], tol, msg='cp'+message)
+                assertNear(h_ck[i], h_yaml[yaml_idx[i]], tol, msg='h'+message)
+                assertNear(s_ck[i], s_yaml[yaml_idx[i]], tol, msg='s'+message)
 
     def check_kinetics(self, ck_phase, yaml_phase, temperatures, pressures, tol=1e-7):
         for T, P in itertools.product(temperatures, pressures):
@@ -902,8 +908,8 @@ class yaml2ckTest(utilities.CanteraTest):
             kr_yaml = yaml_phase.reverse_rate_constants
             for i in range(yaml_phase.n_reactions):
                 message = f"for reaction {i+1}: {yaml_phase.reaction(i)} at T = {T}, P = {P}"
-                self.assertNear(kf_ck[i], kf_yaml[i], rtol=tol, msg="kf " + message)
-                self.assertNear(kr_ck[i], kr_yaml[i], rtol=tol, msg="kr " + message)
+                assertNear(kf_ck[i], kf_yaml[i], rtol=tol, msg="kf " + message)
+                assertNear(kr_ck[i], kr_yaml[i], rtol=tol, msg="kr " + message)
 
     def check_transport(self, ck_phase, yaml_phase, temperatures, model="mixture-averaged"):
         yaml_idx = {ck_phase.species_index(s): yaml_phase.species_index(s) for s in ck_phase.species_names}
@@ -912,14 +918,14 @@ class yaml2ckTest(utilities.CanteraTest):
         for T in temperatures:
             ck_phase.TP = T, ct.one_atm
             yaml_phase.TP = T, ct.one_atm
-            self.assertNear(ck_phase.viscosity, yaml_phase.viscosity)
-            self.assertNear(ck_phase.thermal_conductivity,
+            assertNear(ck_phase.viscosity, yaml_phase.viscosity)
+            assertNear(ck_phase.thermal_conductivity,
                             yaml_phase.thermal_conductivity)
             Dkm_ck = ck_phase.mix_diff_coeffs
             Dkm_yaml = yaml_phase.mix_diff_coeffs
             for i in range(ck_phase.n_species):
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
-                self.assertNear(Dkm_ck[i], Dkm_yaml[yaml_idx[i]], msg=message)
+                assertNear(Dkm_ck[i], Dkm_yaml[yaml_idx[i]], msg=message)
 
     @utilities.slow_test
     def test_gri30(self):
@@ -1081,7 +1087,7 @@ class yaml2ckTest(utilities.CanteraTest):
         assert ck_phase.species("H2").input_data["thermo"]["note"] == "Line 1\nLine 2"
 
 
-class cti2yamlTest(utilities.CanteraTest):
+class Testcti2yaml:
     def convert(self, basename, src_dir=None, encoding=None):
         if src_dir is None:
             src_dir = self.test_data_path
@@ -1097,21 +1103,20 @@ class cti2yamlTest(utilities.CanteraTest):
         ctiPhase = cls(f"{basename}-from-cti.yaml", adjacent=ctiphases, **kwargs)
         yamlPhase = cls(f"{basename}.yaml", adjacent=yamlphases, **kwargs)
 
-        self.assertEqual(ctiPhase.element_names, yamlPhase.element_names)
-        self.assertEqual(ctiPhase.species_names, yamlPhase.species_names)
-        self.assertEqual(ctiPhase.n_reactions, yamlPhase.n_reactions)
+        assert ctiPhase.element_names == yamlPhase.element_names
+        assert ctiPhase.species_names == yamlPhase.species_names
+        assert ctiPhase.n_reactions == yamlPhase.n_reactions
         for C, Y in zip(ctiPhase.species(), yamlPhase.species()):
-            self.assertEqual(C.composition, Y.composition)
+            assert C.composition == Y.composition
 
         for C, Y in zip(ctiPhase.reactions(), yamlPhase.reactions()):
-            self.assertEqual(C.__class__, Y.__class__)
-            self.assertEqual(C.reactants, Y.reactants)
-            self.assertEqual(C.products, Y.products)
-            self.assertEqual(C.duplicate, Y.duplicate)
+            assert C.__class__ == Y.__class__
+            assert C.reactants == Y.reactants
+            assert C.products == Y.products
+            assert C.duplicate == Y.duplicate
 
         for i, sp in zip(range(ctiPhase.n_reactions), ctiPhase.kinetics_species_names):
-            self.assertEqual(ctiPhase.reactant_stoich_coeff(sp, i),
-                             yamlPhase.reactant_stoich_coeff(sp, i))
+            assert ctiPhase.reactant_stoich_coeff(sp, i) == yamlPhase.reactant_stoich_coeff(sp, i)
 
         return ctiPhase, yamlPhase
 
@@ -1129,13 +1134,13 @@ class cti2yamlTest(utilities.CanteraTest):
             h_yaml = yamlPhase.partial_molar_enthalpies
             s_cti = ctiPhase.partial_molar_entropies
             s_yaml = yamlPhase.partial_molar_entropies
-            self.assertNear(ctiPhase.density, yamlPhase.density)
+            assertNear(ctiPhase.density, yamlPhase.density)
             for i in range(ctiPhase.n_species):
                 message = ' for species {0} at T = {1}'.format(i, T)
                 if check_cp:
-                    self.assertNear(cp_cti[i], cp_yaml[i], tol, msg='cp'+message)
-                self.assertNear(h_cti[i], h_yaml[i], tol, msg='h'+message)
-                self.assertNear(s_cti[i], s_yaml[i], tol, msg='s'+message)
+                    assertNear(cp_cti[i], cp_yaml[i], tol, msg='cp'+message)
+                assertNear(h_cti[i], h_yaml[i], tol, msg='h'+message)
+                assertNear(s_cti[i], s_yaml[i], tol, msg='s'+message)
 
     def checkKinetics(self, ctiPhase, yamlPhase, temperatures, pressures, tol=1e-7):
         for T,P in itertools.product(temperatures, pressures):
@@ -1147,8 +1152,8 @@ class cti2yamlTest(utilities.CanteraTest):
             kr_yaml = yamlPhase.reverse_rate_constants
             for i in range(yamlPhase.n_reactions):
                 message = ' for reaction {0} at T = {1}, P = {2}'.format(i, T, P)
-                self.assertNear(kf_cti[i], kf_yaml[i], rtol=tol, msg='kf '+message)
-                self.assertNear(kr_cti[i], kr_yaml[i], rtol=tol, msg='kr '+message)
+                assertNear(kf_cti[i], kf_yaml[i], rtol=tol, msg='kf '+message)
+                assertNear(kr_cti[i], kr_yaml[i], rtol=tol, msg='kr '+message)
 
     def checkTransport(self, ctiPhase, yamlPhase, temperatures,
                        model='mixture-averaged'):
@@ -1157,14 +1162,14 @@ class cti2yamlTest(utilities.CanteraTest):
         for T in temperatures:
             ctiPhase.TP = T, ct.one_atm
             yamlPhase.TP = T, ct.one_atm
-            self.assertNear(ctiPhase.viscosity, yamlPhase.viscosity)
-            self.assertNear(ctiPhase.thermal_conductivity,
+            assertNear(ctiPhase.viscosity, yamlPhase.viscosity)
+            assertNear(ctiPhase.thermal_conductivity,
                             yamlPhase.thermal_conductivity)
             Dkm_cti = ctiPhase.mix_diff_coeffs
             Dkm_yaml = yamlPhase.mix_diff_coeffs
             for i in range(ctiPhase.n_species):
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
-                self.assertNear(Dkm_cti[i], Dkm_yaml[i], msg=message)
+                assertNear(Dkm_cti[i], Dkm_yaml[i], msg=message)
 
     @utilities.slow_test
     def test_gri30(self):
@@ -1213,8 +1218,8 @@ class cti2yamlTest(utilities.CanteraTest):
         ctiMetal, ctiMSurf, ctiOSurf = cti_tpb.adjacent.values()
         yamlMetal, yamlMSurf, yamlOSurf = yaml_tpb.adjacent.values()
 
-        self.assertIn("oxide_bulk", ctiOSurf.adjacent)
-        self.assertIn("gas", ctiOSurf.adjacent)
+        assert "oxide_bulk" in ctiOSurf.adjacent
+        assert "gas" in ctiOSurf.adjacent
 
         self.checkThermo(ctiMSurf, yamlMSurf, [900, 1000, 1100])
         self.checkThermo(ctiOSurf, yamlOSurf, [900, 1000, 1100])
@@ -1305,7 +1310,7 @@ class cti2yamlTest(utilities.CanteraTest):
         self.checkKinetics(ctiGas, yamlGas, [300, 1001, 2500], [1e5, 10e5])
 
 
-class ctml2yamlTest(utilities.CanteraTest):
+class Testctml2yaml:
     def convert(self, basename, src_dir=None):
         if src_dir is None:
             src_dir = self.test_data_path
@@ -1320,21 +1325,20 @@ class ctml2yamlTest(utilities.CanteraTest):
         ctmlPhase = cls(f"{basename}-from-xml.yaml", adjacent=ctmlphases, **kwargs)
         yamlPhase = cls(f"{basename}.yaml", adjacent=yamlphases, **kwargs)
 
-        self.assertEqual(ctmlPhase.element_names, yamlPhase.element_names)
-        self.assertEqual(ctmlPhase.species_names, yamlPhase.species_names)
-        self.assertEqual(ctmlPhase.n_reactions, yamlPhase.n_reactions)
+        assert ctmlPhase.element_names == yamlPhase.element_names
+        assert ctmlPhase.species_names == yamlPhase.species_names
+        assert ctmlPhase.n_reactions == yamlPhase.n_reactions
         for C, Y in zip(ctmlPhase.species(), yamlPhase.species()):
-            self.assertEqual(C.composition, Y.composition)
+            assert C.composition == Y.composition
 
         for C, Y in zip(ctmlPhase.reactions(), yamlPhase.reactions()):
-            self.assertEqual(C.__class__, Y.__class__)
-            self.assertEqual(C.reactants, Y.reactants)
-            self.assertEqual(C.products, Y.products)
-            self.assertEqual(C.duplicate, Y.duplicate)
+            assert C.__class__ == Y.__class__
+            assert C.reactants == Y.reactants
+            assert C.products == Y.products
+            assert C.duplicate == Y.duplicate
 
         for i, sp in zip(range(ctmlPhase.n_reactions), ctmlPhase.kinetics_species_names):
-            self.assertEqual(ctmlPhase.reactant_stoich_coeff(sp, i),
-                             yamlPhase.reactant_stoich_coeff(sp, i))
+            assert ctmlPhase.reactant_stoich_coeff(sp, i) == yamlPhase.reactant_stoich_coeff(sp, i)
 
         return ctmlPhase, yamlPhase
 
@@ -1353,13 +1357,13 @@ class ctml2yamlTest(utilities.CanteraTest):
             h_yaml = yamlPhase.partial_molar_enthalpies
             s_ctml = ctmlPhase.partial_molar_entropies
             s_yaml = yamlPhase.partial_molar_entropies
-            self.assertNear(ctmlPhase.density, yamlPhase.density)
+            assertNear(ctmlPhase.density, yamlPhase.density)
             for i in range(ctmlPhase.n_species):
                 message = ' for species {0} at T = {1}'.format(ctmlPhase.species_names[i], T)
                 if check_cp:
-                    self.assertNear(cp_ctml[i], cp_yaml[i], tol, msg='cp'+message)
-                self.assertNear(h_ctml[i], h_yaml[i], tol, msg='h'+message)
-                self.assertNear(s_ctml[i], s_yaml[i], tol, msg='s'+message)
+                    assertNear(cp_ctml[i], cp_yaml[i], tol, msg='cp'+message)
+                assertNear(h_ctml[i], h_yaml[i], tol, msg='h'+message)
+                assertNear(s_ctml[i], s_yaml[i], tol, msg='s'+message)
 
     def checkKinetics(self, ctmlPhase, yamlPhase, temperatures, pressures, tol=1e-7):
         for T,P in itertools.product(temperatures, pressures):
@@ -1371,8 +1375,8 @@ class ctml2yamlTest(utilities.CanteraTest):
             kr_yaml = yamlPhase.reverse_rate_constants
             for i in range(yamlPhase.n_reactions):
                 message = ' for reaction {0} at T = {1}, P = {2}'.format(i, T, P)
-                self.assertNear(kf_ctml[i], kf_yaml[i], rtol=tol, msg='kf '+message)
-                self.assertNear(kr_ctml[i], kr_yaml[i], rtol=tol, msg='kr '+message)
+                assertNear(kf_ctml[i], kf_yaml[i], rtol=tol, msg='kf '+message)
+                assertNear(kr_ctml[i], kr_yaml[i], rtol=tol, msg='kr '+message)
 
     def checkTransport(self, ctmlPhase, yamlPhase, temperatures,
                        model='mixture-averaged'):
@@ -1381,14 +1385,14 @@ class ctml2yamlTest(utilities.CanteraTest):
         for T in temperatures:
             ctmlPhase.TP = T, ct.one_atm
             yamlPhase.TP = T, ct.one_atm
-            self.assertNear(ctmlPhase.viscosity, yamlPhase.viscosity)
-            self.assertNear(ctmlPhase.thermal_conductivity,
+            assertNear(ctmlPhase.viscosity, yamlPhase.viscosity)
+            assertNear(ctmlPhase.thermal_conductivity,
                             yamlPhase.thermal_conductivity)
             Dkm_ctml = ctmlPhase.mix_diff_coeffs
             Dkm_yaml = yamlPhase.mix_diff_coeffs
             for i in range(ctmlPhase.n_species):
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
-                self.assertNear(Dkm_ctml[i], Dkm_yaml[i], msg=message)
+                assertNear(Dkm_ctml[i], Dkm_yaml[i], msg=message)
 
     @utilities.slow_test
     def test_gri30(self):
@@ -1435,8 +1439,8 @@ class ctml2yamlTest(utilities.CanteraTest):
         ctmlMetal, ctmlMSurf, ctmlOSurf = ctml_tpb.adjacent.values()
         yamlMetal, yamlMSurf, yamlOSurf = yaml_tpb.adjacent.values()
 
-        self.assertIn("oxide_bulk", ctmlOSurf.adjacent)
-        self.assertIn("gas", ctmlOSurf.adjacent)
+        assert "oxide_bulk" in ctmlOSurf.adjacent
+        assert "gas" in  ctmlOSurf.adjacent
 
         self.checkThermo(ctmlMSurf, yamlMSurf, [900, 1000, 1100])
         self.checkThermo(ctmlOSurf, yamlOSurf, [900, 1000, 1100])
@@ -1559,15 +1563,15 @@ class ctml2yamlTest(utilities.CanteraTest):
         self.convert("liquid-water")
         ctmlWater, yamlWater = self.checkConversion("liquid-water")
         self.checkThermo(ctmlWater, yamlWater, [300, 500, 1300, 2000], pressure=22064000.0)
-        self.assertEqual(ctmlWater.transport_model, yamlWater.transport_model)
+        assert ctmlWater.transport_model == yamlWater.transport_model
         ctmlWater.TP = yamlWater.TP = 300, 22064000.0
         dens = ctmlWater.density
         for T in [298, 1001, 2400]:
             ctmlWater.TD = T, dens
             yamlWater.TD = T, dens
-            self.assertNear(ctmlWater.viscosity, yamlWater.viscosity)
-            self.assertNear(ctmlWater.thermal_conductivity,
-                            yamlWater.thermal_conductivity)
+            assertNear(ctmlWater.viscosity, yamlWater.viscosity)
+            assertNear(ctmlWater.thermal_conductivity,
+                       yamlWater.thermal_conductivity)
 
     def test_hmw_nacl_phase(self):
         basename = "HMW_NaCl_sp1977_alt"
@@ -1625,7 +1629,7 @@ class ctml2yamlTest(utilities.CanteraTest):
         self.checkThermo(ctmlPhase, yamlPhase, [300, 500])
 
     def test_idealsolidsoln(self):
-        with self.assertWarnsRegex(UserWarning, "SolidKinetics type is not implemented"):
+        with pytest.warns(UserWarning, match="SolidKinetics type is not implemented"):
             self.convert("IdealSolidSolnPhaseExample")
 
         # SolidKinetics is not implemented, so can't create a Kinetics class instance.
@@ -1633,8 +1637,8 @@ class ctml2yamlTest(utilities.CanteraTest):
         ctmlPhase = ct.ThermoPhase(basename + "-from-xml.yaml")
         yamlPhase = ct.ThermoPhase(basename + ".yaml")
 
-        self.assertEqual(ctmlPhase.element_names, yamlPhase.element_names)
-        self.assertEqual(ctmlPhase.species_names, yamlPhase.species_names)
+        assert ctmlPhase.element_names == yamlPhase.element_names
+        assert ctmlPhase.species_names == yamlPhase.species_names
         self.checkThermo(ctmlPhase, yamlPhase, [300, 500])
 
     def test_idealmolalsoln(self):
@@ -1660,12 +1664,12 @@ class ctml2yamlTest(utilities.CanteraTest):
         self.checkThermo(ctmlPhase, yamlPhase, [300, 500])
 
     def test_duplicate_section_ids(self):
-        with self.assertWarnsRegex(UserWarning, "Duplicate 'speciesData' id"):
+        with pytest.warns(UserWarning, match="Duplicate 'speciesData' id"):
             self.convert("duplicate-speciesData-ids")
-        with self.assertWarnsRegex(UserWarning, "Duplicate 'reactionData' id"):
+        with pytest.warns(UserWarning, match="Duplicate 'reactionData' id"):
             self.convert("duplicate-reactionData-ids")
 
-class lxcat2yamlTest(utilities.CanteraTest):
+class Testlxcat2yaml:
     def convert(self, inputFile=None, database=None, mechFile=None, phase=None,
                 insert=True, output=None):
         if inputFile is not None:

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -5,14 +5,9 @@ from pathlib import Path
 import pytest
 from pytest import approx
 
-from . import utilities
-from .utilities import allow_deprecated
 from .utilities import (
     assertNear,
-    assertArrayNear,
-    assertIsFinite,
-    assertIsNaN,
-    compare
+    assertArrayNear
 )
 
 import cantera as ct
@@ -94,7 +89,7 @@ class Testck2yaml:
                 assertNear(ref_kf[i], gas_kf[i], rtol=tol, msg='kf' + message)
                 assertNear(ref_kr[i], gas_kr[i], rtol=tol, msg='kr' + message)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_gri30(self):
         output = self.convert('gri30.inp', thermo='gri30_thermo.dat',
                               transport='gri30_tran.dat', output='gri30_test')
@@ -391,7 +386,7 @@ class Testck2yaml:
         captured = self._capsys.readouterr()
         assert "Third bodies do not match: 'M' and 'AR'" in captured.out
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_reaction_units(self):
         out_def = self.convert('units-default.inp', thermo='dummy-thermo.dat')
         out_cus = self.convert('units-custom.inp', thermo='dummy-thermo.dat')
@@ -927,7 +922,7 @@ class Testyaml2ck:
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
                 assertNear(Dkm_ck[i], Dkm_yaml[yaml_idx[i]], msg=message)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_gri30(self):
         input_file = self.cantera_data_path / "gri30.yaml"
         self.convert(input_file)
@@ -1171,7 +1166,7 @@ class Testcti2yaml:
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
                 assertNear(Dkm_cti[i], Dkm_yaml[i], msg=message)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_gri30(self):
         self.convert("gri30")
         ctiPhase, yamlPhase = self.checkConversion('gri30')
@@ -1200,7 +1195,7 @@ class Testcti2yaml:
         self.checkThermo(ctiSurf, yamlSurf, [400, 800, 1600])
         self.checkKinetics(ctiSurf, yamlSurf, [500, 1200], [1e4, 3e5])
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_ptcombust_motzwise(self):
         self.convert("ptcombust-motzwise")
         ctiSurf, yamlSurf = self.checkConversion("ptcombust-motzwise", ct.Interface,
@@ -1228,7 +1223,7 @@ class Testcti2yaml:
         ctiMetal.electric_potential = yamlMetal.electric_potential = 4
         self.checkKinetics(cti_tpb, yaml_tpb, [900, 1000, 1100], [1e5])
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_liquidvapor(self):
         self.convert("liquidvapor")
         for name in ["water", "nitrogen", "methane", "hydrogen", "oxygen", "heptane"]:
@@ -1394,7 +1389,7 @@ class Testctml2yaml:
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
                 assertNear(Dkm_ctml[i], Dkm_yaml[i], msg=message)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_gri30(self):
         self.convert("gri30")
         ctmlPhase, yamlPhase = self.checkConversion('gri30')

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -54,7 +54,7 @@ class Testck2yaml:
                         for i in range(ref.n_species)]
         compositionB = [[gas.n_atoms(i,j) for j in range(gas.n_elements)]
                         for i in range(gas.n_species)]
-        assert compositionA, compositionB
+        assert compositionA == compositionB
 
         return ref, gas
 
@@ -70,9 +70,9 @@ class Testck2yaml:
             gas_s = gas.standard_entropies_R
             for i in range(gas.n_species):
                 message = ' for species {0} at T = {1}'.format(i, T)
-                assert ref_cp[i] == approx(gas_cp[i], rel=1e-7)
-                assert ref_h[i] == approx(gas_h[i], rel=1e-7)
-                assert ref_s[i] == approx(gas_s[i], rel=1e-7)
+                assert ref_cp[i] == approx(gas_cp[i], rel=1e-7), 'cp' + message
+                assert ref_h[i] == approx(gas_h[i], rel=1e-7), 'h' + message
+                assert ref_s[i] == approx(gas_s[i], rel=1e-7), 's' + message
 
     def checkKinetics(self, ref, gas, temperatures, pressures, tol=1e-8):
         for T,P in itertools.product(temperatures, pressures):
@@ -84,8 +84,8 @@ class Testck2yaml:
             gas_kr = gas.reverse_rate_constants
             for i in range(gas.n_reactions):
                 message = ' for reaction {0} at T = {1}, P = {2}'.format(i, T, P)
-                assert ref_kf[i] == approx(gas_kf[i], rel=tol)
-                assert ref_kr[i] == approx(gas_kr[i], rel=tol)
+                assert ref_kf[i] == approx(gas_kf[i], rel=tol), 'kf' + message
+                assert ref_kr[i] == approx(gas_kr[i], rel=tol), 'kr' + message
 
     @pytest.mark.slow_test
     def test_gri30(self):
@@ -228,15 +228,15 @@ class Testck2yaml:
         assert list(nu[:,1]) == [-2, 3, 0, -1, 0, 0, 0, 0, 0, 0]
         assert list(nu[:,2]) == [-1, 0, 0, 0, 1, 0, 0, 0, 0, 0]
         assert list(nu[:,3]) == [3, 0, 0, 0, -2, -1, 0, 0, 0, 0]
-        assert list(nu[:,4])== [2, 0, 0, 0, -1, 0, -1, 0, 0, 0]
-        assert list(nu[:,5])== [1, 0, 0, 0, 1, -1, -1, 0, 0, 0]
-        assert list(nu[:,6])== [2, 0, -1, 0, 0, -1, 0, 0, 0, 0]
-        assert list(nu[:,7])== [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
-        assert list(nu[:,8])== [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
-        assert list(nu[:,9])== [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
-        assert list(nu[:,10])== [0, 0, -1, 0, 2, 0, 0, -1, 0, 0]
-        assert list(nu[:,11])== [0, 0, -1, 0, 2, 0, 0, 0, -1, 0]
-        assert list(nu[:,12])== [0, 0, 0, 0, 1, 0, 0, 0, 0, -1]
+        assert list(nu[:,4]) == [2, 0, 0, 0, -1, 0, -1, 0, 0, 0]
+        assert list(nu[:,5]) == [1, 0, 0, 0, 1, -1, -1, 0, 0, 0]
+        assert list(nu[:,6]) == [2, 0, -1, 0, 0, -1, 0, 0, 0, 0]
+        assert list(nu[:,7]) == [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
+        assert list(nu[:,8]) == [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
+        assert list(nu[:,9]) == [0, 0, 0, 0, -1, 1, 0, 0, 0, 0]
+        assert list(nu[:,10]) == [0, 0, -1, 0, 2, 0, 0, -1, 0, 0]
+        assert list(nu[:,11]) == [0, 0, -1, 0, 2, 0, 0, 0, -1, 0]
+        assert list(nu[:,12]) == [0, 0, 0, 0, 1, 0, 0, 0, 0, -1]
 
     def test_unterminatedSections(self):
         output = self.convert('unterminated-sections.inp', quiet=False)
@@ -320,7 +320,7 @@ class Testck2yaml:
         # two irreversible reactions with reactants and products swapped, unless
         # the explicit reverse rate is zero so only the forward reaction is used.
         Rr = gas.reverse_rate_constants
-        assert  Rr[0] == 0.0
+        assert Rr[0] == 0.0
         assert Rr[1] == 0.0
         assert Rr[2] == 0.0
         assert Rr[3] == 0.0
@@ -891,9 +891,9 @@ class Testyaml2ck:
             assert ck_phase.density == approx(yaml_phase.density)
             for i in range(ck_phase.n_species):
                 message = ' for species {0} at T = {1}'.format(i, T)
-                assert cp_ck[i] == approx(cp_yaml[yaml_idx[i]], rel=tol)
-                assert h_ck[i] == approx(h_yaml[yaml_idx[i]], rel=tol)
-                assert s_ck[i] == approx(s_yaml[yaml_idx[i]], rel=tol)
+                assert cp_ck[i] == approx(cp_yaml[yaml_idx[i]], rel=tol), 'cp' + message
+                assert h_ck[i] == approx(h_yaml[yaml_idx[i]], rel=tol), 'h' + message
+                assert s_ck[i] == approx(s_yaml[yaml_idx[i]], rel=tol), 's' + message
 
     def check_kinetics(self, ck_phase, yaml_phase, temperatures, pressures, tol=1e-7):
         for T, P in itertools.product(temperatures, pressures):
@@ -905,8 +905,8 @@ class Testyaml2ck:
             kr_yaml = yaml_phase.reverse_rate_constants
             for i in range(yaml_phase.n_reactions):
                 message = f"for reaction {i+1}: {yaml_phase.reaction(i)} at T = {T}, P = {P}"
-                assert kf_ck[i] == approx(kf_yaml[i], rel=tol)
-                assert kr_ck[i] == approx(kr_yaml[i], rel=tol)
+                assert kf_ck[i] == approx(kf_yaml[i], rel=tol), 'kf ' + message
+                assert kr_ck[i] == approx(kr_yaml[i], rel=tol), 'kr ' + message
 
     def check_transport(self, ck_phase, yaml_phase, temperatures, model="mixture-averaged"):
         yaml_idx = {ck_phase.species_index(s): yaml_phase.species_index(s) for s in ck_phase.species_names}
@@ -921,7 +921,7 @@ class Testyaml2ck:
             Dkm_yaml = yaml_phase.mix_diff_coeffs
             for i in range(ck_phase.n_species):
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
-                assert Dkm_ck[i] == approx(Dkm_yaml[yaml_idx[i]])
+                assert Dkm_ck[i] == approx(Dkm_yaml[yaml_idx[i]]), message
 
     @pytest.mark.slow_test
     def test_gri30(self, cantera_data_path):
@@ -1139,9 +1139,9 @@ class Testcti2yaml:
             for i in range(ctiPhase.n_species):
                 message = ' for species {0} at T = {1}'.format(i, T)
                 if check_cp:
-                    cp_cti[i] == approx(cp_yaml[i], rel=tol)
-                assert h_cti[i] == approx(h_yaml[i], rel=tol)
-                assert s_cti[i] == approx(s_yaml[i], rel=tol)
+                    cp_cti[i] == approx(cp_yaml[i], rel=tol), 'cp' + message
+                assert h_cti[i] == approx(h_yaml[i], rel=tol), 'h' + message
+                assert s_cti[i] == approx(s_yaml[i], rel=tol), 's' + message
 
     def checkKinetics(self, ctiPhase, yamlPhase, temperatures, pressures, tol=1e-7):
         for T,P in itertools.product(temperatures, pressures):
@@ -1153,8 +1153,8 @@ class Testcti2yaml:
             kr_yaml = yamlPhase.reverse_rate_constants
             for i in range(yamlPhase.n_reactions):
                 message = ' for reaction {0} at T = {1}, P = {2}'.format(i, T, P)
-                assert kf_cti[i] == approx(kf_yaml[i], rel=tol)
-                assert kr_cti[i] == approx(kr_yaml[i], rel=tol)
+                assert kf_cti[i] == approx(kf_yaml[i], rel=tol), 'kf ' + message
+                assert kr_cti[i] == approx(kr_yaml[i], rel=tol), 'kr ' + message
 
     def checkTransport(self, ctiPhase, yamlPhase, temperatures,
                        model='mixture-averaged'):
@@ -1169,7 +1169,7 @@ class Testcti2yaml:
             Dkm_yaml = yamlPhase.mix_diff_coeffs
             for i in range(ctiPhase.n_species):
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
-                assert Dkm_cti[i] == approx(Dkm_yaml[i])
+                assert Dkm_cti[i] == approx(Dkm_yaml[i]), message
 
     @pytest.mark.slow_test
     def test_gri30(self):
@@ -1343,7 +1343,8 @@ class Testctml2yaml:
             assert C.duplicate == Y.duplicate
 
         for i, sp in zip(range(ctmlPhase.n_reactions), ctmlPhase.kinetics_species_names):
-            assert ctmlPhase.reactant_stoich_coeff(sp, i) == yamlPhase.reactant_stoich_coeff(sp, i)
+            assert (ctmlPhase.reactant_stoich_coeff(sp, i)
+                    == yamlPhase.reactant_stoich_coeff(sp, i))
 
         return ctmlPhase, yamlPhase
 
@@ -1366,9 +1367,9 @@ class Testctml2yaml:
             for i in range(ctmlPhase.n_species):
                 message = ' for species {0} at T = {1}'.format(ctmlPhase.species_names[i], T)
                 if check_cp:
-                    assert cp_ctml[i] == approx(cp_yaml[i], rel=tol)
-                assert h_ctml[i] == approx(h_yaml[i], rel=tol)
-                assert s_ctml[i] == approx(s_yaml[i], rel=tol)
+                    assert cp_ctml[i] == approx(cp_yaml[i], rel=tol), 'cp' + message
+                assert h_ctml[i] == approx(h_yaml[i], rel=tol), 'h' + message
+                assert s_ctml[i] == approx(s_yaml[i], rel=tol), 's' + message
 
     def checkKinetics(self, ctmlPhase, yamlPhase, temperatures, pressures, tol=1e-7):
         for T,P in itertools.product(temperatures, pressures):
@@ -1380,8 +1381,8 @@ class Testctml2yaml:
             kr_yaml = yamlPhase.reverse_rate_constants
             for i in range(yamlPhase.n_reactions):
                 message = ' for reaction {0} at T = {1}, P = {2}'.format(i, T, P)
-                assert kf_ctml[i] == approx(kf_yaml[i], rel=tol)
-                assert kr_ctml[i] == approx(kr_yaml[i], rel=tol)
+                assert kf_ctml[i] == approx(kf_yaml[i], rel=tol), 'kf ' + message
+                assert kr_ctml[i] == approx(kr_yaml[i], rel=tol), 'kr ' + message
 
     def checkTransport(self, ctmlPhase, yamlPhase, temperatures,
                        model='mixture-averaged'):
@@ -1396,7 +1397,7 @@ class Testctml2yaml:
             Dkm_yaml = yamlPhase.mix_diff_coeffs
             for i in range(ctmlPhase.n_species):
                 message = 'dkm for species {0} at T = {1}'.format(i, T)
-                assert Dkm_ctml[i] == approx(Dkm_yaml[i])
+                assert Dkm_ctml[i] == approx(Dkm_yaml[i]), message
 
     @pytest.mark.slow_test
     def test_gri30(self):

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -1,19 +1,27 @@
-import unittest
-
 import numpy as np
+import pytest
+from pytest import approx
 
 import cantera as ct
 from . import utilities
-
+from .utilities import (
+    assertNear,
+    compare,
+)
 
 class EquilTestCases:
-    def __init__(self, solver):
-        self.solver = solver
+    """
+    Base class for equilibrium test cases, parameterized by the solver to use.
+    """
+    solver = None # must be set by subclass
 
     def check(self, gas, **moles):
+        """
+        Check that the mole fractions in `gas` match the expected values in `moles`.
+        """
         nTotal = sum(moles.values())
         for name, X in moles.items():
-            self.assertAlmostEqual(gas[name].X[0], X/nTotal)
+            assert gas[name].X[0] == approx(X/nTotal)
 
     def test_equil_complete_stoichiometric(self):
         """
@@ -71,25 +79,29 @@ class EquilTestCases:
         self.check(gas, CH4=1, O2=1)
 
 
-class ChemEquilTest(EquilTestCases, utilities.CanteraTest):
-    def __init__(self, *args, **kwargs):
-        EquilTestCases.__init__(self, 'element_potential')
-        unittest.TestCase.__init__(self, *args, **kwargs)
+class TestChemEquil(EquilTestCases):
+    """
+    Tests using the 'element_potential' solver.
+    """
+
+    solver = 'element_potential'
 
 
-class MultiphaseEquilTest(EquilTestCases, utilities.CanteraTest):
-    def __init__(self, *args, **kwargs):
-        EquilTestCases.__init__(self, 'gibbs')
-        unittest.TestCase.__init__(self, *args, **kwargs)
+class TestMultiphaseEquil(EquilTestCases):
+    """
+    Tests using the 'gibbs' solver.
+    """
 
-    @unittest.expectedFailure
+    solver = 'gibbs'
+
+    @pytest.mark.xfail
     def test_equil_gri_stoichiometric(self):
         gas = ct.Solution('gri30.yaml', transport_model=None)
         gas.TPX = 301, 100000, 'CH4:1.0, O2:2.0'
         gas.equilibrate('TP', self.solver)
         self.check(gas, CH4=0, O2=0, H2O=2, CO2=1)
 
-    @unittest.expectedFailure
+    @pytest.mark.xfail
     def test_equil_gri_lean(self):
         gas = ct.Solution('gri30.yaml', transport_model=None)
         gas.TPX = 301, 100000, 'CH4:1.0, O2:3.0'
@@ -97,52 +109,65 @@ class MultiphaseEquilTest(EquilTestCases, utilities.CanteraTest):
         self.check(gas, CH4=0, O2=1, H2O=2, CO2=1)
 
 
-class EquilExtraElements(utilities.CanteraTest):
-    def setUp(self):
-        s = """
-        phases:
-        - name: gas
-          thermo: ideal-gas
-          elements: [H, Ar, C, O, Cl, N]
-          species: [{gri30.yaml/species: [AR, N2, CH4, O2, CO2, H2O, CO, H2, OH]}]
-        """
-        self.gas = ct.Solution(yaml=s)
-        self.gas.TP = 300, 101325
-        self.gas.set_equivalence_ratio(0.8, 'CH4', 'O2:1.0, N2:3.76')
+@pytest.fixture(scope='function')
+def extra_elements(request):
+    s = """
+    phases:
+    - name: gas
+      thermo: ideal-gas
+      elements: [H, Ar, C, O, Cl, N]
+      species: [{gri30.yaml/species: [AR, N2, CH4, O2, CO2, H2O, CO, H2, OH]}]
+    """
+    request.cls.gas = ct.Solution(yaml=s)
+    request.cls.gas.TP = 300, 101325
+    request.cls.gas.set_equivalence_ratio(0.8, 'CH4', 'O2:1.0, N2:3.76')
+
+@pytest.mark.usefixtures('extra_elements')
+class TestEquilExtraElements:
+    """
+    Tests equilibrium with extra elements that are not involved in the reactions.
+    """
 
     def test_auto(self):
         # Succeeds after falling back to VCS
         self.gas.equilibrate('TP')
-        self.assertNear(self.gas['CH4'].X[0], 0.0)
+        assertNear(self.gas['CH4'].X[0], 0.0)
 
-    @unittest.expectedFailure
+    @pytest.mark.xfail
     def test_element_potential(self):
         self.gas.equilibrate('TP', solver='element_potential')
-        self.assertNear(self.gas['CH4'].X[0], 0.0)
+        assertNear(self.gas['CH4'].X[0], 0.0)
 
     def test_gibbs(self):
         self.gas.equilibrate('TP', solver='gibbs')
-        self.assertNear(self.gas['CH4'].X[0], 0.0)
+        assertNear(self.gas['CH4'].X[0], 0.0)
 
     def test_vcs(self):
         self.gas.equilibrate('TP', solver='vcs')
-        self.assertNear(self.gas['CH4'].X[0], 0.0)
+        assertNear(self.gas['CH4'].X[0], 0.0)
 
 
-class VCS_EquilTest(EquilTestCases, utilities.CanteraTest):
-    def __init__(self, *args, **kwargs):
-        EquilTestCases.__init__(self, 'vcs')
-        unittest.TestCase.__init__(self, *args, **kwargs)
+class TestVCS_EquilTest(EquilTestCases):
+    """
+    Tests using the 'vcs' solver.
+    """
+
+    solver = 'vcs'
 
 
-class TestKOH_Equil(utilities.CanteraTest):
-    "Test roughly based on examples/multiphase/plasma_equilibrium.py"
-    def setUp(self):
-        self.phases = ct.import_phases("KOH.yaml",
-                ['K_solid', 'K_liquid', 'KOH_a', 'KOH_b', 'KOH_liquid',
-                 'K2O2_solid', 'K2O_solid', 'KO2_solid', 'ice', 'liquid_water',
-                 'KOH_plasma'])
-        self.mix = ct.Mixture(self.phases)
+@pytest.fixture(scope='function')
+def koh_equil(request):
+    phases = ct.import_phases("KOH.yaml",
+            ['K_solid', 'K_liquid', 'KOH_a', 'KOH_b', 'KOH_liquid',
+             'K2O2_solid', 'K2O_solid', 'KO2_solid', 'ice', 'liquid_water',
+             'KOH_plasma'])
+    request.cls.mix = ct.Mixture(phases)
+
+@pytest.mark.usefixtures('koh_equil')
+class TestKOH_Equil:
+    """
+    Test roughly based on examples/multiphase/plasma_equilibrium.py
+    """
 
     def test_equil_TP(self):
         temperatures = range(350, 5000, 300)
@@ -161,7 +186,7 @@ class TestKOH_Equil(utilities.CanteraTest):
         # VCS solver extrapolating thermo polynomials outside of their valid range. See
         # https://github.com/Cantera/cantera/issues/270. The results show ice at
         # temperatures of over 1000 K, and liquid water for temperatures of 2000-5000 K.
-        self.compare(data, self.test_data_path / "koh-equil-TP.csv")
+        compare(data, self.test_data_path / "koh-equil-TP.csv")
 
     @utilities.slow_test
     def test_equil_HP(self):
@@ -185,17 +210,20 @@ class TestKOH_Equil(utilities.CanteraTest):
             data[i,1] = self.mix.T # equilibrated temperature
             data[i,2:] = self.mix.species_moles
 
-        self.compare(data, self.test_data_path / "koh-equil-HP.csv")
+        compare(data, self.test_data_path / "koh-equil-HP.csv")
 
 
-class TestEquil_GasCarbon(utilities.CanteraTest):
-    "Test rougly based on examples/multiphase/adiabatic.py"
-    def setUp(self):
-        self.gas = ct.Solution('gri30.yaml', transport_model=None)
-        self.carbon = ct.Solution("graphite.yaml")
-        self.fuel = 'CH4'
-        self.mix_phases = [(self.gas, 1.0), (self.carbon, 0.0)]
-        self.n_species = self.gas.n_species + self.carbon.n_species
+@pytest.fixture(scope='function')
+def carbon_equil(request):
+    request.cls.gas = ct.Solution('gri30.yaml', transport_model=None)
+    request.cls.carbon = ct.Solution("graphite.yaml")
+    request.cls.fuel = 'CH4'
+    request.cls.mix_phases = [(request.cls.gas, 1.0), (request.cls.carbon, 0.0)]
+    request.cls.n_species = request.cls.gas.n_species + request.cls.carbon.n_species
+
+@pytest.mark.usefixtures('carbon_equil')
+class TestEquil_GasCarbon:
+    "Test roughly based on examples/multiphase/adiabatic.py"
 
     def solve(self, solver, **kwargs):
         n_points = 12
@@ -215,7 +243,7 @@ class TestEquil_GasCarbon(utilities.CanteraTest):
             data[i,:2] = (phi[i], mix.T)
             data[i,2:] = mix.species_moles
 
-        self.compare(data, self.test_data_path / "gas-carbon-equil.csv")
+        compare(data, self.test_data_path / "gas-carbon-equil.csv")
 
     @utilities.slow_test
     def test_gibbs(self):
@@ -229,11 +257,11 @@ class TestEquil_GasCarbon(utilities.CanteraTest):
         self.solve('vcs', estimate_equil=-1)
 
 
-class Test_IdealSolidSolnPhase_Equil(utilities.CanteraTest):
+class Test_IdealSolidSolnPhase_Equil:
     def test_equil(self):
         gas = ct.ThermoPhase("IdealSolidSolnPhaseExample.yaml")
         gas.TPX = 500, ct.one_atm, 'C2H2-graph: 1.0'
 
         gas.equilibrate('TP', solver='element_potential')
-        self.assertNear(gas['C-graph'].X[0], 2.0 / 3.0)
-        self.assertNear(gas['H2-solute'].X[0], 1.0 / 3.0)
+        assertNear(gas['C-graph'].X[0], 2.0 / 3.0)
+        assertNear(gas['H2-solute'].X[0], 1.0 / 3.0)

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -4,8 +4,7 @@ from pytest import approx
 
 import cantera as ct
 from .utilities import (
-    assertNear,
-    compare,
+    compare
 )
 
 class EquilTestCases:
@@ -130,20 +129,20 @@ class TestEquilExtraElements:
     def test_auto(self):
         # Succeeds after falling back to VCS
         self.gas.equilibrate('TP')
-        assertNear(self.gas['CH4'].X[0], 0.0)
+        assert self.gas['CH4'].X[0] == approx(0.0)
 
     @pytest.mark.xfail
     def test_element_potential(self):
         self.gas.equilibrate('TP', solver='element_potential')
-        assertNear(self.gas['CH4'].X[0], 0.0)
+        assert self.gas['CH4'].X[0] == approx(0.0)
 
     def test_gibbs(self):
         self.gas.equilibrate('TP', solver='gibbs')
-        assertNear(self.gas['CH4'].X[0], 0.0)
+        assert self.gas['CH4'].X[0] == approx(0.0)
 
     def test_vcs(self):
         self.gas.equilibrate('TP', solver='vcs')
-        assertNear(self.gas['CH4'].X[0], 0.0)
+        assert self.gas['CH4'].X[0] == approx(0.0)
 
 
 class TestVCS_EquilTest(EquilTestCases):
@@ -262,5 +261,5 @@ class Test_IdealSolidSolnPhase_Equil:
         gas.TPX = 500, ct.one_atm, 'C2H2-graph: 1.0'
 
         gas.equilibrate('TP', solver='element_potential')
-        assertNear(gas['C-graph'].X[0], 2.0 / 3.0)
-        assertNear(gas['H2-solute'].X[0], 1.0 / 3.0)
+        assert gas['C-graph'].X[0] == approx(2.0 / 3.0)
+        assert gas['H2-solute'].X[0] == approx(1.0 / 3.0)

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -3,7 +3,6 @@ import pytest
 from pytest import approx
 
 import cantera as ct
-from . import utilities
 from .utilities import (
     assertNear,
     compare,
@@ -188,7 +187,7 @@ class TestKOH_Equil:
         # temperatures of over 1000 K, and liquid water for temperatures of 2000-5000 K.
         compare(data, self.test_data_path / "koh-equil-TP.csv")
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_equil_HP(self):
         temperatures = range(350, 5000, 300)
         data = np.zeros((len(temperatures), self.mix.n_species+2))
@@ -245,11 +244,11 @@ class TestEquil_GasCarbon:
 
         compare(data, self.test_data_path / "gas-carbon-equil.csv")
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_gibbs(self):
         self.solve('gibbs')
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_vcs(self):
         self.solve('vcs')
 

--- a/test/python/test_equilibrium.py
+++ b/test/python/test_equilibrium.py
@@ -167,7 +167,7 @@ class TestKOH_Equil:
     Test roughly based on examples/multiphase/plasma_equilibrium.py
     """
 
-    def test_equil_TP(self):
+    def test_equil_TP(self, test_data_path):
         temperatures = range(350, 5000, 300)
         data = np.zeros((len(temperatures), self.mix.n_species+1))
         data[:,0] = temperatures
@@ -184,10 +184,10 @@ class TestKOH_Equil:
         # VCS solver extrapolating thermo polynomials outside of their valid range. See
         # https://github.com/Cantera/cantera/issues/270. The results show ice at
         # temperatures of over 1000 K, and liquid water for temperatures of 2000-5000 K.
-        compare(data, self.test_data_path / "koh-equil-TP.csv")
+        compare(data, test_data_path / "koh-equil-TP.csv")
 
     @pytest.mark.slow_test
-    def test_equil_HP(self):
+    def test_equil_HP(self, test_data_path):
         temperatures = range(350, 5000, 300)
         data = np.zeros((len(temperatures), self.mix.n_species+2))
         data[:,0] = temperatures
@@ -208,7 +208,7 @@ class TestKOH_Equil:
             data[i,1] = self.mix.T # equilibrated temperature
             data[i,2:] = self.mix.species_moles
 
-        compare(data, self.test_data_path / "koh-equil-HP.csv")
+        compare(data, test_data_path / "koh-equil-HP.csv")
 
 
 @pytest.fixture(scope='function')
@@ -222,6 +222,10 @@ def carbon_equil(request):
 @pytest.mark.usefixtures('carbon_equil')
 class TestEquil_GasCarbon:
     "Test roughly based on examples/multiphase/adiabatic.py"
+
+    @pytest.fixture(autouse=True)
+    def inject_fixtures(self, test_data_path):
+        self.test_data_path = test_data_path
 
     def solve(self, solver, **kwargs):
         n_points = 12

--- a/test/python/test_func1.py
+++ b/test/python/test_func1.py
@@ -42,7 +42,7 @@ class TestFunc1(utilities.CanteraTest):
         for t in [0.1, 0.7, 4.5]:
             self.assertNear(f(t), 5)
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             ct.Func1([3,4])
 
     def test_numpy(self):
@@ -54,7 +54,7 @@ class TestFunc1(utilities.CanteraTest):
             self.assertNear(f(t), 5)
             self.assertNear(g(t), 5)
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             ct.Func1(np.array([3,4]))
 
     def test_failure(self):
@@ -62,19 +62,19 @@ class TestFunc1(utilities.CanteraTest):
             raise ValueError('bad')
 
         f = ct.Func1(fails)
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             f(0.1)
 
     def test_unpicklable(self):
         import pickle
         f = ct.Func1(np.sin)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             pickle.dumps(f)
 
     def test_uncopyable(self):
         import copy
         f = ct.Func1(np.sin)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             copy.copy(f)
 
     def test_simple(self):

--- a/test/python/test_func1.py
+++ b/test/python/test_func1.py
@@ -4,7 +4,6 @@ import pytest
 
 import cantera as ct
 
-from . import utilities
 from .utilities import (
     assertNear,
     assertArrayNear

--- a/test/python/test_func1.py
+++ b/test/python/test_func1.py
@@ -1,26 +1,26 @@
 import math
 import numpy as np
 import pytest
+from pytest import approx
 
 import cantera as ct
 
 from .utilities import (
-    assertNear,
     assertArrayNear
 )
 
 class TestFunc1:
     def test_function(self):
         f = ct.Func1(np.sin)
-        assertNear(f(0), np.sin(0))
-        assertNear(f(0.1), np.sin(0.1))
-        assertNear(f(0.7), np.sin(0.7))
+        assert f(0) == approx(np.sin(0))
+        assert f(0.1) == approx(np.sin(0.1))
+        assert f(0.7) == approx(np.sin(0.7))
 
     def test_lambda(self):
         f = ct.Func1(lambda t: np.sin(t)*np.sqrt(t))
         assert f.type == "functor"
         for t in [0.1, 0.7, 4.5]:
-            assertNear(f(t), np.sin(t)*np.sqrt(t))
+            assert f(t) == approx(np.sin(t)*np.sqrt(t))
 
     def test_callable(self):
         class Multiplier:
@@ -33,18 +33,18 @@ class TestFunc1:
         f = ct.Func1(m)
         assert f.type == "functor"
         for t in [0.1, 0.7, 4.5]:
-            assertNear(f(t), 8.1*t)
+            assert f(t) == approx(8.1*t)
 
     def test_constant(self):
         f = ct.Func1(5)
         for t in [0.1, 0.7, 4.5]:
-            assertNear(f(t), 5)
+            assert f(t) == approx(5)
         assert f.type == "constant"
 
     def test_sequence(self):
         f = ct.Func1([5])
         for t in [0.1, 0.7, 4.5]:
-            assertNear(f(t), 5)
+            assert f(t) == approx(5)
 
         with pytest.raises(TypeError):
             ct.Func1([3,4])
@@ -55,8 +55,8 @@ class TestFunc1:
         g = ct.Func1(np.array([[5]]))
         assert g.type == "constant"
         for t in [0.1, 0.7, 4.5]:
-            assertNear(f(t), 5)
-            assertNear(g(t), 5)
+            assert f(t) == approx(5)
+            assert g(t) == approx(5)
 
         with pytest.raises(TypeError):
             ct.Func1(np.array([3,4]))
@@ -97,7 +97,7 @@ class TestFunc1:
             assert func.type == name
             for val in [.1, 1., 10.]:
                 assert name in func.write()
-                assert func(val) == pytest.approx(fcn(coeff * val))
+                assert func(val) == approx(fcn(coeff * val))
 
     def test_deprecated(self):
         with pytest.warns(DeprecationWarning, match="use alternative constructor"):
@@ -117,14 +117,14 @@ class TestFunc1:
             assert func.type == name
             for val in [.1, 1., 10.]:
                 assert name not in func.write()
-                assert func(val) == pytest.approx(fcn(f1(val), f2(val)))
+                assert func(val) == approx(fcn(f1(val), f2(val)))
         f0 = 3.1415
         fcn = lambda x, y: x + y
         func1 = ct.Func1('sum', f0, f1)
         func2 = ct.Func1('sum', f2, f0)
         for val in [.1, 1., 10.]:
-            assert func1(val) == pytest.approx(fcn(f0, f1(val)))
-            assert func2(val) == pytest.approx(fcn(f2(val), f0))
+            assert func1(val) == approx(fcn(f0, f1(val)))
+            assert func2(val) == approx(fcn(f2(val), f0))
         with pytest.raises(ValueError):
             ct.Func1('sum', f0, f0)
         with pytest.raises(ValueError):
@@ -201,7 +201,7 @@ class TestFunc1:
             assert func.type == name
             for val in [.1, 1., 10.]:
                 assert name not in func.write()
-                assert func(val) == pytest.approx(fcn(f1(val), constant))
+                assert func(val) == approx(fcn(f1(val), constant))
 
     def test_tabulated1(self):
         # this implicitly probes advanced functors
@@ -213,8 +213,8 @@ class TestFunc1:
         assert fcn0.type == "tabulated-linear"
         assert fcn1.type == "tabulated-linear"
         for t, f in zip(time, fval):
-            assert fcn0(t) == pytest.approx(f)
-            assert fcn1(t) == pytest.approx(f)
+            assert fcn0(t) == approx(f)
+            assert fcn1(t) == approx(f)
 
     def test_tabulated2(self):
         time = [0, 1, 2]
@@ -222,14 +222,14 @@ class TestFunc1:
         fcn = ct.Tabulated1(time, fval)
         assert fcn.type == "tabulated-linear"
         for t, f in zip(time, fval):
-            assertNear(f, fcn(t))
+            assert f == approx(fcn(t))
 
     def test_tabulated3(self):
         time = 0, 1, 2,
         fval = 2, 1, 0,
         fcn = ct.Tabulated1(time, fval)
-        assertNear(fcn(-1), fval[0])
-        assertNear(fcn(3), fval[-1])
+        assert fcn(-1) == approx(fval[0])
+        assert fcn(3) == approx(fval[-1])
 
     def test_tabulated4(self):
         time = np.array([0, 1, 2])
@@ -238,7 +238,7 @@ class TestFunc1:
         tt = .5*(time[1:] + time[:-1])
         ff = .5*(fval[1:] + fval[:-1])
         for t, f in zip(tt, ff):
-            assertNear(f, fcn(t))
+            assert f == approx(fcn(t))
 
     def test_tabulated5(self):
         time = [0, 1, 2]

--- a/test/python/test_func1.py
+++ b/test/python/test_func1.py
@@ -5,9 +5,6 @@ from pytest import approx
 
 import cantera as ct
 
-from .utilities import (
-    assertArrayNear
-)
 
 class TestFunc1:
     def test_function(self):
@@ -246,7 +243,7 @@ class TestFunc1:
         fcn = ct.Tabulated1(time, fval, method='previous')
         assert fcn.type == "tabulated-previous"
         val = np.array([fcn(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]])
-        assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
+        assert val == approx(np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
 
     def test_tabulated_failures(self):
         with pytest.raises(ct.CanteraError, match="even number of entries"):

--- a/test/python/test_func1.py
+++ b/test/python/test_func1.py
@@ -1,22 +1,27 @@
-import numpy as np
-
-import cantera as ct
-from . import utilities
 import math
+import numpy as np
 import pytest
 
-class TestFunc1(utilities.CanteraTest):
+import cantera as ct
+
+from . import utilities
+from .utilities import (
+    assertNear,
+    assertArrayNear
+)
+
+class TestFunc1:
     def test_function(self):
         f = ct.Func1(np.sin)
-        self.assertNear(f(0), np.sin(0))
-        self.assertNear(f(0.1), np.sin(0.1))
-        self.assertNear(f(0.7), np.sin(0.7))
+        assertNear(f(0), np.sin(0))
+        assertNear(f(0.1), np.sin(0.1))
+        assertNear(f(0.7), np.sin(0.7))
 
     def test_lambda(self):
         f = ct.Func1(lambda t: np.sin(t)*np.sqrt(t))
         assert f.type == "functor"
         for t in [0.1, 0.7, 4.5]:
-            self.assertNear(f(t), np.sin(t)*np.sqrt(t))
+            assertNear(f(t), np.sin(t)*np.sqrt(t))
 
     def test_callable(self):
         class Multiplier:
@@ -29,18 +34,18 @@ class TestFunc1(utilities.CanteraTest):
         f = ct.Func1(m)
         assert f.type == "functor"
         for t in [0.1, 0.7, 4.5]:
-            self.assertNear(f(t), 8.1*t)
+            assertNear(f(t), 8.1*t)
 
     def test_constant(self):
         f = ct.Func1(5)
         for t in [0.1, 0.7, 4.5]:
-            self.assertNear(f(t), 5)
+            assertNear(f(t), 5)
         assert f.type == "constant"
 
     def test_sequence(self):
         f = ct.Func1([5])
         for t in [0.1, 0.7, 4.5]:
-            self.assertNear(f(t), 5)
+            assertNear(f(t), 5)
 
         with pytest.raises(TypeError):
             ct.Func1([3,4])
@@ -51,8 +56,8 @@ class TestFunc1(utilities.CanteraTest):
         g = ct.Func1(np.array([[5]]))
         assert g.type == "constant"
         for t in [0.1, 0.7, 4.5]:
-            self.assertNear(f(t), 5)
-            self.assertNear(g(t), 5)
+            assertNear(f(t), 5)
+            assertNear(g(t), 5)
 
         with pytest.raises(TypeError):
             ct.Func1(np.array([3,4]))
@@ -218,14 +223,14 @@ class TestFunc1(utilities.CanteraTest):
         fcn = ct.Tabulated1(time, fval)
         assert fcn.type == "tabulated-linear"
         for t, f in zip(time, fval):
-            self.assertNear(f, fcn(t))
+            assertNear(f, fcn(t))
 
     def test_tabulated3(self):
         time = 0, 1, 2,
         fval = 2, 1, 0,
         fcn = ct.Tabulated1(time, fval)
-        self.assertNear(fcn(-1), fval[0])
-        self.assertNear(fcn(3), fval[-1])
+        assertNear(fcn(-1), fval[0])
+        assertNear(fcn(3), fval[-1])
 
     def test_tabulated4(self):
         time = np.array([0, 1, 2])
@@ -234,7 +239,7 @@ class TestFunc1(utilities.CanteraTest):
         tt = .5*(time[1:] + time[:-1])
         ff = .5*(fval[1:] + fval[:-1])
         for t, f in zip(tt, ff):
-            self.assertNear(f, fcn(t))
+            assertNear(f, fcn(t))
 
     def test_tabulated5(self):
         time = [0, 1, 2]
@@ -242,7 +247,7 @@ class TestFunc1(utilities.CanteraTest):
         fcn = ct.Tabulated1(time, fval, method='previous')
         assert fcn.type == "tabulated-previous"
         val = np.array([fcn(v) for v in [-0.5, 0, 0.5, 1.5, 2, 2.5]])
-        self.assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
+        assertArrayNear(val, np.array([2.0, 2.0, 2.0, 1.0, 0.0, 0.0]))
 
     def test_tabulated_failures(self):
         with pytest.raises(ct.CanteraError, match="even number of entries"):

--- a/test/python/test_jacobian.py
+++ b/test/python/test_jacobian.py
@@ -1,9 +1,9 @@
 import numpy as np
 import pytest
+from pytest import approx
 
 import cantera as ct
 from .utilities import (
-    assertNear,
     assertArrayNear
 )
 
@@ -109,7 +109,7 @@ class RateExpressionTests:
                 order = self.r_stoich[spc_ix, self.rxn_idx]
             else:
                 order = self.orders[self.gas.species_names[spc_ix]]
-            assertNear(rop[self.rxn_idx],
+            assert rop[self.rxn_idx] == approx(
                 drop[self.rxn_idx, spc_ix] * self.gas.X[spc_ix] / order)
 
             drop_num = self.rop_derivs(spc_ix, mode="forward")
@@ -135,7 +135,7 @@ class RateExpressionTests:
         rop = self.gas.reverse_rates_of_progress
         for spc_ix in self.pix:
             order = self.p_stoich[spc_ix, self.rxn_idx]
-            assertNear(rop[self.rxn_idx],
+            assert rop[self.rxn_idx] == approx(
                 drop[self.rxn_idx, spc_ix] * self.gas.X[spc_ix] / order)
 
             drop_num = self.rop_derivs(spc_ix, mode="reverse")
@@ -185,7 +185,7 @@ class RateExpressionTests:
                 order = self.r_stoich[spc_ix, self.rxn_idx]
             else:
                 order = self.orders[self.gas.species_names[spc_ix]]
-            assertNear(rop[self.rxn_idx],
+            assert rop[self.rxn_idx] == approx(
                 drop[self.rxn_idx, spc_ix] * self.gas.concentrations[spc_ix] / order)
 
             drop_num = self.rop_derivs(spc_ix, mode="forward", ddX=False)
@@ -211,7 +211,7 @@ class RateExpressionTests:
         rop = self.gas.reverse_rates_of_progress
         for spc_ix in self.pix:
             order = self.p_stoich[spc_ix, self.rxn_idx]
-            assertNear(rop[self.rxn_idx],
+            assert rop[self.rxn_idx] == approx(
                 drop[self.rxn_idx, spc_ix] * self.gas.concentrations[spc_ix] / order)
 
             drop_num = self.rop_derivs(spc_ix, mode="reverse", ddX=False)
@@ -267,14 +267,14 @@ class RateExpressionTests:
         drop = self.gas.forward_rates_of_progress_ddT
         drop += self.gas.forward_rates_of_progress_ddC * dcdt
         drop_num = self.rop_ddT(mode="forward", const_p=True)
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
         # constant density (volume) - need to account for pressure change
         dpdt = self.gas.P / self.gas.T
         drop = self.gas.forward_rates_of_progress_ddT
         drop += self.gas.forward_rates_of_progress_ddP * dpdt
         drop_num = self.rop_ddT(mode="forward")
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
         if isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -292,14 +292,14 @@ class RateExpressionTests:
         drop = self.gas.reverse_rates_of_progress_ddT
         drop += self.gas.reverse_rates_of_progress_ddC * dcdt
         drop_num = self.rop_ddT(mode="reverse", const_p=True)
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
         # constant density (volume) - need to account for pressure change
         dpdt = self.gas.P / self.gas.T
         drop = self.gas.reverse_rates_of_progress_ddT
         drop += self.gas.reverse_rates_of_progress_ddP * dpdt
         drop_num = self.rop_ddT(mode="reverse")
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
         if not self.rxn.reversible or isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -317,14 +317,14 @@ class RateExpressionTests:
         drop = self.gas.net_rates_of_progress_ddT
         drop += self.gas.net_rates_of_progress_ddC * dcdt
         drop_num = self.rop_ddT(mode="net", const_p=True)
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
         # constant density (volume) - need to account for pressure change
         dpdt = self.gas.P / self.gas.T
         drop = self.gas.net_rates_of_progress_ddT
         drop += self.gas.net_rates_of_progress_ddP * dpdt
         drop_num = self.rop_ddT(mode="forward") - self.rop_ddT(mode="reverse")
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
         if not self.rxn.reversible or isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -359,7 +359,7 @@ class RateExpressionTests:
         drop = self.gas.forward_rates_of_progress_ddP
         drop += self.gas.forward_rates_of_progress_ddC * dcdp
         drop_num = self.rop_ddP(mode="forward")
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
     def test_reverse_rop_ddP(self):
         # check derivatives of reverse rop with respect to pressure
@@ -369,7 +369,7 @@ class RateExpressionTests:
         drop = self.gas.reverse_rates_of_progress_ddP
         drop += self.gas.reverse_rates_of_progress_ddC * dcdp
         drop_num = self.rop_ddP(mode="reverse")
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
     def test_net_rop_ddP(self):
         # check derivatives of net rop with respect to pressure
@@ -379,7 +379,7 @@ class RateExpressionTests:
         drop = self.gas.net_rates_of_progress_ddP
         drop += self.gas.net_rates_of_progress_ddC * dcdp
         drop_num = self.rop_ddP(mode="net")
-        assertNear(drop[self.rxn_idx], drop_num, self.rtol)
+        assert drop[self.rxn_idx] == approx(drop_num, rel=self.rtol)
 
     def rate_ddT(self, mode=None, const_p=False, rtol=1e-6):
         # numerical derivative for production rates with respect to temperature
@@ -411,7 +411,7 @@ class RateExpressionTests:
         drate += self.gas.net_production_rates_ddC * dcdt
         drate_num = self.rate_ddT(mode="net", const_p=True)
         for spc_ix in self.rix + self.pix:
-            assert drate[spc_ix] == pytest.approx(drate_num[spc_ix], self.rtol)
+            assert drate[spc_ix] == approx(drate_num[spc_ix], rel=self.rtol)
 
         # constant density (volume) - need to account for pressure change
         # numeric: d(omegadot)/dT =
@@ -421,7 +421,7 @@ class RateExpressionTests:
         drate += self.gas.net_production_rates_ddP * dpdt
         drate_num = self.rate_ddT(mode="creation") - self.rate_ddT(mode="destruction")
         for spc_ix in self.rix + self.pix:
-            assert drate[spc_ix] == pytest.approx(drate_num[spc_ix], self.rtol)
+            assert drate[spc_ix] == approx(drate_num[spc_ix], rel=self.rtol)
 
     def rate_ddX(self, spc_ix, mode=None, const_t=True, rtol_deltac=1e-6,
                  atol_deltac=1e-20, ddX=True):
@@ -566,7 +566,7 @@ class TestThreeBody(HydrogenOxygen):
         drops = self.gas.forward_rates_of_progress_ddX
         dropm = drop - drops
         rop = self.gas.forward_rates_of_progress
-        assertNear(rop[self.rxn_idx], (dropm[self.rxn_idx] * self.gas.X).sum())
+        assert rop[self.rxn_idx] == approx((dropm[self.rxn_idx] * self.gas.X).sum())
 
     def test_thirdbodies_reverse(self):
         drop = self.gas.reverse_rates_of_progress_ddX
@@ -574,7 +574,7 @@ class TestThreeBody(HydrogenOxygen):
         drops = self.gas.reverse_rates_of_progress_ddX
         dropm = drop - drops
         rop = self.gas.reverse_rates_of_progress
-        assertNear(rop[self.rxn_idx], (dropm[self.rxn_idx] * self.gas.X).sum())
+        assert rop[self.rxn_idx] == approx((dropm[self.rxn_idx] * self.gas.X).sum())
 
 @pytest.mark.usefixtures("setup_rate_expression_data")
 class EdgeCases(RateExpressionTests):
@@ -985,7 +985,7 @@ class SurfaceRateExpressionTests:
                 order = self.r_stoich[spc_ix, self.rxn_idx]
             else:
                 order = self.orders[specs[spc_ix]]
-            assertNear(rop[self.rxn_idx],
+            assert rop[self.rxn_idx] == approx(
                 drop[self.rxn_idx, spc_ix] * concentrations[spc_ix] / order)
 
     def test_reverse_rop_ddCi(self):
@@ -1000,7 +1000,7 @@ class SurfaceRateExpressionTests:
                 order = self.p_stoich[spc_ix, self.rxn_idx]
             else:
                 order = self.orders[specs[spc_ix]]
-            assertNear(rop[self.rxn_idx],
+            assert rop[self.rxn_idx] == approx(
                        drop[self.rxn_idx, spc_ix] * concentrations[spc_ix] / order)
 
     def test_net_rop_ddCi(self):

--- a/test/python/test_jacobian.py
+++ b/test/python/test_jacobian.py
@@ -3,9 +3,6 @@ import pytest
 from pytest import approx
 
 import cantera as ct
-from .utilities import (
-    assertArrayNear
-)
 
 
 @pytest.fixture(scope='class')
@@ -113,7 +110,7 @@ class RateExpressionTests:
                 drop[self.rxn_idx, spc_ix] * self.gas.X[spc_ix] / order)
 
             drop_num = self.rop_derivs(spc_ix, mode="forward")
-            assertArrayNear(dropm[:, spc_ix] + dropp * self.gas.P, drop_num, self.rtol)
+            assert dropm[:, spc_ix] + dropp * self.gas.P == approx(drop_num, rel=self.rtol)
 
         if isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -139,7 +136,7 @@ class RateExpressionTests:
                 drop[self.rxn_idx, spc_ix] * self.gas.X[spc_ix] / order)
 
             drop_num = self.rop_derivs(spc_ix, mode="reverse")
-            assertArrayNear(dropm[:, spc_ix] + dropp * self.gas.P, drop_num, self.rtol)
+            assert dropm[:, spc_ix] + dropp * self.gas.P == approx(drop_num, rel=self.rtol)
 
         if not self.rxn.reversible or isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -160,7 +157,7 @@ class RateExpressionTests:
             drop_num = self.rop_derivs(spc_ix, mode="net")
             ix = drop[:, spc_ix] != 0
             drop_ = drop[:, spc_ix] + dropp * self.gas.P
-            assertArrayNear(drop_[ix], drop_num[ix], self.rtol)
+            assert drop_[ix] == approx(drop_num[ix], rel=self.rtol)
 
         if not self.rxn.reversible or isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -189,7 +186,7 @@ class RateExpressionTests:
                 drop[self.rxn_idx, spc_ix] * self.gas.concentrations[spc_ix] / order)
 
             drop_num = self.rop_derivs(spc_ix, mode="forward", ddX=False)
-            assertArrayNear(dropm[:, spc_ix] + dropp * self.gas.P, drop_num, 1e-3)
+            assert dropm[:, spc_ix] + dropp * self.gas.P == approx(drop_num, rel=1e-3)
 
         if isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -215,7 +212,7 @@ class RateExpressionTests:
                 drop[self.rxn_idx, spc_ix] * self.gas.concentrations[spc_ix] / order)
 
             drop_num = self.rop_derivs(spc_ix, mode="reverse", ddX=False)
-            assertArrayNear(dropm[:, spc_ix] + dropp * self.gas.P, drop_num, 1e-3)
+            assert dropm[:, spc_ix] + dropp * self.gas.P == approx(drop_num, rel=1e-3)
 
         if not self.rxn.reversible or isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -236,7 +233,7 @@ class RateExpressionTests:
             drop_num = self.rop_derivs(spc_ix, mode="net", ddX=False)
             ix = drop[:, spc_ix] != 0
             drop_ = drop[:, spc_ix] + dropp * self.gas.P
-            assertArrayNear(drop_[ix], drop_num[ix], 1e-4)
+            assert drop_[ix] == approx(drop_num[ix], rel=1e-4)
 
         if not self.rxn.reversible or isinstance(self.rxn.rate, ct.FalloffRate):
             return
@@ -469,7 +466,7 @@ class RateExpressionTests:
             drate_num = self.rate_ddX(spc_ix, "creation")
             ix = drate[:, spc_ix] != 0
             drate[:, spc_ix] += dratep * self.gas.P
-            assertArrayNear(drate[ix, spc_ix], drate_num[ix], self.rtol)
+            assert drate[ix, spc_ix] == approx(drate_num[ix], rel=self.rtol)
 
     def test_destruction_ddX(self):
         # check derivatives of destruction rates with respect to mole fractions
@@ -479,7 +476,7 @@ class RateExpressionTests:
             drate_num = self.rate_ddX(spc_ix, "destruction")
             ix = drate[:, spc_ix] != 0
             drate[:, spc_ix] += dratep * self.gas.P
-            assertArrayNear(drate[ix, spc_ix], drate_num[ix], self.rtol)
+            assert drate[ix, spc_ix] == approx(drate_num[ix], rel=self.rtol)
 
     def test_net_production_ddX(self):
         # check derivatives of destruction rates with respect to mole fractions
@@ -489,7 +486,7 @@ class RateExpressionTests:
             drate_num = self.rate_ddX(spc_ix, "net")
             ix = drate[:, spc_ix] != 0
             drate[:, spc_ix] += dratep * self.gas.P
-            assertArrayNear(drate[ix, spc_ix], drate_num[ix], self.rtol)
+            assert drate[ix, spc_ix] == approx(drate_num[ix], rel=self.rtol)
 
     def test_creation_ddCi(self):
         # check derivatives of creation rates with respect to mole fractions
@@ -499,7 +496,7 @@ class RateExpressionTests:
             drate_num = self.rate_ddX(spc_ix, "creation", ddX=False)
             ix = drate[:, spc_ix] != 0
             drate[:, spc_ix] += dratep * self.gas.P
-            assertArrayNear(drate[ix, spc_ix], drate_num[ix], 1e-3)
+            assert drate[ix, spc_ix] == approx(drate_num[ix], rel=1e-3)
 
     def test_destruction_ddCi(self):
         # check derivatives of destruction rates with respect to mole fractions
@@ -509,7 +506,7 @@ class RateExpressionTests:
             drate_num = self.rate_ddX(spc_ix, "destruction", ddX=False)
             ix = drate[:, spc_ix] != 0
             drate[:, spc_ix] += dratep * self.gas.P
-            assertArrayNear(drate[ix, spc_ix], drate_num[ix], 1e-3)
+            assert drate[ix, spc_ix] == approx(drate_num[ix], rel=1e-3)
 
     def test_net_production_ddCi(self):
         # check derivatives of destruction rates with respect to mole fractions
@@ -519,7 +516,7 @@ class RateExpressionTests:
             drate_num = self.rate_ddX(spc_ix, "net", ddX=False)
             ix = drate[:, spc_ix] != 0
             # drate[:, spc_ix] += dratep * self.gas.P
-            assertArrayNear(drate[ix, spc_ix], drate_num[ix], 1e-3)
+            assert drate[ix, spc_ix] == approx(drate_num[ix], rel=1e-3)
 
 
 @pytest.mark.usefixtures("setup_rate_expression_data")
@@ -743,7 +740,7 @@ class FullTests:
                 # test entries that are not spurious
                 ix = np.abs((stoich[:, i] != 0) * drop[i, :]) > 1e-6
                 drop_ = drop[i, ix] + dropp[i] * self.gas.P
-                assertArrayNear(drop_, drop_num[i, ix], self.rtol)
+                assert drop_ == approx(drop_num[i, ix], rel=self.rtol)
             except AssertionError as err:
                 print(i, self.gas.reaction(i).rate.type)
                 print(self.gas.reaction(i))
@@ -761,7 +758,7 @@ class FullTests:
                 # test entries that are not spurious
                 ix = np.abs((stoich[:, i] != 0) * drop[i, :]) > 1e-6
                 drop_ = drop[i, ix] + dropp[i] * self.gas.P
-                assertArrayNear(drop_, drop_num[i, ix], self.rtol)
+                assert drop_ == approx(drop_num[i, ix], rel=self.rtol)
             except AssertionError as err:
                 print(i, self.gas.reaction(i).rate.type)
                 print(self.gas.reaction(i))
@@ -779,7 +776,7 @@ class FullTests:
                 # test entries that are not spurious
                 ix = np.abs((stoich[:, i] != 0) * drop[i, :]) > 1e-6
                 drop_ = drop[i, ix] + dropp[i] * self.gas.P
-                assertArrayNear(drop_, drop_num[i, ix], self.rtol)
+                assert drop_ == approx(drop_num[i, ix], rel=self.rtol)
             except AssertionError as err:
                 if self.gas.reaction(i).reversible:
                     print(i, self.gas.reaction(i).rate.type)
@@ -799,7 +796,7 @@ class FullTests:
                 # test entries that are not spurious
                 ix = np.abs((stoich[:, i] != 0) * drop[i, :]) > 1e-6
                 drop_ = drop[i, ix] + dropp[i] * self.gas.P
-                assertArrayNear(drop_, drop_num[i, ix], self.rtol)
+                assert drop_ == approx(drop_num[i, ix], rel=self.rtol)
             except AssertionError as err:
                 print(i, self.gas.reaction(i).rate.type)
                 print(self.gas.reaction(i))
@@ -818,7 +815,7 @@ class FullTests:
                 # test entries that are not spurious
                 ix = np.abs((stoich[:, i] != 0) * drop[i, :]) > 1e-6
                 drop_ = drop[i, ix] + dropp[i] * self.gas.P
-                assertArrayNear(drop_, drop_num[i, ix], self.rtol)
+                assert drop_ == approx(drop_num[i, ix], rel=self.rtol)
             except AssertionError as err:
                 print(i, self.gas.reaction(i).rate.type)
                 print(self.gas.reaction(i))
@@ -837,7 +834,7 @@ class FullTests:
                 # test entries that are not spurious
                 ix = np.abs((stoich[:, i] != 0) * drop[i, :]) > 1e-6
                 drop_ = drop[i, ix] + dropp[i] * self.gas.P
-                assertArrayNear(drop_, drop_num[i, ix], self.rtol)
+                assert drop_ == approx(drop_num[i, ix], rel=self.rtol)
             except AssertionError as err:
                 if self.gas.reaction(i).reversible:
                     print(i, self.gas.reaction(i).rate.type)
@@ -868,7 +865,7 @@ class FullTests:
         drop = self.gas.forward_rates_of_progress_ddT
         drop += self.gas.forward_rates_of_progress_ddC * dcdt
         drop_num = self.rop_ddT(mode="forward")
-        assertArrayNear(drop, drop_num, self.rtol)
+        assert drop == approx(drop_num, rel=self.rtol)
 
     def test_reverse_rop_ddT(self):
         # check reverse rop against numerical derivative with respect to temperature
@@ -876,7 +873,7 @@ class FullTests:
         drop = self.gas.reverse_rates_of_progress_ddT
         drop += self.gas.reverse_rates_of_progress_ddC * dcdt
         drop_num = self.rop_ddT(mode="reverse")
-        assertArrayNear(drop, drop_num, self.rtol)
+        assert drop == approx(drop_num, rel=self.rtol)
 
     def test_net_rop_ddT(self):
         # check net rop against numerical derivative with respect to temperature
@@ -885,7 +882,7 @@ class FullTests:
         drop += self.gas.net_rates_of_progress_ddC * dcdt
         drop_num = self.rop_ddT(mode="net")
         try:
-            assertArrayNear(drop, drop_num, self.rtol)
+            assert drop == approx(drop_num, rel=self.rtol)
         except AssertionError as err:
             i = np.argmax(2 * (drop - drop_num) / (drop + drop_num + 2e-4))
             print(i, self.gas.reaction(i).rate.type)
@@ -1014,7 +1011,7 @@ class SurfaceRateExpressionTests:
         for spc_ix in self.rix + self.pix:
             ix = np.abs(drop[:, spc_ix]) > 1
             drop_ = drop[:, spc_ix]
-            assertArrayNear(drop_[ix], rop[ix], 1e-3)
+            assert drop_[ix] == approx(rop[ix], rel=1e-3)
 
 @pytest.mark.usefixtures("surface_rate_expression_data")
 class PlatinumHydrogen(SurfaceRateExpressionTests):
@@ -1121,7 +1118,7 @@ class SurfaceFullTests:
         # rates of progress do not factor in reaction order it must be accounted for
         drop /= total_orders
         # compare the rate of progress vectors produced in different ways
-        assertArrayNear(drop, rop, self.rtol)
+        assert drop == approx(rop, rel=self.rtol)
 
     def test_reverse_rop_ddCi(self):
         # matrix multiplication of the reverse rate of progress derivatives  w.r.t
@@ -1147,7 +1144,7 @@ class SurfaceFullTests:
         # rates of progress do not factor in reaction order it must be accounted for
         drop /= total_orders
         # compare the rate of progress vectors produced in different ways
-        assertArrayNear(drop, rop, self.rtol)
+        assert drop == approx(rop, rel=self.rtol)
 
     def test_net_rop_ddCi(self):
         # check derivatives of net rates of progress with respect to species
@@ -1173,7 +1170,7 @@ class SurfaceFullTests:
                 curr_order += orders[k] if k in orders else v
             ropr[i] *= curr_order
         # compare the rate of progress vectors produced in different ways
-        assertArrayNear(drop, ropf - ropr, self.rtol)
+        assert drop == approx(ropf - ropr, rel=self.rtol)
 
 @pytest.mark.usefixtures("setup_surface_full_data")
 class TestFullPlatinumHydrogen(SurfaceFullTests):

--- a/test/python/test_jacobian.py
+++ b/test/python/test_jacobian.py
@@ -19,7 +19,7 @@ class RateExpressionTests:
     rate_type = None
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.tpx = cls.gas.TPX
 
         cls.r_stoich = cls.gas.reactant_stoich_coeffs
@@ -512,12 +512,12 @@ class RateExpressionTests:
 class HydrogenOxygen(RateExpressionTests):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.gas = ct.Solution("h2o2.yaml", transport_model=None)
         #   species: [H2, H, O, O2, OH, H2O, HO2, H2O2, AR, N2]
         cls.gas.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 0.3, 0.1]
         cls.gas.TP = 800, 2 * ct.one_atm
-        super().setUpClass()
+        super().setup_class()
 
 
 class TestElementaryRev(HydrogenOxygen, utilities.CanteraTest):
@@ -549,8 +549,8 @@ class TestThreeBody(HydrogenOxygen, utilities.CanteraTest):
     rate_type = "Arrhenius"
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setup_class(cls):
+        super().setup_class()
         cls.ix3b = list(range(cls.gas.n_species))
 
     def test_thirdbodies_forward(self):
@@ -573,12 +573,12 @@ class TestThreeBody(HydrogenOxygen, utilities.CanteraTest):
 class EdgeCases(RateExpressionTests):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.gas = ct.Solution("jacobian-tests.yaml", transport_model=None)
         #   species: [H2, H, O, O2, OH, H2O, HO2, H2O2, AR]
         cls.gas.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 0.4]
         cls.gas.TP = 800, 2 * ct.one_atm
-        super().setUpClass()
+        super().setup_class()
 
 
 class TestElementaryIrr(EdgeCases, utilities.CanteraTest):
@@ -617,8 +617,8 @@ class TestThreeBodyNoDefault(EdgeCases, utilities.CanteraTest):
     rate_type = "Arrhenius"
 
     @classmethod
-    def setUpClass(cls):
-        super().setUpClass()
+    def setup_class(cls):
+        super().setup_class()
         efficiencies = {"H2": 2.0, "H2O": 6.0, "AR": 0.7}
         cls.ix3b = [cls.gas.species_index(k) for k in efficiencies.keys()]
 
@@ -626,12 +626,12 @@ class TestThreeBodyNoDefault(EdgeCases, utilities.CanteraTest):
 class FromScratchCases(RateExpressionTests):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.gas = ct.Solution("kineticsfromscratch.yaml", transport_model=None)
         #   species: [AR, O, H2, H, OH, O2, H2O, H2O2, HO2]
         cls.gas.X = [0.1, 3e-4, 5e-5, 6e-6, 3e-3, 0.6, 0.25, 1e-6, 2e-5]
         cls.gas.TP = 2000, 5 * ct.one_atm
-        super().setUpClass()
+        super().setup_class()
 
     @pytest.mark.usefixtures("has_temperature_derivative_warnings")
     def test_forward_rop_ddT(self):
@@ -696,7 +696,7 @@ class FullTests:
     rtol = 1e-4
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.tpx = cls.gas.TPX
 
     def setUp(self):
@@ -901,32 +901,32 @@ class FullTests:
 class FullHydrogenOxygen(FullTests, utilities.CanteraTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.gas = ct.Solution("h2o2.yaml", transport_model=None)
         cls.gas.TPX = 300, 5 * ct.one_atm, "H2:1, O2:3"
         cls.gas.equilibrate("HP")
-        super().setUpClass()
+        super().setup_class()
 
 
 class FullGriMech(FullTests, utilities.CanteraTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.gas = ct.Solution("gri30.yaml", transport_model=None)
         cls.gas.TPX = 300, 5 * ct.one_atm, "CH4:1, C3H8:.1, O2:1, N2:3.76"
         cls.gas.equilibrate("HP")
-        super().setUpClass()
+        super().setup_class()
 
 
 class FullEdgeCases(FullTests, utilities.CanteraTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.gas = ct.Solution("jacobian-tests.yaml", transport_model=None)
         #   species: [H2, H, O, O2, OH, H2O, HO2, H2O2, AR]
         cls.gas.TPX = 300, 2 * ct.one_atm, "H2:1, O2:3, AR:0.4"
         cls.gas.equilibrate("HP")
-        super().setUpClass()
+        super().setup_class()
 
 
 class SurfaceRateExpressionTests:
@@ -942,7 +942,7 @@ class SurfaceRateExpressionTests:
     rate_type = None
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         # all species indices
         all_species = cls.surf.species() + cls.gas.species()
         cls.sidxs  = {spec.name:i for i, spec in enumerate(all_species)}
@@ -1025,7 +1025,7 @@ class SurfaceRateExpressionTests:
 class PlatinumHydrogen(SurfaceRateExpressionTests):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         phase_defs = """
             units: {length: cm, quantity: mol, activation-energy: J/mol}
             phases:
@@ -1052,7 +1052,7 @@ class PlatinumHydrogen(SurfaceRateExpressionTests):
         cls.surf.TPX = 800, 2*ct.one_atm , "PT(S):4.0, H(S):0.5, H2O(S):0.1, OH(S):0.2, O(S):0.8"
         cls.gas_tpx = cls.gas.TPX
         cls.surf_tpx = cls.surf.TPX
-        super().setUpClass()
+        super().setup_class()
 
 class SurfInterfaceArrhenius(PlatinumHydrogen, utilities.CanteraTest):
     rxn_idx = 7
@@ -1080,7 +1080,7 @@ class SurfaceFullTests:
     rtol = 1e-4
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         # all species indices
         all_species = cls.surf.species() + cls.gas.species()
         cls.sidxs  = {spec.name:i for i, spec in enumerate(all_species)}
@@ -1178,7 +1178,7 @@ class SurfaceFullTests:
 class FullPlatinumHydrogen(SurfaceFullTests, utilities.CanteraTest):
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         phase_defs = """
             units: {length: cm, quantity: mol, activation-energy: J/mol}
             phases:
@@ -1205,4 +1205,4 @@ class FullPlatinumHydrogen(SurfaceFullTests, utilities.CanteraTest):
         cls.surf.TPX = 800, 2*ct.one_atm , "PT(S):1.0, H(S):0.5, H2O(S):0.1, OH(S):0.2, O(S):0.8"
         cls.gas_tpx = cls.gas.TPX
         cls.surf_tpx = cls.surf.TPX
-        super().setUpClass()
+        super().setup_class()

--- a/test/python/test_jacobian.py
+++ b/test/python/test_jacobian.py
@@ -626,7 +626,7 @@ class TestElementarySelf(HydrogenOxygen):
 
 class TestFalloff(HydrogenOxygen):
     """ Fall-off reaction"""
-    rtol = 1e-4
+    rtol = 2e-4
 
     @pytest.fixture(scope='class')
     def rxn_idx(self):

--- a/test/python/test_jacobian.py
+++ b/test/python/test_jacobian.py
@@ -2,8 +2,6 @@ import numpy as np
 import pytest
 
 import cantera as ct
-from . import utilities
-from .utilities import has_temperature_derivative_warnings
 from .utilities import (
     assertNear,
     assertArrayNear

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -7,8 +7,6 @@ import re
 
 import cantera as ct
 
-from . import utilities
-from .utilities import allow_deprecated
 from .utilities import (
     assertNear,
     assertArrayNear,

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -8,7 +8,6 @@ import re
 import cantera as ct
 
 from .utilities import (
-    assertNear,
     assertArrayNear,
     compare
 )
@@ -51,14 +50,14 @@ class TestKinetics:
         fwd_rates1 = self.phase.forward_rates_of_progress
         rev_rates1 = self.phase.reverse_rates_of_progress
 
-        assertNear(2 * fwd_rates0[0], fwd_rates1[0])
-        assertNear(0.1 * fwd_rates0[6], fwd_rates1[6])
-        assertNear(2 * rev_rates0[0], rev_rates1[0])
-        assertNear(0.1 * rev_rates0[6], rev_rates1[6])
+        assert 2 * fwd_rates0[0] == approx(fwd_rates1[0])
+        assert 0.1 * fwd_rates0[6] == approx(fwd_rates1[6])
+        assert 2 * rev_rates0[0] == approx(rev_rates1[0])
+        assert 0.1 * rev_rates0[6] == approx(rev_rates1[6])
         for i in range(self.phase.n_reactions):
             if i not in (0, 6):
-                assertNear(fwd_rates0[i], fwd_rates1[i])
-                assertNear(rev_rates0[i], rev_rates1[i])
+                assert fwd_rates0[i] == approx(fwd_rates1[i])
+                assert rev_rates0[i] == approx(rev_rates1[i])
 
         self.phase.set_multiplier(0.5)
         fwd_rates2 = self.phase.forward_rates_of_progress
@@ -162,8 +161,8 @@ class TestKinetics:
 
     def test_heat_release(self):
         hrr = - self.phase.partial_molar_enthalpies.dot(self.phase.net_production_rates)
-        assertNear(hrr, self.phase.heat_release_rate)
-        assertNear(hrr, sum(self.phase.heat_production_rates))
+        assert hrr == approx(self.phase.heat_release_rate)
+        assert hrr == approx(sum(self.phase.heat_production_rates))
 
     def test_rate_constants(self):
         assert len(self.phase.forward_rate_constants) == self.phase.n_reactions
@@ -244,7 +243,7 @@ class TestKineticsFromReactions:
             assert r1.products == r2.products
             assert r1.rate.pre_exponential_factor == r2.rate.pre_exponential_factor
             assert r1.rate.temperature_exponent == r2.rate.temperature_exponent
-            assertNear(r1.rate.activation_energy, r2.rate.activation_energy)
+            assert r1.rate.activation_energy == approx(r2.rate.activation_energy)
 
         assertArrayNear(surf1.delta_enthalpy, surf2.delta_enthalpy)
         assertArrayNear(surf1.forward_rate_constants, surf2.forward_rate_constants)
@@ -255,7 +254,7 @@ class TestKineticsFromReactions:
         for k in gas.species_names + surf1.species_names:
             k1 = surf1.kinetics_species_index(k)
             k2 = surf2.kinetics_species_index(k)
-            assertNear(rop1[k1], rop2[k2])
+            assert rop1[k1] == approx(rop2[k2])
 
     def test_add_reaction(self):
         gas1 = ct.Solution('h2o2.yaml', transport_model=None)
@@ -473,10 +472,10 @@ class TestKineticsRepeatability:
         for i, R in enumerate(gas.reactions()):
             if ('OH' in R.reactants or 'OH' in R.products) and R.reversible:
                 # Rate should be different if reaction involves OH
-                assert not pytest.approx(w2[i] / w1[i], rel=1e-5) == 1
+                assert not approx(w2[i] / w1[i], rel=1e-5) == 1
             else:
                 # Rate should be the same if reaction does not involve OH
-                assert pytest.approx(w2[i] / w1[i], rel=1e-5) == 1
+                assert approx(w2[i] / w1[i], rel=1e-5) == 1
 
     def test_pdep_err(self):
         err_msg = ("InputFileError thrown by PlogRate::validate:",
@@ -814,7 +813,7 @@ class TestReactionPath:
             fluxes = sorted(fluxes.values())
 
             for i in range(1, 20):
-                assertNear(dot_fluxes[-i], fluxes[-i], 1e-2)
+                assert dot_fluxes[-i] == approx(fluxes[-i], rel=1e-2)
 
     def test_dot_oneway_autoscaled(self):
         for element in ['N', 'C', 'H', 'O']:
@@ -833,7 +832,7 @@ class TestReactionPath:
             fluxes = sorted(fluxes.values())
 
             for i in range(1, 20):
-                assertNear(dot_fluxes[-i], fluxes[-i], 1e-2)
+                assert dot_fluxes[-i] == approx(fluxes[-i], rel=1e-2)
 
     def test_fluxes(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
@@ -843,14 +842,14 @@ class TestReactionPath:
         ropr = gas.reverse_rates_of_progress
         fluxes, _ = self.get_fluxes(diagram)
 
-        assertNear(fluxes['HO2','H'], ropr[5] + ropr[9], 1e-5)
-        assertNear(fluxes['H', 'H2'], 2*ropf[11] + ropf[16], 1e-5)
-        assertNear(fluxes['H', 'H2O'], ropf[15], 1e-5)
-        assertNear(fluxes['H', 'OH'], ropf[17], 1e-5)
-        assertNear(fluxes['HO2','H2'], ropf[16], 1e-5)
-        assertNear(fluxes['HO2', 'H2O'], ropf[15], 1e-5)
-        assertNear(fluxes['HO2', 'OH'], ropf[17], 1e-5)
-        assertNear(fluxes['HO2', 'H2O2'], 2*ropf[26] + 2*ropf[27], 1e-5)
+        assert fluxes['HO2','H'] == approx(ropr[5] + ropr[9], rel=1e-5)
+        assert fluxes['H', 'H2'] == approx(2*ropf[11] + ropf[16], rel=1e-5)
+        assert fluxes['H', 'H2O'] == approx(ropf[15], rel=1e-5)
+        assert fluxes['H', 'OH'] == approx(ropf[17], rel=1e-5)
+        assert fluxes['HO2','H2'] == approx(ropf[16], rel=1e-5)
+        assert fluxes['HO2', 'H2O'] == approx(ropf[15], rel=1e-5)
+        assert fluxes['HO2', 'OH'] == approx(ropf[17], rel=1e-5)
+        assert fluxes['HO2', 'H2O2'] == approx(2*ropf[26] + 2*ropf[27], rel=1e-5)
 
 
 class TestChemicallyActivated:
@@ -863,7 +862,7 @@ class TestChemicallyActivated:
 
         for i in range(len(P)):
             gas.TPX = 900.0, P[i], [0.01, 0.01, 0.04, 0.10, 0.84]
-            assertNear(gas.forward_rates_of_progress[0], Rf[i], 2e-5)
+            assert gas.forward_rates_of_progress[0] == approx(Rf[i], rel=2e-5)
 
 @pytest.fixture(scope='function')
 def setup_explicit_forward_order_tests(request):
@@ -884,9 +883,9 @@ class TestExplicitForwardOrder:
         C = self.gas.concentrations
         Rf = self.gas.forward_rates_of_progress
         kf = self.gas.forward_rate_constants
-        assertNear(Rf[0], kf[0] * C[2]**1.5 * C[3]**0.5)
-        assertNear(Rf[1], kf[1] * C[0]**1.0 * C[4]**0.2)
-        assertNear(Rf[2], kf[2] * C[2]**3.0)
+        assert Rf[0] == approx(kf[0] * C[2]**1.5 * C[3]**0.5)
+        assert Rf[1] == approx(kf[1] * C[0]**1.0 * C[4]**0.2)
+        assert Rf[2] == approx(kf[2] * C[2]**3.0)
 
     def test_ratio1(self):
         rop1 = self.gas.forward_rates_of_progress
@@ -894,9 +893,9 @@ class TestExplicitForwardOrder:
         self.gas.TPX = None, None, [0.02, 0.87, 0.04, 0.03, 0.04]
         rop2 = self.gas.forward_rates_of_progress
         ratio = rop2/rop1
-        assertNear(ratio[0], 2**1.5) # order of R1A is 1.5
-        assertNear(ratio[1], 2**1.0) # order of H is 1.0
-        assertNear(ratio[2], 2**3) # order of R1A is 3
+        assert ratio[0] == approx(2**1.5) # order of R1A is 1.5
+        assert ratio[1] == approx(2**1.0) # order of H is 1.0
+        assert ratio[2] == approx(2**3) # order of R1A is 3
 
     def test_ratio2(self):
         rop1 = self.gas.forward_rates_of_progress
@@ -904,9 +903,9 @@ class TestExplicitForwardOrder:
         self.gas.TPX = None, None, [0.01, 0.83, 0.02, 0.06, 0.08]
         rop2 = self.gas.forward_rates_of_progress
         ratio = rop2/rop1
-        assertNear(ratio[0], 2**0.5) # order of R1B is 0.5
-        assertNear(ratio[1], 2**0.2) # order of P1 is 1.0
-        assertNear(ratio[2], 2**0.0) # order of R1B is 0
+        assert ratio[0] == approx(2**0.5) # order of R1B is 0.5
+        assert ratio[1] == approx(2**0.2) # order of P1 is 1.0
+        assert ratio[2] == approx(2**0.0) # order of R1B is 0
 
 
 class TestSofcKinetics:
@@ -1231,9 +1230,9 @@ class TestReaction:
         r = ct.Reaction({"O": 1, "H2": 1}, {"H": 1, "OH": 1},
                         ct.ArrheniusRate(3.87e1, 2.7, 2.6e7))
         data = r.input_data
-        assertNear(data['rate-constant']['A'], 3.87e1)
-        assertNear(data['rate-constant']['b'], 2.7)
-        assertNear(data['rate-constant']['Ea'], 2.6e7)
+        assert data['rate-constant']['A'] == approx(3.87e1)
+        assert data['rate-constant']['b'] == approx(2.7)
+        assert data['rate-constant']['Ea'] == approx(2.6e7)
         terms = data['equation'].split()
         assert 'O' in terms
         assert 'OH' in terms
@@ -1256,8 +1255,8 @@ class TestReaction:
         del rate1
 
         assert gas1.reaction(2).rate.type == 'custom-rate-function'
-        assert gas1.net_production_rates[2] == pytest.approx(
-            self.gas.net_production_rates[2], rel=1e-5)
+        assert gas1.net_production_rates[2] == approx(self.gas.net_production_rates[2],
+                                                      rel=1e-5)
 
     def test_modify_invalid(self):
         # different reaction type
@@ -1287,14 +1286,14 @@ class TestElementaryReaction:
                            species=self.species, reactions=[r])
         gas2.TPX = self.gas.TPX
 
-        assertNear(gas2.forward_rate_constants[0],
-                   self.gas.forward_rate_constants[2])
-        assertNear(gas2.net_rates_of_progress[0],
-                   self.gas.net_rates_of_progress[2])
+        assert gas2.forward_rate_constants[0] == approx(
+               self.gas.forward_rate_constants[2])
+        assert gas2.net_rates_of_progress[0] == approx(
+               self.gas.net_rates_of_progress[2])
 
     def test_arrhenius_rate(self):
         R = self.gas.reaction(2)
-        assertNear(R.rate(self.gas.T), self.gas.forward_rate_constants[2])
+        assert R.rate(self.gas.T) == approx(self.gas.forward_rate_constants[2])
 
     def test_negative_A(self):
         species = ct.Species.list_from_file("gri30.yaml")
@@ -1317,14 +1316,14 @@ class TestElementaryReaction:
         b1 = R.rate.temperature_exponent
         Ta1 = R.rate.activation_energy / ct.gas_constant
         T = gas.T
-        assertNear(A1*T**b1*np.exp(-Ta1/T), gas.forward_rate_constants[2])
+        assert A1*T**b1*np.exp(-Ta1/T) == approx(gas.forward_rate_constants[2])
 
         A2 = 1.5 * A1
         b2 = b1 + 0.1
         Ta2 = Ta1 * 1.2
         R.rate = ct.ArrheniusRate(A2, b2, Ta2 * ct.gas_constant)
         gas.modify_reaction(2, R)
-        assertNear(A2*T**b2*np.exp(-Ta2/T), gas.forward_rate_constants[2])
+        assert A2*T**b2*np.exp(-Ta2/T) == approx(gas.forward_rate_constants[2])
 
 @pytest.mark.usefixtures("setup_reaction_tests")
 class TestFalloffReaction:
@@ -1364,10 +1363,10 @@ class TestFalloffReaction:
                            species=self.species, reactions=[r])
         gas2.TPX = self.gas.TPX
 
-        assertNear(gas2.forward_rate_constants[0],
-                   self.gas.forward_rate_constants[21])
-        assertNear(gas2.net_rates_of_progress[0],
-                    self.gas.net_rates_of_progress[21])
+        assert gas2.forward_rate_constants[0] == approx(
+               self.gas.forward_rate_constants[21])
+        assert gas2.net_rates_of_progress[0] == approx(
+               self.gas.net_rates_of_progress[21])
 
     def test_modify_falloff(self):
         gas = ct.Solution('gri30.yaml', transport_model=None)
@@ -1383,7 +1382,7 @@ class TestFalloffReaction:
 
         gas.modify_reaction(53, r2)
         kf = gas.forward_rate_constants
-        assertNear(kf[49], kf[53])
+        assert kf[49] == approx(kf[53])
 
 @pytest.mark.usefixtures("setup_reaction_tests")
 class TestThreebodyReaction:
@@ -1396,10 +1395,10 @@ class TestThreebodyReaction:
                            species=self.species, reactions=[r])
         gas2.TPX = self.gas.TPX
 
-        assertNear(gas2.forward_rate_constants[0],
-                   self.gas.forward_rate_constants[1])
-        assertNear(gas2.net_rates_of_progress[0],
-                   self.gas.net_rates_of_progress[1])
+        assert gas2.forward_rate_constants[0] == approx(
+               self.gas.forward_rate_constants[1])
+        assert gas2.net_rates_of_progress[0] == approx(
+               self.gas.net_rates_of_progress[1])
 
     def test_modify_third_body(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
@@ -1415,7 +1414,7 @@ class TestThreebodyReaction:
         R.rate = ct.ArrheniusRate(A2, b2, 0.0)
         gas.modify_reaction(5, R)
         kf2 = gas.forward_rate_constants[5]
-        assertNear((A2*T**b2) / (A1*T**b1), kf2/kf1)
+        assert (A2*T**b2) / (A1*T**b1) == approx(kf2/kf1)
 
 @pytest.mark.usefixtures("setup_reaction_tests")
 class TestPlogReaction:
@@ -1439,17 +1438,17 @@ class TestPlogReaction:
 
         for P in [0.001, 0.01, 0.2, 1.0, 1.1, 9.0, 10.0, 99.0, 103.0]:
             gas1.TP = gas2.TP = 900, P * ct.one_atm
-            assertNear(gas2.forward_rate_constants[0],
-                       gas1.forward_rate_constants[0])
-            assertNear(gas2.net_rates_of_progress[0],
-                       gas1.net_rates_of_progress[0])
+            assert gas2.forward_rate_constants[0] == approx(
+                   gas1.forward_rate_constants[0])
+            assert gas2.net_rates_of_progress[0] == approx(
+                   gas1.net_rates_of_progress[0])
 
     def test_plog_rate(self):
         gas1 = ct.Solution('pdep-test.yaml')
         gas1.TP = 800, 2*ct.one_atm
         for i in range(4):
-            assertNear(gas1.reaction(i).rate(gas1.T, gas1.P),
-                       gas1.forward_rate_constants[i])
+            assert gas1.reaction(i).rate(gas1.T, gas1.P) == approx(
+                   gas1.forward_rate_constants[i])
 
     def test_plog_invalid_third_body(self):
         with pytest.raises(ct.CanteraError, match="Found superfluous"):
@@ -1464,12 +1463,12 @@ class TestPlogReaction:
         r0.rate = ct.PlogRate(r1.rate.rates)
         gas.modify_reaction(0, r0)
         kf = gas.forward_rate_constants
-        assertNear(kf[0], kf[1])
+        assert kf[0] == approx(kf[1])
 
         # Removing the high-pressure rates should have no effect at low P...
         r1.rate = ct.PlogRate(rates=r1.rate.rates[:-4])
         gas.modify_reaction(1, r1)
-        assertNear(kf[1], gas.forward_rate_constants[1])
+        assert kf[1] == approx(gas.forward_rate_constants[1])
 
         # ... but should change the rate at higher pressures
         gas.TP = 1010, 12.0 * ct.one_atm
@@ -1498,10 +1497,10 @@ class TestChebyshevReaction:
 
         for T,P in itertools.product([300, 500, 1500], [1e4, 4e5, 3e6]):
             gas1.TP = gas2.TP = T, P
-            assertNear(gas2.forward_rate_constants[0],
-                       gas1.forward_rate_constants[4])
-            assertNear(gas2.net_rates_of_progress[0],
-                       gas1.net_rates_of_progress[4])
+            assert gas2.forward_rate_constants[0] == approx(
+                   gas1.forward_rate_constants[4])
+            assert gas2.net_rates_of_progress[0] == approx(
+                   gas1.net_rates_of_progress[4])
 
     def test_chebyshev_single_P(self):
         species = ct.Species.list_from_file("pdep-test.yaml")
@@ -1523,7 +1522,7 @@ class TestChebyshevReaction:
             k1 = gas.forward_rate_constants[0]
             gas.TP = T, 1e6
             k2 = gas.forward_rate_constants[0]
-            assertNear(k1, k2)
+            assert k1 == approx(k2)
 
     def test_chebyshev_single_T(self):
         species = ct.Species.list_from_file("pdep-test.yaml")
@@ -1542,14 +1541,14 @@ class TestChebyshevReaction:
             k1 = gas.forward_rate_constants[0]
             gas.TP = 1700, P
             k2 = gas.forward_rate_constants[0]
-            assertNear(k1, k2)
+            assert k1 == approx(k2)
 
     def test_chebyshev_rate(self):
         gas1 = ct.Solution('pdep-test.yaml')
         gas1.TP = 800, 2*ct.one_atm
         for i in range(4,6):
-            assertNear(gas1.reaction(i).rate(gas1.T, gas1.P),
-                       gas1.forward_rate_constants[i])
+            assert gas1.reaction(i).rate(gas1.T, gas1.P) == approx(
+                   gas1.forward_rate_constants[i])
 
     def test_chebyshev_bad_shape_yaml(self):
         species = ct.Species.list_from_file("pdep-test.yaml")
@@ -1587,7 +1586,7 @@ class TestChebyshevReaction:
 
         gas.modify_reaction(4, r1)
         kf = gas.forward_rate_constants
-        assertNear(kf[4], kf[5])
+        assert kf[4] == approx(kf[5])
 
 @pytest.mark.usefixtures("setup_reaction_tests")
 class TestBlowersMaselReaction:
@@ -1607,10 +1606,10 @@ class TestBlowersMaselReaction:
         gas1.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
         gas2.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
 
-        assertNear(gas2.forward_rate_constants[0],
-                   gas1.forward_rate_constants[0], rtol=1e-7)
-        assertNear(gas2.net_rates_of_progress[0],
-                   gas1.net_rates_of_progress[0], rtol=1e-7)
+        assert gas2.forward_rate_constants[0] == approx(
+               gas1.forward_rate_constants[0], rel=1e-7)
+        assert gas2.net_rates_of_progress[0] == approx(
+               gas1.net_rates_of_progress[0], rel=1e-7)
 
     def test_negative_A_blowersmasel(self):
         species = ct.Solution("blowers-masel.yaml").species()
@@ -1642,8 +1641,8 @@ class TestBlowersMaselReaction:
         species = gas.species('OH')
 
         gas.reaction(0).rate.delta_enthalpy = deltaH
-        assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH)
-        assertNear(E, gas.reaction(0).rate.activation_energy)
+        assert gas.reaction(0).rate.delta_enthalpy == approx(deltaH)
+        assert E == approx(gas.reaction(0).rate.activation_energy)
 
         perturbed_coeffs = species.thermo.coeffs.copy()
         perturbed_coeffs[6] += deltaH_high / ct.gas_constant
@@ -1652,9 +1651,10 @@ class TestBlowersMaselReaction:
                             species.thermo.reference_pressure, perturbed_coeffs)
         gas.modify_species(index, species)
         gas.reaction(0).rate.delta_enthalpy = deltaH_high
-        assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH_high)
-        assertNear(deltaH_high, gas.reaction(0).rate.activation_energy)
-        assertNear(A*gas.T**b*np.exp(-deltaH_high/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
+        assert gas.reaction(0).rate.delta_enthalpy == approx(deltaH_high)
+        assert deltaH_high == approx(gas.reaction(0).rate.activation_energy)
+        assert A*gas.T**b*np.exp(-deltaH_high/ct.gas_constant/gas.T) == approx(
+               gas.forward_rate_constants[0])
 
         perturbed_coeffs = species.thermo.coeffs.copy()
         perturbed_coeffs[6] += deltaH_low / ct.gas_constant
@@ -1663,9 +1663,10 @@ class TestBlowersMaselReaction:
                             species.thermo.reference_pressure, perturbed_coeffs)
         gas.modify_species(index, species)
         gas.reaction(0).rate.delta_enthalpy = deltaH_low
-        assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH_low)
+        assert gas.reaction(0).rate.delta_enthalpy == approx(deltaH_low)
         assert gas.reaction(0).rate.activation_energy == 0
-        assertNear(A*gas.T**b*np.exp(0/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
+        assert A*gas.T**b*np.exp(0/ct.gas_constant/gas.T) == approx(
+               gas.forward_rate_constants[0])
 
     def test_modify_BlowersMasel(self):
         gas = ct.Solution("blowers-masel.yaml")
@@ -1678,7 +1679,7 @@ class TestBlowersMaselReaction:
         R.rate.delta_enthalpy = delta_enthalpy
         Ta1 = R.rate.activation_energy / ct.gas_constant
         T = gas.T
-        assertNear(A1 * T**b1 * np.exp(-Ta1 / T), gas.forward_rate_constants[0])
+        assert A1 * T**b1 * np.exp(-Ta1 / T) == approx(gas.forward_rate_constants[0])
 
         # randomly modify the rate parameters of a Blowers-Masel reaction
         A2 = 1.5 * A1
@@ -1690,7 +1691,7 @@ class TestBlowersMaselReaction:
         R.rate.delta_enthalpy = delta_enthalpy
         Ta2 = R.rate.activation_energy / ct.gas_constant
         gas.modify_reaction(0, R)
-        assertNear(A2 * T**b2 * np.exp(-Ta2 / T), gas.forward_rate_constants[0])
+        assert A2 * T**b2 * np.exp(-Ta2 / T) == approx(gas.forward_rate_constants[0])
 
 @pytest.mark.usefixtures("setup_reaction_tests")
 class TestInterfaceReaction:
@@ -1702,7 +1703,7 @@ class TestInterfaceReaction:
 
         rate = ct.InterfaceArrheniusRate(3.7e20, 0, 67.4e6)
         rate.coverage_dependencies = {'H(S)': (0, 0, -6e6)}
-        assertNear(rate.coverage_dependencies["H(S)"]["E"], -6e6)
+        assert rate.coverage_dependencies["H(S)"]["E"] == approx(-6e6)
         r1 = ct.Reaction(equation="2 H(S) <=> H2 + 2 PT(S)", rate=rate)
 
         surf2 = ct.Interface(thermo='ideal-surface', species=surf_species,
@@ -1714,10 +1715,10 @@ class TestInterfaceReaction:
 
         for T in [300, 500, 1500]:
             gas.TP = surf1.TP = surf2.TP = T, 5*ct.one_atm
-            assertNear(surf1.forward_rate_constants[1],
-                       surf2.forward_rate_constants[0])
-            assertNear(surf1.net_rates_of_progress[1],
-                       surf2.net_rates_of_progress[0])
+            assert surf1.forward_rate_constants[1] == approx(
+                   surf2.forward_rate_constants[0])
+            assert surf1.net_rates_of_progress[1] == approx(
+                   surf2.net_rates_of_progress[0])
 
     def test_BlowersMaselinterface(self):
         gas = ct.Solution("gri30.yaml", transport_model=None)
@@ -1725,7 +1726,7 @@ class TestInterfaceReaction:
         surf1 = ct.Interface("blowers-masel.yaml", "Pt_surf", [gas])
         rate = ct.InterfaceBlowersMaselRate(3.7e20, 0, 67.4e6, 1e9)
         rate.coverage_dependencies = {"H(S)": (0, 0, -6e6)}
-        assertNear(rate.coverage_dependencies["H(S)"]["E"], -6e6)
+        assert rate.coverage_dependencies["H(S)"]["E"] == approx(-6e6)
 
         r1 = ct.Reaction("H(S):2", "H2:1, PT(S):2", rate)
 
@@ -1741,10 +1742,10 @@ class TestInterfaceReaction:
 
         for T in [300, 500, 1500]:
             gas.TP = surf1.TP = surf2.TP = T, 5*ct.one_atm
-            assertNear(surf1.forward_rate_constants[0],
-                       surf2.forward_rate_constants[0])
-            assertNear(surf1.net_rates_of_progress[0],
-                       surf2.net_rates_of_progress[0])
+            assert surf1.forward_rate_constants[0] == approx(
+                   surf2.forward_rate_constants[0])
+            assert surf1.net_rates_of_progress[0] == approx(
+                   surf2.net_rates_of_progress[0])
 
     def test_modify_interface(self):
         surf = ct.Interface("ptcombust.yaml", "Pt_surf")
@@ -1762,7 +1763,7 @@ class TestInterfaceReaction:
         surf.coverages = 'O(S):0.2, PT(S):0.6, H(S):0.2'
         k3 = surf.forward_rate_constants[1]
         assert k1 != approx(k2)
-        assertNear(k2, k3)
+        assert k2 == approx(k3)
 
     def test_modify_BMinterface(self):
         gas = ct.Solution("gri30.yaml", transport_model=None)
@@ -1787,8 +1788,9 @@ class TestInterfaceReaction:
         surf.coverages = "O(S):0.2, PT(S):0.6, H(S):0.2"
         k3 = surf.forward_rate_constants[0]
 
-        assertNear(k1 / k2, np.exp(-O2_delta_theta_k * Ek / ct.gas_constant / surf.T))
-        assertNear(k2, k3)
+        assert k1 / k2 == approx(np.exp(-O2_delta_theta_k * Ek /
+                                        ct.gas_constant / surf.T))
+        assert k2 == approx(k3)
 
 
 @pytest.mark.usefixtures("setup_reaction_tests")
@@ -1813,7 +1815,7 @@ class TestStickingCoefficient:
         k1 = surf.forward_rate_constants[2]
         surf.modify_reaction(2, R)
         k2 = surf.forward_rate_constants[2]
-        assertNear(k1, 4*k2)
+        assert k1 == approx(4*k2)
 
     def test_motz_wise(self):
         # Motz & Wise off for all reactions
@@ -1828,14 +1830,14 @@ class TestStickingCoefficient:
         k2 = surf2.forward_rate_constants
 
         # M&W toggled on (globally) for reactions 2 and 7
-        assertNear(2.0 * k1[2], k2[2]) # sticking coefficient = 1.0
-        assertNear(1.6 * k1[7], k2[7]) # sticking coefficient = 0.75
+        assert 2.0 * k1[2] == approx(k2[2]) # sticking coefficient = 1.0
+        assert 1.6 * k1[7] == approx(k2[7]) # sticking coefficient = 0.75
 
         # M&W toggled off (locally) for reaction 4
-        assertNear(k1[4], k2[4])
+        assert k1[4] == approx(k2[4])
 
         # M&W toggled on (locally) for reaction 9
-        assertNear(2.0 * k1[9], k2[9]) # sticking coefficient = 1.0
+        assert 2.0 * k1[9] == approx(k2[9]) # sticking coefficient = 1.0
 
     def test_modify_BMsticking(self):
         gas = ct.Solution("gri30.yaml", transport_model=None)
@@ -1850,7 +1852,7 @@ class TestStickingCoefficient:
         k1 = surf.forward_rate_constants[1]
         surf.modify_reaction(1, R)
         k2 = surf.forward_rate_constants[1]
-        assertNear(k1, 4*k2)
+        assert k1 == approx(4*k2)
 
     def test_BMmotz_wise(self):
         # Motz & Wise off for all reactions
@@ -1865,14 +1867,14 @@ class TestStickingCoefficient:
         k2 = surf2.forward_rate_constants
 
         # M&W toggled on (globally) for reactions 1 and 2
-        assertNear(2.0 * k1[1], k2[1]) # sticking coefficient = 1.0
-        assertNear(1.6 * k1[2], k2[2]) # sticking coefficient = 0.75
+        assert 2.0 * k1[1] == approx(k2[1]) # sticking coefficient = 1.0
+        assert 1.6 * k1[2] == approx(k2[2]) # sticking coefficient = 0.75
 
         # M&W toggled off (locally) for reaction 3
-        assertNear(k1[3], k2[3])
+        assert k1[3] == approx(k2[3])
 
         # M&W toggled on (locally) for reaction 4
-        assertNear(k1[4], k2[4]) # sticking coefficient = 1.0
+        assert k1[4] == approx(k2[4]) # sticking coefficient = 1.0
 
 @pytest.mark.usefixtures("setup_reaction_tests")
 class TestElectrochemicalReaction:

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -912,7 +912,7 @@ class TestSofcKinetics:
     """ Test based on sofc.py """
     _mech = "sofc.yaml"
 
-    def test_sofc(self):
+    def test_sofc(self, test_data_path):
         mech = self._mech
         T = 1073.15  # T in K
         P = ct.one_atm
@@ -1010,14 +1010,14 @@ class TestSofcKinetics:
                              cathode_bulk.electric_potential -
                              anode_bulk.electric_potential])
 
-        compare(data, self.test_data_path / "sofc-test.csv", rtol=1e-7)
+        compare(data, test_data_path / "sofc-test.csv", rtol=1e-7)
 
 
 class TestLithiumIonBatteryKinetics:
     """ Test based on lithium_ion_battery.py """
     _mech = "lithium_ion_battery.yaml"
 
-    def test_lithium_ion_battery(self):
+    def test_lithium_ion_battery(self, test_data_path):
         mech = self._mech
         samples = 11
         soc = np.linspace(0., 1., samples)  # [-] Input state of charge (0...1)
@@ -1103,7 +1103,7 @@ class TestLithiumIonBatteryKinetics:
             data.append(phi_s_cathode - phi_s_anode)
 
         data = np.array(data).ravel()
-        ref = np.genfromtxt(self.test_data_path / "lithium-ion-battery-test.csv")
+        ref = np.genfromtxt(test_data_path / "lithium-ion-battery-test.csv")
         assert data == approx(ref, rel=1e-7)
 
     def test_interface_current(self):

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -8,7 +8,6 @@ import re
 import cantera as ct
 
 from .utilities import (
-    assertArrayNear,
     compare
 )
 
@@ -62,8 +61,8 @@ class TestKinetics:
         self.phase.set_multiplier(0.5)
         fwd_rates2 = self.phase.forward_rates_of_progress
         rev_rates2 = self.phase.reverse_rates_of_progress
-        assertArrayNear(0.5 * fwd_rates0, fwd_rates2)
-        assertArrayNear(0.5 * rev_rates0, rev_rates2)
+        assert 0.5 * fwd_rates0 == approx(fwd_rates2)
+        assert 0.5 * rev_rates0 == approx(rev_rates2)
 
     def test_legacy_reaction_rate(self):
         ct.use_legacy_rate_constants(True)
@@ -73,7 +72,7 @@ class TestKinetics:
         ix_3b = np.array([r.reaction_type == "three-body-Arrhenius" for r in self.phase.reactions()])
         ix_other = ix_3b == False
 
-        assertArrayNear(fwd_rates_legacy[ix_other], fwd_rates[ix_other])
+        assert fwd_rates_legacy[ix_other] == approx(fwd_rates[ix_other])
         assert not (fwd_rates_legacy[ix_3b] == fwd_rates[ix_3b]).any()
 
     def test_reaction_type(self):
@@ -156,8 +155,9 @@ class TestKinetics:
 
     def test_rates_of_progress(self):
         assert len(self.phase.net_rates_of_progress) == self.phase.n_reactions
-        assertArrayNear(self.phase.forward_rates_of_progress - self.phase.reverse_rates_of_progress,
-                        self.phase.net_rates_of_progress)
+        assert (self.phase.forward_rates_of_progress -
+                self.phase.reverse_rates_of_progress) == approx(
+               self.phase.net_rates_of_progress)
 
     def test_heat_release(self):
         hrr = - self.phase.partial_molar_enthalpies.dot(self.phase.net_production_rates)
@@ -167,9 +167,9 @@ class TestKinetics:
     def test_rate_constants(self):
         assert len(self.phase.forward_rate_constants) == self.phase.n_reactions
         ix = self.phase.reverse_rate_constants != 0.
-        assertArrayNear(
-            self.phase.forward_rate_constants[ix] / self.phase.reverse_rate_constants[ix],
-            self.phase.equilibrium_constants[ix])
+        assert (self.phase.forward_rate_constants[ix] /
+                self.phase.reverse_rate_constants[ix]) == approx(
+               self.phase.equilibrium_constants[ix])
 
     def test_species_rates(self):
         nu_p = self.phase.product_stoich_coeffs
@@ -179,18 +179,18 @@ class TestKinetics:
         destruction = (np.dot(nu_r, self.phase.forward_rates_of_progress) +
                        np.dot(nu_p, self.phase.reverse_rates_of_progress))
 
-        assertArrayNear(self.phase.creation_rates, creation)
-        assertArrayNear(self.phase.destruction_rates, destruction)
-        assertArrayNear(self.phase.net_production_rates,
-                             creation - destruction)
+        assert self.phase.creation_rates == approx(creation)
+        assert self.phase.destruction_rates == approx(destruction)
+        assert self.phase.net_production_rates == approx(creation - destruction)
 
     def test_reaction_deltas(self):
-        assertArrayNear(self.phase.delta_enthalpy -
-                             self.phase.delta_entropy * self.phase.T,
-                             self.phase.delta_gibbs)
-        assertArrayNear(self.phase.delta_standard_enthalpy -
-                        self.phase.delta_standard_entropy * self.phase.T,
-                        self.phase.delta_standard_gibbs)
+        assert (self.phase.delta_enthalpy -
+                self.phase.delta_entropy * self.phase.T) == approx(
+               self.phase.delta_gibbs)
+
+        assert (self.phase.delta_standard_enthalpy -
+                self.phase.delta_standard_entropy * self.phase.T) == approx(
+               self.phase.delta_standard_gibbs)
 
 
 class TestKineticsFromReactions:
@@ -213,9 +213,9 @@ class TestKineticsFromReactions:
         assert (gas1.reactant_stoich_coeffs == gas2.reactant_stoich_coeffs).all()
         assert (gas1.product_stoich_coeffs == gas2.product_stoich_coeffs).all()
 
-        assertArrayNear(gas1.delta_gibbs, gas2.delta_gibbs)
-        assertArrayNear(gas1.reverse_rate_constants, gas2.reverse_rate_constants)
-        assertArrayNear(gas1.net_production_rates, gas2.net_production_rates)
+        assert gas1.delta_gibbs == approx(gas2.delta_gibbs)
+        assert gas1.reverse_rate_constants == approx(gas2.reverse_rate_constants)
+        assert gas1.net_production_rates == approx(gas2.net_production_rates)
 
     def test_surface(self):
         surf1 = ct.Interface("ptcombust.yaml", "Pt_surf")
@@ -245,9 +245,9 @@ class TestKineticsFromReactions:
             assert r1.rate.temperature_exponent == r2.rate.temperature_exponent
             assert r1.rate.activation_energy == approx(r2.rate.activation_energy)
 
-        assertArrayNear(surf1.delta_enthalpy, surf2.delta_enthalpy)
-        assertArrayNear(surf1.forward_rate_constants, surf2.forward_rate_constants)
-        assertArrayNear(surf1.reverse_rate_constants, surf2.reverse_rate_constants)
+        assert surf1.delta_enthalpy == approx(surf2.delta_enthalpy)
+        assert surf1.forward_rate_constants == approx(surf2.forward_rate_constants)
+        assert surf1.reverse_rate_constants == approx(surf2.reverse_rate_constants)
 
         rop1 = surf1.net_production_rates
         rop2 = surf2.net_production_rates
@@ -275,9 +275,9 @@ class TestKineticsFromReactions:
         assert (gas1.reactant_stoich_coeffs == gas2.reactant_stoich_coeffs).all()
         assert (gas1.product_stoich_coeffs == gas2.product_stoich_coeffs).all()
 
-        assertArrayNear(gas1.delta_gibbs, gas2.delta_gibbs)
-        assertArrayNear(gas1.reverse_rate_constants, gas2.reverse_rate_constants)
-        assertArrayNear(gas1.net_production_rates, gas2.net_production_rates)
+        assert gas1.delta_gibbs == approx(gas2.delta_gibbs)
+        assert gas1.reverse_rate_constants == approx(gas2.reverse_rate_constants)
+        assert gas1.net_production_rates == approx(gas2.net_production_rates)
 
     def test_coverage_dependence_flags(self):
         surf = ct.Interface("ptcombust.yaml", "Pt_surf")
@@ -368,7 +368,7 @@ class TestKineticsRepeatability:
         gas.TDX = self.T0, self.rho0, self.X0
         w4 = gas.net_production_rates
 
-        assertArrayNear(w1, w4)
+        assert w1 == approx(w4)
 
     def check_rates_temperature1(self, mech):
         gas = self.setup_gas(mech)
@@ -386,7 +386,7 @@ class TestKineticsRepeatability:
         gas.TDX = self.T0, self.rho0, self.X0
         w4 = gas.net_production_rates
 
-        assertArrayNear(w1, w4)
+        assert w1 == approx(w4)
 
     def check_rates_temperature2(self, mech):
         gas = self.setup_gas(mech)
@@ -404,7 +404,7 @@ class TestKineticsRepeatability:
         gas.TPX = self.T0, self.P0, self.X0
         w4 = gas.net_production_rates
 
-        assertArrayNear(w1, w4)
+        assert w1 == approx(w4)
 
     def check_rates_pressure(self, mech):
         gas = self.setup_gas(mech)
@@ -422,7 +422,7 @@ class TestKineticsRepeatability:
         gas.TPX = self.T0, self.P0, self.X0
         w4 = gas.net_production_rates
 
-        assertArrayNear(w1, w4)
+        assert w1 == approx(w4)
 
     def test_gri30_composition(self):
         self.check_rates_composition("gri30.yaml")
@@ -722,9 +722,9 @@ class TestEmptyKinetics:
         gas = ct.Solution("air-no-reactions.yaml")
 
         assert gas.n_reactions == 0
-        assertArrayNear(gas.creation_rates, np.zeros(gas.n_species))
-        assertArrayNear(gas.destruction_rates, np.zeros(gas.n_species))
-        assertArrayNear(gas.net_production_rates, np.zeros(gas.n_species))
+        assert gas.creation_rates == approx(np.zeros(gas.n_species))
+        assert gas.destruction_rates == approx(np.zeros(gas.n_species))
+        assert gas.net_production_rates == approx(np.zeros(gas.n_species))
 
 
 @pytest.fixture(scope='class')
@@ -975,18 +975,21 @@ class TestSofcKinetics:
             s.advance_coverages(50.0)
 
         # These values are just a regression test with no theoretical basis
-        assertArrayNear(anode_surf.coverages,
-                        [6.18736878e-01, 3.81123655e-01, 8.6303646e-05,
-                        2.59274203e-06, 5.05700981e-05], 1e-7)
-        assertArrayNear(oxide_surf_a.coverages,
-                        [4.99435780e-02, 9.48927983e-01, 1.12840418e-03,
-                         3.35936530e-08], 1e-7)
-        assertArrayNear(cathode_surf.coverages,
-                        [1.48180380e-07, 7.57234727e-14, 9.99999827e-01,
-                         2.49235513e-08, 4.03296469e-13], 1e-7)
-        assertArrayNear(oxide_surf_c.coverages,
-                        [4.99896947e-02, 9.49804199e-01, 2.06104679e-04,
-                         1.11970271e-09], 1e-7)
+        assert anode_surf.coverages == approx(
+               [6.18736878e-01, 3.81123655e-01, 8.6303646e-05,
+               2.59274203e-06, 5.05700981e-05], rel=1e-7)
+
+        assert oxide_surf_a.coverages == approx(
+               [4.99435780e-02, 9.48927983e-01, 1.12840418e-03,
+               3.35936530e-08], rel=1e-7)
+
+        assert cathode_surf.coverages == approx(
+               [1.48180380e-07, 7.57234727e-14, 9.99999827e-01,
+               2.49235513e-08, 4.03296469e-13], rel=1e-7)
+
+        assert oxide_surf_c.coverages == approx(
+               [4.99896947e-02, 9.49804199e-01, 2.06104679e-04,
+               1.11970271e-09], rel=1e-7)
 
         Ea0 = newton_solve(anode_curr, xstart=-0.51)
         Ec0 = newton_solve(cathode_curr, xstart=0.51)
@@ -1101,7 +1104,7 @@ class TestLithiumIonBatteryKinetics:
 
         data = np.array(data).ravel()
         ref = np.genfromtxt(self.test_data_path / "lithium-ion-battery-test.csv")
-        assert np.allclose(data, ref, rtol=1e-7)
+        assert data == approx(ref, rel=1e-7)
 
     def test_interface_current(self):
         anode_int = ct.Interface("lithium_ion_battery.yaml", "edge_anode_electrolyte")

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -136,7 +136,7 @@ class TestKinetics(utilities.CanteraTest):
         check_product('O', 0, 0)
         check_product('O2', 0, 1)
 
-    @utilities.unittest.skipIf(isinstance(_scipy_sparse, ImportError), "scipy is not installed")
+    @pytest.mark.skipif(isinstance(_scipy_sparse, ImportError), reason="scipy is not installed")
     def test_stoich_coeffs_sparse(self):
         nu_r_dense = self.phase.reactant_stoich_coeffs
         nu_p_dense = self.phase.product_stoich_coeffs
@@ -750,8 +750,8 @@ class TestEmptyKinetics(utilities.CanteraTest):
 
 class TestReactionPath(utilities.CanteraTest):
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution('gri30.yaml', transport_model=None)
         cls.gas.TPX = 1300.0, ct.one_atm, 'CH4:0.4, O2:1, N2:3.76'
         r = ct.IdealGasReactor(cls.gas)
@@ -1193,8 +1193,8 @@ class TestDuplicateReactions(utilities.CanteraTest):
 
 class TestReaction(utilities.CanteraTest):
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
         cls.gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
         cls.gas.TP = 900, 2*ct.one_atm

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -1,13 +1,19 @@
-import numpy as np
-import re
-import itertools
 import importlib.metadata
+import itertools
+import numpy as np
 import pytest
 from pytest import approx
+import re
 
 import cantera as ct
+
 from . import utilities
 from .utilities import allow_deprecated
+from .utilities import (
+    assertNear,
+    assertArrayNear,
+    compare
+)
 
 # avoid explicit dependence of cantera on scipy
 try:
@@ -17,23 +23,25 @@ except importlib.metadata.PackageNotFoundError:
 else:
     from scipy import sparse as _scipy_sparse
 
+@pytest.fixture(scope='function')
+def setup_kinetics(request):
+    request.cls.phase = ct.Solution('h2o2.yaml', transport_model=None)
+    request.cls.phase.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 0.4, 0]
+    request.cls.phase.TP = 800, 2 * ct.one_atm
 
-class TestKinetics(utilities.CanteraTest):
-    def setUp(self):
-        self.phase = ct.Solution('h2o2.yaml', transport_model=None)
-        self.phase.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 0.4, 0]
-        self.phase.TP = 800, 2*ct.one_atm
+@pytest.mark.usefixtures("setup_kinetics")
+class TestKinetics:
 
     @pytest.mark.usefixtures("allow_deprecated")
     def test_counts(self):
-        self.assertEqual(self.phase.n_reactions, 29)
-        self.assertEqual(self.phase.n_total_species, 10)
-        self.assertEqual(self.phase.n_phases, 1)
-        self.assertEqual(self.phase.reaction_phase_index, 0)  # deprecated
+        assert self.phase.n_reactions == 29
+        assert self.phase.n_total_species == 10
+        assert self.phase.n_phases == 1
+        assert self.phase.reaction_phase_index == 0  # deprecated
 
     def test_is_reversible(self):
         for i in range(self.phase.n_reactions):
-            self.assertTrue(self.phase.reaction(i).reversible)
+            assert self.phase.reaction(i).reversible
 
     def test_multiplier(self):
         fwd_rates0 = self.phase.forward_rates_of_progress
@@ -45,20 +53,20 @@ class TestKinetics(utilities.CanteraTest):
         fwd_rates1 = self.phase.forward_rates_of_progress
         rev_rates1 = self.phase.reverse_rates_of_progress
 
-        self.assertNear(2 * fwd_rates0[0], fwd_rates1[0])
-        self.assertNear(0.1 * fwd_rates0[6], fwd_rates1[6])
-        self.assertNear(2 * rev_rates0[0], rev_rates1[0])
-        self.assertNear(0.1 * rev_rates0[6], rev_rates1[6])
+        assertNear(2 * fwd_rates0[0], fwd_rates1[0])
+        assertNear(0.1 * fwd_rates0[6], fwd_rates1[6])
+        assertNear(2 * rev_rates0[0], rev_rates1[0])
+        assertNear(0.1 * rev_rates0[6], rev_rates1[6])
         for i in range(self.phase.n_reactions):
-            if i not in (0,6):
-                self.assertNear(fwd_rates0[i], fwd_rates1[i])
-                self.assertNear(rev_rates0[i], rev_rates1[i])
+            if i not in (0, 6):
+                assertNear(fwd_rates0[i], fwd_rates1[i])
+                assertNear(rev_rates0[i], rev_rates1[i])
 
         self.phase.set_multiplier(0.5)
         fwd_rates2 = self.phase.forward_rates_of_progress
         rev_rates2 = self.phase.reverse_rates_of_progress
-        self.assertArrayNear(0.5 * fwd_rates0, fwd_rates2)
-        self.assertArrayNear(0.5 * rev_rates0, rev_rates2)
+        assertArrayNear(0.5 * fwd_rates0, fwd_rates2)
+        assertArrayNear(0.5 * rev_rates0, rev_rates2)
 
     def test_legacy_reaction_rate(self):
         ct.use_legacy_rate_constants(True)
@@ -68,40 +76,39 @@ class TestKinetics(utilities.CanteraTest):
         ix_3b = np.array([r.reaction_type == "three-body-Arrhenius" for r in self.phase.reactions()])
         ix_other = ix_3b == False
 
-        self.assertArrayNear(fwd_rates_legacy[ix_other], fwd_rates[ix_other])
-        self.assertFalse((fwd_rates_legacy[ix_3b] == fwd_rates[ix_3b]).any())
+        assertArrayNear(fwd_rates_legacy[ix_other], fwd_rates[ix_other])
+        assert not (fwd_rates_legacy[ix_3b] == fwd_rates[ix_3b]).any()
 
     def test_reaction_type(self):
-        self.assertIn(self.phase.reaction(0).reaction_type, "three-body-Arrhenius")
-        self.assertIn(self.phase.reaction(2).reaction_type, "Arrhenius")
-        self.assertIn(self.phase.reaction(2).rate.type, "Arrhenius")
-        self.assertEqual(self.phase.reaction(21).reaction_type, "falloff-Troe")
+        assert self.phase.reaction(0).reaction_type == "three-body-Arrhenius"
+        assert self.phase.reaction(2).reaction_type == "Arrhenius"
+        assert self.phase.reaction(2).rate.type == "Arrhenius"
+        assert self.phase.reaction(21).reaction_type == "falloff-Troe"
 
-        with self.assertRaisesRegex(ct.CanteraError, "outside valid range"):
+        with pytest.raises(ct.CanteraError, match="outside valid range"):
             self.phase.reaction(33).reaction_type
-        with self.assertRaisesRegex(ct.CanteraError, "outside valid range"):
+        with pytest.raises(ct.CanteraError, match="outside valid range"):
             self.phase.reaction(-2).reaction_type
 
     def test_reaction_equations(self):
-        self.assertEqual(self.phase.n_reactions,
-                         len(self.phase.reaction_equations()))
-        r,p = [x.split() for x in self.phase.reaction(18).equation.split('<=>')]
-        self.assertIn('H', r)
-        self.assertIn('H2O2', r)
-        self.assertIn('HO2', p)
-        self.assertIn('H2', p)
+        assert self.phase.n_reactions == len(self.phase.reaction_equations())
+        r, p = [x.split() for x in self.phase.reaction(18).equation.split('<=>')]
+        assert 'H' in r
+        assert 'H2O2' in r
+        assert 'HO2' in p
+        assert 'H2' in p
 
     def test_reactants_products(self):
         for i in range(self.phase.n_reactions):
             R = self.phase.reaction(i).reactant_string
             P = self.phase.reaction(i).product_string
-            self.assertTrue(self.phase.reaction(i).equation.startswith(R))
-            self.assertTrue(self.phase.reaction(i).equation.endswith(P))
+            assert self.phase.reaction(i).equation.startswith(R)
+            assert self.phase.reaction(i).equation.endswith(P)
             for k in range(self.phase.n_species):
-                if self.phase.reactant_stoich_coeff(k,i) != 0:
-                    self.assertIn(self.phase.species_name(k), R)
-                if self.phase.product_stoich_coeff(k,i) != 0:
-                    self.assertIn(self.phase.species_name(k), P)
+                if self.phase.reactant_stoich_coeff(k, i) != 0:
+                    assert self.phase.species_name(k) in R
+                if self.phase.product_stoich_coeff(k, i) != 0:
+                    assert self.phase.species_name(k) in P
 
     def test_stoich_coeffs(self):
         nu_r = self.phase.reactant_stoich_coeffs
@@ -109,15 +116,15 @@ class TestKinetics(utilities.CanteraTest):
 
         def check_reactant(s, i, value):
             k = self.phase.kinetics_species_index(s)
-            self.assertEqual(self.phase.reactant_stoich_coeff(s,i), value)
-            self.assertEqual(self.phase.reactant_stoich_coeff(k,i), value)
-            self.assertEqual(nu_r[k,i], value)
+            assert self.phase.reactant_stoich_coeff(s, i) == value
+            assert self.phase.reactant_stoich_coeff(k, i) == value
+            assert nu_r[k, i] == value
 
         def check_product(s, i, value):
             k = self.phase.kinetics_species_index(s)
-            self.assertEqual(self.phase.product_stoich_coeff(k,i), value)
-            self.assertEqual(self.phase.product_stoich_coeff(s,i), value)
-            self.assertEqual(nu_p[k,i], value)
+            assert self.phase.product_stoich_coeff(k, i) == value
+            assert self.phase.product_stoich_coeff(s, i) == value
+            assert nu_p[k, i] == value
 
         # H + H2O2 <=> HO2 + H2
         check_reactant('H', 18, 1)
@@ -145,26 +152,25 @@ class TestKinetics(utilities.CanteraTest):
         nu_r_sparse = self.phase.reactant_stoich_coeffs
         nu_p_sparse = self.phase.product_stoich_coeffs
 
-        self.assertTrue((nu_r_sparse.toarray() == nu_r_dense).all())
-        self.assertTrue((nu_p_sparse.toarray() == nu_p_dense).all())
+        assert (nu_r_sparse.toarray() == nu_r_dense).all()
+        assert (nu_p_sparse.toarray() == nu_p_dense).all()
 
         ct.use_sparse(False)
 
     def test_rates_of_progress(self):
-        self.assertEqual(len(self.phase.net_rates_of_progress),
-                         self.phase.n_reactions)
-        self.assertArrayNear(self.phase.forward_rates_of_progress - self.phase.reverse_rates_of_progress,
-                             self.phase.net_rates_of_progress)
+        assert len(self.phase.net_rates_of_progress) == self.phase.n_reactions
+        assertArrayNear(self.phase.forward_rates_of_progress - self.phase.reverse_rates_of_progress,
+                        self.phase.net_rates_of_progress)
 
     def test_heat_release(self):
         hrr = - self.phase.partial_molar_enthalpies.dot(self.phase.net_production_rates)
-        self.assertNear(hrr, self.phase.heat_release_rate)
-        self.assertNear(hrr, sum(self.phase.heat_production_rates))
+        assertNear(hrr, self.phase.heat_release_rate)
+        assertNear(hrr, sum(self.phase.heat_production_rates))
 
     def test_rate_constants(self):
-        self.assertEqual(len(self.phase.forward_rate_constants), self.phase.n_reactions)
+        assert len(self.phase.forward_rate_constants) == self.phase.n_reactions
         ix = self.phase.reverse_rate_constants != 0.
-        self.assertArrayNear(
+        assertArrayNear(
             self.phase.forward_rate_constants[ix] / self.phase.reverse_rate_constants[ix],
             self.phase.equilibrium_constants[ix])
 
@@ -176,21 +182,21 @@ class TestKinetics(utilities.CanteraTest):
         destruction = (np.dot(nu_r, self.phase.forward_rates_of_progress) +
                        np.dot(nu_p, self.phase.reverse_rates_of_progress))
 
-        self.assertArrayNear(self.phase.creation_rates, creation)
-        self.assertArrayNear(self.phase.destruction_rates, destruction)
-        self.assertArrayNear(self.phase.net_production_rates,
+        assertArrayNear(self.phase.creation_rates, creation)
+        assertArrayNear(self.phase.destruction_rates, destruction)
+        assertArrayNear(self.phase.net_production_rates,
                              creation - destruction)
 
     def test_reaction_deltas(self):
-        self.assertArrayNear(self.phase.delta_enthalpy -
+        assertArrayNear(self.phase.delta_enthalpy -
                              self.phase.delta_entropy * self.phase.T,
                              self.phase.delta_gibbs)
-        self.assertArrayNear(self.phase.delta_standard_enthalpy -
-                             self.phase.delta_standard_entropy * self.phase.T,
-                             self.phase.delta_standard_gibbs)
+        assertArrayNear(self.phase.delta_standard_enthalpy -
+                        self.phase.delta_standard_entropy * self.phase.T,
+                        self.phase.delta_standard_gibbs)
 
 
-class KineticsFromReactions(utilities.CanteraTest):
+class TestKineticsFromReactions:
     """
     Test for Kinetics objects which are constructed directly from Reaction
     objects instead of from input files.
@@ -203,21 +209,16 @@ class KineticsFromReactions(utilities.CanteraTest):
         gas2 = ct.Solution(thermo='ideal-gas', kinetics='gas',
                            species=S, reactions=R)
 
-        self.assertEqual(gas1.n_reactions, gas2.n_reactions)
+        assert gas1.n_reactions == gas2.n_reactions
         gas1.TPY = 800, 2*ct.one_atm, 'H2:0.3, O2:0.7, OH:2e-4, O:1e-3, H:5e-5'
         gas2.TPY = gas1.TPY
 
-        self.assertTrue((gas1.reactant_stoich_coeffs ==
-                         gas2.reactant_stoich_coeffs).all())
-        self.assertTrue((gas1.product_stoich_coeffs ==
-                         gas2.product_stoich_coeffs).all())
+        assert (gas1.reactant_stoich_coeffs == gas2.reactant_stoich_coeffs).all()
+        assert (gas1.product_stoich_coeffs == gas2.product_stoich_coeffs).all()
 
-        self.assertArrayNear(gas1.delta_gibbs,
-                             gas2.delta_gibbs)
-        self.assertArrayNear(gas1.reverse_rate_constants,
-                             gas2.reverse_rate_constants)
-        self.assertArrayNear(gas1.net_production_rates,
-                             gas2.net_production_rates)
+        assertArrayNear(gas1.delta_gibbs, gas2.delta_gibbs)
+        assertArrayNear(gas1.reverse_rate_constants, gas2.reverse_rate_constants)
+        assertArrayNear(gas1.net_production_rates, gas2.net_production_rates)
 
     def test_surface(self):
         surf1 = ct.Interface("ptcombust.yaml", "Pt_surf")
@@ -232,39 +233,31 @@ class KineticsFromReactions(utilities.CanteraTest):
         gas.TP = surf2.TP = surf1.TP = 900, 2*ct.one_atm
         surf2.coverages = surf1.coverages
 
-        self.assertEqual(surf1.n_reactions, surf2.n_reactions)
+        assert surf1.n_reactions == surf2.n_reactions
 
-        for k,i in itertools.product(['PT(S)','H2','OH','OH(S)'],
-                                     range(surf1.n_species)):
-            self.assertEqual(surf1.reactant_stoich_coeff(k,i),
-                             surf2.reactant_stoich_coeff(k,i))
-            self.assertEqual(surf1.product_stoich_coeff(k,i),
-                             surf2.product_stoich_coeff(k,i))
+        for k, i in itertools.product(['PT(S)', 'H2', 'OH', 'OH(S)'], range(surf1.n_species)):
+            assert surf1.reactant_stoich_coeff(k, i) == surf2.reactant_stoich_coeff(k, i)
+            assert surf1.product_stoich_coeff(k, i) == surf2.product_stoich_coeff(k, i)
 
         for i in range(surf1.n_reactions):
             r1 = surf1.reaction(i)
             r2 = surf2.reaction(i)
-            self.assertEqual(r1.reactants, r2.reactants)
-            self.assertEqual(r1.products, r2.products)
-            self.assertEqual(r1.rate.pre_exponential_factor,
-                             r2.rate.pre_exponential_factor)
-            self.assertEqual(r1.rate.temperature_exponent,
-                             r2.rate.temperature_exponent)
-            self.assertNear(r1.rate.activation_energy, r2.rate.activation_energy)
+            assert r1.reactants == r2.reactants
+            assert r1.products == r2.products
+            assert r1.rate.pre_exponential_factor == r2.rate.pre_exponential_factor
+            assert r1.rate.temperature_exponent == r2.rate.temperature_exponent
+            assertNear(r1.rate.activation_energy, r2.rate.activation_energy)
 
-        self.assertArrayNear(surf1.delta_enthalpy,
-                             surf2.delta_enthalpy)
-        self.assertArrayNear(surf1.forward_rate_constants,
-                             surf2.forward_rate_constants)
-        self.assertArrayNear(surf1.reverse_rate_constants,
-                             surf2.reverse_rate_constants)
+        assertArrayNear(surf1.delta_enthalpy, surf2.delta_enthalpy)
+        assertArrayNear(surf1.forward_rate_constants, surf2.forward_rate_constants)
+        assertArrayNear(surf1.reverse_rate_constants, surf2.reverse_rate_constants)
 
         rop1 = surf1.net_production_rates
         rop2 = surf2.net_production_rates
         for k in gas.species_names + surf1.species_names:
             k1 = surf1.kinetics_species_index(k)
             k2 = surf2.kinetics_species_index(k)
-            self.assertNear(rop1[k1], rop2[k2])
+            assertNear(rop1[k1], rop2[k2])
 
     def test_add_reaction(self):
         gas1 = ct.Solution('h2o2.yaml', transport_model=None)
@@ -280,25 +273,20 @@ class KineticsFromReactions(utilities.CanteraTest):
         for r in R[5:]:
             gas2.add_reaction(r)
 
-        self.assertEqual(gas1.n_reactions, gas2.n_reactions)
+        assert gas1.n_reactions == gas2.n_reactions
 
-        self.assertTrue((gas1.reactant_stoich_coeffs ==
-                         gas2.reactant_stoich_coeffs).all())
-        self.assertTrue((gas1.product_stoich_coeffs ==
-                         gas2.product_stoich_coeffs).all())
+        assert (gas1.reactant_stoich_coeffs == gas2.reactant_stoich_coeffs).all()
+        assert (gas1.product_stoich_coeffs == gas2.product_stoich_coeffs).all()
 
-        self.assertArrayNear(gas1.delta_gibbs,
-                             gas2.delta_gibbs)
-        self.assertArrayNear(gas1.reverse_rate_constants,
-                             gas2.reverse_rate_constants)
-        self.assertArrayNear(gas1.net_production_rates,
-                             gas2.net_production_rates)
+        assertArrayNear(gas1.delta_gibbs, gas2.delta_gibbs)
+        assertArrayNear(gas1.reverse_rate_constants, gas2.reverse_rate_constants)
+        assertArrayNear(gas1.net_production_rates, gas2.net_production_rates)
 
     def test_coverage_dependence_flags(self):
         surf = ct.Interface("ptcombust.yaml", "Pt_surf")
         surf.TP = 900, ct.one_atm
-        surf.coverages = {"PT(S)":1}
-        with self.assertRaises(NotImplementedError):
+        surf.coverages = {"PT(S)": 1}
+        with pytest.raises(NotImplementedError):
             surf.net_rates_of_progress_ddCi
         # set skip and try to get jacobian again
         surf.derivative_settings = {"skip-coverage-dependence": True}
@@ -306,7 +294,7 @@ class KineticsFromReactions(utilities.CanteraTest):
 
     def test_electrochemistry_flags(self):
         anode_int = ct.Interface("lithium_ion_battery.yaml", "edge_anode_electrolyte")
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             anode_int.net_rates_of_progress_ddCi
         # set skip and try to get jacobian again
         anode_int.derivative_settings = {"skip-electrochemistry": True}
@@ -334,7 +322,7 @@ class KineticsFromReactions(utilities.CanteraTest):
         gas = ct.Solution(thermo='ideal-gas', kinetics='gas',
                           species=h2o2.species(), reactions=reactions_plus)
         # there is one third-body reaction with an undeclared third body species
-        gas.n_reactions < len(reactions_plus)
+        assert gas.n_reactions < len(reactions_plus)
         assert gas.n_species == len(h2o2.species_names)
 
         gas = ct.Solution(thermo='ideal-gas', kinetics='gas', species=h2o2.species(),
@@ -346,12 +334,12 @@ class KineticsFromReactions(utilities.CanteraTest):
         gas.write_yaml(yaml_file)
         restored = ct.Solution(yaml_file)
         assert gas.species_names == restored.species_names
-        assert gas.reaction_equations() == restored.reaction_equations()
+        assert gas.reaction_equations() == restored.reaction_equations
 
 
-class KineticsRepeatability(utilities.CanteraTest):
+class TestKineticsRepeatability:
     """
-    Tests to make sure that lazily evaluated of terms in the rate expression
+    Tests to make sure that lazily evaluated terms in the rate expression
     are always updated correctly.
     """
     T0 = 1200
@@ -363,8 +351,8 @@ class KineticsRepeatability(utilities.CanteraTest):
 
     def setup_gas(self, mech):
         gas = ct.Solution(mech)
-        self.X0 = 1 + np.sin(range(1, gas.n_species+1))
-        self.X1 = 1 + np.sin(range(2, gas.n_species+2))
+        self.X0 = 1 + np.sin(range(1, gas.n_species + 1))
+        self.X1 = 1 + np.sin(range(2, gas.n_species + 2))
         return gas
 
     def check_rates_composition(self, mech):
@@ -383,7 +371,7 @@ class KineticsRepeatability(utilities.CanteraTest):
         gas.TDX = self.T0, self.rho0, self.X0
         w4 = gas.net_production_rates
 
-        self.assertArrayNear(w1, w4)
+        assertArrayNear(w1, w4)
 
     def check_rates_temperature1(self, mech):
         gas = self.setup_gas(mech)
@@ -401,7 +389,7 @@ class KineticsRepeatability(utilities.CanteraTest):
         gas.TDX = self.T0, self.rho0, self.X0
         w4 = gas.net_production_rates
 
-        self.assertArrayNear(w1, w4)
+        assertArrayNear(w1, w4)
 
     def check_rates_temperature2(self, mech):
         gas = self.setup_gas(mech)
@@ -419,7 +407,7 @@ class KineticsRepeatability(utilities.CanteraTest):
         gas.TPX = self.T0, self.P0, self.X0
         w4 = gas.net_production_rates
 
-        self.assertArrayNear(w1, w4)
+        assertArrayNear(w1, w4)
 
     def check_rates_pressure(self, mech):
         gas = self.setup_gas(mech)
@@ -437,7 +425,7 @@ class KineticsRepeatability(utilities.CanteraTest):
         gas.TPX = self.T0, self.P0, self.X0
         w4 = gas.net_production_rates
 
-        self.assertArrayNear(w1, w4)
+        assertArrayNear(w1, w4)
 
     def test_gri30_composition(self):
         self.check_rates_composition("gri30.yaml")
@@ -471,9 +459,6 @@ class KineticsRepeatability(utilities.CanteraTest):
 
     def test_modify_thermo(self):
         # Make sure that thermo modifications propagate through to Kinetics
-
-        # Set a gas state that is near enough to equilibrium that changes in the
-        # reverse rate always show up in the net rate
         gas = self.setup_gas("gri30.yaml")
         gas.TPX = self.T0, self.P0, self.X0
         gas.equilibrate('TP')
@@ -487,13 +472,13 @@ class KineticsRepeatability(utilities.CanteraTest):
         gas.modify_species(gas.species_index('OH'), OH)
         w2 = gas.net_rates_of_progress
 
-        for i,R in enumerate(gas.reactions()):
+        for i, R in enumerate(gas.reactions()):
             if ('OH' in R.reactants or 'OH' in R.products) and R.reversible:
                 # Rate should be different if reaction involves OH
-                self.assertNotAlmostEqual(w2[i] / w1[i], 1.0)
+                assert not pytest.approx(w2[i] / w1[i], rel=1e-5)
             else:
                 # Rate should be the same if reaction does not involve OH
-                self.assertAlmostEqual(w2[i] / w1[i], 1.0)
+                assert pytest.approx(w2[i] / w1[i], rel=1e-5)
 
     def test_pdep_err(self):
         err_msg = ("InputFileError thrown by PlogRate::validate:",
@@ -510,13 +495,11 @@ class KineticsRepeatability(utilities.CanteraTest):
                 "InputFileError thrown by Reaction::checkBalance:",
                 "The following reaction is unbalanced: H2O2 + OH <=> 2 H2O + HO2"
             )
-        try:
+        with pytest.raises(ct.CanteraError) as e:
             ct.Solution('addReactions_err_test.yaml')
-            self.fail('CanteraError not raised')
-        except ct.CanteraError as e:
-            err_msg_list = str(e).splitlines()
-            for msg in err_msg:
-                self.assertIn(msg, err_msg_list)
+        err_msg_list = str(e.value).splitlines()
+        for msg in err_msg:
+            assert msg in err_msg_list
 
     def test_sticking_coeff_err(self):
         err_msg = (r"Sticking coefficient is greater than 1 for reaction 'O2 \+ 2 PT\(S\) => 2 O\(S\)'",
@@ -527,8 +510,7 @@ class KineticsRepeatability(utilities.CanteraTest):
                    "at T = 5000.0",
                    "at T = 10000.0",
                    "Sticking coefficient is greater than 1 for reaction",
-                   "StickingRate::validate:",
-                   )
+                   "StickingRate::validate:")
 
         for err in err_msg:
             with pytest.warns(UserWarning, match=err):
@@ -547,7 +529,7 @@ def check_raises(yaml, err_msg, line):
         assert err in msg
 
 
-class TestUndeclared(utilities.CanteraTest):
+class TestUndeclared:
 
     _gas_def = """
             phases:
@@ -585,7 +567,7 @@ class TestUndeclared(utilities.CanteraTest):
             """
 
         gas = ct.Solution(yaml=gas_def)
-        self.assertEqual(gas.n_reactions, 3)
+        assert gas.n_reactions == 3
 
     def test_skip_undeclared_third_bodies2(self):
 
@@ -607,7 +589,7 @@ class TestUndeclared(utilities.CanteraTest):
             if rxn.equation == "H + O2 + M <=> HO2 + M":
                 found = True
                 break
-        self.assertTrue(found)
+        assert found
 
     def test_skip_undeclared_orders(self):
 
@@ -621,7 +603,7 @@ class TestUndeclared(utilities.CanteraTest):
             """
 
         gas = ct.Solution(yaml=gas_def)
-        self.assertEqual(gas.n_reactions, 1)
+        assert gas.n_reactions == 1
 
     def test_raise_nonreactant_orders(self):
 
@@ -664,10 +646,10 @@ class TestUndeclared(utilities.CanteraTest):
             """
         gas = ct.Solution(yaml=phase_defs, name="gas")
         surf = ct.Interface(yaml=phase_defs, name="Pt_surf", adjacent=[gas])
-        self.assertEqual(surf.n_reactions, 14)
+        assert surf.n_reactions == 14
 
 
-class TestInvalidInput(utilities.CanteraTest):
+class TestInvalidInput:
 
     _gas_def = """
             phases:
@@ -738,28 +720,29 @@ class TestInvalidInput(utilities.CanteraTest):
         check_raises(gas_def, "negative pre-exponential factor", line=14)
 
 
-class TestEmptyKinetics(utilities.CanteraTest):
+class TestEmptyKinetics:
     def test_empty(self):
         gas = ct.Solution("air-no-reactions.yaml")
 
-        self.assertEqual(gas.n_reactions, 0)
-        self.assertArrayNear(gas.creation_rates, np.zeros(gas.n_species))
-        self.assertArrayNear(gas.destruction_rates, np.zeros(gas.n_species))
-        self.assertArrayNear(gas.net_production_rates, np.zeros(gas.n_species))
+        assert gas.n_reactions == 0
+        assertArrayNear(gas.creation_rates, np.zeros(gas.n_species))
+        assertArrayNear(gas.destruction_rates, np.zeros(gas.n_species))
+        assertArrayNear(gas.net_production_rates, np.zeros(gas.n_species))
 
 
-class TestReactionPath(utilities.CanteraTest):
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.Solution('gri30.yaml', transport_model=None)
-        cls.gas.TPX = 1300.0, ct.one_atm, 'CH4:0.4, O2:1, N2:3.76'
-        r = ct.IdealGasReactor(cls.gas)
-        net = ct.ReactorNet([r])
+@pytest.fixture(scope='class')
+def setup_reaction_path_tests(request):
+    request.cls.gas = ct.Solution('gri30.yaml', transport_model=None)
+    request.cls.gas.TPX = 1300.0, ct.one_atm, 'CH4:0.4, O2:1, N2:3.76'
+    r = ct.IdealGasReactor(request.cls.gas)
+    net = ct.ReactorNet([r])
+    T = r.T
+    while T < 1900:
+        net.step()
         T = r.T
-        while T < 1900:
-            net.step()
-            T = r.T
+
+@pytest.mark.usefixtures('setup_reaction_path_tests')
+class TestReactionPath:
 
     def check_dot(self, diagram, element):
         diagram.label_threshold = 0
@@ -781,22 +764,22 @@ class TestReactionPath(utilities.CanteraTest):
                 # nodes
                 nodes2.add(A.strip())
                 spec = re.search('label="(.*?)"', B).group(1)
-                self.assertNotIn(spec, species)
+                assert spec not in species
                 species.add(spec)
 
         # Make sure that the output was actually parsable and that we
         # found some nodes
-        self.assertTrue(nodes1)
-        self.assertTrue(species)
+        assert nodes1
+        assert species
 
         # All nodes should be connected to some edge (this does not
         # require the graph to be connected)
-        self.assertEqual(nodes1, nodes2)
+        assert nodes1 == nodes2
 
         # All of the species in the graph should contain the element whose
         # flux we're looking at
         for spec in species:
-            self.assertTrue(self.gas.n_atoms(spec, element) > 0)
+            assert self.gas.n_atoms(spec, element) > 0
 
         # return fluxes from the dot file for further tests
         return [float(re.search('label *= *"(.*?)"', line).group(1))
@@ -822,7 +805,7 @@ class TestReactionPath(utilities.CanteraTest):
         for element in ['N', 'C', 'H', 'O']:
             diagram = ct.ReactionPathDiagram(self.gas, element)
             dot_fluxes = self.check_dot(diagram, element)
-            self.assertEqual(max(dot_fluxes), 1.0)
+            assert max(dot_fluxes) == 1.0
 
     def test_dot_net_unscaled(self):
         for element in ['N', 'C', 'H', 'O']:
@@ -833,14 +816,14 @@ class TestReactionPath(utilities.CanteraTest):
             fluxes = sorted(fluxes.values())
 
             for i in range(1, 20):
-                self.assertNear(dot_fluxes[-i], fluxes[-i], 1e-2)
+                assertNear(dot_fluxes[-i], fluxes[-i], 1e-2)
 
     def test_dot_oneway_autoscaled(self):
         for element in ['N', 'C', 'H', 'O']:
             diagram = ct.ReactionPathDiagram(self.gas, element)
             diagram.flow_type = 'OneWayFlow'
             dot_fluxes = self.check_dot(diagram, element)
-            self.assertEqual(max(dot_fluxes), 1.0)
+            assert max(dot_fluxes) == 1.0
 
     def test_dot_oneway_unscaled(self):
         for element in ['N', 'C', 'H', 'O']:
@@ -852,7 +835,7 @@ class TestReactionPath(utilities.CanteraTest):
             fluxes = sorted(fluxes.values())
 
             for i in range(1, 20):
-                self.assertNear(dot_fluxes[-i], fluxes[-i], 1e-2)
+                assertNear(dot_fluxes[-i], fluxes[-i], 1e-2)
 
     def test_fluxes(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
@@ -862,17 +845,17 @@ class TestReactionPath(utilities.CanteraTest):
         ropr = gas.reverse_rates_of_progress
         fluxes, _ = self.get_fluxes(diagram)
 
-        self.assertNear(fluxes['HO2','H'], ropr[5] + ropr[9], 1e-5)
-        self.assertNear(fluxes['H', 'H2'], 2*ropf[11] + ropf[16], 1e-5)
-        self.assertNear(fluxes['H', 'H2O'], ropf[15], 1e-5)
-        self.assertNear(fluxes['H', 'OH'], ropf[17], 1e-5)
-        self.assertNear(fluxes['HO2','H2'], ropf[16], 1e-5)
-        self.assertNear(fluxes['HO2', 'H2O'], ropf[15], 1e-5)
-        self.assertNear(fluxes['HO2', 'OH'], ropf[17], 1e-5)
-        self.assertNear(fluxes['HO2', 'H2O2'], 2*ropf[26] + 2*ropf[27], 1e-5)
+        assertNear(fluxes['HO2','H'], ropr[5] + ropr[9], 1e-5)
+        assertNear(fluxes['H', 'H2'], 2*ropf[11] + ropf[16], 1e-5)
+        assertNear(fluxes['H', 'H2O'], ropf[15], 1e-5)
+        assertNear(fluxes['H', 'OH'], ropf[17], 1e-5)
+        assertNear(fluxes['HO2','H2'], ropf[16], 1e-5)
+        assertNear(fluxes['HO2', 'H2O'], ropf[15], 1e-5)
+        assertNear(fluxes['HO2', 'OH'], ropf[17], 1e-5)
+        assertNear(fluxes['HO2', 'H2O2'], 2*ropf[26] + 2*ropf[27], 1e-5)
 
 
-class TestChemicallyActivated(utilities.CanteraTest):
+class TestChemicallyActivated:
     def test_rate_evaluation(self):
         gas = ct.Solution("chemically-activated-reaction.yaml")
         P = [2026.5, 202650.0, 10132500.0] # pressure
@@ -882,11 +865,12 @@ class TestChemicallyActivated(utilities.CanteraTest):
 
         for i in range(len(P)):
             gas.TPX = 900.0, P[i], [0.01, 0.01, 0.04, 0.10, 0.84]
-            self.assertNear(gas.forward_rates_of_progress[0], Rf[i], 2e-5)
+            assertNear(gas.forward_rates_of_progress[0], Rf[i], 2e-5)
 
 
-class ExplicitForwardOrderTest(utilities.CanteraTest):
-    def setUp(self):
+class TestExplicitForwardOrder:
+    def setup_method(self):
+        """ Runs before tests """
         self.gas = ct.Solution("explicit-forward-order.yaml")
         self.gas.TPX = 800, 101325, [0.01, 0.90, 0.02, 0.03, 0.04]
 
@@ -894,16 +878,16 @@ class ExplicitForwardOrderTest(utilities.CanteraTest):
         # Reactions are irreversible
         Rr = self.gas.reverse_rate_constants
         for i in range(3):
-            self.assertEqual(Rr[i], 0.0)
+            assert Rr[i] == 0.0
 
     def test_rateConstants(self):
         # species order: [H, AR, R1A, R1B, P1]
         C = self.gas.concentrations
         Rf = self.gas.forward_rates_of_progress
         kf = self.gas.forward_rate_constants
-        self.assertNear(Rf[0], kf[0] * C[2]**1.5 * C[3]**0.5)
-        self.assertNear(Rf[1], kf[1] * C[0]**1.0 * C[4]**0.2)
-        self.assertNear(Rf[2], kf[2] * C[2]**3.0)
+        assertNear(Rf[0], kf[0] * C[2]**1.5 * C[3]**0.5)
+        assertNear(Rf[1], kf[1] * C[0]**1.0 * C[4]**0.2)
+        assertNear(Rf[2], kf[2] * C[2]**3.0)
 
     def test_ratio1(self):
         rop1 = self.gas.forward_rates_of_progress
@@ -911,9 +895,9 @@ class ExplicitForwardOrderTest(utilities.CanteraTest):
         self.gas.TPX = None, None, [0.02, 0.87, 0.04, 0.03, 0.04]
         rop2 = self.gas.forward_rates_of_progress
         ratio = rop2/rop1
-        self.assertNear(ratio[0], 2**1.5) # order of R1A is 1.5
-        self.assertNear(ratio[1], 2**1.0) # order of H is 1.0
-        self.assertNear(ratio[2], 2**3) # order of R1A is 3
+        assertNear(ratio[0], 2**1.5) # order of R1A is 1.5
+        assertNear(ratio[1], 2**1.0) # order of H is 1.0
+        assertNear(ratio[2], 2**3) # order of R1A is 3
 
     def test_ratio2(self):
         rop1 = self.gas.forward_rates_of_progress
@@ -921,12 +905,12 @@ class ExplicitForwardOrderTest(utilities.CanteraTest):
         self.gas.TPX = None, None, [0.01, 0.83, 0.02, 0.06, 0.08]
         rop2 = self.gas.forward_rates_of_progress
         ratio = rop2/rop1
-        self.assertNear(ratio[0], 2**0.5) # order of R1B is 0.5
-        self.assertNear(ratio[1], 2**0.2) # order of P1 is 1.0
-        self.assertNear(ratio[2], 2**0.0) # order of R1B is 0
+        assertNear(ratio[0], 2**0.5) # order of R1B is 0.5
+        assertNear(ratio[1], 2**0.2) # order of P1 is 1.0
+        assertNear(ratio[2], 2**0.0) # order of R1B is 0
 
 
-class TestSofcKinetics(utilities.CanteraTest):
+class TestSofcKinetics:
     """ Test based on sofc.py """
     _mech = "sofc.yaml"
 
@@ -993,18 +977,18 @@ class TestSofcKinetics(utilities.CanteraTest):
             s.advance_coverages(50.0)
 
         # These values are just a regression test with no theoretical basis
-        self.assertArrayNear(anode_surf.coverages,
-                             [6.18736878e-01, 3.81123655e-01, 8.6303646e-05,
-                              2.59274203e-06, 5.05700981e-05], 1e-7)
-        self.assertArrayNear(oxide_surf_a.coverages,
-                             [4.99435780e-02, 9.48927983e-01, 1.12840418e-03,
-                              3.35936530e-08], 1e-7)
-        self.assertArrayNear(cathode_surf.coverages,
-                             [1.48180380e-07, 7.57234727e-14, 9.99999827e-01,
-                              2.49235513e-08, 4.03296469e-13], 1e-7)
-        self.assertArrayNear(oxide_surf_c.coverages,
-                             [4.99896947e-02, 9.49804199e-01, 2.06104679e-04,
-                              1.11970271e-09], 1e-7)
+        assertArrayNear(anode_surf.coverages,
+                        [6.18736878e-01, 3.81123655e-01, 8.6303646e-05,
+                        2.59274203e-06, 5.05700981e-05], 1e-7)
+        assertArrayNear(oxide_surf_a.coverages,
+                        [4.99435780e-02, 9.48927983e-01, 1.12840418e-03,
+                         3.35936530e-08], 1e-7)
+        assertArrayNear(cathode_surf.coverages,
+                        [1.48180380e-07, 7.57234727e-14, 9.99999827e-01,
+                         2.49235513e-08, 4.03296469e-13], 1e-7)
+        assertArrayNear(oxide_surf_c.coverages,
+                        [4.99896947e-02, 9.49804199e-01, 2.06104679e-04,
+                         1.11970271e-09], 1e-7)
 
         Ea0 = newton_solve(anode_curr, xstart=-0.51)
         Ec0 = newton_solve(cathode_curr, xstart=0.51)
@@ -1025,10 +1009,10 @@ class TestSofcKinetics(utilities.CanteraTest):
                              cathode_bulk.electric_potential -
                              anode_bulk.electric_potential])
 
-        self.compare(data, self.test_data_path / "sofc-test.csv", rtol=1e-7)
+        compare(data, self.test_data_path / "sofc-test.csv", rtol=1e-7)
 
 
-class TestLithiumIonBatteryKinetics(utilities.CanteraTest):
+class TestLithiumIonBatteryKinetics:
     """ Test based on lithium_ion_battery.py """
     _mech = "lithium_ion_battery.yaml"
 
@@ -1142,14 +1126,14 @@ class TestLithiumIonBatteryKinetics(utilities.CanteraTest):
             method = anode_int.interface_current(p)
             manual = sum(net_prod_rates * charges) * ct.faraday
 
-            self.assertEqual(method, manual)
+            assert  method == manual
 
 
-class TestDuplicateReactions(utilities.CanteraTest):
+class TestDuplicateReactions:
     infile = 'duplicate-reactions.yaml'
 
     def check(self, name):
-        with self.assertRaisesRegex(ct.CanteraError, 'duplicate reaction'):
+        with pytest.raises(ct.CanteraError, match='duplicate reaction'):
             ct.Solution(self.infile, name)
 
     def test_forward_multiple(self):
@@ -1166,39 +1150,39 @@ class TestDuplicateReactions(utilities.CanteraTest):
 
     def test_opposite_direction4(self):
         gas = ct.Solution(self.infile, 'E')
-        self.assertEqual(gas.n_reactions, 2)
+        assert gas.n_reactions == 2
 
     def test_common_efficiencies(self):
         self.check('F')
 
     def test_disjoint_efficiencies(self):
         gas = ct.Solution(self.infile, 'G')
-        self.assertEqual(gas.n_reactions, 2)
+        assert gas.n_reactions == 2
 
     def test_different_type(self):
         gas = ct.Solution(self.infile, 'H')
-        self.assertEqual(gas.n_reactions, 2)
+        assert gas.n_reactions == 2
 
     def test_declared_duplicate(self):
         gas = ct.Solution(self.infile, 'I')
-        self.assertEqual(gas.n_reactions, 2)
+        assert gas.n_reactions == 2
 
     def test_unmatched_duplicate(self):
         self.check('J')
 
     def test_nonreacting_species(self):
         gas = ct.Solution(self.infile, 'K')
-        self.assertEqual(gas.n_reactions, 3)
+        assert gas.n_reactions == 3
 
+@pytest.fixture(scope='class')
+def setup_reaction_tests(request):
+    request.cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
+    request.cls.gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
+    request.cls.gas.TP = 900, 2*ct.one_atm
+    request.cls.species = ct.Species.list_from_file("h2o2.yaml")
 
-class TestReaction(utilities.CanteraTest):
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.Solution('h2o2.yaml', transport_model=None)
-        cls.gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
-        cls.gas.TP = 900, 2*ct.one_atm
-        cls.species = ct.Species.list_from_file("h2o2.yaml")
+@pytest.mark.usefixtures("setup_reaction_tests")
+class TestReaction:
 
     def test_from_yaml(self):
         r = ct.Reaction.from_yaml(
@@ -1209,19 +1193,19 @@ class TestReaction(utilities.CanteraTest):
                 self.gas)
 
         assert r.third_body is not None
-        self.assertEqual(r.reactants['O'], 2)
-        self.assertEqual(r.products['O2'], 1)
-        self.assertEqual(r.third_body.efficiencies['H2O'], 15.4)
-        self.assertEqual(r.rate.temperature_exponent, -1.0)
-        self.assertIn('O', r)
-        self.assertIn('O2', r)
-        self.assertNotIn('H2O', r)
+        assert r.reactants['O'] == 2
+        assert r.products['O2'] == 1
+        assert r.third_body.efficiencies['H2O'] == 15.4
+        assert r.rate.temperature_exponent == -1.0
+        assert 'O' in r
+        assert 'O2' in r
+        assert 'H2O' not in r
 
-    def test_listFromFile(self):
+    def test_list_from_file(self):
         R = ct.Reaction.list_from_file("h2o2.yaml", self.gas)
         eq1 = [r.equation for r in R]
         eq2 = [r.equation for r in self.gas.reactions()]
-        self.assertEqual(eq1, eq2)
+        assert eq1 == eq2
 
     def test_list_from_yaml(self):
         yaml = """
@@ -1233,28 +1217,27 @@ class TestReaction(utilities.CanteraTest):
               rate-constant: {A: 9.63e+06, b: 2.0, Ea: 4000.0}
         """
         R = ct.Reaction.list_from_yaml(yaml, self.gas)
-        self.assertEqual(len(R), 3)
-        self.assertIn('HO2', R[2].products)
-        self.assertEqual(R[0].rate.temperature_exponent, 2.7)
+        assert len(R) == 3
+        assert 'HO2' in R[2].products
+        assert R[0].rate.temperature_exponent == 2.7
 
     def test_input_data_from_file(self):
         R = self.gas.reaction(0)
         data = R.input_data
-        self.assertEqual(data['type'], 'three-body')
-        self.assertEqual(data['efficiencies'],
-                         {'H2': 2.4, 'H2O': 15.4, 'AR': 0.83})
-        self.assertEqual(data['equation'], R.equation)
+        assert data['type'] == 'three-body'
+        assert data['efficiencies'] == {'H2': 2.4, 'H2O': 15.4, 'AR': 0.83}
+        assert data['equation'] == R.equation
 
     def test_input_data_from_scratch(self):
-        r = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1},
+        r = ct.Reaction({"O": 1, "H2": 1}, {"H": 1, "OH": 1},
                         ct.ArrheniusRate(3.87e1, 2.7, 2.6e7))
         data = r.input_data
-        self.assertNear(data['rate-constant']['A'], 3.87e1)
-        self.assertNear(data['rate-constant']['b'], 2.7)
-        self.assertNear(data['rate-constant']['Ea'], 2.6e7)
+        assertNear(data['rate-constant']['A'], 3.87e1)
+        assertNear(data['rate-constant']['b'], 2.7)
+        assertNear(data['rate-constant']['Ea'], 2.6e7)
         terms = data['equation'].split()
-        self.assertIn('O', terms)
-        self.assertIn('OH', terms)
+        assert 'O' in terms
+        assert 'OH' in terms
 
     def test_custom_from_scratch(self):
         species = self.gas.species()
@@ -1270,12 +1253,32 @@ class TestReaction(utilities.CanteraTest):
                            species=species, reactions=custom_reactions)
         gas1.TPX = self.gas.TPX
 
-        # remove references to Python objects
         del custom_reactions
         del rate1
+
         assert gas1.reaction(2).rate.type == 'custom-rate-function'
         assert gas1.net_production_rates[2] == pytest.approx(
             self.gas.net_production_rates[2], rel=1e-5)
+
+    def test_modify_invalid(self):
+        # different reaction type
+        tbr = self.gas.reaction(0)
+        R2 = ct.Reaction(tbr.reactants, tbr.products, tbr.rate)
+        with pytest.raises(ct.CanteraError, match='types are different'):
+            self.gas.modify_reaction(0, R2)
+
+        # different reactants
+        R = self.gas.reaction(4)
+        with pytest.raises(ct.CanteraError, match='Reactants are different'):
+            self.gas.modify_reaction(24, R)
+
+        # different products
+        R = self.gas.reaction(15)
+        with pytest.raises(ct.CanteraError, match='Products are different'):
+            self.gas.modify_reaction(16, R)
+
+
+class TestElementaryReaction(TestReaction):
 
     def test_elementary(self):
         r = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1},
@@ -1285,21 +1288,21 @@ class TestReaction(utilities.CanteraTest):
                            species=self.species, reactions=[r])
         gas2.TPX = self.gas.TPX
 
-        self.assertNear(gas2.forward_rate_constants[0],
-                        self.gas.forward_rate_constants[2])
-        self.assertNear(gas2.net_rates_of_progress[0],
-                        self.gas.net_rates_of_progress[2])
+        assertNear(gas2.forward_rate_constants[0],
+                   self.gas.forward_rate_constants[2])
+        assertNear(gas2.net_rates_of_progress[0],
+                   self.gas.net_rates_of_progress[2])
 
     def test_arrhenius_rate(self):
         R = self.gas.reaction(2)
-        self.assertNear(R.rate(self.gas.T), self.gas.forward_rate_constants[2])
+        assertNear(R.rate(self.gas.T), self.gas.forward_rate_constants[2])
 
     def test_negative_A(self):
         species = ct.Species.list_from_file("gri30.yaml")
         rate = ct.ArrheniusRate(-2.16e13, -0.23, 0)
         assert rate.allow_negative_pre_exponential_factor is False
 
-        with self.assertRaisesRegex(ct.CanteraError, 'negative pre-exponential'):
+        with pytest.raises(ct.CanteraError, match='negative pre-exponential'):
             r = ct.Reaction("NH:1, NO:1", "N2O:1, H:1", rate)
 
         rate.allow_negative_pre_exponential_factor = True
@@ -1307,28 +1310,84 @@ class TestReaction(utilities.CanteraTest):
         gas = ct.Solution(thermo='ideal-gas', kinetics='gas',
                           species=species, reactions=[r])
 
+    def test_modify_elementary(self):
+        gas = ct.Solution('h2o2.yaml', transport_model=None)
+        gas.TPX = self.gas.TPX
+        R = gas.reaction(2)
+        A1 = R.rate.pre_exponential_factor
+        b1 = R.rate.temperature_exponent
+        Ta1 = R.rate.activation_energy / ct.gas_constant
+        T = gas.T
+        assertNear(A1*T**b1*np.exp(-Ta1/T), gas.forward_rate_constants[2])
+
+        A2 = 1.5 * A1
+        b2 = b1 + 0.1
+        Ta2 = Ta1 * 1.2
+        R.rate = ct.ArrheniusRate(A2, b2, Ta2 * ct.gas_constant)
+        gas.modify_reaction(2, R)
+        assertNear(A2*T**b2*np.exp(-Ta2/T), gas.forward_rate_constants[2])
+
+
+class TestFalloffReaction(TestReaction):
+
     def test_negative_A_falloff(self):
         species = ct.Species.list_from_file("gri30.yaml")
         low_rate = ct.Arrhenius(2.16e13, -0.23, 0)
         high_rate = ct.Arrhenius(-8.16e12, -0.5, 0)
 
-        with self.assertRaisesRegex(ct.CanteraError, 'pre-exponential'):
+        with pytest.raises(ct.CanteraError, match='pre-exponential'):
             ct.LindemannRate(low_rate, high_rate, ())
 
         rate = ct.LindemannRate()
-        self.assertFalse(rate.allow_negative_pre_exponential_factor)
+        assert not rate.allow_negative_pre_exponential_factor
         rate.allow_negative_pre_exponential_factor = True
         rate.high_rate = high_rate
         # Should still fail because of mixed positive and negative A factors
-        with self.assertRaisesRegex(ct.CanteraError, 'pre-exponential'):
+        with pytest.raises(ct.CanteraError, match='pre-exponential'):
             rate.low_rate = low_rate
 
         rate.low_rate = ct.Arrhenius(-2.16e13, -0.23, 0)
         rxn = ct.Reaction("NH:1, NO:1", "N2O:1, H:1", rate)
         gas = ct.Solution(thermo='ideal-gas', kinetics='gas',
                           species=species, reactions=[rxn])
-        self.assertLess(gas.forward_rate_constants, 0)
+        assert gas.forward_rate_constants < 0
 
+    def test_falloff(self):
+        high_rate = ct.Arrhenius(7.4e10, -0.37, 0.0)
+        low_rate = ct.Arrhenius(2.3e12, -0.9, -1700 * 1000 * 4.184)
+        tb = ct.ThirdBody(efficiencies={"AR":0.7, "H2":2.0, "H2O":6.0})
+        r = ct.Reaction("OH:2", "H2O2:1",
+                        ct.TroeRate(low_rate, high_rate, [0.7346, 94, 1756, 5182]),
+                        third_body=tb)
+        assert r.rate.type == "falloff"
+
+        gas2 = ct.Solution(thermo='ideal-gas', kinetics='gas',
+                           species=self.species, reactions=[r])
+        gas2.TPX = self.gas.TPX
+
+        assertNear(gas2.forward_rate_constants[0],
+                   self.gas.forward_rate_constants[21])
+        assertNear(gas2.net_rates_of_progress[0],
+                    self.gas.net_rates_of_progress[21])
+
+    def test_modify_falloff(self):
+        gas = ct.Solution('gri30.yaml', transport_model=None)
+        gas.TPX = 1100, 3 * ct.one_atm, 'CH4:1.0, O2:0.4, CO2:0.1, H2O:0.05'
+        r0 = gas.reaction(11)
+        assert r0.rate.type == "falloff"
+        # these two reactions happen to have the same third-body efficiencies
+        r1 = gas.reaction(49)
+        r2 = gas.reaction(53)
+        assert r2.rate.type == "falloff"
+        assert r1.third_body.efficiencies == r2.third_body.efficiencies
+        r2.rate = r1.rate
+
+        gas.modify_reaction(53, r2)
+        kf = gas.forward_rate_constants
+        assertNear(kf[49], kf[53])
+
+
+class TestThreebodyReaction(TestReaction):
     def test_threebody(self):
         tb = ct.ThirdBody(efficiencies={"AR":0.7, "H2":2.0, "H2O":6.0})
         r = ct.Reaction({"O":1, "H":1}, {"OH":1},
@@ -1338,28 +1397,29 @@ class TestReaction(utilities.CanteraTest):
                            species=self.species, reactions=[r])
         gas2.TPX = self.gas.TPX
 
-        self.assertNear(gas2.forward_rate_constants[0],
-                        self.gas.forward_rate_constants[1])
-        self.assertNear(gas2.net_rates_of_progress[0],
-                        self.gas.net_rates_of_progress[1])
+        assertNear(gas2.forward_rate_constants[0],
+                   self.gas.forward_rate_constants[1])
+        assertNear(gas2.net_rates_of_progress[0],
+                   self.gas.net_rates_of_progress[1])
 
-    def test_falloff(self):
-        high_rate = ct.Arrhenius(7.4e10, -0.37, 0.0)
-        low_rate = ct.Arrhenius(2.3e12, -0.9, -1700 * 1000 * 4.184)
-        tb = ct.ThirdBody(efficiencies={"AR":0.7, "H2":2.0, "H2O":6.0})
-        r = ct.Reaction("OH:2", "H2O2:1",
-                        ct.TroeRate(low_rate, high_rate, [0.7346, 94, 1756, 5182]),
-                        third_body=tb)
-        self.assertEqual(r.rate.type, "falloff")
+    def test_modify_third_body(self):
+        gas = ct.Solution('h2o2.yaml', transport_model=None)
+        gas.TPX = self.gas.TPX
+        R = gas.reaction(5)
+        A1 = R.rate.pre_exponential_factor
+        b1 = R.rate.temperature_exponent
+        T = gas.T
+        kf1 = gas.forward_rate_constants[5]
 
-        gas2 = ct.Solution(thermo='ideal-gas', kinetics='gas',
-                           species=self.species, reactions=[r])
-        gas2.TPX = self.gas.TPX
+        A2 = 1.7 * A1
+        b2 = b1 - 0.1
+        R.rate = ct.ArrheniusRate(A2, b2, 0.0)
+        gas.modify_reaction(5, R)
+        kf2 = gas.forward_rate_constants[5]
+        assertNear((A2*T**b2) / (A1*T**b1), kf2/kf1)
 
-        self.assertNear(gas2.forward_rate_constants[0],
-                        self.gas.forward_rate_constants[21])
-        self.assertNear(gas2.net_rates_of_progress[0],
-                        self.gas.net_rates_of_progress[21])
+
+class TestPlogReaction(TestReaction):
 
     def test_plog(self):
         gas1 = ct.Solution('pdep-test.yaml')
@@ -1380,22 +1440,45 @@ class TestReaction(utilities.CanteraTest):
 
         for P in [0.001, 0.01, 0.2, 1.0, 1.1, 9.0, 10.0, 99.0, 103.0]:
             gas1.TP = gas2.TP = 900, P * ct.one_atm
-            self.assertNear(gas2.forward_rate_constants[0],
-                            gas1.forward_rate_constants[0])
-            self.assertNear(gas2.net_rates_of_progress[0],
-                            gas1.net_rates_of_progress[0])
+            assertNear(gas2.forward_rate_constants[0],
+                       gas1.forward_rate_constants[0])
+            assertNear(gas2.net_rates_of_progress[0],
+                       gas1.net_rates_of_progress[0])
 
     def test_plog_rate(self):
         gas1 = ct.Solution('pdep-test.yaml')
         gas1.TP = 800, 2*ct.one_atm
         for i in range(4):
-            self.assertNear(gas1.reaction(i).rate(gas1.T, gas1.P),
-                            gas1.forward_rate_constants[i])
+            assertNear(gas1.reaction(i).rate(gas1.T, gas1.P),
+                       gas1.forward_rate_constants[i])
 
     def test_plog_invalid_third_body(self):
-        with self.assertRaisesRegex(ct.CanteraError, "Found superfluous"):
+        with pytest.raises(ct.CanteraError, match="Found superfluous"):
             gas = ct.Solution("pdep-test.yaml", "plog-invalid")
 
+    def test_modify_plog(self):
+        gas = ct.Solution('pdep-test.yaml')
+        gas.TPX = 1010, 0.12 * ct.one_atm, 'R1A:0.3, R1B:0.2, H:0.1, R2:0.4'
+
+        r0 = gas.reaction(0)
+        r1 = gas.reaction(1)
+        r0.rate = ct.PlogRate(r1.rate.rates)
+        gas.modify_reaction(0, r0)
+        kf = gas.forward_rate_constants
+        assertNear(kf[0], kf[1])
+
+        # Removing the high-pressure rates should have no effect at low P...
+        r1.rate = ct.PlogRate(rates=r1.rate.rates[:-4])
+        gas.modify_reaction(1, r1)
+        assertNear(kf[1], gas.forward_rate_constants[1])
+
+        # ... but should change the rate at higher pressures
+        gas.TP = 1010, 12.0 * ct.one_atm
+        kf = gas.forward_rates_of_progress
+        kf[0] != approx(kf[1])
+
+
+class TestChebyshevReaction(TestReaction):
     def test_chebyshev(self):
         gas1 = ct.Solution('pdep-test.yaml')
         species = ct.Species.list_from_file("pdep-test.yaml")
@@ -1416,10 +1499,10 @@ class TestReaction(utilities.CanteraTest):
 
         for T,P in itertools.product([300, 500, 1500], [1e4, 4e5, 3e6]):
             gas1.TP = gas2.TP = T, P
-            self.assertNear(gas2.forward_rate_constants[0],
-                            gas1.forward_rate_constants[4])
-            self.assertNear(gas2.net_rates_of_progress[0],
-                            gas1.net_rates_of_progress[4])
+            assertNear(gas2.forward_rate_constants[0],
+                       gas1.forward_rate_constants[4])
+            assertNear(gas2.net_rates_of_progress[0],
+                       gas1.net_rates_of_progress[4])
 
     def test_chebyshev_single_P(self):
         species = ct.Species.list_from_file("pdep-test.yaml")
@@ -1441,7 +1524,7 @@ class TestReaction(utilities.CanteraTest):
             k1 = gas.forward_rate_constants[0]
             gas.TP = T, 1e6
             k2 = gas.forward_rate_constants[0]
-            self.assertNear(k1, k2)
+            assertNear(k1, k2)
 
     def test_chebyshev_single_T(self):
         species = ct.Species.list_from_file("pdep-test.yaml")
@@ -1460,21 +1543,21 @@ class TestReaction(utilities.CanteraTest):
             k1 = gas.forward_rate_constants[0]
             gas.TP = 1700, P
             k2 = gas.forward_rate_constants[0]
-            self.assertNear(k1, k2)
+            assertNear(k1, k2)
 
     def test_chebyshev_rate(self):
         gas1 = ct.Solution('pdep-test.yaml')
         gas1.TP = 800, 2*ct.one_atm
         for i in range(4,6):
-            self.assertNear(gas1.reaction(i).rate(gas1.T, gas1.P),
-                            gas1.forward_rate_constants[i])
+            assertNear(gas1.reaction(i).rate(gas1.T, gas1.P),
+                       gas1.forward_rate_constants[i])
 
     def test_chebyshev_bad_shape_yaml(self):
         species = ct.Species.list_from_file("pdep-test.yaml")
         gas = ct.Solution(thermo='ideal-gas', kinetics='gas',
                           species=species, reactions=[])
 
-        with self.assertRaisesRegex(ct.CanteraError, "Inconsistent"):
+        with pytest.raises(ct.CanteraError, match="Inconsistent"):
             r = ct.Reaction.from_yaml('''
                 equation: R5 + H <=> P5A + P5B
                 type: Chebyshev
@@ -1487,15 +1570,35 @@ class TestReaction(utilities.CanteraTest):
                 - [-0.031285, -0.039412, 0.044375, 0.014458]''', gas)
 
     def test_chebyshev_deprecated_third_body(self):
-        with self.assertRaisesRegex(ct.CanteraError, "in the reaction equation"):
+        with pytest.raises(ct.CanteraError, match="in the reaction equation"):
             gas = ct.Solution("pdep-test.yaml", "chebyshev-deprecated")
+
+    def test_modify_chebyshev(self):
+        gas = ct.Solution('pdep-test.yaml')
+        gas.TPX = 1010, 0.34 * ct.one_atm, 'R1A:0.3, R1B:0.2, H:0.1, R2:0.4'
+
+        r1 = gas.reaction(4)
+        r2 = gas.reaction(5)
+        r1.rate = ct.ChebyshevRate(r2.rate.temperature_range, r2.rate.pressure_range,
+                                   r2.rate.data)
+
+        # rates should be different before calling 'modify_reaction'
+        kf = gas.forward_rate_constants
+        assert kf[4] != approx(kf[5])
+
+        gas.modify_reaction(4, r1)
+        kf = gas.forward_rate_constants
+        assertNear(kf[4], kf[5])
+
+
+class TestBlowersMaselReaction(TestReaction):
 
     def test_BlowersMasel(self):
         r = ct.Reaction({"O":1, "H2":1}, {"H":1, "OH":1},
                 ct.BlowersMaselRate(3.87e1, 2.7, 6260*1000*4.184, 1e9*1000*4.184))
 
         gas1 = ct.Solution("blowers-masel.yaml", "gas")
-        self.assertIsInstance(gas1.reaction(0).rate, ct.BlowersMaselRate)
+        assert isinstance(gas1.reaction(0).rate, ct.BlowersMaselRate)
 
         gas2 = ct.Solution(thermo='ideal-gas', kinetics='gas',
                            species=gas1.species(), reactions=[r])
@@ -1505,16 +1608,16 @@ class TestReaction(utilities.CanteraTest):
         gas1.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
         gas2.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
 
-        self.assertNear(gas2.forward_rate_constants[0],
-                        gas1.forward_rate_constants[0], rtol=1e-7)
-        self.assertNear(gas2.net_rates_of_progress[0],
-                        gas1.net_rates_of_progress[0], rtol=1e-7)
+        assertNear(gas2.forward_rate_constants[0],
+                   gas1.forward_rate_constants[0], rtol=1e-7)
+        assertNear(gas2.net_rates_of_progress[0],
+                   gas1.net_rates_of_progress[0], rtol=1e-7)
 
     def test_negative_A_blowersmasel(self):
         species = ct.Solution("blowers-masel.yaml").species()
         rate = ct.BlowersMaselRate(-3.87e1, 2.7, 6260*1000*4.184, 1e9)
         assert rate.allow_negative_pre_exponential_factor is False
-        with self.assertRaisesRegex(ct.CanteraError, 'negative pre-exponential'):
+        with pytest.raises(ct.CanteraError, match='negative pre-exponential'):
             r = ct.Reaction({'O':1, 'H2':1}, {'H':1, 'OH':1}, rate)
 
         rate.allow_negative_pre_exponential_factor = True
@@ -1540,8 +1643,8 @@ class TestReaction(utilities.CanteraTest):
         species = gas.species('OH')
 
         gas.reaction(0).rate.delta_enthalpy = deltaH
-        self.assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH)
-        self.assertNear(E, gas.reaction(0).rate.activation_energy)
+        assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH)
+        assertNear(E, gas.reaction(0).rate.activation_energy)
 
         perturbed_coeffs = species.thermo.coeffs.copy()
         perturbed_coeffs[6] += deltaH_high / ct.gas_constant
@@ -1550,9 +1653,9 @@ class TestReaction(utilities.CanteraTest):
                             species.thermo.reference_pressure, perturbed_coeffs)
         gas.modify_species(index, species)
         gas.reaction(0).rate.delta_enthalpy = deltaH_high
-        self.assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH_high)
-        self.assertNear(deltaH_high, gas.reaction(0).rate.activation_energy)
-        self.assertNear(A*gas.T**b*np.exp(-deltaH_high/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
+        assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH_high)
+        assertNear(deltaH_high, gas.reaction(0).rate.activation_energy)
+        assertNear(A*gas.T**b*np.exp(-deltaH_high/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
 
         perturbed_coeffs = species.thermo.coeffs.copy()
         perturbed_coeffs[6] += deltaH_low / ct.gas_constant
@@ -1561,9 +1664,37 @@ class TestReaction(utilities.CanteraTest):
                             species.thermo.reference_pressure, perturbed_coeffs)
         gas.modify_species(index, species)
         gas.reaction(0).rate.delta_enthalpy = deltaH_low
-        self.assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH_low)
-        self.assertEqual(0, gas.reaction(0).rate.activation_energy)
-        self.assertNear(A*gas.T**b*np.exp(0/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
+        assertNear(gas.reaction(0).rate.delta_enthalpy, deltaH_low)
+        assert gas.reaction(0).rate.activation_energy == 0
+        assertNear(A*gas.T**b*np.exp(0/ct.gas_constant/gas.T), gas.forward_rate_constants[0])
+
+    def test_modify_BlowersMasel(self):
+        gas = ct.Solution("blowers-masel.yaml")
+        gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
+        gas.TP = self.gas.TP
+        R = gas.reaction(0)
+        delta_enthalpy = gas.delta_enthalpy[0]
+        A1 = R.rate.pre_exponential_factor
+        b1 = R.rate.temperature_exponent
+        R.rate.delta_enthalpy = delta_enthalpy
+        Ta1 = R.rate.activation_energy / ct.gas_constant
+        T = gas.T
+        assertNear(A1 * T**b1 * np.exp(-Ta1 / T), gas.forward_rate_constants[0])
+
+        # randomly modify the rate parameters of a Blowers-Masel reaction
+        A2 = 1.5 * A1
+        b2 = b1 + 0.1
+        Ta_intrinsic = R.rate.activation_energy * 1.2
+        w = R.rate.bond_energy * 0.8
+        R.rate = ct.BlowersMaselRate(A2, b2, Ta_intrinsic, w)
+        delta_enthalpy = gas.delta_enthalpy[0]
+        R.rate.delta_enthalpy = delta_enthalpy
+        Ta2 = R.rate.activation_energy / ct.gas_constant
+        gas.modify_reaction(0, R)
+        assertNear(A2 * T**b2 * np.exp(-Ta2 / T), gas.forward_rate_constants[0])
+
+
+class TestInterfaceReaction(TestReaction):
 
     def test_interface(self):
         surf_species = ct.Species.list_from_file("ptcombust.yaml")
@@ -1572,7 +1703,7 @@ class TestReaction(utilities.CanteraTest):
 
         rate = ct.InterfaceArrheniusRate(3.7e20, 0, 67.4e6)
         rate.coverage_dependencies = {'H(S)': (0, 0, -6e6)}
-        self.assertNear(rate.coverage_dependencies["H(S)"]["E"], -6e6)
+        assertNear(rate.coverage_dependencies["H(S)"]["E"], -6e6)
         r1 = ct.Reaction(equation="2 H(S) <=> H2 + 2 PT(S)", rate=rate)
 
         surf2 = ct.Interface(thermo='ideal-surface', species=surf_species,
@@ -1584,10 +1715,10 @@ class TestReaction(utilities.CanteraTest):
 
         for T in [300, 500, 1500]:
             gas.TP = surf1.TP = surf2.TP = T, 5*ct.one_atm
-            self.assertNear(surf1.forward_rate_constants[1],
-                            surf2.forward_rate_constants[0])
-            self.assertNear(surf1.net_rates_of_progress[1],
-                            surf2.net_rates_of_progress[0])
+            assertNear(surf1.forward_rate_constants[1],
+                       surf2.forward_rate_constants[0])
+            assertNear(surf1.net_rates_of_progress[1],
+                       surf2.net_rates_of_progress[0])
 
     def test_BlowersMaselinterface(self):
         gas = ct.Solution("gri30.yaml", transport_model=None)
@@ -1595,7 +1726,7 @@ class TestReaction(utilities.CanteraTest):
         surf1 = ct.Interface("blowers-masel.yaml", "Pt_surf", [gas])
         rate = ct.InterfaceBlowersMaselRate(3.7e20, 0, 67.4e6, 1e9)
         rate.coverage_dependencies = {"H(S)": (0, 0, -6e6)}
-        self.assertNear(rate.coverage_dependencies["H(S)"]["E"], -6e6)
+        assertNear(rate.coverage_dependencies["H(S)"]["E"], -6e6)
 
         r1 = ct.Reaction("H(S):2", "H2:1, PT(S):2", rate)
 
@@ -1611,139 +1742,10 @@ class TestReaction(utilities.CanteraTest):
 
         for T in [300, 500, 1500]:
             gas.TP = surf1.TP = surf2.TP = T, 5*ct.one_atm
-            self.assertNear(surf1.forward_rate_constants[0],
-                            surf2.forward_rate_constants[0])
-            self.assertNear(surf1.net_rates_of_progress[0],
-                            surf2.net_rates_of_progress[0])
-
-    def test_modify_invalid(self):
-        # different reaction type
-        tbr = self.gas.reaction(0)
-        R2 = ct.Reaction(tbr.reactants, tbr.products, tbr.rate)
-        with self.assertRaisesRegex(ct.CanteraError, 'types are different'):
-            self.gas.modify_reaction(0, R2)
-
-        # different reactants
-        R = self.gas.reaction(4)
-        with self.assertRaisesRegex(ct.CanteraError, 'Reactants are different'):
-            self.gas.modify_reaction(24, R)
-
-        # different products
-        R = self.gas.reaction(15)
-        with self.assertRaisesRegex(ct.CanteraError, 'Products are different'):
-            self.gas.modify_reaction(16, R)
-
-    def test_modify_elementary(self):
-        gas = ct.Solution('h2o2.yaml', transport_model=None)
-        gas.TPX = self.gas.TPX
-        R = gas.reaction(2)
-        A1 = R.rate.pre_exponential_factor
-        b1 = R.rate.temperature_exponent
-        Ta1 = R.rate.activation_energy / ct.gas_constant
-        T = gas.T
-        self.assertNear(A1*T**b1*np.exp(-Ta1/T), gas.forward_rate_constants[2])
-
-        A2 = 1.5 * A1
-        b2 = b1 + 0.1
-        Ta2 = Ta1 * 1.2
-        R.rate = ct.ArrheniusRate(A2, b2, Ta2 * ct.gas_constant)
-        gas.modify_reaction(2, R)
-        self.assertNear(A2*T**b2*np.exp(-Ta2/T), gas.forward_rate_constants[2])
-
-    def test_modify_third_body(self):
-        gas = ct.Solution('h2o2.yaml', transport_model=None)
-        gas.TPX = self.gas.TPX
-        R = gas.reaction(5)
-        A1 = R.rate.pre_exponential_factor
-        b1 = R.rate.temperature_exponent
-        T = gas.T
-        kf1 = gas.forward_rate_constants[5]
-
-        A2 = 1.7 * A1
-        b2 = b1 - 0.1
-        R.rate = ct.ArrheniusRate(A2, b2, 0.0)
-        gas.modify_reaction(5, R)
-        kf2 = gas.forward_rate_constants[5]
-        self.assertNear((A2*T**b2) / (A1*T**b1), kf2/kf1)
-
-    def test_modify_falloff(self):
-        gas = ct.Solution('gri30.yaml', transport_model=None)
-        gas.TPX = 1100, 3 * ct.one_atm, 'CH4:1.0, O2:0.4, CO2:0.1, H2O:0.05'
-        r0 = gas.reaction(11)
-        self.assertEqual(r0.rate.type, "falloff")
-        # these two reactions happen to have the same third-body efficiencies
-        r1 = gas.reaction(49)
-        r2 = gas.reaction(53)
-        self.assertEqual(r2.rate.type, "falloff")
-        self.assertEqual(r1.third_body.efficiencies, r2.third_body.efficiencies)
-        r2.rate = r1.rate
-
-        gas.modify_reaction(53, r2)
-        kf = gas.forward_rate_constants
-        self.assertNear(kf[49], kf[53])
-
-    def test_modify_plog(self):
-        gas = ct.Solution('pdep-test.yaml')
-        gas.TPX = 1010, 0.12 * ct.one_atm, 'R1A:0.3, R1B:0.2, H:0.1, R2:0.4'
-
-        r0 = gas.reaction(0)
-        r1 = gas.reaction(1)
-        r0.rate = ct.PlogRate(r1.rate.rates)
-        gas.modify_reaction(0, r0)
-        kf = gas.forward_rate_constants
-        self.assertNear(kf[0], kf[1])
-
-        # Removing the high-pressure rates should have no effect at low P...
-        r1.rate = ct.PlogRate(rates=r1.rate.rates[:-4])
-        gas.modify_reaction(1, r1)
-        self.assertNear(kf[1], gas.forward_rate_constants[1])
-
-        # ... but should change the rate at higher pressures
-        gas.TP = 1010, 12.0 * ct.one_atm
-        kf = gas.forward_rates_of_progress
-        self.assertNotAlmostEqual(kf[0], kf[1])
-
-    def test_modify_chebyshev(self):
-        gas = ct.Solution('pdep-test.yaml')
-        gas.TPX = 1010, 0.34 * ct.one_atm, 'R1A:0.3, R1B:0.2, H:0.1, R2:0.4'
-
-        r1 = gas.reaction(4)
-        r2 = gas.reaction(5)
-        r1.rate = ct.ChebyshevRate(
-            r2.rate.temperature_range, r2.rate.pressure_range, r2.rate.data)
-
-        # rates should be different before calling 'modify_reaction'
-        kf = gas.forward_rate_constants
-        self.assertNotAlmostEqual(kf[4], kf[5])
-
-        gas.modify_reaction(4, r1)
-        kf = gas.forward_rate_constants
-        self.assertNear(kf[4], kf[5])
-
-    def test_modify_BlowersMasel(self):
-        gas = ct.Solution("blowers-masel.yaml")
-        gas.X = 'H2:0.1, H2O:0.2, O2:0.7, O:1e-4, OH:1e-5, H:2e-5'
-        gas.TP = self.gas.TP
-        R = gas.reaction(0)
-        delta_enthalpy = gas.delta_enthalpy[0]
-        A1 = R.rate.pre_exponential_factor
-        b1 = R.rate.temperature_exponent
-        R.rate.delta_enthalpy = delta_enthalpy
-        Ta1 = R.rate.activation_energy / ct.gas_constant
-        T = gas.T
-        self.assertNear(A1 * T**b1 * np.exp(-Ta1 / T), gas.forward_rate_constants[0])
-
-        # randomly modify the rate parameters of a Blowers-Masel reaction
-        A2 = 1.5 * A1
-        b2 = b1 + 0.1
-        Ta_intrinsic = R.rate.activation_energy * 1.2
-        w = R.rate.bond_energy * 0.8
-        R.rate = ct.BlowersMaselRate(A2, b2, Ta_intrinsic, w)
-        delta_enthalpy = gas.delta_enthalpy[0]
-        R.rate.delta_enthalpy = delta_enthalpy
-        Ta2 = R.rate.activation_energy / ct.gas_constant
-        gas.modify_reaction(0, R)
-        self.assertNear(A2 * T**b2 * np.exp(-Ta2 / T), gas.forward_rate_constants[0])
+            assertNear(surf1.forward_rate_constants[0],
+                       surf2.forward_rate_constants[0])
+            assertNear(surf1.net_rates_of_progress[0],
+                       surf2.net_rates_of_progress[0])
 
     def test_modify_interface(self):
         surf = ct.Interface("ptcombust.yaml", "Pt_surf")
@@ -1760,51 +1762,8 @@ class TestReaction(utilities.CanteraTest):
         k2 = surf.forward_rate_constants[1]
         surf.coverages = 'O(S):0.2, PT(S):0.6, H(S):0.2'
         k3 = surf.forward_rate_constants[1]
-        self.assertNotAlmostEqual(k1, k2)
-        self.assertNear(k2, k3)
-
-    def test_invalid_sticking(self):
-        yaml = """
-        equation: OH + Csoot-H + CB-CB3 + CO => Csoot-* + 2 CO + H2
-        sticking-coefficient: {A: 0.13, b: 0.0, Ea: 0.0}"""
-        surf = ct.Interface("haca2.yaml", "soot_interface")
-        rxn = ct.Reaction.from_yaml(yaml, surf)
-        with pytest.raises(ct.CanteraError, match="non-interface species"):
-            surf.add_reaction(rxn)
-
-    def test_modify_sticking(self):
-        surf = ct.Interface("ptcombust.yaml", "Pt_surf")
-        surf.coverages = "O(S):0.1, PT(S):0.5, H(S):0.4"
-
-        R = surf.reaction(2)
-        R.rate = ct.StickingArrheniusRate(0.25, 0, 0) # original sticking coefficient = 1.0
-
-        k1 = surf.forward_rate_constants[2]
-        surf.modify_reaction(2, R)
-        k2 = surf.forward_rate_constants[2]
-        self.assertNear(k1, 4*k2)
-
-    def test_motz_wise(self):
-        # Motz & Wise off for all reactions
-        surf1 = ct.Interface("ptcombust.yaml", "Pt_surf")
-        surf1.coverages = 'O(S):0.1, PT(S):0.5, H(S):0.4'
-
-        # Motz & Wise correction on for some reactions
-        surf2 = ct.Interface("ptcombust-motzwise.yaml", "Pt_surf")
-        surf2.TPY = surf1.TPY
-
-        k1 = surf1.forward_rate_constants
-        k2 = surf2.forward_rate_constants
-
-        # M&W toggled on (globally) for reactions 2 and 7
-        self.assertNear(2.0 * k1[2], k2[2]) # sticking coefficient = 1.0
-        self.assertNear(1.6 * k1[7], k2[7]) # sticking coefficient = 0.75
-
-        # M&W toggled off (locally) for reaction 4
-        self.assertNear(k1[4], k2[4])
-
-        # M&W toggled on (locally) for reaction 9
-        self.assertNear(2.0 * k1[9], k2[9]) # sticking coefficient = 1.0
+        assert k1 != approx(k2)
+        assertNear(k2, k3)
 
     def test_modify_BMinterface(self):
         gas = ct.Solution("gri30.yaml", transport_model=None)
@@ -1829,8 +1788,54 @@ class TestReaction(utilities.CanteraTest):
         surf.coverages = "O(S):0.2, PT(S):0.6, H(S):0.2"
         k3 = surf.forward_rate_constants[0]
 
-        self.assertNear(k1 / k2, np.exp(-O2_delta_theta_k * Ek / ct.gas_constant / surf.T))
-        self.assertNear(k2, k3)
+        assertNear(k1 / k2, np.exp(-O2_delta_theta_k * Ek / ct.gas_constant / surf.T))
+        assertNear(k2, k3)
+
+
+class TestStickingCoefficient(TestReaction):
+
+    def test_invalid_sticking(self):
+        yaml = """
+        equation: OH + Csoot-H + CB-CB3 + CO => Csoot-* + 2 CO + H2
+        sticking-coefficient: {A: 0.13, b: 0.0, Ea: 0.0}"""
+        surf = ct.Interface("haca2.yaml", "soot_interface")
+        rxn = ct.Reaction.from_yaml(yaml, surf)
+        with pytest.raises(ct.CanteraError, match="non-interface species"):
+            surf.add_reaction(rxn)
+
+    def test_modify_sticking(self):
+        surf = ct.Interface("ptcombust.yaml", "Pt_surf")
+        surf.coverages = "O(S):0.1, PT(S):0.5, H(S):0.4"
+
+        R = surf.reaction(2)
+        R.rate = ct.StickingArrheniusRate(0.25, 0, 0) # original sticking coefficient = 1.0
+
+        k1 = surf.forward_rate_constants[2]
+        surf.modify_reaction(2, R)
+        k2 = surf.forward_rate_constants[2]
+        assertNear(k1, 4*k2)
+
+    def test_motz_wise(self):
+        # Motz & Wise off for all reactions
+        surf1 = ct.Interface("ptcombust.yaml", "Pt_surf")
+        surf1.coverages = 'O(S):0.1, PT(S):0.5, H(S):0.4'
+
+        # Motz & Wise correction on for some reactions
+        surf2 = ct.Interface("ptcombust-motzwise.yaml", "Pt_surf")
+        surf2.TPY = surf1.TPY
+
+        k1 = surf1.forward_rate_constants
+        k2 = surf2.forward_rate_constants
+
+        # M&W toggled on (globally) for reactions 2 and 7
+        assertNear(2.0 * k1[2], k2[2]) # sticking coefficient = 1.0
+        assertNear(1.6 * k1[7], k2[7]) # sticking coefficient = 0.75
+
+        # M&W toggled off (locally) for reaction 4
+        assertNear(k1[4], k2[4])
+
+        # M&W toggled on (locally) for reaction 9
+        assertNear(2.0 * k1[9], k2[9]) # sticking coefficient = 1.0
 
     def test_modify_BMsticking(self):
         gas = ct.Solution("gri30.yaml", transport_model=None)
@@ -1845,7 +1850,7 @@ class TestReaction(utilities.CanteraTest):
         k1 = surf.forward_rate_constants[1]
         surf.modify_reaction(1, R)
         k2 = surf.forward_rate_constants[1]
-        self.assertNear(k1, 4*k2)
+        assertNear(k1, 4*k2)
 
     def test_BMmotz_wise(self):
         # Motz & Wise off for all reactions
@@ -1860,14 +1865,17 @@ class TestReaction(utilities.CanteraTest):
         k2 = surf2.forward_rate_constants
 
         # M&W toggled on (globally) for reactions 1 and 2
-        self.assertNear(2.0 * k1[1], k2[1]) # sticking coefficient = 1.0
-        self.assertNear(1.6 * k1[2], k2[2]) # sticking coefficient = 0.75
+        assertNear(2.0 * k1[1], k2[1]) # sticking coefficient = 1.0
+        assertNear(1.6 * k1[2], k2[2]) # sticking coefficient = 0.75
 
         # M&W toggled off (locally) for reaction 3
-        self.assertNear(k1[3], k2[3])
+        assertNear(k1[3], k2[3])
 
         # M&W toggled on (locally) for reaction 4
-        self.assertNear(k1[4], k2[4]) # sticking coefficient = 1.0
+        assertNear(k1[4], k2[4]) # sticking coefficient = 1.0
+
+
+class TestElectrochemicalReaction(TestReaction):
 
     def test_electron_collision_plasma(self):
         gas1 = ct.Solution('oxygen-plasma.yaml',

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -4,197 +4,198 @@ from pytest import approx
 import cantera as ct
 
 
-@pytest.fixture(scope='class')
-def phases(request):
-    # Create class-level data for each test
-    request.cls.phase1 = ct.Solution('h2o2.yaml', transport_model=None)
-    request.cls.phase2 = ct.Solution('air.yaml')
-
-@pytest.fixture(scope='function')
-def mixture(request, phases):
-    # Create instance-level data for each test
-    request.cls.mix = ct.Mixture([(request.cls.phase1, 1.0), (request.cls.phase2, 2.0)])
-
-@pytest.mark.usefixtures("mixture")
 class TestMixture:
 
-    def test_sizes(self):
-        assert self.mix.n_phases == 2
+    @pytest.fixture(scope='class')
+    def phase1(self):
+        return ct.Solution('h2o2.yaml', transport_model=None)
 
-        assert self.mix.n_species == self.phase1.n_species + self.phase2.n_species
+    @pytest.fixture(scope='class')
+    def phase2(self):
+        return ct.Solution('air.yaml')
 
-        E = set(self.phase1.element_names) | set(self.phase2.element_names)
-        assert len(E) == self.mix.n_elements
+    @pytest.fixture(scope='function')
+    def mix(request, phase1, phase2):
+        # Create instance-level data for each test
+        return  ct.Mixture([(phase1, 1.0), (phase2, 2.0)])
 
-    def test_element_index(self):
-        m_H = self.mix.element_index('H')
-        assert m_H == self.mix.element_index(m_H)
+    def test_sizes(self, mix, phase1, phase2):
+        assert mix.n_phases == 2
+
+        assert mix.n_species == phase1.n_species + phase2.n_species
+
+        E = set(phase1.element_names) | set(phase2.element_names)
+        assert len(E) == mix.n_elements
+
+    def test_element_index(self, mix):
+        m_H = mix.element_index('H')
+        assert m_H == mix.element_index(m_H)
 
         with pytest.raises(ValueError, match='No such element'):
-            self.mix.element_index('W')
+            mix.element_index('W')
 
         with pytest.raises(ValueError, match='No such element'):
-            self.mix.element_index(41)
+            mix.element_index(41)
 
         with pytest.raises(TypeError, match='must be a string or a number'):
-            self.mix.element_index(None)
+            mix.element_index(None)
 
-    def test_speciesIndex(self):
-        names = self.mix.species_names
+    def test_speciesIndex(self, mix, phase1, phase2):
+        names = mix.species_names
         kOH = names.index('OH')
         kN2 = names.index('N2O')
-        assert self.mix.species_name(kOH) == 'OH'
-        assert self.mix.species_name(kN2) == 'N2O'
+        assert mix.species_name(kOH) == 'OH'
+        assert mix.species_name(kN2) == 'N2O'
 
-        assert self.mix.species_index(0, 'OH') == kOH
-        assert self.mix.species_index(self.phase1, 'OH') == kOH
-        assert self.mix.species_index(self.phase1.name, 'OH') == kOH
-        assert self.mix.species_index(0, self.phase1.species_index('OH')) == kOH
-        assert self.mix.species_index(1, self.phase2.species_index('N2O')) == kN2
-        assert self.mix.species_index(1, 'N2O') == kN2
+        assert mix.species_index(0, 'OH') == kOH
+        assert mix.species_index(phase1, 'OH') == kOH
+        assert mix.species_index(phase1.name, 'OH') == kOH
+        assert mix.species_index(0, phase1.species_index('OH')) == kOH
+        assert mix.species_index(1, phase2.species_index('N2O')) == kN2
+        assert mix.species_index(1, 'N2O') == kN2
 
         with pytest.raises(IndexError, match='out of range'):
-            self.mix.species_index(3, 'OH')
+            mix.species_index(3, 'OH')
 
         with pytest.raises(ValueError, match='No such species'):
-            self.mix.species_index(1, 'OH')
+            mix.species_index(1, 'OH')
 
         with pytest.raises(ValueError, match='out of range'):
-            self.mix.species_index(0, -2)
+            mix.species_index(0, -2)
 
         with pytest.raises(ValueError, match='No such species'):
-            self.mix.species_index(1, 'CO2')
+            mix.species_index(1, 'CO2')
 
-    def test_n_atoms(self):
-        names = self.mix.species_names
+    def test_n_atoms(self, mix):
+        names = mix.species_names
         kOH = names.index('OH')
         kN2 = names.index('N2')
-        mH = self.mix.element_index('H')
-        mN = self.mix.element_index('N')
+        mH = mix.element_index('H')
+        mN = mix.element_index('N')
 
-        assert self.mix.n_atoms(kOH, 'H') == 1
-        assert self.mix.n_atoms(kOH, 'O') == 1
-        assert self.mix.n_atoms(kOH, mH) == 1
-        assert self.mix.n_atoms(kOH, mN) == 0
+        assert mix.n_atoms(kOH, 'H') == 1
+        assert mix.n_atoms(kOH, 'O') == 1
+        assert mix.n_atoms(kOH, mH) == 1
+        assert mix.n_atoms(kOH, mN) == 0
 
-        assert self.mix.n_atoms(kN2, mN) == 2
-        assert self.mix.n_atoms(kN2, mH) == 0
+        assert mix.n_atoms(kN2, mN) == 2
+        assert mix.n_atoms(kN2, mH) == 0
 
-    def test_phase(self):
-        assert self.phase1 == self.mix.phase(0)
-        assert self.phase2 == self.mix.phase(1)
+    def test_phase(self, mix, phase1, phase2):
+        assert phase1 == mix.phase(0)
+        assert phase2 == mix.phase(1)
 
-        phaseNames = self.mix.phase_names
-        assert len(phaseNames) == self.mix.n_phases
-        assert phaseNames[0] == self.phase1.name
-        assert phaseNames[1] == self.phase2.name
+        phaseNames = mix.phase_names
+        assert len(phaseNames) == mix.n_phases
+        assert phaseNames[0] == phase1.name
+        assert phaseNames[1] == phase2.name
 
-    def test_phase_index(self):
-        assert self.mix.phase_index(self.phase1) == 0
-        assert self.mix.phase_index(self.phase2) == 1
-        assert self.mix.phase_index(self.phase2.name) == 1
-        assert self.mix.phase_index(1) == 1
+    def test_phase_index(self, mix, phase1, phase2):
+        assert mix.phase_index(phase1) == 0
+        assert mix.phase_index(phase2) == 1
+        assert mix.phase_index(phase2.name) == 1
+        assert mix.phase_index(1) == 1
 
         with pytest.raises(KeyError):
-            self.mix.phase_index('foobar')
+            mix.phase_index('foobar')
 
         with pytest.raises(IndexError):
-            self.mix.phase_index(2)
+            mix.phase_index(2)
 
-    def test_properties(self):
-        self.mix.T = 350
-        assert self.mix.T == 350
+    def test_properties(self, mix):
+        mix.T = 350
+        assert mix.T == 350
 
-        self.mix.P = 2e5
-        assert self.mix.P == 2e5
-        assert self.mix.T == 350
+        mix.P = 2e5
+        assert mix.P == 2e5
+        assert mix.T == 350
 
-        assert self.mix.max_temp > self.mix.min_temp
+        assert mix.max_temp > mix.min_temp
 
-    def test_charge(self):
-        C = sum(self.mix.phase_charge(i) for i in range(self.mix.n_phases))
-        assert self.mix.charge == C
+    def test_charge(self, mix):
+        C = sum(mix.phase_charge(i) for i in range(mix.n_phases))
+        assert mix.charge == C
 
-    def test_phase_moles(self):
-        M = self.mix.phase_moles()
-        assert M[0] == self.mix.phase_moles(0)
-        assert M[1] == self.mix.phase_moles('air')
+    def test_phase_moles(self, mix):
+        M = mix.phase_moles()
+        assert M[0] == mix.phase_moles(0)
+        assert M[1] == mix.phase_moles('air')
 
-        self.mix.set_phase_moles('air', 4)
-        assert self.mix.phase_moles(1) == 4
+        mix.set_phase_moles('air', 4)
+        assert mix.phase_moles(1) == 4
 
-    def test_species_moles(self):
-        self.mix.species_moles = 'H2:1.0, NO2:4.0'
-        P = self.mix.phase_moles()
-        S = self.mix.species_moles
+    def test_species_moles(self, mix, phase1):
+        mix.species_moles = 'H2:1.0, NO2:4.0'
+        P = mix.phase_moles()
+        S = mix.species_moles
 
         assert P[0] == 1
         assert P[1] == 4
 
-        assert S[self.mix.species_index(0, 'H2')] == 1
-        assert S[self.mix.species_index(1, 'NO2')] == 4
+        assert S[mix.species_index(0, 'H2')] == 1
+        assert S[mix.species_index(1, 'NO2')] == 4
 
         S[2] = 7
-        self.mix.species_moles = S
-        assert self.mix.species_moles[2] == approx(S[2])
-        assert self.mix.phase_moles(0) == approx(sum(S[:self.phase1.n_species]))
+        mix.species_moles = S
+        assert mix.species_moles[2] == approx(S[2])
+        assert mix.phase_moles(0) == approx(sum(S[:phase1.n_species]))
 
         with pytest.raises(ValueError):
-            self.mix.species_moles = (1, 2, 3)
+            mix.species_moles = (1, 2, 3)
 
         with pytest.raises(TypeError):
-            self.mix.species_moles = 9
+            mix.species_moles = 9
 
-    def test_element_moles(self):
-        self.mix.species_moles = 'H2:1.0, OH:4.0'
+    def test_element_moles(self, mix):
+        mix.species_moles = 'H2:1.0, OH:4.0'
 
-        assert self.mix.element_moles('H') == approx(6)
-        assert self.mix.element_moles('O') == approx(4)
-        assert self.mix.element_moles('N') == approx(0)
+        assert mix.element_moles('H') == approx(6)
+        assert mix.element_moles('O') == approx(4)
+        assert mix.element_moles('N') == approx(0)
 
-    def test_chemical_potentials(self):
-        C = self.mix.chemical_potentials
-        C1 = self.phase1.chemical_potentials
-        C2 = self.phase2.chemical_potentials
+    def test_chemical_potentials(self, mix, phase1, phase2):
+        C = mix.chemical_potentials
+        C1 = phase1.chemical_potentials
+        C2 = phase2.chemical_potentials
 
-        assert C[:self.phase1.n_species] == approx(C1)
-        assert C[self.phase1.n_species:] == approx(C2)
+        assert C[:phase1.n_species] == approx(C1)
+        assert C[phase1.n_species:] == approx(C2)
 
-    def test_equilibrate1(self):
-        self.mix.species_moles = 'H2:1.0, O2:0.5, N2:1.0'
-        self.mix.T = 400
-        self.mix.P = 2 * ct.one_atm
+    def test_equilibrate1(self, mix):
+        mix.species_moles = 'H2:1.0, O2:0.5, N2:1.0'
+        mix.T = 400
+        mix.P = 2 * ct.one_atm
 
-        E1 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
-        self.mix.equilibrate('TP', solver='vcs', estimate_equil=-1)
+        E1 = [mix.element_moles(m) for m in range(mix.n_elements)]
+        mix.equilibrate('TP', solver='vcs', estimate_equil=-1)
 
-        E2 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
+        E2 = [mix.element_moles(m) for m in range(mix.n_elements)]
         assert E1 == approx(E2)
-        assert self.mix.T == approx(400)
-        assert self.mix.P == approx(2 * ct.one_atm)
+        assert mix.T == approx(400)
+        assert mix.P == approx(2 * ct.one_atm)
 
     @pytest.mark.xfail(reason="See https://github.com/Cantera/cantera/issues/1023")
-    def test_equilibrate2(self):
-        self.mix.species_moles = 'H2:1.0, O2:0.5, N2:1.0'
-        self.mix.T = 400
-        self.mix.P = 2 * ct.one_atm
+    def test_equilibrate2(self, mix):
+        mix.species_moles = 'H2:1.0, O2:0.5, N2:1.0'
+        mix.T = 400
+        mix.P = 2 * ct.one_atm
 
-        E1 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
-        self.mix.equilibrate('TP', solver='gibbs')
+        E1 = [mix.element_moles(m) for m in range(mix.n_elements)]
+        mix.equilibrate('TP', solver='gibbs')
 
-        E2 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
+        E2 = [mix.element_moles(m) for m in range(mix.n_elements)]
         assert E1 == approx(E2)
-        assert self.mix.T == approx(400)
-        assert self.mix.P == approx(2 * ct.one_atm)
+        assert mix.T == approx(400)
+        assert mix.P == approx(2 * ct.one_atm)
 
-    def test_invalid_property(self):
-        x = self.mix
+    def test_invalid_property(self, mix):
+        x = mix
         with pytest.raises(AttributeError):
             x.foobar = 300
         with pytest.raises(AttributeError):
             x.foobar
 
-    def test_invalid_phase_type(self):
+    def test_invalid_phase_type(self, mix, phase1):
         water = ct.Water()
         with pytest.raises(ct.CanteraError, match='not compatible'):
-            self.mix = ct.Mixture([(self.phase1, 1.0), (water, 2.0)])
+            mix = ct.Mixture([(phase1, 1.0), (water, 2.0)])

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -1,6 +1,5 @@
 import pytest
 import cantera as ct
-from . import utilities
 from .utilities import (
     assertNear,
     assertArrayNear

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -2,9 +2,7 @@ import pytest
 from pytest import approx
 
 import cantera as ct
-from .utilities import (
-    assertArrayNear
-)
+
 
 @pytest.fixture(scope='class')
 def phases(request):
@@ -159,8 +157,8 @@ class TestMixture:
         C1 = self.phase1.chemical_potentials
         C2 = self.phase2.chemical_potentials
 
-        assertArrayNear(C[:self.phase1.n_species], C1)
-        assertArrayNear(C[self.phase1.n_species:], C2)
+        assert C[:self.phase1.n_species] == approx(C1)
+        assert C[self.phase1.n_species:] == approx(C2)
 
     def test_equilibrate1(self):
         self.mix.species_moles = 'H2:1.0, O2:0.5, N2:1.0'
@@ -171,7 +169,7 @@ class TestMixture:
         self.mix.equilibrate('TP', solver='vcs', estimate_equil=-1)
 
         E2 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
-        assertArrayNear(E1, E2)
+        assert E1 == approx(E2)
         assert self.mix.T == approx(400)
         assert self.mix.P == approx(2 * ct.one_atm)
 
@@ -185,7 +183,7 @@ class TestMixture:
         self.mix.equilibrate('TP', solver='gibbs')
 
         E2 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
-        assertArrayNear(E1, E2)
+        assert E1 == approx(E2)
         assert self.mix.T == approx(400)
         assert self.mix.P == approx(2 * ct.one_atm)
 

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -5,8 +5,8 @@ from . import utilities
 
 class TestMixture(utilities.CanteraTest):
     @classmethod
-    def setUpClass(self):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(self):
+        utilities.CanteraTest.setup_class()
         self.phase1 = ct.Solution('h2o2.yaml', transport_model=None)
         self.phase2 = ct.Solution('air.yaml')
 

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -17,7 +17,7 @@ class TestMixture:
     @pytest.fixture(scope='function')
     def mix(request, phase1, phase2):
         # Create instance-level data for each test
-        return  ct.Mixture([(phase1, 1.0), (phase2, 2.0)])
+        return ct.Mixture([(phase1, 1.0), (phase2, 2.0)])
 
     def test_sizes(self, mix, phase1, phase2):
         assert mix.n_phases == 2
@@ -28,9 +28,6 @@ class TestMixture:
         assert len(E) == mix.n_elements
 
     def test_element_index(self, mix):
-        m_H = mix.element_index('H')
-        assert m_H == mix.element_index(m_H)
-
         with pytest.raises(ValueError, match='No such element'):
             mix.element_index('W')
 

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -1,7 +1,8 @@
 import pytest
+from pytest import approx
+
 import cantera as ct
 from .utilities import (
-    assertNear,
     assertArrayNear
 )
 
@@ -137,8 +138,8 @@ class TestMixture:
 
         S[2] = 7
         self.mix.species_moles = S
-        assertNear(self.mix.species_moles[2], S[2])
-        assertNear(self.mix.phase_moles(0), sum(S[:self.phase1.n_species]))
+        assert self.mix.species_moles[2] == approx(S[2])
+        assert self.mix.phase_moles(0) == approx(sum(S[:self.phase1.n_species]))
 
         with pytest.raises(ValueError):
             self.mix.species_moles = (1, 2, 3)
@@ -149,9 +150,9 @@ class TestMixture:
     def test_element_moles(self):
         self.mix.species_moles = 'H2:1.0, OH:4.0'
 
-        assertNear(self.mix.element_moles('H'), 6)
-        assertNear(self.mix.element_moles('O'), 4)
-        assertNear(self.mix.element_moles('N'), 0)
+        assert self.mix.element_moles('H') == approx(6)
+        assert self.mix.element_moles('O') == approx(4)
+        assert self.mix.element_moles('N') == approx(0)
 
     def test_chemical_potentials(self):
         C = self.mix.chemical_potentials
@@ -171,8 +172,8 @@ class TestMixture:
 
         E2 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
         assertArrayNear(E1, E2)
-        assertNear(self.mix.T, 400)
-        assertNear(self.mix.P, 2 * ct.one_atm)
+        assert self.mix.T == approx(400)
+        assert self.mix.P == approx(2 * ct.one_atm)
 
     @pytest.mark.xfail(reason="See https://github.com/Cantera/cantera/issues/1023")
     def test_equilibrate2(self):
@@ -185,8 +186,8 @@ class TestMixture:
 
         E2 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
         assertArrayNear(E1, E2)
-        assertNear(self.mix.T, 400)
-        assertNear(self.mix.P, 2 * ct.one_atm)
+        assert self.mix.T == approx(400)
+        assert self.mix.P == approx(2 * ct.one_atm)
 
     def test_invalid_property(self):
         x = self.mix

--- a/test/python/test_mixture.py
+++ b/test/python/test_mixture.py
@@ -1,64 +1,70 @@
-import unittest
+import pytest
 import cantera as ct
 from . import utilities
+from .utilities import (
+    assertNear,
+    assertArrayNear
+)
 
+@pytest.fixture(scope='class')
+def phases(request):
+    # Create class-level data for each test
+    request.cls.phase1 = ct.Solution('h2o2.yaml', transport_model=None)
+    request.cls.phase2 = ct.Solution('air.yaml')
 
-class TestMixture(utilities.CanteraTest):
-    @classmethod
-    def setup_class(self):
-        utilities.CanteraTest.setup_class()
-        self.phase1 = ct.Solution('h2o2.yaml', transport_model=None)
-        self.phase2 = ct.Solution('air.yaml')
+@pytest.fixture(scope='function')
+def mixture(request, phases):
+    # Create instance-level data for each test
+    request.cls.mix = ct.Mixture([(request.cls.phase1, 1.0), (request.cls.phase2, 2.0)])
 
-    def setUp(self):
-        self.mix = ct.Mixture([(self.phase1, 1.0), (self.phase2, 2.0)])
+@pytest.mark.usefixtures("mixture")
+class TestMixture:
 
     def test_sizes(self):
-        self.assertEqual(self.mix.n_phases, 2)
+        assert self.mix.n_phases == 2
 
-        self.assertEqual(self.mix.n_species,
-                         self.phase1.n_species + self.phase2.n_species)
+        assert self.mix.n_species == self.phase1.n_species + self.phase2.n_species
 
         E = set(self.phase1.element_names) | set(self.phase2.element_names)
-        self.assertEqual(len(E), self.mix.n_elements)
+        assert len(E) == self.mix.n_elements
 
     def test_element_index(self):
         m_H = self.mix.element_index('H')
-        self.assertEqual(m_H, self.mix.element_index(m_H))
+        assert m_H == self.mix.element_index(m_H)
 
-        with self.assertRaisesRegex(ValueError, 'No such element'):
+        with pytest.raises(ValueError, match='No such element'):
             self.mix.element_index('W')
 
-        with self.assertRaisesRegex(ValueError, 'No such element'):
+        with pytest.raises(ValueError, match='No such element'):
             self.mix.element_index(41)
 
-        with self.assertRaisesRegex(TypeError, 'must be a string or a number'):
+        with pytest.raises(TypeError, match='must be a string or a number'):
             self.mix.element_index(None)
 
     def test_speciesIndex(self):
         names = self.mix.species_names
         kOH = names.index('OH')
         kN2 = names.index('N2O')
-        self.assertEqual(self.mix.species_name(kOH), 'OH')
-        self.assertEqual(self.mix.species_name(kN2), 'N2O')
+        assert self.mix.species_name(kOH) == 'OH'
+        assert self.mix.species_name(kN2) == 'N2O'
 
-        self.assertEqual(self.mix.species_index(0, 'OH'), kOH)
-        self.assertEqual(self.mix.species_index(self.phase1, 'OH'), kOH)
-        self.assertEqual(self.mix.species_index(self.phase1.name, 'OH'), kOH)
-        self.assertEqual(self.mix.species_index(0, self.phase1.species_index('OH')), kOH)
-        self.assertEqual(self.mix.species_index(1, self.phase2.species_index('N2O')), kN2)
-        self.assertEqual(self.mix.species_index(1, 'N2O'), kN2)
+        assert self.mix.species_index(0, 'OH') == kOH
+        assert self.mix.species_index(self.phase1, 'OH') == kOH
+        assert self.mix.species_index(self.phase1.name, 'OH') == kOH
+        assert self.mix.species_index(0, self.phase1.species_index('OH')) == kOH
+        assert self.mix.species_index(1, self.phase2.species_index('N2O')) == kN2
+        assert self.mix.species_index(1, 'N2O') == kN2
 
-        with self.assertRaisesRegex(IndexError, 'out of range'):
+        with pytest.raises(IndexError, match='out of range'):
             self.mix.species_index(3, 'OH')
 
-        with self.assertRaisesRegex(ValueError, 'No such species'):
+        with pytest.raises(ValueError, match='No such species'):
             self.mix.species_index(1, 'OH')
 
-        with self.assertRaisesRegex(ValueError, 'out of range'):
+        with pytest.raises(ValueError, match='out of range'):
             self.mix.species_index(0, -2)
 
-        with self.assertRaisesRegex(ValueError, 'No such species'):
+        with pytest.raises(ValueError, match='No such species'):
             self.mix.species_index(1, 'CO2')
 
     def test_n_atoms(self):
@@ -68,93 +74,93 @@ class TestMixture(utilities.CanteraTest):
         mH = self.mix.element_index('H')
         mN = self.mix.element_index('N')
 
-        self.assertEqual(self.mix.n_atoms(kOH, 'H'), 1)
-        self.assertEqual(self.mix.n_atoms(kOH, 'O'), 1)
-        self.assertEqual(self.mix.n_atoms(kOH, mH), 1)
-        self.assertEqual(self.mix.n_atoms(kOH, mN), 0)
+        assert self.mix.n_atoms(kOH, 'H') == 1
+        assert self.mix.n_atoms(kOH, 'O') == 1
+        assert self.mix.n_atoms(kOH, mH) == 1
+        assert self.mix.n_atoms(kOH, mN) == 0
 
-        self.assertEqual(self.mix.n_atoms(kN2, mN), 2)
-        self.assertEqual(self.mix.n_atoms(kN2, mH), 0)
+        assert self.mix.n_atoms(kN2, mN) == 2
+        assert self.mix.n_atoms(kN2, mH) == 0
 
     def test_phase(self):
-        self.assertEqual(self.phase1, self.mix.phase(0))
-        self.assertEqual(self.phase2, self.mix.phase(1))
+        assert self.phase1 == self.mix.phase(0)
+        assert self.phase2 == self.mix.phase(1)
 
         phaseNames = self.mix.phase_names
-        self.assertEqual(len(phaseNames), self.mix.n_phases)
-        self.assertEqual(phaseNames[0], self.phase1.name)
-        self.assertEqual(phaseNames[1], self.phase2.name)
+        assert len(phaseNames) == self.mix.n_phases
+        assert phaseNames[0] == self.phase1.name
+        assert phaseNames[1] == self.phase2.name
 
     def test_phase_index(self):
-        self.assertEqual(self.mix.phase_index(self.phase1), 0)
-        self.assertEqual(self.mix.phase_index(self.phase2), 1)
-        self.assertEqual(self.mix.phase_index(self.phase2.name), 1)
-        self.assertEqual(self.mix.phase_index(1), 1)
+        assert self.mix.phase_index(self.phase1) == 0
+        assert self.mix.phase_index(self.phase2) == 1
+        assert self.mix.phase_index(self.phase2.name) == 1
+        assert self.mix.phase_index(1) == 1
 
-        with self.assertRaises(KeyError):
+        with pytest.raises(KeyError):
             self.mix.phase_index('foobar')
 
-        with self.assertRaises(IndexError):
+        with pytest.raises(IndexError):
             self.mix.phase_index(2)
 
     def test_properties(self):
         self.mix.T = 350
-        self.assertEqual(self.mix.T, 350)
+        assert self.mix.T == 350
 
         self.mix.P = 2e5
-        self.assertEqual(self.mix.P, 2e5)
-        self.assertEqual(self.mix.T, 350)
+        assert self.mix.P == 2e5
+        assert self.mix.T == 350
 
-        self.assertGreater(self.mix.max_temp, self.mix.min_temp)
+        assert self.mix.max_temp > self.mix.min_temp
 
     def test_charge(self):
         C = sum(self.mix.phase_charge(i) for i in range(self.mix.n_phases))
-        self.assertEqual(self.mix.charge, C)
+        assert self.mix.charge == C
 
     def test_phase_moles(self):
         M = self.mix.phase_moles()
-        self.assertEqual(M[0], self.mix.phase_moles(0))
-        self.assertEqual(M[1], self.mix.phase_moles('air'))
+        assert M[0] == self.mix.phase_moles(0)
+        assert M[1] == self.mix.phase_moles('air')
 
         self.mix.set_phase_moles('air', 4)
-        self.assertEqual(self.mix.phase_moles(1), 4)
+        assert self.mix.phase_moles(1) == 4
 
     def test_species_moles(self):
         self.mix.species_moles = 'H2:1.0, NO2:4.0'
         P = self.mix.phase_moles()
         S = self.mix.species_moles
 
-        self.assertEqual(P[0], 1)
-        self.assertEqual(P[1], 4)
+        assert P[0] == 1
+        assert P[1] == 4
 
-        self.assertEqual(S[self.mix.species_index(0, 'H2')], 1)
-        self.assertEqual(S[self.mix.species_index(1, 'NO2')], 4)
+        assert S[self.mix.species_index(0, 'H2')] == 1
+        assert S[self.mix.species_index(1, 'NO2')] == 4
 
         S[2] = 7
         self.mix.species_moles = S
-        self.assertNear(self.mix.species_moles[2], S[2])
-        self.assertNear(self.mix.phase_moles(0), sum(S[:self.phase1.n_species]))
+        assertNear(self.mix.species_moles[2], S[2])
+        assertNear(self.mix.phase_moles(0), sum(S[:self.phase1.n_species]))
 
-        with self.assertRaises(ValueError):
-            self.mix.species_moles = (1,2,3)
+        with pytest.raises(ValueError):
+            self.mix.species_moles = (1, 2, 3)
 
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.mix.species_moles = 9
 
     def test_element_moles(self):
         self.mix.species_moles = 'H2:1.0, OH:4.0'
 
-        self.assertNear(self.mix.element_moles('H'), 6)
-        self.assertNear(self.mix.element_moles('O'), 4)
-        self.assertNear(self.mix.element_moles('N'), 0)
+        assertNear(self.mix.element_moles('H'), 6)
+        assertNear(self.mix.element_moles('O'), 4)
+        assertNear(self.mix.element_moles('N'), 0)
 
     def test_chemical_potentials(self):
         C = self.mix.chemical_potentials
         C1 = self.phase1.chemical_potentials
         C2 = self.phase2.chemical_potentials
 
-        self.assertArrayNear(C[:self.phase1.n_species], C1)
-        self.assertArrayNear(C[self.phase1.n_species:], C2)
+        assertArrayNear(C[:self.phase1.n_species], C1)
+        assertArrayNear(C[self.phase1.n_species:], C2)
 
     def test_equilibrate1(self):
         self.mix.species_moles = 'H2:1.0, O2:0.5, N2:1.0'
@@ -165,11 +171,11 @@ class TestMixture(utilities.CanteraTest):
         self.mix.equilibrate('TP', solver='vcs', estimate_equil=-1)
 
         E2 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
-        self.assertArrayNear(E1, E2)
-        self.assertNear(self.mix.T, 400)
-        self.assertNear(self.mix.P, 2 * ct.one_atm)
+        assertArrayNear(E1, E2)
+        assertNear(self.mix.T, 400)
+        assertNear(self.mix.P, 2 * ct.one_atm)
 
-    @unittest.expectedFailure  # See https://github.com/Cantera/cantera/issues/1023
+    @pytest.mark.xfail(reason="See https://github.com/Cantera/cantera/issues/1023")
     def test_equilibrate2(self):
         self.mix.species_moles = 'H2:1.0, O2:0.5, N2:1.0'
         self.mix.T = 400
@@ -179,18 +185,18 @@ class TestMixture(utilities.CanteraTest):
         self.mix.equilibrate('TP', solver='gibbs')
 
         E2 = [self.mix.element_moles(m) for m in range(self.mix.n_elements)]
-        self.assertArrayNear(E1, E2)
-        self.assertNear(self.mix.T, 400)
-        self.assertNear(self.mix.P, 2 * ct.one_atm)
+        assertArrayNear(E1, E2)
+        assertNear(self.mix.T, 400)
+        assertNear(self.mix.P, 2 * ct.one_atm)
 
     def test_invalid_property(self):
         x = self.mix
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             x.foobar = 300
-        with self.assertRaises(AttributeError):
+        with pytest.raises(AttributeError):
             x.foobar
 
     def test_invalid_phase_type(self):
         water = ct.Water()
-        with self.assertRaisesRegex(ct.CanteraError, 'not compatible'):
+        with pytest.raises(ct.CanteraError, match='not compatible'):
             self.mix = ct.Mixture([(self.phase1, 1.0), (water, 2.0)])

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -30,7 +30,7 @@ class TestOnedim(utilities.CanteraTest):
         flame = ct.FreeFlow(gas1)
         sim = ct.Sim1D((inlet, flame))
 
-        self.assertEqual(inlet.name, 'something')
+        assert inlet.name == 'something'
 
         gas2.TPX = 400, 101325, 'H2:0.3, O2:0.5, AR:0.2'
         Xref = gas2.X
@@ -54,24 +54,24 @@ class TestOnedim(utilities.CanteraTest):
         gas = ct.Solution("h2o2.yaml")
         flame = ct.FreeFlow(gas)
 
-        with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
+        with pytest.raises(ct.CanteraError, match='monotonically'):
             flame.grid = [0, 0.1, 0.1, 0.2]
 
-        with self.assertRaisesRegex(ct.CanteraError, 'monotonically'):
+        with pytest.raises(ct.CanteraError, match='monotonically'):
             flame.grid = [0, 0.1, 0.2, 0.05]
 
     def test_unpicklable(self):
         import pickle
         gas = ct.Solution("h2o2.yaml")
         flame = ct.FreeFlow(gas)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             pickle.dumps(flame)
 
     def test_uncopyable(self):
         import copy
         gas = ct.Solution("h2o2.yaml")
         flame = ct.FreeFlow(gas)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             copy.copy(flame)
 
     def test_exceptions(self):
@@ -92,9 +92,9 @@ class TestOnedim(utilities.CanteraTest):
         sim = ct.Sim1D((inlet, flame))
 
         for x in (inlet, flame, sim):
-            with self.assertRaises(AttributeError):
+            with pytest.raises(AttributeError):
                 x.foobar = 300
-            with self.assertRaises(AttributeError):
+            with pytest.raises(AttributeError):
                 x.foobar
 
     def test_tolerances(self):
@@ -105,7 +105,7 @@ class TestOnedim(utilities.CanteraTest):
         # Some things don't work until the domains have been added to a Sim1D
         sim = ct.Sim1D((left, flame, right))
 
-        with self.assertRaisesRegex(ct.CanteraError, 'no component'):
+        with pytest.raises(ct.CanteraError, match='no component'):
             flame.set_steady_tolerances(foobar=(3e-4, 3e-6))
 
         flame.set_steady_tolerances(default=(5e-3, 5e-5),
@@ -121,10 +121,10 @@ class TestOnedim(utilities.CanteraTest):
         rtol_ss = set(flame.steady_reltol())
         rtol_ts = set(flame.transient_reltol())
 
-        self.assertEqual(atol_ss, set((5e-5, 3e-6, 7e-9)))
-        self.assertEqual(atol_ts, set((6e-5, 4e-6, 2e-9)))
-        self.assertEqual(rtol_ss, set((5e-3, 3e-4, 7e-7)))
-        self.assertEqual(rtol_ts, set((6e-3, 4e-4, 2e-7)))
+        assert atol_ss == set((5e-5, 3e-6, 7e-9))
+        assert atol_ts == set((6e-5, 4e-6, 2e-9))
+        assert rtol_ss == set((5e-3, 3e-4, 7e-7))
+        assert rtol_ts == set((6e-3, 4e-4, 2e-7))
 
     def test_switch_transport(self):
         gas = ct.Solution('h2o2.yaml')
@@ -925,7 +925,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
     # (2) Start Python and run:
     #     >>> import cantera.test
     #     >>> t = cantera.test.test_onedim.TestDiffusionFlame()
-    #     >>> t.setUpClass()
+    #     >>> t.setup_class()
     #     >>> t.test_mixture_averaged(True)
     #     >>> t.test_auto(True)
     #     >>> t.test_mixture_averaged_rad(True)
@@ -1357,7 +1357,7 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
     # (2) Start Python and run:
     #     >>> import cantera.test
     #     >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlame()
-    #     >>> t.setUpClass()
+    #     >>> t.setup_class()
     #     >>> t.test_mixture_averaged(True)
     # (3) Compare the reference files created in the current working directory with
     #     the ones in test/data and replace them if needed.
@@ -1475,7 +1475,7 @@ class TestCounterflowPremixedFlameNonIdeal(utilities.CanteraTest):
     # (2) Start Python and run:
     #     >>> import cantera.test
     #     >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlameNonIdeal()
-    #     >>> t.setUpClass()
+    #     >>> t.setup_class()
     #     >>> t.test_mixture_averaged(True)
     # (3) Compare the reference files created in the current working directory with
     #     the ones in test/data and replace them if needed.

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -1,11 +1,19 @@
-import cantera as ct
-from . import utilities
 import numpy as np
-from .utilities import allow_deprecated, yaml
 import pytest
 from pytest import approx
 
-class TestOnedim(utilities.CanteraTest):
+import cantera as ct
+
+from . import utilities
+from .utilities import allow_deprecated, yaml
+from .utilities import (
+    assertNear,
+    assertArrayNear,
+    compareProfiles
+)
+
+
+class TestOnedim:
     def test_instantiate(self):
         gas = ct.Solution("h2o2.yaml")
         free = ct.FreeFlow(gas)
@@ -13,7 +21,8 @@ class TestOnedim(utilities.CanteraTest):
 
     def test_badInstantiate(self):
         solid = ct.Solution("diamond.yaml", "diamond")
-        with pytest.raises(ct.CanteraError, match="An appropriate transport model\nshould be set when instantiating"):
+        with pytest.raises(ct.CanteraError,
+                           match="An appropriate transport model\nshould be set when instantiating"):
             ct.FreeFlow(solid)
 
     def test_instantiateSurface(self):
@@ -37,18 +46,18 @@ class TestOnedim(utilities.CanteraTest):
         Yref = gas2.Y
         inlet.Y = Yref
 
-        self.assertArrayNear(inlet.Y, Yref)
-        self.assertArrayNear(inlet.X, Xref)
+        assertArrayNear(inlet.Y, Yref)
+        assertArrayNear(inlet.X, Xref)
 
         gas2.TPX = 400, 101325, 'H2:0.5, O2:0.2, AR:0.3'
         Xref = gas2.X
         Yref = gas2.Y
         inlet.X = Xref
-        self.assertArrayNear(inlet.X, Xref)
-        self.assertArrayNear(inlet.Y, Yref)
+        assertArrayNear(inlet.X, Xref)
+        assertArrayNear(inlet.Y, Yref)
 
         inlet.X = {'H2':0.3, 'O2':0.5, 'AR':0.2}
-        self.assertNear(inlet.X[gas2.species_index('H2')], 0.3)
+        assertNear(inlet.X[gas2.species_index('H2')], 0.3)
 
     def test_grid_check(self):
         gas = ct.Solution("h2o2.yaml")
@@ -172,7 +181,7 @@ def check_component_order(fname: str, group: str):
             components = value[::-1]
 
 
-class TestFreeFlame(utilities.CanteraTest):
+class TestFreeFlame:
     tol_ss = [1.0e-5, 1.0e-14]  # [rtol atol] for steady-state problem
     tol_ts = [1.0e-4, 1.0e-11]  # [rtol atol] for time stepping
 
@@ -195,7 +204,7 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.energy_enabled = False
         self.sim.solve(loglevel=0, refine_grid=False)
 
-        self.assertFalse(self.sim.energy_enabled)
+        assert not self.sim.energy_enabled
 
     def solve_mix(self, ratio=3.0, slope=0.3, curve=0.2, prune=0.0, refine=True):
         # Solve with the energy equation enabled
@@ -203,20 +212,21 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.energy_enabled = True
         self.sim.solve(loglevel=0, refine_grid=refine)
 
-        self.assertTrue(self.sim.energy_enabled)
-        self.assertEqual(self.sim.transport_model, 'mixture-averaged')
+        assert self.sim.energy_enabled
+        assert self.sim.transport_model == 'mixture-averaged'
 
     def solve_multi(self):
         self.sim.transport_model = 'multicomponent'
         self.sim.solve(loglevel=0, refine_grid=True)
 
-        self.assertEqual(self.sim.transport_model, 'multicomponent')
+        assert self.sim.transport_model == 'multicomponent'
 
     def test_flow_type(self):
         Tin = 300
         p = ct.one_atm
         reactants = 'H2:0.65, O2:0.5, AR:2'
         self.create_sim(p, Tin, reactants, width=0.0001)
+
         assert self.sim.flame.domain_type == "free-flow"
 
     def test_fixed_temperature(self):
@@ -231,8 +241,8 @@ class TestFreeFlame(utilities.CanteraTest):
         tfixed = 900.
         self.sim.fixed_temperature = tfixed
         zfixed = np.interp(tfixed, tvec, zvec)
-        self.assertNear(self.sim.fixed_temperature, tfixed)
-        self.assertNear(self.sim.fixed_temperature_location, zfixed)
+        assertNear(self.sim.fixed_temperature, tfixed)
+        assertNear(self.sim.fixed_temperature_location, zfixed)
 
     @utilities.slow_test
     def test_auto_width(self):
@@ -246,14 +256,14 @@ class TestFreeFlame(utilities.CanteraTest):
         self.gas.TPX = Tin, p, reactants
         self.gas.equilibrate('HP')
         Tad = self.gas.T
-        self.assertNear(Tad, self.sim.T[-1], 2e-2)
+        assertNear(Tad, self.sim.T[-1], 2e-2)
 
         # Re-solving with auto=False should not trigger a DomainTooNarrow
         # exception, and should leave domain width constant
         self.sim.flame.grid *= 0.3
         old_width = self.sim.grid[-1]
         self.sim.solve(loglevel=0, refine_grid=True, auto=False)
-        self.assertNear(self.sim.grid[-1], old_width)
+        assertNear(self.sim.grid[-1], old_width)
 
     def test_auto_width2(self):
         self.create_sim(p=ct.one_atm, Tin=400, reactants='H2:0.8, O2:0.5',
@@ -263,9 +273,9 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.flame.set_steady_tolerances(T=(2e-4, 1e-8))
         self.sim.solve(refine_grid=True, auto=True, loglevel=0)
 
-        self.assertNear(self.sim.velocity[0], 17.02, 1e-1)
-        self.assertLess(self.sim.grid[-1], 2.0) # grid should not be too wide
-        self.assertEqual(self.sim.flame.tolerances("T"), (2e-4, 1e-8))
+        assertNear(self.sim.velocity[0], 17.02, 1e-1)
+        assert self.sim.grid[-1] < 2.0 # grid should not be too wide
+        assert self.sim.flame.tolerances("T") == (2e-4, 1e-8)
 
     @utilities.slow_test
     def test_converge_adiabatic(self):
@@ -296,12 +306,12 @@ class TestFreeFlame(utilities.CanteraTest):
         T3 = self.sim.T[-1]
         X3 = self.sim.X[:,-1]
 
-        self.assertLess(abs(T2-Tad), abs(T1-Tad))
-        self.assertLess(abs(T3-Tad), abs(T2-Tad))
+        assert abs(T2-Tad) < abs(T1-Tad)
+        assert abs(T3-Tad) < abs(T2-Tad)
 
         for k in range(self.gas.n_species):
-            self.assertLessEqual(abs(X2[k]-Xad[k]), abs(X1[k]-Xad[k]))
-            self.assertLessEqual(abs(X3[k]-Xad[k]), abs(X2[k]-Xad[k]))
+            assert abs(X2[k]-Xad[k]) <= abs(X1[k]-Xad[k])
+            assert abs(X3[k]-Xad[k]) <= abs(X2[k]-Xad[k])
 
     def run_mix(self, phi, T, width, p, refine):
         reactants = {'H2': phi, 'O2': 0.5, 'AR': 2}
@@ -312,25 +322,25 @@ class TestFreeFlame(utilities.CanteraTest):
 
         # Check continuity
         for rhou_j in self.sim.density * self.sim.velocity:
-            self.assertNear(rhou_j, rhou, 1e-4)
+            assertNear(rhou_j, rhou, 1e-4)
 
     def test_solution_array_output(self):
         self.run_mix(phi=1.0, T=300, width=2.0, p=1.0, refine=False)
 
         flow = self.sim.to_array(normalize=True)
-        self.assertArrayNear(self.sim.grid, flow.grid)
-        self.assertArrayNear(self.sim.T, flow.T)
+        assertArrayNear(self.sim.grid, flow.grid)
+        assertArrayNear(self.sim.T, flow.T)
 
         f2 = ct.FreeFlame(self.gas)
         f2.from_array(flow)
-        self.assertArrayNear(self.sim.grid, f2.grid)
-        self.assertArrayNear(self.sim.T, f2.T)
+        assertArrayNear(self.sim.grid, f2.grid)
+        assertArrayNear(self.sim.T, f2.T)
 
         inlet = self.sim.to_array(self.sim.inlet)
         f2.from_array(inlet, f2.inlet)
-        self.assertNear(self.sim.inlet.T, f2.inlet.T)
-        self.assertNear(self.sim.inlet.mdot, f2.inlet.mdot)
-        self.assertArrayNear(self.sim.inlet.Y, f2.inlet.Y)
+        assertNear(self.sim.inlet.T, f2.inlet.T)
+        assertNear(self.sim.inlet.mdot, f2.inlet.mdot)
+        assertArrayNear(self.sim.inlet.Y, f2.inlet.Y)
 
     def test_restart_array(self):
         # restart from SolutionArray
@@ -373,7 +383,7 @@ class TestFreeFlame(utilities.CanteraTest):
         # Check continuity
         rhou = self.sim.inlet.mdot
         for rhou_j in self.sim.density * self.sim.velocity:
-            self.assertNear(rhou_j, rhou, 1e-4)
+            assertNear(rhou_j, rhou, 1e-4)
         return data, group
 
     def test_settings(self):
@@ -468,7 +478,7 @@ class TestFreeFlame(utilities.CanteraTest):
             self.sim.solve(loglevel=0, refine_grid=False)
             Suminus = self.sim.velocity[0]
             fwd = (Suplus-Suminus)/(2*Su0*dk)
-            self.assertNear(fwd, dSdk_adj[m], rtol=5e-3, atol=1e-7)
+            assertNear(fwd, dSdk_adj[m], rtol=5e-3, atol=1e-7)
 
     # @utilities.unittest.skip('sometimes slow')
     def test_multicomponent(self):
@@ -485,20 +495,20 @@ class TestFreeFlame(utilities.CanteraTest):
         # the mixture-averaged flame speed.
         self.solve_multi()
         Su_multi = self.sim.velocity[0]
-        self.assertFalse(self.sim.soret_enabled)
+        assert not self.sim.soret_enabled
 
-        self.assertNear(Su_mix, Su_multi, 5e-2)
-        self.assertNotEqual(Su_mix, Su_multi)
+        assertNear(Su_mix, Su_multi, 5e-2)
+        assert Su_mix != Su_multi
 
         # Flame speed with Soret effect should be similar but not identical to
         # the multicomponent flame speed
         self.sim.soret_enabled = True
         self.sim.solve(loglevel=0, refine_grid=True)
-        self.assertTrue(self.sim.soret_enabled)
+        assert self.sim.soret_enabled
         Su_soret = self.sim.velocity[0]
 
-        self.assertNear(Su_multi, Su_soret, 2e-1)
-        self.assertNotEqual(Su_multi, Su_soret)
+        assertNear(Su_multi, Su_soret, 2e-1)
+        assert Su_multi != Su_soret
 
     def test_unity_lewis(self):
         self.create_sim(ct.one_atm, 300, 'H2:1.1, O2:1, AR:5.3')
@@ -513,7 +523,7 @@ class TestFreeFlame(utilities.CanteraTest):
 
         # deviation of enthalpy should be much lower for unity Le model (tends
         # towards zero as grid is refined)
-        self.assertLess(dh_unity_lewis, 0.1 * dh_mix)
+        assert dh_unity_lewis < 0.1 * dh_mix
 
     def test_flux_gradient_mass(self):
         self.create_sim(ct.one_atm, 300, 'H2:1.1, O2:1, AR:5.3')
@@ -536,10 +546,10 @@ class TestFreeFlame(utilities.CanteraTest):
         # multicomponent transport results in an error
 
         self.create_sim(101325, 300, 'H2:1.0, O2:1.0')
-        self.assertFalse(self.sim.soret_enabled)
-        self.assertFalse(self.sim.transport_model == 'multicomponent')
+        assert not self.sim.soret_enabled
+        assert not self.sim.transport_model == 'multicomponent'
 
-        with self.assertRaisesRegex(ct.CanteraError, 'requires.*multicomponent'):
+        with pytest.raises(ct.CanteraError, match='requires.*multicomponent'):
             self.sim.soret_enabled = True
             self.sim.solve(loglevel=0, auto=False)
 
@@ -578,7 +588,7 @@ class TestFreeFlame(utilities.CanteraTest):
         self.solve_mix(slope=0.5, curve=0.3, prune=0.1)
         N2 = len(self.sim.grid)
 
-        self.assertLess(N2, N1)
+        assert N2 < N1
 
         # TODO: check that the solution is actually correct (that is, that the
         # residual satisfies the error tolerances) on the new grid.
@@ -640,24 +650,24 @@ class TestFreeFlame(utilities.CanteraTest):
         # Sim is initially in "steady-state" mode, so this returns the
         # steady-state tolerances
         rtol, atol = self.sim.flame.tolerances("T")
-        self.assertNear(rtol, T_rtol)
-        self.assertNear(atol, T_atol)
-        self.assertFalse(self.sim.energy_enabled)
+        assertNear(rtol, T_rtol)
+        assertNear(atol, T_atol)
+        assert not self.sim.energy_enabled
 
         P2a = self.sim.P
 
-        self.assertNear(p, P1)
-        self.assertNear(P1, P2a)
+        assertNear(p, P1)
+        assertNear(P1, P2a)
 
         Y2 = self.sim.Y
         u2 = self.sim.velocity
         V2 = self.sim.spread_rate
         T2 = self.sim.T
 
-        self.assertArrayNear(Y1, Y2)
-        self.assertArrayNear(u1, u2)
-        self.assertArrayNear(V1, V2)
-        self.assertArrayNear(T1, T2)
+        assertArrayNear(Y1, Y2)
+        assertArrayNear(u1, u2)
+        assertArrayNear(V1, V2)
+        assertArrayNear(T1, T2)
 
         self.solve_fixed_T()
         Y3 = self.sim.Y
@@ -666,16 +676,16 @@ class TestFreeFlame(utilities.CanteraTest):
 
         # TODO: These tolerances seem too loose, but the tests fail on some
         # systems with tighter tolerances.
-        self.assertArrayNear(Y1, Y3, 3e-3)
-        self.assertArrayNear(u1, u3, 1e-3)
-        self.assertArrayNear(V1, V3, 1e-3)
+        assertArrayNear(Y1, Y3, 3e-3)
+        assertArrayNear(u1, u3, 1e-3)
+        assertArrayNear(V1, V3, 1e-3)
 
-        self.assertFalse(self.sim.radiation_enabled)
-        self.assertFalse(self.sim.soret_enabled)
+        assert not self.sim.radiation_enabled
+        assert not self.sim.soret_enabled
 
         self.sim.restore(filename, "test2")
-        self.assertTrue(self.sim.radiation_enabled)
-        self.assertEqual(self.sim.boundary_emissivities, (0.3, 0.8))
+        assert self.sim.radiation_enabled
+        assert self.sim.boundary_emissivities == (0.3, 0.8)
 
         self.sim.solve(loglevel=0)
 
@@ -747,12 +757,12 @@ class TestFreeFlame(utilities.CanteraTest):
         T2 = self.sim.T
         Y2 = self.sim.Y
 
-        self.assertTrue(self.sim.soret_enabled)
-        self.assertEqual(self.sim.max_grid_points, 234)
-        self.assertArrayNear(T1, T2)
+        assert self.sim.soret_enabled
+        assert self.sim.max_grid_points == 234
+        assertArrayNear(T1, T2)
         for k1, species in enumerate(gas1.species_names):
             k2 = gas2.species_index(species)
-            self.assertArrayNear(Y1[k1], Y2[k2])
+            assertArrayNear(Y1[k1], Y2[k2])
 
     @utilities.slow_test
     def test_save_restore_remove_species_yaml(self):
@@ -779,10 +789,10 @@ class TestFreeFlame(utilities.CanteraTest):
         T2 = self.sim.T
         Y2 = self.sim.Y
 
-        self.assertArrayNear(T1, T2)
+        assertArrayNear(T1, T2)
         for k2, species in enumerate(gas2.species_names):
             k1 = gas1.species_index(species)
-            self.assertArrayNear(Y1[k1], Y2[k2])
+            assertArrayNear(Y1[k1], Y2[k2])
 
     def test_write_csv(self):
         filename = self.test_work_path / "onedim-save.csv"
@@ -792,10 +802,10 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.save(filename, basis="mole")
         data = ct.SolutionArray(self.gas)
         data.read_csv(filename)
-        self.assertArrayNear(data.grid, self.sim.grid)
-        self.assertArrayNear(data.T, self.sim.T)
+        assertArrayNear(data.grid, self.sim.grid)
+        assertArrayNear(data.T, self.sim.T)
         k = self.gas.species_index('H2')
-        self.assertArrayNear(data.X[:, k], self.sim.X[k, :])
+        assertArrayNear(data.X[:, k], self.sim.X[k, :])
 
     @pytest.mark.usefixtures("allow_deprecated")
     @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
@@ -877,7 +887,7 @@ class TestFreeFlame(utilities.CanteraTest):
 
         self.sim.set_refine_criteria(*good)
         for i in range(4):
-            with self.assertRaisesRegex(ct.CanteraError, 'Refiner::setCriteria'):
+            with pytest.raises(ct.CanteraError, match='Refiner::setCriteria'):
                 vals = list(good)
                 vals[i] = bad[i]
                 self.sim.set_refine_criteria(*vals)
@@ -887,7 +897,7 @@ class TestFreeFlame(utilities.CanteraTest):
         vals = {'ratio': 3.0, 'slope': 0.1, 'curve': 0.2, 'prune': 0.05}
         self.sim.set_refine_criteria(**vals)
         check = self.sim.get_refine_criteria()
-        self.assertEqual(vals, check)
+        assert vals == check
 
     def test_replace_grid(self):
         self.create_sim(ct.one_atm, 300.0, 'H2:1.1, O2:1, AR:5')
@@ -902,35 +912,37 @@ class TestFreeFlame(utilities.CanteraTest):
         self.sim.set_initial_guess()
 
         self.solve_fixed_T()
-        self.assertNear(self.sim.velocity[-1], ub, 1e-2)
+        assertNear(self.sim.velocity[-1], ub, 1e-2)
 
     def test_exceed_max_grid_points(self):
         self.create_sim(ct.one_atm, 400.0, 'H2:1.1, O2:1, AR:5')
         # Set the maximum grid points to be a low number that should
         # be exceeded by the refinement
         self.sim.max_grid_points = 10
-        with self.assertRaisesRegex(ct.CanteraError, 'max number of grid points'):
+        with pytest.raises(ct.CanteraError, match='max number of grid points'):
             self.sim.solve(loglevel=0, refine_grid=True)
 
     def test_set_max_grid_points(self):
         self.create_sim(ct.one_atm, 400.0, 'H2:1.1, O2:1, AR:5')
-        self.assertEqual(self.sim.max_grid_points, 1000)
+        assert self.sim.max_grid_points == 1000
         self.sim.max_grid_points = 10
-        self.assertEqual(self.sim.max_grid_points, 10)
+        assert self.sim.max_grid_points == 10
 
 
-class TestDiffusionFlame(utilities.CanteraTest):
-    # Note: to re-create the reference files:
-    # (1) set PYTHONPATH to build/python.
-    # (2) Start Python and run:
-    #     >>> import cantera.test
-    #     >>> t = cantera.test.test_onedim.TestDiffusionFlame()
-    #     >>> t.setup_class()
-    #     >>> t.test_mixture_averaged(True)
-    #     >>> t.test_auto(True)
-    #     >>> t.test_mixture_averaged_rad(True)
-    # (3) Compare the reference files created in the current working directory with
-    #     the ones in test/data and replace them if needed.
+class TestDiffusionFlame:
+    """
+    Note: to re-create the reference files:
+    (1) set PYTHONPATH to build/python.
+    (2) Start Python and run:
+        >>> import cantera.test
+        >>> t = cantera.test.test_onedim.TestDiffusionFlame()
+        >>> t.setup_class()
+        >>> t.test_mixture_averaged(True)
+        >>> t.test_auto(True)
+        >>> t.test_mixture_averaged_rad(True)
+    (3) Compare the reference files created in the current working directory with
+        the ones in test/data and replace them if needed.
+    """
 
     def create_sim(self, p, fuel='H2:1.0, AR:1.0', T_fuel=300, mdot_fuel=0.24,
                    oxidizer='O2:0.2, AR:0.8', T_ox=300, mdot_ox=0.72, width=0.02):
@@ -956,7 +968,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
         self.sim.energy_enabled = False
         self.sim.solve(loglevel=0, refine_grid=False)
 
-        self.assertFalse(self.sim.energy_enabled)
+        assert not self.sim.energy_enabled
 
     def solve_mix(self, ratio=3.0, slope=0.1, curve=0.12, prune=0.0):
         # Solve with the energy equation enabled
@@ -965,8 +977,8 @@ class TestDiffusionFlame(utilities.CanteraTest):
         self.sim.energy_enabled = True
         self.sim.solve(loglevel=0, refine_grid=True)
 
-        self.assertTrue(self.sim.energy_enabled)
-        self.assertEqual(self.sim.transport_model, 'mixture-averaged')
+        assert self.sim.energy_enabled
+        assert self.sim.transport_model == 'mixture-averaged'
 
     @utilities.slow_test
     def test_mixture_averaged(self, saveReference=False):
@@ -977,8 +989,8 @@ class TestDiffusionFlame(utilities.CanteraTest):
         nPoints = len(self.sim.grid)
         Tfixed = self.sim.T
         self.solve_fixed_T()
-        self.assertEqual(nPoints, len(self.sim.grid))
-        self.assertArrayNear(Tfixed, self.sim.T)
+        assert nPoints == len(self.sim.grid)
+        assertArrayNear(Tfixed, self.sim.T)
 
         self.solve_mix()
         data = np.empty((self.sim.flame.n_points, self.gas.n_species + 4))
@@ -991,9 +1003,9 @@ class TestDiffusionFlame(utilities.CanteraTest):
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = utilities.compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(self.test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
-            self.assertFalse(bad, bad)
+            assert not bad, bad
 
     def test_auto(self, saveReference=False):
         referenceFile = "DiffusionFlameTest-h2-auto.csv"
@@ -1008,7 +1020,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
 
         def time_step_func(dt):
             timesteps.append(dt)
-            self.assertGreater(dt, 0)
+            assert dt > 0
             return 0
 
         self.sim.set_steady_callback(steady_func)
@@ -1017,8 +1029,8 @@ class TestDiffusionFlame(utilities.CanteraTest):
         self.sim.set_refine_criteria(ratio=3.0, slope=0.1, curve=0.12, prune=0.0)
         self.sim.solve(loglevel=0, auto=True)
 
-        self.assertNotEqual(len(nPoints), 0)
-        self.assertNotEqual(len(timesteps), 0)
+        assert len(nPoints) != 0
+        assert len(timesteps) != 0
 
         data = np.empty((self.sim.flame.n_points, self.gas.n_species + 4))
         data[:,0] = self.sim.grid
@@ -1030,15 +1042,15 @@ class TestDiffusionFlame(utilities.CanteraTest):
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = utilities.compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(self.test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
-            self.assertFalse(bad, bad)
+            assert not bad, bad
 
     def run_extinction(self, mdot_fuel, mdot_ox, T_ox, width, P):
         self.create_sim(fuel='H2:1.0', oxidizer='O2:1.0', p=ct.one_atm*P,
                         mdot_fuel=mdot_fuel, mdot_ox=mdot_ox, T_ox=T_ox, width=width)
         self.sim.solve(loglevel=0, auto=True)
-        self.assertFalse(self.sim.extinct())
+        assert not self.sim.extinct()
 
     def test_extinction_case1(self):
         self.run_extinction(mdot_fuel=0.5, mdot_ox=3.0, T_ox=300, width=0.018, P=1.0)
@@ -1080,9 +1092,9 @@ class TestDiffusionFlame(utilities.CanteraTest):
 
         # Check inlet
         mdot = self.sim.density * self.sim.velocity
-        self.assertNear(mdot[0], self.sim.fuel_inlet.mdot, 1e-4)
-        self.assertNear(self.sim.T[0], self.sim.fuel_inlet.T, 1e-4)
-        self.assertNear(mdot[-1], -self.sim.oxidizer_inlet.mdot, 1e-4)
+        assertNear(mdot[0], self.sim.fuel_inlet.mdot, 1e-4)
+        assertNear(self.sim.T[0], self.sim.fuel_inlet.T, 1e-4)
+        assertNear(mdot[-1], -self.sim.oxidizer_inlet.mdot, 1e-4)
 
     def test_mixture_averaged_rad(self, saveReference=False):
         referenceFile = "DiffusionFlameTest-h2-mix-rad.csv"
@@ -1092,11 +1104,11 @@ class TestDiffusionFlame(utilities.CanteraTest):
         nPoints = len(self.sim.grid)
         Tfixed = self.sim.T
         self.solve_fixed_T()
-        self.assertEqual(nPoints, len(self.sim.grid))
-        self.assertArrayNear(Tfixed, self.sim.T)
-        self.assertFalse(self.sim.radiation_enabled)
+        assert nPoints == len(self.sim.grid)
+        assertArrayNear(Tfixed, self.sim.T)
+        assert not self.sim.radiation_enabled
         self.sim.radiation_enabled = True
-        self.assertTrue(self.sim.radiation_enabled)
+        assert self.sim.radiation_enabled
         self.sim.flame.boundary_emissivities = 0.25, 0.15
 
         self.solve_mix()
@@ -1108,14 +1120,14 @@ class TestDiffusionFlame(utilities.CanteraTest):
         data[:,4:] = self.sim.Y.T
 
         qdot = self.sim.flame.radiative_heat_loss
-        self.assertEqual(len(qdot), self.sim.flame.n_points)
+        assert len(qdot) == self.sim.flame.n_points
 
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = utilities.compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(self.test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
-            self.assertFalse(bad, bad)
+            assert not bad, bad
 
         filename = self.test_work_path / "DiffusionFlameTest-h2-mix-rad.csv"
         # In Python >= 3.8, this can be replaced by the missing_ok argument
@@ -1123,9 +1135,9 @@ class TestDiffusionFlame(utilities.CanteraTest):
             filename.unlink()
 
         self.sim.save(filename, basis="mole") # check output
-        self.assertTrue(filename.is_file())
+        assert filename.is_file()
         csv_data = np.genfromtxt(filename, dtype=float, delimiter=',', names=True)
-        self.assertIn('radiativeheatloss', csv_data.dtype.names)
+        assert 'radiativeheatloss' in csv_data.dtype.names
 
     def test_strain_rate(self):
         # This doesn't test that the values are correct, just that they can be
@@ -1141,32 +1153,32 @@ class TestDiffusionFlame(utilities.CanteraTest):
         a_stoich1 = self.sim.strain_rate('stoichiometric', fuel='H2')
         a_stoich2 = self.sim.strain_rate('stoichiometric', fuel='H2', stoich=0.5)
 
-        self.assertLessEqual(a_mean, a_max)
-        self.assertLessEqual(a_pf_fuel, a_max)
-        self.assertLessEqual(a_pf_oxidizer, a_max)
-        self.assertLessEqual(a_stoich1, a_max)
-        self.assertEqual(a_stoich1, a_stoich2)
+        assert a_mean <= a_max
+        assert a_pf_fuel <= a_max
+        assert a_pf_oxidizer <= a_max
+        assert a_stoich1 <= a_max
+        assert a_stoich1 == a_stoich2
 
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.sim.strain_rate('bad_keyword')
-        with self.assertRaises(KeyError): # missing 'fuel'
+        with pytest.raises(KeyError): # missing 'fuel'
             self.sim.strain_rate('stoichiometric')
-        with self.assertRaises(KeyError): # missing 'stoich'
+        with pytest.raises(KeyError): # missing 'stoich'
             self.sim.strain_rate('stoichiometric', fuel='H2', oxidizer='H2O2')
 
     def test_mixture_fraction(self):
         self.create_sim(p=ct.one_atm)
         self.sim.set_initial_guess()
         Z = self.sim.mixture_fraction('H')
-        self.assertNear(Z[0], 1.0)
-        self.assertNear(Z[-1], 0.0)
-        self.assertTrue(all(Z >= 0))
-        self.assertTrue(all(Z <= 1.0))
+        assertNear(Z[0], 1.0)
+        assertNear(Z[-1], 0.0)
+        assert all(Z >= 0)
+        assert all(Z <= 1.0)
         Z = self.sim.mixture_fraction('Bilger')
-        self.assertNear(Z[0], 1.0)
-        self.assertNear(Z[-1], 0.0)
-        self.assertTrue(all(Z >= 0))
-        self.assertTrue(all(Z <= 1.0))
+        assertNear(Z[0], 1.0)
+        assertNear(Z[-1], 0.0)
+        assert all(Z >= 0)
+        assert all(Z <= 1.0)
 
     def test_equivalence_ratio(self):
         self.create_sim(p=ct.one_atm)
@@ -1194,7 +1206,6 @@ class TestDiffusionFlame(utilities.CanteraTest):
         sim.oxidizer_inlet.X = "O2: 1.0, N2: 3.76"
         sim.fuel_inlet.X = "H2: 1.0"
         sim.set_initial_guess()
-
 
     def test_two_point_control(self):
         """
@@ -1251,7 +1262,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
         temperature_2 = sim.T
 
         # Check difference between the two solutions
-        self.assertArrayNear(temperature_1, temperature_2, rtol=1e-4, atol=1e-6)
+        assertArrayNear(temperature_1, temperature_2, rtol=1e-4, atol=1e-6)
 
 
         # Test - See if the solution is the same when the temperature is decremented and
@@ -1269,7 +1280,7 @@ class TestDiffusionFlame(utilities.CanteraTest):
 
         # Check the difference between the un-perturbed two-point solution and the
         # round-trip solution.
-        self.assertArrayNear(temperature_2, temperature_4, rtol=1e-4, atol=1e-6)
+        assertArrayNear(temperature_2, temperature_4, rtol=1e-4, atol=1e-6)
 
         # Test 4 - Checking property setters/getters
         val_1 = sim.right_control_point_temperature
@@ -1280,7 +1291,6 @@ class TestDiffusionFlame(utilities.CanteraTest):
         val_2 = sim.left_control_point_temperature
         sim.left_control_point_temperature += increment
         assert sim.left_control_point_temperature == val_2 + increment
-
 
         # Test - Check if the parameters are saved and restored correctly
         filename = self.test_work_path / "two_point_control.yaml"
@@ -1351,16 +1361,18 @@ class TestDiffusionFlame(utilities.CanteraTest):
             sim.right_control_point_temperature
 
 
-class TestCounterflowPremixedFlame(utilities.CanteraTest):
-    # Note: to re-create the reference file:
-    # (1) set PYTHONPATH to build/python.
-    # (2) Start Python and run:
-    #     >>> import cantera.test
-    #     >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlame()
-    #     >>> t.setup_class()
-    #     >>> t.test_mixture_averaged(True)
-    # (3) Compare the reference files created in the current working directory with
-    #     the ones in test/data and replace them if needed.
+class TestCounterflowPremixedFlame:
+    """
+    Note: to re-create the reference file:
+    (1) set PYTHONPATH to build/python.
+    (2) Start Python and run:
+        >>> import cantera.test
+        >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlame()
+        >>> t.setup_class()
+        >>> t.test_mixture_averaged(True)
+    (3) Compare the reference files created in the current working directory with
+        the ones in test/data and replace them if needed.
+    """
 
     def test_mixture_averaged(self, saveReference=False):
         T_in = 373.0  # inlet temperature
@@ -1387,7 +1399,7 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
 
         sim.set_refine_criteria(ratio=3, slope=0.2, curve=0.4, prune=0.02)
         sim.energy_enabled = True
-        self.assertFalse(sim.radiation_enabled)
+        assert not sim.radiation_enabled
         sim.solve(loglevel=0, refine_grid=True)
 
         data = np.empty((sim.flame.n_points, gas.n_species + 4))
@@ -1401,17 +1413,17 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = utilities.compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(self.test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
-            self.assertFalse(bad, bad)
+            assert not bad, bad
 
         filename = self.test_work_path / "CounterflowPremixedFlame-h2-mix.csv"
         filename.unlink(missing_ok=True)
 
         sim.save(filename) # check output
-        self.assertTrue(filename.is_file())
+        assert filename.is_file()
         csv_data = np.genfromtxt(filename, dtype=float, delimiter=',', names=True)
-        self.assertNotIn('qdot', csv_data.dtype.names)
+        assert 'qdot' not in csv_data.dtype.names
 
     def run_case(self, phi, T, width, P):
         gas = ct.Solution("h2o2.yaml")
@@ -1421,8 +1433,8 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
         sim.products.mdot = 5 * gas.density
         sim.set_refine_criteria(ratio=6, slope=0.7, curve=0.8, prune=0.2)
         sim.solve(loglevel=0, auto=True)
-        self.assertTrue(all(sim.T >= T - 1e-3))
-        self.assertTrue(all(sim.spread_rate >= -1e-9))
+        assert all(sim.T >= T - 1e-3)
+        assert all(sim.spread_rate >= -1e-9)
         assert np.allclose(sim.L, sim.L[0])
         return sim
 
@@ -1458,8 +1470,8 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
 
         # Check inlet / outlet
         mdot = sim.density * sim.velocity
-        self.assertNear(mdot[0], sim.reactants.mdot, 1e-4)
-        self.assertNear(mdot[-1], -sim.products.mdot, 1e-4)
+        assertNear(mdot[0], sim.reactants.mdot, 1e-4)
+        assertNear(mdot[-1], -sim.products.mdot, 1e-4)
 
     def test_bad_boundary_conditions(self):
         gas = ct.Solution("h2o2.yaml")
@@ -1469,16 +1481,18 @@ class TestCounterflowPremixedFlame(utilities.CanteraTest):
             sim.solve(loglevel=0)
 
 
-class TestCounterflowPremixedFlameNonIdeal(utilities.CanteraTest):
-    # Note: to re-create the reference file:
-    # (1) set PYTHONPATH to build/python.
-    # (2) Start Python and run:
-    #     >>> import cantera.test
-    #     >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlameNonIdeal()
-    #     >>> t.setup_class()
-    #     >>> t.test_mixture_averaged(True)
-    # (3) Compare the reference files created in the current working directory with
-    #     the ones in test/data and replace them if needed.
+class TestCounterflowPremixedFlameNonIdeal:
+    """
+    Note: to re-create the reference file:
+    (1) set PYTHONPATH to build/python.
+    (2) Start Python and run:
+        >>> import cantera.test
+        >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlameNonIdeal()
+        >>> t.setup_class()
+        >>> t.test_mixture_averaged(True)
+    (3) Compare the reference files created in the current working directory with
+        the ones in test/data and replace them if needed.
+    """
 
     def test_mixture_averaged(self, saveReference=False):
         T_in = 373.0  # inlet temperature
@@ -1505,7 +1519,7 @@ class TestCounterflowPremixedFlameNonIdeal(utilities.CanteraTest):
 
         sim.set_refine_criteria(ratio=3, slope=0.2, curve=0.4, prune=0.02)
         sim.energy_enabled = True
-        self.assertFalse(sim.radiation_enabled)
+        assert not sim.radiation_enabled
         sim.solve(loglevel=0, refine_grid=True)
 
         data = np.empty((sim.flame.n_points, gas.n_species + 4))
@@ -1519,54 +1533,53 @@ class TestCounterflowPremixedFlameNonIdeal(utilities.CanteraTest):
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = utilities.compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(self.test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
-            self.assertFalse(bad, bad)
+            assert not bad, bad
 
         filename = self.test_work_path / "CounterflowPremixedFlame-h2-mix-RK.csv"
         filename.unlink(missing_ok=True)
 
         sim.save(filename) # check output
-        self.assertTrue(filename.is_file())
+        assert filename.is_file()
         csv_data = np.genfromtxt(filename, dtype=float, delimiter=',', names=True)
-        self.assertNotIn('qdot', csv_data.dtype.names)
+        assert 'qdot' not in csv_data.dtype.names
 
-    def run_case(self, phi, T, width, P):
-        gas = ct.Solution("h2o2.yaml", "ohmech-RK")
-        gas.TPX = T, P * ct.one_atm, {'H2':phi, 'O2':0.5, 'AR':3}
-        sim = ct.CounterflowPremixedFlame(gas=gas, width=width)
-        sim.reactants.mdot = 10 * gas.density
-        sim.products.mdot = 5 * gas.density
-        sim.set_refine_criteria(ratio=6, slope=0.7, curve=0.8, prune=0.2)
-        sim.solve(loglevel=0, auto=True)
-        self.assertTrue(all(sim.T >= T - 1e-3))
-        self.assertTrue(all(sim.spread_rate >= -1e-9))
-        assert np.allclose(sim.L, sim.L[0])
-        return sim
+    @pytest.fixture(scope='function')
+    def run_case(self):
+        """Helper function to create and run a simulation case."""
+        def _run_case(phi, T, width, P):
+            gas = ct.Solution("h2o2.yaml", "ohmech-RK")
+            gas.TPX = T, P * ct.one_atm, {'H2': phi, 'O2': 0.5, 'AR': 3}
+            sim = ct.CounterflowPremixedFlame(gas=gas, width=width)
+            sim.reactants.mdot = 10 * gas.density
+            sim.products.mdot = 5 * gas.density
+            sim.set_refine_criteria(ratio=6, slope=0.7, curve=0.8, prune=0.2)
+            sim.solve(loglevel=0, auto=True)
+            assert all(sim.T >= T - 1e-3)
+            assert all(sim.spread_rate >= -1e-9)
+            assert np.allclose(sim.L, sim.L[0])
+            return sim
+        return _run_case
+
+    @pytest.mark.parametrize(
+        "phi, T, width, P",
+        [
+            (0.4, 400, 0.05, 10.0),
+            (0.5, 500, 0.03, 2.0),
+            (0.7, 300, 0.05, 2.0),
+            (1.5, 400, 0.03, 0.02),
+            (2.0, 300, 0.2, 0.2),
+        ]
+    )
+    @utilities.slow_test
+    def test_solve_cases(self, run_case, phi, T, width, P):
+        """Parameterized test cases for different simulation setups"""
+        run_case(phi, T, width, P)
 
     @utilities.slow_test
-    def test_solve_case1(self):
-        self.run_case(phi=0.4, T=400, width=0.05, P=10.0)
-
-    @utilities.slow_test
-    def test_solve_case2(self):
-        self.run_case(phi=0.5, T=500, width=0.03, P=2.0)
-
-    @utilities.slow_test
-    def test_solve_case3(self):
-        self.run_case(phi=0.7, T=300, width=0.05, P=2.0)
-
-    @utilities.slow_test
-    def test_solve_case4(self):
-        self.run_case(phi=1.5, T=400, width=0.03, P=0.02)
-
-    @utilities.slow_test
-    def test_solve_case5(self):
-        self.run_case(phi=2.0, T=300, width=0.2, P=0.2)
-
-    @utilities.slow_test
-    def test_restart(self):
-        sim = self.run_case(phi=2.0, T=300, width=0.2, P=0.2)
+    def test_restart(self, run_case):
+        sim = run_case(phi=2.0, T=300, width=0.2, P=0.2)
 
         arr = sim.to_array()
         sim.reactants.mdot *= 1.1
@@ -1576,37 +1589,48 @@ class TestCounterflowPremixedFlameNonIdeal(utilities.CanteraTest):
 
         # Check inlet / outlet
         mdot = sim.density * sim.velocity
-        self.assertNear(mdot[0], sim.reactants.mdot, 1e-4)
-        self.assertNear(mdot[-1], -sim.products.mdot, 1e-4)
+        assertNear(mdot[0], sim.reactants.mdot, 1e-4)
+        assertNear(mdot[-1], -sim.products.mdot, 1e-4)
 
-class TestBurnerFlame(utilities.CanteraTest):
+
+class TestBurnerFlame:
+
+    @pytest.fixture(scope='function')
+    def run_case(self):
+        """Helper function to create and run a simulation case."""
+        def _run_case(phi, T, width, P):
+            gas = ct.Solution("h2o2.yaml")
+            gas.TPX = T, ct.one_atm*P, {'H2':phi, 'O2':0.5, 'AR':1.5}
+            sim = ct.BurnerFlame(gas=gas, width=width)
+            sim.burner.mdot = gas.density * 0.15
+            sim.solve(loglevel=0, auto=True)
+            assert sim.T[1] > T
+            assert np.allclose(sim.L, 0)
+        return _run_case
+
     def solve(self, phi, T, width, P):
         gas = ct.Solution("h2o2.yaml")
         gas.TPX = T, ct.one_atm*P, {'H2':phi, 'O2':0.5, 'AR':1.5}
         sim = ct.BurnerFlame(gas=gas, width=width)
         sim.burner.mdot = gas.density * 0.15
         sim.solve(loglevel=0, auto=True)
-        self.assertGreater(sim.T[1], T)
+        assert sim.T[1] > T
         assert np.allclose(sim.L, 0)
 
-    def test_case1(self):
-        self.solve(phi=0.5, T=500, width=2.0, P=0.1)
-
+    @pytest.mark.parametrize(
+        "phi, T, width, P",
+        [
+            pytest.param(0.5, 500, 2.0, 0.1, id="case1"),
+            pytest.param(2.0, 400, 0.05, 1.0, marks=utilities.slow_test, id="case2"),
+            pytest.param(1.7, 300, 0.05, 1.0, marks=utilities.slow_test, id="case3"),
+            pytest.param(0.5, 300, 1.0, 5.0, marks=utilities.slow_test, id="case4"),
+            pytest.param(1.0, 400, 0.2, 0.01, marks=utilities.slow_test, id="case5"),
+        ]
+    )
     @utilities.slow_test
-    def test_case2(self):
-        self.solve(phi=2.0, T=400, width=0.05, P=1.0)
-
-    @utilities.slow_test
-    def test_case3(self):
-        self.solve(phi=1.7, T=300, width=0.05, P=1.0)
-
-    @utilities.slow_test
-    def test_case4(self):
-        self.solve(phi=0.5, T=300, width=1.0, P=5.0)
-
-    @utilities.slow_test
-    def test_case5(self):
-        self.solve(phi=1.0, T=400, width=0.2, P=0.01)
+    def test_solve_cases(self, run_case, phi, T, width, P):
+        """Parameterized test cases for different simulation setups"""
+        run_case(phi, T, width, P)
 
     def test_fixed_temp(self):
         gas = ct.Solution("h2o2.yaml")
@@ -1618,9 +1642,9 @@ class TestBurnerFlame(utilities.CanteraTest):
 
         sim.energy_enabled = False
         sim.solve(loglevel=0, refine_grid=True)
-        self.assertNear(sim.T[0], 400)
-        self.assertNear(sim.T[-1], 500)
-        self.assertNear(max(sim.T), 1100)
+        assertNear(sim.T[0], 400)
+        assertNear(sim.T[-1], 500)
+        assertNear(max(sim.T), 1100)
 
     def test_blowoff(self):
         gas = ct.Solution("h2o2.yaml")
@@ -1631,9 +1655,9 @@ class TestBurnerFlame(utilities.CanteraTest):
         sim.set_refine_criteria(ratio=3, slope=0.3, curve=0.5, prune=0)
         sim.solve(loglevel=0, auto=True)
         # nonreacting solution
-        self.assertNear(sim.T[-1], sim.T[0], 1e-6)
-        self.assertNear(sim.velocity[-1], sim.velocity[0], 1e-6)
-        self.assertArrayNear(sim.Y[:,0], sim.Y[:,-1], 1e-6, atol=1e-6)
+        assertNear(sim.T[-1], sim.T[0], 1e-6)
+        assertNear(sim.velocity[-1], sim.velocity[0], 1e-6)
+        assertArrayNear(sim.Y[:,0], sim.Y[:,-1], 1e-6, atol=1e-6)
 
     def test_restart(self):
         gas = ct.Solution("h2o2.yaml")
@@ -1652,12 +1676,14 @@ class TestBurnerFlame(utilities.CanteraTest):
         # Check continuity
         rhou = sim.burner.mdot
         for rhou_j in sim.density * sim.velocity:
-            self.assertNear(rhou_j, rhou, 1e-4)
+            assertNear(rhou_j, rhou, 1e-4)
 
+@pytest.fixture(scope='function')
+def setup_stagnation_tests(request):
+    request.cls.gas = ct.Solution("h2o2.yaml")
 
-class TestStagnationFlame(utilities.CanteraTest):
-    def setUp(self):
-        self.gas = ct.Solution("h2o2.yaml")
+@pytest.mark.usefixtures("setup_stagnation_tests")
+class TestStagnationFlame:
 
     def create_stagnation(self, comp, tsurf, tinlet, mdot, width):
         p = 0.05 * ct.one_atm  # pressure
@@ -1737,11 +1763,13 @@ class TestStagnationFlame(utilities.CanteraTest):
 
         jet.solve(loglevel=0)
 
+@pytest.fixture(scope='function')
+def setup_impinging_jet_tests(request):
+    request.cls.surf_phase = ct.Interface("ptcombust-simple.yaml", "Pt_surf")
+    request.cls.gas = request.cls.surf_phase.adjacent["gas"]
 
-class TestImpingingJet(utilities.CanteraTest):
-    def setUp(self):
-        self.surf_phase = ct.Interface("ptcombust-simple.yaml", "Pt_surf")
-        self.gas = self.surf_phase.adjacent["gas"]
+@pytest.mark.usefixtures("setup_impinging_jet_tests")
+class TestImpingingJet:
 
     def create_reacting_surface(self, comp, tsurf, tinlet, width):
         self.gas.TPX = tinlet, ct.one_atm, comp
@@ -1767,9 +1795,9 @@ class TestImpingingJet(utilities.CanteraTest):
 
         sim.solve(loglevel=0, auto=True)
 
-        self.assertTrue(all(np.diff(sim.T) > 0))
-        self.assertTrue(all(np.diff(sim.Y[sim.gas.species_index('CH4')]) < 0))
-        self.assertTrue(all(np.diff(sim.Y[sim.gas.species_index('CO2')]) > 0))
+        assert all(np.diff(sim.T) > 0)
+        assert all(np.diff(sim.Y[sim.gas.species_index('CH4')]) < 0)
+        assert all(np.diff(sim.Y[sim.gas.species_index('CO2')]) > 0)
         self.sim = sim
 
     def test_reacting_surface_case1(self):
@@ -1856,7 +1884,7 @@ class TestImpingingJet(utilities.CanteraTest):
         jet.solve(loglevel=0)
 
 
-class TestTwinFlame(utilities.CanteraTest):
+class TestTwinFlame:
     def solve(self, phi, T, width, P):
         gas = ct.Solution("h2o2.yaml")
         gas.TP = T, ct.one_atm
@@ -1866,7 +1894,7 @@ class TestTwinFlame(utilities.CanteraTest):
         axial_velocity = 2.0
         sim.reactants.mdot = gas.density * axial_velocity
         sim.solve(loglevel=0, auto=True)
-        self.assertGreater(sim.T[-1], T + 100)
+        assert sim.T[-1] > T + 100
         assert np.allclose(sim.L, sim.L[0])
         return sim
 
@@ -1882,8 +1910,8 @@ class TestTwinFlame(utilities.CanteraTest):
 
         # Check inlet
         mdot = sim.density * sim.velocity
-        self.assertNear(mdot[0], sim.reactants.mdot, 1e-4)
-        self.assertNear(sim.T[0], sim.reactants.T, 1e-4)
+        assertNear(mdot[0], sim.reactants.mdot, 1e-4)
+        assertNear(sim.T[0], sim.reactants.T, 1e-4)
 
     def test_save_restore_yaml(self):
         # save and restore using YAML format
@@ -1907,8 +1935,8 @@ class TestTwinFlame(utilities.CanteraTest):
         sim2 = ct.CounterflowTwinPremixedFlame(gas=gas)
         sim2.restore(filename)
 
-        self.assertArrayNear(sim.grid, sim2.grid)
-        self.assertArrayNear(sim.Y, sim2.Y)
+        assertArrayNear(sim.grid, sim2.grid)
+        assertArrayNear(sim.Y, sim2.Y)
 
         sim2.solve(loglevel=0)
         return filename, "solution"
@@ -1920,8 +1948,9 @@ class TestTwinFlame(utilities.CanteraTest):
         with pytest.raises(ct.CanteraError, match="must be positive"):
             sim.solve(loglevel=0)
 
-class TestIonFreeFlame(utilities.CanteraTest):
-    @utilities.slow_test
+class TestIonFreeFlame:
+
+    @pytest.mark.slow_test
     def test_ion_profile(self):
         reactants = 'CH4:0.216, O2:2'
         p = ct.one_atm
@@ -1944,10 +1973,10 @@ class TestIonFreeFlame(utilities.CanteraTest):
         self.sim.solve(loglevel=0, stage=2)
 
         # Regression test
-        self.assertNear(max(self.sim.E), 149.63179056676853, 1e-3)
+        assertNear(max(self.sim.E), 149.63179056676853, 1e-3)
 
 
-class TestIonBurnerFlame(utilities.CanteraTest):
+class TestIonBurnerFlame:
     def test_ion_profile(self):
         reactants = 'CH4:1.0, O2:2.0, N2:7.52'
         p = ct.one_atm
@@ -1965,5 +1994,5 @@ class TestIonBurnerFlame(utilities.CanteraTest):
         self.sim.solve(loglevel=0, stage=2, auto=True)
 
         # Regression test
-        self.assertNear(max(self.sim.E), 591.76, 1e-2)
-        self.assertNear(max(self.sim.X[self.gas.species_index('E')]), 8.024e-9, 1e-2)
+        assertNear(max(self.sim.E), 591.76, 1e-2)
+        assertNear(max(self.sim.X[self.gas.species_index('E')]), 8.024e-9, 1e-2)

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -807,10 +807,10 @@ class TestFreeFlame:
     @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
-    def test_restore_legacy_hdf(self):
+    def test_restore_legacy_hdf(self, test_data_path):
         # Legacy input file was created using the Cantera 2.6 Python test suite:
         # - restore_legacy.h5 -> test_onedim.py::TestFreeFlame::test_write_hdf
-        filename = self.test_data_path / f"freeflame_legacy.h5"
+        filename = test_data_path / f"freeflame_legacy.h5"
 
         self.run_mix(phi=1.1, T=350, width=2.0, p=2.0, refine=False)
         desc = 'mixture-averaged simulation'
@@ -976,7 +976,7 @@ class TestDiffusionFlame:
         assert self.sim.transport_model == 'mixture-averaged'
 
     @pytest.mark.slow_test
-    def test_mixture_averaged(self, saveReference=False):
+    def test_mixture_averaged(self, test_data_path, saveReference=False):
         referenceFile = "DiffusionFlameTest-h2-mix.csv"
         self.create_sim(p=ct.one_atm)
         self.sim.set_initial_guess()
@@ -998,11 +998,11 @@ class TestDiffusionFlame:
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
             assert not bad, bad
 
-    def test_auto(self, saveReference=False):
+    def test_auto(self, test_data_path, saveReference=False):
         referenceFile = "DiffusionFlameTest-h2-auto.csv"
         self.create_sim(p=ct.one_atm, mdot_fuel=2, mdot_ox=3)
 
@@ -1037,7 +1037,7 @@ class TestDiffusionFlame:
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
             assert not bad, bad
 
@@ -1091,7 +1091,7 @@ class TestDiffusionFlame:
         assert self.sim.T[0] == approx(self.sim.fuel_inlet.T, rel=1e-4)
         assert mdot[-1] == approx(-self.sim.oxidizer_inlet.mdot, rel=1e-4)
 
-    def test_mixture_averaged_rad(self, saveReference=False):
+    def test_mixture_averaged_rad(self, test_data_path, saveReference=False):
         referenceFile = "DiffusionFlameTest-h2-mix-rad.csv"
         self.create_sim(p=ct.one_atm)
         self.sim.set_initial_guess()
@@ -1120,7 +1120,7 @@ class TestDiffusionFlame:
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
             assert not bad, bad
 
@@ -1368,7 +1368,7 @@ class TestCounterflowPremixedFlame:
         the ones in test/data and replace them if needed.
     """
 
-    def test_mixture_averaged(self, saveReference=False):
+    def test_mixture_averaged(self, test_data_path, saveReference=False):
         T_in = 373.0  # inlet temperature
         comp = 'H2:1.6, O2:1, AR:7'  # premixed gas composition
 
@@ -1407,7 +1407,7 @@ class TestCounterflowPremixedFlame:
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
             assert not bad, bad
 
@@ -1487,7 +1487,7 @@ class TestCounterflowPremixedFlameNonIdeal:
         the ones in test/data and replace them if needed.
     """
 
-    def test_mixture_averaged(self, saveReference=False):
+    def test_mixture_averaged(self, test_data_path, saveReference=False):
         T_in = 373.0  # inlet temperature
         comp = 'H2:1.6, O2:1, AR:7'  # premixed gas composition
 
@@ -1526,7 +1526,7 @@ class TestCounterflowPremixedFlameNonIdeal:
         if saveReference:
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
-            bad = compareProfiles(self.test_data_path / referenceFile, data,
+            bad = compareProfiles(test_data_path / referenceFile, data,
                                             rtol=1e-2, atol=1e-8, xtol=1e-2)
             assert not bad, bad
 
@@ -1807,10 +1807,10 @@ class TestImpingingJet:
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
     @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
-    def test_restore_legacy_hdf(self):
+    def test_restore_legacy_hdf(self, test_data_path):
         # Legacy input file was created using the Cantera 2.6 Python test suite:
         # - restore_legacy.h5 -> test_onedim.py::TestImpingingJet::test_write_hdf
-        filename = self.test_data_path / f"impingingjet_legacy.h5"
+        filename = test_data_path / f"impingingjet_legacy.h5"
 
         self.run_reacting_surface(xch4=0.095, tsurf=900.0, mdot=0.06, width=0.1)
         jet = ct.ImpingingJet(gas=self.gas, surface=self.surf_phase)

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -4,8 +4,7 @@ from pytest import approx
 
 import cantera as ct
 
-from . import utilities
-from .utilities import allow_deprecated, yaml
+from .utilities import yaml
 from .utilities import (
     assertNear,
     assertArrayNear,
@@ -164,7 +163,6 @@ class TestOnedim:
             with pytest.raises(ValueError, match="mutually exclusive"):
                 sim = cls(gas, grid=[0, 0.1, 0.2], width=0.4)
 
-
 def check_component_order(fname: str, group: str):
     with fname.open("r", encoding="utf-8") as fid:
         reader = yaml.YAML(typ="safe")
@@ -244,7 +242,7 @@ class TestFreeFlame:
         assertNear(self.sim.fixed_temperature, tfixed)
         assertNear(self.sim.fixed_temperature_location, zfixed)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_auto_width(self):
         Tin = 300
         p = ct.one_atm
@@ -277,7 +275,7 @@ class TestFreeFlame:
         assert self.sim.grid[-1] < 2.0 # grid should not be too wide
         assert self.sim.flame.tolerances("T") == (2e-4, 1e-8)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_converge_adiabatic(self):
         # Test that the adiabatic flame temperature and species profiles
         # converge to the correct equilibrium values as the grid is refined
@@ -426,31 +424,31 @@ class TestFreeFlame:
     def test_mixture_averaged_case1(self):
         self.run_mix(phi=0.65, T=300, width=0.03, p=1.0, refine=True)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_mixture_averaged_case2(self):
         self.run_mix(phi=0.5, T=300, width=2.0, p=1.0, refine=False)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_mixture_averaged_case3(self):
         self.run_mix(phi=0.5, T=500, width=0.05, p=1.0, refine=False)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_mixture_averaged_case4(self):
         self.run_mix(phi=0.7, T=400, width=2.0, p=5.0, refine=False)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_mixture_averaged_case5(self):
         self.run_mix(phi=1.0, T=300, width=2.0, p=5.0, refine=False)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_mixture_averaged_case6(self):
         self.run_mix(phi=1.5, T=300, width=0.2, p=1.0, refine=True)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_mixture_averaged_case7(self):
         self.run_mix(phi=1.5, T=500, width=2.0, p=0.1, refine=False)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_mixture_averaged_case8(self):
         self.run_mix(phi=2.0, T=400, width=2.0, p=5.0, refine=False)
 
@@ -553,7 +551,7 @@ class TestFreeFlame:
             self.sim.soret_enabled = True
             self.sim.solve(loglevel=0, auto=False)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_soret_with_auto(self):
         # Test that auto solving with Soret enabled works
         self.create_sim(101325, 300, 'H2:2.0, O2:1.0')
@@ -729,7 +727,7 @@ class TestFreeFlame:
             flame_value = getattr(self.sim, attr)
             assert flame_value.shape == np.asarray(soln_value).shape + grid_shape
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_save_restore_add_species_yaml(self):
         reactants = "H2:1.1, O2:1, AR:5"
         p = 2 * ct.one_atm
@@ -764,7 +762,7 @@ class TestFreeFlame:
             k2 = gas2.species_index(species)
             assertArrayNear(Y1[k1], Y2[k2])
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_save_restore_remove_species_yaml(self):
         reactants = "H2:1.1, O2:1, AR:5"
         p = 2 * ct.one_atm
@@ -980,7 +978,7 @@ class TestDiffusionFlame:
         assert self.sim.energy_enabled
         assert self.sim.transport_model == 'mixture-averaged'
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_mixture_averaged(self, saveReference=False):
         referenceFile = "DiffusionFlameTest-h2-mix.csv"
         self.create_sim(p=ct.one_atm)
@@ -1055,31 +1053,31 @@ class TestDiffusionFlame:
     def test_extinction_case1(self):
         self.run_extinction(mdot_fuel=0.5, mdot_ox=3.0, T_ox=300, width=0.018, P=1.0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_extinction_case2(self):
         self.run_extinction(mdot_fuel=0.5, mdot_ox=1.0, T_ox=300, width=0.01, P=5.0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_extinction_case3(self):
         self.run_extinction(mdot_fuel=1.0, mdot_ox=0.5, T_ox=500, width=0.02, P=5.0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_extinction_case4(self):
         self.run_extinction(mdot_fuel=1.0, mdot_ox=3.0, T_ox=400, width=0.05, P=2.0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_extinction_case5(self):
         self.run_extinction(mdot_fuel=1.0, mdot_ox=3.0, T_ox=300, width=0.1, P=1.0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_extinction_case6(self):
         self.run_extinction(mdot_fuel=0.5, mdot_ox=0.5, T_ox=600, width=0.2, P=0.05)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_extinction_case7(self):
         self.run_extinction(mdot_fuel=0.2, mdot_ox=2.0, T_ox=600, width=0.2, P=0.05)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_restart(self):
         self.run_extinction(mdot_fuel=0.5, mdot_ox=3.0, T_ox=300, width=0.018, P=1.0)
 
@@ -1438,27 +1436,27 @@ class TestCounterflowPremixedFlame:
         assert np.allclose(sim.L, sim.L[0])
         return sim
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_solve_case1(self):
         self.run_case(phi=0.4, T=400, width=0.05, P=10.0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_solve_case2(self):
         self.run_case(phi=0.5, T=500, width=0.03, P=2.0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_solve_case3(self):
         self.run_case(phi=0.7, T=300, width=0.05, P=2.0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_solve_case4(self):
         self.run_case(phi=1.5, T=400, width=0.03, P=0.02)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_solve_case5(self):
         self.run_case(phi=2.0, T=300, width=0.2, P=0.2)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_restart(self):
         sim = self.run_case(phi=2.0, T=300, width=0.2, P=0.2)
 
@@ -1572,12 +1570,12 @@ class TestCounterflowPremixedFlameNonIdeal:
             (2.0, 300, 0.2, 0.2),
         ]
     )
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_solve_cases(self, run_case, phi, T, width, P):
         """Parameterized test cases for different simulation setups"""
         run_case(phi, T, width, P)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_restart(self, run_case):
         sim = run_case(phi=2.0, T=300, width=0.2, P=0.2)
 
@@ -1621,13 +1619,13 @@ class TestBurnerFlame:
         "phi, T, width, P",
         [
             pytest.param(0.5, 500, 2.0, 0.1, id="case1"),
-            pytest.param(2.0, 400, 0.05, 1.0, marks=utilities.slow_test, id="case2"),
-            pytest.param(1.7, 300, 0.05, 1.0, marks=utilities.slow_test, id="case3"),
-            pytest.param(0.5, 300, 1.0, 5.0, marks=utilities.slow_test, id="case4"),
-            pytest.param(1.0, 400, 0.2, 0.01, marks=utilities.slow_test, id="case5"),
+            pytest.param(2.0, 400, 0.05, 1.0, marks=pytest.mark.slow_test, id="case2"),
+            pytest.param(1.7, 300, 0.05, 1.0, marks=pytest.mark.slow_test, id="case3"),
+            pytest.param(0.5, 300, 1.0, 5.0, marks=pytest.mark.slow_test, id="case4"),
+            pytest.param(1.0, 400, 0.2, 0.01, marks=pytest.mark.slow_test, id="case5"),
         ]
     )
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_solve_cases(self, run_case, phi, T, width, P):
         """Parameterized test cases for different simulation setups"""
         run_case(phi, T, width, P)
@@ -1803,11 +1801,11 @@ class TestImpingingJet:
     def test_reacting_surface_case1(self):
         self.run_reacting_surface(xch4=0.095, tsurf=900.0, mdot=0.06, width=0.1)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_reacting_surface_case2(self):
         self.run_reacting_surface(xch4=0.07, tsurf=1200.0, mdot=0.2, width=0.05)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_reacting_surface_case3(self):
         self.run_reacting_surface(xch4=0.2, tsurf=800.0, mdot=0.1, width=0.2)
 

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -927,14 +927,12 @@ class TestFreeFlame:
 
 class TestDiffusionFlame:
     """
-    Note: to re-create the reference files:
-    (1) set PYTHONPATH to build/python.
-    (2) Start Python and run:
-        >>> import cantera.test
-        >>> t = cantera.test.test_onedim.TestDiffusionFlame()
-        >>> t.test_mixture_averaged(True)
-        >>> t.test_auto(True)
-        >>> t.test_mixture_averaged_rad(True)
+    Note: to re-create the reference file:
+    (1) Set PYTHONPATH to build/python.
+    (2) Go into test/python directory and run:
+        pytest --save-reference=diffusion test_onedim.py::TestDiffusionFlame::test_mixture_averaged
+        pytest --save-reference=diffusion test_onedim.py::TestDiffusionFlame::test_auto
+        pytest --save-reference=diffusion test_onedim.py::TestDiffusionFlame::test_mixture_averaged_rad
     (3) Compare the reference files created in the current working directory with
         the ones in test/data and replace them if needed.
     """
@@ -976,7 +974,7 @@ class TestDiffusionFlame:
         assert self.sim.transport_model == 'mixture-averaged'
 
     @pytest.mark.slow_test
-    def test_mixture_averaged(self, test_data_path, saveReference=False):
+    def test_mixture_averaged(self, request, test_data_path):
         referenceFile = "DiffusionFlameTest-h2-mix.csv"
         self.create_sim(p=ct.one_atm)
         self.sim.set_initial_guess()
@@ -995,14 +993,15 @@ class TestDiffusionFlame:
         data[:,3] = self.sim.T
         data[:,4:] = self.sim.Y.T
 
-        if saveReference:
+        saveReference = request.config.getoption("--save-reference")
+        if saveReference == 'diffusion':
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
             bad = compareProfiles(test_data_path / referenceFile, data,
                                   rtol=1e-2, atol=1e-8, xtol=1e-2)
             assert not bad, bad
 
-    def test_auto(self, test_data_path, saveReference=False):
+    def test_auto(self, request, test_data_path):
         referenceFile = "DiffusionFlameTest-h2-auto.csv"
         self.create_sim(p=ct.one_atm, mdot_fuel=2, mdot_ox=3)
 
@@ -1034,7 +1033,8 @@ class TestDiffusionFlame:
         data[:,3] = self.sim.T
         data[:,4:] = self.sim.Y.T
 
-        if saveReference:
+        saveReference = request.config.getoption("--save-reference")
+        if saveReference == 'diffusion':
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
             bad = compareProfiles(test_data_path / referenceFile, data,
@@ -1091,7 +1091,7 @@ class TestDiffusionFlame:
         assert self.sim.T[0] == approx(self.sim.fuel_inlet.T, rel=1e-4)
         assert mdot[-1] == approx(-self.sim.oxidizer_inlet.mdot, rel=1e-4)
 
-    def test_mixture_averaged_rad(self, test_data_path, saveReference=False):
+    def test_mixture_averaged_rad(self, request, test_data_path):
         referenceFile = "DiffusionFlameTest-h2-mix-rad.csv"
         self.create_sim(p=ct.one_atm)
         self.sim.set_initial_guess()
@@ -1117,7 +1117,8 @@ class TestDiffusionFlame:
         qdot = self.sim.flame.radiative_heat_loss
         assert len(qdot) == self.sim.flame.n_points
 
-        if saveReference:
+        saveReference = request.config.getoption("--save-reference")
+        if saveReference == 'diffusion':
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
             bad = compareProfiles(test_data_path / referenceFile, data,
@@ -1359,16 +1360,14 @@ class TestDiffusionFlame:
 class TestCounterflowPremixedFlame:
     """
     Note: to re-create the reference file:
-    (1) set PYTHONPATH to build/python.
-    (2) Start Python and run:
-        >>> import cantera.test
-        >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlame()
-        >>> t.test_mixture_averaged(True)
+    (1) Set PYTHONPATH to build/python.
+    (2) Go into test/python directory and run:
+        pytest --save-reference=counterflow_premixed test_onedim.py::TestCounterflowPremixedFlame::test_mixture_averaged
     (3) Compare the reference files created in the current working directory with
         the ones in test/data and replace them if needed.
     """
 
-    def test_mixture_averaged(self, test_data_path, saveReference=False):
+    def test_mixture_averaged(self, request, test_data_path):
         T_in = 373.0  # inlet temperature
         comp = 'H2:1.6, O2:1, AR:7'  # premixed gas composition
 
@@ -1404,7 +1403,8 @@ class TestCounterflowPremixedFlame:
         data[:,4:] = sim.Y.T
 
         referenceFile = "CounterflowPremixedFlame-h2-mix.csv"
-        if saveReference:
+        saveReference = request.config.getoption("--save-reference")
+        if saveReference == 'counterflow_premixed':
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
             bad = compareProfiles(test_data_path / referenceFile, data,
@@ -1477,16 +1477,14 @@ class TestCounterflowPremixedFlame:
 class TestCounterflowPremixedFlameNonIdeal:
     """
     Note: to re-create the reference file:
-    (1) set PYTHONPATH to build/python.
-    (2) Start Python and run:
-        >>> import cantera.test
-        >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlameNonIdeal()
-        >>> t.test_mixture_averaged(True)
+    (1) Set PYTHONPATH to build/python.
+    (2) Go into test/python directory and run:
+        pytest --save-reference=counterflow_premixed_nonideal test_onedim.py::TestCounterflowPremixedFlameNonIdeal::test_mixture_averaged
     (3) Compare the reference files created in the current working directory with
         the ones in test/data and replace them if needed.
     """
 
-    def test_mixture_averaged(self, test_data_path, saveReference=False):
+    def test_mixture_averaged(self, request, test_data_path):
         T_in = 373.0  # inlet temperature
         comp = 'H2:1.6, O2:1, AR:7'  # premixed gas composition
 
@@ -1522,7 +1520,8 @@ class TestCounterflowPremixedFlameNonIdeal:
         data[:,4:] = sim.Y.T
 
         referenceFile = "CounterflowPremixedFlame-h2-mix-RK.csv"
-        if saveReference:
+        saveReference = request.config.getoption("--save-reference")
+        if saveReference == 'counterflow_premixed_nonideal':
             np.savetxt(referenceFile, data, '%11.6e', ', ')
         else:
             bad = compareProfiles(test_data_path / referenceFile, data,

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -6,7 +6,6 @@ import cantera as ct
 
 from .utilities import yaml
 from .utilities import (
-    assertArrayNear,
     compareProfiles
 )
 
@@ -44,15 +43,15 @@ class TestOnedim:
         Yref = gas2.Y
         inlet.Y = Yref
 
-        assertArrayNear(inlet.Y, Yref)
-        assertArrayNear(inlet.X, Xref)
+        assert inlet.Y == approx(Yref)
+        assert inlet.X == approx(Xref)
 
         gas2.TPX = 400, 101325, 'H2:0.5, O2:0.2, AR:0.3'
         Xref = gas2.X
         Yref = gas2.Y
         inlet.X = Xref
-        assertArrayNear(inlet.X, Xref)
-        assertArrayNear(inlet.Y, Yref)
+        assert inlet.X == approx(Xref)
+        assert inlet.Y == approx(Yref)
 
         inlet.X = {'H2':0.3, 'O2':0.5, 'AR':0.2}
         assert inlet.X[gas2.species_index('H2')] == approx(0.3)
@@ -325,19 +324,19 @@ class TestFreeFlame:
         self.run_mix(phi=1.0, T=300, width=2.0, p=1.0, refine=False)
 
         flow = self.sim.to_array(normalize=True)
-        assertArrayNear(self.sim.grid, flow.grid)
-        assertArrayNear(self.sim.T, flow.T)
+        assert self.sim.grid == approx(flow.grid)
+        assert self.sim.T == approx(flow.T)
 
         f2 = ct.FreeFlame(self.gas)
         f2.from_array(flow)
-        assertArrayNear(self.sim.grid, f2.grid)
-        assertArrayNear(self.sim.T, f2.T)
+        assert self.sim.grid == approx(f2.grid)
+        assert self.sim.T == approx(f2.T)
 
         inlet = self.sim.to_array(self.sim.inlet)
         f2.from_array(inlet, f2.inlet)
         assert self.sim.inlet.T == approx(f2.inlet.T)
         assert self.sim.inlet.mdot == approx(f2.inlet.mdot)
-        assertArrayNear(self.sim.inlet.Y, f2.inlet.Y)
+        assert self.sim.inlet.Y == approx(f2.inlet.Y)
 
     def test_restart_array(self):
         # restart from SolutionArray
@@ -661,10 +660,10 @@ class TestFreeFlame:
         V2 = self.sim.spread_rate
         T2 = self.sim.T
 
-        assertArrayNear(Y1, Y2)
-        assertArrayNear(u1, u2)
-        assertArrayNear(V1, V2)
-        assertArrayNear(T1, T2)
+        assert Y1 == approx(Y2)
+        assert u1 == approx(u2)
+        assert V1 == approx(V2)
+        assert T1 == approx(T2)
 
         self.solve_fixed_T()
         Y3 = self.sim.Y
@@ -673,9 +672,9 @@ class TestFreeFlame:
 
         # TODO: These tolerances seem too loose, but the tests fail on some
         # systems with tighter tolerances.
-        assertArrayNear(Y1, Y3, 3e-3)
-        assertArrayNear(u1, u3, 1e-3)
-        assertArrayNear(V1, V3, 1e-3)
+        assert Y1 == approx(Y3, rel=3e-3)
+        assert u1 == approx(u3, rel=1e-3)
+        assert V1 == approx(V3, rel=1e-3)
 
         assert not self.sim.radiation_enabled
         assert not self.sim.soret_enabled
@@ -756,10 +755,10 @@ class TestFreeFlame:
 
         assert self.sim.soret_enabled
         assert self.sim.max_grid_points == 234
-        assertArrayNear(T1, T2)
+        assert T1 == approx(T2)
         for k1, species in enumerate(gas1.species_names):
             k2 = gas2.species_index(species)
-            assertArrayNear(Y1[k1], Y2[k2])
+            assert Y1[k1] == approx(Y2[k2])
 
     @pytest.mark.slow_test
     def test_save_restore_remove_species_yaml(self):
@@ -786,10 +785,10 @@ class TestFreeFlame:
         T2 = self.sim.T
         Y2 = self.sim.Y
 
-        assertArrayNear(T1, T2)
+        assert T1 == approx(T2)
         for k2, species in enumerate(gas2.species_names):
             k1 = gas1.species_index(species)
-            assertArrayNear(Y1[k1], Y2[k2])
+            assert Y1[k1] == approx(Y2[k2])
 
     def test_write_csv(self):
         filename = self.test_work_path / "onedim-save.csv"
@@ -799,10 +798,10 @@ class TestFreeFlame:
         self.sim.save(filename, basis="mole")
         data = ct.SolutionArray(self.gas)
         data.read_csv(filename)
-        assertArrayNear(data.grid, self.sim.grid)
-        assertArrayNear(data.T, self.sim.T)
+        assert data.grid == approx(self.sim.grid)
+        assert data.T == approx(self.sim.T)
         k = self.gas.species_index('H2')
-        assertArrayNear(data.X[:, k], self.sim.X[k, :])
+        assert data.X[:, k] == approx(self.sim.X[k, :])
 
     @pytest.mark.usefixtures("allow_deprecated")
     @pytest.mark.filterwarnings("ignore:.*legacy HDF.*:UserWarning")
@@ -986,7 +985,7 @@ class TestDiffusionFlame:
         Tfixed = self.sim.T
         self.solve_fixed_T()
         assert nPoints == len(self.sim.grid)
-        assertArrayNear(Tfixed, self.sim.T)
+        assert Tfixed == approx(self.sim.T)
 
         self.solve_mix()
         data = np.empty((self.sim.flame.n_points, self.gas.n_species + 4))
@@ -1101,7 +1100,7 @@ class TestDiffusionFlame:
         Tfixed = self.sim.T
         self.solve_fixed_T()
         assert nPoints == len(self.sim.grid)
-        assertArrayNear(Tfixed, self.sim.T)
+        assert Tfixed == approx(self.sim.T)
         assert not self.sim.radiation_enabled
         self.sim.radiation_enabled = True
         assert self.sim.radiation_enabled
@@ -1258,7 +1257,7 @@ class TestDiffusionFlame:
         temperature_2 = sim.T
 
         # Check difference between the two solutions
-        assertArrayNear(temperature_1, temperature_2, rtol=1e-4, atol=1e-6)
+        assert temperature_1 == approx(temperature_2, rel=1e-4, abs=1e-6)
 
 
         # Test - See if the solution is the same when the temperature is decremented and
@@ -1276,7 +1275,7 @@ class TestDiffusionFlame:
 
         # Check the difference between the un-perturbed two-point solution and the
         # round-trip solution.
-        assertArrayNear(temperature_2, temperature_4, rtol=1e-4, atol=1e-6)
+        assert temperature_2 == approx(temperature_4, rel=1e-4, abs=1e-6)
 
         # Test 4 - Checking property setters/getters
         val_1 = sim.right_control_point_temperature
@@ -1650,7 +1649,7 @@ class TestBurnerFlame:
         # nonreacting solution
         assert sim.T[-1] == approx(sim.T[0], rel=1e-6)
         assert sim.velocity[-1] == approx(sim.velocity[0], rel=1e-6)
-        assertArrayNear(sim.Y[:,0], sim.Y[:,-1], 1e-6, atol=1e-6)
+        assert sim.Y[:,0] == approx(sim.Y[:,-1], rel=1e-6, abs=1e-6)
 
     def test_restart(self):
         gas = ct.Solution("h2o2.yaml")
@@ -1928,8 +1927,8 @@ class TestTwinFlame:
         sim2 = ct.CounterflowTwinPremixedFlame(gas=gas)
         sim2.restore(filename)
 
-        assertArrayNear(sim.grid, sim2.grid)
-        assertArrayNear(sim.Y, sim2.Y)
+        assert sim.grid == approx(sim2.grid)
+        assert sim.Y == approx(sim2.Y)
 
         sim2.solve(loglevel=0)
         return filename, "solution"

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -934,7 +934,6 @@ class TestDiffusionFlame:
     (2) Start Python and run:
         >>> import cantera.test
         >>> t = cantera.test.test_onedim.TestDiffusionFlame()
-        >>> t.setup_class()
         >>> t.test_mixture_averaged(True)
         >>> t.test_auto(True)
         >>> t.test_mixture_averaged_rad(True)
@@ -1366,7 +1365,6 @@ class TestCounterflowPremixedFlame:
     (2) Start Python and run:
         >>> import cantera.test
         >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlame()
-        >>> t.setup_class()
         >>> t.test_mixture_averaged(True)
     (3) Compare the reference files created in the current working directory with
         the ones in test/data and replace them if needed.
@@ -1486,7 +1484,6 @@ class TestCounterflowPremixedFlameNonIdeal:
     (2) Start Python and run:
         >>> import cantera.test
         >>> t = cantera.test.test_onedim.TestCounterflowPremixedFlameNonIdeal()
-        >>> t.setup_class()
         >>> t.test_mixture_averaged(True)
     (3) Compare the reference files created in the current working directory with
         the ones in test/data and replace them if needed.

--- a/test/python/test_purefluid.py
+++ b/test/python/test_purefluid.py
@@ -1,92 +1,98 @@
 import itertools
 import numpy as np
+import pytest
 
 import cantera as ct
 from . import utilities
+from .utilities import (
+    assertNear,
+)
 
+@pytest.fixture(scope='function')
+def water(request):
+    request.cls.water = ct.Water()
 
-class TestPureFluid(utilities.CanteraTest):
+@pytest.mark.usefixtures("water")
+class TestPureFluid:
     """ Test functionality of the PureFluid class """
-    def setUp(self):
-        self.water = ct.Water()
 
     def test_critical_properties(self):
-        self.assertNear(self.water.critical_pressure, 22.089e6)
-        self.assertNear(self.water.critical_temperature, 647.286)
-        self.assertNear(self.water.critical_density, 317.0)
+        assertNear(self.water.critical_pressure, 22.089e6)
+        assertNear(self.water.critical_temperature, 647.286)
+        assertNear(self.water.critical_density, 317.0)
 
     def test_temperature_limits(self):
         co2 = ct.CarbonDioxide()
-        self.assertNear(co2.min_temp, 216.54)
-        self.assertNear(co2.max_temp, 1500.0)
+        assertNear(co2.min_temp, 216.54)
+        assertNear(co2.max_temp, 1500.0)
 
     def test_set_state(self):
         self.water.PQ = 101325, 0.5
-        self.assertNear(self.water.P, 101325)
-        self.assertNear(self.water.Q, 0.5)
+        assertNear(self.water.P, 101325)
+        assertNear(self.water.Q, 0.5)
 
         self.water.TQ = 500, 0.8
-        self.assertNear(self.water.T, 500)
-        self.assertNear(self.water.Q, 0.8)
+        assertNear(self.water.T, 500)
+        assertNear(self.water.Q, 0.8)
 
     def test_substance_set(self):
         self.water.TV = 400, 1.45
-        self.assertNear(self.water.T, 400)
-        self.assertNear(self.water.v, 1.45)
-        with self.assertRaisesRegex(ct.CanteraError, 'Negative specific volume'):
+        assertNear(self.water.T, 400)
+        assertNear(self.water.v, 1.45)
+        with pytest.raises(ct.CanteraError, match='Negative specific volume'):
             self.water.TV = 300, -1.
 
         self.water.PV = 101325, 1.45
-        self.assertNear(self.water.P, 101325)
-        self.assertNear(self.water.v, 1.45)
+        assertNear(self.water.P, 101325)
+        assertNear(self.water.v, 1.45)
 
         self.water.UP = -1.45e7, 101325
-        self.assertNear(self.water.u, -1.45e7)
-        self.assertNear(self.water.P, 101325)
+        assertNear(self.water.u, -1.45e7)
+        assertNear(self.water.P, 101325)
 
         self.water.VH = 1.45, -1.45e7
-        self.assertNear(self.water.v, 1.45)
-        self.assertNear(self.water.h, -1.45e7)
+        assertNear(self.water.v, 1.45)
+        assertNear(self.water.h, -1.45e7)
 
         self.water.TH = 400, -1.45e7
-        self.assertNear(self.water.T, 400)
-        self.assertNear(self.water.h, -1.45e7)
+        assertNear(self.water.T, 400)
+        assertNear(self.water.h, -1.45e7)
 
         self.water.SH = 5000, -1.45e7
-        self.assertNear(self.water.s, 5000)
-        self.assertNear(self.water.h, -1.45e7)
+        assertNear(self.water.s, 5000)
+        assertNear(self.water.h, -1.45e7)
 
         self.water.ST = 5000, 400
-        self.assertNear(self.water.s, 5000)
-        self.assertNear(self.water.T, 400)
+        assertNear(self.water.s, 5000)
+        assertNear(self.water.T, 400)
 
     def test_states(self):
-        self.assertEqual(self.water._native_state, ('T', 'D'))
-        self.assertNotIn('TPY', self.water._full_states.values())
-        self.assertIn('TQ', self.water._partial_states.values())
+        assert self.water._native_state == ('T', 'D')
+        assert 'TPY' not in self.water._full_states.values()
+        assert 'TQ' in self.water._partial_states.values()
 
     def test_set_Q(self):
         self.water.TQ = 500, 0.0
         p = self.water.P
         self.water.Q = 0.8
-        self.assertNear(self.water.P, p)
-        self.assertNear(self.water.T, 500)
-        self.assertNear(self.water.Q, 0.8)
+        assertNear(self.water.P, p)
+        assertNear(self.water.T, 500)
+        assertNear(self.water.Q, 0.8)
 
         self.water.TP = 650, 101325
-        with self.assertRaises(ct.CanteraError):
+        with pytest.raises(ct.CanteraError):
             self.water.Q = 0.1
 
         self.water.TP = 300, 101325
-        with self.assertRaises(ValueError):
+        with pytest.raises(ValueError):
             self.water.Q = 0.3
 
     def test_set_minmax(self):
         self.water.TP = self.water.min_temp, 101325
-        self.assertNear(self.water.T, self.water.min_temp)
+        assertNear(self.water.T, self.water.min_temp)
 
         self.water.TP = self.water.max_temp, 101325
-        self.assertNear(self.water.T, self.water.max_temp)
+        assertNear(self.water.T, self.water.max_temp)
 
     def check_fd_properties(self, T1, P1, T2, P2, tol):
         # Properties which are computed as finite differences
@@ -106,15 +112,15 @@ class TestPureFluid(utilities.CanteraTest):
         alpha2 = self.water.thermal_expansion_coeff
         h2b = self.water.enthalpy_mass
 
-        self.assertNear(cp1, cp2, tol)
-        self.assertNear(cv1, cv2, tol)
-        self.assertNear(k1, k2, tol)
-        self.assertNear(alpha1, alpha2, tol)
+        assertNear(cp1, cp2, tol)
+        assertNear(cv1, cv2, tol)
+        assertNear(k1, k2, tol)
+        assertNear(alpha1, alpha2, tol)
 
         # calculating these finite difference properties should not perturb the
         # state of the object (except for checks on edge cases)
-        self.assertNear(h1a, h1b, 1e-9)
-        self.assertNear(h2a, h2b, 1e-9)
+        assertNear(h1a, h1b, 1e-9)
+        assertNear(h2a, h2b, 1e-9)
 
     def test_properties_near_min(self):
         self.check_fd_properties(self.water.min_temp*(1+1e-5), 101325,
@@ -141,7 +147,7 @@ class TestPureFluid(utilities.CanteraTest):
         ref = ct.Solution('h2o2.yaml', transport_model=None)
         ref.TPX = 450, 12, 'H2O:1.0'
         self.water.TP = 450, 12
-        self.assertNear(ref.isothermal_compressibility,
+        assertNear(ref.isothermal_compressibility,
                         self.water.isothermal_compressibility, 1e-5)
 
     def test_thermal_expansion_coeff_lowP(self):
@@ -149,13 +155,13 @@ class TestPureFluid(utilities.CanteraTest):
         ref = ct.Solution('h2o2.yaml', transport_model=None)
         ref.TPX = 450, 12, 'H2O:1.0'
         self.water.TP = 450, 12
-        self.assertNear(ref.thermal_expansion_coeff,
+        assertNear(ref.thermal_expansion_coeff,
                         self.water.thermal_expansion_coeff, 1e-5)
 
     def test_thermal_expansion_coeff_TD(self):
         for T in [440, 550, 660]:
             self.water.TD = T, 0.1
-            self.assertNear(T * self.water.thermal_expansion_coeff, 1.0, 1e-2)
+            assertNear(T * self.water.thermal_expansion_coeff, 1.0, 1e-2)
 
     def test_pq_setter_triple_check(self):
         self.water.PQ = 101325, .2
@@ -165,8 +171,8 @@ class TestPureFluid(utilities.CanteraTest):
         # ensure that correct triple point pressure is recalculated
         # (necessary as this value is not stored by the C++ base class)
         self.water.PQ = 101325, .2
-        self.assertNear(T, self.water.T, 1e-9)
-        with self.assertRaisesRegex(ct.CanteraError, 'below triple point'):
+        assertNear(T, self.water.T, 1e-9)
+        with pytest.raises(ct.CanteraError, match='below triple point'):
             # min_temp is triple point temperature
             self.water.TP = self.water.min_temp, 101325
             P = self.water.P_sat # triple-point pressure
@@ -176,61 +182,61 @@ class TestPureFluid(utilities.CanteraTest):
         # Critical point
         self.water.TP = 300, ct.one_atm
         self.water.TQ = self.water.critical_temperature, .5
-        self.assertNear(self.water.P, self.water.critical_pressure)
+        assertNear(self.water.P, self.water.critical_pressure)
         self.water.TP = 300, ct.one_atm
         self.water.PQ = self.water.critical_pressure, .5
-        self.assertNear(self.water.T, self.water.critical_temperature)
+        assertNear(self.water.T, self.water.critical_temperature)
 
         # Supercritical
-        with self.assertRaisesRegex(ct.CanteraError, 'supercritical'):
+        with pytest.raises(ct.CanteraError, match='supercritical'):
             self.water.TQ = 1.001 * self.water.critical_temperature, 0.
-        with self.assertRaisesRegex(ct.CanteraError, 'supercritical'):
+        with pytest.raises(ct.CanteraError, match='supercritical'):
             self.water.PQ = 1.001 * self.water.critical_pressure, 0.
 
         # Q negative
-        with self.assertRaisesRegex(ct.CanteraError, 'Invalid vapor fraction'):
+        with pytest.raises(ct.CanteraError, match='Invalid vapor fraction'):
             self.water.TQ = 373.15, -.001
-        with self.assertRaisesRegex(ct.CanteraError, 'Invalid vapor fraction'):
+        with pytest.raises(ct.CanteraError, match='Invalid vapor fraction'):
             self.water.PQ = ct.one_atm, -.001
 
         # Q larger than one
-        with self.assertRaisesRegex(ct.CanteraError, 'Invalid vapor fraction'):
+        with pytest.raises(ct.CanteraError, match='Invalid vapor fraction'):
             self.water.TQ = 373.15, 1.001
-        with self.assertRaisesRegex(ct.CanteraError, 'Invalid vapor fraction'):
+        with pytest.raises(ct.CanteraError, match='Invalid vapor fraction'):
             self.water.PQ = ct.one_atm, 1.001
 
     def test_saturated_mixture(self):
         self.water.TP = 300, ct.one_atm
-        with self.assertRaisesRegex(ct.CanteraError, 'Saturated mixture detected'):
+        with pytest.raises(ct.CanteraError, match='Saturated mixture detected'):
             self.water.TP = 300, self.water.P_sat
 
         w = ct.Water()
 
         # Saturated vapor
         self.water.TQ = 373.15, 1.
-        self.assertEqual(self.water.phase_of_matter, 'liquid-gas-mix')
+        assert self.water.phase_of_matter == 'liquid-gas-mix'
         w.TP = self.water.T, .999 * self.water.P_sat
-        self.assertNear(self.water.cp, w.cp, 1.e-3)
-        self.assertNear(self.water.cv, w.cv, 1.e-3)
-        self.assertNear(self.water.thermal_expansion_coeff, w.thermal_expansion_coeff, 1.e-3)
-        self.assertNear(self.water.isothermal_compressibility, w.isothermal_compressibility, 1.e-3)
+        assertNear(self.water.cp, w.cp, 1.e-3)
+        assertNear(self.water.cv, w.cv, 1.e-3)
+        assertNear(self.water.thermal_expansion_coeff, w.thermal_expansion_coeff, 1.e-3)
+        assertNear(self.water.isothermal_compressibility, w.isothermal_compressibility, 1.e-3)
 
         # Saturated mixture
         self.water.TQ = 373.15, .5
-        self.assertEqual(self.water.phase_of_matter, 'liquid-gas-mix')
-        self.assertEqual(self.water.cp, np.inf)
-        self.assertTrue(np.isnan(self.water.cv))
-        self.assertEqual(self.water.isothermal_compressibility, np.inf)
-        self.assertEqual(self.water.thermal_expansion_coeff, np.inf)
+        assert self.water.phase_of_matter == 'liquid-gas-mix'
+        assert self.water.cp == np.inf
+        assert np.isnan(self.water.cv)
+        assert self.water.isothermal_compressibility == np.inf
+        assert self.water.thermal_expansion_coeff == np.inf
 
         # Saturated liquid
         self.water.TQ = 373.15, 0.
-        self.assertEqual(self.water.phase_of_matter, 'liquid-gas-mix')
+        assert self.water.phase_of_matter == 'liquid-gas-mix'
         w.TP = self.water.T, 1.001 * self.water.P_sat
-        self.assertNear(self.water.cp, w.cp, 1.e-3)
-        self.assertNear(self.water.cv, w.cv, 1.e-3)
-        self.assertNear(self.water.thermal_expansion_coeff, w.thermal_expansion_coeff, 1.e-3)
-        self.assertNear(self.water.isothermal_compressibility, w.isothermal_compressibility, 1.e-3)
+        assertNear(self.water.cp, w.cp, 1.e-3)
+        assertNear(self.water.cv, w.cv, 1.e-3)
+        assertNear(self.water.thermal_expansion_coeff, w.thermal_expansion_coeff, 1.e-3)
+        assertNear(self.water.isothermal_compressibility, w.isothermal_compressibility, 1.e-3)
 
     def test_saturation_near_limits(self):
         # Low temperature limit (triple point)
@@ -241,120 +247,120 @@ class TestPureFluid(utilities.CanteraTest):
         self.water.TP = 300, ct.one_atm
         self.water.P_sat # ensure that solver buffers sufficiently different values
         self.water.TP = 300, psat
-        self.assertNear(self.water.T_sat, self.water.min_temp)
+        assertNear(self.water.T_sat, self.water.min_temp)
 
         # High temperature limit (critical point) - saturation temperature
         self.water.TP = 300, ct.one_atm
         self.water.P_sat # ensure that solver buffers sufficiently different values
         self.water.TP = self.water.critical_temperature, self.water.critical_pressure
-        self.assertNear(self.water.T_sat, self.water.critical_temperature)
+        assertNear(self.water.T_sat, self.water.critical_temperature)
 
         # High temperature limit (critical point) - saturation pressure
         self.water.TP = 300, ct.one_atm
         self.water.P_sat # ensure that solver buffers sufficiently different values
         self.water.TP = self.water.critical_temperature, self.water.critical_pressure
-        self.assertNear(self.water.P_sat, self.water.critical_pressure)
+        assertNear(self.water.P_sat, self.water.critical_pressure)
 
         # Supercricital
-        with self.assertRaisesRegex(ct.CanteraError, 'Illegal temperature value'):
+        with pytest.raises(ct.CanteraError, match='Illegal temperature value'):
             self.water.TP = 1.001 * self.water.critical_temperature, self.water.critical_pressure
             self.water.P_sat
-        with self.assertRaisesRegex(ct.CanteraError, 'Illegal pressure value'):
+        with pytest.raises(ct.CanteraError, match='Illegal pressure value'):
             self.water.TP = self.water.critical_temperature, 1.001 * self.water.critical_pressure
             self.water.T_sat
 
         # Below triple point
-        with self.assertRaisesRegex(ct.CanteraError, 'Illegal temperature'):
+        with pytest.raises(ct.CanteraError, match='Illegal temperature'):
             self.water.TP = .999 * self.water.min_temp, ct.one_atm
             self.water.P_sat
         # @todo: test disabled pending fix of GitHub issue #605
-        # with self.assertRaisesRegex(ct.CanteraError, 'Illegal pressure value'):
+        # with pytest.raises(ct.CanteraError, match='Illegal pressure value'):
         #     self.water.TP = 300, .999 * psat
         #     self.water.T_sat
 
     def test_TPQ(self):
         self.water.TQ = 400, 0.8
         T, P, Q = self.water.TPQ
-        self.assertNear(T, 400)
-        self.assertNear(Q, 0.8)
+        assertNear(T, 400)
+        assertNear(Q, 0.8)
 
         # a supercritical state
         self.water.TPQ = 800, 3e7, 1
-        self.assertNear(self.water.T, 800)
-        self.assertNear(self.water.P, 3e7)
+        assertNear(self.water.T, 800)
+        assertNear(self.water.P, 3e7)
 
         self.water.TPQ = T, P, Q
-        self.assertNear(self.water.Q, 0.8)
-        with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
+        assertNear(self.water.Q, 0.8)
+        with pytest.raises(ct.CanteraError, match='inconsistent'):
             self.water.TPQ = T, .999*P, Q
-        with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
+        with pytest.raises(ct.CanteraError, match='inconsistent'):
             self.water.TPQ = T, 1.001*P, Q
-        with self.assertRaises(TypeError):
+        with pytest.raises(TypeError):
             self.water.TPQ = T, P, 'spam'
 
         self.water.TPQ = 500, 1e5, 1  # superheated steam
-        self.assertNear(self.water.P, 1e5)
-        with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
+        assertNear(self.water.P, 1e5)
+        with pytest.raises(ct.CanteraError, match='inconsistent'):
             self.water.TPQ = 500, 1e5, 0  # vapor fraction should be 1 (T < Tc)
-        with self.assertRaisesRegex(ct.CanteraError, 'inconsistent'):
+        with pytest.raises(ct.CanteraError, match='inconsistent'):
             self.water.TPQ = 700, 1e5, 0  # vapor fraction should be 1 (T > Tc)
 
     def test_phase_of_matter(self):
         self.water.TP = 300, 101325
-        self.assertEqual(self.water.phase_of_matter, "liquid")
+        assert self.water.phase_of_matter == "liquid"
         self.water.TP = 500, 101325
-        self.assertEqual(self.water.phase_of_matter, "gas")
+        assert self.water.phase_of_matter == "gas"
         self.water.TP = self.water.critical_temperature*2, 101325
-        self.assertEqual(self.water.phase_of_matter, "supercritical")
+        assert self.water.phase_of_matter == "supercritical"
         self.water.TP = 300, self.water.critical_pressure*2
-        self.assertEqual(self.water.phase_of_matter, "supercritical")
+        assert self.water.phase_of_matter == "supercritical"
         self.water.TQ = 300, 0.4
-        self.assertEqual(self.water.phase_of_matter, "liquid-gas-mix")
+        assert self.water.phase_of_matter == "liquid-gas-mix"
 
         # These cases work after fixing GH-786
         n2 = ct.Nitrogen()
         n2.TP = 100, 1000
-        self.assertEqual(n2.phase_of_matter, "gas")
+        assert n2.phase_of_matter == "gas"
 
         co2 = ct.CarbonDioxide()
-        self.assertEqual(co2.phase_of_matter, "gas")
+        assert co2.phase_of_matter == "gas"
 
     def test_water_backends(self):
         w = ct.Water(backend='Reynolds')
-        self.assertEqual(w.thermo_model, 'pure-fluid')
+        assert w.thermo_model == 'pure-fluid'
         w = ct.Water(backend='IAPWS95')
-        self.assertEqual(w.thermo_model, 'liquid-water-IAPWS95')
-        with self.assertRaisesRegex(KeyError, 'Unknown backend'):
+        assert w.thermo_model == 'liquid-water-IAPWS95'
+        with pytest.raises(KeyError, match='Unknown backend'):
             ct.Water('foobar')
 
     def test_water_iapws(self):
         w = ct.Water(backend='IAPWS95')
-        self.assertNear(w.critical_density, 322.)
-        self.assertNear(w.critical_temperature, 647.096)
-        self.assertNear(w.critical_pressure, 22064000.0)
+        assertNear(w.critical_density, 322.)
+        assertNear(w.critical_temperature, 647.096)
+        assertNear(w.critical_pressure, 22064000.0)
 
         # test internal TP setters (setters update temperature at constant
         # density before updating pressure)
         w.TP = 300, ct.one_atm
         dens = w.density
         w.TP = 2000, ct.one_atm # supercritical
-        self.assertEqual(w.phase_of_matter, "supercritical")
+        assert w.phase_of_matter == "supercritical"
         w.TP = 300, ct.one_atm # state goes from supercritical -> gas -> liquid
-        self.assertNear(w.density, dens)
-        self.assertEqual(w.phase_of_matter, "liquid")
+        assertNear(w.density, dens)
+        assert w.phase_of_matter == "liquid"
 
         # test setters for critical conditions
         w.TP = w.critical_temperature, w.critical_pressure
-        self.assertNear(w.density, 322.)
+        assertNear(w.density, 322.)
         w.TP = 2000, ct.one_atm # uses current density as initial guess
         w.TP = 273.16, ct.one_atm # uses fixed density as initial guess
-        self.assertNear(w.density, 999.84376)
-        self.assertEqual(w.phase_of_matter, "liquid")
+        assertNear(w.density, 999.84376)
+        assert w.phase_of_matter == "liquid"
         w.TP = w.T, w.P_sat
-        self.assertEqual(w.phase_of_matter, "liquid")
-        with self.assertRaisesRegex(ct.CanteraError, "assumes liquid phase"):
+        assert w.phase_of_matter == "liquid"
+        with pytest.raises(ct.CanteraError, match="assumes liquid phase"):
             w.TP = 273.1599999, ct.one_atm
-        with self.assertRaisesRegex(ct.CanteraError, "assumes liquid phase"):
+        with pytest.raises(ct.CanteraError, match="assumes liquid phase"):
             w.TP = 500, ct.one_atm
 
 
@@ -384,24 +390,26 @@ class Tolerances:
         self.hTs = hTs or 2e-4
 
 
+@pytest.fixture(scope='class')
+def setup_fluid(request):
+    """Fixture to set up fluid, refState, and initial internal energy/entropy."""
+    if request.cls.name not in request.cls.fluids:
+        request.cls.fluids[request.cls.name] = ct.PureFluid("liquidvapor.yaml", request.cls.name)
+    request.cls.fluid = request.cls.fluids[request.cls.name]
+    request.cls.fluid.TD = request.cls.refState.T, request.cls.refState.rho
+    request.cls.u0 = request.cls.fluid.u
+    request.cls.s0 = request.cls.fluid.s
+
+
 class PureFluidTestCases:
     """
     Test the results of pure fluid phase calculations against tabulated
     references and for consistency with basic thermodynamic relations.
     """
     fluids = {}
-
-    def __init__(self, name, refState, tolerances=Tolerances()):
-        if name not in self.fluids:
-            self.fluids[name] = ct.PureFluid("liquidvapor.yaml", name)
-
-        self.fluid = self.fluids[name]
-
-        self.fluid.TD = refState.T, refState.rho
-        self.refState = refState
-        self.u0 = self.fluid.u
-        self.s0 = self.fluid.s
-        self.tol = tolerances
+    states = []
+    refState = None
+    tol = Tolerances()
 
     def a(self, T, rho):
         """ Helmholtz free energy """
@@ -409,7 +417,7 @@ class PureFluidTestCases:
         return self.fluid.u - T * self.fluid.s
 
     def test_has_phase_transition(self):
-        self.assertTrue(self.fluid.has_phase_transition)
+        assert self.fluid.has_phase_transition
 
     def test_consistency_temperature(self):
         for state in self.states:
@@ -423,7 +431,7 @@ class PureFluidTestCases:
 
             # At constant volume, dU = T dS
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            self.assertNear((u2-u1)/(s2-s1), state.T, self.tol.dUdS, msg=msg)
+            assertNear((u2-u1)/(s2-s1), state.T, self.tol.dUdS, msg=msg)
 
     def test_consistency_volume(self):
         for state in self.states:
@@ -440,7 +448,7 @@ class PureFluidTestCases:
 
             # At constant temperature, dA = - p dV
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            self.assertNear(-(a2-a1)/dV, p, tol, msg=msg)
+            assertNear(-(a2-a1)/dV, p, tol, msg=msg)
 
     def test_saturation(self):
         for state in self.states:
@@ -464,11 +472,11 @@ class PureFluidTestCases:
 
             # Clausius-Clapeyron Relation
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            self.assertNear((p2-p1)/dT, (hg-hf)/(state.T * (vg-vf)),
+            assertNear((p2-p1)/dT, (hg-hf)/(state.T * (vg-vf)),
                             self.tol.dPdT, msg=msg)
 
             # True for a change in state at constant pressure and temperature
-            self.assertNear(hg-hf, state.T * (sg-sf), self.tol.hTs, msg=msg)
+            assertNear(hg-hf, state.T * (sg-sf), self.tol.hTs, msg=msg)
 
     def test_pressure(self):
         for state in self.states:
@@ -477,13 +485,13 @@ class PureFluidTestCases:
             tol = 50*self.tol.p if state.phase == 'liquid' else self.tol.p
             tol *= state.tolMod
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            self.assertNear(self.fluid.P, state.p, tol, msg=msg)
+            assertNear(self.fluid.P, state.p, tol, msg=msg)
 
     def test_internal_energy(self):
         for state in self.states:
             self.fluid.TD = state.T, state.rho
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            self.assertNear(self.fluid.u - self.u0,
+            assertNear(self.fluid.u - self.u0,
                             state.u - self.refState.u,
                             self.tol.u * state.tolMod, msg=msg)
 
@@ -491,15 +499,18 @@ class PureFluidTestCases:
         for state in self.states:
             self.fluid.TD = state.T, state.rho
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            self.assertNear(self.fluid.s - self.s0,
+            assertNear(self.fluid.s - self.s0,
                             state.s - self.refState.s,
                             self.tol.s * state.tolMod, msg=msg)
 
 
-# Reference values for HFC134a taken from NIST Chemistry WebBook, which
-# implements the same EOS from Tillner-Roth and Baehr as Cantera, so close
-# agreement is expected.
-class HFC134a(PureFluidTestCases, utilities.CanteraTest):
+@pytest.mark.usefixtures("setup_fluid")
+class TestHFC134a(PureFluidTestCases):
+    """
+    Reference values for HFC134a taken from NIST Chemistry WebBook, which
+    implements the same EOS from Tillner-Roth and Baehr as Cantera, so close
+    agreement is expected.
+    """
     states = [
         StateData('liquid', 175.0, 0.1, rho=1577.6239, u=77.534586, s=0.44788182),
         StateData('liquid', 210.0, 0.1, rho=1483.2128, u=119.48566, s=0.66633877),
@@ -509,11 +520,9 @@ class HFC134a(PureFluidTestCases, utilities.CanteraTest):
         StateData('super', 410.0, 10, rho=736.54666, u=399.02258, s=1.5972395),
         StateData('super', 450.0, 40, rho=999.34087, u=411.92422, s=1.6108568)]
 
-    def __init__(self, *args, **kwargs):
-        refState = StateData('critical', 374.21, 4.05928,
-                             rho=511.900, u=381.70937, s=1.5620991)
-        PureFluidTestCases.__init__(self, "HFC-134a", refState)
-        utilities.CanteraTest.__init__(self, *args, **kwargs)
+    refState = StateData('critical', 374.21, 4.05928, rho=511.900, u=381.70937, s=1.5620991)
+    name = "HFC-134a"
+
 
 
 # Reference values for the following substances are taken from the tables in
@@ -526,7 +535,8 @@ class HFC134a(PureFluidTestCases, utilities.CanteraTest):
 # different methods for satisfying the phase equilibrium condition g_l = g_v.
 # Cantera uses the actual equation of state, while the tabulated values given
 # by Reynolds are based on the given P_sat(T_sat) relations.
-class CarbonDioxide(PureFluidTestCases, utilities.CanteraTest):
+@pytest.mark.usefixtures("setup_fluid")
+class TestCarbonDioxide(PureFluidTestCases):
     states = [
         StateData('liquid', 230.0, 2.0, rho=1132.4, h=28.25, s=0.1208),
         StateData('liquid', 270.0, 10.0, rho=989.97, h=110.59, s=0.4208),
@@ -535,15 +545,13 @@ class CarbonDioxide(PureFluidTestCases, utilities.CanteraTest):
         StateData('super', 500.0, 1.0, v=0.09376, h=613.22, s=2.2649),
         StateData('super', 600.0, 20.0, v=0.00554, h=681.94, s=1.8366)]
 
-    def __init__(self, *args, **kwargs):
-        refState = StateData('critical', 304.21, 7.3834,
-                             rho=464.0, h=257.31, s=0.9312)
-        tols = Tolerances(2e-3, 2e-3, 2e-3)
-        PureFluidTestCases.__init__(self, "carbon-dioxide", refState, tols)
-        utilities.CanteraTest.__init__(self, *args, **kwargs)
+    refState = StateData('critical', 304.21, 7.3834, rho=464.0, h=257.31, s=0.9312)
+    name = "carbon-dioxide"
+    tol = Tolerances(2e-3, 2e-3, 2e-3)
 
 
-class Heptane(PureFluidTestCases, utilities.CanteraTest):
+@pytest.mark.usefixtures("setup_fluid")
+class TestHeptane(PureFluidTestCases):
     states = [
         StateData('liquid', 300.0, 0.006637, v=0.001476, h=0.0, s=0.0, relax=True),  # sat
         StateData('liquid', 400.0, 0.2175, v=0.001712, h=248.01, s=0.709, relax=True),  # sat
@@ -552,16 +560,14 @@ class Heptane(PureFluidTestCases, utilities.CanteraTest):
         StateData('super', 600.0, 2.0, v=0.01992, h=1014.87, s=2.2356),
         StateData('super', 680.0, 0.2, v=0.2790, h=1289.29, s=2.8450)]
 
-    def __init__(self, *args, **kwargs):
-        refState = StateData('critical', 537.68, 2.6199,
-                             rho=197.60, h=747.84, s=1.7456)
-        tols = Tolerances(2e-3, 2e-3, 2e-3)
-        PureFluidTestCases.__init__(self, 'heptane', refState, tols)
-        utilities.CanteraTest.__init__(self, *args, **kwargs)
+    refState = StateData('critical', 537.68, 2.6199, rho=197.60, h=747.84, s=1.7456)
+    name = "heptane"
+    tol = Tolerances(2e-3, 2e-3, 2e-3)
 
 
 # para-hydrogen
-class Hydrogen(PureFluidTestCases, utilities.CanteraTest):
+@pytest.mark.usefixtures("setup_fluid")
+class TestHydrogen(PureFluidTestCases):
     states = [
         StateData('liquid', 18.0, 0.04807, v=0.013660, h=30.1, s=1.856, relax=True),  # sat
         StateData('liquid', 26.0, 0.4029, v=0.015911, h=121.2, s=5.740, relax=True),  # sat
@@ -572,15 +578,12 @@ class Hydrogen(PureFluidTestCases, utilities.CanteraTest):
         StateData('super', 600.0, 1.00, v=2.483, h=8888.4, s=60.398),
         StateData('super', 800.0, 4.0, v=0.8329, h=11840.0, s=58.890)]
 
-    def __init__(self, *args, **kwargs):
-        refState = StateData('critical', 32.938, 1.2838,
-                             rho=31.36, h=346.5, s=12.536)
-        tols = Tolerances(2e-3, 2e-3, 2e-3, 2e-4)
-        PureFluidTestCases.__init__(self, 'hydrogen', refState, tols)
-        utilities.CanteraTest.__init__(self, *args, **kwargs)
+    refState = StateData('critical', 32.938, 1.2838, rho=31.36, h=346.5, s=12.536)
+    name = "hydrogen"
+    tol = Tolerances(2e-3, 2e-3, 2e-3, 2e-4)
 
-
-class Methane(PureFluidTestCases, utilities.CanteraTest):
+@pytest.mark.usefixtures("setup_fluid")
+class TestMethane(PureFluidTestCases):
     states = [
         StateData('liquid', 100.0, 0.50, rho=439.39, h=31.65, s=0.3206),
         StateData('liquid', 140.0, 2.0, rho=379.51, h=175.48, s=1.4963),
@@ -590,15 +593,12 @@ class Methane(PureFluidTestCases, utilities.CanteraTest):
         StateData('super', 200.0, 0.2, v=0.5117, h=767.37, s=6.1574),
         StateData('super', 300.0, 0.5, v=0.3083, h=980.87, s=6.5513)]
 
-    def __init__(self, *args, **kwargs):
-        refState = StateData('critical', 190.555, 4.5988,
-                             rho=160.43, h=490.61, s=3.2853)
-        tols = Tolerances(2e-3, 2e-3, 2e-3)
-        PureFluidTestCases.__init__(self, 'methane', refState, tols)
-        utilities.CanteraTest.__init__(self, *args, **kwargs)
+    refState = StateData('critical', 190.555, 4.5988, rho=160.43, h=490.61, s=3.2853)
+    name = "methane"
+    tol = Tolerances(2e-3, 2e-3, 2e-3)
 
-
-class Nitrogen(PureFluidTestCases, utilities.CanteraTest):
+@pytest.mark.usefixtures("setup_fluid")
+class TestNitrogen(PureFluidTestCases):
     states = [
         StateData('liquid', 80.0, 0.1370, v=0.001256, h=33.50, s=0.4668, relax=True),  # sat
         StateData('vapor', 110.0, 1.467, v=0.01602, h=236.28, s=2.3896, relax=True),  # sat
@@ -607,15 +607,12 @@ class Nitrogen(PureFluidTestCases, utilities.CanteraTest):
         StateData('super', 500.0, 5.0, v=0.03031, h=668.48, s=3.7722),
         StateData('super', 600.0, 100.0, v=0.00276, h=827.54, s=3.0208)]
 
-    def __init__(self, *args, **kwargs):
-        refState = StateData('critical', 126.200, 3.400,
-                             rho=314.03, h=180.78, s=1.7903)
-        tols = Tolerances(2e-3, 2e-3, 2e-3)
-        PureFluidTestCases.__init__(self, 'nitrogen', refState, tols)
-        utilities.CanteraTest.__init__(self, *args, **kwargs)
+    refState = StateData('critical', 126.200, 3.400, rho=314.03, h=180.78, s=1.7903)
+    name = "nitrogen"
+    tol = Tolerances(2e-3, 2e-3, 2e-3)
 
-
-class Oxygen(PureFluidTestCases, utilities.CanteraTest):
+@pytest.mark.usefixtures("setup_fluid")
+class TestOxygen(PureFluidTestCases):
     states = [
         StateData('liquid', 80.0, 0.03009, v=0.000840, h=42.56, s=0.6405, relax=True),  # sat
         StateData('liquid', 125.0, 1.351, v=0.001064, h=123.24, s=1.4236, relax=True),  # sat
@@ -623,18 +620,14 @@ class Oxygen(PureFluidTestCases, utilities.CanteraTest):
         StateData('super', 200.0, 0.050, v=1.038, h=374.65, s=4.1275),
         StateData('super', 300.0, 1.0, v=0.07749, h=463.76, s=3.7135),
         StateData('super', 600.0, 0.20, v=0.7798, h=753.38, s=4.7982),
-        StateData('super', 800.0, 5.0, v=0.04204, h=961.00, s=4.2571)
-        ]
+        StateData('super', 800.0, 5.0, v=0.04204, h=961.00, s=4.2571)]
 
-    def __init__(self, *args, **kwargs):
-        refState = StateData('critical', 154.581, 5.0429,
-                             rho=436.15, h=226.53, s=2.1080)
-        tols = Tolerances(2e-3, 2e-3, 2e-3)
-        PureFluidTestCases.__init__(self, 'oxygen', refState, tols)
-        utilities.CanteraTest.__init__(self, *args, **kwargs)
+    refState = StateData('critical', 154.581, 5.0429, rho=436.15, h=226.53, s=2.1080)
+    name = "oxygen"
+    tol = Tolerances(2e-3, 2e-3, 2e-3)
 
-
-class Water(PureFluidTestCases, utilities.CanteraTest):
+@pytest.mark.usefixtures("setup_fluid")
+class TestWater(PureFluidTestCases):
     states = [
         StateData('liquid', 295.0, 0.002620, v=0.0010025, h=90.7, s=0.3193, relax=True),
         StateData('vapor', 315.0, 0.008143, v=17.80, h=2577.1, s=8.2216, relax=True),
@@ -645,20 +638,19 @@ class Water(PureFluidTestCases, utilities.CanteraTest):
         StateData('super', 800.0, 0.01, v=36.92, h=3546.0, s=9.9699),
         StateData('super', 900.0, 0.70, v=0.5917, h=3759.4, s=8.2621),
         StateData('super', 1000.0, 30.0, v=0.01421, h=3821.6, s=6.6373),
-        StateData('liquid', 500.0, 3.0, rho=832.04, h=975.68, s=2.58049)
-        ]
+        StateData('liquid', 500.0, 3.0, rho=832.04, h=975.68, s=2.58049)]
 
-    def __init__(self, *args, **kwargs):
-        refState = StateData('critical', 647.286, 22.089,
-                             rho=317.0, h=2098.8, s=4.4289)
-        tols = Tolerances(2e-3, 2e-3, 2e-3)
-        PureFluidTestCases.__init__(self, 'water', refState, tols)
-        utilities.CanteraTest.__init__(self, *args, **kwargs)
+    refState = StateData('critical', 647.286, 22.089, rho=317.0, h=2098.8, s=4.4289)
+    name = "water"
+    tol = Tolerances(2e-3, 2e-3, 2e-3)
 
 
-class PureFluidConvergence(utilities.CanteraTest):
-    def setUp(self):
-        self.fluid = ct.Water()
+@pytest.fixture(scope='function')
+def pure_fluid(request):
+    request.cls.fluid = ct.Water()
+
+@pytest.mark.usefixtures('pure_fluid')
+class TestPureFluidConvergence:
 
     def test_TP(self):
         # Focus on the region near the critical point
@@ -674,8 +666,8 @@ class PureFluidConvergence(utilities.CanteraTest):
         for T,P in itertools.product(TT, PP):
             try:
                 self.fluid.TP = T, P
-                self.assertNear(self.fluid.T, T, 1e-6)
-                self.assertNear(self.fluid.P, P, 1e-6)
+                assertNear(self.fluid.T, T, 1e-6)
+                assertNear(self.fluid.P, P, 1e-6)
             except Exception as e:
                 errors += 'Error at T=%r, P=%r:\n%s\n\n' % (T,P,e)
                 nErrors += 1
@@ -692,8 +684,8 @@ class PureFluidConvergence(utilities.CanteraTest):
         for u,v in itertools.product(UU, VV):
             try:
                 self.fluid.UV = u, v
-                self.assertNear(self.fluid.u, u, 1e-6)
-                self.assertNear(self.fluid.v, v, 1e-6)
+                assertNear(self.fluid.u, u, 1e-6)
+                assertNear(self.fluid.v, v, 1e-6)
             except Exception as e:
                 errors += 'Error at u=%r, v=%r:\n%s\n\n' % (u,v,e)
                 nErrors += 1
@@ -710,8 +702,8 @@ class PureFluidConvergence(utilities.CanteraTest):
         for h,P in itertools.product(HH, PP):
             try:
                 self.fluid.HP = h, P
-                self.assertNear(self.fluid.h, h, 1e-6)
-                self.assertNear(self.fluid.P, P, 1e-6)
+                assertNear(self.fluid.h, h, 1e-6)
+                assertNear(self.fluid.P, P, 1e-6)
             except Exception as e:
                 errors += 'Error at h=%r, P=%r:\n%s\n\n' % (h,P,e)
                 nErrors += 1

--- a/test/python/test_purefluid.py
+++ b/test/python/test_purefluid.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 
 import cantera as ct
-from . import utilities
 from .utilities import (
     assertNear,
 )

--- a/test/python/test_purefluid.py
+++ b/test/python/test_purefluid.py
@@ -399,6 +399,7 @@ def setup_fluid(request):
     request.cls.s0 = request.cls.fluid.s
 
 
+@pytest.mark.usefixtures("setup_fluid")
 class PureFluidTestCases:
     """
     Test the results of pure fluid phase calculations against tabulated
@@ -429,7 +430,7 @@ class PureFluidTestCases:
 
             # At constant volume, dU = T dS
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            assert (u2-u1)/(s2-s1) == approx(state.T, rel=self.tol.dUdS)
+            assert (u2-u1)/(s2-s1) == approx(state.T, rel=self.tol.dUdS), msg
 
     def test_consistency_volume(self):
         for state in self.states:
@@ -446,7 +447,7 @@ class PureFluidTestCases:
 
             # At constant temperature, dA = - p dV
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            assert -(a2-a1)/dV == approx(p, rel=tol)
+            assert -(a2-a1)/dV == approx(p, rel=tol), msg
 
     def test_saturation(self):
         for state in self.states:
@@ -471,7 +472,7 @@ class PureFluidTestCases:
             # Clausius-Clapeyron Relation
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
             assert (p2-p1)/dT == approx((hg-hf)/(state.T * (vg-vf)),
-                   rel=self.tol.dPdT)
+                   rel=self.tol.dPdT), msg
 
             # True for a change in state at constant pressure and temperature
             assert hg-hf == approx(state.T * (sg-sf), rel=self.tol.hTs)
@@ -483,24 +484,23 @@ class PureFluidTestCases:
             tol = 70*self.tol.p if state.phase == 'liquid' else self.tol.p
             tol *= state.tolMod
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
-            assert self.fluid.P == approx(state.p, rel=tol)
+            assert self.fluid.P == approx(state.p, rel=tol), msg
 
     def test_internal_energy(self):
         for state in self.states:
             self.fluid.TD = state.T, state.rho
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
             assert self.fluid.u - self.u0 == approx(state.u - self.refState.u,
-                   rel=self.tol.u * state.tolMod)
+                   rel=self.tol.u * state.tolMod), msg
 
     def test_entropy(self):
         for state in self.states:
             self.fluid.TD = state.T, state.rho
             msg = 'At state: T=%s, rho=%s' % (state.T, state.rho)
             assert self.fluid.s - self.s0 == approx(state.s - self.refState.s,
-                   rel=self.tol.s * state.tolMod)
+                   rel=self.tol.s * state.tolMod), msg
 
 
-@pytest.mark.usefixtures("setup_fluid")
 class TestHFC134a(PureFluidTestCases):
     """
     Reference values for HFC134a taken from NIST Chemistry WebBook, which
@@ -531,7 +531,6 @@ class TestHFC134a(PureFluidTestCases):
 # different methods for satisfying the phase equilibrium condition g_l = g_v.
 # Cantera uses the actual equation of state, while the tabulated values given
 # by Reynolds are based on the given P_sat(T_sat) relations.
-@pytest.mark.usefixtures("setup_fluid")
 class TestCarbonDioxide(PureFluidTestCases):
     states = [
         StateData('liquid', 230.0, 2.0, rho=1132.4, h=28.25, s=0.1208),
@@ -546,7 +545,6 @@ class TestCarbonDioxide(PureFluidTestCases):
     tol = Tolerances(2e-3, 2e-3, 2e-3)
 
 
-@pytest.mark.usefixtures("setup_fluid")
 class TestHeptane(PureFluidTestCases):
     states = [
         StateData('liquid', 300.0, 0.006637, v=0.001476, h=0.0, s=0.0, relax=True),  # sat
@@ -562,7 +560,6 @@ class TestHeptane(PureFluidTestCases):
 
 
 # para-hydrogen
-@pytest.mark.usefixtures("setup_fluid")
 class TestHydrogen(PureFluidTestCases):
     states = [
         StateData('liquid', 18.0, 0.04807, v=0.013660, h=30.1, s=1.856, relax=True),  # sat
@@ -578,7 +575,6 @@ class TestHydrogen(PureFluidTestCases):
     name = "hydrogen"
     tol = Tolerances(2e-3, 2e-3, 2e-3, 2e-4)
 
-@pytest.mark.usefixtures("setup_fluid")
 class TestMethane(PureFluidTestCases):
     states = [
         StateData('liquid', 100.0, 0.50, rho=439.39, h=31.65, s=0.3206),
@@ -593,7 +589,6 @@ class TestMethane(PureFluidTestCases):
     name = "methane"
     tol = Tolerances(2e-3, 2e-3, 2e-3)
 
-@pytest.mark.usefixtures("setup_fluid")
 class TestNitrogen(PureFluidTestCases):
     states = [
         StateData('liquid', 80.0, 0.1370, v=0.001256, h=33.50, s=0.4668, relax=True),  # sat
@@ -607,7 +602,6 @@ class TestNitrogen(PureFluidTestCases):
     name = "nitrogen"
     tol = Tolerances(2e-3, 2e-3, 2e-3)
 
-@pytest.mark.usefixtures("setup_fluid")
 class TestOxygen(PureFluidTestCases):
     states = [
         StateData('liquid', 80.0, 0.03009, v=0.000840, h=42.56, s=0.6405, relax=True),  # sat
@@ -622,7 +616,6 @@ class TestOxygen(PureFluidTestCases):
     name = "oxygen"
     tol = Tolerances(2e-3, 2e-3, 2e-3)
 
-@pytest.mark.usefixtures("setup_fluid")
 class TestWater(PureFluidTestCases):
     states = [
         StateData('liquid', 295.0, 0.002620, v=0.0010025, h=90.7, s=0.3193, relax=True),

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -623,7 +623,7 @@ class TestPlogRate(ReactionRateTests):
         """
 
     @pytest.fixture(scope='function', autouse=True)
-    def setup_plog_data(self, setup_test_data):
+    def setup_plog_data(self):
         self._parts = {
             "rates": [(rc["P"], ct.Arrhenius(rc["A"], rc["b"], rc["Ea"]))
                       for rc in self._input["rate-constants"]],
@@ -706,7 +706,7 @@ class TestChebyshevRate(ReactionRateTests):
         """
 
     @pytest.fixture(scope='function', autouse=True)
-    def setup_chebyshev_data(self, setup_test_data):
+    def setup_chebyshev_data(self):
         self._parts = {
             "pressure_range": self._input["pressure-range"],
             "temperature_range": self._input["temperature-range"],
@@ -790,7 +790,7 @@ class SurfaceReactionRateTests(ReactionRateTests):
         pass
 
 class StickingReactionRateTests(SurfaceReactionRateTests):
-    # test suite for surface reaction rate expressions
+    """Test suite for surface reaction rate expressions"""
 
     _sticking_species = None
     _sticking_order = None
@@ -816,7 +816,7 @@ class StickingReactionRateTests(SurfaceReactionRateTests):
         assert rate.sticking_weight == approx(weight)
 
 class TestSurfaceArrheniusRate(SurfaceReactionRateTests):
-    # test interface-Arrhenius rate expressions without coverage dependency
+    """Test interface-Arrhenius rate expressions without coverage dependency"""
 
     _cls = ct.InterfaceArrheniusRate
     _type = "interface-Arrhenius"
@@ -829,7 +829,7 @@ class TestSurfaceArrheniusRate(SurfaceReactionRateTests):
         """
 
 class TestInterfaceArrheniusRate(SurfaceReactionRateTests):
-    # test interface-Arrhenius rate expressions with coverage dependency
+    """Test interface-Arrhenius rate expressions with coverage dependency"""
 
     _cls = ct.InterfaceArrheniusRate
     _type = "interface-Arrhenius"
@@ -847,7 +847,7 @@ class TestInterfaceArrheniusRate(SurfaceReactionRateTests):
         """
 
 class TestStickingRate(StickingReactionRateTests):
-    # test surface-sticking rate expressions without coverage dependency
+    """Test surface-sticking rate expressions without coverage dependency"""
 
     _cls = ct.StickingArrheniusRate
     _type = "sticking-Arrhenius"
@@ -862,7 +862,7 @@ class TestStickingRate(StickingReactionRateTests):
         """
 
 class TestCoverageStickingRate(StickingReactionRateTests):
-    # test sticking rate expressions with coverage dependency
+    """Test sticking rate expressions with coverage dependency"""
 
     _cls = ct.StickingArrheniusRate
     _type = "sticking-Arrhenius"
@@ -882,7 +882,7 @@ class TestCoverageStickingRate(StickingReactionRateTests):
         """
 
 class TestMotzWiseStickingRate(StickingReactionRateTests):
-    # test interface reaction with coverages
+    """Test interface reaction with coverages"""
 
     _cls = ct.StickingArrheniusRate
     _type = "sticking-Arrhenius"
@@ -901,7 +901,7 @@ class TestMotzWiseStickingRate(StickingReactionRateTests):
         """
 
 class TestSurfaceBMRate(SurfaceReactionRateTests):
-    # test coverage-Blowers-Masel rate expressions with coverage dependency
+    """Test coverage-Blowers-Masel rate expressions with coverage dependency"""
 
     _cls = ct.InterfaceBlowersMaselRate
     _type = "interface-Blowers-Masel"
@@ -916,7 +916,7 @@ class TestSurfaceBMRate(SurfaceReactionRateTests):
         """
 
 class TestSurfaceBMRate(SurfaceReactionRateTests):
-    # test coverage-Blowers-Masel rate expressions with coverage dependency
+    """Test coverage-Blowers-Masel rate expressions with coverage dependency"""
 
     _cls = ct.InterfaceBlowersMaselRate
     _type = "interface-Blowers-Masel"
@@ -934,7 +934,7 @@ class TestSurfaceBMRate(SurfaceReactionRateTests):
         """
 
 class TestBMStickate(StickingReactionRateTests):
-    # test coverage-Blowers-Masel stick expressions with coverage dependency
+    """Test coverage-Blowers-Masel stick expressions with coverage dependency"""
 
     _cls = ct.StickingBlowersMaselRate
     _type = "sticking-Blowers-Masel"
@@ -966,7 +966,7 @@ def reaction_data(request, setup_reaction_tests):
     request.cls.adj = []
 
 class ReactionTests:
-    # test suite for reaction expressions
+    """Test suite for reaction expressions"""
 
     _cls = ct.Reaction # reaction object to be tested
     _rate_cls = None # corresponding reaction rate type
@@ -1053,10 +1053,10 @@ class ReactionTests:
     def check_solution(self, sol2):
         # helper function that checks evaluation of reaction rates
         ix = self._index
-        assert sol2.forward_rate_constants[0] == approx(
-               self.soln.forward_rate_constants[ix])
-        assert sol2.net_rates_of_progress[0] == approx(
-               self.soln.net_rates_of_progress[ix])
+        assert (sol2.forward_rate_constants[0]
+                == approx(self.soln.forward_rate_constants[ix]))
+        assert (sol2.net_rates_of_progress[0]
+                == approx(self.soln.net_rates_of_progress[ix]))
 
     def test_rate(self):
         # check consistency of reaction rate and forward rate constant
@@ -1095,7 +1095,8 @@ class ReactionTests:
             sol2.coverages = self.soln.coverages
             sol2.TP = self.soln.TP
         else:
-            sol2 = ct.Solution(thermo=self.soln.thermo_model, kinetics=self.soln.kinetics_model,
+            sol2 = ct.Solution(thermo=self.soln.thermo_model,
+                               kinetics=self.soln.kinetics_model,
                                species=self.species, reactions=[])
             sol2.TPX = self.soln.TPX
             # need to setup electron energy distribution for plasma

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -7,6 +7,7 @@ import sys
 import textwrap
 
 import cantera as ct
+from .utilities import load_yaml
 
 
 @pytest.fixture(scope='class')
@@ -1825,7 +1826,7 @@ class TestExtensible3:
         assert rxn.rate.length == 2
         assert rxn.rate.Ta == approx(1000 / ct.gas_constant)
 
-    def test_output_units(self, load_yaml):
+    def test_output_units(self):
         rxn = """
         equation: H2 + OH = H2O + H
         type: user-rate-2

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -8,14 +8,12 @@ import sys
 import textwrap
 
 import cantera as ct
-from . import utilities
 from .utilities import (
     assertNear,
     assertArrayNear,
     assertIsFinite,
     assertIsNaN
 )
-from .utilities import has_temperature_derivative_warnings
 
 
 @pytest.fixture(scope='class')

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -16,8 +16,8 @@ class TestImplicitThirdBody(utilities.CanteraTest):
     # tests for three-body reactions with specified collision partner
 
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution("gri30.yaml")
 
     def test_implicit_three_body(self):
@@ -172,8 +172,8 @@ class ReactionRateTests:
     _yaml = None # yaml string specifying parameters
 
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.soln = ct.Solution("kineticsfromscratch.yaml")
 
     def setUp(self):
@@ -459,8 +459,8 @@ class FalloffRateTests(ReactionRateTests):
     _n_data = [0] # list of valid falloff coefficient array lengths
 
     @classmethod
-    def setUpClass(cls):
-        ReactionRateTests.setUpClass()
+    def setup_class(cls):
+        ReactionRateTests.setup_class()
         param = cls._input["low-P-rate-constant"]
         cls._parts["low"] = ct.Arrhenius(param["A"], param["b"], param["Ea"])
         param = cls._input["high-P-rate-constant"]
@@ -632,8 +632,8 @@ class TestPlogRate(ReactionRateTests, utilities.CanteraTest):
         """
 
     @classmethod
-    def setUpClass(cls):
-        ReactionRateTests.setUpClass()
+    def setup_class(cls):
+        ReactionRateTests.setup_class()
         cls._parts = {
             "rates": [(rc["P"], ct.Arrhenius(rc["A"], rc["b"], rc["Ea"]))
                       for rc in cls._input["rate-constants"]],
@@ -716,8 +716,8 @@ class TestChebyshevRate(ReactionRateTests, utilities.CanteraTest):
         """
 
     @classmethod
-    def setUpClass(cls):
-        ReactionRateTests.setUpClass()
+    def setup_class(cls):
+        ReactionRateTests.setup_class()
         cls._parts = {
             "pressure_range": cls._input["pressure-range"],
             "temperature_range": cls._input["temperature-range"],
@@ -745,8 +745,8 @@ class SurfaceReactionRateTests(ReactionRateTests):
     # test suite for surface reaction rate expressions
 
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.soln = ct.Interface("kineticsfromscratch.yaml", "Pt_surf", transport_model=None)
         cls.gas = cls.soln.adjacent["ohmech"]
 
@@ -987,8 +987,8 @@ class ReactionTests:
     _rc_units = None # Units of the rate coefficient
 
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.soln = ct.Solution("kineticsfromscratch.yaml", transport_model=None)
         cls.species = cls.soln.species()
 
@@ -1200,8 +1200,8 @@ class TestElementary(ReactionTests, utilities.CanteraTest):
     _rc_units = ct.Units("m^3 / kmol / s")
 
     @classmethod
-    def setUpClass(cls):
-        ReactionTests.setUpClass()
+    def setup_class(cls):
+        ReactionTests.setup_class()
         cls._rate_obj = ct.ArrheniusRate(**cls._rate)
 
 
@@ -1350,8 +1350,8 @@ class TestTroe(ReactionTests, utilities.CanteraTest):
     _rc_units = ct.Units("m^3 / kmol / s")
 
     @classmethod
-    def setUpClass(cls):
-        ReactionTests.setUpClass()
+    def setup_class(cls):
+        ReactionTests.setup_class()
         param = cls._rate["low_P_rate_constant"]
         low = ct.Arrhenius(param["A"], param["b"], param["Ea"])
         param = cls._rate["high_P_rate_constant"]
@@ -1389,8 +1389,8 @@ class TestLindemann(ReactionTests, utilities.CanteraTest):
     _rc_units = ct.Units("m^3 / kmol / s")
 
     @classmethod
-    def setUpClass(cls):
-        ReactionTests.setUpClass()
+    def setup_class(cls):
+        ReactionTests.setup_class()
         param = cls._rate["low_P_rate_constant"]
         low = ct.Arrhenius(param["A"], param["b"], param["Ea"])
         param = cls._rate["high_P_rate_constant"]
@@ -1424,8 +1424,8 @@ class TestChemicallyActivated(ReactionTests, utilities.CanteraTest):
     _rc_units = ct.Units("m^3 / kmol / s")
 
     @classmethod
-    def setUpClass(cls):
-        ReactionTests.setUpClass()
+    def setup_class(cls):
+        ReactionTests.setup_class()
         param = cls._rate["low_P_rate_constant"]
         low = ct.Arrhenius(param["A"], param["b"], param["Ea"])
         param = cls._rate["high_P_rate_constant"]
@@ -1464,8 +1464,8 @@ class TestPlog(ReactionTests, utilities.CanteraTest):
     _rc_units = ct.Units("m^3 / kmol / s")
 
     @classmethod
-    def setUpClass(cls):
-        ReactionTests.setUpClass()
+    def setup_class(cls):
+        ReactionTests.setup_class()
         cls._rate_obj = ct.ReactionRate.from_dict(cls._rate)
 
     def eval_rate(self, rate):
@@ -1704,7 +1704,7 @@ class TestExtensible2(utilities.CanteraTest):
     """
 
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         here = str(Path(__file__).parent)
         if here not in sys.path:
             sys.path.append(here)
@@ -1894,8 +1894,8 @@ class InterfaceReactionTests(ReactionTests):
     _coverage_deps = None
 
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.soln = ct.Interface("kineticsfromscratch.yaml", "Pt_surf", transport_model=None)
         cls.adj = [cls.soln.adjacent["ohmech"]]
         cls.gas = cls.adj[0]
@@ -2197,8 +2197,8 @@ class TestElectronCollisionPlasmaReaction(ReactionTests, utilities.CanteraTest):
     _rc_units = ct.Units("m^3 / kmol / s")
 
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.soln = ct.Solution("oxygen-plasma.yaml",
                                "discretized-electron-energy-plasma",
                                transport_model=None)

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -7,9 +7,6 @@ import sys
 import textwrap
 
 import cantera as ct
-from .utilities import (
-    assertArrayNear
-)
 
 
 @pytest.fixture(scope='class')
@@ -1176,7 +1173,7 @@ class ReactionTests:
         # helper function for deprecation tests
         assert type(one) == type(two)
         if isinstance(one, (list, tuple, np.ndarray)):
-            assertArrayNear(one, two)
+            assert one == approx(two)
         elif isinstance(one, (dict, str)):
             assert one == two
         else:

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -4,7 +4,6 @@ import re
 import numpy as np
 import pytest
 from pytest import approx
-from .utilities import allow_deprecated
 
 import cantera as ct
 
@@ -15,7 +14,6 @@ except ImportError:
 
 from cantera.drawnetwork import _graphviz
 
-from . import utilities
 from .utilities import (
     assertNear,
     assertArrayNear,
@@ -2259,11 +2257,11 @@ class TestReactorSensitivities:
     def test_parameter_order1a(self):
         self._test_parameter_order1(ct.IdealGasReactor)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_parameter_order1b(self):
         self._test_parameter_order1(ct.IdealGasConstPressureReactor)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_parameter_order2(self):
         # Multiple reactors, changing the order in which parameters are added
         gas = ct.Solution('h2o2.yaml', transport_model=None)
@@ -2325,7 +2323,7 @@ class TestReactorSensitivities:
         assertArrayNear(S[1][:N], S[3][N:], 1e-5, 1e-5)
         assertArrayNear(S[1][N:], S[3][:N], 1e-5, 1e-5)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_parameter_order3(self):
         # Test including reacting surfaces
         interface = ct.Interface("diamond.yaml", "diamond_100")
@@ -2474,7 +2472,7 @@ class CombustorTestImplementation:
 
     def setup_method(self):
         """ Runs before tests """
-        self.referenceFile = utilities.TEST_DATA_PATH / "CombustorTest-integrateWithAdvance.csv"
+        self.referenceFile = self.test_data_path / "CombustorTest-integrateWithAdvance.csv"
         self.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
         # create a reservoir for the fuel inlet, and set to pure methane.
@@ -2581,7 +2579,7 @@ class WallTestImplementation:
 
     def setup_method(self):
         """ Runs before tests """
-        self.referenceFile = utilities.TEST_DATA_PATH / "WallTest-integrateWithAdvance.csv"
+        self.referenceFile = self.test_data_path / "WallTest-integrateWithAdvance.csv"
         # reservoir to represent the environment
         self.gas0 = ct.Solution("air.yaml")
         self.gas0.TP = 300, ct.one_atm

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -105,8 +105,10 @@ class TestReactor:
         N = self.net.n_vars // 2
         for i in range(N):
             assert self.r1.component_index(self.r1.component_name(i)) ==  i
-            assert self.net.component_name(i) == '{}: {}'.format(self.r1.name, self.r1.component_name(i))
-            assert self.net.component_name(N+i) == '{}: {}'.format(self.r2.name, self.r2.component_name(i))
+            assert (self.net.component_name(i)
+                    == '{}: {}'.format(self.r1.name, self.r1.component_name(i)))
+            assert (self.net.component_name(N+i)
+                    == '{}: {}'.format(self.r2.name, self.r2.component_name(i)))
 
     def test_independent_variable(self):
         self.make_reactors(independent=False, n_reactors=1)
@@ -215,8 +217,6 @@ class TestReactor:
             t = self.net.step()
             assert t - tPrev <= 1.0001 * dt_max
             assert t == approx(self.net.time)
-
-        #assert self.net.time == approx(tEnd)
 
     def test_maxsteps(self):
         self.make_reactors()
@@ -400,11 +400,11 @@ class TestReactor:
         self.r2.volume = 0.25
         w = self.add_wall(U=100, A=0.5)
 
-        assert w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T) == approx(
-               w.heat_rate)
+        assert (w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T)
+                == approx(w.heat_rate))
         self.net.advance(1.0)
-        assert w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T) == approx(
-               w.heat_rate)
+        assert (w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T)
+                == approx(w.heat_rate))
         T1b = self.r1.T
         T2b = self.r2.T
 
@@ -2443,7 +2443,8 @@ class TestReactorSensitivities:
         return dtdp
 
     # @todo: replace np.trapz with np.trapezoid when dropping support for NumPy 1.x
-    @pytest.mark.skip(reason="Integration of sensitivity ODEs is unreliable, see: https://github.com/Cantera/enhancements/issues/55")
+    @pytest.mark.skip(reason="Integration of sensitivity ODEs is unreliable, "
+                              "see: https://github.com/Cantera/enhancements/issues/55")
     @pytest.mark.filterwarnings("ignore:`trapz` is deprecated")
     def test_ignition_delay_sensitivity(self):
         species = ('H2', 'H', 'O2', 'H2O2', 'H2O', 'OH', 'HO2')
@@ -2455,12 +2456,9 @@ class TestReactorSensitivities:
             assert dtigdh_cvodes[i] == approx(dtigdh, rel=5e-2, abs=1e-14)
 
 
-@pytest.fixture(scope='class')
-def setup_combustor_tests(request, test_data_path):
-    request.cls.referenceFile = test_data_path / "CombustorTest-integrateWithAdvance.csv"
 
 @pytest.fixture(scope='function')
-def setup_combustor_tests_data(request, setup_combustor_tests):
+def setup_combustor_tests_data(request):
     gas = ct.Solution('h2o2.yaml', transport_model=None)
 
     # create a reservoir for the fuel inlet, and set to pure methane.
@@ -2518,8 +2516,9 @@ class CombustorTests:
     with some simplifications so that they run faster and produce more
     consistent output.
     """
+    referenceFile = "CombustorTest-integrateWithAdvance.csv"
 
-    def test_integrateWithStep(self):
+    def test_integrateWithStep(self, test_data_path):
         tnow = 0.0
         tfinal = 0.25
         self.data = []
@@ -2529,11 +2528,11 @@ class CombustorTests:
                              list(self.combustor.thermo.X))
 
         assert tnow >= tfinal
-        bad = compareProfiles(self.referenceFile, self.data,
-                                        rtol=1e-3, atol=1e-9)
+        bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+                              rtol=1e-3, atol=1e-9)
         assert not bad, bad
 
-    def test_integrateWithAdvance(self, saveReference=False):
+    def test_integrateWithAdvance(self, test_data_path, saveReference=False):
         self.data = []
         for t in np.linspace(0, 0.25, 101)[1:]:
             self.sim.advance(t)
@@ -2541,13 +2540,14 @@ class CombustorTests:
                              list(self.combustor.thermo.X))
 
         if saveReference:
-            np.savetxt(self.referenceFile, np.array(self.data), '%11.6e', ', ')
+            np.savetxt(test_data_path / self.referenceFile, np.array(self.data),
+                       '%11.6e', ', ')
         else:
-            bad = compareProfiles(self.referenceFile, self.data,
-                                            rtol=1e-6, atol=1e-12)
+            bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+                                  rtol=1e-6, atol=1e-12)
             assert not bad, bad
 
-    def test_invasive_mdot_function(self):
+    def test_invasive_mdot_function(self, test_data_path):
         def igniter_mdot(t, t0=0.1, fwhm=0.05, amplitude=0.1):
             # Querying properties of the igniter changes the state of the
             # underlying ThermoPhase object, but shouldn't affect the
@@ -2562,17 +2562,13 @@ class CombustorTests:
             self.data.append([t, self.combustor.T] +
                              list(self.combustor.thermo.X))
 
-        bad = compareProfiles(self.referenceFile, self.data,
-                                        rtol=1e-6, atol=1e-12)
+        bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+                              rtol=1e-6, atol=1e-12)
         assert not bad, bad
 
 
-@pytest.fixture(scope='class')
-def setup_wall_tests(request, test_data_path):
-    request.cls.referenceFile = test_data_path / "WallTest-integrateWithAdvance.csv"
-
 @pytest.fixture(scope='function')
-def setup_wall_tests_data(request, setup_wall_tests):
+def setup_wall_tests_data(request):
     # reservoir to represent the environment
     gas0 = ct.Solution("air.yaml")
     gas0.TP = 300, ct.one_atm
@@ -2607,8 +2603,9 @@ class WallTests:
     with some simplifications so that they run faster and produce more
     consistent output.
     """
+    referenceFile = "WallTest-integrateWithAdvance.csv"
 
-    def test_integrateWithStep(self):
+    def test_integrateWithStep(self, test_data_path):
         tnow = 0.0
         tfinal = 0.01
         self.data = []
@@ -2620,11 +2617,11 @@ class WallTests:
                               self.r1.volume, self.r2.volume])
 
         assert tnow >= tfinal
-        bad = compareProfiles(self.referenceFile, self.data,
-                                        rtol=1e-3, atol=1e-8)
+        bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+                              rtol=1e-3, atol=1e-8)
         assert not bad, bad
 
-    def test_integrateWithAdvance(self, saveReference=False):
+    def test_integrateWithAdvance(self, test_data_path, saveReference=False):
         self.data = []
         for t in np.linspace(0, 0.01, 200)[1:]:
             self.sim.advance(t)
@@ -2634,10 +2631,11 @@ class WallTests:
                               self.r1.volume, self.r2.volume])
 
         if saveReference:
-            np.savetxt(self.referenceFile, np.array(self.data), '%11.6e', ', ')
+            np.savetxt(test_data_path / self.referenceFile, np.array(self.data),
+                       '%11.6e', ', ')
         else:
-            bad = compareProfiles(self.referenceFile, self.data,
-                                            rtol=2e-5, atol=1e-9)
+            bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+                                  rtol=2e-5, atol=1e-9)
             assert not bad, bad
 
 
@@ -2731,11 +2729,10 @@ class TestPureFluidReactor:
 
 
 @pytest.fixture(scope='function')
-def setup_advance_converages_data(request, cantera_data_path):
+def setup_advance_converages_data(request):
     mechanism_file = 'ptcombust.yaml'
     interface_phase = 'Pt_surf'
-    request.cls.surf = ct.Interface(f'{cantera_data_path}/{mechanism_file}', interface_phase)
-    #request.cls.surf = ct.Interface(mechanism_file, interface_phase)
+    request.cls.surf = ct.Interface(mechanism_file, interface_phase)
     request.cls.gas = request.cls.surf.adjacent["gas"]
 
 @pytest.mark.usefixtures('setup_advance_converages_data')

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -16,8 +16,13 @@ except ImportError:
 from cantera.drawnetwork import _graphviz
 
 from . import utilities
+from .utilities import (
+    assertNear,
+    assertArrayNear,
+    compareProfiles
+)
 
-class TestReactor(utilities.CanteraTest):
+class TestReactor:
     reactorClass = ct.Reactor
 
     def make_reactors(self, independent=True, n_reactors=2,
@@ -50,7 +55,7 @@ class TestReactor(utilities.CanteraTest):
         self.make_reactors(independent=False, n_reactors=1)
         assert not self.net.verbose
         self.net.verbose = True
-        assert not self.net.verbose
+        assert self.net.verbose
 
     @pytest.mark.usefixtures("allow_deprecated")
     def test_insert(self):
@@ -64,7 +69,7 @@ class TestReactor(utilities.CanteraTest):
         g.TP = 300, 101325
         R.insert(g)
 
-        self.assertNear(R.T, 300)
+        assertNear(R.T, 300)
         assert len(R.kinetics.net_production_rates) == g.n_species
 
     def test_volume(self):
@@ -124,10 +129,10 @@ class TestReactor(utilities.CanteraTest):
         self.net.advance(1.0)
 
         # Nothing should change from the initial condition
-        self.assertNear(T1, self.gas1.T)
-        self.assertNear(T2, self.gas2.T)
-        self.assertNear(P1, self.gas1.P)
-        self.assertNear(P2, self.gas2.P)
+        assertNear(T1, self.gas1.T)
+        assertNear(T2, self.gas2.T)
+        assertNear(P1, self.gas1.P)
+        assertNear(P2, self.gas2.P)
 
     def test_disjoint2(self):
         T1, P1 = 300, 101325
@@ -137,10 +142,10 @@ class TestReactor(utilities.CanteraTest):
         self.net.advance(1.0)
 
         # Nothing should change from the initial condition
-        self.assertNear(T1, self.r1.T)
-        self.assertNear(T2, self.r2.T)
-        self.assertNear(P1, self.r1.thermo.P)
-        self.assertNear(P2, self.r2.thermo.P)
+        assertNear(T1, self.r1.T)
+        assertNear(T2, self.r2.T)
+        assertNear(P1, self.r1.thermo.P)
+        assertNear(P2, self.r2.thermo.P)
 
     def test_derivative(self):
         T1, P1 = 300, 101325
@@ -156,7 +161,7 @@ class TestReactor(utilities.CanteraTest):
         dt += self.net.time
         dy += self.net.get_state()
         for i in range(self.net.n_vars):
-            self.assertNear(dydt[i], dy[i]/dt)
+            assertNear(dydt[i], dy[i]/dt)
 
     def test_finite_difference_jacobian(self):
         self.make_reactors(n_reactors=1, T1=900, P1=101325, X1="H2:0.4, O2:0.4, N2:0.2")
@@ -208,15 +213,15 @@ class TestReactor(utilities.CanteraTest):
         assert self.net.max_time_step == dt_max
         self.net.initial_time = tStart
         assert self.net.initial_time == tStart
-        self.assertNear(self.net.time, tStart)
+        assertNear(self.net.time, tStart)
 
         while t < tEnd:
             tPrev = t
             t = self.net.step()
             assert t - tPrev <= 1.0001 * dt_max
-            self.assertNear(t, self.net.time)
+            assertNear(t, self.net.time)
 
-        #self.assertNear(self.net.time, tEnd)
+        #assertNear(self.net.time, tEnd)
 
     def test_maxsteps(self):
         self.make_reactors()
@@ -274,8 +279,8 @@ class TestReactor(utilities.CanteraTest):
 
         self.net.advance(1.0)
 
-        self.assertNear(self.net.time, 1.0)
-        self.assertNear(self.gas1.P, self.gas2.P)
+        assertNear(self.net.time, 1.0)
+        assertNear(self.gas1.P, self.gas2.P)
         assert self.r1.T != approx(self.r2.T)
 
     def test_tolerances(self, rtol_lim=1e-10, atol_lim=1e-20):
@@ -370,8 +375,8 @@ class TestReactor(utilities.CanteraTest):
         self.add_wall(U=500, A=1.0)
 
         self.net.advance(10.0)
-        self.assertNear(self.net.time, 10.0)
-        self.assertNear(self.r1.T, self.r2.T, 5e-7)
+        assertNear(self.net.time, 10.0)
+        assertNear(self.r1.T, self.r2.T, 5e-7)
         assert self.r1.thermo.P != approx(self.r2.thermo.P)
 
     def test_advance_limits_invalid(self):
@@ -400,16 +405,16 @@ class TestReactor(utilities.CanteraTest):
         self.r2.volume = 0.25
         w = self.add_wall(U=100, A=0.5)
 
-        self.assertNear(w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T),
+        assertNear(w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T),
                         w.heat_rate)
         self.net.advance(1.0)
-        self.assertNear(w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T),
+        assertNear(w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T),
                         w.heat_rate)
         T1b = self.r1.T
         T2b = self.r2.T
 
-        self.assertNear(T1a, T1b)
-        self.assertNear(T2a, T2b)
+        assertNear(T1a, T1b)
+        assertNear(T2a, T2b)
 
     def test_equilibrium_UV(self):
         # Adiabatic, constant volume combustion should proceed to equilibrium
@@ -426,10 +431,10 @@ class TestReactor(utilities.CanteraTest):
         gas.TPX = T0, P0, X0
         gas.equilibrate('UV')
 
-        self.assertNear(self.r1.T, gas.T)
-        self.assertNear(self.r1.thermo.density, gas.density)
-        self.assertNear(self.r1.thermo.P, gas.P)
-        self.assertArrayNear(self.r1.thermo.X, gas.X)
+        assertNear(self.r1.T, gas.T)
+        assertNear(self.r1.thermo.density, gas.density)
+        assertNear(self.r1.thermo.P, gas.P)
+        assertArrayNear(self.r1.thermo.X, gas.X)
 
     def test_equilibrium_HP(self):
         # Adiabatic, constant pressure combustion should proceed to equilibrium
@@ -451,10 +456,10 @@ class TestReactor(utilities.CanteraTest):
         gas2.TPX = T0, P0, X0
         gas2.equilibrate('HP')
 
-        self.assertNear(r1.T, gas2.T)
-        self.assertNear(r1.thermo.P, P0)
-        self.assertNear(r1.thermo.density, gas2.density)
-        self.assertArrayNear(r1.thermo.X, gas2.X)
+        assertNear(r1.T, gas2.T)
+        assertNear(r1.thermo.P, P0)
+        assertNear(r1.thermo.density, gas2.density)
+        assertArrayNear(r1.thermo.X, gas2.X)
 
     def test_wall_velocity(self):
         self.make_reactors()
@@ -472,12 +477,12 @@ class TestReactor(utilities.CanteraTest):
         self.w.velocity = v
         self.net.advance(1.0)
         assert self.w.velocity == approx(v(1.0))
-        self.assertNear(self.w.expansion_rate, 1.0 * A, 1e-7)
+        assertNear(self.w.expansion_rate, 1.0 * A, 1e-7)
         self.net.advance(2.0)
-        self.assertNear(self.w.expansion_rate, 0.0, 1e-7)
+        assertNear(self.w.expansion_rate, 0.0, 1e-7)
 
-        self.assertNear(self.r1.volume, V1 + 1.0 * A, 1e-7)
-        self.assertNear(self.r2.volume, V2 - 1.0 * A, 1e-7)
+        assertNear(self.r1.volume, V1 + 1.0 * A, 1e-7)
+        assertNear(self.r2.volume, V2 - 1.0 * A, 1e-7)
 
     def test_disable_energy(self):
         self.make_reactors(T1=500)
@@ -485,8 +490,8 @@ class TestReactor(utilities.CanteraTest):
         self.add_wall(A=1.0, U=2500)
         self.net.advance(11.0)
 
-        self.assertNear(self.r1.T, 500)
-        self.assertNear(self.r2.T, 500)
+        assertNear(self.r1.T, 500)
+        assertNear(self.r2.T, 500)
 
     def test_disable_chemistry(self):
         self.make_reactors(T1=1000, n_reactors=1, X1='H2:2.0,O2:1.0')
@@ -494,9 +499,9 @@ class TestReactor(utilities.CanteraTest):
 
         self.net.advance(11.0)
 
-        self.assertNear(self.r1.T, 1000)
-        self.assertNear(self.r1.thermo.X[self.r1.thermo.species_index('H2')], 2.0/3.0)
-        self.assertNear(self.r1.thermo.X[self.r1.thermo.species_index('O2')], 1.0/3.0)
+        assertNear(self.r1.T, 1000)
+        assertNear(self.r1.thermo.X[self.r1.thermo.species_index('H2')], 2.0/3.0)
+        assertNear(self.r1.thermo.X[self.r1.thermo.species_index('O2')], 1.0/3.0)
 
     def test_heat_flux_func(self):
         self.make_reactors(T1=500, T2=300)
@@ -518,10 +523,10 @@ class TestReactor(utilities.CanteraTest):
         U1b = self.r1.volume * self.r1.density * self.r1.thermo.u
         U2b = self.r2.volume * self.r2.density * self.r2.thermo.u
 
-        self.assertNear(V1a, self.r1.volume)
-        self.assertNear(V2a, self.r2.volume)
-        self.assertNear(U1a - Q, U1b, 1e-6)
-        self.assertNear(U2a + Q, U2b, 1e-6)
+        assertNear(V1a, self.r1.volume)
+        assertNear(V2a, self.r2.volume)
+        assertNear(U1a - Q, U1b, 1e-6)
+        assertNear(U2a + Q, U2b, 1e-6)
 
     def test_mass_flow_controller(self):
         self.make_reactors(n_reactors=1)
@@ -544,15 +549,15 @@ class TestReactor(utilities.CanteraTest):
             else:
                 return 0.0
         mfc.mass_flow_rate = mdot
-        self.assertEqual(mfc.mass_flow_coeff, 1.)
+        assert mfc.mass_flow_coeff == 1.
 
-        self.assertEqual(mfc.type, type(mfc).__name__)
-        self.assertEqual(len(reservoir.inlets), 0)
-        self.assertEqual(len(reservoir.outlets), 1)
-        self.assertEqual(reservoir.outlets[0], mfc)
-        self.assertEqual(len(self.r1.outlets), 0)
-        self.assertEqual(len(self.r1.inlets), 1)
-        self.assertEqual(self.r1.inlets[0], mfc)
+        assert mfc.type == type(mfc).__name__
+        assert len(reservoir.inlets) == 0
+        assert len(reservoir.outlets) == 1
+        assert reservoir.outlets[0] == mfc
+        assert len(self.r1.outlets) == 0
+        assert len(self.r1.inlets) == 1
+        assert self.r1.inlets[0] == mfc
 
         ma = self.r1.volume * self.r1.density
         Ya = self.r1.Y
@@ -561,21 +566,21 @@ class TestReactor(utilities.CanteraTest):
         self.net.max_time_step = 0.05
 
         self.net.advance(0.1)
-        self.assertNear(mfc.mass_flow_rate, 0.)
+        assertNear(mfc.mass_flow_rate, 0.)
         self.net.advance(0.3)
-        self.assertNear(mfc.mass_flow_rate, 0.04)
+        assertNear(mfc.mass_flow_rate, 0.04)
         self.net.advance(1.0)
-        self.assertNear(mfc.mass_flow_rate, 0.08)
+        assertNear(mfc.mass_flow_rate, 0.08)
         self.net.advance(1.2)
-        self.assertNear(mfc.mass_flow_rate, 0.)
+        assertNear(mfc.mass_flow_rate, 0.)
 
         self.net.advance(2.5)
 
         mb = self.r1.volume * self.r1.density
         Yb = self.r1.Y
 
-        self.assertNear(ma + 0.1, mb)
-        self.assertArrayNear(ma * Ya + 0.1 * gas2.Y, mb * Yb)
+        assertNear(ma + 0.1, mb)
+        assertArrayNear(ma * Ya + 0.1 * gas2.Y, mb * Yb)
 
     def test_mass_flow_controller_type(self):
         self.make_reactors(n_reactors=2)
@@ -592,7 +597,7 @@ class TestReactor(utilities.CanteraTest):
         mfc = ct.MassFlowController(self.r1, self.r2)
         mfc.mass_flow_rate = lambda t: eggs
 
-        with self.assertRaisesRegex(Exception, 'eggs'):
+        with pytest.raises(Exception, match='eggs'):
             self.net.step()
 
         with pytest.raises(NotImplementedError):
@@ -605,13 +610,13 @@ class TestReactor(utilities.CanteraTest):
         k = 2e-5
         valve.valve_coeff = k
 
-        self.assertEqual(self.r1.outlets, self.r2.inlets)
-        self.assertEqual(valve.valve_coeff, k)
-        self.assertTrue(self.r1.energy_enabled)
-        self.assertTrue(self.r2.energy_enabled)
+        assert self.r1.outlets == self.r2.inlets
+        assert valve.valve_coeff == k
+        assert self.r1.energy_enabled
+        assert self.r2.energy_enabled
         self.net.initialize()
-        self.assertNear((self.r1.thermo.P - self.r2.thermo.P) * k,
-                        valve.mass_flow_rate)
+        assertNear((self.r1.thermo.P - self.r2.thermo.P) * k,
+                   valve.mass_flow_rate)
 
         m1a = self.r1.thermo.density * self.r1.volume
         m2a = self.r2.thermo.density * self.r2.volume
@@ -623,13 +628,13 @@ class TestReactor(utilities.CanteraTest):
         m1b = self.r1.thermo.density * self.r1.volume
         m2b = self.r2.thermo.density * self.r2.volume
 
-        self.assertNear((self.r1.thermo.P - self.r2.thermo.P) * k,
+        assertNear((self.r1.thermo.P - self.r2.thermo.P) * k,
                         valve.mass_flow_rate)
-        self.assertNear(m1a+m2a, m1b+m2b)
+        assertNear(m1a+m2a, m1b+m2b)
         Y1b = self.r1.thermo.Y
         Y2b = self.r2.thermo.Y
-        self.assertArrayNear(m1a*Y1a + m2a*Y2a, m1b*Y1b + m2b*Y2b, atol=1e-10)
-        self.assertArrayNear(Y1a, Y1b)
+        assertArrayNear(m1a*Y1a + m2a*Y2a, m1b*Y1b + m2b*Y2b, atol=1e-10)
+        assertArrayNear(Y1a, Y1b)
 
     def test_valve2(self):
         # Similar to test_valve1, but by disabling the energy equation
@@ -642,10 +647,10 @@ class TestReactor(utilities.CanteraTest):
         valve = ct.Valve(self.r1, self.r2)
         k = 2e-5
         valve.valve_coeff = k
-        self.assertEqual(valve.valve_coeff, k)
+        assert valve.valve_coeff == k
 
-        self.assertFalse(self.r1.energy_enabled)
-        self.assertFalse(self.r2.energy_enabled)
+        assert not self.r1.energy_enabled
+        assert not self.r2.energy_enabled
 
         m1a = self.r1.thermo.density * self.r1.volume
         m2a = self.r2.thermo.density * self.r2.volume
@@ -660,9 +665,9 @@ class TestReactor(utilities.CanteraTest):
             self.net.advance(t)
             m1 = self.r1.thermo.density * self.r1.volume
             m2 = self.r2.thermo.density * self.r2.volume
-            self.assertNear(m2, (m2a - A/B) * np.exp(-B * t) + A/B)
-            self.assertNear(m1a+m2a, m1+m2)
-            self.assertArrayNear(self.r1.Y, Y1)
+            assertNear(m2, (m2a - A/B) * np.exp(-B * t) + A/B)
+            assertNear(m1a+m2a, m1+m2)
+            assertArrayNear(self.r1.Y, Y1)
 
     def test_valve3(self):
         # This case specifies a non-linear relationship between pressure drop
@@ -674,7 +679,7 @@ class TestReactor(utilities.CanteraTest):
         valve = ct.Valve(self.r1, self.r2)
         mdot = lambda dP: 5e-3 * np.sqrt(dP) if dP > 0 else 0.0
         valve.pressure_function = mdot
-        self.assertEqual(valve.valve_coeff, 1.)
+        assert valve.valve_coeff == 1.
 
         Y1 = self.r1.Y
         kO2 = self.gas1.species_index('O2')
@@ -690,10 +695,10 @@ class TestReactor(utilities.CanteraTest):
             t = self.net.step()
             p1 = self.r1.thermo.P
             p2 = self.r2.thermo.P
-            self.assertNear(mdot(p1-p2), valve.mass_flow_rate)
-            self.assertArrayNear(Y1, self.r1.Y)
-            self.assertNear(speciesMass(kAr), mAr)
-            self.assertNear(speciesMass(kO2), mO2)
+            assertNear(mdot(p1-p2), valve.mass_flow_rate)
+            assertArrayNear(Y1, self.r1.Y)
+            assertNear(speciesMass(kAr), mAr)
+            assertNear(speciesMass(kO2), mO2)
 
     def test_valve_timing(self):
         # test timed valve
@@ -748,12 +753,12 @@ class TestReactor(utilities.CanteraTest):
         self.make_reactors()
         res = ct.Reservoir()  # warning raised from C++ code
 
-        with self.assertRaisesRegex(ct.CanteraError, 'contents not defined'):
+        with pytest.raises(ct.CanteraError, match='contents not defined'):
             # Must assign contents of both reactors before creating Valve
             v = ct.Valve(self.r1, res)
 
         v = ct.Valve(self.r1, self.r2)
-        with self.assertRaisesRegex(ct.CanteraError, 'Already installed'):
+        with pytest.raises(ct.CanteraError, match='Already installed'):
             # inlet and outlet cannot be reassigned
             v._install(self.r2, self.r1)
 
@@ -773,14 +778,14 @@ class TestReactor(utilities.CanteraTest):
         pc = ct.PressureController(self.r1, outlet_reservoir)
         pc.primary = mfc
         pc.pressure_coeff = 1e-5
-        self.assertEqual(pc.pressure_coeff, 1e-5)
+        assert pc.pressure_coeff == 1e-5
 
         t = 0
         while t < 1.0:
             t = self.net.step()
-            self.assertNear(mdot(t), mfc.mass_flow_rate)
+            assertNear(mdot(t), mfc.mass_flow_rate)
             dP = self.r1.thermo.P - outlet_reservoir.thermo.P
-            self.assertNear(mdot(t) + 1e-5 * dP, pc.mass_flow_rate)
+            assertNear(mdot(t) + 1e-5 * dP, pc.mass_flow_rate)
 
     def test_pressure_controller2(self):
         self.make_reactors(n_reactors=1)
@@ -799,14 +804,14 @@ class TestReactor(utilities.CanteraTest):
         pc.primary = mfc
         pfunc = lambda dp: 1.e-5 * abs(dp)**.5
         pc.pressure_function = pfunc
-        self.assertEqual(pc.pressure_coeff, 1.)
+        assert pc.pressure_coeff == 1.
 
         t = 0
         while t < 1.0:
             t = self.net.step()
-            self.assertNear(mdot(t), mfc.mass_flow_rate)
+            assertNear(mdot(t), mfc.mass_flow_rate)
             dP = self.r1.thermo.P - outlet_reservoir.thermo.P
-            self.assertNear(mdot(t) + pfunc(dP), pc.mass_flow_rate)
+            assertNear(mdot(t) + pfunc(dP), pc.mass_flow_rate)
 
     def test_pressure_controller_type(self):
         self.make_reactors()
@@ -826,11 +831,11 @@ class TestReactor(utilities.CanteraTest):
 
         p = ct.PressureController(self.r1, self.r2, primary=mfc, K=0.5)
 
-        with self.assertRaisesRegex(ct.CanteraError, 'is not ready'):
+        with pytest.raises(ct.CanteraError, match='is not ready'):
             p = ct.PressureController(self.r1, self.r2, K=0.5)
             p.mass_flow_rate
 
-        with self.assertRaisesRegex(ct.CanteraError, 'is not ready'):
+        with pytest.raises(ct.CanteraError, match='is not ready'):
             p = ct.PressureController(self.r1, self.r2)
             p.mass_flow_rate
 
@@ -848,7 +853,7 @@ class TestReactor(utilities.CanteraTest):
         t0 = 0.0
         tf = t0 + 0.5
         self.net.advance(tf)
-        self.assertNear(self.net.time, tf)
+        assertNear(self.net.time, tf)
         p1a = self.r1.thermo.P
         p2a = self.r2.thermo.P
         assert valve.pressure_function == approx(pfunc_a(p1a - p2a))
@@ -863,13 +868,13 @@ class TestReactor(utilities.CanteraTest):
         self.net.initial_time = t0
         tf = t0 + 0.5
         self.net.advance(tf)
-        self.assertNear(self.net.time, tf)
+        assertNear(self.net.time, tf)
         p1b = self.r1.thermo.P
         p2b = self.r2.thermo.P
         assert valve.pressure_function == approx(pfunc_b(p1b - p2b))
 
-        self.assertNear(p1a, p1b)
-        self.assertNear(p2a, p2b)
+        assertNear(p1a, p1b)
+        assertNear(p2a, p2b)
 
     def test_reinitialize(self):
         self.make_reactors(T1=300, T2=1000, independent=False)
@@ -884,43 +889,43 @@ class TestReactor(utilities.CanteraTest):
         self.r2.thermo.TD = 1000, None
         self.r2.syncState()
 
-        self.assertNear(self.r1.T, 300)
-        self.assertNear(self.r2.T, 1000)
+        assertNear(self.r1.T, 300)
+        assertNear(self.r2.T, 1000)
         self.net.advance(2.0)
         T1b = self.r1.T
         T2b = self.r2.T
 
-        self.assertNear(T1a, T1b)
-        self.assertNear(T2a, T2b)
+        assertNear(T1a, T1b)
+        assertNear(T2a, T2b)
 
     def test_unpicklable(self):
         self.make_reactors()
         import pickle
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             pickle.dumps(self.r1)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             pickle.dumps(self.net)
 
     def test_uncopyable(self):
         self.make_reactors()
         import copy
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             copy.copy(self.r1)
-        with self.assertRaises(NotImplementedError):
+        with pytest.raises(NotImplementedError):
             copy.copy(self.net)
 
     def test_invalid_property(self):
         self.make_reactors()
         for x in (self.r1, self.net):
-            with self.assertRaises(AttributeError):
+            with pytest.raises(AttributeError):
                 x.foobar = 300
-            with self.assertRaises(AttributeError):
+            with pytest.raises(AttributeError):
                 x.foobar
 
     def test_bad_kwarg(self):
         g = ct.Solution('h2o2.yaml', transport_model=None)
         self.reactorClass(g, name='ok')
-        with self.assertRaises(ct.CanteraError):
+        with pytest.raises(ct.CanteraError):
             self.reactorClass(foobar=3.14)
 
     def test_preconditioner_unsupported(self):
@@ -928,7 +933,7 @@ class TestReactor(utilities.CanteraTest):
         self.net.preconditioner = ct.AdaptivePreconditioner()
         # initialize should throw an error because the mass fraction
         # reactors do not support preconditioning
-        with self.assertRaises(ct.CanteraError):
+        with pytest.raises(ct.CanteraError):
             self.net.initialize()
 
     @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
@@ -1151,11 +1156,11 @@ class TestMoleReactor(TestReactor):
         for i in np.linspace(0, 0.0025, 50)[1:]:
             net1.advance(i)
             net2.advance(i)
-            self.assertArrayNear(r1.thermo.Y, r2.thermo.Y, rtol=5e-4, atol=1e-6)
-            self.assertNear(r1.T, r2.T, rtol=5e-5)
-            self.assertNear(r1.thermo.P, r2.thermo.P, rtol=1e-6)
-            self.assertArrayNear(rsurf1.coverages, rsurf2.coverages, rtol=1e-4,
-                atol=1e-8)
+            assertArrayNear(r1.thermo.Y, r2.thermo.Y, rtol=5e-4, atol=1e-6)
+            assertNear(r1.T, r2.T, rtol=5e-5)
+            assertNear(r1.thermo.P, r2.thermo.P, rtol=1e-6)
+            assertArrayNear(rsurf1.coverages, rsurf2.coverages, rtol=1e-4,
+                            atol=1e-8)
 
     def test_tolerances(self, rtol_lim=1e-8, atol_lim=1e-18):
         super().test_tolerances(rtol_lim, atol_lim)
@@ -1164,9 +1169,10 @@ class TestIdealGasReactor(TestReactor):
     reactorClass = ct.IdealGasReactor
 
 
-class TestWellStirredReactorIgnition(utilities.CanteraTest):
+class TestWellStirredReactorIgnition:
     """ Ignition (or not) of a well-stirred reactor """
-    def setup(self, T0, P0, mdot_fuel, mdot_ox):
+    def setup_reactor(self, T0, P0, mdot_fuel, mdot_ox):
+        """ Runs before tests """
         gas_def = """
         phases:
         - name: gas
@@ -1226,60 +1232,60 @@ class TestWellStirredReactorIgnition(utilities.CanteraTest):
         mdot_f = 1.0
         mdot_o = 5.0
         T0 = 900.0
-        self.setup(T0, 10*ct.one_atm, mdot_f, mdot_o)
+        self.setup_reactor(T0, 10*ct.one_atm, mdot_f, mdot_o)
         self.gas.set_multiplier(0.0)
         t,T = self.integrate(100.0)
 
         for i in range(len(t)):
-            self.assertNear(T[i], T0, rtol=1e-5)
+            assertNear(T[i], T0, rtol=1e-5)
 
-        self.assertNear(self.combustor.thermo['CH4'].Y,
-                        mdot_f / (mdot_o + mdot_f))
+        assertNear(self.combustor.thermo['CH4'].Y,
+                   mdot_f / (mdot_o + mdot_f))
 
     def test_ignition1(self):
-        self.setup(900.0, 10*ct.one_atm, 1.0, 5.0)
+        self.setup_reactor(900.0, 10*ct.one_atm, 1.0, 5.0)
         t,T = self.integrate(10.0)
 
-        self.assertTrue(T[-1] > 1200) # mixture ignited
+        assert T[-1] > 1200 # mixture ignited
         for i in range(len(t)):
             if T[i] > 0.5 * (T[0] + T[-1]):
                 tIg = t[i]
                 break
 
         # regression test; no external basis for this result
-        self.assertNear(tIg, 2.2249, 1e-3)
+        assertNear(tIg, 2.2249, 1e-3)
 
     def test_ignition2(self):
-        self.setup(900.0, 10*ct.one_atm, 1.0, 20.0)
+        self.setup_reactor(900.0, 10*ct.one_atm, 1.0, 20.0)
         t,T = self.integrate(10.0)
 
-        self.assertTrue(T[-1] > 1200) # mixture ignited
+        assert T[-1] > 1200 # mixture ignited
         for i in range(len(t)):
             if T[i] > 0.5 * (T[0] + T[-1]):
                 tIg = t[i]
                 break
 
         # regression test; no external basis for this result
-        self.assertNear(tIg, 1.4856, 1e-3)
+        assertNear(tIg, 1.4856, 1e-3)
 
     def test_ignition3(self):
-        self.setup(900.0, 10*ct.one_atm, 1.0, 80.0)
+        self.setup_reactor(900.0, 10*ct.one_atm, 1.0, 80.0)
         self.net.max_time_step = 0.5
         t,T = self.integrate(100.0)
-        self.assertTrue(T[-1] < 910) # mixture did not ignite
+        assert T[-1] < 910 # mixture did not ignite
 
     def test_steady_state(self):
-        self.setup(900.0, 10*ct.one_atm, 1.0, 20.0)
+        self.setup_reactor(900.0, 10*ct.one_atm, 1.0, 20.0)
         residuals = self.net.advance_to_steady_state(return_residuals=True)
         # test if steady state is reached
-        self.assertTrue(residuals[-1] < 10. * self.net.rtol)
+        assert residuals[-1] < 10. * self.net.rtol
         # regression test; no external basis for these results
-        self.assertNear(self.combustor.T, 2498.94, 1e-5)
-        self.assertNear(self.combustor.thermo['H2O'].Y[0], 0.103658, 1e-5)
-        self.assertNear(self.combustor.thermo['HO2'].Y[0], 8.734515e-06, 1e-5)
+        assertNear(self.combustor.T, 2498.94, 1e-5)
+        assertNear(self.combustor.thermo['H2O'].Y[0], 0.103658, 1e-5)
+        assertNear(self.combustor.thermo['HO2'].Y[0], 8.734515e-06, 1e-5)
 
 
-class TestConstPressureReactor(utilities.CanteraTest):
+class TestConstPressureReactor:
     """
     The constant pressure reactor should give essentially the same results as
     as a regular "Reactor" with a wall with a very high expansion rate
@@ -1372,27 +1378,27 @@ class TestConstPressureReactor(utilities.CanteraTest):
             N0 = net.n_vars - gas.n_species - iface.n_species
             N1 = net.n_vars - iface.n_species
             for i, name in enumerate(gas.species_names):
-                self.assertEqual(i + N0, r.component_index(name))
+                assert i + N0 == r.component_index(name)
             for i, name in enumerate(iface.species_names):
-                self.assertEqual(i + N1, r.component_index(name))
+                assert i + N1 == r.component_index(name)
 
     def test_component_names(self):
         self.create_reactors(add_surf=True)
         for i in range(self.net1.n_vars):
-            self.assertEqual(self.r1.component_index(self.r1.component_name(i)), i)
-            self.assertEqual(self.net1.component_name(i),
-                '{}: {}'.format(self.r1.name, self.r1.component_name(i)))
+            assert self.r1.component_index(self.r1.component_name(i)) == i
+            assert self.net1.component_name(i) == '{}: {}'.format(self.r1.name,
+                                                                  self.r1.component_name(i))
 
     def integrate(self, surf=False):
         for t in np.arange(0.5, 50, 1.0):
             self.net1.advance(t)
             self.net2.advance(t)
-            self.assertArrayNear(self.r1.thermo.Y, self.r2.thermo.Y,
-                                 rtol=5e-4, atol=1e-6)
-            self.assertNear(self.r1.T, self.r2.T, rtol=5e-5)
-            self.assertNear(self.r1.thermo.P, self.r2.thermo.P, rtol=1e-6)
+            assertArrayNear(self.r1.thermo.Y, self.r2.thermo.Y,
+                            rtol=5e-4, atol=1e-6)
+            assertNear(self.r1.T, self.r2.T, rtol=5e-5)
+            assertNear(self.r1.thermo.P, self.r2.thermo.P, rtol=1e-6)
             if surf:
-                self.assertArrayNear(self.surf1.coverages, self.surf2.coverages,
+                assertArrayNear(self.surf1.coverages, self.surf2.coverages,
                                      rtol=1e-4, atol=1e-8)
 
     def test_closed(self):
@@ -1418,7 +1424,7 @@ class TestConstPressureReactor(utilities.CanteraTest):
         self.net2.preconditioner = ct.AdaptivePreconditioner()
         # initialize should throw an error because the mass fraction
         # reactors do not support preconditioning
-        with self.assertRaises(ct.CanteraError):
+        with pytest.raises(ct.CanteraError):
             self.net2.initialize()
 
 class TestConstPressureMoleReactor(TestConstPressureReactor):
@@ -1450,7 +1456,7 @@ class TestIdealGasConstPressureMoleReactor(TestConstPressureMoleReactor):
         self.create_reactors()
         assert self.precon.side == "right"
         self.net2.initialize()
-        self.assertEqual(self.net2.linear_solver_type, "GMRES")
+        assert self.net2.linear_solver_type == "GMRES"
 
 
 class TestIdealGasMoleReactor(TestMoleReactor):
@@ -1484,13 +1490,12 @@ class TestIdealGasMoleReactor(TestMoleReactor):
         for t in np.arange(0.5, 5, 0.5):
             net1.advance(t)
             net2.advance(t)
-            self.assertArrayNear(r1.thermo.Y, r2.thermo.Y,
-                                 rtol=5e-4, atol=1e-6)
-            self.assertNear(r1.T, r2.T, rtol=1e-5)
-            self.assertNear(r1.thermo.P, r2.thermo.P, rtol=1e-5)
+            assertArrayNear(r1.thermo.Y, r2.thermo.Y, rtol=5e-4, atol=1e-6)
+            assertNear(r1.T, r2.T, rtol=1e-5)
+            assertNear(r1.thermo.P, r2.thermo.P, rtol=1e-5)
 
 
-class TestReactorJacobians(utilities.CanteraTest):
+class TestReactorJacobians:
 
     def test_multi_surface_simple(self):
         # conditions for simulation
@@ -1520,11 +1525,11 @@ class TestReactorJacobians(utilities.CanteraTest):
         # the volume row is not considered in comparisons because it is presently
         # not calculated.
         # check first row is near, terms which are generally on the order of 1e5 to 1e7
-        self.assertArrayNear(jacobian[0, 2:], fd_jacobian[0, 2:], 1e-1, 1e-2)
+        assertArrayNear(jacobian[0, 2:], fd_jacobian[0, 2:], 1e-1, 1e-2)
         # check first col is near, these are finite difference terms and should be close
-        self.assertArrayNear(jacobian[2:, 0], fd_jacobian[2:, 0], 1e-3, 1e-4)
+        assertArrayNear(jacobian[2:, 0], fd_jacobian[2:, 0], 1e-3, 1e-4)
         # check all species are near, these terms are usually ~ 1e2
-        self.assertArrayNear(jacobian[2:, 2:], fd_jacobian[2:, 2:], 1e-3, 1e-4)
+        assertArrayNear(jacobian[2:, 2:], fd_jacobian[2:, 2:], 1e-3, 1e-4)
 
     def test_gas_simple(self):
         # conditions for simulation
@@ -1540,7 +1545,7 @@ class TestReactorJacobians(utilities.CanteraTest):
         net = ct.ReactorNet([r])
         net.initialize()
         # compare jacobians
-        self.assertArrayNear(r.jacobian, r.finite_difference_jacobian, rtol=1e-6)
+        assertArrayNear(r.jacobian, r.finite_difference_jacobian, rtol=1e-6)
 
     def test_const_volume_hydrogen_single(self):
         # conditions for simulation
@@ -1562,11 +1567,11 @@ class TestReactorJacobians(utilities.CanteraTest):
         # the volume row is not considered in comparisons because it is presently
         # not calculated.
         # check first row is near, terms which are generally on the order of 1e5 to 1e7
-        self.assertArrayNear(jacobian[0, 2:], fd_jacobian[0, 2:], 1e-2, 1e-3)
+        assertArrayNear(jacobian[0, 2:], fd_jacobian[0, 2:], 1e-2, 1e-3)
         # check first col is near, these are finite difference terms and should be close
-        self.assertArrayNear(jacobian[2:, 0], fd_jacobian[2:, 0], 1e-3, 1e-4)
+        assertArrayNear(jacobian[2:, 0], fd_jacobian[2:, 0], 1e-3, 1e-4)
         # check all species are near, these terms are usually ~ 1e2
-        self.assertArrayNear(jacobian[2:, 2:], fd_jacobian[2:, 2:], 1e-3, 1e-4)
+        assertArrayNear(jacobian[2:, 2:], fd_jacobian[2:, 2:], 1e-3, 1e-4)
 
     def test_const_pressure_hydrogen_single(self):
         # conditions for simulation
@@ -1583,7 +1588,7 @@ class TestReactorJacobians(utilities.CanteraTest):
         net = ct.ReactorNet([r])
         net.step()
         # compare analytical jacobian with finite difference
-        self.assertArrayNear(r.jacobian, r.finite_difference_jacobian, 1e-3, 1e-4)
+        assertArrayNear(r.jacobian, r.finite_difference_jacobian, 1e-3, 1e-4)
 
     def test_phase_order_surf_jacobian(self):
         # create gas phase
@@ -1633,7 +1638,7 @@ class TestReactorJacobians(utilities.CanteraTest):
         net.derivative_settings = {"skip-coverage-dependence":True}
         net.initialize()
         # check that they two arrays are the same
-        self.assertArrayNear(r1.jacobian, r2.jacobian, 2e-6, 1e-8)
+        assertArrayNear(r1.jacobian, r2.jacobian, 2e-6, 1e-8)
 
 # A rate type used for testing integrator error handling
 class FailRateData(ct.ExtensibleRateData):
@@ -1661,7 +1666,7 @@ class FailRate(ct.ExtensibleRate):
         return 0.0
 
 
-class TestFlowReactor(utilities.CanteraTest):
+class TestFlowReactor:
     gas_def = """
     phases:
     - name: gas
@@ -1686,10 +1691,10 @@ class TestFlowReactor(utilities.CanteraTest):
 
         x = 0
         v0 = r.speed
-        self.assertNear(v0, 10 / r.density)
+        assertNear(v0, 10 / r.density)
         while x < 10.0:
             x = net.step()
-            self.assertNear(v0, r.speed)
+            assertNear(v0, r.speed)
 
     def test_reacting(self):
         g = ct.Solution(yaml=self.gas_def)
@@ -1780,7 +1785,7 @@ class TestFlowReactor(utilities.CanteraTest):
         with pytest.raises(ct.CanteraError, match='out of bounds'):
             r.component_name(200)
 
-class TestFlowReactor2(utilities.CanteraTest):
+class TestFlowReactor2:
     def import_phases(self):
         surf = ct.Interface('SiF4_NH3_mec.yaml', 'SI3N4')
         return surf, surf.adjacent['gas']
@@ -1830,7 +1835,8 @@ class TestFlowReactor2(utilities.CanteraTest):
         surf.TP = gas.TP
         r, rsurf, sim = self.make_reactors(gas, surf)
 
-        with pytest.raises(ct.CanteraError, match="repeated recoverable residual errors"):
+        with pytest.raises(ct.CanteraError,
+                           match="repeated recoverable residual errors"):
             while r.thermo.T > 1300:
                 sim.step()
 
@@ -1846,7 +1852,8 @@ class TestFlowReactor2(utilities.CanteraTest):
         surf.TP = gas.TP
         r, rsurf, sim = self.make_reactors(gas, surf)
 
-        with pytest.raises(ct.CanteraError, match="repeated recoverable residual errors"):
+        with pytest.raises(ct.CanteraError,
+                           match="repeated recoverable residual errors"):
             while r.thermo.T > 1300:
                 sim.advance(sim.distance + 0.01)
 
@@ -2030,7 +2037,7 @@ class TestFlowReactor2(utilities.CanteraTest):
         sim.initialize()
 
 
-class TestSurfaceKinetics(utilities.CanteraTest):
+class TestSurfaceKinetics:
     def make_reactors(self):
         self.net = ct.ReactorNet()
 
@@ -2050,22 +2057,22 @@ class TestSurfaceKinetics(utilities.CanteraTest):
         surf1 = ct.ReactorSurface(self.interface, self.r1)
 
         surf1.coverages = {'c6HH':0.3, 'c6HM':0.7}
-        self.assertNear(surf1.coverages[0], 0.3)
-        self.assertNear(surf1.coverages[1], 0.0)
-        self.assertNear(surf1.coverages[4], 0.7)
+        assertNear(surf1.coverages[0], 0.3)
+        assertNear(surf1.coverages[1], 0.0)
+        assertNear(surf1.coverages[4], 0.7)
         self.net.advance(1e-5)
         C_left = surf1.coverages
 
         self.make_reactors()
         surf2 = ct.ReactorSurface(self.interface, self.r2)
         surf2.coverages = 'c6HH:0.3, c6HM:0.7'
-        self.assertNear(surf2.coverages[0], 0.3)
-        self.assertNear(surf2.coverages[4], 0.7)
+        assertNear(surf2.coverages[0], 0.3)
+        assertNear(surf2.coverages[4], 0.7)
         self.net.advance(1e-5)
         C_right = surf2.coverages
 
-        self.assertNear(sum(C_left), 1.0)
-        self.assertArrayNear(C_left, C_right)
+        assertNear(sum(C_left), 1.0)
+        assertArrayNear(C_left, C_right)
 
         with pytest.raises(ValueError):
             surf2.coverages = np.ones(self.interface.n_species + 1)
@@ -2082,7 +2089,7 @@ class TestSurfaceKinetics(utilities.CanteraTest):
         C[4] = 0.7
 
         surf1.coverages = C
-        self.assertArrayNear(surf1.coverages, C)
+        assertArrayNear(surf1.coverages, C)
         data = []
         test_file = self.test_work_path / "test_coverages_regression1.csv"
         reference_file = self.test_data_path / "WallKinetics-coverages-regression1.csv"
@@ -2093,9 +2100,9 @@ class TestSurfaceKinetics(utilities.CanteraTest):
                         list(self.r1.thermo.X) + list(surf1.coverages))
         np.savetxt(test_file, data, delimiter=',')
 
-        bad = utilities.compareProfiles(reference_file, test_file,
+        bad = compareProfiles(reference_file, test_file,
                                         rtol=1e-5, atol=1e-9, xtol=1e-12)
-        self.assertFalse(bool(bad), bad)
+        assert not bool(bad), bad
 
     def test_coverages_regression2(self):
         # Test with energy equation enabled
@@ -2107,7 +2114,7 @@ class TestSurfaceKinetics(utilities.CanteraTest):
         C[4] = 0.7
 
         surf.coverages = C
-        self.assertArrayNear(surf.coverages, C)
+        assertArrayNear(surf.coverages, C)
         data = []
         test_file = self.test_work_path / "test_coverages_regression2.csv"
         reference_file = self.test_data_path / "WallKinetics-coverages-regression2.csv"
@@ -2118,9 +2125,9 @@ class TestSurfaceKinetics(utilities.CanteraTest):
                         list(self.r1.thermo.X) + list(surf.coverages))
         np.savetxt(test_file, data, delimiter=',')
 
-        bad = utilities.compareProfiles(reference_file, test_file,
+        bad = compareProfiles(reference_file, test_file,
                                         rtol=1e-5, atol=1e-9, xtol=1e-12)
-        self.assertFalse(bool(bad), bad)
+        assert not bool(bad), bad
 
     @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_ReactorSurface(self):
@@ -2135,10 +2142,10 @@ class TestSurfaceKinetics(utilities.CanteraTest):
                     '\t"Reactor surface" [shape=underline style=filled]\n',
                     ('\tReactor -> "Reactor surface" '
                      '[arrowhead=none color=red style=dotted]\n')]
-        self.assertEqual(graph.body, expected)
+        assert graph.body == expected
 
 
-class TestReactorSensitivities(utilities.CanteraTest):
+class TestReactorSensitivities:
     def test_sensitivities1(self):
         net = ct.ReactorNet()
         gas = ct.Solution('gri30.yaml', transport_model=None)
@@ -2146,17 +2153,16 @@ class TestReactorSensitivities(utilities.CanteraTest):
         r1 = ct.IdealGasReactor(gas)
         net.add_reactor(r1)
 
-        self.assertEqual(net.n_sensitivity_params, 0)
+        assert net.n_sensitivity_params == 0
         r1.add_sensitivity_reaction(40)
         r1.add_sensitivity_reaction(41)
 
         net.advance(0.1)
 
-        self.assertEqual(net.n_sensitivity_params, 2)
-        self.assertEqual(net.n_vars,
-                         gas.n_species + r1.component_index(gas.species_name(0)))
+        assert net.n_sensitivity_params == 2
+        assert net.n_vars == gas.n_species + r1.component_index(gas.species_name(0))
         S = net.sensitivities()
-        self.assertEqual(S.shape, (net.n_vars, net.n_sensitivity_params))
+        assert S.shape == (net.n_vars, net.n_sensitivity_params)
 
     def test_sensitivities2(self):
         net = ct.ReactorNet()
@@ -2196,12 +2202,12 @@ class TestReactorSensitivities(utilities.CanteraTest):
             K2 = Ns + gas1.n_species + interface.n_species
 
             # Constant volume should generate zero sensitivity coefficient
-            self.assertArrayNear(S[1,:], np.zeros(2))
-            self.assertArrayNear(S[K2+1,:], np.zeros(2))
+            assertArrayNear(S[1,:], np.zeros(2))
+            assertArrayNear(S[K2+1,:], np.zeros(2))
 
             # Sensitivity coefficients for the disjoint reactors should be zero
-            self.assertNear(np.linalg.norm(S[Ns:K2,1]), 0.0, atol=1e-5)
-            self.assertNear(np.linalg.norm(S[K2+Ns:,0]), 0.0, atol=1e-5)
+            assertNear(np.linalg.norm(S[Ns:K2,1]), 0.0, atol=1e-5)
+            assertNear(np.linalg.norm(S[K2+Ns:,0]), 0.0, atol=1e-5)
 
     def _test_parameter_order1(self, reactorClass):
         # Single reactor, changing the order in which parameters are added
@@ -2229,11 +2235,11 @@ class TestReactorSensitivities(utilities.CanteraTest):
         def check_names(reactor, net, params):
             for i,(kind,p) in enumerate(params):
                 rname, comp = net.sensitivity_parameter_name(i).split(': ')
-                self.assertEqual(reactor.name, rname)
+                assert reactor.name == rname
                 if kind == 'r':
-                    self.assertEqual(gas.reaction(p).equation, comp)
+                    assert gas.reaction(p).equation == comp
                 elif kind == 's':
-                    self.assertEqual(p + ' enthalpy', comp)
+                    assert p + ' enthalpy' == comp
 
         params1 = [('r', 2), ('r', 10), ('r', 18), ('r', 19), ('s', 'O2'),
                    ('s', 'OH'), ('s', 'H2O2')]
@@ -2248,7 +2254,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
         check_names(r2, net2, params2)
 
         for i,j in enumerate((5,3,6,0,4,2,1)):
-            self.assertArrayNear(S1[:,i], S2[:,j])
+            assertArrayNear(S1[:,i], S2[:,j])
 
     def test_parameter_order1a(self):
         self._test_parameter_order1(ct.IdealGasReactor)
@@ -2295,7 +2301,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
 
             pname = lambda r,i: '%s: %s' % (r.name, gas.reaction(i).equation)
             for i,(r,p) in enumerate(params1):
-                self.assertEqual(pname(r,p), net1.sensitivity_parameter_name(i))
+                assert pname(r,p) == net1.sensitivity_parameter_name(i)
 
             rA2,rB2,net2 = setup(reverse)
             params2 = [(rB2,10),(rA2,19),(rB2,18),(rA2,2)]
@@ -2304,20 +2310,20 @@ class TestReactorSensitivities(utilities.CanteraTest):
             S.append(integrate(rA2, net2))
 
             for i,(r,p) in enumerate(params2):
-                self.assertEqual(pname(r,p), net2.sensitivity_parameter_name(i))
+                assert pname(r,p) == net2.sensitivity_parameter_name(i)
 
         # Check that the results reflect the changed parameter ordering
         for a,b in ((0,1), (2,3)):
             for i,j in enumerate((3,1,0,2)):
-                self.assertArrayNear(S[a][:,i], S[b][:,j])
+                assertArrayNear(S[a][:,i], S[b][:,j])
 
         # Check that results are consistent after changing the order that
         # reactors are added to the network
         N = gas.n_species + r.component_index(gas.species_name(0))
-        self.assertArrayNear(S[0][:N], S[2][N:], 1e-5, 1e-5)
-        self.assertArrayNear(S[0][N:], S[2][:N], 1e-5, 1e-5)
-        self.assertArrayNear(S[1][:N], S[3][N:], 1e-5, 1e-5)
-        self.assertArrayNear(S[1][N:], S[3][:N], 1e-5, 1e-5)
+        assertArrayNear(S[0][:N], S[2][N:], 1e-5, 1e-5)
+        assertArrayNear(S[0][N:], S[2][:N], 1e-5, 1e-5)
+        assertArrayNear(S[1][:N], S[3][N:], 1e-5, 1e-5)
+        assertArrayNear(S[1][N:], S[3][:N], 1e-5, 1e-5)
 
     @utilities.slow_test
     def test_parameter_order3(self):
@@ -2384,7 +2390,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
 
         for a,b in [(0,1),(2,3),(4,5),(6,7)]:
             for i,j in enumerate((4,2,1,3,0)):
-                self.assertArrayNear(S[a][:,i], S[b][:,j], 1e-2, 1e-3)
+                assertArrayNear(S[a][:,i], S[b][:,j], 1e-2, 1e-3)
 
     def setup_ignition_delay(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
@@ -2443,9 +2449,8 @@ class TestReactorSensitivities(utilities.CanteraTest):
         dtdp = ((t[-1] - tig)*S[-1,:]*Tf - np.trapz(S*T[:,None], t, axis=0))/(Tf-To)
         return dtdp
 
-    # See https://github.com/Cantera/enhancements/issues/55
     # @todo: replace np.trapz with np.trapezoid when dropping support for NumPy 1.x
-    @pytest.mark.skip(reason="Integration of sensitivity ODEs is unreliable")
+    @pytest.mark.skip(reason="Integration of sensitivity ODEs is unreliable, see: https://github.com/Cantera/enhancements/issues/55")
     @pytest.mark.filterwarnings("ignore:`trapz` is deprecated")
     def test_ignition_delay_sensitivity(self):
         species = ('H2', 'H', 'O2', 'H2O2', 'H2O', 'OH', 'HO2')
@@ -2454,7 +2459,7 @@ class TestReactorSensitivities(utilities.CanteraTest):
         dH = 1e4
         for i,s in enumerate(species):
             dtigdh = (self.calc_tig(s, dH) - tig0) / dH
-            self.assertNear(dtigdh_cvodes[i], dtigdh, atol=1e-14, rtol=5e-2)
+            assertNear(dtigdh_cvodes[i], dtigdh, atol=1e-14, rtol=5e-2)
 
 
 class CombustorTestImplementation:
@@ -2467,7 +2472,8 @@ class CombustorTestImplementation:
     consistent output.
     """
 
-    def setUp(self):
+    def setup_method(self):
+        """ Runs before tests """
         self.referenceFile = utilities.TEST_DATA_PATH / "CombustorTest-integrateWithAdvance.csv"
         self.gas = ct.Solution('h2o2.yaml', transport_model=None)
 
@@ -2525,10 +2531,10 @@ class CombustorTestImplementation:
             self.data.append([tnow, self.combustor.T] +
                              list(self.combustor.thermo.X))
 
-        self.assertTrue(tnow >= tfinal)
-        bad = utilities.compareProfiles(self.referenceFile, self.data,
+        assert tnow >= tfinal
+        bad = compareProfiles(self.referenceFile, self.data,
                                         rtol=1e-3, atol=1e-9)
-        self.assertFalse(bad, bad)
+        assert not bad, bad
 
     def test_integrateWithAdvance(self, saveReference=False):
         self.data = []
@@ -2540,9 +2546,9 @@ class CombustorTestImplementation:
         if saveReference:
             np.savetxt(self.referenceFile, np.array(self.data), '%11.6e', ', ')
         else:
-            bad = utilities.compareProfiles(self.referenceFile, self.data,
+            bad = compareProfiles(self.referenceFile, self.data,
                                             rtol=1e-6, atol=1e-12)
-            self.assertFalse(bad, bad)
+            assert not bad, bad
 
     def test_invasive_mdot_function(self):
         def igniter_mdot(t, t0=0.1, fwhm=0.05, amplitude=0.1):
@@ -2559,9 +2565,9 @@ class CombustorTestImplementation:
             self.data.append([t, self.combustor.T] +
                              list(self.combustor.thermo.X))
 
-        bad = utilities.compareProfiles(self.referenceFile, self.data,
+        bad = compareProfiles(self.referenceFile, self.data,
                                         rtol=1e-6, atol=1e-12)
-        self.assertFalse(bad, bad)
+        assert not bad, bad
 
 class WallTestImplementation:
     """
@@ -2573,7 +2579,8 @@ class WallTestImplementation:
     consistent output.
     """
 
-    def setUp(self):
+    def setup_method(self):
+        """ Runs before tests """
         self.referenceFile = utilities.TEST_DATA_PATH / "WallTest-integrateWithAdvance.csv"
         # reservoir to represent the environment
         self.gas0 = ct.Solution("air.yaml")
@@ -2610,10 +2617,10 @@ class WallTestImplementation:
                               self.r1.thermo.P, self.r2.thermo.P,
                               self.r1.volume, self.r2.volume])
 
-        self.assertTrue(tnow >= tfinal)
-        bad = utilities.compareProfiles(self.referenceFile, self.data,
+        assert tnow >= tfinal
+        bad = compareProfiles(self.referenceFile, self.data,
                                         rtol=1e-3, atol=1e-8)
-        self.assertFalse(bad, bad)
+        assert not bad, bad
 
     def test_integrateWithAdvance(self, saveReference=False):
         self.data = []
@@ -2627,9 +2634,9 @@ class WallTestImplementation:
         if saveReference:
             np.savetxt(self.referenceFile, np.array(self.data), '%11.6e', ', ')
         else:
-            bad = utilities.compareProfiles(self.referenceFile, self.data,
+            bad = compareProfiles(self.referenceFile, self.data,
                                             rtol=2e-5, atol=1e-9)
-            self.assertFalse(bad, bad)
+            assert not bad, bad
 
 
 # Keep the implementations separate from the pytest-derived class
@@ -2638,7 +2645,7 @@ class CombustorTest(CombustorTestImplementation): pass
 class WallTest(WallTestImplementation): pass
 
 
-class PureFluidReactorTest(utilities.CanteraTest):
+class PureFluidReactorTest:
     def test_Reactor(self):
         phase = ct.PureFluid("liquidvapor.yaml", "oxygen")
         air = ct.Solution("air.yaml")
@@ -2666,9 +2673,9 @@ class PureFluidReactorTest(utilities.CanteraTest):
             net.advance(t)
             states.append(TD=r1.thermo.TD, t=net.time)
 
-        self.assertEqual(states.Q[0], 0)
-        self.assertEqual(states.Q[-1], 1)
-        self.assertNear(states.Q[30], 0.54806, 1e-4)
+        assert states.Q[0] == 0
+        assert states.Q[-1] == 1
+        assertNear(states.Q[30], 0.54806, 1e-4)
 
     def test_Reactor_2(self):
         phase = ct.PureFluid("liquidvapor.yaml", "carbon-dioxide")
@@ -2691,9 +2698,9 @@ class PureFluidReactorTest(utilities.CanteraTest):
             net.advance(t)
             states.append(TD=r1.thermo.TD, t=net.time)
 
-        self.assertEqual(states.Q[0], 0)
-        self.assertEqual(states.Q[-1], 1)
-        self.assertNear(states.Q[20], 0.644865, 1e-4)
+        assert states.Q[0] == 0
+        assert states.Q[-1] == 1
+        assertNear(states.Q[20], 0.644865, 1e-4)
 
 
     def test_ConstPressureReactor(self):
@@ -2715,13 +2722,13 @@ class PureFluidReactorTest(utilities.CanteraTest):
             net.advance(t)
             states.append(TD=r1.thermo.TD, t=t)
 
-        self.assertEqual(states.Q[1], 0)
-        self.assertEqual(states.Q[-2], 1)
+        assert states.Q[1] == 0
+        assert states.Q[-2] == 1
         for i in range(3,7):
-            self.assertNear(states.T[i], states.T[2])
+            assertNear(states.T[i], states.T[2])
 
 
-class AdvanceCoveragesTest(utilities.CanteraTest):
+class AdvanceCoveragesTest:
     def setup(self, model="ptcombust.yaml", gas_phase="gas", interface_phase="Pt_surf"):
         # create gas and interface
         self.surf = ct.Interface(model, interface_phase)
@@ -2736,7 +2743,7 @@ class AdvanceCoveragesTest(utilities.CanteraTest):
         max_steps = 10
         max_step_size = dt / (max_steps + 1)
         # this should throw an error, as we can't reach dt
-        with self.assertRaises(ct.CanteraError):
+        with pytest.raises(ct.CanteraError):
             self.surf.advance_coverages(
                 dt=dt, max_step_size=max_step_size, max_steps=max_steps)
 
@@ -2753,13 +2760,16 @@ class AdvanceCoveragesTest(utilities.CanteraTest):
         self.surf.advance_coverages(dt=dt, rtol=1e-7, atol=1e-14)
 
         # check that the solutions are similar, but not identical
-        self.assertArrayNear(cov, self.surf.coverages)
-        self.assertTrue(any(cov != self.surf.coverages))
+        assertArrayNear(cov, self.surf.coverages)
+        assert any(cov != self.surf.coverages)
 
 
-class ExtensibleReactorTest(utilities.CanteraTest):
-    def setUp(self):
-        self.gas = ct.Solution("h2o2.yaml")
+@pytest.fixture(scope='function')
+def setup_extensible_reactor(request):
+    request.cls.gas = ct.Solution("h2o2.yaml")
+
+@pytest.mark.usefixtures('setup_extensible_reactor')
+class ExtensibleReactorTest:
 
     def test_extra_variable(self):
         class InertialWallReactor(ct.ExtensibleIdealGasReactor):
@@ -2806,12 +2816,12 @@ class ExtensibleReactorTest(utilities.CanteraTest):
             V.append(r.volume)
 
         # Wall is accelerating
-        self.assertTrue((np.diff(V, 2) > 0).all())
+        assert (np.diff(V, 2) > 0).all()
 
-        self.assertIn('v_wall', net.component_name(self.gas.n_species + 3))
-        self.assertEqual(r.component_index('volume'), 1)
-        self.assertEqual(r.component_name(self.gas.n_species + 3), 'v_wall')
-        self.assertEqual(r.component_name(2), 'temperature')
+        assert 'v_wall' in net.component_name(self.gas.n_species + 3)
+        assert r.component_index('volume') == 1
+        assert r.component_name(self.gas.n_species + 3) == 'v_wall'
+        assert r.component_name(2) == 'temperature'
 
     def test_replace_equations(self):
         nsp = self.gas.n_species
@@ -2836,14 +2846,14 @@ class ExtensibleReactorTest(utilities.CanteraTest):
 
         while(net.time < 1):
             net.step()
-            self.assertArrayNear(r.get_state(), np.exp(- net.time / tau))
+            assertArrayNear(r.get_state(), np.exp(- net.time / tau))
 
     def test_error_handling(self):
         class DummyReactor1(ct.ExtensibleReactor):
             def replace_eval(self, t): # wrong number of arguments
                 pass
 
-        with self.assertRaisesRegex(ValueError, "right number of arguments"):
+        with pytest.raises(ValueError, match="right number of arguments"):
             DummyReactor1(self.gas)
 
         class DummyReactor2(ct.ExtensibleReactor):
@@ -2855,14 +2865,14 @@ class ExtensibleReactorTest(utilities.CanteraTest):
                 # Otherwise, does not return a value
 
         r2 = DummyReactor2(self.gas)
-        self.assertEqual(r2.component_index("succeed"), 0)
-        with self.assertRaises(TypeError):
+        assert r2.component_index("succeed") == 0
+        with pytest.raises(TypeError):
             r2.component_index("wrong-type")
         # Error information should have been reset
-        self.assertEqual(r2.component_index("succeed"), 0)
-        with self.assertRaisesRegex(ct.CanteraError, "did not return a value"):
+        assert r2.component_index("succeed") == 0
+        with pytest.raises(ct.CanteraError, match="did not return a value"):
             r2.component_index("H2")
-        self.assertEqual(r2.component_index("succeed"), 0)
+        assert r2.component_index("succeed") == 0
 
     def test_delegate_throws(self):
         class TestException(Exception):
@@ -2906,11 +2916,11 @@ class ExtensibleReactorTest(utilities.CanteraTest):
 
         r = DummyReactor(self.gas)
         net = ct.ReactorNet([r])
-        self.assertEqual(r.component_index("H2"), 5 + 3 + self.gas.species_index("H2"))
+        assert r.component_index("H2") == 5 + 3 + self.gas.species_index("H2")
         r.syncState()
         net.advance(1)
         r.syncState()
-        self.assertEqual(r.sync_calls, 2)
+        assert r.sync_calls == 2
 
     def test_RHS_LHS(self):
         # set initial state
@@ -2947,7 +2957,7 @@ class ExtensibleReactorTest(utilities.CanteraTest):
         r1_heat = (mass_lump * cp_lump * (r1.thermo.T - 500) +
                    mass_gas * (self.gas.enthalpy_mass - gas_initial_enthalpy))
         add_heat = Q * time
-        self.assertNear(add_heat, r1_heat, atol=1e-5)
+        assertNear(add_heat, r1_heat, atol=1e-5)
 
     def test_heat_addition(self):
         # Applying heat via 'heat_rate' property should be equivalent to adding it via
@@ -2967,8 +2977,8 @@ class ExtensibleReactorTest(utilities.CanteraTest):
         for t in np.linspace(0.1, 5, 10):
             net.advance(t)
             U = r1.thermo.int_energy_mass * r1.mass
-            self.assertNear(U - U0, (Qext + Qwall) * t)
-            self.assertNear(r1.heat_rate, Qext + Qwall)
+            assertNear(U - U0, (Qext + Qwall) * t)
+            assertNear(r1.heat_rate, Qext + Qwall)
 
     def test_with_surface(self):
         phase_defs = """
@@ -3045,15 +3055,15 @@ class ExtensibleReactorTest(utilities.CanteraTest):
         for t in np.linspace(0.1, 1, 12):
             net.advance(t)
             mH, mO = masses()
-            self.assertNear(mH, mH0)
-            self.assertNear(mO, mO0)
+            assertNear(mH, mH0)
+            assertNear(mO, mO0)
 
         # Regression test values
-        self.assertNear(r1.thermo.P, 647.56016304)
-        self.assertNear(r1.thermo.X[kH2], 0.4784268406)
-        self.assertNear(r1.thermo.X[kO2], 0.5215731594)
-        self.assertNear(r1.surfaces[0].kinetics.X[kHs], 0.3665198138)
-        self.assertNear(r1.surfaces[0].kinetics.X[kPts], 0.6334801862)
+        assertNear(r1.thermo.P, 647.56016304)
+        assertNear(r1.thermo.X[kH2], 0.4784268406)
+        assertNear(r1.thermo.X[kO2], 0.5215731594)
+        assertNear(r1.surfaces[0].kinetics.X[kHs], 0.3665198138)
+        assertNear(r1.surfaces[0].kinetics.X[kPts], 0.6334801862)
 
     def test_interactions(self):
         # Reactors connected by a movable, H2-permeable surface
@@ -3101,16 +3111,16 @@ class ExtensibleReactorTest(utilities.CanteraTest):
         V0 = r1.volume + r2.volume
         for t in np.linspace(0.01, 0.2, 50):
             net.advance(t)
-            self.assertNear(r1.expansion_rate, -r2.expansion_rate)
-            self.assertNear(V0, r1.volume + r2.volume)
+            assertNear(r1.expansion_rate, -r2.expansion_rate)
+            assertNear(V0, r1.volume + r2.volume)
             deltaCnow = deltaC()
-            self.assertLess(deltaCnow, deltaCprev) # difference is always decreasing
+            assert deltaCnow < deltaCprev # difference is always decreasing
             deltaCprev = deltaCnow
-            self.assertArrayNear(M0, r1.mass * r1.thermo.Y + r2.mass * r2.thermo.Y, rtol=2e-8)
+            assertArrayNear(M0, r1.mass * r1.thermo.Y + r2.mass * r2.thermo.Y, rtol=2e-8)
             states1.append(r1.thermo.state, t=net.time, mass=r1.mass, vdot=r1.expansion_rate)
             states2.append(r2.thermo.state, t=net.time, mass=r2.mass, vdot=r2.expansion_rate)
 
         # Regression test values
-        self.assertNear(r1.thermo.P, 151561.15, rtol=1e-6)
-        self.assertNear(r1.thermo["H2"].Y[0], 0.13765976, rtol=1e-6)
-        self.assertNear(r2.thermo["O2"].Y[0], 0.94617029, rtol=1e-6)
+        assertNear(r1.thermo.P, 151561.15, rtol=1e-6)
+        assertNear(r1.thermo["H2"].Y[0], 0.13765976, rtol=1e-6)
+        assertNear(r2.thermo["O2"].Y[0], 0.94617029, rtol=1e-6)

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1169,6 +1169,7 @@ class TestIdealGasReactor(TestReactor):
 
 class TestWellStirredReactorIgnition:
     """ Ignition (or not) of a well-stirred reactor """
+
     def setup_reactor(self, T0, P0, mdot_fuel, mdot_ox):
         """ Runs before tests """
         gas_def = """
@@ -1188,11 +1189,11 @@ class TestWellStirredReactorIgnition:
 
         # fuel inlet
         self.gas.TPX = T0, P0, "CH4:1.0"
-        self.fuel_in = ct.Reservoir(self.gas)
+        fuel_in = ct.Reservoir(self.gas)
 
         # oxidizer inlet
         self.gas.TPX = T0, P0, "N2:3.76, O2:1.0"
-        self.oxidizer_in = ct.Reservoir(self.gas)
+        oxidizer_in = ct.Reservoir(self.gas)
 
         # reactor, initially filled with N2
         self.gas.TPX = T0, P0, "N2:1.0"
@@ -1200,15 +1201,15 @@ class TestWellStirredReactorIgnition:
         self.combustor.volume = 1.0
 
         # outlet
-        self.exhaust = ct.Reservoir(self.gas)
+        exhaust = ct.Reservoir(self.gas)
 
         # connect the reactor to the reservoirs
-        self.fuel_mfc = ct.MassFlowController(self.fuel_in, self.combustor)
-        self.fuel_mfc.mass_flow_rate = mdot_fuel
-        self.oxidizer_mfc = ct.MassFlowController(self.oxidizer_in, self.combustor)
-        self.oxidizer_mfc.mass_flow_rate = mdot_ox
-        self.valve = ct.Valve(self.combustor, self.exhaust)
-        self.valve.valve_coeff = 1.0
+        fuel_mfc = ct.MassFlowController(fuel_in, self.combustor)
+        fuel_mfc.mass_flow_rate = mdot_fuel
+        oxidizer_mfc = ct.MassFlowController(oxidizer_in, self.combustor)
+        oxidizer_mfc.mass_flow_rate = mdot_ox
+        valve = ct.Valve(self.combustor, exhaust)
+        valve.valve_coeff = 1.0
 
         self.net = ct.ReactorNet()
         self.net.add_reactor(self.combustor)
@@ -2460,7 +2461,61 @@ class TestReactorSensitivities:
             assertNear(dtigdh_cvodes[i], dtigdh, atol=1e-14, rtol=5e-2)
 
 
-class CombustorTestImplementation:
+@pytest.fixture(scope='class')
+def setup_combustor_tests(request):
+    request.cls.referenceFile = request.cls.test_data_path / "CombustorTest-integrateWithAdvance.csv"
+
+@pytest.fixture(scope='function')
+def setup_combustor_tests_data(request, setup_combustor_tests):
+    gas = ct.Solution('h2o2.yaml', transport_model=None)
+
+    # create a reservoir for the fuel inlet, and set to pure methane.
+    gas.TPX = 300.0, ct.one_atm, 'H2:1.0'
+    fuel_in = ct.Reservoir(gas)
+    fuel_mw = gas.mean_molecular_weight
+
+    # Oxidizer inlet
+    gas.TPX = 300.0, ct.one_atm, 'O2:1.0, AR:3.0'
+    oxidizer_in = ct.Reservoir(gas)
+    oxidizer_mw = gas.mean_molecular_weight
+
+    # to ignite the fuel/air mixture, we'll introduce a pulse of radicals.
+    # The steady-state behavior is independent of how we do this, so we'll
+    # just use a stream of pure atomic hydrogen.
+    gas.TPX = 300.0, ct.one_atm, 'H:1.0'
+    request.cls.igniter = ct.Reservoir(gas)
+
+    # create the combustor, and fill it in initially with a diluent
+    gas.TPX = 300.0, ct.one_atm, 'AR:1.0'
+    request.cls.combustor = ct.IdealGasReactor(gas)
+
+    # create a reservoir for the exhaust
+    request.cls.exhaust = ct.Reservoir(gas)
+
+    # compute fuel and air mass flow rates
+    factor = 0.1
+    oxidizer_mdot = 4 * factor*oxidizer_mw
+    fuel_mdot = factor*fuel_mw
+
+    # The igniter will use a time-dependent igniter mass flow rate.
+    def igniter_mdot(t, t0=0.1, fwhm=0.05, amplitude=0.1):
+        return amplitude * math.exp(-(t-t0)**2 * 4 * math.log(2) / fwhm**2)
+
+    # create and install the mass flow controllers. Controllers
+    # m1 and m2 provide constant mass flow rates, and m3 provides
+    # a short Gaussian pulse only to ignite the mixture
+    request.cls.m1 = ct.MassFlowController(fuel_in, request.cls.combustor, mdot=fuel_mdot)
+    request.cls.m2 = ct.MassFlowController(oxidizer_in, request.cls.combustor, mdot=oxidizer_mdot)
+    request.cls.m3 = ct.MassFlowController(request.cls.igniter, request.cls.combustor, mdot=igniter_mdot)
+
+    # put a valve on the exhaust line to regulate the pressure
+    request.cls.v = ct.Valve(request.cls.combustor, request.cls.exhaust, K=1.0)
+
+    # the simulation only contains one reactor
+    request.cls.sim = ct.ReactorNet([request.cls.combustor])
+
+@pytest.mark.usefixtures('setup_combustor_tests_data')
+class CombustorTests:
     """
     These tests are based on the sample:
 
@@ -2469,56 +2524,6 @@ class CombustorTestImplementation:
     with some simplifications so that they run faster and produce more
     consistent output.
     """
-
-    def setup_method(self):
-        """ Runs before tests """
-        self.referenceFile = self.test_data_path / "CombustorTest-integrateWithAdvance.csv"
-        self.gas = ct.Solution('h2o2.yaml', transport_model=None)
-
-        # create a reservoir for the fuel inlet, and set to pure methane.
-        self.gas.TPX = 300.0, ct.one_atm, 'H2:1.0'
-        fuel_in = ct.Reservoir(self.gas)
-        fuel_mw = self.gas.mean_molecular_weight
-
-        # Oxidizer inlet
-        self.gas.TPX = 300.0, ct.one_atm, 'O2:1.0, AR:3.0'
-        oxidizer_in = ct.Reservoir(self.gas)
-        oxidizer_mw = self.gas.mean_molecular_weight
-
-        # to ignite the fuel/air mixture, we'll introduce a pulse of radicals.
-        # The steady-state behavior is independent of how we do this, so we'll
-        # just use a stream of pure atomic hydrogen.
-        self.gas.TPX = 300.0, ct.one_atm, 'H:1.0'
-        self.igniter = ct.Reservoir(self.gas)
-
-        # create the combustor, and fill it in initially with a diluent
-        self.gas.TPX = 300.0, ct.one_atm, 'AR:1.0'
-        self.combustor = ct.IdealGasReactor(self.gas)
-
-        # create a reservoir for the exhaust
-        self.exhaust = ct.Reservoir(self.gas)
-
-        # compute fuel and air mass flow rates
-        factor = 0.1
-        oxidizer_mdot = 4 * factor*oxidizer_mw
-        fuel_mdot = factor*fuel_mw
-
-        # The igniter will use a time-dependent igniter mass flow rate.
-        def igniter_mdot(t, t0=0.1, fwhm=0.05, amplitude=0.1):
-            return amplitude * math.exp(-(t-t0)**2 * 4 * math.log(2) / fwhm**2)
-
-        # create and install the mass flow controllers. Controllers
-        # m1 and m2 provide constant mass flow rates, and m3 provides
-        # a short Gaussian pulse only to ignite the mixture
-        self.m1 = ct.MassFlowController(fuel_in, self.combustor, mdot=fuel_mdot)
-        self.m2 = ct.MassFlowController(oxidizer_in, self.combustor, mdot=oxidizer_mdot)
-        self.m3 = ct.MassFlowController(self.igniter, self.combustor, mdot=igniter_mdot)
-
-        # put a valve on the exhaust line to regulate the pressure
-        self.v = ct.Valve(self.combustor, self.exhaust, K=1.0)
-
-        # the simulation only contains one reactor
-        self.sim = ct.ReactorNet([self.combustor])
 
     def test_integrateWithStep(self):
         tnow = 0.0
@@ -2567,7 +2572,39 @@ class CombustorTestImplementation:
                                         rtol=1e-6, atol=1e-12)
         assert not bad, bad
 
-class WallTestImplementation:
+
+@pytest.fixture(scope='class')
+def setup_wall_tests(request):
+    request.cls.referenceFile = request.cls.test_data_path / "WallTest-integrateWithAdvance.csv"
+
+@pytest.fixture(scope='function')
+def setup_wall_tests_data(request, setup_wall_tests):
+    # reservoir to represent the environment
+    gas0 = ct.Solution("air.yaml")
+    gas0.TP = 300, ct.one_atm
+    env = ct.Reservoir(gas0)
+
+    # reactor to represent the side filled with Argon
+    gas1 = ct.Solution("air.yaml")
+    gas1.TPX = 1000.0, 30*ct.one_atm, 'AR:1.0'
+    request.cls.r1 = ct.Reactor(gas1)
+
+    # reactor to represent the combustible mixture
+    gas2 = ct.Solution('h2o2.yaml', transport_model=None)
+    gas2.TPX = 500.0, 1.5*ct.one_atm, 'H2:0.5, O2:1.0, AR:10.0'
+    request.cls.r2 = ct.Reactor(gas2)
+
+    # Wall between the two reactors
+    w1 = ct.Wall(request.cls.r2, request.cls.r1, A=1.0, K=2e-4, U=400.0)
+
+    # Wall to represent heat loss to the environment
+    w2 = ct.Wall(request.cls.r2, env, A=1.0, U=2000.0)
+
+    # Create the reactor network
+    request.cls.sim = ct.ReactorNet([request.cls.r1, request.cls.r2])
+
+@pytest.mark.usefixtures('setup_wall_tests_data')
+class WallTests:
     """
     These tests are based on the sample:
 
@@ -2576,33 +2613,6 @@ class WallTestImplementation:
     with some simplifications so that they run faster and produce more
     consistent output.
     """
-
-    def setup_method(self):
-        """ Runs before tests """
-        self.referenceFile = self.test_data_path / "WallTest-integrateWithAdvance.csv"
-        # reservoir to represent the environment
-        self.gas0 = ct.Solution("air.yaml")
-        self.gas0.TP = 300, ct.one_atm
-        self.env = ct.Reservoir(self.gas0)
-
-        # reactor to represent the side filled with Argon
-        self.gas1 = ct.Solution("air.yaml")
-        self.gas1.TPX = 1000.0, 30*ct.one_atm, 'AR:1.0'
-        self.r1 = ct.Reactor(self.gas1)
-
-        # reactor to represent the combustible mixture
-        self.gas2 = ct.Solution('h2o2.yaml', transport_model=None)
-        self.gas2.TPX = 500.0, 1.5*ct.one_atm, 'H2:0.5, O2:1.0, AR:10.0'
-        self.r2 = ct.Reactor(self.gas2)
-
-        # Wall between the two reactors
-        self.w1 = ct.Wall(self.r2, self.r1, A=1.0, K=2e-4, U=400.0)
-
-        # Wall to represent heat loss to the environment
-        self.w2 = ct.Wall(self.r2, self.env, A=1.0, U=2000.0)
-
-        # Create the reactor network
-        self.sim = ct.ReactorNet([self.r1, self.r2])
 
     def test_integrateWithStep(self):
         tnow = 0.0
@@ -2639,11 +2649,11 @@ class WallTestImplementation:
 
 # Keep the implementations separate from the pytest-derived class
 # so that they can be run independently to generate the reference data files.
-class CombustorTest(CombustorTestImplementation): pass
-class WallTest(WallTestImplementation): pass
+class TestCombustor(CombustorTests): pass
+class TestWall(WallTests): pass
 
 
-class PureFluidReactorTest:
+class TestPureFluidReactor:
     def test_Reactor(self):
         phase = ct.PureFluid("liquidvapor.yaml", "oxygen")
         air = ct.Solution("air.yaml")
@@ -2726,16 +2736,18 @@ class PureFluidReactorTest:
             assertNear(states.T[i], states.T[2])
 
 
-class AdvanceCoveragesTest:
-    def setup(self, model="ptcombust.yaml", gas_phase="gas", interface_phase="Pt_surf"):
-        # create gas and interface
-        self.surf = ct.Interface(model, interface_phase)
-        self.gas = self.surf.adjacent["gas"]
+@pytest.fixture(scope='function')
+def setup_advance_converages_data(request):
+    mechanism_file = 'ptcombust.yaml'
+    interface_phase = 'Pt_surf'
+    #request.cls.surf = ct.Interface(f'{request.cls.test_data_path}/{mechanism_file}', interface_phase)
+    request.cls.surf = ct.Interface(mechanism_file, interface_phase)
+    request.cls.gas = request.cls.surf.adjacent["gas"]
 
-    def test_advance_coverages_parameters(self):
-        # create gas and interface
-        self.setup()
+@pytest.mark.usefixtures('setup_advance_converages_data')
+class TestAdvanceCoverages:
 
+    def test_bad_timestep_specification(self):
         # first, test max step size & max steps
         dt = 1.0
         max_steps = 10
@@ -2745,8 +2757,10 @@ class AdvanceCoveragesTest:
             self.surf.advance_coverages(
                 dt=dt, max_step_size=max_step_size, max_steps=max_steps)
 
-        # next, run with different tolerances
-        self.setup()
+    def test_different_tolerances(self):
+        dt = 1.0
+
+        #Run with different tolerances
         self.surf.coverages = 'O(S):0.1, PT(S):0.5, H(S):0.4'
         self.gas.TP = self.surf.TP
 
@@ -2763,11 +2777,11 @@ class AdvanceCoveragesTest:
 
 
 @pytest.fixture(scope='function')
-def setup_extensible_reactor(request):
+def setup_extensible_reactor_data(request):
     request.cls.gas = ct.Solution("h2o2.yaml")
 
-@pytest.mark.usefixtures('setup_extensible_reactor')
-class ExtensibleReactorTest:
+@pytest.mark.usefixtures('setup_extensible_reactor_data')
+class TestExtensibleReactor:
 
     def test_extra_variable(self):
         class InertialWallReactor(ct.ExtensibleIdealGasReactor):

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1,9 +1,8 @@
 import math
-import re
-
 import numpy as np
 import pytest
 from pytest import approx
+import re
 
 import cantera as ct
 
@@ -15,7 +14,6 @@ except ImportError:
 from cantera.drawnetwork import _graphviz
 
 from .utilities import (
-    assertArrayNear,
     compareProfiles
 )
 
@@ -431,7 +429,7 @@ class TestReactor:
         assert self.r1.T == approx(gas.T)
         assert self.r1.thermo.density == approx(gas.density)
         assert self.r1.thermo.P == approx(gas.P)
-        assertArrayNear(self.r1.thermo.X, gas.X)
+        assert self.r1.thermo.X == approx(gas.X)
 
     def test_equilibrium_HP(self):
         # Adiabatic, constant pressure combustion should proceed to equilibrium
@@ -456,7 +454,7 @@ class TestReactor:
         assert r1.T == approx(gas2.T)
         assert r1.thermo.P == approx(P0)
         assert r1.thermo.density == approx(gas2.density)
-        assertArrayNear(r1.thermo.X, gas2.X)
+        assert r1.thermo.X == approx(gas2.X)
 
     def test_wall_velocity(self):
         self.make_reactors()
@@ -577,7 +575,7 @@ class TestReactor:
         Yb = self.r1.Y
 
         assert ma + 0.1 == approx(mb)
-        assertArrayNear(ma * Ya + 0.1 * gas2.Y, mb * Yb)
+        assert ma * Ya + 0.1 * gas2.Y == approx(mb * Yb)
 
     def test_mass_flow_controller_type(self):
         self.make_reactors(n_reactors=2)
@@ -630,8 +628,8 @@ class TestReactor:
         assert m1a + m2a == approx(m1b + m2b)
         Y1b = self.r1.thermo.Y
         Y2b = self.r2.thermo.Y
-        assertArrayNear(m1a*Y1a + m2a*Y2a, m1b*Y1b + m2b*Y2b, atol=1e-10)
-        assertArrayNear(Y1a, Y1b)
+        assert m1a*Y1a + m2a*Y2a == approx(m1b*Y1b + m2b*Y2b, abs=1e-10)
+        assert Y1a == approx(Y1b)
 
     def test_valve2(self):
         # Similar to test_valve1, but by disabling the energy equation
@@ -664,7 +662,7 @@ class TestReactor:
             m2 = self.r2.thermo.density * self.r2.volume
             assert m2 == approx((m2a - A/B) * np.exp(-B * t) + A/B)
             assert m1a + m2a == approx(m1 + m2)
-            assertArrayNear(self.r1.Y, Y1)
+            assert self.r1.Y == approx(Y1)
 
     def test_valve3(self):
         # This case specifies a non-linear relationship between pressure drop
@@ -693,7 +691,7 @@ class TestReactor:
             p1 = self.r1.thermo.P
             p2 = self.r2.thermo.P
             assert mdot(p1-p2) == approx(valve.mass_flow_rate)
-            assertArrayNear(Y1, self.r1.Y)
+            assert Y1 == approx(self.r1.Y)
             assert speciesMass(kAr) == approx(mAr)
             assert speciesMass(kO2) == approx(mO2)
 
@@ -1153,11 +1151,10 @@ class TestMoleReactor(TestReactor):
         for i in np.linspace(0, 0.0025, 50)[1:]:
             net1.advance(i)
             net2.advance(i)
-            assertArrayNear(r1.thermo.Y, r2.thermo.Y, rtol=5e-4, atol=1e-6)
+            assert r1.thermo.Y == approx(r2.thermo.Y, rel=5e-4, abs=1e-6)
             assert r1.T == approx(r2.T, rel=5e-5)
             assert r1.thermo.P == approx(r2.thermo.P, rel=1e-6)
-            assertArrayNear(rsurf1.coverages, rsurf2.coverages, rtol=1e-4,
-                            atol=1e-8)
+            assert rsurf1.coverages == approx(rsurf2.coverages, rel=1e-4, abs=1e-8)
 
     def test_tolerances(self, rtol_lim=1e-8, atol_lim=1e-18):
         super().test_tolerances(rtol_lim, atol_lim)
@@ -1390,13 +1387,12 @@ class TestConstPressureReactor:
         for t in np.arange(0.5, 50, 1.0):
             self.net1.advance(t)
             self.net2.advance(t)
-            assertArrayNear(self.r1.thermo.Y, self.r2.thermo.Y,
-                            rtol=5e-4, atol=1e-6)
+            assert self.r1.thermo.Y == approx(self.r2.thermo.Y, rel=5e-4, abs=1e-6)
             assert self.r1.T == approx(self.r2.T, rel=5e-5)
             assert self.r1.thermo.P == approx(self.r2.thermo.P, rel=1e-6)
             if surf:
-                assertArrayNear(self.surf1.coverages, self.surf2.coverages,
-                                     rtol=1e-4, atol=1e-8)
+                assert self.surf1.coverages == approx(self.surf2.coverages,
+                                                      rel=1e-4, abs=1e-8)
 
     def test_closed(self):
         self.create_reactors()
@@ -1487,7 +1483,7 @@ class TestIdealGasMoleReactor(TestMoleReactor):
         for t in np.arange(0.5, 5, 0.5):
             net1.advance(t)
             net2.advance(t)
-            assertArrayNear(r1.thermo.Y, r2.thermo.Y, rtol=5e-4, atol=1e-6)
+            assert r1.thermo.Y == approx(r2.thermo.Y, rel=5e-4, abs=1e-6)
             assert r1.T == approx(r2.T, rel=1e-5)
             assert r1.thermo.P == approx(r2.thermo.P, rel=1e-5)
 
@@ -1522,11 +1518,11 @@ class TestReactorJacobians:
         # the volume row is not considered in comparisons because it is presently
         # not calculated.
         # check first row is near, terms which are generally on the order of 1e5 to 1e7
-        assertArrayNear(jacobian[0, 2:], fd_jacobian[0, 2:], 1e-1, 1e-2)
+        assert jacobian[0, 2:] == approx(fd_jacobian[0, 2:], rel=1e-1, abs=1e-2)
         # check first col is near, these are finite difference terms and should be close
-        assertArrayNear(jacobian[2:, 0], fd_jacobian[2:, 0], 1e-3, 1e-4)
+        assert jacobian[2:, 0] == approx(fd_jacobian[2:, 0], rel=1e-3, abs=1e-4)
         # check all species are near, these terms are usually ~ 1e2
-        assertArrayNear(jacobian[2:, 2:], fd_jacobian[2:, 2:], 1e-3, 1e-4)
+        assert jacobian[2:, 2:] == approx(fd_jacobian[2:, 2:], rel=1e-3, abs=1e-4)
 
     def test_gas_simple(self):
         # conditions for simulation
@@ -1542,7 +1538,7 @@ class TestReactorJacobians:
         net = ct.ReactorNet([r])
         net.initialize()
         # compare jacobians
-        assertArrayNear(r.jacobian, r.finite_difference_jacobian, rtol=1e-6)
+        assert r.jacobian == approx(r.finite_difference_jacobian, rel=1e-6)
 
     def test_const_volume_hydrogen_single(self):
         # conditions for simulation
@@ -1564,11 +1560,11 @@ class TestReactorJacobians:
         # the volume row is not considered in comparisons because it is presently
         # not calculated.
         # check first row is near, terms which are generally on the order of 1e5 to 1e7
-        assertArrayNear(jacobian[0, 2:], fd_jacobian[0, 2:], 1e-2, 1e-3)
+        assert jacobian[0, 2:] == approx(fd_jacobian[0, 2:], rel=1e-2, abs=1e-3)
         # check first col is near, these are finite difference terms and should be close
-        assertArrayNear(jacobian[2:, 0], fd_jacobian[2:, 0], 1e-3, 1e-4)
+        assert jacobian[2:, 0] == approx(fd_jacobian[2:, 0], rel=1e-3, abs=1e-4)
         # check all species are near, these terms are usually ~ 1e2
-        assertArrayNear(jacobian[2:, 2:], fd_jacobian[2:, 2:], 1e-3, 1e-4)
+        assert jacobian[2:, 2:] == approx(fd_jacobian[2:, 2:], rel=1e-3, abs=1e-4)
 
     def test_const_pressure_hydrogen_single(self):
         # conditions for simulation
@@ -1585,7 +1581,7 @@ class TestReactorJacobians:
         net = ct.ReactorNet([r])
         net.step()
         # compare analytical jacobian with finite difference
-        assertArrayNear(r.jacobian, r.finite_difference_jacobian, 1e-3, 1e-4)
+        assert r.jacobian == approx(r.finite_difference_jacobian, rel=1e-3, abs=1e-4)
 
     def test_phase_order_surf_jacobian(self):
         # create gas phase
@@ -1635,7 +1631,7 @@ class TestReactorJacobians:
         net.derivative_settings = {"skip-coverage-dependence":True}
         net.initialize()
         # check that they two arrays are the same
-        assertArrayNear(r1.jacobian, r2.jacobian, 2e-6, 1e-8)
+        assert r1.jacobian == approx(r2.jacobian, rel=2e-6, abs=1e-8)
 
 # A rate type used for testing integrator error handling
 class FailRateData(ct.ExtensibleRateData):
@@ -2069,7 +2065,7 @@ class TestSurfaceKinetics:
         C_right = surf2.coverages
 
         assert sum(C_left) == approx(1.0)
-        assertArrayNear(C_left, C_right)
+        assert C_left == approx(C_right)
 
         with pytest.raises(ValueError):
             surf2.coverages = np.ones(self.interface.n_species + 1)
@@ -2086,7 +2082,7 @@ class TestSurfaceKinetics:
         C[4] = 0.7
 
         surf1.coverages = C
-        assertArrayNear(surf1.coverages, C)
+        assert surf1.coverages == approx(C)
         data = []
         test_file = self.test_work_path / "test_coverages_regression1.csv"
         reference_file = self.test_data_path / "WallKinetics-coverages-regression1.csv"
@@ -2111,7 +2107,7 @@ class TestSurfaceKinetics:
         C[4] = 0.7
 
         surf.coverages = C
-        assertArrayNear(surf.coverages, C)
+        assert surf.coverages == approx(C)
         data = []
         test_file = self.test_work_path / "test_coverages_regression2.csv"
         reference_file = self.test_data_path / "WallKinetics-coverages-regression2.csv"
@@ -2199,8 +2195,8 @@ class TestReactorSensitivities:
             K2 = Ns + gas1.n_species + interface.n_species
 
             # Constant volume should generate zero sensitivity coefficient
-            assertArrayNear(S[1,:], np.zeros(2))
-            assertArrayNear(S[K2+1,:], np.zeros(2))
+            assert S[1,:] == approx(np.zeros(2))
+            assert S[K2+1,:] == approx(np.zeros(2))
 
             # Sensitivity coefficients for the disjoint reactors should be zero
             assert np.linalg.norm(S[Ns:K2,1]) == approx(0.0, abs=1e-5)
@@ -2251,7 +2247,7 @@ class TestReactorSensitivities:
         check_names(r2, net2, params2)
 
         for i,j in enumerate((5,3,6,0,4,2,1)):
-            assertArrayNear(S1[:,i], S2[:,j])
+            assert S1[:,i] == approx(S2[:,j])
 
     def test_parameter_order1a(self):
         self._test_parameter_order1(ct.IdealGasReactor)
@@ -2312,15 +2308,15 @@ class TestReactorSensitivities:
         # Check that the results reflect the changed parameter ordering
         for a,b in ((0,1), (2,3)):
             for i,j in enumerate((3,1,0,2)):
-                assertArrayNear(S[a][:,i], S[b][:,j])
+                assert S[a][:,i] == approx(S[b][:,j])
 
         # Check that results are consistent after changing the order that
         # reactors are added to the network
         N = gas.n_species + r.component_index(gas.species_name(0))
-        assertArrayNear(S[0][:N], S[2][N:], 1e-5, 1e-5)
-        assertArrayNear(S[0][N:], S[2][:N], 1e-5, 1e-5)
-        assertArrayNear(S[1][:N], S[3][N:], 1e-5, 1e-5)
-        assertArrayNear(S[1][N:], S[3][:N], 1e-5, 1e-5)
+        assert S[0][:N] == approx(S[2][N:], rel=1e-5, abs=1e-5)
+        assert S[0][N:] == approx(S[2][:N], rel=1e-5, abs=1e-5)
+        assert S[1][:N] == approx(S[3][N:], rel=1e-5, abs=1e-5)
+        assert S[1][N:] == approx(S[3][:N], rel=1e-5, abs=1e-5)
 
     @pytest.mark.slow_test
     def test_parameter_order3(self):
@@ -2387,7 +2383,7 @@ class TestReactorSensitivities:
 
         for a,b in [(0,1),(2,3),(4,5),(6,7)]:
             for i,j in enumerate((4,2,1,3,0)):
-                assertArrayNear(S[a][:,i], S[b][:,j], 1e-2, 1e-3)
+                assert S[a][:,i] == approx(S[b][:,j], rel=1e-2, abs=1e-3)
 
     def setup_ignition_delay(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
@@ -2770,7 +2766,7 @@ class TestAdvanceCoverages:
         self.surf.advance_coverages(dt=dt, rtol=1e-7, atol=1e-14)
 
         # check that the solutions are similar, but not identical
-        assertArrayNear(cov, self.surf.coverages)
+        assert cov == approx(self.surf.coverages)
         assert any(cov != self.surf.coverages)
 
 
@@ -2856,7 +2852,7 @@ class TestExtensibleReactor:
 
         while(net.time < 1):
             net.step()
-            assertArrayNear(r.get_state(), np.exp(- net.time / tau))
+            assert r.get_state() == approx(np.exp(- net.time / tau))
 
     def test_error_handling(self):
         class DummyReactor1(ct.ExtensibleReactor):
@@ -3126,7 +3122,7 @@ class TestExtensibleReactor:
             deltaCnow = deltaC()
             assert deltaCnow < deltaCprev # difference is always decreasing
             deltaCprev = deltaCnow
-            assertArrayNear(M0, r1.mass * r1.thermo.Y + r2.mass * r2.thermo.Y, rtol=2e-8)
+            assert M0 == approx(r1.mass * r1.thermo.Y + r2.mass * r2.thermo.Y, rel=2e-8)
             states1.append(r1.thermo.state, t=net.time, mass=r1.mass, vdot=r1.expansion_rate)
             states2.append(r2.thermo.state, t=net.time, mass=r2.mass, vdot=r2.expansion_rate)
 

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -15,7 +15,6 @@ except ImportError:
 from cantera.drawnetwork import _graphviz
 
 from .utilities import (
-    assertNear,
     assertArrayNear,
     compareProfiles
 )
@@ -67,7 +66,7 @@ class TestReactor:
         g.TP = 300, 101325
         R.insert(g)
 
-        assertNear(R.T, 300)
+        assert R.T == approx(300)
         assert len(R.kinetics.net_production_rates) == g.n_species
 
     def test_volume(self):
@@ -127,10 +126,10 @@ class TestReactor:
         self.net.advance(1.0)
 
         # Nothing should change from the initial condition
-        assertNear(T1, self.gas1.T)
-        assertNear(T2, self.gas2.T)
-        assertNear(P1, self.gas1.P)
-        assertNear(P2, self.gas2.P)
+        assert T1 == approx(self.gas1.T)
+        assert T2 == approx(self.gas2.T)
+        assert P1 == approx(self.gas1.P)
+        assert P2 == approx(self.gas2.P)
 
     def test_disjoint2(self):
         T1, P1 = 300, 101325
@@ -140,10 +139,10 @@ class TestReactor:
         self.net.advance(1.0)
 
         # Nothing should change from the initial condition
-        assertNear(T1, self.r1.T)
-        assertNear(T2, self.r2.T)
-        assertNear(P1, self.r1.thermo.P)
-        assertNear(P2, self.r2.thermo.P)
+        assert T1 == approx(self.r1.T)
+        assert T2 == approx(self.r2.T)
+        assert P1 == approx(self.r1.thermo.P)
+        assert P2 == approx(self.r2.thermo.P)
 
     def test_derivative(self):
         T1, P1 = 300, 101325
@@ -159,7 +158,7 @@ class TestReactor:
         dt += self.net.time
         dy += self.net.get_state()
         for i in range(self.net.n_vars):
-            assertNear(dydt[i], dy[i]/dt)
+            assert dydt[i] == approx(dy[i]/dt)
 
     def test_finite_difference_jacobian(self):
         self.make_reactors(n_reactors=1, T1=900, P1=101325, X1="H2:0.4, O2:0.4, N2:0.2")
@@ -211,15 +210,15 @@ class TestReactor:
         assert self.net.max_time_step == dt_max
         self.net.initial_time = tStart
         assert self.net.initial_time == tStart
-        assertNear(self.net.time, tStart)
+        assert self.net.time == approx(tStart)
 
         while t < tEnd:
             tPrev = t
             t = self.net.step()
             assert t - tPrev <= 1.0001 * dt_max
-            assertNear(t, self.net.time)
+            assert t == approx(self.net.time)
 
-        #assertNear(self.net.time, tEnd)
+        #assert self.net.time == approx(tEnd)
 
     def test_maxsteps(self):
         self.make_reactors()
@@ -277,8 +276,8 @@ class TestReactor:
 
         self.net.advance(1.0)
 
-        assertNear(self.net.time, 1.0)
-        assertNear(self.gas1.P, self.gas2.P)
+        assert self.net.time == approx(1.0)
+        assert self.gas1.P == approx(self.gas2.P)
         assert self.r1.T != approx(self.r2.T)
 
     def test_tolerances(self, rtol_lim=1e-10, atol_lim=1e-20):
@@ -373,8 +372,8 @@ class TestReactor:
         self.add_wall(U=500, A=1.0)
 
         self.net.advance(10.0)
-        assertNear(self.net.time, 10.0)
-        assertNear(self.r1.T, self.r2.T, 5e-7)
+        assert self.net.time == approx(10.0)
+        assert self.r1.T == approx(self.r2.T, rel=5e-7)
         assert self.r1.thermo.P != approx(self.r2.thermo.P)
 
     def test_advance_limits_invalid(self):
@@ -403,16 +402,16 @@ class TestReactor:
         self.r2.volume = 0.25
         w = self.add_wall(U=100, A=0.5)
 
-        assertNear(w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T),
-                        w.heat_rate)
+        assert w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T) == approx(
+               w.heat_rate)
         self.net.advance(1.0)
-        assertNear(w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T),
-                        w.heat_rate)
+        assert w.heat_transfer_coeff * w.area * (self.r1.T - self.r2.T) == approx(
+               w.heat_rate)
         T1b = self.r1.T
         T2b = self.r2.T
 
-        assertNear(T1a, T1b)
-        assertNear(T2a, T2b)
+        assert T1a == approx(T1b)
+        assert T2a == approx(T2b)
 
     def test_equilibrium_UV(self):
         # Adiabatic, constant volume combustion should proceed to equilibrium
@@ -429,9 +428,9 @@ class TestReactor:
         gas.TPX = T0, P0, X0
         gas.equilibrate('UV')
 
-        assertNear(self.r1.T, gas.T)
-        assertNear(self.r1.thermo.density, gas.density)
-        assertNear(self.r1.thermo.P, gas.P)
+        assert self.r1.T == approx(gas.T)
+        assert self.r1.thermo.density == approx(gas.density)
+        assert self.r1.thermo.P == approx(gas.P)
         assertArrayNear(self.r1.thermo.X, gas.X)
 
     def test_equilibrium_HP(self):
@@ -454,9 +453,9 @@ class TestReactor:
         gas2.TPX = T0, P0, X0
         gas2.equilibrate('HP')
 
-        assertNear(r1.T, gas2.T)
-        assertNear(r1.thermo.P, P0)
-        assertNear(r1.thermo.density, gas2.density)
+        assert r1.T == approx(gas2.T)
+        assert r1.thermo.P == approx(P0)
+        assert r1.thermo.density == approx(gas2.density)
         assertArrayNear(r1.thermo.X, gas2.X)
 
     def test_wall_velocity(self):
@@ -475,12 +474,12 @@ class TestReactor:
         self.w.velocity = v
         self.net.advance(1.0)
         assert self.w.velocity == approx(v(1.0))
-        assertNear(self.w.expansion_rate, 1.0 * A, 1e-7)
+        assert self.w.expansion_rate == approx(1.0 * A, rel=1e-7)
         self.net.advance(2.0)
-        assertNear(self.w.expansion_rate, 0.0, 1e-7)
+        assert self.w.expansion_rate == approx(0.0, rel=1e-7)
 
-        assertNear(self.r1.volume, V1 + 1.0 * A, 1e-7)
-        assertNear(self.r2.volume, V2 - 1.0 * A, 1e-7)
+        assert self.r1.volume == approx(V1 + 1.0 * A, rel=1e-7)
+        assert self.r2.volume == approx(V2 - 1.0 * A, rel=1e-7)
 
     def test_disable_energy(self):
         self.make_reactors(T1=500)
@@ -488,8 +487,8 @@ class TestReactor:
         self.add_wall(A=1.0, U=2500)
         self.net.advance(11.0)
 
-        assertNear(self.r1.T, 500)
-        assertNear(self.r2.T, 500)
+        assert self.r1.T == approx(500)
+        assert self.r2.T == approx(500)
 
     def test_disable_chemistry(self):
         self.make_reactors(T1=1000, n_reactors=1, X1='H2:2.0,O2:1.0')
@@ -497,9 +496,9 @@ class TestReactor:
 
         self.net.advance(11.0)
 
-        assertNear(self.r1.T, 1000)
-        assertNear(self.r1.thermo.X[self.r1.thermo.species_index('H2')], 2.0/3.0)
-        assertNear(self.r1.thermo.X[self.r1.thermo.species_index('O2')], 1.0/3.0)
+        assert self.r1.T == approx(1000)
+        assert self.r1.thermo.X[self.r1.thermo.species_index('H2')] == approx(2.0/3.0)
+        assert self.r1.thermo.X[self.r1.thermo.species_index('O2')] == approx(1.0/3.0)
 
     def test_heat_flux_func(self):
         self.make_reactors(T1=500, T2=300)
@@ -521,10 +520,10 @@ class TestReactor:
         U1b = self.r1.volume * self.r1.density * self.r1.thermo.u
         U2b = self.r2.volume * self.r2.density * self.r2.thermo.u
 
-        assertNear(V1a, self.r1.volume)
-        assertNear(V2a, self.r2.volume)
-        assertNear(U1a - Q, U1b, 1e-6)
-        assertNear(U2a + Q, U2b, 1e-6)
+        assert V1a == approx(self.r1.volume)
+        assert V2a == approx(self.r2.volume)
+        assert U1a - Q == approx(U1b, rel=1e-6)
+        assert U2a + Q == approx(U2b, rel=1e-6)
 
     def test_mass_flow_controller(self):
         self.make_reactors(n_reactors=1)
@@ -564,20 +563,20 @@ class TestReactor:
         self.net.max_time_step = 0.05
 
         self.net.advance(0.1)
-        assertNear(mfc.mass_flow_rate, 0.)
+        assert mfc.mass_flow_rate == approx(0.)
         self.net.advance(0.3)
-        assertNear(mfc.mass_flow_rate, 0.04)
+        assert mfc.mass_flow_rate == approx(0.04)
         self.net.advance(1.0)
-        assertNear(mfc.mass_flow_rate, 0.08)
+        assert mfc.mass_flow_rate == approx(0.08)
         self.net.advance(1.2)
-        assertNear(mfc.mass_flow_rate, 0.)
+        assert mfc.mass_flow_rate == approx(0.)
 
         self.net.advance(2.5)
 
         mb = self.r1.volume * self.r1.density
         Yb = self.r1.Y
 
-        assertNear(ma + 0.1, mb)
+        assert ma + 0.1 == approx(mb)
         assertArrayNear(ma * Ya + 0.1 * gas2.Y, mb * Yb)
 
     def test_mass_flow_controller_type(self):
@@ -613,8 +612,8 @@ class TestReactor:
         assert self.r1.energy_enabled
         assert self.r2.energy_enabled
         self.net.initialize()
-        assertNear((self.r1.thermo.P - self.r2.thermo.P) * k,
-                   valve.mass_flow_rate)
+        assert (self.r1.thermo.P - self.r2.thermo.P) * k == approx(
+                valve.mass_flow_rate)
 
         m1a = self.r1.thermo.density * self.r1.volume
         m2a = self.r2.thermo.density * self.r2.volume
@@ -626,9 +625,9 @@ class TestReactor:
         m1b = self.r1.thermo.density * self.r1.volume
         m2b = self.r2.thermo.density * self.r2.volume
 
-        assertNear((self.r1.thermo.P - self.r2.thermo.P) * k,
-                        valve.mass_flow_rate)
-        assertNear(m1a+m2a, m1b+m2b)
+        assert (self.r1.thermo.P - self.r2.thermo.P) * k == approx(
+                valve.mass_flow_rate)
+        assert m1a + m2a == approx(m1b + m2b)
         Y1b = self.r1.thermo.Y
         Y2b = self.r2.thermo.Y
         assertArrayNear(m1a*Y1a + m2a*Y2a, m1b*Y1b + m2b*Y2b, atol=1e-10)
@@ -663,8 +662,8 @@ class TestReactor:
             self.net.advance(t)
             m1 = self.r1.thermo.density * self.r1.volume
             m2 = self.r2.thermo.density * self.r2.volume
-            assertNear(m2, (m2a - A/B) * np.exp(-B * t) + A/B)
-            assertNear(m1a+m2a, m1+m2)
+            assert m2 == approx((m2a - A/B) * np.exp(-B * t) + A/B)
+            assert m1a + m2a == approx(m1 + m2)
             assertArrayNear(self.r1.Y, Y1)
 
     def test_valve3(self):
@@ -693,10 +692,10 @@ class TestReactor:
             t = self.net.step()
             p1 = self.r1.thermo.P
             p2 = self.r2.thermo.P
-            assertNear(mdot(p1-p2), valve.mass_flow_rate)
+            assert mdot(p1-p2) == approx(valve.mass_flow_rate)
             assertArrayNear(Y1, self.r1.Y)
-            assertNear(speciesMass(kAr), mAr)
-            assertNear(speciesMass(kO2), mO2)
+            assert speciesMass(kAr) == approx(mAr)
+            assert speciesMass(kO2) == approx(mO2)
 
     def test_valve_timing(self):
         # test timed valve
@@ -781,9 +780,9 @@ class TestReactor:
         t = 0
         while t < 1.0:
             t = self.net.step()
-            assertNear(mdot(t), mfc.mass_flow_rate)
+            assert mdot(t) == approx(mfc.mass_flow_rate)
             dP = self.r1.thermo.P - outlet_reservoir.thermo.P
-            assertNear(mdot(t) + 1e-5 * dP, pc.mass_flow_rate)
+            assert mdot(t) + 1e-5 * dP == approx(pc.mass_flow_rate)
 
     def test_pressure_controller2(self):
         self.make_reactors(n_reactors=1)
@@ -807,9 +806,9 @@ class TestReactor:
         t = 0
         while t < 1.0:
             t = self.net.step()
-            assertNear(mdot(t), mfc.mass_flow_rate)
+            assert mdot(t) == approx(mfc.mass_flow_rate)
             dP = self.r1.thermo.P - outlet_reservoir.thermo.P
-            assertNear(mdot(t) + pfunc(dP), pc.mass_flow_rate)
+            assert mdot(t) + pfunc(dP) == approx(pc.mass_flow_rate)
 
     def test_pressure_controller_type(self):
         self.make_reactors()
@@ -851,7 +850,7 @@ class TestReactor:
         t0 = 0.0
         tf = t0 + 0.5
         self.net.advance(tf)
-        assertNear(self.net.time, tf)
+        assert self.net.time == approx(tf)
         p1a = self.r1.thermo.P
         p2a = self.r2.thermo.P
         assert valve.pressure_function == approx(pfunc_a(p1a - p2a))
@@ -866,13 +865,13 @@ class TestReactor:
         self.net.initial_time = t0
         tf = t0 + 0.5
         self.net.advance(tf)
-        assertNear(self.net.time, tf)
+        assert self.net.time == approx(tf)
         p1b = self.r1.thermo.P
         p2b = self.r2.thermo.P
         assert valve.pressure_function == approx(pfunc_b(p1b - p2b))
 
-        assertNear(p1a, p1b)
-        assertNear(p2a, p2b)
+        assert p1a == approx(p1b)
+        assert p2a == approx(p2b)
 
     def test_reinitialize(self):
         self.make_reactors(T1=300, T2=1000, independent=False)
@@ -887,14 +886,14 @@ class TestReactor:
         self.r2.thermo.TD = 1000, None
         self.r2.syncState()
 
-        assertNear(self.r1.T, 300)
-        assertNear(self.r2.T, 1000)
+        assert self.r1.T == approx(300)
+        assert self.r2.T == approx(1000)
         self.net.advance(2.0)
         T1b = self.r1.T
         T2b = self.r2.T
 
-        assertNear(T1a, T1b)
-        assertNear(T2a, T2b)
+        assert T1a == approx(T1b)
+        assert T2a == approx(T2b)
 
     def test_unpicklable(self):
         self.make_reactors()
@@ -1155,8 +1154,8 @@ class TestMoleReactor(TestReactor):
             net1.advance(i)
             net2.advance(i)
             assertArrayNear(r1.thermo.Y, r2.thermo.Y, rtol=5e-4, atol=1e-6)
-            assertNear(r1.T, r2.T, rtol=5e-5)
-            assertNear(r1.thermo.P, r2.thermo.P, rtol=1e-6)
+            assert r1.T == approx(r2.T, rel=5e-5)
+            assert r1.thermo.P == approx(r2.thermo.P, rel=1e-6)
             assertArrayNear(rsurf1.coverages, rsurf2.coverages, rtol=1e-4,
                             atol=1e-8)
 
@@ -1236,10 +1235,9 @@ class TestWellStirredReactorIgnition:
         t,T = self.integrate(100.0)
 
         for i in range(len(t)):
-            assertNear(T[i], T0, rtol=1e-5)
+            assert T[i] == approx(T0, rel=1e-5)
 
-        assertNear(self.combustor.thermo['CH4'].Y,
-                   mdot_f / (mdot_o + mdot_f))
+        assert self.combustor.thermo['CH4'].Y == approx(mdot_f / (mdot_o + mdot_f))
 
     def test_ignition1(self):
         self.setup_reactor(900.0, 10*ct.one_atm, 1.0, 5.0)
@@ -1252,7 +1250,7 @@ class TestWellStirredReactorIgnition:
                 break
 
         # regression test; no external basis for this result
-        assertNear(tIg, 2.2249, 1e-3)
+        assert tIg == approx(2.2249, rel=1e-3)
 
     def test_ignition2(self):
         self.setup_reactor(900.0, 10*ct.one_atm, 1.0, 20.0)
@@ -1265,7 +1263,7 @@ class TestWellStirredReactorIgnition:
                 break
 
         # regression test; no external basis for this result
-        assertNear(tIg, 1.4856, 1e-3)
+        assert tIg == approx(1.4856, rel=1e-3)
 
     def test_ignition3(self):
         self.setup_reactor(900.0, 10*ct.one_atm, 1.0, 80.0)
@@ -1279,9 +1277,9 @@ class TestWellStirredReactorIgnition:
         # test if steady state is reached
         assert residuals[-1] < 10. * self.net.rtol
         # regression test; no external basis for these results
-        assertNear(self.combustor.T, 2498.94, 1e-5)
-        assertNear(self.combustor.thermo['H2O'].Y[0], 0.103658, 1e-5)
-        assertNear(self.combustor.thermo['HO2'].Y[0], 8.734515e-06, 1e-5)
+        assert self.combustor.T == approx(2498.94, rel=1e-5)
+        assert self.combustor.thermo['H2O'].Y[0] == approx(0.103658, rel=1e-5)
+        assert self.combustor.thermo['HO2'].Y[0] == approx(8.734515e-06, rel=1e-5)
 
 
 class TestConstPressureReactor:
@@ -1394,8 +1392,8 @@ class TestConstPressureReactor:
             self.net2.advance(t)
             assertArrayNear(self.r1.thermo.Y, self.r2.thermo.Y,
                             rtol=5e-4, atol=1e-6)
-            assertNear(self.r1.T, self.r2.T, rtol=5e-5)
-            assertNear(self.r1.thermo.P, self.r2.thermo.P, rtol=1e-6)
+            assert self.r1.T == approx(self.r2.T, rel=5e-5)
+            assert self.r1.thermo.P == approx(self.r2.thermo.P, rel=1e-6)
             if surf:
                 assertArrayNear(self.surf1.coverages, self.surf2.coverages,
                                      rtol=1e-4, atol=1e-8)
@@ -1490,8 +1488,8 @@ class TestIdealGasMoleReactor(TestMoleReactor):
             net1.advance(t)
             net2.advance(t)
             assertArrayNear(r1.thermo.Y, r2.thermo.Y, rtol=5e-4, atol=1e-6)
-            assertNear(r1.T, r2.T, rtol=1e-5)
-            assertNear(r1.thermo.P, r2.thermo.P, rtol=1e-5)
+            assert r1.T == approx(r2.T, rel=1e-5)
+            assert r1.thermo.P == approx(r2.thermo.P, rel=1e-5)
 
 
 class TestReactorJacobians:
@@ -1690,10 +1688,10 @@ class TestFlowReactor:
 
         x = 0
         v0 = r.speed
-        assertNear(v0, 10 / r.density)
+        assert v0 == approx(10 / r.density)
         while x < 10.0:
             x = net.step()
-            assertNear(v0, r.speed)
+            assert v0 == approx(r.speed)
 
     def test_reacting(self):
         g = ct.Solution(yaml=self.gas_def)
@@ -2056,21 +2054,21 @@ class TestSurfaceKinetics:
         surf1 = ct.ReactorSurface(self.interface, self.r1)
 
         surf1.coverages = {'c6HH':0.3, 'c6HM':0.7}
-        assertNear(surf1.coverages[0], 0.3)
-        assertNear(surf1.coverages[1], 0.0)
-        assertNear(surf1.coverages[4], 0.7)
+        assert surf1.coverages[0] == approx(0.3)
+        assert surf1.coverages[1] == approx(0.0)
+        assert surf1.coverages[4] == approx(0.7)
         self.net.advance(1e-5)
         C_left = surf1.coverages
 
         self.make_reactors()
         surf2 = ct.ReactorSurface(self.interface, self.r2)
         surf2.coverages = 'c6HH:0.3, c6HM:0.7'
-        assertNear(surf2.coverages[0], 0.3)
-        assertNear(surf2.coverages[4], 0.7)
+        assert surf2.coverages[0] == approx(0.3)
+        assert surf2.coverages[4] == approx(0.7)
         self.net.advance(1e-5)
         C_right = surf2.coverages
 
-        assertNear(sum(C_left), 1.0)
+        assert sum(C_left) == approx(1.0)
         assertArrayNear(C_left, C_right)
 
         with pytest.raises(ValueError):
@@ -2205,8 +2203,8 @@ class TestReactorSensitivities:
             assertArrayNear(S[K2+1,:], np.zeros(2))
 
             # Sensitivity coefficients for the disjoint reactors should be zero
-            assertNear(np.linalg.norm(S[Ns:K2,1]), 0.0, atol=1e-5)
-            assertNear(np.linalg.norm(S[K2+Ns:,0]), 0.0, atol=1e-5)
+            assert np.linalg.norm(S[Ns:K2,1]) == approx(0.0, abs=1e-5)
+            assert np.linalg.norm(S[K2+Ns:,0]) == approx(0.0, abs=1e-5)
 
     def _test_parameter_order1(self, reactorClass):
         # Single reactor, changing the order in which parameters are added
@@ -2458,7 +2456,7 @@ class TestReactorSensitivities:
         dH = 1e4
         for i,s in enumerate(species):
             dtigdh = (self.calc_tig(s, dH) - tig0) / dH
-            assertNear(dtigdh_cvodes[i], dtigdh, atol=1e-14, rtol=5e-2)
+            assert dtigdh_cvodes[i] == approx(dtigdh, rel=5e-2, abs=1e-14)
 
 
 @pytest.fixture(scope='class')
@@ -2683,7 +2681,7 @@ class TestPureFluidReactor:
 
         assert states.Q[0] == 0
         assert states.Q[-1] == 1
-        assertNear(states.Q[30], 0.54806, 1e-4)
+        assert states.Q[30] == approx(0.54806, rel=1e-4)
 
     def test_Reactor_2(self):
         phase = ct.PureFluid("liquidvapor.yaml", "carbon-dioxide")
@@ -2708,7 +2706,7 @@ class TestPureFluidReactor:
 
         assert states.Q[0] == 0
         assert states.Q[-1] == 1
-        assertNear(states.Q[20], 0.644865, 1e-4)
+        assert states.Q[20] == approx(0.644865, rel=1e-4)
 
 
     def test_ConstPressureReactor(self):
@@ -2733,7 +2731,7 @@ class TestPureFluidReactor:
         assert states.Q[1] == 0
         assert states.Q[-2] == 1
         for i in range(3,7):
-            assertNear(states.T[i], states.T[2])
+            assert states.T[i] == approx(states.T[2])
 
 
 @pytest.fixture(scope='function')
@@ -2969,7 +2967,7 @@ class TestExtensibleReactor:
         r1_heat = (mass_lump * cp_lump * (r1.thermo.T - 500) +
                    mass_gas * (self.gas.enthalpy_mass - gas_initial_enthalpy))
         add_heat = Q * time
-        assertNear(add_heat, r1_heat, atol=1e-5)
+        assert add_heat == approx(r1_heat, abs=1e-5)
 
     def test_heat_addition(self):
         # Applying heat via 'heat_rate' property should be equivalent to adding it via
@@ -2989,8 +2987,8 @@ class TestExtensibleReactor:
         for t in np.linspace(0.1, 5, 10):
             net.advance(t)
             U = r1.thermo.int_energy_mass * r1.mass
-            assertNear(U - U0, (Qext + Qwall) * t)
-            assertNear(r1.heat_rate, Qext + Qwall)
+            assert U - U0 == approx((Qext + Qwall) * t)
+            assert r1.heat_rate == approx(Qext + Qwall)
 
     def test_with_surface(self):
         phase_defs = """
@@ -3067,15 +3065,15 @@ class TestExtensibleReactor:
         for t in np.linspace(0.1, 1, 12):
             net.advance(t)
             mH, mO = masses()
-            assertNear(mH, mH0)
-            assertNear(mO, mO0)
+            assert mH == approx(mH0)
+            assert mO == approx(mO0)
 
         # Regression test values
-        assertNear(r1.thermo.P, 647.56016304)
-        assertNear(r1.thermo.X[kH2], 0.4784268406)
-        assertNear(r1.thermo.X[kO2], 0.5215731594)
-        assertNear(r1.surfaces[0].kinetics.X[kHs], 0.3665198138)
-        assertNear(r1.surfaces[0].kinetics.X[kPts], 0.6334801862)
+        assert r1.thermo.P == approx(647.56016304)
+        assert r1.thermo.X[kH2] == approx(0.4784268406)
+        assert r1.thermo.X[kO2] == approx(0.5215731594)
+        assert r1.surfaces[0].kinetics.X[kHs] == approx(0.3665198138)
+        assert r1.surfaces[0].kinetics.X[kPts] == approx(0.6334801862)
 
     def test_interactions(self):
         # Reactors connected by a movable, H2-permeable surface
@@ -3123,8 +3121,8 @@ class TestExtensibleReactor:
         V0 = r1.volume + r2.volume
         for t in np.linspace(0.01, 0.2, 50):
             net.advance(t)
-            assertNear(r1.expansion_rate, -r2.expansion_rate)
-            assertNear(V0, r1.volume + r2.volume)
+            assert r1.expansion_rate == approx(-r2.expansion_rate)
+            assert V0 == approx(r1.volume + r2.volume)
             deltaCnow = deltaC()
             assert deltaCnow < deltaCprev # difference is always decreasing
             deltaCprev = deltaCnow
@@ -3133,6 +3131,6 @@ class TestExtensibleReactor:
             states2.append(r2.thermo.state, t=net.time, mass=r2.mass, vdot=r2.expansion_rate)
 
         # Regression test values
-        assertNear(r1.thermo.P, 151561.15, rtol=1e-6)
-        assertNear(r1.thermo["H2"].Y[0], 0.13765976, rtol=1e-6)
-        assertNear(r2.thermo["O2"].Y[0], 0.94617029, rtol=1e-6)
+        assert r1.thermo.P == approx(151561.15, rel=1e-6)
+        assert r1.thermo["H2"].Y[0] == approx(0.13765976, rel=1e-6)
+        assert r2.thermo["O2"].Y[0] == approx(0.94617029, rel=1e-6)

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -2456,58 +2456,7 @@ class TestReactorSensitivities:
             assert dtigdh_cvodes[i] == approx(dtigdh, rel=5e-2, abs=1e-14)
 
 
-
-@pytest.fixture(scope='function')
-def setup_combustor_tests_data(request):
-    gas = ct.Solution('h2o2.yaml', transport_model=None)
-
-    # create a reservoir for the fuel inlet, and set to pure methane.
-    gas.TPX = 300.0, ct.one_atm, 'H2:1.0'
-    fuel_in = ct.Reservoir(gas)
-    fuel_mw = gas.mean_molecular_weight
-
-    # Oxidizer inlet
-    gas.TPX = 300.0, ct.one_atm, 'O2:1.0, AR:3.0'
-    oxidizer_in = ct.Reservoir(gas)
-    oxidizer_mw = gas.mean_molecular_weight
-
-    # to ignite the fuel/air mixture, we'll introduce a pulse of radicals.
-    # The steady-state behavior is independent of how we do this, so we'll
-    # just use a stream of pure atomic hydrogen.
-    gas.TPX = 300.0, ct.one_atm, 'H:1.0'
-    request.cls.igniter = ct.Reservoir(gas)
-
-    # create the combustor, and fill it in initially with a diluent
-    gas.TPX = 300.0, ct.one_atm, 'AR:1.0'
-    request.cls.combustor = ct.IdealGasReactor(gas)
-
-    # create a reservoir for the exhaust
-    request.cls.exhaust = ct.Reservoir(gas)
-
-    # compute fuel and air mass flow rates
-    factor = 0.1
-    oxidizer_mdot = 4 * factor*oxidizer_mw
-    fuel_mdot = factor*fuel_mw
-
-    # The igniter will use a time-dependent igniter mass flow rate.
-    def igniter_mdot(t, t0=0.1, fwhm=0.05, amplitude=0.1):
-        return amplitude * math.exp(-(t-t0)**2 * 4 * math.log(2) / fwhm**2)
-
-    # create and install the mass flow controllers. Controllers
-    # m1 and m2 provide constant mass flow rates, and m3 provides
-    # a short Gaussian pulse only to ignite the mixture
-    request.cls.m1 = ct.MassFlowController(fuel_in, request.cls.combustor, mdot=fuel_mdot)
-    request.cls.m2 = ct.MassFlowController(oxidizer_in, request.cls.combustor, mdot=oxidizer_mdot)
-    request.cls.m3 = ct.MassFlowController(request.cls.igniter, request.cls.combustor, mdot=igniter_mdot)
-
-    # put a valve on the exhaust line to regulate the pressure
-    request.cls.v = ct.Valve(request.cls.combustor, request.cls.exhaust, K=1.0)
-
-    # the simulation only contains one reactor
-    request.cls.sim = ct.ReactorNet([request.cls.combustor])
-
-@pytest.mark.usefixtures('setup_combustor_tests_data')
-class CombustorTests:
+class TestCombustor:
     """
     These tests are based on the sample:
 
@@ -2515,86 +2464,136 @@ class CombustorTests:
 
     with some simplifications so that they run faster and produce more
     consistent output.
+
+    Note: to re-create the reference file:
+    (1) set PYTHONPATH to build/python.
+    (2) go into test/python directory and run:
+        pytest --save-reference=combustor test_reactor.py::TestCombustor::test_integrateWithAdvance
+    (3) Compare the reference files created in the current working directory with
+        the ones in test/data and replace them if needed.
     """
     referenceFile = "CombustorTest-integrateWithAdvance.csv"
 
-    def test_integrateWithStep(self, test_data_path):
+    @pytest.fixture
+    def setup_combustor_tests(self):
+        gas = ct.Solution('h2o2.yaml', transport_model=None)
+
+        # create a reservoir for the fuel inlet, and set to pure methane.
+        gas.TPX = 300.0, ct.one_atm, 'H2:1.0'
+        fuel_in = ct.Reservoir(gas)
+        fuel_mw = gas.mean_molecular_weight
+
+        # Oxidizer inlet
+        gas.TPX = 300.0, ct.one_atm, 'O2:1.0, AR:3.0'
+        oxidizer_in = ct.Reservoir(gas)
+        oxidizer_mw = gas.mean_molecular_weight
+
+        # to ignite the fuel/air mixture, we'll introduce a pulse of radicals.
+        # The steady-state behavior is independent of how we do this, so we'll
+        # just use a stream of pure atomic hydrogen.
+        gas.TPX = 300.0, ct.one_atm, 'H:1.0'
+        igniter = ct.Reservoir(gas)
+
+        # create the combustor, and fill it with a diluent
+        gas.TPX = 300.0, ct.one_atm, 'AR:1.0'
+        combustor = ct.IdealGasReactor(gas)
+
+        # create a reservoir for the exhaust
+        exhaust = ct.Reservoir(gas)
+
+        # compute fuel and air mass flow rates
+        factor = 0.1
+        oxidizer_mdot = 4 * factor * oxidizer_mw
+        fuel_mdot = factor * fuel_mw
+
+        # The igniter will use a time-dependent igniter mass flow rate.
+        def igniter_mdot(t, t0=0.1, fwhm=0.05, amplitude=0.1):
+            return amplitude * math.exp(-(t - t0) ** 2 * 4 * math.log(2) / fwhm ** 2)
+
+        # create and install the mass flow controllers. Controllers m1 and m2 provide
+        # constant mass flow rates, and m3 provides a short Gaussian pulse only to ignite
+        # the mixture
+        m1 = ct.MassFlowController(fuel_in, combustor, mdot=fuel_mdot)
+        m2 = ct.MassFlowController(oxidizer_in, combustor, mdot=oxidizer_mdot)
+        m3 = ct.MassFlowController(igniter, combustor, mdot=igniter_mdot)
+
+        # put a valve on the exhaust line to regulate the pressure
+        valve = ct.Valve(combustor, exhaust, K=1.0)
+
+        # the simulation only contains one reactor
+        sim = ct.ReactorNet([combustor])
+
+        return {
+            'fuel_in': fuel_in,
+            'oxidizer_in': oxidizer_in,
+            'igniter': igniter,
+            'combustor': combustor,
+            'exhaust': exhaust,
+            'm1': m1,
+            'm2': m2,
+            'm3': m3,
+            'valve': valve,
+            'sim': sim
+        }
+
+    def test_integrateWithStep(self, test_data_path, setup_combustor_tests):
+        sim = setup_combustor_tests['sim']
+        combustor = setup_combustor_tests['combustor']
+
         tnow = 0.0
         tfinal = 0.25
-        self.data = []
+        data = []
         while tnow < tfinal:
-            tnow = self.sim.step()
-            self.data.append([tnow, self.combustor.T] +
-                             list(self.combustor.thermo.X))
+            tnow = sim.step()
+            data.append([tnow, combustor.T] + list(combustor.thermo.X))
 
         assert tnow >= tfinal
-        bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+        bad = compareProfiles(test_data_path / self.referenceFile, data,
                               rtol=1e-3, atol=1e-9)
         assert not bad, bad
 
-    def test_integrateWithAdvance(self, test_data_path, saveReference=False):
-        self.data = []
-        for t in np.linspace(0, 0.25, 101)[1:]:
-            self.sim.advance(t)
-            self.data.append([t, self.combustor.T] +
-                             list(self.combustor.thermo.X))
+    def test_integrateWithAdvance(self, request, test_data_path, setup_combustor_tests):
+        sim = setup_combustor_tests['sim']
+        combustor = setup_combustor_tests['combustor']
 
-        if saveReference:
-            np.savetxt(test_data_path / self.referenceFile, np.array(self.data),
-                       '%11.6e', ', ')
+        data = []
+        for t in np.linspace(0, 0.25, 101)[1:]:
+            sim.advance(t)
+            data.append([t, combustor.T] + list(combustor.thermo.X))
+
+        saveReference = request.config.getoption("--save-reference")
+        if saveReference == 'combustor':
+            np.savetxt(self.referenceFile, np.array(data), '%11.6e', ', ')
         else:
-            bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+            bad = compareProfiles(test_data_path / self.referenceFile, data,
                                   rtol=1e-6, atol=1e-12)
             assert not bad, bad
 
-    def test_invasive_mdot_function(self, test_data_path):
+    def test_invasive_mdot_function(self, test_data_path, setup_combustor_tests):
+        igniter = setup_combustor_tests['igniter']
+        m3 = setup_combustor_tests['m3']
+        sim = setup_combustor_tests['sim']
+        combustor = setup_combustor_tests['combustor']
+
         def igniter_mdot(t, t0=0.1, fwhm=0.05, amplitude=0.1):
             # Querying properties of the igniter changes the state of the
             # underlying ThermoPhase object, but shouldn't affect the
             # integration
-            self.igniter.density
+            igniter.density
             return amplitude * math.exp(-(t-t0)**2 * 4 * math.log(2) / fwhm**2)
-        self.m3.mass_flow_rate = igniter_mdot
+        m3.mass_flow_rate = igniter_mdot
 
-        self.data = []
+        data = []
         for t in np.linspace(0, 0.25, 101)[1:]:
-            self.sim.advance(t)
-            self.data.append([t, self.combustor.T] +
-                             list(self.combustor.thermo.X))
+            sim.advance(t)
+            data.append([t, combustor.T] + list(combustor.thermo.X))
 
-        bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+        bad = compareProfiles(test_data_path / self.referenceFile, data,
                               rtol=1e-6, atol=1e-12)
         assert not bad, bad
 
 
-@pytest.fixture(scope='function')
-def setup_wall_tests_data(request):
-    # reservoir to represent the environment
-    gas0 = ct.Solution("air.yaml")
-    gas0.TP = 300, ct.one_atm
-    env = ct.Reservoir(gas0)
-
-    # reactor to represent the side filled with Argon
-    gas1 = ct.Solution("air.yaml")
-    gas1.TPX = 1000.0, 30*ct.one_atm, 'AR:1.0'
-    request.cls.r1 = ct.Reactor(gas1)
-
-    # reactor to represent the combustible mixture
-    gas2 = ct.Solution('h2o2.yaml', transport_model=None)
-    gas2.TPX = 500.0, 1.5*ct.one_atm, 'H2:0.5, O2:1.0, AR:10.0'
-    request.cls.r2 = ct.Reactor(gas2)
-
-    # Wall between the two reactors
-    w1 = ct.Wall(request.cls.r2, request.cls.r1, A=1.0, K=2e-4, U=400.0)
-
-    # Wall to represent heat loss to the environment
-    w2 = ct.Wall(request.cls.r2, env, A=1.0, U=2000.0)
-
-    # Create the reactor network
-    request.cls.sim = ct.ReactorNet([request.cls.r1, request.cls.r2])
-
-@pytest.mark.usefixtures('setup_wall_tests_data')
-class WallTests:
+class TestWall:
     """
     These tests are based on the sample:
 
@@ -2602,47 +2601,74 @@ class WallTests:
 
     with some simplifications so that they run faster and produce more
     consistent output.
+
+    Note: to re-create the reference file:
+    (1) set PYTHONPATH to build/python.
+    (2) go into test/python directory and run:
+        pytest --save-reference=wall test_reactor.py::TestWall::test_integrateWithAdvance
+    (3) Compare the reference files created in the current working directory with
+        the ones in test/data and replace them if needed.
     """
     referenceFile = "WallTest-integrateWithAdvance.csv"
 
-    def test_integrateWithStep(self, test_data_path):
+    @pytest.fixture
+    def setup_wall_tests(self):
+        # reservoir to represent the environment
+        gas0 = ct.Solution("air.yaml")
+        gas0.TP = 300, ct.one_atm
+        env = ct.Reservoir(gas0)
+
+        # reactor to represent the side filled with Argon
+        gas1 = ct.Solution("air.yaml")
+        gas1.TPX = 1000.0, 30*ct.one_atm, 'AR:1.0'
+        r1 = ct.Reactor(gas1)
+
+        # reactor to represent the combustible mixture
+        gas2 = ct.Solution('h2o2.yaml', transport_model=None)
+        gas2.TPX = 500.0, 1.5*ct.one_atm, 'H2:0.5, O2:1.0, AR:10.0'
+        r2 = ct.Reactor(gas2)
+
+        # Wall between the two reactors
+        w1 = ct.Wall(r2, r1, A=1.0, K=2e-4, U=400.0)
+
+        # Wall to represent heat loss to the environment
+        w2 = ct.Wall(r2, env, A=1.0, U=2000.0)
+
+        # Create the reactor network
+        sim = ct.ReactorNet([r1, r2])
+
+        return sim, r1, r2
+
+    def test_integrateWithStep(self, test_data_path, setup_wall_tests):
+        sim, r1, r2 = setup_wall_tests
         tnow = 0.0
         tfinal = 0.01
-        self.data = []
+        data = []
         while tnow < tfinal:
-            tnow = self.sim.step()
-            self.data.append([tnow,
-                              self.r1.T, self.r2.T,
-                              self.r1.thermo.P, self.r2.thermo.P,
-                              self.r1.volume, self.r2.volume])
+            tnow = sim.step()
+            data.append([tnow, r1.T, r2.T, r1.thermo.P,
+                        r2.thermo.P, r1.volume, r2.volume])
 
         assert tnow >= tfinal
-        bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+        bad = compareProfiles(test_data_path / self.referenceFile, data,
                               rtol=1e-3, atol=1e-8)
         assert not bad, bad
 
-    def test_integrateWithAdvance(self, test_data_path, saveReference=False):
-        self.data = []
+    def test_integrateWithAdvance(self, request, test_data_path, setup_wall_tests):
+        sim, r1, r2 = setup_wall_tests
+        data = []
         for t in np.linspace(0, 0.01, 200)[1:]:
-            self.sim.advance(t)
-            self.data.append([t,
-                              self.r1.T, self.r2.T,
-                              self.r1.thermo.P, self.r2.thermo.P,
-                              self.r1.volume, self.r2.volume])
+            sim.advance(t)
+            data.append([t, r1.T, r2.T, r1.thermo.P,
+                        r2.thermo.P, r1.volume, r2.volume])
 
-        if saveReference:
-            np.savetxt(test_data_path / self.referenceFile, np.array(self.data),
-                       '%11.6e', ', ')
+        saveReference = request.config.getoption("--save-reference")
+        if saveReference == 'wall':
+            np.savetxt(self.referenceFile, np.array(self.data), '%11.6e', ', ')
         else:
-            bad = compareProfiles(test_data_path / self.referenceFile, self.data,
+            bad = compareProfiles(test_data_path / self.referenceFile, data,
                                   rtol=2e-5, atol=1e-9)
             assert not bad, bad
-
-
-# Keep the implementations separate from the pytest-derived class
-# so that they can be run independently to generate the reference data files.
-class TestCombustor(CombustorTests): pass
-class TestWall(WallTests): pass
 
 
 class TestPureFluidReactor:
@@ -3119,9 +3145,11 @@ class TestExtensibleReactor:
             deltaCnow = deltaC()
             assert deltaCnow < deltaCprev # difference is always decreasing
             deltaCprev = deltaCnow
-            assert M0 == approx(r1.mass * r1.thermo.Y + r2.mass * r2.thermo.Y, rel=2e-8)
-            states1.append(r1.thermo.state, t=net.time, mass=r1.mass, vdot=r1.expansion_rate)
-            states2.append(r2.thermo.state, t=net.time, mass=r2.mass, vdot=r2.expansion_rate)
+            assert M0 == approx(r1.mass * r1.thermo.Y + r2.mass * r2.thermo.Y,rel=2e-8)
+            states1.append(r1.thermo.state, t=net.time, mass=r1.mass,
+                           vdot=r1.expansion_rate)
+            states2.append(r2.thermo.state, t=net.time, mass=r2.mass,
+                           vdot=r2.expansion_rate)
 
         # Regression test values
         assert r1.thermo.P == approx(151561.15, rel=1e-6)

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -2070,7 +2070,7 @@ class TestSurfaceKinetics:
         with pytest.raises(ValueError):
             surf2.coverages = np.ones(self.interface.n_species + 1)
 
-    def test_coverages_regression1(self):
+    def test_coverages_regression1(self, test_data_path):
         # Test with energy equation disabled
         self.make_reactors()
         self.r1.energy_enabled = False
@@ -2085,7 +2085,7 @@ class TestSurfaceKinetics:
         assert surf1.coverages == approx(C)
         data = []
         test_file = self.test_work_path / "test_coverages_regression1.csv"
-        reference_file = self.test_data_path / "WallKinetics-coverages-regression1.csv"
+        reference_file = test_data_path / "WallKinetics-coverages-regression1.csv"
         data = []
         for t in np.linspace(1e-6, 1e-3):
             self.net.advance(t)
@@ -2097,7 +2097,7 @@ class TestSurfaceKinetics:
                                         rtol=1e-5, atol=1e-9, xtol=1e-12)
         assert not bool(bad), bad
 
-    def test_coverages_regression2(self):
+    def test_coverages_regression2(self, test_data_path):
         # Test with energy equation enabled
         self.make_reactors()
         surf = ct.ReactorSurface(self.interface, self.r1)
@@ -2110,7 +2110,7 @@ class TestSurfaceKinetics:
         assert surf.coverages == approx(C)
         data = []
         test_file = self.test_work_path / "test_coverages_regression2.csv"
-        reference_file = self.test_data_path / "WallKinetics-coverages-regression2.csv"
+        reference_file = test_data_path / "WallKinetics-coverages-regression2.csv"
         data = []
         for t in np.linspace(1e-6, 1e-3):
             self.net.advance(t)
@@ -2456,8 +2456,8 @@ class TestReactorSensitivities:
 
 
 @pytest.fixture(scope='class')
-def setup_combustor_tests(request):
-    request.cls.referenceFile = request.cls.test_data_path / "CombustorTest-integrateWithAdvance.csv"
+def setup_combustor_tests(request, test_data_path):
+    request.cls.referenceFile = test_data_path / "CombustorTest-integrateWithAdvance.csv"
 
 @pytest.fixture(scope='function')
 def setup_combustor_tests_data(request, setup_combustor_tests):
@@ -2568,8 +2568,8 @@ class CombustorTests:
 
 
 @pytest.fixture(scope='class')
-def setup_wall_tests(request):
-    request.cls.referenceFile = request.cls.test_data_path / "WallTest-integrateWithAdvance.csv"
+def setup_wall_tests(request, test_data_path):
+    request.cls.referenceFile = test_data_path / "WallTest-integrateWithAdvance.csv"
 
 @pytest.fixture(scope='function')
 def setup_wall_tests_data(request, setup_wall_tests):
@@ -2731,11 +2731,11 @@ class TestPureFluidReactor:
 
 
 @pytest.fixture(scope='function')
-def setup_advance_converages_data(request):
+def setup_advance_converages_data(request, cantera_data_path):
     mechanism_file = 'ptcombust.yaml'
     interface_phase = 'Pt_surf'
-    #request.cls.surf = ct.Interface(f'{request.cls.test_data_path}/{mechanism_file}', interface_phase)
-    request.cls.surf = ct.Interface(mechanism_file, interface_phase)
+    request.cls.surf = ct.Interface(f'{cantera_data_path}/{mechanism_file}', interface_phase)
+    #request.cls.surf = ct.Interface(mechanism_file, interface_phase)
     request.cls.gas = request.cls.surf.adjacent["gas"]
 
 @pytest.mark.usefixtures('setup_advance_converages_data')

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1626,8 +1626,8 @@ class TestSpeciesThermo(utilities.CanteraTest):
 
 class TestQuantity(utilities.CanteraTest):
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution('gri30.yaml', transport_model=None)
 
     def setUp(self):
@@ -1864,8 +1864,8 @@ class TestMisc(utilities.CanteraTest):
 
 class TestElement(utilities.CanteraTest):
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.ar_sym = ct.Element('Ar')
         cls.ar_name = ct.Element('argon')
         cls.ar_num = ct.Element(18)
@@ -1940,8 +1940,8 @@ class TestElement(utilities.CanteraTest):
 
 class TestSolutionArray(utilities.CanteraTest):
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution('h2o2.yaml')
 
     def test_passthrough(self):

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1114,6 +1114,7 @@ class TestThermo:
 @pytest.fixture(scope='function')
 def setup_interface_tests(request):
     request.cls.interface = ct.Interface("diamond.yaml", "diamond_100")
+
 @pytest.mark.usefixtures("setup_interface_tests")
 class TestInterfacePhase:
 

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1402,9 +1402,9 @@ class TestSpecies:
         assert species[1].composition == {'H': 1, 'O': 2}
         assert species[0].thermo.h(300) == approx(100)
 
-    def test_list_from_yaml_section(self):
+    def test_list_from_yaml_section(self, test_data_path):
         species = ct.Species.list_from_yaml(
-            (self.test_data_path / "ideal-gas.yaml").read_text(),
+            (test_data_path / "ideal-gas.yaml").read_text(),
             'species')
 
         assert species[0].name == 'O2'

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -6,7 +6,6 @@ from pytest import approx
 
 import cantera as ct
 from .utilities import (
-    assertNear,
     assertArrayNear
 )
 
@@ -119,8 +118,8 @@ class TestThermoPhase:
 
         mO = self.phase.element_index('O')
         assert Zo == self.phase.elemental_mass_fraction(mO)
-        assertNear(Zo, 0.5 + 0.5 * (15.999 / 18.015))
-        assertNear(Zh, 0.5 * (2.016 / 18.015))
+        assert Zo == approx(0.5 + 0.5 * (15.999 / 18.015))
+        assert Zh == approx(0.5 * (2.016 / 18.015))
         assert Zar == 0.0
 
         with pytest.raises(ValueError, match='No such element'):
@@ -136,8 +135,8 @@ class TestThermoPhase:
 
         mO = self.phase.element_index('O')
         assert Zo == self.phase.elemental_mole_fraction(mO)
-        assertNear(Zo, (0.5 + 1) / (0.5 * 3 + 0.5 * 2))
-        assertNear(Zh, (2 * 0.5) / (0.5 * 3 + 0.5 * 2))
+        assert Zo == approx((0.5 + 1) / (0.5 * 3 + 0.5 * 2))
+        assert Zh == approx((2 * 0.5) / (0.5 * 3 + 0.5 * 2))
         assert Zar == 0.0
 
         with pytest.raises(ValueError, match='No such element'):
@@ -157,9 +156,9 @@ class TestThermoPhase:
                         for i in range(self.phase.n_elements))
 
             for i in range(self.phase.n_elements):
-                assertNear(self.phase.elemental_mass_fraction(i),
-                           self.phase.elemental_mole_fraction(i)
-                           * self.phase.atomic_weight(i) / denom)
+                assert self.phase.elemental_mass_fraction(i) == approx(
+                       self.phase.elemental_mole_fraction(i)
+                       * self.phase.atomic_weight(i) / denom)
 
     def test_weights(self):
         atomic_weights = self.phase.atomic_weights
@@ -171,7 +170,7 @@ class TestThermoPhase:
             test_weight = 0.0
             for j, aw in enumerate(atomic_weights):
                 test_weight += aw * self.phase.n_atoms(i, j)
-            assertNear(test_weight, mw)
+            assert test_weight == approx(mw)
 
     def test_charges(self):
         gas = ct.Solution('ch4_ion.yaml')
@@ -199,8 +198,8 @@ class TestThermoPhase:
     def test_setCompositionString(self):
         self.phase.X = 'h2:1.0, o2:1.0'
         X = self.phase.X
-        assertNear(X[0], 0.5)
-        assertNear(X[3], 0.5)
+        assert X[0] == approx(0.5)
+        assert X[3] == approx(0.5)
 
         with pytest.raises(ct.CanteraError, match='Unknown species'):
             self.phase.X = 'H2:1.0, CO2:1.5'
@@ -226,13 +225,13 @@ class TestThermoPhase:
     def test_setCompositionDict(self):
         self.phase.X = {b'H2': 1.0, b'O2': 3.0}
         X = self.phase.X
-        assertNear(X[0], 0.25)
-        assertNear(X[3], 0.75)
+        assert X[0] == approx(0.25)
+        assert X[3] == approx(0.75)
 
         self.phase.Y = {'H2': 1.0, 'O2': 3.0}
         Y = self.phase.Y
-        assertNear(Y[0], 0.25)
-        assertNear(Y[3], 0.75)
+        assert Y[0] == approx(0.25)
+        assert Y[3] == approx(0.75)
 
     def test_getCompositionDict(self):
         self.phase.X = 'oh:1e-9, O2:0.4, AR:0.6'
@@ -241,8 +240,8 @@ class TestThermoPhase:
 
         self.phase.Y = 'O2:0.4, AR:0.6'
         Y1 = self.phase.mass_fraction_dict()
-        assertNear(Y1['O2'], 0.4)
-        assertNear(Y1['AR'], 0.6)
+        assert Y1['O2'] == approx(0.4)
+        assert Y1['AR'] == approx(0.6)
 
     def test_setCompositionNoNorm(self):
         X = np.zeros(self.phase.n_species)
@@ -250,14 +249,14 @@ class TestThermoPhase:
         X[0] = 0.01
         self.phase.set_unnormalized_mole_fractions(X)
         assertArrayNear(self.phase.X, X)
-        assertNear(sum(X), 1.01)
+        assert sum(X) == approx(1.01)
 
         Y = np.zeros(self.phase.n_species)
         Y[2] = 1.0
         Y[0] = 0.01
         self.phase.set_unnormalized_mass_fractions(Y)
         assertArrayNear(self.phase.Y, Y)
-        assertNear(sum(Y), 1.01)
+        assert sum(Y) == approx(1.01)
 
     def test_setCompositionNoNormBad(self):
         X = np.zeros(self.phase.n_species - 1)
@@ -278,8 +277,8 @@ class TestThermoPhase:
     def test_setCompositionSlice(self):
         self.phase['h2', 'o2'].X = 0.1, 0.9
         X = self.phase.X
-        assertNear(X[0], 0.1)
-        assertNear(X[3], 0.9)
+        assert X[0] == approx(0.1)
+        assert X[3] == approx(0.9)
 
     def test_setCompositionSingleSpecies(self):
         yaml_def = """
@@ -323,7 +322,7 @@ class TestThermoPhase:
             gas.equilibrate('TP')
             assert gas['O2'].X[0] > excess
             excess = gas['O2'].X[0]
-        assertNear(sum(gas['O2','N2'].X), 1.0)
+        assert sum(gas['O2','N2'].X) == approx(1.0)
 
     def test_set_equivalence_ratio_sulfur(self):
         sulfur_species = [k for k in ct.Species.list_from_file("nasa_gas.yaml")
@@ -336,17 +335,17 @@ class TestThermoPhase:
         def test_sulfur_results(gas, fuel, ox, basis):
             gas.set_equivalence_ratio(2.0, fuel, ox, basis)
             Z = gas.mixture_fraction(fuel, ox, basis)
-            assertNear(gas.stoich_air_fuel_ratio(fuel, ox, basis)/((1.0-Z)/Z),  2.0)
+            assert gas.stoich_air_fuel_ratio(fuel, ox, basis)/((1.0-Z)/Z) == approx(2.0)
             gas.set_mixture_fraction(Z, fuel, ox, basis)
-            assertNear(gas['SO2'].X[0], 31.0/212.0)
-            assertNear(gas['O2'].X[0],  31.0/106.0)
-            assertNear(gas['SO'].X[0],  11.0/106.0)
-            assertNear(gas['CO2'].X[0], 31.0/424.0)
-            assertNear(gas['CH3'].X[0], 11.0/53.0)
-            assertNear(gas['N2'].X[0],  11.0/212.0)
-            assertNear(gas['CH'].X[0],  31.0/424.0)
-            assertNear(gas['OH'].X[0],  11.0/212.0)
-            assertNear(gas.equivalence_ratio(fuel, ox, basis),  2.0)
+            assert gas['SO2'].X[0] == approx(31.0/212.0)
+            assert gas['O2'].X[0] == approx(31.0/106.0)
+            assert gas['SO'].X[0] == approx(11.0/106.0)
+            assert gas['CO2'].X[0] == approx(31.0/424.0)
+            assert gas['CH3'].X[0] == approx(11.0/53.0)
+            assert gas['N2'].X[0] == approx(11.0/212.0)
+            assert gas['CH'].X[0] == approx(31.0/424.0)
+            assert gas['OH'].X[0] == approx(11.0/212.0)
+            assert gas.equivalence_ratio(fuel, ox, basis) == approx(2.0)
 
         test_sulfur_results(gas, fuel, ox, 'mole')
 
@@ -360,7 +359,7 @@ class TestThermoPhase:
         gas = ct.Solution('gri30.yaml', transport_model=None)
         for phi in np.linspace(0.5, 2.0, 5):
             gas.set_equivalence_ratio(phi, 'CH4:0.8, CH3OH:0.2', 'O2:1.0, N2:3.76')
-            assertNear(phi, gas.equivalence_ratio('CH4:0.8, CH3OH:0.2', 'O2:1.0, N2:3.76'))
+            assert phi == approx(gas.equivalence_ratio('CH4:0.8, CH3OH:0.2', 'O2:1.0, N2:3.76'))
         # Check sulfur species
         sulfur_species = [k for k in ct.Species.list_from_file("nasa_gas.yaml")
                           if k.name in ("SO", "SO2")]
@@ -368,7 +367,7 @@ class TestThermoPhase:
                           species=ct.Species.list_from_file("gri30.yaml") + sulfur_species)
         for phi in np.linspace(0.5, 2.0, 5):
             gas.set_equivalence_ratio(phi, 'CH3:0.5, SO:0.25, OH:0.125, N2:0.125', 'O2:0.5, SO2:0.25, CO2:0.125')
-            assertNear(phi, gas.equivalence_ratio('CH3:0.5, SO:0.25, OH:0.125, N2:0.125', 'O2:0.5, SO2:0.25, CO2:0.125'))
+            assert phi == approx(gas.equivalence_ratio('CH3:0.5, SO:0.25, OH:0.125, N2:0.125', 'O2:0.5, SO2:0.25, CO2:0.125'))
         gas.X = 'CH4:1' # pure fuel
         assert gas.equivalence_ratio() == np.inf
 
@@ -403,15 +402,15 @@ class TestThermoPhase:
             gas.set_mixture_fraction(mf, fuel,ox, basis)
             phi2 = gas.equivalence_ratio(fuel, ox, basis)
 
-            assertNear(phi, 1.3)
-            assertNear(phi2, 1.3)
-            assertNear(phi_loc, 1.1726068608195617)
-            assertNear(mf, 0.13415725911057605)
-            assertNear(mf_C, (gas.elemental_mass_fraction("C")-Y_Co)/(Y_Cf-Y_Co))
-            assertNear(mf_O, (gas.elemental_mass_fraction("O")-Y_Oo)/(Y_Of-Y_Oo))
-            assertNear(l, 8.3901204498353561)
-            assertNear(gas.P, 1e5)
-            assertNear(T, 300.0)
+            assert phi == approx(1.3)
+            assert phi2 == approx(1.3)
+            assert phi_loc == approx(1.1726068608195617)
+            assert mf == approx(0.13415725911057605)
+            assert mf_C == approx((gas.elemental_mass_fraction("C")-Y_Co)/(Y_Cf-Y_Co))
+            assert mf_O == approx((gas.elemental_mass_fraction("O")-Y_Oo)/(Y_Of-Y_Oo))
+            assert l == approx(8.3901204498353561)
+            assert gas.P == approx(1e5)
+            assert T == approx(300.0)
 
         test_equil_results(gas, fuel, ox, Y_Cf, Y_Of, Y_Co, Y_Oo, 'mole')
 
@@ -437,11 +436,11 @@ class TestThermoPhase:
         T, P = 300, 1e5
         gas.TPX = T, P, X
         original_X = gas.X
-        assertNear(gas.equivalence_ratio(include_species=["H2", "O2"]), 2)
-        assertNear(gas.equivalence_ratio("H2", "O2",
-                                              include_species=["H2", "O2"]), 2)
-        assertNear(gas.T, T)
-        assertNear(gas.P, P)
+        assert gas.equivalence_ratio(include_species=["H2", "O2"]) == approx(2)
+        assert gas.equivalence_ratio("H2", "O2",
+                                     include_species=["H2", "O2"]) == approx(2)
+        assert gas.T == approx(T)
+        assert gas.P == approx(P)
         assertArrayNear(gas.X, original_X)
 
         def test_simple_dilution(fraction, basis):
@@ -461,37 +460,34 @@ class TestThermoPhase:
             gas.set_equivalence_ratio(phi, "H2", "O2", fraction=fraction,
                                       diluent="CO2", basis=basis)
             if basis == "mole" and fraction_type == "diluent":
-                assertNear(gas["H2"].X[0], (1 - fraction_value)
-                                * inv_afr / (inv_afr + 1))
-                assertNear(gas["O2"].X[0], (1 - fraction_value) / (inv_afr + 1))
-                assertNear(gas["CO2"].X[0], fraction_value)
+                assert gas["H2"].X[0] == approx((1 - fraction_value)
+                                                * inv_afr / (inv_afr + 1))
+                assert gas["O2"].X[0] == approx((1 - fraction_value) / (inv_afr + 1))
+                assert gas["CO2"].X[0] == approx(fraction_value)
             elif basis == "mass" and fraction_type == "diluent":
-                assertNear(gas["H2"].Y[0] / gas["O2"].Y[0], inv_afr * M_H2 / M_O2)
-                assertNear(gas["CO2"].Y[0], fraction_value)
+                assert gas["H2"].Y[0] / gas["O2"].Y[0] == approx(inv_afr * M_H2 / M_O2)
+                assert gas["CO2"].Y[0] == approx(fraction_value)
             elif basis == "mole" and fraction_type == "fuel":
-                assertNear(gas["H2"].X[0], fraction_value)
-                assertNear(gas["O2"].X[0], fraction_value / inv_afr)
-                assertNear(gas["CO2"].X[0], 1 - fraction_value * (1 + 1 / inv_afr))
+                assert gas["H2"].X[0] == approx(fraction_value)
+                assert gas["O2"].X[0] == approx(fraction_value / inv_afr)
+                assert gas["CO2"].X[0] == approx(1 - fraction_value * (1 + 1 / inv_afr))
             elif basis == "mass" and fraction_type == "fuel":
-                assertNear(gas["H2"].Y[0], fraction_value)
-                assertNear(gas["H2"].Y[0] / gas["O2"].Y[0], inv_afr * M_H2 / M_O2)
+                assert gas["H2"].Y[0] == approx(fraction_value)
+                assert gas["H2"].Y[0] / gas["O2"].Y[0] == approx(inv_afr * M_H2 / M_O2)
             elif basis == "mole" and fraction_type == "oxidizer":
-                assertNear(gas["H2"].X[0], fraction_value * inv_afr)
-                assertNear(gas["O2"].X[0], fraction_value)
-                assertNear(gas["CO2"].X[0], 1 - fraction_value * (1 + inv_afr))
+                assert gas["H2"].X[0] == approx(fraction_value * inv_afr)
+                assert gas["O2"].X[0] == approx(fraction_value)
+                assert gas["CO2"].X[0] == approx(1 - fraction_value * (1 + inv_afr))
             elif basis == "mass" and fraction_type == "oxidizer":
-                assertNear(gas["O2"].Y[0], fraction_value)
-                assertNear(gas["H2"].Y[0] / gas["O2"].Y[0], inv_afr * M_H2 / M_O2)
+                assert gas["O2"].Y[0] == approx(fraction_value)
+                assert gas["H2"].Y[0] / gas["O2"].Y[0] == approx(inv_afr * M_H2 / M_O2)
 
             Y = gas.Y
-            assertNear(gas.equivalence_ratio("H2", "O2",
-                                                  include_species=["H2", "O2"],
-                                                  basis=basis), phi)
-            assertNear(gas.equivalence_ratio(include_species=["H2", "O2"],
-                                                  basis=basis), phi)
+            assert phi == approx(gas.equivalence_ratio("H2", "O2", include_species=["H2", "O2"], basis=basis))
+            assert phi == approx(gas.equivalence_ratio(include_species=["H2", "O2"], basis=basis))
             assertArrayNear(Y, gas.Y)
-            assertNear(gas.T, T)
-            assertNear(gas.P, P)
+            assert gas.T == approx(T)
+            assert gas.P == approx(P)
 
         # brute force all possible input combinations
         test_simple_dilution("diluent:0.3", "mole")
@@ -611,24 +607,24 @@ class TestThermoPhase:
 
     def test_mass_basis(self):
         assert self.phase.basis == 'mass'
-        assertNear(self.phase.density_mass, self.phase.density)
-        assertNear(self.phase.enthalpy_mass, self.phase.h)
-        assertNear(self.phase.entropy_mass, self.phase.s)
-        assertNear(self.phase.int_energy_mass, self.phase.u)
-        assertNear(self.phase.volume_mass, self.phase.v)
-        assertNear(self.phase.cv_mass, self.phase.cv)
-        assertNear(self.phase.cp_mass, self.phase.cp)
+        assert self.phase.density_mass == approx(self.phase.density)
+        assert self.phase.enthalpy_mass == approx(self.phase.h)
+        assert self.phase.entropy_mass == approx(self.phase.s)
+        assert self.phase.int_energy_mass == approx(self.phase.u)
+        assert self.phase.volume_mass == approx(self.phase.v)
+        assert self.phase.cv_mass == approx(self.phase.cv)
+        assert self.phase.cp_mass == approx(self.phase.cp)
 
     def test_molar_basis(self):
         self.phase.basis = 'molar'
         assert self.phase.basis == 'molar'
-        assertNear(self.phase.density_mole, self.phase.density)
-        assertNear(self.phase.enthalpy_mole, self.phase.h)
-        assertNear(self.phase.entropy_mole, self.phase.s)
-        assertNear(self.phase.int_energy_mole, self.phase.u)
-        assertNear(self.phase.volume_mole, self.phase.v)
-        assertNear(self.phase.cv_mole, self.phase.cv)
-        assertNear(self.phase.cp_mole, self.phase.cp)
+        assert self.phase.density_mole == approx(self.phase.density)
+        assert self.phase.enthalpy_mole == approx(self.phase.h)
+        assert self.phase.entropy_mole == approx(self.phase.s)
+        assert self.phase.int_energy_mole == approx(self.phase.u)
+        assert self.phase.volume_mole == approx(self.phase.v)
+        assert self.phase.cv_mole == approx(self.phase.cv)
+        assert self.phase.cp_mole == approx(self.phase.cp)
 
     def check_setters(self, T1, rho1, Y1):
         T0, rho0, Y0 = self.phase.TDY
@@ -641,9 +637,9 @@ class TestThermoPhase:
         v1 = self.phase.v
 
         def check_state(T, rho, Y):
-            assertNear(self.phase.T, T)
-            assertNear(self.phase.Te, T)
-            assertNear(self.phase.density, rho)
+            assert self.phase.T == approx(T)
+            assert self.phase.Te == approx(T)
+            assert self.phase.density == approx(rho)
             assertArrayNear(self.phase.Y, Y)
 
         self.phase.TDY = T0, rho0, Y0
@@ -719,23 +715,23 @@ class TestThermoPhase:
             second_val = getattr(self.phase, second)
 
             setattr(self.phase, pair, (values[first], None))
-            assertNear(getattr(self.phase, first), values[first])
-            assertNear(getattr(self.phase, second), second_val)
+            assert getattr(self.phase, first) == approx(values[first])
+            assert getattr(self.phase, second) == approx(second_val)
 
             self.phase.TDX = 500, 2.5, 'H2:0.1, O2:1.0, AR:3.0'
             setattr(self.phase, pair, (None, values[second]))
-            assertNear(getattr(self.phase, first), first_val)
-            assertNear(getattr(self.phase, second), values[second])
+            assert getattr(self.phase, first) == approx(first_val)
+            assert getattr(self.phase, second) == approx(values[second])
 
             self.phase.TDX = 500, 2.5, 'H2:0.1, O2:1.0, AR:3.0'
             setattr(self.phase, pair + 'X', (None, None, values['X']))
-            assertNear(getattr(self.phase, first), first_val)
-            assertNear(getattr(self.phase, second), second_val)
+            assert getattr(self.phase, first) == approx(first_val)
+            assert getattr(self.phase, second) == approx(second_val)
 
             self.phase.TDX = 500, 2.5, 'H2:0.1, O2:1.0, AR:3.0'
             setattr(self.phase, pair + 'Y', (None, None, values['Y']))
-            assertNear(getattr(self.phase, first), first_val)
-            assertNear(getattr(self.phase, second), second_val)
+            assert getattr(self.phase, first) == approx(first_val)
+            assert getattr(self.phase, second) == approx(second_val)
 
     def test_setter_errors(self):
         with pytest.raises(TypeError):
@@ -759,105 +755,105 @@ class TestThermoPhase:
 
     def check_getters(self):
         T,D,X = self.phase.TDX
-        assertNear(T, self.phase.T)
-        assertNear(D, self.phase.density)
+        assert T == approx(self.phase.T)
+        assert D == approx(self.phase.density)
         assertArrayNear(X, self.phase.X)
 
         T,D,Y = self.phase.TDY
-        assertNear(T, self.phase.T)
-        assertNear(D, self.phase.density)
+        assert T == approx(self.phase.T)
+        assert D == approx(self.phase.density)
         assertArrayNear(Y, self.phase.Y)
 
         T,D = self.phase.TD
-        assertNear(T, self.phase.T)
-        assertNear(D, self.phase.density)
+        assert T == approx(self.phase.T)
+        assert D == approx(self.phase.density)
 
         T,P,X = self.phase.TPX
-        assertNear(T, self.phase.T)
-        assertNear(P, self.phase.P)
+        assert T == approx(self.phase.T)
+        assert P == approx(self.phase.P)
         assertArrayNear(X, self.phase.X)
 
         T,P,Y = self.phase.TPY
-        assertNear(T, self.phase.T)
-        assertNear(P, self.phase.P)
+        assert T == approx(self.phase.T)
+        assert P == approx(self.phase.P)
         assertArrayNear(Y, self.phase.Y)
 
         T,P = self.phase.TP
-        assertNear(T, self.phase.T)
-        assertNear(P, self.phase.P)
+        assert T == approx(self.phase.T)
+        assert P == approx(self.phase.P)
 
         H,P,X = self.phase.HPX
-        assertNear(H, self.phase.h)
-        assertNear(P, self.phase.P)
+        assert H == approx(self.phase.h)
+        assert P == approx(self.phase.P)
         assertArrayNear(X, self.phase.X)
 
         H,P,Y = self.phase.HPY
-        assertNear(H, self.phase.h)
-        assertNear(P, self.phase.P)
+        assert H == approx(self.phase.h)
+        assert P == approx(self.phase.P)
         assertArrayNear(Y, self.phase.Y)
 
         H,P = self.phase.HP
-        assertNear(H, self.phase.h)
-        assertNear(P, self.phase.P)
+        assert H == approx(self.phase.h)
+        assert P == approx(self.phase.P)
 
         U,V,X = self.phase.UVX
-        assertNear(U, self.phase.u)
-        assertNear(V, self.phase.v)
+        assert U == approx(self.phase.u)
+        assert V == approx(self.phase.v)
         assertArrayNear(X, self.phase.X)
 
         U,V,Y = self.phase.UVY
-        assertNear(U, self.phase.u)
-        assertNear(V, self.phase.v)
+        assert U == approx(self.phase.u)
+        assert V == approx(self.phase.v)
         assertArrayNear(Y, self.phase.Y)
 
         U,V = self.phase.UV
-        assertNear(U, self.phase.u)
-        assertNear(V, self.phase.v)
+        assert U == approx(self.phase.u)
+        assert V == approx(self.phase.v)
 
         S,P,X = self.phase.SPX
-        assertNear(S, self.phase.s)
-        assertNear(P, self.phase.P)
+        assert S == approx(self.phase.s)
+        assert P == approx(self.phase.P)
         assertArrayNear(X, self.phase.X)
 
         S,P,Y = self.phase.SPY
-        assertNear(S, self.phase.s)
-        assertNear(P, self.phase.P)
+        assert S == approx(self.phase.s)
+        assert P == approx(self.phase.P)
         assertArrayNear(Y, self.phase.Y)
 
         S,P = self.phase.SP
-        assertNear(S, self.phase.s)
-        assertNear(P, self.phase.P)
+        assert S == approx(self.phase.s)
+        assert P == approx(self.phase.P)
 
         S,V,X = self.phase.SVX
-        assertNear(S, self.phase.s)
-        assertNear(V, self.phase.v)
+        assert S == approx(self.phase.s)
+        assert V == approx(self.phase.v)
         assertArrayNear(X, self.phase.X)
 
         S,V,Y = self.phase.SVY
-        assertNear(S, self.phase.s)
-        assertNear(V, self.phase.v)
+        assert S == approx(self.phase.s)
+        assert V == approx(self.phase.v)
         assertArrayNear(Y, self.phase.Y)
 
         S,V = self.phase.SV
-        assertNear(S, self.phase.s)
-        assertNear(V, self.phase.v)
+        assert S == approx(self.phase.s)
+        assert V == approx(self.phase.v)
 
         D,P,X = self.phase.DPX
-        assertNear(D, self.phase.density)
-        assertNear(P, self.phase.P)
+        assert D == approx(self.phase.density)
+        assert P == approx(self.phase.P)
         assertArrayNear(X, self.phase.X)
 
         D,P,Y = self.phase.DPY
-        assertNear(D, self.phase.density)
-        assertNear(P, self.phase.P)
+        assert D == approx(self.phase.density)
+        assert P == approx(self.phase.P)
         assertArrayNear(Y, self.phase.Y)
 
         D,P = self.phase.DP
-        assertNear(D, self.phase.density)
-        assertNear(P, self.phase.P)
+        assert D == approx(self.phase.density)
+        assert P == approx(self.phase.P)
 
         Te = self.phase.Te
-        assertNear(Te, self.phase.Te)
+        assert Te == approx(self.phase.Te)
 
     def test_getState_mass(self):
         self.phase.TDY = 350.0, 0.7, 'H2:0.1, H2O2:0.1, AR:0.8'
@@ -869,38 +865,38 @@ class TestThermoPhase:
         self.check_getters()
 
     def test_getState(self):
-        assertNear(self.phase.P, ct.one_atm)
-        assertNear(self.phase.T, 300)
+        assert self.phase.P == approx(ct.one_atm)
+        assert self.phase.T == approx(300)
 
     def test_partial_molar(self):
         self.phase.TDY = 350.0, 0.6, 'H2:0.1, H2O2:0.1, AR:0.8'
-        assertNear(sum(self.phase.partial_molar_enthalpies * self.phase.X),
-                   self.phase.enthalpy_mole)
+        assert sum(self.phase.partial_molar_enthalpies * self.phase.X) == approx(
+               self.phase.enthalpy_mole)
 
-        assertNear(sum(self.phase.partial_molar_entropies * self.phase.X),
-                   self.phase.entropy_mole)
+        assert sum(self.phase.partial_molar_entropies * self.phase.X) == approx(
+               self.phase.entropy_mole)
 
-        assertNear(sum(self.phase.partial_molar_int_energies * self.phase.X),
-                   self.phase.int_energy_mole)
+        assert sum(self.phase.partial_molar_int_energies * self.phase.X) == approx(
+               self.phase.int_energy_mole)
 
-        assertNear(sum(self.phase.chemical_potentials * self.phase.X),
-                   self.phase.gibbs_mole)
+        assert sum(self.phase.chemical_potentials * self.phase.X) == approx(
+               self.phase.gibbs_mole)
 
-        assertNear(sum(self.phase.partial_molar_cp * self.phase.X),
-                   self.phase.cp_mole)
+        assert sum(self.phase.partial_molar_cp * self.phase.X) == approx(
+               self.phase.cp_mole)
 
     def test_nondimensional(self):
         self.phase.TDY = 850.0, 0.2, 'H2:0.1, H2O:0.6, AR:0.3'
         H = (sum(self.phase.standard_enthalpies_RT * self.phase.X) *
              ct.gas_constant * self.phase.T)
-        assertNear(H, self.phase.enthalpy_mole)
+        assert H == approx(self.phase.enthalpy_mole)
 
         U = (sum(self.phase.standard_int_energies_RT * self.phase.X) *
              ct.gas_constant * self.phase.T)
-        assertNear(U, self.phase.int_energy_mole)
+        assert U == approx(self.phase.int_energy_mole)
 
         cp = sum(self.phase.standard_cp_R * self.phase.X) * ct.gas_constant
-        assertNear(cp, self.phase.cp_mole)
+        assert cp == approx(self.phase.cp_mole)
 
     def test_activities(self):
         self.phase.TDY = 850.0, 0.2, 'H2:0.1, H2O:0.6, AR:0.3'
@@ -910,15 +906,15 @@ class TestThermoPhase:
                         np.ones(self.phase.n_species))
 
     def test_isothermal_compressibility(self):
-        assertNear(self.phase.isothermal_compressibility, 1.0/self.phase.P)
+        assert self.phase.isothermal_compressibility == approx(1.0/self.phase.P)
 
     def test_thermal_expansion_coeff(self):
-        assertNear(self.phase.thermal_expansion_coeff, 1.0/self.phase.T)
+        assert self.phase.thermal_expansion_coeff == approx(1.0/self.phase.T)
 
     def test_ref_info(self):
-        assertNear(self.phase.reference_pressure, ct.one_atm)
-        assertNear(self.phase.min_temp, 300.0)
-        assertNear(self.phase.max_temp, 3500.0)
+        assert self.phase.reference_pressure == approx(ct.one_atm)
+        assert self.phase.min_temp == approx(300.0)
+        assert self.phase.max_temp == approx(3500.0)
 
     def test_uncopyable(self):
         import copy
@@ -938,8 +934,8 @@ class TestThermoPhase:
         state = 400, 2e5, 'H2:0.7, CO2:0.2, CO:0.1'
         ref.TPY = state
         self.phase.TPY = state
-        assertNear(self.phase.enthalpy_mass, ref.enthalpy_mass)
-        assertNear(self.phase.entropy_mole, ref.entropy_mole)
+        assert self.phase.enthalpy_mass == approx(ref.enthalpy_mass)
+        assert self.phase.entropy_mole == approx(ref.entropy_mole)
         assertArrayNear(ref[self.phase.species_names].partial_molar_cp,
                         self.phase.partial_molar_cp)
 
@@ -1016,8 +1012,8 @@ class TestThermo:
         s1, v1 = self.gas.SV
         self.gas.SV = s1, 3 * v1
 
-        assertNear(self.gas.s, s1)
-        assertNear(self.gas.v, 3 * v1)
+        assert self.gas.s == approx(s1)
+        assert self.gas.v == approx(3 * v1)
         assert self.gas.T < self.gas.min_temp
 
     def test_setSV_low_invalid(self):
@@ -1036,8 +1032,8 @@ class TestThermo:
         s1, v1 = self.gas.SV
         self.gas.SV = s1, 0.3 * v1
 
-        assertNear(self.gas.s, s1)
-        assertNear(self.gas.v, 0.3 * v1)
+        assert self.gas.s == approx(s1)
+        assert self.gas.v == approx(0.3 * v1)
         assert self.gas.T > self.gas.max_temp
 
     def test_setHP_lowT(self):
@@ -1051,8 +1047,8 @@ class TestThermo:
         h1, p1 = self.gas.HP
         self.gas.HP = h1 - deltaH, None
 
-        assertNear(self.gas.h, h1 - deltaH)
-        assertNear(self.gas.P, p1)
+        assert self.gas.h == approx(h1 - deltaH)
+        assert self.gas.P == approx(p1)
         assert self.gas.T < self.gas.min_temp
 
     def test_setHP_low_invalid(self):
@@ -1076,8 +1072,8 @@ class TestThermo:
         h1, p1 = self.gas.HP
         self.gas.HP = h1 + deltaH, None
 
-        assertNear(self.gas.h, h1 + deltaH)
-        assertNear(self.gas.P, p1)
+        assert self.gas.h == approx(h1 + deltaH)
+        assert self.gas.P == approx(p1)
         assert self.gas.T > self.gas.max_temp
 
     def test_volume(self):
@@ -1085,38 +1081,38 @@ class TestThermo:
         This phase should follow the ideal gas law
         """
         g = self.gas
-        assertNear(g.P, g.density_mole * ct.gas_constant * g.T)
+        assert g.P == approx(g.density_mole * ct.gas_constant * g.T)
 
-        assertNear(g.P / g.density,
-                   ct.gas_constant / g.mean_molecular_weight * g.T)
+        assert g.P / g.density == approx(
+               ct.gas_constant / g.mean_molecular_weight * g.T)
 
-        assertNear(g.density, 1.0 / g.volume_mass)
+        assert g.density == approx(1.0 / g.volume_mass)
 
     def test_energy(self):
         g = self.gas
         mmw = g.mean_molecular_weight
-        assertNear(g.enthalpy_mass, g.enthalpy_mole / mmw)
-        assertNear(g.int_energy_mass, g.int_energy_mole / mmw)
-        assertNear(g.gibbs_mass, g.gibbs_mole / mmw)
-        assertNear(g.entropy_mass, g.entropy_mole / mmw)
+        assert g.enthalpy_mass == approx(g.enthalpy_mole / mmw)
+        assert g.int_energy_mass == approx(g.int_energy_mole / mmw)
+        assert g.gibbs_mass == approx(g.gibbs_mole / mmw)
+        assert g.entropy_mass == approx(g.entropy_mole / mmw)
 
-        assertNear(g.cv_mass, g.cv_mole / mmw)
-        assertNear(g.cp_mass, g.cp_mole / mmw)
-        assertNear(g.cv_mole + ct.gas_constant, g.cp_mole)
+        assert g.cv_mass == approx(g.cv_mole / mmw)
+        assert g.cp_mass == approx(g.cp_mole / mmw)
+        assert g.cv_mole + ct.gas_constant == approx(g.cp_mole)
 
     def test_nondimensional(self):
         g = self.gas
         R = ct.gas_constant
 
-        assertNear(np.dot(g.standard_cp_R, g.X), g.cp_mole / R)
-        assertNear(np.dot(g.standard_enthalpies_RT, g.X),
-                   g.enthalpy_mole / (R*g.T))
+        assert np.dot(g.standard_cp_R, g.X) == approx(g.cp_mole / R)
+        assert np.dot(g.standard_enthalpies_RT, g.X) == approx(
+               g.enthalpy_mole / (R*g.T))
 
         Smix_R = - np.dot(g.X, np.log(g.X+1e-20))
-        assertNear(np.dot(g.standard_entropies_R, g.X) + Smix_R,
-                   g.entropy_mole / R)
-        assertNear(np.dot(g.standard_gibbs_RT, g.X) - Smix_R,
-                   g.gibbs_mole / (R*g.T))
+        assert np.dot(g.standard_entropies_R, g.X) + Smix_R == approx(
+               g.entropy_mole / R)
+        assert np.dot(g.standard_gibbs_RT, g.X) - Smix_R == approx(
+               g.gibbs_mole / (R*g.T))
 
 
 @pytest.fixture(scope='function')
@@ -1127,7 +1123,7 @@ class TestInterfacePhase:
 
     def test_properties(self):
         self.interface.site_density = 100
-        assertNear(self.interface.site_density, 100)
+        assert self.interface.site_density == approx(100)
 
     def test_coverages_array(self):
         C = np.zeros(self.interface.n_species)
@@ -1137,26 +1133,26 @@ class TestInterfacePhase:
         self.interface.coverages = C
         C = self.interface.coverages
         # should now be normalized
-        assertNear(C[1], 0.5)
-        assertNear(C[3], 0.25)
-        assertNear(C[4], 0.25)
-        assertNear(sum(C), 1.0)
+        assert C[1] == approx(0.5)
+        assert C[3] == approx(0.25)
+        assert C[4] == approx(0.25)
+        assert sum(C) == approx(1.0)
 
     def test_mole_fractions(self):
         self.interface.X = 'c6HM:0.3, c6H*:0.7'
-        assertNear(sum(self.interface.concentrations), self.interface.site_density)
+        assert sum(self.interface.concentrations) == approx(self.interface.site_density)
 
     def test_coverages_string(self):
         self.interface.coverages = 'c6HM:0.2, c6H*:0.8'
         C = self.interface.coverages
-        assertNear(C[self.interface.species_index('c6HM')], 0.2)
-        assertNear(C[self.interface.species_index('c6H*')], 0.8)
+        assert C[self.interface.species_index('c6HM')] == approx(0.2)
+        assert C[self.interface.species_index('c6H*')] == approx(0.8)
 
     def test_coverages_dict(self):
         self.interface.coverages = {'c6**':1.0, 'c6*M':3.0}
         C = self.interface.coverages
-        assertNear(C[self.interface.species_index('c6**')], 0.25)
-        assertNear(C[self.interface.species_index('c6*M')], 0.75)
+        assert C[self.interface.species_index('c6**')] == approx(0.25)
+        assert C[self.interface.species_index('c6*M')] == approx(0.75)
 
 
 class TestInterfacePhase2:
@@ -1199,12 +1195,12 @@ class TestPlasmaPhase:
     def test_converting_electron_energy_to_temperature(self, phase):
         phase.mean_electron_energy = 1.0
         Te = 2.0 / 3.0 * ct.electron_charge / ct.boltzmann
-        assertNear(phase.Te, Te)
+        assert phase.Te == approx(Te)
 
     def test_converting_electron_temperature_to_energy(self, phase):
         phase.Te = 10000
         energy = phase.Te * 3.0 / 2.0 / ct.electron_charge * ct.boltzmann
-        assertNear(phase.mean_electron_energy, energy)
+        assert phase.mean_electron_energy == approx(energy)
 
     def test_set_get_electron_energy_levels(self, phase):
         levels = np.linspace(0.01, 10, num=9)
@@ -1217,7 +1213,7 @@ class TestPlasmaPhase:
         phase.Te = 2e5
         mean_electron_energy = 3.0 / 2.0 * (phase.Te * ct.gas_constant /
                                (ct.avogadro * ct.electron_charge))
-        assertNear(mean_electron_energy, phase.mean_electron_energy)
+        assert mean_electron_energy == approx(phase.mean_electron_energy)
 
     # @todo: replace np.trapz with np.trapezoid when dropping support for NumPy 1.x
     @pytest.mark.filterwarnings("ignore:`trapz` is deprecated")
@@ -1230,15 +1226,14 @@ class TestPlasmaPhase:
         assertArrayNear(levels, phase.electron_energy_levels)
         assertArrayNear(dist, phase.electron_energy_distribution)
         mean_energy = 2.0 / 5.0 * np.trapz(dist, np.power(levels, 5./2.))
-        assertNear(phase.mean_electron_energy, mean_energy, 1e-4)
+        assert phase.mean_electron_energy == approx(mean_energy, rel=1e-4)
         electron_temp = 2.0 / 3.0 * (phase.mean_electron_energy *
                         ct.avogadro * ct.electron_charge / ct.gas_constant)
-        assertNear(phase.Te, electron_temp)
+        assert phase.Te == approx(electron_temp)
 
     def test_electron_thermodynamic_properties(self, phase):
-        assertNear(phase.standard_gibbs_RT[0],
-                   phase.standard_enthalpies_RT[0] -
-                   phase.standard_entropies_R[0])
+        assert phase.standard_gibbs_RT[0] == approx(
+               phase.standard_enthalpies_RT[0] - phase.standard_entropies_R[0])
 
     def test_add_multiple_electron_species(self, phase):
         electron = ct.Species('Electron', 'E:1')
@@ -1254,8 +1249,8 @@ class TestImport:
     """
     def check(self, gas, phase, T, P, nSpec, nElem):
         assert gas.name == phase
-        assertNear(gas.T, T)
-        assertNear(gas.P, P)
+        assert gas.T == approx(T)
+        assert gas.P == approx(P)
         assert gas.n_species == nSpec
         assert gas.n_elements == nElem
 
@@ -1270,7 +1265,7 @@ class TestImport:
         gas2.equilibrate('HP')
         assert gas1.n_elements == gas2.n_elements
         assert gas1.species_names == gas2.species_names
-        assertNear(gas1.T, gas2.T)
+        assert gas1.T == approx(gas2.T)
         assertArrayNear(gas1.X, gas2.X)
 
     def test_yaml_ideal_gas_simple(self):
@@ -1301,7 +1296,7 @@ class TestSpecies:
         assert len(c) == 2
         assert c['C'] == 1
         assert c['H'] == 4
-        assertNear(s.molecular_weight, 16.043)
+        assert s.molecular_weight == approx(16.043)
 
     def test_molecular_weight_with_unstable_element(self):
         s = ct.Species("CPo", {"C": 1, "Po": 1})
@@ -1320,11 +1315,9 @@ class TestSpecies:
         gas = ct.Solution("ideal-gas.yaml", "element-override")
         # Check that the molecular weight stored in the phase definition is the same
         # as the one on the Species instance
-        assertNear(
-            gas["AR"].molecular_weights[0], gas.species("AR").molecular_weight
-        )
+        assert gas["AR"].molecular_weights[0] == approx(gas.species("AR").molecular_weight)
         # Check that the custom value is actually used
-        assertNear(gas.species("AR").molecular_weight, 36.0)
+        assert gas.species("AR").molecular_weight == approx(36.0)
 
     def test_species_can_be_added_to_phase(self):
         s = ct.Species.from_dict({
@@ -1333,14 +1326,12 @@ class TestSpecies:
             "thermo": {"model": "constant-cp", "h0": 100}
         })
         # Access the molecular weight to make sure it's been computed by the Species
-        assertNear(s.molecular_weight, 39.95 * 2)
+        assert s.molecular_weight == approx(39.95 * 2)
         # This should not cause a warning because the Ar element definition in
         # self.gas is the same as the default
         self.gas.add_species(s)
-        assertNear(
-            self.gas["AR2"].molecular_weights[0],
-            self.gas.species("AR2").molecular_weight
-        )
+        assert self.gas["AR2"].molecular_weights[0] == approx(
+               self.gas.species("AR2").molecular_weight)
 
     def test_species_warns_when_changing_molecular_weight(self):
         s = ct.Species.from_dict({
@@ -1349,7 +1340,7 @@ class TestSpecies:
             "thermo": {"model": "constant-cp", "h0": 100}
         })
         # Access the molecular weight to make sure it's been computed by the Species
-        assertNear(s.molecular_weight, 39.95 * 2)
+        assert s.molecular_weight == approx(39.95 * 2)
         gas = ct.Solution("ideal-gas.yaml", "element-override")
         # The warning here is because the weight of the Argon element has been changed in
         # the phase definition, but the molecular weight of the species has already been
@@ -1368,11 +1359,9 @@ class TestSpecies:
         # to the phase to make sure the weight has not been computed by the Species
         gas = ct.Solution("ideal-gas.yaml", "element-override")
         gas.add_species(s)
-        assertNear(
-            gas["AR2"].molecular_weights[0],
-            gas.species("AR2").molecular_weight
-        )
-        assertNear(s.molecular_weight, gas.species("AR2").molecular_weight)
+        assert  gas["AR2"].molecular_weights[0] == approx(
+                gas.species("AR2").molecular_weight)
+        assert s.molecular_weight == approx(gas.species("AR2").molecular_weight)
 
     def test_defaults(self):
         s = ct.Species('H2')
@@ -1415,7 +1404,7 @@ class TestSpecies:
         species = ct.Species.list_from_yaml(yaml)
         assert species[0].name == 'H2O'
         assert species[1].composition == {'H': 1, 'O': 2}
-        assertNear(species[0].thermo.h(300), 100)
+        assert species[0].thermo.h(300) == approx(100)
 
     def test_list_from_yaml_section(self):
         species = ct.Species.list_from_yaml(
@@ -1434,7 +1423,7 @@ class TestSpecies:
         species = ct.Species.from_yaml(yaml)
         assert species.name == 'H2O'
         assert species.composition == {'H': 2, 'O': 1}
-        assertNear(species.thermo.h(300), 100)
+        assert species.thermo.h(300) == approx(100)
 
     def test_from_dict(self):
         data = {
@@ -1445,7 +1434,7 @@ class TestSpecies:
         species = ct.Species.from_dict(data)
         assert species.name == 'H2O'
         assert species.composition == {'H': 2, 'O': 1}
-        assertNear(species.thermo.h(300), 100)
+        assert species.thermo.h(300) == approx(100)
 
     def test_modify_thermo(self):
         S = {sp.name: sp for sp in ct.Species.list_from_file("h2o2.yaml")}
@@ -1457,7 +1446,7 @@ class TestSpecies:
         # Replace O2 thermo with the data from H2
         S['O2'].thermo = S['H2'].thermo
         self.gas.modify_species(self.gas.species_index('O2'), S['O2'])
-        assertNear(g0, self.gas.gibbs_mole)
+        assert g0 == approx(self.gas.gibbs_mole)
 
     def test_modify_thermo_invalid(self):
         S = {sp.name: sp for sp in ct.Species.list_from_file("h2o2.yaml")}
@@ -1490,7 +1479,7 @@ class TestSpecies:
         self.gas.add_species_alias('H2', 'hydrogen')
         assert self.gas.species_index('hydrogen') == 0
         self.gas.X = 'hydrogen:.5, O2:.5'
-        assertNear(self.gas.X[0], 0.5)
+        assert self.gas.X[0] == approx(0.5)
         with pytest.raises(ct.CanteraError, match='Invalid alias'):
             self.gas.add_species_alias('H2', 'O2')
         with pytest.raises(ct.CanteraError, match='Unable to add alias'):
@@ -1526,9 +1515,9 @@ class TestSpeciesThermo:
 
         for T in [300, 500, 900, 1200, 2000]:
             self.gas.TP = T, 101325
-            assertNear(st.cp(T), self.gas.cp_mole)
-            assertNear(st.h(T), self.gas.enthalpy_mole)
-            assertNear(st.s(T), self.gas.entropy_mole)
+            assert st.cp(T) == approx(self.gas.cp_mole)
+            assert st.h(T) == approx(self.gas.enthalpy_mole)
+            assert st.s(T) == approx(self.gas.entropy_mole)
 
     def test_invalid(self):
         with pytest.raises(ValueError, match='incorrect length'):
@@ -1543,9 +1532,9 @@ class TestSpeciesThermo:
 
         for T in [300, 500, 900, 1200, 2000]:
             self.gas.TP = T, 101325
-            assertNear(st.cp(T), self.gas.cp_mole)
-            assertNear(st.h(T), self.gas.enthalpy_mole)
-            assertNear(st.s(T), self.gas.entropy_mole)
+            assert st.cp(T) == approx(self.gas.cp_mole)
+            assert st.h(T) == approx(self.gas.enthalpy_mole)
+            assert st.s(T) == approx(self.gas.entropy_mole)
 
     def test_coeffs(self):
         st = ct.NasaPoly2(300, 3500, 101325, self.h2o_coeffs)
@@ -1576,9 +1565,9 @@ class TestSpeciesThermo:
         assert st.max_temp == t_max
         assert st.reference_pressure == p_ref
         for T in range(300, 20000, 1000):
-            assertNear(st.cp(T), st2.cp(T))
-            assertNear(st.h(T), st2.h(T))
-            assertNear(st.s(T), st2.s(T))
+            assert st.cp(T) == approx(st2.cp(T))
+            assert st.h(T) == approx(st2.h(T))
+            assert st.s(T) == approx(st2.s(T))
 
     def test_shomate_load(self):
         sol = ct.Solution('thermo-models.yaml', 'molten-salt-Margules')
@@ -1600,9 +1589,9 @@ class TestSpeciesThermo:
         assert st.max_temp == t_max
         assert st.reference_pressure == p_ref
         for T in [300, 500, 700, 900]:
-            assertNear(st.cp(T), st2.cp(T))
-            assertNear(st.h(T), st2.h(T))
-            assertNear(st.s(T), st2.s(T))
+            assert st.cp(T) == approx(st2.cp(T))
+            assert st.h(T) == approx(st2.h(T))
+            assert st.s(T) == approx(st2.s(T))
 
     def test_piecewise_gibbs_load(self):
         sol = ct.Solution('thermo-models.yaml', 'HMW-NaCl-electrolyte')
@@ -1638,9 +1627,9 @@ class TestSpeciesThermo:
         assert st.max_temp == t_max
         assert st.reference_pressure == p_ref
         for T in [300, 500, 700, 900]:
-            assertNear(st.cp(T), st2.cp(T))
-            assertNear(st.h(T), st2.h(T))
-            assertNear(st.s(T), st2.s(T))
+            assert st.cp(T) == approx(st2.cp(T))
+            assert st.h(T) == approx(st2.h(T))
+            assert st.s(T) == approx(st2.s(T))
 
 
 @pytest.fixture(scope='class')
@@ -1657,30 +1646,30 @@ class TestQuantity:
 
     def test_mass_moles(self):
         q1 = ct.Quantity(self.gas, mass=5)
-        assertNear(q1.mass, 5)
-        assertNear(q1.moles, 5 / q1.mean_molecular_weight)
+        assert q1.mass == approx(5)
+        assert q1.moles == approx(5 / q1.mean_molecular_weight)
 
         q1.mass = 7
-        assertNear(q1.moles, 7 / q1.mean_molecular_weight)
+        assert q1.moles == approx(7 / q1.mean_molecular_weight)
 
         q1.moles = 9
-        assertNear(q1.moles, 9)
-        assertNear(q1.mass, 9 * q1.mean_molecular_weight)
+        assert q1.moles == approx(9)
+        assert q1.mass == approx(9 * q1.mean_molecular_weight)
 
     def test_extensive(self):
         q1 = ct.Quantity(self.gas, mass=5)
-        assertNear(q1.mass, 5)
+        assert q1.mass == approx(5)
 
-        assertNear(q1.volume * q1.density, q1.mass)
-        assertNear(q1.V * q1.density, q1.mass)
-        assertNear(q1.int_energy, q1.moles * q1.int_energy_mole)
-        assertNear(q1.enthalpy, q1.moles * q1.enthalpy_mole)
-        assertNear(q1.entropy, q1.moles * q1.entropy_mole)
-        assertNear(q1.gibbs, q1.moles * q1.gibbs_mole)
-        assertNear(q1.int_energy, q1.U)
-        assertNear(q1.enthalpy, q1.H)
-        assertNear(q1.entropy, q1.S)
-        assertNear(q1.gibbs, q1.G)
+        assert q1.volume * q1.density == approx(q1.mass)
+        assert q1.V * q1.density == approx(q1.mass)
+        assert q1.int_energy == approx(q1.moles * q1.int_energy_mole)
+        assert q1.enthalpy == approx(q1.moles * q1.enthalpy_mole)
+        assert q1.entropy == approx(q1.moles * q1.entropy_mole)
+        assert q1.gibbs == approx(q1.moles * q1.gibbs_mole)
+        assert q1.int_energy == approx(q1.U)
+        assert q1.enthalpy == approx(q1.H)
+        assert q1.entropy == approx(q1.S)
+        assert q1.gibbs == approx(q1.G)
 
     def test_set_equivalence_ratio(self):
         q1 = ct.Quantity(self.gas, mass=3)
@@ -1712,9 +1701,9 @@ class TestQuantity:
     def test_multiply(self):
         q1 = ct.Quantity(self.gas, mass=5)
         q2 = q1 * 2.5
-        assertNear(q1.mass * 2.5, q2.mass)
-        assertNear(q1.moles * 2.5, q2.moles)
-        assertNear(q1.entropy * 2.5, q2.entropy)
+        assert q1.mass * 2.5 == approx(q2.mass)
+        assert q1.moles * 2.5 == approx(q2.moles)
+        assert q1.entropy * 2.5 == approx(q2.entropy)
         assertArrayNear(q1.X, q2.X)
 
     def test_multiply_HP(self):
@@ -1723,9 +1712,9 @@ class TestQuantity:
         q2 = ct.Quantity(self.gas, mass=1, constant='HP')
         q2.equilibrate('HP')
         q3 = 0.2 * q1 + q2 * 0.4
-        assertNear(q1.P, q3.P)
-        assertNear(q1.enthalpy_mass, q3.enthalpy_mass)
-        assertNear(q2.enthalpy_mass, q3.enthalpy_mass)
+        assert q1.P == approx(q3.P)
+        assert q1.enthalpy_mass == approx(q3.enthalpy_mass)
+        assert q2.enthalpy_mass == approx(q3.enthalpy_mass)
 
     def test_iadd(self):
         q0 = ct.Quantity(self.gas, mass=5)
@@ -1734,10 +1723,10 @@ class TestQuantity:
         q2.TPX = 500, 101325, 'CH4:1.0'
 
         q1 += q2
-        assertNear(q0.mass + q2.mass, q1.mass)
+        assert q0.mass + q2.mass == approx(q1.mass)
         # addition is at constant UV
-        assertNear(q0.U + q2.U, q1.U)
-        assertNear(q0.V + q2.V, q1.V)
+        assert q0.U + q2.U == approx(q1.U)
+        assert q0.V + q2.V == approx(q1.V)
         assertArrayNear(q0.X*q0.moles + q2.X*q2.moles, q1.X*q1.moles)
 
     def test_add(self):
@@ -1746,10 +1735,10 @@ class TestQuantity:
         q2.TPX = 500, 101325, 'CH4:1.0'
 
         q3 = q1 + q2
-        assertNear(q1.mass + q2.mass, q3.mass)
+        assert q1.mass + q2.mass == approx(q3.mass)
         # addition is at constant UV
-        assertNear(q1.U + q2.U, q3.U)
-        assertNear(q1.V + q2.V, q3.V)
+        assert q1.U + q2.U == approx(q3.U)
+        assert q1.V + q2.V == approx(q3.V)
         assertArrayNear(q1.X*q1.moles + q2.X*q2.moles, q3.X*q3.moles)
 
     def test_add_molar(self):
@@ -1790,9 +1779,9 @@ class TestQuantity:
         self.gas.equilibrate('HP')
         T2 = self.gas.T
 
-        assertNear(q1.T, 300)
+        assert q1.T == approx(300)
         q1.equilibrate('HP')
-        assertNear(q1.T, T2)
+        assert q1.T == approx(T2)
 
     def test_invalid_setter(self):
         q1 = ct.Quantity(self.gas, mass =3)
@@ -1840,9 +1829,9 @@ class TestMisc:
         assert not gas.case_sensitive_species_names
         assert gas.species_index('h2') == 0
         gas.X = 'h2:.5, o2:.5'
-        assertNear(gas.X[0], 0.5)
+        assert gas.X[0] == approx(0.5)
         gas.Y = 'h2:.5, o2:.5'
-        assertNear(gas.Y[0], 0.5)
+        assert gas.Y[0] == approx(0.5)
 
         gas.case_sensitive_species_names = True
         assert gas.case_sensitive_species_names
@@ -1899,9 +1888,9 @@ class TestElement:
         assert carbon.symbol == 'C'
 
     def test_element_weight(self):
-        assertNear(self.ar_sym.weight, 39.95)
-        assertNear(self.ar_name.weight, 39.95)
-        assertNear(self.ar_num.weight, 39.95)
+        assert self.ar_sym.weight == approx(39.95)
+        assert self.ar_name.weight == approx(39.95)
+        assert self.ar_num.weight == approx(39.95)
 
     def test_element_symbol(self):
         assert self.ar_sym.symbol == 'Ar'
@@ -1942,13 +1931,13 @@ class TestElement:
     def test_get_isotope(self):
         d_sym = ct.Element('D')
         assert d_sym.atomic_number == 1
-        assertNear(d_sym.weight, 2.0141017781)
+        assert d_sym.weight == approx(2.0141017781)
         assert d_sym.name == 'deuterium'
         assert d_sym.symbol == 'D'
 
         d_name = ct.Element('deuterium')
         assert d_name.atomic_number == 1
-        assertNear(d_name.weight, 2.0141017781)
+        assert d_name.weight == approx(2.0141017781)
         assert d_name.name == 'deuterium'
         assert d_name.symbol == 'D'
 
@@ -2019,7 +2008,7 @@ class TestSolutionArray:
         Dkm = states.mix_diff_coeffs
         for i in range(N):
             self.gas.TPX = T[i], P[i], X
-            assertNear(self.gas.enthalpy_mass, h[i])
+            assert self.gas.enthalpy_mass == approx(h[i])
             assertArrayNear(self.gas.reverse_rates_of_progress, ropr[i])
             assertArrayNear(self.gas.mix_diff_coeffs, Dkm[i])
 
@@ -2043,7 +2032,7 @@ class TestSolutionArray:
 
         for i,j,k in np.ndindex(TT.shape):
             self.gas.TPX = T[k], P[i][0][0], X[j]
-            assertNear(self.gas.enthalpy_mass, h[i,j,k])
+            assert self.gas.enthalpy_mass == approx(h[i,j,k])
             assertArrayNear(self.gas.reverse_rates_of_progress, ropr[i,j,k])
             assertArrayNear(self.gas.mix_diff_coeffs, Dkm[i,j,k])
 
@@ -2084,15 +2073,15 @@ class TestSolutionArray:
         # Verify that original object is updated when slices change
         state = states[1]
         state.TD = 300, 0.5
-        assertNear(states.T[0], 500)
-        assertNear(states.T[1], 300)
-        assertNear(states.P[2], 2e5)
-        assertNear(states.density[1], 0.5)
+        assert states.T[0] == approx(500)
+        assert states.T[1] == approx(300)
+        assert states.P[2] == approx(2e5)
+        assert states.density[1] == approx(0.5)
 
         # Verify that the slices are updated when the original object changes
         states.TD = 900, None
-        assertNear(state.T, 900)
-        assertNear(states.density[1], 0.5)
+        assert state.T == approx(900)
+        assert states.density[1] == approx(0.5)
 
     def test_slicing_ndim(self):
         states = ct.SolutionArray(self.gas, (2,5))
@@ -2241,22 +2230,22 @@ class TestSolutionArray:
 
         states.append(T=1100, P=3e5, X='AR:1.0')
         assert states.cp_mass.shape == (6,)
-        assertNear(states.P[-1], 3e5)
-        assertNear(states.T[-1], 1100)
+        assert states.P[-1] == approx(3e5)
+        assert states.T[-1] == approx(1100)
 
         self.gas.TPX = 1200, 5e5, 'O2:0.3, AR:0.7'
         states.append(self.gas.state)
         assert states.cp_mass.shape == (7,)
-        assertNear(states.P[-1], 5e5)
-        assertNear(states.X[-1, self.gas.species_index('AR')], 0.7)
+        assert states.P[-1] == approx(5e5)
+        assert states.X[-1, self.gas.species_index('AR')] == approx(0.7)
 
         self.gas.TPX = 300, 1e4, 'O2:0.5, AR:0.5'
         HPY = self.gas.HPY
         self.gas.TPX = 1200, 5e5, 'O2:0.3, AR:0.7'  # to make sure it gets changed
         states.append(HPY=HPY)
         assert states.cp_mass.shape == (8,)
-        assertNear(states.P[-1], 1e4)
-        assertNear(states.T[-1], 300)
+        assert states.P[-1] == approx(1e4)
+        assert states.T[-1] == approx(300)
 
     def test_append_with_extra(self):
         states = ct.SolutionArray(self.gas, 5, extra={"prop": "value"})
@@ -2323,7 +2312,7 @@ class TestSolutionArray:
 
         P = states.P
         for i in range(1, 5):
-            assertNear(P[0], P[i])
+            assert P[0] == approx(P[i])
 
         states.TP = np.linspace(400, 500, 5), 101325
         assertArrayNear(states.Q.squeeze(), np.ones(5))
@@ -2363,13 +2352,13 @@ class TestSolutionArray:
           pure-fluid-name: water
         """
         w = ct.PureFluid(yaml=yaml.format(T=373.177233, Q=0.5))
-        assertNear(w.Q, 0.5)
+        assert w.Q == approx(0.5)
 
         with pytest.raises(ct.CanteraError, match="setState"):
             ct.PureFluid(yaml=yaml.format(T=373, Q=0.5))
 
         w = ct.PureFluid(yaml=yaml.format(T=370, Q=0.0))
-        assertNear(w.P, 101325)
+        assert w.P == approx(101325)
 
         with pytest.raises(ct.CanteraError, match="setState"):
             ct.PureFluid(yaml=yaml.format(T=370, Q=1.0))

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -5,12 +5,10 @@ import pytest
 from pytest import approx
 
 import cantera as ct
-from . import utilities
 from .utilities import (
     assertNear,
     assertArrayNear
 )
-from .utilities import allow_deprecated
 
 @pytest.fixture(scope='function')
 def setup_thermo_phase_tests(request):
@@ -307,7 +305,7 @@ class TestThermoPhase:
             self.phase.Y = np.array([])
         assertArrayNear(self.phase.X, X0)
 
-    @utilities.slow_test
+    @pytest.mark.slow_test
     def test_set_equivalence_ratio_stoichiometric(self):
         gas = ct.Solution('gri30.yaml', transport_model=None)
         for fuel in ('C2H6', 'H2:0.7, CO:0.3', 'NH3:0.4, CH3OH:0.6'):

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -3,7 +3,6 @@ import numpy as np
 import pytest
 
 import cantera as ct
-from . import utilities
 from .utilities import (
     assertNear,
     assertArrayNear

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -4,9 +4,7 @@ import pytest
 from pytest import approx
 
 import cantera as ct
-from .utilities import (
-    assertArrayNear
-)
+
 
 @pytest.fixture(scope='function')
 def setup_transport(request):
@@ -47,11 +45,11 @@ class TestTransport:
         Dkm2b = self.phase.mix_diff_coeffs_mole
         Dkm2c = self.phase.mix_diff_coeffs_mass
         Dbin2 = self.phase.binary_diff_coeffs
-        assertArrayNear(Dkm1, Dkm2)
-        assertArrayNear(Dkm1b, Dkm2b)
-        assertArrayNear(Dkm1c, Dkm2c)
-        assertArrayNear(Dbin1, Dbin2)
-        assertArrayNear(Dbin1, Dbin1.T)
+        assert Dkm1 == approx(Dkm2)
+        assert Dkm1b == approx(Dkm2b)
+        assert Dkm1c == approx(Dkm2c)
+        assert Dbin1 == approx(Dbin2)
+        assert Dbin1 == approx(Dbin1.T)
 
     def test_mixDiffCoeffsChange(self):
         # This test is mainly to make code coverage in GasTransport.cpp
@@ -91,15 +89,14 @@ class TestTransport:
         self.phase.transport_model = 'mixture-averaged'
         Dkm2 = self.phase.mix_diff_coeffs
         Dbin2 = self.phase.binary_diff_coeffs
-        assertArrayNear(Dkm1, Dkm2)
-        assertArrayNear(Dbin1, Dbin2)
+        assert Dkm1 == approx(Dkm2)
+        assert Dbin1 == approx(Dbin2)
 
     def test_multiComponent(self):
         with pytest.raises(NotImplementedError):
             self.phase.multi_diff_coeffs
 
-        assertArrayNear(self.phase.thermal_diff_coeffs,
-                             np.zeros(self.phase.n_species))
+        assert self.phase.thermal_diff_coeffs == approx(np.zeros(self.phase.n_species))
 
         self.phase.transport_model = 'multicomponent'
         assert all(self.phase.multi_diff_coeffs.flat >= 0.0)
@@ -126,8 +123,8 @@ class TestTransport:
 
         assert gas1.viscosity == approx(gas2.viscosity)
         assert gas1.thermal_conductivity == approx(gas2.thermal_conductivity)
-        assertArrayNear(gas1.binary_diff_coeffs, gas2.binary_diff_coeffs)
-        assertArrayNear(gas1.mix_diff_coeffs, gas2.mix_diff_coeffs)
+        assert gas1.binary_diff_coeffs == approx(gas2.binary_diff_coeffs)
+        assert gas1.mix_diff_coeffs == approx(gas2.mix_diff_coeffs)
 
     def test_add_species_multi(self):
         yaml = (self.cantera_data_path / "gri30.yaml").read_text()
@@ -149,7 +146,7 @@ class TestTransport:
         gas2.TPX = state
 
         assert gas1.thermal_conductivity == approx(gas2.thermal_conductivity)
-        assertArrayNear(gas1.multi_diff_coeffs, gas2.multi_diff_coeffs)
+        assert gas1.multi_diff_coeffs == approx(gas2.multi_diff_coeffs)
 
     def test_species_visosities(self):
         for species_name in self.phase.species_names:
@@ -334,12 +331,12 @@ class TestDustyGas:
     def test_porosity(self):
         self.phase.porosity = 0.4
         D = self.phase.multi_diff_coeffs
-        assertArrayNear(self.Dref * 2, D)
+        assert self.Dref * 2 == approx(D)
 
     def test_tortuosity(self):
         self.phase.tortuosity = 0.6
         D = self.phase.multi_diff_coeffs
-        assertArrayNear(self.Dref * 0.5, D)
+        assert self.Dref * 0.5 == approx(D)
 
     # The other parameters don't have such simple relationships to the diffusion
     # coefficients, so we can't test them as easily
@@ -351,7 +348,7 @@ class TestDustyGas:
         T2, rho2, Y2 = self.phase.TDY
 
         fluxes0 = self.phase.molar_fluxes(T1, T1, rho1, rho1, Y1, Y1, 1e-4)
-        assertArrayNear(fluxes0, np.zeros(self.phase.n_species))
+        assert fluxes0 == approx(np.zeros(self.phase.n_species))
 
         fluxes1 = self.phase.molar_fluxes(T1, T2, rho1, rho2, Y1, Y2, 1e-4)
         kH2 = self.phase.species_index('H2')

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -102,8 +102,8 @@ class TestTransport:
         assert all(self.phase.multi_diff_coeffs.flat >= 0.0)
         assert all(self.phase.thermal_diff_coeffs.flat != 0.0)
 
-    def test_add_species_mix(self):
-        yaml = (self.cantera_data_path / "gri30.yaml").read_text()
+    def test_add_species_mix(self, cantera_data_path):
+        yaml = (cantera_data_path / "gri30.yaml").read_text()
         S = {s.name: s for s in ct.Species.list_from_yaml(yaml, "species")}
 
         base = ['H', 'H2', 'OH', 'O2', 'AR']
@@ -126,8 +126,8 @@ class TestTransport:
         assert gas1.binary_diff_coeffs == approx(gas2.binary_diff_coeffs)
         assert gas1.mix_diff_coeffs == approx(gas2.mix_diff_coeffs)
 
-    def test_add_species_multi(self):
-        yaml = (self.cantera_data_path / "gri30.yaml").read_text()
+    def test_add_species_multi(self, cantera_data_path):
+        yaml = (cantera_data_path / "gri30.yaml").read_text()
         S = {s.name: s for s in ct.Species.list_from_yaml(yaml, "species")}
 
         base = ['H', 'H2', 'OH', 'O2', 'AR', 'N2']

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -1,10 +1,10 @@
 import copy
 import numpy as np
 import pytest
+from pytest import approx
 
 import cantera as ct
 from .utilities import (
-    assertNear,
     assertArrayNear
 )
 
@@ -31,9 +31,9 @@ class TestTransport:
 
         eps = np.spacing(1) # Machine precision
         assert all(np.diff(Dkm) < 2*eps)
-        assertNear(Dkm[0], alpha)
+        assert Dkm[0] == approx(alpha)
         assert all(np.diff(Dkm_prime) < 2*eps)
-        assertNear(Dkm_prime[0], alpha)
+        assert Dkm_prime[0] == approx(alpha)
 
     def test_mixtureAveraged(self):
         assert self.phase.transport_model == 'mixture-averaged'
@@ -124,8 +124,8 @@ class TestTransport:
             gas2.add_species(S[s])
         gas2.TPX = state
 
-        assertNear(gas1.viscosity, gas2.viscosity)
-        assertNear(gas1.thermal_conductivity, gas2.thermal_conductivity)
+        assert gas1.viscosity == approx(gas2.viscosity)
+        assert gas1.thermal_conductivity == approx(gas2.thermal_conductivity)
         assertArrayNear(gas1.binary_diff_coeffs, gas2.binary_diff_coeffs)
         assertArrayNear(gas1.mix_diff_coeffs, gas2.mix_diff_coeffs)
 
@@ -148,7 +148,7 @@ class TestTransport:
             gas2.add_species(S[s])
         gas2.TPX = state
 
-        assertNear(gas1.thermal_conductivity, gas2.thermal_conductivity)
+        assert gas1.thermal_conductivity == approx(gas2.thermal_conductivity)
         assertArrayNear(gas1.multi_diff_coeffs, gas2.multi_diff_coeffs)
 
     def test_species_visosities(self):
@@ -158,12 +158,10 @@ class TestTransport:
             self.phase.X = {species_name: 1}
             self.phase.TP = 800, 2*ct.one_atm
             visc = self.phase.viscosity
-            assertNear(self.phase[species_name].species_viscosities[0],
-                            visc)
+            assert self.phase[species_name].species_viscosities[0] == approx(visc)
             # and ensure it doesn't change with pressure
             self.phase.TP = 800, 5*ct.one_atm
-            assertNear(self.phase[species_name].species_viscosities[0],
-                            visc)
+            assert self.phase[species_name].species_viscosities[0] == approx(visc)
 
     def test_transport_polynomial_fits_viscosity(self):
         visc1_h2o = self.phase['H2O'].species_viscosities[0]
@@ -229,19 +227,19 @@ class TestIonTransport:
 
     def test_binary_diffusion(self):
         bdiff = self.gas.binary_diff_coeffs[self.kN2][self.kH3Op]
-        assertNear(bdiff, 4.258e-4, 1e-4)  # Regression test
+        assert bdiff == approx(4.258e-4, rel=1e-4)  # Regression test
 
     def test_mixture_diffusion(self):
         mdiff = self.gas.mix_diff_coeffs[self.kH3Op]
-        assertNear(mdiff, 5.057e-4, 1e-4)  # Regression test
+        assert mdiff == approx(5.057e-4, rel=1e-4)  # Regression test
 
     def test_O2_anion_mixture_diffusion(self):
         mdiff = self.gas['O2-'].mix_diff_coeffs[0]
-        assertNear(mdiff, 2.784e-4, 1e-3)  # Regression test
+        assert mdiff == approx(2.784e-4, rel=1e-3)  # Regression test
 
     def test_mobility(self):
         mobi = self.gas.mobilities[self.kH3Op]
-        assertNear(mobi, 2.623e-3, 1e-4)  # Regression test
+        assert mobi == approx(2.623e-3, rel=1e-4)  # Regression test
 
     def test_update_temperature(self):
         bdiff = self.gas.binary_diff_coeffs[self.kN2][self.kH3Op]
@@ -362,7 +360,8 @@ class TestDustyGas:
         assert fluxes1[kH2O] > 0
 
         # Not sure why the following condition is not satisfied:
-        # assertNear(sum(fluxes1) / sum(abs(fluxes1)), 0.0)
+        #assert sum(fluxes1) == approx(0.0)
+        #assert sum(fluxes1) / sum(abs(fluxes1)) == approx(0.0)
 
     def test_thermal_conductivity(self):
         gas1 = ct.Solution("h2o2.yaml", transport_model="multicomponent")
@@ -387,11 +386,11 @@ class TestWaterTransport:
 
     def check_viscosity(self, T, P, mu, rtol):
         self.water.TP = T, P
-        assertNear(self.water.viscosity, mu, rtol)
+        assert self.water.viscosity == approx(mu, rel=rtol)
 
     def check_thermal_conductivity(self, T, P, k, rtol):
         self.water.TP = T, P
-        assertNear(self.water.thermal_conductivity, k, rtol)
+        assert self.water.thermal_conductivity == approx(k, rel=rtol)
 
     def test_viscosity_liquid(self):
         self.check_viscosity(400, 1e6, 2.1880e-4, 1e-3)
@@ -440,11 +439,11 @@ class TestIAPWS95WaterTransport:
 
     def check_viscosity(self, T, P, mu, rtol):
         self.water.TP = T, P
-        assertNear(self.water.viscosity, mu, rtol)
+        assert self.water.viscosity == approx(mu, rel=rtol)
 
     def check_thermal_conductivity(self, T, P, k, rtol):
         self.water.TP = T, P
-        assertNear(self.water.thermal_conductivity, k, rtol)
+        assert self.water.thermal_conductivity == approx(k, rel=rtol)
 
     def test_viscosity_liquid(self):
         self.check_viscosity(400, 1e6, 2.1880e-4, 2e-4)
@@ -481,21 +480,21 @@ class TestTransportData:
     def test_read(self):
         tr = self.gas.species('H2').transport
         assert tr.geometry == 'linear'
-        assertNear(tr.diameter, 2.92e-10)
-        assertNear(tr.well_depth, 38.0 * ct.boltzmann)
-        assertNear(tr.polarizability, 0.79e-30)
-        assertNear(tr.rotational_relaxation, 280)
+        assert tr.diameter == approx(2.92e-10)
+        assert tr.well_depth == approx(38.0 * ct.boltzmann)
+        assert tr.polarizability == approx(0.79e-30)
+        assert tr.rotational_relaxation == approx(280)
 
     def test_set_customary_units(self):
         tr1 = ct.GasTransportData()
         tr1.set_customary_units('nonlinear', 2.60, 572.40, 1.84, 0.0, 4.00)
         tr2 = self.gas.species('H2O').transport
         assert tr1.geometry == tr2.geometry
-        assertNear(tr1.diameter, tr2.diameter)
-        assertNear(tr1.well_depth, tr2.well_depth)
-        assertNear(tr1.dipole, tr2.dipole)
-        assertNear(tr1.polarizability, tr2.polarizability)
-        assertNear(tr1.rotational_relaxation, tr2.rotational_relaxation)
+        assert tr1.diameter == approx(tr2.diameter)
+        assert tr1.well_depth == approx(tr2.well_depth)
+        assert tr1.dipole == approx(tr2.dipole)
+        assert tr1.polarizability == approx(tr2.polarizability)
+        assert tr1.rotational_relaxation == approx(tr2.rotational_relaxation)
 
 
 @pytest.fixture(scope='function')
@@ -508,8 +507,8 @@ class TestIonGasTransportData:
 
     def test_read_ion(self):
         tr = self.gas.species('N2').transport
-        assertNear(tr.dispersion_coefficient, 2.995e-50)
-        assertNear(tr.quadrupole_polarizability, 3.602e-50)
+        assert tr.dispersion_coefficient == approx(2.995e-50)
+        assert tr.quadrupole_polarizability == approx(3.602e-50)
 
     def test_set_customary_units(self):
         tr1 = ct.GasTransportData()
@@ -517,5 +516,5 @@ class TestIonGasTransportData:
                                 dispersion_coefficient = 2.995,
                                 quadrupole_polarizability = 3.602)
         tr2 = self.gas.species('N2').transport
-        assertNear(tr1.dispersion_coefficient, tr2.dispersion_coefficient)
-        assertNear(tr1.quadrupole_polarizability, tr2.quadrupole_polarizability)
+        assert tr1.dispersion_coefficient == approx(tr2.dispersion_coefficient)
+        assert tr1.quadrupole_polarizability == approx(tr2.quadrupole_polarizability)

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -209,18 +209,10 @@ class TestTransport:
 
 class TestIonTransport:
 
-    @pytest.fixture(scope='class')
-    def initial_conditions(self):
-        return {
-            'T': 2237,
-            'P': ct.one_atm,
-            'X': 'O2:0.7010, H2O:0.1885, CO2:9.558e-2'
-        }
-
     @pytest.fixture(scope='function')
-    def gas(self, initial_conditions):
+    def gas(self):
         gas = ct.Solution('ch4_ion.yaml')
-        gas.TPX = initial_conditions['T'], initial_conditions['P'], initial_conditions['X']
+        gas.TPX = 2237, ct.one_atm, 'O2:0.7010, H2O:0.1885, CO2:9.558e-2'
         return gas
 
     @pytest.fixture(scope='function')
@@ -401,10 +393,6 @@ class TestWaterTransport:
     def water(self):
         return ct.Water()
 
-    @pytest.fixture(scope='class')
-    def water(self):
-        return ct.Water()
-
     @pytest.mark.parametrize("T, P, mu, rtol", [
         (400, 1e6, 2.1880e-4, 1e-3),
         (400, 8e6, 2.2061e-4, 1e-3),
@@ -517,10 +505,6 @@ class TestTransportData:
     def gas(self):
         gas = ct.Solution("h2o2.yaml")
         return gas
-
-    @pytest.fixture(scope='function', autouse=True)
-    def initial_condition(self, gas):
-        gas.X = 'H2O:0.6, H2:0.4'
 
     def test_read(self, gas):
         tr = gas.species('H2').transport

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -215,19 +215,16 @@ class TestIonTransport:
         gas.TPX = 2237, ct.one_atm, 'O2:0.7010, H2O:0.1885, CO2:9.558e-2'
         return gas
 
-    @pytest.fixture(scope='function')
-    def N2_idx(self, gas):
-        return gas.species_index("N2")
+    def test_binary_diffusion(self, gas):
+        N2_idx = gas.species_index("N2")
+        H3Op_idx = gas.species_index("H3O+")
 
-    @pytest.fixture(scope='function')
-    def H3Op_idx(self, gas):
-        return gas.species_index("H3O+")
-
-    def test_binary_diffusion(self, gas, N2_idx, H3Op_idx):
         bdiff = gas.binary_diff_coeffs[N2_idx][H3Op_idx]
         assert bdiff == approx(4.258e-4, rel=1e-4)  # Regression test
 
-    def test_mixture_diffusion(self, gas, H3Op_idx):
+    def test_mixture_diffusion(self, gas):
+        H3Op_idx = gas.species_index("H3O+")
+
         mdiff = gas.mix_diff_coeffs[H3Op_idx]
         assert mdiff == approx(5.057e-4, rel=1e-4)  # Regression test
 
@@ -235,11 +232,16 @@ class TestIonTransport:
         mdiff = gas['O2-'].mix_diff_coeffs[0]
         assert mdiff == approx(2.784e-4, rel=1e-3)  # Regression test
 
-    def test_mobility(self, gas, H3Op_idx):
+    def test_mobility(self, gas):
+        H3Op_idx = gas.species_index("H3O+")
+
         mobi = gas.mobilities[H3Op_idx]
         assert mobi == approx(2.623e-3, rel=1e-4)  # Regression test
 
-    def test_update_temperature(self, gas, N2_idx, H3Op_idx):
+    def test_update_temperature(self, gas):
+        N2_idx = gas.species_index("N2")
+        H3Op_idx = gas.species_index("H3O+")
+
         bdiff = gas.binary_diff_coeffs[N2_idx][H3Op_idx]
         mdiff = gas.mix_diff_coeffs[H3Op_idx]
         mobi = gas.mobilities[H3Op_idx]
@@ -318,18 +320,10 @@ class TestTransportGeometryFlags:
 
 class TestDustyGas:
 
-    @pytest.fixture(scope='class')
-    def initial_conditions(self):
-        return {
-            'T': 500.0,
-            'P': ct.one_atm,
-            'X': "O2:2.0, H2:1.0, H2O:1.0"
-        }
-
     @pytest.fixture
-    def phase(self, initial_conditions):
+    def phase(self):
         phase = ct.DustyGas("h2o2.yaml")
-        phase.TPX = initial_conditions['T'], initial_conditions['P'], initial_conditions['X']
+        phase.TPX = 500.0, ct.one_atm, "O2:2.0, H2:1.0, H2O:1.0"
         phase.porosity = 0.2
         phase.tortuosity = 0.3
         phase.mean_pore_radius = 1e-4

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -1,21 +1,27 @@
+import copy
 import numpy as np
+import pytest
 
 import cantera as ct
 from . import utilities
-from .utilities import allow_deprecated
-import copy
-import pytest
+from .utilities import (
+    assertNear,
+    assertArrayNear
+)
 
+@pytest.fixture(scope='function')
+def setup_transport(request):
+    # Create instance-level data for each test
+    request.cls.phase = ct.Solution('h2o2.yaml')
+    request.cls.phase.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 1e-6, 0.4]
+    request.cls.phase.TP = 800, 2*ct.one_atm
 
-class TestTransport(utilities.CanteraTest):
-    def setUp(self):
-        self.phase = ct.Solution("h2o2.yaml")
-        self.phase.X = [0.1, 1e-4, 1e-5, 0.2, 2e-4, 0.3, 1e-6, 5e-5, 1e-6, 0.4]
-        self.phase.TP = 800, 2*ct.one_atm
+@pytest.mark.usefixtures("setup_transport")
+class TestTransport:
 
     def test_scalar_properties(self):
-        self.assertTrue(self.phase.viscosity > 0.0)
-        self.assertTrue(self.phase.thermal_conductivity > 0.0)
+        assert self.phase.viscosity > 0.0
+        assert self.phase.thermal_conductivity > 0.0
 
     def test_unityLewis(self):
         self.phase.transport_model = 'unity-Lewis-number'
@@ -25,13 +31,13 @@ class TestTransport(utilities.CanteraTest):
         Dkm = self.phase.mix_diff_coeffs_mass
 
         eps = np.spacing(1) # Machine precision
-        self.assertTrue(all(np.diff(Dkm) < 2*eps))
-        self.assertNear(Dkm[0], alpha)
-        self.assertTrue(all(np.diff(Dkm_prime) < 2*eps))
-        self.assertNear(Dkm_prime[0], alpha)
+        assert all(np.diff(Dkm) < 2*eps)
+        assertNear(Dkm[0], alpha)
+        assert all(np.diff(Dkm_prime) < 2*eps)
+        assertNear(Dkm_prime[0], alpha)
 
     def test_mixtureAveraged(self):
-        self.assertEqual(self.phase.transport_model, 'mixture-averaged')
+        assert self.phase.transport_model == 'mixture-averaged'
         Dkm1 = self.phase.mix_diff_coeffs
         Dkm1b = self.phase.mix_diff_coeffs_mole
         Dkm1c = self.phase.mix_diff_coeffs_mass
@@ -42,11 +48,11 @@ class TestTransport(utilities.CanteraTest):
         Dkm2b = self.phase.mix_diff_coeffs_mole
         Dkm2c = self.phase.mix_diff_coeffs_mass
         Dbin2 = self.phase.binary_diff_coeffs
-        self.assertArrayNear(Dkm1, Dkm2)
-        self.assertArrayNear(Dkm1b, Dkm2b)
-        self.assertArrayNear(Dkm1c, Dkm2c)
-        self.assertArrayNear(Dbin1, Dbin2)
-        self.assertArrayNear(Dbin1, Dbin1.T)
+        assertArrayNear(Dkm1, Dkm2)
+        assertArrayNear(Dkm1b, Dkm2b)
+        assertArrayNear(Dkm1c, Dkm2c)
+        assertArrayNear(Dbin1, Dbin2)
+        assertArrayNear(Dbin1, Dbin1.T)
 
     def test_mixDiffCoeffsChange(self):
         # This test is mainly to make code coverage in GasTransport.cpp
@@ -55,26 +61,26 @@ class TestTransport(utilities.CanteraTest):
         Dkm1 = self.phase.mix_diff_coeffs_mole
         self.phase.TP = self.phase.T + 1, None
         Dkm2 = self.phase.mix_diff_coeffs_mole
-        self.assertTrue(all(Dkm2 > Dkm1))
+        assert all(Dkm2 > Dkm1)
 
         Dkm1 = self.phase.mix_diff_coeffs_mass
         self.phase.TP = self.phase.T + 1, None
         Dkm2 = self.phase.mix_diff_coeffs_mass
-        self.assertTrue(all(Dkm2 > Dkm1))
+        assert all(Dkm2 > Dkm1)
 
         Dkm1 = self.phase.mix_diff_coeffs
         self.phase.TP = self.phase.T + 1, None
         Dkm2 = self.phase.mix_diff_coeffs
-        self.assertTrue(all(Dkm2 > Dkm1))
+        assert all(Dkm2 > Dkm1)
 
     def test_CK_mode(self):
         mu_ct = self.phase.viscosity
         self.phase.transport_model = 'mixture-averaged-CK'
-        self.assertEqual(self.phase.transport_model, 'mixture-averaged-CK')
+        assert self.phase.transport_model == 'mixture-averaged-CK'
         mu_ck = self.phase.viscosity
         # values should be close, but not identical
-        self.assertGreater(abs(mu_ct - mu_ck) / mu_ct, 1e-8)
-        self.assertLess(abs(mu_ct - mu_ck) / mu_ct, 1e-2)
+        assert abs(mu_ct - mu_ck) / mu_ct > 1e-8
+        assert abs(mu_ct - mu_ck) / mu_ct < 1e-2
 
     def test_ionGas(self):
         # IonGasTransport gives the same result for a mixture
@@ -86,19 +92,19 @@ class TestTransport(utilities.CanteraTest):
         self.phase.transport_model = 'mixture-averaged'
         Dkm2 = self.phase.mix_diff_coeffs
         Dbin2 = self.phase.binary_diff_coeffs
-        self.assertArrayNear(Dkm1, Dkm2)
-        self.assertArrayNear(Dbin1, Dbin2)
+        assertArrayNear(Dkm1, Dkm2)
+        assertArrayNear(Dbin1, Dbin2)
 
     def test_multiComponent(self):
         with pytest.raises(NotImplementedError):
             self.phase.multi_diff_coeffs
 
-        self.assertArrayNear(self.phase.thermal_diff_coeffs,
+        assertArrayNear(self.phase.thermal_diff_coeffs,
                              np.zeros(self.phase.n_species))
 
         self.phase.transport_model = 'multicomponent'
-        self.assertTrue(all(self.phase.multi_diff_coeffs.flat >= 0.0))
-        self.assertTrue(all(self.phase.thermal_diff_coeffs.flat != 0.0))
+        assert all(self.phase.multi_diff_coeffs.flat >= 0.0)
+        assert all(self.phase.thermal_diff_coeffs.flat != 0.0)
 
     def test_add_species_mix(self):
         yaml = (self.cantera_data_path / "gri30.yaml").read_text()
@@ -119,10 +125,10 @@ class TestTransport(utilities.CanteraTest):
             gas2.add_species(S[s])
         gas2.TPX = state
 
-        self.assertNear(gas1.viscosity, gas2.viscosity)
-        self.assertNear(gas1.thermal_conductivity, gas2.thermal_conductivity)
-        self.assertArrayNear(gas1.binary_diff_coeffs, gas2.binary_diff_coeffs)
-        self.assertArrayNear(gas1.mix_diff_coeffs, gas2.mix_diff_coeffs)
+        assertNear(gas1.viscosity, gas2.viscosity)
+        assertNear(gas1.thermal_conductivity, gas2.thermal_conductivity)
+        assertArrayNear(gas1.binary_diff_coeffs, gas2.binary_diff_coeffs)
+        assertArrayNear(gas1.mix_diff_coeffs, gas2.mix_diff_coeffs)
 
     def test_add_species_multi(self):
         yaml = (self.cantera_data_path / "gri30.yaml").read_text()
@@ -143,8 +149,8 @@ class TestTransport(utilities.CanteraTest):
             gas2.add_species(S[s])
         gas2.TPX = state
 
-        self.assertNear(gas1.thermal_conductivity, gas2.thermal_conductivity)
-        self.assertArrayNear(gas1.multi_diff_coeffs, gas2.multi_diff_coeffs)
+        assertNear(gas1.thermal_conductivity, gas2.thermal_conductivity)
+        assertArrayNear(gas1.multi_diff_coeffs, gas2.multi_diff_coeffs)
 
     def test_species_visosities(self):
         for species_name in self.phase.species_names:
@@ -153,11 +159,11 @@ class TestTransport(utilities.CanteraTest):
             self.phase.X = {species_name: 1}
             self.phase.TP = 800, 2*ct.one_atm
             visc = self.phase.viscosity
-            self.assertNear(self.phase[species_name].species_viscosities[0],
+            assertNear(self.phase[species_name].species_viscosities[0],
                             visc)
             # and ensure it doesn't change with pressure
             self.phase.TP = 800, 5*ct.one_atm
-            self.assertNear(self.phase[species_name].species_viscosities[0],
+            assertNear(self.phase[species_name].species_viscosities[0],
                             visc)
 
     def test_transport_polynomial_fits_viscosity(self):
@@ -169,9 +175,9 @@ class TestTransport(utilities.CanteraTest):
         visc2_h2 = self.phase['H2'].species_viscosities[0]
         self.phase.set_viscosity_polynomial(self.phase.species_index('H2'), mu_poly_h2)
         visc3_h2 = self.phase['H2'].species_viscosities[0]
-        self.assertTrue(visc1_h2o != visc1_h2)
-        self.assertEqual(visc1_h2o, visc2_h2)
-        self.assertEqual(visc1_h2, visc3_h2)
+        assert visc1_h2o != visc1_h2
+        assert visc1_h2o == visc2_h2
+        assert visc1_h2 == visc3_h2
 
     def test_transport_polynomial_fits_conductivity(self):
         self.phase.X = {'O2': 1}
@@ -184,9 +190,9 @@ class TestTransport(utilities.CanteraTest):
         cond2_h2 = self.phase.thermal_conductivity
         self.phase.set_thermal_conductivity_polynomial(self.phase.species_index('H2'), lambda_poly_h2)
         cond3_h2 = self.phase.thermal_conductivity
-        self.assertTrue(cond1_o2 != cond1_h2)
-        self.assertEqual(cond1_o2, cond2_h2)
-        self.assertEqual(cond1_h2, cond3_h2)
+        assert cond1_o2 != cond1_h2
+        assert cond1_o2 == cond2_h2
+        assert cond1_h2 == cond3_h2
 
     def test_transport_polynomial_fits_diffusion(self):
         D12 = self.phase.binary_diff_coeffs[1, 2]
@@ -201,50 +207,54 @@ class TestTransport(utilities.CanteraTest):
         self.phase.set_binary_diff_coeffs_polynomial(2, 3, bd_poly_23)
         D12new = self.phase.binary_diff_coeffs[1, 2]
         D23new = self.phase.binary_diff_coeffs[2, 3]
-        self.assertTrue(D12 != D23)
-        self.assertEqual(D12, D23mod)
-        self.assertEqual(D23, D12mod)
-        self.assertEqual(D12, D12new)
-        self.assertEqual(D23, D23new)
+        assert D12 != D23
+        assert D12 == D23mod
+        assert D23 == D12mod
+        assert D12 == D12new
+        assert D23 == D23new
 
 
-class TestIonTransport(utilities.CanteraTest):
-    def setUp(self):
-        self.p = ct.one_atm
-        self.T = 2237
-        self.gas = ct.Solution('ch4_ion.yaml')
-        self.gas.X = 'O2:0.7010, H2O:0.1885, CO2:9.558e-2'
-        self.gas.TP = self.T, self.p
-        self.kN2 = self.gas.species_index("N2")
-        self.kH3Op = self.gas.species_index("H3O+")
+@pytest.fixture(scope='function')
+def setup_ion_transport(request):
+    # Create instance-level data for each test
+    request.cls.p = ct.one_atm
+    request.cls.T = 2237
+    request.cls.gas = ct.Solution('ch4_ion.yaml')
+    request.cls.gas.X = 'O2:0.7010, H2O:0.1885, CO2:9.558e-2'
+    request.cls.gas.TP = request.cls.T, request.cls.p
+    request.cls.kN2 = request.cls.gas.species_index("N2")
+    request.cls.kH3Op = request.cls.gas.species_index("H3O+")
+
+@pytest.mark.usefixtures("setup_ion_transport")
+class TestIonTransport:
 
     def test_binary_diffusion(self):
         bdiff = self.gas.binary_diff_coeffs[self.kN2][self.kH3Op]
-        self.assertNear(bdiff, 4.258e-4, 1e-4)  # Regression test
+        assertNear(bdiff, 4.258e-4, 1e-4)  # Regression test
 
     def test_mixture_diffusion(self):
         mdiff = self.gas.mix_diff_coeffs[self.kH3Op]
-        self.assertNear(mdiff, 5.057e-4, 1e-4)  # Regression test
+        assertNear(mdiff, 5.057e-4, 1e-4)  # Regression test
 
     def test_O2_anion_mixture_diffusion(self):
         mdiff = self.gas['O2-'].mix_diff_coeffs[0]
-        self.assertNear(mdiff, 2.784e-4, 1e-3)  # Regression test
+        assertNear(mdiff, 2.784e-4, 1e-3)  # Regression test
 
     def test_mobility(self):
         mobi = self.gas.mobilities[self.kH3Op]
-        self.assertNear(mobi, 2.623e-3, 1e-4)  # Regression test
+        assertNear(mobi, 2.623e-3, 1e-4)  # Regression test
 
     def test_update_temperature(self):
         bdiff = self.gas.binary_diff_coeffs[self.kN2][self.kH3Op]
         mdiff = self.gas.mix_diff_coeffs[self.kH3Op]
         mobi = self.gas.mobilities[self.kH3Op]
         self.gas.TP = 0.9 * self.T, self.p
-        self.assertTrue(bdiff != self.gas.binary_diff_coeffs[self.kN2][self.kH3Op])
-        self.assertTrue(mdiff != self.gas.mix_diff_coeffs[self.kH3Op])
-        self.assertTrue(mobi != self.gas.mobilities[self.kH3Op])
+        assert bdiff != self.gas.binary_diff_coeffs[self.kN2][self.kH3Op]
+        assert mdiff != self.gas.mix_diff_coeffs[self.kH3Op]
+        assert mobi != self.gas.mobilities[self.kH3Op]
 
 
-class TestTransportGeometryFlags(utilities.CanteraTest):
+class TestTransportGeometryFlags:
     species_data = """
     - name: H2
       composition: {{H: 2}}
@@ -306,29 +316,33 @@ class TestTransportGeometryFlags(utilities.CanteraTest):
         for geoms in bad:
             test = copy.copy(good)
             test.update(geoms)
-            with self.assertRaisesRegex(ct.CanteraError, 'invalid geometry'):
+            with pytest.raises(ct.CanteraError, match='invalid geometry'):
                 ct.Species.list_from_yaml(self.species_data.format(**test))
 
 
-class TestDustyGas(utilities.CanteraTest):
-    def setUp(self):
-        self.phase = ct.DustyGas("h2o2.yaml")
-        self.phase.TPX = 500.0, ct.one_atm, "O2:2.0, H2:1.0, H2O:1.0"
-        self.phase.porosity = 0.2
-        self.phase.tortuosity = 0.3
-        self.phase.mean_pore_radius = 1e-4
-        self.phase.mean_particle_diameter = 5e-4
-        self.Dref = self.phase.multi_diff_coeffs
+@pytest.fixture(scope='function')
+def setup_dusty_gas(request):
+    # Create instance-level data for each test
+    request.cls.phase = ct.DustyGas("h2o2.yaml")
+    request.cls.phase.TPX = 500.0, ct.one_atm, "O2:2.0, H2:1.0, H2O:1.0"
+    request.cls.phase.porosity = 0.2
+    request.cls.phase.tortuosity = 0.3
+    request.cls.phase.mean_pore_radius = 1e-4
+    request.cls.phase.mean_particle_diameter = 5e-4
+    request.cls.Dref = request.cls.phase.multi_diff_coeffs
+
+@pytest.mark.usefixtures("setup_dusty_gas")
+class TestDustyGas:
 
     def test_porosity(self):
         self.phase.porosity = 0.4
         D = self.phase.multi_diff_coeffs
-        self.assertArrayNear(self.Dref * 2, D)
+        assertArrayNear(self.Dref * 2, D)
 
     def test_tortuosity(self):
         self.phase.tortuosity = 0.6
         D = self.phase.multi_diff_coeffs
-        self.assertArrayNear(self.Dref * 0.5, D)
+        assertArrayNear(self.Dref * 0.5, D)
 
     # The other parameters don't have such simple relationships to the diffusion
     # coefficients, so we can't test them as easily
@@ -340,24 +354,30 @@ class TestDustyGas(utilities.CanteraTest):
         T2, rho2, Y2 = self.phase.TDY
 
         fluxes0 = self.phase.molar_fluxes(T1, T1, rho1, rho1, Y1, Y1, 1e-4)
-        self.assertArrayNear(fluxes0, np.zeros(self.phase.n_species))
+        assertArrayNear(fluxes0, np.zeros(self.phase.n_species))
 
         fluxes1 = self.phase.molar_fluxes(T1, T2, rho1, rho2, Y1, Y2, 1e-4)
         kH2 = self.phase.species_index('H2')
         kH2O = self.phase.species_index('H2O')
-        self.assertTrue(fluxes1[kH2] < 0)
-        self.assertTrue(fluxes1[kH2O] > 0)
+        assert fluxes1[kH2] < 0
+        assert fluxes1[kH2O] > 0
 
         # Not sure why the following condition is not satisfied:
-        # self.assertNear(sum(fluxes1) / sum(abs(fluxes1)), 0.0)
+        # assertNear(sum(fluxes1) / sum(abs(fluxes1)), 0.0)
 
     def test_thermal_conductivity(self):
         gas1 = ct.Solution("h2o2.yaml", transport_model="multicomponent")
         gas1.TPX = self.phase.TPX
 
-        self.assertEqual(self.phase.thermal_conductivity, gas1.thermal_conductivity)
+        assert self.phase.thermal_conductivity == gas1.thermal_conductivity
 
-class TestWaterTransport(utilities.CanteraTest):
+
+@pytest.fixture(scope='function')
+def water(request):
+    request.cls.water = ct.Water()
+
+@pytest.mark.usefixtures("water")
+class TestWaterTransport:
     """
     Comparison values are taken from the NIST Chemistry WebBook. Agreement is
     limited by the use of a different equation of state here (Reynolds) than
@@ -365,17 +385,14 @@ class TestWaterTransport(utilities.CanteraTest):
     the transport property model. Differences are largest in the region near
     the critical point.
     """
-    @classmethod
-    def setup_class(cls):
-        cls.water = ct.Water()
 
     def check_viscosity(self, T, P, mu, rtol):
         self.water.TP = T, P
-        self.assertNear(self.water.viscosity, mu, rtol)
+        assertNear(self.water.viscosity, mu, rtol)
 
     def check_thermal_conductivity(self, T, P, k, rtol):
         self.water.TP = T, P
-        self.assertNear(self.water.thermal_conductivity, k, rtol)
+        assertNear(self.water.thermal_conductivity, k, rtol)
 
     def test_viscosity_liquid(self):
         self.check_viscosity(400, 1e6, 2.1880e-4, 1e-3)
@@ -409,22 +426,26 @@ class TestWaterTransport(utilities.CanteraTest):
         self.check_thermal_conductivity(660, 2.54e7, 0.35484, 2e-2)
         self.check_thermal_conductivity(660, 2.8e7, 0.38479, 1e-2)
 
-class TestIAPWS95WaterTransport(utilities.CanteraTest):
+
+@pytest.fixture(scope='function')
+def setup_IAPWS95Water(request):
+    # Create instance-level data for each test
+    request.cls.water = ct.Solution('thermo-models.yaml', 'liquid-water')
+
+@pytest.mark.usefixtures("setup_IAPWS95Water")
+class TestIAPWS95WaterTransport:
     """
     Water transport properties test using the IAPWS95 equation of state. This
     results in better comparisons with data from the NIST Webbook.
     """
-    @classmethod
-    def setup_class(cls):
-        cls.water = ct.Solution('thermo-models.yaml', 'liquid-water')
 
     def check_viscosity(self, T, P, mu, rtol):
         self.water.TP = T, P
-        self.assertNear(self.water.viscosity, mu, rtol)
+        assertNear(self.water.viscosity, mu, rtol)
 
     def check_thermal_conductivity(self, T, P, k, rtol):
         self.water.TP = T, P
-        self.assertNear(self.water.thermal_conductivity, k, rtol)
+        assertNear(self.water.thermal_conductivity, k, rtol)
 
     def test_viscosity_liquid(self):
         self.check_viscosity(400, 1e6, 2.1880e-4, 2e-4)
@@ -449,41 +470,47 @@ class TestIAPWS95WaterTransport(utilities.CanteraTest):
         self.check_thermal_conductivity(660, 2.8e7, 0.38479, 1e-4)
 
 
-class TestTransportData(utilities.CanteraTest):
-    @classmethod
-    def setup_class(cls):
-        utilities.CanteraTest.setup_class()
-        cls.gas = ct.Solution("h2o2.yaml")
-        cls.gas.X = 'H2O:0.6, H2:0.4'
+@pytest.fixture(scope='function')
+def setup_transport_data(request):
+    # Create instance-level data for each test
+    request.cls.gas = ct.Solution("h2o2.yaml")
+    request.cls.gas.X = 'H2O:0.6, H2:0.4'
+
+@pytest.mark.usefixtures("setup_transport_data")
+class TestTransportData:
 
     def test_read(self):
         tr = self.gas.species('H2').transport
-        self.assertEqual(tr.geometry, 'linear')
-        self.assertNear(tr.diameter, 2.92e-10)
-        self.assertNear(tr.well_depth, 38.0 * ct.boltzmann)
-        self.assertNear(tr.polarizability, 0.79e-30)
-        self.assertNear(tr.rotational_relaxation, 280)
+        assert tr.geometry == 'linear'
+        assertNear(tr.diameter, 2.92e-10)
+        assertNear(tr.well_depth, 38.0 * ct.boltzmann)
+        assertNear(tr.polarizability, 0.79e-30)
+        assertNear(tr.rotational_relaxation, 280)
 
     def test_set_customary_units(self):
         tr1 = ct.GasTransportData()
         tr1.set_customary_units('nonlinear', 2.60, 572.40, 1.84, 0.0, 4.00)
         tr2 = self.gas.species('H2O').transport
-        self.assertEqual(tr1.geometry, tr2.geometry)
-        self.assertNear(tr1.diameter, tr2.diameter)
-        self.assertNear(tr1.well_depth, tr2.well_depth)
-        self.assertNear(tr1.dipole, tr2.dipole)
-        self.assertNear(tr1.polarizability, tr2.polarizability)
-        self.assertNear(tr1.rotational_relaxation, tr2.rotational_relaxation)
+        assert tr1.geometry == tr2.geometry
+        assertNear(tr1.diameter, tr2.diameter)
+        assertNear(tr1.well_depth, tr2.well_depth)
+        assertNear(tr1.dipole, tr2.dipole)
+        assertNear(tr1.polarizability, tr2.polarizability)
+        assertNear(tr1.rotational_relaxation, tr2.rotational_relaxation)
 
 
-class TestIonGasTransportData(utilities.CanteraTest):
-    def setUp(self):
-        self.gas = ct.Solution("ch4_ion.yaml")
+@pytest.fixture(scope='function')
+def setup_ion_transport_data(request):
+    # Create instance-level data for each test
+    request.cls.gas = ct.Solution("ch4_ion.yaml")
+
+@pytest.mark.usefixtures("setup_ion_transport_data")
+class TestIonGasTransportData:
 
     def test_read_ion(self):
         tr = self.gas.species('N2').transport
-        self.assertNear(tr.dispersion_coefficient, 2.995e-50)
-        self.assertNear(tr.quadrupole_polarizability, 3.602e-50)
+        assertNear(tr.dispersion_coefficient, 2.995e-50)
+        assertNear(tr.quadrupole_polarizability, 3.602e-50)
 
     def test_set_customary_units(self):
         tr1 = ct.GasTransportData()
@@ -491,5 +518,5 @@ class TestIonGasTransportData(utilities.CanteraTest):
                                 dispersion_coefficient = 2.995,
                                 quadrupole_polarizability = 3.602)
         tr2 = self.gas.species('N2').transport
-        self.assertNear(tr1.dispersion_coefficient, tr2.dispersion_coefficient)
-        self.assertNear(tr1.quadrupole_polarizability, tr2.quadrupole_polarizability)
+        assertNear(tr1.dispersion_coefficient, tr2.dispersion_coefficient)
+        assertNear(tr1.quadrupole_polarizability, tr2.quadrupole_polarizability)

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -366,7 +366,7 @@ class TestWaterTransport(utilities.CanteraTest):
     the critical point.
     """
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.water = ct.Water()
 
     def check_viscosity(self, T, P, mu, rtol):
@@ -415,7 +415,7 @@ class TestIAPWS95WaterTransport(utilities.CanteraTest):
     results in better comparisons with data from the NIST Webbook.
     """
     @classmethod
-    def setUpClass(cls):
+    def setup_class(cls):
         cls.water = ct.Solution('thermo-models.yaml', 'liquid-water')
 
     def check_viscosity(self, T, P, mu, rtol):
@@ -451,8 +451,8 @@ class TestIAPWS95WaterTransport(utilities.CanteraTest):
 
 class TestTransportData(utilities.CanteraTest):
     @classmethod
-    def setUpClass(cls):
-        utilities.CanteraTest.setUpClass()
+    def setup_class(cls):
+        utilities.CanteraTest.setup_class()
         cls.gas = ct.Solution("h2o2.yaml")
         cls.gas.X = 'H2O:0.6, H2:0.4'
 

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -1,13 +1,9 @@
-from pathlib import Path
 import numpy as np
+from pathlib import Path
 import pytest
 from pytest import approx
 
 import cantera as ct
-from .utilities import (
-    assertArrayNear
-)
-
 from cantera._utils import _py_to_any_to_py, _py_to_anymap_to_py
 
 
@@ -91,17 +87,17 @@ class TestUnitSystem:
     def test_convert_to_array(self):
         system = ct.UnitSystem({"length": "km"})
         x = np.array(((3, 4), (0.5, 2.0), (1.0, 0.0)))
-        assertArrayNear(system.convert_to(x, "m"), 1000 * x)
+        assert system.convert_to(x, "m") == approx(1000 * x)
 
     def test_convert_activation_energy_to_array(self):
         system = ct.UnitSystem({"activation-energy": "J/mol"})
         x = np.array(((3, 4), (0.5, 2.0), (1.0, 0.0)))
-        assertArrayNear(system.convert_activation_energy_to(x, "J/kmol"), 1000 * x)
+        assert system.convert_activation_energy_to(x, "J/kmol") == approx(1000 * x)
 
     def test_convert_rate_coeff_to_array(self):
         system = ct.UnitSystem({"length": "cm"})
         x = np.array(((3, 4), (0.5, 2.0), (1.0, 0.0)))
-        assertArrayNear(system.convert_rate_coeff_to(x, "m^2/kmol/s"), 0.0001 * x)
+        assert system.convert_rate_coeff_to(x, "m^2/kmol/s") == approx(0.0001 * x)
 
     def test_convert_to_sequence(self):
         system = ct.UnitSystem({"length": "km"})

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -4,9 +4,7 @@ import pytest
 from pytest import approx
 
 import cantera as ct
-from . import utilities
 from .utilities import (
-    assertNear,
     assertArrayNear
 )
 

--- a/test/python/utilities.py
+++ b/test/python/utilities.py
@@ -1,6 +1,6 @@
 import numpy as np
 from pathlib import Path, PurePath
-import pytest
+from pytest import approx
 import warnings
 
 try:
@@ -10,39 +10,6 @@ except ImportError:
 
 
 # Custom assertions functions
-
-def assertNear(a, b, rtol=1e-8, atol=1e-12, msg=None):
-    if a == b:
-        return  # handles case where a == b == inf
-    cmp = 2 * abs(a - b)/(abs(a) + abs(b) + 2 * atol / rtol)
-    if not cmp < rtol:
-        message = ('AssertNear: %.14g - %.14g = %.14g\n' % (a, b, a-b) +
-                    'Relative error of %10e exceeds rtol = %10e' % (cmp, rtol))
-        if msg:
-            message = msg + '\n' + message
-        pytest.fail(message)
-
-def assertArrayNear(A, B, rtol=1e-8, atol=1e-12, msg=None):
-    if len(A) != len(B):
-        pytest.fail("Arrays are of different lengths ({0}, {1})".format(len(A), len(B)))
-    A = np.asarray(A)
-    B = np.asarray(B)
-
-    worst = 0, ''
-    for i in np.ndindex(A.shape):
-        a = A[i]
-        b = B[i]
-        cmp = 2 * abs(a - b)/(abs(a) + abs(b) + 2 * atol / rtol)
-        if not cmp < rtol:
-            message = ('AssertNear: {:.14g} - {:.14g} = {:.14g}\n'.format(a, b, a-b) +
-                        'Relative error for element {} of {:10e} exceeds rtol = {:10e}'.format(i, cmp, rtol))
-            if msg:
-                message = msg + '\n' + message
-            if not cmp < worst[0]:
-                worst = cmp, message
-
-    if worst[0]:
-        pytest.fail(worst[1])
 
 def compare(data, reference_file, rtol=1e-8, atol=1e-12):
     """
@@ -55,7 +22,7 @@ def compare(data, reference_file, rtol=1e-8, atol=1e-12):
         ref = np.genfromtxt(reference_file)
         assert data.shape == ref.shape
         for i in range(ref.shape[0]):
-            assertArrayNear(ref[i], data[i], rtol, atol)
+            assert ref[i] == approx(data[i], rel=rtol, abs=atol)
     else:
         # Generate the output file for the first time
         warnings.warn('Generating test data file:' +

--- a/test/python/utilities.py
+++ b/test/python/utilities.py
@@ -9,7 +9,19 @@ except ImportError:
     import ruamel_yaml as yaml
 
 
-# Custom assertions functions
+def load_yaml(yml_file):
+    """
+    Load YAML data from file using the "safe" loading option.
+    """
+    try:
+        yaml_parser = yaml.YAML(typ="safe")
+        with open(yml_file, "rt", encoding="utf-8") as stream:
+            return yaml_parser.load(stream)
+    except yaml.constructor.ConstructorError:
+        with open(yml_file, "rt", encoding="utf-8") as stream:
+            # Ensure that  the loader remains backward-compatible with legacy
+            # ruamel.yaml versions (prior to 0.17.0).
+            return yaml.safe_load(stream)
 
 def compare(data, reference_file, rtol=1e-8, atol=1e-12):
     """

--- a/test/python/utilities.py
+++ b/test/python/utilities.py
@@ -10,13 +10,6 @@ except ImportError:
 
 
 # Custom assertions functions
-def assertIsFinite(value):
-    if not np.isfinite(value):
-        pytest.fail(f"Value '{value}' is not finite")
-
-def assertIsNaN(value):
-    if not np.isnan(value):
-        pytest.fail(f"Value '{value}' is a number")
 
 def assertNear(a, b, rtol=1e-8, atol=1e-12, msg=None):
     if a == b:

--- a/test/python/utilities.py
+++ b/test/python/utilities.py
@@ -37,8 +37,7 @@ def compare(data, reference_file, rtol=1e-8, atol=1e-12):
             assert ref[i] == approx(data[i], rel=rtol, abs=atol)
     else:
         # Generate the output file for the first time
-        warnings.warn('Generating test data file:' +
-                        Path(reference_file).resolve())
+        warnings.warn('Generating test data file:' + Path(reference_file).resolve())
         np.savetxt(reference_file, data, fmt='%.10e')
 
 def compareProfiles(reference, sample, rtol=1e-5, atol=1e-12, xtol=1e-5):

--- a/test/python/utilities.py
+++ b/test/python/utilities.py
@@ -1,117 +1,13 @@
 import numpy as np
-from os import environ
-import warnings
-import tempfile
 from pathlib import Path, PurePath
 import pytest
+import warnings
 
 try:
     from ruamel import yaml
 except ImportError:
     import ruamel_yaml as yaml
 
-import cantera
-
-slow_test = pytest.mark.skipif(environ.get("CT_SKIP_SLOW", "0") == "1", reason="slow test")
-
-TEST_DATA_PATH = Path(__file__).parents[1] / "data"
-CANTERA_DATA_PATH = Path(cantera.__file__).parent / "data"
-
-
-@pytest.fixture
-def allow_deprecated():
-    cantera.suppress_deprecation_warnings()
-    yield
-    cantera.make_deprecation_warnings_fatal()
-
-
-@pytest.fixture
-def has_temperature_derivative_warnings():
-    with pytest.warns(UserWarning, match="ddTScaledFromStruct"):
-        # test warning raised for BlowersMasel and TwoTempPlasma derivatives
-        yield
-
-@pytest.fixture(scope="session")
-def load_yaml():
-    """
-    Fixture to load YAML files safely.
-    """
-    def _load(yml_file):
-        try:
-            yaml_parser = yaml.YAML(typ="safe")
-            with open(yml_file, "rt", encoding="utf-8") as stream:
-                return yaml_parser.load(stream)
-        except yaml.constructor.ConstructorError:
-            with open(yml_file, "rt", encoding="utf-8") as stream:
-                # Ensure that the loader remains backward-compatible with legacy
-                # ruamel.yaml versions (prior to 0.17.0).
-                return yaml.safe_load(stream)
-    return _load
-
-@pytest.fixture(scope="session", autouse=True)
-def cantera_setup():
-    """
-    Fixture to set up Cantera environment for the entire test session.
-    """
-    # Add data directories
-    cantera.add_directory(TEST_DATA_PATH)
-    cantera.add_directory(CANTERA_DATA_PATH)
-    cantera.print_stack_trace_on_segfault()
-    cantera.CanteraError.set_stack_trace_depth(20)
-
-    # Yield control to tests
-    yield
-
-
-@pytest.fixture(scope="class", autouse=True)
-def test_work_path(request):
-    """
-    Fixture to create a working directory for a test class.
-    This will only run for class-based tests.
-
-    The check on the request.cls attribute is to ensure that this fixture
-    does not run for function-based tests. There is likely a better way to
-    do this, perhaps by disabling autouse and using the fixture explicitly
-    in the test classes that need it.
-    """
-
-    if request.cls is None:
-        # If this is not a class-based test, do nothing.
-        yield
-        return
-
-    root_dir = Path(__file__).parents[2].resolve()
-    if (root_dir / "SConstruct").is_file():
-        work_path = root_dir / "test" / "work" / "python"
-        using_tempfile = False
-        try:
-            work_path.mkdir(parents=True, exist_ok=True)
-        except FileNotFoundError:
-            work_path = Path(tempfile.mkdtemp())
-            using_tempfile = True
-    else:
-        work_path = Path(tempfile.mkdtemp())
-        using_tempfile = True
-
-    cantera.add_directory(work_path)
-    cantera.make_deprecation_warnings_fatal()
-
-    # Assign to the test class
-    request.cls.test_work_path = work_path
-    request.cls.using_tempfile = using_tempfile
-    request.cls.test_data_path = TEST_DATA_PATH
-    request.cls.cantera_data_path = CANTERA_DATA_PATH
-
-    yield
-
-    # Teardown: Remove the working directory if it was a temporary one
-    if using_tempfile:
-        try:
-            for f in work_path.glob("*.*"):
-                f.unlink()
-            work_path.rmdir()
-        except FileNotFoundError:
-            pass
 
 # Custom assertions functions
 def assertIsFinite(value):


### PR DESCRIPTION
Updating the python unit tests to use pytest uniformly in all the tests. Ray had mentioned at one point that the pytest transition was going a bit slow, so I thought I'd give it a shot. I still have about 3 test files left, and they are quite large.

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
