### PR TITLE
Clone Solution objects used by Reactor / ReactorSurface

### DIFF
--- a/doc/sphinx/develop/reactor-integration.md
+++ b/doc/sphinx/develop/reactor-integration.md
@@ -20,7 +20,7 @@ up an isolated reactor in Python.
 import cantera as ct
 gas = ct.Solution("gri30.yaml")
 gas.TPX = 1000.0, ct.one_atm, "H2:2,O2:1,N2:4"
-reac = ct.IdealGasReactor(gas)
+reac = ct.IdealGasReactor(gas, clone=False)
 sim = ct.ReactorNet([reac])
 ```
 

--- a/doc/sphinx/python/zerodim.rst
+++ b/doc/sphinx/python/zerodim.rst
@@ -42,71 +42,71 @@ Reservoir
 
 Reactor
 ^^^^^^^
-.. autoclass:: Reactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: Reactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 MoleReactor
 ^^^^^^^^^^^
-.. autoclass:: MoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: MoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasReactor
 ^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasMoleReactor
 ^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ConstPressureReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ConstPressureReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ConstPressureMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ConstPressureMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasConstPressureReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasConstPressureReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasConstPressureMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasConstPressureMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 FlowReactor
 ^^^^^^^^^^^
-.. autoclass:: FlowReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: FlowReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleReactor
 ^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleConstPressureReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleConstPressureReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasConstPressureReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasConstPressureReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleConstPressureMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleConstPressureMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasConstPressureMoleReactor(contents=None, *, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasConstPressureMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 Walls
 -----
@@ -121,7 +121,7 @@ Surfaces
 
 ReactorSurface
 ^^^^^^^^^^^^^^
-.. autoclass:: ReactorSurface(kin=None, r=None, *, A=None)
+.. autoclass:: ReactorSurface(contents, r=None, clone=None, name="(none)", *, A=None)
 
 Flow Controllers
 ----------------

--- a/doc/sphinx/yaml/phases.md
+++ b/doc/sphinx/yaml/phases.md
@@ -113,6 +113,12 @@ are:
   - `surface` ({ct}`details <InterfaceKinetics>`)
   - `edge` ({ct}`details <EdgeKinetics>`)
 
+(sec-yaml-rate-multipliers)=
+`rate-multipliers`
+: A mapping of reaction indices and multipliers applied to the forward rate
+  constants. The key `default` is used to specify the default rate multiplier, which is
+  used for reactions not specified in the mapping.
+
 (sec-yaml-phase-reactions)=
 `reactions`
 : Source of reactions to include in the phase, if a kinetics model has been specified.

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -58,7 +58,10 @@ public:
     //! Create a new Solution object with cloned ThermoPhase and Kinetics objects that
     //! use the same species definitions, thermodynamic parameters, and reactions as
     //! this one.
-    shared_ptr<Solution> clone() const;
+    //! @param adjacent  For surface phases, an optional list of new adjacent phases
+    //!     to link to the InterfaceKinetics object. If not provided, the existing
+    //!     adjacent phases will be cloned.
+    shared_ptr<Solution> clone(const vector<shared_ptr<Solution>>& adjacent={}) const;
 
     //! Return the name of this Solution object
     string name() const;

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -59,8 +59,8 @@ public:
     //! use the same species definitions, thermodynamic parameters, and reactions as
     //! this one.
     //! @param adjacent  For surface phases, an optional list of new adjacent phases
-    //!     to link to the InterfaceKinetics object. If not provided, the existing
-    //!     adjacent phases will be cloned.
+    //!     to link to the InterfaceKinetics object. Any adjacent phases not provided
+    //!     will have their ThermoPhase model automatically cloned.
     //! @param withKinetics  Flag indicating whether to clone the Kinetics object
     //!    associated with this phase
     //! @param withTransport  Flag indicating whether to clone the Transport object

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -117,9 +117,7 @@ public:
     }
 
     //! Get the Solution object for an adjacent phase by name
-    shared_ptr<Solution> adjacent(const string& name) {
-        return m_adjacentByName.at(name);
-    }
+    shared_ptr<Solution> adjacent(const string& name);
 
     //! Get the number of adjacent phases
     size_t nAdjacent() const {

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -55,16 +55,19 @@ public:
         return shared_ptr<Solution>( new Solution );
     }
 
-    //! Create a new Solution object with cloned ThermoPhase and Kinetics objects that
-    //! use the same species definitions, thermodynamic parameters, and reactions as
-    //! this one.
+    //! Create a new Solution object with cloned ThermoPhase, Kinetics, and Transport
+    //! objects that use the same species definitions, thermodynamic parameters, and
+    //! reactions as this one.
     //! @param adjacent  For surface phases, an optional list of new adjacent phases
     //!     to link to the InterfaceKinetics object. Any adjacent phases not provided
     //!     will have their ThermoPhase model automatically cloned.
     //! @param withKinetics  Flag indicating whether to clone the Kinetics object
-    //!    associated with this phase
+    //!    associated with this phase. If `false`, the cloned Solution will not include
+    //!    a kinetics manager.
     //! @param withTransport  Flag indicating whether to clone the Transport object
-    //!    associated with this phase
+    //!    associated with this phase. If `false`, the cloned Solution will not include
+    //!    a transport property manager.
+    //! @since New in %Cantera 3.2.
     shared_ptr<Solution> clone(const vector<shared_ptr<Solution>>& adjacent={},
                                bool withKinetics=true, bool withTransport=true) const;
 

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -55,6 +55,11 @@ public:
         return shared_ptr<Solution>( new Solution );
     }
 
+    //! Create a new Solution object with cloned ThermoPhase and Kinetics objects that
+    //! use the same species definitions, thermodynamic parameters, and reactions as
+    //! this one.
+    shared_ptr<Solution> clone() const;
+
     //! Return the name of this Solution object
     string name() const;
 

--- a/include/cantera/base/Solution.h
+++ b/include/cantera/base/Solution.h
@@ -61,7 +61,12 @@ public:
     //! @param adjacent  For surface phases, an optional list of new adjacent phases
     //!     to link to the InterfaceKinetics object. If not provided, the existing
     //!     adjacent phases will be cloned.
-    shared_ptr<Solution> clone(const vector<shared_ptr<Solution>>& adjacent={}) const;
+    //! @param withKinetics  Flag indicating whether to clone the Kinetics object
+    //!    associated with this phase
+    //! @param withTransport  Flag indicating whether to clone the Transport object
+    //!    associated with this phase
+    shared_ptr<Solution> clone(const vector<shared_ptr<Solution>>& adjacent={},
+                               bool withKinetics=true, bool withTransport=true) const;
 
     //! Return the name of this Solution object
     string name() const;

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -142,6 +142,7 @@ public:
     //! @param phases Phases used to specify the state for the newly cloned Kinetics
     //!     object. These can be created from the phases used by this object using the
     //!     ThermoPhase::clone() method.
+    //! @since New in %Cantera 3.2.
     shared_ptr<Kinetics> clone(const vector<shared_ptr<ThermoPhase>>& phases) const;
 
     //! Identifies the Kinetics manager type.

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -1280,7 +1280,7 @@ public:
     //! Return the parameters for a phase definition which are needed to
     //! reconstruct an identical object using the newKinetics function. This
     //! excludes the reaction definitions, which are handled separately.
-    AnyMap parameters();
+    AnyMap parameters() const;
 
     /**
      * Resize arrays with sizes that depend on the total number of species.

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -1284,6 +1284,10 @@ public:
      */
     virtual void init() {}
 
+    //! Set kinetics-related parameters from an AnyMap phase description.
+    //! @since New in %Cantera 3.2.
+    virtual void setParameters(const AnyMap& phaseNode);
+
     //! Return the parameters for a phase definition which are needed to
     //! reconstruct an identical object using the newKinetics function. This
     //! excludes the reaction definitions, which are handled separately.
@@ -1488,6 +1492,10 @@ protected:
     //! Vector of perturbation factors for each reaction's rate of
     //! progress vector. It is initialized to one.
     vector<double> m_perturb;
+
+    //! Default values for perturbations defined in the phase definition's
+    //! `rate-multipliers` field. Key -1 contains the default multiplier.
+    map<size_t, double> m_defaultPerturb = {{-1, 1.0}};
 
     //! Vector of Reaction objects represented by this Kinetics manager
     vector<shared_ptr<Reaction>> m_reactions;

--- a/include/cantera/kinetics/Kinetics.h
+++ b/include/cantera/kinetics/Kinetics.h
@@ -137,6 +137,13 @@ public:
     Kinetics(const Kinetics&) = delete;
     Kinetics& operator=(const Kinetics&)= delete;
 
+    //! Create a new Kinetics object with the same kinetics model and reactions as
+    //! this one.
+    //! @param phases Phases used to specify the state for the newly cloned Kinetics
+    //!     object. These can be created from the phases used by this object using the
+    //!     ThermoPhase::clone() method.
+    shared_ptr<Kinetics> clone(const vector<shared_ptr<ThermoPhase>>& phases) const;
+
     //! Identifies the Kinetics manager type.
     //! Each class derived from Kinetics should override this method to return
     //! a meaningful identifier.

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -396,6 +396,10 @@ public:
     //! so this constructor should not be called explicitly.
     ThermoPhase() = default;
 
+    //! Create a new ThermoPhase object using the same species definitions,
+    //! thermodynamic parameters, and state as this one.
+    shared_ptr<ThermoPhase> clone() const;
+
     //! @name  Information Methods
     //! @{
 

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -2035,6 +2035,13 @@ public:
         m_soln = soln;
     }
 
+    //! Get the Solution object containing this ThermoPhase object and linked
+    //! Kinetics and Transport objects.
+    //! @since New in %Cantera 3.2.
+    shared_ptr<Solution> root() const {
+        return m_soln.lock();
+    }
+
 protected:
     //! Store the parameters of a ThermoPhase object such that an identical
     //! one could be reconstructed using the newThermo(AnyMap&) function. This

--- a/include/cantera/thermo/ThermoPhase.h
+++ b/include/cantera/thermo/ThermoPhase.h
@@ -398,6 +398,7 @@ public:
 
     //! Create a new ThermoPhase object using the same species definitions,
     //! thermodynamic parameters, and state as this one.
+    //! @since New in %Cantera 3.2.
     shared_ptr<ThermoPhase> clone() const;
 
     //! @name  Information Methods

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -86,6 +86,8 @@ public:
     Transport(const Transport&) = delete;
     Transport& operator=(const Transport&) = delete;
 
+    shared_ptr<Transport> clone(shared_ptr<ThermoPhase> thermo) const;
+
     //! Identifies the model represented by this Transport object. Each derived class
     //! should override this method to return a meaningful identifier.
     //! @since New in %Cantera 3.0. The name returned by this method corresponds
@@ -404,8 +406,23 @@ public:
      * @param thermo  Pointer to the ThermoPhase object
      * @param mode    Chemkin compatible mode or not. This alters the
      *                 specification of the collision integrals. defaults to no.
+     * @deprecated To be removed after %Cantera 3.2. Use version that takes
+     *     `shared_ptr<ThermoPhase>`.
      */
     virtual void init(ThermoPhase* thermo, int mode=0) {}
+
+    //! Initialize a transport manager
+    /*!
+     * This routine sets up a transport manager. It calculates the collision
+     * integrals and populates species-dependent data structures.
+     *
+     * @param thermo  ThermoPhase object determining conditions for which to compute
+     *     transport properties.
+     * @param mode  Chemkin compatible mode or not. This alters the
+     *     specification of the collision integrals. defaults to no.
+     * @since  Changed to use `shared_ptr<ThermoPhase>` in %Cantera 3.2.
+     */
+    virtual void init(shared_ptr<ThermoPhase> thermo, int mode=0) {}
 
     //! Boolean indicating the form of the transport properties polynomial fits.
     //! Returns true if the Chemkin form is used.

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -86,6 +86,12 @@ public:
     Transport(const Transport&) = delete;
     Transport& operator=(const Transport&) = delete;
 
+    //! Create a new Transport object using the same transport model and species
+    //! transport properties as this one.
+    //! @param phase ThermoPhase used to specify the state for the newly cloned
+    //!     Transport object. Can be created from the phase used by the current
+    //!     Transport object using the ThermoPhase::clone() method.
+    //! @since New in %Cantera 3.2.
     shared_ptr<Transport> clone(shared_ptr<ThermoPhase> thermo) const;
 
     //! Identifies the model represented by this Transport object. Each derived class

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -48,6 +48,8 @@ class Reactor : public ReactorBase
 public:
     Reactor(shared_ptr<Solution> sol, const string& name="(none)");
     Reactor(shared_ptr<Solution> sol, bool clone, const string& name="(none)");
+    //! TODO: Remove after %Cantera 3.2 -- all derived classes should use Solution-based
+    //! constructors.
     using ReactorBase::ReactorBase; // inherit constructors
 
     string type() const override {

--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -47,6 +47,7 @@ class Reactor : public ReactorBase
 {
 public:
     Reactor(shared_ptr<Solution> sol, const string& name="(none)");
+    Reactor(shared_ptr<Solution> sol, bool clone, const string& name="(none)");
     using ReactorBase::ReactorBase; // inherit constructors
 
     string type() const override {

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -84,6 +84,9 @@ public:
     //!              ReactorBase with Solution object.
     void setSolution(shared_ptr<Solution> sol);
 
+    //! Access the Solution object used to represent the contents of this reactor.
+    shared_ptr<Solution> solution() { return m_solution; }
+
     //! @name Methods to set up a simulation
     //! @{
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -49,11 +49,24 @@ class ReactorBase
 {
 public:
     explicit ReactorBase(const string& name="(none)");
+
     //! Instantiate a ReactorBase object with Solution contents.
     //! @param sol  Solution object to be set.
     //! @param name  Name of the reactor.
     //! @since New in %Cantera 3.1.
     ReactorBase(shared_ptr<Solution> sol, const string& name="(none)");
+
+    //! Instantiate a ReactorBase object with Solution contents.
+    //! @param sol  Solution object representing the contents of this reactor
+    //! @param clone  Determines whether to clone `sol` so that the internal state of
+    //!     this reactor is independent of the original Solution object and any Solution
+    //!     objects used by other reactors in the network.
+    //! @param name  Name of the reactor.
+    //! @since Added the `clone` argument in %Cantera 3.2. If not specified, the default
+    //!     behavior in %Cantera 3.2 is not to clone the Solution object. This will
+    //!     change after %Cantera 3.2 to default to `true`.
+    ReactorBase(shared_ptr<Solution> sol, bool clone, const string& name="(none)");
+
     virtual ~ReactorBase();
     ReactorBase(const ReactorBase&) = delete;
     ReactorBase& operator=(const ReactorBase&) = delete;

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -48,6 +48,7 @@ struct SensitivityParameter
 class ReactorBase
 {
 public:
+    //! @deprecated After %Cantera 3.2, this constructor will become protected
     explicit ReactorBase(const string& name="(none)");
 
     //! Instantiate a ReactorBase object with Solution contents.

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -142,9 +142,15 @@ public:
     WallBase& wall(size_t n);
 
     //! Add a ReactorSurface object to a Reactor object.
+    //! @attention This method should generally not be called directly by users.
+    //!     Reactor and ReactorSurface objects should be connected by providing adjacent
+    //!     reactors to the newReactorSurface factory function.
     virtual void addSurface(ReactorSurface* surf);
 
     //! Add a ReactorSurface object to a Reactor object.
+    //! @attention This method should generally not be called directly by users.
+    //!     Reactor and ReactorSurface objects should be connected by providing adjacent
+    //!     reactors to the newReactorSurface factory function.
     void addSurface(shared_ptr<ReactorBase> surf);
 
     //! Return a reference to the *n*-th ReactorSurface connected to this reactor.

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -168,6 +168,7 @@ public:
     //! @attention This method should generally not be called directly by users.
     //!     Reactor and ReactorSurface objects should be connected by providing adjacent
     //!     reactors to the newReactorSurface factory function.
+    //! @deprecated  Unused. To be removed after %Cantera 3.2.
     void addSurface(shared_ptr<ReactorBase> surf);
 
     //! Return a reference to the *n*-th ReactorSurface connected to this reactor.

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -59,8 +59,8 @@ template <class R>
 class ReactorDelegator : public Delegator, public R, public ReactorAccessor
 {
 public:
-    ReactorDelegator(shared_ptr<Solution> contents, const string& name="(none)")
-        : R(contents, name)
+    ReactorDelegator(shared_ptr<Solution> contents, bool clone, const string& name="(none)")
+        : R(contents, clone, name)
     {
         install("initialize", m_initialize, [this](double t0) { R::initialize(t0); });
         install("syncState", m_syncState, [this]() { R::syncState(); });

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -69,6 +69,13 @@ shared_ptr<Reactor> newReactor4(
 shared_ptr<Reservoir> newReservoir(
     shared_ptr<Solution> contents, const string& name="(none)");
 
+//! Create a ReactorSurface object with the specified contents and adjacent reactors
+//! participating in surface reactions.
+//! @since  New in %Cantera 3.2.
+shared_ptr<ReactorSurface> newReactorSurface(
+    shared_ptr<Solution> soln, const vector<shared_ptr<ReactorBase>>& reactors,
+    const string& name="(none)");
+
 //! @}
 
 }

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -22,7 +22,7 @@ class Reservoir;
 //! ```cpp
 //!     shared_ptr<ReactorBase> r1 = newReactor("IdealGasReactor");
 //! ```
-class ReactorFactory : public Factory<ReactorBase, shared_ptr<Solution>, const string&>
+class ReactorFactory : public Factory<ReactorBase, shared_ptr<Solution>, bool, const string&>
 {
 public:
     static ReactorFactory* factory();
@@ -49,7 +49,8 @@ private:
 //! Create a ReactorBase object of the specified type and contents.
 //! @since  New in %Cantera 3.2.
 shared_ptr<ReactorBase> newReactorBase(
-    const string& model, shared_ptr<Solution> contents, const string& name="(none)");
+    const string& model, shared_ptr<Solution> contents, bool clone=true,
+    const string& name="(none)");
 
 //! Create a Reactor object of the specified type and contents
 //! @since Starting in %Cantera 3.1, this method requires a valid Solution object and
@@ -62,19 +63,20 @@ shared_ptr<ReactorBase> newReactor(
 //! Create a Reactor object of the specified type and contents
 //! @since  New in %Cantera 3.2. Transitional method returning a `Reactor` object.
 shared_ptr<Reactor> newReactor4(
-    const string& model, shared_ptr<Solution> contents, const string& name="(none)");
+    const string& model, shared_ptr<Solution> contents, bool clone=true,
+    const string& name="(none)");
 
 //! Create a Reservoir object with the specified contents
 //! @since New in %Cantera 3.2.
 shared_ptr<Reservoir> newReservoir(
-    shared_ptr<Solution> contents, const string& name="(none)");
+    shared_ptr<Solution> contents, bool clone=true, const string& name="(none)");
 
 //! Create a ReactorSurface object with the specified contents and adjacent reactors
 //! participating in surface reactions.
 //! @since  New in %Cantera 3.2.
 shared_ptr<ReactorSurface> newReactorSurface(
     shared_ptr<Solution> soln, const vector<shared_ptr<ReactorBase>>& reactors,
-    const string& name="(none)");
+    bool clone=true, const string& name="(none)");
 
 //! @}
 

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -61,21 +61,42 @@ shared_ptr<ReactorBase> newReactor(
     const string& model, shared_ptr<Solution> contents, const string& name="(none)");
 
 //! Create a Reactor object of the specified type and contents
+//! @param  model  Reactor type to be created. See [this list of reactor
+//!     types](../reference/reactors/index.html) for available options.
+//! @param  contents  Solution object to model the thermodynamic properties and
+//!     reactions occurring in the reactor
+//! @param clone  Determines whether to clone `sol` so that the internal state of this
+//!     reactor is independent of the original Solution object and any Solution objects
+//!     used by other reactors in the network.
+//! @param name  Name of the reactor.
 //! @since  New in %Cantera 3.2. Transitional method returning a `Reactor` object.
 shared_ptr<Reactor> newReactor4(
     const string& model, shared_ptr<Solution> contents, bool clone=true,
     const string& name="(none)");
 
 //! Create a Reservoir object with the specified contents
+//! @param  contents  Solution object to model the contents of this reservoir
+//! @param clone  Determines whether to clone `sol` so that the internal state of this
+//!     reservoir is independent of the original Solution object and any Solution
+//!     objects used by other reactors in the network.
+//! @param name  Name of the reservoir.
 //! @since New in %Cantera 3.2.
 shared_ptr<Reservoir> newReservoir(
     shared_ptr<Solution> contents, bool clone=true, const string& name="(none)");
 
 //! Create a ReactorSurface object with the specified contents and adjacent reactors
 //! participating in surface reactions.
+//! @param  contents  Solution (Interface) object to model the thermodynamic properties
+//!     and reactions occurring in the reactor
+//! @param  reactors  List of Reactors adjacent to this surface, whose contents
+//!     participate in reactions occurring on this surface.
+//! @param clone  Determines whether to clone `sol` so that the internal state of this
+//!     surface is independent of the original Interface object and any Solution objects
+//!     used by other reactors in the network except those in the `reactors` list.
+//! @param name  Name of the reactor surface.
 //! @since  New in %Cantera 3.2.
 shared_ptr<ReactorSurface> newReactorSurface(
-    shared_ptr<Solution> soln, const vector<shared_ptr<ReactorBase>>& reactors,
+    shared_ptr<Solution> contents, const vector<shared_ptr<ReactorBase>>& reactors,
     bool clone=true, const string& name="(none)");
 
 //! @}

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -22,13 +22,19 @@ public:
     //! Create a new ReactorSurface
     //! @param soln  Thermodynamic and kinetic model representing species and reactions
     //!     on the surface
+    //! @param clone  Determines whether to clone `soln` so that the internal state of
+    //!     this reactor surface is independent of the original Solution (Interface)
+    //!     object and any Solution objects used by other reactors in the network.
     //! @param reactors  One or more reactors whose phases participate in reactions
     //!     occurring on the surface. For the purpose of rate evaluation, the
     //!     temperature of the surface is set equal to the temperature of the first
     //!     reactor specified.
     //! @param name  Name used to identify the surface
+    //! @since  Constructor signature including `reactors` and `clone` arguments
+    //!     introduced in %Cantera 3.2.
     ReactorSurface(shared_ptr<Solution> soln,
                    const vector<shared_ptr<ReactorBase>>& reactors,
+                   bool clone,
                    const string& name="(none)");
 
     ReactorSurface(shared_ptr<Solution> sol, const string& name="(none)");

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -40,7 +40,10 @@ public:
     //! @deprecated To be removed after Cantera 3.2. Replaced by constructor where
     //!    contents and adjacent reactors are specified
     ReactorSurface(shared_ptr<Solution> sol, const string& name="(none)");
-    using ReactorBase::ReactorBase; // inherit constructors
+
+    //! @deprecated To be removed after Cantera 3.2. Replaced by constructor where
+    //!    contents and adjacent reactors are specified
+    ReactorSurface(shared_ptr<Solution> sol, bool clone, const string& name="(none)");
 
     //! String indicating the wall model implemented.
     string type() const override {

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -19,6 +19,18 @@ class SurfPhase;
 class ReactorSurface : public ReactorBase
 {
 public:
+    //! Create a new ReactorSurface
+    //! @param soln  Thermodynamic and kinetic model representing species and reactions
+    //!     on the surface
+    //! @param reactors  One or more reactors whose phases participate in reactions
+    //!     occurring on the surface. For the purpose of rate evaluation, the
+    //!     temperature of the surface is set equal to the temperature of the first
+    //!     reactor specified.
+    //! @param name  Name used to identify the surface
+    ReactorSurface(shared_ptr<Solution> soln,
+                   const vector<shared_ptr<ReactorBase>>& reactors,
+                   const string& name="(none)");
+
     ReactorSurface(shared_ptr<Solution> sol, const string& name="(none)");
     using ReactorBase::ReactorBase; // inherit constructors
 
@@ -67,6 +79,8 @@ public:
     }
 
     //! Set the reactor that this Surface interacts with
+    //! @deprecated To be removed after %Cantera 3.2. Superseded by constructor taking
+    //!     a list of adjacent reactors.
     void setReactor(ReactorBase* reactor);
 
     //! Set the surface coverages. Array `cov` has length equal to the number of
@@ -115,7 +129,7 @@ protected:
 
     SurfPhase* m_surf = nullptr;
     Kinetics* m_kinetics = nullptr;
-    ReactorBase* m_reactor = nullptr;
+    vector<ReactorBase*> m_reactors;
     vector<double> m_cov;
 };
 

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -37,6 +37,8 @@ public:
                    bool clone,
                    const string& name="(none)");
 
+    //! @deprecated To be removed after Cantera 3.2. Replaced by constructor where
+    //!    contents and adjacent reactors are specified
     ReactorSurface(shared_ptr<Solution> sol, const string& name="(none)");
     using ReactorBase::ReactorBase; // inherit constructors
 

--- a/interfaces/clib/SConscript
+++ b/interfaces/clib/SConscript
@@ -52,6 +52,8 @@ sourcegen = env.Command(
      f"--api=clib --output={Path(Dir('#interfaces/clib').abspath)}")
 )
 env.Depends(sourcegen, [File(ff) for ff in yaml_files])
+env.Depends(sourcegen, env.Glob("#interfaces/sourcegen/src/sourcegen/*.py"))
+env.Depends(sourcegen, env.Glob("#interfaces/sourcegen/src/sourcegen/clib/*.*"))
 
 build(tags)
 build(sourcegen)

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -83,7 +83,6 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     # reactor surface
 
     cdef cppclass CxxReactorSurface "Cantera::ReactorSurface":
-        CxxReactorSurface(string) except +translate_exception
         string type()
         string name()
         void setName(string) except +translate_exception
@@ -93,6 +92,9 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void setCoverages(double*)
         void setCoverages(Composition&) except +translate_exception
         void syncState()
+
+    cdef shared_ptr[CxxReactorBase] CxxNewReactorSurface "newReactorSurface" (
+        shared_ptr[CxxSolution], vector[shared_ptr[CxxReactorBase]]&, string) except +translate_exception
 
     # connectors
 
@@ -277,7 +279,7 @@ cdef class ExtensibleReactor(Reactor):
 
 cdef class ReactorSurface(ReactorBase):
     cdef CxxReactorSurface* surface
-    cdef ReactorBase _reactor
+    cdef list _reactors
 
 cdef class ConnectorNode:
     cdef shared_ptr[CxxConnectorNode] _node

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -38,6 +38,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         CxxReactorBase() except +translate_exception
         string type()
         void setSolution(shared_ptr[CxxSolution]) except +translate_exception
+        shared_ptr[CxxSolution] solution()
         void restoreState() except +translate_exception
         void syncState() except +translate_exception
         double volume()

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -30,7 +30,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
     cdef cppclass CxxFlowDevice "Cantera::FlowDevice"
 
     # factories
-    cdef shared_ptr[CxxReactorBase] newReactorBase(string, shared_ptr[CxxSolution], string) except +translate_exception
+    cdef shared_ptr[CxxReactorBase] newReactorBase(string, shared_ptr[CxxSolution], cbool, string) except +translate_exception
     cdef shared_ptr[CxxConnectorNode] newConnectorNode(string, shared_ptr[CxxReactorBase], shared_ptr[CxxReactorBase], string) except +translate_exception
 
     # reactors
@@ -95,7 +95,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         void syncState()
 
     cdef shared_ptr[CxxReactorBase] CxxNewReactorSurface "newReactorSurface" (
-        shared_ptr[CxxSolution], vector[shared_ptr[CxxReactorBase]]&, string) except +translate_exception
+        shared_ptr[CxxSolution], vector[shared_ptr[CxxReactorBase]]&, cbool, string) except +translate_exception
 
     # connectors
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -27,8 +27,7 @@ cdef class ReactorBase:
         self._outlets = []
         self._walls = []
         self._surfaces = []
-        if isinstance(contents, _SolutionBase):
-            self._contents = contents
+        self._contents = _wrap_Solution(self.rbase.solution())
 
         if volume is not None:
             self.volume = volume

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -852,8 +852,10 @@ cdef class ReactorSurface(ReactorBase):
                 "adjacent reactors `r` will be a required constructor argument and the "
                 "install method will be removed.",
                 DeprecationWarning)
-
             self._reactors = []
+        else:
+            raise TypeError("Parameter 'r' should be a ReactorBase object or a list "
+                            "of ReactorBase objects.")
 
         self._rbase = CxxNewReactorSurface(contents._base, cxx_adj, clone, stringify(name))
         self.rbase = self._rbase.get()
@@ -875,6 +877,9 @@ cdef class ReactorSurface(ReactorBase):
            Replaced by specifying list of adjacent reactors in the `ReactorSurface`
            constructor.
         """
+        warnings.warn("ReactorSurface.install: To be removed after Cantera 3.2. "
+            "Adjacent reactors should be specified in the ReactorSurface constructor.",
+            DeprecationWarning)
         r._surfaces.append(self)
         r.reactor.addSurface(self.surface)
         self._reactors.append(r)

--- a/interfaces/cython/cantera/solutionbase.pxd
+++ b/interfaces/cython/cantera/solutionbase.pxd
@@ -52,6 +52,7 @@ cdef extern from "cantera/base/Solution.h" namespace "Cantera":
         size_t nAdjacent()
         shared_ptr[CxxSolution] adjacent(size_t)
         void holdExternalHandle(string&, shared_ptr[CxxExternalHandle])
+        shared_ptr[CxxExternalHandle] getExternalHandle(string&)
         void registerChangedCallback(void*, function[void()])
         void removeChangedCallback(void*)
 
@@ -101,7 +102,7 @@ ctypedef void (*transportPolyMethod1i)(CxxTransport*, size_t, double*) except +t
 ctypedef void (*transportPolyMethod2i)(CxxTransport*, size_t, size_t, double*) except +translate_exception
 
 cdef _assign_Solution(_SolutionBase soln, shared_ptr[CxxSolution] cxx_soln,
-                      pybool reset_adjacent, pybool weak=?)
+                      pybool reset_adjacent, pybool weak=?, pybool hold=?)
 cdef object _wrap_Solution(shared_ptr[CxxSolution] cxx_soln)
 
 cdef class _SolutionBase:

--- a/interfaces/sourcegen/src/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/clib/config.yaml
@@ -69,6 +69,7 @@ includes:
   - cantera/numerics/Func1Factory.h
   ReactorBase:
   - cantera/zeroD/ReactorFactory.h
+  - cantera/zeroD/ReactorSurface.h
   - cantera/zeroD/FlowReactor.h
   ConnectorNode:
   - cantera/zeroD/ConnectorFactory.h

--- a/interfaces/sourcegen/src/sourcegen/clib/config.yaml
+++ b/interfaces/sourcegen/src/sourcegen/clib/config.yaml
@@ -69,8 +69,9 @@ includes:
   - cantera/numerics/Func1Factory.h
   ReactorBase:
   - cantera/zeroD/ReactorFactory.h
-  - cantera/zeroD/ReactorSurface.h
   - cantera/zeroD/FlowReactor.h
+  ReactorSurface:
+  - cantera/zeroD/ReactorSurface.h
   ConnectorNode:
   - cantera/zeroD/ConnectorFactory.h
   - cantera/zeroD/flowControllers.h

--- a/interfaces/sourcegen/src/sourcegen/headers/ctreactor_auto.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctreactor_auto.yaml
@@ -13,6 +13,8 @@ derived:  # Specialization/prefix dictionary
 recipes:
 - name: new
   wraps: newReactorBase
+- name: newSurface
+  wraps: newReactorSurface
 - name: type
 - name: name
 - name: setName

--- a/interfaces/sourcegen/src/sourcegen/headers/ctreactor_auto.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctreactor_auto.yaml
@@ -16,6 +16,8 @@ recipes:
 - name: type
 - name: name
 - name: setName
+- name: solution
+  what: accessor
 - name: setInitialVolume
 - name: setChemistry
 - name: setEnergy

--- a/samples/clib/demo.c
+++ b/samples/clib/demo.c
@@ -100,7 +100,7 @@ int main(int argc, char** argv)
     thermo_print(thermo, 1, 1e-6);
 
     printf("\ntime       Temperature\n");
-    int32_t reactor = reactor_new("IdealGasReactor", sol, "test");
+    int32_t reactor = reactor_new("IdealGasReactor", sol, 1, "test");
     int32_t reactors[1];
     reactors[0] = reactor;
     int32_t net = reactornet_new(1, &reactors[0]);

--- a/samples/cxx/kinetics1/kinetics1.cpp
+++ b/samples/cxx/kinetics1/kinetics1.cpp
@@ -45,7 +45,7 @@ int kinetics1(int np, void* p)
     // create a 2D array to hold the output variables,
     // and store the values for the initial state
     Array2D states(nsp+4, 1);
-    saveSoln(0, 0.0, *(sol->thermo()), states);
+    saveSoln(0, 0.0, *r->solution()->thermo(), states);
 
     // create a container object for reactor to run the simulation
     ReactorNet sim(r);
@@ -56,13 +56,13 @@ int kinetics1(int np, void* p)
         double tm = i*dt;
         sim.advance(tm);
         cout << "time = " << tm << " s" << endl;
-        saveSoln(tm, *(sol->thermo()), states);
+        saveSoln(tm, *r->solution()->thermo(), states);
     }
     clock_t t1 = clock(); // save end time
 
 
     // make a CSV output file
-    writeCsv("kin1.csv", *sol->thermo(), states);
+    writeCsv("kin1.csv", *r->solution()->thermo(), states);
 
     // print final temperature and timing data
     double tmm = 1.0*(t1 - t0)/CLOCKS_PER_SEC;

--- a/samples/cxx/openmp_ignition/openmp_ignition.cpp
+++ b/samples/cxx/openmp_ignition/openmp_ignition.cpp
@@ -35,7 +35,7 @@ void run()
     // be created for each new Reactor automatically.
     auto sol = newSolution("gri30.yaml", "gri30", "none");
     for (int i = 0; i < nThreads; i++) {
-        reactors.emplace_back(new IdealGasConstPressureReactor(sol));
+        reactors.emplace_back(new IdealGasConstPressureReactor(sol, true));
         nets.emplace_back(new ReactorNet(reactors.back()));
     }
 

--- a/samples/matlab_experimental/catcomb.m
+++ b/samples/matlab_experimental/catcomb.m
@@ -16,9 +16,6 @@
 
 help catcomb;
 
-clear all
-close all
-
 t0 = cputime; % record the starting time
 
 %% Set parameter values

--- a/samples/matlab_experimental/diamond_cvd.m
+++ b/samples/matlab_experimental/diamond_cvd.m
@@ -16,9 +16,6 @@
 
 %% Initialization
 
-clear all
-close all
-
 help diamond_cvd
 t0 = cputime; % record the starting time
 

--- a/samples/matlab_experimental/diff_flame.m
+++ b/samples/matlab_experimental/diff_flame.m
@@ -9,9 +9,6 @@
 
 %% Initialization
 
-clear all
-close all
-
 tic % total running time of the script
 help diff_flame
 

--- a/samples/matlab_experimental/equil.m
+++ b/samples/matlab_experimental/equil.m
@@ -6,9 +6,6 @@ function equil(g)
     %
     % .. tags:: Matlab, combustion, equilibrium, plotting
 
-    clear all
-    close all
-
     tic
     help equil
 

--- a/samples/matlab_experimental/flame1.m
+++ b/samples/matlab_experimental/flame1.m
@@ -7,9 +7,6 @@
 
 %% Initialization
 
-clear all
-close all
-
 tic
 help flame1
 

--- a/samples/matlab_experimental/flame2.m
+++ b/samples/matlab_experimental/flame2.m
@@ -6,9 +6,6 @@
 
 %% Initialization
 
-clear all
-close all
-
 tic
 help flame2
 

--- a/samples/matlab_experimental/ignite.m
+++ b/samples/matlab_experimental/ignite.m
@@ -8,9 +8,6 @@ function plotdata = ignite(g)
     %
     % .. tags:: Matlab, combustion, reactor network, ignition delay, plotting
 
-    clear all
-    close all
-
     tic
     help ignite
 

--- a/samples/matlab_experimental/ignite_hp.m
+++ b/samples/matlab_experimental/ignite_hp.m
@@ -6,9 +6,6 @@ function ignite_hp(gas)
     %
     % .. tags:: Matlab, combustion, user-defined model, ignition delay, plotting
 
-    clear all
-    close all
-
     tic
     help ignite_hp
 

--- a/samples/matlab_experimental/ignite_uv.m
+++ b/samples/matlab_experimental/ignite_uv.m
@@ -6,9 +6,6 @@ function ignite_uv(gas)
     %
     % .. tags:: Matlab, combustion, user-defined model, ignition delay, plotting
 
-    clear all
-    close all
-
     tic
     help ignite_uv
 

--- a/samples/matlab_experimental/isentropic.m
+++ b/samples/matlab_experimental/isentropic.m
@@ -6,9 +6,6 @@ function isentropic(g)
     %
     % .. tags:: Matlab, thermodynamics, compressible flow, plotting
 
-    clear all
-    close all
-
     tic
     help isentropic
 

--- a/samples/matlab_experimental/lithium_ion_battery.m
+++ b/samples/matlab_experimental/lithium_ion_battery.m
@@ -25,9 +25,6 @@
 
 %% Initialization
 
-clear all
-close all
-
 tic
 help lithium_ion_battery
 

--- a/samples/matlab_experimental/periodic_cstr.m
+++ b/samples/matlab_experimental/periodic_cstr.m
@@ -24,9 +24,6 @@ function periodic_cstr
     %
     % .. tags:: Matlab, combustion, reactor network, well-stirred reactor, plotting
 
-    clear all
-    close all
-
     tic
     help periodic_cstr
 

--- a/samples/matlab_experimental/plug_flow_reactor.m
+++ b/samples/matlab_experimental/plug_flow_reactor.m
@@ -25,9 +25,6 @@
 
 %% Initialization
 
-clear all
-close all
-
 tic
 help plug_flow_reactor
 

--- a/samples/matlab_experimental/prandtl1.m
+++ b/samples/matlab_experimental/prandtl1.m
@@ -7,9 +7,6 @@ function prandtl1(g)
     %
     % .. tags:: Matlab, equilibrium, transport, plotting
 
-    clear all
-    close all
-
     tic
     help prandtl1
 

--- a/samples/matlab_experimental/prandtl2.m
+++ b/samples/matlab_experimental/prandtl2.m
@@ -6,9 +6,6 @@ function prandtl2(g)
     %
     % .. tags:: Matlab, transport, equilibrium, multicomponent transport, plotting
 
-    clear all
-    close all
-
     tic
     help prandtl2
 

--- a/samples/matlab_experimental/rankine.m
+++ b/samples/matlab_experimental/rankine.m
@@ -5,9 +5,6 @@
 %
 % .. tags:: Matlab, thermodynamics, thermodynamic cycle, non-ideal fluid
 
-clear all
-close all
-
 help rankine
 
 %% Initialize parameters

--- a/samples/matlab_experimental/reactor1.m
+++ b/samples/matlab_experimental/reactor1.m
@@ -7,9 +7,6 @@ function reactor1(g)
     %
     % .. tags:: Matlab, combustion, reactor network, ignition delay, plotting
 
-    clear all
-    close all
-
     tic
     help reactor1
 

--- a/samples/matlab_experimental/reactor2.m
+++ b/samples/matlab_experimental/reactor2.m
@@ -7,9 +7,6 @@ function reactor2(g)
     %
     % .. tags:: Matlab, combustion, reactor network, ignition delay, plotting
 
-    clear all
-    close all
-
     tic
     help reactor2
 

--- a/samples/matlab_experimental/surf_reactor.m
+++ b/samples/matlab_experimental/surf_reactor.m
@@ -7,9 +7,6 @@
 
 %% Initialization
 
-clear all
-close all
-
 tic
 help surf_reactor
 
@@ -105,6 +102,5 @@ plot(tim, x);
 xlabel('Time (s)');
 ylabel('Mole Fractions');
 legend(names);
-clear all
 
 toc

--- a/samples/python/kinetics/custom_reactions.py
+++ b/samples/python/kinetics/custom_reactions.py
@@ -121,7 +121,7 @@ def ignition(gas, dT=0):
     # set up reactor
     gas.TP = 1000 + dT, 5 * ct.one_atm
     gas.set_equivalence_ratio(0.8, fuel, 'O2:1.0, N2:3.773')
-    r = ct.IdealGasReactor(gas)
+    r = ct.IdealGasReactor(gas, clone=False)
     net = ct.ReactorNet([r])
     net.rtol_sensitivity = 2.e-5
 

--- a/samples/python/kinetics/interactive_path_diagram.py
+++ b/samples/python/kinetics/interactive_path_diagram.py
@@ -84,9 +84,9 @@ time = 0
 steps = 0
 while time < residence_time:
     profiles["time"].append(time)
-    profiles["pressure"].append(gas.P)
-    profiles["temperature"].append(gas.T)
-    profiles["mole_fractions"].append(gas.X)
+    profiles["pressure"].append(reactor.thermo.P)
+    profiles["temperature"].append(reactor.thermo.T)
+    profiles["mole_fractions"].append(reactor.thermo.X)
     time = reactor_network.step()
     steps += 1
 

--- a/samples/python/kinetics/interactive_path_diagram.py
+++ b/samples/python/kinetics/interactive_path_diagram.py
@@ -71,7 +71,7 @@ residence_time = 1e-3
 # %%
 # Create a batch reactor object and set solver tolerances
 
-reactor = ct.IdealGasConstPressureReactor(gas, energy="on")
+reactor = ct.IdealGasConstPressureReactor(gas, energy="on", clone=False)
 reactor_network = ct.ReactorNet([reactor])
 reactor_network.atol = 1e-12
 reactor_network.rtol = 1e-12

--- a/samples/python/kinetics/jet_stirred_reactor.py
+++ b/samples/python/kinetics/jet_stirred_reactor.py
@@ -66,10 +66,10 @@ inputs = {
 def getStirredReactor(gas,inputs):
     reactorRadius = (inputs['V']*3/4/np.pi)**(1/3) # [m3]
     reactorSurfaceArea =4*np.pi*reactorRadius**2 # [m3]
-    fuelAirMixtureTank = ct.Reservoir(gas)
-    exhaust = ct.Reservoir(gas)
-    env = ct.Reservoir(gas)
-    reactor = ct.IdealGasReactor(gas, energy='on', volume=inputs['V'])
+    fuelAirMixtureTank = ct.Reservoir(gas, clone=True)
+    exhaust = ct.Reservoir(gas, clone=True)
+    env = ct.Reservoir(gas, clone=True)
+    reactor = ct.IdealGasReactor(gas, energy='on', clone=True, volume=inputs['V'])
     ct.MassFlowController(upstream=fuelAirMixtureTank,
                           downstream=reactor,
                           mdot=reactor.mass/inputs['tau'])

--- a/samples/python/kinetics/mechanism_reduction.py
+++ b/samples/python/kinetics/mechanism_reduction.py
@@ -56,7 +56,7 @@ while sim.time < 0.04:
     sim.step()
     tt.append(1000 * sim.time)
     TT.append(r.T)
-    rnet = abs(gas.net_rates_of_progress)
+    rnet = abs(r.thermo.net_rates_of_progress)
     rnet /= max(rnet)
     Rmax = np.maximum(Rmax, rnet)
 

--- a/samples/python/kinetics/mechanism_reduction.py
+++ b/samples/python/kinetics/mechanism_reduction.py
@@ -44,7 +44,7 @@ gas.TP = T0, P0
 
 # %%
 # Run a simulation with the full mechanism
-r = ct.IdealGasConstPressureMoleReactor(gas)
+r = ct.IdealGasConstPressureMoleReactor(gas, clone=False)
 sim = ct.ReactorNet([r])
 sim.preconditioner = ct.AdaptivePreconditioner()
 
@@ -93,7 +93,7 @@ for i, N in enumerate([100, 200, 300, 400, 600, 800]):
 
     # Re-run the ignition problem with the reduced mechanism
     gas2.TPX = T0, P0, X0
-    r = ct.IdealGasConstPressureMoleReactor(gas2)
+    r = ct.IdealGasConstPressureMoleReactor(gas2, clone=False)
     sim = ct.ReactorNet([r])
     sim.preconditioner = ct.AdaptivePreconditioner()
 

--- a/samples/python/kinetics/reaction_path.py
+++ b/samples/python/kinetics/reaction_path.py
@@ -26,7 +26,7 @@ import cantera as ct
 # an object of a class derived from class Kinetics in some state.
 gas = ct.Solution('gri30.yaml')
 gas.TPX = 1300.0, ct.one_atm, 'CH4:0.4, O2:1, N2:3.76'
-r = ct.IdealGasReactor(gas)
+r = ct.IdealGasReactor(gas, clone=False)
 net = ct.ReactorNet([r])
 T = r.T
 while T < 1900:

--- a/samples/python/kinetics/shock_tube.py
+++ b/samples/python/kinetics/shock_tube.py
@@ -52,7 +52,7 @@ for k, m in enumerate(models):
     gas = ct.Solution(file, name=models[m])
     X = {'H2O2':X_H2O2, 'H2O':X_H2O, 'O2':X_O2, 'CO2':X_CO2, 'AR':X_Ar}
     gas.TPX = 1196, 2.127*ct.one_atm, X
-    r = ct.Reactor(contents=gas,energy="on")
+    r = ct.Reactor(contents=gas, energy="on", clone=False)
     reactorNetwork = ct.ReactorNet([r])
     timeHistory = ct.SolutionArray(gas, extra=['t'])
     estIgnitDelay = 1

--- a/samples/python/reactors/1D_pfr_surfchem.py
+++ b/samples/python/reactors/1D_pfr_surfchem.py
@@ -41,12 +41,12 @@ D = 5.08e-2  # diameter of the tube [m]
 Ac = np.pi * D**2 / 4  # cross section of the tube [m]
 u0 = 11.53  # m/s initial velocity of the flow
 
-reactor = ct.FlowReactor(gas)
+reactor = ct.FlowReactor(gas, clone=True)
 reactor.area = Ac
 reactor.mass_flow_rate = gas.density * u0 * Ac
 reactor.energy_enabled = False
 
-rsurf = ct.ReactorSurface(gas_si_n_interface, reactor)
+rsurf = ct.ReactorSurface(gas_si_n_interface, reactor, clone=True)
 net = ct.ReactorNet([reactor])
 soln = ct.SolutionArray(gas, extra=['x', 'speed', 'surf_coverages', 'N_dep', 'Si_dep'])
 kN = gas_si_n_interface.kinetics_species_index('N(D)')

--- a/samples/python/reactors/combustor.py
+++ b/samples/python/reactors/combustor.py
@@ -34,7 +34,7 @@ gas = ct.Solution('gri30.yaml', transport_model=None)
 equiv_ratio = 0.5  # lean combustion
 gas.TP = 300.0, ct.one_atm
 gas.set_equivalence_ratio(equiv_ratio, 'CH4:1.0', 'O2:1.0, N2:3.76')
-inlet = ct.Reservoir(gas)
+inlet = ct.Reservoir(gas, clone=True)
 
 # %%
 # Create the combustor, and fill it initially with a mixture consisting of the
@@ -43,12 +43,12 @@ inlet = ct.Reservoir(gas)
 # initial condition from which to reach a steady-state solution on the reacting
 # branch.
 gas.equilibrate('HP')
-combustor = ct.IdealGasReactor(gas)
+combustor = ct.IdealGasReactor(gas, clone=True)
 combustor.volume = 1.0
 
 # %%
 # Create a reservoir for the exhaust:
-exhaust = ct.Reservoir(gas)
+exhaust = ct.Reservoir(gas, clone=True)
 
 # %%
 # Use a variable mass flow rate to keep the residence time in the reactor

--- a/samples/python/reactors/continuous_reactor.py
+++ b/samples/python/reactors/continuous_reactor.py
@@ -103,10 +103,11 @@ max_simulation_time = 50  # seconds
 # Initialize the stirred reactor and connect all peripherals
 # ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
-fuel_air_mixture_tank = ct.Reservoir(gas)
-exhaust = ct.Reservoir(gas)
+fuel_air_mixture_tank = ct.Reservoir(gas, clone=True)
+exhaust = ct.Reservoir(gas, clone=True)
 
-stirred_reactor = ct.IdealGasMoleReactor(gas, energy="off", volume=reactor_volume)
+stirred_reactor = ct.IdealGasMoleReactor(gas, energy="off",
+                                         clone=True, volume=reactor_volume)
 
 mass_flow_controller = ct.MassFlowController(
     upstream=fuel_air_mixture_tank,
@@ -221,11 +222,15 @@ reactor_X = inlet_X
 
 for reactor_temperature in T:
     gas.TPX = reactor_temperature, reactor_pressure, inlet_X
-    fuel_air_mixture_tank = ct.Reservoir(gas)
+    fuel_air_mixture_tank = ct.Reservoir(gas, clone=True)
 
     # Use composition from the previous iteration to speed up convergence
     gas.TPX = reactor_temperature, reactor_pressure, reactor_X
-    stirred_reactor = ct.IdealGasReactor(gas, energy="off", volume=reactor_volume)
+    stirred_reactor = ct.IdealGasReactor(gas, energy="off", clone=True,
+                                         volume=reactor_volume)
+    fuel_air_mixture_tank = ct.Reservoir(gas, clone=True)
+    stirred_reactor = ct.IdealGasReactor(gas, energy="off", clone=True,
+                                         volume=reactor_volume)
     mass_flow_controller = ct.MassFlowController(
         upstream=fuel_air_mixture_tank,
         downstream=stirred_reactor,

--- a/samples/python/reactors/custom2.py
+++ b/samples/python/reactors/custom2.py
@@ -76,8 +76,8 @@ P = ct.one_atm
 gas.TPY = 920, P, 'H2:1.0, O2:1.0, N2:3.76'
 
 # Set up the reactor network
-res = ct.Reservoir(gas)
-r = InertialWallReactor(gas, neighbor=res)
+res = ct.Reservoir(gas, clone=True)
+r = InertialWallReactor(gas, clone=True, neighbor=res)
 w = ct.Wall(r, res)
 net = ct.ReactorNet([r])
 

--- a/samples/python/reactors/fuel_injection.py
+++ b/samples/python/reactors/fuel_injection.py
@@ -24,13 +24,13 @@ gas.case_sensitive_species_names = True
 
 # Create a Reservoir for the fuel inlet, set to pure dodecane
 gas.TPX = 300, 20*ct.one_atm, 'c12h26:1.0'
-inlet = ct.Reservoir(gas)
+inlet = ct.Reservoir(gas, clone=True)
 
 # Create Reactor and set initial contents to be products of lean combustion
 gas.TP = 1000, 20*ct.one_atm
 gas.set_equivalence_ratio(0.30, 'c12h26', 'n2:3.76, o2:1.0')
 gas.equilibrate('TP')
-r = ct.IdealGasReactor(gas)
+r = ct.IdealGasReactor(gas, clone=True)
 r.volume = 0.001  # 1 liter
 
 def fuel_mdot(total_mass=3.0e-3, std_dev=0.5, center_time=2.0):

--- a/samples/python/reactors/ic_engine.py
+++ b/samples/python/reactors/ic_engine.py
@@ -99,14 +99,14 @@ gas = ct.Solution(reaction_mechanism, phase_name)
 
 # define initial state and set up reactor
 gas.TPX = T_inlet, p_inlet, comp_inlet
-cyl = ct.IdealGasReactor(gas)
+cyl = ct.IdealGasReactor(gas, clone=True)
 cyl.volume = V_oT
 
 # define inlet state
 gas.TPX = T_inlet, p_inlet, comp_inlet
 # Note: The previous line is technically not needed as the state of the gas object is
 # already set correctly; change if inlet state is different from the reactor state.
-inlet = ct.Reservoir(gas)
+inlet = ct.Reservoir(gas, clone=True)
 
 # inlet valve
 inlet_valve = ct.Valve(inlet, cyl)
@@ -117,7 +117,7 @@ inlet_valve.time_function = (
 
 # define injector state (gaseous!)
 gas.TPX = T_injector, p_injector, comp_injector
-injector = ct.Reservoir(gas)
+injector = ct.Reservoir(gas, clone=True)
 
 # injector is modeled as a mass flow controller
 injector_mfc = ct.MassFlowController(injector, cyl)
@@ -129,7 +129,7 @@ injector_mfc.time_function = (
 
 # define outlet pressure (temperature and composition don't matter)
 gas.TPX = T_ambient, p_outlet, comp_ambient
-outlet = ct.Reservoir(gas)
+outlet = ct.Reservoir(gas, clone=True)
 
 # outlet valve
 outlet_valve = ct.Valve(cyl, outlet)
@@ -140,7 +140,7 @@ outlet_valve.time_function = (
 
 # define ambient pressure (temperature and composition don't matter)
 gas.TPX = T_ambient, p_ambient, comp_ambient
-ambient_air = ct.Reservoir(gas)
+ambient_air = ct.Reservoir(gas, clone=True)
 
 # piston is modeled as a moving wall
 piston = ct.Wall(ambient_air, cyl)

--- a/samples/python/reactors/mix1.py
+++ b/samples/python/reactors/mix1.py
@@ -47,16 +47,16 @@ rho_b = gas_b.density
 # replaced with a reactor with no outlet, if it is desired to integrate the
 # composition leaving the mixer in time, or by an arbitrary network of
 # downstream reactors.
-res_a = ct.Reservoir(gas_a, name='Air Reservoir')
-res_b = ct.Reservoir(gas_b, name='Fuel Reservoir')
-downstream = ct.Reservoir(gas_a, name='Outlet Reservoir')
+res_a = ct.Reservoir(gas_a, name='Air Reservoir', clone=True)
+res_b = ct.Reservoir(gas_b, name='Fuel Reservoir', clone=True)
+downstream = ct.Reservoir(gas_a, name='Outlet Reservoir', clone=True)
 
 # %%
 # Create a reactor for the mixer. A reactor is required instead of a
 # reservoir, since the state will change with time if the inlet mass flow
 # rates change or if there is chemistry occurring.
 gas_b.TPX = 300.0, ct.one_atm, 'O2:0.21, N2:0.78, AR:0.01'
-mixer = ct.IdealGasReactor(gas_b, name='Mixer')
+mixer = ct.IdealGasReactor(gas_b, name='Mixer', clone=True)
 
 # %%
 # Create two mass flow controllers connecting the upstream reservoirs to the

--- a/samples/python/reactors/nanosecond_pulse_discharge.py
+++ b/samples/python/reactors/nanosecond_pulse_discharge.py
@@ -43,7 +43,7 @@ gas.TPX = 300., 101325., 'CH4:0.095, O2:0.19, N2:0.715, e:1E-11'
 gas.reduced_electric_field = gaussian_EN(0)
 gas.update_electron_energy_distribution()
 
-r = ct.ConstPressureReactor(gas, energy="off")
+r = ct.ConstPressureReactor(gas, energy="off", clone=False)
 
 sim = ct.ReactorNet([r])
 sim.verbose = False

--- a/samples/python/reactors/non_ideal_shock_tube.py
+++ b/samples/python/reactors/non_ideal_shock_tube.py
@@ -117,7 +117,7 @@ real_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
 
 # Create a reactor object and add it to a reactor network
 # In this example, this will be the only reactor in the network
-r = ct.Reactor(contents=real_gas)
+r = ct.Reactor(contents=real_gas, clone=False)
 reactor_network = ct.ReactorNet([r])
 time_history_RG = ct.SolutionArray(real_gas, extra=['t'])
 
@@ -154,7 +154,7 @@ ideal_gas.TP = reactor_temperature, reactor_pressure
 ideal_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                 oxidizer={'o2': 1.0, 'n2': 3.76})
 
-r = ct.Reactor(contents=ideal_gas)
+r = ct.Reactor(contents=ideal_gas, clone=False)
 reactor_network = ct.ReactorNet([r])
 time_history_IG = ct.SolutionArray(ideal_gas, extra=['t'])
 
@@ -231,7 +231,7 @@ for i, temperature in enumerate(T):
     real_gas.TP = reactor_temperature, reactor_pressure
     real_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                    oxidizer={'o2': 1.0, 'n2': 3.76})
-    r = ct.Reactor(contents=real_gas)
+    r = ct.Reactor(contents=real_gas, clone=False)
     reactor_network = ct.ReactorNet([r])
 
     # create an array of solution states
@@ -263,7 +263,7 @@ for i, temperature in enumerate(T):
     ideal_gas.TP = reactor_temperature, reactor_pressure
     ideal_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                     oxidizer={'o2': 1.0, 'n2': 3.76})
-    r = ct.Reactor(contents=ideal_gas)
+    r = ct.Reactor(contents=ideal_gas, clone=False)
     reactor_network = ct.ReactorNet([r])
 
     # create an array of solution states

--- a/samples/python/reactors/periodic_cstr.py
+++ b/samples/python/reactors/periodic_cstr.py
@@ -44,21 +44,21 @@ gas.TPX = t, p, 'H2:2, O2:1'
 # Create an upstream reservoir that will supply the reactor. The temperature,
 # pressure, and composition of the upstream reservoir are set to those of the
 # ``gas`` object at the time the reservoir is created.
-upstream = ct.Reservoir(gas)
+upstream = ct.Reservoir(gas, clone=True)
 
 # %%
 # Now create the reactor object with the same initial state.
 #
 # Set its volume to 10 cm³. In this problem, the reactor volume is fixed, so
 # the initial volume is the volume at all later times.
-cstr = ct.IdealGasReactor(gas)
+cstr = ct.IdealGasReactor(gas, clone=True)
 cstr.volume = 10.0*1.0e-6
 
 # %%
 # We need to have heat loss to see the oscillations. Create a reservoir to
 # represent the environment, and initialize its temperature to the reactor
 # temperature.
-env = ct.Reservoir(gas)
+env = ct.Reservoir(gas, clone=True)
 
 # %%
 # Create a heat-conducting wall between the reactor and the environment. Set its
@@ -79,7 +79,7 @@ mfc = ct.MassFlowController(upstream, cstr, mdot=mdot)
 # Now create a downstream reservoir to exhaust into and connect the reactor to this
 # reservoir with a valve. Set the coefficient sufficiently large to keep the reactor
 # pressure close to the downstream pressure of 60 Torr.
-downstream = ct.Reservoir(gas)
+downstream = ct.Reservoir(gas, clone=True)
 v = ct.Valve(cstr, downstream, K=1.0e-9)
 
 # %%

--- a/samples/python/reactors/pfr.py
+++ b/samples/python/reactors/pfr.py
@@ -115,17 +115,18 @@ m = ct.MassFlowController(upstream, r2, mdot=mass_flow_rate2)
 v = ct.PressureController(r2, downstream, primary=m, K=1e-5)
 
 sim2 = ct.ReactorNet([r2])
+sim2.max_time_step = 1e4
 
 # define time, space, and other information vectors
 z2 = (np.arange(n_steps) + 1) * dz
 t_r2 = np.zeros_like(z2)  # residence time in each reactor
 u2 = np.zeros_like(z2)
 t2 = np.zeros_like(z2)
-states2 = ct.SolutionArray(r2.thermo)
+states2 = ct.SolutionArray(gas2)
 # iterate through the PFR cells
 for n in range(n_steps):
     # Set the state of the reservoir to match that of the previous reactor
-    gas2.TDY = r2.thermo.TDY
+    upstream.thermo.TDY = r2.thermo.TDY
     upstream.syncState()
     # integrate the reactor forward in time until steady state is reached
     sim2.reinitialize()

--- a/samples/python/reactors/pfr.py
+++ b/samples/python/reactors/pfr.py
@@ -50,7 +50,7 @@ gas1.TPX = T_0, pressure, composition_0
 mass_flow_rate1 = u_0 * gas1.density * area
 
 # create a new reactor
-r1 = ct.IdealGasConstPressureReactor(gas1)
+r1 = ct.IdealGasConstPressureReactor(gas1, clone=True)
 # create a reactor network for performing time integration
 sim1 = ct.ReactorNet([r1])
 
@@ -94,16 +94,16 @@ dz = length / n_steps
 r_vol = area * dz
 
 # create a new reactor
-r2 = ct.IdealGasReactor(gas2)
+r2 = ct.IdealGasReactor(gas2, clone=True)
 r2.volume = r_vol
 
 # create a reservoir to represent the reactor immediately upstream. Note
 # that the gas object is set already to the state of the upstream reactor
-upstream = ct.Reservoir(gas2, name='upstream')
+upstream = ct.Reservoir(gas2, name='upstream', clone=True)
 
 # create a reservoir for the reactor to exhaust into. The composition of
 # this reservoir is irrelevant.
-downstream = ct.Reservoir(gas2, name='downstream')
+downstream = ct.Reservoir(gas2, name='downstream', clone=True)
 
 # The mass flow rate into the reactor will be fixed by using a
 # MassFlowController object.

--- a/samples/python/reactors/piston.py
+++ b/samples/python/reactors/piston.py
@@ -43,9 +43,9 @@ gas1.TPX = 900.0, ct.one_atm, 'H2:2, O2:1, AR:20'
 gas2 = ct.Solution('gri30.yaml')
 gas2.TPX = 900.0, ct.one_atm, 'CO:2, H2O:0.01, O2:5'
 
-r1 = ct.IdealGasReactor(gas1)
+r1 = ct.IdealGasReactor(gas1, clone=True)
 r1.volume = 0.5
-r2 = ct.IdealGasReactor(gas2)
+r2 = ct.IdealGasReactor(gas2, clone=True)
 r2.volume = 0.1
 
 # %%

--- a/samples/python/reactors/porous_media_burner.py
+++ b/samples/python/reactors/porous_media_burner.py
@@ -183,6 +183,7 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
     def __init__(self, *args, props, **kwargs):
         super().__init__(*args, **kwargs)
 
+        self.thermo.transport_model = "mixture-averaged"
         self.Ts = props.TsInit                     # initial temperature of the solid
         self.neighbor_left = None                  # reference to reactor on the left
         self.neighbor_right = None                 # reference to reactor on the right
@@ -355,7 +356,7 @@ for rL in lengths:
             TsInit=TsInit,
             solid=YZA40PPI)
 
-        reactors.append(PMReactor(gas_init, props=props))
+        reactors.append(PMReactor(gas_init, props=props, clone=True))
 
     elif midpoint < total_length * 0.75:
         # for 2 inches < x < 3 inches, fill the reactors with hot 3 PPI SiC
@@ -367,7 +368,7 @@ for rL in lengths:
             TsInit=gas_hot.T,
             solid=SiC3PPI)
 
-        reactors.append(PMReactor(gas_hot, props=props))
+        reactors.append(PMReactor(gas_hot, props=props, clone=True))
 
     else:
         # x >= 3 inches, fill the reactors with hot 10 PPI SiC
@@ -379,7 +380,7 @@ for rL in lengths:
             TsInit=gas_hot.T,
             solid=SiC10PPI)
 
-        reactors.append(PMReactor(gas_hot, props=props))
+        reactors.append(PMReactor(gas_hot, props=props, clone=True))
 
 # set the neighbor relations between the reactors
 for i, r in enumerate(reactors):

--- a/samples/python/reactors/preconditioned_integration.py
+++ b/samples/python/reactors/preconditioned_integration.py
@@ -27,7 +27,7 @@ def integrate_reactor(preconditioner=True):
     gas = ct.Solution('example_data/n-hexane-NUIG-2015.yaml')
     gas.TP = 1000, ct.one_atm
     gas.set_equivalence_ratio(1, 'NC6H14', 'N2:3.76, O2:1.0')
-    reactor = ct.IdealGasConstPressureMoleReactor(gas)
+    reactor = ct.IdealGasConstPressureMoleReactor(gas, clone=False)
     # set volume for reactors
     reactor.volume = 0.1
     # Create reactor network

--- a/samples/python/reactors/reactor1.py
+++ b/samples/python/reactors/reactor1.py
@@ -13,7 +13,7 @@ import cantera as ct
 
 gas = ct.Solution('h2o2.yaml')
 gas.TPX = 1001.0, ct.one_atm, 'H2:2,O2:1,N2:4'
-r = ct.IdealGasConstPressureReactor(gas)
+r = ct.IdealGasConstPressureReactor(gas, clone=False)
 
 sim = ct.ReactorNet([r])
 sim.verbose = True

--- a/samples/python/reactors/reactor2.py
+++ b/samples/python/reactors/reactor2.py
@@ -40,10 +40,10 @@ ar = ct.Solution('air.yaml')
 ar.TPX = 1000.0, 20.0 * ct.one_atm, "AR:1"
 
 # create a reactor to represent the side of the cylinder filled with argon
-r1 = ct.IdealGasReactor(ar, name="Argon partition")
+r1 = ct.IdealGasReactor(ar, name="Argon partition", clone=True)
 
 # create a reservoir for the environment, and fill it with air.
-env = ct.Reservoir(ct.Solution('air.yaml'), name="Environment")
+env = ct.Reservoir(ct.Solution('air.yaml'), name="Environment", clone=True)
 
 # use GRI-Mech 3.0 for the methane/air mixture, and set its initial state
 gas = ct.Solution('gri30.yaml')
@@ -51,7 +51,7 @@ gas.TP = 500.0, 0.2 * ct.one_atm
 gas.set_equivalence_ratio(1.1, 'CH4:1.0', 'O2:1, N2:3.76')
 
 # create a reactor for the methane/air side
-r2 = ct.IdealGasReactor(gas, name="Reacting partition")
+r2 = ct.IdealGasReactor(gas, name="Reacting partition", clone=True)
 
 # Now couple the reactors by defining common walls that may move (a piston) or
 # conduct heat

--- a/samples/python/reactors/sensitivity1.py
+++ b/samples/python/reactors/sensitivity1.py
@@ -17,7 +17,7 @@ temp = 1500.0
 pres = ct.one_atm
 
 gas.TPX = temp, pres, 'CH4:0.1, O2:2, N2:7.52'
-r = ct.IdealGasConstPressureReactor(gas, name='R1')
+r = ct.IdealGasConstPressureReactor(gas, name='R1', clone=False)
 sim = ct.ReactorNet([r])
 
 # enable sensitivity with respect to the rates of the first 10

--- a/samples/python/reactors/surf_pfr.py
+++ b/samples/python/reactors/surf_pfr.py
@@ -50,14 +50,14 @@ gas.TPX = t, ct.one_atm, 'CH4:1, O2:1.5, AR:0.1'
 mass_flow_rate = velocity * gas.density * area * porosity
 
 # create a new reactor
-r = ct.FlowReactor(gas)
+r = ct.FlowReactor(gas, clone=True)
 r.area = area
 r.surface_area_to_volume_ratio = cat_area_per_vol * porosity
 r.mass_flow_rate = mass_flow_rate
 r.energy_enabled = False
 
 # Add the reacting surface to the reactor
-rsurf = ct.ReactorSurface(surf, r)
+rsurf = ct.ReactorSurface(surf, r, clone=True)
 
 sim = ct.ReactorNet([r])
 

--- a/samples/python/reactors/surf_pfr_chain.py
+++ b/samples/python/reactors/surf_pfr_chain.py
@@ -75,20 +75,20 @@ print('    distance       X_CH4        X_H2        X_CO')
 
 # create a new reactor
 gas.TDY = TDY
-r = ct.IdealGasReactor(gas, energy='off')
+r = ct.IdealGasReactor(gas, energy='off', clone=True)
 r.volume = rvol
 
 # create a reservoir to represent the reactor immediately upstream. Note
 # that the gas object is set already to the state of the upstream reactor
-upstream = ct.Reservoir(gas, name='upstream')
+upstream = ct.Reservoir(gas, name='upstream', clone=True)
 
 # create a reservoir for the reactor to exhaust into. The composition of
 # this reservoir is irrelevant.
-downstream = ct.Reservoir(gas, name='downstream')
+downstream = ct.Reservoir(gas, name='downstream', clone=True)
 
 # Add the reacting surface to the reactor. The area is set to the desired
 # catalyst area in the reactor.
-rsurf = ct.ReactorSurface(surf, r, A=cat_area)
+rsurf = ct.ReactorSurface(surf, r, A=cat_area, clone=True)
 
 # The mass flow rate into the reactor will be fixed by using a
 # MassFlowController object.

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -22,6 +22,15 @@
 namespace Cantera
 {
 
+shared_ptr<Solution> Solution::clone() const
+{
+    shared_ptr<Solution> out = create();
+    out->setThermo(m_thermo->clone());
+    out->setKinetics(m_kinetics->clone({out->thermo()}));
+    out->setName(name());
+    return out;
+}
+
 string Solution::name() const {
     if (m_thermo) {
         return m_thermo->name();

--- a/src/base/Solution.cpp
+++ b/src/base/Solution.cpp
@@ -151,6 +151,16 @@ void Solution::addAdjacent(shared_ptr<Solution> adjacent) {
     m_adjacentByName[adjacent->name()] = adjacent;
 }
 
+shared_ptr<Solution> Solution::adjacent(const string& name)
+{
+    try {
+        return m_adjacentByName.at(name);
+    } catch (std::exception&) {
+        throw CanteraError("Solution::adjacent", "Solution '{}' does not have an "
+            "adjacent phase named '{}'", this->name(), name);
+    }
+}
+
 AnyMap Solution::parameters(bool withInput) const
 {
     AnyMap out = m_thermo->parameters(false);

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -284,6 +284,7 @@ extern "C" {
     int reactornet_addreactor(int i, int n)
     {
         try {
+            suppress_deprecation_warnings(); // No other option for legacy CLib
             NetworkCabinet::at(i)->addReactor(
                 dynamic_cast<Reactor&>(*ReactorCabinet::at(n)));
             return 0;
@@ -579,6 +580,7 @@ extern "C" {
     int reactorsurface_install(int i, int n)
     {
         try {
+            suppress_deprecation_warnings(); // No other option for legacy CLib
             ReactorCabinet::at(n)->addSurface(ReactorCabinet::as<ReactorSurface>(i).get());
             return 0;
         } catch (...) {

--- a/src/clib/ctreactor.cpp
+++ b/src/clib/ctreactor.cpp
@@ -41,7 +41,9 @@ extern "C" {
     {
         try {
             return ReactorCabinet::add(
-                newReactorBase(type, SolutionCabinet::at(n), name));
+                // Legacy clib will continue to use use input Solution objects without
+                // cloning
+                newReactorBase(type, SolutionCabinet::at(n), false, name));
         } catch (...) {
             return handleAllExceptions(-1, ERR);
         }

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -582,7 +582,7 @@ void Kinetics::addThermo(shared_ptr<ThermoPhase> thermo)
     resizeSpecies();
 }
 
-AnyMap Kinetics::parameters()
+AnyMap Kinetics::parameters() const
 {
     AnyMap out;
     string name = KineticsFactory::factory()->canonicalize(kineticsType());

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -222,6 +222,8 @@ pair<size_t, size_t> Kinetics::checkDuplicates(bool throw_err, bool fix)
             } else if (fix) {
                 R.duplicate = true;
                 other.duplicate = true;
+                unmatched_duplicates.erase(i);
+                unmatched_duplicates.erase(m);
             } else {
                 return {i,m};
             }

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -24,6 +24,21 @@ using namespace std;
 namespace Cantera
 {
 
+shared_ptr<Kinetics> Kinetics::clone(
+    const vector<shared_ptr<ThermoPhase>>& phases) const
+{
+    vector<AnyMap> reactionDefs;
+    for (size_t i = 0; i < nReactions(); i++) {
+        reactionDefs.push_back(reaction(i)->parameters());
+    }
+    AnyMap phaseNode = parameters();
+    phaseNode["__fix-duplicate-reactions__"] = true;
+    AnyMap rootNode;
+    rootNode["reactions"] = std::move(reactionDefs);
+    rootNode.applyUnits();
+    return newKinetics(phases, phaseNode, rootNode, phases[0]->root());
+}
+
 void Kinetics::checkReactionIndex(size_t i) const
 {
     if (i >= nReactions()) {

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -90,6 +90,7 @@ shared_ptr<Kinetics> newKinetics(const vector<shared_ptr<ThermoPhase>>& phases,
     for (auto& phase : phases) {
         kin->addThermo(phase);
     }
+    kin->setParameters(phaseNode);
     kin->init();
     addReactions(*kin, phaseNode, rootNode);
     return kin;
@@ -106,11 +107,6 @@ shared_ptr<Kinetics> newKinetics(const vector<shared_ptr<ThermoPhase>>& phases,
 
 void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode)
 {
-    kin.skipUndeclaredThirdBodies(
-        phaseNode.getBool("skip-undeclared-third-bodies", false));
-    kin.setExplicitThirdBodyDuplicateHandling(
-        phaseNode.getString("explicit-third-body-duplicates", "warn"));
-
     loadExtensions(rootNode);
 
     // Find sections containing reactions to add

--- a/src/kinetics/KineticsFactory.cpp
+++ b/src/kinetics/KineticsFactory.cpp
@@ -213,7 +213,9 @@ void addReactions(Kinetics& kin, const AnyMap& phaseNode, const AnyMap& rootNode
     if (add_rxn_err.size()) {
         throw CanteraError("addReactions", to_string(add_rxn_err));
     }
-    kin.checkDuplicates();
+    // Hidden flag possibly set by Kinetics::clone
+    bool fixDuplicates = phaseNode.getBool("__fix-duplicate-reactions__", false);
+    kin.checkDuplicates(!fixDuplicates, fixDuplicates);
     kin.resizeReactions();
 }
 

--- a/src/oneD/MultiNewton.cpp
+++ b/src/oneD/MultiNewton.cpp
@@ -151,15 +151,12 @@ int MultiNewton::dampStep(const double* x0, const double* step0,
             // stepping mode.
             step(x1, step1, r, loglevel-1);
         } catch (CanteraError& err) {
-            if (r.rdt() == 0) {
-                if (loglevel > 1) {
-                    writelog("\n  Steady-state Newton step failed:"
-                             "\n  {}:\n    {}", err.getMethod(), err.getMessage());
-                }
-                return -5;
-            } else {
-                throw;
+            if (loglevel > 1) {
+                writelog("\n  Reducing step size due to evaluation failure on trial step:"
+                            "\n  {}:\n    {}", err.getMethod(), err.getMessage());
             }
+            alpha /= m_dampFactor;
+            continue;
         }
 
         // compute the weighted norm of step1

--- a/src/thermo/ThermoPhase.cpp
+++ b/src/thermo/ThermoPhase.cpp
@@ -25,6 +25,21 @@ using namespace std;
 namespace Cantera
 {
 
+shared_ptr<ThermoPhase> ThermoPhase::clone() const
+{
+    AnyMap phase = parameters();
+    AnyMap root;
+    vector<AnyMap> speciesDefs;
+    speciesDefs.reserve(nSpecies());
+    for (const auto& name : speciesNames()) {
+        speciesDefs.emplace_back(species(name)->parameters(this));
+    }
+    root["species"] = std::move(speciesDefs);
+    phase.applyUnits();
+    root.applyUnits();
+    return newThermo(phase, root);
+}
+
 void ThermoPhase::resetHf298(size_t k) {
     if (k != npos) {
         m_spthermo.resetHf298(k);

--- a/src/transport/Transport.cpp
+++ b/src/transport/Transport.cpp
@@ -13,6 +13,11 @@
 namespace Cantera
 {
 
+shared_ptr<Transport> Transport::clone(shared_ptr<ThermoPhase> thermo) const
+{
+    return newTransport(thermo, transportModel());
+}
+
 void Transport::checkSpeciesIndex(size_t k) const
 {
     if (k >= m_nsp) {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -34,6 +34,18 @@ Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
     m_vol = 1.0; // By default, the volume is set to 1.0 m^3.
 }
 
+Reactor::Reactor(shared_ptr<Solution> sol, bool clone, const string& name)
+    : ReactorBase(sol, clone, name)
+{
+    m_kin = m_solution->kinetics().get();
+    if (m_kin->nReactions() == 0) {
+        setChemistry(false);
+    } else {
+        setChemistry(true);
+    }
+    m_vol = 1.0; // By default, the volume is set to 1.0 m^3.
+}
+
 void Reactor::setDerivativeSettings(AnyMap& settings)
 {
     m_kin->setDerivativeSettings(settings);

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -22,6 +22,8 @@ namespace bmt = boost::math::tools;
 namespace Cantera
 {
 
+// TODO: After Cantera 3.2, this method can be replaced by delegating to
+// Reactor::Reactor(sol, true, name)
 Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
     : ReactorBase(sol, name)
 {

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -25,7 +25,7 @@ namespace Cantera
 Reactor::Reactor(shared_ptr<Solution> sol, const string& name)
     : ReactorBase(sol, name)
 {
-    m_kin = sol->kinetics().get();
+    m_kin = m_solution->kinetics().get();
     if (m_kin->nReactions() == 0) {
         setChemistry(false);
     } else {

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -24,7 +24,7 @@ ReactorBase::ReactorBase(shared_ptr<Solution> sol, const string& name)
         throw CanteraError("ReactorBase::ReactorBase",
                            "Missing or incomplete Solution object.");
     }
-    m_solution = sol;
+    m_solution = sol->clone({}, true, false);
     m_solution->thermo()->addSpeciesLock();
     m_thermo = m_solution->thermo().get();
     m_nsp = m_thermo->nSpecies();
@@ -72,9 +72,9 @@ void ReactorBase::setSolution(shared_ptr<Solution> sol)
     }
     m_solution = sol;
     m_solution->thermo()->addSpeciesLock();
-    setThermo(*sol->thermo());
+    setThermo(*m_solution->thermo());
     try {
-        setKinetics(*sol->kinetics());
+        setKinetics(*m_solution->kinetics());
     } catch (NotImplementedError&) {
         // kinetics not used (example: Reservoir)
     }

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -17,6 +17,8 @@ ReactorBase::ReactorBase(const string& name) : m_name(name)
 {
 }
 
+// TODO: After Cantera 3.2, this method can be replaced by delegating to
+// ReactorBase::ReactorBase(sol, true, name)
 ReactorBase::ReactorBase(shared_ptr<Solution> sol, const string& name)
     : ReactorBase(name)
 {

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -163,6 +163,8 @@ void ReactorBase::addSurface(ReactorSurface* surf)
 
 void ReactorBase::addSurface(shared_ptr<ReactorBase> surf)
 {
+    warn_deprecated("ReactorBase::addSurface(shared_ptr<ReactorBase>)",
+                    "To be removed after Cantear 3.2. Use alternate constructor.");
     auto r = std::dynamic_pointer_cast<ReactorSurface>(surf);
     if (!r) {
         throw CanteraError("ReactorBase::addSurface",

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -25,62 +25,62 @@ std::mutex ReactorFactory::reactor_mutex;
 ReactorFactory::ReactorFactory()
 {
     reg("Reservoir",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new Reservoir(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new Reservoir(sol, clone, name); });
     reg("Reactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new Reactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new Reactor(sol, clone, name); });
     reg("ConstPressureReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ConstPressureReactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ConstPressureReactor(sol, clone, name); });
     reg("FlowReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new FlowReactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new FlowReactor(sol, clone, name); });
     reg("IdealGasReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new IdealGasReactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new IdealGasReactor(sol, clone, name); });
     reg("IdealGasConstPressureReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new IdealGasConstPressureReactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new IdealGasConstPressureReactor(sol, clone, name); });
     reg("ExtensibleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorDelegator<Reactor>(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorDelegator<Reactor>(sol, clone, name); });
     reg("ExtensibleIdealGasReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorDelegator<IdealGasReactor>(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorDelegator<IdealGasReactor>(sol, clone, name); });
     reg("ExtensibleConstPressureReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorDelegator<ConstPressureReactor>(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorDelegator<ConstPressureReactor>(sol, clone, name); });
     reg("ExtensibleIdealGasConstPressureReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorDelegator<IdealGasConstPressureReactor>(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorDelegator<IdealGasConstPressureReactor>(sol, clone, name); });
     reg("ExtensibleMoleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorDelegator<MoleReactor>(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorDelegator<MoleReactor>(sol, clone, name); });
     reg("ExtensibleConstPressureMoleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorDelegator<ConstPressureMoleReactor>(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorDelegator<ConstPressureMoleReactor>(sol, clone, name); });
     reg("ExtensibleIdealGasMoleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorDelegator<IdealGasMoleReactor>(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorDelegator<IdealGasMoleReactor>(sol, clone, name); });
     reg("ExtensibleIdealGasConstPressureMoleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorDelegator<IdealGasConstPressureMoleReactor>(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorDelegator<IdealGasConstPressureMoleReactor>(sol, clone, name); });
     reg("IdealGasConstPressureMoleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new IdealGasConstPressureMoleReactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new IdealGasConstPressureMoleReactor(sol, clone, name); });
     reg("IdealGasMoleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new IdealGasMoleReactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new IdealGasMoleReactor(sol, clone, name); });
     reg("ConstPressureMoleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ConstPressureMoleReactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ConstPressureMoleReactor(sol, clone, name); });
     reg("MoleReactor",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new MoleReactor(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new MoleReactor(sol, clone, name); });
     reg("ReactorSurface",
-        [](shared_ptr<Solution> sol, const string& name)
-        { return new ReactorSurface(sol, name); });
+        [](shared_ptr<Solution> sol, bool clone, const string& name)
+        { return new ReactorSurface(sol, clone, name); });
 }
 
 ReactorFactory* ReactorFactory::factory() {
@@ -98,10 +98,10 @@ void ReactorFactory::deleteFactory() {
 }
 
 shared_ptr<ReactorBase> newReactorBase(
-    const string& model, shared_ptr<Solution> contents, const string& name)
+    const string& model, shared_ptr<Solution> contents, bool clone, const string& name)
 {
     return shared_ptr<ReactorBase>(
-        ReactorFactory::factory()->create(model, contents, name));
+        ReactorFactory::factory()->create(model, contents, clone, name));
 }
 
 shared_ptr<ReactorBase> newReactor(
@@ -109,14 +109,14 @@ shared_ptr<ReactorBase> newReactor(
 {
     warn_deprecated("newReactor", "Behavior changes after Cantera 3.2, when a "
         "'shared_ptr<Reactor>' is returned.\nFor new behavior, use 'newReactor4'.");
-    return newReactorBase(model, contents, name);
+    return newReactorBase(model, contents, false, name);
 }
 
 shared_ptr<Reactor> newReactor4(
-    const string& model, shared_ptr<Solution> contents, const string& name)
+    const string& model, shared_ptr<Solution> contents, bool clone, const string& name)
 {
     auto reactor = std::dynamic_pointer_cast<Reactor>(
-        newReactorBase(model, contents, name));
+        newReactorBase(model, contents, clone, name));
     if (!reactor) {
         throw CanteraError("newReactor4",
             "Model type '{}' does not specify a bulk reactor.", model);
@@ -124,10 +124,11 @@ shared_ptr<Reactor> newReactor4(
     return reactor;
 }
 
-shared_ptr<Reservoir> newReservoir(shared_ptr<Solution> contents, const string& name)
+shared_ptr<Reservoir> newReservoir(
+    shared_ptr<Solution> contents, bool clone, const string& name)
 {
     auto reservoir = std::dynamic_pointer_cast<Reservoir>(
-        newReactorBase("Reservoir", contents, name));
+        newReactorBase("Reservoir", contents, clone, name));
     if (!reservoir) {
         throw CanteraError("newReservoir",
             "Caught unexpected inconsistency in factory method.");
@@ -136,9 +137,9 @@ shared_ptr<Reservoir> newReservoir(shared_ptr<Solution> contents, const string& 
 }
 
 shared_ptr<ReactorSurface> newReactorSurface(shared_ptr<Solution> soln,
-    const vector<shared_ptr<ReactorBase>>& reactors, const string& name)
+    const vector<shared_ptr<ReactorBase>>& reactors, bool clone, const string& name)
 {
-    return make_shared<ReactorSurface>(soln, reactors, name);
+    return make_shared<ReactorSurface>(soln, reactors, clone, name);
 }
 
 }

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -78,6 +78,7 @@ ReactorFactory::ReactorFactory()
     reg("MoleReactor",
         [](shared_ptr<Solution> sol, bool clone, const string& name)
         { return new MoleReactor(sol, clone, name); });
+    // TODO: Remove after Cantera 3.2
     reg("ReactorSurface",
         [](shared_ptr<Solution> sol, bool clone, const string& name)
         { return new ReactorSurface(sol, clone, name); });

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -110,6 +110,10 @@ shared_ptr<ReactorBase> newReactor(
 {
     warn_deprecated("newReactor", "Behavior changes after Cantera 3.2, when a "
         "'shared_ptr<Reactor>' is returned.\nFor new behavior, use 'newReactor4'.");
+    warn_deprecated("newReactor", "`clone` argument not specified; Default behavior "
+        "will change from `clone=False` to `clone=True` after Cantera 3.2.\n"
+        "Use the transitional newReactor4() function to provide a value for the clone "
+        "argument");
     return newReactorBase(model, contents, false, name);
 }
 
@@ -137,10 +141,10 @@ shared_ptr<Reservoir> newReservoir(
     return reservoir;
 }
 
-shared_ptr<ReactorSurface> newReactorSurface(shared_ptr<Solution> soln,
+shared_ptr<ReactorSurface> newReactorSurface(shared_ptr<Solution> contents,
     const vector<shared_ptr<ReactorBase>>& reactors, bool clone, const string& name)
 {
-    return make_shared<ReactorSurface>(soln, reactors, clone, name);
+    return make_shared<ReactorSurface>(contents, reactors, clone, name);
 }
 
 }

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -135,4 +135,10 @@ shared_ptr<Reservoir> newReservoir(shared_ptr<Solution> contents, const string& 
     return reservoir;
 }
 
+shared_ptr<ReactorSurface> newReactorSurface(shared_ptr<Solution> soln,
+    const vector<shared_ptr<ReactorBase>>& reactors, const string& name)
+{
+    return make_shared<ReactorSurface>(soln, reactors, name);
+}
+
 }

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -15,6 +15,7 @@ namespace Cantera
 
 ReactorSurface::ReactorSurface(shared_ptr<Solution> soln,
                                const vector<shared_ptr<ReactorBase>>& reactors,
+                               bool clone,
                                const string& name)
     : ReactorBase(name)
 {
@@ -24,7 +25,11 @@ ReactorSurface::ReactorSurface(shared_ptr<Solution> soln,
         m_reactors.push_back(R.get());
         R->addSurface(this);
     }
-    m_solution = soln->clone(adjacent, true, false);
+    if (clone) {
+        m_solution = soln->clone(adjacent, true, false);
+    } else {
+        m_solution = soln;
+    }
     m_solution->thermo()->addSpeciesLock();
     setThermo(*m_solution->thermo());
     if (!std::dynamic_pointer_cast<SurfPhase>(soln->thermo())) {
@@ -48,7 +53,7 @@ ReactorSurface::ReactorSurface(shared_ptr<Solution> soln,
 }
 
 ReactorSurface::ReactorSurface(shared_ptr<Solution> sol, const string& name)
-    : ReactorBase(sol, name)
+    : ReactorBase(sol, false, name)
 {
     if (!std::dynamic_pointer_cast<SurfPhase>(sol->thermo())) {
         throw CanteraError("ReactorSurface::ReactorSurface",

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -19,6 +19,7 @@ ReactorSurface::ReactorSurface(shared_ptr<Solution> soln,
                                const string& name)
     : ReactorBase(name)
 {
+    // TODO: After Cantera 3.2, raise an exception of 'reactors' is empty
     vector<shared_ptr<Solution>> adjacent;
     for (auto R : reactors) {
         adjacent.push_back(R->solution());
@@ -146,6 +147,13 @@ void ReactorSurface::getCoverages(double* cov) const
 
 void ReactorSurface::syncState()
 {
+    if (m_reactors.empty()) {
+        // TODO: Remove this check after Cantera 3.2, since it will no longer be
+        // possible to create the ReactorSurface without specifying the adjacent
+        // reactors in the constructor.
+        throw CanteraError("ReactorSurface::syncState",
+                           "Surface is not installed on any Reactor");
+    }
     m_surf->setTemperature(m_reactors[0]->temperature());
     m_surf->setCoveragesNoNorm(m_cov.data());
 }

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -76,6 +76,16 @@ ReactorSurface::ReactorSurface(shared_ptr<Solution> sol, const string& name)
     m_surf->getCoverages(m_cov.data());
 }
 
+ReactorSurface::ReactorSurface(shared_ptr<Solution> sol, bool clone, const string& name)
+    : ReactorSurface(sol, name)
+{
+    // TODO: Remove after Cantera 3.2 when removing ReactorSurface from ReactorFactory
+    if (clone) {
+        throw CanteraError("ReactorSurface::ReactorSurface", "Bad constructor arguments."
+            " When clone=true, list of adjacent reactors must be provided");
+    }
+}
+
 double ReactorSurface::area() const
 {
     return m_area;

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -102,3 +102,39 @@ TEST(ctreactor, reactor_clone)
     EXPECT_DOUBLE_EQ(thermo_temperature(thermo), T);
     EXPECT_GT(thermo_temperature(contents_thermo), T);
 }
+
+TEST(ctreactor, surface)
+{
+    vector<double> Tref = {
+        1050.000, 1050.517, 1051.107, 1051.744, 1052.443, 1053.220, 1054.102, 1055.124,
+        1056.344, 1057.849, 1059.791, 1062.453, 1066.443, 1073.424, 1091.018, 2918.287,
+        2918.287, 2918.287, 2918.287, 2918.287};
+
+    double T = 1050;
+    double P = 5 * 101325;
+    string X = "CH4:1.0, O2:2.0, N2:7.52";
+
+    int32_t surf = sol_newInterface("ptcombust.yaml", "Pt_surf", 0, 0);
+    int32_t gas = sol_adjacent(surf, 0);
+    int32_t gas_thermo = sol_thermo(gas);
+    thermo_setMoleFractionsByName(gas_thermo, X.c_str());
+    thermo_setTemperature(gas_thermo, T);
+    thermo_setPressure(gas_thermo, P);
+
+    int32_t reactor = reactor_new("IdealGasReactor", gas, 1, "test");
+    vector<int32_t> adjacent = {reactor};
+    int32_t rsurf = reactor_newSurface(surf, 1, adjacent.data(), 1, "surf");
+    ASSERT_GE(rsurf, 0);
+    int32_t net = reactornet_new(1, adjacent.data());
+    ASSERT_GE(net, 0);
+
+    double t = 0.0;
+    int count = 0;
+    while (t < 0.1) {
+        ASSERT_NEAR(reactor_temperature(reactor), Tref[count], 1e-2);
+        t = reactornet_time(net) + 5e-3;
+        int32_t status = reactornet_advance(net, t);
+        ASSERT_EQ(status, 0);
+        count++;
+    }
+}

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -14,7 +14,7 @@ using namespace Cantera;
 TEST(ctreactor, reactor_soln)
 {
     int32_t sol = sol_newSolution("gri30.yaml", "gri30", "none");
-    int32_t reactor = reactor_new("IdealGasReactor", sol, "test");
+    int32_t reactor = reactor_new("IdealGasReactor", sol, 1, "test");
     ASSERT_EQ(reactor, 0);
 
     int32_t ret = reactor_setName(reactor, "spam");
@@ -43,7 +43,7 @@ TEST(ctreactor, reactor_simple)
     thermo_setTemperature(thermo, T);
     thermo_setPressure(thermo, P);
 
-    int32_t reactor = reactor_new("IdealGasReactor", sol, "test");
+    int32_t reactor = reactor_new("IdealGasReactor", sol, 1, "test");
     vector<int32_t> reactors{reactor};
     int32_t net = reactornet_new(1, reactors.data());
     ASSERT_EQ(net, 0);

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -15,7 +15,7 @@ TEST(ctreactor, reactor_soln)
 {
     int32_t sol = sol_newSolution("gri30.yaml", "gri30", "none");
     int32_t reactor = reactor_new("IdealGasReactor", sol, 1, "test");
-    ASSERT_EQ(reactor, 0);
+    ASSERT_GE(reactor, 0);
 
     int32_t ret = reactor_setName(reactor, "spam");
     ASSERT_EQ(ret, 0);
@@ -43,10 +43,10 @@ TEST(ctreactor, reactor_simple)
     thermo_setTemperature(thermo, T);
     thermo_setPressure(thermo, P);
 
-    int32_t reactor = reactor_new("IdealGasReactor", sol, 1, "test");
+    int32_t reactor = reactor_new("IdealGasReactor", sol, 0, "test");
     vector<int32_t> reactors{reactor};
     int32_t net = reactornet_new(1, reactors.data());
-    ASSERT_EQ(net, 0);
+    ASSERT_GE(net, 0);
 
     double t = 0.0;
     int32_t count = 0;
@@ -58,4 +58,47 @@ TEST(ctreactor, reactor_simple)
         ASSERT_EQ(ret, 0);
         count++;
     }
+    // Reactor contents should be the same Solution & ThermoPhase objects
+    int32_t contents = reactor_solution(reactor);
+    int32_t contents_thermo = sol_thermo(contents);
+    EXPECT_DOUBLE_EQ(thermo_temperature(contents_thermo), thermo_temperature(thermo));
+    thermo_setTemperature(contents_thermo, 345.0);
+    EXPECT_DOUBLE_EQ(thermo_temperature(thermo), 345.0);
+}
+
+TEST(ctreactor, reactor_clone)
+{
+    double T = 1050;
+    double P = 5 * 101325;
+    string X = "CH4:1.0, O2:2.0, N2:7.52";
+
+    int32_t sol = sol_newSolution("gri30.yaml", "gri30", "none");
+    int32_t thermo = sol_thermo(sol);
+    thermo_setMoleFractionsByName(thermo, X.c_str());
+    thermo_setTemperature(thermo, T);
+    thermo_setPressure(thermo, P);
+
+    int32_t reactor = reactor_new("IdealGasReactor", sol, 1, "test");
+    vector<int32_t> reactors{reactor};
+    int32_t net = reactornet_new(1, reactors.data());
+    ASSERT_GE(net, 0);
+
+    double t = 0.0;
+    int32_t count = 0;
+    while (t < 0.1) {
+        double Tref = T_ctreactor[count];
+        ASSERT_NEAR(reactor_temperature(reactor), Tref, 1e-2);
+        t = reactornet_time(net) + 5e-3;
+        int32_t ret = reactornet_advance(net, t);
+        ASSERT_EQ(ret, 0);
+        count++;
+    }
+    // Reactor contents should be independent objects with a distinct state, and the
+    // original thermo object should be unmodified
+    int32_t contents = reactor_solution(reactor);
+    ASSERT_GE(contents, 0);
+    int32_t contents_thermo = sol_thermo(contents);
+    ASSERT_GE(contents_thermo, 0);
+    EXPECT_DOUBLE_EQ(thermo_temperature(thermo), T);
+    EXPECT_GT(thermo_temperature(contents_thermo), T);
 }

--- a/test/clib_legacy/test_ctreactor.cpp
+++ b/test/clib_legacy/test_ctreactor.cpp
@@ -23,13 +23,14 @@ TEST(ctreactor, reactor_soln)
     ASSERT_EQ(rName, "spam");
 }
 
-vector<double> T_ctreactor = {
-    1050.000, 1050.064, 1050.197, 1050.369, 1050.593, 1050.881, 1051.253, 1051.736,
-    1052.370, 1053.216, 1054.372, 1056.007, 1058.448, 1062.431, 1070.141, 1094.331,
-    2894.921, 2894.921, 2894.921, 2894.921, 2894.921};
 
 TEST(ctreactor, reactor_simple)
 {
+    vector<double> Tref = {
+        1050.000, 1050.064, 1050.197, 1050.369, 1050.593, 1050.881, 1051.253, 1051.736,
+        1052.370, 1053.216, 1054.372, 1056.007, 1058.448, 1062.431, 1070.141, 1094.331,
+        2894.921, 2894.921, 2894.921, 2894.921, 2894.921};
+
     double T = 1050;
     double P = 5 * 101325;
     string X = "CH4:1.0, O2:2.0, N2:7.52";
@@ -50,11 +51,51 @@ TEST(ctreactor, reactor_simple)
     double t = 0.0;
     int count = 0;
     while (t < 0.1) {
-        double Tref = T_ctreactor[count];
-        ASSERT_NEAR(reactor_temperature(reactor), Tref, 1e-2);
+        ASSERT_NEAR(reactor_temperature(reactor), Tref[count], 1e-2);
         t = reactornet_time(net) + 5e-3;
         ret = reactornet_advance(net, t);
         ASSERT_EQ(ret, 0);
+        count++;
+    }
+}
+
+TEST(ctreactor, surface)
+{
+    vector<double> Tref = {
+        1050.000, 1050.517, 1051.107, 1051.744, 1052.443, 1053.220, 1054.102, 1055.124,
+        1056.344, 1057.849, 1059.791, 1062.453, 1066.443, 1073.424, 1091.018, 2918.287,
+        2918.287, 2918.287, 2918.287, 2918.287};
+
+    double T = 1050;
+    double P = 5 * 101325;
+    string X = "CH4:1.0, O2:2.0, N2:7.52";
+
+    int surf = soln_newInterface("ptcombust.yaml", "Pt_surf", 0, 0);
+    int gas = soln_adjacent(surf, 0);
+    int gas_thermo = soln_thermo(gas);
+    thermo_setMoleFractionsByName(gas_thermo, X.c_str());
+    thermo_setTemperature(gas_thermo, T);
+    thermo_setPressure(gas_thermo, P);
+
+    int reactor = reactor_new("IdealGasReactor", gas, "test");
+    suppress_deprecation_warnings();
+    int rsurf = reactor_new("ReactorSurface", surf, "surf");
+    ASSERT_GE(rsurf, 0);
+    int status = reactorsurface_install(rsurf, reactor);
+    ASSERT_EQ(status, 0);
+    int net = reactornet_new();
+
+    status = reactornet_addreactor(net, reactor);
+    make_deprecation_warnings_fatal();
+    ASSERT_EQ(status, 0);
+
+    double t = 0.0;
+    int count = 0;
+    while (t < 0.1) {
+        ASSERT_NEAR(reactor_temperature(reactor), Tref[count], 1e-2);
+        t = reactornet_time(net) + 5e-3;
+        status = reactornet_advance(net, t);
+        ASSERT_EQ(status, 0);
         count++;
     }
 }

--- a/test/general/test_composite.cpp
+++ b/test/general/test_composite.cpp
@@ -1,6 +1,7 @@
 #include "gtest/gtest.h"
 #include "cantera/base/Interface.h"
 #include "cantera/base/SolutionArray.h"
+#include "cantera/transport/Transport.h"
 
 using namespace Cantera;
 
@@ -21,6 +22,8 @@ TEST(Solution, clone_idealgas)
     for (size_t i = 0; i < nrxn; i++) {
         EXPECT_NEAR(kf1[i], kf2[i], 1e-12*kf1[i]);
     }
+    EXPECT_NEAR(soln->transport()->thermalConductivity(),
+                dup->transport()->thermalConductivity(), 1e-11);
     dup->thermo()->setState_TP(600, OneAtm);
     EXPECT_DOUBLE_EQ(soln->thermo()->temperature(), 400.0);
     dup->kinetics()->getFwdRateConstants(kf2.data());

--- a/test/matlab_experimental/ctTestReactor.m
+++ b/test/matlab_experimental/ctTestReactor.m
@@ -19,7 +19,6 @@ classdef ctTestReactor < ctTestCase
         function makeReactors(self, arg)
             arguments
                 self
-                arg.independent (1,1) logical = true
                 arg.nr (1,1) double {mustBeInteger} = 2
                 arg.T1 (1,1) double {mustBeNumeric} = 300
                 arg.P1 (1,1) double {mustBeNumeric} = 101325
@@ -33,15 +32,10 @@ classdef ctTestReactor < ctTestCase
             self.gas1.TPX = {arg.T1, arg.P1, arg.X1};
             self.r1 = Reactor(self.gas1);
 
-            if arg.independent
-                self.gas2 = Solution('h2o2.yaml', '', 'none');
-            else
-                self.gas2 = self.gas1;
-            end
-
             if arg.nr == 1
                 self.net = ReactorNet(self.r1);
             elseif arg.nr >= 2
+                self.gas2 = Solution('h2o2.yaml', '', 'none');
                 self.gas2.TPX = {arg.T2, arg.P2, arg.X2};
                 self.r2 = Reactor(self.gas2);
                 self.r2.energy = 'on';
@@ -83,11 +77,11 @@ classdef ctTestReactor < ctTestCase
         end
 
         function testIndependentVariable(self)
-            self.makeReactors('independent', false, 'nr', 1);
+            self.makeReactors('nr', 1);
             self.verifyEqual(self.net.time, 0.0, 'AbsTol', self.atol);
         end
 
-        function testDisjoint1(self)
+        function testDisjoint(self)
             self.makeReactors('T1', 300, 'P1', 101325, 'T2', 500, 'P2', 300000);
             self.net.advance(1.0);
 
@@ -95,17 +89,6 @@ classdef ctTestReactor < ctTestCase
             self.verifyEqual(self.gas2.T, 500, 'AbsTol', self.atol);
             self.verifyEqual(self.gas1.P, 101325, 'AbsTol', self.atol);
             self.verifyEqual(self.gas2.P, 300000, 'AbsTol', self.atol);
-        end
-
-        function testDisjoint2(self)
-            self.makeReactors('independent', false, ...
-                              'T1', 300, 'P1', 101325, 'T2', 500, 'P2', 300000);
-            self.net.advance(1.0);
-
-            self.verifyEqual(self.r1.T, 300, 'AbsTol', self.atol);
-            self.verifyEqual(self.r2.T, 500, 'AbsTol', self.atol);
-            self.verifyEqual(self.r1.P, 101325, 'AbsTol', self.atol);
-            self.verifyEqual(self.r2.P, 300000, 'AbsTol', self.atol);
         end
 
         function testTimeStepping(self)

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -739,7 +739,7 @@ class TestReactionPath:
         while T < 1900:
             net.step()
             T = r.T
-        return gas
+        return r.thermo
 
     def check_dot(self, gas, diagram, element):
         diagram.label_threshold = 0

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -733,7 +733,7 @@ class TestReactionPath:
         gas.TPX = 1300.0, ct.one_atm, 'CH4:0.4, O2:1, N2:3.76'
 
         # Advance the reactor
-        r = ct.IdealGasReactor(gas)
+        r = ct.IdealGasReactor(gas, clone=False)
         net = ct.ReactorNet([r])
         T = r.T
         while T < 1900:

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -26,7 +26,7 @@ class TestReactor:
 
         self.gas1 = ct.Solution('h2o2.yaml', transport_model=None)
         self.gas1.TPX = T1, P1, X1
-        self.r1 = self.reactorClass(self.gas1)
+        self.r1 = self.reactorClass(self.gas1, clone=True)
 
         if independent:
             self.gas2 = ct.Solution('h2o2.yaml', transport_model=None)
@@ -37,7 +37,7 @@ class TestReactor:
             self.net = ct.ReactorNet([self.r1])
         else:
             self.gas2.TPX = T2, P2, X2
-            self.r2 = self.reactorClass(self.gas2)
+            self.r2 = self.reactorClass(self.gas2, clone=True)
             self.net = ct.ReactorNet([self.r1, self.r2])
         assert self.net.initial_time == 0.
 
@@ -53,7 +53,7 @@ class TestReactor:
 
     def test_volume(self):
         g = ct.Solution('h2o2.yaml', transport_model=None)
-        R = self.reactorClass(g, volume=11)
+        R = self.reactorClass(g, volume=11, clone=True)
         assert R.volume == 11
 
         R.volume = 9
@@ -231,7 +231,7 @@ class TestReactor:
 
     def test_wall_type2(self):
         self.make_reactors(n_reactors=1)
-        res = ct.Reservoir(self.gas1)
+        res = ct.Reservoir(self.gas1, clone=True)
         w = ct.Wall(self.r1, res)
         net = ct.ReactorNet([self.r1])  # assigns default names
         assert self.r1.name.startswith(f"{self.r1.type}_")  # default name
@@ -240,7 +240,7 @@ class TestReactor:
 
     def test_wall_type3(self):
         self.make_reactors(n_reactors=1)
-        res = ct.Reservoir(self.gas1)
+        res = ct.Reservoir(self.gas1, clone=True)
         w = ct.Wall(res, self.r1)
         net = ct.ReactorNet([self.r1])  # assigns default names
         assert self.r1.name.startswith(f"{self.r1.type}_")  # default name
@@ -425,7 +425,7 @@ class TestReactor:
 
         gas1 = ct.Solution('h2o2.yaml', transport_model=None)
         gas1.TPX = T0, P0, X0
-        r1 = ct.IdealGasConstPressureReactor(gas1)
+        r1 = ct.IdealGasConstPressureReactor(gas1, clone=True)
 
         net = ct.ReactorNet([r1])
         net.advance(1.0)
@@ -510,7 +510,7 @@ class TestReactor:
         self.make_reactors(n_reactors=1)
         gas2 = ct.Solution('h2o2.yaml', transport_model=None)
         gas2.TPX = 300, 10*101325, 'H2:1.0'
-        reservoir = ct.Reservoir(gas2)
+        reservoir = ct.Reservoir(gas2, clone=True)
 
         # Apply a mass flow rate that is not a smooth function of time. This
         # demonstrates the accuracy that can be achieved by having the mass flow rate
@@ -708,7 +708,7 @@ class TestReactor:
 
     def test_valve_type1(self):
         self.make_reactors()
-        res = ct.Reservoir(self.gas1)
+        res = ct.Reservoir(self.gas1, clone=True)
         v = ct.Valve(self.r1, res)
         ct.ReactorNet([self.r1])  # assigns default names
         assert self.r1.name.startswith(f"{self.r1.type}_")  # default name
@@ -720,7 +720,7 @@ class TestReactor:
 
     def test_valve_type2(self):
         self.make_reactors()
-        res = ct.Reservoir(self.gas1)
+        res = ct.Reservoir(self.gas1, clone=True)
         ct.Valve(res, self.r1)
         ct.ReactorNet([self.r1])  # assigns default names
         assert self.r1.name.startswith(f"{self.r1.type}_")  # default name
@@ -730,9 +730,9 @@ class TestReactor:
         self.make_reactors(n_reactors=1)
         g = ct.Solution('h2o2.yaml', transport_model=None)
         g.TPX = 500, 2*101325, 'H2:1.0'
-        inlet_reservoir = ct.Reservoir(g)
+        inlet_reservoir = ct.Reservoir(g, clone=True)
         g.TP = 300, 101325
-        outlet_reservoir = ct.Reservoir(g)
+        outlet_reservoir = ct.Reservoir(g, clone=True)
 
         mfc = ct.MassFlowController(inlet_reservoir, self.r1)
         mdot = lambda t: np.exp(-100*(t-0.5)**2)
@@ -758,9 +758,9 @@ class TestReactor:
         self.make_reactors(n_reactors=1)
         g = ct.Solution('h2o2.yaml', transport_model=None)
         g.TPX = 500, 2*101325, 'H2:1.0'
-        inlet_reservoir = ct.Reservoir(g)
+        inlet_reservoir = ct.Reservoir(g, clone=True)
         g.TP = 300, 101325
-        outlet_reservoir = ct.Reservoir(g)
+        outlet_reservoir = ct.Reservoir(g, clone=True)
 
         mfc = ct.MassFlowController(inlet_reservoir, self.r1)
         mdot = lambda t: np.exp(-100*(t-0.5)**2)
@@ -782,7 +782,7 @@ class TestReactor:
 
     def test_pressure_controller_type(self):
         self.make_reactors()
-        res = ct.Reservoir(self.gas1)
+        res = ct.Reservoir(self.gas1, clone=True)
         mfc = ct.MassFlowController(res, self.r1, mdot=0.6)
         p = ct.PressureController(self.r1, self.r2, primary=mfc, K=0.5)
         net = ct.ReactorNet([self.r1, self.r2])  # assigns default names
@@ -793,7 +793,7 @@ class TestReactor:
 
     def test_pressure_controller_errors(self):
         self.make_reactors()
-        res = ct.Reservoir(self.gas1)
+        res = ct.Reservoir(self.gas1, clone=True)
         mfc = ct.MassFlowController(res, self.r1, mdot=0.6)
 
         p = ct.PressureController(self.r1, self.r2, primary=mfc, K=0.5)
@@ -904,9 +904,9 @@ class TestReactor:
 
     def test_bad_kwarg(self):
         g = ct.Solution('h2o2.yaml', transport_model=None)
-        self.reactorClass(g, name='ok')
+        self.reactorClass(g, name='ok', clone=True)
         with pytest.raises(TypeError):
-            self.reactorClass(g, foobar=3.14)
+            self.reactorClass(g, foobar=3.14, clone=True)
 
     def test_preconditioner_unsupported(self):
         self.make_reactors()
@@ -922,7 +922,7 @@ class TestReactor:
         T1, P1, X1 = 300, 101325, 'O2:1.0'
         self.gas1.TPX = T1, P1, X1
         # set attributes during creation
-        r1 = self.reactorClass(self.gas1, node_attr={'fillcolor': 'red'})
+        r1 = self.reactorClass(self.gas1, node_attr={'fillcolor': 'red'}, clone=True)
         r1.name = "Name"
         # overwrite fillcolor in object attributes
         r1.node_attr = {'style': 'filled', 'fillcolor': 'green'}
@@ -1038,9 +1038,9 @@ class TestReactor:
         self.r1.name = "Reactor"
         gas2 = ct.Solution('h2o2.yaml', transport_model=None)
         gas2.TPX = 300, 10*101325, 'H2:1.0'
-        inlet_reservoir = ct.Reservoir(gas2, name='Inlet')
+        inlet_reservoir = ct.Reservoir(gas2, name='Inlet', clone=True)
         gas2.TPX = 300, 101325, 'H2:1.0'
-        outlet_reservoir = ct.Reservoir(gas2, name='Outlet')
+        outlet_reservoir = ct.Reservoir(gas2, name='Outlet', clone=True)
         mfc = ct.MassFlowController(inlet_reservoir, self.r1, mdot=2,
                                     edge_attr={'xlabel': 'MFC'}, name="MFC")
         ct.PressureController(self.r1, outlet_reservoir, primary=mfc, name="PC")
@@ -1060,10 +1060,10 @@ class TestReactor:
         self.add_wall(U=10, name="wall")
         gas2 = ct.Solution('h2o2.yaml', transport_model=None)
         gas2.TPX = 600, 101325, 'O2:1.0'
-        hot_inlet = ct.Reservoir(gas2, name='InH')
+        hot_inlet = ct.Reservoir(gas2, name='InH', clone=True)
         gas2.TPX = 200, 101325, 'O2:1.0'
-        cold_inlet = ct.Reservoir(gas2, name='InC')
-        outlet = ct.Reservoir(gas2, name='Out')
+        cold_inlet = ct.Reservoir(gas2, name='InC', clone=True)
+        outlet = ct.Reservoir(gas2, name='Out', clone=True)
         mfc_hot1 = ct.MassFlowController(hot_inlet, self.r1, mdot=1.5, name='mfc_h1')
         mfc_hot2 = ct.MassFlowController(hot_inlet, self.r1, mdot=1, name='mfc_h2')
         mfc_cold = ct.MassFlowController(cold_inlet, self.r2, mdot=2, name='mfc_c')
@@ -1111,25 +1111,25 @@ class TestMoleReactor(TestReactor):
         gas1 = ct.Solution(model, transport_model=None)
         gas1.TP = T0, P0
         gas1.set_equivalence_ratio(equiv_ratio, fuel, air)
-        r1 = self.reactorClass(gas1)
+        r1 = self.reactorClass(gas1, clone=True)
         # comparison reactor
         gas2 = ct.Solution(model, transport_model=None)
         gas2.TP = T0, P0
         gas2.set_equivalence_ratio(equiv_ratio, fuel, air)
         if "ConstPressure" in r1.type:
-            r2 = ct.ConstPressureReactor(gas2)
+            r2 = ct.ConstPressureReactor(gas2, clone=True)
         else:
-            r2 = ct.Reactor(gas2)
+            r2 = ct.Reactor(gas2, clone=True)
         # surf 1
         surf1 = ct.Interface(model, "Pt_surf", [gas1])
         surf1.TP = T0, P0
         surf1.coverages = {"PT(S)":1}
-        rsurf1 = ct.ReactorSurface(surf1, r1, A=surf_area)
+        rsurf1 = ct.ReactorSurface(surf1, r1, A=surf_area, clone=True)
         # surf 2
         surf2 = ct.Interface(model, "Pt_surf", [gas2])
         surf2.TP = T0, P0
         surf2.coverages = {"PT(S)":1}
-        rsurf2 = ct.ReactorSurface(surf2, r2, A=surf_area)
+        rsurf2 = ct.ReactorSurface(surf2, r2, A=surf_area, clone=True)
         # reactor network setup
         net1 = ct.ReactorNet([r1,])
         net2 = ct.ReactorNet([r2,])
@@ -1174,19 +1174,19 @@ class TestWellStirredReactorIgnition:
 
         # fuel inlet
         self.gas.TPX = T0, P0, "CH4:1.0"
-        fuel_in = ct.Reservoir(self.gas)
+        fuel_in = ct.Reservoir(self.gas, clone=True)
 
         # oxidizer inlet
         self.gas.TPX = T0, P0, "N2:3.76, O2:1.0"
-        oxidizer_in = ct.Reservoir(self.gas)
+        oxidizer_in = ct.Reservoir(self.gas, clone=True)
 
         # reactor, initially filled with N2
         self.gas.TPX = T0, P0, "N2:1.0"
-        self.combustor = reactor_class(self.gas)
+        self.combustor = reactor_class(self.gas, clone=True)
         self.combustor.volume = 1.0
 
         # outlet
-        exhaust = ct.Reservoir(self.gas)
+        exhaust = ct.Reservoir(self.gas, clone=True)
 
         # connect the reactor to the reservoirs
         fuel_mfc = ct.MassFlowController(fuel_in, self.combustor)
@@ -1316,14 +1316,14 @@ class TestConstPressureReactor:
         self.gas1.TPX = T0, P0, X0
         self.gas2.TPX = T0, P0, X0
 
-        self.r1 = ct.IdealGasReactor(self.gas1)
-        self.r2 = self.reactorClass(self.gas2)
+        self.r1 = ct.IdealGasReactor(self.gas1, clone=True)
+        self.r2 = self.reactorClass(self.gas2, clone=True)
 
         self.r1.volume = 0.2
         self.r2.volume = 0.2
 
         resGas.TP = T0 - 300, P0
-        env = ct.Reservoir(resGas)
+        env = ct.Reservoir(resGas, clone=True)
 
         U = 300 if add_Q else 0
 
@@ -1345,15 +1345,17 @@ class TestConstPressureReactor:
             C[4] = 0.7
             if use_surf_install:
                 with pytest.deprecated_call():
-                    self.surf1 = ct.ReactorSurface(self.interface1, A=0.2)
-                    self.surf2 = ct.ReactorSurface(self.interface2, A=0.2)
+                    self.surf1 = ct.ReactorSurface(self.interface1, A=0.2, clone=True)
+                    self.surf2 = ct.ReactorSurface(self.interface2, A=0.2, clone=True)
                 self.surf1.coverages = C
                 self.surf2.coverages = C
                 self.surf1.install(self.r1)
                 self.surf2.install(self.r2)
             else:
-                self.surf1 = ct.ReactorSurface(self.interface1, r=self.r1, A=0.2)
-                self.surf2 = ct.ReactorSurface(self.interface2, r=[self.r2], A=0.2)
+                self.surf1 = ct.ReactorSurface(self.interface1, r=self.r1, A=0.2,
+                                               clone=True)
+                self.surf2 = ct.ReactorSurface(self.interface2, r=[self.r2], A=0.2,
+                                               clone=True)
                 self.surf1.coverages = C
                 self.surf2.coverages = C
 
@@ -1476,13 +1478,13 @@ class TestIdealGasMoleReactor(TestMoleReactor):
         gas1 = ct.Solution("gri30.yaml")
         gas1.TP = T0, P0
         gas1.set_equivalence_ratio(1, "CH4", "O2:1, N2:3.76")
-        r1 = ct.IdealGasMoleReactor(gas1)
+        r1 = ct.IdealGasMoleReactor(gas1, clone=True)
         net1 = ct.ReactorNet([r1])
         # Network two with mole reactor and preconditioner
         gas2 = ct.Solution("gri30.yaml")
         gas2.TP = T0, P0
         gas2.set_equivalence_ratio(1, "CH4", "O2:1, N2:3.76")
-        r2 = ct.IdealGasMoleReactor(gas2)
+        r2 = ct.IdealGasMoleReactor(gas2, clone=True)
         net2 = ct.ReactorNet([r2])
         # add preconditioner
         net2.preconditioner = ct.AdaptivePreconditioner()
@@ -1515,11 +1517,11 @@ class TestReactorJacobians:
         surf.coverages = 'A(S):0.1, B(S):0.2, C(S):0.3, D(S):0.2, (S):0.2'
         surf2.coverages = 'A(S):0.1, D(S):0.2, (S):0.2'
         # create reactor
-        r = ct.IdealGasMoleReactor(gas)
+        r = ct.IdealGasMoleReactor(gas, clone=True)
         r.volume = 3
         # create surfaces
-        rsurf1 = ct.ReactorSurface(surf, r, A=9e-4)
-        rsurf2 = ct.ReactorSurface(surf2, r, A=5e-4)
+        rsurf1 = ct.ReactorSurface(surf, r, A=9e-4, clone=True)
+        rsurf2 = ct.ReactorSurface(surf2, r, A=5e-4, clone=True)
         # create network
         net = ct.ReactorNet([r])
         net.step()
@@ -1543,7 +1545,7 @@ class TestReactorJacobians:
         gas = ct.Solution(yml, "gas")
         gas.TPX = 1000, 2e5, fuel
         # create reactor
-        r = ct.IdealGasMoleReactor(gas)
+        r = ct.IdealGasMoleReactor(gas, clone=True)
         r.volume = 1
         # create network
         net = ct.ReactorNet([r])
@@ -1560,7 +1562,7 @@ class TestReactorJacobians:
         gas.set_multiplier(0)
         gas.set_multiplier(1, 14)
         # create reactor
-        r = ct.IdealGasMoleReactor(gas)
+        r = ct.IdealGasMoleReactor(gas, clone=True)
         r.volume = 2
         # create network
         net = ct.ReactorNet([r])
@@ -1586,7 +1588,7 @@ class TestReactorJacobians:
         gas.set_multiplier(0)
         gas.set_multiplier(1, 14)
         # create reactor
-        r = ct.IdealGasConstPressureMoleReactor(gas)
+        r = ct.IdealGasConstPressureMoleReactor(gas, clone=True)
         r.volume = 2
         # create network
         net = ct.ReactorNet([r])
@@ -1615,8 +1617,8 @@ class TestReactorJacobians:
         X0 = 'CH4:0.5, H2O:0.2, CO:0.3'
         gas.TPX = T0, P0, X0
         # create reactors
-        r1 = ct.IdealGasMoleReactor(gas)
-        r2 = ct.IdealGasMoleReactor(gas)
+        r1 = ct.IdealGasMoleReactor(gas, clone=True)
+        r2 = ct.IdealGasMoleReactor(gas, clone=True)
         r1.volume = 0.1
         r2.volume = 0.1
         # create solid and interfaces
@@ -1630,8 +1632,8 @@ class TestReactorJacobians:
         C[0] = 0.3
         C[4] = 0.7
         # creating reactor surfaces
-        surf1 = ct.ReactorSurface(interface1, r=r1, A=1e-3)
-        surf2 = ct.ReactorSurface(interface2, r=r2, A=1e-3)
+        surf1 = ct.ReactorSurface(interface1, r=r1, A=1e-3, clone=True)
+        surf2 = ct.ReactorSurface(interface2, r=r2, A=1e-3, clone=True)
         surf1.coverages = C
         surf2.coverages = C
         # create reactor network
@@ -1692,7 +1694,7 @@ class TestFlowReactor:
     def test_nonreacting(self):
         g = ct.Solution(yaml=self.gas_def)
         g.TPX = 300, 101325, 'O2:1.0'
-        r = ct.FlowReactor(g)
+        r = ct.FlowReactor(g, clone=True)
         r.mass_flow_rate = 10
 
         net = ct.ReactorNet([r])
@@ -1708,7 +1710,7 @@ class TestFlowReactor:
         g = ct.Solution(yaml=self.gas_def)
         g.TPX = 1400, 20*101325, 'CO:1.0, H2O:1.0'
 
-        r = ct.FlowReactor(g)
+        r = ct.FlowReactor(g, clone=True)
         r.mass_flow_rate = 10
         net = ct.ReactorNet([r])
 
@@ -1738,7 +1740,7 @@ class TestFlowReactor:
         gas.TPX = T0, P0, X0
         surf.TP = T0, P0
 
-        r = ct.FlowReactor(gas)
+        r = ct.FlowReactor(gas, clone=True)
         r.area = 1e-4
         porosity = 0.3
         velocity = 0.4 / 60
@@ -1747,7 +1749,7 @@ class TestFlowReactor:
         r.mass_flow_rate = mdot
         r.energy_enabled = False
 
-        rsurf = ct.ReactorSurface(surf, r)
+        rsurf = ct.ReactorSurface(surf, r, clone=True)
 
         sim = ct.ReactorNet([r])
         kCH4 = gas.species_index('CH4')
@@ -1772,9 +1774,9 @@ class TestFlowReactor:
     def test_component_names(self):
         surf = ct.Interface('methane_pox_on_pt.yaml', 'Pt_surf')
         gas = surf.adjacent['gas']
-        r = ct.FlowReactor(gas)
+        r = ct.FlowReactor(gas, clone=True)
         r.mass_flow_rate = 0.1
-        rsurf = ct.ReactorSurface(surf, r)
+        rsurf = ct.ReactorSurface(surf, r, clone=True)
         sim = ct.ReactorNet([r])
         sim.initialize()
 
@@ -1797,11 +1799,11 @@ class TestFlowReactor2:
         return surf, surf.adjacent['gas']
 
     def make_reactors(self, gas, surf):
-        r = ct.FlowReactor(gas)
+        r = ct.FlowReactor(gas, clone=True)
         r.area = 1e-4
         r.surface_area_to_volume_ratio = 5000
         r.mass_flow_rate = 0.02
-        rsurf = ct.ReactorSurface(surf, r)
+        rsurf = ct.ReactorSurface(surf, r, clone=True)
         sim = ct.ReactorNet([r])
         return r, rsurf, sim
 
@@ -1816,16 +1818,16 @@ class TestFlowReactor2:
 
     def test_no_mass_flow_rate(self):
         surf, gas = self.import_phases()
-        r = ct.FlowReactor(gas)
-        rsurf = ct.ReactorSurface(surf, r)
+        r = ct.FlowReactor(gas, clone=True)
+        rsurf = ct.ReactorSurface(surf, r, clone=True)
         sim = ct.ReactorNet([r])
         with pytest.raises(ct.CanteraError, match="mass flow rate"):
             sim.initialize()
 
     def test_mixed_reactor_types(self):
         surf, gas = self.import_phases()
-        r1 = ct.FlowReactor(gas)
-        r2 = ct.IdealGasReactor(gas)
+        r1 = ct.FlowReactor(gas, clone=True)
+        r2 = ct.IdealGasReactor(gas, clone=True)
         with pytest.raises(ct.CanteraError, match="Cannot mix Reactor types"):
             ct.ReactorNet([r1, r2])
 
@@ -2048,16 +2050,16 @@ class TestSurfaceKinetics:
         self.interface = ct.Interface('diamond.yaml', 'diamond_100')
         self.gas = self.interface.adjacent['gas']
         self.gas.TPX = None, 1.0e3, 'H:0.002, H2:1, CH4:0.01, CH3:0.0002'
-        self.r1 = ct.IdealGasReactor(self.gas)
+        self.r1 = ct.IdealGasReactor(self.gas, clone=True)
         self.r1.volume = 0.01
-        self.r2 = ct.IdealGasReactor(self.gas)
+        self.r2 = ct.IdealGasReactor(self.gas, clone=True)
         self.r2.volume = 0.01
 
         self.net = ct.ReactorNet([self.r1, self.r2])
 
     def test_coverages(self):
         self.make_reactors()
-        surf1 = ct.ReactorSurface(self.interface, self.r1)
+        surf1 = ct.ReactorSurface(self.interface, self.r1, clone=True)
 
         surf1.coverages = {'c6HH':0.3, 'c6HM':0.7}
         assert surf1.coverages[0] == approx(0.3)
@@ -2067,7 +2069,7 @@ class TestSurfaceKinetics:
         C_left = surf1.coverages
 
         self.make_reactors()
-        surf2 = ct.ReactorSurface(self.interface, self.r2)
+        surf2 = ct.ReactorSurface(self.interface, self.r2, clone=True)
         surf2.coverages = 'c6HH:0.3, c6HM:0.7'
         assert surf2.coverages[0] == approx(0.3)
         assert surf2.coverages[4] == approx(0.7)
@@ -2085,7 +2087,7 @@ class TestSurfaceKinetics:
         self.make_reactors()
         self.r1.energy_enabled = False
         self.r2.energy_enabled = False
-        surf1 = ct.ReactorSurface(self.interface, self.r1)
+        surf1 = ct.ReactorSurface(self.interface, self.r1, clone=True)
 
         C = np.zeros(self.interface.n_species)
         C[0] = 0.3
@@ -2110,7 +2112,7 @@ class TestSurfaceKinetics:
     def test_coverages_regression2(self, test_data_path):
         # Test with energy equation enabled
         self.make_reactors()
-        surf = ct.ReactorSurface(self.interface, self.r1)
+        surf = ct.ReactorSurface(self.interface, self.r1, clone=True)
 
         C = np.zeros(self.interface.n_species)
         C[0] = 0.3
@@ -2135,7 +2137,7 @@ class TestSurfaceKinetics:
     @pytest.mark.skipif(_graphviz is None, reason="graphviz is not installed")
     def test_draw_ReactorSurface(self):
         self.make_reactors()
-        surf = ct.ReactorSurface(self.interface, self.r1)
+        surf = ct.ReactorSurface(self.interface, self.r1, clone=True)
         self.r1.name = "Reactor"
 
         graph = surf.draw(node_attr={'style': 'filled'},
@@ -2152,7 +2154,7 @@ class TestReactorSensitivities:
     def test_sensitivities1(self):
         gas = ct.Solution('gri30.yaml', transport_model=None)
         gas.TPX = 1300, 20*101325, 'CO:1.0, H2:0.1, CH4:0.1, H2O:0.5'
-        r1 = ct.IdealGasReactor(gas)
+        r1 = ct.IdealGasReactor(gas, clone=True)
         net = ct.ReactorNet([r1])
 
         assert net.n_sensitivity_params == 0
@@ -2169,17 +2171,17 @@ class TestReactorSensitivities:
     def test_sensitivities2(self):
         interface = ct.Interface("diamond.yaml", "diamond_100")
         gas1 = interface.adjacent["gas"]
-        r1 = ct.IdealGasReactor(gas1)
+        r1 = ct.IdealGasReactor(gas1, clone=True)
 
         gas2 = ct.Solution('h2o2.yaml', transport_model=None)
         gas2.TPX = 900, 101325, 'H2:0.1, OH:1e-7, O2:0.1, AR:1e-5'
-        r2 = ct.IdealGasReactor(gas2)
+        r2 = ct.IdealGasReactor(gas2, clone=True)
 
         net = ct.ReactorNet([r1, r2])
         net.atol_sensitivity = 1e-10
         net.rtol_sensitivity = 1e-8
 
-        surf = ct.ReactorSurface(interface, r1, A=1.5)
+        surf = ct.ReactorSurface(interface, r1, A=1.5, clone=True)
 
         C = np.zeros(interface.n_species)
         C[0] = 0.3
@@ -2215,7 +2217,7 @@ class TestReactorSensitivities:
 
         def setup(params):
             gas.TPX = 900, 101325, 'H2:0.1, OH:1e-7, O2:0.1, AR:1e-5'
-            r = reactorClass(gas)
+            r = reactorClass(gas, clone=True)
             net = ct.ReactorNet([r])
 
             for kind, p in params:
@@ -2269,11 +2271,11 @@ class TestReactorSensitivities:
         def setup(reverse=False):
             gas1 = ct.Solution('h2o2.yaml', transport_model=None)
             gas1.TPX = 900, 101325, 'H2:0.1, OH:1e-7, O2:0.1, AR:1e-5'
-            rA = ct.IdealGasReactor(gas1)
+            rA = ct.IdealGasReactor(gas1, clone=True)
 
             gas2 = ct.Solution('h2o2.yaml', transport_model=None)
             gas2.TPX = 920, 101325, 'H2:0.1, OH:1e-7, O2:0.1, AR:0.5'
-            rB = ct.IdealGasReactor(gas2)
+            rB = ct.IdealGasReactor(gas2, clone=True)
             reactors = [rA, rB]
             if reverse:
                 reactors = reactors[-1::-1]
@@ -2331,15 +2333,15 @@ class TestReactorSensitivities:
         def setup(order):
             gas1.TPX = 1200, 1e3, 'H:0.002, H2:1, CH4:0.01, CH3:0.0002'
             gas2.TPX = 900, 101325, 'H2:0.1, OH:1e-7, O2:0.1, AR:1e-5'
-            rA = ct.IdealGasReactor(gas1)
-            rB = ct.IdealGasReactor(gas2)
+            rA = ct.IdealGasReactor(gas1, clone=True)
+            rB = ct.IdealGasReactor(gas2, clone=True)
 
             if order % 2 == 0:
-                surfX = ct.ReactorSurface(interface, rA, A=0.1)
-                surfY = ct.ReactorSurface(interface, rA, A=10)
+                surfX = ct.ReactorSurface(interface, rA, A=0.1, clone=True)
+                surfY = ct.ReactorSurface(interface, rA, A=10, clone=True)
             else:
-                surfY = ct.ReactorSurface(interface, rA, A=10)
-                surfX = ct.ReactorSurface(interface, rA, A=0.1)
+                surfY = ct.ReactorSurface(interface, rA, A=10, clone=True)
+                surfX = ct.ReactorSurface(interface, rA, A=0.1, clone=True)
 
             C1 = np.zeros(interface.n_species)
             C2 = np.zeros(interface.n_species)
@@ -2388,7 +2390,7 @@ class TestReactorSensitivities:
         gas = ct.Solution('h2o2.yaml', transport_model=None)
         gas.TP = 900, 5*ct.one_atm
         gas.set_equivalence_ratio(0.4, 'H2', 'O2:1.0, AR:4.0')
-        r = ct.IdealGasReactor(gas)
+        r = ct.IdealGasReactor(gas, clone=True)
         net = ct.ReactorNet([r])
         net.rtol_sensitivity = 2e-5
         return gas, r, net
@@ -2479,26 +2481,26 @@ class TestCombustor:
 
         # create a reservoir for the fuel inlet, and set to pure methane.
         gas.TPX = 300.0, ct.one_atm, 'H2:1.0'
-        fuel_in = ct.Reservoir(gas)
+        fuel_in = ct.Reservoir(gas, clone=True)
         fuel_mw = gas.mean_molecular_weight
 
         # Oxidizer inlet
         gas.TPX = 300.0, ct.one_atm, 'O2:1.0, AR:3.0'
-        oxidizer_in = ct.Reservoir(gas)
+        oxidizer_in = ct.Reservoir(gas, clone=True)
         oxidizer_mw = gas.mean_molecular_weight
 
         # to ignite the fuel/air mixture, we'll introduce a pulse of radicals.
         # The steady-state behavior is independent of how we do this, so we'll
         # just use a stream of pure atomic hydrogen.
         gas.TPX = 300.0, ct.one_atm, 'H:1.0'
-        igniter = ct.Reservoir(gas)
+        igniter = ct.Reservoir(gas, clone=True)
 
         # create the combustor, and fill it with a diluent
         gas.TPX = 300.0, ct.one_atm, 'AR:1.0'
-        combustor = ct.IdealGasReactor(gas)
+        combustor = ct.IdealGasReactor(gas, clone=True)
 
         # create a reservoir for the exhaust
-        exhaust = ct.Reservoir(gas)
+        exhaust = ct.Reservoir(gas, clone=True)
 
         # compute fuel and air mass flow rates
         factor = 0.1
@@ -2615,17 +2617,17 @@ class TestWall:
         # reservoir to represent the environment
         gas0 = ct.Solution("air.yaml")
         gas0.TP = 300, ct.one_atm
-        env = ct.Reservoir(gas0)
+        env = ct.Reservoir(gas0, clone=True)
 
         # reactor to represent the side filled with Argon
         gas1 = ct.Solution("air.yaml")
         gas1.TPX = 1000.0, 30*ct.one_atm, 'AR:1.0'
-        r1 = ct.Reactor(gas1)
+        r1 = ct.Reactor(gas1, clone=True)
 
         # reactor to represent the combustible mixture
         gas2 = ct.Solution('h2o2.yaml', transport_model=None)
         gas2.TPX = 500.0, 1.5*ct.one_atm, 'H2:0.5, O2:1.0, AR:10.0'
-        r2 = ct.Reactor(gas2)
+        r2 = ct.Reactor(gas2, clone=True)
 
         # Wall between the two reactors
         w1 = ct.Wall(r2, r1, A=1.0, K=2e-4, U=400.0)
@@ -2676,15 +2678,15 @@ class TestPureFluidReactor:
         air = ct.Solution("air.yaml")
 
         phase.TP = 93, 4e5
-        r1 = ct.Reactor(phase)
+        r1 = ct.Reactor(phase, clone=True)
         r1.volume = 0.1
 
         air.TP = 300, 4e5
-        r2 = ct.Reactor(air)
+        r2 = ct.Reactor(air, clone=True)
         r2.volume = 10.0
 
         air.TP = 500, 4e5
-        env = ct.Reservoir(air)
+        env = ct.Reservoir(air, clone=True)
 
         w1 = ct.Wall(r1,r2)
         w1.expansion_rate_coeff = 1e-3
@@ -2707,11 +2709,11 @@ class TestPureFluidReactor:
         air = ct.Solution("air.yaml")
 
         phase.TP = 218, 5e6
-        r1 = ct.Reactor(phase)
+        r1 = ct.Reactor(phase, clone=True)
         r1.volume = 0.1
 
         air.TP = 500, 5e6
-        r2 = ct.Reactor(air)
+        r2 = ct.Reactor(air, clone=True)
         r2.volume = 10.0
 
         w1 = ct.Wall(r1, r2, U=10000, A=1)
@@ -2733,11 +2735,11 @@ class TestPureFluidReactor:
         air = ct.Solution("air.yaml")
 
         phase.TP = 75, 4e5
-        r1 = ct.ConstPressureReactor(phase)
+        r1 = ct.ConstPressureReactor(phase, clone=True)
         r1.volume = 0.1
 
         air.TP = 500, 4e5
-        env = ct.Reservoir(air)
+        env = ct.Reservoir(air, clone=True)
 
         w2 = ct.Wall(env,r1, Q=250000, A=1)
         net = ct.ReactorNet([r1])
@@ -2832,9 +2834,9 @@ class TestExtensibleReactor:
                     return 'v_wall'
 
         self.gas.TP = 300, ct.one_atm
-        res = ct.Reservoir(self.gas)
+        res = ct.Reservoir(self.gas, clone=True)
         self.gas.TP = 300, 2 * ct.one_atm
-        r = InertialWallReactor(self.gas, neighbor=res)
+        r = InertialWallReactor(self.gas, neighbor=res, clone=True)
         w = ct.Wall(r, res)
         net = ct.ReactorNet([r])
 
@@ -2868,7 +2870,7 @@ class TestExtensibleReactor:
             def replace_eval(self, t, LHS, RHS):
                 RHS[:] = - self.y / tau
 
-        r = DummyReactor(self.gas)
+        r = DummyReactor(self.gas, clone=True)
         net = ct.ReactorNet([r])
         net.rtol *= 0.1
 
@@ -2882,7 +2884,7 @@ class TestExtensibleReactor:
                 pass
 
         with pytest.raises(ValueError, match="right number of arguments"):
-            DummyReactor1(self.gas)
+            DummyReactor1(self.gas, clone=True)
 
         class DummyReactor2(ct.ExtensibleReactor):
             def replace_component_index(self, name):
@@ -2892,7 +2894,7 @@ class TestExtensibleReactor:
                     return "spam"
                 # Otherwise, does not return a value
 
-        r2 = DummyReactor2(self.gas)
+        r2 = DummyReactor2(self.gas, clone=True)
         assert r2.component_index("succeed") == 0
         with pytest.raises(TypeError):
             r2.component_index("wrong-type")
@@ -2915,7 +2917,7 @@ class TestExtensibleReactor:
                 if name == "fail":
                     raise TestException()
 
-        r = DummyReactor(self.gas)
+        r = DummyReactor(self.gas, clone=True)
         net = ct.ReactorNet([r])
         net.max_steps = 10
 
@@ -2930,8 +2932,8 @@ class TestExtensibleReactor:
 
     def test_misc(self):
         class DummyReactor(ct.ExtensibleReactor):
-            def __init__(self, gas):
-                super().__init__(gas)
+            def __init__(self, gas, *args, **kwargs):
+                super().__init__(gas, *args, **kwargs)
                 self.sync_calls = 0
 
             def after_species_index(self, name):
@@ -2942,7 +2944,7 @@ class TestExtensibleReactor:
             def before_sync_state(self):
                 self.sync_calls += 1
 
-        r = DummyReactor(self.gas)
+        r = DummyReactor(self.gas, clone=True)
         net = ct.ReactorNet([r])
         assert r.component_index("H2") == 5 + 3 + self.gas.species_index("H2")
         r.syncState()
@@ -2973,7 +2975,7 @@ class TestExtensibleReactor:
                 LHS[1] = mass_lump * cp_lump + self.m_mass * self.thermo.cp_mass
                 RHS[1] = Q
 
-        r1 = DummyReactor(self.gas)
+        r1 = DummyReactor(self.gas, clone=True)
         r1_net = ct.ReactorNet([r1])
 
         for n in range(n_steps):
@@ -2997,8 +2999,8 @@ class TestExtensibleReactor:
                 self.heat_rate += Qext
 
         self.gas.TPX = 300, ct.one_atm, "N2:1.0"
-        r1 = HeatedReactor(self.gas)
-        res = ct.Reservoir(self.gas)
+        r1 = HeatedReactor(self.gas, clone=True)
+        res = ct.Reservoir(self.gas, clone=True)
         wall = ct.Wall(res, r1, Q=Qwall, A=1)
         net = ct.ReactorNet([r1])
         U0 = r1.thermo.int_energy_mass * r1.mass
@@ -3062,10 +3064,10 @@ class TestExtensibleReactor:
                 # this is the same thing the original method does
                 self.surfaces[0].coverages = y
 
-        r1 = SurfReactor(gas)
+        r1 = SurfReactor(gas, clone=True)
         r1.volume = 1e-6 # 1 cm^3
         r1.energy_enabled = False
-        rsurf = ct.ReactorSurface(surf, r=r1, A=0.01)
+        rsurf = ct.ReactorSurface(surf, r=r1, A=0.01, clone=True)
         net = ct.ReactorNet([r1])
 
         Hweight = ct.Element("H").weight
@@ -3096,8 +3098,8 @@ class TestExtensibleReactor:
         # Reactors connected by a movable, H2-permeable surface
         kH2 = self.gas.species_index("H2")
         class TestReactor(ct.ExtensibleIdealGasReactor):
-            def __init__(self, gas):
-                super().__init__(gas)
+            def __init__(self, gas, *args, **kwargs):
+                super().__init__(gas, *args, **kwargs)
                 self.neighbor = None
                 self.h2coeff = 12  # mass transfer coeff
                 self.p_coeff = 5 # expansion coeff
@@ -3120,9 +3122,9 @@ class TestExtensibleReactor:
                     # enthalpy flux is neglected, so energy isn't properly conserved
 
         self.gas.TPX = 300, 2*101325, "H2:0.8, N2:0.2"
-        r1 = TestReactor(self.gas)
+        r1 = TestReactor(self.gas, clone=True)
         self.gas.TPX = 300, 101325, "H2:0.1, O2:0.9"
-        r2 = TestReactor(self.gas)
+        r2 = TestReactor(self.gas, clone=True)
         r1.neighbor = r2
         r2.neighbor = r1
         net = ct.ReactorNet([r1, r2])
@@ -3164,11 +3166,11 @@ class TestSteadySolver:
         gas.set_equivalence_ratio(1.2, "H2:1.0", "O2:1.0, N2:3.76")
         gas.TP = 500, 20 * ct.one_atm
 
-        upstream = ct.Reservoir(gas)
+        upstream = ct.Reservoir(gas, clone=True)
         gas.equilibrate("HP")
-        downstream = ct.Reservoir(gas)
+        downstream = ct.Reservoir(gas, clone=True)
         V0 = 1e-3
-        r = reactor_class(gas, volume=V0)
+        r = reactor_class(gas, volume=V0, clone=True)
         inlet = ct.MassFlowController(upstream, r, mdot=120)
         ct.PressureController(r, downstream, primary=inlet)
         net = ct.ReactorNet([r])
@@ -3185,10 +3187,10 @@ class TestSteadySolver:
         gas.set_equivalence_ratio(1.2, "H2:1.0", "O2:1.0, N2:3.76")
         gas.TP = 500, 20 * ct.one_atm
 
-        upstream = ct.Reservoir(gas)
+        upstream = ct.Reservoir(gas, clone=True)
         gas.equilibrate("HP")
-        downstream = ct.Reservoir(gas)
-        r = reactor_class(gas, volume=1e-3)
+        downstream = ct.Reservoir(gas, clone=True)
+        r = reactor_class(gas, volume=1e-3, clone=True)
         m0 = r.mass
         ct.MassFlowController(upstream, r, mdot=160)
         ct.MassFlowController(r, downstream, mdot=160)
@@ -3213,11 +3215,11 @@ class TestSteadySolver:
         T0 = 1700
         gas.TP = T0, 5 * ct.one_atm
 
-        upstream = ct.Reservoir(gas)
+        upstream = ct.Reservoir(gas, clone=True)
         gas.equilibrate("TP")
-        downstream = ct.Reservoir(gas)
+        downstream = ct.Reservoir(gas, clone=True)
         V0 = 1e-3
-        r = reactor_class(gas, volume=V0)
+        r = reactor_class(gas, volume=V0, clone=True)
         r.energy_enabled = False
         inlet = ct.MassFlowController(upstream, r, mdot=120)
         ct.PressureController(r, downstream, primary=inlet)
@@ -3231,12 +3233,12 @@ class TestSteadySolver:
         gas.set_equivalence_ratio(1.2, "H2:1.0", "O2:1.0, N2:3.76")
         gas.TP = 500, 20 * ct.one_atm
 
-        upstream = ct.Reservoir(gas)
+        upstream = ct.Reservoir(gas, clone=True)
         gas.equilibrate("HP")
-        downstream = ct.Reservoir(gas)
+        downstream = ct.Reservoir(gas, clone=True)
         V0 = 1e-3
-        r1 = ct.IdealGasReactor(gas, volume=V0)
-        r2 = ct.MoleReactor(gas, volume=2*V0)
+        r1 = ct.IdealGasReactor(gas, volume=V0, clone=True)
+        r2 = ct.MoleReactor(gas, volume=2*V0, clone=True)
         inlet = ct.MassFlowController(upstream, r1, mdot=120)
         middle = ct.PressureController(r1, r2, primary=inlet)
         ct.PressureController(r2, downstream, primary=inlet)
@@ -3258,11 +3260,11 @@ class TestSteadySolver:
         gas.set_equivalence_ratio(0.22, "CH4:1.0", "O2:1.0, AR:3.76")
         gas.TP = 500, 20 * ct.one_atm
 
-        upstream = ct.Reservoir(gas)
+        upstream = ct.Reservoir(gas, clone=True)
         gas.equilibrate("HP")
-        downstream = ct.Reservoir(gas)
-        r = reactor_class(gas, volume=1e-2)
-        ct.ReactorSurface(surf, r, A=0.1)
+        downstream = ct.Reservoir(gas, clone=True)
+        r = reactor_class(gas, volume=1e-2, clone=True)
+        ct.ReactorSurface(surf, r, A=0.1, clone=True)
         mdot = 0.2
         inlet = ct.MassFlowController(upstream, r, mdot=mdot)
         ct.MassFlowController(r, downstream, mdot=mdot)
@@ -3281,12 +3283,12 @@ class TestSteadySolver:
         gas.set_equivalence_ratio(1.2, "H2:1.0", "O2:1.0, N2:3.76")
         gas.TP = 500, 20 * ct.one_atm
 
-        upstream = ct.Reservoir(gas)
+        upstream = ct.Reservoir(gas, clone=True)
         gas.equilibrate("HP")
-        downstream = ct.Reservoir(gas)
+        downstream = ct.Reservoir(gas, clone=True)
         V0 = 1e-3
         mdot = 120
-        r = ct.MoleReactor(gas, volume=V0)
+        r = ct.MoleReactor(gas, volume=V0, clone=True)
         r.thermo.set_multiplier(0.0)
         inlet = ct.MassFlowController(upstream, r, mdot=mdot)
         ct.MassFlowController(r, downstream, mdot=mdot)
@@ -3324,11 +3326,11 @@ class TestSteadySolver:
             gas.set_equivalence_ratio(1.2, "H2:1.0", "O2:1.0, N2:3.76")
             gas.TP = 500, 20 * ct.one_atm
 
-            upstream = ct.Reservoir(gas)
+            upstream = ct.Reservoir(gas, clone=True)
             gas.equilibrate("HP")
-            downstream = ct.Reservoir(gas)
+            downstream = ct.Reservoir(gas, clone=True)
             V0 = 1e-3
-            r = ct.IdealGasReactor(gas, volume=V0)
+            r = ct.IdealGasReactor(gas, volume=V0, clone=True)
             inlet = ct.MassFlowController(upstream, r, mdot=120)
             ct.PressureController(r, downstream, primary=inlet)
             net = ct.ReactorNet([r])

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -939,7 +939,7 @@ class TestThermoPhase:
         ref = ct.Solution('gri30.yaml', transport_model=None)
 
         self.phase.transport_model = "unity-Lewis-number"
-        reactor = ct.IdealGasReactor(self.phase)
+        reactor = ct.IdealGasReactor(self.phase, clone=False)
         with pytest.raises(ct.CanteraError, match='Cannot add species'):
             reactor.thermo.add_species(ref.species('CH4'))
         del reactor

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -941,7 +941,7 @@ class TestThermoPhase:
         self.phase.transport_model = "unity-Lewis-number"
         reactor = ct.IdealGasReactor(self.phase)
         with pytest.raises(ct.CanteraError, match='Cannot add species'):
-            self.phase.add_species(ref.species('CH4'))
+            reactor.thermo.add_species(ref.species('CH4'))
         del reactor
         gc.collect()
         self.phase.add_species(ref.species('CH4'))

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -16,7 +16,7 @@ TEST(zerodim, simple)
 
     auto sol = newSolution("gri30.yaml", "gri30", "none");
     sol->thermo()->setState_TPX(T, P, X);
-    auto reactor = newReactor4("IdealGasReactor", sol, "simple");
+    auto reactor = newReactor4("IdealGasReactor", sol, true, "simple");
     ASSERT_EQ(reactor->name(), "simple");
     reactor->initialize();
     ReactorNet network(reactor);
@@ -55,7 +55,7 @@ TEST(zerodim, test_guards)
 TEST(zerodim, reservoir)
 {
     auto gas = newSolution("gri30.yaml", "gri30", "none");
-    auto res = newReservoir(gas, "my-reservoir");
+    auto res = newReservoir(gas, true, "my-reservoir");
     ASSERT_EQ(res->type(), "Reservoir");
     ASSERT_EQ(res->name(), "my-reservoir");
 }
@@ -64,8 +64,8 @@ TEST(zerodim, flowdevice)
 {
     auto gas = newSolution("gri30.yaml", "gri30", "none");
 
-    auto node0 = newReactor4("IdealGasReactor", gas, "upstream");
-    auto node1 = newReactor4("IdealGasReactor", gas, "downstream");
+    auto node0 = newReactor4("IdealGasReactor", gas, true, "upstream");
+    auto node1 = newReactor4("IdealGasReactor", gas, true, "downstream");
 
     auto valve = newFlowDevice("Valve", node0, node1, "valve");
     ASSERT_EQ(valve->name(), "valve");
@@ -82,8 +82,8 @@ TEST(zerodim, wall)
 {
     auto gas = newSolution("gri30.yaml", "gri30", "none");
 
-    auto node0 = newReactor4("IdealGasReactor", gas, "left");
-    auto node1 = newReactor4("IdealGasReactor", gas, "right");
+    auto node0 = newReactor4("IdealGasReactor", gas, true, "left");
+    auto node1 = newReactor4("IdealGasReactor", gas, true, "right");
 
     auto wall = newWall("Wall", node0, node1, "wall");
     ASSERT_EQ(wall->name(), "wall");
@@ -99,10 +99,10 @@ TEST(zerodim, mole_reactor)
     // simplified version of continuous_reactor.py
     auto gas = newSolution("h2o2.yaml", "ohmech", "none");
 
-    auto tank = make_shared<Reservoir>(gas, "fuel-air-tank");
-    auto exhaust = make_shared<Reservoir>(gas, "exhaust");
+    auto tank = make_shared<Reservoir>(gas, true, "fuel-air-tank");
+    auto exhaust = make_shared<Reservoir>(gas, true, "exhaust");
 
-    auto stirred = make_shared<IdealGasMoleReactor>(gas, "stirred-reactor");
+    auto stirred = make_shared<IdealGasMoleReactor>(gas, true, "stirred-reactor");
     stirred->setEnergy(0);
     stirred->setInitialVolume(30.5 * 1e-6);
 
@@ -124,11 +124,11 @@ TEST(zerodim, mole_reactor_2)
     // simplified version of continuous_reactor.py
     auto gas = newSolution("h2o2.yaml", "ohmech", "none");
 
-    auto tank = newReservoir(gas, "fuel-air-tank");
-    auto exhaust = newReservoir(gas, "exhaust");
+    auto tank = newReservoir(gas, true, "fuel-air-tank");
+    auto exhaust = newReservoir(gas, true, "exhaust");
 
     auto stirred = newReactor4(
-        "IdealGasMoleReactor", gas, "stirred-reactor");
+        "IdealGasMoleReactor", gas, true, "stirred-reactor");
     stirred->setEnergy(0);
     stirred->setInitialVolume(30.5 * 1e-6);
 
@@ -162,7 +162,7 @@ TEST(zerodim, test_individual_reactor_initialization)
     shared_ptr<Solution> sol1 = newSolution("h2o2.yaml");
     sol1->thermo()->setState_TPX(T0, P0, X0);
     // set up reactor object
-    auto reactor1 = newReactor4("Reactor", sol1);
+    auto reactor1 = newReactor4("Reactor", sol1, true);
     // initialize reactor prior to integration to ensure no impact
     reactor1->initialize();
     // setup reactor network and integrate
@@ -174,7 +174,7 @@ TEST(zerodim, test_individual_reactor_initialization)
     sol2->thermo()->setState_TPX(T0, P0, X0);
     sol2->thermo()->equilibrate("UV");
     // secondary reactor for comparison
-    auto reactor2 = newReactor4("Reactor", sol2);
+    auto reactor2 = newReactor4("Reactor", sol2, true);
     reactor2->initialize(0.0);
     // get state of reactors
     vector<double> state1(reactor1->neq());
@@ -194,7 +194,7 @@ TEST(MoleReactorTestSet, test_mole_reactor_get_state)
     double tol = 1e-8;
     auto sol = newSolution("h2o2.yaml");
     sol->thermo()->setState_TPY(1000.0, OneAtm, "H2:0.5, O2:0.5");
-    IdealGasConstPressureMoleReactor reactor(sol);
+    IdealGasConstPressureMoleReactor reactor(sol, true);
     reactor.setInitialVolume(0.5);
     reactor.setEnergy(false);
     reactor.initialize();
@@ -273,7 +273,7 @@ TEST(AdaptivePreconditionerTests, test_precon_solver_stats)
     // setting up solution object and thermo/kinetics pointers
     auto sol = newSolution("h2o2.yaml");
     sol->thermo()->setState_TPY(1000.0, OneAtm, "H2:0.5, O2:0.5");
-    auto reactor = newReactor4("IdealGasMoleReactor", sol);
+    auto reactor = newReactor4("IdealGasMoleReactor", sol, true);
     reactor->setInitialVolume(0.5);
     // setup reactor network and integrate
     ReactorNet network(reactor);


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Partially implements changes envisioned in Cantera/enhancements#201:
  - Implements `clone` method for `Solution`, `ThermoPhase`, `Kinetics`, and `Transport`, based on `AnyMap` serialization
  - constructors for `Reactor` objects now take an optional `clone` argument, which determines whether the `Solution` object used should be cloned. The default is currently `false`, which will raise a warning. After Cantera 3.2, this default will be changed to `true`, with no warning (so, for the duration of Cantera 3.2, this argument is not optional if you don't want a warning).
  - `ReactorNet::initialize` checks all `Solution` and `Interface` objects used by `Reactor` and `ReactorSurface` objects in the network to make sure that they are all unique. If not, a warning is issued. This warning will be an error after Cantera 3.2.
- Provides user interface side of Cantera/enhancements#202
  - Constructing cloned `Interface` objects requires having access to the (probably cloned) `Solution` objects for the adjacent phases at the time the `ReactorSurface` is created, which necessitates the introduction of a new constructor for `ReactorSurface`. In doing so, we also resolve the issue of linking a single `ReactorSurface` to multiple adjacent `Reactor`s.
 - Include reaction rate multipliers in serialized Solution state.

**If applicable, fill in the issue number this pull request is fixing**

After Cantera 3.2, when we can guarantee that the `ReactorNet` contains no re-used `Solution` objects, there is additional refactoring to the logic for how `ReactorNet::eval` works that can be implemented to complete these two enhancements.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
