### PR TITLE
Deprecate legacy convenience headers 

### DIFF
--- a/doc/sphinx/userguide/cxx-tutorial.md
+++ b/doc/sphinx/userguide/cxx-tutorial.md
@@ -65,15 +65,27 @@ calculations. The headers and their functions are:
 
 `thermo.h`
 : Base thermodynamic classes and functions for creating {ct}`ThermoPhase` objects from
-  input files *(Superseded by `core.h` in Cantera 3.0)*.
+  input files.
+  :::{deprecated} 3.2
+  Superseded by `core.h` in Cantera 3.0, deprecated in Cantera 3.2, and to be removed in
+  Cantera 3.3.
+  :::
 
 `kinetics.h`
 : Base kinetics classes and functions for creating {ct}`Kinetics` objects from input
-  files *(Superseded by `core.h` in Cantera 3.0)*.
+  files.
+  :::{deprecated} 3.2
+  Superseded by `core.h` in Cantera 3.0, deprecated in Cantera 3.2, and to be removed in
+  Cantera 3.3.
+  :::
 
 `transport.h`
 : Base transport property classes and functions for creating {ct}`Transport` objects
-  from input files *(Superseded by `core.h` in Cantera 3.0)*.
+  from input files.
+  :::{deprecated} 3.2
+  Superseded by `core.h` in Cantera 3.0, deprecated in Cantera 3.2, and to be removed in
+  Cantera 3.3.
+  :::
 
 ### Creating a `Solution` object from an input file
 

--- a/include/cantera/core.h
+++ b/include/cantera/core.h
@@ -12,7 +12,9 @@
 #include "cantera/base/Solution.h"
 #include "cantera/base/Interface.h"
 #include "cantera/thermo/ThermoPhase.h"
+#include "cantera/thermo/Species.h"
 #include "cantera/kinetics/Kinetics.h"
+#include "cantera/kinetics/Reaction.h"
 #include "cantera/transport/Transport.h"
 
 #endif

--- a/include/cantera/kinetics.h
+++ b/include/cantera/kinetics.h
@@ -9,6 +9,9 @@
 #ifndef CXX_INCL_KINETICS
 #define CXX_INCL_KINETICS
 
+#pragma message("warning: kinetics.h is deprecated and will be removed after " \
+                "Cantera 3.2. Use core.h and/or kinetics/KineticsFactory.h instead.")
+
 #include "kinetics/Kinetics.h"
 #include "kinetics/Reaction.h"
 #include "kinetics/KineticsFactory.h"

--- a/include/cantera/thermo.h
+++ b/include/cantera/thermo.h
@@ -9,6 +9,9 @@
 #ifndef CT_THERMO_INCL
 #define CT_THERMO_INCL
 
+#pragma message("warning: thermo.h is deprecated and will be removed after " \
+                "Cantera 3.2. Use core.h and/or thermo/ThermoFactory.h instead.")
+
 #include "thermo/ThermoPhase.h"
 #include "thermo/Species.h"
 #include "thermo/ThermoFactory.h"

--- a/include/cantera/transport.h
+++ b/include/cantera/transport.h
@@ -9,6 +9,9 @@
 #ifndef CT_TRANSPORT_INCL
 #define CT_TRANSPORT_INCL
 
+#pragma message("warning: transport.h is deprecated and will be removed after " \
+                "Cantera 3.2. Use core.h and/or transport/TransportFactory.h instead.")
+
 #include "transport/TransportFactory.h"
 
 #endif

--- a/test/general/test_serialization.cpp
+++ b/test/general/test_serialization.cpp
@@ -2,11 +2,11 @@
 // at https://cantera.org/license.txt for license and copyright information.
 
 #include "gtest/gtest.h"
+#include "cantera/core.h"
 #include "cantera/base/YamlWriter.h"
-#include "cantera/thermo.h"
-#include "cantera/thermo/SurfPhase.h"
-#include "cantera/base/Solution.h"
-#include "cantera/kinetics.h"
+#include "cantera/thermo/ThermoFactory.h"
+#include "cantera/kinetics/Reaction.h"
+#include "cantera/kinetics/KineticsFactory.h"
 #include "cantera/transport/TransportData.h"
 #include "cantera/base/Storage.h"
 #include <fstream>

--- a/test/kinetics/rates.cpp
+++ b/test/kinetics/rates.cpp
@@ -1,10 +1,7 @@
 #include "gtest/gtest.h"
-#include "cantera/thermo.h"
-#include "cantera/kinetics.h"
+#include "cantera/core.h"
 #include "cantera/thermo/ThermoFactory.h"
-#include "cantera/thermo/IdealGasPhase.h"
-#include "cantera/base/Solution.h"
-#include "cantera/base/Interface.h"
+#include "cantera/kinetics/KineticsFactory.h"
 
 namespace Cantera
 {

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -1,8 +1,5 @@
 #include "gtest/gtest.h"
-#include "cantera/thermo.h"
-#include "cantera/kinetics.h"
 #include "cantera/zerodim.h"
-#include "cantera/base/Interface.h"
 #include "cantera/numerics/eigen_sparse.h"
 #include "cantera/numerics/SystemJacobianFactory.h"
 #include "cantera/numerics/AdaptivePreconditioner.h"

--- a/test_problems/CpJump/CpJump.cpp
+++ b/test_problems/CpJump/CpJump.cpp
@@ -4,8 +4,7 @@
 // This test checks the algorithm used in setState_HP() to make sure that it is
 // tolerant of (small) jumps in the value of H or Cp at temperature boundaries.
 
-#include "cantera/thermo.h"
-#include "cantera/base/Solution.h"
+#include "cantera/core.h"
 
 #include <iostream>
 

--- a/test_problems/VCSnonideal/LatticeSolid_LiSi/latsol.cpp
+++ b/test_problems/VCSnonideal/LatticeSolid_LiSi/latsol.cpp
@@ -1,10 +1,10 @@
-#include "cantera/thermo.h"
+#include "cantera/thermo/Species.h"
+#include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/MargulesVPSSTP.h"
-#include "cantera/thermo/LatticeSolidPhase.h"
 #include "cantera/thermo/ConstCpPoly.h"
 #include "cantera/equil/vcs_MultiPhaseEquil.h"
 
-#include <stdio.h>
+#include <iostream>
 
 using namespace Cantera;
 

--- a/test_problems/cathermo/HMW_graph_CpvT/HMW_graph_CpvT.cpp
+++ b/test_problems/cathermo/HMW_graph_CpvT/HMW_graph_CpvT.cpp
@@ -2,10 +2,10 @@
  *  @file HMW_graph_1.cpp
  */
 
-#include "TemperatureTable.h"
-
-#include "cantera/thermo.h"
+#include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/HMWSoln.h"
+
+#include "TemperatureTable.h"
 
 #include <cstdio>
 

--- a/test_problems/cathermo/HMW_graph_GvT/HMW_graph_GvT.cpp
+++ b/test_problems/cathermo/HMW_graph_GvT/HMW_graph_GvT.cpp
@@ -3,8 +3,7 @@
  *  @file HMW_graph_1.cpp
  */
 
-#include "cantera/thermo/ThermoPhase.h"
-#include "cantera/thermo.h"
+#include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/HMWSoln.h"
 
 #include "TemperatureTable.h"
@@ -30,7 +29,7 @@ int main(int argc, char** argv)
          */
         string nacl_s = "NaCl_Solid.yaml";
         string id = "NaCl(S)";
-        auto solid = Cantera::newThermo(nacl_s, id);
+        auto solid = newThermo(nacl_s, id);
 
         size_t nsp = HMW->nSpecies();
         double acMol[100];

--- a/test_problems/cathermo/HMW_graph_HvT/HMW_graph_HvT.cpp
+++ b/test_problems/cathermo/HMW_graph_HvT/HMW_graph_HvT.cpp
@@ -2,7 +2,7 @@
  *  @file HMW_graph_1.cpp
  */
 
-#include "cantera/thermo.h"
+#include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/HMWSoln.h"
 
 #include "TemperatureTable.h"

--- a/test_problems/cathermo/HMW_graph_VvT/HMW_graph_VvT.cpp
+++ b/test_problems/cathermo/HMW_graph_VvT/HMW_graph_VvT.cpp
@@ -2,9 +2,10 @@
  *  @file HMW_graph_VvT
  */
 
-#include "cantera/thermo.h"
-#include "TemperatureTable.h"
+#include "cantera/thermo/ThermoFactory.h"
 #include "cantera/thermo/HMWSoln.h"
+
+#include "TemperatureTable.h"
 
 #include <cstdio>
 

--- a/test_problems/diamondSurf/runDiamond.cpp
+++ b/test_problems/diamondSurf/runDiamond.cpp
@@ -2,9 +2,9 @@
  *  @file runDiamond.cpp
  */
 
-#include "cantera/thermo.h"
-#include "cantera/kinetics.h"
-#include "cantera/kinetics/InterfaceKinetics.h"
+#include "cantera/core.h"
+#include "cantera/thermo/ThermoFactory.h"
+#include "cantera/kinetics/KineticsFactory.h"
 #include <iostream>
 
 using namespace std;

--- a/test_problems/dustyGasTransport/dustyGasTransportTest.cpp
+++ b/test_problems/dustyGasTransport/dustyGasTransportTest.cpp
@@ -1,7 +1,6 @@
-#include "cantera/thermo.h"
-#include "cantera/transport.h"
+#include "cantera/thermo/ThermoFactory.h"
+#include "cantera/transport/TransportFactory.h"
 #include "cantera/transport/DustyGasTransport.h"
-#include "cantera/base/utilities.h"
 #include <cstdio>
 
 using namespace std;

--- a/test_problems/pureFluidTest/testPureWater.cpp
+++ b/test_problems/pureFluidTest/testPureWater.cpp
@@ -1,5 +1,4 @@
-#include "cantera/thermo/PureFluidPhase.h"
-#include "cantera/thermo.h"
+#include "cantera/thermo/ThermoFactory.h"
 #include <cstdio>
 
 using namespace std;

--- a/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
+++ b/test_problems/stoichSolidKinetics/stoichSolidKinetics.cpp
@@ -1,7 +1,4 @@
-#include "cantera/thermo.h"
-#include "cantera/kinetics.h"
-#include "cantera/kinetics/InterfaceKinetics.h"
-#include "cantera/base/Interface.h"
+#include "cantera/core.h"
 
 #include <iomanip>
 #include <sstream>

--- a/test_problems/surfSolverTest/surfaceSolver.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver.cpp
@@ -6,14 +6,9 @@
 // This file is part of Cantera. See License.txt in the top-level directory or
 // at https://cantera.org/license.txt for license and copyright information.
 
-#include "cantera/base/Interface.h"
-#include "cantera/thermo/SurfPhase.h"
-#include "cantera/kinetics.h"
-#include "cantera/kinetics/ImplicitSurfChem.h"
-#include "cantera/kinetics/InterfaceKinetics.h"
-#include "cantera/kinetics/solveSP.h"
-#include "cantera/base/fmt.h"
-#include <cstdio>
+#include "cantera/core.h"
+
+#include <iostream>
 #include <fstream>
 
 using namespace std;

--- a/test_problems/surfSolverTest/surfaceSolver2.cpp
+++ b/test_problems/surfSolverTest/surfaceSolver2.cpp
@@ -9,12 +9,10 @@
 #define MSSIZE 200
 
 #include "cantera/thermo/ThermoFactory.h"
-#include "cantera/kinetics.h"
+#include "cantera/kinetics/KineticsFactory.h"
 #include "cantera/kinetics/ImplicitSurfChem.h"
-#include "cantera/kinetics/InterfaceKinetics.h"
-#include "cantera/kinetics/solveSP.h"
-#include "cantera/base/fmt.h"
-#include <cstdio>
+
+#include <iostream>
 #include <fstream>
 
 using namespace std;


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

The convenience headers `thermo.h`, `kinetics.h` and `transport.h` have been marked as 'superseded by `core.h`' since Cantera 3.0. This PR deprecates them with Cantera 3.2.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
