### PR TITLE
Fix lxcat2yaml.py for empty product case

### DIFF
--- a/test/data/lxcat-test-convert-species.yaml
+++ b/test/data/lxcat-test-convert-species.yaml
@@ -1,0 +1,23 @@
+description: |-
+  This file is for testing purpose. The species data is needed to construct the
+  reactions in the generated list of the plasma collision reactions from the lxcat file.
+  Reactions which contains species not in the species list will be ignored.
+
+units: {length: cm, quantity: molec, activation-energy: K}
+
+phases:
+- name: isotropic-electron-energy-plasma
+  thermo: plasma
+  elements: [O, C, E]
+  species:
+  - nasa_gas.yaml/species: [O2, O2-, CO2]
+  - lxcat-test-convert.yaml/species: [E, O2(Total-Ionization)+]
+
+  kinetics: gas
+  reactions: none
+  transport: Ion
+  electron-energy-distribution:
+    type: isotropic
+    shape-factor: 2.0
+    mean-electron-energy: 1.0 eV
+    energy-levels: [0.0, 0.1, 1.0, 10.0]

--- a/test/data/lxcat-test-convert.xml
+++ b/test/data/lxcat-test-convert.xml
@@ -4,6 +4,17 @@
     <groups>
       <group id="CO2">
         <processes>
+          <process collisionType="elastic">
+            <reactants>
+              <electron/>
+              <molecule>CO2</molecule>
+            </reactants>
+            <parameters>
+              <parameter name="mM">1.240000e-5</parameter>
+            </parameters>
+            <data_x type="energy" units="eV">0.0 1.0</data_x>
+            <data_y type="cross_section" units="m2">0.0 1.0e-22</data_y>
+          </process>
           <!-- The electron energy starts from a value larger than the threshold-->
           <process collisionType="inelastic" inelasticType="ionization">
             <reactants>

--- a/test/python/test_convert.py
+++ b/test/python/test_convert.py
@@ -1736,10 +1736,10 @@ class Testlxcat2yaml:
                      database="test", insert=False,
                      output=outfile)
 
-        # get Solution from the mechanism file
+        # get Solution from the input file
         phase = "isotropic-electron-energy-plasma"
-        mechFile = "lxcat-test-convert.yaml"
-        gas = ct.Solution(self.test_data_path / mechFile,
+        inputFile = "lxcat-test-convert-species.yaml"
+        gas = ct.Solution(self.test_data_path / inputFile,
                            phase=phase, transport_model=None)
 
         # add collisions to the reaction list
@@ -1747,13 +1747,18 @@ class Testlxcat2yaml:
                                               gas, section="collisions")
 
         # verify the data
-        assert len(rxn_list) == 2
-        assert rxn_list[0].equation == "O2 + e => O2(Total-Ionization)+ + 2 e"
+        assert len(rxn_list) == 3
+        assert rxn_list[0].equation == "CO2 + e => CO2 + e"
         assert rxn_list[0].reaction_type == "electron-collision-plasma"
-        assert rxn_list[0].rate.energy_levels == approx([15., 20.])
-        assert rxn_list[0].rate.cross_sections == approx([0.0, 5.5e-22])
+        assert rxn_list[0].rate.energy_levels == approx([0.0, 1.0])
+        assert rxn_list[0].rate.cross_sections == approx([0.0, 1.0e-22])
 
-        assert rxn_list[1].equation == "O2 + e => O2-"
+        assert rxn_list[1].equation == "O2 + e => O2(Total-Ionization)+ + 2 e"
         assert rxn_list[1].reaction_type == "electron-collision-plasma"
-        assert rxn_list[1].rate.energy_levels == approx([0.0, 1.0])
-        assert rxn_list[1].rate.cross_sections == approx([0.0, 1.0e-22])
+        assert rxn_list[1].rate.energy_levels == approx([15., 20.])
+        assert rxn_list[1].rate.cross_sections == approx([0.0, 5.5e-22])
+
+        assert rxn_list[2].equation == "O2 + e => O2-"
+        assert rxn_list[2].reaction_type == "electron-collision-plasma"
+        assert rxn_list[2].rate.energy_levels == approx([0.0, 1.0])
+        assert rxn_list[2].rate.cross_sections == approx([0.0, 1.0e-22])


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Issue: lxcat2yaml.py can throw error if a collision process has no product (the xml file has no products node). This is  usually for elastic collision. For example, O2 + e -> O2 + e
Solution: Use the reactant as the product to complete the reaction equation.


**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
