### PR TITLE
Fix building sdist into wheels and avoid broken Cython

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -21,8 +21,8 @@ permissions:
   contents: read
 
 env:
-  PIP_EXTRA_INDEX_URL: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
-  PIP_ONLY_BINARY: ":all:"
+  UV_INDEX: https://pypi.anaconda.org/scientific-python-nightly-wheels/simple
+  REQUIREMENTS_TXT_FILE: "platform/ci_support/post_merge_reqs.txt"
 
 jobs:
   prerelease-cython:
@@ -38,29 +38,34 @@ jobs:
     - name: Setup Python
       uses: actions/setup-python@v5
       with:
-        python-version: 3.11
-        architecture: x64
+        python-version: 3.12
+    - name: Install uv
+      uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # v6.3.0
+      with:
+        python-version: 3.12
+        cache-dependency-glob: |
+          ${{ env.REQUIREMENTS_TXT_FILE }}
+        enable-cache: true
     - name: Install Apt dependencies
       run: |
         sudo apt update
         sudo apt install libboost-dev libopenblas-dev libhdf5-dev doxygen
-    - name: Upgrade pip
-      run: python3 -m pip install -U pip setuptools wheel
     - name: Install Python dependencies
       run: |
-        python3 -m pip install ruamel.yaml scons numpy pandas pytest pint \
-          pytest-xdist pytest-github-actions-annotate-failures graphviz Jinja2
-        python3 -m pip install --pre cython
+        uv venv --python 3.12 --seed
+        sed -i 's/cython.*//g' "${REQUIREMENTS_TXT_FILE}"
+        uv pip install -r "${REQUIREMENTS_TXT_FILE}"
+        uv pip install --prerelease=allow --only-binary=":all:" cython
     - name: Build Cantera
-      run: python3 `which scons` build env_vars=all
+      run: uv run scons build env_vars=all
         CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
         -j4 debug=n --debug=time logging=debug python_package=y
     - name: Build Tests
-      run: python3 `which scons` -j4 build-tests
+      run: uv run scons -j4 build-tests
     - name: Run compiled tests
-      run: python3 `which scons` test-gtest test-legacy --debug=time
+      run: uv run scons test-gtest test-legacy --debug=time
     - name: Run Python tests
-      run: python3 -m pytest -raP -v -n auto --durations=50 test/python
+      run: uv run pytest -raP -v -n auto --durations=50 test/python
       env:
         LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:build/lib"
         PYTHONPATH: build/python
@@ -79,7 +84,7 @@ jobs:
     - name: Install git on ubuntu:${{ matrix.image }}
       run: |
         apt update -y
-        apt install -y git
+        apt install -y --no-install-recommends git ca-certificates
         git config --global init.defaultBranch main
         git config --global --add safe.directory /__w/cantera/cantera
     - uses: actions/checkout@v4
@@ -90,7 +95,7 @@ jobs:
     - name: Install Apt dependencies
       # Use packages from ubuntu image when possible
       run: |
-        apt install -y python3 python3-pip pipenv scons build-essential \
+        apt install -y --no-install-recommends python3 python3-pip pipenv scons build-essential \
         libboost-dev gfortran libopenmpi-dev libpython3-dev \
         libblas-dev liblapack-dev libhdf5-dev libfmt-dev libyaml-cpp-dev \
         libgtest-dev libgmock-dev libeigen3-dev libsundials-dev \
@@ -184,43 +189,49 @@ jobs:
       uses: actions/setup-python@v5
       with:
         python-version: ${{ matrix.python-version }}
-        architecture: x64
         allow-prereleases: true
+    - name: Install uv
+      uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # v6.3.0
+      with:
+        python-version: ${{ matrix.python-version }}
+        enable-cache: true
+        cache-dependency-glob: |
+          ${{ env.REQUIREMENTS_TXT_FILE }}
     - name: Install Apt dependencies
       run: |
         sudo apt update
         sudo apt install libboost-dev gfortran libopenmpi-dev \
-        libblas-dev liblapack-dev libhdf5-dev libfmt-dev doxygen
+        libblas-dev liblapack-dev libhdf5-dev libfmt-dev doxygen \
+        libopenblas-dev
         gcc --version
-    - name: Upgrade pip
-      run: python3 -m pip install -U pip setuptools wheel packaging
+    # As of June 22, 2025, Pandas does not have nightly wheels for Python 3.14
     - name: Install Python dependencies
       run: |
-        python3 -m pip install ruamel.yaml scons pytest \
-        pytest-xdist pytest-github-actions-annotate-failures pint graphviz Jinja2
-        python3 -m pip install --pre numpy cython pandas scipy
+        uv venv --python ${{ matrix.python-version }} --seed
+        sed -i 's/cython.*\|pandas\|numpy\|scipy//g' "${REQUIREMENTS_TXT_FILE}"
+        uv pip install -r "${REQUIREMENTS_TXT_FILE}"
+        uv pip install --prerelease=allow numpy cython pandas scipy
     - name: Build Cantera
       run: |
-        python3 `which scons` build env_vars=all -j4 debug=n --debug=time logging=debug \
+        uv run scons build env_vars=all -j4 debug=n --debug=time logging=debug \
         system_fmt=y system_blas_lapack=y hdf_support=y cc_flags=-D_GLIBCXX_ASSERTIONS \
         python_package=y
     - name: Build Tests
-      run: python3 `which scons` -j4 build-tests
+      run: uv run scons -j4 build-tests
     - name: Run compiled tests
-      run: python3 `which scons` test-gtest test-legacy --debug=time
+      run: uv run scons test-gtest test-legacy --debug=time
     - name: Run Python tests
-      run: python3 -m pytest -raP -v -n auto --durations=50 test/python
+      run: uv run pytest -raP -v -n auto --durations=50 test/python
       env:
         LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:build/lib"
         PYTHONPATH: build/python
 
   macos-homebrew:
-    name: Install Latest Python ${{ matrix.python-version }} with Homebrew on ${{ matrix.os }}
+    name: Install Latest Python with Homebrew on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
       matrix:
-        python-version: ['3.13']
         os: ['macos-14', 'macos-15']
       fail-fast: false
     steps:
@@ -229,34 +240,38 @@ jobs:
       with:
         submodules: recursive
         persist-credentials: false
+    - name: Setup uv
+      uses: astral-sh/setup-uv@445689ea25e0de0a23313031f5fe577c74ae45a1 # v6.3.0
+      with:
+        enable-cache: true
+        cache-dependency-glob: |
+          ${{ env.REQUIREMENTS_TXT_FILE }}
     # NumPy is installed here for the Python custom rate tests
     - name: Install Brew dependencies
-      run: brew install --display-times boost libomp hdf5 python numpy doxygen
+      run: |
+        brew install --display-times boost libomp hdf5 python numpy doxygen
     - name: Set Include folder
       run: echo "BOOST_INC_DIR=$(brew --prefix)/include" >> $GITHUB_ENV
     # This is necessary because of PEP 668 https://peps.python.org/pep-0668/
     # PEP 668 prohibits installation to system Python packages via pip
     - name: Create a virtualenv for dependencies
       run: |
-        $(brew --prefix)/bin/python${{ matrix.python-version }} -m venv .venv
+        uv venv --python "$(brew --prefix)/bin/python3" --seed
     - name: Install Python dependencies
       # SCons must be installed into the virtualenv because packaging is a dependency
       # and we can't install packaging for the homebrew Python
       run: |
-        ./.venv/bin/python -m pip install -U pip setuptools wheel build
-        ./.venv/bin/python -m pip install ruamel.yaml numpy cython pandas pytest \
-          pytest-xdist pytest-github-actions-annotate-failures pint graphviz \
-          scons packaging Jinja2
+        uv pip install -r "${REQUIREMENTS_TXT_FILE}"
     - name: Build Cantera
       run: |
-        ./.venv/bin/scons build env_vars=all -j3 debug=n --debug=time logging=debug \
+        uv run scons build env_vars=all -j3 debug=n --debug=time logging=debug \
         boost_inc_dir=${BOOST_INC_DIR} python_package=y
     - name: Build Tests
-      run: ./.venv/bin/scons -j3 build-tests
+      run: uv run scons -j3 build-tests
     - name: Run compiled tests
-      run: ./.venv/bin/scons test-gtest test-legacy --debug=time
+      run: uv run scons test-gtest test-legacy --debug=time
     - name: Run Python tests
-      run: ./.venv/bin/python -m pytest -raP -v -n auto --durations=50 test/python
+      run: uv run pytest -raP -v -n auto --durations=50 test/python
       env:
         DYLD_LIBRARY_PATH: "${DYLD_LIBRARY_PATH}:build/lib"
         PYTHONPATH: build/python

--- a/SConstruct
+++ b/SConstruct
@@ -1628,7 +1628,7 @@ env['python_cmd_esc'] = quoted(env['python_cmd'])
 env["python_min_version"] = python_min_version
 env["python_max_version"] = python_max_version
 env["py_requires_ver_str"] = py_requires_ver_str
-env["cython_version_spec"] = SpecifierSet(">=0.29.31", prereleases=True)
+env["cython_version_spec"] = SpecifierSet(">=0.29.31,!=3.1.2", prereleases=True)
 # When updating NumPy spec, also update interfaces/python_sdist/pyproject.toml.in.
 env["numpy_version_spec"] = SpecifierSet(">=1.21.0,<3", prereleases=True)
 env["cython_version_spec_str"] = str(env["cython_version_spec"])

--- a/SConstruct
+++ b/SConstruct
@@ -181,6 +181,10 @@ python_max_version = parse_version("3.14")
 # The string is used to set python_requires in setup.cfg.in
 py_requires_ver_str = f">={python_min_version},<{python_max_version}"
 
+cython_version_spec = SpecifierSet(">=0.29.31,!=3.1.2", prereleases=True)
+numpy_version_spec = SpecifierSet(">=1.21.0,<3", prereleases=True)
+ruamel_version_spec = SpecifierSet(">=0.17.21,<1", prereleases=True)
+
 if "sdist" in COMMAND_LINE_TARGETS:
     if "clean" in COMMAND_LINE_TARGETS:
         COMMAND_LINE_TARGETS.remove("clean")
@@ -198,6 +202,9 @@ if "sdist" in COMMAND_LINE_TARGETS:
             py_requires_ver_str,
             cantera_version,
             cantera_short_version,
+            str(cython_version_spec),
+            str(numpy_version_spec),
+            str(ruamel_version_spec),
         ],
         check=True,
     )
@@ -1628,17 +1635,15 @@ env['python_cmd_esc'] = quoted(env['python_cmd'])
 env["python_min_version"] = python_min_version
 env["python_max_version"] = python_max_version
 env["py_requires_ver_str"] = py_requires_ver_str
-env["cython_version_spec"] = SpecifierSet(">=0.29.31,!=3.1.2", prereleases=True)
-# When updating NumPy spec, also update interfaces/python_sdist/pyproject.toml.in.
-env["numpy_version_spec"] = SpecifierSet(">=1.21.0,<3", prereleases=True)
-env["cython_version_spec_str"] = str(env["cython_version_spec"])
-env["numpy_version_spec_str"] = str(env["numpy_version_spec"])
+env["cython_version_spec"] = cython_version_spec
+env["cython_version_spec_str"] = str(cython_version_spec)
+env["numpy_version_spec"] = numpy_version_spec
+env["numpy_version_spec_str"] = str(numpy_version_spec)
 
 # We choose ruamel.yaml 0.17.16 as the minimum version since it is the highest version
-# available in the Ubuntu 22.04 repositories. When updating this, also update the
-# version string in interfaces/python_sdist/pyproject.toml.in.
-env["ruamel_version_spec"] = SpecifierSet(">=0.17.16", prereleases=True)
-env["ruamel_version_spec_str"] = str(env["ruamel_version_spec"])
+# available in the Ubuntu 22.04 repositories.
+env["ruamel_version_spec"] = ruamel_version_spec
+env["ruamel_version_spec_str"] = str(ruamel_version_spec)
 
 # Minimum pytest version assumed based on Ubuntu 20.04
 env["pytest_version_spec"] = SpecifierSet(">=4.6.9", prereleases=True)

--- a/SConstruct
+++ b/SConstruct
@@ -1639,9 +1639,6 @@ env["cython_version_spec"] = cython_version_spec
 env["cython_version_spec_str"] = str(cython_version_spec)
 env["numpy_version_spec"] = numpy_version_spec
 env["numpy_version_spec_str"] = str(numpy_version_spec)
-
-# We choose ruamel.yaml 0.17.16 as the minimum version since it is the highest version
-# available in the Ubuntu 22.04 repositories.
 env["ruamel_version_spec"] = ruamel_version_spec
 env["ruamel_version_spec_str"] = str(ruamel_version_spec)
 

--- a/interfaces/cython/pyproject.toml
+++ b/interfaces/cython/pyproject.toml
@@ -1,3 +1,3 @@
 [build-system]
-requires = ["setuptools>=43.0.0", "wheel", "Cython>=0.29.12"]
+requires = ["setuptools>=43.0.0", "wheel", "Cython>=0.29.12,!=3.1.2"]
 build-backend = "setuptools.build_meta"

--- a/interfaces/python_sdist/build_sdist.py
+++ b/interfaces/python_sdist/build_sdist.py
@@ -61,12 +61,20 @@ def do_configure_substitution(
 
 
 def do_pyproject_substitution(
-    pyproject_toml_source: Path, py_requires_ver_str: str, cantera_version: str
+    pyproject_toml_source: Path,
+    py_requires_ver_str: str,
+    cantera_version: str,
+    cython_requires_ver_str: str,
+    numpy_requires_ver_str: str,
+    ruamel_requires_ver_str: str,
 ) -> str:
     pyproject_toml_template = pyproject_toml_source.read_text().splitlines()
     pyproject_subst = {
         "@py_requires_ver_str@": py_requires_ver_str,
         "@cantera_version@": cantera_version,
+        "@cython_version_spec_str@": cython_requires_ver_str,
+        "@numpy_requires_ver_str@": numpy_requires_ver_str,
+        "@ruamel_requires_ver_str@": ruamel_requires_ver_str,
     }
     pyproject_toml_output = _substitute_lines(pyproject_toml_template, pyproject_subst)
     return "\n".join(pyproject_toml_output)
@@ -91,6 +99,9 @@ def main(
     py_requires_ver_str: str,
     cantera_version: str,
     cantera_short_version: str,
+    cython_requires: str,
+    numpy_requires: str,
+    ruamel_requires: str,
 ):
     src_source = source_directory / "src"
     src_target = target_directory / "src"
@@ -169,7 +180,12 @@ def main(
     pyproject_toml_target = target_directory / "pyproject.toml"
     pyproject_toml_target.write_text(
         do_pyproject_substitution(
-            pyproject_toml_source, py_requires_ver_str, cantera_version
+            pyproject_toml_source,
+            py_requires_ver_str,
+            cantera_version,
+            cython_requires,
+            numpy_requires,
+            ruamel_requires,
         )
     )
 
@@ -197,6 +213,9 @@ def parse_args(argv: list[str] | None = None) -> argparse.Namespace:
     parser.add_argument("python_version_req")
     parser.add_argument("cantera_version")
     parser.add_argument("cantera_short_version")
+    parser.add_argument("cython_requires")
+    parser.add_argument("numpy_requires")
+    parser.add_argument("ruamel_requires")
     args = parser.parse_args(argv)
     return args
 
@@ -210,4 +229,7 @@ if __name__ == "__main__":
         args.python_version_req,
         args.cantera_version,
         args.cantera_short_version,
+        args.cython_requires,
+        args.numpy_requires,
+        args.ruamel_requires,
     )

--- a/interfaces/python_sdist/pyproject.toml.in
+++ b/interfaces/python_sdist/pyproject.toml.in
@@ -1,5 +1,5 @@
 [build-system]
-requires = ["scikit-build-core", "cython", "numpy>=2.0"]
+requires = ["scikit-build-core", "cython @cython_version_spec_str@", "numpy>=2.0"]
 build-backend = "scikit_build_core.build"
 
 [project]
@@ -32,8 +32,8 @@ classifiers = [
 ]
 requires-python = "@py_requires_ver_str@"
 dependencies = [
-    "numpy >= 1.21.0,<3",
-    "ruamel.yaml >= 0.17.16",
+    "numpy @numpy_version_spec_str@",
+    "ruamel.yaml @ruamel_version_spec_str@",
 ]
 
 [project.readme]

--- a/platform/ci_support/post_merge_reqs.txt
+++ b/platform/ci_support/post_merge_reqs.txt
@@ -1,0 +1,20 @@
+# Requirements to build Cantera
+scons
+cython !=3.1.2
+numpy
+jinja2
+setuptools
+wheel
+packaging
+build
+
+# Requirements for running the Python interface
+pandas
+pint
+graphviz
+ruamel.yaml
+
+# Requirements for testing
+pytest
+pytest-xdist
+pytest-github-actions-annotate-failures


### PR DESCRIPTION
**Changes proposed in this pull request**

- **[Cython] Enforce cython cannot be v3.1.2**
- **[Sdist] Template requirements versions**

Building wheels is currently broken due to the regression fixed for CI in #1908 here and cython/cython#6957 in Cython. Since this version will always be broken, we should enforce in the build systems that it is incompatible.

**If applicable, fill in the issue number this pull request is fixing**

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
