### PR TITLE
Extend functionality of LinearBurkeRate

### DIFF
--- a/doc/doxygen/cantera.bib
+++ b/doc/doxygen/cantera.bib
@@ -442,6 +442,8 @@
     doi = {10.1016/j.proci.2024.105779},
     url = {https://doi.org/10.1016/j.proci.2024.105779},
     volume = {40},
+    number = {1--4},
+    pages = {105779},
     year = {2024}}
 @article{stewart1989,
     author = {P.~H.~Stewart and C.~W.~Larson and D.~Golden},

--- a/include/cantera/kinetics/LinearBurkeRate.h
+++ b/include/cantera/kinetics/LinearBurkeRate.h
@@ -4,11 +4,13 @@
 
 #ifndef CT_LINEARBURKERATE_H
 #define CT_LINEARBURKERATE_H
+
 #include "cantera/kinetics/Arrhenius.h"
-#include <boost/variant.hpp>
 #include "cantera/kinetics/Falloff.h"
 #include "cantera/kinetics/ChebyshevRate.h"
 #include "cantera/kinetics/PlogRate.h"
+
+#include <variant>
 
 namespace Cantera
 {
@@ -96,9 +98,9 @@ public:
     void getParameters(AnyMap& rateNode) const override;
 
     //! Type alias that refers to PlogRate, TroeRate, and ChebyshevRate
-    using RateTypes = boost::variant<PlogRate, TroeRate, ChebyshevRate>;
+    using RateTypes = std::variant<PlogRate, TroeRate, ChebyshevRate>;
     //! Type alias that refers to PlogData, FalloffData, and ChebyshevData
-    using DataTypes = boost::variant<PlogData, FalloffData, ChebyshevData>;
+    using DataTypes = std::variant<PlogData, FalloffData, ChebyshevData>;
 
     double evalFromStruct(const LinearBurkeData& shared_data);
 

--- a/include/cantera/kinetics/LinearBurkeRate.h
+++ b/include/cantera/kinetics/LinearBurkeRate.h
@@ -129,9 +129,8 @@ protected:
     //! Index of each collider in the kinetics object species list where the vector
     //! elements appear in the same order as that of the original reaction input.
     vector<size_t> m_colliderIndices;
-
-    //! Allows data from setParameters() to be later accessed by getParameters()
-    map<string, AnyMap> m_colliderInfo;
+    //! Indicates which colliders have a distinct k(T,P) versus only an efficiency
+    vector<bool> m_hasRateConstant;
 
     //! Third-body collision efficiency object for k(T,P,X) and eig0_mix calculation
     vector<ArrheniusRate> m_epsObjs1;

--- a/include/cantera/kinetics/LinearBurkeRate.h
+++ b/include/cantera/kinetics/LinearBurkeRate.h
@@ -153,8 +153,6 @@ protected:
     //! Stores data objects corresponding to each non-M collider, which can be either
     //! PlogData, TroeData, or ChebyshevData
     vector<DataTypes> m_dataObjs; //!< list for non-M colliders
-
-    size_t m_nSpecies; //!< total number of species in the kinetics object
 };
 
 }

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -667,8 +667,17 @@ cdef class LinearBurkeRate(ReactionRate):
     """
     _reaction_rate_type = "linear-Burke"
 
-    def __cinit__(self, rates=None, input_data=None, init=True):
+    def __cinit__(self, input_data=None, init=True):
         self.set_cxx_object()
+
+        if init:
+            if isinstance(input_data, dict):
+                self._rate.reset(new CxxLinearBurkeRate(py_to_anymap(input_data)))
+            elif input_data:
+                raise TypeError("'input_data' must be a dict")
+            else:
+                raise ValueError("No input data provided")
+            self.set_cxx_object()
 
     cdef CxxLinearBurkeRate* cxx_object(self):
         return <CxxLinearBurkeRate*>self.rate

--- a/samples/python/kinetics/jet_stirred_reactor.py
+++ b/samples/python/kinetics/jet_stirred_reactor.py
@@ -26,7 +26,7 @@ References:
 
     [3] P. J. Singal, J. Lee, L. Lei, R. L. Speth, M. P. Burke, Implementation of New
     Mixture Rules Has a Substantial Impact on Combustion Predictions for H2 and NH3,
-    Proc. Combust. Inst. 40 (2024).
+    Proc. Combust. Inst. 40 (2024) 105779.
 
 Requires: cantera >= 3.1, pandas, matplotlib
 

--- a/samples/python/kinetics/shock_tube.py
+++ b/samples/python/kinetics/shock_tube.py
@@ -25,7 +25,7 @@ References:
 
     [3] P. J. Singal, J. Lee, L. Lei, R. L. Speth, M. P. Burke, Implementation of New
     Mixture Rules Has a Substantial Impact on Combustion Predictions for H2 and NH3,
-    Proc. Combust. Inst. 40 (2024).
+    Proc. Combust. Inst. 40 (2024) 105779.
 
 Requires: cantera >= 3.1, matplotlib
 

--- a/samples/python/onedim/flame_speed.py
+++ b/samples/python/onedim/flame_speed.py
@@ -22,7 +22,7 @@ References:
 
     [3] P. J. Singal, J. Lee, L. Lei, R. L. Speth, M. P. Burke, Implementation of New
     Mixture Rules Has a Substantial Impact on Combustion Predictions for H2 and NH3,
-    Proc. Combust. Inst. 40 (2024).
+    Proc. Combust. Inst. 40 (2024) 105779.
 
 Requires: cantera >= 3.1
 

--- a/src/kinetics/LinearBurkeRate.cpp
+++ b/src/kinetics/LinearBurkeRate.cpp
@@ -292,6 +292,7 @@ double LinearBurkeRate::evalFromStruct(const LinearBurkeData& shared_data)
     // logPeff = shared_data.logP + log(eps_mix) - log(eps_M)
     // but log(eps_M)=0 always
     logPeff = shared_data.logP + log(eps_mix);
+
     // We actually have
     // k_LMR_+=evalPlogRate(shared_data,m_dataObj_M,m_rateObj_M)*eps_M*sigmaX_M/eps_mix
     // k_LMR_+=evalTroeRate(shared_data,m_dataObj_M,m_rateObj_M)*eps_M*sigmaX_M/eps_mix

--- a/test/data/kineticsfromscratch.yaml
+++ b/test/data/kineticsfromscratch.yaml
@@ -101,6 +101,23 @@ reactions:
 - equation: O + H2 + M <=> H2O + M  # Reaction 14
   type: Blowers-Masel
   rate-constant: {A: 38700, b: 2.7, Ea0: 2.619184e4, w: 4.184e9}
+- equation: H + OH <=> H2O  # Reaction 15
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: pressure-dependent-Arrhenius
+    rate-constants:
+    - {P: 1.000e-01 atm, A: 5.13043e+15, b: -2.80388e+00, Ea: 5.08801e+02}
+    - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+    - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+  - name: O2
+    type: falloff
+    efficiency: {A: 1.24932e+02, b: -5.93263e-01, Ea: 5.40921e+02}
+    low-P-rate-constant: {A: 6.366e+20, b: -1.72, Ea: 524.8}
+    high-P-rate-constant: {A: 4.7e+12, b: 0.44, Ea: 0.0}
+    Troe: {A: 0.5, T3: 1.0e-30, T1: 1.0e+30}
 
 surface:
 - units: {length: cm, quantity: mol, activation-energy: J/mol}

--- a/test/data/linearBurke-test.yaml
+++ b/test/data/linearBurke-test.yaml
@@ -12,7 +12,7 @@ description: |-
 
     [2] P. J. Singal, J. Lee, L. Lei, R. L. Speth, M. P. Burke, Implementation of New
     Mixture Rules Has a Substantial Impact on Combustion Predictions for H2 and NH3,
-    Proc. Combust. Inst. 40 (2024).
+    Proc. Combust. Inst. 40 (2024) 105779.
 
 units: {length: cm, time: s, quantity: mol, activation-energy: cal/mol}
 

--- a/test/data/linearBurke-test.yaml
+++ b/test/data/linearBurke-test.yaml
@@ -35,6 +35,14 @@ phases:
   transport: mixture-averaged
   state: {T: 300.0, P: 1 atm}
 
+- name: linear-Burke-complex
+  thermo: ideal-gas
+  species:
+  - pdep-test.yaml/species: all
+  kinetics: bulk
+  reactions: [reactions-complex]
+  state: {T: 300.0, P: 1 atm}
+
 species:
 - name: H
   composition: {H: 1}
@@ -247,6 +255,78 @@ linear-Burke_reactions:
       1.5925e-03]
   - name: H2O
     efficiency: {A: 10, b: 0, Ea: 0}
+
+# A more complex linear-Burke definition with multiple colliders that use different
+# parameterizations. Duplicate reactions using the baseline parameterizations are
+# included for rate comparisons
+reactions-complex:
+- equation: R1A + R1B (+M) <=> P1 + H (+M) # Reaction 1
+  type: linear-Burke
+  duplicate: true
+  colliders:
+  - name: M
+    type: Chebyshev
+    temperature-range: [300.0, 2000.0]
+    pressure-range: [1e3, 1e7]
+    data:
+    - [8.2883, -1.1397, -0.12059, 0.016034]
+    - [1.9764, 1.0037, 7.2865e-03, -0.030432]
+    - [0.3177, 0.26889, 0.094806, -7.6385e-03]
+    - [-0.031285, -0.039412, 0.044375, 0.014458]
+  - name: P3A
+    efficiency: {A: 3.0, b: 0.0, Ea: 0.0}
+    type: pressure-dependent-Arrhenius
+    rate-constants:
+    - {P: 0.01 atm, A: 1.2124e+16, b: -0.5779, Ea: 1.08727e+04}
+    - {P: 1.0 atm, A: 4.9108e+31, b: -4.8507, Ea: 2.47728e+04}
+    - {P: 10.0 atm, A: 1.2866e+47, b: -9.0246, Ea: 3.97965e+04}
+    - {P: 100.0 atm, A: 5.9632e+56, b: -11.529, Ea: 5.25996e+04}
+  - name: P3B
+    efficiency: {A: 5.0, b: 0.0, Ea: 0.0}
+    type: falloff
+    low-P-rate-constant: {A: 2.3e+18, b: -0.9, Ea: -1700.0}
+    high-P-rate-constant: {A: 7.4e+13, b: -0.37, Ea: 0.0}
+    Troe: {A: 0.7346, T3: 94.0, T1: 1756.0, T2: 5182.0}
+  - name: P5A  # identical rate to M, unity efficiency
+    type: Chebyshev
+    efficiency: {A: 1.0, b: 0.0, Ea: 0.0}
+    temperature-range: [300.0, 2000.0]
+    pressure-range: [1e3, 1e7]
+    data:
+    - [8.2883, -1.1397, -0.12059, 0.016034]
+    - [1.9764, 1.0037, 7.2865e-03, -0.030432]
+    - [0.3177, 0.26889, 0.094806, -7.6385e-03]
+    - [-0.031285, -0.039412, 0.044375, 0.014458]
+  - name: R6
+    efficiency: {A: 7.0, b: 0.0, Ea: 0.0}
+
+- equation: R1A + R1B <=> P1 + H  # M for Reaction 1
+  type: Chebyshev
+  duplicate: true
+  temperature-range: [300.0, 2000.0]
+  pressure-range: [1e3, 1e7]
+  data:
+  - [8.2883, -1.1397, -0.12059, 0.016034]
+  - [1.9764, 1.0037, 7.2865e-03, -0.030432]
+  - [0.3177, 0.26889, 0.094806, -7.6385e-03]
+  - [-0.031285, -0.039412, 0.044375, 0.014458]
+
+- equation: R1A + R1B <=> P1 + H  # collider P3A for Reaction 1
+  type: pressure-dependent-Arrhenius
+  duplicate: true
+  rate-constants:
+  - {P: 0.01 atm, A: 1.2124e+16, b: -0.5779, Ea: 1.08727e+04}
+  - {P: 1.0 atm, A: 4.9108e+31, b: -4.8507, Ea: 2.47728e+04}
+  - {P: 10.0 atm, A: 1.2866e+47, b: -9.0246, Ea: 3.97965e+04}
+  - {P: 100.0 atm, A: 5.9632e+56, b: -11.529, Ea: 5.25996e+04}
+
+- equation: R1A + R1B (+M) <=> P1 + H (+M)  # collider P3B for Reaction 1
+  type: falloff
+  duplicate: true
+  low-P-rate-constant: {A: 2.3e+18, b: -0.9, Ea: -1700.0}
+  high-P-rate-constant: {A: 7.4e+13, b: -0.37, Ea: 0.0}
+  Troe: {A: 0.7346, T3: 94.0, T1: 1756.0, T2: 5182.0}
+
 
 # Invalid reaction definitions to test various input errors
 

--- a/test/data/linearBurke-test.yaml
+++ b/test/data/linearBurke-test.yaml
@@ -219,6 +219,7 @@ linear-Burke_reactions:
     low-P-rate-constant: {A: 6.366e+20, b: -1.72, Ea: 524.8}
     high-P-rate-constant: {A: 4.7e+12, b: 0.44, Ea: 0.0}
     Troe: {A: 0.5, T3: 1.0e-30, T1: 1.0e+30}
+    efficiency: {A: 1.0, b: 0.0, Ea: 0}
   - name: H2O
     efficiency: {A: 10, b: 0, Ea: 0}
 
@@ -246,3 +247,151 @@ linear-Burke_reactions:
       1.5925e-03]
   - name: H2O
     efficiency: {A: 10, b: 0, Ea: 0}
+
+# Invalid reaction definitions to test various input errors
+
+reactions-no-colliders:
+- equation: H + O2 (+M) <=> HO2 (+M)
+  type: linear-Burke
+  name: M
+  low-P-rate-constant: {A: 6.366e+20, b: -1.72, Ea: 524.8}
+  high-P-rate-constant: {A: 4.7e+12, b: 0.44, Ea: 0.0}
+  Troe: {A: 0.5, T3: 1.0e-30, T1: 1.0e+30}
+
+reactions-no-name-first:
+- equation: H + O2 (+M) <=> HO2 (+M)
+  type: linear-Burke
+  colliders:
+  - type: falloff
+    low-P-rate-constant: {A: 6.366e+20, b: -1.72, Ea: 524.8}
+    high-P-rate-constant: {A: 4.7e+12, b: 0.44, Ea: 0.0}
+    Troe: {A: 0.5, T3: 1.0e-30, T1: 1.0e+30}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+
+reactions-no-name-later:
+- equation: H + O2 (+M) <=> HO2 (+M)
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: falloff
+    low-P-rate-constant: {A: 6.366e+20, b: -1.72, Ea: 524.8}
+    high-P-rate-constant: {A: 4.7e+12, b: 0.44, Ea: 0.0}
+    Troe: {A: 0.5, T3: 1.0e-30, T1: 1.0e+30}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+  - type: pressure-dependent-Arrhenius
+    rate-constants:
+    - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+    - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+    efficiency: {A: 3.0, b: 0, Ea: 0}
+
+reactions-no-M:
+- equation: H + OH <=> H2O
+  type: linear-Burke
+  colliders:
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+
+reactions-missing-eig0:
+- equation: H + OH <=> H2O
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: pressure-dependent-Arrhenius
+    rate-constants:
+    - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+    - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+    eig0: {A: 2.20621e-02, b: 4.74036e-01, Ea: -1.13148e+02}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+
+reactions-missing-efficiency:
+- equation: H + OH <=> H2O
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: pressure-dependent-Arrhenius
+    rate-constants:
+    - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+    - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+  - name: H2O
+    type: falloff
+    low-P-rate-constant: {A: 2.4e+14, b: 0.206, Ea: -1550.0}
+    high-P-rate-constant: {A: 1.5e+15, b: -0.41, Ea: 0.0}
+    Troe: {A: 0.82, T3: 1.0e-30, T1: 1.0e+30, T2: 1.0e+30}
+
+reactions-eig0-and-efficiency:
+- equation: H + O2 (+M) <=> HO2 (+M)
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: pressure-dependent-Arrhenius
+    rate-constants:
+    - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+    - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+  - name: AR
+    efficiency: {A: 5, b: 0, Ea: 0}
+    eig0: {A: 2.4e+14, b: 0.206, Ea: -1550.0}
+
+reactions-missing-M-rate:
+- equation: H + OH <=> H2O
+  type: linear-Burke
+  colliders:
+  - name: M
+    rate-constants:
+    - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+    - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+
+reactions-bad-M-rate:
+- equation: H + OH <=> H2O
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: Arrhenius
+    rate-constant: {A: 4.7e+12, b: 0.44, Ea: 0.0}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+
+reactions-bad-M-efficiency:
+- equation: H + O2 (+M) <=> HO2 (+M)
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: falloff
+    low-P-rate-constant: {A: 6.366e+20, b: -1.72, Ea: 524.8}
+    high-P-rate-constant: {A: 4.7e+12, b: 0.44, Ea: 0.0}
+    Troe: {A: 0.5, T3: 1.0e-30, T1: 1.0e+30}
+    efficiency: {A: 1.0, b: 0.5, Ea: 0}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+
+reactions-bad-other-rate:
+- equation: H + OH <=> H2O
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: pressure-dependent-Arrhenius
+    rate-constants:
+    - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+    - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+  - name: H2O
+    efficiency: {A: 10, b: 0, Ea: 0}
+    type: Arrhenius
+    rate-constant: {A: 1.6e+34, b: -5.49, Ea: 1987.0}
+
+reactions-negative-efficiency:
+- equation: H + OH <=> H2O
+  type: linear-Burke
+  colliders:
+  - name: M
+    type: pressure-dependent-Arrhenius
+    rate-constants:
+    - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+    - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+  - name: AR
+    efficiency: {A: -3.1, b: 0.5, Ea: 0}

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -1479,56 +1479,20 @@ class TestPlogReaction:
         assert kf[0] != approx(kf[1])
 
 class TestLinearBurkeReaction:
-    def test_linearburke_plog(self):
-        reaction = "H + OH <=> H2O"
-        gas_baseline = ct.Solution('linearBurke-test.yaml',
-                                   name='baseline_mechanism')
-        gas_linearBurke = ct.Solution('linearBurke-test.yaml',
-                                      name='linear-Burke_mechanism')
-        T = 1000 # [K]
-        P_ls = [0.1,1,10,100] # [atm]
-        for P in P_ls:
-            def getK(gas, T, P, X):
-                gas.TPX = T,P,X
-                eqn = gas.reaction_equations().index(reaction)
-                return gas.forward_rate_constants[eqn]
-            # collider 'O2' treated as M in this test reaction
-            k_baseline = getK(gas_baseline, T, P,'O2:1')
-            k_linearBurke = getK(gas_linearBurke, T, P,'O2:1')
-            assert k_baseline == approx(k_linearBurke)
-            # collider 'H2O' must behave as 'M' if 'M' were eval. at 10x the pressure
-            k_baseline = getK(gas_baseline, T, P*10,'H2O:1')
-            k_linearBurke = getK(gas_linearBurke, T, P,'H2O:1')
-            assert k_baseline == approx(k_linearBurke)
+    @pytest.fixture(scope='class')
+    def gas_baseline(self):
+        return ct.Solution('linearBurke-test.yaml', name='baseline_mechanism')
 
-    def test_linearburke_troe(self):
-        reaction = "H + O2 (+M) <=> HO2 (+M)"
-        gas_baseline = ct.Solution('linearBurke-test.yaml',
-                                   name='baseline_mechanism')
-        gas_linearBurke = ct.Solution('linearBurke-test.yaml',
-                                      name='linear-Burke_mechanism')
-        T = 1000 # [K]
-        P_ls = [0.1,1,10,100] # [atm]
-        for P in P_ls:
-            def getK(gas, T, P, X):
-                gas.TPX = T,P,X
-                eqn = gas.reaction_equations().index(reaction)
-                return gas.forward_rate_constants[eqn]
-            # collider 'O2' treated as M in this test reaction
-            k_baseline = getK(gas_baseline, T, P,'O2:1')
-            k_linearBurke = getK(gas_linearBurke, T, P,'O2:1')
-            assert k_baseline == approx(k_linearBurke)
-            # collider 'H2O' must behave as 'M' if 'M' were eval. at 10x the pressure
-            k_baseline = getK(gas_baseline, T, P*10,'H2O:1')
-            k_linearBurke = getK(gas_linearBurke, T, P,'H2O:1')
-            assert k_baseline == approx(k_linearBurke)
+    @pytest.fixture(scope='class')
+    def gas_linearBurke(self):
+        return ct.Solution('linearBurke-test.yaml', name='linear-Burke_mechanism')
 
-    def test_linearburke_chebyshev(self):
-        reaction = "H2O2 <=> 2 OH"
-        gas_baseline = ct.Solution('linearBurke-test.yaml',
-                                   name='baseline_mechanism')
-        gas_linearBurke = ct.Solution('linearBurke-test.yaml',
-                                      name='linear-Burke_mechanism')
+    @pytest.mark.parametrize("reaction", [
+        pytest.param("H + OH <=> H2O", id="PLOG"),
+        pytest.param("H + O2 (+M) <=> HO2 (+M)", id="Troe"),
+        pytest.param("H2O2 <=> 2 OH", id="Chebyshev"),
+    ])
+    def test_efficiency(self, gas_baseline, gas_linearBurke, reaction):
         T = 1000 # [K]
         P_ls = [0.1,1,10,100] # [atm]
         for P in P_ls:

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -810,6 +810,41 @@ class TestLinearBurkeRate(ReactionRateTests):
             ct.Reaction.list_from_file("linearBurke-test.yaml", self.soln,
                                        f"reactions-{section}")
 
+    def test_serialization1(self):
+        gas = ct.Solution("linearBurke-test.yaml", "linear-Burke_mechanism")
+        Mdata = []
+        for R in gas.reactions():
+            R.clear_user_data()
+            colliders = R.input_data["colliders"]
+            assert colliders[0]["name"] == "M"
+            Mdata.append(colliders[0])
+
+        assert Mdata[0]["type"] == "pressure-dependent-Arrhenius"
+        assert len(Mdata[0]["rate-constants"]) == 9
+        assert Mdata[1]["type"] == "falloff"
+        assert "Troe" in Mdata[1]
+        assert Mdata[2]["type"] == "Chebyshev"
+        assert Mdata[2]["data"][0][0] == approx(-1.5843e+01)
+
+    def test_serialization2(self):
+        gas = ct.Solution("linearBurke-test.yaml", "linear-Burke-complex")
+        rdata = []
+        for R in gas.reactions():
+            R.clear_user_data()
+            rdata.append(R.input_data)
+        colliders = rdata[0]["colliders"]
+
+        for field in ["type", "temperature-range", "pressure-range", "data"]:
+            assert colliders[0][field] == rdata[1][field], field
+        for field in ["type", "rate-constants"]:
+            assert colliders[1][field] == rdata[2][field], field
+        for field in ["type", "low-P-rate-constant", "high-P-rate-constant", "Troe"]:
+            assert colliders[2][field] == rdata[3][field], field
+        for field in ["type", "temperature-range", "pressure-range", "data"]:
+            assert colliders[3][field] == rdata[1][field], field
+        assert colliders[4] == {"name": "R6", "efficiency": {"A": 7, "b": 0, "Ea": 0}}
+
+
 class SurfaceReactionRateTests(ReactionRateTests):
     """Test suite for surface reaction rate expressions"""
 

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -730,6 +730,68 @@ class TestChebyshevRate(ReactionRateTests):
         assert rate.n_temperature == rate.data.shape[0]
 
 
+class TestLinearBurkeRate(ReactionRateTests):
+    _cls = ct.LinearBurkeRate
+    _type = "linear-Burke"
+    _index = 14
+    _input = {
+        "colliders": [
+            {"name": "M",
+             "type": "pressure-dependent-Arrhenius",
+             "rate-constants": [
+                 {"P": 10132.5, "A": 5.13043e+15, "b": -2.80388, "Ea": 5.08801e+02 * 4184},
+                 {"P": 101325.0, "A": 5.47458e+16, "b": -2.81214, "Ea": 5.50629e+02 * 4184},
+                 {"P": 1013250.0, "A": 1.04665e+18, "b": -2.89077, "Ea": 8.27164e+02 * 4184},
+             ],
+            },
+            {"name": "H2O",
+             "efficiency": {"A": 10, "b": 0, "Ea": 0}},
+            {"name": "O2",
+             "type": "falloff",
+             "efficiency": {"A": 1.24932e+02, "b": -5.93263e-01, "Ea": 5.40921e+02 * 4184},
+             "low-P-rate-constant": [6.366e+20, -1.72, 524.8 * 4184],
+             "high-P-rate-constant": [4.7e+12, 0.44, 0.0],
+             "Troe": {"A": 0.5, "T3": 1.0e-30, "T1": 1.0e+30}
+            },
+        ]
+    }
+    _yaml = """
+        units: {activation-energy: cal/mol}
+        type: linear-Burke
+        colliders:
+        - name: M
+          type: pressure-dependent-Arrhenius
+          rate-constants:
+          - {P: 1.000e-01 atm, A: 5.13043e+15, b: -2.80388e+00, Ea: 5.08801e+02}
+          - {P: 1.000e+00 atm, A: 5.47458e+16, b: -2.81214e+00, Ea: 5.50629e+02}
+          - {P: 1.000e+01 atm, A: 1.04665e+18, b: -2.89077e+00, Ea: 8.27164e+02}
+        - name: H2O
+          efficiency: {A: 10, b: 0, Ea: 0}
+        - name: O2
+          type: falloff
+          efficiency: {A: 1.24932e+02, b: -5.93263e-01, Ea: 5.40921e+02}
+          low-P-rate-constant: {A: 6.366e+20, b: -1.72, Ea: 524.8}
+          high-P-rate-constant: {A: 4.7e+12, b: 0.44, Ea: 0.0}
+          Troe: {A: 0.5, T3: 1.0e-30, T1: 1.0e+30}
+    """
+
+    @pytest.mark.skip("construction from parts not yet supported")
+    def test_from_parts(self):
+        pass
+
+    @pytest.mark.skip("deferred construction not yet supported")
+    def test_unconfigured(self):
+        pass
+
+    def eval(self, rate):
+        # Rate can only be evaluated in the context of a Kinetics object
+        gas = ct.Solution(thermo='ideal-gas', kinetics='bulk',
+                          species=self.soln.species())
+        gas.add_reaction(ct.Reaction(equation='H + O = OH', rate=rate))
+        gas.TPX = self.soln.TPX
+        return gas.forward_rate_constants[0]
+
+
 class SurfaceReactionRateTests(ReactionRateTests):
     """Test suite for surface reaction rate expressions"""
 

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -791,6 +791,24 @@ class TestLinearBurkeRate(ReactionRateTests):
         gas.TPX = self.soln.TPX
         return gas.forward_rate_constants[0]
 
+    @pytest.mark.parametrize("section,message", [
+        ("no-colliders", "'colliders' key missing"),
+        ("no-name-first", "'name' key missing from collider entry"),
+        ("no-name-later", "'name' key missing from collider entry"),
+        ("no-M", "The first collider must be 'M'"),
+        ("missing-eig0", "Collider 'H2O' lacks an 'eig0' key"),
+        ("missing-efficiency", "Collider 'H2O' lacks an 'efficiency' key."),
+        ("eig0-and-efficiency", "Collider 'AR' cannot contain both"),
+        ("missing-M-rate", "'type' key missing for 'M'"),
+        ("bad-M-rate", "Collider 'M' must be specified"),
+        ("bad-M-efficiency", "not necessary to provide an 'efficiency' for 'M'"),
+        ("bad-other-rate", "Collider 'H2O': 'Arrhenius' rate parameterization"),
+        ("negative-efficiency", "Invalid 'efficiency' entry for collider 'AR'"),
+    ])
+    def test_input_errors(self, section, message):
+        with pytest.raises(ct.CanteraError, match=message):
+            ct.Reaction.list_from_file("linearBurke-test.yaml", self.soln,
+                                       f"reactions-{section}")
 
 class SurfaceReactionRateTests(ReactionRateTests):
     """Test suite for surface reaction rate expressions"""


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

This wraps up a few loose ends from the main PR implementing the Burke linear mixing rule rate (#1710).

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix round-trip YAML serialization
- Enable creation in Python from `dict` input
- Add standard set of Python reaction rate tests

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
