### PR TITLE
Fix non-working donation links

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -118,11 +118,11 @@ NumFOCUS
 Cantera is a fiscally-sponsored project of `NumFOCUS <https://numfocus.org>`__,
 a non-profit dedicated to supporting the open source scientific computing
 community. Please consider `making a donation
-<https://numfocus.salsalabs.org/donate-to-cantera/index.html>`__ to support the
+<https://numfocus.org/donate-to-cantera>`__ to support the
 development of Cantera through NumFOCUS.
 
 .. image:: https://img.shields.io/badge/powered%20by-NumFOCUS-orange.svg?style=flat&colorA=E1523D&colorB=007D8A
-    :target: https://numfocus.salsalabs.org/donate-to-cantera/index.html
+    :target: https://numfocus.org/donate-to-cantera
     :alt: Powered by NumFOCUS
 
 .. |cantera| image:: https://cantera.org/assets/img/cantera-logo.png

--- a/doc/sphinx/_templates/numfocus.html
+++ b/doc/sphinx/_templates/numfocus.html
@@ -1,5 +1,5 @@
 <div id="numfocus">
-<a href="https://numfocus.salsalabs.org/donate-to-cantera/index.html"
+<a href="https://numfocus.org/donate-to-cantera"
    class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-secondary reference external"
    type="button">Donate to Cantera</a>
 <a href="https://numfocus.org/"><img src="{{pathto("_static/images/powered_by_NumFOCUS.svg", 1) }}" border="0" alt="NumFOCUS"/></a>


### PR DESCRIPTION
Fix non-working Salsa Labs hosted donation pages with links to NumFOCUS website. This is similar to the change done in
https://github.com/Cantera/cantera-website/pull/93.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
