### PR TITLE
Toward consistent naming of reactor "contents"

### DIFF
--- a/doc/sphinx/userguide/extensible-reactor.md
+++ b/doc/sphinx/userguide/extensible-reactor.md
@@ -137,7 +137,7 @@ for mass_rock in [0.0, 1.0, 3.0]:
     # Integrate for 10 seconds
     net.advance(10)
 
-    print(f'mass_rock = {mass_rock} kg; ΔT = {r1.thermo.T - T0:.2f} K')
+    print(f'mass_rock = {mass_rock} kg; ΔT = {r1.contents.T - T0:.2f} K')
 ```
 
 As expected, we see that the temperature rise decreases as the thermal mass of the

--- a/doc/sphinx/userguide/reactor-tutorial.md
+++ b/doc/sphinx/userguide/reactor-tutorial.md
@@ -38,7 +38,7 @@ reac = ct.IdealGasReactor(gas)
 sim = ct.ReactorNet([reac])
 
 # View the initial state of the mixture
-reac.thermo()
+reac.contents()
 ```
 
 Now, let's advance the simulation in time to an absolute time of 1 second, and examine
@@ -52,7 +52,7 @@ ignited for a wide range of initial conditions.
 sim.advance(1)
 
 # view the updated state of the mixture, reflecting properties at t = 1 sec
-reac.thermo()
+reac.contents()
 ```
 
 ## Methods for Time Integration
@@ -161,7 +161,7 @@ sim.preconditioner = precon  # Add it to the network
 The results of the time integration are the same as before:
 ```{code-cell} python
 sim.advance(1)
-reac.thermo()
+reac.contents()
 ```
 
 The approximate Jacobian matrices used to construct the preconditioners do not currently

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -199,7 +199,7 @@ public:
 
     //! Set the state of the Phase object associated with this reactor to the
     //! reactor's current state.
-    void restoreState();
+    virtual void restoreState();
 
     //! Set the state of the reactor to the associated ThermoPhase object.
     //! This method is the inverse of restoreState() and will trigger integrator

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -99,7 +99,16 @@ public:
     void setSolution(shared_ptr<Solution> sol);
 
     //! Access the Solution object used to represent the contents of this reactor.
-    shared_ptr<Solution> solution() { return m_solution; }
+    //! @since New in %Cantera 3.2
+    //! @todo Transition to `contents()` method for returning `shared_ptr<Solution>`
+    //!     after %Cantera 3.2.
+    shared_ptr<Solution> contents4() { return m_solution; }
+
+    //! Access the Solution object used to represent the contents of this reactor.
+    //! @since New in %Cantera 3.2
+    //! @todo Transition to `contents()` method for returning `shared_ptr<Solution>`
+    //!     after %Cantera 3.2.
+    shared_ptr<const Solution> contents4() const { return m_solution; }
 
     //! @name Methods to set up a simulation
     //! @{
@@ -198,7 +207,11 @@ public:
     virtual void syncState();
 
     //! return a reference to the contents.
+    //! @deprecated  To be changed after Cantera 3.2 to return a `shared_ptr<Solution>`.
+    //!     For transitional access to the Solution object, use contents4().
     ThermoPhase& contents() {
+        warn_deprecated("ReactorBase::contents", "Return value will change to "
+            "shared_ptr<Solution> after Cantera 3.2. Use contents4() for transition.");
         if (!m_thermo) {
             throw CanteraError("ReactorBase::contents",
                                "Reactor contents not defined.");
@@ -206,7 +219,14 @@ public:
         return *m_thermo;
     }
 
+    //! return a reference to the contents.
+    //! @deprecated  To be changed after Cantera 3.2 to return a
+    //!     `shared_ptr<const Solution>`. For transitional access to the Solution
+    //!     object, use contents4().
     const ThermoPhase& contents() const {
+        warn_deprecated("ReactorBase::contents", "Return value will change to "
+            "shared_ptr<const Solution> after Cantera 3.2. Use contents4() for "
+            "transition.");
         if (!m_thermo) {
             throw CanteraError("ReactorBase::contents",
                                "Reactor contents not defined.");

--- a/include/cantera/zeroD/ReactorSurface.h
+++ b/include/cantera/zeroD/ReactorSurface.h
@@ -111,6 +111,14 @@ public:
     //! Set the coverages and temperature in the surface phase object to the
     //! values for this surface. The temperature is set to match the bulk phase
     //! of the attached Reactor.
+    //! @since  Prior to %Cantera 3.2, this operation was performed by syncState()
+    void restoreState() override;
+
+    //! Set the coverages for this ReactorSurface based on the attached SurfPhase.
+    //! @since  Behavior changed in %Cantera 3.2 for consistency with
+    //!     ReactorBase::syncState(). Previously, this method performed the inverse
+    //!     operation of setting the ReactorSurface state based on the SurfPhase and
+    //!     attached Reactor.
     void syncState() override;
 
     void addSensitivityReaction(size_t rxn) override;

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -48,19 +48,19 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
     # include full reactor state in representation if desired
     if print_state:
         T_label = f"T (K)\\n{r.T:.2f}"
-        P_label = f"P (bar)\\n{r.thermo.P*1e-5:.3f}"
+        P_label = f"P (bar)\\n{r.contents.P*1e-5:.3f}"
 
         if species == True or species == "X":
-            s_dict = r.thermo.mole_fraction_dict(1e-4)
+            s_dict = r.contents.mole_fraction_dict(1e-4)
             species_list = s_dict.keys()
             s_label = "X"
         elif species == "Y":
-            s_dict = r.thermo.mass_fraction_dict(1e-4)
+            s_dict = r.contents.mass_fraction_dict(1e-4)
             species_list = s_dict.keys()
             s_label = "Y"
         # If individual species are provided as iterable of strings
         elif species:
-            s_dict = r.thermo.mole_fraction_dict(threshold=-1)
+            s_dict = r.contents.mole_fraction_dict(threshold=-1)
             species_list = species
             s_label = "X"
         else:

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -38,7 +38,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         CxxReactorBase() except +translate_exception
         string type()
         void setSolution(shared_ptr[CxxSolution]) except +translate_exception
-        shared_ptr[CxxSolution] solution()
+        shared_ptr[CxxSolution] contents4()
         void restoreState() except +translate_exception
         void syncState() except +translate_exception
         double volume()

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -78,10 +78,27 @@ cdef class ReactorBase:
     property thermo:
         """
         The `ThermoPhase` object representing the reactor's contents.
+
+        .. deprecated:: 3.2
+           Renamed to ``contents``
         """
         def __get__(self):
+            warnings.warn("ReactorBase.thermo: To be removed after Cantera 3.2. "
+                "Renamed to `contents`.",
+                DeprecationWarning)
             self.rbase.restoreState()
             return self._contents
+
+    @property
+    def contents(self):
+        """
+        The `Solution` object representing the reactor's contents.
+
+        .. versionchanged:: 3.2
+           Renamed from ``thermo``.
+        """
+        self.rbase.restoreState()
+        return self._contents
 
     property volume:
         """The volume [m³] of the reactor."""
@@ -94,22 +111,22 @@ cdef class ReactorBase:
     property T:
         """The temperature [K] of the reactor's contents."""
         def __get__(self):
-            return self.thermo.T
+            return self.contents.T
 
     property density:
         """The density [kg/m³ or kmol/m³] of the reactor's contents."""
         def __get__(self):
-            return self.thermo.density
+            return self.contents.density
 
     property mass:
         """The mass of the reactor's contents."""
         def __get__(self):
-            return self.thermo.density_mass * self.volume
+            return self.contents.density_mass * self.volume
 
     property Y:
         """The mass fractions of the reactor's contents."""
         def __get__(self):
-            return self.thermo.Y
+            return self.contents.Y
 
     def add_sensitivity_reaction(self, int m):
         """
@@ -310,7 +327,7 @@ cdef class Reactor(ReactorBase):
         species ``k`` should be computed. The reactor must be part of a network
         first.
         """
-        self.reactor.addSensitivitySpeciesEnthalpy(self.thermo.species_index(k))
+        self.reactor.addSensitivitySpeciesEnthalpy(self.contents.species_index(k))
 
     def component_index(self, name):
         """

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -293,8 +293,13 @@ cdef class Reactor(ReactorBase):
         """
         The `Kinetics` object used for calculating kinetic rates in
         this reactor.
+
+        .. deprecated:: 3.2
+            Replaced by ``contents`` property.
         """
         def __get__(self):
+            warnings.warn("Reactor.kinetics: To be removed after Cantera 3.2. "
+                "Renamed to `contents`.", DeprecationWarning)
             self.rbase.restoreState()
             return self._contents
 
@@ -912,8 +917,13 @@ cdef class ReactorSurface(ReactorBase):
         """
         The `InterfaceKinetics` object used for calculating reaction rates on
         this surface.
+
+        .. deprecated:: 3.2
+            Replaced by ``contents`` property.
         """
         def __get__(self):
+            warnings.warn("ReactorSurface.kinetics: To be removed after Cantera 3.2. "
+                "Renamed to `contents`.", DeprecationWarning)
             self.syncState()
             return self._contents
 

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -934,7 +934,7 @@ cdef class ReactorSurface(ReactorBase):
         def __get__(self):
             if self._contents is None:
                 raise CanteraError('No kinetics manager present')
-            self.syncState()
+            self.rbase.restoreState()
             return self._contents.coverages
         def __set__(self, coverages):
             if self._contents is None:

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -35,7 +35,7 @@ cdef class ReactorBase:
         self._outlets = []
         self._walls = []
         self._surfaces = []
-        self._contents = _wrap_Solution(self.rbase.solution())
+        self._contents = _wrap_Solution(self.rbase.contents4())
 
         if volume is not None:
             self.volume = volume

--- a/interfaces/sourcegen/src/sourcegen/headers/ctreactor_auto.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctreactor_auto.yaml
@@ -18,7 +18,9 @@ recipes:
 - name: type
 - name: name
 - name: setName
-- name: solution
+- name: contents
+  # Temporary name due to conflict with deprecated method returning ThermoPhase&
+  wraps: contents4
   what: accessor
 - name: setInitialVolume
 - name: setChemistry

--- a/samples/cxx/combustor/combustor.cpp
+++ b/samples/cxx/combustor/combustor.cpp
@@ -112,9 +112,9 @@ void runexample()
         f << tnow << ", "
           << combustor->temperature() << ", "
           << tres << ", ";
-        ThermoPhase& c = combustor->contents();
+        const auto& c = combustor->contents4()->thermo();
         for (size_t i = 0; i < k_out.size(); i++) {
-            f << c.moleFraction(k_out[i]) << ", ";
+            f << c->moleFraction(k_out[i]) << ", ";
         }
         f << std::endl;
     }

--- a/samples/cxx/kinetics1/kinetics1.cpp
+++ b/samples/cxx/kinetics1/kinetics1.cpp
@@ -45,7 +45,7 @@ int kinetics1(int np, void* p)
     // create a 2D array to hold the output variables,
     // and store the values for the initial state
     Array2D states(nsp+4, 1);
-    saveSoln(0, 0.0, *r->solution()->thermo(), states);
+    saveSoln(0, 0.0, *r->contents4()->thermo(), states);
 
     // create a container object for reactor to run the simulation
     ReactorNet sim(r);
@@ -56,13 +56,13 @@ int kinetics1(int np, void* p)
         double tm = i*dt;
         sim.advance(tm);
         cout << "time = " << tm << " s" << endl;
-        saveSoln(tm, *r->solution()->thermo(), states);
+        saveSoln(tm, *r->contents4()->thermo(), states);
     }
     clock_t t1 = clock(); // save end time
 
 
     // make a CSV output file
-    writeCsv("kin1.csv", *r->solution()->thermo(), states);
+    writeCsv("kin1.csv", *r->contents4()->thermo(), states);
 
     // print final temperature and timing data
     double tmm = 1.0*(t1 - t0)/CLOCKS_PER_SEC;

--- a/samples/cxx/openmp_ignition/openmp_ignition.cpp
+++ b/samples/cxx/openmp_ignition/openmp_ignition.cpp
@@ -60,7 +60,7 @@ void run()
     for (int i = 0; i < nPoints; i++) {
         // Get the Cantera objects that were initialized for this thread
         size_t j = omp_get_thread_num();
-        auto gas = reactors[j]->solution()->thermo();
+        auto gas = reactors[j]->contents4()->thermo();
         Reactor& reactor = *reactors[j];
         ReactorNet& net = *nets[j];
 

--- a/samples/python/kinetics/interactive_path_diagram.py
+++ b/samples/python/kinetics/interactive_path_diagram.py
@@ -5,7 +5,7 @@ Interactive Reaction Path Diagrams
 This example uses ``ipywidgets`` to create interactive displays of reaction path
 diagrams from Cantera simulations.
 
-Requires: cantera >= 3.0.0, matplotlib >= 2.0, ipywidgets, graphviz, scipy
+Requires: cantera >= 3.2.0, matplotlib >= 2.0, ipywidgets, graphviz, scipy
 
 .. tags:: Python, combustion, reactor network, plotting, reaction path analysis
 
@@ -84,9 +84,9 @@ time = 0
 steps = 0
 while time < residence_time:
     profiles["time"].append(time)
-    profiles["pressure"].append(reactor.thermo.P)
-    profiles["temperature"].append(reactor.thermo.T)
-    profiles["mole_fractions"].append(reactor.thermo.X)
+    profiles["pressure"].append(reactor.contents.P)
+    profiles["temperature"].append(reactor.contents.T)
+    profiles["mole_fractions"].append(reactor.contents.X)
     time = reactor_network.step()
     steps += 1
 

--- a/samples/python/kinetics/jet_stirred_reactor.py
+++ b/samples/python/kinetics/jet_stirred_reactor.py
@@ -28,7 +28,7 @@ References:
     Mixture Rules Has a Substantial Impact on Combustion Predictions for H2 and NH3,
     Proc. Combust. Inst. 40 (2024) 105779.
 
-Requires: cantera >= 3.1, pandas, matplotlib
+Requires: cantera >= 3.2, pandas, matplotlib
 
 .. tags:: jet-stirred reactor, kinetics, combustion
 """
@@ -94,11 +94,11 @@ def getTemperatureDependence(gas, inputs):
         t = 0
         while t < inputs['t_max']:
             t = reactorNetwork.step()
-        state = np.hstack([stirredReactor.thermo.P,
+        state = np.hstack([stirredReactor.contents.P,
                         stirredReactor.mass,
                         stirredReactor.volume,
                         stirredReactor.T,
-                        stirredReactor.thermo.X])
+                        stirredReactor.contents.X])
         tempDependence.loc[T] = state
     return tempDependence
 

--- a/samples/python/kinetics/mechanism_reduction.py
+++ b/samples/python/kinetics/mechanism_reduction.py
@@ -15,7 +15,7 @@ and the associated species, and run the simulations again with these mechanisms
 to see whether the reduced mechanisms with a certain number of species are able
 to adequately simulate the ignition delay problem.
 
-Requires: cantera >= 3.1.0, matplotlib >= 2.0
+Requires: cantera >= 3.2.0, matplotlib >= 2.0
 
 .. tags:: Python, kinetics, combustion, reactor network, editing mechanisms,
           ignition delay, plotting
@@ -56,7 +56,7 @@ while sim.time < 0.04:
     sim.step()
     tt.append(1000 * sim.time)
     TT.append(r.T)
-    rnet = abs(r.thermo.net_rates_of_progress)
+    rnet = abs(r.contents.net_rates_of_progress)
     rnet /= max(rnet)
     Rmax = np.maximum(Rmax, rnet)
 

--- a/samples/python/kinetics/shock_tube.py
+++ b/samples/python/kinetics/shock_tube.py
@@ -27,7 +27,7 @@ References:
     Mixture Rules Has a Substantial Impact on Combustion Predictions for H2 and NH3,
     Proc. Combust. Inst. 40 (2024) 105779.
 
-Requires: cantera >= 3.1, matplotlib
+Requires: cantera >= 3.2, matplotlib
 
 .. tags:: Python, shock tube, kinetics, combustion
 """
@@ -61,7 +61,7 @@ for k, m in enumerate(models):
     while t < estIgnitDelay:
         t = reactorNetwork.step()
         if counter % 10 == 0:
-            timeHistory.append(r.thermo.state, t=t)
+            timeHistory.append(r.contents.state, t=t)
         counter += 1
 
     results[m] = timeHistory

--- a/samples/python/reactors/1D_pfr_surfchem.py
+++ b/samples/python/reactors/1D_pfr_surfchem.py
@@ -17,7 +17,7 @@ original example from:
 The results are somewhat different from those in the Larson report in part due to the
 fact that this example does not include the frictional pressure drop.
 
-Requires: cantera >= 3.0, matplotlib >= 2.0
+Requires: cantera >= 3.2, matplotlib >= 2.0
 
 .. tags:: Python, catalysis, plug flow reactor, reactor network, surface chemistry
 """
@@ -57,7 +57,7 @@ while net.distance < 0.6:
     print(net.distance, rsurf.coverages)
     net.step()
     wdot = rsurf.kinetics.net_production_rates
-    soln.append(TDY=reactor.thermo.TDY,
+    soln.append(TDY=reactor.contents.TDY,
                 x=net.distance,
                 speed=reactor.speed,
                 surf_coverages=rsurf.coverages,

--- a/samples/python/reactors/1D_pfr_surfchem.py
+++ b/samples/python/reactors/1D_pfr_surfchem.py
@@ -56,7 +56,7 @@ kSi = gas_si_n_interface.kinetics_species_index('Si(D)')
 while net.distance < 0.6:
     print(net.distance, rsurf.coverages)
     net.step()
-    wdot = rsurf.kinetics.net_production_rates
+    wdot = rsurf.contents.net_production_rates
     soln.append(TDY=reactor.contents.TDY,
                 x=net.distance,
                 speed=reactor.speed,

--- a/samples/python/reactors/combustor.py
+++ b/samples/python/reactors/combustor.py
@@ -81,7 +81,7 @@ while combustor.T > 500:
     sim.initial_time = 0.0  # reset the integrator
     sim.solve_steady()
     print('tres = {:.2e}; T = {:.1f}'.format(residence_time, combustor.T))
-    states.append(combustor.thermo.state, tres=residence_time)
+    states.append(combustor.contents.state, tres=residence_time)
     residence_time *= 0.9  # decrease the residence time for the next iteration
 
 # %%

--- a/samples/python/reactors/continuous_reactor.py
+++ b/samples/python/reactors/continuous_reactor.py
@@ -9,7 +9,7 @@ stirred reactor (WSR), a jet stirred reactor (JSR), or a
 `Longwell reactor <https://nap.nationalacademies.org/read/13160/chapter/48>`__ (and
 there may well be more "aliases").
 
-Requires: cantera >= 3.0, matplotlib >= 2.0, pandas
+Requires: cantera >= 3.2, matplotlib >= 2.0, pandas
 
 .. tags:: Python, combustion, reactor network, well-stirred reactor
 
@@ -143,7 +143,7 @@ while t < max_simulation_time:
     # will be 1200+ columns for us to work with
     if counter % 10 == 0:
         # Extract the state of the reactor
-        time_history.append(stirred_reactor.thermo.state, t=t)
+        time_history.append(stirred_reactor.contents.state, t=t)
 
     counter += 1
 
@@ -252,8 +252,8 @@ for reactor_temperature in T:
     print(f"Simulation at T={reactor_temperature} K took {toc-tic:3.2f} s to compute "
           f"with {counter} steps")
 
-    reactor_X = stirred_reactor.thermo.X
-    temp_dependence.append(stirred_reactor.thermo.state)
+    reactor_X = stirred_reactor.contents.X
+    temp_dependence.append(stirred_reactor.contents.state)
 
 # %%
 # Compare the model results with experimental data

--- a/samples/python/reactors/custom2.py
+++ b/samples/python/reactors/custom2.py
@@ -17,7 +17,7 @@ acceleration is proportional to the pressure difference, and the velocity is
 determined by integrating the equation of motion. This requires adding a new
 variable to the reactor's state vector which represents the wall velocity.
 
-Requires: cantera >= 3.0, matplotlib >= 2.0
+Requires: cantera >= 3.2, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, user-defined model, plotting
 """
@@ -55,7 +55,7 @@ class InertialWallReactor(ct.ExtensibleIdealGasReactor):
 
     def after_eval(self, t, LHS, RHS):
         # Calculate the time derivative for the additional equation
-        a = self.k_wall * (self.thermo.P - self.neighbor.thermo.P)
+        a = self.k_wall * (self.contents.P - self.neighbor.contents.P)
         RHS[self.i_wall] = a
 
     def before_component_index(self, name):
@@ -85,7 +85,7 @@ net = ct.ReactorNet([r])
 states = ct.SolutionArray(gas, 1, extra={'t': [0.0], 'V': [r.volume]})
 while net.time < 0.5:
     net.advance(net.time + 0.005)
-    states.append(TPY=r.thermo.TPY, V=r.volume, t=net.time)
+    states.append(TPY=r.contents.TPY, V=r.volume, t=net.time)
 
 # Plot the results
 try:

--- a/samples/python/reactors/fuel_injection.py
+++ b/samples/python/reactors/fuel_injection.py
@@ -9,7 +9,7 @@ Demonstrates the use of a user-supplied function for the mass flow rate through
 a `MassFlowController`, and the use of the `SolutionArray` class to store results
 during reactor network integration and use these results to generate plots.
 
-Requires: cantera >= 3.1, matplotlib >= 2.0
+Requires: cantera >= 3.2, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, kinetics, pollutant formation, plotting
 """
@@ -61,7 +61,7 @@ while tnow < tfinal:
     if tnow-tprev > 1e-2 or i == 10:
         i = 0
         tprev = tnow
-        states.append(r.thermo.state, t=tnow)
+        states.append(r.contents.state, t=tnow)
 
 # nice names for species, including PAH species that can be considered
 # as precursors to soot formation

--- a/samples/python/reactors/ic_engine.py
+++ b/samples/python/reactors/ic_engine.py
@@ -6,7 +6,7 @@ The simulation uses n-dodecane as fuel, which is injected close to top dead
 center. Note that this example uses numerous simplifying assumptions and
 thus serves for illustration purposes only.
 
-Requires: cantera >= 3.0, scipy >= 0.19, matplotlib >= 2.0
+Requires: cantera >= 3.2, scipy >= 0.19, matplotlib >= 2.0
 
 .. tags:: Python, combustion, thermodynamics, internal combustion engine,
           thermodynamic cycle, reactor network, plotting, pollutant formation
@@ -158,7 +158,7 @@ cyl.set_advance_limit('temperature', delta_T_max)
 
 # set up output data arrays
 states = ct.SolutionArray(
-    cyl.thermo,
+    cyl.contents,
     extra=('t', 'ca', 'V', 'm', 'mdot_in', 'mdot_out', 'dWv_dt'),
 )
 
@@ -171,11 +171,11 @@ while sim.time < t_stop:
     sim.advance(sim.time + dt)
 
     # calculate results to be stored
-    dWv_dt = - (cyl.thermo.P - ambient_air.thermo.P) * A_piston * \
+    dWv_dt = - (cyl.contents.P - ambient_air.contents.P) * A_piston * \
         piston_speed(sim.time)
 
     # append output data
-    states.append(cyl.thermo.state,
+    states.append(cyl.contents.state,
                   t=sim.time, ca=crank_angle(sim.time),
                   V=cyl.volume, m=cyl.mass,
                   mdot_in=inlet_valve.mass_flow_rate,

--- a/samples/python/reactors/mix1.py
+++ b/samples/python/reactors/mix1.py
@@ -79,7 +79,7 @@ sim = ct.ReactorNet([mixer])
 sim.solve_steady()
 
 # view the state of the gas in the mixer
-print(mixer.thermo.report())
+print(mixer.contents.report())
 
 # %%
 # Show the network structure

--- a/samples/python/reactors/nanosecond_pulse_discharge.py
+++ b/samples/python/reactors/nanosecond_pulse_discharge.py
@@ -64,8 +64,8 @@ while t < t_total:
     t_end = min(t + dt_chunk, t_total)
     while sim.time < t_end:
         sim.advance(sim.time + dt_max) #use sim.step
-        states.append(r.thermo.state, t=sim.time)
-        print(f"{sim.time:10.3e} {r.T:10.3f} {r.thermo.P:10.3f} {r.thermo.h:14.6f}")
+        states.append(r.contents.state, t=sim.time)
+        print(f"{sim.time:10.3e} {r.T:10.3f} {r.contents.P:10.3f} {r.contents.h:14.6f}")
 
     EN_t = gaussian_EN(t)
     gas.reduced_electric_field = EN_t

--- a/samples/python/reactors/non_ideal_shock_tube.py
+++ b/samples/python/reactors/non_ideal_shock_tube.py
@@ -11,7 +11,7 @@ The example is written in a general way, that is, no particular equation of stat
 is presumed and ideal and real gas EoS can be used equally easily. The example here
 demonstrates the calculations carried out by G. Kogekar et al. [1]_.
 
-Requires: cantera >= 2.5.0, matplotlib >= 2.0
+Requires: cantera >= 3.2.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, non-ideal fluid, ignition delay, plotting
 """
@@ -133,7 +133,7 @@ while t < estimated_ignition_delay_time:
     if counter % 20 == 0:
         # We will save only every 20th value. Otherwise, this takes too long
         # Note that the species concentrations are mass fractions
-        time_history_RG.append(r.thermo.state, t=t)
+        time_history_RG.append(r.contents.state, t=t)
     counter += 1
 
 # We will use the 'oh' species to compute the ignition delay
@@ -166,7 +166,7 @@ while t < estimated_ignition_delay_time:
     if counter % 20 == 0:
         # We will save only every 20th value. Otherwise, this takes too long
         # Note that the species concentrations are mass fractions
-        time_history_IG.append(r.thermo.state, t=t)
+        time_history_IG.append(r.contents.state, t=t)
     counter += 1
 
 # We will use the 'oh' species to compute the ignition delay
@@ -243,7 +243,7 @@ for i, temperature in enumerate(T):
     while t < estimated_ignition_delay_times[i]:
         t = reactor_network.step()
         if counter % 20 == 0:
-            time_history.append(r.thermo.state, t=t)
+            time_history.append(r.contents.state, t=t)
         counter += 1
 
     tau = ignition_delay(time_history, 'oh')
@@ -276,7 +276,7 @@ for i, temperature in enumerate(T):
     while t < estimated_ignition_delay_times[i]:
         t = reactor_network.step()
         if counter % 20 == 0:
-            time_history.append(r.thermo.state, t=t)
+            time_history.append(r.contents.state, t=t)
         counter += 1
 
     tau = ignition_delay(time_history, 'oh')

--- a/samples/python/reactors/periodic_cstr.py
+++ b/samples/python/reactors/periodic_cstr.py
@@ -22,7 +22,7 @@ example.
 *Acknowledgments*: The idea for this example and an estimate of the conditions
 needed to see the oscillations came from Bob Kee, Colorado School of Mines
 
-Requires: cantera >= 2.5.0, matplotlib >= 2.0
+Requires: cantera >= 3.2.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, well-stirred reactor, plotting
 """
@@ -92,7 +92,7 @@ states = ct.SolutionArray(gas, extra=['t'])
 while t < 300.0:
     t += dt
     network.advance(t)
-    states.append(cstr.thermo.state, t=t)
+    states.append(cstr.contents.state, t=t)
 
 aliases = {'H2': 'H$_2$', 'O2': 'O$_2$', 'H2O': 'H$_2$O'}
 for name, alias in aliases.items():

--- a/samples/python/reactors/pfr.py
+++ b/samples/python/reactors/pfr.py
@@ -6,7 +6,7 @@ This example solves a plug-flow reactor problem of hydrogen-oxygen combustion.
 The PFR is computed by two approaches: The simulation of a Lagrangian fluid
 particle, and the simulation of a chain of reactors.
 
-Requires: cantera >= 3.0, matplotlib >= 2.0
+Requires: cantera >= 3.2, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, plug flow reactor
 """
@@ -61,14 +61,14 @@ dt = t_total / n_steps
 t1 = (np.arange(n_steps) + 1) * dt
 z1 = np.zeros_like(t1)
 u1 = np.zeros_like(t1)
-states1 = ct.SolutionArray(r1.thermo)
+states1 = ct.SolutionArray(r1.contents)
 for n1, t_i in enumerate(t1):
     # perform time integration
     sim1.advance(t_i)
     # compute velocity and transform into space
-    u1[n1] = mass_flow_rate1 / area / r1.thermo.density
+    u1[n1] = mass_flow_rate1 / area / r1.contents.density
     z1[n1] = z1[n1 - 1] + u1[n1] * dt
-    states1.append(r1.thermo.state)
+    states1.append(r1.contents.state)
 #####################################################################
 
 
@@ -126,17 +126,17 @@ states2 = ct.SolutionArray(gas2)
 # iterate through the PFR cells
 for n in range(n_steps):
     # Set the state of the reservoir to match that of the previous reactor
-    upstream.thermo.TDY = r2.thermo.TDY
+    upstream.contents.TDY = r2.contents.TDY
     upstream.syncState()
     # integrate the reactor forward in time until steady state is reached
     sim2.reinitialize()
     sim2.advance_to_steady_state()
     # compute velocity and transform into time
-    u2[n] = mass_flow_rate2 / area / r2.thermo.density
+    u2[n] = mass_flow_rate2 / area / r2.contents.density
     t_r2[n] = r2.mass / mass_flow_rate2  # residence time in this reactor
     t2[n] = np.sum(t_r2)
     # write output data
-    states2.append(r2.thermo.state)
+    states2.append(r2.contents.state)
 #####################################################################
 
 

--- a/samples/python/reactors/piston.py
+++ b/samples/python/reactors/piston.py
@@ -24,7 +24,7 @@ proportional to the pressure difference between the two chambers.
 
 Note that each side uses a *different* reaction mechanism
 
-Requires: cantera >= 2.5.0, matplotlib >= 2.0
+Requires: cantera >= 3.2.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, plotting
 """
@@ -55,7 +55,7 @@ def v(t):
     if t < 0.1:
         return 0.0
     else:
-        return (r1.thermo.P - r2.thermo.P) * 1e-4
+        return (r1.contents.P - r2.contents.P) * 1e-4
 
 w = ct.Wall(r1, r2, velocity=v)
 
@@ -63,8 +63,8 @@ net = ct.ReactorNet([r1, r2])
 
 # %%
 # Run the simulation and collect the states of each reactor
-states1 = ct.SolutionArray(r1.thermo, extra=['t', 'volume'])
-states2 = ct.SolutionArray(r2.thermo, extra=['t', 'volume'])
+states1 = ct.SolutionArray(r1.contents, extra=['t', 'volume'])
+states2 = ct.SolutionArray(r2.contents, extra=['t', 'volume'])
 
 fmt = '{:10.3f}  {:10.1f}  {:10.4f}  {:10.4g}  {:10.4g}  {:10.4g}  {:10.4g}'
 print('{:>10}  {:>10}  {:>10}  {:>10}  {:>10}  {:>10}  {:>10}'.format(
@@ -74,10 +74,10 @@ for n in range(200):
     net.advance(time)
     if n % 4 == 3:
         print(fmt.format(time, r1.T, r2.T, r1.volume, r2.volume,
-                         r1.volume + r2.volume, r2.thermo['CO'].X[0]))
+                         r1.volume + r2.volume, r2.contents['CO'].X[0]))
 
-    states1.append(r1.thermo.state, t=1000*time, volume=r1.volume)
-    states2.append(r2.thermo.state, t=1000*time, volume=r2.volume)
+    states1.append(r1.contents.state, t=1000*time, volume=r1.volume)
+    states2.append(r2.contents.state, t=1000*time, volume=r2.volume)
 
 # %%
 # Plot the results

--- a/samples/python/reactors/porous_media_burner.py
+++ b/samples/python/reactors/porous_media_burner.py
@@ -282,7 +282,7 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
         #                             species mass fractions                          #
         # ============================================================================#
 
-        wdot = self.kinetics.net_production_rates # chemical source terms
+        wdot = self.contents.net_production_rates # chemical source terms
         if not self.chemistry:
             wdot *= 0.0
 

--- a/samples/python/reactors/preconditioned_integration.py
+++ b/samples/python/reactors/preconditioned_integration.py
@@ -5,7 +5,7 @@ Acceleration of reactor integration using a sparse preconditioned solver
 Ideal gas, constant-pressure, adiabatic kinetics simulation that compares preconditioned
 and non-preconditioned integration of n-hexane.
 
-Requires: cantera >= 3.0.0, matplotlib >= 2.0
+Requires: cantera >= 3.2.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, preconditioner
 """
@@ -40,10 +40,10 @@ def integrate_reactor(preconditioner=True):
     # Advance to steady state
     integ_time = default_timer()
     # solution array for state data
-    states = ct.SolutionArray(reactor.thermo, extra=['time'])
+    states = ct.SolutionArray(reactor.contents, extra=['time'])
     # advance to steady state manually
     while (sim.time < 0.1):
-        states.append(reactor.thermo.state, time=sim.time)
+        states.append(reactor.contents.state, time=sim.time)
         sim.step()
     integ_time = default_timer() - integ_time
     # Return time to integrate

--- a/samples/python/reactors/reactor1.py
+++ b/samples/python/reactors/reactor1.py
@@ -2,7 +2,7 @@
 Constant-pressure, adiabatic kinetics simulation
 ================================================
 
-Requires: cantera >= 2.5.0, matplotlib >= 2.0
+Requires: cantera >= 3.2.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, plotting
 """
@@ -30,9 +30,9 @@ print('{:10s} {:10s} {:10s} {:14s}'.format(
     't [s]', 'T [K]', 'P [Pa]', 'u [J/kg]'))
 while sim.time < t_end:
     sim.advance(sim.time + dt_max)
-    states.append(r.thermo.state, t=sim.time*1e3)
+    states.append(r.contents.state, t=sim.time*1e3)
     print('{:10.3e} {:10.3f} {:10.3f} {:14.6f}'.format(
-            sim.time, r.T, r.thermo.P, r.thermo.u))
+            sim.time, r.T, r.contents.P, r.contents.u))
 
 # Plot the results if matplotlib is installed.
 # See http://matplotlib.org/ to get it.

--- a/samples/python/reactors/reactor2.py
+++ b/samples/python/reactors/reactor2.py
@@ -18,7 +18,7 @@ through the outer cylinder walls to the environment.
 Note that this simulation, being zero-dimensional, takes no account of shock
 wave propagation. It is somewhat artificial, but nevertheless instructive.
 
-Requires: cantera >= 2.5.0, matplotlib >= 2.0, pandas
+Requires: cantera >= 3.2.0, matplotlib >= 2.0, pandas
 
 .. tags:: combustion, reactor network, plotting
 """
@@ -82,8 +82,8 @@ states2 = ct.SolutionArray(gas, extra=['t', 'V'])
 for n in range(n_steps):
     time += 4.e-4
     sim.advance(time)
-    states1.append(r1.thermo.state, t=time, V=r1.volume)
-    states2.append(r2.thermo.state, t=time, V=r2.volume)
+    states1.append(r1.contents.state, t=time, V=r1.volume)
+    states2.append(r2.contents.state, t=time, V=r2.volume)
 
 # %%
 # Combine the results and save for later processing or plotting

--- a/samples/python/reactors/sensitivity1.py
+++ b/samples/python/reactors/sensitivity1.py
@@ -2,7 +2,7 @@
 Constant-pressure, adiabatic kinetics simulation with sensitivity analysis
 ==========================================================================
 
-Requires: cantera >= 2.5.0, matplotlib >= 2.0
+Requires: cantera >= 3.2.0, matplotlib >= 2.0
 
 .. tags:: Python, combustion, reactor network, sensitivity analysis, plotting
 """
@@ -37,10 +37,10 @@ for t in np.arange(0, 2e-3, 5e-6):
     sim.advance(t)
     s2 = sim.sensitivity('OH', 2)  # sensitivity of OH to reaction 2
     s3 = sim.sensitivity('OH', 3)  # sensitivity of OH to reaction 3
-    states.append(r.thermo.state, t=1000*t, s2=s2, s3=s3)
+    states.append(r.contents.state, t=1000*t, s2=s2, s3=s3)
 
     print('{:10.3e} {:10.3f} {:10.3f} {:14.6e} {:10.3f} {:10.3f}'.format(
-        sim.time, r.T, r.thermo.P, r.thermo.u, s2, s3))
+        sim.time, r.T, r.contents.P, r.contents.u, s2, s3))
 
 # plot the results if matplotlib is installed.
 # see http://matplotlib.org/ to get it

--- a/samples/python/reactors/surf_pfr.py
+++ b/samples/python/reactors/surf_pfr.py
@@ -80,7 +80,7 @@ while sim.distance < length:
     output_data.append(
         [dist, r.T - 273.15, r.contents.P / ct.one_atm]
         + list(r.contents.X)  # use r.contents.X not gas.X
-        + list(rsurf.kinetics.coverages)  # use rsurf.kinetics.coverages not surf.coverages
+        + list(rsurf.contents.coverages)  # use rsurf.contents.coverages not surf.coverages
     )
 
 with open(output_filename, 'w', newline="") as outfile:

--- a/samples/python/reactors/surf_pfr.py
+++ b/samples/python/reactors/surf_pfr.py
@@ -7,7 +7,7 @@ packed bed reactor. This example solves the DAE system directly, using the `Flow
 class and the SUNDIALS IDA solver, in contrast to the approximation as a chain of
 steady-state WSRs used in :doc:`surf_pfr_chain.py <surf_pfr_chain>`.
 
-Requires: cantera >= 3.0.0
+Requires: cantera >= 3.2.0
 
 .. tags:: Python, catalysis, reactor network, surface chemistry, plug flow reactor,
           packed bed reactor
@@ -65,7 +65,7 @@ output_data = []
 n = 0
 print('    distance       X_CH4        X_H2        X_CO')
 print('  {:10f}  {:10f}  {:10f}  {:10f}'.format(
-      0, *r.thermo['CH4', 'H2', 'CO'].X))
+      0, *r.contents['CH4', 'H2', 'CO'].X))
 
 while sim.distance < length:
     dist = sim.distance * 1e3  # convert to mm
@@ -73,13 +73,13 @@ while sim.distance < length:
 
     if n % 100 == 0 or (dist > 1 and n % 10 == 0):
         print('  {:10f}  {:10f}  {:10f}  {:10f}'.format(
-              dist, *r.thermo['CH4', 'H2', 'CO'].X))
+              dist, *r.contents['CH4', 'H2', 'CO'].X))
     n += 1
 
     # write the gas mole fractions and surface coverages vs. distance
     output_data.append(
-        [dist, r.T - 273.15, r.thermo.P / ct.one_atm]
-        + list(r.thermo.X)  # use r.thermo.X not gas.X
+        [dist, r.T - 273.15, r.contents.P / ct.one_atm]
+        + list(r.contents.X)  # use r.contents.X not gas.X
         + list(rsurf.kinetics.coverages)  # use rsurf.kinetics.coverages not surf.coverages
     )
 

--- a/samples/python/reactors/surf_pfr_chain.py
+++ b/samples/python/reactors/surf_pfr_chain.py
@@ -119,7 +119,7 @@ for n in range(NReactors):
     output_data.append(
         [dist, r.T - 273.15, r.contents.P / ct.one_atm]
         + list(r.contents.X)  # use r.contents.X not gas.X
-        + list(rsurf.kinetics.coverages)  # use rsurf.kinetics.coverages not surf.coverages
+        + list(rsurf.contents.coverages)  # use rsurf.contents.coverages not surf.coverages
     )
 
 with open(output_filename, 'w', newline="") as outfile:

--- a/samples/python/reactors/surf_pfr_chain.py
+++ b/samples/python/reactors/surf_pfr_chain.py
@@ -8,7 +8,7 @@ platinum catalyst in a packed bed reactor. To avoid needing to solve a DAE syste
 PFR is approximated as a chain of successive WSRs. See :doc:`surf_pfr.py <surf_pfr>` for
 a more advanced implementation that solves the DAE system directly.
 
-Requires: cantera >= 3.0
+Requires: cantera >= 3.2
 
 .. tags:: Python, catalysis, reactor network, surface chemistry, plug flow reactor,
           packed bed reactor
@@ -105,7 +105,7 @@ output_data = []
 
 for n in range(NReactors):
     # Set the state of the reservoir to match that of the previous reactor
-    gas.TDY = r.thermo.TDY
+    gas.TDY = r.contents.TDY
     upstream.syncState()
     sim.reinitialize()
     sim.advance_to_steady_state()
@@ -113,12 +113,12 @@ for n in range(NReactors):
 
     if n % 10 == 0:
         print('  {0:10f}  {1:10f}  {2:10f}  {3:10f}'.format(
-            dist, *r.thermo['CH4', 'H2', 'CO'].X))
+            dist, *r.contents['CH4', 'H2', 'CO'].X))
 
     # write the gas mole fractions and surface coverages vs. distance
     output_data.append(
-        [dist, r.T - 273.15, r.thermo.P / ct.one_atm]
-        + list(r.thermo.X)  # use r.thermo.X not gas.X
+        [dist, r.T - 273.15, r.contents.P / ct.one_atm]
+        + list(r.contents.X)  # use r.contents.X not gas.X
         + list(rsurf.kinetics.coverages)  # use rsurf.kinetics.coverages not surf.coverages
     )
 

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -26,8 +26,8 @@ FlowDevice::FlowDevice(shared_ptr<ReactorBase> r0, shared_ptr<ReactorBase> r1,
     m_out->addInlet(*this);
 
     // construct adapters between inlet and outlet species
-    const ThermoPhase& mixin = m_in->contents();
-    const ThermoPhase& mixout = m_out->contents();
+    const ThermoPhase& mixin = *m_in->contents4()->thermo();
+    const ThermoPhase& mixout = *m_out->contents4()->thermo();
 
     m_nspin = mixin.nSpecies();
     m_nspout = mixout.nSpecies();

--- a/src/zeroD/FlowReactor.cpp
+++ b/src/zeroD/FlowReactor.cpp
@@ -50,7 +50,7 @@ void FlowReactor::getStateDae(double* y, double* ydot)
     // need to advance the reactor surface to steady state to get the initial
     // coverages
     for (auto m_surf : m_surfaces) {
-        m_surf->syncState();
+        m_surf->restoreState();
         auto kin = static_cast<InterfaceKinetics*>(m_surf->kinetics());
         kin->advanceCoverages(100.0, m_ss_rtol, m_ss_atol, 0, m_max_ss_steps,
                               m_max_ss_error_fails);
@@ -238,7 +238,7 @@ void FlowReactor::updateSurfaceState(double* y)
         // the system.
         // note: the ReactorSurface class doesn't normalize when calling setCoverages
         S->setCoverages(y+loc);
-        S->syncState();
+        S->restoreState();
         loc += S->thermo()->nSpecies();
     }
 }

--- a/src/zeroD/MoleReactor.cpp
+++ b/src/zeroD/MoleReactor.cpp
@@ -67,7 +67,7 @@ void MoleReactor::evalSurfaces(double* LHS, double* RHS, double* sdot)
         SurfPhase* surf = S->thermo();
         double wallarea = S->area();
         size_t nk = surf->nSpecies();
-        S->syncState();
+        S->restoreState();
         kin->getNetProductionRates(&m_work[0]);
         for (size_t k = 0; k < nk; k++) {
             RHS[loc + k] = m_work[k] * wallarea / surf->size(k);
@@ -86,7 +86,7 @@ void MoleReactor::addSurfaceJacobian(vector<Eigen::Triplet<double>> &triplets)
 {
     size_t offset = m_nsp;
     for (auto& S : m_surfaces) {
-        S->syncState();
+        S->restoreState();
         double A = S->area();
         auto kin = S->kinetics();
         size_t nk = S->thermo()->nSpecies();

--- a/src/zeroD/Reactor.cpp
+++ b/src/zeroD/Reactor.cpp
@@ -318,7 +318,7 @@ void Reactor::evalSurfaces(double* LHS, double* RHS, double* sdot)
         double rs0 = 1.0/surf->siteDensity();
         size_t nk = surf->nSpecies();
         double sum = 0.0;
-        S->syncState();
+        S->restoreState();
         kin->getNetProductionRates(&m_work[0]);
         for (size_t k = 1; k < nk; k++) {
             RHS[loc + k] = m_work[k] * rs0 * surf->size(k);
@@ -416,7 +416,7 @@ void Reactor::evalSurfaces(double* RHS, double* sdot)
         double rs0 = 1.0/surf->siteDensity();
         size_t nk = surf->nSpecies();
         double sum = 0.0;
-        S->syncState();
+        S->restoreState();
         kin->getNetProductionRates(&m_work[0]);
         for (size_t k = 1; k < nk; k++) {
             RHS[loc + k] = m_work[k] * rs0 * surf->size(k);

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -118,7 +118,7 @@ void ReactorNet::initialize()
     m_start.assign(1, 0);
     for (size_t n = 0; n < m_reactors.size(); n++) {
         Reactor& r = *m_reactors[n];
-        shared_ptr<Solution> bulk = r.solution();
+        shared_ptr<Solution> bulk = r.contents4();
         r.initialize(m_time);
         size_t nv = r.neq();
         m_nv += nv;
@@ -134,7 +134,7 @@ void ReactorNet::initialize()
         }
         solutions[bulk.get()].push_back(r.name());
         for (size_t i = 0; i < r.nSurfs(); i++) {
-            if (r.surface(i)->solution()->adjacent(bulk->name()) != bulk) {
+            if (r.surface(i)->contents4()->adjacent(bulk->name()) != bulk) {
                 throw CanteraError("ReactorNet::initialize",
                     "Bulk phase '{}' used by interface '{}' must be the same object\n"
                     "as the contents of the adjacent reactor '{}'.",
@@ -144,7 +144,7 @@ void ReactorNet::initialize()
         }
     }
     for (auto surf : surfaces) {
-        solutions[surf->solution().get()].push_back(surf->name());
+        solutions[surf->contents4().get()].push_back(surf->name());
     }
     for (auto& [soln, reactors] : solutions) {
         if (reactors.size() > 1) {

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -22,7 +22,7 @@ ReactorSurface::ReactorSurface(shared_ptr<Solution> soln,
     // TODO: After Cantera 3.2, raise an exception of 'reactors' is empty
     vector<shared_ptr<Solution>> adjacent;
     for (auto R : reactors) {
-        adjacent.push_back(R->solution());
+        adjacent.push_back(R->contents4());
         m_reactors.push_back(R.get());
         R->addSurface(this);
     }

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -155,7 +155,7 @@ void ReactorSurface::getCoverages(double* cov) const
     copy(m_cov.begin(), m_cov.end(), cov);
 }
 
-void ReactorSurface::syncState()
+void ReactorSurface::restoreState()
 {
     if (m_reactors.empty()) {
         // TODO: Remove this check after Cantera 3.2, since it will no longer be
@@ -166,6 +166,14 @@ void ReactorSurface::syncState()
     }
     m_surf->setTemperature(m_reactors[0]->temperature());
     m_surf->setCoveragesNoNorm(m_cov.data());
+}
+
+void ReactorSurface::syncState()
+{
+    warn_user("ReactorSurface::syncState", "Behavior changed in Cantera 3.2 for "
+        "consistency with ReactorBase. To set SurfPhase state from ReactorSurface "
+        "object, use restoreState().");
+    m_surf->getCoverages(m_cov.data());
 }
 
 void ReactorSurface::addSensitivityReaction(size_t rxn)

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -59,7 +59,7 @@ TEST(ctreactor, reactor_simple)
         count++;
     }
     // Reactor contents should be the same Solution & ThermoPhase objects
-    int32_t contents = reactor_solution(reactor);
+    int32_t contents = reactor_contents(reactor);
     int32_t contents_thermo = sol_thermo(contents);
     EXPECT_DOUBLE_EQ(thermo_temperature(contents_thermo), thermo_temperature(thermo));
     thermo_setTemperature(contents_thermo, 345.0);
@@ -95,7 +95,7 @@ TEST(ctreactor, reactor_clone)
     }
     // Reactor contents should be independent objects with a distinct state, and the
     // original thermo object should be unmodified
-    int32_t contents = reactor_solution(reactor);
+    int32_t contents = reactor_contents(reactor);
     ASSERT_GE(contents, 0);
     int32_t contents_thermo = sol_thermo(contents);
     ASSERT_GE(contents_thermo, 0);

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -739,7 +739,7 @@ class TestReactionPath:
         while T < 1900:
             net.step()
             T = r.T
-        return r.thermo
+        return r.contents
 
     def check_dot(self, gas, diagram, element):
         diagram.label_threshold = 0

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -2000,7 +2000,7 @@ class TestFlowReactor2:
         r.mass_flow_rate = 0.01
         sim.advance(0.6)
         Ygas1 = r.contents.Y
-        cov1 = rsurf.kinetics.coverages
+        cov1 = rsurf.contents.coverages
 
         # Reset the reactor to the same initial state
         r.contents.TPX = 1700, 4000, 'NH3:1.0, SiF4:0.4'
@@ -2011,7 +2011,7 @@ class TestFlowReactor2:
         sim.initial_time = 0.
         sim.advance(0.6)
         Ygas2 = r.contents.Y
-        cov2 = rsurf.kinetics.coverages
+        cov2 = rsurf.contents.coverages
 
         assert Ygas1 == approx(Ygas2)
         assert cov1 == approx(cov2)
@@ -3069,7 +3069,7 @@ class TestExtensibleReactor:
         kO2 = gas.species_index("O2")
         class SurfReactor(ct.ExtensibleIdealGasReactor):
             def replace_eval_surfaces(self, LHS, RHS, sdot):
-                site_density = self.surfaces[0].kinetics.site_density
+                site_density = self.surfaces[0].contents.site_density
                 sdot[:] = 0.0
                 LHS[:] = 1.0
                 RHS[:] = 0.0
@@ -3100,7 +3100,7 @@ class TestExtensibleReactor:
         total_sites = rsurf.area * surf.site_density
         def masses():
             mass_H = (r1.contents.elemental_mass_fraction("H") * r1.mass +
-                      total_sites * r1.surfaces[0].kinetics["H(s)"].X * Hweight)
+                      total_sites * r1.surfaces[0].contents["H(s)"].X * Hweight)
             mass_O = r1.contents.elemental_mass_fraction("O") * r1.mass
             return mass_H, mass_O
 
@@ -3117,8 +3117,8 @@ class TestExtensibleReactor:
         assert r1.contents.P == approx(647.56016304)
         assert r1.contents.X[kH2] == approx(0.4784268406)
         assert r1.contents.X[kO2] == approx(0.5215731594)
-        assert r1.surfaces[0].kinetics.X[kHs] == approx(0.3665198138)
-        assert r1.surfaces[0].kinetics.X[kPts] == approx(0.6334801862)
+        assert r1.surfaces[0].contents.X[kHs] == approx(0.3665198138)
+        assert r1.surfaces[0].contents.X[kPts] == approx(0.6334801862)
 
     def test_interactions(self):
         # Reactors connected by a movable, H2-permeable surface

--- a/test/python/test_reactor.py
+++ b/test/python/test_reactor.py
@@ -108,10 +108,10 @@ class TestReactor:
         self.net.advance(1.0)
 
         # Nothing should change from the initial condition
-        assert T1 == approx(self.r1.thermo.T)
-        assert T2 == approx(self.r2.thermo.T)
-        assert P1 == approx(self.r1.thermo.P)
-        assert P2 == approx(self.r2.thermo.P)
+        assert T1 == approx(self.r1.contents.T)
+        assert T2 == approx(self.r2.contents.T)
+        assert P1 == approx(self.r1.contents.P)
+        assert P2 == approx(self.r2.contents.P)
 
     def test_disjoint2(self):
         T1, P1 = 300, 101325
@@ -123,8 +123,8 @@ class TestReactor:
         # Nothing should change from the initial condition
         assert T1 == approx(self.r1.T)
         assert T2 == approx(self.r2.T)
-        assert P1 == approx(self.r1.thermo.P)
-        assert P2 == approx(self.r2.thermo.P)
+        assert P1 == approx(self.r1.contents.P)
+        assert P2 == approx(self.r2.contents.P)
 
     def test_derivative(self):
         T1, P1 = 300, 101325
@@ -145,7 +145,7 @@ class TestReactor:
     def test_finite_difference_jacobian(self):
         self.make_reactors(n_reactors=1, T1=900, P1=101325, X1="H2:0.4, O2:0.4, N2:0.2")
         kH2 = self.gas1.species_index("H2")
-        while self.r1.thermo.X[kH2] > 0.3:
+        while self.r1.contents.X[kH2] > 0.3:
             self.net.step()
 
         J = self.r1.finite_difference_jacobian
@@ -257,7 +257,7 @@ class TestReactor:
         self.net.advance(1.0)
 
         assert self.net.time == approx(1.0)
-        assert self.r1.thermo.P == approx(self.r2.thermo.P)
+        assert self.r1.contents.P == approx(self.r2.contents.P)
         assert self.r1.T != approx(self.r2.T)
 
     def test_tolerances(self, rtol_lim=1e-10, atol_lim=1e-20):
@@ -354,7 +354,7 @@ class TestReactor:
         self.net.advance(10.0)
         assert self.net.time == approx(10.0)
         assert self.r1.T == approx(self.r2.T, rel=5e-7)
-        assert self.r1.thermo.P != approx(self.r2.thermo.P)
+        assert self.r1.contents.P != approx(self.r2.contents.P)
 
     def test_advance_limits_invalid(self):
         self.make_reactors(n_reactors=1)
@@ -409,9 +409,9 @@ class TestReactor:
         gas.equilibrate('UV')
 
         assert self.r1.T == approx(gas.T)
-        assert self.r1.thermo.density == approx(gas.density)
-        assert self.r1.thermo.P == approx(gas.P)
-        assert self.r1.thermo.X == approx(gas.X)
+        assert self.r1.contents.density == approx(gas.density)
+        assert self.r1.contents.P == approx(gas.P)
+        assert self.r1.contents.X == approx(gas.X)
 
     def test_equilibrium_HP(self):
         # Adiabatic, constant pressure combustion should proceed to equilibrium
@@ -433,9 +433,9 @@ class TestReactor:
         gas2.equilibrate('HP')
 
         assert r1.T == approx(gas2.T)
-        assert r1.thermo.P == approx(P0)
-        assert r1.thermo.density == approx(gas2.density)
-        assert r1.thermo.X == approx(gas2.X)
+        assert r1.contents.P == approx(P0)
+        assert r1.contents.density == approx(gas2.density)
+        assert r1.contents.X == approx(gas2.X)
 
     def test_wall_velocity(self):
         self.make_reactors()
@@ -476,15 +476,15 @@ class TestReactor:
         self.net.advance(11.0)
 
         assert self.r1.T == approx(1000)
-        assert self.r1.thermo.X[self.r1.thermo.species_index('H2')] == approx(2.0/3.0)
-        assert self.r1.thermo.X[self.r1.thermo.species_index('O2')] == approx(1.0/3.0)
+        assert self.r1.contents.X[self.r1.contents.species_index('H2')] == approx(2.0/3.0)
+        assert self.r1.contents.X[self.r1.contents.species_index('O2')] == approx(1.0/3.0)
 
     def test_heat_flux_func(self):
         self.make_reactors(T1=500, T2=300)
         self.r1.volume = 0.5
 
-        U1a = self.r1.volume * self.r1.density * self.r1.thermo.u
-        U2a = self.r2.volume * self.r2.density * self.r2.thermo.u
+        U1a = self.r1.volume * self.r1.density * self.r1.contents.u
+        U2a = self.r2.volume * self.r2.density * self.r2.contents.u
 
         V1a = self.r1.volume
         V2a = self.r2.volume
@@ -496,8 +496,8 @@ class TestReactor:
 
         self.net.advance(1.1)
         assert self.w.heat_flux == hfunc(1.1)
-        U1b = self.r1.volume * self.r1.density * self.r1.thermo.u
-        U2b = self.r2.volume * self.r2.density * self.r2.thermo.u
+        U1b = self.r1.volume * self.r1.density * self.r1.contents.u
+        U2b = self.r2.volume * self.r2.density * self.r2.contents.u
 
         assert V1a == approx(self.r1.volume)
         assert V2a == approx(self.r2.volume)
@@ -591,24 +591,24 @@ class TestReactor:
         assert self.r1.energy_enabled
         assert self.r2.energy_enabled
         self.net.initialize()
-        assert (self.r1.thermo.P - self.r2.thermo.P) * k == approx(
+        assert (self.r1.contents.P - self.r2.contents.P) * k == approx(
                 valve.mass_flow_rate)
 
-        m1a = self.r1.thermo.density * self.r1.volume
-        m2a = self.r2.thermo.density * self.r2.volume
-        Y1a = self.r1.thermo.Y
-        Y2a = self.r2.thermo.Y
+        m1a = self.r1.contents.density * self.r1.volume
+        m2a = self.r2.contents.density * self.r2.volume
+        Y1a = self.r1.contents.Y
+        Y2a = self.r2.contents.Y
 
         self.net.advance(0.1)
 
-        m1b = self.r1.thermo.density * self.r1.volume
-        m2b = self.r2.thermo.density * self.r2.volume
+        m1b = self.r1.contents.density * self.r1.volume
+        m2b = self.r2.contents.density * self.r2.volume
 
-        assert (self.r1.thermo.P - self.r2.thermo.P) * k == approx(
+        assert (self.r1.contents.P - self.r2.contents.P) * k == approx(
                 valve.mass_flow_rate)
         assert m1a + m2a == approx(m1b + m2b)
-        Y1b = self.r1.thermo.Y
-        Y2b = self.r2.thermo.Y
+        Y1b = self.r1.contents.Y
+        Y2b = self.r2.contents.Y
         assert m1a*Y1a + m2a*Y2a == approx(m1b*Y1b + m2b*Y2b, abs=1e-10)
         assert Y1a == approx(Y1b)
 
@@ -628,10 +628,10 @@ class TestReactor:
         assert not self.r1.energy_enabled
         assert not self.r2.energy_enabled
 
-        m1a = self.r1.thermo.density * self.r1.volume
-        m2a = self.r2.thermo.density * self.r2.volume
-        P1a = self.r1.thermo.P
-        P2a = self.r2.thermo.P
+        m1a = self.r1.contents.density * self.r1.volume
+        m2a = self.r2.contents.density * self.r2.volume
+        P1a = self.r1.contents.P
+        P2a = self.r2.contents.P
         Y1 = self.r1.Y
 
         A = k * P1a * (1 + m2a/m1a)
@@ -639,8 +639,8 @@ class TestReactor:
 
         for t in np.linspace(1e-5, 0.5):
             self.net.advance(t)
-            m1 = self.r1.thermo.density * self.r1.volume
-            m2 = self.r2.thermo.density * self.r2.volume
+            m1 = self.r1.contents.density * self.r1.volume
+            m2 = self.r2.contents.density * self.r2.volume
             assert m2 == approx((m2a - A/B) * np.exp(-B * t) + A/B)
             assert m1a + m2a == approx(m1 + m2)
             assert self.r1.Y == approx(Y1)
@@ -669,8 +669,8 @@ class TestReactor:
         t = 0
         while t < 1.0:
             t = self.net.step()
-            p1 = self.r1.thermo.P
-            p2 = self.r2.thermo.P
+            p1 = self.r1.contents.P
+            p2 = self.r2.contents.P
             assert mdot(p1-p2) == approx(valve.mass_flow_rate)
             assert Y1 == approx(self.r1.Y)
             assert speciesMass(kAr) == approx(mAr)
@@ -685,8 +685,8 @@ class TestReactor:
         valve.valve_coeff = k
         valve.time_function = lambda t: t > .01
 
-        delta_p = lambda: self.r1.thermo.P - self.r2.thermo.P
-        mdot = lambda: valve.valve_coeff * (self.r1.thermo.P - self.r2.thermo.P)
+        delta_p = lambda: self.r1.contents.P - self.r2.contents.P
+        mdot = lambda: valve.valve_coeff * (self.r1.contents.P - self.r2.contents.P)
         self.net.initialize()
         assert valve.time_function == 0.0
         assert valve.pressure_function == approx(delta_p())
@@ -749,7 +749,7 @@ class TestReactor:
         while t < 1.0:
             t = self.net.step()
             assert mdot(t) == approx(mfc.mass_flow_rate)
-            dP = self.r1.thermo.P - outlet_reservoir.thermo.P
+            dP = self.r1.contents.P - outlet_reservoir.contents.P
             assert mdot(t) + 1e-5 * dP == approx(pc.mass_flow_rate)
 
     def test_pressure_controller2(self):
@@ -775,7 +775,7 @@ class TestReactor:
         while t < 1.0:
             t = self.net.step()
             assert mdot(t) == approx(mfc.mass_flow_rate)
-            dP = self.r1.thermo.P - outlet_reservoir.thermo.P
+            dP = self.r1.contents.P - outlet_reservoir.contents.P
             assert mdot(t) + pfunc(dP) == approx(pc.mass_flow_rate)
 
     def test_pressure_controller_type(self):
@@ -819,8 +819,8 @@ class TestReactor:
         tf = t0 + 0.5
         self.net.advance(tf)
         assert self.net.time == approx(tf)
-        p1a = self.r1.thermo.P
-        p2a = self.r2.thermo.P
+        p1a = self.r1.contents.P
+        p2a = self.r2.contents.P
         assert valve.pressure_function == approx(pfunc_a(p1a - p2a))
 
         self.make_reactors(P1=10*ct.one_atm, X1='AR:1.0', X2='O2:1.0')
@@ -834,8 +834,8 @@ class TestReactor:
         tf = t0 + 0.5
         self.net.advance(tf)
         assert self.net.time == approx(tf)
-        p1b = self.r1.thermo.P
-        p2b = self.r2.thermo.P
+        p1b = self.r1.contents.P
+        p2b = self.r2.contents.P
         assert valve.pressure_function == approx(pfunc_b(p1b - p2b))
 
         assert p1a == approx(p1b)
@@ -848,10 +848,10 @@ class TestReactor:
         T1a = self.r1.T
         T2a = self.r2.T
 
-        self.r1.thermo.TD = 300, None
+        self.r1.contents.TD = 300, None
         self.r1.syncState()
 
-        self.r2.thermo.TD = 1000, None
+        self.r2.contents.TD = 1000, None
         self.r2.syncState()
 
         assert self.r1.T == approx(300)
@@ -870,7 +870,7 @@ class TestReactor:
         wall = ct.Wall(self.r1, reservoir, U=500)
         self.net.advance(1.0)
         assert self.r1.T == approx(872.099, rel=1e-3)
-        reservoir.thermo.TP = 700, ct.one_atm
+        reservoir.contents.TP = 700, ct.one_atm
         reservoir.syncState()
         self.net.reinitialize()
         self.net.advance(2.0)
@@ -1137,9 +1137,9 @@ class TestMoleReactor(TestReactor):
         for i in np.linspace(0, 0.0025, 50)[1:]:
             net1.advance(i)
             net2.advance(i)
-            assert r1.thermo.Y == approx(r2.thermo.Y, rel=5e-4, abs=1e-6)
+            assert r1.contents.Y == approx(r2.contents.Y, rel=5e-4, abs=1e-6)
             assert r1.T == approx(r2.T, rel=5e-5)
-            assert r1.thermo.P == approx(r2.thermo.P, rel=1e-6)
+            assert r1.contents.P == approx(r2.contents.P, rel=1e-6)
             assert rsurf1.coverages == approx(rsurf2.coverages, rel=1e-4, abs=1e-8)
 
     def test_tolerances(self, rtol_lim=1e-8, atol_lim=1e-18):
@@ -1214,13 +1214,13 @@ class TestWellStirredReactorIgnition:
         mdot_o = 5.0
         T0 = 900.0
         self.setup_reactor(T0, 10*ct.one_atm, mdot_f, mdot_o)
-        self.combustor.thermo.set_multiplier(0.0)
+        self.combustor.contents.set_multiplier(0.0)
         t,T = self.integrate(100.0)
 
         for i in range(len(t)):
             assert T[i] == approx(T0, rel=1e-5)
 
-        assert self.combustor.thermo['CH4'].Y == approx(mdot_f / (mdot_o + mdot_f))
+        assert self.combustor.contents['CH4'].Y == approx(mdot_f / (mdot_o + mdot_f))
 
     def test_ignition1(self):
         self.setup_reactor(900.0, 10*ct.one_atm, 1.0, 5.0)
@@ -1263,8 +1263,8 @@ class TestWellStirredReactorIgnition:
         assert residuals[-1] < 10. * self.net.rtol
         # regression test; no external basis for these results
         assert self.combustor.T == approx(2498.94, rel=1e-5)
-        assert self.combustor.thermo['H2O'].Y[0] == approx(0.103658, rel=1e-5)
-        assert self.combustor.thermo['HO2'].Y[0] == approx(8.734515e-06, rel=1e-5)
+        assert self.combustor.contents['H2O'].Y[0] == approx(0.103658, rel=1e-5)
+        assert self.combustor.contents['HO2'].Y[0] == approx(8.734515e-06, rel=1e-5)
 
     @pytest.mark.parametrize("reactor_class",
         [ct.Reactor, ct.IdealGasReactor, ct.MoleReactor, ct.IdealGasMoleReactor])
@@ -1273,8 +1273,8 @@ class TestWellStirredReactorIgnition:
         self.net.solve_steady()
         # regression test; based on test_advance_to_steady_state
         assert self.combustor.T == approx(2498.94, rel=1e-5)
-        assert self.combustor.thermo['H2O'].Y[0] == approx(0.103658, rel=1e-5)
-        assert self.combustor.thermo['HO2'].Y[0] == approx(8.734515e-06, rel=1e-5)
+        assert self.combustor.contents['H2O'].Y[0] == approx(0.103658, rel=1e-5)
+        assert self.combustor.contents['HO2'].Y[0] == approx(8.734515e-06, rel=1e-5)
 
 class TestConstPressureReactor:
     """
@@ -1395,9 +1395,9 @@ class TestConstPressureReactor:
         for t in np.arange(0.5, 50, 1.0):
             self.net1.advance(t)
             self.net2.advance(t)
-            assert self.r1.thermo.Y == approx(self.r2.thermo.Y, rel=5e-4, abs=1e-6)
+            assert self.r1.contents.Y == approx(self.r2.contents.Y, rel=5e-4, abs=1e-6)
             assert self.r1.T == approx(self.r2.T, rel=5e-5)
-            assert self.r1.thermo.P == approx(self.r2.thermo.P, rel=1e-6)
+            assert self.r1.contents.P == approx(self.r2.contents.P, rel=1e-6)
             if surf:
                 assert self.surf1.coverages == approx(self.surf2.coverages,
                                                       rel=1e-4, abs=1e-8)
@@ -1495,9 +1495,9 @@ class TestIdealGasMoleReactor(TestMoleReactor):
         for t in np.arange(0.5, 5, 0.5):
             net1.advance(t)
             net2.advance(t)
-            assert r1.thermo.Y == approx(r2.thermo.Y, rel=5e-4, abs=1e-6)
+            assert r1.contents.Y == approx(r2.contents.Y, rel=5e-4, abs=1e-6)
             assert r1.T == approx(r2.T, rel=1e-5)
-            assert r1.thermo.P == approx(r2.thermo.P, rel=1e-5)
+            assert r1.contents.P == approx(r2.contents.P, rel=1e-5)
 
 
 class TestReactorJacobians:
@@ -1756,19 +1756,19 @@ class TestFlowReactor:
         kCO = gas.species_index('CO')
 
         sim.advance(1e-7)
-        X = r.thermo['CH4', 'H2', 'CO'].X
+        X = r.contents['CH4', 'H2', 'CO'].X
         assert X == approx([0.10578801, 0.001654415, 0.012103974])
-        assert r.thermo.density * r.area * r.speed == approx(mdot)
+        assert r.contents.density * r.area * r.speed == approx(mdot)
 
         sim.advance(1e-5)
-        X = r.thermo['CH4', 'H2', 'CO'].X
+        X = r.contents['CH4', 'H2', 'CO'].X
         assert X == approx([0.07748481, 0.048165072, 0.01446654])
-        assert r.thermo.density * r.area * r.speed == approx(mdot)
+        assert r.contents.density * r.area * r.speed == approx(mdot)
 
         sim.advance(1e-3)
-        X = r.thermo['CH4', 'H2', 'CO'].X
+        X = r.contents['CH4', 'H2', 'CO'].X
         assert X == approx([0.01815402, 0.21603645, 0.045640395])
-        assert r.thermo.density * r.area * r.speed == approx(mdot)
+        assert r.contents.density * r.area * r.speed == approx(mdot)
 
     def test_component_names(self):
         surf = ct.Interface('methane_pox_on_pt.yaml', 'Pt_surf')
@@ -1844,7 +1844,7 @@ class TestFlowReactor2:
 
         with pytest.raises(ct.CanteraError,
                            match="repeated recoverable residual errors"):
-            while r.thermo.T > 1300:
+            while r.contents.T > 1300:
                 sim.step()
 
     def test_integrator_errors_advance(self):
@@ -1861,7 +1861,7 @@ class TestFlowReactor2:
 
         with pytest.raises(ct.CanteraError,
                            match="repeated recoverable residual errors"):
-            while r.thermo.T > 1300:
+            while r.contents.T > 1300:
                 sim.advance(sim.distance + 0.01)
 
     def test_recoverable_integrator_errors(self):
@@ -1876,11 +1876,11 @@ class TestFlowReactor2:
         surf.TP = gas.TP
         r, rsurf, sim = self.make_reactors(gas, surf)
 
-        while r.thermo.T > 1300:
+        while r.contents.T > 1300:
             sim.step()
 
         # At least some "recoverable" errors occurred
-        assert r.thermo.reaction(gas.n_reactions - 1).rate.count > 0
+        assert r.contents.reaction(gas.n_reactions - 1).rate.count > 0
 
     def test_max_steps(self):
         surf, gas = self.import_phases()
@@ -1999,18 +1999,18 @@ class TestFlowReactor2:
         r, rsurf, sim = self.make_reactors(gas, surf)
         r.mass_flow_rate = 0.01
         sim.advance(0.6)
-        Ygas1 = r.thermo.Y
+        Ygas1 = r.contents.Y
         cov1 = rsurf.kinetics.coverages
 
         # Reset the reactor to the same initial state
-        r.thermo.TPX = 1700, 4000, 'NH3:1.0, SiF4:0.4'
+        r.contents.TPX = 1700, 4000, 'NH3:1.0, SiF4:0.4'
         surf.TP = 1700, 4000
         r.mass_flow_rate = 0.01
         r.syncState()
 
         sim.initial_time = 0.
         sim.advance(0.6)
-        Ygas2 = r.thermo.Y
+        Ygas2 = r.contents.Y
         cov2 = rsurf.kinetics.coverages
 
         assert Ygas1 == approx(Ygas2)
@@ -2100,8 +2100,8 @@ class TestSurfaceKinetics:
         data = []
         for t in np.linspace(1e-6, 1e-3):
             self.net.advance(t)
-            data.append([t, self.r1.T, self.r1.thermo.P, self.r1.mass] +
-                        list(self.r1.thermo.X) + list(surf1.coverages))
+            data.append([t, self.r1.T, self.r1.contents.P, self.r1.mass] +
+                        list(self.r1.contents.X) + list(surf1.coverages))
         np.savetxt(test_file, data, delimiter=',')
 
         bad = compareProfiles(reference_file, test_file,
@@ -2125,8 +2125,8 @@ class TestSurfaceKinetics:
         data = []
         for t in np.linspace(1e-6, 1e-3):
             self.net.advance(t)
-            data.append([t, self.r1.T, self.r1.thermo.P, self.r1.mass] +
-                        list(self.r1.thermo.X) + list(surf.coverages))
+            data.append([t, self.r1.T, self.r1.contents.P, self.r1.mass] +
+                        list(self.r1.contents.X) + list(surf.coverages))
         np.savetxt(test_file, data, delimiter=',')
 
         bad = compareProfiles(reference_file, test_file,
@@ -2435,7 +2435,7 @@ class TestReactorSensitivities:
         T = []
         while net.time < 0.6:
             t.append(net.time)
-            T.append(r.thermo.T)
+            T.append(r.contents.T)
             net.step()
         T = np.array(T)
         t = np.array(t)
@@ -2456,7 +2456,7 @@ class TestReactorSensitivities:
         while net.time < 0.6:
             net.step()
             t.append(net.time)
-            T.append(r.thermo.T)
+            T.append(r.contents.T)
             S.append(net.sensitivities()[iTemp])
 
         T = np.array(T)
@@ -2572,7 +2572,7 @@ class TestCombustor:
         data = []
         while tnow < tfinal:
             tnow = sim.step()
-            data.append([tnow, combustor.T] + list(combustor.thermo.X))
+            data.append([tnow, combustor.T] + list(combustor.contents.X))
 
         assert tnow >= tfinal
         bad = compareProfiles(test_data_path / self.referenceFile, data,
@@ -2586,7 +2586,7 @@ class TestCombustor:
         data = []
         for t in np.linspace(0, 0.25, 101)[1:]:
             sim.advance(t)
-            data.append([t, combustor.T] + list(combustor.thermo.X))
+            data.append([t, combustor.T] + list(combustor.contents.X))
 
         saveReference = request.config.getoption("--save-reference")
         if saveReference == 'combustor':
@@ -2613,7 +2613,7 @@ class TestCombustor:
         data = []
         for t in np.linspace(0, 0.25, 101)[1:]:
             sim.advance(t)
-            data.append([t, combustor.T] + list(combustor.thermo.X))
+            data.append([t, combustor.T] + list(combustor.contents.X))
 
         bad = compareProfiles(test_data_path / self.referenceFile, data,
                               rtol=1e-6, atol=1e-12)
@@ -2673,8 +2673,8 @@ class TestWall:
         data = []
         while tnow < tfinal:
             tnow = sim.step()
-            data.append([tnow, r1.T, r2.T, r1.thermo.P,
-                        r2.thermo.P, r1.volume, r2.volume])
+            data.append([tnow, r1.T, r2.T, r1.contents.P,
+                        r2.contents.P, r1.volume, r2.volume])
 
         assert tnow >= tfinal
         bad = compareProfiles(test_data_path / self.referenceFile, data,
@@ -2686,8 +2686,8 @@ class TestWall:
         data = []
         for t in np.linspace(0, 0.01, 200)[1:]:
             sim.advance(t)
-            data.append([t, r1.T, r2.T, r1.thermo.P,
-                        r2.thermo.P, r1.volume, r2.volume])
+            data.append([t, r1.T, r2.T, r1.contents.P,
+                        r2.contents.P, r1.volume, r2.volume])
 
         saveReference = request.config.getoption("--save-reference")
         if saveReference == 'wall':
@@ -2724,7 +2724,7 @@ class TestPureFluidReactor:
         states = ct.SolutionArray(phase, extra='t')
         for t in np.arange(0.0, 60.0, 1):
             net.advance(t)
-            states.append(TD=r1.thermo.TD, t=net.time)
+            states.append(TD=r1.contents.TD, t=net.time)
 
         assert states.Q[0] == 0
         assert states.Q[-1] == 1
@@ -2749,7 +2749,7 @@ class TestPureFluidReactor:
         states = ct.SolutionArray(phase, extra='t')
         for t in np.arange(0.0, 60.0, 1):
             net.advance(t)
-            states.append(TD=r1.thermo.TD, t=net.time)
+            states.append(TD=r1.contents.TD, t=net.time)
 
         assert states.Q[0] == 0
         assert states.Q[-1] == 1
@@ -2773,7 +2773,7 @@ class TestPureFluidReactor:
         states = ct.SolutionArray(phase, extra='t')
         for t in np.arange(0.0, 100.0, 10):
             net.advance(t)
-            states.append(TD=r1.thermo.TD, t=t)
+            states.append(TD=r1.contents.TD, t=t)
 
         assert states.Q[1] == 0
         assert states.Q[-2] == 1
@@ -2848,7 +2848,7 @@ class TestExtensibleReactor:
 
             def after_eval(self, t, LHS, RHS):
                 # Extra equation is d(v_wall)/dt = k * delta P
-                a = self.k_wall * (self.thermo.P - self.neighbor.thermo.P)
+                a = self.k_wall * (self.contents.P - self.neighbor.contents.P)
                 RHS[self.i_wall] = a
 
             def before_component_index(self, name):
@@ -2998,7 +2998,7 @@ class TestExtensibleReactor:
             # modify energy equation to include solid mass in reactor
             def after_eval(self,t,LHS,RHS):
                 self.m_mass = mass_gas
-                LHS[1] = mass_lump * cp_lump + self.m_mass * self.thermo.cp_mass
+                LHS[1] = mass_lump * cp_lump + self.m_mass * self.contents.cp_mass
                 RHS[1] = Q
 
         r1 = DummyReactor(self.gas, clone=True)
@@ -3010,8 +3010,8 @@ class TestExtensibleReactor:
 
         # compare heat added (add_heat) to the equivalent energy contained by the solid
         # and gaseous mass in the reactor
-        r1_heat = (mass_lump * cp_lump * (r1.thermo.T - 500) +
-                   mass_gas * (r1.thermo.enthalpy_mass - gas_initial_enthalpy))
+        r1_heat = (mass_lump * cp_lump * (r1.contents.T - 500) +
+                   mass_gas * (r1.contents.enthalpy_mass - gas_initial_enthalpy))
         add_heat = Q * time
         assert add_heat == approx(r1_heat, abs=1e-5)
 
@@ -3029,10 +3029,10 @@ class TestExtensibleReactor:
         res = ct.Reservoir(self.gas, clone=True)
         wall = ct.Wall(res, r1, Q=Qwall, A=1)
         net = ct.ReactorNet([r1])
-        U0 = r1.thermo.int_energy_mass * r1.mass
+        U0 = r1.contents.int_energy_mass * r1.mass
         for t in np.linspace(0.1, 5, 10):
             net.advance(t)
-            U = r1.thermo.int_energy_mass * r1.mass
+            U = r1.contents.int_energy_mass * r1.mass
             assert U - U0 == approx((Qext + Qwall) * t)
             assert r1.heat_rate == approx(Qext + Qwall)
 
@@ -3073,7 +3073,7 @@ class TestExtensibleReactor:
                 sdot[:] = 0.0
                 LHS[:] = 1.0
                 RHS[:] = 0.0
-                C = self.thermo.concentrations
+                C = self.contents.concentrations
                 theta = self.surfaces[0].coverages
 
                 # Replace actual reactions with simple absorption of H2 -> H(S)
@@ -3099,9 +3099,9 @@ class TestExtensibleReactor:
         Hweight = ct.Element("H").weight
         total_sites = rsurf.area * surf.site_density
         def masses():
-            mass_H = (r1.thermo.elemental_mass_fraction("H") * r1.mass +
+            mass_H = (r1.contents.elemental_mass_fraction("H") * r1.mass +
                       total_sites * r1.surfaces[0].kinetics["H(s)"].X * Hweight)
-            mass_O = r1.thermo.elemental_mass_fraction("O") * r1.mass
+            mass_O = r1.contents.elemental_mass_fraction("O") * r1.mass
             return mass_H, mass_O
 
         net.step()
@@ -3114,9 +3114,9 @@ class TestExtensibleReactor:
             assert mO == approx(mO0)
 
         # Regression test values
-        assert r1.thermo.P == approx(647.56016304)
-        assert r1.thermo.X[kH2] == approx(0.4784268406)
-        assert r1.thermo.X[kO2] == approx(0.5215731594)
+        assert r1.contents.P == approx(647.56016304)
+        assert r1.contents.X[kH2] == approx(0.4784268406)
+        assert r1.contents.X[kO2] == approx(0.5215731594)
         assert r1.surfaces[0].kinetics.X[kHs] == approx(0.3665198138)
         assert r1.surfaces[0].kinetics.X[kPts] == approx(0.6334801862)
 
@@ -3131,8 +3131,8 @@ class TestExtensibleReactor:
                 self.p_coeff = 5 # expansion coeff
 
             def after_update_connected(self, do_pressure):
-                self.conc_H2 = self.thermo.concentrations[kH2]
-                self.P = self.thermo.P
+                self.conc_H2 = self.contents.concentrations[kH2]
+                self.P = self.contents.P
 
             def replace_eval_walls(self, t):
                 if self.neighbor:
@@ -3143,7 +3143,7 @@ class TestExtensibleReactor:
                 if self.neighbor:
                     mdot_H2 = self.h2coeff * (self.neighbor.conc_H2 - self.conc_H2)
                     RHS[kH2+3] += mdot_H2
-                    RHS[3:] -= self.thermo.Y * mdot_H2
+                    RHS[3:] -= self.contents.Y * mdot_H2
                     RHS[0] += mdot_H2
                     # enthalpy flux is neglected, so energy isn't properly conserved
 
@@ -3157,10 +3157,10 @@ class TestExtensibleReactor:
         states1 = ct.SolutionArray(self.gas, extra=["t", "mass", "vdot"])
         states2 = ct.SolutionArray(self.gas, extra=["t", "mass", "vdot"])
         net.step()
-        M0 = r1.mass * r1.thermo.Y + r2.mass * r2.thermo.Y
+        M0 = r1.mass * r1.contents.Y + r2.mass * r2.contents.Y
 
         def deltaC():
-            return r1.thermo["H2"].concentrations[0] - r2.thermo["H2"].concentrations[0]
+            return r1.contents["H2"].concentrations[0] - r2.contents["H2"].concentrations[0]
         deltaCprev = deltaC()
 
         V0 = r1.volume + r2.volume
@@ -3171,16 +3171,16 @@ class TestExtensibleReactor:
             deltaCnow = deltaC()
             assert deltaCnow < deltaCprev # difference is always decreasing
             deltaCprev = deltaCnow
-            assert M0 == approx(r1.mass * r1.thermo.Y + r2.mass * r2.thermo.Y,rel=2e-8)
-            states1.append(r1.thermo.state, t=net.time, mass=r1.mass,
+            assert M0 == approx(r1.mass * r1.contents.Y + r2.mass * r2.contents.Y,rel=2e-8)
+            states1.append(r1.contents.state, t=net.time, mass=r1.mass,
                            vdot=r1.expansion_rate)
-            states2.append(r2.thermo.state, t=net.time, mass=r2.mass,
+            states2.append(r2.contents.state, t=net.time, mass=r2.mass,
                            vdot=r2.expansion_rate)
 
         # Regression test values
-        assert r1.thermo.P == approx(151561.15, rel=1e-6)
-        assert r1.thermo["H2"].Y[0] == approx(0.13765976, rel=1e-6)
-        assert r2.thermo["O2"].Y[0] == approx(0.94617029, rel=1e-6)
+        assert r1.contents.P == approx(151561.15, rel=1e-6)
+        assert r1.contents["H2"].Y[0] == approx(0.13765976, rel=1e-6)
+        assert r2.contents["O2"].Y[0] == approx(0.94617029, rel=1e-6)
 
 
 class TestSteadySolver:
@@ -3202,7 +3202,7 @@ class TestSteadySolver:
         net = ct.ReactorNet([r])
         net.solve_steady()
         assert r.volume == approx(V0)
-        assert r.thermo.T == approx(2429.2709)
+        assert r.contents.T == approx(2429.2709)
         assert r.mass == approx(0.002288176)
 
     @pytest.mark.parametrize("reactor_class",
@@ -3226,7 +3226,7 @@ class TestSteadySolver:
             net.solve_steady()
 
             assert r.mass == approx(m0)
-            assert r.thermo.T == approx(2407.35011)
+            assert r.contents.T == approx(2407.35011)
         else:
             # Expected to raise until https://github.com/Cantera/enhancements/issues/234
             # is implemented
@@ -3251,8 +3251,8 @@ class TestSteadySolver:
         ct.PressureController(r, downstream, primary=inlet)
         net = ct.ReactorNet([r])
         net.solve_steady()
-        assert r.thermo.T == approx(T0)
-        assert r.thermo["H2O"].Y[0] == approx(0.2161327927)
+        assert r.contents.T == approx(T0)
+        assert r.contents["H2O"].Y[0] == approx(0.2161327927)
 
     def test_multiple_reactors(self):
         gas = ct.Solution("h2o2.yaml", transport_model=None)
@@ -3272,8 +3272,8 @@ class TestSteadySolver:
         net.solve_steady()
 
         # reference values obtained from net.advance(1.0)
-        assert r1.thermo.T == approx(2429.27092)
-        assert r2.thermo.T == approx(2538.63069)
+        assert r1.contents.T == approx(2429.27092)
+        assert r2.contents.T == approx(2538.63069)
 
     @pytest.mark.parametrize("reactor_class",
         [ct.ConstPressureReactor, ct.IdealGasConstPressureReactor,
@@ -3300,9 +3300,9 @@ class TestSteadySolver:
             net.solve_steady()
 
         # Regression values based on net.advance_to_steady_state():
-        # assert r.thermo.T == approx(983.7363377)
-        # assert r.thermo.coverages[0] == approx(0.387425501)
-        # assert sum(r.thermo.coverages) == approx(1.0)
+        # assert r.contents.T == approx(983.7363377)
+        # assert r.contents.coverages[0] == approx(0.387425501)
+        # assert sum(r.contents.coverages) == approx(1.0)
 
     def test_jacobian(self):
         gas = ct.Solution("h2o2.yaml", transport_model=None)
@@ -3315,7 +3315,7 @@ class TestSteadySolver:
         V0 = 1e-3
         mdot = 120
         r = ct.MoleReactor(gas, volume=V0, clone=True)
-        r.thermo.set_multiplier(0.0)
+        r.contents.set_multiplier(0.0)
         inlet = ct.MassFlowController(upstream, r, mdot=mdot)
         ct.MassFlowController(r, downstream, mdot=mdot)
         net = ct.ReactorNet([r])
@@ -3325,7 +3325,7 @@ class TestSteadySolver:
         # Compare analytical derivatives of species equations which include only terms
         # related to outlet mass flow since reactions are disabled.
         W = gas.molecular_weights
-        Y = r.thermo.Y
+        Y = r.contents.Y
         mass = r.mass
         names = gas.species_names
         for i, k in np.ndindex(gas.n_species, gas.n_species):

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -941,7 +941,7 @@ class TestThermoPhase:
         self.phase.transport_model = "unity-Lewis-number"
         reactor = ct.IdealGasReactor(self.phase, clone=False)
         with pytest.raises(ct.CanteraError, match='Cannot add species'):
-            reactor.thermo.add_species(ref.species('CH4'))
+            reactor.contents.add_species(ref.species('CH4'))
         del reactor
         gc.collect()
         self.phase.add_species(ref.species('CH4'))

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -200,7 +200,7 @@ TEST(MoleReactorTestSet, test_mole_reactor_get_state)
     reactor.initialize();
     vector<double> state(reactor.neq());
     // test get state
-    const ThermoPhase& thermo = reactor.contents();
+    const ThermoPhase& thermo = *reactor.contents4()->thermo();
     const vector<double>& imw = thermo.inverseMolecularWeights();
     // prescribed state
     double mass = reactor.volume() * thermo.density();


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Python:
- Add new `contents` property for `ReactorBase` objects that returns a `Solution` object
- Deprecate old `thermo` and `kinetics` properties of `ReactorBase`, `Reactor`, and `ReactorSurface`

C++:
- Deprecate the existing `ReactorBase::contents` method that returns `ThermoPhase&`
- Rename the `solution` property of `ReactorBase` (which returns `shared_ptr<Solution>` to `contents4`, with the expectation of renaming this `contents` in a future version
- Change the implementation of `ReactorSurface::syncState` which actually did the opposite of the `ReactorBase::syncState` method. I don't think there's a non-breaking way to implement this change, but I also don't think there is much if any user code that calls this method directly. Normally, users would rely on `Reactor` methods to do this synchronization.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
