### PR TITLE
advance limit handling to improve performance (#1453)

### DIFF
--- a/include/cantera/numerics/CVodesIntegrator.h
+++ b/include/cantera/numerics/CVodesIntegrator.h
@@ -81,6 +81,12 @@ public:
     //! Error message information provide by CVodes
     string m_error_message;
 
+    double currentTime() const override {
+        return m_time;
+    }
+
+    void setRootFunctionCount(size_t nroots) override;
+
 protected:
     //! Applies user-specified options to the underlying CVODES solver. Called
     //! during integrator initialization or reinitialization.
@@ -132,6 +138,7 @@ private:
     //! Indicates whether the sensitivities stored in m_yS have been updated
     //! for at the current integrator time.
     bool m_sens_ok = false;
+    size_t m_nRootFunctions = 0;
 };
 
 } // namespace

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -145,16 +145,18 @@ public:
     /**
      * Evaluate the event/root functions currently in play.
      * Integrators invoke this whenever root finding is enabled; implementations
-     * should fill `gout` with the function values and return 0 on success.
+     * should fill `gout` with the function values.
      * @param[in] t Time at which to evaluate the root functions
      * @param[in] y Current solution vector at time *t* of length neq()
      * @param[out] gout Array of length nRootFunctions() to be filled with the
      *      values of the root functions
-     * @returns 0 on success
      */
-    virtual int evalRootFunctions(double t, const double* y, double* gout) {
-        return 0;
-    }
+    virtual void evalRootFunctions(double t, const double* y, double* gout) { }
+
+    //! Wrapper for evalRootFunctions that converts exceptions to return codes.
+    //! @returns 0 for a successful evaluation, 1 after a potentially-
+    //!     recoverable error, or -1 after an unrecoverable error.
+    int evalRootFunctionsNoThrow(double t, const double* y, double* gout);
 
     //! Fill in the vector *y* with the current state of the system.
     //! Used for getting the initial state for ODE systems.

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -137,12 +137,15 @@ public:
      */
     int preconditioner_solve_nothrow(double* rhs, double* output);
 
-    //! Number of root functions used for event detection
+    //! Number of event/root functions exposed to the integrator (0 disables root finding)
     virtual size_t nRootFunctions() const {
         return 0;
     }
 
-    //! Evaluate root functions used for event detection
+    /** Evaluate the event/root functions currently in play.
+     * Integrators invoke this whenever root finding is enabled; implementations
+     * should fill `gout` with the function values and return 0 on success.
+     */
     virtual int evalRootFunctions(double t, const double* y, double* gout) {
         return 0;
     }

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -137,6 +137,16 @@ public:
      */
     int preconditioner_solve_nothrow(double* rhs, double* output);
 
+    //! Number of root functions used for event detection
+    virtual size_t nRootFunctions() const {
+        return 0;
+    }
+
+    //! Evaluate root functions used for event detection
+    virtual int evalRootFunctions(double t, const double* y, double* gout) {
+        return 0;
+    }
+
     //! Fill in the vector *y* with the current state of the system.
     //! Used for getting the initial state for ODE systems.
     virtual void getState(double* y) {

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -142,9 +142,15 @@ public:
         return 0;
     }
 
-    /** Evaluate the event/root functions currently in play.
+    /**
+     * Evaluate the event/root functions currently in play.
      * Integrators invoke this whenever root finding is enabled; implementations
      * should fill `gout` with the function values and return 0 on success.
+     * @param[in] t Time at which to evaluate the root functions
+     * @param[in] y Current solution vector at time *t* of length neq()
+     * @param[out] gout Array of length nRootFunctions() to be filled with the
+     *      values of the root functions
+     * @returns 0 on success
      */
     virtual int evalRootFunctions(double t, const double* y, double* gout) {
         return 0;

--- a/include/cantera/numerics/FuncEval.h
+++ b/include/cantera/numerics/FuncEval.h
@@ -137,7 +137,8 @@ public:
      */
     int preconditioner_solve_nothrow(double* rhs, double* output);
 
-    //! Number of event/root functions exposed to the integrator (0 disables root finding)
+    //! Number of event/root functions exposed to the integrator.
+    //! 0 indicates root finding is disabled.
     virtual size_t nRootFunctions() const {
         return 0;
     }

--- a/include/cantera/numerics/IdasIntegrator.h
+++ b/include/cantera/numerics/IdasIntegrator.h
@@ -82,6 +82,10 @@ public:
     }
     void includeAlgebraicInErrorTest(bool yesno) override;
 
+    double currentTime() const override {
+        return m_time;
+    }
+
     void setMethod(MethodType t) override;
 
 protected:

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -93,9 +93,7 @@ public:
      * ReactorNet enforces advance limits).
      * @param nroots Number of root functions
      */
-    virtual void setRootFunctionCount(size_t nroots) {
-        (void) nroots;
-    }
+    virtual void setRootFunctionCount([[maybe_unused]] size_t nroots) {}
 
     //! Current value of the independent variable tracked by the integrator
     virtual double currentTime() const = 0;

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -87,12 +87,17 @@ public:
         warn("setLinearSolverType");
     }
 
-    //! Configure the number of root functions evaluated by the integrator
+    //! Configure how many event/root functions the integrator should monitor
+    /*!
+     * Callers toggle this to enable/disable root finding on the fly (when
+       ReactorNet enforces advance limits).
+     * @param nroots Number of root functions
+     */
     virtual void setRootFunctionCount(size_t nroots) {
         (void) nroots;
     }
 
-    //! Current value of the independent variable represented by the integrator
+    //! Current value of the independent variable tracked by the integrator
     virtual double currentTime() const = 0;
 
     //! Set preconditioner used by the linear solver

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -87,10 +87,10 @@ public:
         warn("setLinearSolverType");
     }
 
-    //! Configure how many event/root functions the integrator should monitor
-    /*!
+    /** Configure how many event/root functions the integrator should monitor
+     *
      * Callers toggle this to enable/disable root finding on the fly (when
-       ReactorNet enforces advance limits).
+     * ReactorNet enforces advance limits).
      * @param nroots Number of root functions
      */
     virtual void setRootFunctionCount(size_t nroots) {

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -87,6 +87,14 @@ public:
         warn("setLinearSolverType");
     }
 
+    //! Configure the number of root functions evaluated by the integrator
+    virtual void setRootFunctionCount(size_t nroots) {
+        (void) nroots;
+    }
+
+    //! Current value of the independent variable represented by the integrator
+    virtual double currentTime() const = 0;
+
     //! Set preconditioner used by the linear solver
     /*!
      * @param preconditioner preconditioner object used for the linear solver

--- a/include/cantera/numerics/Integrator.h
+++ b/include/cantera/numerics/Integrator.h
@@ -87,8 +87,8 @@ public:
         warn("setLinearSolverType");
     }
 
-    /** Configure how many event/root functions the integrator should monitor
-     *
+    //! Configure how many event/root functions the integrator should monitor
+    /**
      * Callers toggle this to enable/disable root finding on the fly (when
      * ReactorNet enforces advance limits).
      * @param nroots Number of root functions

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -363,13 +363,19 @@ public:
     //! @param settings the settings map propagated to all reactors and kinetics objects
     virtual void setDerivativeSettings(AnyMap& settings);
 
-    //! Root function used by the integrator to detect advance limit crossings
-    //! during calls to advance(t, applylimit=True). Returns 0 on success.
-    //! The function evaluates gout[0] = 1 - max_i(|y[i]-y_base[i]|/limit[i]).
-    //! If advance limits are disabled or the limit check is inactive, gout[0]
-    //! is set to a positive value so that no root is detected.
+    //! Root finding is enabled only while enforcing advance limits
     size_t nRootFunctions() const override;
+
+    //! Relay the advance-limit root function to the integrator
     int evalRootFunctions(double t, const double* y, double* gout) override;
+
+    /** Root callback used to stop integration when an advance limit is reached
+     *
+     * When limit enforcement is active this evaluates
+     * `gout[0] = 1 - max_i(|y[i] - y_base[i]| / limit[i])`, so a zero signals that
+     * some component has reached its limit. If limits are inactive the method fills
+     * `gout[0]` with a positive value to prevent a false root. Returns 0 on success.
+     */
     int advanceLimitRootFunc(double t, const double* y, double* gout);
 
 protected:

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -368,6 +368,8 @@ public:
     //! The function evaluates gout[0] = 1 - max_i(|y[i]-y_base[i]|/limit[i]).
     //! If advance limits are disabled or the limit check is inactive, gout[0]
     //! is set to a positive value so that no root is detected.
+    size_t nRootFunctions() const override;
+    int evalRootFunctions(double t, const double* y, double* gout) override;
     int advanceLimitRootFunc(double t, const double* y, double* gout);
 
 protected:

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -366,9 +366,12 @@ public:
     //! Root finding is enabled only while enforcing advance limits
     size_t nRootFunctions() const override;
 
-    //! Evaluate the advance-limit root function used to stop integration once a limit is met.
-    //! When limits are active this sets `gout[0] = 1 - max_i(|y[i]-y_base[i]| / limit[i])`
-    //! so a zero indicates a component has reached its limit; otherwise gout[0] is positive.
+    //! Evaluate the advance-limit root function used to stop integration once a limit
+    //! is met.
+    //!
+    //! When limits are active, this sets `gout[0]` to
+    //! `1 - max_i(|y[i]-y_base[i]| / limit[i])` so a zero indicates a component has
+    //! reached its limit; otherwise `gout[0]` is positive.
     void evalRootFunctions(double t, const double* y, double* gout) override;
 
 protected:
@@ -434,13 +437,13 @@ protected:
     vector<double> m_ydot;
     vector<double> m_yest;
     vector<double> m_advancelimits;
-    //! Base state used for evaluating advance limits during a single advance
+    //! Base state used for evaluating advance limits during a single advance()
     //! call when root-finding is enabled
     vector<double> m_ybase;
-    //! Base time corresponding to m_ybase
+    //! Base time corresponding to #m_ybase
     double m_ybase_time = 0.0;
     //! Indicates whether the advance-limit root check is active for the
-    //! current call to advance(t, applylimit=True)
+    //! current call to `advance(t, applylimit=true)`
     bool m_limit_check_active = false;
     //! m_LHS is a vector representing the coefficients on the
     //! "left hand side" of each governing equation

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -366,17 +366,10 @@ public:
     //! Root finding is enabled only while enforcing advance limits
     size_t nRootFunctions() const override;
 
-    //! Relay the advance-limit root function to the integrator
+    //! Evaluate the advance-limit root function used to stop integration once a limit is met.
+    //! When limits are active this sets `gout[0] = 1 - max_i(|y[i]-y_base[i]| / limit[i])`
+    //! so a zero indicates a component has reached its limit; otherwise gout[0] is positive.
     int evalRootFunctions(double t, const double* y, double* gout) override;
-
-    /** Root callback used to stop integration when an advance limit is reached
-     *
-     * When limit enforcement is active this evaluates
-     * `gout[0] = 1 - max_i(|y[i] - y_base[i]| / limit[i])`, so a zero signals that
-     * some component has reached its limit. If limits are inactive the method fills
-     * `gout[0]` with a positive value to prevent a false root. Returns 0 on success.
-     */
-    int advanceLimitRootFunc(double t, const double* y, double* gout);
 
 protected:
     //! Add the reactor *r* to this reactor network.
@@ -400,7 +393,6 @@ protected:
     //! The function is intended for internal use by ReactorNet::advance
     //! and deliberately not exposed in external interfaces.
     virtual int lastOrder() const;
-
 
     vector<Reactor*> m_reactors;
     map<string, int> m_counts;  //!< Map used for default name generation

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -363,6 +363,13 @@ public:
     //! @param settings the settings map propagated to all reactors and kinetics objects
     virtual void setDerivativeSettings(AnyMap& settings);
 
+    //! Root function used by the integrator to detect advance limit crossings
+    //! during calls to advance(t, applylimit=True). Returns 0 on success.
+    //! The function evaluates gout[0] = 1 - max_i(|y[i]-y_base[i]|/limit[i]).
+    //! If advance limits are disabled or the limit check is inactive, gout[0]
+    //! is set to a positive value so that no root is detected.
+    int advanceLimitRootFunc(double t, const double* y, double* gout);
+
 protected:
     //! Add the reactor *r* to this reactor network.
     //! @since  Changed in %Cantera 3.2. Previous version used a reference.
@@ -385,6 +392,7 @@ protected:
     //! The function is intended for internal use by ReactorNet::advance
     //! and deliberately not exposed in external interfaces.
     virtual int lastOrder() const;
+
 
     vector<Reactor*> m_reactors;
     map<string, int> m_counts;  //!< Map used for default name generation
@@ -426,6 +434,14 @@ protected:
     vector<double> m_ydot;
     vector<double> m_yest;
     vector<double> m_advancelimits;
+    //! Base state used for evaluating advance limits during a single advance
+    //! call when root-finding is enabled
+    vector<double> m_ybase;
+    //! Base time corresponding to m_ybase
+    double m_ybase_time = 0.0;
+    //! Indicates whether the advance-limit root check is active for the
+    //! current call to advance(t, applylimit=True)
+    bool m_limit_check_active = false;
     //! m_LHS is a vector representing the coefficients on the
     //! "left hand side" of each governing equation
     vector<double> m_LHS;

--- a/include/cantera/zeroD/ReactorNet.h
+++ b/include/cantera/zeroD/ReactorNet.h
@@ -369,7 +369,7 @@ public:
     //! Evaluate the advance-limit root function used to stop integration once a limit is met.
     //! When limits are active this sets `gout[0] = 1 - max_i(|y[i]-y_base[i]| / limit[i])`
     //! so a zero indicates a component has reached its limit; otherwise gout[0] is positive.
-    int evalRootFunctions(double t, const double* y, double* gout) override;
+    void evalRootFunctions(double t, const double* y, double* gout) override;
 
 protected:
     //! Add the reactor *r* to this reactor network.

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -102,7 +102,7 @@ extern "C" {
     static int cvodes_root(sunrealtype t, N_Vector y, sunrealtype *gout, void *user_data)
     {
         auto* f = static_cast<FuncEval*>(user_data);
-        return f->evalRootFunctions(t, NV_DATA_S(y), gout);
+        return f->evalRootFunctionsNoThrow(t, NV_DATA_S(y), gout);
     }
 }
 

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -94,12 +94,13 @@ extern "C" {
     /**
      * SUNDIALS callback that forwards root evaluations to the FuncEval.
      * @param[in] t Current integration time at which roots are requested
-     * @param[in] y Solution vector provided by CVODE (length neq())
-     * @param[out] gout Output array that must be filled with nRootFunctions() values
+     * @param[in] y Solution vector provided by CVODE (length FuncEval::neq())
+     * @param[out] gout Output array that must be filled with FuncEval::nRootFunctions()
+     *     values
      * @param[in] user_data Opaque pointer (FuncEval*) supplied during integrator setup
      * @returns The result of FuncEval::evalRootFunctions (0 on success)
      */
-    static int cvodes_root(sunrealtype t, N_Vector y, sunrealtype *gout, void *user_data)
+    static int cvodes_root(sunrealtype t, N_Vector y, sunrealtype* gout, void* user_data)
     {
         auto* f = static_cast<FuncEval*>(user_data);
         return f->evalRootFunctionsNoThrow(t, NV_DATA_S(y), gout);
@@ -550,7 +551,8 @@ void CVodesIntegrator::integrate(double tout)
                 flag, m_error_message, f_errs, getErrorInfo(10));
         }
         if (flag == CV_ROOT_RETURN) {
-            // Stop early at root (e.g., advance limit reached); align tout to the root time
+            // Stop early at root (e.g., advance limit reached); align tout to the
+            // root time
             tout = m_tInteg;
             break;
         }

--- a/src/numerics/CVodesIntegrator.cpp
+++ b/src/numerics/CVodesIntegrator.cpp
@@ -92,7 +92,7 @@ extern "C" {
     }
 
     //! Sundials callback. Forwards root evaluations to the active FuncEval
-    static int cvodes_root(realtype t, N_Vector y, realtype *gout, void *user_data)
+    static int cvodes_root(sunrealtype t, N_Vector y, sunrealtype *gout, void *user_data)
     {
         auto* f = static_cast<FuncEval*>(user_data);
         if (!f) {
@@ -238,8 +238,8 @@ void CVodesIntegrator::setRootFunctionCount(size_t nroots)
         return;
     }
     // Register (or remove) the root callback; passing nullptr disables root finding
-    int flag = CVodeRootInit(m_cvode_mem, static_cast<int>(nroots),
-        nroots ? cvodes_root : nullptr);
+    CVRootFn root_cb = nroots ? &cvodes_root : nullptr;
+    int flag = CVodeRootInit(m_cvode_mem, static_cast<int>(nroots), root_cb);
     checkError(flag, "setRootFunctionCount", "CVodeRootInit");
 }
 

--- a/src/numerics/FuncEval.cpp
+++ b/src/numerics/FuncEval.cpp
@@ -143,4 +143,37 @@ int FuncEval::preconditioner_solve_nothrow(double* rhs, double* output)
     return 0; // successful evaluation
 }
 
+int FuncEval::evalRootFunctionsNoThrow(double t, const double* y, double* gout)
+{
+    try {
+        evalRootFunctions(t, y, gout);
+    } catch (CanteraError& err) {
+        if (suppressErrors()) {
+            m_errors.push_back(err.what());
+        } else {
+            writelog(err.what());
+        }
+        return 1; // possibly recoverable error
+    } catch (std::exception& err) {
+        if (suppressErrors()) {
+            m_errors.push_back(err.what());
+        } else {
+            writelog("FuncEval::evalRootFunctionsNoThrow: unhandled exception:\n");
+            writelog(err.what());
+            writelogendl();
+        }
+        return -1; // unrecoverable error
+    } catch (...) {
+        string msg = "FuncEval::evalRootFunctionsNoThrow: unhandled exception"
+            "  of unknown type\n";
+        if (suppressErrors()) {
+            m_errors.push_back(msg);
+        } else {
+            writelog(msg);
+        }
+        return -1; // unrecoverable error
+    }
+    return 0; // successful evaluation
+}
+
 }

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -397,7 +397,7 @@ size_t ReactorNet::nRootFunctions() const
     return (m_limit_check_active && hasAdvanceLimits()) ? 1 : 0;
 }
 
-int ReactorNet::evalRootFunctions(double t, const double* y, double* gout)
+void ReactorNet::evalRootFunctions(double t, const double* y, double* gout)
 {
     // Default: no root detected
     double g = 1.0;
@@ -424,7 +424,6 @@ int ReactorNet::evalRootFunctions(double t, const double* y, double* gout)
     }
 
     gout[0] = g;
-    return 0;
 }
 
 void ReactorNet::addReactor(Reactor& r)

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -248,16 +248,15 @@ double ReactorNet::advance(double time, bool applylimit)
         return time;
     }
 
-    // Enable root-based limit detection for this advance call
-    // Set the base state to the current state
+    // Enable root-based limit detection and set the base state to the current state
     m_ybase.assign(m_nv, 0.0);
     getState(m_ybase.data());
     m_ybase_time = m_time;
     m_limit_check_active = true;
     m_integ->setRootFunctionCount(nRootFunctions());
 
-    // Integrate toward the requested time; integrator will return early
-    // if a limit is reached (CV_ROOT_RETURN)
+    // Integrate toward the requested time; integrator will return early if a limit is
+    // reached (CV_ROOT_RETURN)
     try {
         m_integ->integrate(time);
     } catch (...) {
@@ -267,17 +266,16 @@ double ReactorNet::advance(double time, bool applylimit)
     }
     m_time = m_integ->currentTime();
 
-    // Update reactor states to match the integrator solution at the time
-    // reached (which may be earlier than 'time' if a limit was triggered)
+    // Update reactor states to match the integrator solution at the time reached
+    // (which may be earlier than 'time' if a limit was triggered)
     updateState(m_integ->solution());
 
     // Disable limit checking after this call
     m_limit_check_active = false;
     m_integ->setRootFunctionCount(nRootFunctions());
 
-    // Verbose logging analogous to prior predictive limiter: when a root event
-    // stopped integration before reaching the requested time, report the most
-    // limiting component and details about the step.
+    // When a root event stopped integration before reaching the requested time, report
+    // the most limiting component and details about the step.
     if (m_verbose && m_time < time) {
         // Ensure limits are available
         if (m_advancelimits.size() != m_nv) {

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -305,7 +305,8 @@ double ReactorNet::advance(double time, bool applylimit)
             double y_end = ycurr[jmax];
             double delta = y_end - y_start;
             writelog("    Advance limit triggered for component {:d} (dt = {:9.4g}):"
-                     " y_start = {:11.6g}, y_end = {:11.6g}, delta = {:11.6g}, limit = {:9.4g}\n",
+                     " y_start = {:11.6g}, y_end = {:11.6g},"
+                     " delta = {:11.6g}, limit = {:9.4g}\n",
                      jmax, dt, y_start, y_end, delta, best_limit);
         }
     }


### PR DESCRIPTION
This was just an attempt to try and resolve the issue discussed in #1453. This may be too invasive to be useful to the code base, but just wanted to open a pull request just in case.


Event-based limiter: Enforce advance limits with a CVODE root function so integration stops exactly when any component reaches its configured limit, preventing large overshoots between output points. Hooked via CVodeRootInit and handled CV_ROOT_RETURN.

Closes #1453 

<details>
<summary>First example case from #1453 </summary>

```
import cantera as ct
import matplotlib.pyplot as plt
gas = ct.Solution('gri30.yaml')

def integrate(limit=None):
    P0 = 10 * ct.one_atm
    T0 = 990
    X0 = 'CH4:1.0, O2:1.0, AR:5.0'
    gas.TPX = T0, P0, X0
    r1 = ct.IdealGasReactor(gas)
    net = ct.ReactorNet([r1])
    ix = net.global_component_index('CH4', 0)
    r1.set_advance_limit('CH4', limit)

    tEnd = 1.0
    tStep = 0.1
    nSteps = 0

    states = ct.SolutionArray(gas, extra=['t', 'steps'])
    t = tStep
    yp = net.get_state()[ix]
    steps_p = net.solver_stats['steps']
    dy_max = 0
    while t < tEnd:
        steps = net.solver_stats['steps']
        states.append(TPX=r1.thermo.TPX, t=net.time, steps=(steps-steps_p))
        steps_p = steps
        t_curr = net.advance(t)
        y = net.get_state()[ix]
        dy_max = max(dy_max, abs(y-yp))
        yp = y
        nSteps += 1
        if t_curr >= t:
            t += tStep

    print(f'case: {limit=}, {dy_max=}, {nSteps=}')
    return nSteps, states

n_baseline, states_baseline = integrate()
n_advance_coarse, states_coarse = integrate(0.005)
n_advance_fine, states_fine = integrate(0.001)

f, ax = plt.subplots(figsize=(5,3))
ax.plot(states_fine.t, states_fine('CH4').Y, '.-', label='fine')
ax.plot(states_coarse.t, states_coarse('CH4').Y, '.-', label='coarse')
ax.legend()
# Show plot on screen
plt.show()
```

</details>

The plot from that case using this updated approach is:

<img width="1352" height="509" alt="Figure_1" src="https://github.com/user-attachments/assets/5793afb8-d53c-401d-9b3f-93e02b01f60d" />


I also ran the case from the original issue report with the unit test parameters.

<details>
<summary>Click to view code example 1 </summary>

```
import cantera as ct
import matplotlib.pyplot as plt


gas = ct.Solution('h2o2.yaml')

def integrate(limit=None):
    P0 = 10 * ct.one_atm
    T0 = 1100
    X0 = 'H2:1.0, O2:0.5, AR:8.0'
    gas.TPX = T0, P0, X0
    r1 = ct.IdealGasReactor(gas)
    net = ct.ReactorNet([r1])
    ix = net.global_component_index('H2', 0)
    r1.set_advance_limit('H2', limit)

    # Unit test parameters
    tEnd = 0.01
    tStep = 1e-3
    nSteps = 0

    #tEnd = 0.01
    #tStep = 1.1e-4
    #nSteps = 0

    states = ct.SolutionArray(gas, extra=['t', 'steps'])
    t = tStep
    yp = net.get_state()[ix]
    steps_p = net.solver_stats['steps']
    dy_max = 0
    while t < tEnd:
        steps = net.solver_stats['steps']
        states.append(TPX=r1.thermo.TPX, t=net.time, steps=(steps-steps_p))
        steps_p = steps
        t_curr = net.advance(t)
        y = net.get_state()[ix]
        dy_max = max(dy_max, abs(y-yp))
        yp = y
        nSteps += 1
        if t_curr >= t:
            t += tStep

    print(f'case: {limit=}, {dy_max=}, {nSteps=}')
    return nSteps, states

n_baseline, states_baseline = integrate()
n_advance_coarse, states_coarse = integrate(0.01)
n_advance_fine, states_fine = integrate(0.001)

fig, axes = plt.subplots(
    nrows=4, ncols=1, figsize=(6, 10), sharex=True,
    gridspec_kw={'height_ratios': [2, 1, 1, 1], 'hspace': 0.25}
)
ax_main, ax_fine, ax_coarse, ax_baseline = axes

# Main plot: fine and coarse together
ax_main.plot(states_fine.t, states_fine('H2').Y, '-', color='orange', label='fine (line)')
ax_main.plot(states_fine.t, states_fine('H2').Y, '.', color='orange', label='fine (points)')
ax_main.plot(states_coarse.t, states_coarse('H2').Y, '--', color='blue', label='coarse (dashed)')
ax_main.plot(states_coarse.t, states_coarse('H2').Y, 'o', color='blue', label='coarse (points)')
ax_main.plot(states_baseline.t, states_baseline('H2').Y, '-', color='green', label='baseline')
ax_main.plot(states_baseline.t, states_baseline('H2').Y, '.', color='green')
ax_main.set_ylabel('Y(H2)')
ax_main.legend(loc='best')

# Subplot 1: fine only
ax_fine.plot(states_fine.t, states_fine('H2').Y, '-', color='orange', label='fine')
ax_fine.plot(states_fine.t, states_fine('H2').Y, '.', color='orange')
ax_fine.set_ylabel('Y(H2)')
ax_fine.legend(loc='best')

# Subplot 2: coarse only
ax_coarse.plot(states_coarse.t, states_coarse('H2').Y, '--', color='blue', label='coarse')
ax_coarse.plot(states_coarse.t, states_coarse('H2').Y, 'o', color='blue')
ax_coarse.set_ylabel('Y(H2)')
ax_coarse.legend(loc='best')

# Subplot 3: baseline only
ax_baseline.plot(states_baseline.t, states_baseline('H2').Y, '-', color='green', label='baseline')
ax_baseline.plot(states_baseline.t, states_baseline('H2').Y, '.', color='green')
ax_baseline.set_ylabel('Y(H2)')
ax_baseline.set_xlabel('time [s]')
ax_baseline.legend(loc='best')

plt.show()

```

</details>

This was using the  default values from the unit test
<img width="1061" height="974" alt="Figure_1" src="https://github.com/user-attachments/assets/a67efb07-d5a4-48e2-bfd5-3bd16bb5bf65" />


And this was using the tighter tolerance values from the issue discussion.

<img width="1532" height="723" alt="Figure_1" src="https://github.com/user-attachments/assets/badb45e2-9435-4c4e-a8ee-2e8a4089be28" />


```
case: limit=None, dy_max=0.00551594315108739, nSteps=90
case: limit=0.01, dy_max=0.00551594315108739, nSteps=90
case: limit=0.001, dy_max=0.0010000000000554895, nSteps=95
```



For reference, this is the behavior of the Cantera version (3.1.0) running the same script with the tighter tolerances.

<img width="1561" height="974" alt="Figure_1" src="https://github.com/user-attachments/assets/bc8c9d64-cdc3-4e8c-92a8-f4fd98337edc" />

```
case: limit=None, dy_max=0.0055159431511252995, nSteps=90
case: limit=0.01, dy_max=0.005365298679090868, nSteps=93
case: limit=0.001, dy_max=0.005365298679090868, nSteps=93
```





