### PR TITLE
Add announcement banner

### DIFF
--- a/doc/sphinx/_static/custom.css
+++ b/doc/sphinx/_static/custom.css
@@ -7,12 +7,12 @@ html[data-theme=light] {
     --pst-color-surface: rgb(250, 250, 250);
     --pst-color-primary: rgb(4, 97, 113);
     /* used by banner */
-    --pst-color-secondary-bg: #fbc58d;
+    --pst-color-secondary-bg: #fdddbe;
 }
 
 html[data-theme="dark"] {
     /* used by banner */
-    --pst-color-secondary-bg: #652a02;
+    --pst-color-secondary-bg: #402001;
 }
 
 p + div.math {

--- a/doc/sphinx/_static/custom.css
+++ b/doc/sphinx/_static/custom.css
@@ -6,6 +6,13 @@ html[data-theme=light] {
     /* Improve contrast with foreground colors */
     --pst-color-surface: rgb(250, 250, 250);
     --pst-color-primary: rgb(4, 97, 113);
+    /* used by banner */
+    --pst-color-secondary-bg: #fbc58d;
+}
+
+html[data-theme="dark"] {
+    /* used by banner */
+    --pst-color-secondary-bg: #652a02;
 }
 
 p + div.math {

--- a/doc/sphinx/_templates/numfocus.html
+++ b/doc/sphinx/_templates/numfocus.html
@@ -1,4 +1,4 @@
-<div id="numfocus">
+<div id="numfocus" style="padding-bottom: 30px;">
 <a href="https://numfocus.org/donate-to-cantera"
    class="sd-sphinx-override sd-btn sd-text-wrap sd-btn-secondary reference external"
    type="button">Donate to Cantera</a>

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -341,6 +341,11 @@ html_theme_options = {
             "type": "fontawesome",
         }
    ],
+    "announcement": (
+        "This is a community-supported project. If you'd like to contribute, "
+        "<a href='https://groups.google.com/group/cantera-users'>check out our User Group</a>. "
+        "Your contributions are welcome!"
+    ),
 }
 
 # Add any paths that contain custom themes here, relative to this directory.

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -11,7 +11,10 @@
 # All configuration values have a default; values that are commented out
 # serve to show the default.
 
-import sys, os, re
+import sys
+import os
+import re
+from datetime import date
 from pathlib import Path
 from sphinx_gallery.sorting import ExplicitOrder
 
@@ -250,7 +253,8 @@ master_doc = 'index'
 
 # General information about the project.
 project = 'Cantera'
-copyright = "2001-2024, Cantera Developers"
+year = date.today().year
+copyright = f"2001-{year}, Cantera Developers"
 
 # The version info for the project you're documenting, acts as replacement for
 # |version| and |release|, also used in various other places throughout the

--- a/doc/sphinx/conf.py
+++ b/doc/sphinx/conf.py
@@ -341,14 +341,13 @@ html_theme_options = {
         {
             "name": "GitHub",
             "url": "https://github.com/Cantera/cantera",
-            "icon": "fa-brands fa-square-github",
+            "icon": "fa-brands fa-github",
             "type": "fontawesome",
         }
-   ],
+    ],
     "announcement": (
-        "This is a community-supported project. If you'd like to contribute, "
-        "<a href='https://groups.google.com/group/cantera-users'>check out our User Group</a>. "
-        "Your contributions are welcome!"
+        "Cantera is community-driven and needs your help! "
+        "<a href='https://cantera.org/getting-involved.html'>Get involved here</a>."
     ),
 }
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

I noticed that the [pydata-sphinx-theme](https://pydata-sphinx-theme.readthedocs.io/) project uses a banner to invite the community to contribute. I'd suggest doing the same for the Cantera project.

Here's a screenshot:

<img width="1380" alt="image" src="https://github.com/user-attachments/assets/9dfd936f-e32d-4536-9bef-10d08bbe81cf" />

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
