### PR TITLE
Replace transport logging with programmatic access

### DIFF
--- a/include/cantera/transport/GasTransport.h
+++ b/include/cantera/transport/GasTransport.h
@@ -148,7 +148,7 @@ public:
                                         double* bstar_coeffs,
                                         double* cstar_coeffs, bool actualT) override;
 
-    void init(ThermoPhase* thermo, int mode=0, int log_level=0) override;
+    void init(ThermoPhase* thermo, int mode=0, int log_level=-7) override;
 
     bool CKMode() const override {
         return m_mode == CK_Mode;
@@ -541,7 +541,8 @@ protected:
     //! Quadrupole polarizability
     vector<double> m_quad_polar;
 
-    //! Level of verbose printing during initialization
+    //! Level of verbose printing during initialization.
+    //! @deprecated To be removed after %Cantera 3.1.
     int m_log_level = 0;
 };
 

--- a/include/cantera/transport/IonGasTransport.h
+++ b/include/cantera/transport/IonGasTransport.h
@@ -40,7 +40,7 @@ public:
         return "ionized-gas";
     }
 
-    void init(ThermoPhase* thermo, int mode, int log_level) override;
+    void init(ThermoPhase* thermo, int mode, int log_level=-7) override;
 
     //! Viscosity of the mixture  (kg/m/s).
     //! Only Neutral species contribute to Viscosity.

--- a/include/cantera/transport/MixTransport.h
+++ b/include/cantera/transport/MixTransport.h
@@ -147,7 +147,7 @@ public:
                           size_t ldx, const double* const grad_X,
                           size_t ldf, double* const fluxes) override;
 
-    void init(ThermoPhase* thermo, int mode=0, int log_level=0) override;
+    void init(ThermoPhase* thermo, int mode=0, int log_level=-7) override;
 
 protected:
     //! Update the temperature dependent parts of the species thermal

--- a/include/cantera/transport/MultiTransport.h
+++ b/include/cantera/transport/MultiTransport.h
@@ -100,7 +100,7 @@ public:
     void getMassFluxes(const double* state1, const double* state2, double delta,
                        double* fluxes) override;
 
-    void init(ThermoPhase* thermo, int mode=0, int log_level=0) override;
+    void init(ThermoPhase* thermo, int mode=0, int log_level=-7) override;
 
 protected:
     //! Update basic temperature-dependent quantities if the temperature has

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -413,8 +413,10 @@ public:
      * @param mode    Chemkin compatible mode or not. This alters the
      *                 specification of the collision integrals. defaults to no.
      * @param log_level Defaults to zero, no logging
+     * @deprecated The `log_level` parameter is deprecated and will be removed after
+     *     %Cantera 3.1.
      */
-    virtual void init(ThermoPhase* thermo, int mode=0, int log_level=0) {}
+    virtual void init(ThermoPhase* thermo, int mode=0, int log_level=-7) {}
 
     //! Boolean indicating the form of the transport properties polynomial fits.
     //! Returns true if the Chemkin form is used.

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -20,12 +20,12 @@
 
 #include "cantera/base/ct_defs.h"
 #include "cantera/base/ctexceptions.h"
+#include "cantera/base/AnyMap.h"
 
 namespace Cantera
 {
 
 class ThermoPhase;
-class AnyMap;
 
 /**
  * @addtogroup tranprops
@@ -389,6 +389,16 @@ public:
     //! separately.
     AnyMap parameters() const;
 
+    //! Get error metrics about any functional fits calculated for pure species
+    //! transport properties.
+    //!
+    //! See GasTransport::fitDiffCoeffs and GasTransport::fitProperties.
+    //!
+    //! @warning  This method is an experimental part of the %Cantera API and may be
+    //!      changed or removed without notice.
+    //! @since New in %Cantera 3.1.
+    AnyMap fittingErrors() const { return m_fittingErrors; };
+
     //! @name Transport manager construction
     //!
     //! These methods are used during construction.
@@ -421,6 +431,9 @@ protected:
 
     //! Number of species
     size_t m_nsp = 0;
+
+    //! Maximum errors associated with fitting pure species transport properties.
+    AnyMap m_fittingErrors;
 };
 
 }

--- a/include/cantera/transport/TransportFactory.h
+++ b/include/cantera/transport/TransportFactory.h
@@ -54,16 +54,22 @@ public:
      *  @param model     String name for the transport manager
      *  @param thermo    ThermoPhase object
      *  @param log_level log level
+     *
+     *  @deprecated The `log_level` parameter is deprecated and will be removed after
+     *      %Cantera 3.1.
      */
-    Transport* newTransport(const string& model, ThermoPhase* thermo, int log_level=0);
+    Transport* newTransport(const string& model, ThermoPhase* thermo, int log_level=-7);
 
     //! Build a new transport manager using the default transport manager
     //! in the phase description and return a base class pointer to it
     /*!
      * @param thermo    ThermoPhase object
      * @param log_level log level
+     *
+     * @deprecated The `log_level` parameter is deprecated and will be removed after
+     *     %Cantera 3.1.
      */
-    Transport* newTransport(ThermoPhase* thermo, int log_level=0);
+    Transport* newTransport(ThermoPhase* thermo, int log_level=-7);
 
 private:
     //! Static instance of the factor -> This is the only instance of this

--- a/include/cantera/transport/WaterTransport.h
+++ b/include/cantera/transport/WaterTransport.h
@@ -57,7 +57,7 @@ public:
      */
     double thermalConductivity() override;
 
-    void init(ThermoPhase* thermo, int mode=0, int log_level=0) override;
+    void init(ThermoPhase* thermo, int mode=0, int log_level=-7) override;
 };
 }
 #endif

--- a/interfaces/cython/cantera/transport.pxd
+++ b/interfaces/cython/cantera/transport.pxd
@@ -18,7 +18,7 @@ cdef extern from "cantera/transport/Transport.h" namespace "Cantera":
         void getSpeciesViscosities(double*) except +translate_exception
         void getCollisionIntegralPolynomial(size_t i, size_t j, double* dataA, double* dataB, double* dataC) except +translate_exception
         void setCollisionIntegralPolynomial(size_t i, size_t j, double* dataA, double* dataB, double* dataC, cbool flag) except +translate_exception
-
+        CxxAnyMap fittingErrors()
 
 cdef extern from "cantera/transport/DustyGasTransport.h" namespace "Cantera":
     cdef cppclass CxxDustyGasTransport "Cantera::DustyGasTransport":

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -393,6 +393,23 @@ cdef class Transport(_SolutionBase):
         self.transport.setCollisionIntegralPolynomial(i, j, &adata[0], &bdata[0],
                                                       &cdata[0], actualT)
 
+    property transport_fitting_errors:
+        """
+        Get error metrics about any functional fits calculated for pure species
+        transport properties. See {ct}`GasTransport::fitDiffCoeffs` and
+        {ct}`GasTransport::fitProperties`.
+
+        .. warning::
+
+            This property is an experimental part of the Cantera API and
+            may be changed or removed without notice.
+
+        .. versionadded:: 3.1
+        """
+        def __get__(self):
+            cdef CxxAnyMap stats = self.transport.fittingErrors()
+            return anymap_to_py(stats)
+
 cdef class DustyGasTransport(Transport):
     """
     Implements the "dusty gas" model for transport in porous media.

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -29,7 +29,7 @@ void GasTransport::update_T()
 {
     if (m_thermo->nSpecies() != m_nsp) {
         // Rebuild data structures if number of species has changed
-        init(m_thermo, m_mode, m_log_level);
+        init(m_thermo, m_mode, m_log_level != 0 ? m_log_level : -7);
     }
 
     double T = m_thermo->temperature();
@@ -263,6 +263,12 @@ void GasTransport::init(ThermoPhase* thermo, int mode, int log_level)
     m_thermo = thermo;
     m_nsp = m_thermo->nSpecies();
     m_mode = mode;
+    if (log_level == -7) {
+        log_level = 0;
+    } else {
+        warn_deprecated("Transport::init", "The log_level parameter "
+            "is deprecated and will be removed after Cantera 3.1.");
+    }
     m_log_level = log_level;
 
     // set up Monchick and Mason collision integrals
@@ -372,7 +378,7 @@ void GasTransport::setupCollisionIntegral()
     // initialize the collision integral calculator for the desired T* range
     debuglog("*** collision_integrals ***\n", m_log_level);
     MMCollisionInt integrals;
-    integrals.init(tstar_min, tstar_max, m_log_level);
+    integrals.init(tstar_min, tstar_max, m_log_level != 0 ? m_log_level : -7);
     fitCollisionIntegrals(integrals);
     debuglog("*** end of collision_integrals ***\n", m_log_level);
     // make polynomial fits

--- a/src/transport/GasTransport.cpp
+++ b/src/transport/GasTransport.cpp
@@ -616,6 +616,8 @@ void GasTransport::fitProperties(MMCollisionInt& integrals)
             mxerr = std::max(mxerr, fabs(err));
             mxrelerr = std::max(mxrelerr, fabs(relerr));
         }
+        m_fittingErrors["viscosity-max-abs-error"] = mxerr;
+        m_fittingErrors["viscosity-max-rel-error"] = mxrelerr;
 
         // evaluate max fit errors for conductivity
         for (size_t n = 0; n < np; n++) {
@@ -635,6 +637,8 @@ void GasTransport::fitProperties(MMCollisionInt& integrals)
         }
         m_visccoeffs.push_back(c);
         m_condcoeffs.push_back(c2);
+        m_fittingErrors["conductivity-max-abs-error"] = mxerr_cond;
+        m_fittingErrors["conductivity-max-rel-error"] = mxrelerr_cond;
 
         if (m_log_level >= 2) {
             writelog(m_thermo->speciesName(k) + ": [" + vec2str(c) + "]\n");
@@ -690,8 +694,7 @@ void GasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
 
     // vector of polynomial coefficients
     vector<double> c(degree + 1), c2(degree + 1);
-    double err, relerr,
-               mxerr = 0.0, mxrelerr = 0.0;
+    double err, relerr, mxerr = 0.0, mxrelerr = 0.0;
 
     vector<double> diff(np + 1);
     m_diffcoeffs.clear();
@@ -744,6 +747,9 @@ void GasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
             }
         }
     }
+
+    m_fittingErrors["diff-coeff-max-abs-error"] = mxerr;
+    m_fittingErrors["diff-coeff-max-rel-error"] = mxrelerr;
     if (m_log_level) {
         writelogf("Maximum binary diffusion coefficient absolute error:"
                  "  %12.6g\n", mxerr);

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -23,6 +23,12 @@ void IonGasTransport::init(ThermoPhase* thermo, int mode, int log_level)
         throw CanteraError("IonGasTransport::init",
                            "mode = CK_Mode, which is an outdated lower-order fit.");
     }
+    if (log_level == -7) {
+        log_level = 0;
+    } else {
+        warn_deprecated("Transport::init", "The log_level parameter "
+            "is deprecated and will be removed after Cantera 3.1.");
+    }
     m_log_level = log_level;
     // make a local copy of species charge
     for (size_t k = 0; k < m_nsp; k++) {

--- a/src/transport/IonGasTransport.cpp
+++ b/src/transport/IonGasTransport.cpp
@@ -235,6 +235,12 @@ void IonGasTransport::fitDiffCoeffs(MMCollisionInt& integrals)
             }
         }
     }
+    m_fittingErrors["diff-coeff-max-abs-error"] =
+        std::max(m_fittingErrors.getDouble("diff-coeff-max-abs-error", 0.0),
+                 mxerr);
+    m_fittingErrors["diff-coeff-max-rel-error"] =
+        std::max(m_fittingErrors.getDouble("diff-coeff-max-rel-error", 0.0),
+                 mxrelerr);
 
     if (m_log_level) {
         writelogf("Maximum binary diffusion coefficient absolute error:"

--- a/src/transport/MMCollisionInt.cpp
+++ b/src/transport/MMCollisionInt.cpp
@@ -215,6 +215,12 @@ double MMCollisionInt::cstar_table[39*8] = {
 
 void MMCollisionInt::init(double tsmin, double tsmax, int log_level)
 {
+    if (log_level == -7) {
+        log_level = 0;
+    } else {
+        warn_deprecated("MMCollisionInt::init", "The log_level parameter "
+            "is deprecated and will be removed after Cantera 3.1.");
+    }
     m_loglevel = log_level;
     debuglog("Collision Integral Polynomial Fits\n", m_loglevel > 0);
     m_nmin = -1;

--- a/src/transport/MMCollisionInt.h
+++ b/src/transport/MMCollisionInt.h
@@ -33,8 +33,10 @@ public:
      *  @param tsmax       Maximum value of Tstar to carry out the fitting
      *  @param loglevel    Set the loglevel for the object. The default
      *                     loglevel is zero, indicating no output.
+     * @deprecated The `log_level` parameter is deprecated and will be removed after
+     *     %Cantera 3.1.
      */
-    void init(double tsmin, double tsmax, int loglevel = 0);
+    void init(double tsmin, double tsmax, int loglevel = -7);
 
     double omega22(double ts, double deltastar);
     double astar(double ts, double deltastar);

--- a/src/transport/TransportFactory.cpp
+++ b/src/transport/TransportFactory.cpp
@@ -68,6 +68,10 @@ void TransportFactory::deleteFactory()
 Transport* TransportFactory::newTransport(const string& transportModel,
         ThermoPhase* phase, int log_level)
 {
+    if (log_level != -7) {
+        warn_deprecated("TransportFactory::newTransport", "The log_level parameter "
+            "is deprecated and will be removed after Cantera 3.1.");
+    }
     if (transportModel != "DustyGas" && canonicalize(transportModel) == "none") {
         return create(transportModel);
     }
@@ -98,6 +102,10 @@ Transport* TransportFactory::newTransport(const string& transportModel,
 
 Transport* TransportFactory::newTransport(ThermoPhase* phase, int log_level)
 {
+    if (log_level != -7) {
+        warn_deprecated("TransportFactory::newTransport", "The log_level parameter "
+            "is deprecated and will be removed after Cantera 3.1.");
+    }
     string transportModel = "none";
     AnyMap& input = phase->input();
     if (input.hasKey("transport")) {
@@ -110,9 +118,9 @@ shared_ptr<Transport> newTransport(shared_ptr<ThermoPhase> thermo, const string&
 {
     Transport* tr;
     if (model == "default") {
-        tr = TransportFactory::factory()->newTransport(thermo.get(), 0);
+        tr = TransportFactory::factory()->newTransport(thermo.get());
     } else {
-        tr = TransportFactory::factory()->newTransport(model, thermo.get(), 0);
+        tr = TransportFactory::factory()->newTransport(model, thermo.get());
     }
     return shared_ptr<Transport>(tr);
 }

--- a/src/transport/WaterTransport.cpp
+++ b/src/transport/WaterTransport.cpp
@@ -7,6 +7,7 @@
 #include "cantera/thermo/VPStandardStateTP.h"
 #include "cantera/thermo/PDSS_Water.h"
 #include "cantera/thermo/WaterSSTP.h"
+#include "cantera/base/global.h"
 
 namespace {
 
@@ -32,6 +33,10 @@ namespace Cantera
 
 void WaterTransport::init(ThermoPhase* thermo, int mode, int log_level)
 {
+    if (log_level != -7) {
+        warn_deprecated("Transport::init", "The log_level parameter "
+            "is deprecated and will be removed after Cantera 3.1.");
+    }
     m_thermo = thermo;
 }
 

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -71,12 +71,18 @@ class TestTransport:
 
     def test_CK_mode(self, phase):
         mu_ct = phase.viscosity
+        err_ct = phase.transport_fitting_errors
         phase.transport_model = 'mixture-averaged-CK'
         assert phase.transport_model == 'mixture-averaged-CK'
         mu_ck = phase.viscosity
+        err_ck = phase.transport_fitting_errors
         # values should be close, but not identical
         assert abs(mu_ct - mu_ck) / mu_ct > 1e-8
         assert abs(mu_ct - mu_ck) / mu_ct < 1e-2
+
+        # Cantera's fits should be an improvement in all cases
+        for key in err_ct:
+            assert err_ct[key] < err_ck[key]
 
     def test_ionGas(self, phase):
         # IonGasTransport gives the same result for a mixture


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Deprecate the difficult-to-use logging of the transport data fitting process
- Make metrics of fit quality available from the `Transport` object

Partly, the aim here is to allow eventual removal of a chunk of logging code that isn't covered by the test suite.

**If applicable, provide an example illustrating new features this pull request is introducing**

```pycon
>>> import cantera as ct
>>> gas = ct.Solution('gri30.yaml')
>>> gas.transport_fitting_errors
{'viscosity-max-abs-error': 1.1723671895608157e-07,
 'viscosity-max-rel-error': 0.0015412152759781718,
 'conductivity-max-abs-error': 0.002485267630085386,
 'conductivity-max-rel-error': 0.008498505452411067,
 'diff-coeff-max-abs-error': 0.37192622300915446,
 'diff-coeff-max-rel-error': 0.001570500793197145}
```

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
