### PR TITLE
Fix SUNDIALS 7.x compatibility/library list checks

### DIFF
--- a/SConstruct
+++ b/SConstruct
@@ -1468,7 +1468,7 @@ if env["system_sundials"] in ("n", "default"):
 
 if env['system_sundials'] == 'y':
     env['sundials_libs'] = ['sundials_cvodes', 'sundials_idas', 'sundials_nvecserial']
-    if parse_version(env["sundials_version"]) >= parse_version("7.2.0"):
+    if parse_version(env["sundials_version"]) >= parse_version("7.0.0"):
         env['sundials_libs'].append('sundials_core')
     if env['use_lapack']:
         if env.get('has_sundials_lapack'):

--- a/site_scons/buildutils.py
+++ b/site_scons/buildutils.py
@@ -1764,7 +1764,7 @@ def check_sundials(conf: "SConfigure", sundials_version: str) -> Dict[str, Union
         if should_exit_with_error:
             config_error(f"Sundials version must be >=3.0,<8.0. Found {sundials_ver}.")
         return {"system_sundials": "n", "sundials_version": "", "has_sundials_lapack": 0}
-    elif sundials_ver > parse_version("7.0.0"):
+    elif sundials_ver > parse_version("7.2.0"):
         logger.warning(f"Sundials version {sundials_ver} has not been tested.")
 
     cvode_checks = {


### PR DESCRIPTION
**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Correct SUNDIALS version checks so `sundials_core` is linked for SUNDIALS 7.0 and newer, and the warning about being untested only occurs for versions newer than 7.2.0.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
