### PR TITLE
Fix warnings printed in Python test suite

### DIFF
--- a/include/cantera/kinetics/BlowersMaselRate.h
+++ b/include/cantera/kinetics/BlowersMaselRate.h
@@ -135,7 +135,7 @@ protected:
     //! Return the effective activation energy (a function of the delta H of reaction)
     //! divided by the gas constant (that is, the activation temperature) [K]
     double effectiveActivationEnergy_R(double deltaH_R) const {
-        if (deltaH_R < -4 * m_Ea_R) {
+        if (deltaH_R <= -4 * m_Ea_R) {
             return 0.;
         }
         if (deltaH_R > 4 * m_Ea_R) {

--- a/include/cantera/numerics/SundialsContext.h
+++ b/include/cantera/numerics/SundialsContext.h
@@ -24,7 +24,7 @@ public:
     SundialsContext() {
         #if SUNDIALS_VERSION_MAJOR >= 7
             SUNContext_Create(SUN_COMM_NULL, &m_context);
-
+            SUNContext_ClearErrHandlers(m_context);
         #else
             SUNContext_Create(nullptr, &m_context);
         #endif

--- a/src/kinetics/Kinetics.cpp
+++ b/src/kinetics/Kinetics.cpp
@@ -193,7 +193,9 @@ pair<size_t, size_t> Kinetics::checkDuplicates(bool throw_err, bool fix)
                             "should be handled and suppress this warning.\n"
                             "Reaction {}: {}\nReaction {}: {}\n",
                             m+1, R.equation(), i+1, other.equation());
-                        warn_user("Kinetics::checkDuplicates", msg.what());
+                        if (!fix) {
+                            warn_user("Kinetics::checkDuplicates", msg.what());
+                        }
                         continue;
                     } // else m_explicit_third_body_duplicates == "error"
                 }

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -493,8 +493,7 @@ class TestKineticsRepeatability:
             assert msg in err_msg_list
 
     def test_sticking_coeff_err(self):
-        err_msg = (r"Sticking coefficient is greater than 1 for reaction 'O2 \+ 2 PT\(S\) => 2 O\(S\)'",
-                   "at T = 200.0",
+        err_msg = ("at T = 200.0",
                    "at T = 500.0",
                    "at T = 1000.0",
                    "at T = 2000.0",
@@ -503,9 +502,13 @@ class TestKineticsRepeatability:
                    "Sticking coefficient is greater than 1 for reaction",
                    "StickingRate::validate:")
 
-        for err in err_msg:
-            with pytest.warns(UserWarning, match=err):
-                ct.Interface("sticking_coeff_check.yaml", "Pt_surf")
+        with pytest.warns(UserWarning) as record:
+            ct.Interface("sticking_coeff_check.yaml", "Pt_surf")
+        assert len(record) == 2
+        for msg in err_msg:
+            assert msg in str(record[0].message)
+        assert "reaction 'O2 + 2 PT(S) => 2 O(S)'" in str(record[0].message)
+        assert "reaction 'OH + PT(S) => OH(S)'" in str(record[1].message)
 
 
 def check_raises(yaml, err_msg, line):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix #1937
- Fix tests of `StickingRate::validate` to capture all warnings
- Suppress direct logging of SUNDIALS errors, in favor of our usual methods for handling these errors

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
