### PR TITLE
Fix 1D flame auto-solve after restoring from Pandas

### DIFF
--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -1141,7 +1141,7 @@ cdef class Sim1D:
 
         # 'data' entry is used for restart
         data = self._initial_guess_kwargs.get('data')
-        if data:
+        if data is not None:
            nPoints = [len(flow_domains[0].grid)]
         else:
            nPoints = [len(flow_domains[0].grid), 12, 24, 48]
@@ -1154,7 +1154,7 @@ cdef class Sim1D:
                 if N != len(D.grid):
                     D.grid = np.linspace(zmin[i], zmax[i], N)
 
-            if not data:
+            if data is None:
                 self.set_initial_guess(*self._initial_guess_args,
                                        **self._initial_guess_kwargs)
 


### PR DESCRIPTION


<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Make checks in `Sim1D.solve` explicitly against `None` rather than just truthiness

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Fixes #1889

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
