### PR TITLE
Deprecate ReactorBase::addThermo

### DIFF
--- a/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureMoleReactor.h
@@ -49,8 +49,6 @@ public:
     double lowerBound(size_t k) const override;
 
 protected:
-    void setThermo(ThermoPhase& thermo) override;
-
     vector<double> m_hk; //!< Species molar enthalpies
 };
 

--- a/include/cantera/zeroD/IdealGasConstPressureReactor.h
+++ b/include/cantera/zeroD/IdealGasConstPressureReactor.h
@@ -45,8 +45,6 @@ public:
     double lowerBound(size_t k) const override;
 
 protected:
-    void setThermo(ThermoPhase& thermo) override;
-
     vector<double> m_hk; //!< Species molar enthalpies
 };
 }

--- a/include/cantera/zeroD/IdealGasMoleReactor.h
+++ b/include/cantera/zeroD/IdealGasMoleReactor.h
@@ -50,8 +50,6 @@ public:
     bool preconditionerSupported() const override {return true;};
 
 protected:
-    void setThermo(ThermoPhase& thermo) override;
-
     vector<double> m_uk; //!< Species molar internal energies
 };
 

--- a/include/cantera/zeroD/IdealGasReactor.h
+++ b/include/cantera/zeroD/IdealGasReactor.h
@@ -44,8 +44,6 @@ public:
     double lowerBound(size_t k) const override;
 
 protected:
-    void setThermo(ThermoPhase& thermo) override;
-
     vector<double> m_uk; //!< Species molar internal energies
 };
 

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -287,6 +287,8 @@ protected:
     //! this substance is stored, and as the integration proceeds, the state of
     //! the substance is modified.
     //! @since New in %Cantera 3.1.
+    //! @deprecated  To be removed after %Cantera 3.2. Superseded by instantiation of
+    //!              ReactorBase with Solution object.
     virtual void setThermo(ThermoPhase& thermo);
 
     //! Specify the kinetics manager for the reactor. Called by setSolution().

--- a/src/zeroD/IdealGasConstPressureMoleReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureMoleReactor.cpp
@@ -17,15 +17,6 @@
 namespace Cantera
 {
 
-void IdealGasConstPressureMoleReactor::setThermo(ThermoPhase& thermo)
-{
-    if (thermo.type() != "ideal-gas") {
-        throw CanteraError("IdealGasConstPressureMoleReactor::setThermo",
-                           "Incompatible phase type provided");
-    }
-    ConstPressureMoleReactor::setThermo(thermo);
-}
-
 void IdealGasConstPressureMoleReactor::getState(double* y)
 {
     if (m_thermo == 0) {
@@ -45,6 +36,10 @@ void IdealGasConstPressureMoleReactor::getState(double* y)
 
 void IdealGasConstPressureMoleReactor::initialize(double t0)
 {
+    if (m_thermo->type() != "ideal-gas") {
+        throw CanteraError("IdealGasConstPressureMoleReactor::initialize",
+                           "Incompatible phase type '{}' provided", m_thermo->type());
+    }
     ConstPressureMoleReactor::initialize(t0);
     m_hk.resize(m_nsp, 0.0);
 }

--- a/src/zeroD/IdealGasConstPressureReactor.cpp
+++ b/src/zeroD/IdealGasConstPressureReactor.cpp
@@ -13,17 +13,6 @@
 namespace Cantera
 {
 
-void IdealGasConstPressureReactor::setThermo(ThermoPhase& thermo)
-{
-    //! @todo: Add a method to ThermoPhase that indicates whether a given
-    //! subclass is compatible with this reactor model
-    if (thermo.type() != "ideal-gas") {
-        throw CanteraError("IdealGasConstPressureReactor::setThermo",
-                           "Incompatible phase type provided");
-    }
-    Reactor::setThermo(thermo);
-}
-
 void IdealGasConstPressureReactor::getState(double* y)
 {
     if (m_thermo == 0) {
@@ -48,7 +37,12 @@ void IdealGasConstPressureReactor::getState(double* y)
 
 void IdealGasConstPressureReactor::initialize(double t0)
 {
-    ConstPressureReactor::initialize(t0);
+    //! @todo: Add a method to ThermoPhase that indicates whether a given
+    //! subclass is compatible with this reactor model
+    if (m_thermo->type() != "ideal-gas") {
+        throw CanteraError("IdealGasConstPressureReactor::initialize",
+                           "Incompatible phase type '{}' provided", m_thermo->type());
+    }    ConstPressureReactor::initialize(t0);
     m_hk.resize(m_nsp, 0.0);
 }
 

--- a/src/zeroD/IdealGasMoleReactor.cpp
+++ b/src/zeroD/IdealGasMoleReactor.cpp
@@ -17,15 +17,6 @@
 namespace Cantera
 {
 
-void IdealGasMoleReactor::setThermo(ThermoPhase& thermo)
-{
-    if (thermo.type() != "ideal-gas") {
-        throw CanteraError("IdealGasMoleReactor::setThermo",
-                           "Incompatible phase type provided");
-    }
-    MoleReactor::setThermo(thermo);
-}
-
 void IdealGasMoleReactor::getState(double* y)
 {
     if (m_thermo == 0) {
@@ -75,6 +66,10 @@ string IdealGasMoleReactor::componentName(size_t k)
 
 void IdealGasMoleReactor::initialize(double t0)
 {
+    if (m_thermo->type() != "ideal-gas") {
+        throw CanteraError("IdealGasMoleReactor::initialize",
+                           "Incompatible phase type '{}' provided", m_thermo->type());
+    }
     MoleReactor::initialize(t0);
     m_uk.resize(m_nsp, 0.0);
 }

--- a/src/zeroD/IdealGasReactor.cpp
+++ b/src/zeroD/IdealGasReactor.cpp
@@ -13,17 +13,6 @@
 namespace Cantera
 {
 
-void IdealGasReactor::setThermo(ThermoPhase& thermo)
-{
-    //! @todo: Add a method to ThermoPhase that indicates whether a given
-    //! subclass is compatible with this reactor model
-    if (thermo.type() != "ideal-gas") {
-        throw CanteraError("IdealGasReactor::setThermo",
-                           "Incompatible phase type provided");
-    }
-    Reactor::setThermo(thermo);
-}
-
 void IdealGasReactor::getState(double* y)
 {
     if (m_thermo == 0) {
@@ -52,6 +41,12 @@ void IdealGasReactor::getState(double* y)
 
 void IdealGasReactor::initialize(double t0)
 {
+    //! @todo: Add a method to ThermoPhase that indicates whether a given
+    //! subclass is compatible with this reactor model
+    if (m_thermo->type() != "ideal-gas") {
+        throw CanteraError("IdealGasReactor::initialize",
+                           "Incompatible phase type '{}' provided", m_thermo->type());
+    }
     Reactor::initialize(t0);
     m_uk.resize(m_nsp, 0.0);
 }


### PR DESCRIPTION
The virtual `ReactorBase::addThermo` does not function as intended, since overrides are not executed when this method is called from the base class constructor. Derived classes needing customized behavior must implement it in their own constructors or in overrides of the initialize method.

This erroneous usage was mostly invisible because we have only been using these overrides to ensure that the `ThermoPhase` objects used in the "ideal gas" reactor types are in fact ideal gasses.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Move checks out of overrides of `ReactorBase::addThermo`
- Deprecate `ReactorBase::addThermo`

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
