### PR TITLE
Update SConscript

### DIFF
--- a/interfaces/cython/SConscript
+++ b/interfaces/cython/SConscript
@@ -59,7 +59,7 @@ for pyxfile in multi_glob(localenv, "cantera", "pyx"):
 
     cythonized = cython_env.Command(
          cython_output, pyxfile,
-         f'''${{python_cmd}} -c "import Cython.Build; Cython.Build.cythonize(r'${{SOURCE}}', compiler_directives={directives!r})"'''
+         f'''${{python_cmd}} -c "import setuptools; import Cython.Build; Cython.Build.cythonize(r'${{SOURCE}}', compiler_directives={directives!r})"'''
     )
     for pxd in multi_glob(cython_env, "cantera", "pxd"):
         cython_env.Depends(cythonized, pxd)


### PR DESCRIPTION
import setuptools before calling Cython.Build.cythonize to prevent distutils ModuleNotFoundError

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->
Simply adding a command to import setuptools before calling cythonize to prevent a ModuleNotFoundError due to distutils.  This is applicable when trying to build Cantera from source.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

 `touch test.pyx`
`python3 -c "import Cython.Build; Cython.Build.cythonize('test.pyx')"`
Results in error
`python3 -c "import setuptools; import Cython.Build; Cython.Build.cythonize('test.pyx')"`
Success


<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
