### PR TITLE
Correct heat transfer coefficient unit in docstring

### DIFF
--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -978,7 +978,7 @@ cdef class WallBase(ConnectorNode):
         :param K:
             Wall expansion rate parameter [m/s/Pa]. Defaults to 0.0.
         :param U:
-            Overall heat transfer coefficient [W/m^2]. Defaults to 0.0
+            Overall heat transfer coefficient [W/m^2/K]. Defaults to 0.0
             (adiabatic wall).
         :param Q:
             Heat flux function :math:`q_0(t)` [W/m^2]. Optional. Default:


### PR DESCRIPTION
The [C++ documentation](https://cantera.org/dev/cxx/db/d1e/classCantera_1_1Wall.html) specifies that param U is actually of unit [W/m^2/K].

The [current Python documentation](https://cantera.org/dev/python/zerodim.html#walls) of the calculation of the heat transfer q [W/m^2] involves U * deltaT, with deltaT of unit [K], also implying U is of unit [W/m^2/K].

From some practical experience, it seems that the current Python documentation is inaccurate with respect to U. I could not find any other references to U in the `cantera` or `cantera-website` repositories, so I'm assuming the documentation is generated from the python docstrings. If that's the case, this edit should fix the issues.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix unit of heat transfer coefficient U in Python docstring of the `ct.Wall` class.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Didn't create an issue for this. Would you prefer if I create issues for minor fixes like these in the future?

**If applicable, provide an example illustrating new features this pull request is introducing**

See [the current docs](https://cantera.org/dev/python/zerodim.html#walls) and https://github.com/Cantera/cantera/blob/57b15843a30118b968576817fcebfd102b4cdc3e/interfaces/cython/cantera/reactor.pyx#L980-L982

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
