### PR TITLE
Update ReactorSurface / generalize ReactorBase

### DIFF
--- a/include/cantera/clib/ctreactor.h
+++ b/include/cantera/clib/ctreactor.h
@@ -76,15 +76,9 @@ extern "C" {
     CANTERA_CAPI int wall_setVelocity(int i, int n);
     CANTERA_CAPI int wall_setEmissivity(int i, double epsilon);
 
-    CANTERA_CAPI int reactorsurface_new(const char* name);
-    CANTERA_CAPI int reactorsurface_del(int i);
-    CANTERA_CAPI int reactorsurface_name(int i, int len, char* nbuf);
-    CANTERA_CAPI int reactorsurface_setName(int i, const char* name);
     CANTERA_CAPI int reactorsurface_install(int i, int n);
-    CANTERA_CAPI int reactorsurface_setkinetics(int i, int n);
     CANTERA_CAPI double reactorsurface_area(int i);
     CANTERA_CAPI int reactorsurface_setArea(int i, double v);
-    CANTERA_CAPI int reactorsurface_addSensitivityReaction(int i, int rxn);
 
     CANTERA_CAPI int ct_clearReactors();
 

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -145,13 +145,11 @@ public:
     //! Set the state of the reactor to correspond to the state vector *y*.
     virtual void updateState(double* y);
 
-    //! Number of sensitivity parameters associated with this reactor
+    //! Number of sensitivity parameters associated with this reactor.
     //! (including walls)
-    virtual size_t nSensParams() const;
+    size_t nSensParams() const override;
 
-    //! Add a sensitivity parameter associated with the reaction number *rxn*
-    //! (in the homogeneous phase).
-    virtual void addSensitivityReaction(size_t rxn);
+    void addSensitivityReaction(size_t rxn) override;
 
     //! Add a sensitivity parameter associated with the enthalpy formation of
     //! species *k* (in the homogeneous phase)
@@ -286,9 +284,6 @@ protected:
     size_t m_nv_surf; //!!< Number of variables associated with reactor surfaces
 
     vector<double> m_advancelimits; //!< Advance step limit
-
-    // Data associated each sensitivity parameter
-    vector<SensitivityParameter> m_sensParams;
 
     //! Vector of triplets representing the jacobian
     vector<Eigen::Triplet<double>> m_jac_trips;

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -276,7 +276,6 @@ protected:
 
     double m_Qdot = 0.0; //!< net heat transfer into the reactor, through walls [W]
 
-    double m_mass = 0.0; //!< total mass
     vector<double> m_work;
 
     //! Production rates of gas phase species on surfaces [kmol/s]

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -226,6 +226,8 @@ public:
     virtual bool preconditionerSupported() const {return false;};
 
 protected:
+    //! @deprecated To be removed after %Cantera 3.2. Use constructor with
+    //!     Solution object instead.
     void setKinetics(Kinetics& kin) override;
 
     //! Return the index in the solution vector for this reactor of the species

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -66,6 +66,10 @@ public:
         return true;
     }
 
+    void setInitialVolume(double vol) override {
+        m_vol = vol;
+    }
+
     void setChemistry(bool cflag=true) override {
         m_chem = cflag;
     }

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -104,10 +104,10 @@ public:
     }
 
     //! Connect an inlet FlowDevice to this reactor
-    void addInlet(FlowDevice& inlet);
+    virtual void addInlet(FlowDevice& inlet);
 
     //! Connect an outlet FlowDevice to this reactor
-    void addOutlet(FlowDevice& outlet);
+    virtual void addOutlet(FlowDevice& outlet);
 
     //! Return a reference to the *n*-th inlet FlowDevice connected to this
     //! reactor.
@@ -139,7 +139,7 @@ public:
      *  this reactor is to the right of the wall. This method is called
      *  automatically for both the left and right reactors by WallBase::install.
      */
-    void addWall(WallBase& w, int lr);
+    virtual void addWall(WallBase& w, int lr);
 
     //! Return a reference to the *n*-th Wall connected to this reactor.
     WallBase& wall(size_t n);

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -236,7 +236,7 @@ public:
 
     //! Returns the mass (kg) of the reactor's contents.
     double mass() const {
-        return m_vol * density();
+        return m_mass;
     }
 
     //! Return the vector of species mass fractions.
@@ -295,6 +295,7 @@ protected:
 
     ThermoPhase* m_thermo = nullptr;
     double m_vol = 0.0; //!< Current volume of the reactor [m^3]
+    double m_mass = 0.0; //!< Current mass of the reactor [kg]
     double m_enthalpy = 0.0; //!< Current specific enthalpy of the reactor [J/kg]
     double m_intEnergy = 0.0; //!< Current internal energy of the reactor [J/kg]
     double m_pressure = 0.0; //!< Current pressure in the reactor [Pa]

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -40,9 +40,9 @@ struct SensitivityParameter
 };
 
 /**
- * Base class for stirred reactors. Allows using any substance model, with
- * arbitrary inflow, outflow, heat loss/gain, surface chemistry, and volume
- * change.
+ * Base class for reactor objects. Allows using any substance model, with arbitrary
+ * inflow, outflow, heat loss/gain, surface chemistry, and volume change, whenever
+ * defined.
  * @ingroup reactorGroup
  */
 class ReactorBase
@@ -109,12 +109,10 @@ public:
     //! Connect an outlet FlowDevice to this reactor
     virtual void addOutlet(FlowDevice& outlet);
 
-    //! Return a reference to the *n*-th inlet FlowDevice connected to this
-    //! reactor.
+    //! Return a reference to the *n*-th inlet FlowDevice connected to this reactor.
     FlowDevice& inlet(size_t n = 0);
 
-    //! Return a reference to the *n*-th outlet FlowDevice connected to this
-    //! reactor.
+    //! Return a reference to the *n*-th outlet FlowDevice connected to this reactor.
     FlowDevice& outlet(size_t n = 0);
 
     //! Return the number of inlet FlowDevice objects connected to this reactor.
@@ -122,8 +120,7 @@ public:
         return m_inlet.size();
     }
 
-    //! Return the number of outlet FlowDevice objects connected to this
-    //! reactor.
+    //! Return the number of outlet FlowDevice objects connected to this reactor.
     size_t nOutlets() {
         return m_outlet.size();
     }
@@ -146,8 +143,7 @@ public:
 
     virtual void addSurface(ReactorSurface* surf);
 
-    //! Return a reference to the *n*-th ReactorSurface connected to this
-    //! reactor
+    //! Return a reference to the *n*-th ReactorSurface connected to this reactor.
     ReactorSurface* surface(size_t n);
 
     //! Return the number of surfaces in a reactor

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -87,9 +87,10 @@ public:
     //! @name Methods to set up a simulation
     //! @{
 
-    //! Set the initial reactor volume. By default, the volume is 1.0 m^3.
-    void setInitialVolume(double vol) {
-        m_vol = vol;
+    //! Set the initial reactor volume.
+    virtual void setInitialVolume(double vol) {
+        throw NotImplementedError("ReactorBase::setInitialVolume",
+            "Volume is undefined for reactors of type '{}'.", type());
     }
 
     //! Enable or disable changes in reactor composition due to chemical reactions.
@@ -297,7 +298,7 @@ protected:
     size_t m_nsp = 0;
 
     ThermoPhase* m_thermo = nullptr;
-    double m_vol = 1.0; //!< Current volume of the reactor [m^3]
+    double m_vol = 0.0; //!< Current volume of the reactor [m^3]
     double m_enthalpy = 0.0; //!< Current specific enthalpy of the reactor [J/kg]
     double m_intEnergy = 0.0; //!< Current internal energy of the reactor [J/kg]
     double m_pressure = 0.0; //!< Current pressure in the reactor [Pa]

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -287,6 +287,8 @@ protected:
 
     //! Specify the kinetics manager for the reactor. Called by setSolution().
     //! @since New in %Cantera 3.1.
+    //! @deprecated  To be removed after %Cantera 3.2. Superseded by instantiation of
+    //!              ReactorBase with Solution object.
     virtual void setKinetics(Kinetics& kin) {
         throw NotImplementedError("ReactorBase::setKinetics");
     }

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -268,6 +268,16 @@ public:
     //! Set the ReactorNet that this reactor belongs to.
     void setNetwork(ReactorNet* net);
 
+    //! Add a sensitivity parameter associated with the reaction number *rxn*
+    virtual void addSensitivityReaction(size_t rxn) {
+        throw NotImplementedError("ReactorBase::addSensitivityReaction");
+    }
+
+    //! Number of sensitivity parameters associated with this reactor.
+    virtual size_t nSensParams() const {
+        return m_sensParams.size();
+    }
+
 protected:
     //! Specify the mixture contained in the reactor. Note that a pointer to
     //! this substance is stored, and as the integration proceeds, the state of
@@ -306,6 +316,9 @@ protected:
 
     //! Composite thermo/kinetics/transport handler
     shared_ptr<Solution> m_solution;
+
+    // Data associated each sensitivity parameter
+    vector<SensitivityParameter> m_sensParams;
 };
 }
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -164,10 +164,13 @@ public:
     //! reactor's current state.
     void restoreState();
 
-    //! Set the state of the reactor to correspond to the state of the
-    //! associated ThermoPhase object. This is the inverse of restoreState().
-    //! Calling this will trigger integrator reinitialization.
-    virtual void syncState();
+    //! Set the state of the reactor to the associated ThermoPhase object.
+    //! This method is the inverse of restoreState() and will trigger integrator
+    //! reinitialization.
+    //! The method needs to be implemented by a ReactorBase specialization.
+    virtual void syncState() {
+        throw NotImplementedError("ReactorBase::syncState");
+    }
 
     //! return a reference to the contents.
     ThermoPhase& contents() {

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -48,6 +48,24 @@ public:
     //!     Solution object instead.
     void setKinetics(Kinetics* kin);
 
+    void addInlet(FlowDevice& inlet) override {
+        throw NotImplementedError("ReactorSurface::addInlet",
+            "Inlets are undefined for reactors of type '{}'.", type());
+    }
+
+    void addOutlet(FlowDevice& outlet) override {
+        throw NotImplementedError("ReactorSurface::addOutlet",
+            "Outlets are undefined for reactors of type '{}'.", type());
+    }
+
+    void addWall(WallBase& w, int lr) override {
+        throw NotImplementedError("ReactorSurface::addWall");
+    }
+
+    void addSurface(ReactorSurface* surf) override {
+        throw NotImplementedError("ReactorSurface::addSurface");
+    }
+
     //! Set the reactor that this Surface interacts with
     void setReactor(ReactorBase* reactor);
 

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -83,6 +83,10 @@ public:
     void resetSensitivityParameters();
 
 protected:
+    //! Methods needed to disambiguate from non-protected variant.
+    //! @since New in %Cantera 3.2.
+    //! @deprecated To be removed after %Cantera 3.2. Use constructor with
+    //!     Solution object instead.
     void setKinetics(Kinetics& kin) override;
 
     double m_area = 1.0;

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -51,12 +51,6 @@ public:
     //! Set the reactor that this Surface interacts with
     void setReactor(ReactorBase* reactor);
 
-    //! Number of sensitivity parameters associated with reactions on this
-    //! surface
-    size_t nSensParams() const {
-        return m_params.size();
-    }
-
     //! Set the surface coverages. Array `cov` has length equal to the number of
     //! surface species.
     void setCoverages(const double* cov);
@@ -76,9 +70,7 @@ public:
     //! of the attached Reactor.
     void syncState() override;
 
-    //! Enable calculation of sensitivities with respect to the rate constant
-    //! for reaction `i`.
-    void addSensitivityReaction(size_t i);
+    void addSensitivityReaction(size_t rxn) override;
 
     //! Set reaction rate multipliers. `params` is the global vector of
     //! sensitivity parameters. This function is called within
@@ -99,7 +91,6 @@ protected:
     Kinetics* m_kinetics = nullptr;
     ReactorBase* m_reactor = nullptr;
     vector<double> m_cov;
-    vector<SensitivityParameter> m_params;
 };
 
 }

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -101,7 +101,9 @@ public:
     void resetSensitivityParameters();
 
 protected:
-    //! Methods needed to disambiguate from non-protected variant.
+    //! Set the InterfaceKinetics object for this surface.
+    //! Method is needed to prevent compiler warnings by disambiguating from the
+    //! non-protected variant.
     //! @since New in %Cantera 3.2.
     //! @deprecated To be removed after %Cantera 3.2. Use constructor with
     //!     Solution object instead.

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -11,36 +11,19 @@
 namespace Cantera
 {
 
-class Kinetics;
 class SurfPhase;
 
 //! A surface where reactions can occur that is in contact with the bulk fluid of a
 //! Reactor.
-class ReactorSurface
+class ReactorSurface : public ReactorBase
 {
 public:
-    ReactorSurface(const string& name="(none)") : m_name(name) {}
-    virtual ~ReactorSurface() = default;
-    ReactorSurface(const ReactorSurface&) = delete;
-    ReactorSurface& operator=(const ReactorSurface&) = delete;
+    using ReactorBase::ReactorBase; // inherit constructors
 
     //! String indicating the wall model implemented.
-    virtual string type() const {
+    string type() const override {
         return "ReactorSurface";
     }
-
-    //! Retrieve reactor surface name.
-    string name() const {
-        return m_name;
-    }
-
-    //! Set reactor surface name.
-    void setName(const string& name) {
-        m_name = name;
-    }
-
-    //! Set the default name of a wall. Returns `false` if it was previously set.
-    bool setDefaultName(map<string, int>& counts);
 
     //! Returns the surface area [m^2]
     double area() const;
@@ -87,7 +70,7 @@ public:
     //! Set the coverages and temperature in the surface phase object to the
     //! values for this surface. The temperature is set to match the bulk phase
     //! of the attached Reactor.
-    void syncState();
+    void syncState() override;
 
     //! Enable calculation of sensitivities with respect to the rate constant
     //! for reaction `i`.
@@ -104,8 +87,7 @@ public:
     void resetSensitivityParameters();
 
 protected:
-    string m_name;  //!< Reactor surface name.
-    bool m_defaultNameSet = false;  //!< `true` if default name has been previously set.
+    void setKinetics(Kinetics& kin) override;
 
     double m_area = 1.0;
 

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -35,7 +35,7 @@ public:
 
     //! Accessor for the SurfPhase object
     SurfPhase* thermo() {
-        return m_thermo;
+        return m_surf;
     }
 
     //! Accessor for the InterfaceKinetics object
@@ -101,6 +101,8 @@ public:
     void resetSensitivityParameters();
 
 protected:
+    void setThermo(ThermoPhase& thermo) override {}
+
     //! Set the InterfaceKinetics object for this surface.
     //! Method is needed to prevent compiler warnings by disambiguating from the
     //! non-protected variant.
@@ -111,7 +113,7 @@ protected:
 
     double m_area = 1.0;
 
-    SurfPhase* m_thermo = nullptr;
+    SurfPhase* m_surf = nullptr;
     Kinetics* m_kinetics = nullptr;
     ReactorBase* m_reactor = nullptr;
     vector<double> m_cov;

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -15,9 +15,11 @@ class SurfPhase;
 
 //! A surface where reactions can occur that is in contact with the bulk fluid of a
 //! Reactor.
+//! @ingroup reactorGroup
 class ReactorSurface : public ReactorBase
 {
 public:
+    ReactorSurface(shared_ptr<Solution> sol, const string& name="(none)");
     using ReactorBase::ReactorBase; // inherit constructors
 
     //! String indicating the wall model implemented.
@@ -42,6 +44,8 @@ public:
     }
 
     //! Set the InterfaceKinetics object for this surface
+    //! @deprecated To be removed after %Cantera 3.2. Use constructor with
+    //!     Solution object instead.
     void setKinetics(Kinetics* kin);
 
     //! Set the reactor that this Surface interacts with

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -25,6 +25,8 @@ public:
     }
 
     void initialize(double t0=0.0) override {}
+
+    void syncState() override {}
 };
 
 }

--- a/interfaces/matlab_experimental/Reactor/ReactorSurface.m
+++ b/interfaces/matlab_experimental/Reactor/ReactorSurface.m
@@ -1,4 +1,4 @@
-classdef ReactorSurface < handle
+classdef ReactorSurface < Reactor
     % ReactorSurface Class ::
     %
     %     >> s = ReactorSurface(surf, reactor, name)
@@ -21,13 +21,7 @@ classdef ReactorSurface < handle
     % :return:
     %    Instance of class :mat:class:`ReactorSurface`.
 
-    properties (SetAccess = immutable)
-        surfID
-    end
-
     properties (SetAccess = public)
-        name  % Name of reactor surface.
-
         area % Area of the reactor surface in m^2.
     end
 
@@ -39,62 +33,27 @@ classdef ReactorSurface < handle
 
             ctIsLoaded;
 
-            if ~isa(surf, 'Kinetics') || ~isa(reactor, 'Reactor')
+            if ~isa(surf, 'Solution') || ~isa(reactor, 'Reactor')
                 error('Invalid parameters.')
             end
             if nargin < 3
                 name = '(none)';
             end
 
-            s.surfID = ctFunc('reactorsurface_new', name);
-            ctFunc('reactorsurface_setkinetics', s.surfID, surf.kinID);
-            ctFunc('reactorsurface_install', s.surfID, reactor.id);
-        end
-
-        %% ReactorSurface Class Destructor
-
-        function delete(s)
-            % Delete the :mat:class:`ReactorSurface` object.
-
-            if isempty(s.surfID)
-                return
-            end
-            ctFunc('reactorsurface_del', s.surfID);
-        end
-
-        %% ReactorSurface Utility Methods
-
-        function addSensitivityReaction(s, m)
-            % Specifies that the sensitivity of the state variables with
-            % respect to reaction m should be computed. The surface must be
-            % installed on a reactor and part of a network first. ::
-            %
-            %     >> s.addSensitivityReaction(m)
-            %
-            % :param m:
-            %    Index number of reaction.
-
-            ctFunc('reactorsurface_addSensitivityReaction', s.surfID, m);
+            s.surfID = ctFunc('reactor_new', 'ReactorSurface', surf.solnID, name);
+            ctFunc('reactorsurface_install', s.id, reactor.id);
         end
 
         %% ReactorSurface Get Methods
 
-        function name = get.name(s)
-            name = ctString('reactorsurface_name', s.surfID);
-        end
-
         function a = get.area(s)
-            a = ctFunc('reactorsurface_area', s.surfID);
+            a = ctFunc('reactorsurface_area', s.id);
         end
 
         %% ReactorSurface Set Methods
 
-        function set.name(s, name)
-            ctFunc('reactorsurface_setName', s.surfID, name);
-        end
-
         function set.area(s, a)
-            ctFunc('reactorsurface_setArea', s.surfID, a);
+            ctFunc('reactorsurface_setArea', s.id, a);
         end
 
     end

--- a/interfaces/sourcegen/sourcegen/csharp/config.yaml
+++ b/interfaces/sourcegen/sourcegen/csharp/config.yaml
@@ -45,6 +45,7 @@ derived_handles:
   SurfaceHandle: ThermoPhaseHandle
   WallHandle: ConnectorHandle
   FlowDeviceHandle: ConnectorHandle
+  ReactorSurfaceHandle: ReactorHandle
 
 # Provides info for scaffolding higher-level idiomatic C# classes
 # At this stage, we can scaffold simple properties that follow the

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -24,12 +24,10 @@ typedef Cabinet<Func1> FuncCabinet;
 typedef Cabinet<ThermoPhase> ThermoCabinet;
 typedef Cabinet<Kinetics> KineticsCabinet;
 typedef Cabinet<Solution> SolutionCabinet;
-typedef Cabinet<ReactorSurface> ReactorSurfaceCabinet;
 
 template<> ReactorCabinet* ReactorCabinet::s_storage = 0;
 template<> NetworkCabinet* NetworkCabinet::s_storage = 0;
 template<> ConnectorCabinet* ConnectorCabinet::s_storage = 0;
-template<> ReactorSurfaceCabinet* ReactorSurfaceCabinet::s_storage = 0;
 template<> FuncCabinet* FuncCabinet::s_storage; // defined in ctfunc.cpp
 template<> ThermoCabinet* ThermoCabinet::s_storage; // defined in ct.cpp
 template<> KineticsCabinet* KineticsCabinet::s_storage; // defined in ct.cpp
@@ -576,59 +574,10 @@ extern "C" {
 
     // ReactorSurface
 
-    int reactorsurface_new(const char* name)
-    {
-        try {
-            return ReactorSurfaceCabinet::add(make_shared<ReactorSurface>(name));
-        } catch (...) {
-            return handleAllExceptions(-1, ERR);
-        }
-    }
-
-    int reactorsurface_del(int i)
-    {
-        try {
-            ReactorSurfaceCabinet::del(i);
-            return 0;
-        } catch (...) {
-            return handleAllExceptions(-1, ERR);
-        }
-    }
-
-    int reactorsurface_name(int i, int len, char* nbuf)
-    {
-        try {
-            return static_cast<int>(
-                copyString(ReactorSurfaceCabinet::at(i)->name(), nbuf, len));
-        } catch (...) {
-            return handleAllExceptions(-1, ERR);
-        }
-    }
-
-    int reactorsurface_setName(int i, const char* name)
-    {
-        try {
-            ReactorSurfaceCabinet::at(i)->setName(name);
-            return 0;
-        } catch (...) {
-            return handleAllExceptions(-1, ERR);
-        }
-    }
-
     int reactorsurface_install(int i, int n)
     {
         try {
-            ReactorCabinet::at(n)->addSurface(ReactorSurfaceCabinet::at(i).get());
-            return 0;
-        } catch (...) {
-            return handleAllExceptions(-1, ERR);
-        }
-    }
-
-    int reactorsurface_setkinetics(int i, int n)
-    {
-        try {
-            ReactorSurfaceCabinet::at(i)->setKinetics(KineticsCabinet::at(n).get());
+            ReactorCabinet::at(n)->addSurface(ReactorCabinet::as<ReactorSurface>(i).get());
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -638,7 +587,7 @@ extern "C" {
     double reactorsurface_area(int i)
     {
         try {
-            return ReactorSurfaceCabinet::at(i)->area();
+            return ReactorCabinet::as<ReactorSurface>(i)->area();
         } catch (...) {
             return handleAllExceptions(DERR, DERR);
         }
@@ -647,17 +596,7 @@ extern "C" {
     int reactorsurface_setArea(int i, double v)
     {
         try {
-            ReactorSurfaceCabinet::at(i)->setArea(v);
-            return 0;
-        } catch (...) {
-            return handleAllExceptions(-1, ERR);
-        }
-    }
-
-    int reactorsurface_addSensitivityReaction(int i, int rxn)
-    {
-        try {
-            ReactorSurfaceCabinet::at(i)->addSensitivityReaction(rxn);
+            ReactorCabinet::as<ReactorSurface>(i)->setArea(v);
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);
@@ -670,7 +609,6 @@ extern "C" {
             ReactorCabinet::clear();
             NetworkCabinet::clear();
             ConnectorCabinet::clear();
-            ReactorSurfaceCabinet::clear();
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -184,7 +184,7 @@ void FlowReactor::initialize(double t0)
 
 void FlowReactor::syncState()
 {
-    ReactorBase::syncState();
+    Reactor::syncState();
     m_rho = m_thermo->density();
     m_P = m_thermo->pressure();
     m_T = m_thermo->temperature();

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -130,8 +130,14 @@ size_t Reactor::nSensParams() const
 
 void Reactor::syncState()
 {
-    ReactorBase::syncState();
+    m_thermo->saveState(m_state);
+    m_enthalpy = m_thermo->enthalpy_mass();
+    m_intEnergy = m_thermo->intEnergy_mass();
+    m_pressure = m_thermo->pressure();
     m_mass = m_thermo->density() * m_vol;
+    if (m_net) {
+        m_net->setNeedsReinit();
+    }
 }
 
 void Reactor::updateState(double* y)

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -131,8 +131,10 @@ size_t Reactor::nSensParams() const
 void Reactor::syncState()
 {
     m_thermo->saveState(m_state);
-    m_enthalpy = m_thermo->enthalpy_mass();
-    m_intEnergy = m_thermo->intEnergy_mass();
+    if (m_energy) {
+        m_enthalpy = m_thermo->enthalpy_mass();
+        m_intEnergy = m_thermo->intEnergy_mass();
+    }
     m_pressure = m_thermo->pressure();
     m_mass = m_thermo->density() * m_vol;
     if (m_net) {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -25,7 +25,12 @@ namespace Cantera
 Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
     : ReactorBase(sol, name)
 {
-    setKinetics(*sol->kinetics());
+    m_kin = sol->kinetics().get();
+    if (m_kin->nReactions() == 0) {
+        setChemistry(false);
+    } else {
+        setChemistry(true);
+    }
 }
 
 void Reactor::setDerivativeSettings(AnyMap& settings)
@@ -39,6 +44,9 @@ void Reactor::setDerivativeSettings(AnyMap& settings)
 
 void Reactor::setKinetics(Kinetics& kin)
 {
+    warn_deprecated("Reactor::setKinetics",
+        "After Cantera 3.2, a change of reactor contents after instantiation "
+        "will be disabled.");
     m_kin = &kin;
     if (m_kin->nReactions() == 0) {
         setChemistry(false);

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -31,6 +31,7 @@ Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
     } else {
         setChemistry(true);
     }
+    m_vol = 1.0; // By default, the volume is set to 1.0 m^3.
 }
 
 void Reactor::setDerivativeSettings(AnyMap& settings)

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -76,20 +76,9 @@ void ReactorBase::setThermo(ThermoPhase& thermo)
     m_thermo = &thermo;
     m_nsp = m_thermo->nSpecies();
     m_thermo->saveState(m_state);
-    m_enthalpy = m_thermo->enthalpy_mass();
+    m_enthalpy = m_thermo->enthalpy_mass(); // Used by Reservoir
     m_intEnergy = m_thermo->intEnergy_mass();
-    m_pressure = m_thermo->pressure();
-}
-
-void ReactorBase::syncState()
-{
-    m_thermo->saveState(m_state);
-    m_enthalpy = m_thermo->enthalpy_mass();
-    m_intEnergy = m_thermo->intEnergy_mass();
-    m_pressure = m_thermo->pressure();
-    if (m_net) {
-        m_net->setNeedsReinit();
-    }
+    m_pressure = m_thermo->pressure(); // Used by Reservoir
 }
 
 void ReactorBase::addInlet(FlowDevice& inlet)

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -25,13 +25,8 @@ ReactorBase::ReactorBase(shared_ptr<Solution> sol, const string& name)
                            "Missing or incomplete Solution object.");
     }
     m_solution = sol;
-    setThermo(*sol->thermo());
-    try {
-        setKinetics(*sol->kinetics());
-    } catch (NotImplementedError&) {
-        // kinetics not used (example: Reservoir)
-    }
     m_solution->thermo()->addSpeciesLock();
+    setThermo(*sol->thermo());
 }
 
 ReactorBase::~ReactorBase()
@@ -67,13 +62,13 @@ void ReactorBase::setSolution(shared_ptr<Solution> sol)
         m_solution->thermo()->removeSpeciesLock();
     }
     m_solution = sol;
+    m_solution->thermo()->addSpeciesLock();
     setThermo(*sol->thermo());
     try {
         setKinetics(*sol->kinetics());
     } catch (NotImplementedError&) {
         // kinetics not used (example: Reservoir)
     }
-    m_solution->thermo()->addSpeciesLock();
 }
 
 void ReactorBase::setThermo(ThermoPhase& thermo)

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -76,9 +76,13 @@ void ReactorBase::setThermo(ThermoPhase& thermo)
     m_thermo = &thermo;
     m_nsp = m_thermo->nSpecies();
     m_thermo->saveState(m_state);
-    m_enthalpy = m_thermo->enthalpy_mass(); // Used by Reservoir
-    m_intEnergy = m_thermo->intEnergy_mass();
-    m_pressure = m_thermo->pressure(); // Used by Reservoir
+    m_enthalpy = m_thermo->enthalpy_mass(); // Needed for flow and wall interactions
+    m_pressure = m_thermo->pressure(); // Needed for flow and wall interactions
+    try {
+        m_intEnergy = m_thermo->intEnergy_mass();
+    } catch (NotImplementedError&) {
+        // some ThermoPhase objects do not implement intEnergy_mass()
+    }
 }
 
 void ReactorBase::addInlet(FlowDevice& inlet)

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -78,6 +78,9 @@ ReactorFactory::ReactorFactory()
     reg("MoleReactor",
         [](shared_ptr<Solution> sol, const string& name)
         { return new MoleReactor(sol, name); });
+    reg("ReactorSurface",
+        [](shared_ptr<Solution> sol, const string& name)
+        { return new ReactorSurface(sol, name); });
 }
 
 ReactorFactory* ReactorFactory::factory() {

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -74,7 +74,7 @@ void ReactorSurface::setKinetics(Kinetics* kin)
 
 void ReactorSurface::setKinetics(Kinetics& kin)
 {
-    throw NotImplementedError("ReactorSurface::setKinetics");
+    setKinetics(&kin);
 }
 
 void ReactorSurface::setReactor(ReactorBase* reactor)

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -12,19 +12,6 @@
 namespace Cantera
 {
 
-bool ReactorSurface::setDefaultName(map<string, int>& counts)
-{
-    if (m_defaultNameSet) {
-        return false;
-    }
-    m_defaultNameSet = true;
-    if (m_name == "(none)" || m_name == "") {
-        m_name = fmt::format("{}_{}", type(), counts[type()]);
-    }
-    counts[type()]++;
-    return true;
-}
-
 double ReactorSurface::area() const
 {
     return m_area;
@@ -35,7 +22,8 @@ void ReactorSurface::setArea(double a)
     m_area = a;
 }
 
-void ReactorSurface::setKinetics(Kinetics* kin) {
+void ReactorSurface::setKinetics(Kinetics* kin)
+{
     m_kinetics = kin;
     if (kin == nullptr) {
         m_thermo = nullptr;
@@ -50,6 +38,11 @@ void ReactorSurface::setKinetics(Kinetics* kin) {
     }
     m_cov.resize(m_thermo->nSpecies());
     m_thermo->getCoverages(m_cov.data());
+}
+
+void ReactorSurface::setKinetics(Kinetics& kin)
+{
+    throw NotImplementedError("ReactorSurface::setKinetics");
 }
 
 void ReactorSurface::setReactor(ReactorBase* reactor)

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -110,21 +110,21 @@ void ReactorSurface::syncState()
     m_thermo->setCoveragesNoNorm(m_cov.data());
 }
 
-void ReactorSurface::addSensitivityReaction(size_t i)
+void ReactorSurface::addSensitivityReaction(size_t rxn)
 {
-    if (i >= m_kinetics->nReactions()) {
+    if (rxn >= m_kinetics->nReactions()) {
         throw CanteraError("ReactorSurface::addSensitivityReaction",
-                           "Reaction number out of range ({})", i);
+                           "Reaction number out of range ({})", rxn);
     }
     size_t p = m_reactor->network().registerSensitivityParameter(
-        m_kinetics->reaction(i)->equation(), 1.0, 1.0);
-    m_params.emplace_back(
-        SensitivityParameter{i, p, 1.0, SensParameterType::reaction});
+        m_kinetics->reaction(rxn)->equation(), 1.0, 1.0);
+    m_sensParams.emplace_back(
+        SensitivityParameter{rxn, p, 1.0, SensParameterType::reaction});
 }
 
 void ReactorSurface::setSensitivityParameters(const double* params)
 {
-    for (auto& p : m_params) {
+    for (auto& p : m_sensParams) {
         p.value = m_kinetics->multiplier(p.local);
         m_kinetics->setMultiplier(p.local, p.value*params[p.global]);
     }
@@ -132,7 +132,7 @@ void ReactorSurface::setSensitivityParameters(const double* params)
 
 void ReactorSurface::resetSensitivityParameters()
 {
-    for (auto& p : m_params) {
+    for (auto& p : m_sensParams) {
         m_kinetics->setMultiplier(p.local, p.value);
     }
 }


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR pulls in suggestions from #1788, while trying to avoid unnecessary churn. 

* `ReactorSurface` is now a specialization of `ReactorBase`
* Propagate changes to all APIs (Python, CLib and MATLAB)
* Clarify ambiguous definitions that may apply in non-physical or undefined contexts (e.g., setting volume on a `Reservoir`)
* Adopt some fixes from #1860 that touch the same lines

Changes are made in anticipation of the experimental CLib zeroD interface per Cantera/enhancements#220; other references are Cantera/enhancements#202 and Cantera/enhancements#61.

The resulting inheritance diagram is:
<img width="906" alt="image" src="https://github.com/user-attachments/assets/15b7f2ed-e6b7-4f60-b49f-8da9ed5cf130" />

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes Cantera/enhancements#213

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
