### PR TITLE
Fix flowcontroller visualisation (#1938)

### DIFF
--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -224,21 +224,18 @@ def draw_flow_controllers(flow_controllers, graph=None, graph_attr=None, node_at
 
         # find "duplicate" flow controllers that connect the same two objects to
         # eventually draw them as a single connection
-        duplicates, inv_duplicates = set(), set()
+        duplicates = set()
         for fc_ in flow_controllers:
             if fc_.upstream is r_in and fc_.downstream is r_out:
                 duplicates.add(fc_)
-            elif fc_.downstream is r_in and fc_.upstream is r_out:
-                inv_duplicates.add(fc_)
 
         # remove duplicates from the set of the flow elements still to be drawn
-        flow_controllers -= duplicates | inv_duplicates
+        flow_controllers -= duplicates
 
         assert r_in.name != r_out.name, "All reactors must have unique names when drawn."
 
         # sum up mass flow rate while considering the direction
-        rate = (fc.mass_flow_rate + sum(dupe.mass_flow_rate for dupe in duplicates)
-                - sum(idupe.mass_flow_rate for idupe in inv_duplicates))
+        rate = (fc.mass_flow_rate + sum(dupe.mass_flow_rate for dupe in duplicates))
 
         inflow_name, outflow_name = r_in.name, r_out.name
         if rate < 0:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->
- Fixes #1938: graphviz visualisations correctly combine all flow controllers connecting the same reactors, but they disrespect bi-directionality.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1938 

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
