### PR TITLE
Simplify logger setup

### DIFF
--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -147,7 +147,7 @@ bool usesHDF5();
 //! @addtogroup logGroup
 //! @{
 
-//! @copydoc Application::Messages::writelog(const string&)
+//! @copydoc Application::writelog(const string&)
 void writelog_direct(const string& msg);
 
 //! Write a message to the log only if loglevel > 0
@@ -307,7 +307,7 @@ bool legacy_rate_constants_used();
 
 // @} End of globalSettings group
 
-//! @copydoc Application::Messages::setLogger
+//! @copydoc Application::setLogger
 //! @ingroup logGroup
 void setLogger(Logger* logwriter);
 

--- a/include/cantera/base/global.h
+++ b/include/cantera/base/global.h
@@ -307,9 +307,16 @@ bool legacy_rate_constants_used();
 
 // @} End of globalSettings group
 
-//! @copydoc Application::setLogger
+//! @copydoc Application::setLogger(Logger*)
+//! @deprecated To be removed after %Cantera 3.2. Replaced by version taking
+//!     `unique_ptr`.
 //! @ingroup logGroup
 void setLogger(Logger* logwriter);
+
+//! @copydoc Application::setLogger(unique_ptr<Logger>)
+//! @since Changed in %Cantera 3.2 to take `unique_ptr` instead of bare pointer.
+//! @ingroup logGroup
+void setLogger(unique_ptr<Logger> logwriter);
 
 //! Enables printing a stacktrace to `std::err` if a segfault occurs. The Boost
 //! documentation says doing this from an error handler is not safe on all platforms

--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -5,6 +5,7 @@
 #distutils: language=c++
 
 from libcpp.unordered_map cimport unordered_map
+from libcpp.memory cimport unique_ptr, make_unique
 
 from .ctcxx cimport *
 from .units cimport UnitSystem, CxxUnits
@@ -95,10 +96,11 @@ cdef extern from "cantera/cython/utils_utils.h":
     cdef string get_cantera_version_py()
     cdef string get_cantera_git_commit_py()
     cdef string get_sundials_version()
+
     cdef cppclass CxxPythonLogger "PythonLogger":
         pass
 
-    cdef void CxxSetLogger "setLogger" (CxxPythonLogger*)
+    cdef void CxxSetLogger "setLogger" (unique_ptr[CxxPythonLogger])
 
 cdef class AnyMap(dict):
     cdef _set_CxxUnitSystem(self, shared_ptr[CxxUnitSystem] units)

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -5,6 +5,7 @@ import sys
 import os
 import warnings
 from cpython.ref cimport PyObject
+from libcpp.utility cimport move
 import numbers
 import importlib.metadata
 from collections import namedtuple
@@ -27,8 +28,8 @@ def _import_scipy_sparse():
         from scipy import sparse as _scipy_sparse
 
 
-cdef CxxPythonLogger* _logger = new CxxPythonLogger()
-CxxSetLogger(_logger)
+cdef unique_ptr[CxxPythonLogger] _logger = make_unique[CxxPythonLogger]()
+CxxSetLogger(move(_logger))
 
 cdef string stringify(x) except *:
     """ Converts Python strings to std::string. """

--- a/interfaces/sourcegen/src/sourcegen/headers/ct_auto.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ct_auto.yaml
@@ -53,9 +53,8 @@ recipes:
   parameters:
     writer: Callback that is invoked to produce log output.
   code: |-
-    static unique_ptr<Logger> logwriter;
-    logwriter = make_unique<ExternalLogger>(writer);
-    setLogger(logwriter.get());
+    auto logwriter = make_unique<ExternalLogger>(writer);
+    setLogger(std::move(logwriter));
     return 0;
 - name: writeLog
   wraps: writelog_direct  # inconsistent API (preexisting)

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -193,6 +193,11 @@ void Application::setLogger(Logger* _logwriter)
     m_logwriter.reset(_logwriter);
 }
 
+void Application::setLogger(unique_ptr<Logger> _logwriter)
+{
+    m_logwriter = std::move(_logwriter);
+}
+
 void Application::writelog(const string& msg)
 {
     m_logwriter->write(msg);

--- a/src/base/application.cpp
+++ b/src/base/application.cpp
@@ -35,13 +35,6 @@ static std::mutex dir_mutex;
 //! Mutex for creating singletons within the application object
 static std::mutex app_mutex;
 
-Application::Messages::Messages()
-{
-    // install a default logwriter that writes to standard
-    // output / standard error
-    logwriter = make_unique<Logger>();
-}
-
 void Application::Messages::addError(const string& r, const string& msg)
 {
     if (msg.size() != 0) {
@@ -59,26 +52,6 @@ void Application::Messages::addError(const string& r, const string& msg)
 int Application::Messages::getErrorCount()
 {
     return static_cast<int>(errorMessage.size());
-}
-
-void Application::Messages::setLogger(Logger* _logwriter)
-{
-    logwriter.reset(_logwriter);
-}
-
-void Application::Messages::writelog(const string& msg)
-{
-    logwriter->write(msg);
-}
-
-void Application::Messages::writelogendl()
-{
-    logwriter->writeendl();
-}
-
-void Application::Messages::warnlog(const string& warning, const string& msg)
-{
-    logwriter->warn(warning, msg);
 }
 
 //! Mutex for access to string messages
@@ -109,8 +82,8 @@ void Application::ThreadMessages::removeThreadMessages()
 
 Application::Application()
 {
-    // install a default logwriter that writes to standard
-    // output / standard error
+    // install a default logwriter that writes to standard output / standard error
+    m_logwriter = make_unique<Logger>();
     setDefaultDirectories();
 }
 
@@ -207,10 +180,32 @@ void Application::Messages::getErrors(std::ostream& f)
 void Application::Messages::logErrors()
 {
     for (size_t j = 0; j < errorMessage.size(); j++) {
-        writelog(errorMessage[j]);
-        writelogendl();
+        Cantera::writelog(errorMessage[j]);
+        Cantera::writelogendl();
     }
     errorMessage.clear();
+}
+
+// Application methods
+
+void Application::setLogger(Logger* _logwriter)
+{
+    m_logwriter.reset(_logwriter);
+}
+
+void Application::writelog(const string& msg)
+{
+    m_logwriter->write(msg);
+}
+
+void Application::writelogendl()
+{
+    m_logwriter->writeendl();
+}
+
+void Application::warnlog(const string& warning, const string& msg)
+{
+    m_logwriter->warn(warning, msg);
 }
 
 void Application::setDefaultDirectories()

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -366,8 +366,21 @@ public:
      * @param logwriter Pointer to a logger object
      * @see Logger.
      * @ingroup logGroup
+     *
+     * @deprecated To be removed after %Cantera 3.2. Replaced by version taking
+     *     `unique_ptr`.
      */
     void setLogger(Logger* logwriter);
+
+    //! Install a Logger.
+    /*!
+     * Called by the language interfaces to install an appropriate logger.
+     * The logger is used for the writelog() function
+     *
+     * @since Changed in %Cantera 3.2 to take `unique_ptr` instead of bare pointer.
+     * @ingroup logGroup
+     */
+    void setLogger(unique_ptr<Logger> logwriter);
 
     //! Delete and free memory allocated per thread in multithreaded applications
     /*!

--- a/src/base/application.h
+++ b/src/base/application.h
@@ -45,8 +45,7 @@ protected:
     class Messages
     {
     public:
-        Messages();
-
+        Messages() = default;
         Messages(const Messages& r) = delete;
         Messages& operator=(const Messages& r) = delete;
 
@@ -114,49 +113,9 @@ protected:
          */
         void logErrors();
 
-        //!  Write a message to the screen.
-        /*!
-         * The string may be of any length, and may contain end-of-line
-         * characters. This method is used throughout %Cantera to write log
-         * messages. It can also be called by user programs.  The advantage of
-         * using writelog over writing directly to the standard output is that
-         * messages written with writelog will display correctly even when
-         * %Cantera is used from MATLAB or other application that do not have a
-         * standard output stream.
-         *
-         * @param msg  c++ string to be written to the screen
-         * @ingroup logGroup
-         */
-        void writelog(const string& msg);
-
-        //! Write an end of line character to the screen and flush output
-        void writelogendl();
-
-        //!  Write a warning message to the screen.
-        /*!
-         * @param warning  String specifying type of warning; see Logger::warn()
-         * @param msg  String to be written to the screen
-         * @ingroup logGroup
-         */
-        void warnlog(const string& warning, const string& msg);
-
-        //! Install a logger.
-        /*!
-         * Called by the language interfaces to install an appropriate logger.
-         * The logger is used for the writelog() function
-         *
-         * @param logwriter Pointer to a logger object
-         * @see Logger.
-         * @ingroup logGroup
-         */
-        void setLogger(Logger* logwriter);
-
     protected:
         //! Current list of error messages
         vector<string> errorMessage;
-
-        //! Current pointer to the logwriter
-        unique_ptr<Logger> logwriter;
     };
 
     //! Typedef for thread specific messages
@@ -301,20 +260,30 @@ public:
                                    string& value, const string& defaultValue);
 #endif
 
-    //! @copydoc Messages::writelog
-    void writelog(const string& msg) {
-        pMessenger->writelog(msg);
-    }
+    //! Write a message to the logger.
+    /*!
+     * The string may be of any length, and may contain end-of-line characters. This
+     * method is used throughout %Cantera to write log messages. It can also be called
+     * by user programs.  The advantage of using writelog over writing directly to the
+     * standard output is that messages written with writelog will display correctly
+     * even when %Cantera is used from MATLAB or other application that do not have a
+     * standard output stream.
+     *
+     * @param msg  C++ string to be written to the logger
+     * @ingroup logGroup
+     */
+    void writelog(const string& msg);
 
-    //! Write an endl to the screen and flush output
-    void writelogendl() {
-        pMessenger->writelogendl();
-    }
+    //! Write an end of line character to the logger and flush output
+    void writelogendl();
 
-    //! @copydoc Messages::warnlog
-    void warnlog(const string& warning, const string& msg) {
-        pMessenger->warnlog(warning, msg);
-    }
+    //! Write a warning message to the logger.
+    /*!
+     * @param warning  Type of warning; see Logger::warn()
+     * @param msg  Message to be written to the logger
+     * @ingroup logGroup
+     */
+    void warnlog(const string& warning, const string& msg);
 
     //! Print a warning indicating that *method* is deprecated. Additional
     //! information (removal version, alternatives) can be specified in
@@ -389,10 +358,16 @@ public:
         return m_use_legacy_rate_constants;
     }
 
-    //! @copydoc Messages::setLogger
-    void setLogger(Logger* logwriter) {
-        pMessenger->setLogger(logwriter);
-    }
+    //! Install a logger.
+    /*!
+     * Called by the language interfaces to install an appropriate logger.
+     * The logger is used for the writelog() function
+     *
+     * @param logwriter Pointer to a logger object
+     * @see Logger.
+     * @ingroup logGroup
+     */
+    void setLogger(Logger* logwriter);
 
     //! Delete and free memory allocated per thread in multithreaded applications
     /*!
@@ -449,6 +424,9 @@ protected:
     set<pair<string, string>> m_loaded_extensions;
 
     ThreadMessages pMessenger;
+
+    //! Current log writer
+    unique_ptr<Logger> m_logwriter;
 
 private:
     //! Pointer to the single Application instance

--- a/src/base/global.cpp
+++ b/src/base/global.cpp
@@ -33,6 +33,15 @@ void setLogger(Logger* logwriter)
     }
 }
 
+void setLogger(unique_ptr<Logger> logwriter)
+{
+    try {
+        app()->setLogger(std::move(logwriter));
+    } catch (const std::bad_alloc&) {
+        logwriter->error("bad alloc thrown by app()");
+    }
+}
+
 void writelog_direct(const string& msg)
 {
     app()->writelog(msg);

--- a/src/clib/ct.cpp
+++ b/src/clib/ct.cpp
@@ -1687,10 +1687,9 @@ extern "C" {
 
     int ct_setLogCallback(LogCallback writer)
     {
-        static unique_ptr<Logger> logwriter;
         try {
-            logwriter = make_unique<ExternalLogger>(writer);
-            setLogger(logwriter.get());
+            auto logwriter = make_unique<ExternalLogger>(writer);
+            setLogger(std::move(logwriter));
             return 0;
         } catch (...) {
             return handleAllExceptions(-1, ERR);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make logging global rather than thread-specific. Thread-specific logging is difficult to initialize when the user doesn't
control thread creation, as in environments like .NET.
- Fix ownership handling of `Logger` objects. The `Application` instance takes ownership of these objects. Changing
the interface to use `unique_ptr` reflects this and prevents errors like the double-delete during application teardown that was previously occurring (as identified by @burkenyo).

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
