### PR TITLE
Update minimum CMake version in generated build scripts

### DIFF
--- a/doc/sphinx/userguide/compiling-cxx.md
+++ b/doc/sphinx/userguide/compiling-cxx.md
@@ -26,7 +26,7 @@ files). The configuration file for a CMake project is called `CMakeLists.txt`. A
 `CMakeLists.txt` file for compiling a program that uses Cantera might look like this:
 
 ```cmake
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.18...3.31)
 project (sample)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/include/cantera/zerodim.h
+++ b/include/cantera/zerodim.h
@@ -37,5 +37,6 @@
 
 // func1
 #include "cantera/numerics/Func1.h"
+#include "cantera/numerics/Func1Factory.h"
 
 #endif

--- a/samples/clib_generated/CMakeLists.txt.in
+++ b/samples/clib_generated/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.18...3.31)
 project (@tmpl_progname@)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/samples/clib_legacy/CMakeLists.txt.in
+++ b/samples/clib_legacy/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.18...3.31)
 project (@tmpl_progname@)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/samples/cxx/CMakeLists.txt.in
+++ b/samples/cxx/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.18...3.31)
 project (@tmpl_progname@)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)

--- a/samples/cxx/combustor/combustor.cpp
+++ b/samples/cxx/combustor/combustor.cpp
@@ -75,10 +75,10 @@ void runexample()
     double A = 0.1;
     double FWHM = 0.2;
     double t0 = 0.5;
-    Gaussian1 igniter_mdot(A, t0, FWHM);
+    shared_ptr<Func1> igniter_mdot = newFunc1("Gaussian", {A, t0, FWHM});
 
     MassFlowController m3(igniter, combustor);
-    m3.setTimeFunction(&igniter_mdot);
+    m3.setTimeFunction(igniter_mdot);
 
     // put a valve on the exhaust line to regulate the pressure
     Valve v(combustor, exhaust);

--- a/samples/f90/CMakeLists.txt.in
+++ b/samples/f90/CMakeLists.txt.in
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.18...3.31)
 project (@tmpl_progname@)
 
 set(CMAKE_VERBOSE_MAKEFILE ON)


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Update the minimum CMake version in generated `CMakeLists.txt` files. A minimum version of at least 3.5 is required to work with the current CMake version (3.31). I went higher than this for the sake of not having to update this for a good long while. 3.18 is the CMake version in Debian Bullseye, currently the "oldstable" release, so this shouldn't be much of a hurdle.
- Fix the use of a deprecated version of `MassFlowController.setTimeFunction` in `combustor.cpp`.

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

The first issue here is one of the problems currently preventing successful Conda package builds (see https://github.com/conda-forge/cantera-feedstock/pull/63).

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
