### PR TITLE
feat: pickling of SolutionArray objects (fixes #543)

### DIFF
--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -66,6 +66,7 @@ update, please report on Cantera's
 - **Matthew Quiram** [@mquiram](https://github.com/mquiram) - Massachusetts Institute of Technology
 - **Corey R. Randall** [@c-randall](https://github.com/c-randall) - Colorado School of Mines
 - **Andreas Rücker** [@cannondale1492](https://github.com/cannondale1492)
+- **Martijn Ruijzendaal** [@mruijzendaal](https://github.com/mruijzendaal) - Maastricht University
 - **Jeff Santner** [@jsantner](https://github.com/jsantner)
 - **Satyam Saxena** [@CyberDrudge](https://github.com/CyberDrudge)
 - **Ingmar Schoegl** [@ischoegl](https://github.com/ischoegl) - Louisiana State University

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1306,11 +1306,61 @@ class SolutionArray(SolutionArrayBase):
         self.shape = self._api_shape()
         return meta
 
+    def _to_picklable(self):
+        import os
+        from pathlib import Path
+        import tempfile
+
+        # Save to a temporary YAML file
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tf = Path(tmpdir, "cantera_solarr_save_tempfile.yaml")
+
+            # Remove the file if it already exists
+            if (tf.exists()):
+                os.unlink(tf)
+            self.save(tf, name="solarr", overwrite=True)
+
+            # Read the YAML file into a string and delete the file
+            with open(tf, 'r') as f:
+                yaml_data = f.read()
+
+        return {
+            'yaml_data': yaml_data,
+            'phase': self._phase, # Solution object, which is already picklable
+        }
+
+    @classmethod
+    def _from_pickle(cls, state):
+        from pathlib import Path
+        import os
+        import tempfile
+        # Recreate phase
+        phase = state.get('phase')
+        
+        # Create empty SolutionArray
+        arr = cls(phase)
+
+        # Write the YAML string to a temporary file
+        with tempfile.TemporaryDirectory() as tmpdir:
+            tf = Path(tmpdir, "cantera_solarr_load_tempfile.yaml")
+
+            # Remove the file if it already exists
+            if (tf.exists()):
+                os.unlink(tf)
+            with tf.open('w') as f:
+                f.write(state['yaml_data'])
+                f.flush()
+                
+            # Restore the SolutionArray from the yaml
+            arr.restore(tf, 'solarr')
+
+        return arr
+    
     def __reduce__(self):
-        raise NotImplementedError('SolutionArray object is not picklable')
+        return (self.__class__._from_pickle, (self._to_picklable(),))
 
     def __copy__(self):
-        raise NotImplementedError('SolutionArray object is not copyable')
+        return self.__class__._from_pickle(self._to_picklable())
 
 
 def _state2_prop(name, doc_source):

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -2,14 +2,14 @@
 # at https://cantera.org/license.txt for license and copyright information.
 from __future__ import annotations as _annotations
 
-import numpy as np
 import importlib as _importlib
+from tempfile import NamedTemporaryFile as _NamedTemporaryFile
+from os import unlink as _unlink
+import numpy as np
 from ._cantera import (
     DustyGasTransport, InterfaceKinetics, InterfacePhase, Kinetics, PureFluid,
     SolutionArrayBase, ThermoPhase, Transport,
 )
-import os as _os
-import tempfile as _tempfile
 
 _pandas = None
 def _import_pandas():
@@ -1309,30 +1309,35 @@ class SolutionArray(SolutionArrayBase):
         return meta
 
     def _to_picklable(self):
-        with _tempfile.NamedTemporaryFile(suffix='.yaml') as temp_file:
-            _os.unlink(temp_file.name)
-            self.save(temp_file.name, name='solarr', overwrite=True)
-            with open(temp_file.name, 'r') as fid:
-                yaml_data = fid.read()
+        temp_file = _NamedTemporaryFile(suffix=".yaml", delete=False).name
+
+        try:
+            self.save(temp_file, name="solution_array", overwrite=True)
+            with open(temp_file, "r", encoding="utf-8") as t_file:
+                yaml_data = t_file.read()
+        finally:
+            _unlink(temp_file)
 
         return {
-            'yaml_data': yaml_data,
-            'phase': self._phase, # Solution object, which is already picklable
+            "yaml_data": yaml_data,
+            "phase": self._phase,  # Solution object, which is already picklable
         }
 
     @classmethod
     def _from_pickle(cls, state):
-        # Recreate phase
-        phase = state.get('phase')
+        phase = state.get("phase")  # Recreate Solution object from pickled state
 
-        # Create empty SolutionArray
+        # Restore SolutionArray
+        with _NamedTemporaryFile(suffix=".yaml", mode="w", encoding="utf-8",
+                                 delete=False) as t_file:
+            t_file.write(state["yaml_data"])
+            temp_file = t_file.name
+
         arr = cls(phase)
-
-        with _tempfile.NamedTemporaryFile(suffix='.yaml', mode='w') as temp_file:
-            temp_file.write(state['yaml_data'])
-            temp_file.flush()
-
-            arr.restore(temp_file.name, 'solarr')
+        try:
+            arr.restore(temp_file, "solution_array")
+        finally:
+            _unlink(temp_file)
 
         return arr
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1334,10 +1334,10 @@ class SolutionArray(SolutionArrayBase):
         from pathlib import Path
         import os
         import tempfile
-        
+
         # Recreate phase
         phase = state.get('phase')
-        
+
         # Create empty SolutionArray
         arr = cls(phase)
 
@@ -1352,11 +1352,11 @@ class SolutionArray(SolutionArrayBase):
             with tf.open('w') as f:
                 f.write(state['yaml_data'])
                 f.flush()
-                
+
             # Restore the SolutionArray from the yaml
             arr.restore(tf, 'solarr')
         return arr
-    
+
     def __reduce__(self):
         return (self.__class__._from_pickle, (self._to_picklable(),))
 

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -1334,6 +1334,7 @@ class SolutionArray(SolutionArrayBase):
         from pathlib import Path
         import os
         import tempfile
+        
         # Recreate phase
         phase = state.get('phase')
         
@@ -1347,13 +1348,13 @@ class SolutionArray(SolutionArrayBase):
             # Remove the file if it already exists
             if (tf.exists()):
                 os.unlink(tf)
+
             with tf.open('w') as f:
                 f.write(state['yaml_data'])
                 f.flush()
                 
             # Restore the SolutionArray from the yaml
             arr.restore(tf, 'solarr')
-
         return arr
     
     def __reduce__(self):

--- a/src/base/SolutionArray.cpp
+++ b/src/base/SolutionArray.cpp
@@ -1341,7 +1341,8 @@ void SolutionArray::save(const string& fname, const string& name, const string& 
     if (extension == "yaml" || extension == "yml") {
         // Check for an existing file and load it if present
         AnyMap data;
-        if (std::ifstream(fname).good()) {
+        std::ifstream file(fname);
+        if (file.good() && file.peek() != std::ifstream::traits_type::eof()) {
             data = AnyMap::fromYamlFile(fname);
         }
         writeHeader(data, name, desc, overwrite);

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -308,6 +308,34 @@ class TestSolutionArray:
         arr = ct.SolutionArray(gas, shape=1)
         assert arr.net_production_rates.size == gas.n_species
 
+    def test_pickle_solutionarray(self):
+        sol = ct.Solution("gri30.yaml")
+        solarr = ct.SolutionArray(sol, 10)
+        # Fill with some data
+        T = np.linspace(300, 2000, 10)
+        P = np.linspace(1e5, 5e5, 10)
+        X = np.zeros((10, sol.n_species))
+        X[:, sol.species_index("H2")] = 0.7
+        X[:, sol.species_index("O2")] = 0.3
+        solarr.TPX = T, P, X
+
+        outfile = self.test_work_path / "solarr.pkl"
+        with open(outfile, "wb") as f:
+            pickle.dump(solarr, f)
+
+        with open(outfile, "rb") as f:
+            solarr_loaded = pickle.load(f)
+
+        # Compare all fields
+        assert solarr.shape == solarr_loaded.shape
+        assert solarr.T == approx(solarr_loaded.T)
+        assert solarr.P == approx(solarr_loaded.P)
+        assert solarr.X == approx(solarr_loaded.X)
+        # Check all state vectors
+        for orig, loaded in zip(solarr, solarr_loaded):
+            assert orig.T == approx(loaded.T)
+            assert orig.P == approx(loaded.P)
+            assert orig.X == approx(loaded.X)
 
 @pytest.fixture(scope='class')
 def setup_solution_array_info_tests(request):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Implement `__reduce__` and `__copy__` methods for `SolutionArray`, such that it is picklable and copyable.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Fixes #543, continuation of #1426, see [cantera/enhancements/#162](https://github.com/Cantera/enhancements/issues/162#issuecomment-3256561347) 


**If applicable, provide an example illustrating new features this pull request is introducing**

In short, this pull request enables pickling and copying of SolutionArray objects with YAML as a proxy:  
```python
import cantera as ct
import pickle
import copy

sol = ct.Solution('gri30.yaml')  # load GRI-Mech 3.0 mechanism
solarr = ct.SolutionArray(sol, 100)  # create a solution array to store results

with open('sol_saved.pkl', 'wb') as f:
    pickle.dump(solarr, f)

with open('sol_saved.pkl', 'rb') as f:
    solarr_loaded = pickle.load(f)

copy.copy(solarr_loaded)
```

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review


(Edit: format proposed changes)