### PR TITLE
Restore compatibility with expected minimum Cython version

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -59,7 +59,7 @@ jobs:
           select-by-folder: /home/runner/work/cantera/cantera/test/matlab_experimental
 
   ubuntu-multiple-pythons:
-    name: ${{ matrix.os }} with Python ${{ matrix.python-version }}, Numpy ${{ matrix.numpy || 'latest' }}
+    name: ${{ matrix.os }} with Python ${{ matrix.python-version }}, Numpy ${{ matrix.numpy || 'latest' }}, Cython ${{ matrix.cython || 'latest' }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 60
     strategy:
@@ -67,11 +67,19 @@ jobs:
         python-version: ['3.8', '3.10', '3.11', '3.12']
         os: ['ubuntu-20.04', 'ubuntu-22.04']
         numpy: ['']
+        cython: ['']
         include:
           # Keep some test cases with NumPy 1.x until we drop support
         - python-version: '3.12'
           os: 'ubuntu-24.04'
           numpy: "'<2.0'"
+          # Keep some test cases with older Cython versions
+        - python-version: '3.10'
+          os: 'ubuntu-24.04'
+          cython: "==0.29.31" # minimum supported version
+        - python-version: '3.11'
+          os: 'ubuntu-24.04'
+          cython: "==3.0.8" # System version for Ubuntu 24.04
 
       fail-fast: false
     steps:
@@ -95,8 +103,8 @@ jobs:
     - name: Install Python dependencies
       run: |
         python3 -m pip install ruamel.yaml scons==3.1.2 numpy${{ matrix.numpy }} \
-          cython pandas pytest pytest-github-actions-annotate-failures pytest-xdist \
-          pint graphviz
+          cython${{ matrix.cython }} pandas pytest \
+          pytest-github-actions-annotate-failures pytest-xdist pint graphviz
     - name: Build Cantera
       run: |
         python3 `which scons` build env_vars=all -j4 debug=n --debug=time \

--- a/interfaces/cython/cantera/func1.pxd
+++ b/interfaces/cython/cantera/func1.pxd
@@ -59,6 +59,6 @@ cdef class Func1:
     cdef object exception
     cpdef void _set_callback(self, object) except *
     @staticmethod
-    cdef shared_ptr[CxxFunc1] _make_cxx_func1(string, tuple)
+    cdef shared_ptr[CxxFunc1] _make_cxx_func1(string, tuple) except *
     @staticmethod
     cdef Func1 _make_func1(shared_ptr[CxxFunc1])

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -152,7 +152,7 @@ cdef class Func1:
         return pystr(self.func.type())
 
     @staticmethod
-    cdef shared_ptr[CxxFunc1] _make_cxx_func1(string cxx_string, tuple args):
+    cdef shared_ptr[CxxFunc1] _make_cxx_func1(string cxx_string, tuple args) except *:
         """Create C++ functor from type specifier and arguments."""
         cdef shared_ptr[CxxFunc1] func
         cdef Func1 f0
@@ -244,7 +244,15 @@ cdef class Func1:
         if not isinstance(other, Func1):
             other = Func1(other)
         cdef Func1 f1 = other
-        return Func1._make_func1(CxxNewSumFunction(self._func, f1._func))
+
+        # @todo: When dropping support for Cython < 3.0.0, 'f0' can be removed and
+        # 'self._func' can be used directly in the C++ call
+        cdef Func1 f0
+        if isinstance(self, Func1):
+            f0 = self
+        else:
+            f0 = Func1(self)
+        return Func1._make_func1(CxxNewSumFunction(f0._func, f1._func))
 
     def __radd__(self, other):
         if not isinstance(other, Func1):
@@ -256,7 +264,15 @@ cdef class Func1:
         if not isinstance(other, Func1):
             other = Func1(other)
         cdef Func1 f1 = other
-        return Func1._make_func1(CxxNewDiffFunction(self._func, f1._func))
+
+        # @todo: When dropping support for Cython < 3.0.0, 'f0' can be removed and
+        # 'self._func' can be used directly in the C++ call
+        cdef Func1 f0
+        if isinstance(self, Func1):
+            f0 = self
+        else:
+            f0 = Func1(self)
+        return Func1._make_func1(CxxNewDiffFunction(f0._func, f1._func))
 
     def __rsub__(self, other):
         if not isinstance(other, Func1):
@@ -268,7 +284,14 @@ cdef class Func1:
         if not isinstance(other, Func1):
             other = Func1(other)
         cdef Func1 f1 = other
-        return Func1._make_func1(CxxNewProdFunction(self._func, f1._func))
+        # @todo: When dropping support for Cython < 3.0.0, 'f0' can be removed and
+        # 'self._func' can be used directly in the C++ call
+        cdef Func1 f0
+        if isinstance(self, Func1):
+            f0 = self
+        else:
+            f0 = Func1(self)
+        return Func1._make_func1(CxxNewProdFunction(f0._func, f1._func))
 
     def __rmul__(self, other):
         if not isinstance(other, Func1):
@@ -280,7 +303,14 @@ cdef class Func1:
         if not isinstance(other, Func1):
             other = Func1(other)
         cdef Func1 f1 = other
-        return Func1._make_func1(CxxNewRatioFunction(self._func, f1._func))
+        # @todo: When dropping support for Cython < 3.0.0, 'f0' can be removed and
+        # 'self._func' can be used directly in the C++ call
+        cdef Func1 f0
+        if isinstance(self, Func1):
+            f0 = self
+        else:
+            f0 = Func1(self)
+        return Func1._make_func1(CxxNewRatioFunction(f0._func, f1._func))
 
     def __rtruediv__(self, other):
         if not isinstance(other, Func1):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

The stated minimum version of Cython is 0.29.31, in both the documentation of the dependencies and as checked by SCons. However, Cantera currently fails to compile except with Cython 3.0.0 and newer due to differences in the way `__add__`/`__radd__` and related operators are implemented.

While I expect we'll probably drop support for anything older than Cython 3.0.0 after the Cantera 3.1 release, I'd like to maintain support for these older versions for the time being.

This also updates the CI configuration to make sure we're testing more than just the latest and greatest Cython version.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
