### PR TITLE
Fix synchronization of Reservoir state

### DIFF
--- a/include/cantera/zeroD/Reactor.h
+++ b/include/cantera/zeroD/Reactor.h
@@ -152,8 +152,6 @@ public:
     //! @since New in %Cantera 3.2.
     virtual vector<size_t> steadyConstraints() const;
 
-    void syncState() override;
-
     //! Set the state of the reactor to correspond to the state vector *y*.
     virtual void updateState(double* y);
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -171,10 +171,7 @@ public:
     //! Set the state of the reactor to the associated ThermoPhase object.
     //! This method is the inverse of restoreState() and will trigger integrator
     //! reinitialization.
-    //! The method needs to be implemented by a ReactorBase specialization.
-    virtual void syncState() {
-        throw NotImplementedError("ReactorBase::syncState");
-    }
+    virtual void syncState();
 
     //! return a reference to the contents.
     ThermoPhase& contents() {

--- a/include/cantera/zeroD/Reservoir.h
+++ b/include/cantera/zeroD/Reservoir.h
@@ -25,8 +25,6 @@ public:
     }
 
     void initialize(double t0=0.0) override {}
-
-    void syncState() override {}
 };
 
 }

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -128,24 +128,6 @@ size_t Reactor::nSensParams() const
     return ns;
 }
 
-void Reactor::syncState()
-{
-    m_thermo->saveState(m_state);
-    if (m_energy) {
-        m_enthalpy = m_thermo->enthalpy_mass();
-        try {
-            m_intEnergy = m_thermo->intEnergy_mass();
-        } catch (NotImplementedError&) {
-            m_intEnergy = NAN;
-        }
-    }
-    m_pressure = m_thermo->pressure();
-    m_mass = m_thermo->density() * m_vol;
-    if (m_net) {
-        m_net->setNeedsReinit();
-    }
-}
-
 void Reactor::updateState(double* y)
 {
     // The components of y are [0] the total mass, [1] the total volume,

--- a/src/zeroD/ReactorBase.cpp
+++ b/src/zeroD/ReactorBase.cpp
@@ -140,6 +140,22 @@ void ReactorBase::restoreState() {
     m_thermo->restoreState(m_state);
 }
 
+void ReactorBase::syncState()
+{
+    m_thermo->saveState(m_state);
+    m_enthalpy = m_thermo->enthalpy_mass();
+    try {
+        m_intEnergy = m_thermo->intEnergy_mass();
+    } catch (NotImplementedError&) {
+        m_intEnergy = NAN;
+    }
+    m_pressure = m_thermo->pressure();
+    m_mass = m_thermo->density() * m_vol;
+    if (m_net) {
+        m_net->setNeedsReinit();
+    }
+}
+
 ReactorNet& ReactorBase::network()
 {
     if (m_net) {

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -865,6 +865,19 @@ class TestReactor:
         assert T1a == approx(T1b)
         assert T2a == approx(T2b)
 
+    def test_reservoir_sync(self):
+        self.make_reactors(T1=800, n_reactors=1)
+        self.gas2.TP = 900, ct.one_atm
+        reservoir = ct.Reservoir(self.gas2)
+        wall = ct.Wall(self.r1, reservoir, U=500)
+        self.net.advance(1.0)
+        assert self.r1.T == approx(872.099, rel=1e-3)
+        self.gas2.TP = 700, ct.one_atm
+        reservoir.syncState()
+        self.net.reinitialize()
+        self.net.advance(2.0)
+        assert self.r1.T == approx(747.27, rel=1e-3)
+
     def test_unpicklable(self):
         self.make_reactors()
         import pickle


### PR DESCRIPTION
Fixes #1905

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Fix synchronization of `Reservoir` state. While the reservoir itself has no governing equations, updating the state of its underlying `ThermoPhase` object can affect reactors linked by valves, walls, etc.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1905 

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
