### PR TITLE
Fix handling of falloff reactions with extra apparent third body

### DIFF
--- a/test/kinetics/kineticsFromYaml.cpp
+++ b/test/kinetics/kineticsFromYaml.cpp
@@ -372,6 +372,36 @@ TEST(Reaction, FalloffFromYaml3)
     EXPECT_EQ(R->input["source"].asString(), "ARL-TR-5088");
 }
 
+TEST(Reaction, FalloffFromYaml4)
+{
+    auto sol = newSolution("soot.yaml", "", "none");
+    AnyMap rxn = AnyMap::fromYamlString(
+        "{equation: C6H5 + BIN5 (+H2) => 0.984615 BIN5 + 0.0153846 BIN6 + 3.1538 H (+H2),"
+        " type: falloff,"
+        " low-P-rate-constant: {A: 5.62e+09, b: 1.5, Ea: 0.0},"
+        " high-P-rate-constant: {A: 5.62e+09, b: 0.5, Ea: 0.0}}"
+    );
+    auto R = newReaction(rxn, *(sol->kinetics()));
+    EXPECT_TRUE(R->usesThirdBody());
+    EXPECT_EQ(R->type(), "falloff-Lindemann");
+    EXPECT_DOUBLE_EQ(R->thirdBody()->efficiency("H2"), 1.0);
+    EXPECT_DOUBLE_EQ(R->thirdBody()->efficiency("BIN5"), 0.0);
+}
+
+TEST(Reaction, FalloffFromYaml5)
+{
+    auto sol = newSolution("soot.yaml", "", "none");
+    AnyMap rxn = AnyMap::fromYamlString(
+        "{equation: C6H5 + BIN5 (+M) => 0.984615 BIN5 + 0.0153846 BIN6 + 3.1538 H (+M),"
+        " type: falloff,"
+        " low-P-rate-constant: {A: 5.62e+09, b: 1.5, Ea: 0.0},"
+        " high-P-rate-constant: {A: 5.62e+09, b: 0.5, Ea: 0.0}}"
+    );
+    auto R = newReaction(rxn, *(sol->kinetics()));
+    EXPECT_TRUE(R->usesThirdBody());
+    EXPECT_EQ(R->type(), "falloff-Lindemann");
+}
+
 TEST(Reaction, ChemicallyActivatedFromYaml)
 {
     auto sol = newSolution("gri30.yaml", "", "none");


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix parsing of falloff reactions that contain another species that can be (incorrectly) interpreted as a third-body

For example, the following two reactions previously generated errors:
```yaml
- equation: C6H5 + BIN5 (+H2) => 0.984615 BIN5 + 0.0153846 BIN6 + 3.1538 H (+H2)
  type: falloff
  low-P-rate-constant: {A: 5.62e+09, b: 1.5, Ea: 0.0}
  high-P-rate-constant: {A: 5.62e+09, b: 0.5, Ea: 0.0}

- equation: C6H5 + BIN5 (+M) => 0.984615 BIN5 + 0.0153846 BIN6 + 3.1538 H (+M)
  type: falloff
  low-P-rate-constant: {A: 5.62e+09, b: 1.5, Ea: 0.0}
  high-P-rate-constant: {A: 5.62e+09, b: 0.5, Ea: 0.0}
```

The first reaction reported an incorrect error:
```
*******************************************************************************
CanteraError thrown by addReactions:

*******************************************************************************
InputFileError thrown by Reaction::setRate:
Error on line 10 of ./debug-M.yaml:
Reaction equation for falloff reaction '(+H2) + BIN5 + C6H5 => (+H2) + 0.984615 BIN5 + 0.0153846 BIN6 + 3.1538 H'
 does not contain valid pressure-dependent third body
|  Line |
|     5 |   kinetics: gas
|     6 |   reactions: all
|     7 |   state: {T: 300.0 K, P: 1.01325e+05 Pa}
|     8 | 
|     9 | reactions:
>    10 > - equation: C6H5 + BIN5 (+H2) => 0.984615 BIN5 + 0.0153846 BIN6 + 3.1538 H (+H2)
            ^
|    11 |   type: falloff
|    12 |   low-P-rate-constant: {A: 5.62e+09, b: 1.5, Ea: 0.0}
|    13 |   high-P-rate-constant: {A: 5.62e+09, b: 0.5, Ea: 0.0}
*******************************************************************************
*******************************************************************************
```
while the second reaction generated a segfault inside `Reaction::setParameters` that I was able to trace to calling `erase` on the non-dereferenceable `end()` iterator of `Reaction.reactants` or `Reaction.products`.

**If applicable, fill in the issue number this pull request is fixing**

Fixes an issue reported on the [Cantera Users' Group](https://groups.google.com/g/cantera-users/c/BNgdbQzDDXA).

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
