### PR TITLE
Ensure correct transport model in 1D set_initial_state

### DIFF
--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -70,6 +70,10 @@ public:
     //! Set the Transport object directly
     virtual void setTransport(shared_ptr<Transport> transport);
 
+    //! Retrieve transport model name
+    //! @since New in %Cantera 3.2
+    string transportModel();
+
     //! Set the Transport object by name
     //! @param model  name of transport model; if omitted, the default model is used
     //! @since New in %Cantera 3.0

--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -119,6 +119,10 @@ public:
     //! Retrieve associated ThermoPhase object
     shared_ptr<ThermoPhase> thermo();
 
+    //! Retrieve associated Transport model
+    //! @since New in %Cantera 3.2
+    string transportModel();
+
     //! Retrieve list of component names
     vector<string> componentNames() const;
 

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -75,6 +75,13 @@ public:
         throw NotImplementedError("Domain1D::setTransport");
     }
 
+    //! Set transport model by name.
+    //! @param model  String specifying model name.
+    //! @since New in %Cantera 3.2.
+    virtual void setTransportModel(const string& model) {
+        throw NotImplementedError("Domain1D::setTransportModel");
+    }
+
     //! The container holding this domain.
     const OneDim& container() const {
         return *m_container;

--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -97,7 +97,7 @@ public:
 
     //! Set the transport model
     //! @since New in %Cantera 3.0.
-    void setTransportModel(const string& trans);
+    void setTransportModel(const string& model) override;
 
     //! Retrieve transport model
     //! @since New in %Cantera 3.0.

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -47,7 +47,6 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         shared_ptr[CxxKinetics] kinetics()
         void setKinetics(shared_ptr[CxxKinetics]) except +translate_exception
         shared_ptr[CxxTransport] transport()
-        void setTransport(shared_ptr[CxxTransport]) except +translate_exception
         void setTransportModel(const string&) except +translate_exception
         CxxAnyMap parameters(cbool) except +translate_exception
         size_t nAdjacent()

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -195,7 +195,7 @@ cdef class Transport(_SolutionBase):
             return pystr(self.transport.transportModel())
 
         def __set__(self, model):
-            self.base.setTransport(newTransport(self.base.thermo(), stringify(model)))
+            self.base.setTransportModel(stringify(model))
 
     property CK_mode:
         """Boolean to indicate if the chemkin interpretation is used."""
@@ -421,7 +421,7 @@ cdef class DustyGasTransport(Transport):
     coefficients are not implemented.
     """
     def __init__(self, *args, **kwargs):
-        self.base.setTransport(newTransport(self.base.thermo(), stringify("DustyGas")))
+        self.base.setTransportModel(stringify("DustyGas"))
         self.transport = self.base.transport().get()
         super().__init__(*args, **kwargs)
 

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -60,6 +60,15 @@ void Solution::setKinetics(shared_ptr<Kinetics> kinetics) {
     }
 }
 
+string Solution::transportModel()
+{
+    if (!m_transport) {
+        throw CanteraError("Solution::transportModel",
+            "The Transport object is not initialized.");
+    }
+    return m_transport->transportModel();
+}
+
 void Solution::setTransport(shared_ptr<Transport> transport) {
     if (transport == m_transport) {
         return;
@@ -74,6 +83,9 @@ void Solution::setTransportModel(const string& model) {
     if (!m_thermo) {
         throw CanteraError("Solution::setTransportModel",
             "Unable to set Transport model without valid ThermoPhase object.");
+    }
+    if (m_transport && transportModel() == model) {
+        return;
     }
     setTransport(newTransport(m_thermo, model));
 }

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -561,6 +561,11 @@ shared_ptr<ThermoPhase> SolutionArray::thermo()
     return m_sol->thermo();
 }
 
+string SolutionArray::transportModel()
+{
+    return m_sol->transportModel();
+}
+
 vector<string> SolutionArray::componentNames() const
 {
     vector<string> components;

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -1160,6 +1160,9 @@ void SolutionArray::writeEntry(const string& fname, const string& name,
     } else {
         more["api-shape"] = m_apiShape;
     }
+    if (!m_meta.hasKey("transport-model") && m_sol->transport()) {
+        more["transport-model"] = m_sol->transportModel();
+    }
     more["components"] = componentNames();
     file.writeAttributes(path, more);
     if (!m_dataSize) {
@@ -1225,6 +1228,9 @@ void SolutionArray::writeEntry(AnyMap& root, const string& name, const string& s
         data["size"] = int(m_dataSize);
     } else {
         data["api-shape"] = m_apiShape;
+    }
+    if (m_sol->transport() && m_sol->transportModel() != "none") {
+        data["transport-model"] = m_sol->transportModel();
     }
     data.update(m_meta);
 
@@ -1814,6 +1820,10 @@ void SolutionArray::readEntry(const string& fname, const string& name,
             }
         }
     }
+
+    if (m_meta.hasKey("transport-model")) {
+        m_sol->setTransportModel(m_meta["transport-model"].asString());
+    }
 }
 
 void SolutionArray::readEntry(const AnyMap& root, const string& name, const string& sub)
@@ -1958,6 +1968,10 @@ void SolutionArray::readEntry(const AnyMap& root, const string& name, const stri
         if (!exclude.count(name)) {
             m_meta[name] = value;
         }
+    }
+
+    if (m_meta.hasKey("transport-model")) {
+        m_sol->setTransportModel(m_meta["transport-model"].asString());
     }
 }
 

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -207,9 +207,14 @@ void Flow1D::resetBadValues(double* xg)
     }
 }
 
-void Flow1D::setTransportModel(const string& trans)
+void Flow1D::setTransportModel(const string& model)
 {
-    m_solution->setTransportModel(trans);
+    if (model == "none") {
+        throw CanteraError("Flow1D::setTransportModel",
+            "Invalid Transport model 'none'.");
+    }
+    m_solution->setTransportModel(model);
+    Flow1D::setTransport(m_solution->transport());
 }
 
 string Flow1D::transportModel() const {
@@ -981,7 +986,9 @@ void Flow1D::setMeta(const AnyMap& state)
         }
     }
 
-    setTransportModel(state.getString("transport-model", "mixture-averaged"));
+    if (state.hasKey("transport-model")) {
+        setTransportModel(state["transport-model"].asString());
+    }
 
     if (state.hasKey("Soret-enabled")) {
         m_do_soret = state["Soret-enabled"].asBool();

--- a/test/general/test_composite.cpp
+++ b/test/general/test_composite.cpp
@@ -59,6 +59,9 @@ TEST(SolutionArray, simple)
     auto gas = newSolution("h2o2.yaml",  "", "none");
     auto arr = SolutionArray::create(gas, 5);
 
+    ASSERT_EQ(gas->transportModel(), "none");
+    ASSERT_EQ(arr->transportModel(), "none");
+
     ASSERT_EQ(arr->size(), 5);
     ASSERT_EQ(arr->meta(), AnyMap());
 

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -477,11 +477,12 @@ class TestSolutionArrayIO:
 
     @pytest.mark.skipif("native" not in ct.hdf_support(),
                         reason="Cantera compiled without HDF support")
-    def test_import_no_norm_data(self):
+    def test_import_no_norm_data_h5(self):
         outfile = self.test_work_path / "solutionarray_no_norm.h5"
         outfile.unlink(missing_ok=True)
 
         gas = ct.Solution("h2o2.yaml")
+        gas.transport_model = "multicomponent"
         gas.set_unnormalized_mole_fractions(np.full(gas.n_species, 0.3))
         states = ct.SolutionArray(gas, 5)
         states.save(outfile, "group0")
@@ -492,6 +493,25 @@ class TestSolutionArrayIO:
         assert states.T == approx(b.T)
         assert states.P == approx(b.P)
         assert states.X == approx(b.X)
+        assert gas_new.transport_model == "multicomponent"
+
+    def test_import_no_norm_data_yaml(self):
+        outfile = self.test_work_path / "solutionarray_no_norm.yaml"
+        outfile.unlink(missing_ok=True)
+
+        gas = ct.Solution("h2o2.yaml")
+        gas.transport_model = "multicomponent"
+        gas.set_unnormalized_mole_fractions(np.full(gas.n_species, 0.3))
+        states = ct.SolutionArray(gas, 5)
+        states.save(outfile, "group0")
+
+        gas_new = ct.Solution("h2o2.yaml")
+        b = ct.SolutionArray(gas_new)
+        b.restore(outfile, "group0") #, normalize=False)
+        assert states.T == approx(b.T)
+        assert states.P == approx(b.P)
+        assert states.X == approx(b.X)
+        assert gas_new.transport_model == "multicomponent"
 
     def check_arrays(self, a, b, rtol=1e-8):
         assert a.T == approx(b.T, rel=rtol)

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -217,6 +217,15 @@ class TestFreeFlame:
 
         assert self.sim.transport_model == 'multicomponent'
 
+        data = self.test_work_path / f"multicomponent.yaml"
+        data.unlink(missing_ok=True)
+        group = "multicomponent"
+        self.sim.save(data, group)
+
+        arr = ct.SolutionArray(self.sim.gas)
+        arr.restore(data, "multicomponent/flame")
+        assert arr.transport_model == "multicomponent"
+
     def test_flow_type(self):
         Tin = 300
         p = ct.one_atm


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

If set by `SolutionArray`, the 1D Flame object inherits the transport model used by `SolutionArray`. The PR also fixes a couple of other paper cuts.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1839

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
