### PR TITLE
Fix E -> Ea in creating-mechanisms.md

### DIFF
--- a/doc/sphinx/userguide/creating-mechanisms.md
+++ b/doc/sphinx/userguide/creating-mechanisms.md
@@ -683,7 +683,7 @@ exponent, $E_a$ is the activation energy, and $R$ is the gas constant. Rates in 
 form can be written as YAML mappings. For example:
 
 ```yaml
-{A: 1.0e13, b: 0, E: 7.3 kcal/mol}
+{A: 1.0e13, b: 0, Ea: 7.3 kcal/mol}
 ```
 
 The units of $A$ can be specified explicitly if desired. If not specified, they will be
@@ -701,7 +701,7 @@ are really the units for $k_f$. One way to formally express this is to replace $
 by the non-dimensional quantity $[T/(1\;\t{K})]^b$.
 ```
 
-The key `E` is used to specify $E_a$.
+The key `Ea` is used to specify $E_a$.
 
 The following examples show some reaction definitions making use of Arrhenius and
 Arrhenius-like rate parameterizations:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The instructions on writing YAML files said to use `E` for the activation energy, but all (but one of) the examples use `Ea`, which I think is correct. I updated the instructions and the one example that had `E`.

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
