### PR TITLE
[C++] Fix unsigned integer check in Solution.h

### DIFF
--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -115,8 +115,8 @@ public:
 
     //! Get the name of an adjacent phase by index
     string adjacentName(size_t i) const {
-        if (i < 0 || i >= m_adjacent.size()) {
-            throw CanteraError("Solution::adjacentName", "Invalid index {}.", i);
+        if (i >= m_adjacent.size()) {
+            throw IndexError("Solution::adjacentName", "m_adjacent", i, m_adjacent.size()-1);
         }
         return m_adjacent.at(i)->name();
     }

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -180,7 +180,8 @@ public:
      * @param arrayName name of the corresponding array
      * @param m   This is the value of the out-of-bounds index.
      * @param mmax This is the maximum allowed value of the index. The
-     *             minimum allowed value is assumed to be 0.
+     *             minimum allowed value is assumed to be 0. The special
+     *             value npos indicates that the array is empty.
      */
     IndexError(const string& func, const string& arrayName, size_t m, size_t mmax) :
         CanteraError(func), arrayName_(arrayName), m_(m), mmax_(mmax) {}

--- a/src/base/ctexceptions.cpp
+++ b/src/base/ctexceptions.cpp
@@ -72,6 +72,10 @@ string ArraySizeError::getMessage() const
 
 string IndexError::getMessage() const
 {
+    if (mmax_ == npos) {
+        return fmt::format("IndexError: index {} given, but array{} is empty.",
+                           m_, arrayName_.empty() ? arrayName_ : " "+arrayName_);
+    }
     if (arrayName_ == "") {
         return fmt::format("IndexError: {} outside valid range of 0 to {}.", m_, mmax_);
     }


### PR DESCRIPTION
**Changes proposed in this pull request**

Remove check for negative index value and use the `IndexError` exception type in Solution.h.

Closes https://github.com/Cantera/cantera/issues/1849.

Before merging the PR: Is `m_adjacent` guaranteed to have at least one element? Otherwise, the maximum allowed index (last parameter in `IndexError`'s constructor) should probably be handled differently for `m_adjacent.size() == 0`.


**Checklist**

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
