### PR TITLE
[docs] Add link to 3.1 C++ documentation

### DIFF
--- a/doc/doxygen/versions.md
+++ b/doc/doxygen/versions.md
@@ -4,14 +4,27 @@
 > interface documentation, refer to
 > [cantera.org](https://cantera.org/stable/reference/index.html).
 
-**%Cantera C++ API** versions:
+**%Cantera C++ API Documentation**
 
-* [dev/latest](https://cantera.org/dev/cxx/index.html) (unstable)
-* [v3.0.0](https://cantera.org/3.0/doxygen/html/index.html)
-* [v2.6.0](https://cantera.org/2.6/doxygen/html/modules.html)
-* [v2.5.1](https://cantera.org/2.5/doxygen/html/modules.html)
-* [v2.4.0](https://cantera.org/2.4/doxygen/html/modules.html)
-* [v2.3.0](https://cantera.org/2.3/doxygen/html/modules.html)
-* [v2.2.1](https://cantera.org/2.2/doxygen/html/modules.html)
-* [v2.1.2](https://cantera.org/2.1/doxygen/html/modules.html)
-* [v2.0.2](https://cantera.org/2.0/doxygen/html/modules.html)
+| Version | Status | Release Date |
+|---------|--------|--------------|
+| [dev/latest](https://cantera.org/dev/cxx/index.html) | unstable | -- |
+| [v3.1.0](https://cantera.org/stable/cxx/index.html) | stable |*December 2024* |
+| [v3.0.0](https://cantera.org/3.0/doxygen/html/index.html) | legacy | *August 2023* |
+| [v2.6.0](https://cantera.org/2.6/doxygen/html/modules.html) | archived | *May 2022* |
+| [v2.5.1](https://cantera.org/2.5/doxygen/html/modules.html) | archived | *February 2021* |
+| [v2.4.0](https://cantera.org/2.4/doxygen/html/modules.html) | archived | *August 2018* |
+| [v2.3.0](https://cantera.org/2.3/doxygen/html/modules.html) | archived | *January 2017* |
+| [v2.2.1](https://cantera.org/2.2/doxygen/html/modules.html) | archived | *January 2016* |
+| [v2.1.2](https://cantera.org/2.1/doxygen/html/modules.html) | archived | *September 2014* |
+| [v2.0.2](https://cantera.org/2.0/doxygen/html/modules.html) | archived | *March 2013* |
+| v1.7.0 | archived | *November 2006* |
+| v1.6.0 | archived | *June 2005* |
+| v1.5.5 | archived | *December 2004* |
+| v1.4 | archived | *April 2003* |
+
+**%Cantera Sources:**
+
+* v2.4.0 and newer: Releases are accessible via [GitHub](https://github.com/Cantera/cantera/releases).
+* v1.4 to v2.3.0: Releases are archived on %Cantera's former [SourceForge site](https://sourceforge.net/projects/cantera/).
+* v1.5.5 and newer: `git` tags can be accessed, for example via [GitHub](https://github.com/Cantera/cantera/tags).


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

Add missing link to C++ documentation for Cantera 3.1. 

Also, reformat release information as a table and add information about access to Cantera sources.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

~Relates to Cantera/cantera-website#267~ _PS: overlooked a link._

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
