### PR TITLE
Replace macos-13 runners

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -239,17 +239,13 @@ jobs:
         macos-version: ['macos-14', 'macos-15']
         python-version: ['3.12', '3.13']
         include:
-          - macos-version: 'macos-13'
-            python-version: '3.11'
-          - macos-version: 'macos-13'
-            python-version: '3.12'
-          # - macos-version: 'macos-13'
-          #   python-version: '3.13.4'
           - macos-version: 'macos-14'
             python-version: '3.10'
             extra-build-args: cxx_flags='-std=c++20'
           - macos-version: 'macos-15'
             python-version: '3.11'
+          # - macos-version: 'macos-15-intel'
+          #   python-version: '3.1x'  # sporadic failures: tracked in post-merge-tests
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
@@ -289,13 +285,13 @@ jobs:
     - name: Rebuild Cantera with generated CLib
       run: |
         scons build clib_legacy=n -j3
-      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-13'
+      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-14'
     - name: Run googletests for generated CLib
       run: scons test-clib --debug=time
-      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-13'
+      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-14'
     - name: Upload shared library
       uses: actions/upload-artifact@v4
-      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-13'
+      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-14'
       with:
         path: build/lib/libcantera_shared.dylib
         name: libcantera_shared.dylib
@@ -1006,7 +1002,7 @@ jobs:
     name: .NET on ${{ matrix.os }}
     strategy:
       matrix:
-        os: [ubuntu-22.04, windows-2022, macos-13]
+        os: [ubuntu-22.04, windows-2022, macos-14]
       fail-fast: false
     runs-on: ${{ matrix.os }}
     needs: [ubuntu-multiple-pythons, macos-multiple-pythons, windows-2022]
@@ -1016,18 +1012,18 @@ jobs:
       name: Checkout the repository
       with:
         persist-credentials: false
-    - name: Override default Python (Windows)
-      # Other operating systems use default system Python 3
+    - name: Set Python version (Windows)
       uses: actions/setup-python@v6
       with:
         python-version: "3.10"
         architecture: x64
       if: matrix.os == 'windows-2022'
-    - name: Install Python dependencies
-      # Install Python dependencies, which are used by 'dotnet build'
-      run: |
-        python3 -m pip install --upgrade pip setuptools wheel build
-        python3 -m pip install ruamel.yaml Jinja2 typing-extensions
+    - name: Set Python version (macOS)
+      uses: actions/setup-python@v6
+      with:
+        python-version: "3.12"
+      if: matrix.os == 'macos-14'
+      # Ubuntu uses default system Python 3
     - name: Install library dependencies with micromamba (Windows)
       uses: mamba-org/setup-micromamba@add3a49764cedee8ee24e82dfde87f5bc2914462 # v2.0.7
       with:
@@ -1041,12 +1037,17 @@ jobs:
       if: matrix.os == 'windows-2022'
     - name: Install Brew dependencies (macOS)
       run: brew install --display-times hdf5
-      if: matrix.os == 'macos-13'
+      if: matrix.os == 'macos-14'
     - name: Install Apt dependencies (Ubuntu)
       run: |
         sudo apt update
         sudo apt install libhdf5-dev libfmt-dev libopenblas0-openmp
       if: matrix.os == 'ubuntu-22.04'
+    - name: Install Python dependencies
+      # Install Python dependencies, which are used by 'dotnet build'
+      run: |
+        python3 -m pip install --upgrade pip setuptools wheel build
+        python3 -m pip install ruamel.yaml Jinja2 typing-extensions
     - name: Setup .NET Core SDK
       uses: actions/setup-dotnet@v5
       with:

--- a/.github/workflows/post-merge-tests.yml
+++ b/.github/workflows/post-merge-tests.yml
@@ -379,8 +379,8 @@ jobs:
     timeout-minutes: 90
     strategy:
       matrix:
-        macos-version: ['macos-13'] # 'macos-13-large', 'macos-13-xlarge' require paid plans
-        python-version: ['3.13']  # previously failed for 3.13.4 and 3.13.5 on macos-13
+        macos-version: ['macos-15-intel']
+        python-version: ['3.10', '3.11', '3.12', '3.13', '3.14']
       fail-fast: false
     steps:
     - uses: actions/checkout@v5
@@ -397,6 +397,7 @@ jobs:
         python-version: ${{ matrix.python-version }}
         cache: pip
         cache-dependency-path: requirements.txt
+        allow-prereleases: true
     - name: Install Brew dependencies
       run: brew install --display-times boost libomp hdf5 doxygen
     - name: Set Include folder
@@ -420,14 +421,5 @@ jobs:
     - name: Rebuild Cantera with generated CLib
       run: |
         scons build clib_legacy=n -j3
-      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-13'
     - name: Run googletests for generated CLib
       run: scons test-clib --debug=time
-      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-13'
-    - name: Upload shared library
-      uses: actions/upload-artifact@v4
-      if: matrix.python-version == '3.12' && matrix.macos-version == 'macos-13'
-      with:
-        path: build/lib/libcantera_shared.dylib
-        name: libcantera_shared.dylib
-        retention-days: 2


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This PR is related to #1992 and testing for issue #1916

- ~Issue #1916 cannot be reproduced on `macos-15-intel`; with other tests by @speth failing to reproduce this locally, the only instance where sporadic failures are observed will not be reproducible anywhere once the `macOS-13` runner is removed.~
- ~Initial testing indicates that intel hardware does not cause issues on macOS-15.~
- After passing initially, a subsequent run reproduced #1916 on macos-15-intel 😕 

_Update: also replacing `macos-13` runners._

Closes #1992

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
