### PR TITLE
Make generated sources and one error message deterministic

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -918,7 +918,7 @@ class SolutionArray(SolutionArrayBase):
             if valid_species:
 
                 if len(valid_species) != len(all_species):
-                    incompatible = list(set(valid_species) ^ set(all_species))
+                    incompatible = sorted(set(valid_species) ^ set(all_species))
                     raise ValueError('incompatible species information for '
                                     '{}'.format(incompatible))
 

--- a/samples/cxx/SConscript
+++ b/samples/cxx/SConscript
@@ -89,10 +89,10 @@ for sample in samples:
         incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
         incdirs.append(localenv["hdf_include"])
         incdirs.extend(localenv["extra_inc_dirs"])
-        incdirs = list(set(incdirs))
+        incdirs = sorted(set(incdirs))
 
         libdirs.extend(localenv["extra_lib_dirs"])
-        libdirs = list(set(libdirs))
+        libdirs = sorted(set(libdirs))
 
     if env["OS"] == "Darwin" and env["use_rpath_linkage"] and not env.subst("$__RPATH"):
         # SCons fails to specify RPATH on macOS, so circumvent that behavior by

--- a/samples/f77/SConscript
+++ b/samples/f77/SConscript
@@ -39,12 +39,12 @@ else:
     incdirs.extend([localenv["sundials_include"], localenv["boost_inc_dir"]])
     incdirs.append(localenv["hdf_include"])
     incdirs.extend(localenv["extra_inc_dirs"])
-    incdirs = list(set(incdirs))
+    incdirs = sorted(set(incdirs))
 
     libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
     libdirs.append(localenv["hdf_libdir"])
     libdirs.extend(localenv["extra_lib_dirs"])
-    libdirs = list(set(libdirs))
+    libdirs = sorted(set(libdirs))
 
 libs = ["cantera_fortran"] + localenv["cantera_libs"] + localenv["cxx_stdlib"]
 

--- a/samples/f90/SConscript
+++ b/samples/f90/SConscript
@@ -25,7 +25,7 @@ for programName, sources in samples:
         libdirs.extend([localenv["sundials_libdir"], localenv["blas_lapack_dir"]])
         libdirs.append(localenv["hdf_libdir"])
         libdirs.extend(localenv["extra_lib_dirs"])
-        libdirs = list(set(libdirs))
+        libdirs = sorted(set(libdirs))
 
     libs = ['cantera_fortran'] + localenv['cantera_libs'] + env['cxx_stdlib']
 


### PR DESCRIPTION
Replace `list(set(…))` by `sorted(set(…))` to avoid randomness in builds and at runtime.