### PR TITLE
Simplify Molar Mixture Properties

### DIFF
--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -109,6 +109,11 @@ public:
          return m_adjacent.size();
     }
 
+    //! Get the name of an adjacent phase by index
+    string adjacentName(size_t i) const {
+        return m_adjacent.at(i)->name();
+    }
+
     AnyMap parameters(bool withInput=false) const;
 
     //! Access input data associated with header definition

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -106,11 +106,14 @@ public:
 
     //! Get the number of adjacent phases
     size_t nAdjacent() const {
-         return m_adjacent.size();
+        return m_adjacent.size();
     }
 
     //! Get the name of an adjacent phase by index
     string adjacentName(size_t i) const {
+        if (i < 0 || i >= m_adjacent.size()) {
+            throw CanteraError("Solution::adjacentName", "Invalid index {}.", i);
+        }
         return m_adjacent.at(i)->name();
     }
 

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -436,7 +436,6 @@ public:
     //! @{
 
     double gibbs_mole() const override;
-    double cp_mole() const override;
 
     //! @}
     //! @name Mechanical Equation of State Properties

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -435,8 +435,6 @@ public:
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    double enthalpy_mole() const override;
-
     //! Molar entropy. Units: J/kmol/K.
     /**
      * For an ideal, constant partial molar volume solution mixture with

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -432,12 +432,6 @@ public:
     }
 
     //! @}
-    //! @name  Molar Thermodynamic Properties of the Solution
-    //! @{
-
-    double gibbs_mole() const override;
-
-    //! @}
     //! @name Mechanical Equation of State Properties
     //!
     //! In this equation of state implementation, the density is a function only

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -435,23 +435,6 @@ public:
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    //! Molar entropy. Units: J/kmol/K.
-    /**
-     * For an ideal, constant partial molar volume solution mixture with
-     * pure species phases which exhibit zero volume expansivity:
-     * @f[
-     * \hat s(T, P, X_k) = \sum_k X_k \hat s^0_k(T)
-     *      - \hat R  \sum_k X_k \ln(X_k)
-     * @f]
-     * The reference-state pure-species entropies
-     * @f$ \hat s^0_k(T,p_{ref}) @f$ are computed by the
-     *  species thermodynamic
-     * property manager. The pure species entropies are independent of
-     * temperature since the volume expansivities are equal to zero.
-     * @see MultiSpeciesThermo
-     */
-    double entropy_mole() const override;
-
     double gibbs_mole() const override;
     double cp_mole() const override;
 

--- a/include/cantera/thermo/DebyeHuckel.h
+++ b/include/cantera/thermo/DebyeHuckel.h
@@ -911,9 +911,6 @@ protected:
     //! Pointer to the water property calculator
     unique_ptr<WaterProps> m_waterProps;
 
-    //! vector of size m_kk, used as a temporary holding area.
-    mutable vector<double> m_tmpV;
-
     /**
      * Stoichiometric species charge -> This is for calculations
      * of the ionic strength which ignore ion-ion pairing into

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1422,9 +1422,6 @@ private:
     //! Pointer to the water property calculator
     unique_ptr<WaterProps> m_waterProps;
 
-    //! vector of size m_kk, used as a temporary holding area.
-    mutable vector<double> m_tmpV;
-
     /**
      *  Array of 2D data used in the Pitzer/HMW formulation. Beta0_ij[i][j] is
      *  the value of the Beta0 coefficient for the ij salt. It will be nonzero

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -804,8 +804,6 @@ public:
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    double enthalpy_mole() const override;
-
     /**
      * Excess molar enthalpy of the solution from
      * the mixing process. Units: J/ kmol.

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -821,25 +821,6 @@ public:
      */
     virtual double relative_molal_enthalpy() const;
 
-    //! Molar entropy. Units: J/kmol/K.
-    /**
-     * Molar entropy of the solution. Units: J/kmol/K. For an ideal, constant
-     * partial molar volume solution mixture with pure species phases which
-     * exhibit zero volume expansivity:
-     * @f[
-     * \hat s(T, P, X_k) = \sum_k X_k \hat s^0_k(T)
-     *      - \hat R  \sum_k X_k \ln(X_k)
-     * @f]
-     * The reference-state pure-species entropies @f$ \hat s^0_k(T,p_{ref}) @f$
-     * are computed by the species thermodynamic property manager. The pure
-     * species entropies are independent of temperature since the volume
-     * expansivities are equal to zero.
-     * @see MultiSpeciesThermo
-     *
-     *      (HKM -> Bump up to Parent object)
-     */
-    double entropy_mole() const override;
-
     double gibbs_mole() const override;
 
     double cp_mole() const override;

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -821,8 +821,6 @@ public:
      */
     virtual double relative_molal_enthalpy() const;
 
-    double gibbs_mole() const override;
-
     double cv_mole() const override;
 
     //! @}

--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -823,8 +823,6 @@ public:
 
     double gibbs_mole() const override;
 
-    double cp_mole() const override;
-
     double cv_mole() const override;
 
     //! @}

--- a/include/cantera/thermo/IdealGasPhase.h
+++ b/include/cantera/thermo/IdealGasPhase.h
@@ -289,7 +289,7 @@ public:
      * enthalpies @f$ \hat h^0_k(T) @f$ are computed by the species
      * thermodynamic property manager.
      *
-     * \see MultiSpeciesThermo
+     * @see MultiSpeciesThermo
      */
     double enthalpy_mole() const override {
         return RT() * mean_X(enthalpy_RT_ref());

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -89,22 +89,6 @@ public:
     //! @name  Molar Thermodynamic Properties of the Solution
     //! @{
 
-    //! Molar enthalpy of the solution. Units: J/kmol.
-    /*!
-     * Returns the amount of enthalpy per mole of solution. For an ideal molal
-     * solution,
-     * @f[
-     * \bar{h}(T, P, X_k) = \sum_k X_k \bar{h}_k(T)
-     * @f]
-     * The formula is written in terms of the partial molar enthalpies.
-     * @f$ \bar{h}_k(T, p, m_k) @f$.
-     * See the partial molar enthalpy function, getPartialMolarEnthalpies(),
-     * for details.
-     *
-     * Units: J/kmol
-     */
-    double enthalpy_mole() const override;
-
     //! Molar internal energy of the solution: Units: J/kmol.
     /*!
      * Returns the amount of internal energy per mole of solution. For an ideal

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -111,9 +111,6 @@ public:
     //! cause an exception to be thrown.
     //! @{
 
-protected:
-    void calcDensity() override;
-
 public:
     //! The isothermal compressibility. Units: 1/Pa.
     /*!

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -404,9 +404,6 @@ protected:
     int IMS_typeCutoff_ = 0;
 
 private:
-    //! vector of size m_kk, used as a temporary holding area.
-    mutable vector<double> m_tmpV;
-
     //! Logarithm of the molal activity coefficients
     /*!
      *   Normally these are all one. However, stability schemes will change that

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -101,22 +101,6 @@ public:
      */
     double intEnergy_mole() const override;
 
-    //! Molar entropy of the solution. Units: J/kmol/K.
-    /*!
-     * Returns the amount of entropy per mole of solution. For an ideal molal
-     * solution,
-     * @f[
-     * \bar{s}(T, P, X_k) = \sum_k X_k \bar{s}_k(T)
-     * @f]
-     * The formula is written in terms of the partial molar entropies.
-     * @f$ \bar{s}_k(T, p, m_k) @f$.
-     * See the partial molar entropies function, getPartialMolarEntropies(),
-     * for details.
-     *
-     * Units: J/kmol/K.
-     */
-    double entropy_mole() const override;
-
     //! Molar Gibbs function for the solution: Units J/kmol.
     /*!
      * Returns the Gibbs free energy of the solution per mole of the solution.

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -113,16 +113,6 @@ public:
      */
     double gibbs_mole() const override;
 
-    //! Molar heat capacity of the solution at constant pressure. Units: J/kmol/K.
-    /*!
-     * @f[
-     * \bar{c}_p(T, P, X_k) = \sum_k X_k \bar{c}_{p,k}(T)
-     * @f]
-     *
-     * Units: J/kmol/K
-     */
-    double cp_mole() const override;
-
     //! @}
     //! @name Mechanical Equation of State Properties
     //!

--- a/include/cantera/thermo/IdealMolalSoln.h
+++ b/include/cantera/thermo/IdealMolalSoln.h
@@ -101,18 +101,6 @@ public:
      */
     double intEnergy_mole() const override;
 
-    //! Molar Gibbs function for the solution: Units J/kmol.
-    /*!
-     * Returns the Gibbs free energy of the solution per mole of the solution.
-     *
-     * @f[
-     * \bar{g}(T, P, X_k) = \sum_k X_k \mu_k(T)
-     * @f]
-     *
-     * Units: J/kmol
-     */
-    double gibbs_mole() const override;
-
     //! @}
     //! @name Mechanical Equation of State Properties
     //!

--- a/include/cantera/thermo/IdealSolidSolnPhase.h
+++ b/include/cantera/thermo/IdealSolidSolnPhase.h
@@ -71,20 +71,6 @@ public:
     //! @{
 
     /**
-     * Molar enthalpy of the solution. Units: J/kmol. For an ideal, constant
-     * partial molar volume solution mixture with pure species phases which
-     * exhibit zero volume expansivity and zero isothermal compressibility:
-     * @f[
-     * \hat h(T,P) = \sum_k X_k \hat h^0_k(T) + (P - P_{ref}) (\sum_k X_k \hat V^0_k)
-     * @f]
-     * The reference-state pure-species enthalpies at the reference pressure Pref
-     * @f$ \hat h^0_k(T) @f$, are computed by the species thermodynamic
-     * property manager. They are polynomial functions of temperature.
-     * @see MultiSpeciesThermo
-     */
-    double enthalpy_mole() const override;
-
-    /**
      * Molar entropy of the solution. Units: J/kmol/K. For an ideal, constant
      * partial molar volume solution mixture with pure species phases which
      * exhibit zero volume expansivity:

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -240,6 +240,12 @@ public:
      */
     double entropy_mole() const override;
 
+    //! Molar Gibbs function of the solution. Units: J/kmol
+    /*!
+     * Uses thermodynamic property relations.
+     */
+    double gibbs_mole() const override;
+
     //! Molar heat capacity at constant pressure of the solution.
     //! Units: J/kmol/K.
     /*!

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -218,7 +218,7 @@ public:
      * computed first by the species reference state thermodynamic property
      * manager and then a small pressure dependent term is added in.
      *
-     * \see MultiSpeciesThermo
+     * @see MultiSpeciesThermo
      */
     double enthalpy_mole() const override;
 

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -230,7 +230,6 @@ public:
     //! @name  Molar Thermodynamic Properties
     //! @{
 
-    double cp_mole() const override;
     double cv_mole() const override;
 
     //! @}

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -230,7 +230,6 @@ public:
     //! @name  Molar Thermodynamic Properties
     //! @{
 
-    double entropy_mole() const override;
     double cp_mole() const override;
     double cv_mole() const override;
 

--- a/include/cantera/thermo/MargulesVPSSTP.h
+++ b/include/cantera/thermo/MargulesVPSSTP.h
@@ -230,7 +230,6 @@ public:
     //! @name  Molar Thermodynamic Properties
     //! @{
 
-    double enthalpy_mole() const override;
     double entropy_mole() const override;
     double cp_mole() const override;
     double cv_mole() const override;

--- a/include/cantera/thermo/MixtureFugacityTP.h
+++ b/include/cantera/thermo/MixtureFugacityTP.h
@@ -265,8 +265,6 @@ protected:
      */
     virtual void _updateReferenceStateThermo() const;
 
-    //! Temporary storage - length = m_kk.
-    mutable vector<double> m_tmpV;
 public:
 
     //! @name Thermodynamic Values for the Species Reference States

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -874,6 +874,9 @@ protected:
     //! Flag determining whether case sensitive species names are enforced
     bool m_caseSensitiveSpecies = false;
 
+    //! Vector of size m_kk, used as a temporary holding area.
+    mutable vector<double> m_tmpV;
+
 private:
     //! Find lowercase species name in m_speciesIndices when case sensitive
     //! species names are not enforced and a user specifies a non-canonical

--- a/include/cantera/thermo/Phase.h
+++ b/include/cantera/thermo/Phase.h
@@ -875,7 +875,7 @@ protected:
     bool m_caseSensitiveSpecies = false;
 
     //! Vector of size m_kk, used as a temporary holding area.
-    mutable vector<double> m_tmpV;
+    mutable vector<double> m_workS;
 
 private:
     //! Find lowercase species name in m_speciesIndices when case sensitive

--- a/include/cantera/thermo/PlasmaPhase.h
+++ b/include/cantera/thermo/PlasmaPhase.h
@@ -213,7 +213,7 @@ public:
      * enthalpies @f$ \hat h^0_k(T) @f$ are computed by the species
      * thermodynamic property manager.
      *
-     * \see MultiSpeciesThermo
+     * @see MultiSpeciesThermo
      */
     double enthalpy_mole() const override;
 

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -248,7 +248,6 @@ public:
     //! @name  Molar Thermodynamic Properties
     //! @{
 
-    double cp_mole() const override;
     double cv_mole() const override;
 
     //! @}

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -248,7 +248,6 @@ public:
     //! @name  Molar Thermodynamic Properties
     //! @{
 
-    double entropy_mole() const override;
     double cp_mole() const override;
     double cv_mole() const override;
 

--- a/include/cantera/thermo/RedlichKisterVPSSTP.h
+++ b/include/cantera/thermo/RedlichKisterVPSSTP.h
@@ -248,7 +248,6 @@ public:
     //! @name  Molar Thermodynamic Properties
     //! @{
 
-    double enthalpy_mole() const override;
     double entropy_mole() const override;
     double cp_mole() const override;
     double cv_mole() const override;

--- a/include/cantera/thermo/SurfPhase.h
+++ b/include/cantera/thermo/SurfPhase.h
@@ -124,7 +124,7 @@ public:
      * Enthalpies @f$ \hat h^0_k(T) @f$ are computed by the species
      * thermodynamic property manager.
      *
-     * \see MultiSpeciesThermo
+     * @see MultiSpeciesThermo
      */
     double enthalpy_mole() const override;
 

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -527,15 +527,13 @@ public:
     /**
      * Returns the amount of enthalpy per mole,
      * @f[
-     * \bar{h}(T, P, X_k) = \sum_k X_k \bar{h}_k(T)
+     * \hat{h} = \sum_k X_k \hat{h}_k
      * @f]
-     * The formula is written in terms of the partial molar enthalpies.
-     * @f$ \bar{h}_k(T, p, m_k) @f$.
-     * @relates getPartialMolarEnthalpies()
+     * @see getPartialMolarEnthalpies()
      */
     virtual double enthalpy_mole() const {
-        getPartialMolarEnthalpies(m_tmpV.data());
-        return mean_X(m_tmpV);
+        getPartialMolarEnthalpies(m_workS.data());
+        return mean_X(m_workS);
     }
 
     //! Molar internal energy. Units: J/kmol.
@@ -547,40 +545,38 @@ public:
     /**
      * Returns the amount of entropy per mole,
      * @f[
-     * \bar{s}(T, P, X_k) = \sum_k X_k \bar{s}_k(T)
+     * \hat{s} = \sum_k X_k \hat{s}_k
      * @f]
-     * The formula is written in terms of the partial molar entropies.
-     * @f$ \bar{s}_k(T, p, m_k) @f$.
-     * @relates getPartialMolarEnthalpies()
+     * @see getPartialMolarEnthalpies()
      */
     virtual double entropy_mole() const {
-        getPartialMolarEntropies(m_tmpV.data());
-        return mean_X(m_tmpV);
+        getPartialMolarEntropies(m_workS.data());
+        return mean_X(m_workS);
     }
 
     //! Molar Gibbs function. Units: J/kmol.
     /*!
      * Returns the Gibbs free energy per mole,
      * @f[
-     * \bar{g}(T, P, X_k) = \sum_k X_k \mu_k(T)
+     * \hat{g} = \sum_k X_k \mu_k
      * @f]
-     * @relates getChemPotentials()
+     * @see getChemPotentials()
      */
     virtual double gibbs_mole() const {
-        getChemPotentials(m_tmpV.data());
-        return mean_X(m_tmpV);
+        getChemPotentials(m_workS.data());
+        return mean_X(m_workS);
     }
 
     //! Molar heat capacity at constant pressure. Units: J/kmol/K.
     /*!
      * @f[
-     * \bar{c}_p(T, P, X_k) = \sum_k X_k \bar{c}_{p,k}(T)
+     * \hat{c}_p = \sum_k X_k \hat{c}_{p,k}
      * @f]
-     * @relates getPartialMolarCp()
+     * @see getPartialMolarCp()
      */
     virtual double cp_mole() const {
-        getPartialMolarCp(m_tmpV.data());
-        return mean_X(m_tmpV);
+        getPartialMolarCp(m_workS.data());
+        return mean_X(m_workS);
     }
 
     //! Molar heat capacity at constant volume. Units: J/kmol/K.

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -525,8 +525,7 @@ public:
 
     //! Molar enthalpy. Units: J/kmol.
     /**
-     * Returns the amount of enthalpy per mole of solution. For an ideal molal
-     * solution,
+     * Returns the amount of enthalpy per mole,
      * @f[
      * \bar{h}(T, P, X_k) = \sum_k X_k \bar{h}_k(T)
      * @f]
@@ -546,7 +545,7 @@ public:
 
     //! Molar entropy. Units: J/kmol/K.
     /**
-     * Returns the amount of entropy per mole of solution,
+     * Returns the amount of entropy per mole,
      * @f[
      * \bar{s}(T, P, X_k) = \sum_k X_k \bar{s}_k(T)
      * @f]
@@ -565,8 +564,15 @@ public:
     }
 
     //! Molar heat capacity at constant pressure. Units: J/kmol/K.
+    /*!
+     * @f[
+     * \bar{c}_p(T, P, X_k) = \sum_k X_k \bar{c}_{p,k}(T)
+     * @f]
+     * @relates getPartialMolarCp()
+     */
     virtual double cp_mole() const {
-        throw NotImplementedError("ThermoPhase::cp_mole");
+        getPartialMolarCp(m_tmpV.data());
+        return mean_X(m_tmpV);
     }
 
     //! Molar heat capacity at constant volume. Units: J/kmol/K.

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -559,8 +559,16 @@ public:
     }
 
     //! Molar Gibbs function. Units: J/kmol.
+    /*!
+     * Returns the Gibbs free energy per mole,
+     * @f[
+     * \bar{g}(T, P, X_k) = \sum_k X_k \mu_k(T)
+     * @f]
+     * @relates getChemPotentials()
+     */
     virtual double gibbs_mole() const {
-        return enthalpy_mole() - temperature()*entropy_mole();
+        getChemPotentials(m_tmpV.data());
+        return mean_X(m_tmpV);
     }
 
     //! Molar heat capacity at constant pressure. Units: J/kmol/K.

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -585,7 +585,8 @@ public:
 
     //! Molar heat capacity at constant volume. Units: J/kmol/K.
     virtual double cv_mole() const {
-        throw NotImplementedError("ThermoPhase::cv_mole");
+        throw NotImplementedError("ThermoPhase::cv_mole",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! @}
@@ -604,7 +605,8 @@ public:
      * @f]
      */
     virtual double isothermalCompressibility() const {
-        throw NotImplementedError("ThermoPhase::isothermalCompressibility");
+        throw NotImplementedError("ThermoPhase::isothermalCompressibility",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Return the volumetric thermal expansion coefficient. Units: 1/K.
@@ -615,7 +617,8 @@ public:
      * @f]
      */
     virtual double thermalExpansionCoeff() const {
-        throw NotImplementedError("ThermoPhase::thermalExpansionCoeff");
+        throw NotImplementedError("ThermoPhase::thermalExpansionCoeff",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Return the speed of sound. Units: m/s.
@@ -626,7 +629,8 @@ public:
      * @f]
      */
     virtual double soundSpeed() const {
-        throw NotImplementedError("ThermoPhase::soundSpeed");
+        throw NotImplementedError("ThermoPhase::soundSpeed",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! @}
@@ -732,7 +736,8 @@ public:
      *           the phase.
      */
     virtual void getActivityConcentrations(double* c) const {
-        throw NotImplementedError("ThermoPhase::getActivityConcentrations");
+        throw NotImplementedError("ThermoPhase::getActivityConcentrations",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Return the standard concentration for the kth species
@@ -753,7 +758,8 @@ public:
      *   dependent on the ThermoPhase and kinetics manager representation.
      */
     virtual double standardConcentration(size_t k=0) const {
-        throw NotImplementedError("ThermoPhase::standardConcentration");
+        throw NotImplementedError("ThermoPhase::standardConcentration",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Natural logarithm of the standard concentration of the kth species.
@@ -785,7 +791,8 @@ public:
         if (m_kk == 1) {
             ac[0] = 1.0;
         } else {
-            throw NotImplementedError("ThermoPhase::getActivityCoefficients");
+            throw NotImplementedError("ThermoPhase::getActivityCoefficients",
+                                      "Not implemented for phase type '{}'", type());
         }
     }
 
@@ -810,7 +817,8 @@ public:
      *            potentials. Length: m_kk. Units: J/kmol
      */
     virtual void getChemPotentials(double* mu) const {
-        throw NotImplementedError("ThermoPhase::getChemPotentials");
+        throw NotImplementedError("ThermoPhase::getChemPotentials",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //!  Get the species electrochemical potentials.
@@ -836,7 +844,8 @@ public:
      *                Length: m_kk. units are J/kmol.
      */
     virtual void getPartialMolarEnthalpies(double* hbar) const {
-        throw NotImplementedError("ThermoPhase::getPartialMolarEnthalpies");
+        throw NotImplementedError("ThermoPhase::getPartialMolarEnthalpies",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Returns an array of partial molar entropies of the species in the
@@ -846,7 +855,8 @@ public:
      *                Length = m_kk. units are J/kmol/K.
      */
     virtual void getPartialMolarEntropies(double* sbar) const {
-        throw NotImplementedError("ThermoPhase::getPartialMolarEntropies");
+        throw NotImplementedError("ThermoPhase::getPartialMolarEntropies",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Return an array of partial molar internal energies for the
@@ -856,7 +866,8 @@ public:
      *                Length = m_kk. units are J/kmol.
      */
     virtual void getPartialMolarIntEnergies(double* ubar) const {
-        throw NotImplementedError("ThermoPhase::getPartialMolarIntEnergies");
+        throw NotImplementedError("ThermoPhase::getPartialMolarIntEnergies",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Return an array of partial molar heat capacities for the
@@ -867,7 +878,8 @@ public:
      *                Length = m_kk. units are J/kmol/K.
      */
     virtual void getPartialMolarCp(double* cpbar) const {
-        throw NotImplementedError("ThermoPhase::getPartialMolarCp");
+        throw NotImplementedError("ThermoPhase::getPartialMolarCp",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Return an array of partial molar volumes for the
@@ -877,7 +889,8 @@ public:
      *                Length = m_kk. units are m^3/kmol.
      */
     virtual void getPartialMolarVolumes(double* vbar) const {
-        throw NotImplementedError("ThermoPhase::getPartialMolarVolumes");
+        throw NotImplementedError("ThermoPhase::getPartialMolarVolumes",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! @}
@@ -895,7 +908,8 @@ public:
      *                Length: m_kk.
      */
     virtual void getStandardChemPotentials(double* mu) const {
-        throw NotImplementedError("ThermoPhase::getStandardChemPotentials");
+        throw NotImplementedError("ThermoPhase::getStandardChemPotentials",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Get the nondimensional Enthalpy functions for the species at their
@@ -905,7 +919,8 @@ public:
      *                 Length: m_kk.
      */
     virtual void getEnthalpy_RT(double* hrt) const {
-        throw NotImplementedError("ThermoPhase::getEnthalpy_RT");
+        throw NotImplementedError("ThermoPhase::getEnthalpy_RT",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Get the array of nondimensional Entropy functions for the standard state
@@ -915,7 +930,8 @@ public:
      *             Length: m_kk.
      */
     virtual void getEntropy_R(double* sr) const {
-        throw NotImplementedError("ThermoPhase::getEntropy_R");
+        throw NotImplementedError("ThermoPhase::getEntropy_R",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Get the nondimensional Gibbs functions for the species in their standard
@@ -925,7 +941,8 @@ public:
      *             energies. Length: m_kk.
      */
     virtual void getGibbs_RT(double* grt) const {
-        throw NotImplementedError("ThermoPhase::getGibbs_RT");
+        throw NotImplementedError("ThermoPhase::getGibbs_RT",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Get the Gibbs functions for the standard state of the species at the
@@ -936,7 +953,8 @@ public:
      *               Length: m_kk.
      */
     virtual void getPureGibbs(double* gpure) const {
-        throw NotImplementedError("ThermoPhase::getPureGibbs");
+        throw NotImplementedError("ThermoPhase::getPureGibbs",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Returns the vector of nondimensional Internal Energies of the standard
@@ -946,7 +964,8 @@ public:
      *             of the species. Length: m_kk.
      */
     virtual void getIntEnergy_RT(double* urt) const {
-        throw NotImplementedError("ThermoPhase::getIntEnergy_RT");
+        throw NotImplementedError("ThermoPhase::getIntEnergy_RT",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Get the nondimensional Heat Capacities at constant pressure for the
@@ -957,7 +976,8 @@ public:
      *              capacities. Length: m_kk.
      */
     virtual void getCp_R(double* cpr) const {
-        throw NotImplementedError("ThermoPhase::getCp_R");
+        throw NotImplementedError("ThermoPhase::getCp_R",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //!  Get the molar volumes of the species standard states at the current
@@ -969,7 +989,8 @@ public:
      *                Length: m_kk.
      */
     virtual void getStandardVolumes(double* vol) const {
-        throw NotImplementedError("ThermoPhase::getStandardVolumes");
+        throw NotImplementedError("ThermoPhase::getStandardVolumes",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! @}
@@ -984,7 +1005,8 @@ public:
      *                state enthalpies. Length: m_kk.
      */
     virtual void getEnthalpy_RT_ref(double* hrt) const {
-        throw NotImplementedError("ThermoPhase::getEnthalpy_RT_ref");
+        throw NotImplementedError("ThermoPhase::getEnthalpy_RT_ref",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Returns the vector of nondimensional Gibbs Free Energies of the
@@ -995,7 +1017,8 @@ public:
      *                Gibbs Free energies.  Length: m_kk.
      */
     virtual void getGibbs_RT_ref(double* grt) const {
-        throw NotImplementedError("ThermoPhase::getGibbs_RT_ref");
+        throw NotImplementedError("ThermoPhase::getGibbs_RT_ref",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Returns the vector of the Gibbs function of the reference state at the
@@ -1006,7 +1029,8 @@ public:
      *                Gibbs Free energies. Length: m_kk. Units: J/kmol.
      */
     virtual void getGibbs_ref(double* g) const {
-        throw NotImplementedError("ThermoPhase::getGibbs_ref");
+        throw NotImplementedError("ThermoPhase::getGibbs_ref",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Returns the vector of nondimensional entropies of the reference state at
@@ -1017,7 +1041,8 @@ public:
      *                state entropies. Length: m_kk.
      */
     virtual void getEntropy_R_ref(double* er) const {
-        throw NotImplementedError("ThermoPhase::getEntropy_R_ref");
+        throw NotImplementedError("ThermoPhase::getEntropy_R_ref",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Returns the vector of nondimensional internal Energies of the reference
@@ -1028,7 +1053,8 @@ public:
      *               energies of the species. Length: m_kk
      */
     virtual void getIntEnergy_RT_ref(double* urt) const {
-        throw NotImplementedError("ThermoPhase::getIntEnergy_RT_ref");
+        throw NotImplementedError("ThermoPhase::getIntEnergy_RT_ref",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Returns the vector of nondimensional constant pressure heat capacities
@@ -1040,7 +1066,8 @@ public:
      *               Length: m_kk
      */
     virtual void getCp_R_ref(double* cprt) const {
-        throw NotImplementedError("ThermoPhase::getCp_R_ref");
+        throw NotImplementedError("ThermoPhase::getCp_R_ref",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Get the molar volumes of the species reference states at the current
@@ -1052,7 +1079,8 @@ public:
      *                Length: m_kk.
      */
     virtual void getStandardVolumes_ref(double* vol) const {
-        throw NotImplementedError("ThermoPhase::getStandardVolumes_ref");
+        throw NotImplementedError("ThermoPhase::getStandardVolumes_ref",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     // The methods below are not virtual, and should not be overloaded.
@@ -1256,7 +1284,8 @@ public:
      *              are being calculated.
      */
     virtual void setState_ST(double s, double t, double tol=1e-9) {
-        throw NotImplementedError("ThermoPhase::setState_ST");
+        throw NotImplementedError("ThermoPhase::setState_ST",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Set the temperature (K) and specific volume (m^3/kg).
@@ -1272,7 +1301,8 @@ public:
      *              are being calculated.
      */
     virtual void setState_TV(double t, double v, double tol=1e-9) {
-        throw NotImplementedError("ThermoPhase::setState_TV");
+        throw NotImplementedError("ThermoPhase::setState_TV",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Set the pressure (Pa) and specific volume (m^3/kg).
@@ -1288,7 +1318,8 @@ public:
      *              are being calculated.
      */
     virtual void setState_PV(double p, double v, double tol=1e-9) {
-        throw NotImplementedError("ThermoPhase::setState_PV");
+        throw NotImplementedError("ThermoPhase::setState_PV",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Set the specific internal energy (J/kg) and pressure (Pa).
@@ -1304,7 +1335,8 @@ public:
      *              are being calculated.
      */
     virtual void setState_UP(double u, double p, double tol=1e-9) {
-        throw NotImplementedError("ThermoPhase::setState_UP");
+        throw NotImplementedError("ThermoPhase::setState_UP",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Set the specific volume (m^3/kg) and the specific enthalpy (J/kg)
@@ -1320,7 +1352,8 @@ public:
      *              are being calculated.
      */
     virtual void setState_VH(double v, double h, double tol=1e-9) {
-        throw NotImplementedError("ThermoPhase::setState_VH");
+        throw NotImplementedError("ThermoPhase::setState_VH",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Set the temperature (K) and the specific enthalpy (J/kg)
@@ -1336,7 +1369,8 @@ public:
      *              are being calculated.
      */
     virtual void setState_TH(double t, double h, double tol=1e-9) {
-        throw NotImplementedError("ThermoPhase::setState_TH");
+        throw NotImplementedError("ThermoPhase::setState_TH",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Set the specific entropy (J/kg/K) and the specific enthalpy (J/kg)
@@ -1352,7 +1386,8 @@ public:
      *              are being calculated.
      */
     virtual void setState_SH(double s, double h, double tol=1e-9) {
-        throw NotImplementedError("ThermoPhase::setState_SH");
+        throw NotImplementedError("ThermoPhase::setState_SH",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Set the density (kg/m**3) and pressure (Pa) at constant composition
@@ -1370,7 +1405,8 @@ public:
      * @since New in %Cantera 3.0.
      */
     virtual void setState_DP(double rho, double p) {
-        throw NotImplementedError("ThermoPhase::setState_DP");
+        throw NotImplementedError("ThermoPhase::setState_DP",
+                                  "Not implemented for phase type '{}'", type());
     }
 
     //! Set the state using an AnyMap containing any combination of properties

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -545,8 +545,18 @@ public:
     }
 
     //! Molar entropy. Units: J/kmol/K.
+    /**
+     * Returns the amount of entropy per mole of solution,
+     * @f[
+     * \bar{s}(T, P, X_k) = \sum_k X_k \bar{s}_k(T)
+     * @f]
+     * The formula is written in terms of the partial molar entropies.
+     * @f$ \bar{s}_k(T, p, m_k) @f$.
+     * @relates getPartialMolarEnthalpies()
+     */
     virtual double entropy_mole() const {
-        throw NotImplementedError("ThermoPhase::entropy_mole");
+        getPartialMolarEntropies(m_tmpV.data());
+        return mean_X(m_tmpV);
     }
 
     //! Molar Gibbs function. Units: J/kmol.

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -524,8 +524,19 @@ public:
     //! @{
 
     //! Molar enthalpy. Units: J/kmol.
+    /**
+     * Returns the amount of enthalpy per mole of solution. For an ideal molal
+     * solution,
+     * @f[
+     * \bar{h}(T, P, X_k) = \sum_k X_k \bar{h}_k(T)
+     * @f]
+     * The formula is written in terms of the partial molar enthalpies.
+     * @f$ \bar{h}_k(T, p, m_k) @f$.
+     * @relates getPartialMolarEnthalpies()
+     */
     virtual double enthalpy_mole() const {
-        throw NotImplementedError("ThermoPhase::enthalpy_mole");
+        getPartialMolarEnthalpies(m_tmpV.data());
+        return mean_X(m_tmpV);
     }
 
     //! Molar internal energy. Units: J/kmol.

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -234,10 +234,7 @@ extern "C" {
     {
         try {
             auto soln = SolutionCabinet::at(n);
-            if (a < 0 || a >= static_cast<int>(soln->nAdjacent())) {
-                throw CanteraError("soln_adjacentName", "Invalid index {}.", a);
-            }
-            return static_cast<int>(copyString(soln->adjacent(a)->name(), nm, lennm));
+            return static_cast<int>(copyString(soln->adjacentName(a), nm, lennm));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -45,12 +45,6 @@ DebyeHuckel::~DebyeHuckel()
 
 // -------- Molar Thermodynamic Properties of the Solution ---------------
 
-double DebyeHuckel::entropy_mole() const
-{
-    getPartialMolarEntropies(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 double DebyeHuckel::gibbs_mole() const
 {
     getChemPotentials(m_tmpV.data());

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -43,14 +43,6 @@ DebyeHuckel::~DebyeHuckel()
     // Defined in .cpp to limit dependence on WaterProps.h
 }
 
-// -------- Molar Thermodynamic Properties of the Solution ---------------
-
-double DebyeHuckel::gibbs_mole() const
-{
-    getChemPotentials(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 // ------- Mechanical Equation of State Properties ------------------------
 
 void DebyeHuckel::calcDensity()

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -649,7 +649,6 @@ bool DebyeHuckel::addSpecies(shared_ptr<Species> spec)
         m_d2lnActCoeffMolaldT2.push_back(0.0);
         m_dlnActCoeffMolaldP.push_back(0.0);
         m_B_Dot.push_back(0.0);
-        m_tmpV.push_back(0.0);
 
         // NAN will be replaced with default value
         double Aionic = NAN;

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -51,12 +51,6 @@ double DebyeHuckel::gibbs_mole() const
     return mean_X(m_tmpV);
 }
 
-double DebyeHuckel::cp_mole() const
-{
-    getPartialMolarCp(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 // ------- Mechanical Equation of State Properties ------------------------
 
 void DebyeHuckel::calcDensity()

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -52,9 +52,7 @@ void DebyeHuckel::calcDensity()
         // this for all other species if they had pressure dependent properties.
         m_densWaterSS = m_waterSS->density();
     }
-    getPartialMolarVolumes(m_tmpV.data());
-    double dd = meanMolecularWeight() / mean_X(m_tmpV);
-    Phase::assignDensity(dd);
+    VPStandardStateTP::calcDensity();
 }
 
 // ------- Activities and Activity Concentrations

--- a/src/thermo/DebyeHuckel.cpp
+++ b/src/thermo/DebyeHuckel.cpp
@@ -45,12 +45,6 @@ DebyeHuckel::~DebyeHuckel()
 
 // -------- Molar Thermodynamic Properties of the Solution ---------------
 
-double DebyeHuckel::enthalpy_mole() const
-{
-    getPartialMolarEnthalpies(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 double DebyeHuckel::entropy_mole() const
 {
     getPartialMolarEntropies(m_tmpV.data());

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -53,8 +53,8 @@ HMWSoln::HMWSoln(const string& inputFile, const string& id_) :
 
 double HMWSoln::relative_enthalpy() const
 {
-    getPartialMolarEnthalpies(m_tmpV.data());
-    double hbar = mean_X(m_tmpV);
+    getPartialMolarEnthalpies(m_workS.data());
+    double hbar = mean_X(m_workS);
     getEnthalpy_RT(m_gamma_tmp.data());
     for (size_t k = 0; k < m_kk; k++) {
         m_gamma_tmp[k] *= RT();
@@ -66,20 +66,20 @@ double HMWSoln::relative_enthalpy() const
 double HMWSoln::relative_molal_enthalpy() const
 {
     double L = relative_enthalpy();
-    getMoleFractions(m_tmpV.data());
+    getMoleFractions(m_workS.data());
     double xanion = 0.0;
     size_t kcation = npos;
     double xcation = 0.0;
     size_t kanion = npos;
     for (size_t k = 0; k < m_kk; k++) {
         if (charge(k) > 0.0) {
-            if (m_tmpV[k] > xanion) {
-                xanion = m_tmpV[k];
+            if (m_workS[k] > xanion) {
+                xanion = m_workS[k];
                 kanion = k;
             }
         } else if (charge(k) < 0.0) {
-            if (m_tmpV[k] > xcation) {
-                xcation = m_tmpV[k];
+            if (m_workS[k] > xcation) {
+                xcation = m_workS[k];
                 kcation = k;
             }
         }
@@ -144,8 +144,8 @@ void HMWSoln::getActivityConcentrations(double* c) const
 
 double HMWSoln::standardConcentration(size_t k) const
 {
-    getStandardVolumes(m_tmpV.data());
-    double mvSolvent = m_tmpV[0];
+    getStandardVolumes(m_workS.data());
+    double mvSolvent = m_workS[0];
     if (k > 0) {
         return m_Mnaught / mvSolvent;
     }
@@ -1104,7 +1104,7 @@ double HMWSoln::d2A_DebyedT2_TP(double tempArg, double presArg) const
 
 void HMWSoln::initLengths()
 {
-    m_tmpV.resize(m_kk, 0.0);
+    m_workS.resize(m_kk, 0.0);
     m_molalitiesCropped.resize(m_kk, 0.0);
 
     size_t maxCounterIJlen = 1 + (m_kk-1) * (m_kk-2) / 2;
@@ -3936,7 +3936,7 @@ void HMWSoln::s_updateIMS_lnMolalityActCoeff() const
 void HMWSoln::printCoeffs() const
 {
     calcMolalities();
-    vector<double>& moleF = m_tmpV;
+    vector<double>& moleF = m_workS;
 
     // Update the coefficients wrt Temperature. Calculate the derivatives as well
     s_updatePitzer_CoeffWRTemp(2);

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -103,12 +103,6 @@ double HMWSoln::relative_molal_enthalpy() const
     return L / xuse;
 }
 
-double HMWSoln::entropy_mole() const
-{
-    getPartialMolarEntropies(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 double HMWSoln::gibbs_mole() const
 {
     getChemPotentials(m_tmpV.data());

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -51,12 +51,6 @@ HMWSoln::HMWSoln(const string& inputFile, const string& id_) :
 
 // -------- Molar Thermodynamic Properties of the Solution ---------------
 
-double HMWSoln::enthalpy_mole() const
-{
-    getPartialMolarEnthalpies(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 double HMWSoln::relative_enthalpy() const
 {
     getPartialMolarEnthalpies(m_tmpV.data());

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -103,12 +103,6 @@ double HMWSoln::relative_molal_enthalpy() const
     return L / xuse;
 }
 
-double HMWSoln::gibbs_mole() const
-{
-    getChemPotentials(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 double HMWSoln::cv_mole() const
 {
     double kappa_t = isothermalCompressibility();

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -123,11 +123,8 @@ void HMWSoln::calcDensity()
         return;
     }
 
-    // Calculate all of the other standard volumes. Note these are constant for
-    // now
-    getPartialMolarVolumes(m_tmpV.data());
-    double dd = meanMolecularWeight() / mean_X(m_tmpV);
-    Phase::assignDensity(dd);
+    // Calculate all of the other standard volumes. Note these are constant for now
+    VPStandardStateTP::calcDensity();
 }
 
 // ------- Activities and Activity Concentrations

--- a/src/thermo/HMWSoln.cpp
+++ b/src/thermo/HMWSoln.cpp
@@ -109,12 +109,6 @@ double HMWSoln::gibbs_mole() const
     return mean_X(m_tmpV);
 }
 
-double HMWSoln::cp_mole() const
-{
-    getPartialMolarCp(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 double HMWSoln::cv_mole() const
 {
     double kappa_t = isothermalCompressibility();

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -47,8 +47,8 @@ IdealMolalSoln::IdealMolalSoln(const string& inputFile, const string& id_) :
 
 double IdealMolalSoln::intEnergy_mole() const
 {
-    getPartialMolarIntEnergies(m_tmpV.data());
-    return mean_X(m_tmpV);
+    getPartialMolarIntEnergies(m_workS.data());
+    return mean_X(m_workS);
 }
 
 // ------- Mechanical Equation of State Properties ------------------------

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -295,7 +295,6 @@ bool IdealMolalSoln::addSpecies(shared_ptr<Species> spec)
     bool added = MolalityVPSSTP::addSpecies(spec);
     if (added) {
         m_speciesMolarVolume.push_back(0.0);
-        m_tmpV.push_back(0.0);
         IMS_lnActCoeffMolal_.push_back(0.0);
     }
     return added;

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -51,12 +51,6 @@ double IdealMolalSoln::intEnergy_mole() const
     return mean_X(m_tmpV);
 }
 
-double IdealMolalSoln::entropy_mole() const
-{
-    getPartialMolarEntropies(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 double IdealMolalSoln::gibbs_mole() const
 {
     getChemPotentials(m_tmpV.data());

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -51,12 +51,6 @@ double IdealMolalSoln::intEnergy_mole() const
     return mean_X(m_tmpV);
 }
 
-double IdealMolalSoln::gibbs_mole() const
-{
-    getChemPotentials(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 // ------- Mechanical Equation of State Properties ------------------------
 
 void IdealMolalSoln::calcDensity()

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -53,13 +53,6 @@ double IdealMolalSoln::intEnergy_mole() const
 
 // ------- Mechanical Equation of State Properties ------------------------
 
-void IdealMolalSoln::calcDensity()
-{
-    getPartialMolarVolumes(m_tmpV.data());
-    double dd = meanMolecularWeight() / mean_X(m_tmpV);
-    Phase::assignDensity(dd);
-}
-
 double IdealMolalSoln::isothermalCompressibility() const
 {
     return 0.0;

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -57,12 +57,6 @@ double IdealMolalSoln::gibbs_mole() const
     return mean_X(m_tmpV);
 }
 
-double IdealMolalSoln::cp_mole() const
-{
-    getPartialMolarCp(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 // ------- Mechanical Equation of State Properties ------------------------
 
 void IdealMolalSoln::calcDensity()

--- a/src/thermo/IdealMolalSoln.cpp
+++ b/src/thermo/IdealMolalSoln.cpp
@@ -45,12 +45,6 @@ IdealMolalSoln::IdealMolalSoln(const string& inputFile, const string& id_) :
     initThermoFile(inputFile, id_);
 }
 
-double IdealMolalSoln::enthalpy_mole() const
-{
-    getPartialMolarEnthalpies(m_tmpV.data());
-    return mean_X(m_tmpV);
-}
-
 double IdealMolalSoln::intEnergy_mole() const
 {
     getPartialMolarIntEnergies(m_tmpV.data());

--- a/src/thermo/IdealSolidSolnPhase.cpp
+++ b/src/thermo/IdealSolidSolnPhase.cpp
@@ -24,12 +24,6 @@ IdealSolidSolnPhase::IdealSolidSolnPhase(const string& inputFile, const string& 
 
 // Molar Thermodynamic Properties of the Solution
 
-double IdealSolidSolnPhase::enthalpy_mole() const
-{
-    double htp = RT() * mean_X(enthalpy_RT_ref());
-    return htp + (pressure() - m_Pref)/molarDensity();
-}
-
 double IdealSolidSolnPhase::entropy_mole() const
 {
     return GasConstant * (mean_X(entropy_R_ref()) - sum_xlogx());

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -34,6 +34,10 @@ double LatticePhase::entropy_mole() const
     return GasConstant * (mean_X(entropy_R_ref()) - sum_xlogx());
 }
 
+double LatticePhase::gibbs_mole() const {
+    return enthalpy_mole() - temperature() * entropy_mole();
+}
+
 double LatticePhase::cp_mole() const
 {
     return GasConstant * mean_X(cp_R_ref());

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -49,18 +49,6 @@ void MargulesVPSSTP::getChemPotentials(double* mu) const
     }
 }
 
-double MargulesVPSSTP::cp_mole() const
-{
-    size_t kk = nSpecies();
-    double cp = 0;
-    vector<double> cpbar(kk);
-    getPartialMolarCp(&cpbar[0]);
-    for (size_t i = 0; i < kk; i++) {
-        cp += moleFractions_[i]*cpbar[i];
-    }
-    return cp;
-}
-
 double MargulesVPSSTP::cv_mole() const
 {
     return cp_mole() - GasConstant;

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -49,18 +49,6 @@ void MargulesVPSSTP::getChemPotentials(double* mu) const
     }
 }
 
-double MargulesVPSSTP::enthalpy_mole() const
-{
-    size_t kk = nSpecies();
-    double h = 0;
-    vector<double> hbar(kk);
-    getPartialMolarEnthalpies(&hbar[0]);
-    for (size_t i = 0; i < kk; i++) {
-        h += moleFractions_[i]*hbar[i];
-    }
-    return h;
-}
-
 double MargulesVPSSTP::entropy_mole() const
 {
     size_t kk = nSpecies();

--- a/src/thermo/MargulesVPSSTP.cpp
+++ b/src/thermo/MargulesVPSSTP.cpp
@@ -49,18 +49,6 @@ void MargulesVPSSTP::getChemPotentials(double* mu) const
     }
 }
 
-double MargulesVPSSTP::entropy_mole() const
-{
-    size_t kk = nSpecies();
-    double s = 0;
-    vector<double> sbar(kk);
-    getPartialMolarEntropies(&sbar[0]);
-    for (size_t i = 0; i < kk; i++) {
-        s += moleFractions_[i]*sbar[i];
-    }
-    return s;
-}
-
 double MargulesVPSSTP::cp_mole() const
 {
     size_t kk = nSpecies();

--- a/src/thermo/MixtureFugacityTP.cpp
+++ b/src/thermo/MixtureFugacityTP.cpp
@@ -171,7 +171,6 @@ bool MixtureFugacityTP::addSpecies(shared_ptr<Species> spec)
         m_cp0_R.push_back(0.0);
         m_g0_RT.push_back(0.0);
         m_s0_R.push_back(0.0);
-        m_tmpV.push_back(0.0);
     }
     return added;
 }

--- a/src/thermo/NasaPoly2.cpp
+++ b/src/thermo/NasaPoly2.cpp
@@ -1,3 +1,5 @@
+//! @file NasaPoly2.cpp
+
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 

--- a/src/thermo/PengRobinson.cpp
+++ b/src/thermo/PengRobinson.cpp
@@ -129,8 +129,8 @@ double PengRobinson::pressure() const
 
 double PengRobinson::standardConcentration(size_t k) const
 {
-    getStandardVolumes(m_tmpV.data());
-    return 1.0 / m_tmpV[k];
+    getStandardVolumes(m_workS.data());
+    return 1.0 / m_workS[k];
 }
 
 void PengRobinson::getActivityCoefficients(double* ac) const
@@ -256,9 +256,9 @@ void PengRobinson::getPartialMolarEntropies(double* sbar) const
     // Using the identity : (hk - T*sk) = gk
     double T = temperature();
     getPartialMolarEnthalpies(sbar);
-    getChemPotentials(m_tmpV.data());
+    getChemPotentials(m_workS.data());
     for (size_t k = 0; k < m_kk; k++) {
-        sbar[k] = (sbar[k] - m_tmpV[k])/T;
+        sbar[k] = (sbar[k] - m_workS[k])/T;
     }
 }
 
@@ -267,9 +267,9 @@ void PengRobinson::getPartialMolarIntEnergies(double* ubar) const
     // u_i = h_i - p*v_i
     double p = pressure();
     getPartialMolarEnthalpies(ubar);
-    getPartialMolarVolumes(m_tmpV.data());
+    getPartialMolarVolumes(m_workS.data());
     for (size_t k = 0; k < m_kk; k++) {
-        ubar[k] = ubar[k] - p*m_tmpV[k];
+        ubar[k] = ubar[k] - p*m_workS[k];
     }
 }
 

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -806,7 +806,7 @@ bool Phase::addSpecies(shared_ptr<Species> spec)
         m_y.push_back(0.0);
         m_ym.push_back(0.0);
     }
-    m_tmpV.push_back(0.0);
+    m_workS.push_back(0.0);
     invalidateCache();
     return true;
 }

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -806,6 +806,7 @@ bool Phase::addSpecies(shared_ptr<Species> spec)
         m_y.push_back(0.0);
         m_ym.push_back(0.0);
     }
+    m_tmpV.push_back(0.0);
     invalidateCache();
     return true;
 }

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -50,17 +50,6 @@ void RedlichKisterVPSSTP::getChemPotentials(double* mu) const
     }
 }
 
-double RedlichKisterVPSSTP::enthalpy_mole() const
-{
-    double h = 0;
-    vector<double> hbar(m_kk);
-    getPartialMolarEnthalpies(&hbar[0]);
-    for (size_t i = 0; i < m_kk; i++) {
-        h += moleFractions_[i]*hbar[i];
-    }
-    return h;
-}
-
 double RedlichKisterVPSSTP::entropy_mole() const
 {
     double s = 0;

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -50,17 +50,6 @@ void RedlichKisterVPSSTP::getChemPotentials(double* mu) const
     }
 }
 
-double RedlichKisterVPSSTP::entropy_mole() const
-{
-    double s = 0;
-    vector<double> sbar(m_kk);
-    getPartialMolarEntropies(&sbar[0]);
-    for (size_t i = 0; i < m_kk; i++) {
-        s += moleFractions_[i]*sbar[i];
-    }
-    return s;
-}
-
 double RedlichKisterVPSSTP::cp_mole() const
 {
     double cp = 0;

--- a/src/thermo/RedlichKisterVPSSTP.cpp
+++ b/src/thermo/RedlichKisterVPSSTP.cpp
@@ -50,17 +50,6 @@ void RedlichKisterVPSSTP::getChemPotentials(double* mu) const
     }
 }
 
-double RedlichKisterVPSSTP::cp_mole() const
-{
-    double cp = 0;
-    vector<double> cpbar(m_kk);
-    getPartialMolarCp(&cpbar[0]);
-    for (size_t i = 0; i < m_kk; i++) {
-        cp += moleFractions_[i]*cpbar[i];
-    }
-    return cp;
-}
-
 double RedlichKisterVPSSTP::cv_mole() const
 {
     return cp_mole();

--- a/src/thermo/RedlichKwongMFTP.cpp
+++ b/src/thermo/RedlichKwongMFTP.cpp
@@ -140,8 +140,8 @@ double RedlichKwongMFTP::pressure() const
 
 double RedlichKwongMFTP::standardConcentration(size_t k) const
 {
-    getStandardVolumes(m_tmpV.data());
-    return 1.0 / m_tmpV[k];
+    getStandardVolumes(m_workS.data());
+    return 1.0 / m_workS[k];
 }
 
 void RedlichKwongMFTP::getActivityCoefficients(double* ac) const
@@ -237,10 +237,10 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(double* hbar) const
     double fac = TKelvin * dadt - 3.0 * m_a_current / 2.0;
 
     for (size_t k = 0; k < m_kk; k++) {
-        m_tmpV[k] = 0.0;
+        m_workS[k] = 0.0;
         for (size_t i = 0; i < m_kk; i++) {
             size_t counter = k + m_kk*i;
-            m_tmpV[k] += 2.0 * moleFractions_[i] * TKelvin * a_coeff_vec(1,counter) - 3.0 * moleFractions_[i] * a_vec_Curr_[counter];
+            m_workS[k] += 2.0 * moleFractions_[i] * TKelvin * a_coeff_vec(1,counter) - 3.0 * moleFractions_[i] * a_vec_Curr_[counter];
         }
     }
 
@@ -248,7 +248,7 @@ void RedlichKwongMFTP::getPartialMolarEnthalpies(double* hbar) const
     double fac2 = mv + TKelvin * dpdT_ / dpdV_;
     for (size_t k = 0; k < m_kk; k++) {
         double hE_v = (mv * dpdni_[k] - RT() - b_vec_Curr_[k]/ (m_b_current * m_b_current * sqt) * log(vpb/mv)*fac
-                       + 1.0 / (m_b_current * sqt) * log(vpb/mv) * m_tmpV[k]
+                       + 1.0 / (m_b_current * sqt) * log(vpb/mv) * m_workS[k]
                        +  b_vec_Curr_[k] / vpb / (m_b_current * sqt) * fac);
         hbar[k] = hbar[k] + hE_v;
         hbar[k] -= fac2 * dpdni_[k];
@@ -276,10 +276,10 @@ void RedlichKwongMFTP::getPartialMolarEntropies(double* sbar) const
         }
     }
     for (size_t k = 0; k < m_kk; k++) {
-        m_tmpV[k] = 0.0;
+        m_workS[k] = 0.0;
         for (size_t i = 0; i < m_kk; i++) {
             size_t counter = k + m_kk*i;
-            m_tmpV[k] += moleFractions_[i] * a_coeff_vec(1,counter);
+            m_workS[k] += moleFractions_[i] * a_coeff_vec(1,counter);
         }
     }
 
@@ -293,7 +293,7 @@ void RedlichKwongMFTP::getPartialMolarEntropies(double* sbar) const
                    + GasConstant * log(mv/vmb)
                    + GasConstant * b_vec_Curr_[k]/vmb
                    + m_pp[k]/(m_b_current * TKelvin * sqt) * log(vpb/mv)
-                   - 2.0 * m_tmpV[k]/(m_b_current * sqt) * log(vpb/mv)
+                   - 2.0 * m_workS[k]/(m_b_current * sqt) * log(vpb/mv)
                    + b_vec_Curr_[k] / (m_b_current * m_b_current * sqt) * log(vpb/mv) * fac
                    - 1.0 / (m_b_current * sqt) * b_vec_Curr_[k] / vpb * fac
                   );
@@ -327,10 +327,10 @@ void RedlichKwongMFTP::getPartialMolarVolumes(double* vbar) const
         }
     }
     for (size_t k = 0; k < m_kk; k++) {
-        m_tmpV[k] = 0.0;
+        m_workS[k] = 0.0;
         for (size_t i = 0; i < m_kk; i++) {
             size_t counter = k + m_kk*i;
-            m_tmpV[k] += moleFractions_[i] * a_coeff_vec(1,counter);
+            m_workS[k] += moleFractions_[i] * a_coeff_vec(1,counter);
         }
     }
 

--- a/src/thermo/Species.cpp
+++ b/src/thermo/Species.cpp
@@ -1,3 +1,5 @@
+//! @file Species.cpp
+
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -199,8 +199,8 @@ void VPStandardStateTP::setPressure(double p)
 
 void VPStandardStateTP::calcDensity()
 {
-    getPartialMolarVolumes(m_tmpV.data());
-    double dd = meanMolecularWeight() / mean_X(m_tmpV);
+    getPartialMolarVolumes(m_workS.data());
+    double dd = meanMolecularWeight() / mean_X(m_workS);
     Phase::assignDensity(dd);
 }
 

--- a/src/thermo/VPStandardStateTP.cpp
+++ b/src/thermo/VPStandardStateTP.cpp
@@ -199,7 +199,9 @@ void VPStandardStateTP::setPressure(double p)
 
 void VPStandardStateTP::calcDensity()
 {
-    throw NotImplementedError("VPStandardStateTP::calcDensity");
+    getPartialMolarVolumes(m_tmpV.data());
+    double dd = meanMolecularWeight() / mean_X(m_tmpV);
+    Phase::assignDensity(dd);
 }
 
 void VPStandardStateTP::setState_TP(double t, double pres)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

There are some instances where `ThermoPhase` objects use redundant code for the evaluation of molar mixture properties.

This PR seeks to provide a more uniform approach to evaluating molar properties. By default, average properties should be calculated as a weighted sum, e.g. $\bar{h} = \sum X_k \bar{h}_k$. `getPartialMolar<>` getters are used to obtain partial molar properties.

- default behavior for molar mixture properties is changed to summation rather than throwing an exception
- improve exception handling for any virtual `ThermoPhase` method that is not implemented
- redundant/equivalent overrides are removed unless speed advantages are apparent

One caveat is that this approach has limitations for `intEnergy_mole` and `cv_mole`. These properties are implemented differently as they are largely based on simplified thermodynamic relationships rather than summations. Interestingly, an attempt to base `intEnergy_mole` on `getPartialMolarIntEnergies` causes failures in the zeroD module, albeit only on windows and sundials runners.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
