### PR TITLE
[C++] Provide const access to falloff rate parameters

### DIFF
--- a/include/cantera/kinetics/Falloff.h
+++ b/include/cantera/kinetics/Falloff.h
@@ -206,11 +206,21 @@ public:
         return m_lowRate;
     }
 
+    //! Get reaction rate in the low-pressure limit
+    const ArrheniusRate& lowRate() const {
+        return m_lowRate;
+    }
+
     //! Set reaction rate in the low-pressure limit
     void setLowRate(const ArrheniusRate& low);
 
     //! Get reaction rate in the high-pressure limit
     ArrheniusRate& highRate() {
+        return m_highRate;
+    }
+
+    //! Get reaction rate in the high-pressure limit
+    const ArrheniusRate& highRate() const {
         return m_highRate;
     }
 


### PR DESCRIPTION
**Changes proposed in this pull request**

Currently, a constant kinetics object cannot be used to obtain the Arrhenius parameters of falloff reactions in the C++ interface without creating a copy of the reaction. Let's assume I need to access the Arrhenius parameters of a falloff reaction. I am working on a constant reference of the kinetics object:
```cpp
void f(const BulkKinetics& kin) // pass the kinetics object as const ref
{
    // I want to access the Arrhenius parameters of the first reaction,
    // which I know is of type falloff
    const ArrheniusRate& rate = std::dynamic_pointer_cast<const FalloffRate>
                                 (kin.reaction(0)->rate())->lowRate();
    // ERROR: lowRate() is not a constant member function
}
```
To address this, constant variants of the `lowRate()` and `highRate()` member functions are added in this PR.

- [X] The pull request includes a clear description of this code change
- [X] Commit messages have short titles and reference relevant issues
- [X] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [X] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [X] The pull request is ready for review
