### PR TITLE
Fix Windows MSVC job in CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -820,10 +820,6 @@ jobs:
         run: |
           python -m pip install -U pip setuptools wheel
           python -m pip install 'scons<4.4.0' pypiwin32 numpy ruamel.yaml cython!=3.1.2 pandas graphviz pytest pytest-xdist pytest-github-actions-annotate-failures
-      - name: Set up MSVC environment
-        uses: ilammy/msvc-dev-cmd@v1
-        with:
-          arch: x64
       - name: Restore Boost cache
         uses: actions/cache@v4
         id: cache-boost
@@ -843,7 +839,7 @@ jobs:
       - name: Build Cantera
         run: scons build -j4 boost_inc_dir=$Env:BOOST_ROOT debug=n logging=debug
           python_package=y env_vars=USERPROFILE,GITHUB_ACTIONS clib_legacy=y
-          f90_interface=n --debug=time
+          f90_interface=n toolchain=msvc --debug=time
       - name: Build Tests
         run: scons -j4 build-tests --debug=time
       - name: Run compiled tests

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -815,17 +815,21 @@ jobs:
         with:
           python-version: ${{ matrix.python-version }}
           architecture: x64
+          check-latest: true
       - name: Install Python dependencies
         run: |
           python -m pip install -U pip setuptools wheel
           python -m pip install 'scons<4.4.0' pypiwin32 numpy ruamel.yaml cython!=3.1.2 pandas graphviz pytest pytest-xdist pytest-github-actions-annotate-failures
+      - name: Set up MSVC environment
+        uses: ilammy/msvc-dev-cmd@v1
+        with:
+          arch: x64
       - name: Restore Boost cache
         uses: actions/cache@v4
         id: cache-boost
         with:
           path: ${{env.BOOST_ROOT}}
           key: boost-187-win
-
       - name: Install Boost Headers
         if: steps.cache-boost.outputs.cache-hit != 'true'
         run: |


### PR DESCRIPTION
This PR fixes failures in the Windows 2025 CI jobs caused by:
1. Python 3.13.4 linking error: `python313t.lib` was missing due to a [known bug](https://github.com/python/cpython/issues/135151) in that version. 
2. Wrong compiler: Windows Server 2025 comes shipped with MinGW and MSVC. If the MSVC environment variables are not explicitly set, MinGW is used by default. We previously didn't catch this problem because the first issue wasn't present and the job completed despite not using the wrong compiler.  

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Updated the Python setup step to use the latest build which solved the 1st issue. 
- Added a [step](https://github.com/ilammy/msvc-dev-cmd) to initialize the MSVC environment.

**Checklist**

- [ ] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [ ] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
