### PR TITLE
Added descriptive error text to assert statements

### DIFF
--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -230,8 +230,10 @@ class Quantity:
         else:
             self.mass = 1.0
 
-        assert constant in ('TP','TV','HP','SP','SV','UV'), 
-            "Error: constant must be one of 'TP','TV','HP','SP','SV', or 'UV'" 
+        if constant not in ('TP','TV','HP','SP','SV','UV'): 
+            raise ValueError(
+                f"Constant {constant} is invalid."
+                "Must be one of 'TP','TV','HP','SP','SV', or 'UV'")
         self.constant = constant
 
     @property
@@ -315,10 +317,13 @@ class Quantity:
 
     def __iadd__(self, other):
         if self._id != other._id:
-            raise ValueError('Cannot add Quantities with different phase '
-                'definitions.')
-        assert self.constant == other.constant,
-            "Error: Cannot add Quantities when with different constant values" 
+            raise ValueError(
+                'Cannot add Quantities with different phase '
+                f'definitions. {self._id} != {other._id}')
+        if self.constant != other.constant:
+            raise ValueError(
+                "Cannot add Quantities with different "
+                f"constant values. {self.constant} != {other.constant}")
 
         m = self.mass + other.mass
         Y = (self.Y * self.mass + other.Y * other.mass)
@@ -333,7 +338,8 @@ class Quantity:
         else:  # self.constant == 'HP'
             dp_rel = 2 * abs(self.P - other.P) / (self.P + other.P)
             if dp_rel > 1.0e-7:
-                raise ValueError('Cannot add Quantities at constant pressure when'
+                raise ValueError(
+                    'Cannot add Quantities at constant pressure when '
                     f'pressure is not equal ({self.P} != {other.P})')
 
             H = self.enthalpy + other.enthalpy
@@ -1331,7 +1337,8 @@ def _state2_prop(name, doc_source):
         return a, b
 
     def setter(self, AB):
-        assert len(AB) == 2, "Expected 2 elements, got {}".format(len(AB))
+        if len(AB) != 2: 
+            raise ValueError("Expected 2 elements, got {}".format(len(AB)))
         A, B, _ = np.broadcast_arrays(AB[0], AB[1], self._output_dummy)
         for loc, index in enumerate(self._indices):
             self._set_loc(loc)
@@ -1357,7 +1364,8 @@ def _state3_prop(name, doc_source, scalar=False):
         return a, b, c
 
     def setter(self, ABC):
-        assert len(ABC) == 3, "Expected 3 elements, got {}".format(len(ABC))
+        if len(ABC) != 3: 
+            raise ValueError("Expected 3 elements, got {}".format(len(ABC)))
         A, B, _ = np.broadcast_arrays(ABC[0], ABC[1], self._output_dummy)
         XY = ABC[2] # composition
         if len(np.shape(XY)) < 2:

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -230,7 +230,7 @@ class Quantity:
         else:
             self.mass = 1.0
 
-        if constant not in ('TP','TV','HP','SP','SV','UV'): 
+        if constant not in ('TP','TV','HP','SP','SV','UV'):
             raise ValueError(
                 f"Constant {constant} is invalid."
                 "Must be one of 'TP','TV','HP','SP','SV', or 'UV'")
@@ -1337,7 +1337,7 @@ def _state2_prop(name, doc_source):
         return a, b
 
     def setter(self, AB):
-        if len(AB) != 2: 
+        if len(AB) != 2:
             raise ValueError("Expected 2 elements, got {}".format(len(AB)))
         A, B, _ = np.broadcast_arrays(AB[0], AB[1], self._output_dummy)
         for loc, index in enumerate(self._indices):
@@ -1364,7 +1364,7 @@ def _state3_prop(name, doc_source, scalar=False):
         return a, b, c
 
     def setter(self, ABC):
-        if len(ABC) != 3: 
+        if len(ABC) != 3:
             raise ValueError("Expected 3 elements, got {}".format(len(ABC)))
         A, B, _ = np.broadcast_arrays(ABC[0], ABC[1], self._output_dummy)
         XY = ABC[2] # composition

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -232,7 +232,7 @@ class Quantity:
 
         if constant not in ('TP','TV','HP','SP','SV','UV'):
             raise ValueError(
-                f"Constant {constant} is invalid."
+                f"Constant {constant} is invalid. "
                 "Must be one of 'TP','TV','HP','SP','SV', or 'UV'")
         self.constant = constant
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -230,7 +230,8 @@ class Quantity:
         else:
             self.mass = 1.0
 
-        assert constant in ('TP','TV','HP','SP','SV','UV')
+        assert constant in ('TP','TV','HP','SP','SV','UV'), 
+            "Error: constant must be one of 'TP','TV','HP','SP','SV', or 'UV'" 
         self.constant = constant
 
     @property
@@ -316,7 +317,8 @@ class Quantity:
         if self._id != other._id:
             raise ValueError('Cannot add Quantities with different phase '
                 'definitions.')
-        assert self.constant == other.constant
+        assert self.constant == other.constant,
+            "Error: Cannot add Quantities when with different constant values" 
 
         m = self.mass + other.mass
         Y = (self.Y * self.mass + other.Y * other.mass)


### PR DESCRIPTION
**Changes proposed in this pull request**

- Added descriptive error text to two `assert` statements in interfaces/cython/cantera/composite.py

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [ x ] The pull request includes a clear description of this code change
- [ x ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ x ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ x ] The pull request is ready for review
