### PR TITLE
Fix reaction balance check for elements with negative abundances

### DIFF
--- a/include/cantera/thermo/HMWSoln.h
+++ b/include/cantera/thermo/HMWSoln.h
@@ -1386,7 +1386,7 @@ private:
      *          dw = C_0 * M_0 (density of water) (kg/m3)
      *             = 1.0E3 at 25C
      */
-    mutable double m_A_Debye;
+    mutable double m_A_Debye = 1.172576;
 
     //! Water standard state calculator
     /*!

--- a/src/kinetics/Reaction.cpp
+++ b/src/kinetics/Reaction.cpp
@@ -624,9 +624,9 @@ void Reaction::checkBalance(const Kinetics& kin) const
     string msg;
     bool ok = true;
     for (const auto& [elem, balance] : balr) {
-        double elemsum = balr[elem] + balp[elem];
+        double scale = std::max(std::abs(balr[elem]), std::abs(balp[elem]));
         double elemdiff = fabs(balp[elem] - balr[elem]);
-        if (elemsum > 0.0 && elemdiff / elemsum > 1e-4) {
+        if (elemdiff > 1e-4 * scale) {
             ok = false;
             msg += fmt::format("  {}           {}           {}\n",
                                elem, balr[elem], balp[elem]);

--- a/test/SConscript
+++ b/test/SConscript
@@ -177,7 +177,7 @@ def addPythonTest(testname, subset):
                 if class_name.startswith("build.python.cantera.test."):
                     class_name = class_name[26:]
                 test_name = "python: {}.{}".format(class_name, test.get('name'))
-                if test.findall('failure'):
+                if test.findall('failure') or test.findall('error'):
                     test_results.failed[test_name] = 1
                     failures += 1
                 else:

--- a/test/data/kineticsfromscratch.yaml
+++ b/test/data/kineticsfromscratch.yaml
@@ -12,7 +12,6 @@ units: {activation-energy: cal/mol}
 phases:
 - name: ohmech
   thermo: ideal-gas
-  elements: [O, H, Ar]
   species:
   - h2o2.yaml/species: [AR, O, H2, H, OH, O2, H2O, H2O2, HO2]
   kinetics: gas
@@ -32,6 +31,14 @@ phases:
     T: 900.0
     coverages: {PT(S): 0.35, H(S): 0.35, H2O(S): .1, OH(S): 0.1, O(S): 0.1}
   site-density: 2.7063e-09
+- name: ions
+  thermo: ideal-gas
+  species:
+  - h2o2.yaml/species: [AR, O, H2, H, OH, O2, H2O, H2O2, HO2]
+  - ch4_ion.yaml/species: [E, O2-, H3O+]
+  kinetics: gas
+  reactions: none
+  state: {T: 300.0, P: 1.01325e+05}
 
 reactions:
 - equation: O + H2 <=> H + OH  # Reaction 1

--- a/test/kinetics/kineticsFromScratch.cpp
+++ b/test/kinetics/kineticsFromScratch.cpp
@@ -567,6 +567,38 @@ TEST_F(KineticsFromScratch, invalid_nonreactant_order)
     ASSERT_EQ((size_t) 0, kin.nReactions());
 }
 
+TEST_F(KineticsFromScratch, unbalanced_neutral)
+{
+    Composition reac = parseCompString("O:1 H2:1");
+    Composition prod = parseCompString("H:1 H2O:1");
+    auto rate = make_shared<ArrheniusRate>(1.0, 0.0, 0.0);
+    auto R = make_shared<Reaction>(reac, prod, rate);
+    ASSERT_THROW(kin.addReaction(R), CanteraError);
+    ASSERT_EQ((size_t) 0, kin.nReactions());
+}
+
+TEST(KineticsFromScratch2, unbalanced_positive_ion)
+{
+    auto soln = newSolution("kineticsfromscratch.yaml", "ions");
+    Composition reac = parseCompString("H3O+:1");
+    Composition prod = parseCompString("H2O:1 H:1");
+    auto rate = make_shared<ArrheniusRate>(1.0, 0.0, 0.0);
+    auto R = make_shared<Reaction>(reac, prod, rate);
+    ASSERT_THROW(soln->kinetics()->addReaction(R), CanteraError);
+    ASSERT_EQ((size_t) 0, soln->kinetics()->nReactions());
+}
+
+TEST(KineticsFromScratch2, unbalanced_negative_ion)
+{
+    auto soln = newSolution("kineticsfromscratch.yaml", "ions");
+    Composition reac = parseCompString("O2-:1");
+    Composition prod = parseCompString("O2:1 E:2");
+    auto rate = make_shared<ArrheniusRate>(1.0, 0.0, 0.0);
+    auto R = make_shared<Reaction>(reac, prod, rate);
+    ASSERT_THROW(soln->kinetics()->addReaction(R), CanteraError);
+    ASSERT_EQ((size_t) 0, soln->kinetics()->nReactions());
+}
+
 class InterfaceKineticsFromScratch : public testing::Test
 {
 public:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix reaction balance check when there are species with negative element abundances (namely, electrons in positive ions)
- Fix counting of Pytest tests that report "error" status as failing in the `scons test` summary
- Fix flapping test coverage in `HMWSoln::s_update_lnMolalityActCoeff`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1910

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
