### PR TITLE
Revert "[Python/Test] Work around pint TypeError - pint #1969 resolved"

### DIFF
--- a/test/python/test_units.py
+++ b/test/python/test_units.py
@@ -1,14 +1,10 @@
+from contextlib import nullcontext
 from dataclasses import dataclass
 from typing import Optional, Tuple, Dict
+import sys
 
 import pytest
-try:
-    pint = pytest.importorskip("pint", "0.17.0")
-except TypeError as e:
-    # The extra exception handling is here because pint is incompatible with
-    # Python 3.13. Once https://github.com/hgrecco/pint/issues/1969 is resolved the
-    # try/except here can be restored to just the importorskip.
-    pytest.skip(f"pint import failed due to {e}", allow_module_level=True)
+pytest.importorskip("pint", "0.17.0")
 import cantera.with_units as ctu
 import cantera as ct
 try:


### PR DESCRIPTION
This reverts commit dd03a35ca724b06c6f64029c8c31d44437efe87e.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Revert commit made as workaround until [pint#1969](https://github.com/hgrecco/pint/issues/1969) resolved (it is resolved)

**If applicable, fill in the issue number this pull request is fixing**

closes #1525 (already closed, but superior)


**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [ ] The pull request is ready for review
