### PR TITLE
Fix CI broken by change in wheel name generated by setuptools

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -134,7 +134,7 @@ jobs:
     - name: Save the wheel file to install Cantera
       uses: actions/upload-artifact@v4
       with:
-        path: build/python/dist/Cantera*.whl
+        path: build/python/dist/cantera*.whl
         retention-days: 2
         name: cantera-wheel-${{ matrix.python-version }}-${{ matrix.os }}
         if-no-files-found: error
@@ -869,8 +869,8 @@ jobs:
     - name: Upload Wheel
       uses: actions/upload-artifact@v4
       with:
-        path: build\python\dist\Cantera*.whl
-        name: Cantera-win_amd64.whl
+        path: build\python\dist\cantera*.whl
+        name: cantera-win_amd64.whl
         retention-days: 2
     - name: Build Tests
       run: scons -j4 build-tests --debug=time


### PR DESCRIPTION
Setuptools 75.3.1 changed the wheel file naming convention such that it is now all lowercase.

See this PR: https://github.com/pypa/setuptools/pull/4766.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**If applicable, fill in the issue number this pull request is fixing**

Fixes recent CI failures.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
