### PR TITLE
Make imports of external Python modules private

### DIFF
--- a/interfaces/cython/cantera/__init__.py
+++ b/interfaces/cython/cantera/__init__.py
@@ -10,15 +10,9 @@ from .utils import *
 from .data import *
 import cantera.interrupts  # Helps with standalone packaging (PyInstaller etc.)
 
-import os
-import sys
 from pathlib import Path
 import warnings
 
 warnings.filterwarnings('default', module='cantera')
 add_directory(Path(__file__).parent / "data")
 add_directory('.')  # Move current working directory to the front of the path
-
-# Python interpreter used for converting mechanisms
-if 'PYTHON_CMD' not in os.environ:
-    os.environ['PYTHON_CMD'] = sys.executable

--- a/interfaces/cython/cantera/__init__.py
+++ b/interfaces/cython/cantera/__init__.py
@@ -16,3 +16,5 @@ import warnings
 warnings.filterwarnings('default', module='cantera')
 add_directory(Path(__file__).parent / "data")
 add_directory('.')  # Move current working directory to the front of the path
+
+del warnings, Path, np, os

--- a/interfaces/cython/cantera/_cantera.pyx
+++ b/interfaces/cython/cantera/_cantera.pyx
@@ -4,14 +4,15 @@
 #cython: language_level=3
 #distutils: language=c++
 
-import sys
-import importlib
-import importlib.abc
-import importlib.util
+import sys as _sys
+import importlib as _importlib
+import importlib.util as _importlib_util
+from importlib.abc import MetaPathFinder as _MetaPathFinder
+
 
 # Chooses the right init function
 # See https://stackoverflow.com/a/52714500
-class CythonPackageMetaPathFinder(importlib.abc.MetaPathFinder):
+class CythonPackageMetaPathFinder(_MetaPathFinder):
     def __init__(self, name_filter):
         super().__init__()
         self.name_filter = name_filter
@@ -19,12 +20,12 @@ class CythonPackageMetaPathFinder(importlib.abc.MetaPathFinder):
     def find_spec(self, fullname, path, target=None):
         if fullname.startswith(self.name_filter):
             # use this extension-file but PyInit-function of another module:
-            loader = importlib.machinery.ExtensionFileLoader(fullname, __file__)
-            return importlib.util.spec_from_loader(fullname, loader)
+            loader = _importlib.machinery.ExtensionFileLoader(fullname, __file__)
+            return _importlib_util.spec_from_loader(fullname, loader)
 
 
 # Inject custom finder/loaders into sys.meta_path:
-sys.meta_path.append(CythonPackageMetaPathFinder("cantera."))
+_sys.meta_path.append(CythonPackageMetaPathFinder("cantera."))
 
 # Import the contents of the individual .pyx files
 from ._utils import *
@@ -46,4 +47,4 @@ from .constants import *
 from .jacobians import *
 
 # Custom finder/loader no longer needed, so remove it
-sys.meta_path.pop()
+_sys.meta_path.pop()

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -1,14 +1,13 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-import sys
 import os
 import warnings
 from cpython.ref cimport PyObject
 from libcpp.utility cimport move
-import numbers
-import importlib.metadata
-from collections import namedtuple
+import numbers as _numbers
+import importlib as _importlib
+from collections import namedtuple as _namedtuple
 import numpy as np
 from .units cimport Units
 
@@ -21,8 +20,8 @@ def _import_scipy_sparse():
         return
 
     try:
-        importlib.metadata.version('scipy')
-    except importlib.metadata.PackageNotFoundError:
+        _importlib.metadata.version('scipy')
+    except _importlib.metadata.PackageNotFoundError:
         raise ImportError('Method requires a working scipy installation.')
     else:
         from scipy import sparse as _scipy_sparse
@@ -162,9 +161,9 @@ class CanteraError(RuntimeError):
         """
         CxxCanteraError.setStackTraceDepth(depth)
 
-_DimensionalValue = namedtuple('_DimensionalValue',
-                              ('value', 'units', 'activation_energy'),
-                              defaults=[False])
+_DimensionalValue = _namedtuple('_DimensionalValue',
+                                ('value', 'units', 'activation_energy'),
+                                defaults=[False])
 
 cdef public PyObject* pyCanteraError = <PyObject*>CanteraError
 
@@ -334,10 +333,10 @@ cdef get_types(item):
         return None, 1
 
     elif isinstance(item, np.ndarray):
-        if isinstance(item.flat[0], numbers.Integral):
-            itype = numbers.Integral
-        elif isinstance(item.flat[0], numbers.Real):
-            itype = numbers.Real
+        if isinstance(item.flat[0], _numbers.Integral):
+            itype = _numbers.Integral
+        elif isinstance(item.flat[0], _numbers.Real):
+            itype = _numbers.Real
         elif isinstance(item.flat[0], np.str_):
             itype = str
         else:
@@ -357,15 +356,15 @@ cdef get_types(item):
                 itype.add(list)
             elif type(i) == bool:
                 itype.add(bool)  # otherwise bools will get counted as integers
-            elif isinstance(i, numbers.Integral):
-                itype.add(numbers.Integral)
-            elif isinstance(i, numbers.Real):
-                itype.add(numbers.Real)
+            elif isinstance(i, _numbers.Integral):
+                itype.add(_numbers.Integral)
+            elif isinstance(i, _numbers.Real):
+                itype.add(_numbers.Real)
             else:
                 itype.add(type(i))
 
-        if itype == {numbers.Real, numbers.Integral}:
-            itype = {numbers.Real}
+        if itype == {_numbers.Real, _numbers.Integral}:
+            itype = {_numbers.Real}
 
         if itype == {list}:
             inner_types = set()
@@ -397,9 +396,9 @@ cdef CxxAnyValue python_to_anyvalue(item, name=None) except *:
                 v = list_string_to_anyvalue(item)
             elif itype == bool:
                 v = list_bool_to_anyvalue(item)
-            elif itype == numbers.Integral:
+            elif itype == _numbers.Integral:
                 v = list_int_to_anyvalue(item)
-            elif itype == numbers.Real:
+            elif itype == _numbers.Real:
                 v = list_double_to_anyvalue(item)
             elif itype == dict:
                 v = list_dict_to_anyvalue(item)
@@ -410,9 +409,9 @@ cdef CxxAnyValue python_to_anyvalue(item, name=None) except *:
                 v = list2_string_to_anyvalue(item)
             elif itype == bool:
                 v = list2_bool_to_anyvalue(item)
-            elif itype == numbers.Integral:
+            elif itype == _numbers.Integral:
                 v = list2_int_to_anyvalue(item)
-            elif itype == numbers.Real:
+            elif itype == _numbers.Real:
                 v = list2_double_to_anyvalue(item)
             else:
                 v = list_to_anyvalue(item)

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -2,12 +2,12 @@
 # at https://cantera.org/license.txt for license and copyright information.
 from __future__ import annotations as _annotations
 
-from ._cantera import *
 import numpy as np
-import csv as _csv
 import importlib as _importlib
-import warnings
-
+from ._cantera import (
+    DustyGasTransport, InterfaceKinetics, InterfacePhase, Kinetics, PureFluid,
+    SolutionArrayBase, ThermoPhase, Transport,
+)
 
 _pandas = None
 def _import_pandas():

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1,11 +1,11 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
-from __future__ import annotations
+from __future__ import annotations as _annotations
 
 from ._cantera import *
 import numpy as np
 import csv as _csv
-import importlib.metadata
+import importlib as _importlib
 import warnings
 
 
@@ -16,8 +16,8 @@ def _import_pandas():
     if _pandas is not None:
         return
     try:
-        importlib.metadata.version('pandas')
-    except importlib.metadata.PackageNotFoundError:
+        _importlib.metadata.version('pandas')
+    except _importlib.metadata.PackageNotFoundError:
         raise ImportError('Method requires a working pandas installation.')
     else:
         import pandas as _pandas

--- a/interfaces/cython/cantera/data.py
+++ b/interfaces/cython/cantera/data.py
@@ -1,7 +1,7 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-from pathlib import Path
+from pathlib import Path as _Path
 from ._utils import get_data_directories, add_directory
 
 
@@ -17,7 +17,7 @@ def list_data_files(ext=".yaml"):
     """
     data_files = set()
     for folder in get_data_directories():
-        here = Path(folder)
+        here = _Path(folder)
         if folder == ".":
             data_files.update(f.name for f in here.glob(f"*{ext}"))
         elif here.is_dir():

--- a/interfaces/cython/cantera/delegator.pyx
+++ b/interfaces/cython/cantera/delegator.pyx
@@ -1,9 +1,9 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-import inspect
-import sys
-import importlib
+import inspect as _inspect
+import sys as _sys
+import importlib as _importlib
 
 from libc.stdlib cimport malloc
 from libc.string cimport strcpy
@@ -91,7 +91,7 @@ cdef void callback_v(PyFuncInfo& funcInfo) noexcept:
     try:
         (<object>funcInfo.func())()
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -100,7 +100,7 @@ cdef void callback_v_d(PyFuncInfo& funcInfo, double arg) noexcept:
     try:
         (<object>funcInfo.func())(arg)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -109,7 +109,7 @@ cdef void callback_v_b(PyFuncInfo& funcInfo, cbool arg) noexcept:
     try:
         (<object>funcInfo.func())(arg)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -122,7 +122,7 @@ cdef void callback_v_AMr(PyFuncInfo& funcInfo, CxxAnyMap& arg) noexcept:
         # unwillingness to assign to a reference
         (&arg)[0] = py_to_anymap(pyArg)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -135,7 +135,7 @@ cdef void callback_v_cAMr_cUSr(PyFuncInfo& funcInfo, const CxxAnyMap& arg1,
     try:
         (<object>funcInfo.func())(pyArg1, pyArg2)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -145,7 +145,7 @@ cdef void callback_v_csr_vp(PyFuncInfo& funcInfo,
     try:
         (<object>funcInfo.func())(pystr(arg1), <object>obj)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -156,7 +156,7 @@ cdef void callback_v_dp(PyFuncInfo& funcInfo, size_array1 sizes, double* arg) no
     try:
         (<object>funcInfo.func())(view)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -168,7 +168,7 @@ cdef void callback_v_d_dp(PyFuncInfo& funcInfo, size_array1 sizes, double arg1,
     try:
         (<object>funcInfo.func())(arg1, view)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -182,7 +182,7 @@ cdef void callback_v_dp_dp_dp(PyFuncInfo& funcInfo,
     try:
         (<object>funcInfo.func())(view1, view2, view3)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -196,7 +196,7 @@ cdef int callback_d_vp(PyFuncInfo& funcInfo, double& out, void* obj) noexcept:
             (&out)[0] = ret
             return 1
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
     return -1
@@ -211,7 +211,7 @@ cdef int callback_s_sz(PyFuncInfo& funcInfo, string& out, size_t arg) noexcept:
             (&out)[0] = stringify(ret)
             return 1
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
     return -1
@@ -226,7 +226,7 @@ cdef int callback_sz_csr(PyFuncInfo& funcInfo, size_t& out, const string& arg) n
             (&out)[0] = ret
             return 1
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
     return -1
@@ -240,7 +240,7 @@ cdef void callback_v_d_dp_dp(PyFuncInfo& funcInfo, size_array2 sizes, double arg
     try:
         (<object>funcInfo.func())(arg1, view1, view2)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
         funcInfo.setExceptionType(<PyObject*>exc_type)
         funcInfo.setExceptionValue(<PyObject*>exc_value)
 
@@ -316,7 +316,7 @@ cdef int assign_delegates(obj, CxxDelegator* delegator) except -1:
         else:
             callback_args = callback.count(",") + 1
 
-        signature = inspect.signature(method)
+        signature = _inspect.signature(method)
         params = signature.parameters.values()
         min_args = len([p for p in params if p.default is p.empty])
         max_args = len([p for p in params if p.kind is not p.KEYWORD_ONLY])
@@ -399,7 +399,7 @@ cdef public object ct_newPythonExtensibleRate(CxxReactionRateDelegator* delegato
                                               const string& module_name,
                                               const string& class_name):
 
-    mod = importlib.import_module(module_name.decode())
+    mod = _importlib.import_module(module_name.decode())
     cdef ExtensibleRate rate = getattr(mod, class_name.decode())(init=False)
     rate.set_cxx_object(delegator)
     return rate
@@ -409,7 +409,7 @@ cdef public object ct_newPythonExtensibleRateData(CxxReactionDataDelegator* dele
                                                   const string& module_name,
                                                   const string& class_name):
 
-    mod = importlib.import_module(module_name.decode())
+    mod = _importlib.import_module(module_name.decode())
     cdef ExtensibleRateData data = getattr(mod, class_name.decode())()
     data.set_cxx_object(delegator)
     return data

--- a/interfaces/cython/cantera/func1.pyx
+++ b/interfaces/cython/cantera/func1.pyx
@@ -1,7 +1,7 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-import sys
+import sys as _sys
 cimport numpy as np
 import numpy as np
 import warnings
@@ -19,7 +19,7 @@ cdef double func_callback(double t, void* obj, void** err) except? 0.0:
     try:
         return (<Func1>obj).callable(t)
     except BaseException as e:
-        exc_type, exc_value = sys.exc_info()[:2]
+        exc_type, exc_value = _sys.exc_info()[:2]
 
         # Stash the exception info to prevent it from being garbage collected
         (<Func1>obj).exception = exc_type, exc_value

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -1,7 +1,7 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-from ctypes import c_int
+from ctypes import c_int as _c_int
 import warnings
 cimport numpy as np
 import numpy as np
@@ -37,8 +37,8 @@ cdef np.ndarray get_dense(CxxSparseMatrix& smat):
         return np.zeros((smat.rows(), 0))
 
     # index/value triplets
-    cdef np.ndarray[int, ndim=1, mode="c"] rows = np.empty(length, dtype=c_int)
-    cdef np.ndarray[int, ndim=1, mode="c"] cols = np.empty(length, dtype=c_int)
+    cdef np.ndarray[int, ndim=1, mode="c"] rows = np.empty(length, dtype=_c_int)
+    cdef np.ndarray[int, ndim=1, mode="c"] cols = np.empty(length, dtype=_c_int)
     cdef np.ndarray[np.double_t, ndim=1] data = np.empty(length)
 
     size = CxxSparseTriplets(smat, &rows[0], &cols[0], &data[0], length)
@@ -51,11 +51,11 @@ cdef get_sparse(CxxSparseMatrix& smat):
     # pointers to values and inner indices of CSC storage
     cdef size_t length = smat.nonZeros()
     cdef np.ndarray[np.double_t, ndim=1] value = np.empty(length)
-    cdef np.ndarray[int, ndim=1, mode="c"] inner = np.empty(length, dtype=c_int)
+    cdef np.ndarray[int, ndim=1, mode="c"] inner = np.empty(length, dtype=_c_int)
 
     # pointers outer indices of CSC storage
     cdef size_t ncols = smat.outerSize()
-    cdef np.ndarray[int, ndim=1, mode="c"] outer = np.empty(ncols + 1, dtype=c_int)
+    cdef np.ndarray[int, ndim=1, mode="c"] outer = np.empty(ncols + 1, dtype=_c_int)
 
     CxxSparseCscData(smat, &value[0], &inner[0], &outer[0])
     return value, inner, outer

--- a/interfaces/cython/cantera/liquidvapor.py
+++ b/interfaces/cython/cantera/liquidvapor.py
@@ -1,8 +1,8 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-from . import PureFluid, _cantera
-
+from .thermo import PureFluid
+from .transport import Transport
 
 def Water(backend='Reynolds'):
     """
@@ -41,7 +41,7 @@ def Water(backend='Reynolds'):
     :ct:`WaterSSTP` and :ct:`WaterTransport` in the Cantera C++ source
     code documentation.
     """
-    class WaterWithTransport(_cantera.Transport, PureFluid):
+    class WaterWithTransport(Transport, PureFluid):
         __slots__ = ()
 
     if backend == 'Reynolds':

--- a/interfaces/cython/cantera/mixture.pyx
+++ b/interfaces/cython/cantera/mixture.pyx
@@ -1,7 +1,6 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-import warnings
 import numpy as np
 
 from .solutionbase cimport *

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -6,9 +6,12 @@ from pathlib import Path as _Path
 import warnings
 import numpy as np
 
-from ._cantera import *
+from ._onedim import (
+    AxisymmetricFlow, FreeFlow, Inlet1D, Outlet1D, ReactingSurface1D, Sim1D,
+    Surface1D, SymmetryPlane1D, UnstrainedFlow,
+)
+from ._utils import CanteraError, __git_commit__, __version__, hdf_support
 from .composite import Solution, SolutionArray
-from . import __version__, __git_commit__, hdf_support
 
 
 class FlameBase(Sim1D):

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -1,8 +1,8 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-from math import erf
-from pathlib import Path
+from math import erf as _erf
+from pathlib import Path as _Path
 import warnings
 import numpy as np
 
@@ -95,7 +95,7 @@ class FlameBase(Sim1D):
             # already a solution array
             arr = data
 
-        elif isinstance(data, (str, Path)):
+        elif isinstance(data, (str, _Path)):
             data = str(data)
             arr = SolutionArray(self.gas)
             if any(data.endswith(suffix) for suffix in [".hdf5", ".h5", ".hdf"]):
@@ -1007,7 +1007,7 @@ class CounterflowDiffusionFlame(FlameBase):
         for j in range(nz):
             x = zz[j] - zz[0]
             zeta = f * (x - x0)
-            zmix = 0.5 * (1.0 - erf(zeta))
+            zmix = 0.5 * (1.0 - _erf(zeta))
             if zmix > zst:
                 Y[j] = Yeq + (Yin_f - Yeq) * (zmix - zst) / (1.0 - zst)
                 T[j] = Teq + (T0f - Teq) * (zmix - zst) / (1.0 - zst)

--- a/interfaces/cython/cantera/reactionpath.pyx
+++ b/interfaces/cython/cantera/reactionpath.pyx
@@ -1,7 +1,7 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-from pathlib import Path
+from pathlib import Path as _Path
 
 from ._utils cimport *
 
@@ -146,7 +146,7 @@ cdef class ReactionPathDiagram:
         Write the reaction path diagram formatted for use by Graphviz's 'dot'
         program to the file named ``filename``.
         """
-        Path(filename).write_text(self.get_dot())
+        _Path(filename).write_text(self.get_dot())
 
     def get_data(self):
         """

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -4,10 +4,9 @@
 import warnings
 import numbers as _numbers
 from cython.operator cimport dereference as deref
+import numpy as np
 
-from .thermo cimport *
 from ._utils cimport pystr, stringify, comp_map, py_to_anymap, anymap_to_py
-from ._utils import *
 from .delegator cimport *
 from .drawnetwork import *
 

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -3,8 +3,8 @@
 
 cimport numpy as np
 import numpy as np
-from pathlib import PurePath
-from os import get_terminal_size
+from pathlib import PurePath as _PurePath
+from os import get_terminal_size as _get_terminal_size
 import warnings
 
 from .thermo cimport *
@@ -64,7 +64,7 @@ cdef class _SolutionBase:
             self._adjacent = other._adjacent
             return
 
-        if isinstance(infile, PurePath):
+        if isinstance(infile, _PurePath):
             infile = str(infile)
 
         # Transport model: "" is a sentinel value to use the default model
@@ -556,7 +556,7 @@ cdef class SolutionArrayBase:
                     cxx_keys.push_back(stringify(key))
         if width is None:
             try:
-                width = get_terminal_size().columns
+                width = _get_terminal_size().columns
             except:
                 width = 100
 

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -2,7 +2,7 @@
 # at https://cantera.org/license.txt for license and copyright information.
 
 import warnings
-import weakref
+import weakref as _weakref
 import numbers as _numbers
 import numpy as np
 cimport numpy as np
@@ -273,7 +273,7 @@ cdef class ThermoPhase(_SolutionBase):
         # object is used to track whether the ThermoPhase is being used by other
         # objects that require the number of species to remain constant and do not
         # have C++ implementations (e.g. Quantity objects).
-        self._references = weakref.WeakKeyDictionary()
+        self._references = _weakref.WeakKeyDictionary()
         # validate plasma phase
         self._enable_plasma = False
         if dynamic_cast[CxxPlasmaPhasePtr](self.thermo):

--- a/interfaces/cython/cantera/units.pyx
+++ b/interfaces/cython/cantera/units.pyx
@@ -1,9 +1,8 @@
 # This file is part of Cantera. See License.txt in the top-level directory or
 # at https://cantera.org/license.txt for license and copyright information.
 
-from typing import Dict
-from collections.abc import Sequence
-import numbers
+from collections.abc import Sequence as _Sequence
+import numbers as _numbers
 import numpy as np
 
 from ._utils cimport *
@@ -44,7 +43,7 @@ cdef class Units:
         return self.units.dimension(stringify(primary))
 
     @property
-    def dimensions(self) -> Dict[str, float]:
+    def dimensions(self) -> dict[str, float]:
         """A dictionary of the primary unit components to their dimensions.
 
         .. versionadded:: 3.0
@@ -173,7 +172,7 @@ cdef class UnitSystem:
                 return self.unitsystem.convert(val_units, (<Units>dest).units)
             else:
                 raise TypeError("'dest' must be a string or 'Units' object")
-        elif isinstance(quantity, numbers.Real):
+        elif isinstance(quantity, _numbers.Real):
             value = quantity
             if isinstance(dest, str):
                 return self.unitsystem.convertTo(value, stringify(dest))
@@ -183,7 +182,7 @@ cdef class UnitSystem:
                 raise TypeError("'dest' must be a string or 'Units' object")
         elif isinstance(quantity, np.ndarray):
             return np.vectorize(lambda item: self.convert_to(item, dest))(quantity)
-        elif isinstance(quantity, Sequence):
+        elif isinstance(quantity, _Sequence):
             return [self.convert_to(item, dest) for item in quantity]
         else:
             raise TypeError("'quantity' must be either a string or a number")
@@ -210,13 +209,13 @@ cdef class UnitSystem:
         if isinstance(quantity, str):
             val_units = python_to_anyvalue(quantity)
             return self.unitsystem.convertActivationEnergy(val_units, stringify(dest))
-        elif isinstance(quantity, numbers.Real):
+        elif isinstance(quantity, _numbers.Real):
             value = quantity
             return self.unitsystem.convertActivationEnergyTo(value, stringify(dest))
         elif isinstance(quantity, np.ndarray):
             return np.vectorize(
                 lambda item: self.convert_activation_energy_to(item, dest))(quantity)
-        elif isinstance(quantity, Sequence):
+        elif isinstance(quantity, _Sequence):
             return [self.convert_activation_energy_to(item, dest) for item in quantity]
         else:
             raise TypeError("'quantity' must be either a string or a number")
@@ -240,13 +239,13 @@ cdef class UnitSystem:
             raise TypeError("'dest' must be a string, Units, or UnitStack object")
 
         cdef CxxAnyValue val_units
-        if isinstance(quantity, (str, numbers.Real)):
+        if isinstance(quantity, (str, _numbers.Real)):
             val_units = python_to_anyvalue(quantity)
             return self.unitsystem.convertRateCoeff(val_units, dest_units.units)
         elif isinstance(quantity, np.ndarray):
             return np.vectorize(
                 lambda q: self.convert_rate_coeff_to(q, dest_units))(quantity)
-        elif isinstance(quantity, Sequence):
+        elif isinstance(quantity, _Sequence):
             return [self.convert_rate_coeff_to(q, dest_units) for q in quantity]
         else:
             raise TypeError("'quantity' must be either a string or a number")

--- a/interfaces/cython/cantera/utils.py
+++ b/interfaces/cython/cantera/utils.py
@@ -4,8 +4,8 @@
 import os
 import inspect as _inspect
 
-from . import Solution, add_directory
-
+from ._utils import add_directory
+from .composite import Solution
 
 def import_phases(filename, phase_names):
     """

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -2,6 +2,7 @@ import numpy as np
 from pathlib import Path
 import pytest
 from pytest import approx
+from types import ModuleType
 
 import cantera as ct
 from cantera._utils import _py_to_any_to_py, _py_to_anymap_to_py
@@ -330,3 +331,14 @@ class TestListDataFiles:
         data_files = ct.list_data_files()
         assert "gri30.yaml" in data_files
         assert str(Path("example_data/oxygen-plasma-itikawa.yaml")) in data_files
+
+
+def test_namespace_cleanliness():
+    for name in dir(ct):
+        if name.startswith('_'):
+            continue
+        var = getattr(ct, name)
+        if hasattr(var, "__module__") and not var.__module__.startswith("cantera"):
+            pytest.fail(f"cantera module is exporting external class/function '{name}'")
+        elif isinstance(var, ModuleType) and not var.__name__.startswith("cantera"):
+            pytest.fail(f"cantera module is exporting external module '{name}'")


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Import external Python modules and functions using "private" names (for example, `_sys`) so they don't get included as members of the `cantera` module.
  - The one exception to this is `np`, which is used so extensively that I didn't want to have to change it. This one is removed by a `del` in `__init__.py`.
- Test that the resulting Python module does not (directly) contain any such modules or functions

This is an alternative approach to the same goal as #1947. There are a couple of things I discovered while preparing this.

- Because Pylance / VS Code builds its list of members through static analysis rather than by actually importing the module, some clever tricks to dynamically edit the list of namespace/module members don't work. Here, I still end up with the VS Code autocomplete showing me that `warnings`, `Path`, `np`, and `os` are members of the `cantera` namespace, despite being deleted in `__init__.py`
- The list of members obtained using the `dir` function, Jupyter's autocomplete (after import) and the autocomplete of `from cantera import ...` in IPython are correctly limited. 

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
