### PR TITLE
Fix missing return code check in SConstruct script

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1375,7 +1375,7 @@ env['HAS_OPENMP'] = conf.CheckLibWithHeader(
     ["iomp5", "omp", "gomp"], "omp.h", language="C++"
 )
 
-_, boost_lib_version = run_preprocessor(conf, ["<boost/version.hpp>"], "BOOST_LIB_VERSION")
+retcode, boost_lib_version = run_preprocessor(conf, ["<boost/version.hpp>"], "BOOST_LIB_VERSION")
 if not retcode:
     config_error("Boost could not be found. Install Boost headers or set "
                  "'boost_inc_dir' to point to the boost headers.")


### PR DESCRIPTION
**Changes proposed in this pull request**

Currently, when Boost is not found, the SConstruct script crashes. This is fixed by not ignoring the return code from the run_preprocessor call that checks the Boost version.

**Checklist**

- [v] The pull request includes a clear description of this code change
- [v] Commit messages have short titles and reference relevant issues
- [v] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [v] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [v] The pull request is ready for review
