### PR TITLE
Fix installation path for generated clib sample

### DIFF
--- a/samples/clib_generated/SConscript
+++ b/samples/clib_generated/SConscript
@@ -53,11 +53,11 @@ for programName, sources in samples:
     localenv['tmpl_sourcename'] = programName + '.c'
 
     sconstruct = localenv.SubstFile('SConstruct', 'SConstruct.in')
-    install("$inst_sampledir/clib_generated", sconstruct)
+    install("$inst_sampledir/clib", sconstruct)
 
     # Generate CMakeLists.txt to be installed
     localenv['cmake_cantera_incdirs'] = ' '.join(quoted(x) for x in incdirs if x)
     localenv['cmake_cantera_libs'] = ' '.join(localenv['cantera_shared_libs'])
     localenv['cmake_cantera_libdirs'] = ' '.join(quoted(x) for x in libdirs if x)
     cmakelists = localenv.SubstFile('CMakeLists.txt', 'CMakeLists.txt.in')
-    install("$inst_sampledir/clib_generated", cmakelists)
+    install("$inst_sampledir/clib", cmakelists)


### PR DESCRIPTION
The source file and the build scripts should be installed to the same directory.

<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**If applicable, fill in the issue number this pull request is fixing**

Fixes another issue identified while updating the conda-forge recipe (https://github.com/conda-forge/cantera-feedstock/pull/63).

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
