### PR TITLE
Adding another readable unit m^3

### DIFF
--- a/doc/sphinx/install/pip.md
+++ b/doc/sphinx/install/pip.md
@@ -120,7 +120,7 @@ You should get the following output:
 
       temperature   300 K
          pressure   1.0133e+05 Pa
-          density   0.081894 kg/m^3
+          density   0.081894 kg/m³
  mean mol. weight   2.016 kg/kmol
   phase of matter   gas
 

--- a/doc/sphinx/userguide/creating-mechanisms.md
+++ b/doc/sphinx/userguide/creating-mechanisms.md
@@ -381,7 +381,7 @@ phases:
 - name: my-other-phase
   ...
   state:
-    density: 100 kg/m^3
+    density: 100 kg/m³
     T: 298
     Y:
       CH4: 0.2

--- a/doc/sphinx/userguide/input-tutorial.md
+++ b/doc/sphinx/userguide/input-tutorial.md
@@ -178,7 +178,7 @@ that is required is to write the units after the value, separated by a space:
 pressure: 1.0e5  # default is Pascals
 pressure: 1.0 bar  # this is equivalent
 density: 4.0 g/cm^3
-density: 4000.0  # kg/m^3
+density: 4000.0  # kg/m³
 ```
 
 Compound unit strings may be used, as long as a few rules are followed:
@@ -213,7 +213,7 @@ mappings:
 units: {length: cm, mass: kg}
 section1:
   units: {length: m}
-  density: 4000  # interpreted as 4000 kg/m^3
+  density: 4000  # interpreted as 4000 kg/m³
 section2:
   density: 0.1  # interpreted as 0.1 kg/cm^3
 section3:

--- a/doc/sphinx/yaml/general.md
+++ b/doc/sphinx/yaml/general.md
@@ -63,7 +63,7 @@ Supported compound units are:
   `cal/mol`, etc.), or any unit of energy (such as `eV`)
 - Force: `N`, `dyn`
 - Pressure: `Pa`, `atm`, `bar`, `dyn/cm^2`
-- Volume: `m^3`, `liter`, `L`, `l`, `cc`
+- Volume: `m^3`, `m³`, `liter`, `L`, `l`, `cc`
 - Other electrical units: `ohm`, `V`, `coulomb`
 
 Units can be specified on individual input values by placing them after the value,

--- a/src/base/Units.cpp
+++ b/src/base/Units.cpp
@@ -66,6 +66,7 @@ const map<string, Units> knownUnits{
 
     // Volume [L^3]
     {"m^3", Units(1.0, 0, 3, 0)},
+    {"m³", Units(1.0, 0, 3, 0)},
     {"liter", Units(0.001, 0, 3, 0)},
     {"L", Units(0.001, 0, 3, 0)},
     {"l", Units(0.001, 0, 3, 0)},

--- a/test/general/test_units.cpp
+++ b/test/general/test_units.cpp
@@ -12,9 +12,12 @@ TEST(Units, from_string) {
     EXPECT_EQ(Units("kg").str(), "kg");
     EXPECT_EQ(Units("1.0 kg^0.5").str(), "kg^0.5");
     EXPECT_EQ(Units("kg / m^3").str(), "kg / m^3");
+    EXPECT_EQ(Units("kg / m³").str(), "kg / m^3");
     EXPECT_EQ(Units("1 / s").str(), "1 / s");
     EXPECT_EQ(Units("0.001 m^3").factor(), 0.001);
+    EXPECT_EQ(Units("0.001 m³").factor(), 0.001);
     EXPECT_EQ(Units("0.001 m^3").str(), "0.001 m^3");
+    EXPECT_EQ(Units("0.001 m³").str(), "0.001 m^3");
 }
 
 TEST(Units, from_string_long) {
@@ -24,6 +27,7 @@ TEST(Units, from_string_long) {
     EXPECT_EQ(Units("kg").str(false), "1.0 kg");
     EXPECT_EQ(Units("1.0 kg^0.5").str(false), "1.0 kg^0.5");
     EXPECT_EQ(Units("kg / m^3").str(false), "1.0 kg / m^3");
+    EXPECT_EQ(Units("kg / m³").str(false), "1.0 kg / m^3");
 }
 
 TEST(Units, from_string_fail) {
@@ -33,6 +37,7 @@ TEST(Units, from_string_fail) {
     EXPECT_THROW(Units("1 bar", true), CanteraError);
     EXPECT_THROW(Units("1 kJ", true), CanteraError);
     EXPECT_THROW(Units("0.001 m^3", true), CanteraError);
+    EXPECT_THROW(Units("0.001 m³", true), CanteraError);
 }
 
 TEST(Units, convert_to_base_units) {
@@ -76,6 +81,7 @@ TEST(Units, with_defaults1) {
     UnitSystem U({"cm", "g", "mol", "atm", "kcal"});
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "m"), 0.01);
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "kmol/m^3"), 1000);
+    EXPECT_DOUBLE_EQ(U.convertTo(1.0, "kmol/m³"), 1000);
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "kg/kmol"), 1.0);
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "cm^2"), 1.0);
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "Pa"), 101325);
@@ -102,6 +108,7 @@ TEST(Units, with_defaults_map) {
     U.setDefaults(defaults);
     EXPECT_DOUBLE_EQ(U.convertFrom(0.01, "m"), 1.0);
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "kmol/m^3"), 1000);
+    EXPECT_DOUBLE_EQ(U.convertTo(1.0, "kmol/m³"), 1000);
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "kg/kmol"), 1.0);
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "cm^2"), 1.0);
     EXPECT_DOUBLE_EQ(U.convertTo(1.0, "Pa"), 101325);
@@ -189,8 +196,10 @@ TEST(Units, from_anymap) {
     EXPECT_DOUBLE_EQ(m.convert("v", "cm/min"), 1.0);
     EXPECT_DOUBLE_EQ(m.convert("A", "mm^2"), 100);
     EXPECT_DOUBLE_EQ(m.convert("V", "m^3"), 1e-9);
+    EXPECT_DOUBLE_EQ(m.convert("V", "m³"), 1e-9);
     auto k1 = m["k1"].asVector<AnyValue>();
     EXPECT_DOUBLE_EQ(U.convert(k1[0], "m^3/kmol"), 1e-9*5e2);
+    EXPECT_DOUBLE_EQ(U.convert(k1[0], "m³/kmol"), 1e-9*5e2);
     EXPECT_DOUBLE_EQ(U.convertActivationEnergy(k1[2], "J/kmol"), 29000);
 
     // calling applyUnits again should not affect results
@@ -198,6 +207,7 @@ TEST(Units, from_anymap) {
     m.applyUnits();
     EXPECT_DOUBLE_EQ(m.convert("p", "Pa"), 12e5);
     EXPECT_DOUBLE_EQ(U.convert(k1[0], "m^3/kmol"), 1e-9*5e2);
+    EXPECT_DOUBLE_EQ(U.convert(k1[0], "m³/kmol"), 1e-9*5e2);
 }
 
 TEST(Units, from_anymap_default) {
@@ -235,6 +245,7 @@ TEST(Units, to_anymap) {
     AnyMap m;
     m["h0"].setQuantity(90, "kJ/kg");
     m["density"].setQuantity({10, 20}, "kg/m^3");
+    m["density"].setQuantity({10, 20}, "kg/m³");
     m.setUnits(U);
     m.applyUnits();
     EXPECT_DOUBLE_EQ(m["h0"].asDouble(), 90e3 / 4184);
@@ -245,6 +256,7 @@ TEST(Units, anymap_quantities) {
     AnyMap m;
     vector<AnyValue> values(2);
     values[0].setQuantity(8, "kg/m^3");
+    values[0].setQuantity(8, "kg/m³");
     values[1].setQuantity(12, "mg/cl");
     m["a"] = values;
     values.emplace_back("hello");

--- a/test/general/test_units.cpp
+++ b/test/general/test_units.cpp
@@ -60,6 +60,7 @@ TEST(Units, basic_conversions) {
     EXPECT_DOUBLE_EQ(U.convert(2, "kmol", "mol"), 2000);
     EXPECT_DOUBLE_EQ(U.convert(1000, "cal", "J"), 4184);
     EXPECT_DOUBLE_EQ(U.convert(2, "m^3", "l"), 2000);
+    EXPECT_DOUBLE_EQ(U.convert(2, "m³", "l"), 2000);
     EXPECT_DOUBLE_EQ(U.convert(1, "atm", "Pa"), 101325);
 }
 

--- a/test/python/test_reaction.py
+++ b/test/python/test_reaction.py
@@ -1911,6 +1911,18 @@ class TestExtensible3:
         assert rxn.rate.length == 2
         assert rxn.rate.Ta == approx(1000 / ct.gas_constant)
 
+    def test_explicit_unicode_units(self):
+        rxn = """
+        equation: H2 + OH = H2O + H
+        type: user-rate-2
+        A: 1000 cm³/kmol/s
+        L: 200 cm
+        Ea: 1000
+        """
+        rxn = ct.Reaction.from_yaml(rxn, kinetics=self.gas)
+        assert rxn.rate.length == 2
+        assert rxn.rate.Ta == approx(1000 / ct.gas_constant)
+
     def test_implicit_units(self):
         rxn = """
         equation: H2 + OH = H2O + H

--- a/test/python/test_utils.py
+++ b/test/python/test_utils.py
@@ -78,7 +78,9 @@ class TestUnitSystem:
     def test_convert_rate_coeff(self):
         system = ct.UnitSystem({"length": "cm"})
         assert system.convert_rate_coeff_to(11, ct.Units("m^3/kmol/s")) == approx(11e-6)
+        assert system.convert_rate_coeff_to(11, ct.Units("m³/kmol/s")) == approx(11e-6)
         assert system.convert_rate_coeff_to("22 m^3/mol/s", "m^3/kmol/s") == approx(22e3)
+        assert system.convert_rate_coeff_to("22 m³/mol/s", "m³/kmol/s") == approx(22e3)
 
     def test_convert_to_custom(self):
         system = ct.UnitSystem({"length": "cm", "mass": "g"})
@@ -120,6 +122,7 @@ class TestUnitSystem:
         system = ct.UnitSystem({"length": "cm"})
         x = [("3000 mm^3/kmol/s", 4), (0.5, 2.0), 1.0]
         x_m = system.convert_rate_coeff_to(x, ct.Units("m^3/kmol/s"))
+        x_m = system.convert_rate_coeff_to(x, ct.Units("m³/kmol/s"))
         assert x_m[0][0] == approx(3000 / 1e9)
         assert x_m[1][1] == approx(2 / 1e6)
         assert x_m[2] == approx(1e-6)
@@ -141,6 +144,9 @@ class TestUnitSystem:
         with pytest.raises(ct.CanteraError):
             system.convert_activation_energy_to(4, "m^3/s")
 
+        with pytest.raises(ct.CanteraError):
+            system.convert_activation_energy_to(4, "m³/s")
+
         with pytest.raises(TypeError):
             system.convert_activation_energy_to(5, True)
 
@@ -152,6 +158,9 @@ class TestUnitSystem:
 
         with pytest.raises(TypeError):
             system.convert_rate_coeff_to(11, ["m^3"])
+
+        with pytest.raises(TypeError):
+            system.convert_rate_coeff_to(11, ["m³"])
 
         with pytest.raises(TypeError):
             system.convert_rate_coeff_to({"spam": 13}, "m^6/kmol^2/s")
@@ -301,6 +310,7 @@ class TestAnyMap:
         params = ct.AnyMap()
         params.set_quantity('spam', [2, 3, 4], 'Gg')
         params.set_quantity('eggs', 10, ct.Units('kg/m^3'))
+        params.set_quantity('eggs', 10, ct.Units('kg/m³'))
         params.set_activation_energy('beans', 5, 'K')
 
         converted = _py_to_anymap_to_py(params)


### PR DESCRIPTION
**Changes proposed in this pull request**
- Added the "m³" line in src/base/Units.cpp so Cantera can not only get m^3 but also read m³ as volume unit.
- Added the "m³" in unit basic conversion in test/general/test_units.cpp so it can also be tested.

**If applicable, provide an example illustrating new features this pull request is introducing**

When reading a .yaml file, it must have the units that the coefficients are referring to. However, sometimes people may use the same unit but in a different format, for example, m³ instead of m^3. Now, both ways can be read.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [ ] Commit messages have short titles and reference relevant issues
- [ ] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines]
- [x] The pull request is ready for review
