### PR TITLE
Add Domain1D info to Python API

### DIFF
--- a/include/cantera/oneD/Boundary1D.h
+++ b/include/cantera/oneD/Boundary1D.h
@@ -173,7 +173,7 @@ public:
     }
     void init() override;
     void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
-    shared_ptr<SolutionArray> toArray(bool normalize=false) const override;
+    shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
 protected:
@@ -216,7 +216,7 @@ public:
 
     void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
-    shared_ptr<SolutionArray> toArray(bool normalize=false) const override;
+    shared_ptr<SolutionArray> toArray(bool normalize=false) override;
 };
 
 /**
@@ -245,7 +245,7 @@ public:
 
     void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
-    shared_ptr<SolutionArray> toArray(bool normalize=false) const override;
+    shared_ptr<SolutionArray> toArray(bool normalize=false) override;
 };
 
 
@@ -275,7 +275,7 @@ public:
 
     void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
-    shared_ptr<SolutionArray> toArray(bool normalize=false) const override;
+    shared_ptr<SolutionArray> toArray(bool normalize=false) override;
 };
 
 
@@ -312,7 +312,7 @@ public:
 
     void init() override;
     void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
-    shared_ptr<SolutionArray> toArray(bool normalize=false) const override;
+    shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
 protected:
@@ -347,7 +347,7 @@ public:
 
     void init() override;
     void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
-    shared_ptr<SolutionArray> toArray(bool normalize=false) const override;
+    shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
     void show(const double* x) override;
 };
@@ -392,7 +392,7 @@ public:
     void eval(size_t jg, double* xg, double* rg, integer* diagg, double rdt) override;
 
     double value(const string& component) const override;
-    shared_ptr<SolutionArray> toArray(bool normalize=false) const override;
+    shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
     void _getInitialSoln(double* x) override {

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -518,7 +518,7 @@ public:
      * @since New in %Cantera 3.0.
      * @deprecated To be removed after %Cantera 3.2. Replaceable by toArray().
      */
-    shared_ptr<SolutionArray> asArray(const double* soln) const {
+    shared_ptr<SolutionArray> asArray(const double* soln) {
         warn_deprecated("Domain1D::asArray",
             "To be removed after Cantera 3.2. Replaceable by 'toArray'.");
         return toArray();
@@ -532,7 +532,7 @@ public:
      *
      * @since New in %Cantera 3.0.
      */
-    virtual shared_ptr<SolutionArray> toArray(bool normalize=false) const {
+    virtual shared_ptr<SolutionArray> toArray(bool normalize=false) {
         throw NotImplementedError("Domain1D::toArray", "Needs to be overloaded.");
     }
 
@@ -562,6 +562,28 @@ public:
      */
     virtual void fromArray(const shared_ptr<SolutionArray>& arr) {
         throw NotImplementedError("Domain1D::fromArray", "Needs to be overloaded.");
+    }
+
+
+    /**
+     * Print a concise summary of a Domain.
+     * @see SolutionArray.info()
+     * @param keys  List of components to be displayed; if empty, all components are
+     *      considered.
+     * @param rows  Maximum number of rendered rows.
+     * @param width  Maximum width of rendered output.
+     */
+    string info(const vector<string>& keys, int rows=10, int width=80);
+
+    /**
+     * Print a concise summary of a Domain.
+     * Skips keys input while `vector<string>` is not implemented in sourcegen.
+     * @see SolutionArray.info()
+     * @param rows  Maximum number of rendered rows.
+     * @param width  Maximum width of rendered output.
+     */
+    string _info(int rows=10, int width=80) {
+        return info({}, rows, width);
     }
 
     //! Return thermo/kinetics/transport manager used in the domain

--- a/include/cantera/oneD/Domain1D.h
+++ b/include/cantera/oneD/Domain1D.h
@@ -566,21 +566,23 @@ public:
 
 
     /**
-     * Print a concise summary of a Domain.
+     * Return a concise summary of a Domain.
      * @see SolutionArray.info()
      * @param keys  List of components to be displayed; if empty, all components are
      *      considered.
      * @param rows  Maximum number of rendered rows.
      * @param width  Maximum width of rendered output.
+     * @since New in %Cantera 3.2.
      */
     string info(const vector<string>& keys, int rows=10, int width=80);
 
     /**
-     * Print a concise summary of a Domain.
+     * Return a concise summary of a Domain.
      * Skips keys input while `vector<string>` is not implemented in sourcegen.
      * @see SolutionArray.info()
      * @param rows  Maximum number of rendered rows.
      * @param width  Maximum width of rendered output.
+     * @since New in %Cantera 3.2.
      */
     string _info(int rows=10, int width=80) {
         return info({}, rows, width);

--- a/include/cantera/oneD/Flow1D.h
+++ b/include/cantera/oneD/Flow1D.h
@@ -193,7 +193,7 @@ public:
                     const vector<double>& pos, const vector<double>& values) override;
     void setFlatProfile(const string& component, double value) override;
 
-    shared_ptr<SolutionArray> toArray(bool normalize=false) const override;
+    shared_ptr<SolutionArray> toArray(bool normalize=false) override;
     void fromArray(const shared_ptr<SolutionArray>& arr) override;
 
     //! Set flow configuration for freely-propagating flames, using an internal point

--- a/interfaces/cython/cantera/_onedim.pxd
+++ b/interfaces/cython/cantera/_onedim.pxd
@@ -25,6 +25,7 @@ cdef extern from "cantera/oneD/Domain1D.h":
         string componentName(size_t) except +translate_exception
         size_t componentIndex(string&) except +translate_exception
         cbool hasComponent(string&) except +translate_exception
+        string info(vector[string]&, int, int) except +translate_exception
         void updateState(size_t) except +translate_exception
         vector[double] grid() except +translate_exception
         void setupGrid(vector[double]&) except +translate_exception

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -3,6 +3,7 @@
 
 from .interrupts import no_op
 import warnings
+from os import get_terminal_size as _get_terminal_size
 import numpy as np
 
 from ._utils cimport stringify, pystr, anymap_to_py
@@ -89,6 +90,31 @@ cdef class Domain1D:
     def _has_component(self, str name):
         """Check whether `Domain1D` has component"""
         return self.domain.hasComponent(stringify(name))
+
+    def info(self, keys=None, rows=10, width=None, display=True):
+        """
+        Print a concise summary of a `Domain1D`.
+
+        :param keys: List of components to be displayed; if `None`, all components are
+            considered.
+        :param rows: Maximum number of rendered rows.
+        :param width: Maximum width of rendered output.
+        :param display: If `True`, display result (default), otherwise, return a string.
+        """
+        cdef vector[string] cxx_keys
+        if keys is not None:
+            for key in keys:
+                cxx_keys.push_back(stringify(key))
+        if width is None:
+            try:
+                width = _get_terminal_size().columns
+            except:
+                width = 100
+
+        ret = pystr(self.domain.info(cxx_keys, rows, width))
+        if not display:
+            return ret
+        print(ret)
 
     def update_state(self, int loc):
         """

--- a/interfaces/cython/cantera/_onedim.pyx
+++ b/interfaces/cython/cantera/_onedim.pyx
@@ -93,13 +93,19 @@ cdef class Domain1D:
 
     def info(self, keys=None, rows=10, width=None, display=True):
         """
-        Print a concise summary of a `Domain1D`.
+        Display or return a concise summary of a `Domain1D`.
 
         :param keys: List of components to be displayed; if `None`, all components are
             considered.
         :param rows: Maximum number of rendered rows.
         :param width: Maximum width of rendered output.
         :param display: If `True`, display result (default), otherwise, return a string.
+
+        .. versionadded:: 3.2
+
+        .. todo::
+
+            Consolidate with `Sim1D.show`
         """
         cdef vector[string] cxx_keys
         if keys is not None:
@@ -108,7 +114,7 @@ cdef class Domain1D:
         if width is None:
             try:
                 width = _get_terminal_size().columns
-            except:
+            except OSError:
                 width = 100
 
         ret = pystr(self.domain.info(cxx_keys, rows, width))
@@ -1242,7 +1248,13 @@ cdef class Sim1D:
         self.sim.setFlatProfile(dom, comp, value)
 
     def show(self):
-        """ print the current solution. """
+        """
+        Print the current solution.
+
+        .. todo::
+
+            Consolidate with `Domain1D.info`
+        """
         if not self._initialized:
             self.set_initial_guess()
         self.sim.show()

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -550,13 +550,17 @@ cdef class SolutionArrayBase:
 
     def info(self, keys=None, rows=10, width=None, display=True):
         """
-        Print a concise summary of a `SolutionArray`.
+        Display or return a concise summary of a `SolutionArray`.
 
         :param keys: List of components to be displayed; if `None`, all components are
             considered.
         :param rows: Maximum number of rendered rows.
         :param width: Maximum width of rendered output.
         :param display: If `True`, display result (default), otherwise, return a string.
+
+        .. versionchanged:: 3.2
+
+            Added ``display`` parameter.
         """
         cdef vector[string] cxx_keys
         if keys is not None:
@@ -574,7 +578,7 @@ cdef class SolutionArrayBase:
         if width is None:
             try:
                 width = _get_terminal_size().columns
-            except:
+            except OSError:
                 width = 100
 
         ret = pystr(self.base.info(cxx_keys, rows, width))

--- a/interfaces/cython/cantera/solutionbase.pyx
+++ b/interfaces/cython/cantera/solutionbase.pyx
@@ -529,7 +529,7 @@ cdef class SolutionArrayBase:
         return dest
 
     def __repr__(self):
-        return self.info()
+        return self.info(display=False)
 
     @property
     def size(self):
@@ -548,7 +548,7 @@ cdef class SolutionArrayBase:
             cxx_shape.push_back(dim)
         self.base.setApiShape(cxx_shape)
 
-    def info(self, keys=None, rows=10, width=None):
+    def info(self, keys=None, rows=10, width=None, display=True):
         """
         Print a concise summary of a `SolutionArray`.
 
@@ -556,6 +556,7 @@ cdef class SolutionArrayBase:
             considered.
         :param rows: Maximum number of rendered rows.
         :param width: Maximum width of rendered output.
+        :param display: If `True`, display result (default), otherwise, return a string.
         """
         cdef vector[string] cxx_keys
         if keys is not None:
@@ -576,7 +577,10 @@ cdef class SolutionArrayBase:
             except:
                 width = 100
 
-        return pystr(self.base.info(cxx_keys, rows, width))
+        ret = pystr(self.base.info(cxx_keys, rows, width))
+        if not display:
+            return ret
+        print(ret)
 
     @property
     def meta(self):

--- a/src/oneD/Boundary1D.cpp
+++ b/src/oneD/Boundary1D.cpp
@@ -264,7 +264,7 @@ void Inlet1D::eval(size_t jg, double* xg, double* rg,
     }
 }
 
-shared_ptr<SolutionArray> Inlet1D::toArray(bool normalize) const
+shared_ptr<SolutionArray> Inlet1D::toArray(bool normalize)
 {
     AnyMap meta = Boundary1D::getMeta();
     meta["mass-flux"] = m_mdot;
@@ -313,7 +313,7 @@ void Empty1D::eval(size_t jg, double* xg, double* rg,
 {
 }
 
-shared_ptr<SolutionArray> Empty1D::toArray(bool normalize) const
+shared_ptr<SolutionArray> Empty1D::toArray(bool normalize)
 {
     AnyMap meta = Boundary1D::getMeta();
     return SolutionArray::create(m_solution, 0, meta);
@@ -365,7 +365,7 @@ void Symm1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
     }
 }
 
-shared_ptr<SolutionArray> Symm1D::toArray(bool normalize) const
+shared_ptr<SolutionArray> Symm1D::toArray(bool normalize)
 {
     AnyMap meta = Boundary1D::getMeta();
     return SolutionArray::create(m_solution, 0, meta);
@@ -432,7 +432,7 @@ void Outlet1D::eval(size_t jg, double* xg, double* rg, integer* diagg,
     }
 }
 
-shared_ptr<SolutionArray> Outlet1D::toArray(bool normalize) const
+shared_ptr<SolutionArray> Outlet1D::toArray(bool normalize)
 {
     AnyMap meta = Boundary1D::getMeta();
     return SolutionArray::create(m_solution, 0, meta);
@@ -514,7 +514,7 @@ void OutletRes1D::eval(size_t jg, double* xg, double* rg,
     }
 }
 
-shared_ptr<SolutionArray> OutletRes1D::toArray(bool normalize) const
+shared_ptr<SolutionArray> OutletRes1D::toArray(bool normalize)
 {
     AnyMap meta = Boundary1D::getMeta();
     meta["temperature"] = m_temp;
@@ -576,7 +576,7 @@ void Surf1D::eval(size_t jg, double* xg, double* rg,
     }
 }
 
-shared_ptr<SolutionArray> Surf1D::toArray(bool normalize) const
+shared_ptr<SolutionArray> Surf1D::toArray(bool normalize)
 {
     AnyMap meta = Boundary1D::getMeta();
     meta["temperature"] = m_temp;
@@ -766,7 +766,7 @@ double ReactingSurf1D::value(const string& component) const
     return soln[index(i, 0)];
 }
 
-shared_ptr<SolutionArray> ReactingSurf1D::toArray(bool normalize) const
+shared_ptr<SolutionArray> ReactingSurf1D::toArray(bool normalize)
 {
     if (!m_state) {
         throw CanteraError("ReactingSurf1D::toArray",

--- a/src/oneD/Domain1D.cpp
+++ b/src/oneD/Domain1D.cpp
@@ -41,6 +41,11 @@ void Domain1D::setSolution(shared_ptr<Solution> sol)
     m_solution->thermo()->addSpeciesLock();
 }
 
+string Domain1D::info(const vector<string>& keys, int rows, int width)
+{
+    return toArray()->info(keys, rows, width);
+}
+
 void Domain1D::resize(size_t nv, size_t np)
 {
     // if the number of components is being changed, then a

--- a/src/oneD/Flow1D.cpp
+++ b/src/oneD/Flow1D.cpp
@@ -1077,7 +1077,7 @@ void Flow1D::setFlatProfile(const string& component, double value)
     }
 }
 
-shared_ptr<SolutionArray> Flow1D::toArray(bool normalize) const
+shared_ptr<SolutionArray> Flow1D::toArray(bool normalize)
 {
     if (!m_state) {
         throw CanteraError("Flow1D::toArray",
@@ -1104,6 +1104,7 @@ shared_ptr<SolutionArray> Flow1D::toArray(bool normalize) const
             arr->setComponent(name, value);
         }
     }
+    updateThermo(soln, 0, m_points-1);
     value = m_rho;
     arr->setComponent("D", value); // use density rather than pressure
 

--- a/test/python/test_composite.py
+++ b/test/python/test_composite.py
@@ -388,79 +388,79 @@ class TestSolutionArrayInfo:
 
     def test_short(self):
         arr = ct.SolutionArray(self.gas, 5)
-        self.check(arr, arr.info(rows=10, width=self.width), 5)
+        self.check(arr, arr.info(rows=10, width=self.width, display=False), 5)
 
     def test_long(self):
         arr = ct.SolutionArray(self.gas, 20, extra={"spam": "eggs"})
-        self.check(arr, arr.info(rows=10, width=self.width), 11)
+        self.check(arr, arr.info(rows=10, width=self.width, display=False), 11)
 
     def test_scientific(self):
         arr = ct.SolutionArray(self.gas, 20)
         arr.set_equivalence_ratio(np.linspace(.5, 1.5, 20), "H2", "O2:1,N2:10")
         arr.equilibrate("HP")
-        self.check(arr, arr.info(rows=7, width=self.width), 8)
+        self.check(arr, arr.info(rows=7, width=self.width, display=False), 8)
 
     def test_plus_minus_i(self):
         arr = ct.SolutionArray(self.gas, 20,
                                extra={"foo": 10 * np.arange(-10, 10, dtype=int)})
-        self.check(arr, arr.info(rows=12, width=self.width), 13)
+        self.check(arr, arr.info(rows=12, width=self.width, display=False), 13)
 
     def test_plus_minus_f(self):
         arr = ct.SolutionArray(self.gas, 20, extra={"foo": "bar", "spam": "eggs"})
-        self.check(arr, arr.info(rows=9), 10)
+        self.check(arr, arr.info(rows=9, display=False), 10)
         arr.foo = np.linspace(-1, 1.5, 20)
-        self.check(arr, arr.info(rows=12, width=self.width), 13)
+        self.check(arr, arr.info(rows=12, width=self.width, display=False), 13)
 
     def test_plus_minus_e(self):
         arr = ct.SolutionArray(self.gas, 20, extra={"foo": "bar", "spam": "eggs"})
-        self.check(arr, arr.info(rows=9, width=100), 10)
+        self.check(arr, arr.info(rows=9, width=100, display=False), 10)
         arr.foo = np.linspace(-1e6, 1.5e6, 20)
-        self.check(arr, arr.info(rows=12, width=self.width), 13)
+        self.check(arr, arr.info(rows=12, width=self.width, display=False), 13)
 
     def test_strings(self):
         arr = ct.SolutionArray(self.gas, 26, extra={"foo": "bar", "spam": "eggs"})
         arr.spam = ["abcdefghijklmnopqrstuvwxyz"[:ix+1] for ix in range(26)]
-        self.check(arr, arr.info(rows=12, width=self.width), 13)
+        self.check(arr, arr.info(rows=12, width=self.width, display=False), 13)
 
     def test_double_vector(self):
         arr = ct.SolutionArray(self.gas, 15, extra={"spam": "eggs"})
         arr.spam = [[1.1, 2.2, 3.3] for _ in range(15)]
-        self.check(arr, arr.info(rows=12, width=self.width), 13)
+        self.check(arr, arr.info(rows=12, width=self.width, display=False), 13)
 
     def test_integer_vector(self):
         arr = ct.SolutionArray(self.gas, 15, extra={"spam": "eggs"})
         arr.spam = [np.array([1, 2, 3], dtype=int) for _ in range(15)]
-        self.check(arr, arr.info(rows=12, width=self.width), 13)
+        self.check(arr, arr.info(rows=12, width=self.width, display=False), 13)
 
     def test_string_vector(self):
         arr = ct.SolutionArray(self.gas, 15, extra={"spam": "eggs"})
         arr.spam = [["foo", "bar"] for _ in range(15)]
-        self.check(arr, arr.info(rows=12, width=self.width), 13)
+        self.check(arr, arr.info(rows=12, width=self.width, display=False), 13)
 
     def test_select_species(self):
         arr = ct.SolutionArray(self.gas, 5)
         arr2 = arr("H2")
-        lines = arr2.info(width=self.width).split("\n")
+        lines = arr2.info(width=self.width, display=False).split("\n")
         assert lines[0].split() == ["T", "D", "H2"]
 
     def test_select_rows(self):
         arr = ct.SolutionArray(self.gas, 25)
         ix = [2, 5, 6, 9, 15, 3]
         arr2 = arr[ix]
-        self.check(arr2, arr2.info(width=self.width), 6)
-        lines = arr2.info(width=self.width).split("\n")[1:-2]
+        self.check(arr2, arr2.info(width=self.width, display=False), 6)
+        lines = arr2.info(width=self.width, display=False).split("\n")[1:-2]
         loc = [int(line.split()[0]) for line in lines]
         assert loc == ix
 
     def test_water_simple(self):
         w = ct.Water()
         arr = ct.SolutionArray(w, 10)
-        self.check(arr, arr.info(rows=12, width=self.width), 10)
+        self.check(arr, arr.info(rows=12, width=self.width, display=False), 10)
 
     def test_water_extra(self):
         w = ct.Water()
         arr = ct.SolutionArray(w, 15, extra={"spam": np.arange(15, dtype=int)})
-        self.check(arr, arr.info(rows=7, width=self.width), 8)
+        self.check(arr, arr.info(rows=7, width=self.width, display=False), 8)
 
 @pytest.fixture(scope='class')
 def setup_solution_array_io_tests(request):


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Add a missing `updateThermo` call prior to export as `SolutionArray`. This ensures consistent thermodynamic states.

- Fixes `Flow1D::toArray`
- Add `Domain1D.info` to Python API (same as `SolutionArray.info`)

**If applicable, fill in the issue number this pull request is fixing**

<!-- Issues with issue number '<issue>' are referenced as #<issue>. To link to an issue in the enhancements repository, use Cantera/enhancements#<issue>. -->

Closes #2007

**If applicable, provide an example illustrating new features this pull request is introducing**

<!-- A minimal, complete, and reproducible example demonstrating features introduced by this pull request. See https://stackoverflow.com/help/minimal-reproducible-example for additional suggestions on how to create such an example. -->

```
>>> import cantera as ct
>>> gas = ct.Solution("h2o2.yaml")
>>> gas.set_equivalence_ratio(1., "H2", "O2:0.21,N2:0.79")
>>> stack = ct.FreeFlame(gas)
>>> stack.flame.set_profile("T", [0, 0.3, 0.7, 1], [300, 300, 2000, 2000])
>>> stack.flame.set_profile("velocity", [0, 0.3, 0.7, 1], [.3, .3, .3 * 20/3, .3 * 20/3])
>>> stack.flame.info()
     grid velocity     T         D         H2    H    O        O2   OH  H2O  HO2 H2O2   AR        N2
0   0.000   0.3000   300  0.849553  0.0285116    0    0  0.226269    0    0    0    0    0  0.745220
1   0.020   0.3000   300  0.849553  0.0285116    0    0  0.226269    0    0    0    0    0  0.745220
2   0.040   0.7250   725  0.351539  0.0285116    0    0  0.226269    0    0    0    0    0  0.745220
3   0.060   1.5750  1575  0.161820  0.0285116    0    0  0.226269    0    0    0    0    0  0.745220
4   0.080   2.0000  2000  0.127433  0.0285116    0    0  0.226269    0    0    0    0    0  0.745220
5   0.100   2.0000  2000  0.127433  0.0285116    0    0  0.226269    0    0    0    0    0  0.745220

[6 rows x 14 components; state='TDY']
>>> stack.inlet.info()
      T         D         H2    H    O        O2   OH  H2O  HO2 H2O2   AR        N2
0   300  0.849553  0.0285116    0    0  0.226269    0    0    0    0    0  0.745220

[1 rows x 12 components; state='TDY']
```

**Other thoughts**

Inconsistent states are only present prior to the first call to `Sim1D.solve`; any subsequent output will be consistent as long as states are not overwritten. While `SolutionArray` with inconsistent states may have been saved in prior versions of Cantera, a re-import to `Sim1D` / `Domain1D` will still work correctly, as an inconsistent density `D` is ignored. The same is not true if an inconsistent `SolutionArray` is imported directly; in that case, states will be set using `Solution.TDY` with an incorrect pressure trace.

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
