### PR TITLE
Deprecate LatticePhase and LatticeSolidPhase

### DIFF
--- a/data/sofc.yaml
+++ b/data/sofc.yaml
@@ -107,7 +107,7 @@ phases:
     X: {electron: 1.0}
   density: 9.0 kg/m^3
 - name: oxide_bulk
-  thermo: lattice
+  thermo: ideal-condensed
   elements: [O, E]
   species: [Ox, VO**]
   state:
@@ -161,6 +161,9 @@ species:
     model: constant-cp
     h0: 0.0 kJ/mol
   note: A bulk lattice vacancy
+  equation-of-state:
+    model: constant-volume
+    molar-density: 0.0176 mol/cm^3
 - name: Ox
   composition: {O: 1, E: 2}
   thermo:
@@ -168,6 +171,9 @@ species:
     h0: -170.0 kJ/mol
     s0: 50.0 J/K/mol
   note: A bulk lattice oxygen
+  equation-of-state:
+    model: constant-volume
+    molar-density: 0.0176 mol/cm^3
 - name: (m)
   composition: {}
   thermo:

--- a/doc/sphinx/reference/thermo/phase-thermo.md
+++ b/doc/sphinx/reference/thermo/phase-thermo.md
@@ -123,13 +123,14 @@ Lattice Phase
 : A simple thermodynamic model for a bulk phase, assuming an incompressible lattice of
   solid atoms. Defined in the YAML format by specifying [`lattice`](sec-yaml-lattice) in
   the `thermo` field of the phase definition. Implemented by class {ct}`LatticePhase`.
+  *Deprecated in Cantera 3.2.*
 
 (sec-compound-lattice-phase)=
 Compound Lattice Phase
 : A phase that is comprised of a fixed additive combination of other lattice phases.
   Defined in the YAML format by specifying [`compound-lattice`](sec-yaml-compound-lattice)
   in the `thermo` field of the phase definition. Implemented by class
-  {ct}`LatticeSolidPhase`.
+  {ct}`LatticeSolidPhase`. *Deprecated in Cantera 3.2.*
 
 
 ## Non-ideal Solid and Liquid Solutions

--- a/doc/sphinx/userguide/creating-mechanisms.md
+++ b/doc/sphinx/userguide/creating-mechanisms.md
@@ -433,55 +433,61 @@ not shown for clarity:
 
 ```yaml
 phases:
-- name: graphite
-  thermo: lattice
+- name: gas
+  thermo: ideal-gas
   species:
-  - graphite-species: all
-  state: {T: 300, P: 101325, X: {C6: 1.0, LiC6: 1e-5}}
-  density: 2.26 g/cm^3
-
-- name: electrolyte
-  thermo: lattice
-  species: [{electrolyte-species: all}]
-  density: 1208.2 kg/m^3
+  - gri30.yaml/species: [H, H2, CH3, CH4]
   state:
-    T: 300
-    P: 101325
-    X: {Li+(e): 0.08, PF6-(e): 0.08, EC(e): 0.28, EMC(e): 0.56}
-
-- name: anode-surface
+    T: 1200.0
+    P: 2666.4473684210525
+    X: {H: 2.0e-03, H2: 0.988, CH3: 2.0e-04, CH4: 0.01}
+- name: diamond
+  thermo: fixed-stoichiometry
+  species: [{bulk-species: [C(d)]}]
+- name: diamond_100
   thermo: ideal-surface
-  adjacent: [graphite, electrolyte]
+  adjacent-phases: [gas, diamond]
+  species: [{surf-species: all}]
   kinetics: surface
-  reactions: [graphite-anode-reactions]
-  species: [{anode-species: all}]
-  site-density: 1.0 mol/cm^2
-  state: {T: 300, P: 101325}
+  reactions: all
+  state:
+    T: 1200.0
+    coverages: {c6H*: 0.1, c6HH: 0.9}
+  site-density: 3.0e-09 mol/cm^2
 
-graphite-species:
-- name: C6
+bulk-species:
+- name: C(d)
+  composition: {C: 1}
+  thermo:
+    model: constant-cp
+  equation-of-state:
+    model: constant-volume
+    density: 3.52 g/cm^3
+
+surf-species:
+- name: c6H*
   ...
-- name: LiC6
+- name: c6*H
+  ...
+- name: c6HH
+  ...
+- name: c6HM
+  ...
+- name: c6HM*
+  ...
+- name: c6*M
+  ...
+- name: c6**
+  ...
+- name: c6B
   ...
 
-electrolyte-species:
-- name: Li+(e)
-  ...
-- name: PF6-(e)
-  ...
-- name: EC(e)
-  ...
-- name: EMC(e)
-  ...
-
-anode-species:
-- name: (int)
-  ...
-
-graphite-anode-reactions:
-- equation: LiC6 <=> Li+(e) + C6
-  rate-constant: [5.74, 0.0, 0.0]
-  beta: 0.4
+reactions:
+- equation: c6HH + H   <=> c6H* + H2  # Reaction 1
+  rate-constant: {A: 1.3e+14, b: 0.0, Ea: 7.3}
+- equation: c6H* + H   <=> c6HH  # Reaction 2
+  rate-constant: {A: 1.0e+13, b: 0.0, Ea: 0.0}
+...
 ```
 
 (sec-yaml-guide-species)=

--- a/doc/sphinx/yaml/phases.md
+++ b/doc/sphinx/yaml/phases.md
@@ -262,6 +262,11 @@ Includes the fields of [](sec-yaml-ideal-condensed), plus:
 A phase that is comprised of a fixed additive combination of other lattice phases, as
 {ct}`described here <LatticeSolidPhase>`.
 
+:::{deprecated} 3.2
+To be removed after Cantera 3.2. No known usage exists, and the model does not satisfy
+several basic thermodynamic identities. See[Issue #1310](https://github.com/Cantera/cantera/issues/1310).
+:::
+
 Additional fields:
 
 `composition`
@@ -749,6 +754,12 @@ Example:
 
 A simple thermodynamic model for a bulk phase, assuming an incompressible lattice of
 solid atoms, as {ct}`described here <LatticePhase>`.
+
+:::{deprecated} 3.2
+Can be replaced by the [`ideal-condensed`](sec-yaml-ideal-condensed) phase
+model with the `site-density` field used to set the molar density of each constituent
+species in that species' [`equation-of-state`](sec-yaml-eos-constant-volume) field.
+:::
 
 Additional fields:
 

--- a/include/cantera/thermo/LatticePhase.h
+++ b/include/cantera/thermo/LatticePhase.h
@@ -19,6 +19,10 @@ namespace Cantera
 //! A simple thermodynamic model for a bulk phase, assuming a lattice of solid
 //! atoms
 /*!
+ * @deprecated To be removed after Cantera 3.2. Can be replaced by use of
+ *     IdealSolidSolnPhase with the site density used to set the molar density of each
+ *     constituent species.
+ *
  * The bulk consists of a matrix of equivalent sites whose molar density does
  * not vary with temperature or pressure. The thermodynamics obeys the ideal
  * solution laws. The phase and the pure species phases which comprise the

--- a/include/cantera/thermo/LatticeSolidPhase.h
+++ b/include/cantera/thermo/LatticeSolidPhase.h
@@ -19,6 +19,10 @@ namespace Cantera
 //! A phase that is comprised of a fixed additive combination of other lattice
 //! phases
 /*!
+ * @deprecated To be removed after Cantera 3.2. No known usage exists, and the model
+ *     does not satisfy several basic thermodynamic identities.
+ *     See https://github.com/Cantera/cantera/issues/1310.
+ *
  * This is the main way %Cantera describes semiconductors and other solid
  * phases. This ThermoPhase object calculates its properties as a sum over other
  * LatticePhase objects. Each of the LatticePhase objects is a ThermoPhase
@@ -105,7 +109,7 @@ class LatticeSolidPhase : public ThermoPhase
 {
 public:
     //! Base empty constructor
-    LatticeSolidPhase() = default;
+    LatticeSolidPhase();
 
     string type() const override {
         return "compound-lattice";

--- a/src/thermo/LatticePhase.cpp
+++ b/src/thermo/LatticePhase.cpp
@@ -20,6 +20,9 @@ namespace Cantera
 
 LatticePhase::LatticePhase(const string& inputFile, const string& id_)
 {
+    warn_deprecated("class LatticePhase", "To be removed after Cantera 3.2. Can be "
+        "replaced by use of IdealSolidSolnPhase with the site density used to set the "
+        "molar density of each constituent species.");
     initThermoFile(inputFile, id_);
 }
 

--- a/src/thermo/LatticeSolidPhase.cpp
+++ b/src/thermo/LatticeSolidPhase.cpp
@@ -23,6 +23,13 @@ namespace ba = boost::algorithm;
 namespace Cantera
 {
 
+LatticeSolidPhase::LatticeSolidPhase()
+{
+    warn_deprecated("class LatticeSolidPhase", "To be removed after Cantera 3.2. No "
+        "known usage exists, and the model does not satisfy several basic thermodynamic"
+        "identities. See https://github.com/Cantera/cantera/issues/1310.");
+}
+
 double LatticeSolidPhase::minTemp(size_t k) const
 {
     if (k != npos) {

--- a/test/data/consistency-cases.yaml
+++ b/test/data/consistency-cases.yaml
@@ -276,6 +276,7 @@ lattice:
   setup:
     file: thermo-models.yaml
     phase: Li7Si3-interstitial
+    ignore-deprecations: true
     known-failures:
       _sum_.+_Xk: "Implementation is wrong. See GitHub Issue #1309"
       gk_eq_hk_minus_T_sk: "Implementation is wrong. See GitHub Issue #1309"
@@ -290,6 +291,7 @@ compound-lattice:
   setup:
     file: thermo-models.yaml
     phase: Li7Si3_and_interstitials
+    ignore-deprecations: true
     known-failures:
       _sum_.+_Xk: "LatticePhase implementation is wrong. See GitHub Issue #1309"
       h_eq_u_plus_Pv: "Implementation is inconsistent. See GitHub Issue #1310"

--- a/test/data/surface-phases.yaml
+++ b/test/data/surface-phases.yaml
@@ -32,13 +32,12 @@ phases:
   state: {T: 1073.15 K, P: 1 atm, coverages: {(tpb): 1.0}}
 
 - name: graphite
-  thermo: lattice
+  thermo: ideal-condensed
   species: [{graphite-anode-species: [C6, LiC6]}]
   state: {T: 300, P: 101325, X: {C6: 1.0, LiC6: 1e-5}}
-  density: 2.26 g/cm^3
 
 - name: electrolyte
-  thermo: lattice
+  thermo: ideal-condensed
   species: [{graphite-anode-species: [Li+(e), PF6-(e), EC(e), EMC(e)]}]
   density: 1208.2 kg/m^3
   state:
@@ -157,29 +156,50 @@ graphite-anode-species:
 - name: EC(e)
   composition: {C: 3, H: 4, O: 3}
   thermo: {model: constant-cp}
+  equation-of-state:
+    model: constant-volume
+    density: 2.26 g/cm^3
 - name: EMC(e)
   composition: {C: 4, H: 8, O: 3}
   thermo: {model: constant-cp}
+  equation-of-state:
+    model: constant-volume
+    density: 2.26 g/cm^3
 - name: O2(e)
   composition: {O: 2}
   thermo:
     model: constant-cp
     h0: 0.00177285 kJ/mol
     s0: 143.5777069 J/mol/K
+  equation-of-state:
+    model: constant-volume
+    density: 2.26 g/cm^3
 - name: Li+(e)
   composition: {Li: 1, E: -1}
   thermo: {model: constant-cp}
+  equation-of-state:
+    model: constant-volume
+    density: 2.26 g/cm^3
 - name: PF6-(e)
   composition: {P: 1, F: 6, E: 1}
   thermo: {model: constant-cp}
+  equation-of-state:
+    model: constant-volume
+    density: 2.26 g/cm^3
 - name: C6
   composition: {C: 6}
   thermo: {model: constant-cp}
+  equation-of-state:
+    model: constant-volume
+    density: 2.26 g/cm^3
 - name: LiC6
   composition: {C: 6, Li: 1, E: -1}
   thermo:
     model: constant-cp
     h0: -11.65 kJ/mol
+  equation-of-state:
+    model: constant-volume
+    density: 2.26 g/cm^3
 # dummy species for anode/electrolyte interface
 - name: (int)
   composition: {}

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -1211,6 +1211,7 @@ class Testcti2yaml:
         self.checkThermo(ctiSurf, yamlSurf, [400, 800, 1600])
         self.checkKinetics(ctiSurf, yamlSurf, [900], [101325])
 
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_sofc(self):
         self.convert("sofc")
         cti_tpb, yaml_tpb = self.checkConversion("sofc", ct.Interface, name="tpb")
@@ -1437,6 +1438,7 @@ class Testctml2yaml:
         self.checkThermo(ctmlSurf, yamlSurf, [400, 800, 1600])
         self.checkKinetics(ctmlSurf, yamlSurf, [500, 1200], [1e4, 3e5])
 
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_sofc(self):
         self.convert("sofc")
         ctml_tpb, yaml_tpb = self.checkConversion("sofc", ct.Interface, name="tpb")
@@ -1620,6 +1622,7 @@ class Testctml2yaml:
         ctmlPhase, yamlPhase = self.checkConversion("pdss_hkft")
         self.checkThermo(ctmlPhase, yamlPhase, [300, 500])
 
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_lattice_solid(self):
         self.convert("Li7Si3_ls")
         ctmlPhase, yamlPhase = self.checkConversion("Li7Si3_ls",

--- a/test/thermo/phaseConstructors.cpp
+++ b/test/thermo/phaseConstructors.cpp
@@ -342,6 +342,7 @@ TEST(MargulesVPSSTP, fromScratch)
 
 TEST(LatticeSolidPhase, fromScratch)
 {
+    suppress_deprecation_warnings();
     auto base = make_shared<StoichSubstance>();
     base->setName("Li7Si3(S)");
     auto sLi7Si3 = make_shomate2_species("Li7Si3(S)", "Li:7 Si:3", li7si3_shomate_coeffs);
@@ -382,6 +383,7 @@ TEST(LatticeSolidPhase, fromScratch)
         EXPECT_NEAR(mu[k], mu_ref[k], 1e-7*fabs(mu_ref[k]));
         EXPECT_NEAR(vol[k], vol_ref[k], 1e-7);
     }
+    make_deprecation_warnings_fatal();
 }
 
 TEST(IdealSolidSolnPhase, fromScratch)

--- a/test/thermo/thermoFromYaml.cpp
+++ b/test/thermo/thermoFromYaml.cpp
@@ -370,7 +370,9 @@ TEST(ThermoFromYaml, IdealSolidSolnPhase)
 
 TEST(ThermoFromYaml, Lattice)
 {
+    suppress_deprecation_warnings();
     auto thermo = newThermo("thermo-models.yaml", "Li7Si3_and_interstitials");
+    make_deprecation_warnings_fatal();
 
     // Regression test based on modified version of Li7Si3_ls.xml
     EXPECT_NEAR(thermo->enthalpy_mass(), -2077955.0584538165, 1e-6);
@@ -395,9 +397,11 @@ TEST(ThermoFromYaml, Lattice_fromString)
     std::stringstream buffer;
     buffer << infile.rdbuf();
     AnyMap input = AnyMap::fromYamlString(buffer.str());
+    suppress_deprecation_warnings();
     auto thermo = newThermo(
         input["phases"].getMapWhere("name", "Li7Si3_and_interstitials"),
         input);
+    make_deprecation_warnings_fatal();
 
     // Regression test based on modified version of Li7Si3_ls.xml
     EXPECT_NEAR(thermo->enthalpy_mass(), -2077955.0584538165, 1e-6);

--- a/test/thermo/thermoToYaml.cpp
+++ b/test/thermo/thermoToYaml.cpp
@@ -91,7 +91,9 @@ TEST_F(ThermoToYaml, StoichSubstance2)
 
 TEST_F(ThermoToYaml, Lattice)
 {
+    suppress_deprecation_warnings();
     setup("thermo-models.yaml", "Li7Si3-interstitial");
+    make_deprecation_warnings_fatal();
     EXPECT_DOUBLE_EQ(data["site-density"].asDouble(), 1.046344e+01);
     EXPECT_DOUBLE_EQ(eosData[0]["molar-volume"].asDouble(), 0.2);
     EXPECT_EQ(eosData[1].size(), (size_t) 0);
@@ -99,7 +101,9 @@ TEST_F(ThermoToYaml, Lattice)
 
 TEST_F(ThermoToYaml, LatticeSolid)
 {
+    suppress_deprecation_warnings();
     setup("thermo-models.yaml", "Li7Si3_and_interstitials");
+    make_deprecation_warnings_fatal();
     EXPECT_DOUBLE_EQ(data["composition"]["Li7Si3(s)"].asDouble(), 1.0);
     EXPECT_DOUBLE_EQ(data["composition"]["Li7Si3-interstitial"].asDouble(), 1.0);
 }
@@ -490,8 +494,10 @@ TEST_F(ThermoYamlRoundTrip, IdealSolutionVpss)
 
 TEST_F(ThermoYamlRoundTrip, LatticeSolid)
 {
+    suppress_deprecation_warnings();
     roundtrip("thermo-models.yaml", "Li7Si3_and_interstitials",
               {"Li7Si3(s)", "Li7Si3-interstitial"});
+    make_deprecation_warnings_fatal();
     compareThermo(710, 10e5);
 }
 

--- a/test_problems/VCSnonideal/LatticeSolid_LiSi/latsol.cpp
+++ b/test_problems/VCSnonideal/LatticeSolid_LiSi/latsol.cpp
@@ -10,6 +10,7 @@ using namespace Cantera;
 
 void testProblem(int printLvl)
 {
+    suppress_deprecation_warnings();
     double T = 273.15 + 352.0;
     VCS_SOLVE::disableTiming();
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

As far as I can tell, the `LatticePhase` class (YAML name `lattice`) doesn't do anything (correctly) that isn't handled by the `IdealSolidSolnPhase` class (YAML name `ideal-condensed`).

Besides the erroneous behavior described in #1309, the only difference is how the density of the phase is set. For the `lattice` model, this is done in the phase definition with a `site-density` field (which is then constant independent of composition). The same behavior can be obtained by setting the `molar-density` of each species in an `ideal-condensed` phase to the same value.

The `LatticeSolidPhase` also has numerous serious consistency issues (#1310), has never had a meaningful example (outside of one undocumented/unexplained case used for some tests), and does not appear to be significantly used (based on searching the Users' Group posts).

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Resolves #1309 
- Resolves #1310
- Resolves #642 (though not as originally intended)

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
