### PR TITLE
Make IndexError consistent

### DIFF
--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -116,7 +116,8 @@ public:
     //! Get the name of an adjacent phase by index
     string adjacentName(size_t i) const {
         if (i >= m_adjacent.size()) {
-            throw IndexError("Solution::adjacentName", "m_adjacent", i, m_adjacent.size()-1);
+            throw IndexError("Solution::adjacentName", "m_adjacent",
+                             i, m_adjacent.size());
         }
         return m_adjacent.at(i)->name();
     }

--- a/include/cantera/base/ctexceptions.h
+++ b/include/cantera/base/ctexceptions.h
@@ -175,16 +175,13 @@ public:
     /*!
      * This class indicates an out-of-bounds array index.
      *
-     * @param func String name for the function within which the error was
-     *             generated.
-     * @param arrayName name of the corresponding array
-     * @param m   This is the value of the out-of-bounds index.
-     * @param mmax This is the maximum allowed value of the index. The
-     *             minimum allowed value is assumed to be 0. The special
-     *             value npos indicates that the array is empty.
+     * @param func  String name for the function within which the error was generated.
+     * @param arrayName  Name of the corresponding array or empty string @c "".
+     * @param m     Value of the out-of-bounds index.
+     * @param arrSize  Size of the array.
      */
-    IndexError(const string& func, const string& arrayName, size_t m, size_t mmax) :
-        CanteraError(func), arrayName_(arrayName), m_(m), mmax_(mmax) {}
+    IndexError(const string& func, const string& arrayName, size_t m, size_t arrSize) :
+        CanteraError(func), arrayName_(arrayName), m_(m), m_size(arrSize) {}
 
     ~IndexError() throw() override {};
     string getMessage() const override;
@@ -194,7 +191,8 @@ public:
 
 private:
     string arrayName_;
-    size_t m_, mmax_;
+    size_t m_;
+    size_t m_size;
 };
 
 //! An error indicating that an unimplemented function has been called

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -153,7 +153,7 @@ public:
     //! Throws an exception if n is greater than nComponents()-1
     void checkComponentIndex(size_t n) const {
         if (n >= m_nv) {
-            throw IndexError("Domain1D::checkComponentIndex", "points", n, m_nv-1);
+            throw IndexError("Domain1D::checkComponentIndex", "points", n, m_nv);
         }
     }
 
@@ -175,7 +175,7 @@ public:
     //! Throws an exception if n is greater than nPoints()-1
     void checkPointIndex(size_t n) const {
         if (n >= m_points) {
-            throw IndexError("Domain1D::checkPointIndex", "points", n, m_points-1);
+            throw IndexError("Domain1D::checkPointIndex", "points", n, m_points);
         }
     }
 

--- a/include/cantera/oneD/OneDim.h
+++ b/include/cantera/oneD/OneDim.h
@@ -89,8 +89,7 @@ public:
     //! Throws an exception if n is greater than nDomains()-1
     void checkDomainIndex(size_t n) const {
         if (n >= m_dom.size()) {
-            throw IndexError("OneDim::checkDomainIndex", "domains", n,
-                             m_dom.size()-1);
+            throw IndexError("OneDim::checkDomainIndex", "domains", n, m_dom.size());
         }
     }
 

--- a/interfaces/sourcegen/sourcegen/clib/templates.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/templates.yaml
@@ -172,7 +172,7 @@ clib-accessor: |-
       {% if checks %}
       ## accessor uses index checker (see: sol3_adjacent)
       if ({{ c_args[1] }} < 0 || {{ c_args[1] }} >= {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}()) {
-          throw IndexError("{{ c_func }}", "", {{ c_args[1] }}, {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}() - 1);
+          throw IndexError("{{ c_func }}", "", {{ c_args[1] }}, {{ base }}Cabinet::at({{ handle }})->{{ checks[0] }}());
       }
       {% endif %}{# checks #}
       {% if shared %}

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -781,7 +781,7 @@ void SolutionArray::setLoc(int loc, bool restore)
     } else if (static_cast<size_t>(m_active[loc_]) == m_loc) {
         return;
     } else if (loc_ >= m_size) {
-        throw IndexError("SolutionArray::setLoc", "indices", loc_, m_size - 1);
+        throw IndexError("SolutionArray::setLoc", "indices", loc_, m_size);
     }
     m_loc = static_cast<size_t>(m_active[loc_]);
     if (restore) {

--- a/src/base/ctexceptions.cpp
+++ b/src/base/ctexceptions.cpp
@@ -72,15 +72,16 @@ string ArraySizeError::getMessage() const
 
 string IndexError::getMessage() const
 {
-    if (mmax_ == npos) {
+    if (m_size == 0) {
         return fmt::format("IndexError: index {} given, but array{} is empty.",
                            m_, arrayName_.empty() ? arrayName_ : " "+arrayName_);
     }
     if (arrayName_ == "") {
-        return fmt::format("IndexError: {} outside valid range of 0 to {}.", m_, mmax_);
+        return fmt::format("IndexError: {} outside valid range of 0 to {}.",
+                           m_, m_size - 1);
     }
     return fmt::format("IndexError: {}[{}] outside valid range of 0 to {}.",
-                       arrayName_, m_, mmax_);
+                       arrayName_, m_, m_size - 1);
 }
 
 } // namespace Cantera

--- a/src/equil/MultiPhase.cpp
+++ b/src/equil/MultiPhase.cpp
@@ -177,7 +177,7 @@ ThermoPhase& MultiPhase::phase(size_t n)
 void MultiPhase::checkPhaseIndex(size_t m) const
 {
     if (m >= nPhases()) {
-        throw IndexError("MultiPhase::checkPhaseIndex", "phase", m, nPhases()-1);
+        throw IndexError("MultiPhase::checkPhaseIndex", "phase", m, nPhases());
     }
 }
 
@@ -720,7 +720,7 @@ void MultiPhase::setTemperature(const double T)
 void MultiPhase::checkElementIndex(size_t m) const
 {
     if (m >= m_nel) {
-        throw IndexError("MultiPhase::checkElementIndex", "elements", m, m_nel-1);
+        throw IndexError("MultiPhase::checkElementIndex", "elements", m, m_nel);
     }
 }
 
@@ -749,7 +749,7 @@ size_t MultiPhase::elementIndex(const string& name) const
 void MultiPhase::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_nsp) {
-        throw IndexError("MultiPhase::checkSpeciesIndex", "species", k, m_nsp-1);
+        throw IndexError("MultiPhase::checkSpeciesIndex", "species", k, m_nsp);
     }
 }
 

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -27,8 +27,7 @@ namespace Cantera
 void Kinetics::checkReactionIndex(size_t i) const
 {
     if (i >= nReactions()) {
-        throw IndexError("Kinetics::checkReactionIndex", "reactions", i,
-                         nReactions()-1);
+        throw IndexError("Kinetics::checkReactionIndex", "reactions", i, nReactions());
     }
 }
 
@@ -62,7 +61,7 @@ void Kinetics::checkReactionArraySize(size_t ii) const
 void Kinetics::checkPhaseIndex(size_t m) const
 {
     if (m >= nPhases()) {
-        throw IndexError("Kinetics::checkPhaseIndex", "phase", m, nPhases()-1);
+        throw IndexError("Kinetics::checkPhaseIndex", "phase", m, nPhases());
     }
 }
 
@@ -81,7 +80,7 @@ shared_ptr<ThermoPhase> Kinetics::reactionPhase() const
 void Kinetics::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_kk) {
-        throw IndexError("Kinetics::checkSpeciesIndex", "species", k, m_kk-1);
+        throw IndexError("Kinetics::checkSpeciesIndex", "species", k, m_kk);
     }
 }
 

--- a/src/thermo/Phase.cpp
+++ b/src/thermo/Phase.cpp
@@ -35,7 +35,7 @@ size_t Phase::nElements() const
 void Phase::checkElementIndex(size_t m) const
 {
     if (m >= m_mm) {
-        throw IndexError("Phase::checkElementIndex", "elements", m, m_mm-1);
+        throw IndexError("Phase::checkElementIndex", "elements", m, m_mm);
     }
 }
 
@@ -153,7 +153,7 @@ const vector<string>& Phase::speciesNames() const
 void Phase::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_kk) {
-        throw IndexError("Phase::checkSpeciesIndex", "species", k, m_kk-1);
+        throw IndexError("Phase::checkSpeciesIndex", "species", k, m_kk);
     }
 }
 

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -16,7 +16,7 @@ namespace Cantera
 void Transport::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_nsp) {
-        throw IndexError("Transport::checkSpeciesIndex", "species", k, m_nsp-1);
+        throw IndexError("Transport::checkSpeciesIndex", "species", k, m_nsp);
     }
 }
 

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -403,7 +403,7 @@ double ReactorNet::sensitivity(size_t k, size_t p)
     }
     if (p >= m_sens_params.size()) {
         throw IndexError("ReactorNet::sensitivity",
-                         "m_sens_params", p, m_sens_params.size()-1);
+                         "m_sens_params", p, m_sens_params.size());
     }
     double denom = m_integ->solution(k);
     if (denom == 0.0) {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Minor follow-up to #1850. `IndexError` and `ArraySizeError` have different APIs (one uses max index and the other array size), where the former has the wrinkle that it won't work for empty arrays (with `npos` being a workaround). The update avoids having to call `IndexError` with array size - 1.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
