### PR TITLE
Add sundials mpi check

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -223,11 +223,15 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        macos-version: ['macos-13', 'macos-14', 'macos-15']
+        macos-version: ['macos-14', 'macos-15']
         python-version: ['3.12', '3.13']
         include:
           - macos-version: 'macos-13'
             python-version: '3.11'
+          - macos-version: 'macos-13'
+            python-version: '3.12'
+          - macos-version: 'macos-13'
+            python-version: '3.13.4'
           - macos-version: 'macos-14'
             python-version: '3.10'
             extra-build-args: cxx_flags='-std=c++20'

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -71,10 +71,16 @@ jobs:
         PYTHONPATH: build/python
 
   ubuntu-docker:
-    name: Docker 'ubuntu:${{ matrix.image }}' image
+    name: Docker 'ubuntu:${{ matrix.image }}' image with Sundials MPI ${{ matrix.mpi }}
     strategy:
       matrix:
-        image: [devel, rolling]
+        include:
+        - image: "devel"
+          options: ""
+          mpi: override  # fall back to bundled Sundials (system_sundials=default)
+        - image: "rolling"
+          options: "system_sundials=y CC=mpicc CXX=mpicxx FORTRAN=mpifort"
+          mpi: enabled  # use MPI compiler wrappers
       fail-fast: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
@@ -95,10 +101,11 @@ jobs:
     - name: Install Apt dependencies
       # Use packages from ubuntu image when possible
       run: |
-        apt install -y --no-install-recommends python3 python3-pip pipenv scons build-essential \
-        libboost-dev gfortran libopenmpi-dev libpython3-dev \
+        apt install -y --no-install-recommends python3 python3-pip pipenv scons \
+        build-essential libboost-dev gfortran libopenmpi-dev libpython3-dev \
         libblas-dev liblapack-dev libhdf5-dev libfmt-dev libyaml-cpp-dev \
         libgtest-dev libgmock-dev libeigen3-dev libsundials-dev \
+        openmpi-bin libopenmpi-dev \
         cython3 python3-numpy python3-pandas python3-pint python3-graphviz \
         python3-ruamel.yaml python3-setuptools python3-wheel python3-pytest \
         python3-pytest-xdist doxygen python3-jinja2
@@ -109,9 +116,9 @@ jobs:
     - name: Build Cantera
       run: |
         scons build env_vars=all -j4 debug=n --debug=time logging=debug \
-        system_eigen=y system_fmt=y system_sundials=y system_yamlcpp=y \
-        system_blas_lapack=y hdf_support=y f90_interface=y \
-        cc_flags=-D_GLIBCXX_ASSERTIONS python_package=y
+        system_eigen=y system_fmt=y ${{ matrix.options }} \
+        system_yamlcpp=y system_blas_lapack=y hdf_support=y \
+        cc_flags=-D_GLIBCXX_ASSERTIONS python_package=y f90_interface=y
     - name: Build Tests
       run: scons -j4 build-tests
     - name: Run compiled tests


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Create a more meaningful error message if Sundials is compiled with MPI support but `mpi.h` is not found.

~I am hesitant to fix the post-merge tests via~
```
scons build CC=mpicc CXX=mpicxx env_vars=all
```
~though, as there is still some hope that Debian maintainers will reconsider the MPI default - relinking https://bugs.debian.org/cgi-bin/bugreport.cgi?bug=1082085~

* _Post-merge tests are fixed_
* _Fixed issue for `FORTRAN=mpifort`_

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Relates to #1843

**If applicable, provide an example illustrating new features this pull request is introducing**

~See failing "post-merge" tests.~ _Edit: no longer failing_

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
