### PR TITLE
Remove workaround for cibuildwheel problem

### DIFF
--- a/interfaces/python_sdist/pyproject.toml.in
+++ b/interfaces/python_sdist/pyproject.toml.in
@@ -96,11 +96,6 @@ before-build = "pip install delvewheel"
 repair-wheel-command = "delvewheel repair --add-path %HDF5_LIB_DIR%;%ZLIB_LIB_DIR% -w {dest_dir} {wheel}"
 test-command = "pytest -vv --durations=100 %CANTERA_TEST_DIR%\\test\\python"
 
-[[tool.cibuildwheel.overrides]]
-select = "*_aarch64*"
-# Work around https://github.com/pypa/cibuildwheel/issues/1771
-container-engine = { name = "docker", create-args = ["--platform", "linux/arm64"]}
-
 [tool.cibuildwheel.macos]
 # https://cibuildwheel.pypa.io/en/stable/faq/#macos-passing-dyld_library_path-to-delocate
 repair-wheel-command = """\


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Remove the workaround for pypa/cibuildwheel#1771
- Requires Cantera/pypi-packages#7

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
