### PR TITLE
Workaround for optimization bug in MSVC 17.14.36203.30

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -738,13 +738,13 @@ jobs:
         create-args: >-
           python=${{ matrix.python-version }} scons numpy cython!=3.1.2 ruamel.yaml boost-cpp
           eigen yaml-cpp pandas pytest pytest-xdist highfive pint python-graphviz
-          fmt=${{ matrix.fmt-ver }} setuptools Jinja2 doxygen
+          fmt=${{ matrix.fmt-ver }} setuptools Jinja2 doxygen openblas
         post-cleanup: none
         init-shell: powershell
     - name: Build Cantera with legacy CLib
       run: scons build system_eigen=y system_yamlcpp=y system_highfive=y logging=debug
         toolchain=msvc f90_interface=n debug=n ${{ matrix.extra-build-args }}
-        --debug=time clib_legacy=y -j4
+        --debug=time clib_legacy=y -j4 blas_lapack_libs=openblas optimize=n
     - name: Build Tests
       run: scons -j4 build-tests --debug=time
     - name: Run compiled tests
@@ -839,7 +839,7 @@ jobs:
       - name: Build Cantera
         run: scons build -j4 boost_inc_dir=$Env:BOOST_ROOT debug=n logging=debug
           python_package=y env_vars=USERPROFILE,GITHUB_ACTIONS clib_legacy=y
-          f90_interface=n toolchain=msvc --debug=time
+          f90_interface=n toolchain=msvc --debug=time optimize=n
       - name: Build Tests
         run: scons -j4 build-tests --debug=time
       - name: Run compiled tests
@@ -1005,7 +1005,7 @@ jobs:
         # fmt needs to match the version of the windows-2022 runner selected to upload
         # the cantera_shared.dll artifact
         create-args: >-
-          yaml-cpp mkl highfive fmt=9.1
+          yaml-cpp openblas highfive fmt=9.1
         init-shell: bash powershell
         post-cleanup: none
       if: matrix.os == 'windows-2022'


### PR DESCRIPTION
All MSVC CI builds are currently failing due to a recent update of the GitHub Actions runners to use Visual Studio 2022 version 17.14.36203.30 (updated from 17.13.35825.156; see [here](https://github.com/actions/runner-images/commit/c11d5d691f731833c155c54c21a5de30e06f1235). This version has a bug in the code optimization which affects use of `std::transform`. See the issue report [here](https://developercommunity.visualstudio.com/t/Code-optimization-bug-SIMD-std::vector/10912292?sort=newest&q=transform+vector). The issues is already fixed upstream, but I don't know know how long that will take to filter down into a VS update followed by an update to the GitHub actions runners.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Disable optimization of MSVC builds for now
- On the builds where we're using conda, link to OpenBLAS to avoid needing to run unoptimized linear algebra methods

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
