### PR TITLE
Update Pint version check

### DIFF
--- a/test/python/test_units.py
+++ b/test/python/test_units.py
@@ -1,14 +1,12 @@
 from dataclasses import dataclass
 from typing import Optional, Tuple, Dict
+import sys
 
 import pytest
-try:
-    pint = pytest.importorskip("pint", "0.17.0")
-except TypeError as e:
-    # The extra exception handling is here because pint is incompatible with
-    # Python 3.13. Once https://github.com/hgrecco/pint/issues/1969 is resolved the
-    # try/except here can be restored to just the importorskip.
-    pytest.skip(f"pint import failed due to {e}", allow_module_level=True)
+
+pint_min_version = "0.24.4" if sys.version_info >= (3, 13) else "0.17.0"
+pint = pytest.importorskip("pint", pint_min_version)
+
 import cantera.with_units as ctu
 import cantera as ct
 try:


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

Pint 0.24.4 resolved the compatibility issue between Pint and Python 3.13 (latest release is Pint 0.25). This restores the simpler version check (though old versions of Pint installed with Python 3.13+ will result in an an error while importing `pint`).

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Supersedes #1912.

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
