### PR TITLE
Fix layout of multi_diff_coeffs matrix in Python

### DIFF
--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -20,7 +20,8 @@ cdef np.ndarray get_transport_1d(Transport tran, transportMethod1d method):
 
 cdef np.ndarray get_transport_2d(Transport tran, transportMethod2d method):
     cdef size_t kk = tran.thermo.nSpecies()
-    cdef np.ndarray[np.double_t, ndim=2] data = np.empty((kk, kk))
+    # getMultiDiffCoeffs returns an array using Fortran ordering
+    cdef np.ndarray[np.double_t, ndim=2, mode='fortran'] data = np.empty((kk, kk), order='F')
     method(tran.transport, kk, &data[0,0])
     return data
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix the orientation of the multicomponent diffusion coefficient matrix when returned in Python.
- Add a test that checks that the fluxes computed using these diffusion coefficients conserve mass

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Resolves an issue reported on the [Cantera Users' Group](https://groups.google.com/g/cantera-users/c/myZ8hZnHFfo).

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
