### PR TITLE
Eliminate redundancy in Arrhenius / ArrheniusRate

### DIFF
--- a/interfaces/cython/cantera/reaction.pxd
+++ b/interfaces/cython/cantera/reaction.pxd
@@ -53,6 +53,7 @@ cdef extern from "cantera/kinetics/Arrhenius.h" namespace "Cantera":
     cdef cppclass CxxArrheniusRate "Cantera::ArrheniusRate" (CxxArrheniusBase):
         CxxArrheniusRate(double, double, double)
         CxxArrheniusRate(CxxAnyMap) except +translate_exception
+        CxxArrheniusRate(CxxArrheniusRate&) except +translate_exception
         double evalRate(double, double)
 
     cdef cppclass CxxBlowersMasel "Cantera::BlowersMasel" (CxxArrheniusBase):
@@ -301,7 +302,3 @@ cdef class Reaction:
 
 cdef class Arrhenius:
     cdef CxxArrheniusRate* base
-    cdef cbool own_rate
-    cdef Reaction reaction # parent reaction, to prevent garbage collection
-    @staticmethod
-    cdef wrap(CxxArrheniusRate*)

--- a/interfaces/cython/cantera/reaction.pyx
+++ b/interfaces/cython/cantera/reaction.pyx
@@ -1651,6 +1651,9 @@ cdef class Reaction:
         def __set__(self, rate):
             if isinstance(rate, ReactionRate):
                 self._rate = rate
+            elif isinstance(rate, Arrhenius):
+                self._rate = ArrheniusRate(rate.pre_exponential_factor,
+                    rate.temperature_exponent, rate.activation_energy)
             elif callable(rate):
                 self._rate = CustomRate(rate)
             else:

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -1333,6 +1333,13 @@ class TestElementaryReaction:
         gas.modify_reaction(2, R)
         assert A2*T**b2*np.exp(-Ta2/T) == approx(gas.forward_rate_constants[2])
 
+        A3 = 1.9 * A1
+        b3 = b1 + 0.3
+        Ta3 = Ta1 * 2.2
+        R.rate = ct.Arrhenius(A3, b3, Ta3 * ct.gas_constant)
+        gas.modify_reaction(2, R)
+        assert A3*T**b3*np.exp(-Ta3/T) == approx(gas.forward_rate_constants[2])
+
 class TestFalloffReaction:
 
     def test_negative_A_falloff(self):

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -1316,6 +1316,7 @@ class TestElementaryReaction:
         gas = ct.Solution(thermo='ideal-gas', kinetics='gas',
                           species=species, reactions=[r])
 
+    @pytest.mark.usefixtures("allow_deprecated")  # for class Arrhenius
     def test_modify_elementary(self, gas):
         gas = ct.Solution('h2o2.yaml', transport_model=None)
         gas.TPX = gas.TPX
@@ -1342,7 +1343,9 @@ class TestElementaryReaction:
 
 class TestFalloffReaction:
 
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_negative_A_falloff(self):
+        # TODO: After Cantera 3.2, replace Arrhenius with ArrheniusRate
         species = ct.Species.list_from_file("gri30.yaml")
         low_rate = ct.Arrhenius(2.16e13, -0.23, 0)
         high_rate = ct.Arrhenius(-8.16e12, -0.5, 0)
@@ -1358,15 +1361,15 @@ class TestFalloffReaction:
         with pytest.raises(ct.CanteraError, match='pre-exponential'):
             rate.low_rate = low_rate
 
-        rate.low_rate = ct.Arrhenius(-2.16e13, -0.23, 0)
+        rate.low_rate = ct.ArrheniusRate(-2.16e13, -0.23, 0)
         rxn = ct.Reaction("NH:1, NO:1", "N2O:1, H:1", rate)
         gas = ct.Solution(thermo='ideal-gas', kinetics='gas',
                           species=species, reactions=[rxn])
         assert gas.forward_rate_constants < 0
 
     def test_falloff(self, gas, species):
-        high_rate = ct.Arrhenius(7.4e10, -0.37, 0.0)
-        low_rate = ct.Arrhenius(2.3e12, -0.9, -1700 * 1000 * 4.184)
+        high_rate = ct.ArrheniusRate(7.4e10, -0.37, 0.0)
+        low_rate = ct.ArrheniusRate(2.3e12, -0.9, -1700 * 1000 * 4.184)
         tb = ct.ThirdBody(efficiencies={"AR":0.7, "H2":2.0, "H2O":6.0})
         r = ct.Reaction("OH:2", "H2O2:1",
                         ct.TroeRate(low_rate, high_rate, [0.7346, 94, 1756, 5182]),
@@ -1435,10 +1438,10 @@ class TestPlogReaction:
         species = ct.Species.list_from_file("pdep-test.yaml")
 
         rate = ct.PlogRate([
-            (0.01*ct.one_atm, ct.Arrhenius(1.2124e13, -0.5779, 10872.7*4184)),
-            (1.0*ct.one_atm, ct.Arrhenius(4.9108e28, -4.8507, 24772.8*4184)),
-            (10.0*ct.one_atm, ct.Arrhenius(1.2866e44, -9.0246, 39796.5*4184)),
-            (100.0*ct.one_atm, ct.Arrhenius(5.9632e53, -11.529, 52599.6*4184))
+            (0.01*ct.one_atm, ct.ArrheniusRate(1.2124e13, -0.5779, 10872.7*4184)),
+            (1.0*ct.one_atm, ct.ArrheniusRate(4.9108e28, -4.8507, 24772.8*4184)),
+            (10.0*ct.one_atm, ct.ArrheniusRate(1.2866e44, -9.0246, 39796.5*4184)),
+            (100.0*ct.one_atm, ct.ArrheniusRate(5.9632e53, -11.529, 52599.6*4184))
         ])
         r = ct.Reaction({"R1A":1, "R1B":1}, {"P1":1, "H":1}, rate)
 

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -457,9 +457,9 @@ class FalloffRateTests(ReactionRateTests):
     @pytest.fixture(scope='class', autouse=True)
     def setup_falloff_data(self):
         param = self._input["low-P-rate-constant"]
-        self._parts["low"] = ct.Arrhenius(param["A"], param["b"], param["Ea"])
+        self._parts["low"] = ct.ArrheniusRate(param["A"], param["b"], param["Ea"])
         param = self._input["high-P-rate-constant"]
-        self._parts["high"] = ct.Arrhenius(param["A"], param["b"], param["Ea"])
+        self._parts["high"] = ct.ArrheniusRate(param["A"], param["b"], param["Ea"])
 
     def eval(self, rate):
         concm = self.soln.third_body_concentrations[self._index]
@@ -625,7 +625,7 @@ class TestPlogRate(ReactionRateTests):
     @pytest.fixture(scope='function', autouse=True)
     def setup_plog_data(self):
         self._parts = {
-            "rates": [(rc["P"], ct.Arrhenius(rc["A"], rc["b"], rc["Ea"]))
+            "rates": [(rc["P"], ct.ArrheniusRate(rc["A"], rc["b"], rc["Ea"]))
                       for rc in self._input["rate-constants"]],
             }
 
@@ -648,6 +648,8 @@ class TestPlogRate(ReactionRateTests):
             assert rate.temperature_exponent == approx(other[index]["b"])
             assert rate.activation_energy == approx(other[index]["Ea"])
 
+    # TODO: After Cantera 3.2, replace Arrhenius with ArrheniusRate
+    @pytest.mark.usefixtures("allow_deprecated")
     def test_set_rates(self):
         # test setter for property rates
         other = [
@@ -1432,9 +1434,9 @@ class TestThreeBodyBlowersMasel(TestBlowersMasel):
 @pytest.fixture(scope='class')
 def setup_troe_tests(request, setup_reaction_tests):
     param = request.cls._rate["low_P_rate_constant"]
-    low = ct.Arrhenius(param["A"], param["b"], param["Ea"])
+    low = ct.ArrheniusRate(param["A"], param["b"], param["Ea"])
     param = request.cls._rate["high_P_rate_constant"]
-    high = ct.Arrhenius(param["A"], param["b"], param["Ea"])
+    high = ct.ArrheniusRate(param["A"], param["b"], param["Ea"])
     param = request.cls._rate["Troe"]
     data = [param["A"], param["T3"], param["T1"], param["T2"]]
     request.cls._rate_obj = ct.TroeRate(low=low, high=high, falloff_coeffs=data)
@@ -1472,9 +1474,9 @@ class TestTroe(ReactionTests):
 @pytest.fixture(scope='class')
 def setup_lindemann_tests(request, setup_reaction_tests):
     param = request.cls._rate["low_P_rate_constant"]
-    low = ct.Arrhenius(param["A"], param["b"], param["Ea"])
+    low = ct.ArrheniusRate(param["A"], param["b"], param["Ea"])
     param = request.cls._rate["high_P_rate_constant"]
-    high = ct.Arrhenius(param["A"], param["b"], param["Ea"])
+    high = ct.ArrheniusRate(param["A"], param["b"], param["Ea"])
     request.cls._rate_obj = ct.LindemannRate(low=low, high=high, falloff_coeffs=[])
 
 @pytest.mark.usefixtures("setup_lindemann_tests")
@@ -1509,9 +1511,9 @@ class TestLindemann(ReactionTests):
 @pytest.fixture(scope='class')
 def setup_chemically_activated_tests(request, setup_reaction_tests):
     param = request.cls._rate["low_P_rate_constant"]
-    low = ct.Arrhenius(param["A"], param["b"], param["Ea"])
+    low = ct.ArrheniusRate(param["A"], param["b"], param["Ea"])
     param = request.cls._rate["high_P_rate_constant"]
-    high = ct.Arrhenius(param["A"], param["b"], param["Ea"])
+    high = ct.ArrheniusRate(param["A"], param["b"], param["Ea"])
     request.cls._rate_obj = ct.LindemannRate(low=low, high=high, falloff_coeffs=[])
     request.cls._rate_obj.chemically_activated = True
 


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Fix setting the `rate` member of a `Reaction` object to work with `Arrhenius` objects
- Deprecate  the Python `Arrhenius` class in favor of `ArrheniusRate`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Closes #1870

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
