### PR TITLE
Fix ck2yaml handling of unnamed surfaces

### DIFF
--- a/interfaces/cython/cantera/ck2yaml.py
+++ b/interfaces/cython/cantera/ck2yaml.py
@@ -1721,11 +1721,12 @@ class Parser:
         # First line contains optional parameters, followed by species declarations
         tokens = lines[0,2].split() or ['']
         self.current_range = [lines[0,0]] * 2
-        if '/' in tokens[0]:
-            surf_name = tokens[0].split('/')[1]
+        if tokens[0].startswith('/'):
+            surf_name = tokens[0].strip('/')
+            tokens = tokens[1:]
         else:
             surf_name = 'surface{}'.format(len(self.surfaces)+1)
-        tokens = tokens[1:]
+
         site_density = None
         for token in tokens[:]:
             if token.upper().startswith('SDEN/'):

--- a/test/data/surface2.inp
+++ b/test/data/surface2.inp
@@ -1,4 +1,4 @@
-SITE/PT_SURFACE/    SDEN/2.72E-9/
+SITE       SDEN/2.72E-9/
 _Pt_ H_Pt O2_Pt/3/ H2O_Pt OH_Pt O_Pt
 
 

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -635,13 +635,14 @@ class Testck2yaml:
 
     def test_surface_mech3(self):
         # This tests the case where the thermo data for both the gas and surface are
-        # combined in a file separate from the gas and surface definitions.
+        # combined in a file separate from the gas and surface definitions. Also covers
+        # the case where the surface does not have a name specified.
 
         output = self.convert('surface2-gas.inp', thermo='surface2-thermo.dat',
                               surface='surface2.inp', output='surface2')
         captured = self._capsys.readouterr()
         assert "SITE section implicitly ended" in captured.out
-        surf = ct.Interface(output, 'PT_SURFACE')
+        surf = ct.Interface(output, 'surface1')
 
         assert surf.n_species == 6
         assert surf.n_reactions ==  15


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix `ck2yaml`'s handling of surface phase definitions that don't provide a name

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1845

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
