### PR TITLE
Fix use of kineticsSpeciesIndex in diamond_cvd examples

### DIFF
--- a/samples/matlab_experimental/diamond_cvd.m
+++ b/samples/matlab_experimental/diamond_cvd.m
@@ -56,7 +56,7 @@ surf_phase = Interface('diamond.yaml', 'diamond_100', gas, dbulk);
 
 %% Advance Coverages
 
-iC = surf_phase.kineticsSpeciesIndex('C(d)', 'diamond');
+iC = surf_phase.kineticsSpeciesIndex('C(d)');
 
 xx = [];
 rr = [];

--- a/samples/python/kinetics/diamond_cvd.py
+++ b/samples/python/kinetics/diamond_cvd.py
@@ -41,7 +41,7 @@ with open('diamond.csv', 'w', newline='') as f:
     writer.writerow(['H mole Fraction', 'Growth Rate (microns/hour)'] +
                     d.species_names)
 
-    iC = d.kinetics_species_index(dbulk.species_index('C(d)'), 1)
+    iC = d.kinetics_species_index('C(d)')
 
     for n in range(20):
         x[ih] /= 1.4


### PR DESCRIPTION
Fixes #1806

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix incorrect arguments to `kineticsSpeciesIndex` in both the Python and Matlab versions of the `diamond_cvd` example

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1806

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
