### PR TITLE
Autogenerated clib core objects

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -40,6 +40,7 @@ environment.y*
 *.mex*
 *.asv
 *.gv*
+*.mod
 .cproject
 .project
 .pydevproject

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -95,6 +95,17 @@ public:
      *
      *  @param p pointer to the phase object
      *  @param moles total number of moles of all species in this phase
+     *  @since New in %Cantera 3.2.
+     */
+    void addPhase(shared_ptr<ThermoPhase> p, double moles);
+
+    //! Add a phase to the mixture.
+    /*!
+     *  This function must be called before the init() function is called,
+     *  which serves to freeze the MultiPhase.
+     *
+     *  @param p pointer to the phase object
+     *  @param moles total number of moles of all species in this phase
      */
     void addPhase(ThermoPhase* p, double moles);
 
@@ -575,6 +586,11 @@ private:
     //! Vector of the ThermoPhase pointers.
     vector<ThermoPhase*> m_phase;
 
+    //! Vector of shared ThermoPhase pointers.
+    //! Contains valid phase entries if added by addPhase(shared_ptr<ThermoPhase>) and
+    //! null pointers if a phase is added via addPhase(ThermoPhase*).
+    vector<shared_ptr<ThermoPhase>> m_sharedPhase;
+
     //! Global Stoichiometric Coefficient array
     /*!
      * This is a two dimensional array m_atoms(m, k). The first index is the
@@ -660,6 +676,9 @@ private:
      */
     mutable vector<double> m_elemAbundances;
 };
+
+//! Create a new empty MultiPhase object
+shared_ptr<MultiPhase> newMultiPhase();
 
 //! Function to output a MultiPhase description to a stream
 /*!

--- a/include/cantera/equil/MultiPhase.h
+++ b/include/cantera/equil/MultiPhase.h
@@ -677,9 +677,6 @@ private:
     mutable vector<double> m_elemAbundances;
 };
 
-//! Create a new empty MultiPhase object
-shared_ptr<MultiPhase> newMultiPhase();
-
 //! Function to output a MultiPhase description to a stream
 /*!
  *  Writes out a description of the contents of each phase of the

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -218,6 +218,16 @@ public:
     shared_ptr<ThermoPhase> reactionPhase() const;
 
     /**
+     * Return pointer to phase associated with Kinetics by index.
+     * @param n Index of the ThermoPhase being sought.
+     * @since New in %Cantera 3.2.
+     * @see thermo
+     */
+    shared_ptr<ThermoPhase> phase(size_t n=0) const {
+        return m_thermo[n];
+    }
+
+    /**
      * This method returns a reference to the nth ThermoPhase object defined
      * in this kinetics mechanism. It is typically used so that member
      * functions of the ThermoPhase object may be called. For homogeneous

--- a/interfaces/sourcegen/sourcegen/_data/README.md
+++ b/interfaces/sourcegen/sourcegen/_data/README.md
@@ -23,10 +23,11 @@ based on a recipe, which is subsequently used to scaffold API functions using de
 *Jinja* templates. The following recipe/CLib function types are differentiated:
 
 - `function`: Regular function defined in the `Cantera` namespace.
-- `constructor`: A CLib constructor adds new (or existing) C++ objects to CLib storage.
-    As all objects are handled via smart `shared_ptr<>`, a CLib constructor requires a
-    C++ utility functions that returning a pointer to a new object or an object that is
-    not yet added to CLib storage. Constructor names should start with `new`.
+- `constructor`: A CLib constructor adds new C++ objects to CLib storage. Constructor
+    names should start with `new`. As all objects are handled via smart `shared_ptr<>`,
+    CLib constructors require C++ utility functions that return a pointer to a new
+    object. Constructors with the name `new` will use the C++ default constructor.
+- `accessor`: a CLib accessor adds existing or spawned C++ objects to CLib storage.
 - `destructor`: A CLib destructor removes a C++ object from CLib. Destructor names
     should start with `del`.
 - `getter`: Implements a getter method of a C++ class.

--- a/interfaces/sourcegen/sourcegen/_data/ct_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ct_auto.yaml
@@ -7,12 +7,10 @@ docstring: |-
 prefix: ct3
 base: ""
 recipes:
-- name: getCanteraVersion
-  implements: version
-- name: getGitCommit
-  implements: gitCommit
+- name: version  # previously: getCanteraVersion
+- name: gitCommit  # previously: getGitCommit
 - name: getCanteraError
-- name: addCanteraDirectory
+- name: addDataDirectory  # previously: addCanteraDirectory
   implements: addDirectory
 - name: getDataDirectories
 - name: findInputFile
@@ -22,6 +20,8 @@ recipes:
 - name: warnings_suppressed
 - name: make_warnings_fatal
 - name: suppress_thermo_warnings
+- name: use_legacy_rate_constants
+- name: appdelete
 - name: clearStorage
 - name: resetStorage
 - name: setLogWriter

--- a/interfaces/sourcegen/sourcegen/_data/ct_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ct_auto.yaml
@@ -24,5 +24,5 @@ recipes:
 - name: suppress_thermo_warnings
 - name: clearStorage
 - name: resetStorage
-# - name: setLogWriter  # only used by .NET API
-# - name: setLogCallback  # only used by .NET API
+- name: setLogWriter
+- name: setLogCallback

--- a/interfaces/sourcegen/sourcegen/_data/ct_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ct_auto.yaml
@@ -7,20 +7,22 @@ docstring: |-
 prefix: ct3
 base: ""
 recipes:
-- name: version  # previously: getCanteraVersion
-- name: gitCommit  # previously: getGitCommit
+- name: getCanteraVersion
+  implements: version  # inconsistent API (preexisting)
+- name: getGitCommit
+  implements: gitCommit  # inconsistent API (preexisting)
 - name: getCanteraError
-- name: addDataDirectory  # previously: addCanteraDirectory
-  implements: addDirectory
+- name: addCanteraDirectory
+  implements: addDirectory  # inconsistent API (preexisting)
 - name: getDataDirectories
 - name: findInputFile
-- name: suppress_deprecation_warnings
-- name: make_deprecation_warnings_fatal
-- name: suppress_warnings
-- name: warnings_suppressed
-- name: make_warnings_fatal
-- name: suppress_thermo_warnings
-- name: use_legacy_rate_constants
+- name: suppress_deprecation_warnings  # inconsistent API (snake_case; preexisting)
+- name: make_deprecation_warnings_fatal  # inconsistent API (snake_case; preexisting)
+- name: suppress_warnings  # inconsistent API (snake_case; preexisting)
+- name: warnings_suppressed  # inconsistent API (snake_case; preexisting)
+- name: make_warnings_fatal  # inconsistent API (snake_case; preexisting)
+- name: suppress_thermo_warnings  # inconsistent API (snake_case; preexisting)
+- name: use_legacy_rate_constants  # inconsistent API (snake_case; preexisting)
 - name: appdelete
 - name: clearStorage
 - name: resetStorage

--- a/interfaces/sourcegen/sourcegen/_data/ctfunc_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctfunc_auto.yaml
@@ -7,28 +7,28 @@ docstring: |-
 prefix: func13
 base: Func1
 recipes:
-- name: check
-  implements: checkFunc1
-- name: newBasic
+- name: checkFunc1  # previously: check
+- name: newBasic  # previously: new_basic
   implements: newFunc1(const string&, double)
-- name: newAdvanced
+- name: newAdvanced  # previously: new_advanced
   implements: newFunc1(const string&, const vector<double>&)
-- name: newCompound
+- name: newCompound  # previously: new_compound
   implements: newFunc1(const string&, const shared_ptr<Func1>, const shared_ptr<Func1>)
-- name: newModified
+- name: newModified  # previously: new_modified
   implements: newFunc1(const string&, const shared_ptr<Func1>, double)
-- name: newSum
+- name: newSum  # previously: new_sum
   implements: newSumFunction
-- name: newDiff
+- name: newDiff  # previously: new_diff
   implements: newDiffFunction
-- name: newProd
+- name: newProd  # previously: new_prod
   implements: newProdFunction
-- name: newRatio
+- name: newRatio  # previously: new_ratio
   implements: newRatioFunction
 - name: type
-- name: eval
+- name: eval  # previously: value
 - name: derivative
   what: accessor
+# - name: duplicate  <--- unnecessary: traditional CLib duplicates function
 - name: write
 - name: del
   what: destructor

--- a/interfaces/sourcegen/sourcegen/_data/ctfunc_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctfunc_auto.yaml
@@ -7,25 +7,27 @@ docstring: |-
 prefix: func13
 base: Func1
 recipes:
-- name: checkFunc1  # previously: check
-- name: newBasic  # previously: new_basic
+- name: check
+  implements: checkFunc1  # inconsistent API (preexisting)
+- name: new_basic  # inconsistent API (snake_case; preexisting)
   implements: newFunc1(const string&, double)
-- name: newAdvanced  # previously: new_advanced
+- name: new_advanced  # inconsistent API (snake_case; preexisting)
   implements: newFunc1(const string&, const vector<double>&)
-- name: newCompound  # previously: new_compound
+- name: new_compound  # inconsistent API (snake_case; preexisting)
   implements: newFunc1(const string&, const shared_ptr<Func1>, const shared_ptr<Func1>)
-- name: newModified  # previously: new_modified
+- name: new_modified  # inconsistent API (snake_case; preexisting)
   implements: newFunc1(const string&, const shared_ptr<Func1>, double)
-- name: newSum  # previously: new_sum
-  implements: newSumFunction
-- name: newDiff  # previously: new_diff
-  implements: newDiffFunction
-- name: newProd  # previously: new_prod
-  implements: newProdFunction
-- name: newRatio  # previously: new_ratio
-  implements: newRatioFunction
+- name: new_sum
+  implements: newSumFunction  # inconsistent API (preexisting)
+- name: new_diff
+  implements: newDiffFunction  # inconsistent API (preexisting)
+- name: new_prod
+  implements: newProdFunction  # inconsistent API (preexisting)
+- name: new_ratio
+  implements: newRatioFunction  # inconsistent API (preexisting)
 - name: type
-- name: eval  # previously: value
+- name: value
+  implements: eval  # inconsistent API (preexisting)
 - name: derivative
   what: accessor
 # - name: duplicate  <--- unnecessary: traditional CLib duplicates function

--- a/interfaces/sourcegen/sourcegen/_data/ctfunc_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctfunc_auto.yaml
@@ -27,9 +27,8 @@ recipes:
   implements: newRatioFunction
 - name: type
 - name: eval
-- name: newDerivative
-  what: constructor
-  implements: Func1::derivative
+- name: derivative
+  what: accessor
 - name: write
 - name: del
   what: destructor

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -30,7 +30,8 @@ recipes:
 - name: isReversible
 - name: kineticsSpeciesIndex  # previously: speciesIndex
   implements: Kinetics::kineticsSpeciesIndex(const string&)
-# - name: advanceCoverages  # <--- needs to be implemented
+- name: advanceCoverages
+  implements: InterfaceKinetics::advanceCoverages(double)
 # - name: getReactionString  # <--- needs Reaction interface
 # - name: getReactionType  # <--- needs Reaction interface
 # - name: getSourceTerms  # <--- used by MATLAB interface for "massProdRate"

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -9,11 +9,17 @@ base: Kinetics
 parents: []  # List of parent classes
 derived: [InterfaceKinetics]  # List of specializations
 recipes:
-- name: nReactions
 - name: kineticsType  # previously getType
-- name: nTotalSpecies  # previously: nSpecies
+- name: nReactions
+- name: reaction  # new
+  uses: nReactions
+  what: constructor  # registers object in CLib storage
 - name: nPhases
+- name: phase
+  uses: nPhases
+  what: constructor  # registers object in CLib storage
 - name: phaseIndex
+- name: nTotalSpecies  # previously: nSpecies
 - name: reactantStoichCoeff
 - name: productStoichCoeff
 - name: getFwdRatesOfProgress
@@ -32,10 +38,6 @@ recipes:
   implements: Kinetics::kineticsSpeciesIndex(const string&)
 - name: advanceCoverages
   implements: InterfaceKinetics::advanceCoverages(double)
-- name: reaction  # new
-  what: constructor  # registers object in CLib storage
-- name: phase
-  what: constructor
 - name: getDeltaEnthalpy  # previously: part of getDelta
 - name: getDeltaGibbs  # previously: part of getDelta
 - name: getDeltaEntropy  # previously: part of getDelta

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -36,9 +36,9 @@ recipes:
 - name: setMultiplier
 - name: isReversible
 - name: kineticsSpeciesIndex  # previously: speciesIndex
-  implements: Kinetics::kineticsSpeciesIndex(const string&)
+  implements: kineticsSpeciesIndex(const string&)
 - name: advanceCoverages
-  implements: InterfaceKinetics::advanceCoverages(double)
+  implements: advanceCoverages(double)
 - name: getDeltaEnthalpy  # previously: part of getDelta
 - name: getDeltaGibbs  # previously: part of getDelta
 - name: getDeltaEntropy  # previously: part of getDelta

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -16,6 +16,7 @@ recipes:
   what: constructor  # registers object in CLib storage
 - name: nPhases
 - name: phase
+  implements: Kinetics::thermo
   uses: nPhases
   what: constructor  # registers object in CLib storage
 - name: phaseIndex

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -7,11 +7,41 @@ docstring: |-
 prefix: kin3
 base: Kinetics
 parents: []  # List of parent classes
-derived: []  # List of specializations
+derived: [InterfaceKinetics]  # List of specializations
 recipes:
 - name: nReactions
-- name: kineticsType
+- name: kineticsType  # previously getType
+- name: nTotalSpecies  # previously: nSpecies
+- name: nPhases
+- name: phaseIndex
+- name: reactantStoichCoeff
+- name: productStoichCoeff
 - name: getFwdRatesOfProgress
+- name: getRevRatesOfProgress
+- name: getNetRatesOfProgress
+- name: getEquilibriumConstants
+- name: getFwdRateConstants
+- name: getRevRateConstants
+- name: getCreationRates
+- name: getDestructionRates
+- name: getNetProductionRates
+- name: multiplier
+- name: setMultiplier
+- name: isReversible
+- name: kineticsSpeciesIndex  # previously: speciesIndex
+  implements: Kinetics::kineticsSpeciesIndex(const string&)
+# - name: advanceCoverages  # <--- needs to be implemented
+# - name: getReactionString  # <--- needs Reaction interface
+# - name: getReactionType  # <--- needs Reaction interface
+# - name: getSourceTerms  # <--- used by MATLAB interface for "massProdRate"
+# - name: phase  # <--- appears to be unused
+- name: getDeltaEnthalpy  # previously: part of getDelta
+- name: getDeltaGibbs  # previously: part of getDelta
+- name: getDeltaEntropy  # previously: part of getDelta
+- name: getDeltaSSEnthalpy  # previously: part of getDelta
+- name: getDeltaSSGibbs  # previously: part of getDelta
+- name: getDeltaSSEntropy  # previously: part of getDelta
+# - name: start  # <--- appears to be unused
 - name: del
   what: noop
   brief: Destructor; required by some APIs although object is managed by Solution.

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -32,16 +32,17 @@ recipes:
   implements: Kinetics::kineticsSpeciesIndex(const string&)
 - name: advanceCoverages
   implements: InterfaceKinetics::advanceCoverages(double)
-# - name: getReactionString  # <--- needs Reaction interface
-# - name: getReactionType  # <--- needs Reaction interface
-# - name: getSourceTerms  # <--- used by MATLAB interface for "massProdRate"
-# - name: phase  # <--- appears to be unused
+- name: reaction  # new
+  what: constructor  # registers object in CLib storage
+- name: phase
+  what: constructor
 - name: getDeltaEnthalpy  # previously: part of getDelta
 - name: getDeltaGibbs  # previously: part of getDelta
 - name: getDeltaEntropy  # previously: part of getDelta
 - name: getDeltaSSEnthalpy  # previously: part of getDelta
 - name: getDeltaSSGibbs  # previously: part of getDelta
 - name: getDeltaSSEntropy  # previously: part of getDelta
+# - name: getSourceTerms  # <--- used by MATLAB interface for "massProdRate"
 # - name: start  # <--- appears to be unused
 - name: del
   what: noop

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -16,7 +16,6 @@ recipes:
   what: constructor  # registers object in CLib storage
 - name: nPhases
 - name: phase
-  implements: Kinetics::thermo
   uses: nPhases
   what: constructor  # registers object in CLib storage
 - name: phaseIndex

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -9,18 +9,20 @@ base: Kinetics
 parents: []  # List of parent classes
 derived: [InterfaceKinetics]  # List of specializations
 recipes:
-- name: kineticsType  # previously: getType
+- name: getType
+  implements: kineticsType  # inconsistent API (preexisting)
 - name: nReactions
-- name: reaction  # new
+- name: reaction  # New in Cantera 3.2
   uses: nReactions
   what: accessor
 - name: nPhases
 - name: phase
   uses: nPhases
   what: accessor
-- name: reactionPhase  # new
+- name: reactionPhase  # New in Cantera 3.2
 - name: phaseIndex
-- name: nTotalSpecies  # previously: nSpecies
+- name: nSpecies
+  implements: nTotalSpecies  # inconsistent API (preexisting)
 - name: reactantStoichCoeff
 - name: productStoichCoeff
 - name: getFwdRatesOfProgress
@@ -35,8 +37,8 @@ recipes:
 - name: multiplier
 - name: setMultiplier
 - name: isReversible
-- name: kineticsSpeciesIndex  # previously: speciesIndex
-  implements: kineticsSpeciesIndex(const string&)
+- name: speciesIndex
+  implements: kineticsSpeciesIndex(const string&)  # inconsistent API (preexisting)
 - name: advanceCoverages
   implements: advanceCoverages(double)
 - name: getDeltaEnthalpy  # previously: part of getDelta

--- a/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctkin_auto.yaml
@@ -9,15 +9,16 @@ base: Kinetics
 parents: []  # List of parent classes
 derived: [InterfaceKinetics]  # List of specializations
 recipes:
-- name: kineticsType  # previously getType
+- name: kineticsType  # previously: getType
 - name: nReactions
 - name: reaction  # new
   uses: nReactions
-  what: constructor  # registers object in CLib storage
+  what: accessor
 - name: nPhases
 - name: phase
   uses: nPhases
-  what: constructor  # registers object in CLib storage
+  what: accessor
+- name: reactionPhase  # new
 - name: phaseIndex
 - name: nTotalSpecies  # previously: nSpecies
 - name: reactantStoichCoeff
@@ -45,7 +46,7 @@ recipes:
 - name: getDeltaSSGibbs  # previously: part of getDelta
 - name: getDeltaSSEntropy  # previously: part of getDelta
 # - name: getSourceTerms  # <--- used by MATLAB interface for "massProdRate"
-# - name: start  # <--- appears to be unused
+# - name: start  # <--- unused except for FORTRAN API
 - name: del
   what: noop
   brief: Destructor; required by some APIs although object is managed by Solution.

--- a/interfaces/sourcegen/sourcegen/_data/ctmix_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctmix_auto.yaml
@@ -11,14 +11,14 @@ derived: []  # List of specializations
 recipes:
 - name: new
 - name: addPhase
-  implements: MultiPhase::addPhase(shared_ptr<ThermoPhase>, double)
+  implements: addPhase(shared_ptr<ThermoPhase>, double)
 - name: init
 - name: updatePhases
 - name: nElements
 - name: elementIndex
 - name: nSpecies
 - name: speciesIndex
-  implements: MultiPhase::speciesIndex(size_t, size_t)
+  implements: speciesIndex(size_t, size_t)
 - name: temperature
 - name: setTemperature
 - name: minTemp
@@ -33,11 +33,11 @@ recipes:
 - name: setPhaseMoles
 - name: setMoles
 - name: setMolesByName
-  implements: MultiPhase::setMolesByName(const string&)
+  implements: setMolesByName(const string&)
 - name: speciesMoles
 - name: elementMoles
 - name: equilibrate
-  implements: MultiPhase::equilibrate(int, const char*, double, int, int, int)
+  implements: equilibrate(int, const char*, double, int, int, int)
 - name: getChemPotentials
 - name: enthalpy
 - name: entropy

--- a/interfaces/sourcegen/sourcegen/_data/ctmix_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctmix_auto.yaml
@@ -10,7 +10,6 @@ parents: []  # List of parent classes
 derived: []  # List of specializations
 recipes:
 - name: new
-  implements: newMultiPhase
 - name: addPhase
   implements: MultiPhase::addPhase(shared_ptr<ThermoPhase>, double)
 - name: init

--- a/interfaces/sourcegen/sourcegen/_data/ctmix_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctmix_auto.yaml
@@ -1,0 +1,52 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+docstring: |-
+  Auto-generated CLib API for %Cantera's MultiPhase class.
+  Implements a replacement for CLib's traditional @c ctmultiphase library.
+prefix: mix3
+base: MultiPhase
+parents: []  # List of parent classes
+derived: []  # List of specializations
+recipes:
+- name: new
+  implements: newMultiPhase
+- name: addPhase
+  implements: MultiPhase::addPhase(shared_ptr<ThermoPhase>, double)
+- name: init
+- name: updatePhases
+- name: nElements
+- name: elementIndex
+- name: nSpecies
+- name: speciesIndex
+  implements: MultiPhase::speciesIndex(size_t, size_t)
+- name: temperature
+- name: setTemperature
+- name: minTemp
+- name: maxTemp
+- name: charge
+- name: phaseCharge
+- name: pressure
+- name: setPressure
+- name: nAtoms
+- name: nPhases
+- name: phaseMoles
+- name: setPhaseMoles
+- name: setMoles
+- name: setMolesByName
+  implements: MultiPhase::setMolesByName(const string&)
+- name: speciesMoles
+- name: elementMoles
+- name: equilibrate
+  implements: MultiPhase::equilibrate(int, const char*, double, int, int, int)
+- name: getChemPotentials
+- name: enthalpy
+- name: entropy
+- name: gibbs
+- name: cp
+- name: volume
+- name: speciesPhaseIndex
+- name: moleFraction
+- name: del
+- name: cabinetSize
+- name: parentHandle

--- a/interfaces/sourcegen/sourcegen/_data/ctrxn_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctrxn_auto.yaml
@@ -1,0 +1,17 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+docstring: |-
+  Auto-generated CLib API for %Cantera's Reaction class.
+  Implements an extension of CLib's traditional @c ct library.
+prefix: rxn3
+base: Reaction
+parents: []  # List of parent classes
+derived: []  # List of specializations
+recipes:
+#- name: new
+- name: equation  # previously: ctkin_getReactionString
+- name: type  # previously: ctkin_getReactionType
+- name: del
+- name: cabinetSize
+- name: parentHandle

--- a/interfaces/sourcegen/sourcegen/_data/ctrxn_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctrxn_auto.yaml
@@ -12,6 +12,9 @@ recipes:
 - name: new
 - name: equation  # previously: ctkin_getReactionString
 - name: type  # previously: ctkin_getReactionType
+- name: usesThirdBody
+- name: valid
+# - name: id  <--- member variable (access not yet implemented)
 - name: del
 - name: cabinetSize
 - name: parentHandle

--- a/interfaces/sourcegen/sourcegen/_data/ctrxn_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctrxn_auto.yaml
@@ -9,7 +9,7 @@ base: Reaction
 parents: []  # List of parent classes
 derived: []  # List of specializations
 recipes:
-#- name: new
+- name: new
 - name: equation  # previously: ctkin_getReactionString
 - name: type  # previously: ctkin_getReactionType
 - name: del

--- a/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
@@ -25,16 +25,8 @@ recipes:
 - name: transport
 - name: transportModel
 - name: setTransportModel
-  code: |-
-    try {
-        auto obj = SolutionCabinet::at(handle);
-        TransportCabinet::del(
-            TransportCabinet::index(*(obj->transport()), handle));
-        obj->setTransportModel(model);
-        return TransportCabinet::add(obj->transport(), handle);
-    } catch (...) {
-        return handleAllExceptions(-2, ERR);
-    }
+  uses: [transport]
+  what: constructor
 - name: nAdjacent
 - name: adjacent
   implements: Solution::adjacent(size_t)

--- a/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
@@ -38,7 +38,7 @@ recipes:
 - name: nAdjacent
 - name: adjacent
   implements: Solution::adjacent(size_t)
-  uses: [thermo, kinetics, transport]
+  uses: [nAdjacent, thermo, kinetics, transport]
   what: constructor  # registers object in CLib storage
 - name: adjacentName
 - name: source

--- a/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
@@ -23,6 +23,7 @@ recipes:
 - name: thermo
 - name: kinetics
 - name: transport
+- name: transportModel
 - name: setTransportModel
   code: |-
     try {
@@ -40,4 +41,5 @@ recipes:
   uses: [thermo, kinetics, transport]
   what: constructor  # registers object in CLib storage
 - name: adjacentName
+- name: source
 - name: cabinetSize

--- a/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
@@ -26,12 +26,12 @@ recipes:
 - name: transportModel
 - name: setTransportModel
   uses: [transport]
-  what: constructor
+  what: accessor
 - name: nAdjacent
 - name: adjacent
   implements: Solution::adjacent(size_t)
   uses: [nAdjacent, thermo, kinetics, transport]
-  what: constructor  # registers object in CLib storage
+  what: accessor
 - name: adjacentName
 - name: source
 - name: cabinetSize

--- a/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctsol_auto.yaml
@@ -29,7 +29,7 @@ recipes:
   what: accessor
 - name: nAdjacent
 - name: adjacent
-  implements: Solution::adjacent(size_t)
+  implements: adjacent(size_t)
   uses: [nAdjacent, thermo, kinetics, transport]
   what: accessor
 - name: adjacentName

--- a/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
@@ -3,11 +3,12 @@
 
 docstring: |-
   Auto-generated CLib API for %Cantera's ThermoPhase class.
-  Partially implements a replacement for CLib's traditional @c ct library.
+  Partially implements a replacement for CLib's traditional @c ct and
+  @c ctsurf libraries.
 prefix: thermo3
 base: ThermoPhase
 parents: [Phase]  # List of parent classes
-derived: []  # List of specializations
+derived: [SurfPhase]  # List of specializations
 recipes:
 - name: report
 - name: name  # previously: getName
@@ -126,6 +127,14 @@ recipes:
 - name: satPressure
 - name: setState_Psat
 - name: setState_Tsat
+- name: getCoverages  # previously: used 'surf' prefix'
+- name: setCoverages  # previously: used 'surf' prefix'
+- name: getConcentrations  # previously: used 'surf' prefix'
+- name: setConcentrations  # previously: used 'surf' prefix'
+- name: siteDensity  # previously: used 'surf' prefix'
+- name: setSiteDensity  # previously: used 'surf' prefix'
+- name: setCoveragesByName  # previously: used 'surf' prefix'
+  implements: SurfPhase::setCoveragesByName(const string&)
 - name: del
   what: noop
   brief: Destructor; required by some APIs although object is managed by Solution.

--- a/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
@@ -11,10 +11,11 @@ parents: [Phase]  # List of parent classes
 derived: [SurfPhase]  # List of specializations
 recipes:
 - name: report
-- name: name  # previously: getName
+- name: getName
+  implements: name  # inconsistent API (preexisting)
 - name: setName
 - name: getEosType
-  implements: type
+  implements: type  # inconsistent API (preexisting)
 - name: nElements
 - name: nSpecies
 - name: temperature
@@ -41,16 +42,17 @@ recipes:
   implements: setMoleFractionsByName(const string&)
 - name: setMassFractionsByName
   implements: setMassFractionsByName(const string&)
-- name: atomicWeights  # previously: getAtomicWeights
+- name: getAtomicWeights
   uses: nElements
+  implements: atomicWeights  # inconsistent API (preexisting)
 - name: getMolecularWeights
   uses: nSpecies
 - name: getCharges
   uses: nElements
-- name: elementName  # previously: getElementName
-  implements: elementName(int)
-- name: speciesName  # previously: getSpeciesName
-  implements: speciesName(int)
+- name: getElementName
+  implements: elementName(int)  # inconsistent API (preexisting)
+- name: getSpeciesName
+  implements: speciesName(int)  # inconsistent API (preexisting)
 - name: elementIndex
 - name: speciesIndex
 - name: nAtoms
@@ -71,9 +73,9 @@ recipes:
 - name: cv_mole
 - name: cv_mass
 - name: chemPotentials
-  implements: getChemPotentials
+  implements: getChemPotentials  # inconsistent API (preexisting)
 - name: electroChemPotentials
-  implements: getElectrochemPotentials
+  implements: getElectrochemPotentials  # inconsistent API (preexisting)
 - name: electricPotential
 - name: setElectricPotential
 - name: thermalExpansionCoeff
@@ -83,38 +85,38 @@ recipes:
 - name: getPartialMolarIntEnergies
 - name: getPartialMolarCp
 - name: getPartialMolarVolumes
-- name: setState_TPX  # new
+- name: setState_TPX  # New in Cantera 3.2
   implements: setState_TPX(double, double, const double*)
-- name: setState_TPY  # new
+- name: setState_TPY  # New in Cantera 3.2
   implements: setState_TPY(double, double, const double*)
-- name: setState_TP  # previously: set_TP
-  implements: setState_TP(double, double)
-- name: setState_TD  # previously: set_TD
-  implements: setState_TD(double, double)
-- name: setState_DP  # previously: set_DP
-  implements: setState_DP(double, double)
-- name: setState_HP  # previously: set_HP
-  implements: setState_HP(double, double)
-- name: setState_UV  # previously: set_UV
-  implements: setState_UV(double, double)
-- name: setState_SV  # previously: set_SV
-  implements: setState_SV(double, double)
-- name: setState_SP  # previously: set_SP
-  implements: setState_SP(double, double)
-- name: setState_ST  # previously: set_ST
-  implements: setState_ST(double, double)
-- name: setState_TV  # previously: set_TV
-  implements: setState_TV(double, double)
-- name: setState_PV  # previously: set_PV
-  implements: setState_PV(double, double)
-- name: setState_UP  # previously: set_UP
-  implements: setState_UP(double, double)
-- name: setState_VH  # previously: set_VH
-  implements: setState_VH(double, double)
-- name: setState_TH  # previously: set_TH
-  implements: setState_TH(double, double)
-- name: setState_SH  # previously: set_SH
-  implements: setState_SH(double, double)
+- name: set_TP
+  implements: setState_TP(double, double)  # inconsistent API (preexisting)
+- name: set_TD
+  implements: setState_TD(double, double)  # inconsistent API (preexisting)
+- name: set_DP
+  implements: setState_DP(double, double)  # inconsistent API (preexisting)
+- name: set_HP
+  implements: setState_HP(double, double)  # inconsistent API (preexisting)
+- name: set_UV
+  implements: setState_UV(double, double)  # inconsistent API (preexisting)
+- name: set_SV
+  implements: setState_SV(double, double)  # inconsistent API (preexisting)
+- name: set_SP
+  implements: setState_SP(double, double)  # inconsistent API (preexisting)
+- name: set_ST
+  implements: setState_ST(double, double)  # inconsistent API (preexisting)
+- name: set_TV
+  implements: setState_TV(double, double)  # inconsistent API (preexisting)
+- name: set_PV
+  implements: setState_PV(double, double)  # inconsistent API (preexisting)
+- name: set_UP
+  implements: setState_UP(double, double)  # inconsistent API (preexisting)
+- name: set_VH
+  implements: setState_VH(double, double)  # inconsistent API (preexisting)
+- name: set_TH
+  implements: setState_TH(double, double)  # inconsistent API (preexisting)
+- name: set_SH
+  implements: setState_SH(double, double)  # inconsistent API (preexisting)
 - name: equilibrate
   implements:
     ThermoPhase::equilibrate(const string&, const string&, double, int, int, int)

--- a/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
@@ -10,6 +10,10 @@ parents: [Phase]  # List of parent classes
 derived: []  # List of specializations
 recipes:
 - name: report
+- name: name  # previously: getName
+- name: setName
+- name: getEosType
+  implements: Phase::type
 - name: nElements
 - name: nSpecies
 - name: temperature
@@ -36,22 +40,91 @@ recipes:
   implements: Phase::setMoleFractionsByName(const string&)
 - name: setMassFractionsByName
   implements: Phase::setMassFractionsByName(const string&)
+# - name: getAtomicWeights
+#   implements: Phase::atomicWeights
+#   uses: nElements
+- name: getMolecularWeights
+  uses: nSpecies
+- name: getCharges
+- name: getElementName
+  implements: Phase::elementName(int)
+- name: getSpeciesName
+  implements: Phase::speciesName(int)
+- name: elementIndex
+- name: speciesIndex
+- name: nAtoms
+- name: addElement
+- name: refPressure
+- name: minTemp
+- name: maxTemp
 - name: enthalpy_mole
 - name: enthalpy_mass
 - name: entropy_mole
 - name: entropy_mass
 - name: intEnergy_mole
 - name: intEnergy_mass
+- name: gibbs_mole
+- name: gibbs_mass
 - name: cp_mole
 - name: cp_mass
+- name: cv_mole
+- name: cv_mass
+- name: chemPotentials
+  implements: ThermoPhase::getChemPotentials
+- name: electroChemPotentials
+  implements: ThermoPhase::getElectrochemPotentials
+- name: electricPotential
+- name: setElectricPotential
+- name: thermalExpansionCoeff
+- name: isothermalCompressibility
 - name: getPartialMolarEnthalpies
 - name: getPartialMolarEntropies
 - name: getPartialMolarIntEnergies
 - name: getPartialMolarCp
 - name: getPartialMolarVolumes
+- name: setState_TPX  # new
+  implements: ThermoPhase::setState_TPX(double, double, const double*)
+- name: setState_TPY  # new
+  implements: ThermoPhase::setState_TPY(double, double, const double*)
+- name: setState_TP  # previously: set_TP
+  implements: ThermoPhase::setState_TP(double, double)
+- name: setState_TD  # previously: set_TD
+  implements: Phase::setState_TD(double, double)
+- name: setState_DP  # previously: set_DP
+  implements: ThermoPhase::setState_DP(double, double)
+- name: setState_HP  # previously: set_HP
+  implements: ThermoPhase::setState_HP(double, double)
+- name: setState_UV  # previously: set_UV
+  implements: ThermoPhase::setState_UV(double, double)
+- name: setState_SV  # previously: set_SV
+  implements: ThermoPhase::setState_SV(double, double)
+- name: setState_SP  # previously: set_SP
+  implements: ThermoPhase::setState_SP(double, double)
+- name: setState_ST  # previously: set_ST
+  implements: ThermoPhase::setState_ST(double, double)
+- name: setState_TV  # previously: set_TV
+  implements: ThermoPhase::setState_TV(double, double)
+- name: setState_PV  # previously: set_PV
+  implements: ThermoPhase::setState_PV(double, double)
+- name: setState_UP  # previously: set_UP
+  implements: ThermoPhase::setState_UP(double, double)
+- name: setState_VH  # previously: set_VH
+  implements: ThermoPhase::setState_VH(double, double)
+- name: setState_TH  # previously: set_TH
+  implements: ThermoPhase::setState_TH(double, double)
+- name: setState_SH  # previously: set_SH
+  implements: ThermoPhase::setState_SH(double, double)
 - name: equilibrate
   implements:
     ThermoPhase::equilibrate(const string&, const string&, double, int, int, int)
+- name: critTemperature
+- name: critPressure
+- name: critDensity
+- name: vaporFraction
+- name: satTemperature
+- name: satPressure
+- name: setState_Psat
+- name: setState_Tsat
 - name: del
   what: noop
   brief: Destructor; required by some APIs although object is managed by Solution.

--- a/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
@@ -40,12 +40,13 @@ recipes:
   implements: Phase::setMoleFractionsByName(const string&)
 - name: setMassFractionsByName
   implements: Phase::setMassFractionsByName(const string&)
-# - name: getAtomicWeights
-#   implements: Phase::atomicWeights
-#   uses: nElements
+- name: getAtomicWeights
+  implements: Phase::atomicWeights
+  uses: nElements
 - name: getMolecularWeights
   uses: nSpecies
 - name: getCharges
+  uses: nElements
 - name: getElementName
   implements: Phase::elementName(int)
 - name: getSpeciesName

--- a/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctthermo_auto.yaml
@@ -14,7 +14,7 @@ recipes:
 - name: name  # previously: getName
 - name: setName
 - name: getEosType
-  implements: Phase::type
+  implements: type
 - name: nElements
 - name: nSpecies
 - name: temperature
@@ -26,9 +26,9 @@ recipes:
 - name: molarDensity
 - name: meanMolecularWeight
 - name: moleFraction
-  implements: Phase::moleFraction(size_t)
+  implements: moleFraction(size_t)
 - name: massFraction
-  implements: Phase::massFraction(size_t)
+  implements: massFraction(size_t)
 - name: getMoleFractions
   uses: nSpecies
 - name: getMassFractions
@@ -38,20 +38,19 @@ recipes:
 - name: setMassFractions
   uses: nSpecies
 - name: setMoleFractionsByName
-  implements: Phase::setMoleFractionsByName(const string&)
+  implements: setMoleFractionsByName(const string&)
 - name: setMassFractionsByName
-  implements: Phase::setMassFractionsByName(const string&)
-- name: getAtomicWeights
-  implements: Phase::atomicWeights
+  implements: setMassFractionsByName(const string&)
+- name: atomicWeights  # previously: getAtomicWeights
   uses: nElements
 - name: getMolecularWeights
   uses: nSpecies
 - name: getCharges
   uses: nElements
-- name: getElementName
-  implements: Phase::elementName(int)
-- name: getSpeciesName
-  implements: Phase::speciesName(int)
+- name: elementName  # previously: getElementName
+  implements: elementName(int)
+- name: speciesName  # previously: getSpeciesName
+  implements: speciesName(int)
 - name: elementIndex
 - name: speciesIndex
 - name: nAtoms
@@ -72,9 +71,9 @@ recipes:
 - name: cv_mole
 - name: cv_mass
 - name: chemPotentials
-  implements: ThermoPhase::getChemPotentials
+  implements: getChemPotentials
 - name: electroChemPotentials
-  implements: ThermoPhase::getElectrochemPotentials
+  implements: getElectrochemPotentials
 - name: electricPotential
 - name: setElectricPotential
 - name: thermalExpansionCoeff
@@ -85,37 +84,37 @@ recipes:
 - name: getPartialMolarCp
 - name: getPartialMolarVolumes
 - name: setState_TPX  # new
-  implements: ThermoPhase::setState_TPX(double, double, const double*)
+  implements: setState_TPX(double, double, const double*)
 - name: setState_TPY  # new
-  implements: ThermoPhase::setState_TPY(double, double, const double*)
+  implements: setState_TPY(double, double, const double*)
 - name: setState_TP  # previously: set_TP
-  implements: ThermoPhase::setState_TP(double, double)
+  implements: setState_TP(double, double)
 - name: setState_TD  # previously: set_TD
-  implements: Phase::setState_TD(double, double)
+  implements: setState_TD(double, double)
 - name: setState_DP  # previously: set_DP
-  implements: ThermoPhase::setState_DP(double, double)
+  implements: setState_DP(double, double)
 - name: setState_HP  # previously: set_HP
-  implements: ThermoPhase::setState_HP(double, double)
+  implements: setState_HP(double, double)
 - name: setState_UV  # previously: set_UV
-  implements: ThermoPhase::setState_UV(double, double)
+  implements: setState_UV(double, double)
 - name: setState_SV  # previously: set_SV
-  implements: ThermoPhase::setState_SV(double, double)
+  implements: setState_SV(double, double)
 - name: setState_SP  # previously: set_SP
-  implements: ThermoPhase::setState_SP(double, double)
+  implements: setState_SP(double, double)
 - name: setState_ST  # previously: set_ST
-  implements: ThermoPhase::setState_ST(double, double)
+  implements: setState_ST(double, double)
 - name: setState_TV  # previously: set_TV
-  implements: ThermoPhase::setState_TV(double, double)
+  implements: setState_TV(double, double)
 - name: setState_PV  # previously: set_PV
-  implements: ThermoPhase::setState_PV(double, double)
+  implements: setState_PV(double, double)
 - name: setState_UP  # previously: set_UP
-  implements: ThermoPhase::setState_UP(double, double)
+  implements: setState_UP(double, double)
 - name: setState_VH  # previously: set_VH
-  implements: ThermoPhase::setState_VH(double, double)
+  implements: setState_VH(double, double)
 - name: setState_TH  # previously: set_TH
-  implements: ThermoPhase::setState_TH(double, double)
+  implements: setState_TH(double, double)
 - name: setState_SH  # previously: set_SH
-  implements: ThermoPhase::setState_SH(double, double)
+  implements: setState_SH(double, double)
 - name: equilibrate
   implements:
     ThermoPhase::equilibrate(const string&, const string&, double, int, int, int)
@@ -134,7 +133,7 @@ recipes:
 - name: siteDensity  # previously: used 'surf' prefix'
 - name: setSiteDensity  # previously: used 'surf' prefix'
 - name: setCoveragesByName  # previously: used 'surf' prefix'
-  implements: SurfPhase::setCoveragesByName(const string&)
+  implements: setCoveragesByName(const string&)
 - name: del
   what: noop
   brief: Destructor; required by some APIs although object is managed by Solution.

--- a/interfaces/sourcegen/sourcegen/_data/cttrans_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/cttrans_auto.yaml
@@ -15,7 +15,8 @@ recipes:
 - name: electricalConductivity
 - name: getThermalDiffCoeffs
 - name: getMixDiffCoeffs
-- name: getBinaryDiffCoeffs  # previously: getBinDiffCoeffs
+- name: getBinDiffCoeffs
+  implements: getBinaryDiffCoeffs  # inconsistent API (preexisting)
 - name: getMultiDiffCoeffs
 - name: getMolarFluxes
 - name: getMassFluxes

--- a/interfaces/sourcegen/sourcegen/_data/cttrans_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/cttrans_auto.yaml
@@ -12,7 +12,13 @@ recipes:
 - name: transportModel
 - name: viscosity
 - name: thermalConductivity
+- name: electricalConductivity
+- name: getThermalDiffCoeffs
 - name: getMixDiffCoeffs
+- name: getBinaryDiffCoeffs  # previously: getBinDiffCoeffs
+- name: getMultiDiffCoeffs
+- name: getMolarFluxes
+- name: getMassFluxes
 - name: del
   what: noop
   brief: Destructor; required by some APIs although object is managed by Solution.

--- a/interfaces/sourcegen/sourcegen/_orchestrate.py
+++ b/interfaces/sourcegen/sourcegen/_orchestrate.py
@@ -9,7 +9,6 @@ import sys
 
 from ._HeaderFileParser import HeaderFileParser
 from ._SourceGenerator import SourceGenerator
-from .clib import CLibSourceGenerator
 from ._helpers import read_config
 
 
@@ -45,22 +44,12 @@ def generate_source(lang: str, out_dir: str, verbose: bool = False) -> None:
     msg = f"Starting sourcegen for {lang!r} API"
     _LOGGER.info(msg)
 
-    if lang == "clib":
-        # prepare for generation of CLib headers in main processing step
-        files = HeaderFileParser.headers_from_yaml(ignore_files, ignore_funcs)
-    elif lang == "csharp":
+    if lang == "csharp":
         # csharp parses existing (traditional) CLib header files
         files = HeaderFileParser.headers_from_h(ignore_files, ignore_funcs)
     else:
-        # generate CLib headers from YAML specifications as a preprocessing step
+        # generate CLib headers from YAML specifications
         files = HeaderFileParser.headers_from_yaml(ignore_files, ignore_funcs)
-        clib_root = Path(__file__).parent / "clib"
-        clib_config = read_config(clib_root / "config.yaml")
-        clib_templates = read_config(clib_root / "templates.yaml")
-        for key in ["ignore_files", "ignore_funcs"]:
-            clib_config.pop(key)
-        clib_scaffolder = CLibSourceGenerator(None, clib_config, clib_templates)
-        clib_scaffolder.resolve_tags(files)
 
     # find and instantiate the language-specific SourceGenerator
     msg = f"Generating {lang!r} source files..."

--- a/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
+++ b/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
@@ -297,8 +297,9 @@ class CLibSourceGenerator(SourceGenerator):
 
         ret = {
             "handle": handle, "lines": lines, "buffer": buffer, "uses": uses,
-            "cxx_base": base, "cxx_name": cxx_func.name, "cxx_args": args,
-            "cxx_implements": cxx_func.short_declaration(), "error": error,
+            "base": base, "error": error,
+            "cxx_base": cxx_func.base, "cxx_name": cxx_func.name, "cxx_args": args,
+            "cxx_implements": cxx_func.short_declaration(),
             "c_func": c_func.name, "c_args": [arg.name for arg in c_func.arglist],
         }
         return ret, bases

--- a/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
+++ b/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
@@ -277,8 +277,15 @@ class CLibSourceGenerator(SourceGenerator):
             cxx_ix += 1
 
         # Obtain class and getter for managed objects
-        uses = [(shared_object(uu.ret_type), uu.name) for uu in c_func.uses]
-        bases |= {uu[0] for uu in uses if uu[0]}
+        shared = []
+        checks = []
+        for uu in c_func.uses:
+            obj = shared_object(uu.ret_type)
+            if obj:
+                shared.append((obj, uu.name))
+                bases |= {obj}
+            else:
+                checks.append(uu.name)
 
         # Ensure that all error codes are set correctly
         error = [-1, "ERR"]
@@ -299,8 +306,8 @@ class CLibSourceGenerator(SourceGenerator):
             buffer = ["", "", "0"]
 
         ret = {
-            "handle": handle, "lines": lines, "buffer": buffer, "uses": uses,
-            "base": base, "error": error,
+            "base": base, "handle": handle, "lines": lines, "buffer": buffer,
+            "shared": shared, "checks": checks, "error": error,
             "cxx_base": cxx_func.base, "cxx_name": cxx_func.name, "cxx_args": args,
             "cxx_implements": cxx_func.short_declaration(),
             "c_func": c_func.name, "c_args": [arg.name for arg in c_func.arglist],

--- a/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
+++ b/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
@@ -425,6 +425,10 @@ class CLibSourceGenerator(SourceGenerator):
         if recipe.implements:
             msg = f"   generating {func_name!r} -> {recipe.implements}"
             _LOGGER.debug(msg)
+            parts = list(recipe.implements.partition("("))
+            if not self._doxygen_tags.exists(parts[0]):
+                parts[0] = self._doxygen_tags.detect(parts[0], bases, False)
+                recipe.implements = "".join(parts)
             cxx_func = self._doxygen_tags.cxx_func(recipe.implements)
 
             # Convert C++ return type to format suitable for crosswalk:

--- a/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
+++ b/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
@@ -90,8 +90,8 @@ class CLibSourceGenerator(SourceGenerator):
             if ret_type == "char*":
                 # string expressions require special handling
                 returns = Param(
-                    "int", "", "Actual length of string including \\0 "
-                    "or -1 for exception handling.")
+                    "int", "", "Actual length of string including string-terminating "
+                    "null byte, \\0, or -1 for exception handling.")
                 buffer = [
                     Param("int", "bufLen", "Length of reserved array.", "in"),
                     Param(ret_type, "buf", "Returned string value.", "out")]

--- a/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
+++ b/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
@@ -336,6 +336,9 @@ class CLibSourceGenerator(SourceGenerator):
         elif recipe.what == "constructor":
             template = loader.from_string(self._templates["clib-constructor"])
 
+        elif recipe.what == "accessor":
+            template = loader.from_string(self._templates["clib-accessor"])
+
         elif recipe.what == "destructor":
             template = loader.from_string(self._templates["clib-destructor"])
 

--- a/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
+++ b/interfaces/sourcegen/sourcegen/clib/_CLibSourceGenerator.py
@@ -317,7 +317,8 @@ class CLibSourceGenerator(SourceGenerator):
 
     def _scaffold_body(self, c_func: CFunc, recipe: Recipe) -> tuple[str, set[str]]:
         """Scaffold body of generic CLib function via Jinja."""
-        loader = Environment(loader=BaseLoader, trim_blocks=True, lstrip_blocks=True)
+        loader = Environment(loader=BaseLoader, trim_blocks=True, lstrip_blocks=True,
+                             line_comment_prefix="##")
         args, bases = self._reverse_crosswalk(c_func, recipe.base)
         args["what"] = recipe.what
 
@@ -364,7 +365,11 @@ class CLibSourceGenerator(SourceGenerator):
             _LOGGER.critical(msg)
             exit(1)
 
-        return template.render(**args), bases
+        body = template.render(**args)
+        # remove blank lines left by line comments
+        # see https://github.com/pallets/jinja/issues/204
+        body = "\n".join(line for line in body.split("\n") if line.strip())
+        return body, bases
 
     def _resolve_recipe(self, recipe: Recipe) -> CFunc:
         """Build CLib header from recipe and doxygen annotations."""

--- a/interfaces/sourcegen/sourcegen/clib/_Config.py
+++ b/interfaces/sourcegen/sourcegen/clib/_Config.py
@@ -27,6 +27,7 @@ class Config:
         "bool": "int",
         "int": "int",
         "size_t": "int",
+        "const size_t": "int",
         "double": "double",
         "const double": "double",
         "double*": "double*",

--- a/interfaces/sourcegen/sourcegen/clib/_Config.py
+++ b/interfaces/sourcegen/sourcegen/clib/_Config.py
@@ -19,8 +19,10 @@ class Config:
         "double": "double",
         "shared_ptr<T>": "int",
         "string": "char*",
+        "const string": "char*",
         "vector<double>": "double[]",
         "vector<int>": "int[]",
+        "const vector<double>&": "double[]",
     }
 
     prop_type_crosswalk = {
@@ -31,6 +33,7 @@ class Config:
         "const double": "double",
         "double*": "double*",
         "double* const": "double*",
+        "const double*": "const double*",
         "const double* const": "const double*",
         "const string&": "const char*",
         "shared_ptr<T>": "int",

--- a/interfaces/sourcegen/sourcegen/clib/_Config.py
+++ b/interfaces/sourcegen/sourcegen/clib/_Config.py
@@ -20,9 +20,7 @@ class Config:
         "shared_ptr<T>": "int",
         "string": "char*",
         "const string": "char*",
-        "vector<double>": "double[]",
-        "vector<int>": "int[]",
-        "const vector<double>&": "double[]",
+        "const vector<double>&": "double*",
     }
 
     prop_type_crosswalk = {

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -3,13 +3,13 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-# Ignore these files entirely:
+# List of files to ignore entirely:
 ignore_files: []
 
-# Ignore these specific functions:
+# Dictionary of file names and list of functions to ignore.
+# Example: ctkin_auto.yaml: [phase]
 ignore_funcs:
   ct_auto.yaml: [setLogWriter, setLogCallback]
-  ctkin_auto.yaml: [phase]
 
 # Cabinets with associated includes
 includes:

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -9,6 +9,7 @@ ignore_files: []
 # Ignore these specific functions:
 ignore_funcs:
   ct_auto.yaml: [setLogWriter, setLogCallback]
+  ctkin_auto.yaml: [reaction, phase]
   ctmix_auto.yaml: [addPhase]
 
 # Cabinets with associated includes
@@ -30,5 +31,7 @@ includes:
   MultiPhase:
   - cantera/equil/MultiPhase.h
   - cantera/thermo/ThermoPhase.h
+  Reaction:
+  - cantera/kinetics/Reaction.h
   Func1:
   - cantera/numerics/Func1Factory.h

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -9,8 +9,7 @@ ignore_files: []
 # Ignore these specific functions:
 ignore_funcs:
   ct_auto.yaml: [setLogWriter, setLogCallback]
-  ctkin_auto.yaml: [reaction, phase]
-  ctmix_auto.yaml: [addPhase]
+  ctkin_auto.yaml: [phase]
 
 # Cabinets with associated includes
 includes:

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -9,6 +9,7 @@ ignore_files: []
 # Ignore these specific functions:
 ignore_funcs:
   ct_auto.yaml: [setLogWriter, setLogCallback]
+  ctmix_auto.yaml: [addPhase]
 
 # Cabinets with associated includes
 includes:
@@ -26,5 +27,8 @@ includes:
   - cantera/kinetics/InterfaceKinetics.h
   Transport:
   - cantera/transport/TransportFactory.h
+  MultiPhase:
+  - cantera/equil/MultiPhase.h
+  - cantera/thermo/ThermoPhase.h
   Func1:
   - cantera/numerics/Func1Factory.h

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -20,8 +20,10 @@ includes:
   - cantera/base/Interface.h
   ThermoPhase:
   - cantera/thermo/ThermoFactory.h
+  - cantera/thermo/SurfPhase.h
   Kinetics:
   - cantera/kinetics/KineticsFactory.h
+  - cantera/kinetics/InterfaceKinetics.h
   Transport:
   - cantera/transport/TransportFactory.h
   Func1:

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -7,8 +7,8 @@
 ignore_files: []
 
 # Ignore these specific functions:
-ignore_funcs: {}
-  # ctsol_auto.yaml: [setTransport]
+ignore_funcs:
+  ct_auto.yaml: [setLogWriter, setLogCallback]
 
 # Cabinets with associated includes
 includes:

--- a/interfaces/sourcegen/sourcegen/clib/templates.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/templates.yaml
@@ -134,43 +134,80 @@ clib-function: |-
   }
 
 clib-constructor: |-
+  ## CLib constructor template:
+  ## may either instantiate new object or expose existing C++ object to CLib
   // constructor: {{ cxx_implements }}
   try {
       {% for line in lines %}
+      ## add lines used for CLib/C++ variable crosswalk
       {{ line }}
       {% endfor %}
       {% if handle and checks %}
+      ## constructor accesses existing object and uses index checker (see: sol3_adjacent)
       if ({{ c_args[1] }} < 0 || {{ c_args[1] }} >= {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}()) {
           throw IndexError("{{ c_func }}", "", {{ c_args[1] }}, {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}() - 1);
       }
-      {% endif %}
+      {% endif %}{# handle and checks #}
       {% if shared %}
+      ## instantiated object manages associated objects (see: sol3_newSolution)
+      ## storage of associated objects requires id (handle) of new object
       {% if handle %}
-      auto obj = {{ cxx_rbase }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      ## constructor exposes existing C++ object to CLib
+      ## the accessed C++ object may have a different base
+      {% if cxx_rbase %}
+      ## method returns new object
+      auto obj = {{ cxx_base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
       int id = {{ cxx_rbase }}Cabinet::add(obj);
-      {% else %}
+      {% else %}{# not cxx_rbase #}
+      ## method modifies associated objects (see: sol3_setTransportModel)
+      auto obj = {{ cxx_base }}Cabinet::at({{ handle }});
+      {% for typ, getter in shared %}
+      ## remove associated objects
+      if (obj->{{ getter }}()) {
+          {{ typ }}Cabinet::del(
+              {{ typ }}Cabinet::index(*(obj->{{ getter }}()), handle));
+      }
+      {% endfor %}
+      obj->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {% endif %}{# cxx_rbase #}
+      {% else %}{# not handle #}
+      ## constructor creates new object
       auto obj = {{ cxx_name }}({{ ', '.join(cxx_args) }});
       int id = {{ base }}Cabinet::add(obj);
-      {% endif %}
-      // add all associated objects
+      {% endif %}{# handle #}
+      {% if cxx_rbase %}
+      ## return handle of newly created / accessed object
       {% for typ, getter in shared %}
+      ## add associated objects (see: sol3_newSolution, sol3_adjacent)
       if (obj->{{ getter }}()) {
           {{ typ }}Cabinet::add(obj->{{ getter }}(), id);
       }
       {% endfor %}
       return id;
-      {% else %}
+      {% else %}{# not cxx_rbase #}
+      ## return handle to modified associated object (see: sol3_setTransportModel)
+      {% for typ, getter in shared %}
+      ## shared should have single entry
+      return {{ typ }}Cabinet::add(obj->{{ getter }}(), handle);
+      {% endfor %}
+      {% endif %}{# cxx_rbase #}
+      {% else %}{# not shared #}
+      ## instantiated object has no associated objects; no id is needed
       {% if handle %}
+      ## constructor exposes existing C++ object to CLib
+      ## the accessed C++ object may have a different base
       return {{ cxx_rbase }}Cabinet::add({{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }}));
-      {% else %}
+      {% else %}{# not handle #}
+      ## constructor creates new object
       return {{ base }}Cabinet::add({{ cxx_name }}({{ ', '.join(cxx_args) }}));
-      {% endif %}
-      {% endif %}
+      {% endif %}{# handle #}
+      {% endif %}{# shared #}
   } catch (...) {
       return handleAllExceptions({{ error[0] }}, {{ error[1] }});
   }
 
 clib-destructor: |-
+  ## CLib destructor template
   // destructor
   try {
       {% if shared %}
@@ -192,9 +229,12 @@ clib-destructor: |-
   }
 
 clib-method: |-
+  ## CLib method template:
+  ## covers methods as well as getters and setters for scalars
   // {{ what }}: {{ cxx_implements }}
   try {
       {% for line in lines %}
+      ## add lines used for CLib/C++ variable crosswalk
       {{ line }}
       {% endfor %}
       {% if buffer %}
@@ -227,11 +267,14 @@ clib-method: |-
   }
 
 clib-array-getter: |-
+  ## CLib array getter template
   // getter: {{ cxx_implements }}
   try {
       {% if cxx_base == base %}
+      ## object can be accessed directly
       auto& obj = {{ base }}Cabinet::at({{ handle }});
       {% else %}
+      ## object needs a cast as method is defined for specialization
       auto obj = {{ base }}Cabinet::as<{{ cxx_base }}>({{ handle }});
       {% endif %}
       {% if checks %}
@@ -256,6 +299,7 @@ clib-array-getter: |-
   }
 
 clib-array-setter: |-
+  ## CLib array setter template
   // setter: {{ cxx_implements }}
   try {
       {% if cxx_base == base %}

--- a/interfaces/sourcegen/sourcegen/clib/templates.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/templates.yaml
@@ -139,7 +139,14 @@ clib-constructor: |-
       {% for line in lines %}
       {{ line }}
       {% endfor %}
-      {% if uses %}
+      {% if handle and checks %}
+      if ({{ c_args[1] }} < 0 || {{ c_args[1] }} >= {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}()) {
+          throw IndexError("{{ c_func }}", "", {{ c_args[1] }}, {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}() - 1);
+      }
+      {% else %}
+      // no size checking specified
+      {% endif %}
+      {% if shared %}
       {% if handle %}
       auto obj = {{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
       {% else %}
@@ -147,7 +154,7 @@ clib-constructor: |-
       {% endif %}
       int id = {{ base }}Cabinet::add(obj);
       // add all associated objects
-      {% for typ, getter in uses %}
+      {% for typ, getter in shared %}
       if (obj->{{ getter }}()) {
           {{ typ }}Cabinet::add(obj->{{ getter }}(), id);
       }
@@ -167,10 +174,10 @@ clib-constructor: |-
 clib-destructor: |-
   // destructor
   try {
-      {% if uses %}
+      {% if shared %}
       auto obj = {{ base }}Cabinet::at({{ handle }});
       // remove all associated objects in reversed order
-      {% for typ, getter in uses[-1::-1] %}
+      {% for typ, getter in shared[-1::-1] %}
       if (obj->{{ getter }}()) {
           int index = {{ typ }}Cabinet::index(*(obj->{{ getter }}()), {{ handle }});
           if (index >= 0) {
@@ -228,11 +235,9 @@ clib-array-getter: |-
       {% else %}
       auto obj = {{ base }}Cabinet::as<{{ cxx_base }}>({{ handle }});
       {% endif %}
-      {% if uses %}
-      if ({{ c_args[1] }} < obj->{{ uses[0][1] }}()) {
-          throw CanteraError("{{ c_func }}",
-              "Invalid output array size; expected minimum size {} but received {}.",
-              obj->{{ uses[0][1] }}(), {{ c_args[1] }});
+      {% if checks %}
+      if ({{ c_args[1] }} < obj->{{ checks[0] }}()) {
+          throw ArraySizeError("{{ c_func }}", {{ c_args[1] }}, obj->{{ checks[0] }}());
       }
       {% else %}
       // no size checking specified
@@ -259,11 +264,9 @@ clib-array-setter: |-
       {% else %}
       auto obj = {{ base }}Cabinet::as<{{ cxx_base }}>({{ handle }});
       {% endif %}
-      {% if uses %}
-      if ({{ c_args[1] }} != obj->{{ uses[0][1] }}()) {
-          throw CanteraError("{{ c_func }}",
-              "Invalid input array size; expected size {} but received {}.",
-              obj->{{ uses[0][1] }}(), {{ c_args[1] }});
+      {% if checks %}
+      if ({{ c_args[1] }} != obj->{{ checks[0] }}()) {
+          throw ArraySizeError("{{ c_func }}", {{ c_args[1] }}, obj->{{ checks[0] }}());
       }
       {% else %}
       // no size checking specified

--- a/interfaces/sourcegen/sourcegen/clib/templates.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/templates.yaml
@@ -134,30 +134,62 @@ clib-function: |-
   }
 
 clib-constructor: |-
-  ## CLib constructor template:
-  ## may either instantiate new object or expose existing C++ object to CLib
+  ## CLib constructor template: instantiates new object
   // constructor: {{ cxx_implements }}
   try {
       {% for line in lines %}
       ## add lines used for CLib/C++ variable crosswalk
       {{ line }}
       {% endfor %}
-      {% if handle and checks %}
-      ## constructor accesses existing object and uses index checker (see: sol3_adjacent)
-      if ({{ c_args[1] }} < 0 || {{ c_args[1] }} >= {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}()) {
-          throw IndexError("{{ c_func }}", "", {{ c_args[1] }}, {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}() - 1);
-      }
-      {% endif %}{# handle and checks #}
       {% if shared %}
       ## instantiated object manages associated objects (see: sol3_newSolution)
       ## storage of associated objects requires id (handle) of new object
-      {% if handle %}
-      ## constructor exposes existing C++ object to CLib
-      ## the accessed C++ object may have a different base
+      auto obj = {{ cxx_name }}({{ ', '.join(cxx_args) }});
+      int id = {{ base }}Cabinet::add(obj);
+      {% for typ, getter in shared %}
+      ## add associated objects (see: sol3_newSolution, sol3_adjacent)
+      if (obj->{{ getter }}()) {
+          {{ typ }}Cabinet::add(obj->{{ getter }}(), id);
+      }
+      {% endfor %}
+      return id;
+      {% else %}{# not shared #}
+      ## instantiated object has no associated objects; no id is needed
+      return {{ base }}Cabinet::add({{ cxx_name }}({{ ', '.join(cxx_args) }}));
+      {% endif %}{# shared #}
+  } catch (...) {
+      return handleAllExceptions({{ error[0] }}, {{ error[1] }});
+  }
+
+clib-accessor: |-
+  ## CLib accessor template: exposes existing C++ object to CLib
+  // accessor: {{ cxx_implements }}
+  try {
+      {% for line in lines %}
+      ## add lines used for CLib/C++ variable crosswalk
+      {{ line }}
+      {% endfor %}
+      {% if checks %}
+      ## accessor uses index checker (see: sol3_adjacent)
+      if ({{ c_args[1] }} < 0 || {{ c_args[1] }} >= {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}()) {
+          throw IndexError("{{ c_func }}", "", {{ c_args[1] }}, {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}() - 1);
+      }
+      {% endif %}{# checks #}
+      {% if shared %}
+      ## accessed object manages associated objects (see: sol3_newSolution)
+      ## storage of associated objects requires id (handle) of new object
       {% if cxx_rbase %}
-      ## method returns new object
+      ## returned and accessed C++ objects may have a different bases
       auto obj = {{ cxx_base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
       int id = {{ cxx_rbase }}Cabinet::add(obj);
+      ## return handle of newly created / accessed object
+      {% for typ, getter in shared %}
+      ## add associated objects (see: sol3_newSolution, sol3_adjacent)
+      if (obj->{{ getter }}()) {
+          {{ typ }}Cabinet::add(obj->{{ getter }}(), id);
+      }
+      {% endfor %}
+      return id;
       {% else %}{# not cxx_rbase #}
       ## method modifies associated objects (see: sol3_setTransportModel)
       auto obj = {{ cxx_base }}Cabinet::at({{ handle }});
@@ -169,22 +201,6 @@ clib-constructor: |-
       }
       {% endfor %}
       obj->{{ cxx_name }}({{ ', '.join(cxx_args) }});
-      {% endif %}{# cxx_rbase #}
-      {% else %}{# not handle #}
-      ## constructor creates new object
-      auto obj = {{ cxx_name }}({{ ', '.join(cxx_args) }});
-      int id = {{ base }}Cabinet::add(obj);
-      {% endif %}{# handle #}
-      {% if cxx_rbase %}
-      ## return handle of newly created / accessed object
-      {% for typ, getter in shared %}
-      ## add associated objects (see: sol3_newSolution, sol3_adjacent)
-      if (obj->{{ getter }}()) {
-          {{ typ }}Cabinet::add(obj->{{ getter }}(), id);
-      }
-      {% endfor %}
-      return id;
-      {% else %}{# not cxx_rbase #}
       ## return handle to modified associated object (see: sol3_setTransportModel)
       {% for typ, getter in shared %}
       ## shared should have single entry
@@ -193,14 +209,8 @@ clib-constructor: |-
       {% endif %}{# cxx_rbase #}
       {% else %}{# not shared #}
       ## instantiated object has no associated objects; no id is needed
-      {% if handle %}
-      ## constructor exposes existing C++ object to CLib
-      ## the accessed C++ object may have a different base
+      ## returned and accessed C++ objects may have a different bases
       return {{ cxx_rbase }}Cabinet::add({{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }}));
-      {% else %}{# not handle #}
-      ## constructor creates new object
-      return {{ base }}Cabinet::add({{ cxx_name }}({{ ', '.join(cxx_args) }}));
-      {% endif %}{# handle #}
       {% endif %}{# shared #}
   } catch (...) {
       return handleAllExceptions({{ error[0] }}, {{ error[1] }});

--- a/interfaces/sourcegen/sourcegen/clib/templates.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/templates.yaml
@@ -141,11 +141,11 @@ clib-constructor: |-
       {% endfor %}
       {% if uses %}
       {% if handle %}
-      auto obj = {{ cxx_base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      auto obj = {{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
       {% else %}
       auto obj = {{ cxx_name }}({{ ', '.join(cxx_args) }});
       {% endif %}
-      int id = {{ cxx_base }}Cabinet::add(obj);
+      int id = {{ base }}Cabinet::add(obj);
       // add all associated objects
       {% for typ, getter in uses %}
       if (obj->{{ getter }}()) {
@@ -155,9 +155,9 @@ clib-constructor: |-
       return id;
       {% else %}
       {% if handle %}
-      return {{ cxx_base }}Cabinet::add({{ cxx_base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }}));
+      return {{ base }}Cabinet::add({{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }}));
       {% else %}
-      return {{ cxx_base }}Cabinet::add({{ cxx_name }}({{ ', '.join(cxx_args) }}));
+      return {{ base }}Cabinet::add({{ cxx_name }}({{ ', '.join(cxx_args) }}));
       {% endif %}
       {% endif %}
   } catch (...) {
@@ -168,7 +168,7 @@ clib-destructor: |-
   // destructor
   try {
       {% if uses %}
-      auto obj = {{ cxx_base }}Cabinet::at({{ handle }});
+      auto obj = {{ base }}Cabinet::at({{ handle }});
       // remove all associated objects in reversed order
       {% for typ, getter in uses[-1::-1] %}
       if (obj->{{ getter }}()) {
@@ -179,7 +179,7 @@ clib-destructor: |-
       }
       {% endfor %}
       {% endif %}
-      {{ cxx_base }}Cabinet::del({{ handle }});
+      {{ base }}Cabinet::del({{ handle }});
       return 0;
   } catch (...) {
       return handleAllExceptions(-1, ERR);
@@ -193,16 +193,28 @@ clib-method: |-
       {% endfor %}
       {% if buffer %}
       {% if buffer[0] %}
-      {{ buffer[0] }} = {{ cxx_base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {% if cxx_base == base %}
+      {{ buffer[0] }} = {{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
       {% else %}
-      {{ cxx_base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {{ buffer[0] }} = {{ base }}Cabinet::as<{{ cxx_base }}>({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {% endif %}
+      {% else %}
+      {% if cxx_base == base %}
+      {{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {% else %}
+      {{ base }}Cabinet::as<{{ cxx_base }}>({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {% endif %}
       {% endif %}
       {% if buffer[1] %}
       {{ buffer[1] }}
       {% endif %}
       return {{ buffer[2] }};
       {% else %}
-      return {{ cxx_base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {% if cxx_base == base %}
+      return {{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {% else %}
+      return {{ base }}Cabinet::as<{{ cxx_base }}>({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      {% endif %}
       {% endif %}
   } catch (...) {
       return handleAllExceptions({{ error[0] }}, {{ error[1] }});
@@ -211,7 +223,11 @@ clib-method: |-
 clib-array-getter: |-
   // getter: {{ cxx_implements }}
   try {
-      auto& obj = {{ cxx_base }}Cabinet::at({{ handle }});
+      {% if cxx_base == base %}
+      auto& obj = {{ base }}Cabinet::at({{ handle }});
+      {% else %}
+      auto obj = {{ base }}Cabinet::as<{{ cxx_base }}>({{ handle }});
+      {% endif %}
       {% if uses %}
       if ({{ c_args[1] }} < obj->{{ uses[0][1] }}()) {
           throw CanteraError("{{ c_func }}",
@@ -238,7 +254,11 @@ clib-array-getter: |-
 clib-array-setter: |-
   // setter: {{ cxx_implements }}
   try {
-      auto& obj = {{ cxx_base }}Cabinet::at({{ handle }});
+      {% if cxx_base == base %}
+      auto& obj = {{ base }}Cabinet::at({{ handle }});
+      {% else %}
+      auto obj = {{ base }}Cabinet::as<{{ cxx_base }}>({{ handle }});
+      {% endif %}
       {% if uses %}
       if ({{ c_args[1] }} != obj->{{ uses[0][1] }}()) {
           throw CanteraError("{{ c_func }}",
@@ -273,17 +293,17 @@ clib-implementation: |-
   }
 
 clib-reserved-parentHandle-cpp: |-
-  // reserved: {{ cxx_base }} cabinet parent
+  // reserved: {{ base }} cabinet parent
   try {
-      return {{ cxx_base }}Cabinet::parent(handle);
+      return {{ base }}Cabinet::parent(handle);
   } catch (...) {
       return handleAllExceptions(-2, ERR);
   }
 
 clib-reserved-cabinetSize-cpp: |-
-  // reserved: int Cabinet<{{ cxx_base }}>.size()
+  // reserved: int Cabinet<{{ base }}>.size()
   try {
-      return {{ cxx_base }}Cabinet::size();
+      return {{ base }}Cabinet::size();
   } catch (...) {
       return handleAllExceptions(-1, ERR);
   }

--- a/interfaces/sourcegen/sourcegen/clib/templates.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/templates.yaml
@@ -143,16 +143,15 @@ clib-constructor: |-
       if ({{ c_args[1] }} < 0 || {{ c_args[1] }} >= {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}()) {
           throw IndexError("{{ c_func }}", "", {{ c_args[1] }}, {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}() - 1);
       }
-      {% else %}
-      // no size checking specified
       {% endif %}
       {% if shared %}
       {% if handle %}
-      auto obj = {{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      auto obj = {{ cxx_rbase }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }});
+      int id = {{ cxx_rbase }}Cabinet::add(obj);
       {% else %}
       auto obj = {{ cxx_name }}({{ ', '.join(cxx_args) }});
-      {% endif %}
       int id = {{ base }}Cabinet::add(obj);
+      {% endif %}
       // add all associated objects
       {% for typ, getter in shared %}
       if (obj->{{ getter }}()) {
@@ -162,7 +161,7 @@ clib-constructor: |-
       return id;
       {% else %}
       {% if handle %}
-      return {{ base }}Cabinet::add({{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }}));
+      return {{ cxx_rbase }}Cabinet::add({{ base }}Cabinet::at({{ handle }})->{{ cxx_name }}({{ ', '.join(cxx_args) }}));
       {% else %}
       return {{ base }}Cabinet::add({{ cxx_name }}({{ ', '.join(cxx_args) }}));
       {% endif %}

--- a/interfaces/sourcegen/sourcegen/clib/templates.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/templates.yaml
@@ -221,8 +221,16 @@ clib-array-getter: |-
       {% else %}
       // no size checking specified
       {% endif %}
+      {% if buffer and buffer[0] %}
+      {{ buffer[0] }} = obj->{{ cxx_name }}({{ cxx_args[0] }});;
+      {% if buffer[1] %}
+      {{ buffer[1] }}
+      {% endif %}
+      return {{ buffer[2] }};
+      {% else %}
       obj->{{ cxx_name }}({{ cxx_args[0] }});
       return 0;
+      {% endif %}
   } catch (...) {
       return handleAllExceptions(-1, ERR);
   }

--- a/interfaces/sourcegen/sourcegen/yaml/config.yaml
+++ b/interfaces/sourcegen/sourcegen/yaml/config.yaml
@@ -4,7 +4,8 @@
 # at https://cantera.org/license.txt for license and copyright information.
 
 # Ignore these files entirely:
-ignore_files: []
+ignore_files:
+- ctfunc_auto.yaml  # for testing purposes
 
 # Ignore these specific functions:
 ignore_funcs: {}

--- a/src/base/ctexceptions.cpp
+++ b/src/base/ctexceptions.cpp
@@ -72,6 +72,9 @@ string ArraySizeError::getMessage() const
 
 string IndexError::getMessage() const
 {
+    if (arrayName_ == "") {
+        return fmt::format("IndexError: {} outside valid range of 0 to {}.", m_, mmax_);
+    }
     return fmt::format("IndexError: {}[{}] outside valid range of 0 to {}.",
                        arrayName_, m_, mmax_);
 }

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -32,11 +32,13 @@ typedef Cabinet<ThermoPhase> ThermoCabinet;
 typedef Cabinet<Kinetics> KineticsCabinet;
 typedef Cabinet<Transport> TransportCabinet;
 typedef Cabinet<Solution> SolutionCabinet;
+typedef Cabinet<Reaction> ReactionCabinet;
 
 template<> ThermoCabinet* ThermoCabinet::s_storage = 0;
 template<> KineticsCabinet* KineticsCabinet::s_storage = 0;
 template<> TransportCabinet* TransportCabinet::s_storage = 0;
 template<> SolutionCabinet* SolutionCabinet::s_storage = 0;
+template<> ReactionCabinet* ReactionCabinet::s_storage = 0;
 
 /**
  * Exported functions.

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -43,6 +43,12 @@ void MultiPhase::addPhases(vector<ThermoPhase*>& phases,
     init();
 }
 
+void MultiPhase::addPhase(shared_ptr<ThermoPhase> p, double moles)
+{
+    addPhase(p.get(), moles);
+    m_sharedPhase.back() = p;
+}
+
 void MultiPhase::addPhase(ThermoPhase* p, double moles)
 {
     if (m_init) {
@@ -57,6 +63,7 @@ void MultiPhase::addPhase(ThermoPhase* p, double moles)
 
     // save the pointer to the phase object
     m_phase.push_back(p);
+    m_sharedPhase.push_back(nullptr);
 
     // store its number of moles
     m_moles.push_back(moles);
@@ -830,6 +837,11 @@ void MultiPhase::updatePhases() const
             m_temp_OK[p] = false;
         }
     }
+}
+
+shared_ptr<MultiPhase> newMultiPhase()
+{
+    return make_shared<MultiPhase>();
 }
 
 std::ostream& operator<<(std::ostream& s, MultiPhase& x)

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -839,11 +839,6 @@ void MultiPhase::updatePhases() const
     }
 }
 
-shared_ptr<MultiPhase> newMultiPhase()
-{
-    return make_shared<MultiPhase>();
-}
-
 std::ostream& operator<<(std::ostream& s, MultiPhase& x)
 {
     x.updatePhases();

--- a/test/clib_experimental/test_ctfunc3.cpp
+++ b/test/clib_experimental/test_ctfunc3.cpp
@@ -12,19 +12,19 @@ using namespace Cantera;
 TEST(ctfunc3, invalid)
 {
     // exceptions return -1
-    ASSERT_EQ(func13_newBasic("spam", 0.), -2);
-    ASSERT_EQ(func13_newAdvanced("eggs", 0, NULL), -2);
+    ASSERT_EQ(func13_new_basic("spam", 0.), -2);
+    ASSERT_EQ(func13_new_advanced("eggs", 0, NULL), -2);
 }
 
 TEST(ctfunc3, sin)
 {
     double omega = 2.1;
-    int fcn = func13_newBasic("sin", omega);
+    int fcn = func13_new_basic("sin", omega);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), sin(omega * 0.5));
 
     int dfcn = func13_derivative(fcn);
-    EXPECT_DOUBLE_EQ(func13_eval(dfcn, 0.5), omega * cos(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(dfcn, 0.5), omega * cos(omega * 0.5));
 
     int buflen = func13_write(fcn, "x", 0, 0);
     vector<char> buf(buflen);
@@ -36,77 +36,77 @@ TEST(ctfunc3, sin)
 TEST(ctfunc3, cos)
 {
     double omega = 2.;
-    int fcn = func13_newBasic("cos", omega);
+    int fcn = func13_new_basic("cos", omega);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), cos(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), cos(omega * 0.5));
 
     int dfcn = func13_derivative(fcn);
-    EXPECT_DOUBLE_EQ(func13_eval(dfcn, 0.5), -omega * sin(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(dfcn, 0.5), -omega * sin(omega * 0.5));
 }
 
 TEST(ctfunc3, exp)
 {
     double omega = 2.;
-    int fcn = func13_newBasic("exp", omega);
+    int fcn = func13_new_basic("exp", omega);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), exp(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), exp(omega * 0.5));
 
     int dfcn = func13_derivative(fcn);
-    EXPECT_DOUBLE_EQ(func13_eval(dfcn, 0.5), omega * exp(omega * 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(dfcn, 0.5), omega * exp(omega * 0.5));
 }
 
 TEST(ctfunc3, log)
 {
     double omega = 2.;
-    int fcn = func13_newBasic("log", omega);
+    int fcn = func13_new_basic("log", omega);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 1. / omega), 0.);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 1. / omega), 0.);
 
     int dfcn = func13_derivative(fcn);
-    EXPECT_DOUBLE_EQ(func13_eval(dfcn, .5), omega / .5);
+    EXPECT_DOUBLE_EQ(func13_value(dfcn, .5), omega / .5);
 }
 
 TEST(ctfunc3, pow)
 {
     double exp = .5;
-    int fcn = func13_newBasic("pow", exp);
+    int fcn = func13_new_basic("pow", exp);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), pow(0.5, exp));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), pow(0.5, exp));
 
     int dfcn = func13_derivative(fcn);
-    EXPECT_DOUBLE_EQ(func13_eval(dfcn, 0.5), exp * pow(0.5, exp - 1));
+    EXPECT_DOUBLE_EQ(func13_value(dfcn, 0.5), exp * pow(0.5, exp - 1));
 }
 
 TEST(ctfunc3, constant)
 {
     double a = .5;
-    int fcn = func13_newBasic("constant", a);
+    int fcn = func13_new_basic("constant", a);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), a);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), a);
 
     int dfcn = func13_derivative(fcn);
-    EXPECT_DOUBLE_EQ(func13_eval(dfcn, .5), 0.);
+    EXPECT_DOUBLE_EQ(func13_value(dfcn, .5), 0.);
 }
 
 TEST(ctfunc3, tabulated_linear)
 {
     vector<double> params = {0., 1., 2., 1., 0., 1.};
 
-    int fcn = func13_newAdvanced("tabulated-linear", params.size(), params.data());
+    int fcn = func13_new_advanced("tabulated-linear", params.size(), params.data());
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), 0.5);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), 0.5);
 
     // exceptions return -1
-    EXPECT_EQ(func13_newAdvanced("tabulated-linear", 5, params.data()), -2);
+    EXPECT_EQ(func13_new_advanced("tabulated-linear", 5, params.data()), -2);
 }
 
 TEST(ctfunc3, tabulated_previous)
 {
     vector<double> params = {0., 1., 2., 1., 0., 1.};
 
-    int fcn = func13_newAdvanced("tabulated-previous", params.size(), params.data());
+    int fcn = func13_new_advanced("tabulated-previous", params.size(), params.data());
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), 1.);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), 1.);
 }
 
 TEST(ctfunc3, poly)
@@ -115,12 +115,12 @@ TEST(ctfunc3, poly)
     double a1 = .25;
     double a2 = .125;
     vector<double> params = {a2, a1, a0};
-    int fcn = func13_newAdvanced("polynomial3", params.size(), params.data());
+    int fcn = func13_new_advanced("polynomial3", params.size(), params.data());
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, .5), (a2 * .5 + a1) * .5 + a0);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, .5), (a2 * .5 + a1) * .5 + a0);
 
     params = {1, 0, -2.2, 3.1};
-    fcn = func13_newAdvanced("polynomial3", params.size(), params.data());
+    fcn = func13_new_advanced("polynomial3", params.size(), params.data());
     int buflen = func13_write(fcn, "x", 0, 0);
     vector<char> buf(buflen);
     func13_write(fcn, "x", buflen, buf.data());
@@ -135,10 +135,10 @@ TEST(ctfunc3, Fourier)
     double b1 = .125;
     double omega = 2.;
     vector<double> params = {a0, a1, omega, b1};
-    int fcn = func13_newAdvanced("Fourier", params.size(), params.data());
+    int fcn = func13_new_advanced("Fourier", params.size(), params.data());
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(
-        func13_eval(fcn, .5), .5 * a0 + a1 * cos(omega * .5) + b1 * sin(omega * .5));
+        func13_value(fcn, .5), .5 * a0 + a1 * cos(omega * .5) + b1 * sin(omega * .5));
 }
 
 TEST(ctfunc3, Gaussian)
@@ -147,14 +147,14 @@ TEST(ctfunc3, Gaussian)
     double t0 = .6;
     double fwhm = .25;
     vector<double> params = {A, t0, fwhm};
-    int fcn = func13_newAdvanced("Gaussian", params.size(), params.data());
+    int fcn = func13_new_advanced("Gaussian", params.size(), params.data());
     ASSERT_GE(fcn, 0);
     double tau = fwhm / (2. * sqrt(log(2.)));
     double x = - t0 / tau;
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.), A * exp(-x * x));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.), A * exp(-x * x));
 
     // exceptions return -1
-    EXPECT_EQ(func13_newAdvanced("Gaussian", 2, params.data()), -2);
+    EXPECT_EQ(func13_new_advanced("Gaussian", 2, params.data()), -2);
 }
 
 TEST(ctfunc3, Arrhenius)
@@ -163,106 +163,106 @@ TEST(ctfunc3, Arrhenius)
     double b = 2.7;
     double E = 2.619184e+07 / GasConstant;
     vector<double> params = {A, b, E};
-    int fcn = func13_newAdvanced("Arrhenius", params.size(), params.data());
+    int fcn = func13_new_advanced("Arrhenius", params.size(), params.data());
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 1000.), A * pow(1000., b) * exp(-E/1000.));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 1000.), A * pow(1000., b) * exp(-E/1000.));
 }
 
 TEST(ctmath, invalid)
 {
     // exceptions return -1
-    int fcn0 = func13_newBasic("sin", 1.);
-    int fcn1 = func13_newBasic("cos", 1.);
-    ASSERT_EQ(func13_newCompound("foo", fcn0, fcn1), -2);
-    ASSERT_EQ(func13_newModified("bar", fcn0, 0.), -2);
+    int fcn0 = func13_new_basic("sin", 1.);
+    int fcn1 = func13_new_basic("cos", 1.);
+    ASSERT_EQ(func13_new_compound("foo", fcn0, fcn1), -2);
+    ASSERT_EQ(func13_new_modified("bar", fcn0, 0.), -2);
 }
 
 TEST(ctmath, sum)
 {
     double omega = 2.;
-    int fcn0 = func13_newBasic("sin", omega);
-    int fcn1 = func13_newBasic("cos", omega);
-    int fcn = func13_newCompound("sum", fcn0, fcn1);
+    int fcn0 = func13_new_basic("sin", omega);
+    int fcn1 = func13_new_basic("cos", omega);
+    int fcn = func13_new_compound("sum", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * 0.5) + cos(omega * 0.5));
-    int fcn2 = func13_newSum(fcn0, fcn1);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), func13_eval(fcn2, 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), sin(omega * 0.5) + cos(omega * 0.5));
+    int fcn2 = func13_new_sum(fcn0, fcn1);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), func13_value(fcn2, 0.5));
 }
 
 TEST(ctmath, diff)
 {
     double omega = 2.;
-    int fcn0 = func13_newBasic("sin", omega);
-    int fcn1 = func13_newBasic("cos", omega);
-    int fcn = func13_newCompound("diff", fcn0, fcn1);
+    int fcn0 = func13_new_basic("sin", omega);
+    int fcn1 = func13_new_basic("cos", omega);
+    int fcn = func13_new_compound("diff", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * 0.5) - cos(omega * 0.5));
-    int fcn2 = func13_newDiff(fcn0, fcn1);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), func13_eval(fcn2, 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), sin(omega * 0.5) - cos(omega * 0.5));
+    int fcn2 = func13_new_diff(fcn0, fcn1);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), func13_value(fcn2, 0.5));
 }
 
 TEST(ctmath, prod)
 {
     double omega = 2.;
-    int fcn0 = func13_newBasic("sin", omega);
-    int fcn1 = func13_newBasic("cos", omega);
-    int fcn = func13_newCompound("product", fcn0, fcn1);
+    int fcn0 = func13_new_basic("sin", omega);
+    int fcn1 = func13_new_basic("cos", omega);
+    int fcn = func13_new_compound("product", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * 0.5) * cos(omega * 0.5));
-    int fcn2 = func13_newProd(fcn0, fcn1);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), func13_eval(fcn2, 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), sin(omega * 0.5) * cos(omega * 0.5));
+    int fcn2 = func13_new_prod(fcn0, fcn1);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), func13_value(fcn2, 0.5));
 }
 
 TEST(ctmath, ratio)
 {
     double omega = 2.;
-    int fcn0 = func13_newBasic("sin", omega);
-    int fcn1 = func13_newBasic("cos", omega);
-    int fcn = func13_newCompound("ratio", fcn0, fcn1);
+    int fcn0 = func13_new_basic("sin", omega);
+    int fcn1 = func13_new_basic("cos", omega);
+    int fcn = func13_new_compound("ratio", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * 0.5) / cos(omega * 0.5));
-    int fcn2 = func13_newRatio(fcn0, fcn1);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), func13_eval(fcn2, 0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), sin(omega * 0.5) / cos(omega * 0.5));
+    int fcn2 = func13_new_ratio(fcn0, fcn1);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), func13_value(fcn2, 0.5));
 }
 
 TEST(ctmath, composite)
 {
     double omega = 2.;
-    int fcn0 = func13_newBasic("sin", omega);
-    int fcn1 = func13_newBasic("cos", omega);
-    int fcn = func13_newCompound("composite", fcn0, fcn1);
+    int fcn0 = func13_new_basic("sin", omega);
+    int fcn1 = func13_new_basic("cos", omega);
+    int fcn = func13_new_compound("composite", fcn0, fcn1);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * cos(omega * 0.5)));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), sin(omega * cos(omega * 0.5)));
 }
 
 TEST(ctmath, times_constant)
 {
     double omega = 2.;
-    int fcn0 = func13_newBasic("sin", omega);
+    int fcn0 = func13_new_basic("sin", omega);
     double A = 1.234;
-    int fcn = func13_newModified("times-constant", fcn0, A);
+    int fcn = func13_new_modified("times-constant", fcn0, A);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * 0.5) * A);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), sin(omega * 0.5) * A);
 }
 
 TEST(ctmath, plus_constant)
 {
     double omega = 2.;
-    int fcn0 = func13_newBasic("sin", omega);
+    int fcn0 = func13_new_basic("sin", omega);
     double A = 1.234;
-    int fcn = func13_newModified("plus-constant", fcn0, A);
+    int fcn = func13_new_modified("plus-constant", fcn0, A);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * 0.5) + A);
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), sin(omega * 0.5) + A);
 }
 
 TEST(ctmath, periodic)
 {
     double omega = 2.;
-    int fcn0 = func13_newBasic("sin", omega);
+    int fcn0 = func13_new_basic("sin", omega);
     double A = 1.234;
-    int fcn = func13_newModified("periodic", fcn0, A);
+    int fcn = func13_new_modified("periodic", fcn0, A);
     ASSERT_GE(fcn, 0);
-    EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), func13_eval(fcn, 0.5 + A));
+    EXPECT_DOUBLE_EQ(func13_value(fcn, 0.5), func13_value(fcn, 0.5 + A));
 }
 
 TEST(ctmath, generic)
@@ -270,36 +270,36 @@ TEST(ctmath, generic)
     // Composite function reported in issue #752
 
     vector<double> params = {0., 0., 1., 1.};
-    int fs = func13_newAdvanced("Fourier", params.size(), params.data()); // sin(x)
+    int fs = func13_new_advanced("Fourier", params.size(), params.data()); // sin(x)
     auto func13_s = newFunc1("sin", 1.);
-    EXPECT_DOUBLE_EQ(func13_eval(fs, 0.5), func13_s->eval(0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fs, 0.5), func13_s->eval(0.5));
 
-    int fs2 = func13_newCompound("product", fs, fs);  // (sin(x)^2)
+    int fs2 = func13_new_compound("product", fs, fs);  // (sin(x)^2)
     auto func13_s2 = newFunc1("product", func13_s, func13_s);
-    EXPECT_DOUBLE_EQ(func13_eval(fs2, 0.5), func13_s2->eval(0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fs2, 0.5), func13_s2->eval(0.5));
 
     double one = 1.;
-    int fs1 = func13_newAdvanced("polynomial3", 1, &one); // 1.
+    int fs1 = func13_new_advanced("polynomial3", 1, &one); // 1.
     auto func13_s1 = newFunc1("constant", 1.);
-    EXPECT_DOUBLE_EQ(func13_eval(fs1, 0.5), func13_s1->eval(0.5));
-    EXPECT_DOUBLE_EQ(func13_eval(fs1, 0.5), 1.);
+    EXPECT_DOUBLE_EQ(func13_value(fs1, 0.5), func13_s1->eval(0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fs1, 0.5), 1.);
 
-    int fs2_1 = func13_newCompound("diff", fs1, fs2);  // 1-(sin(x))^2
+    int fs2_1 = func13_new_compound("diff", fs1, fs2);  // 1-(sin(x))^2
     auto func13_s2_1 = newFunc1("diff", func13_s1, func13_s2);
-    EXPECT_DOUBLE_EQ(func13_eval(fs2_1, 0.5), func13_s2_1->eval(0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fs2_1, 0.5), func13_s2_1->eval(0.5));
 
     vector<double> p_arr = {1., .5, 0.};
-    int fs3 = func13_newAdvanced("Arrhenius", 3, p_arr.data());  // sqrt function
+    int fs3 = func13_new_advanced("Arrhenius", 3, p_arr.data());  // sqrt function
     auto func13_s3 = newFunc1("Arrhenius", p_arr);
-    EXPECT_DOUBLE_EQ(func13_eval(fs3, 0.5), func13_s3->eval(0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fs3, 0.5), func13_s3->eval(0.5));
 
     // overall composite function
-    int fs4 = func13_newCompound("composite", fs3, fs2_1);  // sqrt(1-(sin(x))^2)
+    int fs4 = func13_new_compound("composite", fs3, fs2_1);  // sqrt(1-(sin(x))^2)
     auto func13_s4 = newFunc1("composite", func13_s3, func13_s2_1);
-    EXPECT_DOUBLE_EQ(func13_eval(fs4, 0.5), func13_s4->eval(0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fs4, 0.5), func13_s4->eval(0.5));
 
     // an easier equivalent expression (using trigonometry)
     auto func13_s5 = newFunc1("cos", 1.);  // missing the absolute value
-    EXPECT_DOUBLE_EQ(func13_eval(fs4, 0.5), func13_s5->eval(0.5));
-    EXPECT_DOUBLE_EQ(func13_eval(fs4, 3.5), -func13_s5->eval(3.5));
+    EXPECT_DOUBLE_EQ(func13_value(fs4, 0.5), func13_s5->eval(0.5));
+    EXPECT_DOUBLE_EQ(func13_value(fs4, 3.5), -func13_s5->eval(3.5));
 }

--- a/test/clib_experimental/test_ctfunc3.cpp
+++ b/test/clib_experimental/test_ctfunc3.cpp
@@ -23,7 +23,7 @@ TEST(ctfunc3, sin)
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), sin(omega * 0.5));
 
-    int dfcn = func13_newDerivative(fcn);
+    int dfcn = func13_derivative(fcn);
     EXPECT_DOUBLE_EQ(func13_eval(dfcn, 0.5), omega * cos(omega * 0.5));
 
     int buflen = func13_write(fcn, "x", 0, 0);
@@ -40,7 +40,7 @@ TEST(ctfunc3, cos)
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), cos(omega * 0.5));
 
-    int dfcn = func13_newDerivative(fcn);
+    int dfcn = func13_derivative(fcn);
     EXPECT_DOUBLE_EQ(func13_eval(dfcn, 0.5), -omega * sin(omega * 0.5));
 }
 
@@ -51,7 +51,7 @@ TEST(ctfunc3, exp)
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), exp(omega * 0.5));
 
-    int dfcn = func13_newDerivative(fcn);
+    int dfcn = func13_derivative(fcn);
     EXPECT_DOUBLE_EQ(func13_eval(dfcn, 0.5), omega * exp(omega * 0.5));
 }
 
@@ -62,7 +62,7 @@ TEST(ctfunc3, log)
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func13_eval(fcn, 1. / omega), 0.);
 
-    int dfcn = func13_newDerivative(fcn);
+    int dfcn = func13_derivative(fcn);
     EXPECT_DOUBLE_EQ(func13_eval(dfcn, .5), omega / .5);
 }
 
@@ -73,7 +73,7 @@ TEST(ctfunc3, pow)
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), pow(0.5, exp));
 
-    int dfcn = func13_newDerivative(fcn);
+    int dfcn = func13_derivative(fcn);
     EXPECT_DOUBLE_EQ(func13_eval(dfcn, 0.5), exp * pow(0.5, exp - 1));
 }
 
@@ -84,7 +84,7 @@ TEST(ctfunc3, constant)
     ASSERT_GE(fcn, 0);
     EXPECT_DOUBLE_EQ(func13_eval(fcn, 0.5), a);
 
-    int dfcn = func13_newDerivative(fcn);
+    int dfcn = func13_derivative(fcn);
     EXPECT_DOUBLE_EQ(func13_eval(dfcn, .5), 0.);
 }
 

--- a/test/clib_experimental/test_ctkin3.cpp
+++ b/test/clib_experimental/test_ctkin3.cpp
@@ -1,0 +1,86 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <fstream>
+
+#include "cantera/core.h"
+#include "cantera/kinetics/Reaction.h"
+#include "cantera/clib/clib_defs.h"
+#include "cantera/clib_experimental/ct3.h"
+#include "cantera/clib_experimental/ctsol3.h"
+#include "cantera/clib_experimental/ctthermo3.h"
+#include "cantera/clib_experimental/ctkin3.h"
+#include "cantera/clib_experimental/ctrxn3.h"
+
+using namespace Cantera;
+using ::testing::HasSubstr;
+
+string reportError();  // forward declaration
+
+
+TEST(ctkin3, kinetics)
+{
+    int sol0 = sol3_newSolution("gri30.yaml", "gri30", "none");
+    int thermo = sol3_thermo(sol0);
+    int kin = sol3_kinetics(sol0);
+    ASSERT_GE(kin, 0);
+
+    size_t nr = kin3_nReactions(kin);
+    ASSERT_EQ(nr, 325u);
+
+    thermo3_equilibrate(thermo, "HP", "auto", 1e-9, 50000, 1000, 0);
+    double T = thermo3_temperature(thermo);
+    thermo3_setTemperature(thermo, T - 200);
+
+    auto sol = newSolution("gri30.yaml", "gri30", "none");
+    auto phase = sol->thermo();
+    auto kinetics = sol->kinetics();
+
+    phase->equilibrate("HP");
+    ASSERT_NEAR(T, phase->temperature(), 1e-2);
+    phase->setTemperature(T - 200);
+
+    vector<double> c_ropf(nr);
+    kin3_getFwdRatesOfProgress(kin, 325, c_ropf.data());
+    vector<double> cpp_ropf(nr);
+    kinetics->getFwdRatesOfProgress(cpp_ropf.data());
+
+    for (size_t n = 0; n < nr; n++) {
+        ASSERT_NEAR(cpp_ropf[n], c_ropf[n], 1e-6);
+    }
+}
+
+TEST(ctkin3, exceptions)
+{
+    int sol0 = sol3_newSolution("h2o2.yaml", "", "none");
+    int kin = sol3_kinetics(sol0);
+
+    kin3_reaction(kin, 998);
+    string err = reportError();
+    EXPECT_THAT(err, HasSubstr("IndexError: 998 outside valid range of 0 to 28."));
+}
+
+TEST(ctkin3, reaction)
+{
+    int sol0 = sol3_newSolution("h2o2.yaml", "", "none");
+    int kin = sol3_kinetics(sol0);
+    int rxn = kin3_reaction(kin, 0);
+
+    auto sol = newSolution("h2o2.yaml", "", "none");
+    auto kinetics = sol->kinetics();
+    auto reaction = kinetics->reaction(0);
+
+    int buflen = rxn3_type(rxn, 0, 0);
+    vector<char> buf(buflen);
+    rxn3_type(rxn, buflen, buf.data());
+    string rxnType = buf.data();
+    ASSERT_EQ(rxnType, reaction->type());
+    ASSERT_EQ(rxnType, "three-body-Arrhenius");
+
+    buflen = rxn3_equation(rxn, 0, 0);
+    buf.resize(buflen);
+    rxn3_equation(rxn, buflen, buf.data());
+    string rxnEqn = buf.data();
+    ASSERT_EQ(rxnEqn, reaction->equation());
+    ASSERT_EQ(rxnEqn, "2 O + M <=> O2 + M");
+    ASSERT_EQ(rxn3_usesThirdBody(rxn), 1);
+}

--- a/test/clib_experimental/test_ctmix3.cpp
+++ b/test/clib_experimental/test_ctmix3.cpp
@@ -1,0 +1,25 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <fstream>
+
+#include "cantera/core.h"
+#include "cantera/clib/clib_defs.h"
+#include "cantera/clib_experimental/ct3.h"
+#include "cantera/clib_experimental/ctsol3.h"
+#include "cantera/clib_experimental/ctmix3.h"
+
+using namespace Cantera;
+
+
+TEST(ctmix3, new)
+{
+    int sol0 = sol3_newSolution("h2o2.yaml", "", "none");
+    int thermo = sol3_thermo(sol0);
+    int mix = mix3_new();
+    ASSERT_GE(mix, 0);
+    int ret = mix3_addPhase(mix, thermo, 1.);
+    ASSERT_EQ(ret, 0);
+
+    ASSERT_EQ(mix3_nPhases(mix), 1);
+    ASSERT_EQ(mix3_nElements(mix), 4);
+}

--- a/test/clib_experimental/test_ctthermo3.cpp
+++ b/test/clib_experimental/test_ctthermo3.cpp
@@ -1,0 +1,82 @@
+#include <gtest/gtest.h>
+#include <gmock/gmock.h>
+#include <fstream>
+
+#include "cantera/core.h"
+#include "cantera/clib/clib_defs.h"
+#include "cantera/clib_experimental/ct3.h"
+#include "cantera/clib_experimental/ctsol3.h"
+#include "cantera/clib_experimental/ctthermo3.h"
+
+using namespace Cantera;
+
+
+TEST(ctthermo3, thermo)
+{
+    int ret;
+    int sol = sol3_newSolution("gri30.yaml", "gri30", "none");
+    int thermo = sol3_thermo(sol);
+    ASSERT_GE(thermo, 0);
+    size_t nsp = thermo3_nSpecies(thermo);
+    ASSERT_EQ(nsp, 53u);
+
+    ret = thermo3_setTemperature(thermo, 500);
+    ASSERT_EQ(ret, 0);
+    ret = thermo3_setPressure(thermo, 5 * 101325);
+    ASSERT_EQ(ret, 0);
+    ret = thermo3_setMoleFractionsByName(thermo, "CH4:1.0, O2:2.0, N2:7.52");
+    ASSERT_EQ(ret, 0);
+
+    ret = thermo3_equilibrate(thermo, "HP", "auto", 1e-9, 50000, 1000, 0);
+    ASSERT_EQ(ret, 0);
+    double T = thermo3_temperature(thermo);
+    ASSERT_GT(T, 2200);
+    ASSERT_LT(T, 2300);
+
+    size_t ns = thermo3_nSpecies(thermo);
+    vector<double> work(ns);
+    vector<double> X(ns);
+    thermo3_getMoleFractions(thermo, ns, X.data());
+
+    thermo3_getPartialMolarEnthalpies(thermo, ns, work.data());
+    double prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, thermo3_enthalpy_mole(thermo), 1e-6);
+
+    thermo3_getPartialMolarEntropies(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, thermo3_entropy_mole(thermo), 1e-6);
+
+    thermo3_getPartialMolarIntEnergies(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, thermo3_intEnergy_mole(thermo), 1e-6);
+
+    thermo3_getPartialMolarCp(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, thermo3_cp_mole(thermo), 1e-6);
+
+    thermo3_getPartialMolarVolumes(thermo, ns, work.data());
+    prod = std::inner_product(X.begin(), X.end(), work.begin(), 0.0);
+    ASSERT_NEAR(prod, 1./thermo3_molarDensity(thermo), 1e-6);
+}
+
+TEST(ctthermo3, atomicWeights)
+{
+    int ret;
+    int sol = sol3_newSolution("h2o2.yaml", "", "none");
+    int thermo = sol3_thermo(sol);
+
+    auto cxx_sol = newSolution("h2o2.yaml", "", "none");
+    auto cxx_thermo = cxx_sol->thermo();
+    auto cxx_weights = cxx_thermo->atomicWeights();
+    ASSERT_EQ(cxx_weights.size(), cxx_thermo->nElements());
+
+    int buflen = thermo3_nElements(thermo);
+    ASSERT_EQ(buflen, cxx_thermo->nElements());  // 4
+    vector<double> buf(buflen);
+    ret = thermo3_getAtomicWeights(thermo, buflen, buf.data());
+    ASSERT_EQ(ret, buflen);
+
+    for (size_t i = 0; i < buflen; i++) {
+        ASSERT_NEAR(buf[i], cxx_weights[i], 1e-6);
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add all Cantera "core" objects to experimental CLib 
- APIs for `Solution`, `ThermoPhase`, `Kinetics`, `Transport` and `MultiPhase` have reached parity with traditional CLib
- Additional unit tests are added (go beyond traditional CLib test suite)
- Some differences of method names compared to traditional CLib API are rolled back - pre-existing inconsistencies are left to be addressed at a later point
- Logic in `_orchestrate.py` is simplified

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Addresses Cantera/enhancements#220

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
