### PR TITLE
Fix introspection of key names in AnyMap generated from Python

### DIFF
--- a/interfaces/cython/cantera/_utils.pxd
+++ b/interfaces/cython/cantera/_utils.pxd
@@ -56,6 +56,7 @@ cdef extern from "cantera/base/AnyMap.h" namespace "Cantera":
         void setQuantity(vector[double]&, string&) except +translate_exception
         void setQuantity(double, CxxUnits&) except +translate_exception
         T& asType "as" [T]() except +translate_exception
+        void setKey(string)
         vector[T]& asVector[T]() except +translate_exception
         string type_str()
         cbool empty()

--- a/interfaces/cython/cantera/_utils.pyx
+++ b/interfaces/cython/cantera/_utils.pyx
@@ -387,6 +387,8 @@ cdef get_types(item):
 
 cdef CxxAnyValue python_to_anyvalue(item, name=None) except *:
     cdef CxxAnyValue v
+    if name is not None:
+        v.setKey(stringify(name))
     if isinstance(item, dict):
         v = py_to_anymap(item)
     elif isinstance(item, (list, tuple, set, np.ndarray)):

--- a/test/python/test_transport.py
+++ b/test/python/test_transport.py
@@ -415,6 +415,21 @@ def test_bad_transport_input(key, value, message):
     with pytest.raises(ct.CanteraError, match=message):
         ct.Species.list_from_yaml(species_data)
 
+
+def test_bad_transport_from_dict():
+    H2 = ct.Species.list_from_file("h2o2.yaml")[0]
+    spec = H2.input_data
+
+    spec["transport"]["well-depth"] = "three"
+    with pytest.raises(ct.CanteraError, match="Key 'well-depth' contains a 'string'"):
+        ct.Species.from_dict(spec)
+
+    spec["transport"]["well-depth"] = None
+    with pytest.raises(ct.CanteraError,
+                       match="Key 'well-depth' not found or contains no value"):
+        ct.Species.from_dict(spec)
+
+
 @pytest.mark.parametrize(
     "model",
     [


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Attach key names to `AnyValue` objects when building an `AnyMap` object from a Python `dict`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

- Closes #1925

**If applicable, provide an example illustrating new features this pull request is introducing**

The example from #1925 now produces the following exception:
```
cantera._utils.CanteraError: 
*******************************************************************************
InputFileError thrown by AnyValue::as:
Key 'well-depth' not found or contains no value
-------------------------------------------------------------------------------
```

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
