### PR TITLE
Add standard CI cases using Python 3.13

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -179,14 +179,16 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        macos-version: ['macos-12', 'macos-14']
-        python-version: ['3.11', '3.12', '3.13']
+        macos-version: ['macos-13', 'macos-14', 'macos-15']
+        python-version: ['3.12', '3.13']
         include:
-          - macos-version: 'macos-12'
+          - macos-version: 'macos-13'
             python-version: '3.8'
           - macos-version: 'macos-14'
             python-version: '3.10'
             extra-build-args: cxx_flags='-std=c++20'
+          - macos-version: 'macos-15'
+            python-version: '3.11'
       fail-fast: false
     steps:
     - uses: actions/checkout@v4
@@ -218,7 +220,7 @@ jobs:
       # Pin to 4.3.4 to resolve errors around only uploading symlinks.
       # See https://github.com/actions/upload-artifact/issues/589
       uses: actions/upload-artifact@v4.3.4
-      if: matrix.python-version == '3.11' && matrix.macos-version == 'macos-12'
+      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-13'
       with:
         path: build/lib/libcantera_shared.dylib
         name: libcantera_shared.dylib

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -64,7 +64,7 @@ jobs:
     timeout-minutes: 60
     strategy:
       matrix:
-        python-version: ['3.8', '3.10', '3.11', '3.12']
+        python-version: ['3.8', '3.10', '3.11', '3.12', '3.13']
         os: ['ubuntu-20.04', 'ubuntu-22.04']
         numpy: ['']
         cython: ['']
@@ -180,7 +180,7 @@ jobs:
     strategy:
       matrix:
         macos-version: ['macos-12', 'macos-14']
-        python-version: ['3.11', '3.12']
+        python-version: ['3.11', '3.12', '3.13']
         include:
           - macos-version: 'macos-12'
             python-version: '3.8'
@@ -439,6 +439,9 @@ jobs:
         - os: "ubuntu-20.04"
           python-version: "3.12"
           numpy: ""
+        - os: "ubuntu-22.04"
+          python-version: "3.13"
+          numpy: ""
       fail-fast: false
     steps:
       # We're not building Cantera here, we only need the checkout for the samples
@@ -591,7 +594,7 @@ jobs:
           fmt-ver: '9.1'
         - python-version: '3.12'
           fmt-ver: '7.1'
-        - python-version: '3.12'
+        - python-version: '3.13'
           fmt-ver: '11.0'
           extra-build-args: cxx_flags='/EHsc /std:c++20 /utf-8'
       fail-fast: false
@@ -669,7 +672,7 @@ jobs:
     strategy:
       matrix:
         vs-toolset: ['14.2']
-        python-version: ["3.8", "3.10", "3.11", "3.12"]
+        python-version: ["3.8", "3.10", "3.11", "3.12", "3.13"]
       fail-fast: false
     steps:
       - uses: actions/checkout@v4

--- a/SConstruct
+++ b/SConstruct
@@ -182,7 +182,7 @@ else:
 # Python Package Settings
 python_min_version = parse_version("3.8")
 # Newest Python version not supported/tested by Cantera
-python_max_version = parse_version("3.13")
+python_max_version = parse_version("3.14")
 # The string is used to set python_requires in setup.cfg.in
 py_requires_ver_str = f">={python_min_version},<{python_max_version}"
 

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -434,7 +434,8 @@ protected:
     vector<string> inputDirs;
 
     //! Versions of Python to consider when attempting to load user extensions
-    vector<string> m_pythonSearchVersions = {"3.13", "3.12", "3.11", "3.10", "3.9", "3.8"};
+    vector<string> m_pythonSearchVersions = {"3.14", "3.13", "3.12", "3.11", "3.10",
+                                             "3.9", "3.8"};
 
     //! Set of deprecation warnings that have been emitted (to suppress duplicates)
     set<string> warnings;


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add standard CI runs using Python 3.13
- Update macOS runner version to include the most recent one (`macos-15`) and drop `macos-12` which is pending removal by GitHub

The one test failure is caused by the example that uses CoolProp, which has not yet been updated for Python 3.13. 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
