### PR TITLE
Experimental CLib zeroD API

### DIFF
--- a/include/cantera/clib/ct.h
+++ b/include/cantera/clib/ct.h
@@ -187,6 +187,7 @@ extern "C" {
     CANTERA_CAPI int ct_getCanteraVersion(int buflen, char* buf);
     CANTERA_CAPI int ct_getGitCommit(int buflen, char* buf);
     CANTERA_CAPI int ct_suppress_thermo_warnings(int suppress);
+    CANTERA_CAPI int ct_suppress_deprecation_warnings(int suppress);
     CANTERA_CAPI int ct_use_legacy_rate_constants(int legacy);
     CANTERA_CAPI int ct_clearStorage();
     CANTERA_CAPI int ct_resetStorage();

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -42,9 +42,32 @@ public:
         }
     }
 
-    //! Update the mass flow rate at time 'time'. This must be overloaded in
-    //! subclasses to update m_mdot.
+    //! Update the mass flow rate at time 'time'.
+    //! This must be overloaded in derived classes to update m_mdot.
     virtual void updateMassFlowRate(double time) {}
+
+    //! Set the fixed mass flow rate (kg/s) through a flow device.
+    virtual void setMassFlowRate(double mdot) {
+        throw NotImplementedError("FlowDevice::setMassFlowRate");
+    }
+
+    //! Get the device coefficient (defined by derived class).
+    //! @since  New in %Cantera 3.2.
+    double deviceCoefficient() {
+        return m_coeff;
+    }
+
+    //! Set the device coefficient (defined by derived class).
+    //! @since  New in %Cantera 3.2.
+    void setDeviceCoefficient(double c) {
+        m_coeff = c;
+    }
+
+    //! Set the primary mass flow controller.
+    //! @since New in %Cantera 3.2.
+    virtual void setPrimary(shared_ptr<ConnectorNode> primary) {
+        throw NotImplementedError("FlowDevice::setPrimary");
+    }
 
     //! Mass flow rate (kg/s) of outlet species k. Returns zero if this species
     //! is not present in the upstream mixture.

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -53,7 +53,7 @@ public:
 
     //! Get the device coefficient (defined by derived class).
     //! @since  New in %Cantera 3.2.
-    double deviceCoefficient() {
+    double deviceCoefficient() const {
         return m_coeff;
     }
 
@@ -117,7 +117,7 @@ public:
     //! Set a function of pressure that is used in determining the
     //! mass flow rate through the device. The evaluation of mass flow
     //! depends on the derived flow device class.
-    //! @deprecated  To be removed after Cantera 3.2. Replaceable by version using
+    //! @deprecated  To be removed after %Cantera 3.2. Replaceable by version using
     //!     shared pointer.
     virtual void setPressureFunction(Func1* f);
 
@@ -125,7 +125,7 @@ public:
     //! Set a function of pressure that is used in determining the
     //! mass flow rate through the device. The evaluation of mass flow
     //! depends on the derived flow device class.
-    //! @since  Changed in %Cantera 3.2.
+    //! @since  Changed in %Cantera 3.2. Previous version used a raw pointer.
     virtual void setPressureFunction(shared_ptr<Func1> f) {
         m_pfunc = f.get();
     }
@@ -142,7 +142,7 @@ public:
     //! Set a function of time that is used in determining
     //! the mass flow rate through the device. The evaluation of mass flow
     //! depends on the derived flow device class.
-    //! @deprecated  To be removed after Cantera 3.2. Replaceable by version using
+    //! @deprecated  To be removed after %Cantera 3.2. Replaceable by version using
     //!     shared pointer.
     virtual void setTimeFunction(Func1* g);
 
@@ -150,7 +150,7 @@ public:
     //! Set a function of time that is used in determining
     //! the mass flow rate through the device. The evaluation of mass flow
     //! depends on the derived flow device class.
-    //! @since  Changed in %Cantera 3.2.
+    //! @since  Changed in %Cantera 3.2. Previous version used a raw pointer.
     virtual void setTimeFunction(shared_ptr<Func1> g) {
         m_tfunc = g.get();
     }

--- a/include/cantera/zeroD/FlowDevice.h
+++ b/include/cantera/zeroD/FlowDevice.h
@@ -117,7 +117,18 @@ public:
     //! Set a function of pressure that is used in determining the
     //! mass flow rate through the device. The evaluation of mass flow
     //! depends on the derived flow device class.
+    //! @deprecated  To be removed after Cantera 3.2. Replaceable by version using
+    //!     shared pointer.
     virtual void setPressureFunction(Func1* f);
+
+    //! Set a function of pressure to modify the pressure response.
+    //! Set a function of pressure that is used in determining the
+    //! mass flow rate through the device. The evaluation of mass flow
+    //! depends on the derived flow device class.
+    //! @since  Changed in %Cantera 3.2.
+    virtual void setPressureFunction(shared_ptr<Func1> f) {
+        m_pfunc = f.get();
+    }
 
     //! Return current value of the time function.
     /*!
@@ -131,7 +142,18 @@ public:
     //! Set a function of time that is used in determining
     //! the mass flow rate through the device. The evaluation of mass flow
     //! depends on the derived flow device class.
+    //! @deprecated  To be removed after Cantera 3.2. Replaceable by version using
+    //!     shared pointer.
     virtual void setTimeFunction(Func1* g);
+
+    //! Set a function of time to modulate the mass flow rate.
+    //! Set a function of time that is used in determining
+    //! the mass flow rate through the device. The evaluation of mass flow
+    //! depends on the derived flow device class.
+    //! @since  Changed in %Cantera 3.2.
+    virtual void setTimeFunction(shared_ptr<Func1> g) {
+        m_tfunc = g.get();
+    }
 
     //! Set current reactor network time
     /*!

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -143,6 +143,9 @@ public:
 
     virtual void addSurface(ReactorSurface* surf);
 
+    //! Add a ReactorSurface object to a Reactor object.
+    void addSurface(shared_ptr<ReactorBase> surf);
+
     //! Return a reference to the *n*-th ReactorSurface connected to this reactor.
     ReactorSurface* surface(size_t n);
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -141,6 +141,7 @@ public:
     //! Return a reference to the *n*-th Wall connected to this reactor.
     WallBase& wall(size_t n);
 
+    //! Add a ReactorSurface object to a Reactor object.
     virtual void addSurface(ReactorSurface* surf);
 
     //! Add a ReactorSurface object to a Reactor object.

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -12,6 +12,9 @@
 namespace Cantera
 {
 
+class Reactor;
+class Reservoir;
+
 //! Factory class to create reactor objects
 //!
 //! This class is mainly used via the newReactor() function, for example:
@@ -43,11 +46,28 @@ private:
 //! @ingroup zerodGroup
 //! @{
 
+//! Create a ReactorBase object of the specified type and contents.
+//! @since  New in %Cantera 3.2.
+shared_ptr<ReactorBase> newReactorBase(
+    const string& model, shared_ptr<Solution> contents, const string& name="(none)");
+
 //! Create a Reactor object of the specified type and contents
 //! @since Starting in %Cantera 3.1, this method requires a valid Solution object and
 //!     returns a `shared_ptr<ReactorBase>` instead of a `ReactorBase*`.
+//! @deprecated  Behavior changes after %Cantera 3.2, when a `shared_ptr<Reactor>` will
+//!     be returned. For new behavior, see `newReactor4`.
 shared_ptr<ReactorBase> newReactor(
     const string& model, shared_ptr<Solution> contents, const string& name="(none)");
+
+//! Create a Reactor object of the specified type and contents
+//! @since  New in %Cantera 3.2. Transitional method returning a `Reactor` object.
+shared_ptr<Reactor> newReactor4(
+    const string& model, shared_ptr<Solution> contents, const string& name="(none)");
+
+//! Create a Reservoir object with the specified contents
+//! @since New in %Cantera 3.2.
+shared_ptr<Reservoir> newReservoir(
+    shared_ptr<Solution> contents, const string& name="(none)");
 
 //! @}
 

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -30,9 +30,11 @@ class ReactorNet : public FuncEval
 {
 public:
     ReactorNet();
-    //! Create reactor net containing single reactor.
+    //! Create reactor network containing single reactor.
+    //! @since New in %Cantera 3.2.
     ReactorNet(shared_ptr<ReactorBase> reactor);
-    //! Create reactor net from multiple reactors.
+    //! Create reactor network from multiple reactors.
+    //! @since New in %Cantera 3.2.
     ReactorNet(vector<shared_ptr<ReactorBase>>& reactors);
     ~ReactorNet() override;
     ReactorNet(const ReactorNet&) = delete;
@@ -140,7 +142,7 @@ public:
     double step();
 
     //! Add the reactor *r* to this reactor network.
-    //! @deprecated  To be removed after Cantera 3.2. Replaceable by reactor net
+    //! @deprecated  To be removed after %Cantera 3.2. Replaceable by reactor net
     //!     instantiation with contents.
     void addReactor(Reactor& r);
 
@@ -307,7 +309,7 @@ public:
 
 protected:
     //! Add the reactor *r* to this reactor network.
-    //! @since  Changed in %Cantera 3.2.
+    //! @since  Changed in %Cantera 3.2. Previous version used a reference.
     void addReactor(shared_ptr<ReactorBase> reactor);
 
     //! Check that preconditioning is supported by all reactors in the network

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -30,6 +30,10 @@ class ReactorNet : public FuncEval
 {
 public:
     ReactorNet();
+    //! Create reactor net containing single reactor.
+    ReactorNet(shared_ptr<ReactorBase> reactor);
+    //! Create reactor net from multiple reactors.
+    ReactorNet(vector<shared_ptr<ReactorBase>>& reactors);
     ~ReactorNet() override;
     ReactorNet(const ReactorNet&) = delete;
     ReactorNet& operator=(const ReactorNet&) = delete;
@@ -136,6 +140,8 @@ public:
     double step();
 
     //! Add the reactor *r* to this reactor network.
+    //! @deprecated  To be removed after Cantera 3.2. Replaceable by reactor net
+    //!     instantiation with contents.
     void addReactor(Reactor& r);
 
     //! Return a reference to the *n*-th reactor in this network. The reactor
@@ -300,6 +306,10 @@ public:
     virtual void setDerivativeSettings(AnyMap& settings);
 
 protected:
+    //! Add the reactor *r* to this reactor network.
+    //! @since  Changed in %Cantera 3.2.
+    void addReactor(shared_ptr<ReactorBase> reactor);
+
     //! Check that preconditioning is supported by all reactors in the network
     virtual void checkPreconditionerSupported() const;
 
@@ -363,6 +373,15 @@ protected:
     vector<double> m_LHS;
     vector<double> m_RHS;
 };
+
+/**
+ * Create a reactor network containing one or more coupled reactors.
+ * Wall and FlowDevice objects should be installed prior to calling newReactorNet().
+ * @param reactors  A vector of shared pointers to the reactors to be linked together.
+ * @since New in %Cantera 3.2.
+ */
+shared_ptr<ReactorNet> newReactorNet(vector<shared_ptr<ReactorBase>>& reactors);
+
 }
 
 #endif

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -122,9 +122,22 @@ public:
     double velocity() const;
 
     //! Set the wall velocity to a specified function of time, @f$ v(t) @f$.
+    //! @deprecated  To be removed after Cantera 3.2. Replaceable by version using
+    //!     shared pointer.
     void setVelocity(Func1* f=0) {
+        warn_deprecated("Wall::setVelocity",
+            "To be removed after Cantera 3.2. Replaceable by version using "
+            "shared pointer.");
         if (f) {
             m_vf = f;
+        }
+    }
+
+    //! Set the wall velocity to a specified function of time, @f$ v(t) @f$.
+    //! @since  Changed in %Cantera 3.2.
+    void setVelocity(shared_ptr<Func1> f) {
+        if (f) {
+            m_vf = f.get();
         }
     }
 
@@ -147,8 +160,19 @@ public:
     double heatFlux() const;
 
     //! Specify the heat flux function @f$ q_0(t) @f$.
+    //! @deprecated  To be removed after Cantera 3.2. Replaceable by version using
+    //!     shared pointer.
     void setHeatFlux(Func1* q) {
+        warn_deprecated("Wall::setHeatFlux",
+                        "To be removed after Cantera 3.2. Replaceable by version using "
+                        "shared pointer.");
         m_qf = q;
+    }
+
+    //! Specify the heat flux function @f$ q_0(t) @f$.
+    //! @since  Changed in %Cantera 3.2.
+    void setHeatFlux(shared_ptr<Func1> q) {
+        m_qf = q.get();
     }
 
     //! Heat flow rate through the wall (W).

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -188,6 +188,7 @@ public:
      */
     double heatRate() override;
 
+    //! Set the thermal resistance of the wall [K*m^2/W].
     void setThermalResistance(double Rth) {
         m_rrth = 1.0/Rth;
     }

--- a/include/cantera/zeroD/Wall.h
+++ b/include/cantera/zeroD/Wall.h
@@ -122,7 +122,7 @@ public:
     double velocity() const;
 
     //! Set the wall velocity to a specified function of time, @f$ v(t) @f$.
-    //! @deprecated  To be removed after Cantera 3.2. Replaceable by version using
+    //! @deprecated  To be removed after %Cantera 3.2. Replaceable by version using
     //!     shared pointer.
     void setVelocity(Func1* f=0) {
         warn_deprecated("Wall::setVelocity",
@@ -134,7 +134,7 @@ public:
     }
 
     //! Set the wall velocity to a specified function of time, @f$ v(t) @f$.
-    //! @since  Changed in %Cantera 3.2.
+    //! @since  Changed in %Cantera 3.2. Previous version used a raw pointer.
     void setVelocity(shared_ptr<Func1> f) {
         if (f) {
             m_vf = f.get();
@@ -160,7 +160,7 @@ public:
     double heatFlux() const;
 
     //! Specify the heat flux function @f$ q_0(t) @f$.
-    //! @deprecated  To be removed after Cantera 3.2. Replaceable by version using
+    //! @deprecated  To be removed after %Cantera 3.2. Replaceable by version using
     //!     shared pointer.
     void setHeatFlux(Func1* q) {
         warn_deprecated("Wall::setHeatFlux",
@@ -170,7 +170,7 @@ public:
     }
 
     //! Specify the heat flux function @f$ q_0(t) @f$.
-    //! @since  Changed in %Cantera 3.2.
+    //! @since  Changed in %Cantera 3.2. Previous version used a raw pointer.
     void setHeatFlux(shared_ptr<Func1> q) {
         m_qf = q.get();
     }

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -16,12 +16,12 @@ namespace Cantera
  * A class for mass flow controllers. The mass flow rate is constant or
  * specified as a function of time.
  *
- * The device coefficient *c* is specifies the mass flow coefficient with units of kg/s.
+ * The device coefficient *c* specifies the mass flow coefficient with units of kg/s.
  * The mass flow rate is computed as:
- * @f[\dot{m} = m g(t) @f]
+ * @f[\dot{m} = c g(t) @f]
  * where *g* is a function of time that is set by `setTimeFunction`.
  * If no function is specified, the mass flow rate defaults to:
- * @f[\dot{m} = m @f]
+ * @f[\dot{m} = c @f]
  *
  * @ingroup connectorGroup
  */
@@ -39,7 +39,7 @@ public:
     //! Set the mass flow coefficient.
     /*!
      * *m* has units of kg/s. The mass flow rate is computed as:
-     * @f[\dot{m} = m g(t) @f]
+     *
      * where *g* is a function of time that is set by `setTimeFunction`.
      * If no function is specified, the mass flow rate defaults to:
      * @f[\dot{m} = m @f]
@@ -95,15 +95,7 @@ public:
         return FlowDevice::ready() && m_primary != 0;
     }
 
-    void setPrimary(shared_ptr<ConnectorNode> primary) override {
-        if (!std::dynamic_pointer_cast<MassFlowController>(primary)) {
-            throw CanteraError("PressureController::setPrimary",
-                               "Invalid primary mass flow controller with type {}.",
-                               primary->type());
-        }
-        auto dev = std::dynamic_pointer_cast<FlowDevice>(primary);
-        m_primary = dev.get();
-    }
+    void setPrimary(shared_ptr<ConnectorNode> primary) override;
 
     //! Set the primary mass flow controller.
     //! @since New in %Cantera 3.0.
@@ -125,14 +117,6 @@ public:
     }
 
     //! Set the proportionality constant between pressure drop and mass flow rate.
-    /*!
-     * *c* has units of kg/s/Pa. The mass flow rate is computed as:
-     * @f[\dot{m} = \dot{m}_{primary} + c f(\Delta P) @f]
-     * where *f* is a functions of pressure drop that is set by
-     * `setPressureFunction`. If no functions is specified, the mass flow
-     * rate defaults to:
-     * @f[\dot{m} = \dot{m}_{primary} + c \Delta P @f]
-     */
     void setPressureCoeff(double c) {
         m_coeff = c;
     }
@@ -174,14 +158,6 @@ public:
     }
 
     //! Set the proportionality constant between pressure drop and mass flow rate.
-    /*!
-     * *c* has units of kg/s/Pa. The mass flow rate is computed as:
-     * @f[\dot{m} = c g(t) f(\Delta P) @f]
-     * where *g* and *f* are functions of time and pressure drop that are set
-     * by `setTimeFunction` and `setPressureFunction`, respectively. If no functions are
-     * specified, the mass flow rate defaults to:
-     * @f[\dot{m} = c \Delta P @f]
-     */
     void setValveCoeff(double c) {
         m_coeff = c;
     }

--- a/include/cantera/zeroD/flowControllers.h
+++ b/include/cantera/zeroD/flowControllers.h
@@ -57,6 +57,10 @@ public:
         throw NotImplementedError("MassFlowController::setPressureFunction");
     }
 
+    void setPressureFunction(shared_ptr<Func1> f) override {
+        throw NotImplementedError("MassFlowController::setPressureFunction");
+    }
+
     //! If a function of time has been specified for mdot, then update the
     //! stored mass flow rate. Otherwise, mdot is a constant, and does not
     //! need updating.
@@ -113,6 +117,10 @@ public:
     }
 
     void setTimeFunction(Func1* g) override {
+        throw NotImplementedError("PressureController::setTimeFunction");
+    }
+
+    void setTimeFunction(shared_ptr<Func1> f) override {
         throw NotImplementedError("PressureController::setTimeFunction");
     }
 

--- a/interfaces/sourcegen/sourcegen/_data/ctconnector_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctconnector_auto.yaml
@@ -1,0 +1,45 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+docstring: |-
+  Auto-generated CLib API for %Cantera's ConnectorNode class.
+  Partially implements a replacement for CLib's traditional @c ctreactor library.
+prefix: connector3
+base: ConnectorNode
+parents: []  # List of parent classes
+derived:  # Specialization/prefix dictionary
+  FlowDevice: flowdev3
+  WallBase: wall3
+  Wall: wall3
+recipes:
+- name: new
+  implements: newConnector
+- name: type
+- name: name
+- name: setName
+# FlowDevice
+- name: setPrimary
+- name: massFlowRate
+- name: deviceCoefficient  # new in Cantera 3.2
+- name: setDeviceCoefficient  # new in Cantera 3.2
+- name: setPressureFunction
+  implements: setPressureFunction(shared_ptr<Func1>)  # alternative is deprecated
+- name: setTimeFunction
+  implements: setTimeFunction(shared_ptr<Func1>)  # alternative is deprecated
+# Wall
+- name: expansionRate
+- name: heatRate
+- name: area
+- name: setArea
+- name: setThermalResistance
+- name: setHeatTransferCoeff
+- name: setHeatFlux
+  implements: setHeatFlux(shared_ptr<Func1>)  # alternative is deprecated
+- name: setExpansionRateCoeff
+- name: setVelocity
+  implements: setVelocity(shared_ptr<Func1>)  # alternative is deprecated
+- name: setEmissivity
+# service functions
+- name: del
+- name: cabinetSize
+- name: parentHandle

--- a/interfaces/sourcegen/sourcegen/_data/ctreactor_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctreactor_auto.yaml
@@ -30,7 +30,7 @@ recipes:
 - name: massFraction
 - name: nSensParams
 - name: addSensitivityReaction
-- name: install
+- name: install  # inconsistent API (pre-existing)
   implements: addSurface(shared_ptr<ReactorBase>)
 # FlowReactor
 - name: setMassFlowRate

--- a/interfaces/sourcegen/sourcegen/_data/ctreactor_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctreactor_auto.yaml
@@ -1,0 +1,43 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+docstring: |-
+  Auto-generated CLib API for %Cantera's ReactorBase class.
+  Partially implements a replacement for CLib's traditional @c ctreactor library.
+prefix: reactor3
+base: ReactorBase
+parents: []  # List of parent classes
+derived:  # Specialization/prefix dictionary
+  Reactor: reactor3
+  FlowReactor: reactor3
+  ReactorSurface: reactorsurface3
+recipes:
+- name: new
+  implements: newReactorBase
+- name: type
+- name: name
+- name: setName
+- name: setInitialVolume
+- name: setChemistry
+- name: setEnergy
+- name: mass
+- name: volume
+- name: density
+- name: temperature
+- name: enthalpy_mass
+- name: intEnergy_mass
+- name: pressure
+- name: massFraction
+- name: nSensParams
+- name: addSensitivityReaction
+- name: install
+  implements: addSurface(shared_ptr<ReactorBase>)
+# FlowReactor
+- name: setMassFlowRate
+# ReactorSurface
+- name: area
+- name: setArea
+# service functions
+- name: del
+- name: cabinetSize
+- name: parentHandle

--- a/interfaces/sourcegen/sourcegen/_data/ctreactornet_auto.yaml
+++ b/interfaces/sourcegen/sourcegen/_data/ctreactornet_auto.yaml
@@ -1,0 +1,27 @@
+# This file is part of Cantera. See License.txt in the top-level directory or
+# at https://cantera.org/license.txt for license and copyright information.
+
+docstring: |-
+  Auto-generated CLib API for %Cantera's ReactorNet class.
+  Partially implements a replacement for CLib's traditional @c ctreactor library.
+prefix: reactornet3
+base: ReactorNet
+recipes:
+- name: new
+  implements: newReactorNet
+- name: setInitialTime
+- name: setMaxTimeStep
+- name: setTolerances
+- name: setSensitivityTolerances
+- name: advance
+  implements: advance(double)
+- name: step
+- name: time
+- name: rtol
+- name: atol
+- name: sensitivity
+  implements: sensitivity(const string&, size_t, int)
+# service functions
+- name: del
+- name: cabinetSize
+- name: parentHandle

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -41,6 +41,9 @@ includes:
   - cantera/kinetics/ReactionPath.h
   Func1:
   - cantera/numerics/Func1Factory.h
+  ReactorBase:
+  - cantera/zeroD/ReactorFactory.h
+  - cantera/zeroD/FlowReactor.h
   Domain1D:
   - cantera/oneD/DomainFactory.h
   Flow1D:

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -44,6 +44,10 @@ includes:
   ReactorBase:
   - cantera/zeroD/ReactorFactory.h
   - cantera/zeroD/FlowReactor.h
+  ConnectorNode:
+  - cantera/zeroD/ConnectorFactory.h
+  - cantera/zeroD/flowControllers.h
+  - cantera/zeroD/Wall.h
   Domain1D:
   - cantera/oneD/DomainFactory.h
   Flow1D:

--- a/interfaces/sourcegen/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/sourcegen/clib/config.yaml
@@ -48,6 +48,8 @@ includes:
   - cantera/zeroD/ConnectorFactory.h
   - cantera/zeroD/flowControllers.h
   - cantera/zeroD/Wall.h
+  ReactorNet:
+  - cantera/zeroD/ReactorNet.h
   Domain1D:
   - cantera/oneD/DomainFactory.h
   Flow1D:

--- a/samples/clib/demo.c
+++ b/samples/clib/demo.c
@@ -42,6 +42,8 @@ void exit_with_error()
 
 int main(int argc, char** argv)
 {
+    ct_suppress_deprecation_warnings(0); // throw errors for deprecated functions
+
     int soln = soln_newSolution("gri30.yaml", "gri30", "default");
     // In principle, one ought to check for errors after every Cantera call. But this
     // is the only one likely to occur in part of this example, due to the input file
@@ -89,7 +91,9 @@ int main(int argc, char** argv)
     printf("\ntime       Temperature\n");
     int reactor = reactor_new("IdealGasReactor", soln, "test");
     int net = reactornet_new();
+    ct_suppress_deprecation_warnings(1);
     reactornet_addreactor(net, reactor);
+    ct_suppress_deprecation_warnings(0);
 
     double t = 0.0;
     int ret = 0;

--- a/samples/cxx/kinetics1/kinetics1.cpp
+++ b/samples/cxx/kinetics1/kinetics1.cpp
@@ -37,7 +37,7 @@ int kinetics1(int np, void* p)
     // Note that it is ok to insert the same gas object into multiple reactors
     // or reservoirs. All this means is that this object will be used to evaluate
     // thermodynamic or kinetic quantities needed.
-    IdealGasConstPressureReactor r(sol);
+    auto r = newReactorBase("IdealGasConstPressureReactor", sol);
 
     double dt = 1.e-5; // interval at which output is written
     int nsteps = 100; // number of intervals
@@ -47,10 +47,8 @@ int kinetics1(int np, void* p)
     Array2D states(nsp+4, 1);
     saveSoln(0, 0.0, *(sol->thermo()), states);
 
-    // create a container object to run the simulation
-    // and add the reactor to it
-    ReactorNet sim;
-    sim.addReactor(r);
+    // create a container object for reactor to run the simulation
+    ReactorNet sim(r);
 
     // main loop
     clock_t t0 = clock(); // save start time
@@ -68,7 +66,7 @@ int kinetics1(int np, void* p)
 
     // print final temperature and timing data
     double tmm = 1.0*(t1 - t0)/CLOCKS_PER_SEC;
-    cout << " Tfinal = " << r.temperature() << endl;
+    cout << " Tfinal = " << r->temperature() << endl;
     cout << " time = " << tmm << endl;
     cout << " number of residual function evaluations = "
          << sim.integrator().nEvals() << endl;

--- a/samples/cxx/openmp_ignition/openmp_ignition.cpp
+++ b/samples/cxx/openmp_ignition/openmp_ignition.cpp
@@ -28,7 +28,7 @@ void run()
     // to have its own set of linked Cantera objects. Multiple threads accessing
     // the same objects at the same time will cause errors.
     vector<shared_ptr<Solution>> sols;
-    vector<unique_ptr<IdealGasConstPressureReactor>> reactors;
+    vector<shared_ptr<IdealGasConstPressureReactor>> reactors;
     vector<unique_ptr<ReactorNet>> nets;
 
     // Create and link the Cantera objects for each thread. This step should be
@@ -37,8 +37,7 @@ void run()
         auto sol = newSolution("gri30.yaml", "gri30", "none");
         sols.emplace_back(sol);
         reactors.emplace_back(new IdealGasConstPressureReactor(sol));
-        nets.emplace_back(new ReactorNet());
-        nets.back()->addReactor(*reactors.back());
+        nets.emplace_back(new ReactorNet(reactors.back()));
     }
 
     // Points at which to compute ignition delay time

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1650,6 +1650,20 @@ extern "C" {
         }
     }
 
+    int ct_suppress_deprecation_warnings(int suppress)
+    {
+        try {
+            if (suppress != 0) {
+                suppress_deprecation_warnings();
+            } else {
+                make_deprecation_warnings_fatal();
+            }
+            return 0;
+        } catch (...) {
+            return handleAllExceptions(-1, ERR);
+        }
+    }
+
     int ct_use_legacy_rate_constants(int legacy)
     {
         try {

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -41,7 +41,7 @@ extern "C" {
     {
         try {
             return ReactorCabinet::add(
-                newReactor(type, SolutionCabinet::at(n), name));
+                newReactorBase(type, SolutionCabinet::at(n), name));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -81,6 +81,9 @@ bool FlowDevice::install(ReactorBase& in, ReactorBase& out)
 
 void FlowDevice::setPressureFunction(Func1* f)
 {
+    warn_deprecated("FlowDevice::setPressureFunction",
+                    "To be removed after Cantera 3.2. Replaceable by version using "
+                    "shared pointer.");
     m_pfunc = f;
 }
 
@@ -95,6 +98,9 @@ double FlowDevice::evalPressureFunction()
 
 void FlowDevice::setTimeFunction(Func1* g)
 {
+    warn_deprecated("FlowDevice::setTimeFunction",
+        "To be removed after Cantera 3.2. Replaceable by version using "
+        "shared pointer.");
     m_tfunc = g;
 }
 

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -16,7 +16,7 @@ FlowDevice::FlowDevice(shared_ptr<ReactorBase> r0, shared_ptr<ReactorBase> r1,
 {
     if (!m_nodes.first || !m_nodes.second) {
         warn_deprecated("FlowDevice::FlowDevice",
-            "After Cantera 3.1, Reactors must be provided to a FlowDevice "
+            "After Cantera 3.2, Reactors must be provided to a FlowDevice "
             "constructor.");
         return;
     }
@@ -48,7 +48,7 @@ FlowDevice::FlowDevice(shared_ptr<ReactorBase> r0, shared_ptr<ReactorBase> r1,
 bool FlowDevice::install(ReactorBase& in, ReactorBase& out)
 {
     warn_deprecated("FlowDevice::install",
-        "To be removed after Cantera 3.1. Reactors should be provided to constructor "
+        "To be removed after Cantera 3.2. Reactors should be provided to constructor "
         "instead.");
     if (m_in || m_out) {
         throw CanteraError("FlowDevice::install", "Already installed");

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -118,6 +118,16 @@ void ReactorBase::addSurface(ReactorSurface* surf)
     }
 }
 
+void ReactorBase::addSurface(shared_ptr<ReactorBase> surf)
+{
+    auto r = std::dynamic_pointer_cast<ReactorSurface>(surf);
+    if (!r) {
+        throw CanteraError("ReactorBase::addSurface",
+                           "Invalid reactor type '{}'.", surf->type());
+    }
+    addSurface(r.get());
+}
+
 ReactorSurface* ReactorBase::surface(size_t n)
 {
     return m_surfaces[n];

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -97,17 +97,42 @@ void ReactorFactory::deleteFactory() {
     s_factory = 0;
 }
 
-shared_ptr<ReactorBase> newReactor(const string& model)
+shared_ptr<ReactorBase> newReactorBase(
+    const string& model, shared_ptr<Solution> contents, const string& name)
 {
     return shared_ptr<ReactorBase>(
-        ReactorFactory::factory()->create(model, nullptr, ""));
+        ReactorFactory::factory()->create(model, contents, name));
 }
 
 shared_ptr<ReactorBase> newReactor(
     const string& model, shared_ptr<Solution> contents, const string& name)
 {
-    return shared_ptr<ReactorBase>(
-        ReactorFactory::factory()->create(model, contents, name));
+    warn_deprecated("newReactor", "Behavior changes after Cantera 3.2, when a "
+        "'shared_ptr<Reactor>' is returned.\nFor new behavior, use 'newReactor4'.");
+    return newReactorBase(model, contents, name);
+}
+
+shared_ptr<Reactor> newReactor4(
+    const string& model, shared_ptr<Solution> contents, const string& name)
+{
+    auto reactor = std::dynamic_pointer_cast<Reactor>(
+        newReactorBase(model, contents, name));
+    if (!reactor) {
+        throw CanteraError("newReactor4",
+            "Model type '{}' does not specify a bulk reactor.", model);
+    }
+    return reactor;
+}
+
+shared_ptr<Reservoir> newReservoir(shared_ptr<Solution> contents, const string& name)
+{
+    auto reservoir = std::dynamic_pointer_cast<Reservoir>(
+        newReactorBase("Reservoir", contents, name));
+    if (!reservoir) {
+        throw CanteraError("newReservoir",
+            "Caught unexpected inconsistency in factory method.");
+    }
+    return reservoir;
 }
 
 }

--- a/src/zeroD/flowControllers.cpp
+++ b/src/zeroD/flowControllers.cpp
@@ -49,6 +49,17 @@ void PressureController::updateMassFlowRate(double time)
     m_mdot = std::max(mdot, 0.0);
 }
 
+void PressureController::setPrimary(shared_ptr<ConnectorNode> primary)
+{
+    auto dev = std::dynamic_pointer_cast<FlowDevice>(primary);
+    if (!dev) {
+        throw CanteraError("PressureController::setPrimary",
+                           "Invalid primary mass flow controller with type {}.",
+                           primary->type());
+    }
+    m_primary = dev.get();
+}
+
 void Valve::updateMassFlowRate(double time)
 {
     if (!ready()) {

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -42,7 +42,9 @@ TEST(ctreactor, reactor_simple)
 
     int reactor = reactor_new("IdealGasReactor", sol, "test");
     int net = reactornet_new();
+    suppress_deprecation_warnings();
     int ret = reactornet_addreactor(net, reactor);
+    make_deprecation_warnings_fatal();
     ASSERT_EQ(ret, 0);
 
     double t = 0.0;

--- a/test/clib_experimental/test_ctreactor3.cpp
+++ b/test/clib_experimental/test_ctreactor3.cpp
@@ -1,0 +1,61 @@
+#include <gtest/gtest.h>
+
+#include "cantera/core.h"
+#include "cantera/zerodim.h"
+
+#include "cantera/clib_experimental/ct3.h"
+#include "cantera/clib_experimental/ctsol3.h"
+#include "cantera/clib_experimental/ctthermo3.h"
+#include "cantera/clib_experimental/ctreactor3.h"
+#include "cantera/clib_experimental/ctreactornet3.h"
+
+using namespace Cantera;
+
+TEST(ctreactor3, reactor_soln)
+{
+    int sol = sol3_newSolution("gri30.yaml", "gri30", "none");
+    int reactor = reactor3_new("IdealGasReactor", sol, "test");
+    ASSERT_EQ(reactor, 0);
+
+    int ret = reactor3_setName(reactor, "spam");
+    ASSERT_EQ(ret, 0);
+    int buflen = reactor3_name(reactor, 0, 0);
+    vector<char> buf(buflen);
+    reactor3_name(reactor, buflen, buf.data());
+    string rName(buf.data());
+    ASSERT_EQ(rName, "spam");
+}
+
+vector<double> T_ctreactor = {
+    1050.000, 1050.064, 1050.197, 1050.369, 1050.593, 1050.881, 1051.253, 1051.736,
+    1052.370, 1053.216, 1054.372, 1056.007, 1058.448, 1062.431, 1070.141, 1094.331,
+    2894.921, 2894.921, 2894.921, 2894.921, 2894.921};
+
+TEST(ctreactor3, reactor_simple)
+{
+    double T = 1050;
+    double P = 5 * 101325;
+    string X = "CH4:1.0, O2:2.0, N2:7.52";
+
+    int sol = sol3_newSolution("gri30.yaml", "gri30", "none");
+    int thermo = sol3_thermo(sol);
+    thermo3_setMoleFractionsByName(thermo, X.c_str());
+    thermo3_setTemperature(thermo, T);
+    thermo3_setPressure(thermo, P);
+
+    int reactor = reactor3_new("IdealGasReactor", sol, "test");
+    vector<int> reactors{reactor};
+    int net = reactornet3_new(1, reactors.data());
+    ASSERT_EQ(net, 0);
+
+    double t = 0.0;
+    int count = 0;
+    while (t < 0.1) {
+        double Tref = T_ctreactor[count];
+        ASSERT_NEAR(reactor3_temperature(reactor), Tref, 1e-2);
+        t = reactornet3_time(net) + 5e-3;
+        int ret = reactornet3_advance(net, t);
+        ASSERT_EQ(ret, 0);
+        count++;
+    }
+}


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

With this PR, `clib_experimental` reaches parity with the traditional `clib`.

- Add `zeroD` objects to experimental CLib 
- Further streamline C++ zeroD API:
  - Create `ReactorNet` with list of `ReactorBase`; deprecate incremental path via `addReactor`
  - Introduce several convenience methods for C++ API (`newReservoir`) and clarify future use of `newReactor`.
  - Avoid raw pointers in user-facing API methods.
- Replace deprecated functions and methods in `samples` ... previously overlooked due to #1603
- Propagate all changes to Python interface

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Addresses Cantera/enhancements#220

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
