### PR TITLE
Reverse reaction (super-elastic) electron collision reaction

### DIFF
--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -9,7 +9,6 @@
 #define CT_BULKKINETICS_H
 
 #include "Kinetics.h"
-#include "MultiRate.h"
 #include "ThirdBodyCalc.h"
 
 namespace Cantera
@@ -146,10 +145,6 @@ protected:
     void assertDerivativesValid(const string& name);
 
     //! @}
-
-    //! Vector of rate handlers
-    vector<unique_ptr<MultiRateBase>> m_bulk_rates;
-    map<string, size_t> m_bulk_types; //!< Mapping of rate handlers
 
     //! Difference between the global reactants order and the global products
     //! order. Of type "double" to account for the fact that we can have real-

--- a/include/cantera/kinetics/BulkKinetics.h
+++ b/include/cantera/kinetics/BulkKinetics.h
@@ -28,7 +28,6 @@ public:
         return "bulk";
     }
 
-    bool isReversible(size_t i) override;
     //! @}
 
     //! @name Reaction Mechanism Setup Routines
@@ -151,9 +150,6 @@ protected:
     //! Vector of rate handlers
     vector<unique_ptr<MultiRateBase>> m_bulk_rates;
     map<string, size_t> m_bulk_types; //!< Mapping of rate handlers
-
-    vector<size_t> m_revindex; //!< Indices of reversible reactions
-    vector<size_t> m_irrev; //!< Indices of irreversible reactions
 
     //! Difference between the global reactants order and the global products
     //! order. Of type "double" to account for the fact that we can have real-

--- a/include/cantera/kinetics/ElectronCollisionPlasmaRate.h
+++ b/include/cantera/kinetics/ElectronCollisionPlasmaRate.h
@@ -121,6 +121,9 @@ public:
      */
     double evalFromStruct(const ElectronCollisionPlasmaData& shared_data);
 
+    void modifyRateConstants(const ElectronCollisionPlasmaData& shared_data,
+                             double& kf, double& kr);
+
     //! Evaluate derivative of reaction rate with respect to temperature
     //! divided by reaction rate
     //! @param shared_data  data shared by all reactions of a given type
@@ -155,6 +158,12 @@ private:
 
     //! collision cross sections [m2] after interpolation
     vector<double> m_crossSectionsInterpolated;
+
+    //! collision cross section [m2] interpolated on #m_energyLevels offset by the
+    //! threshold energy (the first energy level).
+    //! This is used for the calculation of the super-elastic collision reaction
+    //! rate coefficient.
+    Eigen::ArrayXd m_crossSectionsOffset;
 };
 
 }

--- a/include/cantera/kinetics/ElectronCollisionPlasmaRate.h
+++ b/include/cantera/kinetics/ElectronCollisionPlasmaRate.h
@@ -61,29 +61,41 @@ protected:
  *
  * where @f$ \gamma = \sqrt{2/m_e} @f$ (Eqn.4 in @cite hagelaar2015),
  * @f$ m_e @f$ [kg] is the electron mass, @f$ \epsilon @f$ [J] is the electron
- * energy, @f$ \sigma @f$ [m2] is the reaction collision cross section,
- * @f$ F_0 @f$ [J^(-3/2)] is the normalized electron energy distribution function,
- * and @f$ k @f$ has the unit of [m3/s]. The collision process is treated as a
- * bimolecular reaction and should have units of [m3/kmol/s]. Therefore the
- * forward reaction coefficient becomes,
+ * energy, @f$ \sigma @f$ [m²] is the reaction collision cross section,
+ * @f$ F_0 @f$ [@f$ \mbox{J}^{-3/2} @f$] is the normalized electron energy
+ * distribution function, and @f$ k @f$ has the unit of [m³/s]. The collision
+ * process is treated as a bimolecular reaction and should have units of [m³/kmol/s].
+ * Therefore the forward reaction coefficient becomes,
  *
  *   @f[
  *        k_f = \gamma N_A \int_0^{\infty} \epsilon \sigma F_0 d\epsilon,
  *   @f]
  *
  * where @f$ N_A @f$ [1/kmol] is the Avogadro's number. Since the unit of the
- * electron energy downloaded from LXCat is in [V], the forward reaction
+ * electron energy downloaded from LXCat is in [eV], the elementary charge, e,
+ * can be taken out of the integral and combine with @f$ \gamma @f$ to get,
+ *
+ *   @f[
+ *        k_f = \sqrt{\frac{2e}{m_e}} N_A \int_0^{\infty} \epsilon_V \sigma F_{0,V} d\epsilon_V.
+ *   @f]
+ *
+ * In addition to the forward reaction coefficient, the reverse (super-elastic) reaction
  * coefficient can be written as,
  *
  *   @f[
- *        k_f = \sqrt{\frac{2e}{m_e}} N_A \int_0^{\infty} \epsilon_V \sigma F_0 d\epsilon_V.
+ *        k_r = \sqrt{\frac{2e}{m_e}} N_A \int_0^{\infty} \epsilon_V \sigma_{super}
+ *              F_{0,V} d\epsilon_V,
  *   @f]
  *
- * For the convenience of calculation, the final form becomes,
+ * where @f$ \sigma_{super} @f$ is the super-elastic cross section, defined by the principle
+ * of detailed balancing as:
  *
  *   @f[
- *        k_f = 0.5 \sqrt{\frac{2e}{m_e}} N_A \int_0^{\infty} \sigma F_0 d{{\epsilon_V}^2}.
+ *        \sigma_{super}(\epsilon) = \frac{\epsilon + U}{\epsilon} \sigma(\epsilon + U),
  *   @f]
+ *
+ * where @f$ U @f$ is the threshold energy [eV], equal to the first energy level of the cross
+ * section (#m_energyLevels).
  *
  * @ingroup otherRateGroup
  * @since New in %Cantera 3.1.

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -9,7 +9,6 @@
 #define CT_IFACEKINETICS_H
 
 #include "Kinetics.h"
-#include "MultiRate.h"
 
 namespace Cantera
 {
@@ -319,10 +318,6 @@ protected:
     vector<double> m_grt;
 
     bool m_redo_rates = false;
-
-    //! Vector of rate handlers for interface reactions
-    vector<unique_ptr<MultiRateBase>> m_interfaceRates;
-    map<string, size_t> m_interfaceTypes; //!< Rate handler mapping
 
     //! Array of concentrations for each species in the kinetics mechanism
     /*!

--- a/include/cantera/kinetics/InterfaceKinetics.h
+++ b/include/cantera/kinetics/InterfaceKinetics.h
@@ -100,16 +100,6 @@ public:
     //! @{
 
     void getActivityConcentrations(double* const conc) override;
-
-    bool isReversible(size_t i) override {
-        if (std::find(m_revindex.begin(), m_revindex.end(), i)
-                < m_revindex.end()) {
-            return true;
-        } else {
-            return false;
-        }
-    }
-
     void getFwdRateConstants(double* kfwd) override;
     void getRevRateConstants(double* krev, bool doIrreversible=false) override;
 
@@ -328,24 +318,11 @@ protected:
     //! Temporary work vector of length m_kk
     vector<double> m_grt;
 
-    //! List of reactions numbers which are reversible reactions
-    /*!
-     *  This is a vector of reaction numbers. Each reaction in the list is
-     *  reversible. Length = number of reversible reactions
-     */
-    vector<size_t> m_revindex;
-
     bool m_redo_rates = false;
 
     //! Vector of rate handlers for interface reactions
     vector<unique_ptr<MultiRateBase>> m_interfaceRates;
     map<string, size_t> m_interfaceTypes; //!< Rate handler mapping
-
-    //! Vector of irreversible reaction numbers
-    /*!
-     * vector containing the reaction numbers of irreversible reactions.
-     */
-    vector<size_t> m_irrev;
 
     //! Array of concentrations for each species in the kinetics mechanism
     /*!

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -13,6 +13,7 @@
 
 #include "StoichManager.h"
 #include "cantera/base/ValueCache.h"
+#include "MultiRate.h"
 
 namespace Cantera
 {
@@ -1445,6 +1446,10 @@ protected:
      *    Otherwise, it returns the ratio of the stoichiometric coefficients.
      */
     double checkDuplicateStoich(map<int, double>& r1, map<int, double>& r2) const;
+
+    //! Vector of rate handlers
+    vector<unique_ptr<MultiRateBase>> m_rateHandlers;
+    map<string, size_t> m_rateTypes; //!< Mapping of rate handlers
 
     //! @name Stoichiometry management
     //!

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -1202,8 +1202,8 @@ public:
      *
      * @param i   reaction index
      */
-    virtual bool isReversible(size_t i) {
-        throw NotImplementedError("Kinetics::isReversible");
+    bool isReversible(size_t i) const {
+        return std::find(m_revindex.begin(), m_revindex.end(), i) < m_revindex.end();
     }
 
     /**
@@ -1526,6 +1526,9 @@ protected:
 
     //! Net rate-of-progress for each reaction
     vector<double> m_ropnet;
+
+    vector<size_t> m_revindex; //!< Indices of reversible reactions
+    vector<size_t> m_irrev; //!< Indices of irreversible reactions
 
     //! The enthalpy change for each reaction to calculate Blowers-Masel rates
     vector<double> m_dH;

--- a/include/cantera/kinetics/MultiRate.h
+++ b/include/cantera/kinetics/MultiRate.h
@@ -21,6 +21,7 @@ template <class RateType, class DataType>
 class MultiRate final : public MultiRateBase
 {
     CT_DEFINE_HAS_MEMBER(has_update, updateFromStruct)
+    CT_DEFINE_HAS_MEMBER(has_modifyRateConstants, modifyRateConstants)
     CT_DEFINE_HAS_MEMBER(has_ddT, ddTScaledFromStruct)
     CT_DEFINE_HAS_MEMBER(has_ddP, perturbPressure)
     CT_DEFINE_HAS_MEMBER(has_ddM, perturbThirdBodies)
@@ -68,6 +69,14 @@ public:
     void getRateConstants(double* kf) override {
         for (auto& [iRxn, rate] : m_rxn_rates) {
             kf[iRxn] = rate.evalFromStruct(m_shared);
+        }
+    }
+
+    void modifyRateConstants(double* kf, double* kr) override {
+        if constexpr (has_modifyRateConstants<RateType>::value) {
+            for (auto& [iRxn, rate] : m_rxn_rates) {
+                rate.modifyRateConstants(m_shared, kf[iRxn], kr[iRxn]);
+            }
         }
     }
 

--- a/include/cantera/kinetics/MultiRateBase.h
+++ b/include/cantera/kinetics/MultiRateBase.h
@@ -52,6 +52,19 @@ public:
     //! @param kf  array of rate constants
     virtual void getRateConstants(double* kf) = 0;
 
+    //! For certain reaction types that do not follow mass action kinetics (for example,
+    //! Butler-Volmer), calculate modifications to the forward and reverse rate
+    //! constants.
+    //! @param[in, out] kf  On input, contains the rate constants as computed by
+    //!     getRateConstants(). The output value is updated by the reactant
+    //!     StoichManagerN to determine the forward rates of progress.
+    //! @param[in, out] kr  On input, contains the reverse rate constants computed from
+    //!     the forward rate constants and the equilibrium constants. The output value
+    //!     is updated by the product StoichManagerN to determine the reverse rates of
+    //!     progress.
+    //! @since New in %Cantera 3.2
+    virtual void modifyRateConstants(double* kf, double* kr) = 0;
+
     //! Evaluate all rate constant temperature derivatives handled by the evaluator;
     //! which are multiplied with the array of rate-of-progress variables.
     //! Depending on the implementation of a rate object, either an exact derivative or

--- a/include/cantera/kinetics/ReactionRate.h
+++ b/include/cantera/kinetics/ReactionRate.h
@@ -26,9 +26,13 @@ class Reaction;
 //! In addition to the pure virtual methods declared in this class, complete derived
 //! classes must implement the method `evalFromStruct(const DataType& shared_data)`,
 //! where `DataType` is a container for parameters needed to evaluate reactions of that
-//! type. In addition, derived classes may also implement the method
-//! `updateFromStruct(const DataType& shared_data)` to update buffered data that
+//! type. In addition, derived classes may also implement the following methods:
+//! - `updateFromStruct(const DataType& shared_data)`, to update buffered data that
 //! is specific to a given reaction rate.
+//! - `modifyRateConstants(const DataType& shared_data, double& kf, double& kr)`, to
+//!   implement modifications to the forward and reverse rate constants for reactions
+//!   that do not follow mass action kinetics or use the equilibrium constant to
+//!   implement reversibility.
 //!
 //! The calculation of derivatives (or Jacobians) relies on the following methods:
 //!  -  Derived classes may implement the method
@@ -44,6 +48,8 @@ class Reaction;
 //!     which allow for the calculation of numerical derivatives.
 //!  -  For additional information, refer to the @ref kinDerivs "Kinetics Derivatives"
 //!     documentation.
+//!
+//! @since The `modifyRateConstants` method is new in Cantera 3.2.
 //! @ingroup reactionGroup
 class ReactionRate
 {

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -12,10 +12,6 @@ BulkKinetics::BulkKinetics() {
     setDerivativeSettings(AnyMap()); // use default settings
 }
 
-bool BulkKinetics::isReversible(size_t i) {
-    return std::find(m_revindex.begin(), m_revindex.end(), i) < m_revindex.end();
-}
-
 bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
 {
     bool added = Kinetics::addReaction(r, resize);
@@ -32,12 +28,6 @@ bool BulkKinetics::addReaction(shared_ptr<Reaction> r, bool resize)
     }
 
     m_dn.push_back(dn);
-
-    if (r->reversible) {
-        m_revindex.push_back(nReactions()-1);
-    } else {
-        m_irrev.push_back(nReactions()-1);
-    }
 
     shared_ptr<ReactionRate> rate = r->rate();
     string rtype = rate->subType();

--- a/src/kinetics/BulkKinetics.cpp
+++ b/src/kinetics/BulkKinetics.cpp
@@ -508,12 +508,17 @@ void BulkKinetics::updateROP()
     processThirdBodies(m_ropf.data());
     copy(m_ropf.begin(), m_ropf.end(), m_ropr.begin());
 
-    // multiply ropf by concentration products
-    m_reactantStoich.multiply(m_act_conc.data(), m_ropf.data());
-
     // for reversible reactions, multiply ropr by concentration products
     applyEquilibriumConstants(m_ropr.data());
+
+    for (auto& rates : m_rateHandlers) {
+        rates->modifyRateConstants(m_ropf.data(), m_ropr.data());
+    }
+
+    // multiply ropf and ropr by concentration products
+    m_reactantStoich.multiply(m_act_conc.data(), m_ropf.data());
     m_revProductStoich.multiply(m_act_conc.data(), m_ropr.data());
+
     for (size_t j = 0; j != nReactions(); ++j) {
         m_ropnet[j] = m_ropf[j] - m_ropr[j];
     }

--- a/src/kinetics/ElectronCollisionPlasmaRate.cpp
+++ b/src/kinetics/ElectronCollisionPlasmaRate.cpp
@@ -105,8 +105,8 @@ double ElectronCollisionPlasmaRate::evalFromStruct(
     );
 
     // unit in kmol/m3/s
-    return 0.5 * pow(2.0 * ElectronCharge / ElectronMass, 0.5) * Avogadro *
-           simpson(distribution.cwiseProduct(cs_array), eps.pow(2.0));
+    return pow(2.0 * ElectronCharge / ElectronMass, 0.5) * Avogadro *
+           simpson(eps.cwiseProduct(distribution.cwiseProduct(cs_array)), eps);
 }
 
 void ElectronCollisionPlasmaRate::modifyRateConstants(

--- a/src/kinetics/ElectronCollisionPlasmaRate.cpp
+++ b/src/kinetics/ElectronCollisionPlasmaRate.cpp
@@ -111,14 +111,6 @@ double ElectronCollisionPlasmaRate::evalFromStruct(
 
 void ElectronCollisionPlasmaRate::setContext(const Reaction& rxn, const Kinetics& kin)
 {
-    // ElectronCollisionPlasmaReaction is for a non-equilibrium plasma, and the reverse rate
-    // cannot be calculated from the conventional thermochemistry.
-    // @todo implement the reversible rate for non-equilibrium plasma
-    if (rxn.reversible) {
-        throw InputFileError("ElectronCollisionPlasmaRate::setContext", rxn.input,
-            "ElectronCollisionPlasmaRate does not support reversible reactions");
-    }
-
     // get electron species name
     string electronName;
     if (kin.thermo().type() == "plasma") {
@@ -139,6 +131,24 @@ void ElectronCollisionPlasmaRate::setContext(const Reaction& rxn, const Kinetics
     if (rxn.reactants.at(electronName) != 1) {
         throw InputFileError("ElectronCollisionPlasmaRate::setContext", rxn.input,
             "ElectronCollisionPlasmaRate requires one and only one electron");
+    }
+
+    if (!rxn.reversible) {
+        return; // end checking of forward reaction
+    }
+
+    // For super-elastic collisions
+    if (rxn.products.size() != 2) {
+        throw InputFileError("ElectronCollisionPlasmaRate::setContext", rxn.input,
+            "ElectronCollisionPlasmaRate requires exactly two products"
+            "if the reaction is reversible (super-elastic collisions)");
+    }
+
+    // Must have only one electron
+    if (rxn.products.at(electronName) != 1) {
+        throw InputFileError("ElectronCollisionPlasmaRate::setContext", rxn.input,
+            "ElectronCollisionPlasmaRate requires one and only one electron in products"
+            "if the reaction is reversible (super-elastic collisions)");
     }
 }
 

--- a/src/kinetics/ElectronCollisionPlasmaRate.cpp
+++ b/src/kinetics/ElectronCollisionPlasmaRate.cpp
@@ -112,6 +112,12 @@ double ElectronCollisionPlasmaRate::evalFromStruct(
 void ElectronCollisionPlasmaRate::modifyRateConstants(
     const ElectronCollisionPlasmaData& shared_data, double& kf, double& kr)
 {
+    if (kr == 0.0) {
+        // The reverse rate constant is only for reversible reactions
+        // kr = 0.0 indicates that the reaction is irreversible
+        return;
+    }
+
     // Interpolate cross-sections data to the energy levels of
     // the electron energy distribution function
     if (shared_data.levelChanged) {

--- a/src/kinetics/ElectronCollisionPlasmaRate.cpp
+++ b/src/kinetics/ElectronCollisionPlasmaRate.cpp
@@ -179,14 +179,14 @@ void ElectronCollisionPlasmaRate::setContext(const Reaction& rxn, const Kinetics
     if (rxn.products.size() != 2) {
         throw InputFileError("ElectronCollisionPlasmaRate::setContext", rxn.input,
             "ElectronCollisionPlasmaRate requires exactly two products"
-            "if the reaction is reversible (super-elastic collisions)");
+            " if the reaction is reversible (super-elastic collisions)");
     }
 
     // Must have only one electron
     if (rxn.products.at(electronName) != 1) {
         throw InputFileError("ElectronCollisionPlasmaRate::setContext", rxn.input,
             "ElectronCollisionPlasmaRate requires one and only one electron in products"
-            "if the reaction is reversible (super-elastic collisions)");
+            " if the reaction is reversible (super-elastic collisions)");
     }
 }
 

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -218,6 +218,10 @@ void InterfaceKinetics::updateROP()
         m_ropr[i] = m_ropf[i] * m_rkcn[i];
     }
 
+    for (auto& rates : m_rateHandlers) {
+        rates->modifyRateConstants(m_ropf.data(), m_ropr.data());
+    }
+
     // multiply ropf by the activity concentration reaction orders to obtain
     // the forward rates of progress.
     m_reactantStoich.multiply(m_actConc.data(), m_ropf.data());

--- a/src/kinetics/InterfaceKinetics.cpp
+++ b/src/kinetics/InterfaceKinetics.cpp
@@ -389,12 +389,6 @@ bool InterfaceKinetics::addReaction(shared_ptr<Reaction> r_base, bool resize)
         return false;
     }
 
-    if (r_base->reversible) {
-        m_revindex.push_back(i);
-    } else {
-        m_irrev.push_back(i);
-    }
-
     m_rxnPhaseIsReactant.emplace_back(nPhases(), false);
     m_rxnPhaseIsProduct.emplace_back(nPhases(), false);
 

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -676,7 +676,10 @@ bool Kinetics::addReaction(shared_ptr<Reaction> r, bool resize)
     // product orders = product stoichiometric coefficients
     m_productStoich.add(irxn, pk, pstoich, pstoich);
     if (r->reversible) {
+        m_revindex.push_back(irxn);
         m_revProductStoich.add(irxn, pk, pstoich, pstoich);
+    } else {
+        m_irrev.push_back(irxn);
     }
 
     m_reactions.push_back(r);

--- a/test/data/oxygen-plasma.yaml
+++ b/test/data/oxygen-plasma.yaml
@@ -51,7 +51,7 @@ reactions:
   type: two-temperature-plasma
   rate-constant: {A: 4.2e-27, b: -1.0, Ea-gas: 600, Ea-electron: 700}
 
-- equation: O2 + E => E + O2
+- equation: O2 + E <=> E + O2
   type: electron-collision-plasma
   note: This is a electron collision process of plasma
   energy-levels: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -2284,9 +2284,9 @@ class TestElectronCollisionPlasmaReaction(ReactionTests):
     # reaction rate is much complicated and depends on electron energy distribution
     # function.
     _rate_cls = ct.ElectronCollisionPlasmaRate
-    _equation = "O2 + E => E + O2"
+    _equation = "O2 + E <=> E + O2"
     _rate = {
-        "equation": "O2 + E => E + O2",
+        "equation": "O2 + E <=> E + O2",
         "type": "electron-collision-plasma",
         "energy-levels": [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0],
         "cross-sections": [0.0, 5.97e-20, 6.45e-20, 6.74e-20, 6.93e-20, 7.2e-20,
@@ -2295,7 +2295,7 @@ class TestElectronCollisionPlasmaReaction(ReactionTests):
     _index = 1
     _rate_type = "electron-collision-plasma"
     _yaml = """
-        equation: O2 + E => E + O2
+        equation: O2 + E <=> E + O2
         type: electron-collision-plasma
         energy-levels: [0.0, 1.0, 2.0, 3.0, 4.0, 5.0, 6.0, 7.0, 8.0, 9.0, 10.0]
         cross-sections: [0.0, 5.97e-20, 6.45e-20, 6.74e-20, 6.93e-20, 7.2e-20,


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

The reverse reaction rate of electron collision reaction is added. The reverse rate is calculated super-elastic formula. In the test, a reversible elastic reaction is used for testing purpose only. The reverse rate is the same as the forward rate if the threshold energy is zero.


<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Use commits from [@speth](https://github.com/speth/cantera/tree/electrochem) for modification of the reverse rate.
- Make electron collision plasma reaction (ECPR) reversible.
- Add test for ECPR.
- I will add the example later - while working on this I found https://github.com/Cantera/cantera/issues/1856

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Cantera/enhancements#192

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
