### PR TITLE
Update example formatting for better sphinx-gallery rendering

### DIFF
--- a/doc/sphinx/ctutils.py
+++ b/doc/sphinx/ctutils.py
@@ -6,7 +6,6 @@ class ResetArgv:
     wants_plot = {
         "adiabatic.py",
         "premixed_counterflow_twin_flame.py",
-        "piston.py",
         "reactor1.py",
         "reactor2.py",
         "sensitivity1.py",

--- a/samples/python/kinetics/custom_reactions.py
+++ b/samples/python/kinetics/custom_reactions.py
@@ -25,8 +25,13 @@ gas0 = ct.Solution(mech)
 species = gas0.species()
 reactions = gas0.reactions()
 
-# construct reactions based on CustomRate: replace two reactions with equivalent
-# custom versions (uses Func1 functors defined by Python lambda functions)
+# %%
+# Define custom reaction rates
+# ----------------------------
+
+# %%
+# Construct reactions based on `CustomRate`: replace two reactions with equivalent
+# custom versions (uses `Func1` functors defined by Python lambda functions)
 reactions[2] = ct.Reaction(
     equation='H2 + O <=> H + OH',
     rate=lambda T: 38.7 * T**2.7 * exp(-3150.1542797022735/T))
@@ -37,8 +42,9 @@ reactions[4] = ct.Reaction(
 gas1a = ct.Solution(thermo='ideal-gas', kinetics='gas',
                     species=species, reactions=reactions)
 
-# construct reactions based on CustomRate: replace two reactions with equivalent
-# custom versions (uses Func1 functors defined by C++ class Arrhenius1)
+# %%
+# construct reactions based on `CustomRate`: replace two reactions with equivalent
+# custom versions (uses `Func1` functors defined by C++ class :ct:`Arrhenius1`)
 reactions[2] = ct.Reaction(
     equation='H2 + O <=> H + OH',
     rate=ct.Func1("Arrhenius", [38.7, 2.7, 3150.1542797022735]))
@@ -49,7 +55,8 @@ reactions[4] = ct.Reaction(
 gas1b = ct.Solution(thermo='ideal-gas', kinetics='gas',
                     species=species, reactions=reactions)
 
-# construct reactions based on ExtensibleRate: replace two reactions with equivalent
+# %%
+# Construct reactions based on `ExtensibleRate`: replace two reactions with equivalent
 # extensible versions
 class ExtensibleArrheniusData(ct.ExtensibleRateData):
     __slots__ = ("T",)
@@ -107,6 +114,7 @@ reactions[4] = ct.Reaction.from_yaml(extensible_yaml4, gas0)
 gas2 = ct.Solution(thermo="ideal-gas", kinetics="gas",
                    species=species, reactions=reactions)
 
+# %%
 # construct test case - simulate ignition
 
 def ignition(gas, dT=0):
@@ -124,7 +132,9 @@ def ignition(gas, dT=0):
 
     return t2 - t1, net.solver_stats['steps']
 
-# output results
+# %%
+# Run simulations and output results
+# ----------------------------------
 
 repeat = 100
 print(f"Average time of {repeat} simulation runs for '{mech}' ({fuel})")

--- a/samples/python/kinetics/diamond_cvd.py
+++ b/samples/python/kinetics/diamond_cvd.py
@@ -17,11 +17,12 @@ Requires: cantera >= 2.6.0, pandas >= 0.25.0, matplotlib >= 2.0
 """
 
 import csv
+import matplotlib.pyplot as plt
+import pandas as pd
 import cantera as ct
 
-print('\n******  CVD Diamond Example  ******\n')
-
-# import the model for the diamond (100) surface and the adjacent bulk phases
+# %%
+# Import the model for the diamond (100) surface and the adjacent bulk phases
 d = ct.Interface("diamond.yaml", "diamond_100")
 g = d.adjacent["gas"]
 dbulk = d.adjacent["diamond"]
@@ -37,6 +38,8 @@ ih = g.species_index('H')
 
 xh0 = x[ih]
 
+# %%
+# Calculate growth rate as a function of H mole fraction in the gas
 with open('diamond.csv', 'w', newline='') as f:
     writer = csv.writer(f)
     writer.writerow(['H mole Fraction', 'Growth Rate (microns/hour)'] +
@@ -56,20 +59,18 @@ with open('diamond.csv', 'w', newline='') as f:
     print('H concentration, growth rate, and surface coverages '
           'written to file diamond.csv')
 
-try:
-    import matplotlib.pyplot as plt
-    import pandas as pd
-    data = pd.read_csv('diamond.csv')
+# %%
+# Plot the results
+data = pd.read_csv('diamond.csv')
 
-    data.plot(x="H mole Fraction", y="Growth Rate (microns/hour)", legend=False)
-    plt.xlabel('H Mole Fraction')
-    plt.ylabel('Growth Rate (microns/hr)')
-    plt.show()
+data.plot(x="H mole Fraction", y="Growth Rate (microns/hour)", legend=False)
+plt.xlabel('H Mole Fraction')
+plt.ylabel('Growth Rate (microns/hr)')
+plt.show()
 
-    names = [name for name in data.columns if not name.startswith(('H mole', 'Growth'))]
-    data.plot(x='H mole Fraction', y=names, legend=True)
-    plt.xlabel('H Mole Fraction')
-    plt.ylabel('Coverage')
-    plt.show()
-except ImportError:
-    print("Install matplotlib and pandas to plot the outputs")
+# %%
+names = [name for name in data.columns if not name.startswith(('H mole', 'Growth'))]
+data.plot(x='H mole Fraction', y=names, legend=True)
+plt.xlabel('H Mole Fraction')
+plt.ylabel('Coverage')
+plt.show()

--- a/samples/python/kinetics/extract_submechanism.py
+++ b/samples/python/kinetics/extract_submechanism.py
@@ -23,7 +23,8 @@ input_file = 'gri30.yaml'
 all_species = ct.Species.list_from_file(input_file)
 species = []
 
-# Filter species
+# %%
+# Filter species.
 for S in all_species:
     comp = S.composition
     if 'C' in comp and 'H' in comp:
@@ -41,7 +42,8 @@ for S in all_species:
 species_names = {S.name for S in species}
 print('Species: {0}'.format(', '.join(S.name for S in species)))
 
-# Filter reactions, keeping only those that only involve the selected species
+# %%
+# Filter reactions, keeping only those that only involve the selected species.
 ref_phase = ct.Solution(thermo='ideal-gas', kinetics='gas', species=all_species)
 all_reactions = ct.Reaction.list_from_file(input_file, ref_phase)
 reactions = []
@@ -64,10 +66,13 @@ gas2 = ct.Solution(name="gri30-CO-H2-submech",
                    transport_model="mixture-averaged",
                    species=species, reactions=reactions)
 
-# Save the resulting mechanism for later use
+# %%
+# Save the resulting mechanism for later use.
 gas2.update_user_header({"description": "CO-H2 submechanism extracted from GRI-Mech 3.0"})
 gas2.write_yaml("gri30-CO-H2-submech.yaml", header=True)
 
+# %%
+# Simulate a flame with each mechanism.
 def solve_flame(gas):
     gas.TPX = 373, 0.05*ct.one_atm, 'H2:0.4, CO:0.6, O2:1, N2:3.76'
 
@@ -81,7 +86,6 @@ def solve_flame(gas):
     sim.solve(0, auto=True)
     return sim
 
-
 t1 = default_timer()
 sim1 = solve_flame(gas1)
 t2 = default_timer()
@@ -89,6 +93,9 @@ print('Solved with GRI 3.0 in {0:.2f} seconds'.format(t2-t1))
 sim2 = solve_flame(gas2)
 t3 = default_timer()
 print('Solved with CO/H2 submechanism in {0:.2f} seconds'.format(t3-t2))
+
+# %%
+# Plot the results to show that the submechanism gives the same results as the original.
 
 plt.plot(sim1.grid, sim1.heat_release_rate,
          lw=2, label='GRI 3.0')

--- a/samples/python/kinetics/jet_stirred_reactor.py
+++ b/samples/python/kinetics/jet_stirred_reactor.py
@@ -41,7 +41,7 @@ import matplotlib.pyplot as plt
 
 f, ax = plt.subplots(1, 3)
 plt.subplots_adjust(wspace=0.6)
-colours = ["xkcd:grey",'xkcd:purple']
+colors = ["xkcd:grey",'xkcd:purple']
 file = 'example_data/ammonia-CO-H2-Alzueta-2023.yaml'
 models = {'Original': 'baseline', 'LMR-R': 'linear-Burke'}
 
@@ -108,9 +108,9 @@ for k,m in enumerate(models):
     tempDependence = getTemperatureDependence(gas,inputs)
     ax[0].plot(tempDependence.index,
                np.subtract(tempDependence['temperature'],tempDependence.index),
-               color=colours[k],label=m)
-    ax[1].plot(tempDependence.index, tempDependence['O2']*100, color=colours[k])
-    ax[2].plot(tempDependence.index, tempDependence['H2']*100, color=colours[k])
+               color=colors[k],label=m)
+    ax[1].plot(tempDependence.index, tempDependence['O2']*100, color=colors[k])
+    ax[2].plot(tempDependence.index, tempDependence['H2']*100, color=colors[k])
 ax[0].plot(inputs['data']['T_range'], inputs['data']['deltaT'], 'o', fillstyle='none',
            color='k', label="Sabia et al.")
 ax[1].plot(inputs['data']['T_range'], inputs['data']['X_O2'], 'o', fillstyle='none',

--- a/samples/python/kinetics/mechanism_reduction.py
+++ b/samples/python/kinetics/mechanism_reduction.py
@@ -5,8 +5,8 @@ Mechanism reduction
 A simplistic approach to mechanism reduction which demonstrates Cantera's
 features for dynamically manipulating chemical mechanisms.
 
-Here, we use the full GRI 3.0 mechanism to simulate adiabatic, constant pressure
-ignition of a lean methane/air mixture. We track the maximum reaction rates for
+Here, we use the detailed NUI Galway mechanism to simulate adiabatic, constant pressure
+ignition of a lean n-hexane/air mixture. We track the maximum reaction rates for
 each reaction to determine which reactions are the most important, according to
 a simple metric based on the relative net reaction rate.
 
@@ -15,8 +15,7 @@ and the associated species, and run the simulations again with these mechanisms
 to see whether the reduced mechanisms with a certain number of species are able
 to adequately simulate the ignition delay problem.
 
-Requires: cantera >= 2.6.0, matplotlib >= 2.0
-
+Requires: cantera >= 3.1.0, matplotlib >= 2.0
 
 .. tags:: Python, kinetics, combustion, reactor network, editing mechanisms,
           ignition delay, plotting
@@ -25,42 +24,59 @@ Requires: cantera >= 2.6.0, matplotlib >= 2.0
 import cantera as ct
 import numpy as np
 import matplotlib.pyplot as plt
+import dataclasses
 
-gas = ct.Solution('gri30.yaml')
-initial_state = 1200, 5 * ct.one_atm, 'CH4:0.35, O2:1.0, N2:3.76'
+@dataclasses.dataclass
+class Result:
+    species: int
+    reactions: int
+    time: list
+    temperature: list
 
+
+ct.suppress_thermo_warnings()
+T0 = 975
+P0 = 5 * ct.one_atm
+gas = ct.Solution('example_data/n-hexane-NUIG-2015.yaml')
+gas.set_equivalence_ratio(0.8, 'NC6H14:1.0', 'O2:1.0, N2:3.76')
+X0 = gas.mole_fraction_dict()
+gas.TP = T0, P0
+
+# %%
 # Run a simulation with the full mechanism
-gas.TPX = initial_state
-r = ct.IdealGasConstPressureReactor(gas)
+r = ct.IdealGasConstPressureMoleReactor(gas)
 sim = ct.ReactorNet([r])
+sim.preconditioner = ct.AdaptivePreconditioner()
 
 tt = []
 TT = []
-t = 0.0
-# Rmax is the maximum relative reaction rate at any timestep
+# Rmax is the maximum relative reaction rate at any timestep.
 Rmax = np.zeros(gas.n_reactions)
-while t < 0.02:
-    t = sim.step()
-    tt.append(1000 * t)
+while sim.time < 0.04:
+    sim.step()
+    tt.append(1000 * sim.time)
     TT.append(r.T)
     rnet = abs(gas.net_rates_of_progress)
     rnet /= max(rnet)
     Rmax = np.maximum(Rmax, rnet)
 
-plt.plot(tt, TT, label='K=53, R=325', color='k', lw=3, zorder=100)
+baseline = Result(gas.n_species, gas.n_reactions, tt, TT)
 
-# Get the reaction objects, and sort them so the most active reactions are first
+# %%
+# Get the reaction objects, and sort them so the most active reactions are first.
 R = sorted(zip(Rmax, gas.reactions()), key=lambda x: -x[0])
 
-# Test reduced mechanisms with different numbers of reactions
-C = plt.cm.winter(np.linspace(0, 1, 5))
-for i, N in enumerate([40, 50, 60, 70, 80]):
+# %%
+# Test reduced mechanisms with different numbers of reactions and collect results for
+# plotting.
+results = []
+for i, N in enumerate([100, 200, 300, 400, 600, 800]):
     # Get the N most active reactions
     reactions = [r[1] for r in R[:N]]
 
     # find the species involved in these reactions. At a minimum, include all
     # species in the reactant mixture
-    species_names = {'N2', 'CH4', 'O2'}
+    species_names = {'N2', 'NC6H14', 'O2'}
     for reaction in reactions:
         species_names.update(reaction.reactants)
         species_names.update(reaction.products)
@@ -73,30 +89,37 @@ for i, N in enumerate([40, 50, 60, 70, 80]):
                        species=species, reactions=reactions)
 
     # save the reduced mechanism for later use
-    gas2.write_yaml("gri30-reduced-{}-reaction.yaml".format(N))
+    gas2.write_yaml(f"hexane-reduced-{N}-reaction.yaml")
 
     # Re-run the ignition problem with the reduced mechanism
-    gas2.TPX = initial_state
-    r = ct.IdealGasConstPressureReactor(gas2)
+    gas2.TPX = T0, P0, X0
+    r = ct.IdealGasConstPressureMoleReactor(gas2)
     sim = ct.ReactorNet([r])
-
-    t = 0.0
+    sim.preconditioner = ct.AdaptivePreconditioner()
 
     tt = []
     TT = []
-    while t < 0.02:
-        t = sim.step()
-        tt.append(1000 * t)
+    while sim.time < 0.04:
+        sim.step()
+        tt.append(1000 * sim.time)
         TT.append(r.T)
 
-    plt.plot(tt, TT, lw=2, color=C[i],
-             label='K={0}, R={1}'.format(gas2.n_species, N))
-    plt.xlabel('Time (ms)')
-    plt.ylabel('Temperature (K)')
-    plt.legend(loc='upper left')
-    plt.title('Reduced mechanism ignition delay times\n'
-              'K: number of species; R: number of reactions')
-    plt.xlim(0, 20)
+    results.append(Result(gas2.n_species, gas2.n_reactions, tt, TT))
 
-plt.tight_layout()
+# %%
+# Plot the results.
+C = plt.cm.winter(np.linspace(0, 1, 6))
+
+fig, ax = plt.subplots()
+ax.plot(baseline.time, baseline.temperature, color='k', lw=3, zorder=100,
+        label=f'K={baseline.species}, R={baseline.reactions}')
+
+for i, result in enumerate(results):
+    ax.plot(result.time, result.temperature, lw=2, color=C[i],
+            label=f'K={result.species}, R={result.reactions}')
+ax.set(xlabel='Time (ms)', ylabel='Temperature (K)')
+ax.legend(loc='upper left')
+ax.set_title('Reduced mechanism ignition delay times\n'
+             'K: number of species; R: number of reactions')
+ax.set_xlim(0, 40)
 plt.show()

--- a/samples/python/kinetics/shock_tube.py
+++ b/samples/python/kinetics/shock_tube.py
@@ -29,19 +29,21 @@ References:
 
 Requires: cantera >= 3.1, matplotlib
 
-.. tags:: shock tube, kinetics, combustion
+.. tags:: Python, shock tube, kinetics, combustion
 """
 
 import cantera as ct
 import matplotlib.pyplot as plt
 import numpy as np
 
-fig, ax = plt.subplots()
 file = 'example_data/ammonia-CO-H2-Alzueta-2023.yaml'
 models = {'Original': 'baseline', 'LMR-R': 'linear-Burke'}
-colours = ["xkcd:grey",'xkcd:purple']
+colours = {'Original': "xkcd:grey", 'LMR-R': 'xkcd:purple'}
+results = {}
 
-for k,m in enumerate(models):
+# %%
+# Run simulations with baseline and revised reaction mechanisms
+for k, m in enumerate(models):
     X_H2O2 = 1163e-6
     X_H2O = 1330e-6
     X_O2 = 665e-6
@@ -61,7 +63,12 @@ for k,m in enumerate(models):
         if counter % 10 == 0:
             timeHistory.append(r.thermo.state, t=t)
         counter += 1
-    ax.plot(timeHistory.t*1e6, timeHistory('H2O').X*100, color=colours[k],label=m)
+
+    results[m] = timeHistory
+
+# %%
+# Plot the resulting species profiles and compare with the experimental data from Shao
+# et al.
 expData = {
     't': [12.3,20.3,26.4,39.6,58.5,79.2,96.1,113.8,131.6,145.7,161.2,181.6,195.3,219.9,
           237.2,248.6,262.4,272.2,280.9],
@@ -69,6 +76,12 @@ expData = {
               2.26E-03,2.30E-03,2.39E-03,2.38E-03,2.40E-03,2.42E-03,2.47E-03,2.53E-03,
               2.51E-03,2.50E-03,2.47E-03]
 }
+
+fig, ax = plt.subplots()
+
+for m, timeHistory in results.items():
+    ax.plot(timeHistory.t*1e6, timeHistory('H2O').X*100, color=colours[m], label=m)
+
 ax.plot(expData['t'], np.array(expData['X_H2O'])*100, 'o', fillstyle='none', color='k',
         label='Shao et al.')
 ax.legend(frameon=False, loc='lower right')

--- a/samples/python/kinetics/shock_tube.py
+++ b/samples/python/kinetics/shock_tube.py
@@ -38,7 +38,7 @@ import numpy as np
 
 file = 'example_data/ammonia-CO-H2-Alzueta-2023.yaml'
 models = {'Original': 'baseline', 'LMR-R': 'linear-Burke'}
-colours = {'Original': "xkcd:grey", 'LMR-R': 'xkcd:purple'}
+colors = {'Original': "xkcd:grey", 'LMR-R': 'xkcd:purple'}
 results = {}
 
 # %%
@@ -80,7 +80,7 @@ expData = {
 fig, ax = plt.subplots()
 
 for m, timeHistory in results.items():
-    ax.plot(timeHistory.t*1e6, timeHistory('H2O').X*100, color=colours[m], label=m)
+    ax.plot(timeHistory.t*1e6, timeHistory('H2O').X*100, color=colors[m], label=m)
 
 ax.plot(expData['t'], np.array(expData['X_H2O'])*100, 'o', fillstyle='none', color='k',
         label='Shao et al.')

--- a/samples/python/onedim/burner_flame.py
+++ b/samples/python/onedim/burner_flame.py
@@ -4,13 +4,14 @@ Burner-stabilized flame
 
 A burner-stabilized lean premixed hydrogen-oxygen flame at low pressure.
 
-Requires: cantera >= 3.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, 1D flow, premixed flame, saving output,
           multicomponent transport
 """
 
 from pathlib import Path
+import matplotlib.pyplot as plt
 import cantera as ct
 
 p = 0.05 * ct.one_atm
@@ -45,3 +46,42 @@ f.show()
 f.save(output, name="multi", description="solution with multicomponent transport")
 
 f.save('burner_flame.csv', basis="mole", overwrite=True)
+
+# %%
+# Temperature and Heat Release Rate
+# ---------------------------------
+fig, ax1 = plt.subplots()
+
+ax1.plot(f.grid, f.heat_release_rate / 1e6, color='C4')
+ax1.set_ylabel('heat release rate [MW/m³]', color='C4')
+ax1.set_xlim(0, 0.2)
+ax1.set(xlabel='distance from burner [m]')
+
+ax2 = ax1.twinx()
+ax2.plot(f.grid, f.T, color='C3')
+ax2.set_ylabel('temperature [K]', color='C3')
+plt.show()
+
+# %%
+# Major Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+major = ('O2', 'H2', 'H2O')
+states = f.to_array()
+ax.plot(states.grid, states(*major).X, label=major)
+ax.set(xlabel='distance from burner [m]', ylabel='mole fractions')
+ax.set_xlim(0, 0.2)
+ax.legend()
+plt.show()
+
+# %%
+# Minor Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+minor = ('OH', 'H', 'O')
+
+ax.plot(states.grid, states(*minor).X, label=minor, linestyle='--')
+ax.set(xlabel='distance from burner [m]', ylabel='mole fractions', )
+ax.set_xlim(0, 0.2)
+ax.legend()
+plt.show()

--- a/samples/python/onedim/catalytic_combustion.py
+++ b/samples/python/onedim/catalytic_combustion.py
@@ -11,12 +11,13 @@ and has some effect very near the surface.
 The catalytic combustion mechanism is from Deutschmann et al., 26th
 Symp. (Intl.) on Combustion,1996 pp. 1747-1754
 
-Requires: cantera >= 3.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 
 .. tags:: Python, catalysis, combustion, 1D flow, surface chemistry
 """
 
 import numpy as np
+import matplotlib.pyplot as plt
 import cantera as ct
 
 # %%
@@ -131,9 +132,30 @@ if "native" in ct.hdf_support():
     filename = "catalytic_combustion.h5"
 else:
     filename = "catalytic_combustion.yaml"
-sim.save(filename, "soln1", description="catalytic combustion example")
+sim.save(filename, "soln1", description="catalytic combustion example",
+         overwrite=True)
 
 # save selected solution components in a CSV file for plotting in Excel or MATLAB.
 sim.save('catalytic_combustion.csv', basis="mole", overwrite=True)
 
 sim.show_stats(0)
+
+# %%
+# Temperature Profile
+# -------------------
+fig, ax = plt.subplots()
+ax.plot(sim.grid, sim.T, color='C3')
+ax.set_ylabel('heat release rate [MW/m³]')
+ax.set(xlabel='distance from inlet [m]')
+plt.show()
+
+# %%
+# Major Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+major = ('O2', 'CH4', 'H2O', 'CO2')
+states = sim.to_array()
+ax.plot(states.grid, states(*major).X, label=major)
+ax.set(xlabel='distance from inlet [m]', ylabel='mole fractions')
+ax.legend()
+plt.show()

--- a/samples/python/onedim/catalytic_combustion.py
+++ b/samples/python/onedim/catalytic_combustion.py
@@ -19,13 +19,18 @@ Requires: cantera >= 3.0
 import numpy as np
 import cantera as ct
 
-#  Parameter values are collected here to make it easier to modify them
+# %%
+# Problem Definition
+# ------------------
+#
+# Parameter values are collected here to make it easier to modify them
 p = ct.one_atm  # pressure
 tinlet = 300.0  # inlet temperature
 tsurf = 900.0  # surface temperature
 mdot = 0.06  # kg/m^2/s
 transport = 'mixture-averaged'  # transport model
 
+# %%
 # We will solve first for a hydrogen/air case to use as the initial estimate
 # for the methane/air case
 
@@ -40,14 +45,16 @@ width = 0.1  # m
 
 loglevel = 1  # amount of diagnostic output (0 to 5)
 
-################ create the phase objects ##################
+# %%
+# Create the phase objects
+# ------------------------
 #
-# The 'surf_phase' object will be used to evaluate all surface chemical production
-# rates. It will be created from the interface definition 'Pt_surf' in input file
-# 'ptcombust.yaml,' which implements the reaction mechanism of Deutschmann et
+# The ``surf_phase`` object will be used to evaluate all surface chemical production
+# rates. It will be created from the interface definition ``Pt_surf`` in input file
+# ``ptcombust.yaml``, which implements the reaction mechanism of Deutschmann et
 # al., 1995 for catalytic combustion on platinum.
 #
-# This phase definition also references the phase 'gas' in the same input file,
+# This phase definition also references the phase ``gas`` in the same input file,
 # which will be created and used to evaluate all thermodynamic, kinetic, and
 # transport properties. It is a stripped-down version of GRI-Mech 3.0.
 surf_phase = ct.Interface("ptcombust.yaml", "Pt_surf")
@@ -70,9 +77,11 @@ sim.inlet.T = tinlet
 sim.inlet.X = comp1
 sim.surface.T = tsurf
 
+# %%
 # Show the initial solution estimate
 sim.show()
 
+# %%
 # Solving problems with stiff chemistry coupled to flow can require a
 # sequential approach where solutions are first obtained for simpler problems
 # and used as the initial guess for more difficult problems.
@@ -83,10 +92,12 @@ sim.surface.coverage_enabled = False
 surf_phase.set_multiplier(0.0)
 gas.set_multiplier(0.0)
 
+# %%
 # solve the problem, refining the grid if needed, to determine the non-
 # reacting velocity and temperature distributions
 sim.solve(loglevel, auto=True)
 
+# %%
 # now turn on the surface coverage equations, and turn the chemistry on slowly
 sim.surface.coverage_enabled = True
 for mult in np.logspace(-5, 0, 6):
@@ -95,9 +106,11 @@ for mult in np.logspace(-5, 0, 6):
     print('Multiplier =', mult)
     sim.solve(loglevel)
 
+# %%
 # At this point, we should have the solution for the hydrogen/air problem.
 sim.show()
 
+# %%
 # Now switch the inlet to the methane/air composition.
 sim.inlet.X = comp2
 
@@ -107,10 +120,12 @@ sim.set_refine_criteria(100.0, 0.15, 0.2, 0.0)
 # solve the problem for the final time
 sim.solve(loglevel)
 
+# %%
 # show the solution
 sim.show()
 
-# save the full solution to HDF or YAML container files. The 'restore' method can be
+# %%
+# Save the full solution to HDF or YAML container files. The ``restore`` method can be
 # used to restore or restart a simulation from a solution stored in this form.
 if "native" in ct.hdf_support():
     filename = "catalytic_combustion.h5"

--- a/samples/python/onedim/diffusion_flame.py
+++ b/samples/python/onedim/diffusion_flame.py
@@ -14,7 +14,7 @@ from pathlib import Path
 import cantera as ct
 import matplotlib.pyplot as plt
 
-
+# %%
 # Input parameters
 p = ct.one_atm  # pressure
 tin_f = 300.0  # fuel inlet temperature
@@ -28,6 +28,9 @@ comp_f = 'C2H6:1'  # fuel composition
 width = 0.02  # Distance between inlets is 2 cm
 
 loglevel = 1  # amount of diagnostic output (0 to 5)
+
+# %%
+# Set up the simulation:
 
 # Create the gas object used to evaluate all thermodynamic, kinetic, and
 # transport properties.
@@ -55,8 +58,11 @@ f.radiation_enabled = False
 
 f.set_refine_criteria(ratio=4, slope=0.2, curve=0.3, prune=0.04)
 
+# %%
 # Solve the problem
 f.solve(loglevel, auto=True)
+
+# %%
 f.show()
 
 if "native" in ct.hdf_support():
@@ -67,25 +73,27 @@ output.unlink(missing_ok=True)
 
 f.save(output)
 
+# %%
 # write the velocity, temperature, and mole fractions to a CSV file
 f.save('diffusion_flame.csv', basis="mole", overwrite=True)
-
 f.show_stats(0)
+no_rad = f.to_array()
 
-# Plot Temperature without radiation
-figTemperatureModifiedFlame = plt.figure()
-plt.plot(f.flame.grid, f.T, label='Temperature without radiation')
-plt.title('Temperature of the flame')
-plt.ylim(0,2500)
-plt.xlim(0.000, 0.020)
-
+# %%
 # Turn on radiation and solve again
 f.radiation_enabled = True
 f.solve(loglevel=1, refine_grid=False)
+
+# %%
 f.show()
 
-# Plot Temperature with radiation
-plt.plot(f.flame.grid, f.T, label='Temperature with radiation')
-plt.legend()
-plt.legend(loc=2)
-plt.savefig('./diffusion_flame.pdf')
+# %%
+# Plot temperature with and without radiation
+fig, ax = plt.subplots()
+ax.plot(no_rad.grid, no_rad.T, label='Temperature without radiation')
+plt.plot(f.grid, f.T, label='Temperature with radiation')
+ax.set_title('Temperature of the flame')
+ax.set(ylim=(0,2500), xlim=(0.000, 0.020))
+ax.legend()
+fig.savefig('./diffusion_flame.pdf')
+plt.show()

--- a/samples/python/onedim/diffusion_flame_batch.py
+++ b/samples/python/onedim/diffusion_flame_batch.py
@@ -98,7 +98,7 @@ def names(test):
 # Save to data directory
 file_name, entry = names("initial-solution")
 desc = "Initial hydrogen-oxygen counterflow flame at 1 bar and low strain rate"
-f.save(file_name, name=entry, description=desc)
+f.save(file_name, name=entry, description=desc, overwrite=True)
 
 # %%
 # Batch Pressure Loop
@@ -148,7 +148,8 @@ for p in p_range:
         # Try solving the flame
         f.solve(loglevel=0)
         file_name, entry = names(f"pressure-loop/{p:05.1f}")
-        f.save(file_name, name=entry, description=f"pressure = {p} bar")
+        f.save(file_name, name=entry, description=f"pressure = {p} bar",
+               overwrite=True)
         p_previous = p
     except ct.CanteraError as e:
         print('Error occurred while solving:', e, 'Try next pressure level')
@@ -201,7 +202,7 @@ while np.max(f.T) > temperature_limit_extinction:
         f.solve(loglevel=0)
         file_name, entry = names(f"strain-loop/{n:02d}")
         f.save(file_name, name=entry,
-               description=f"strain rate iteration {n}")
+               description=f"strain rate iteration {n}", overwrite=True)
     except FlameExtinguished:
         print('Flame extinguished')
         break
@@ -238,9 +239,10 @@ fig1.savefig(output_path / "figure_T_p.png")
 ax2.legend(loc=0)
 ax2.set_xlabel(r'$z/z_{max}$')
 ax2.set_ylabel(r'$u/u_f$')
-fig1.savefig(output_path / "figure_u_p.png")
+fig2.savefig(output_path / "figure_u_p.png")
 plt.show()
 
+# %%
 fig3 = plt.figure()
 fig4 = plt.figure()
 ax3 = fig3.add_subplot(1, 1, 1)
@@ -261,10 +263,10 @@ for n in n_selected:
 ax3.legend(loc=0)
 ax3.set_xlabel(r'$z/z_{max}$')
 ax3.set_ylabel(r'$T$ [K]')
-fig1.savefig(output_path / "figure_T_a.png")
+fig3.savefig(output_path / "figure_T_a.png")
 
 ax4.legend(loc=0)
 ax4.set_xlabel(r'$z/z_{max}$')
 ax4.set_ylabel(r'$u/u_f$')
-fig1.savefig(output_path / "figure_u_a.png")
+fig4.savefig(output_path / "figure_u_a.png")
 plt.show()

--- a/samples/python/onedim/diffusion_flame_batch.py
+++ b/samples/python/onedim/diffusion_flame_batch.py
@@ -33,8 +33,10 @@ class FlameExtinguished(Exception):
     pass
 
 
-# PART 1: INITIALIZATION
-
+# %%
+# Initialization
+# --------------
+#
 # Set up an initial hydrogen-oxygen counterflow flame at 1 bar and low strain
 # rate (maximum axial velocity gradient = 2414 1/s)
 
@@ -55,6 +57,7 @@ f.oxidizer_inlet.T = 300  # K
 # Set refinement parameters, if used
 f.set_refine_criteria(ratio=3.0, slope=0.1, curve=0.2, prune=0.03)
 
+# %%
 # Define a limit for the maximum temperature below which the flame is
 # considered as extinguished and the computation is aborted
 # This increases the speed of refinement, if enabled
@@ -69,6 +72,7 @@ def interrupt_extinction(t):
 
 f.set_interrupt(interrupt_extinction)
 
+# %%
 # Initialize and solve
 print('Creating the initial solution')
 f.solve(loglevel=0, auto=True)
@@ -96,16 +100,19 @@ file_name, entry = names("initial-solution")
 desc = "Initial hydrogen-oxygen counterflow flame at 1 bar and low strain rate"
 f.save(file_name, name=entry, description=desc)
 
-
-# PART 2: BATCH PRESSURE LOOP
-
+# %%
+# Batch Pressure Loop
+# -------------------
+#
 # Compute counterflow diffusion flames over a range of pressures
+
 # Arbitrarily define a pressure range (in bar)
 p_range = np.round(np.logspace(0, 2, 50), decimals=1)
 
+# %%
 # Exponents for the initial solution variation with changes in pressure Taken
 # from Fiala and Sattelmayer (2014). The exponents are adjusted such that the
-# strain rates increases proportional to p^(3/2), which results in flames
+# strain rates increases proportional to :math:`p^{3/2}`, which results in flames
 # similar with respect to the extinction strain rate.
 exp_d_p = -5. / 4.
 exp_u_p = 1. / 4.
@@ -148,16 +155,17 @@ for p in p_range:
         # If solution failed: Restore the last successful solution and continue
         f.restore(file_name, name=entry)
 
-
-# PART 3: STRAIN RATE LOOP
-
+# %%
+# Strain Rate Loop
+# ----------------
 # Compute counterflow diffusion flames at increasing strain rates at 1 bar
 # The strain rate is assumed to increase by 25% in each step until the flame is
 # extinguished
 strain_factor = 1.25
 
-# Exponents for the initial solution variation with changes in strain rate
-# Taken from Fiala and Sattelmayer (2014)
+# %%
+# Exponents for the initial solution variation with changes in strain rate.
+# Taken from Fiala and Sattelmayer (2014).
 exp_d_a = - 1. / 2.
 exp_u_a = 1. / 2.
 exp_V_a = 1.
@@ -201,8 +209,9 @@ while np.max(f.T) > temperature_limit_extinction:
         print('Error occurred while solving:', e)
         break
 
-
-# PART 4: PLOT SOME FIGURES
+# %%
+# Plotting Results
+# ----------------
 
 fig1 = plt.figure()
 fig2 = plt.figure()
@@ -230,6 +239,7 @@ ax2.legend(loc=0)
 ax2.set_xlabel(r'$z/z_{max}$')
 ax2.set_ylabel(r'$u/u_f$')
 fig1.savefig(output_path / "figure_u_p.png")
+plt.show()
 
 fig3 = plt.figure()
 fig4 = plt.figure()
@@ -257,3 +267,4 @@ ax4.legend(loc=0)
 ax4.set_xlabel(r'$z/z_{max}$')
 ax4.set_ylabel(r'$u/u_f$')
 fig1.savefig(output_path / "figure_u_a.png")
+plt.show()

--- a/samples/python/onedim/diffusion_flame_extinction.py
+++ b/samples/python/onedim/diffusion_flame_extinction.py
@@ -146,7 +146,8 @@ while True:
         # Flame is still burning, so proceed to next strain rate
         n_last_burning = n
         file_name, entry = names(f"extinction/{n:04d}")
-        f.save(file_name, name=entry, description=f"Solution at alpha = {alpha[-1]}")
+        f.save(file_name, name=entry, description=f"Solution at alpha = {alpha[-1]}",
+               overwrite=True)
 
         print('Flame burning at alpha = {:8.4F}. Proceeding to the next iteration, '
               'with delta_alpha = {}'.format(alpha[-1], delta_alpha))
@@ -155,7 +156,8 @@ while True:
         # strain rate increase is reached, save the last, non-burning, solution
         # to the output file and break the loop
         file_name, entry = names(f"extinction/{n:04d}")
-        f.save(file_name, name=entry, description=f"Flame extinguished at alpha={alpha[-1]}")
+        f.save(file_name, name=entry, overwrite=True,
+               description=f"Flame extinguished at alpha={alpha[-1]}")
 
         print('Flame extinguished at alpha = {0:8.4F}.'.format(alpha[-1]),
               'Abortion criterion satisfied.')

--- a/samples/python/onedim/diffusion_flame_extinction.py
+++ b/samples/python/onedim/diffusion_flame_extinction.py
@@ -25,8 +25,9 @@ import matplotlib.pyplot as plt
 import cantera as ct
 
 
-# PART 1: INITIALIZATION
-
+# %%
+# Initialization
+# --------------
 # Set up an initial hydrogen-oxygen counterflow flame at 1 bar and low strain
 # rate (maximum axial velocity gradient = 2414 1/s)
 
@@ -74,11 +75,11 @@ def names(test):
     return file_name, "solution"
 
 file_name, entry = names("initial-solution")
-f.save(file_name, name=entry, description="Initial solution")
+f.save(file_name, name=entry, description="Initial solution", overwrite=True)
 
-
-# PART 2: COMPUTE EXTINCTION STRAIN
-
+# %%
+# Compute Extinction Strain Rate
+# ------------------------------
 # Exponents for the initial solution variation with changes in strain rate
 # Taken from Fiala and Sattelmayer (2014)
 exp_d_a = - 1. / 2.
@@ -107,6 +108,7 @@ T_max = [np.max(f.T)]
 # List of maximum axial velocity gradients
 a_max = [np.max(np.abs(np.gradient(f.velocity) / np.gradient(f.grid)))]
 
+# %%
 # Simulate counterflow flames at increasing strain rates until the flame is
 # extinguished. To achieve a fast simulation, an initial coarse strain rate
 # increase is set. This increase is reduced after an extinction event and
@@ -171,7 +173,9 @@ while True:
         file_name, entry = names(f"extinction/{n_last_burning:04d}")
         f.restore(file_name, entry)
 
-
+# %%
+# Results
+# -------
 # Print some parameters at the extinction point, after restoring the last burning
 # solution
 file_name, entry = names(f"extinction/{n_last_burning:04d}")
@@ -190,9 +194,11 @@ print('Oxidizer inlet potential flow axial strain rate a_ox={0:.2e} 1/s'.format(
 print('Axial strain rate at stoichiometric surface a_stoich={0:.2e} 1/s'.format(
       f.strain_rate('stoichiometric', fuel='H2')))
 
+# %%
 # Plot the maximum temperature over the maximum axial velocity gradient
 plt.figure()
 plt.semilogx(a_max, T_max)
 plt.xlabel(r'$a_{max}$ [1/s]')
 plt.ylabel(r'$T_{max}$ [K]')
 plt.savefig(output_path / "figure_T_max_a_max.png")
+plt.show()

--- a/samples/python/onedim/flame_fixed_T.py
+++ b/samples/python/onedim/flame_fixed_T.py
@@ -5,7 +5,7 @@ Burner-stabilized flame with imposed temperature profile
 A burner-stabilized, premixed methane/air flat flame with multicomponent
 transport properties and a specified temperature profile.
 
-Requires: cantera >= 3.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, 1D flow, burner-stabilized flame, premixed flame, plotting,
           saving output
@@ -13,6 +13,7 @@ Requires: cantera >= 3.0
 
 from pathlib import Path
 import numpy as np
+import matplotlib.pyplot as plt
 import cantera as ct
 
 
@@ -116,3 +117,42 @@ f.save(output, name="multi", description="solution with multicomponent transport
 # write the velocity, temperature, density, and mole fractions to a CSV file
 f.save('flame_fixed_T.csv', basis="mole", overwrite=True)
 f.show_stats()
+
+# %%
+# Temperature and Heat Release Rate
+# ---------------------------------
+fig, ax1 = plt.subplots()
+
+ax1.plot(f.grid, f.heat_release_rate / 1e6, color='C4')
+ax1.set_ylabel('heat release rate [MW/m³]', color='C4')
+ax1.set_xlim(0, 0.01)
+ax1.set(xlabel='distance from burner [m]')
+
+ax2 = ax1.twinx()
+ax2.plot(f.grid, f.T, color='C3')
+ax2.set_ylabel('temperature [K]', color='C3')
+plt.show()
+
+# %%
+# Major Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+major = ('O2', 'H2', 'H2O')
+states = f.to_array()
+ax.plot(states.grid, states(*major).X, label=major)
+ax.set(xlabel='distance from burner [m]', ylabel='mole fractions')
+ax.set_xlim(0, 0.01)
+ax.legend()
+plt.show()
+
+# %%
+# Minor Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+minor = ('OH', 'H', 'O')
+
+ax.plot(states.grid, states(*minor).X, label=minor, linestyle='--')
+ax.set(xlabel='distance from burner [m]', ylabel='mole fractions', )
+ax.set_xlim(0, 0.01)
+ax.legend()
+plt.show()

--- a/samples/python/onedim/flame_initial_guess.py
+++ b/samples/python/onedim/flame_initial_guess.py
@@ -64,7 +64,8 @@ output_path.mkdir(parents=True, exist_ok=True)
 
 print("Save YAML")
 yaml_filepath = output_path / "flame.yaml"
-f.save(yaml_filepath, name="solution", description="Initial methane flame")
+f.save(yaml_filepath, name="solution", description="Initial methane flame",
+       overwrite=True)
 
 print("Save CSV")
 csv_filepath = output_path / "flame.csv"
@@ -74,7 +75,8 @@ if "native" in ct.hdf_support():
     # HDF is not a required dependency
     hdf_filepath = output_path / "flame.h5"
     hdf_filepath.unlink(missing_ok=True)
-    f.save(hdf_filepath, name="freeflame", description="Initial methane flame")
+    f.save(hdf_filepath, name="freeflame", description="Initial methane flame",
+           overwrite=True)
     print("Save HDF\n")
 else:
     print(f"Skipping HDF: Cantera compiled without HDF support\n")

--- a/samples/python/onedim/flame_initial_guess.py
+++ b/samples/python/onedim/flame_initial_guess.py
@@ -18,6 +18,9 @@ try:
 except ImportError:
     pd = None
 
+# %%
+# Initialization
+# --------------
 
 # Simulation parameters
 p = ct.one_atm  # pressure [Pa]
@@ -52,7 +55,9 @@ def describe(flame):
 
 describe(f)
 
+# %%
 # Save the flame in a few different formats
+# -----------------------------------------
 
 output_path = Path() / "flame_initial_guess_data"
 output_path.mkdir(parents=True, exist_ok=True)
@@ -75,37 +80,44 @@ else:
     print(f"Skipping HDF: Cantera compiled without HDF support\n")
     hdf_filepath = None
 
+# %%
 # Restore the flame from different formats
-
-print("Restore solution from YAML")
+# ----------------------------------------
+#
+# Restore solution from YAML
 gas.TPX = Tin, p, reactants
 f2 = ct.FreeFlame(gas, width=width)
 f2.restore(yaml_filepath, name="solution")
 describe(f2)
 
+# %%
+# Restore solution from HDF
 if hdf_filepath:
-    print("Restore solution from HDF")
     gas.TPX = Tin, p, reactants
     f2 = ct.FreeFlame(gas, width=width)
     f2.restore(hdf_filepath, name="freeflame")
     describe(f2)
 
+# %%
 # Restore the flame via initial guess
-
-print("Load initial guess from CSV file directly")
+# -----------------------------------
+# Load initial guess from CSV file directly
 gas.TPX = Tin, p, reactants  # set the gas T back to the inlet before making new flame
 f2 = ct.FreeFlame(gas, width=width)
 f2.set_initial_guess(data=csv_filepath)
 describe(f2)
 
+# %%
+# Load initial guess from HDF file directly
 if hdf_filepath:
-    print("Load initial guess from HDF file directly")
     gas.TPX = Tin, p, reactants  # set the gas T back to the inlet before making new flame
     f2 = ct.FreeFlame(gas, width=width)
     f2.set_initial_guess(data=hdf_filepath, group="freeflame")
     describe(f2)
 
-    print("Load initial guess from HDF file via SolutionArray")
+# %%
+# Load initial guess from HDF file via SolutionArray
+if hdf_filepath:
     arr2 = ct.SolutionArray(gas)
     # the flame domain needs to be specified as subgroup
     arr2.restore(hdf_filepath, name="freeflame", sub="flame")
@@ -114,19 +126,22 @@ if hdf_filepath:
     f2.set_initial_guess(data=arr2)
     describe(f2)
 
+# %%
 if pd is None:
     # skip remaining examples, as optional dependency 'pandas' is not installed
     print("All done")
     sys.exit()
 
-print("Load initial guess from CSV file via Pandas")
+# %%
+# Load initial guess from CSV file via Pandas
 df = pd.read_csv(csv_filepath)
 gas.TPX = Tin, p, reactants  # set the gas T back to the inlet before making new flame
 f2 = ct.FreeFlame(gas, width=width)
 f2.set_initial_guess(data=df)
 describe(f2)
 
-print("Load initial guess from CSV file via Pandas and SolutionArray")
+# %%
+# Load initial guess from CSV file via Pandas and SolutionArray
 df = pd.read_csv(csv_filepath)
 arr2 = ct.SolutionArray(gas)
 arr2.from_pandas(df)
@@ -135,37 +150,41 @@ f2 = ct.FreeFlame(gas, width=width)
 f2.set_initial_guess(data=arr2)
 describe(f2)
 
+# %%
 # Restart flame simulations with modified initial guesses
-
-print("Load initial guess from CSV file via Pandas, with modifications.\n")
+# -------------------------------------------------------
+# Load initial guess from CSV file via Pandas, with modifications.
 df = pd.read_csv(csv_filepath)
-print("Modify the Pandas dataframe, removing half the grid points")
+
+# %%
+# Modify the Pandas dataframe, removing half the grid points
 df_pruned = df[::2]  # remove half of the grid points
 gas.TPX = Tin, p, reactants  # set the gas T back to the inlet before making new flame
 f2 = ct.FreeFlame(gas, width=width)
 f2.set_refine_criteria(**refine_criteria)
 f2.set_initial_guess(data=df_pruned)
 f2.solve()
+
+# %%
 # We wouldn't expect the flame solutions to be exactly the same
 describe(f2)
 
-print(
-    "Modify the Pandas dataframe, removing half the grid points "
-    "and all but the first 20 species"
-)
+# %%
+# Modify the Pandas dataframe, removing half the grid points and all but the first 20
+# species
 df_pruned = df.iloc[::2, :24]
 gas.TPX = Tin, p, reactants  # set the gas T back to the inlet before making new flame
 f2 = ct.FreeFlame(gas, width=width)
 f2.set_refine_criteria(**refine_criteria)
 f2.set_initial_guess(data=df_pruned)
 f2.solve()
+
+# %%
 # We wouldn't expect the flame solutions to be exactly the same
 describe(f2)
 
-print(
-    "Modify the Pandas dataframe, removing half the grid points, "
-    "and raise the T by 50 K"
-)
+# %%
+# Modify the Pandas dataframe, removing half the grid points, and raise the T by 50 K
 df_pruned = df.iloc[::2]
 # set the gas T back to the (new) inlet before making new flame
 gas.TPX = (Tin + 50, p, reactants)
@@ -173,7 +192,7 @@ f2 = ct.FreeFlame(gas, width=width)
 f2.set_refine_criteria(**refine_criteria)
 f2.set_initial_guess(data=df_pruned)
 f2.solve()
+
+# %%
 # We expect these flames to be different because we raised the temperature.
 describe(f2)
-
-print("All done")

--- a/samples/python/onedim/flame_speed.py
+++ b/samples/python/onedim/flame_speed.py
@@ -33,17 +33,22 @@ import cantera as ct
 import matplotlib.pyplot as plt
 import numpy as np
 
-fig, ax = plt.subplots()
+# %%
+# Run Simulations
+# ---------------
+
 file = 'example_data/ammonia-CO-H2-Alzueta-2023.yaml'
 models = {'Original': 'baseline', 'LMR-R': 'linear-Burke'}
-colours = ["xkcd:grey",'xkcd:purple']
+colours = {'Original': "xkcd:grey", 'LMR-R': 'xkcd:purple'}
+results = {}
+
 Tin = 296  # unburned gas temperature [K]
 p=760  # pressure [torr]
 n=16 # number of points to simulate
 phi_list = np.linspace(0.6,2.0,n) # equivalence ratios to simulate across
-for k, m in enumerate(models):
+for m, name in models.items():
     vel_list = []
-    gas = ct.Solution(file, name=models[m])
+    gas = ct.Solution(file, name=name)
     for j, phi in enumerate(phi_list):
         gas.set_equivalence_ratio(phi, 'NH3', {'O2':1, 'N2': 3.76})
         gas.TP = Tin, (p/760)*ct.one_atm
@@ -53,14 +58,25 @@ for k, m in enumerate(models):
         # f.soret_enabled = True  # optionally enable
         f.solve(loglevel=1, auto=True)
         vel_list.append(f.velocity[0] * 100) # cm/s
-    ax.plot(phi_list, vel_list, color=colours[k], label=m)
+    results[m] = vel_list
+
+# %%
+# Experimental data from Ronney (1988)
 expData = {
    'X_NH3': [16.3,16.4,17.0,18.0,19.0,20.0,21.9,24.0,26.0,28.5,29.0,30.0,31.0,31.5],
    'vel': [1.35,1.48,2.30,3.36,4.01,5.88,6.80,8.14,6.73,5.00,4.78,3.3,2.9,3.0]
 }
-X_NH3 = np.divide(expData['X_NH3'],100)
-X_O2 = np.multiply(np.subtract(1,X_NH3), 0.21)
-phi_data = np.divide(np.divide(X_NH3,X_O2),np.divide(4,3))
+X_NH3 = np.array(expData['X_NH3']) / 100
+X_O2 = (1 - X_NH3) * 0.21
+phi_data = (X_NH3/X_O2) / (4/3)
+
+# %%
+# Plot Results
+# ------------
+
+fig, ax = plt.subplots()
+for m, vel_list in results.items():
+    ax.plot(phi_list, vel_list, color=colours[m], label=m)
 ax.plot(phi_data, expData['vel'], 'o', fillstyle='none', color='k', label='Ronney')
 ax.legend(frameon=False, loc='upper right')
 ax.set_ylabel(r'Burning velocity [cm $\rm s^{-1}$]')

--- a/samples/python/onedim/flame_speed.py
+++ b/samples/python/onedim/flame_speed.py
@@ -39,7 +39,7 @@ import numpy as np
 
 file = 'example_data/ammonia-CO-H2-Alzueta-2023.yaml'
 models = {'Original': 'baseline', 'LMR-R': 'linear-Burke'}
-colours = {'Original': "xkcd:grey", 'LMR-R': 'xkcd:purple'}
+colors = {'Original': "xkcd:grey", 'LMR-R': 'xkcd:purple'}
 results = {}
 
 Tin = 296  # unburned gas temperature [K]
@@ -76,7 +76,7 @@ phi_data = (X_NH3/X_O2) / (4/3)
 
 fig, ax = plt.subplots()
 for m, vel_list in results.items():
-    ax.plot(phi_list, vel_list, color=colours[m], label=m)
+    ax.plot(phi_list, vel_list, color=colors[m], label=m)
 ax.plot(phi_data, expData['vel'], 'o', fillstyle='none', color='k', label='Ronney')
 ax.legend(frameon=False, loc='upper right')
 ax.set_ylabel(r'Burning velocity [cm $\rm s^{-1}$]')

--- a/samples/python/onedim/ion_burner_flame.py
+++ b/samples/python/onedim/ion_burner_flame.py
@@ -4,14 +4,14 @@ Burner-stabilized flame including ionized species
 
 A burner-stabilized premixed methane-air flame with charged species.
 
-Requires: cantera >= 3.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, 1D flow, burner-stabilized flame, plasma, premixed flame
 """
 
 from pathlib import Path
+import matplotlib.pyplot as plt
 import cantera as ct
-
 
 p = ct.one_atm
 tburner = 600.0
@@ -40,3 +40,44 @@ output.unlink(missing_ok=True)
 f.save(output, name="mix", description="solution with mixture-averaged transport")
 
 f.save('ion_burner_flame.csv', basis="mole", overwrite=True)
+
+# %%
+# Temperature and Heat Release Rate
+# ---------------------------------
+fig, ax1 = plt.subplots()
+
+ax1.plot(f.grid * 1000, f.heat_release_rate / 1e6, color='C4')
+ax1.set_ylabel('heat release rate [MW/m³]', color='C4')
+ax1.set_xlim(0, 3.0)
+ax1.set(xlabel='distance from burner [mm]')
+
+ax2 = ax1.twinx()
+ax2.plot(f.grid * 1000, f.T, color='C3')
+ax2.set_ylabel('temperature [K]', color='C3')
+plt.show()
+
+# %%
+# Major Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+major = ('O2', 'CH4', 'H2O', 'CO2')
+states = f.to_array()
+ax.plot(states.grid * 1000, states(*major).X, label=major)
+ax.set(xlabel='distance from burner [mm]', ylabel='mole fractions')
+ax.set_xlim(0, 3.0)
+ax.legend()
+plt.show()
+
+#sphinx_gallery_thumbnail_number = 2
+
+# %%
+# Ionized Species Profiles
+# ------------------------
+fig, ax = plt.subplots()
+minor = ('E', 'H3O+', 'HCO+')
+
+ax.semilogy(states.grid * 1000, states(*minor).X, label=minor, linestyle='--')
+ax.set(xlabel='distance from burner [mm]', ylabel='mole fractions', )
+ax.set_xlim(0, 3.0)
+ax.legend()
+plt.show()

--- a/samples/python/onedim/ion_free_flame.py
+++ b/samples/python/onedim/ion_free_flame.py
@@ -4,12 +4,14 @@ Freely-propagating flame with charged species
 
 A freely-propagating, premixed methane-air flat flame with charged species.
 
-Requires: cantera >= 3.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, 1D flow, burner-stabilized flame, plasma, premixed flame
 """
 
 from pathlib import Path
+import numpy as np
+import matplotlib.pyplot as plt
 import cantera as ct
 
 
@@ -49,3 +51,53 @@ print(f"mixture-averaged flamespeed = {f.velocity[0]:7f} m/s")
 
 # write the velocity, temperature, density, and mole fractions to a CSV file
 f.save('ion_free_flame.csv', basis="mole", overwrite=True)
+
+# %%
+# Temperature and Heat Release Rate
+# ---------------------------------
+
+# Find the region that covers most of the temperature rise
+z = 1000 * f.grid  # convert to mm
+i_left = np.where(f.T > f.T[0] + 0.01 * (f.T[-1] - f.T[0]))[0][0]
+i_right = np.where(f.T > f.T[0] + 0.95 * (f.T[-1] - f.T[0]))[0][0]
+z_left = z[i_left]
+z_right = z[i_right]
+dz = z_right - z_left
+z_left -= 0.3 * dz
+z_right += 0.3 * dz
+
+fig, ax1 = plt.subplots()
+ax1.plot(z, f.heat_release_rate / 1e6, color='C4')
+ax1.set_ylabel('heat release rate [MW/m³]', color='C4')
+ax1.set(xlabel='flame coordinate [mm]', xlim=[z_left, z_right])
+
+ax2 = ax1.twinx()
+ax2.plot(z, f.T, color='C3')
+ax2.set_ylabel('temperature [K]', color='C3')
+plt.show()
+
+# %%
+# Major Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+major = ('O2', 'CH4', 'H2O', 'CO2')
+states = f.to_array()
+ax.plot(z, states(*major).X, label=major)
+ax.set(xlabel='flame coordinate [mm]', ylabel='mole fractions')
+ax.set_xlim(z_left, z_right)
+ax.legend()
+plt.show()
+
+# %%
+# Minor / Ionized Species Profiles
+# --------------------------------
+fig, ax = plt.subplots()
+minor = ('OH', 'H', 'O', 'E', 'HCO+', 'H3O+')
+
+ax.semilogy(z, states(*minor).X, label=minor, linestyle='--')
+ax.set(xlabel='flame coordinate [mm]', ylabel='mole fractions')
+ax.set_xlim(z_left, z_right)
+ax.legend()
+plt.show()
+
+#sphinx_gallery_thumbnail_number = -1

--- a/samples/python/onedim/premixed_counterflow_flame.py
+++ b/samples/python/onedim/premixed_counterflow_flame.py
@@ -5,14 +5,14 @@ Opposed-flow premixed strained flame
 This script simulates a lean hydrogen-oxygen flame stabilized in a strained
 flowfield, with an opposed flow consisting of equilibrium products.
 
-Requires: cantera >= 3.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, 1D flow, premixed flame, strained flame
 """
 
 from pathlib import Path
+import matplotlib.pyplot as plt
 import cantera as ct
-
 
 # parameter values
 p = 0.05 * ct.one_atm  # pressure
@@ -58,3 +58,38 @@ sim.save(output, name="mix", description="solution with mixture-averaged transpo
 sim.save("premixed_counterflow_flame.csv", basis="mole", overwrite=True)
 sim.show_stats()
 sim.show()
+
+# %%
+# Temperature and Heat Release Rate
+# ---------------------------------
+fig, ax1 = plt.subplots()
+
+ax1.plot(sim.grid, sim.heat_release_rate / 1e6, color='C4')
+ax1.set_ylabel('heat release rate [MW/m³]', color='C4')
+ax1.set(xlabel='flame coordinate [m]')
+
+ax2 = ax1.twinx()
+ax2.plot(sim.grid, sim.T, color='C3')
+ax2.set_ylabel('temperature [K]', color='C3')
+plt.show()
+
+# %%
+# Major Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+major = ('O2', 'H2', 'H2O')
+states = sim.to_array()
+ax.plot(states.grid, states(*major).X, label=major)
+ax.set(xlabel='flame coordinate [m]', ylabel='mole fractions')
+ax.legend()
+plt.show()
+
+# %%
+# Minor Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+minor = ('OH', 'H', 'O')
+ax.plot(states.grid, states(*minor).X, label=minor, linestyle='--')
+ax.set(xlabel='flame coordinate [m]', ylabel='mole fractions', )
+ax.legend()
+plt.show()

--- a/samples/python/onedim/stagnation_flame.py
+++ b/samples/python/onedim/stagnation_flame.py
@@ -15,12 +15,13 @@ the mass flowrate is increased. Without using 'prune', a large number of grid
 points would be concentrated upstream of the flame, where the flamefront had
 been previously. (To see this, try setting prune to zero.)
 
-Requires: cantera >= 3.0
+Requires: cantera >= 3.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, 1D flow, premixed flame, strained flame
 """
 
 from pathlib import Path
+import matplotlib.pyplot as plt
 import cantera as ct
 
 # %%
@@ -87,12 +88,66 @@ else:
     output = output_path / "stagnation_flame.yaml"
 output.unlink(missing_ok=True)
 
+results = []
 for m, md in enumerate(mdot):
     sim.inlet.mdot = md
     sim.solve(loglevel)
+    results.append(sim.to_array())
     sim.save(output, name=f"mdot-{m}", description=f"mdot = {md} kg/m2/s")
 
     # write the velocity, temperature, and mole fractions to a CSV file
     sim.save(output_path / f"stagnation_flame_{m}.csv", basis="mole", overwrite=True)
 
 sim.show_stats()
+
+# %%
+# Temperature and Heat Release Rate
+# ---------------------------------
+fig, ax1 = plt.subplots()
+ax2 = ax1.twinx()
+styles = ['-', '--']
+for n, i in enumerate([1, -1]):
+    ax1.plot(results[i].grid, results[i].heat_release_rate / 1e6,
+             linestyle=styles[n], color='C4', label=rf'$\dot m = {mdot[i]:.2f}$ kg/s')
+    ax2.plot(results[i].grid, results[i].T,
+             linestyle=styles[n], color='C3', label=rf'$\dot m = {mdot[i]:.2f}$ kg/s')
+
+ax1.set_ylabel('heat release rate [MW/m³]', color='C4')
+ax1.set(xlabel='distance from inlet [m]')
+ax2.set_ylabel('temperature [K]', color='C3')
+ax2.legend()
+plt.show()
+
+# %%
+# Major Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+major = ('O2', 'H2', 'H2O')
+states = sim.to_array()
+handles = []
+for n, i in enumerate([1, -1]):
+    for k, spec in enumerate(major):
+        h = ax.plot(results[i].grid, results[i](spec).X,
+                    linestyle=styles[n], color=f'C{k}',
+                    label=rf'{spec}, $\dot m = {mdot[i]}$ kg/s')
+
+ax.set(xlabel='distance from inlet [m]', ylabel='mole fractions')
+ax.legend()
+plt.show()
+
+# %%
+# Minor Species Profiles
+# ----------------------
+fig, ax = plt.subplots()
+minor = ('OH', 'H', 'O')
+states = sim.to_array()
+handles = []
+for n, i in enumerate([1, -1]):
+    for k, spec in enumerate(minor):
+        h = ax.plot(results[i].grid, results[i](spec).X,
+                    linestyle=styles[n], color=f'C{k+5}',
+                    label=rf'{spec}, $\dot m = {mdot[i]}$ kg/s')
+
+ax.set(xlabel='distance from inlet [m]', ylabel='mole fractions')
+ax.legend()
+plt.show()

--- a/samples/python/onedim/stagnation_flame.py
+++ b/samples/python/onedim/stagnation_flame.py
@@ -23,8 +23,9 @@ Requires: cantera >= 3.0
 from pathlib import Path
 import cantera as ct
 
-
-# parameter values
+# %%
+# Parameter Values
+# ----------------
 p = 0.05 * ct.one_atm  # pressure
 tburner = 373.0  # burner temperature
 tsurf = 500.0
@@ -47,7 +48,9 @@ slope = 0.1
 curve = 0.2
 prune = 0.06
 
-# Set up the problem
+# %%
+# Set Up the Problem
+# ------------------
 gas = ct.Solution(rxnmech)
 
 # set state to that of the unburned gas at the burner
@@ -70,6 +73,9 @@ sim.set_refine_criteria(ratio=ratio, slope=slope, curve=curve, prune=prune)
 sim.set_initial_guess(products='equil')  # assume adiabatic equilibrium products
 sim.show()
 
+# %%
+# Solve the Problem and Write Output
+# ----------------------------------
 sim.solve(loglevel, auto=True)
 
 output_path = Path() / "stagnation_flame_data"

--- a/samples/python/reactors/periodic_cstr.py
+++ b/samples/python/reactors/periodic_cstr.py
@@ -29,7 +29,9 @@ Requires: cantera >= 2.5.0, matplotlib >= 2.0
 
 import cantera as ct
 import matplotlib.pyplot as plt
-# create the gas mixture
+
+# %%
+# Create the gas mixture and set initial conditions
 gas = ct.Solution('h2o2.yaml')
 
 # pressure = 60 Torr, T = 770 K
@@ -38,29 +40,34 @@ t = 770.0
 
 gas.TPX = t, p, 'H2:2, O2:1'
 
-# create an upstream reservoir that will supply the reactor. The temperature,
+# %%
+# Create an upstream reservoir that will supply the reactor. The temperature,
 # pressure, and composition of the upstream reservoir are set to those of the
-# 'gas' object at the time the reservoir is created.
+# ``gas`` object at the time the reservoir is created.
 upstream = ct.Reservoir(gas)
 
-# Now create the reactor object with the same initial state
-cstr = ct.IdealGasReactor(gas)
-
-# Set its volume to 10 cm^3. In this problem, the reactor volume is fixed, so
+# %%
+# Now create the reactor object with the same initial state.
+#
+# Set its volume to 10 cm³. In this problem, the reactor volume is fixed, so
 # the initial volume is the volume at all later times.
+cstr = ct.IdealGasReactor(gas)
 cstr.volume = 10.0*1.0e-6
 
+# %%
 # We need to have heat loss to see the oscillations. Create a reservoir to
 # represent the environment, and initialize its temperature to the reactor
 # temperature.
 env = ct.Reservoir(gas)
 
+# %%
 # Create a heat-conducting wall between the reactor and the environment. Set its
-# area, and its overall heat transfer coefficient. Larger U causes the reactor
-# to be closer to isothermal. If U is too small, the gas ignites, and the
+# area, and its overall heat transfer coefficient. Larger ``U`` causes the reactor
+# to be closer to isothermal. If ``U`` is too small, the gas ignites, and the
 # temperature spikes and stays high.
 w = ct.Wall(cstr, env, A=1.0, U=0.02)
 
+# %%
 # Connect the upstream reservoir to the reactor with a mass flow controller
 # (constant mdot). Set the mass flow rate to 1.25 sccm.
 sccm = 1.25
@@ -68,18 +75,16 @@ vdot = sccm * 1.0e-6 / 60.0 * ((ct.one_atm / gas.P) * (gas.T / 273.15))  # m^3/s
 mdot = gas.density * vdot  # kg/s
 mfc = ct.MassFlowController(upstream, cstr, mdot=mdot)
 
-# now create a downstream reservoir to exhaust into.
+# %%
+# Now create a downstream reservoir to exhaust into and connect the reactor to this
+# reservoir with a valve. Set the coefficient sufficiently large to keep the reactor
+# pressure close to the downstream pressure of 60 Torr.
 downstream = ct.Reservoir(gas)
-
-# connect the reactor to the downstream reservoir with a valve, and set the
-# coefficient sufficiently large to keep the reactor pressure close to the
-# downstream pressure of 60 Torr.
 v = ct.Valve(cstr, downstream, K=1.0e-9)
 
-# create the network
+# %%
+# Create the network and integrate in time:
 network = ct.ReactorNet([cstr])
-
-# now integrate in time
 t = 0.0
 dt = 0.1
 
@@ -93,12 +98,10 @@ aliases = {'H2': 'H$_2$', 'O2': 'O$_2$', 'H2O': 'H$_2$O'}
 for name, alias in aliases.items():
     gas.add_species_alias(name, alias)
 
-if __name__ == '__main__':
-    print(__doc__)
-    plt.figure(1)
-    for spc in aliases.values():
-        plt.plot(states.t, states(spc).Y, label=spc)
-    plt.legend(loc='upper right')
-    plt.xlabel('time [s]')
-    plt.ylabel('mass fraction')
-    plt.show()
+fig, ax = plt.subplots()
+for spc in aliases.values():
+    ax.plot(states.t, states(spc).Y, label=spc)
+plt.legend(loc='upper right')
+plt.xlabel('time [s]')
+plt.ylabel('mass fraction')
+plt.show()

--- a/samples/python/thermo/coverage_dependent_surf.py
+++ b/samples/python/thermo/coverage_dependent_surf.py
@@ -29,7 +29,9 @@ import cantera as ct
 import numpy as np
 import matplotlib.pyplot as plt
 
-# first demonstration: the four coverage dependency models
+# %%
+# First demonstration: the four coverage dependency models
+# --------------------------------------------------------
 
 # provide discrete enthalpy and entropy values calculated with DFT
 # array of CO* coverage
@@ -72,33 +74,35 @@ for model in models_dict:
         models_dict[model]['hrt'].append(phase.standard_enthalpies_RT[i_CO])
         models_dict[model]['sr'].append(phase.standard_entropies_R[i_CO])
 
-# plot coverage-dependent enthalpy against DFT-derived enthalpy data
-plt.plot(dft_covs, dft_hrts, marker='o', color='k', linewidth=0,
-         label='DFT data')
+# %%
+# Plot coverage-dependent enthalpy against DFT-derived enthalpy data
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+fig, ax = plt.subplots()
+ax.plot(dft_covs, dft_hrts, marker='o', color='k', linewidth=0, label='DFT data')
 for model in models_dict:
-    plt.plot(CO_covs, models_dict[model]['hrt'], label=model)
-plt.xlabel(r'$\theta_\mathrm{CO*}$')
-plt.ylabel(r'$h^{\circ}_\mathrm{CO*}/\mathrm{R}T$')
-plt.legend(loc='best')
-plt.title('CO* standard state enthalpy\n'
-           + 'with four dependency models at 300 K, 1 atm')
+    ax.plot(CO_covs, models_dict[model]['hrt'], label=model)
+ax.set(xlabel=r'$\theta_\mathrm{CO*}$')
+ax.set(ylabel=r'$h^{\circ}_\mathrm{CO*}/\mathrm{R}T$')
+ax.legend(loc='best')
+ax.set_title('CO* standard state enthalpy\nwith four dependency models at 300 K, 1 atm')
 plt.show()
-plt.clf()
 
-# plot coverage-dependent entropy against DFT-derived enthalpy data
-plt.plot(dft_covs, dft_srs, marker='o', color='k', linewidth=0,
-         label='DFT data')
+# %%
+# Plot coverage-dependent entropy against DFT-derived enthalpy data
+# ~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~~
+fig, ax = plt.subplots()
+ax.plot(dft_covs, dft_srs, marker='o', color='k', linewidth=0, label='DFT data')
 for model in models_dict:
-    plt.plot(CO_covs, models_dict[model]['sr'], label=model)
-plt.xlabel(r'$\theta_\mathrm{CO*}$')
-plt.ylabel(r'$s^{\circ}_\mathrm{CO*}/\mathrm{R}$')
-plt.legend(loc='best')
-plt.title('CO* standard state entropy\n'
-          + 'with four dependency models at 300 K, 1 atm')
+    ax.plot(CO_covs, models_dict[model]['sr'], label=model)
+ax.set(xlabel=r'$\theta_\mathrm{CO*}$')
+ax.set(ylabel=r'$s^{\circ}_\mathrm{CO*}/\mathrm{R}$')
+ax.legend(loc='best')
+ax.set_title('CO* standard state entropy\nwith four dependency models at 300 K, 1 atm')
 plt.show()
-plt.clf()
 
-# second demonstration: coverage dependence from self- and cross-interaction
+# %%
+# Second demonstration: coverage dependence from self- and cross-interaction
+# --------------------------------------------------------------------------
 
 # import a phase with both types of lateral interactions
 phase = ct.Interface('example_data/covdepsurf.yaml', 'covdep_cross')
@@ -117,15 +121,16 @@ for i, CO_cov in enumerate(covs):
         phase.coverages = [1. - CO_cov - O_cov, CO_cov, O_cov]
         CO_hrts[i,j] = phase.standard_enthalpies_RT[i_CO]
 
-# plot the enthalpy matrix
-cntr = plt.contourf(covs, covs, CO_hrts,
-                    levels=np.linspace(-120, -50, 71),
-                    cmap='inferno')
+# %%
+# Plot the enthalpy matrix
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+fig, ax = plt.subplots()
+cntr = ax.contourf(covs, covs, CO_hrts,
+                   levels=np.linspace(-120, -50, 71),
+                   cmap='inferno')
 
-plt.xlabel(r'$\theta_\mathrm{CO*}$')
-plt.ylabel(r'$\theta_\mathrm{O*}$')
-cbar = plt.colorbar(cntr)
+ax.set(xlabel=r'$\theta_\mathrm{CO*}$', ylabel=r'$\theta_\mathrm{O*}$')
+cbar = fig.colorbar(cntr)
 cbar.ax.set_ylabel(r'$h^{\circ}_\mathrm{CO*}/\mathrm{R}T$')
-plt.title('CO* standard state enthalpy\n'
-          + 'with CO*$-$CO* and CO*$-$O* interactions')
+ax.set_title('CO* standard state enthalpy\nwith CO*$-$CO* and CO*$-$O* interactions')
 plt.show()

--- a/samples/python/thermo/critical_properties.py
+++ b/samples/python/thermo/critical_properties.py
@@ -9,7 +9,10 @@ built-in liquid/vapor equations of state.
 """
 
 import cantera as ct
+import matplotlib.pyplot as plt
 
+# %%
+# Create `PureFluid` objects:
 fluids = {'water': ct.Water(),
           'nitrogen': ct.Nitrogen(),
           'methane': ct.Methane(),
@@ -17,11 +20,16 @@ fluids = {'water': ct.Water(),
           'oxygen': ct.Oxygen(),
           'carbon dioxide': ct.CarbonDioxide(),
           'heptane': ct.Heptane(),
-          'hfc134a': ct.Hfc134a()
+          'HFC-134a': ct.Hfc134a()
           }
 
+# %%
+# Plot critical properties and print tabulated values:
+fig, ax = plt.subplots()
+
 print('Critical State Properties')
-print('%20s  %10s  %10s  %10s' % ('Fluid','Tc [K]', 'Pc [Pa]', 'Zc'))
+print(f"{'Fluid':^16s}   {'Tc [K]':^7s}   {'Pc [Pa]':^10s}   {'Zc':^7s}")
+print(f"{'-'*16}   {'-'*7}   {'-'*10}   {'-'*7}")
 for name in fluids:
     f = fluids[name]
     tc = f.critical_temperature
@@ -29,4 +37,11 @@ for name in fluids:
     rc = f.critical_density
     mw = f.mean_molecular_weight
     zc = pc * mw / (rc * ct.gas_constant * tc)
-    print('%20s   %10.4g   %10.4G  %10.4G' % (name, tc, pc, zc))
+    ax.plot(tc, pc, 'o')
+    ax.annotate(name, (tc, pc), (4, 2), textcoords='offset points', size=9)
+    print(f'{name:16s}   {tc:7.2f}   {pc:10.4g}   {zc:7.4f}')
+
+ax.set(xlabel='Critical Temperature [K]', ylabel='Critical Pressure [Pa]')
+ax.set(xlim=(0, 750))
+ax.grid(True)
+plt.show()

--- a/samples/python/thermo/mixing.py
+++ b/samples/python/thermo/mixing.py
@@ -13,6 +13,10 @@ Requires: cantera >= 2.5.0
 .. tags:: Python, thermodynamics, mixture
 """
 
+# %%
+# Set up streams
+# --------------
+
 import cantera as ct
 
 gas = ct.Solution('gri30.yaml')
@@ -31,10 +35,14 @@ A.moles = 1
 nO2 = A.X[A.species_index('O2')]
 B.moles = nO2 * 0.5
 
+# %%
 # Compute the mixed state
+# -----------------------
 M = A + B
 print(M.report())
 
+# %%
 # Show that this state corresponds to stoichiometric combustion
+# -------------------------------------------------------------
 M.equilibrate('TP')
 print(M.report())

--- a/samples/python/thermo/rankine.py
+++ b/samples/python/thermo/rankine.py
@@ -12,12 +12,16 @@ Requires: Cantera >= 2.5.0
 
 import cantera as ct
 
-# parameters
-eta_pump = 0.6     # pump isentropic efficiency
+# %%
+# Parameters
+# ----------
+eta_pump = 0.6  # pump isentropic efficiency
 eta_turbine = 0.8  # turbine isentropic efficiency
-p_max = 8.0e5       # maximum pressure
+p_max = 8.0e5  # maximum pressure
 
-
+# %%
+# Helper Functions
+# ----------------
 def pump(fluid, p_final, eta):
     """Adiabatically pump a fluid to pressure p_final, using
     a pump with isentropic efficiency eta."""
@@ -50,34 +54,40 @@ def printState(n, fluid):
     print('\n***************** State {0} ******************'.format(n))
     print(fluid.report())
 
+# %%
+# Evaluate Rankine Cycle
+# ----------------------
 
-if __name__ == '__main__':
-    # create an object representing water
-    w = ct.Water()
+# Create an object representing water:
+w = ct.Water()
 
-    # start with saturated liquid water at 300 K
-    w.TQ = 300.0, 0.0
-    h1 = w.h
-    p1 = w.P
-    printState(1, w)
+# %%
+# Start with saturated liquid water at 300 K:
+w.TQ = 300.0, 0.0
+h1 = w.h
+p1 = w.P
+printState(1, w)
 
-    # pump it adiabatically to p_max
-    pump_work = pump(w, p_max, eta_pump)
-    h2 = w.h
-    printState(2, w)
+# %%
+# Pump it adiabatically to ``p_max``:
+pump_work = pump(w, p_max, eta_pump)
+h2 = w.h
+printState(2, w)
 
-    # heat it at constant pressure until it reaches the saturated vapor state
-    # at this pressure
-    w.PQ = p_max, 1.0
-    h3 = w.h
-    heat_added = h3 - h2
-    printState(3, w)
+# %%
+# Heat it at constant pressure until it reaches the saturated vapor state
+# at this pressure:
+w.PQ = p_max, 1.0
+h3 = w.h
+heat_added = h3 - h2
+printState(3, w)
 
-    # expand back to p1
-    turbine_work = expand(w, p1, eta_turbine)
-    printState(4, w)
+# %%
+# expand back to ``p1``:
+turbine_work = expand(w, p1, eta_turbine)
+printState(4, w)
 
-    # efficiency
-    eff = (turbine_work - pump_work)/heat_added
-
-    print('efficiency = ', eff)
+# %%
+# Calculate the efficiency:
+eff = (turbine_work - pump_work)/heat_added
+print('efficiency = ', eff)

--- a/samples/python/thermo/rankine_units.py
+++ b/samples/python/thermo/rankine_units.py
@@ -12,12 +12,16 @@ Requires: Cantera >= 3.0.0, pint
 
 import cantera.with_units as ctu
 
-# parameters
+# %%
+# Parameters
+# ----------
 eta_pump = 0.6 * ctu.units.dimensionless  # pump isentropic efficiency
-eta_turbine = 0.8 * ctu.units.dimensionless # turbine isentropic efficiency
+eta_turbine = 0.8 * ctu.units.dimensionless  # turbine isentropic efficiency
 p_max = 116.03 * ctu.units.psi  # maximum pressure
 
-
+# %%
+# Helper Functions
+# ----------------
 def pump(fluid, p_final, eta):
     """Adiabatically pump a fluid to pressure p_final, using
     a pump with isentropic efficiency eta."""
@@ -50,34 +54,40 @@ def print_state(n, fluid):
     print('\n***************** State {0} ******************'.format(n))
     print(fluid.report())
 
+# %%
+# Evaluate Rankine Cycle
+# ----------------------
 
-if __name__ == '__main__':
-    # create an object representing water
-    w = ctu.Water()
+# Create an object representing water:
+w = ctu.Water()
 
-    # start with saturated liquid water at 80.33 degrees Fahrenheit
-    w.TQ = ctu.Q_(80.33, "degF"), 0.0 * ctu.units.dimensionless
-    h1 = w.h
-    p1 = w.P
-    print_state(1, w)
+# %%
+# Start with saturated liquid water at 80.33 degrees Fahrenheit:
+w.TQ = ctu.Q_(80.33, "degF"), 0.0 * ctu.units.dimensionless
+h1 = w.h
+p1 = w.P
+print_state(1, w)
 
-    # pump it adiabatically to p_max
-    pump_work = pump(w, p_max, eta_pump)
-    h2 = w.h
-    print_state(2, w)
+# %%
+# Pump it adiabatically to ``p_max``:
+pump_work = pump(w, p_max, eta_pump)
+h2 = w.h
+print_state(2, w)
 
-    # heat it at constant pressure until it reaches the saturated vapor state
-    # at this pressure
-    w.PQ = p_max, 1.0 * ctu.units.dimensionless
-    h3 = w.h
-    heat_added = h3 - h2
-    print_state(3, w)
+# %%
+# Heat it at constant pressure until it reaches the saturated vapor state
+# at this pressure:
+w.PQ = p_max, 1.0 * ctu.units.dimensionless
+h3 = w.h
+heat_added = h3 - h2
+print_state(3, w)
 
-    # expand back to p1
-    turbine_work = expand(w, p1, eta_turbine)
-    print_state(4, w)
+# %%
+# expand back to ``p1``:
+turbine_work = expand(w, p1, eta_turbine)
+print_state(4, w)
 
-    # efficiency
-    eff = (turbine_work - pump_work)/heat_added
-
-    print('efficiency = ', eff)
+# %%
+# Calculate the efficiency:
+eff = (turbine_work - pump_work)/heat_added
+print('efficiency = ', eff)

--- a/samples/python/thermo/sound_speed.py
+++ b/samples/python/thermo/sound_speed.py
@@ -4,7 +4,7 @@ Sound speeds
 
 Compute the "equilibrium" and "frozen" sound speeds for a gas
 
-Requires: cantera >= 3.0.0
+Requires: cantera >= 3.0.0, matplotlib
 
 .. tags:: Python, thermodynamics, equilibrium
 """
@@ -12,9 +12,10 @@ Requires: cantera >= 3.0.0
 import cantera as ct
 import math
 import numpy as np
+import matplotlib.pyplot as plt
 
 
-def equilSoundSpeeds(gas, rtol=1.0e-6, max_iter=5000):
+def equilSoundSpeeds(gas, rtol=1.0e-8, max_iter=5000):
     """
     Returns a tuple containing the equilibrium and frozen sound speeds for a
     gas with an equilibrium composition.  The gas is first set to an
@@ -51,12 +52,28 @@ def equilSoundSpeeds(gas, rtol=1.0e-6, max_iter=5000):
 
     return aequil, afrozen, afrozen2
 
+# %%
+# Calculate sound speed at a range of temperatures
+gas = ct.Solution('gri30_highT.yaml')
+gas.X = 'CH4:1.00, O2:2.0, N2:7.52'
+T_range = np.arange(300, 5901, 200)
+data = []
+print('   T     Equilibrium  Frozen manual  Frozen built-in')
+print('  [K]       [m/s]         [m/s]           [m/s]')
+print('-------  -----------  -------------  ---------------')
+for T in T_range:
+    gas.TP = T, ct.one_atm
+    aequil, afrozen, afrozen2 = equilSoundSpeeds(gas)
+    data.append((T, aequil, afrozen, afrozen2))
+    print(f'{T:6.1f}  {aequil:12.2f}  {afrozen:13.2f}  {afrozen2:15.2f}')
 
-# test program
-if __name__ == "__main__":
-    gas = ct.Solution('gri30.yaml')
-    gas.X = 'CH4:1.00, O2:2.0, N2:7.52'
-    T_range = np.arange(300, 2901, 100)
-    for T in T_range:
-        gas.TP = T, ct.one_atm
-        print(T, equilSoundSpeeds(gas))
+# %%
+# Plot results
+data = np.array(data)
+fig, ax = plt.subplots()
+ax.plot(data[:,0], data[:,1], label='Equilibrium')
+ax.plot(data[:,0], data[:,2], label='Frozen (manual)')
+ax.plot(data[:,0], data[:,3], linestyle='none', marker='.', label='Frozen (built-in)')
+ax.set(xlabel='T [K]', ylabel='Sound Speed [m/s]')
+ax.legend()
+plt.show()


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add plots to several examples
- Add `sphinx-gallery` section headings / description blocks to several examples
- Adjust plotting in some examples to avoid re-use of existing figures (which doesn't work well with `sphinx-gallery`) and use `plt.show()` more consistently for when examples are run from the command line
- More extensive revisions to `piston.py`, `mechanism_reduction.py`, `isentropic.py`, and `blowers_masel.py`
- Fix some issues with output files and missing `overwrite` flags when saving 1D flame data

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
