### PR TITLE
[thermo] Improve solveCubic exception handling

### DIFF
--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -892,9 +892,9 @@ int MixtureFugacityTP::solveCubic(double T, double pres, double a, double b,
             if (fabs(tmp) > 1.0E-4) {
                 for (int j = 0; j < 3; j++) {
                     if (j != i && fabs(Vroot[i] - Vroot[j]) < 1.0E-4 * (fabs(Vroot[i]) + fabs(Vroot[j]))) {
-                        writelog("MixtureFugacityTP::solveCubic(T ={}, p ={}):"
-                                 " WARNING roots have merged: {}, {}\n",
-                                 T, pres, Vroot[i], Vroot[j]);
+                        warn_user("MixtureFugacityTP::solveCubic",
+                                  "roots have merged for T = {}, p = {}: {}, {}",
+                                  T, pres, Vroot[i], Vroot[j]);
                     }
                 }
             }
@@ -954,9 +954,9 @@ int MixtureFugacityTP::solveCubic(double T, double pres, double a, double b,
             }
         }
         if ((fabs(res) > 1.0E-14) && (fabs(res) > 1.0E-14 * fabs(dresdV) * fabs(Vroot[i]))) {
-            writelog("MixtureFugacityTP::solveCubic(T = {}, p = {}): "
-                "WARNING root didn't converge V = {}", T, pres, Vroot[i]);
-            writelogendl();
+            throw CanteraError("MixtureFugacityTP::solveCubic",
+                               "root failed to converge for T = {}, p = {} with "
+                               "V = {}", T, pres, Vroot[i]);
         }
     }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Convert `writelog` messages for `MixtureFugacity::solveCubic` to exception (no root found) and warning (merged roots) respectively.
- Band-aid until permanent fix for #1699 is found (as recommended on [UG post](https://groups.google.com/g/cantera-users/c/xTc9Yq5KiMM/m/AMmQ95_CAAAJ))

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Band-aid for #1699

The example from #1699 now fails with:
```
CanteraError:
*******************************************************************************
CanteraError thrown by MixtureFugacityTP::solveCubic:
root failed to converge for T = 250.45022511255627, p = 30717382.242601085 with V = -8038.658839830863
*******************************************************************************
```
which allows for improved exception handling (rather than checking for invalid densities).

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
