### PR TITLE
Add post-merge CI jobs for dev versions of dependencies

### DIFF
--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -141,24 +141,33 @@ jobs:
         LD_LIBRARY_PATH: "${LD_LIBRARY_PATH}:build/lib"
         PYTHONPATH: build/python
 
-  ubuntu-docker:
-    name: Docker 'ubuntu:${{ matrix.image }}' image with Sundials MPI ${{ matrix.mpi }}
+  debuntu-docker:
+    name: Docker '${{ matrix.image }}' image with Sundials MPI ${{ matrix.mpi }}
     strategy:
       matrix:
         include:
-        - image: "devel"
+        - image: "ubuntu:devel"
           options: ""
           mpi: override  # fall back to bundled Sundials (system_sundials=default)
-        - image: "rolling"
+        - image: "ubuntu:rolling"
+          options: "system_sundials=y CC=mpicc CXX=mpicxx FORTRAN=mpifort"
+          mpi: enabled  # use MPI compiler wrappers
+        - image: "debian:stable"
+          options: "system_sundials=y CC=mpicc CXX=mpicxx FORTRAN=mpifort"
+          mpi: enabled  # use MPI compiler wrappers
+        - image: "debian:testing"
+          options: "system_sundials=y CC=mpicc CXX=mpicxx FORTRAN=mpifort"
+          mpi: enabled  # use MPI compiler wrappers
+        - image: "debian:unstable"
           options: "system_sundials=y CC=mpicc CXX=mpicxx FORTRAN=mpifort"
           mpi: enabled  # use MPI compiler wrappers
       fail-fast: false
     runs-on: ubuntu-latest
     timeout-minutes: 60
     container:
-      image: ubuntu:${{ matrix.image }}
+      image: ${{ matrix.image }} # zizmor: ignore[unpinned-images]
     steps:
-    - name: Install git on ubuntu:${{ matrix.image }}
+    - name: Install git on ${{ matrix.image }}
       run: |
         apt update -y
         apt install -y --no-install-recommends git ca-certificates

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -25,10 +25,14 @@ env:
   REQUIREMENTS_TXT_FILE: "platform/ci_support/post_merge_reqs.txt"
 
 jobs:
-  prerelease-cython:
-    name: Pre-release Cython
-    runs-on: ubuntu-22.04
+  prerelease-dependencies:
+    name: Pre-release ${{ matrix.name }}
+    runs-on: ubuntu-24.04
     timeout-minutes: 60
+    strategy:
+      matrix:
+        name: [cython, eigen, libfmt, SUNDIALS, yaml-cpp, HighFive, SCons]
+      fail-fast: false
     steps:
     - uses: actions/checkout@v4
       name: Checkout the repository
@@ -53,13 +57,80 @@ jobs:
     - name: Install Python dependencies
       run: |
         uv venv --python 3.13 --seed
-        sed -i 's/cython.*//g' "${REQUIREMENTS_TXT_FILE}"
         uv pip install -r "${REQUIREMENTS_TXT_FILE}"
+    - name: Install pre-release Cython
+      if: matrix.name == 'cython'
+      run: |
+        uv pip uninstall cython
         uv pip install --prerelease=allow --only-binary=":all:" cython
+    - name: Install pre-release Eigen
+      if: matrix.name == 'eigen'
+      run: |
+        git fetch origin
+        git reset --hard origin/HEAD
+      working-directory: ext/eigen
+    - name: Build prerelease libfmt
+      if: matrix.name == 'libfmt'
+      run: |
+        echo "system_fmt = 'y'" >> cantera.conf
+        echo "extra_inc_dirs = 'fmt/install/include'" >> cantera.conf
+        echo "extra_lib_dirs = 'fmt/install/lib'" >> cantera.conf
+        git clone https://github.com/fmtlib/fmt
+        mkdir fmt/build
+        cd fmt/build
+        cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_SHARED_LIBS=Y ..
+        make -j4
+        make install
+    - name: Build prerelease SUNDIALS
+      if: matrix.name == 'SUNDIALS'
+      run: |
+        echo "system_sundials = 'y'" >> cantera.conf
+        echo "extra_inc_dirs = 'sundials/install/include'" >> cantera.conf
+        echo "extra_lib_dirs = 'sundials/install/lib'" >> cantera.conf
+        git clone https://github.com/LLNL/sundials
+        cd sundials
+        git switch develop
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_SHARED_LIBS=Y ..
+        make -j4
+        make install
+    - name: Build prerelease yaml-cpp
+      if: matrix.name == 'yaml-cpp'
+      run: |
+        echo "system_yamlcpp = 'y'" >> cantera.conf
+        echo "extra_inc_dirs = 'yaml-cpp/install/include'" >> cantera.conf
+        echo "extra_lib_dirs = 'yaml-cpp/install/lib'" >> cantera.conf
+        git clone https://github.com/jbeder/yaml-cpp
+        cd yaml-cpp
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=../install -DBUILD_SHARED_LIBS=Y ..
+        make -j4
+        make install
+    - name: Build prerelease HighFive
+      if: matrix.name == 'HighFive'
+      run: |
+        echo "system_highfive = 'y'" >> cantera.conf
+        echo "extra_inc_dirs = 'highfive/install/include'" >> cantera.conf
+        git clone --recursive https://github.com/highfive-devs/highfive
+        cd highfive
+        mkdir build
+        cd build
+        cmake -DCMAKE_INSTALL_PREFIX=../install -DHIGHFIVE_EXAMPLES=N \
+            -DHIGHFIVE_UNIT_TESTS=N -DHIGHFIVE_BUILD_DOCS=N ..
+        make
+        make install
+    - name: Install prerelease SCons
+      if: matrix.name == 'SCons'
+      run: |
+        uv pip uninstall scons
+        git clone https://github.com/SCons/scons
+        cd scons
+        uv pip install -e .
     - name: Build Cantera
-      run: uv run scons build env_vars=all
-        CXX=clang++-14 CC=clang-14 f90_interface=n extra_lib_dirs=/usr/lib/llvm/lib
-        -j4 debug=n --debug=time logging=debug python_package=y
+      run: uv run scons build env_vars=all f90_interface=n -j4 debug=n
+        --debug=time logging=debug python_package=y
     - name: Build Tests
       run: uv run scons -j4 build-tests
     - name: Run compiled tests

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -313,7 +313,7 @@ jobs:
         PYTHONPATH: build/python
 
   macos-homebrew:
-    name: Install Latest Python with Homebrew on ${{ matrix.os }}
+    name: Homebrew Python/GCC on ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     timeout-minutes: 90
     strategy:
@@ -332,12 +332,14 @@ jobs:
         enable-cache: true
         cache-dependency-glob: |
           ${{ env.REQUIREMENTS_TXT_FILE }}
-    # NumPy is installed here for the Python custom rate tests
+    # - NumPy is installed here for the Python custom rate tests.
+    # - Do not install brew SUNDIALS because it requires open-mpi and the brew open-mpi
+    #   package uses the system Clang to provide mpicc/mpicxx.
+    # - Do not install brew dependencies for C++ because these are built with libc++
+    #   while GCC will use libstdc++, and combining these will lead to linker errors
     - name: Install Brew dependencies
-      run: |
-        brew install --display-times boost libomp hdf5 python numpy doxygen
-    - name: Set Include folder
-      run: echo "BOOST_INC_DIR=$(brew --prefix)/include" >> $GITHUB_ENV
+      run:
+        brew install --display-times boost libomp hdf5 python numpy doxygen gcc eigen
     # This is necessary because of PEP 668 https://peps.python.org/pep-0668/
     # PEP 668 prohibits installation to system Python packages via pip
     - name: Create a virtualenv for dependencies
@@ -350,8 +352,15 @@ jobs:
         uv pip install -r "${REQUIREMENTS_TXT_FILE}"
     - name: Build Cantera
       run: |
+        BREW_PREFIX=`brew --prefix`
+        GCC_VER=`brew info gcc --json | jq -r '.[0]["installed"][0]["version"] | split(".")[0]'`
+        echo "CC = '$BREW_PREFIX/bin/gcc-$GCC_VER'" >> cantera.conf
+        echo "CXX = '$BREW_PREFIX/bin/g++-$GCC_VER'" >> cantera.conf
+        echo "AR = '$BREW_PREFIX/bin/gcc-ar-$GCC_VER'" >> cantera.conf
+        echo "extra_inc_dirs = '${BREW_PREFIX}/include'" >> cantera.conf
+        echo "extra_lib_dirs = '${BREW_PREFIX}/lib'" >> cantera.conf
         uv run scons build env_vars=all -j3 debug=n --debug=time logging=debug \
-        boost_inc_dir=${BOOST_INC_DIR} python_package=y
+            python_package=y system_eigen=y
     - name: Build Tests
       run: uv run scons -j3 build-tests
     - name: Run compiled tests

--- a/.gitmodules
+++ b/.gitmodules
@@ -15,7 +15,7 @@
 	url = https://github.com/jbeder/yaml-cpp.git
 [submodule "ext/HighFive"]
 	path = ext/HighFive
-	url = https://github.com/BlueBrain/HighFive.git
+	url = https://github.com/highfive-devs/highfive
 [submodule "ext/doxygen-awesome-css"]
 	path = ext/doxygen-awesome-css
 	url = https://github.com/jothepro/doxygen-awesome-css.git

--- a/SConstruct
+++ b/SConstruct
@@ -1441,6 +1441,8 @@ if env['system_sundials'] in ("y", "default"):
         env["system_sundials"] = sundials_info["system_sundials"]
         env["sundials_version"] = sundials_info["sundials_version"]
         env["has_sundials_lapack"] = sundials_info["has_sundials_lapack"]
+    elif env["system_sundials"] == "y":
+        config_error("System SUNDIALS was specified but libraries were not found.")
 
 if env["system_sundials"] in ("n", "default"):
     if not os.path.exists('ext/sundials/include/cvodes/cvodes.h'):

--- a/SConstruct
+++ b/SConstruct
@@ -1494,7 +1494,7 @@ else:
 
 if env["use_hdf5"] and env["system_highfive"] in ("y", "default"):
     if conf.CheckLibWithHeader(
-            "hdf5", "highfive/H5File.hpp", language="C++", autoadd=False):
+            env["hdf5_lib"], "highfive/H5File.hpp", language="C++", autoadd=False):
 
         highfive_include = "<highfive/H5Version.hpp>"
         retcode, h5_lib_version = run_preprocessor(conf, [highfive_include], "HIGHFIVE_VERSION")

--- a/SConstruct
+++ b/SConstruct
@@ -1191,7 +1191,7 @@ def get_expression_value(includes, expression):
 # Need to ensure that RPATH is working before we can continue with library checks
 env['HAS_CLANG'] = conf.CheckDeclaration('__clang__', '', 'C++')
 
-if env['OS'] == 'Solaris' or env['HAS_CLANG']:
+if env['OS'] == 'Solaris' or env['HAS_CLANG'] or env["OS"] == "Darwin":
     env["RPATHPREFIX"] = "-Wl,-rpath,"
 
 # Add initial libraries to RPATH

--- a/doc/sphinx/develop/compiling/dependencies.md
+++ b/doc/sphinx/develop/compiling/dependencies.md
@@ -133,7 +133,7 @@ compiler is required only if you plan to build the Fortran module.
   - Required to read and write data files in the HDF5 format
   - Known to work with versions 1.12 and 1.14.
 
-- [HighFive](https://github.com/BlueBrain/HighFive)
+- [HighFive](https://highfive-devs.github.io/highfive/)
 
   - Required to read and write data files in the HDF5 format
   - If HighFive is not installed and you have checked out the Cantera source code

--- a/interfaces/python_sdist/src/CMakeLists.txt
+++ b/interfaces/python_sdist/src/CMakeLists.txt
@@ -43,7 +43,7 @@ FetchContent_Declare(
 set(HIGHFIVE_VERSION 2.10.0)
 FetchContent_Declare(
   HighFive
-  URL https://github.com/BlueBrain/HighFive/archive/refs/tags/v${HIGHFIVE_VERSION}.tar.gz
+  URL https://github.com/highfive-devs/HighFive/archive/refs/tags/v${HIGHFIVE_VERSION}.tar.gz
   URL_HASH SHA256=c29e8e1520e7298fabb26545f804e35bb3af257005c1c2df62e39986458d7c38
   # FIND_PACKAGE_ARGS has to be the last thing in this call because it greedily takes
   # everything after it to pass to `find_package()`


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Add post-merge CI jobs using (separately) the latest development versions of Eigen, SUNDIALS, libfmt, yaml-cpp, HighFive, and SCons
- Add post-merge CI jobs using Docker images for Debian stable, testing, and unstable images
- Update post-merge CI job using Homebrew Python to also use Homebrew-provided GCC to compile Cantera
- Fix handling of the name of the HDF5 library when using a "system" version of HighFive (can be `hdf5_serial`, as we automatically detect)
- Fix setting of `RPATH` flags when using Homebrew GCC
- Fix the error message provided when the `system_sundials=y` flag is specified but SUNDIALS is not found

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Completes Cantera/enhancements#37

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
