### PR TITLE
Fix and simplify options for solving electric field/ion diffusion

### DIFF
--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -216,23 +216,31 @@ public:
 
     //! Get the solving stage (used by IonFlow specialization)
     //! @since New in %Cantera 3.0
+    //! @deprecated To be removed after Cantera 3.2. Use doElectricField() instead.
     virtual size_t getSolvingStage() const;
 
     //! Solving stage mode for handling ionized species (used by IonFlow specialization)
     //! - @c stage=1: the fluxes of charged species are set to zero
     //! - @c stage=2: the electric field equation is solved, and the drift flux for
     //!     ionized species is evaluated
+    //! @deprecated To be removed after Cantera 3.2. Use solveElectricField() instead.
     virtual void setSolvingStage(const size_t stage);
 
     //! Set to solve electric field in a point (used by IonFlow specialization)
+    //! @deprecated After Cantera 3.2, the argument will be removed; the option of
+    //!     solving the electric field applies to the whole domain.
     virtual void solveElectricField(size_t j=npos);
 
     //! Set to fix voltage in a point (used by IonFlow specialization)
+    //! @deprecated After Cantera 3.2, the argument will be removed; the option of
+    //!     solving the electric field applies to the whole domain.
     virtual void fixElectricField(size_t j=npos);
 
     //! Retrieve flag indicating whether electric field is solved or not (used by
     //! IonFlow specialization)
-    virtual bool doElectricField(size_t j) const;
+    //! @deprecated After Cantera 3.2, the argument will be removed; the option of
+    //!     solving the electric field applies to the whole domain.
+    virtual bool doElectricField(size_t j=npos) const;
 
     //! Turn radiation on / off.
     void enableRadiation(bool doRadiation) {

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -45,19 +45,23 @@ public:
     string domainType() const override;
 
     size_t getSolvingStage() const override {
-        return m_stage;
+        warn_deprecated("IonFlow::getSolvingStage", "To be removed after Cantera 3.2. "
+            " Use doElectricField() instead.");
+        return (m_do_electric_field) ? 2 : 1;
     }
     void setSolvingStage(const size_t stage) override;
 
     void resize(size_t components, size_t points) override;
     bool componentActive(size_t n) const override;
 
-    void _finalize(const double* x) override;
-
     void solveElectricField(size_t j=npos) override;
     void fixElectricField(size_t j=npos) override;
-    bool doElectricField(size_t j) const override {
-        return m_do_electric_field[j];
+    bool doElectricField(size_t j=npos) const override {
+        if (j != npos) {
+            warn_deprecated("IonFlow::doElectricField", "Argument to be removed after "
+                "Cantera 3.2.");
+        }
+        return m_do_electric_field;
     }
 
     /**
@@ -112,13 +116,14 @@ protected:
                      double rdt, size_t jmin, size_t jmax) override;
     void updateTransport(double* x, size_t j0, size_t j1) override;
     void updateDiffFluxes(const double* x, size_t j0, size_t j1) override;
-    //! Solving phase one: the fluxes of charged species are turned off
+    //! Solving phase one: the fluxes of charged species are turned off and the electric
+    //! field is not solved.
     void frozenIonMethod(const double* x, size_t j0, size_t j1);
     //! Solving phase two: the electric field equation is added coupled
     //! by the electrical drift
     void electricFieldMethod(const double* x, size_t j0, size_t j1);
     //! flag for solving electric field or not
-    vector<bool> m_do_electric_field;
+    bool m_do_electric_field = false;
 
     //! flag for importing transport of electron
     bool m_import_electron_transport = false;
@@ -144,9 +149,6 @@ protected:
 
     //! mobility
     vector<double> m_mobility;
-
-    //! solving stage
-    size_t m_stage = 1;
 
     //! index of electron
     size_t m_kElectron = npos;

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -80,7 +80,7 @@ cdef extern from "cantera/oneD/Flow1D.h":
         void setSolvingStage(size_t) except +translate_exception
         void solveElectricField() except +translate_exception
         void fixElectricField() except +translate_exception
-        cbool doElectricField(size_t) except +translate_exception
+        cbool doElectricField() except +translate_exception
         void setBoundaryEmissivities(double, double)
         double leftEmissivity()
         double rightEmissivity()

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -627,6 +627,11 @@ cdef class FlowBase(Domain1D):
         - ``stage == 1``: the fluxes of charged species are set to zero
         - ``stage == 2``: the electric field equation is solved, and the drift flux for
           ionized species is evaluated
+
+        .. deprecated:: 3.2
+
+            To be removed after Cantera 3.2. Use the `electric_field_enabled` property
+            instead.
         """
         return self.flow.getSolvingStage()
 
@@ -640,7 +645,7 @@ cdef class FlowBase(Domain1D):
         Determines whether or not to solve the electric field equation (only relevant
         if transport model is ``ionized-gas``).
         """
-        return self.flow.doElectricField(0)
+        return self.flow.doElectricField()
 
     @electric_field_enabled.setter
     def electric_field_enabled(self, enable):

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -458,7 +458,13 @@ class FlameBase(Sim1D):
 
     @property
     def electric_field_enabled(self):
-        """ Get/Set whether or not to solve the Poisson's equation."""
+        """
+        Get/Set whether or not to solve the Poisson's equation.
+
+        Used in conjunction with the ``ion-transport`` transport model to model
+        diffusion of ionized species. See classes :ct:`IonFlow` and
+        :ct:`IonGasTransport`.
+        """
         return self.flame.electric_field_enabled
 
     @electric_field_enabled.setter
@@ -678,7 +684,7 @@ class FreeFlame(FlameBase):
             self.set_profile(self.gas.species_name(n),
                              locs, [Y0[n], Y0[n], Yeq[n], Yeq[n]])
 
-    def solve(self, loglevel=1, refine_grid=True, auto=False, stage=1):
+    def solve(self, loglevel=1, refine_grid=True, auto=False, stage=None):
         """
         Solve the problem.
 
@@ -696,9 +702,18 @@ class FreeFlame(FlameBase):
             transport is enabled, an additional solution using these options
             will be calculated.
         :param stage: solution stage; only used when transport model is ``ionized-gas``.
+
+        .. deprecated:: 3.2
+
+            The ``stage`` argument will be removed after Cantera 3.2. Replaced by
+            setting the `electric_field_enabled` property.
         """
-        if self.flame.transport_model == 'ionized-gas':
-            self.flame.solving_stage = stage
+        if stage is not None:
+            warnings.warn("The `stage` argument will be removed after Cantera 3.2. "
+                          "Replaced by setting the `electric_field_enabled` property.",
+                          DeprecationWarning)
+            if self.flame.transport_model == 'ionized-gas':
+                self.flame.electric_field_enabled = (stage == 2)
 
         if not auto:
             return super().solve(loglevel, refine_grid, auto)
@@ -851,7 +866,7 @@ class BurnerFlame(FlameBase):
             self.set_profile(self.gas.species_name(n),
                              locs, [Y0[n], Yeq[n], Yeq[n]])
 
-    def solve(self, loglevel=1, refine_grid=True, auto=False, stage=1):
+    def solve(self, loglevel=1, refine_grid=True, auto=False, stage=None):
         """
         Solve the problem.
 
@@ -869,9 +884,18 @@ class BurnerFlame(FlameBase):
             transport is enabled, an additional solution using these options
             will be calculated.
         :param stage: solution stage; only used when transport model is ``ionized-gas``.
+
+        .. deprecated:: 3.2
+
+            The ``stage`` argument will be removed after Cantera 3.2. Replaced by
+            setting the `electric_field_enabled` property.
         """
-        if self.flame.transport_model == 'ionized-gas':
-            self.flame.solving_stage = stage
+        if stage is not None:
+            warnings.warn("The `stage` argument will be removed after Cantera 3.2. "
+                          "Replaced by setting the `electric_field_enabled` property.",
+                          DeprecationWarning)
+            if self.flame.transport_model == 'ionized-gas':
+                self.flame.electric_field_enabled = (stage == 2)
 
         # Use a callback function to check that the flame has not been blown off
         # the burner surface. If the user provided a callback, store this so it
@@ -1032,7 +1056,7 @@ class CounterflowDiffusionFlame(FlameBase):
     def extinct(self):
         return max(self.T) - max(self.fuel_inlet.T, self.oxidizer_inlet.T) < 10
 
-    def solve(self, loglevel=1, refine_grid=True, auto=False, stage=1):
+    def solve(self, loglevel=1, refine_grid=True, auto=False, stage=None):
         """
         Solve the problem.
 
@@ -1050,12 +1074,21 @@ class CounterflowDiffusionFlame(FlameBase):
             transport is enabled, an additional solution using these options
             will be calculated.
         :param stage: solution stage; only used when transport model is ``ionized-gas``.
+
+        .. deprecated:: 3.2
+
+            The ``stage`` argument will be removed after Cantera 3.2. Replaced by
+            setting the `electric_field_enabled` property.
         """
         if self.flame.transport_model == 'ionized-gas':
             warnings.warn(
                 "The 'ionized-gas' transport model is untested for "
                 "'CounterflowDiffusionFlame' objects.", UserWarning)
-            self.flame.solving_stage = stage
+            if stage is not None:
+                warnings.warn("The `stage` argument will be removed after Cantera 3.2. "
+                            "Replaced by setting the `electric_field_enabled` property.",
+                            DeprecationWarning)
+                self.flame.electric_field_enabled = (stage == 2)
 
         super().solve(loglevel, refine_grid, auto)
         # Do some checks if loglevel is set

--- a/samples/python/onedim/ion_burner_flame.py
+++ b/samples/python/onedim/ion_burner_flame.py
@@ -28,8 +28,10 @@ f.burner.mdot = mdot
 f.set_refine_criteria(ratio=3.0, slope=0.05, curve=0.1)
 f.show()
 
+f.electric_field_enabled = False
 f.solve(loglevel, auto=True)
-f.solve(loglevel=loglevel, stage=2)
+f.electric_field_enabled = True
+f.solve(loglevel=loglevel)
 
 if "native" in ct.hdf_support():
     output = Path() / "ion_burner_flame.h5"

--- a/samples/python/onedim/ion_free_flame.py
+++ b/samples/python/onedim/ion_free_flame.py
@@ -14,7 +14,6 @@ import numpy as np
 import matplotlib.pyplot as plt
 import cantera as ct
 
-
 # Simulation parameters
 p = ct.one_atm  # pressure [Pa]
 Tin = 300.0  # unburned gas temperature [K]
@@ -32,11 +31,12 @@ f = ct.FreeFlame(gas, width=width)
 f.set_refine_criteria(ratio=3, slope=0.05, curve=0.1)
 f.show()
 
-# stage one
+# stage one (no diffusion of ions)
 f.solve(loglevel=loglevel, auto=True)
 
 # stage two
-f.solve(loglevel=loglevel, stage=2)
+f.electric_field_enabled = True
+f.solve(loglevel=loglevel)
 
 if "native" in ct.hdf_support():
     output = Path() / "ion_free_flame.h5"

--- a/test/python/test_onedim.py
+++ b/test/python/test_onedim.py
@@ -1982,8 +1982,6 @@ class TestTwinFlame:
             sim.solve(loglevel=0)
 
 class TestIonFreeFlame:
-
-    @pytest.mark.slow_test
     def test_ion_profile(self):
         reactants = 'CH4:0.216, O2:2'
         p = ct.one_atm
@@ -2000,10 +1998,13 @@ class TestIonFreeFlame:
         self.sim.flame.set_steady_tolerances(Y=(1e-4, 1e-12))
 
         # stage one
+        assert self.sim.electric_field_enabled is False
         self.sim.solve(loglevel=0, auto=True)
+        assert max(np.abs(self.sim.E)) == approx(0.0, abs=1e-3)
 
         #stage two
-        self.sim.solve(loglevel=0, stage=2)
+        self.sim.electric_field_enabled = True
+        self.sim.solve(loglevel=0)
 
         # Regression test
         assert max(self.sim.E) == approx(149.63179056676853, rel=1e-3)
@@ -2024,7 +2025,8 @@ class TestIonBurnerFlame:
         self.sim.set_refine_criteria(ratio=4, slope=0.1, curve=0.1)
         self.sim.burner.mdot = self.gas.density * 0.15
 
-        self.sim.solve(loglevel=0, stage=2, auto=True)
+        self.sim.electric_field_enabled = True
+        self.sim.solve(loglevel=0, auto=True)
 
         # Regression test
         assert max(self.sim.E) == approx(591.76, rel=1e-2)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix "electric_field_enabled" property to have it actually control whether the electric field is solved for.
- Deprecate the "stage" option to the "solve" method which previously was the only way to control this.
- Deprecate the "solving stage" property as well

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #1957

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
