### PR TITLE
Rename `ReactorBase::contents` to `ReactorBase::phase`

### DIFF
--- a/doc/sphinx/python/zerodim.rst
+++ b/doc/sphinx/python/zerodim.rst
@@ -38,75 +38,75 @@ Reactors
 
 Reservoir
 ^^^^^^^^^
-.. autoclass:: Reservoir(phase=None, name=None)
+.. autoclass:: Reservoir(phase, name=None)
 
 Reactor
 ^^^^^^^
-.. autoclass:: Reactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: Reactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 MoleReactor
 ^^^^^^^^^^^
-.. autoclass:: MoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: MoleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasReactor
 ^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasMoleReactor
 ^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasMoleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ConstPressureReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ConstPressureReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ConstPressureMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ConstPressureMoleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasConstPressureReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasConstPressureReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasConstPressureMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasConstPressureMoleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 FlowReactor
 ^^^^^^^^^^^
-.. autoclass:: FlowReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: FlowReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleReactor
 ^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleConstPressureReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleConstPressureReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasConstPressureReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasConstPressureReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleMoleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasMoleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleConstPressureMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleConstPressureMoleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasConstPressureMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasConstPressureMoleReactor(phase, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 Walls
 -----

--- a/doc/sphinx/python/zerodim.rst
+++ b/doc/sphinx/python/zerodim.rst
@@ -38,75 +38,75 @@ Reactors
 
 Reservoir
 ^^^^^^^^^
-.. autoclass:: Reservoir(contents=None, name=None)
+.. autoclass:: Reservoir(phase=None, name=None)
 
 Reactor
 ^^^^^^^
-.. autoclass:: Reactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: Reactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 MoleReactor
 ^^^^^^^^^^^
-.. autoclass:: MoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: MoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasReactor
 ^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasMoleReactor
 ^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ConstPressureReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ConstPressureReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ConstPressureMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ConstPressureMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasConstPressureReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasConstPressureReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 IdealGasConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: IdealGasConstPressureMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: IdealGasConstPressureMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 FlowReactor
 ^^^^^^^^^^^
-.. autoclass:: FlowReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: FlowReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleReactor
 ^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleConstPressureReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleConstPressureReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasConstPressureReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasConstPressureReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasConstPressureReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleConstPressureMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleConstPressureMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 ExtensibleIdealGasConstPressureMoleReactor
 ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-.. autoclass:: ExtensibleIdealGasConstPressureMoleReactor(contents=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
+.. autoclass:: ExtensibleIdealGasConstPressureMoleReactor(phase=None, *, clone=None, name=None, energy='on', node_attr=None, group_name="")
 
 Walls
 -----
@@ -121,7 +121,7 @@ Surfaces
 
 ReactorSurface
 ^^^^^^^^^^^^^^
-.. autoclass:: ReactorSurface(contents, r=None, clone=None, name="(none)", *, A=None)
+.. autoclass:: ReactorSurface(phase, r=None, clone=None, name="(none)", *, A=None)
 
 Flow Controllers
 ----------------

--- a/doc/sphinx/userguide/extensible-reactor.md
+++ b/doc/sphinx/userguide/extensible-reactor.md
@@ -137,7 +137,7 @@ for mass_rock in [0.0, 1.0, 3.0]:
     # Integrate for 10 seconds
     net.advance(10)
 
-    print(f'mass_rock = {mass_rock} kg; ΔT = {r1.contents.T - T0:.2f} K')
+    print(f'mass_rock = {mass_rock} kg; ΔT = {r1.phase.T - T0:.2f} K')
 ```
 
 As expected, we see that the temperature rise decreases as the thermal mass of the

--- a/doc/sphinx/userguide/reactor-tutorial.md
+++ b/doc/sphinx/userguide/reactor-tutorial.md
@@ -38,7 +38,7 @@ reac = ct.IdealGasReactor(gas)
 sim = ct.ReactorNet([reac])
 
 # View the initial state of the mixture
-reac.contents()
+reac.phase()
 ```
 
 Now, let's advance the simulation in time to an absolute time of 1 second, and examine
@@ -52,7 +52,7 @@ ignited for a wide range of initial conditions.
 sim.advance(1)
 
 # view the updated state of the mixture, reflecting properties at t = 1 sec
-reac.contents()
+reac.phase()
 ```
 
 ## Methods for Time Integration
@@ -161,7 +161,7 @@ sim.preconditioner = precon  # Add it to the network
 The results of the time integration are the same as before:
 ```{code-cell} python
 sim.advance(1)
-reac.contents()
+reac.phase()
 ```
 
 The approximate Jacobian matrices used to construct the preconditioners do not currently

--- a/doc/sphinx/userguide/reactor-tutorial.md
+++ b/doc/sphinx/userguide/reactor-tutorial.md
@@ -32,7 +32,7 @@ gas = ct.Solution("gri30.yaml")
 gas.TPX = 1000.0, ct.one_atm, "H2:2,O2:1,N2:4"
 
 # create a reactor containing the gas
-reac = ct.IdealGasReactor(gas)
+reac = ct.IdealGasReactor(gas, clone=True)
 
 # Add the reactor to a new ReactorNet simulator
 sim = ct.ReactorNet([reac])
@@ -152,7 +152,7 @@ follows:
 import cantera as ct
 gas = ct.Solution("gri30.yaml")
 gas.TPX = 1000.0, ct.one_atm, "H2:2,O2:1,N2:4"
-reac = ct.IdealGasMoleReactor(gas)  # Use reactor type that supports preconditioning
+reac = ct.IdealGasMoleReactor(gas, clone=True)  # Supports preconditioning
 sim = ct.ReactorNet([reac])
 precon = ct.AdaptivePreconditioner()  # Create the preconditioner
 sim.preconditioner = precon  # Add it to the network

--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -88,7 +88,7 @@ public:
 
     //! Create a new Transport object using the same transport model and species
     //! transport properties as this one.
-    //! @param phase ThermoPhase used to specify the state for the newly cloned
+    //! @param thermo ThermoPhase used to specify the state for the newly cloned
     //!     Transport object. Can be created from the phase used by the current
     //!     Transport object using the ThermoPhase::clone() method.
     //! @since New in %Cantera 3.2.

--- a/include/cantera/zeroD/ReactorBase.h
+++ b/include/cantera/zeroD/ReactorBase.h
@@ -100,15 +100,11 @@ public:
 
     //! Access the Solution object used to represent the contents of this reactor.
     //! @since New in %Cantera 3.2
-    //! @todo Transition to `contents()` method for returning `shared_ptr<Solution>`
-    //!     after %Cantera 3.2.
-    shared_ptr<Solution> contents4() { return m_solution; }
+    shared_ptr<Solution> phase() { return m_solution; }
 
     //! Access the Solution object used to represent the contents of this reactor.
     //! @since New in %Cantera 3.2
-    //! @todo Transition to `contents()` method for returning `shared_ptr<Solution>`
-    //!     after %Cantera 3.2.
-    shared_ptr<const Solution> contents4() const { return m_solution; }
+    shared_ptr<const Solution> phase() const { return m_solution; }
 
     //! @name Methods to set up a simulation
     //! @{
@@ -207,11 +203,11 @@ public:
     virtual void syncState();
 
     //! return a reference to the contents.
-    //! @deprecated  To be changed after Cantera 3.2 to return a `shared_ptr<Solution>`.
-    //!     For transitional access to the Solution object, use contents4().
+    //! @deprecated  To be removed after Cantera 3.2. Replaceable by
+    //!     ReactorBase->phase()->thermo().
     ThermoPhase& contents() {
-        warn_deprecated("ReactorBase::contents", "Return value will change to "
-            "shared_ptr<Solution> after Cantera 3.2. Use contents4() for transition.");
+        warn_deprecated("ReactorBase::contents", "To be removed after Cantera 3.2. "
+            "Replaceable by ReactorBase->phase()->thermo().");
         if (!m_thermo) {
             throw CanteraError("ReactorBase::contents",
                                "Reactor contents not defined.");
@@ -220,13 +216,11 @@ public:
     }
 
     //! return a reference to the contents.
-    //! @deprecated  To be changed after Cantera 3.2 to return a
-    //!     `shared_ptr<const Solution>`. For transitional access to the Solution
-    //!     object, use contents4().
+    //! @deprecated  To be removed after Cantera 3.2. Replaceable by
+    //!     ReactorBase->phase()->thermo().
     const ThermoPhase& contents() const {
-        warn_deprecated("ReactorBase::contents", "Return value will change to "
-            "shared_ptr<const Solution> after Cantera 3.2. Use contents4() for "
-            "transition.");
+        warn_deprecated("ReactorBase::contents", "To be removed after Cantera 3.2. "
+            "Replaceable by ReactorBase->phase()->thermo().");
         if (!m_thermo) {
             throw CanteraError("ReactorBase::contents",
                                "Reactor contents not defined.");

--- a/include/cantera/zeroD/ReactorDelegator.h
+++ b/include/cantera/zeroD/ReactorDelegator.h
@@ -59,8 +59,8 @@ template <class R>
 class ReactorDelegator : public Delegator, public R, public ReactorAccessor
 {
 public:
-    ReactorDelegator(shared_ptr<Solution> contents, bool clone, const string& name="(none)")
-        : R(contents, clone, name)
+    ReactorDelegator(shared_ptr<Solution> phase, bool clone, const string& name="(none)")
+        : R(phase, clone, name)
     {
         install("initialize", m_initialize, [this](double t0) { R::initialize(t0); });
         install("syncState", m_syncState, [this]() { R::syncState(); });

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -63,7 +63,7 @@ shared_ptr<ReactorBase> newReactor(
 //! Create a Reactor object of the specified type and contents
 //! @param  model  Reactor type to be created. See [this list of reactor
 //!     types](../reference/reactors/index.html) for available options.
-//! @param  contents  Solution object to model the thermodynamic properties and
+//! @param phase  Solution object to model the thermodynamic properties and
 //!     reactions occurring in the reactor
 //! @param clone  Determines whether to clone `sol` so that the internal state of this
 //!     reactor is independent of the original Solution object and any Solution objects
@@ -75,7 +75,7 @@ shared_ptr<Reactor> newReactor4(
     const string& name="(none)");
 
 //! Create a Reservoir object with the specified contents
-//! @param  contents  Solution object to model the contents of this reservoir
+//! @param phase  Solution object to model the contents of this reservoir
 //! @param clone  Determines whether to clone `sol` so that the internal state of this
 //!     reservoir is independent of the original Solution object and any Solution
 //!     objects used by other reactors in the network.
@@ -86,7 +86,7 @@ shared_ptr<Reservoir> newReservoir(
 
 //! Create a ReactorSurface object with the specified contents and adjacent reactors
 //! participating in surface reactions.
-//! @param  contents  Solution (Interface) object to model the thermodynamic properties
+//! @param phase  Solution (Interface) object to model the thermodynamic properties
 //!     and reactions occurring in the reactor
 //! @param  reactors  List of Reactors adjacent to this surface, whose contents
 //!     participate in reactions occurring on this surface.

--- a/include/cantera/zeroD/ReactorFactory.h
+++ b/include/cantera/zeroD/ReactorFactory.h
@@ -49,7 +49,7 @@ private:
 //! Create a ReactorBase object of the specified type and contents.
 //! @since  New in %Cantera 3.2.
 shared_ptr<ReactorBase> newReactorBase(
-    const string& model, shared_ptr<Solution> contents, bool clone=true,
+    const string& model, shared_ptr<Solution> phase, bool clone=true,
     const string& name="(none)");
 
 //! Create a Reactor object of the specified type and contents
@@ -58,7 +58,7 @@ shared_ptr<ReactorBase> newReactorBase(
 //! @deprecated  Behavior changes after %Cantera 3.2, when a `shared_ptr<Reactor>` will
 //!     be returned. For new behavior, see `newReactor4`.
 shared_ptr<ReactorBase> newReactor(
-    const string& model, shared_ptr<Solution> contents, const string& name="(none)");
+    const string& model, shared_ptr<Solution> phase, const string& name="(none)");
 
 //! Create a Reactor object of the specified type and contents
 //! @param  model  Reactor type to be created. See [this list of reactor
@@ -71,7 +71,7 @@ shared_ptr<ReactorBase> newReactor(
 //! @param name  Name of the reactor.
 //! @since  New in %Cantera 3.2. Transitional method returning a `Reactor` object.
 shared_ptr<Reactor> newReactor4(
-    const string& model, shared_ptr<Solution> contents, bool clone=true,
+    const string& model, shared_ptr<Solution> phase, bool clone=true,
     const string& name="(none)");
 
 //! Create a Reservoir object with the specified contents
@@ -82,7 +82,7 @@ shared_ptr<Reactor> newReactor4(
 //! @param name  Name of the reservoir.
 //! @since New in %Cantera 3.2.
 shared_ptr<Reservoir> newReservoir(
-    shared_ptr<Solution> contents, bool clone=true, const string& name="(none)");
+    shared_ptr<Solution> phase, bool clone=true, const string& name="(none)");
 
 //! Create a ReactorSurface object with the specified contents and adjacent reactors
 //! participating in surface reactions.
@@ -96,7 +96,7 @@ shared_ptr<Reservoir> newReservoir(
 //! @param name  Name of the reactor surface.
 //! @since  New in %Cantera 3.2.
 shared_ptr<ReactorSurface> newReactorSurface(
-    shared_ptr<Solution> contents, const vector<shared_ptr<ReactorBase>>& reactors,
+    shared_ptr<Solution> phase, const vector<shared_ptr<ReactorBase>>& reactors,
     bool clone=true, const string& name="(none)");
 
 //! @}

--- a/interfaces/cython/cantera/drawnetwork.py
+++ b/interfaces/cython/cantera/drawnetwork.py
@@ -48,19 +48,19 @@ def draw_reactor(r, graph=None, graph_attr=None, node_attr=None, print_state=Fal
     # include full reactor state in representation if desired
     if print_state:
         T_label = f"T (K)\\n{r.T:.2f}"
-        P_label = f"P (bar)\\n{r.contents.P*1e-5:.3f}"
+        P_label = f"P (bar)\\n{r.phase.P*1e-5:.3f}"
 
         if species == True or species == "X":
-            s_dict = r.contents.mole_fraction_dict(1e-4)
+            s_dict = r.phase.mole_fraction_dict(1e-4)
             species_list = s_dict.keys()
             s_label = "X"
         elif species == "Y":
-            s_dict = r.contents.mass_fraction_dict(1e-4)
+            s_dict = r.phase.mass_fraction_dict(1e-4)
             species_list = s_dict.keys()
             s_label = "Y"
         # If individual species are provided as iterable of strings
         elif species:
-            s_dict = r.contents.mole_fraction_dict(threshold=-1)
+            s_dict = r.phase.mole_fraction_dict(threshold=-1)
             species_list = species
             s_label = "X"
         else:

--- a/interfaces/cython/cantera/reactionpath.pyx
+++ b/interfaces/cython/cantera/reactionpath.pyx
@@ -7,14 +7,14 @@ from ._utils cimport *
 
 
 cdef class ReactionPathDiagram:
-    def __cinit__(self, _SolutionBase contents, str element, *args, **kwargs):
+    def __cinit__(self, _SolutionBase phase, str element, *args, **kwargs):
         """
         Create a reaction path diagram for the fluxes of the element ``element``
         according the the net reaction rates determined by the `Kinetics` object
         ``kin``.
         """
-        self.kinetics = contents
-        cdef shared_ptr[CxxKinetics] cxx_kin = contents.base.kinetics()
+        self.kinetics = phase
+        cdef shared_ptr[CxxKinetics] cxx_kin = phase.base.kinetics()
         self._diagram = CxxNewReactionPathDiagram(cxx_kin, stringify(element))
         self.diagram = self._diagram.get()
 

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -228,7 +228,7 @@ ctypedef CxxReactorAccessor* CxxReactorAccessorPtr
 cdef class ReactorBase:
     cdef shared_ptr[CxxReactorBase] _rbase
     cdef CxxReactorBase* rbase
-    cdef object _contents
+    cdef object _phase
     cdef list _inlets
     cdef list _outlets
     cdef list _walls

--- a/interfaces/cython/cantera/reactor.pxd
+++ b/interfaces/cython/cantera/reactor.pxd
@@ -38,7 +38,7 @@ cdef extern from "cantera/zerodim.h" namespace "Cantera":
         CxxReactorBase() except +translate_exception
         string type()
         void setSolution(shared_ptr[CxxSolution]) except +translate_exception
-        shared_ptr[CxxSolution] contents4()
+        shared_ptr[CxxSolution] phase()
         void restoreState() except +translate_exception
         void syncState() except +translate_exception
         double volume()

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -35,7 +35,7 @@ cdef class ReactorBase:
         self._outlets = []
         self._walls = []
         self._surfaces = []
-        self._contents = _wrap_Solution(self.rbase.contents4())
+        self._contents = _wrap_Solution(self.rbase.phase())
 
         if volume is not None:
             self.volume = volume

--- a/interfaces/cython/cantera/reactor.pyx
+++ b/interfaces/cython/cantera/reactor.pyx
@@ -273,11 +273,10 @@ cdef class Reactor(ReactorBase):
         >>> gas = Solution('gri30.yaml')
         >>> r1 = Reactor(gas)
 
-        Arguments may be specified using keywords in any order:
+        Arguments may be specified using keywords:
 
-        >>> r2 = Reactor(phase=gas, energy='off',
+        >>> r2 = Reactor(gas, energy='off',
         ...              name='isothermal_reactor')
-        >>> r3 = Reactor(name='adiabatic_reactor', phase=gas)
 
         """
         super().__init__(phase, clone=clone, name=name, **kwargs)
@@ -883,7 +882,7 @@ cdef class ReactorSurface(ReactorBase):
         self.rbase = self._rbase.get()
         self.surface = <CxxReactorSurface*>(self.rbase)
 
-    def __init__(self, phase=None, r=None, clone=None, *,
+    def __init__(self, phase=None, r=None, *, clone=None,
                  name="(none)", A=None, node_attr=None):
         super().__init__(phase, name=name)
 

--- a/interfaces/matlab_experimental/Reactor/ConstPressureReactor.m
+++ b/interfaces/matlab_experimental/Reactor/ConstPressureReactor.m
@@ -1,7 +1,7 @@
 classdef ConstPressureReactor < Reactor
     % Create a constant pressure reactor object. ::
     %
-    %     >> r = ConstPressureReactor(contents, name)
+    %     >> r = ConstPressureReactor(phase, name)
     %
     % A :mat:class:`ConstPressureReactor` is an instance of class
     % :mat:class:`Reactor` where the pressure is held constant. The volume
@@ -10,11 +10,11 @@ classdef ConstPressureReactor < Reactor
     %
     % .. code-block:: matlab
     %
-    %     r2 = ConstPressureReactor(contents)    % a reactor containing contents
+    %     r2 = ConstPressureReactor(phase)    % a reactor containing contents
     %
     % See also: :mat:class:`Reactor`
     %
-    % :param contents:
+    % :param phase:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
     % :param name:
     %     Reactor name (optional; default is ``(none)``).
@@ -23,14 +23,14 @@ classdef ConstPressureReactor < Reactor
 
     methods
 
-        function r = ConstPressureReactor(contents, name)
+        function r = ConstPressureReactor(phase, name)
             % Constructor
 
             if nargin < 2
                 name = '(none)';
             end
 
-            r@Reactor(contents, 'ConstPressureReactor', name);
+            r@Reactor(phase, 'ConstPressureReactor', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/FlowReactor.m
+++ b/interfaces/matlab_experimental/Reactor/FlowReactor.m
@@ -1,7 +1,7 @@
 classdef FlowReactor < Reactor
     % Create a flow reactor object. ::
     %
-    %     >> r = FlowReactor(contents, name)
+    %     >> r = FlowReactor(phase, name)
     %
     % A reactor representing adiabatic plug flow in a constant-area
     % duct. Examples:
@@ -12,7 +12,7 @@ classdef FlowReactor < Reactor
     %
     % See also: :mat:class:`Reactor`
     %
-    % :param contents:
+    % :param phase:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
     % :param name:
     %     Reactor name (optional; default is ``(none)``).
@@ -21,14 +21,14 @@ classdef FlowReactor < Reactor
 
     methods
 
-        function r = FlowReactor(contents, name)
+        function r = FlowReactor(phase, name)
             % Constructor
 
             if nargin < 2
                 name = '(none)';
             end
 
-            r@Reactor(contents, 'FlowReactor', name);
+            r@Reactor(phase, 'FlowReactor', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/IdealGasConstPressureReactor.m
+++ b/interfaces/matlab_experimental/Reactor/IdealGasConstPressureReactor.m
@@ -1,7 +1,7 @@
 classdef IdealGasConstPressureReactor < Reactor
     % Create a constant pressure reactor with an ideal gas. ::
     %
-    %     >> r = IdealGasConstPressureReactor(contents, name)
+    %     >> r = IdealGasConstPressureReactor(phase, name)
     %
     % An :mat:class:`IdealGasConstPressureReactor` is an instance of
     % :mat:class:`Reactor` where the pressure is held constant.
@@ -17,7 +17,7 @@ classdef IdealGasConstPressureReactor < Reactor
     %
     % See also: :mat:class:`Reactor`
     %
-    % :param contents:
+    % :param phase:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
     % :param name:
     %     Reactor name (optional; default is ``(none)``).
@@ -26,14 +26,14 @@ classdef IdealGasConstPressureReactor < Reactor
 
     methods
 
-        function r = IdealGasConstPressureReactor(contents, name)
+        function r = IdealGasConstPressureReactor(phase, name)
             % Constructor
 
             if nargin < 2
                 name = '(none)';
             end
 
-            r@Reactor(contents, 'IdealGasConstPressureReactor', name);
+            r@Reactor(phase, 'IdealGasConstPressureReactor', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/IdealGasReactor.m
+++ b/interfaces/matlab_experimental/Reactor/IdealGasReactor.m
@@ -1,7 +1,7 @@
 classdef IdealGasReactor < Reactor
     % Create a reactor with an ideal gas. ::
     %
-    %     >> r = IdealGasReactor(contents, name)
+    %     >> r = IdealGasReactor(phase, name)
     %
     % An :mat:class:`IdealGasReactor` is an instance of :mat:class:`Reactor` where
     % the governing equations are specialized for the ideal gas equation of state
@@ -13,7 +13,7 @@ classdef IdealGasReactor < Reactor
     %
     % See also: :mat:class:`Reactor`
     %
-    % :param contents:
+    % :param phase:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
     % :param name:
     %     Reactor name (optional; default is ``(none)``).
@@ -22,14 +22,14 @@ classdef IdealGasReactor < Reactor
 
     methods
 
-        function r = IdealGasReactor(contents, name)
+        function r = IdealGasReactor(phase, name)
             % Constructor
 
             if nargin < 2
                 name = '(none)';
             end
 
-            r@Reactor(contents, 'IdealGasReactor', name);
+            r@Reactor(phase, 'IdealGasReactor', name);
         end
 
     end

--- a/interfaces/matlab_experimental/Reactor/Reactor.m
+++ b/interfaces/matlab_experimental/Reactor/Reactor.m
@@ -12,7 +12,7 @@ classdef Reactor < handle
 
         name  % Name of reactor.
 
-        contents
+        phase
 
         % Density of the reactor contents at the end of the last call to
         % "advance" or "step". Unit: kg/m^3.
@@ -89,17 +89,17 @@ classdef Reactor < handle
     methods
         %% Reactor Class Constructor
 
-        function r = Reactor(content, typ, name)
+        function r = Reactor(phase, typ, name)
             % Reactor Class ::
             %
-            %     >> r = Reactor(content, typ, name)
+            %     >> r = Reactor(phase, typ, name)
             %
             % A :mat:class:`Reactor` object simulates a perfectly-stirred reactor.
             % It has a time-dependent state, and may be coupled to other
             % reactors through flow lines or through walls that may expand
             % or contract and/or conduct heat.
             %
-            % :param content:
+            % :param phase:
             %    Instance of :mat:class:`Solution` representing the contents of
             %    the reactor.
             % :param typ:
@@ -128,12 +128,12 @@ classdef Reactor < handle
                 error('too many arguments');
             end
 
-            if ~isa(content, 'Solution')
+            if ~isa(phase, 'Solution')
                 error('Reactor contents must be an object of type "Solution"');
             end
 
-            r.id = ctFunc('reactor_new', typ, content.solnID, name);
-            r.contents = content;
+            r.id = ctFunc('reactor_new', typ, phase.solnID, name);
+            r.phase = phase;
         end
 
         %% Reactor Class Destructor
@@ -203,7 +203,7 @@ classdef Reactor < handle
             %    String or one-based integer id of the species.
 
             if ischar(species)
-                k = r.contents.speciesIndex(species) - 1;
+                k = r.phase.speciesIndex(species) - 1;
             else k = species - 1;
             end
 
@@ -212,7 +212,7 @@ classdef Reactor < handle
 
         function massFractions = get.Y(r)
 
-            nsp = r.contents.nSpecies;
+            nsp = r.phase.nSpecies;
             massFractions = zeros(1, nsp);
 
             for i = 1:nsp

--- a/interfaces/matlab_experimental/Reactor/Reservoir.m
+++ b/interfaces/matlab_experimental/Reactor/Reservoir.m
@@ -1,7 +1,7 @@
 classdef Reservoir < Reactor
     % Create a :mat:class:`Reservoir` object. ::
     %
-    %     >> r = Reservoir(contents, name)
+    %     >> r = Reservoir(phase, name)
     %
     % A :mat:class:`Reservoir` is an instance of class :mat:class:`Reactor`
     % configured so that its intensive state is constant in time. A reservoir
@@ -18,7 +18,7 @@ classdef Reservoir < Reactor
     %
     % See also: :mat:class:`Reactor`
     %
-    % :param contents:
+    % :param phase:
     %     Cantera :mat:class:`Solution` to be set as the contents of the reactor.
     % :param name:
     %     Reservoir name (optional; default is ``(none)``).
@@ -27,14 +27,14 @@ classdef Reservoir < Reactor
 
     methods
 
-        function r = Reservoir(contents, name)
+        function r = Reservoir(phase, name)
             % Constructor
 
             if nargin < 2
                 name = '(none)';
             end
 
-            r@Reactor(contents, 'Reservoir', name);
+            r@Reactor(phase, 'Reservoir', name);
         end
 
     end

--- a/interfaces/sourcegen/src/sourcegen/csharp/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/csharp/generator.py
@@ -215,9 +215,9 @@ class CSharpSourceGenerator(SourceGenerator):
         _LOGGER.info(f"  writing {file_name!r}")
         t_file = Path(__file__).parent / template_name
         template = _LOADER.from_string(t_file.read_text(encoding="utf-8"))
-        phase = template.render(file_name=file_name, **kwargs)
+        contents = template.render(file_name=file_name, **kwargs)
 
-        self._out_dir.joinpath(file_name).write_text(phase, encoding="utf-8")
+        self._out_dir.joinpath(file_name).write_text(contents, encoding="utf-8")
 
     def _scaffold_interop(self, header_file: str, cs_funcs: list[CsFunc]) -> None:
         def region(description, functions: list[str]) -> list[str]:

--- a/interfaces/sourcegen/src/sourcegen/csharp/generator.py
+++ b/interfaces/sourcegen/src/sourcegen/csharp/generator.py
@@ -215,9 +215,9 @@ class CSharpSourceGenerator(SourceGenerator):
         _LOGGER.info(f"  writing {file_name!r}")
         t_file = Path(__file__).parent / template_name
         template = _LOADER.from_string(t_file.read_text(encoding="utf-8"))
-        contents = template.render(file_name=file_name, **kwargs)
+        phase = template.render(file_name=file_name, **kwargs)
 
-        self._out_dir.joinpath(file_name).write_text(contents, encoding="utf-8")
+        self._out_dir.joinpath(file_name).write_text(phase, encoding="utf-8")
 
     def _scaffold_interop(self, header_file: str, cs_funcs: list[CsFunc]) -> None:
         def region(description, functions: list[str]) -> list[str]:

--- a/interfaces/sourcegen/src/sourcegen/headers/ctreactor_auto.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ctreactor_auto.yaml
@@ -18,9 +18,7 @@ recipes:
 - name: type
 - name: name
 - name: setName
-- name: contents
-  # Temporary name due to conflict with deprecated method returning ThermoPhase&
-  wraps: contents4
+- name: phase
   what: accessor
 - name: setInitialVolume
 - name: setChemistry

--- a/samples/cxx/combustor/combustor.cpp
+++ b/samples/cxx/combustor/combustor.cpp
@@ -112,7 +112,7 @@ void runexample()
         f << tnow << ", "
           << combustor->temperature() << ", "
           << tres << ", ";
-        const auto& c = combustor->contents4()->thermo();
+        const auto& c = combustor->phase()->thermo();
         for (size_t i = 0; i < k_out.size(); i++) {
             f << c->moleFraction(k_out[i]) << ", ";
         }

--- a/samples/cxx/kinetics1/kinetics1.cpp
+++ b/samples/cxx/kinetics1/kinetics1.cpp
@@ -45,7 +45,7 @@ int kinetics1(int np, void* p)
     // create a 2D array to hold the output variables,
     // and store the values for the initial state
     Array2D states(nsp+4, 1);
-    saveSoln(0, 0.0, *r->contents4()->thermo(), states);
+    saveSoln(0, 0.0, *r->phase()->thermo(), states);
 
     // create a container object for reactor to run the simulation
     ReactorNet sim(r);
@@ -56,13 +56,13 @@ int kinetics1(int np, void* p)
         double tm = i*dt;
         sim.advance(tm);
         cout << "time = " << tm << " s" << endl;
-        saveSoln(tm, *r->contents4()->thermo(), states);
+        saveSoln(tm, *r->phase()->thermo(), states);
     }
     clock_t t1 = clock(); // save end time
 
 
     // make a CSV output file
-    writeCsv("kin1.csv", *r->contents4()->thermo(), states);
+    writeCsv("kin1.csv", *r->phase()->thermo(), states);
 
     // print final temperature and timing data
     double tmm = 1.0*(t1 - t0)/CLOCKS_PER_SEC;

--- a/samples/cxx/openmp_ignition/openmp_ignition.cpp
+++ b/samples/cxx/openmp_ignition/openmp_ignition.cpp
@@ -60,7 +60,7 @@ void run()
     for (int i = 0; i < nPoints; i++) {
         // Get the Cantera objects that were initialized for this thread
         size_t j = omp_get_thread_num();
-        auto gas = reactors[j]->contents4()->thermo();
+        auto gas = reactors[j]->phase()->thermo();
         Reactor& reactor = *reactors[j];
         ReactorNet& net = *nets[j];
 

--- a/samples/python/kinetics/interactive_path_diagram.py
+++ b/samples/python/kinetics/interactive_path_diagram.py
@@ -84,9 +84,9 @@ time = 0
 steps = 0
 while time < residence_time:
     profiles["time"].append(time)
-    profiles["pressure"].append(reactor.contents.P)
-    profiles["temperature"].append(reactor.contents.T)
-    profiles["mole_fractions"].append(reactor.contents.X)
+    profiles["pressure"].append(reactor.phase.P)
+    profiles["temperature"].append(reactor.phase.T)
+    profiles["mole_fractions"].append(reactor.phase.X)
     time = reactor_network.step()
     steps += 1
 

--- a/samples/python/kinetics/jet_stirred_reactor.py
+++ b/samples/python/kinetics/jet_stirred_reactor.py
@@ -94,11 +94,11 @@ def getTemperatureDependence(gas, inputs):
         t = 0
         while t < inputs['t_max']:
             t = reactorNetwork.step()
-        state = np.hstack([stirredReactor.contents.P,
+        state = np.hstack([stirredReactor.phase.P,
                         stirredReactor.mass,
                         stirredReactor.volume,
                         stirredReactor.T,
-                        stirredReactor.contents.X])
+                        stirredReactor.phase.X])
         tempDependence.loc[T] = state
     return tempDependence
 

--- a/samples/python/kinetics/mechanism_reduction.py
+++ b/samples/python/kinetics/mechanism_reduction.py
@@ -56,7 +56,7 @@ while sim.time < 0.04:
     sim.step()
     tt.append(1000 * sim.time)
     TT.append(r.T)
-    rnet = abs(r.contents.net_rates_of_progress)
+    rnet = abs(r.phase.net_rates_of_progress)
     rnet /= max(rnet)
     Rmax = np.maximum(Rmax, rnet)
 

--- a/samples/python/kinetics/shock_tube.py
+++ b/samples/python/kinetics/shock_tube.py
@@ -52,7 +52,7 @@ for k, m in enumerate(models):
     gas = ct.Solution(file, name=models[m])
     X = {'H2O2':X_H2O2, 'H2O':X_H2O, 'O2':X_O2, 'CO2':X_CO2, 'AR':X_Ar}
     gas.TPX = 1196, 2.127*ct.one_atm, X
-    r = ct.Reactor(contents=gas, energy="on", clone=False)
+    r = ct.Reactor(phase=gas, energy="on", clone=False)
     reactorNetwork = ct.ReactorNet([r])
     timeHistory = ct.SolutionArray(gas, extra=['t'])
     estIgnitDelay = 1
@@ -61,7 +61,7 @@ for k, m in enumerate(models):
     while t < estIgnitDelay:
         t = reactorNetwork.step()
         if counter % 10 == 0:
-            timeHistory.append(r.contents.state, t=t)
+            timeHistory.append(r.phase.state, t=t)
         counter += 1
 
     results[m] = timeHistory

--- a/samples/python/kinetics/shock_tube.py
+++ b/samples/python/kinetics/shock_tube.py
@@ -52,7 +52,7 @@ for k, m in enumerate(models):
     gas = ct.Solution(file, name=models[m])
     X = {'H2O2':X_H2O2, 'H2O':X_H2O, 'O2':X_O2, 'CO2':X_CO2, 'AR':X_Ar}
     gas.TPX = 1196, 2.127*ct.one_atm, X
-    r = ct.Reactor(phase=gas, energy="on", clone=False)
+    r = ct.Reactor(gas, energy="on", clone=False)
     reactorNetwork = ct.ReactorNet([r])
     timeHistory = ct.SolutionArray(gas, extra=['t'])
     estIgnitDelay = 1

--- a/samples/python/reactors/1D_pfr_surfchem.py
+++ b/samples/python/reactors/1D_pfr_surfchem.py
@@ -56,8 +56,8 @@ kSi = gas_si_n_interface.kinetics_species_index('Si(D)')
 while net.distance < 0.6:
     print(net.distance, rsurf.coverages)
     net.step()
-    wdot = rsurf.contents.net_production_rates
-    soln.append(TDY=reactor.contents.TDY,
+    wdot = rsurf.phase.net_production_rates
+    soln.append(TDY=reactor.phase.TDY,
                 x=net.distance,
                 speed=reactor.speed,
                 surf_coverages=rsurf.coverages,

--- a/samples/python/reactors/combustor.py
+++ b/samples/python/reactors/combustor.py
@@ -81,7 +81,7 @@ while combustor.T > 500:
     sim.initial_time = 0.0  # reset the integrator
     sim.solve_steady()
     print('tres = {:.2e}; T = {:.1f}'.format(residence_time, combustor.T))
-    states.append(combustor.contents.state, tres=residence_time)
+    states.append(combustor.phase.state, tres=residence_time)
     residence_time *= 0.9  # decrease the residence time for the next iteration
 
 # %%

--- a/samples/python/reactors/continuous_reactor.py
+++ b/samples/python/reactors/continuous_reactor.py
@@ -143,7 +143,7 @@ while t < max_simulation_time:
     # will be 1200+ columns for us to work with
     if counter % 10 == 0:
         # Extract the state of the reactor
-        time_history.append(stirred_reactor.contents.state, t=t)
+        time_history.append(stirred_reactor.phase.state, t=t)
 
     counter += 1
 
@@ -252,8 +252,8 @@ for reactor_temperature in T:
     print(f"Simulation at T={reactor_temperature} K took {toc-tic:3.2f} s to compute "
           f"with {counter} steps")
 
-    reactor_X = stirred_reactor.contents.X
-    temp_dependence.append(stirred_reactor.contents.state)
+    reactor_X = stirred_reactor.phase.X
+    temp_dependence.append(stirred_reactor.phase.state)
 
 # %%
 # Compare the model results with experimental data

--- a/samples/python/reactors/custom2.py
+++ b/samples/python/reactors/custom2.py
@@ -55,7 +55,7 @@ class InertialWallReactor(ct.ExtensibleIdealGasReactor):
 
     def after_eval(self, t, LHS, RHS):
         # Calculate the time derivative for the additional equation
-        a = self.k_wall * (self.contents.P - self.neighbor.contents.P)
+        a = self.k_wall * (self.phase.P - self.neighbor.phase.P)
         RHS[self.i_wall] = a
 
     def before_component_index(self, name):
@@ -85,7 +85,7 @@ net = ct.ReactorNet([r])
 states = ct.SolutionArray(gas, 1, extra={'t': [0.0], 'V': [r.volume]})
 while net.time < 0.5:
     net.advance(net.time + 0.005)
-    states.append(TPY=r.contents.TPY, V=r.volume, t=net.time)
+    states.append(TPY=r.phase.TPY, V=r.volume, t=net.time)
 
 # Plot the results
 try:

--- a/samples/python/reactors/fuel_injection.py
+++ b/samples/python/reactors/fuel_injection.py
@@ -61,7 +61,7 @@ while tnow < tfinal:
     if tnow-tprev > 1e-2 or i == 10:
         i = 0
         tprev = tnow
-        states.append(r.contents.state, t=tnow)
+        states.append(r.phase.state, t=tnow)
 
 # nice names for species, including PAH species that can be considered
 # as precursors to soot formation

--- a/samples/python/reactors/ic_engine.py
+++ b/samples/python/reactors/ic_engine.py
@@ -158,7 +158,7 @@ cyl.set_advance_limit('temperature', delta_T_max)
 
 # set up output data arrays
 states = ct.SolutionArray(
-    cyl.contents,
+    cyl.phase,
     extra=('t', 'ca', 'V', 'm', 'mdot_in', 'mdot_out', 'dWv_dt'),
 )
 
@@ -171,11 +171,11 @@ while sim.time < t_stop:
     sim.advance(sim.time + dt)
 
     # calculate results to be stored
-    dWv_dt = - (cyl.contents.P - ambient_air.contents.P) * A_piston * \
+    dWv_dt = - (cyl.phase.P - ambient_air.phase.P) * A_piston * \
         piston_speed(sim.time)
 
     # append output data
-    states.append(cyl.contents.state,
+    states.append(cyl.phase.state,
                   t=sim.time, ca=crank_angle(sim.time),
                   V=cyl.volume, m=cyl.mass,
                   mdot_in=inlet_valve.mass_flow_rate,

--- a/samples/python/reactors/mix1.py
+++ b/samples/python/reactors/mix1.py
@@ -79,7 +79,7 @@ sim = ct.ReactorNet([mixer])
 sim.solve_steady()
 
 # view the state of the gas in the mixer
-print(mixer.contents.report())
+print(mixer.phase.report())
 
 # %%
 # Show the network structure

--- a/samples/python/reactors/nanosecond_pulse_discharge.py
+++ b/samples/python/reactors/nanosecond_pulse_discharge.py
@@ -64,8 +64,8 @@ while t < t_total:
     t_end = min(t + dt_chunk, t_total)
     while sim.time < t_end:
         sim.advance(sim.time + dt_max) #use sim.step
-        states.append(r.contents.state, t=sim.time)
-        print(f"{sim.time:10.3e} {r.T:10.3f} {r.contents.P:10.3f} {r.contents.h:14.6f}")
+        states.append(r.phase.state, t=sim.time)
+        print(f"{sim.time:10.3e} {r.T:10.3f} {r.phase.P:10.3f} {r.phase.h:14.6f}")
 
     EN_t = gaussian_EN(t)
     gas.reduced_electric_field = EN_t

--- a/samples/python/reactors/non_ideal_shock_tube.py
+++ b/samples/python/reactors/non_ideal_shock_tube.py
@@ -117,7 +117,7 @@ real_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
 
 # Create a reactor object and add it to a reactor network
 # In this example, this will be the only reactor in the network
-r = ct.Reactor(contents=real_gas, clone=False)
+r = ct.Reactor(phase=real_gas, clone=False)
 reactor_network = ct.ReactorNet([r])
 time_history_RG = ct.SolutionArray(real_gas, extra=['t'])
 
@@ -133,7 +133,7 @@ while t < estimated_ignition_delay_time:
     if counter % 20 == 0:
         # We will save only every 20th value. Otherwise, this takes too long
         # Note that the species concentrations are mass fractions
-        time_history_RG.append(r.contents.state, t=t)
+        time_history_RG.append(r.phase.state, t=t)
     counter += 1
 
 # We will use the 'oh' species to compute the ignition delay
@@ -154,7 +154,7 @@ ideal_gas.TP = reactor_temperature, reactor_pressure
 ideal_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                 oxidizer={'o2': 1.0, 'n2': 3.76})
 
-r = ct.Reactor(contents=ideal_gas, clone=False)
+r = ct.Reactor(phase=ideal_gas, clone=False)
 reactor_network = ct.ReactorNet([r])
 time_history_IG = ct.SolutionArray(ideal_gas, extra=['t'])
 
@@ -166,7 +166,7 @@ while t < estimated_ignition_delay_time:
     if counter % 20 == 0:
         # We will save only every 20th value. Otherwise, this takes too long
         # Note that the species concentrations are mass fractions
-        time_history_IG.append(r.contents.state, t=t)
+        time_history_IG.append(r.phase.state, t=t)
     counter += 1
 
 # We will use the 'oh' species to compute the ignition delay
@@ -231,7 +231,7 @@ for i, temperature in enumerate(T):
     real_gas.TP = reactor_temperature, reactor_pressure
     real_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                    oxidizer={'o2': 1.0, 'n2': 3.76})
-    r = ct.Reactor(contents=real_gas, clone=False)
+    r = ct.Reactor(phase=real_gas, clone=False)
     reactor_network = ct.ReactorNet([r])
 
     # create an array of solution states
@@ -243,7 +243,7 @@ for i, temperature in enumerate(T):
     while t < estimated_ignition_delay_times[i]:
         t = reactor_network.step()
         if counter % 20 == 0:
-            time_history.append(r.contents.state, t=t)
+            time_history.append(r.phase.state, t=t)
         counter += 1
 
     tau = ignition_delay(time_history, 'oh')
@@ -263,7 +263,7 @@ for i, temperature in enumerate(T):
     ideal_gas.TP = reactor_temperature, reactor_pressure
     ideal_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                     oxidizer={'o2': 1.0, 'n2': 3.76})
-    r = ct.Reactor(contents=ideal_gas, clone=False)
+    r = ct.Reactor(phase=ideal_gas, clone=False)
     reactor_network = ct.ReactorNet([r])
 
     # create an array of solution states
@@ -276,7 +276,7 @@ for i, temperature in enumerate(T):
     while t < estimated_ignition_delay_times[i]:
         t = reactor_network.step()
         if counter % 20 == 0:
-            time_history.append(r.contents.state, t=t)
+            time_history.append(r.phase.state, t=t)
         counter += 1
 
     tau = ignition_delay(time_history, 'oh')

--- a/samples/python/reactors/non_ideal_shock_tube.py
+++ b/samples/python/reactors/non_ideal_shock_tube.py
@@ -117,7 +117,7 @@ real_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
 
 # Create a reactor object and add it to a reactor network
 # In this example, this will be the only reactor in the network
-r = ct.Reactor(phase=real_gas, clone=False)
+r = ct.Reactor(real_gas, clone=False)
 reactor_network = ct.ReactorNet([r])
 time_history_RG = ct.SolutionArray(real_gas, extra=['t'])
 
@@ -154,7 +154,7 @@ ideal_gas.TP = reactor_temperature, reactor_pressure
 ideal_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                 oxidizer={'o2': 1.0, 'n2': 3.76})
 
-r = ct.Reactor(phase=ideal_gas, clone=False)
+r = ct.Reactor(ideal_gas, clone=False)
 reactor_network = ct.ReactorNet([r])
 time_history_IG = ct.SolutionArray(ideal_gas, extra=['t'])
 
@@ -231,7 +231,7 @@ for i, temperature in enumerate(T):
     real_gas.TP = reactor_temperature, reactor_pressure
     real_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                    oxidizer={'o2': 1.0, 'n2': 3.76})
-    r = ct.Reactor(phase=real_gas, clone=False)
+    r = ct.Reactor(real_gas, clone=False)
     reactor_network = ct.ReactorNet([r])
 
     # create an array of solution states
@@ -263,7 +263,7 @@ for i, temperature in enumerate(T):
     ideal_gas.TP = reactor_temperature, reactor_pressure
     ideal_gas.set_equivalence_ratio(phi=1.0, fuel='c12h26',
                                     oxidizer={'o2': 1.0, 'n2': 3.76})
-    r = ct.Reactor(phase=ideal_gas, clone=False)
+    r = ct.Reactor(ideal_gas, clone=False)
     reactor_network = ct.ReactorNet([r])
 
     # create an array of solution states

--- a/samples/python/reactors/periodic_cstr.py
+++ b/samples/python/reactors/periodic_cstr.py
@@ -92,7 +92,7 @@ states = ct.SolutionArray(gas, extra=['t'])
 while t < 300.0:
     t += dt
     network.advance(t)
-    states.append(cstr.contents.state, t=t)
+    states.append(cstr.phase.state, t=t)
 
 aliases = {'H2': 'H$_2$', 'O2': 'O$_2$', 'H2O': 'H$_2$O'}
 for name, alias in aliases.items():

--- a/samples/python/reactors/pfr.py
+++ b/samples/python/reactors/pfr.py
@@ -61,14 +61,14 @@ dt = t_total / n_steps
 t1 = (np.arange(n_steps) + 1) * dt
 z1 = np.zeros_like(t1)
 u1 = np.zeros_like(t1)
-states1 = ct.SolutionArray(r1.contents)
+states1 = ct.SolutionArray(r1.phase)
 for n1, t_i in enumerate(t1):
     # perform time integration
     sim1.advance(t_i)
     # compute velocity and transform into space
-    u1[n1] = mass_flow_rate1 / area / r1.contents.density
+    u1[n1] = mass_flow_rate1 / area / r1.phase.density
     z1[n1] = z1[n1 - 1] + u1[n1] * dt
-    states1.append(r1.contents.state)
+    states1.append(r1.phase.state)
 #####################################################################
 
 
@@ -126,17 +126,17 @@ states2 = ct.SolutionArray(gas2)
 # iterate through the PFR cells
 for n in range(n_steps):
     # Set the state of the reservoir to match that of the previous reactor
-    upstream.contents.TDY = r2.contents.TDY
+    upstream.phase.TDY = r2.phase.TDY
     upstream.syncState()
     # integrate the reactor forward in time until steady state is reached
     sim2.reinitialize()
     sim2.advance_to_steady_state()
     # compute velocity and transform into time
-    u2[n] = mass_flow_rate2 / area / r2.contents.density
+    u2[n] = mass_flow_rate2 / area / r2.phase.density
     t_r2[n] = r2.mass / mass_flow_rate2  # residence time in this reactor
     t2[n] = np.sum(t_r2)
     # write output data
-    states2.append(r2.contents.state)
+    states2.append(r2.phase.state)
 #####################################################################
 
 

--- a/samples/python/reactors/piston.py
+++ b/samples/python/reactors/piston.py
@@ -55,7 +55,7 @@ def v(t):
     if t < 0.1:
         return 0.0
     else:
-        return (r1.contents.P - r2.contents.P) * 1e-4
+        return (r1.phase.P - r2.phase.P) * 1e-4
 
 w = ct.Wall(r1, r2, velocity=v)
 
@@ -63,8 +63,8 @@ net = ct.ReactorNet([r1, r2])
 
 # %%
 # Run the simulation and collect the states of each reactor
-states1 = ct.SolutionArray(r1.contents, extra=['t', 'volume'])
-states2 = ct.SolutionArray(r2.contents, extra=['t', 'volume'])
+states1 = ct.SolutionArray(r1.phase, extra=['t', 'volume'])
+states2 = ct.SolutionArray(r2.phase, extra=['t', 'volume'])
 
 fmt = '{:10.3f}  {:10.1f}  {:10.4f}  {:10.4g}  {:10.4g}  {:10.4g}  {:10.4g}'
 print('{:>10}  {:>10}  {:>10}  {:>10}  {:>10}  {:>10}  {:>10}'.format(
@@ -74,10 +74,10 @@ for n in range(200):
     net.advance(time)
     if n % 4 == 3:
         print(fmt.format(time, r1.T, r2.T, r1.volume, r2.volume,
-                         r1.volume + r2.volume, r2.contents['CO'].X[0]))
+                         r1.volume + r2.volume, r2.phase['CO'].X[0]))
 
-    states1.append(r1.contents.state, t=1000*time, volume=r1.volume)
-    states2.append(r2.contents.state, t=1000*time, volume=r2.volume)
+    states1.append(r1.phase.state, t=1000*time, volume=r1.volume)
+    states2.append(r2.phase.state, t=1000*time, volume=r2.volume)
 
 # %%
 # Plot the results

--- a/samples/python/reactors/porous_media_burner.py
+++ b/samples/python/reactors/porous_media_burner.py
@@ -183,7 +183,7 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
     def __init__(self, *args, props, **kwargs):
         super().__init__(*args, **kwargs)
 
-        self.contents.transport_model = "mixture-averaged"
+        self.phase.transport_model = "mixture-averaged"
         self.Ts = props.TsInit                     # initial temperature of the solid
         self.neighbor_left = None                  # reference to reactor on the left
         self.neighbor_right = None                 # reference to reactor on the right
@@ -199,12 +199,12 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
     def after_initialize(self, t0):
         self.n_vars += 1                # additional equation for the solid temperature
         self.index_Ts = self.n_vars - 1
-        self.species_offset = self.component_index(self.contents.species_name(0))
-        self.molecular_weights = self.contents.molecular_weights
+        self.species_offset = self.component_index(self.phase.species_name(0))
+        self.molecular_weights = self.phase.molecular_weights
 
     def after_get_state(self, y):
         y[self.index_Ts] = self.Ts
-        y[self.component_index("mass")] = self.contents.density_mass * self.V
+        y[self.component_index("mass")] = self.phase.density_mass * self.V
 
     # compute the effective conductivity for heat conduction within the solid
     def solidHeatConductivity(self):
@@ -222,13 +222,13 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
     # heat transfer coefficient (htc) based on a Nusselt (Nu) correlation
     def htc(self):
         d_h = 4.0 * self.solid.porosity / self.solid.specific_area # hydraulic diameter
-        density = self.contents.density_mass
-        u = mdot / (density * self.solid.porosity)                   # gas velocity
-        Re = density * u * d_h / self.contents.viscosity               # Reynolds number
-        lambda_gas = self.contents.thermal_conductivity
-        Pr = self.contents.cp_mass * self.contents.viscosity /lambda_gas # Prandtl number
+        density = self.phase.density_mass
+        u = mdot / (density * self.solid.porosity)                  # gas velocity
+        Re = density * u * d_h / self.phase.viscosity               # Reynolds number
+        lambda_gas = self.phase.thermal_conductivity
+        Pr = self.phase.cp_mass * self.phase.viscosity /lambda_gas  # Prandtl number
         Nu = 3.7 * (Re**0.38) * (Pr**0.25)
-        return Nu * self.solid.specific_area * self.contents.thermal_conductivity / d_h
+        return Nu * self.solid.specific_area * self.phase.thermal_conductivity / d_h
 
     # implement the new governing equations
     def replace_eval(self, t, LHS, RHS):
@@ -241,9 +241,9 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
         self.solid.solid_phase.TP = self.Ts, constantP
 
         # create some variables for convenience
-        Y = self.contents.Y
-        density = self.contents.density_mass
-        cp = self.contents.cp_mass
+        Y = self.phase.Y
+        density = self.phase.density_mass
+        cp = self.phase.cp_mass
         porosity = self.solid.porosity
         solid_density = self.solid.solid_phase.density
         solid_cp = self.solid.solid_phase.cp
@@ -254,8 +254,8 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
             Y_in = Y_in_inlet
             h_in = h_in_inlet
         else:  # otherwise, take the mass fraction and enthalpy from the left neighbor
-            Y_in = self.neighbor_left.contents.Y
-            h_in = self.neighbor_left.contents.enthalpy_mass
+            Y_in = self.neighbor_left.phase.Y
+            h_in = self.neighbor_left.phase.enthalpy_mass
 
         # ============================================================================#
         #                          Temperature of the solid                           #
@@ -264,7 +264,7 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
         LHS[self.index_Ts] = (1.0 - porosity) * solid_cp * solid_density * self.V
 
         # heat transfer between gas and solid
-        RHS[self.index_Ts] += self.htc() * (self.contents.T - self.Ts) * self.V
+        RHS[self.index_Ts] += self.htc() * (self.phase.T - self.Ts) * self.V
 
         # compute the axial heat loss due to radiation to the ambience
         # if this is the first or last reactor in the cascade
@@ -282,12 +282,12 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
         #                             species mass fractions                          #
         # ============================================================================#
 
-        wdot = self.contents.net_production_rates # chemical source terms
+        wdot = self.phase.net_production_rates # chemical source terms
         if not self.chemistry:
             wdot *= 0.0
 
         # right hand side of the mass fraction equations
-        for k in range(self.contents.n_species):
+        for k in range(self.phase.n_species):
             index = k + self.species_offset
             # chemical source term
             RHS[index] += wdot[k] * self.molecular_weights[k] / density
@@ -300,15 +300,15 @@ class PMReactor(ct.ExtensibleIdealGasConstPressureReactor):
         # ============================================================================#
 
         # right hand side of the gas phase temperature equation
-        enthalpy_loss = np.dot(self.contents.partial_molar_enthalpies
+        enthalpy_loss = np.dot(self.phase.partial_molar_enthalpies
                                / self.molecular_weights, Y_in)
 
-        hrr = -np.dot(self.contents.partial_molar_enthalpies, wdot)  # (W/m^3)
+        hrr = -np.dot(self.phase.partial_molar_enthalpies, wdot)  # (W/m^3)
 
         Tindex = self.component_index("temperature")
         LHS[Tindex] = porosity * density * cp * self.V
         # heat transfer between solid and gas-phase
-        RHS[Tindex] -= self.htc() * (self.contents.T - self.Ts) * self.V
+        RHS[Tindex] -= self.htc() * (self.phase.T - self.Ts) * self.V
         # convective transport
         RHS[Tindex] += self.A * mdot * (h_in - enthalpy_loss)
         # chemical contribution
@@ -401,7 +401,7 @@ net.rtol_sensitivity = 0.05
 net.advance_to_steady_state()
 
 x = [r.midpoint for r in reactors]
-T = [r.contents.T for r in reactors]
+T = [r.phase.T for r in reactors]
 Ts = [r.Ts for r in reactors]
 
 plt.plot(x, T, "-o", label="T gas")

--- a/samples/python/reactors/preconditioned_integration.py
+++ b/samples/python/reactors/preconditioned_integration.py
@@ -40,10 +40,10 @@ def integrate_reactor(preconditioner=True):
     # Advance to steady state
     integ_time = default_timer()
     # solution array for state data
-    states = ct.SolutionArray(reactor.contents, extra=['time'])
+    states = ct.SolutionArray(reactor.phase, extra=['time'])
     # advance to steady state manually
     while (sim.time < 0.1):
-        states.append(reactor.contents.state, time=sim.time)
+        states.append(reactor.phase.state, time=sim.time)
         sim.step()
     integ_time = default_timer() - integ_time
     # Return time to integrate

--- a/samples/python/reactors/reactor1.py
+++ b/samples/python/reactors/reactor1.py
@@ -30,9 +30,9 @@ print('{:10s} {:10s} {:10s} {:14s}'.format(
     't [s]', 'T [K]', 'P [Pa]', 'u [J/kg]'))
 while sim.time < t_end:
     sim.advance(sim.time + dt_max)
-    states.append(r.contents.state, t=sim.time*1e3)
+    states.append(r.phase.state, t=sim.time*1e3)
     print('{:10.3e} {:10.3f} {:10.3f} {:14.6f}'.format(
-            sim.time, r.T, r.contents.P, r.contents.u))
+          sim.time, r.T, r.phase.P, r.phase.u))
 
 # Plot the results if matplotlib is installed.
 # See http://matplotlib.org/ to get it.

--- a/samples/python/reactors/reactor2.py
+++ b/samples/python/reactors/reactor2.py
@@ -82,8 +82,8 @@ states2 = ct.SolutionArray(gas, extra=['t', 'V'])
 for n in range(n_steps):
     time += 4.e-4
     sim.advance(time)
-    states1.append(r1.contents.state, t=time, V=r1.volume)
-    states2.append(r2.contents.state, t=time, V=r2.volume)
+    states1.append(r1.phase.state, t=time, V=r1.volume)
+    states2.append(r2.phase.state, t=time, V=r2.volume)
 
 # %%
 # Combine the results and save for later processing or plotting

--- a/samples/python/reactors/sensitivity1.py
+++ b/samples/python/reactors/sensitivity1.py
@@ -37,10 +37,10 @@ for t in np.arange(0, 2e-3, 5e-6):
     sim.advance(t)
     s2 = sim.sensitivity('OH', 2)  # sensitivity of OH to reaction 2
     s3 = sim.sensitivity('OH', 3)  # sensitivity of OH to reaction 3
-    states.append(r.contents.state, t=1000*t, s2=s2, s3=s3)
+    states.append(r.phase.state, t=1000*t, s2=s2, s3=s3)
 
     print('{:10.3e} {:10.3f} {:10.3f} {:14.6e} {:10.3f} {:10.3f}'.format(
-        sim.time, r.T, r.contents.P, r.contents.u, s2, s3))
+        sim.time, r.T, r.phase.P, r.phase.u, s2, s3))
 
 # plot the results if matplotlib is installed.
 # see http://matplotlib.org/ to get it

--- a/samples/python/reactors/surf_pfr.py
+++ b/samples/python/reactors/surf_pfr.py
@@ -65,7 +65,7 @@ output_data = []
 n = 0
 print('    distance       X_CH4        X_H2        X_CO')
 print('  {:10f}  {:10f}  {:10f}  {:10f}'.format(
-      0, *r.contents['CH4', 'H2', 'CO'].X))
+      0, *r.phase['CH4', 'H2', 'CO'].X))
 
 while sim.distance < length:
     dist = sim.distance * 1e3  # convert to mm
@@ -73,14 +73,14 @@ while sim.distance < length:
 
     if n % 100 == 0 or (dist > 1 and n % 10 == 0):
         print('  {:10f}  {:10f}  {:10f}  {:10f}'.format(
-              dist, *r.contents['CH4', 'H2', 'CO'].X))
+              dist, *r.phase['CH4', 'H2', 'CO'].X))
     n += 1
 
     # write the gas mole fractions and surface coverages vs. distance
     output_data.append(
-        [dist, r.T - 273.15, r.contents.P / ct.one_atm]
-        + list(r.contents.X)  # use r.contents.X not gas.X
-        + list(rsurf.contents.coverages)  # use rsurf.contents.coverages not surf.coverages
+        [dist, r.T - 273.15, r.phase.P / ct.one_atm]
+        + list(r.phase.X)  # use r.phase.X not gas.X
+        + list(rsurf.phase.coverages)  # use rsurf.phase.coverages not surf.coverages
     )
 
 with open(output_filename, 'w', newline="") as outfile:

--- a/samples/python/reactors/surf_pfr_chain.py
+++ b/samples/python/reactors/surf_pfr_chain.py
@@ -105,7 +105,7 @@ output_data = []
 
 for n in range(NReactors):
     # Set the state of the reservoir to match that of the previous reactor
-    gas.TDY = r.contents.TDY
+    gas.TDY = r.phase.TDY
     upstream.syncState()
     sim.reinitialize()
     sim.advance_to_steady_state()
@@ -113,13 +113,13 @@ for n in range(NReactors):
 
     if n % 10 == 0:
         print('  {0:10f}  {1:10f}  {2:10f}  {3:10f}'.format(
-            dist, *r.contents['CH4', 'H2', 'CO'].X))
+            dist, *r.phase['CH4', 'H2', 'CO'].X))
 
     # write the gas mole fractions and surface coverages vs. distance
     output_data.append(
-        [dist, r.T - 273.15, r.contents.P / ct.one_atm]
-        + list(r.contents.X)  # use r.contents.X not gas.X
-        + list(rsurf.contents.coverages)  # use rsurf.contents.coverages not surf.coverages
+        [dist, r.T - 273.15, r.phase.P / ct.one_atm]
+        + list(r.phase.X)  # use r.phase.X not gas.X
+        + list(rsurf.phase.coverages)  # use rsurf.phase.coverages not surf.coverages
     )
 
 with open(output_filename, 'w', newline="") as outfile:

--- a/src/zeroD/FlowDevice.cpp
+++ b/src/zeroD/FlowDevice.cpp
@@ -26,8 +26,8 @@ FlowDevice::FlowDevice(shared_ptr<ReactorBase> r0, shared_ptr<ReactorBase> r1,
     m_out->addInlet(*this);
 
     // construct adapters between inlet and outlet species
-    const ThermoPhase& mixin = *m_in->contents4()->thermo();
-    const ThermoPhase& mixout = *m_out->contents4()->thermo();
+    const ThermoPhase& mixin = *m_in->phase()->thermo();
+    const ThermoPhase& mixout = *m_out->phase()->thermo();
 
     m_nspin = mixin.nSpecies();
     m_nspout = mixout.nSpecies();

--- a/src/zeroD/ReactorFactory.cpp
+++ b/src/zeroD/ReactorFactory.cpp
@@ -99,14 +99,14 @@ void ReactorFactory::deleteFactory() {
 }
 
 shared_ptr<ReactorBase> newReactorBase(
-    const string& model, shared_ptr<Solution> contents, bool clone, const string& name)
+    const string& model, shared_ptr<Solution> phase, bool clone, const string& name)
 {
     return shared_ptr<ReactorBase>(
-        ReactorFactory::factory()->create(model, contents, clone, name));
+        ReactorFactory::factory()->create(model, phase, clone, name));
 }
 
 shared_ptr<ReactorBase> newReactor(
-    const string& model, shared_ptr<Solution> contents, const string& name)
+    const string& model, shared_ptr<Solution> phase, const string& name)
 {
     warn_deprecated("newReactor", "Behavior changes after Cantera 3.2, when a "
         "'shared_ptr<Reactor>' is returned.\nFor new behavior, use 'newReactor4'.");
@@ -114,14 +114,14 @@ shared_ptr<ReactorBase> newReactor(
         "will change from `clone=False` to `clone=True` after Cantera 3.2.\n"
         "Use the transitional newReactor4() function to provide a value for the clone "
         "argument");
-    return newReactorBase(model, contents, false, name);
+    return newReactorBase(model, phase, false, name);
 }
 
 shared_ptr<Reactor> newReactor4(
-    const string& model, shared_ptr<Solution> contents, bool clone, const string& name)
+    const string& model, shared_ptr<Solution> phase, bool clone, const string& name)
 {
     auto reactor = std::dynamic_pointer_cast<Reactor>(
-        newReactorBase(model, contents, clone, name));
+        newReactorBase(model, phase, clone, name));
     if (!reactor) {
         throw CanteraError("newReactor4",
             "Model type '{}' does not specify a bulk reactor.", model);
@@ -130,10 +130,10 @@ shared_ptr<Reactor> newReactor4(
 }
 
 shared_ptr<Reservoir> newReservoir(
-    shared_ptr<Solution> contents, bool clone, const string& name)
+    shared_ptr<Solution> phase, bool clone, const string& name)
 {
     auto reservoir = std::dynamic_pointer_cast<Reservoir>(
-        newReactorBase("Reservoir", contents, clone, name));
+        newReactorBase("Reservoir", phase, clone, name));
     if (!reservoir) {
         throw CanteraError("newReservoir",
             "Caught unexpected inconsistency in factory method.");
@@ -141,10 +141,10 @@ shared_ptr<Reservoir> newReservoir(
     return reservoir;
 }
 
-shared_ptr<ReactorSurface> newReactorSurface(shared_ptr<Solution> contents,
+shared_ptr<ReactorSurface> newReactorSurface(shared_ptr<Solution> phase,
     const vector<shared_ptr<ReactorBase>>& reactors, bool clone, const string& name)
 {
-    return make_shared<ReactorSurface>(contents, reactors, clone, name);
+    return make_shared<ReactorSurface>(phase, reactors, clone, name);
 }
 
 }

--- a/src/zeroD/ReactorNet.cpp
+++ b/src/zeroD/ReactorNet.cpp
@@ -118,7 +118,7 @@ void ReactorNet::initialize()
     m_start.assign(1, 0);
     for (size_t n = 0; n < m_reactors.size(); n++) {
         Reactor& r = *m_reactors[n];
-        shared_ptr<Solution> bulk = r.contents4();
+        shared_ptr<Solution> bulk = r.phase();
         r.initialize(m_time);
         size_t nv = r.neq();
         m_nv += nv;
@@ -134,7 +134,7 @@ void ReactorNet::initialize()
         }
         solutions[bulk.get()].push_back(r.name());
         for (size_t i = 0; i < r.nSurfs(); i++) {
-            if (r.surface(i)->contents4()->adjacent(bulk->name()) != bulk) {
+            if (r.surface(i)->phase()->adjacent(bulk->name()) != bulk) {
                 throw CanteraError("ReactorNet::initialize",
                     "Bulk phase '{}' used by interface '{}' must be the same object\n"
                     "as the contents of the adjacent reactor '{}'.",
@@ -144,7 +144,7 @@ void ReactorNet::initialize()
         }
     }
     for (auto surf : surfaces) {
-        solutions[surf->contents4().get()].push_back(surf->name());
+        solutions[surf->phase().get()].push_back(surf->name());
     }
     for (auto& [soln, reactors] : solutions) {
         if (reactors.size() > 1) {

--- a/src/zeroD/ReactorSurface.cpp
+++ b/src/zeroD/ReactorSurface.cpp
@@ -22,7 +22,7 @@ ReactorSurface::ReactorSurface(shared_ptr<Solution> soln,
     // TODO: After Cantera 3.2, raise an exception of 'reactors' is empty
     vector<shared_ptr<Solution>> adjacent;
     for (auto R : reactors) {
-        adjacent.push_back(R->contents4());
+        adjacent.push_back(R->phase());
         m_reactors.push_back(R.get());
         R->addSurface(this);
     }

--- a/test/clib/test_ctreactor.cpp
+++ b/test/clib/test_ctreactor.cpp
@@ -59,10 +59,10 @@ TEST(ctreactor, reactor_simple)
         count++;
     }
     // Reactor contents should be the same Solution & ThermoPhase objects
-    int32_t contents = reactor_contents(reactor);
-    int32_t contents_thermo = sol_thermo(contents);
-    EXPECT_DOUBLE_EQ(thermo_temperature(contents_thermo), thermo_temperature(thermo));
-    thermo_setTemperature(contents_thermo, 345.0);
+    int32_t phase = reactor_phase(reactor);
+    int32_t phase_thermo = sol_thermo(phase);
+    EXPECT_DOUBLE_EQ(thermo_temperature(phase_thermo), thermo_temperature(thermo));
+    thermo_setTemperature(phase_thermo, 345.0);
     EXPECT_DOUBLE_EQ(thermo_temperature(thermo), 345.0);
 }
 
@@ -95,12 +95,12 @@ TEST(ctreactor, reactor_clone)
     }
     // Reactor contents should be independent objects with a distinct state, and the
     // original thermo object should be unmodified
-    int32_t contents = reactor_contents(reactor);
-    ASSERT_GE(contents, 0);
-    int32_t contents_thermo = sol_thermo(contents);
-    ASSERT_GE(contents_thermo, 0);
+    int32_t phase = reactor_phase(reactor);
+    ASSERT_GE(phase, 0);
+    int32_t phase_thermo = sol_thermo(phase);
+    ASSERT_GE(phase_thermo, 0);
     EXPECT_DOUBLE_EQ(thermo_temperature(thermo), T);
-    EXPECT_GT(thermo_temperature(contents_thermo), T);
+    EXPECT_GT(thermo_temperature(phase_thermo), T);
 }
 
 TEST(ctreactor, surface)

--- a/test/matlab_experimental/ctTestConstPressureReactor.m
+++ b/test/matlab_experimental/ctTestConstPressureReactor.m
@@ -110,7 +110,7 @@ classdef ctTestConstPressureReactor < ctTestCase
                 surf (1,1) logical = false
             end
 
-            self.verifyEqual(self.r1.contents.Y, self.r2.contents.Y, ...
+            self.verifyEqual(self.r1.phase.Y, self.r2.phase.Y, ...
                             'RelTol', 5e-4, 'AbsTol', 1e-6);
             self.verifyEqual(self.r1.T, self.r2.T, 'RelTol', 5e-5);
             self.verifyEqual(self.r1.P, self.r2.P, 'RelTol', 1e-6);

--- a/test/matlab_experimental/ctTestFlowDevice.m
+++ b/test/matlab_experimental/ctTestFlowDevice.m
@@ -94,15 +94,15 @@ classdef ctTestFlowDevice < ctTestCase
 
             m1a = self.r1.D * self.r1.V;
             m2a = self.r2.D * self.r2.V;
-            Y1a = self.r1.contents.Y;
-            Y2a = self.r2.contents.Y;
+            Y1a = self.r1.phase.Y;
+            Y2a = self.r2.phase.Y;
 
             self.net.advance(0.1);
 
             m1b = self.r1.D * self.r1.V;
             m2b = self.r2.D * self.r2.V;
-            Y1b = self.r1.contents.Y;
-            Y2b = self.r2.contents.Y;
+            Y1b = self.r1.phase.Y;
+            Y2b = self.r2.phase.Y;
 
             % self.verifyEqual((self.r1.P - self.r2.P) * k, valve.massFlowRate, ...
             %                  'RelTol', self.rtol);

--- a/test/matlab_experimental/ctTestReactor.m
+++ b/test/matlab_experimental/ctTestReactor.m
@@ -251,7 +251,7 @@ classdef ctTestReactor < ctTestCase
             self.verifyEqual(self.r1.T, gas.T, 'RelTol', self.rtol);
             self.verifyEqual(self.r1.D, gas.D, 'RelTol', self.rtol);
             self.verifyEqual(self.r1.P, gas.P, 'RelTol', self.rtol);
-            self.verifyEqual(self.r1.contents.X, gas.X, 'RelTol', self.rtol);
+            self.verifyEqual(self.r1.phase.X, gas.X, 'RelTol', self.rtol);
         end
 
         function testEquilibriumHP(self)
@@ -275,7 +275,7 @@ classdef ctTestReactor < ctTestCase
             self.verifyEqual(self.r1.T, self.gas2.T, 'RelTol', self.rtol);
             self.verifyEqual(self.r1.D, self.gas2.D, 'RelTol', self.rtol);
             self.verifyEqual(self.r1.P, P0, 'RelTol', self.rtol);
-            self.verifyEqual(self.r1.contents.X, self.gas2.X, 'RelTol', self.rtol);
+            self.verifyEqual(self.r1.phase.X, self.gas2.X, 'RelTol', self.rtol);
         end
 
         function testWallVelocity(self)
@@ -318,8 +318,8 @@ classdef ctTestReactor < ctTestCase
             self.makeReactors('T1', 1000, 'nr', 1, 'X1', 'H2:2.0,O2:1.0');
             self.r1.chemistry = 'off';
             self.net.advance(11.0);
-            x1 = self.r1.contents.X(self.r1.contents.speciesIndex('H2'));
-            x2 = self.r1.contents.X(self.r1.contents.speciesIndex('O2'));
+            x1 = self.r1.phase.X(self.r1.phase.speciesIndex('H2'));
+            x2 = self.r1.phase.X(self.r1.phase.speciesIndex('O2'));
 
             self.verifyEqual(self.r1.T, 1000, 'RelTol', self.rtol);
             self.verifyEqual(x1, 2.0 / 3.0, 'RelTol', self.rtol);
@@ -331,8 +331,8 @@ classdef ctTestReactor < ctTestCase
             self.makeReactors('T1', 500, 'T2', 300);
             self.r1.V = 0.5;
 
-            U1a = self.r1.V * self.r1.D * self.r1.contents.U;
-            U2a = self.r2.V * self.r2.D * self.r2.contents.U;
+            U1a = self.r1.V * self.r1.D * self.r1.phase.U;
+            U2a = self.r2.V * self.r2.D * self.r2.phase.U;
             V1a = self.r1.V;
             V2a = self.r2.V;
 
@@ -343,8 +343,8 @@ classdef ctTestReactor < ctTestCase
 
             self.net.advance(1.1);
             self.verifyEqual(self.w.heatFlux, f(1.1), 'RelTol', self.rtol);
-            U1b = self.r1.V * self.r1.D * self.r1.contents.U;
-            U2b = self.r2.V * self.r2.D * self.r2.contents.U;
+            U1b = self.r1.V * self.r1.D * self.r1.phase.U;
+            U2b = self.r2.V * self.r2.D * self.r2.phase.U;
 
             self.verifyEqual(V1a, self.r1.V, 'RelTol', self.rtol);
             self.verifyEqual(V2a, self.r2.V, 'RelTol', self.rtol);

--- a/test/matlab_experimental/ctTestWellStirredReactor.m
+++ b/test/matlab_experimental/ctTestWellStirredReactor.m
@@ -74,8 +74,8 @@ classdef ctTestWellStirredReactor < ctTestCase
                 self.verifyEqual(T(i), 900, 'RelTol', 1e-5);
             end
 
-            val1 = self.combustor.contents.Y...
-                   (self.combustor.contents.speciesIndex('CH4'));
+            val1 = self.combustor.phase.Y...
+                   (self.combustor.phase.speciesIndex('CH4'));
             val2 = (1.0 / 6.0);
             self.verifyEqual(val1, val2, 'RelTol', 1e-5);
         end

--- a/test/python/test_kinetics.py
+++ b/test/python/test_kinetics.py
@@ -739,7 +739,7 @@ class TestReactionPath:
         while T < 1900:
             net.step()
             T = r.T
-        return r.contents
+        return r.phase
 
     def check_dot(self, gas, diagram, element):
         diagram.label_threshold = 0

--- a/test/python/test_thermo.py
+++ b/test/python/test_thermo.py
@@ -941,7 +941,7 @@ class TestThermoPhase:
         self.phase.transport_model = "unity-Lewis-number"
         reactor = ct.IdealGasReactor(self.phase, clone=False)
         with pytest.raises(ct.CanteraError, match='Cannot add species'):
-            reactor.contents.add_species(ref.species('CH4'))
+            reactor.phase.add_species(ref.species('CH4'))
         del reactor
         gc.collect()
         self.phase.add_species(ref.species('CH4'))

--- a/test/zeroD/test_zeroD.cpp
+++ b/test/zeroD/test_zeroD.cpp
@@ -200,7 +200,7 @@ TEST(MoleReactorTestSet, test_mole_reactor_get_state)
     reactor.initialize();
     vector<double> state(reactor.neq());
     // test get state
-    const ThermoPhase& thermo = *reactor.contents4()->thermo();
+    const ThermoPhase& thermo = *reactor.phase()->thermo();
     const vector<double>& imw = thermo.inverseMolecularWeights();
     // prescribed state
     double mass = reactor.volume() * thermo.density();


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

This is a follow-up to #2001. Upon further consideration, updating the nomenclature to `phase` rather than `contents` will be less disruptive, as `SolutionArray` and 1D objects already use a `phase` property.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
