### PR TITLE
Fix sourcegen markup

### DIFF
--- a/include/cantera/transport/Transport.h
+++ b/include/cantera/transport/Transport.h
@@ -88,7 +88,7 @@ public:
 
     //! Create a new Transport object using the same transport model and species
     //! transport properties as this one.
-    //! @param phase ThermoPhase used to specify the state for the newly cloned
+    //! @param thermo ThermoPhase used to specify the state for the newly cloned
     //!     Transport object. Can be created from the phase used by the current
     //!     Transport object using the ThermoPhase::clone() method.
     //! @since New in %Cantera 3.2.

--- a/interfaces/sourcegen/src/sourcegen/headers/ct_auto.yaml
+++ b/interfaces/sourcegen/src/sourcegen/headers/ct_auto.yaml
@@ -8,6 +8,7 @@ base: ""
 recipes:
 - name: version  # Renamed in Cantera 3.2 (previously getCanteraVersion)
 - name: gitCommit  # Renamed in Cantera 3.2 (previously getGitCommit)
+- name: usesHDF5
 - name: addDataDirectory
 - name: getDataDirectories
 - name: findInputFile


### PR DESCRIPTION
<!-- Thanks for contributing code! Please include a description of your change and check your pull request against the list below. For further questions, refer to the contributing guide (https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md). -->

**Changes proposed in this pull request**

<!-- Provide a clear and concise description of changes and/or features introduced in this pull request. -->

Fix issues where XML markup causes docstrings extracted by sourcegen to cut off (`<bold>`, `<emphasis>`, `<computeroutput>`).

**Checklist**

- [x] The pull request includes a clear description of this code change
- [x] Commit messages have short titles and reference relevant issues
- [x] Build passes (`scons build` & `scons test`) and unit tests address code coverage
- [x] Style & formatting of contributed code follows [contributing guidelines](https://github.com/Cantera/cantera/blob/main/CONTRIBUTING.md)
- [x] The pull request is ready for review
