### PR TITLE
[C++] Explicitly define copy constructor for AnyBase

### DIFF
--- a/include/cantera/base/AnyMap.h
+++ b/include/cantera/base/AnyMap.h
@@ -34,6 +34,7 @@ namespace Cantera
 class AnyBase {
 public:
     AnyBase() = default;
+    AnyBase(const AnyBase& other) = default;
     virtual ~AnyBase() = default;
     AnyBase& operator=(const AnyBase& other);
 


### PR DESCRIPTION
**Changes proposed in this pull request**

Gcc 14.2 generates a warning (-Wdeprecated-copy) for AnyBase because the assignment operator is defined explicitly but the copy constructor is defined implicitly.

**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
