### PR TITLE
Deprecate legacy Domain1D constructors

### DIFF
--- a/include/cantera/base/SolutionArray.h
+++ b/include/cantera/base/SolutionArray.h
@@ -112,7 +112,16 @@ public:
     }
 
     //! Retrieve associated Solution object
+    //! @deprecated To be removed after %Cantera 3.2. Renamed to phase().
     shared_ptr<Solution> solution() {
+        warn_deprecated("SolutionArray::solution",
+            "To be removed after Cantera 3.2. Renamed to phase().");
+        return m_sol;
+    }
+
+    //! Retrieve associated Solution object
+    //! @since New in %Cantera 3.2
+    shared_ptr<Solution> phase() {
         return m_sol;
     }
 

--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -144,9 +144,9 @@ public:
     Inlet1D();
 
     //! Constructor with contents
-    //! @param solution  Solution representing contents of adjacent flow domain
+    //! @param phase  Solution representing contents of adjacent flow domain
     //! @param id  Name used to identify this domain
-    Inlet1D(shared_ptr<Solution> solution, const string& id="");
+    Inlet1D(shared_ptr<Solution> phase, const string& id="");
 
     string domainType() const override {
         return "inlet";
@@ -199,10 +199,11 @@ public:
     Empty1D() = default;
 
     //! Constructor with contents
-    //! @param solution  Solution representing contents
+    //! @param phase  Solution representing contents
     //! @param id  Name used to identify this domain
-    Empty1D(shared_ptr<Solution> solution, const string& id="") : Empty1D() {
-        setSolution(solution);
+    Empty1D(shared_ptr<Solution> phase, const string& id="") : Empty1D() {
+        m_solution = phase;
+        m_solution->thermo()->addSpeciesLock();
         m_id = id;
     }
 
@@ -230,10 +231,11 @@ public:
     Symm1D() = default;
 
     //! Constructor with contents
-    //! @param solution  Solution representing contents of adjacent flow domain
+    //! @param phase  Solution representing contents of adjacent flow domain
     //! @param id  Name used to identify this domain
-    Symm1D(shared_ptr<Solution> solution, const string& id="") : Symm1D() {
-        setSolution(solution);
+    Symm1D(shared_ptr<Solution> phase, const string& id="") : Symm1D() {
+        m_solution = phase;
+        m_solution->thermo()->addSpeciesLock();
         m_id = id;
     }
 
@@ -260,10 +262,11 @@ public:
     Outlet1D() = default;
 
     //! Constructor with contents
-    //! @param solution  Solution representing contents of adjacent flow domain
+    //! @param phase  Solution representing contents of adjacent flow domain
     //! @param id  Name used to identify this domain
-    Outlet1D(shared_ptr<Solution> solution, const string& id="") : Outlet1D() {
-        setSolution(solution);
+    Outlet1D(shared_ptr<Solution> phase, const string& id="") : Outlet1D() {
+        m_solution = phase;
+        m_solution->thermo()->addSpeciesLock();
         m_id = id;
     }
 
@@ -290,9 +293,9 @@ public:
     OutletRes1D();
 
     //! Constructor with contents
-    //! @param solution  Solution representing contents of adjacent flow domain
+    //! @param phase  Solution representing contents of adjacent flow domain
     //! @param id  Name used to identify this domain
-    OutletRes1D(shared_ptr<Solution> solution, const string& id="");
+    OutletRes1D(shared_ptr<Solution> phase, const string& id="");
 
     string domainType() const override {
         return "outlet-reservoir";
@@ -334,10 +337,11 @@ public:
     Surf1D() = default;
 
     //! Constructor with contents
-    //! @param solution  Solution representing contents of adjacent flow domain
+    //! @param phase  Solution representing contents of adjacent flow domain
     //! @param id  Name used to identify this domain
-    Surf1D(shared_ptr<Solution> solution, const string& id="") : Surf1D() {
-        setSolution(solution);
+    Surf1D(shared_ptr<Solution> phase, const string& id="") : Surf1D() {
+        m_solution = phase;
+        m_solution->thermo()->addSpeciesLock();
         m_id = id;
     }
 
@@ -362,9 +366,9 @@ public:
     ReactingSurf1D();
 
     //! Constructor with contents
-    //! @param solution  Solution representing contents of adjacent flow domain
+    //! @param phase  Solution representing contents of adjacent flow domain
     //! @param id  Name used to identify this domain
-    ReactingSurf1D(shared_ptr<Solution> solution, const string& id="");
+    ReactingSurf1D(shared_ptr<Solution> phase, const string& id="");
 
     string domainType() const override {
         return "reacting-surface";

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -68,7 +68,8 @@ public:
 
     //! Set the kinetics manager.
     //! @since New in %Cantera 3.0.
-    //! @todo Convert warning message to new exception and remove virtual.
+    //! @deprecated To be removed after %Cantera 3.2. A change of domain contents after
+    //!     instantiation will be disabled.
     virtual void setKinetics(shared_ptr<Kinetics> kin) {
         warn_deprecated("Domain1D::setKinetics",
             "After Cantera 3.2, a change of domain contents after instantiation "

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -33,8 +33,9 @@ public:
      * @param nv      Number of variables at each grid point.
      * @param points  Number of grid points.
      * @param time    (unused)
+     * @deprecated After %Cantera 3.2, this constructor will become protected
      */
-    Domain1D(size_t nv=1, size_t points=1, double time=0.0);
+    explicit Domain1D(size_t nv=1, size_t points=1, double time=0.0);
 
     virtual ~Domain1D();
     Domain1D(const Domain1D&) = delete;
@@ -61,17 +62,27 @@ public:
 
     //! Set the solution manager.
     //! @since New in %Cantera 3.0.
+    //! @deprecated To be removed after %Cantera 3.2. Solution objects must be
+    //!     provided to constructors instead.
     void setSolution(shared_ptr<Solution> sol);
 
     //! Set the kinetics manager.
     //! @since New in %Cantera 3.0.
+    //! @todo Convert warning message to new exception and remove virtual.
     virtual void setKinetics(shared_ptr<Kinetics> kin) {
+        warn_deprecated("Domain1D::setKinetics",
+            "After Cantera 3.2, a change of domain contents after instantiation "
+            "will be disabled.");
         throw NotImplementedError("Domain1D::setKinetics");
     }
 
     //! Set transport model to existing instance
     //! @since New in %Cantera 3.0.
+    //! @todo Convert warning message to new exception and remove virtual.
     virtual void setTransport(shared_ptr<Transport> trans) {
+        warn_deprecated("Domain1D::setTransport",
+            "After Cantera 3.2, a change of domain contents after instantiation "
+            "will be disabled.");
         throw NotImplementedError("Domain1D::setTransport");
     }
 
@@ -82,6 +93,20 @@ public:
         throw NotImplementedError("Domain1D::setTransportModel");
     }
 
+protected:
+    //! Update transport model to existing instance
+    //! @since New in %Cantera 3.2.
+    virtual void _setKinetics(shared_ptr<Kinetics> kin) {
+        throw NotImplementedError("Domain1D::_setKinetics");
+    }
+
+    //! Update transport model to existing instance
+    //! @since New in %Cantera 3.2.
+    virtual void _setTransport(shared_ptr<Transport> trans) {
+        throw NotImplementedError("Domain1D::_setTransport");
+    }
+
+public:
     //! The container holding this domain.
     const OneDim& container() const {
         return *m_container;
@@ -566,7 +591,16 @@ public:
 
     //! Return thermo/kinetics/transport manager used in the domain
     //! @since New in %Cantera 3.0.
+    //! @deprecated To be removed after %Cantera 3.2. Renamed to phase().
     shared_ptr<Solution> solution() const {
+        warn_deprecated("Domain1D::solution",
+            "To be removed after Cantera 3.2. Renamed to phase().");
+        return m_solution;
+    }
+
+    //! Return thermo/kinetics/transport manager used in the domain
+    //! @since New in %Cantera 3.2.
+    shared_ptr<Solution> phase() const {
         return m_solution;
     }
 
@@ -602,8 +636,8 @@ public:
      */
     void linkLeft(Domain1D* left) {
         m_left = left;
-        if (!m_solution && left && left->solution()) {
-            setSolution(left->solution());
+        if (!m_solution && left && left->phase()) {
+            setSolution(left->phase());
         }
         locate();
     }
@@ -611,8 +645,8 @@ public:
     //! Set the right neighbor to domain 'right.'
     void linkRight(Domain1D* right) {
         m_right = right;
-        if (!m_solution && right && right->solution()) {
-            setSolution(right->solution());
+        if (!m_solution && right && right->phase()) {
+            setSolution(right->phase());
         }
     }
 

--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -55,20 +55,30 @@ public:
     //!     to evaluate all thermodynamic, kinetic, and transport properties.
     //! @param nsp  Number of species.
     //! @param points  Initial number of grid points
+    //! @deprecated To be removed after %Cantera 3.2. Use constructor using Solution
+    //!     instead.
     Flow1D(ThermoPhase* ph = 0, size_t nsp = 1, size_t points = 1);
 
     //! Delegating constructor
+    //! @deprecated To be removed after %Cantera 3.2. Use constructor using Solution
+    //!     instead.
     Flow1D(shared_ptr<ThermoPhase> th, size_t nsp = 1, size_t points = 1);
 
     //! Create a new flow domain.
-    //! @param sol  Solution object used to evaluate all thermodynamic, kinetic, and
+    //! @param phase  Solution object used to evaluate all thermodynamic, kinetic, and
     //!     transport properties
     //! @param id  name of flow domain
     //! @param points  initial number of grid points
-    Flow1D(shared_ptr<Solution> sol, const string& id="", size_t points=1);
+    Flow1D(shared_ptr<Solution> phase, const string& id="", size_t points=1);
 
     ~Flow1D();
 
+private:
+    //! Initialize arrays.
+    //! @todo Consolidate after removal of legacy constructors.
+    void _init(ThermoPhase* ph, size_t nsp, size_t points);
+
+public:
     string domainType() const override;
 
     //! @name Problem Specification
@@ -96,6 +106,11 @@ public:
     //! Set the transport manager used for transport property calculations
     void setTransport(shared_ptr<Transport> trans) override;
 
+protected:
+    void _setKinetics(shared_ptr<Kinetics> kin) override;
+    void _setTransport(shared_ptr<Transport> trans) override;
+
+public:
     //! Set the transport model
     //! @since New in %Cantera 3.0.
     void setTransportModel(const string& model) override;

--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -75,7 +75,7 @@ public:
 
 private:
     //! Initialize arrays.
-    //! @todo Consolidate after removal of legacy constructors.
+    //! @todo Consolidate once legacy constructors are removed after %Cantera 3.2.
     void _init(ThermoPhase* ph, size_t nsp, size_t points);
 
 public:

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -33,15 +33,23 @@ public:
     //!     to evaluate all thermodynamic, kinetic, and transport properties.
     //! @param nsp  Number of species.
     //! @param points  Initial number of grid points
+    //! @deprecated To be removed after %Cantera 3.2. Use constructor using Solution
+    //!     instead.
     IonFlow(ThermoPhase* ph = 0, size_t nsp = 1, size_t points = 1);
 
     //! Create a new IonFlow domain.
-    //! @param sol  Solution object used to evaluate all thermodynamic, kinetic, and
+    //! @param phase  Solution object used to evaluate all thermodynamic, kinetic, and
     //!     transport properties
     //! @param id  name of flow domain
     //! @param points  initial number of grid points
-    IonFlow(shared_ptr<Solution> sol, const string& id="", size_t points = 1);
+    IonFlow(shared_ptr<Solution> phase, const string& id="", size_t points = 1);
 
+private:
+    //! Initialize arrays.
+    //! @todo Consolidate after removal of legacy constructors.
+    void _init(ThermoPhase* ph, size_t nsp, size_t points);
+
+public:
     string domainType() const override;
 
     size_t getSolvingStage() const override {

--- a/include/cantera/oneD/IonFlow.h
+++ b/include/cantera/oneD/IonFlow.h
@@ -46,7 +46,7 @@ public:
 
 private:
     //! Initialize arrays.
-    //! @todo Consolidate after removal of legacy constructors.
+    //! @todo Consolidate once legacy constructors are removed after %Cantera 3.2.
     void _init(ThermoPhase* ph, size_t nsp, size_t points);
 
 public:

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -975,7 +975,16 @@ cdef class Sim1D:
 
         :param domain: Index of domain within `Sim1D.domains` list; the default
             is to return the phase of the parent `Sim1D` object.
+
+        .. deprecated:: 3.2
+
+            To be removed after Cantera 3.2. Contents should be accessed via
+            `Domain1D.phase` properties of domain objects instead.
         """
+        warnings.warn(
+            "To be removed after Cantera 3.2. Contents should be accessed via "
+            "property 'phase' of domain objects instead.",
+            DeprecationWarning)
         if domain is None:
             return self.gas
 

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -34,6 +34,9 @@ void Domain1D::setSolution(shared_ptr<Solution> sol)
         throw CanteraError("Domain1D::setSolution",
             "Missing or incomplete Solution object.");
     }
+    warn_deprecated("Domain1D::setSolution",
+        "After Cantera 3.2, a change of domain contents after instantiation "
+        "will be disabled.");
     if (m_solution) {
         m_solution->thermo()->removeSpeciesLock();
     }

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -33,7 +33,7 @@ Flow1D::Flow1D(ThermoPhase* ph, size_t nsp, size_t points) :
     Domain1D(nsp+c_offset_Y, points),
     m_nsp(nsp)
 {
-    warn_deprecated("Flow1D::Flow1D",
+    warn_deprecated("Flow1D::Flow1D(ThermoPhase*, size_t, size_t)",
         "To be removed after Cantera 3.2. Use constructor using Solution instead.");
     _init(ph, nsp, points);
 }

--- a/src/oneD/IonFlow.cpp
+++ b/src/oneD/IonFlow.cpp
@@ -18,7 +18,7 @@ namespace Cantera
 IonFlow::IonFlow(ThermoPhase* ph, size_t nsp, size_t points) :
     Flow1D(ph, nsp, points)
 {
-    warn_deprecated("IonFlow::IonFlow",
+    warn_deprecated("IonFlow::IonFlow(ThermoPhase*, size_t, size_t)",
         "To be removed after Cantera 3.2. Use constructor using Solution instead.");
     _init(ph, nsp, points);
 }

--- a/src/oneD/Sim1D.cpp
+++ b/src/oneD/Sim1D.cpp
@@ -257,7 +257,7 @@ AnyMap Sim1D::restore(const string& fname, const string& name)
         header = SolutionArray::readHeader(fname, name);
 
         for (auto dom : m_dom) {
-            auto arr = SolutionArray::create(dom->solution());
+            auto arr = SolutionArray::create(dom->phase());
             try {
                 arr->readEntry(fname, name, dom->id());
             } catch (CanteraError& err) {
@@ -289,7 +289,7 @@ AnyMap Sim1D::restore(const string& fname, const string& name)
         header = SolutionArray::readHeader(root, name);
 
         for (auto dom : m_dom) {
-            auto arr = SolutionArray::create(dom->solution());
+            auto arr = SolutionArray::create(dom->phase());
             try {
                 arr->readEntry(root, name, dom->id());
             } catch (CanteraError& err) {


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

- Deprecate legacy `Domain1D` constructors that rely on `ThermoPhase*`
- Deprecate Python's `Sim1D.phase`
- Rename `SolutionArray::solution` to `SolutionArray::phase`

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Partially addresses Cantera/enhancements#239

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
