### PR TITLE
Use unicode superscript in Python docstrings / tweak pickle

### DIFF
--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -323,7 +323,7 @@ cdef class Boundary1D(Domain1D):
             self.boundary.setTemperature(T)
 
     property mdot:
-        """ The mass flow rate per unit area [kg/s/m^2] """
+        """The mass flow rate per unit area [kg/s/m²]"""
         def __get__(self):
             return self.boundary.mdot()
         def __set__(self, mdot):

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -258,7 +258,7 @@ class Quantity:
 
     @property
     def volume(self):
-        """ Get the total volume [m^3] represented by the `Quantity`. """
+        """Get the total volume [m³] represented by the `Quantity`."""
         return self.mass * self.phase.volume_mass
 
     @property

--- a/interfaces/cython/cantera/composite.py
+++ b/interfaces/cython/cantera/composite.py
@@ -591,7 +591,8 @@ class SolutionArray(SolutionArrayBase):
 
     _purefluid_scalar = ['Q']
 
-    def __init__(self, phase, shape=(0,), states=None, extra=None, meta={}, init=True):
+    def __init__(self, phase, shape=(0,), states=None, extra=None, meta=None,
+                 init=True):
         self._phase = phase
         if not init:
             return
@@ -1306,7 +1307,9 @@ class SolutionArray(SolutionArrayBase):
         return meta
 
     def _to_picklable(self):
-        temp_file = _NamedTemporaryFile(suffix=".yaml", delete=False).name
+        with _NamedTemporaryFile(suffix=".yaml", delete=False) as t_file:
+            # Context manager ensures that temporary file is properly created
+            temp_file = t_file.name
 
         try:
             self.save(temp_file, name="solution_array", overwrite=True)
@@ -1325,12 +1328,12 @@ class SolutionArray(SolutionArrayBase):
         phase = state.get("phase")  # Recreate Solution object from pickled state
 
         # Restore SolutionArray
+        arr = cls(phase)
         with _NamedTemporaryFile(suffix=".yaml", mode="w", encoding="utf-8",
                                  delete=False) as t_file:
             t_file.write(state["yaml_data"])
             temp_file = t_file.name
 
-        arr = cls(phase)
         try:
             arr.restore(temp_file, "solution_array")
         finally:

--- a/interfaces/cython/cantera/constants.pyx
+++ b/interfaces/cython/cantera/constants.pyx
@@ -6,10 +6,10 @@
 
 from .constants cimport *
 
-#: Avogadro's Number, /kmol
+#: Avogadro's constant, 1/kmol
 avogadro = CxxAvogadro
 
-#: The ideal gas constant in J/kmol-K
+#: The ideal gas constant in J/kmol/K
 gas_constant = CxxGasConstant
 
 #: One atmosphere in Pascals
@@ -21,7 +21,7 @@ boltzmann = CxxBoltzmann
 #: Planck constant (J/s)
 planck = CxxPlanck
 
-#: The Stefan-Boltzmann constant, W/m^2K^4
+#: The Stefan-Boltzmann constant, W/m²/K⁴
 stefan_boltzmann = CxxStefanBoltz
 
 #: The charge on an electron (C)
@@ -36,8 +36,8 @@ faraday = CxxFaraday
 #: Speed of Light (m/s).
 light_speed = CxxLightSpeed
 
-#: Permeability of free space :math:`\mu_0` in N/A^2.
+#: Permeability of free space :math:`\mu_0` in N/A².
 permeability_0 = CxxPermeability_0
 
-#: Permittivity of free space (Farads/m = C^2/N/m^2)
+#: Permittivity of free space (Farads/m = C²/N/m²)
 epsilon_0 = CxxEpsilon_0

--- a/interfaces/cython/cantera/cti2yaml.py
+++ b/interfaces/cython/cantera/cti2yaml.py
@@ -512,7 +512,7 @@ class gas_transport:
         :param dipole:
             The permanent dipole moment in Debye. Default: 0.0
         :param polar:
-            The polarizability in A^3. Default: 0.0
+            The polarizability in Å³. Default: 0.0
         :param rot_relax:
             The rotational relaxation collision number at 298 K. Dimensionless.
             Default: 0.0
@@ -520,10 +520,10 @@ class gas_transport:
             Pitzer's acentric factor.  Dimensionless.
             Default: 0.0
         :param disp_coeff:
-            The dispersion coefficient in A^5
+            The dispersion coefficient in Å⁵.
             Default: 0.0
         :param quad_polar:
-            The quadrupole polarizability
+            The quadrupole polarizability.
             Default: 0.0
         """
         self.geometry = geom

--- a/interfaces/cython/cantera/kinetics.pyx
+++ b/interfaces/cython/cantera/kinetics.pyx
@@ -302,24 +302,24 @@ cdef class Kinetics(_SolutionBase):
 
     property forward_rates_of_progress:
         """
-        Forward rates of progress for the reactions. [kmol/m^3/s] for bulk
-        phases or [kmol/m^2/s] for surface phases.
+        Forward rates of progress for the reactions. [kmol/m³/s] for bulk
+        phases or [kmol/m²/s] for surface phases.
         """
         def __get__(self):
             return get_reaction_array(self, kin_getFwdRatesOfProgress)
 
     property reverse_rates_of_progress:
         """
-        Reverse rates of progress for the reactions. [kmol/m^3/s] for bulk
-        phases or [kmol/m^2/s] for surface phases.
+        Reverse rates of progress for the reactions. [kmol/m³/s] for bulk
+        phases or [kmol/m²/s] for surface phases.
         """
         def __get__(self):
             return get_reaction_array(self, kin_getRevRatesOfProgress)
 
     property net_rates_of_progress:
         """
-        Net rates of progress for the reactions. [kmol/m^3/s] for bulk phases
-        or [kmol/m^2/s] for surface phases.
+        Net rates of progress for the reactions. [kmol/m³/s] for bulk phases
+        or [kmol/m²/s] for surface phases.
         """
         def __get__(self):
             return get_reaction_array(self, kin_getNetRatesOfProgress)
@@ -355,24 +355,24 @@ cdef class Kinetics(_SolutionBase):
 
     property creation_rates:
         """
-        Creation rates for each species. [kmol/m^3/s] for bulk phases or
-        [kmol/m^2/s] for surface phases.
+        Creation rates for each species. [kmol/m³/s] for bulk phases or
+        [kmol/m²/s] for surface phases.
         """
         def __get__(self):
             return get_species_array(self, kin_getCreationRates)
 
     property destruction_rates:
         """
-        Destruction rates for each species. [kmol/m^3/s] for bulk phases or
-        [kmol/m^2/s] for surface phases.
+        Destruction rates for each species. [kmol/m³/s] for bulk phases or
+        [kmol/m²/s] for surface phases.
         """
         def __get__(self):
             return get_species_array(self, kin_getDestructionRates)
 
     property net_production_rates:
         """
-        Net production rates for each species. [kmol/m^3/s] for bulk phases or
-        [kmol/m^2/s] for surface phases.
+        Net production rates for each species. [kmol/m³/s] for bulk phases or
+        [kmol/m²/s] for surface phases.
         """
         def __get__(self):
             return get_species_array(self, kin_getNetProductionRates)
@@ -893,7 +893,7 @@ cdef class Kinetics(_SolutionBase):
 
     property heat_release_rate:
         """
-        Get the total volumetric heat release rate [W/m^3].
+        Get the total volumetric heat release rate [W/m³].
         """
         def __get__(self):
             return - np.sum(self.partial_molar_enthalpies *
@@ -901,7 +901,7 @@ cdef class Kinetics(_SolutionBase):
 
     property heat_production_rates:
         """
-        Get the volumetric heat production rates [W/m^3] on a per-reaction
+        Get the volumetric heat production rates [W/m³] on a per-reaction
         basis. The sum over all reactions results in the total volumetric heat
         release rate.
         Example: C. K. Law: Combustion Physics (2006), Fig. 7.8.6
@@ -995,7 +995,7 @@ cdef class InterfaceKinetics(Kinetics):
         """
         The interface current is useful when charge transfer reactions occur at
         an interface. It is defined here as the net positive charge entering the
-        phase ``phase`` (Units: A/m^2 for a surface, A/m for an edge reaction).
+        phase ``phase`` (Units: A/m² for a surface, A/m for an edge reaction).
         """
         i_phase = self.phase_index(phase)
         return (<CxxInterfaceKinetics*>self.kinetics).interfaceCurrent(i_phase)

--- a/interfaces/cython/cantera/onedim.py
+++ b/interfaces/cython/cantera/onedim.py
@@ -291,7 +291,7 @@ class FlameBase(Sim1D):
     @property
     def L(self):
         """
-        Array containing the radial pressure gradient (1/r)(dP/dr) [N/m^4] at
+        Array containing the radial pressure gradient (1/r)(dP/dr) [N/m⁴] at
         each point. Note: This value is named 'lambda' in the C++ code.
         """
         return self.profile(self.flame, 'lambda')
@@ -566,7 +566,7 @@ for _attr in ['X', 'Y', 'concentrations', 'partial_molar_enthalpies',
 # Remove misleading examples and references to setters that don't exist
 FlameBase.X.__doc__ = "Array of mole fractions of size `n_species` x `n_points`"
 FlameBase.Y.__doc__ = "Array of mass fractions of size `n_species` x `n_points`"
-FlameBase.concentrations.__doc__ = ("Array of species concentrations [kmol/m^3]"
+FlameBase.concentrations.__doc__ = ("Array of species concentrations [kmol/m³]"
                                     " of size `n_species` x `n_points`")
 
 # Add properties with values for each reaction

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1009,7 +1009,7 @@ cdef class InterfaceRateBase(ArrheniusRateBase):
 
     property site_density:
         """
-        Site density [kmol/m^2]
+        Site density [kmol/m²].
 
         The site density is not an independent property, as it is set by an associated
         `InterfaceKinetics` object. Accordingly, the setter should be only used for

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -76,7 +76,7 @@ cdef class ReactorBase:
             return self._contents
 
     property volume:
-        """The volume [m^3] of the reactor."""
+        """The volume [m³] of the reactor."""
         def __get__(self):
             return self.rbase.volume()
 
@@ -89,7 +89,7 @@ cdef class ReactorBase:
             return self.thermo.T
 
     property density:
-        """The density [kg/m^3 or kmol/m^3] of the reactor's contents."""
+        """The density [kg/m³ or kmol/m³] of the reactor's contents."""
         def __get__(self):
             return self.thermo.density
 
@@ -482,7 +482,7 @@ cdef class FlowReactor(Reactor):
     @property
     def area(self):
         """
-        Get/set the area of the reactor [m^2].
+        Get/set the area of the reactor [m²].
 
         When the area is changed, the flow speed is scaled to keep the total mass flow
         rate constant.
@@ -543,7 +543,7 @@ cdef class FlowReactor(Reactor):
 
     @property
     def surface_area_to_volume_ratio(self):
-        """ Get/Set the surface area to volume ratio of the reactor [m^-1] """
+        """Get/Set the surface area to volume ratio of the reactor [1/m]"""
         return (<CxxFlowReactor*>self.reactor).surfaceAreaToVolumeRatio()
 
     @surface_area_to_volume_ratio.setter
@@ -674,7 +674,7 @@ cdef class ExtensibleReactor(Reactor):
     @property
     def expansion_rate(self):
         """
-        Get/Set the net rate of volume change (for example, from moving walls) [m^3/s]
+        Get/Set the net rate of volume change (for example, from moving walls) [m³/s]
 
         .. versionadded:: 3.0
         """
@@ -791,7 +791,7 @@ cdef class ReactorSurface(ReactorBase):
     :param r:
         The `Reactor` into which this surface should be installed.
     :param A:
-        The area of the reacting surface [m^2]
+        The area of the reacting surface [m²].
     :param node_attr:
         Attributes to be passed to the ``node`` method invoked to draw this surface.
         See https://graphviz.org/docs/nodes/ for a list of all usable attributes.
@@ -823,7 +823,7 @@ cdef class ReactorSurface(ReactorBase):
         self._reactor = r
 
     property area:
-        """ Area on which reactions can occur [m^2] """
+        """Area on which reactions can occur [m²]."""
         def __get__(self):
             return self.surface.area()
         def __set__(self, A):
@@ -974,14 +974,14 @@ cdef class WallBase(ConnectorNode):
             the type of the wall and *n* is an integer assigned in the order walls are
             detected.
         :param A:
-            Wall area [m^2]. Defaults to 1.0 m^2.
+            Wall area [m²]. Defaults to 1.0 m².
         :param K:
             Wall expansion rate parameter [m/s/Pa]. Defaults to 0.0.
         :param U:
-            Overall heat transfer coefficient [W/m^2/K]. Defaults to 0.0
+            Overall heat transfer coefficient [W/m²/K]. Defaults to 0.0
             (adiabatic wall).
         :param Q:
-            Heat flux function :math:`q_0(t)` [W/m^2]. Optional. Default:
+            Heat flux function :math:`q_0(t)` [W/m²]. Optional. Default:
             :math:`q_0(t) = 0.0`.
         :param velocity:
             Wall velocity function :math:`v_0(t)` [m/s].
@@ -1016,7 +1016,7 @@ cdef class WallBase(ConnectorNode):
         self._right_reactor = right
 
     property area:
-        """ The wall area [m^2]. """
+        """The wall area [m²]."""
         def __get__(self):
             return self.wall.area()
         def __set__(self, double value):
@@ -1043,7 +1043,7 @@ cdef class WallBase(ConnectorNode):
     @property
     def expansion_rate(self):
         """
-        Get the rate of volumetric change [m^3/s] associated with the wall at the
+        Get the rate of volumetric change [m³/s] associated with the wall at the
         current reactor network time. A positive value corresponds to the left-hand
         reactor volume increasing, and the right-hand reactor volume decreasing.
 
@@ -1143,7 +1143,7 @@ cdef class Wall(WallBase):
             (<CxxWall*>(self.wall)).setExpansionRateCoeff(val)
 
     property heat_transfer_coeff:
-        """the overall heat transfer coefficient [W/m^2/K]"""
+        """The overall heat transfer coefficient [W/m²/K]."""
         def __get__(self):
             return (<CxxWall*>(self.wall)).getHeatTransferCoeff()
         def __set__(self, double value):
@@ -1180,7 +1180,7 @@ cdef class Wall(WallBase):
     @property
     def heat_flux(self):
         """
-        Heat flux [W/m^2] across the wall. May be either set to a constant or
+        Heat flux [W/m²] across the wall. May be either set to a constant or
         an arbitrary function of time. See `Func1`.
 
         .. versionadded:: 3.0

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -29,6 +29,10 @@ cdef class _SolutionBase:
     def __cinit__(self, infile='', name='', adjacent=(), *, origin=None,
                   yaml=None, thermo=None, species=(),
                   kinetics=None, reactions=(), init=True, **kwargs):
+        if not isinstance(infile, (str, _PurePath)):
+            raise TypeError("Invalid object type: expected a 'str' or path object for "
+                            "parameter 'infile', but received "
+                            f"{type(infile).__name__!r}.")
 
         self._references = None
         # run instantiation only if valid sources are specified

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -496,6 +496,10 @@ cdef class SolutionArrayBase:
 
     def __cinit__(self, _SolutionBase phase, shape=(0,),
                   states=None, extra=None, meta=None, init=True):
+        if not isinstance(phase, _SolutionBase):
+            raise TypeError("Invalid object type: expected a '_SolutionBase' object, "
+                            f"but received {type(phase).__name__!r}.")
+
         size = np.prod(shape)
         cdef CxxAnyMap cxx_meta
         if meta is not None:

--- a/interfaces/cython/cantera/thermo.pyx
+++ b/interfaces/cython/cantera/thermo.pyx
@@ -708,7 +708,7 @@ cdef class ThermoPhase(_SolutionBase):
 
     property concentrations:
         """
-        Get/Set the species concentrations. Units are kmol/m^3 for bulk phases, kmol/m^2
+        Get/Set the species concentrations. Units are kmol/m³ for bulk phases, kmol/m²
         for surface phases, and kmol/m for edge phases.
         """
         def __get__(self):
@@ -1183,32 +1183,32 @@ cdef class ThermoPhase(_SolutionBase):
             return self.thermo.temperature()
 
     property density:
-        """Density [kg/m^3 or kmol/m^3] depending on `basis`."""
+        """Density [kg/m³ or kmol/m³] depending on `basis`."""
         def __get__(self):
             return self.thermo.density() / self._mass_factor()
 
     property density_mass:
-        """(Mass) density [kg/m^3]."""
+        """(Mass) density [kg/m³]."""
         def __get__(self):
             return self.thermo.density()
 
     property density_mole:
-        """Molar density [kmol/m^3]."""
+        """Molar density [kmol/m³]."""
         def __get__(self):
             return self.thermo.molarDensity()
 
     property v:
-        """Specific volume [m^3/kg or m^3/kmol] depending on `basis`."""
+        """Specific volume [m³/kg or m³/kmol] depending on `basis`."""
         def __get__(self):
             return self._mass_factor() / self.thermo.density()
 
     property volume_mass:
-        """Specific volume [m^3/kg]."""
+        """Specific volume [m³/kg]."""
         def __get__(self):
             return 1.0 / self.thermo.density()
 
     property volume_mole:
-        """Molar volume [m^3/kmol]."""
+        """Molar volume [m³/kmol]."""
         def __get__(self):
             return self.thermo.molarVolume()
 
@@ -1319,7 +1319,7 @@ cdef class ThermoPhase(_SolutionBase):
             return self.thermo.critPressure()
 
     property critical_density:
-        """Critical density [kg/m^3 or kmol/m^3] depending on `basis`."""
+        """Critical density [kg/m³ or kmol/m³] depending on `basis`."""
         def __get__(self):
             return self.thermo.critDensity() / self._mass_factor()
 
@@ -1368,7 +1368,7 @@ cdef class ThermoPhase(_SolutionBase):
             self.thermo.restoreState(len(state), &cstate[0])
 
     property TD:
-        """Get/Set temperature [K] and density [kg/m^3 or kmol/m^3]."""
+        """Get/Set temperature [K] and density [kg/m³ or kmol/m³]."""
         def __get__(self):
             return self.T, self.density
         def __set__(self, values):
@@ -1379,8 +1379,7 @@ cdef class ThermoPhase(_SolutionBase):
 
     property TDX:
         """
-        Get/Set temperature [K], density [kg/m^3 or kmol/m^3], and mole
-        fractions.
+        Get/Set temperature [K], density [kg/m³ or kmol/m³], and mole fractions.
         """
         def __get__(self):
             return self.T, self.density, self.X
@@ -1393,8 +1392,7 @@ cdef class ThermoPhase(_SolutionBase):
 
     property TDY:
         """
-        Get/Set temperature [K] and density [kg/m^3 or kmol/m^3], and mass
-        fractions.
+        Get/Set temperature [K] and density [kg/m³ or kmol/m³], and mass fractions.
         """
         def __get__(self):
             return self.T, self.density, self.Y
@@ -1439,8 +1437,7 @@ cdef class ThermoPhase(_SolutionBase):
 
     property UV:
         """
-        Get/Set internal energy [J/kg or J/kmol] and specific volume
-        [m^3/kg or m^3/kmol].
+        Get/Set internal energy [J/kg or J/kmol] and specific volume [m³/kg or m³/kmol].
         """
         def __get__(self):
             return self.u, self.v
@@ -1453,8 +1450,8 @@ cdef class ThermoPhase(_SolutionBase):
 
     property UVX:
         """
-        Get/Set internal energy [J/kg or J/kmol], specific volume
-        [m^3/kg or m^3/kmol], and mole fractions.
+        Get/Set internal energy [J/kg or J/kmol], specific volume [m³/kg or m³/kmol],
+        and mole fractions.
         """
         def __get__(self):
             return self.u, self.v, self.X
@@ -1468,8 +1465,8 @@ cdef class ThermoPhase(_SolutionBase):
 
     property UVY:
         """
-        Get/Set internal energy [J/kg or J/kmol], specific volume
-        [m^3/kg or m^3/kmol], and mass fractions.
+        Get/Set internal energy [J/kg or J/kmol], specific volume [m³/kg or m³/kmol],
+        and mass fractions.
         """
         def __get__(self):
             return self.u, self.v, self.Y
@@ -1482,7 +1479,7 @@ cdef class ThermoPhase(_SolutionBase):
                                     V / self._mass_factor())
 
     property DP:
-        """Get/Set density [kg/m^3] and pressure [Pa]."""
+        """Get/Set density [kg/m³] and pressure [Pa]."""
         def __get__(self):
             return self.density, self.P
         def __set__(self, values):
@@ -1492,7 +1489,7 @@ cdef class ThermoPhase(_SolutionBase):
             self.thermo.setState_DP(D*self._mass_factor(), P)
 
     property DPX:
-        """Get/Set density [kg/m^3], pressure [Pa], and mole fractions."""
+        """Get/Set density [kg/m³], pressure [Pa], and mole fractions."""
         def __get__(self):
             return self.density, self.P, self.X
         def __set__(self, values):
@@ -1503,7 +1500,7 @@ cdef class ThermoPhase(_SolutionBase):
             self.thermo.setState_DP(D*self._mass_factor(), P)
 
     property DPY:
-        """Get/Set density [kg/m^3], pressure [Pa], and mass fractions."""
+        """Get/Set density [kg/m³], pressure [Pa], and mass fractions."""
         def __get__(self):
             return self.density, self.P, self.Y
         def __set__(self, values):
@@ -1579,8 +1576,7 @@ cdef class ThermoPhase(_SolutionBase):
 
     property SV:
         """
-        Get/Set entropy [J/kg/K or J/kmol/K] and specific volume [m^3/kg or
-        m^3/kmol].
+        Get/Set entropy [J/kg/K or J/kmol/K] and specific volume [m³/kg or m³/kmol].
         """
         def __get__(self):
             return self.s, self.v
@@ -1593,8 +1589,8 @@ cdef class ThermoPhase(_SolutionBase):
 
     property SVX:
         """
-        Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
-        m^3/kmol], and mole fractions.
+        Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m³/kg or m³/kmol], and
+        mole fractions.
         """
         def __get__(self):
             return self.s, self.v, self.X
@@ -1608,8 +1604,8 @@ cdef class ThermoPhase(_SolutionBase):
 
     property SVY:
         """
-        Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
-        m^3/kmol], and mass fractions.
+        Get/Set entropy [J/kg/K or J/kmol/K], specific volume [m³/kg or m³/kmol], and
+        mass fractions.
         """
         def __get__(self):
             return self.s, self.v, self.Y
@@ -1656,7 +1652,7 @@ cdef class ThermoPhase(_SolutionBase):
             return self._getArray1(thermo_getPartialMolarCp)
 
     property partial_molar_volumes:
-        """Array of species partial molar volumes [m^3/kmol]."""
+        """Array of species partial molar volumes [m³/kmol]."""
         def __get__(self):
             return self._getArray1(thermo_getPartialMolarVolumes)
 
@@ -1980,7 +1976,7 @@ cdef class InterfacePhase(ThermoPhase):
 
     property site_density:
         """
-        Get/Set the site density. [kmol/m^2] for surface phases; [kmol/m] for
+        Get/Set the site density. [kmol/m²] for surface phases; [kmol/m] for
         edge phases.
         """
         def __get__(self):
@@ -2074,8 +2070,7 @@ cdef class PureFluid(ThermoPhase):
 
     property TV:
         """
-        Get/Set the temperature [K] and specific volume [m^3/kg] of
-        a PureFluid.
+        Get/Set the temperature [K] and specific volume [m³/kg] of a PureFluid.
         """
         def __get__(self):
             return self.T, self.v
@@ -2086,8 +2081,7 @@ cdef class PureFluid(ThermoPhase):
 
     property PV:
         """
-        Get/Set the pressure [Pa] and specific volume [m^3/kg] of
-        a PureFluid.
+        Get/Set the pressure [Pa] and specific volume [m³/kg] of a PureFluid.
         """
         def __get__(self):
             return self.P, self.v
@@ -2110,7 +2104,7 @@ cdef class PureFluid(ThermoPhase):
 
     property VH:
         """
-        Get/Set the specific volume [m^3/kg] and the specific
+        Get/Set the specific volume [m³/kg] and the specific
         enthalpy [J/kg] of a PureFluid.
         """
         def __get__(self):
@@ -2146,8 +2140,7 @@ cdef class PureFluid(ThermoPhase):
 
     property TDQ:
         """
-        Get the temperature [K], density [kg/m^3 or kmol/m^3], and vapor
-        fraction.
+        Get the temperature [K], density [kg/m³ or kmol/m³], and vapor fraction.
         """
         def __get__(self):
             return self.T, self.density, self.Q
@@ -2170,13 +2163,13 @@ cdef class PureFluid(ThermoPhase):
     property UVQ:
         """
         Get the internal energy [J/kg or J/kmol], specific volume
-        [m^3/kg or m^3/kmol], and vapor fraction.
+        [m³/kg or m³/kmol], and vapor fraction.
         """
         def __get__(self):
             return self.u, self.v, self.Q
 
     property DPQ:
-        """Get the density [kg/m^3], pressure [Pa], and vapor fraction."""
+        """Get the density [kg/m³], pressure [Pa], and vapor fraction."""
         def __get__(self):
             return self.density, self.P, self.Q
 
@@ -2196,8 +2189,8 @@ cdef class PureFluid(ThermoPhase):
 
     property SVQ:
         """
-        Get the entropy [J/kg/K or J/kmol/K], specific volume [m^3/kg or
-        m^3/kmol], and vapor fraction.
+        Get the entropy [J/kg/K or J/kmol/K], specific volume [m³/kg or
+        m³/kmol], and vapor fraction.
         """
         def __get__(self):
             return self.s, self.v, self.Q

--- a/interfaces/cython/cantera/transport.pyx
+++ b/interfaces/cython/cantera/transport.pyx
@@ -68,7 +68,7 @@ cdef class GasTransportData:
                             quadrupole_polarizability=0.0):
         """
         Set the parameters using "customary" units: diameter in Angstroms, well
-        depth in Kelvin, dipole in Debye, and polarizability in Angstroms^3.
+        depth in Kelvin, dipole in Debye, and polarizability in Angstroms³.
         These are the units used in in CK-style input files.
         """
         self.data.setCustomaryUnits(stringify(geometry), diameter, well_depth,
@@ -131,7 +131,7 @@ cdef class GasTransportData:
             self.data.dipole = dipole
 
     property polarizability:
-        """ Get/Set the polarizability of the molecule [m^3]. """
+        """Get/Set the polarizability of the molecule [m³]."""
         def __get__(self):
             return self.data.polarizability
         def __set__(self, polarizability):
@@ -149,21 +149,21 @@ cdef class GasTransportData:
             self.data.rotational_relaxation = rotational_relaxation
 
     property acentric_factor:
-        """ Get/Set Pitzer's acentric factor. [dimensionless] """
+        """Get/Set Pitzer's acentric factor [dimensionless]."""
         def __get__(self):
             return self.data.acentric_factor
         def __set__(self, acentric_factor):
             self.data.acentric_factor = acentric_factor
 
     property dispersion_coefficient:
-        """ Get/Set dispersion coefficient. [m^5] """
+        """Get/Set dispersion coefficient [m⁵]."""
         def __get__(self):
             return self.data.dispersion_coefficient
         def __set__(self, dispersion_coefficient):
             self.data.dispersion_coefficient = dispersion_coefficient
 
     property quadrupole_polarizability:
-        """ Get/Set quadrupole polarizability. [m^5] """
+        """Get/Set quadrupole polarizability [m⁵]."""
         def __get__(self):
             return self.data.quadrupole_polarizability
         def __set__(self, quadrupole_polarizability):
@@ -227,7 +227,7 @@ cdef class Transport(_SolutionBase):
 
     property mix_diff_coeffs:
         """
-        Mixture-averaged diffusion coefficients [m^2/s] relating the
+        Mixture-averaged diffusion coefficients [m²/s] relating the
         mass-averaged diffusive fluxes (with respect to the mass averaged
         velocity) to gradients in the species mole fractions.
         """
@@ -236,7 +236,7 @@ cdef class Transport(_SolutionBase):
 
     property mix_diff_coeffs_mass:
         """
-        Mixture-averaged diffusion coefficients [m^2/s] relating the
+        Mixture-averaged diffusion coefficients [m²/s] relating the
         diffusive mass fluxes to gradients in the species mass fractions.
         """
         def __get__(self):
@@ -244,7 +244,7 @@ cdef class Transport(_SolutionBase):
 
     property mix_diff_coeffs_mole:
         """
-        Mixture-averaged diffusion coefficients [m^2/s] relating the
+        Mixture-averaged diffusion coefficients [m²/s] relating the
         molar diffusive fluxes to gradients in the species mole fractions.
         """
         def __get__(self):
@@ -266,13 +266,13 @@ cdef class Transport(_SolutionBase):
             return get_transport_2d(self, tran_getMultiDiffCoeffs)
 
     property binary_diff_coeffs:
-        """Binary diffusion coefficients [m^2/s]."""
+        """Binary diffusion coefficients [m²/s]."""
         def __get__(self):
             return get_transport_2d(self, tran_getBinaryDiffCoeffs)
 
     property mobilities:
         """
-        Electrical mobilities of charged species [m^2/s-V]
+        Electrical mobilities of charged species [m²/s/V].
         """
         def __get__(self):
             return get_transport_1d(self, tran_getMobilities)
@@ -447,7 +447,7 @@ cdef class DustyGasTransport(Transport):
             (<CxxDustyGasTransport*>self.transport).setMeanParticleDiameter(value)
 
     property permeability:
-        """Permeability of the porous medium [m^2]."""
+        """Permeability of the porous medium [m²]."""
         def __set__(self, value):
             (<CxxDustyGasTransport*>self.transport).setPermeability(value)
 
@@ -463,7 +463,7 @@ cdef class DustyGasTransport(Transport):
 
     def molar_fluxes(self, T1, T2, rho1, rho2, Y1, Y2, delta):
         """
-        Get the molar fluxes [kmol/m^2/s], given the thermodynamic state at
+        Get the molar fluxes [kmol/m²/s], given the thermodynamic state at
         two nearby points.
 
         :param T1:
@@ -471,9 +471,9 @@ cdef class DustyGasTransport(Transport):
         :param T2:
             Temperature [K] at the second point
         :param rho1:
-            Density [kg/m^3] at the first point
+            Density [kg/m³] at the first point
         :param rho2:
-            Density [kg/m^3] at the second point
+            Density [kg/m³] at the second point
         :param Y1:
             Array of mass fractions at the first point. Length `n_species`.
         :param Y2:

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -26,6 +26,10 @@ class TestModels:
     def yml(self, yml_file):
         return load_yaml(yml_file)
 
+    def test_invalid(self):
+        with pytest.raises(TypeError):
+            ct.Solution(None)
+
     def test_load_thermo_models(self, yml, yml_file):
         for ph in yml['phases']:
             ph_name = ph['name']
@@ -246,6 +250,12 @@ class TestSolutionArray:
         assert (arr_trunc[:2].T == arr.T[ix:ix+2]).all()
         with pytest.raises(IndexError):
             arr_trunc[10]
+
+    def test_invalid(self):
+        with pytest.raises(TypeError):
+            ct.SolutionArray(None)
+        with pytest.raises(TypeError):
+            ct.SolutionArray("gri30.yaml")
 
     def test_from_state_numpy(self, gas):
         states = np.array([[list(gas.state)] * 5] * 3)

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -1914,8 +1914,9 @@ class TestQuantity:
 
 class TestMisc:
     def test_stringify_bad(self):
+        gas = ct.Solution("h2o2.yaml")
         with pytest.raises(AttributeError):
-            ct.Solution(3)
+            gas.add_species_alias("H2", 3)
 
     def test_case_sensitive_names(self):
         gas = ct.Solution('h2o2.yaml', transport_model=None)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Replace unicode superscripts in docstrings (in analogy to recent changes in C++ recommendations)
- Apply changes requested after #1964 was merged.
- Avoid creation of `Solution` and `SolutionArray` from `None` (the latter would have caused a hard crash)

As an aside: there could be an argument for typesetting units as math text, but that would result in a much larger scope/effort.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
