### PR TITLE
Remove constrains of using PlasmaPhase for 0D reactor and fix the species lock

### DIFF
--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -128,6 +128,12 @@ size_t Reactor::nSensParams() const
 void Reactor::syncState()
 {
     ReactorBase::syncState();
+    if (m_energy) {
+        // sync of the thermal properties below is enabled only
+        // if the energy equation is solved.
+        m_enthalpy = m_thermo->enthalpy_mass();
+        m_intEnergy = m_thermo->intEnergy_mass();
+    }
     m_mass = m_thermo->density() * m_vol;
 }
 

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -1140,9 +1140,23 @@ class TestMoleReactor(TestReactor):
     def test_tolerances(self, rtol_lim=1e-8, atol_lim=1e-18):
         super().test_tolerances(rtol_lim, atol_lim)
 
+class TestIdealGasMoleReactor(TestReactor):
+    reactorClass = ct.IdealGasMoleReactor
+
+    def test_plasma_reactor(self):
+        plasma = ct.Solution('oxygen-plasma.yaml', transport_model=None)
+        # Use PlasmaPhase for this reactor should throw the error below
+        with pytest.raises(ct.CanteraError, match="Incompatible phase type provided"):
+            self.reactorClass(plasma, energy='off')
+
 class TestIdealGasReactor(TestReactor):
     reactorClass = ct.IdealGasReactor
 
+    def test_plasma_reactor(self):
+        plasma = ct.Solution('oxygen-plasma.yaml', transport_model=None)
+        # Use PlasmaPhase for this reactor should throw the error below
+        with pytest.raises(ct.CanteraError, match="Incompatible phase type provided"):
+            self.reactorClass(plasma, energy='off')
 
 class TestWellStirredReactorIgnition:
     """ Ignition (or not) of a well-stirred reactor """


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

This change fix the Reactor and ReactorBase so more phase can use reactor in the future. I also make the error message "incompatible phase type provided" visible. We can have more discussion on this and figure out the better solution if needed.

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- When the phase is not compatible with the reactor, setThermo triggers the destruction of the reactorBase object which calls removeSpecieslocks(). Looking at ReactorBase::setSolution, the lock is already removed from at line 56. This makes  removeSpecieslocks() throw the error. Therefore, I think it is better to check whether locks exist before we remove it. 
- For phase like PlasmaPhase, intEnergy_mass is not implemented yet, but we should allow them into a reactor if the energy equation is disabled. Therefore, In setThermo, the assignment of those properties are moved into a try block. (the m_energy is not initiated yet so I use try instead)
- Similarly, I put a guard using m_energy for syncState.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
